### PR TITLE
Add iRules event handlers as outline symbols with nesting

### DIFF
--- a/docs/kcs/features/kcs-feature-document-symbols.md
+++ b/docs/kcs/features/kcs-feature-document-symbols.md
@@ -21,6 +21,10 @@ all-editors, MCP, analyser
 
 Produces a hierarchical symbol tree with procs nested inside namespaces, variables inside procs, and event handlers (iRules `when` blocks) at the top level.
 
+An iRules `when EVENT { … }` handler is an outline entry of its own kind (LSP `Event`), named for its event and ranged over the whole handler. Like the `tcltest` definitions below it is registry-driven — `when` declares `defines_symbol` naming argument 0 — so `when EVENT priority 500 { … }` and a `when` reached through any of its keyword-tail forms all list identically, while a dynamic `when $evt { … }` is skipped rather than shown as `$evt`.
+
+A body that does **not** open a scope — a `when` handler, a `tcltest::test` case — contributes its definitions to the *enclosing* scope, so the handler and the variables set inside it arrive as siblings with overlapping ranges. The provider re-parents each symbol under the innermost sibling whose range contains it, so the outline is a proper tree (a nested `when` inside a `when` nests too). Documents without that shape — every plain Tcl file, where a scope body *is* a scope — are unaffected.
+
 Commands that *define a named unit* also contribute an outline entry, each under its own kind: `tcltest::test NAME …` (a function-like test case, description shown as detail), `tcltest::testConstraint NAME value` (a constant-kind constraint — only the two-argument setter defines; the one-argument getter is a reference), and `tcltest::customMatch MODE command` (an operator-kind match mode). All forms are recognised whether the command is called qualified or via `namespace import ::tcltest::*`, and a definition inside `namespace eval` nests under it. This is registry-driven: a command declares `defines_symbol` in its [`CommandSpec`](../../design/compiler/command-registry.md) and every symbol consumer (document + workspace symbols, MCP) picks it up generically, so adding the next such command is a spec change, not a compiler edit. The *name* is resolved through the analyser's constant-propagation lattice, so a name written as a literal, a quoted string, or a constant `$var` all resolve; a genuinely dynamic name is skipped rather than shown as raw `$var` text (#790).
 
 A `TclOO` class body contributes its members as children of the class symbol: `method` (instance), `classmethod` and `self method` (class-side, shown with a `classmethod` detail), `constructor`, `destructor`, and `property`. Both spellings of the class-side and visibility wrappers list — the prefix form (`self method make {n} {…}`) and the *block* form (`self { method make {n} {…} }`), and likewise `private method …` / `private { method … }`. The block form is normalised into the prefix form by the definition-body walker from registry data (the definer grammar marks `self` and `private` as wrapper members that also take a bare script block), so both spellings travel one code path and pick up dispatch, hover, and go-to-definition together with the outline entry (#1081). A `self` *introspection* call inside a method body (`[self class]`, `[self object]`) is an ordinary command substitution and contributes nothing to the outline. A dynamic block word (`self $body`) is skipped rather than guessed at.
@@ -36,6 +40,7 @@ A BIG-IP `.conf` file (any canonical basename — `bigip.conf`, `bigip_base.conf
 - `rust/tcl-lsp-core/src/bigip.rs` — BIG-IP outline + basename detection (native server)
 - `rust/tcl-lsp-core/src/document_symbols.rs` — native outline builder (walks the analyser scope tree)
 - `rust/tcl-registry/src/symbol_def.rs` — `SymbolDef` / `DefinedSymbolKind` (registry-driven symbol-definer commands)
+- `rust/tcl-registry/src/commands/irules/when.rs` — `when` declares its event name as the handler's outline entry
 - `rust/tcl-compiler/src/analyser/handlers.rs` — `handle_defines_symbol` (records test cases, constant-propagated name)
 - `rust/tcl-compiler/src/analyser/oo.rs` — `expand_wrapper_block_members` (`self { … }` / `private { … }` block forms), `apply_oo_self`
 - `rust/tcl-registry/src/definer.rs` — `MemberSpec::wrapper_or_body` (which members take a bare script block), `MemberSpec::retracts_named_members` (which member words delete the members they name, with the oracle transcript)
@@ -52,7 +57,8 @@ A BIG-IP `.conf` file (any canonical basename — `bigip.conf`, `bigip_base.conf
 - `rust/tcl-lsp-core/src/document_symbols.rs` — TP/FP/TN/FN unit tests for `tcltest` test cases
 - `rust/tcl-lsp-server/tests/e2e/document_symbols.rs` — `tcltest_*` e2e cases (document + workspace symbols)
 - `rust/tcl-registry/tests/tcltest_specs.rs::test_command_declares_a_symbol_definer`
-- `editors/vscode/src/test/documentSymbols.test.ts` — "lists tcltest test cases as symbols"
+- `rust/tcl-registry/tests/registry_commands.rs::when_defines_its_event_as_an_outline_symbol`
+- `editors/vscode/src/test/documentSymbols.test.ts` — "lists tcltest test cases as symbols", "lists iRules event handlers as Event symbols"
 
 ## Screenshots
 

--- a/docs/kcs/features/kcs-feature-folding.md
+++ b/docs/kcs/features/kcs-feature-folding.md
@@ -20,6 +20,14 @@ all-editors, analyser
 
 Folding ranges are computed from the parsed AST, identifying proc bodies, namespace blocks, `when` event handlers, and multi-line braced expressions.
 
+BIG-IP configs (`bigip.conf` and friends) are not Tcl source, so they fold on
+their own path: a brace-balanced scan of the stanza tree that folds every
+multi-line `{ … }` region at any depth — `ltm virtual … { … }`, the
+`profiles` / `records` / `members` blocks nested in it, and the Tcl inside an
+`ltm rule` body — plus the same comment-block folds the Tcl provider emits.
+Before that split the Tcl brace walk ran over config text and found only
+comment blocks, leaving every stanza unfoldable.
+
 In VS Code the folding ranges also drive **sticky scroll** for Tcl code
 languages. VS Code picks the sticky model from a fallback chain — outline
 model → folding-range provider → indentation heuristic — and a non-empty
@@ -28,11 +36,13 @@ outline stops the chain. A Tcl script whose top level is `if` / `for` /
 pins nothing and sticky scroll goes blank (issue #1122). The extension
 therefore contributes
 `"editor.stickyScroll.defaultModel": "foldingProviderModel"` as a
-language-scoped default for every Tcl code language, which pins the same
-block headers folding already knows about. BIG-IP config is the opposite
-shape — a rich `module → kind → object` stanza outline and almost no folds —
-so `tcl-bigip` stays on the outline model. Both are defaults: a user setting
-for `editor.stickyScroll.defaultModel` still wins.
+language-scoped default for every Tcl language, which pins the same block
+headers folding already knows about. BIG-IP config needs the same default
+for a different reason: its outline is a synthesised `module → kind →
+object` tree whose module and kind nodes take their selection range from
+their first child, so the outline model pins the first `ltm` stanza in the
+file no matter where the cursor is. It is a default, so a user setting for
+`editor.stickyScroll.defaultModel` still wins.
 
 The version-pinned dialect languages (`tcl8.4`, `tcl8.5`, `tcl9.0`, `tcl9.1`)
 are the one gap. A language id containing a `.` cannot be used as a
@@ -43,6 +53,9 @@ remaining override in the block — so those four keep the outline model.
 ## File-path anchors
 
 - `server/features/folding.py`
+- `rust/tcl-lsp-core/src/folding.rs` — Tcl folding walk (native server)
+- `rust/tcl-lsp-core/src/bigip.rs` — `folding_ranges` (BIG-IP stanza folds)
+- `editors/vscode/package.json` — `configurationDefaults` sticky-scroll model per language
 
 ## Failure modes
 
@@ -51,6 +64,9 @@ remaining override in the block — so those four keep the outline model.
 ## Test anchors
 
 - `tests/test_folding.py`
+- `rust/tcl-lsp-core/src/bigip.rs` — stanza / embedded-rule / unbalanced-input fold unit tests
+- `rust/tcl-lsp-server/tests/e2e/bigip.rs` — `conf_stanzas_and_their_nested_blocks_fold`
+- `editors/vscode/src/test/stickyScroll.test.ts` — per-language sticky-scroll defaults
 
 ## Screenshots
 

--- a/docs/kcs/features/kcs-feature-folding.md
+++ b/docs/kcs/features/kcs-feature-folding.md
@@ -20,6 +20,26 @@ all-editors, analyser
 
 Folding ranges are computed from the parsed AST, identifying proc bodies, namespace blocks, `when` event handlers, and multi-line braced expressions.
 
+In VS Code the folding ranges also drive **sticky scroll** for Tcl code
+languages. VS Code picks the sticky model from a fallback chain — outline
+model → folding-range provider → indentation heuristic — and a non-empty
+outline stops the chain. A Tcl script whose top level is `if` / `for` /
+`foreach` has only single-line symbols in its outline, so the outline model
+pins nothing and sticky scroll goes blank (issue #1122). The extension
+therefore contributes
+`"editor.stickyScroll.defaultModel": "foldingProviderModel"` as a
+language-scoped default for every Tcl code language, which pins the same
+block headers folding already knows about. BIG-IP config is the opposite
+shape — a rich `module → kind → object` stanza outline and almost no folds —
+so `tcl-bigip` stays on the outline model. Both are defaults: a user setting
+for `editor.stickyScroll.defaultModel` still wins.
+
+The version-pinned dialect languages (`tcl8.4`, `tcl8.5`, `tcl9.0`, `tcl9.1`)
+are the one gap. A language id containing a `.` cannot be used as a
+configuration override identifier — VS Code splits `[tcl8.4]` on the dot while
+building the default-configuration value tree, throws, and drops every
+remaining override in the block — so those four keep the outline model.
+
 ## File-path anchors
 
 - `server/features/folding.py`

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2962,6 +2962,36 @@
             "italic": true
           }
         }
+      },
+      "[tcl]": {
+        "editor.stickyScroll.defaultModel": "foldingProviderModel"
+      },
+      "[tcl-irule]": {
+        "editor.stickyScroll.defaultModel": "foldingProviderModel"
+      },
+      "[tcl-iapp]": {
+        "editor.stickyScroll.defaultModel": "foldingProviderModel"
+      },
+      "[tcl-apl]": {
+        "editor.stickyScroll.defaultModel": "foldingProviderModel"
+      },
+      "[tcl-synopsys]": {
+        "editor.stickyScroll.defaultModel": "foldingProviderModel"
+      },
+      "[tcl-cadence]": {
+        "editor.stickyScroll.defaultModel": "foldingProviderModel"
+      },
+      "[tcl-xilinx]": {
+        "editor.stickyScroll.defaultModel": "foldingProviderModel"
+      },
+      "[tcl-quartus]": {
+        "editor.stickyScroll.defaultModel": "foldingProviderModel"
+      },
+      "[tcl-mentor]": {
+        "editor.stickyScroll.defaultModel": "foldingProviderModel"
+      },
+      "[tcl-expect]": {
+        "editor.stickyScroll.defaultModel": "foldingProviderModel"
       }
     },
     "configuration": [

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2975,6 +2975,9 @@
       "[tcl-apl]": {
         "editor.stickyScroll.defaultModel": "foldingProviderModel"
       },
+      "[tcl-bigip]": {
+        "editor.stickyScroll.defaultModel": "foldingProviderModel"
+      },
       "[tcl-synopsys]": {
         "editor.stickyScroll.defaultModel": "foldingProviderModel"
       },

--- a/editors/vscode/src/test/documentSymbols.test.ts
+++ b/editors/vscode/src/test/documentSymbols.test.ts
@@ -190,4 +190,29 @@ suite("Document Symbols", () => {
     assert.ok(names.includes(":"), `the ':' proc appears in the outline: ${names}`);
     assert.ok(names.includes("a:b"), `the 'a:b' proc appears in the outline: ${names}`);
   });
+
+  // An iRule's structure is its `when` blocks.  They carried no outline
+  // symbol at all, so the outline, breadcrumbs and Cmd+Shift+O listed only
+  // whatever variables the handlers happened to set.
+  test("lists iRules event handlers as Event symbols", async () => {
+    const uri = getDocUri("dialect.irul");
+    await activate(uri);
+
+    const symbols = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeDocumentSymbolProvider", uri),
+      (r) => {
+        const syms = r as (vscode.DocumentSymbol[] | vscode.SymbolInformation[]) | undefined;
+        return !!syms && syms.some((s) => s.name === "HTTP_REQUEST");
+      },
+      { timeout: 10_000, label: "iRules event-handler symbol" },
+    )) as vscode.DocumentSymbol[] | vscode.SymbolInformation[];
+
+    const handler = symbols.find((s) => s.name === "HTTP_REQUEST");
+    assert.ok(handler, `Should list the HTTP_REQUEST handler, got: ${symbols.map((s) => s.name)}`);
+    assert.strictEqual(
+      handler.kind,
+      vscode.SymbolKind.Event,
+      "event handler should have Event kind",
+    );
+  });
 });

