### PR TITLE
Wildcard-import gating: order the install against the call, stop the tail match overruling it, and cache the workspace name set

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -83,6 +83,11 @@ surface.
 - [cross-file-command-resolution-lattice.md](cross-file-command-resolution-lattice.md)
   — the proposal for the cross-file resolution lattice: settling a call to its
   defining proc/class across the workspace index, sound by abstention.
+- [import-order-source-graph.md](import-order-source-graph.md) — design sketch
+  (unimplemented) for a load-order partial order derived from the `source` /
+  `package require` graph: which facts the analyser and index already record,
+  what the ordering relation needs, which wildcard-import abstentions it would
+  lift, and why no trivial subset exists below the resolver plumbing.
 - [name-resolution-tcl-version-and-c-source.md](name-resolution-tcl-version-and-c-source.md)
   — the version-sensitive resolution semantics (8.4→9.1), each fact pinned to a
   stable C-Tcl source permalink (`tclNamesp.c` / `tclVar.c`).

--- a/docs/design/contracts/command-resolution.md
+++ b/docs/design/contracts/command-resolution.md
@@ -128,8 +128,11 @@ not change the rule, and must not grow bespoke resolution logic. Every
   pinned), and are not references to commands: `namespace export p` before
   `proc p` still exports it (pinned). A non-glob `namespace import` of an
   unexported name is a silent no-op, not an error (pinned) — so the **exact**
-  form is snapshot-gated exactly like the glob one; importing onto
-  an existing command errors unless `-force` (pinned). Both subcommands
+  form is snapshot-gated exactly like the glob one, including a pattern rooted
+  at the global namespace (`namespace import ::p`, whose source namespace is
+  `::`, not "none" — pinned); importing onto
+  an existing command errors unless `-force`, whichever of the two spellings
+  bound the name first (pinned). Both subcommands
   consume at most **one** leading flag word: a second `-clear` is an ordinary
   export pattern (and `-clear` is then a genuinely importable command name),
   a second — or trailing — `-force` is an import pattern that aborts the
@@ -188,6 +191,15 @@ not change the rule, and must not grow bespoke resolution logic. Every
     follow the chain while every hop is provable, bounded by
     `analyser::indirection::MAX_COMMAND_NAME_HOPS`, and abstain otherwise.
 
