### PR TITLE
Object-handle lattice: one owner-attributed carrier and a sound empty-seed fast path (#994 stage C5a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -136,7 +136,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -729,27 +729,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06aeba2c965fc446d13c56a6ccb2631b78445d7544543dd9a25289977630914"
+checksum = "47ca6361f42d0c945fadc1103501e1c07438e034fd5a86896a3074eff3e860bd"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2d2dde4ec1352715595b5cfa6fe2e5b8ebb9da3457b3ee8db0aa2808c069aa"
+checksum = "2c1dbc96db7cebf747bd5722d482338a5acff91d6be43b6bec145f9471327ffa"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b4982ef9fa54ec9eee841e891e7ddc5434be1250e88de31572e000c888f30b"
+checksum = "353b309eef494e4adb4c6cca76f30ef27daa907534db7d05b5986500f51aa4e1"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -757,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529143118c4eeb58c39ecb02319557d512be6c61348486422974ab8e3906b8a8"
+checksum = "e3cafe127a4c5d9765b1df54052245d2cbaca7238782805bb5ac94986ccdb591"
 dependencies = [
  "serde",
  "serde_derive",
@@ -768,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7780677247ad3577e3a6a3ebf43f39b325a11d6393db72b2c9968a910d4d13d"
+checksum = "3964f31c6dc9d21e926ef884d3eec2f1ca83266a233521da4a737143262ceb84"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -799,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9645250416cbf92454fe61160e17e026e0ce405906a54500b114f923ddffc9"
+checksum = "b2f8b35746603b792e4ae34499a39251f310a06c98d4bc2ca02cf4bd29ce3c84"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -812,24 +812,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ee8d222ff0fd3681791979afbf88586ac9f49010d3db96b3cbe4c96759aee3"
+checksum = "584bd91987927dfe35e79c5d6dd52a117cb64c4fce26df881d02dcc17bd59a8f"
 
 [[package]]
 name = "cranelift-control"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591abe6f5312bd2c4220f1b3bead56c2ad00257c52668015ba013b85dcf2a17a"
+checksum = "af277352af76db01bb42fa4978b672a44406715798edb693cc02e363e12dc505"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5300c49cf940526fe771517b3b3eabd5d0ff164ee61698579cf403fe8d3af3c"
+checksum = "42ad4f0c556d3d57580d07477be9e665f4d2a826971a5ab4642ead20a19df443"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -839,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4adbf760207fdbbe130f1191cce01cdef66831a9f648b1f39ff2800d126d45"
+checksum = "29d69a6b7d8412c716e8599c7330dfbd122c1bc145f3bda05a9e237fba20419d"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.1",
@@ -852,15 +852,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8315b21ff018226a42a60a4702c2dd75f6447cac26e9bca622e14c22088c2ff5"
+checksum = "52fcdcd4a5c7fa8bfea35e72c0979ad5a699c836364870f0a84169d02a085a88"
 
 [[package]]
 name = "cranelift-native"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d506ef23a60715bde451b06620b14402166ded3b648454fccbf04f3e46a4aa70"
+checksum = "0fee933cf8ec90e58e68163a02bdb0e4d29f2260a7592b3f09cbba52fcd34d12"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -869,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ed47e602652e3410f9387fc0db70fefadcee4d78a78881421aabcab4e26b89"
+checksum = "6bd75e1e2719808c80af27ebe168d2220ec10e519e1d5a52bdbed9bd5cac1a32"
 
 [[package]]
 name = "crc32fast"
@@ -1359,7 +1359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2806,9 +2806,9 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pulley-interpreter"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b92604caae1a1899b6a5b54967289dd538177c626004c91accf9d0ec7e4a12"
+checksum = "3683e69168d2e2374cea51a79fce2e9870e7c622366b8bf7af87fb5c2428a2a9"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -2818,9 +2818,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7ac85c0bb3fb351f10d531230aaa5e366b46d7c4e5328e5f02801d6dac1165"
+checksum = "8ebbd6dada1e3df36ea4a4b8feca2ed230aa92d59e55bf5714eb4286cdd632b0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3376,7 +3376,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3824,7 +3824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4512,7 +4512,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4522,7 +4522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5108,9 +5108,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4213d2f019a5e44aa8a61d8826dd33a505bff79f749b14a8bafd67321cb9351"
+checksum = "ed27b4a4a5271d2608406a99c8d1cf8aea1e894fe4ec361d470063bcf342f1d7"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -5146,9 +5146,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45863de41977ec6453e859cf843d456fa3fcb45a659b66d16e794f90ec4f5b7"
+checksum = "7712f99b0920d4638023405eb9723ef200efd6d39bfc7466c92e926ca5d130f0"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -5177,15 +5177,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819ad5abd5822a22dbf4014475cdfd1fe790707761cd732d74aaa3ba4d5ba489"
+checksum = "c777c83bb4c3414b23fe84fecd47a46016a0a0b0a39aa786cad0a701fe3cbc7f"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc28372e36eaf8cf70faa83b5779137f7e99c8d18569a125d1580e735cc9e4d"
+checksum = "ffb54b5de8723a9acf2c0bc531df8e773462796a5f87e8f49a3d5ea5c3b32ef7"
 dependencies = [
  "hashbrown 0.17.1",
  "libm",
@@ -5194,9 +5194,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a433efc6e35112a5457e1dc8bc4d8d39820ac7722267e89bc04e5df641f32124"
+checksum = "9c60bb70116a88791ccceef605b31010c4888a7305e450f01dc7d4f430ad25f0"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -5221,9 +5221,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a1d3a39d0d210f6b8574ee96a4315e0a14c67f3a1fc3cd5372cb10d2fb4422"
+checksum = "24bdf54907e0bad31ad6676d03ed1008fa21489725635136f9c38979c39a98ed"
 dependencies = [
  "cc",
  "cfg-if",
@@ -5236,9 +5236,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f667288cb4dfa68a4639ffac4d5628535dda64ebdc2b990526efb12b30ba803"
+checksum = "ef4edaf07e20511f3ca070a4a0f026c407969f09e536075729872f548ca6f8d4"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros",
@@ -5246,9 +5246,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba651d44ab0faad4c58106b3adb45068189fb65ef50f0c404b6d9e3bf81a357"
+checksum = "f96a6d7eb246d1306b7db8915a169cd8628a9e6b8299d1d1f8ab109801ef0a66"
 dependencies = [
  "cfg-if",
  "libc",
@@ -5258,9 +5258,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ecc52563b0558af2a7487eb710de07cc4532564b55528876129238e83118cb1"
+checksum = "39472572ea3eb11b7cc7fe7bd6df0005cef87b580eb06a3378d103ac99d45bc3"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -5271,9 +5271,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e747f4a074699ba1b4e4d841fb263f9b7df5bd1555181c4752bf5990d21ba676"
+checksum = "7bf2eff1c108b01566a7c8870de34821e7bda7d327e86e12a548c026e1e3677d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5383,7 +5383,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/docs/design/compiler/README.md
+++ b/docs/design/compiler/README.md
@@ -154,6 +154,11 @@ User-facing compiler troubleshooting and how-tos live in
   derived from one file's call sites may be trusted as a fact about every
   caller: cross-file evidence, registry-declared unit boundaries, and the
   interprocedural constant seed's gate.
+- [object-type-lattice.md](object-type-lattice.md) — the object-handle →
+  class carrier (`ObjectHandleFacts`): the four maps that answer
+  "what class does `$obj` hold?", owner attribution per VTA edge, the
+  `by_scope` vs `any_scope` soundness directions each consumer must read,
+  and the empty-seed fast path's three-part gate.
 
 ## Optimisation passes
 

--- a/docs/design/compiler/object-type-lattice.md
+++ b/docs/design/compiler/object-type-lattice.md
@@ -1,0 +1,171 @@
+# Object-type lattice — the object-handle → class carrier
+
+The contract for `rust/tcl-compiler/src/object_types.rs` and the
+`AnalysisResult::object_handle_facts` carrier it fills. This is the fact
+behind every "`$obj method …` resolves to class `C`" answer the LSP gives:
+semantic tokens, go-to-definition, find-references, rename safety, the
+W307 / W308 diagnostics, and the optimiser's devirtualisation.
+
+Issue #994 is the unification this doc records the shape of; the staged
+landing is C5a (this carrier, no consumer), C5b (the five dispatch
+consumers plus tokens), C5c (the cross-document index facts of #1099).
+Cost measurement for C5a: `experiments/object_lattice/RESULTS.md`.
+
+## §0 — Four maps, four different keys
+
+Before the unification there were **four** independently-produced answers to
+"what class does this name hold?", and they could disagree on the same
+document:
+
+| map | produced by | key | scope | consumers |
+|---|---|---|---|---|
+| `AnalysisResult::instance_classes` | the analyser's syntactic walk, settled late from the CU (`analyser/diagnostics.rs`, `settle_pending_instance_class_sites`) | bare name | last-write-wins across the file | find-references, rename, definition ×2, code lens, W307 / W308 |
+| `object_handle_classes` | the VTA-lite lattice over the `CompilationUnit` | bare name | union across the file | optimiser, `compilation_unit`, `interprocedural`, `type_infer`, semantic tokens |
+| `object_collection_classes` | the SSA type lattice's container element-typing | bare name | union across the file | collection dispatch (`[dict get $pins $k] m`) |
+| `AnalysisResult::instance_command_bindings` | the analyser's `CLASS create NAME` sites | **namespace-qualified** command name | per creation site | the #981 namespace-scoped object-command path |
+
+The failure mode this shape produces is structural, not incidental: tokens
+read the lattice, navigation reads `instance_classes`, so the same
+`$obj method` could be coloured as a resolved dispatch and simultaneously
+have no definition to jump to. Every precision fix had to be made — and
+kept in sync — in up to four places.
+
+`instance_command_bindings` is deliberately **not** folded into the
+lattice: it is keyed by qualified command name precisely because the
+name-keyed maps cannot tell `::a::rex` from `::b::rex`, and reading a
+name-keyed map on that path is the #981 bug.
+
+## §1 — The carrier
+
+`object_handle_facts(cu, registry) -> ObjectHandleFacts`, produced **once**
+per analysis at `analyser/diagnostics.rs`'s CU-derived fact seam
+(`settle_cu_derived_object_facts`), which both the whole-file and the
+per-item incremental path reach.
+
+| field | key | contents |
+|---|---|---|
+| `any_scope` | bare name | the pre-existing union — `object_handle_classes` verbatim |
+| `by_scope` | `(owner_qualified_name, name)` | the same bindings, attributed to the unit the binding edge binds in |
+| `owner_spans` | sorted by `(start, end)` | `(span, unit, class?)` per proc / method, for `owner_at(offset)` |
+| `collections` | bare name | `object_collection_classes` verbatim |
+| `returns_object` | proc qualified name | the factory-return class (previously computed inside the fixpoint and discarded) |
+| `global_object_cells` | `::`-qualified name | the `::`-qualified subset of `any_scope` |
+
+### Owner attribution
+
+The owner is *where the name lives*, which for each VTA edge is:
+
+| edge | example | owner |
+|---|---|---|
+| seed (harvest) | `set c [Chart new]` | the harvesting unit |
+| aliasing | `set b $a` | the assigning unit |
+| proc return | `set q [make]` | the assigning unit |
+| proc parameter | `connect $p` → `dev` | the **callee** (`::connect`) |
+| constructor parameter | `Wrap new $p` → `inner` | the **constructor** (`::Wrap::<constructor>`) |
+
+…with one override: a name that is a **class instance variable** is owned
+by the **class**, unioned across its methods. That union is not a
+convenience — it is the interprocedural bridge issue #797 needs. An object
+built into `Pins` in `Device::add` and dispatched from `Pins` in
+`Device::use` is connected by exactly nothing else: no intraprocedural
+lattice can join two method bodies, and `mro_eval` measured 99.8 % ⊤
+intraprocedurally on real TclOO corpora. Keying instance variables by class
+reproduces the bridge while still refusing to merge a `chart` local in one
+proc with a `chart` local in another.
+
+`classes_in_scope(offset, var)` implements the consumer-side lookup: the
+owning unit's key first, the enclosing class's key second.
+`owner_spans` carries one entry per proc and method plus a whole-file entry
+for `::top`, so a top-level handle has an owner too. Synthetic **body
+units** (`apply` lambdas, `namespace eval` blocks) deliberately get no
+entry: the harvest does not visit them at all, so a byte inside one
+resolves to its enclosing owner rather than to a scope the lattice knows
+nothing about.
+
+### Soundness directions
+
+Every map is **best-effort**. An absent key means *no evidence in this
+document*; it is never proof that a name holds no object. The empty default
+is what every CU-less path produces (structure-only analysis, a panicking
+CU build), so a consumer must degrade to its pre-lattice behaviour rather
+than conclude anything from emptiness.
+
+`by_scope` is the *narrow* map, `any_scope` the *wide* one. Which to read is
+decided by what a wrong answer costs:
+
+| consumer | map | why |
+|---|---|---|
+| rename edits, find-references | `by_scope` only | widening rewrites an unrelated variable — a wrong edit, not a missed one |
+| definition, type-definition, hover | `by_scope`, then `any_scope` labelled as a guess | a wrong jump is recoverable; a missing one is not |
+| semantic tokens / highlighting | either | colour-only, and the union is what shipped before |
+| "provably a *different* class, so refuse/skip" gates | `by_scope` singletons only | widening turns an abstention into a false certainty, silencing a refusal that protects the user |
+
+The invariant behind the last row, from the #994 design: **an abstention
+must never become "provably not family"**. Documented abstentions —
+dict/list-carried and callback-registered handles, computed array indices,
+interp boundaries, unqualified globals — are all backstopped by the
+untracked-receiver refusal.
+
+## §2 — How the lattice is built
+
+1. **Harvest** every unit (top level, procs, methods): syntactic
+   `set VAR [Class new|create …]` assignments, registry naming factories
+   (`struct::graph myG`, and Tk widget paths once the registry declares
+   them — #927), and every SSA value the type lattice typed `OBJECT(class)`
+   (which is where collection retrievals like `set p [dict get $pins $k]`
+   enter).
+2. **Propagate** along the four VTA edges (Sundaresan et al., OOPSLA'00) to
+   a bounded 6-round fixpoint. Nodes are name-keyed — field-based and
+   object-insensitive, VTA's economy — and the join is set union.
+   Convergence is decided by `any_scope` alone, so the scope-keyed twin can
+   never change the number of rounds or the union's contents.
+
+### The empty-seed fast path
+
+The propagation's original early-out tested the **callee-side** maps
+(returns / proc params / ctor params), which are non-empty for any file that
+merely defines a proc — so every ordinary non-OO file paid a full statement
+walk to discover it had nothing to propagate. The fast path skips the walk
+when no edge can fire, which needs **three** conditions, not one:
+
+- no seeded handle (kills every `out`-driven edge), **and**
+- no procedure returns an object (kills the proc-return edge), **and**
+- no argument could be a bracketed registry constructor (kills
+  `arg_classes`' direct-constructor branch, which reads no seed at all).
+
+Dropping the second or third condition is a real regression, not a
+theoretical one: `proc make {} { return [Pin new] }; set c [make]`,
+`take [listbox .l]`, `Wrap new [listbox .l]`, and `take [struct::graph]`
+each bind from an empty seed set. `object_handle_classes_full_walk` keeps
+the pre-fast-path walk available so the unit test can pin the equality, and
+`experiments/object_lattice/RESULTS.md` measures what the gate saves
+(109 of 154 corpus files skip the walk; 55 % of their lattice time).
+
+## §3 — What the lattice deliberately does not do
+
+- It does not replace `instance_classes`. Literal replacement destroys the
+  ambiguity signal (`ambiguous_instance_names`), changes W307 / W308 / W123,
+  and breaks the per-item `extend` merge.
+- It is not consulted per-consumer with per-consumer precedence rules. Five
+  independent precedence rules drift; the carrier exists so all five
+  dispatch sites read **one** fact through **one** accessor.
+- It does not bind the `= | := | as | deserialize` operator words a
+  `struct::graph = $serial` deserialise form puts in the name slot. That
+  abstention holds in **both** maps: a bogus `=` handle would suppress a
+  real W123 / W307 and, once C5b's consumers read `by_scope`, would
+  mis-resolve a command literally named `=`.
+- It does not make the fixpoint cleverer. On 66,827 lines of real TclOO the
+  four propagation edges fired 3 times against 86 harvest seeds; the value
+  is in the carrier being shared, not in the propagation.
+
+## See also
+
+- [`cfg-ssa-fact-model.md`](cfg-ssa-fact-model.md) — the fact model the
+  lattice reads (`FunctionUnit::types`, `return_type`).
+- [`compilation-unit-contracts.md`](compilation-unit-contracts.md) — the
+  unit the lattice rides on and its incremental cache expectations.
+- [`interprocedural-analysis.md`](interprocedural-analysis.md) — the
+  `ObjectTypeMap` consumer of `object_handle_classes`.
+- `experiments/object_lattice/RESULTS.md` — C5a's cost gate (M1).
+- `experiments/mro_eval/RESULTS.md` — why the cross-file class index, not
+  the intraprocedural lattice, is where dispatch resolution comes from.

--- a/docs/design/compiler/object-type-lattice.md
+++ b/docs/design/compiler/object-type-lattice.md
@@ -73,6 +73,39 @@ intraprocedurally on real TclOO corpora. Keying instance variables by class
 reproduces the bridge while still refusing to merge a `chart` local in one
 proc with a `chart` local in another.
 
+### Scoped propagation, not just scoped keying
+
+Owner attribution decides where a binding is *written*. It is not enough on
+its own: the edge's **source** must be resolved in the scope that owns it
+too, or the narrow map inherits the wide map's collisions. After
+
+```tcl
+proc a {} { set x [Pin new] }
+proc b {} { set x 0; set y $x }
+```
+
+resolving `b`'s `set y $x` against the union would find `a`'s `x` and record
+`(::b, y) → ::Pin` — a **false singleton** in the map C5b's rename edits and
+the "provably a different class" refusal gate treat as authoritative. That is
+the R2 wrong-rewrite hazard `by_scope` exists to prevent, so the fixpoint
+resolves each edge's source through `by_scope` itself:
+
+| edge | source | resolved in |
+|---|---|---|
+| aliasing | the read variable | the **reading unit** (then its class, for an instance variable; then nothing) |
+| proc return | the callee's return type | nowhere — it is not a variable read, so it is unit-independent |
+| proc parameter | the call-site argument | the **caller**, bound in the callee |
+| constructor parameter | the call-site argument | the **caller**, bound in the constructor |
+
+The two lower rows are genuine cross-scope flows and are unaffected: what is
+excluded is only a name-keyed variable *read* resolving through another
+unit's binding.
+
+Both facts advance in one walk, each reading back only its own map, so
+`any_scope` stays exactly the union it has always been — the module's
+documented highlight-grade heuristic, which semantic tokens and the existing
+compiler consumers still read.
+
 `classes_in_scope(offset, var)` implements the consumer-side lookup: the
 owning unit's key first, the enclosing class's key second.
 `owner_spans` carries one entry per proc and method plus a whole-file entry
@@ -95,7 +128,7 @@ decided by what a wrong answer costs:
 
 | consumer | map | why |
 |---|---|---|
-| rename edits, find-references | `by_scope` only | widening rewrites an unrelated variable — a wrong edit, not a missed one |
+| rename edits, find-references | `by_scope` only | widening rewrites an unrelated variable — a wrong edit, not a missed one (and see "Scoped propagation" above: the narrowness must survive the fixpoint, not just the key) |
 | definition, type-definition, hover | `by_scope`, then `any_scope` labelled as a guess | a wrong jump is recoverable; a missing one is not |
 | semantic tokens / highlighting | either | colour-only, and the union is what shipped before |
 | "provably a *different* class, so refuse/skip" gates | `by_scope` singletons only | widening turns an abstention into a false certainty, silencing a refusal that protects the user |

--- a/experiments/object_lattice/RESULTS.md
+++ b/experiments/object_lattice/RESULTS.md
@@ -1,0 +1,230 @@
+# object_lattice — object-handle lattice cost (issue #994 C5a gate M1): results
+
+Measurement gate for stage **C5a** of the object-type-lattice unification
+(issue #994, coupled with #1099). Design: `docs/design/compiler/object-type-lattice.md`.
+Implementation: `rust/tcl-compiler/src/object_types.rs`. Harness:
+`rust/tcl-compiler/examples/object_lattice_cost.rs`.
+
+Reproduce:
+
+```sh
+# fetch the external corpus (git-ignored, pinned to the MANIFEST SHAs)
+experiments/corpus/fetch_corpus.sh
+CORPUS="experiments/corpus/georgtree experiments/corpus/adversarial \
+        experiments/corpus/vendor experiments/corpus/repo-fixtures"
+# per-file CU build / lattice / scope-keying cost, gate verdicts, edge mix
+cargo run --release -p tcl-compiler --example object_lattice_cost -- $CORPUS
+# behaviour equality of the empty-seed fast path (unit gate)
+cargo test -p tcl-compiler --lib object_types
+```
+
+`REPEATS=n` (default 3) runs each timed phase `n` times and keeps the
+minimum. Numbers below: `--release`, `REPEATS=3`, x86-64 Linux, one file at
+a time (no parallelism), Rust 1.97.0.
+
+## Hypothesis (restated)
+
+C5a widens the object-handle carrier — the union map
+`object_handle_classes` already produces, plus a **scope-keyed** twin, an
+owner-span index, the collection map, the factory-return fact, and the
+global-cell subset — and produces it once per analysis from the
+`CompilationUnit` the CFG/SSA diagnostics already build.
+
+The stop-gate question is **not** "is the lattice fast in absolute terms".
+It is: **is the lattice cheap relative to the compilation unit it rides
+on?** If it is not, C5b's consumers cannot afford to read it on the LSP
+request path and the whole staged plan stops here.
+
+## Metric definitions
+
+- **CU build ms** — `CompilationUnit::build_for` + `with_interprocedural`,
+  the pass the lattice rides on. Already paid by every analysis
+  (`Analyser::analyse` → `emit_cfg_ssa_diagnostics`), memoised behind the
+  salsa `compilation_unit` query.
+- **lattice ms** — `object_handle_classes`: the harvest plus the VTA-lite
+  fixpoint. This is what ships today.
+- **+scope-keying ms** — `object_handle_facts` minus the above: owner
+  attribution, the owner-span index, the collection map, and the two
+  exported sub-facts. The *new* cost C5a adds.
+- **rounds** — VTA fixpoint rounds actually run (0 when the empty-seed fast
+  path fired, or when the callee-side early-out did).
+- **bindings by edge kind** — the four VTA type-propagation edges
+  (aliasing, proc return, proc parameter, constructor parameter).
+
+## Corpus
+
+154 Tcl files, 66,827 lines — the same corpus as `experiments/mro_eval`,
+pinned by `experiments/corpus/MANIFEST.md`.
+
+| source | files | lines |
+|---|--:|--:|
+| georgtree (SpiceGenTcl, tclopt, ruff, argparse, …) | 140 | 49,960 |
+| tcllib (clay, oodialect, oometa, oooption, ooutil) | 6 | 3,360 |
+| Tcl core `oo` tests (8.6 + 9.0) | 5 | 13,404 |
+| repo OO fixtures | 2 | 32 |
+| adversarial (hand-written) | 1 | 71 |
+
+One reproduction caveat: `fetch_corpus.sh`'s shallow clone could not fetch
+SpiceGenTcl's pinned `d9d7187` (GitHub refuses a shallow fetch of an
+arbitrary SHA); the pin was recovered with `git fetch --unshallow` +
+`git checkout d9d7187`. tcllib and the core `oo` tests were fetched
+file-by-file from `raw.githubusercontent.com` (the session had no
+`tmp/tcllib-2.0` / `tmp/tcl*` trees for the script's copy path); Tcl
+8.6.16 has no `tests/ooUtil.test`, so the `oo`-test set is 8.6 `oo` +
+`ooNext2` and 9.0 `oo` + `ooNext2` + `ooUtil` — 5 files, 13,404 lines,
+matching the MANIFEST totals exactly.
+
+## Headline result
+
+```
+measured 154 files, 66,827 lines
+totals: CU build 1213.2 ms, lattice 3.8 ms (0.32 % of CU),
+        +scope-keying 0.8 ms (0.06 % of CU)
+```
+
+| gate | threshold | measured | verdict |
+|---|--:|--:|---|
+| median lattice / CU build | ≤ 5 % | **0.22 %** | **PASS** (23× margin) |
+| p99 lattice / CU build | ≤ 15 % | **1.46 %** | **PASS** (10× margin) |
+| worst-file lattice time | ≤ 25 ms | **0.648 ms** | **PASS** (39× margin) |
+
+**Worst file:** `experiments/corpus/georgtree/SpiceGenTcl/src/generalClasses.tcl`
+— 3,038 lines, 0.648 ms of lattice on a 79.8 ms CU build (**0.81 %**), 2
+fixpoint rounds, 3 handles. It is the worst file by *absolute* lattice time,
+not by ratio; the worst *ratio* is 1.55 %
+(`SpiceGenTcl/examples/ltspice/advanced/diode_extract.tcl`, 143 lines).
+
+Scope-keying — the thing C5a actually adds — costs **0.8 ms across the
+whole corpus**, 0.06 % of the CU build and 21 % of the lattice itself. It
+is not a measurable cost at LSP latencies.
+
+Run-to-run spread across repeats of the whole sweep is ~5 % on the totals
+and does not move any verdict: the tightest gate still clears by 10×.
+
+## Per-file (slowest 15 by lattice ms)
+
+| file | lines | CU build ms | lattice ms | lattice % of CU | +scope-keying ms | rounds | handles | scoped |
+|---|--:|--:|--:|--:|--:|--:|--:|--:|
+| `georgtree/SpiceGenTcl/src/generalClasses.tcl` | 3038 | 79.763 | 0.648 | 0.81 % | 0.172 | 2 | 3 | 3 |
+| `georgtree/tclopt/tclopt.tcl` | 3843 | 121.984 | 0.475 | 0.39 % | 0.134 | 1 | 0 | 0 |
+| `vendor/tcllib/clay.tcl` | 2227 | 77.332 | 0.182 | 0.23 % | 0.043 | 1 | 0 | 0 |
+| `georgtree/SpiceGenTcl/src/specElementsClassesCommon.tcl` | 1307 | 23.322 | 0.164 | 0.70 % | 0.039 | 1 | 0 | 0 |
+| `georgtree/SpiceGenTcl/src/ngspice/specElementsClassesNgspice.tcl` | 1491 | 24.736 | 0.162 | 0.66 % | 0.023 | 1 | 0 | 0 |
+| `georgtree/SpiceGenTcl/src/ltspice/specElementsClassesLtspice.tcl` | 1533 | 27.206 | 0.159 | 0.58 % | 0.037 | 1 | 0 | 0 |
+| `georgtree/argparse/argparse.tcl` | 977 | 58.632 | 0.149 | 0.25 % | 0.000 | 1 | 0 | 0 |
+| `georgtree/SpiceGenTcl/src/xyce/specElementsClassesXyce.tcl` | 1053 | 18.619 | 0.116 | 0.62 % | 0.007 | 1 | 0 | 0 |
+| `georgtree/ruff/src/ruff.tcl` | 3060 | 72.291 | 0.105 | 0.14 % | 0.024 | 0 | 0 | 0 |
+| `georgtree/SpiceGenTcl/src/ngspice/netlistParserClassNgspice.tcl` | 1123 | 34.298 | 0.104 | 0.30 % | 0.054 | 0 | 0 | 0 |
+| `georgtree/SpiceGenTcl/examples/ltspice/advanced/diode_extract.tcl` | 143 | 4.774 | 0.074 | 1.55 % | 0.003 | 1 | 3 | 3 |
+| `georgtree/SpiceGenTcl/examples/ngspice/advanced/inverter_optimization.tcl` | 190 | 6.712 | 0.074 | 1.10 % | 0.000 | 1 | 1 | 1 |
+| `georgtree/SpiceGenTcl/examples/ngspice/advanced/verilog_a_magnetic.tcl` | 166 | 5.654 | 0.073 | 1.30 % | 0.020 | 1 | 13 | 13 |
+| `georgtree/tcl_tools/gnuplotutil.tcl` | 861 | 28.876 | 0.070 | 0.24 % | 0.002 | 0 | 0 | 0 |
+| `georgtree/SpiceGenTcl/examples/ngspice/advanced/diode_extract.tcl` | 142 | 4.502 | 0.069 | 1.54 % | 0.002 | 1 | 3 | 3 |
+
+The `handles` / `scoped` columns are the sizes of `any_scope` and
+`by_scope`. They are equal on every corpus file: no file in this corpus has
+the same handle name bound in two different scopes, so scope-keying costs
+nothing in *entries* here — it buys the ability to tell those apart when
+they do occur, which is the rename-correctness case C5b needs.
+
+## Empty-seed fast path
+
+The C5a design flagged that the propagation's early-out checks the wrong
+condition: it returns only when the **callee-side** maps (returns / proc
+params / ctor params) are all empty, which is false for any file that
+merely defines a proc. So a file with zero object seeds still paid a full
+statement walk.
+
+| files | lattice ms (fast path) | lattice ms (pre-#994 walk) | saved | saved / file |
+|--:|--:|--:|--:|--:|
+| 109 of 154 | 1.012 | 2.323 | 1.311 ms (**56.4 %**) | 0.0120 ms |
+
+Biggest single-file win: `georgtree/ruff/src/ruff.tcl` (3,060 lines, no
+object seeds) — **0.248 ms → 0.105 ms**, a 58 % cut on a file where the
+entire propagation was provably dead.
+
+**The obvious gate is unsound.** `if out.is_empty() { return; }` — the
+literal check the design proposed — *loses real bindings*, because two
+edges fire with an empty seed set:
+
+| shape | binding lost by `out.is_empty()` |
+|---|---|
+| `proc make {} { return [Pin new] }` + `set c [make]` | `c → ::Pin` (proc-return edge; the object never lands in a `set` target the harvest sees) |
+| `proc take {dev} {…}` + `take [listbox .l]` | `dev → listbox` (`arg_classes`' direct-constructor branch reads no seed) |
+| `Wrap new [listbox .l]` | `inner → listbox` (same branch, constructor parameter) |
+| `take [struct::graph]` | `dev → struct::graph` (naming-factory form) |
+
+The shipped gate is therefore the three-part condition "no seeded handle
+**and** no object-returning proc **and** no argument that could be a
+bracketed registry constructor", the third part computed for free during
+the harvest walk that is already running. All four shapes above are pinned
+by `empty_seed_fast_path_is_behaviour_preserving`, which compares the fast
+path against `object_handle_classes_full_walk` (the pre-#994 unconditional
+walk, kept for exactly this purpose).
+
+## Bindings by VTA edge kind (corpus total)
+
+| edge | bindings |
+|---|--:|
+| seed (harvest) | 86 |
+| aliasing `set A $B` | 2 |
+| proc return `set A [f]` | 1 |
+| proc parameter `f $obj` | 0 |
+| constructor parameter `C new $obj` | 0 |
+
+Fixpoint rounds: max **2**, median **0**; 122 of 154 files run no round at
+all (109 via the new fast path, 13 more via the pre-existing callee-side
+early-out).
+
+This is the same picture `mro_eval` measured from the other direction: on
+real TclOO corpora, objects are overwhelmingly *received*, not
+*constructed*, in the scope that dispatches on them — the intraprocedural
+seeds are few (86 across 66,827 lines) and the propagation edges fire
+rarely. It also explains why the cost gates pass by more than an order of
+magnitude: there is almost nothing to propagate.
+
+Two consequences worth carrying into C5b:
+
+1. **The lattice's value is not in its fixpoint.** 89 of 89 propagated
+   bindings come from the seed harvest and three alias/return edges. C5b's
+   ⊤-rate improvement must come from the *carrier* — one shared fact, read
+   by all five dispatch consumers — not from the propagation getting
+   cleverer.
+2. **Cost is a non-issue at this scale, so the C5b gate is precision, not
+   latency.** A wrong resolution is a rename that breaks code; the design
+   already sets 100 % precision on hand-labelled newly-bound sites as the
+   C5b bar, and nothing here argues for relaxing it.
+
+## Differential gates (no behaviour change)
+
+C5a adds a producer and no consumer, so the diagnostics must be
+byte-identical. Two corpus-wide differentials were run over **1,388 files**
+(Tcl 8.6.16 `library/` + tcllib 2.0 `modules/` + this experiment's 154-file
+OO corpus):
+
+| differential | question | result |
+|---|---|--:|
+| `object_handle_classes` vs `object_handle_classes_full_walk` | does the empty-seed fast path — the only change to an existing output — move any consumer's map? | **0 / 1,388 divergences** |
+| `analyse` vs `analyse_per_item` on `object_handle_facts` | does the new fact need a per-item merge? | **0 / 1,388 divergences** |
+
+The first is the load-bearing one: the fast path is the *only* thing in
+C5a that can change what an existing consumer (the optimiser, the
+interprocedural seed, `type_infer`, semantic tokens) sees, so zero
+divergence over 1,388 real files is what makes "no behaviour change"
+a measurement rather than an assertion.
+
+Also green:
+
+- `cargo test -p tcl-compiler` — 7,726 tests, 0 failures (25 of them in
+  `object_types`, including `any_scope_is_verbatim_object_handle_classes`
+  and the four-shape fast-path equality gate).
+- `cargo test -p tcl-compiler --test per_item_corpus -- --ignored` — 818
+  files, 25 whole-`AnalysisResult` mismatches, **all pre-existing**: every
+  one was checked and `object_handle_facts` is identical between the two
+  paths in each (the 15 the describer could not pinpoint were probed
+  field-by-field; the other 10 name pre-existing fields —
+  `instance_classes`, `diagnostics`, `global_scope`).
+- `cargo run -p tcl-lsp-db --example fa_diff` — `safe.tcl` 50=50,
+  `init.tcl` 23=23, `clay/clay.tcl` 94=94 diagnostics, 0 either-only.
+- `cargo run -p tcl-lsp-db --example cc_diff` — same three files, 0
+  memo-only / fresh-only checks **and** optimisations.

--- a/experiments/object_lattice/RESULTS.md
+++ b/experiments/object_lattice/RESULTS.md
@@ -78,48 +78,58 @@ matching the MANIFEST totals exactly.
 
 ```
 measured 154 files, 66,827 lines
-totals: CU build 1213.2 ms, lattice 3.8 ms (0.32 % of CU),
+totals: CU build 1371.1 ms, lattice 5.0 ms (0.36 % of CU),
         +scope-keying 0.8 ms (0.06 % of CU)
 ```
 
 | gate | threshold | measured | verdict |
 |---|--:|--:|---|
-| median lattice / CU build | ≤ 5 % | **0.22 %** | **PASS** (23× margin) |
-| p99 lattice / CU build | ≤ 15 % | **1.46 %** | **PASS** (10× margin) |
-| worst-file lattice time | ≤ 25 ms | **0.648 ms** | **PASS** (39× margin) |
+| median lattice / CU build | ≤ 5 % | **0.24 %** | **PASS** (21× margin) |
+| p99 lattice / CU build | ≤ 15 % | **1.43 %** | **PASS** (10× margin) |
+| worst-file lattice time | ≤ 25 ms | **0.802 ms** | **PASS** (31× margin) |
 
 **Worst file:** `experiments/corpus/georgtree/SpiceGenTcl/src/generalClasses.tcl`
-— 3,038 lines, 0.648 ms of lattice on a 79.8 ms CU build (**0.81 %**), 2
+— 3,038 lines, 0.802 ms of lattice on an 85.2 ms CU build (**0.94 %**), 2
 fixpoint rounds, 3 handles. It is the worst file by *absolute* lattice time,
-not by ratio; the worst *ratio* is 1.55 %
+not by ratio; the worst *ratio* is 1.86 %
 (`SpiceGenTcl/examples/ltspice/advanced/diode_extract.tcl`, 143 lines).
 
-Scope-keying — the thing C5a actually adds — costs **0.8 ms across the
-whole corpus**, 0.06 % of the CU build and 21 % of the lattice itself. It
-is not a measurable cost at LSP latencies.
+Scope-keying — the thing C5a actually adds, including the scoped source
+resolution the `by_scope` fixpoint runs — costs **0.8 ms across the whole
+corpus**, 0.06 % of the CU build and 16 % of the lattice itself. It is not a
+measurable cost at LSP latencies.
 
-Run-to-run spread across repeats of the whole sweep is ~5 % on the totals
-and does not move any verdict: the tightest gate still clears by 10×.
+Run-to-run spread across repeats of the whole sweep is ~10 % on the totals
+(the harness shares the box with other builds; this sweep's CU-build total
+is 13 % above the pre-scoped-propagation sweep's, which moves the lattice
+column with it) and does not move any verdict: the tightest gate still
+clears by 10×.
+
+Scoped propagation — resolving each edge's source variable in its owning
+scope for the `by_scope` fact — was added after review (see "Scoped
+propagation" below) and cost nothing measurable: median ratio 0.22 % →
+0.24 %, p99 1.46 % → 1.43 %, `+scope-keying` 0.8 ms → 0.8 ms, on a sweep
+whose baseline CU build was itself 13 % slower.
 
 ## Per-file (slowest 15 by lattice ms)
 
 | file | lines | CU build ms | lattice ms | lattice % of CU | +scope-keying ms | rounds | handles | scoped |
 |---|--:|--:|--:|--:|--:|--:|--:|--:|
-| `georgtree/SpiceGenTcl/src/generalClasses.tcl` | 3038 | 79.763 | 0.648 | 0.81 % | 0.172 | 2 | 3 | 3 |
-| `georgtree/tclopt/tclopt.tcl` | 3843 | 121.984 | 0.475 | 0.39 % | 0.134 | 1 | 0 | 0 |
-| `vendor/tcllib/clay.tcl` | 2227 | 77.332 | 0.182 | 0.23 % | 0.043 | 1 | 0 | 0 |
-| `georgtree/SpiceGenTcl/src/specElementsClassesCommon.tcl` | 1307 | 23.322 | 0.164 | 0.70 % | 0.039 | 1 | 0 | 0 |
-| `georgtree/SpiceGenTcl/src/ngspice/specElementsClassesNgspice.tcl` | 1491 | 24.736 | 0.162 | 0.66 % | 0.023 | 1 | 0 | 0 |
-| `georgtree/SpiceGenTcl/src/ltspice/specElementsClassesLtspice.tcl` | 1533 | 27.206 | 0.159 | 0.58 % | 0.037 | 1 | 0 | 0 |
-| `georgtree/argparse/argparse.tcl` | 977 | 58.632 | 0.149 | 0.25 % | 0.000 | 1 | 0 | 0 |
-| `georgtree/SpiceGenTcl/src/xyce/specElementsClassesXyce.tcl` | 1053 | 18.619 | 0.116 | 0.62 % | 0.007 | 1 | 0 | 0 |
-| `georgtree/ruff/src/ruff.tcl` | 3060 | 72.291 | 0.105 | 0.14 % | 0.024 | 0 | 0 | 0 |
-| `georgtree/SpiceGenTcl/src/ngspice/netlistParserClassNgspice.tcl` | 1123 | 34.298 | 0.104 | 0.30 % | 0.054 | 0 | 0 | 0 |
-| `georgtree/SpiceGenTcl/examples/ltspice/advanced/diode_extract.tcl` | 143 | 4.774 | 0.074 | 1.55 % | 0.003 | 1 | 3 | 3 |
-| `georgtree/SpiceGenTcl/examples/ngspice/advanced/inverter_optimization.tcl` | 190 | 6.712 | 0.074 | 1.10 % | 0.000 | 1 | 1 | 1 |
-| `georgtree/SpiceGenTcl/examples/ngspice/advanced/verilog_a_magnetic.tcl` | 166 | 5.654 | 0.073 | 1.30 % | 0.020 | 1 | 13 | 13 |
-| `georgtree/tcl_tools/gnuplotutil.tcl` | 861 | 28.876 | 0.070 | 0.24 % | 0.002 | 0 | 0 | 0 |
-| `georgtree/SpiceGenTcl/examples/ngspice/advanced/diode_extract.tcl` | 142 | 4.502 | 0.069 | 1.54 % | 0.002 | 1 | 3 | 3 |
+| `georgtree/SpiceGenTcl/src/generalClasses.tcl` | 3038 | 85.171 | 0.802 | 0.94 % | 0.264 | 2 | 3 | 3 |
+| `georgtree/tclopt/tclopt.tcl` | 3843 | 137.230 | 0.645 | 0.47 % | 0.138 | 1 | 0 | 0 |
+| `vendor/tcllib/clay.tcl` | 2227 | 92.637 | 0.251 | 0.27 % | 0.019 | 1 | 0 | 0 |
+| `georgtree/SpiceGenTcl/src/ltspice/specElementsClassesLtspice.tcl` | 1533 | 31.775 | 0.203 | 0.64 % | 0.023 | 1 | 0 | 0 |
+| `georgtree/SpiceGenTcl/src/ngspice/specElementsClassesNgspice.tcl` | 1491 | 30.497 | 0.195 | 0.64 % | 0.019 | 1 | 0 | 0 |
+| `georgtree/SpiceGenTcl/src/specElementsClassesCommon.tcl` | 1307 | 28.175 | 0.194 | 0.69 % | 0.027 | 1 | 0 | 0 |
+| `georgtree/argparse/argparse.tcl` | 977 | 63.258 | 0.177 | 0.28 % | 0.000 | 1 | 0 | 0 |
+| `georgtree/ruff/src/ruff.tcl` | 3060 | 78.705 | 0.147 | 0.19 % | 0.008 | 0 | 0 | 0 |
+| `georgtree/SpiceGenTcl/src/xyce/specElementsClassesXyce.tcl` | 1053 | 22.182 | 0.139 | 0.63 % | 0.007 | 1 | 0 | 0 |
+| `georgtree/SpiceGenTcl/src/ngspice/netlistParserClassNgspice.tcl` | 1123 | 41.077 | 0.135 | 0.33 % | 0.057 | 0 | 0 | 0 |
+| `georgtree/SpiceGenTcl/examples/ltspice/advanced/diode_extract.tcl` | 143 | 5.715 | 0.106 | 1.86 % | 0.006 | 1 | 3 | 3 |
+| `georgtree/SpiceGenTcl/examples/ngspice/advanced/inverter_optimization.tcl` | 190 | 7.971 | 0.103 | 1.30 % | 0.000 | 1 | 1 | 1 |
+| `georgtree/SpiceGenTcl/examples/ngspice/advanced/verilog_a_magnetic.tcl` | 166 | 6.845 | 0.098 | 1.43 % | 0.010 | 1 | 13 | 13 |
+| `georgtree/SpiceGenTcl/examples/ngspice/advanced/diode_extract.tcl` | 142 | 5.495 | 0.094 | 1.70 % | 0.005 | 1 | 3 | 3 |
+| `georgtree/tcl_tools/gnuplotutil.tcl` | 861 | 34.207 | 0.091 | 0.27 % | 0.000 | 0 | 0 | 0 |
 
 The `handles` / `scoped` columns are the sizes of `any_scope` and
 `by_scope`. They are equal on every corpus file: no file in this corpus has
@@ -137,10 +147,10 @@ statement walk.
 
 | files | lattice ms (fast path) | lattice ms (pre-#994 walk) | saved | saved / file |
 |--:|--:|--:|--:|--:|
-| 109 of 154 | 1.012 | 2.323 | 1.311 ms (**56.4 %**) | 0.0120 ms |
+| 109 of 154 | 1.366 | 2.976 | 1.610 ms (**54.1 %**) | 0.0148 ms |
 
 Biggest single-file win: `georgtree/ruff/src/ruff.tcl` (3,060 lines, no
-object seeds) — **0.248 ms → 0.105 ms**, a 58 % cut on a file where the
+object seeds) — **0.340 ms → 0.147 ms**, a 57 % cut on a file where the
 entire propagation was provably dead.
 
 **The obvious gate is unsound.** `if out.is_empty() { return; }` — the
@@ -162,15 +172,57 @@ by `empty_seed_fast_path_is_behaviour_preserving`, which compares the fast
 path against `object_handle_classes_full_walk` (the pre-#994 unconditional
 walk, kept for exactly this purpose).
 
+## Scoped propagation (post-review fix)
+
+Owner attribution decides where a binding is *written*. Review (Codex on
+PR #1127) found that is not enough on its own: the fixpoint was resolving
+every edge's **source** against the scope-blind union, then attributing the
+result to a specific owner. Given
+
+```tcl
+proc a {} { set x [Pin new] }
+proc b {} { set x 0; set y $x }
+```
+
+`b`'s alias read `a`'s `x` and recorded `(::b, y) → ::Pin` — a false
+**singleton** in the map C5b's rename edits and the "provably a different
+class" refusal gate treat as authoritative. That is precisely the
+wrong-rewrite hazard `by_scope` exists to prevent, so a scope-keyed *output*
+over a scope-blind *propagation* is not a narrow map at all.
+
+The fix resolves each edge's source in the scope that owns it:
+
+| edge | source | resolved in |
+|---|---|---|
+| aliasing | the read variable | the **reading unit**, then its class for an instance variable, then nothing |
+| proc return | the callee's return type | nowhere — not a variable read, so unit-independent |
+| proc parameter | the call-site argument | the **caller**, bound in the callee |
+| constructor parameter | the call-site argument | the **caller**, bound in the constructor |
+
+Both facts advance in one walk, each reading back only its own map, so
+`any_scope` is untouched — verified below, not assumed. Cost: nil (see the
+headline table's last paragraph).
+
+Guarded by `by_scope_does_not_import_another_units_binding_through_an_alias`
+(the FP guard, Codex's exact shape) plus three TP twins:
+`by_scope_alias_within_one_unit_still_propagates`,
+`by_scope_instance_var_alias_reads_the_class_owner` (the #797 bridge under
+scoped resolution), and `by_scope_cross_unit_call_edges_still_bind`.
+
 ## Bindings by VTA edge kind (corpus total)
 
 | edge | bindings |
 |---|--:|
 | seed (harvest) | 86 |
 | aliasing `set A $B` | 2 |
-| proc return `set A [f]` | 1 |
+| proc return `set A [f]` | 2 |
 | proc parameter `f $obj` | 0 |
 | constructor parameter `C new $obj` | 0 |
+
+(Edge counts are per-round *emissions*, not distinct bindings: an edge whose
+source was already at its fixpoint is re-emitted and re-unioned as a no-op.
+The proc-return count is 2 rather than 1 because the scope-keyed fact can
+lag the union by a round, so one file runs one extra round.)
 
 Fixpoint rounds: max **2**, median **0**; 122 of 154 files run no round at
 all (109 via the new fast path, 13 more via the pre-existing callee-side
@@ -185,8 +237,9 @@ magnitude: there is almost nothing to propagate.
 
 Two consequences worth carrying into C5b:
 
-1. **The lattice's value is not in its fixpoint.** 89 of 89 propagated
-   bindings come from the seed harvest and three alias/return edges. C5b's
+1. **The lattice's value is not in its fixpoint.** Effectively every
+   binding comes from the seed harvest, with three alias/return edges on top.
+   C5b's
    ⊤-rate improvement must come from the *carrier* — one shared fact, read
    by all five dispatch consumers — not from the propagation getting
    cleverer.
@@ -198,33 +251,34 @@ Two consequences worth carrying into C5b:
 ## Differential gates (no behaviour change)
 
 C5a adds a producer and no consumer, so the diagnostics must be
-byte-identical. Two corpus-wide differentials were run over **1,388 files**
-(Tcl 8.6.16 `library/` + tcllib 2.0 `modules/` + this experiment's 154-file
-OO corpus):
+byte-identical. Four invariants, checked over **435 files** (the 154-file OO
+corpus plus `samples/`, `editors/vscode/testFixture/`, and the compiler's
+own fixtures):
 
-| differential | question | result |
+| invariant | question | result |
 |---|---|--:|
-| `object_handle_classes` vs `object_handle_classes_full_walk` | does the empty-seed fast path — the only change to an existing output — move any consumer's map? | **0 / 1,388 divergences** |
-| `analyse` vs `analyse_per_item` on `object_handle_facts` | does the new fact need a per-item merge? | **0 / 1,388 divergences** |
+| `object_handle_classes` vs `object_handle_classes_full_walk` | does the empty-seed fast path — the only change to an existing output — move any consumer's map? | **0 divergences** |
+| `object_handle_facts(..).any_scope` vs `object_handle_classes(..)` | does the scoped `by_scope` propagation perturb the union fact the shipping consumers read? | **0 divergences** |
+| `analyse` vs `analyse_per_item` on `object_handle_facts` | does the new fact need a per-item merge? | **0 divergences** |
+| `by_scope[(owner, name)] ⊆ any_scope[name]` | is the narrow map really a refinement of the wide one? | **0 violations** |
 
-The first is the load-bearing one: the fast path is the *only* thing in
-C5a that can change what an existing consumer (the optimiser, the
-interprocedural seed, `type_infer`, semantic tokens) sees, so zero
-divergence over 1,388 real files is what makes "no behaviour change"
-a measurement rather than an assertion.
+The first two are the load-bearing ones: between them they say the *only*
+things an existing consumer can see — the union map — did not move, by
+measurement rather than assertion. An earlier sweep of the first and third
+over 1,388 files (Tcl 8.6.16 `library/` + tcllib 2.0 `modules/` + the OO
+corpus) was likewise clean.
 
 Also green:
 
-- `cargo test -p tcl-compiler` — 7,726 tests, 0 failures (25 of them in
-  `object_types`, including `any_scope_is_verbatim_object_handle_classes`
-  and the four-shape fast-path equality gate).
+- `cargo test -p tcl-compiler` — 7,733 tests, 0 failures (29 of them in
+  `object_types`).
 - `cargo test -p tcl-compiler --test per_item_corpus -- --ignored` — 818
-  files, 25 whole-`AnalysisResult` mismatches, **all pre-existing**: every
-  one was checked and `object_handle_facts` is identical between the two
-  paths in each (the 15 the describer could not pinpoint were probed
-  field-by-field; the other 10 name pre-existing fields —
-  `instance_classes`, `diagnostics`, `global_scope`).
-- `cargo run -p tcl-lsp-db --example fa_diff` — `safe.tcl` 50=50,
-  `init.tcl` 23=23, `clay/clay.tcl` 94=94 diagnostics, 0 either-only.
-- `cargo run -p tcl-lsp-db --example cc_diff` — same three files, 0
-  memo-only / fresh-only checks **and** optimisations.
+  files, 25 whole-`AnalysisResult` mismatches, **all pre-existing**:
+  `object_handle_facts` is identical between the two paths in every one.
+- `cargo run -p tcl-lsp-db --example fa_diff` — `clay.tcl` 94=94,
+  `generalClasses.tcl` 88=88, `ruff.tcl` 32=32 diagnostics, 0 either-only.
+- `cargo run -p tcl-lsp-db --example cc_diff` — 0 memo-only / fresh-only on
+  `clay.tcl` and `ruff.tcl`. `generalClasses.tcl` reports 20 fresh-only
+  O100s; that is the pre-existing `function_lattice` memo divergence
+  `cc_diff` was written to reproduce — A/B-checked identical with and
+  without this change.

--- a/rust/tcl-compiler/examples/object_lattice_cost.rs
+++ b/rust/tcl-compiler/examples/object_lattice_cost.rs
@@ -1,0 +1,354 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! `object_lattice_cost` — measurement gate **M1** for issue #994's C5a.
+//!
+//! The object-handle lattice ([`tcl_compiler::object_types`]) rides on a
+//! [`CompilationUnit`] the analyser already builds, so the only question C5a
+//! has to answer is whether the lattice — and the scope-keying C5b's consumers
+//! need — is cheap *relative to the unit it rides on*.  This harness measures
+//! exactly that, per file:
+//!
+//! * **CU build ms** — `build_for` + `with_interprocedural`, the pass the
+//!   lattice rides on.
+//! * **lattice ms** — [`object_handle_classes`], the union-only map that ships
+//!   today.
+//! * **+scope-keying ms** — [`object_handle_facts`] minus the above: the owner
+//!   attribution, owner-span index, collection map, and exported sub-facts.
+//! * **fixpoint rounds** and **bindings by VTA edge kind**.
+//! * **fast-path delta** — the same lattice with and without the empty-seed
+//!   fast path, so the win on a file with no object seeds is visible.
+//!
+//! Gates (from the C5a design): median lattice ≤ 5 % of CU build, p99 ≤ 15 %,
+//! and no single file over 25 ms of lattice time.
+//!
+//! Usage:
+//!
+//! ```text
+//! cargo run --release -p tcl-compiler --example object_lattice_cost -- \
+//!     experiments/corpus/georgtree experiments/corpus/adversarial \
+//!     experiments/corpus/vendor experiments/corpus/repo-fixtures
+//! ```
+//!
+//! `REPEATS=n` (default 3) runs each timed phase `n` times and keeps the
+//! minimum, which suppresses scheduler noise on the small files.
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use tcl_compiler::compilation_unit::CompilationUnit;
+use tcl_compiler::object_types::{
+    LatticeStats, object_handle_classes, object_handle_classes_full_walk, object_handle_facts,
+};
+use tcl_registry::CommandRegistry;
+
+/// Lossless-for-realistic-counts `usize`→`f64`, as `mro_eval` does it.
+fn as_f64(n: usize) -> f64 {
+    f64::from(u32::try_from(n).unwrap_or(u32::MAX))
+}
+
+/// One measured file.
+struct Row {
+    path: PathBuf,
+    lines: usize,
+    cu_ms: f64,
+    lattice_ms: f64,
+    scope_ms: f64,
+    fast_walk_ms: f64,
+    stats: LatticeStats,
+    handles: usize,
+    scoped_handles: usize,
+}
+
+impl Row {
+    /// Lattice time as a percentage of the CU build it rides on.
+    fn ratio(&self) -> f64 {
+        if self.cu_ms <= 0.0 {
+            0.0
+        } else {
+            100.0 * self.lattice_ms / self.cu_ms
+        }
+    }
+}
+
+/// Recursively collect `.tcl` / `.test` files under `root`.
+fn collect_tcl_files(root: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+            if matches!(name, ".git" | "target" | "node_modules" | ".venv") {
+                continue;
+            }
+            collect_tcl_files(&path, out);
+        } else if path
+            .extension()
+            .and_then(|s| s.to_str())
+            .is_some_and(|ext| ext == "tcl" || ext == "test")
+        {
+            out.push(path);
+        }
+    }
+}
+
+/// Run `f` `repeats` times, returning the fastest elapsed milliseconds.
+fn best_ms(repeats: usize, mut f: impl FnMut()) -> f64 {
+    let mut best = f64::MAX;
+    for _ in 0..repeats.max(1) {
+        let t0 = Instant::now();
+        f();
+        best = best.min(t0.elapsed().as_secs_f64() * 1000.0);
+    }
+    best
+}
+
+/// Measure one file; `None` on read error / oversize / panic.
+fn measure(path: &Path, reg: &CommandRegistry, repeats: usize) -> Option<Row> {
+    let src = std::fs::read_to_string(path).ok()?;
+    if src.len() > 2_000_000 {
+        return None;
+    }
+    let lines = src.lines().count();
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let cu_ms = best_ms(repeats, || {
+            let cu = CompilationUnit::build_for(&src, reg, false)
+                .with_interprocedural(reg, Some("tcl8.6"));
+            std::hint::black_box(&cu);
+        });
+        let cu =
+            CompilationUnit::build_for(&src, reg, false).with_interprocedural(reg, Some("tcl8.6"));
+        let lattice_ms = best_ms(repeats, || {
+            std::hint::black_box(object_handle_classes(&cu, reg));
+        });
+        let full_ms = best_ms(repeats, || {
+            std::hint::black_box(object_handle_facts(&cu, reg));
+        });
+        let fast_walk_ms = best_ms(repeats, || {
+            std::hint::black_box(object_handle_classes_full_walk(&cu, reg));
+        });
+        let (facts, stats) = tcl_compiler::object_types::object_handle_facts_instrumented(&cu, reg);
+        Row {
+            path: path.to_path_buf(),
+            lines,
+            cu_ms,
+            lattice_ms,
+            scope_ms: (full_ms - lattice_ms).max(0.0),
+            fast_walk_ms,
+            stats,
+            handles: facts.any_scope.len(),
+            scoped_handles: facts.by_scope.len(),
+        }
+    }))
+    .ok()
+}
+
+/// The `num`/`den` quantile of an already-sorted slice, by nearest rank.
+/// Integer arithmetic throughout, so there is no float→index cast to justify.
+fn quantile(sorted: &[f64], num: usize, den: usize) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    let last = sorted.len() - 1;
+    sorted[((last * num) + den / 2) / den]
+}
+
+/// Print the per-file table (the slowest `n` rows plus every row over the
+/// per-file ceiling).
+fn print_per_file(rows: &[&Row], limit: usize) {
+    println!("\n## Per-file (slowest {limit} by lattice ms)\n");
+    println!(
+        "| file | lines | CU build ms | lattice ms | lattice % of CU | +scope-keying ms | rounds | handles | scoped |"
+    );
+    println!("|---|--:|--:|--:|--:|--:|--:|--:|--:|");
+    for r in rows.iter().take(limit) {
+        println!(
+            "| `{}` | {} | {:.3} | {:.3} | {:.2} % | {:.3} | {} | {} | {} |",
+            r.path.display(),
+            r.lines,
+            r.cu_ms,
+            r.lattice_ms,
+            r.ratio(),
+            r.scope_ms,
+            r.stats.rounds,
+            r.handles,
+            r.scoped_handles,
+        );
+    }
+}
+
+/// Print the aggregate gate verdicts.
+fn print_gates(rows: &[Row]) {
+    let mut ratios: Vec<f64> = rows.iter().map(Row::ratio).collect();
+    ratios.sort_by(f64::total_cmp);
+    let median = quantile(&ratios, 1, 2);
+    let p99 = quantile(&ratios, 99, 100);
+    let worst_file = rows
+        .iter()
+        .max_by(|a, b| a.lattice_ms.total_cmp(&b.lattice_ms));
+    let worst_ms = worst_file.map_or(0.0, |r| r.lattice_ms);
+
+    let verdict = |ok: bool| if ok { "PASS" } else { "**FAIL**" };
+    println!("\n## Gate verdicts\n");
+    println!("| gate | threshold | measured | verdict |");
+    println!("|---|--:|--:|---|");
+    println!(
+        "| median lattice / CU build | ≤ 5 % | {median:.2} % | {} |",
+        verdict(median <= 5.0)
+    );
+    println!(
+        "| p99 lattice / CU build | ≤ 15 % | {p99:.2} % | {} |",
+        verdict(p99 <= 15.0)
+    );
+    println!(
+        "| worst-file lattice time | ≤ 25 ms | {worst_ms:.3} ms | {} |",
+        verdict(worst_ms <= 25.0)
+    );
+    if let Some(w) = worst_file {
+        println!(
+            "\nWorst file: `{}` — {:.3} ms lattice on a {:.3} ms CU build ({:.2} %), {} lines, {} rounds.",
+            w.path.display(),
+            w.lattice_ms,
+            w.cu_ms,
+            w.ratio(),
+            w.lines,
+            w.stats.rounds,
+        );
+    }
+}
+
+/// Print the empty-seed fast-path win and the edge-kind roll-up.
+fn print_fast_path_and_edges(rows: &[Row]) {
+    let hits: Vec<&Row> = rows.iter().filter(|r| r.stats.fast_path_hit).collect();
+    let with: f64 = hits.iter().map(|r| r.lattice_ms).sum();
+    let without: f64 = hits.iter().map(|r| r.fast_walk_ms).sum();
+    println!("\n## Empty-seed fast path\n");
+    println!(
+        "| files | lattice ms (fast path) | lattice ms (pre-#994 walk) | saved | saved / file |"
+    );
+    println!("|--:|--:|--:|--:|--:|");
+    let saved = without - with;
+    println!(
+        "| {} of {} | {with:.3} | {without:.3} | {saved:.3} ms ({:.1} %) | {:.4} ms |",
+        hits.len(),
+        rows.len(),
+        if without > 0.0 {
+            100.0 * saved / without
+        } else {
+            0.0
+        },
+        saved / as_f64(hits.len().max(1)),
+    );
+    if let Some(w) = hits
+        .iter()
+        .max_by(|a, b| (a.fast_walk_ms - a.lattice_ms).total_cmp(&(b.fast_walk_ms - b.lattice_ms)))
+    {
+        println!(
+            "\nBiggest single-file win: `{}` ({} lines) — {:.3} ms → {:.3} ms.",
+            w.path.display(),
+            w.lines,
+            w.fast_walk_ms,
+            w.lattice_ms,
+        );
+    }
+
+    let sum = |f: fn(&LatticeStats) -> usize| rows.iter().map(|r| f(&r.stats)).sum::<usize>();
+    println!("\n## Bindings by VTA edge kind (corpus total)\n");
+    println!("| edge | bindings |");
+    println!("|---|--:|");
+    println!("| seed (harvest) | {} |", sum(|s| s.seeds));
+    println!("| aliasing `set A $B` | {} |", sum(|s| s.alias_bindings));
+    println!(
+        "| proc return `set A [f]` | {} |",
+        sum(|s| s.return_bindings)
+    );
+    println!(
+        "| proc parameter `f $obj` | {} |",
+        sum(|s| s.param_bindings)
+    );
+    println!(
+        "| constructor parameter `C new $obj` | {} |",
+        sum(|s| s.ctor_param_bindings)
+    );
+    let mut rounds: Vec<usize> = rows.iter().map(|r| r.stats.rounds as usize).collect();
+    rounds.sort_unstable();
+    println!(
+        "\nFixpoint rounds: max {}, median {}, {} files ran none (fast path).",
+        rounds.last().copied().unwrap_or(0),
+        rounds.get(rounds.len() / 2).copied().unwrap_or(0),
+        rows.iter().filter(|r| r.stats.rounds == 0).count(),
+    );
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let roots: Vec<PathBuf> = if args.is_empty() {
+        ["experiments/corpus"].iter().map(PathBuf::from).collect()
+    } else {
+        args.iter().map(PathBuf::from).collect()
+    };
+    let repeats: usize = std::env::var("REPEATS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(3);
+
+    let mut files = Vec::new();
+    for r in &roots {
+        collect_tcl_files(r, &mut files);
+    }
+    files.sort();
+    if files.is_empty() {
+        eprintln!("no Tcl files under {roots:?}");
+        std::process::exit(1);
+    }
+
+    println!("# object_lattice_cost — issue #994 C5a measurement gate M1");
+    println!(
+        "\ncorpus roots: {:?}\nfiles: {}, repeats: {repeats}",
+        roots
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>(),
+        files.len(),
+    );
+
+    let reg = CommandRegistry::build_default();
+    let rows: Vec<Row> = files
+        .iter()
+        .filter_map(|p| measure(p, &reg, repeats))
+        .collect();
+
+    let total_lines: usize = rows.iter().map(|r| r.lines).sum();
+    let cu_total: f64 = rows.iter().map(|r| r.cu_ms).sum();
+    let lattice_total: f64 = rows.iter().map(|r| r.lattice_ms).sum();
+    let scope_total: f64 = rows.iter().map(|r| r.scope_ms).sum();
+    let measured = rows.len();
+    let lattice_pct = 100.0 * lattice_total / cu_total.max(1e-9);
+    let scope_pct = 100.0 * scope_total / cu_total.max(1e-9);
+    println!(
+        "measured {measured} files, {total_lines} lines\ntotals: CU build {cu_total:.1} ms, lattice {lattice_total:.1} ms ({lattice_pct:.2} % of CU), +scope-keying {scope_total:.1} ms ({scope_pct:.2} % of CU)"
+    );
+
+    print_gates(&rows);
+    let mut by_cost: Vec<&Row> = rows.iter().collect();
+    by_cost.sort_by(|a, b| b.lattice_ms.total_cmp(&a.lattice_ms));
+    print_per_file(&by_cost, 15);
+    print_fast_path_and_edges(&rows);
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -186,6 +186,42 @@ impl Analyser {
         }));
     }
 
+    /// The compilation-unit-derived object-fact seam, run before any emitter
+    /// that reads those facts.
+    ///
+    /// Issue #923 idx 121: the pending `$class`-headed `TclOO`
+    /// instance-creation sites must settle against `cu`'s flow-sensitive value
+    /// model **first** — `emit_var_command_diagnostics` reads
+    /// `instance_classes` to suppress W307 / validate W308, so the settle must
+    /// land before that read, not after (unlike `settle_const_dispatches`,
+    /// which only feeds `command_invocations` and has no such in-pass reader).
+    fn settle_cu_derived_object_facts(
+        &mut self,
+        cu: &crate::compilation_unit::CompilationUnit,
+        registry: &tcl_registry::CommandRegistry,
+    ) {
+        self.settle_pending_instance_class_sites(cu);
+        self.produce_object_handle_facts(cu, registry);
+    }
+
+    /// Issue #994 (C5a): the **one** producer of
+    /// [`crate::analyser::types::AnalysisResult::object_handle_facts`], from
+    /// the same `cu` the CFG/SSA diagnostics ride on.
+    ///
+    /// Both analysis paths reach it — the whole-file
+    /// [`Self::emit_cfg_ssa_diagnostics`] build and the per-item incremental
+    /// path's memoised shell unit — so the fact is produced exactly once per
+    /// analysis and never merged per grafted body (`analyser/per_item.rs`
+    /// pins that with the same reasoning).  No consumer reads it in this PR;
+    /// the five dispatch sites and semantic tokens migrate in C5b.
+    fn produce_object_handle_facts(
+        &mut self,
+        cu: &crate::compilation_unit::CompilationUnit,
+        registry: &tcl_registry::CommandRegistry,
+    ) {
+        self.result.object_handle_facts = crate::object_types::object_handle_facts(cu, registry);
+    }
+
     /// Emit the CFG/SSA-derived diagnostics from an already-built
     /// [`crate::compilation_unit::CompilationUnit`].
     ///
@@ -200,14 +236,7 @@ impl Analyser {
         cu: &crate::compilation_unit::CompilationUnit,
         registry: &tcl_registry::CommandRegistry,
     ) {
-        // Issue #923 idx 121: resolve pending `$class`-headed `TclOO`
-        // instance-creation sites against `cu`'s flow-sensitive value
-        // model *first* — `emit_var_command_diagnostics` below reads
-        // `instance_classes` to suppress W307 / validate W308, so the
-        // settle must land before that read, not after (unlike
-        // `settle_const_dispatches`, which only feeds `command_invocations`
-        // and has no such in-pass reader).
-        self.settle_pending_instance_class_sites(cu);
+        self.settle_cu_derived_object_facts(cu, registry);
 
         // **W128.** Flag calls to commands renamed or
         // deleted earlier in the file via the flow-sensitive

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -542,6 +542,21 @@ impl Analyser {
             self.result.object_methods.entry(k).or_default().extend(v);
         }
         self.result.instance_classes.extend(r.instance_classes);
+        // `object_handle_facts` is deliberately **not** merged here (issue #994
+        // C5a).  It has exactly one producer — `emit_cfg_ssa_diagnostics_with_cu`
+        // — which runs on the *shell*, once, against the whole-file compilation
+        // unit the per-item path supplies via `set_cu_override`.  An isolated
+        // body fragment never reaches that producer (`analyse_proc_body_isolated`
+        // calls `analyse_body`, not `analyse`, so the diagnostic tail never
+        // runs), so `r.object_handle_facts` is always the empty default and a
+        // merge here could only ever be a no-op — or, if the fragment ever did
+        // gain facts, a *wrong* one: the fragment's owner keys are body-local
+        // and its spans are offset-0, neither of which `rebase_fragment` knows
+        // how to correct.  The `per_item_corpus` differential gate pins the
+        // equality this comment asserts; the assertion below pins the premise
+        // it rests on, so a future change that starts producing facts inside a
+        // body fragment fails loudly here instead of silently dropping them.
+        assert_no_body_object_facts(&r.object_handle_facts);
         self.result
             .created_instance_commands
             .extend(r.created_instance_commands);
@@ -855,6 +870,19 @@ pub fn analyse_proc_body_isolated<S: std::hash::BuildHasher>(
         w304: a.pending_w304,
         instances: a.pending_instances.unwrap_or_default(),
     }
+}
+
+/// Debug-only pin for the premise `graft_proc_body`'s `object_handle_facts`
+/// comment rests on: an isolated body fragment never reaches the fact's one
+/// producer, so there is nothing to merge.  A future change that starts
+/// producing facts inside a body fails here instead of silently dropping them.
+fn assert_no_body_object_facts(facts: &crate::object_types::ObjectHandleFacts) {
+    debug_assert_eq!(
+        *facts,
+        crate::object_types::ObjectHandleFacts::default(),
+        "an isolated body fragment must not produce object_handle_facts — see \
+         `graft_proc_body` before adding a merge"
+    );
 }
 
 /// Merge body-derived variables into a scope/`all_variables` map: an existing

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -1159,8 +1159,12 @@ pub struct AnalysisResult {
     ///
     /// **Which map to read.**  `by_scope` is keyed by the owning unit and is
     /// the *narrow* map: it never merges a `chart` in one proc with a `chart`
-    /// in another.  `any_scope` is the union across every scope and is the
-    /// *wide* map.  So:
+    /// in another.  That holds through the *propagation*, not just the keying —
+    /// every variable read an edge resolves is resolved in the reading unit's
+    /// own scope (or its class, for an instance variable), so one proc's
+    /// binding can never reach another's same-named local and leave a false
+    /// singleton behind.  `any_scope` is the union across every scope and is
+    /// the *wide* map — deliberately imprecise, and unchanged.  So:
     ///
     /// | consumer | map | why |
     /// |---|---|---|

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -1105,6 +1105,33 @@ pub struct AnalysisResult {
     /// last assignment wins, matching the global-by-var-name
     /// shape the W308 emitter already uses.
     pub instance_classes: HashMap<String, String>,
+    /// Owner-attributed object-handle provenance from the compilation unit's
+    /// VTA-lite lattice ([`crate::object_types::object_handle_facts`]) — the
+    /// carrier issue #994's unification is built on.
+    ///
+    /// **Contract.** Best-effort, exactly like [`Self::instance_classes`]: an
+    /// absent key means *no evidence was found in this document*, never *proof
+    /// that the name holds no object*.  An empty value (the default) is what
+    /// every CU-less analysis path produces, so a consumer must degrade to its
+    /// pre-lattice behaviour rather than concluding anything from emptiness.
+    ///
+    /// **Which map to read.**  `by_scope` is keyed by the owning unit and is
+    /// the *narrow* map: it never merges a `chart` in one proc with a `chart`
+    /// in another.  `any_scope` is the union across every scope and is the
+    /// *wide* map.  So:
+    ///
+    /// | consumer | map | why |
+    /// |---|---|---|
+    /// | edits (rename), find-references | `by_scope` only | widening here rewrites an unrelated variable — a wrong edit, not a missed one |
+    /// | navigation (definition, type-definition), hover | `by_scope`, then `any_scope` labelled as a guess | a wrong jump is recoverable; a missing one is not |
+    /// | semantic tokens / highlighting | either | colour-only, and the union is what shipped before |
+    /// | "provably a *different* class, so refuse/skip" gates | `by_scope` singletons only | widening turns an abstention into a false certainty, which silences a refusal that protects the user |
+    ///
+    /// Populated once per analysis, from the same `CompilationUnit` the
+    /// CFG/SSA diagnostics ride on (`analyser/diagnostics.rs`); no other
+    /// producer writes it and the per-item incremental path inherits it from
+    /// the shell, so there is nothing to merge per grafted body.
+    pub object_handle_facts: crate::object_types::ObjectHandleFacts,
     /// Simple names of instance commands created by a `CLASS create NAME …`
     /// construct — both when `CLASS` is a known user class *and* when it is an
     /// unresolved (external-package) command whose `create NAME` idiom clearly

--- a/rust/tcl-compiler/src/object_types.rs
+++ b/rust/tcl-compiler/src/object_types.rs
@@ -86,7 +86,7 @@ pub struct OwnerSpan {
 /// | map | key | widening risk | safe for |
 /// |---|---|---|---|
 /// | [`Self::any_scope`] | bare name | same name in two procs collides | highlighting, navigation (labelled) |
-/// | [`Self::by_scope`] | `(owner, name)` | none beyond the union join | edits, references, rename, refusal gates |
+/// | [`Self::by_scope`] | `(owner, name)` | none: sources resolve in their own scope | edits, references, rename, refusal gates |
 /// | [`Self::collections`] | bare name | cross-scope union (deliberate — the #797 bridge) | highlighting, collection dispatch |
 /// | [`Self::returns_object`] | proc qname | none (one return type per proc) | factory-call typing |
 /// | [`Self::global_object_cells`] | `::`-qualified name | none (the name *is* the cell) | cross-document index seeds |
@@ -101,6 +101,19 @@ pub struct ObjectHandleFacts {
     /// *callee*, a constructor-parameter edge in the *constructor*, and a
     /// class instance variable in the *class* (unioned across its methods —
     /// that union is the interprocedural bridge issue #797 needs).
+    ///
+    /// **Scoped propagation, not just scoped keying.**  Every variable *read*
+    /// an edge resolves is resolved in the reading unit's own scope (falling
+    /// back to its class for an instance variable, and to nothing otherwise) —
+    /// never through [`Self::any_scope`].  Keying the output alone would be
+    /// unsound: after `proc a {} { set x [Pin new] }`, the alias in
+    /// `proc b {} { set x 0; set y $x }` would read `a`'s `x` and record
+    /// `(::b, y) → ::Pin`, a false *singleton* in the map the rename edits and
+    /// the "provably a different class" refusal gate treat as authoritative.
+    /// Cross-*unit* edges are unaffected, because their source is not a scoped
+    /// variable read: a proc-return edge's source is the callee's return type,
+    /// and a parameter edge resolves its argument in the caller before binding
+    /// the parameter in the callee.
     pub by_scope: HashMap<(String, String), HashSet<String>>,
     /// Owning-scope extents, sorted by start (then by end descending) for the
     /// binary search in [`Self::owner_at`].  One entry per procedure and
@@ -381,6 +394,19 @@ struct OwnerIndex {
 }
 
 impl OwnerIndex {
+    /// A shared index that owns nothing — the scan context a
+    /// [`FactMode::AnyScopeOnly`] build carries, which never consults it.
+    /// Mirrors [`crate::compilation_unit::ModuleTraceFacts::none`]'s
+    /// "immutable empty, handed out for any lifetime" shape.
+    fn shared_empty() -> &'static Self {
+        static EMPTY: std::sync::OnceLock<OwnerIndex> = std::sync::OnceLock::new();
+        EMPTY.get_or_init(|| Self {
+            method_class: HashMap::new(),
+            class_instance_vars: HashMap::new(),
+            spans: Vec::new(),
+        })
+    }
+
     fn build(cu: &CompilationUnit, mode: FactMode) -> Self {
         let mut method_class: HashMap<String, String> = HashMap::new();
         let mut class_instance_vars: HashMap<String, HashSet<String>> = HashMap::new();
@@ -564,9 +590,13 @@ fn propagate_object_flow<'a>(
     };
 
     // Bounded fixpoint: a handful of rounds cover realistic alias/call chains
-    // without risking a runaway on a cyclic call graph.
+    // without risking a runaway on a cyclic call graph.  Both facts advance in
+    // the same walk, each reading back only its own map — the union stays the
+    // union it always was, and the scope-keyed map only ever grows from
+    // sources resolved in their owning scope.
+    let scoped = (sink.mode == FactMode::Full).then_some(sink.owners);
     for _ in 0..6 {
-        let bindings = scan_flow_edges(cu, registry, &sink.facts.any_scope, &index);
+        let bindings = scan_flow_edges(cu, registry, &sink.facts, scoped, &index);
         sink.stats.rounds += 1;
         let mut changed = false;
         for binding in bindings {
@@ -576,29 +606,31 @@ fn propagate_object_flow<'a>(
                 ObjectFlowEdge::ProcParam => sink.stats.param_bindings += 1,
                 ObjectFlowEdge::CtorParam => sink.stats.ctor_param_bindings += 1,
             }
-            // Convergence is decided by the union alone, so the scope-keyed
-            // twin can never change the number of rounds (nor, therefore,
-            // `any_scope`'s contents).
             let entry = sink
                 .facts
                 .any_scope
                 .entry(binding.name.clone())
                 .or_default();
-            let mut fresh = false;
-            for c in &binding.classes {
-                fresh |= entry.insert(c.clone());
+            for c in &binding.union_classes {
+                changed |= entry.insert(c.clone());
             }
-            changed |= fresh;
-            if sink.mode == FactMode::Full {
+            if sink.mode == FactMode::Full && !binding.scoped_classes.is_empty() {
                 let owner = sink
                     .owners
                     .owner_for(&binding.owner, &binding.name)
                     .to_owned();
-                sink.facts
+                let entry = sink
+                    .facts
                     .by_scope
                     .entry((owner, binding.name))
-                    .or_default()
-                    .extend(binding.classes);
+                    .or_default();
+                // The scope-keyed fact can still be growing after the union has
+                // settled (it lags by the round its source needed), so it drives
+                // the loop too.  Extra rounds cannot change `any_scope`: unioning
+                // a converged fixpoint with itself is a no-op.
+                for c in binding.scoped_classes {
+                    changed |= entry.insert(c);
+                }
             }
         }
         if !changed {
@@ -620,11 +652,43 @@ struct FlowIndex<'a> {
 /// One type-propagation edge's product: the classes `name` gains, and the unit
 /// the edge binds that name **in** (the assigning unit for an alias / return,
 /// the callee for a parameter, the constructor for a constructor parameter).
+///
+/// The two class sets are the two facts the module maintains, and they are
+/// **not** the same set:
+///
+/// * `union_classes` resolves the edge's source against the scope-blind
+///   [`ObjectHandleFacts::any_scope`] map, and feeds it back — the deliberate,
+///   documented highlight-grade imprecision this module has always had.
+/// * `scoped_classes` resolves the edge's source *in the scope that owns it*
+///   and feeds [`ObjectHandleFacts::by_scope`].  Empty means "no evidence in
+///   the owning scope", which is the whole point: a `set y $x` in one proc
+///   must not read a same-named `x` bound in another (issue #994 C5a review —
+///   a false singleton in the narrow map is a wrong rename, not a missed one).
 struct Binding {
     owner: String,
     name: String,
-    classes: HashSet<String>,
+    union_classes: HashSet<String>,
+    scoped_classes: HashSet<String>,
     kind: ObjectFlowEdge,
+}
+
+/// The two class sets one edge yields — see [`Binding`].
+struct EdgeClasses {
+    union: HashSet<String>,
+    scoped: HashSet<String>,
+}
+
+impl EdgeClasses {
+    /// An edge whose source is **unit-independent** (a callee's return type, a
+    /// literal `[Class new]` argument): both facts agree, because there is no
+    /// variable read to scope.
+    fn unscoped(class: &str) -> Self {
+        let one: HashSet<String> = std::iter::once(class.to_owned()).collect();
+        Self {
+            union: one.clone(),
+            scoped: one,
+        }
+    }
 }
 
 /// One round of the VTA-lite fixpoint: scan every statement, reading current
@@ -634,7 +698,8 @@ struct Binding {
 fn scan_flow_edges(
     cu: &CompilationUnit,
     registry: &CommandRegistry,
-    out: &HashMap<String, HashSet<String>>,
+    facts: &ObjectHandleFacts,
+    scoped: Option<&OwnerIndex>,
     index: &FlowIndex,
 ) -> Vec<Binding> {
     let FlowIndex {
@@ -676,11 +741,19 @@ fn scan_flow_edges(
     let units = std::iter::once(&cu.top_level)
         .chain(cu.procedures.values())
         .chain(cu.methods.values());
+    // A `FactMode::AnyScopeOnly` build has no scope-keyed fact to maintain, so
+    // it never pays for the scoped lookups; the empty index only satisfies the
+    // shared context type.
+    let owners: &OwnerIndex = scoped.unwrap_or_else(|| OwnerIndex::shared_empty());
+    let by_scope = scoped.map(|_| &facts.by_scope);
     for fu in units {
         let ctx = ScanContext {
             ctor_params,
-            out,
+            out: &facts.any_scope,
+            by_scope,
+            owners,
             registry,
+            unit: &fu.name,
         };
         for block in fu.cfg.blocks.values() {
             for stmt in &block.statements {
@@ -754,14 +827,16 @@ fn scan_assign_edges(
     bindings: &mut Vec<Binding>,
 ) {
     let v = site.value.trim();
-    // Aliasing edge: `set A $B` copies B's classes to A.
+    // Aliasing edge: `set A $B` copies B's classes to A.  `B` is read *in this
+    // unit*, so the scope-keyed fact resolves it here and nowhere else.
     if let Some(src) = deref_arg_var(v)
         && let Some(classes) = ctx.out.get(src).filter(|s| !s.is_empty())
     {
         bindings.push(Binding {
             owner: site.unit.to_owned(),
             name: site.name.to_owned(),
-            classes: classes.clone(),
+            union_classes: classes.clone(),
+            scoped_classes: ctx.scoped_classes(src),
             kind: ObjectFlowEdge::Alias,
         });
     }
@@ -778,10 +853,15 @@ fn scan_assign_edges(
         .get(cmd.as_str())
         .or_else(|| returns.get(qualified.as_str()))
     {
+        // A legitimately cross-scope flow: the source is the *callee's* return
+        // type, not a variable read, so there is no scope to confuse and both
+        // facts take it.
+        let classes = EdgeClasses::unscoped(class);
         bindings.push(Binding {
             owner: site.unit.to_owned(),
             name: site.name.to_owned(),
-            classes: std::iter::once((*class).to_owned()).collect(),
+            union_classes: classes.union,
+            scoped_classes: classes.scoped,
             kind: ObjectFlowEdge::ProcReturn,
         });
     }
@@ -811,11 +891,14 @@ fn emit_proc_param_bindings(
         if pname == "args" {
             break;
         }
-        if let Some(classes) = arg_classes(arg, ctx.out, ctx.registry) {
+        // Also legitimately cross-scope: the argument is resolved in the
+        // *caller* (`ctx.unit`) and the parameter is bound in the callee.
+        if let Some(classes) = arg_classes(arg, ctx) {
             bindings.push(Binding {
                 owner: callee.to_owned(),
                 name: pname.clone(),
-                classes,
+                union_classes: classes.union,
+                scoped_classes: classes.scoped,
                 kind: ObjectFlowEdge::ProcParam,
             });
         }
@@ -831,11 +914,38 @@ struct CtorCall<'a> {
 
 /// The read-only context one scan round resolves an argument's classes
 /// against.
+///
+/// `out` is the scope-blind union; `by_scope` (present only in
+/// [`FactMode::Full`]) is the scope-keyed map the *narrow* fact is resolved
+/// through.  `unit` is the [`FunctionUnit`] the statement being scanned lives
+/// in — the scope a `$var` read in it resolves against.
 #[derive(Clone, Copy)]
 struct ScanContext<'a> {
     ctor_params: &'a HashMap<&'a str, (&'a str, &'a [String])>,
     out: &'a HashMap<String, HashSet<String>>,
+    by_scope: Option<&'a HashMap<(String, String), HashSet<String>>>,
+    owners: &'a OwnerIndex,
     registry: &'a CommandRegistry,
+    unit: &'a str,
+}
+
+impl ScanContext<'_> {
+    /// The classes `var` holds **in the unit being scanned** — the owning
+    /// unit's binding, or its class's when `var` is one of that class's
+    /// instance variables (the cross-method bridge issue #797 needs).
+    ///
+    /// Empty when there is no binding in that scope, which is exactly what
+    /// stops one unit's `x` from flowing into another's.
+    fn scoped_classes(&self, var: &str) -> HashSet<String> {
+        let Some(by_scope) = self.by_scope else {
+            return HashSet::new();
+        };
+        let owner = self.owners.owner_for(self.unit, var);
+        by_scope
+            .get(&(owner.to_owned(), var.to_owned()))
+            .cloned()
+            .unwrap_or_default()
+    }
 }
 
 /// Bind a constructor's parameters to the object classes of its arguments for a
@@ -875,11 +985,12 @@ fn emit_ctor_param_bindings(
         if pname == "args" {
             break;
         }
-        if let Some(classes) = arg_classes(arg, ctx.out, ctx.registry) {
+        if let Some(classes) = arg_classes(arg, ctx) {
             bindings.push(Binding {
                 owner: (*ctor_unit).to_owned(),
                 name: pname.clone(),
-                classes,
+                union_classes: classes.union,
+                scoped_classes: classes.scoped,
                 kind: ObjectFlowEdge::CtorParam,
             });
         }
@@ -889,18 +1000,22 @@ fn emit_ctor_param_bindings(
 /// The object classes an argument denotes: a tracked `$var` handle, or a direct
 /// `[Class new]` registry constructor.  `None` when the argument is not a known
 /// object.
-fn arg_classes(
-    arg: &str,
-    out: &HashMap<String, HashSet<String>>,
-    registry: &CommandRegistry,
-) -> Option<HashSet<String>> {
-    if let Some(classes) = deref_arg_var(arg)
-        .and_then(|v| out.get(v))
-        .filter(|s| !s.is_empty())
+///
+/// A `$var` argument is resolved twice — blind for the union fact, and in
+/// `ctx`'s own unit for the scope-keyed fact.  A literal constructor argument
+/// is unit-independent, so both agree.  `by_scope` is a subset of `any_scope`
+/// per name by construction, so an empty union implies an empty scoped set and
+/// the blind lookup can gate both.
+fn arg_classes(arg: &str, ctx: ScanContext) -> Option<EdgeClasses> {
+    if let Some(var) = deref_arg_var(arg)
+        && let Some(classes) = ctx.out.get(var).filter(|s| !s.is_empty())
     {
-        return Some(classes.clone());
+        return Some(EdgeClasses {
+            union: classes.clone(),
+            scoped: ctx.scoped_classes(var),
+        });
     }
-    constructor_class(arg, registry).map(|c| std::iter::once(c.to_string()).collect())
+    constructor_class(arg, ctx.registry).map(EdgeClasses::unscoped)
 }
 
 /// The variable name a `$name` / `${name}` argument dereferences, or `None` for
@@ -1611,6 +1726,112 @@ mod tests {
                 facts.by_scope
             );
         }
+    }
+
+    #[test]
+    fn by_scope_does_not_import_another_units_binding_through_an_alias() {
+        // FP guard (Codex review of #1127).  `x` is a `::Pin` in `::a` and a
+        // plain integer in `::b`.  `any_scope` unions the two — that is its
+        // documented, deliberate imprecision — but the alias `set y $x` inside
+        // `::b` must resolve `x` **in `::b`**, where there is no object.  A
+        // `(::b, y) → ::Pin` entry would be a false *singleton* in the map
+        // C5b's rename edits and the "provably a different class" refusal gate
+        // read as authoritative: it would rewrite an unrelated integer.
+        let (_r, facts) = facts_for(
+            "oo::class create Pin { method cfg {args} {} }\n\
+             proc a {} { set x [Pin new] }\n\
+             proc b {} { set x 0\n set y $x }\n",
+        );
+        assert_eq!(
+            scoped(&facts, "::a", "x"),
+            vec!["::Pin".to_owned()],
+            "the seed itself must still be scope-keyed to ::a"
+        );
+        assert!(
+            scoped(&facts, "::b", "y").is_empty(),
+            "`y` in ::b aliases ::b's own integer `x`, not ::a's Pin; \
+             by_scope must not import the other unit's binding (any_scope \
+             legitimately unions it: {:?})",
+            facts.any_scope.get("y")
+        );
+        assert!(
+            scoped(&facts, "::b", "x").is_empty(),
+            "::b's `x` is an integer; by_scope must not bind it"
+        );
+    }
+
+    #[test]
+    fn by_scope_alias_within_one_unit_still_propagates() {
+        // TP twin of the guard above: the same alias edge, both ends in the
+        // same unit, must still bind.
+        let (_r, facts) = facts_for(
+            "oo::class create Pin { method cfg {args} {} }\n\
+             proc c {} { set p [Pin new]\n set q $p\n $q cfg }\n",
+        );
+        assert_eq!(
+            scoped(&facts, "::c", "q"),
+            vec!["::Pin".to_owned()],
+            "an alias whose source is bound in the *same* unit must propagate; \
+             by_scope={:?}",
+            facts.by_scope
+        );
+    }
+
+    #[test]
+    fn by_scope_instance_var_alias_reads_the_class_owner() {
+        // The #797 bridge under scoped propagation: `engine` is written in the
+        // constructor and read in another method.  The source lookup for
+        // `set m $engine` inside `::Car::go` must fall back to the *class*
+        // owner, or the bridge the design is built on would break.
+        let (_r, facts) = facts_for(
+            "oo::class create Motor { method spin {args} {} }\n\
+             oo::class create Car {\n\
+               variable engine\n\
+               constructor {e} { set engine $e }\n\
+               method go {} { set m $engine\n $m spin }\n\
+             }\n\
+             set mo [Motor new]\n\
+             set c [Car new $mo]\n",
+        );
+        assert_eq!(
+            scoped(&facts, "::Car", "engine"),
+            vec!["::Motor".to_owned()],
+            "the class-owned instance variable must still bind"
+        );
+        assert_eq!(
+            scoped(&facts, "::Car::go", "m"),
+            vec!["::Motor".to_owned()],
+            "reading a class-owned instance variable from a method must resolve \
+             through the class owner; by_scope={:?}",
+            facts.by_scope
+        );
+    }
+
+    #[test]
+    fn by_scope_cross_unit_call_edges_still_bind() {
+        // The two legitimately cross-scope edges must survive the scoped
+        // source resolution: a proc-return edge (the source is the callee's
+        // return type, which is unit-independent) and a proc-parameter edge
+        // (the argument is resolved in the *caller*, bound in the callee).
+        let (_r, facts) = facts_for(
+            "oo::class create Pin { method cfg {args} {} }\n\
+             proc make {} { set p [Pin new]\n return $p }\n\
+             proc connect {dev} { $dev cfg }\n\
+             proc drive {} { set q [make]\n connect $q }\n",
+        );
+        assert_eq!(
+            scoped(&facts, "::drive", "q"),
+            vec!["::Pin".to_owned()],
+            "the proc-return edge binds in the assigning unit; by_scope={:?}",
+            facts.by_scope
+        );
+        assert_eq!(
+            scoped(&facts, "::connect", "dev"),
+            vec!["::Pin".to_owned()],
+            "the proc-parameter edge reads the argument in ::drive and binds \
+             the parameter in ::connect; by_scope={:?}",
+            facts.by_scope
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/object_types.rs
+++ b/rust/tcl-compiler/src/object_types.rs
@@ -35,14 +35,128 @@
 //! `TclOO` corpora, factory-return / cross-method dominating).  An
 //! un-provenanced receiver is still left to the generic shape-based option
 //! fallback rather than resolved with a wrong-or-abstain lattice.
+//!
+//! [`object_handle_facts`] is the widened entry point issue #994's staged
+//! unification (C5a) is built on: the same union **plus** a scope-keyed twin,
+//! an owner-span index, the collection map, the factory-return fact, and the
+//! `::`-qualified subset — one fact for all five dispatch consumers instead of
+//! four maps that can disagree on the same document.
+//! [`object_handle_classes`] is that entry point restricted to the union, so
+//! every existing consumer is untouched.  Contract and consumer/soundness
+//! tables: `docs/design/compiler/object-type-lattice.md`.
 
 use std::collections::{HashMap, HashSet};
 
+use tcl_lexer::Span;
 use tcl_registry::CommandRegistry;
 
 use crate::compilation_unit::{CompilationUnit, FunctionUnit};
 use crate::ir::Statement;
 use crate::value_shapes::parse_command_substitution;
+
+/// The source extent of one owning scope, plus the keys a
+/// [`ObjectHandleFacts::by_scope`] lookup at an offset inside it may use.
+///
+/// `unit` is the [`FunctionUnit`] key (`::proc`, `::Class::method`,
+/// `::Class::<constructor>`, `::top`).  `class` is `Some` for a method body —
+/// an *instance-variable* name is owned by the class, not by the method that
+/// happens to write it, so a consumer resolving a receiver inside a method
+/// tries `(unit, var)` first and `(class, var)` second.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OwnerSpan {
+    /// Byte extent of the owning definition, absolute in the analysed source.
+    pub span: Span,
+    /// The [`FunctionUnit`] key that owns names written in this extent.
+    pub unit: String,
+    /// The enclosing class qualified name, for a method/constructor body.
+    pub class: Option<String>,
+}
+
+/// Owner-attributed object-handle provenance for one
+/// [`CompilationUnit`] — the carrier issue #994's staged unification (C5a)
+/// puts on [`crate::analyser::types::AnalysisResult`].
+///
+/// Every map is **best-effort**: an absent key means *no evidence was found*,
+/// never *proof that the name holds no object*.  A consumer that needs a sound
+/// "provably a different class" answer must read [`Self::by_scope`] singletons
+/// and treat every other shape as an abstention.
+///
+/// Soundness directions, by map:
+///
+/// | map | key | widening risk | safe for |
+/// |---|---|---|---|
+/// | [`Self::any_scope`] | bare name | same name in two procs collides | highlighting, navigation (labelled) |
+/// | [`Self::by_scope`] | `(owner, name)` | none beyond the union join | edits, references, rename, refusal gates |
+/// | [`Self::collections`] | bare name | cross-scope union (deliberate — the #797 bridge) | highlighting, collection dispatch |
+/// | [`Self::returns_object`] | proc qname | none (one return type per proc) | factory-call typing |
+/// | [`Self::global_object_cells`] | `::`-qualified name | none (the name *is* the cell) | cross-document index seeds |
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ObjectHandleFacts {
+    /// The scope-blind union — **verbatim** what [`object_handle_classes`]
+    /// returns, so a consumer can migrate one map at a time.
+    pub any_scope: HashMap<String, HashSet<String>>,
+    /// The same bindings keyed by `(owner_qualified_name, var)`, where the
+    /// owner is the unit the binding edge actually binds in: an alias / proc
+    /// return binds in the *assigning* unit, a proc-parameter edge in the
+    /// *callee*, a constructor-parameter edge in the *constructor*, and a
+    /// class instance variable in the *class* (unioned across its methods —
+    /// that union is the interprocedural bridge issue #797 needs).
+    pub by_scope: HashMap<(String, String), HashSet<String>>,
+    /// Owning-scope extents, sorted by start (then by end descending) for the
+    /// binary search in [`Self::owner_at`].  One entry per procedure and
+    /// method, plus a whole-file entry for the top level.
+    pub owner_spans: Vec<OwnerSpan>,
+    /// [`object_collection_classes`] verbatim: `List`/`Dict` variable → the
+    /// classes of its elements.
+    pub collections: HashMap<String, HashSet<String>>,
+    /// Procedure qualified name → the class of the object it returns.  The
+    /// factory-proc fact the VTA fixpoint computes internally and used to
+    /// discard; exported so a cross-document index can seed on it (#1099).
+    pub returns_object: HashMap<String, String>,
+    /// The `::`-qualified subset of [`Self::any_scope`] — object handles that
+    /// live in a *global* cell rather than a local, so another document's
+    /// analysis can join against them.
+    pub global_object_cells: HashMap<String, HashSet<String>>,
+}
+
+impl ObjectHandleFacts {
+    /// The innermost owning scope containing `offset`, or `None` at a byte no
+    /// tracked definition covers (top-level code outside every proc/method).
+    ///
+    /// [`Self::owner_spans`] is sorted by start ascending (then end
+    /// *descending*), so the candidates are found by binary search and the walk
+    /// back from the partition point returns the last entry that still contains
+    /// `offset` — which for the properly-nested definition spans of a Tcl file
+    /// is the innermost scope, including when a scope and its enclosing one
+    /// begin at the same byte.
+    #[must_use]
+    pub fn owner_at(&self, offset: u32) -> Option<&OwnerSpan> {
+        let upto = self
+            .owner_spans
+            .partition_point(|o| o.span.start() <= offset);
+        self.owner_spans[..upto]
+            .iter()
+            .rev()
+            .find(|o| o.span.end() >= offset)
+    }
+
+    /// The classes `var` can hold **in the scope containing `offset`**: the
+    /// owning unit's binding, else the enclosing class's instance-variable
+    /// binding.  `None` when there is no evidence — which is *not* proof the
+    /// name holds no object (see the type-level contract).
+    #[must_use]
+    pub fn classes_in_scope(&self, offset: u32, var: &str) -> Option<&HashSet<String>> {
+        let owner = self.owner_at(offset)?;
+        self.by_scope
+            .get(&(owner.unit.clone(), var.to_owned()))
+            .or_else(|| {
+                owner
+                    .class
+                    .as_ref()
+                    .and_then(|c| self.by_scope.get(&(c.clone(), var.to_owned())))
+            })
+    }
+}
 
 /// Map every variable that holds an object handle to the set of class names it
 /// can hold, across the top level, procedures, and method bodies of `cu`.
@@ -65,26 +179,348 @@ pub fn object_handle_classes(
     cu: &CompilationUnit,
     registry: &CommandRegistry,
 ) -> HashMap<String, HashSet<String>> {
-    let mut out: HashMap<String, HashSet<String>> = HashMap::new();
+    build_facts(cu, registry, FactMode::AnyScopeOnly)
+        .0
+        .any_scope
+}
+
+/// [`object_handle_classes`] **without** the empty-seed fast path — the
+/// propagation walk exactly as it ran before issue #994's C5a.
+///
+/// Exists so the measurement harness (`examples/object_lattice_cost.rs`) and
+/// the unit test below can pin the fast path as behaviour-preserving and
+/// quantify what it saves on a file with no object seeds.  Never call this
+/// from shipping code: it is strictly slower and, by construction, produces
+/// the same map.
+#[doc(hidden)]
+#[must_use]
+pub fn object_handle_classes_full_walk(
+    cu: &CompilationUnit,
+    registry: &CommandRegistry,
+) -> HashMap<String, HashSet<String>> {
+    build_facts_gated(cu, registry, FactMode::AnyScopeOnly, false)
+        .0
+        .any_scope
+}
+
+/// The type-propagation edge a binding came from — the VTA edge taxonomy,
+/// carried so the measurement harness can report bindings by edge kind.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObjectFlowEdge {
+    /// `set A $B`.
+    Alias,
+    /// `set A [factoryProc …]`.
+    ProcReturn,
+    /// `f $obj` → `f`'s parameter.
+    ProcParam,
+    /// `C new $obj` → `C`'s constructor parameter.
+    CtorParam,
+}
+
+/// Shape/cost counters for one lattice build — the measurement gate M1's
+/// per-file row (`examples/object_lattice_cost.rs`).  Not a shipping fact.
+#[doc(hidden)]
+#[derive(Debug, Clone, Default)]
+pub struct LatticeStats {
+    /// Handles the harvest seeded before any propagation.
+    pub seeds: usize,
+    /// Fixpoint rounds actually run (0 when the fast path fired).
+    pub rounds: u32,
+    /// Whether the empty-seed fast path skipped the propagation walk.
+    pub fast_path_hit: bool,
+    /// Bindings produced per [`ObjectFlowEdge`], summed over all rounds.
+    pub alias_bindings: usize,
+    /// See [`Self::alias_bindings`].
+    pub return_bindings: usize,
+    /// See [`Self::alias_bindings`].
+    pub param_bindings: usize,
+    /// See [`Self::alias_bindings`].
+    pub ctor_param_bindings: usize,
+}
+
+/// [`object_handle_facts`] plus the build's [`LatticeStats`].
+#[doc(hidden)]
+#[must_use]
+pub fn object_handle_facts_instrumented(
+    cu: &CompilationUnit,
+    registry: &CommandRegistry,
+) -> (ObjectHandleFacts, LatticeStats) {
+    build_facts_gated(cu, registry, FactMode::Full, true)
+}
+
+/// The full owner-attributed object-handle fact set for `cu` — the C5a
+/// carrier described on [`ObjectHandleFacts`].
+///
+/// [`object_handle_classes`] is this entry point restricted to
+/// [`ObjectHandleFacts::any_scope`]; the union it returns is byte-identical
+/// either way, so the scope-keyed maps are pure addition.  The extra work over
+/// the union-only path is the owner attribution, the owner-span index, the
+/// collection map, and the two exported sub-facts.
+#[must_use]
+pub fn object_handle_facts(cu: &CompilationUnit, registry: &CommandRegistry) -> ObjectHandleFacts {
+    build_facts(cu, registry, FactMode::Full).0
+}
+
+/// How much of [`ObjectHandleFacts`] a build populates.
+///
+/// The union-only mode exists so [`object_handle_classes`]'s existing
+/// consumers (the optimiser, the compilation-unit interprocedural seed,
+/// `type_infer`, semantic tokens) keep paying exactly what they paid before
+/// the scope-keyed carrier was added.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FactMode {
+    /// Populate [`ObjectHandleFacts::any_scope`] only.
+    AnyScopeOnly,
+    /// Populate every map.
+    Full,
+}
+
+fn build_facts(
+    cu: &CompilationUnit,
+    registry: &CommandRegistry,
+    mode: FactMode,
+) -> (ObjectHandleFacts, LatticeStats) {
+    build_facts_gated(cu, registry, mode, true)
+}
+
+/// The one implementation behind both public entry points.
+///
+/// `empty_seed_fast_path` is `true` for every production caller; only
+/// [`object_handle_classes_full_walk`] passes `false`, to reproduce the
+/// pre-#994 walk for the behaviour-equality test and the cost measurement.
+fn build_facts_gated(
+    cu: &CompilationUnit,
+    registry: &CommandRegistry,
+    mode: FactMode,
+    empty_seed_fast_path: bool,
+) -> (ObjectHandleFacts, LatticeStats) {
+    let owners = OwnerIndex::build(cu, mode);
+    let mut sink = FactSink {
+        facts: ObjectHandleFacts::default(),
+        owners: &owners,
+        mode,
+        saw_constructor_arg: false,
+        stats: LatticeStats::default(),
+    };
     let units = std::iter::once(&cu.top_level)
         .chain(cu.procedures.values())
         .chain(cu.methods.values());
     for fu in units {
-        harvest_unit(fu, registry, &mut out);
+        harvest_unit(fu, registry, &mut sink);
     }
-    // VTA-lite object-flow propagation.  Having seeded the handles that are
-    // locally provable (constructor assignments + SSA `OBJECT` values), push
-    // those classes along the type-propagation edges of Variable Type Analysis
-    // (Sundaresan et al., OOPSLA'00) to a bounded fixpoint:
-    //   - *aliasing*         `set A $B`            → A ⊇ classes(B)
-    //   - *proc return*      `set A [make …]`      → A ⊇ return-class(make)
-    //   - *proc parameter*   `f $obj`              → f's param ⊇ classes($obj)
-    //   - *constructor param* `C new $obj`         → C's ctor param ⊇ classes($obj)
-    // Nodes are name-keyed (field-based, object-insensitive) and joins are set
-    // union — the economy VTA trades precision for.  Highlight-only, matching
-    // the imprecision tolerance documented above.
-    propagate_object_flow(cu, registry, &mut out);
-    out
+    sink.stats.seeds = sink.facts.any_scope.len();
+    let returns = returning_procs(cu);
+    // Fast path (issue #994 C5a).  The early-out inside `propagate_object_flow`
+    // checks the *callee-side* maps (returns / proc params / ctor params),
+    // which are non-empty for any file that merely defines a proc — so every
+    // ordinary non-OO file paid a full statement walk to discover that it had
+    // nothing to propagate.  Skip the walk when no edge can fire, which is
+    // exactly when all three of these hold:
+    //
+    //  - the harvest seeded no handle, so every `out`-driven edge (aliasing,
+    //    and the `$var` half of both parameter edges) is dead;
+    //  - no procedure returns an object, so the proc-return edge is dead; and
+    //  - no argument is a bracketed registry constructor, so the *other* half
+    //    of the parameter edges — `arg_classes`' `[Factory new]` branch, which
+    //    reads no seed at all — is dead too.
+    //
+    // The third condition is why `out.is_empty()` alone is **not**
+    // behaviour-preserving: `proc take {dev} {…}; take [listbox .l]` binds
+    // `dev` from an empty seed set, as do `Wrap new [listbox .l]` and
+    // `take [struct::graph]`.  `empty_seed_fast_path_is_behaviour_preserving`
+    // pins all three shapes.
+    let any_edge_can_fire =
+        !sink.facts.any_scope.is_empty() || !returns.is_empty() || sink.saw_constructor_arg;
+    sink.stats.fast_path_hit = !any_edge_can_fire && empty_seed_fast_path;
+    if any_edge_can_fire || !empty_seed_fast_path {
+        // VTA-lite object-flow propagation.  Having seeded the handles that are
+        // locally provable (constructor assignments + SSA `OBJECT` values), push
+        // those classes along the type-propagation edges of Variable Type
+        // Analysis (Sundaresan et al., OOPSLA'00) to a bounded fixpoint:
+        //   - *aliasing*         `set A $B`            → A ⊇ classes(B)
+        //   - *proc return*      `set A [make …]`      → A ⊇ return-class(make)
+        //   - *proc parameter*   `f $obj`              → f's param ⊇ classes($obj)
+        //   - *constructor param* `C new $obj`         → C's ctor param ⊇ classes($obj)
+        // Nodes are name-keyed (field-based, object-insensitive) and joins are
+        // set union — the economy VTA trades precision for.  Highlight-only,
+        // matching the imprecision tolerance documented above.
+        propagate_object_flow(cu, registry, &returns, &mut sink);
+    }
+    let stats = sink.stats;
+    let mut facts = sink.facts;
+    if mode == FactMode::Full {
+        facts.owner_spans = owners.spans;
+        facts.returns_object = returns
+            .into_iter()
+            .map(|(k, v)| (k.to_owned(), v.to_owned()))
+            .collect();
+        facts.collections = object_collection_classes(cu);
+        facts.global_object_cells = facts
+            .any_scope
+            .iter()
+            .filter(|(name, _)| name.starts_with("::"))
+            .map(|(name, classes)| (name.clone(), classes.clone()))
+            .collect();
+    }
+    (facts, stats)
+}
+
+/// Which unit — or class — owns a name written inside a given
+/// [`FunctionUnit`], plus the sorted span index consumers resolve an offset
+/// against.
+struct OwnerIndex {
+    /// Method [`FunctionUnit`] key → its class's qualified name.
+    method_class: HashMap<String, String>,
+    /// Class qualified name → the instance-variable names in scope for any of
+    /// its methods.  A name in this set is owned by the *class*, so a handle
+    /// stored in one method is visible to a dispatch in another (issue #797).
+    class_instance_vars: HashMap<String, HashSet<String>>,
+    /// [`ObjectHandleFacts::owner_spans`], already sorted.
+    spans: Vec<OwnerSpan>,
+}
+
+impl OwnerIndex {
+    fn build(cu: &CompilationUnit, mode: FactMode) -> Self {
+        let mut method_class: HashMap<String, String> = HashMap::new();
+        let mut class_instance_vars: HashMap<String, HashSet<String>> = HashMap::new();
+        let mut spans: Vec<OwnerSpan> = Vec::new();
+        if mode == FactMode::AnyScopeOnly {
+            return Self {
+                method_class,
+                class_instance_vars,
+                spans,
+            };
+        }
+        for (mqname, m) in &cu.ir_module.methods {
+            method_class.insert(mqname.clone(), m.class_name.clone());
+            class_instance_vars
+                .entry(m.class_name.clone())
+                .or_default()
+                .extend(m.instance_vars.iter().cloned());
+            if let Some(span) = m.span {
+                spans.push(OwnerSpan {
+                    span,
+                    unit: mqname.clone(),
+                    class: Some(m.class_name.clone()),
+                });
+            }
+        }
+        for p in cu.ir_module.procedures.values() {
+            spans.push(OwnerSpan {
+                span: p.span,
+                unit: p.qualified_name.clone(),
+                class: None,
+            });
+        }
+        // The top level owns everything no proc or method body covers.  Its
+        // span starts at 0, so it sorts first and `owner_at`'s
+        // greatest-start-that-contains walk still finds the enclosing proc for
+        // a byte inside one — but a top-level `set chart [Chart new]` now has
+        // an owner to resolve against instead of falling off the index.
+        //
+        // Synthetic *body units* (`apply` lambdas, `namespace eval` blocks)
+        // deliberately get **no** span: the harvest does not visit them
+        // (`build_facts_gated` iterates top level / procedures / methods), so a
+        // byte inside one resolves to its enclosing owner, which is where any
+        // knowledge about the name actually lives.
+        spans.push(OwnerSpan {
+            span: Span::new(0, u32::try_from(cu.source.len()).unwrap_or(u32::MAX)),
+            unit: cu.top_level.name.clone(),
+            class: None,
+        });
+        // Sorted by start ascending for the binary search, then by end
+        // *descending* so that when two scopes begin at the same byte — a proc
+        // written at offset 0 and the whole-file `::top` entry — the wider one
+        // sorts first and `owner_at`'s backward walk still reaches the narrower
+        // (innermost) one first.  The unit key is the final tie-break, so the
+        // vector is a deterministic function of the source rather than of
+        // `HashMap` iteration order (the per-item differential gate compares
+        // whole `AnalysisResult`s for equality).
+        spans.sort_by(|a, b| {
+            (a.span.start(), std::cmp::Reverse(a.span.end()), &a.unit).cmp(&(
+                b.span.start(),
+                std::cmp::Reverse(b.span.end()),
+                &b.unit,
+            ))
+        });
+        Self {
+            method_class,
+            class_instance_vars,
+            spans,
+        }
+    }
+
+    /// The owner key for `name` as written inside `unit`: the enclosing class
+    /// when `name` is one of its instance variables, else the unit itself.
+    fn owner_for<'a>(&'a self, unit: &'a str, name: &str) -> &'a str {
+        if let Some(class) = self.method_class.get(unit)
+            && self
+                .class_instance_vars
+                .get(class)
+                .is_some_and(|vars| vars.contains(name))
+        {
+            return class;
+        }
+        unit
+    }
+}
+
+/// Accumulator threaded through the harvest and the fixpoint so the union and
+/// the scope-keyed map are filled from the same binding events.
+struct FactSink<'a> {
+    facts: ObjectHandleFacts,
+    owners: &'a OwnerIndex,
+    mode: FactMode,
+    /// Whether the harvest saw an argument that could be a bracketed registry
+    /// constructor — the one type-propagation edge that fires without any
+    /// seeded handle.  Over-approximate on purpose; see
+    /// [`may_be_constructor_word`].
+    saw_constructor_arg: bool,
+    /// Cost/shape counters for the measurement gate.
+    stats: LatticeStats,
+}
+
+impl FactSink<'_> {
+    /// Record that `name`, written in `unit`, can hold `class`.
+    fn bind(&mut self, unit: &str, name: &str, class: &str) {
+        self.facts
+            .any_scope
+            .entry(name.to_owned())
+            .or_default()
+            .insert(class.to_owned());
+        if self.mode == FactMode::Full {
+            let owner = self.owners.owner_for(unit, name).to_owned();
+            self.facts
+                .by_scope
+                .entry((owner, name.to_owned()))
+                .or_default()
+                .insert(class.to_owned());
+        }
+    }
+
+    /// Record whether any of `args` could be the seed-free constructor
+    /// argument the fast-path gate must not skip past.
+    fn note_constructor_args(&mut self, args: &[String], registry: &CommandRegistry) {
+        if self.saw_constructor_arg {
+            return;
+        }
+        self.saw_constructor_arg = args.iter().any(|a| may_be_constructor_word(a, registry));
+    }
+}
+
+/// Callee proc qualified name → the class of the object it returns (the
+/// factory-proc signal behind `set c [makeThing]`).
+fn returning_procs(cu: &CompilationUnit) -> HashMap<&str, &str> {
+    cu.procedures
+        .values()
+        .filter_map(|fu| {
+            (fu.return_type.tcl_type() == Some(tcl_registry::TclType::Object))
+                .then_some(fu.return_type.class_name())
+                .flatten()
+                .map(|c| (fu.name.as_str(), c))
+        })
+        .collect()
 }
 
 /// VTA-lite object-flow fixpoint.  Propagates object classes from the seeded
@@ -94,23 +530,12 @@ pub fn object_handle_classes(
 /// regardless of scope, VTA's field-based object-insensitive economy) and the
 /// join is set union.  Highlight-only and union-imprecise, matching the rest of
 /// this module.
-fn propagate_object_flow(
-    cu: &CompilationUnit,
+fn propagate_object_flow<'a>(
+    cu: &'a CompilationUnit,
     registry: &CommandRegistry,
-    out: &mut HashMap<String, HashSet<String>>,
+    returns: &HashMap<&'a str, &'a str>,
+    sink: &mut FactSink,
 ) {
-    // Callee proc qualified name → returned object class (the factory-proc
-    // signal `set c [makeThing]`).
-    let returns: HashMap<&str, &str> = cu
-        .procedures
-        .values()
-        .filter_map(|fu| {
-            (fu.return_type.tcl_type() == Some(tcl_registry::TclType::Object))
-                .then_some(fu.return_type.class_name())
-                .flatten()
-                .map(|c| (fu.name.as_str(), c))
-        })
-        .collect();
     // Callee proc qualified name → parameter names.
     let proc_params: HashMap<&str, &[String]> = cu
         .ir_module
@@ -118,36 +543,88 @@ fn propagate_object_flow(
         .values()
         .map(|p| (p.qualified_name.as_str(), p.params.as_slice()))
         .collect();
-    // Class qualified name → constructor parameter names (keyed
-    // `::Class::<constructor>` in the IR module).
-    let ctor_params: HashMap<&str, &[String]> = cu
+    // Class qualified name → its constructor's `FunctionUnit` key + parameter
+    // names (the IR module keys a constructor `::Class::<constructor>`).
+    let ctor_params: HashMap<&str, (&str, &[String])> = cu
         .ir_module
         .methods
         .iter()
         .filter_map(|(k, m)| {
             k.ends_with("::<constructor>")
-                .then_some((m.class_name.as_str(), m.params.as_slice()))
+                .then_some((m.class_name.as_str(), (k.as_str(), m.params.as_slice())))
         })
         .collect();
     if returns.is_empty() && proc_params.is_empty() && ctor_params.is_empty() {
         return;
     }
+    let index = FlowIndex {
+        returns: returns.clone(),
+        proc_params,
+        ctor_params,
+    };
 
     // Bounded fixpoint: a handful of rounds cover realistic alias/call chains
     // without risking a runaway on a cyclic call graph.
     for _ in 0..6 {
-        let bindings = scan_flow_edges(cu, registry, out, &returns, &proc_params, &ctor_params);
+        let bindings = scan_flow_edges(cu, registry, &sink.facts.any_scope, &index);
+        sink.stats.rounds += 1;
         let mut changed = false;
-        for (name, classes) in bindings {
-            let entry = out.entry(name).or_default();
-            for c in classes {
-                changed |= entry.insert(c);
+        for binding in bindings {
+            match binding.kind {
+                ObjectFlowEdge::Alias => sink.stats.alias_bindings += 1,
+                ObjectFlowEdge::ProcReturn => sink.stats.return_bindings += 1,
+                ObjectFlowEdge::ProcParam => sink.stats.param_bindings += 1,
+                ObjectFlowEdge::CtorParam => sink.stats.ctor_param_bindings += 1,
+            }
+            // Convergence is decided by the union alone, so the scope-keyed
+            // twin can never change the number of rounds (nor, therefore,
+            // `any_scope`'s contents).
+            let entry = sink
+                .facts
+                .any_scope
+                .entry(binding.name.clone())
+                .or_default();
+            let mut fresh = false;
+            for c in &binding.classes {
+                fresh |= entry.insert(c.clone());
+            }
+            changed |= fresh;
+            if sink.mode == FactMode::Full {
+                let owner = sink
+                    .owners
+                    .owner_for(&binding.owner, &binding.name)
+                    .to_owned();
+                sink.facts
+                    .by_scope
+                    .entry((owner, binding.name))
+                    .or_default()
+                    .extend(binding.classes);
             }
         }
         if !changed {
             break;
         }
     }
+}
+
+/// The callee-side maps one fixpoint round resolves call edges against.
+struct FlowIndex<'a> {
+    /// Proc qualified name → returned object class.
+    returns: HashMap<&'a str, &'a str>,
+    /// Proc qualified name → parameter names.
+    proc_params: HashMap<&'a str, &'a [String]>,
+    /// Class qualified name → (constructor unit key, constructor parameters).
+    ctor_params: HashMap<&'a str, (&'a str, &'a [String])>,
+}
+
+/// One type-propagation edge's product: the classes `name` gains, and the unit
+/// the edge binds that name **in** (the assigning unit for an alias / return,
+/// the callee for a parameter, the constructor for a constructor parameter).
+struct Binding {
+    owner: String,
+    name: String,
+    classes: HashSet<String>,
+    kind: ObjectFlowEdge,
 }
 
 /// One round of the VTA-lite fixpoint: scan every statement, reading current
@@ -158,10 +635,13 @@ fn scan_flow_edges(
     cu: &CompilationUnit,
     registry: &CommandRegistry,
     out: &HashMap<String, HashSet<String>>,
-    returns: &HashMap<&str, &str>,
-    proc_params: &HashMap<&str, &[String]>,
-    ctor_params: &HashMap<&str, &[String]>,
-) -> Vec<(String, HashSet<String>)> {
+    index: &FlowIndex,
+) -> Vec<Binding> {
+    let FlowIndex {
+        returns,
+        proc_params,
+        ctor_params,
+    } = index;
     // Resolve a proc call head to its callee key, tolerating the `::` global
     // qualifier the way `CommandRegistry::get` does.
     let resolve_proc = |cmd: &str, canonical: Option<&str>| -> Option<&str> {
@@ -172,13 +652,6 @@ fn scan_flow_edges(
         }
         let q = format!("::{}", cmd.trim_start_matches("::"));
         proc_params.get_key_value(q.as_str()).map(|(k, _)| *k)
-    };
-    let resolve_return = |cmd: &str| -> Option<&str> {
-        if let Some((k, _)) = returns.get_key_value(cmd) {
-            return Some(*k);
-        }
-        let q = format!("::{}", cmd.trim_start_matches("::"));
-        returns.get_key_value(q.as_str()).map(|(k, _)| *k)
     };
     // Resolve a constructor-call head (`Pin`, `::ns::Pin`) to a class that
     // declares a constructor.  Prefers an exact / `::`-qualified match, then
@@ -199,44 +672,31 @@ fn scan_flow_edges(
             .map(|k| (*k).to_owned())
     };
 
-    let mut bindings: Vec<(String, HashSet<String>)> = Vec::new();
+    let mut bindings: Vec<Binding> = Vec::new();
     let units = std::iter::once(&cu.top_level)
         .chain(cu.procedures.values())
         .chain(cu.methods.values());
     for fu in units {
+        let ctx = ScanContext {
+            ctor_params,
+            out,
+            registry,
+        };
         for block in fu.cfg.blocks.values() {
             for stmt in &block.statements {
                 match stmt {
                     Statement::AssignValue { name, value, .. } => {
-                        let v = value.trim();
-                        // Aliasing edge: `set A $B` copies B's classes to A.
-                        if let Some(src) = deref_arg_var(v)
-                            && let Some(classes) = out.get(src).filter(|s| !s.is_empty())
-                        {
-                            bindings.push((name.clone(), classes.clone()));
-                        }
-                        // Proc-return edge: `set A [make …]`.
-                        if v.starts_with('[')
-                            && let Some((cmd, args)) = parse_command_substitution(v)
-                        {
-                            if let Some(callee) = resolve_return(&cmd) {
-                                bindings.push((
-                                    name.clone(),
-                                    std::iter::once(returns[callee].to_owned()).collect(),
-                                ));
-                            }
-                            // Constructor-parameter edge for a nested
-                            // `[Class new …]` / `[Class create …]`.
-                            emit_ctor_param_bindings(
-                                &cmd,
-                                &args,
-                                &resolve_ctor_class,
-                                ctor_params,
-                                out,
-                                registry,
-                                &mut bindings,
-                            );
-                        }
+                        scan_assign_edges(
+                            AssignSite {
+                                unit: &fu.name,
+                                name,
+                                value,
+                            },
+                            &resolve_ctor_class,
+                            returns,
+                            ctx,
+                            &mut bindings,
+                        );
                     }
                     Statement::Call {
                         command,
@@ -244,27 +704,25 @@ fn scan_flow_edges(
                         args,
                         ..
                     } => {
-                        // Proc-parameter edge: `f $obj` binds f's params.
+                        // Proc-parameter edge: `f $obj` binds f's params — in
+                        // the *callee*, which is where the name lives.
                         if let Some(callee) = resolve_proc(command, canonical_command.as_deref()) {
-                            let params = proc_params[callee];
-                            for (i, arg) in args.iter().enumerate() {
-                                let Some(pname) = params.get(i) else { break };
-                                if pname == "args" {
-                                    break;
-                                }
-                                if let Some(classes) = arg_classes(arg, out, registry) {
-                                    bindings.push((pname.clone(), classes));
-                                }
-                            }
+                            emit_proc_param_bindings(
+                                callee,
+                                proc_params[callee],
+                                args,
+                                ctx,
+                                &mut bindings,
+                            );
                         }
                         // Constructor-parameter edge: `Class create NAME …`.
                         emit_ctor_param_bindings(
-                            command,
-                            args,
+                            CtorCall {
+                                head: command,
+                                verb_and_args: args,
+                            },
                             &resolve_ctor_class,
-                            ctor_params,
-                            out,
-                            registry,
+                            ctx,
                             &mut bindings,
                         );
                     }
@@ -276,19 +734,124 @@ fn scan_flow_edges(
     bindings
 }
 
+/// One `set NAME VALUE` statement, with the unit it is written in.
+#[derive(Clone, Copy)]
+struct AssignSite<'a> {
+    unit: &'a str,
+    name: &'a str,
+    value: &'a str,
+}
+
+/// The two edges an assignment can carry — aliasing (`set A $B`) and proc
+/// return (`set A [make …]`) — plus the nested-constructor parameter edge of a
+/// `set W [Class new $obj]` value.  Both assignment edges bind in the
+/// *assigning* unit; the constructor edge binds in the constructor.
+fn scan_assign_edges(
+    site: AssignSite,
+    resolve_ctor_class: &impl Fn(&str) -> Option<String>,
+    returns: &HashMap<&str, &str>,
+    ctx: ScanContext,
+    bindings: &mut Vec<Binding>,
+) {
+    let v = site.value.trim();
+    // Aliasing edge: `set A $B` copies B's classes to A.
+    if let Some(src) = deref_arg_var(v)
+        && let Some(classes) = ctx.out.get(src).filter(|s| !s.is_empty())
+    {
+        bindings.push(Binding {
+            owner: site.unit.to_owned(),
+            name: site.name.to_owned(),
+            classes: classes.clone(),
+            kind: ObjectFlowEdge::Alias,
+        });
+    }
+    if !v.starts_with('[') {
+        return;
+    }
+    let Some((cmd, args)) = parse_command_substitution(v) else {
+        return;
+    };
+    // Proc-return edge: `set A [make …]`, tolerating the `::` global
+    // qualifier the way `CommandRegistry::get` does.
+    let qualified = format!("::{}", cmd.trim_start_matches("::"));
+    if let Some(class) = returns
+        .get(cmd.as_str())
+        .or_else(|| returns.get(qualified.as_str()))
+    {
+        bindings.push(Binding {
+            owner: site.unit.to_owned(),
+            name: site.name.to_owned(),
+            classes: std::iter::once((*class).to_owned()).collect(),
+            kind: ObjectFlowEdge::ProcReturn,
+        });
+    }
+    // Constructor-parameter edge for a nested `[Class new …]` / `[Class create …]`.
+    emit_ctor_param_bindings(
+        CtorCall {
+            head: &cmd,
+            verb_and_args: &args,
+        },
+        resolve_ctor_class,
+        ctx,
+        bindings,
+    );
+}
+
+/// Bind `callee`'s parameters to the object classes of a call's arguments.
+/// Stops at `args` (a variadic tail is not positionally bindable).
+fn emit_proc_param_bindings(
+    callee: &str,
+    params: &[String],
+    args: &[String],
+    ctx: ScanContext,
+    bindings: &mut Vec<Binding>,
+) {
+    for (i, arg) in args.iter().enumerate() {
+        let Some(pname) = params.get(i) else { break };
+        if pname == "args" {
+            break;
+        }
+        if let Some(classes) = arg_classes(arg, ctx.out, ctx.registry) {
+            bindings.push(Binding {
+                owner: callee.to_owned(),
+                name: pname.clone(),
+                classes,
+                kind: ObjectFlowEdge::ProcParam,
+            });
+        }
+    }
+}
+
+/// A candidate constructor call: the class command and everything after it.
+#[derive(Clone, Copy)]
+struct CtorCall<'a> {
+    head: &'a str,
+    verb_and_args: &'a [String],
+}
+
+/// The read-only context one scan round resolves an argument's classes
+/// against.
+#[derive(Clone, Copy)]
+struct ScanContext<'a> {
+    ctor_params: &'a HashMap<&'a str, (&'a str, &'a [String])>,
+    out: &'a HashMap<String, HashSet<String>>,
+    registry: &'a CommandRegistry,
+}
+
 /// Bind a constructor's parameters to the object classes of its arguments for a
 /// `Class new ARGS…` / `Class create NAME ARGS…` call.  `head` is the class
 /// command; `verb_and_args` is everything after it (`["new", "$x"]` /
 /// `["create", "foo", "$x"]`).
 fn emit_ctor_param_bindings(
-    head: &str,
-    verb_and_args: &[String],
+    call: CtorCall,
     resolve_ctor_class: &impl Fn(&str) -> Option<String>,
-    ctor_params: &HashMap<&str, &[String]>,
-    out: &HashMap<String, HashSet<String>>,
-    registry: &CommandRegistry,
-    bindings: &mut Vec<(String, HashSet<String>)>,
+    ctx: ScanContext,
+    bindings: &mut Vec<Binding>,
 ) {
+    let CtorCall {
+        head,
+        verb_and_args,
+    } = call;
     let ctor_args: &[String] = match verb_and_args.split_first() {
         Some((verb, rest)) if verb == "new" => rest,
         // `create NAME …` — skip the instance name.
@@ -304,7 +867,7 @@ fn emit_ctor_param_bindings(
     let Some(class) = resolve_ctor_class(head) else {
         return;
     };
-    let Some(params) = ctor_params.get(class.as_str()) else {
+    let Some((ctor_unit, params)) = ctx.ctor_params.get(class.as_str()) else {
         return;
     };
     for (i, arg) in ctor_args.iter().enumerate() {
@@ -312,8 +875,13 @@ fn emit_ctor_param_bindings(
         if pname == "args" {
             break;
         }
-        if let Some(classes) = arg_classes(arg, out, registry) {
-            bindings.push((pname.clone(), classes));
+        if let Some(classes) = arg_classes(arg, ctx.out, ctx.registry) {
+            bindings.push(Binding {
+                owner: (*ctor_unit).to_owned(),
+                name: pname.clone(),
+                classes,
+                kind: ObjectFlowEdge::CtorParam,
+            });
         }
     }
 }
@@ -376,11 +944,7 @@ pub fn object_collection_classes(cu: &CompilationUnit) -> HashMap<String, HashSe
     out
 }
 
-fn harvest_unit(
-    fu: &FunctionUnit,
-    registry: &CommandRegistry,
-    out: &mut HashMap<String, HashSet<String>>,
-) {
+fn harvest_unit(fu: &FunctionUnit, registry: &CommandRegistry, sink: &mut FactSink) {
     // Syntactic constructor assignments (`set VAR [Class new|create …]`) and
     // naming object-factories (`struct::graph myG` — the created object command
     // is `myG`, not a `set` target the SSA lattice can carry).
@@ -388,10 +952,14 @@ fn harvest_unit(
         for stmt in &block.statements {
             match stmt {
                 Statement::AssignValue { name, value, .. } => {
-                    if let Some(class) = constructor_class(value, registry) {
-                        out.entry(name.clone())
-                            .or_default()
-                            .insert(class.to_string());
+                    if let Some((head, args)) = parse_command_substitution(value.trim()) {
+                        if let Some(class) = constructor_class_of(&head, &args, registry) {
+                            sink.bind(&fu.name, name, class);
+                        }
+                        // The nested-constructor half of the fast-path gate:
+                        // `set w [Wrap new [listbox .l]]` reaches `arg_classes`
+                        // through `emit_ctor_param_bindings`.
+                        sink.note_constructor_args(&args, registry);
                     }
                 }
                 // A registry naming factory (`creates_instance_at` + a class)
@@ -406,10 +974,12 @@ fn harvest_unit(
                         && let Some(name) = args.get(idx as usize)
                         && is_plain_object_name(name)
                     {
-                        out.entry(name.clone())
-                            .or_default()
-                            .insert(oc.class_name.to_string());
+                        sink.bind(&fu.name, name, oc.class_name);
                     }
+                    // Both parameter edges read a call's arguments through
+                    // `arg_classes`, whose `[Factory new]` branch needs no
+                    // seeded handle — so the fast-path gate must see them.
+                    sink.note_constructor_args(args, registry);
                 }
                 _ => {}
             }
@@ -421,9 +991,8 @@ fn harvest_unit(
         if t.tcl_type() == Some(tcl_registry::TclType::Object)
             && let Some(class) = t.class_name()
         {
-            out.entry(fu.ssa.var_name(*sym).to_owned())
-                .or_default()
-                .insert(class.to_owned());
+            let name = fu.ssa.var_name(*sym).to_owned();
+            sink.bind(&fu.name, &name, class);
         }
     }
 }
@@ -434,18 +1003,62 @@ fn harvest_unit(
 /// [`CommandRegistry::object_class`] strips it as [`CommandRegistry::get`] does.
 fn constructor_class<'r>(value: &str, registry: &'r CommandRegistry) -> Option<&'r str> {
     let (head, args) = parse_command_substitution(value.trim())?;
+    constructor_class_of(&head, &args, registry)
+}
+
+/// [`constructor_class`] on an already-parsed command substitution, so a caller
+/// that needs the parsed words for something else does not parse twice.
+fn constructor_class_of<'r>(
+    head: &str,
+    args: &[String],
+    registry: &'r CommandRegistry,
+) -> Option<&'r str> {
     // `[Class new|create …]` — or a registry naming factory returning its own
     // instance (`[struct::graph]` / `[struct::graph name]`), matching the SSA
     // lattice's `return_type_for_command` object-factory typing so the syntactic
     // and lattice signals agree.
     if args.first().is_some_and(|s| s == "new" || s == "create") {
-        return registry.object_class(&head).map(|c| c.class_name);
+        return registry.object_class(head).map(|c| c.class_name);
     }
     registry
-        .get(&head)
+        .get(head)
         .filter(|s| s.creates_instance_at.is_some())
         .and_then(|s| s.object_class)
         .map(|c| c.class_name)
+}
+
+/// Could `word` be the bracketed registry-constructor call that makes
+/// [`arg_classes`] yield a class with **no** seeded handle in play
+/// (`take [listbox .l]`)?
+///
+/// Deliberately over-approximate and deliberately cheap: it reads the head word
+/// with a string split instead of lexing, because it runs on every argument of
+/// every call during the harvest.  A false "yes" only costs the propagation
+/// walk that would have run anyway; a false "no" would drop a binding, so a
+/// head this cannot read as a bareword (a braced, quoted, substituted, or
+/// expanded head) answers "yes".
+fn may_be_constructor_word(word: &str, registry: &CommandRegistry) -> bool {
+    let trimmed = word.trim();
+    if !trimmed.starts_with('[') {
+        return false;
+    }
+    let Some(inner) = trimmed
+        .strip_prefix('[')
+        .and_then(|w| w.strip_suffix(']'))
+        .map(str::trim_start)
+    else {
+        return false;
+    };
+    let head = inner
+        .find(char::is_whitespace)
+        .map_or(inner, |end| &inner[..end]);
+    if head.is_empty() || head.starts_with(['{', '"', '$', '[', '\\']) {
+        return true;
+    }
+    registry.object_class(head).is_some()
+        || registry
+            .get(head)
+            .is_some_and(|s| s.creates_instance_at.is_some())
 }
 
 /// Whether `name` is a plain object-command name a naming factory binds — a
@@ -756,6 +1369,297 @@ mod tests {
             map.get("Pins").map(|s| s.contains("::SpiceGenTcl::Pin")),
             Some(true),
             "Pins should be a collection of ::SpiceGenTcl::Pin; got {map:?}"
+        );
+    }
+
+    /// Build a unit and its full fact set in one step (the C5a tests below all
+    /// want both).
+    fn facts_for(src: &str) -> (CommandRegistry, ObjectHandleFacts) {
+        let registry = CommandRegistry::build_default();
+        let cu = CompilationUnit::build_for(src, &registry, false);
+        let facts = object_handle_facts(&cu, &registry);
+        (registry, facts)
+    }
+
+    /// The classes `by_scope` binds for `(owner, var)`, sorted for a stable
+    /// assertion message.
+    fn scoped(facts: &ObjectHandleFacts, owner: &str, var: &str) -> Vec<String> {
+        let mut v: Vec<String> = facts
+            .by_scope
+            .get(&(owner.to_owned(), var.to_owned()))
+            .map(|s| s.iter().cloned().collect())
+            .unwrap_or_default();
+        v.sort();
+        v
+    }
+
+    #[test]
+    fn any_scope_is_verbatim_object_handle_classes() {
+        // The widened carrier must not perturb the map every existing consumer
+        // reads: `any_scope` is the old return value, byte-for-byte.
+        for src in [
+            "set chart [ticklecharts::chart new]\n$chart Xaxis -name x\n",
+            "oo::class create Pin { method cfg {args} {} }\n\
+             proc connect {dev} { $dev cfg }\n\
+             set p [Pin new]\nconnect $p\n",
+            "set x [expr {1 + 2}]\n",
+            "",
+        ] {
+            let registry = CommandRegistry::build_default();
+            let cu = CompilationUnit::build_for(src, &registry, false);
+            assert_eq!(
+                object_handle_facts(&cu, &registry).any_scope,
+                object_handle_classes(&cu, &registry),
+                "any_scope must equal object_handle_classes for `{src}`"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_seed_fast_path_is_behaviour_preserving() {
+        // The fast path skips the propagation walk when no edge can fire.  Pin
+        // it against the pre-#994 unconditional walk on every shape that binds
+        // from an *empty seed set* — a bare `out.is_empty()` gate (the obvious
+        // one) silently drops all four of the middle cases here.
+        for src in [
+            // Nothing at all: the fast path fires.
+            "proc noop {} { return 1 }\nset a 1\nputs $a\n",
+            "proc a {x} { b $x }\nproc b {y} { puts $y }\na 1\n",
+            // Proc-return edge from a factory whose object never lands in a
+            // `set` target the harvest can see.
+            "oo::class create Pin { method cfg {args} {} }\n\
+             proc make {} { return [Pin new] }\n\
+             set c [make]\n$c cfg\n",
+            // `arg_classes`' direct-constructor branch: a registry factory
+            // written straight into a proc-parameter, a constructor
+            // parameter, and a bare naming factory.
+            "proc take {dev} { $dev curselection }\ntake [listbox .l]\n",
+            "oo::class create Wrap { constructor {inner} { $inner curselection } }\n\
+             Wrap new [listbox .l]\n",
+            "proc take {dev} { $dev walk root }\ntake [struct::graph]\n",
+            // Nested inside an assigned value.
+            "oo::class create Wrap { constructor {inner} {} }\n\
+             set w [Wrap new [listbox .l]]\n",
+        ] {
+            let registry = CommandRegistry::build_default();
+            let cu = CompilationUnit::build_for(src, &registry, false);
+            assert_eq!(
+                object_handle_classes(&cu, &registry),
+                object_handle_classes_full_walk(&cu, &registry),
+                "the empty-seed fast path changed the map for `{src}`"
+            );
+        }
+    }
+
+    #[test]
+    fn owner_attribution_alias_edge_binds_in_the_assigning_unit() {
+        // `set b $a` inside `mk` binds `b` in `::mk`, not globally — the
+        // same-name collision across procs `any_scope` cannot avoid.
+        let (_r, facts) = facts_for(
+            "oo::class create Pin { method cfg {args} {} }\n\
+             proc mk {} { set a [Pin new]\n set b $a\n $b cfg }\n\
+             proc other {} { set b 7\n puts $b }\n",
+        );
+        assert_eq!(scoped(&facts, "::mk", "b"), vec!["::Pin".to_owned()]);
+        assert!(
+            scoped(&facts, "::other", "b").is_empty(),
+            "`b` in ::other is an unrelated integer; by_scope must not widen \
+             onto it (any_scope does: {:?})",
+            facts.any_scope.get("b")
+        );
+    }
+
+    #[test]
+    fn owner_attribution_return_edge_binds_in_the_assigning_unit() {
+        let (_r, facts) = facts_for(
+            "oo::class create Pin { method cfg {args} {} }\n\
+             proc make {} { set p [Pin new]\n return $p }\n\
+             proc use {} { set q [make]\n $q cfg }\n",
+        );
+        assert_eq!(scoped(&facts, "::use", "q"), vec!["::Pin".to_owned()]);
+        assert_eq!(
+            facts.returns_object.get("::make").map(String::as_str),
+            Some("::Pin"),
+            "the factory-proc return fact must be exported; got {:?}",
+            facts.returns_object
+        );
+    }
+
+    #[test]
+    fn owner_attribution_param_edge_binds_in_the_callee() {
+        // `connect $p` binds `dev` in `::connect` — the callee, where the name
+        // lives — not in the caller that supplied the argument.
+        let (_r, facts) = facts_for(
+            "oo::class create Pin { method cfg {args} {} }\n\
+             proc connect {dev} { $dev cfg }\n\
+             set p [Pin new]\nconnect $p\n",
+        );
+        assert_eq!(scoped(&facts, "::connect", "dev"), vec!["::Pin".to_owned()]);
+        assert!(
+            scoped(&facts, "::top", "dev").is_empty(),
+            "the param edge must not bind `dev` at the call site's scope"
+        );
+        assert_eq!(scoped(&facts, "::top", "p"), vec!["::Pin".to_owned()]);
+    }
+
+    #[test]
+    fn owner_attribution_ctor_param_edge_binds_in_the_constructor() {
+        let (_r, facts) = facts_for(
+            "oo::class create Pin { method cfg {args} {} }\n\
+             oo::class create Wrap {\n\
+               variable held\n\
+               constructor {inner} { $inner cfg; set held $inner }\n\
+             }\n\
+             set p [Pin new]\nset w [Wrap new $p]\n",
+        );
+        assert_eq!(
+            scoped(&facts, "::Wrap::<constructor>", "inner"),
+            vec!["::Pin".to_owned()],
+            "the ctor param is owned by the constructor unit; by_scope={:?}",
+            facts.by_scope
+        );
+    }
+
+    #[test]
+    fn owner_attribution_instance_var_is_owned_by_the_class() {
+        // The #797 bridge: `engine` is written in `Car`'s constructor and read
+        // in `Car`'s `go`.  Keying it by the *class* (not by either method)
+        // is what makes the cross-method dispatch resolvable at all.
+        let (_r, facts) = facts_for(
+            "oo::class create Motor { method spin {args} {} }\n\
+             oo::class create Car {\n\
+               variable engine\n\
+               constructor {e} { set engine $e }\n\
+               method go {} { $engine spin }\n\
+             }\n\
+             set m [Motor new]\nset c [Car new $m]\n",
+        );
+        assert_eq!(
+            scoped(&facts, "::Car", "engine"),
+            vec!["::Motor".to_owned()],
+            "instance var `engine` is owned by ::Car; by_scope={:?}",
+            facts.by_scope
+        );
+        assert!(
+            scoped(&facts, "::Car::<constructor>", "engine").is_empty(),
+            "an instance variable must not also be keyed by the writing method"
+        );
+        // …and `classes_in_scope` finds it from a byte inside the *other*
+        // method, via the class fallback.
+        let offset = facts
+            .owner_spans
+            .iter()
+            .find(|o| o.unit == "::Car::go")
+            .expect("::Car::go has an owner span")
+            .span
+            .start();
+        assert_eq!(
+            facts
+                .classes_in_scope(offset, "engine")
+                .map(|s| s.contains("::Motor")),
+            Some(true),
+            "classes_in_scope inside ::Car::go must reach the class-owned name"
+        );
+    }
+
+    #[test]
+    fn collection_and_global_cell_facts_are_exported() {
+        let (_r, facts) = facts_for(
+            "oo::class create Pin { method cfg {args} {} }\n\
+             dict set pins a [Pin new]\n\
+             set ::board [listbox .l]\n",
+        );
+        assert_eq!(
+            facts.collections.get("pins").map(|s| s.contains("::Pin")),
+            Some(true),
+            "collections must carry object_collection_classes verbatim; got {:?}",
+            facts.collections
+        );
+        assert_eq!(
+            facts
+                .global_object_cells
+                .get("::board")
+                .map(|s| s.contains("listbox")),
+            Some(true),
+            "a `::`-qualified handle must be exported as a global cell; got {:?}",
+            facts.global_object_cells
+        );
+        assert!(
+            !facts.global_object_cells.contains_key("pins"),
+            "an unqualified local is not a global cell"
+        );
+    }
+
+    #[test]
+    fn registry_factory_operator_form_binds_nothing_by_scope() {
+        // The `by_scope` twin of `registry_factory_operator_form_binds_nothing`:
+        // the deserialise operator words name no object command, so the
+        // abstention must survive in the scope-keyed map too — a bogus `=`
+        // binding there would be read by the C5b rename/refusal consumers.
+        let registry = CommandRegistry::build_default();
+        for op in ["=", ":=", "as", "deserialize"] {
+            let src = format!("struct::graph {op} $serial\n");
+            let cu = CompilationUnit::build_for(&src, &registry, false);
+            let facts = object_handle_facts(&cu, &registry);
+            assert!(
+                !facts.any_scope.contains_key(op),
+                "`struct::graph {op}` must not track `{op}` in any_scope"
+            );
+            assert!(
+                facts.by_scope.keys().all(|(_owner, name)| name != op),
+                "`struct::graph {op}` must not track `{op}` in by_scope; got {:?}",
+                facts.by_scope
+            );
+        }
+    }
+
+    #[test]
+    fn owner_spans_are_sorted_and_resolve_the_innermost_scope() {
+        let (_r, facts) = facts_for(
+            "set g 1\n\
+             proc alpha {} { set a 1 }\n\
+             oo::class create K { method m {} { set b 2 } }\n\
+             proc beta {} { set c 3 }\n",
+        );
+        assert!(
+            facts
+                .owner_spans
+                .windows(2)
+                .all(|w| w[0].span.start() <= w[1].span.start()),
+            "owner_spans must be start-sorted for binary search; got {:?}",
+            facts.owner_spans
+        );
+        // Top-level bytes resolve to `::top`, so a top-level handle has an
+        // owner to key against rather than falling off the index.
+        assert_eq!(
+            facts.owner_at(0).map(|o| o.unit.as_str()),
+            Some("::top"),
+            "byte 0 is top-level code; got {:?}",
+            facts.owner_at(0)
+        );
+        for unit in ["::alpha", "::beta", "::K::m"] {
+            let span = facts
+                .owner_spans
+                .iter()
+                .find(|o| o.unit == unit)
+                .unwrap_or_else(|| panic!("{unit} must have an owner span"))
+                .span;
+            assert_eq!(
+                facts.owner_at(span.start()).map(|o| o.unit.as_str()),
+                Some(unit),
+                "owner_at must resolve a byte inside {unit} to it, not to the \
+                 enclosing top level; owner_spans={:?}",
+                facts.owner_spans
+            );
+        }
+        assert_eq!(
+            facts
+                .owner_spans
+                .iter()
+                .find(|o| o.unit == "::K::m")
+                .and_then(|o| o.class.as_deref()),
+            Some("::K"),
+            "a method's owner span must name its class for the fallback key"
         );
     }
 }


### PR DESCRIPTION
## Summary

Stage **C5a** of the object-type-lattice unification (#994, design at https://github.com/bitwisecook/tcl-lsp/issues/994#issuecomment-5142198644) — compiler-only plumbing for the carrier the five dispatch consumers will share in C5b. **No consumer reads the new fact in this PR** and diagnostics are byte-identical.

- **`object_handle_facts(cu, registry)`** is the widened entry point: `any_scope` (the existing union verbatim), a scope-keyed **`by_scope`** twin keyed `(owner_qualified_name, name)` — alias/return edges bind in the assigning unit, param edges in the callee, ctor-param in the constructor, and a class instance variable is owned by the *class* unioned across its methods (reproducing the #797 collection bridge while refusing to merge same-named locals across procs) — plus `owner_spans`, `collections`, `returns_object` (the factory-return fact the fixpoint previously computed and discarded), and `global_object_cells`. `object_handle_classes` stays as a thin wrapper, so the optimiser, `compilation_unit`, `interprocedural`, `type_infer`, and semantic tokens pay exactly what they paid before.
- **A sound empty-seed fast path**: the existing early-out checked the wrong condition, so every file with any proc paid a full propagation walk with zero object seeds. 109 of 154 corpus files now skip propagation entirely; behaviour-equality pinned.
- The fact is produced at exactly one point (`analyser/diagnostics.rs`, beside `settle_pending_instance_class_sites`) that both the whole-file and per-item paths reach — nothing to merge in `per_item`.

**Measurement gate M1 (the design's stop-gate): PASS with order-of-magnitude margins** — median lattice cost **0.22%** of the CU build it rides on (gate ≤5%, 23×), p99 **1.46%** (gate ≤15%, 10×), worst file **0.648ms** (gate ≤25ms, 39×; `generalClasses.tcl`, 3,038 lines). Scope-keying itself costs 0.8ms across the whole 66,827-line corpus. Full results with reproduce block in `experiments/object_lattice/RESULTS.md`; the design tables live on in `docs/design/compiler/object-type-lattice.md`. Key carry-forward for C5b: 89 of 89 propagated bindings come from the harvest and simple edges — the value is the shared carrier, not the fixpoint, and the C5b gate is precision, not latency.

**Verification beyond the gates** (the differentials caught two *pre-existing* bugs, both A/B-proved identical on base and this commit, filed rather than absorbed): #1117 (memoised compiler checks drop ~20 O-hints vs a fresh run) and #1123 (the `--ignored` per-item corpus differential is red on `rust` with 45 findings — identical file sets and structural divergences on both sides of the A/B).

## Validation

- [x] `cargo test --workspace --all-features` — exit 0, zero failures (clean rebuild).
- [x] M1 gates PASS (table above); `fa_diff` clean (88=88, 0 divergent); `cc_diff` and per-item corpus **identical to base** by A/B.
- [x] 25 unit tests: owner attribution per edge kind, collection ownership, global-cell export, empty-fast-path behaviour equality, the `registry_factory_operator_form_binds_nothing` abstention in both maps.
- [x] clippy clean, zero new allows; fmt clean; `make xtask-check` OK. Base-merged with #1115/#1118-era `rust`; carries the #1124 wasmtime bump (identical content).

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — `AnalysisResult::object_handle_facts` is a new best-effort fact (empty = no evidence, never proof of absence; by_scope/any_scope soundness directions documented).
- [x] KCS notes updated: new `docs/design/compiler/object-type-lattice.md` (the four-maps-today table, the carrier, the consumer/soundness table), linked from the design index.
- [ ] New compiler KCS note linked. (the new design doc is the note)

Part of #994; C5b (consumers) and C5c (#1099 provenance) follow behind their own gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7)_