--- a/editors/vscode/src/test/stickyScroll.test.ts
+++ b/editors/vscode/src/test/stickyScroll.test.ts
@@ -1,0 +1,130 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { TCL_LANGUAGE_IDS } from "../languageIds";
+import { getDocUri, activate, pollUntil } from "./helper";
+
+// VS Code picks the sticky-scroll model per language with a fallback chain:
+// outline model → folding-range provider → indentation heuristic.  A
+// *non-empty* outline stops the chain, so registering a document-symbol
+// provider silently replaces the indentation heuristic the user had before
+// the extension was installed (issue #1122).  For Tcl code the outline is
+// definitions only — a script whose top level is `if` / `for` / `foreach`
+// contributes nothing sticky, so sticky scroll goes blank.  Our folding
+// ranges cover exactly those blocks, so Tcl code languages default to the
+// folding-provider model.  BIG-IP config is the opposite shape (a rich
+// stanza outline, almost no folds) and stays on the outline model.
+//
+// The version-pinned dialects (`tcl8.4`, `tcl9.0`, …) are excluded because a
+// language id containing a `.` cannot be used as a configuration override
+// identifier: VS Code splits `[tcl8.4]` on the dot while building the
+// default-configuration value tree, throws, and drops every remaining
+// override in the same `configurationDefaults` block.  See the
+// "dotted language ids" test below.
+const DOTTED_LANGUAGE_IDS = [...TCL_LANGUAGE_IDS].filter((id) => id.includes("."));
+const STICKY_FOLDING_LANGUAGES = [...TCL_LANGUAGE_IDS].filter(
+  (id) => id !== "tcl-bigip" && !id.includes("."),
+);
+
+suite("Sticky Scroll", () => {
+  const stickyModelFor = (languageId: string): string | undefined =>
+    vscode.workspace
+      .getConfiguration("editor", { languageId })
+      .get<string>("stickyScroll.defaultModel");
+
+  for (const languageId of STICKY_FOLDING_LANGUAGES) {
+    test(`'${languageId}' defaults sticky scroll to the folding-provider model`, () => {
+      assert.strictEqual(
+        stickyModelFor(languageId),
+        "foldingProviderModel",
+        `'${languageId}' should default editor.stickyScroll.defaultModel to foldingProviderModel`,
+      );
+    });
+  }
+
+  test("dotted language ids cannot carry a sticky-scroll default", () => {
+    // Known VS Code limitation, asserted so we notice if it is ever fixed:
+    // `"[tcl8.4]"` in `configurationDefaults` makes VS Code throw while
+    // updating the default configuration model, so the override never lands
+    // (and takes the rest of the block with it).  If this starts returning
+    // `foldingProviderModel`, add the dotted ids back to the manifest.
+    assert.ok(DOTTED_LANGUAGE_IDS.length > 0, "expected version-pinned dialects like tcl9.0");
+    for (const languageId of DOTTED_LANGUAGE_IDS) {
+      assert.strictEqual(stickyModelFor(languageId), "outlineModel", languageId);
+    }
+  });
+
+  test("'tcl-bigip' keeps the outline model", () => {
+    // The BIG-IP outline is the stanza tree (module → kind → object) and is
+    // far richer than the handful of folds a `.conf` produces, so the
+    // default chain is already the right one there.
+    assert.strictEqual(stickyModelFor("tcl-bigip"), "outlineModel");
+  });
+
+  test("control-flow-only Tcl has no sticky outline but does have folds", async () => {
+    // The regression the default guards against: every symbol in this
+    // document is single-line, so VS Code's outline sticky model yields
+    // nothing while the folding model pins `for` / `if` / `else`.
+    await activate(getDocUri("folding.tcl"));
+
+    const doc = await vscode.workspace.openTextDocument({
+      language: "tcl",
+      content: [
+        "set total 0",
+        "",
+        "for {set i 0} {$i < 5} {incr i} {",
+        "    set total [expr {$total + $i}]",
+        "}",
+        "",
+        "if {$total > 5} {",
+        '    puts "total is $total"',
+        "} else {",
+        '    puts "small total"',
+        "}",
+        "",
+      ].join("\n"),
+    });
+    await vscode.window.showTextDocument(doc);
+
+    const symbols =
+      ((await vscode.commands.executeCommand(
+        "vscode.executeDocumentSymbolProvider",
+        doc.uri,
+      )) as vscode.DocumentSymbol[]) ?? [];
+    const multiLine = symbols.filter((s) => s.selectionRange.start.line !== s.range.end.line);
+    assert.deepStrictEqual(
+      multiLine.map((s) => s.name),
+      [],
+      "outline model would have nothing to stick for a control-flow-only script",
+    );
+
+    const ranges = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeFoldingRangeProvider", doc.uri),
+      (r) => Array.isArray(r) && r.length > 0,
+      { timeout: 10_000, label: "folding ranges present" },
+    )) as vscode.FoldingRange[];
+    const starts = ranges.map((r) => r.start).sort((a, b) => a - b);
+    assert.deepStrictEqual(
+      starts,
+      [2, 6, 8],
+      `folding should pin the for/if/else headers, got ${JSON.stringify(ranges)}`,
+    );
+  });
+});