+  - **The install is ordered against the call, too.** A bare call written
+    *before* its own `namespace import` reaches nothing (`invalid command
+    name`); the same call written after it works (pinned). That order is the
+    ordinary load-time one, so a call inside a **proc body** still resolves
+    through an import written later in the same file — the whole file loads,
+    imports included, before any body runs (pinned: procs first, `namespace
+    import` last, the call works) — while an import written after the call in
+    that *same* body has genuinely not run yet (pinned). Issue #1104 item 1.
+
   Statically the removals join the same ordered event log: `namespace forget`
   as `SignatureNamespaceForget`, a destroying `rename OLD {}` /
   `interp alias {} NAME {}` as `AnalysisResult::destroyed_commands` (a *re*name
@@ -195,7 +207,8 @@ not change the rule, and must not grow bespoke resolution logic. Every
   `SignatureNamespaceImport::forced` — read, like `-clear`, as "the declared
   leading option word was consumed", never as a `-force` name match. Both tiers
   answer through one shared decision function
-  (`tcl_lsp_core::namespace_import::alias_live_at`), under the same
+  (`tcl_lsp_core::namespace_import::alias_live_at`), which gates **every**
+  ordered event — installs as much as removals — under the same
   `in_effect` / `in_effect_within` order rule as the export snapshot, and it
   gates the **exact**-import link the same way it gates a glob lookup.
   Byte offsets order events only *within* one document, so a cross-file event

--- a/docs/design/contracts/command-resolution.md
+++ b/docs/design/contracts/command-resolution.md
@@ -168,8 +168,12 @@ not change the rule, and must not grow bespoke resolution logic. Every
     raises the same error and leaves `origin` at `::A::p`, while `-force`
     makes it `::B::p` and a preceding `namespace forget` lets the unforced one
     through (all pinned). Re-importing from the *same* source is a silent
-    no-op, not a conflict (pinned). Statically the "installed nothing" /
-    "replaced what was there" halves are both modelled; the error's
+    no-op, not a conflict (pinned). Which of the two ran first is **load
+    order**, not written order: a body-local `namespace import ::B::x` loses to
+    a top-level `namespace import ::A::*` written below it, because the file
+    loads before any body runs — `namespace origin ::dst::x` → `::A::x` and the
+    body's import raises `already exists` (pinned). Statically the "installed
+    nothing" / "replaced what was there" halves are both modelled; the error's
     *control-flow* consequence (nothing after it in that script runs) is
     deliberately out of scope.
   - **Redefining the imported name ends the alias.** A `proc ::dst::p` written

--- a/docs/design/contracts/workspace-indexing.md
+++ b/docs/design/contracts/workspace-indexing.md
@@ -260,6 +260,18 @@ command-name set the cross-file unknown-command pass consults
 400-file / 10 000-proc workspace, ~7 ms to build, ~120 ns to serve from the
 cache.
 
+The rule is a single type, `Derived<T>`, rather than one hand-rolled
+`OnceLock` + reset per view (issue #1105).  Three views use it:
+`command_names`, the `command_links` liveness mask, and the two
+`defined_command_names` readings (with and without the names links
+introduce — a consumer wants exactly one, since folding link names into the
+direct set would let rename rewrite a call that merely spells an imported
+name).  The last of those was the motivating regression:
+`workspace_command_exists` rebuilt the whole set per call, and
+`follow_import_chain` asks it once per candidate per hop.  Measured on the
+same 400-file / 10 000-proc workspace, 10 000 existence checks take **870 µs**
+cached against **7.87 s** rebuilding per call.
+
 ## Decision rules / contracts
 
 1. Document-state updates must preserve cache correctness across edits/errors.

--- a/docs/design/contracts/workspace-indexing.md
+++ b/docs/design/contracts/workspace-indexing.md
@@ -119,6 +119,21 @@ kind made the rule directional).  A same-source re-import is a silent no-op,
 never a conflict, and two imports in different documents have no static load
 order and do not conflict at all.
 
+"Earlier" is **load order**, not byte offset
+(`tcl_lsp_core::namespace_import::load_order`, shared with the same-document
+tier's slot-log fold): a load-level statement runs before every body of its
+file however far below it is written, a body-local one never counts as having
+run at load level, and within one tier the key degenerates to the offset
+comparison it replaces.  A raw offset test let a body-local import install over
+a top-level one written after it — oracle (8.6.14 / 9.0.4): with `proc p {}
+{namespace import ::B::x}` in `::dst` followed by a top-level `namespace import
+::A::*`, `namespace origin ::dst::x` is `::A::x` and `::dst::p` raises `can't
+import command "x": already exists`.  This is deliberately *not*
+`in_effect_within`, the primitive the lifecycle checks use: that one counts an
+event in a body that may never run, which is the safe direction for a removal
+and the unsafe one for a conflict — it would make both imports above cancel
+each other and the name resolve nowhere.
+
 A pattern rooted at the global namespace (`namespace import ::p`,
 `namespace import ::*`) splits to an *empty* source namespace, which both tiers
 once read as "no source" and skipped — the last import shape that bypassed the

--- a/docs/design/contracts/workspace-indexing.md
+++ b/docs/design/contracts/workspace-indexing.md
@@ -17,7 +17,7 @@ entry has an identity another document can spell:
 | Table | Holds | Bound |
 |---|---|---|
 | `procs` / `classes` | every `proc` / class definition | qualified name |
-| `invocations` | every call site, with its ordered resolution candidates | — |
+| `invocations` | every call site, with its ordered resolution candidates and its enclosing body span | — |
 | `variables` | namespace- and global-scope variable declarations | **qualified name only** |
 | `variable_refs` | occurrences written with a `::` qualifier | **qualified name only** |
 | `namespace_refs` | every word naming a namespace, declaring or not | qualified name (rooted at record time) |
@@ -68,6 +68,11 @@ question about the *call*, not the import, and the same shared decision
 function the same-document resolver uses
 (`tcl_lsp_core::namespace_import::alias_live_at`) answers it for both tiers.
 
+That decision function gates **installs as well as removals** (issue #1104
+item 1): a bare call written before its own `namespace import` reaches nothing
+(oracle: first call `invalid command name`, post-import call works), so an
+install that has not run at the query point does not count.
+
 Ordering is per document on **both** sides of the comparison: an install
 whose document differs from the call's is passed unordered too, because a byte
 offset in the importing file and one in the calling file are unrelated numbers
@@ -75,16 +80,25 @@ offset in the importing file and one in the calling file are unrelated numbers
 import purely because its local offset happened to be larger (issue #1116
 finding 1).  Unordered, the shared function keeps the alias.
 
-Three further points are deliberate.  A removal in a **different document**
+Within one document the comparison is `in_effect_within` on **both** sides
+too, which is why `CallSite` carries the call's own `enclosing_body` span and
+`invocations` rows store one.  A plain offset test was wrong in both
+directions: it left a body-local call resolving through a top-level
+`namespace forget` written before it (issue #1116 item 3, the lenient
+direction), and — once installs became order-gated — it would have dropped the
+alias of every proc body that calls a name its own file imports further down,
+which is the ordinary shape of a library module (tcllib's
+`modules/uev/uevent.tcl` writes its procs first and its `namespace import`s
+last).  The column is built with one stack sweep over each document's body
+spans and call offsets rather than one `innermost_definition_body_span` per
+row, so the cost is `O((P + I) log (P + I))` per document instead of the
+`O(procs × invocations)` that kept the fact out of the index.
+
+Two further points are deliberate.  A removal in a **different document**
 from the call revokes nothing, the same unordered-event rule the `-clear`
-tombstones follow.  Within one document the removal is ordered by a plain
-offset comparison rather than `in_effect_within`, because the index stores an
-enclosing-body span per *import* row, not per invocation, and building one per
-call site would be O(procs × invocations) at index time; the missing fact can
-only make a removal look not-yet-run, i.e. keep answering, never invent one.
-And **destroying** the source command is not treated as a slot event on a
-timeline at all — the command object is gone workspace-wide — so it revokes
-wherever it is written.
+tombstones follow.  And **destroying** the source command is not treated as a
+slot event on a timeline at all — the command object is gone workspace-wide —
+so it revokes wherever it is written.
 
 The **exact**-import link tier runs the same decision function with no call
 site (`WildcardImportIndex::link_alias_live`, issue #1116 finding 2): the
@@ -93,10 +107,24 @@ recorded removal counts as having run and the ordering that remains is the
 removal's position relative to the *import* — a forget or a redefinition of
 the imported name in the import's own document revokes the link when written
 after it, one before it is undone by the import, and one in another document
-revokes nothing.  A non-`-force` exact import also conflicts with an earlier
-exact import of the same name from a **different** source in the same document
-(`earlier_conflicting_link`), matching the glob tier's
-`conflicting_alias_at`.
+revokes nothing.
+
+The import **conflict** rule is one function over both tables
+(`WildcardImportIndex::conflicting_alias_at`).  Tcl installs one alias per
+name; whether the import that installed it was spelled as a glob or as an
+exact pattern is a fact about the source text, not about the command table, so
+an earlier import of either spelling makes a later non-`-force` import of the
+other install nothing (issue #1116 item 7 — asking each side only about its own
+kind made the rule directional).  A same-source re-import is a silent no-op,
+never a conflict, and two imports in different documents have no static load
+order and do not conflict at all.
+
+A pattern rooted at the global namespace (`namespace import ::p`,
+`namespace import ::*`) splits to an *empty* source namespace, which both tiers
+once read as "no source" and skipped — the last import shape that bypassed the
+gate.  It is `::`, the same spelling a global-level `namespace export` record
+carries, and it is gated like any other (#1104's review note; oracle: an
+unexported global command makes the import a silent no-op).
 
 Resolution follows **import chains**: when the hop's source namespace does not
 itself define the name, the walk continues from there, bounded by

--- a/docs/design/import-order-source-graph.md
+++ b/docs/design/import-order-source-graph.md
@@ -1,0 +1,180 @@
+# A load-order partial order from the `source` / `package require` graph
+
+Design sketch for the single remaining abstention shared by the whole
+wildcard-import gating family (#1104 item 3, #1116 items 3 and 6, and the
+cross-file half of every rule in
+[`contracts/command-resolution.md`](contracts/command-resolution.md)'s import
+section). **Nothing here is implemented.** This note records which facts the
+analyser and the index already hold, what a partial load order would need on
+top of them, which abstentions it would lift, and what it would cost.
+
+## 1. The abstention, stated once
+
+Both LSP resolution tiers order import-lifecycle events by **byte offset
+within one document**, via
+`tcl_compiler::analyser::indirection::in_effect_within`. Across documents
+they order nothing, because nothing in a Tcl source tree says which file runs
+first. Every cross-file event is therefore passed to the shared decision
+functions (`namespace_import::exported_at_import_site`,
+`namespace_import::alias_live_at`) with `at: None`, and those abstain toward
+*answering*:
+
+| Fact in another file | Today |
+|---|---|
+| `namespace export p` | counts (the import may resolve) |
+| `namespace export -clear` | revokes nothing |
+| `namespace import` (an install) | counts |
+| `namespace forget` | revokes nothing |
+| a second import of the same name | never conflicts (#1116 item 6) |
+
+Each row is one-directional leniency. The genuinely-sequenced idiom
+`source lib.tcl ; namespace forget ::lib::p` gets *both* halves wrong: the
+install from `lib.tcl` counts (right), and the forget beside it revokes
+nothing (wrong). One partial order fixes the whole table at once, which is
+why it is worth doing as one piece of work rather than five.
+
+## 2. What is already recorded
+
+### 2.1 `source`
+
+`tcl_compiler::signature_scan::types::SignatureSource` — one row per `source`
+statement, surfaced in the index as `WorkspaceSource`:
+
+| Field | Meaning | Enough for load order? |
+|---|---|---|
+| `raw_path` | the path word verbatim, `${var}` / `[cmd]` markers preserved | needs resolving |
+| `range` | byte span of the path argument **in the sourcing file** | **yes** — this is the sequencing fact |
+| `is_literal` | no `$` / `[` in the word | the decidability flag |
+| `site_namespace` | command-resolution namespace at the `source` call | not needed here (used by M9 re-homing) |
+
+The offset is the important one and it is already there: a `source` statement
+is an ordinary statement of the sourcing file, so it is ordered against that
+file's imports and exports by exactly the rule already in use.
+
+`WorkspaceIndex` exposes the graph twice:
+
+- `source_ancestor_package_requires(target_uri, resolve)` — reverse
+  reachability, used by the workspace W120 refinement.
+- `source_seed_map(resolve)` — the M9 namespace re-homing seeds.
+
+Both take a `resolve` **closure supplied by the server**, because the index
+holds no URI↔path mapping of its own. `crate::source_graph` owns the pure
+half (`resolve_source_target`, `resolve_under`, `ancestor_requires`,
+lexical `.`/`..` folding, no filesystem access).
+
+### 2.2 `package require` / `package provide`
+
+- `WorkspacePackageRequire { uri, name }` — **no offset, no version**. It
+  says *that* a file requires a package, not *where*, so it cannot sequence
+  anything as it stands.
+- `SignaturePackageProvide { name, version, range }` per document — the other
+  end of the edge, with an offset.
+- `SignatureAutoPathEntry { raw, range }` — `auto_path` mutations, one row per
+  element, offsets included.
+- `tcl_lsp_core::package_resolver` + the autoload tier resolve a required
+  package to its `pkgIndex.tcl` and merge the defining library file into the
+  index on demand.
+
+## 3. What a partial order needs
+
+1. **Resolved edges in the index.** A `(parent_uri, child_uri, at)` triple per
+   literal `source`, with `at` the sourcing statement's own offset. Today the
+   URI half only exists inside a server-supplied closure; the graph consumers
+   rebuild it per call. A load-order gate runs *inside* the per-call
+   import walk, so the edges have to be resolved once and cached — naturally
+   alongside `WildcardImportIndex`, which is already built once per query and
+   invalidated per `WorkspaceIndex::generation()`.
+
+2. **A "has already run" relation over (document, offset) pairs**, replacing
+   the current `uri == other.uri` test. The relation `A@a ≺ B@b` should hold
+   when there is a path `A → … → B` in the source graph whose first edge sits
+   at an offset `≺` `a` under the existing `in_effect_within` rule, and `B`'s
+   whole body precedes `b` only if `B` is the same document. Concretely the
+   three cases the gate needs:
+
+   - same document → today's `in_effect_within` (unchanged);
+   - `A` sources `B`, and the `source` statement is in effect at the query
+     point in `A` → every statement of `B` has run;
+   - `A` sources `B` *after* the query point in `A` → **nothing** in `B` has
+     run — the first ordering that can currently only abstain.
+
+3. **Soundness gates on the edge set.** An edge is usable only when the whole
+   path is unconditional and statically known:
+   - `is_literal` (a `source $dir/x.tcl` sequences nothing);
+   - the `source` statement is not inside a proc/class body whose execution is
+     conditional — the same `nested` judgement `WorkspaceProc::nested` and
+     `WorkspaceCommandLink::nested` already apply;
+   - the graph is acyclic on the path used (Tcl tolerates re-sourcing; a cycle
+     means the order is not a partial order and the pair must abstain);
+   - a file reachable by **two** paths with different orders relative to the
+     query point abstains — the order must be unique to be a fact.
+
+4. **`package require` sequencing (optional, second phase).** A
+   `package require` is an ordered statement too, and its package's files load
+   at that point. To use it, `WorkspacePackageRequire` needs the `at` /
+   `enclosing_body` pair `WorkspaceGlobImport` already carries, plus the
+   resolver's package→URI mapping recorded in the index rather than consulted
+   ad hoc. `package provide` gives the other end. This is strictly more
+   speculative than the `source` half: `auto_path` is mutable at runtime and
+   a package may already be loaded, so "the require ran here" does not imply
+   "the package's files ran here and not earlier".
+
+## 4. Which abstentions it lifts
+
+| Issue | Abstention | Lifted by |
+|---|---|---|
+| #1104 item 3 | foreign `namespace export` patterns always count; foreign `-clear`s never revoke | §3.2 all three cases |
+| #1116 item 6 | two imports of one name in different files never conflict | §3.2, case 2 (the earlier file's import is known to have run) |
+| #1116 (finding 1 note) | `source lib.tcl ; namespace forget ::lib::p` — install counts, forget revokes nothing | §3.2, cases 2 and 3 together |
+| #1116 item 1 | in-document `-force` shadow with the export in another file | *not* lifted by ordering — it is an *observability* question, answered by the workspace tier's `observable_namespaces` |
+| #1116 item 4 | import-error control flow (a failed import aborts the rest of its script) | *not* lifted — a different model (intra-script abort), though it shares the "what has run" vocabulary |
+
+Note the two negatives. A load order says *when* a statement ran; it does not
+say whether a statement exists in a file nobody indexed, and it does not model
+a script aborting part-way. Those stay separate.
+
+## 5. Cost, and why this is not a one-liner
+
+The gate runs in the per-call import walk, which the workspace tier already
+had to hoist an index out of to keep off the profiler
+(`WorkspaceIndex::resolve_wildcard_import_indexed`'s doc records the
+regression that forced it). Adding a graph reachability query per event would
+put it straight back. The shape that fits is a **precomputed order** built
+once per `generation()`:
+
+- resolve every literal `source` edge once → `O(sources)` with the server's
+  resolver;
+- topologically order the DAG → `O(V + E)`;
+- store, per document, its position and the offsets at which each child is
+  entered, so the three cases in §3.2 are `O(1)` lookups.
+
+The one thing that cannot be precomputed cheaply is the *server-supplied
+resolver*: `WorkspaceIndex` deliberately holds no filesystem knowledge, so
+either the resolved edges get pushed in at `add_document` time (changing the
+index's public shape) or the order is built lazily behind the same
+`generation()` cache the live-link mask uses, taking the resolver as an
+argument. The second is the smaller change and matches `live_command_links`'s
+existing pattern.
+
+**A trivial subset was considered and rejected for this round.** "Same
+document `source a.tcl` written before an import of a namespace `a.tcl`
+declares" still needs (1) the raw path resolved to a URI, which only the
+server can do, and (2) that resolution reaching into `exports_name_at` /
+`alias_live_at`, i.e. the whole plumbing above. There is no subset that is
+provable without the resolver, so the work does not decompose below §3.1.
+
+## 6. Direction if it is built
+
+Keep the discipline the family already has: **one** decision function per
+question, both tiers calling it. The order belongs behind a single predicate
+with the shape
+
+```rust
+fn has_run(&self, event: (uri, at, enclosing_body), query: (uri, at, enclosing_body)) -> Option<bool>
+```
+
+— `None` meaning "no static order", which is what the existing `at: None`
+event encoding already expresses. Every current caller then keeps its shape:
+`ExportEvent::at` / `AliasEvent::at` become `Some(_)` in strictly more cases,
+the shared decision functions are untouched, and the abstention table in §1
+shrinks without a second rule appearing anywhere.

--- a/docs/kcs/features/kcs-feature-definition.md
+++ b/docs/kcs/features/kcs-feature-definition.md
@@ -58,7 +58,9 @@ are glob *patterns*, not command references — `namespace export get*` covers
 `getX` and not `setX`, and `namespace export p` written before `proc p` still
 exports it. The same gate applies to an *exact* `namespace import ::src::p`:
 real Tcl silently binds nothing when `p` is not exported, so neither does
-navigation.
+navigation — and that includes an import of a global command
+(`namespace import ::p`), which needs a global `namespace export p` like
+anything else.
 
 Ordering follows the same load-order rule renames and aliases do. An import
 written **inside a proc or method body** sees every top-level statement of its
@@ -67,6 +69,23 @@ export further down the file still counts; an export written after the import
 *in that same body* does not. Ordering only exists inside one document; when
 the import and the export are in different files, nothing fixes which loads
 first, so navigation keeps answering rather than guessing a revocation.
+
+A call written **before** its own `namespace import` reaches nothing, and Go to
+Definition says so: the import has not run yet, exactly as a `rename` written
+below a call has not. The same load-order rule as everywhere else applies, so
+this is about *statements*, not about lines — a call inside a proc or method
+body still jumps through an import written further down the same file, because
+the whole file loads before any body runs. That is the ordinary shape of a
+library module: the procs first, the `namespace import`s at the bottom. An
+import written after the call *inside that same body* is a later statement of
+the running script, and the call before it resolves to nothing.
+
+The tail-match fallback no longer papers over any of this. Go to Definition
+keeps a lenient last resort — a proc whose defining namespace is not
+statically visible at the call still jumps — but it will not answer with a
+command whose only route to the call was an import the rules above have just
+ruled out. Nothing else about the fallback changes: a same-file proc no import
+mentions still jumps as before.
 
 An import is not a permanent name, either. `namespace forget ::src::p` — or
 the unqualified `namespace forget p`, which drops whatever this namespace
@@ -83,7 +102,9 @@ import carries `-force`, and the failed import installs nothing — so a bare
 call still reaches the *local* definition, and Go to Definition stays on it.
 "Already has" includes a name it imported earlier from somewhere else: a
 second unforced import of the same name from a different namespace fails too,
-and navigation keeps answering the first source. With `-force` the import
+and navigation keeps answering the first source — whichever way round the two
+were spelled, `namespace import ::A::*` then `namespace import ::B::p` or the
+other way about. With `-force` the import
 replaces whatever was there, and from that point on the same bare call jumps
 to the **source** instead — until a `proc` of that name is written, which
 silently takes the name back and sends navigation to the new local

--- a/docs/kcs/features/kcs-feature-definition.md
+++ b/docs/kcs/features/kcs-feature-definition.md
@@ -104,7 +104,10 @@ call still reaches the *local* definition, and Go to Definition stays on it.
 second unforced import of the same name from a different namespace fails too,
 and navigation keeps answering the first source — whichever way round the two
 were spelled, `namespace import ::A::*` then `namespace import ::B::p` or the
-other way about. With `-force` the import
+other way about. "First" is the order they *run*, not the order they are
+written: an import inside a proc body loses to a top-level import of the same
+name anywhere in that file, even one written below it, because the file loads
+before any body runs. With `-force` the import
 replaces whatever was there, and from that point on the same bare call jumps
 to the **source** instead — until a `proc` of that name is written, which
 silently takes the name back and sends navigation to the new local

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -2784,11 +2784,42 @@ fn live_import_at(
 }
 
 /// Every [`SlotEvent`] bearing on `<importing_ns>::<word>` in this document,
-/// in source order.
+/// in **execution** order.
 ///
 /// Ordering the four record kinds against each other once, here, is what lets
 /// [`live_import_at`] answer the conflict question and the call-site question
 /// with the same log instead of two ad-hoc scans.
+///
+/// # Why not source order
+///
+/// The whole file loads — running every top-level statement — before any
+/// proc/class body runs, so a top-level statement written *below* a
+/// body-local one still happens first. That is the same load-order rule
+/// [`indirection::in_effect`] states pointwise; sorted here it is the total
+/// order the conflict fold needs. Oracle, byte-identical on tclsh 8.6.14 and
+/// 9.0.4:
+///
+/// ```tcl
+/// namespace eval ::A { proc x {} {return A}; namespace export x }
+/// namespace eval ::B { proc x {} {return B}; namespace export x }
+/// namespace eval ::dst { proc p {} { namespace import ::B::x } }
+/// namespace eval ::dst { namespace import ::A::* }
+/// namespace origin ::dst::x   ;# → ::A::x
+/// ::dst::p                    ;# → can't import command "x": already exists
+/// namespace origin ::dst::x   ;# → ::A::x   (unchanged)
+/// ```
+///
+/// Folding that log in raw offset order got *both* halves wrong: it let the
+/// body-local `::B` import install, and then conflicted the top-level `::A`
+/// one away. Within one tier — all top level, or all inside one body — the
+/// key degenerates to the offset comparison it replaces, so genuinely
+/// sequenced statements are unaffected. Two events in *different* bodies have
+/// no static order either way; they keep their offset order, as before.
+///
+/// The workspace tier reaches the same answer through
+/// `WildcardImportIndex::conflicting_alias_at`, which asks
+/// [`indirection::in_effect_within`] per candidate rather than sorting a log —
+/// same rule, stated over the facts each tier holds.
 fn slot_events<'a>(
     analysis: &'a AnalysisResult,
     importing_ns: &str,
@@ -2867,7 +2898,18 @@ fn slot_events<'a>(
     {
         events.push(SlotEvent::Declare { at });
     }
-    events.sort_by_key(|ev| ev.at());
+    // Load level first, then bodies — see the doc comment. The key is the one
+    // the cross-document tier compares its two import sites with, so neither
+    // can drift. `sort_by_cached_key` because the body test is a scan of the
+    // recorded definition bodies, so it must run once per event, not once per
+    // comparison. Equal offsets imply equal body-ness, so the dedup below
+    // still sees its duplicates adjacent.
+    events.sort_by_cached_key(|ev| {
+        crate::namespace_import::load_order(
+            ev.at(),
+            analysis.offset_is_inside_any_definition_body(ev.at()),
+        )
+    });
     events.dedup_by_key(|ev| (ev.at(), std::mem::discriminant(ev)));
     events
 }
@@ -4419,6 +4461,48 @@ mod tests {
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::B::p"),
             "a `-force` import replaces a live alias too: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn a_body_local_import_conflicts_with_a_later_top_level_import() {
+        // TN (CRITICAL) — the in-document twin of the workspace tier's own
+        // check: which import installs is decided in *execution* order, not
+        // written order. Oracle, byte-identical on tclsh 8.6.14 and 9.0.4:
+        //
+        //   namespace eval ::dst { proc p {} { namespace import ::B::x } }
+        //   namespace eval ::dst { namespace import ::A::* }
+        //   namespace origin ::dst::x  -> ::A::x
+        //   ::dst::p                   -> can't import command "x": already exists
+        //   namespace origin ::dst::x  -> ::A::x   (unchanged)
+        //
+        // The whole file loads before any body runs, so the top-level `::A`
+        // import owns the name and the body-local `::B` one installs nothing.
+        // Folding the slot log in raw offset order got both halves wrong: it
+        // installed `::B` and then conflicted `::A` away.
+        let src = "namespace eval A {\n    proc p {} { return AP }\n    namespace export p\n}\nnamespace eval B {\n    proc p {} { return BP }\n    namespace export p\n}\nnamespace eval dst {\n    proc runner {} { namespace import ::B::p }\n}\nnamespace eval dst {\n    namespace import ::A::*\n}\n";
+        let analysis = analyse(src);
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::A::p"),
+            "the top-level import runs first and the body-local one installs \
+             nothing: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn a_later_import_in_the_same_body_still_loses_to_the_earlier_one() {
+        // TN guard — inside one body the offsets *are* execution order again.
+        // Oracle: `proc q {} { namespace import ::A::* ; namespace import
+        // ::B::p }` → the first succeeds, the second raises `already exists`,
+        // `namespace origin` stays `::A::p`.
+        let src = "namespace eval A {\n    proc p {} { return AP }\n    namespace export p\n}\nnamespace eval B {\n    proc p {} { return BP }\n    namespace export p\n}\nnamespace eval dst {\n    proc q {} { namespace import ::A::* ; namespace import ::B::p }\n}\n";
+        let analysis = analyse(src);
+        let call = after_last(src, "namespace import ::B::p");
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", call);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::A::p"),
+            "the second import of the same body installs nothing: {hit:?}"
         );
     }
 

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -2402,37 +2402,54 @@ enum ImportQuery {
     /// "Has a `namespace import -force` taken this name away from the
     /// importing namespace's own command table?" ([`forced_import_shadows`])
     /// Only forced imports count, and the export gate abstains for a source
-    /// namespace this document cannot see at all: `namespace import -force
-    /// ::Lib::*` deletes the local command whether or not `::Lib`'s export
-    /// declaration happens to live in *this* file, and answering with the
-    /// deleted definition would be worse than abstaining. The same
-    /// "absence of an export is evidence only where the definitions are
-    /// visible too" rule `WorkspaceIndex::live_command_links` applies
-    /// cross-document.
+    /// namespace whose export list this document cannot see
+    /// ([`namespace_exports_observable`]): `namespace import -force ::Lib::*`
+    /// deletes the local command whether or not `::Lib`'s export declaration
+    /// happens to live in *this* file, and answering with the deleted
+    /// definition would be worse than abstaining. The same "absence of an
+    /// export is evidence only where the exports are visible too" rule
+    /// `WorkspaceIndex::live_command_links` applies cross-document, over the
+    /// whole workspace's export records rather than one file's.
     ForcedShadow,
 }
 
-/// Whether this document can say anything at all about `source_ns` — it holds
-/// a proc or class of that namespace, or an export declaration for it.
+/// Whether this document can see `source_ns`'s **export list** — the only
+/// evidence that makes "`source_ns` did not export this name" a fact rather
+/// than a gap.
 ///
 /// The in-document twin of `WorkspaceIndex::observable_namespaces`, and the
 /// discriminator [`ImportQuery::ForcedShadow`] needs between "this namespace
-/// did not export the name" (a fact) and "this namespace is in another file"
-/// (no information).
-fn namespace_is_observable(analysis: &AnalysisResult, source_ns: &str) -> bool {
+/// did not export the name" (a fact) and "this namespace's exports are in
+/// another file" (no information).
+///
+/// # Why exports, not definitions (issue #1116 item 1)
+///
+/// This used to answer "does this document hold a proc, a class, **or** an
+/// export of `source_ns`", mirroring the workspace-wide
+/// `observable_namespaces`. Cross-document that is right — the index really
+/// does hold every file. In *one* document it is not: a namespace can be
+/// perfectly visible here (its procs are in this file) while its `namespace
+/// export` sits in another, and then a `namespace import -force ::src::*`
+/// really did delete the local command that single-file go-to-definition went
+/// on answering with.
+///
+/// The proposition being asserted is about the export list, so the evidence
+/// has to be the export list. A document that declares no export at all for
+/// `source_ns` knows nothing about what it exports, and
+/// [`ImportQuery::ForcedShadow`] abstains toward the shadow having fired
+/// (answering with a command the import deleted is worse than answering
+/// nothing and letting the cross-document resolver take over).
+///
+/// **Residual**: a document holding *some* of `source_ns`'s exports but not
+/// the one that covers this name still reads the gap as a fact. Narrowing
+/// that further needs the workspace index's whole-program view, which is
+/// exactly what the cross-document tier already applies.
+fn namespace_exports_observable(analysis: &AnalysisResult, source_ns: &str) -> bool {
     let bare = source_ns.trim_start_matches("::");
-    let owns = |qualified: &String| {
-        qualified
-            .trim_start_matches("::")
-            .rsplit_once("::")
-            .is_some_and(|(ns, _)| ns == bare)
-    };
-    analysis.all_procs.keys().any(owns)
-        || analysis.all_classes.keys().any(owns)
-        || analysis
-            .namespace_exports
-            .iter()
-            .any(|e| e.ns.trim_start_matches("::") == bare)
+    analysis
+        .namespace_exports
+        .iter()
+        .any(|e| e.ns.trim_start_matches("::") == bare)
 }
 
 /// Shared candidate walk behind [`proc_visible_via_wildcard_import`],
@@ -2653,9 +2670,17 @@ fn forget_covers(forget_source: Option<&str>, source_ns: &str) -> bool {
 /// Ordering is [`indirection::in_effect`] — the same "had this statement
 /// run?" primitive the export snapshot and the `rename` / `interp alias`
 /// timeline use, so none of them can disagree about what "already ran" means.
-/// It gates the *removals*; whether a call written before its own import
-/// should stop resolving is #1104 item 1's separate, still-open leniency (see
-/// [`crate::namespace_import::alias_live_at`]).
+/// It gates the *installs* as well as the removals (issue #1104 item 1): a
+/// bare call written before its own `namespace import` reaches nothing
+/// (oracle on [`crate::namespace_import::alias_live_at`]), and because the
+/// primitive is `in_effect` rather than a raw offset test, a call inside a
+/// proc body still observes a top-level import written later in the same file
+/// — the whole file loads before any body runs.
+///
+/// The conflict fold below is deliberately *not* gated that way: which import
+/// installs anything is decided at each import's **own** position, wherever
+/// the call sits. Only the choice of winning edge, and the edge's own
+/// lifecycle, are judged from the call.
 fn live_import_at(
     analysis: &AnalysisResult,
     importing_ns: &str,
@@ -2705,12 +2730,14 @@ fn live_import_at(
                 // local declaration.
                 declared = false;
                 installs.push((at, source_ns));
-                // The latest install wins the source namespace. Deliberately
-                // *not* filtered against `call_off`: whether a call written
-                // before its own import should stop resolving is the
-                // separate, still-open leniency #1104 item 1 — see
-                // `crate::namespace_import::alias_live_at`.
-                if latest.is_none_or(|(best, _)| at > best) {
+                // The latest install *that has already run at the call* wins
+                // the source namespace (issue #1104 item 1). An import the
+                // call has not reached yet cannot decide which edge the call
+                // takes — the same gate `alias_live_at` then applies to the
+                // edge's own log, so the two cannot pick different imports.
+                if indirection::in_effect(analysis, at, call_off)
+                    && latest.is_none_or(|(best, _)| at > best)
+                {
                     latest = Some((at, source_ns));
                 }
             }
@@ -2780,12 +2807,27 @@ fn slot_events<'a>(
         let Some((source_ns, export_tail)) = imp.pattern.rsplit_once("::") else {
             continue;
         };
-        if source_ns.is_empty() || !tcl_syntax::glob::string_match(export_tail, word) {
+        // A pattern rooted at the global namespace (`namespace import ::p`,
+        // `namespace import ::*`) splits to an *empty* source namespace, which
+        // both tiers used to read as "no source" and skip — leaving the one
+        // import shape that bypassed the export gate entirely (#1104's review
+        // note). Real Tcl gives it no special treatment: `proc p {}` with no
+        // `namespace export p` at global level makes `namespace import ::p` a
+        // silent no-op like any other unexported import, and `info commands
+        // ::dst::*` stays empty (oracle 8.6.14 / 9.0.4). `::` *is* the source
+        // namespace — the spelling every export record for global scope
+        // already uses.
+        let source_ns = if source_ns.is_empty() {
+            "::"
+        } else {
+            source_ns
+        };
+        if !tcl_syntax::glob::string_match(export_tail, word) {
             continue;
         }
         let at = imp.range.start();
         if !exported_at_import(analysis, source_ns, word, at)
-            && (query == ImportQuery::Resolve || namespace_is_observable(analysis, source_ns))
+            && (query == ImportQuery::Resolve || namespace_exports_observable(analysis, source_ns))
         {
             continue;
         }
@@ -2953,7 +2995,105 @@ pub(crate) fn resolve_called_proc<'a>(
         // lives in another file.
         return None;
     }
-    fallback_proc_by_simple_name(analysis, source, word)
+    let hit = fallback_proc_by_simple_name(analysis, source, word)?;
+    // …and the lenient tail match must not smuggle back in the one answer the
+    // import gate has just refused (issue #1104 item 2).
+    if only_route_is_a_dead_import(analysis, namespace, word, call_off, &hit.qualified_name) {
+        return None;
+    }
+    Some(hit)
+}
+
+/// Whether the *only* way the call at `call_off` could have reached
+/// `target_qname` is a `namespace import` that this document has already
+/// judged not to be in force — the case where
+/// [`fallback_proc_by_simple_name`]'s tail match would silently overrule the
+/// gate (issue #1104 item 2).
+///
+/// The false positive it closes is #1027's Direction B, still visible through
+/// single-file go-to-definition after #1102 gated everything else: with
+///
+/// ```tcl
+/// namespace eval ::src { proc p {} {return P} }
+/// namespace eval ::dst { namespace import ::src::* }
+/// namespace eval ::src { namespace export p }
+/// namespace eval ::dst { p }        ;# → invalid command name "p"
+/// ```
+///
+/// every ordered route said "no" and the tail match answered `::src::p`
+/// anyway, because it never asks *how* the name would be reachable.
+///
+/// # Why this is narrow on purpose
+///
+/// Other same-file fallbacks are deliberate and pinned by tests: a proc whose
+/// defining namespace simply is not statically visible at the call still
+/// answers, and must keep answering. So this refuses only when **both** hold:
+///
+/// 1. an import in scope for the call (its own namespace, a `namespace path`
+///    entry, or global) syntactically covers `word` *from the namespace the
+///    fallback answer lives in* — i.e. that import is the route, not some
+///    unrelated leniency; and
+/// 2. the live-import walk ([`wildcard_import_source_namespace`]) does not
+///    land on that namespace — the route exists in the text but is not in
+///    force here (unexported at the import, forgotten, conflicted away, or
+///    simply not run yet).
+///
+/// A call with no import naming that namespace at all is untouched, and so is
+/// one whose import *does* resolve (which never reaches the fallback anyway).
+fn only_route_is_a_dead_import(
+    analysis: &AnalysisResult,
+    namespace: &str,
+    word: &str,
+    call_off: u32,
+    target_qname: &str,
+) -> bool {
+    if word.contains("::") {
+        return false;
+    }
+    let Some((target_ns, tail)) = target_qname.rsplit_once("::") else {
+        return false;
+    };
+    if tail != word {
+        return false;
+    }
+    let target_ns = if target_ns.is_empty() {
+        "::"
+    } else {
+        target_ns
+    };
+    let path = analysis
+        .namespace_paths
+        .get(namespace)
+        .map_or(&[][..], Vec::as_slice);
+    let in_scope: Vec<String> =
+        tcl_syntax::naming::command_resolution_candidates(namespace, path, word)
+            .into_iter()
+            .filter_map(|cand| {
+                cand.rsplit_once("::").map(|(prefix, _)| {
+                    if prefix.is_empty() {
+                        "::".to_owned()
+                    } else {
+                        prefix.to_owned()
+                    }
+                })
+            })
+            .collect();
+    let covered = analysis.namespace_imports.iter().any(|imp| {
+        in_scope.contains(&imp.ns)
+            && imp.pattern.rsplit_once("::").is_some_and(|(src, pat)| {
+                let src = if src.is_empty() { "::" } else { src };
+                same_namespace(src, target_ns) && tcl_syntax::glob::string_match(pat, word)
+            })
+    });
+    covered
+        && wildcard_import_source_namespace(analysis, namespace, word, call_off)
+            .is_none_or(|live| !same_namespace(&live, target_ns))
+}
+
+/// Namespace-name equality, ignoring the leading `::` one spelling carries and
+/// the other does not.
+fn same_namespace(a: &str, b: &str) -> bool {
+    a.trim_start_matches("::") == b.trim_start_matches("::")
 }
 
 /// Resolve the `(all_procs key, ProcDef)` that a proc-oriented editor
@@ -3641,6 +3781,121 @@ mod tests {
     }
 
     #[test]
+    fn a_global_rooted_import_is_export_gated_in_document_too() {
+        // TN / TP pair for #1104's review note — `namespace import ::p` reads
+        // as an *empty* source namespace, which both tiers skipped, leaving
+        // the last import shape that bypassed the gate. Oracle (8.6.14 /
+        // 9.0.4): without `namespace export p` at global level the import is a
+        // silent no-op and `info commands ::dst::*` stays empty; with it,
+        // `::dst::p` binds.
+        let ungated =
+            "proc p {} { return GLOBAL }\nnamespace eval dst {\n    namespace import ::p\n}\n";
+        let analysis = analyse(ungated);
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX).is_none(),
+            "an unexported global command installs nothing",
+        );
+        let gated = "proc p {} { return GLOBAL }\nnamespace export p\nnamespace eval dst {\n    namespace import ::p\n}\n";
+        let analysis = analyse(gated);
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX)
+                .is_some_and(|p| p.qualified_name == "::p"),
+            "with the export it binds",
+        );
+    }
+
+    // The same gate, as the **provider** answers it (issue #1104 item 2).
+    // Everything above drives `proc_visible_via_wildcard_import` directly
+    // because `resolve_called_proc`'s lenient tail match used to overrule it;
+    // these pin that it no longer does.
+
+    #[test]
+    fn single_file_definition_refuses_direction_b_through_the_fallback() {
+        // FP guard (CRITICAL), issue #1104 item 2 — the whole Direction-B
+        // fixture in one document. Oracle (8.6.14 / 9.0.4): the bare call is
+        // `invalid command name "p"` and `info commands ::dst::*` is empty, so
+        // go-to-definition must not answer `::src::p` — which it did, via
+        // `fallback_proc_by_simple_name`, long after #1102 gated every other
+        // route.
+        let src = "namespace eval src {\n    proc p {} { return P }\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval src {\n    namespace export p\n}\nnamespace eval dst {\n    p\n}\n";
+        let analysis = analyse(src);
+        let locs = definition(src, 10, 4, &analysis);
+        assert!(
+            locs.is_empty(),
+            "the lenient tail match must not overrule the import gate: {locs:?}"
+        );
+    }
+
+    #[test]
+    fn single_file_definition_still_answers_when_the_import_is_live() {
+        // TP — the same fixture with the export written *before* the import
+        // must still resolve, or the tightening has simply broken the feature.
+        let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval dst {\n    p\n}\n";
+        let analysis = analyse(src);
+        let locs = definition(src, 8, 4, &analysis);
+        assert_eq!(locs.len(), 1, "{locs:?}");
+        assert_eq!(locs[0].start_line, 1);
+    }
+
+    #[test]
+    fn the_tail_match_still_answers_where_no_import_names_that_namespace() {
+        // FN guard (CRITICAL) — the deliberate same-file leniency other tests
+        // pin: a proc whose defining namespace is not statically visible at
+        // the call still resolves. Nothing imports `::other` here, so the
+        // tightening must not touch it.
+        let src = "namespace eval other {\n    proc helper {} { return H }\n}\nnamespace eval dst {\n    helper\n}\n";
+        let analysis = analyse(src);
+        let locs = definition(src, 4, 4, &analysis);
+        assert_eq!(
+            locs.len(),
+            1,
+            "an unrelated same-file tail match must keep answering: {locs:?}"
+        );
+    }
+
+    #[test]
+    fn the_tail_match_still_answers_when_a_gated_import_names_another_namespace() {
+        // FN guard — the gate is scoped to the namespace the fallback answer
+        // lives in. A dead import of `::src` says nothing about a tail match
+        // landing in `::other`, so that one must survive.
+        let src = "namespace eval src {\n    proc helper {} { return S }\n}\nnamespace eval other {\n    proc helper2 {} { return O }\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval dst {\n    helper2\n}\n";
+        let analysis = analyse(src);
+        let locs = definition(src, 10, 4, &analysis);
+        assert_eq!(locs.len(), 1, "{locs:?}");
+        assert_eq!(locs[0].start_line, 4);
+    }
+
+    #[test]
+    fn the_tail_match_refuses_a_forgotten_import_too() {
+        // TN — the same tightening covers every way the route can be dead,
+        // not just the export snapshot: after `namespace forget ::src::p` the
+        // bare call is `invalid command name` (oracle on `alias_live_at`), so
+        // the fallback must not answer either.
+        let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval dst {\n    namespace forget ::src::p\n}\nnamespace eval dst {\n    p\n}\n";
+        let analysis = analyse(src);
+        let locs = definition(src, 11, 4, &analysis);
+        assert!(locs.is_empty(), "{locs:?}");
+    }
+
+    #[test]
+    fn the_tail_match_refuses_a_call_written_before_its_import() {
+        // TN — and the new call-site ordering (issue #1104 item 1) reaches the
+        // provider through the same door: the call above the import resolves
+        // nowhere, the one below it resolves.
+        let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval dst {\n    p\n}\n";
+        let analysis = analyse(src);
+        assert!(
+            definition(src, 5, 4, &analysis).is_empty(),
+            "the call before the import must not resolve",
+        );
+        assert_eq!(
+            definition(src, 11, 4, &analysis).len(),
+            1,
+            "the call after it must",
+        );
+    }
+
+    #[test]
     fn a_second_import_after_a_later_export_does_pick_the_name_up() {
         // TP — each import takes its own snapshot, so the *second* import,
         // written after the export, binds `q` even though the first could
@@ -3919,6 +4174,119 @@ mod tests {
         );
     }
 
+    // Behaviour 1b — the install is order-gated too (issue #1104 item 1).
+    //
+    // Oracle, byte-identical on tclsh 8.6.14 and 9.0.4:
+    //
+    //   namespace eval ::src { proc p {} {return P}; namespace export p }
+    //   namespace eval ::dst { p }                    → invalid command name "p"
+    //   namespace eval ::dst { namespace import ::src::* }
+    //   namespace eval ::dst { p }                    → P
+    //
+    //   namespace eval ::app { proc run {} { helper } }
+    //   namespace eval ::app { namespace import ::src::* }
+    //   ::app::run                                    → HELP
+    //
+    //   namespace eval ::app2 { proc run2 {} {
+    //       catch {helper} e ; namespace import ::src::* ; return "$e [helper]" } }
+    //   ::app2::run2       → {invalid command name "helper"} HELP
+
+    #[test]
+    fn a_top_level_call_before_its_own_import_resolves_nothing() {
+        // TN (the leniency #1102 deferred): both statements are top level, so
+        // the offsets are in genuine execution order.
+        let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\np\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
+        let analysis = analyse(src);
+        let call = at_first(src, "\np\n") + 1;
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", call);
+        assert!(
+            hit.is_none(),
+            "a call written before its own import reaches nothing: {hit:?}"
+        );
+        // TP — the same call after the import does resolve.
+        let after = after_last(src, "namespace import ::src::*\n}\n");
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, "dst", "p", after)
+                .is_some_and(|p| p.qualified_name == "::src::p"),
+        );
+    }
+
+    #[test]
+    fn a_body_local_call_sees_an_import_written_later_in_the_file() {
+        // TP (CRITICAL) — the gate is `in_effect`, not `at < call_off`: the
+        // whole file loads, imports included, before any body runs. This is
+        // the shape `tcllib`'s `modules/uev/uevent.tcl` is written in (procs
+        // first, `namespace import` at the bottom); a plain-offset gate broke
+        // every one of its call sites.
+        let src = "namespace eval src {\n    proc helper {} { return HELP }\n    namespace export helper\n}\nnamespace eval app {\n    proc run {} { helper }\n}\nnamespace eval app {\n    namespace import ::src::*\n}\n";
+        let analysis = analyse(src);
+        let call = at_first(src, "helper }");
+        let hit = proc_visible_via_wildcard_import(&analysis, "app", "helper", call);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::src::helper"),
+            "a body-local call observes its own file's later top-level import: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn a_call_before_an_import_in_that_same_body_resolves_nothing() {
+        // TN — the FN guard: an import written in the *same* body after the
+        // call is an ordinary later statement of the running script, exactly
+        // as the export snapshot already treats one.
+        let src = "namespace eval src {\n    proc helper {} { return HELP }\n    namespace export helper\n}\nnamespace eval app {\n    proc run {} { helper ; namespace import ::src::* ; helper }\n}\n";
+        let analysis = analyse(src);
+        let first = at_first(src, "helper ;");
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, "app", "helper", first).is_none(),
+            "the first call runs before the same body's import",
+        );
+        let second = after_last(src, "namespace import ::src::* ; ");
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, "app", "helper", second)
+                .is_some_and(|p| p.qualified_name == "::src::helper"),
+            "the second call runs after it",
+        );
+    }
+
+    #[test]
+    fn a_call_before_a_forced_import_is_not_shadowed_yet() {
+        // TP — the same gate through `ImportQuery::ForcedShadow`: a `-force`
+        // import has not replaced the local command until it runs, so a call
+        // written before it still reaches the local definition (oracle:
+        // `::dst::p` → LOCAL before the forced import, → SRC after).
+        let src = "namespace eval src {\n    proc p {} { return SRC }\n    namespace export p\n}\nnamespace eval dst {\n    proc p {} { return LOCAL }\n}\np\nnamespace eval dst {\n    namespace import -force ::src::*\n}\n";
+        let analysis = analyse(src);
+        let before = at_first(src, "\np\n") + 1;
+        assert!(
+            !forced_import_shadows(&analysis, "dst", "p", before),
+            "the shadow is not in effect before the forced import runs",
+        );
+        let after = after_last(src, "namespace import -force ::src::*\n}\n");
+        assert!(forced_import_shadows(&analysis, "dst", "p", after));
+    }
+
+    #[test]
+    fn a_later_conflicting_import_does_not_decide_an_earlier_call() {
+        // TP — the winning source is chosen from the installs already in
+        // effect, so a `-force` re-import from a different namespace written
+        // *after* the call cannot retarget it (oracle: with `::A` imported
+        // first, a call between the two imports runs `::A::p`).
+        let src = "namespace eval A {\n    proc p {} { return A }\n    namespace export p\n}\nnamespace eval B {\n    proc p {} { return B }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::A::*\n}\np\nnamespace eval dst {\n    namespace import -force ::B::*\n}\n";
+        let analysis = analyse(src);
+        let call = at_first(src, "\np\n") + 1;
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", call);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::A::p"),
+            "the call between the two imports takes the first edge: {hit:?}"
+        );
+        let after = after_last(src, "namespace import -force ::B::*\n}\n");
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, "dst", "p", after)
+                .is_some_and(|p| p.qualified_name == "::B::p"),
+            "…and a call after the forced re-import takes the second",
+        );
+    }
+
     // Behaviour 2 — `-force` / import-conflict semantics.
 
     #[test]
