### PR TITLE
Memoised compiler checks now cover method and body-unit bodies (#1117)

### DIFF
--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -1634,14 +1634,14 @@ impl CompilationUnit {
     /// [`Self::analysable_functions`] elsewhere and wants *only* these two
     /// extra function kinds added, without double-visiting top-level or a
     /// procedure or double-counting a diagnostic. Used by
-    /// `tcl-lsp-db::proc_taint_solve`'s shimmer-family top-up loop: that
-    /// memoised query's main per-function loop still iterates
+    /// `tcl-lsp-db::proc_taint_solve`'s `function_nontaint_checks` top-up loop:
+    /// that memoised query's main per-function loop still iterates
     /// [`Self::analysable_functions`] (proc-only), unlike
     /// `compiler_checks::run_all_checks_with_solved_and_patterns`'s direct
     /// path, which iterates the wider [`Self::all_body_function_units`]
     /// (filtered) and so needs no separate top-up — adding this iterator's
-    /// output there too would re-run `shimmer_family_checks` a second time
-    /// over the methods/body units `function_nontaint_checks` already covers.
+    /// output there too would re-run `function_nontaint_checks` a second time
+    /// over the methods/body units the direct path already covers.
     pub fn analysable_methods_and_body_units(&self) -> impl Iterator<Item = &FunctionUnit> {
         let mut v: Vec<&FunctionUnit> = self
             .methods

--- a/rust/tcl-compiler/src/compiler_checks.rs
+++ b/rust/tcl-compiler/src/compiler_checks.rs
@@ -298,12 +298,13 @@ pub fn run_all_checks_with_solved_and_patterns(
     // shimmer / thunking / byte-array), computed on each procedure — **and**,
     // via `analysable_body_function_units`, every `TclOO` method body and
     // synthetic body unit (`apply` lambda, `namespace eval` body) too, so the
-    // shimmer family `function_nontaint_checks` folds in reaches those places
-    // as well (no separate widening loop needed here: unlike
-    // `tcl-lsp-db::proc_taint_solve`'s memoised path below, which still
-    // iterates the proc-only `analysable_functions` and so keeps its own
-    // explicit `shimmer_family_checks` pass over methods/body units) —
-    // rebased to its offset. Factored into [`function_nontaint_checks`] so
+    // whole family this folds in (SCCP constant branches, GVN redundancies and
+    // the shimmer half alike) reaches those places as well (no separate
+    // widening loop needed here: unlike `tcl-lsp-db::proc_taint_solve`'s
+    // memoised path, which still iterates the proc-only `analysable_functions`
+    // and so keeps its own explicit `function_nontaint_checks` top-up pass over
+    // methods/body units) — rebased to its offset. Factored into
+    // [`function_nontaint_checks`] so
     // the LSP db can memoise it per procedure on the offset-0 `FnLatticeKey`
     // (SRV-INCREMENTAL 2a): an unedited procedure's checks are a cache hit
     // instead of recomputed over the whole unit every edit.

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -1760,19 +1760,31 @@ pub fn proc_taint_solve<'db>(
         }
     }
 
-    // The intrep-shimmer family alone, extended to `TclOO` method bodies and
+    // The per-function non-taint checks over `TclOO` method bodies and
     // synthetic body units (`apply` lambdas, `namespace eval` bodies). The
-    // main per-function loop above still iterates the proc-only
+    // main per-function loop above iterates the proc-only
     // `analysable_functions`, unlike `compiler_checks::run_all_checks_with_solved_and_patterns`'s
-    // direct path (which iterates the wider `all_body_function_units` and so
-    // needs no separate top-up — see `analysable_methods_and_body_units`'s
+    // direct path (which iterates the wider `analysable_body_function_units`
+    // and so needs no separate top-up — see `analysable_methods_and_body_units`'s
     // own doc comment for why adding it there too would double-count), so
     // this memoised path needs its own top-up loop to reach the same
-    // methods/body units. These never get an offset-0 `FnLatticeKey`, so
-    // they carry absolute spans already and need no rebase, same as the
-    // `None` arm above.
+    // methods/body units.
+    //
+    // This must run the **whole** `function_nontaint_checks` family, not just
+    // its `shimmer_family_checks` half: the direct path folds the SCCP
+    // constant-branch (O100) and GVN full / partial / loop-invariant
+    // (O105/O106) halves in here too, and running only the shimmer half made
+    // the memoised path silently drop every O1xx finding inside a method or a
+    // `namespace eval` body — 20 of them on one large TclOO corpus file
+    // (issue #1117), a diff users on the LSP (memoised) path saw as missing
+    // hints the CLI reported.
+    //
+    // These units never get an offset-0 `FnLatticeKey`, so they carry absolute
+    // spans already and need no rebase, same as the `None` arm above (the
+    // direct path's `shift` is likewise the identity here — a whole-module
+    // build leaves every `FunctionUnit::base_offset` at 0).
     for fu in cu.analysable_methods_and_body_units() {
-        for d in tcl_compiler::compiler_checks::shimmer_family_checks(
+        for d in tcl_compiler::compiler_checks::function_nontaint_checks(
             fu,
             registry,
             dialect_opt,
@@ -3545,6 +3557,139 @@ mod tests {
                 "optimisations differ for ({dialect}):\n{src}"
             );
         }
+    }
+
+    /// A `TclOO` method body / `namespace eval` body / `apply` lambda is not a
+    /// procedure, so it never gets an offset-0 `FnLatticeKey` and is invisible to
+    /// [`proc_taint_solve`]'s main `analysable_functions` loop — it is reached
+    /// only by that query's explicit top-up over
+    /// `analysable_methods_and_body_units`.  That top-up used to run just the
+    /// `shimmer_family_checks` half of `function_nontaint_checks`, so every SCCP
+    /// constant-branch (`O100`) and GVN full / partial / loop-invariant
+    /// (`O105`/`O106`) finding inside a method or a body unit was silently
+    /// dropped from the memoised path while the direct
+    /// [`compiler_check_diagnostics_uncached`] build reported it — 20 missing
+    /// hints on one large `TclOO` corpus file (issue #1117).
+    ///
+    /// The existing corpus differential could not see this: it sweeps the
+    /// procedural `tmp/tcl*/library` + `tcllib` trees, which define almost no
+    /// `TclOO` methods.  This fixture pins the shape directly, and asserts the
+    /// counts are **non-zero** so the equality cannot pass vacuously.
+    #[test]
+    fn compiler_check_memo_covers_method_and_body_unit_checks() {
+        let dialect = "tcl8.6";
+        // Each body carries an `O100` (SCCP-folded existence branch) *and* an
+        // `O106` (loop-invariant `lindex`), once inside a `TclOO` method, once
+        // inside a `destructor`, once inside an `apply` lambda, and once inside a
+        // `namespace eval` body — the four function kinds outside
+        // `analysable_functions`.
+        let body = "if {[info exists Missing]} { puts no }\n\
+                    for {set i 0} {$i < [llength $vals]} {incr i 2} {\n\
+                        set v [lindex $vals [expr {$i+1}]]\n\
+                        puts $v\n\
+                    }\n";
+        let src = format!(
+            "oo::class create K {{\n\
+                 variable vals\n\
+                 method m {{}} {{\n{body}}}\n\
+                 destructor {{\n{body}}}\n\
+             }}\n\
+             apply {{{{vals}} {{\n{body}}}}} {{a b}}\n\
+             namespace eval ns {{\n set vals {{a b}}\n{body}}}\n"
+        );
+
+        let db = TclDatabase::default();
+        let file = SourceFile::new(&db, src.clone(), dialect.to_owned(), None);
+        let got = compiler_check_diagnostics(&db, file, cfg(&db));
+        let registry = db.registry(dialect);
+        let want = compiler_check_diagnostics_uncached(&src, registry, dialect, None, None);
+
+        let o1xx = |ds: &[CompilerCheck]| {
+            ds.iter()
+                .filter(|d| matches!(d.code, DiagCode::O100 | DiagCode::O105 | DiagCode::O106))
+                .count()
+        };
+        assert!(
+            o1xx(&want.checks) >= 4,
+            "fixture must actually produce O1xx checks in the non-proc bodies, got {:?}",
+            want.checks
+        );
+        assert_eq!(
+            got.checks, want.checks,
+            "memoised checks drop findings inside TclOO method / body-unit bodies (#1117)"
+        );
+        assert_eq!(
+            o1xx(&got.checks),
+            o1xx(&want.checks),
+            "memoised O1xx hint count must equal the fresh build's"
+        );
+        assert_eq!(got.optimisations, want.optimisations);
+    }
+
+    /// The #1117 top-up must also **invalidate**: an edit inside a `TclOO`
+    /// method body has to move the memoised path's O1xx hints with it (and drop
+    /// them when the construct goes away), not serve a stale `proc_taint_solve`
+    /// result — the opposite failure direction from the missing-hints bug.
+    #[test]
+    fn method_body_checks_invalidate_on_edit() {
+        use salsa::Setter as _;
+        let dialect = "tcl8.6";
+        let with_hint = |pad: &str| {
+            format!(
+                "oo::class create K {{\n{pad}\
+                 method m {{}} {{\n\
+                     if {{[info exists Missing]}} {{ puts no }}\n\
+                 }}\n\
+                 }}\n"
+            )
+        };
+        // Same class with the constant-branch guard removed — no O100 at all.
+        let without_hint = "oo::class create K {\n\
+             method m {} {\n\
+                 puts no\n\
+             }\n\
+             }\n";
+
+        let mut db = TclDatabase::default();
+        let registry = db.registry(dialect);
+        let file = SourceFile::new(&db, with_hint(""), dialect.to_owned(), None);
+
+        let o100_spans = |ds: &[CompilerCheck]| -> Vec<(u32, u32)> {
+            ds.iter()
+                .filter(|d| d.code == DiagCode::O100)
+                .map(|d| (d.span.start(), d.span.end()))
+                .collect()
+        };
+
+        let mut seen: Vec<Vec<(u32, u32)>> = Vec::new();
+        // 1. baseline, 2. body shifted by a prepended line (spans must move),
+        // 3. the guard deleted (hint must disappear), 4. restored.
+        for src in [
+            with_hint(""),
+            with_hint("\n\n"),
+            without_hint.to_owned(),
+            with_hint(""),
+        ] {
+            file.set_text(&mut db).to(src.clone());
+            let got = compiler_check_diagnostics(&db, file, cfg(&db));
+            let want = compiler_check_diagnostics_uncached(&src, registry, dialect, None, None);
+            assert_eq!(got.checks, want.checks, "stale memo after edit to:\n{src}");
+            seen.push(o100_spans(&got.checks));
+        }
+        assert_eq!(seen[0].len(), 1, "baseline must have the method-body O100");
+        assert_ne!(
+            seen[0], seen[1],
+            "prepending lines must shift the method-body O100 span, not reuse the stale one"
+        );
+        assert!(
+            seen[2].is_empty(),
+            "deleting the guard must drop the method-body O100, got {:?}",
+            seen[2]
+        );
+        assert_eq!(
+            seen[3], seen[0],
+            "restoring the guard must restore the span"
+        );
     }
 
     /// The interprocedural taint cascade (`taint_cascade`, backlog #1) must stay

--- a/rust/tcl-lsp-db/tests/compiler_check_corpus.rs
+++ b/rust/tcl-lsp-db/tests/compiler_check_corpus.rs
@@ -136,6 +136,48 @@ fn compiler_check_memo_matches_uncached_init() {
     );
 }
 
+/// Focused regression for issue #1117 — the exact file the `cc_diff` repro
+/// names.  `generalClasses.tcl` is ~140 KB of `TclOO`: almost all of its code
+/// lives in *method* bodies, which are not procedures and so never reach
+/// `proc_taint_solve`'s `analysable_functions` loop.  That query's top-up over
+/// `analysable_methods_and_body_units` used to run only `shimmer_family_checks`
+/// instead of the whole `function_nontaint_checks` family, so the memoised path
+/// reported 20 fewer `O100`/`O105`/`O106` hints than the direct build.  The
+/// procedural `tmp/tcl*/library` + `tcllib` sweep below cannot see this: those
+/// trees define practically no `TclOO` methods.
+///
+/// Corpus-gated (`experiments/corpus/fetch_corpus.sh`), so it skips when the
+/// checkout is absent, exactly like the `tmp/` fixtures above.
+#[test]
+fn compiler_check_memo_matches_uncached_tcloo_corpus() {
+    let dialect = "tcl8.6";
+    let path = repo_root().join("experiments/corpus/georgtree/SpiceGenTcl/src/generalClasses.tcl");
+    let Ok(src) = std::fs::read_to_string(&path) else {
+        eprintln!("skip: {} not present", path.display());
+        return;
+    };
+    let db = TclDatabase::default();
+    let file = SourceFile::new(&db, src.clone(), dialect.to_owned(), None);
+    let got = compiler_check_diagnostics(&db, file, default_config(&db));
+    let registry = db.registry(dialect);
+    let want = compiler_check_diagnostics_uncached(&src, registry, dialect, None, None);
+    assert_eq!(
+        got.checks.len(),
+        want.checks.len(),
+        "generalClasses.tcl check count diverges (memo {} vs uncached {}) — #1117",
+        got.checks.len(),
+        want.checks.len()
+    );
+    assert_eq!(
+        got.checks, want.checks,
+        "generalClasses.tcl checks diverge (memo vs uncached) — #1117"
+    );
+    assert_eq!(
+        got.optimisations, want.optimisations,
+        "generalClasses.tcl optimisations diverge (memo vs uncached)"
+    );
+}
+
 #[test]
 #[ignore = "slow corpus sweep (~100s over tmp/); run with --ignored"]
 fn compiler_check_memo_matches_uncached_over_corpus() {


### PR DESCRIPTION
## Summary

Fixes #1117 — the memoised `compiler_check_diagnostics` path silently dropped every SCCP/GVN check (O100/O105/O106) in TclOO methods, destructors, `apply` lambdas, and `namespace eval` bodies. Root cause is a coverage gap, not a salsa staleness bug: the fresh path iterates `analysable_body_function_units()` (everything), while the memo path's main loop can only cover top-level + procs and compensated with a top-up loop over methods/body units that called **`shimmer_family_checks`** — the shimmer half only. The SCCP and GVN halves were never computed there. **The fix is one call swap** (`shimmer_family_checks` → `function_nontaint_checks`); no rebasing is needed because whole-module builds leave `base_offset` at 0 (shimmer spans already matched byte-for-byte, proving it).

The signature was not file-specific: 4 of 10 sampled corpus files carried it (`tclopt.tcl` worst at 24 dropped hints; the issue's `generalClasses.tcl` at 20), all now 0 fresh-only with DIAGS unchanged. Which side was right was established, not assumed: an A/B fixture with identical code as a proc vs a method shows both paths agree on the proc and only the never-run method diverged — and the existing corpus gate missed this because it sweeps essentially procedural trees.

**Found along the way, filed as #1129 (deliberately not folded in):** 17 of the 20 restored hints on the repro file are themselves false positives on *both* paths — `existence_constant_branches` refuses to fold `info exists` over `global`/`variable`/`upvar`/`namespace upvar` aliases but is blind to TclOO instance variables, which also feeds false I230s today. That is a shared-helper defect with its own blast radius (I230/O101/DCE), needing instance-var facts in `FunctionUnit::build_full` and a diagnostic-delta measurement.

## Validation

- [x] Three A/B-proven tests (each verified failing with the fix reverted): a four-body-kind fixture asserting memo == fresh with a non-vacuous ≥4 hint floor; an invalidation test (warm db, four edits, span moves/disappears/returns — guarding the opposite failure direction); and the issue's exact repro file as a corpus-gated regression.
- [x] `cargo test -p tcl-lsp-db` all targets green; `cargo test -p tcl-lsp-server` green (run separately after the disk crunch that deferred it); clippy/fmt clean, zero new allows; `make xtask-check` 12/12.
- [x] TN: `fa_diff` DIAGS unchanged on three corpus files (88=88, 112=112, 94=94).

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Behaviourally: the memoised LSP path now reports the same O1xx set as the fresh/CLI path over method and body-unit bodies (that equality was already the documented contract; it now holds).
- [x] KCS notes: stale cross-reference comments in `compiler_checks.rs`/`compilation_unit.rs` corrected to describe both paths.
- [ ] New compiler KCS note linked. (n/a)

Closes #1117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7)_