--- a/editors/vscode/src/test/stickyScroll.test.ts
+++ b/editors/vscode/src/test/stickyScroll.test.ts
@@ -28,9 +28,11 @@ import { getDocUri, activate, pollUntil } from "./helper";
 // the extension was installed (issue #1122).  For Tcl code the outline is
 // definitions only — a script whose top level is `if` / `for` / `foreach`
 // contributes nothing sticky, so sticky scroll goes blank.  Our folding
-// ranges cover exactly those blocks, so Tcl code languages default to the
-// folding-provider model.  BIG-IP config is the opposite shape (a rich
-// stanza outline, almost no folds) and stays on the outline model.
+// ranges cover exactly those blocks, so Tcl languages default to the
+// folding-provider model.  BIG-IP config needs it for a different reason:
+// its outline is a synthesised `module → kind → object` tree whose module
+// and kind nodes select the line of their *first* child, so the outline
+// model pins the first `ltm` stanza in the file no matter where you scroll.
 //
 // The version-pinned dialects (`tcl8.4`, `tcl9.0`, …) are excluded because a
 // language id containing a `.` cannot be used as a configuration override
@@ -39,9 +41,7 @@ import { getDocUri, activate, pollUntil } from "./helper";
 // override in the same `configurationDefaults` block.  See the
 // "dotted language ids" test below.
 const DOTTED_LANGUAGE_IDS = [...TCL_LANGUAGE_IDS].filter((id) => id.includes("."));
