### PR TITLE
LSP memory-leak and large-project performance fixes from the corpus perf session (#1144–#1161)

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,8 +655,8 @@ test parse-1.1 {parses a row} -body { ... } -result ok
 
 ### Workspace symbols
 
-Search for procs, classes, methods, and `tcltest` test cases across the
-workspace (Ctrl+T / Cmd+T).
+Search for procs, classes, methods, and `tcltest` test cases across the whole
+workspace (Ctrl+T / Cmd+T) — including files you have not opened.
 
 ```tcl
 # File: utils.tcl

--- a/docs/design/contracts/workspace-indexing.md
+++ b/docs/design/contracts/workspace-indexing.md
@@ -22,6 +22,7 @@ entry has an identity another document can spell:
 | `variable_refs` | occurrences written with a `::` qualifier | **qualified name only** |
 | `namespace_refs` | every word naming a namespace, declaring or not | qualified name (rooted at record time) |
 | `sources` / `package_requires` / `command_links` / `glob_imports` / `namespace_exports` | the cross-file graph edges | — |
+| `defined_symbols` | registry symbol-definer definitions — `tcltest` test cases / constraints / match modes, iRules `when EVENT` handlers | qualified name |
 
 `glob_imports` and `namespace_exports` each carry their document **and their
 byte offset within it**, because a `namespace import` binds the names its
@@ -263,6 +264,12 @@ silently misses something:
   A computed cell names no fixed variable, so it can be neither found by a
   candidate scan nor rewritten.  The match stays narrow: whichever half of
   the cell is still written literally must agree with the cell being renamed.
+
+`workspace/symbol` is answered from here too (`symbols_matching`, issue
+#1156), which is why a class record carries its methods' `name_span`s and its
+`constructor_spans`, and why `defined_symbols` exists: the picker must be able
+to locate a member in a file the editor never opened.  Cross-file *dispatch*
+needs none of those spans; they are carried for the picker alone.
 
 ## How the tables are stored
 

--- a/docs/design/contracts/workspace-indexing.md
+++ b/docs/design/contracts/workspace-indexing.md
@@ -314,16 +314,26 @@ command-name set the cross-file unknown-command pass consults
 cache.
 
 The rule is a single type, `Derived<T>`, rather than one hand-rolled
-`OnceLock` + reset per view (issue #1105).  Three views use it:
-`command_names`, the `command_links` liveness mask, and the two
+`OnceLock` + reset per view (issue #1105).  Every view uses it:
+`command_names`, the `command_links` liveness mask, the two
 `defined_command_names` readings (with and without the names links
 introduce — a consumer wants exactly one, since folding link names into the
 direct set would let rename rewrite a call that merely spells an imported
-name).  The last of those was the motivating regression:
+name), the `command_link_map`, and the two `invocations_by_settled_target`
+readings.  `defined_command_names` was the motivating regression:
 `workspace_command_exists` rebuilt the whole set per call, and
 `follow_import_chain` asks it once per candidate per hop.  Measured on the
 same 400-file / 10 000-proc workspace, 10 000 existence checks take **870 µs**
 cached against **7.87 s** rebuilding per call.
+
+`invocations_by_settled_target` is the same shape one level up (issue #1152):
+settling *is* the expensive answer, so every invocation is settled once per
+generation and the results grouped by their target, rather than re-settling
+the whole workspace once per candidate.  The view stores `(document slot,
+index within that slot's invocations)` pairs, which stay valid because a
+document's invocation vector is only ever cleared and refilled wholesale, and
+anything that could invalidate a pair also bumps the generation and drops the
+view.
 
 ## Decision rules / contracts
 

--- a/docs/design/contracts/workspace-indexing.md
+++ b/docs/design/contracts/workspace-indexing.md
@@ -264,6 +264,37 @@ silently misses something:
   candidate scan nor rewritten.  The match stays narrow: whichever half of
   the cell is still written literally must agree with the cell being renamed.
 
+## How the tables are stored
+
+The tables are held **per document** (`DocumentRecords`, one slot per URI)
+and exposed as workspace-wide iterators that chain the slots in slot order —
+`procs()`, `classes()`, `invocations()` and the rest return an
+`impl Iterator`, not a slice.  That is what makes `remove_document` cost the
+removed document's own rows rather than a pass over the whole workspace
+(issue #1149): flat workspace-wide vectors made a removal fourteen
+`Vec::retain` passes with a `String` compare per element, over tables that
+hold one row per call site and per qualified variable occurrence — 10⁵–10⁶
+rows on tcllib — and the server re-indexes a document on every diagnostics
+publish.
+
+A removal clears the document's slot and returns it to a LIFO free list, so
+the remove-then-add of a publish hands the document straight back the slot it
+just gave up: its position in the workspace-wide order is stable across a
+re-index, and the slot vector stays bounded by the workspace's peak document
+count.  Adding the **same** URI twice without an intervening removal
+accumulates (it does not replace): the M9 source-rehoming pass indexes one
+analysis per source-site namespace, and those views are several runtime
+identities of one physical file.
+
+An **edit** does not touch the index.  `did_change` commits the buffer splice
+and the salsa source only; `publish_diagnostics_result` re-indexes the
+document (remove + add) under the `documents` lock behind its `is_current`
+re-check, so it can only ever install the analysis of the revision the buffer
+actually holds.  Between the two the document contributes its *previous
+published* rows — the same staleness every other document carries between
+publishes, and strictly less misleading than a per-keystroke window in which
+the edited file contributes no procs, classes or call sites at all.
+
 ## Derived views and their invalidation
 
 `WorkspaceIndex::generation()` is bumped by `add_document` /

--- a/docs/design/srv-incremental/README.md
+++ b/docs/design/srv-incremental/README.md
@@ -62,9 +62,12 @@ Per `textDocument/didChange` (`rust/tcl-lsp-server/src/lib.rs`, `did_change`):
 2. `db_set_source` → salsa `SourceFile::set_text` with the **whole-file `String`**
    (one flat input per file; no chunk/per-proc granularity), bumping the input
    revision and marking every dependent query dirty.
-3. `workspace_index.remove_document(uri)` — drops file A's symbols from the
-   cross-document aggregate. **This is the only cross-file action, and it triggers
-   no re-analysis of any other file.**
+3. *(removed in #1149)* `did_change` used to call
+   `workspace_index.remove_document(uri)`, dropping file A's symbols from the
+   cross-document aggregate. The edit path no longer touches the index at all —
+   `publish_diagnostics_result` re-indexes the document on publish, behind its
+   own currency check. **The edit path triggers no cross-file work and no
+   re-analysis of any other file.**
 4. debounced `schedule_diagnostics` → two salsa queries:
    `file_analysis_incremental(file, config)` (the per-item analyser walk) and
    `compiler_check_diagnostics(file)` (`run_all_checks` + `optimise_unit` over the

--- a/docs/kcs/features/kcs-feature-workspace-symbols.md
+++ b/docs/kcs/features/kcs-feature-workspace-symbols.md
@@ -5,7 +5,8 @@
 
 ## Summary
 
-Search symbols across all open files in the workspace.
+Search symbols across every indexed file in the workspace — including files
+the editor has never opened.
 
 ## Applies to
 
@@ -18,19 +19,53 @@ all-editors, analyser
 
 ## Operational context
 
-Searches the workspace index for procs, namespaces, variables, and `tcltest` definitions (test cases, constraints, custom match modes) matching the query. Relies on the workspace scanner for cross-file indexing. These are recorded from any command whose registry `CommandSpec` declares `defines_symbol`, so the set grows by spec data rather than provider edits (#790).
+Answered from the workspace index (`WorkspaceIndex::symbols_matching`): every
+proc, class, method, `classmethod`, constructor, and registry symbol-definer
+definition — `tcltest` test cases, constraints, custom match modes, and iRules
+`when EVENT` handlers — whose simple or qualified name contains the query,
+case-insensitively (an empty query matches everything). The definer-backed
+kinds are recorded from any command whose registry `CommandSpec` declares
+`defines_symbol`, so the set grows by spec data rather than provider edits
+(#790).
+
+Because the answer comes from the index and not from the open-document map, a
+symbol in a file the folder scan indexed but the editor never opened is
+searchable (#1156). The index is refreshed on each document's diagnostics
+publish, which the debounce puts about 50 ms behind an edit, so a name typed a
+moment ago appears once that publish lands; an open-but-not-yet-published
+buffer still contributes the symbols of its last publish.
+
+The answer is capped at `MAX_WORKSPACE_SYMBOL_RESULTS` (1000). VS Code
+re-issues the request on every keystroke in the Ctrl+T box, so the cap is
+applied while scanning the index — it bounds the work, not merely the payload
+— and the scan is document-major, so a truncated answer is a prefix of the
+workspace rather than a prefix of one symbol table.
 
 ## File-path anchors
 
-- `server/features/workspace_symbols.py`
+- `rust/tcl-lsp-core/src/workspace_symbols.rs` — the wire contract: symbol
+  kinds, the query match, the result cap
+- `rust/tcl-lsp-core/src/workspace_index.rs` — `WorkspaceIndex::symbols_matching`,
+  the scan itself
+- `rust/tcl-lsp-server/src/lib.rs` — the `workspace/symbol` handler, which
+  resolves each hit's byte span against its document's source
 
 ## Failure modes
 
-- Stale results if the workspace index is not refreshed.
+- Results up to one diagnostics publish behind the buffer for a document being
+  edited.
+- A hit is dropped when its document can be neither read from the open buffers
+  nor from disk (a file deleted since it was indexed).
 
 ## Test anchors
 
-- `tests/test_workspace_symbols.py`
+- `rust/tcl-lsp-core/src/workspace_symbols.rs` — unit tests for kinds,
+  containers, the query match, the unopened-document case, and the cap
+- `rust/tcl-lsp-core/tests/lsp_edit_workspace.rs` — `workspace_symbols_*`
+- `rust/tcl-lsp-server/src/lib.rs` — `workspace_symbol_finds_a_symbol_in_an_unopened_indexed_file`,
+  `workspace_symbol_caps_its_answer`
+- `rust/tcl-lsp-server/tests/e2e/structure.rs`,
+  `rust/tcl-lsp-server/tests/e2e/document_symbols.rs`
 
 ## Example
 

--- a/rust/tcl-cli/src/commands/minimize.rs
+++ b/rust/tcl-cli/src/commands/minimize.rs
@@ -36,7 +36,7 @@
 //! irrelevant to the reduction — both engines reduce to a snippet that still
 //! fires CODE.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fmt::Write as _;
 
 use serde::Serialize;
@@ -192,7 +192,11 @@ fn collect_rename_edits(
     // known-command universe is empty — matches the old `registry: None`
     // behaviour (the recovery diagnostics are discarded below anyway; only
     // the segmented command shapes matter here).
-    let (cmds, _) = segment_with_recovery(source, LexerConfig::default(), &HashSet::new());
+    let (cmds, _) = segment_with_recovery(
+        source,
+        LexerConfig::default(),
+        &tcl_compiler::analyser::utils::RecoveryKnownCommands::default(),
+    );
     for cmd in &cmds {
         if cmd.texts.is_empty() {
             continue;

--- a/rust/tcl-compiler/src/analyser/class_lattice.rs
+++ b/rust/tcl-compiler/src/analyser/class_lattice.rs
@@ -639,7 +639,7 @@ fn seed_from_type_lattice<S: std::hash::BuildHasher + Clone>(
     out: &mut HashMap<String, ClassValue>,
 ) {
     use crate::types::TypeKind;
-    for ((sym, _ver), tl) in &fu.types {
+    for ((sym, _ver), tl) in fu.types.iter() {
         if tl.kind() != TypeKind::Known {
             continue;
         }

--- a/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
@@ -281,7 +281,7 @@ impl Analyser {
         let collect_object_types =
             |fu: &crate::compilation_unit::FunctionUnit,
              out: &mut std::collections::HashMap<String, HashSet<String>>| {
-                for ((sym, _ver), tl) in &fu.types {
+                for ((sym, _ver), tl) in fu.types.iter() {
                     if tl.kind() != TypeKind::Known {
                         continue;
                     }

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -1498,7 +1498,7 @@ impl Analyser {
         // dispatches each command at the new proc scope path.
         // Per-item shell pass: defer the body (its scope is already
         // created with params; a second pass fills it in place).
-        let body_text = args[2].clone();
+        let body_text: std::sync::Arc<str> = std::sync::Arc::from(args[2].as_str());
         if self.defer_proc_bodies {
             let safe_interp_ctx = self.safe_interp_ctx_snapshot();
             self.deferred_bodies.push(super::per_item::DeferredBody {
@@ -1662,7 +1662,7 @@ impl Analyser {
             }
 
             let saved_comment = std::mem::take(&mut self.last_comment);
-            let body_text = args[2].clone();
+            let body_text: std::sync::Arc<str> = std::sync::Arc::from(args[2].as_str());
             if self.defer_proc_bodies {
                 let safe_interp_ctx = self.safe_interp_ctx_snapshot();
                 self.deferred_bodies.push(super::per_item::DeferredBody {
@@ -1962,7 +1962,7 @@ impl Analyser {
         };
 
         let params = parse_param_list(params_text);
-        let body_text = body_text.to_string();
+        let body_text: std::sync::Arc<str> = std::sync::Arc::from(body_text);
         let body_span = body_tok.span;
         // Anonymous, but keyed by source position so two lambdas never collide
         // in `all_variables` (keyed `"<scope_name>::<var>"`).

--- a/rust/tcl-compiler/src/analyser/oo.rs
+++ b/rust/tcl-compiler/src/analyser/oo.rs
@@ -819,7 +819,7 @@ impl Analyser {
             let namespace = self.command_resolution_namespace(scope_path);
             let safe_interp_ctx = self.safe_interp_ctx_snapshot();
             self.deferred_bodies.push(super::per_item::DeferredBody {
-                body_text: mb.body_text.clone(),
+                body_text: std::sync::Arc::from(mb.body_text.as_str()),
                 body_tok: mb.body_tok,
                 scope_path: method_path,
                 is_method: true,

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -337,11 +337,7 @@ impl Analyser {
             self.registry.expect("registry just stashed"),
             &self.extra_commands,
         );
-        let known: HashSet<&str> = self
-            .recovery_known_commands
-            .iter()
-            .map(String::as_str)
-            .collect();
+        let known: HashSet<&str> = self.recovery_known_commands.iter().collect();
         crate::segmenter::segment_commands_with_recovery_and_config(
             source,
             &known,

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -121,7 +121,11 @@ impl PerItemFallback {
 #[derive(Debug, Clone)]
 pub struct DeferredBody {
     /// Body text (braces stripped), as `analyse_body` expects.
-    pub body_text: String,
+    ///
+    /// Shared behind an `Arc` so the LSP query database can intern it into its
+    /// per-body memo key without a second copy of every proc body's full source
+    /// on every edit (issue #1159 — `tcl-lsp-db`'s `ItemBodyKey`).
+    pub body_text: std::sync::Arc<str>,
     /// The body's `Str` token (absolute span) — drives offset arithmetic.
     pub body_tok: Token,
     /// Path to the already-created (empty) proc / method scope to fill.
@@ -768,7 +772,7 @@ pub fn analyse_proc_body_isolated<S: std::hash::BuildHasher>(
     a.stub_overlay = stub_overlay;
     // Offset 0: the body content is the whole source; a synthetic `Str` body
     // token spans it with `content_offset = 0` (no `{` to skip).
-    a.source.clone_from(&db.body_text);
+    a.source = db.body_text.to_string();
     // Source spans are `u32`; a proc body longer than 4 GiB is not
     // representable (and never occurs), so clamp to `u32::MAX`.
     let body_len = u32::try_from(db.body_text.len()).unwrap_or(u32::MAX);

--- a/rust/tcl-compiler/src/analyser/recovery.rs
+++ b/rust/tcl-compiler/src/analyser/recovery.rs
@@ -807,7 +807,7 @@ mod tests {
         // running the braced prose through command analysis.
         let source = "switch $x\na { puts hi }\nrenderReport { prose text }";
         let mut a = analyser_with_source(source);
-        a.extra_commands.insert("renderReport".to_string());
+        a.extra_commands = std::sync::Arc::new(["renderReport".to_owned()].into_iter().collect());
         let commands: Vec<SegmentedCommand> = segment_commands_with_offset(source, 0);
         let mut switch_cmd = commands[0].clone();
         let consumed = a.recover_missing_open_brace(&mut switch_cmd, &commands, 0);

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -23,6 +23,7 @@
 //! …) but all operate on the same ``&mut Analyser``.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use tcl_core_types::DiagCode;
 
 use tcl_lexer::Span;
@@ -200,7 +201,16 @@ pub struct Analyser {
     pub disabled_diagnostics: HashSet<String>,
     /// User-declared extra command names (`tclLsp.extraCommands`) treated as
     /// known, so calling them never draws an unknown-command W123.
-    pub extra_commands: HashSet<String>,
+    ///
+    /// Shared behind an `Arc` because the LSP's unclosed-delimiter recovery
+    /// path widens this set with every workspace-indexed proc / class and every
+    /// auto-loadable command name (`widen_recovery_extra_commands` in
+    /// `tcl-lsp-server`) — tens of thousands of names on a large workspace.
+    /// That set is a pure function of the workspace index and the package
+    /// database, so the server caches it and hands the same allocation to every
+    /// analyser it configures; an owned `HashSet` here would deep-copy it on
+    /// each keystroke.
+    pub extra_commands: Arc<HashSet<String>>,
     /// Last seen comment text, for proc / class doc-comment
     /// harvesting.
     pub last_comment: String,
@@ -521,7 +531,7 @@ pub struct Analyser {
     /// scan-to-next recovery and the E100/E201/E202/E203 diagnostics agree
     /// on what counts as a "real command" starting a new line. Empty
     /// outside an active analysis run.
-    pub recovery_known_commands: HashSet<String>,
+    pub recovery_known_commands: super::utils::RecoveryKnownCommands,
     /// When `true`, the proc handler runs the deep-recursive
     /// pass of [`super::param_traits::infer_param_traits_deep`]
     /// after the shallow pass and unions the results via
@@ -872,7 +882,7 @@ impl Analyser {
             source: String::new(),
             profile: tcl_dialect::DialectProfile::plain_tcl(),
             disabled_diagnostics: disabled,
-            extra_commands: HashSet::new(),
+            extra_commands: Arc::new(HashSet::new()),
             last_comment: String::new(),
             file_path: None,
             const_strings: HashMap::new(),
@@ -919,7 +929,7 @@ impl Analyser {
             interp_var_bindings: HashMap::new(),
             unresolved_commands_emitted: false,
             registry: None,
-            recovery_known_commands: HashSet::new(),
+            recovery_known_commands: super::utils::RecoveryKnownCommands::default(),
             deep_param_traits: false,
             stub_overlay: None,
             line_offsets: None,
@@ -970,7 +980,15 @@ impl Analyser {
     /// returning `self` for builder-style configuration. These names are
     /// treated as known commands by the unknown-command (W123) check.
     #[must_use]
-    pub fn with_extra_commands(mut self, extra: HashSet<String>) -> Self {
+    pub fn with_extra_commands(self, extra: HashSet<String>) -> Self {
+        self.with_shared_extra_commands(Arc::new(extra))
+    }
+
+    /// [`Self::with_extra_commands`] taking an already-shared set, so a caller
+    /// that caches the (potentially very large) widened recovery name set hands
+    /// it over as a refcount bump rather than a deep copy.
+    #[must_use]
+    pub fn with_shared_extra_commands(mut self, extra: Arc<HashSet<String>>) -> Self {
         self.extra_commands = extra;
         self
     }
@@ -1146,11 +1164,7 @@ impl Analyser {
             self.registry.expect("registry just stashed"),
             &self.extra_commands,
         );
-        let known_commands: HashSet<&str> = self
-            .recovery_known_commands
-            .iter()
-            .map(String::as_str)
-            .collect();
+        let known_commands: HashSet<&str> = self.recovery_known_commands.iter().collect();
         let mut commands = crate::segmenter::segment_commands_with_recovery_and_config(
             source,
             &known_commands,
@@ -1677,7 +1691,7 @@ impl Analyser {
     pub(super) fn fresh_full_analyse(&self, new_text: &str, dialect: &str) -> AnalysisResult {
         let mut fresh = Analyser::with_disabled_diagnostics(self.disabled_diagnostics.clone())
             .with_non_ascii_mode(self.non_ascii_mode)
-            .with_extra_commands(self.extra_commands.clone());
+            .with_shared_extra_commands(Arc::clone(&self.extra_commands));
         fresh.analyse(new_text, dialect)
     }
 

--- a/rust/tcl-compiler/src/analyser/syntax_checks.rs
+++ b/rust/tcl-compiler/src/analyser/syntax_checks.rs
@@ -48,10 +48,10 @@ use crate::segmenter::SegmentedCommand;
 /// token it picks, in priority order, where the `]` belongs: before a `#`
 /// comment line, a known-command line, or a `{`; otherwise it anchors at
 /// the `[`.
-pub(crate) fn unterminated_bracket_diagnostics<S: std::hash::BuildHasher>(
+pub(crate) fn unterminated_bracket_diagnostics(
     cmd: &SegmentedCommand,
     source: &str,
-    known: &HashSet<String, S>,
+    known: &super::utils::RecoveryKnownCommands,
 ) -> Vec<Diagnostic> {
     let mut out = Vec::new();
     for tok in &cmd.all_tokens {
@@ -95,11 +95,11 @@ fn is_unterminated_cmd(tok: &Token, source: &str) -> bool {
 /// Build the E201 diagnostic for an unterminated `[`, choosing the
 /// insertion point via the comment / known-command / brace heuristics
 /// (in priority order), falling back to the bare `[`.
-fn detect_e201<S: std::hash::BuildHasher>(
+fn detect_e201(
     content: &str,
     content_start: u32,
     bracket_off: u32,
-    known: &HashSet<String, S>,
+    known: &super::utils::RecoveryKnownCommands,
 ) -> Diagnostic {
     // The heuristics *propose* an insertion offset (semantic); the
     // structural index *validates* it (syntactic). A proposed `]` that
@@ -214,11 +214,11 @@ fn e201_at_comment(content: &str, content_start: u32, bracket_off: u32) -> Optio
 /// content captured real commands inside a brace word. `detect_e201` uses
 /// that to suppress the `e201_at_brace` fallback, which would otherwise
 /// insert `]` before the `{` and hide the swallowed command from analysis.
-fn e201_at_command<S: std::hash::BuildHasher>(
+fn e201_at_command(
     content: &str,
     content_start: u32,
     bracket_off: u32,
-    known: &HashSet<String, S>,
+    known: &super::utils::RecoveryKnownCommands,
     index: &tcl_lexer::BracketIndex,
 ) -> (Option<Diagnostic>, bool) {
     let lines: Vec<&str> = content.split('\n').collect();
@@ -297,12 +297,12 @@ fn e201_at_brace(content: &str, content_start: u32, bracket_off: u32) -> Option<
 /// when scanning a nested body whose tokens are absolute spans into the
 /// full `source`. The "reaches EOF" / "no closing delimiter" tests are
 /// relative to that end.
-pub(crate) fn unterminated_delimiter_diagnostics<S: std::hash::BuildHasher>(
+pub(crate) fn unterminated_delimiter_diagnostics(
     cmd: &SegmentedCommand,
     source: &str,
     region_end: usize,
     registry: Option<&CommandRegistry>,
-    known: &HashSet<String, S>,
+    known: &super::utils::RecoveryKnownCommands,
 ) -> Vec<Diagnostic> {
     let mut out = Vec::new();
     for (idx, tok) in cmd.all_tokens.iter().enumerate() {
@@ -420,10 +420,10 @@ fn is_suspicious_str(tok: &Token, source: &str, region_end: usize) -> bool {
 /// Build the E202 diagnostic for an unterminated `"`: the known-command
 /// heuristic (insert `"` right after the opener) or the fix-less
 /// fallback.
-fn detect_e202<S: std::hash::BuildHasher>(
+fn detect_e202(
     tok: &Token,
     source: &str,
-    known: &HashSet<String, S>,
+    known: &super::utils::RecoveryKnownCommands,
 ) -> Diagnostic {
     let quote_off = tok.span.start();
     let diag_span = Span::new(quote_off, quote_off);
@@ -469,12 +469,12 @@ fn detect_e202<S: std::hash::BuildHasher>(
 /// Build the E203 diagnostic for an unterminated `{`: the de-indented
 /// known-command heuristic (insert `}` at the newline before that line)
 /// or the fix-less fallback.
-fn detect_e203<S: std::hash::BuildHasher>(
+fn detect_e203(
     tok: &Token,
     cmd: &SegmentedCommand,
     source: &str,
     registry: Option<&CommandRegistry>,
-    known: &HashSet<String, S>,
+    known: &super::utils::RecoveryKnownCommands,
 ) -> Diagnostic {
     let brace_off = tok.span.start();
     let diag_span = Span::new(brace_off, brace_off);
@@ -543,11 +543,11 @@ fn unterminated_arg_is_expr(
 /// braces the line must be **de-indented** (the conservative heuristic);
 /// for `expr_role` braces any following known-command line qualifies (the
 /// aggressive command-break via `ArgRole` routing).
-fn e203_brace_fix<S: std::hash::BuildHasher>(
+fn e203_brace_fix(
     tok: &Token,
     source: &str,
     content_start: u32,
-    known: &HashSet<String, S>,
+    known: &super::utils::RecoveryKnownCommands,
     expr_role: bool,
 ) -> Option<CodeFix> {
     let text = token_inner(source, tok)?;

--- a/rust/tcl-compiler/src/analyser/utils.rs
+++ b/rust/tcl-compiler/src/analyser/utils.rs
@@ -218,27 +218,89 @@ pub fn scan_stub_command_names(source: &str) -> HashSet<String> {
 /// skips that extra scan entirely — zero added cost on the overwhelmingly
 /// common well-formed edit.
 #[must_use]
-pub fn recovery_known_commands<S: std::hash::BuildHasher>(
+pub fn recovery_known_commands(
     source: &str,
     registry: &CommandRegistry,
-    extra: &HashSet<String, S>,
-) -> HashSet<String> {
+    extra: &SharedNameSet,
+) -> RecoveryKnownCommands {
     let mut names: HashSet<String> = registry.command_names().map(str::to_owned).collect();
-    names.extend(extra.iter().cloned());
-    if tcl_lexer::script_is_complete(source) {
-        return names;
+    if !tcl_lexer::script_is_complete(source) {
+        let sig = crate::signature_scan::extract_signatures(source, registry);
+        for qname in sig
+            .procs
+            .keys()
+            .chain(sig.classes.keys())
+            .chain(sig.command_aliases.keys())
+            .chain(sig.renames.keys())
+        {
+            insert_qualified_and_tail(&mut names, qname);
+        }
     }
-    let sig = crate::signature_scan::extract_signatures(source, registry);
-    for qname in sig
-        .procs
-        .keys()
-        .chain(sig.classes.keys())
-        .chain(sig.command_aliases.keys())
-        .chain(sig.renames.keys())
-    {
-        insert_qualified_and_tail(&mut names, qname);
+    RecoveryKnownCommands {
+        local: names,
+        extra: std::sync::Arc::clone(extra),
     }
-    names
+}
+
+/// The recovery known-command universe [`recovery_known_commands`] builds,
+/// held as **two layers** rather than one merged set.
+///
+/// `local` is derived from the document being analysed (the active registry's
+/// names plus the document's own proc / class / alias / rename names), so it is
+/// rebuilt on every edit. `extra` is the caller-supplied name set
+/// ([`super::state::Analyser::extra_commands`]), which on the LSP's
+/// unclosed-delimiter recovery path is the *widened* set — every
+/// workspace-indexed proc and class, plus every auto-loadable command name:
+/// tens of thousands of entries on a large workspace, and unchanged between
+/// keystrokes. Merging the two would deep-copy that set on every analysis of a
+/// document with an open delimiter — which is the *normal* mid-typing state, so
+/// it happened on every debounced run (issue #1154). Sharing it behind an `Arc`
+/// makes the layering free.
+///
+/// Every consumer only ever asks "is this name known?" or enumerates the
+/// universe once, both of which the two layers answer directly.
+#[derive(Debug, Default, Clone)]
+pub struct RecoveryKnownCommands {
+    local: HashSet<String>,
+    extra: SharedNameSet,
+}
+
+/// A command-name set shared between the analyser and its caller — see
+/// [`RecoveryKnownCommands`] and [`super::state::Analyser::extra_commands`].
+pub type SharedNameSet = std::sync::Arc<HashSet<String>>;
+
+impl RecoveryKnownCommands {
+    /// Whether `name` is a known command in either layer.
+    #[must_use]
+    pub fn contains(&self, name: &str) -> bool {
+        self.local.contains(name) || self.extra.contains(name)
+    }
+
+    /// Every known name, `local` first. A name present in both layers is
+    /// yielded twice; every consumer collects into a set, so that is harmless
+    /// and avoids a de-duplication pass over the (large) shared layer.
+    pub fn iter(&self) -> impl Iterator<Item = &str> {
+        self.local
+            .iter()
+            .chain(self.extra.iter())
+            .map(String::as_str)
+    }
+
+    /// Drop the per-document layer and release the shared one — the
+    /// between-runs reset ([`super::state::Analyser::clear_run_state`]).
+    pub fn clear(&mut self) {
+        self.local.clear();
+        self.extra = std::sync::Arc::default();
+    }
+}
+
+impl FromIterator<String> for RecoveryKnownCommands {
+    fn from_iter<I: IntoIterator<Item = String>>(iter: I) -> Self {
+        Self {
+            local: iter.into_iter().collect(),
+            extra: std::sync::Arc::default(),
+        }
+    }
 }
 
 /// True when an earlier *unconditional* user `proc` named `qualified_name`
@@ -1647,7 +1709,8 @@ proc foo {} {}
 
     #[test]
     fn recovery_known_commands_includes_registry_names() {
-        let known = recovery_known_commands("set x [foo\n", &registry(), &HashSet::new());
+        let known =
+            recovery_known_commands("set x [foo\n", &registry(), &std::sync::Arc::default());
         assert!(known.contains("set"));
         assert!(known.contains("puts"));
     }
@@ -1658,9 +1721,35 @@ proc foo {} {}
         // unconditionally, same as the registry — unlike the in-file
         // signature scan it is not gated on `script_is_complete`, since it
         // costs nothing extra to fold in a set the caller already built.
-        let extra: HashSet<String> = ["workspace_helper".to_string()].into_iter().collect();
+        let extra: std::sync::Arc<HashSet<String>> =
+            std::sync::Arc::new(["workspace_helper".to_string()].into_iter().collect());
         let known = recovery_known_commands("set x 1\n", &registry(), &extra);
         assert!(known.contains("workspace_helper"));
+    }
+
+    /// Issue #1154: the caller-supplied set must be *shared*, not copied — on
+    /// the LSP recovery path it holds every workspace-indexed proc and class,
+    /// and the recovery branch runs on every keystroke inside an unterminated
+    /// block.
+    #[test]
+    fn recovery_known_commands_shares_the_extra_set_rather_than_copying_it() {
+        let extra: SharedNameSet =
+            std::sync::Arc::new(["workspace_helper".to_string()].into_iter().collect());
+        let before = std::sync::Arc::strong_count(&extra);
+        let known = recovery_known_commands("set q {\nunclosed\n", &registry(), &extra);
+        assert_eq!(
+            std::sync::Arc::strong_count(&extra),
+            before + 1,
+            "the extra layer must be shared with the caller, not deep-copied",
+        );
+        assert!(known.contains("workspace_helper"));
+        assert!(known.contains("set"), "the registry layer is still present");
+        drop(known);
+        assert_eq!(
+            std::sync::Arc::strong_count(&extra),
+            before,
+            "dropping the universe must release the shared layer",
+        );
     }
 
     #[test]
@@ -1672,7 +1761,7 @@ proc foo {} {}
         let known = recovery_known_commands(
             "proc my_helper {} {}\nmy_helper\n",
             &registry(),
-            &HashSet::new(),
+            &std::sync::Arc::default(),
         );
         assert!(!known.contains("my_helper"));
         assert!(known.contains("proc")); // registry names are always present
@@ -1681,7 +1770,7 @@ proc foo {} {}
     #[test]
     fn recovery_known_commands_adds_user_proc_qualified_and_tail() {
         let src = "namespace eval myns {\n  proc helper {x} {return $x}\n}\n\nset q {\nunclosed\n";
-        let known = recovery_known_commands(src, &registry(), &HashSet::new());
+        let known = recovery_known_commands(src, &registry(), &std::sync::Arc::default());
         assert!(
             known.contains("myns::helper"),
             "expected the qualified name: {known:?}"
@@ -1699,7 +1788,7 @@ proc foo {} {}
         // Tcl syntax), so the leading-`::` form must be recognised
         // alongside the stripped/tail forms asserted above.
         let src = "namespace eval myns {\n  proc helper {x} {return $x}\n}\n\nset q {\nunclosed\n";
-        let known = recovery_known_commands(src, &registry(), &HashSet::new());
+        let known = recovery_known_commands(src, &registry(), &std::sync::Arc::default());
         assert!(
             known.contains("::myns::helper"),
             "expected the fully-qualified leading-:: form: {known:?}"
@@ -1710,7 +1799,7 @@ proc foo {} {}
     fn recovery_known_commands_adds_user_class_and_alias() {
         let src =
             "oo::class create Widget {}\ninterp alias {} greet {} puts hi\n\nset q {\nunclosed\n";
-        let known = recovery_known_commands(src, &registry(), &HashSet::new());
+        let known = recovery_known_commands(src, &registry(), &std::sync::Arc::default());
         assert!(known.contains("Widget"), "{known:?}");
         assert!(known.contains("greet"), "{known:?}");
     }
@@ -1718,7 +1807,7 @@ proc foo {} {}
     #[test]
     fn recovery_known_commands_adds_rename_target() {
         let src = "rename puts my_puts\n\nset q {\nunclosed\n";
-        let known = recovery_known_commands(src, &registry(), &HashSet::new());
+        let known = recovery_known_commands(src, &registry(), &std::sync::Arc::default());
         assert!(
             known.contains("my_puts"),
             "expected the rename target: {known:?}"
@@ -1728,7 +1817,7 @@ proc foo {} {}
     #[test]
     fn recovery_known_commands_adds_namespaced_rename_target() {
         let src = "namespace eval myns {\n  rename puts loud_puts\n}\n\nset q {\nunclosed\n";
-        let known = recovery_known_commands(src, &registry(), &HashSet::new());
+        let known = recovery_known_commands(src, &registry(), &std::sync::Arc::default());
         assert!(
             known.contains("myns::loud_puts"),
             "expected the qualified rename target: {known:?}"
@@ -1744,14 +1833,14 @@ proc foo {} {}
         // `rename OLD {}` deletes OLD; it must not introduce an empty-string
         // "command name".
         let src = "rename puts {}\n\nset q {\nunclosed\n";
-        let known = recovery_known_commands(src, &registry(), &HashSet::new());
+        let known = recovery_known_commands(src, &registry(), &std::sync::Arc::default());
         assert!(!known.contains(""));
     }
 
     #[test]
     fn recovery_known_commands_does_not_invent_undefined_names() {
         let src = "set q {\nunclosed\n";
-        let known = recovery_known_commands(src, &registry(), &HashSet::new());
+        let known = recovery_known_commands(src, &registry(), &std::sync::Arc::default());
         assert!(!known.contains("not_a_real_proc"));
         assert!(!known.contains("unclosed")); // plain data, not a definition
     }

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -29,6 +29,7 @@
 //! hasn't been run on this unit yet.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::sync::Arc;
 
 use tcl_registry::CommandRegistry;
 
@@ -176,7 +177,7 @@ pub struct UnitBuildOptions<'a> {
 /// [`InterproceduralAnalysis`], returns its (memoised) interprocedural taints,
 /// or `None` to fall back to a fresh [`FunctionUnit::interproc_taints`] re-run.
 pub type TaintCascadeCallback<'a> =
-    dyn FnMut(&str, &InterproceduralAnalysis) -> Option<HashMap<ValueKey, TaintLattice>> + 'a;
+    dyn FnMut(&str, &InterproceduralAnalysis) -> Option<Arc<HashMap<ValueKey, TaintLattice>>> + 'a;
 
 // Per-function analysis bundle
 
@@ -195,7 +196,14 @@ pub struct FunctionUnit {
     /// SSA form.
     pub ssa: SsaFunction,
     /// Def-use chains.
-    pub def_use: DefUseResult,
+    ///
+    /// Shared behind an `Arc` (like `types` / `taints` / `rendered_props`)
+    /// because it is **span-free**: [`crate::lattice_rebase::rebase_function_unit`]
+    /// never touches it, so a memoised unit taken from the salsa
+    /// `function_lattice` cache and rebased to a new offset keeps the very same
+    /// lattice. Deep-copying it per procedure per read was pure waste
+    /// (issue #1159).
+    pub def_use: Arc<DefUseResult>,
     /// SCCP result: lattice values, executable blocks, constant
     /// branches.
     pub sccp: SccpResult,
@@ -203,7 +211,9 @@ pub struct FunctionUnit {
     ///
     /// Computed by the type-propagation pass. Absent entries are
     /// implicitly `TypeLattice::unknown()`.
-    pub types: HashMap<ValueKey, TypeLattice>,
+    ///
+    /// Shared behind an `Arc` — see [`Self::def_use`].
+    pub types: Arc<HashMap<ValueKey, TypeLattice>>,
     /// Inferred return type — the join of the types produced at every
     /// executable `Return` terminator.  `Unknown` when the function
     /// has no executable return value.  Computed by
@@ -211,14 +221,21 @@ pub struct FunctionUnit {
     pub return_type: TypeLattice,
     /// Taint lattice values per SSA definition.
     ///
-    /// Computed by the intra-procedural taint-propagation pass.
-    /// Absent entries are implicitly clean (untainted).
-    pub taints: HashMap<ValueKey, TaintLattice>,
+    /// Computed by the intra-procedural taint-propagation pass, then replaced
+    /// by the interprocedural re-run ([`Self::interproc_taints`], memoised by
+    /// `tcl-lsp-db`'s `taint_cascade`).
+    ///
+    /// Shared behind an `Arc` — see [`Self::def_use`]. That also makes the
+    /// `taint_cascade` memo hit a refcount bump rather than a deep copy of the
+    /// whole per-procedure taint map.
+    pub taints: Arc<HashMap<ValueKey, TaintLattice>>,
     /// Rendered-string-property lattice values per SSA definition.
     ///
     /// Computed by `propagate_rendered_props`. Absent entries are
     /// implicitly `RenderedValueProps::bottom()`.
-    pub rendered_props: HashMap<ValueKey, RenderedValueProps>,
+    ///
+    /// Shared behind an `Arc` — see [`Self::def_use`].
+    pub rendered_props: Arc<HashMap<ValueKey, RenderedValueProps>>,
     /// Optional memory-SSA annotations (populated on demand).
     pub memory_ssa: Option<MemorySsaFunction>,
     /// Whether this function accesses variables whose *name* is computed at
@@ -580,12 +597,12 @@ impl FunctionUnit {
             name: name.into(),
             cfg,
             ssa,
-            def_use,
+            def_use: Arc::new(def_use),
             sccp,
-            types,
+            types: Arc::new(types),
             return_type,
-            taints,
-            rendered_props,
+            taints: Arc::new(taints),
+            rendered_props: Arc::new(rendered_props),
             memory_ssa: None,
             dynamic_names,
             complexity_guarded: false,
@@ -604,12 +621,12 @@ impl FunctionUnit {
             name: name.into(),
             cfg,
             ssa,
-            def_use: DefUseResult::default(),
+            def_use: Arc::default(),
             sccp: SccpResult::default(),
-            types: HashMap::new(),
+            types: Arc::default(),
             return_type: TypeLattice::unknown(),
-            taints: HashMap::new(),
-            rendered_props: HashMap::new(),
+            taints: Arc::default(),
+            rendered_props: Arc::default(),
             memory_ssa: None,
             // A guarded unit's lattices are all trivial and every per-proc
             // pass skips it, so the barrier stays clear (never consulted).
@@ -1463,7 +1480,7 @@ impl CompilationUnit {
         // Re-run taint with the new summary + dialect. We borrow
         // `interproc` immutably while each function unit re-runs
         // `propagate_taints`.
-        self.top_level.taints = propagate_taints(
+        self.top_level.taints = Arc::new(propagate_taints(
             &self.top_level.cfg,
             &self.top_level.ssa,
             &self.top_level.sccp,
@@ -1473,9 +1490,9 @@ impl CompilationUnit {
             dialect,
             None,
             None,
-        );
+        ));
         for fu in self.procedures.values_mut() {
-            fu.taints = propagate_taints(
+            fu.taints = Arc::new(propagate_taints(
                 &fu.cfg,
                 &fu.ssa,
                 &fu.sccp,
@@ -1485,7 +1502,7 @@ impl CompilationUnit {
                 dialect,
                 None,
                 None,
-            );
+            ));
         }
 
         self.interproc = Some(interproc);
@@ -1526,16 +1543,16 @@ impl CompilationUnit {
         let top_taints = self
             .top_level
             .interproc_taints(registry, &interproc, dialect);
-        self.top_level.taints = top_taints;
+        self.top_level.taints = Arc::new(top_taints);
 
         // Compute each procedure's taints (memoised via `taint_cb`, or fresh on a
         // miss) before mutating, so the immutable `&self.procedures` borrow the
         // fallback needs doesn't overlap the write-back.
-        let mut new_taints: Vec<(String, HashMap<ValueKey, TaintLattice>)> =
+        let mut new_taints: Vec<(String, Arc<HashMap<ValueKey, TaintLattice>>)> =
             Vec::with_capacity(self.procedures.len());
         for (qname, fu) in &self.procedures {
             let taints = taint_cb(qname, &interproc)
-                .unwrap_or_else(|| fu.interproc_taints(registry, &interproc, dialect));
+                .unwrap_or_else(|| Arc::new(fu.interproc_taints(registry, &interproc, dialect)));
             new_taints.push((qname.clone(), taints));
         }
         for (qname, taints) in new_taints {

--- a/rust/tcl-compiler/src/object_types.rs
+++ b/rust/tcl-compiler/src/object_types.rs
@@ -1048,7 +1048,7 @@ pub fn object_collection_classes(cu: &CompilationUnit) -> HashMap<String, HashSe
         .chain(cu.procedures.values())
         .chain(cu.methods.values());
     for fu in units {
-        for ((sym, _ver), t) in &fu.types {
+        for ((sym, _ver), t) in fu.types.iter() {
             if let Some(class) = t.element_class() {
                 out.entry(fu.ssa.var_name(*sym).to_owned())
                     .or_default()
@@ -1102,7 +1102,7 @@ fn harvest_unit(fu: &FunctionUnit, registry: &CommandRegistry, sink: &mut FactSi
     }
     // SSA values typed `OBJECT(class)` — includes collection retrievals
     // (`set p [dict get $pins $k]`) the syntactic scan above cannot see.
-    for ((sym, _ver), t) in &fu.types {
+    for ((sym, _ver), t) in fu.types.iter() {
         if t.tcl_type() == Some(tcl_registry::TclType::Object)
             && let Some(class) = t.class_name()
         {

--- a/rust/tcl-compiler/src/optimiser/branch_folding.rs
+++ b/rust/tcl-compiler/src/optimiser/branch_folding.rs
@@ -385,7 +385,6 @@ mod tests {
     use crate::analyses::{ConstValue, LatticeValue};
     use crate::cfg::{Block, BlockId, Function as CfgFunction, Terminator};
     use crate::compilation_unit::{CompilationUnit, FunctionUnit};
-    use crate::def_use::DefUseResult;
     use crate::expr_ast::{BinOp, ExprNode};
     use crate::interprocedural::InterproceduralAnalysis;
     use crate::sccp::{ConstantBranch, SccpResult};
@@ -468,12 +467,12 @@ mod tests {
             name: name.into(),
             cfg,
             ssa,
-            def_use: DefUseResult::default(),
+            def_use: std::sync::Arc::default(),
             sccp,
-            types: std::collections::HashMap::new(),
+            types: std::sync::Arc::default(),
             return_type: crate::types::TypeLattice::unknown(),
-            taints: std::collections::HashMap::new(),
-            rendered_props: std::collections::HashMap::new(),
+            taints: std::sync::Arc::default(),
+            rendered_props: std::sync::Arc::default(),
             memory_ssa: None,
             dynamic_names: crate::dynamic_names::DynamicNameBarrier::default(),
             complexity_guarded: false,

--- a/rust/tcl-compiler/src/optimiser/helpers/expr_simplify.rs
+++ b/rust/tcl-compiler/src/optimiser/helpers/expr_simplify.rs
@@ -116,7 +116,7 @@ pub fn operand_types(fu: &FunctionUnit) -> OperandTypes {
     use std::collections::HashMap;
     // symbol → (all-versions-numeric, all-versions-integer).
     let mut acc: HashMap<crate::ssa::Symbol, (bool, bool)> = HashMap::new();
-    for ((sym, _ver), lattice) in &fu.types {
+    for ((sym, _ver), lattice) in fu.types.iter() {
         let is_num = lattice_is_numeric(lattice);
         let is_int = lattice_is_integer(lattice);
         acc.entry(*sym)

--- a/rust/tcl-compiler/src/optimiser/pattern_recognition.rs
+++ b/rust/tcl-compiler/src/optimiser/pattern_recognition.rs
@@ -81,7 +81,7 @@ pub fn run(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
 fn int_var_names(fu: &FunctionUnit) -> HashSet<String> {
     use std::collections::HashMap;
     let mut acc: HashMap<crate::ssa::Symbol, bool> = HashMap::new();
-    for ((sym, _ver), lattice) in &fu.types {
+    for ((sym, _ver), lattice) in fu.types.iter() {
         let is_int = lattice_is_int(lattice);
         acc.entry(*sym)
             .and_modify(|v| *v = *v && is_int)

--- a/rust/tcl-compiler/src/segmenter.rs
+++ b/rust/tcl-compiler/src/segmenter.rs
@@ -581,17 +581,14 @@ where
 /// The E204-E206 lexer-warning
 /// codes are emitted separately by the analyser.
 #[must_use]
-pub fn segment_with_recovery<S>(
+pub fn segment_with_recovery(
     source: &str,
     config: LexerConfig,
-    known: &std::collections::HashSet<String, S>,
+    known: &crate::analyser::utils::RecoveryKnownCommands,
 ) -> (
     Vec<SegmentedCommand>,
     Vec<crate::analyser::types::Diagnostic>,
-)
-where
-    S: std::hash::BuildHasher,
-{
+) {
     // Cap the re-lex iterations to bound work on pathological input.
     const MAX_GHOST_RECOVERY_PASSES: usize = 32;
 
@@ -851,7 +848,7 @@ mod tests {
         // known command re-lexes into a clean two-command stream and
         // yields an E201 diagnostic.
         let reg = tcl_registry::CommandRegistry::build_default();
-        let known: std::collections::HashSet<String> =
+        let known: crate::analyser::utils::RecoveryKnownCommands =
             reg.command_names().map(str::to_owned).collect();
         let cfg = LexerConfig::default();
         let (rec, diags) = segment_with_recovery("set x [foo bar\nputs done\n", cfg, &known);
@@ -865,7 +862,7 @@ mod tests {
     #[test]
     fn recovery_is_a_noop_on_clean_input() {
         let reg = tcl_registry::CommandRegistry::build_default();
-        let known: std::collections::HashSet<String> =
+        let known: crate::analyser::utils::RecoveryKnownCommands =
             reg.command_names().map(str::to_owned).collect();
         let cfg = LexerConfig::default();
         let src = "set ok [foo]\nputs hi\n";

--- a/rust/tcl-compiler/src/taint.rs
+++ b/rust/tcl-compiler/src/taint.rs
@@ -6431,7 +6431,7 @@ mod tests {
             };
 
             let fu = cu.function("::p").unwrap();
-            let patched = apply_module_variable_traces(fu.taints.clone(), &fu.ssa, traces);
+            let patched = apply_module_variable_traces((*fu.taints).clone(), &fu.ssa, traces);
             let sym = fu.ssa.var_symbol("t").expect("t interned");
             assert!(
                 patched.get(&(sym, 1)).is_some_and(|t| t.is_tainted()),
@@ -6454,9 +6454,9 @@ mod tests {
                 has_dynamic_variable_trace: cu.ir_module.has_dynamic_variable_trace,
             };
             let fu = cu.function("::p").unwrap();
-            let patched = apply_module_variable_traces(fu.taints.clone(), &fu.ssa, traces);
+            let patched = apply_module_variable_traces((*fu.taints).clone(), &fu.ssa, traces);
             assert_eq!(
-                patched, fu.taints,
+                patched, *fu.taints,
                 "no trace in scope — map must be unchanged"
             );
         }

--- a/rust/tcl-compiler/src/type_infer.rs
+++ b/rust/tcl-compiler/src/type_infer.rs
@@ -2446,7 +2446,7 @@ mod tests {
     ) -> TypeLattice {
         let fu = cu.function(func).unwrap();
         let mut acc = TypeLattice::unknown();
-        for ((sym, ver), t) in &fu.types {
+        for ((sym, ver), t) in fu.types.iter() {
             if *ver > 0 && fu.ssa.var_name(*sym) == var {
                 acc = type_join(&acc, t);
             }

--- a/rust/tcl-compiler/tests/type_propagation.rs
+++ b/rust/tcl-compiler/tests/type_propagation.rs
@@ -62,7 +62,7 @@ fn var_types(src: &str, qname: &str, var: &str) -> HashMap<u32, TypeLattice> {
             .unwrap_or_else(|| panic!("procedure {qname} not found"))
     };
     let mut out = HashMap::new();
-    for ((sym, ver), t) in &fu.types {
+    for ((sym, ver), t) in fu.types.iter() {
         if fu.ssa.var_name(*sym) == var {
             out.insert(*ver, t.clone());
         }

--- a/rust/tcl-lexer/src/line_index.rs
+++ b/rust/tcl-lexer/src/line_index.rs
@@ -192,6 +192,29 @@ impl LineIndex {
         self.line_starts = next.into_boxed_slice();
     }
 
+    /// Whether `source` contains a *lone* `\r` — a `\r` not immediately
+    /// followed by `\n`.
+    ///
+    /// This is the exact ambiguity that separates [`Self::new_lsp`] from
+    /// [`Self::new`]: a CRLF pair is a single break at the `\n` in *both*
+    /// models, so it is never itself the source of a divergence, but a bare
+    /// `\r` is a break under [`Self::new_lsp`] and plain whitespace under
+    /// [`Self::new`]. When `source` has none, `new_lsp(source)` and
+    /// `new(source)` therefore agree line-start-for-line-start, which is
+    /// exactly the condition [`Self::apply_edit`] needs to stay sound when
+    /// patching an `new_lsp`-built index (see its fuzz-equivalence test,
+    /// which never puts a `\r` in its edit alphabet, and the LSP server's
+    /// `did_change`, which uses this to decide whether the incremental patch
+    /// remains valid for a given document).
+    #[must_use]
+    pub fn contains_bare_cr(source: &str) -> bool {
+        let bytes = source.as_bytes();
+        bytes
+            .iter()
+            .enumerate()
+            .any(|(i, &b)| b == b'\r' && bytes.get(i + 1) != Some(&b'\n'))
+    }
+
     /// Number of lines in the index. Always ≥ 1 for any `LineIndex`
     /// built from a non-`None` source (even an empty string contains
     /// one line).
@@ -671,6 +694,17 @@ mod tests {
             idx.position_at(4),
             SourcePosition::new(0, ByteCol::new(4), 4)
         );
+    }
+
+    #[test]
+    fn contains_bare_cr_distinguishes_lone_cr_from_crlf() {
+        assert!(!LineIndex::contains_bare_cr("abc\ndef"));
+        assert!(!LineIndex::contains_bare_cr("abc\r\ndef\r\n"));
+        assert!(!LineIndex::contains_bare_cr(""));
+        assert!(LineIndex::contains_bare_cr("abc\rdef"));
+        assert!(LineIndex::contains_bare_cr("abc\r\ndef\r"));
+        // A trailing `\r` with nothing after it is bare.
+        assert!(LineIndex::contains_bare_cr("abc\r"));
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/code_lens.rs
+++ b/rust/tcl-lsp-core/src/code_lens.rs
@@ -370,6 +370,72 @@ pub fn reference_count_title(count: usize) -> String {
     }
 }
 
+/// Whether `qname` names a symbol [`code_lenses`] would emit a lens for in
+/// this document — a proc, a class, or one of a class's members (method /
+/// classmethod / property / constructor / destructor), matching exactly the
+/// same "declared members only" guards `code_lenses` /
+/// `emit_class_member_lenses` apply (a member with an empty `name_span`
+/// gets no lens, so it must not answer `true` here either).
+///
+/// `codeLens/resolve` (issue #1152) used this existence check to decide
+/// whether a lens is genuinely one of this document's own lenses before
+/// resolving its click locations — previously by calling [`code_lenses`] in
+/// full and searching its output for a matching `qname`, which recomputed
+/// every *other* proc's / class's / member's reference count (each itself a
+/// resolver walk) just to answer one boolean. This answers the same
+/// question with direct `HashMap`/`Vec` lookups: O(1) for a plain proc or
+/// class, O(the document's own class count) for a member qname (bounded by
+/// how many classes share its `{class}::…` prefix, never by proc count or
+/// by any reference-resolution work).
+#[must_use]
+pub fn lens_qname_exists(analysis: &AnalysisResult, qname: &str) -> bool {
+    if analysis.all_procs.contains_key(qname) || analysis.all_classes.contains_key(qname) {
+        return true;
+    }
+    for (class_q, class_def) in &analysis.all_classes {
+        let Some(rest) = qname.strip_prefix(class_q.as_str()) else {
+            continue;
+        };
+        // A shorter `class_q` can still produce a `rest` that happens to
+        // start with one of these markers (e.g. a class literally named
+        // `method` nested under this one) — only trust a *hit*, and keep
+        // checking the other classes on a miss rather than trusting a wrong
+        // split's "not found" as the final answer.
+        let found = if let Some(name) = rest.strip_prefix("::method::") {
+            class_def
+                .methods
+                .get(name)
+                .is_some_and(|m| !m.name_span.is_empty())
+        } else if let Some(name) = rest.strip_prefix("::classmethod::") {
+            class_def
+                .class_methods
+                .get(name)
+                .is_some_and(|m| !m.name_span.is_empty())
+        } else if let Some(name) = rest.strip_prefix("::property::") {
+            class_def
+                .properties
+                .get(name)
+                .is_some_and(|p| !p.name_span.is_empty())
+        } else if rest == "::constructor" {
+            class_def
+                .constructors
+                .last()
+                .is_some_and(|c| !c.name_span.is_empty())
+        } else if rest == "::destructor" {
+            class_def
+                .destructor
+                .as_ref()
+                .is_some_and(|d| !d.name_span.is_empty())
+        } else {
+            false
+        };
+        if found {
+            return true;
+        }
+    }
+    false
+}
+
 /// Count invocations targeting the given class — `ClassName
 /// new ...`, `ClassName create instance`, and inheritance
 /// references in `oo::class create Sub { superclass ClassName
@@ -1238,5 +1304,121 @@ mod tests {
         let li = LineIndex::new(src);
         let name_line = li.position_at_utf16(build_span.start(), src).line;
         assert_lens_matches_references(src, name_line);
+    }
+
+    // lens_qname_exists (issue #1152: codeLens/resolve's targeted existence
+    // check, replacing a full `code_lenses` walk)
+
+    #[test]
+    fn lens_qname_exists_finds_a_plain_proc() {
+        let analysis = analyse("proc foo {} {}\n");
+        assert!(lens_qname_exists(&analysis, "::foo"));
+        assert!(!lens_qname_exists(&analysis, "::bar"));
+    }
+
+    #[test]
+    fn lens_qname_exists_finds_a_plain_class() {
+        let analysis = analyse("oo::class create Widget {}\n");
+        if analysis.all_classes.is_empty() {
+            return;
+        }
+        assert!(lens_qname_exists(&analysis, "::Widget"));
+        assert!(!lens_qname_exists(&analysis, "::Other"));
+    }
+
+    #[test]
+    fn lens_qname_exists_finds_a_method_and_classmethod_and_disambiguates() {
+        let src = "oo::class create C {\n    method foo {} {}\n    classmethod foo {} {}\n}\n";
+        let analysis = analyse(src);
+        assert!(lens_qname_exists(
+            &analysis,
+            &tcl_compiler::analyser::class_member_key("::C", "foo", false)
+        ));
+        assert!(lens_qname_exists(
+            &analysis,
+            &tcl_compiler::analyser::class_member_key("::C", "foo", true)
+        ));
+        // A name neither table declares must not exist.
+        assert!(!lens_qname_exists(
+            &analysis,
+            &tcl_compiler::analyser::class_member_key("::C", "missing", false)
+        ));
+    }
+
+    #[test]
+    fn lens_qname_exists_finds_a_property() {
+        let src = "oo::class create Widget {\n    property size\n}\n";
+        let analysis = analyse90(src);
+        assert!(lens_qname_exists(
+            &analysis,
+            &tcl_compiler::analyser::class_property_key("::Widget", "size")
+        ));
+        assert!(!lens_qname_exists(
+            &analysis,
+            &tcl_compiler::analyser::class_property_key("::Widget", "missing")
+        ));
+    }
+
+    #[test]
+    fn lens_qname_exists_finds_constructor_and_destructor() {
+        let src = "oo::class create Bar {\n    constructor {} {}\n    destructor {}\n}\n";
+        let analysis = analyse(src);
+        assert!(lens_qname_exists(
+            &analysis,
+            &tcl_compiler::analyser::class_constructor_key("::Bar")
+        ));
+        assert!(lens_qname_exists(
+            &analysis,
+            &tcl_compiler::analyser::class_destructor_key("::Bar")
+        ));
+        // A class with no explicit constructor/destructor gets neither.
+        let plain = analyse("oo::class create Plain {\n    method use {} {}\n}\n");
+        assert!(!lens_qname_exists(
+            &plain,
+            &tcl_compiler::analyser::class_constructor_key("::Plain")
+        ));
+        assert!(!lens_qname_exists(
+            &plain,
+            &tcl_compiler::analyser::class_destructor_key("::Plain")
+        ));
+    }
+
+    #[test]
+    fn lens_qname_exists_rejects_an_unrelated_qname() {
+        let src = "proc foo {} {}\noo::class create Bar {\n    method m {} {}\n}\n";
+        let analysis = analyse(src);
+        assert!(!lens_qname_exists(&analysis, "::nope"));
+        assert!(!lens_qname_exists(&analysis, "::Bar::method::nope"));
+        assert!(!lens_qname_exists(&analysis, "::NoSuchClass::method::m"));
+    }
+
+    #[test]
+    fn lens_qname_exists_agrees_with_code_lenses_output() {
+        // Structural parity: every qname `code_lenses` actually emits a lens
+        // for must be found by the targeted check, and nothing else is.
+        let src = concat!(
+            "proc helper {} {}\n",
+            "oo::class create Bar {\n",
+            "    variable _x\n",
+            "    constructor {} { set _x 0 }\n",
+            "    destructor {}\n",
+            "    method get {} { return $_x }\n",
+            "    classmethod make {} { return [Bar new] }\n",
+            "    property colour\n",
+            "}\n",
+            "helper\n",
+            "set b [Bar new]\n",
+            "$b get\n",
+        );
+        let analysis = analyse90(src);
+        let lenses = code_lenses(src, "tcl9.0", Some(&analysis), None, "");
+        assert!(!lenses.is_empty(), "sanity: some lenses expected");
+        for lens in &lenses {
+            assert!(
+                lens_qname_exists(&analysis, &lens.qname),
+                "code_lenses emitted a qname the targeted check rejects: {}",
+                lens.qname,
+            );
+        }
     }
 }

--- a/rust/tcl-lsp-core/src/completion.rs
+++ b/rust/tcl-lsp-core/src/completion.rs
@@ -391,8 +391,9 @@ fn context_aware_completions(
     // the ensemble operations of a scoped command (`top ` → `set`/`get`/`enable`
     // /…) complete at word index 1.  Checked before the registry lookup because
     // a scoped head (`top`) is not a registered command.
+    let line_index = tcl_lexer::LineIndex::new(source);
     if word_idx == 1
-        && let Some(env) = scoped_env_at(analysis, source, line, character)
+        && let Some(env) = scoped_env_at(analysis, source, line, character, &line_index)
         && let Some(scoped) = env.command(&cmd)
         && !scoped.subcommands.is_empty()
     {
@@ -515,6 +516,28 @@ fn context_aware_completions(
     None
 }
 
+/// [`completions`]'s `$var` / `${var}` trigger branch, split out so the
+/// parent function stays under the line-count lint. `None` when the cursor
+/// isn't on a variable trigger — the caller falls through to the rest of the
+/// completion pipeline.
+fn variable_trigger_completions(
+    source: &str,
+    line: u32,
+    character: u32,
+    analysis: &AnalysisResult,
+) -> Option<Vec<CompletionItem>> {
+    let (trigger, partial) = variable_trigger(source, line, character)?;
+    Some(variable_completions(
+        source,
+        line,
+        character,
+        &analysis.global_scope,
+        &partial,
+        trigger,
+        analysis.ns_var_global_fallback(),
+    ))
+}
+
 /// Compute completions for a position in `source`.
 ///
 /// `analysis` is the pre-computed analyser result; the caller
@@ -549,18 +572,12 @@ pub fn completions(
     workspace: Option<&crate::workspace_index::WorkspaceIndex>,
     dialect: &str,
 ) -> Vec<CompletionItem> {
-    if let Some((trigger, partial)) = variable_trigger(source, line, character) {
-        return variable_completions(
-            source,
-            line,
-            character,
-            &analysis.global_scope,
-            &partial,
-            trigger,
-            analysis.ns_var_global_fallback(),
-        );
+    if let Some(items) = variable_trigger_completions(source, line, character, analysis) {
+        return items;
     }
     let partial = word_partial_at_position(source, line, character);
+    // Shared by the position lookups below instead of each rebuilding its own.
+    let line_index = tcl_lexer::LineIndex::new(source);
 
     // Context-aware completions — switch + subcommand + event-name.
     // All three require the caller-provided registry to look up
@@ -589,7 +606,7 @@ pub fn completions(
     // The context test is registry-driven (`ArgRole::Expr`); see
     // `crate::expr_context`.
     if let Some(registry) = registry
-        && crate::expr_context::expr_arg_context_at(source, line, character, registry)
+        && crate::expr_context::expr_arg_context_at(source, line, character, &line_index, registry)
     {
         items.extend(math_function_completions(
             registry,
@@ -604,7 +621,7 @@ pub fn completions(
         // that, a plain `.tcl` script must not be offered `button`/`pack`/… .
         let tk_loaded =
             dialect == "tk" || analysis.package_requires.iter().any(|req| req.name == "Tk");
-        let oo_frame = oo_frame_at(analysis, source, line, character);
+        let oo_frame = oo_frame_at(analysis, source, line, character, &line_index);
         items.extend(builtin_completions(
             registry, dialect, &partial, &usage, tk_loaded, analysis, oo_frame,
         ));
@@ -613,7 +630,7 @@ pub fn completions(
     // offer its command heads (`top`, `data`, `columns`, …) alongside the
     // ordinary command/proc set — a style body uses both scoped and core
     // commands.  Deduped by label so a scoped name never doubles a core one.
-    if let Some(env) = scoped_env_at(analysis, source, line, character) {
+    if let Some(env) = scoped_env_at(analysis, source, line, character, &line_index) {
         let present: FxHashSet<String> = items.iter().map(|i| i.label.clone()).collect();
         for item in scoped_command_completions(env, &partial) {
             if !present.contains(&item.label) {
@@ -687,7 +704,15 @@ pub fn completions(
     // the fragment, so any fragment that matches something today keeps
     // today's response byte-for-byte.
     if items.is_empty() {
-        items = fuzzy_command_fallback(source, line, character, analysis, registry, dialect);
+        items = fuzzy_command_fallback(
+            source,
+            line,
+            character,
+            analysis,
+            registry,
+            dialect,
+            &line_index,
+        );
     }
     items
 }
@@ -1553,9 +1578,9 @@ fn scoped_env_at(
     source: &str,
     line: u32,
     character: u32,
+    line_index: &tcl_lexer::LineIndex,
 ) -> Option<&'static tcl_registry::scoped::ScopedCommandEnv> {
-    let line_index = tcl_lexer::LineIndex::new(source);
-    let offset = crate::definition::byte_offset_at(&line_index, source, line, character);
+    let offset = crate::definition::byte_offset_at(line_index, source, line, character);
     analysis
         .scoped_command_regions
         .iter()
@@ -1736,9 +1761,9 @@ fn oo_frame_at(
     source: &str,
     line: u32,
     character: u32,
+    line_index: &tcl_lexer::LineIndex,
 ) -> crate::oo_dispatch::OoFrame {
-    let line_index = tcl_lexer::LineIndex::new(source);
-    let offset = crate::definition::byte_offset_at(&line_index, source, line, character);
+    let offset = crate::definition::byte_offset_at(line_index, source, line, character);
     crate::oo_dispatch::OoFrame::at(analysis, offset)
 }
 
@@ -2036,6 +2061,7 @@ fn fuzzy_command_fallback(
     analysis: &AnalysisResult,
     registry: Option<&CommandRegistry>,
     dialect: &str,
+    line_index: &tcl_lexer::LineIndex,
 ) -> Vec<CompletionItem> {
     let partial = word_partial_at_position(source, line, character);
     if partial.chars().count() < MIN_FUZZY_FRAGMENT_CHARS {
@@ -2067,12 +2093,12 @@ fn fuzzy_command_fallback(
     if let Some(registry) = registry {
         let tk_loaded =
             dialect == "tk" || analysis.package_requires.iter().any(|req| req.name == "Tk");
-        let oo_frame = oo_frame_at(analysis, source, line, character);
+        let oo_frame = oo_frame_at(analysis, source, line, character, line_index);
         universe.extend(builtin_completions(
             registry, dialect, "", &usage, tk_loaded, analysis, oo_frame,
         ));
     }
-    if let Some(env) = scoped_env_at(analysis, source, line, character) {
+    if let Some(env) = scoped_env_at(analysis, source, line, character, line_index) {
         let present: FxHashSet<String> = universe.iter().map(|i| i.label.clone()).collect();
         universe.extend(
             scoped_command_completions(env, "")

--- a/rust/tcl-lsp-core/src/expr_context.rs
+++ b/rust/tcl-lsp-core/src/expr_context.rs
@@ -284,16 +284,20 @@ fn word_at_is_expr_argument(source: &str, probe: usize, registry: &CommandRegist
 /// argument is the braced word and the cursor is inside it.  A `[…]`
 /// substitution re-enters script context, so a cursor inside one is never in
 /// an expression argument of the command outside it.
+///
+/// Takes a pre-built `line_index` so a caller resolving several positions per
+/// request (`completions`) shares one index instead of each probe rebuilding
+/// its own.
 #[must_use]
 pub fn expr_arg_context_at(
     source: &str,
     line: u32,
     character: u32,
+    line_index: &tcl_lexer::LineIndex,
     registry: &CommandRegistry,
 ) -> bool {
-    let line_index = tcl_lexer::LineIndex::new(source);
     let cursor_off =
-        crate::definition::byte_offset_at(&line_index, source, line, character) as usize;
+        crate::definition::byte_offset_at(line_index, source, line, character) as usize;
     match innermost_unclosed_opener(source, cursor_off) {
         // Inside a braced word: that word is the candidate argument.
         Some((pos, '{')) => word_at_is_expr_argument(source, pos, registry),
@@ -311,38 +315,45 @@ mod tests {
         tcl_registry::registry_for_dialect("tcl8.6")
     }
 
+    /// Builds the `line_index` [`expr_arg_context_at`] now expects, so the
+    /// tests keep passing a bare source string.
+    fn ctx(source: &str, line: u32, character: u32) -> bool {
+        let line_index = tcl_lexer::LineIndex::new(source);
+        expr_arg_context_at(source, line, character, &line_index, reg())
+    }
+
     /// TP: the canonical incomplete-source shape from issue #974 defect 2.
     #[test]
     fn expr_context_detected_in_a_partially_typed_expr() {
         let src = "set a [expr {si";
-        assert!(expr_arg_context_at(src, 0, 15, reg()));
+        assert!(ctx(src, 0, 15));
     }
 
     /// TP: `if` / `while` / `for` conditions are EXPR-role arguments too — the
     /// registry says so, nothing here names a command.
     #[test]
     fn expr_context_detected_in_if_and_while_conditions() {
-        assert!(expr_arg_context_at("if {si", 0, 6, reg()));
-        assert!(expr_arg_context_at("while {ma", 0, 9, reg()));
+        assert!(ctx("if {si", 0, 6));
+        assert!(ctx("while {ma", 0, 9));
         // `for`'s third word is the condition; its second is a body.
-        assert!(expr_arg_context_at("for {set i 0} {si", 0, 17, reg()));
+        assert!(ctx("for {set i 0} {si", 0, 17));
     }
 
     /// TN: command position, an ordinary argument, a body argument, and a
     /// `[…]` substitution nested inside an expression (script context again).
     #[test]
     fn expr_context_not_detected_outside_expression_arguments() {
-        assert!(!expr_arg_context_at("si", 0, 2, reg()));
-        assert!(!expr_arg_context_at("puts si", 0, 7, reg()));
-        assert!(!expr_arg_context_at("set si", 0, 6, reg()));
-        assert!(!expr_arg_context_at("if {1} {si", 0, 10, reg()));
-        assert!(!expr_arg_context_at("set a [expr {[si", 0, 16, reg()));
+        assert!(!ctx("si", 0, 2));
+        assert!(!ctx("puts si", 0, 7));
+        assert!(!ctx("set si", 0, 6));
+        assert!(!ctx("if {1} {si", 0, 10));
+        assert!(!ctx("set a [expr {[si", 0, 16));
     }
 
     /// The unbraced `expr` form is an EXPR argument as well.
     #[test]
     fn expr_context_detected_for_the_unbraced_expr_form() {
-        assert!(expr_arg_context_at("set a [expr si", 0, 14, reg()));
+        assert!(ctx("set a [expr si", 0, 14));
     }
 
     /// A completed earlier command on a previous line must not leak its role
@@ -350,7 +361,7 @@ mod tests {
     #[test]
     fn expr_context_is_scoped_to_the_command_being_typed() {
         let src = "if {$a > 1} { puts hi }\nputs si";
-        assert!(!expr_arg_context_at(src, 1, 7, reg()));
+        assert!(!ctx(src, 1, 7));
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/inlay_hints.rs
+++ b/rust/tcl-lsp-core/src/inlay_hints.rs
@@ -145,6 +145,26 @@ pub fn inlay_hints(
     }
 
     if parameter_hints {
+        // The segmenter has no sound way to start mid-file (a command
+        // boundary requires tracking brace/bracket nesting from the top), so
+        // it still walks the whole document. What a requested viewport buys
+        // is skipping the *resolution* work per segment — the namespace walk
+        // (`lookup_proc`) and the registry synopsis lookup — for a command
+        // that falls entirely outside the range: cheap span arithmetic on
+        // data the segmenter already produced, applied before any of that
+        // work runs, not after (the `position_within_range` filter inside
+        // `emit_hints_for_call`/`emit_builtin_hints` only ever trimmed the
+        // *output*).
+        let range_start_off = line_index.offset_at_utf16(
+            range.start_line,
+            tcl_lexer::Utf16Col::new(range.start_character),
+            source,
+        );
+        let range_end_off = line_index.offset_at_utf16(
+            range.end_line,
+            tcl_lexer::Utf16Col::new(range.end_character),
+            source,
+        );
         let segments = tcl_compiler::segmenter::segment_commands_with_offset_and_config(
             source,
             0,
@@ -152,6 +172,9 @@ pub fn inlay_hints(
         );
         for seg in &segments {
             if seg.texts.is_empty() || seg.argv.is_empty() {
+                continue;
+            }
+            if seg.span.end() <= range_start_off || seg.span.start() >= range_end_off {
                 continue;
             }
             let cmd_name = &seg.texts[0];
@@ -1197,6 +1220,44 @@ mod tests {
         let hints = inlay_hints(src, "tcl", range, Some(&analysis), None, false, true);
         assert_eq!(hints.len(), 1, "{hints:?}");
         assert_eq!(hints[0].position_line, 2);
+    }
+
+    /// Issue #1160: a command whose span falls entirely outside the
+    /// requested range must never reach `lookup_proc` or the registry
+    /// synopsis lookup. There is no call counter to assert against through
+    /// the public API, so this is parity: the narrow-range result must equal
+    /// the in-range subset of the full-range result, for a document whose
+    /// out-of-range lines exercise *both* resolution branches the skip has to
+    /// short-circuit — an unresolvable call (line 2) and a real builtin call
+    /// that would otherwise emit its own hints (line 3, `puts`, two
+    /// positionals).
+    #[test]
+    fn out_of_range_segments_are_skipped_without_changing_in_range_results() {
+        let src =
+            "proc greet {name} {}\ngreet alice\nunknownproc foo bar\nputs hello world\ngreet zed\n";
+        let analysis = analyse(src);
+        let reg = registry();
+        let full = LspRange {
+            start_line: 0,
+            start_character: 0,
+            end_line: 10,
+            end_character: 0,
+        };
+        let narrow = LspRange {
+            start_line: 4,
+            start_character: 0,
+            end_line: 4,
+            end_character: u32::MAX,
+        };
+        let full_hints = inlay_hints(src, "tcl", full, Some(&analysis), Some(&reg), false, true);
+        let narrow_hints =
+            inlay_hints(src, "tcl", narrow, Some(&analysis), Some(&reg), false, true);
+        let expected: Vec<_> = full_hints
+            .into_iter()
+            .filter(|h| h.position_line == 4)
+            .collect();
+        assert_eq!(narrow_hints, expected);
+        assert_eq!(narrow_hints.len(), 1, "{narrow_hints:?}");
     }
 
     // built-in command synopsis hints

--- a/rust/tcl-lsp-core/src/inlay_hints.rs
+++ b/rust/tcl-lsp-core/src/inlay_hints.rs
@@ -263,7 +263,7 @@ fn collect_type_hints(
     let mut by_function: FxHashMap<String, FxHashMap<String, String>> = FxHashMap::default();
     for fu in cu.functions() {
         let mut m: FxHashMap<String, String> = FxHashMap::default();
-        for ((name, _ver), tl) in &fu.types {
+        for ((name, _ver), tl) in fu.types.iter() {
             if let Some(display) = type_display(tl) {
                 m.insert(fu.ssa.var_name(*name).to_owned(), display);
             }

--- a/rust/tcl-lsp-core/src/package_resolver.rs
+++ b/rust/tcl-lsp-core/src/package_resolver.rs
@@ -664,11 +664,39 @@ fn collapse_colons(cmd: &str) -> (String, usize) {
 /// first discovered — and *ties are broken by discovery order*, so listing a
 /// workspace-local copy first still shadows an equally-versioned installed
 /// one.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct PackageResolver {
     packages: HashMap<String, Vec<PackageInfo>>,
     auto_index: HashMap<String, Vec<PathBuf>>,
     scanned_dirs: Vec<PathBuf>,
+    revision: u64,
+}
+
+/// Source of [`PackageResolver::revision`] values.
+///
+/// Drawn from one process-wide counter (rather than a per-resolver `+= 1`) so a
+/// revision identifies *which* database state, not just how many mutations it
+/// has seen: the server replaces the resolver wholesale on a rescan
+/// (`*package_resolver.write().await = resolver`), and a per-instance counter
+/// would let a fresh resolver's low revision collide with an older, already-
+/// cached one. Every value handed out here is unique for the process lifetime,
+/// so "same revision" means "same resolver contents" for any consumer caching
+/// a derived view.
+static RESOLVER_REVISION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+fn next_resolver_revision() -> u64 {
+    RESOLVER_REVISION.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+}
+
+impl Default for PackageResolver {
+    fn default() -> Self {
+        Self {
+            packages: HashMap::new(),
+            auto_index: HashMap::new(),
+            scanned_dirs: Vec::new(),
+            revision: next_resolver_revision(),
+        }
+    }
 }
 
 impl PackageResolver {
@@ -678,10 +706,28 @@ impl PackageResolver {
         Self::default()
     }
 
+    /// An opaque token identifying this resolver's current contents.
+    ///
+    /// Bumped by every mutation ([`Self::add_pkg_index`], [`Self::add_tcl_index`],
+    /// [`Self::scan_path`], [`Self::scan_tree`]) and unique across resolver
+    /// instances, so a consumer caching something derived from the package
+    /// database (the recovery known-command widening in `tcl-lsp-server`) can
+    /// tell whether its cache is still valid without diffing the database.
+    #[must_use]
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    /// Note a mutation: take a fresh, process-unique revision.
+    fn invalidate(&mut self) {
+        self.revision = next_resolver_revision();
+    }
+
     /// Record a parsed `pkgIndex.tcl`'s declarations, appended in discovery
     /// order (selection among them is
     /// [`Self::resolve_require`]'s job, not this one's).
     pub fn add_pkg_index(&mut self, infos: Vec<PackageInfo>) {
+        self.invalidate();
         for info in infos {
             self.packages
                 .entry(info.name.clone())
@@ -692,6 +738,7 @@ impl PackageResolver {
 
     /// Record a parsed `tclIndex`'s declarations.
     pub fn add_tcl_index(&mut self, entries: Vec<AutoIndexEntry>) {
+        self.invalidate();
         for entry in entries {
             self.auto_index
                 .entry(entry.proc_name)

--- a/rust/tcl-lsp-core/src/package_resolver.rs
+++ b/rust/tcl-lsp-core/src/package_resolver.rs
@@ -708,11 +708,16 @@ impl PackageResolver {
 
     /// An opaque token identifying this resolver's current contents.
     ///
-    /// Bumped by every mutation ([`Self::add_pkg_index`], [`Self::add_tcl_index`],
-    /// [`Self::scan_path`], [`Self::scan_tree`]) and unique across resolver
-    /// instances, so a consumer caching something derived from the package
-    /// database (the recovery known-command widening in `tcl-lsp-server`) can
-    /// tell whether its cache is still valid without diffing the database.
+    /// Bumped by every mutation of the package database
+    /// ([`Self::add_pkg_index`] and [`Self::add_tcl_index`], including the
+    /// calls [`Self::scan_path`] / [`Self::scan_tree`] make when they discover
+    /// index files) and unique across resolver instances, so a consumer
+    /// caching something derived from the package database (the recovery
+    /// known-command widening in `tcl-lsp-server`) can tell whether its cache
+    /// is still valid without diffing the database. A scan that discovers no
+    /// index files records the directory as visited but leaves the revision
+    /// unchanged — nothing a consumer can derive differs, so its caches stay
+    /// valid.
     #[must_use]
     pub fn revision(&self) -> u64 {
         self.revision

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -438,6 +438,23 @@ pub struct VarNameArgRoles {
     /// ([`ProcArgTrait::Command`] — a `$param` command head or a `CommandPrefix`
     /// argument), so a literal call-site arg highlights as a command.
     command: FxHashMap<String, Vec<u32>>,
+    /// Names this index *abstained* on because the procs it was built from
+    /// disagreed about their indices, per direction.
+    ///
+    /// Carried rather than discarded so [`VarNameArgRoles::merge`] can fold
+    /// per-file indexes into a project-wide one that equals
+    /// [`VarNameArgRoles::from_procs`] over every file's procs at once: without
+    /// it, a name one file already dropped as ambiguous would silently be
+    /// re-adopted from another file's unambiguous entry.
+    ambiguous: RoleAmbiguity,
+}
+
+/// The per-direction abstention sets of a [`VarNameArgRoles`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct RoleAmbiguity {
+    write: FxHashSet<String>,
+    read: FxHashSet<String>,
+    command: FxHashSet<String>,
 }
 
 impl VarNameArgRoles {
@@ -467,10 +484,42 @@ impl VarNameArgRoles {
             read.insert(&keys, &proc_var_read_indices(proc));
             command.insert(&keys, &proc_command_indices(proc));
         }
+        Self::from_builders(write, read, command)
+    }
+
+    /// Fold per-file indexes into one project-wide index, applying the same
+    /// abstain-on-conflict rule [`Self::from_procs`] applies within a file — and
+    /// inheriting each part's own abstentions, so the result is exactly
+    /// `from_procs` over every part's procs concatenated, and independent of the
+    /// order the parts arrive in.
+    #[must_use]
+    pub fn merge<'a>(parts: impl IntoIterator<Item = &'a Self>) -> Self {
+        let mut write = RoleMapBuilder::default();
+        let mut read = RoleMapBuilder::default();
+        let mut command = RoleMapBuilder::default();
+        for part in parts {
+            write.absorb(&part.write, &part.ambiguous.write);
+            read.absorb(&part.read, &part.ambiguous.read);
+            command.absorb(&part.command, &part.ambiguous.command);
+        }
+        Self::from_builders(write, read, command)
+    }
+
+    /// Close the three per-direction builders into an index, keeping each
+    /// direction's abstentions alongside its map.
+    fn from_builders(write: RoleMapBuilder, read: RoleMapBuilder, command: RoleMapBuilder) -> Self {
+        let (write, write_ambiguous) = write.finish();
+        let (read, read_ambiguous) = read.finish();
+        let (command, command_ambiguous) = command.finish();
         Self {
-            write: write.finish(),
-            read: read.finish(),
-            command: command.finish(),
+            write,
+            read,
+            command,
+            ambiguous: RoleAmbiguity {
+                write: write_ambiguous,
+                read: read_ambiguous,
+                command: command_ambiguous,
+            },
         }
     }
 
@@ -538,8 +587,20 @@ impl RoleMapBuilder {
         }
     }
 
-    fn finish(self) -> FxHashMap<String, Vec<u32>> {
-        self.map
+    /// Fold an already-built map and its abstention set in, so merging finished
+    /// indexes reaches the same fixed point as inserting every underlying proc.
+    fn absorb(&mut self, map: &FxHashMap<String, Vec<u32>>, ambiguous: &FxHashSet<String>) {
+        for key in ambiguous {
+            self.map.remove(key);
+            self.ambiguous.insert(key.clone());
+        }
+        for (key, indices) in map {
+            self.insert(std::slice::from_ref(key), indices);
+        }
+    }
+
+    fn finish(self) -> (FxHashMap<String, Vec<u32>>, FxHashSet<String>) {
+        (self.map, self.ambiguous)
     }
 }
 

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -1673,6 +1673,17 @@ impl WorkspaceIndex {
         slot
     }
 
+    /// Whether `uri` currently has a slot in the index.
+    ///
+    /// Lets the server spot an **open** document whose entry is momentarily
+    /// absent — `did_open` drops it and the debounced diagnostics publish is
+    /// what puts it back — so a workspace-wide query can fill the gap from
+    /// that document's own analysis instead of silently omitting it.
+    #[must_use]
+    pub fn contains_document(&self, uri: &str) -> bool {
+        self.slots.contains_key(uri)
+    }
+
     /// Drop every entry that came from `uri` (used before
     /// re-indexing a changed document, or on `did_close`).
     ///

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -1303,6 +1303,13 @@ pub struct WorkspaceIndex {
     /// same set with the names links introduce — see
     /// [`WorkspaceIndex::defined_command_names`].
     defined_names: [Derived<HashSet<String>>; 2],
+    /// `linked name -> target name` over the live links — see
+    /// [`WorkspaceIndex::command_link_map`].
+    command_link_map: Derived<std::collections::HashMap<String, String>>,
+    /// Every invocation's settled target, grouped by that target, with and
+    /// without link-following — see
+    /// [`WorkspaceIndex::invocations_by_settled_target`].
+    settled_invocations: [Derived<SettledTargets>; 2],
 }
 
 /// A whole-index **derived view**: a value that is a pure function of the
@@ -1336,6 +1343,25 @@ impl<T> Derived<T> {
         Arc::clone(self.0.get_or_init(|| Arc::new(build())))
     }
 }
+
+/// Every invocation's **settled target**, grouped by that target's
+/// `::`-stripped qualified name: `target -> [(doc slot, index within that
+/// slot's invocations)]`.
+///
+/// [`WorkspaceIndex::invocations_of`] (code-lens's per-proc / per-class
+/// reference count, issue #1152) used to re-settle *every* invocation in the
+/// workspace against the candidate target on every call — `code_lenses`
+/// calls it once per proc and once per class, so an N-proc document paid an
+/// O(N × invocations) walk, each rebuilding [`WildcardImportIndex`] (five
+/// `HashMap`s over the whole index) from scratch. Settling every invocation
+/// once per generation and grouping the results turns each subsequent
+/// `invocations_of` call into a hash lookup plus a direct index into the
+/// owning document's slot — the indices are stable because a document's
+/// `Vec<WorkspaceInvocation>` is only ever cleared and refilled wholesale
+/// (`DocumentRecords::clear` / `index_document`), never reordered in place,
+/// and any mutation that could invalidate a stored `(slot, index)` pair also
+/// bumps the generation and drops the [`Derived`] view holding it.
+type SettledTargets = std::collections::HashMap<String, Vec<(usize, usize)>>;
 
 impl WorkspaceIndex {
     /// Empty index.
@@ -1486,6 +1512,8 @@ impl WorkspaceIndex {
         self.command_names = Derived::default();
         self.live_links = Derived::default();
         self.defined_names = <[Derived<HashSet<String>>; 2]>::default();
+        self.command_link_map = Derived::default();
+        self.settled_invocations = <[Derived<SettledTargets>; 2]>::default();
     }
 
     /// The command name-links that are actually installed — every `interp
@@ -2673,6 +2701,13 @@ impl WorkspaceIndex {
     /// names and the winning candidate is chased along the link map to its
     /// ultimate target; without it, only real proc/class definitions settle a
     /// call (the direct-reference behaviour rename relies on).
+    ///
+    /// A hash lookup into [`Self::invocations_by_settled_target`] plus a
+    /// direct index into each hit's owning document slot — the settlement
+    /// walk itself (which needs [`Self::defined_command_names`],
+    /// [`Self::command_link_map`] and a [`WildcardImportIndex`]) runs at most
+    /// once per generation, not once per call (issue #1152: `code_lenses`
+    /// calls this once per proc *and* once per class in the document).
     fn invocations_settling_to<'a>(
         &'a self,
         qualified_name: &str,
@@ -2680,39 +2715,71 @@ impl WorkspaceIndex {
         follow_links: bool,
     ) -> Vec<&'a WorkspaceInvocation> {
         let target = qualified_name.trim_start_matches("::");
-        // Build the workspace command set once (normalised qualified names of
-        // every proc and class, plus linked names when following), so each
-        // candidate existence check is O(1). Same reasoning for the
-        // wildcard-import index — see `WildcardImportIndex`'s own doc.
-        let defined = self.defined_command_names(follow_links);
-        let links = follow_links.then(|| self.command_link_map());
-        let wci = WildcardImportIndex::build(self);
-        self.invocations()
+        let by_target = self.invocations_by_settled_target(follow_links);
+        let Some(sites) = by_target.get(target) else {
+            return Vec::new();
+        };
+        sites
+            .iter()
+            .map(|&(slot, idx)| &self.docs[slot].invocations[idx])
             .filter(|i| i.uri != exclude_uri)
-            .filter(|i| self.invocation_resolves_to(i, &defined, links.as_ref(), &wci, target))
             .collect()
     }
 
-    /// Whether call site `inv` resolves to the command whose `::`-stripped
-    /// qualified name is `target`: the first of its candidates defined anywhere
-    /// in the workspace is the call's true target, chased along `links` (when
-    /// supplied) to the command it ultimately names.
-    fn invocation_resolves_to(
+    /// Every indexed invocation's settled target, `::`-stripped and grouped
+    /// into `target -> [(doc slot, index within that slot's invocations)]`
+    /// — one entry per invocation that settles to *some* command, in the
+    /// same relative order [`Self::invocations`] would visit them in.
+    /// A [`Derived`] view, one reading per `follow_links` value; see
+    /// [`SettledTargets`] for why the stored `(slot, index)` pairs stay valid
+    /// for the view's whole lifetime.
+    fn invocations_by_settled_target(&self, follow_links: bool) -> Arc<SettledTargets> {
+        self.settled_invocations[usize::from(follow_links)].get_or_build(|| {
+            // Built once per generation (both the command set and the
+            // wildcard-import index — see `WildcardImportIndex`'s own doc),
+            // then reused for every invocation in the workspace.
+            let defined = self.defined_command_names(follow_links);
+            let links = follow_links.then(|| self.command_link_map());
+            let wci = WildcardImportIndex::build(self);
+            let mut by_target: SettledTargets = std::collections::HashMap::new();
+            for (slot, doc) in self.docs.iter().enumerate() {
+                for (idx, inv) in doc.invocations.iter().enumerate() {
+                    if let Some(target) =
+                        self.settle_invocation(inv, &defined, links.as_deref(), &wci)
+                    {
+                        by_target.entry(target).or_default().push((slot, idx));
+                    }
+                }
+            }
+            by_target
+        })
+    }
+
+    /// The command `inv` settles to, `::`-stripped, or `None` when nothing in
+    /// the workspace resolves it: the first of its candidates defined
+    /// anywhere in the workspace, chased along `links` (when supplied) to its
+    /// ultimate target — falling back, when following links, to a wildcard
+    /// `namespace import NS::*` in scope (issue #923 idx 18). The settlement
+    /// logic itself is unchanged from the pre-#1152 `invocation_resolves_to`,
+    /// restated as "what does this settle to" (grouped by the answer) rather
+    /// than "does this settle to the one target the caller named" (checked
+    /// once per candidate target).
+    fn settle_invocation(
         &self,
         inv: &WorkspaceInvocation,
         defined: &HashSet<String>,
-        links: Option<&std::collections::HashMap<&str, &str>>,
+        links: Option<&std::collections::HashMap<String, String>>,
         wci: &WildcardImportIndex<'_>,
-        target: &str,
-    ) -> bool {
+    ) -> Option<String> {
         if let Some(winner) = inv
             .resolution_candidates
             .iter()
             .find(|c| defined.contains(c.trim_start_matches("::")))
         {
             let winner = winner.trim_start_matches("::");
-            let settled = links.map_or(winner, |m| Self::follow_links(m, winner));
-            return settled == target;
+            return Some(
+                links.map_or_else(|| winner.to_owned(), |m| Self::follow_links(m, winner)),
+            );
         }
         // No real command or name-link settled this call — try a wildcard
         // `namespace import NS::*` in scope for the call's own namespace
@@ -2722,49 +2789,50 @@ impl WorkspaceIndex {
         // by find-references) and never the direct-only view rename relies
         // on — a call spelling the local imported name is not text-rewritten
         // just because its ultimate source is renamed.
-        links.is_some()
-            && self
-                .resolve_wildcard_import_indexed(
-                    &inv.name,
-                    &inv.resolution_candidates,
-                    CallSite {
-                        uri: &inv.uri,
-                        at: inv.range.start(),
-                        enclosing_body: inv.enclosing_body,
-                    },
-                    wci,
-                )
-                .is_some_and(|resolved| resolved.trim_start_matches("::") == target)
+        links?;
+        self.resolve_wildcard_import_indexed(
+            &inv.name,
+            &inv.resolution_candidates,
+            CallSite {
+                uri: &inv.uri,
+                at: inv.range.start(),
+                enclosing_body: inv.enclosing_body,
+            },
+            wci,
+        )
+        .map(|resolved| resolved.trim_start_matches("::").to_owned())
     }
 
     /// The command name-link map (`::`-stripped `linked → immediate target`)
     /// used to chase an import / alias / rename to the command it names.
-    fn command_link_map(&self) -> std::collections::HashMap<&str, &str> {
-        self.live_command_links()
-            .into_iter()
-            .map(|l| {
-                (
-                    l.linked_qname.trim_start_matches("::"),
-                    l.target_qname.trim_start_matches("::"),
-                )
-            })
-            .collect()
+    /// A [`Derived`] view rather than a fresh walk of
+    /// [`Self::live_command_links`] per call (issue #1152); owned (`String`,
+    /// not `&str`) so the view is independent of any one call's borrow.
+    fn command_link_map(&self) -> Arc<std::collections::HashMap<String, String>> {
+        self.command_link_map.get_or_build(|| {
+            self.live_command_links()
+                .into_iter()
+                .map(|l| {
+                    (
+                        l.linked_qname.trim_start_matches("::").to_owned(),
+                        l.target_qname.trim_start_matches("::").to_owned(),
+                    )
+                })
+                .collect()
+        })
     }
 
     /// Chase `start` along the link map to its ultimate target, stopping at a
     /// name that is not itself a linked name.  Bounded by cycle detection (an
     /// alias-of-an-alias loop) so a malformed chain cannot spin.
-    fn follow_links<'a>(
-        links: &std::collections::HashMap<&'a str, &'a str>,
-        start: &'a str,
-    ) -> &'a str {
-        let mut cur = start;
+    fn follow_links(links: &std::collections::HashMap<String, String>, start: &str) -> String {
+        let mut cur = start.to_owned();
         let mut seen = std::collections::HashSet::new();
-        while let Some(&next) = links.get(cur) {
-            if !seen.insert(cur) {
+        while let Some(next) = links.get(&cur) {
+            if !seen.insert(cur.clone()) {
                 break;
             }
-            cur = next;
+            cur.clone_from(next);
         }
         cur
     }
@@ -2898,14 +2966,17 @@ impl WorkspaceIndex {
     /// alias / rename introduces join the set, so a call reaching one of them
     /// settles (and is then chased to its ultimate target).
     ///
-    /// A [`Derived`] view rather than a fresh walk (issue #1105): it is
-    /// `O(procs + classes + links)` to build, and
+    /// A [`Derived`] view rather than a fresh walk (issues #1105 / #1152): it
+    /// is `O(procs + classes + links)` to build, and
     /// [`Self::workspace_command_exists`] asks for it *per candidate* inside
-    /// [`Self::follow_import_chain`]'s loop, which turned an existence test
-    /// into a workspace-wide scan. The two `include_links` readings are two
-    /// separate views because a consumer wants exactly one of them: the
-    /// direct-only set is what rename relies on, and folding the link names
-    /// into it would let a call spelling an imported name be text-rewritten.
+    /// [`Self::follow_import_chain`]'s loop — and
+    /// [`Self::invocations_by_settled_target`] once per settling pass — which
+    /// turned an existence test into a workspace-wide scan. Owned (`String`,
+    /// not `&str`) so the view is independent of any one call's borrow. The
+    /// two `include_links` readings are two separate views because a consumer
+    /// wants exactly one of them: the direct-only set is what rename relies
+    /// on, and folding the link names into it would let a call spelling an
+    /// imported name be text-rewritten.
     fn defined_command_names(&self, include_links: bool) -> Arc<HashSet<String>> {
         self.defined_names[usize::from(include_links)].get_or_build(|| {
             let mut names: HashSet<String> = self
@@ -2972,7 +3043,7 @@ impl WorkspaceIndex {
     /// The indexed core of [`Self::resolve_wildcard_import`], taking a
     /// precomputed [`WildcardImportIndex`] instead of scanning
     /// `glob_imports`/`namespace_exports` in full — the fast path
-    /// [`Self::invocation_resolves_to`] uses so a workspace-wide
+    /// [`Self::settle_invocation`] uses so a workspace-wide
     /// invocation-settling pass builds the index once (O(every glob import
     /// / export in the workspace)) rather than once per invocation (which
     /// would be O(invocation count × workspace-wide glob-import count) —
@@ -6145,6 +6216,104 @@ mod tests {
         // A clone starts with a fresh (empty) cache and rebuilds identically.
         let cloned = index.clone();
         assert_eq!(*cloned.command_names(), *third);
+    }
+
+    /// Issue #1152: `defined_command_names` used to rebuild its `HashSet`
+    /// from scratch on every call. It is now cached — one slot per
+    /// `include_links` value — and dropped only by a mutation, same
+    /// `Arc::ptr_eq` proof as [`command_names_are_cached_until_the_index_changes`].
+    #[test]
+    fn defined_command_names_are_cached_per_generation() {
+        let a = analyse("proc ::alpha {} {}\n");
+        let mut index = WorkspaceIndex::new();
+        index.add_document("file:///a.tcl", &a);
+        let first = index.defined_command_names(false);
+        assert!(first.contains("alpha"), "{first:?}");
+        assert!(
+            Arc::ptr_eq(&first, &index.defined_command_names(false)),
+            "an unchanged index must serve the cache, not rebuild it",
+        );
+        // The `include_links` variants are cached independently: reading one
+        // must not populate (or invalidate) the other's slot.
+        let with_links_first = index.defined_command_names(true);
+        assert!(
+            !Arc::ptr_eq(&first, &with_links_first),
+            "the two `include_links` slots are distinct caches",
+        );
+        assert!(
+            Arc::ptr_eq(&with_links_first, &index.defined_command_names(true)),
+            "the with-links slot must also serve from cache once built",
+        );
+
+        let b = analyse("proc ::beta {} {}\n");
+        index.add_document("file:///b.tcl", &b);
+        let after_mutation = index.defined_command_names(false);
+        assert!(
+            !Arc::ptr_eq(&first, &after_mutation),
+            "indexing a document must drop both cached slots",
+        );
+        assert!(after_mutation.contains("beta"), "{after_mutation:?}");
+    }
+
+    /// Issue #1152: `command_link_map` used to rebuild its `HashMap` (from
+    /// `live_command_links`, itself already cached) on every call. It is now
+    /// cached directly, same discipline as `command_names`.
+    #[test]
+    fn command_link_map_is_cached_per_generation() {
+        let a = analyse("proc ::real {} {}\ninterp alias {} ::aliased {} ::real\n");
+        let mut index = WorkspaceIndex::new();
+        index.add_document("file:///a.tcl", &a);
+        let first = index.command_link_map();
+        assert_eq!(first.get("aliased").map(String::as_str), Some("real"));
+        assert!(
+            Arc::ptr_eq(&first, &index.command_link_map()),
+            "an unchanged index must serve the cache, not rebuild it",
+        );
+        index.remove_document("file:///a.tcl");
+        assert!(
+            !Arc::ptr_eq(&first, &index.command_link_map()),
+            "a mutation must drop the cache",
+        );
+    }
+
+    /// Issue #1152: `invocations_of` (via `invocations_by_settled_target`)
+    /// used to re-settle every invocation in the workspace, and rebuild
+    /// `WildcardImportIndex` from scratch, on every call — the cost
+    /// `code_lenses` multiplied by one call per proc *and* per class in the
+    /// document. The settled-target grouping is now cached per generation;
+    /// repeated `invocations_of` calls against an unchanged index must
+    /// share it rather than re-settle.
+    #[test]
+    fn invocations_by_settled_target_is_cached_per_generation() {
+        let a = analyse("proc helper {} {}\nproc other {} {}\n");
+        let b = analyse("helper\nhelper\nother\n");
+        let mut index = WorkspaceIndex::new();
+        index.add_document("file:///a.tcl", &a);
+        index.add_document("file:///b.tcl", &b);
+
+        let first = index.invocations_by_settled_target(false);
+        assert_eq!(first.get("helper").map(Vec::len), Some(2), "{first:?}");
+        assert!(
+            Arc::ptr_eq(&first, &index.invocations_by_settled_target(false)),
+            "an unchanged index must serve the cache, not re-settle",
+        );
+        // Querying different targets against the same generation must hit
+        // the same cached map, not re-settle per target.
+        let helper_calls = index.invocations_of("::helper", "");
+        let other_calls = index.invocations_of("::other", "");
+        assert_eq!(helper_calls.len(), 2, "{helper_calls:?}");
+        assert_eq!(other_calls.len(), 1, "{other_calls:?}");
+
+        // A mutation invalidates the cache and the next call re-settles
+        // against the new state.
+        let c = analyse("helper\n");
+        index.add_document("file:///c.tcl", &c);
+        let after_mutation = index.invocations_by_settled_target(false);
+        assert!(
+            !Arc::ptr_eq(&first, &after_mutation),
+            "indexing a document must drop the settled-invocations cache",
+        );
+        assert_eq!(index.invocations_of("::helper", "").len(), 3);
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -727,11 +727,22 @@ fn sorted_names(names: &std::collections::HashSet<String>) -> Vec<String> {
     out
 }
 
-/// Cross-document aggregate of proc / class definitions,
-/// command-invocation sites, `source` references, command
-/// name-links, and `package require` declarations.
+/// The fourteen record tables **one document** contributes to the index.
+///
+/// Grouping the tables per document is what makes
+/// [`WorkspaceIndex::remove_document`] cost the document's own records rather
+/// than the workspace's (issue #1149).  Flat workspace-wide vectors made a
+/// removal fourteen `Vec::retain` passes with a `String` compare per element
+/// over tables that hold one row per call site and per qualified variable
+/// occurrence — 10⁵–10⁶ rows on a tcllib-sized workspace — and the server runs
+/// a removal on every diagnostics publish.
+///
+/// Consumers never see this type: [`WorkspaceIndex`] exposes each table as a
+/// workspace-wide iterator that chains the per-document vectors in slot order,
+/// which is the order the records were added in and therefore exactly the
+/// order the previous flat vectors held them in.
 #[derive(Debug, Clone, Default)]
-pub struct WorkspaceIndex {
+struct DocumentRecords {
     procs: Vec<WorkspaceProc>,
     classes: Vec<WorkspaceClass>,
     variables: Vec<WorkspaceVariable>,
@@ -746,254 +757,56 @@ pub struct WorkspaceIndex {
     namespace_exports: Vec<WorkspaceNamespaceExport>,
     namespace_forgets: Vec<WorkspaceNamespaceForget>,
     command_deletions: Vec<WorkspaceCommandDeletion>,
-    generation: u64,
-    /// Every command name the workspace defines, in each spelling a call site
-    /// may write — see [`WorkspaceIndex::command_names`].
-    command_names: Derived<HashSet<String>>,
-    /// Parallel liveness mask over `command_links` — see
-    /// [`WorkspaceIndex::live_command_links`].
-    live_links: Derived<Vec<bool>>,
-    /// `::`-stripped qualified names of every indexed proc and class, and the
-    /// same set with the names links introduce — see
-    /// [`WorkspaceIndex::defined_command_names`].
-    defined_names: [Derived<HashSet<String>>; 2],
 }
 
-/// A whole-index **derived view**: a value that is a pure function of the
-/// index's contents, built at most once per [`WorkspaceIndex::generation`] and
-/// dropped by the mutation hook that bumps it.
-///
-/// The workspace-indexing contract's rule 5 in one type, so the reset/build
-/// boilerplate is written once rather than per view (issue #1105). Excluded
-/// from equality and dropped on clone — the same discipline
-/// `tcl_compiler::analyser::HierarchyCache` uses for the class hierarchy it
-/// derives from `all_classes`. `Arc` because a caller may hold the view while
-/// the index it came from is dropped or re-derived.
-#[derive(Debug)]
-struct Derived<T>(std::sync::OnceLock<Arc<T>>);
-
-impl<T> Default for Derived<T> {
-    fn default() -> Self {
-        Self(std::sync::OnceLock::new())
-    }
-}
-
-impl<T> Clone for Derived<T> {
-    fn clone(&self) -> Self {
-        Self::default()
-    }
-}
-
-impl<T> Derived<T> {
-    /// The cached value, building it with `build` on first use.
-    fn get_or_build(&self, build: impl FnOnce() -> T) -> Arc<T> {
-        Arc::clone(self.0.get_or_init(|| Arc::new(build())))
-    }
-}
-
-impl WorkspaceIndex {
-    /// Empty index.
-    #[must_use]
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Build an index from an iterator of `(uri, analysis)`
-    /// pairs — typically the server's cached-analysis map.
-    #[must_use]
-    pub fn from_documents<'a, I>(documents: I) -> Self
-    where
-        I: IntoIterator<Item = (&'a str, &'a AnalysisResult)>,
-    {
-        let mut index = Self::new();
-        for (uri, analysis) in documents {
-            index.add_document(uri, analysis);
-        }
-        index
-    }
-
-    /// A counter bumped by every mutation ([`Self::add_document`] /
-    /// [`Self::remove_document`]).  Lets a consumer tell whether the index has
-    /// changed since it last looked without diffing its contents.
-    #[must_use]
-    pub fn generation(&self) -> u64 {
-        self.generation
-    }
-
-    /// Every command name the workspace defines — each indexed proc and class
-    /// in the three forms a call site may spell (`::ns::name`, `ns::name`,
-    /// `name`).
+impl DocumentRecords {
+    /// Drop every record, keeping each table's allocation.
     ///
-    /// This is the cross-file "does this command exist anywhere in the
-    /// project?" set the unknown-command (W123) refinement consults.  It is
-    /// **derived**, so it is built once and cached until the next index
-    /// mutation rather than walked per request: on a 400-file / 10 000-proc
-    /// workspace it is ~20 000 names and ~7 ms to build, against ~120 ns to
-    /// serve from the cache.
-    #[must_use]
-    pub fn command_names(&self) -> Arc<HashSet<String>> {
-        self.command_names.get_or_build(|| {
-            let mut names: HashSet<String> = HashSet::new();
-            for p in &self.procs {
-                tcl_compiler::analyser::utils::insert_qualified_and_tail(
-                    &mut names,
-                    &p.qualified_name,
-                );
-            }
-            for c in &self.classes {
-                tcl_compiler::analyser::utils::insert_qualified_and_tail(
-                    &mut names,
-                    &c.qualified_name,
-                );
-            }
-            names
-        })
+    /// The capacity is deliberately retained: a re-index of the same document
+    /// (the remove-then-add every publish performs) refills tables of very
+    /// nearly the same size, so the slot's buffers are reused instead of being
+    /// freed and regrown fourteen times per publish.  A slot whose document is
+    /// gone for good keeps its capacity until another document reuses the slot
+    /// — bounded by the workspace's peak document count, not by the number of
+    /// removals.
+    fn clear(&mut self) {
+        let Self {
+            procs,
+            classes,
+            variables,
+            variable_refs,
+            variable_aliases,
+            namespace_refs,
+            invocations,
+            sources,
+            package_requires,
+            command_links,
+            glob_imports,
+            namespace_exports,
+            namespace_forgets,
+            command_deletions,
+        } = self;
+        procs.clear();
+        classes.clear();
+        variables.clear();
+        variable_refs.clear();
+        variable_aliases.clear();
+        namespace_refs.clear();
+        invocations.clear();
+        sources.clear();
+        package_requires.clear();
+        command_links.clear();
+        glob_imports.clear();
+        namespace_exports.clear();
+        namespace_forgets.clear();
+        command_deletions.clear();
     }
 
-    /// Note a mutation: bump the generation and drop every derived cache.
-    fn invalidate(&mut self) {
-        self.generation = self.generation.wrapping_add(1);
-        self.command_names = Derived::default();
-        self.live_links = Derived::default();
-        self.defined_names = <[Derived<HashSet<String>>; 2]>::default();
-    }
-
-    /// The command name-links that are actually installed — every `interp
-    /// alias` / `rename` link, plus each exact `namespace import` link whose
-    /// [`WorkspaceCommandLink::import_gate`] its source namespace's export
-    /// timeline admits (issue #1027).
+    /// Lift one document's analysis into this record set.
     ///
-    /// Every consumer of `command_links` that answers "does this name exist /
-    /// what does it reach" goes through here, so an import Tcl never
-    /// installed cannot leak into definition, references, or the existence
-    /// oracle through one of them. The mask is built once per
-    /// [`Self::generation`] ([`LiveLinkCache`]); this call is then a `Vec` of
-    /// borrows, the same order of cost as the `HashMap`/`HashSet` each caller
-    /// already builds.
-    ///
-    /// The gate only fires for a source namespace the workspace can actually
-    /// *observe* ([`Self::observable_namespaces`]).  `namespace import
-    /// ::msgcat::mc` names a namespace that lives in an installed package, not
-    /// in any indexed document: the index holds no export declaration for it
-    /// and never will, so treating that silence as "not exported" would revoke
-    /// a real command and hand W123 a fresh false positive on every bare `mc`
-    /// call.  Absence of an export is evidence only where the definitions are
-    /// visible too — otherwise this abstains and keeps the link, the same
-    /// abstain-toward-silence rule the unknown-command pass follows.
-    fn live_command_links(&self) -> Vec<&WorkspaceCommandLink> {
-        let mask = self.live_links.get_or_build(|| {
-            let wci = WildcardImportIndex::build(self);
-            let observable = self.observable_namespaces();
-            self.command_links
-                .iter()
-                .map(|l| {
-                    l.import_gate.as_ref().is_none_or(|g| {
-                        if !observable.contains(g.source_ns.trim_start_matches("::")) {
-                            return true;
-                        }
-                        if !wci.exports_name_at(&g.source_ns, &g.name, g.site(&l.uri)) {
-                            return false;
-                        }
-                        // A non-`-force` import onto a name the target
-                        // namespace already holds installs nothing at all
-                        // (oracle on `WorkspaceGlobImport::forced`), so
-                        // the link it would introduce is not live either.
-                        // "Already holds" is a real *definition* or an
-                        // earlier live alias from a **different** source
-                        // in the same document (issue #1116 finding 4);
-                        // a same-source re-import is a silent no-op, and
-                        // two links cancelling each other out is what the
-                        // different-source test rules out.
-                        let importing_ns = importing_namespace_of(&l.linked_qname);
-                        if !g.forced
-                            && (self.defines_command(&l.linked_qname)
-                                || wci.conflicting_alias_at(
-                                    importing_ns,
-                                    &g.source_ns,
-                                    &g.name,
-                                    g.site(&l.uri),
-                                ))
-                        {
-                            return false;
-                        }
-                        // …and the alias it installed can be taken away
-                        // again: `namespace forget`, a redefinition of the
-                        // imported name, or destruction of the source
-                        // command (issue #1116 finding 2).
-                        wci.link_alias_live(importing_ns, g, &l.uri)
-                    })
-                })
-                .collect()
-        });
-        self.command_links
-            .iter()
-            .zip(mask.iter())
-            .filter_map(|(link, &live)| live.then_some(link))
-            .collect()
-    }
-
-    /// Whether the workspace holds a real proc or class definition at
-    /// `qualified_name` — the "already exists" side of a non-`-force`
-    /// `namespace import` conflict.
-    ///
-    /// Deliberately *not* [`Self::workspace_command_exists`], which also
-    /// admits linked names: a link is what this question is being asked
-    /// about, so counting one would make an import conflict with itself.
-    fn defines_command(&self, qualified_name: &str) -> bool {
-        let target = qualified_name.trim_start_matches("::");
-        self.procs
-            .iter()
-            .any(|p| p.qualified_name.trim_start_matches("::") == target)
-            || self
-                .classes
-                .iter()
-                .any(|c| c.qualified_name.trim_start_matches("::") == target)
-    }
-
-    /// The `::`-stripped namespaces the workspace can say anything about: one
-    /// that owns an indexed proc or class, that declares a `namespace export`
-    /// somewhere, or that an indexed `namespace eval` block declares.
-    ///
-    /// The discriminator between "this namespace does not export the name"
-    /// (a fact) and "this namespace is not in the workspace at all" (no
-    /// information) — see [`Self::live_command_links`].
-    ///
-    /// The declaring-block source (issue #1088) closes a hole the first two
-    /// leave: a `namespace eval ::ns { namespace import ::other::* }` block
-    /// that declares no proc, class, or export of its own *is* a namespace
-    /// the workspace can see, and treating it as unknown made the import gate
-    /// abstain where it had the evidence to decide.
-    fn observable_namespaces(&self) -> HashSet<&str> {
-        fn owning_ns(qualified: &str) -> &str {
-            qualified
-                .trim_start_matches("::")
-                .rsplit_once("::")
-                .map_or("", |(ns, _)| ns)
-        }
-        self.procs
-            .iter()
-            .map(|p| owning_ns(&p.qualified_name))
-            .chain(self.classes.iter().map(|c| owning_ns(&c.qualified_name)))
-            .chain(
-                self.namespace_exports
-                    .iter()
-                    .map(|e| e.ns.trim_start_matches("::")),
-            )
-            .chain(
-                self.namespace_refs
-                    .iter()
-                    .filter(|n| n.declares)
-                    .map(|n| n.qualified_name.trim_start_matches("::")),
-            )
-            .collect()
-    }
-
-    /// Add (or refresh) one document's proc / class definitions.
-    ///
-    /// Call [`Self::remove_document`] first when re-indexing a
-    /// changed document to avoid stale duplicates.
-    pub fn add_document(&mut self, uri: &str, analysis: &AnalysisResult) {
-        self.invalidate();
+    /// The caller ([`WorkspaceIndex::add_document`]) has already cleared the
+    /// slot, so this only ever appends.
+    fn index_document(&mut self, uri: &str, analysis: &AnalysisResult) {
         // `all_procs` / `all_classes` / a class's `methods` are `HashMap`s, so
         // iterating them directly would order this document's index entries by
         // the process's random hash seed — and consumers that answer with the
@@ -1011,49 +824,10 @@ impl WorkspaceIndex {
                 nested: analysis.offset_is_inside_any_definition_body(proc_def.name_span.start()),
             });
         }
-        for class_def in sorted_by_span(analysis.all_classes.values(), |c| c.name_span) {
-            let methods: Vec<WorkspaceMethod> =
-                sorted_by_span(class_def.methods.values(), |m| m.name_span)
-                    .into_iter()
-                    .map(|m| WorkspaceMethod {
-                        name: m.name.clone(),
-                        kind: m.kind.clone(),
-                        exported: m.visibility == "public",
-                        private: m.visibility == "private",
-                        is_self_method: m.is_self_method,
-                    })
-                    .chain(
-                        sorted_by_span(class_def.class_methods.values(), |m| m.name_span)
-                            .into_iter()
-                            .map(|m| WorkspaceMethod {
-                                name: m.name.clone(),
-                                kind: "classmethod".to_string(),
-                                exported: m.visibility == "public",
-                                private: m.visibility == "private",
-                                is_self_method: m.is_self_method,
-                            }),
-                    )
-                    .collect();
-            self.classes.push(WorkspaceClass {
-                uri: uri.to_owned(),
-                name: class_def.name.clone(),
-                qualified_name: class_def.qualified_name.clone(),
-                name_span: class_def.name_span,
-                superclasses: class_def.superclasses.clone(),
-                mixins: class_def.mixins.clone(),
-                methods,
-                exports: sorted_names(&class_def.exports),
-                unexports: sorted_names(&class_def.unexports),
-                class_exports: sorted_names(&class_def.class_exports),
-                class_unexports: sorted_names(&class_def.class_unexports),
-                retracted_members: class_def.retracted_members.clone(),
-                via_define: class_def.via_define,
-                metaclass: class_def.metaclass.clone(),
-            });
-        }
+        self.index_classes(uri, analysis);
         self.index_variables(uri, analysis);
         self.index_namespace_refs(uri, analysis);
-        let bodies = Self::enclosing_body_spans(
+        let bodies = WorkspaceIndex::enclosing_body_spans(
             analysis,
             &analysis
                 .command_invocations
@@ -1100,51 +874,53 @@ impl WorkspaceIndex {
         self.index_command_links(uri, analysis);
     }
 
-    /// [`tcl_compiler::analyser::AnalysisResult::innermost_definition_body_span`]
-    /// for a whole column of offsets at once, in the order they were given.
+    /// Lift one document's class definitions, each with its members flattened
+    /// into one source-ordered [`WorkspaceMethod`] list (instance methods
+    /// first, then the class-side ones).
     ///
-    /// That single-offset lookup scans every recorded proc and class body, so
-    /// calling it once per invocation is `O(procs × invocations)` — the cost
-    /// that kept a per-call body span out of the index (issue #1116 item 3).
-    /// It is not the cost the answer actually needs: definition bodies are
-    /// syntactic, so they **nest properly** — no two of them partially overlap
-    /// — which means one pass over the bodies in start order, keeping the
-    /// currently-open chain on a stack, yields the innermost body of every
-    /// offset in increasing order. Sorting both sides makes the whole column
-    /// `O((P + I) log (P + I))` instead, small beside the analysis that
-    /// produced them.
-    ///
-    /// Ties in `start` are ordered by *longer first*, so a body sharing its
-    /// start with a nested one is pushed before its child and the stack top
-    /// stays the innermost.
-    fn enclosing_body_spans(analysis: &AnalysisResult, offsets: &[u32]) -> Vec<Option<Span>> {
-        let mut bodies: Vec<Span> = analysis
-            .all_procs
-            .values()
-            .map(|p| p.body_span)
-            .chain(analysis.all_classes.values().map(|c| c.body_span))
-            .collect();
-        if bodies.is_empty() {
-            return vec![None; offsets.len()];
+    /// Split out of [`Self::index_document`] only for size; the source-order
+    /// rule that walk documents applies here unchanged.
+    fn index_classes(&mut self, uri: &str, analysis: &AnalysisResult) {
+        for class_def in sorted_by_span(analysis.all_classes.values(), |c| c.name_span) {
+            let methods: Vec<WorkspaceMethod> =
+                sorted_by_span(class_def.methods.values(), |m| m.name_span)
+                    .into_iter()
+                    .map(|m| WorkspaceMethod {
+                        name: m.name.clone(),
+                        kind: m.kind.clone(),
+                        exported: m.visibility == "public",
+                        private: m.visibility == "private",
+                        is_self_method: m.is_self_method,
+                    })
+                    .chain(
+                        sorted_by_span(class_def.class_methods.values(), |m| m.name_span)
+                            .into_iter()
+                            .map(|m| WorkspaceMethod {
+                                name: m.name.clone(),
+                                kind: "classmethod".to_string(),
+                                exported: m.visibility == "public",
+                                private: m.visibility == "private",
+                                is_self_method: m.is_self_method,
+                            }),
+                    )
+                    .collect();
+            self.classes.push(WorkspaceClass {
+                uri: uri.to_owned(),
+                name: class_def.name.clone(),
+                qualified_name: class_def.qualified_name.clone(),
+                name_span: class_def.name_span,
+                superclasses: class_def.superclasses.clone(),
+                mixins: class_def.mixins.clone(),
+                methods,
+                exports: sorted_names(&class_def.exports),
+                unexports: sorted_names(&class_def.unexports),
+                class_exports: sorted_names(&class_def.class_exports),
+                class_unexports: sorted_names(&class_def.class_unexports),
+                retracted_members: class_def.retracted_members.clone(),
+                via_define: class_def.via_define,
+                metaclass: class_def.metaclass.clone(),
+            });
         }
-        bodies.sort_unstable_by_key(|s| (s.start(), std::cmp::Reverse(s.end())));
-        let mut order: Vec<usize> = (0..offsets.len()).collect();
-        order.sort_unstable_by_key(|&i| offsets[i]);
-        let mut out = vec![None; offsets.len()];
-        let mut open: Vec<Span> = Vec::new();
-        let mut next = 0usize;
-        for i in order {
-            let off = offsets[i];
-            while next < bodies.len() && bodies[next].start() <= off {
-                open.push(bodies[next]);
-                next += 1;
-            }
-            while open.last().is_some_and(|b| b.end() <= off) {
-                open.pop();
-            }
-            out[i] = open.last().copied();
-        }
-        out
     }
 
     /// Lift a document's `namespace forget` events and command **destructions**
@@ -1349,37 +1125,398 @@ impl WorkspaceIndex {
             });
         }
     }
+}
+
+/// Cross-document aggregate of proc / class definitions,
+/// command-invocation sites, `source` references, command
+/// name-links, and `package require` declarations.
+///
+/// Records are stored per document ([`DocumentRecords`]) in a slot vector, with
+/// `slots` mapping a document URI to its slot.  Removing a document clears its
+/// slot and returns the index to `free_slots`; the next document to be added —
+/// in practice the same one, since the server's re-index is a remove
+/// immediately followed by an add — takes the most recently freed slot back, so
+/// a document keeps its position across a re-index and the slot vector stays
+/// bounded by the workspace's peak document count.
+#[derive(Debug, Clone, Default)]
+pub struct WorkspaceIndex {
+    docs: Vec<DocumentRecords>,
+    slots: std::collections::HashMap<String, usize>,
+    free_slots: Vec<usize>,
+    generation: u64,
+    /// Every command name the workspace defines, in each spelling a call site
+    /// may write — see [`WorkspaceIndex::command_names`].
+    command_names: Derived<HashSet<String>>,
+    /// Parallel liveness mask over `command_links` — see
+    /// [`WorkspaceIndex::live_command_links`].
+    live_links: Derived<Vec<bool>>,
+    /// `::`-stripped qualified names of every indexed proc and class, and the
+    /// same set with the names links introduce — see
+    /// [`WorkspaceIndex::defined_command_names`].
+    defined_names: [Derived<HashSet<String>>; 2],
+}
+
+/// A whole-index **derived view**: a value that is a pure function of the
+/// index's contents, built at most once per [`WorkspaceIndex::generation`] and
+/// dropped by the mutation hook that bumps it.
+///
+/// The workspace-indexing contract's rule 5 in one type, so the reset/build
+/// boilerplate is written once rather than per view (issue #1105). Excluded
+/// from equality and dropped on clone — the same discipline
+/// `tcl_compiler::analyser::HierarchyCache` uses for the class hierarchy it
+/// derives from `all_classes`. `Arc` because a caller may hold the view while
+/// the index it came from is dropped or re-derived.
+#[derive(Debug)]
+struct Derived<T>(std::sync::OnceLock<Arc<T>>);
+
+impl<T> Default for Derived<T> {
+    fn default() -> Self {
+        Self(std::sync::OnceLock::new())
+    }
+}
+
+impl<T> Clone for Derived<T> {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+impl<T> Derived<T> {
+    /// The cached value, building it with `build` on first use.
+    fn get_or_build(&self, build: impl FnOnce() -> T) -> Arc<T> {
+        Arc::clone(self.0.get_or_init(|| Arc::new(build())))
+    }
+}
+
+impl WorkspaceIndex {
+    /// Empty index.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build an index from an iterator of `(uri, analysis)`
+    /// pairs — typically the server's cached-analysis map.
+    #[must_use]
+    pub fn from_documents<'a, I>(documents: I) -> Self
+    where
+        I: IntoIterator<Item = (&'a str, &'a AnalysisResult)>,
+    {
+        let mut index = Self::new();
+        for (uri, analysis) in documents {
+            index.add_document(uri, analysis);
+        }
+        index
+    }
+
+    /// A counter bumped by every mutation ([`Self::add_document`] /
+    /// [`Self::remove_document`]).  Lets a consumer tell whether the index has
+    /// changed since it last looked without diffing its contents.
+    #[must_use]
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    /// Every indexed qualified variable **occurrence**.
+    fn variable_refs(&self) -> impl Iterator<Item = &WorkspaceVariableRef> {
+        self.docs.iter().flat_map(|doc| doc.variable_refs.iter())
+    }
+
+    /// Every indexed **alias** of a qualified variable cell.
+    fn variable_aliases(&self) -> impl Iterator<Item = &WorkspaceVariableAlias> {
+        self.docs.iter().flat_map(|doc| doc.variable_aliases.iter())
+    }
+
+    /// Every indexed wildcard `namespace import NS::*`.
+    fn glob_imports(&self) -> impl Iterator<Item = &WorkspaceGlobImport> {
+        self.docs.iter().flat_map(|doc| doc.glob_imports.iter())
+    }
+
+    /// Every indexed `namespace export` declaration.
+    fn namespace_exports(&self) -> impl Iterator<Item = &WorkspaceNamespaceExport> {
+        self.docs
+            .iter()
+            .flat_map(|doc| doc.namespace_exports.iter())
+    }
+
+    /// Every indexed `namespace forget`.
+    fn namespace_forgets(&self) -> impl Iterator<Item = &WorkspaceNamespaceForget> {
+        self.docs
+            .iter()
+            .flat_map(|doc| doc.namespace_forgets.iter())
+    }
+
+    /// Every indexed command **destruction** (`rename OLD {}` / a destroying
+    /// `interp alias`).
+    fn command_deletions(&self) -> impl Iterator<Item = &WorkspaceCommandDeletion> {
+        self.docs
+            .iter()
+            .flat_map(|doc| doc.command_deletions.iter())
+    }
+
+    /// [`tcl_compiler::analyser::AnalysisResult::innermost_definition_body_span`]
+    /// for a whole column of offsets at once, in the order they were given.
+    ///
+    /// That single-offset lookup scans every recorded proc and class body, so
+    /// calling it once per invocation is `O(procs × invocations)` — the cost
+    /// that kept a per-call body span out of the index (issue #1116 item 3).
+    /// It is not the cost the answer actually needs: definition bodies are
+    /// syntactic, so they **nest properly** — no two of them partially overlap
+    /// — which means one pass over the bodies in start order, keeping the
+    /// currently-open chain on a stack, yields the innermost body of every
+    /// offset in increasing order. Sorting both sides makes the whole column
+    /// `O((P + I) log (P + I))` instead, small beside the analysis that
+    /// produced them.
+    ///
+    /// Ties in `start` are ordered by *longer first*, so a body sharing its
+    /// start with a nested one is pushed before its child and the stack top
+    /// stays the innermost.
+    fn enclosing_body_spans(analysis: &AnalysisResult, offsets: &[u32]) -> Vec<Option<Span>> {
+        let mut bodies: Vec<Span> = analysis
+            .all_procs
+            .values()
+            .map(|p| p.body_span)
+            .chain(analysis.all_classes.values().map(|c| c.body_span))
+            .collect();
+        if bodies.is_empty() {
+            return vec![None; offsets.len()];
+        }
+        bodies.sort_unstable_by_key(|s| (s.start(), std::cmp::Reverse(s.end())));
+        let mut order: Vec<usize> = (0..offsets.len()).collect();
+        order.sort_unstable_by_key(|&i| offsets[i]);
+        let mut out = vec![None; offsets.len()];
+        let mut open: Vec<Span> = Vec::new();
+        let mut next = 0usize;
+        for i in order {
+            let off = offsets[i];
+            while next < bodies.len() && bodies[next].start() <= off {
+                open.push(bodies[next]);
+                next += 1;
+            }
+            while open.last().is_some_and(|b| b.end() <= off) {
+                open.pop();
+            }
+            out[i] = open.last().copied();
+        }
+        out
+    }
+
+    /// Every command name the workspace defines — each indexed proc and class
+    /// in the three forms a call site may spell (`::ns::name`, `ns::name`,
+    /// `name`).
+    ///
+    /// This is the cross-file "does this command exist anywhere in the
+    /// project?" set the unknown-command (W123) refinement consults.  It is
+    /// **derived**, so it is built once and cached until the next index
+    /// mutation rather than walked per request: on a 400-file / 10 000-proc
+    /// workspace it is ~20 000 names and ~7 ms to build, against ~120 ns to
+    /// serve from the cache.
+    #[must_use]
+    pub fn command_names(&self) -> Arc<HashSet<String>> {
+        self.command_names.get_or_build(|| {
+            let mut names: HashSet<String> = HashSet::new();
+            for p in self.procs() {
+                tcl_compiler::analyser::utils::insert_qualified_and_tail(
+                    &mut names,
+                    &p.qualified_name,
+                );
+            }
+            for c in self.classes() {
+                tcl_compiler::analyser::utils::insert_qualified_and_tail(
+                    &mut names,
+                    &c.qualified_name,
+                );
+            }
+            names
+        })
+    }
+
+    /// Note a mutation: bump the generation and drop every derived cache.
+    fn invalidate(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+        self.command_names = Derived::default();
+        self.live_links = Derived::default();
+        self.defined_names = <[Derived<HashSet<String>>; 2]>::default();
+    }
+
+    /// The command name-links that are actually installed — every `interp
+    /// alias` / `rename` link, plus each exact `namespace import` link whose
+    /// [`WorkspaceCommandLink::import_gate`] its source namespace's export
+    /// timeline admits (issue #1027).
+    ///
+    /// Every consumer of `command_links` that answers "does this name exist /
+    /// what does it reach" goes through here, so an import Tcl never
+    /// installed cannot leak into definition, references, or the existence
+    /// oracle through one of them. The mask is built once per
+    /// [`Self::generation`] (a [`Derived`] view); this call is then a `Vec` of
+    /// borrows, the same order of cost as the `HashMap`/`HashSet` each caller
+    /// already builds.
+    ///
+    /// The gate only fires for a source namespace the workspace can actually
+    /// *observe* ([`Self::observable_namespaces`]).  `namespace import
+    /// ::msgcat::mc` names a namespace that lives in an installed package, not
+    /// in any indexed document: the index holds no export declaration for it
+    /// and never will, so treating that silence as "not exported" would revoke
+    /// a real command and hand W123 a fresh false positive on every bare `mc`
+    /// call.  Absence of an export is evidence only where the definitions are
+    /// visible too — otherwise this abstains and keeps the link, the same
+    /// abstain-toward-silence rule the unknown-command pass follows.
+    fn live_command_links(&self) -> Vec<&WorkspaceCommandLink> {
+        let mask = self.live_links.get_or_build(|| {
+            let wci = WildcardImportIndex::build(self);
+            let observable = self.observable_namespaces();
+            self.command_links()
+                .map(|l| {
+                    l.import_gate.as_ref().is_none_or(|g| {
+                        if !observable.contains(g.source_ns.trim_start_matches("::")) {
+                            return true;
+                        }
+                        if !wci.exports_name_at(&g.source_ns, &g.name, g.site(&l.uri)) {
+                            return false;
+                        }
+                        // A non-`-force` import onto a name the target
+                        // namespace already holds installs nothing at all
+                        // (oracle on `WorkspaceGlobImport::forced`), so
+                        // the link it would introduce is not live either.
+                        // "Already holds" is a real *definition* or an
+                        // earlier live alias from a **different** source
+                        // in the same document (issue #1116 finding 4);
+                        // a same-source re-import is a silent no-op, and
+                        // two links cancelling each other out is what the
+                        // different-source test rules out.
+                        let importing_ns = importing_namespace_of(&l.linked_qname);
+                        if !g.forced
+                            && (self.defines_command(&l.linked_qname)
+                                || wci.conflicting_alias_at(
+                                    importing_ns,
+                                    &g.source_ns,
+                                    &g.name,
+                                    g.site(&l.uri),
+                                ))
+                        {
+                            return false;
+                        }
+                        // …and the alias it installed can be taken away
+                        // again: `namespace forget`, a redefinition of the
+                        // imported name, or destruction of the source
+                        // command (issue #1116 finding 2).
+                        wci.link_alias_live(importing_ns, g, &l.uri)
+                    })
+                })
+                .collect()
+        });
+        self.command_links()
+            .zip(mask.iter())
+            .filter_map(|(link, &live)| live.then_some(link))
+            .collect()
+    }
+
+    /// Whether the workspace holds a real proc or class definition at
+    /// `qualified_name` — the "already exists" side of a non-`-force`
+    /// `namespace import` conflict.
+    ///
+    /// Deliberately *not* [`Self::workspace_command_exists`], which also
+    /// admits linked names: a link is what this question is being asked
+    /// about, so counting one would make an import conflict with itself.
+    fn defines_command(&self, qualified_name: &str) -> bool {
+        let target = qualified_name.trim_start_matches("::");
+        self.procs()
+            .any(|p| p.qualified_name.trim_start_matches("::") == target)
+            || self
+                .classes()
+                .any(|c| c.qualified_name.trim_start_matches("::") == target)
+    }
+
+    /// The `::`-stripped namespaces the workspace can say anything about: one
+    /// that owns an indexed proc or class, that declares a `namespace export`
+    /// somewhere, or that an indexed `namespace eval` block declares.
+    ///
+    /// The discriminator between "this namespace does not export the name"
+    /// (a fact) and "this namespace is not in the workspace at all" (no
+    /// information) — see [`Self::live_command_links`].
+    ///
+    /// The declaring-block source (issue #1088) closes a hole the first two
+    /// leave: a `namespace eval ::ns { namespace import ::other::* }` block
+    /// that declares no proc, class, or export of its own *is* a namespace
+    /// the workspace can see, and treating it as unknown made the import gate
+    /// abstain where it had the evidence to decide.
+    fn observable_namespaces(&self) -> HashSet<&str> {
+        fn owning_ns(qualified: &str) -> &str {
+            qualified
+                .trim_start_matches("::")
+                .rsplit_once("::")
+                .map_or("", |(ns, _)| ns)
+        }
+        self.procs()
+            .map(|p| owning_ns(&p.qualified_name))
+            .chain(self.classes().map(|c| owning_ns(&c.qualified_name)))
+            .chain(
+                self.namespace_exports()
+                    .map(|e| e.ns.trim_start_matches("::")),
+            )
+            .chain(
+                self.namespace_refs()
+                    .filter(|n| n.declares)
+                    .map(|n| n.qualified_name.trim_start_matches("::")),
+            )
+            .collect()
+    }
+
+    /// Add (or refresh) one document's records.
+    ///
+    /// Call [`Self::remove_document`] first when re-indexing a changed document
+    /// to avoid stale duplicates.  Adding the **same** URI twice without an
+    /// intervening removal deliberately accumulates: the M9 source-rehoming
+    /// pass indexes one analysis per source-site namespace, and those views are
+    /// several runtime identities of one physical file, not a replacement of
+    /// each other.
+    pub fn add_document(&mut self, uri: &str, analysis: &AnalysisResult) {
+        self.invalidate();
+        let slot = self.slot_for(uri);
+        self.docs[slot].index_document(uri, analysis);
+    }
+
+    /// `uri`'s slot, allocating one — the most recently freed, else a fresh
+    /// one — if it has none.
+    ///
+    /// The free list is LIFO so that the server's remove-then-add re-index
+    /// hands the document straight back the slot it just gave up, keeping its
+    /// position (and its tables' allocations) across a publish.
+    fn slot_for(&mut self, uri: &str) -> usize {
+        if let Some(&slot) = self.slots.get(uri) {
+            return slot;
+        }
+        let slot = if let Some(free) = self.free_slots.pop() {
+            free
+        } else {
+            self.docs.push(DocumentRecords::default());
+            self.docs.len() - 1
+        };
+        self.slots.insert(uri.to_owned(), slot);
+        slot
+    }
 
     /// Drop every entry that came from `uri` (used before
     /// re-indexing a changed document, or on `did_close`).
+    ///
+    /// Costs that document's own records, not the workspace's: its slot is
+    /// cleared and handed back to the free list (issue #1149).
     pub fn remove_document(&mut self, uri: &str) {
         self.invalidate();
-        self.procs.retain(|p| p.uri != uri);
-        self.classes.retain(|c| c.uri != uri);
-        self.variables.retain(|v| v.uri != uri);
-        self.variable_refs.retain(|v| v.uri != uri);
-        self.variable_aliases.retain(|v| v.uri != uri);
-        self.namespace_refs.retain(|n| n.uri != uri);
-        self.invocations.retain(|i| i.uri != uri);
-        self.sources.retain(|s| s.uri != uri);
-        self.package_requires.retain(|pr| pr.uri != uri);
-        self.command_links.retain(|l| l.uri != uri);
-        self.glob_imports.retain(|g| g.uri != uri);
-        self.namespace_exports.retain(|e| e.uri != uri);
-        self.namespace_forgets.retain(|f| f.uri != uri);
-        self.command_deletions.retain(|d| d.uri != uri);
+        if let Some(slot) = self.slots.remove(uri) {
+            self.docs[slot].clear();
+            self.free_slots.push(slot);
+        }
     }
 
     /// Every indexed `source FILE` reference.
-    #[must_use]
-    pub fn sources(&self) -> &[WorkspaceSource] {
-        &self.sources
+    pub fn sources(&self) -> impl Iterator<Item = &WorkspaceSource> {
+        self.docs.iter().flat_map(|doc| doc.sources.iter())
     }
 
     /// Every indexed `package require NAME` declaration.
-    #[must_use]
-    pub fn package_requires(&self) -> &[WorkspacePackageRequire] {
-        &self.package_requires
+    pub fn package_requires(&self) -> impl Iterator<Item = &WorkspacePackageRequire> {
+        self.docs.iter().flat_map(|doc| doc.package_requires.iter())
     }
 
     /// The package names `uri` `package require`s, de-duplicated. Used to seed
@@ -1388,8 +1525,7 @@ impl WorkspaceIndex {
     #[must_use]
     pub fn package_requires_for(&self, uri: &str) -> Vec<String> {
         let mut out: Vec<String> = self
-            .package_requires
-            .iter()
+            .package_requires()
             .filter(|pr| pr.uri == uri)
             .map(|pr| pr.name.clone())
             .collect();
@@ -1415,14 +1551,13 @@ impl WorkspaceIndex {
         resolve: impl Fn(&str, &str) -> Option<String>,
     ) -> Vec<String> {
         let edges: Vec<(String, String)> = self
-            .sources
-            .iter()
+            .sources()
             .filter(|s| s.is_literal)
             .filter_map(|s| resolve(&s.uri, &s.raw_path).map(|child| (s.uri.clone(), child)))
             .collect();
         let mut requires: std::collections::HashMap<String, Vec<String>> =
             std::collections::HashMap::new();
-        for pr in &self.package_requires {
+        for pr in self.package_requires() {
             requires
                 .entry(pr.uri.clone())
                 .or_default()
@@ -1450,7 +1585,7 @@ impl WorkspaceIndex {
     ) -> std::collections::HashMap<String, std::collections::BTreeSet<String>> {
         let mut out: std::collections::HashMap<String, std::collections::BTreeSet<String>> =
             std::collections::HashMap::new();
-        for src in &self.sources {
+        for src in self.sources() {
             let Some(child) = resolve(&src.uri, &src.raw_path, src.is_literal) else {
                 continue;
             };
@@ -1473,25 +1608,22 @@ impl WorkspaceIndex {
     /// workspaces that never `source`.
     #[must_use]
     pub fn has_source_edges(&self) -> bool {
-        !self.sources.is_empty()
+        self.sources().next().is_some()
     }
 
     /// Every indexed proc.
-    #[must_use]
-    pub fn procs(&self) -> &[WorkspaceProc] {
-        &self.procs
+    pub fn procs(&self) -> impl Iterator<Item = &WorkspaceProc> {
+        self.docs.iter().flat_map(|doc| doc.procs.iter())
     }
 
     /// Every indexed class.
-    #[must_use]
-    pub fn classes(&self) -> &[WorkspaceClass] {
-        &self.classes
+    pub fn classes(&self) -> impl Iterator<Item = &WorkspaceClass> {
+        self.docs.iter().flat_map(|doc| doc.classes.iter())
     }
 
     /// Every indexed `namespace import` / `interp alias` / `rename` link.
-    #[must_use]
-    pub fn command_links(&self) -> &[WorkspaceCommandLink] {
-        &self.command_links
+    pub fn command_links(&self) -> impl Iterator<Item = &WorkspaceCommandLink> {
+        self.docs.iter().flat_map(|doc| doc.command_links.iter())
     }
 
     /// Workspace classes whose qualified name matches `name` exactly or via
@@ -1509,8 +1641,7 @@ impl WorkspaceIndex {
     #[must_use]
     pub fn classes_named<'a>(&'a self, name: &str) -> Vec<&'a WorkspaceClass> {
         let q = format!("::{}", name.trim_start_matches("::"));
-        self.classes
-            .iter()
+        self.classes()
             .filter(|c| c.qualified_name == name || c.qualified_name == q)
             .collect()
     }
@@ -1525,12 +1656,9 @@ impl WorkspaceIndex {
         std::collections::HashSet<&str>,
         std::collections::HashMap<String, Vec<String>>,
     ) {
-        let known: std::collections::HashSet<&str> = self
-            .classes
-            .iter()
-            .map(|c| c.qualified_name.as_str())
-            .collect();
-        let tail_index = build_tail_index(self.classes.iter().map(|c| &c.qualified_name));
+        let known: std::collections::HashSet<&str> =
+            self.classes().map(|c| c.qualified_name.as_str()).collect();
+        let tail_index = build_tail_index(self.classes().map(|c| &c.qualified_name));
         (known, tail_index)
     }
 
@@ -1549,7 +1677,7 @@ impl WorkspaceIndex {
     ) -> Vec<String> {
         let mut out: Vec<String> = Vec::new();
         let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-        for c in self.classes.iter().filter(|c| c.qualified_name == qname) {
+        for c in self.classes().filter(|c| c.qualified_name == qname) {
             for s in c.superclasses.iter().chain(c.mixins.iter()) {
                 if let Some(p) =
                     resolve_class_name(s, qname, |cand| known.contains(cand), tail_index)
@@ -1584,7 +1712,7 @@ impl WorkspaceIndex {
             if !seen.insert(q.clone()) {
                 continue;
             }
-            out.extend(self.classes.iter().filter(|c| c.qualified_name == q));
+            out.extend(self.classes().filter(|c| c.qualified_name == q));
         }
         out
     }
@@ -1597,8 +1725,7 @@ impl WorkspaceIndex {
     #[must_use]
     pub fn subclasses_of<'a>(&'a self, class_qname: &str) -> Vec<&'a WorkspaceClass> {
         let (known, tail_index) = self.class_name_universe();
-        self.classes
-            .iter()
+        self.classes()
             .filter(|c| {
                 c.superclasses.iter().chain(c.mixins.iter()).any(|s| {
                     resolve_class_name(
@@ -1635,7 +1762,7 @@ impl WorkspaceIndex {
             std::collections::HashMap::new();
         let mut mixins_map: std::collections::HashMap<String, Vec<String>> =
             std::collections::HashMap::new();
-        for c in &self.classes {
+        for c in self.classes() {
             let owner = c.qualified_name.as_str();
             let resolve = |name: &str| {
                 resolve_class_name(name, owner, |cand| known.contains(cand), &tail_index)
@@ -1742,8 +1869,7 @@ impl WorkspaceIndex {
             // happened to be indexed.  Document URI then source position is
             // that stable order (issue #1028).
             let mut records: Vec<&WorkspaceClass> = self
-                .classes
-                .iter()
+                .classes()
                 .filter(|c| c.qualified_name == class_q)
                 .collect();
             records.sort_by_key(|c| (c.uri.as_str(), c.name_span.start(), c.name_span.end()));
@@ -1839,8 +1965,7 @@ impl WorkspaceIndex {
         let family = self.method_family_qnames(seed_class, method);
         let family_set: std::collections::HashSet<&str> =
             family.iter().map(String::as_str).collect();
-        self.classes
-            .iter()
+        self.classes()
             .filter(|c| family_set.contains(c.qualified_name.as_str()))
             .collect()
     }
@@ -1872,12 +1997,10 @@ impl WorkspaceIndex {
         let (known, tail_index) = self.class_name_universe();
         let parents = |qname: &str| self.resolved_parents_of(qname, &known, &tail_index);
         let defines = |qname: &str| {
-            self.classes
-                .iter()
+            self.classes()
                 .any(|c| c.qualified_name == qname && c.defines_method(method))
         };
-        self.classes
-            .iter()
+        self.classes()
             .filter(|c| {
                 // A definer is handled by the family itself, not here.
                 if c.defines_method(method) || family_set.contains(c.qualified_name.as_str()) {
@@ -1934,8 +2057,7 @@ impl WorkspaceIndex {
         };
         let connected = |a: &str, b: &str| a == b || is_ancestor(a, b) || is_ancestor(b, a);
         let class_defines = |qname: &str| {
-            self.classes
-                .iter()
+            self.classes()
                 .any(|c| c.qualified_name == qname && c.defines_method(method))
         };
         // Seed: the class under the cursor if it defines `method`, else the
@@ -1964,8 +2086,7 @@ impl WorkspaceIndex {
         // Every indexed definer of `method` (qualified names, de-duplicated).
         let definers: Vec<String> = {
             let mut ds: Vec<String> = self
-                .classes
-                .iter()
+                .classes()
                 .filter(|c| c.defines_method(method))
                 .map(|c| c.qualified_name.clone())
                 .collect();
@@ -1997,8 +2118,7 @@ impl WorkspaceIndex {
     /// provider already surfaces).  Empty `prefix` matches all.
     #[must_use]
     pub fn procs_matching<'a>(&'a self, prefix: &str, exclude_uri: &str) -> Vec<&'a WorkspaceProc> {
-        self.procs
-            .iter()
+        self.procs()
             .filter(|p| p.uri != exclude_uri)
             .filter(|p| {
                 prefix.is_empty()
@@ -2016,8 +2136,7 @@ impl WorkspaceIndex {
     #[must_use]
     pub fn proc_definitions<'a>(&'a self, name: &str, exclude_uri: &str) -> Vec<&'a WorkspaceProc> {
         let qualified = format!("::{name}");
-        self.procs
-            .iter()
+        self.procs()
             .filter(|p| p.uri != exclude_uri)
             .filter(|p| p.name == name || p.qualified_name == name || p.qualified_name == qualified)
             .collect()
@@ -2032,8 +2151,7 @@ impl WorkspaceIndex {
         exclude_uri: &str,
     ) -> Vec<&'a WorkspaceClass> {
         let qualified = format!("::{name}");
-        self.classes
-            .iter()
+        self.classes()
             .filter(|c| c.uri != exclude_uri)
             .filter(|c| c.name == name || c.qualified_name == name || c.qualified_name == qualified)
             .collect()
@@ -2055,8 +2173,7 @@ impl WorkspaceIndex {
         exclude_uri: &str,
     ) -> Vec<&'a WorkspaceProc> {
         let target = qualified_name.trim_start_matches("::");
-        self.procs
-            .iter()
+        self.procs()
             .filter(|p| p.uri != exclude_uri)
             .filter(|p| p.qualified_name.trim_start_matches("::") == target)
             .collect()
@@ -2072,23 +2189,20 @@ impl WorkspaceIndex {
         exclude_uri: &str,
     ) -> Vec<&'a WorkspaceClass> {
         let target = qualified_name.trim_start_matches("::");
-        self.classes
-            .iter()
+        self.classes()
             .filter(|c| c.uri != exclude_uri)
             .filter(|c| c.qualified_name.trim_start_matches("::") == target)
             .collect()
     }
 
     /// Every indexed invocation site.
-    #[must_use]
-    pub fn invocations(&self) -> &[WorkspaceInvocation] {
-        &self.invocations
+    pub fn invocations(&self) -> impl Iterator<Item = &WorkspaceInvocation> {
+        self.docs.iter().flat_map(|doc| doc.invocations.iter())
     }
 
     /// Every indexed namespace-qualified variable declaration.
-    #[must_use]
-    pub fn variables(&self) -> &[WorkspaceVariable] {
-        &self.variables
+    pub fn variables(&self) -> impl Iterator<Item = &WorkspaceVariable> {
+        self.docs.iter().flat_map(|doc| doc.variables.iter())
     }
 
     /// Declaration sites of the namespace variable whose `::`-rooted
@@ -2108,8 +2222,7 @@ impl WorkspaceIndex {
         exclude_uri: &str,
     ) -> Vec<&'a WorkspaceVariable> {
         let target = qualified_name.trim_start_matches("::");
-        self.variables
-            .iter()
+        self.variables()
             .filter(|v| v.uri != exclude_uri)
             .filter(|v| v.qualified_name.trim_start_matches("::") == target)
             .collect()
@@ -2142,19 +2255,16 @@ impl WorkspaceIndex {
             }
         };
         let mut uris: Vec<String> = self
-            .procs
-            .iter()
+            .procs()
             .filter(|p| parent_matches(&p.qualified_name))
             .map(|p| p.uri.clone())
             .chain(
-                self.classes
-                    .iter()
+                self.classes()
                     .filter(|c| parent_matches(&c.qualified_name))
                     .map(|c| c.uri.clone()),
             )
             .chain(
-                self.variables
-                    .iter()
+                self.variables()
                     .filter(|v| parent_matches(&v.qualified_name))
                     .map(|v| v.uri.clone()),
             )
@@ -2184,8 +2294,7 @@ impl WorkspaceIndex {
     pub fn documents_aliasing_variable(&self, qualified_name: &str) -> Vec<String> {
         let target = qualified_name.trim_start_matches("::");
         let mut uris: Vec<String> = self
-            .variable_aliases
-            .iter()
+            .variable_aliases()
             .filter(|a| !alias_cell_is_computed(&a.qualified_name))
             .filter(|a| a.qualified_name.trim_start_matches("::") == target)
             .map(|a| a.uri.clone())
@@ -2218,8 +2327,7 @@ impl WorkspaceIndex {
         let bare = qualified_name.trim_start_matches("::");
         let (cell_ns, cell_tail) = bare.rsplit_once("::").unwrap_or(("", bare));
         let mut uris: Vec<String> = self
-            .variable_aliases
-            .iter()
+            .variable_aliases()
             .filter(|a| alias_cell_is_computed(&a.qualified_name))
             .filter(|a| {
                 let written = a.qualified_name.trim_start_matches("::");
@@ -2236,9 +2344,8 @@ impl WorkspaceIndex {
     }
 
     /// Every indexed namespace-name occurrence.
-    #[must_use]
-    pub fn namespace_refs(&self) -> &[WorkspaceNamespaceRef] {
-        &self.namespace_refs
+    pub fn namespace_refs(&self) -> impl Iterator<Item = &WorkspaceNamespaceRef> {
+        self.docs.iter().flat_map(|doc| doc.namespace_refs.iter())
     }
 
     /// **Declaring** sites of the namespace `qualified_name` — the name word
@@ -2260,8 +2367,7 @@ impl WorkspaceIndex {
         exclude_uri: &str,
     ) -> Vec<&'a WorkspaceNamespaceRef> {
         let target = qualified_name.trim_start_matches("::");
-        self.namespace_refs
-            .iter()
+        self.namespace_refs()
             .filter(|n| n.declares && n.uri != exclude_uri)
             .filter(|n| n.qualified_name.trim_start_matches("::") == target)
             .collect()
@@ -2277,8 +2383,7 @@ impl WorkspaceIndex {
         exclude_uri: &str,
     ) -> Vec<&'a WorkspaceNamespaceRef> {
         let target = qualified_name.trim_start_matches("::");
-        self.namespace_refs
-            .iter()
+        self.namespace_refs()
             .filter(|n| !n.declares && n.uri != exclude_uri)
             .filter(|n| n.qualified_name.trim_start_matches("::") == target)
             .collect()
@@ -2295,8 +2400,7 @@ impl WorkspaceIndex {
         exclude_uri: &str,
     ) -> Vec<&'a WorkspaceVariableRef> {
         let target = qualified_name.trim_start_matches("::");
-        self.variable_refs
-            .iter()
+        self.variable_refs()
             .filter(|v| v.uri != exclude_uri)
             .filter(|v| v.qualified_name.trim_start_matches("::") == target)
             .collect()
@@ -2310,11 +2414,10 @@ impl WorkspaceIndex {
     #[must_use]
     pub fn document_uris(&self) -> Vec<String> {
         let mut uris: Vec<String> = self
-            .procs
-            .iter()
+            .procs()
             .map(|p| p.uri.clone())
-            .chain(self.classes.iter().map(|c| c.uri.clone()))
-            .chain(self.invocations.iter().map(|i| i.uri.clone()))
+            .chain(self.classes().map(|c| c.uri.clone()))
+            .chain(self.invocations().map(|i| i.uri.clone()))
             .collect();
         uris.sort();
         uris.dedup();
@@ -2403,8 +2506,7 @@ impl WorkspaceIndex {
         let defined = self.defined_command_names(follow_links);
         let links = follow_links.then(|| self.command_link_map());
         let wci = WildcardImportIndex::build(self);
-        self.invocations
-            .iter()
+        self.invocations()
             .filter(|i| i.uri != exclude_uri)
             .filter(|i| self.invocation_resolves_to(i, &defined, links.as_ref(), &wci, target))
             .collect()
@@ -2526,10 +2628,7 @@ impl WorkspaceIndex {
     /// consumer document's `set d [::other::Cls new]` resolves cross-file.
     #[must_use]
     pub fn all_class_qnames(&self) -> std::collections::HashSet<String> {
-        self.classes
-            .iter()
-            .map(|c| c.qualified_name.clone())
-            .collect()
+        self.classes().map(|c| c.qualified_name.clone()).collect()
     }
 
     /// The URIs of documents that invoke (a constructor of) any class in
@@ -2544,8 +2643,7 @@ impl WorkspaceIndex {
         &self,
         class_qnames: &std::collections::HashSet<&str>,
     ) -> std::collections::HashSet<String> {
-        self.invocations
-            .iter()
+        self.invocations()
             .filter(|i| {
                 i.resolution_candidates
                     .iter()
@@ -2602,12 +2700,10 @@ impl WorkspaceIndex {
             return self.workspace_command_exists(qualified_name);
         }
         let target = qualified_name.trim_start_matches("::");
-        self.procs
-            .iter()
+        self.procs()
             .any(|p| !p.nested && p.qualified_name.trim_start_matches("::") == target)
             || self
-                .classes
-                .iter()
+                .classes()
                 .any(|c| c.qualified_name.trim_start_matches("::") == target)
             || self
                 .live_command_links()
@@ -2632,12 +2728,10 @@ impl WorkspaceIndex {
     fn defined_command_names(&self, include_links: bool) -> Arc<HashSet<String>> {
         self.defined_names[usize::from(include_links)].get_or_build(|| {
             let mut names: HashSet<String> = self
-                .procs
-                .iter()
+                .procs()
                 .map(|p| p.qualified_name.trim_start_matches("::").to_owned())
                 .chain(
-                    self.classes
-                        .iter()
+                    self.classes()
                         .map(|c| c.qualified_name.trim_start_matches("::").to_owned()),
                 )
                 .collect();
@@ -2838,12 +2932,12 @@ impl<'a> WildcardImportIndex<'a> {
     fn build(index: &'a WorkspaceIndex) -> Self {
         let mut imports_by_ns: std::collections::HashMap<&str, Vec<&WorkspaceGlobImport>> =
             std::collections::HashMap::new();
-        for imp in &index.glob_imports {
+        for imp in index.glob_imports() {
             imports_by_ns.entry(imp.ns.as_str()).or_default().push(imp);
         }
         let mut exact_by_ns: std::collections::HashMap<&str, Vec<(&str, &WorkspaceImportGate)>> =
             std::collections::HashMap::new();
-        for link in &index.command_links {
+        for link in index.command_links() {
             if let Some(gate) = link.import_gate.as_ref() {
                 exact_by_ns
                     .entry(importing_namespace_of(&link.linked_qname))
@@ -2853,17 +2947,17 @@ impl<'a> WildcardImportIndex<'a> {
         }
         let mut exports_by_ns: std::collections::HashMap<&str, Vec<&WorkspaceNamespaceExport>> =
             std::collections::HashMap::new();
-        for exp in &index.namespace_exports {
+        for exp in index.namespace_exports() {
             exports_by_ns.entry(exp.ns.as_str()).or_default().push(exp);
         }
         let mut forgets_by_ns: std::collections::HashMap<&str, Vec<&WorkspaceNamespaceForget>> =
             std::collections::HashMap::new();
-        for fgt in &index.namespace_forgets {
+        for fgt in index.namespace_forgets() {
             forgets_by_ns.entry(fgt.ns.as_str()).or_default().push(fgt);
         }
         let mut deletions_by_name: std::collections::HashMap<&str, Vec<&WorkspaceCommandDeletion>> =
             std::collections::HashMap::new();
-        for del in &index.command_deletions {
+        for del in index.command_deletions() {
             deletions_by_name
                 .entry(del.qualified_name.as_str())
                 .or_default()
@@ -2872,8 +2966,7 @@ impl<'a> WildcardImportIndex<'a> {
         let mut declarations_by_qname: std::collections::HashMap<&str, Vec<(&str, u32)>> =
             std::collections::HashMap::new();
         for (qname, uri, at) in index
-            .procs
-            .iter()
+            .procs()
             .map(|p| {
                 (
                     p.qualified_name.as_str(),
@@ -2881,7 +2974,7 @@ impl<'a> WildcardImportIndex<'a> {
                     p.name_span.start(),
                 )
             })
-            .chain(index.classes.iter().map(|c| {
+            .chain(index.classes().map(|c| {
                 (
                     c.qualified_name.as_str(),
                     c.uri.as_str(),
@@ -3633,8 +3726,7 @@ mod tests {
         );
         // ::C::Widget's supertypes abstain (Base is ambiguous, ::C has none).
         let widget = index
-            .classes
-            .iter()
+            .classes()
             .find(|c| c.qualified_name == "::C::Widget")
             .expect("Widget indexed");
         assert!(
@@ -3758,9 +3850,9 @@ mod tests {
         let a = analyse("proc greet {name} {}\n");
         let b = analyse("proc farewell {} {}\nproc greet2 {x y} {}\n");
         let index = WorkspaceIndex::from_documents([("file:///a.tcl", &a), ("file:///b.tcl", &b)]);
-        assert_eq!(index.procs().len(), 3);
+        assert_eq!(index.procs().count(), 3);
         // Param counts captured.
-        let greet = index.procs().iter().find(|p| p.name == "greet").unwrap();
+        let greet = index.procs().find(|p| p.name == "greet").unwrap();
         assert_eq!(greet.param_count, 1);
         assert_eq!(greet.uri, "file:///a.tcl");
     }
@@ -3797,10 +3889,80 @@ mod tests {
         let mut index = WorkspaceIndex::new();
         index.add_document("file:///a.tcl", &a);
         index.add_document("file:///b.tcl", &b);
-        assert_eq!(index.procs().len(), 2);
+        assert_eq!(index.procs().count(), 2);
         index.remove_document("file:///a.tcl");
-        assert_eq!(index.procs().len(), 1);
-        assert_eq!(index.procs()[0].name, "b");
+        assert_eq!(index.procs().count(), 1);
+        assert_eq!(index.procs().next().map(|p| p.name.as_str()), Some("b"));
+    }
+
+    /// Issue #1149: a removal is scoped to the removed document.  Every other
+    /// document's records survive it untouched, in their original order —
+    /// which is what lets the removal cost that one document's rows instead of
+    /// a pass over every table in the workspace.
+    #[test]
+    fn remove_document_leaves_the_other_documents_alone() {
+        let a = analyse("proc a {} {}\na\n");
+        let b = analyse("proc b {} {}\nb\n");
+        let c = analyse("proc c {} {}\nc\n");
+        let mut index = WorkspaceIndex::new();
+        index.add_document("file:///a.tcl", &a);
+        index.add_document("file:///b.tcl", &b);
+        index.add_document("file:///c.tcl", &c);
+        index.remove_document("file:///b.tcl");
+        let names: Vec<&str> = index.procs().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["a", "c"]);
+        let call_uris: std::collections::BTreeSet<&str> =
+            index.invocations().map(|i| i.uri.as_str()).collect();
+        assert_eq!(
+            call_uris,
+            ["file:///a.tcl", "file:///c.tcl"].into_iter().collect()
+        );
+        assert_eq!(
+            index.document_uris(),
+            vec!["file:///a.tcl", "file:///c.tcl"]
+        );
+    }
+
+    /// Issue #1149: the remove-then-add every diagnostics publish performs must
+    /// neither grow the index nor shuffle the workspace — the document goes
+    /// back into the slot it just vacated.
+    #[test]
+    fn re_indexing_a_document_keeps_its_size_and_its_place() {
+        let a = analyse("proc a {} {}\n");
+        let b = analyse("proc b {} {}\n");
+        let mut index = WorkspaceIndex::new();
+        index.add_document("file:///a.tcl", &a);
+        index.add_document("file:///b.tcl", &b);
+        for _ in 0..5 {
+            index.remove_document("file:///a.tcl");
+            index.add_document("file:///a.tcl", &a);
+        }
+        let names: Vec<&str> = index.procs().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["a", "b"]);
+    }
+
+    /// Issue #1149: removing a URI the index never held changes nothing.
+    #[test]
+    fn removing_an_unindexed_document_changes_nothing() {
+        let a = analyse("proc a {} {}\n");
+        let mut index = WorkspaceIndex::new();
+        index.add_document("file:///a.tcl", &a);
+        index.remove_document("file:///never-indexed.tcl");
+        assert_eq!(index.procs().count(), 1);
+    }
+
+    /// Several analyses of one URI — M9's one re-homed view per source-site
+    /// namespace — still accumulate under that URI, and one removal drops the
+    /// whole set.
+    #[test]
+    fn several_views_of_one_document_accumulate_and_drop_together() {
+        let a = analyse("proc helper {} {}\n");
+        let mut index = WorkspaceIndex::new();
+        index.add_document("file:///a.tcl", &a);
+        index.add_document("file:///a.tcl", &a);
+        assert_eq!(index.procs().count(), 2);
+        index.remove_document("file:///a.tcl");
+        assert_eq!(index.procs().count(), 0);
     }
 
     #[test]
@@ -4739,7 +4901,7 @@ mod tests {
         // …and the column really is populated on the rows the resolver reads.
         let index = WorkspaceIndex::from_documents([("file:///a.tcl", &a)]);
         assert!(
-            index.invocations.iter().any(|i| i.enclosing_body.is_some()),
+            index.invocations().any(|i| i.enclosing_body.is_some()),
             "body-local invocations must carry their span",
         );
     }
@@ -5475,7 +5637,6 @@ mod tests {
         let index = WorkspaceIndex::from_documents([("file:///a.tcl", &a)]);
         let set_proc = index
             .procs()
-            .iter()
             .find(|p| p.qualified_name == "::set")
             .expect("nested ::set proc indexed");
         assert!(
@@ -5555,7 +5716,7 @@ mod tests {
                 .namespace_declarations_qualified("::gone", "")
                 .is_empty()
         );
-        assert!(index.namespace_refs().is_empty());
+        assert!(index.namespace_refs().next().is_none());
     }
 
     #[test]
@@ -5590,7 +5751,6 @@ mod tests {
         let index = WorkspaceIndex::from_documents([("file:///a.tcl", &a)]);
         let puts_proc = index
             .procs()
-            .iter()
             .find(|p| p.qualified_name == "::puts")
             .expect("top-level ::puts proc indexed");
         assert!(!puts_proc.nested, "a top-level proc is never nested");
@@ -5610,7 +5770,6 @@ mod tests {
         let index = WorkspaceIndex::from_documents([("file:///a.tcl", &a)]);
         let link = index
             .command_links()
-            .iter()
             .find(|l| l.linked_qname.trim_start_matches("::") == "set")
             .expect("top-level alias link indexed");
         assert!(!link.nested, "a top-level alias is never nested");
@@ -5633,7 +5792,6 @@ mod tests {
         let index = WorkspaceIndex::from_documents([("file:///a.tcl", &a)]);
         let link = index
             .command_links()
-            .iter()
             .find(|l| l.linked_qname.trim_start_matches("::") == "set")
             .expect("nested alias link indexed");
         assert!(
@@ -5755,9 +5913,9 @@ mod tests {
         let mut index = WorkspaceIndex::new();
         index.add_document("file:///a.tcl", &a);
         assert!(
-            !index.variables().iter().any(|v| v.name == "localOnly"),
+            !index.variables().any(|v| v.name == "localOnly"),
             "indexed variables: {:?}",
-            index.variables(),
+            index.variables().collect::<Vec<_>>(),
         );
     }
 
@@ -5856,9 +6014,9 @@ mod tests {
         let a = analyse("helper\n");
         let mut index = WorkspaceIndex::new();
         index.add_document("file:///a.tcl", &a);
-        assert!(!index.invocations().is_empty());
+        assert!(index.invocations().next().is_some());
         index.remove_document("file:///a.tcl");
-        assert!(index.invocations().is_empty());
+        assert!(index.invocations().next().is_none());
     }
 
     #[test]
@@ -5871,7 +6029,7 @@ mod tests {
             vec!["Tk".to_owned(), "http".to_owned()]
         );
         index.remove_document("file:///a.tcl");
-        assert!(index.package_requires().is_empty());
+        assert!(index.package_requires().next().is_none());
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -76,6 +76,9 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use crate::workspace_symbols::{
+    IndexedWorkspaceSymbol, WorkspaceSymbolKind, matches_query, namespace_of,
+};
 use tcl_compiler::analyser::class_hierarchy::{build_tail_index, resolve_class_name};
 use tcl_compiler::analyser::{AnalysisResult, MemberSide};
 use tcl_lexer::Span;
@@ -182,6 +185,12 @@ pub struct WorkspaceClass {
     /// `classmethod` / snit `typemethod` (dispatched as two bare words)
     /// without a local `ClassDef` to ask.
     pub metaclass: String,
+    /// Byte spans of this record's `constructor` name tokens, in declaration
+    /// order (`oo::configurable` admits more than one).  Constructors are not
+    /// dispatchable members, so they stay out of [`Self::methods`]; they are
+    /// carried only so `workspace/symbol` can offer them from an unopened file
+    /// the way the per-document outline does (issue #1156).
+    pub constructor_spans: Vec<Span>,
 }
 
 impl WorkspaceClass {
@@ -252,6 +261,11 @@ pub struct WorkspaceMethod {
     /// carrying it here is what lets a *cross-file* consumer scan tell the
     /// two apart (Codex review on #1047).
     pub is_self_method: bool,
+    /// Byte span of the method's name token in the declaring record's
+    /// document.  Carried so `workspace/symbol` can locate a method in a file
+    /// the editor has never opened (issue #1156); cross-file *dispatch* uses
+    /// the name and the visibility flags and does not need it.
+    pub name_span: Span,
 }
 
 /// The access context of a method call site — `TclOO` dispatches an
@@ -311,6 +325,30 @@ pub struct WorkspaceInvocation {
     /// [`WorkspaceIndex::enclosing_body_spans`] computes the whole column in
     /// one stack sweep instead, `O((P + I) log (P + I))` per document.
     pub enclosing_body: Option<Span>,
+}
+
+/// One **registry symbol-definer** definition recorded in the index — a
+/// `tcltest::test` case, a `testConstraint`, a `customMatch` mode, or an
+/// iRules `when EVENT` handler (issue #790's outline tier, lifted to the
+/// workspace for issue #1156).
+///
+/// Cross-document identity, as the index requires of every table: each of
+/// these is a *named* definition carrying its enclosing namespace, spellable
+/// from another file exactly as a proc's qualified name is.  They are not
+/// callable commands, so they stay out of `procs` and out of the command
+/// existence oracle; the workspace-symbol picker is their consumer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceDefinedSymbol {
+    /// Document the definition is in.
+    pub uri: String,
+    /// Definition name as resolved (a test's case label, an event's name).
+    pub name: String,
+    /// Fully-qualified name, with the enclosing namespace applied.
+    pub qualified_name: String,
+    /// The registry's outline category for it.
+    pub kind: tcl_registry::DefinedSymbolKind,
+    /// Byte span of the name token in `uri`'s source.
+    pub name_span: Span,
 }
 
 /// One **namespace-qualified** variable declaration recorded in the index —
@@ -757,6 +795,7 @@ struct DocumentRecords {
     namespace_exports: Vec<WorkspaceNamespaceExport>,
     namespace_forgets: Vec<WorkspaceNamespaceForget>,
     command_deletions: Vec<WorkspaceCommandDeletion>,
+    defined_symbols: Vec<WorkspaceDefinedSymbol>,
 }
 
 impl DocumentRecords {
@@ -785,6 +824,7 @@ impl DocumentRecords {
             namespace_exports,
             namespace_forgets,
             command_deletions,
+            defined_symbols,
         } = self;
         procs.clear();
         classes.clear();
@@ -800,6 +840,103 @@ impl DocumentRecords {
         namespace_exports.clear();
         namespace_forgets.clear();
         command_deletions.clear();
+        defined_symbols.clear();
+    }
+
+    /// Append this document's [`IndexedWorkspaceSymbol`]s matching
+    /// `lower_query` to `out`, stopping once `out` reaches `limit`.
+    ///
+    /// The order — procs, then classes with their members, then registry
+    /// symbol-definer definitions — mirrors the per-document outline the
+    /// document-symbol provider produces, and each table is already in source
+    /// order (see [`sorted_by_span`]).
+    fn collect_symbols_matching(
+        &self,
+        lower_query: &str,
+        limit: usize,
+        out: &mut Vec<IndexedWorkspaceSymbol>,
+    ) {
+        for proc_def in &self.procs {
+            if out.len() >= limit {
+                return;
+            }
+            if matches_query(&proc_def.name, lower_query)
+                || matches_query(&proc_def.qualified_name, lower_query)
+            {
+                out.push(IndexedWorkspaceSymbol {
+                    uri: proc_def.uri.clone(),
+                    name: proc_def.name.clone(),
+                    container_name: namespace_of(&proc_def.qualified_name),
+                    kind: WorkspaceSymbolKind::Function,
+                    name_span: proc_def.name_span,
+                });
+            }
+        }
+        // A constructor's only name is the keyword, so whether the query
+        // admits one is decided once rather than per class.
+        let wants_constructors = matches_query("constructor", lower_query);
+        for class_def in &self.classes {
+            if out.len() >= limit {
+                return;
+            }
+            if matches_query(&class_def.name, lower_query)
+                || matches_query(&class_def.qualified_name, lower_query)
+            {
+                out.push(IndexedWorkspaceSymbol {
+                    uri: class_def.uri.clone(),
+                    name: class_def.name.clone(),
+                    container_name: namespace_of(&class_def.qualified_name),
+                    kind: WorkspaceSymbolKind::Class,
+                    name_span: class_def.name_span,
+                });
+            }
+            // Members carry the class's qualified name as their container, so
+            // an editor renders them as `ClassName::methodName`.
+            for method in &class_def.methods {
+                if out.len() >= limit {
+                    return;
+                }
+                if matches_query(&method.name, lower_query) {
+                    out.push(IndexedWorkspaceSymbol {
+                        uri: class_def.uri.clone(),
+                        name: method.name.clone(),
+                        container_name: Some(class_def.qualified_name.clone()),
+                        kind: WorkspaceSymbolKind::Method,
+                        name_span: method.name_span,
+                    });
+                }
+            }
+            if wants_constructors {
+                for &name_span in &class_def.constructor_spans {
+                    if out.len() >= limit {
+                        return;
+                    }
+                    out.push(IndexedWorkspaceSymbol {
+                        uri: class_def.uri.clone(),
+                        name: "constructor".to_owned(),
+                        container_name: Some(class_def.qualified_name.clone()),
+                        kind: WorkspaceSymbolKind::Constructor,
+                        name_span,
+                    });
+                }
+            }
+        }
+        for sym in &self.defined_symbols {
+            if out.len() >= limit {
+                return;
+            }
+            if matches_query(&sym.name, lower_query)
+                || matches_query(&sym.qualified_name, lower_query)
+            {
+                out.push(IndexedWorkspaceSymbol {
+                    uri: sym.uri.clone(),
+                    name: sym.name.clone(),
+                    container_name: namespace_of(&sym.qualified_name),
+                    kind: WorkspaceSymbolKind::from(sym.kind),
+                    name_span: sym.name_span,
+                });
+            }
+        }
     }
 
     /// Lift one document's analysis into this record set.
@@ -825,6 +962,15 @@ impl DocumentRecords {
             });
         }
         self.index_classes(uri, analysis);
+        for sym in sorted_by_span(&analysis.all_defined_symbols, |s| s.name_span) {
+            self.defined_symbols.push(WorkspaceDefinedSymbol {
+                uri: uri.to_owned(),
+                name: sym.name.clone(),
+                qualified_name: sym.qualified_name.clone(),
+                kind: sym.kind,
+                name_span: sym.name_span,
+            });
+        }
         self.index_variables(uri, analysis);
         self.index_namespace_refs(uri, analysis);
         let bodies = WorkspaceIndex::enclosing_body_spans(
@@ -891,6 +1037,7 @@ impl DocumentRecords {
                         exported: m.visibility == "public",
                         private: m.visibility == "private",
                         is_self_method: m.is_self_method,
+                        name_span: m.name_span,
                     })
                     .chain(
                         sorted_by_span(class_def.class_methods.values(), |m| m.name_span)
@@ -901,6 +1048,7 @@ impl DocumentRecords {
                                 exported: m.visibility == "public",
                                 private: m.visibility == "private",
                                 is_self_method: m.is_self_method,
+                                name_span: m.name_span,
                             }),
                     )
                     .collect();
@@ -919,6 +1067,7 @@ impl DocumentRecords {
                 retracted_members: class_def.retracted_members.clone(),
                 via_define: class_def.via_define,
                 metaclass: class_def.metaclass.clone(),
+                constructor_spans: class_def.constructors.iter().map(|c| c.name_span).collect(),
             });
         }
     }
@@ -1609,6 +1758,38 @@ impl WorkspaceIndex {
     #[must_use]
     pub fn has_source_edges(&self) -> bool {
         self.sources().next().is_some()
+    }
+
+    /// The workspace's symbols matching `query`, at most `limit` of them —
+    /// the whole `workspace/symbol` answer (issue #1156).
+    ///
+    /// Every indexed document is searched, not only the ones the editor has
+    /// open, so a symbol in a file the user has never opened is reachable from
+    /// the picker.  The index is refreshed on each document's diagnostics
+    /// publish (~50 ms after an edit), which is the freshness a symbol picker
+    /// gets: a name typed a moment ago appears once that publish lands.  It is
+    /// the same staleness every other cross-document feature answers with, and
+    /// the alternative — re-analysing every open buffer per keystroke in the
+    /// Ctrl+T box — is what this replaces.
+    ///
+    /// The scan is **document-major**: each document contributes its procs,
+    /// then its classes (with their methods and constructors), then its
+    /// registry symbol-definer definitions, before the next document is
+    /// looked at.  So a `limit`-truncated answer is a prefix of the workspace
+    /// rather than a prefix of one symbol table — a capped result still holds
+    /// classes and test cases, not only procs — and results arrive grouped by
+    /// URI, which lets the caller resolve each document's source once.
+    #[must_use]
+    pub fn symbols_matching(&self, query: &str, limit: usize) -> Vec<IndexedWorkspaceSymbol> {
+        let lower_query = query.to_lowercase();
+        let mut out: Vec<IndexedWorkspaceSymbol> = Vec::new();
+        for doc in &self.docs {
+            if out.len() >= limit {
+                break;
+            }
+            doc.collect_symbols_matching(&lower_query, limit, &mut out);
+        }
+        out
     }
 
     /// Every indexed proc.

--- a/rust/tcl-lsp-core/src/workspace_symbols.rs
+++ b/rust/tcl-lsp-core/src/workspace_symbols.rs
@@ -18,17 +18,28 @@
 
 //! Workspace-symbols provider.
 //!
-//! Lists every proc, class, method, `classmethod`, and
-//! constructor recorded in the analyser's
-//! `AnalysisResult` for the **current document**, filtered by
-//! a query string.  This provider operates on a single
-//! document; it does not yet walk every document in the
-//! workspace index.
+//! Answers `workspace/symbol` from the [`crate::workspace_index::WorkspaceIndex`]:
+//! every proc, class, method, `classmethod`, constructor, and registry
+//! symbol-definer definition (a `tcltest::test` case, a `testConstraint`, a
+//! `customMatch` mode, an iRules `when EVENT` handler) the **whole workspace**
+//! holds, filtered by a query string.
+//!
+//! This module owns the wire contract — what counts as a workspace symbol,
+//! what kind it reports, and how a query matches.  The scan itself is
+//! [`crate::workspace_index::WorkspaceIndex::symbols_matching`], which walks
+//! the index document by document so that a capped answer is a slice of the
+//! workspace rather than a slice of one symbol table.
 
-use tcl_compiler::analyser::AnalysisResult;
-use tcl_lexer::LineIndex;
+use tcl_lexer::Span;
 
-use crate::definition::LspRange;
+/// The most symbols one `workspace/symbol` answer carries.
+///
+/// VS Code re-issues the request on every keystroke in its Ctrl+T box, and a
+/// short query matches most of a large workspace — on the order of 100 000
+/// symbols on tcllib, none of which a picker can usefully show.  The cap is
+/// applied *while scanning the index*, so it bounds the work and not merely
+/// the payload.
+pub const MAX_WORKSPACE_SYMBOL_RESULTS: usize = 1000;
 
 /// Workspace-symbol kind.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -65,190 +76,116 @@ impl From<tcl_registry::DefinedSymbolKind> for WorkspaceSymbolKind {
     }
 }
 
-/// One entry in a workspace-symbols response.
+/// One entry in a `workspace/symbol` response.
+///
+/// The location is a byte [`Span`] in `uri`'s source, not an LSP range: a
+/// range needs the target document's text, which the index does not hold, so
+/// the server resolves it at delivery time — the rule every other
+/// cross-document index answer follows.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WorkspaceSymbol {
+pub struct IndexedWorkspaceSymbol {
+    /// Document the definition is in.
+    pub uri: String,
     /// Display name (unqualified).
     pub name: String,
-    /// Container name (e.g. namespace), or `None`.
+    /// Container name — the enclosing namespace, or the owning class for a
+    /// method or constructor — or `None`.
     pub container_name: Option<String>,
     /// Symbol kind.
     pub kind: WorkspaceSymbolKind,
-    /// Definition span.
-    pub range: LspRange,
+    /// Byte span of the definition's name token in `uri`'s source.
+    pub name_span: Span,
 }
 
-/// Compute workspace symbols for the current document
-/// matching `query`.
-#[must_use]
-pub fn workspace_symbols(
-    source: &str,
-    query: &str,
-    analysis: &AnalysisResult,
-) -> Vec<WorkspaceSymbol> {
-    let line_index = LineIndex::new(source);
-    let lower_query = query.to_lowercase();
-    let mut out = Vec::new();
-    for (qname, proc_def) in &analysis.all_procs {
-        if matches_query(&proc_def.name, &lower_query) || matches_query(qname, &lower_query) {
-            out.push(WorkspaceSymbol {
-                name: proc_def.name.clone(),
-                container_name: namespace_of(qname),
-                kind: WorkspaceSymbolKind::Function,
-                range: span_to_range(source, &line_index, proc_def.name_span),
-            });
-        }
-    }
-    for class_def in analysis.all_classes.values() {
-        if matches_query(&class_def.name, &lower_query)
-            || matches_query(&class_def.qualified_name, &lower_query)
-        {
-            out.push(WorkspaceSymbol {
-                name: class_def.name.clone(),
-                container_name: namespace_of(&class_def.qualified_name),
-                kind: WorkspaceSymbolKind::Class,
-                range: span_to_range(source, &line_index, class_def.name_span),
-            });
-        }
-        // Instance + class methods + constructors — surface each
-        // member with the class's qualified name as the
-        // container, so editors render them as
-        // `ClassName::methodName` and can navigate to them via
-        // the symbol-list jump.
-        let container = Some(class_def.qualified_name.clone());
-        for method in class_def.methods.values() {
-            if matches_query(&method.name, &lower_query) {
-                out.push(WorkspaceSymbol {
-                    name: method.name.clone(),
-                    container_name: container.clone(),
-                    kind: WorkspaceSymbolKind::Method,
-                    range: span_to_range(source, &line_index, method.name_span),
-                });
-            }
-        }
-        for method in class_def.class_methods.values() {
-            if matches_query(&method.name, &lower_query) {
-                out.push(WorkspaceSymbol {
-                    name: method.name.clone(),
-                    container_name: container.clone(),
-                    kind: WorkspaceSymbolKind::Method,
-                    range: span_to_range(source, &line_index, method.name_span),
-                });
-            }
-        }
-        for ctor in &class_def.constructors {
-            if matches_query("constructor", &lower_query) {
-                out.push(WorkspaceSymbol {
-                    name: "constructor".to_string(),
-                    container_name: container.clone(),
-                    kind: WorkspaceSymbolKind::Constructor,
-                    range: span_to_range(source, &line_index, ctor.name_span),
-                });
-            }
-        }
-    }
-    // Registry symbol-definer definitions (tcltest tests, …) — same shape as
-    // procs, keyed on the resolved name and its enclosing namespace container.
-    for sym in &analysis.all_defined_symbols {
-        if matches_query(&sym.name, &lower_query)
-            || matches_query(&sym.qualified_name, &lower_query)
-        {
-            out.push(WorkspaceSymbol {
-                name: sym.name.clone(),
-                container_name: namespace_of(&sym.qualified_name),
-                kind: WorkspaceSymbolKind::from(sym.kind),
-                range: span_to_range(source, &line_index, sym.name_span),
-            });
-        }
-    }
-    out
-}
-
-fn matches_query(name: &str, lower_query: &str) -> bool {
+/// Whether `name` satisfies `lower_query`: a case-insensitive substring
+/// match, with an empty query matching everything.
+pub(crate) fn matches_query(name: &str, lower_query: &str) -> bool {
     if lower_query.is_empty() {
         return true;
     }
     name.to_lowercase().contains(lower_query)
 }
 
-fn namespace_of(qname: &str) -> Option<String> {
+/// The enclosing namespace of a qualified name, or `None` when it names a
+/// global.
+pub(crate) fn namespace_of(qname: &str) -> Option<String> {
     let stripped = qname.strip_prefix("::").unwrap_or(qname);
     let last_sep = stripped.rfind("::")?;
     Some(format!("::{}", &stripped[..last_sep]))
 }
 
-fn span_to_range(source: &str, line_index: &LineIndex, span: tcl_lexer::Span) -> LspRange {
-    let start = line_index.position_at_utf16(span.start(), source);
-    let end = line_index.position_at_utf16(span.end(), source);
-    LspRange {
-        start_line: start.line,
-        start_character: start.character.get(),
-        end_line: end.line,
-        end_character: end.character.get(),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tcl_compiler::analyser::Analyser;
+    use crate::workspace_index::WorkspaceIndex;
+    use tcl_compiler::analyser::{Analyser, AnalysisResult};
 
     fn analyse(source: &str) -> AnalysisResult {
         let mut a = Analyser::new();
         a.analyse(source, "tcl8.6").clone()
     }
 
+    /// One document indexed under `file:///a.tcl`, queried for `query`.
+    fn symbols(source: &str, query: &str) -> Vec<IndexedWorkspaceSymbol> {
+        let analysis = analyse(source);
+        let mut index = WorkspaceIndex::new();
+        index.add_document("file:///a.tcl", &analysis);
+        index.symbols_matching(query, MAX_WORKSPACE_SYMBOL_RESULTS)
+    }
+
     #[test]
     fn empty_query_returns_all_symbols() {
-        let src = "proc alpha {} {}\nproc beta {} {}\n";
-        let analysis = analyse(src);
-        let syms = workspace_symbols(src, "", &analysis);
+        let syms = symbols("proc alpha {} {}\nproc beta {} {}\n", "");
         assert_eq!(syms.len(), 2);
     }
 
     #[test]
     fn query_filters_by_substring_case_insensitive() {
-        let src = "proc alpha {} {}\nproc beta {} {}\n";
-        let analysis = analyse(src);
-        let syms = workspace_symbols(src, "Alp", &analysis);
+        let syms = symbols("proc alpha {} {}\nproc beta {} {}\n", "Alp");
         assert_eq!(syms.len(), 1);
         assert_eq!(syms[0].name, "alpha");
+    }
+
+    #[test]
+    fn a_qualified_name_matches_the_query_too() {
+        let syms = symbols("namespace eval util { proc helper {} {} }\n", "util::help");
+        assert_eq!(syms.len(), 1, "{syms:?}");
+        assert_eq!(syms[0].name, "helper");
+        assert_eq!(syms[0].container_name.as_deref(), Some("::util"));
     }
 
     // class methods
 
     #[test]
     fn class_methods_surface_as_workspace_symbols() {
-        let src = "oo::class create MyClass {\n\
-                       method greet {} {}\n\
-                       method farewell {} {}\n\
-                   }\n";
-        let analysis = analyse(src);
-        let syms = workspace_symbols(src, "", &analysis);
-        // Should include the class, both methods.
-        let by_name: std::collections::HashMap<&str, &WorkspaceSymbol> =
+        let syms = symbols(
+            "oo::class create MyClass {\n\
+                 method greet {} {}\n\
+                 method farewell {} {}\n\
+             }\n",
+            "",
+        );
+        let by_name: std::collections::HashMap<&str, &IndexedWorkspaceSymbol> =
             syms.iter().map(|s| (s.name.as_str(), s)).collect();
         assert!(by_name.contains_key("MyClass"), "{syms:?}");
         assert!(by_name.contains_key("greet"), "{syms:?}");
         assert!(by_name.contains_key("farewell"), "{syms:?}");
-        // Class kind.
         assert_eq!(by_name["MyClass"].kind, WorkspaceSymbolKind::Class);
-        // Methods are tagged Method and have the class's qualified
-        // name as container.
         assert_eq!(by_name["greet"].kind, WorkspaceSymbolKind::Method);
         assert_eq!(
             by_name["greet"].container_name.as_deref(),
-            Some("::MyClass"),
+            Some("::MyClass")
         );
     }
 
     #[test]
     fn classmethod_surfaces_with_method_kind() {
-        let src = "oo::class create MyClass {\n\
-                       classmethod factory {} {}\n\
-                   }\n";
-        let analysis = analyse(src);
-        let syms = workspace_symbols(src, "factory", &analysis);
+        let syms = symbols(
+            "oo::class create MyClass {\n\
+                 classmethod factory {} {}\n\
+             }\n",
+            "factory",
+        );
         assert_eq!(syms.len(), 1);
         assert_eq!(syms[0].name, "factory");
         assert_eq!(syms[0].kind, WorkspaceSymbolKind::Method);
@@ -256,13 +193,13 @@ mod tests {
 
     #[test]
     fn constructor_surfaces_with_constructor_kind() {
-        let src = "oo::class create MyClass {\n\
-                       constructor {arg} {}\n\
-                   }\n";
-        let analysis = analyse(src);
-        let syms = workspace_symbols(src, "constructor", &analysis);
-        // At least one constructor entry, with the right kind.
-        let ctors: Vec<&WorkspaceSymbol> = syms
+        let syms = symbols(
+            "oo::class create MyClass {\n\
+                 constructor {arg} {}\n\
+             }\n",
+            "constructor",
+        );
+        let ctors: Vec<&IndexedWorkspaceSymbol> = syms
             .iter()
             .filter(|s| s.kind == WorkspaceSymbolKind::Constructor)
             .collect();
@@ -273,12 +210,13 @@ mod tests {
 
     #[test]
     fn query_matches_method_substring() {
-        let src = "oo::class create MyClass {\n\
-                       method greetUser {} {}\n\
-                       method farewell {} {}\n\
-                   }\n";
-        let analysis = analyse(src);
-        let syms = workspace_symbols(src, "greet", &analysis);
+        let syms = symbols(
+            "oo::class create MyClass {\n\
+                 method greetUser {} {}\n\
+                 method farewell {} {}\n\
+             }\n",
+            "greet",
+        );
         let labels: Vec<&str> = syms.iter().map(|s| s.name.as_str()).collect();
         assert!(labels.contains(&"greetUser"), "{syms:?}");
         assert!(!labels.contains(&"farewell"), "{syms:?}");
@@ -288,11 +226,12 @@ mod tests {
 
     #[test]
     fn tcltest_test_surfaces_as_workspace_symbol() {
-        let src = "package require tcltest\n\
-                   namespace import ::tcltest::*\n\
-                   test find-me-1 {desc} -body { set x 1 } -result 1\n";
-        let analysis = analyse(src);
-        let syms = workspace_symbols(src, "find-me", &analysis);
+        let syms = symbols(
+            "package require tcltest\n\
+             namespace import ::tcltest::*\n\
+             test find-me-1 {desc} -body { set x 1 } -result 1\n",
+            "find-me",
+        );
         let hit = syms
             .iter()
             .find(|s| s.name == "find-me-1")
@@ -302,13 +241,14 @@ mod tests {
 
     #[test]
     fn constraint_and_matcher_surface_with_own_kinds() {
-        let src = "package require tcltest\n\
-                   namespace import ::tcltest::*\n\
-                   testConstraint slowNet 1\n\
-                   customMatch approxEq ::approx\n";
-        let analysis = analyse(src);
-        let syms = workspace_symbols(src, "", &analysis);
-        let by_name: std::collections::HashMap<&str, &WorkspaceSymbol> =
+        let syms = symbols(
+            "package require tcltest\n\
+             namespace import ::tcltest::*\n\
+             testConstraint slowNet 1\n\
+             customMatch approxEq ::approx\n",
+            "",
+        );
+        let by_name: std::collections::HashMap<&str, &IndexedWorkspaceSymbol> =
             syms.iter().map(|s| (s.name.as_str(), s)).collect();
         assert_eq!(
             by_name.get("slowNet").map(|s| s.kind),
@@ -324,17 +264,61 @@ mod tests {
 
     #[test]
     fn test_case_in_namespace_has_container() {
-        let src = "package require tcltest\n\
-                   namespace eval suite {\n\
-                       tcltest::test scoped-1 {desc} -body { set x 1 } -result 1\n\
-                   }\n";
-        let analysis = analyse(src);
-        let syms = workspace_symbols(src, "scoped", &analysis);
+        let syms = symbols(
+            "package require tcltest\n\
+             namespace eval suite {\n\
+                 tcltest::test scoped-1 {desc} -body { set x 1 } -result 1\n\
+             }\n",
+            "scoped",
+        );
         let hit = syms
             .iter()
             .find(|s| s.name == "scoped-1")
             .unwrap_or_else(|| panic!("scoped test not found in {syms:?}"));
         assert_eq!(hit.kind, WorkspaceSymbolKind::Test);
         assert_eq!(hit.container_name.as_deref(), Some("::suite"));
+    }
+
+    /// Issue #1156: a document the editor never opened — only scanned into the
+    /// index — is searchable.  The previous handler walked the *open-document*
+    /// map, so every symbol in an unopened file was invisible to Ctrl+T.
+    #[test]
+    fn symbols_come_from_every_indexed_document_not_only_open_ones() {
+        let a = analyse("proc opened_one {} {}\n");
+        let b = analyse("proc never_opened {} {}\n");
+        let mut index = WorkspaceIndex::new();
+        index.add_document("file:///open.tcl", &a);
+        index.add_document("file:///scanned.tcl", &b);
+        let syms = index.symbols_matching("never_opened", MAX_WORKSPACE_SYMBOL_RESULTS);
+        assert_eq!(syms.len(), 1, "{syms:?}");
+        assert_eq!(syms[0].uri, "file:///scanned.tcl");
+    }
+
+    /// Issue #1156: the cap bounds the answer, and it bounds it *by document*
+    /// — a truncated result is a prefix of the workspace, not a prefix of one
+    /// symbol table.
+    #[test]
+    fn the_result_cap_holds_and_truncates_by_document() {
+        let mut index = WorkspaceIndex::new();
+        for doc in 0..10 {
+            let src = (0..10).fold(String::new(), |mut src, n| {
+                use std::fmt::Write;
+                let _ = writeln!(src, "proc p{doc}_{n} {{}} {{}}");
+                src
+            });
+            let analysis = analyse(&src);
+            index.add_document(&format!("file:///d{doc}.tcl"), &analysis);
+        }
+        assert_eq!(index.symbols_matching("", 100).len(), 100);
+        let capped = index.symbols_matching("", 25);
+        assert_eq!(capped.len(), 25);
+        let uris: std::collections::BTreeSet<&str> =
+            capped.iter().map(|s| s.uri.as_str()).collect();
+        assert_eq!(
+            uris,
+            ["file:///d0.tcl", "file:///d1.tcl", "file:///d2.tcl"]
+                .into_iter()
+                .collect(),
+        );
     }
 }

--- a/rust/tcl-lsp-core/tests/lsp_edit_workspace.rs
+++ b/rust/tcl-lsp-core/tests/lsp_edit_workspace.rs
@@ -19,8 +19,8 @@
 //! Behaviour-driven coverage of several `tcl-lsp-core` editing / workspace
 //! providers and utilities:
 //!
-//!   * `workspace_symbols::workspace_symbols` — symbol search over the
-//!     analysed document.
+//!   * `workspace_index::WorkspaceIndex::symbols_matching` — workspace
+//!     symbol search over the indexed documents.
 //!   * `minify::{minify_tcl, minify_tcl_compact, minify_tcl_aggressive, …}`
 //!     — the Tcl minifier tiers.
 //!   * `snippets::snippet_completions` — context-aware snippet templates.
@@ -78,7 +78,10 @@ use tcl_lsp_core::source_style::{
     DEFAULT_LINE_ENDING, DEFAULT_LINE_LENGTH, StyleSeverity, check_comment_continuation,
     check_line_endings, check_line_length, check_trailing_whitespace, style_diagnostics,
 };
-use tcl_lsp_core::workspace_symbols::{WorkspaceSymbol, WorkspaceSymbolKind, workspace_symbols};
+use tcl_lsp_core::workspace_index::WorkspaceIndex;
+use tcl_lsp_core::workspace_symbols::{
+    IndexedWorkspaceSymbol, MAX_WORKSPACE_SYMBOL_RESULTS, WorkspaceSymbolKind,
+};
 use tcl_registry::{CommandRegistry, registry_for_dialect};
 
 // ---------------------------------------------------------------------------
@@ -95,8 +98,25 @@ fn registry() -> &'static CommandRegistry {
 }
 
 /// Map symbol name -> symbol, for order-independent lookups.
-fn by_name(syms: &[WorkspaceSymbol]) -> HashMap<&str, &WorkspaceSymbol> {
+fn by_name(syms: &[IndexedWorkspaceSymbol]) -> HashMap<&str, &IndexedWorkspaceSymbol> {
     syms.iter().map(|s| (s.name.as_str(), s)).collect()
+}
+
+/// `source` indexed as the workspace's only document, queried for `query`.
+fn symbols(source: &str, query: &str) -> Vec<IndexedWorkspaceSymbol> {
+    let analysis = analyse(source);
+    let mut index = WorkspaceIndex::new();
+    index.add_document("file:///doc.tcl", &analysis);
+    index.symbols_matching(query, MAX_WORKSPACE_SYMBOL_RESULTS)
+}
+
+/// The zero-based line a symbol's name token starts on.  The index stores a
+/// byte span; the server resolves it against the target document's source, and
+/// so does this.
+fn start_line(source: &str, sym: &IndexedWorkspaceSymbol) -> u32 {
+    tcl_lexer::LineIndex::new(source)
+        .position_at_utf16(sym.name_span.start(), source)
+        .line
 }
 
 /// Empty disabled-set / suppression-map for the `style_diagnostics`
@@ -136,8 +156,7 @@ fn workspace_symbols_empty_query_returns_every_declaration() {
     // report `alpha` and `info procs ::ns::*` report `::ns::beta`;
     // `oo::class create Widget {method draw …}` makes
     // `info class methods Widget` report `draw`. An empty query matches all.
-    let an = analyse(SYMBOL_DOC);
-    let syms = workspace_symbols(SYMBOL_DOC, "", &an);
+    let syms = symbols(SYMBOL_DOC, "");
     let map = by_name(&syms);
     // Structural: the full declared set surfaces.
     assert!(map.contains_key("alpha"), "{syms:?}");
@@ -149,8 +168,7 @@ fn workspace_symbols_empty_query_returns_every_declaration() {
 
 #[test]
 fn workspace_symbols_kinds_and_containers_are_structural() {
-    let an = analyse(SYMBOL_DOC);
-    let syms = workspace_symbols(SYMBOL_DOC, "", &an);
+    let syms = symbols(SYMBOL_DOC, "");
     let map = by_name(&syms);
     // Kinds (editor-presentation, asserted structurally).
     assert_eq!(map["alpha"].kind, WorkspaceSymbolKind::Function);
@@ -166,25 +184,25 @@ fn workspace_symbols_kinds_and_containers_are_structural() {
         map["constructor"].container_name.as_deref(),
         Some("::Widget")
     );
-    // The definition range points at the declaring line (structural).
-    assert_eq!(map["alpha"].range.start_line, 0);
-    assert_eq!(map["draw"].range.start_line, 5);
+    // Every symbol names the document it was indexed from (structural).
+    assert!(syms.iter().all(|s| s.uri == "file:///doc.tcl"), "{syms:?}");
+    // The definition span points at the declaring line (structural).
+    assert_eq!(start_line(SYMBOL_DOC, map["alpha"]), 0);
+    assert_eq!(start_line(SYMBOL_DOC, map["draw"]), 5);
 }
 
 #[test]
 fn workspace_symbols_query_is_case_insensitive_substring() {
-    let an = analyse(SYMBOL_DOC);
     // Mixed-case substring of `alpha` matches exactly that proc.
-    let syms = workspace_symbols(SYMBOL_DOC, "LPH", &an);
+    let syms = symbols(SYMBOL_DOC, "LPH");
     let names: Vec<&str> = syms.iter().map(|s| s.name.as_str()).collect();
     assert_eq!(names, vec!["alpha"], "{syms:?}");
 }
 
 #[test]
 fn workspace_symbols_query_matches_class_member_by_substring() {
-    let an = analyse(SYMBOL_DOC);
     // `draw` is reachable by a substring of its own name.
-    let syms = workspace_symbols(SYMBOL_DOC, "dra", &an);
+    let syms = symbols(SYMBOL_DOC, "dra");
     let names: Vec<&str> = syms.iter().map(|s| s.name.as_str()).collect();
     assert!(names.contains(&"draw"), "{syms:?}");
     // The unrelated top-level proc `alpha` must not match `dra`.
@@ -193,18 +211,16 @@ fn workspace_symbols_query_matches_class_member_by_substring() {
 
 #[test]
 fn workspace_symbols_no_match_returns_empty() {
-    let an = analyse(SYMBOL_DOC);
     assert!(
-        workspace_symbols(SYMBOL_DOC, "zzz_nonexistent", &an).is_empty(),
+        symbols(SYMBOL_DOC, "zzz_nonexistent").is_empty(),
         "a query matching nothing yields no symbols",
     );
 }
 
 #[test]
 fn workspace_symbols_empty_document_is_empty_and_does_not_panic() {
-    let an = analyse("");
-    assert!(workspace_symbols("", "", &an).is_empty());
-    assert!(workspace_symbols("", "anything", &an).is_empty());
+    assert!(symbols("", "").is_empty());
+    assert!(symbols("", "anything").is_empty());
 }
 
 #[test]
@@ -213,11 +229,29 @@ fn workspace_symbols_classmethod_surfaces_as_method() {
     // method) is a real member — `info class methods C -all` lists it. The
     // provider surfaces a classmethod with kind Method (structural).
     let src = "oo::class create C {\n    classmethod make {} {}\n}\n";
-    let an = analyse(src);
-    let syms = workspace_symbols(src, "make", &an);
+    let syms = symbols(src, "make");
     assert_eq!(syms.len(), 1, "{syms:?}");
     assert_eq!(syms[0].name, "make");
     assert_eq!(syms[0].kind, WorkspaceSymbolKind::Method);
+}
+
+#[test]
+fn workspace_symbols_span_every_indexed_document() {
+    // Issue #1156: the answer is the whole workspace, not the caller's
+    // document — two indexed documents both contribute, each naming its own
+    // URI.
+    let a = analyse("proc from_a {} {}\n");
+    let b = analyse("proc from_b {} {}\n");
+    let mut index = WorkspaceIndex::new();
+    index.add_document("file:///a.tcl", &a);
+    index.add_document("file:///b.tcl", &b);
+    let syms = index.symbols_matching("from_", MAX_WORKSPACE_SYMBOL_RESULTS);
+    let by_uri: HashMap<&str, &str> = syms
+        .iter()
+        .map(|s| (s.uri.as_str(), s.name.as_str()))
+        .collect();
+    assert_eq!(by_uri.get("file:///a.tcl"), Some(&"from_a"), "{syms:?}");
+    assert_eq!(by_uri.get("file:///b.tcl"), Some(&"from_b"), "{syms:?}");
 }
 
 // ===========================================================================

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -32,6 +32,52 @@
 //! carried as a durable field on the database and read via [`TclDb::registry`]
 //! rather than modelled as a salsa input — reading an immutable value inside a
 //! tracked query is sound and avoids requiring `CommandRegistry: PartialEq`.
+//!
+//! # Deep-memo eviction (`lru = N`)
+//!
+//! Salsa has no input-deletion API and re-setting an input frees nothing:
+//! an invalidated memo keeps its old value until the query re-executes and
+//! *replaces* it, and setting identical text backdates and changes nothing at
+//! all.  So a session that opens 150 files and closes them again retains
+//! every deep memo those files accrued while open — measured at ~930 MB of
+//! unreclaimed RSS across exactly that cycle (issue #1144 follow-up, PR #1179
+//! review).  Dropping the closed files' `SourceFile` handles does not help;
+//! the memos are keyed on the salsa ids, which stay in the tables.
+//!
+//! `#[salsa::tracked(lru = N)]` is the one mechanism that releases a memo's
+//! payload: at each revision boundary the least-recently-used ids have
+//! `memo.value` cleared while their dependency information is kept, so an
+//! evicted query is simply recomputed on demand.  It is sound by construction
+//! — salsa refuses to evict anything that is not `Derived` — and this crate
+//! has no untracked reads (`registry()` is a process-wide immutable cache), so
+//! every deep query qualifies.
+//!
+//! Two caps, sized by what the key counts:
+//!
+//! * **512** on the per-*item* queries (`item_body_analysis`,
+//!   `function_lattice`, `lower_proc_body`, `taint_cascade`,
+//!   `proc_summary_cascade`, `function_checks`, `proc_taint_solve`,
+//!   `function_optimisations`, `compilation_unit`).  Their keys are interned
+//!   per procedure body, so the live set is roughly *procedures per file ×
+//!   open files*; 512 covers a realistic working set (say twenty open
+//!   documents of twenty-five procedures) without holding a browsed-and-closed
+//!   file's bodies for the session.
+//! * **64** on the per-*file* queries (`file_analysis_incremental`,
+//!   `compiler_check_diagnostics`, `document_compilation_unit`) — one entry
+//!   per open document, and no reader walks them project-wide (the whole-file
+//!   aggregates read the light `file_token_facts` / `item_sigs` tiers
+//!   instead), so the cap cannot thrash on a large workspace.
+//!
+//! The light signature/structure tiers (`file_decls`, `item_sigs`,
+//! `file_token_facts`, the `project_*` aggregates) are deliberately **not**
+//! capped: they are small, they are what an unopened workspace file is meant
+//! to be resolvable from, and evicting them would make the cross-file
+//! resolution every open document depends on recompute from scratch.
+//!
+//! This composes correctly only because closed files no longer create deep
+//! memos at all (#1144: the closed-file republish takes the uncached
+//! pipeline).  While they did, every closed-file sweep would `record_use` on
+//! hundreds of closed files and evict the *open* documents' units instead.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
@@ -985,7 +1031,8 @@ pub struct ItemBodyKey<'db> {
 /// Memoised offset-0 isolated analysis of one `proc` body.  A body-only edit
 /// changes only that body's [`ItemBodyKey`], so salsa reuses every other body's
 /// result; an edit that merely *shifts* a body leaves its key unchanged.
-#[salsa::tracked]
+// LRU-capped: per-item key, see the crate docs' "Deep-memo eviction".
+#[salsa::tracked(lru = 512)]
 pub fn item_body_analysis<'db>(db: &'db dyn TclDb, key: ItemBodyKey<'db>) -> Arc<BodyFragment> {
     // The isolated analysis works at offset 0 and ignores `body_tok` / scope
     // path (the aggregator supplies the real position when grafting), so a
@@ -1095,7 +1142,8 @@ pub struct FnLatticeKey<'db> {
 /// new key).  The interprocedural taint re-run still happens at aggregation time
 /// (`with_interprocedural`).  Uses `db.registry` — byte-identical to the
 /// registry both diagnostics consumers build (`build_default` + `load_dialect`).
-#[salsa::tracked]
+// LRU-capped: per-item key, see the crate docs' "Deep-memo eviction".
+#[salsa::tracked(lru = 512)]
 pub fn function_lattice<'db>(db: &'db dyn TclDb, key: FnLatticeKey<'db>) -> Arc<FunctionUnit> {
     let context = key.context(db);
     let upvar: HashMap<String, UpvarInfo> = context.upvar_ctx(db).iter().cloned().collect();
@@ -1164,7 +1212,8 @@ pub struct ProcBodyKey<'db> {
 /// with an empty const-map frame, lowering at offset 0).  Byte-identical to the
 /// body the whole-file lowering produces for that procedure, normalised to
 /// offset 0 — for the context-free files the caller gates on.
-#[salsa::tracked]
+// LRU-capped: per-item key, see the crate docs' "Deep-memo eviction".
+#[salsa::tracked(lru = 512)]
 pub fn lower_proc_body<'db>(db: &'db dyn TclDb, key: ProcBodyKey<'db>) -> Arc<Script> {
     let registry = db.registry(key.dialect(db));
     let config = tcl_lexer::LexerConfig {
@@ -1436,7 +1485,8 @@ fn taint_summary_key<'db>(
 /// installed directly into the rebased unit (no rebase needed).  Byte-identical
 /// to [`CompilationUnit::with_interprocedural`]'s per-procedure re-run, guarded
 /// by the `compiler_check` corpus differential + the taint-cascade edit tests.
-#[salsa::tracked]
+// LRU-capped: per-item key, see the crate docs' "Deep-memo eviction".
+#[salsa::tracked(lru = 512)]
 pub fn taint_cascade<'db>(
     db: &'db dyn TclDb,
     lattice_key: FnLatticeKey<'db>,
@@ -1603,7 +1653,8 @@ fn summary_deps_key<'db>(
 /// parameter/return taint, not positions), so the offset-0 result is the same
 /// the whole-module build computes.  A body edit re-keys only the edited
 /// procedure and the callers that reach it; everything else is a cache hit.
-#[salsa::tracked]
+// LRU-capped: per-item key, see the crate docs' "Deep-memo eviction".
+#[salsa::tracked(lru = 512)]
 pub fn proc_summary_cascade<'db>(
     db: &'db dyn TclDb,
     lattice_key: FnLatticeKey<'db>,
@@ -1668,7 +1719,8 @@ pub fn proc_summary_cascade<'db>(
 /// offset-0 [`function_lattice`] unit, *before* `rebase_function_unit`); the
 /// caller adds the procedure's `body_offset`.  A body edit re-runs only the
 /// edited procedure's checks; every other proc is a cache hit.
-#[salsa::tracked]
+// LRU-capped: per-item key, see the crate docs' "Deep-memo eviction".
+#[salsa::tracked(lru = 512)]
 pub fn function_checks<'db>(db: &'db dyn TclDb, key: FnLatticeKey<'db>) -> Arc<Vec<CompilerCheck>> {
     let fu = function_lattice(db, key);
     let dialect = key.dialect(db);
@@ -1747,7 +1799,8 @@ fn rebase_check(mut d: CompilerCheck, body_offset: u32) -> CompilerCheck {
 
 /// Byte-identical to a bare `run_all_checks`, guarded by the `compiler_check`
 /// corpus differential + the debug fixpoint guard.
-#[salsa::tracked]
+// LRU-capped: per-item key, see the crate docs' "Deep-memo eviction".
+#[salsa::tracked(lru = 512)]
 pub fn proc_taint_solve<'db>(
     db: &'db dyn TclDb,
     file: SourceFile,
@@ -2072,7 +2125,8 @@ fn opt_deps_key<'db>(
 /// `body_offset` and runs the whole-module [`finalise_optimisations`] over the
 /// assembled set.  A body edit re-runs only the edited proc; an unrelated proc's
 /// edit is a cache hit unless this proc reads its summary (a resolved direct call).
-#[salsa::tracked]
+// LRU-capped: per-item key, see the crate docs' "Deep-memo eviction".
+#[salsa::tracked(lru = 512)]
 pub fn function_optimisations<'db>(
     db: &'db dyn TclDb,
     key: FnLatticeKey<'db>,
@@ -2390,7 +2444,8 @@ fn lexer_cfg_key(db: &dyn TclDb, config: tcl_lexer::LexerConfig) -> LexerCfgKey<
 /// / `f5-irules`); for those two dialects the configs differ, so each consumer
 /// builds its own (status quo).  Byte-identical to a direct
 /// `memoised_compilation_unit` call.
-#[salsa::tracked]
+// LRU-capped: per-item key, see the crate docs' "Deep-memo eviction".
+#[salsa::tracked(lru = 512)]
 pub fn compilation_unit<'db>(
     db: &'db dyn TclDb,
     file: SourceFile,
@@ -2421,7 +2476,8 @@ pub fn compilation_unit<'db>(
 /// (and rebased) instead of rebuilt.  Byte-identical to [`file_analysis`] (and
 /// `analyse`) — proven by the `per_item_corpus` gate over the shared
 /// `analyse_per_item_with` orchestration.
-#[salsa::tracked]
+// LRU-capped: per-file key, see the crate docs' "Deep-memo eviction".
+#[salsa::tracked(lru = 64)]
 pub fn file_analysis_incremental(
     db: &dyn TclDb,
     file: SourceFile,
@@ -2514,7 +2570,8 @@ fn compiler_diagnostics_from_unit(
 /// the analyser tail's default config, so the two intern different bodies and
 /// never cross-pollute.  Byte-identical to the former direct
 /// `lift_compiler_diagnostics` build.
-#[salsa::tracked]
+// LRU-capped: per-file key, see the crate docs' "Deep-memo eviction".
+#[salsa::tracked(lru = 64)]
 pub fn compiler_check_diagnostics(
     db: &dyn TclDb,
     file: SourceFile,
@@ -2600,7 +2657,8 @@ pub fn document_symbols(
 /// file's dialect, so callers that only have `(db, file)` (semantic tokens,
 /// server-side accessors) share the same memoised build as the diagnostics
 /// path.
-#[salsa::tracked]
+// LRU-capped: per-file key, see the crate docs' "Deep-memo eviction".
+#[salsa::tracked(lru = 64)]
 pub fn document_compilation_unit(db: &dyn TclDb, file: SourceFile) -> Arc<CompilationUnit> {
     let cfg_key = lexer_cfg_key(db, tcl_lexer::LexerConfig::for_dialect(file.dialect(db)));
     compilation_unit(db, file, cfg_key)

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -356,8 +356,31 @@ fn component_root(parent: &mut [usize], mut i: usize) -> usize {
     i
 }
 
-/// The procedures an *unenumerable* dispatch in `file` may reach — every proc
-/// declared by a file in the same `source`-connected component.
+/// The `source`-connected components of a project, each carrying the merged
+/// declarations of its members — the per-project half of
+/// [`file_dispatch_reach`].
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct DispatchComponents {
+    /// Component number of each project file, positionally aligned with
+    /// [`Project::files`].
+    component_of: Vec<usize>,
+    /// Per component, every procedure its member files declare.  Shared by
+    /// `Arc` with each member's [`file_dispatch_reach`], so a component is
+    /// merged once and stored once however many files belong to it.
+    procs: Vec<Arc<BTreeSet<String>>>,
+}
+
+impl DispatchComponents {
+    /// The procedures the file at `index` in [`Project::files`] may reach
+    /// through an unenumerable dispatch; `None` when `index` is past the file
+    /// set this was computed for.
+    #[must_use]
+    pub fn reach(&self, index: usize) -> Option<&Arc<BTreeSet<String>>> {
+        self.procs.get(*self.component_of.get(index)?)
+    }
+}
+
+/// Decompose the project into `source`-connected components once per revision.
 ///
 /// `set cmd [gets stdin]; $cmd dev` names a command this analysis cannot
 /// determine, so it is a caller of *something*. Which something is bounded by
@@ -375,15 +398,19 @@ fn component_root(parent: &mut [usize], mut i: usize) -> usize {
 /// library's unreadable dispatch silently fails to retract its sourcing file's
 /// seeds — the hole this replaces.
 ///
+/// **Why this is a project query rather than per-file work** (issue #1148): the
+/// union-find is over the whole `source` graph and the merge visits every
+/// component member's [`file_decls`], so computing it inside
+/// [`file_dispatch_reach`] cost `O(N)` *per file* — `O(N²)` `String` clones and
+/// path-map inserts across a project, which a signature edit re-paid in full
+/// because it invalidates every file's reach at once. Hoisted here it is paid
+/// once, and each file's reach becomes an `Arc` clone.
+///
 /// Depends only on signature-level facts ([`file_link_targets`],
 /// [`file_decls`]), so it sits behind the same firewall as the rest of the
 /// cross-file layer.
 #[salsa::tracked]
-pub fn file_dispatch_reach(
-    db: &dyn TclDb,
-    file: SourceFile,
-    project: Project,
-) -> Arc<BTreeSet<String>> {
+pub fn project_dispatch_components(db: &dyn TclDb, project: Project) -> Arc<DispatchComponents> {
     let files = project.files(db);
     // Index files by path so `source` targets can be matched to project files.
     let mut by_path: HashMap<&str, usize> = HashMap::new();
@@ -408,17 +435,49 @@ pub fn file_dispatch_reach(
             }
         }
     }
-    let Some(me) = files.iter().position(|f| *f == file) else {
+    // Number the roots densely, then merge each component's declarations once.
+    let mut number: HashMap<usize, usize> = HashMap::new();
+    let mut component_of: Vec<usize> = Vec::with_capacity(files.len());
+    for i in 0..files.len() {
+        let root = component_root(&mut parent, i);
+        let next = number.len();
+        component_of.push(*number.entry(root).or_insert(next));
+    }
+    let mut merged: Vec<BTreeSet<String>> = vec![BTreeSet::new(); number.len()];
+    for (i, f) in files.iter().enumerate() {
+        merged[component_of[i]].extend(file_decls(db, *f).procs.iter().cloned());
+    }
+    Arc::new(DispatchComponents {
+        component_of,
+        procs: merged.into_iter().map(Arc::new).collect(),
+    })
+}
+
+/// The procedures an *unenumerable* dispatch in `file` may reach — every proc
+/// declared by a file in the same `source`-connected component.
+///
+/// An index into [`project_dispatch_components`], which does the work; see
+/// there for what the component bound means and why it is not computed here.
+/// A file the project does not contain reaches only its own declarations.
+///
+/// Kept as its own query so the result still early-cutoffs per file: a decl
+/// change in one component recomputes the project decomposition, but every
+/// file outside that component gets back an equal set and backdates, leaving
+/// [`file_call_site_evidence`] untouched.
+#[salsa::tracked]
+pub fn file_dispatch_reach(
+    db: &dyn TclDb,
+    file: SourceFile,
+    project: Project,
+) -> Arc<BTreeSet<String>> {
+    let Some(me) = project.files(db).iter().position(|f| *f == file) else {
         return Arc::new(file_decls(db, file).procs.clone());
     };
-    let mine = component_root(&mut parent, me);
-    let mut reach: BTreeSet<String> = BTreeSet::new();
-    for (i, f) in files.iter().enumerate() {
-        if component_root(&mut parent, i) == mine {
-            reach.extend(file_decls(db, *f).procs.iter().cloned());
-        }
+    let components = project_dispatch_components(db, project);
+    match components.reach(me) {
+        Some(reach) => Arc::clone(reach),
+        None => Arc::new(file_decls(db, file).procs.clone()),
     }
-    Arc::new(reach)
 }
 
 /// Every call site **this** file contributes, resolved against the whole
@@ -3114,6 +3173,132 @@ mod tests {
                 .to("source lib.tcl\nset unrelated 1\nhelper dev\n".to_owned());
             let after = file_external_call_sites(&db, lib, project);
             assert_eq!(*before, *after, "an unrelated edit must not move evidence");
+        }
+
+        /// The component bound itself: both ends of a `source` edge see the
+        /// same merged set — and see the *same* `Arc`, so a component is
+        /// stored once however many files belong to it.  An unlinked file
+        /// shares no interpreter, so it reaches only its own declarations.
+        #[test]
+        fn dispatch_reach_is_the_shared_source_component_merge() {
+            let db = TclDatabase::default();
+            let a = SourceFile::new(
+                &db,
+                "source b.tcl\nproc a {} {}\n".to_owned(),
+                "tcl8.6".to_owned(),
+                Some("/w/a.tcl".to_owned()),
+            );
+            let b = SourceFile::new(
+                &db,
+                "proc b {} {}\n".to_owned(),
+                "tcl8.6".to_owned(),
+                Some("/w/b.tcl".to_owned()),
+            );
+            let unlinked = SourceFile::new(
+                &db,
+                "proc c {} {}\n".to_owned(),
+                "tcl8.6".to_owned(),
+                Some("/w/c.tcl".to_owned()),
+            );
+            let project = Project::new(&db, vec![a, b, unlinked]);
+            let reach_a = file_dispatch_reach(&db, a, project);
+            let reach_b = file_dispatch_reach(&db, b, project);
+            let reach_c = file_dispatch_reach(&db, unlinked, project);
+            assert_eq!(
+                reach_a.iter().map(String::as_str).collect::<Vec<_>>(),
+                vec!["::a", "::b"],
+                "the sourcing file reaches its own and the sourced file's procs"
+            );
+            assert!(
+                Arc::ptr_eq(&reach_a, &reach_b),
+                "component members share one merged set: {reach_b:?}"
+            );
+            assert_eq!(
+                reach_c.iter().map(String::as_str).collect::<Vec<_>>(),
+                vec!["::c"],
+                "an unlinked file shares no interpreter"
+            );
+        }
+
+        /// Issue #1148: the `source`-graph decomposition is *project* work, not
+        /// per-file work.  Demanding every file's reach must execute
+        /// [`project_dispatch_components`] exactly **once** — the property that
+        /// turns the old union-find-and-merge-per-file into `O(N)` — and a decl
+        /// change must recompute it once for the project rather than once per
+        /// file.  A body edit backdates its inputs and recomputes nothing.
+        #[test]
+        fn dispatch_components_are_computed_once_per_project_revision() {
+            use salsa::Setter as _;
+            const FILES: usize = 6;
+            let log: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+            let mut db = {
+                let sink = Arc::clone(&log);
+                TclDatabase::with_event_logger(move |key| sink.lock().unwrap().push(key))
+            };
+            // A single `source` chain, so every file lands in one component —
+            // the shape whose merge the old query re-paid per file.
+            let body = |i: usize| {
+                if i + 1 < FILES {
+                    format!("source f{}.tcl\nproc p{i} {{}} {{ set r 1 }}\n", i + 1)
+                } else {
+                    format!("proc p{i} {{}} {{ set r 1 }}\n")
+                }
+            };
+            let files: Vec<SourceFile> = (0..FILES)
+                .map(|i| {
+                    SourceFile::new(
+                        &db,
+                        body(i),
+                        "tcl8.6".to_owned(),
+                        Some(format!("/w/f{i}.tcl")),
+                    )
+                })
+                .collect();
+            let project = Project::new(&db, files.clone());
+            let drain = || std::mem::take(&mut *log.lock().unwrap());
+            let decompositions = |events: &[String]| {
+                events
+                    .iter()
+                    .filter(|key| key.contains("project_dispatch_components"))
+                    .count()
+            };
+
+            for &file in &files {
+                let _ = file_dispatch_reach(&db, file, project);
+            }
+            assert_eq!(
+                decompositions(&drain()),
+                1,
+                "cold: one decomposition serves every file's reach"
+            );
+
+            files[3]
+                .set_text(&mut db)
+                .to("source f4.tcl\nproc p3 {} { set r 999 }\n".to_owned());
+            for &file in &files {
+                let _ = file_dispatch_reach(&db, file, project);
+            }
+            assert_eq!(
+                decompositions(&drain()),
+                0,
+                "a body edit leaves file_decls / file_link_targets equal"
+            );
+
+            files[3]
+                .set_text(&mut db)
+                .to("source f4.tcl\nproc p3 {} { set r 999 }\nproc extra {} {}\n".to_owned());
+            for &file in &files {
+                let _ = file_dispatch_reach(&db, file, project);
+            }
+            assert_eq!(
+                decompositions(&drain()),
+                1,
+                "a decl change recomputes the decomposition once, not once per file"
+            );
+            assert!(
+                file_dispatch_reach(&db, files[0], project).contains("::extra"),
+                "the new proc joins every component member's reach"
+            );
         }
     }
 

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -2645,27 +2645,70 @@ pub fn semantic_tokens(db: &dyn TclDb, file: SourceFile, config: AnalyserConfig)
     )
 }
 
+/// The cross-file facts the project-level token aggregates read from **one**
+/// file: its class definitions and its inferred variable-name argument roles.
+///
+/// Deliberately small and `PartialEq`: it is the per-file firewall in front of
+/// [`project_class_index`] / [`project_proc_var_index`], so an edit that leaves
+/// a file's classes and parameter roles alone — which is nearly every keystroke
+/// — backdates here and the project aggregates do not re-execute at all.
+#[derive(Clone, Default, PartialEq)]
+pub struct FileTokenFacts {
+    /// Classes declared in this file, keyed by qualified name.
+    pub classes: HashMap<String, ClassDef>,
+    /// The file's user-proc parameter roles.
+    pub proc_roles: VarNameArgRoles,
+}
+
+/// The light (structure-only) per-file tier feeding [`project_class_index`] and
+/// [`project_proc_var_index`] (issue #1163).
+///
+/// These aggregates read *every* file in the project, so whatever per-file
+/// query they call decides what an interactive `semanticTokens` request costs
+/// on a large workspace.  Reading the deep tier
+/// ([`file_analysis_incremental`]) meant one whole-workspace *deep* analysis —
+/// CFG/SSA units, per-body lattices, diagnostic emitters — behind a token
+/// request for a single file: measured at ~19 s of CPU over an 883-file
+/// tcllib checkout, which no request survives.  Every attempt was cancelled by
+/// the next `set_text`, so it never memoised and every subsequent request paid
+/// it again, while the in-flight read blocked the writer that cancelled it
+/// (`didOpen`'s `set_text` measured at 270–660 ms) — the open-to-tokens spikes
+/// #1163 reports.
+///
+/// The structural facts these aggregates want do not need the deep tier: an
+/// unopened workspace file only ever needs the lightweight state the scan
+/// leaves it at.  `structure_only` builds the identical declaration structure
+/// while skipping diagnostic emission and cross-feature recording — the bulk of
+/// the cost — for the same 883 files in ~2.9 s, and the result is a projection
+/// small enough to backdate.
+///
+/// Config-independent by construction: `structure_only` emits no diagnostics,
+/// so the disabled-diagnostic set / non-ASCII mode / extra commands cannot
+/// reach the class and role facts.  That is what lets both aggregates drop
+/// their `AnalyserConfig` key — one index per project rather than one per
+/// distinct per-folder config.
+#[salsa::tracked]
+pub fn file_token_facts(db: &dyn TclDb, file: SourceFile) -> Arc<FileTokenFacts> {
+    let mut analyser = Analyser::new()
+        .structure_only()
+        .with_file_path(file.path(db).clone());
+    let result = analyser.analyse(file.text(db), file.dialect(db));
+    Arc::new(FileTokenFacts {
+        proc_roles: VarNameArgRoles::from_procs(result.all_procs.values()),
+        classes: result.all_classes,
+    })
+}
+
 /// The project's workspace-merged class hierarchy: every file's `ClassDef`s
 /// unioned into one cross-file MRO index, so a `$obj method` dispatch resolves
 /// against a class defined in *another* file.
 ///
-/// Aggregates `file_analysis_incremental(f, config).all_classes` across
-/// `project`.  A body-only edit rebuilds this (cheap re-aggregation) but yields
-/// an equal [`ClassHierarchy`], so salsa backdates and dependent token queries
-/// do not recompute.  On a class-signature change the merged index changes and
-/// the affected tokens recompute — the correct cross-file invalidation.
-///
-/// Uses the incremental, per-item-memoised [`file_analysis_incremental`] (not
-/// the coarse [`file_analysis`]) for each project file, the same template
-/// [`project_diagnostics`] establishes: a file whose diagnostics the worker has
-/// already analysed for this revision is a cache hit here too, rather than a
-/// second independent whole-file walk (issue #829).
+/// Aggregates [`file_token_facts`]`(f).classes` across `project`.  A body-only
+/// edit backdates at the per-file firewall, so this does not even re-aggregate.
+/// On a class-signature change the merged index changes and the affected tokens
+/// recompute — the correct cross-file invalidation.
 #[salsa::tracked]
-pub fn project_class_index(
-    db: &dyn TclDb,
-    project: Project,
-    config: AnalyserConfig,
-) -> Arc<ClassHierarchy> {
+pub fn project_class_index(db: &dyn TclDb, project: Project) -> Arc<ClassHierarchy> {
     // `project.files(db)` is an unordered `Vec` with no stable identity, so a
     // "first definition wins" merge would make the winner for a duplicate
     // qualified class name depend on file-enumeration order — non-deterministic
@@ -2677,8 +2720,7 @@ pub fn project_class_index(
     let mut merged: HashMap<String, ClassDef> = HashMap::new();
     let mut ambiguous: HashSet<String> = HashSet::new();
     for &file in project.files(db) {
-        let analysis = file_analysis_incremental(db, file, config);
-        for (name, class) in &analysis.all_classes {
+        for (name, class) in &file_token_facts(db, file).classes {
             if ambiguous.contains(name) {
                 continue;
             }
@@ -2704,26 +2746,20 @@ pub fn project_class_index(
 /// target even when `myproc` is defined in another file (issue #813 follow-up).
 ///
 /// A proc name defined with *conflicting* roles across files is dropped as
-/// ambiguous by [`VarNameArgRoles::from_procs`], so the merged index is
+/// ambiguous by [`VarNameArgRoles::merge`], so the merged index is
 /// order-independent — matching the abstention posture of
 /// [`project_class_index`].
 ///
-/// Uses [`file_analysis_incremental`] per file, matching [`project_class_index`]
-/// and [`project_diagnostics`] — a cache hit against the diagnostics worker's
-/// already-computed per-item analysis rather than a second whole-file walk.
+/// Reads the same light [`file_token_facts`] firewall as [`project_class_index`].
 #[salsa::tracked]
-pub fn project_proc_var_index(
-    db: &dyn TclDb,
-    project: Project,
-    config: AnalyserConfig,
-) -> Arc<VarNameArgRoles> {
-    let analyses: Vec<Arc<AnalysisResult>> = project
+pub fn project_proc_var_index(db: &dyn TclDb, project: Project) -> Arc<VarNameArgRoles> {
+    let per_file: Vec<Arc<FileTokenFacts>> = project
         .files(db)
         .iter()
-        .map(|&file| file_analysis_incremental(db, file, config))
+        .map(|&file| file_token_facts(db, file))
         .collect();
-    Arc::new(VarNameArgRoles::from_procs(
-        analyses.iter().flat_map(|a| a.all_procs.values()),
+    Arc::new(VarNameArgRoles::merge(
+        per_file.iter().map(|f| &f.proc_roles),
     ))
 }
 
@@ -2731,17 +2767,21 @@ pub fn project_proc_var_index(
 /// a `$obj method …` dispatch on a class defined in another project file
 /// resolves too.  The server calls this when a [`Project`] is available; the
 /// bare [`semantic_tokens`] (local file only) is the fallback.
+///
+/// Takes no [`AnalyserConfig`]: every input it reads — the document's
+/// compilation unit and the two project indexes — is config-independent, so
+/// keying on one would only fragment the memo across per-folder configs that
+/// cannot change the answer.
 #[salsa::tracked]
 pub fn semantic_tokens_project(
     db: &dyn TclDb,
     file: SourceFile,
-    config: AnalyserConfig,
     project: Project,
 ) -> SemanticTokens {
     let registry = db.registry(file.dialect(db));
     let cu = document_compilation_unit(db, file);
-    let classes = project_class_index(db, project, config);
-    let proc_roles = project_proc_var_index(db, project, config);
+    let classes = project_class_index(db, project);
+    let proc_roles = project_proc_var_index(db, project);
     tcl_lsp_core::semantic_tokens::full_with_cu_and_classes_and_roles(
         file.text(db),
         file.dialect(db),
@@ -3434,14 +3474,8 @@ mod tests {
         }
     }
 
-    /// [`project_class_index`] and [`project_proc_var_index`] must likewise
-    /// use [`file_analysis_incremental`] per project file (not the coarse
-    /// [`file_analysis`]), matching [`project_diagnostics`]'s established
-    /// template — otherwise `semantic_tokens_project` pays for a fresh
-    /// whole-file walk of every project file on top of what diagnostics
-    /// already computed for them.
-    #[test]
-    fn project_indexes_use_incremental_analysis_not_coarse() {
+    /// Build a database whose executed-query keys land in the returned log.
+    fn logging_db() -> (TclDatabase, Arc<Mutex<Vec<String>>>) {
         let log: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
         let sink = {
             let l = Arc::clone(&log);
@@ -3454,14 +3488,20 @@ mod tests {
         let db = TclDatabase {
             storage: salsa::Storage::new(Some(Box::new(sink))),
         };
-        let cfg = AnalyserConfig::new(
-            &db,
-            Vec::new(),
-            NonAsciiMode::Default,
-            Vec::new(),
-            None,
-            None,
-        );
+        (db, log)
+    }
+
+    /// Issue #1163: [`project_class_index`] / [`project_proc_var_index`] read
+    /// *every* file in the project, so the tier they read decides what an
+    /// interactive `semanticTokens` request costs on a large workspace. They
+    /// must stay on the light [`file_token_facts`] tier and never reach the deep
+    /// one — reading `file_analysis_incremental` there meant a whole-workspace
+    /// deep analysis (CFG/SSA units, per-body lattices, diagnostic emitters)
+    /// behind a token request for one file, which on an 883-file checkout never
+    /// completed before the next `set_text` cancelled it.
+    #[test]
+    fn project_indexes_never_touch_the_deep_tier() {
+        let (db, log) = logging_db();
         let lib = SourceFile::new(
             &db,
             "oo::configurable create ::Pin { property node }\n".to_owned(),
@@ -3476,51 +3516,28 @@ mod tests {
         );
         let project = Project::new(&db, vec![lib, main]);
 
-        let _ = project_class_index(&db, project, cfg);
-        let _ = project_proc_var_index(&db, project, cfg);
+        let _ = project_class_index(&db, project);
+        let _ = project_proc_var_index(&db, project);
         let log_snapshot = log.lock().unwrap().clone();
         assert!(
-            log_snapshot
-                .iter()
-                .any(|s| s.contains("file_analysis_incremental")),
-            "project indexes must read the incremental analysis: {log_snapshot:?}"
+            log_snapshot.iter().any(|s| s.contains("file_token_facts")),
+            "project indexes must read the light per-file tier: {log_snapshot:?}"
         );
         assert!(
-            log_snapshot.iter().all(|s| !s.contains("file_analysis(")),
-            "project indexes must never invoke the coarse file_analysis query: \
-             {log_snapshot:?}"
+            log_snapshot.iter().all(|s| !s.contains("file_analysis")),
+            "project indexes must never analyse a project file at the deep tier \
+             (#1163): {log_snapshot:?}"
         );
     }
 
+    /// The per-file [`file_token_facts`] firewall: a body edit that changes no
+    /// class and no parameter role backdates, so neither project index
+    /// re-executes — the property that keeps the cross-file token aggregates off
+    /// the per-keystroke path once they are warm.
     #[test]
-    fn pre_warming_makes_project_index_loop_all_cache_hits() {
-        // #844 Gap 3: the server-layer parallel warm pre-populates
-        // `file_analysis_incremental` for every project file so the enriched
-        // `project_class_index` / `project_proc_var_index` loops are pure cache
-        // hits — no per-file re-analysis. That is exactly what lets the warm
-        // collapse a cold workspace's serial walk into a parallel one: the
-        // tracked query does only the cheap cross-file aggregation, not N whole
-        // -file analyses. This pins the salsa property the warm relies on.
-        let log: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
-        let sink = {
-            let l = Arc::clone(&log);
-            move |ev: salsa::Event| {
-                if let salsa::EventKind::WillExecute { database_key } = ev.kind {
-                    l.lock().unwrap().push(format!("{database_key:?}"));
-                }
-            }
-        };
-        let db = TclDatabase {
-            storage: salsa::Storage::new(Some(Box::new(sink))),
-        };
-        let cfg = AnalyserConfig::new(
-            &db,
-            Vec::new(),
-            NonAsciiMode::Default,
-            Vec::new(),
-            None,
-            None,
-        );
+    fn project_indexes_backdate_on_a_role_neutral_body_edit() {
+        use salsa::Setter as _;
+        let (mut db, log) = logging_db();
         let lib = SourceFile::new(
             &db,
             "oo::configurable create ::Pin { property node }\n".to_owned(),
@@ -3534,26 +3551,59 @@ mod tests {
             None,
         );
         let project = Project::new(&db, vec![lib, main]);
+        let _ = project_class_index(&db, project);
+        let _ = project_proc_var_index(&db, project);
 
-        // The warm: analyse every project file once, exactly what
-        // `spawn_workspace_warm` fans across the blocking pool.  Uses the *same*
-        // `(file, config)` keys the project indexes will read.
-        for &file in project.files(&db) {
-            let _ = file_analysis_incremental(&db, file, cfg);
-        }
-        // From here the project-index loops must not re-execute the per-file
-        // query — every read is served from the warmed cache.
         log.lock().unwrap().clear();
-        let _ = project_class_index(&db, project, cfg);
-        let _ = project_proc_var_index(&db, project, cfg);
+        main.set_text(&mut db)
+            .to("proc ::helper {a b} { return [expr {$a * $b}] }\n".to_owned());
+        let _ = project_class_index(&db, project);
+        let _ = project_proc_var_index(&db, project);
         let after = log.lock().unwrap().clone();
         assert!(
-            after
-                .iter()
-                .all(|s| !s.contains("file_analysis_incremental")),
-            "after the warm, the project indexes must hit cache, not re-run \
-             file_analysis_incremental: {after:?}"
+            after.iter().any(|s| s.contains("file_token_facts")),
+            "the edited file's own facts must be recomputed: {after:?}"
         );
+        assert!(
+            after.iter().all(
+                |s| !s.contains("project_class_index") && !s.contains("project_proc_var_index")
+            ),
+            "a role-neutral body edit must backdate at the per-file firewall, \
+             leaving the project aggregates memoised: {after:?}"
+        );
+    }
+
+    /// The merged project role index must equal one built from every file's
+    /// procs at once — including the abstentions each file made on its own, so
+    /// a name one file already dropped as ambiguous is not re-adopted from
+    /// another file's unambiguous entry.
+    #[test]
+    fn merged_role_index_equals_the_all_at_once_build() {
+        let sources = [
+            // `::a::grow` and `::b::grow` disagree, so this file abstains on the
+            // bare `grow` key all by itself.
+            "namespace eval a { proc grow {v} { upvar 1 $v x; set x 1 } }\n\
+             namespace eval b { proc grow {n v} { upvar 1 $v x; set x 1 } }\n",
+            // A third `grow`, unambiguous within its own file.
+            "namespace eval c { proc grow {v} { upvar 1 $v x; set x 2 } }\n",
+        ];
+        let db = TclDatabase::default();
+        let files: Vec<SourceFile> = sources
+            .iter()
+            .map(|s| SourceFile::new(&db, (*s).to_owned(), "tcl8.6".to_owned(), None))
+            .collect();
+        let project = Project::new(&db, files.clone());
+
+        let all_procs: Vec<Arc<AnalysisResult>> = sources
+            .iter()
+            .map(|s| Arc::new(Analyser::new().structure_only().analyse(s, "tcl8.6")))
+            .collect();
+        let expected =
+            VarNameArgRoles::from_procs(all_procs.iter().flat_map(|a| a.all_procs.values()));
+        assert_eq!(*project_proc_var_index(&db, project), expected);
+        // Order-independent: reversing the project's files changes nothing.
+        let reversed = Project::new(&db, files.into_iter().rev().collect());
+        assert_eq!(*project_proc_var_index(&db, reversed), expected);
     }
 
     #[test]
@@ -3576,7 +3626,7 @@ mod tests {
             None,
         );
         let project = Project::new(&db, vec![lib, user]);
-        let cross = semantic_tokens_project(&db, user, cfg(&db), project);
+        let cross = semantic_tokens_project(&db, user, project);
         let local = semantic_tokens(&db, user, cfg(&db));
         assert_ne!(
             cross.data, local.data,
@@ -3584,7 +3634,7 @@ mod tests {
         );
         // The merged index sees the class from the other file.
         assert!(
-            project_class_index(&db, project, cfg(&db))
+            project_class_index(&db, project)
                 .classes
                 .contains_key("::Pin"),
             "project index should contain ::Pin from the library file"
@@ -3615,7 +3665,7 @@ mod tests {
         for files in [vec![a, b], vec![b, a]] {
             let project = Project::new(&db, files);
             assert!(
-                !project_class_index(&db, project, cfg(&db))
+                !project_class_index(&db, project)
                     .classes
                     .contains_key("::Pin"),
                 "an ambiguous cross-file class name must be dropped, not resolved"

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -3501,6 +3501,40 @@ mod tests {
         assert_eq!(got, expected);
     }
 
+    /// Folding served through salsa is memoised: a repeat request for the
+    /// same revision must not re-execute the tracked query — the property
+    /// `Backend::db_folding_ranges` relies on to avoid a fresh
+    /// segmenter/registry walk on every `textDocument/foldingRange`.
+    #[test]
+    fn folding_ranges_memoised_across_repeat_queries() {
+        let log: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let db = {
+            let sink = Arc::clone(&log);
+            TclDatabase::with_event_logger(move |key| sink.lock().unwrap().push(key))
+        };
+        let file = SourceFile::new(&db, SRC.to_owned(), "tcl".to_owned(), None);
+        let drain = || std::mem::take(&mut *log.lock().unwrap());
+        let executions = |events: &[String]| {
+            events
+                .iter()
+                .filter(|key| key.contains("folding_ranges"))
+                .count()
+        };
+
+        let _ = folding_ranges(&db, file);
+        assert_eq!(
+            executions(&drain()),
+            1,
+            "cold: one execution for the first request"
+        );
+        let _ = folding_ranges(&db, file);
+        assert_eq!(
+            executions(&drain()),
+            0,
+            "warm: memoised, no re-execution for a repeat request at the same revision"
+        );
+    }
+
     #[test]
     fn editing_text_recomputes() {
         use salsa::Setter as _;

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -940,8 +940,16 @@ pub fn project_diagnostics(
 /// the offset-0 facts by the body's real span).
 #[salsa::interned]
 pub struct ItemBodyKey<'db> {
+    /// The proc / method body source, shared with the
+    /// [`tcl_compiler::analyser::per_item::DeferredBody`] the aggregator built
+    /// it from rather than copied out of it.  Interning is content-addressed, so
+    /// the text must be *in* the key; what it must not be is a fresh `String`
+    /// per proc per edit (issue #1159 — on a 114-proc file that was 114 full
+    /// body copies before a single memo was consulted, and the copies were
+    /// discarded the moment the intern hit).  `Arc<str>` also makes
+    /// [`item_body_analysis`]'s rebuild of the `DeferredBody` a refcount bump.
     #[returns(ref)]
-    pub body_text: String,
+    pub body_text: Arc<str>,
     #[returns(ref)]
     pub namespace: String,
     #[returns(ref)]
@@ -983,7 +991,7 @@ pub fn item_body_analysis<'db>(db: &'db dyn TclDb, key: ItemBodyKey<'db>) -> Arc
     // path (the aggregator supplies the real position when grafting), so a
     // placeholder token is fine.
     let body = DeferredBody {
-        body_text: key.body_text(db).clone(),
+        body_text: Arc::clone(key.body_text(db)),
         body_tok: tcl_lexer::Token::new(tcl_lexer::TokenType::Str, tcl_lexer::Span::new(0, 0)),
         scope_path: Vec::new(),
         is_method: key.is_method(db),
@@ -1265,6 +1273,19 @@ fn build_unit_with_keys<'db>(
             req.has_dynamic_variable_trace,
         );
         lattice_keys.insert(req.qname.to_owned(), key);
+        // The memo stores the unit at **offset 0** and the builder rebases the
+        // returned unit to the procedure's real position
+        // (`lattice_rebase::rebase_function_unit` mutates `cfg` / `ssa` /
+        // `sccp.constant_branches` in place), so the span-carrying half genuinely
+        // has to be owned here — an `Arc` reader would only defer the copy to
+        // the rebase. Issue #1159's win is instead that the *span-free* half
+        // (`def_use` / `types` / `taints` / `rendered_props`) is now `Arc`-held
+        // inside `FunctionUnit`, so this clone is a refcount bump for each of
+        // those four lattices and copies only what the rebase must rewrite.
+        // Making the whole read an `Arc` would mean lazy rebasing via
+        // `FunctionUnit::base_offset` / `abs_span`, which was deliberately
+        // rejected: consumers read `fu.cfg` spans directly and would silently
+        // get relative positions.
         (*function_lattice(db, key)).clone()
     };
     // SRV-INCREMENTAL Task 3: lower each *eligible* top-level proc body through the
@@ -1282,6 +1303,9 @@ fn build_unit_with_keys<'db>(
     let cu = if tcl_compiler::lowering::source_may_alias_commands(source) {
         CompilationUnit::build_for_memoized(source, options, &mut lattice_memo)
     } else {
+        // Same offset-0-plus-rebase contract as `lattice_memo` above: the caller
+        // shifts the returned `Script` to the body's real position, so it needs
+        // an owned copy (issue #1159).
         let body_memo = |body_text: &str, namespace: &str| -> Script {
             let key = ProcBodyKey::new(
                 db,
@@ -1309,7 +1333,11 @@ fn build_unit_with_keys<'db>(
         &mut |qname: &str, ia: &InterproceduralAnalysis| {
             let key = *lattice_keys.get(qname)?;
             let summary_key = taint_summary_key(db, ia, qname, dialect);
-            Some((*taint_cascade(db, key, summary_key)).clone())
+            // A hit returns the memoised map by refcount: `FunctionUnit::taints`
+            // is span-free (the offset rebase never touches it), so the unit can
+            // share the cached lattice rather than deep-copying it per procedure
+            // per build (issue #1159).
+            Some(taint_cascade(db, key, summary_key))
         },
     );
     (unit, lattice_keys)
@@ -2424,7 +2452,7 @@ pub fn file_analysis_incremental(
     let mut body_fn = |body: &DeferredBody| -> BodyFragment {
         let key = ItemBodyKey::new(
             db,
-            body.body_text.clone(),
+            Arc::clone(&body.body_text),
             body.namespace.clone(),
             body.scope_name.clone(),
             body.params.clone(),
@@ -2436,6 +2464,9 @@ pub fn file_analysis_incremental(
             disabled_vec.clone(),
             non_ascii,
         );
+        // Owned for the same reason as the lattice memo: `graft_proc_body`
+        // rebases the offset-0 fragment to the body's real span and then moves
+        // its fields into the shell, so the fragment cannot be shared.
         (*item_body_analysis(db, key)).clone()
     };
     Arc::new(analyser.analyse_per_item_with(&text, &dialect, &mut body_fn))
@@ -2799,6 +2830,107 @@ mod tests {
         let expected = direct.analyse(SRC, "tcl");
         assert_eq!(*got, expected);
         assert!(got.all_procs.contains_key("::greet"));
+    }
+
+    /// Issue #1159: a memo *hit* must hand its per-procedure lattices over by
+    /// refcount, not deep-copy them.
+    ///
+    /// The span-carrying halves of a `FunctionUnit` (`cfg` / `ssa` /
+    /// `sccp.constant_branches`) genuinely have to be copied — the memo stores
+    /// the unit at offset 0 and every consumer is rebased to the procedure's
+    /// real position — but `def_use` / `types` / `taints` / `rendered_props` are
+    /// span-free, so a rebuild that hits the memo must share them.
+    #[test]
+    fn memoised_lattices_are_shared_not_deep_copied_across_builds() {
+        const SRC: &str = "proc alpha {a b} {\n    set s [expr {$a + $b}]\n    return $s\n}\n\
+                           proc beta {x} {\n    return [alpha $x 1]\n}\n";
+        let db = TclDatabase::default();
+        let registry = db.registry("tcl8.6");
+        let options = || UnitBuildOptions {
+            registry,
+            defer_top_level: false,
+            config: tcl_lexer::LexerConfig::default(),
+            dialect: "tcl8.6",
+            external_call_sites: None,
+        };
+        let first = memoised_compilation_unit(&db, SRC, options());
+        let second = memoised_compilation_unit(&db, SRC, options());
+        for qname in ["::alpha", "::beta"] {
+            let a = first
+                .procedures
+                .get(qname)
+                .expect("procedure in first build");
+            let b = second
+                .procedures
+                .get(qname)
+                .expect("procedure in second build");
+            assert!(
+                Arc::ptr_eq(&a.def_use, &b.def_use),
+                "{qname}: def-use chains must be shared across a memo hit",
+            );
+            assert!(
+                Arc::ptr_eq(&a.types, &b.types),
+                "{qname}: the type lattice must be shared across a memo hit",
+            );
+            assert!(
+                Arc::ptr_eq(&a.rendered_props, &b.rendered_props),
+                "{qname}: rendered properties must be shared across a memo hit",
+            );
+            assert!(
+                Arc::ptr_eq(&a.taints, &b.taints),
+                "{qname}: the taint cascade result must be shared across a memo hit",
+            );
+        }
+    }
+
+    /// Issue #1159: an unchanged proc body must re-intern to the *same*
+    /// `ItemBodyKey` (so the memo hits) and must not cost a fresh copy of the
+    /// body text to get there — the key shares the analyser's `Arc<str>`.
+    #[test]
+    fn unchanged_body_reinterns_to_the_same_key_without_copying_its_text() {
+        let db = TclDatabase::default();
+        let body: Arc<str> = Arc::from("set s 1\nreturn $s\n");
+        let make = || {
+            ItemBodyKey::new(
+                &db,
+                Arc::clone(&body),
+                "::".to_owned(),
+                "alpha".to_owned(),
+                Vec::new(),
+                false,
+                false,
+                Vec::new(),
+                None,
+                "tcl8.6".to_owned(),
+                Vec::new(),
+                NonAsciiMode::Default,
+            )
+        };
+        assert!(make() == make(), "unchanged text must re-intern to one key");
+        assert!(
+            Arc::ptr_eq(make().body_text(&db), &body),
+            "the interned key must share the caller's body text, not copy it",
+        );
+        // A different body must not collide with it.
+        let other: Arc<str> = Arc::from("set s 2\nreturn $s\n");
+        let other_key = ItemBodyKey::new(
+            &db,
+            other,
+            "::".to_owned(),
+            "alpha".to_owned(),
+            Vec::new(),
+            false,
+            false,
+            Vec::new(),
+            None,
+            "tcl8.6".to_owned(),
+            Vec::new(),
+            NonAsciiMode::Default,
+        );
+        assert!(
+            make() != other_key,
+            "distinct bodies must intern distinctly"
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -3859,9 +3859,7 @@ impl Backend {
         let snapshot = self.db.lock().await.clone();
         Some(tokio::task::spawn_blocking(move || {
             salsa::Cancelled::catch(|| match project {
-                Some(project) => {
-                    tcl_lsp_db::semantic_tokens_project(&snapshot, file, config, project)
-                }
+                Some(project) => tcl_lsp_db::semantic_tokens_project(&snapshot, file, project),
                 None => tcl_lsp_db::semantic_tokens(&snapshot, file, config),
             })
             .ok()
@@ -4387,11 +4385,12 @@ impl Backend {
     ///
     /// When a `Project` is indexed, the background computation is
     /// `semantic_tokens_project`, whose cross-file class/proc-role indices
-    /// (`project_class_index` / `project_proc_var_index`) analyse every
-    /// project file, not just this one — on a large workspace this can take
-    /// far longer than a single file's own analysis. That cost has always
-    /// existed; what this fast path changes is that it can no longer block a
-    /// token response — it only delays how soon the *refresh* follows.
+    /// (`project_class_index` / `project_proc_var_index`) read every project
+    /// file, not just this one.  They read it at the light `file_token_facts`
+    /// tier and behind a per-file backdating firewall (#1163), so on a warm
+    /// workspace this is an aggregation, not a walk; a cold one still pays a
+    /// first pass, which this fast path keeps off the token response — it only
+    /// delays how soon the *refresh* follows.
     /// Viewport tokens for a document that is **not Tcl** — an APL presentation
     /// or a BIG-IP config — or `None` when the document *is* Tcl and belongs on
     /// the normal pipeline.
@@ -9977,11 +9976,12 @@ impl Backend {
     /// narrowed by #1151).
     ///
     /// Deep state (`file_analysis_incremental` and everything built on it —
-    /// `compilation_unit`, `project_class_index`, `project_proc_var_index`) is an
+    /// `compilation_unit`) is an
     /// open-document cost, not a workspace one: an on-disk file the editor hasn't
     /// opened only needs to answer cross-file resolution (`workspace_index`,
     /// fed by the scan's own analyser pass, plus the light `file_decls` /
-    /// `item_sigs` signature tier salsa computes on demand from the `SourceFile`
+    /// `item_sigs` / `file_token_facts` tier salsa computes on demand from the
+    /// `SourceFile`
     /// inputs `db_set_sources_batch` sets). Warming the deep tier for every
     /// workspace file — the pre-#1151 behaviour — analysed the whole project a
     /// *second* time through salsa on top of the scan's own analyser walk, and
@@ -10016,7 +10016,7 @@ impl Backend {
     /// product: that product existed only to cover `project_class_index` /
     /// `project_proc_var_index` applying one config to *every* project file,
     /// which no longer matters here because this warm no longer touches
-    /// unopened files at all.
+    /// unopened files at all and those two indexes are now config-free (#1163).
     fn spawn_workspace_warm(&self) {
         let db = Arc::clone(&self.db);
         let db_files = Arc::clone(&self.db_files);

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -2359,6 +2359,15 @@ pub struct Backend {
     /// server-side lift.  Folders without such overrides fall back to
     /// [`Backend::db_config`].
     folder_db_configs: Arc<Mutex<Vec<(Uri, tcl_lsp_db::AnalyserConfig)>>>,
+    /// Retired per-folder `AnalyserConfig` handles, keyed by folder URI (#1145).
+    ///
+    /// The `AnalyserConfig` half of [`Backend::db_tombstones`], and there for
+    /// the same reason: a folder whose override set empties (or which leaves the
+    /// workspace) drops its handle, and re-enabling an override would allocate a
+    /// second one salsa can never reclaim.  A `.tcl-lsp.ini` watcher re-pulls the
+    /// whole layered config on every save, so the churn is per keystroke-save,
+    /// not per session.
+    folder_db_config_tombstones: Arc<Mutex<HashMap<Uri, tcl_lsp_db::AnalyserConfig>>>,
     /// W108 non-ASCII detection mode (`tclLsp.style.nonAscii`).
     /// [`NonAsciiMode::Default`] until an editor configures it via
     /// `initializationOptions` or `workspace/didChangeConfiguration`.
@@ -2476,6 +2485,22 @@ pub struct Backend {
     /// Per-URI salsa `SourceFile` input handles — the input-of-record the
     /// query graph reads.  Kept current by `did_open` / `did_change`.
     db_files: Arc<Mutex<HashMap<Uri, tcl_lsp_db::SourceFile>>>,
+    /// Retired `SourceFile` handles, keyed by the URI they belonged to (#1145).
+    ///
+    /// Salsa never reclaims an input: `SourceFile::new` only ever allocates, so
+    /// a URI that is removed and later re-created would strand its old input —
+    /// full text and every memo keyed on it — for the process's life.  A watched
+    /// `DELETED`→`CREATED` pair (a `git checkout` retriggers one per file), an
+    /// untitled buffer closing, a workspace folder being removed and re-added,
+    /// and a rename's [`Backend::retire_renamed_uri`] all take that path.
+    ///
+    /// So a removal *retires* the handle here with its payload cleared instead
+    /// of dropping it, and [`Backend::db_set_source`] revives it rather than
+    /// allocating a second one.  The cost is one input per distinct URI the
+    /// session ever saw, each holding near-nothing while retired.  Retired
+    /// handles are never in `db_files`, so they never reach the salsa
+    /// [`tcl_lsp_db::Project`] file set either.
+    db_tombstones: Arc<Mutex<HashMap<Uri, tcl_lsp_db::SourceFile>>>,
     /// The salsa `Project` input — the workspace file set, kept in lock-step with
     /// `db_files` (re-set only when membership changes, on open/close), driving
     /// the cross-file `project_diagnostics` query.
@@ -2986,6 +3011,7 @@ impl Backend {
             folder_dialects: Mutex::new(Vec::new()),
             folder_configs: Mutex::new(Vec::new()),
             folder_db_configs: Arc::new(Mutex::new(Vec::new())),
+            folder_db_config_tombstones: Arc::new(Mutex::new(HashMap::new())),
             non_ascii_mode: Mutex::new(NonAsciiMode::Default),
             disabled_diagnostics: Mutex::new(default_disabled_set()),
             severity_overrides: Mutex::new(HashMap::new()),
@@ -3009,6 +3035,7 @@ impl Backend {
             style_line_length: Mutex::new(120),
             db: Arc::new(Mutex::new(db)),
             db_files: Arc::new(Mutex::new(HashMap::new())),
+            db_tombstones: Arc::new(Mutex::new(HashMap::new())),
             db_project: Arc::new(Mutex::new(None)),
             db_config: Arc::new(Mutex::new(db_config)),
             pull_diag_cache: Arc::new(Mutex::new(HashMap::new())),
@@ -3025,7 +3052,7 @@ impl Backend {
 
     /// Create or update the salsa `SourceFile` input for `uri`.  Called by
     /// `did_open` / `did_change` so the query graph always reads current text.
-    /// Lock order is always `db` then `db_files`.
+    /// Lock order is always `db` → `db_files` → `db_tombstones` → `db_project`.
     async fn db_set_source(&self, uri: &Uri, text: String, dialect: String) {
         use salsa::Setter as _;
         let mut db = self.db.lock().await;
@@ -3036,8 +3063,10 @@ impl Backend {
             file.set_text(&mut *db).to(text);
             file.set_dialect(&mut *db).to(dialect);
         } else {
-            let path = uri.to_file_path().map(|p| p.display().to_string());
-            let file = tcl_lsp_db::SourceFile::new(&*db, text, dialect, path);
+            let file = {
+                let mut tombstones = self.db_tombstones.lock().await;
+                Self::revive_or_create_db_source(&mut db, &mut tombstones, uri, text, dialect)
+            };
             files.insert(uri.clone(), file);
             // Membership changed — re-set the `Project` file set.
             let mut project = self.db_project.lock().await;
@@ -3045,14 +3074,67 @@ impl Backend {
         }
     }
 
-    /// Drop the salsa `SourceFile` input for `uri` (on `did_close`).  Lock order
-    /// is `db` → `db_files` → `db_project`, matching [`Self::db_set_source`].
+    /// Retire the salsa `SourceFile` input for `uri` (on `did_close`).  Lock
+    /// order is `db` → `db_files` → `db_tombstones` → `db_project`, matching
+    /// [`Self::db_set_source`].
     async fn db_remove_source(&self, uri: &Uri) {
         let mut db = self.db.lock().await;
         let mut files = self.db_files.lock().await;
-        if files.remove(uri).is_some() {
+        let retired = {
+            let mut tombstones = self.db_tombstones.lock().await;
+            Self::retire_db_source(&mut db, &mut files, &mut tombstones, uri)
+        };
+        if retired {
             let mut project = self.db_project.lock().await;
             Self::sync_db_project(&mut db, &files, &mut project);
+        }
+    }
+
+    /// Move `uri`'s live `SourceFile` handle into the tombstone map with its
+    /// payload released, returning whether there was one (#1145).
+    ///
+    /// Salsa 0.27 allocates inputs and never frees them, so dropping the handle
+    /// would strand the text and every memo keyed on it.  Emptying the text and
+    /// clearing the cross-file evidence releases the payload *and* backdates the
+    /// memos that read them, which is the closest a caller can get to reclaiming
+    /// the input.  `path` and `dialect` are left alone: both are small, and the
+    /// path is a pure function of the URI this handle is filed under, so a
+    /// revival re-derives the same value.
+    fn retire_db_source(
+        db: &mut tcl_lsp_db::TclDatabase,
+        files: &mut HashMap<Uri, tcl_lsp_db::SourceFile>,
+        tombstones: &mut HashMap<Uri, tcl_lsp_db::SourceFile>,
+        uri: &Uri,
+    ) -> bool {
+        use salsa::Setter as _;
+        let Some(file) = files.remove(uri) else {
+            return false;
+        };
+        file.set_text(db).to(String::new());
+        file.set_external_call_sites(db).to(None);
+        tombstones.insert(uri.clone(), file);
+        true
+    }
+
+    /// The `SourceFile` handle to file under `uri`: its retired one revived with
+    /// the new text, or a fresh input when the session has never seen this URI
+    /// (#1145).  Reviving keeps one input per distinct URI however many
+    /// delete/re-create cycles the URI goes through.
+    fn revive_or_create_db_source(
+        db: &mut tcl_lsp_db::TclDatabase,
+        tombstones: &mut HashMap<Uri, tcl_lsp_db::SourceFile>,
+        uri: &Uri,
+        text: String,
+        dialect: String,
+    ) -> tcl_lsp_db::SourceFile {
+        use salsa::Setter as _;
+        if let Some(file) = tombstones.remove(uri) {
+            file.set_text(db).to(text);
+            file.set_dialect(db).to(dialect);
+            file
+        } else {
+            let path = uri.to_file_path().map(|p| p.display().to_string());
+            tcl_lsp_db::SourceFile::new(&*db, text, dialect, path)
         }
     }
 
@@ -3061,7 +3143,7 @@ impl Backend {
     /// if membership changed — not once per file (which would be O(files²) over a
     /// large tree).  Used so cross-file diagnostics resolve against the *whole*
     /// workspace (matching `workspace_index`), not only open documents.  Lock order
-    /// is `db` → `db_files` → `db_project`, as everywhere.
+    /// is `db` → `db_files` → `db_tombstones` → `db_project`, as everywhere.
     async fn db_set_sources_batch(&self, entries: &[(Uri, String, String)]) {
         use salsa::Setter as _;
         if entries.is_empty() {
@@ -3069,39 +3151,48 @@ impl Backend {
         }
         let mut db = self.db.lock().await;
         let mut files = self.db_files.lock().await;
+        let mut tombstones = self.db_tombstones.lock().await;
         let mut membership_changed = false;
         for (uri, text, dialect) in entries {
             if let Some(&file) = files.get(uri) {
                 file.set_text(&mut *db).to(text.clone());
                 file.set_dialect(&mut *db).to(dialect.clone());
             } else {
-                let path = uri.to_file_path().map(|p| p.display().to_string());
-                let file = tcl_lsp_db::SourceFile::new(&*db, text.clone(), dialect.clone(), path);
+                let file = Self::revive_or_create_db_source(
+                    &mut db,
+                    &mut tombstones,
+                    uri,
+                    text.clone(),
+                    dialect.clone(),
+                );
                 files.insert(uri.clone(), file);
                 membership_changed = true;
             }
         }
+        drop(tombstones);
         if membership_changed {
             let mut project = self.db_project.lock().await;
             Self::sync_db_project(&mut db, &files, &mut project);
         }
     }
 
-    /// Drop many salsa `SourceFile` inputs at once (files under a removed workspace
-    /// folder), re-setting the `Project` once if membership changed.  Lock order is
-    /// `db` → `db_files` → `db_project`.
+    /// Retire many salsa `SourceFile` inputs at once (files under a removed
+    /// workspace folder), re-setting the `Project` once if membership changed.
+    /// Lock order is `db` → `db_files` → `db_tombstones` → `db_project`.
     async fn db_remove_sources_batch(&self, uris: &[Uri]) {
         if uris.is_empty() {
             return;
         }
         let mut db = self.db.lock().await;
         let mut files = self.db_files.lock().await;
+        let mut tombstones = self.db_tombstones.lock().await;
         let mut membership_changed = false;
         for uri in uris {
-            if files.remove(uri).is_some() {
+            if Self::retire_db_source(&mut db, &mut files, &mut tombstones, uri) {
                 membership_changed = true;
             }
         }
+        drop(tombstones);
         if membership_changed {
             let mut project = self.db_project.lock().await;
             Self::sync_db_project(&mut db, &files, &mut project);
@@ -7923,6 +8014,14 @@ impl Backend {
     /// overrides the disabled-diagnostics set or non-ASCII mode (others inherit
     /// [`Backend::db_config`]); existing handles are reused across re-pulls so
     /// the salsa store does not accumulate dead config inputs.
+    ///
+    /// A folder that stops overriding anything — or leaves the workspace — has
+    /// its handle *retired* into [`Backend::folder_db_config_tombstones`] with
+    /// its payload cleared, not dropped, and a folder that starts overriding
+    /// again revives the retired handle (#1145).  Salsa never frees an input, so
+    /// dropping one leaks it: `.tcl-lsp.ini` re-pulls the whole layered config
+    /// on every save, which would otherwise allocate a fresh config input per
+    /// save for a folder toggling an override.
     async fn apply_folder_configs(&self, parsed: Vec<(Uri, FolderConfig)>) {
         use salsa::Setter as _;
         {
@@ -7941,6 +8040,12 @@ impl Backend {
             let global_generic = self.generic_variable_patterns.lock().await.clone();
             let mut db = self.db.lock().await;
             let mut handles = self.folder_db_configs.lock().await;
+            let mut tombstones = self.folder_db_config_tombstones.lock().await;
+            // Every live handle starts out claimed-back; whatever is still here
+            // when the loop ends belongs to a folder that no longer needs one and
+            // is retired below.
+            let mut reclaimable: HashMap<Uri, tcl_lsp_db::AnalyserConfig> =
+                handles.drain(..).collect();
             let mut next: Vec<(Uri, tcl_lsp_db::AnalyserConfig)> = Vec::new();
             for (folder, fc) in &parsed {
                 // A handle is only needed when the folder overrides one of the
@@ -7967,17 +8072,32 @@ impl Backend {
                     FolderGenericPatterns::BuiltinDefaults => None,
                     FolderGenericPatterns::Replace(list) => Some(list.clone()),
                 };
-                if let Some((_, handle)) = handles.iter().find(|(u, _)| u == folder) {
+                // The folder's own live handle first, then its retired one, and
+                // only then a fresh input.
+                if let Some(handle) = reclaimable
+                    .remove(folder)
+                    .or_else(|| tombstones.remove(folder))
+                {
                     handle.set_disabled_diagnostics(&mut *db).to(disabled);
                     handle.set_non_ascii_mode(&mut *db).to(mode);
                     handle.set_extra_commands(&mut *db).to(extra);
                     handle.set_generic_variable_patterns(&mut *db).to(generic);
-                    next.push((folder.clone(), *handle));
+                    next.push((folder.clone(), handle));
                 } else {
                     let handle =
                         tcl_lsp_db::AnalyserConfig::new(&*db, disabled, mode, extra, generic, None);
                     next.push((folder.clone(), handle));
                 }
+            }
+            for (folder, handle) in reclaimable {
+                // Release the payload before retiring, so a folder that toggles
+                // an override off does not keep its old code lists (and the
+                // memos keyed on them) alive until it is toggled back on.
+                handle.set_disabled_diagnostics(&mut *db).to(Vec::new());
+                handle.set_extra_commands(&mut *db).to(Vec::new());
+                handle.set_generic_variable_patterns(&mut *db).to(None);
+                handle.set_bigip_version(&mut *db).to(None);
+                tombstones.insert(folder, handle);
             }
             *handles = next;
         }
@@ -18226,6 +18346,7 @@ mod tests {
             folder_dialects: Mutex::new(Vec::new()),
             folder_configs: Mutex::new(Vec::new()),
             folder_db_configs: Arc::new(Mutex::new(Vec::new())),
+            folder_db_config_tombstones: Arc::new(Mutex::new(HashMap::new())),
             non_ascii_mode: Mutex::new(NonAsciiMode::Default),
             disabled_diagnostics: Mutex::new(default_disabled_set()),
             severity_overrides: Mutex::new(HashMap::new()),
@@ -18249,6 +18370,7 @@ mod tests {
             style_line_length: Mutex::new(120),
             db: Arc::new(Mutex::new(db)),
             db_files: Arc::new(Mutex::new(HashMap::new())),
+            db_tombstones: Arc::new(Mutex::new(HashMap::new())),
             db_project: Arc::new(Mutex::new(None)),
             db_config: Arc::new(Mutex::new(db_config)),
             pull_diag_cache: Arc::new(Mutex::new(HashMap::new())),
@@ -19141,6 +19263,204 @@ mod tests {
             "deleting a closed file must clear its badge",
         );
         std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// #1145: removing a source retires its salsa input with an emptied payload
+    /// instead of dropping it, and re-creating the same URI revives that handle
+    /// rather than allocating a second one salsa can never free.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn db_remove_source_retires_input_for_reuse() {
+        let backend = test_backend();
+        let uri = Uri::from_str("file:///retired.tcl").unwrap();
+        backend
+            .db_set_source(&uri, "proc foo {} {}\n".to_owned(), "tcl8.6".to_owned())
+            .await;
+        let first = *backend
+            .db_files
+            .lock()
+            .await
+            .get(&uri)
+            .expect("the source is tracked once set");
+
+        backend.db_remove_source(&uri).await;
+
+        assert!(
+            !backend.db_files.lock().await.contains_key(&uri),
+            "a removed source must leave the live file set",
+        );
+        {
+            let db = backend.db.lock().await;
+            let tombstones = backend.db_tombstones.lock().await;
+            let retired = *tombstones
+                .get(&uri)
+                .expect("the input must be retired, not dropped — salsa never frees one");
+            assert!(retired == first, "the retired handle is the original input");
+            assert!(
+                retired.text(&*db).is_empty(),
+                "a retired input must release its text: {:?}",
+                retired.text(&*db),
+            );
+            assert!(
+                retired.external_call_sites(&*db).is_none(),
+                "a retired input must release its cross-file evidence",
+            );
+        }
+
+        backend
+            .db_set_source(&uri, "proc bar {} {}\n".to_owned(), "tcl8.6".to_owned())
+            .await;
+        let second = *backend
+            .db_files
+            .lock()
+            .await
+            .get(&uri)
+            .expect("the re-created source is tracked again");
+        assert!(
+            first == second,
+            "re-creating a removed URI must revive its retired input",
+        );
+        assert!(
+            backend.db_tombstones.lock().await.is_empty(),
+            "a revived input must leave the tombstone map",
+        );
+        // The revived handle carries the new text and is the project's only file.
+        {
+            let db = backend.db.lock().await;
+            assert_eq!(second.text(&*db), "proc bar {} {}\n");
+            let project = backend.db_project.lock().await;
+            let files = project
+                .expect("a project exists once a file is tracked")
+                .files(&*db);
+            assert!(
+                files.as_slice() == [second],
+                "the project file set must hold exactly the one live input",
+            );
+        }
+    }
+
+    /// #1145: a watched `DELETED` → `CREATED` pair — what a `git checkout` or
+    /// branch switch fires for every changed file — must not allocate a second
+    /// salsa input per cycle.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn watched_delete_then_create_reuses_source_input() {
+        let root = unique_scratch_dir("watched-recreate");
+        let on_disk = root.join("switched.tcl");
+        std::fs::write(&on_disk, "proc foo {} {}\n").unwrap();
+        let backend = test_backend();
+        let uri = Uri::from_file_path(&on_disk).unwrap();
+        backend
+            .db_set_source(&uri, "proc foo {} {}\n".to_owned(), "tcl8.6".to_owned())
+            .await;
+        let before = *backend
+            .db_files
+            .lock()
+            .await
+            .get(&uri)
+            .expect("the scanned file is tracked");
+
+        // The branch switch: the file disappears, then reappears with new content.
+        std::fs::remove_file(&on_disk).unwrap();
+        backend
+            .did_change_watched_files(DidChangeWatchedFilesParams {
+                changes: vec![tower_lsp_server::ls_types::FileEvent {
+                    uri: uri.clone(),
+                    typ: FileChangeType::DELETED,
+                }],
+            })
+            .await;
+        std::fs::write(&on_disk, "proc bar {} {}\n").unwrap();
+        backend
+            .did_change_watched_files(DidChangeWatchedFilesParams {
+                changes: vec![tower_lsp_server::ls_types::FileEvent {
+                    uri: uri.clone(),
+                    typ: FileChangeType::CREATED,
+                }],
+            })
+            .await;
+
+        let after = *backend
+            .db_files
+            .lock()
+            .await
+            .get(&uri)
+            .expect("the re-created file is tracked again");
+        assert!(
+            before == after,
+            "a delete/re-create cycle must reuse the retired input, not leak it",
+        );
+        assert!(
+            backend.db_tombstones.lock().await.is_empty(),
+            "the revived input must leave the tombstone map",
+        );
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// #1145: a folder whose override set empties retires its `AnalyserConfig`
+    /// handle (payload cleared) and revives it when the override comes back —
+    /// `.tcl-lsp.ini` churn must not allocate a config input per save.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn folder_db_config_handle_is_retired_and_revived() {
+        let backend = test_backend();
+        let folder = Uri::from_str("file:///proj-a").unwrap();
+        *backend.workspace_folders.lock().await = vec![folder.clone()];
+        let overriding = || FolderConfig {
+            disabled_diagnostics: Some(std::iter::once("W100".to_owned()).collect()),
+            ..FolderConfig::default()
+        };
+
+        backend
+            .apply_folder_configs(vec![(folder.clone(), overriding())])
+            .await;
+        let first = backend
+            .folder_db_configs
+            .lock()
+            .await
+            .iter()
+            .find(|(u, _)| u == &folder)
+            .map(|(_, handle)| *handle)
+            .expect("an overriding folder gets its own AnalyserConfig handle");
+
+        // The next re-pull drops the override, so the folder needs no handle.
+        backend
+            .apply_folder_configs(vec![(folder.clone(), FolderConfig::default())])
+            .await;
+        assert!(
+            backend.folder_db_configs.lock().await.is_empty(),
+            "a folder with no overrides must not keep a live handle",
+        );
+        {
+            let db = backend.db.lock().await;
+            let tombstones = backend.folder_db_config_tombstones.lock().await;
+            let retired = *tombstones
+                .get(&folder)
+                .expect("the handle must be retired, not dropped");
+            assert!(retired == first, "the retired handle is the original input");
+            assert!(
+                retired.disabled_diagnostics(&*db).is_empty(),
+                "a retired config must release its code list",
+            );
+        }
+
+        // Re-enabling the override revives the retired handle.
+        backend
+            .apply_folder_configs(vec![(folder.clone(), overriding())])
+            .await;
+        let second = backend
+            .folder_db_configs
+            .lock()
+            .await
+            .iter()
+            .find(|(u, _)| u == &folder)
+            .map(|(_, handle)| *handle)
+            .expect("the re-enabled folder has a handle again");
+        assert!(
+            first == second,
+            "re-enabling an override must revive the retired config input",
+        );
+        assert!(
+            backend.folder_db_config_tombstones.lock().await.is_empty(),
+            "a revived config must leave the tombstone map",
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -294,6 +294,16 @@ const WORKSPACE_ANALYSIS_MAX_CONCURRENCY: usize = 16;
 /// boundary.
 const SCAN_MERGE_BATCH_SIZE: usize = 200;
 
+/// How long a workspace-wide query waits for the initial folder scan before
+/// answering from whatever the index already holds (see
+/// [`Backend::wait_for_workspace_scan`]).  Generous enough to cover a real
+/// project's startup scan — the alternative is a confidently empty answer to
+/// the very first `workspace/symbol` of a session — but bounded, so a
+/// pathological workspace degrades to a stale answer instead of hanging the
+/// picker.  Paid at most once per session: after the first scan completes the
+/// wait is a relaxed atomic load.
+const INITIAL_WORKSPACE_SCAN_WAIT: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// Debounce window for coalescing `workspace/semanticTokens/refresh` pushes
 /// (see [`SemanticTokensRefreshCtx::request_refresh_coalesced`]). Comparable
 /// to [`DIAGNOSTICS_DEBOUNCE`]: many cold large documents finishing their
@@ -2710,6 +2720,11 @@ pub struct Backend {
     /// could race the scan and silently find nothing, even though the same
     /// request moments later would have resolved correctly (issue #1003).
     workspace_scan_gate: tokio::sync::Mutex<()>,
+    /// Released once the first `scan_workspace_folders` pass has completed —
+    /// the "the scan has not started yet" half of the startup race
+    /// `workspace_scan_gate` alone cannot cover.  See
+    /// [`WorkspaceScanReadiness`].
+    workspace_scan_ready: Arc<WorkspaceScanReadiness>,
     /// Library files the autoload tier (M8) has merged into the workspace
     /// index on demand, so references / rename keep reaching them.  Cleared
     /// (and their index entries dropped) whenever the package database is
@@ -3005,6 +3020,56 @@ impl Drop for EditTurn<'_> {
             .now_serving
             .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
         self.order.advanced.notify_waiters();
+    }
+}
+
+/// One-shot readiness signal for the first [`Backend::scan_workspace_folders`]
+/// pass.
+///
+/// [`Backend::workspace_scan_gate`] lets a request wait out a scan that is
+/// *already running*, which is enough for a handler reached long after
+/// startup.  It is not enough at startup: `initialized` pulls the client
+/// config and registers file watchers — two client round-trips — **before** it
+/// starts the scan, and a request that lands in that window acquires a free
+/// gate and answers against an empty index (issue #1179: the first
+/// `workspace/symbol` query of a session returned nothing while the second,
+/// moments later, returned the same file's symbols).  This signal is what a
+/// cross-file handler waits on instead: it is only released once a scan has
+/// actually completed, so "the scan has not begun yet" and "the scan is in
+/// flight" both wait.
+#[derive(Debug, Default)]
+struct WorkspaceScanReadiness {
+    complete: std::sync::atomic::AtomicBool,
+    completed: tokio::sync::Notify,
+}
+
+impl WorkspaceScanReadiness {
+    /// Record that a scan pass has finished and wake every waiter.
+    fn mark_complete(&self) {
+        self.complete
+            .store(true, std::sync::atomic::Ordering::Release);
+        self.completed.notify_waiters();
+    }
+
+    fn is_complete(&self) -> bool {
+        self.complete.load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    /// Wait until the first scan pass has completed.  Callers bound this with
+    /// their own timeout — a workspace scan is disk-bound and a request must
+    /// degrade to a stale answer rather than hang.
+    async fn wait(&self) {
+        loop {
+            let completed = self.completed.notified();
+            tokio::pin!(completed);
+            // Register before re-reading, so a completion landing between the
+            // check and the await cannot be missed.
+            completed.as_mut().enable();
+            if self.is_complete() {
+                return;
+            }
+            completed.await;
+        }
     }
 }
 
@@ -3393,6 +3458,7 @@ impl Backend {
             package_resolver: Arc::new(RwLock::new(PackageResolver::new())),
             recovery_names: Arc::new(Mutex::new(RecoveryNameCache::default())),
             workspace_scan_gate: tokio::sync::Mutex::new(()),
+            workspace_scan_ready: Arc::new(WorkspaceScanReadiness::default()),
             autoloaded_library_uris: Arc::new(Mutex::new(HashSet::new())),
             rehomed_source_seeds: Arc::new(Mutex::new(HashMap::new())),
             rehoming_gate: tokio::sync::Mutex::new(()),
@@ -9720,6 +9786,70 @@ impl Backend {
         out
     }
 
+    /// Wait (bounded) for the workspace index to reflect a completed folder
+    /// scan before answering a workspace-wide query.
+    ///
+    /// Covers both halves of the startup race: the readiness signal covers
+    /// "the scan has not begun yet" (`initialized` pulls config and registers
+    /// watchers, two client round-trips, before it scans), and the gate covers
+    /// "a scan is in flight" — including a later folder-/config-change
+    /// rebuild.  The gate is acquired and released, never held while the
+    /// caller answers, so a query cannot stall a scan.
+    ///
+    /// A session with no workspace folders has no scan worth waiting for, so
+    /// it returns immediately rather than burning the budget.
+    async fn wait_for_workspace_scan(&self) {
+        if !self.workspace_scan_ready.is_complete() && self.workspace_folder_urls().await.is_empty()
+        {
+            return;
+        }
+        let _ = tokio::time::timeout(INITIAL_WORKSPACE_SCAN_WAIT, async {
+            self.workspace_scan_ready.wait().await;
+            drop(self.workspace_scan_gate.lock().await);
+        })
+        .await;
+    }
+
+    /// The `workspace/symbol` matches contributed by **open** documents the
+    /// workspace index does not currently hold.
+    ///
+    /// `did_open` drops the opened document's index entry — its on-disk
+    /// records stop being authoritative the moment a live buffer exists — and
+    /// the debounced diagnostics publish is what re-adds it.  Between the two
+    /// the file is invisible to the picker, which is exactly the moment a user
+    /// (or a test) searches for something they just opened (#1179).  A new
+    /// untitled buffer has the same gap until its first publish.
+    ///
+    /// Bounded by the open-document set and empty in steady state; the
+    /// analysis is read from the salsa memo the pending publish computes
+    /// anyway, so nothing is analysed twice.
+    async fn open_but_unindexed_symbols(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> Vec<core_workspace_symbols::IndexedWorkspaceSymbol> {
+        let unindexed: Vec<Uri> = {
+            // `documents` → `workspace_index`, the lock order `did_open`
+            // establishes.
+            let docs = self.documents.lock().await;
+            let index = self.workspace_index.read().await;
+            docs.keys()
+                .filter(|uri| !index.contains_document(uri.as_str()))
+                .cloned()
+                .collect()
+        };
+        if unindexed.is_empty() {
+            return Vec::new();
+        }
+        let mut pending = core_workspace_index::WorkspaceIndex::new();
+        for uri in &unindexed {
+            if let Some(analysis) = self.cached_analysis(uri).await {
+                pending.add_document(uri.as_str(), &analysis);
+            }
+        }
+        pending.symbols_matching(query, limit)
+    }
+
     async fn scan_workspace_folders(&self) {
         // Held for the whole scan so `ensure_autoload_indexed` can wait out
         // an in-flight scan instead of racing it — see the field doc on
@@ -9832,6 +9962,9 @@ impl Backend {
         // just batched in, which answer `file_decls` / `item_sigs` on demand)
         // until a request actually needs their deep analysis.
         self.spawn_workspace_warm();
+        // In-process readiness signal, released before the log line so a
+        // handler waiting on it is not held up by a client round-trip.
+        self.workspace_scan_ready.mark_complete();
         // Readiness signal for `package_resolver` / `workspace_index` having
         // just been (re)built from disk — a client (or a test) that needs to
         // know the autoload / cross-file workspace state is current rather
@@ -12251,17 +12384,29 @@ impl LanguageServer for Backend {
         // Freshness: the index is refreshed on each document's diagnostics
         // publish, which the debounce puts ~50 ms behind an edit.  A symbol
         // picker tolerates that — it is the same staleness every other
-        // cross-document feature answers with — and an open-but-not-yet-
-        // published buffer still contributes the symbols of its last publish
-        // (or of the folder scan), so nothing that used to be listed stops
-        // being listed.
-        let hits = {
+        // cross-document feature answers with.  What it does *not* tolerate is
+        // an index that has not been populated at all yet, so wait out the
+        // initial folder scan first (#1179).  The `didOpen`/`didChange`
+        // barrier comes first for the same reason every other reader takes it:
+        // a query issued after an open must observe that open.
+        self.edits_settled().await;
+        self.wait_for_workspace_scan().await;
+        let limit = core_workspace_symbols::MAX_WORKSPACE_SYMBOL_RESULTS;
+        // Open buffers the index does not currently hold, filled in from their
+        // own analysis.  `did_open` drops a document's index entry (its
+        // on-disk records stop being authoritative the moment a buffer exists)
+        // and the debounced publish is what puts it back, so for that window
+        // every symbol in the file the user *just opened* — the file most
+        // likely to be searched for — was missing from the picker (#1179).
+        // Bounded by the open-document set, empty in steady state, and the
+        // analysis read here is the memoised one the pending publish is
+        // already computing.
+        let mut hits = self.open_but_unindexed_symbols(&params.query, limit).await;
+        if hits.len() < limit {
+            let remaining = limit - hits.len();
             let index = self.workspace_index.read().await;
-            index.symbols_matching(
-                &params.query,
-                core_workspace_symbols::MAX_WORKSPACE_SYMBOL_RESULTS,
-            )
-        };
+            hits.extend(index.symbols_matching(&params.query, remaining));
+        }
         if hits.is_empty() {
             return Ok(None);
         }
@@ -19465,6 +19610,7 @@ mod tests {
             package_resolver: Arc::new(RwLock::new(PackageResolver::new())),
             recovery_names: Arc::new(Mutex::new(RecoveryNameCache::default())),
             workspace_scan_gate: tokio::sync::Mutex::new(()),
+            workspace_scan_ready: Arc::new(WorkspaceScanReadiness::default()),
             autoloaded_library_uris: Arc::new(Mutex::new(HashSet::new())),
             rehomed_source_seeds: Arc::new(Mutex::new(HashMap::new())),
             rehoming_gate: tokio::sync::Mutex::new(()),

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -3095,6 +3095,42 @@ fn longest_folder_match<'a, T>(entries: &'a [(Uri, T)], uri: &Uri) -> Option<&'a
     best.map(|(_, value)| value)
 }
 
+/// Drive `futures` to completion with at most `concurrency` live at once,
+/// collecting the `Some` results (`None` — an unreadable / no-longer-a-file
+/// entry — is dropped).  Used by the `did_change_watched_files` batch reindex
+/// (#1161), which analyses its whole (bounded, per-event) file set in one
+/// pass; [`Backend::scan_workspace_folders`] (#1151) needs to merge completed
+/// analyses into the index in batches rather than all at once (a large tree's
+/// `AnalysisResult`s must not all be live in memory together), so it runs the
+/// same acquire-before-spawn dispatch inline instead of reusing this return-a-
+/// `Vec` shape. Mirrors [`Backend::spawn_workspace_warm`]'s permit pattern: a
+/// permit is held for the caller's whole future, so `concurrency` bounds files
+/// genuinely in flight, not merely tasks parked waiting for one.
+async fn run_bounded<R, F>(futures: Vec<F>, concurrency: usize) -> Vec<R>
+where
+    R: Send + 'static,
+    F: std::future::Future<Output = Option<R>> + Send + 'static,
+{
+    let permits = Arc::new(Semaphore::new(concurrency.max(1)));
+    let mut tasks = tokio::task::JoinSet::new();
+    for fut in futures {
+        let Ok(permit) = Arc::clone(&permits).acquire_owned().await else {
+            break;
+        };
+        tasks.spawn(async move {
+            let _permit = permit;
+            fut.await
+        });
+    }
+    let mut out = Vec::with_capacity(tasks.len());
+    while let Some(res) = tasks.join_next().await {
+        if let Ok(Some(item)) = res {
+            out.push(item);
+        }
+    }
+    out
+}
+
 impl std::fmt::Debug for Backend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Backend").finish_non_exhaustive()
@@ -3845,6 +3881,39 @@ impl Backend {
     ///    URLs, use the deepest-matching folder's dialect.
     /// 4. The session-wide ``default_dialect`` fallback.
     async fn dialect_for_open(&self, uri: &Uri, language_id: &str, text: &str) -> String {
+        let folder_dialects = self.folder_dialects.lock().await.clone();
+        let default_dialect = self.default_dialect.lock().await.clone();
+        Self::dialect_for_open_sync(uri, language_id, text, &folder_dialects, &default_dialect)
+    }
+
+    /// Pure core of [`Self::dialect_for_open`] (and so of
+    /// [`Self::dialect_for_closed`]): every input the resolution needs reduced
+    /// to plain arguments, so a caller that already holds a `folder_dialects` /
+    /// `default_dialect` snapshot — a batched watched-file reindex resolving
+    /// many URIs at once (#1161) — can resolve a dialect without a per-file
+    /// `&self` lock round trip. `dialect_for_open` is the only other caller;
+    /// keeping the logic in one place is what makes the two paths agree.
+    ///
+    /// Resolution order:
+    ///
+    /// 1. The LSP ``languageId`` field — when it names a known
+    ///    dialect (``"tcl-irule"`` / ``"f5-irules"`` / ``"tcl9.0"``
+    ///    / etc.), use it directly.
+    /// 2. Detection over the document itself — for the bare ``"tcl"``
+    ///    id every editor sends for a `.tcl` buffer, the shared
+    ///    [`tcl_registry::dialects::detect_dialect`] (directive,
+    ///    shebang, version guard, content signatures, then extension).
+    /// 3. The per-folder override map (`folder_dialects`) — when
+    ///    the document URI sits under one of the configured folder
+    ///    URLs, use the deepest-matching folder's dialect.
+    /// 4. The session-wide ``default_dialect`` fallback.
+    fn dialect_for_open_sync(
+        uri: &Uri,
+        language_id: &str,
+        text: &str,
+        folder_dialects: &[(Uri, String)],
+        default_dialect: &str,
+    ) -> String {
         // An explicit BIG-IP language id (`tcl-bigip`, advertised by the VS
         // Code extension, or the canonical `f5-bigip`) selects the BIG-IP
         // config dialect even when the basename is not a canonical
@@ -3912,10 +3981,10 @@ impl Backend {
         {
             return d.to_owned();
         }
-        if let Some(d) = self.resolve_folder_dialect(uri).await {
+        if let Some(d) = folder_dialect_for(uri, folder_dialects) {
             return d;
         }
-        self.default_dialect.lock().await.clone()
+        default_dialect.to_owned()
     }
 
     /// Whether `dialect` denotes an F5 BIG-IP config document — the
@@ -4457,42 +4526,135 @@ impl Backend {
         }
     }
 
-    async fn reindex_index_from_disk(&self, uri: &Uri) {
-        // Read + analyse off-lock.  Keep the source text + dialect too: the salsa
-        // db (cross-file diagnostics) must track the same on-disk population as the
-        // workspace index, so a proc defined in a closed/never-opened file still
-        // suppresses W123 / drives the arity error in its siblings.
-        let scanned: Option<(String, String, AnalysisResult)> =
-            if let Some(path) = uri.to_file_path().map(std::borrow::Cow::into_owned) {
-                // Read the on-disk text off-lock first, then resolve the dialect
-                // from its content the way `did_open` would (#865): a BIG-IP
-                // config, an iRule, or a `# tcl-dialect:`-pinned file keeps its
-                // real dialect rather than defaulting to generic Tcl.  The salsa
-                // `file_analysis_incremental` base pass reads the dialect from the
-                // stored `SourceFile`, so it must be right here — not just on the
-                // `publish_closed_file_diagnostics` lift path.
-                match tokio::task::spawn_blocking(move || std::fs::read_to_string(path).ok())
-                    .await
-                    .ok()
-                    .flatten()
-                {
-                    Some(text) => {
-                        let dialect = self.dialect_for_closed(uri, &text).await;
-                        let (a_text, a_dialect) = (text.clone(), dialect.clone());
-                        match tokio::task::spawn_blocking(move || {
-                            Analyser::new().analyse(&a_text, &a_dialect)
-                        })
-                        .await
-                        {
-                            Ok(analysis) => Some((text, dialect, analysis)),
-                            Err(_) => None,
-                        }
-                    }
-                    None => None,
+    /// Read `uri` from disk, resolve its dialect and run a full uncached
+    /// `Analyser::analyse`, all on one blocking-pool call.  Returns `None`
+    /// when the file no longer reads as one (deleted, or unreadable, since
+    /// the caller queued it) — the caller then routes it through the
+    /// tombstone retire path, exactly like a `DELETED` watched-file event.
+    /// Shared by [`Self::reindex_index_from_disk`] (the single-file path used
+    /// by `did_close` / `didRenameFiles`) and the watched-files batch
+    /// reindex (#1161), so both agree on exactly how a disk-backed file is
+    /// turned into an index/salsa entry.
+    async fn scan_disk_file(
+        uri: Uri,
+        folder_dialects: Arc<Vec<(Uri, String)>>,
+        default_dialect: Arc<String>,
+    ) -> Option<(Uri, String, String, AnalysisResult)> {
+        tokio::task::spawn_blocking(move || {
+            let path = uri.to_file_path()?;
+            let text = std::fs::read_to_string(&path).ok()?;
+            let dialect =
+                Self::dialect_for_closed_sync(&uri, &text, &folder_dialects, &default_dialect);
+            let analysis = Analyser::new().analyse(&text, &dialect);
+            Some((uri, text, dialect, analysis))
+        })
+        .await
+        .ok()
+        .flatten()
+    }
+
+    /// Batched counterpart of [`Self::reindex_index_from_disk`] for the
+    /// `did_change_watched_files` CREATED/CHANGED set (#1161): reads and
+    /// analyses every URI in `uris` across the bounded worker pool
+    /// [`run_bounded`] drives (shared with `scan_workspace_folders`, #1151),
+    /// then applies one batched `db_set_sources_batch` / `db_remove_sources_batch`
+    /// pair and one batched `workspace_index` mutation instead of
+    /// `uris.len()` sequential full analyses.
+    ///
+    /// Currency: `documents` is re-checked once, right before the batched
+    /// apply — the same guard [`Self::reindex_index_from_disk`] uses (closed
+    /// re-check under the lock, `RUST_ISSUE_098`) — so a `did_open` racing in
+    /// for one of the URIs mid-batch still wins for that URI: its scanned
+    /// copy is dropped rather than clobbering the live buffer, exactly as the
+    /// single-file path behaves for that same race. An entry that reads as
+    /// unreadable / no-longer-a-file (named by the event but gone by the time
+    /// its read landed) is folded into the same batched retire call a
+    /// `DELETED` entry uses, rather than a separate per-file `db_remove_source`.
+    async fn batch_reindex_from_disk(&self, uris: &[Uri]) {
+        if uris.is_empty() {
+            return;
+        }
+        let folder_dialects = Arc::new(self.folder_dialects.lock().await.clone());
+        let default_dialect = Arc::new(self.default_dialect.lock().await.clone());
+        let concurrency = std::thread::available_parallelism()
+            .map_or(4, std::num::NonZeroUsize::get)
+            .min(WORKSPACE_ANALYSIS_MAX_CONCURRENCY);
+        let futures: Vec<_> = uris
+            .iter()
+            .cloned()
+            .map(|uri| {
+                let folder_dialects = Arc::clone(&folder_dialects);
+                let default_dialect = Arc::clone(&default_dialect);
+                async move {
+                    let scanned =
+                        Self::scan_disk_file(uri.clone(), folder_dialects, default_dialect).await;
+                    Some((uri, scanned))
                 }
-            } else {
-                None
-            };
+            })
+            .collect();
+        let results = run_bounded(futures, concurrency).await;
+
+        // Hold `documents` across the still-closed re-check and both updates
+        // (the `documents` → db → `workspace_index` order established by
+        // `did_open`), matching the single-file path.
+        let docs = self.documents.lock().await;
+        let mut applied: Vec<(Uri, String, String, AnalysisResult)> = Vec::new();
+        let mut to_remove: Vec<Uri> = Vec::new();
+        for (uri, scanned) in results {
+            if docs.contains_key(&uri) {
+                continue;
+            }
+            match scanned {
+                Some((uri, text, dialect, analysis)) => {
+                    applied.push((uri, text, dialect, analysis));
+                }
+                None => to_remove.push(uri),
+            }
+        }
+        // Salsa db first (locks db → db_files → db_project, all *before* the
+        // workspace_index lock) to preserve the global lock order.
+        let db_entries: Vec<(Uri, String, String)> = applied
+            .iter()
+            .map(|(uri, text, dialect, _)| (uri.clone(), text.clone(), dialect.clone()))
+            .collect();
+        self.db_set_sources_batch(&db_entries).await;
+        self.db_remove_sources_batch(&to_remove).await;
+        {
+            let mut index = self.workspace_index.write().await;
+            for (uri, _, _, _) in &applied {
+                index.remove_document(uri.as_str());
+            }
+            for uri in &to_remove {
+                index.remove_document(uri.as_str());
+            }
+            for (uri, _, _, analysis) in &applied {
+                index.add_document(uri.as_str(), analysis);
+            }
+        }
+        drop(docs);
+        // Every applied/removed URI is now indexed standalone (or gone):
+        // invalidate its M9 applied-seed record so the next cross-document
+        // query re-applies the source-site views, matching the single-file
+        // path.
+        let mut seeds = self.rehomed_source_seeds.lock().await;
+        for (uri, _, _, _) in &applied {
+            seeds.remove(uri.as_str());
+        }
+        for uri in &to_remove {
+            seeds.remove(uri.as_str());
+        }
+    }
+
+    async fn reindex_index_from_disk(&self, uri: &Uri) {
+        // Read + analyse off-lock, on the same read-dialect-analyse helper the
+        // watched-files batch reindex uses (#1161).  Keep the source text +
+        // dialect too: the salsa db (cross-file diagnostics) must track the
+        // same on-disk population as the workspace index, so a proc defined in
+        // a closed/never-opened file still suppresses W123 / drives the arity
+        // error in its siblings.
+        let folder_dialects = Arc::new(self.folder_dialects.lock().await.clone());
+        let default_dialect = Arc::new(self.default_dialect.lock().await.clone());
+        let scanned = Self::scan_disk_file(uri.clone(), folder_dialects, default_dialect).await;
         // Hold `documents` across the still-closed re-check and both updates (the
         // `documents` → db → `workspace_index` order established by `did_open`) so a
         // concurrent `did_open` cannot open the buffer between them and have its
@@ -4504,7 +4666,7 @@ impl Backend {
         // Salsa db first (locks db → db_files → db_project, all *before* the
         // workspace_index lock) to preserve the global lock order.
         match &scanned {
-            Some((text, dialect, _)) => {
+            Some((_, text, dialect, _)) => {
                 self.db_set_source(uri, text.clone(), dialect.clone()).await;
             }
             // No readable on-disk copy (untitled / deleted) — drop it from the
@@ -4513,7 +4675,7 @@ impl Backend {
         }
         let mut index = self.workspace_index.write().await;
         index.remove_document(uri.as_str());
-        if let Some((_, _, analysis)) = &scanned {
+        if let Some((_, _, _, analysis)) = &scanned {
             index.add_document(uri.as_str(), analysis);
         }
         drop(index);
@@ -4604,6 +4766,20 @@ impl Backend {
     async fn dialect_for_closed(&self, uri: &Uri, text: &str) -> String {
         let language_id = tcl_registry::dialect_from_extension(uri.as_str()).unwrap_or("tcl");
         self.dialect_for_open(uri, language_id, text).await
+    }
+
+    /// Pure core of [`Self::dialect_for_closed`] — see
+    /// [`Self::dialect_for_open_sync`]. Lets the watched-files batch reindex
+    /// (#1161) resolve every changed file's dialect from one snapshot instead
+    /// of a `&self` lock round trip per file.
+    fn dialect_for_closed_sync(
+        uri: &Uri,
+        text: &str,
+        folder_dialects: &[(Uri, String)],
+        default_dialect: &str,
+    ) -> String {
+        let language_id = tcl_registry::dialect_from_extension(uri.as_str()).unwrap_or("tcl");
+        Self::dialect_for_open_sync(uri, language_id, text, folder_dialects, default_dialect)
     }
 
     /// Bump and return `uri`'s closed-file diagnostics generation (#865). Each
@@ -10541,15 +10717,15 @@ impl LanguageServer for Backend {
         // file, a deletion — must refresh the cross-document index so
         // definition / references / rename / call-hierarchy keep seeing the
         // project's true on-disk state between restarts.
-        let mut domain_changed = false;
         let mut config_changed = false;
-        // Closed files that already carry a badge (a pull-cache entry) and whose
-        // on-disk change must refresh (#865) or clear that badge.  Collected here
-        // and applied after the whole batch has updated the resolution domain, so
-        // each refresh analyses against the final on-disk state — never a
-        // half-applied one when several files change together.
-        let mut closed_badge_refresh: Vec<Uri> = Vec::new();
-        let mut closed_badge_clear: Vec<Uri> = Vec::new();
+        // Reduce to the *last* event per URI before partitioning: a batch can
+        // legitimately name the same path twice (a delete-and-recreate a
+        // branch switch or a rapid rename can coalesce into one
+        // `didChangeWatchedFiles` notification), and the serial per-file path
+        // this replaces applied each event as it arrived, so only the last
+        // one for a given URI survived. A HashMap insert naturally keeps that
+        // "last write wins" semantics without needing to preserve array order.
+        let mut last_kind: HashMap<Uri, FileChangeType> = HashMap::new();
         for change in params.changes {
             // A project `.tcl-lsp.ini` (or user `config.ini`) edit re-applies the
             // layered config — a live-reload for these files.
@@ -10557,37 +10733,71 @@ impl LanguageServer for Backend {
                 config_changed = true;
                 continue;
             }
+            last_kind.insert(change.uri, change.typ);
+        }
+        // Partition the (deduplicated) event set so the disk-backed work below
+        // runs once per kind — a parallel read+analyse and one batched
+        // index/db mutation — instead of once per file (#1161: a 500-file
+        // branch switch used to run 500 sequential full analyses, each with
+        // its own `documents.lock()` / pull-cache probe, here).
+        let mut deleted: Vec<Uri> = Vec::new();
+        let mut changed: Vec<Uri> = Vec::new();
+        for (uri, typ) in last_kind {
             // Files the editor has open are driven by did_open/did_change; their
             // unsaved buffer must not be clobbered by the on-disk copy.
-            // `reindex_index_from_disk` re-checks this under the lock as well.
-            if self.documents.lock().await.contains_key(&change.uri) {
+            // `batch_reindex_from_disk` re-checks this under the lock as well.
+            if self.documents.lock().await.contains_key(&uri) {
                 continue;
             }
-            // Only a file that already has a badge (was opened, so it has a
-            // pull-cache entry) has its diagnostics refreshed/cleared here — a
-            // never-opened file that changes on disk gains no surprise badge.
-            let had_badge = self.pull_diag_cache.lock().await.contains_key(&change.uri);
-            if change.typ == FileChangeType::DELETED {
-                self.workspace_index
-                    .write()
-                    .await
-                    .remove_document(change.uri.as_str());
-                // Drop it from the salsa `Project` too, so a deleted file's procs
-                // stop suppressing W123 / driving the arity error cross-file.
-                self.db_remove_source(&change.uri).await;
-                if had_badge {
-                    closed_badge_clear.push(change.uri.clone());
-                }
+            if typ == FileChangeType::DELETED {
+                deleted.push(uri);
             } else {
                 // CREATED or CHANGED: re-analyse from disk (a Tcl source file)
                 // or drop it if it no longer reads as one.
-                self.reindex_index_from_disk(&change.uri).await;
-                if had_badge {
-                    closed_badge_refresh.push(change.uri.clone());
+                changed.push(uri);
+            }
+        }
+        let domain_changed = !deleted.is_empty() || !changed.is_empty();
+
+        // Closed files that already carry a badge (a pull-cache entry) and whose
+        // on-disk change must refresh (#865) or clear that badge — computed once
+        // under one lock rather than once per file, and applied after the whole
+        // batch has updated the resolution domain, so each refresh analyses
+        // against the final on-disk state — never a half-applied one when
+        // several files change together.
+        let (closed_badge_clear, closed_badge_refresh): (Vec<Uri>, Vec<Uri>) = {
+            let cache = self.pull_diag_cache.lock().await;
+            (
+                deleted
+                    .iter()
+                    .filter(|uri| cache.contains_key(uri))
+                    .cloned()
+                    .collect(),
+                changed
+                    .iter()
+                    .filter(|uri| cache.contains_key(uri))
+                    .cloned()
+                    .collect(),
+            )
+        };
+
+        // DELETED: one batched index mutation, then one batched salsa retire —
+        // dropping each file's procs from the workspace index and the salsa
+        // `Project` so a deleted file stops suppressing W123 / driving the
+        // arity error cross-file.
+        if !deleted.is_empty() {
+            {
+                let mut index = self.workspace_index.write().await;
+                for uri in &deleted {
+                    index.remove_document(uri.as_str());
                 }
             }
-            domain_changed = true;
+            self.db_remove_sources_batch(&deleted).await;
         }
+        // CREATED / CHANGED: read + analyse every file across the bounded
+        // worker pool, then one batched index/db merge.
+        self.batch_reindex_from_disk(&changed).await;
+
         // Refresh/clear the badges of the closed files that changed on disk, now
         // the resolution domain has settled (#865).
         for uri in &closed_badge_clear {
@@ -20021,6 +20231,115 @@ mod tests {
             !backend.pull_diag_cache.lock().await.contains_key(&uri),
             "deleting a closed file must clear its badge",
         );
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// #1161: a single `did_change_watched_files` event batch carrying a
+    /// CREATED, a CHANGED and a DELETED file together must land on the same
+    /// end state the old one-file-at-a-time serial path produced — the
+    /// `workspace_index` and salsa db reflecting exactly the final on-disk
+    /// population, in one batched pass rather than three sequential full
+    /// analyses.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn watched_files_batch_applies_created_changed_and_deleted_together() {
+        let root = unique_scratch_dir("watched-batch");
+        let created_path = root.join("created.tcl");
+        let changed_path = root.join("changed.tcl");
+        let deleted_path = root.join("deleted.tcl");
+        std::fs::write(&created_path, "proc created_proc {} {}\n").unwrap();
+        std::fs::write(&changed_path, "proc changed_proc {} {}\n").unwrap();
+        std::fs::write(&deleted_path, "proc deleted_proc {} {}\n").unwrap();
+
+        let backend = test_backend();
+        let created_uri = Uri::from_file_path(&created_path).unwrap();
+        let changed_uri = Uri::from_file_path(&changed_path).unwrap();
+        let deleted_uri = Uri::from_file_path(&deleted_path).unwrap();
+
+        // Seed the pre-event state: `changed.tcl` and `deleted.tcl` are
+        // already indexed (as a prior scan would have left them) under their
+        // *old* content — `changed.tcl`'s on-disk copy above is already the
+        // new content, standing in for the edit the CHANGED event reports;
+        // `deleted.tcl`'s on-disk file is removed below before the event
+        // fires, standing in for the delete. `created.tcl` starts entirely
+        // unindexed.
+        for (uri, old_src) in [
+            (&changed_uri, "proc old_changed_proc {} {}\n"),
+            (&deleted_uri, "proc deleted_proc {} {}\n"),
+        ] {
+            backend
+                .db_set_source(uri, (*old_src).to_owned(), "tcl8.6".to_owned())
+                .await;
+            let mut analyser = Analyser::new();
+            let analysis = analyser.analyse(old_src, "tcl8.6").clone();
+            backend
+                .workspace_index
+                .write()
+                .await
+                .add_document(uri.as_str(), &analysis);
+        }
+        std::fs::remove_file(&deleted_path).unwrap();
+
+        backend
+            .did_change_watched_files(DidChangeWatchedFilesParams {
+                changes: vec![
+                    tower_lsp_server::ls_types::FileEvent {
+                        uri: created_uri.clone(),
+                        typ: FileChangeType::CREATED,
+                    },
+                    tower_lsp_server::ls_types::FileEvent {
+                        uri: changed_uri.clone(),
+                        typ: FileChangeType::CHANGED,
+                    },
+                    tower_lsp_server::ls_types::FileEvent {
+                        uri: deleted_uri.clone(),
+                        typ: FileChangeType::DELETED,
+                    },
+                ],
+            })
+            .await;
+
+        let index = backend.workspace_index.read().await;
+        assert!(
+            !index
+                .proc_definitions("created_proc", "created_proc")
+                .is_empty(),
+            "the CREATED file must be indexed",
+        );
+        assert!(
+            !index
+                .proc_definitions("changed_proc", "changed_proc")
+                .is_empty(),
+            "the CHANGED file's new content must be indexed",
+        );
+        assert!(
+            index
+                .proc_definitions("old_changed_proc", "old_changed_proc")
+                .is_empty(),
+            "the CHANGED file's stale content must not survive the batch",
+        );
+        assert!(
+            index
+                .proc_definitions("deleted_proc", "deleted_proc")
+                .is_empty(),
+            "the DELETED file must be dropped from the index",
+        );
+        drop(index);
+
+        let files = backend.db_files.lock().await;
+        assert!(
+            files.contains_key(&created_uri),
+            "the CREATED file must gain a salsa SourceFile input",
+        );
+        assert!(
+            files.contains_key(&changed_uri),
+            "the CHANGED file keeps its salsa SourceFile input",
+        );
+        assert!(
+            !files.contains_key(&deleted_uri),
+            "the DELETED file's salsa SourceFile input must be retired",
+        );
+        drop(files);
+
         std::fs::remove_dir_all(&root).ok();
     }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -14600,12 +14600,22 @@ const DIALECT_HINT_LINE_MARGIN: u32 = 20;
 ///
 /// A conservative superset, not an exact replay of the detector: `true` when
 /// the edit touches the leading [`DIALECT_HINT_LINE_MARGIN`] lines (covers the
-/// directive/shebang tiers with margin), or when either the removed or
-/// inserted text contains one of the substrings
+/// directive/shebang tiers with margin), or when the **whole lines** the edit
+/// touches — before *and* after the splice — contain one of the substrings
 /// [`tcl_registry::dialects::dialect_hint_markers`] lists (covers the
 /// content-signature / version-guard tiers, wherever in the document they
 /// land). A `None` range (a full-document replacement) always returns `true`
 /// — there is no local edit to reason about.
+///
+/// Widening to line boundaries is what makes the marker test sound.
+/// [`tcl_registry::dialects::detect_dialect`] scans the *whole* source for
+/// those tiers (head first, then the full text on a miss), so a marker at line
+/// 500 counts — and a one-character edit *inside* such a line changes what the
+/// detector returns while the changed slice itself holds no marker at all.
+/// Editing the `6` of `package require Tcl 8.6` is the canonical case: the
+/// removed and inserted slices are both a single digit. Reading the touched
+/// lines instead costs those lines, not the document, and the persisted
+/// [`tcl_lexer::LineIndex`] gives their bounds without a scan.
 fn change_could_affect_dialect_hint(
     text: &str,
     range: Option<Range>,
@@ -14618,23 +14628,39 @@ fn change_could_affect_dialect_hint(
     if range.start.line < DIALECT_HINT_LINE_MARGIN {
         return true;
     }
-    if contains_dialect_hint_marker(new_text) {
+    let len = text.len();
+    let offset = |line: u32, character: u32| {
+        index.offset_at_utf16(line, tcl_lexer::Utf16Col::new(character), text) as usize
+    };
+    let (first_line, last_line) = (
+        range.start.line.min(range.end.line),
+        range.start.line.max(range.end.line),
+    );
+    // The touched lines in full, in the pre-edit text: `[line_start(first) ..
+    // line_start(last + 1))`, clamped for the last line of the document.
+    let line_from = offset(first_line, 0).min(len);
+    let line_to = if (last_line as usize) + 1 < index.line_count() {
+        offset(last_line + 1, 0).min(len)
+    } else {
+        len
+    };
+    let touched = &text[line_from..line_to.max(line_from)];
+    if contains_dialect_hint_marker(touched) {
         return true;
     }
-    let a = index.offset_at_utf16(
-        range.start.line,
-        tcl_lexer::Utf16Col::new(range.start.character),
-        text,
-    ) as usize;
-    let b = index.offset_at_utf16(
-        range.end.line,
-        tcl_lexer::Utf16Col::new(range.end.character),
-        text,
-    ) as usize;
-    let len = text.len();
-    let start = a.min(b).min(len);
-    let end = a.max(b).min(len);
-    contains_dialect_hint_marker(&text[start..end])
+    // The same lines as the splice leaves them: everything before the edit on
+    // the first touched line, the inserted text, everything after the edit on
+    // the last one. Built rather than tested piecewise so a marker straddling
+    // the splice point is still seen.
+    let a = offset(range.start.line, range.start.character).min(len);
+    let b = offset(range.end.line, range.end.character).min(len);
+    let (cut_from, cut_to) = (a.min(b), a.max(b));
+    let mut spliced =
+        String::with_capacity((cut_from - line_from) + new_text.len() + (line_to - cut_to));
+    spliced.push_str(&text[line_from..cut_from]);
+    spliced.push_str(new_text);
+    spliced.push_str(&text[cut_to..line_to.max(cut_to)]);
+    contains_dialect_hint_marker(&spliced)
 }
 
 /// Whether `s` contains any of [`tcl_registry::dialects::dialect_hint_markers`].
@@ -18170,6 +18196,93 @@ mod tests {
             "puts hi\n",
             &index
         ));
+    }
+
+    /// PR #1179 review (Codex P1): the marker test must widen the edit to the
+    /// **lines** it touches, not just the changed slice.
+    ///
+    /// `detect_dialect` scans the whole source for the version-guard and
+    /// content-signature tiers, so a `package require Tcl 8.6` at line 500 is
+    /// live — and retyping its version digit changes what the detector
+    /// returns while the removed and inserted slices are both a bare digit
+    /// holding no marker at all.  The gate must re-trigger on that, and still
+    /// not on an edit to an ordinary line at the same depth.
+    #[test]
+    fn dialect_hint_gate_catches_an_edit_inside_a_deep_marker_line() {
+        use std::fmt::Write as _;
+        let mut body = String::from("# an ordinary Tcl script\n");
+        for i in 0..500 {
+            writeln!(body, "puts {i}").unwrap();
+        }
+        // Line 501 (0-based) carries a live version guard, far past the
+        // leading-lines margin.
+        let guard_line = u32::try_from(body.lines().count()).unwrap();
+        body.push_str("package require Tcl 8.6\n");
+        writeln!(body, "puts done").unwrap();
+        let index = tcl_lexer::LineIndex::new_lsp(&body);
+        // Retype the minor version: `8.6` → `8.4`. The slice on both sides of
+        // the splice is one digit.
+        let digit = u32::try_from("package require Tcl 8.".len()).unwrap();
+        let version_edit = Range {
+            start: pos(guard_line, digit),
+            end: pos(guard_line, digit + 1),
+        };
+        assert!(
+            change_could_affect_dialect_hint(&body, Some(version_edit), "4", &index),
+            "a version-digit edit inside a deep `package require` line must re-trigger detection"
+        );
+        // Deleting the digit (no inserted text at all) is the same case.
+        assert!(
+            change_could_affect_dialect_hint(&body, Some(version_edit), "", &index),
+            "deleting inside the marker line must re-trigger detection too"
+        );
+        // The plain line right after it, at the same depth, still does not.
+        let plain_edit = Range {
+            start: pos(guard_line + 1, 5),
+            end: pos(guard_line + 1, 6),
+        };
+        assert!(
+            !change_could_affect_dialect_hint(&body, Some(plain_edit), "x", &index),
+            "an edit to an ordinary deep line must still skip the rescan"
+        );
+        // A marker typed one character at a time is caught the moment the
+        // spliced line first spells one out, even though no single keystroke
+        // ever carries the whole marker.
+        let partial_line = u32::try_from(body.lines().count()).unwrap();
+        body.push_str("packag\n");
+        let index = tcl_lexer::LineIndex::new_lsp(&body);
+        let finish_marker = Range {
+            start: pos(partial_line, 6),
+            end: pos(partial_line, 6),
+        };
+        assert!(
+            change_could_affect_dialect_hint(&body, Some(finish_marker), "e", &index),
+            "the keystroke that completes a marker on the line must re-trigger detection"
+        );
+    }
+
+    /// The pre-edit half of the widened test: **removing** a marker matters as
+    /// much as adding one.  Deleting the `package require Tcl 8.4` line from
+    /// deep in a document changes the detected dialect back to the default,
+    /// and the deleted slice is the only place that marker still appears.
+    #[test]
+    fn dialect_hint_gate_catches_deleting_a_deep_marker_line() {
+        use std::fmt::Write as _;
+        let mut body = String::from("# an ordinary Tcl script\n");
+        for i in 0..500 {
+            writeln!(body, "puts {i}").unwrap();
+        }
+        let guard_line = u32::try_from(body.lines().count()).unwrap();
+        body.push_str("package require Tcl 8.4\n");
+        let index = tcl_lexer::LineIndex::new_lsp(&body);
+        let delete_line = Range {
+            start: pos(guard_line, 0),
+            end: pos(guard_line + 1, 0),
+        };
+        assert!(
+            change_could_affect_dialect_hint(&body, Some(delete_line), "", &index),
+            "deleting the whole marker line must re-trigger detection"
+        );
     }
 
     /// The source-style pass must reach the

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -395,15 +395,20 @@ struct SemanticTokensRefreshCtx {
     client: Client,
     last_semantic_tokens: SemanticTokensCache,
     refresh_pending: Arc<std::sync::atomic::AtomicBool>,
+    refresh_asked: EnrichedRefreshAsked,
 }
 
 /// URIs whose detached semantic-token convergence continuation is still in
-/// flight (#1147) — the dedup set behind [`ConvergenceGuard`].
+/// flight (#1147) — the dedup map behind [`ConvergenceGuard`].
 ///
-/// A `std::sync::Mutex`: every critical section is a single `HashSet` insert or
-/// remove, never held across an await, and the remove has to happen from
+/// The value records whether any later request was **coalesced** onto that
+/// claim, so the claim holder knows it is answering for more than itself (see
+/// [`ConvergenceGuard::release`]).
+///
+/// A `std::sync::Mutex`: every critical section is a single map insert, lookup,
+/// or remove, never held across an await, and the remove has to happen from
 /// [`ConvergenceGuard`]'s `Drop`, which cannot await.
-type ConvergenceInFlight = Arc<std::sync::Mutex<HashSet<Uri>>>;
+type ConvergenceInFlight = Arc<std::sync::Mutex<HashMap<Uri, bool>>>;
 
 /// A claim on one URI's convergence continuation: at most one may be detached
 /// per document at a time (#1147).
@@ -429,27 +434,65 @@ type ConvergenceInFlight = Arc<std::sync::Mutex<HashSet<Uri>>>;
 struct ConvergenceGuard {
     uri: Uri,
     in_flight: ConvergenceInFlight,
+    /// Set by [`Self::release`], so `Drop` does not remove an entry a *later*
+    /// claim has since installed for the same URI.
+    released: bool,
 }
 
 impl ConvergenceGuard {
     /// Claim `uri`, or `None` when a continuation for it is already pending — in
-    /// which case the caller skips detaching and settles as `coalesced`.
+    /// which case the caller skips detaching and settles as `coalesced`, and
+    /// the pending claim is marked as now answering for that request too.
     fn claim(in_flight: &ConvergenceInFlight, uri: &Uri) -> Option<Self> {
-        let claimed = in_flight
+        let mut in_flight_map = in_flight
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .insert(uri.clone());
-        claimed.then(|| Self {
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(coalesced) = in_flight_map.get_mut(uri) {
+            *coalesced = true;
+            return None;
+        }
+        in_flight_map.insert(uri.clone(), false);
+        drop(in_flight_map);
+        Some(Self {
             uri: uri.clone(),
             in_flight: Arc::clone(in_flight),
+            released: false,
         })
+    }
+
+    /// Release the claim, reporting whether any request was coalesced onto it
+    /// while it was held (PR #1179 review, Codex P2).
+    ///
+    /// A coalesced request skips its own continuation on the strength of this
+    /// one's refresh — but this one only refreshes when *its own* comparison
+    /// found a difference.  When the claim holder's viewport happened to match
+    /// the coarse tier (or its reads were cancelled outright) while a skipped
+    /// viewport would have differed, the skipped one stays coarse until
+    /// something unrelated re-requests it.  Reading the flag as part of the
+    /// same critical section that removes the entry is what makes acting on it
+    /// sound: a request arriving after this returns finds no claim and takes
+    /// out a fresh one rather than being silently dropped into a claim that is
+    /// already gone.
+    fn release(&mut self) -> bool {
+        if self.released {
+            return false;
+        }
+        self.released = true;
+        self.in_flight
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(&self.uri)
+            .unwrap_or(false)
     }
 }
 
 impl Drop for ConvergenceGuard {
     fn drop(&mut self) {
+        if self.released {
+            return;
+        }
         // Recovering from a poisoned lock rather than skipping the removal: the
-        // set holds no invariant a panic could have broken, and leaving a marker
+        // map holds no invariant a panic could have broken, and leaving a marker
         // behind would permanently silence this URI's convergence.
         self.in_flight
             .lock()
@@ -457,6 +500,62 @@ impl Drop for ConvergenceGuard {
             .remove(&self.uri);
     }
 }
+
+/// Digest of an enriched token stream, for the repeat-ask bound (see
+/// [`EnrichedRefreshAsked`]).  A hash rather than the stream itself: the value
+/// is only ever compared for equality, and a token stream is one `u32` per
+/// five per token — far too much to retain per open document just to notice a
+/// repeat.
+fn enriched_token_digest(data: &[u32]) -> u64 {
+    use std::hash::{Hash as _, Hasher as _};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    data.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Release `guard` and, when the continuation is finishing **without** having
+/// asked for a refresh but requests were coalesced onto its claim, ask for one
+/// anyway.  Returns what the settled marker should record as `refresh=`.
+///
+/// Shared by the `range` and `full` continuations because the stranding is the
+/// same on both: they claim from one set precisely because either one's
+/// workspace-scoped `workspace/semanticTokens/refresh` covers the other's
+/// skipped requests, which only holds if the claim holder actually fires one.
+fn refresh_if_coalesced(
+    refresh_ctx: &SemanticTokensRefreshCtx,
+    guard: &mut ConvergenceGuard,
+    refreshed: bool,
+) -> bool {
+    let coalesced = guard.release();
+    if refreshed || !coalesced {
+        return refreshed;
+    }
+    refresh_ctx.request_refresh_coalesced();
+    true
+}
+
+/// Per-URI hash of the enriched token stream a convergence continuation has
+/// already asked the client to re-pull (PR #1179 review).
+///
+/// The termination bound on the converge → refresh → re-request cycle.  A
+/// request that overruns [`SEMANTIC_TOKENS_FAST_PATH_BUDGET`] serves the coarse
+/// tier and caches *that* as the URI's last stream, so the continuation's
+/// enriched result differs from the cache and asks for a refresh.  The client
+/// re-requests — and if that request also overruns the budget (a loaded
+/// machine misses it even on a warm memo, since the budget races
+/// `spawn_blocking` dispatch and the `db` lock), the coarse tier is served and
+/// cached again, and the identical enriched stream asks for the identical
+/// refresh.  Nothing broke the cycle: the server kept firing a workspace-wide
+/// `workspace/semanticTokens/refresh` every debounce window, which cancels and
+/// re-issues the editor's in-flight token request forever.  Recording the
+/// stream we already asked about means a *repeat* ask for the same bytes is
+/// dropped: the client has been told, and telling it again cannot change the
+/// answer.  Any real change — an edit, a cross-file class landing — produces
+/// different enriched bytes and re-arms the ask.
+///
+/// Entries are dropped with the token cache on close / rename, so this is
+/// bounded by the open-document set.
+type EnrichedRefreshAsked = Arc<Mutex<HashMap<Uri, u64>>>;
 
 /// Per-URI cache of the last semantic-token stream served: `(resultId, packed
 /// integer data)`. Shared type alias for [`Backend::last_semantic_tokens`] and
@@ -518,10 +617,25 @@ impl SemanticTokensRefreshCtx {
             let cache = self.last_semantic_tokens.lock().await;
             cache.get(uri).is_none_or(|(_, cached)| cached != data)
         };
-        if changed {
-            self.request_refresh_coalesced();
+        changed && self.request_refresh_for_enriched(uri, data).await
+    }
+
+    /// Ask the client to re-pull tokens because `uri`'s enriched stream
+    /// differs from what was served — **once** per distinct enriched stream
+    /// (see [`EnrichedRefreshAsked`]).  Returns whether an ask was actually
+    /// made, so the settled marker records what happened rather than what was
+    /// wanted.
+    async fn request_refresh_for_enriched(&self, uri: &Uri, data: &[u32]) -> bool {
+        let digest = enriched_token_digest(data);
+        {
+            let mut asked = self.refresh_asked.lock().await;
+            if asked.get(uri) == Some(&digest) {
+                return false;
+            }
+            asked.insert(uri.clone(), digest);
         }
-        changed
+        self.request_refresh_coalesced();
+        true
     }
 
     /// Emit the `full` convergence continuation's settled marker.
@@ -2888,6 +3002,10 @@ pub struct Backend {
     /// [`Backend::semantic_tokens_core_data`]) can compare the enriched result
     /// it lands against what was last served, without borrowing `Backend`.
     last_semantic_tokens: SemanticTokensCache,
+    /// Per-URI hash of the enriched token stream a convergence continuation has
+    /// already asked the client to re-pull — the termination bound on the
+    /// converge → refresh → re-request cycle.  See [`EnrichedRefreshAsked`].
+    semantic_tokens_refresh_asked: EnrichedRefreshAsked,
     /// Per-URI memo of [`Backend::analyse_with_workspace_classes`] — the
     /// analysis that resolves a cross-file constructor (`set d [::other::Cls
     /// new]`) by feeding the workspace class set to instance inference.
@@ -3485,9 +3603,10 @@ impl Backend {
             closed_diag_order: Arc::new(Mutex::new(VecDeque::new())),
             client_supports_pull_diagnostics: std::sync::atomic::AtomicBool::new(false),
             last_semantic_tokens: Arc::new(Mutex::new(HashMap::new())),
+            semantic_tokens_refresh_asked: Arc::new(Mutex::new(HashMap::new())),
             workspace_class_analyses: Arc::new(Mutex::new(HashMap::new())),
             semantic_tokens_refresh_pending: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            semantic_tokens_convergence: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            semantic_tokens_convergence: Arc::new(std::sync::Mutex::new(HashMap::new())),
             warm_task: std::sync::Mutex::new(None),
             edit_order: EditOrder::default(),
         }
@@ -4634,8 +4753,10 @@ impl Backend {
             client: self.client.clone(),
             last_semantic_tokens: Arc::clone(&self.last_semantic_tokens),
             refresh_pending: Arc::clone(&self.semantic_tokens_refresh_pending),
+            refresh_asked: Arc::clone(&self.semantic_tokens_refresh_asked),
         };
         let uri = uri.clone();
+        let mut guard = guard;
         tokio::spawn(async move {
             // Settle either way — including on a cancelled read — so a waiter can
             // key on the marker instead of racing the debounced refresh that only
@@ -4647,12 +4768,16 @@ impl Backend {
                 ),
                 _ => (false, FullSettleOutcome::Cancelled),
             };
+            // Release the per-URI claim only now the decision is made, so every
+            // request that arrived while this ran rode along with it — and honour
+            // what rode along: a request skipped as `coalesced` has no refresh of
+            // its own, so if this one decided against refreshing (its own read
+            // matched the cache, or was cancelled) the coalesced ones would be
+            // stranded.  The refresh is workspace-scoped, so one covers them all.
+            let refreshed = refresh_if_coalesced(&refresh_ctx, &mut guard, refreshed);
             refresh_ctx
                 .log_full_convergence_settled(&uri, refreshed, outcome)
                 .await;
-            // Release the per-URI claim only now the decision is made, so every
-            // request that arrived while this ran rode along with it.
-            drop(guard);
         });
     }
 
@@ -5033,6 +5158,7 @@ impl Backend {
             .remove_document(uri.as_str());
         self.db_remove_source(uri).await;
         self.last_semantic_tokens.lock().await.remove(uri);
+        self.semantic_tokens_refresh_asked.lock().await.remove(uri);
         self.workspace_class_analyses.lock().await.remove(uri);
         self.evict_diag_slot(uri).await;
         // Publishes the empty set and drops the pull-cache + closed-generation
@@ -10353,10 +10479,15 @@ impl Backend {
             range,
         } = inputs;
         let (cu_slot, analysis_slot, cu_handle, analysis_handle) = pending;
+        let mut guard = guard;
+        // `uri` here is the log-line string; the claim carries the typed URI the
+        // repeat-ask bound is keyed by.
+        let claim_uri = guard.uri.clone();
         let refresh_ctx = SemanticTokensRefreshCtx {
             client: self.client.clone(),
             last_semantic_tokens: Arc::clone(&self.last_semantic_tokens),
             refresh_pending: Arc::clone(&self.semantic_tokens_refresh_pending),
+            refresh_asked: Arc::clone(&self.semantic_tokens_refresh_asked),
         };
         tokio::spawn(async move {
             // Reuse a result that already landed within the budget; otherwise await
@@ -10391,9 +10522,14 @@ impl Backend {
                 })
                 .await;
                 match enriched {
+                    // Same repeat-ask bound as the `full` path
+                    // ([`EnrichedRefreshAsked`]): a viewport whose enriched
+                    // recompute keeps landing identical must not keep asking
+                    // the client to re-pull the tokens it already asked for.
                     Ok(enriched) if enriched != served => {
-                        refresh_ctx.request_refresh_coalesced();
-                        true
+                        refresh_ctx
+                            .request_refresh_for_enriched(&claim_uri, &enriched)
+                            .await
                     }
                     _ => false,
                 }
@@ -10410,10 +10546,15 @@ impl Backend {
             } else {
                 RangeSettleOutcome::Compared
             };
-            log_range_convergence_settled(&refresh_ctx.client, &uri, refreshed, outcome).await;
             // Release the per-URI claim only now the decision is made, so every
-            // viewport request that arrived while this ran rode along with it.
-            drop(guard);
+            // viewport request that arrived while this ran rode along with it —
+            // and honour what rode along: a viewport skipped as `coalesced` has
+            // no continuation of its own, so if this one's comparison found no
+            // difference (or its reads were cancelled) the skipped viewports
+            // would stay coarse until an unrelated re-request.  The refresh is
+            // workspace-scoped, so one covers every one of them.
+            let refreshed = refresh_if_coalesced(&refresh_ctx, &mut guard, refreshed);
+            log_range_convergence_settled(&refresh_ctx.client, &uri, refreshed, outcome).await;
         });
     }
 }
@@ -10872,6 +11013,7 @@ impl LanguageServer for Backend {
         // Drop the cached semantic-token baseline so a reopened document starts
         // from a fresh `full` rather than diffing against a stale stream.
         self.last_semantic_tokens.lock().await.remove(uri);
+        self.semantic_tokens_refresh_asked.lock().await.remove(uri);
         // The workspace-class analysis memo is keyed by URI; a closed
         // document's entry would otherwise linger for the process's life.
         self.workspace_class_analyses.lock().await.remove(uri);
@@ -19750,9 +19892,10 @@ mod tests {
             closed_diag_order: Arc::new(Mutex::new(VecDeque::new())),
             client_supports_pull_diagnostics: std::sync::atomic::AtomicBool::new(false),
             last_semantic_tokens: Arc::new(Mutex::new(HashMap::new())),
+            semantic_tokens_refresh_asked: Arc::new(Mutex::new(HashMap::new())),
             workspace_class_analyses: Arc::new(Mutex::new(HashMap::new())),
             semantic_tokens_refresh_pending: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            semantic_tokens_convergence: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            semantic_tokens_convergence: Arc::new(std::sync::Mutex::new(HashMap::new())),
             warm_task: std::sync::Mutex::new(None),
             edit_order: EditOrder::default(),
         }
@@ -25909,6 +26052,7 @@ mod tests {
             client: backend.client.clone(),
             last_semantic_tokens: Arc::clone(&backend.last_semantic_tokens),
             refresh_pending: Arc::clone(&backend.semantic_tokens_refresh_pending),
+            refresh_asked: Arc::clone(&backend.semantic_tokens_refresh_asked),
         };
 
         // No cache entry yet: "changed" (there is nothing to match), but still
@@ -25950,6 +26094,74 @@ mod tests {
         );
     }
 
+    /// PR #1179 review: the converge → refresh → re-request cycle must
+    /// terminate.
+    ///
+    /// A request that overruns the fast-path budget serves the coarse tier and
+    /// caches *that*, so the continuation's enriched stream differs and asks
+    /// for a refresh.  If the client's re-request also overruns the budget —
+    /// which a loaded machine does even on a warm memo — the coarse tier is
+    /// served and cached again, and the identical enriched stream asks for the
+    /// identical refresh.  Left unbounded the server fires a workspace-wide
+    /// `workspace/semanticTokens/refresh` every debounce window forever,
+    /// cancelling and re-issuing the editor's in-flight token request each
+    /// time, so a `provideDocumentSemanticTokens` call never settles.  The
+    /// second ask for the same enriched bytes must be dropped; a genuinely
+    /// different enriched stream must still get through.
+    #[tokio::test]
+    async fn a_repeated_identical_enriched_stream_asks_for_one_refresh_only() {
+        let backend = test_backend();
+        let uri = Uri::from_str("file:///storm.tcl").unwrap();
+        let other = Uri::from_str("file:///storm-other.tcl").unwrap();
+        let ctx = SemanticTokensRefreshCtx {
+            client: backend.client.clone(),
+            last_semantic_tokens: Arc::clone(&backend.last_semantic_tokens),
+            refresh_pending: Arc::clone(&backend.semantic_tokens_refresh_pending),
+            refresh_asked: Arc::clone(&backend.semantic_tokens_refresh_asked),
+        };
+        // Round 1: the coarse tier was served and cached; the enriched stream
+        // differs, so the client is asked to re-pull.
+        let coarse = ("coarse".to_owned(), vec![0, 0, 3, 1, 0]);
+        let enriched = vec![0, 0, 3, 7, 0];
+        backend
+            .last_semantic_tokens
+            .lock()
+            .await
+            .insert(uri.clone(), coarse.clone());
+        assert!(
+            ctx.deliver_if_changed(&uri, &enriched).await,
+            "the first enriched stream that differs must ask for a refresh",
+        );
+        // Round 2: the re-request overran the budget again, so the same coarse
+        // stream is cached and the same enriched stream lands. Asking again
+        // could only repeat what the client has already been told.
+        backend
+            .last_semantic_tokens
+            .lock()
+            .await
+            .insert(uri.clone(), coarse.clone());
+        assert!(
+            !ctx.deliver_if_changed(&uri, &enriched).await,
+            "a repeat ask for the identical enriched stream must be dropped",
+        );
+        // A genuinely different enriched stream (an edit landed, a cross-file
+        // class resolved) re-arms the ask.
+        assert!(
+            ctx.deliver_if_changed(&uri, &[0, 0, 3, 9, 0]).await,
+            "a changed enriched stream must ask again",
+        );
+        // The bound is per URI, not global.
+        backend
+            .last_semantic_tokens
+            .lock()
+            .await
+            .insert(other.clone(), coarse);
+        assert!(
+            ctx.deliver_if_changed(&other, &enriched).await,
+            "another document's identical stream must ask on its own account",
+        );
+    }
+
     /// A fire already scheduled must absorb a second request rather than
     /// scheduling a duplicate: the `workspace/semanticTokens/refresh`
     /// notification carries no data, so a client that receives it re-pulls
@@ -25965,6 +26177,7 @@ mod tests {
             client: backend.client.clone(),
             last_semantic_tokens: Arc::clone(&backend.last_semantic_tokens),
             refresh_pending: Arc::clone(&backend.semantic_tokens_refresh_pending),
+            refresh_asked: Arc::clone(&backend.semantic_tokens_refresh_asked),
         };
 
         // Simulate a fire already scheduled (e.g. by a different document's
@@ -26051,6 +26264,7 @@ mod tests {
             client: backend.client.clone(),
             last_semantic_tokens: Arc::clone(&backend.last_semantic_tokens),
             refresh_pending: Arc::clone(&backend.semantic_tokens_refresh_pending),
+            refresh_asked: Arc::clone(&backend.semantic_tokens_refresh_asked),
         };
         ctx.deliver_if_changed(&uri, &[9, 9, 9]).await;
         assert!(
@@ -26078,7 +26292,7 @@ mod tests {
     /// independent.
     #[test]
     fn convergence_guard_admits_one_continuation_per_uri() {
-        let in_flight: ConvergenceInFlight = Arc::new(std::sync::Mutex::new(HashSet::new()));
+        let in_flight: ConvergenceInFlight = Arc::new(std::sync::Mutex::new(HashMap::new()));
         let uri = Uri::from_str("file:///cold.tcl").unwrap();
         let other = Uri::from_str("file:///warm.tcl").unwrap();
 
@@ -26106,12 +26320,98 @@ mod tests {
         );
     }
 
+    /// PR #1179 review (Codex P2): a claim reports whether anything was
+    /// coalesced onto it, and `refresh_if_coalesced` turns that into a refresh
+    /// exactly when the claim holder itself decided against one.
+    ///
+    /// Without this a skipped viewport is stranded: it detached no
+    /// continuation of its own on the strength of this claim's refresh, but
+    /// the claim only refreshes when *its* comparison found a difference.
+    #[tokio::test]
+    async fn coalesced_claim_refreshes_even_when_the_holder_found_no_difference() {
+        let backend = test_backend();
+        let refresh_ctx = SemanticTokensRefreshCtx {
+            client: backend.client.clone(),
+            last_semantic_tokens: Arc::clone(&backend.last_semantic_tokens),
+            refresh_pending: Arc::clone(&backend.semantic_tokens_refresh_pending),
+            refresh_asked: Arc::clone(&backend.semantic_tokens_refresh_asked),
+        };
+        let in_flight: ConvergenceInFlight = Arc::new(std::sync::Mutex::new(HashMap::new()));
+        let uri = Uri::from_str("file:///coalesced.tcl").unwrap();
+
+        // Nothing coalesced, no difference found: today's behaviour — no refresh.
+        let mut lone = ConvergenceGuard::claim(&in_flight, &uri).expect("claimed");
+        assert!(
+            !refresh_if_coalesced(&refresh_ctx, &mut lone, false),
+            "a solitary claim that found no difference must not refresh",
+        );
+        assert!(
+            !backend
+                .semantic_tokens_refresh_pending
+                .load(std::sync::atomic::Ordering::Acquire),
+            "no refresh may have been scheduled",
+        );
+
+        // A viewport coalesced onto the claim, and the holder still found no
+        // difference: the coalesced one would otherwise stay coarse forever.
+        let mut held = ConvergenceGuard::claim(&in_flight, &uri).expect("re-claimed after release");
+        assert!(
+            ConvergenceGuard::claim(&in_flight, &uri).is_none(),
+            "the second request coalesces onto the held claim",
+        );
+        assert!(
+            refresh_if_coalesced(&refresh_ctx, &mut held, false),
+            "a coalesced claim must refresh on behalf of the requests it absorbed",
+        );
+        assert!(
+            backend
+                .semantic_tokens_refresh_pending
+                .load(std::sync::atomic::Ordering::Acquire),
+            "the coalesced refresh must actually have been scheduled",
+        );
+        assert!(
+            in_flight
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .is_empty(),
+            "releasing must drop the claim so the next request converges normally",
+        );
+    }
+
+    /// The cancelled/error arm of the same rule: the claim holder's reads dying
+    /// must not swallow the coalesced requests' only chance at a refresh.
+    #[test]
+    fn a_released_claims_coalesced_flag_survives_a_cancelled_holder() {
+        let in_flight: ConvergenceInFlight = Arc::new(std::sync::Mutex::new(HashMap::new()));
+        let uri = Uri::from_str("file:///cancelled.tcl").unwrap();
+        let mut held = ConvergenceGuard::claim(&in_flight, &uri).expect("claimed");
+        assert!(ConvergenceGuard::claim(&in_flight, &uri).is_none());
+        assert!(ConvergenceGuard::claim(&in_flight, &uri).is_none());
+        assert!(
+            held.release(),
+            "two coalesced requests must be reported to the holder",
+        );
+        // Idempotent: a second release (or the guard's own `Drop`) must not
+        // report again, nor remove a claim a later request has since taken.
+        let later = ConvergenceGuard::claim(&in_flight, &uri).expect("re-claimed");
+        assert!(!held.release());
+        drop(held);
+        assert!(
+            in_flight
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .contains_key(&uri),
+            "the released guard must not evict the later claim",
+        );
+        drop(later);
+    }
+
     /// #1147: the claim is a guard, not a flag, so a continuation that is
     /// aborted mid-flight (or panics) still releases its URI — a stuck marker
     /// would silence convergence for that document for the session.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn convergence_guard_releases_on_cancellation() {
-        let in_flight: ConvergenceInFlight = Arc::new(std::sync::Mutex::new(HashSet::new()));
+        let in_flight: ConvergenceInFlight = Arc::new(std::sync::Mutex::new(HashMap::new()));
         let uri = Uri::from_str("file:///aborted.tcl").unwrap();
         let guard = ConvergenceGuard::claim(&in_flight, &uri).expect("claimed");
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -5439,36 +5439,61 @@ impl Backend {
     /// `Location`s, converting each span against the *target*
     /// document's source.  Targets whose document isn't in the
     /// store, or whose URI doesn't parse, are dropped.
+    ///
+    /// `targets` holds one entry per reference **site**, but many sites
+    /// share a URI (a heavily-`source`d proc can have hundreds of call sites
+    /// in a handful of files). Resolving per site used to call
+    /// [`Self::read_document`] — a full `DocumentState` clone, or a
+    /// `std::fs::read_to_string` for a closed file, plus an `edits_settled()`
+    /// wait — once per site; on 800 sites across 60 files that was 800 reads
+    /// for 60 documents' worth of real work (issue #1153). Read each unique
+    /// URI once instead, then look every site's span up against its
+    /// document's already-resolved `line_index`. `targets`' own order is
+    /// untouched (a document is read once, on its first site, but sites are
+    /// still emitted in their original relative order — some callers dedup
+    /// results and others (the code-lens click target, #991) rely on the
+    /// order matching `textDocument/references`'), so no caller needs to
+    /// change.
     async fn resolve_target_locations(
         &self,
         targets: Vec<(String, tcl_lexer::Span)>,
     ) -> Vec<Location> {
-        let mut locations = Vec::new();
-        for (target_uri, span) in targets {
-            let Ok(parsed) = Uri::from_str(&target_uri) else {
+        let mut docs: HashMap<&str, Option<(Uri, DocumentState)>> = HashMap::new();
+        for (target_uri, _) in &targets {
+            if docs.contains_key(target_uri.as_str()) {
                 continue;
+            }
+            let resolved = match Uri::from_str(target_uri) {
+                Ok(parsed) => self.read_document(&parsed).await.map(|doc| (parsed, doc)),
+                Err(_) => None,
             };
-            let Some(target_doc) = self.read_document(&parsed).await else {
-                continue;
-            };
-            let line_index = target_doc.line_index.clone();
-            let start = line_index.position_at_utf16(span.start(), &target_doc.text);
-            let end = line_index.position_at_utf16(span.end(), &target_doc.text);
-            locations.push(Location {
-                uri: parsed,
-                range: Range {
-                    start: Position {
-                        line: start.line,
-                        character: start.character.get(),
-                    },
-                    end: Position {
-                        line: end.line,
-                        character: end.character.get(),
-                    },
-                },
-            });
+            docs.insert(target_uri.as_str(), resolved);
         }
-        locations
+        targets
+            .iter()
+            .filter_map(|(target_uri, span)| {
+                let (uri, target_doc) = docs.get(target_uri.as_str())?.as_ref()?;
+                let start = target_doc
+                    .line_index
+                    .position_at_utf16(span.start(), &target_doc.text);
+                let end = target_doc
+                    .line_index
+                    .position_at_utf16(span.end(), &target_doc.text);
+                Some(Location {
+                    uri: uri.clone(),
+                    range: Range {
+                        start: Position {
+                            line: start.line,
+                            character: start.character.get(),
+                        },
+                        end: Position {
+                            line: end.line,
+                            character: end.character.get(),
+                        },
+                    },
+                })
+            })
+            .collect()
     }
 
     /// Resolve the proc / class symbol at `pos` (a bare command word, not a
@@ -22170,6 +22195,76 @@ mod tests {
             .write()
             .await
             .add_document(uri.as_str(), &analysis);
+    }
+
+    /// Issue #1153: `resolve_target_locations` now reads each unique target
+    /// URI once rather than once per site. Correctness check: several sites
+    /// interleaved across two documents must all resolve, each against the
+    /// *right* document's source, and the result must keep the exact input
+    /// order (some callers, e.g. the code-lens click target, rely on
+    /// `resolve_target_locations`'s order matching `textDocument/references`'
+    /// own).
+    #[tokio::test]
+    async fn resolve_target_locations_groups_by_uri_and_preserves_site_order() {
+        let backend = test_backend();
+        let a = Uri::from_str("file:///a.tcl").unwrap();
+        let b = Uri::from_str("file:///b.tcl").unwrap();
+        // a.tcl: "aaa\nbbb\nccc\n" — three one-word lines.
+        // b.tcl: "xxx\nyyy\n" — two one-word lines.
+        register(&backend, &a, "aaa\nbbb\nccc\n").await;
+        register(&backend, &b, "xxx\nyyy\n").await;
+        let span_at = |line_start_byte: u32, len: u32| {
+            tcl_lexer::Span::new(line_start_byte, line_start_byte + len)
+        };
+        // Interleaved: b, a, b, a, a — deliberately not grouped by URI, and
+        // not in either document's own line order, so a naive "sort by URI"
+        // implementation would be caught by the order assertion below.
+        let targets = vec![
+            (b.to_string(), span_at(4, 3)), // b.tcl line 1: "yyy"
+            (a.to_string(), span_at(8, 3)), // a.tcl line 2: "ccc"
+            (b.to_string(), span_at(0, 3)), // b.tcl line 0: "xxx"
+            (a.to_string(), span_at(0, 3)), // a.tcl line 0: "aaa"
+            (a.to_string(), span_at(4, 3)), // a.tcl line 1: "bbb"
+        ];
+        let locations = backend.resolve_target_locations(targets).await;
+        assert_eq!(locations.len(), 5, "{locations:?}");
+        let got: Vec<(String, u32)> = locations
+            .iter()
+            .map(|l| (l.uri.to_string(), l.range.start.line))
+            .collect();
+        assert_eq!(
+            got,
+            vec![
+                (b.to_string(), 1),
+                (a.to_string(), 2),
+                (b.to_string(), 0),
+                (a.to_string(), 0),
+                (a.to_string(), 1),
+            ],
+            "grouping by URI must not reorder the result",
+        );
+    }
+
+    /// A target URI that fails to parse, or has no document, is dropped
+    /// (matching the pre-#1153 per-site behaviour) without disturbing the
+    /// other targets' resolution or order.
+    #[tokio::test]
+    async fn resolve_target_locations_drops_unresolvable_targets_and_keeps_the_rest() {
+        let backend = test_backend();
+        let a = Uri::from_str("file:///a.tcl").unwrap();
+        register(&backend, &a, "aaa\nbbb\n").await;
+        let targets = vec![
+            ("not a uri".to_owned(), tcl_lexer::Span::new(0, 3)),
+            (a.to_string(), tcl_lexer::Span::new(0, 3)),
+            (
+                "file:///never-opened-and-not-on-disk.tcl".to_owned(),
+                tcl_lexer::Span::new(0, 3),
+            ),
+            (a.to_string(), tcl_lexer::Span::new(4, 7)),
+        ];
+        let locations = backend.resolve_target_locations(targets).await;
+        let got: Vec<u32> = locations.iter().map(|l| l.range.start.line).collect();
+        assert_eq!(got, vec![0, 1], "{locations:?}");
     }
 
     #[tokio::test]

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -14806,8 +14806,16 @@ fn change_could_affect_dialect_hint(
 }
 
 /// Whether `s` contains any of [`tcl_registry::dialects::dialect_hint_markers`].
+///
+/// Case-insensitive to match the detector: the `tcl-dialect:` directive key is
+/// compared with `eq_ignore_ascii_case` and the content-signature tiers
+/// lowercase their words, so `# TCL-DIALECT: irules` is live to
+/// [`tcl_registry::dialects::detect_dialect`] and must not slip past this
+/// filter. The haystack is only an edit's touched lines, so the lowercase
+/// copy is a few bytes, not the document.
 fn contains_dialect_hint_marker(s: &str) -> bool {
-    tcl_registry::dialects::dialect_hint_markers().any(|m| s.contains(m))
+    let lower = s.to_ascii_lowercase();
+    tcl_registry::dialects::dialect_hint_markers().any(|m| lower.contains(m))
 }
 
 fn lift_span(source: &str, line_index: &tcl_lexer::LineIndex, span: tcl_lexer::Span) -> Range {
@@ -18404,6 +18412,45 @@ mod tests {
     }
 
     /// The pre-edit half of the widened test: **removing** a marker matters as
+    /// PR #1179 review (Copilot): the marker filter must be case-insensitive,
+    /// because the detector is.  The `tcl-dialect:` directive key is matched
+    /// with `eq_ignore_ascii_case` and the content-signature tiers lowercase
+    /// their words, so `# TCL-DIALECT: irules` typed deep in a document is
+    /// live to `detect_dialect` — a case-sensitive `contains` over the
+    /// lowercase marker list would skip the re-detect and strand the buffer
+    /// on its stale dialect.
+    #[test]
+    fn dialect_hint_gate_is_case_insensitive_like_the_detector() {
+        use std::fmt::Write as _;
+        let mut body = String::from("# an ordinary Tcl script\n");
+        for i in 0..500 {
+            writeln!(body, "puts {i}").unwrap();
+        }
+        let index = tcl_lexer::LineIndex::new_lsp(&body);
+        let deep_insert = Range {
+            start: pos(500, 0),
+            end: pos(500, 0),
+        };
+        assert!(
+            change_could_affect_dialect_hint(
+                &body,
+                Some(deep_insert),
+                "# TCL-DIALECT: irules\n",
+                &index
+            ),
+            "an upper-case directive is live to the detector and must re-trigger"
+        );
+        assert!(
+            change_could_affect_dialect_hint(
+                &body,
+                Some(deep_insert),
+                "PACKAGE REQUIRE Tcl 8.6\n",
+                &index
+            ),
+            "upper-case marker words must re-trigger like their lower-case forms"
+        );
+    }
+
     /// much as adding one.  Deleting the `package require Tcl 8.4` line from
     /// deep in a document changes the detected dialect back to the default,
     /// and the deleted slice is the only place that marker still appears.

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -1486,12 +1486,7 @@ fn spawn_diagnostics_worker(slots: Arc<Mutex<HashMap<Uri, DiagSlot>>>, uri: Uri)
             // semantic-token enrichment tier on a large document).
             // Handles for the post-publish evidence refresh below
             // (`run_diagnostics_core` consumes `inputs`).
-            let evidence_handles = (
-                Arc::clone(&inputs.db),
-                Arc::clone(&inputs.db_files),
-                Arc::clone(&inputs.db_project),
-                Arc::clone(&inputs.workspace_index),
-            );
+            let evidence_handles = EvidenceHandles::from_inputs(&inputs);
             // Capture + analyse the document's current state.  If it is gone
             // (closed) there is nothing to publish — retire, unless a `did_open`
             // re-armed the slot in the meantime, in which case keep draining
@@ -1527,34 +1522,42 @@ fn spawn_diagnostics_worker(slots: Arc<Mutex<HashMap<Uri, DiagSlot>>>, uri: Uri)
             // publish-then-enrich shape the semantic-token tiers use. Salsa
             // memoisation makes the second pass cheap apart from what the
             // evidence genuinely invalidated.
-            let (db, db_files, db_project, workspace_index) = evidence_handles;
-            let changed =
-                sync_cross_file_evidence(&db, &db_files, &db_project, &workspace_index).await;
-            // Re-analyse *this* document only when the refresh gave it evidence
-            // that can actually change its result: a non-empty table means some
-            // other file calls into it, which is what retracts a fold. Going
-            // from "no view" to an *empty* view leaves the merged evidence
-            // identical, so re-running would publish a byte-identical second
-            // result — and one publish per version is a contract
-            // (`diagnostics_delivery_smoke`, and the duplicate-diagnostics KCS
-            // note). Residual: an empty view also lifts a `LOADS_EXTERNAL_UNIT`
-            // decline, which can *add* a fold; not republishing leaves that as
-            // a missing hint until the next edit, the safe direction.
-            if changed.contains(&uri)
-                && has_external_callers(&db, &db_files, &uri).await
-                && let Some(slot) = slots.lock().await.get_mut(&uri)
-            {
-                slot.dirty = true;
-            }
-            // Republish every peer the refresh invalidated. Only documents
-            // that already have resolved inputs are eligible: a file nobody
-            // has analysed has no published diagnostics to go stale, and its
-            // inputs cannot be resolved from here anyway. This converges — the
-            // peer's own run re-syncs, finds nothing changed
-            // (compare-then-set), and reschedules nobody.
-            reschedule_peers(&slots, &uri, changed).await;
+            refresh_cross_file_evidence(&evidence_handles, &slots, &uri).await;
         }
     });
+}
+
+/// Refresh the project's cross-file call-site evidence after a worker pass
+/// published, then reschedule whatever the refresh invalidated.
+async fn refresh_cross_file_evidence(
+    handles: &EvidenceHandles,
+    slots: &Arc<Mutex<HashMap<Uri, DiagSlot>>>,
+    uri: &Uri,
+) {
+    let changed = sync_cross_file_evidence(handles).await;
+    // Re-analyse *this* document only when the refresh gave it evidence
+    // that can actually change its result: a non-empty table means some
+    // other file calls into it, which is what retracts a fold. Going
+    // from "no view" to an *empty* view leaves the merged evidence
+    // identical, so re-running would publish a byte-identical second
+    // result — and one publish per version is a contract
+    // (`diagnostics_delivery_smoke`, and the duplicate-diagnostics KCS
+    // note). Residual: an empty view also lifts a `LOADS_EXTERNAL_UNIT`
+    // decline, which can *add* a fold; not republishing leaves that as
+    // a missing hint until the next edit, the safe direction.
+    if changed.contains(uri)
+        && has_external_callers(&handles.db, &handles.db_files, uri).await
+        && let Some(slot) = slots.lock().await.get_mut(uri)
+    {
+        slot.dirty = true;
+    }
+    // Republish every peer the refresh invalidated. Only documents
+    // that already have resolved inputs are eligible: a file nobody
+    // has analysed has no published diagnostics to go stale, and its
+    // inputs cannot be resolved from here anyway. This converges — the
+    // peer's own run re-syncs, finds nothing changed
+    // (compare-then-set), and reschedules nobody.
+    reschedule_peers(slots, uri, changed).await;
 }
 
 /// Mark each peer dirty and start its worker if one is not already draining
@@ -1609,6 +1612,26 @@ async fn has_external_callers(
     })
 }
 
+/// The handles [`sync_cross_file_evidence`] needs, cloned off a [`DiagInputs`]
+/// before [`run_diagnostics_core`] consumes it.
+struct EvidenceHandles {
+    db: Arc<Mutex<tcl_lsp_db::TclDatabase>>,
+    db_files: Arc<Mutex<HashMap<Uri, tcl_lsp_db::SourceFile>>>,
+    db_project: Arc<Mutex<Option<tcl_lsp_db::Project>>>,
+    workspace_index: Arc<RwLock<core_workspace_index::WorkspaceIndex>>,
+}
+
+impl EvidenceHandles {
+    fn from_inputs(inputs: &DiagInputs) -> Self {
+        Self {
+            db: Arc::clone(&inputs.db),
+            db_files: Arc::clone(&inputs.db_files),
+            db_project: Arc::clone(&inputs.db_project),
+            workspace_index: Arc::clone(&inputs.workspace_index),
+        }
+    }
+}
+
 /// Refresh every project file's [`tcl_lsp_db::SourceFile::external_call_sites`]
 /// — the call sites in *other* files that reach the procedures it declares
 /// (issue #977) — and report the URIs whose evidence actually moved.
@@ -1630,57 +1653,116 @@ async fn has_external_callers(
 ///
 /// Salsa cancellation is caught and reported as "nothing changed": the edit
 /// that cancelled this pass drives its own refresh.
-async fn sync_cross_file_evidence(
-    db: &Mutex<tcl_lsp_db::TclDatabase>,
-    db_files: &Mutex<HashMap<Uri, tcl_lsp_db::SourceFile>>,
-    db_project: &Mutex<Option<tcl_lsp_db::Project>>,
-    workspace_index: &RwLock<core_workspace_index::WorkspaceIndex>,
-) -> Vec<Uri> {
+///
+/// **The project-wide read runs on a cloned salsa snapshot inside
+/// `spawn_blocking`** (issue #1148), so the `db` mutex — which every feature
+/// read path and every `db_set_source` contends on — is held only long enough
+/// to clone the handle, and again for the short write section at the end. Held
+/// across the read, as it used to be, one worker pass over a large workspace
+/// stalled hover, completion and the next keystroke's `set_text` for the whole
+/// scan. The snapshot shares salsa's memo storage with the live database, so
+/// the writes below still see everything the read computed.
+///
+/// **Not gated on `crossFileResolution`**, despite feeding a cross-file fact.
+/// That toggle gates `project_diagnostics` — cross-file W120/W123 suppression
+/// and cross-file arity. What this writes is consumed by
+/// `document_compilation_unit`'s interprocedural seed, which is *soundness*,
+/// not an opt-in refinement: without the project's call sites a library file
+/// folds on its own callers' literals and reports an I230 the workspace
+/// contradicts (issue #977). Skipping the pass when the toggle is off
+/// reinstates exactly that unsound fold —
+/// `caller_in_a_sourcing_file_with_a_differing_literal_clears_i230` in the e2e
+/// suite runs with `crossFileResolution` at its default (off) and fails
+/// immediately if this is gated on it.
+async fn sync_cross_file_evidence(handles: &EvidenceHandles) -> Vec<Uri> {
     use salsa::Setter as _;
     // Which files the host can honestly claim a closed world for, resolved
     // before taking the db locks (the index has its own).
-    let covered = files_with_covered_load_targets(db_files, workspace_index).await;
-    let mut db = db.lock().await;
-    let files = db_files.lock().await;
-    let project = db_project.lock().await;
-    let Some(&project) = project.as_ref() else {
-        return Vec::new();
+    let covered =
+        files_with_covered_load_targets(&handles.db_files, &handles.workspace_index).await;
+    let (snapshot, files, project) = {
+        let db = handles.db.lock().await;
+        let db_files = handles.db_files.lock().await;
+        let db_project = handles.db_project.lock().await;
+        let Some(&project) = db_project.as_ref() else {
+            return Vec::new();
+        };
+        let files: Vec<(Uri, tcl_lsp_db::SourceFile)> =
+            db_files.iter().map(|(u, &f)| (u.clone(), f)).collect();
+        (db.clone(), files, project)
     };
-    let snapshot: Vec<(Uri, tcl_lsp_db::SourceFile)> =
-        files.iter().map(|(u, &f)| (u.clone(), f)).collect();
     // `AssertUnwindSafe`: the closure only *reads* the database, and a
     // cancellation unwind discards the whole `pending` list without applying
     // anything, so no torn state can be observed afterwards.
-    let pending = salsa::Cancelled::catch(std::panic::AssertUnwindSafe(|| {
-        snapshot
-            .iter()
-            .filter_map(|(uri, file)| {
-                // A file whose `source` target the host never indexed has a
-                // caller the project cannot enumerate, so it gets **no**
-                // evidence: `None` keeps its `LOADS_EXTERNAL_UNIT` boundary
-                // closed rather than letting `Some(empty)` assert a closed
-                // world the scan cannot back (issue #977).
-                let want = covered
-                    .contains(uri)
-                    .then(|| tcl_lsp_db::file_external_call_sites(&*db, *file, project));
-                let unchanged = match (&want, file.external_call_sites(&*db)) {
-                    (Some(want), Some(have)) => **have == **want,
-                    (None, None) => true,
-                    _ => false,
-                };
-                (!unchanged).then(|| (uri.clone(), *file, want))
-            })
-            .collect::<Vec<_>>()
-    }));
-    let Ok(pending) = pending else {
+    let pending = tokio::task::spawn_blocking(move || {
+        salsa::Cancelled::catch(std::panic::AssertUnwindSafe(|| {
+            files
+                .into_iter()
+                .filter_map(|(uri, file)| {
+                    let want = wanted_call_site_evidence(&snapshot, &uri, file, project, &covered);
+                    let have = file.external_call_sites(&snapshot).as_ref();
+                    (!call_site_evidence_matches(have, want.as_ref())).then_some((uri, file, want))
+                })
+                .collect::<Vec<_>>()
+        }))
+        .ok()
+    })
+    .await;
+    let Ok(Some(pending)) = pending else {
         return Vec::new();
     };
+    // Short write section. The read ran off-lock, so re-run the comparison
+    // against the live database before writing: a concurrent worker's sync may
+    // already have applied the same value, and re-checking keeps the
+    // compare-then-set contract (an input that does not move invalidates
+    // nothing) rather than trusting a snapshot's view of it.
+    let mut db = handles.db.lock().await;
     let mut changed = Vec::with_capacity(pending.len());
     for (uri, file, want) in pending {
+        if call_site_evidence_matches(file.external_call_sites(&*db).as_ref(), want.as_ref()) {
+            continue;
+        }
         file.set_external_call_sites(&mut *db).to(want);
         changed.push(uri);
     }
     changed
+}
+
+/// The evidence `uri` should be carrying, or `None` when the host cannot claim
+/// a closed world over its callers.
+///
+/// A file whose `source` target the host never indexed has a caller the project
+/// cannot enumerate, so it gets **no** evidence: `None` keeps its
+/// `LOADS_EXTERNAL_UNIT` boundary closed rather than letting `Some(empty)`
+/// assert a closed world the scan cannot back (issue #977).
+fn wanted_call_site_evidence(
+    db: &tcl_lsp_db::TclDatabase,
+    uri: &Uri,
+    file: tcl_lsp_db::SourceFile,
+    project: tcl_lsp_db::Project,
+    covered: &HashSet<Uri>,
+) -> Option<Arc<tcl_compiler::unit_scope::CallSiteEvidence>> {
+    covered
+        .contains(uri)
+        .then(|| tcl_lsp_db::file_external_call_sites(db, file, project))
+}
+
+/// Whether a file's stored cross-file evidence already equals what the project
+/// says it should be — the compare half of the compare-then-set.
+///
+/// The pointer check is the steady-state fast path: `file_external_call_sites`
+/// hands back the *same* memoised `Arc` the previous sync stored whenever the
+/// query did not re-execute, so an unchanged project settles in one comparison
+/// per file instead of a deep set comparison per file (issue #1148).
+fn call_site_evidence_matches(
+    have: Option<&Arc<tcl_compiler::unit_scope::CallSiteEvidence>>,
+    want: Option<&Arc<tcl_compiler::unit_scope::CallSiteEvidence>>,
+) -> bool {
+    match (have, want) {
+        (Some(have), Some(want)) => Arc::ptr_eq(have, want) || **have == **want,
+        (None, None) => true,
+        _ => false,
+    }
 }
 
 /// The project files whose unit-loading boundaries the host can actually
@@ -19478,6 +19560,60 @@ mod tests {
                 "the project file set must hold exactly the one live input",
             );
         }
+    }
+
+    /// #1148: the project-wide evidence read now runs on a cloned salsa
+    /// snapshot off the `db` mutex, so the write section has to re-check
+    /// currency against the live database rather than trusting the snapshot's
+    /// view.  A second pass over an unchanged project must therefore write
+    /// nothing — no input moves, nothing downstream is invalidated, and no peer
+    /// is rescheduled — which is also what stops the worker/peer loop from
+    /// running forever.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cross_file_evidence_sync_settles_after_one_pass() {
+        let backend = test_backend();
+        let lib = Uri::from_str("file:///w/lib.tcl").unwrap();
+        let main = Uri::from_str("file:///w/main.tcl").unwrap();
+        backend
+            .db_set_source(
+                &lib,
+                "proc helper {mode} { return $mode }\n".to_owned(),
+                "tcl8.6".to_owned(),
+            )
+            .await;
+        backend
+            .db_set_source(&main, "helper dev\n".to_owned(), "tcl8.6".to_owned())
+            .await;
+        let handles = EvidenceHandles {
+            db: Arc::clone(&backend.db),
+            db_files: Arc::clone(&backend.db_files),
+            db_project: Arc::clone(&backend.db_project),
+            workspace_index: Arc::clone(&backend.workspace_index),
+        };
+
+        let first = sync_cross_file_evidence(&handles).await;
+        assert_eq!(
+            first.len(),
+            2,
+            "the cold pass gives both covered files a view: {first:?}"
+        );
+        let second = sync_cross_file_evidence(&handles).await;
+        assert!(
+            second.is_empty(),
+            "an unchanged project must write no input: {second:?}"
+        );
+
+        let db = backend.db.lock().await;
+        let files = backend.db_files.lock().await;
+        let evidence = files[&lib]
+            .external_call_sites(&*db)
+            .clone()
+            .expect("a covered file gets a view");
+        assert_eq!(
+            evidence.callees().collect::<Vec<_>>(),
+            vec!["::helper"],
+            "main.tcl's call reaches lib.tcl's proc"
+        );
     }
 
     /// #1145: a watched `DELETED` → `CREATED` pair — what a `git checkout` or

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -11646,55 +11646,88 @@ impl LanguageServer for Backend {
         {
             return Ok(None);
         }
-        // Walk every cached document and collect matching
-        // symbols.  This iterates the document
-        // store on the LSP loop (acquiring the mutex briefly).
-        let docs = self.documents.lock().await.clone();
-        if docs.is_empty() {
+        // Answered from the workspace index, not from the open-document map
+        // (#1156).  VS Code re-issues this request on every keystroke in its
+        // Ctrl+T box, and the previous handler cloned the whole document store
+        // — every buffer and its `LineIndex` — and then serially re-analysed
+        // each open document per keystroke, while missing every symbol in a
+        // file the editor had not opened.  The index already holds each of
+        // them, filters before materialising, and caps the answer.
+        //
+        // Freshness: the index is refreshed on each document's diagnostics
+        // publish, which the debounce puts ~50 ms behind an edit.  A symbol
+        // picker tolerates that — it is the same staleness every other
+        // cross-document feature answers with — and an open-but-not-yet-
+        // published buffer still contributes the symbols of its last publish
+        // (or of the folder scan), so nothing that used to be listed stops
+        // being listed.
+        let hits = {
+            let index = self.workspace_index.read().await;
+            index.symbols_matching(
+                &params.query,
+                core_workspace_symbols::MAX_WORKSPACE_SYMBOL_RESULTS,
+            )
+        };
+        if hits.is_empty() {
             return Ok(None);
         }
-        let query = params.query;
-        let mut all: Vec<SymbolInformation> = Vec::new();
-        for (uri, doc) in docs {
-            let text = doc.text.clone();
-            let dialect = doc.dialect.clone();
-            let q = query.clone();
-            let analysis = self.analysis_for(&uri, text.clone(), dialect.clone()).await;
-            let symbols = tokio::task::spawn_blocking(move || {
-                core_workspace_symbols::workspace_symbols(&text, &q, &analysis)
-            })
-            .await
-            .map_err(|err| jsonrpc::Error {
-                code: jsonrpc::ErrorCode::InternalError,
-                message: format!("workspace_symbols worker panicked: {err}").into(),
-                data: None,
-            })?;
-            for s in symbols {
-                #[allow(deprecated)]
-                all.push(SymbolInformation {
-                    name: s.name,
-                    kind: match s.kind {
-                        // A tcltest case has no dedicated LSP kind; it lists as
-                        // a function alongside real functions.
-                        CoreWorkspaceSymbolKind::Function | CoreWorkspaceSymbolKind::Test => {
-                            SymbolKind::FUNCTION
-                        }
-                        CoreWorkspaceSymbolKind::Class => SymbolKind::CLASS,
-                        CoreWorkspaceSymbolKind::Method => SymbolKind::METHOD,
-                        CoreWorkspaceSymbolKind::Constructor => SymbolKind::CONSTRUCTOR,
-                        CoreWorkspaceSymbolKind::Constant => SymbolKind::CONSTANT,
-                        CoreWorkspaceSymbolKind::Operator => SymbolKind::OPERATOR,
-                        CoreWorkspaceSymbolKind::Event => SymbolKind::EVENT,
-                    },
-                    tags: None,
-                    deprecated: None,
-                    location: Location {
-                        uri: uri.clone(),
-                        range: lift_lsp_range(s.range),
-                    },
-                    container_name: s.container_name,
-                });
+        // A name span becomes an LSP range only against its own document's
+        // source, which the index deliberately does not hold.  `hits` arrives
+        // grouped by URI, so each document is resolved once — from the open
+        // buffer when there is one, else from disk.
+        let mut sources: HashMap<String, Option<DocumentState>> = HashMap::new();
+        let mut all: Vec<SymbolInformation> = Vec::with_capacity(hits.len());
+        for hit in hits {
+            if !sources.contains_key(&hit.uri) {
+                let loaded = match Uri::from_str(&hit.uri) {
+                    Ok(uri) => self.read_document(&uri).await,
+                    Err(_) => None,
+                };
+                sources.insert(hit.uri.clone(), loaded);
             }
+            let (Some(Some(doc)), Ok(uri)) = (sources.get(&hit.uri), Uri::from_str(&hit.uri))
+            else {
+                continue;
+            };
+            let start = doc
+                .line_index
+                .position_at_utf16(hit.name_span.start(), &doc.text);
+            let end = doc
+                .line_index
+                .position_at_utf16(hit.name_span.end(), &doc.text);
+            #[allow(deprecated)]
+            all.push(SymbolInformation {
+                name: hit.name,
+                kind: match hit.kind {
+                    // A tcltest case has no dedicated LSP kind; it lists as
+                    // a function alongside real functions.
+                    CoreWorkspaceSymbolKind::Function | CoreWorkspaceSymbolKind::Test => {
+                        SymbolKind::FUNCTION
+                    }
+                    CoreWorkspaceSymbolKind::Class => SymbolKind::CLASS,
+                    CoreWorkspaceSymbolKind::Method => SymbolKind::METHOD,
+                    CoreWorkspaceSymbolKind::Constructor => SymbolKind::CONSTRUCTOR,
+                    CoreWorkspaceSymbolKind::Constant => SymbolKind::CONSTANT,
+                    CoreWorkspaceSymbolKind::Operator => SymbolKind::OPERATOR,
+                    CoreWorkspaceSymbolKind::Event => SymbolKind::EVENT,
+                },
+                tags: None,
+                deprecated: None,
+                location: Location {
+                    uri,
+                    range: Range {
+                        start: Position {
+                            line: start.line,
+                            character: start.character.get(),
+                        },
+                        end: Position {
+                            line: end.line,
+                            character: end.character.get(),
+                        },
+                    },
+                },
+                container_name: hit.container_name,
+            });
         }
         if all.is_empty() {
             return Ok(None);
@@ -24670,6 +24703,87 @@ mod tests {
                 .expect("ok")
                 .is_none(),
             "workspaceSymbols disabled must yield None",
+        );
+    }
+
+    /// Issue #1156: `workspace/symbol` is answered from the workspace index,
+    /// so a file the folder scan indexed but the editor never opened is
+    /// searchable.  The previous handler walked the open-document map, which
+    /// made every symbol in an unopened file invisible to Ctrl+T.
+    #[tokio::test]
+    async fn workspace_symbol_finds_a_symbol_in_an_unopened_indexed_file() {
+        let backend = test_backend();
+        let root = unique_scratch_dir("ws-symbol-unopened");
+        let on_disk = root.join("scanned.tcl");
+        let src = "proc scanned_only_helper {} {}\n";
+        std::fs::write(&on_disk, src).unwrap();
+        let uri = Uri::from_file_path(&on_disk).unwrap();
+        // Indexed like the folder scan does it — never inserted into
+        // `documents`, so the old open-document walk could not have seen it.
+        let analysis = {
+            let mut a = Analyser::new();
+            a.analyse(src, "tcl8.6").clone()
+        };
+        backend
+            .workspace_index
+            .write()
+            .await
+            .add_document(uri.as_str(), &analysis);
+        assert!(
+            backend.documents.lock().await.is_empty(),
+            "the fixture must not be an open document",
+        );
+
+        let found = backend
+            .symbol(WorkspaceSymbolParams {
+                query: "scanned_only".to_owned(),
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+            })
+            .await
+            .expect("ok");
+        let Some(WorkspaceSymbolResponse::Flat(syms)) = found else {
+            panic!("expected a flat symbol list, got {found:?}");
+        };
+        assert_eq!(syms.len(), 1, "{syms:?}");
+        assert_eq!(syms[0].name, "scanned_only_helper");
+        assert_eq!(syms[0].kind, SymbolKind::FUNCTION);
+        assert_eq!(syms[0].location.uri, uri);
+        // The span was resolved against the file's own text, read from disk.
+        assert_eq!(syms[0].location.range.start.line, 0);
+        assert_eq!(syms[0].location.range.start.character, 5);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// Issue #1156: the answer is capped, so an empty or one-character query
+    /// against a large workspace cannot turn a per-keystroke request into an
+    /// unbounded response.
+    #[tokio::test]
+    async fn workspace_symbol_caps_its_answer() {
+        let backend = test_backend();
+        let uri = Uri::from_str("file:///w/many.tcl").unwrap();
+        let over_the_cap = core_workspace_symbols::MAX_WORKSPACE_SYMBOL_RESULTS + 25;
+        let src = (0..over_the_cap).fold(String::new(), |mut src, n| {
+            use std::fmt::Write;
+            let _ = writeln!(src, "proc capped_{n} {{}} {{}}");
+            src
+        });
+        register(&backend, &uri, &src).await;
+
+        let found = backend
+            .symbol(WorkspaceSymbolParams {
+                query: "capped_".to_owned(),
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+            })
+            .await
+            .expect("ok");
+        let Some(WorkspaceSymbolResponse::Flat(syms)) = found else {
+            panic!("expected a flat symbol list, got {found:?}");
+        };
+        assert_eq!(
+            syms.len(),
+            core_workspace_symbols::MAX_WORKSPACE_SYMBOL_RESULTS,
         );
     }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -10012,23 +10012,29 @@ impl LanguageServer for Backend {
             entry.bump_revision(change_version);
             let dialect = entry.dialect.clone();
             let language_id = entry.language_id.clone();
-            // Update the salsa `SourceFile` input + the cross-document index
-            // WHILE still holding the `documents` lock (the `documents` →
-            // `workspace_index` order that replaced the global gate): no
-            // concurrent request can observe the new `doc.text` (from
-            // `read_document`) with a stale query result for the old text, and
-            // no diagnostics run can re-add a stale index entry between the
-            // commit and the removal.  (db_set_source locks db→db_files, never
-            // documents, so this nesting introduces no lock-order cycle.)
+            // Update the salsa `SourceFile` input WHILE still holding the
+            // `documents` lock, so no concurrent request can observe the new
+            // `doc.text` (from `read_document`) with a stale query result for
+            // the old text.  (db_set_source locks db→db_files, never documents,
+            // so this nesting introduces no lock-order cycle.)
+            //
+            // The workspace index is deliberately *not* touched here (#1149).
+            // Dropping the edited document's entries per keystroke bought
+            // nothing — `publish_diagnostics_result` re-indexes the document
+            // (remove + add) under the same `documents` lock behind an
+            // `is_current` re-check, so it can only ever install the analysis of
+            // the revision the buffer actually holds, and nothing between the
+            // edit and that publish requires the entries to be absent: every
+            // index consumer in the interim reads a *previous* published
+            // revision of this document, which is the same staleness the rest of
+            // the workspace already carries between publishes, and strictly less
+            // misleading than the alternative (a mid-keystroke window where the
+            // file contributes no procs, classes or call sites at all).
             self.db_set_source(&uri, text, dialect.clone()).await;
-            self.workspace_index
-                .write()
-                .await
-                .remove_document(uri.as_str());
             drop(docs);
             (dialect, language_id)
         };
-        // The splice, the salsa source and the index entry are committed, so
+        // The splice and the salsa source are committed, so
         // hand the ordering turn on before the tail below (#1150).  Everything
         // after this point is order-insensitive — marking the diagnostics slot
         // dirty (the worker reads the document's *current* state at drain time),
@@ -10067,11 +10073,10 @@ impl LanguageServer for Backend {
                     };
                     entry.dialect.clone_from(&new_dialect);
                     let text = entry.text.clone();
+                    // As above (#1149): the reschedule below republishes, and
+                    // the publish re-indexes the document under its own
+                    // currency check.
                     self.db_set_source(&uri, text, new_dialect.clone()).await;
-                    self.workspace_index
-                        .write()
-                        .await
-                        .remove_document(uri.as_str());
                 }
                 self.reschedule_diagnostics(uri, new_dialect).await;
             }
@@ -22019,9 +22024,9 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
-    /// #1150, the edit side: `did_change` must hand its turn on once the splice,
-    /// the salsa source and the index entry are committed — not hold it across
-    /// the diagnostics scheduling and the whole-source `detect_dialect` re-scan.
+    /// #1150, the edit side: `did_change` must hand its turn on once the splice
+    /// and the salsa source are committed — not hold it across the diagnostics
+    /// scheduling and the whole-source `detect_dialect` re-scan.
     ///
     /// `diag_slots` stands in for that tail here: the ordered mutations never
     /// take it and `schedule_diagnostics` takes it first thing, so a held
@@ -22067,6 +22072,64 @@ mod tests {
                 .as_deref(),
             Some("set x 2\n"),
             "the splice the ticket covers must already be committed",
+        );
+
+        drop(slots_held);
+        tokio::time::timeout(std::time::Duration::from_secs(30), editing)
+            .await
+            .expect("the edit must finish once its tail can take the diag_slots lock")
+            .expect("did_change panicked");
+    }
+
+    /// #1149: an edit no longer evicts the edited document from the workspace
+    /// index.  `publish_diagnostics_result` re-indexes it (remove + add) behind
+    /// its own `is_current` check, so all the per-keystroke removal bought was
+    /// a window in which the file contributed no procs, classes or call sites
+    /// to any cross-file query — on top of fourteen workspace-wide `retain`
+    /// passes per edit.
+    ///
+    /// Pinned the same way as the #1150 test above: `diag_slots` is held, so
+    /// the handler is parked in its tail and no publish can have run by the
+    /// time the assertion reads the index.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn did_change_does_not_evict_the_document_from_the_workspace_index() {
+        use tower_lsp_server::ls_types::{
+            TextDocumentContentChangeEvent, VersionedTextDocumentIdentifier,
+        };
+        let backend = Arc::new(test_backend());
+        let uri = Uri::from_str("file:///w/indexed.tcl").unwrap();
+        register(&backend, &uri, "proc published {} {}\n").await;
+
+        let slots_held = backend.diag_slots.lock().await;
+        let editing = tokio::spawn({
+            let backend = Arc::clone(&backend);
+            let uri = uri.clone();
+            async move {
+                backend
+                    .did_change(DidChangeTextDocumentParams {
+                        text_document: VersionedTextDocumentIdentifier { uri, version: 2 },
+                        content_changes: vec![TextDocumentContentChangeEvent {
+                            range: None,
+                            range_length: None,
+                            text: "proc renamed {} {}\n".to_owned(),
+                        }],
+                    })
+                    .await;
+            }
+        });
+
+        assert!(
+            one_edit_turn_released(&backend).await,
+            "did_change must release its turn before scheduling diagnostics",
+        );
+        assert!(
+            backend
+                .workspace_index
+                .read()
+                .await
+                .procs()
+                .any(|p| p.uri == uri.as_str() && p.name == "published"),
+            "the last published analysis must still be indexed mid-edit",
         );
 
         drop(slots_held);
@@ -24847,7 +24910,7 @@ mod tests {
             },
         );
         backend.closed_diag_gen.lock().await.insert(old.clone(), 3);
-        assert_eq!(backend.workspace_index.read().await.procs().len(), 1);
+        assert_eq!(backend.workspace_index.read().await.procs().count(), 1);
 
         let params = RenameFilesParams {
             files: vec![tower_lsp_server::ls_types::FileRename {
@@ -24866,7 +24929,6 @@ mod tests {
                 .read()
                 .await
                 .procs()
-                .iter()
                 .all(|p| p.uri != old.as_str()),
         );
         // #1146: and out of the salsa db, so the renamed file's procedures are

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -267,15 +267,32 @@ const IRULES_DIALECT: &str = "f5-irules";
 /// The iApps dialect key — an APL presentation's embedded `[ … ]` Tcl.
 const IAPPS_DIALECT: &str = "f5-iapps";
 
-/// Ceiling on how many project files the background workspace warm (#844 Gap 3)
-/// analyses concurrently.  The warm pre-populates the memoised per-file analysis
-/// across the blocking pool so a cold workspace's first enriched
-/// `semantic_tokens_project` finds cache hits instead of serially walking every
-/// file; the cap keeps it from monopolising the blocking pool (or holding too
-/// many salsa snapshots at once, which would stall a concurrent edit's
-/// `set_text`) on a huge workspace, and it is clamped to the machine's parallelism
-/// so small hosts stay responsive.
+/// Ceiling on how many **open** documents the background workspace warm (#844
+/// Gap 3, narrowed by #1151) analyses concurrently.  The warm pre-populates the
+/// memoised per-file analysis for already-open documents across the blocking
+/// pool so their first hover / semantic-tokens / diagnostics request finds a
+/// cache hit instead of a cold `file_analysis_incremental` walk; the cap keeps
+/// it from monopolising the blocking pool (or holding too many salsa snapshots
+/// at once, which would stall a concurrent edit's `set_text`), and it is
+/// clamped to the machine's parallelism so small hosts stay responsive.
 const WORKSPACE_WARM_MAX_CONCURRENCY: usize = 16;
+
+/// Ceiling on how many workspace files [`Backend::scan_workspace_folders`] and
+/// the [`Backend::did_change_watched_files`] batch reindex analyse concurrently
+/// (#1151 / #1161).  Both read-and-analyse many independent on-disk files, so
+/// they share this bound and the [`run_bounded`] helper; clamped to the
+/// machine's parallelism (see [`WORKSPACE_WARM_MAX_CONCURRENCY`]'s rationale)
+/// so a huge tree can't oversubscribe the blocking pool.
+const WORKSPACE_ANALYSIS_MAX_CONCURRENCY: usize = 16;
+
+/// How many analysed files [`Backend::scan_workspace_folders`] accumulates
+/// before merging them into `workspace_index` / the salsa `Project` (#1151).
+/// Merging in batches rather than once for the whole scan bounds how many
+/// `AnalysisResult`s (and their source text) are held in memory at once on a
+/// large tree, while still running the *analysis* itself across the full
+/// [`WORKSPACE_ANALYSIS_MAX_CONCURRENCY`]-wide pool without waiting on a batch
+/// boundary.
+const SCAN_MERGE_BATCH_SIZE: usize = 200;
 
 /// Debounce window for coalescing `workspace/semanticTokens/refresh` pushes
 /// (see [`SemanticTokensRefreshCtx::request_refresh_coalesced`]). Comparable
@@ -9430,12 +9447,14 @@ impl Backend {
         }
         let discovered_cell = Arc::clone(&self.discovered_tcl);
 
+        // Stage 1: build the package database and walk the workspace trees for
+        // candidate paths. Cheap directory-metadata work, so it stays a single
+        // blocking call; the expensive per-file parse-and-analyse is stage 2,
+        // parallelised below (#1151 — this loop used to also run every file's
+        // `Analyser::analyse` here, serially, one root cause of the 38.7s/883-file
+        // startup cost).
         let resolver_roots = roots.clone();
-        let analysed = tokio::task::spawn_blocking(move || {
-            // Build the package database: the workspace trees plus the resolved
-            // `auto_path` (editor + config-file `libraryPaths`, discovered Tcl
-            // installations, and `TCLLIBPATH`). Discovery is cached for the
-            // session.
+        let (resolver, files) = tokio::task::spawn_blocking(move || {
             let discovered = discovered_cell.get_or_init(|| {
                 core_tcl_install::discover(&core_tcl_install::default_search_bases())
             });
@@ -9445,46 +9464,21 @@ impl Backend {
                 discovered,
                 WORKSPACE_SCAN_DIR_CAP,
             );
-
             let mut files: Vec<PathBuf> = Vec::new();
             for root in &roots {
                 collect_tcl_files(root, WORKSPACE_SCAN_FILE_CAP, &mut files);
             }
-            // Carry the source text + dialect alongside the analysis so the salsa
-            // db (cross-file diagnostics) can index the same disk-backed files.
-            let mut out: Vec<(Uri, String, String, AnalysisResult)> = Vec::new();
-            for path in files {
-                let Some(uri) = Uri::from_file_path(&path) else {
-                    continue;
-                };
-                if open.contains(&uri) {
-                    continue;
-                }
-                let Ok(text) = std::fs::read_to_string(&path) else {
-                    continue;
-                };
-                let dialect = folder_dialect_for(&uri, &folder_dialects)
-                    .unwrap_or_else(|| default_dialect.clone());
-                let mut analyser = Analyser::new();
-                let analysis = analyser.analyse(&text, &dialect);
-                out.push((uri, text, dialect, analysis));
-            }
-            (resolver, out)
+            (resolver, files)
         })
         .await
         .unwrap_or_else(|_| (PackageResolver::new(), Vec::new()));
-        let (resolver, analysed) = analysed;
 
-        // Fold in the `auto_path` the workspace's own files install
-        // (`lappend auto_path [file dirname [file dirname [info script]]]`),
-        // then publish the package database for the diagnostics worker and
-        // merge the per-file analysis into the index + salsa db.
-        let resolver = extend_resolver_with_document_auto_paths(resolver, &analysed);
-        *self.package_resolver.write().await = resolver;
-        // The package database changed: drop the library files the autoload
-        // tier (M8) merged under the previous database.  A stale entry would
-        // keep answering for a library no longer on the resolved `auto_path`;
-        // dropping is cheap and the next query re-merges on demand.
+        // Drop the library files the autoload tier (M8) merged under the
+        // *previous* package database before this scan's own batches add their
+        // fresh entries below — a stale entry must not survive a rescan, and
+        // (rare, but possible) a workspace file that used to be reached only via
+        // autoload must end up present, not removed, if a later batch re-adds it
+        // under its own URI.
         let stale_library_uris: Vec<String> =
             self.autoloaded_library_uris.lock().await.drain().collect();
         if !stale_library_uris.is_empty() {
@@ -9493,13 +9487,31 @@ impl Backend {
                 index.remove_document(uri);
             }
         }
-        let files_count = analysed.len();
-        self.merge_workspace_scan_results(&analysed).await;
+
+        // Stage 2: read + analyse the candidate files across a bounded worker
+        // pool, merging into `workspace_index` / the salsa `Project` in
+        // batches as they complete.
+        let (resolver, files_count) = self
+            .analyse_and_merge_scanned_files(
+                files,
+                open,
+                folder_dialects,
+                default_dialect,
+                resolver,
+            )
+            .await;
+
+        // Publish the package database for the diagnostics worker now every
+        // batch's auto-path contribution has folded in.
+        *self.package_resolver.write().await = resolver;
         // Re-home sourced documents under their source-site namespaces (M9).
         self.refresh_source_rehoming().await;
-        // Now that the `Project` covers the whole workspace, warm the salsa
-        // per-file analysis in parallel (#844 Gap 3) so the first cross-file /
-        // enriched-token query finds cache hits instead of a serial cold walk.
+        // Warm the deep salsa tier for documents already open (#844 Gap 3,
+        // narrowed by #1151) so their first hover / semantic-tokens /
+        // diagnostics request is a cache hit; unopened files stay at the
+        // lightweight tier (`workspace_index` + the salsa `SourceFile` inputs
+        // just batched in, which answer `file_decls` / `item_sigs` on demand)
+        // until a request actually needs their deep analysis.
         self.spawn_workspace_warm();
         // Readiness signal for `package_resolver` / `workspace_index` having
         // just been (re)built from disk — a client (or a test) that needs to
@@ -9516,6 +9528,86 @@ impl Backend {
                 ),
             )
             .await;
+    }
+
+    /// Stage 2 of [`Self::scan_workspace_folders`] (#1151): read + analyse
+    /// `files` across a bounded worker pool (the `spawn_workspace_warm`
+    /// semaphore pattern — acquire a permit before spawning, so at most
+    /// `WORKSPACE_ANALYSIS_MAX_CONCURRENCY` files are being read+analysed at
+    /// once), merging into `workspace_index` / the salsa `Project` in batches
+    /// as they complete rather than collecting every `AnalysisResult` for the
+    /// whole tree before merging any of it — bounding how much of the scan's
+    /// own output is ever live in memory at once on a large workspace. `files`
+    /// already open in the editor are skipped (their live buffer must not be
+    /// clobbered by the on-disk copy); an unreadable path is dropped.
+    ///
+    /// Returns `resolver` extended with every batch's own `auto_path`
+    /// contribution, plus the number of files actually analysed.
+    async fn analyse_and_merge_scanned_files(
+        &self,
+        files: Vec<PathBuf>,
+        open: HashSet<Uri>,
+        folder_dialects: Vec<(Uri, String)>,
+        default_dialect: String,
+        mut resolver: PackageResolver,
+    ) -> (PackageResolver, usize) {
+        let open = Arc::new(open);
+        let folder_dialects = Arc::new(folder_dialects);
+        let concurrency = std::thread::available_parallelism()
+            .map_or(4, std::num::NonZeroUsize::get)
+            .min(WORKSPACE_ANALYSIS_MAX_CONCURRENCY);
+        let permits = Arc::new(Semaphore::new(concurrency));
+        let mut tasks = tokio::task::JoinSet::new();
+        for path in files {
+            let Ok(permit) = Arc::clone(&permits).acquire_owned().await else {
+                break;
+            };
+            let open = Arc::clone(&open);
+            let folder_dialects = Arc::clone(&folder_dialects);
+            let default_dialect = default_dialect.clone();
+            tasks.spawn(async move {
+                let _permit = permit;
+                tokio::task::spawn_blocking(move || {
+                    let uri = Uri::from_file_path(&path)?;
+                    if open.contains(&uri) {
+                        return None;
+                    }
+                    let text = std::fs::read_to_string(&path).ok()?;
+                    let dialect = folder_dialect_for(&uri, &folder_dialects)
+                        .unwrap_or_else(|| default_dialect.clone());
+                    let mut analyser = Analyser::new();
+                    let analysis = analyser.analyse(&text, &dialect);
+                    Some((uri, text, dialect, analysis))
+                })
+                .await
+                .ok()
+                .flatten()
+            });
+        }
+        let mut files_count = 0usize;
+        let mut batch: Vec<(Uri, String, String, AnalysisResult)> = Vec::new();
+        while let Some(result) = tasks.join_next().await {
+            let Ok(Some(item)) = result else {
+                continue;
+            };
+            batch.push(item);
+            if batch.len() >= SCAN_MERGE_BATCH_SIZE {
+                files_count += batch.len();
+                // Fold in the `auto_path` mutations this batch's own files
+                // install (`lappend auto_path [file dirname …]`) before
+                // merging, so the package database sees them as soon as
+                // their batch lands rather than only at the end of the scan.
+                resolver = extend_resolver_with_document_auto_paths(resolver, &batch);
+                self.merge_workspace_scan_results(&batch).await;
+                batch.clear();
+            }
+        }
+        if !batch.is_empty() {
+            files_count += batch.len();
+            resolver = extend_resolver_with_document_auto_paths(resolver, &batch);
+            self.merge_workspace_scan_results(&batch).await;
+        }
+        (resolver, files_count)
     }
 
     /// Merge disk-backed workspace scan results into the shared index **and** the
@@ -9561,21 +9653,32 @@ impl Backend {
     }
 
     /// Kick off a detached, concurrency-bounded parallel **warm** of the salsa
-    /// per-file analysis for every project file (#844 Gap 3).
+    /// per-file analysis for every currently **open** document (#844 Gap 3,
+    /// narrowed by #1151).
     ///
-    /// On a cold workspace the first enriched `semantic_tokens_project` otherwise
-    /// serially analyses every file inside `project_class_index` /
-    /// `project_proc_var_index`.  Pre-populating the memoised
-    /// `file_analysis_incremental` across the blocking pool collapses that serial
-    /// cold walk to a parallel one, so the tracked query's loop is all cache hits
-    /// by the time the enriched token / cross-file diagnostics query runs — the
-    /// enrichment side's analogue of the diagnostics deep pass's `join!`.
+    /// Deep state (`file_analysis_incremental` and everything built on it —
+    /// `compilation_unit`, `project_class_index`, `project_proc_var_index`) is an
+    /// open-document cost, not a workspace one: an on-disk file the editor hasn't
+    /// opened only needs to answer cross-file resolution (`workspace_index`,
+    /// fed by the scan's own analyser pass, plus the light `file_decls` /
+    /// `item_sigs` signature tier salsa computes on demand from the `SourceFile`
+    /// inputs `db_set_sources_batch` sets). Warming the deep tier for every
+    /// workspace file — the pre-#1151 behaviour — analysed the whole project a
+    /// *second* time through salsa on top of the scan's own analyser walk, and
+    /// materialised `file_analysis` for files nobody has open (measured: 786 MB
+    /// RSS after a tcllib scan). This warm now only primes the files already
+    /// open when it runs, so the first hover / semantic-tokens / diagnostics
+    /// request on an already-open tab (e.g. several restored editor tabs right
+    /// after `initialized`, or a big multi-root reload) is a cache hit instead
+    /// of a cold `file_analysis_incremental` walk; an unopened file pays its
+    /// deep-tier cost only if a request actually needs it, exactly like a
+    /// document opened after the scan already does.
     ///
     /// Purely an optimisation, and safe by construction:
     /// - **Correctness**: it only primes the salsa cache; a concurrent real read
     ///   of the same `(file, config)` dedups against it (salsa blocks the second
     ///   requester and shares the memoised result — never a double analysis or a
-    ///   divergent one), so results are identical to the serial walk.
+    ///   divergent one), so results are identical to an unwarmed cold read.
     /// - **Never blocks a request**: fire-and-forget on a detached task.
     /// - **Never stalls an edit**: at most `WORKSPACE_WARM_MAX_CONCURRENCY`
     ///   snapshots are live at once (each warm clones its snapshot only after
@@ -9587,78 +9690,29 @@ impl Backend {
     ///   / config-change) keep that bound *global*, not merely per-warm, and drop
     ///   the redundant re-walk.
     ///
-    /// Warms under every distinct config a request could resolve to — the global
-    /// `db_config` plus each folder-scoped override in `folder_db_configs` —
-    /// because `project_class_index` / `project_proc_var_index` apply a single
-    /// `resolved_db_config(uri)` uniformly to *every* project file. A
-    /// global-config-only warm would therefore miss the whole-project enrichment
-    /// loop for every file the moment any folder sets an override (not just the
-    /// overridden folder's files), since the loop keys `file_analysis_incremental`
-    /// on that one resolved config. Deduped, so a single-config workspace (the
-    /// common case) still warms each file exactly once; for the handful of override
-    /// folders a real workspace has, the extra `files × configs` primes are cheap
-    /// salsa cache fills.
+    /// Each open document warms under its own [`Self::resolved_db_config`] —
+    /// the config the diagnostics / hover / completion path would actually
+    /// resolve for it — rather than the former full `files × configs` cross
+    /// product: that product existed only to cover `project_class_index` /
+    /// `project_proc_var_index` applying one config to *every* project file,
+    /// which no longer matters here because this warm no longer touches
+    /// unopened files at all.
     fn spawn_workspace_warm(&self) {
         let db = Arc::clone(&self.db);
-        let db_project = Arc::clone(&self.db_project);
+        let db_files = Arc::clone(&self.db_files);
+        let documents = Arc::clone(&self.documents);
         let db_config = Arc::clone(&self.db_config);
         let folder_db_configs = Arc::clone(&self.folder_db_configs);
-        let task = tokio::spawn(async move {
-            let Some(project) = *db_project.lock().await else {
-                return;
-            };
-            // Every config a request could resolve to: the global one plus each
-            // folder override, deduped (a single-config workspace warms once).
-            let mut configs = vec![*db_config.lock().await];
-            for (_, folder_config) in folder_db_configs.lock().await.iter() {
-                if !configs.contains(folder_config) {
-                    configs.push(*folder_config);
-                }
-            }
-            let files: Vec<tcl_lsp_db::SourceFile> = {
-                let snapshot = db.lock().await.clone();
-                project.files(&snapshot).clone()
-            };
-            if files.is_empty() {
-                return;
-            }
-            let concurrency = std::thread::available_parallelism()
-                .map_or(4, std::num::NonZeroUsize::get)
-                .min(WORKSPACE_WARM_MAX_CONCURRENCY);
-            let permits = Arc::new(Semaphore::new(concurrency));
-            let mut warms = tokio::task::JoinSet::new();
-            for config in configs {
-                for file in files.iter().copied() {
-                    // Acquire the permit *before* spawning so at most `concurrency`
-                    // warm tasks (and thus snapshots) exist at once: the loop
-                    // backpressures on a very large workspace rather than parking one
-                    // pending task per item on the semaphore. `acquire_owned` moves
-                    // the permit into the task, which holds it until its analysis
-                    // returns.
-                    let Ok(permit) = Arc::clone(&permits).acquire_owned().await else {
-                        break;
-                    };
-                    let db = Arc::clone(&db);
-                    warms.spawn(async move {
-                        let _permit = permit;
-                        // Clone the snapshot only after the permit is held, so
-                        // `set_text` never waits on more than `concurrency` in-flight
-                        // reads.
-                        let snapshot = db.lock().await.clone();
-                        let _ = tokio::task::spawn_blocking(move || {
-                            let _ = salsa::Cancelled::catch(|| {
-                                tcl_lsp_db::file_analysis_incremental(&snapshot, file, config)
-                            });
-                        })
-                        .await;
-                    });
-                }
-            }
-            while warms.join_next().await.is_some() {}
-        });
+        let task = tokio::spawn(Self::warm_open_documents(
+            db,
+            db_files,
+            documents,
+            db_config,
+            folder_db_configs,
+        ));
         // Supersede any still-running warm so overlapping scans (initialize /
         // folder-add / config-change) can't stack their snapshots or redundantly
-        // re-walk the workspace. Aborting at the per-item await boundaries (with
+        // re-walk the open set. Aborting at the per-item await boundaries (with
         // the existing `Cancelled::catch`) keeps the global snapshot bound at
         // `WORKSPACE_WARM_MAX_CONCURRENCY`.
         if let Ok(mut guard) = self.warm_task.lock()
@@ -9666,6 +9720,72 @@ impl Backend {
         {
             prev.abort();
         }
+    }
+
+    /// The body [`Self::spawn_workspace_warm`] detaches — pulled out as its own
+    /// `async fn` over cloned `Arc` fields (rather than `&self`) so a test can
+    /// `.await` it directly and observe, deterministically, exactly which salsa
+    /// queries it executes (`TclDatabase::with_event_logger`) instead of racing
+    /// a fire-and-forget `tokio::spawn`.
+    async fn warm_open_documents(
+        db: Arc<Mutex<tcl_lsp_db::TclDatabase>>,
+        db_files: Arc<Mutex<HashMap<Uri, tcl_lsp_db::SourceFile>>>,
+        documents: Arc<Mutex<HashMap<Uri, DocumentState>>>,
+        db_config: Arc<Mutex<tcl_lsp_db::AnalyserConfig>>,
+        folder_db_configs: Arc<Mutex<Vec<(Uri, tcl_lsp_db::AnalyserConfig)>>>,
+    ) {
+        let open_uris: Vec<Uri> = documents.lock().await.keys().cloned().collect();
+        if open_uris.is_empty() {
+            return;
+        }
+        let global_config = *db_config.lock().await;
+        let folder_configs = folder_db_configs.lock().await.clone();
+        let work: Vec<(tcl_lsp_db::SourceFile, tcl_lsp_db::AnalyserConfig)> = {
+            let files = db_files.lock().await;
+            open_uris
+                .iter()
+                .filter_map(|uri| {
+                    let file = *files.get(uri)?;
+                    let config = longest_folder_match(&folder_configs, uri)
+                        .copied()
+                        .unwrap_or(global_config);
+                    Some((file, config))
+                })
+                .collect()
+        };
+        if work.is_empty() {
+            return;
+        }
+        let concurrency = std::thread::available_parallelism()
+            .map_or(4, std::num::NonZeroUsize::get)
+            .min(WORKSPACE_WARM_MAX_CONCURRENCY);
+        let permits = Arc::new(Semaphore::new(concurrency));
+        let mut warms = tokio::task::JoinSet::new();
+        for (file, config) in work {
+            // Acquire the permit *before* spawning so at most `concurrency`
+            // warm tasks (and thus snapshots) exist at once: the loop
+            // backpressures rather than parking one pending task per item on
+            // the semaphore. `acquire_owned` moves the permit into the task,
+            // which holds it until its analysis returns.
+            let Ok(permit) = Arc::clone(&permits).acquire_owned().await else {
+                break;
+            };
+            let db = Arc::clone(&db);
+            warms.spawn(async move {
+                let _permit = permit;
+                // Clone the snapshot only after the permit is held, so
+                // `set_text` never waits on more than `concurrency` in-flight
+                // reads.
+                let snapshot = db.lock().await.clone();
+                let _ = tokio::task::spawn_blocking(move || {
+                    let _ = salsa::Cancelled::catch(|| {
+                        tcl_lsp_db::file_analysis_incremental(&snapshot, file, config)
+                    });
+                })
+                .await;
+            });
+        }
+        while warms.join_next().await.is_some() {}
     }
 
     /// Race the memoised CU + analysis reads for `uri` against
@@ -21305,6 +21425,129 @@ mod tests {
         drop(index);
 
         std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// #1151: a workspace scan of unopened files must build only the
+    /// lightweight tier — `workspace_index` (from the scan's own analyser
+    /// pass) and the salsa `SourceFile` inputs — never the deep salsa tier
+    /// (`file_analysis_incremental` / `compilation_unit` /
+    /// `compiler_check_diagnostics`).  Uses the same
+    /// `TclDatabase::with_event_logger` technique as
+    /// `closed_file_republish_does_not_memoise_the_deep_compiler_tier` to
+    /// observe exactly which salsa queries a scan with no open documents
+    /// executes.
+    #[tokio::test]
+    async fn scan_workspace_folders_does_not_build_deep_tier_for_unopened_files() {
+        let root = unique_scratch_dir("scan-no-deep-tier");
+        std::fs::write(
+            root.join("lib.tcl"),
+            "proc greet {name} { puts \"hi $name\" }\n",
+        )
+        .unwrap();
+        std::fs::write(root.join("main.tcl"), "greet world\n").unwrap();
+
+        let executed: Arc<std::sync::Mutex<Vec<String>>> = Arc::default();
+        let sink = Arc::clone(&executed);
+        let backend = test_backend_over(tcl_lsp_db::TclDatabase::with_event_logger(move |key| {
+            sink.lock().unwrap().push(key);
+        }));
+        let root_url = Uri::from_file_path(&root).unwrap();
+        *backend.workspace_folders.lock().await = vec![root_url];
+
+        backend.scan_workspace_folders().await;
+
+        let deep: Vec<String> = executed
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|key| {
+                [
+                    "compilation_unit",
+                    "compiler_check_diagnostics",
+                    "file_analysis_incremental",
+                ]
+                .iter()
+                .any(|query| key.contains(query))
+            })
+            .cloned()
+            .collect();
+        assert!(
+            deep.is_empty(),
+            "a workspace scan with no open documents must not build any \
+             deep-tier salsa query for the files it discovers: {deep:?}",
+        );
+
+        // The lightweight index the scan's own analyser pass builds must still
+        // cover both files — cross-file resolution for open documents is not
+        // lost, only the eager deep-tier warm.
+        let index = backend.workspace_index.read().await;
+        assert!(
+            !index.proc_definitions("greet", "greet").is_empty(),
+            "the scan must still index the unopened file's declarations",
+        );
+        assert!(
+            !index.invocations_of("greet", "").is_empty(),
+            "the scan must still index the unopened file's call sites",
+        );
+        drop(index);
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// #1151: [`Backend::warm_open_documents`] (the body
+    /// [`Backend::spawn_workspace_warm`] detaches) primes the deep salsa tier
+    /// for an **open** document but must not touch an unopened one the scan
+    /// only fed into `db_files` as a lightweight `SourceFile` input.
+    #[tokio::test]
+    async fn warm_open_documents_only_touches_open_files() {
+        let executed: Arc<std::sync::Mutex<Vec<String>>> = Arc::default();
+        let sink = Arc::clone(&executed);
+        let backend = test_backend_over(tcl_lsp_db::TclDatabase::with_event_logger(move |key| {
+            sink.lock().unwrap().push(key);
+        }));
+        let open_uri = Uri::from_str("file:///workspace/open.tcl").unwrap();
+        let closed_uri = Uri::from_str("file:///workspace/closed.tcl").unwrap();
+        backend.documents.lock().await.insert(
+            open_uri.clone(),
+            DocumentState::new("proc open_proc {} {}\n".to_owned(), "tcl8.6".to_owned()),
+        );
+        backend
+            .db_set_source(
+                &open_uri,
+                "proc open_proc {} {}\n".to_owned(),
+                "tcl8.6".to_owned(),
+            )
+            .await;
+        // Never opened, but present in `db_files` — exactly the state a
+        // workspace scan leaves an unopened file in after #1151.
+        backend
+            .db_set_source(
+                &closed_uri,
+                "proc closed_proc {} {}\n".to_owned(),
+                "tcl8.6".to_owned(),
+            )
+            .await;
+
+        Backend::warm_open_documents(
+            Arc::clone(&backend.db),
+            Arc::clone(&backend.db_files),
+            Arc::clone(&backend.documents),
+            Arc::clone(&backend.db_config),
+            Arc::clone(&backend.folder_db_configs),
+        )
+        .await;
+
+        let deep_runs = executed
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|key| key.contains("file_analysis_incremental"))
+            .count();
+        assert_eq!(
+            deep_runs, 1,
+            "the warm must run the deep tier exactly once, for the one open \
+             document, never for the unopened one",
+        );
     }
 
     #[tokio::test]

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -32,7 +32,7 @@
 
 pub mod config_ini;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::ops::ControlFlow;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -275,6 +275,19 @@ const WORKSPACE_WARM_MAX_CONCURRENCY: usize = 16;
 /// restores several tabs) would otherwise each fire their own workspace-wide
 /// refresh; this collapses a burst into one fire per window.
 const SEMANTIC_TOKENS_REFRESH_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(50);
+
+/// How many **closed** files keep a server-side diagnostics badge record
+/// (`pull_diag_cache` + `closed_diag_gen`) before the least-recently-published
+/// one is evicted (#1144).
+///
+/// #865 keeps a closed workspace file's Problems badge, but the cache had no
+/// bound: browsing a large tree retained a full `Vec<Diagnostic>` for every file
+/// the editor ever opened, for the process's life.  Every entry is re-derivable
+/// from disk, so evicting the oldest costs nothing but a recompute on reopen.
+/// Sized well above a realistic "recently visited" working set (VS Code's own
+/// Problems view is the consumer) yet far below the thousands of files a
+/// workspace walk touches.
+const CLOSED_DIAG_BADGE_CAP: usize = 512;
 
 /// What "still the current state" means for a diagnostics run at publish time,
 /// and therefore what the currency guard re-checks under the `documents` lock
@@ -1118,9 +1131,18 @@ async fn compute_base_analysis(
         let (a_text, a_dialect, a_disabled) =
             (text.to_owned(), dialect.to_owned(), disabled.clone());
         let a_extra = extra_commands.clone();
+        // The path- and release-keyed inputs `file_analysis_incremental` reads
+        // off the salsa `SourceFile` / `AnalyserConfig` (pkgIndex.tcl and
+        // tclpkg.tcl scoping; the BIG-IP library-version axis).  This branch is
+        // the **closed-file** tier since #1144, not just a rare fallback, so a
+        // closed file's badge must not lose them.
+        let a_path = uri.to_file_path().map(|p| p.display().to_string());
+        let a_bigip = config.bigip_version(&*db.lock().await).clone();
         let analysis = tokio::task::spawn_blocking(move || {
             Arc::new(
                 Backend::configured_analyser(a_disabled, non_ascii_mode, a_extra)
+                    .with_file_path(a_path)
+                    .with_bigip_version(a_bigip)
                     .analyse(&a_text, &a_dialect)
                     .clone(),
             )
@@ -1326,6 +1348,30 @@ async fn compute_compiler_diags(
     }
 }
 
+/// Release the worker's claim on `uri`'s slot.
+///
+/// A slot whose `latest_inputs` were cleared belongs to a document that is no
+/// longer open ([`Backend::evict_diag_slot`] clears them on close), so the slot
+/// itself is dropped; an open document keeps its slot, with `running` cleared so
+/// the next edit starts a fresh worker.
+///
+/// Dropping the slot is what bounds closed-file state (#1144): every URI ever
+/// scheduled used to keep a [`DiagInputs`] — per-URI clones of the disabled /
+/// extra-command / severity-override / entry-point sets — for the process's
+/// life, so browsing a workspace grew `diag_slots` without limit.  Retaining it
+/// bought nothing: `did_open` re-resolves the inputs unconditionally
+/// (`reschedule_diagnostics`, #104), so a reopened document never reads them.
+fn retire_slot(slots: &mut HashMap<Uri, DiagSlot>, uri: &Uri) {
+    let Some(slot) = slots.get_mut(uri) else {
+        return;
+    };
+    if slot.latest_inputs.is_none() {
+        slots.remove(uri);
+    } else {
+        slot.running = false;
+    }
+}
+
 /// The debounced, detached diagnostics worker for one document.
 ///
 /// A free function rather than an inline `tokio::spawn` body so it can
@@ -1350,16 +1396,15 @@ fn spawn_diagnostics_worker(slots: Arc<Mutex<HashMap<Uri, DiagSlot>>>, uri: Uri)
                     slot.dirty = false;
                     slot.latest_inputs.clone()
                 } else {
-                    slot.running = false;
+                    retire_slot(&mut guard, &uri);
                     return;
                 }
             };
-            // `latest_inputs` is set alongside `dirty`, so this is `Some`;
-            // guard defensively and retire if it is somehow absent.
+            // `latest_inputs` is set alongside `dirty`, so this is `Some` unless
+            // `Backend::evict_diag_slot` cleared it while we were draining;
+            // either way there is nothing to analyse, so retire.
             let Some(inputs) = inputs else {
-                if let Some(slot) = slots.lock().await.get_mut(&uri) {
-                    slot.running = false;
-                }
+                retire_slot(&mut *slots.lock().await, &uri);
                 return;
             };
             // A document that has never had cross-file evidence set gets it
@@ -1379,11 +1424,15 @@ fn spawn_diagnostics_worker(slots: Arc<Mutex<HashMap<Uri, DiagSlot>>>, uri: Uri)
                 Arc::clone(&inputs.workspace_index),
             );
             // Capture + analyse the document's current state.  If it is gone
-            // (closed) there is nothing to publish — retire.
+            // (closed) there is nothing to publish — retire, unless a `did_open`
+            // re-armed the slot in the meantime, in which case keep draining
+            // rather than orphaning its dirty bit with no worker behind it.
             let Some(job) = inputs.capture_job(&uri).await else {
                 let mut guard = slots.lock().await;
-                if let Some(slot) = guard.get_mut(&uri) {
-                    slot.running = false;
+                match guard.get(&uri) {
+                    Some(slot) if slot.dirty => continue,
+                    Some(_) => retire_slot(&mut guard, &uri),
+                    None => {}
                 }
                 return;
             };
@@ -2445,6 +2494,11 @@ pub struct Backend {
     /// so overlapping close / watched-change refreshes cannot let an older run
     /// publish stale diagnostics over a newer one — see [`DiagInputs::closed_diag_gen`].
     closed_diag_gen: Arc<Mutex<HashMap<Uri, u64>>>,
+    /// Publish order of the **closed** files that currently hold a badge record,
+    /// oldest first — the recency list backing [`CLOSED_DIAG_BADGE_CAP`] (#1144).
+    /// Only [`Backend::record_closed_diag_badge`] touches it, so an open
+    /// document's cache entry is never queued and never evicted.
+    closed_diag_order: Arc<Mutex<VecDeque<Uri>>>,
     /// Whether the client advertised pull-diagnostic support
     /// (`textDocument.diagnostic` client capability) at `initialize`.
     ///
@@ -2959,6 +3013,7 @@ impl Backend {
             db_config: Arc::new(Mutex::new(db_config)),
             pull_diag_cache: Arc::new(Mutex::new(HashMap::new())),
             closed_diag_gen: Arc::new(Mutex::new(HashMap::new())),
+            closed_diag_order: Arc::new(Mutex::new(VecDeque::new())),
             client_supports_pull_diagnostics: std::sync::atomic::AtomicBool::new(false),
             last_semantic_tokens: Arc::new(Mutex::new(HashMap::new())),
             workspace_class_analyses: Arc::new(Mutex::new(HashMap::new())),
@@ -4169,10 +4224,24 @@ impl Backend {
             language_id: String::new(),
             currency: DiagCurrency::ClosedFromDisk(generation),
             version: None,
-            file: Some(file),
+            // #1144: deliberately **not** `Some(file)`.  Routing a closed file
+            // through the salsa queries would memoise its whole deep compiler
+            // tier — the `compilation_unit` IR/CFG/SSA build behind
+            // `file_analysis_incremental` / `compiler_check_diagnostics` — and
+            // salsa cannot evict it, so every file the editor ever opened kept
+            // ~12 MB of compiler memos for the process's life (a workspace
+            // browse OOM-killed the server).  This run happens *inline* on every
+            // close, so it, not the debounced open path, is what pinned a memo
+            // chain for files the user merely glanced at.  The uncached pipeline
+            // computes the same per-file diagnostics and drops everything it
+            // built, keeping the closed tier bounded; the file's `SourceFile`
+            // input stays in the `Project` so its *lightweight* decls/signature
+            // queries keep serving open documents' cross-file resolution.
+            file: None,
             config,
         };
         run_diagnostics_core(inputs, uri, job).await;
+        self.record_closed_diag_badge(uri).await;
     }
 
     /// Resolve the dialect for a **closed** on-disk file the way
@@ -4218,6 +4287,72 @@ impl Backend {
         // Drop the closed-run generation too, so the map does not accumulate an
         // entry for a URI that no longer carries a badge.
         self.closed_diag_gen.lock().await.remove(uri);
+        // …and its place in the closed-badge recency list, so a cleared URI does
+        // not count against [`CLOSED_DIAG_BADGE_CAP`] (#1144).
+        self.closed_diag_order
+            .lock()
+            .await
+            .retain(|queued| queued != uri);
+    }
+
+    /// Release `uri`'s diagnostics slot when its document closes (#1144).
+    ///
+    /// With no worker draining it the slot is dropped outright.  With one
+    /// in flight the slot must stay — it is the worker's own liveness record —
+    /// so only the heavy [`DiagInputs`] are released and the dirty bit cleared;
+    /// [`retire_slot`] then drops the slot as the worker retires (and a
+    /// `did_open` racing in front of that re-arms it before the worker looks,
+    /// so nothing is orphaned).
+    async fn evict_diag_slot(&self, uri: &Uri) {
+        let mut slots = self.diag_slots.lock().await;
+        let Some(slot) = slots.get_mut(uri) else {
+            return;
+        };
+        if slot.running {
+            slot.latest_inputs = None;
+            slot.dirty = false;
+        } else {
+            slots.remove(uri);
+        }
+    }
+
+    /// Record that `uri` now carries a **closed**-file badge and evict the
+    /// oldest closed badges beyond [`CLOSED_DIAG_BADGE_CAP`] (#1144).
+    ///
+    /// Open documents are never queued here, so they are never evicted.  An
+    /// evicted URI only loses the server's *record* of its badge — the client
+    /// keeps the diagnostics it was last sent, and reopening the file (or a
+    /// watched-file change) recomputes them from disk — so #865's retained
+    /// badge survives; what stops growing is the per-URI `Vec<Diagnostic>` the
+    /// server would otherwise hold for every file the user ever opened.
+    async fn record_closed_diag_badge(&self, uri: &Uri) {
+        let evicted: Vec<Uri> = {
+            let mut order = self.closed_diag_order.lock().await;
+            order.retain(|queued| queued != uri);
+            order.push_back(uri.clone());
+            let mut evicted = Vec::new();
+            while order.len() > CLOSED_DIAG_BADGE_CAP {
+                if let Some(oldest) = order.pop_front() {
+                    evicted.push(oldest);
+                }
+            }
+            evicted
+        };
+        if evicted.is_empty() {
+            return;
+        }
+        let docs = self.documents.lock().await;
+        let mut cache = self.pull_diag_cache.lock().await;
+        let mut gens = self.closed_diag_gen.lock().await;
+        for uri in &evicted {
+            if docs.contains_key(uri) {
+                continue;
+            }
+            cache.remove(uri);
+            // Same lifetime as the cache entry — the generation only orders
+            // runs for a URI the server is still tracking.
+            gens.remove(uri);
+        }
     }
 
     /// Refresh the diagnostics of every **closed** file that currently carries a
@@ -9681,6 +9816,12 @@ impl LanguageServer for Backend {
                 .remove_document(uri.as_str());
             drop(docs);
         }
+        // Release the per-URI diagnostics slot (#1144).  The slot used to be
+        // kept deliberately, but the reason no longer holds: `did_open` re-
+        // resolves the inputs unconditionally (`reschedule_diagnostics`, #104),
+        // so a reopened document never reads the retained ones — while every
+        // browsed-and-closed file left its `DiagInputs` behind for good.
+        self.evict_diag_slot(uri).await;
         // Drop the cached semantic-token baseline so a reopened document starts
         // from a fresh `full` rather than diffing against a stale stream.
         self.last_semantic_tokens.lock().await.remove(uri);
@@ -18036,8 +18177,16 @@ mod tests {
     /// `LspService::new` and copy the wrapped `Client` into a
     /// fresh `Backend` with reset state.
     fn test_backend() -> Backend {
+        test_backend_over(tcl_lsp_db::TclDatabase::default())
+    }
+
+    /// [`test_backend`] over a caller-supplied query database, so a test can
+    /// supply one with an event logger attached and observe which salsa queries
+    /// a handler actually executes.  The `AnalyserConfig` input must be created
+    /// against the same database, which is why it cannot simply be swapped in
+    /// after the fact.
+    fn test_backend_over(db: tcl_lsp_db::TclDatabase) -> Backend {
         let (service, _socket) = tower_lsp_server::LspService::new(Backend::new);
-        let db = tcl_lsp_db::TclDatabase::default();
         let db_config = tcl_lsp_db::AnalyserConfig::new(
             &db,
             default_disabled_set().into_iter().collect(),
@@ -18082,6 +18231,7 @@ mod tests {
             db_config: Arc::new(Mutex::new(db_config)),
             pull_diag_cache: Arc::new(Mutex::new(HashMap::new())),
             closed_diag_gen: Arc::new(Mutex::new(HashMap::new())),
+            closed_diag_order: Arc::new(Mutex::new(VecDeque::new())),
             client_supports_pull_diagnostics: std::sync::atomic::AtomicBool::new(false),
             last_semantic_tokens: Arc::new(Mutex::new(HashMap::new())),
             workspace_class_analyses: Arc::new(Mutex::new(HashMap::new())),
@@ -18242,21 +18392,204 @@ mod tests {
         );
     }
 
+    /// #1144: `diag_slots` must shrink when a document closes.  Every URI ever
+    /// scheduled used to keep its slot — and with it a [`DiagInputs`] holding
+    /// per-URI clones of the disabled / extra-command / severity-override /
+    /// entry-point sets — for the process's life, so browsing a workspace grew
+    /// the map without bound.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn did_close_drops_the_diagnostics_slot() {
+        let backend = test_backend();
+        let uri = Uri::from_str("file:///slot-drop.tcl").unwrap();
+        backend
+            .did_open(DidOpenTextDocumentParams {
+                text_document: tower_lsp_server::ls_types::TextDocumentItem {
+                    uri: uri.clone(),
+                    language_id: "tcl".to_owned(),
+                    version: 1,
+                    text: "proc foo {} { set y 1 }\n".to_owned(),
+                },
+            })
+            .await;
+        assert!(
+            backend.diag_slots.lock().await.contains_key(&uri),
+            "sanity: opening a document schedules it, creating the slot",
+        );
+
+        backend
+            .did_close(DidCloseTextDocumentParams {
+                text_document: TextDocumentIdentifier { uri: uri.clone() },
+            })
+            .await;
+
+        // The close releases the inputs immediately; the slot itself goes with
+        // them once the debounced worker that was draining the open buffer
+        // retires (`retire_slot`), so poll rather than assume an instant drop.
+        assert!(
+            wait_for(|| async { !backend.diag_slots.lock().await.contains_key(&uri) }).await,
+            "a closed document must not keep its diagnostics slot (#1144)",
+        );
+    }
+
+    /// #1144: the closed-file badge cache is bounded.  #865 keeps a closed
+    /// file's diagnostics, but every entry used to live for the process's life,
+    /// so browsing a large tree retained a `Vec<Diagnostic>` per file ever
+    /// opened.  Past [`CLOSED_DIAG_BADGE_CAP`] the least-recently-published
+    /// closed entry is evicted from both `pull_diag_cache` and `closed_diag_gen`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn closed_diag_badge_cache_is_capped() {
+        let backend = test_backend();
+        let uri_at = |i: usize| Uri::from_str(&format!("file:///browse/f{i}.tcl")).unwrap();
+        let total = CLOSED_DIAG_BADGE_CAP + 64;
+        for i in 0..total {
+            let uri = uri_at(i);
+            backend.pull_diag_cache.lock().await.insert(
+                uri.clone(),
+                PullDiagEntry {
+                    result_id: next_pull_diag_result_id(),
+                    revision: 0,
+                    diagnostics: Vec::new(),
+                },
+            );
+            backend.closed_diag_gen.lock().await.insert(uri.clone(), 1);
+            backend.record_closed_diag_badge(&uri).await;
+        }
+
+        let cache = backend.pull_diag_cache.lock().await;
+        assert_eq!(
+            cache.len(),
+            CLOSED_DIAG_BADGE_CAP,
+            "the closed-file badge cache must stop at the cap",
+        );
+        let gens = backend.closed_diag_gen.lock().await;
+        assert_eq!(
+            gens.len(),
+            CLOSED_DIAG_BADGE_CAP,
+            "the closed-run generations share the cache entry's lifetime",
+        );
+        // The oldest badge is gone; the newest is kept (least-recently-published
+        // eviction, not arbitrary).
+        assert!(!cache.contains_key(&uri_at(0)), "oldest badge evicted");
+        assert!(!gens.contains_key(&uri_at(0)), "oldest generation evicted");
+        assert!(cache.contains_key(&uri_at(total - 1)), "newest badge kept");
+    }
+
+    /// #1144: the inline closed-file republish must not memoise the deep
+    /// compiler tier.  `did_close` runs `run_diagnostics_core` synchronously for
+    /// every file the editor ever opened; routing that through the salsa
+    /// `SourceFile` pinned the file's `compilation_unit` (IR/CFG/SSA) and
+    /// `compiler_check_diagnostics` memos, which salsa cannot evict — the
+    /// unbounded term that OOM-killed the server on a workspace browse.  The
+    /// badge itself (#865) is unchanged: the same diagnostics, computed
+    /// uncached and thrown away.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn closed_file_republish_does_not_memoise_the_deep_compiler_tier() {
+        let root = unique_scratch_dir("close-no-deep-memo");
+        let on_disk = root.join("warn.tcl");
+        let src = "proc foo {} { set y 1 }\n";
+        std::fs::write(&on_disk, src).unwrap();
+        let executed: Arc<std::sync::Mutex<Vec<String>>> = Arc::default();
+        let sink = Arc::clone(&executed);
+        let backend = test_backend_over(tcl_lsp_db::TclDatabase::with_event_logger(move |key| {
+            sink.lock().unwrap().push(key);
+        }));
+        let uri = Uri::from_file_path(&on_disk).unwrap();
+        register(&backend, &uri, src).await;
+        backend
+            .db_set_source(&uri, src.to_owned(), "tcl8.6".to_owned())
+            .await;
+
+        backend
+            .did_close(DidCloseTextDocumentParams {
+                text_document: TextDocumentIdentifier { uri: uri.clone() },
+            })
+            .await;
+
+        // The lightweight signature/decl queries a closed file still answers for
+        // open documents' cross-file resolution are fine; the deep tier is not.
+        let deep: Vec<String> = executed
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|key| {
+                [
+                    "compilation_unit",
+                    "compiler_check_diagnostics",
+                    "file_analysis_incremental",
+                ]
+                .iter()
+                .any(|query| key.contains(query))
+            })
+            .cloned()
+            .collect();
+        assert!(
+            deep.is_empty(),
+            "a closed file's republish must not build memoised deep-tier queries: {deep:?}",
+        );
+        // …and it still produces the badge #865 promises.
+        let cache = backend.pull_diag_cache.lock().await;
+        let entry = cache.get(&uri).expect("closed on-disk file keeps a badge");
+        assert!(
+            entry.diagnostics.iter().any(|d| matches!(
+                &d.code,
+                Some(tower_lsp_server::ls_types::NumberOrString::String(c)) if c == "W211"
+            )),
+            "the uncached closed tier must still carry the file's W211: {:?}",
+            entry.diagnostics,
+        );
+        drop(cache);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// #1144: an **open** document is exempt from the closed-badge cap — its
+    /// cache entry is owned by the open pipeline and must survive an eviction
+    /// sweep that happens to reach its URI.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn closed_diag_badge_cap_spares_reopened_documents() {
+        let backend = test_backend();
+        let reopened = Uri::from_str("file:///browse/reopened.tcl").unwrap();
+        backend.pull_diag_cache.lock().await.insert(
+            reopened.clone(),
+            PullDiagEntry {
+                result_id: next_pull_diag_result_id(),
+                revision: 0,
+                diagnostics: Vec::new(),
+            },
+        );
+        // Queued while closed, then reopened before the cap pushed it out.
+        backend.record_closed_diag_badge(&reopened).await;
+        backend.documents.lock().await.insert(
+            reopened.clone(),
+            DocumentState::new("set x 1\n".to_owned(), "tcl8.6".to_owned()),
+        );
+        for i in 0..CLOSED_DIAG_BADGE_CAP {
+            let uri = Uri::from_str(&format!("file:///browse/g{i}.tcl")).unwrap();
+            backend.record_closed_diag_badge(&uri).await;
+        }
+
+        assert!(
+            backend.pull_diag_cache.lock().await.contains_key(&reopened),
+            "an open document's cache entry must survive the closed-badge sweep",
+        );
+    }
+
     /// #104 regression: reopening a document after the diagnostics master
     /// switch (`tclLsp.features.diagnostics`) was turned off *while the file
     /// was closed* must analyse under the current (off) switch and clear the
     /// squiggles — not republish the file's pre-toggle diagnostics.
     ///
-    /// Root cause: `did_close` retains the URI's [`DiagSlot`] (only the live
-    /// document and index entry are dropped), so `slot.latest_inputs` keeps the
-    /// `diagnostics_enabled = true` captured on the pre-close analysis. `did_open`
-    /// used to take the reuse-cached-inputs fast path (`schedule_diagnostics`,
-    /// `force_refresh = false`), so the reopen's worker drained under those stale
-    /// on-switch inputs and republished the diagnostics even though the master
-    /// switch was now off (the `test-ext` `#104` flake, which only lined up under
-    /// full-suite load). Opening a document is a config-context boundary, so it
-    /// now force-refreshes the inputs; the slot's post-reopen
-    /// `diagnostics_enabled` reflecting the *current* toggle proves it.
+    /// Root cause: `did_close` used to retain the URI's [`DiagSlot`] (only the
+    /// live document and index entry were dropped), so `slot.latest_inputs` kept
+    /// the `diagnostics_enabled = true` captured on the pre-close analysis.
+    /// `did_open` used to take the reuse-cached-inputs fast path
+    /// (`schedule_diagnostics`, `force_refresh = false`), so the reopen's worker
+    /// drained under those stale on-switch inputs and republished the diagnostics
+    /// even though the master switch was now off (the `test-ext` `#104` flake,
+    /// which only lined up under full-suite load). Opening a document is a
+    /// config-context boundary, so it now force-refreshes the inputs; the slot's
+    /// post-reopen `diagnostics_enabled` reflecting the *current* toggle proves
+    /// it.  (#1144 additionally releases the slot on close, so the stale inputs
+    /// are gone by then too — belt and braces for the same bug.)
     ///
     /// Asserted on the slot's captured inputs (set synchronously by
     /// `schedule_diagnostics_impl` before the worker spawns) rather than a
@@ -18292,9 +18625,9 @@ mod tests {
             "sanity: the initial open captures the master switch as on",
         );
 
-        // 2. Close the tab — the DiagSlot (with its now-stale inputs) is
-        //    retained, so the file keeps a badge (#865). The switch is still on
-        //    at close time, so the retained inputs are `true`.
+        // 2. Close the tab. The slot's captured inputs are released (#1144) —
+        //    either with the slot itself or, if its worker is still draining,
+        //    as a cleared `latest_inputs`. Nothing stale survives to be reused.
         backend
             .did_close(DidCloseTextDocumentParams {
                 text_document: TextDocumentIdentifier { uri: uri.clone() },
@@ -18302,13 +18635,13 @@ mod tests {
             .await;
         assert_eq!(
             captured_switch().await,
-            Some(true),
-            "did_close retains the DiagSlot with its (now-stale) on-switch inputs",
+            None,
+            "did_close must release the slot's captured inputs (#1144)",
         );
 
         // 3. Turn the diagnostics master switch off while the file is closed —
-        //    the toggle store changes, but nothing re-resolves the closed URI's
-        //    retained slot inputs.
+        //    the toggle store changes, and the closed URI holds no resolved
+        //    inputs to go stale.
         backend.feature_toggles.lock().await.apply(
             serde_json::json!({ "diagnostics": false })
                 .as_object()
@@ -20392,6 +20725,23 @@ mod tests {
         assert!(is_skipped_scan_dir(Path::new("/a/tmp")));
         assert!(!is_skipped_scan_dir(Path::new("/a/src")));
         assert!(!is_skipped_scan_dir(Path::new("/a/irules")));
+    }
+
+    /// Poll `cond` until it holds or ~2s elapse, reporting whether it held.
+    /// For assertions on state a detached background task settles (a debounced
+    /// diagnostics worker retiring, say) rather than the awaited call itself.
+    async fn wait_for<F, Fut>(mut cond: F) -> bool
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = bool>,
+    {
+        for _ in 0..200 {
+            if cond().await {
+                return true;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        false
     }
 
     /// Build a unique scratch directory under the system temp dir

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -361,6 +361,67 @@ struct SemanticTokensRefreshCtx {
     refresh_pending: Arc<std::sync::atomic::AtomicBool>,
 }
 
+/// URIs whose detached semantic-token convergence continuation is still in
+/// flight (#1147) — the dedup set behind [`ConvergenceGuard`].
+///
+/// A `std::sync::Mutex`: every critical section is a single `HashSet` insert or
+/// remove, never held across an await, and the remove has to happen from
+/// [`ConvergenceGuard`]'s `Drop`, which cannot await.
+type ConvergenceInFlight = Arc<std::sync::Mutex<HashSet<Uri>>>;
+
+/// A claim on one URI's convergence continuation: at most one may be detached
+/// per document at a time (#1147).
+///
+/// A `semanticTokens/range` or `semanticTokens/full` request that overruns
+/// [`SEMANTIC_TOKENS_FAST_PATH_BUDGET`] detaches a continuation that holds the
+/// document's text and its coarse token stream and queues a blocking recompute.
+/// Nothing bounded that: an editor scrolling a cold file issues a viewport
+/// request per frame, so N in-flight range requests on one document meant N live
+/// document copies and N queued jobs, and the pre-existing coalescing
+/// ([`SemanticTokensRefreshCtx::request_refresh_coalesced`]) collapsed only the
+/// resulting notification, never the work behind it.
+///
+/// The continuations are redundant with each other by construction: the only
+/// output is a *workspace-scoped* `workspace/semanticTokens/refresh`, which asks
+/// the client to re-pull tokens for every open document. So a pending
+/// continuation already covers every later request for the same URI, and the
+/// `range` and `full` paths share one set for that reason.
+///
+/// A guard rather than a bare flag so an aborted or panicking continuation
+/// releases the claim as its frame unwinds — a stuck marker would silence the
+/// URI's convergence for the rest of the session.
+struct ConvergenceGuard {
+    uri: Uri,
+    in_flight: ConvergenceInFlight,
+}
+
+impl ConvergenceGuard {
+    /// Claim `uri`, or `None` when a continuation for it is already pending — in
+    /// which case the caller skips detaching and settles as `coalesced`.
+    fn claim(in_flight: &ConvergenceInFlight, uri: &Uri) -> Option<Self> {
+        let claimed = in_flight
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(uri.clone());
+        claimed.then(|| Self {
+            uri: uri.clone(),
+            in_flight: Arc::clone(in_flight),
+        })
+    }
+}
+
+impl Drop for ConvergenceGuard {
+    fn drop(&mut self) {
+        // Recovering from a poisoned lock rather than skipping the removal: the
+        // set holds no invariant a panic could have broken, and leaving a marker
+        // behind would permanently silence this URI's convergence.
+        self.in_flight
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(&self.uri);
+    }
+}
+
 /// Per-URI cache of the last semantic-token stream served: `(resultId, packed
 /// integer data)`. Shared type alias for [`Backend::last_semantic_tokens`] and
 /// [`SemanticTokensRefreshCtx::last_semantic_tokens`] — the same cache, read
@@ -393,7 +454,10 @@ struct RangeConvergenceInputs {
     /// The coarse token stream already served, to diff the enriched recompute against.
     served: Vec<u32>,
     registry: &'static CommandRegistry,
-    text: String,
+    /// The document text, shared with the request's own coarse tokenisation
+    /// rather than cloned for the continuation (#1147): one buffer per request,
+    /// not one per tier.
+    text: Arc<str>,
     dialect: String,
     range: CoreLspRange,
 }
@@ -525,6 +589,10 @@ enum FullSettleOutcome {
     /// The document has no salsa input, so the response was computed enriched
     /// from a freshly-built unit + analysis.
     NoAnalysis,
+    /// A convergence continuation for this document was already in flight, so
+    /// no second one was detached (#1147): the pending one's workspace-scoped
+    /// refresh covers this request too.
+    Coalesced,
 }
 
 impl FullSettleOutcome {
@@ -533,6 +601,7 @@ impl FullSettleOutcome {
             Self::Landed => "landed",
             Self::Cancelled => "cancelled",
             Self::NoAnalysis => "no-analysis",
+            Self::Coalesced => "coalesced",
         }
     }
 }
@@ -2577,6 +2646,13 @@ pub struct Backend {
     /// not coalesce them itself (VS Code does; eglot may not) would re-pull
     /// every open document once per refresh.
     semantic_tokens_refresh_pending: Arc<std::sync::atomic::AtomicBool>,
+    /// URIs with a detached semantic-token convergence continuation in flight
+    /// (#1147).  `semantic_tokens_refresh_pending` above coalesces the resulting
+    /// *notification*; this bounds the **work**, which is what holds a document
+    /// copy and a queued blocking job.  Shared by the `range` and `full` timeout
+    /// paths, since both settle into the same workspace-scoped refresh — see
+    /// [`ConvergenceGuard`].
+    semantic_tokens_convergence: ConvergenceInFlight,
     /// Abort handle for the most recent [`Backend::spawn_workspace_warm`] task, so
     /// a fresh warm (from `initialize` / folder-add / config-change) supersedes any
     /// still-running one. Without it, overlapping warms each hold their own
@@ -3045,6 +3121,7 @@ impl Backend {
             last_semantic_tokens: Arc::new(Mutex::new(HashMap::new())),
             workspace_class_analyses: Arc::new(Mutex::new(HashMap::new())),
             semantic_tokens_refresh_pending: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            semantic_tokens_convergence: Arc::new(std::sync::Mutex::new(HashSet::new())),
             warm_task: std::sync::Mutex::new(None),
             edit_order: EditOrder::default(),
         }
@@ -4093,31 +4170,10 @@ impl Backend {
                 .await;
             }
             () = tokio::time::sleep(SEMANTIC_TOKENS_FAST_PATH_BUDGET) => {
-                // Too slow for a synchronous first paint. Detach a
-                // continuation that keeps waiting on the still-running
-                // enriched computation and asks the client to re-request once
-                // it lands, instead of blocking this response on it.
-                let refresh_ctx = SemanticTokensRefreshCtx {
-                    client: self.client.clone(),
-                    last_semantic_tokens: Arc::clone(&self.last_semantic_tokens),
-                    refresh_pending: Arc::clone(&self.semantic_tokens_refresh_pending),
-                };
-                let uri = uri.clone();
-                tokio::spawn(async move {
-                    // Settle either way — including on a cancelled read — so a
-                    // waiter can key on the marker instead of racing the
-                    // debounced refresh that only *sometimes* follows.
-                    let (refreshed, outcome) = match enriched.await {
-                        Ok(Some(tokens)) => (
-                            refresh_ctx.deliver_if_changed(&uri, &tokens.data).await,
-                            FullSettleOutcome::Landed,
-                        ),
-                        _ => (false, FullSettleOutcome::Cancelled),
-                    };
-                    refresh_ctx
-                        .log_full_convergence_settled(&uri, refreshed, outcome)
-                        .await;
-                });
+                // Too slow for a synchronous first paint: hand the still-running
+                // enriched read to a detached continuation rather than blocking
+                // this response on it, and serve the coarse tier below.
+                self.spawn_full_convergence(uri, enriched).await;
             }
         }
 
@@ -4132,6 +4188,53 @@ impl Backend {
             message: format!("semantic_tokens worker panicked: {err}").into(),
             data: None,
         })
+    }
+
+    /// Detach the `semanticTokens/full` convergence continuation for a request
+    /// whose enriched read overran [`SEMANTIC_TOKENS_FAST_PATH_BUDGET`]: keep
+    /// awaiting the read and ask the client to re-request once it lands, so the
+    /// enrichment reaches the editor without waiting for the next edit.
+    ///
+    /// At most one continuation per document (#1147), on the same claim set the
+    /// `range` path uses: both end in the same workspace-scoped
+    /// `workspace/semanticTokens/refresh`, so a continuation already pending for
+    /// this URI covers this request too and a second one would only hold a
+    /// second live read for the same answer. The skipped request still settles,
+    /// as `coalesced` — the marker is emitted on *every* path by contract.
+    async fn spawn_full_convergence(
+        &self,
+        uri: &Uri,
+        enriched: tokio::task::JoinHandle<Option<tcl_lsp_core::semantic_tokens::SemanticTokens>>,
+    ) {
+        let Some(guard) = ConvergenceGuard::claim(&self.semantic_tokens_convergence, uri) else {
+            log_full_convergence_settled(&self.client, uri, false, FullSettleOutcome::Coalesced)
+                .await;
+            return;
+        };
+        let refresh_ctx = SemanticTokensRefreshCtx {
+            client: self.client.clone(),
+            last_semantic_tokens: Arc::clone(&self.last_semantic_tokens),
+            refresh_pending: Arc::clone(&self.semantic_tokens_refresh_pending),
+        };
+        let uri = uri.clone();
+        tokio::spawn(async move {
+            // Settle either way — including on a cancelled read — so a waiter can
+            // key on the marker instead of racing the debounced refresh that only
+            // *sometimes* follows.
+            let (refreshed, outcome) = match enriched.await {
+                Ok(Some(tokens)) => (
+                    refresh_ctx.deliver_if_changed(&uri, &tokens.data).await,
+                    FullSettleOutcome::Landed,
+                ),
+                _ => (false, FullSettleOutcome::Cancelled),
+            };
+            refresh_ctx
+                .log_full_convergence_settled(&uri, refreshed, outcome)
+                .await;
+            // Release the per-URI claim only now the decision is made, so every
+            // request that arrived while this ran rode along with it.
+            drop(guard);
+        });
     }
 
     /// Re-index a (now-closed) document from its on-disk contents so
@@ -9488,10 +9591,15 @@ impl Backend {
     /// `workspace/semanticTokens/refresh` if it genuinely differs from the coarse
     /// `served` stream. The range stream is never in `last_semantic_tokens`, so
     /// the diff is against the exact `served` bytes rather than the token cache.
+    ///
+    /// `guard` is the caller's per-URI claim (#1147); it is held for the
+    /// continuation's whole life so a later request for the same document skips
+    /// detaching a redundant second one.
     fn spawn_range_convergence(
         &self,
         inputs: RangeConvergenceInputs,
         pending: RangeConvergencePending,
+        guard: ConvergenceGuard,
     ) {
         let RangeConvergenceInputs {
             uri,
@@ -9560,6 +9668,9 @@ impl Backend {
                 RangeSettleOutcome::Compared
             };
             log_range_convergence_settled(&refresh_ctx.client, &uri, refreshed, outcome).await;
+            // Release the per-URI claim only now the decision is made, so every
+            // viewport request that arrived while this ran rode along with it.
+            drop(guard);
         });
     }
 }
@@ -9582,6 +9693,10 @@ enum RangeSettleOutcome {
     /// unindexed buffer, or a `did_close` racing the two reads), so there is no
     /// enriched tier for this request to converge to.
     NoAnalysis,
+    /// A convergence continuation for this document was already in flight, so
+    /// no second one was detached (#1147): the pending one's workspace-scoped
+    /// refresh covers this viewport too.
+    Coalesced,
 }
 
 impl RangeSettleOutcome {
@@ -9591,6 +9706,7 @@ impl RangeSettleOutcome {
             Self::Cancelled => "cancelled",
             Self::ServedEnriched => "served-enriched",
             Self::NoAnalysis => "no-analysis",
+            Self::Coalesced => "coalesced",
         }
     }
 }
@@ -11313,13 +11429,18 @@ impl LanguageServer for Backend {
         // handles at all.
         let served_enriched = cached_cu.is_some() || cached_analysis.is_some();
         // Pure-CPU tokenisation on a worker so a parser panic is contained
-        // as a JSON-RPC error.
-        let (text, dialect) = (doc.text.clone(), doc.dialect.clone());
+        // as a JSON-RPC error.  The text goes in behind an `Arc` so the
+        // convergence continuation below shares this buffer instead of taking a
+        // second full-document copy (#1147).
+        let text: Arc<str> = Arc::from(doc.text.as_str());
+        let dialect = doc.dialect.clone();
+        let serve_text = Arc::clone(&text);
+        let serve_dialect = dialect.clone();
         let serve_registry = registry;
         let core_data = tokio::task::spawn_blocking(move || {
             core_semantic_tokens::range_with_cu_and_analysis(
-                &text,
-                &dialect,
+                &serve_text,
+                &serve_dialect,
                 core_range,
                 serve_registry,
                 cached_cu.as_deref(),
@@ -11338,17 +11459,37 @@ impl LanguageServer for Backend {
         // enriched reads overran the budget, detach a continuation that awaits
         // them and refreshes once the enriched viewport differs.
         if let Some(pending) = pending {
-            self.spawn_range_convergence(
-                RangeConvergenceInputs {
-                    uri: uri.as_str().to_owned(),
-                    served: core_data.clone(),
-                    registry,
-                    text: doc.text.clone(),
-                    dialect: doc.dialect.clone(),
-                    range: core_range,
-                },
-                pending,
-            );
+            // At most one continuation per document (#1147): a client scrolling
+            // a cold file issues a viewport request per frame, and each detached
+            // continuation holds the document and queues a blocking recompute
+            // only to ask for the same workspace-wide refresh the pending one
+            // will already ask for.
+            if let Some(guard) = ConvergenceGuard::claim(&self.semantic_tokens_convergence, uri) {
+                self.spawn_range_convergence(
+                    RangeConvergenceInputs {
+                        uri: uri.as_str().to_owned(),
+                        served: core_data.clone(),
+                        registry,
+                        text,
+                        dialect,
+                        range: core_range,
+                    },
+                    pending,
+                    guard,
+                );
+            } else {
+                // Settle here: the in-flight continuation settles under its own
+                // request's marker, so without this one an observer waiting on
+                // *this* request's decision would wait for a line that never
+                // comes.
+                log_range_convergence_settled(
+                    &self.client,
+                    uri.as_str(),
+                    false,
+                    RangeSettleOutcome::Coalesced,
+                )
+                .await;
+            }
         } else {
             // No continuation to detach, so settle here instead: this request's
             // convergence decision is already final and an observer waiting on
@@ -18380,6 +18521,7 @@ mod tests {
             last_semantic_tokens: Arc::new(Mutex::new(HashMap::new())),
             workspace_class_analyses: Arc::new(Mutex::new(HashMap::new())),
             semantic_tokens_refresh_pending: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            semantic_tokens_convergence: Arc::new(std::sync::Mutex::new(HashSet::new())),
             warm_task: std::sync::Mutex::new(None),
             edit_order: EditOrder::default(),
         }
@@ -23977,6 +24119,64 @@ mod tests {
                 .is_none(),
             "deliver_if_changed must not resurrect a cache entry for a \
              closed document",
+        );
+    }
+
+    /// #1147: only the first of several concurrent convergence attempts on one
+    /// URI may detach a continuation, and the claim is released once it
+    /// finishes, so the next request converges normally. Other URIs are
+    /// independent.
+    #[test]
+    fn convergence_guard_admits_one_continuation_per_uri() {
+        let in_flight: ConvergenceInFlight = Arc::new(std::sync::Mutex::new(HashSet::new()));
+        let uri = Uri::from_str("file:///cold.tcl").unwrap();
+        let other = Uri::from_str("file:///warm.tcl").unwrap();
+
+        let first = ConvergenceGuard::claim(&in_flight, &uri).expect("the first attempt detaches");
+        assert!(
+            ConvergenceGuard::claim(&in_flight, &uri).is_none(),
+            "a second attempt on the same URI must not detach a redundant \
+             continuation",
+        );
+        let sibling =
+            ConvergenceGuard::claim(&in_flight, &other).expect("a different URI is unaffected");
+
+        // The continuation finishes: the URI converges again on the next request.
+        drop(first);
+        let again = ConvergenceGuard::claim(&in_flight, &uri)
+            .expect("a completed continuation releases its URI");
+        drop(again);
+        drop(sibling);
+        assert!(
+            in_flight
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .is_empty(),
+            "every released claim must leave the in-flight set",
+        );
+    }
+
+    /// #1147: the claim is a guard, not a flag, so a continuation that is
+    /// aborted mid-flight (or panics) still releases its URI — a stuck marker
+    /// would silence convergence for that document for the session.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn convergence_guard_releases_on_cancellation() {
+        let in_flight: ConvergenceInFlight = Arc::new(std::sync::Mutex::new(HashSet::new()));
+        let uri = Uri::from_str("file:///aborted.tcl").unwrap();
+        let guard = ConvergenceGuard::claim(&in_flight, &uri).expect("claimed");
+
+        let task = tokio::spawn(async move {
+            // Never completes; the abort below drops the future — and the guard
+            // it owns — instead.
+            tokio::time::sleep(std::time::Duration::from_hours(1)).await;
+            drop(guard);
+        });
+        task.abort();
+        assert!(task.await.is_err(), "the continuation was cancelled");
+
+        assert!(
+            ConvergenceGuard::claim(&in_flight, &uri).is_some(),
+            "a cancelled continuation must release its URI",
         );
     }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -727,6 +727,9 @@ struct DiagInputs {
     rehomed_source_seeds: Arc<Mutex<HashMap<String, Vec<String>>>>,
     /// Package database for the W120 workspace-refinement post-filter (#723).
     package_resolver: Arc<RwLock<PackageResolver>>,
+    /// Memo for the unclosed-delimiter recovery path's widened known-command
+    /// set (see [`RecoveryNameCache`]).
+    recovery_names: Arc<Mutex<RecoveryNameCache>>,
     /// `.tcl-lsp.ini [project] entryPoints` for this document's folder (#804):
     /// when non-empty, the W120 refinement inherits these entries' requires and
     /// disables the automatic `source`-graph inheritance.
@@ -1130,9 +1133,7 @@ async fn compute_base_analysis(
     disabled: &HashSet<String>,
     extra_commands: &HashSet<String>,
     non_ascii_mode: NonAsciiMode,
-    registry: &CommandRegistry,
-    workspace_index: &Arc<RwLock<core_workspace_index::WorkspaceIndex>>,
-    package_resolver: &Arc<RwLock<PackageResolver>>,
+    recovery: &RecoveryWidenCtx<'_>,
 ) -> ControlFlow<bool, Arc<AnalysisResult>> {
     let &SalsaAnalysisCtx {
         db,
@@ -1157,19 +1158,11 @@ async fn compute_base_analysis(
     // `recovery_known_commands`'s own `script_is_complete` gate: a
     // well-formed document pays nothing extra.
     if !tcl_lexer::script_is_complete(text) {
-        let widened = widen_recovery_extra_commands(
-            extra_commands,
-            text,
-            dialect,
-            registry,
-            workspace_index,
-            package_resolver,
-        )
-        .await;
+        let widened = widen_recovery_extra_commands(recovery, extra_commands, text, dialect).await;
         let (a_text, a_dialect, a_disabled) =
             (text.to_owned(), dialect.to_owned(), disabled.clone());
         return match tokio::task::spawn_blocking(move || {
-            Backend::configured_analyser(a_disabled, non_ascii_mode, widened)
+            Backend::recovery_analyser(a_disabled, non_ascii_mode, widened)
                 .analyse(&a_text, &a_dialect)
                 .clone()
         })
@@ -1248,6 +1241,67 @@ async fn compute_base_analysis(
     }
 }
 
+/// The workspace handles [`widen_recovery_extra_commands`] reads, plus the memo
+/// it fills — grouped so [`compute_base_analysis`] threads one borrow rather
+/// than four.
+struct RecoveryWidenCtx<'a> {
+    cache: &'a Arc<Mutex<RecoveryNameCache>>,
+    registry: &'a CommandRegistry,
+    workspace_index: &'a Arc<RwLock<core_workspace_index::WorkspaceIndex>>,
+    package_resolver: &'a Arc<RwLock<PackageResolver>>,
+}
+
+/// The inputs [`RecoveryNameCache`] keys its entries on — everything the
+/// widened set is a function of, and nothing else.
+///
+/// `index_generation` / `resolver_revision` are the two whole-workspace change
+/// signals ([`core_workspace_index::WorkspaceIndex::generation`] /
+/// [`PackageResolver::revision`]); the rest is per-document or per-config and
+/// cheap to compare.
+#[derive(Clone, PartialEq, Eq)]
+struct RecoveryNameKey {
+    index_generation: u64,
+    resolver_revision: u64,
+    base: Vec<String>,
+    requires: Vec<String>,
+    dialect: String,
+}
+
+/// Two-tier memo for [`widen_recovery_extra_commands`] (issue #1154).
+///
+/// The **shared** tier — `tclLsp.extraCommands` widened with every
+/// workspace-indexed proc / class and every auto-loadable command name — is the
+/// expensive one (three `String` allocations per indexed name) and depends only
+/// on `(index_generation, resolver_revision, base)`. The **widened** tier adds
+/// the document's own `package require` closure on top, which additionally
+/// depends on `(requires, dialect)` and reads implementation files from disk.
+///
+/// Keeping the shared tier separate means a document whose `package require`
+/// lines change (or a different document taking the recovery branch) still
+/// reuses the workspace/auto-command union; only the small package layer is
+/// rebuilt. Both tiers are handed out as `Arc`, so the analyser receives the
+/// set as a refcount bump — see `Analyser::with_shared_extra_commands`.
+///
+/// One entry each: mid-typing there is one document with an open delimiter, so
+/// a larger cache would buy nothing but memory.
+#[derive(Default)]
+struct RecoveryNameCache {
+    /// The workspace + auto-command union, without any document's package
+    /// closure.
+    shared: Option<SharedRecoveryNames>,
+    /// The full widened set for the last document that needed one.
+    widened: Option<(RecoveryNameKey, Arc<HashSet<String>>)>,
+}
+
+/// [`RecoveryNameCache`]'s document-independent tier and the inputs it was
+/// built from.
+struct SharedRecoveryNames {
+    index_generation: u64,
+    resolver_revision: u64,
+    base: Vec<String>,
+    names: Arc<HashSet<String>>,
+}
+
 /// Widen `base` (the resolved `tclLsp.extraCommands`) with the workspace's
 /// own proc/class names and the commands available to `text` through package
 /// resolution — the LSP-layer name-resolution hierarchy the unclosed-
@@ -1267,26 +1321,100 @@ async fn compute_base_analysis(
 /// document's requires from an *already-published* analysis, which this
 /// document, being analysed for the first time right now, cannot yet have.
 ///
+/// Memoised through `cache` — see [`RecoveryNameCache`]. The recovery branch is
+/// the *normal* state while a delimiter is open, so this runs on every debounced
+/// run of a document being typed into; without the memo each of those rebuilt
+/// the whole set from scratch.
+///
+/// Only called from [`compute_base_analysis`]'s `!script_is_complete`
+/// recovery branch — never on the well-formed-document hot path.
+async fn widen_recovery_extra_commands(
+    ctx: &RecoveryWidenCtx<'_>,
+    base: &HashSet<String>,
+    text: &str,
+    dialect: &str,
+) -> Arc<HashSet<String>> {
+    // `base` is the user's configured list — small, and its identity is part of
+    // the key, so normalise it once into a comparable form.
+    let mut base_key: Vec<String> = base.iter().cloned().collect();
+    base_key.sort_unstable();
+    let requires: Vec<String> =
+        tcl_compiler::signature_scan::extract_signatures(text, ctx.registry)
+            .package_requires
+            .into_iter()
+            .map(|pr| pr.name)
+            .collect();
+    let index_generation = ctx.workspace_index.read().await.generation();
+    let resolver_revision = ctx.package_resolver.read().await.revision();
+    let key = RecoveryNameKey {
+        index_generation,
+        resolver_revision,
+        base: base_key,
+        requires,
+        dialect: dialect.to_owned(),
+    };
+    {
+        let cached = ctx.cache.lock().await;
+        if let Some((cached_key, names)) = cached.widened.as_ref()
+            && *cached_key == key
+        {
+            return Arc::clone(names);
+        }
+    }
+
+    let shared = shared_recovery_names(ctx, &key).await;
+    let widened = if key.requires.is_empty() {
+        shared
+    } else {
+        let mut names = (*shared).clone();
+        // Same release-aware package view the W123 refinement uses, so the
+        // known-name set and the diagnostic filter cannot disagree about which
+        // guarded packages this document can actually load.
+        let target = tcl_dialect::TclVersion::from_dialect(Some(dialect));
+        let commands = ctx.package_resolver.read().await.package_defined_commands(
+            &key.requires,
+            target,
+            &|path| {
+                std::fs::read_to_string(path)
+                    .map(|text| defined_command_tails(&text, dialect))
+                    .unwrap_or_default()
+            },
+        );
+        names.extend(commands);
+        Arc::new(names)
+    };
+    ctx.cache.lock().await.widened = Some((key, Arc::clone(&widened)));
+    widened
+}
+
+/// The document-independent tier of [`widen_recovery_extra_commands`]:
+/// `base` ∪ every workspace-indexed proc/class name ∪ every auto-loadable
+/// command name, cached on `(index generation, resolver revision, base)`.
+///
 /// Workspace names go through `tcl_compiler::analyser::utils::insert_qualified_and_tail`
 /// — the same three-form (as-is / `::`-stripped / tail) insertion
 /// `recovery_known_commands` uses for a document's own procs/classes/
 /// aliases/renames — rather than a second, hand-rolled copy: a workspace
 /// proc referenced by its absolute `::ns::name` form needs recognising just
-/// as much as one referenced relatively.
-///
-/// Only called from [`compute_base_analysis`]'s `!script_is_complete`
-/// recovery branch — never on the well-formed-document hot path.
-async fn widen_recovery_extra_commands(
-    base: &HashSet<String>,
-    text: &str,
-    dialect: &str,
-    registry: &CommandRegistry,
-    workspace_index: &Arc<RwLock<core_workspace_index::WorkspaceIndex>>,
-    package_resolver: &Arc<RwLock<PackageResolver>>,
-) -> HashSet<String> {
-    let mut names = base.clone();
+/// as much as one referenced relatively. The auto-loadable names mirror the
+/// #832 W123 refinement (`tclIndex`-style, no `package require` needed).
+async fn shared_recovery_names(
+    ctx: &RecoveryWidenCtx<'_>,
+    key: &RecoveryNameKey,
+) -> Arc<HashSet<String>> {
     {
-        let index = workspace_index.read().await;
+        let cached = ctx.cache.lock().await;
+        if let Some(shared) = cached.shared.as_ref()
+            && shared.index_generation == key.index_generation
+            && shared.resolver_revision == key.resolver_revision
+            && shared.base == key.base
+        {
+            return Arc::clone(&shared.names);
+        }
+    }
+    let mut names: HashSet<String> = key.base.iter().cloned().collect();
+    {
+        let index = ctx.workspace_index.read().await;
         for p in index.procs() {
             tcl_compiler::analyser::utils::insert_qualified_and_tail(&mut names, &p.qualified_name);
         }
@@ -1294,27 +1422,16 @@ async fn widen_recovery_extra_commands(
             tcl_compiler::analyser::utils::insert_qualified_and_tail(&mut names, &c.qualified_name);
         }
     }
-    let requires: Vec<String> = tcl_compiler::signature_scan::extract_signatures(text, registry)
-        .package_requires
-        .into_iter()
-        .map(|pr| pr.name)
-        .collect();
-    let resolver = package_resolver.read().await;
-    for name in resolver.auto_command_names() {
+    for name in ctx.package_resolver.read().await.auto_command_names() {
         names.insert(name.trim_start_matches("::").to_owned());
     }
-    if !requires.is_empty() {
-        // Same release-aware package view the W123 refinement uses, so the
-        // known-name set and the diagnostic filter cannot disagree about which
-        // guarded packages this document can actually load.
-        let target = tcl_dialect::TclVersion::from_dialect(Some(dialect));
-        let commands = resolver.package_defined_commands(&requires, target, &|path| {
-            std::fs::read_to_string(path)
-                .map(|text| defined_command_tails(&text, dialect))
-                .unwrap_or_default()
-        });
-        names.extend(commands);
-    }
+    let names = Arc::new(names);
+    ctx.cache.lock().await.shared = Some(SharedRecoveryNames {
+        index_generation: key.index_generation,
+        resolver_revision: key.resolver_revision,
+        base: key.base.clone(),
+        names: Arc::clone(&names),
+    });
     names
 }
 
@@ -1867,6 +1984,7 @@ async fn run_diagnostics_core(inputs: DiagInputs, uri: &Uri, job: DiagJob) -> bo
         workspace_index,
         rehomed_source_seeds,
         package_resolver,
+        recovery_names,
         entry_points,
         folder_root,
         db,
@@ -1880,14 +1998,6 @@ async fn run_diagnostics_core(inputs: DiagInputs, uri: &Uri, job: DiagJob) -> bo
         db_config: _,
         folder_db_configs: _,
     } = inputs;
-    let DiagToggles {
-        diagnostics_enabled,
-        optimiser_enabled,
-        xc: XcToggles {
-            xc_diagnostics,
-            cross_file_resolution,
-        },
-    } = toggles;
     let DiagJob {
         text,
         dialect,
@@ -1909,7 +2019,7 @@ async fn run_diagnostics_core(inputs: DiagInputs, uri: &Uri, job: DiagJob) -> bo
         client_supports_pull,
     };
 
-    if !diagnostics_enabled {
+    if !toggles.diagnostics_enabled {
         return run_diagnostics_master_off(&delivery).await;
     }
 
@@ -1933,9 +2043,9 @@ async fn run_diagnostics_core(inputs: DiagInputs, uri: &Uri, job: DiagJob) -> bo
         disabled: &disabled,
         severity_overrides: &severity_overrides,
         opt_disabled: &opt_disabled,
-        optimiser_enabled,
+        optimiser_enabled: toggles.optimiser_enabled,
         style_line_length,
-        xc_diagnostics,
+        xc_diagnostics: toggles.xc.xc_diagnostics,
     };
     run_diagnostics_analyser_path(
         &delivery,
@@ -1950,9 +2060,10 @@ async fn run_diagnostics_core(inputs: DiagInputs, uri: &Uri, job: DiagJob) -> bo
             workspace_index: &workspace_index,
             rehomed_source_seeds: &rehomed_source_seeds,
             package_resolver: &package_resolver,
+            recovery_names: &recovery_names,
             entry_points: &entry_points,
             folder_root: folder_root.as_deref(),
-            cross_file_resolution,
+            cross_file_resolution: toggles.xc.cross_file_resolution,
         },
     )
     .await
@@ -1969,6 +2080,9 @@ struct AnalyserPathInputs<'a> {
     /// M9 applied-seed record; the publish path invalidates entries.
     rehomed_source_seeds: &'a Arc<Mutex<HashMap<String, Vec<String>>>>,
     package_resolver: &'a Arc<RwLock<PackageResolver>>,
+    /// Memo for the unclosed-delimiter recovery path's widened known-command
+    /// set (see [`RecoveryNameCache`]).
+    recovery_names: &'a Arc<Mutex<RecoveryNameCache>>,
     /// #804 W120 inheritance for this document's folder (see [`DiagInputs`]).
     entry_points: &'a [String],
     folder_root: Option<&'a Path>,
@@ -2025,14 +2139,18 @@ async fn run_diagnostics_analyser_path(
     // the deep future is parked. This is the explicit form of what salsa's
     // block-and-share gave implicitly, but without the second `compute_base_analysis`
     // call parking a blocking-pool thread on the already-in-flight base read.
+    let recovery = RecoveryWidenCtx {
+        cache: inputs.recovery_names,
+        registry: inputs.registry,
+        workspace_index: inputs.workspace_index,
+        package_resolver: inputs.package_resolver,
+    };
     let base = compute_base_analysis(
         salsa_ctx,
         lift_inputs.disabled,
         inputs.extra_commands,
         inputs.non_ascii_mode,
-        inputs.registry,
-        inputs.workspace_index,
-        inputs.package_resolver,
+        &recovery,
     )
     .shared();
 
@@ -2572,6 +2690,16 @@ pub struct Backend {
     /// `package require myTkPackage` (transitively) pulls in Tk (#723).
     /// Rebuilt by `scan_workspace_folders`.
     package_resolver: Arc<RwLock<PackageResolver>>,
+    /// Memo for [`widen_recovery_extra_commands`] — the unclosed-delimiter
+    /// recovery path's widened known-command set (issue #1154).
+    ///
+    /// That set is a pure function of the workspace index, the package
+    /// database, the configured `tclLsp.extraCommands`, and the document's own
+    /// `package require`s; none of those change per keystroke, but the recovery
+    /// branch is the *normal* mid-typing state, so rebuilding it on every
+    /// debounced run cost three `String` allocations per workspace-indexed proc
+    /// and class (tens of thousands on a tcllib-sized workspace) per edit.
+    recovery_names: Arc<Mutex<RecoveryNameCache>>,
     /// Held for the duration of every `scan_workspace_folders` call (the
     /// blocking tree walk + analysis that rebuilds `package_resolver`).
     /// `ensure_autoload_indexed` acquires (and immediately releases) this
@@ -3263,6 +3391,7 @@ impl Backend {
             severity_overrides: Mutex::new(HashMap::new()),
             workspace_index: Arc::new(RwLock::new(core_workspace_index::WorkspaceIndex::new())),
             package_resolver: Arc::new(RwLock::new(PackageResolver::new())),
+            recovery_names: Arc::new(Mutex::new(RecoveryNameCache::default())),
             workspace_scan_gate: tokio::sync::Mutex::new(()),
             autoloaded_library_uris: Arc::new(Mutex::new(HashSet::new())),
             rehomed_source_seeds: Arc::new(Mutex::new(HashMap::new())),
@@ -8988,6 +9117,20 @@ impl Backend {
             .with_extra_commands(extra_commands)
     }
 
+    /// [`Self::configured_analyser`] taking the recovery path's **shared**
+    /// widened known-command set (see [`RecoveryNameCache`]), so the cached set
+    /// is handed over as a refcount bump instead of being deep-copied into the
+    /// analyser on every keystroke.
+    fn recovery_analyser(
+        disabled: HashSet<String>,
+        mode: NonAsciiMode,
+        extra_commands: Arc<HashSet<String>>,
+    ) -> Analyser {
+        Analyser::with_disabled_diagnostics(disabled)
+            .with_non_ascii_mode(mode)
+            .with_shared_extra_commands(extra_commands)
+    }
+
     /// Return the command registry with `dialect` loaded on top of the
     /// default Tcl + stdlib + tcllib specs.
     ///
@@ -9039,6 +9182,7 @@ impl Backend {
             workspace_index: Arc::clone(&self.workspace_index),
             rehomed_source_seeds: Arc::clone(&self.rehomed_source_seeds),
             package_resolver: Arc::clone(&self.package_resolver),
+            recovery_names: Arc::clone(&self.recovery_names),
             entry_points,
             folder_root,
             db: Arc::clone(&self.db),
@@ -19319,6 +19463,7 @@ mod tests {
             severity_overrides: Mutex::new(HashMap::new()),
             workspace_index: Arc::new(RwLock::new(core_workspace_index::WorkspaceIndex::new())),
             package_resolver: Arc::new(RwLock::new(PackageResolver::new())),
+            recovery_names: Arc::new(Mutex::new(RecoveryNameCache::default())),
             workspace_scan_gate: tokio::sync::Mutex::new(()),
             autoloaded_library_uris: Arc::new(Mutex::new(HashSet::new())),
             rehomed_source_seeds: Arc::new(Mutex::new(HashMap::new())),
@@ -20059,6 +20204,98 @@ mod tests {
         );
         drop(db);
         std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// Issue #1154: the recovery path's widened known-command set must be
+    /// rebuilt only when the workspace index (or the package database, or the
+    /// configured extra commands) actually changes — not on every keystroke
+    /// inside an unterminated block.
+    #[tokio::test]
+    async fn recovery_widening_is_reused_across_edits_and_invalidated_by_the_index() {
+        let backend = test_backend();
+        let registry = tcl_registry::cache::registry_for_profile(
+            tcl_dialect::DialectProfile::by_name("tcl8.6"),
+        );
+        let ctx = RecoveryWidenCtx {
+            cache: &backend.recovery_names,
+            registry,
+            workspace_index: &backend.workspace_index,
+            package_resolver: &backend.package_resolver,
+        };
+        let base: HashSet<String> = ["mycmd".to_owned()].into_iter().collect();
+
+        // Seed the index with a workspace proc, so the widened set has
+        // something index-derived in it.
+        {
+            let mut analysis = tcl_compiler::analyser::Analyser::new();
+            let result = analysis.analyse("proc ::ws::helper {} {}\n", "tcl8.6");
+            backend
+                .workspace_index
+                .write()
+                .await
+                .add_document("file:///ws.tcl", &result);
+        }
+
+        let first = widen_recovery_extra_commands(&ctx, &base, "proc foo {", "tcl8.6").await;
+        assert!(
+            first.contains("ws::helper") && first.contains("helper") && first.contains("mycmd"),
+            "the widened set must carry the workspace proc (qualified + tail) and the base",
+        );
+
+        // A keystroke inside the same unterminated block: different text, same
+        // index / package database / config — the identical allocation is
+        // handed back.
+        let second = widen_recovery_extra_commands(&ctx, &base, "proc foo {x", "tcl8.6").await;
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "an edit that does not change the index must reuse the cached set",
+        );
+
+        // Indexing another document bumps the index generation, which must
+        // invalidate the memo.
+        {
+            let mut analysis = tcl_compiler::analyser::Analyser::new();
+            let result = analysis.analyse("proc ::ws::second {} {}\n", "tcl8.6");
+            backend
+                .workspace_index
+                .write()
+                .await
+                .add_document("file:///ws2.tcl", &result);
+        }
+        let third = widen_recovery_extra_commands(&ctx, &base, "proc foo {x", "tcl8.6").await;
+        assert!(
+            !Arc::ptr_eq(&second, &third),
+            "an index change must rebuild the widened set",
+        );
+        assert!(
+            third.contains("ws::second"),
+            "the rebuilt set must carry the newly-indexed proc",
+        );
+    }
+
+    /// A `PackageResolver` mutation must move its revision, and an unmutated
+    /// resolver must keep it — the signal the recovery memo keys on for the
+    /// package half of the widened set (issue #1154).
+    #[test]
+    fn package_resolver_revision_tracks_mutations() {
+        let mut resolver = PackageResolver::new();
+        let start = resolver.revision();
+        assert_eq!(
+            start,
+            resolver.revision(),
+            "a read must not move the revision"
+        );
+        resolver.add_tcl_index(Vec::new());
+        assert_ne!(
+            start,
+            resolver.revision(),
+            "recording an index must move the revision",
+        );
+        assert_ne!(
+            PackageResolver::new().revision(),
+            PackageResolver::new().revision(),
+            "two distinct resolvers must never share a revision",
+        );
     }
 
     /// Codex #2: a closed run whose generation has been superseded by a newer

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -143,6 +143,11 @@ struct DocumentState {
     /// line). Kept in lock-step with `text`: every mutation of `text` rebuilds
     /// this alongside it (see [`apply_content_change_indexed`]).
     line_index: tcl_lexer::LineIndex,
+    /// Whether `text` contains a bare `\r` — [`tcl_lexer::LineIndex::contains_bare_cr`]
+    /// at the last point `line_index` was rebuilt from scratch. `did_change`
+    /// uses this to decide whether [`tcl_lexer::LineIndex::apply_edit`] remains
+    /// sound for the next incremental edit (see [`apply_content_change_indexed`]).
+    has_bare_cr: bool,
     dialect: String,
     /// The LSP `languageId` the client opened this document with (empty
     /// for documents materialised from disk by the folder scan).  Retained
@@ -164,9 +169,11 @@ struct DocumentState {
 impl DocumentState {
     fn new(text: String, dialect: String) -> Self {
         let line_index = tcl_lexer::LineIndex::new_lsp(&text);
+        let has_bare_cr = tcl_lexer::LineIndex::contains_bare_cr(&text);
         Self {
             text,
             line_index,
+            has_bare_cr,
             dialect,
             language_id: String::new(),
             revision: 0,
@@ -176,9 +183,11 @@ impl DocumentState {
 
     fn with_version(text: String, dialect: String, version: i32) -> Self {
         let line_index = tcl_lexer::LineIndex::new_lsp(&text);
+        let has_bare_cr = tcl_lexer::LineIndex::contains_bare_cr(&text);
         Self {
             text,
             line_index,
+            has_bare_cr,
             dialect,
             language_id: String::new(),
             revision: 0,
@@ -10036,7 +10045,7 @@ impl LanguageServer for Backend {
             return;
         }
         let change_version = params.text_document.version;
-        let (dialect, language_id) = {
+        let (dialect, language_id, dialect_hint_may_have_changed) = {
             let mut docs = self.documents.lock().await;
             // tower-lsp-server 0.23 dispatches notification handlers
             // concurrently (`buffer_unordered(4)`), so a `didChange` can be
@@ -10056,11 +10065,30 @@ impl LanguageServer for Backend {
             // rebuilding it per edit / per position lookup.
             // Take it out, patch through the edit sequence, put it back.
             let mut index = std::mem::replace(&mut entry.line_index, tcl_lexer::LineIndex::new(""));
+            let mut has_bare_cr = entry.has_bare_cr;
+            // Only a generically-opened `tcl` buffer re-resolves the in-source
+            // dialect hint below (see the tail block), so only that case is
+            // worth watching the edits for a hint-touching change.
+            let watch_dialect_hint = entry.language_id == "tcl";
+            let mut dialect_hint_may_have_changed = false;
             for change in &params.content_changes {
-                text = apply_content_change_indexed(&text, change.range, &change.text, &mut index);
+                if watch_dialect_hint
+                    && !dialect_hint_may_have_changed
+                    && change_could_affect_dialect_hint(&text, change.range, &change.text, &index)
+                {
+                    dialect_hint_may_have_changed = true;
+                }
+                text = apply_content_change_indexed(
+                    &text,
+                    change.range,
+                    &change.text,
+                    &mut index,
+                    &mut has_bare_cr,
+                );
             }
             entry.text = text.clone();
             entry.line_index = index;
+            entry.has_bare_cr = has_bare_cr;
             entry.bump_revision(change_version);
             let dialect = entry.dialect.clone();
             let language_id = entry.language_id.clone();
@@ -10084,7 +10112,7 @@ impl LanguageServer for Backend {
             // file contributes no procs, classes or call sites at all).
             self.db_set_source(&uri, text, dialect.clone()).await;
             drop(docs);
-            (dialect, language_id)
+            (dialect, language_id, dialect_hint_may_have_changed)
         };
         // The splice and the salsa source are committed, so
         // hand the ordering turn on before the tail below (#1150).  Everything
@@ -10104,7 +10132,14 @@ impl LanguageServer for Backend {
         // the source (an explicit versioned / non-Tcl languageId is fixed), and
         // only the source hint is edit-sensitive, so this is the sole case that
         // can change.  When it does, commit the new dialect and re-analyse.
-        if language_id == "tcl" {
+        //
+        // `dialect_hint_may_have_changed` (computed above, alongside the
+        // splice) gates the whole-source `detect_dialect` re-scan and its
+        // text clone: the overwhelming majority of keystrokes land well past
+        // the directive/shebang lines and contain none of the content-signature
+        // marker words, so they cannot have changed what `detect_dialect`
+        // would return — re-running it on every such edit was pure waste.
+        if language_id == "tcl" && dialect_hint_may_have_changed {
             // Read the open buffer directly rather than through
             // `read_document`, which would wait for edits this one no longer
             // holds up and answer from a buffer this handler has already
@@ -13772,33 +13807,80 @@ fn parse_folder_config(cfg: &serde_json::Value) -> Option<FolderConfig> {
 /// char boundaries within `text`.
 #[cfg(test)]
 fn apply_content_change(text: &str, range: Option<Range>, new_text: &str) -> String {
-    // Throwaway index for the splice-behaviour tests; the live path persists one
-    // through [`apply_content_change_indexed`].
+    // Throwaway index + flag for the splice-behaviour tests; the live path
+    // persists both through [`apply_content_change_indexed`].
     let mut index = tcl_lexer::LineIndex::new_lsp(text);
-    apply_content_change_indexed(text, range, new_text, &mut index)
+    let mut has_bare_cr = tcl_lexer::LineIndex::contains_bare_cr(text);
+    apply_content_change_indexed(text, range, new_text, &mut index, &mut has_bare_cr)
+}
+
+/// Whether splicing `new_text` into `text[start..end)` could leave a bare
+/// `\r` — a `\r` not immediately followed by `\n` — somewhere the edit
+/// touches, given that `text` itself has none (checked by the caller via
+/// [`tcl_lexer::LineIndex::contains_bare_cr`] before relying on this).
+///
+/// A change can only ever *introduce* a bare `\r` at the seam it touches: a
+/// `\r` inside `new_text` itself, or a `\r` immediately before `start` that
+/// `new_text` no longer pairs with a following `\n`. Nothing elsewhere in
+/// `text` is affected, so this is a local, `O(new_text.len())` check — not a
+/// document-wide rescan.
+fn edit_introduces_bare_cr(text: &str, start: usize, end: usize, new_text: &str) -> bool {
+    let bytes = text.as_bytes();
+    let new_bytes = new_text.as_bytes();
+    let stays_paired = |next: Option<u8>| next == Some(b'\n');
+    if start > 0
+        && bytes[start - 1] == b'\r'
+        && !stays_paired(
+            new_bytes
+                .first()
+                .copied()
+                .or_else(|| bytes.get(end).copied()),
+        )
+    {
+        return true;
+    }
+    new_bytes.iter().enumerate().any(|(i, &b)| {
+        b == b'\r'
+            && !stays_paired(
+                new_bytes
+                    .get(i + 1)
+                    .copied()
+                    .or_else(|| bytes.get(end).copied()),
+            )
+    })
 }
 
 /// [`apply_content_change`] that resolves the edit through a **persisted**
 /// [`tcl_lexer::LineIndex`] built with the LSP end-of-line model
-/// ([`tcl_lexer::LineIndex::new_lsp`]), then rebuilds it from the spliced
-/// result so it stays consistent with the returned text.
+/// ([`tcl_lexer::LineIndex::new_lsp`]), keeping it (and `has_bare_cr`) in
+/// lock-step with the returned text.
 ///
 /// The index **must** use the LSP EOL model (`\n`, `\r\n`, *and lone `\r`*):
 /// the client resolves the incoming `range` against that model, so a `\n`-only
 /// index would resolve a bare-`\r` file's edit to the wrong byte offset and
-/// corrupt the shadow buffer. The `\n`-only [`tcl_lexer::LineIndex::apply_edit`]
-/// cannot maintain an LSP index incrementally across CR/LF boundary ambiguity,
-/// and re-analysis after a change is whole-document regardless, so the index is
-/// rebuilt (not patched) — correctness over a micro-optimisation that never
-/// dominated the change handler's cost.
+/// corrupt the shadow buffer.
+///
+/// [`tcl_lexer::LineIndex::apply_edit`] only tracks `\n`-delimited breaks
+/// (plus the LF half of a CRLF pair), so it patches an `new_lsp`-built index
+/// exactly as a full [`tcl_lexer::LineIndex::new_lsp`] rebuild would **only**
+/// while the document has no bare `\r` to disambiguate — the same condition
+/// its own fuzz-equivalence test (`apply_edit_matches_rebuild_under_fuzz`,
+/// whose edit alphabet is `\n`/`x` only) relies on. `*has_bare_cr` is the
+/// document-level fast path (checked once per edit rather than rescanning);
+/// [`edit_introduces_bare_cr`] additionally catches an edit that would be the
+/// *first* to introduce one, so a document that opened clean stays on the
+/// incremental path for exactly as long as it stays clean, and falls back —
+/// correctly, not just fast — the moment it doesn't.
 fn apply_content_change_indexed(
     text: &str,
     range: Option<Range>,
     new_text: &str,
     index: &mut tcl_lexer::LineIndex,
+    has_bare_cr: &mut bool,
 ) -> String {
     let Some(range) = range else {
         *index = tcl_lexer::LineIndex::new_lsp(new_text);
+        *has_bare_cr = tcl_lexer::LineIndex::contains_bare_cr(new_text);
         return new_text.to_owned();
     };
     let a = index.offset_at_utf16(
@@ -13818,9 +13900,72 @@ fn apply_content_change_indexed(
     out.push_str(&text[..start]);
     out.push_str(new_text);
     out.push_str(&text[end..]);
-    // Rebuild the LSP-EOL index from the spliced document.
-    *index = tcl_lexer::LineIndex::new_lsp(&out);
+    if *has_bare_cr || edit_introduces_bare_cr(text, start, end, new_text) {
+        *index = tcl_lexer::LineIndex::new_lsp(&out);
+        *has_bare_cr = tcl_lexer::LineIndex::contains_bare_cr(&out);
+    } else {
+        index.apply_edit(
+            u32::try_from(start).expect("splice start fits u32 (LineIndex's own 4 GiB budget)"),
+            u32::try_from(end).expect("splice end fits u32 (LineIndex's own 4 GiB budget)"),
+            new_text,
+        );
+    }
     out
+}
+
+/// Leading lines within which a directive/shebang dialect hint can appear —
+/// generous margin over [`tcl_registry::dialects::DIALECT_DIRECTIVE_SCAN_LINES`]
+/// (5 lines) and the shebang's line 0, so a short header comment ahead of one
+/// still counts as "near the top" for [`change_could_affect_dialect_hint`].
+const DIALECT_HINT_LINE_MARGIN: u32 = 20;
+
+/// Whether an edit could change what [`Backend::dialect_for_open`]'s in-source
+/// detection ([`tcl_registry::dialects::detect_dialect`]) returns for this
+/// document, so `did_change` can skip the whole-document clone + rescan it
+/// would otherwise pay on every keystroke of a `languageId: "tcl"` buffer.
+///
+/// A conservative superset, not an exact replay of the detector: `true` when
+/// the edit touches the leading [`DIALECT_HINT_LINE_MARGIN`] lines (covers the
+/// directive/shebang tiers with margin), or when either the removed or
+/// inserted text contains one of the substrings
+/// [`tcl_registry::dialects::dialect_hint_markers`] lists (covers the
+/// content-signature / version-guard tiers, wherever in the document they
+/// land). A `None` range (a full-document replacement) always returns `true`
+/// — there is no local edit to reason about.
+fn change_could_affect_dialect_hint(
+    text: &str,
+    range: Option<Range>,
+    new_text: &str,
+    index: &tcl_lexer::LineIndex,
+) -> bool {
+    let Some(range) = range else {
+        return true;
+    };
+    if range.start.line < DIALECT_HINT_LINE_MARGIN {
+        return true;
+    }
+    if contains_dialect_hint_marker(new_text) {
+        return true;
+    }
+    let a = index.offset_at_utf16(
+        range.start.line,
+        tcl_lexer::Utf16Col::new(range.start.character),
+        text,
+    ) as usize;
+    let b = index.offset_at_utf16(
+        range.end.line,
+        tcl_lexer::Utf16Col::new(range.end.character),
+        text,
+    ) as usize;
+    let len = text.len();
+    let start = a.min(b).min(len);
+    let end = a.max(b).min(len);
+    contains_dialect_hint_marker(&text[start..end])
+}
+
+/// Whether `s` contains any of [`tcl_registry::dialects::dialect_hint_markers`].
+fn contains_dialect_hint_marker(s: &str) -> bool {
+    tcl_registry::dialects::dialect_hint_markers().any(|m| s.contains(m))
 }
 
 fn lift_span(source: &str, line_index: &tcl_lexer::LineIndex, span: tcl_lexer::Span) -> Range {
@@ -17189,6 +17334,7 @@ mod tests {
         };
         let mut text = "abc\ndef\nghi\n".to_string();
         let mut index = tcl_lexer::LineIndex::new_lsp(&text);
+        let mut has_bare_cr = false;
         let edits = [
             (
                 Some(Range {
@@ -17213,8 +17359,15 @@ mod tests {
                 "Z",
             ), // collapse a line
         ];
+        // None of these edits ever puts a `\r` in the buffer, so every one of
+        // them stays on the incremental `LineIndex::apply_edit` path — the
+        // same `\r`-free alphabet `apply_edit_matches_rebuild_under_fuzz`
+        // (tcl-lexer's own fuzz-equivalence gate) proves patched-vs-rebuilt
+        // for. This test is the `did_change` integration of that guarantee.
         for (range, new_text) in edits {
-            text = apply_content_change_indexed(&text, range, new_text, &mut index);
+            text =
+                apply_content_change_indexed(&text, range, new_text, &mut index, &mut has_bare_cr);
+            assert!(!has_bare_cr, "no edit here ever introduces a bare CR");
             assert_eq!(
                 line_starts(&index),
                 line_starts(&tcl_lexer::LineIndex::new_lsp(&text)),
@@ -17225,12 +17378,22 @@ mod tests {
 
     /// `RUST_ISSUE_033`: an incremental edit on an old-Mac (bare-`\r`) buffer must
     /// resolve against the LSP EOL model so the splice lands at the right byte
-    /// and the shadow buffer stays correct.
+    /// and the shadow buffer stays correct. A bare-`\r` document is exactly the
+    /// case [`apply_content_change_indexed`] cannot patch incrementally (the
+    /// `\n`-only `LineIndex::apply_edit` has no way to place the extra `\r`
+    /// break), so it must fall back to a full rebuild here — asserted via
+    /// `has_bare_cr` staying `true`, not just via the result being correct
+    /// (both paths would produce the same index; only the fallback is sound).
     #[test]
     fn apply_content_change_indexed_handles_bare_cr_document() {
         // Client models "a\rb\rc" as 3 lines (0="a", 1="b", 2="c").
         let mut text = "a\rb\rc".to_string();
         let mut index = tcl_lexer::LineIndex::new_lsp(&text);
+        let mut has_bare_cr = tcl_lexer::LineIndex::contains_bare_cr(&text);
+        assert!(
+            has_bare_cr,
+            "the fixture must actually be a bare-CR document"
+        );
         // Replace line 1 ("b") with "BB": range (1,0)..(1,1).
         text = apply_content_change_indexed(
             &text,
@@ -17240,14 +17403,99 @@ mod tests {
             }),
             "BB",
             &mut index,
+            &mut has_bare_cr,
         );
         assert_eq!(text, "a\rBB\rc", "edit spliced at the wrong offset");
+        assert!(has_bare_cr, "the document is still bare-CR after the edit");
         // The persisted index matches a fresh LSP rebuild.
         let rebuilt = tcl_lexer::LineIndex::new_lsp(&text);
         assert_eq!(index.line_count(), rebuilt.line_count());
         for l in 0..u32::try_from(index.line_count()).unwrap() {
             assert_eq!(index.line_start(l), rebuilt.line_start(l), "line {l}");
         }
+    }
+
+    /// An edit on a document already free of a bare CR takes the incremental
+    /// `LineIndex::apply_edit` path from then on, only falling back for the
+    /// *specific* edit that would introduce one — [`edit_introduces_bare_cr`]
+    /// is the decision function that draws that line.
+    #[test]
+    fn edit_introduces_bare_cr_detects_boundary_and_internal_lone_cr() {
+        // A `\r` inside `new_text` with no following `\n` is bare.
+        assert!(edit_introduces_bare_cr("abc", 1, 1, "\rX"));
+        // `\r\n` inside `new_text` is a valid pair, not bare.
+        assert!(!edit_introduces_bare_cr("abc", 1, 1, "\r\nX"));
+        // A trailing `\r` in `new_text` that lands right before a pre-existing
+        // `\n` (at `end`) is not bare — the pair straddles the edit boundary.
+        assert!(!edit_introduces_bare_cr("a\nb", 1, 1, "\r"));
+        // The same trailing `\r`, but nothing follows it, is bare.
+        assert!(edit_introduces_bare_cr("ab", 1, 1, "\r"));
+        // A `\r` already sitting just before `start`, still paired with the
+        // `\n` that follows the edit, is not bare.
+        assert!(!edit_introduces_bare_cr("a\r\nb", 2, 2, ""));
+        // The same `\r`, once the edit removes the `\n` it was paired with,
+        // becomes bare.
+        assert!(edit_introduces_bare_cr("a\r\nb", 2, 3, ""));
+        // No `\r` anywhere near the edit.
+        assert!(!edit_introduces_bare_cr("abcdef", 2, 3, "XY"));
+    }
+
+    /// Pure unit coverage of the dialect-hint edit gate — no async backend
+    /// needed, since [`change_could_affect_dialect_hint`] is a pure function
+    /// of the edit and the pre-edit buffer. A plain-file edit deep in the
+    /// document does not look hint-touching; the same edit landing on line 0
+    /// (or spelling out a directive/content-signature marker) does.
+    #[test]
+    fn dialect_hint_gate_skips_a_deep_plain_edit_but_catches_a_directive() {
+        use std::fmt::Write as _;
+        let mut body = String::from("# an ordinary Tcl script\n");
+        for i in 0..500 {
+            writeln!(body, "puts {i}").unwrap();
+        }
+        let index = tcl_lexer::LineIndex::new_lsp(&body);
+        // An edit at line 500 that only touches ordinary text: no hint marker
+        // anywhere near it, nowhere near the directive/shebang lines.
+        let deep_edit = Range {
+            start: pos(500, 5),
+            end: pos(500, 6),
+        };
+        assert!(
+            !change_could_affect_dialect_hint(&body, Some(deep_edit), "9", &index),
+            "an edit to a bare digit deep in a plain file must not re-trigger detection"
+        );
+        // The same line, but the inserted text spells out a directive form —
+        // caught by the marker-text check even though it's nowhere near the
+        // top of the file.
+        let deep_directive_edit = Range {
+            start: pos(500, 0),
+            end: pos(500, 0),
+        };
+        assert!(
+            change_could_affect_dialect_hint(
+                &body,
+                Some(deep_directive_edit),
+                "# tcl-dialect: tcl8.4\n",
+                &index
+            ),
+            "inserting a tcl-dialect directive text must re-trigger detection"
+        );
+        // An edit on line 0 (where a directive or shebang could land) always
+        // re-triggers, regardless of what the edit itself contains.
+        let top_edit = Range {
+            start: pos(0, 0),
+            end: pos(0, 0),
+        };
+        assert!(
+            change_could_affect_dialect_hint(&body, Some(top_edit), "x", &index),
+            "an edit on the leading lines must always re-trigger detection"
+        );
+        // A full-document replacement always re-triggers.
+        assert!(change_could_affect_dialect_hint(
+            &body,
+            None,
+            "puts hi\n",
+            &index
+        ));
     }
 
     /// The source-style pass must reach the

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -2570,6 +2570,24 @@ pub struct Backend {
     /// only re-analyses on change, and so declaration-side queries can map a
     /// standalone name to its re-homed twin.
     rehomed_source_seeds: Arc<Mutex<HashMap<String, Vec<String>>>>,
+    /// Serialises [`Backend::refresh_source_rehoming`] passes.
+    ///
+    /// A dozen request handlers (references, definition, hover, rename, …)
+    /// each call `refresh_source_rehoming` at their own entry, and
+    /// `scan_workspace_folders` calls it again after every merge. Without
+    /// this gate, concurrent callers each ran the full (up to 4-round)
+    /// convergence loop independently — on a `source`-heavy workspace, every
+    /// one of them re-read and re-analysed the same re-homed documents and
+    /// took its own turn on `workspace_index`'s write lock, so N concurrent
+    /// requests paid N times the real reconciliation cost and serialised
+    /// against each other on that lock (issue #1158: the measured 130 s
+    /// `references` call that head-of-line-blocked an unrelated `definition`
+    /// request). With the gate, a caller that lands while a pass is already
+    /// running simply waits for it — `refresh_source_rehoming`'s own
+    /// early-return ("nothing left to reconcile") then answers instantly for
+    /// every waiter but the one that did the real work. Same "wait out the
+    /// in-flight pass" idiom as [`Self::workspace_scan_gate`] (issue #1003).
+    rehoming_gate: tokio::sync::Mutex<()>,
     /// Tcl installations discovered by scanning common install locations on
     /// disk (never by executing `tclsh`). Cached once per session. The package
     /// database scans these (plus configured `libraryPaths`) so it can see
@@ -3186,6 +3204,7 @@ impl Backend {
             workspace_scan_gate: tokio::sync::Mutex::new(()),
             autoloaded_library_uris: Arc::new(Mutex::new(HashSet::new())),
             rehomed_source_seeds: Arc::new(Mutex::new(HashMap::new())),
+            rehoming_gate: tokio::sync::Mutex::new(()),
             discovered_tcl: Arc::new(std::sync::OnceLock::new()),
             editor_library_paths: Mutex::new(Vec::new()),
             extra_commands: Mutex::new(Vec::new()),
@@ -9215,7 +9234,15 @@ impl Backend {
     /// several views when sourced from several namespaces — all true at
     /// run time).  Iterates to a fixpoint (bounded) because a seeded parent
     /// records *composed* namespaces for its own nested `source` calls.
+    ///
+    /// Serialised by [`Self::rehoming_gate`] (issue #1158): a caller that
+    /// lands while another pass (a peer request, or `scan_workspace_folders`'
+    /// own call after a merge) is already reconciling waits for it instead of
+    /// running its own redundant copy of the loop below — the early return a
+    /// few lines down then answers "already converged" for every waiter but
+    /// whichever caller actually did the work.
     async fn refresh_source_rehoming(&self) {
+        let _guard = self.rehoming_gate.lock().await;
         for _round in 0..4 {
             let desired = {
                 let index = self.workspace_index.read().await;
@@ -18662,6 +18689,7 @@ mod tests {
             workspace_scan_gate: tokio::sync::Mutex::new(()),
             autoloaded_library_uris: Arc::new(Mutex::new(HashSet::new())),
             rehomed_source_seeds: Arc::new(Mutex::new(HashMap::new())),
+            rehoming_gate: tokio::sync::Mutex::new(()),
             discovered_tcl: Arc::new(std::sync::OnceLock::new()),
             editor_library_paths: Mutex::new(Vec::new()),
             extra_commands: Mutex::new(Vec::new()),
@@ -22769,6 +22797,76 @@ mod tests {
             a_edit_lines,
             [2, 3].into_iter().collect(),
             "both views' callers must be rewritten: {changes:?}"
+        );
+    }
+
+    /// Issue #1158: concurrent `refresh_source_rehoming` callers (every
+    /// navigation handler calls it at its own entry) must not each run their
+    /// own full re-analysis of the same re-homed document — that duplicated
+    /// disk reads / analyses and serialised on `workspace_index`'s write
+    /// lock, turning one caller's O(sourced files) convergence cost into
+    /// O(concurrent callers × that cost) and head-of-line-blocking unrelated
+    /// requests behind it.
+    ///
+    /// Proxy for "did the real reconciliation work run more than once":
+    /// each genuine reconciliation of a document is one `remove_document` +
+    /// one `add_document`, so it bumps [`core_workspace_index::WorkspaceIndex::generation`]
+    /// by exactly 2; a second, redundant pass over the same document would
+    /// bump it by 2 more. Run on a real multi-thread runtime with genuine
+    /// `tokio::spawn` tasks (not `tokio::join!` on one task, which never
+    /// gives two `.await`-separated bodies true concurrent access to the
+    /// gate) so the two calls can actually race for
+    /// [`Backend::rehoming_gate`] — with the gate, the outcome is
+    /// deterministic regardless of scheduling: whichever call acquires it
+    /// second always finds the reconciliation already converged, because the
+    /// first call fully completes (and releases the gate) before the second
+    /// can proceed. A build that dropped the gate could still pass this test
+    /// on an unlucky schedule (the two spawned tasks not actually
+    /// overlapping), so it is a genuine, non-flaky proof *with* the fix
+    /// rather than a guaranteed catch of its absence — the reconciliation
+    /// path's several `.await` points (disk read, `spawn_blocking`, index
+    /// write) give a wide window for the race to manifest in practice.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rehoming_gate_dedups_concurrent_reconciliation_passes() {
+        let backend = Arc::new(test_backend());
+        let a = Uri::from_str("file:///proj/a.tcl").unwrap();
+        let b = Uri::from_str("file:///proj/b.tcl").unwrap();
+        register(&backend, &b, "proc helper {} {}\n").await;
+        register(
+            &backend,
+            &a,
+            "namespace eval ::x { source b.tcl }\n::x::helper\n",
+        )
+        .await;
+
+        let before = backend.workspace_index.read().await.generation();
+        let (b1, b2) = (Arc::clone(&backend), Arc::clone(&backend));
+        let (r1, r2) = tokio::join!(
+            tokio::spawn(async move { b1.refresh_source_rehoming().await }),
+            tokio::spawn(async move { b2.refresh_source_rehoming().await }),
+        );
+        r1.expect("first pass must not panic");
+        r2.expect("second pass must not panic");
+        let after = backend.workspace_index.read().await.generation();
+        assert_eq!(
+            after.wrapping_sub(before),
+            2,
+            "two concurrent reconciliation passes must not each re-index the same document",
+        );
+
+        // The result is still correct: b.tcl's declaration is reachable
+        // under its seeded identity from a.tcl's qualified call.
+        let b_src = "proc helper {} {}\n";
+        let analysis = {
+            let mut an = Analyser::new();
+            an.analyse(b_src, "tcl8.6").clone()
+        };
+        let refs = backend
+            .cross_document_references(&b, b_src, &analysis, Position::new(0, 6), false)
+            .await;
+        assert!(
+            refs.iter().any(|l| l.uri == a),
+            "the sourcing document's qualified call must still resolve: {refs:?}"
         );
     }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -3533,6 +3533,27 @@ impl Backend {
         .flatten()
     }
 
+    /// Run the salsa `folding_ranges` query for `uri` on a worker thread,
+    /// reading the current `SourceFile` input. Returns `None` when the input
+    /// is absent or a concurrent edit cancels the read, so the caller can
+    /// fall back to a direct computation (behaviour preserved). Mirrors
+    /// [`Self::db_document_symbols`]; the BIG-IP dialect has no salsa query
+    /// (it folds on the stanza tree, not the Tcl analyser) and so never
+    /// calls this.
+    async fn db_folding_ranges(
+        &self,
+        uri: &Uri,
+    ) -> Option<Vec<tcl_lsp_core::folding::FoldingRange>> {
+        let file = (*self.db_files.lock().await).get(uri).copied()?;
+        let snapshot = self.db.lock().await.clone();
+        tokio::task::spawn_blocking(move || {
+            salsa::Cancelled::catch(|| tcl_lsp_db::folding_ranges(&snapshot, file)).ok()
+        })
+        .await
+        .ok()
+        .flatten()
+    }
+
     /// Resolve the salsa `AnalyserConfig` handle for `uri`, mirroring
     /// [`DiagInputs::capture_job`]: a folder that overrides the disabled-codes
     /// set / non-ASCII mode (and so has its own handle in `folder_db_configs`)
@@ -3705,7 +3726,7 @@ impl Backend {
         };
         tokio::task::spawn_blocking(move || {
             let mut analyser = Self::configured_analyser(disabled, na_mode, extra);
-            Arc::new(analyser.analyse(&text, &dialect).clone())
+            Arc::new(analyser.analyse(&text, &dialect))
         })
         .await
         .unwrap_or_default()
@@ -4442,7 +4463,7 @@ impl Backend {
                         let dialect = self.dialect_for_closed(uri, &text).await;
                         let (a_text, a_dialect) = (text.clone(), dialect.clone());
                         match tokio::task::spawn_blocking(move || {
-                            Analyser::new().analyse(&a_text, &a_dialect).clone()
+                            Analyser::new().analyse(&a_text, &a_dialect)
                         })
                         .await
                         {
@@ -4754,7 +4775,7 @@ impl Backend {
         // below).  Without this gate, an argument word that happens to
         // collide with a sibling proc/class name produces a
         // false-positive go-to-definition jump.
-        let on_command_head = position_is_command_head(&doc.text, pos, &analysis);
+        let on_command_head = position_is_command_head(&doc.text, pos, &analysis, &doc.line_index);
         // A namespace-name argument is answered here, in full, and never
         // reaches the tiers below.  Two reasons, both from the review of
         // #1088: the position is *definitive* (a proc or class of the same
@@ -7346,7 +7367,7 @@ impl Backend {
             let analysis = self
                 .cached_analysis(&doc_uri)
                 .await
-                .unwrap_or_else(|| Arc::new(Analyser::new().analyse(&source, &dialect).clone()));
+                .unwrap_or_else(|| Arc::new(Analyser::new().analyse(&source, &dialect)));
             let calls = core_call_hierarchy::incoming_calls_for_target(
                 &source, &analysis, simple, qualified, None,
             );
@@ -7765,7 +7786,7 @@ impl Backend {
             for _ in 0..4 {
                 let mut analyser =
                     Self::configured_analyser(disabled.clone(), na_mode, extra.clone());
-                let analysis = analyser.analyse(&source, &dialect).clone();
+                let analysis = analyser.analyse(&source, &dialect);
                 // First fix per safe diagnostic, sorted by start offset.
                 let mut fixes: Vec<(u32, u32, String, String, String)> = Vec::new();
                 for d in &analysis.diagnostics {
@@ -9293,11 +9314,9 @@ impl Backend {
                         .map(|seed| {
                             let mut analyser = Analyser::new();
                             if seed == "::" {
-                                analyser.analyse(&text, &dialect).clone()
+                                analyser.analyse(&text, &dialect)
                             } else {
-                                analyser
-                                    .analyse_with_source_namespace(&text, &dialect, seed)
-                                    .clone()
+                                analyser.analyse_with_source_namespace(&text, &dialect, seed)
                             }
                         })
                         .collect::<Vec<AnalysisResult>>()
@@ -9447,7 +9466,7 @@ impl Backend {
                 let dialect = folder_dialect_for(&uri, &folder_dialects)
                     .unwrap_or_else(|| default_dialect.clone());
                 let mut analyser = Analyser::new();
-                let analysis = analyser.analyse(&text, &dialect).clone();
+                let analysis = analyser.analyse(&text, &dialect);
                 out.push((uri, text, dialect, analysis));
             }
             (resolver, out)
@@ -10569,23 +10588,37 @@ impl LanguageServer for Backend {
         // blocks and leaves every stanza unfoldable) — the folding twin of
         // the outline split in `document_symbol`.
         let bigip = Self::is_bigip_dialect(&doc.dialect);
-        let registry = self.registry_for_dialect(&doc.dialect).await;
-        // Pure-CPU tokenise/segment work; run on a worker so a parser panic
-        // is contained as a JSON-RPC error rather than unwinding the event
-        // loop (defence in depth).
-        let ranges = tokio::task::spawn_blocking(move || {
-            if bigip {
-                core_bigip::folding_ranges(&doc.text)
-            } else {
+        let ranges = if bigip {
+            let text = doc.text.clone();
+            // Pure-CPU tokenise/segment work; run on a worker so a parser
+            // panic is contained as a JSON-RPC error rather than unwinding
+            // the event loop (defence in depth).
+            tokio::task::spawn_blocking(move || core_bigip::folding_ranges(&text))
+                .await
+                .map_err(|err| jsonrpc::Error {
+                    code: jsonrpc::ErrorCode::InternalError,
+                    message: format!("folding worker panicked: {err}").into(),
+                    data: None,
+                })?
+        } else if let Some(ranges) = self.db_folding_ranges(&params.text_document.uri).await {
+            // Served from the salsa query graph (memoised); avoids a fresh
+            // segmenter/registry walk on every request.
+            ranges
+        } else {
+            // Cold / cancelled fallback: compute directly so the request
+            // never returns empty due to a concurrent edit (behaviour
+            // preserved).
+            let registry = self.registry_for_dialect(&doc.dialect).await;
+            tokio::task::spawn_blocking(move || {
                 tcl_lsp_core::folding::folding_ranges(&doc.text, &doc.dialect, registry)
-            }
-        })
-        .await
-        .map_err(|err| jsonrpc::Error {
-            code: jsonrpc::ErrorCode::InternalError,
-            message: format!("folding worker panicked: {err}").into(),
-            data: None,
-        })?;
+            })
+            .await
+            .map_err(|err| jsonrpc::Error {
+                code: jsonrpc::ErrorCode::InternalError,
+                message: format!("folding worker panicked: {err}").into(),
+                data: None,
+            })?
+        };
         Ok(Some(ranges.into_iter().map(lift_folding_range).collect()))
     }
 
@@ -12763,7 +12796,7 @@ impl LanguageServer for Backend {
         // same gate `compute_definition` applies — otherwise an argument word
         // that happens to share a sibling proc's name would pop up that proc's
         // signature.  Computed here, while `analysis` is still in scope.
-        let on_command_head = position_is_command_head(&doc.text, pos, &analysis);
+        let on_command_head = position_is_command_head(&doc.text, pos, &analysis, &doc.line_index);
         // A namespace-name argument is answered here, in full, and never
         // reaches the tiers below — the position is definitive, and the
         // counts describe the whole workspace rather than just this document
@@ -12895,7 +12928,19 @@ fn materialise_selection_range(
 /// `character` is a UTF-16 code-unit offset. `None` when the line is
 /// out of range.
 fn line_col_to_byte_offset(source: &str, line: u32, col: u32) -> Option<usize> {
-    let index = tcl_lexer::LineIndex::new_lsp(source);
+    line_col_to_byte_offset_indexed(&tcl_lexer::LineIndex::new_lsp(source), source, line, col)
+}
+
+/// [`line_col_to_byte_offset`], but resolved through a caller-supplied
+/// `index` instead of rebuilding one — for a caller that already holds the
+/// document's persisted [`tcl_lexer::LineIndex`] (`DocumentState::line_index`),
+/// so a per-request lookup doesn't pay for a whole-document rescan.
+fn line_col_to_byte_offset_indexed(
+    index: &tcl_lexer::LineIndex,
+    source: &str,
+    line: u32,
+    col: u32,
+) -> Option<usize> {
     if line as usize >= index.line_count() {
         return None;
     }
@@ -12907,8 +12952,18 @@ fn line_col_to_byte_offset(source: &str, line: u32, col: u32) -> Option<usize> {
 /// invocations.  Used to gate the cross-document go-to-definition
 /// fallback so it only fires on call sites, not on argument words
 /// that happen to collide with a sibling proc/class name.
-fn position_is_command_head(source: &str, pos: Position, analysis: &AnalysisResult) -> bool {
-    let Some(offset) = line_col_to_byte_offset(source, pos.line, pos.character) else {
+///
+/// `index` is the caller's persisted [`tcl_lexer::LineIndex`]
+/// (`DocumentState::line_index`) — resolved through it rather than a fresh
+/// rebuild, since both hover and go-to-definition call this on every request.
+fn position_is_command_head(
+    source: &str,
+    pos: Position,
+    analysis: &AnalysisResult,
+    index: &tcl_lexer::LineIndex,
+) -> bool {
+    let Some(offset) = line_col_to_byte_offset_indexed(index, source, pos.line, pos.character)
+    else {
         return false;
     };
     analysis.command_invocations.iter().any(|inv| {
@@ -21945,6 +22000,7 @@ mod tests {
     fn command_head_gate_distinguishes_head_from_argument() {
         let src = "proc greet {x} {}\ngreet arg\n";
         let analysis = Analyser::new().analyse(src, "tcl8.6").clone();
+        let index = tcl_lexer::LineIndex::new_lsp(src);
         // `greet` at line 1 is a command head (the call site).
         assert!(position_is_command_head(
             src,
@@ -21953,6 +22009,7 @@ mod tests {
                 character: 2
             },
             &analysis,
+            &index,
         ));
         // `arg` at line 1 is an argument word, not a command head, so
         // the cross-document fallback must not fire on it.
@@ -21963,6 +22020,7 @@ mod tests {
                 character: 7
             },
             &analysis,
+            &index,
         ));
     }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -2766,6 +2766,14 @@ pub struct Backend {
 /// waits for its turn. Request handlers draw no ticket; they only wait for the
 /// edits already received ([`EditOrder::settled`]), so read concurrency is
 /// unaffected.
+///
+/// A turn covers the handler's **ordered mutations only** — the buffer splice,
+/// the salsa source, the index entry — and is handed on the moment they are
+/// committed, not when the handler returns (#1150). This is a *global* barrier:
+/// every request handler waits on it, so work a handler does after its
+/// mutations (a disk reindex, a closed-file republish, a dialect re-scan) must
+/// not sit inside the turn, or one document's close stalls every other
+/// document's hover.
 #[derive(Debug, Default)]
 struct EditOrder {
     next_ticket: std::sync::atomic::AtomicU64,
@@ -9970,7 +9978,7 @@ impl LanguageServer for Backend {
         // otherwise two rapid incremental edits splice out of order and corrupt
         // the buffer. The ticket must be drawn before the first await.
         let ticket = self.edit_order.take_ticket();
-        let _turn = self.edit_order.wait_turn(ticket).await;
+        let turn = self.edit_order.wait_turn(ticket).await;
         let uri = params.text_document.uri.clone();
         if params.content_changes.is_empty() {
             return;
@@ -10020,8 +10028,17 @@ impl LanguageServer for Backend {
             drop(docs);
             (dialect, language_id)
         };
-        self.schedule_diagnostics(uri.clone(), dialect.clone())
-            .await;
+        // The splice, the salsa source and the index entry are committed, so
+        // hand the ordering turn on before the tail below (#1150).  Everything
+        // after this point is order-insensitive — marking the diagnostics slot
+        // dirty (the worker reads the document's *current* state at drain time),
+        // and the dialect re-resolve, which re-reads the buffer under the
+        // `documents` lock before it commits anything.  Held across the tail,
+        // the ticket kept a whole-source `detect_dialect` scan and a full-text
+        // clone in front of every request handler's `edits_settled` and in front
+        // of the next keystroke.
+        drop(turn);
+        self.schedule_diagnostics(uri.clone(), dialect).await;
         // Re-resolve in-source dialect hints (a `# tcl-dialect:` directive, a
         // `#!…tclshX.Y` shebang, or `package require Tcl X.Y`) after the edit —
         // adding or changing one in an already-open buffer must take effect
@@ -10030,16 +10047,19 @@ impl LanguageServer for Backend {
         // only the source hint is edit-sensitive, so this is the sole case that
         // can change.  When it does, commit the new dialect and re-analyse.
         if language_id == "tcl" {
-            // Read the open buffer directly: `read_document` waits for this
-            // handler's own turn to finish (see `edits_settled`), so routing
-            // through it here would self-deadlock. The document is open — a
-            // closed one returned above.
-            let text = match self.documents.lock().await.get(&uri) {
-                Some(entry) => entry.text.clone(),
+            // Read the open buffer directly rather than through
+            // `read_document`, which would wait for edits this one no longer
+            // holds up and answer from a buffer this handler has already
+            // superseded.  The *current* dialect comes from the same read: with
+            // the turn handed on, a newer edit may have re-resolved it already,
+            // and comparing against this handler's own captured value would
+            // re-commit a dialect that is no longer news.
+            let (text, current_dialect) = match self.documents.lock().await.get(&uri) {
+                Some(entry) => (entry.text.clone(), entry.dialect.clone()),
                 None => return,
             };
             let new_dialect = self.dialect_for_open(&uri, &language_id, &text).await;
-            if new_dialect != dialect {
+            if new_dialect != current_dialect {
                 {
                     let mut docs = self.documents.lock().await;
                     let Some(entry) = docs.get_mut(&uri) else {
@@ -10143,7 +10163,7 @@ impl LanguageServer for Backend {
         // close can't be reordered ahead of an in-flight edit. The ticket must be
         // drawn before the first await.
         let ticket = self.edit_order.take_ticket();
-        let _turn = self.edit_order.wait_turn(ticket).await;
+        let turn = self.edit_order.wait_turn(ticket).await;
         let uri = &params.text_document.uri;
         {
             // Remove the live document + its index entry while holding
@@ -10171,6 +10191,21 @@ impl LanguageServer for Backend {
         // The workspace-class analysis memo is keyed by URI; a closed
         // document's entry would otherwise linger for the process's life.
         self.workspace_class_analyses.lock().await.remove(uri);
+        // Everything the ordering ticket exists to protect is now applied, so
+        // hand the turn on before the heavy tail below (#1150).  `EditOrder` is
+        // a *global* barrier — every request handler awaits `edits_settled`, and
+        // the next `did_change` waits for this ticket — so holding it across a
+        // disk read, a full uncached `Analyser::analyse`, an index rebuild and
+        // the closed-file diagnostics pipeline froze hover / completion /
+        // semantic tokens in *every* open document for the length of a close.
+        // None of that tail is an ordered buffer mutation: the document map,
+        // the index entry and the salsa source are already updated above, which
+        // is exactly what stops a close being reordered ahead of an in-flight
+        // edit.  Observable ordering is unchanged — the republish still happens
+        // after the mutations, on this same handler task — and both steps below
+        // re-check that the document is still closed under the `documents` lock,
+        // so a `did_open` that now wins the race still wins it.
+        drop(turn);
         // Re-index the file from disk rather than dropping it: the file still
         // exists on disk and was (or would be) part of the on-disk index, so
         // cross-document definition / references / rename / call-hierarchy — and
@@ -21899,6 +21934,146 @@ mod tests {
             .expect("read_document must resolve once the edit lands")
             .expect("reader task panicked");
         assert_eq!(text.as_deref(), Some("set x 2\n"));
+    }
+
+    /// Wait for the single document-sync handler under test to draw its
+    /// `EditOrder` ticket **and** hand it on, or give up.
+    ///
+    /// `edits_settled` alone cannot express this: called before the handler has
+    /// drawn its ticket it returns immediately and proves nothing, so the wait
+    /// is on the counters directly.
+    async fn one_edit_turn_released(backend: &Backend) -> bool {
+        use std::sync::atomic::Ordering;
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let order = &backend.edit_order;
+                if order.next_ticket.load(Ordering::Acquire) == 1
+                    && order.now_serving.load(Ordering::Acquire) == 1
+                {
+                    return;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .is_ok()
+    }
+
+    /// #1150: `did_close` must hand its `EditOrder` turn on as soon as the
+    /// ordered mutations are applied, rather than holding it across the disk
+    /// reindex and the closed-file republish.  The ticket is a *global*
+    /// barrier — every request handler awaits `edits_settled` and the next
+    /// `did_change` waits for the ticket itself — so a close that keeps it
+    /// across that tail freezes hover / completion / semantic tokens in every
+    /// open document for as long as the close takes.
+    ///
+    /// The `db` mutex stands in for the tail's cost: the ordered mutations (the
+    /// documents map, the index entry) never take it, and the reindex always
+    /// does, so holding it here pins the close inside its tail — with the turn
+    /// necessarily already handed on, or, before the fix, still held.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn did_close_hands_its_edit_turn_on_before_the_reindex_tail() {
+        let backend = Arc::new(test_backend());
+        let root = unique_scratch_dir("close-off-ticket");
+        let on_disk = root.join("closing.tcl");
+        std::fs::write(&on_disk, "proc foo {} {}\n").unwrap();
+        let uri = Uri::from_file_path(&on_disk).unwrap();
+        register(&backend, &uri, "proc foo {} {}\n").await;
+
+        let db_held = backend.db.lock().await;
+        let closing = tokio::spawn({
+            let backend = Arc::clone(&backend);
+            let uri = uri.clone();
+            async move {
+                backend
+                    .did_close(DidCloseTextDocumentParams {
+                        text_document: TextDocumentIdentifier { uri },
+                    })
+                    .await;
+            }
+        });
+
+        assert!(
+            one_edit_turn_released(&backend).await,
+            "did_close must release its turn before the reindex, which cannot \
+             run while the db lock is held",
+        );
+        assert!(
+            !backend.documents.lock().await.contains_key(&uri),
+            "the mutations the ticket covers must already be applied",
+        );
+        assert!(
+            !backend.closed_diag_gen.lock().await.contains_key(&uri),
+            "the closed republish is the tail; it must still be pending here",
+        );
+
+        drop(db_held);
+        tokio::time::timeout(std::time::Duration::from_secs(30), closing)
+            .await
+            .expect("the close must finish once its tail can take the db lock")
+            .expect("did_close panicked");
+        assert!(
+            backend.closed_diag_gen.lock().await.contains_key(&uri),
+            "the closed republish still lands, ordered after the mutations",
+        );
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// #1150, the edit side: `did_change` must hand its turn on once the splice,
+    /// the salsa source and the index entry are committed — not hold it across
+    /// the diagnostics scheduling and the whole-source `detect_dialect` re-scan.
+    ///
+    /// `diag_slots` stands in for that tail here: the ordered mutations never
+    /// take it and `schedule_diagnostics` takes it first thing, so a held
+    /// `diag_slots` lock pins the handler in its tail.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn did_change_hands_its_edit_turn_on_before_the_scheduling_tail() {
+        use tower_lsp_server::ls_types::{
+            TextDocumentContentChangeEvent, VersionedTextDocumentIdentifier,
+        };
+        let backend = Arc::new(test_backend());
+        let uri = Uri::from_str("file:///w/edited.tcl").unwrap();
+        register(&backend, &uri, "set x 1\n").await;
+
+        let slots_held = backend.diag_slots.lock().await;
+        let editing = tokio::spawn({
+            let backend = Arc::clone(&backend);
+            let uri = uri.clone();
+            async move {
+                backend
+                    .did_change(DidChangeTextDocumentParams {
+                        text_document: VersionedTextDocumentIdentifier { uri, version: 2 },
+                        content_changes: vec![TextDocumentContentChangeEvent {
+                            range: None,
+                            range_length: None,
+                            text: "set x 2\n".to_owned(),
+                        }],
+                    })
+                    .await;
+            }
+        });
+
+        assert!(
+            one_edit_turn_released(&backend).await,
+            "did_change must release its turn before scheduling diagnostics",
+        );
+        assert_eq!(
+            backend
+                .documents
+                .lock()
+                .await
+                .get(&uri)
+                .map(|doc| doc.text.clone())
+                .as_deref(),
+            Some("set x 2\n"),
+            "the splice the ticket covers must already be committed",
+        );
+
+        drop(slots_held);
+        tokio::time::timeout(std::time::Duration::from_secs(30), editing)
+            .await
+            .expect("the edit must finish once its tail can take the diag_slots lock")
+            .expect("did_change panicked");
     }
 
     async fn register(backend: &Backend, uri: &Uri, src: &str) {

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -4295,6 +4295,31 @@ impl Backend {
             .retain(|queued| queued != uri);
     }
 
+    /// Retire every trace of a path a `workspace/didRenameFiles` moved away
+    /// from (#1146).
+    ///
+    /// The old path no longer exists on disk, so it is treated exactly as
+    /// [`LanguageServer::did_change_watched_files`] treats a `DELETED` file:
+    /// dropping only the `workspace_index` entry left its salsa `SourceFile` in
+    /// the `Project` — so the renamed file's procedures were counted twice in
+    /// cross-file resolution, and the old URI's whole memo chain, pull-cache
+    /// entry, semantic-token baseline and class analysis survived every rename
+    /// for the process's life.  The empty publish is what removes the client's
+    /// Problems entry for the dead path.
+    async fn retire_renamed_uri(&self, uri: &Uri) {
+        self.workspace_index
+            .write()
+            .await
+            .remove_document(uri.as_str());
+        self.db_remove_source(uri).await;
+        self.last_semantic_tokens.lock().await.remove(uri);
+        self.workspace_class_analyses.lock().await.remove(uri);
+        self.evict_diag_slot(uri).await;
+        // Publishes the empty set and drops the pull-cache + closed-generation
+        // entries, matching the watched-file DELETED branch's badge clear.
+        self.clear_closed_diagnostics(uri).await;
+    }
+
     /// Release `uri`'s diagnostics slot when its document closes (#1144).
     ///
     /// With no worker draining it the slot is dropped outright.  With one
@@ -12145,9 +12170,9 @@ impl LanguageServer for Backend {
     }
 
     /// `workspace/didRenameFiles`: after the client applies a
-    /// rename on disk, refresh the workspace index — drop the old URI's
-    /// entries and re-index the renamed file from its new path so
-    /// cross-document features (including future renames) stay current.
+    /// rename on disk, refresh the workspace — retire the old URI entirely
+    /// and re-index the renamed file from its new path so cross-document
+    /// features (including future renames) stay current.
     async fn did_rename_files(&self, params: RenameFilesParams) {
         // Same workspace-file-ops gate as `will_rename_files`.
         if !self
@@ -12160,10 +12185,7 @@ impl LanguageServer for Backend {
         }
         for f in &params.files {
             if let Ok(old_url) = Uri::from_str(&f.old_uri) {
-                self.workspace_index
-                    .write()
-                    .await
-                    .remove_document(old_url.as_str());
+                self.retire_renamed_uri(&old_url).await;
             }
             if let Ok(new_url) = Uri::from_str(&f.new_uri) {
                 self.reindex_index_from_disk(&new_url).await;
@@ -23953,8 +23975,49 @@ mod tests {
     async fn did_rename_reindexes_moved_document() {
         let backend = test_backend();
         let old = Uri::from_str("file:///gone.tcl").unwrap();
-        register(&backend, &old, "proc helper {} {}\n").await;
+        let src = "proc helper {} {}\n";
+        register(&backend, &old, src).await;
+        // A renamed-away path is not an open buffer — the client moved the file
+        // on disk — so drop the live document `register` seeded and stand the
+        // rest of the old URI's per-URI state up as a real session would have.
+        backend.documents.lock().await.remove(&old);
+        backend
+            .db_set_source(&old, src.to_owned(), "tcl8.6".to_owned())
+            .await;
+        let old_file = *backend
+            .db_files
+            .lock()
+            .await
+            .get(&old)
+            .expect("precondition: the old URI has a salsa source");
+        backend
+            .last_semantic_tokens
+            .lock()
+            .await
+            .insert(old.clone(), ("st-1".to_owned(), Vec::new()));
+        backend.workspace_class_analyses.lock().await.insert(
+            old.clone(),
+            WorkspaceClassAnalysis {
+                fingerprint: (0, 0),
+                analysis: Arc::default(),
+            },
+        );
+        backend
+            .diag_slots
+            .lock()
+            .await
+            .insert(old.clone(), DiagSlot::default());
+        backend.pull_diag_cache.lock().await.insert(
+            old.clone(),
+            PullDiagEntry {
+                result_id: next_pull_diag_result_id(),
+                revision: 0,
+                diagnostics: Vec::new(),
+            },
+        );
+        backend.closed_diag_gen.lock().await.insert(old.clone(), 3);
         assert_eq!(backend.workspace_index.read().await.procs().len(), 1);
+
         let params = RenameFilesParams {
             files: vec![tower_lsp_server::ls_types::FileRename {
                 old_uri: old.to_string(),
@@ -23964,9 +24027,48 @@ mod tests {
             }],
         };
         backend.did_rename_files(params).await;
+
         // The old document's proc is gone from the index.
-        let index = backend.workspace_index.read().await;
-        assert!(index.procs().iter().all(|p| p.uri != old.as_str()));
+        assert!(
+            backend
+                .workspace_index
+                .read()
+                .await
+                .procs()
+                .iter()
+                .all(|p| p.uri != old.as_str()),
+        );
+        // #1146: and out of the salsa db, so the renamed file's procedures are
+        // not counted twice in cross-file resolution (and the old URI's memo
+        // chain is not retained for the process's life).
+        assert!(
+            !backend.db_files.lock().await.contains_key(&old),
+            "the old URI's salsa SourceFile must be dropped",
+        );
+        let project_holds_old = {
+            let db = backend.db.lock().await;
+            backend
+                .db_project
+                .lock()
+                .await
+                .is_some_and(|project| project.files(&*db).contains(&old_file))
+        };
+        assert!(
+            !project_holds_old,
+            "the old URI must leave the salsa Project file set",
+        );
+        // …along with every per-URI cache keyed on the dead path, and its badge.
+        assert!(!backend.pull_diag_cache.lock().await.contains_key(&old));
+        assert!(!backend.closed_diag_gen.lock().await.contains_key(&old));
+        assert!(!backend.diag_slots.lock().await.contains_key(&old));
+        assert!(!backend.last_semantic_tokens.lock().await.contains_key(&old));
+        assert!(
+            !backend
+                .workspace_class_analyses
+                .lock()
+                .await
+                .contains_key(&old)
+        );
     }
 
     #[tokio::test]

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -12009,33 +12009,19 @@ impl LanguageServer for Backend {
         let analysis = self
             .analysis_for(&uri, doc.text.clone(), doc.dialect.clone())
             .await;
-        // Share the workspace index with the worker via a refcounted
-        // handle and take the read lock inside the blocking closure,
-        // so the recomputed count walk holds a shared read lock
-        // rather than a private copy.
-        let workspace_index = Arc::clone(&self.workspace_index);
-        let uri_str = uri.to_string();
-        let analysis_for_count = Arc::clone(&analysis);
-        let count_text = doc.text.clone();
-        let count_dialect = doc.dialect.clone();
-        let lenses = tokio::task::spawn_blocking(move || {
-            let workspace = workspace_index.blocking_read();
-            core_code_lens::code_lenses(
-                &count_text,
-                &count_dialect,
-                Some(&analysis_for_count),
-                Some(&*workspace),
-                &uri_str,
-            )
-        })
-        .await
-        .map_err(|err| jsonrpc::Error {
-            code: jsonrpc::ErrorCode::InternalError,
-            message: format!("code_lens_resolve worker panicked: {err}").into(),
-            data: None,
-        })?;
         let mut lens = lens;
-        if lenses.iter().any(|l| l.qname == qname) {
+        // Existence check only — is `qname` one of *this* document's own
+        // lenses at all? Previously answered by recomputing the whole
+        // document's lens set (`code_lenses`, O(every proc + every class +
+        // every member's own reference-resolution walk)) and searching it for
+        // a matching `qname`, even though that result was discarded the
+        // moment the check passed — the title below always comes from
+        // `reference_locations_at`, never from `code_lenses`'s own count
+        // (issue #991). `lens_qname_exists` answers the same question with
+        // direct lookups against `analysis`'s own tables (issue #1152), so a
+        // click on one lens no longer re-derives every *other* lens in the
+        // document.
+        if core_code_lens::lens_qname_exists(&analysis, &qname) {
             // Resolve the actual reference locations so clicking the lens opens
             // a peek (the lens title alone is informational — a bare title with
             // no command is rendered but inert, the "reference is not active"

--- a/rust/tcl-lsp-server/tests/e2e/common/mod.rs
+++ b/rust/tcl-lsp-server/tests/e2e/common/mod.rs
@@ -626,6 +626,11 @@ impl Lsp {
     /// Run the `initialize` handshake and send `initialized`.
     pub fn initialize(&mut self) -> Value {
         let root = format!("file:///e2e/root-{}", std::process::id());
+        self.initialize_at(&root)
+    }
+
+    /// [`Lsp::initialize`] against an explicit workspace-root URI.
+    pub fn initialize_at(&mut self, root: &str) -> Value {
         let result = self.request_timeout(
             "initialize",
             json!({
@@ -640,6 +645,20 @@ impl Lsp {
         self.initialize_result = result.clone();
         self.notify("initialized", json!({}));
         result
+    }
+
+    /// Spawn a server rooted at a **real on-disk directory** and return the
+    /// moment the `initialize` handshake is done — no config settle, no wait
+    /// for the startup workspace scan.
+    ///
+    /// [`Lsp::tcl`] deliberately settles the config first, which incidentally
+    /// gives the startup scan time to finish; a test that means to *race* that
+    /// scan (the way a real editor's first `workspace/symbol` does) must not
+    /// pay that barrier.
+    pub fn at_workspace_root(root: &std::path::Path) -> Self {
+        let mut lsp = Self::spawn(json!({ "features": { "linkedEditingRange": true } }));
+        lsp.initialize_at(&format!("file://{}", root.to_string_lossy()));
+        lsp
     }
 
     /// The full `initialize` result.

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -2112,6 +2112,10 @@ fn unresolved_word_without_an_unknown_handler_still_fires_i230() {
 /// in-file callers.
 const CROSS_FILE_LIB: &str = "proc helper {mode} {\n    if {$mode eq \"prod\"} { set r 1 } else { set r 2 }\n}\nhelper prod\nhelper prod\n";
 
+/// Also the standing proof that the project's call-site evidence is **not**
+/// an opt-in refinement: this session leaves `tclLsp.features.
+/// crossFileResolution` at its default (off), so gating the server's evidence
+/// sync on that toggle reinstates the unsound fold and fails here (#1148).
 #[test]
 fn caller_in_a_sourcing_file_with_a_differing_literal_clears_i230() {
     let mut lsp = Lsp::tcl();

--- a/rust/tcl-lsp-server/tests/e2e/document_symbols.rs
+++ b/rust/tcl-lsp-server/tests/e2e/document_symbols.rs
@@ -660,3 +660,71 @@ fn event_handler_is_a_workspace_symbol() {
         "workspace symbol not found: {syms:?}"
     );
 }
+
+/// Regression (#1179): the **first** `workspace/symbol` of a session must not
+/// answer out of a still-empty index.
+///
+/// `initialized` pulls the client config and registers file watchers — two
+/// client round-trips — before it starts the folder scan, so a query issued
+/// straight after the handshake used to find nothing, while the identical
+/// query a moment later found everything.  The VS Code suite reproduced this
+/// as a flaky first test; this is the same race without an editor.
+#[test]
+fn workspace_symbol_waits_out_the_startup_scan() {
+    let root = std::env::temp_dir().join(format!(
+        "tcl-lsp-e2e-ws-symbol-scan-{}-{}",
+        std::process::id(),
+        line!()
+    ));
+    std::fs::create_dir_all(&root).expect("mk workspace root");
+    std::fs::write(root.join("scanned.tcl"), "proc scan_race_helper {} {}\n")
+        .expect("write fixture");
+
+    // No config settle, no scan wait, no `didOpen` — the query races the scan.
+    let mut lsp = Lsp::at_workspace_root(&root);
+    let result = lsp.workspace_symbols("scan_race_helper");
+    let syms = result.as_array().cloned().unwrap_or_default();
+    assert!(
+        syms.iter().any(|s| name(s) == "scan_race_helper"),
+        "the on-disk fixture's proc must be found on the first query: {syms:?}"
+    );
+
+    std::fs::remove_dir_all(&root).ok();
+}
+
+/// Regression (#1179): a document the editor has **just opened** must stay
+/// searchable.
+///
+/// `didOpen` drops the document's index entry (its on-disk records stop being
+/// authoritative once a live buffer exists) and the debounced diagnostics
+/// publish is what puts it back, so for that window every proc in the
+/// just-opened file vanished from the picker.  That is precisely what the VS
+/// Code suite hit: `fib` lives only in the file it had opened, so it found
+/// nothing, while `factorial` — which a second, unopened fixture also defines
+/// — kept working.
+#[test]
+fn workspace_symbol_finds_a_just_opened_documents_proc() {
+    let root = std::env::temp_dir().join(format!(
+        "tcl-lsp-e2e-ws-symbol-open-{}-{}",
+        std::process::id(),
+        line!()
+    ));
+    std::fs::create_dir_all(&root).expect("mk workspace root");
+    let path = root.join("procs.tcl");
+    let src = "proc open_race_fib {n} { return $n }\n";
+    std::fs::write(&path, src).expect("write fixture");
+
+    let mut lsp = Lsp::at_workspace_root(&root);
+    let uri = format!("file://{}", path.to_string_lossy());
+    // `open_document`, not `open_ready`: do not wait for the publish that
+    // re-adds the index entry.
+    lsp.open_document(&uri, src);
+    let result = lsp.workspace_symbols("open_race_fib");
+    let syms = result.as_array().cloned().unwrap_or_default();
+    assert!(
+        syms.iter().any(|s| name(s) == "open_race_fib"),
+        "the open document's proc must be found while its index entry is pending: {syms:?}"
+    );
+
+    std::fs::remove_dir_all(&root).ok();
+}

--- a/rust/tcl-lsp-server/tests/e2e/semantic_tokens_reference_client.rs
+++ b/rust/tcl-lsp-server/tests/e2e/semantic_tokens_reference_client.rs
@@ -1074,7 +1074,9 @@ fn range_semantic_tokens_no_spurious_refresh_when_converged() {
     // it against the recomputed enriched viewport.  A loaded machine can instead
     // reach `no-analysis` (the document is not yet in the salsa db when the
     // request lands) or `cancelled`, and a very quick one `served-enriched` —
-    // none of which run the compare.  The refresh assertion below is asserted in
+    // none of which run the compare.  `coalesced` (#1147) is a fourth: a
+    // continuation for this document was already in flight, so this request rode
+    // along with it.  The refresh assertion below is asserted in
     // *every* case, because "no spurious refresh" must hold on all of them; the
     // outcome is reported so a run that did not exercise the compare is visible
     // rather than silently vacuous.

--- a/rust/tcl-registry/src/dialects.rs
+++ b/rust/tcl-registry/src/dialects.rs
@@ -395,6 +395,29 @@ fn has_irules_when(head: &str) -> bool {
     false
 }
 
+/// Textual substrings that a plausible in-source dialect hint would contain:
+/// the directive key, a shebang marker, the `package`/`vsatisfies`
+/// version-guard vocabulary, and every [`CONTENT_SIGNATURES`] marker word
+/// (plus `has_irules_when`'s `when` keyword).
+///
+/// A conservative *superset* filter for "could this text change what
+/// [`detect_dialect`] returns" — it does not replicate the word-boundary or
+/// tokenisation rules those heuristics apply, so it can false-positive (a
+/// comment mentioning "package" re-triggers a detect that then confirms
+/// nothing changed), but nothing that changes the detected dialect can
+/// appear in a diff without containing one of these substrings. Intended for
+/// a caller that wants to skip a full re-detect on an edit that plainly
+/// cannot touch the hint (see the LSP server's `did_change`), not as a
+/// detector in its own right.
+pub fn dialect_hint_markers() -> impl Iterator<Item = &'static str> {
+    const EXTRA: &[&str] = &["tcl-dialect:", "#!", "package", "vsatisfies", "when"];
+    EXTRA.iter().copied().chain(
+        CONTENT_SIGNATURES
+            .iter()
+            .flat_map(|&(_, markers)| markers.iter().copied()),
+    )
+}
+
 /// Content signatures for the non-Tcl-core dialects, checked in priority order.
 /// Each entry is `(dialect, &[marker words])`; a marker matches when it appears
 /// as a whole word anywhere in the scanned head. Ordered most-specific first so


### PR DESCRIPTION
## Summary

- Fixes the 18 memory-leak and performance issues found in the editor/LSP perf session (#1144, #1145, #1146, #1147, #1148, #1149, #1150, #1151, #1152, #1153, #1154, #1155, #1156, #1157, #1158, #1159, #1160, #1161), one commit per issue. Findings came from two static audits plus live-server experiments against a ~1.06M-line corpus (tcllib, tklib, tk, XilinxTclStore, alited, pave, georgtree's and nico-robert's projects); the headline reproductions were an OOM after 150 didOpen/didClose cycles (~12 MB retained per closed file), a 130 s find-all-references on tcllib (+1.85 GB RSS), and 6.6 s diagnostics latency for signature edits in a large workspace.
- Memory: closed files no longer create or pin deep compiler memos and their badge/slot caches are bounded (#1144); retired salsa `SourceFile`/`AnalyserConfig` inputs are tombstoned and revived instead of orphaned on delete/re-create, rename, and folder-config churn (#1145, #1146); semantic-token convergence continuations are deduplicated per URI and share one `Arc<str>` buffer (#1147).
- Large-project paths: the cross-file evidence sync's union-find is a once-per-revision project query read off-lock (#1148); the workspace index is per-URI slot storage with O(document) removal and `Derived`-cached views (#1149, #1152); `EditOrder` tickets are scoped to the ordered mutations only (#1150); the startup scan is parallelised, merges incrementally, and no longer warms unopened files' deep tier — unopened files carry only the lightweight index (#1151); references resolves per unique URI (#1153) and concurrent `refresh_source_rehoming` passes are serialised behind a gate (#1158, the actual cause of the 130 s references call); watched-file events are batched (#1161).
- Per-keystroke paths: incremental `LineIndex::apply_edit` on bare-CR-free documents, gated dialect re-detection, and dead full-document copies removed in `did_change` (#1155); the mid-typing recovery branch reuses a generation-keyed widened-command set instead of rebuilding ~60k strings per edit (#1154); salsa memo hits share span-free lattices by refcount instead of deep-copying (#1159); `workspace/symbol` answers from the index (#1156); folding is memoised, redundant `AnalysisResult` clones dropped, persisted `LineIndex` threaded through providers (#1157); inlay hints skip resolution outside the requested range (#1160).
- Rebased onto `rust` (`0e0ad44`), converging this branch's index caches onto #1176's `Derived<T>` idiom.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `cargo test --workspace --all-features` — 312 suites, 15,664 tests, 0 failures (from a clean build, pre-rebase tip).
  - After the rebase: `cargo test -p tcl-lsp-core -p tcl-lsp-server -p tcl-lsp-db` (52 suites, 0 failures), `cargo clippy --workspace --all-targets` (zero warnings, no new `#[allow]`), `cargo fmt --check`, `make xtask-check` (drift gates OK).
  - Each of the 8 fix waves ran `cargo fmt`, per-crate clippy, and the affected crates' full test suites (including the 1,178-test native e2e suite) before its commits landed.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract? — No: the changes are LSP server/index/caching mechanics; analyser and compiler outputs are unchanged (`docs/design/contracts/workspace-indexing.md` was updated for the new index storage model, and the recovery/`Derived` caching notes live in the relevant design docs).
- [ ] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`. — n/a
- [ ] If I added a new compiler KCS note, I linked it from both. — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9neL52xtEZveBzgvJSAFe

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9neL52xtEZveBzgvJSAFe)_