@@ -4108,6 +4476,50 @@ mod tests {
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::dst::p"),
             "after the forget the local definition is what the call reaches: {hit:?}"
+        );
+    }
+
+    // Behaviour 2b — what an *absent* export means for `-force`
+    // (issue #1116 item 1).
+
+    #[test]
+    fn a_forced_import_shadows_when_this_file_holds_no_export_for_the_source() {
+        // TP (CRITICAL) — the partly-observable source. `::src`'s proc is in
+        // this document, its `namespace export` is not, so the old
+        // "does this file hold *anything* of `::src`" test read the gap as
+        // "not exported" and single-file go-to-definition kept answering the
+        // local `::app::helper`. Oracle (8.6.14 / 9.0.4) with the export
+        // present anywhere in the program: `::app::helper` → SRC and
+        // `namespace origin ::app::helper` → `::src::helper`.
+        let src = "namespace eval src {\n    proc helper {} { return SRC }\n}\nnamespace eval app {\n    proc helper {} { return LOCAL }\n}\nnamespace eval app {\n    namespace import -force ::src::*\n}\nnamespace eval app {\n    helper\n}\n";
+        let analysis = analyse(src);
+        let call = after_last(src, "    helper\n");
+        assert!(
+            forced_import_shadows(&analysis, "::app", "helper", call),
+            "a `-force` import of a namespace whose exports this file cannot \
+             see must presume the shadow",
+        );
+        assert!(
+            resolve_called_proc(&analysis, src, "::app", "helper", call, None).is_none(),
+            "…and the local definition the import deleted must not be the answer",
+        );
+    }
+
+    #[test]
+    fn a_forced_import_does_not_shadow_when_this_file_holds_the_export_list() {
+        // TN / FP guard — with an export declaration for `::src` in this
+        // document the gap *is* evidence: `helper` is not among what `::src`
+        // exports, so the forced import installs nothing and the local
+        // definition is still what the call reaches (oracle: with only
+        // `namespace export other`, `::app::helper` → LOCAL).
+        let src = "namespace eval src {\n    proc helper {} { return SRC }\n    proc other {} { return O }\n    namespace export other\n}\nnamespace eval app {\n    proc helper {} { return LOCAL }\n}\nnamespace eval app {\n    namespace import -force ::src::*\n}\nnamespace eval app {\n    helper\n}\n";
+        let analysis = analyse(src);
+        let call = after_last(src, "    helper\n");
+        assert!(!forced_import_shadows(&analysis, "::app", "helper", call));
+        let hit = resolve_called_proc(&analysis, src, "::app", "helper", call, None);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::app::helper"),
+            "the local definition survives an import that binds nothing: {hit:?}"
         );
     }
 