-const STICKY_FOLDING_LANGUAGES = [...TCL_LANGUAGE_IDS].filter(
-  (id) => id !== "tcl-bigip" && !id.includes("."),
-);
+const STICKY_FOLDING_LANGUAGES = [...TCL_LANGUAGE_IDS].filter((id) => !id.includes("."));
 
 suite("Sticky Scroll", () => {
   const stickyModelFor = (languageId: string): string | undefined =>
@@ -71,11 +71,41 @@ suite("Sticky Scroll", () => {
     }
   });
 
-  test("'tcl-bigip' keeps the outline model", () => {
-    // The BIG-IP outline is the stanza tree (module → kind → object) and is
-    // far richer than the handful of folds a `.conf` produces, so the
-    // default chain is already the right one there.
-    assert.strictEqual(stickyModelFor("tcl-bigip"), "outlineModel");
+  test("BIG-IP config stanzas fold, so sticky scroll has real lines to pin", async () => {
+    // A `.conf` is not Tcl, so it used to produce only comment folds and the
+    // folding model would have had nothing to stick.  Folding now runs off
+    // the stanza tree, at every nesting depth.
+    await activate(getDocUri("folding.tcl"));
+
+    const doc = await vscode.workspace.openTextDocument({
+      language: "tcl-bigip",
+      content: [
+        "ltm virtual /Common/www_vs {",
+        "    destination /Common/1.2.3.4:80",
+        "    profiles {",
+        "        /Common/http {",
+        "        }",
+        "    }",
+        "}",
+        "",
+      ].join("\n"),
+    });
+    await vscode.window.showTextDocument(doc);
+
+    const ranges = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeFoldingRangeProvider", doc.uri),
+      (r) => Array.isArray(r) && r.length > 0,
+      { timeout: 10_000, label: "BIG-IP folding ranges present" },
+    )) as vscode.FoldingRange[];
+    const spans = ranges.map((r) => [r.start, r.end]).sort((a, b) => a[0] - b[0]);
+    assert.deepStrictEqual(
+      spans,
+      [
+        [0, 5],
+        [2, 4],
+      ],
+      `stanza and nested profiles block should fold, got ${JSON.stringify(ranges)}`,
+    );
   });
 
   test("control-flow-only Tcl has no sticky outline but does have folds", async () => {

--- a/rust/tcl-lsp-core/src/bigip.rs
+++ b/rust/tcl-lsp-core/src/bigip.rs
@@ -46,6 +46,7 @@ use tcl_lexer::LineIndex;
 use tcl_registry::bigip::BigipRegistry;
 
 use crate::document_symbols::{DocumentSymbol, LineRange, SymbolKind};
+use crate::folding::{FoldKind, FoldingRange};
 
 /// Canonical BIG-IP configuration file names, matched by basename
 /// (not extension).
@@ -252,6 +253,128 @@ fn object_types_by_module(
 /// One grouped outline leaf: object name, its range, and the header's
 /// start byte (used only to sort entries within a kind group).
 type Entry = (String, LineRange, usize);
+
+/// Compute folding ranges for a BIG-IP config.
+///
+/// A `.conf` is not Tcl source, so the Tcl folding walk finds nothing in it
+/// beyond comment blocks: every stanza — `ltm virtual … { … }` and each of
+/// its nested `profiles { … }` / `records { … }` sub-blocks — stays
+/// unfoldable.  This is the config-shaped equivalent: a brace-balanced scan
+/// that folds every multi-line `{ … }` region at any depth, plus the same
+/// comment-block folds the Tcl provider emits.
+///
+/// The embedded Tcl inside an `ltm rule` body folds through the same scan —
+/// its `when` / `if` / `foreach` blocks are brace regions like any other.
+///
+/// Regions are properly nested by construction (they come off a brace
+/// stack), so no overlap normalisation is needed.  The end line is the line
+/// *before* the closing brace, matching the Tcl provider so the `}` stays
+/// visible when a region is collapsed.
+#[must_use]
+pub fn folding_ranges(source: &str) -> Vec<FoldingRange> {
+    if source.is_empty() {
+        return Vec::new();
+    }
+    let line_index = LineIndex::new(source);
+    let mut seen: FxHashSet<(u32, u32)> = FxHashSet::default();
+    let mut ranges: Vec<FoldingRange> = Vec::new();
+
+    for (open, close) in brace_regions(source) {
+        let (Ok(open), Ok(close)) = (u32::try_from(open), u32::try_from(close)) else {
+            continue;
+        };
+        let start_line = line_index.line_at(open);
+        // The closing brace's own line stays visible, so the fold ends on
+        // the line above it — a single-line `{ … }` folds to nothing.
+        let Some(end_line) = line_index.line_at(close).checked_sub(1) else {
+            continue;
+        };
+        if end_line <= start_line || !seen.insert((start_line, end_line)) {
+            continue;
+        }
+        ranges.push(FoldingRange {
+            start_line,
+            end_line,
+            kind: FoldKind::Region,
+        });
+    }
+
+    crate::folding::collect_comment_folds(source, &mut seen, &mut ranges);
+    ranges.sort_by_key(|r| (r.start_line, std::cmp::Reverse(r.end_line)));
+    ranges
+}
+
+/// Every `{ … }` region in `source`, at any nesting depth, as
+/// `(open-brace offset, close-brace offset)` pairs.
+///
+/// Iterative (a brace stack, not recursion), so a pathologically nested
+/// config cannot overflow the native stack.  Quoted spans, backslash
+/// escapes and whole-line `#` comments are skipped so a brace inside one
+/// does not unbalance the scan — the same structural bytes
+/// [`extract_blocks`] respects, applied at every depth rather than only at
+/// the top level.  Unbalanced input degrades quietly: an unmatched `{` is
+/// dropped with the stack, an unmatched `}` is ignored.
+fn brace_regions(source: &str) -> Vec<(usize, usize)> {
+    let bytes = source.as_bytes();
+    let length = bytes.len();
+    let mut stack: Vec<usize> = Vec::new();
+    let mut regions: Vec<(usize, usize)> = Vec::new();
+    let mut pos = 0;
+    // Whether only whitespace has been seen so far on the current line —
+    // a `#` there opens a comment, a `#` anywhere else is ordinary text
+    // (BIG-IP descriptions and iRule string literals both contain them).
+    let mut line_blank_so_far = true;
+
+    while pos < length {
+        match bytes[pos] {
+            b'\n' => {
+                line_blank_so_far = true;
+                pos += 1;
+            }
+            b' ' | b'\t' | b'\r' => pos += 1,
+            b'#' if line_blank_so_far => {
+                while pos < length && bytes[pos] != b'\n' {
+                    pos += 1;
+                }
+            }
+            b'\\' => {
+                // A backslash-newline continues the logical line, but the
+                // *physical* next line still starts fresh for `#` purposes.
+                line_blank_so_far = bytes.get(pos + 1) == Some(&b'\n');
+                pos += 2;
+            }
+            b'"' => {
+                line_blank_so_far = false;
+                pos += 1;
+                while pos < length && bytes[pos] != b'"' {
+                    if bytes[pos] == b'\\' {
+                        pos += 1;
+                    }
+                    pos += 1;
+                }
+                pos += 1;
+            }
+            b'{' => {
+                line_blank_so_far = false;
+                stack.push(pos);
+                pos += 1;
+            }
+            b'}' => {
+                line_blank_so_far = false;
+                if let Some(open) = stack.pop() {
+                    regions.push((open, pos));
+                }
+                pos += 1;
+            }
+            _ => {
+                line_blank_so_far = false;
+                pos += 1;
+            }
+        }
+    }
+
+    regions
+}
 
 /// Build a `module → kind → object` outline for a BIG-IP config.
 ///
@@ -528,5 +651,90 @@ ltm rule /Common/r {
     #[test]
     fn empty_source_yields_no_symbols() {
         assert!(document_symbols("").is_empty());
+    }
+
+    /// `(start_line, end_line)` pairs for every region fold, in order.
+    fn regions(source: &str) -> Vec<(u32, u32)> {
+        folding_ranges(source)
+            .into_iter()
+            .filter(|r| r.kind == FoldKind::Region)
+            .map(|r| (r.start_line, r.end_line))
+            .collect()
+    }
+
+    #[test]
+    fn folds_stanzas_and_their_nested_blocks() {
+        // `ltm pool` (11..15) wraps `members` (12..14) wraps the member
+        // stanza — which is single-line and so folds to nothing.
+        let folds = regions(SAMPLE);
+        assert!(folds.contains(&(11, 14)), "pool stanza missing: {folds:?}");
+        assert!(
+            folds.contains(&(12, 13)),
+            "members block missing: {folds:?}"
+        );
+        // Every region nests properly: no partial overlaps.
+        for (i, a) in folds.iter().enumerate() {
+            for b in &folds[i + 1..] {
+                let disjoint = b.0 > a.1 || a.0 > b.1;
+                let nested = (a.0 <= b.0 && b.1 <= a.1) || (b.0 <= a.0 && a.1 <= b.1);
+                assert!(disjoint || nested, "partial overlap {a:?} / {b:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn folds_tcl_inside_an_embedded_rule() {
+        // The `ltm rule` body is Tcl; its `when` block is a brace region
+        // like any other, so it folds through the same scan.
+        let folds = regions(SAMPLE);
+        assert!(folds.contains(&(16, 19)), "rule stanza missing: {folds:?}");
+        assert!(folds.contains(&(17, 18)), "when block missing: {folds:?}");
+    }
+
+    #[test]
+    fn single_line_block_does_not_fold() {
+        // `1.2.3.4:80 { }` opens and closes on one line — nothing to hide.
+        assert!(regions("ltm pool /Common/p {\n    1.2.3.4:80 { }\n}\n").contains(&(0, 1)));
+        assert!(regions("x { }\n").is_empty());
+    }
+
+    #[test]
+    fn braces_in_comments_and_strings_do_not_unbalance_the_scan() {
+        let source = "\
+# a stray { in a comment
+ltm virtual /Common/v {
+    description \"unbalanced } in a string\"
+    destination /Common/1.2.3.4:80
+}
+";
+        assert_eq!(regions(source), vec![(1, 3)]);
+    }
+
+    #[test]
+    fn unbalanced_input_degrades_quietly() {
+        // An unclosed stanza yields no fold rather than a bogus one, and a
+        // stray closer is ignored.
+        assert!(regions("ltm pool /Common/p {\n    members {\n").is_empty());
+        assert_eq!(
+            regions("}\nltm pool /Common/p {\n    a 1\n}\n"),
+            vec![(1, 2)]
+        );
+    }
+
+    #[test]
+    fn comment_blocks_fold_like_the_tcl_provider() {
+        let source = "# one\n# two\n# three\nltm node /Common/n {\n    address 1.2.3.4\n}\n";
+        let folds = folding_ranges(source);
+        assert!(
+            folds
+                .iter()
+                .any(|r| r.kind == FoldKind::Comment && (r.start_line, r.end_line) == (0, 2)),
+            "{folds:?}"
+        );
+    }
+
+    #[test]
+    fn empty_source_yields_no_folds() {
+        assert!(folding_ranges("").is_empty());
     }
 }

--- a/rust/tcl-lsp-core/src/document_symbols.rs
+++ b/rust/tcl-lsp-core/src/document_symbols.rs
@@ -81,6 +81,10 @@ pub enum SymbolKind {
     /// A BIG-IP tmsh module folder (`ltm`, `net`, `sys`, …) — the
     /// top level of the BIG-IP config outline.
     Module,
+    /// An event handler bound by a registry event-handler command — a
+    /// `when EVENT { … }` block in an iRule.  Surfaced with the LSP `Event`
+    /// wire kind, which editors render with their event glyph.
+    Event,
 }
 
 impl SymbolKind {
@@ -100,6 +104,7 @@ impl SymbolKind {
             Self::Constant => "Constant",
             Self::Operator => "Operator",
             Self::Module => "Module",
+            Self::Event => "Event",
         }
     }
 }
@@ -113,6 +118,7 @@ impl From<tcl_registry::DefinedSymbolKind> for SymbolKind {
             tcl_registry::DefinedSymbolKind::Test => Self::Test,
             tcl_registry::DefinedSymbolKind::Constraint => Self::Constant,
             tcl_registry::DefinedSymbolKind::Matcher => Self::Operator,
+            tcl_registry::DefinedSymbolKind::Event => Self::Event,
         }
     }
 }
@@ -444,7 +450,108 @@ fn scope_symbols(
         }
     }
 
-    symbols
+    nest_by_containment(symbols)
+}
+
+/// Does `outer` strictly contain `inner` — covering it, but not equal to it?
+fn strictly_contains(outer: LineRange, inner: LineRange) -> bool {
+    outer != inner
+        && pos_leq(
+            outer.start_line,
+            outer.start_character,
+            inner.start_line,
+            inner.start_character,
+        )
+        && pos_leq(
+            inner.end_line,
+            inner.end_character,
+            outer.end_line,
+            outer.end_character,
+        )
+}
+
+/// Re-parent siblings that lexically nest inside one another.
+///
+/// A scope's symbol list is flat by construction, because a body that does
+/// *not* open a scope contributes its definitions to the enclosing one: the
+/// `set`s inside an iRules `when EVENT { … }` handler (or a
+/// `tcltest::test` case) land in the same scope as the handler itself, so
+/// they arrive as siblings whose ranges sit inside the handler's.  The LSP
+/// contract wants a tree — and VS Code's outline, breadcrumbs and sticky
+/// scroll all assume one — so each symbol moves under the innermost sibling
+/// whose range strictly contains it.
+///
+/// Symbols that contain nothing are left exactly as they were, so every
+/// document without this shape (which is every plain Tcl file, where scope
+/// bodies *are* scopes) round-trips unchanged.
+fn nest_by_containment(mut symbols: Vec<DocumentSymbol>) -> Vec<DocumentSymbol> {
+    let count = symbols.len();
+    if count < 2 {
+        return symbols;
+    }
+    // `parent[i]` = index of the innermost sibling containing `i`, found by
+    // one containment sweep: visiting outermost-first (start ascending, then
+    // the wider range first) means the enclosing symbols are exactly the ones
+    // still on the stack, so this is O(n log n) rather than a pairwise scan
+    // over a document that can carry thousands of top-level symbols.
+    let mut sweep: Vec<usize> = (0..count).collect();
+    sweep.sort_by_key(|&i| {
+        let r = symbols[i].range;
+        (
+            r.start_line,
+            r.start_character,
+            std::cmp::Reverse((r.end_line, r.end_character)),
+        )
+    });
+    let mut parent: Vec<Option<usize>> = vec![None; count];
+    let mut open: Vec<usize> = Vec::new();
+    let mut nested = false;
+    for &i in &sweep {
+        // Equal ranges do not contain one another, so the earlier of a tied
+        // pair is popped and both stay siblings.
+        while open
+            .last()
+            .is_some_and(|&p| !strictly_contains(symbols[p].range, symbols[i].range))
+        {
+            open.pop();
+        }
+        if let Some(&p) = open.last() {
+            parent[i] = Some(p);
+            nested = true;
+        }
+        open.push(i);
+    }
+    if !nested {
+        return symbols;
+    }
+    // Move each nested symbol into its parent.  A child always sorts after
+    // its parent in the sweep, so walking the sweep backwards assembles a
+    // chain (`when` → `test` → `set`) from the inside out.  Indices stay
+    // valid because entries are taken, never removed.
+    let mut slots: Vec<Option<DocumentSymbol>> = symbols.drain(..).map(Some).collect();
+    for &i in sweep.iter().rev() {
+        let Some(p) = parent[i] else { continue };
+        let Some(child) = slots[i].take() else {
+            continue;
+        };
+        if let Some(host) = slots[p].as_mut() {
+            host.children.push(child);
+        }
+    }
+    for slot in slots.iter_mut().flatten() {
+        sort_nested_children(slot);
+    }
+    slots.into_iter().flatten().collect()
+}
+
+/// Put a symbol's children back into source order after re-parenting.
+fn sort_nested_children(symbol: &mut DocumentSymbol) {
+    symbol
+        .children
+        .sort_by_key(|c| (c.range.start_line, c.range.start_character));
+    for child in &mut symbol.children {
+        sort_nested_children(child);
+    }
 }
 
 fn class_symbol(source: &str, class_def: &ClassDef, line_index: &LineIndex) -> DocumentSymbol {
@@ -1428,5 +1535,109 @@ mod tests {
         let symbols = document_symbols(src, "tcl8.6");
         let greet = find(&symbols, "greet").expect("greet symbol");
         assert_eq!(greet.detail.as_deref(), Some("(args)"), "{greet:?}");
+    }
+
+    const IRULES: &str = "f5-irules";
+
+    #[test]
+    fn irule_event_handlers_are_outline_symbols() {
+        // An iRule's structure is its `when` blocks; before the registry
+        // `defines_symbol` on `when`, the outline listed only the variables
+        // the handlers happened to set.
+        let src = concat!(
+            "when HTTP_REQUEST {\n",
+            "    set host [HTTP::host]\n",
+            "}\n",
+            "when HTTP_RESPONSE priority 500 {\n",
+            "    HTTP::header insert X-Served-By $host\n",
+            "}\n",
+        );
+        let symbols = document_symbols(src, IRULES);
+        assert_eq!(names(&symbols), vec!["HTTP_REQUEST", "HTTP_RESPONSE"]);
+        assert!(
+            symbols.iter().all(|s| s.kind == SymbolKind::Event),
+            "{:?}",
+            flat(&symbols)
+        );
+    }
+
+    #[test]
+    fn event_handler_range_spans_the_body_and_selects_the_event_name() {
+        let src = "when HTTP_REQUEST {\n    set host [HTTP::host]\n}\n";
+        let symbols = document_symbols(src, IRULES);
+        let handler = &symbols[0];
+        // Selection is the event name on line 0; the range reaches the
+        // closing brace so the outline can fold (and stick) the handler.
+        assert_eq!(handler.selection_range.start_line, 0);
+        assert_eq!(handler.selection_range.start_character, 5);
+        assert_eq!(handler.range.end_line, 2);
+        assert!(range_contains(handler.range, handler.selection_range));
+    }
+
+    #[test]
+    fn variables_set_in_a_handler_nest_under_it() {
+        // A `when` body is structural, not a scope, so its `set`s land in
+        // the global scope alongside the handler.  They belong *under* it.
+        let src = concat!(
+            "set global_one 1\n",
+            "when HTTP_REQUEST {\n",
+            "    set inner 2\n",
+            "}\n",
+        );
+        let symbols = document_symbols(src, IRULES);
+        assert_eq!(names(&symbols), vec!["global_one", "HTTP_REQUEST"]);
+        let handler = find(&symbols, "HTTP_REQUEST").expect("handler");
+        assert_eq!(names(&handler.children), vec!["inner"]);
+    }
+
+    #[test]
+    fn nested_handlers_nest_in_the_outline() {
+        // A `when` inside a `when` is legal iRules; the inner handler is a
+        // child, not a sibling with an overlapping range.
+        let src = concat!(
+            "when CLIENT_ACCEPTED {\n",
+            "    when HTTP_REQUEST {\n",
+            "        set deep 1\n",
+            "    }\n",
+            "}\n",
+        );
+        let symbols = document_symbols(src, IRULES);
+        assert_eq!(names(&symbols), vec!["CLIENT_ACCEPTED"]);
+        let outer = &symbols[0];
+        assert_eq!(names(&outer.children), vec!["HTTP_REQUEST"]);
+        assert_eq!(names(&outer.children[0].children), vec!["deep"]);
+    }
+
+    #[test]
+    fn plain_tcl_outline_is_unchanged_by_containment_nesting() {
+        // Every plain-Tcl body opens a scope, so nothing re-parents: the
+        // nesting pass must leave these documents byte-identical.
+        let src = concat!(
+            "set top 1\n",
+            "proc greet {name} {\n",
+            "    set msg \"hi\"\n",
+            "}\n",
+            "namespace eval ns {\n",
+            "    variable v 1\n",
+            "}\n",
+        );
+        let symbols = document_symbols(src, "tcl8.6");
+        assert_eq!(names(&symbols), vec!["greet", "top", "ns"]);
+        // `msg` is proc-local, so it is not an outline symbol at all — and
+        // `greet` must not swallow `top` or `ns`, which sit outside it.
+        assert!(names(&find(&symbols, "greet").unwrap().children).is_empty());
+        assert_eq!(names(&find(&symbols, "ns").unwrap().children), vec!["v"]);
+    }
+
+    #[test]
+    fn dynamic_event_name_is_not_an_outline_symbol() {
+        // `when $evt { … }` has no statically-known event; the definer walk
+        // skips a non-constant name rather than listing `$evt`.
+        let src = "set evt HTTP_REQUEST\nwhen $evt {\n    set x 1\n}\n";
+        let all = flat(&document_symbols(src, IRULES));
+        assert!(
+            !all.iter().any(|(name, _)| name.contains('$')),
+            "dynamic event name leaked into the outline: {all:?}"
+        );
     }
 }

--- a/rust/tcl-lsp-core/src/folding.rs
+++ b/rust/tcl-lsp-core/src/folding.rs
@@ -223,7 +223,11 @@ fn collect_scope_folds(
 /// lines.  An internal block (one followed by a non-comment line)
 /// needs at least three lines; a trailing block at end-of-file needs
 /// at least two.
-fn collect_comment_folds(
+///
+/// Shared with the BIG-IP folding path ([`crate::bigip::folding_ranges`]),
+/// which reuses it verbatim so a comment block folds identically whether
+/// it sits in Tcl source or in a `.conf`.
+pub(crate) fn collect_comment_folds(
     source: &str,
     seen: &mut FxHashSet<(u32, u32)>,
     ranges: &mut Vec<FoldingRange>,

--- a/rust/tcl-lsp-core/src/workspace_symbols.rs
+++ b/rust/tcl-lsp-core/src/workspace_symbols.rs
@@ -49,6 +49,8 @@ pub enum WorkspaceSymbolKind {
     Constant,
     /// A named `tcltest::customMatch` mode — a custom result matcher.
     Operator,
+    /// An iRules `when EVENT { … }` event handler.
+    Event,
 }
 
 impl From<tcl_registry::DefinedSymbolKind> for WorkspaceSymbolKind {
@@ -58,6 +60,7 @@ impl From<tcl_registry::DefinedSymbolKind> for WorkspaceSymbolKind {
             tcl_registry::DefinedSymbolKind::Test => Self::Test,
             tcl_registry::DefinedSymbolKind::Constraint => Self::Constant,
             tcl_registry::DefinedSymbolKind::Matcher => Self::Operator,
+            tcl_registry::DefinedSymbolKind::Event => Self::Event,
         }
     }
 }

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -9930,12 +9930,21 @@ impl LanguageServer for Backend {
         let Some(doc) = self.read_document(&params.text_document.uri).await else {
             return Ok(None);
         };
+        // BIG-IP config documents fold on their stanza tree rather than the
+        // Tcl brace walk (which, on non-Tcl config text, finds only comment
+        // blocks and leaves every stanza unfoldable) — the folding twin of
+        // the outline split in `document_symbol`.
+        let bigip = Self::is_bigip_dialect(&doc.dialect);
         let registry = self.registry_for_dialect(&doc.dialect).await;
         // Pure-CPU tokenise/segment work; run on a worker so a parser panic
         // is contained as a JSON-RPC error rather than unwinding the event
         // loop (defence in depth).
         let ranges = tokio::task::spawn_blocking(move || {
-            tcl_lsp_core::folding::folding_ranges(&doc.text, &doc.dialect, registry)
+            if bigip {
+                core_bigip::folding_ranges(&doc.text)
+            } else {
+                tcl_lsp_core::folding::folding_ranges(&doc.text, &doc.dialect, registry)
+            }
         })
         .await
         .map_err(|err| jsonrpc::Error {
@@ -11103,6 +11112,7 @@ impl LanguageServer for Backend {
                         CoreWorkspaceSymbolKind::Constructor => SymbolKind::CONSTRUCTOR,
                         CoreWorkspaceSymbolKind::Constant => SymbolKind::CONSTANT,
                         CoreWorkspaceSymbolKind::Operator => SymbolKind::OPERATOR,
+                        CoreWorkspaceSymbolKind::Event => SymbolKind::EVENT,
                     },
                     tags: None,
                     deprecated: None,
@@ -14796,6 +14806,7 @@ fn lift_symbol_kind(k: CoreSymbolKind) -> SymbolKind {
         CoreSymbolKind::Constant => SymbolKind::CONSTANT,
         CoreSymbolKind::Operator => SymbolKind::OPERATOR,
         CoreSymbolKind::Module => SymbolKind::MODULE,
+        CoreSymbolKind::Event => SymbolKind::EVENT,
     }
 }
 

--- a/rust/tcl-lsp-server/tests/e2e/bigip.rs
+++ b/rust/tcl-lsp-server/tests/e2e/bigip.rs
@@ -136,6 +136,54 @@ fn nameless_singleton_falls_back_to_kind_label() {
     assert!(names.contains("auth"), "{names:?}");
 }
 
+// -- TestBigipFolding ----------------------------------------------------
+// A `.conf` is not Tcl, so the Tcl brace walk found only comment blocks in it
+// and left every stanza unfoldable; folding now runs off the stanza tree.
+
+/// The `(startLine, endLine)` pairs of a folding-range result.
+fn fold_spans(result: &Value) -> BTreeSet<(i64, i64)> {
+    result
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .map(|r| {
+                    (
+                        r.get("startLine").and_then(Value::as_i64).unwrap_or(-1),
+                        r.get("endLine").and_then(Value::as_i64).unwrap_or(-1),
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[test]
+fn conf_stanzas_and_their_nested_blocks_fold() {
+    let mut lsp = Lsp::bigip();
+    let uri = bigip_uri();
+    lsp.open_document(&uri, BIGIP_CONF);
+    lsp.await_diagnostics_version(&uri, Some(1), Duration::from_secs(30));
+    let spans = fold_spans(&lsp.folding_range(&uri));
+    // `net self-allow` (3..7) and the `defaults` block it wraps (4..6).
+    assert!(spans.contains(&(3, 6)), "self-allow stanza: {spans:?}");
+    assert!(spans.contains(&(4, 5)), "defaults block: {spans:?}");
+    // `ltm pool` (11..15) and its `members` block (12..14).
+    assert!(spans.contains(&(11, 14)), "pool stanza: {spans:?}");
+    assert!(spans.contains(&(12, 13)), "members block: {spans:?}");
+}
+
+#[test]
+fn tcl_inside_an_embedded_rule_folds() {
+    let mut lsp = Lsp::bigip();
+    let uri = bigip_uri();
+    lsp.open_document(&uri, BIGIP_CONF);
+    lsp.await_diagnostics_version(&uri, Some(1), Duration::from_secs(30));
+    let spans = fold_spans(&lsp.folding_range(&uri));
+    // `ltm rule /Common/r` (16..20) and the `when HTTP_REQUEST` block in it.
+    assert!(spans.contains(&(16, 19)), "rule stanza: {spans:?}");
+    assert!(spans.contains(&(17, 18)), "when block: {spans:?}");
+}
+
 // -- TestBigipDiagnosticSuppression --------------------------------------
 // Issue #571 — no general Tcl diagnostics on BIG-IP config text.
 

--- a/rust/tcl-lsp-server/tests/e2e/document_symbols.rs
+++ b/rust/tcl-lsp-server/tests/e2e/document_symbols.rs
@@ -37,6 +37,7 @@ const FUNCTION: i64 = 12;
 const VARIABLE: i64 = 13;
 const CONSTANT: i64 = 14;
 const OPERATOR: i64 = 25;
+const EVENT: i64 = 24;
 
 /// The top-level document symbols for `uri` as a list (`or []`).
 fn top(lsp: &mut Lsp, uri: &str) -> Vec<Value> {
@@ -529,5 +530,69 @@ fn colon_named_proc_has_a_non_empty_symbol_name() {
     assert!(
         names.iter().all(|n| !n.is_empty()),
         "no falsy symbol names: {names:?}"
+    );
+}
+
+// -- TestIrulesEventHandlers ---------------------------------------------
+// An iRule's structure is its `when` blocks.  They carried no outline symbol
+// at all, so the outline, breadcrumbs and Cmd+Shift+O listed only whatever
+// variables the handlers happened to set.
+
+#[test]
+fn irule_event_handlers_are_outline_symbols() {
+    let mut lsp = Lsp::irules();
+    let uri = unique_uri("irule");
+    lsp.open_ready_lang(
+        &uri,
+        "when HTTP_REQUEST {\n\
+        \x20   set host [HTTP::host]\n\
+         }\n\
+         when HTTP_RESPONSE priority 500 {\n\
+        \x20   HTTP::header insert X-Host $host\n\
+         }\n",
+        "tcl-irule",
+    );
+    let syms = top(&mut lsp, &uri);
+    let handlers: Vec<String> = syms
+        .iter()
+        .filter(|s| kind(s) == EVENT)
+        .map(|s| name(s).to_owned())
+        .collect();
+    assert_eq!(handlers, vec!["HTTP_REQUEST", "HTTP_RESPONSE"], "{syms:?}");
+}
+
+#[test]
+fn variables_set_in_a_handler_nest_under_it() {
+    // A `when` body is structural, not a scope, so its `set`s land in the
+    // same scope as the handler — they must still nest under it in the tree.
+    let mut lsp = Lsp::irules();
+    let uri = unique_uri("irule");
+    lsp.open_ready_lang(
+        &uri,
+        "when HTTP_REQUEST {\n\x20   set host [HTTP::host]\n}\n",
+        "tcl-irule",
+    );
+    let syms = top(&mut lsp, &uri);
+    assert_eq!(syms.len(), 1, "{syms:?}");
+    assert_eq!(name(&syms[0]), "HTTP_REQUEST");
+    let kids = children(&syms[0]);
+    let inner: Vec<&str> = kids.iter().map(name).collect();
+    assert_eq!(inner, vec!["host"], "{syms:?}");
+}
+
+#[test]
+fn event_handler_is_a_workspace_symbol() {
+    let mut lsp = Lsp::irules();
+    let uri = unique_uri("irule");
+    lsp.open_ready_lang(
+        &uri,
+        "when CLIENTSSL_HANDSHAKE {\n\x20   log local0. ok\n}\n",
+        "tcl-irule",
+    );
+    let result = lsp.workspace_symbols("CLIENTSSL_HANDSHAKE");
+    let syms = result.as_array().cloned().unwrap_or_default();
+    assert!(
+        syms.iter().any(|s| name(s) == "CLIENTSSL_HANDSHAKE"),
+        "workspace symbol not found: {syms:?}"
     );
 }

--- a/rust/tcl-registry/src/commands/irules/when.rs
+++ b/rust/tcl-registry/src/commands/irules/when.rs
@@ -74,6 +74,12 @@ pub const fn spec() -> CommandSpec {
         dialects: Some(DialectSet::IRULES),
         arity: Arity::new(2, 6),
         arg_role_resolver: Some(when_arg_roles),
+        // The event name (argument 0) is the handler's outline entry: an
+        // iRule's structure *is* its `when` blocks, so the outline, the
+        // breadcrumb bar and workspace symbols list them the way they list a
+        // `proc`.  Declared as registry data, so the document-symbol provider
+        // discovers it generically rather than matching on the command name.
+        defines_symbol: Some(SymbolDef::new(0, DefinedSymbolKind::Event)),
         lowering_hook: Some(LoweringHookId::When),
         // iRules event handler bodies run in the event
         // dispatcher's frame — separate from the top-level rule

--- a/rust/tcl-registry/src/symbol_def.rs
+++ b/rust/tcl-registry/src/symbol_def.rs
@@ -62,6 +62,10 @@ pub enum DefinedSymbolKind {
     /// command` — a new value accepted by `test -match`, backed by a comparison
     /// command.  A custom comparison strategy, so it reads as an operator.
     Matcher,
+    /// An event handler bound by an event-handler command (`when EVENT { … }`
+    /// in iRules), named for its event.  The top-level structure of an iRule
+    /// is its handlers, so they are the entries the outline exists to show.
+    Event,
 }
 
 impl DefinedSymbolKind {
@@ -72,6 +76,7 @@ impl DefinedSymbolKind {
             Self::Test => "test",
             Self::Constraint => "constraint",
             Self::Matcher => "match mode",
+            Self::Event => "event",
         }
     }
 }

--- a/rust/tcl-registry/tests/registry_commands.rs
+++ b/rust/tcl-registry/tests/registry_commands.rs
@@ -901,6 +901,25 @@ fn tcltest_test_is_namespace_exported() {
 /// `test_when_body_is_structural` — iRules `when` body runs in the dispatcher's
 /// frame, not the caller's.
 ///
+/// `when` declares its event name (argument 0) as a navigable definition, so
+/// the document-symbol / workspace-symbol providers list event handlers the
+/// way they list a `proc` — registry data, not a command-name check.
+///
+/// f5-dialect + registry-metadata.
+#[test]
+fn when_defines_its_event_as_an_outline_symbol() {
+    use tcl_registry::DefinedSymbolKind;
+    let (reg, ds) = reg_and_set("f5-irules");
+    let sym = reg
+        .defines_symbol("when", ds)
+        .expect("when should declare a symbol definer");
+    assert_eq!(sym.name_arg, 0, "the event name is the first argument");
+    assert_eq!(sym.kind, DefinedSymbolKind::Event);
+    // Every `when` call binds a handler — there is no getter form to gate on.
+    assert_eq!(sym.requires_arg, None);
+    assert!(reg.commands_defining_symbols().contains(&"when"));
+}
+
 /// f5-dialect + registry-metadata.
 #[test]
 fn when_body_is_structural() {

--- a/rust/tcl-spec-studio/src/catalogue.rs
+++ b/rust/tcl-spec-studio/src/catalogue.rs
@@ -835,7 +835,8 @@ mod tests {
             match k {
                 DefinedSymbolKind::Test
                 | DefinedSymbolKind::Constraint
-                | DefinedSymbolKind::Matcher => true,
+                | DefinedSymbolKind::Matcher
+                | DefinedSymbolKind::Event => true,
             }
         }
         fn side(k: ConnectionSide) -> bool {


### PR DESCRIPTION
## Summary

- Add `Event` symbol kind to represent iRules `when EVENT { … }` handlers as first-class outline entries
- Implement symbol nesting by containment to properly parent variables and nested handlers under their enclosing `when` blocks
- Add folding ranges for BIG-IP config stanzas and nested blocks via brace-balanced scan
- Configure sticky scroll to use folding-provider model for Tcl languages to handle control-flow-only scripts
- Update registry metadata to declare `when` as a symbol definer with `Event` kind

## Details

### Document Symbols (iRules Event Handlers)

iRules `when EVENT { … }` handlers now appear as outline symbols with kind `Event`, making them navigable through document symbols, workspace symbols, breadcrumbs, and Cmd+Shift+O. Previously only variables set within handlers were listed.

The `when` command's event name (argument 0) is registered as a symbol definition in the registry, surfaced with LSP `Event` kind which editors render with their event glyph.

### Symbol Nesting by Containment

A scope's symbol list is flat by construction because bodies that don't open a scope (like `when` handlers and `tcltest::test` cases) contribute their definitions to the enclosing scope. Variables set inside a handler arrive as siblings with ranges inside the handler's range.

New `nest_by_containment()` function re-parents symbols that lexically nest inside one another, building a proper tree for the LSP contract. This uses an O(n log n) containment sweep rather than pairwise scanning. Plain Tcl files (where scope bodies are scopes) round-trip unchanged.

### BIG-IP Config Folding

BIG-IP configs (`.conf` files) now fold on their stanza tree rather than the Tcl brace walk, which found only comment blocks on non-Tcl text. New `folding_ranges()` and `brace_regions()` functions perform a brace-balanced scan that folds every multi-line `{ … }` region at any depth — stanzas, nested blocks like `profiles { … }`, and Tcl inside `ltm rule` bodies.

### Sticky Scroll Configuration

VS Code's sticky scroll uses a fallback chain: outline model → folding-range provider → indentation heuristic. A non-empty outline stops the chain. Tcl scripts with only control-flow (`if`/`for`/`foreach`) have single-line symbols, so the outline model pins nothing.

Added `"editor.stickyScroll.defaultModel": "foldingProviderModel"` as a language-scoped default for all Tcl languages (except version-pinned dialects like `tcl8.4` which cannot use dotted language ids in configuration overrides). This pins the same block headers that folding already knows about.

BIG-IP config needs the same default for a different reason: its outline is synthesised from the stanza tree, so the outline model would pin the first stanza regardless of scroll position.

## Validation

- Added unit tests for event handler symbols, nesting behavior, and BIG-IP folding
- Added e2e tests for iRules event handlers in document and workspace symbols
- Added VS Code integration tests for sticky scroll configuration and folding ranges
- Existing tests pass; new tests cover the nesting algorithm, containment logic, and brace-region scanning

https://claude.ai/code/session_01GFqhEcZvYm4Jk1MTZhCeHP