### PR TITLE
Add a kernel-loadable BPF-Tcl XDP target

### DIFF
--- a/docs/design/compiler/README.md
+++ b/docs/design/compiler/README.md
@@ -129,6 +129,9 @@ User-facing compiler troubleshooting and how-tos live in
   labels, and peephole optimisation.
 - [wasm-codegen.md](wasm-codegen.md) — WASM codegen pipeline: scan,
   imports, per-command dispatch, and runtime interop contract.
+- [ebpf-backend.md](ebpf-backend.md) — BPF-Tcl layering, typed core and BPF-IR,
+  current `rbpf` codegen ABI, event/framework capabilities, verified design
+  issues, real-world use cases, and the production-kernel roadmap.
 - [recursive-descent-depth-limits.md](recursive-descent-depth-limits.md) —
   why deeply-nested Tcl source could crash the analyser (issue #996): the
   depth-cap + generous-stack-budget model every recursive-descent walker

--- a/docs/design/compiler/ebpf-backend.md
+++ b/docs/design/compiler/ebpf-backend.md
@@ -1,0 +1,302 @@
+# BPF-Tcl eBPF backend architecture and production roadmap
+
+> **Status:** Experimental dual-target backend, audited 2026-08-01.
+> The default target runs under the bundled `rbpf` harness. The explicit
+> `kernel-xdp` target now verifier-loads and test-runs map-free, verdict-only
+> XDP handlers; packet access, maps, and live attachment remain future work.
+
+## Purpose
+
+BPF-Tcl is a small, statically typed packet-programming language with Tcl
+syntax. It is not a Tcl interpreter inside the kernel. The front-end accepts a
+closed, verifier-friendly command set, lowers it to a dedicated BPF
+intermediate representation, and emits eBPF instructions without LLVM.
+
+The framework layer borrows the readable `when EVENT priority N { ... }` shape
+from F5 iRules, but its events belong to a separate eBPF namespace. Today that
+namespace contains only socket filters and XDP packet handlers.
+
+## Layer map
+
+```mermaid
+flowchart TB
+    Source[".bpftcl source"]
+    Framework["Framework layer<br/>profile, template/use, allow/deny,<br/>attach, when EVENT priority N"]
+    Core["Typed core language<br/>setint/seti32/setu32, packet loads,<br/>maps, if, bounded loop, verdicts"]
+    TclIR["Shared Tcl front-end<br/>lexer → command IR → CFG"]
+    BpfIR["BPF-IR<br/>typed slots, blocks, loads, map ops,<br/>branches, typed verdict"]
+    Codegen["eBPF codegen<br/>stack-machine lowering, jumps,<br/>raw bytes, disassembly, ELF wrapper"]
+    Rbpf["Current target<br/>rbpf FixedMbuff userspace VM"]
+    Kernel["Current kernel-xdp slice<br/>map-free verdict-only XDP"]
+    Production["Required production expansion<br/>context ABI, verifier proofs,<br/>maps/relocations, loader and links"]
+
+    Source --> Framework --> Core --> TclIR --> BpfIR --> Codegen
+    Codegen --> Rbpf
+    Codegen --> Kernel
+    Kernel -. incomplete .-> Production
+```
+
+The important boundary is BPF-IR. Framework conveniences must expand into
+typed core operations before CFG construction, and code generation must depend
+only on explicit BPF-IR semantics. A kernel target should be a separate ABI
+flavour below this boundary, not a collection of kernel special cases in the
+framework.
+
+## Layer 1: low-level eBPF code generation
+
+`bpf-tcl-codegen/src/ebpf/` implements an instruction encoder, a two-pass block
+layout, a disassembler, and a hand-written ELF64 relocatable-object writer.
+
+The default `rbpf` emitter uses a simple and predictable strategy:
+
+1. `r1` points to an `rbpf` metadata buffer containing 64-bit `data` and
+   `data_end` pointers at offsets 0 and 8.
+2. The prologue copies those pointers into callee-saved `r6` and `r7`.
+3. Every BPF-IR slot owns one eight-byte eBPF stack location.
+4. Each instruction reloads operands into scratch registers, computes the
+   result, and writes it back to the stack.
+5. A second pass resolves block IDs to signed 16-bit relative jumps.
+6. Map operations call userspace helper IDs 1 and 2 with map indexes and
+   integer keys and values passed by value.
+
+This is a good reference backend: the mapping from BPF-IR to instructions is
+easy to inspect, deterministic, and covered end to end under `rbpf`. Its packet
+and map operations are not a Linux-kernel ABI:
+
+- XDP's real context is `struct xdp_md`, whose `data` and `data_end` fields are
+  32-bit offsets in the context, not 64-bit pointers at offsets 0 and 8.
+- A socket filter receives `struct __sk_buff`; it does not share the XDP direct
+  packet-access ABI.
+- Packet loads have no emitted `data_end` proof before dereference. The `rbpf`
+  VM bounds-checks them at execution time, but the kernel verifier would reject
+  them.
+- Map helpers need map file descriptors or BTF-defined maps, pointer arguments,
+  helper-compatible value lifetimes, and ELF relocations. The current ELF
+  writer rejects every object containing a map.
+- The ELF writer records a conventional program section and GPL licence, but
+  `attach` is metadata only and there is no loader.
+
+The explicit `kernel-xdp` ABI omits the simulator prologue and currently accepts
+only map-free XDP programs that do not read packet context. This verdict-only
+slice produces kernel-loadable ELF. Default `bpf-tcl compile --emit elf`
+remains an `rbpf` object for `readelf` and `llvm-objdump`; kernel objects must
+be requested with `--target kernel-xdp`. Neither target performs live
+attachment.
+
+### Linux verifier experiment
+
+The audit ran the shipped map-free XDP output through libbpf and the Linux 6.17
+verifier on an x86-64 host. `readelf` accepted the object as `ELF64`, `REL`,
+`Linux BPF`; LLVM disassembled all seven instructions; and libbpf found the
+`xdp` program and GPL licence. Kernel loading then stopped at instruction zero:
+
+```text
+0: (79) r6 = *(u64 *)(r1 +0)
+invalid bpf_context access off=0 size=8
+```
+
+This isolated the first production blocker precisely: ELF structure was not the
+problem. The `rbpf` context prologue is invalid for `struct xdp_md`.
+
+The first fix introduced a separate `kernel-xdp` target and made it reject all
+context and map operations until their verifier-safe lowering exists. A
+five-instruction `pass` handler was then accepted by the Linux 6.17 verifier
+with a stack depth of eight bytes. `BPF_PROG_TEST_RUN` over a 64-byte synthetic
+frame returned `2` (`XDP_PASS`) in 232 ns. Neither experiment attached to an
+interface, and the temporary pins, objects, packets, logs, and copied tool were
+removed from the host.
+
+## Layer 2: typed low-level language and BPF-IR
+
+The low-level language is deliberately closed. Its 24 registered commands are:
+
+| Group | Commands | Meaning |
+|---|---|---|
+| Typed scalars | `setint`, `seti32`, `setu32` | Evaluate integer expressions and commit a 64-, signed 32-, or unsigned 32-bit value. |
+| Packet context | `setbuf`, `pktlen`, `load8`, `load16`, `load32` | Bind the packet, inspect its length, and read fixed-width fields at constant offsets. |
+| State | `map`, `map_get`, `map_set` | Declare and access userspace-emulated integer-to-integer maps. |
+| Control flow | `if`, `loop` | Branch, or expand a literal-count loop up to 64 iterations before CFG construction. |
+| Socket verdicts | `accept`, `drop` | Return an accepted byte count or zero. |
+| XDP verdicts | `pass`, `drop`, `tx` | Return `XDP_PASS`, `XDP_DROP`, or `XDP_TX`. |
+| Framework | `when`, `profile`, `field`, `template`, `use`, `allow`, `deny`, `attach` | Declare handlers and expand policy/configuration conveniences. |
+
+Expressions support signed integer arithmetic, bitwise operations, shifts, and
+numeric comparisons. Dynamic Tcl values, strings, command substitution,
+procedures, namespaces, coroutines, event loops, native `while`/`for`, file or
+socket I/O, and arbitrary commands are rejected.
+
+BPF-IR is a typed three-address CFG over mutable slots. It models constants,
+copies, integer operations, context pointer/length acquisition, packet loads,
+map access, branches, and verdict returns. Types currently distinguish an
+integer from a packet-context pointer; widths are attached to load operations.
+This narrow waist is the right place to add target-independent guarantees such
+as checked packet ranges, byte order, map schemas, and event-context field
+access.
+
+## Layer 3: framework and event model
+
+The framework processes declarations in this order:
+
+1. collect one optional packet profile;
+2. collect reusable templates;
+3. collect the capability allow/deny policy;
+4. find each `when` declaration and resolve its event type;
+5. expand `use`, bounded `loop`, and named profile fields;
+6. enforce capability policy over the expanded body;
+7. build CFG and typed BPF-IR independently for each handler;
+8. apply matching `attach` metadata; and
+9. sort programs by ascending priority and event name.
+
+### Events handled today
+
+| Event | Alias | Input available to the program | Valid explicit verdicts | Current execution |
+|---|---|---|---|---|
+| `SOCKET_FILTER` | `SOCKET` | Synthetic packet bytes and length | `accept ?N?`, `drop` | `rbpf` userspace VM; result is an accepted byte count. |
+| `XDP` | — | The same synthetic packet model | `pass`, `drop`, `tx` | `rbpf` userspace VM; result is an XDP action number. |
+
+There are no TC, cgroup, tracepoint, kprobe, uprobe, perf-event, LSM, socket-op,
+or syscall events. There is no event-specific metadata such as interface index,
+queue, process ID, user ID, cgroup, socket tuple, tracepoint fields, or return
+value. There is also no ring buffer or perf buffer for sending records to
+userspace.
+
+Multiple handlers are separate programs. Priority currently controls only
+their order in the `BpfModule` and CLI program indexes; it does not generate a
+dispatcher, program array, tail-call chain, or link ordering. An external
+loader therefore cannot yet preserve the apparent multi-handler semantics.
+
+## Profiles, templates, capabilities, and deployment metadata
+
+- Built-in profiles expose fixed-offset fields for Ethernet, IPv4, TCP, and
+  UDP. Combined profiles assume Ethernet + a 20-byte IPv4 header with no VLAN
+  tags or IPv4 options.
+- User profiles declare their own fixed-offset 8-, 16-, or 32-bit fields.
+- Templates are compile-time statement macros with integer bindings.
+- `allow` restricts packet/map access verbs; `deny` can also prohibit verdicts.
+  Enforcement happens after all macro and profile expansion.
+- `attach KIND TARGET` is validated against handler types and printed by
+  `check`, but code generation and execution ignore it.
+
+## Verified design issues
+
+### Production blockers
+
+1. **The kernel target is only a verdict-only vertical slice.** It intentionally
+   rejects context access and maps. XDP context lowering and a separate socket-
+   filter ABI still need to be implemented.
+2. **No verifier-visible packet bounds checks.** Source can guard `pktlen`
+   manually, but the emitted pointer arithmetic and load do not express the
+   proof required by the kernel verifier.
+3. **No kernel maps or relocations.** Map kind, key/value sizes, and capacity
+   are metadata in the simulator; capacity is not enforced. ELF rejects maps.
+4. **Packet fields are native-endian.** Multi-byte network fields are compared
+   in host order. Existing tests deliberately use little-endian synthetic
+   bytes, so realistic network-order packets expose the mismatch.
+5. **No loader or attachment lifecycle.** `attach xdp eth0` does not create a
+   BPF link, configure an interface, pin maps, detach cleanly, or roll back a
+   partial deployment.
+
+### Low-layer correctness and maintainability
+
+1. **The registry does not describe lowering.** BPF command specs contain
+   names and arities, while `bpf-tcl-ir` matches command names again. Adding a
+   verb can make registry, lowering, capability policy, and documentation drift.
+   A typed BPF lowering descriptor or hook ID should make the registry the
+   command source of truth.
+2. **Malformed framework syntax can be accepted.** A non-integer priority
+   silently becomes 500, extra `when` header words can be ignored, and
+   non-`field` statements inside a user profile are dropped. This is tracked as
+   `RUST_ISSUE_063`.
+3. **The IR cannot state byte order or checked ranges.** `Load` carries only a
+   pointer, width, and constant offset. It cannot distinguish host/network
+   order or prove what failure verdict to use when the packet is short.
+4. **Integer semantics are only partly Tcl-like.** Signed BPF division
+   truncates towards zero, while Tcl integer division is floor division. Large
+   constants are rejected because the emitter only creates 32-bit immediates.
+5. **Stack allocation is intentionally naive.** Every temporary receives a
+   permanent eight-byte slot, all slots are zeroed, and there is no liveness-
+   based reuse. Unrolled handlers can hit the 64-slot limit well before the
+   instruction limit.
+6. **Map absence is conflated with zero.** `map_get` returns zero for a missing
+   key, so callers cannot distinguish absence from a stored zero.
+
+### Framework limitations
+
+1. **Priority has no deployment semantics.** It sorts independent artefacts but
+   does not define how their verdicts compose or how later handlers run.
+2. **One global profile, policy, and attach declaration constrain mixed-event
+   files.** Event-specific context and deployment settings need scoped config.
+3. **Fixed packet profiles do not parse protocols.** VLAN tags, variable IPv4
+   header length, fragments, IPv6 extension headers, and tunnels invalidate
+   hard-coded transport offsets.
+4. **Events are a two-arm string match.** There is no schema that pairs an event
+   with context type, allowed helpers, attachment parameters, fields, return
+   convention, and minimum kernel capability.
+5. **No userspace event channel exists.** Observability programs need typed
+   records and ring-buffer/perf-buffer delivery, not packet verdicts.
+6. **Kernel tests cover only the first verdict-only program.** There is no
+   automated privileged verifier gate, loader/link-lifecycle,
+   network-byte-order, packet-access, map, or live namespace test yet.
+
+## Real-world use cases
+
+### Useful with the current userspace target
+
+- Teach and inspect how a restricted event DSL becomes BPF-IR and eBPF.
+- Unit-test packet decisions against synthetic byte arrays without root.
+- Prototype profiles, templates, capability policies, and bounded state logic.
+- Inspect deterministic assembly and structurally valid ELF sections.
+
+### Useful with the current kernel target
+
+- Verifier-load and test-run map-free, verdict-only XDP policies.
+- Exercise the full source-to-kernel-object path without attaching to a live
+  interface.
+- Establish a fail-closed target boundary: unsupported packet or map semantics
+  are diagnosed instead of being emitted with the simulator ABI.
+
+### Enabled by a production XDP/socket-filter target
+
+- Drop known-bad L2/L3/L4 traffic before the host network stack.
+- Apply small allow/deny lists for exposed services.
+- Sample or pre-filter packet capture traffic on a socket.
+- Count packets or flows in persistent maps.
+- Implement simple SYN, UDP, or destination-port rate controls, subject to a
+  well-defined concurrency model for map updates.
+
+### Enabled by a broader event framework
+
+- TC ingress/egress classification, marking, redirect, and shaping decisions.
+- Cgroup connect/bind policy for containers and services.
+- Tracepoint and kprobe latency/error telemetry with ring-buffer records.
+- Uprobe instrumentation for selected application functions.
+- Socket lifecycle and flow telemetry with event-specific context schemas.
+- LSM policy only after stronger verification, capability, and deployment
+  guarantees are in place.
+
+## Target design and sequencing
+
+The production path is deliberately split into three GitHub work packages:
+
+1. **[Harden the low-level language and BPF-IR contracts](https://github.com/bitwisecook/tcl-lsp/issues/1202).** Make command
+   lowering registry-described, reject malformed framework input, add explicit
+   endian/checked-load/map semantics, and improve slot allocation.
+2. **[Complete the Linux-kernel codegen and ELF ABI](https://github.com/bitwisecook/tcl-lsp/issues/1203).** Keep `rbpf` as a simulator,
+   add target-specific contexts and verifier proofs, emit maps/relocations, and
+   test with the Linux verifier and `BPF_PROG_TEST_RUN`.
+3. **[Build the event framework and loader](https://github.com/bitwisecook/tcl-lsp/issues/1204).** Define event schemas, scoped
+   configuration, handler composition, attachment/link lifecycle, typed
+   userspace records, and operational introspection.
+
+The low-layer contract work should land first. Kernel codegen can then consume
+explicit checked loads, byte order, and maps. The event framework should add
+new event families only after the kernel target and loader can verify, load,
+attach, observe, and detach one program safely.
+
+## Runnable examples
+
+See [`samples/bpf-tcl/README.md`](../../../samples/bpf-tcl/README.md). The demo
+userspace script builds `bpf-tcl`, checks and executes socket-filter and XDP
+handlers, shows a stateful map, demonstrates priority/attach metadata, emits
+assembly, and inspects a map-free ELF object. The separate kernel script
+verifier-loads and test-runs the verdict-only XDP example without attaching it.

--- a/rust/bpf-tcl-codegen/src/ebpf/emit.rs
+++ b/rust/bpf-tcl-codegen/src/ebpf/emit.rs
@@ -20,12 +20,16 @@
 //! in its own stack slot, and each instruction loads its operands into scratch
 //! registers, computes, and stores back. No register allocation, no calls.
 //!
-//! Calling convention (socket filter, via rbpf's `EbpfVmFixedMbuff`, the real
-//! eBPF `data`/`data_end` model): `r1` is a metadata buffer whose first two
+//! The default calling convention uses rbpf's `EbpfVmFixedMbuff`: `r1` is a
+//! metadata buffer whose first two
 //! 64-bit words are the packet `data` pointer (offset 0) and `data_end` pointer
 //! (offset 8). The prologue loads them into the callee-saved `r6` (`data`) and
 //! `r7` (`data_end`) so they survive the whole program; the packet length is
 //! `data_end - data`.
+//!
+//! The explicit kernel-XDP target is a separate ABI. Its initial vertical slice
+//! supports map-free verdict-only programs and rejects context access until
+//! verifier-safe `xdp_md` lowering exists.
 
 use std::collections::HashMap;
 
@@ -55,10 +59,34 @@ const MAP_GET_ID: i32 = 1;
 /// Helper id for `map_set`.
 const MAP_SET_ID: i32 = 2;
 
+/// The execution ABI an emitted instruction stream targets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetAbi {
+    /// The userspace `rbpf::EbpfVmFixedMbuff` metadata-buffer ABI.
+    RbpfFixedMbuff,
+    /// Linux `BPF_PROG_TYPE_XDP`. The first vertical slice supports map-free,
+    /// verdict-only programs; context access is rejected until its verifier
+    /// proof lowering lands.
+    KernelXdp,
+}
+
+impl TargetAbi {
+    /// Stable CLI/display spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::RbpfFixedMbuff => "rbpf",
+            Self::KernelXdp => "kernel-xdp",
+        }
+    }
+}
+
 /// A compiled eBPF object: the instruction array plus its raw little-endian
 /// byte encoding (exactly what `rbpf` executes).
 #[derive(Debug, Clone)]
 pub struct EbpfObject {
+    /// The context/helper ABI this instruction stream targets.
+    pub target_abi: TargetAbi,
     /// The program type (so the object is self-describing for a loader).
     pub prog_type: ProgType,
     /// The decoded instructions.
@@ -70,12 +98,18 @@ pub struct EbpfObject {
 }
 
 impl EbpfObject {
-    fn assemble(prog_type: ProgType, insns: Vec<Insn>, maps: Vec<MapDef>) -> Self {
+    fn assemble(
+        target_abi: TargetAbi,
+        prog_type: ProgType,
+        insns: Vec<Insn>,
+        maps: Vec<MapDef>,
+    ) -> Self {
         let mut raw = Vec::with_capacity(insns.len() * 8);
         for i in &insns {
             raw.extend_from_slice(&i.to_le_bytes());
         }
         Self {
+            target_abi,
             prog_type,
             insns,
             raw,
@@ -110,13 +144,31 @@ fn slot_off(slot: u32) -> i16 {
 /// Returns a [`BpfError`] for v1 codegen limits (constant out of 32-bit range,
 /// load offset out of 16-bit range, program too large for a 16-bit jump).
 pub fn emit_program(prog: &BpfProgram) -> Result<EbpfObject, BpfError> {
+    emit_program_for_target(prog, TargetAbi::RbpfFixedMbuff)
+}
+
+/// Emit an eBPF object for a typed program and explicit execution ABI.
+///
+/// # Errors
+/// Returns a [`BpfError`] for unsupported target/program combinations and the
+/// same codegen limits as [`emit_program`].
+pub fn emit_program_for_target(
+    prog: &BpfProgram,
+    target_abi: TargetAbi,
+) -> Result<EbpfObject, BpfError> {
+    validate_target(prog, target_abi)?;
     let mut pend: Vec<Pending> = Vec::new();
 
-    // Prologue: load the packet `data` / `data_end` pointers from the metadata
-    // buffer (r1, the socket-filter context), then zero every slot so no value
-    // is ever read before it is written (verifier "init before read").
-    pend.push(Pending::Ins(ldx(SZ_DW, RPTR, R1, DATA_OFF)));
-    pend.push(Pending::Ins(ldx(SZ_DW, REND, R1, DATA_END_OFF)));
+    // The rbpf target exposes `data` / `data_end` as two 64-bit metadata words.
+    // A verdict-only kernel-XDP program does not touch its context, so it needs
+    // no prologue. Kernel context access is rejected by `validate_target` until
+    // correct `xdp_md` loads and verifier proofs are implemented.
+    if target_abi == TargetAbi::RbpfFixedMbuff {
+        pend.push(Pending::Ins(ldx(SZ_DW, RPTR, R1, DATA_OFF)));
+        pend.push(Pending::Ins(ldx(SZ_DW, REND, R1, DATA_END_OFF)));
+    }
+    // Zero every slot so no value is read before it is written (verifier "init
+    // before read").
     for i in 0..prog.num_slots {
         pend.push(Pending::Ins(st_imm(SZ_DW, R10, slot_off(i), 0)));
     }
@@ -154,10 +206,50 @@ pub fn emit_program(prog: &BpfProgram) -> Result<EbpfObject, BpfError> {
         insns.push(insn);
     }
     Ok(EbpfObject::assemble(
+        target_abi,
         prog.prog_type,
         insns,
         prog.maps.clone(),
     ))
+}
+
+fn validate_target(prog: &BpfProgram, target_abi: TargetAbi) -> Result<(), BpfError> {
+    if target_abi == TargetAbi::RbpfFixedMbuff {
+        return Ok(());
+    }
+    if prog.prog_type != ProgType::Xdp {
+        return Err(BpfError::new(
+            BpfDiag::OutOfSubset,
+            Span::empty(0),
+            "the `kernel-xdp` target only accepts `when XDP` programs",
+        ));
+    }
+    if !prog.maps.is_empty() {
+        return Err(BpfError::new(
+            BpfDiag::OutOfSubset,
+            prog.maps[0].span,
+            "the first `kernel-xdp` target slice is map-free (kernel map relocations are not implemented yet)",
+        ));
+    }
+    for inst in prog.blocks.iter().flat_map(|block| &block.insts) {
+        let (unsupported, span) = match inst {
+            Inst::CtxPtr { span, .. } => (Some("`setbuf`"), *span),
+            Inst::CtxLen { span, .. } => (Some("`pktlen`"), *span),
+            Inst::Load { span, .. } => (Some("packet loads"), *span),
+            Inst::MapGet { span, .. } | Inst::MapSet { span, .. } => (Some("map access"), *span),
+            _ => (None, Span::empty(0)),
+        };
+        if let Some(operation) = unsupported {
+            return Err(BpfError::new(
+                BpfDiag::OutOfSubset,
+                span,
+                format!(
+                    "{operation} is not available in the first `kernel-xdp` target slice; only map-free, verdict-only handlers are kernel-loadable"
+                ),
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn rel_off(from: usize, to: usize) -> Result<i16, BpfError> {
@@ -353,6 +445,26 @@ mod tests {
         // Prologue loads data/data_end from the metadata buffer (r1).
         assert_eq!(obj.insns[0], ldx(SZ_DW, R6, R1, 0)); // r6 = data
         assert_eq!(obj.insns[1], ldx(SZ_DW, R7, R1, 8)); // r7 = data_end
+    }
+
+    #[test]
+    fn kernel_xdp_verdict_only_has_no_rbpf_context_prologue() {
+        let module = compile_module("when XDP { pass }\n").expect("compiles");
+        let obj = emit_program_for_target(&module.programs[0].program, TargetAbi::KernelXdp)
+            .expect("emits for the kernel");
+        assert_eq!(obj.target_abi, TargetAbi::KernelXdp);
+        assert_eq!(obj.insns.len(), 5);
+        assert_ne!(obj.insns[0], ldx(SZ_DW, R6, R1, 0));
+        assert_eq!(obj.insns.last().unwrap().op, 0x95);
+    }
+
+    #[test]
+    fn kernel_xdp_rejects_context_access_until_proof_lowering_exists() {
+        let module = compile_module("when XDP { setbuf packet ctx\n pass }\n").expect("compiles");
+        let err = emit_program_for_target(&module.programs[0].program, TargetAbi::KernelXdp)
+            .expect_err("context ABI is not implemented");
+        assert_eq!(err.code, BpfDiag::OutOfSubset);
+        assert!(err.msg.contains("verdict-only"));
     }
 
     #[test]

--- a/rust/bpf-tcl-codegen/src/ebpf/mod.rs
+++ b/rust/bpf-tcl-codegen/src/ebpf/mod.rs
@@ -26,5 +26,5 @@ pub mod insn;
 
 pub use disasm::disasm;
 pub use elf::{ElfError, write_object};
-pub use emit::{EbpfObject, emit_program};
+pub use emit::{EbpfObject, TargetAbi, emit_program, emit_program_for_target};
 pub use insn::Insn;

--- a/rust/bpf-tcl/src/lib.rs
+++ b/rust/bpf-tcl/src/lib.rs
@@ -28,8 +28,10 @@ pub mod run;
 use std::fmt::Write as _;
 use std::process::ExitCode;
 
-use bpf_tcl_codegen::ebpf::{EbpfObject, disasm, emit_program, write_object};
-use bpf_tcl_ir::{BpfError, BpfProgramDecl, compile_module};
+use bpf_tcl_codegen::ebpf::{
+    EbpfObject, TargetAbi, disasm, emit_program, emit_program_for_target, write_object,
+};
+use bpf_tcl_ir::{BpfError, BpfProgramDecl, ProgType, compile_module};
 use tcl_lexer::SourceMap;
 
 /// CLI entry point.
@@ -63,8 +65,8 @@ fn usage() {
     eprintln!(
         "usage:\n  \
          bpf-tcl check   <file.bpftcl>\n  \
-         bpf-tcl compile <file.bpftcl> [--emit asm|hex|raw|elf] [--program N] [-o OUT]\n  \
-         bpf-tcl run     <file.bpftcl> --packet <HEX> [--program N]"
+         bpf-tcl compile <file.bpftcl> [--target rbpf|kernel-xdp] [--emit asm|hex|raw|elf] [--program N] [-o OUT]\n  \
+         bpf-tcl run     <file.bpftcl> --packet <HEX> [--program N] [--repeat N]"
     );
 }
 
@@ -126,11 +128,26 @@ fn cmd_compile(args: &[String]) -> ExitCode {
     let mut emit = "asm".to_string();
     let mut program: Option<usize> = None;
     let mut out: Option<String> = None;
+    let mut target_abi = TargetAbi::RbpfFixedMbuff;
 
     let mut it = args.iter();
     while let Some(a) = it.next() {
         match a.as_str() {
             "--emit" => emit = it.next().cloned().unwrap_or_default(),
+            "--target" => {
+                let Some(value) = it.next() else {
+                    eprintln!("compile: --target expects rbpf or kernel-xdp");
+                    return ExitCode::FAILURE;
+                };
+                target_abi = match value.as_str() {
+                    "rbpf" => TargetAbi::RbpfFixedMbuff,
+                    "kernel-xdp" => TargetAbi::KernelXdp,
+                    other => {
+                        eprintln!("compile: unknown --target `{other}` (want rbpf|kernel-xdp)");
+                        return ExitCode::FAILURE;
+                    }
+                };
+            }
             "--program" => program = it.next().and_then(|s| s.parse().ok()),
             "-o" => out = it.next().cloned(),
             other => {
@@ -179,7 +196,7 @@ fn cmd_compile(args: &[String]) -> ExitCode {
     }
 
     for (i, d) in selected {
-        let obj = match emit_program(&d.program) {
+        let obj = match emit_program_for_target(&d.program, target_abi) {
             Ok(o) => o,
             Err(e) => {
                 print_error(&path, &src, &e);
@@ -198,12 +215,24 @@ fn cmd_run(args: &[String]) -> ExitCode {
     let mut path: Option<String> = None;
     let mut packet_hex: Option<String> = None;
     let mut program = 0usize;
+    let mut repeat = 1usize;
 
     let mut it = args.iter();
     while let Some(a) = it.next() {
         match a.as_str() {
             "--packet" => packet_hex = it.next().cloned(),
             "--program" => program = it.next().and_then(|s| s.parse().ok()).unwrap_or(0),
+            "--repeat" => {
+                let Some(value) = it.next().and_then(|s| s.parse::<usize>().ok()) else {
+                    eprintln!("run: --repeat expects a positive integer");
+                    return ExitCode::FAILURE;
+                };
+                if value == 0 {
+                    eprintln!("run: --repeat expects a positive integer");
+                    return ExitCode::FAILURE;
+                }
+                repeat = value;
+            }
             other => {
                 if path.is_none() {
                     path = Some(other.to_string());
@@ -252,14 +281,22 @@ fn cmd_run(args: &[String]) -> ExitCode {
         None => Vec::new(),
     };
 
-    match run::run_socket_filter(&obj, &mut packet) {
-        Ok(v) => {
-            // A socket-filter verdict is the low 32 bits of r0 (bytes to accept).
-            let verdict = u32::try_from(v & 0xffff_ffff).unwrap_or(u32::MAX);
-            if verdict == 0 {
-                println!("drop (r0=0)");
-            } else {
-                println!("accept {verdict} bytes (r0={v})");
+    match run::run_socket_filter_repeated(&obj, &mut packet, repeat) {
+        Ok((verdict, maps)) => {
+            println!("{}", format_verdict(obj.prog_type, verdict));
+            for (def, values) in obj.maps.iter().zip(maps) {
+                let mut entries: Vec<(u64, u64)> = values.into_iter().collect();
+                entries.sort_unstable_by_key(|(key, _)| *key);
+                if entries.is_empty() {
+                    println!("map {}: <empty>", def.name);
+                } else {
+                    let rendered = entries
+                        .iter()
+                        .map(|(key, value)| format!("{key}={value}"))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    println!("map {}: {rendered}", def.name);
+                }
             }
             ExitCode::SUCCESS
         }
@@ -267,6 +304,22 @@ fn cmd_run(args: &[String]) -> ExitCode {
             eprintln!("run: {e}");
             ExitCode::FAILURE
         }
+    }
+}
+
+fn format_verdict(prog_type: ProgType, value: u64) -> String {
+    let verdict = u32::try_from(value & 0xffff_ffff).unwrap_or(u32::MAX);
+    match prog_type {
+        ProgType::SocketFilter if verdict == 0 => "drop (r0=0)".to_owned(),
+        ProgType::SocketFilter => format!("accept {verdict} bytes (r0={value})"),
+        ProgType::Xdp => match verdict {
+            0 => "XDP_ABORTED (r0=0)".to_owned(),
+            1 => "XDP_DROP (r0=1)".to_owned(),
+            2 => "XDP_PASS (r0=2)".to_owned(),
+            3 => "XDP_TX (r0=3)".to_owned(),
+            4 => "XDP_REDIRECT (r0=4)".to_owned(),
+            _ => format!("unknown XDP verdict {verdict} (r0={value})"),
+        },
     }
 }
 
@@ -281,9 +334,10 @@ fn emit_object(
     match emit {
         "asm" => {
             println!(
-                "// program #{idx}: when {} priority {} ({} insns)",
+                "// program #{idx}: when {} priority {} (target {}, {} insns)",
                 decl.event,
                 decl.priority,
+                obj.target_abi.as_str(),
                 obj.insns.len()
             );
             print!("{}", disasm(&obj.insns));
@@ -332,4 +386,20 @@ fn parse_hex(s: &str) -> Option<Vec<u8>> {
         .step_by(2)
         .map(|i| u8::from_str_radix(&cleaned[i..i + 2], 16).ok())
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verdict_format_respects_program_type() {
+        assert_eq!(
+            format_verdict(ProgType::SocketFilter, 2),
+            "accept 2 bytes (r0=2)"
+        );
+        assert_eq!(format_verdict(ProgType::Xdp, 1), "XDP_DROP (r0=1)");
+        assert_eq!(format_verdict(ProgType::Xdp, 2), "XDP_PASS (r0=2)");
+        assert_eq!(format_verdict(ProgType::Xdp, 3), "XDP_TX (r0=3)");
+    }
 }

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -849,6 +849,10 @@ struct DiagInputs {
     /// path invalidates a document's entry when it re-indexes it standalone,
     /// so the next cross-document query re-applies the seeded views.
     rehomed_source_seeds: Arc<Mutex<HashMap<String, Vec<String>>>>,
+    /// Serialises standalone index publication with source-site reconciliation
+    /// and the workspace-wide query snapshot that consumes it. See
+    /// [`Backend::rehoming_gate`].
+    rehoming_gate: Arc<tokio::sync::Mutex<()>>,
     /// Package database for the W120 workspace-refinement post-filter (#723).
     package_resolver: Arc<RwLock<PackageResolver>>,
     /// Memo for the unclosed-delimiter recovery path's widened known-command
@@ -2107,6 +2111,7 @@ async fn run_diagnostics_core(inputs: DiagInputs, uri: &Uri, job: DiagJob) -> bo
         documents,
         workspace_index,
         rehomed_source_seeds,
+        rehoming_gate,
         package_resolver,
         recovery_names,
         entry_points,
@@ -2183,6 +2188,7 @@ async fn run_diagnostics_core(inputs: DiagInputs, uri: &Uri, job: DiagJob) -> bo
             db_project: &db_project,
             workspace_index: &workspace_index,
             rehomed_source_seeds: &rehomed_source_seeds,
+            rehoming_gate: &rehoming_gate,
             package_resolver: &package_resolver,
             recovery_names: &recovery_names,
             entry_points: &entry_points,
@@ -2203,6 +2209,8 @@ struct AnalyserPathInputs<'a> {
     workspace_index: &'a Arc<RwLock<core_workspace_index::WorkspaceIndex>>,
     /// M9 applied-seed record; the publish path invalidates entries.
     rehomed_source_seeds: &'a Arc<Mutex<HashMap<String, Vec<String>>>>,
+    /// M9 publication/query transaction gate; see [`Backend::rehoming_gate`].
+    rehoming_gate: &'a Arc<tokio::sync::Mutex<()>>,
     package_resolver: &'a Arc<RwLock<PackageResolver>>,
     /// Memo for the unclosed-delimiter recovery path's widened known-command
     /// set (see [`RecoveryNameCache`]).
@@ -2442,6 +2450,7 @@ async fn run_deep_diagnostics(
         delivery,
         inputs.workspace_index,
         inputs.rehomed_source_seeds,
+        inputs.rehoming_gate,
         &analysis,
         result,
         timing,
@@ -2630,6 +2639,7 @@ async fn publish_diagnostics_result(
     delivery: &DeliveryCtx<'_>,
     workspace_index: &Arc<RwLock<core_workspace_index::WorkspaceIndex>>,
     rehomed_source_seeds: &Arc<Mutex<HashMap<String, Vec<String>>>>,
+    rehoming_gate: &Arc<tokio::sync::Mutex<()>>,
     analysis: &Arc<AnalysisResult>,
     result: Result<Vec<tower_lsp_server::ls_types::Diagnostic>, tokio::task::JoinError>,
     timing: PublishTiming<'_>,
@@ -2649,6 +2659,13 @@ async fn publish_diagnostics_result(
     };
     let diag_count = diags.len();
     {
+        // A workspace query holds this gate from source-site reconciliation
+        // through its final index snapshot. Take it before `documents` (the
+        // same order as reconciliation's `read_document`) so this standalone
+        // publish cannot replace a re-homed view in the gap between those two
+        // operations. Previously that gap made declaration-side references
+        // intermittently resolve `::helper` instead of `::x::helper` (M9).
+        let rehoming_guard = rehoming_gate.lock().await;
         // Hold the `documents` lock across the currency re-check, the
         // workspace-index update, AND the pull-cache/publish delivery so a
         // concurrent `did_change`/`did_close` (which also take `documents`)
@@ -2679,6 +2696,7 @@ async fn publish_diagnostics_result(
             .lock()
             .await
             .remove(delivery.uri.as_str());
+        drop(rehoming_guard);
         // Keep the pull-diagnostic cache in lock-step with the push: a
         // `textDocument/diagnostic` request now returns this exact set with
         // a fresh `result_id`, and an editor that already holds it gets a
@@ -2870,7 +2888,7 @@ pub struct Backend {
     /// early-return ("nothing left to reconcile") then answers instantly for
     /// every waiter but the one that did the real work. Same "wait out the
     /// in-flight pass" idiom as [`Self::workspace_scan_gate`] (issue #1003).
-    rehoming_gate: tokio::sync::Mutex<()>,
+    rehoming_gate: Arc<tokio::sync::Mutex<()>>,
     /// Tcl installations discovered by scanning common install locations on
     /// disk (never by executing `tclsh`). Cached once per session. The package
     /// database scans these (plus configured `libraryPaths`) so it can see
@@ -3579,7 +3597,7 @@ impl Backend {
             workspace_scan_ready: Arc::new(WorkspaceScanReadiness::default()),
             autoloaded_library_uris: Arc::new(Mutex::new(HashSet::new())),
             rehomed_source_seeds: Arc::new(Mutex::new(HashMap::new())),
-            rehoming_gate: tokio::sync::Mutex::new(()),
+            rehoming_gate: Arc::new(tokio::sync::Mutex::new(())),
             discovered_tcl: Arc::new(std::sync::OnceLock::new()),
             editor_library_paths: Mutex::new(Vec::new()),
             extra_commands: Mutex::new(Vec::new()),
@@ -4803,9 +4821,10 @@ impl Backend {
             return;
         }
         let folder_strs: Vec<String> = folders.iter().map(|u| u.as_str().to_owned()).collect();
-        // Hold `documents` across the open-set read + index removals (the
-        // `documents` → `workspace_index` order used since the global gate was
-        // retired) so a file opening mid-reconcile keeps its open-buffer entry.
+        // Keep source-site reconciliation/query snapshots atomic with the
+        // removal, then hold `documents` across the open-set read + index
+        // removals. Global order: rehoming_gate → documents → workspace_index.
+        let rehoming_guard = self.rehoming_gate.lock().await;
         let docs = self.documents.lock().await;
         let open: HashSet<String> = docs.keys().map(|u| u.as_str().to_owned()).collect();
         let mut index = self.workspace_index.write().await;
@@ -4835,6 +4854,13 @@ impl Backend {
             .collect();
         self.db_remove_sources_batch(&removed_urls).await;
         drop(docs);
+        {
+            let mut seeds = self.rehomed_source_seeds.lock().await;
+            for uri in &to_remove {
+                seeds.remove(uri);
+            }
+        }
+        drop(rehoming_guard);
         // Clear the Problems / File-Explorer badge of any removed-folder file
         // that still carried one (#865) — it is no longer part of the workspace,
         // so a retained closed-file badge would be stale.
@@ -4913,9 +4939,11 @@ impl Backend {
             .collect();
         let results = run_bounded(futures, concurrency).await;
 
-        // Hold `documents` across the still-closed re-check and both updates
-        // (the `documents` → db → `workspace_index` order established by
-        // `did_open`), matching the single-file path.
+        // Serialise this standalone replacement with source-site reconciliation
+        // and navigation snapshots, then hold `documents` across the
+        // still-closed re-check and both updates. Global order:
+        // rehoming_gate → documents → db → workspace_index.
+        let _rehoming_guard = self.rehoming_gate.lock().await;
         let docs = self.documents.lock().await;
         let mut applied: Vec<(Uri, String, String, AnalysisResult)> = Vec::new();
         let mut to_remove: Vec<Uri> = Vec::new();
@@ -4974,10 +5002,11 @@ impl Backend {
         let folder_dialects = Arc::new(self.folder_dialects.lock().await.clone());
         let default_dialect = Arc::new(self.default_dialect.lock().await.clone());
         let scanned = Self::scan_disk_file(uri.clone(), folder_dialects, default_dialect).await;
-        // Hold `documents` across the still-closed re-check and both updates (the
-        // `documents` → db → `workspace_index` order established by `did_open`) so a
-        // concurrent `did_open` cannot open the buffer between them and have its
-        // live text clobbered by this disk-backed copy.
+        // Serialise the standalone replacement with source-site reconciliation,
+        // then hold `documents` across the still-closed re-check and both
+        // updates. Global order: rehoming_gate → documents → db →
+        // workspace_index.
+        let _rehoming_guard = self.rehoming_gate.lock().await;
         let docs = self.documents.lock().await;
         if docs.contains_key(uri) {
             return;
@@ -5426,7 +5455,7 @@ impl Backend {
         analysis: &AnalysisResult,
         cell: &str,
     ) -> Vec<Location> {
-        self.refresh_source_rehoming().await;
+        let rehoming_guard = self.rehomed_index_guard().await;
         let mut targets: Vec<(String, tcl_lexer::Span)> =
             core_namespace_symbol::namespace_declaration_spans(analysis, cell)
                 .into_iter()
@@ -5441,6 +5470,7 @@ impl Backend {
                     .map(|n| (n.uri.clone(), n.span)),
             );
         }
+        drop(rehoming_guard);
         dedup_span_targets(&mut targets);
         self.resolve_target_locations(targets).await
     }
@@ -5465,7 +5495,7 @@ impl Backend {
         analysis: &AnalysisResult,
         cell: &str,
     ) -> Option<CoreHover> {
-        self.refresh_source_rehoming().await;
+        let rehoming_guard = self.rehomed_index_guard().await;
         let local = core_namespace_symbol::namespace_facts(analysis, cell);
         let facts = {
             let index = self.workspace_index.read().await;
@@ -5487,6 +5517,7 @@ impl Backend {
             }
             merged
         };
+        drop(rehoming_guard);
         core_hover::namespace_hover(cell, facts)
     }
 
@@ -5506,7 +5537,7 @@ impl Backend {
         cell: &str,
         include_declaration: bool,
     ) -> Vec<Location> {
-        self.refresh_source_rehoming().await;
+        let rehoming_guard = self.rehomed_index_guard().await;
         let mut targets: Vec<(String, tcl_lexer::Span)> =
             core_namespace_symbol::namespace_all_spans(analysis, cell, include_declaration)
                 .into_iter()
@@ -5529,6 +5560,7 @@ impl Backend {
                 );
             }
         }
+        drop(rehoming_guard);
         dedup_span_targets(&mut targets);
         self.resolve_target_locations(targets).await
     }
@@ -5554,7 +5586,7 @@ impl Backend {
         };
         // The index answers under source-site namespaces too (M9), so
         // reconcile before asking, exactly as the proc/class tier does.
-        self.refresh_source_rehoming().await;
+        let rehoming_guard = self.rehomed_index_guard().await;
         let targets: Vec<(String, tcl_lexer::Span)> = {
             let index = self.workspace_index.read().await;
             index
@@ -5563,6 +5595,7 @@ impl Backend {
                 .map(|v| (v.uri.clone(), v.name_span))
                 .collect()
         };
+        drop(rehoming_guard);
         self.resolve_target_locations(targets).await
     }
 
@@ -5770,6 +5803,7 @@ impl Backend {
             }
         }
         let mut resolved = None;
+        let mut analysed = Vec::new();
         for path in files {
             let Some(target_uri) = Uri::from_file_path(&path) else {
                 continue;
@@ -5784,15 +5818,6 @@ impl Backend {
                     target_doc.dialect.clone(),
                 )
                 .await;
-            {
-                let mut index = self.workspace_index.write().await;
-                index.remove_document(target_uri.as_str());
-                index.add_document(target_uri.as_str(), &file_analysis);
-            }
-            self.autoloaded_library_uris
-                .lock()
-                .await
-                .insert(target_uri.as_str().to_owned());
             if resolved.is_none() {
                 resolved = absolute
                     .iter()
@@ -5801,6 +5826,31 @@ impl Backend {
                             || file_analysis.all_classes.contains_key(*cand)
                     })
                     .cloned();
+            }
+            analysed.push((target_uri, file_analysis));
+        }
+        if analysed.is_empty() {
+            return resolved;
+        }
+
+        // Publish every file as one standalone replacement transaction. A
+        // navigation snapshot either sees the previous index or the complete
+        // library merge, never a partially merged package nor a standalone
+        // replacement of a freshly re-homed source-site view.
+        let _rehoming_guard = self.rehoming_gate.lock().await;
+        {
+            let mut index = self.workspace_index.write().await;
+            for (target_uri, file_analysis) in &analysed {
+                index.remove_document(target_uri.as_str());
+                index.add_document(target_uri.as_str(), file_analysis);
+            }
+        }
+        {
+            let mut seeds = self.rehomed_source_seeds.lock().await;
+            let mut autoloaded = self.autoloaded_library_uris.lock().await;
+            for (target_uri, _) in &analysed {
+                seeds.remove(target_uri.as_str());
+                autoloaded.insert(target_uri.as_str().to_owned());
             }
         }
         resolved
@@ -5873,7 +5923,7 @@ impl Backend {
         analysis: &AnalysisResult,
     ) -> Option<CoreHover> {
         let cell = Self::qualified_variable_cell(source, &analysis.dialect, analysis, pos)?;
-        self.refresh_source_rehoming().await;
+        let rehoming_guard = self.rehomed_index_guard().await;
         let target_uris: Vec<String> = {
             let index = self.workspace_index.read().await;
             index
@@ -5882,6 +5932,7 @@ impl Backend {
                 .map(|v| v.uri.clone())
                 .collect()
         };
+        drop(rehoming_guard);
         for target_uri in target_uris {
             let Ok(parsed) = Uri::from_str(&target_uri) else {
                 continue;
@@ -5947,7 +5998,9 @@ impl Backend {
     ) -> jsonrpc::Result<Vec<Location>> {
         // Reconcile the index with the source graph first (M9): sourced
         // documents answer under their source-site namespaces.
-        self.refresh_source_rehoming().await;
+        let (rehoming_guard, symbols) = self
+            .resolved_symbol_index_snapshot(uri, source, analysis, pos)
+            .await;
         // Resolve the call at the cursor to its qualified identity set
         // through the workspace oracle, then jump to *those* symbols'
         // definitions — never every same-simple-name proc/class across the
@@ -5955,9 +6008,6 @@ impl Backend {
         // jump targets.  (A multi-seeded declaration cursor yields several
         // identities sharing one physical definition — the target set
         // dedupes to the physical site.)
-        let symbols = self
-            .resolve_workspace_symbols(uri, source, analysis, pos)
-            .await;
         if symbols.is_empty() {
             return Ok(Vec::new());
         }
@@ -5994,6 +6044,7 @@ impl Backend {
             targets.dedup();
             targets
         };
+        drop(rehoming_guard);
         Ok(self.resolve_target_locations(targets).await)
     }
 
@@ -6080,7 +6131,7 @@ impl Backend {
     /// Anything else (a bareword argument, whitespace, a `$var`) resolves to
     /// nothing (an empty set), so no coincidental word links to a sibling
     /// symbol.
-    async fn resolve_workspace_symbols(
+    async fn resolve_workspace_symbols_indexed(
         &self,
         uri: &Uri,
         source: &str,
@@ -6222,8 +6273,31 @@ impl Backend {
                 return vec![target];
             }
         }
+        Vec::new()
+    }
+
+    /// Resolve against the current index, then populate the autoload/package
+    /// tier on a genuine miss. This function deliberately takes no source-site
+    /// transaction guard: [`Self::ensure_library_indexed`] may wait for
+    /// `workspace_scan_gate`, and a workspace scan takes `rehoming_gate` while
+    /// merging its results. Nesting those gates in the opposite order would
+    /// deadlock a navigation request against an in-flight scan.
+    async fn resolve_workspace_symbols(
+        &self,
+        uri: &Uri,
+        source: &str,
+        analysis: &AnalysisResult,
+        pos: Position,
+    ) -> Vec<String> {
+        let indexed = self
+            .resolve_workspace_symbols_indexed(uri, source, analysis, pos)
+            .await;
+        if !indexed.is_empty() {
+            return indexed;
+        }
+
         // Autoload tier (M8): the command resolves nowhere in the open
-        // workspace.  Ask the auto-load / package database, merging the
+        // workspace. Ask the auto-load / package database, merging the
         // defining library file into the index so this query — and every
         // later references / rename / definition — sees its definitions.
         let Some((word, namespace)) = core_definition::command_head_and_namespace_at(
@@ -6238,6 +6312,48 @@ impl Backend {
             .await
             .into_iter()
             .collect()
+    }
+
+    /// Prepare any on-demand library indexing without holding
+    /// `rehoming_gate`, then reconcile and return the symbol identities while
+    /// keeping that gate held for the caller's complete workspace-index read.
+    ///
+    /// The second indexed lookup is essential: reconciliation may replace a
+    /// sourced document's standalone identity with one or more source-site
+    /// identities. If that replacement invalidates a preflight hit, retry the
+    /// autoload path once outside the transaction before taking the final
+    /// snapshot.
+    async fn resolved_symbol_index_snapshot<'a>(
+        &'a self,
+        uri: &Uri,
+        source: &str,
+        analysis: &AnalysisResult,
+        pos: Position,
+    ) -> (tokio::sync::MutexGuard<'a, ()>, Vec<String>) {
+        let preflight = self
+            .resolve_workspace_symbols(uri, source, analysis, pos)
+            .await;
+        let guard = self.rehomed_index_guard().await;
+        let symbols = self
+            .resolve_workspace_symbols_indexed(uri, source, analysis, pos)
+            .await;
+        if !symbols.is_empty() || preflight.is_empty() {
+            return (guard, symbols);
+        }
+
+        // The preflight resolved only through a stale standalone view that
+        // reconciliation removed. Any package lookup must happen after
+        // releasing the transaction gate, then the final snapshot reconciles
+        // once more around the resulting index state.
+        drop(guard);
+        let _ = self
+            .resolve_workspace_symbols(uri, source, analysis, pos)
+            .await;
+        let guard = self.rehomed_index_guard().await;
+        let symbols = self
+            .resolve_workspace_symbols_indexed(uri, source, analysis, pos)
+            .await;
+        (guard, symbols)
     }
 
     /// Cross-document references for the proc / class at `pos`:
@@ -6313,9 +6429,8 @@ impl Backend {
         include_declaration: bool,
         exclude_uri: &str,
     ) -> Vec<Location> {
-        self.refresh_source_rehoming().await;
-        let symbols = self
-            .resolve_workspace_symbols(uri, source, analysis, pos)
+        let (rehoming_guard, symbols) = self
+            .resolved_symbol_index_snapshot(uri, source, analysis, pos)
             .await;
         if symbols.is_empty() {
             return Vec::new();
@@ -6355,6 +6470,7 @@ impl Backend {
             t.dedup();
             t
         };
+        drop(rehoming_guard);
         self.resolve_target_locations(targets).await
     }
 
@@ -6510,7 +6626,7 @@ impl Backend {
         else {
             return Vec::new();
         };
-        self.refresh_source_rehoming().await;
+        let rehoming_guard = self.rehomed_index_guard().await;
         let targets: Vec<(String, tcl_lexer::Span)> = {
             let index = self.workspace_index.read().await;
             let declarations: Vec<(String, tcl_lexer::Span)> = index
@@ -6531,6 +6647,7 @@ impl Backend {
             t.dedup();
             t
         };
+        drop(rehoming_guard);
         self.resolve_target_locations(targets).await
     }
 
@@ -7224,10 +7341,10 @@ impl Backend {
         if !core_rename::is_safe_symbol_name(new_name) {
             return Ok(changes);
         }
-        self.refresh_source_rehoming().await;
-        let namespace = cell.rsplit_once("::").map_or("::", |(ns, _)| ns);
-        let new_cell = format!("{namespace}::{new_name}");
         let candidates: Vec<String> = {
+            let _rehoming_guard = self.rehomed_index_guard().await;
+            let namespace = cell.rsplit_once("::").map_or("::", |(ns, _)| ns);
+            let new_cell = format!("{namespace}::{new_name}");
             let index = self.workspace_index.read().await;
             // Collision gate: the target cell already exists, so the rename
             // would silently merge two distinct namespace variables.
@@ -7700,9 +7817,8 @@ impl Backend {
         new_name: &str,
         changes: &mut std::collections::HashMap<Uri, Vec<TextEdit>>,
     ) -> bool {
-        self.refresh_source_rehoming().await;
-        let symbols = self
-            .resolve_workspace_symbols(uri, source, analysis, pos)
+        let (rehoming_guard, symbols) = self
+            .resolved_symbol_index_snapshot(uri, source, analysis, pos)
             .await;
         let intents = {
             let index = self.workspace_index.read().await;
@@ -7720,6 +7836,7 @@ impl Backend {
             }
             intents
         };
+        drop(rehoming_guard);
         self.merge_rename_intents(intents, changes).await;
         false
     }
@@ -7741,9 +7858,8 @@ impl Backend {
         new_name: &str,
         changes: &mut std::collections::HashMap<Uri, Vec<TextEdit>>,
     ) {
-        self.refresh_source_rehoming().await;
-        let symbols = self
-            .resolve_workspace_symbols(uri, source, analysis, pos)
+        let (rehoming_guard, symbols) = self
+            .resolved_symbol_index_snapshot(uri, source, analysis, pos)
             .await;
         if symbols.is_empty() {
             return;
@@ -7779,6 +7895,7 @@ impl Backend {
             }
             intents
         };
+        drop(rehoming_guard);
         self.merge_rename_intents(intents, changes).await;
     }
 
@@ -9410,6 +9527,7 @@ impl Backend {
             documents: Arc::clone(&self.documents),
             workspace_index: Arc::clone(&self.workspace_index),
             rehomed_source_seeds: Arc::clone(&self.rehomed_source_seeds),
+            rehoming_gate: Arc::clone(&self.rehoming_gate),
             package_resolver: Arc::clone(&self.package_resolver),
             recovery_names: Arc::clone(&self.recovery_names),
             entry_points,
@@ -9838,7 +9956,21 @@ impl Backend {
     /// few lines down then answers "already converged" for every waiter but
     /// whichever caller actually did the work.
     async fn refresh_source_rehoming(&self) {
-        let _guard = self.rehoming_gate.lock().await;
+        let _guard = self.rehomed_index_guard().await;
+    }
+
+    /// Reconcile source-site views and keep the transaction gate held for the
+    /// caller's subsequent workspace-index snapshot. Standalone publishers use
+    /// the same gate, so none can invalidate the freshly re-homed view between
+    /// reconciliation and a definition/reference/rename read.
+    async fn rehomed_index_guard(&self) -> tokio::sync::MutexGuard<'_, ()> {
+        let guard = self.rehoming_gate.lock().await;
+        self.refresh_source_rehoming_locked().await;
+        guard
+    }
+
+    /// [`Self::refresh_source_rehoming`] with the transaction gate already held.
+    async fn refresh_source_rehoming_locked(&self) {
         for _round in 0..4 {
             let desired = {
                 let index = self.workspace_index.read().await;
@@ -10095,9 +10227,15 @@ impl Backend {
         let stale_library_uris: Vec<String> =
             self.autoloaded_library_uris.lock().await.drain().collect();
         if !stale_library_uris.is_empty() {
+            let _rehoming_guard = self.rehoming_gate.lock().await;
             let mut index = self.workspace_index.write().await;
             for uri in &stale_library_uris {
                 index.remove_document(uri);
+            }
+            drop(index);
+            let mut seeds = self.rehomed_source_seeds.lock().await;
+            for uri in &stale_library_uris {
+                seeds.remove(uri);
             }
         }
 
@@ -10239,10 +10377,10 @@ impl Backend {
         &self,
         analysed: &[(Uri, String, String, AnalysisResult)],
     ) {
-        // Hold `documents` across the open-set read, the salsa-db batch, and the
-        // index merge (the `documents` → db → `workspace_index` order established
-        // by `did_open`) so a file opening mid-merge can't have its live buffer
-        // overwritten by this disk-backed scan result in either store.
+        // Serialise each standalone merge with source-site reconciliation, then
+        // hold `documents` across the open-set read, salsa-db batch, and index
+        // merge. Global order: rehoming_gate → documents → db → workspace_index.
+        let _rehoming_guard = self.rehoming_gate.lock().await;
         let docs = self.documents.lock().await;
         let open: HashSet<String> = docs.keys().map(|u| u.as_str().to_owned()).collect();
         // Salsa db first (db → db_files → db_project), before the workspace_index
@@ -11243,6 +11381,7 @@ impl LanguageServer for Backend {
         // `Project` so a deleted file stops suppressing W123 / driving the
         // arity error cross-file.
         if !deleted.is_empty() {
+            let _rehoming_guard = self.rehoming_gate.lock().await;
             {
                 let mut index = self.workspace_index.write().await;
                 for uri in &deleted {
@@ -11250,6 +11389,10 @@ impl LanguageServer for Backend {
                 }
             }
             self.db_remove_sources_batch(&deleted).await;
+            let mut seeds = self.rehomed_source_seeds.lock().await;
+            for uri in &deleted {
+                seeds.remove(uri.as_str());
+            }
         }
         // CREATED / CHANGED: read + analyse every file across the bounded
         // worker pool, then one batched index/db merge.
@@ -19953,7 +20096,7 @@ mod tests {
             workspace_scan_ready: Arc::new(WorkspaceScanReadiness::default()),
             autoloaded_library_uris: Arc::new(Mutex::new(HashSet::new())),
             rehomed_source_seeds: Arc::new(Mutex::new(HashMap::new())),
-            rehoming_gate: tokio::sync::Mutex::new(()),
+            rehoming_gate: Arc::new(tokio::sync::Mutex::new(())),
             discovered_tcl: Arc::new(std::sync::OnceLock::new()),
             editor_library_paths: Mutex::new(Vec::new()),
             extra_commands: Mutex::new(Vec::new()),
@@ -24210,6 +24353,51 @@ mod tests {
         );
     }
 
+    /// A source-site snapshot may need M8's autoload tier, which waits for an
+    /// in-flight workspace scan. It must perform that wait *before* taking
+    /// `rehoming_gate`: the scan holds `workspace_scan_gate` while its merge
+    /// takes `rehoming_gate`, so the reverse nesting deadlocks both tasks.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rehomed_symbol_snapshot_does_not_hold_its_gate_while_waiting_for_scan() {
+        let backend = Arc::new(test_backend());
+        seed_autoload_library(&backend, "autoload-rehoming-order").await;
+        let app = Uri::from_str("file:///app.tcl").unwrap();
+        let app_src = "Rbc_ActiveLegend .g\n";
+        register(&backend, &app, app_src).await;
+        let analysis = Arc::new(Analyser::new().analyse(app_src, "tcl8.6").clone());
+
+        let scan_guard = backend.workspace_scan_gate.lock().await;
+        let query_backend = Arc::clone(&backend);
+        let query_app = app.clone();
+        let query = tokio::spawn(async move {
+            let (guard, symbols) = query_backend
+                .resolved_symbol_index_snapshot(&query_app, app_src, &analysis, Position::new(0, 3))
+                .await;
+            drop(guard);
+            symbols
+        });
+        tokio::task::yield_now().await;
+        assert!(
+            !query.is_finished(),
+            "autoload preflight must wait for the in-flight workspace scan"
+        );
+
+        let rehoming_guard = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            backend.rehoming_gate.lock(),
+        )
+        .await
+        .expect("the waiting query must not hold rehoming_gate");
+        drop(rehoming_guard);
+        drop(scan_guard);
+
+        let symbols = tokio::time::timeout(std::time::Duration::from_secs(2), query)
+            .await
+            .expect("query must complete after the scan releases its gate")
+            .expect("query task panicked");
+        assert_eq!(symbols, vec!["::Rbc_ActiveLegend"]);
+    }
+
     /// FP guard: when the workspace itself defines the command, the autoload
     /// tier must not fire — the workspace definition wins and no library file
     /// is merged into the index.
@@ -24459,6 +24647,111 @@ mod tests {
         assert!(
             refs.iter().any(|l| l.uri == a),
             "the sourcing document's qualified call must still resolve: {refs:?}"
+        );
+    }
+
+    /// A diagnostics run publishes a standalone analysis before the next M9
+    /// reconciliation. It must not do that while a navigation request is
+    /// consuming the freshly re-homed index snapshot: otherwise the query can
+    /// map the declaration through `::x` and then gather calls from the
+    /// standalone `::helper` view, yielding an empty reference set.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn diagnostics_publish_waits_for_rehomed_navigation_snapshot() {
+        let backend = Arc::new(test_backend());
+        let a = Uri::from_str("file:///proj/a.tcl").unwrap();
+        let b = Uri::from_str("file:///proj/b.tcl").unwrap();
+        let b_src = "proc helper {} {}\n";
+        register(&backend, &b, b_src).await;
+        register(
+            &backend,
+            &a,
+            "namespace eval ::x { source b.tcl }\n::x::helper\n",
+        )
+        .await;
+
+        let query_guard = backend.rehomed_index_guard().await;
+        let query_started = Arc::new(tokio::sync::Notify::new());
+        let publish_finished = Arc::new(tokio::sync::Notify::new());
+        let publisher_backend = Arc::clone(&backend);
+        let publisher_b = b.clone();
+        let publisher_started = Arc::clone(&query_started);
+        let publisher_finished = Arc::clone(&publish_finished);
+        let standalone = Arc::new(Analyser::new().analyse(b_src, "tcl8.6").clone());
+        let publisher = tokio::spawn(async move {
+            let revision = publisher_backend
+                .documents
+                .lock()
+                .await
+                .get(&publisher_b)
+                .expect("b.tcl stays open")
+                .revision;
+            let uri_string = publisher_b.to_string();
+            let delivery = DeliveryCtx {
+                client: &publisher_backend.client,
+                documents: &publisher_backend.documents,
+                pull_diag_cache: &publisher_backend.pull_diag_cache,
+                closed_diag_gen: &publisher_backend.closed_diag_gen,
+                uri: &publisher_b,
+                currency: DiagCurrency::Open(revision),
+                version: None,
+                client_supports_pull: false,
+            };
+            publisher_started.notify_one();
+            let settled = publish_diagnostics_result(
+                &delivery,
+                &publisher_backend.workspace_index,
+                &publisher_backend.rehomed_source_seeds,
+                &publisher_backend.rehoming_gate,
+                &standalone,
+                Ok(Vec::new()),
+                PublishTiming {
+                    started: std::time::Instant::now(),
+                    uri_str: &uri_string,
+                    line_count: 1,
+                },
+            )
+            .await;
+            publisher_finished.notify_one();
+            settled
+        });
+
+        query_started.notified().await;
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(100),
+                publish_finished.notified(),
+            )
+            .await
+            .is_err(),
+            "standalone diagnostics publication must wait for the active re-homed snapshot",
+        );
+        {
+            let index = backend.workspace_index.read().await;
+            assert!(
+                index
+                    .linked_invocations_of("::x::helper", b.as_str())
+                    .iter()
+                    .any(|site| site.uri == a.as_str()),
+                "the guarded snapshot must retain the source-site call view",
+            );
+        }
+        drop(query_guard);
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_secs(5), publisher)
+                .await
+                .expect("publisher must resume after the query releases the gate")
+                .expect("publisher task must not panic"),
+            "the current diagnostics run must publish",
+        );
+
+        let analysis = Analyser::new().analyse(b_src, "tcl8.6").clone();
+        let refs = backend
+            .cross_document_references(&b, b_src, &analysis, Position::new(0, 6), false)
+            .await;
+        assert!(
+            refs.iter().any(|location| location.uri == a),
+            "the next query must reconcile the standalone publish before reading: {refs:?}",
         );
     }
 

--- a/samples/bpf-tcl/README.md
+++ b/samples/bpf-tcl/README.md
@@ -1,0 +1,209 @@
+# BPF-Tcl userspace demos
+
+These demos exercise both backend targets that exist today. The default `rbpf`
+target executes real eBPF instructions over synthetic packet bytes in a
+userspace virtual machine. The explicit `kernel-xdp` target supports a small,
+map-free, verdict-only XDP subset that the Linux kernel can verifier-load and
+test-run.
+
+The clean-room instructions and full script were validated on Ubuntu 26.04
+with Rust 1.97.0, GNU `readelf`, and LLVM 21.
+
+The demos do **not** attach programs to a network interface or socket. Default
+ELF output uses the simulator context ABI and is for inspection only; pass an
+object to `bpftool prog load` only when it was compiled with `--target
+kernel-xdp`. See the
+[backend architecture and roadmap](../../docs/design/compiler/ebpf-backend.md).
+
+## Install prerequisites on Debian or Ubuntu
+
+Install the native build tools and ELF inspector:
+
+```sh
+sudo apt-get update
+sudo apt-get install -y \
+  curl ca-certificates build-essential pkg-config libssl-dev binutils git
+```
+
+The workspace follows the current stable Rust release. Distribution `cargo`
+packages are often older than the `rust-version` in the top-level
+`Cargo.toml`, so install Rust through `rustup`:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+  | sh -s -- -y --profile minimal --default-toolchain stable
+. "${HOME}/.cargo/env"
+rustup update stable
+rustc --version
+cargo --version
+```
+
+On a recent Ubuntu release that packages `rustup`, this is also valid:
+
+```sh
+sudo apt-get install -y rustup
+rustup default stable
+```
+
+`readelf` comes from `binutils`. LLVM disassembly is optional:
+
+```sh
+sudo apt-get install -y llvm
+```
+
+`bpftool` is not required for these demos. It can inspect the host's BPF
+capabilities. The separate verdict-only kernel demo below requires it:
+
+```sh
+sudo apt-get install -y bpftool
+```
+
+## Get and compile the project
+
+```sh
+git clone https://github.com/bitwisecook/tcl-lsp.git
+cd tcl-lsp
+
+source scripts/dev/agent-build-env.sh
+cargo build -p bpf-tcl --release
+target/release/bpf-tcl --help
+```
+
+The compiled executable is `target/release/bpf-tcl`. The demo script below
+builds and uses `target/debug/bpf-tcl` automatically instead, which is quicker
+for development builds and behaves identically for the examples.
+
+## Run everything
+
+From the repository root on a Linux server:
+
+```sh
+bash samples/bpf-tcl/run-demos.sh
+```
+
+The script builds `bpf-tcl`, then demonstrates:
+
+1. a socket filter that drops undersized packets and accepts complete packets;
+2. an XDP handler using a user-defined packet profile and template;
+3. an integer map that persists across repeated simulator invocations;
+4. framework priority sorting and descriptive `attach` metadata;
+5. emitted eBPF assembly; and
+6. a map-free `EM_BPF` ELF object inspected with `readelf` when available.
+
+The XDP marker example uses an 8-bit field at byte zero, avoiding the current
+native-endian limitation for multi-byte network fields.
+
+## Run one example
+
+```sh
+source scripts/dev/agent-build-env.sh
+cargo build -p bpf-tcl
+
+target/debug/bpf-tcl check samples/bpf-tcl/xdp-marker.bpftcl
+target/debug/bpf-tcl run samples/bpf-tcl/xdp-marker.bpftcl --packet 7f000102
+target/debug/bpf-tcl run samples/bpf-tcl/xdp-marker.bpftcl --packet 01020304
+```
+
+Expected verdicts are `XDP_DROP` for a first byte of `0x7f`, and `XDP_PASS`
+for a first byte of `0x01`.
+
+Use `--repeat N` to execute one emitted program repeatedly while preserving its
+simulated maps:
+
+```sh
+target/debug/bpf-tcl run samples/bpf-tcl/map-counter.bpftcl \
+  --packet 0000000000000000 --repeat 3
+```
+
+The final output includes `map hits: 0=3`.
+
+## Run the first real kernel XDP program
+
+The explicit `kernel-xdp` target currently supports map-free, verdict-only XDP
+handlers. It rejects packet/context access and maps until their verifier-proof
+and relocation lowering is implemented. This gives the project a small but
+genuine kernel-loaded vertical slice without silently emitting unsafe code.
+
+Requirements:
+
+- Linux with XDP and the `bpf()` system call enabled;
+- root or sudo access with the required BPF capabilities;
+- `bpftool`, `readelf`, Cargo, and a mounted BPF filesystem at `/sys/fs/bpf`.
+
+Run:
+
+```sh
+bash samples/bpf-tcl/run-kernel-xdp-demo.sh
+```
+
+The script:
+
+1. compiles `xdp-kernel-pass.bpftcl` with `--target kernel-xdp`;
+2. inspects the ELF object;
+3. verifier-loads and pins it temporarily with `bpftool`;
+4. executes it over a synthetic 64-byte Ethernet frame using
+   `BPF_PROG_TEST_RUN`;
+5. expects return value `2` (`XDP_PASS`); and
+6. removes the pin and all temporary files on exit.
+
+It does not attach the program to a network interface. If the BPF filesystem is
+not mounted, mount it once with:
+
+```sh
+sudo mount -t bpf bpf /sys/fs/bpf
+```
+
+## Compile a `.bpftcl` file
+
+`check` runs the framework expansion and typed lowering without emitting an
+object:
+
+```sh
+target/debug/bpf-tcl check samples/bpf-tcl/priority-bundle.bpftcl
+```
+
+`compile` can emit readable assembly, raw instruction bytes, hex, or a
+structural ELF object. A bundle with multiple handlers needs `--program N` for
+ELF because each program receives its own object:
+
+```sh
+target/debug/bpf-tcl compile samples/bpf-tcl/priority-bundle.bpftcl \
+  --emit asm --program 0
+
+target/debug/bpf-tcl compile samples/bpf-tcl/priority-bundle.bpftcl \
+  --emit elf --program 0 -o /tmp/bpf-tcl-xdp.o
+
+readelf -h -S -s /tmp/bpf-tcl-xdp.o
+llvm-objdump -d /tmp/bpf-tcl-xdp.o  # optional
+```
+
+The ELF has an `EM_BPF` machine header, an `xdp` or `socket` program section, a
+GPL licence section, and a function symbol. The default target is still
+`rbpf`, so structural validity does not imply kernel loadability. Use
+`--target kernel-xdp` only with the currently supported verdict-only XDP subset.
+
+## Execute synthetic packets
+
+`run` accepts packet bytes as hexadecimal. Whitespace inside the value is
+ignored. It compiles the selected handler and executes the resulting eBPF under
+the userspace VM:
+
+```sh
+target/debug/bpf-tcl run samples/bpf-tcl/socket-length.bpftcl \
+  --packet 01020304
+```
+
+For a multi-handler file, use `--program N`. Program indexes are the order
+printed by `check`, after priority sorting.
+
+## Troubleshooting
+
+- If Cargo says the compiler is too old, run `rustup update stable`, ensure
+  `${HOME}/.cargo/bin` is on `PATH`, and retry.
+- If `readelf` is missing, install `binutils`. If `llvm-objdump` is missing,
+  install `llvm`; the demo script treats both inspectors as optional.
+- No `sudo` is needed after prerequisites are installed. The userspace VM does
+  not require `CAP_BPF`, `CAP_NET_ADMIN`, a mounted BPF filesystem, or kernel
+  headers.
+- An out-of-bounds synthetic packet load is an execution error. Keep explicit
+  `pktlen` guards before fixed-offset loads.

--- a/samples/bpf-tcl/map-counter.bpftcl
+++ b/samples/bpf-tcl/map-counter.bpftcl
@@ -1,0 +1,8 @@
+# Userspace-emulated map state persists across --repeat invocations in one run.
+when SOCKET_FILTER {
+    map hits hash 8 8 16
+    map_get count hits {0}
+    setint next {$count + 1}
+    map_set hits {0} {$next}
+    accept {$next}
+}

--- a/samples/bpf-tcl/priority-bundle.bpftcl
+++ b/samples/bpf-tcl/priority-bundle.bpftcl
@@ -1,0 +1,11 @@
+# Programs are sorted by priority. The attach declaration is validated and
+# displayed, but it is descriptive metadata until a kernel loader exists.
+attach xdp demo0
+
+when SOCKET_FILTER priority 200 {
+    accept
+}
+
+when XDP priority 25 {
+    pass
+}

--- a/samples/bpf-tcl/run-demos.sh
+++ b/samples/bpf-tcl/run-demos.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -euo pipefail
+
+demo_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${demo_dir}/../.." && pwd)"
+cd "${repo_root}"
+
+source scripts/dev/agent-build-env.sh
+cargo build -p bpf-tcl
+bpf_bin="${CARGO_TARGET_DIR}/debug/bpf-tcl"
+
+run_demo() {
+    printf '\n$'
+    printf ' %q' "$@"
+    printf '\n'
+    "$@"
+}
+
+printf 'BPF-Tcl userspace eBPF demos\n'
+printf 'No root access or kernel attachment is used.\n'
+
+run_demo "${bpf_bin}" check "${demo_dir}/socket-length.bpftcl"
+run_demo "${bpf_bin}" run "${demo_dir}/socket-length.bpftcl" --packet 0102
+run_demo "${bpf_bin}" run "${demo_dir}/socket-length.bpftcl" --packet 01020304
+
+run_demo "${bpf_bin}" check "${demo_dir}/xdp-marker.bpftcl"
+run_demo "${bpf_bin}" run "${demo_dir}/xdp-marker.bpftcl" --packet 7f000102
+run_demo "${bpf_bin}" run "${demo_dir}/xdp-marker.bpftcl" --packet 01020304
+
+run_demo "${bpf_bin}" run "${demo_dir}/map-counter.bpftcl" \
+    --packet 0000000000000000 --repeat 3
+
+run_demo "${bpf_bin}" check "${demo_dir}/priority-bundle.bpftcl"
+run_demo "${bpf_bin}" compile "${demo_dir}/priority-bundle.bpftcl" \
+    --emit asm --program 0
+
+demo_out="$(mktemp -d "${TMPDIR:-/tmp}/bpf-tcl-demo.XXXXXX")"
+elf_path="${demo_out}/xdp.o"
+run_demo "${bpf_bin}" compile "${demo_dir}/priority-bundle.bpftcl" \
+    --emit elf --program 0 -o "${elf_path}"
+
+if command -v readelf >/dev/null 2>&1; then
+    run_demo readelf -h -S -s "${elf_path}"
+else
+    printf '\nreadelf is not installed; ELF inspection skipped.\n'
+fi
+
+if command -v llvm-objdump >/dev/null 2>&1; then
+    run_demo llvm-objdump -d "${elf_path}"
+else
+    printf '\nllvm-objdump is not installed; disassembly inspection skipped.\n'
+fi
+
+printf '\nELF inspection artefact: %s\n' "${elf_path}"
+printf 'This object is structural output for inspection, not kernel-loadable.\n'

--- a/samples/bpf-tcl/run-kernel-xdp-demo.sh
+++ b/samples/bpf-tcl/run-kernel-xdp-demo.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -euo pipefail
+
+demo_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${demo_dir}/../.." && pwd)"
+cd "${repo_root}"
+
+if [ "$(uname -s)" != Linux ]; then
+    echo "run-kernel-xdp-demo.sh requires Linux" >&2
+    exit 1
+fi
+for tool in cargo bpftool readelf; do
+    if ! command -v "${tool}" >/dev/null 2>&1; then
+        echo "missing required tool: ${tool}" >&2
+        exit 1
+    fi
+done
+if ! mountpoint -q /sys/fs/bpf; then
+    echo "/sys/fs/bpf is not mounted; run: sudo mount -t bpf bpf /sys/fs/bpf" >&2
+    exit 1
+fi
+
+source scripts/dev/agent-build-env.sh
+cargo build -p bpf-tcl
+bpf_bin="${CARGO_TARGET_DIR}/debug/bpf-tcl"
+
+demo_tmp="$(mktemp -d "${TMPDIR:-/tmp}/bpf-tcl-kernel-demo.XXXXXX")"
+elf_path="${demo_tmp}/xdp-pass.o"
+packet_path="${demo_tmp}/packet.bin"
+packet_out_path="${demo_tmp}/packet-out.bin"
+run_log_path="${demo_tmp}/run.log"
+pin_path="/sys/fs/bpf/bpf-tcl-xdp-pass-$$"
+
+cleanup() {
+    if sudo test -e "${pin_path}"; then
+        sudo unlink "${pin_path}"
+    fi
+    if [ -e "${elf_path}" ]; then
+        unlink "${elf_path}"
+    fi
+    if [ -e "${packet_path}" ]; then
+        unlink "${packet_path}"
+    fi
+    if [ -e "${packet_out_path}" ]; then
+        unlink "${packet_out_path}"
+    fi
+    if [ -e "${run_log_path}" ]; then
+        unlink "${run_log_path}"
+    fi
+    rmdir "${demo_tmp}" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+if sudo test -e "${pin_path}"; then
+    echo "refusing to replace existing pin: ${pin_path}" >&2
+    exit 1
+fi
+
+"${bpf_bin}" compile "${demo_dir}/xdp-kernel-pass.bpftcl" \
+    --target kernel-xdp --emit elf --program 0 -o "${elf_path}"
+readelf -h -S -s "${elf_path}"
+
+dd if=/dev/zero of="${packet_path}" bs=64 count=1 status=none
+sudo bpftool -d prog load "${elf_path}" "${pin_path}" type xdp
+sudo bpftool prog run pinned "${pin_path}" data_in "${packet_path}" \
+    data_out "${packet_out_path}" repeat 1 | tee "${run_log_path}"
+if ! grep -Fq "Return value: 2" "${run_log_path}"; then
+    echo "expected BPF_PROG_TEST_RUN to return 2 (XDP_PASS)" >&2
+    exit 1
+fi
+
+echo "Verified return value: 2 (XDP_PASS)"
+echo "The program was verifier-loaded and test-run, but not attached to an interface."

--- a/samples/bpf-tcl/socket-length.bpftcl
+++ b/samples/bpf-tcl/socket-length.bpftcl
@@ -1,0 +1,9 @@
+# A socket-filter event returns an accepted byte count. Guard every packet
+# access explicitly; the userspace VM catches bad loads, but the future kernel
+# target must turn this into a verifier-visible data_end proof.
+when SOCKET_FILTER priority 100 {
+    setbuf packet ctx
+    pktlen length packet
+    if {$length < 4} { drop }
+    accept
+}

--- a/samples/bpf-tcl/xdp-kernel-pass.bpftcl
+++ b/samples/bpf-tcl/xdp-kernel-pass.bpftcl
@@ -1,0 +1,6 @@
+# The first Linux-kernel target slice: a map-free, verdict-only XDP program.
+# It does not read the context, so codegen can emit a verifier-valid program
+# before checked xdp_md packet access and kernel maps are implemented.
+when XDP {
+    pass
+}

--- a/samples/bpf-tcl/xdp-marker.bpftcl
+++ b/samples/bpf-tcl/xdp-marker.bpftcl
@@ -1,0 +1,17 @@
+# A profile names packet fields, a template supplies compile-time policy, and
+# the capability declaration limits the expanded handler to an 8-bit load.
+profile marker_packet {
+    field marker 0 8
+}
+
+template reject_marker {blocked} {
+    if {$value == $blocked} { drop }
+}
+
+allow load8
+
+when XDP priority 50 {
+    marker value
+    use reject_marker blocked=127
+    pass
+}


### PR DESCRIPTION
## Summary

- add an explicit `kernel-xdp` code-generation target alongside the existing `rbpf` simulator ABI
- verifier-load map-free, verdict-only XDP programs while rejecting context and map operations until proof-bearing lowering exists
- add Debian/Ubuntu setup, userspace demonstrations, a kernel verifier/test-run demonstration, and an architecture/design audit

## Why

The previous ELF writer produced structurally valid `EM_BPF` objects, but every emitted program used the `rbpf` FixedMbuff context prologue. Linux rejected that prologue as an invalid `xdp_md` context access. Separating target ABIs provides a working kernel vertical slice without silently emitting unsupported packet or map semantics.

## Impact

`bpf-tcl compile ... --target kernel-xdp --emit elf` now emits a map-free, verdict-only XDP object that can be loaded by the Linux verifier and exercised with `BPF_PROG_TEST_RUN`. The default target remains `rbpf`, preserving existing userspace behaviour. XDP verdicts are also rendered by name, and repeated simulator runs can display deterministic map state.

## Validation

- Linux 6.17 verifier accepted the generated five-instruction XDP program
- `BPF_PROG_TEST_RUN` returned `2` (`XDP_PASS`)
- `make prep-pr`
- `make check-rust`
- `make test-ext` (734 passing)
- `make test-emacs`
- `make runtime-rust-test` (331 passing)
- `make check-all`

Related to #1202, #1203, and #1204.