--- a/rust/tcl-lsp-core/src/namespace_import.rs
+++ b/rust/tcl-lsp-core/src/namespace_import.rs
@@ -210,6 +210,63 @@ pub fn exported_at_import_site(
     ordered_match || unordered_match
 }
 
+/// The **load-order** position of a statement in its own document: `false`
+/// (load level) sorts before `true` (inside a proc/class body), and within
+/// each tier by byte offset. `load_order(a) < load_order(b)` reads "a had
+/// definitely already run when b ran".
+///
+/// # Why the import-conflict rule needs its own order
+///
+/// [`alias_live_at`]'s query point is a *call*, and its ordering primitive is
+/// [`tcl_compiler::analyser::indirection::in_effect_within`], which is
+/// deliberately **lenient**: an event in some other proc's body counts as
+/// having run, because whether that proc was called is not statically
+/// decidable. For a removal that is the safe direction — the conservative
+/// answer is that the alias may be gone.
+///
+/// The conflict question inverts the sign. A conflict *cancels an install*, so
+/// the same leniency invents conflicts and drops aliases the program really
+/// has: applied to
+/// `namespace eval ::dst {proc p {} {namespace import ::B::x}}` followed by a
+/// top-level `namespace import ::A::*`, it makes each import cancel the other
+/// and the name resolves nowhere, where real Tcl binds `::A::x`. What the
+/// conflict rule needs is the *strict* reading — "did this definitely already
+/// run" — which is exactly load order:
+///
+/// | event | query | ran before? |
+/// |---|---|---|
+/// | load level | load level | by offset |
+/// | load level | inside a body | **yes**, wherever written — the file loads first |
+/// | inside a body | load level | **no** — that body may never run |
+/// | same body | same body | by offset |
+///
+/// Two statements in *different* bodies have no static order at all; they keep
+/// their offset order, which is what both tiers did before and what the
+/// enclosing abstentions already assume.
+///
+/// Both tiers order conflicts through this one function — the same-document
+/// resolver by sorting its slot log with it (`definition::slot_events`), the
+/// cross-document one by comparing two sites with it
+/// (`WildcardImportIndex::conflicting_alias_at`) — so neither can drift from
+/// the other, exactly as they share [`exported_at_import_site`] and
+/// [`alias_live_at`].
+///
+/// Oracle for every row, byte-identical on tclsh 8.6.14 and 9.0.4:
+///
+/// ```tcl
+/// namespace eval ::A { proc x {} {return A}; namespace export x }
+/// namespace eval ::B { proc x {} {return B}; namespace export x }
+/// namespace eval ::dst { proc p {} { namespace import ::B::x } }
+/// namespace eval ::dst { namespace import ::A::* }
+/// namespace origin ::dst::x   ;# → ::A::x
+/// ::dst::p                    ;# → can't import command "x": already exists
+/// namespace origin ::dst::x   ;# → ::A::x   (unchanged)
+/// ```
+#[must_use]
+pub fn load_order(at: u32, body_local: bool) -> (bool, u32) {
+    (body_local, at)
+}
+
 /// What one lifecycle event does to an import edge — see [`AliasEvent`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AliasEventKind {
