### PR TITLE
The info-exists fold abstains on TclOO instance state; method parameters fold true on both paths

### DIFF
--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -653,6 +653,20 @@ impl Analyser {
             ));
         }
         let ir_proc = ir_module.procedures.get(&function_unit.name);
+        // A `TclOO` method body is in `ir_module.methods`, never
+        // `ir_module.procedures`, so `ir_proc` is `None` for one — its entry
+        // facts (params, plus the class's instance variables) come from the
+        // `MethodDef` instead.  Without them the `[info exists]` fold read an
+        // instance variable as a never-defined local and called it always
+        // absent (issue #1129).
+        let method_ir = ir_module.methods.get(&function_unit.name);
+        let existence_frame = crate::sccp::ExistenceFrame {
+            params: ir_proc
+                .map(|p| p.params.as_slice())
+                .or_else(|| method_ir.map(|m| m.params.as_slice()))
+                .unwrap_or_default(),
+            object_state: method_ir.map(|m| &m.instance_vars),
+        };
         self.emit_dead_store_diagnostics(function_unit, &defined, &scope_aliases, cross_event_vars);
         self.emit_unused_variable_diagnostics(
             function_unit,
@@ -702,7 +716,7 @@ impl Analyser {
         // W210 on reads of a provably-no-match regexp / scan output var.
         self.emit_provably_unset_w210(function_unit, &considered, &defined);
         self.emit_constant_branch_diagnostics(function_unit);
-        self.emit_existence_constant_branch_diagnostics(function_unit, ir_proc);
+        self.emit_existence_constant_branch_diagnostics(function_unit, existence_frame);
         self.emit_invalid_ip_diagnostics(function_unit);
         self.emit_w233_divide_by_zero(function_unit);
         self.emit_interval_bounds_diagnostics(function_unit);

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -115,6 +115,106 @@ mod var_command;
 pub(in crate::analyser) mod version_gate;
 pub(in crate::analyser) mod widget_command;
 
+/// Which IR object owns the body the per-function dispatcher is running over.
+///
+/// Supplied by the caller: every diagnostic loop iterates exactly one of the
+/// compilation unit's body maps (`procedures`, `methods`, `body_units`) and
+/// therefore already knows the kind.  It must **not** be re-derived by
+/// probing those maps for the unit's qualified name, because a `TclOO` method
+/// and a namespace procedure may legitimately carry the same key.  Verified
+/// on tclsh 9.0.4 and 8.6.14 — `oo::class create C` does not create a
+/// namespace, so the procedure needs one made first, after which both exist
+/// as wholly separate entities:
+///
+/// ```tcl
+/// oo::class create C { variable x; constructor {} { set x 42 }
+///                      method m {p} { list method [info exists p] $p $x } }
+/// namespace eval ::C {}
+/// proc ::C::m {q} { list proc [info exists q] $q [info exists x] }
+/// [C new] m hello    ;# → method 1 hello 42
+/// ::C::m world       ;# → proc 1 world 0
+/// ```
+///
+/// A name probe would hand the method the procedure's parameters (so its own
+/// `[info exists p]` folds "always false") and hand the procedure the class's
+/// instance variables (so it abstains on names it fully owns).
+#[derive(Clone, Copy, Default)]
+pub enum BodyFrame<'a> {
+    /// The compilation unit's top level — no parameters, no object state.
+    #[default]
+    TopLevel,
+    /// A named procedure, an `apply` lambda body, or a `namespace eval` body:
+    /// a fresh frame whose bound-at-entry names are its formal parameters.
+    Procedure(&'a crate::ir::Procedure),
+    /// A `TclOO` method body: its own parameters *plus* the class's instance
+    /// variables, which the runtime links into the frame at entry.
+    Method(&'a crate::ir::MethodDef),
+}
+
+/// The two connection-scope name sets an iRule event handler inherits, as
+/// `(dead-store / unused suppression, read-before-set suppression)`.
+///
+/// The first is `cross_event_defs | cross_event_imports`: a variable another
+/// event on the same connection reads is not a dead store here.  The second is
+/// `cross_event_imports` alone: a variable another event *defines* (and the
+/// event registry's scope gate accepted the pair) is already set by the time
+/// this event reads it — `set g 1` in `HTTP_REQUEST` feeds `set x $g` in
+/// `HTTP_RESPONSE`, so that read is not read-before-set.
+///
+/// Both are empty for anything that is not a `::when::*` procedure, and for
+/// any unit with no connection scope at all.
+fn when_proc_cross_event_names(
+    cu: &crate::compilation_unit::CompilationUnit,
+    qname: &str,
+) -> (HashSet<String>, HashSet<String>) {
+    let Some(scope) = cu.connection_scope.as_ref().filter(|_| {
+        // `crate::ir::when_event_name`'s prefix — an iRule event handler.
+        qname.starts_with("::when::")
+    }) else {
+        return (HashSet::new(), HashSet::new());
+    };
+    (
+        scope
+            .cross_event_defs
+            .iter()
+            .chain(scope.cross_event_imports.iter())
+            .cloned()
+            .collect(),
+        scope.cross_event_imports.iter().cloned().collect(),
+    )
+}
+
+impl<'a> BodyFrame<'a> {
+    /// The [`crate::ir::Procedure`] backing this frame, or `None` when the
+    /// body is not a procedure-shaped one.  The parameter-specific emitters
+    /// (W214 unused-parameter, and the W210 read-before-set parameter
+    /// suppression) key off this.
+    #[must_use]
+    fn procedure(self) -> Option<&'a crate::ir::Procedure> {
+        match self {
+            Self::Procedure(p) => Some(p),
+            Self::TopLevel | Self::Method(_) => None,
+        }
+    }
+
+    /// The entry facts the `[info exists]` fold needs (issue #1129): the
+    /// frame's formal parameters, plus a method's instance variables.
+    #[must_use]
+    fn existence_frame(self) -> crate::sccp::ExistenceFrame<'a> {
+        match self {
+            Self::TopLevel => crate::sccp::ExistenceFrame::default(),
+            Self::Procedure(p) => crate::sccp::ExistenceFrame {
+                params: &p.params,
+                object_state: None,
+            },
+            Self::Method(m) => crate::sccp::ExistenceFrame {
+                params: &m.params,
+                object_state: Some(&m.instance_vars),
+            },
+        }
+    }
+}
+
 impl Analyser {
     /// Scope-tree-driven variable diagnostic emitter.
     ///
@@ -331,7 +431,7 @@ impl Analyser {
         // module through.
         self.emit_cfg_ssa_diagnostics_for_function_full(
             &cu.top_level,
-            &cu.ir_module,
+            BodyFrame::TopLevel,
             &top_level_known_defined,
             &top_level_cross_event_vars,
         );
@@ -342,21 +442,8 @@ impl Analyser {
             // ConnectionScope so dead-store / unused-variable
             // diagnostics suppress vars that may be read in a
             // different iRule event.
-            let mut cross_event_vars: HashSet<String> =
-                if let Some(scope) = cu.connection_scope.as_ref() {
-                    if qname.starts_with("::when::") {
-                        scope
-                            .cross_event_defs
-                            .iter()
-                            .chain(scope.cross_event_imports.iter())
-                            .cloned()
-                            .collect()
-                    } else {
-                        HashSet::new()
-                    }
-                } else {
-                    HashSet::new()
-                };
+            let (mut cross_event_vars, extra_known_defined) =
+                when_proc_cross_event_names(cu, qname);
             // Suppress dead-store on caller-locals this
             // proc passes by name to an upvar callee.
             cross_event_vars.extend(crate::interprocedural::collect_call_by_name_reads(
@@ -364,27 +451,12 @@ impl Analyser {
                 &cbn_proc_index,
             ));
             cross_event_vars.extend(traced_globals.iter().cloned());
-            // Consumer-side cross-event suppression for W210: a variable
-            // another event on the same connection defines (and the event
-            // registry's scope gate accepted the pair) is set by the time
-            // this event reads it — `set g 1` in HTTP_REQUEST feeds
-            // `set x $g` in HTTP_RESPONSE, so the read is not
-            // read-before-set. `cross_event_imports` is exactly that set;
-            // without threading it here the RBS pass saw only an empty
-            // `extra_known_defined` and flagged every such read.
-            let extra_known_defined: HashSet<String> =
-                if let Some(scope) = cu.connection_scope.as_ref() {
-                    if qname.starts_with("::when::") {
-                        scope.cross_event_imports.iter().cloned().collect()
-                    } else {
-                        HashSet::new()
-                    }
-                } else {
-                    HashSet::new()
-                };
             self.emit_cfg_ssa_diagnostics_for_function_full(
                 fu,
-                &cu.ir_module,
+                cu.ir_module
+                    .procedures
+                    .get(qname)
+                    .map_or(BodyFrame::TopLevel, BodyFrame::Procedure),
                 &extra_known_defined,
                 &cross_event_vars,
             );
@@ -493,7 +565,7 @@ impl Analyser {
             cross_event_vars.extend(traced_globals.iter().cloned());
             self.emit_cfg_ssa_diagnostics_for_function_full(
                 fu,
-                &cu.ir_module,
+                method_ir.map_or(BodyFrame::TopLevel, BodyFrame::Method),
                 &known_bound,
                 &cross_event_vars,
             );
@@ -555,7 +627,7 @@ impl Analyser {
             cross_event_vars.extend(traced_globals.iter().cloned());
             self.emit_cfg_ssa_diagnostics_for_function_full(
                 fu,
-                &cu.ir_module,
+                BodyFrame::Procedure(ir_proc),
                 &known_bound,
                 &cross_event_vars,
             );
@@ -571,11 +643,11 @@ impl Analyser {
     pub fn emit_cfg_ssa_diagnostics_for_function(
         &mut self,
         function_unit: &crate::compilation_unit::FunctionUnit,
-        ir_module: &crate::ir::Module,
+        frame: BodyFrame<'_>,
     ) {
         self.emit_cfg_ssa_diagnostics_for_function_full(
             function_unit,
-            ir_module,
+            frame,
             &HashSet::new(),
             &HashSet::new(),
         );
@@ -593,12 +665,12 @@ impl Analyser {
     pub fn emit_cfg_ssa_diagnostics_for_function_with_extra(
         &mut self,
         function_unit: &crate::compilation_unit::FunctionUnit,
-        ir_module: &crate::ir::Module,
+        frame: BodyFrame<'_>,
         extra_known_defined: &HashSet<String>,
     ) {
         self.emit_cfg_ssa_diagnostics_for_function_full(
             function_unit,
-            ir_module,
+            frame,
             extra_known_defined,
             &HashSet::new(),
         );
@@ -618,7 +690,7 @@ impl Analyser {
     pub fn emit_cfg_ssa_diagnostics_for_function_full(
         &mut self,
         function_unit: &crate::compilation_unit::FunctionUnit,
-        ir_module: &crate::ir::Module,
+        frame: BodyFrame<'_>,
         extra_known_defined: &HashSet<String>,
         cross_event_vars: &HashSet<String>,
     ) {
@@ -652,21 +724,14 @@ impl Analyser {
                 registry,
             ));
         }
-        let ir_proc = ir_module.procedures.get(&function_unit.name);
-        // A `TclOO` method body is in `ir_module.methods`, never
-        // `ir_module.procedures`, so `ir_proc` is `None` for one — its entry
-        // facts (params, plus the class's instance variables) come from the
-        // `MethodDef` instead.  Without them the `[info exists]` fold read an
-        // instance variable as a never-defined local and called it always
-        // absent (issue #1129).
-        let method_ir = ir_module.methods.get(&function_unit.name);
-        let existence_frame = crate::sccp::ExistenceFrame {
-            params: ir_proc
-                .map(|p| p.params.as_slice())
-                .or_else(|| method_ir.map(|m| m.params.as_slice()))
-                .unwrap_or_default(),
-            object_state: method_ir.map(|m| &m.instance_vars),
-        };
+        // Frame identity comes from the caller, which knows which of the
+        // compilation unit's body maps it is iterating.  It must not be
+        // re-derived by probing those maps for `function_unit.name`: a
+        // `TclOO` method and a namespace procedure may legitimately share a
+        // qualified name, so the name alone cannot tell them apart (see
+        // [`BodyFrame`]).
+        let ir_proc = frame.procedure();
+        let existence_frame = frame.existence_frame();
         self.emit_dead_store_diagnostics(function_unit, &defined, &scope_aliases, cross_event_vars);
         self.emit_unused_variable_diagnostics(
             function_unit,

--- a/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
@@ -1783,28 +1783,31 @@ file; this call falls through to the 'unknown' handler."
     /// SCCP can't fold these (the predicate lowers to an
     /// opaque `ExprNode::Command`, and SCCP has no parameter/existence
     /// facts), so the fold is computed by
-    /// [`crate::sccp::existence_constant_branches`] using
-    /// `ir_proc.params` — the same helper whose result
+    /// [`crate::sccp::existence_constant_branches`] using the frame's formal
+    /// parameters — the same helper whose result
     /// `FunctionUnit::build` appends to `sccp.constant_branches` for the
     /// optimiser's O101 fold / DCE.  Emitting the I230 here (rather than
     /// via [`Self::emit_constant_branch_diagnostics`]) is deliberate:
     /// that emitter gates on the not-taken arm being unreachable in
     /// `executable_blocks`, which these post-pass folds don't update, so
     /// it skips them and there is no double emission.
+    ///
+    /// `frame` supplies the typed entry facts for whichever kind of body
+    /// this is (issue #1129): a procedure contributes its parameters, a
+    /// `TclOO` method body contributes its parameters **and** its class's
+    /// instance variables, on which the fold must abstain.  Both halves come
+    /// from the same IR the optimiser's copy of the fold reads, so the two
+    /// consumers cannot drift.
     pub(super) fn emit_existence_constant_branch_diagnostics(
         &mut self,
         fu: &crate::compilation_unit::FunctionUnit,
-        ir_proc: Option<&crate::ir::Procedure>,
+        frame: crate::sccp::ExistenceFrame<'_>,
     ) {
         // The fold consults the registry's scope-alias roles to skip
         // out-of-frame-linked locals; a registry-less analyser falls back to
         // the cached default registry (the same convention as
         // `command_takes_regex_pattern` — direct handler calls in unit
         // tests), so the alias skip stays sound there too.
-        let params: HashSet<&str> = match ir_proc {
-            Some(p) => p.params.iter().map(String::as_str).collect(),
-            None => HashSet::new(),
-        };
         let branches = {
             // Scoped borrow: `self.registry` must release before the
             // `&mut self` diagnostic pushes below.
@@ -1812,7 +1815,7 @@ file; this call falls through to the 'unknown' handler."
                 || tcl_registry::cache::registry_for_dialect("tcl8.6"),
                 |r| r,
             );
-            crate::sccp::existence_constant_branches(&fu.cfg, &params, registry, fu.dynamic_names)
+            crate::sccp::existence_constant_branches(&fu.cfg, frame, registry, fu.dynamic_names)
         };
         for cb in branches {
             let Some(span) = cb.span.map(|s| fu.abs_span(s)) else {

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -5578,6 +5578,138 @@ fn info_exists_fold_survives_unrelated_scope_alias() {
     );
 }
 
+// `info exists` over TclOO instance state (issue #1129)
+//
+// Oracle, tclsh 9.0.4 (TclOO 1.3.1) and tclsh 8.6.14 (TclOO 1.1.0), identical
+// on both:
+//
+// ```tcl
+// oo::class create C { variable x; constructor {} { set x 1 }
+//                      method m {} { puts [info exists x] } }
+// [C new] m                                            ;# → 1
+// oo::class create D { variable x
+//                      method m {} { puts [info exists x] } }
+// [D new] m                                            ;# → 0
+// oo::class create F { variable x; method setit {} { set x 42 }
+//                      method m {} { puts [info exists x] } }
+// set f [F new]; $f m ;# → 0     $f setit; $f m        ;# → 1
+// oo::class create G { variable a; constructor {} { set b 7 } }
+// oo::define G { variable b; method m {} {
+//     puts [list a [info exists a] b [info exists b]] } }
+// [G new] m                                            ;# → a 0 b 1
+// ```
+//
+// So a class-level `variable` declaration does *not* create the variable —
+// but any earlier method call on the same instance may have, which is a
+// per-instance runtime fact no per-method fold can decide.  Abstain.
+
+#[test]
+fn info_exists_does_not_fold_instance_var_assigned_in_constructor() {
+    // FP guard — `[C new] m` prints 1 on both runtimes, but the fold saw no
+    // assignment to `x` inside `m`'s own body and called the guard always
+    // false.
+    let codes = codes_for(
+        "oo::class create C {\n variable x\n constructor {} { set x 1 }\n \
+         method m {} { if {[info exists x]} { puts hi } }\n}\n",
+    );
+    assert!(
+        !codes.contains(&"I230".to_string()),
+        "an instance variable assigned in the constructor must not fold; got {codes:?}",
+    );
+}
+
+#[test]
+fn info_exists_does_not_fold_instance_var_assigned_in_sibling_method() {
+    // FP guard — existence depends on call order on the instance
+    // (`$f m` → 0 before `$f setit`, → 1 after), so neither direction folds.
+    let codes = codes_for(
+        "oo::class create F {\n variable x\n method setit {} { set x 42 }\n \
+         method m {} { if {[info exists x]} { puts hi } }\n}\n",
+    );
+    assert!(
+        !codes.contains(&"I230".to_string()),
+        "an instance variable a sibling method assigns must not fold; got {codes:?}",
+    );
+}
+
+#[test]
+fn info_exists_does_not_fold_instance_var_declared_in_later_define_block() {
+    // FP guard, cross-definition-block shape (#1131): `variable b` is declared
+    // by an `oo::define` block that lowering may walk *after* the method that
+    // queries it.  `MethodDef::instance_vars` is the per-class union precisely
+    // so this is order-free — the fold must abstain either way.
+    let codes = codes_for(
+        "oo::class create G {\n variable a\n constructor {} { set b 7 }\n}\n\
+         oo::define G {\n variable b\n \
+         method m {} { if {[info exists b]} { puts hi } }\n}\n",
+    );
+    assert!(
+        !codes.contains(&"I230".to_string()),
+        "an instance variable declared in a later oo::define block must not fold; got {codes:?}",
+    );
+}
+
+#[test]
+fn info_exists_does_not_fold_my_variable_local_in_method() {
+    // FP guard — `my variable x` binds the object's variable into the method
+    // frame; existence is the object's, not the frame's.  Already covered by
+    // the registry-driven scope-alias skip (`my variable` resolves through the
+    // spec's own `ArgRole::VarWrite` resolver), pinned here so the TclOO
+    // shape cannot regress with the rest of #1129.
+    let codes = codes_for(
+        "oo::class create E {\n method m {} { my variable x\n \
+         if {[info exists x]} { puts hi } }\n}\n",
+    );
+    assert!(
+        !codes.contains(&"I230".to_string()),
+        "a `my variable` local must not fold; got {codes:?}",
+    );
+}
+
+#[test]
+fn info_exists_still_folds_never_set_non_instance_local_in_method() {
+    // TP guard — the abstention is name-scoped, not a blanket "no folds in
+    // method bodies": `zzz` is neither instance state nor a parameter nor ever
+    // assigned, so it still folds false exactly as it would inside a proc.
+    let codes = codes_for(
+        "oo::class create C {\n variable x\n constructor {} { set x 1 }\n \
+         method m {} { if {[info exists zzz]} { puts hi } }\n}\n",
+    );
+    assert!(
+        codes.contains(&"I230".to_string()),
+        "a never-set non-instance local in a method body must still fold; got {codes:?}",
+    );
+}
+
+#[test]
+fn info_exists_folds_true_not_false_for_method_parameter() {
+    // The second false-positive shape of #1129, found while building the
+    // fix: the analyser looked a body's parameters up in
+    // `ir_module.procedures`, which a *method*'s qualified name is never in
+    // (methods live in `ir_module.methods`), so every method parameter read
+    // as a never-defined local and the guard folded **always false** —
+    // `[C new] m x` runs the `then` arm on both tclsh 9.0.4 and 8.6.14.
+    // The optimiser's copy of the fold never had this bug
+    // (`build_method_units` always passed `MethodDef::params`), so the two
+    // consumers disagreed; both now read the same `MethodDef`.
+    let mut a = Analyser::new();
+    a.emit_cfg_ssa_diagnostics(
+        "oo::class create C {\n method m {p} { if {[info exists p]} { puts hi } }\n}\n",
+    );
+    let i230: Vec<&str> = a
+        .result
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == DiagCode::I230)
+        .map(|d| d.message.as_str())
+        .collect();
+    assert_eq!(i230.len(), 1, "a method parameter must fold; got {i230:?}");
+    assert!(
+        i230[0].contains("always true"),
+        "a method parameter exists at entry — the fold must be true, got {i230:?}",
+    );
+}
+
 #[test]
 fn analyse_w307_suppressed_for_known_class_constructor_chain() {
     // ``[Dog new] bark`` — ``Dog`` is a user class so

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -5710,6 +5710,141 @@ fn info_exists_folds_true_not_false_for_method_parameter() {
     );
 }
 
+/// Every I230 message emitted for `src`, in emission order.
+fn i230_messages(src: &str) -> Vec<String> {
+    let mut a = Analyser::new();
+    a.emit_cfg_ssa_diagnostics(src);
+    a.result
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == DiagCode::I230)
+        .map(|d| d.message.clone())
+        .collect()
+}
+
+#[test]
+fn info_exists_folds_true_for_method_parameter_shadowing_an_instance_var() {
+    // Codex P2 on PR #1175, finding A — confirmed against the oracle.  A
+    // formal parameter whose name collides with a class-level `variable`
+    // declaration **shadows** it outright: the name is an ordinary local that
+    // always exists, and writes through it never reach object state.  So the
+    // instance-variable abstention must not swallow it.
+    //
+    // tclsh 9.0.4 (TclOO 1.3.1) and 8.6.14 (TclOO 1.1.0), identical:
+    //
+    //   oo::class create A1 { variable x; constructor {} { set x 42 }
+    //                         method m {x} { set r [list [info exists x] $x]
+    //                                        set x 9; return $r }
+    //                         method peek {} { list [info exists x] $x } }
+    //   set a [A1 new]; $a m hello  ;# → exists 1 value hello
+    //   $a peek                     ;# → exists 1 value 42   (`set x 9` did
+    //                                                         not reach it)
+    //
+    // and with the instance variable never assigned, the parameter still
+    // binds (`A2 in-method: exists 1 value hello`, `A2 after m: 0`).
+    let msgs = i230_messages(
+        "oo::class create A {\n variable x\n constructor {} { set x 42 }\n \
+         method m {x} { if {[info exists x]} { puts hi } }\n}\n",
+    );
+    assert_eq!(
+        msgs.len(),
+        1,
+        "the shadowing parameter must still fold; got {msgs:?}",
+    );
+    assert!(
+        msgs[0].contains("always true"),
+        "a parameter shadowing an instance variable always exists — the fold \
+         must be true, got {msgs:?}",
+    );
+}
+
+#[test]
+fn info_exists_still_abstains_on_the_non_shadowed_instance_vars() {
+    // Companion control for the shadowing case: shadowing is per-name.  `x`
+    // is shadowed by the parameter and folds; the sibling instance variable
+    // `y`, which nothing in this method binds, must keep abstaining.
+    let msgs = i230_messages(
+        "oo::class create A {\n variable x y\n constructor {} { set x 42 }\n \
+         method m {x} {\n if {[info exists x]} { puts hi }\n \
+         if {[info exists y]} { puts ho }\n }\n}\n",
+    );
+    assert_eq!(
+        msgs.len(),
+        1,
+        "only the shadowed name may fold; got {msgs:?}",
+    );
+    assert!(msgs[0].contains("always true"), "got {msgs:?}");
+}
+
+#[test]
+fn info_exists_frame_facts_survive_a_proc_method_qname_collision() {
+    // Codex P2 on PR #1175, finding B — confirmed against the oracle.  A
+    // `TclOO` method and a namespace procedure can carry the same qualified
+    // name, so the per-function dispatcher must take its frame identity from
+    // the caller (which knows the map it is walking) rather than probing
+    // `ir_module.procedures` / `.methods` by name.
+    //
+    // tclsh 9.0.4 and 8.6.14, identical — note `oo::class create C` does not
+    // create namespace `::C`, so the procedure needs `namespace eval` first:
+    //
+    //   oo::class create C { variable x; constructor {} { set x 42 }
+    //                        method m {p} { list method [info exists p] $p $x } }
+    //   namespace eval ::C {}
+    //   proc ::C::m {q} { list proc [info exists q] $q [info exists x] }
+    //   [C new] m hello   ;# → method 1 hello 42
+    //   ::C::m world      ;# → proc 1 world 0
+    //
+    // Both frames are wholly separate: the procedure sees none of the class's
+    // instance state. Pre-fix the name probe gave the *method* the
+    // procedure's parameter list (so its own `[info exists p]` folded "always
+    // false") and gave the *procedure* the class's instance variables (so it
+    // abstained on `x`, a name it fully owns as a never-set local).
+    let msgs = i230_messages(
+        "oo::class create C {\n variable x\n constructor {} { set x 42 }\n \
+         method m {p} { if {[info exists p]} { puts inmethod } }\n}\n\
+         namespace eval ::C {}\n\
+         proc ::C::m {q} {\n if {[info exists q]} { puts inproc }\n \
+         if {[info exists x]} { puts nope }\n}\n",
+    );
+    // Method: `p` is its own parameter → always true.
+    // Proc: `q` is its own parameter → always true; `x` is a never-set local
+    // of the *procedure* (the class's instance state is not in scope there)
+    // → always false.
+    assert_eq!(
+        msgs.len(),
+        3,
+        "each frame must fold its own three guards; got {msgs:?}",
+    );
+    assert_eq!(
+        msgs.iter().filter(|m| m.contains("always true")).count(),
+        2,
+        "both parameter guards must fold true; got {msgs:?}",
+    );
+    assert_eq!(
+        msgs.iter().filter(|m| m.contains("always false")).count(),
+        1,
+        "the procedure's never-set `x` must fold false — it is not object \
+         state in a procedure frame; got {msgs:?}",
+    );
+}
+
+#[test]
+fn info_exists_folds_true_for_an_apply_lambda_parameter() {
+    // Follow-on from finding B's remedy: the lambda loop now hands the
+    // dispatcher the body unit's own `Procedure` rather than letting it probe
+    // `ir_module.procedures` for a key that map never holds, so a lambda's
+    // parameters reach the fold like a proc's.  A lambda is an anonymous
+    // procedure with a fresh frame whose bound names are exactly its
+    // parameter list — tclsh 9.0.4 / 8.6.14: `apply {{a} {info exists a}} 1`
+    // → 1.
+    let msgs = i230_messages("apply {{a} { if {[info exists a]} { puts hi } }} 1\n");
+    assert_eq!(msgs.len(), 1, "a lambda parameter must fold; got {msgs:?}");
+    assert!(
+        msgs[0].contains("always true"),
+        "a lambda parameter exists at entry, got {msgs:?}",
+    );
+}
+
 #[test]
 fn analyse_w307_suppressed_for_known_class_constructor_chain() {
     // ``[Dog new] bark`` — ``Dog`` is a user class so

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -288,6 +288,11 @@ struct FunctionBuildInputs<'a> {
     extra_global_escaping: &'a HashSet<String>,
     /// Whole-module variable-trace facts.
     trace_facts: ModuleTraceFacts<'a>,
+    /// Names auto-bound to out-of-frame *object* storage on entry — a
+    /// `TclOO` method body's [`crate::ir::MethodDef::instance_vars`].  `None`
+    /// for procs, lambdas, and the top level, none of which have any.  The
+    /// `[info exists]` fold must abstain on these (issue #1129).
+    object_state: Option<&'a HashSet<String>>,
 }
 
 impl ModuleTraceFacts<'_> {
@@ -393,6 +398,69 @@ impl FunctionUnit {
                 known_classes,
                 extra_global_escaping: &no_extra_escaping,
                 trace_facts,
+                object_state: None,
+            },
+        )
+    }
+
+    /// Build the compilation unit's **top-level** body unit — no parameters,
+    /// no interprocedural seeds, no object state, but a non-empty
+    /// `extra_global_escaping` (top-level names already live in the global
+    /// frame, so another procedure's `global NAME` can reassign them; see
+    /// [`crate::sccp::sccp_with_extra_escaping`]).
+    #[must_use]
+    pub fn build_top_level(
+        cfg: CfgFunction,
+        registry: &CommandRegistry,
+        known_classes: &HashSet<String>,
+        extra_global_escaping: &HashSet<String>,
+        trace_facts: ModuleTraceFacts<'_>,
+    ) -> Self {
+        Self::build_full(
+            "::top",
+            cfg,
+            FunctionBuildInputs {
+                params: &[],
+                registry,
+                param_constants: None,
+                known_classes,
+                extra_global_escaping,
+                trace_facts,
+                object_state: None,
+            },
+        )
+    }
+
+    /// Build a **`TclOO` method body**'s unit from its typed
+    /// [`crate::ir::MethodDef`], so the analyses see the method's own params
+    /// *and* the class's instance variables (the cross-definition-block union
+    /// lowering computes — see [`crate::ir::MethodDef::instance_vars`]).
+    ///
+    /// Only the existence fold consumes the instance-variable half today: a
+    /// class-level `variable x` binds `x` in every method frame with no
+    /// binding command in the body, so without it `[info exists x]` folded to
+    /// "always absent" (issue #1129).
+    #[must_use]
+    pub fn build_for_method(
+        name: impl Into<String>,
+        cfg: CfgFunction,
+        method: &crate::ir::MethodDef,
+        registry: &CommandRegistry,
+        known_classes: &HashSet<String>,
+        trace_facts: ModuleTraceFacts<'_>,
+    ) -> Self {
+        let no_extra_escaping = HashSet::new();
+        Self::build_full(
+            name,
+            cfg,
+            FunctionBuildInputs {
+                params: &method.params,
+                registry,
+                param_constants: None,
+                known_classes,
+                extra_global_escaping: &no_extra_escaping,
+                trace_facts,
+                object_state: Some(&method.instance_vars),
             },
         )
     }
@@ -421,6 +489,7 @@ impl FunctionUnit {
             known_classes,
             extra_global_escaping,
             trace_facts,
+            object_state,
         } = inputs;
         // Complexity guard (block-count half): a pathologically large body
         // would cost seconds of SSA + dataflow for near-zero findings, so skip
@@ -459,9 +528,10 @@ impl FunctionUnit {
         // as constant branches so the optimiser's O101 fold / DCE sees
         // them. The analyser's I230 uses the same fold via
         // `existence_constant_branches`; the SCCP pass proper has no
-        // parameter/existence facts to fold them itself.
-        let param_set: std::collections::HashSet<&str> =
-            params.iter().map(String::as_str).collect();
+        // parameter/existence facts to fold them itself.  A method body's
+        // instance variables are handed over too, so the fold abstains on
+        // object state instead of calling it absent (issue #1129).
+        //
         // Dynamic-name facts (issue #923 audit cluster C10): a `set $var v`
         // means any name may be defined, an `unset $n` that any name may have
         // stopped existing — so the existence fold must abstain in that
@@ -470,7 +540,10 @@ impl FunctionUnit {
         sccp.constant_branches
             .extend(crate::sccp::existence_constant_branches(
                 &cfg,
-                &param_set,
+                crate::sccp::ExistenceFrame {
+                    params,
+                    object_state,
+                },
                 registry,
                 dynamic_names,
             ));
@@ -1140,17 +1213,12 @@ impl CompilationUnit {
             traced_variables: &ir_module.traced_variables,
             has_dynamic_variable_trace: ir_module.has_dynamic_variable_trace,
         };
-        let top_level = FunctionUnit::build_full(
-            "::top",
+        let top_level = FunctionUnit::build_top_level(
             cfg_module.top_level.clone(),
-            FunctionBuildInputs {
-                params: &[],
-                registry,
-                param_constants: None,
-                known_classes: &known_class_set,
-                extra_global_escaping: &top_level_extra_escaping,
-                trace_facts,
-            },
+            registry,
+            &known_class_set,
+            &top_level_extra_escaping,
+            trace_facts,
         );
         let built = build_procedure_units(
             &ProcedureBuildContext {
@@ -1258,12 +1326,11 @@ impl CompilationUnit {
                 let fu = if body_bytes > crate::ssa::DEEP_ANALYSIS_BODY_BYTES {
                     FunctionUnit::trivial_guarded(mqname, cfg)
                 } else {
-                    FunctionUnit::build_with_param_constants_and_classes(
+                    FunctionUnit::build_for_method(
                         mqname,
                         cfg,
-                        &method.params,
+                        method,
                         registry,
-                        None,
                         known_class_set,
                         trace_facts,
                     )

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -835,6 +835,46 @@ fn collect_constant_branches(
     constant_branches
 }
 
+/// Every variable name the function assigns, and every name it `unset`s by
+/// literal — the two whole-body facts [`existence_constant_branches`] folds
+/// against.  A `Call`'s `defs` cover the commands that define a name without
+/// an assignment statement (`global` / `variable` / `upvar`, `regexp -inline`
+/// match vars, …).
+fn scan_defined_and_unset(cfg: &CfgFunction) -> (FxHashSet<String>, FxHashSet<&str>) {
+    let mut defined: FxHashSet<String> = FxHashSet::default();
+    let mut unset: FxHashSet<&str> = FxHashSet::default();
+    for block in cfg.blocks.values() {
+        for stmt in &block.statements {
+            match stmt {
+                Statement::AssignConst { name, .. }
+                | Statement::AssignExpr { name, .. }
+                | Statement::AssignValue { name, .. }
+                | Statement::Incr { name, .. } => {
+                    let n = crate::naming::normalise_var_name(name);
+                    if !n.is_empty() {
+                        defined.insert(n.to_string());
+                    }
+                }
+                Statement::Call {
+                    command,
+                    args,
+                    defs,
+                    ..
+                } => {
+                    for d in defs {
+                        defined.insert(d.clone());
+                    }
+                    if command == "unset" {
+                        unset.extend(args.iter().map(String::as_str));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    (defined, unset)
+}
+
 /// The entry facts one function frame contributes to the existence fold
 /// ([`existence_constant_branches`]), sourced from the typed IR for whichever
 /// kind of body it is — a [`crate::ir::Procedure`], a
@@ -909,6 +949,23 @@ pub struct ExistenceFrame<'a> {
 /// The declaration alone does not create the variable, but *any earlier call
 /// on the same instance* may have — a dynamic fact no per-method analysis can
 /// decide, so these names join `aliased` and never fold either way.
+///
+/// A method parameter that *collides* with an instance-variable name is the
+/// exception, and still folds `true`: the parameter shadows the class-level
+/// declaration completely, and writes through it never reach object state
+/// (again identical on 9.0.4 and 8.6.14).
+///
+/// ```tcl
+/// oo::class create A { variable x; constructor {} { set x 42 }
+///                      method m {x} { set r [info exists x]; set x 9; return $r }
+///                      method peek {} { return $x } }
+/// set a [A new]; $a m hello   ;# → 1
+/// $a peek                     ;# → 42, untouched by the method's `set x 9`
+/// ```
+///
+/// This also holds for a *defaulted* parameter called with no argument
+/// (`method m {{x def}} …` → `info exists x` is 1 and `$x` is `def`), and
+/// when the instance variable was never assigned at all.
 #[must_use]
 pub fn existence_constant_branches(
     cfg: &CfgFunction,
@@ -924,38 +981,7 @@ pub fn existence_constant_branches(
     }) {
         return out;
     }
-    // Vars defined / unset anywhere in the function.
-    let mut defined: FxHashSet<String> = FxHashSet::default();
-    let mut unset: FxHashSet<&str> = FxHashSet::default();
-    for block in cfg.blocks.values() {
-        for stmt in &block.statements {
-            match stmt {
-                Statement::AssignConst { name, .. }
-                | Statement::AssignExpr { name, .. }
-                | Statement::AssignValue { name, .. }
-                | Statement::Incr { name, .. } => {
-                    let n = crate::naming::normalise_var_name(name);
-                    if !n.is_empty() {
-                        defined.insert(n.to_string());
-                    }
-                }
-                Statement::Call {
-                    command,
-                    args,
-                    defs,
-                    ..
-                } => {
-                    for d in defs {
-                        defined.insert(d.clone());
-                    }
-                    if command == "unset" {
-                        unset.extend(args.iter().map(String::as_str));
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
+    let (defined, unset) = scan_defined_and_unset(cfg);
     // Locals bound to out-of-frame storage (`global` / `variable` / `upvar` /
     // `namespace upvar`): whether such a name exists depends on the *linked*
     // variable, which this function cannot see, so its existence query must
@@ -971,8 +997,35 @@ pub fn existence_constant_branches(
     // Object state is aliased the same way, minus a visible binding command:
     // `TclOO` links every class-level `variable` declaration into each method
     // frame at entry, so the body's own command scan cannot see it (#1129).
+    //
+    // A formal parameter of the same name is the one exception: it shadows the
+    // class-level declaration outright, so the name is an ordinary local that
+    // always exists and must keep folding `true`.  tclsh 9.0.4 / 8.6.14 agree
+    // — the parameter wins completely, and writes to it do **not** reach
+    // object state:
+    //
+    //   oo::class create A { variable x; constructor {} { set x 42 }
+    //                        method m {x} { set r [info exists x]  ;# → 1
+    //                                       set x 9; return $r }
+    //                        method peek {} { return $x } }
+    //   set a [A new]; $a m hello   ;# → 1  ($x inside m is "hello")
+    //   $a peek                     ;# → 42, unchanged by `set x 9`
+    //
+    // Only the *object-state* half yields to parameters.  The
+    // command-derived aliases keep full precedence: an explicit `global` /
+    // `variable` / `upvar` / `namespace upvar` / `my variable` on a name that
+    // is already a parameter is a runtime error on both runtimes (`variable
+    // "x" already exists`), so it never legally co-occurs, while a variable
+    // *trace* on a parameter does — and a trace callback can unset its own
+    // target, which is exactly why `scan_scope_aliases` includes trace
+    // targets and why they must go on abstaining.
     if let Some(instance_vars) = frame.object_state {
-        aliased.extend(instance_vars.iter().cloned());
+        aliased.extend(
+            instance_vars
+                .iter()
+                .filter(|name| !frame.params.iter().any(|p| p == *name))
+                .cloned(),
+        );
     }
     for block in cfg.blocks.values() {
         let Some(Terminator::Branch {

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -835,6 +835,26 @@ fn collect_constant_branches(
     constant_branches
 }
 
+/// The entry facts one function frame contributes to the existence fold
+/// ([`existence_constant_branches`]), sourced from the typed IR for whichever
+/// kind of body it is — a [`crate::ir::Procedure`], a
+/// [`crate::ir::MethodDef`], or neither (the top level, a lambda).
+///
+/// Bundled rather than passed positionally so a new fact reaches both
+/// consumers of the fold — the analyser's I230 and the optimiser's O101 — by
+/// construction: the two build the same struct from the same IR, so they
+/// cannot drift (they did, on method parameters — issue #1129).
+#[derive(Clone, Copy, Default)]
+pub struct ExistenceFrame<'a> {
+    /// The body's formal parameter names: bound on entry, so they exist.
+    /// Empty for the top level and for any body with no parameter list.
+    pub params: &'a [String],
+    /// Names auto-bound to out-of-frame *object* storage on entry — a
+    /// `TclOO` method body's [`crate::ir::MethodDef::instance_vars`].
+    /// `None` for every body kind that has none.
+    pub object_state: Option<&'a HashSet<String>>,
+}
+
 /// Fold `[info exists X]` / `[array exists X]`
 /// if-conditions into [`ConstantBranch`] entries for the two
 /// false-positive-free cases — a parameter always exists (`true`); a
@@ -843,7 +863,7 @@ fn collect_constant_branches(
 ///
 /// SCCP itself can't fold these (the predicate is an opaque
 /// `ExprNode::Command`, and SCCP has neither parameter nor existence
-/// facts), so this runs as a post-pass with the proc's `params`.  The
+/// facts), so this runs as a post-pass with the frame's own facts.  The
 /// result feeds both the analyser's I230 (constant condition) and the
 /// optimiser's O101 (constant-branch fold / DCE).  Only simple local
 /// names are folded, and only in functions free of opaque barriers (an
@@ -863,10 +883,36 @@ fn collect_constant_branches(
 ///
 /// Both abstain by declining the fold, which silences I230 and leaves O101
 /// with nothing to fold — say less rather than say something wrong.
+///
+/// [`ExistenceFrame::object_state`] carries the frame's *auto-bound*
+/// out-of-frame names — a `TclOO` method body's
+/// [`crate::ir::MethodDef::instance_vars`] (issue
+/// #1129).  A class-level `variable x` declaration binds `x` in **every**
+/// method's frame with no `variable` statement in the body itself, so
+/// [`crate::optimiser::elimination::scan_scope_aliases`] (which only sees the
+/// body's own commands) cannot find it — the name looks like a never-defined
+/// local and the fold used to call it "always absent".  It is not: existence
+/// is per-instance runtime state, set by whichever method or constructor
+/// assigned it first.  tclsh 9.0.4 and 8.6.14 agree:
+///
+/// ```tcl
+/// oo::class create C { variable x; constructor {} { set x 1 }
+///                      method m {} { info exists x } }   ;# [C new] m → 1
+/// oo::class create D { variable x
+///                      method m {} { info exists x } }   ;# [D new] m → 0
+/// oo::class create F { variable x; method setit {} { set x 42 }
+///                      method m {} { info exists x } }
+/// set f [F new]; $f m   ;# → 0
+/// $f setit; $f m        ;# → 1
+/// ```
+///
+/// The declaration alone does not create the variable, but *any earlier call
+/// on the same instance* may have — a dynamic fact no per-method analysis can
+/// decide, so these names join `aliased` and never fold either way.
 #[must_use]
-pub fn existence_constant_branches<S: std::hash::BuildHasher>(
+pub fn existence_constant_branches(
     cfg: &CfgFunction,
-    params: &HashSet<&str, S>,
+    frame: ExistenceFrame<'_>,
     registry: &tcl_registry::CommandRegistry,
     dynamic_names: crate::dynamic_names::DynamicNameBarrier,
 ) -> Vec<ConstantBranch> {
@@ -921,7 +967,13 @@ pub fn existence_constant_branches<S: std::hash::BuildHasher>(
     // `::safe::CheckInterp` guard shape (safe.tcl:109).  The scanner also
     // returns `trace` targets, which only widens the skip — conservative,
     // never a false fold.
-    let aliased = crate::optimiser::elimination::scan_scope_aliases(cfg, registry);
+    let mut aliased = crate::optimiser::elimination::scan_scope_aliases(cfg, registry);
+    // Object state is aliased the same way, minus a visible binding command:
+    // `TclOO` links every class-level `variable` declaration into each method
+    // frame at entry, so the body's own command scan cannot see it (#1129).
+    if let Some(instance_vars) = frame.object_state {
+        aliased.extend(instance_vars.iter().cloned());
+    }
     for block in cfg.blocks.values() {
         let Some(Terminator::Branch {
             condition,
@@ -946,7 +998,7 @@ pub fn existence_constant_branches<S: std::hash::BuildHasher>(
         if aliased.contains(var.as_str()) {
             continue;
         }
-        let exists = if params.contains(var.as_str()) {
+        let exists = if frame.params.iter().any(|p| p == &var) {
             // A literal `unset x` already blocks this; a computed
             // `unset $n` can name the parameter just as well
             // (tclsh 9.0.4 / 8.6.14: `proc f {p n} {unset $n; info exists p}`

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -3626,6 +3626,65 @@ mod tests {
         assert_eq!(got.optimisations, want.optimisations);
     }
 
+    /// Issue #1129 — `[info exists x]` where `x` is `TclOO` instance state
+    /// must not fold on **either** compiler-check path.
+    ///
+    /// A class-level `variable x` binds `x` in every method frame with no
+    /// binding command in the body, so the existence fold saw a
+    /// never-defined local and produced an "always false" constant branch —
+    /// an `O100` hint (and its `I230` twin) on code that runs.  Oracle,
+    /// identical on tclsh 9.0.4 and 8.6.14: `oo::class create C { variable x;
+    /// constructor {} { set x 1 }; method m {} { puts [info exists x] } }`
+    /// then `[C new] m` → `1`.
+    ///
+    /// The 17 corpus false positives were identical on the memoised and the
+    /// cold path (a fold-logic bug, not a memoisation one), so this pins both
+    /// halves: the instance-variable guard yields no `O100` anywhere, a
+    /// non-instance local in the same body still does, and the two paths
+    /// agree byte-for-byte.
+    #[test]
+    fn instance_variable_existence_guard_does_not_fold_on_either_check_path() {
+        let dialect = "tcl8.6";
+        let src = "oo::class create C {\n\
+                       variable x\n\
+                       constructor {} { set x 1 }\n\
+                       method m {} {\n\
+                           if {[info exists x]} { puts got }\n\
+                           if {[info exists zzz]} { puts never }\n\
+                       }\n\
+                   }\n";
+
+        let db = TclDatabase::default();
+        let file = SourceFile::new(&db, src.to_owned(), dialect.to_owned(), None);
+        let got = compiler_check_diagnostics(&db, file, cfg(&db));
+        let registry = db.registry(dialect);
+        let want = compiler_check_diagnostics_uncached(src, registry, dialect, None, None);
+
+        // The O100 message names CFG blocks, not the source condition, so
+        // identify the folded guard by slicing the span out of the source.
+        let folded = |ds: &[CompilerCheck]| -> Vec<String> {
+            ds.iter()
+                .filter(|d| d.code == DiagCode::O100)
+                .map(|d| src[d.span.start() as usize..d.span.end() as usize].to_owned())
+                .collect()
+        };
+        assert_eq!(
+            got.checks, want.checks,
+            "memoised and cold compiler checks must agree on the instance-var fold"
+        );
+        let hints = folded(&got.checks);
+        assert_eq!(
+            hints.len(),
+            1,
+            "exactly the never-set `zzz` guard may fold, got {hints:?}"
+        );
+        assert!(
+            hints[0].contains("zzz") && !hints[0].contains("exists x"),
+            "the folded guard must be `zzz`, not the instance variable, got {hints:?}"
+        );
+        assert_eq!(folded(&want.checks), hints, "cold path must match");
+    }
+
     /// The #1117 top-up must also **invalidate**: an edit inside a `TclOO`
     /// method body has to move the memoised path's O1xx hints with it (and drop
     /// them when the construct goes away), not serve a stale `proc_taint_solve`


### PR DESCRIPTION
## Summary

Fixes #1129 — the `info exists` constant fold was blind to TclOO instance variables, producing 17 false positives on the corpus (identical on the memoised and cold check paths, so fold logic, not memoisation).

**Oracle first** (tclsh 9.0.4 + 8.6.14, byte-identical): a class-level `variable x` declaration does *not* create the variable (`info vars` lists it, `info exists` is 0); existence flips true when any method/constructor on that instance assigns it and false again after `unset` — a per-instance, call-order-dependent runtime fact (the same method on the same object prints 0 then 1). The only sound fold behaviour is **abstention**, and the #1131 cross-block union shape is pinned too (`set b 7` in a constructor written before the `oo::define` block declaring `variable b` still binds instance state).

**Root cause**: `sccp::existence_constant_branches` already abstains for scope-alias locals (`global`/`variable`/`upvar`/`namespace upvar`) via `scan_scope_aliases`, but that scan walks the body's own commands — an instance variable has *no binding command in the body*, so it looked like a never-defined local and folded false. **A second latent FP found en route**: the analyser's copy of the fold sourced parameters from `ir_module.procedures`, where a method's qualified name never appears — so method *parameters* also folded false on the I230 path (the optimiser copy never had this bug; the two consumers of one fold silently disagreed).

**Fix** (registry/IR-typed, no name matching): new `sccp::ExistenceFrame { params, object_state }` replaces the loose parameter set; `object_state` (from `MethodDef::instance_vars`, the #1131 cross-block union) extends the existing, already-tested `aliased` abstention path. `FunctionUnit::build_for_method` builds method units from the typed `MethodDef`, and the I230 emitter constructs the same `ExistenceFrame` from the same IR — the two consumers cannot drift again. `my variable` needed no change (the registry's `ArgRole::VarWrite` resolver already covers it — verified and pinned).

**Codex fix round (882df929b)**, both findings oracle-confirmed real and fixed:
- *Parameter shadows instance variable*: the formal parameter wins outright on both runtimes (the write never reaches object state — full shadow, not a link). Fixed by per-name precedence scoped to the object-state half only, so command-derived aliases (including legal variable-trace targets on parameters) keep full precedence.
- *Proc/method qname collision*: a namespace proc and a method can legitimately share a qualified key across the two IR maps; the by-name probe handed each frame the other's facts. Fixed structurally with a `BodyFrame` enum supplied by each diagnostic loop — `ir_module` is gone from the emitter signatures entirely, and the same disease's **third** instance fell out: `apply` lambda parameters (never in `procedures`) folded always-false; now always-true, oracle-pinned. W214/W210's parameter sourcing had the identical collision bug and is fixed by the same carrier.

**Consumer audit**: O100/O101 + DCE fixed at source; I230 fixed; `drop_cross_event_existence_folds`, `lattice_rebase`, `connection_scope::scan_info_exists` confirmed unaffected; salsa memo untouched by construction (method units build identically on both paths — exactly why the FP counts matched).

**Corpus delta, re-measured directly** (per-item differential skipped due to #1123 rot; single-build A/B harness over 115 `oo::`-bearing files instead): method-body existence folds **25 → 2**, unchanged through the fix round. The issue's 17 reproduces exactly in SpiceGenTcl's generalClasses.tcl (16 instance-var + 1 method-parameter); that file goes **17 → 1**, and the survivor is a **true positive** — `EmptyTrace::getDataPoints` guards a superclass-declared variable, and a superclass `variable` declaration is *not* inherited into subclass method frames (oracle-pinned; `$D` there raises `can't read`). The other corpus survivor (ruff) is a pre-existing, unrelated FP — `my`-dispatched upvar callees are invisible to the caller's upvar context — filed as #1177, measured identical before and after this PR.

**Tests**: 10 in tcl-compiler (FP guards verified to fail pre-fix; TP guards that a never-set non-instance local *still* folds and that method/lambda parameters fold *always true*; the qname-collision test asserts each frame folds its own guards) + 1 memo-parity A/B in tcl-lsp-db following the #1117/#1130 pattern.

**Residuals filed**: #1172 (lowering's OO extraction literal-matches two spellings — objdefine/snit/itcl bodies never become method units), #1173 (precision follow-ups: array-element guards, whole-class never-assigned fold-false), #1174 (consolidate the parallel channels carrying instance-var facts), #1177 (the ruff FP above).

Two commits: f718325e5 (+358/−31 across 6 files), 882df929b (+343/−90 across 3 files).

## Validation

- [x] `cargo test -p tcl-compiler` — 7767 passed, 0 failed
- [x] `cargo test -p tcl-lsp-db` — 84 passed, 0 failed (5 pre-existing corpus-gated ignores)
- [x] `cargo clippy -p tcl-compiler -p tcl-lsp-db --all-targets` — clean, zero new allows (all pedantic hits fixed on the merits)
- [x] `cargo fmt --all --check` — clean
- [x] Oracle transcripts pinned (9.0.4 + 8.6.14, byte-identical) in the test headers and the `ExistenceFrame` doc-comment, including the shadowing and qname-collision shapes

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — `ExistenceFrame` is the new typed input to the existence fold; `BodyFrame` replaces by-name IR probing in the diagnostic emitters; I230/O100 abstain on instance state.
- [x] KCS notes: fold behaviour documented in the `sccp.rs` doc-comment with the oracle transcript.
- [x] New compiler KCS note linked: n/a — no new diagnostic code; existing I230/O100 semantics corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7