@@ -501,6 +558,38 @@ mod tests {
     fn no_events_means_not_exported() {
         let mut evs = [].into_iter();
         assert!(!exported_at_import_site(&mut evs, "p", &before(20)));
+    }
+
+    // ---- load order, for the conflict rule --------------------------------
+
+    #[test]
+    fn load_order_is_the_strict_did_this_already_run_relation() {
+        const LOAD: bool = false;
+        const BODY: bool = true;
+        let ran_before =
+            |e: (u32, bool), q: (u32, bool)| load_order(e.0, e.1) < load_order(q.0, q.1);
+        // Two load-level statements: plain offset order.
+        assert!(ran_before((10, LOAD), (20, LOAD)));
+        assert!(!ran_before((20, LOAD), (10, LOAD)));
+        // A load-level statement runs before *any* body, however far below it
+        // is written — the whole file loads before any body runs.
+        assert!(ran_before((900, LOAD), (10, BODY)));
+        assert!(ran_before((10, LOAD), (900, BODY)));
+        // …and a body-local statement never counts as having run at load
+        // level, because that body may never be entered. This is where the
+        // lenient `in_effect_within` differs, and why the conflict rule
+        // cannot use it: it would invent a conflict and drop a real alias.
+        assert!(!ran_before((10, BODY), (900, LOAD)));
+        assert!(tcl_compiler::analyser::indirection::in_effect_within(
+            10, 900, None
+        ));
+        // Inside one body the offsets are genuine execution order again.
+        assert!(ran_before((10, BODY), (20, BODY)));
+        assert!(!ran_before((20, BODY), (10, BODY)));
+        // Nothing runs before itself — which is what excludes an import from
+        // conflicting with itself, at either level.
+        assert!(!ran_before((10, LOAD), (10, LOAD)));
+        assert!(!ran_before((10, BODY), (10, BODY)));
     }
 
     // ---- the import edge's own lifecycle (issue #1103) -------------------

--- a/rust/tcl-lsp-core/src/namespace_import.rs
+++ b/rust/tcl-lsp-core/src/namespace_import.rs
@@ -281,34 +281,46 @@ pub struct AliasEvent {
 /// unordered removal revokes nothing, exactly as an unordered `-clear` does
 /// not revoke an export.
 ///
-/// # What `removal_in_effect` does and does not gate
+/// # What `in_effect` gates
 ///
-/// `removal_in_effect` decides, for a **removal** at the given offset,
-/// whether it had already run at the query point. Both tiers pass the
-/// order-gating primitive they already use for the export snapshot
+/// `in_effect` decides, for an ordered event at the given offset, whether it
+/// had already run at the query point — and it is applied to **every** ordered
+/// event, install and removal alike. Both tiers pass the order-gating
+/// primitive they already use for the export snapshot
 /// ([`tcl_compiler::analyser::indirection::in_effect`] /
 /// [`tcl_compiler::analyser::indirection::in_effect_within`]), so "has run by
 /// here" cannot mean two things.
 ///
-/// It deliberately does **not** filter installs. Whether a bare call written
-/// *before* its own `namespace import` should stop resolving is a separate,
-/// still-open leniency (issue #1104 item 1: the workspace tier has no
-/// call-site body span to apply the identical rule with, so gating only
-/// in-document would make the two tiers disagree — the divergence the shared
-/// decision function exists to prevent). Installs still carry their offsets,
-/// because a removal revokes only the installs *before* it; they are simply
-/// not dropped for being later than the call.
+/// Gating the *install* is what makes a bare call written **before** its own
+/// `namespace import` stop resolving through it (issue #1104 item 1). Oracle
+/// (tclsh 8.6.14 / 9.0.4, byte-identical):
 ///
-/// With no install at all the answer is `false`: nothing put the alias there.
-/// Callers that have already proven an import matches (pattern, export
-/// snapshot, conflict rule) pass it as an [`AliasEventKind::Install`].
+/// ```tcl
+/// namespace eval ::src { proc p {} {return P}; namespace export p }
+/// namespace eval ::dst { p }                    ;# → invalid command name "p"
+/// namespace eval ::dst { namespace import ::src::* }
+/// namespace eval ::dst { p }                    ;# → P
+/// ```
+///
+/// That gate is *not* a plain offset comparison, and must not be reduced to
+/// one: a call inside a proc body is not ordered against a top-level import of
+/// the same file at all, because the whole file loads — running every
+/// top-level statement, imports included — before any body runs. `in_effect` /
+/// `in_effect_within` already state exactly that rule, which is why both tiers
+/// pass one of them rather than `at < call_off`. A tier that compared offsets
+/// alone would drop every proc body calling a name imported further down its
+/// own file — the overwhelmingly common shape in real code.
+///
+/// With no install in effect the answer is `false`: nothing had put the alias
+/// there yet. Callers that have already proven an import matches (pattern,
+/// export snapshot, conflict rule) pass it as an [`AliasEventKind::Install`].
 ///
 /// Single pass, two running maxima, no allocation — the same shape and the
 /// same cost as [`exported_at_import_site`], which it runs beside.
 #[must_use]
 pub fn alias_live_at(
     events: &mut dyn Iterator<Item = AliasEvent>,
-    removal_in_effect: &dyn Fn(u32) -> bool,
+    in_effect: &dyn Fn(u32) -> bool,
 ) -> bool {
     let mut installed: Option<u32> = None;
     let mut removed: Option<u32> = None;
@@ -318,13 +330,12 @@ pub fn alias_live_at(
             unordered_install |= ev.kind == AliasEventKind::Install;
             continue;
         };
+        if !in_effect(at) {
+            continue;
+        }
         match ev.kind {
             AliasEventKind::Install => installed = installed.max(Some(at)),
-            AliasEventKind::Remove => {
-                if removal_in_effect(at) {
-                    removed = removed.max(Some(at));
-                }
-            }
+            AliasEventKind::Remove => removed = removed.max(Some(at)),
         }
     }
     let ordered_live = installed.is_some_and(|i| removed.is_none_or(|r| i > r));
@@ -512,7 +523,7 @@ mod tests {
         AliasEvent { kind, at: None }
     }
 
-    /// `removal_in_effect` for a call at `call_at`: plain textual order.
+    /// `in_effect` for a call at `call_at`: plain textual order.
     fn ran_before(call_at: u32) -> impl Fn(u32) -> bool {
         move |at| at < call_at
     }
@@ -558,15 +569,37 @@ mod tests {
     }
 
     #[test]
-    fn an_install_later_than_the_call_still_counts() {
-        // Whether a call written *before* its own import resolves is #1104
-        // item 1's still-open leniency: this function must not decide it, so
-        // an install at 30 with the call at 20 still installs.
+    fn an_install_later_than_the_call_has_not_run_yet() {
+        // #1104 item 1: a bare call written *before* its own `namespace
+        // import` reaches nothing (oracle in the function's docs), so an
+        // install at 30 with the call at 20 does not install here.
         let mut evs = [install(30)].into_iter();
+        assert!(!alias_live_at(&mut evs, &ran_before(20)));
+        // The earlier install is the one that counts, and a removal between
+        // the two still kills it.
+        let mut evs = [install(5), install(30)].into_iter();
         assert!(alias_live_at(&mut evs, &ran_before(20)));
-        // …but a removal between them is still a removal.
-        let mut evs = [install(30), remove(10)].into_iter();
-        assert!(alias_live_at(&mut evs, &ran_before(20)));
+        let mut evs = [install(5), remove(10), install(30)].into_iter();
+        assert!(!alias_live_at(&mut evs, &ran_before(20)));
+    }
+
+    #[test]
+    fn a_body_local_call_observes_a_later_top_level_install() {
+        // The install gate is `in_effect`, not `at < call_off`: a call inside
+        // a proc body at 20 sees a top-level import at 30, because the whole
+        // file loads before any body runs. Modelled here by the predicate the
+        // real callers pass.
+        let body = tcl_lexer::Span::new(15, 25);
+        let mut evs = [install(30)].into_iter();
+        assert!(alias_live_at(&mut evs, &|at| {
+            tcl_compiler::analyser::indirection::in_effect_within(at, 20, Some(body))
+        }));
+        // …but an install written inside that same body after the call is an
+        // ordinary later statement of the running script.
+        let mut evs = [install(22)].into_iter();
+        assert!(!alias_live_at(&mut evs, &|at| {
+            tcl_compiler::analyser::indirection::in_effect_within(at, 20, Some(body))
+        }));
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -274,6 +274,21 @@ pub struct WorkspaceInvocation {
     /// the rename providers must abstain for the whole symbol rather than
     /// leave the site dispatching the old name (issue #945 fault 1).
     pub rename_safe: bool,
+    /// Span of the innermost proc/class **body** containing this call site,
+    /// within [`Self::uri`]; `None` when the call sits at load level.
+    ///
+    /// The call-side twin of [`WorkspaceGlobImport::enclosing_body`], and for
+    /// the same reason: ordering an import edge's events against a call is
+    /// [`tcl_compiler::analyser::indirection::in_effect_within`], not an
+    /// offset compare, because the whole file loads before any body runs.
+    /// Carried per row so [`WorkspaceIndex::invocation_resolves_to`] — which
+    /// has no calling-document `AnalysisResult` in hand — can build a complete
+    /// [`CallSite`] (issue #1116 item 3).
+    ///
+    /// The naive per-row lookup would be `O(procs × invocations)`;
+    /// [`WorkspaceIndex::enclosing_body_spans`] computes the whole column in
+    /// one stack sweep instead, `O((P + I) log (P + I))` per document.
+    pub enclosing_body: Option<Span>,
 }
 
 /// One **namespace-qualified** variable declaration recorded in the index —
@@ -853,9 +868,15 @@ impl WorkspaceIndex {
                             // a same-source re-import is a silent no-op, and
                             // two links cancelling each other out is what the
                             // different-source test rules out.
+                            let importing_ns = importing_namespace_of(&l.linked_qname);
                             if !g.forced
                                 && (self.defines_command(&l.linked_qname)
-                                    || self.earlier_conflicting_link(l))
+                                    || wci.conflicting_alias_at(
+                                        importing_ns,
+                                        &g.source_ns,
+                                        &g.name,
+                                        g.site(&l.uri),
+                                    ))
                             {
                                 return false;
                             }
@@ -863,10 +884,6 @@ impl WorkspaceIndex {
                             // again: `namespace forget`, a redefinition of the
                             // imported name, or destruction of the source
                             // command (issue #1116 finding 2).
-                            let importing_ns = l
-                                .linked_qname
-                                .rsplit_once("::")
-                                .map_or("::", |(ns, _)| if ns.is_empty() { "::" } else { ns });
                             wci.link_alias_live(importing_ns, g, &l.uri)
                         })
                     })
@@ -887,32 +904,6 @@ impl WorkspaceIndex {
     /// Deliberately *not* [`Self::workspace_command_exists`], which also
     /// admits linked names: a link is what this question is being asked
     /// about, so counting one would make an import conflict with itself.
-    /// Whether another **exact** import link in the same document installs
-    /// the same name from a *different* source before this one — the live
-    /// alias a non-`-force` import conflicts with (issue #1116 finding 4).
-    ///
-    /// Oracle (9.0.4 / 8.6.14): with `::dst` already importing `::A::p`, a
-    /// later `namespace import ::B::p` raises `can't import command "p":
-    /// already exists` and leaves `namespace origin ::dst::p` → `::A::p`.
-    ///
-    /// Restricted to one document because that is where an order exists: two
-    /// imports in different files have none, and conflicting on a guess would
-    /// drop a link Tcl really installed. A **same-source** re-import is a
-    /// silent no-op (oracle), so it is not a conflict — which is also what
-    /// stops a link from conflicting with itself.
-    fn earlier_conflicting_link(&self, link: &WorkspaceCommandLink) -> bool {
-        self.command_links.iter().any(|other| {
-            other.uri == link.uri
-                && other.linked_qname == link.linked_qname
-                && other.target_qname != link.target_qname
-                && other
-                    .import_gate
-                    .as_ref()
-                    .zip(link.import_gate.as_ref())
-                    .is_some_and(|(o, l)| o.at < l.at)
-        })
-    }
-
     fn defines_command(&self, qualified_name: &str) -> bool {
         let target = qualified_name.trim_start_matches("::");
         self.procs
@@ -1025,7 +1016,15 @@ impl WorkspaceIndex {
         }
         self.index_variables(uri, analysis);
         self.index_namespace_refs(uri, analysis);
-        for inv in &analysis.command_invocations {
+        let bodies = Self::enclosing_body_spans(
+            analysis,
+            &analysis
+                .command_invocations
+                .iter()
+                .map(|inv| inv.range.start())
+                .collect::<Vec<_>>(),
+        );
+        for (inv, enclosing_body) in analysis.command_invocations.iter().zip(bodies) {
             self.invocations.push(WorkspaceInvocation {
                 uri: uri.to_owned(),
                 name: inv.name.clone(),
@@ -1033,6 +1032,7 @@ impl WorkspaceIndex {
                 range: inv.range,
                 indirect: inv.indirect,
                 rename_safe: inv.rename_safe,
+                enclosing_body,
             });
         }
         for target in &analysis.source_targets {
@@ -1061,6 +1061,53 @@ impl WorkspaceIndex {
         }
         self.index_import_lifecycle(uri, analysis);
         self.index_command_links(uri, analysis);
+    }
+
+    /// [`tcl_compiler::analyser::AnalysisResult::innermost_definition_body_span`]
+    /// for a whole column of offsets at once, in the order they were given.
+    ///
+    /// That single-offset lookup scans every recorded proc and class body, so
+    /// calling it once per invocation is `O(procs × invocations)` — the cost
+    /// that kept a per-call body span out of the index (issue #1116 item 3).
+    /// It is not the cost the answer actually needs: definition bodies are
+    /// syntactic, so they **nest properly** — no two of them partially overlap
+    /// — which means one pass over the bodies in start order, keeping the
+    /// currently-open chain on a stack, yields the innermost body of every
+    /// offset in increasing order. Sorting both sides makes the whole column
+    /// `O((P + I) log (P + I))` instead, small beside the analysis that
+    /// produced them.
+    ///
+    /// Ties in `start` are ordered by *longer first*, so a body sharing its
+    /// start with a nested one is pushed before its child and the stack top
+    /// stays the innermost.
+    fn enclosing_body_spans(analysis: &AnalysisResult, offsets: &[u32]) -> Vec<Option<Span>> {
+        let mut bodies: Vec<Span> = analysis
+            .all_procs
+            .values()
+            .map(|p| p.body_span)
+            .chain(analysis.all_classes.values().map(|c| c.body_span))
+            .collect();
+        if bodies.is_empty() {
+            return vec![None; offsets.len()];
+        }
+        bodies.sort_unstable_by_key(|s| (s.start(), std::cmp::Reverse(s.end())));
+        let mut order: Vec<usize> = (0..offsets.len()).collect();
+        order.sort_unstable_by_key(|&i| offsets[i]);
+        let mut out = vec![None; offsets.len()];
+        let mut open: Vec<Span> = Vec::new();
+        let mut next = 0usize;
+        for i in order {
+            let off = offsets[i];
+            while next < bodies.len() && bodies[next].start() <= off {
+                open.push(bodies[next]);
+                next += 1;
+            }
+            while open.last().is_some_and(|b| b.end() <= off) {
+                open.pop();
+            }
+            out[i] = open.last().copied();
+        }
+        out
     }
 
     /// Lift a document's `namespace forget` events and command **destructions**
@@ -1169,13 +1216,11 @@ impl WorkspaceIndex {
         // invocation actually writes (issue #923 idx 18).
         for imp in &analysis.namespace_imports {
             if imp.pattern.contains(['*', '?', '[']) {
-                if let Some((source_ns, tail_pattern)) = imp.pattern.rsplit_once("::")
-                    && !source_ns.is_empty()
-                {
+                if let Some((source_ns, tail_pattern)) = imp.pattern.rsplit_once("::") {
                     self.glob_imports.push(WorkspaceGlobImport {
                         uri: uri.to_owned(),
                         ns: imp.ns.clone(),
-                        source_ns: source_ns.to_owned(),
+                        source_ns: global_rooted(source_ns).to_owned(),
                         tail_pattern: tail_pattern.to_owned(),
                         at: imp.range.start(),
                         enclosing_body: analysis.innermost_definition_body_span(imp.range.start()),
@@ -1190,19 +1235,25 @@ impl WorkspaceIndex {
             // An exact import is export-gated exactly like a glob one — real
             // Tcl silently installs nothing when the name is not exported at
             // the import's own position (issue #1027; oracle on
-            // `WorkspaceCommandLink::import_gate`). Two shapes stay ungated:
-            // a pattern with no source namespace (`namespace import ::p` —
-            // the same empty-`source_ns` case the glob branch above skips),
-            // and a *conjectured* import, which is inferred from a tcllib
+            // `WorkspaceCommandLink::import_gate`). One shape stays ungated:
+            // a *conjectured* import, which is inferred from a tcllib
             // `<NS>::import <ALIAS>` wrapper rather than read off a real
             // `namespace import` word, so there is no export declaration for
             // it to have passed and gating it would drop the idiom entirely.
+            //
+            // A pattern rooted at the global namespace (`namespace import
+            // ::p`) is **not** one of them, though it reads as an empty
+            // source namespace and both tiers used to skip it on that basis —
+            // the last import shape bypassing the gate (#1104's review note).
+            // Real Tcl treats it like any other unexported import: a silent
+            // no-op leaving `info commands ::dst::*` empty (oracle 8.6.14 /
+            // 9.0.4). `::` is its source namespace, the same spelling every
+            // global-level `namespace export` record already carries.
             let import_gate = (!imp.conjectured)
                 .then(|| imp.pattern.rsplit_once("::"))
                 .flatten()
-                .filter(|(source_ns, _)| !source_ns.is_empty())
                 .map(|(source_ns, _)| WorkspaceImportGate {
-                    source_ns: source_ns.to_owned(),
+                    source_ns: global_rooted(source_ns).to_owned(),
                     name: tail.to_owned(),
                     at: imp.range.start(),
                     enclosing_body: analysis.innermost_definition_body_span(imp.range.start()),
@@ -2296,6 +2347,7 @@ impl WorkspaceIndex {
                     CallSite {
                         uri: &inv.uri,
                         at: inv.range.start(),
+                        enclosing_body: inv.enclosing_body,
                     },
                     wci,
                 )
@@ -2592,7 +2644,7 @@ impl WorkspaceIndex {
         let mut current = ns.to_owned();
         for _ in 0..tcl_compiler::analyser::indirection::MAX_COMMAND_NAME_HOPS {
             let hop = self.import_hop(&current, word, call, wci)?;
-            let target = format!("{hop}::{word}");
+            let target = tcl_syntax::naming::qualify(&hop, word);
             if self.workspace_command_exists(&target) {
                 return Some(target);
             }
@@ -2639,7 +2691,7 @@ impl WorkspaceIndex {
             .filter(|imp| wci.exports_name_at(&imp.source_ns, word, imp.site()))
             .filter(|imp| {
                 imp.forced
-                    || !(self.defines_command(&format!("{ns}::{word}"))
+                    || !(self.defines_command(&tcl_syntax::naming::qualify(ns, word))
                         || wci.conflicting_alias_at(ns, &imp.source_ns, word, imp.site()))
             })
             .filter(|imp| wci.alias_live_at(ns, &imp.source_ns, word, imp.site(), call))
@@ -2655,6 +2707,12 @@ impl WorkspaceIndex {
 /// [`WorkspaceIndex::resolve_wildcard_import_indexed`]'s doc for why.
 struct WildcardImportIndex<'a> {
     imports_by_ns: std::collections::HashMap<&'a str, Vec<&'a WorkspaceGlobImport>>,
+    /// Every **exact** `namespace import` link, by importing namespace, as
+    /// `(document, gate)`. The exact-pattern twin of [`Self::imports_by_ns`]:
+    /// the two tables are one command table as far as the import-conflict rule
+    /// is concerned, which is why [`Self::conflicting_alias_at`] reads both
+    /// (issue #1116 item 7).
+    exact_by_ns: std::collections::HashMap<&'a str, Vec<(&'a str, &'a WorkspaceImportGate)>>,
     exports_by_ns: std::collections::HashMap<&'a str, Vec<&'a WorkspaceNamespaceExport>>,
     forgets_by_ns: std::collections::HashMap<&'a str, Vec<&'a WorkspaceNamespaceForget>>,
     deletions_by_name: std::collections::HashMap<&'a str, Vec<&'a WorkspaceCommandDeletion>>,
@@ -2671,6 +2729,16 @@ impl<'a> WildcardImportIndex<'a> {
             std::collections::HashMap::new();
         for imp in &index.glob_imports {
             imports_by_ns.entry(imp.ns.as_str()).or_default().push(imp);
+        }
+        let mut exact_by_ns: std::collections::HashMap<&str, Vec<(&str, &WorkspaceImportGate)>> =
+            std::collections::HashMap::new();
+        for link in &index.command_links {
+            if let Some(gate) = link.import_gate.as_ref() {
+                exact_by_ns
+                    .entry(importing_namespace_of(&link.linked_qname))
+                    .or_default()
+                    .push((link.uri.as_str(), gate));
+            }
         }
         let mut exports_by_ns: std::collections::HashMap<&str, Vec<&WorkspaceNamespaceExport>> =
             std::collections::HashMap::new();
@@ -2717,6 +2785,7 @@ impl<'a> WildcardImportIndex<'a> {
         }
         Self {
             imports_by_ns,
+            exact_by_ns,
             exports_by_ns,
             forgets_by_ns,
             deletions_by_name,
@@ -2806,12 +2875,17 @@ impl<'a> WildcardImportIndex<'a> {
     /// happened to be the larger one. Unordered, the shared function keeps the
     /// alias — the same direction every other cross-file event takes here.
     ///
-    /// Within one document the comparison is a plain offset test rather than
-    /// [`tcl_compiler::analyser::indirection::in_effect_within`], because the
-    /// index does not store a *call site's* enclosing body span — only an
-    /// import's. That can only make a removal look not-yet-run, i.e. keep
-    /// answering, which is the abstention direction navigation wants; it can
-    /// never invent a removal and drop a live alias.
+    /// Within one document the comparison is
+    /// [`tcl_compiler::analyser::indirection::in_effect_within`] — the
+    /// *identical* rule the same-document tier applies — stated over the
+    /// call's own offset and enclosing body span ([`CallSite`]). A plain
+    /// offset test is not good enough in either direction: it would leave a
+    /// body-local call resolving through a top-level `namespace forget`
+    /// written before it (issue #1116 item 3, the lenient direction), and,
+    /// now that installs are order-gated too (issue #1104 item 1), it would
+    /// drop the alias of every proc body calling a name its own file imports
+    /// further down (the *un*safe direction, which is why the span became a
+    /// required [`CallSite`] field rather than an optional refinement).
     fn alias_live_at(
         &self,
         importing_ns: &str,
@@ -2831,17 +2905,35 @@ impl<'a> WildcardImportIndex<'a> {
                     (d.uri == call.uri).then_some(d.at)
                 }),
             );
-        crate::namespace_import::alias_live_at(&mut events, &|at| at < call.at)
+        crate::namespace_import::alias_live_at(&mut events, &|at| {
+            tcl_compiler::analyser::indirection::in_effect_within(at, call.at, call.enclosing_body)
+        })
     }
 
     /// Whether `ns` already holds a live alias for `name` from a namespace
     /// other than `source_ns` when the import at `site` runs — the conflict a
     /// non-`-force` `namespace import` aborts on (issue #1116 finding 4).
     ///
+    /// Oracle (9.0.4 / 8.6.14): with `::dst` already importing `p` from `::A`,
+    /// a later unforced import of `p` from `::B` raises `can't import command
+    /// "p": already exists` and leaves `namespace origin ::dst::p` → `::A::p`.
+    ///
+    /// **Both spellings of an import count on both sides** (issue #1116 item
+    /// 7). Tcl installs one alias per name; whether the import that installed
+    /// it was written as a glob or as an exact pattern is a fact about the
+    /// *source text*, not about the command table. The index splits them —
+    /// a glob pattern names no single command, so it becomes a
+    /// [`WorkspaceGlobImport`] consulted per call, while an exact one becomes
+    /// a fixed [`WorkspaceCommandLink`] — and asking each side only about its
+    /// own kind made the conflict rule directional: a glob import that had
+    /// already bound the name did not conflict with a later exact import of
+    /// it. One function, both tables, so neither caller can drift.
+    ///
     /// Ordered within the import's own document only: two imports in
     /// different files have no static load order, and conflicting on a guess
     /// would drop an alias Tcl really installed. A **same-source** re-import
-    /// is a silent no-op (oracle), never a conflict.
+    /// is a silent no-op (oracle), never a conflict — which is also what stops
+    /// an import from conflicting with itself.
     fn conflicting_alias_at(
         &self,
         ns: &str,
@@ -2849,28 +2941,35 @@ impl<'a> WildcardImportIndex<'a> {
         name: &str,
         site: ImportSite<'_>,
     ) -> bool {
-        self.imports_by_ns
+        let call = CallSite {
+            uri: site.uri,
+            at: site.at,
+            enclosing_body: site.enclosing_body,
+        };
+        let mut earlier = self
+            .imports_by_ns
             .get(ns)
             .map(Vec::as_slice)
             .unwrap_or_default()
             .iter()
-            .any(|other| {
-                other.uri == site.uri
-                    && other.at < site.at
-                    && other.source_ns != source_ns
-                    && tcl_syntax::glob::string_match(&other.tail_pattern, name)
-                    && self.exports_name_at(&other.source_ns, name, other.site())
-                    && self.alias_live_at(
-                        ns,
-                        &other.source_ns,
-                        name,
-                        other.site(),
-                        CallSite {
-                            uri: site.uri,
-                            at: site.at,
-                        },
-                    )
-            })
+            .filter(|other| tcl_syntax::glob::string_match(&other.tail_pattern, name))
+            .map(|other| (other.source_ns.as_str(), other.site()))
+            .chain(
+                self.exact_by_ns
+                    .get(ns)
+                    .map(Vec::as_slice)
+                    .unwrap_or_default()
+                    .iter()
+                    .filter(|(_, gate)| gate.name == name)
+                    .map(|(uri, gate)| (gate.source_ns.as_str(), gate.site(uri))),
+            );
+        earlier.any(|(other_source, other_site)| {
+            other_site.uri == site.uri
+                && other_site.at < site.at
+                && !ns_eq(other_source, source_ns)
+                && self.exports_name_at(other_source, name, other_site)
+                && self.alias_live_at(ns, other_source, name, other_site, call)
+        })
     }
 
     /// Whether an **exact** import link is still installed, with no call site
@@ -2885,7 +2984,7 @@ impl<'a> WildcardImportIndex<'a> {
     ///
     /// The question a link answers is "does this alias exist for navigation",
     /// which has no query point of its own, so every recorded removal counts
-    /// as having run (`removal_in_effect` is unconditionally true) and the
+    /// as having run (the order predicate is unconditionally true) and the
     /// ordering that remains is the removal's position relative to the
     /// **import**:
     ///
@@ -2951,6 +3050,31 @@ impl<'a> WildcardImportIndex<'a> {
     }
 }
 
+/// The namespace an imported name is installed *into*, read off the link's
+/// `linked_qname` (`::app::helper` → `::app`, a global-level import → `::`).
+fn importing_namespace_of(linked_qname: &str) -> &str {
+    linked_qname
+        .rsplit_once("::")
+        .map_or("::", |(ns, _)| if ns.is_empty() { "::" } else { ns })
+}
+
+/// The source namespace an import pattern names, reading the empty prefix a
+/// global-rooted pattern (`::p`, `::*`) splits to as the global namespace it
+/// actually is (#1104's review note).
+fn global_rooted(source_ns: &str) -> &str {
+    if source_ns.is_empty() {
+        "::"
+    } else {
+        source_ns
+    }
+}
+
+/// Namespace-name equality, ignoring a leading `::` one spelling carries and
+/// the other does not.
+fn ns_eq(a: &str, b: &str) -> bool {
+    a.trim_start_matches("::") == b.trim_start_matches("::")
+}
+
 /// Where a `namespace import` sits, as the export-snapshot gate needs to see
 /// it: the document, the offset, and the innermost proc/class body containing
 /// it (`None` at load level).
@@ -2976,16 +3100,31 @@ struct ImportSite<'a> {
 /// the call's own position, which
 /// [`WorkspaceIndex::resolve_wildcard_import`] previously never received.
 ///
-/// Carries no enclosing-body span: the index stores one per *import* row, not
-/// per invocation, and building it per call would be O(procs × invocations)
-/// at index time. See [`WildcardImportIndex::alias_live_at`] for why its
-/// absence can only make this abstain toward answering.
+/// Carries the call's own **enclosing body span** as well, for the same reason
+/// [`WorkspaceGlobImport::enclosing_body`] exists on the import side: ordering
+/// an import against a call is not a plain offset compare. A call inside a
+/// proc body observes every top-level statement of its own file, wherever
+/// written, because the whole file loads before any body runs — so a body-local
+/// call of a name imported further down the same file still resolves, and a
+/// top-level `namespace forget` written after such a body does revoke it
+/// (issue #1116 item 3). Comparing offsets alone got the first wrong the
+/// moment installs became order-gated (issue #1104 item 1), which is why the
+/// span is no longer optional to supply.
+///
+/// `None` means "top level" — the same encoding
+/// [`tcl_compiler::analyser::AnalysisResult::innermost_definition_body_span`]
+/// uses, which is where every producer gets it: directly for a caller holding
+/// the calling document's analysis, and from
+/// [`WorkspaceInvocation::enclosing_body`] for the index-driven sweep.
 #[derive(Debug, Clone, Copy)]
 pub struct CallSite<'a> {
     /// Document the call is in.
     pub uri: &'a str,
     /// Byte offset of the call's command-head token within `uri`.
     pub at: u32,
+    /// Span of the innermost proc/class **body** containing the call, within
+    /// `uri`; `None` when the call sits at load level.
+    pub enclosing_body: Option<Span>,
 }
 
 #[cfg(test)]
@@ -3130,7 +3269,17 @@ mod tests {
     }
 
     fn call_from(uri: &str) -> CallSite<'_> {
-        CallSite { uri, at: u32::MAX }
+        call_at(uri, u32::MAX)
+    }
+
+    /// A **top-level** call site at `at` in `uri` — the shape every ordering
+    /// test below uses, since a load-level call carries no enclosing body.
+    fn call_at(uri: &str, at: u32) -> CallSite<'_> {
+        CallSite {
+            uri,
+            at,
+            enclosing_body: None,
+        }
     }
 
     #[test]
@@ -3906,10 +4055,7 @@ mod tests {
         let resolved = index.resolve_wildcard_import(
             "helper",
             &["::app::helper".to_string(), "::helper".to_string()],
-            CallSite {
-                uri: "file:///app.tcl",
-                at: call,
-            },
+            call_at("file:///app.tcl", call),
         );
         assert!(
             resolved.is_none(),
@@ -3932,10 +4078,7 @@ mod tests {
         let resolved = index.resolve_wildcard_import(
             "helper",
             &["::app::helper".to_string(), "::helper".to_string()],
-            CallSite {
-                uri: "file:///app.tcl",
-                at: call,
-            },
+            call_at("file:///app.tcl", call),
         );
         assert_eq!(resolved.as_deref(), Some("::mymod::helper"));
     }
@@ -3980,10 +4123,7 @@ mod tests {
         let resolved = index.resolve_wildcard_import(
             "helper",
             &["::app::helper".to_string(), "::helper".to_string()],
-            CallSite {
-                uri: "file:///app.tcl",
-                at: call,
-            },
+            call_at("file:///app.tcl", call),
         );
         assert!(resolved.is_none(), "{resolved:?}");
     }
@@ -4004,10 +4144,7 @@ mod tests {
         let resolved = index.resolve_wildcard_import(
             "helper",
             &["::app::helper".to_string(), "::helper".to_string()],
-            CallSite {
-                uri: "file:///app.tcl",
-                at: call,
-            },
+            call_at("file:///app.tcl", call),
         );
         assert_eq!(resolved.as_deref(), Some("::mymod::helper"));
     }
@@ -4123,10 +4260,7 @@ mod tests {
         let resolved = index.resolve_wildcard_import(
             "helper",
             &["::app::helper".to_string(), "::helper".to_string()],
-            CallSite {
-                uri: "file:///caller.tcl",
-                at: call,
-            },
+            call_at("file:///caller.tcl", call),
         );
         assert_eq!(
             resolved.as_deref(),
@@ -4153,12 +4287,349 @@ mod tests {
         let resolved = index.resolve_wildcard_import(
             "helper",
             &["::app::helper".to_string(), "::helper".to_string()],
+            call_at("file:///app.tcl", call),
+        );
+        assert!(resolved.is_none(), "{resolved:?}");
+    }
+
+    // ---- call-site ordering of the install (issue #1104 item 1) ----------
+    //
+    // Oracle, byte-identical on tclsh 8.6.14 and 9.0.4:
+    //
+    //   namespace eval ::src { proc p {} {return P}; namespace export p }
+    //   namespace eval ::dst { p }                  ;# invalid command name "p"
+    //   namespace eval ::dst { namespace import ::src::* }
+    //   namespace eval ::dst { p }                  ;# P
+    //
+    // …and the body-scope half, same transcript run:
+    //
+    //   namespace eval ::app { proc run {} { helper } }
+    //   namespace eval ::app { namespace import ::src::* }
+    //   ::app::run                                  ;# HELP
+    //
+    //   namespace eval ::app2 { proc run2 {} {
+    //       catch {helper} e ; namespace import ::src::* ; return "$e [helper]" } }
+    //   ::app2::run2   ;# {invalid command name "helper"} HELP
+
+    #[test]
+    fn a_top_level_call_before_its_own_import_does_not_resolve() {
+        // TN. Both call sites are top level, so the offsets are in genuine
+        // execution order and the earlier one reaches nothing.
+        let src = "helper\nnamespace eval ::app {\n    namespace import ::mymod::*\n}\nhelper\n";
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse(src);
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        let candidates = ["::app::helper".to_string(), "::helper".to_string()];
+        let before = u32::try_from(app_src_offset(src, "helper\n")).expect("tiny source");
+        assert!(
+            index
+                .resolve_wildcard_import("helper", &candidates, call_at("file:///app.tcl", before))
+                .is_none(),
+            "a call written before its own import must not resolve through it",
+        );
+        // TP — the same call after the import still does.
+        let after = u32::try_from(app_src_offset(src, "\nhelper\n") + 1).expect("tiny source");
+        assert_eq!(
+            index
+                .resolve_wildcard_import("helper", &candidates, call_at("file:///app.tcl", after))
+                .as_deref(),
+            Some("::mymod::helper"),
+        );
+    }
+
+    #[test]
+    fn a_body_local_call_resolves_through_an_import_written_later_in_its_file() {
+        // TP (CRITICAL) — the reason the install gate is `in_effect_within`
+        // and not `at < call`: the whole file loads, imports included, before
+        // any body runs, so this shape (procs first, `namespace import` at the
+        // bottom) still resolves. `tcllib`'s `modules/uev/uevent.tcl` is
+        // exactly it; a plain-offset gate broke all five of its call sites.
+        let src = "namespace eval ::app {\n    proc run {} { helper }\n}\nnamespace eval ::app {\n    namespace import ::mymod::*\n}\n";
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse(src);
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        let call = u32::try_from(app_src_offset(src, "helper }")).expect("tiny source");
+        let resolved = index.resolve_wildcard_import(
+            "helper",
+            &["::app::helper".to_string(), "::helper".to_string()],
             CallSite {
                 uri: "file:///app.tcl",
                 at: call,
+                enclosing_body: app.innermost_definition_body_span(call),
+            },
+        );
+        assert_eq!(
+            resolved.as_deref(),
+            Some("::mymod::helper"),
+            "a body-local call observes its own file's later top-level import",
+        );
+    }
+
+    #[test]
+    fn a_body_local_call_before_an_import_in_that_same_body_does_not_resolve() {
+        // TN — the FN guard for the leniency above: an import written in the
+        // *same* body after the call is an ordinary later statement of the
+        // running script, exactly as the export snapshot already treats one.
+        let src =
+            "namespace eval ::app {\n    proc run {} { helper ; namespace import ::mymod::* }\n}\n";
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse(src);
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        let call = u32::try_from(app_src_offset(src, "helper ;")).expect("tiny source");
+        let resolved = index.resolve_wildcard_import(
+            "helper",
+            &["::app::helper".to_string(), "::helper".to_string()],
+            CallSite {
+                uri: "file:///app.tcl",
+                at: call,
+                enclosing_body: app.innermost_definition_body_span(call),
             },
         );
         assert!(resolved.is_none(), "{resolved:?}");
+    }
+
+    #[test]
+    fn a_call_before_an_import_in_another_file_still_resolves() {
+        // TP — cross-file installs have no static load order, so the gate
+        // cannot fire on a foreign offset (the same abstention every other
+        // cross-file event takes here). `at` is deliberately tiny.
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let imports = analyse("namespace eval ::app { namespace import ::mymod::* }\n");
+        let caller = analyse("helper\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///imports.tcl", &imports),
+            ("file:///caller.tcl", &caller),
+        ]);
+        assert_eq!(
+            index
+                .resolve_wildcard_import(
+                    "helper",
+                    &["::app::helper".to_string(), "::helper".to_string()],
+                    call_at("file:///caller.tcl", 0),
+                )
+                .as_deref(),
+            Some("::mymod::helper"),
+        );
+    }
+
+    #[test]
+    fn the_body_span_column_matches_the_per_offset_lookup() {
+        // `enclosing_body_spans` is a stack sweep standing in for one
+        // `innermost_definition_body_span` per row (issue #1116 item 3's
+        // O(procs × invocations)); nesting, shared starts and calls between
+        // sibling bodies are where the two could part company.
+        let a = analyse(
+            "proc outer {} {\n  proc inner {} { set x 1 }\n  set y 2\n}\nset z 3\noo::class create C { method m {} { set w 4 } }\nset q 5\n",
+        );
+        let offsets: Vec<u32> = a
+            .command_invocations
+            .iter()
+            .map(|i| i.range.start())
+            .collect();
+        assert!(offsets.len() > 5, "the fixture must exercise the sweep");
+        let swept = WorkspaceIndex::enclosing_body_spans(&a, &offsets);
+        let naive: Vec<Option<Span>> = offsets
+            .iter()
+            .map(|&o| a.innermost_definition_body_span(o))
+            .collect();
+        assert_eq!(swept, naive);
+        // …and the column really is populated on the rows the resolver reads.
+        let index = WorkspaceIndex::from_documents([("file:///a.tcl", &a)]);
+        assert!(
+            index.invocations.iter().any(|i| i.enclosing_body.is_some()),
+            "body-local invocations must carry their span",
+        );
+    }
+
+    // ---- global-rooted imports go through the gate too (#1104 review note) -
+    //
+    // Oracle, byte-identical on tclsh 8.6.14 and 9.0.4:
+    //
+    //   proc p {} { return GLOBAL }
+    //   namespace eval ::dst  { namespace import ::p }   ;# no error…
+    //   info commands ::dst::*                           ;# …and nothing bound
+    //   namespace export p
+    //   namespace eval ::dst2 { namespace import ::p }
+    //   info commands ::dst2::*                          ;# ::dst2::p
+
+    #[test]
+    fn a_global_rooted_exact_import_is_export_gated() {
+        // TN — `::p` splits to an *empty* source namespace, which both tiers
+        // read as "no source" and skipped, leaving the one import shape that
+        // bypassed the gate entirely.
+        let lib = analyse("proc p {} { return GLOBAL }\n");
+        let dst = analyse("namespace eval ::dst { namespace import ::p }\n");
+        let index =
+            WorkspaceIndex::from_documents([("file:///lib.tcl", &lib), ("file:///dst.tcl", &dst)]);
+        assert_eq!(
+            index.resolve_command_target("::dst::p"),
+            "::dst::p",
+            "an unexported global command installs nothing",
+        );
+    }
+
+    #[test]
+    fn a_global_rooted_exact_import_of_an_exported_name_still_binds() {
+        // TP — the export at global level is recorded with `ns` = `::`, the
+        // same spelling the gate now asks with, so the working case works.
+        let lib = analyse("proc p {} { return GLOBAL }\nnamespace export p\n");
+        let dst = analyse("namespace eval ::dst { namespace import ::p }\n");
+        let index =
+            WorkspaceIndex::from_documents([("file:///lib.tcl", &lib), ("file:///dst.tcl", &dst)]);
+        assert_eq!(index.resolve_command_target("::dst::p"), "::p");
+    }
+
+    #[test]
+    fn a_global_rooted_glob_import_is_export_gated() {
+        // TN — the glob spelling of the same shape, which the index used to
+        // drop on the floor rather than record.
+        let lib = analyse("proc p {} { return GLOBAL }\n");
+        let dst = analyse("namespace eval ::dst { namespace import ::* }\np\n");
+        let index =
+            WorkspaceIndex::from_documents([("file:///lib.tcl", &lib), ("file:///dst.tcl", &dst)]);
+        let candidates = ["::dst::p".to_string(), "::p".to_string()];
+        assert!(
+            index
+                .resolve_wildcard_import("p", &candidates, call_from("file:///dst.tcl"))
+                .is_none(),
+            "an unexported global command is not reachable through `::*`",
+        );
+        // TP — with the export, it is.
+        let lib = analyse("proc p {} { return GLOBAL }\nnamespace export p\n");
+        let index =
+            WorkspaceIndex::from_documents([("file:///lib.tcl", &lib), ("file:///dst.tcl", &dst)]);
+        assert_eq!(
+            index
+                .resolve_wildcard_import("p", &candidates, call_from("file:///dst.tcl"))
+                .as_deref(),
+            Some("::p"),
+        );
+    }
+
+    // ---- glob / exact import conflicts are symmetric (issue #1116 item 7) --
+    //
+    // Oracle, byte-identical on tclsh 8.6.14 and 9.0.4, both orders:
+    //
+    //   namespace eval ::A { proc p {} {return A}; namespace export p }
+    //   namespace eval ::B { proc p {} {return B}; namespace export p }
+    //   namespace eval ::dst  { namespace import ::A::* ; namespace import ::B::p }
+    //   namespace eval ::dst2 { namespace import ::A::p ; namespace import ::B::* }
+    //   → both second imports: can't import command "p": already exists
+    //   → namespace origin ::dst::p  = ::A::p ; ::dst::p  → A
+    //   → namespace origin ::dst2::p = ::A::p ; ::dst2::p → A
+
+    /// The `::A` / `::B` sources both exporting `p`, used by the conflict
+    /// tests below.
+    fn two_exporting_sources() -> (AnalysisResult, AnalysisResult) {
+        (
+            analyse("namespace eval ::A { proc p {} { return A }\n namespace export p }\n"),
+            analyse("namespace eval ::B { proc p {} { return B }\n namespace export p }\n"),
+        )
+    }
+
+    #[test]
+    fn a_glob_import_conflicts_with_a_later_exact_import_of_the_same_name() {
+        // TN (the gap) — the exact link's conflict check only ever compared
+        // other *exact* links, so the earlier glob import was invisible to it
+        // and `::dst::p` resolved to `::B::p`, the one binding Tcl refuses.
+        let (a, b) = two_exporting_sources();
+        let dst = analyse(
+            "namespace eval ::dst {\n    namespace import ::A::*\n    namespace import ::B::p\n}\np\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///a.tcl", &a),
+            ("file:///b.tcl", &b),
+            ("file:///dst.tcl", &dst),
+        ]);
+        assert_ne!(
+            index.resolve_command_target("::dst::p"),
+            "::B::p",
+            "the exact import installs nothing over the live glob alias",
+        );
+        // …and the name the call really reaches is the glob import's source.
+        assert_eq!(
+            index
+                .resolve_wildcard_import(
+                    "p",
+                    &["::dst::p".to_string(), "::p".to_string()],
+                    call_from("file:///dst.tcl"),
+                )
+                .as_deref(),
+            Some("::A::p"),
+        );
+    }
+
+    #[test]
+    fn an_exact_import_conflicts_with_a_later_glob_import_of_the_same_name() {
+        // TN, the other direction of the same rule — the glob side asked only
+        // about other glob imports.
+        let (a, b) = two_exporting_sources();
+        let dst = analyse(
+            "namespace eval ::dst {\n    namespace import ::A::p\n    namespace import ::B::*\n}\np\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///a.tcl", &a),
+            ("file:///b.tcl", &b),
+            ("file:///dst.tcl", &dst),
+        ]);
+        let resolved = index.resolve_wildcard_import(
+            "p",
+            &["::dst::p".to_string(), "::p".to_string()],
+            call_from("file:///dst.tcl"),
+        );
+        assert!(
+            resolved.is_none_or(|r| r == "::A::p"),
+            "the later glob import must not install over a live exact alias",
+        );
+        assert_eq!(index.resolve_command_target("::dst::p"), "::A::p");
+    }
+
+    #[test]
+    fn a_forced_exact_import_still_replaces_a_live_glob_alias() {
+        // TP / FN guard — `-force` is exactly the case that *does* install
+        // over whatever was there (oracle on `WorkspaceGlobImport::forced`),
+        // so widening the conflict check must not swallow it.
+        let (a, b) = two_exporting_sources();
+        let dst = analyse(
+            "namespace eval ::dst {\n    namespace import ::A::*\n    namespace import -force ::B::p\n}\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///a.tcl", &a),
+            ("file:///b.tcl", &b),
+            ("file:///dst.tcl", &dst),
+        ]);
+        assert_eq!(index.resolve_command_target("::dst::p"), "::B::p");
+    }
+
+    #[test]
+    fn a_glob_import_in_another_file_does_not_conflict_with_an_exact_one() {
+        // FP guard — two imports in different documents have no static load
+        // order, so conflicting on a guess would drop a link Tcl installed.
+        // The abstention is the same one every other cross-file event takes.
+        let (a, b) = two_exporting_sources();
+        let globbed = analyse("namespace eval ::dst { namespace import ::A::* }\n");
+        let exact = analyse("namespace eval ::dst { namespace import ::B::p }\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///a.tcl", &a),
+            ("file:///b.tcl", &b),
+            ("file:///glob.tcl", &globbed),
+            ("file:///exact.tcl", &exact),
+        ]);
+        assert_eq!(index.resolve_command_target("::dst::p"), "::B::p");
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -711,47 +711,47 @@ pub struct WorkspaceIndex {
     namespace_forgets: Vec<WorkspaceNamespaceForget>,
     command_deletions: Vec<WorkspaceCommandDeletion>,
     generation: u64,
-    command_names: CommandNameCache,
-    live_links: LiveLinkCache,
+    /// Every command name the workspace defines, in each spelling a call site
+    /// may write — see [`WorkspaceIndex::command_names`].
+    command_names: Derived<HashSet<String>>,
+    /// Parallel liveness mask over `command_links` — see
+    /// [`WorkspaceIndex::live_command_links`].
+    live_links: Derived<Vec<bool>>,
+    /// `::`-stripped qualified names of every indexed proc and class, and the
+    /// same set with the names links introduce — see
+    /// [`WorkspaceIndex::defined_command_names`].
+    defined_names: [Derived<HashSet<String>>; 2],
 }
 
-/// Lazily-built cache of [`WorkspaceIndex::command_names`], reset by every
-/// index mutation.
+/// A whole-index **derived view**: a value that is a pure function of the
+/// index's contents, built at most once per [`WorkspaceIndex::generation`] and
+/// dropped by the mutation hook that bumps it.
 ///
-/// The set is a pure function of the index's procs and classes, so it is
-/// excluded from equality and dropped on clone (rebuilt on demand) — the same
-/// discipline `tcl_compiler::analyser::HierarchyCache` uses for the class
-/// hierarchy it derives from `all_classes`.
-#[derive(Debug, Default)]
-struct CommandNameCache(std::sync::OnceLock<Arc<HashSet<String>>>);
+/// The workspace-indexing contract's rule 5 in one type, so the reset/build
+/// boilerplate is written once rather than per view (issue #1105). Excluded
+/// from equality and dropped on clone — the same discipline
+/// `tcl_compiler::analyser::HierarchyCache` uses for the class hierarchy it
+/// derives from `all_classes`. `Arc` because a caller may hold the view while
+/// the index it came from is dropped or re-derived.
+#[derive(Debug)]
+struct Derived<T>(std::sync::OnceLock<Arc<T>>);
 
-impl Clone for CommandNameCache {
-    fn clone(&self) -> Self {
+impl<T> Default for Derived<T> {
+    fn default() -> Self {
         Self(std::sync::OnceLock::new())
     }
 }
 
-/// Lazily-built parallel mask over [`WorkspaceIndex::command_links`]: `true`
-/// where the link is actually installed.
-///
-/// An `interp alias` / `rename` link always is; an **exact** `namespace
-/// import` link is only installed when its
-/// [`WorkspaceCommandLink::import_gate`] passes against the whole current
-/// index (the export it depends on typically lives in another document).
-/// That makes liveness a function of the *entire* index, not of the link's
-/// own document — so, per the workspace-indexing contract's "a whole-index
-/// derived view lives on the index, built lazily and dropped by the same
-/// mutation hook that bumps `generation()`" rule, it is cached here rather
-/// than recomputed per consumer, and dropped by
-/// [`WorkspaceIndex::invalidate`]. Deciding it eagerly at link-creation time
-/// would instead freeze a cross-document answer that goes stale as soon as
-/// the exporting file is edited.
-#[derive(Debug, Default)]
-struct LiveLinkCache(std::sync::OnceLock<Arc<Vec<bool>>>);
-
-impl Clone for LiveLinkCache {
+impl<T> Clone for Derived<T> {
     fn clone(&self) -> Self {
-        Self(std::sync::OnceLock::new())
+        Self::default()
+    }
+}
+
+impl<T> Derived<T> {
+    /// The cached value, building it with `build` on first use.
+    fn get_or_build(&self, build: impl FnOnce() -> T) -> Arc<T> {
+        Arc::clone(self.0.get_or_init(|| Arc::new(build())))
     }
 }
 
@@ -796,7 +796,7 @@ impl WorkspaceIndex {
     /// serve from the cache.
     #[must_use]
     pub fn command_names(&self) -> Arc<HashSet<String>> {
-        Arc::clone(self.command_names.0.get_or_init(|| {
+        self.command_names.get_or_build(|| {
             let mut names: HashSet<String> = HashSet::new();
             for p in &self.procs {
                 tcl_compiler::analyser::utils::insert_qualified_and_tail(
@@ -810,15 +810,16 @@ impl WorkspaceIndex {
                     &c.qualified_name,
                 );
             }
-            Arc::new(names)
-        }))
+            names
+        })
     }
 
     /// Note a mutation: bump the generation and drop every derived cache.
     fn invalidate(&mut self) {
         self.generation = self.generation.wrapping_add(1);
-        self.command_names = CommandNameCache::default();
-        self.live_links = LiveLinkCache::default();
+        self.command_names = Derived::default();
+        self.live_links = Derived::default();
+        self.defined_names = <[Derived<HashSet<String>>; 2]>::default();
     }
 
     /// The command name-links that are actually installed — every `interp
@@ -844,52 +845,50 @@ impl WorkspaceIndex {
     /// visible too — otherwise this abstains and keeps the link, the same
     /// abstain-toward-silence rule the unknown-command pass follows.
     fn live_command_links(&self) -> Vec<&WorkspaceCommandLink> {
-        let mask = Arc::clone(self.live_links.0.get_or_init(|| {
+        let mask = self.live_links.get_or_build(|| {
             let wci = WildcardImportIndex::build(self);
             let observable = self.observable_namespaces();
-            Arc::new(
-                self.command_links
-                    .iter()
-                    .map(|l| {
-                        l.import_gate.as_ref().is_none_or(|g| {
-                            if !observable.contains(g.source_ns.trim_start_matches("::")) {
-                                return true;
-                            }
-                            if !wci.exports_name_at(&g.source_ns, &g.name, g.site(&l.uri)) {
-                                return false;
-                            }
-                            // A non-`-force` import onto a name the target
-                            // namespace already holds installs nothing at all
-                            // (oracle on `WorkspaceGlobImport::forced`), so
-                            // the link it would introduce is not live either.
-                            // "Already holds" is a real *definition* or an
-                            // earlier live alias from a **different** source
-                            // in the same document (issue #1116 finding 4);
-                            // a same-source re-import is a silent no-op, and
-                            // two links cancelling each other out is what the
-                            // different-source test rules out.
-                            let importing_ns = importing_namespace_of(&l.linked_qname);
-                            if !g.forced
-                                && (self.defines_command(&l.linked_qname)
-                                    || wci.conflicting_alias_at(
-                                        importing_ns,
-                                        &g.source_ns,
-                                        &g.name,
-                                        g.site(&l.uri),
-                                    ))
-                            {
-                                return false;
-                            }
-                            // …and the alias it installed can be taken away
-                            // again: `namespace forget`, a redefinition of the
-                            // imported name, or destruction of the source
-                            // command (issue #1116 finding 2).
-                            wci.link_alias_live(importing_ns, g, &l.uri)
-                        })
+            self.command_links
+                .iter()
+                .map(|l| {
+                    l.import_gate.as_ref().is_none_or(|g| {
+                        if !observable.contains(g.source_ns.trim_start_matches("::")) {
+                            return true;
+                        }
+                        if !wci.exports_name_at(&g.source_ns, &g.name, g.site(&l.uri)) {
+                            return false;
+                        }
+                        // A non-`-force` import onto a name the target
+                        // namespace already holds installs nothing at all
+                        // (oracle on `WorkspaceGlobImport::forced`), so
+                        // the link it would introduce is not live either.
+                        // "Already holds" is a real *definition* or an
+                        // earlier live alias from a **different** source
+                        // in the same document (issue #1116 finding 4);
+                        // a same-source re-import is a silent no-op, and
+                        // two links cancelling each other out is what the
+                        // different-source test rules out.
+                        let importing_ns = importing_namespace_of(&l.linked_qname);
+                        if !g.forced
+                            && (self.defines_command(&l.linked_qname)
+                                || wci.conflicting_alias_at(
+                                    importing_ns,
+                                    &g.source_ns,
+                                    &g.name,
+                                    g.site(&l.uri),
+                                ))
+                        {
+                            return false;
+                        }
+                        // …and the alias it installed can be taken away
+                        // again: `namespace forget`, a redefinition of the
+                        // imported name, or destruction of the source
+                        // command (issue #1116 finding 2).
+                        wci.link_alias_live(importing_ns, g, &l.uri)
                     })
-                    .collect(),
-            )
-        }));
+                })
+                .collect()
+        });
         self.command_links
             .iter()
             .zip(mask.iter())
@@ -2317,7 +2316,7 @@ impl WorkspaceIndex {
     fn invocation_resolves_to(
         &self,
         inv: &WorkspaceInvocation,
-        defined: &std::collections::HashSet<&str>,
+        defined: &HashSet<String>,
         links: Option<&std::collections::HashMap<&str, &str>>,
         wci: &WildcardImportIndex<'_>,
         target: &str,
@@ -2520,25 +2519,36 @@ impl WorkspaceIndex {
     /// [`Self::invocations_of`].  With `include_links`, the names an import /
     /// alias / rename introduces join the set, so a call reaching one of them
     /// settles (and is then chased to its ultimate target).
-    fn defined_command_names(&self, include_links: bool) -> std::collections::HashSet<&str> {
-        let mut names: std::collections::HashSet<&str> = self
-            .procs
-            .iter()
-            .map(|p| p.qualified_name.trim_start_matches("::"))
-            .chain(
-                self.classes
-                    .iter()
-                    .map(|c| c.qualified_name.trim_start_matches("::")),
-            )
-            .collect();
-        if include_links {
-            names.extend(
-                self.live_command_links()
-                    .into_iter()
-                    .map(|l| l.linked_qname.trim_start_matches("::")),
-            );
-        }
-        names
+    ///
+    /// A [`Derived`] view rather than a fresh walk (issue #1105): it is
+    /// `O(procs + classes + links)` to build, and
+    /// [`Self::workspace_command_exists`] asks for it *per candidate* inside
+    /// [`Self::follow_import_chain`]'s loop, which turned an existence test
+    /// into a workspace-wide scan. The two `include_links` readings are two
+    /// separate views because a consumer wants exactly one of them: the
+    /// direct-only set is what rename relies on, and folding the link names
+    /// into it would let a call spelling an imported name be text-rewritten.
+    fn defined_command_names(&self, include_links: bool) -> Arc<HashSet<String>> {
+        self.defined_names[usize::from(include_links)].get_or_build(|| {
+            let mut names: HashSet<String> = self
+                .procs
+                .iter()
+                .map(|p| p.qualified_name.trim_start_matches("::").to_owned())
+                .chain(
+                    self.classes
+                        .iter()
+                        .map(|c| c.qualified_name.trim_start_matches("::").to_owned()),
+                )
+                .collect();
+            if include_links {
+                names.extend(
+                    self.live_command_links()
+                        .into_iter()
+                        .map(|l| l.linked_qname.trim_start_matches("::").to_owned()),
+                );
+            }
+            names
+        })
     }
 
     /// Resolve a bare call through a wildcard `namespace import NS::*` —
@@ -5413,6 +5423,49 @@ mod tests {
         // A clone starts with a fresh (empty) cache and rebuilds identically.
         let cloned = index.clone();
         assert_eq!(*cloned.command_names(), *third);
+    }
+
+    #[test]
+    fn defined_command_names_are_cached_per_reading_and_dropped_on_mutation() {
+        // Issue #1105 — `workspace_command_exists` asks for this set once per
+        // candidate inside the import-chain loop, so it has to be a derived
+        // view like `command_names`, not a fresh O(procs + classes + links)
+        // walk. The two `include_links` readings are separate views: folding
+        // the link names into the direct one would let rename rewrite a call
+        // that merely spells an imported name.
+        let a = analyse(
+            "namespace eval ::lib { proc alpha {} {}\n namespace export alpha }\nnamespace eval ::app { namespace import ::lib::alpha }\n",
+        );
+        let mut index = WorkspaceIndex::new();
+        index.add_document("file:///a.tcl", &a);
+
+        let direct = index.defined_command_names(false);
+        let linked = index.defined_command_names(true);
+        assert!(direct.contains("lib::alpha"));
+        assert!(
+            !direct.contains("app::alpha"),
+            "the direct reading must not admit a link: {direct:?}",
+        );
+        assert!(
+            linked.contains("app::alpha"),
+            "the linked reading must: {linked:?}",
+        );
+        assert!(
+            Arc::ptr_eq(&direct, &index.defined_command_names(false))
+                && Arc::ptr_eq(&linked, &index.defined_command_names(true)),
+            "an unchanged index must serve both caches, not rebuild them",
+        );
+
+        let b = analyse("proc ::beta {} {}\n");
+        index.add_document("file:///b.tcl", &b);
+        let after = index.defined_command_names(false);
+        assert!(
+            !Arc::ptr_eq(&direct, &after),
+            "indexing a document must drop the cache",
+        );
+        assert!(after.contains("beta"), "{after:?}");
+        // A clone starts with a fresh cache and rebuilds identically.
+        assert_eq!(*index.clone().defined_command_names(false), *after);
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -2944,6 +2944,29 @@ impl<'a> WildcardImportIndex<'a> {
     /// would drop an alias Tcl really installed. A **same-source** re-import
     /// is a silent no-op (oracle), never a conflict — which is also what stops
     /// an import from conflicting with itself.
+    ///
+    /// Within that document the order is
+    /// [`crate::namespace_import::load_order`], shared with the same-document
+    /// resolver's slot-log fold. A raw `other.at < site.at` was wrong for
+    /// exactly the shape this whole family exists to model: a **body-local**
+    /// import is not ordered against a top-level import of its own file by
+    /// offset at all, because the file loads — running every top-level
+    /// statement, imports included — before any body runs, so the top-level
+    /// one owns the name however far below it is written (oracle transcript on
+    /// `load_order`). The offset comparison saw `::A` written *later* and let
+    /// the body-local `::B` import install, so navigation answered a source
+    /// the program never reaches.
+    ///
+    /// It is deliberately **not**
+    /// [`tcl_compiler::analyser::indirection::in_effect_within`], the
+    /// primitive the lifecycle check below runs on: that one is lenient about
+    /// events in bodies that may never run, which is the safe direction for a
+    /// *removal* and the unsafe one for a conflict — applied here it made the
+    /// two imports above cancel each other and the name resolve nowhere.
+    /// [`crate::namespace_import::load_order`] carries the reasoning.
+    ///
+    /// Self-exclusion survives the swap for free: an import's own key is never
+    /// less than itself, so it still cannot conflict with itself.
     fn conflicting_alias_at(
         &self,
         ns: &str,
@@ -2951,11 +2974,13 @@ impl<'a> WildcardImportIndex<'a> {
         name: &str,
         site: ImportSite<'_>,
     ) -> bool {
+        use crate::namespace_import::load_order;
         let call = CallSite {
             uri: site.uri,
             at: site.at,
             enclosing_body: site.enclosing_body,
         };
+        let here = load_order(site.at, site.enclosing_body.is_some());
         let mut earlier = self
             .imports_by_ns
             .get(ns)
@@ -2975,7 +3000,7 @@ impl<'a> WildcardImportIndex<'a> {
             );
         earlier.any(|(other_source, other_site)| {
             other_site.uri == site.uri
-                && other_site.at < site.at
+                && load_order(other_site.at, other_site.enclosing_body.is_some()) < here
                 && !ns_eq(other_source, source_ns)
                 && self.exports_name_at(other_source, name, other_site)
                 && self.alias_live_at(ns, other_source, name, other_site, call)
@@ -4623,6 +4648,110 @@ mod tests {
             ("file:///dst.tcl", &dst),
         ]);
         assert_eq!(index.resolve_command_target("::dst::p"), "::B::p");
+    }
+
+    #[test]
+    fn a_body_local_import_conflicts_with_a_later_top_level_import() {
+        // TN (CRITICAL) — the conflict check must order the two imports the
+        // way they *run*, not the way they are written. Oracle, byte-identical
+        // on tclsh 8.6.14 and 9.0.4:
+        //
+        //   namespace eval ::A { proc x {} {return A}; namespace export x }
+        //   namespace eval ::B { proc x {} {return B}; namespace export x }
+        //   namespace eval ::dst { proc p {} { namespace import ::B::x } }
+        //   namespace eval ::dst { namespace import ::A::* }
+        //   namespace origin ::dst::x  -> ::A::x   (after load)
+        //   ::dst::p                   -> can't import command "x": already exists
+        //   namespace origin ::dst::x  -> ::A::x   (unchanged)
+        //
+        // The whole file loads before any body runs, so the top-level `::A`
+        // glob import owns the name by the time `p`'s body-local `::B` import
+        // executes — and that one installs nothing. A plain offset compare
+        // sees `::A` written *later* and lets `::B` install.
+        let (a, b) = two_exporting_sources();
+        let dst = analyse(
+            "namespace eval ::dst {\n    proc runner {} { namespace import ::B::p }\n}\nnamespace eval ::dst {\n    namespace import ::A::*\n}\np\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///a.tcl", &a),
+            ("file:///b.tcl", &b),
+            ("file:///dst.tcl", &dst),
+        ]);
+        assert_ne!(
+            index.resolve_command_target("::dst::p"),
+            "::B::p",
+            "the body-local import runs after the top-level one and installs nothing",
+        );
+        assert_eq!(
+            index
+                .resolve_wildcard_import(
+                    "p",
+                    &["::dst::p".to_string(), "::p".to_string()],
+                    call_from("file:///dst.tcl"),
+                )
+                .as_deref(),
+            Some("::A::p"),
+            "the top-level glob import is the edge the name really has",
+        );
+    }
+
+    #[test]
+    fn a_top_level_import_is_not_conflicted_by_a_later_top_level_one() {
+        // TN guard — at load level the offsets *are* execution order, so the
+        // first import still wins and the second is the one that installs
+        // nothing. Oracle (8.6.14 / 9.0.4): after `namespace import ::A::*`
+        // then `namespace import ::B::p`, the second raises `can't import
+        // command "p": already exists` and `namespace origin ::dst::p` stays
+        // `::A::p`. Making the check body-aware must not reorder these.
+        let (a, b) = two_exporting_sources();
+        let dst = analyse(
+            "namespace eval ::dst {\n    namespace import ::A::*\n}\nnamespace eval ::dst {\n    namespace import ::B::p\n}\np\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///a.tcl", &a),
+            ("file:///b.tcl", &b),
+            ("file:///dst.tcl", &dst),
+        ]);
+        assert_ne!(index.resolve_command_target("::dst::p"), "::B::p");
+        assert_eq!(
+            index
+                .resolve_wildcard_import(
+                    "p",
+                    &["::dst::p".to_string(), "::p".to_string()],
+                    call_from("file:///dst.tcl"),
+                )
+                .as_deref(),
+            Some("::A::p"),
+        );
+    }
+
+    #[test]
+    fn a_later_import_in_the_same_body_has_not_run_yet() {
+        // TN guard, the other half — inside one body the offsets are genuine
+        // execution order again. Oracle (8.6.14 / 9.0.4): `proc q {} {
+        // namespace import ::A::* ; namespace import ::B::p }` → the first
+        // succeeds, the second raises `already exists`, origin stays `::A::p`.
+        // So the *first* must not be conflicted away by the second.
+        let (a, b) = two_exporting_sources();
+        let dst = analyse(
+            "namespace eval ::dst {\n    proc q {} { namespace import ::A::* ; namespace import ::B::p }\n}\np\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///a.tcl", &a),
+            ("file:///b.tcl", &b),
+            ("file:///dst.tcl", &dst),
+        ]);
+        assert_ne!(index.resolve_command_target("::dst::p"), "::B::p");
+        assert_eq!(
+            index
+                .resolve_wildcard_import(
+                    "p",
+                    &["::dst::p".to_string(), "::p".to_string()],
+                    call_from("file:///dst.tcl"),
+                )
+                .as_deref(),
+            Some("::A::p"),
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -5184,6 +5184,7 @@ impl Backend {
                 core_workspace_index::CallSite {
                     uri: uri.as_str(),
                     at: inv.range.start(),
+                    enclosing_body: analysis.innermost_definition_body_span(inv.range.start()),
                 },
             ) {
                 return vec![target];


### PR DESCRIPTION
## Summary

Two commits: the C7 gating-precision stage (addresses #1104 items 1–2 and #1116 items 1, 3, 7) and the #1105 perf rider (closes #1105).

**Install ordering (#1104 item 1).** `alias_live_at` now gates *every* ordered event — install and removal alike, one predicate consumed by both tiers. The gate is `in_effect`/`in_effect_within`, **not** a plain offset compare: oracle-pinned (8.6.14 + 9.0.4, byte-identical) that a proc *body* written before a top-level `namespace import` still resolves through it at call time, while a top-level call before its own import does not, and an import inside the same body splits first-call-fails/second-succeeds. On the tcllib-2.0 corpus (791 documents, 173k invocations, 59 glob imports) the ordered gate changes **0** call sites vs baseline, while a plain-offset gate would have broken 5 genuine pre-import body calls in `uevent.tcl` — now a test-fixture reference.

**Tail-match refusal (#1104 item 2).** `fallback_proc_by_simple_name` refuses via `only_route_is_a_dead_import` only when an in-scope import syntactically covers the word *from the namespace the fallback answer lives in* and the live walk does not land there — with two FN guards pinning the deliberate leniencies. Also fixed en route: `namespace import ::p` (empty source namespace is `::`) and a `format!("{ns}::{word}")` → `qualify` bug producing `::::p` in the workspace walk.

**#1116 items.** Item 1: the `-force` partly-observable discriminator moved from "holds anything of `::src`" to "holds `::src`'s *export list*" (narrowed residual documented below). Item 3: closed for free by the body-span column. Item 7: one `conflicting_alias_at` over glob + exact tables (`earlier_conflicting_link` deleted). Item 6: abstains, documented in code + FP-guard test — needs the source-graph order.

**Body-span column, measured.** `CallSite`/`WorkspaceInvocation` gain `enclosing_body` via one stack sweep (`O((P+I) log(P+I))`, 7.8ms vs 18.5ms per-row inside a 109ms index build; sweep-equals-lookup asserted on all 791 corpus documents and as a unit test). Without it the workspace tier cannot gate installs safely — dropping a body-local alias is the unsafe direction.

**#1105 rider.** `workspace_command_exists` rebuilt the full name set per call; now a `Derived<T>` view (third instance extracted the boilerplate — replaces `CommandNameCache` + `LiveLinkCache`). The two `defined_command_names` readings stay separate deliberately: folding link names into the direct set would let rename rewrite a call spelling an imported name. Measured: 10k existence checks 870µs cached vs 7.87s rebuilt.

**Source-graph survey** (#1104 item 3, #1116 item 6 — the family's single future fix): `docs/design/import-order-source-graph.md` records what exists (`SignatureSource.range` is already the sequencing fact; the index holds no URI↔path mapping — the resolver is server-supplied), what's needed (cached resolved edges per generation, a three-case `has_run` relation, soundness gates), what it lifts and doesn't. No trivial subset exists — same-document `source` before an import already needs the full plumbing.

**Remaining in the parent issues** (kept open): #1104 item 3 (source-graph order), #1116 items 4, 5, 6, and the narrowed item-1 residual — a document holding *some* of a namespace's exports but not the covering one still reads the gap as fact.

11 files, +1510/−281 across the two commits.

## Validation

- [x] `cargo test --workspace` — exit 0 (incl. doctests; server e2e 1173 passed, core lib 1469 passed)
- [x] `cargo clippy --workspace --all-targets` — clean, zero new allows
- [x] `cargo fmt --all --check` — clean
- [x] `make xtask-check` — all OK (incl. resolution-drift, command-backing 384/384)
- [x] Oracle transcripts (8.6.14 + 9.0.4, byte-identical) for install ordering; tcllib-2.0 corpus before/after diffed (0 changed sites; plain-offset counterfactual = 5 real breaks)
- [x] Every TN test verified to fail with its gate toggled off

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — `CallSite::enclosing_body`, `alias_live_at` gating every ordered event, `conflicting_alias_at` unification; contracts docs updated (`workspace-indexing.md`, `command-resolution.md`).
- [x] KCS notes: `kcs/features/kcs-feature-definition.md` updated; new design doc `import-order-source-graph.md` indexed in `design/README.md`.
- [x] New compiler KCS note linked: covered by the updated contract docs above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7)_