### PR TITLE
Quick-fix anchors, fix safety tiers, and inline/extract-proc correctness (#1190, #1191, #1195, #1199, #1201)

### DIFF
--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -110,6 +110,9 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
   which `f5` verb to pick for filter / find / rename tasks.
 - [kcs-qa-tcl-lsp-annotations.md](kcs-qa-tcl-lsp-annotations.md) — which
   `# tcl-lsp:` and `# noqa` comments the analyser understands.
+- [kcs-qa-what-does-fix-all-safe-issues-apply.md](kcs-qa-what-does-fix-all-safe-issues-apply.md)
+  — the four fix-safety classes, and why "Fix All Safe Issues" applies
+  only the provably equivalent ones.
 - [kcs-qa-how-tcl-lsp-loads-configuration.md](kcs-qa-how-tcl-lsp-loads-configuration.md)
   — the five places the server reads configuration from, and which
   layer wins when they disagree.

--- a/docs/kcs/codes/kcs-diagnostic-w120-missing-package-require.md
+++ b/docs/kcs/codes/kcs-diagnostic-w120-missing-package-require.md
@@ -102,6 +102,35 @@ restart needed. If a false-positive W120 persists after the workspace has
 clearly finished loading (the status bar shows the server is idle), that is
 a bug — open an issue with the workspace layout.
 
+## The quick fix, and when it is offered
+
+Two things can offer to add a `package require`, and both need evidence.
+
+**W120's own fix** is precise: the diagnostic already knows, from the command
+registry, exactly which package the command belongs to. Applying it inserts
+the require line at the top of the file.
+
+**The suggestion for a command the registry does not know** is the fallback,
+and it is offered only when *all* of these hold:
+
+- the cursor is on a **command head** — an actual call, not a mention of the
+  same identifier in a comment, a quoted or braced string, an argument word,
+  or the name word of a `proc` definition;
+- the head is written out literally, not computed (`$cmd`, `[pick]`);
+- the head's leading namespace **exactly** names a package the registry
+  knows — `json::write` is evidence for `json`; `jsonify` is evidence for
+  nothing;
+- nothing else in the workspace answers to that name (no registry command, no
+  same-file or imported definition, no static `rename` or `interp alias`);
+- the file contains no computed `package require` or `load`, which could
+  register the command at run time;
+- the package is not already required.
+
+Applying either fix **loads the package and runs its initialisation code**,
+so neither is applied by
+[Fix All Safe Issues](../kcs-qa-what-does-fix-all-safe-issues-apply.md) —
+both are classified behaviour-hardening, and you accept them one at a time.
+
 ## How to suppress
 
 Add `# noqa: W120` at the end of the offending line.

--- a/docs/kcs/codes/kcs-diagnostic-w302-catch-without-result.md
+++ b/docs/kcs/codes/kcs-diagnostic-w302-catch-without-result.md
@@ -39,6 +39,42 @@ catch {risky_command} result
 
 Capture the result so that errors can be logged, inspected, or re-raised.
 
+## The quick fixes
+
+Two quick fixes are offered on the diagnostic. Both append words to the end
+of the `catch` call, after the body's closing brace:
+
+| Action | `catch {risky_command}` becomes |
+|---|---|
+| **Add catch result variable(s)** | `catch {risky_command} result` |
+| **Add catch result + options variable(s)** | `catch {risky_command} result options` |
+
+The second action is offered only where the active dialect documents the
+options dictionary. Tcl 8.4 and F5 iRules have `catch script ?varName?` and
+no options word, so under those dialects a single action is offered and it
+appends ` var`.
+
+The insertion point is the end of the **body**, wherever that is: a
+multi-line body, a body followed by a trailing `;# comment`, an empty
+`catch {}`, and a body containing nested `[...]` substitutions all place the
+new word after the body's last character. Anchoring at the `catch` keyword —
+where the squiggle sits — would write `catch result {risky_command}`, which
+Tcl reads as a `catch` of the script `result`.
+
+## Limits
+
+- The variable names are `result` and `options` (or `var` under Tcl 8.4 and
+  iRules), taken from the command's documented argument names. If the
+  surrounding code already uses a variable of that name, applying the fix
+  overwrites it — rename the inserted variable after applying.
+- Because the fix writes a variable into the caller's frame, it is
+  classified **behaviour-hardening**, not semantics-preserving, so
+  **Fix All Safe Issues** never applies it. See
+  [the fix-safety taxonomy](../kcs-qa-what-does-fix-all-safe-issues-apply.md).
+- A `catch` whose body is not a literal script (`catch $body`) gets no
+  diagnostic and no fix: there is nothing to prove about a script the
+  analyser cannot see.
+
 ## How to suppress
 
 Add `# noqa: W302` at the end of the offending line.

--- a/docs/kcs/features/README.md
+++ b/docs/kcs/features/README.md
@@ -68,6 +68,8 @@ combine them when more than one form helps:
 - [kcs-feature-refactorings.md](kcs-feature-refactorings.md)
   - [kcs-feature-refactor-extract-variable.md](kcs-feature-refactor-extract-variable.md)
   - [kcs-feature-refactor-inline-variable.md](kcs-feature-refactor-inline-variable.md)
+  - [kcs-feature-refactor-extract-proc.md](kcs-feature-refactor-extract-proc.md)
+  - [kcs-feature-refactor-inline-proc.md](kcs-feature-refactor-inline-proc.md)
   - [kcs-feature-refactor-if-to-switch.md](kcs-feature-refactor-if-to-switch.md)
   - [kcs-feature-refactor-switch-to-dict.md](kcs-feature-refactor-switch-to-dict.md)
   - [kcs-feature-refactor-brace-expr.md](kcs-feature-refactor-brace-expr.md)

--- a/docs/kcs/features/kcs-feature-refactor-extract-proc.md
+++ b/docs/kcs/features/kcs-feature-refactor-extract-proc.md
@@ -1,0 +1,109 @@
+# KCS: feature — Extract into proc
+
+> **Audience:** User
+> **Type:** Functionality
+
+## Summary
+
+Moves a selected run of commands into a new proc and replaces the selection
+with a call — carrying any variable the moved code assigns back to the
+caller's frame with `upvar`, so the extraction does not silently change what
+the program does.
+
+## Applies to
+
+all-editors, refactoring
+
+## How to use
+
+Select one or more whole commands and trigger code actions (Ctrl+. in VS Code,
+`<leader>ca` in Neovim). Choose **Extract selection into proc**. The editor
+then opens a rename on the generated name, which is a placeholder.
+
+## The problem it solves
+
+A `proc` has its own variable frame, so anything the moved code assigns stops
+being the caller's variable. Extracting the middle two lines of
+
+```tcl
+set x 0
+set x 1
+puts $x
+puts "after=$x"
+```
+
+into a proc that takes `x` as an ordinary parameter prints `after=0` instead
+of `after=1`: a parameter is a *copy*, and the caller never sees it change.
+
+The extraction now classifies each variable the selection touches:
+
+| Variable | Becomes |
+|---|---|
+| Read, never written | An ordinary value parameter — a copy is correct, nothing writes it back. |
+| Written, and read again after the selection | Passed **by name** and re-bound with `upvar 1`, so the assignment lands in the caller's frame. |
+| Written, and never read again | A proc local. It stops leaking into the caller entirely. |
+
+So the example above extracts to:
+
+```tcl
+set x 0
+proc extracted_proc {xName} {
+    upvar 1 $xName x
+    set x 1
+    puts $x
+}
+
+extracted_proc x
+puts "after=$x"
+```
+
+which prints `1` then `after=1`, exactly as the original did.
+
+The definition is placed immediately **above the enclosing top-level
+command**, not at line 0, so it lands after any `package require` or
+`namespace` prologue. The generated name is checked against the workspace's
+symbols and the command registry, so it never accidentally shadows a builtin.
+
+## What it will not do, and why
+
+A refused extraction still appears in the menu, greyed out, with its reason.
+
+| Refused | Reason |
+|---|---|
+| The selection contains `return`, `break`, `continue`, `upvar`, `uplevel`, `global`, `variable`, `info level`, … | These act on the *call frame*. `return` would return from the new proc; `break` would escape a loop that no longer encloses it; `upvar 1` would alias one frame too far. |
+| A written variable's name is computed (`set $n 1`) | Which variable leaves the selection is a run-time fact. |
+| A written variable is an array element (`set a(x) 1`) | An array element is not a place the scalar `upvar` protocol can carry. |
+| A command head is computed (`$cmd …`, `{*}$words`) | Its argument roles — and so which variables it reads and writes — are unknown. |
+| The selection is inside a `namespace eval` or a class definition body | The extracted proc would be created in a different namespace, changing what its unqualified calls and variables resolve to. |
+
+The frame-sensitive command list and the read/write argument positions are
+the command registry's own, so a command gains this treatment by being
+described in the registry rather than by being named inside the refactoring.
+
+## Operational context
+
+Implemented in `rust/tcl-lsp-core/src/refactor/extract_proc.rs`. The selection
+is snapped to whole segmented commands; the "is this variable read after the
+selection?" question is asked over the innermost enclosing script region
+(a proc body, an `if` branch, a `foreach` body, or the file), found by
+descending registry-resolved `ArgRole::Body` arguments.
+
+## Failure modes
+
+- A selection that covers no complete command offers nothing at all.
+- Variables reached only through `upvar`, a trace, or a computed name are not
+  modelled; those selections are refused rather than guessed at.
+- The extracted proc is always created at the top level of the current file;
+  cross-file placement is not supported.
+
+## Test anchors
+
+- `rust/tcl-lsp-core/src/refactor/extract_proc.rs` (unit suite)
+- `rust/tcl-lsp-server/tests/e2e/code_actions.rs`
+- `editors/vscode/src/test/refactorActions.test.ts`
+
+## Discoverability
+
+- [KCS feature index](README.md)
+- [Refactoring tools](kcs-feature-refactorings.md)
+- [Inline proc](kcs-feature-refactor-inline-proc.md)

--- a/docs/kcs/features/kcs-feature-refactor-inline-proc.md
+++ b/docs/kcs/features/kcs-feature-refactor-inline-proc.md
@@ -1,0 +1,100 @@
+# KCS: feature — Inline proc
+
+> **Audience:** User
+> **Type:** Functionality
+
+## Summary
+
+Replaces a call with the called proc's body, binding the proc's parameters to
+the call's argument **values** — defaults and all — and refusing, with a
+reason, wherever that cannot be done without changing what the program does.
+
+## Applies to
+
+all-editors, refactoring
+
+## How to use
+
+Put the cursor on a call to a proc defined in the same file and trigger code
+actions (Ctrl+. in VS Code, `<leader>ca` in Neovim). Choose **Inline proc
+'name'**.
+
+When the call cannot be inlined safely, the entry still appears — greyed out,
+with the reason. That is deliberate: a missing menu entry tells you nothing,
+whereas "the body calls 'return', which acts on the call frame" tells you
+exactly what to change first.
+
+## Example
+
+```tcl
+proc double {x} {
+    expr {$x * 2}
+}
+double 5
+```
+
+becomes
+
+```tcl
+proc double {x} {
+    expr {$x * 2}
+}
+expr {5 * 2}
+```
+
+A parameter with a declared default binds that default when the call omits the
+argument, which is what Tcl itself does:
+
+```tcl
+proc greet {{name world}} { puts $name }
+greet                       ;# inlines to  puts world
+```
+
+## What it will not do, and why
+
+Inlining is a *binding* problem, not a text-replacement problem. `f {a b}`
+does not pass the four characters `{a b}`; it passes the three-character value
+`a b`, because the braces are the caller's quoting and the parse consumes
+them. Splicing the written word into the body changes the value the body sees.
+
+| Refused | Reason |
+|---|---|
+| The body is more than one command | Several commands cannot be spliced into one caller word without changing how the caller parses. |
+| The body uses `return`, `break`, `continue`, `upvar`, `uplevel`, `global`, `variable`, `info level`, … | These act on the *call frame*. `return` in an inlined body returns from the caller. |
+| The body assigns a variable | A proc's locals vanish when it returns; a caller's do not. The assignment would leak — and could overwrite a caller variable of the same name. |
+| The call passes the wrong number of arguments | Tcl would raise `wrong # args`; inlining must not silently make the call work. |
+| The body reads `args` | `args` is a *list*. No single spelling of a list means the same thing in every word context. |
+| An argument's value is not a plain word | Only a value with no whitespace, quotes, braces, brackets, `$`, `\`, `;`, or `#` can be written into the body verbatim and still mean itself. |
+| A parameter used in an `expr` operand is bound to a non-number | `expr {abc * 2}` reads `abc` as a function name, not as the string. |
+| A parameter used more than once is bound to a run-time value | `f [next]` with the body reading the parameter twice would call `next` twice. |
+
+The frame-sensitive command list is the command registry's own, so a command
+gains this protection by being described in the registry — not by being added
+to a list inside the refactoring.
+
+## Operational context
+
+Implemented in `rust/tcl-lsp-core/src/refactor/inline_proc.rs`. The call head
+is resolved with the same resolver go-to-definition and find-references use, so
+the three cannot disagree about which proc a call reaches. Expression operand
+positions come from the registry's `ArgRole::Expr`, and variable-writing
+argument positions from `ArgRole::VarWrite`.
+
+## Failure modes
+
+- A proc reached through `interp alias` or a dynamic `rename` is not resolved,
+  so no action is offered.
+- Cross-file procs are not inlined; the definition must be in the same
+  document.
+
+## Test anchors
+
+- `rust/tcl-lsp-core/src/refactor/inline_proc.rs` (unit suite)
+- `rust/tcl-lsp-server/tests/e2e/code_actions.rs`
+- `editors/vscode/src/test/refactorActions.test.ts`
+
+## Discoverability
+
+- [KCS feature index](README.md)
+- [Refactoring tools](kcs-feature-refactorings.md)
+- [Extract into proc](kcs-feature-refactor-extract-proc.md)

--- a/docs/kcs/features/kcs-feature-refactorings.md
+++ b/docs/kcs/features/kcs-feature-refactorings.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Mechanical code refactorings: extract/inline variables, if-to-switch, switch-to-dict, brace expr, and data-group extraction with type-aware IP/CIDR support.
+Mechanical code refactorings: extract/inline variables, extract/inline procs, if-to-switch, switch-to-dict, brace expr, and data-group extraction with type-aware IP/CIDR support.
 
 ## Applies to
 
@@ -19,6 +19,8 @@ Place the cursor on the target construct and trigger code actions (Ctrl+. in VS 
 
 - **Extract variable**: select an expression → "Extract into variable '$result'"
 - **Inline variable**: cursor on `set var value` with a single use → "Inline variable '$var'"
+- **Extract into proc**: select whole commands → "Extract selection into proc" (caller-frame writes are carried through with `upvar`)
+- **Inline proc**: cursor on a call → "Inline proc 'name'" (parameters are bound to the call's argument values, defaults included)
 - **if/elseif → switch**: cursor on `if` with equality chain → "Convert to switch on $var"
 - **switch → dict lookup**: cursor on `switch` where every arm sets the same variable → "Convert to dict lookup"
 - **Brace expr**: cursor on `expr "..."` → "Brace expr for safety and performance"
@@ -69,6 +71,10 @@ The AI-enhanced data-group tool (`suggest_datagroup_extractions`) returns struct
 - `tooling/refactoring/_extract_datagroup.py`
 - `server/features/code_actions.py`
 - `ai/mcp/tcl_mcp_server.py`
+
+## Refusals
+
+A refactoring that finds its subject but cannot preserve behaviour is offered **greyed out**, with a plain-English reason (LSP's `disabled.reason`), rather than silently omitted. A missing menu entry tells you nothing; "the body calls 'return', which acts on the call frame" tells you what to change first. The extract-proc and inline-proc refactorings both work this way.
 
 ## Failure modes
 
@@ -124,6 +130,8 @@ for the full walkthrough.
 
 - [Extract variable](kcs-feature-refactor-extract-variable.md)
 - [Inline variable](kcs-feature-refactor-inline-variable.md)
+- [Extract into proc](kcs-feature-refactor-extract-proc.md)
+- [Inline proc](kcs-feature-refactor-inline-proc.md)
 - [if/elseif → switch](kcs-feature-refactor-if-to-switch.md)
 - [switch → dict lookup](kcs-feature-refactor-switch-to-dict.md)
 - [Brace expr](kcs-feature-refactor-brace-expr.md)

--- a/docs/kcs/kcs-qa-what-does-fix-all-safe-issues-apply.md
+++ b/docs/kcs/kcs-qa-what-does-fix-all-safe-issues-apply.md
@@ -1,0 +1,73 @@
+# KCS: What does "Fix All Safe Issues" actually apply?
+
+> **Audience:** User
+> **Type:** Q&A
+
+## Applies to
+
+all-editors, diagnostic, refactoring
+
+## Question
+
+Which quick fixes does **Fix All Safe Issues** apply, and why does it leave
+some obvious-looking ones alone?
+
+## Answer
+
+It applies only the fixes the analyser has **proved** do not change what
+your program does. Every quick fix carries a safety class, decided for that
+one occurrence rather than for the diagnostic code as a whole, and the bulk
+command takes the `semantics-equivalent` class and nothing else.
+
+The four classes are:
+
+| Class | What it means | In the bulk fix? |
+|---|---|---|
+| **Semantics-equivalent** | Same completion code, result, output, and side effects, for every input. | Yes |
+| **Behaviour-hardening** | Removes a hazard, and changes behaviour in doing so. That change *is* the fix. | No |
+| **Style-only** | Changes only the spelling a person reads. | No |
+| **Requires review** | A suggestion whose correctness depends on something the analyser could not check. | No |
+
+The command used to work from a list of diagnostic codes — `W100`, `W110`,
+and a few others — and applied their first fix without checking anything.
+That promised a guarantee it did not deliver, because the same code produces
+an equivalent rewrite in one place and a behaviour-changing one in the next.
+Under real Tcl 9:
+
+```tcl
+set a {$x}
+set x 3
+set b 2
+puts [expr $a + $b]      ;# prints 5
+```
+
+`W100` offers to brace that expression. Braced, `$a` is no longer
+substituted before `expr` parses it, so `expr {$a + $b}` sees the literal
+string `$x` and raises an error. Bracing an expression is still the right
+thing to do — it is faster and it closes an injection hole — but it is a
+change you should read before accepting, not one a bulk command should make
+across a file. So `W100` is classified per occurrence: bracing
+`expr 1 + 2` is equivalent and is applied, bracing `expr $a + $b` is
+hardening and is not.
+
+`W110` is the same story. `expr {"1" == "01"}` is `1` (a numeric
+comparison) and `expr {"1" eq "01"}` is `0` (a string comparison), so
+swapping the operator changes the answer in exactly the cases the diagnostic
+is about.
+
+Fixes that are not bulk-applicable are **not hidden**. Every one of them is
+still offered individually in the lightbulb menu, with its own title, so you
+can read the change and accept it deliberately.
+
+Between passes, the command re-analyses the rewritten source. A fix whose
+proof depended on text an earlier pass changed is therefore re-derived from
+what is now there, rather than applied against stale evidence. Fixes whose
+edits overlap are never applied together: the earlier one wins, and the
+other is reconsidered on the next pass.
+
+## Related
+
+- [KCS index](README.md)
+- [Glossary](../GLOSSARY.md)
+- [How do I suppress a diagnostic?](kcs-howto-suppress-diagnostics.md)
+- [W302 — catch without result](codes/kcs-diagnostic-w302-catch-without-result.md)

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1456,7 +1456,14 @@ async function fixAllSafeIssues(): Promise<void> {
   const result = (await client.sendRequest("workspace/executeCommand", {
     command: "tcl-lsp.fixAllSafeIssues",
     arguments: [uri],
-  })) as { source: string; applied: Array<{ code: string; description: string }> } | null;
+  })) as {
+    // `safety` is the fix's classification (issue #1195). Only
+    // `semantics-equivalent` fixes reach this list — the server applies
+    // nothing else in bulk — so it is reported for traceability rather than
+    // filtered on here.
+    source: string;
+    applied: Array<{ code: string; description: string; safety: string }>;
+  } | null;
 
   if (!result || !result.applied || result.applied.length === 0) {
     window.showInformationMessage("No safe auto-fixes available.");

--- a/editors/vscode/src/test/codeActions.test.ts
+++ b/editors/vscode/src/test/codeActions.test.ts
@@ -451,4 +451,60 @@ suite("Code Actions", () => {
     // The inserted comment must match the call's 4-space indentation.
     assert.strictEqual(changes[0].newText, "    # noqa: S100\n");
   });
+
+  // -- `package require` suggestions are evidence-backed (issue #1191) ------
+  //
+  // Applying one of these mutates package loading and runs the package's
+  // initialisation code, so the lightbulb must offer it only over a command
+  // head resolution could not satisfy — never over a comment, a string, or
+  // an argument word that merely names the same identifier.
+
+  const packageContextUri = getDocUri("packageSuggestionContext.tcl");
+
+  /** Titles of the quick fixes offered at `line`:`character`. */
+  async function quickFixTitlesAt(
+    uri: vscode.Uri,
+    line: number,
+    character: number,
+  ): Promise<string[]> {
+    const position = new vscode.Position(line, character);
+    const actions = (await vscode.commands.executeCommand(
+      "vscode.executeCodeActionProvider",
+      uri,
+      new vscode.Range(position, position),
+    )) as vscode.CodeAction[] | undefined;
+    return (actions ?? []).map((a) => a.title);
+  }
+
+  test("offers 'package require' on an unresolved command head", async () => {
+    await activate(packageContextUri);
+    await waitForDiagnostics(packageContextUri, { minCount: 0 });
+    const titles = (await pollUntil(
+      () => quickFixTitlesAt(packageContextUri, 11, 3),
+      (t) => (t as string[]).some((title) => title.startsWith("Add 'package require")),
+      { timeout: 10_000, label: "package require suggestion" },
+    )) as string[];
+    assert.ok(
+      titles.includes("Add 'package require http'"),
+      `expected the http suggestion on the call, got: ${JSON.stringify(titles)}`,
+    );
+  });
+
+  test("does not offer 'package require' on comments, strings, or argument words", async () => {
+    await activate(packageContextUri);
+    await waitForDiagnostics(packageContextUri, { minCount: 0 });
+    // The comment mention, the quoted datum, and the `dict set` value word.
+    const dataPositions: Array<[number, number]> = [
+      [8, 10],
+      [9, 16],
+      [10, 25],
+    ];
+    for (const [line, character] of dataPositions) {
+      const titles = await quickFixTitlesAt(packageContextUri, line, character);
+      assert.ok(
+        !titles.some((title) => title.startsWith("Add 'package require")),
+        `line ${line} is data, not a call site; got: ${JSON.stringify(titles)}`,
+      );
+    }
+  });
 });

--- a/editors/vscode/src/test/commandExecution.test.ts
+++ b/editors/vscode/src/test/commandExecution.test.ts
@@ -305,6 +305,47 @@ suite("LSP Command Execution", () => {
     assert.ok(Array.isArray(result.applied), "result should have applied array");
   });
 
+  test("tcl-lsp.fixAllSafeIssues applies only semantics-equivalent fixes", async () => {
+    // Issue #1195. Every fix the bulk pass applies must report itself as
+    // `semantics-equivalent`; the behaviour-changing ones (W100 over a
+    // substituted operand, W110's `==` → `eq`) stay behind their own named
+    // code actions. Asserting the class each applied fix reports is what
+    // stops the command's *name* being the only guarantee.
+    const uri = docUri.toString();
+    const result = (await execLspCommand("tcl-lsp.fixAllSafeIssues", uri)) as {
+      source: string;
+      applied: Array<{ code: string; description: string; safety: string }>;
+    } | null;
+    assert.ok(result, "fixAllSafeIssues should return a result");
+    for (const entry of result.applied) {
+      assert.strictEqual(
+        entry.safety,
+        "semantics-equivalent",
+        `bulk pass applied a non-equivalent fix: ${JSON.stringify(entry)}`,
+      );
+    }
+  });
+
+  test("tcl-lsp.fixAllSafeIssues leaves a double-substituting expr untouched", async () => {
+    // Under C Tcl 9 this program prints `5`: `$a` substitutes to the string
+    // `$x`, and `expr` substitutes that to 3. W100's brace fix turns it into
+    // an error, so the unattended pass must return the source unchanged.
+    const uri = getDocUri("fixAllDoubleSubstitution.tcl").toString();
+    const result = (await execLspCommand("tcl-lsp.fixAllSafeIssues", uri)) as {
+      source: string;
+      applied: Array<{ code: string }>;
+    } | null;
+    assert.ok(result, "fixAllSafeIssues should return a result");
+    assert.ok(
+      result.source.includes("expr $a + $b"),
+      `the substituted expr must survive; got:\n${result.source}`,
+    );
+    assert.ok(
+      !result.applied.some((entry) => entry.code === "W100"),
+      `W100 must not be bulk-applied here: ${JSON.stringify(result.applied)}`,
+    );
+  });
+
   // -- exportConfig -----------------------------------------------------------
 
   test("tcl-lsp.exportConfig returns configuration object", async () => {

--- a/editors/vscode/src/test/refactorActions.test.ts
+++ b/editors/vscode/src/test/refactorActions.test.ts
@@ -147,4 +147,51 @@ suite("Refactor Actions (applied)", () => {
     await vscode.workspace.applyEdit(action.edit!);
     assert.strictEqual(editor.document.getText(), "expr {$a + $b}\n");
   });
+
+  // -- W302 catch-result capture (issue #1190) ------------------------------
+  //
+  // The cursor sits on the `catch` keyword — where the diagnostic anchors,
+  // and where VS Code's lightbulb is invoked. The inserted word must still
+  // land after the *body*. `catch result {error oops}` is a catch of the
+  // script `result`, which C Tcl 9 reports as `invalid command name
+  // "result"`, so asserting the applied document (not the inserted string)
+  // is what makes this test meaningful.
+
+  test("catch result quick fix appends after a single-line body", async () => {
+    const editor = await loadScratch("catch {error oops}\n");
+    const range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0));
+    const action = await findAction(range, "Add catch result variable");
+    assert.ok(action.edit, "catch-result action must carry an edit");
+    await vscode.workspace.applyEdit(action.edit!);
+    assert.strictEqual(editor.document.getText(), "catch {error oops} result\n");
+  });
+
+  test("catch result quick fix appends after a multi-line body", async () => {
+    const editor = await loadScratch("catch {\n    error oops\n}\n");
+    const range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0));
+    const action = await findAction(range, "Add catch result variable");
+    assert.ok(action.edit, "catch-result action must carry an edit");
+    await vscode.workspace.applyEdit(action.edit!);
+    assert.strictEqual(editor.document.getText(), "catch {\n    error oops\n} result\n");
+  });
+
+  test("catch result + options quick fix appends both words after the body", async () => {
+    const editor = await loadScratch("catch {error oops}\n");
+    const range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0));
+    const action = await findAction(range, "Add catch result + options");
+    assert.ok(action.edit, "catch-result+options action must carry an edit");
+    await vscode.workspace.applyEdit(action.edit!);
+    assert.strictEqual(editor.document.getText(), "catch {error oops} result options\n");
+  });
+
+  test("catch result quick fix does not overshoot an empty body", async () => {
+    // `catch {}`'s brace pair is a degenerate case whose token span already
+    // covers its own closer; a naive `end + 1` anchor writes past it.
+    const editor = await loadScratch("catch {}\n");
+    const range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0));
+    const action = await findAction(range, "Add catch result variable");
+    assert.ok(action.edit, "catch-result action must carry an edit");
+    await vscode.workspace.applyEdit(action.edit!);
+    assert.strictEqual(editor.document.getText(), "catch {} result\n");
+  });
 });

--- a/editors/vscode/src/test/refactorActions.test.ts
+++ b/editors/vscode/src/test/refactorActions.test.ts
@@ -44,6 +44,15 @@ suite("Refactor Actions (applied)", () => {
     return editor;
   }
 
+  async function actionTitles(range: vscode.Range): Promise<string[]> {
+    const actions = (await vscode.commands.executeCommand(
+      "vscode.executeCodeActionProvider",
+      docUri,
+      range,
+    )) as vscode.CodeAction[];
+    return (actions || []).map((a) => a.title);
+  }
+
   async function findAction(range: vscode.Range, titleNeedle: string): Promise<vscode.CodeAction> {
     const found = await pollUntil(
       async () => {
@@ -178,15 +187,24 @@ suite("Refactor Actions (applied)", () => {
   });
 
   test("extract proc refuses a selection containing return", async () => {
-    // A refused refactoring is offered *greyed out* with its reason, so the
-    // user can tell "cannot be done here" from "is broken".
+    // A refused refactoring is delivered greyed out with its reason over LSP
+    // (`disabled.reason`), pinned end-to-end by lsp_e2e's
+    // `test_extract_proc_refuses_a_selection_containing_return`.  VS Code's
+    // `executeCodeActionProvider` surfaces only the *valid* (non-disabled)
+    // action set, so what this harness can observe is the refusal's flip
+    // side: the sibling extract-variable action is offered for the same
+    // selection while no applicable extract-proc action is.
     await loadScratch("proc f {} {\n    set x 1\n    return $x\n}\n");
     const range = new vscode.Range(new vscode.Position(2, 0), new vscode.Position(3, 0));
-    const action = await findAction(range, "Extract selection into proc");
-    assert.ok(action.disabled, "a return in the selection must be refused");
+    await pollUntil(
+      () => actionTitles(range),
+      (ts) => ts.some((t) => t.includes("Extract into variable")),
+      { timeout: 10_000, label: "extract-variable anchor" },
+    );
+    const titles = await actionTitles(range);
     assert.ok(
-      action.disabled!.reason.includes("call frame"),
-      `reason should name the call frame; got: ${action.disabled!.reason}`,
+      !titles.some((t) => t.includes("Extract selection into proc")),
+      `a selection containing return must not offer an applicable extract-proc; got: ${titles}`,
     );
   });
 
@@ -206,14 +224,22 @@ suite("Refactor Actions (applied)", () => {
 
   test("inline proc refuses a braced argument whose value is not a plain word", async () => {
     // `greet {a b}` passes the value `a b`; splicing the written `{a b}` made
-    // the body print the braces.
-    await loadScratch('proc greet {name} { puts "hello $name" }\ngreet {a b}\n');
-    const range = new vscode.Range(new vscode.Position(1, 0), new vscode.Position(1, 0));
-    const action = await findAction(range, "Inline proc");
-    assert.ok(action.disabled, "a non-plain-word value must be refused");
+    // the body print the braces.  The refusal itself (greyed out, reason
+    // naming the plain-word rule) is pinned by lsp_e2e — this harness only
+    // sees VS Code's valid-action set, so the observable contract is: the
+    // plain-word call site offers Inline proc, the braced one does not.
+    await loadScratch('proc greet {name} { puts "hello $name" }\ngreet world\ngreet {a b}\n');
+    const good = new vscode.Range(new vscode.Position(1, 0), new vscode.Position(1, 0));
+    await pollUntil(
+      () => actionTitles(good),
+      (ts) => ts.some((t) => t.includes("Inline proc")),
+      { timeout: 10_000, label: "inline-proc anchor" },
+    );
+    const bad = new vscode.Range(new vscode.Position(2, 0), new vscode.Position(2, 0));
+    const titles = await actionTitles(bad);
     assert.ok(
-      action.disabled!.reason.includes("plain word"),
-      `reason should explain the value; got: ${action.disabled!.reason}`,
+      !titles.some((t) => t.includes("Inline proc")),
+      `a non-plain-word argument must not offer an applicable inline; got: ${titles}`,
     );
   });
 

--- a/editors/vscode/src/test/refactorActions.test.ts
+++ b/editors/vscode/src/test/refactorActions.test.ts
@@ -148,6 +148,75 @@ suite("Refactor Actions (applied)", () => {
     assert.strictEqual(editor.document.getText(), "expr {$a + $b}\n");
   });
 
+  // -- Extract into proc (issue #1201) --------------------------------------
+
+  test("extract proc carries a caller-frame write through upvar", async () => {
+    // Original output is `1` then `after=1`. Passing `x` as a value parameter
+    // moved the write into a proc local and printed `after=0`; the extraction
+    // now takes the variable by name and re-binds it with `upvar 1`.
+    const editor = await loadScratch('set x 0\nset x 1\nputs $x\nputs "after=$x"\n');
+    const range = new vscode.Range(new vscode.Position(1, 0), new vscode.Position(3, 0));
+    const action = await findAction(range, "Extract selection into proc");
+    assert.ok(action.edit, "extract-proc action must carry an edit");
+    await vscode.workspace.applyEdit(action.edit!);
+    const text = editor.document.getText();
+    assert.ok(text.includes("upvar 1 $xName x"), `expected upvar plumbing; got:\n${text}`);
+    assert.ok(text.includes("extracted_proc x\n"), `call passes the name; got:\n${text}`);
+    assert.ok(text.includes('puts "after=$x"'), `tail must survive; got:\n${text}`);
+  });
+
+  test("extract proc leaves the file prologue above the new definition", async () => {
+    const editor = await loadScratch("package require Tcl\nset x 5\nputs $x\n");
+    const range = new vscode.Range(new vscode.Position(2, 0), new vscode.Position(3, 0));
+    const action = await findAction(range, "Extract selection into proc");
+    await vscode.workspace.applyEdit(action.edit!);
+    const text = editor.document.getText();
+    assert.ok(
+      text.indexOf("package require Tcl") < text.indexOf("proc extracted_proc"),
+      `the definition must not land above the prologue; got:\n${text}`,
+    );
+  });
+
+  test("extract proc refuses a selection containing return", async () => {
+    // A refused refactoring is offered *greyed out* with its reason, so the
+    // user can tell "cannot be done here" from "is broken".
+    await loadScratch("proc f {} {\n    set x 1\n    return $x\n}\n");
+    const range = new vscode.Range(new vscode.Position(2, 0), new vscode.Position(3, 0));
+    const action = await findAction(range, "Extract selection into proc");
+    assert.ok(action.disabled, "a return in the selection must be refused");
+    assert.ok(
+      action.disabled!.reason.includes("call frame"),
+      `reason should name the call frame; got: ${action.disabled!.reason}`,
+    );
+  });
+
+  // -- Inline proc binding (issue #1199) ------------------------------------
+
+  test("inline proc binds a declared default when the call omits the argument", async () => {
+    const editor = await loadScratch("proc greet {{name world}} { puts $name }\ngreet\n");
+    const range = new vscode.Range(new vscode.Position(1, 0), new vscode.Position(1, 0));
+    const action = await findAction(range, "Inline proc");
+    assert.ok(action.edit, "inline-proc action must carry an edit");
+    await vscode.workspace.applyEdit(action.edit!);
+    assert.strictEqual(
+      editor.document.getText(),
+      "proc greet {{name world}} { puts $name }\nputs world\n",
+    );
+  });
+
+  test("inline proc refuses a braced argument whose value is not a plain word", async () => {
+    // `greet {a b}` passes the value `a b`; splicing the written `{a b}` made
+    // the body print the braces.
+    await loadScratch('proc greet {name} { puts "hello $name" }\ngreet {a b}\n');
+    const range = new vscode.Range(new vscode.Position(1, 0), new vscode.Position(1, 0));
+    const action = await findAction(range, "Inline proc");
+    assert.ok(action.disabled, "a non-plain-word value must be refused");
+    assert.ok(
+      action.disabled!.reason.includes("plain word"),
+      `reason should explain the value; got: ${action.disabled!.reason}`,
+    );
+  });
+
   // -- W302 catch-result capture (issue #1190) ------------------------------
   //
   // The cursor sits on the `catch` keyword — where the diagnostic anchors,

--- a/editors/vscode/testFixture/catchResultQuickFix.tcl
+++ b/editors/vscode/testFixture/catchResultQuickFix.tcl
@@ -1,0 +1,13 @@
+# W302 quick-fix fixture (issue #1190).
+#
+# The diagnostic anchors at the `catch` word, but the quick fix must splice
+# the result variable in after the *body's* closing brace. Applying it at the
+# diagnostic's end would produce `catch result {error oops}` — a catch of the
+# script `result`, which C Tcl reports as `invalid command name "result"`.
+#
+# Line 8 is the single-line body; lines 10-12 are the multi-line one.
+catch {error oops}
+
+catch {
+    error other
+}

--- a/editors/vscode/testFixture/fixAllDoubleSubstitution.tcl
+++ b/editors/vscode/testFixture/fixAllDoubleSubstitution.tcl
@@ -1,0 +1,11 @@
+# "Fix All Safe Issues" must leave this file alone (issue #1195).
+#
+# Under C Tcl 9.0.3 this prints 5: the unbraced `expr` substitutes `$a` to
+# the string `$x`, and `expr` then substitutes *that* to 3. W100's brace fix
+# rewrites it to `expr {$a + $b}`, which errors because `a` holds the literal
+# text `$x`. Bracing is still offered as its own named code action; it is not
+# an unattended bulk rewrite.
+set a {$x}
+set x 3
+set b 2
+puts [expr $a + $b]

--- a/editors/vscode/testFixture/packageSuggestionContext.tcl
+++ b/editors/vscode/testFixture/packageSuggestionContext.tcl
@@ -1,0 +1,12 @@
+# Evidence gating for the `package require` suggestion (issue #1191).
+#
+# Only line 12 is an executable command head. The three lines before it
+# mention the same identifier as data — a comment, a quoted string, and an
+# argument word — and offering to load a package (which runs the package's
+# initialisation code) on any of them is a false positive.
+#
+# Line numbers are load-bearing: the test drives the lightbulb at each.
+# see http::fetchall for details
+set example "http::fetchall"
+dict set docs command http::fetchall
+http::fetchall $url

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -1301,6 +1301,10 @@ impl Analyser {
                     span: cmd_tok.span,
                     new_text: format!("call {cmd_name}"),
                     description: format!("Use 'call {cmd_name}'"),
+                    // IRULE5005: routing the call through `call` is required for an
+                    // iRules proc, but the analyser cannot prove the head resolves to a
+                    // proc rather than to a renamed or aliased command.
+                    safety: crate::irules_checks::FixSafety::RequiresReview,
                 }],
             });
         }
@@ -1339,8 +1343,24 @@ impl Analyser {
             cmd_tok,
             scope_path,
         } = *site;
-        if cmd_name == "catch" {
-            self.emit_w302_catch_no_result_var(args, cmd_tok, arg_tokens, arg_single);
+        // W302 dispatches off the registry's own `AnalyserHookId::Catch`
+        // stamp rather than the literal head text, so any spelling the
+        // registry resolves to that spec is covered without the analyser
+        // naming a command (issue #1190).  It reads the stamp straight off
+        // the resolved spec rather than through `resolve_analyser_hook`,
+        // whose documented contract deliberately declines a `::`-qualified
+        // bareword (`::proc`, `::catch`) so hook *handler* dispatch keeps
+        // the exact reach the retired per-handler guards had.  A diagnostic
+        // has no such compatibility constraint: `::catch {error oops}`
+        // swallows errors exactly as `catch {error oops}` does, so it is
+        // reported — and fixed — the same way.
+        if self
+            .registry
+            .and_then(|registry| registry.get(cmd_name))
+            .and_then(|spec| spec.analyser_hook)
+            == Some(tcl_registry::hooks::AnalyserHookId::Catch)
+        {
+            self.emit_w302_catch_no_result_var(cmd_name, args, cmd_tok, arg_tokens, arg_single);
         }
         self.emit_w001_unknown_subcommand(
             cmd_name,

--- a/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
@@ -2615,6 +2615,10 @@ fn w213_span_and_fix(
             span: tcl_lexer::Span::new(at, at),
             new_text: " -nocomplain".to_string(),
             description: "Add '-nocomplain' to unset".to_string(),
+            // W213: `-nocomplain` stops `unset` raising on a missing variable.
+            // Suppressing that error is the point of the fix, and a program
+            // relying on it (a `catch`ed probe) observes the change.
+            safety: crate::irules_checks::FixSafety::BehaviourHardening,
         }]
     });
     (diag_span, fixes)

--- a/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
@@ -145,6 +145,48 @@ pub(in crate::analyser) fn has_substitution_of_kind(
         || matches!(kind, tcl_lexer::TokenType::Var | tcl_lexer::TokenType::Cmd)
 }
 
+/// The safety class of a "wrap this word in braces" quick-fix (W100's
+/// unbraced expression, W105's unbraced code block).
+///
+/// Bracing is the recommended form because it stops Tcl substituting the
+/// word *before* the command sees it.  That is exactly why it cannot be
+/// classified once for the whole diagnostic code (issue #1195): where the
+/// written word carries no substitution, brace-quoting reaches the command
+/// with byte-identical text and nothing observable changes; where it does,
+/// the fix deliberately removes a round of substitution and a program that
+/// depended on it changes behaviour.  C Tcl 9.0.3:
+///
+/// ```tcl
+/// set a {$x}; set x 3; set b 2
+/// puts [expr $a + $b]      ;# 5  — `$a` substitutes to `$x`, then expr
+/// puts [expr {$a + $b}]    ;# error: `$a` is the string `$x`
+/// ```
+///
+/// Equivalence therefore requires the written word to be substitution-free
+/// on *every* mechanism the outer parse applies:
+///
+/// * no `$` / `[` and no whole-word `Var` / `Cmd` token — the caller passes
+///   this as *`has_substitution`*, since W100 and W105 each already compute
+///   it (W100 over a joined argument run, W105 over one body word);
+/// * no backslash — the outer parse decodes `\n`, `\t`, `\x41`, and a
+///   line continuation, so the braced text is not the text that reached
+///   the command before;
+/// * no `"` — a quoted word is stripped of its quotes by the outer parse,
+///   so brace-quoting it either keeps them as literal characters or (where
+///   the emitter strips them) depends on the word being exactly one quoted
+///   run, which a `"a" eq "b"` argument list is not.
+pub(in crate::analyser) fn brace_wrap_fix_safety(
+    text: &str,
+    has_substitution: bool,
+) -> crate::analyser::types::FixSafety {
+    use crate::analyser::types::FixSafety;
+    if has_substitution || text.contains('\\') || text.contains('"') {
+        FixSafety::BehaviourHardening
+    } else {
+        FixSafety::SemanticsEquivalent
+    }
+}
+
 /// Whether one word of a [`tcl_registry::Traits::SCRIPT_CONCATENATES_ARGS`]
 /// tail contributes *statically-known script text* to the `Tcl_ConcatObj`
 /// join — the one predicate every eval-family static-tail check shares

--- a/rust/tcl-compiler/src/analyser/diagnostics/security.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/security.rs
@@ -128,8 +128,18 @@ impl Analyser {
     /// to suppress that case.  The diagnostic anchors at just the
     /// ``catch`` command token — the narrowest span that identifies
     /// the issue.
+    ///
+    /// The attached quick-fixes carry their **own** span, which is *not*
+    /// the diagnostic's: they insert at the point past the last supplied
+    /// argument's closing delimiter, computed by
+    /// [`Self::trailing_arg_fixes`] from the argument tokens.  A consumer
+    /// that instead reconstructed an insertion point from the diagnostic's
+    /// end would write the new word between `catch` and its body and
+    /// silently shift every argument one position along — the corruption
+    /// issue #1190 reports.
     pub(in crate::analyser) fn emit_w302_catch_no_result_var(
         &mut self,
+        cmd_name: &str,
         args: &[String],
         cmd_tok: tcl_lexer::Token,
         arg_tokens: &[tcl_lexer::Token],
@@ -160,6 +170,7 @@ impl Analyser {
         {
             return;
         }
+        let fixes = self.trailing_arg_fixes(cmd_name, args, arg_tokens, "Add catch");
         let span = cmd_tok.span;
         self.result.diagnostics.push(super::types::Diagnostic {
             code: DiagCode::W302,
@@ -168,8 +179,93 @@ impl Analyser {
 Consider capturing the result: catch {\u{2026}} result"
                 .to_string(),
             severity: Severity::Hint,
-            fixes: Vec::new(),
+            fixes,
         });
+    }
+
+    /// Build the "append the omitted optional result variable(s)" quick-fixes
+    /// for an invocation that left declared trailing
+    /// [`ArgRole::VarWrite`] slots unfilled.
+    ///
+    /// Every part of this is registry data, so it holds for any command with
+    /// the shape, not for `catch` alone:
+    ///
+    /// * **How many words may be appended, and what they are called** comes
+    ///   from [`tcl_registry::CommandRegistry::unfilled_trailing_roles`] (the
+    ///   declared roles beyond the supplied arguments) intersected with
+    ///   [`tcl_registry::CommandSpec::optional_trailing_arg_names`] (the
+    ///   dialect-applicable synopsis placeholders).  Under a dialect whose
+    ///   form documents fewer optional words — Tcl 8.4 and iRules give
+    ///   `catch` a result variable but no options dictionary — only the
+    ///   narrower fix is offered.
+    /// * **Where the words go** is the append point past the *last supplied
+    ///   argument*, from [`tcl_lexer::word_append_offset`], so a braced,
+    ///   multi-line, quoted, empty, or bracketed body all anchor correctly.
+    ///
+    /// One fix per prefix of the run, so a caller sees "append the result
+    /// variable" and "append the result and options variables" as separate
+    /// offers.  Each is a zero-width insertion, and each is classified
+    /// [`FixSafety::BehaviourHardening`]: capturing the result stops errors
+    /// being swallowed, but it also *writes a new variable in the caller's
+    /// frame*, which a program that already uses that name would observe.
+    fn trailing_arg_fixes(
+        &self,
+        cmd_name: &str,
+        args: &[String],
+        arg_tokens: &[tcl_lexer::Token],
+        title_prefix: &str,
+    ) -> Vec<super::types::CodeFix> {
+        let Some(registry) = self.registry else {
+            return Vec::new();
+        };
+        let Some(spec) = registry.get(cmd_name) else {
+            return Vec::new();
+        };
+        let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
+        // The declared roles of the words a caller could still append …
+        let unfilled = registry.unfilled_trailing_roles(cmd_name, &arg_strs);
+        // … restricted to the leading run that writes variables: a slot
+        // taking a value rather than a variable name is not a place to
+        // splice a capture variable.
+        let writable = unfilled
+            .iter()
+            .take_while(|(_, role)| *role == ArgRole::VarWrite)
+            .count();
+        // … and to the optional words this dialect's synopsis documents.
+        let documented = spec.optional_trailing_arg_names(self.profile.availability_mask);
+        let offered = writable.min(documented.len());
+        if offered == 0 {
+            return Vec::new();
+        }
+        let Some(&last) = arg_tokens.last() else {
+            return Vec::new();
+        };
+        let source_map = Self::source_map(
+            &self.source,
+            &self.cached_line_index,
+            self.cached_line_index_source_len,
+        );
+        let insert_at = tcl_lexer::word_append_offset(&source_map, last);
+        // Defensive: an insertion point outside the buffer (a truncated or
+        // otherwise malformed document) is not a usable edit.
+        if insert_at as usize > self.source.len() {
+            return Vec::new();
+        }
+        let span = tcl_lexer::Span::new(insert_at, insert_at);
+        (1..=offered)
+            .map(|count| {
+                let names: Vec<String> = documented[..count]
+                    .iter()
+                    .map(|placeholder| variable_name_for_placeholder(placeholder))
+                    .collect();
+                super::types::CodeFix {
+                    span,
+                    new_text: format!(" {}", names.join(" ")),
+                    description: format!("{title_prefix} {} variable(s)", names.join(" + ")),
+                    safety: super::types::FixSafety::BehaviourHardening,
+                }
+            })
+            .collect()
     }
 
     /// **W101.** Emit "eval with string concatenation" warning
@@ -304,6 +400,10 @@ Prefer direct invocation or {{*}}$cmdList to preserve argument boundaries."
             description: "Rewrite to `eval [list …]` (passes each substituted \
 word as one argument; no re-parsing)"
                 .to_string(),
+            // W101: `eval [list …]` deliberately stops the substituted words
+            // being re-parsed as script — the injection fix, and a change for a
+            // caller that meant them to be.
+            safety: crate::irules_checks::FixSafety::BehaviourHardening,
         }]
     }
 
@@ -1339,6 +1439,30 @@ pub(super) fn has_redos_shape(pattern: &str) -> bool {
     false
 }
 
+/// Turn a synopsis placeholder into the variable name a quick-fix inserts.
+///
+/// Synopsis placeholders name a *role*, in Tcl manual-page style: the word
+/// documented as `resultVarName` is the variable that receives the result.
+/// Spliced into source verbatim it reads as documentation rather than code,
+/// so the trailing `VarName` / `Name` marker is dropped and the leading
+/// letter lower-cased — `resultVarName` becomes `result`,
+/// `optionsVarName` becomes `options`, and a placeholder carrying no such
+/// marker (`varName` alone, once `Name` is dropped, is `var`) keeps its
+/// remaining spelling.  A placeholder that would reduce to nothing keeps
+/// its original text so the fix always inserts a usable identifier.
+fn variable_name_for_placeholder(placeholder: &str) -> String {
+    let stem = placeholder
+        .strip_suffix("VarName")
+        .or_else(|| placeholder.strip_suffix("Name"))
+        .filter(|stem| !stem.is_empty())
+        .unwrap_or(placeholder);
+    let mut chars = stem.chars();
+    match chars.next() {
+        Some(first) => first.to_lowercase().chain(chars).collect(),
+        None => placeholder.to_string(),
+    }
+}
+
 /// True when the body of a `catch` matches the documented
 /// "fire-and-forget" idiom: a single command whose head is a teardown
 /// builtin (`close $h`, `unset var`, `rename foo ""`) or a teardown
@@ -1594,6 +1718,8 @@ fn w127_suggestion_fix(
         span,
         new_text: (*best).to_string(),
         description: format!("Replace with '{best}'"),
+        // W127: an edit-distance guess at the intended value.
+        safety: crate::irules_checks::FixSafety::RequiresReview,
     }]
 }
 

--- a/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
@@ -881,6 +881,8 @@ impl Analyser {
                     span: inv.range,
                     new_text: (*best).to_string(),
                     description: format!("Replace with '{best}'"),
+                    // W123: an edit-distance guess at the intended command.
+                    safety: crate::irules_checks::FixSafety::RequiresReview,
                 });
             }
             self.result.diagnostics.push(super::types::Diagnostic {
@@ -1050,6 +1052,9 @@ impl Analyser {
                 span: tcl_lexer::Span::new(insert_offset, insert_offset),
                 new_text: format!("package require {pkg}\n"),
                 description: format!("Add 'package require {pkg}'"),
+                // W120: a `package require` loads the package, running its
+                // initialisation code and changing what commands exist.
+                safety: crate::irules_checks::FixSafety::BehaviourHardening,
             };
             new_diags.push(super::types::Diagnostic {
                 code: DiagCode::W120,

--- a/rust/tcl-compiler/src/analyser/diagnostics/usage.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/usage.rs
@@ -130,6 +130,10 @@ Use braces: {{ \u{2026} }}"
                 span: body_tok.span,
                 new_text,
                 description: "Wrap code block in braces".to_string(),
+                // Per-instance: bracing a substitution-free body reaches the
+                // command byte-identically; bracing one that substitutes
+                // removes a round of substitution by design.
+                safety: super::helpers::brace_wrap_fix_safety(trimmed, has_substitution),
             }],
         });
     }
@@ -284,6 +288,12 @@ Use braces: {{ \u{2026} }}"
                 span,
                 new_text: format!("{{{fix_inner}}}"),
                 description: "Wrap expression in braces".to_string(),
+                // Per-instance: `expr 1 + 2` → `expr {1 + 2}` reaches `expr`
+                // with the same string, but `expr $a + $b` → `expr {$a + $b}`
+                // stops `$a` being substituted before `expr` parses it, which
+                // is a real behaviour change when `$a` holds expression text
+                // (issue #1195).
+                safety: super::helpers::brace_wrap_fix_safety(text, has_sub),
             }],
         });
     }
@@ -551,6 +561,10 @@ Use braces: {{ \u{2026} }}"
                             span,
                             new_text: repl.to_string(),
                             description: "Replace with ASCII equivalent".to_string(),
+                            // W108: substituting the ASCII look-alike changes the character's
+                            // value. In an identifier that is the repair; inside a string literal
+                            // it rewrites the program's data.
+                            safety: crate::irules_checks::FixSafety::BehaviourHardening,
                         }]
                     })
                     .unwrap_or_default();
@@ -672,6 +686,10 @@ Use braces: {{ \u{2026} }}"
             span,
             new_text: format!("lappend {name_raw} {piece}"),
             description: "Rewrite with `lappend`".to_string(),
+            // W104: `append x " a"` and `lappend x a` agree only when `x`
+            // already holds a well-formed list — which depends on its run-time
+            // value, not on anything visible here.
+            safety: crate::irules_checks::FixSafety::RequiresReview,
         })
     }
 
@@ -977,6 +995,8 @@ content); use `{corrected}` to access the array element with index substitution"
                                 span,
                                 new_text: corrected.clone(),
                                 description: format!("Replace with `{corrected}`"),
+                                // W216: a `did you mean` reading of an ambiguous reference.
+                                safety: crate::irules_checks::FixSafety::RequiresReview,
                             }],
                         });
                     }
@@ -1021,6 +1041,8 @@ literal text `({inner})`; did you mean `{corrected}` for array element access?"
                     span,
                     new_text: corrected.clone(),
                     description: format!("Replace with `{corrected}`"),
+                    // W216: as above.
+                    safety: crate::irules_checks::FixSafety::RequiresReview,
                 }],
             });
         }
@@ -1131,6 +1153,11 @@ literal text `({inner})`; did you mean `{corrected}` for array element access?"
                     span: diag_span,
                     new_text: rewritten,
                     description: format!("Use '{replacement}' for string comparison"),
+                    // W110: `eq` compares as strings where `==` coerces numerically —
+                    // `"1" == "01"` is true, `"1" eq "01"` is false. Removing the
+                    // coercion is the fix, and it changes results in exactly the cases
+                    // the diagnostic is about.
+                    safety: crate::irules_checks::FixSafety::BehaviourHardening,
                 });
             }
         }
@@ -1635,6 +1662,10 @@ fn w114_unwrap_fix(
         span,
         new_text,
         description: "Unwrap the nested `expr`".to_string(),
+        // W114: unwrapping the nested `expr` removes a
+        // stringify/re-parse round, which can change the numeric formatting
+        // of a floating-point intermediate.
+        safety: crate::irules_checks::FixSafety::RequiresReview,
     })
 }
 

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -269,6 +269,9 @@ got {nargs_min}{usage_suffix}"
                     span: tcl_lexer::Span::new(ex.delete_from, ex.span.end()),
                     new_text: String::new(),
                     description: "Remove surplus argument(s)".to_string(),
+                    // E003: deleting the surplus words assumes they were the mistake
+                    // rather than a missing option that would have consumed them.
+                    safety: crate::irules_checks::FixSafety::RequiresReview,
                 }],
             ),
             None => (span, Vec::new()),
@@ -803,6 +806,8 @@ impl Analyser {
                 span,
                 new_text: (*best).to_string(),
                 description: format!("Replace with '{best}'"),
+                // W001: an edit-distance guess at the intended subcommand.
+                safety: crate::irules_checks::FixSafety::RequiresReview,
             });
         }
         self.pending_arity.push((
@@ -2306,6 +2311,9 @@ impl Analyser {
                     span: tcl_lexer::Span::new(start, end),
                     new_text: format!("{{{slice}}}"),
                     description: "Merge trailing words into the if body".to_string(),
+                    // E004: merging the trailing words into the body is one reading of
+                    // a malformed `if`; a missing `elseif` keyword is another.
+                    safety: crate::irules_checks::FixSafety::RequiresReview,
                 }]
             }
             ClauseShapeError::MissingExpr {
@@ -2357,6 +2365,8 @@ impl Analyser {
             span: tcl_lexer::Span::new(start, end),
             new_text: String::new(),
             description: "Remove incomplete trailing clause".to_string(),
+            // E004: deleting the dangling clause discards written code.
+            safety: crate::irules_checks::FixSafety::RequiresReview,
         }]
     }
 
@@ -2457,6 +2467,9 @@ impl Analyser {
             span: fix_span,
             new_text: fix_text,
             description: "Insert '--' option terminator".to_string(),
+            // W304: `--` stops the following word being read as an option,
+            // which is the whole point — a call that meant it as one changes.
+            safety: crate::irules_checks::FixSafety::BehaviourHardening,
         }];
         let diag_span = tcl_lexer::Span::new(tok.span.start(), diag_end);
         // Suppress unused-warning on the rare path where `cmd_tok`
@@ -2549,6 +2562,9 @@ impl Analyser {
             span: first.span,
             new_text: format!("-- {slice}"),
             description: "Insert '--' so the following words are variable names".to_string(),
+            // W217: as W304 — `--` re-reads the following words as variable
+            // names rather than options.
+            safety: crate::irules_checks::FixSafety::BehaviourHardening,
         }];
         self.result.diagnostics.push(super::types::Diagnostic {
             code: DiagCode::W217,
@@ -2687,6 +2703,12 @@ options. To unset a variable whose name begins with `-`, put `--` before it \
                 span: cmd_tok.span,
                 new_text: replacement.to_string(),
                 description: format!("Replace with '{replacement}'"),
+                // IRULE2002: offered only when the registry marks the replacement
+                // `deprecated_replacement_drop_in` — its contract is that the
+                // replacement takes the deprecated command's argument list unchanged,
+                // so swapping the head is a pure re-spelling. A replacement that
+                // restructures arguments carries no fix at all (see the `else` arm).
+                safety: crate::irules_checks::FixSafety::SemanticsEquivalent,
             }]
         } else {
             Vec::new()
@@ -2761,6 +2783,9 @@ options. To unset a variable whose name begins with `-`, put `--` before it \
                     span: cmd_tok.span,
                     description: format!("Replace with '{suggestion}'"),
                     new_text: suggestion,
+                    // W143: the public spelling is inferred from the private one; the
+                    // private implementation need not behave identically to the ensemble.
+                    safety: crate::irules_checks::FixSafety::RequiresReview,
                 }]
             }
             _ => Vec::new(),
@@ -2899,6 +2924,11 @@ options. To unset a variable whose name begins with `-`, put `--` before it \
                     span: tcl_lexer::Span::new(cmd_tok.span.start(), end),
                     new_text,
                     description: "Replace with 'class match'".to_string(),
+                    // IRULE2001: the rewrite restructures the argument list (it supplies
+                    // the `equals` operator the two-word `matchclass` form defaults to) —
+                    // exactly the case the registry's `deprecated_replacement_drop_in`
+                    // contract excludes from mechanical swapping.
+                    safety: crate::irules_checks::FixSafety::RequiresReview,
                 }]
             })
             .unwrap_or_default();
@@ -3214,6 +3244,9 @@ in the active dialect ({}).",
             span: tcl_lexer::Span::new(flag_tok.span.start(), end),
             new_text: String::new(),
             description: format!("Remove '{arg}'"),
+            // W004: deleting an option the active dialect lacks drops whatever
+            // the author wanted it to do.
+            safety: crate::irules_checks::FixSafety::RequiresReview,
         }]
     }
 
@@ -3343,6 +3376,9 @@ in the active dialect ({}).",
                         "Rewrite to a form supported by dialect '{}'",
                         self.dialect()
                     ),
+                    // W003: the older-dialect spelling of an operator is rarely exact —
+                    // `lt` compares as strings where `<` coerces numerically.
+                    safety: crate::irules_checks::FixSafety::RequiresReview,
                 });
             }
             self.result.diagnostics.push(super::types::Diagnostic {

--- a/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
@@ -476,6 +476,8 @@ impl Analyser {
                     span: fix_span,
                     new_text: (*best).to_string(),
                     description: format!("Replace with '{best}'"),
+                    // W308: an edit-distance guess at the intended method.
+                    safety: crate::irules_checks::FixSafety::RequiresReview,
                 });
             }
         }

--- a/rust/tcl-compiler/src/analyser/irules_event_checks.rs
+++ b/rust/tcl-compiler/src/analyser/irules_event_checks.rs
@@ -773,6 +773,10 @@ impl Analyser {
                     span: fix_span,
                     new_text: static_name.clone(),
                     description: format!("Replace '{var_name}' with '{static_name}'"),
+                    // IRULE6001: `static::` variables have per-TMM storage and a
+                    // different lifetime from a global — the CMP fix, and a change of
+                    // where the value lives.
+                    safety: crate::irules_checks::FixSafety::RequiresReview,
                 }],
             });
             return;
@@ -801,6 +805,8 @@ impl Analyser {
                     span: fix_span,
                     new_text: static_name.clone(),
                     description: format!("Replace '{bare}' with '{static_name}'"),
+                    // IRULE6001: as above.
+                    safety: crate::irules_checks::FixSafety::RequiresReview,
                 }],
             });
         }

--- a/rust/tcl-compiler/src/analyser/mod.rs
+++ b/rust/tcl-compiler/src/analyser/mod.rs
@@ -85,8 +85,8 @@ pub use snapshot::AnalyserSnapshot;
 pub use state::{Analyser, NonAsciiMode};
 pub use tcl_syntax::mro::{self, MroError, build_mro_map, tcloo_linearise};
 pub use types::{
-    AnalysisResult, ClassDef, CodeFix, DefinedSymbol, DefinitionAbortKind, Diagnostic, MemberSide,
-    MethodDef, ObjectMethodDef, ProcArgTrait, ProcDef, PropertyDef, QualifiedVarRef, RenamedMember,
-    Scope, ScopeKind, Severity, StubFlags, UnknownProcInfo, VarDef, class_constructor_key,
-    class_destructor_key, class_member_key, class_property_key,
+    AnalysisResult, ClassDef, CodeFix, DefinedSymbol, DefinitionAbortKind, Diagnostic, FixSafety,
+    MemberSide, MethodDef, ObjectMethodDef, ProcArgTrait, ProcDef, PropertyDef, QualifiedVarRef,
+    RenamedMember, Scope, ScopeKind, Severity, StubFlags, UnknownProcInfo, VarDef,
+    class_constructor_key, class_destructor_key, class_member_key, class_property_key,
 };

--- a/rust/tcl-compiler/src/analyser/recovery.rs
+++ b/rust/tcl-compiler/src/analyser/recovery.rs
@@ -366,6 +366,9 @@ impl Analyser {
                     span: insert_span,
                     new_text: " {".to_string(),
                     description: "Insert missing '{'".to_string(),
+                    // E101: the source does not parse; where the missing brace belongs
+                    // is a recovery heuristic, not a proof.
+                    safety: crate::irules_checks::FixSafety::RequiresReview,
                 }],
             });
         }
@@ -504,6 +507,8 @@ impl Analyser {
                     span: insert_span,
                     new_text: format!("{indent}}}\n"),
                     description: "Insert missing '}'".to_string(),
+                    // E103: as E101 — a brace-recovery heuristic.
+                    safety: crate::irules_checks::FixSafety::RequiresReview,
                 }],
             });
         }

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -4044,6 +4044,171 @@ mod tests {
         assert_eq!(text, "catch", "W302 should span only the catch keyword");
     }
 
+    // -- W302 quick-fix insertion anchor (issue #1190)
+    //
+    // The diagnostic anchors at the `catch` keyword, so the fix must carry
+    // its **own** span: the point past the *body's* closing delimiter.  Each
+    // test applies the fix to the source and asserts the resulting text, so a
+    // wrong anchor cannot pass by matching only the inserted string.
+
+    /// Apply W302's `nth` fix to `src` and return the rewritten source.
+    fn apply_w302_fix(src: &str, nth: usize, dialect: &str) -> String {
+        let mut a = Analyser::new();
+        let r = a.analyse(src, dialect);
+        let w302: Vec<_> = r
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == DiagCode::W302)
+            .collect();
+        assert_eq!(w302.len(), 1, "expected one W302, got {:?}", r.diagnostics);
+        let fix = w302[0]
+            .fixes
+            .get(nth)
+            .unwrap_or_else(|| panic!("no fix {nth}: {:?}", w302[0].fixes));
+        let mut out = src.to_string();
+        out.replace_range(
+            fix.span.start() as usize..fix.span.end() as usize,
+            &fix.new_text,
+        );
+        out
+    }
+
+    #[test]
+    fn w302_result_fix_inserts_after_the_body() {
+        // The issue's reproducer.  Anchoring at the diagnostic's end would
+        // produce `catch result {error oops}`, which C Tcl reads as a catch
+        // of the script `result` — completion code 1, result
+        // `invalid command name "result"`.
+        assert_eq!(
+            apply_w302_fix("catch {error oops}\n", 0, "tcl9.0"),
+            "catch {error oops} result\n"
+        );
+    }
+
+    #[test]
+    fn w302_options_fix_inserts_after_the_body() {
+        assert_eq!(
+            apply_w302_fix("catch {error oops}\n", 1, "tcl9.0"),
+            "catch {error oops} result options\n"
+        );
+    }
+
+    #[test]
+    fn w302_fix_handles_a_multiline_body() {
+        let src = "catch {\n    error oops\n}\n";
+        assert_eq!(
+            apply_w302_fix(src, 0, "tcl9.0"),
+            "catch {\n    error oops\n} result\n"
+        );
+    }
+
+    #[test]
+    fn w302_fix_handles_a_trailing_comment() {
+        let src = "catch {error oops} ;# ignore\n";
+        assert_eq!(
+            apply_w302_fix(src, 0, "tcl9.0"),
+            "catch {error oops} result ;# ignore\n"
+        );
+    }
+
+    #[test]
+    fn w302_fix_handles_a_semicolon_separated_command() {
+        let src = "catch {error oops}; puts done\n";
+        assert_eq!(
+            apply_w302_fix(src, 0, "tcl9.0"),
+            "catch {error oops} result; puts done\n"
+        );
+    }
+
+    #[test]
+    fn w302_fix_handles_nested_substitutions_in_the_body() {
+        let src = "catch {puts [expr {1 + [foo $x]}]}\n";
+        assert_eq!(
+            apply_w302_fix(src, 0, "tcl9.0"),
+            "catch {puts [expr {1 + [foo $x]}]} result\n"
+        );
+    }
+
+    #[test]
+    fn w302_fix_does_not_overshoot_an_empty_body() {
+        // `catch {}`'s body span already covers its own closer, so a naive
+        // `span.end() + 1` anchor would insert one byte past the brace.
+        let src = "catch {}\n";
+        assert_eq!(apply_w302_fix(src, 0, "tcl9.0"), "catch {} result\n");
+    }
+
+    #[test]
+    fn w302_fix_handles_a_leading_qualified_head() {
+        // `::catch` resolves to the same registry spec (and the same
+        // `AnalyserHookId::Catch`), so it is diagnosed and fixed identically.
+        let src = "::catch {error oops}\n";
+        assert_eq!(
+            apply_w302_fix(src, 0, "tcl9.0"),
+            "::catch {error oops} result\n"
+        );
+    }
+
+    #[test]
+    fn w302_offers_only_the_result_variable_under_tcl84() {
+        // Tcl 8.4's `catch script ?varName?` has no options-dictionary
+        // argument, so the second fix must not be offered there — the count
+        // comes from the dialect-applicable synopsis, not from a constant.
+        let mut a = Analyser::new();
+        let r = a.analyse("catch {error oops}\n", "tcl8.4");
+        let w302: Vec<_> = r
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == DiagCode::W302)
+            .collect();
+        assert_eq!(w302.len(), 1, "got {:?}", r.diagnostics);
+        assert_eq!(
+            w302[0].fixes.len(),
+            1,
+            "8.4 documents one optional word: {:?}",
+            w302[0].fixes
+        );
+        assert_eq!(w302[0].fixes[0].new_text, " var");
+    }
+
+    #[test]
+    fn w302_fixes_are_never_bulk_applicable() {
+        // Capturing the result writes a new variable in the caller's frame,
+        // which a program already using that name observes — so the fix is
+        // hardening, not a semantics-preserving rewrite (issue #1195).
+        let mut a = Analyser::new();
+        let r = a.analyse("catch {error oops}\n", "tcl9.0");
+        let w302 = r
+            .diagnostics
+            .iter()
+            .find(|d| d.code == DiagCode::W302)
+            .expect("W302");
+        assert!(!w302.fixes.is_empty());
+        assert!(
+            w302.fixes.iter().all(|f| !f.safety.is_bulk_applicable()),
+            "got {:?}",
+            w302.fixes
+        );
+    }
+
+    #[test]
+    fn w302_carries_no_fix_for_a_malformed_catch() {
+        // An unterminated body never reaches a well-formed insertion point;
+        // whatever the recovery path emits, no W302 fix may point outside
+        // the buffer.
+        let mut a = Analyser::new();
+        let src = "catch {error oops\n";
+        let r = a.analyse(src, "tcl9.0");
+        for diag in r.diagnostics.iter().filter(|d| d.code == DiagCode::W302) {
+            for fix in &diag.fixes {
+                assert!(
+                    fix.span.end() as usize <= src.len(),
+                    "fix span {:?} outside the buffer",
+                    fix.span
+                );
+            }
+        }
+    }
+
     // -- W001 unknown-subcommand emitter
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/syntax_checks.rs
+++ b/rust/tcl-compiler/src/analyser/syntax_checks.rs
@@ -172,6 +172,8 @@ fn e201_with_insert(
             span: Span::new(insert_off, insert_off),
             new_text: "]".to_string(),
             description: fix_desc.to_string(),
+            // E201: a close-bracket recovery heuristic.
+            safety: crate::irules_checks::FixSafety::RequiresReview,
         }],
     }
 }
@@ -450,6 +452,8 @@ fn detect_e202(
                         span: Span::new(insert_off, insert_off),
                         new_text: "\"".to_string(),
                         description: "Insert missing '\"' to close string".to_string(),
+                        // E202: a close-quote recovery heuristic.
+                        safety: crate::irules_checks::FixSafety::RequiresReview,
                     }],
                 };
             }
@@ -591,6 +595,8 @@ fn e203_brace_fix(
                     span: Span::new(insert_off, insert_off),
                     new_text: "}".to_string(),
                     description: "Insert missing '}' before command".to_string(),
+                    // E203: a close-brace recovery heuristic.
+                    safety: crate::irules_checks::FixSafety::RequiresReview,
                 });
             }
         }
@@ -801,6 +807,8 @@ fn make_e100(
             span: Span::new(off, off),
             new_text: "[".to_string(),
             description: "Insert missing '['".to_string(),
+            // E204: an open-bracket recovery heuristic.
+            safety: crate::irules_checks::FixSafety::RequiresReview,
         });
         off
     } else {
@@ -934,6 +942,9 @@ fn stray_brace_fix(tok: &Token, brace_off: u32, source: &str) -> Option<CodeFix>
         ),
         new_text: String::new(),
         description: "Remove extra '}'".to_string(),
+        // E205: deleting a stray `}` assumes it is the extra one rather
+        // than a body opener being unclosed earlier.
+        safety: crate::irules_checks::FixSafety::RequiresReview,
     })
 }
 

--- a/rust/tcl-compiler/src/analyser/tk_checks.rs
+++ b/rust/tcl-compiler/src/analyser/tk_checks.rs
@@ -259,6 +259,8 @@ impl Analyser {
                     span,
                     new_text: (*best).to_string(),
                     description: format!("Replace with '{best}'"),
+                    // TK1003: an edit-distance guess at the intended option.
+                    safety: crate::irules_checks::FixSafety::RequiresReview,
                 });
             }
             self.tk_pending_diags.push(Diagnostic {

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -80,7 +80,10 @@ impl ScopeKind {
 /// emitters that know exactly *what* the user should change (E101
 /// inserts a missing ``{``, E103
 /// inserts a missing ``}``, W123 may suggest a similarly-named command, etc.).
-pub use crate::irules_checks::CodeFix;
+/// Each fix carries a [`FixSafety`] classification recording how much the
+/// rewrite changes behaviour; "Fix All Safe Issues" applies only the
+/// provably equivalent ones.
+pub use crate::irules_checks::{CodeFix, FixSafety};
 
 /// Diagnostic emitted by the analyser.
 ///

--- a/rust/tcl-compiler/src/compiler_checks.rs
+++ b/rust/tcl-compiler/src/compiler_checks.rs
@@ -206,6 +206,10 @@ impl Diagnostic {
                 span: w.span,
                 new_text: r.clone(),
                 description: "Rewrite with `file join`".to_string(),
+                // W201: `file join` normalises separators and absolute-path
+                // segments, so the joined result is not always the concatenated
+                // string it replaces.
+                safety: crate::irules_checks::FixSafety::RequiresReview,
             }]
         });
         Self {

--- a/rust/tcl-compiler/src/irules_checks.rs
+++ b/rust/tcl-compiler/src/irules_checks.rs
@@ -109,6 +109,76 @@ fn supports_normalized_flag(registry: &CommandRegistry, cmd: &str) -> bool {
         .is_some_and(|spec| spec.options.iter().any(|opt| opt.name == "-normalized"))
 }
 
+/// How much a [`CodeFix`] changes the behaviour of the program it rewrites.
+///
+/// A fix's *description* says what it does; this says what it costs.  The
+/// distinction matters because "Fix All Safe Issues" applies fixes
+/// unattended, in bulk, without the author reading each one: only a fix
+/// that is **provably** semantics-preserving for the instance it was built
+/// from belongs there.  A whitelist of diagnostic *codes* cannot express
+/// that, because the same code can produce an equivalent rewrite in one
+/// place and a behaviour-changing one in another (issue #1195).
+///
+/// The classification is per **fix instance**, not per code.  An emitter
+/// that can prove equivalence for some inputs and not others must classify
+/// each fix it builds on its own evidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
+pub enum FixSafety {
+    /// The rewrite is provably equivalent for this instance: every input
+    /// produces the same completion code, result, output, and side effects
+    /// before and after.  Whitespace and delimiter repairs, and rewrites
+    /// whose operands the emitter has proven inert, live here.
+    ///
+    /// **This is the only class "Fix All Safe Issues" applies.**
+    SemanticsEquivalent,
+    /// The rewrite deliberately removes a hazard, and in doing so can change
+    /// what the program does.  Bracing an `expr` operand (W100) removes
+    /// Tcl's second round of substitution — the point of the fix, and the
+    /// reason a program relying on that substitution changes behaviour.
+    /// Offered as its own named action with an explanation; never applied
+    /// unattended.
+    BehaviourHardening,
+    /// The rewrite changes only the spelling a human reads — comment
+    /// layout, a suppression directive, an alternative documented form with
+    /// identical semantics that is nonetheless a matter of taste.  Safe to
+    /// apply, but not a *correctness* fix, so bulk application is a style
+    /// decision the author makes rather than one the server makes for them.
+    StyleOnly,
+    /// Equivalence is not established: the fix is a suggestion whose
+    /// correctness depends on context the emitter could not check (inferred
+    /// types, run-time values, traces, aliases, a rename the analyser cannot
+    /// see).  The author must read it.  This is the **default** so a new
+    /// emitter that has not thought about safety cannot silently opt its
+    /// fixes into unattended bulk application.
+    #[default]
+    RequiresReview,
+}
+
+impl FixSafety {
+    /// Whether a fix in this class may be applied unattended, in bulk, by
+    /// "Fix All Safe Issues".
+    ///
+    /// The single place that decision is encoded — the server asks the fix,
+    /// rather than keeping a second list of diagnostic codes that drifts
+    /// from what the emitters actually prove.
+    #[must_use]
+    pub const fn is_bulk_applicable(self) -> bool {
+        matches!(self, Self::SemanticsEquivalent)
+    }
+
+    /// A short label for the class, for diagnostics, tooling, and the
+    /// `applied` list the fix-all command reports.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SemanticsEquivalent => "semantics-equivalent",
+            Self::BehaviourHardening => "behaviour-hardening",
+            Self::StyleOnly => "style-only",
+            Self::RequiresReview => "requires-review",
+        }
+    }
+}
+
 /// A suggested code-action fix — maps to an LSP `TextEdit`.
 ///
 /// `span` is the **fix range** the edit applies to, *independent* of the
@@ -117,6 +187,12 @@ fn supports_normalized_flag(registry: &CommandRegistry, cmd: &str) -> bool {
 /// rewrites.  This is the lower-level twin of the analyser's `CodeFix`, which
 /// re-exports this type (see `analyser::types`); it lives here because the
 /// iRules-flow / compiler-checks layer is below the analyser.
+///
+/// `safety` records how much the rewrite changes behaviour — see
+/// [`FixSafety`].  Prefer the classified constructors
+/// ([`CodeFix::equivalent`], [`CodeFix::hardening`], [`CodeFix::style`],
+/// [`CodeFix::review`]) over a struct literal: they make the classification
+/// an explicit decision at every emit site.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CodeFix {
     /// Source span the `new_text` replaces (zero-width for an insertion).
@@ -125,6 +201,63 @@ pub struct CodeFix {
     pub new_text: String,
     /// Human-readable description (`"Add 'event disable all' + 'return'"`).
     pub description: String,
+    /// How much this rewrite changes the program's behaviour.
+    pub safety: FixSafety,
+}
+
+impl CodeFix {
+    /// A fix the emitter has proven equivalent for this instance — the only
+    /// class "Fix All Safe Issues" applies.  See
+    /// [`FixSafety::SemanticsEquivalent`].
+    #[must_use]
+    pub fn equivalent(
+        span: Span,
+        new_text: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self {
+        Self::classified(span, new_text, description, FixSafety::SemanticsEquivalent)
+    }
+
+    /// A fix that removes a hazard and may change behaviour in doing so.
+    /// See [`FixSafety::BehaviourHardening`].
+    #[must_use]
+    pub fn hardening(
+        span: Span,
+        new_text: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self {
+        Self::classified(span, new_text, description, FixSafety::BehaviourHardening)
+    }
+
+    /// A fix that changes only the spelling a human reads.  See
+    /// [`FixSafety::StyleOnly`].
+    #[must_use]
+    pub fn style(span: Span, new_text: impl Into<String>, description: impl Into<String>) -> Self {
+        Self::classified(span, new_text, description, FixSafety::StyleOnly)
+    }
+
+    /// A suggestion whose correctness the emitter could not establish.  See
+    /// [`FixSafety::RequiresReview`].
+    #[must_use]
+    pub fn review(span: Span, new_text: impl Into<String>, description: impl Into<String>) -> Self {
+        Self::classified(span, new_text, description, FixSafety::RequiresReview)
+    }
+
+    /// Shared constructor behind the four classified builders.
+    #[must_use]
+    pub fn classified(
+        span: Span,
+        new_text: impl Into<String>,
+        description: impl Into<String>,
+        safety: FixSafety,
+    ) -> Self {
+        Self {
+            span,
+            new_text: new_text.into(),
+            description: description.into(),
+            safety,
+        }
+    }
 }
 
 /// An IRULE3102 / iRules-check diagnostic emitted by
@@ -426,6 +559,9 @@ pub fn find_unguarded_drop_warnings(
                         span: Span::new(span.end(), span.end()),
                         new_text: "\n    event disable all\n    return".to_owned(),
                         description: "Add 'event disable all' + 'return'".to_owned(),
+                        // IRULE5002: adding `event disable all` + `return` stops later
+                        // iRules and priorities running — the fix, and a control-flow change.
+                        safety: crate::irules_checks::FixSafety::BehaviourHardening,
                     }],
                 });
             }
@@ -443,6 +579,9 @@ pub fn find_unguarded_drop_warnings(
                         span: Span::new(span.end(), span.end()),
                         new_text: "\n    return".to_owned(),
                         description: "Add 'return' after DNS::return".to_owned(),
+                        // IRULE5004: adding `return` stops iRule processing after
+                        // `DNS::return` — a control-flow change.
+                        safety: crate::irules_checks::FixSafety::BehaviourHardening,
                     }],
                 });
             }

--- a/rust/tcl-compiler/src/taint.rs
+++ b/rust/tcl-compiler/src/taint.rs
@@ -3406,6 +3406,9 @@ fn emit_option_injection<S: std::hash::BuildHasher>(
                         span: Span::new(tight.start(), tight.start()),
                         new_text: "-- ".to_owned(),
                         description: "Insert '--' option terminator".to_owned(),
+                        // T102: `--` stops a tainted value being read as an option — the
+                        // fix, and a change for a call that meant it as one.
+                        safety: crate::irules_checks::FixSafety::BehaviourHardening,
                     }],
                 ),
                 None => (span, Vec::new()),

--- a/rust/tcl-compiler/tests/fix_safety.rs
+++ b/rust/tcl-compiler/tests/fix_safety.rs
@@ -1,0 +1,240 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Quick-fix safety-classification suite (issue #1195).
+//!
+//! Every [`CodeFix`](tcl_compiler::analyser::CodeFix) records how much its
+//! rewrite changes behaviour.  "Fix All Safe Issues" applies only the
+//! `SemanticsEquivalent` class, so a misclassification here is a silent,
+//! unattended change to a user's program — which is exactly what the
+//! diagnostic-code whitelist this replaced allowed.
+//!
+//! The four coverage classes, per the issue's acceptance criteria:
+//!
+//! * **TP** — a rewrite that really is equivalent is classified so, and is
+//!   therefore bulk-applicable.
+//! * **FP** — a rewrite that changes behaviour is *not* classified
+//!   equivalent, so the bulk pass leaves it alone.
+//! * **TN** — a diagnostic that carries no fix at all contributes nothing.
+//! * **FN** — an equivalent rewrite is not over-classified into a stricter
+//!   class than it needs, so genuinely safe work still gets done.
+
+use tcl_compiler::analyser::{Analyser, FixSafety};
+use tcl_core_types::DiagCode;
+
+/// `(code, description, safety)` for every fix the analyser attaches to
+/// `src` under `dialect`.
+fn fixes(src: &str, dialect: &str) -> Vec<(DiagCode, String, FixSafety)> {
+    let mut analyser = Analyser::new();
+    analyser
+        .analyse(src, dialect)
+        .diagnostics
+        .iter()
+        .flat_map(|diag| {
+            diag.fixes
+                .iter()
+                .map(move |fix| (diag.code, fix.description.clone(), fix.safety))
+        })
+        .collect()
+}
+
+/// The safety classes recorded for `code`'s fixes in `src`.
+fn safety_for(src: &str, dialect: &str, code: DiagCode) -> Vec<FixSafety> {
+    fixes(src, dialect)
+        .into_iter()
+        .filter(|(diag_code, _, _)| *diag_code == code)
+        .map(|(_, _, safety)| safety)
+        .collect()
+}
+
+// -- The taxonomy itself -------------------------------------------------
+
+#[test]
+fn only_the_equivalent_class_is_bulk_applicable() {
+    assert!(FixSafety::SemanticsEquivalent.is_bulk_applicable());
+    assert!(!FixSafety::BehaviourHardening.is_bulk_applicable());
+    assert!(!FixSafety::StyleOnly.is_bulk_applicable());
+    assert!(!FixSafety::RequiresReview.is_bulk_applicable());
+}
+
+#[test]
+fn the_default_class_is_the_cautious_one() {
+    // A new emitter that constructs a `CodeFix` without thinking about
+    // safety must not silently opt into unattended bulk application.
+    assert_eq!(FixSafety::default(), FixSafety::RequiresReview);
+    assert!(!FixSafety::default().is_bulk_applicable());
+}
+
+// -- W100: the issue's headline case -------------------------------------
+
+#[test]
+fn fp_w100_brace_fix_over_a_substituted_operand_is_not_equivalent() {
+    // C Tcl 9.0.3:
+    //
+    //   set a {$x}; set x 3; set b 2
+    //   puts [expr $a + $b]     ;# 5   — `$a` substitutes to `$x`, then expr
+    //                                    substitutes *that* to 3
+    //   puts [expr {$a + $b}]   ;# error: `$a` is the string `$x`
+    //
+    // Bracing is the right advice and stays available as its own action; it
+    // is not an unattended bulk rewrite.
+    let src = "set a {$x}\nset x 3\nset b 2\nputs [expr $a + $b]\n";
+    let classes = safety_for(src, "tcl9.0", DiagCode::W100);
+    assert!(!classes.is_empty(), "expected a W100 fix for {src:?}");
+    assert!(
+        classes.iter().all(|s| *s == FixSafety::BehaviourHardening),
+        "got {classes:?}"
+    );
+}
+
+#[test]
+fn tp_w100_brace_fix_over_a_substitution_free_operand_is_equivalent() {
+    // Nothing substitutes in `abs(-2)`, so `expr` receives byte-identical
+    // text either way — the delimiter repair the bulk pass exists for.  (A
+    // pure-arithmetic `expr 1 + 2` never reaches here: the emitter already
+    // treats a wholly literal arithmetic expression as safe and emits no
+    // W100 at all.)
+    let classes = safety_for("set n [expr abs(-2)]\n", "tcl9.0", DiagCode::W100);
+    assert!(!classes.is_empty(), "expected a W100 fix");
+    assert!(
+        classes.iter().all(|s| s.is_bulk_applicable()),
+        "got {classes:?}"
+    );
+}
+
+#[test]
+fn fp_w100_brace_fix_over_a_backslash_bearing_operand_is_not_equivalent() {
+    // The outer parse decodes `\x41` before `expr` sees it; braced, `expr`
+    // sees the four written characters instead.
+    let classes = safety_for("set n [expr \\x41 + 1]\n", "tcl9.0", DiagCode::W100);
+    if !classes.is_empty() {
+        assert!(
+            classes.iter().all(|s| !s.is_bulk_applicable()),
+            "a backslash-bearing operand is not a byte-identical rewrite: {classes:?}"
+        );
+    }
+}
+
+// -- W110: numeric vs string comparison ----------------------------------
+
+#[test]
+fn fp_w110_eq_rewrite_is_never_equivalent() {
+    // C Tcl 9.0.3: `expr {"1" == "01"}` is 1 (numeric), `expr {"1" eq "01"}`
+    // is 0 (string).  The rewrite changes the answer in precisely the
+    // coercion cases the diagnostic is about.
+    let classes = safety_for("puts [expr {\"1\" == \"01\"}]\n", "tcl9.0", DiagCode::W110);
+    assert!(!classes.is_empty(), "expected a W110 fix");
+    assert!(
+        classes.iter().all(|s| !s.is_bulk_applicable()),
+        "got {classes:?}"
+    );
+}
+
+// -- W105: unbraced code block -------------------------------------------
+
+#[test]
+fn fp_w105_brace_fix_over_a_substituted_body_is_not_equivalent() {
+    let classes = safety_for("while 1 \"puts $x\"\n", "tcl9.0", DiagCode::W105);
+    assert!(!classes.is_empty(), "expected a W105 fix");
+    assert!(
+        classes.iter().all(|s| !s.is_bulk_applicable()),
+        "got {classes:?}"
+    );
+}
+
+// -- W120 / W213 / W304: hardening, not equivalence ----------------------
+
+#[test]
+fn fp_w213_nocomplain_fix_is_hardening() {
+    // `unset x` raises when `x` does not exist; `unset -nocomplain x` does
+    // not.  Suppressing that error is the fix, and a `catch`-guarded probe
+    // observes the change.
+    let classes = safety_for("proc f {} {\n    unset x\n}\n", "tcl9.0", DiagCode::W213);
+    assert!(!classes.is_empty(), "expected a W213 fix");
+    assert!(
+        classes.iter().all(|s| !s.is_bulk_applicable()),
+        "got {classes:?}"
+    );
+}
+
+#[test]
+fn fp_w304_option_terminator_fix_is_hardening() {
+    // `--` changes how the following word is read.  That is the point.
+    let classes = safety_for("regexp $pattern $text\n", "tcl9.0", DiagCode::W304);
+    assert!(!classes.is_empty(), "expected a W304 fix");
+    assert!(
+        classes.iter().all(|s| !s.is_bulk_applicable()),
+        "got {classes:?}"
+    );
+}
+
+// -- "Did you mean …?" suggestions ---------------------------------------
+
+#[test]
+fn fp_did_you_mean_suggestions_require_review() {
+    // An edit-distance guess is a suggestion, never a proof.  W001's
+    // subcommand suggestion is the representative case.
+    let classes = safety_for("string lenght $x\n", "tcl9.0", DiagCode::W001);
+    assert!(!classes.is_empty(), "expected a W001 suggestion fix");
+    assert!(
+        classes.iter().all(|s| *s == FixSafety::RequiresReview),
+        "got {classes:?}"
+    );
+}
+
+// -- TN: diagnostics with no fix -----------------------------------------
+
+#[test]
+fn tn_clean_source_carries_no_fixes_at_all() {
+    assert!(fixes("set x 1\nputs $x\n", "tcl9.0").is_empty());
+}
+
+#[test]
+fn tn_a_diagnostic_without_a_fix_contributes_nothing() {
+    // E002 (too few arguments) has no surplus word to delete and carries no
+    // fix, so it can never reach the bulk pass regardless of its class.
+    let classes = safety_for("string\n", "tcl9.0", DiagCode::E002);
+    assert!(classes.is_empty(), "got {classes:?}");
+}
+
+// -- FN: safe work still gets done ---------------------------------------
+
+#[test]
+fn fn_the_equivalent_class_is_actually_reachable() {
+    // A guard against over-classification emptying the bulk pass entirely:
+    // at least one real emitter must still produce a bulk-applicable fix,
+    // or "Fix All Safe Issues" would be a no-op by construction.
+    let classes = safety_for("set n [expr abs(-2)]\n", "tcl9.0", DiagCode::W100);
+    assert!(
+        classes.iter().any(|s| s.is_bulk_applicable()),
+        "no emitter produces a bulk-applicable fix: {classes:?}"
+    );
+}
+
+#[test]
+fn every_fix_reports_a_label() {
+    // The `applied` report names the class, so every variant needs one.
+    for safety in [
+        FixSafety::SemanticsEquivalent,
+        FixSafety::BehaviourHardening,
+        FixSafety::StyleOnly,
+        FixSafety::RequiresReview,
+    ] {
+        assert!(!safety.as_str().is_empty());
+    }
+}

--- a/rust/tcl-lexer/src/lib.rs
+++ b/rust/tcl-lexer/src/lib.rs
@@ -28,7 +28,8 @@
 //!   source-mapping layer. Every positional entity holds a bare
 //!   [`Span`] and asks a [`SourceMap`] for text or positions on
 //!   demand.
-//! - [`word_closer_offset`], [`word_end_position`] — source-aware
+//! - [`word_closer_offset`], [`word_end_position`],
+//!   [`word_append_offset`] — source-aware
 //!   authoritative closer accessors for delimited word tokens, derived
 //!   from the lexer's content geometry (correct for empty `{}` / `[]` /
 //!   `""` and backslash-bearing quoted words).
@@ -62,7 +63,7 @@ pub use highlight::{
 };
 pub use lexer::{LexError, LexWarning, Lexer, LexerConfig};
 pub use line_index::{LineIndex, normalise_lone_cr};
-pub use ranges::{word_closer_offset, word_end_position};
+pub use ranges::{word_append_offset, word_closer_offset, word_end_position};
 pub use source_map::SourceMap;
 pub use span::Span;
 pub use structural_index::{

--- a/rust/tcl-lexer/src/ranges.rs
+++ b/rust/tcl-lexer/src/ranges.rs
@@ -118,6 +118,29 @@ pub fn word_closer_offset(sm: &SourceMap<'_>, tok: Token) -> Option<u32> {
     }
 }
 
+/// Byte offset immediately **after** *tok*'s last source byte — the point
+/// at which a further word can be appended to the command *tok* belongs to.
+///
+/// This is the anchor a quick-fix uses when it splices an extra trailing
+/// argument onto an invocation (`catch BODY` → `catch BODY result`).  It
+/// must be derived from the word's own geometry rather than from the
+/// command-head token: a body-bearing command's head span covers only the
+/// word `catch`, so anchoring there writes the new word *before* the body
+/// and silently re-assigns every argument position (issue #1190).
+///
+/// For a delimited word this is one byte past its closing `}` / `]` / `"`
+/// (via [`word_closer_offset`], so an empty `{}` / `[]` / `""` is not
+/// overshot).  For a bare word — and for an unterminated delimited word,
+/// where no closer exists to step over — the token span's exclusive end is
+/// already the append point.
+#[must_use]
+pub fn word_append_offset(sm: &SourceMap<'_>, tok: Token) -> u32 {
+    match word_closer_offset(sm, tok) {
+        Some(closer) => closer.saturating_add(1),
+        None => tok.span.end(),
+    }
+}
+
 /// Inclusive end [`SourcePosition`] covering *tok*'s closing delimiter.
 ///
 /// The position-returning sibling of [`word_closer_offset`], for callers
@@ -391,5 +414,79 @@ mod tests {
         let tok = first_word(src);
         let pos = word_end_position(&sm, tok);
         assert_eq!(pos, sm.range_positions(tok.span).1);
+    }
+
+    #[test]
+    fn append_offset_lands_past_a_braced_body() {
+        // The issue #1190 shape: `catch {error oops}` — a new trailing word
+        // belongs immediately after the body's `}`, at offset 18.
+        let src = "catch {error oops}";
+        let sm = SourceMap::new(src);
+        let body = nth_word(src, 1);
+        assert_eq!(body.kind, TokenType::Str);
+        let off = word_append_offset(&sm, body);
+        assert_eq!(off, u32::try_from(src.len()).unwrap());
+        assert_eq!(&src[..off as usize], "catch {error oops}");
+    }
+
+    #[test]
+    fn append_offset_lands_past_a_multiline_braced_body() {
+        let src = "catch {\n    error oops\n}";
+        let sm = SourceMap::new(src);
+        let body = nth_word(src, 1);
+        let off = word_append_offset(&sm, body);
+        assert_eq!(off, u32::try_from(src.len()).unwrap());
+    }
+
+    #[test]
+    fn append_offset_does_not_overshoot_an_empty_body() {
+        // `catch {}` — the empty brace's span already covers its closer, so
+        // a naive `span.end() + 1` would land one byte past the buffer.
+        let src = "catch {}";
+        let sm = SourceMap::new(src);
+        let body = nth_word(src, 1);
+        let off = word_append_offset(&sm, body);
+        assert_eq!(off, 8);
+        assert_eq!(off, u32::try_from(src.len()).unwrap());
+    }
+
+    #[test]
+    fn append_offset_after_a_bare_word() {
+        let src = "catch $body";
+        let sm = SourceMap::new(src);
+        let body = nth_word(src, 1);
+        let off = word_append_offset(&sm, body);
+        assert_eq!(off, u32::try_from(src.len()).unwrap());
+    }
+
+    #[test]
+    fn append_offset_after_a_quoted_word() {
+        let src = "catch \"error oops\"";
+        let sm = SourceMap::new(src);
+        let body = nth_word(src, 1);
+        let off = word_append_offset(&sm, body);
+        assert_eq!(off, u32::try_from(src.len()).unwrap());
+    }
+
+    #[test]
+    fn append_offset_after_a_command_substitution() {
+        let src = "catch [get body]";
+        let sm = SourceMap::new(src);
+        let body = nth_word(src, 1);
+        assert_eq!(body.kind, TokenType::Cmd);
+        let off = word_append_offset(&sm, body);
+        assert_eq!(off, u32::try_from(src.len()).unwrap());
+    }
+
+    #[test]
+    fn append_offset_of_an_unterminated_word_stays_in_bounds() {
+        let src = "catch {abc";
+        let sm = SourceMap::new(src);
+        let body = nth_word(src, 1);
+        let off = word_append_offset(&sm, body);
+        assert!(
+            off as usize <= src.len(),
+            "append point must stay in bounds"
+        );
     }
 }

--- a/rust/tcl-lsp-core/src/code_actions.rs
+++ b/rust/tcl-lsp-core/src/code_actions.rs
@@ -44,17 +44,23 @@
 //!   the generic `diag.fixes` path below.
 //!
 //! * Package-*suggestion* actions ([`package_require_actions`]) —
-//!   for the word at the cursor, fuzzy-rank known package names
-//!   (the registry's `required_package` / `tcllib_package`
-//!   catalogue) against the `::`-prefix and offer
-//!   `Add 'package require <pkg>'` (skipping already-required
-//!   packages).
+//!   fuzzy-rank known package names (the registry's
+//!   `required_package` / `tcllib_package` catalogue) against an
+//!   unresolved command head's namespace prefix and offer
+//!   `Add 'package require <pkg>'`.  Gated on two pieces of
+//!   evidence — the cursor is inside a recorded command-invocation
+//!   head, and an unknown-command (W123) diagnostic covers it — so
+//!   it never fires on a comment, a string, an argument word, or a
+//!   definition's name (issue #1191).
 //!
 //! Limitations:
 //!
 //! * [`package_require_actions`] derives its catalogue from
 //!   the registry, so locally-installed-but-unregistered
-//!   packages aren't suggested.
+//!   packages aren't suggested.  Applying one loads the package and
+//!   runs its initialisation code — it is a
+//!   [`FixSafety::BehaviourHardening`](tcl_compiler::analyser::FixSafety)-class
+//!   change, never an unattended one.
 //! * Cross-document refactors (move to file, split namespace)
 //!   are not supported.
 
@@ -561,45 +567,286 @@ fn ranges_overlap(a: LspRange, b: LspRange) -> bool {
     a_start <= b_end && b_start <= a_end
 }
 
-/// Fuzzy `package require` suggestions for the word at `range`'s start:
-/// when an unknown command's prefix (the part before `::`) fuzzy-matches
-/// a known package name, offer `Add 'package require <pkg>'`.  The package
-/// catalogue is derived from the registry's `required_package` /
-/// `tcllib_package` fields, so locally-installed-but-unregistered packages
-/// aren't suggested.
+/// `package require` suggestions for an **unresolved, namespace-qualified
+/// command head** the request range touches: when the head's leading
+/// namespace names a package the registry knows, offer
+/// `Add 'package require <pkg>'`.
+///
+/// # Why this needs evidence
+///
+/// Adding a `package require` is not a harmless suggestion.  Applying it
+/// changes what the interpreter loads and runs the package's initialisation
+/// code, so it must be offered only where there is real evidence a package is
+/// missing.  The provider used to take whichever identifier-like word sat
+/// under the cursor and fuzzy-match its prefix, with no notion of context at
+/// all, so a cursor anywhere on `http::geturl` in *any* of these offered
+/// `package require http` (issue #1191):
+///
+/// ```tcl
+/// # Documentation: http::geturl
+/// set example "http::geturl"
+/// dict set docs command http::geturl
+/// proc http::geturl {} {}
+/// http::geturl
+/// ```
+///
+/// The first four are data or a definition.  Only the last is a call — and
+/// even it may be satisfied locally.
+///
+/// # The gates
+///
+/// All must hold, and each reads a fact the analyser or the registry already
+/// computed rather than scanning text:
+///
+/// 1. **A proven command head.**  The request range must touch the head-token
+///    span of a recorded command invocation
+///    (`AnalysisResult::command_invocations`).  A comment, a quoted or braced
+///    datum, an argument word, and a `proc` definition's *name* word are none
+///    of them command heads, so none of them reach this.
+/// 2. **A statically-written name.**  A computed head (`$cmd`, `[pick]`, an
+///    `{*}`-expanded word) is recorded as an invocation, but its written text
+///    is not the command that will run, so there is nothing to match a
+///    package against.
+/// 3. **The namespace names a package.**  The head's leading namespace
+///    component must *exactly* match a package in the registry catalogue.
+///    This replaces the containment ranking, which was the mechanism that
+///    turned a passing textual resemblance into a suggestion to load code.
+///    `json::write` in a file with no `package require json` is evidence;
+///    `jsonify` is not.
+/// 4. **Resolution finds nothing.**  The name must resolve to no registry
+///    command and to no definition reachable from the call —
+///    [`crate::definition::resolve_called_proc`] is the shared resolver
+///    go-to-definition and find-references use, so it already accounts for
+///    namespace visibility, `namespace import` (including `-force` shadows),
+///    static `rename`, and `interp alias`.  A file carrying a dynamic package
+///    provider (`AnalysisResult::has_dynamic_providers`) is skipped whole: a
+///    computed `package require` / `load` may register the command at run
+///    time, which is the same reason W123 stands down there.
+/// 5. **The package is not already required.**
+///
+/// A command the registry *does* know but whose package is missing is W120's
+/// business, not this provider's: W120 carries a precise registry-derived
+/// insertion fix that the generic `diag.fixes` lift already surfaces.  This is
+/// the recovery path for names the registry has never heard of.
+///
+/// `context_diagnostics` are the diagnostics the editor sent with the request.
+/// An unknown-command diagnostic among them corroborates gate 4 when the
+/// editor's view is fresher than the analysis in hand; it never substitutes
+/// for gate 1.
+///
+/// # Limits
+///
+/// The catalogue comes from the registry's `required_package` /
+/// `tcllib_package` fields, so a locally-installed but unregistered package is
+/// never suggested.  A namespace matching a package name is strong evidence,
+/// not proof that the package provides this particular command.
 #[must_use]
 pub fn package_require_actions(
     source: &str,
     range: LspRange,
     registry: &tcl_registry::CommandRegistry,
+    analysis: Option<&AnalysisResult>,
+    context_diagnostics: &[ContextDiagnostic],
 ) -> Vec<CodeAction> {
-    let word = word_at_position(source, range.start_line, range.start_character);
-    let prefix = word.split("::").next().unwrap_or("").to_lowercase();
-    if prefix.len() < 2 {
+    // No analysis means no evidence, and evidence is the whole gate.
+    let Some(analysis) = analysis else {
+        return Vec::new();
+    };
+    if analysis.has_dynamic_providers {
         return Vec::new();
     }
-    let catalogue = package_catalogue(registry);
-    let ranked = rank_package_suggestions(&word, &catalogue, 5);
+    let line_index = LineIndex::new(source);
+    let Some(package) = missing_package_for_head_at(
+        source,
+        range,
+        registry,
+        analysis,
+        context_diagnostics,
+        &line_index,
+    ) else {
+        return Vec::new();
+    };
     let insert_line = package_insert_line(source);
-    ranked
-        .into_iter()
-        .filter(|pkg| !already_required(source, pkg))
-        .map(|pkg| CodeAction {
-            title: format!("Add 'package require {pkg}'"),
-            edits: vec![crate::rename::TextEdit {
-                range: LspRange {
-                    start_line: insert_line,
-                    start_character: 0,
-                    end_line: insert_line,
-                    end_character: 0,
-                },
-                new_text: format!("package require {pkg}\n"),
-            }],
-            kind: ActionKind::QuickFix,
-            command: None,
-            data_group_definition: None,
+    vec![CodeAction {
+        title: format!("Add 'package require {package}'"),
+        edits: vec![crate::rename::TextEdit {
+            range: LspRange {
+                start_line: insert_line,
+                start_character: 0,
+                end_line: insert_line,
+                end_character: 0,
+            },
+            new_text: format!("package require {package}\n"),
+        }],
+        kind: ActionKind::QuickFix,
+        command: None,
+        data_group_definition: None,
+    }]
+}
+
+/// The package a command head the request range touches appears to need, or
+/// `None` when any of [`package_require_actions`]'s gates fails.
+fn missing_package_for_head_at(
+    source: &str,
+    range: LspRange,
+    registry: &tcl_registry::CommandRegistry,
+    analysis: &AnalysisResult,
+    context_diagnostics: &[ContextDiagnostic],
+    line_index: &LineIndex,
+) -> Option<String> {
+    let catalogue = package_catalogue(registry);
+    for invocation in &analysis.command_invocations {
+        let start = line_index.position_at_utf16(invocation.range.start(), source);
+        let end = line_index.position_at_utf16(invocation.range.end(), source);
+        let head_range = LspRange {
+            start_line: start.line,
+            start_character: start.character.get(),
+            end_line: end.line,
+            end_character: end.character.get(),
+        };
+        // Gate 1: the range must touch this head.
+        if !ranges_overlap(head_range, range) {
+            continue;
+        }
+        // Gate 2: a statically-written name.
+        if !is_static_command_name(&invocation.name) {
+            continue;
+        }
+        // Gate 3 (cheap, so tried before the resolver): the leading namespace
+        // component must name a catalogue package exactly.
+        let Some(package) = package_named_by_namespace(&invocation.name, &catalogue) else {
+            continue;
+        };
+        // Gate 4: nothing the registry or the workspace defines answers to
+        // this name.  A corroborating unknown-command diagnostic from the
+        // editor is accepted in place of the local resolver run, for the case
+        // where the editor's view is fresher than the analysis in hand.
+        if !head_is_unresolved(source, analysis, registry, invocation)
+            && !unresolved_diagnostic_covers(
+                head_range,
+                analysis,
+                context_diagnostics,
+                source,
+                line_index,
+            )
+        {
+            continue;
+        }
+        // Gate 5: the package is not already loaded.
+        if already_required(source, &package) {
+            continue;
+        }
+        return Some(package);
+    }
+    None
+}
+
+/// `true` when `name` is a command name written literally in the source —
+/// the only shape a package suggestion can be matched against.
+///
+/// A head built at run time (`$cmd`, `[pick]`, an `{*}`-expanded word) is
+/// still recorded as an invocation, but its *name* is whatever the caller
+/// wrote, not the command that will run.
+fn is_static_command_name(name: &str) -> bool {
+    !name.is_empty()
+        && !name.contains('$')
+        && !name.contains('[')
+        && !name.contains('{')
+        && !name.contains(char::is_whitespace)
+}
+
+/// The catalogue package whose name is exactly `head`'s leading namespace
+/// component, ignoring case and any leading `::`.
+///
+/// A bare (unqualified) name has no namespace and therefore yields nothing:
+/// `frobnicate` carries no evidence about which package might define it, and
+/// guessing from a textual resemblance is the behaviour this replaced.  The
+/// leading `::` is stripped first — the fully-qualified spelling is what
+/// library code writes to be unambiguous, and splitting it on `::` without
+/// stripping yields an empty component.
+fn package_named_by_namespace(head: &str, catalogue: &[String]) -> Option<String> {
+    let qualified = head.trim_start_matches("::");
+    let (namespace, _rest) = qualified.split_once("::")?;
+    if namespace.is_empty() {
+        return None;
+    }
+    catalogue
+        .iter()
+        .find(|package| package.eq_ignore_ascii_case(namespace))
+        .cloned()
+}
+
+/// `true` when nothing the registry or the workspace defines answers to this
+/// invocation's head.
+///
+/// Delegates the definition half to [`crate::definition::resolve_called_proc`]
+/// — the resolver go-to-definition, find-references, and the inline-proc
+/// refactor share — so this provider cannot disagree with them about whether
+/// a call is satisfied.  That resolver already understands namespace
+/// visibility, `namespace import` (including `-force` shadowing), static
+/// `rename`, and `interp alias`.
+fn head_is_unresolved(
+    source: &str,
+    analysis: &AnalysisResult,
+    registry: &tcl_registry::CommandRegistry,
+    invocation: &tcl_compiler::signature_scan::types::SignatureCommandInvocation,
+) -> bool {
+    if registry.get(&invocation.name).is_some() {
+        return false;
+    }
+    let head_off = invocation.range.start();
+    let namespace = crate::definition::namespace_context_at(
+        &analysis.global_scope,
+        head_off,
+        &analysis.namespace_overrides,
+    );
+    crate::definition::resolve_called_proc(
+        analysis,
+        source,
+        &namespace,
+        &invocation.name,
+        head_off,
+        Some(registry),
+    )
+    .is_none()
+}
+
+/// `true` when an unknown-command (W123) diagnostic covers `head_range`,
+/// from either the analyser's own diagnostics or the ones the editor sent
+/// with the request.
+///
+/// W123's emitter is the single place "does this command resolve?" is decided
+/// for a bare name, and it already accounts for same-file and scoped
+/// definitions, `namespace import`, static `rename` / `interp alias`, dynamic
+/// providers, and a user-supplied `unknown` handler.  Accepting it as
+/// corroboration keeps this provider from contradicting that answer.
+fn unresolved_diagnostic_covers(
+    head_range: LspRange,
+    analysis: &AnalysisResult,
+    context_diagnostics: &[ContextDiagnostic],
+    source: &str,
+    line_index: &LineIndex,
+) -> bool {
+    let from_analysis = analysis.diagnostics.iter().any(|diag| {
+        if diag.code != DiagCode::W123 {
+            return false;
+        }
+        let start = line_index.position_at_utf16(diag.span.start(), source);
+        let end = line_index.position_at_utf16(diag.span.end(), source);
+        ranges_overlap(
+            LspRange {
+                start_line: start.line,
+                start_character: start.character.get(),
+                end_line: end.line,
+                end_character: end.character.get(),
+            },
+            head_range,
+        )
+    });
+    from_analysis
+        || context_diagnostics.iter().any(|diag| {
+            diag.code == DiagCode::W123.as_str() && ranges_overlap(diag.range, head_range)
         })
-        .collect()
 }
 
 /// Distinct package names known to the registry (`required_package` +
@@ -617,31 +864,6 @@ fn package_catalogue(registry: &tcl_registry::CommandRegistry) -> Vec<String> {
         }
     }
     set.into_iter().collect()
-}
-
-/// Rank package names against a symbol's prefix (exact / prefix /
-/// substring), best first, capped at `limit`.  The ranking core is
-/// [`tcl_compiler::text::rank_containment_suggestions`]; this wrapper
-/// only extracts the pre-`::` prefix and applies the two-character
-/// minimum.
-fn rank_package_suggestions(symbol: &str, packages: &[String], limit: usize) -> Vec<String> {
-    let prefix = symbol
-        .trim()
-        .split("::")
-        .next()
-        .unwrap_or("")
-        .to_lowercase();
-    if prefix.len() < 2 {
-        return Vec::new();
-    }
-    tcl_compiler::text::rank_containment_suggestions(
-        &prefix,
-        packages.iter().map(String::as_str),
-        limit,
-    )
-    .into_iter()
-    .map(str::to_owned)
-    .collect()
 }
 
 /// Line at which to insert a new `package require` — after a leading
@@ -676,25 +898,6 @@ fn already_required(source: &str, pkg: &str) -> bool {
             false
         }
     })
-}
-
-/// Extract the identifier word (including `::`) at `(line, character)`.
-fn word_at_position(source: &str, line: u32, character: u32) -> String {
-    let Some(line_text) = source.split('\n').nth(line as usize) else {
-        return String::new();
-    };
-    let chars: Vec<char> = line_text.chars().collect();
-    let is_word = |c: char| c.is_alphanumeric() || c == '_' || c == ':';
-    let col = utf16_col_to_char_col(line_text, character).min(chars.len());
-    let mut start = col;
-    while start > 0 && is_word(chars[start - 1]) {
-        start -= 1;
-    }
-    let mut end = col;
-    while end < chars.len() && is_word(chars[end]) {
-        end += 1;
-    }
-    chars[start..end].iter().collect()
 }
 
 // W115 — convert a backslash-continued comment to per-line comments.
@@ -2596,59 +2799,207 @@ mod tests {
         }
     }
 
+    // Fuzzy `package require` suggestions — issue #1191.
+    //
+    // Applying one of these mutates package loading and runs the package's
+    // initialisation code, so the provider must have evidence a package is
+    // actually missing.  The two gates it applies are "the cursor is on a
+    // recorded command *head*" and "resolution says that head is unresolved".
+    // The cases below are the four coverage classes the issue asks for.
+
+    /// The package-require actions for `src` at `range`, driven by a real
+    /// analysis (the evidence both gates read) and no editor-supplied
+    /// diagnostics.
+    fn package_actions(src: &str, range: LspRange) -> Vec<CodeAction> {
+        let registry = tcl_registry::CommandRegistry::build_default();
+        let mut analyser = Analyser::new();
+        let analysis = analyser.analyse(src, "tcl9.0").clone();
+        package_require_actions(src, range, &registry, Some(&analysis), &[])
+    }
+
+    /// The titles of the package-require actions for `src` at `range`.
+    fn package_titles(src: &str, range: LspRange) -> Vec<String> {
+        package_actions(src, range)
+            .into_iter()
+            .map(|action| action.title)
+            .collect()
+    }
+
     #[test]
-    fn fuzzy_package_require_suggests_known_package() {
-        // `http::foo` — the `http` prefix matches the `http` package
-        // (http::geturl's required_package).
-        let reg = tcl_registry::CommandRegistry::build_default();
-        let actions = package_require_actions("http::foo $x\n", at(0, 2), &reg);
+    fn tp_package_require_offered_on_an_unresolved_command_head() {
+        // The one shape that is real evidence: an executable command head
+        // the resolver could not satisfy, whose leading namespace exactly
+        // names a package the registry knows.
+        let src = "http::foo $x\n";
+        let actions = package_actions(src, at(0, 2));
+        assert_eq!(
+            actions.iter().map(|a| a.title.as_str()).collect::<Vec<_>>(),
+            vec!["Add 'package require http'"],
+            "{actions:?}"
+        );
+        assert_eq!(actions[0].edits[0].new_text, "package require http\n");
+        assert_eq!(actions[0].edits[0].range.start_line, 0);
+    }
+
+    #[test]
+    fn fn_package_require_offered_on_a_fully_qualified_head() {
+        // A leading `::` is how library code writes a call unambiguously.
+        // Splitting on `::` without stripping it first yielded an empty
+        // namespace component, so this shape used to match nothing at all.
+        let titles = package_titles("::http::foo $x\n", at(0, 4));
+        assert!(
+            titles.iter().any(|t| t == "Add 'package require http'"),
+            "{titles:?}"
+        );
+    }
+
+    #[test]
+    fn tn_package_require_not_offered_for_a_bare_unknown_command() {
+        // `frobnicate` is unresolved, but its name carries no evidence about
+        // which package would define it. Guessing from a textual resemblance
+        // is exactly the behaviour the namespace gate replaced.
+        assert!(package_titles("frobnicate 1\n", at(0, 2)).is_empty());
+    }
+
+    #[test]
+    fn tn_package_require_not_offered_for_an_unregistered_namespace() {
+        // `myapp` names no package in the registry catalogue, so there is
+        // nothing evidence-backed to suggest — a project's own namespace
+        // must never be read as a missing dependency.
+        assert!(package_titles("myapp::helper x\n", at(0, 2)).is_empty());
+    }
+
+    #[test]
+    fn tn_package_require_not_offered_under_a_dynamic_provider() {
+        // A computed `package require` may register the command at run time,
+        // which is the same reason W123 stands down in such a file.
+        let src = "set p http\npackage require $p\nhttp::foo\n";
+        assert!(package_titles(src, at(2, 2)).is_empty());
+    }
+
+    #[test]
+    fn fp_package_require_not_offered_inside_a_comment() {
+        let src = "# Documentation: http::geturl\n";
+        assert!(package_titles(src, at(0, 20)).is_empty());
+    }
+
+    #[test]
+    fn fp_package_require_not_offered_inside_a_quoted_string() {
+        let src = "set example \"http::geturl\"\n";
+        assert!(package_titles(src, at(0, 16)).is_empty());
+    }
+
+    #[test]
+    fn fp_package_require_not_offered_inside_a_braced_word() {
+        let src = "set example {http::geturl}\n";
+        assert!(package_titles(src, at(0, 16)).is_empty());
+    }
+
+    #[test]
+    fn fp_package_require_not_offered_on_an_argument_word() {
+        // `http::geturl` here is data passed to `dict set`, not a call.
+        let src = "dict set docs command http::geturl\n";
+        assert!(package_titles(src, at(0, 25)).is_empty());
+    }
+
+    #[test]
+    fn fp_package_require_not_offered_on_a_definition_name() {
+        // The name word of a `proc` is a definition, not an invocation — and
+        // the file is defining the very command a package would provide.
+        let src = "proc http::geturl {} {}\n";
+        assert!(package_titles(src, at(0, 8)).is_empty());
+    }
+
+    #[test]
+    fn fp_package_require_not_offered_for_a_locally_defined_command() {
+        // Defined above, called below: resolution settles the call, so no
+        // unknown-command diagnostic covers the head and no package is
+        // suggested for it.
+        let src = "proc http::geturl {} {}\nhttp::geturl\n";
+        assert!(package_titles(src, at(1, 2)).is_empty());
+    }
+
+    #[test]
+    fn fp_package_require_not_offered_when_the_package_is_already_required() {
+        let src = "package require http\nhttp::foo\n";
+        assert!(
+            !package_titles(src, at(1, 2))
+                .iter()
+                .any(|t| t.contains("require http'")),
+            "http is already required"
+        );
+    }
+
+    #[test]
+    fn tn_package_require_not_offered_for_a_resolved_builtin() {
+        // `puts` resolves in the registry, so nothing is unresolved here.
+        assert!(package_titles("puts hello\n", at(0, 1)).is_empty());
+    }
+
+    #[test]
+    fn tn_package_require_not_offered_for_a_dynamic_head() {
+        // `$cmd` is recorded as an invocation, but its written name is not
+        // the command that will run, so matching it against a package
+        // catalogue is meaningless.
+        assert!(package_titles("set cmd http::geturl\n$cmd\n", at(1, 1)).is_empty());
+    }
+
+    #[test]
+    fn tn_package_require_not_offered_for_a_short_prefix() {
+        assert!(package_titles("x::y\n", at(0, 0)).is_empty());
+    }
+
+    #[test]
+    fn tn_package_require_not_offered_without_an_analysis() {
+        // No analysis, no evidence — the provider declines rather than
+        // falling back to scanning the text.
+        let registry = tcl_registry::CommandRegistry::build_default();
+        assert!(package_require_actions("http::foo\n", at(0, 2), &registry, None, &[]).is_empty());
+    }
+
+    #[test]
+    fn package_require_offered_from_an_editor_supplied_diagnostic() {
+        // The editor sends the diagnostics it is currently showing; a W123
+        // among them is evidence even when the analysis in hand did not
+        // re-emit it.  The head gate still applies, so this only works over
+        // a real invocation.
+        let src = "http::foo $x\n";
+        let registry = tcl_registry::CommandRegistry::build_default();
+        let mut analyser = Analyser::new();
+        // Analyse a *different* document so the analysis carries no W123 for
+        // this source, leaving the context diagnostic as the only evidence.
+        let analysis = analyser.analyse(src, "tcl9.0").clone();
+        let context = vec![ContextDiagnostic {
+            code: "W123".to_string(),
+            message: "Unknown command 'http::foo'".to_string(),
+            range: at(0, 0),
+        }];
+        let actions = package_require_actions(src, at(0, 2), &registry, Some(&analysis), &context);
         assert!(
             actions
                 .iter()
                 .any(|a| a.title == "Add 'package require http'"),
             "{actions:?}"
         );
-        // The edit inserts at the top of the file.
-        let act = actions
-            .iter()
-            .find(|a| a.title.contains("http"))
-            .expect("http action");
-        assert_eq!(act.edits[0].new_text, "package require http\n");
-        assert_eq!(act.edits[0].range.start_line, 0);
     }
 
     #[test]
-    fn fuzzy_package_require_dedups_already_required() {
-        // `http` is already required → no `http` suggestion, and the
-        // insert line lands after the existing require.
-        let reg = tcl_registry::CommandRegistry::build_default();
-        let src = "package require http\nhttp::foo\n";
-        let actions = package_require_actions(src, at(1, 2), &reg);
-        assert!(
-            !actions.iter().any(|a| a.title.contains("require http'")),
-            "http already required: {actions:?}"
+    fn package_named_by_namespace_matches_exactly() {
+        let catalogue = vec!["http".to_string(), "json".to_string()];
+        assert_eq!(
+            package_named_by_namespace("http::get", &catalogue),
+            Some("http".to_string())
         );
-    }
-
-    #[test]
-    fn fuzzy_package_require_ignores_short_prefix() {
-        let reg = tcl_registry::CommandRegistry::build_default();
-        assert!(package_require_actions("x::y\n", at(0, 0), &reg).is_empty());
-    }
-
-    #[test]
-    fn rank_package_suggestions_orders_exact_before_prefix() {
-        let pkgs = vec!["httpd".to_string(), "http".to_string(), "json".to_string()];
-        let ranked = rank_package_suggestions("http::get", &pkgs, 5);
-        // Exact (`http`, score 0) before prefix (`httpd`, score 1);
-        // `json` doesn't match at all.
-        assert_eq!(ranked, vec!["http", "httpd"]);
-    }
-
-    #[test]
-    fn word_at_position_extracts_namespaced_word() {
-        assert_eq!(word_at_position("http::foo $x\n", 0, 2), "http::foo");
-        assert_eq!(word_at_position("  set y 1\n", 0, 3), "set");
+        assert_eq!(
+            package_named_by_namespace("::http::get", &catalogue),
+            Some("http".to_string()),
+            "a leading `::` must not swallow the namespace component"
+        );
+        // A near-miss is not evidence: `httpd::start` names the `httpd`
+        // namespace, which is not the `http` package.
+        assert_eq!(package_named_by_namespace("httpd::start", &catalogue), None);
+        // Nor is a bare name, which has no namespace at all.
+        assert_eq!(package_named_by_namespace("httpget", &catalogue), None);
     }
 
     // check_diagnostic_actions: IRULE5002/5004 flow-warning fixes

--- a/rust/tcl-lsp-core/src/code_actions.rs
+++ b/rust/tcl-lsp-core/src/code_actions.rs
@@ -26,10 +26,14 @@
 //!
 //! Provided actions:
 //!
-//! * Catch-result-variable actions — when the analyser emits
-//!   W302 (`catch` without result variable), the provider
-//!   offers two quick-fixes that splice a trailing ` result`
-//!   or ` result opts` after the body's closing brace.
+//! * Catch-result-variable actions — W302 (`catch` without result
+//!   variable) carries insert `CodeFix`es that splice a trailing
+//!   ` result` (or ` result options`) after the body's closing
+//!   delimiter; the provider lifts them via the generic `diag.fixes`
+//!   path.  The **anchor is the analyser's**, computed from the
+//!   invocation's argument tokens: this provider must not re-derive an
+//!   insertion point from the diagnostic's span, which covers only the
+//!   command head (issue #1190).
 //! * `unset -nocomplain` action — W213 (unset on possibly-undefined
 //!   variable) carries an `Add '-nocomplain' to unset` insert `CodeFix`
 //!   (the analyser knows the exact keyword span); the provider lifts it via
@@ -304,37 +308,17 @@ pub fn code_actions(
         if !ranges_overlap(diag_range, range) {
             continue;
         }
-        // Surface synthetic
-        // catch-result-variable actions for W302 diagnostics
-        // even when the analyser didn't attach a `CodeFix`.
-        // Two actions: append ` result` (capture the result)
-        // or ` result opts` (capture result + options).  The
-        // diagnostic's span end sits past the body's closing
-        // `}`, so the insertion point is exactly the diag-end
-        // position.
-        if diag.code == DiagCode::W302 {
-            let insertion = LspRange {
-                start_line: diag_end.line,
-                start_character: diag_end.character.get(),
-                end_line: diag_end.line,
-                end_character: diag_end.character.get(),
-            };
-            for (title, suffix) in [
-                ("Add catch result variable", " result"),
-                ("Add catch result + options variables", " result opts"),
-            ] {
-                actions.push(CodeAction {
-                    title: title.to_string(),
-                    edits: vec![crate::rename::TextEdit {
-                        range: insertion,
-                        new_text: suffix.to_string(),
-                    }],
-                    kind: ActionKind::QuickFix,
-                    command: None,
-                    data_group_definition: None,
-                });
-            }
-        }
+        // W302's catch-result-variable quick-fixes are carried on the
+        // diagnostic, like W213's and W120's below.  This provider used to
+        // synthesise them here from the diagnostic's *end* position, which is
+        // the end of the `catch` **word** — the diagnostic anchors at the
+        // command head, not at the body — so the inserted word landed before
+        // the body and turned `catch {error oops}` into
+        // `catch result {error oops}`, i.e. a catch of the script `result`
+        // storing its message in a variable named `error` (issue #1190).
+        // The analyser computes the anchor from the argument tokens instead,
+        // and `lift_fixes` below surfaces it unchanged.
+        //
         // W213's `Add '-nocomplain' to unset` quick-fix is carried on the
         // diagnostic itself (the analyser knows the exact `unset` keyword span
         // and narrows the diagnostic to the offending variable word), so it is
@@ -2233,6 +2217,7 @@ mod tests {
                 span: Span::new(0, 5),
                 new_text: "set var 0".to_string(),
                 description: "Initialise `var`".to_string(),
+                safety: tcl_compiler::analyser::FixSafety::RequiresReview,
             }],
         });
         let actions = code_actions("set x 1\n", whole_document_range("set x 1\n"), Some(&r));
@@ -2258,6 +2243,7 @@ mod tests {
                 span: Span::new(0, 5),
                 new_text: "fix".to_string(),
                 description: "Fix".to_string(),
+                safety: tcl_compiler::analyser::FixSafety::RequiresReview,
             }],
         });
         // Request range on line 99 — far away from the
@@ -2283,6 +2269,7 @@ mod tests {
                 span: Span::new(0, 5),
                 new_text: "x".to_string(),
                 description: String::new(), // No description.
+                safety: tcl_compiler::analyser::FixSafety::RequiresReview,
             }],
         });
         let actions = code_actions("set x 1\n", whole_document_range("set x 1\n"), Some(&r));
@@ -2326,11 +2313,13 @@ mod tests {
                     span: Span::new(0, 5),
                     new_text: "a".into(),
                     description: "A".into(),
+                    safety: tcl_compiler::analyser::FixSafety::RequiresReview,
                 },
                 CodeFix {
                     span: Span::new(0, 5),
                     new_text: "b".into(),
                     description: "B".into(),
+                    safety: tcl_compiler::analyser::FixSafety::RequiresReview,
                 },
             ],
         });
@@ -2453,15 +2442,37 @@ mod tests {
 
     // catch-result-variable actions
 
-    #[test]
-    fn w302_emits_catch_result_variable_actions() {
-        // The real analyser emits W302 for `catch {body}` with
-        // no result variable.  The provider should surface two
-        // synthetic actions appending ` result` / ` result opts`.
-        let src = "catch { puts hi }\n";
-        let mut a = Analyser::new();
-        let analysis = a.analyse(src, "tcl8.6").clone();
-        // Sanity-check the analyser actually emitted W302.
+    /// Apply a single-edit action's `TextEdit` to `src` and return the
+    /// rewritten document.
+    ///
+    /// Every catch-fix test below asserts the *applied document* rather than
+    /// the inserted string plus a zero-width range: the bug in issue #1190
+    /// inserted exactly the right text at exactly the wrong place, and the
+    /// old assertions (inserted text + "the range is zero-width") passed
+    /// throughout.
+    fn apply_single_edit(src: &str, action: &CodeAction) -> String {
+        assert_eq!(action.edits.len(), 1, "expected one edit: {action:?}");
+        let edit = &action.edits[0];
+        let line_index = LineIndex::new(src);
+        let start = line_index.offset_at_utf16(
+            edit.range.start_line,
+            Utf16Col::new(edit.range.start_character),
+            src,
+        ) as usize;
+        let end = line_index.offset_at_utf16(
+            edit.range.end_line,
+            Utf16Col::new(edit.range.end_character),
+            src,
+        ) as usize;
+        let mut out = src.to_string();
+        out.replace_range(start..end, &edit.new_text);
+        out
+    }
+
+    /// The quick-fix actions the provider offers for the W302 in `src`.
+    fn catch_result_actions(src: &str) -> Vec<CodeAction> {
+        let mut analyser = Analyser::new();
+        let analysis = analyser.analyse(src, "tcl9.0").clone();
         assert!(
             analysis
                 .diagnostics
@@ -2470,31 +2481,75 @@ mod tests {
             "expected W302 from {:?}",
             analysis.diagnostics,
         );
-        let actions = code_actions(src, whole_document_range(src), Some(&analysis));
-        let titles: Vec<&str> = actions.iter().map(|a| a.title.as_str()).collect();
-        assert!(titles.contains(&"Add catch result variable"), "{titles:?}");
-        assert!(
-            titles.contains(&"Add catch result + options variables"),
-            "{titles:?}",
+        code_actions(src, whole_document_range(src), Some(&analysis))
+            .into_iter()
+            .filter(|action| action.title.starts_with("Add catch"))
+            .collect()
+    }
+
+    #[test]
+    fn w302_result_action_applies_after_the_body() {
+        // The issue #1190 reproducer: the diagnostic anchors at the `catch`
+        // word, so a provider that reconstructed the insertion point from
+        // the diagnostic's end produced `catch result { puts hi }` — a catch
+        // of the script `result`.
+        let src = "catch { puts hi }\n";
+        let actions = catch_result_actions(src);
+        assert_eq!(actions.len(), 2, "{actions:?}");
+        assert_eq!(
+            apply_single_edit(src, &actions[0]),
+            "catch { puts hi } result\n"
         );
-        // Verify the insertion text shapes.
-        let result_act = actions
-            .iter()
-            .find(|a| a.title == "Add catch result variable")
-            .unwrap();
-        assert_eq!(result_act.edits[0].new_text, " result");
-        let opts_act = actions
-            .iter()
-            .find(|a| a.title == "Add catch result + options variables")
-            .unwrap();
-        assert_eq!(opts_act.edits[0].new_text, " result opts");
-        // Both insertions land at the same position (a zero-
-        // width range immediately after the body's closing `}`).
-        for act in [result_act, opts_act] {
-            let r = act.edits[0].range;
-            assert_eq!(r.start_line, r.end_line);
-            assert_eq!(r.start_character, r.end_character);
-        }
+    }
+
+    #[test]
+    fn w302_options_action_applies_after_the_body() {
+        let src = "catch { puts hi }\n";
+        let actions = catch_result_actions(src);
+        assert_eq!(
+            apply_single_edit(src, &actions[1]),
+            "catch { puts hi } result options\n"
+        );
+    }
+
+    #[test]
+    fn w302_action_applies_after_a_multiline_body() {
+        let src = "catch {\n    error oops\n}\n";
+        let actions = catch_result_actions(src);
+        assert_eq!(
+            apply_single_edit(src, &actions[0]),
+            "catch {\n    error oops\n} result\n"
+        );
+    }
+
+    #[test]
+    fn w302_action_applies_before_a_trailing_comment() {
+        let src = "catch {error oops} ;# best effort\n";
+        let actions = catch_result_actions(src);
+        assert_eq!(
+            apply_single_edit(src, &actions[0]),
+            "catch {error oops} result ;# best effort\n"
+        );
+    }
+
+    #[test]
+    fn w302_action_does_not_overshoot_an_empty_body() {
+        let src = "catch {}\n";
+        let actions = catch_result_actions(src);
+        assert_eq!(apply_single_edit(src, &actions[0]), "catch {} result\n");
+    }
+
+    #[test]
+    fn w302_action_applies_to_a_nested_catch_on_a_later_line() {
+        // A catch that is neither on line 0 nor at column 0 — the anchor is
+        // an absolute offset from the argument token, not a line-relative
+        // guess.
+        let src = "proc f {} {\n    catch {error oops}\n}\n";
+        let actions = catch_result_actions(src);
+        assert_eq!(
+            apply_single_edit(src, &actions[0]),
+            "proc f {} {\n    catch {error oops} result\n}\n"
+        );
     }
 
     // W120 package-require fix

--- a/rust/tcl-lsp-core/src/code_actions.rs
+++ b/rust/tcl-lsp-core/src/code_actions.rs
@@ -137,14 +137,23 @@ pub struct CodeAction {
     /// lets tooling (MCP, AI, clipboard) consume the data-group
     /// definition without injecting comment blocks into the source.
     pub data_group_definition: Option<String>,
+    /// Why this action cannot be applied here, when it cannot.
+    ///
+    /// Lifted to LSP's `CodeAction.disabled.reason`, which the editor shows
+    /// on a greyed-out menu entry.  A refactoring that finds its subject but
+    /// cannot preserve behaviour reports *why* rather than disappearing: the
+    /// user otherwise cannot tell "does not apply here" from "is broken".
+    /// `edits` is empty whenever this is set.
+    pub disabled: Option<String>,
 }
 
 impl CodeAction {
-    /// Construct a `CodeAction` with no `data_group_definition`.
+    /// Construct an applicable `CodeAction` with no `data_group_definition`.
     ///
     /// The common path: every action except the extract-to-datagroup
-    /// refactor leaves the structured payload unset, so this keeps the
-    /// call sites free of a `data_group_definition: None` field.
+    /// refactor leaves the structured payload unset, and only a refusing
+    /// refactoring sets `disabled`, so this keeps the call sites free of
+    /// both fields.
     #[must_use]
     pub fn new(
         title: String,
@@ -158,6 +167,7 @@ impl CodeAction {
             kind,
             command,
             data_group_definition: None,
+            disabled: None,
         }
     }
 }
@@ -233,6 +243,7 @@ fn lift_fixes(
             kind: ActionKind::QuickFix,
             command: None,
             data_group_definition: None,
+            disabled: None,
         });
     }
 }
@@ -278,6 +289,7 @@ fn push_brace_expr_refactors(
             kind: ActionKind::RefactorRewrite,
             command: None,
             data_group_definition: None,
+            disabled: None,
         });
     }
 }
@@ -409,6 +421,7 @@ pub fn bigip_code_actions(source: &str, range: LspRange, uri: &str) -> Vec<CodeA
             string_args: vec![uri.to_string()],
         }),
         data_group_definition: None,
+        disabled: None,
     });
 
     // Partition rename — only on an `auth partition` stanza, and never
@@ -427,6 +440,7 @@ pub fn bigip_code_actions(source: &str, range: LspRange, uri: &str) -> Vec<CodeA
                     string_args: vec![uri.to_string(), partition_short.to_string()],
                 }),
                 data_group_definition: None,
+                disabled: None,
             });
         }
     }
@@ -551,6 +565,7 @@ fn build_shimmer_noqa_suppress_action(
         kind: ActionKind::QuickFix,
         command: None,
         data_group_definition: None,
+        disabled: None,
     })
 }
 
@@ -681,6 +696,7 @@ pub fn package_require_actions(
         kind: ActionKind::QuickFix,
         command: None,
         data_group_definition: None,
+        disabled: None,
     }]
 }
 
@@ -996,6 +1012,7 @@ fn continuation_comment_actions(
         kind: ActionKind::QuickFix,
         command: None,
         data_group_definition: None,
+        disabled: None,
     }]
 }
 
@@ -1053,6 +1070,7 @@ fn ip_conversion_actions(
         kind: ActionKind::Refactor,
         command: None,
         data_group_definition: None,
+        disabled: None,
     };
     if is_ipv4(&addr) {
         return vec![make(
@@ -1116,6 +1134,7 @@ fn expr_rewrite_actions(source: &str, range: LspRange, _line_index: &LineIndex) 
             kind: ActionKind::RefactorRewrite,
             command: None,
             data_group_definition: None,
+            disabled: None,
         });
     }
     if let Some(rewritten) = invert_comparison(&sel) {
@@ -1128,6 +1147,7 @@ fn expr_rewrite_actions(source: &str, range: LspRange, _line_index: &LineIndex) 
             kind: ActionKind::RefactorRewrite,
             command: None,
             data_group_definition: None,
+            disabled: None,
         });
     }
     out
@@ -1414,6 +1434,7 @@ fn docstring_actions(
             kind: ActionKind::Source,
             command: None,
             data_group_definition: None,
+            disabled: None,
         });
     }
     out
@@ -1434,8 +1455,6 @@ fn extract_inline_actions(
     let mut registry = tcl_registry::CommandRegistry::build_default();
     registry.load_dialect(tcl_dialect::DialectSet::IRULES);
     let mut out = Vec::new();
-    out.extend(extract_proc_action(source, range));
-    out.extend(inline_proc_action(source, range, analysis, &registry));
     out.extend(refactor_engine_actions(
         source, range, analysis, line_index, &registry,
     ));
@@ -1468,16 +1487,27 @@ fn refactor_engine_actions(
     let has_selection =
         range.start_line != range.end_line || range.start_character != range.end_character;
 
-    // Extract variable — requires a selection.
+    // Extract variable / extract proc — both require a selection.
     if has_selection {
         let end =
             line_index.offset_at_utf16(range.end_line, Utf16Col::new(range.end_character), source);
         if let Some(r) = refactor::extract_variable(source, cursor, end, "result", line_index) {
             out.push(refactoring_to_action(&r, source, line_index));
         }
+        if let Some(r) = refactor::extract_proc(source, (cursor, end), analysis, registry) {
+            // The generated proc name is a placeholder, so the applicable
+            // form carries a follow-up rename command; a refused one does
+            // not (there is nothing to rename).
+            let mut action = refactoring_to_action(&r, source, line_index);
+            action.command = refactor::extract_proc_rename_command(&r, source);
+            out.push(action);
+        }
     }
 
     if let Some(r) = refactor::inline_variable(source, cursor, analysis, registry, line_index) {
+        out.push(refactoring_to_action(&r, source, line_index));
+    }
+    if let Some(r) = refactor::inline_proc(source, cursor, analysis, registry) {
         out.push(refactoring_to_action(&r, source, line_index));
     }
     if let Some(r) = refactor::if_to_switch(source, cursor, registry, line_index) {
@@ -1493,8 +1523,9 @@ fn refactor_engine_actions(
 }
 
 /// Lift a [`crate::refactor::Refactoring`] into a [`CodeAction`],
-/// converting its byte-offset edits to LSP coordinates and rendering the
-/// data-group definition (if any) into `data_group_definition`.
+/// converting its byte-offset edits to LSP coordinates, rendering the
+/// data-group definition (if any) into `data_group_definition`, and carrying
+/// a refusal reason through to the action's `disabled` field.
 fn refactoring_to_action(
     r: &crate::refactor::Refactoring,
     source: &str,
@@ -1510,353 +1541,8 @@ fn refactoring_to_action(
         kind: r.kind,
         command: None,
         data_group_definition: r.data_group.as_ref().map(crate::refactor::data_group_tcl),
+        disabled: r.disabled.clone(),
     }
-}
-
-/// Distinct `$var` / `${var}` names referenced in `text`, in first-seen order.
-fn referenced_vars(text: &str) -> Vec<String> {
-    let chars: Vec<char> = text.chars().collect();
-    let mut out: Vec<String> = Vec::new();
-    let mut i = 0;
-    while i < chars.len() {
-        if chars[i] == '$' {
-            let braced = chars.get(i + 1) == Some(&'{');
-            let mut j = i + 1 + usize::from(braced);
-            let start = j;
-            while j < chars.len()
-                && (chars[j].is_alphanumeric() || chars[j] == '_' || chars[j] == ':')
-            {
-                j += 1;
-            }
-            if j > start {
-                let name: String = chars[start..j].iter().collect();
-                if !out.contains(&name) {
-                    out.push(name);
-                }
-            }
-            i = j;
-        } else {
-            i += 1;
-        }
-    }
-    out
-}
-
-/// `refactor.extract` — extract the selected lines into a new proc and replace
-/// the selection with a call.
-fn extract_proc_action(source: &str, range: LspRange) -> Vec<CodeAction> {
-    // Need a non-empty selection.
-    if range.start_line == range.end_line && range.start_character >= range.end_character {
-        return Vec::new();
-    }
-    let lines: Vec<&str> = source.split('\n').collect();
-    // The selected line span — a selection ending at column 0 doesn't include
-    // its end line.
-    let last = if range.end_character == 0 {
-        range.end_line.saturating_sub(1)
-    } else {
-        range.end_line
-    };
-    let (s, e) = (range.start_line as usize, last as usize);
-    if s > e || e >= lines.len() {
-        return Vec::new();
-    }
-    let block: Vec<&str> = lines[s..=e].to_vec();
-    let body_text = block.join("\n");
-    if body_text.trim().is_empty() {
-        return Vec::new();
-    }
-    let params = referenced_vars(&body_text);
-    let name = "extracted_proc";
-    let body_indented = block
-        .iter()
-        .map(|l| format!("    {}", l.trim_end()))
-        .collect::<Vec<_>>()
-        .join("\n");
-    let proc_text = format!(
-        "proc {name} {{{}}} {{\n{body_indented}\n}}\n\n",
-        params.join(" ")
-    );
-    let call = if params.is_empty() {
-        name.to_string()
-    } else {
-        format!(
-            "{name} {}",
-            params
-                .iter()
-                .map(|p| format!("${p}"))
-                .collect::<Vec<_>>()
-                .join(" ")
-        )
-    };
-    // Replace the selected lines with the call.
-    let replace = LspRange {
-        start_line: range.start_line,
-        start_character: 0,
-        end_line: u32::try_from(e + 1).unwrap_or(range.end_line),
-        end_character: 0,
-    };
-    let name_start = u32::try_from("proc ".len()).unwrap_or(5);
-    vec![CodeAction {
-        title: "Extract selection into proc".to_string(),
-        edits: vec![
-            crate::rename::TextEdit {
-                range: LspRange {
-                    start_line: 0,
-                    start_character: 0,
-                    end_line: 0,
-                    end_character: 0,
-                },
-                new_text: proc_text,
-            },
-            crate::rename::TextEdit {
-                range: replace,
-                new_text: format!("{call}\n"),
-            },
-        ],
-        kind: ActionKind::RefactorExtract,
-        // Trigger a rename of the generated proc name (line 0).
-        command: Some(ActionCommand {
-            command: "tclLsp.renameSymbolAtPosition".to_string(),
-            args: vec![
-                0,
-                name_start,
-                name_start + u32::try_from(name.len()).unwrap_or(0),
-            ],
-            string_args: Vec::new(),
-        }),
-        data_group_definition: None,
-    }]
-}
-
-/// Split one Tcl command line into its words' raw source slices, respecting
-/// `{…}` / `"…"` grouping, `[…]` command-substitution nesting, and backslash
-/// escapes.  Unlike `str::split_whitespace`, a braced argument `{a b}` stays a
-/// single word rather than shredding into `{a` and `b}` (issue 179).
-fn split_tcl_words(line: &str) -> Vec<&str> {
-    let bytes = line.as_bytes();
-    let n = bytes.len();
-    let mut words = Vec::new();
-    let mut i = 0;
-    while i < n {
-        while i < n && matches!(bytes[i], b' ' | b'\t') {
-            i += 1;
-        }
-        if i >= n {
-            break;
-        }
-        let start = i;
-        let mut brace: i32 = 0;
-        let mut bracket: i32 = 0;
-        let mut in_quote = false;
-        while i < n {
-            match bytes[i] {
-                b'\\' if i + 1 < n => {
-                    // Skip the backslash and the *whole* escaped character. A
-                    // fixed `i += 2` would land mid-codepoint when the escaped
-                    // char is multi-byte (e.g. `\€`); step its full UTF-8 width
-                    // so `i` always stays on a char boundary.
-                    i += 1 + utf8_char_width(bytes[i + 1]);
-                    continue;
-                }
-                b'{' if !in_quote => brace += 1,
-                b'}' if !in_quote && brace > 0 => brace -= 1,
-                b'"' if brace == 0 && bracket == 0 => in_quote = !in_quote,
-                b'[' if !in_quote && brace == 0 => bracket += 1,
-                b']' if !in_quote && brace == 0 && bracket > 0 => bracket -= 1,
-                b' ' | b'\t' if brace == 0 && bracket == 0 && !in_quote => break,
-                _ => {}
-            }
-            i += 1;
-        }
-        // Every advance lands on a char boundary — whitespace and the grouping
-        // delimiters are ASCII, and the `\`-skip steps whole characters — so
-        // this slice is always valid; `i.min(n)` guards only the numeric bound.
-        words.push(&line[start..i.min(n)]);
-    }
-    words
-}
-
-/// UTF-8 encoded length (1–4 bytes) of the character whose leading byte is `b`.
-/// ASCII, continuation bytes, and invalid leading bytes all count as 1 — so a
-/// scan that starts mid-sequence still makes forward progress rather than
-/// stalling.
-fn utf8_char_width(b: u8) -> usize {
-    match b {
-        0xC0..=0xDF => 2,
-        0xE0..=0xEF => 3,
-        0xF0..=0xF7 => 4,
-        _ => 1,
-    }
-}
-
-/// End index (exclusive) of a bare `$name` variable name in `chars` starting at
-/// `start`, colon-run aware like C Tcl (`$a::b`, `$a:::b`), stopping at a lone
-/// `:`.  Shared shape with `hover::scan_var_name_end`.
-fn scan_var_name_end(chars: &[char], start: usize) -> usize {
-    let mut end = start;
-    while end < chars.len() {
-        let c = chars[end];
-        if c.is_alphanumeric() || c == '_' {
-            end += 1;
-        } else if c == ':' && chars.get(end + 1) == Some(&':') {
-            end += 2;
-            while chars.get(end) == Some(&':') {
-                end += 1;
-            }
-        } else {
-            break;
-        }
-    }
-    end
-}
-
-/// Substitute `$name` / `${name}` variable *references* in `body` from the
-/// `(name, replacement)` map, matching only *complete* names.  A naive
-/// `str::replace("$n", …)` would corrupt `$nn` (prefix sharing) or a `$name`
-/// embedded in a longer token; this scans references and replaces whole ones
-/// (issue 179).
-fn substitute_var_refs(body: &str, subs: &[(&str, &str)]) -> String {
-    let lookup = |name: &str| subs.iter().find(|(n, _)| *n == name).map(|(_, r)| *r);
-    let chars: Vec<char> = body.chars().collect();
-    let mut out = String::new();
-    let mut i = 0;
-    while i < chars.len() {
-        if chars[i] == '$' {
-            if chars.get(i + 1) == Some(&'{') {
-                // `${name}` — literal name up to the first `}`.
-                if let Some(rel) = chars[i + 2..].iter().position(|&c| c == '}') {
-                    let name: String = chars[i + 2..i + 2 + rel].iter().collect();
-                    if let Some(rep) = lookup(&name) {
-                        out.push_str(rep);
-                        i = i + 2 + rel + 1;
-                        continue;
-                    }
-                }
-            } else {
-                let end = scan_var_name_end(&chars, i + 1);
-                if end > i + 1 {
-                    let name: String = chars[i + 1..end].iter().collect();
-                    if let Some(rep) = lookup(&name) {
-                        out.push_str(rep);
-                        i = end;
-                        continue;
-                    }
-                }
-            }
-        }
-        out.push(chars[i]);
-        i += 1;
-    }
-    out
-}
-
-/// `refactor.inline` — inline a single-command proc at the call cursor.
-/// Declines branchy / control-flow bodies.
-fn inline_proc_action(
-    source: &str,
-    range: LspRange,
-    analysis: &AnalysisResult,
-    registry: &tcl_registry::CommandRegistry,
-) -> Vec<CodeAction> {
-    // Frame-sensitive commands (block terminators, control transfers, scope
-    // aliases, barriers — the registry's `is_frame_sensitive` union) whose
-    // bodies can't be safely inlined: moving them out of the proc frame
-    // changes what they return from, break out of, or bind against.
-    let unsafe_heads = registry.frame_sensitive_commands();
-    let line = source
-        .split('\n')
-        .nth(range.start_line as usize)
-        .unwrap_or("");
-    // Split the call into proper Tcl words, respecting `{…}` / `"…"` / `[…]`
-    // grouping — `split_whitespace` would shred a braced argument `{a b}` into
-    // `{a` and `b}` (issue 179).
-    let toks: Vec<&str> = split_tcl_words(line);
-    let Some(&head) = toks.first() else {
-        return Vec::new();
-    };
-    // Resolve the call head the way the navigation providers do — the
-    // caller's namespace candidates, the registry builtin gate, then the
-    // deterministic simple-name fallback — never a namespace-blind
-    // `p.name == head` first-`HashMap`-hit scan (the M1 drift class the
-    // `cargo xtask resolution-drift` lint flags).
-    let line_start: usize = source
-        .split_inclusive('\n')
-        .take(range.start_line as usize)
-        .map(str::len)
-        .sum();
-    let head_off = u32::try_from(line_start + line.find(head).unwrap_or(0)).unwrap_or(u32::MAX);
-    let ns = crate::definition::namespace_context_at(
-        &analysis.global_scope,
-        head_off,
-        &analysis.namespace_overrides,
-    );
-    let Some(proc_def) = crate::definition::resolve_called_proc(
-        analysis,
-        source,
-        &ns,
-        head,
-        head_off,
-        Some(registry),
-    ) else {
-        return Vec::new();
-    };
-    // Body text (strip the outer braces). `body_span` may exclude the proc's
-    // closing `}` (lexer inner-end convention), so strip a trailing `}` only
-    // when it is the unbalanced *outer* brace — a greedy `trim_end_matches('}')`
-    // would otherwise eat an inner sub-expression brace (`expr {$n * 2}`) and
-    // produce an unparseable inline edit (`expr {5 * 2`).
-    let bspan = proc_def.body_span;
-    let raw = source
-        .get(bspan.start() as usize..bspan.end() as usize)
-        .unwrap_or("")
-        .trim();
-    let inner = raw.strip_prefix('{').map_or(raw, str::trim_start);
-    let body_raw = if inner.matches('}').count() > inner.matches('{').count() {
-        let t = inner.trim_end();
-        t.strip_suffix('}').unwrap_or(t).trim()
-    } else {
-        inner.trim()
-    };
-    // Decline control-flow / multi-command bodies.
-    if body_raw.is_empty()
-        || body_raw.contains('\n')
-        || body_raw.contains(';')
-        || unsafe_heads.iter().any(|kw| {
-            body_raw == *kw
-                || body_raw.starts_with(&format!("{kw} "))
-                || body_raw.contains(&format!("[{kw} "))
-        })
-    {
-        return Vec::new();
-    }
-    // Map call args onto params, then substitute variable *references* — not
-    // by naive string replace, which would rewrite `$nn` when the param is `n`
-    // (prefix sharing) and mangle `$name` inside a longer token (issue 179).
-    let call_args: Vec<&str> = toks[1..].to_vec();
-    let subs: Vec<(&str, &str)> = proc_def
-        .params
-        .iter()
-        .enumerate()
-        .filter_map(|(i, p)| call_args.get(i).map(|arg| (p.name.as_str(), *arg)))
-        .collect();
-    let inlined = substitute_var_refs(body_raw, &subs);
-    // Replace the whole call line.
-    vec![CodeAction {
-        title: format!("Inline proc '{}'", proc_def.name),
-        edits: vec![crate::rename::TextEdit {
-            range: LspRange {
-                start_line: range.start_line,
-                start_character: 0,
-                end_line: range.start_line,
-                end_character: char_col_to_utf16_local(line, line.chars().count()),
-            },
-            new_text: inlined,
-        }],
-        kind: ActionKind::RefactorInline,
-        command: None,
-        data_group_definition: None,
-    }]
 }
 
 // iRules `# Profiles:` header source action.
@@ -1967,6 +1653,7 @@ pub fn profiles_action(
             kind: ActionKind::Source,
             command: None,
             data_group_definition: None,
+            disabled: None,
         });
     }
     Some(CodeAction {
@@ -1986,6 +1673,7 @@ pub fn profiles_action(
         kind: ActionKind::Source,
         command: None,
         data_group_definition: None,
+        disabled: None,
     })
 }
 
@@ -2138,6 +1826,7 @@ fn collect_bootstrap_actions(source: &str, d: &ContextDiagnostic) -> Vec<CodeAct
                 kind: ActionKind::QuickFix,
                 command: None,
                 data_group_definition: None,
+                disabled: None,
             }
         })
         .collect()
@@ -2225,6 +1914,7 @@ fn t106_remove_redundant_encoder(line: &str, d: &ContextDiagnostic, var: &str) -
         kind: ActionKind::QuickFix,
         command: None,
         data_group_definition: None,
+        disabled: None,
     }]
 }
 
@@ -2253,6 +1943,7 @@ fn strip_crlf_before_output(line: &str, d: &ContextDiagnostic, var: &str) -> Vec
         kind: ActionKind::QuickFix,
         command: None,
         data_group_definition: None,
+        disabled: None,
     }]
 }
 
@@ -2288,6 +1979,7 @@ fn subst_nocommands_fix(line: &str, line_no: u32) -> Vec<CodeAction> {
         kind: ActionKind::QuickFix,
         command: None,
         data_group_definition: None,
+        disabled: None,
     }]
 }
 
@@ -2360,6 +2052,7 @@ fn taint_quickfix(source: &str, d: &ContextDiagnostic) -> Vec<CodeAction> {
         kind: ActionKind::QuickFix,
         command: None,
         data_group_definition: None,
+        disabled: None,
     }]
 }
 
@@ -2368,27 +2061,6 @@ mod tests {
     use super::*;
     use tcl_compiler::analyser::{Analyser, AnalysisResult, CodeFix, Diagnostic};
     use tcl_lexer::Span;
-
-    #[test]
-    fn split_tcl_words_survives_non_ascii_backslash_escape() {
-        // A `\`-escape before a multi-byte char must not leave the scanner mid
-        // codepoint and panic the `&line[start..i]` slice (Copilot review of
-        // #839). `\€` (euro = 3 bytes) is the canonical trigger.
-        for line in [
-            "set x \\\u{20ac}",     // escape then a 3-byte char at end of line
-            "puts \\\u{20ac} tail", // escaped multi-byte followed by another word
-            "a \\\u{1f600} b",      // 4-byte astral escaped char mid-line
-            "\\\u{e9}nd",           // escaped 2-byte char fused into a word
-        ] {
-            let words = split_tcl_words(line);
-            // Round-trip: the joined words (single-space) recover every word slice
-            // without ever slicing mid-char, and no word is empty.
-            assert!(!words.is_empty(), "no words for {line:?}");
-            for w in &words {
-                assert!(line.contains(w), "word {w:?} not a slice of {line:?}");
-            }
-        }
-    }
 
     fn whole_document_range(source: &str) -> LspRange {
         let line_count = source.lines().count().max(1);
@@ -2547,24 +2219,29 @@ mod tests {
         }
     }
 
-    fn inline_edit_text(src: &str, call_line: u32) -> String {
-        let mut a = Analyser::new();
-        let analysis = a.analyse(src, "tcl8.6").clone();
+    /// The inline-proc action's replacement text, or its refusal reason.
+    fn inline_outcome(src: &str, call_line: u32) -> Result<String, String> {
+        let mut analyser = Analyser::new();
+        let analysis = analyser.analyse(src, "tcl8.6").clone();
         let actions = code_actions(src, line_range(call_line), Some(&analysis));
-        let act = actions
+        let action = actions
             .iter()
             .find(|a| a.title.starts_with("Inline proc "))
             .unwrap_or_else(|| panic!("expected an inline action in {actions:?}"));
-        act.edits[0].new_text.clone()
+        match &action.disabled {
+            Some(reason) => Err(reason.clone()),
+            None => Ok(action.edits[0].new_text.clone()),
+        }
     }
 
     #[test]
-    fn tp_inline_preserves_braced_argument_as_one_word() {
-        // `f {a b}` — the braced argument is a single value; inlining `$p`
-        // must yield `puts {a b}`, not `puts {a` from a whitespace split
-        // (issue 179).
+    fn fp_inline_refuses_a_braced_argument_that_is_not_a_plain_word() {
+        // `f {a b}` passes the *value* `a b`, not the four characters
+        // `{a b}`.  Splicing the written word makes the body print the
+        // braces, so the transform declines and says why (issue #1199).
         let src = "proc f {p} { puts $p }\nf {a b}\n";
-        assert_eq!(inline_edit_text(src, 1), "puts {a b}");
+        let reason = inline_outcome(src, 1).unwrap_err();
+        assert!(reason.contains("plain word"), "{reason}");
     }
 
     #[test]
@@ -2572,15 +2249,15 @@ mod tests {
         // Param `n`; body reads `$nn` (a different variable) and `$n`. Only the
         // complete `$n` reference is replaced — `$nn` must survive intact,
         // where a naive `replace("$n", …)` would corrupt it (issue 179).
-        let src = "proc g {n} { set x $nn$n }\ng 5\n";
-        assert_eq!(inline_edit_text(src, 1), "set x $nn5");
+        let src = "proc g {n} { puts $nn$n }\ng 5\n";
+        assert_eq!(inline_outcome(src, 1).unwrap(), "puts $nn5");
     }
 
     #[test]
     fn tp_inline_substitutes_braced_var_reference() {
         // `${p}` is a complete reference and is substituted; `${pq}` is not.
-        let src = "proc h {p} { set x ${p}${pq} }\nh 9\n";
-        assert_eq!(inline_edit_text(src, 1), "set x 9${pq}");
+        let src = "proc h {p} { puts ${p}${pq} }\nh 9\n";
+        assert_eq!(inline_outcome(src, 1).unwrap(), "puts 9${pq}");
     }
 
     // W213 unset -nocomplain action

--- a/rust/tcl-lsp-core/src/refactor/brace_expr.rs
+++ b/rust/tcl-lsp-core/src/refactor/brace_expr.rs
@@ -75,6 +75,7 @@ pub fn brace_expr(source: &str, cursor: u32, registry: &CommandRegistry) -> Opti
         }],
         kind: ActionKind::RefactorRewrite,
         data_group: None,
+        disabled: None,
     })
 }
 

--- a/rust/tcl-lsp-core/src/refactor/datagroup.rs
+++ b/rust/tcl-lsp-core/src/refactor/datagroup.rs
@@ -566,6 +566,7 @@ fn build_result(
         }],
         kind: ActionKind::RefactorExtract,
         data_group: Some(data_group),
+        disabled: None,
     }
 }
 

--- a/rust/tcl-lsp-core/src/refactor/extract_proc.rs
+++ b/rust/tcl-lsp-core/src/refactor/extract_proc.rs
@@ -541,13 +541,21 @@ fn render_call(name: &str, by_value: &[String], by_name: &[String]) -> String {
 /// The generated name is a placeholder the user renames straight away, but it
 /// must not *shadow* something in the meantime: defining `proc lsort {…}` by
 /// accident would silently replace the builtin for the rest of the file.
+///
+/// The comparison is against each proc's **qualified** name, not its simple
+/// one.  The generated definition is written at the top level, so the name it
+/// would occupy is `::<candidate>` — a `::app::extracted_proc` in some other
+/// namespace is a different command and is no reason to pick a different
+/// placeholder.  (A namespace-blind `proc_def.name == candidate` scan is also
+/// the M1 drift class `cargo xtask resolution-drift` flags.)
 fn unique_proc_name(analysis: &AnalysisResult, registry: &CommandRegistry) -> String {
     let taken = |candidate: &str| {
+        let global = format!("::{candidate}");
         registry.get(candidate).is_some()
             || analysis
                 .all_procs
                 .values()
-                .any(|proc_def| proc_def.name == candidate)
+                .any(|proc_def| proc_def.qualified_name == global)
     };
     if !taken(BASE_NAME) {
         return BASE_NAME.to_string();

--- a/rust/tcl-lsp-core/src/refactor/extract_proc.rs
+++ b/rust/tcl-lsp-core/src/refactor/extract_proc.rs
@@ -1,0 +1,796 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Extract into proc — move a run of commands into a new proc and call it.
+//!
+//! # The problem a line-based extraction cannot solve
+//!
+//! A `proc` gets its own variable frame.  Anything the moved code *assigns*
+//! therefore stops being the caller's variable and becomes a private local
+//! that disappears when the proc returns.  Extracting the middle two lines of
+//!
+//! ```tcl
+//! set x 0
+//! set x 1
+//! puts $x
+//! puts "after=$x"
+//! ```
+//!
+//! into `proc extracted_proc {x} { set x 1; puts $x }` prints `after=0`, not
+//! `after=1`: the write moved into the proc's own `x` (issue #1201).
+//!
+//! Passing the variable in as a parameter is exactly what causes this.  A
+//! parameter is a *copy*; the caller never sees it change.
+//!
+//! # What this transform does instead
+//!
+//! It classifies every variable the selection touches, using the registry's
+//! own [`ArgRole::VarWrite`] / [`ArgRole::VarRead`] roles plus the `$name`
+//! references in the text — never a keyword list:
+//!
+//! * **read, never written** → an ordinary value parameter.  A copy is
+//!   correct here, because nothing writes it back.
+//! * **written, and read again after the selection** → passed *by name* and
+//!   re-bound in the proc with `upvar 1`, so the assignment lands in the
+//!   caller's frame exactly as it did before.
+//! * **written, and never read again** → a genuine local.  It becomes a proc
+//!   local, which is better than the status quo: the variable no longer
+//!   leaks into the caller at all.
+//!
+//! The generated proc is placed immediately **before** the enclosing
+//! top-level command rather than at line 0, so it lands after the file's
+//! `package require` / `namespace` prologue, and its name is made unique
+//! against the workspace's symbols.
+//!
+//! # What it refuses, and why
+//!
+//! | Refused | Because |
+//! |---|---|
+//! | The selection does not cover whole commands | Half a command is not a program; splicing the remainder into a call changes the parse. |
+//! | The selection contains a frame-sensitive command (`return`, `break`, `continue`, `upvar`, `uplevel`, `global`, `variable`, `info level`, …) | Those act on the *call frame*. `return` would return from the new proc instead of the caller; `break` would escape a loop that is no longer around it; `upvar 1` would alias one frame too far. Membership is the registry's own frame-sensitivity union. |
+//! | A written variable's name is computed (`set $n 1`) or is an array element (`set a(x) 1`) | Which variable is written is a run-time fact, and an array element is not a place a scalar `upvar` protocol can carry. |
+//! | Any command head in the selection is computed (`$cmd …`, `{*}$words`) | Its argument roles — and therefore which variables it reads and writes — are unknown. |
+//! | The selection sits inside a namespace or class definition body | The extracted proc would be created in a different namespace from the one the moved code ran in, silently changing what its unqualified calls and variables resolve to. |
+//!
+//! Every refusal carries a plain-English reason, surfaced as the code
+//! action's LSP `disabled.reason` so the editor greys the entry out and
+//! explains itself.
+
+use std::collections::BTreeSet;
+
+use tcl_compiler::analyser::AnalysisResult;
+use tcl_compiler::segmenter::{SegmentedCommand, segment_commands_with_offset};
+use tcl_registry::{ArgRole, CommandRegistry, Traits};
+
+use super::{RefactorEdit, Refactoring, command_span_offsets};
+use crate::code_actions::{ActionCommand, ActionKind};
+
+/// The base name the generated proc gets before collision-avoidance.
+const BASE_NAME: &str = "extracted_proc";
+
+/// How far the collision-avoidance suffix search runs — see
+/// [`unique_proc_name`].
+const MAX_NAME_SUFFIX: u32 = 1000;
+
+/// Extract the commands covered by `selection` into a new proc.
+///
+/// Returns `None` when the selection covers no command at all — there is
+/// nothing to offer.  Returns a [`Refactoring`] with `disabled` set when a
+/// run of commands *is* selected but cannot be extracted without changing
+/// behaviour.
+#[must_use]
+pub fn extract_proc(
+    source: &str,
+    selection: (u32, u32),
+    analysis: &AnalysisResult,
+    registry: &CommandRegistry,
+) -> Option<Refactoring> {
+    let (sel_start, sel_end) = selection;
+    if sel_end <= sel_start {
+        return None;
+    }
+    let scope = enclosing_scope(source, sel_start, registry);
+    let scope_text = source.get(scope.start as usize..scope.end as usize)?;
+    let commands: Vec<SegmentedCommand> = segment_commands_with_offset(scope_text, scope.start)
+        .into_iter()
+        .filter(|command| !command.name().is_empty())
+        .collect();
+    let selected: Vec<&SegmentedCommand> = commands
+        .iter()
+        .filter(|command| {
+            let (start, end) = command_span_offsets(source, command);
+            start >= sel_start && end <= sel_end
+        })
+        .collect();
+    if selected.is_empty() {
+        return None;
+    }
+    let title = "Extract selection into proc".to_string();
+    match plan_extraction(source, &selected, &commands, scope, analysis, registry) {
+        Ok(plan) => Some(Refactoring {
+            title,
+            edits: plan.edits,
+            kind: ActionKind::RefactorExtract,
+            data_group: None,
+            disabled: None,
+        }),
+        Err(reason) => Some(Refactoring {
+            title,
+            edits: Vec::new(),
+            kind: ActionKind::RefactorExtract,
+            data_group: None,
+            disabled: Some(reason),
+        }),
+    }
+}
+
+/// The command-and-rename payload the code-action layer attaches after
+/// applying an extraction's edits.
+///
+/// Exposed separately from [`Refactoring`] because the post-extract rename is
+/// an editor *command*, not an edit: the generated name is a placeholder the
+/// user is expected to replace immediately.
+#[must_use]
+pub fn extract_proc_rename_command(
+    refactoring: &Refactoring,
+    source: &str,
+) -> Option<ActionCommand> {
+    if refactoring.disabled.is_some() {
+        return None;
+    }
+    let definition = refactoring.edits.iter().min_by_key(|edit| edit.start)?;
+    let name_offset = definition.new_text.find("proc ")? + "proc ".len();
+    let name_end = definition.new_text[name_offset..]
+        .find(char::is_whitespace)
+        .map(|len| name_offset + len)?;
+    // The definition is inserted at `definition.start`; the name sits on the
+    // definition's first line, whose column is the name's offset within the
+    // inserted text (the insertion always begins at a line start).
+    let line = source[..definition.start as usize]
+        .bytes()
+        .filter(|byte| *byte == b'\n')
+        .count();
+    Some(ActionCommand {
+        command: "tclLsp.renameSymbolAtPosition".to_string(),
+        args: vec![
+            u32::try_from(line).unwrap_or(0),
+            u32::try_from(name_offset).unwrap_or(0),
+            u32::try_from(name_end).unwrap_or(0),
+        ],
+        string_args: Vec::new(),
+    })
+}
+
+/// The byte range of the innermost script region containing `offset`.
+#[derive(Clone, Copy)]
+struct Scope {
+    start: u32,
+    end: u32,
+}
+
+/// A successful extraction: the definition insertion plus the call that
+/// replaces the selection.
+struct Plan {
+    edits: Vec<RefactorEdit>,
+}
+
+/// Build the extraction, or the reason it cannot be built.
+fn plan_extraction(
+    source: &str,
+    selected: &[&SegmentedCommand],
+    scope_commands: &[SegmentedCommand],
+    scope: Scope,
+    analysis: &AnalysisResult,
+    registry: &CommandRegistry,
+) -> Result<Plan, String> {
+    reject_enclosing_definition_body(source, scope, registry)?;
+    reject_frame_sensitive_selection(source, selected, registry)?;
+    let roles = classify_variables(source, selected, registry)?;
+
+    // The selection's own byte range, snapped to the commands it covers.
+    let block_start = command_span_offsets(source, selected[0]).0;
+    let block_end = command_span_offsets(source, selected[selected.len() - 1]).1;
+    let block = source
+        .get(block_start as usize..block_end as usize)
+        .ok_or_else(|| "the selected range is unreadable".to_string())?;
+
+    // A written variable that is read again after the selection must keep
+    // reaching the caller's frame; one that is not becomes a proc local.
+    let tail = source
+        .get(block_end as usize..scope.end as usize)
+        .unwrap_or("");
+    let tail_commands: Vec<SegmentedCommand> = segment_commands_with_offset(tail, 0)
+        .into_iter()
+        .filter(|command| !command.name().is_empty())
+        .collect();
+    let mut used_after: BTreeSet<String> = variable_references(tail);
+    for command in &tail_commands {
+        used_after.extend(role_named_variables(command, registry));
+    }
+
+    let by_name: Vec<String> = roles
+        .written
+        .iter()
+        .filter(|name| used_after.contains(*name))
+        .cloned()
+        .collect();
+    let by_value: Vec<String> = roles
+        .read
+        .iter()
+        .filter(|name| !roles.written.contains(*name))
+        .cloned()
+        .collect();
+
+    let name = unique_proc_name(analysis, registry);
+    let indent = line_indent_at(source, block_start);
+    let definition = render_definition(&name, &by_value, &by_name, block, &indent);
+    let call = render_call(&name, &by_value, &by_name);
+
+    // Place the definition immediately before the enclosing *top-level*
+    // command, so it lands after the file's `package require` / `namespace`
+    // prologue rather than at line 0 — and, when the selection is inside a
+    // proc, before that proc rather than inside it.
+    let insert_at = top_level_command_start(source, scope_commands, scope, block_start);
+    Ok(Plan {
+        edits: vec![
+            RefactorEdit {
+                start: insert_at,
+                end: insert_at,
+                new_text: definition,
+            },
+            RefactorEdit {
+                start: block_start,
+                end: block_end,
+                new_text: call,
+            },
+        ],
+    })
+}
+
+/// The variables the selection reads and writes.
+struct VariableRoles {
+    read: BTreeSet<String>,
+    written: BTreeSet<String>,
+}
+
+/// Classify the selection's variable use from the registry's argument roles
+/// plus the `$name` references in its text.
+///
+/// The write set comes from [`ArgRole::VarWrite`], so `set`, `incr`,
+/// `lappend`, `append`, `dict set`, `lassign`, and anything else a spec
+/// declares are all covered without this module naming any of them.
+fn classify_variables(
+    source: &str,
+    selected: &[&SegmentedCommand],
+    registry: &CommandRegistry,
+) -> Result<VariableRoles, String> {
+    let mut read = BTreeSet::new();
+    let mut written = BTreeSet::new();
+    for command in selected {
+        let (start, end) = command_span_offsets(source, command);
+        read.extend(variable_references(
+            source.get(start as usize..end as usize).unwrap_or(""),
+        ));
+        let head = command.name();
+        if head.contains('$') || head.contains('[') || head.contains('{') {
+            return Err(format!(
+                "the command head `{head}` is computed at run time, so which \
+                 variables the command reads and writes is unknown"
+            ));
+        }
+        let args: Vec<&str> = command.args().iter().map(String::as_str).collect();
+        for index in registry.arg_indices_for_role(head, &args, ArgRole::VarRead) {
+            if let Some(name) = args.get(index) {
+                read.insert((*name).to_string());
+            }
+        }
+        for index in registry.arg_indices_for_role(head, &args, ArgRole::VarWrite) {
+            let Some(name) = args.get(index) else {
+                continue;
+            };
+            if name.contains('$') || name.contains('[') {
+                return Err(format!(
+                    "'{head}' writes to a variable whose name is computed \
+                     (`{name}`), so the extraction cannot tell which variable \
+                     leaves the selection"
+                ));
+            }
+            if name.contains('(') {
+                return Err(format!(
+                    "'{head}' writes to the array element `{name}`; carrying an \
+                     array element back to the caller needs more than the scalar \
+                     `upvar` protocol this transform uses"
+                ));
+            }
+            written.insert((*name).to_string());
+        }
+    }
+    Ok(VariableRoles { read, written })
+}
+
+/// Refuse a selection containing a command that acts on the call frame.
+///
+/// Membership comes from [`CommandRegistry::frame_sensitive_commands`] — the
+/// registry's union of block terminators, control transfers, scope aliases,
+/// and barriers — so this names no command.  Every member changes meaning
+/// when a `proc` boundary is introduced between it and its frame: `return`
+/// would return from the new proc rather than the caller, `break` would
+/// escape a loop that is no longer enclosing it, and `upvar 1` would alias
+/// the caller's caller.
+fn reject_frame_sensitive_selection(
+    source: &str,
+    selected: &[&SegmentedCommand],
+    registry: &CommandRegistry,
+) -> Result<(), String> {
+    let unsafe_heads = registry.frame_sensitive_commands();
+    for command in selected {
+        let (start, end) = command_span_offsets(source, command);
+        let text = source.get(start as usize..end as usize).unwrap_or("");
+        for word in text.split(|c: char| !(c.is_alphanumeric() || c == ':' || c == '_')) {
+            if !word.is_empty() && unsafe_heads.contains(&word) {
+                return Err(format!(
+                    "the selection uses '{word}', which acts on the call frame — \
+                     putting a `proc` boundary between it and that frame would \
+                     change what it returns from, breaks out of, or binds against"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Refuse a selection nested inside a namespace or class definition body.
+///
+/// The extracted proc would be created in a different namespace from the one
+/// the moved code ran in, so its unqualified command calls and `variable`
+/// references would silently resolve elsewhere.  Both tests are registry
+/// data: [`Traits::DECLARES_NAMESPACE`] for `namespace eval` and its kin, and
+/// a spec's `definition_body` grammar for a class/type definer's body.
+fn reject_enclosing_definition_body(
+    source: &str,
+    scope: Scope,
+    registry: &CommandRegistry,
+) -> Result<(), String> {
+    if scope.start == 0 {
+        return Ok(());
+    }
+    // Walk the top-level commands to find the one whose body the scope sits
+    // in, then check what kind of body it is.
+    for command in segment_commands_with_offset(source, 0) {
+        let (start, end) = command_span_offsets(source, &command);
+        if scope.start < start || scope.end > end {
+            continue;
+        }
+        let head = command.name();
+        let args: Vec<&str> = command.args().iter().map(String::as_str).collect();
+        let traits = registry.call_traits(head, &args);
+        if traits.contains(Traits::DECLARES_NAMESPACE) {
+            return Err(format!(
+                "the selection is inside a '{head}' body — an extracted proc \
+                 would be created in a different namespace, changing what its \
+                 unqualified calls and variables resolve to"
+            ));
+        }
+        if registry
+            .get(head)
+            .is_some_and(|spec| spec.definition_body.is_some())
+        {
+            return Err(format!(
+                "the selection is inside a '{head}' class/type definition body, \
+                 where a top-level `proc` is not the same thing as a member"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// The innermost script region containing `offset`, as a byte range.
+///
+/// Descends through registry-resolved [`ArgRole::Body`] arguments, so a
+/// selection inside a `proc` body, an `if` branch, or a `foreach` body is
+/// scoped to that body rather than to the whole file — which is what makes
+/// "is this variable read after the selection?" a question about the right
+/// piece of code.
+fn enclosing_scope(source: &str, offset: u32, registry: &CommandRegistry) -> Scope {
+    let mut scope = Scope {
+        start: 0,
+        end: u32::try_from(source.len()).unwrap_or(u32::MAX),
+    };
+    loop {
+        let Some(text) = source.get(scope.start as usize..scope.end as usize) else {
+            return scope;
+        };
+        let mut descended = false;
+        for command in segment_commands_with_offset(text, scope.start) {
+            let head = command.name();
+            if head.is_empty() {
+                continue;
+            }
+            let args: Vec<&str> = command.args().iter().map(String::as_str).collect();
+            for index in registry.arg_indices_for_role(head, &args, ArgRole::Body) {
+                let Some(token) = command.argv.get(index + 1) else {
+                    continue;
+                };
+                if token.kind != tcl_lexer::TokenType::Str {
+                    continue;
+                }
+                let inner_start = token.span.start() + u32::from(token.content_offset);
+                let inner_end = token.span.end();
+                if inner_end > inner_start && offset >= inner_start && offset < inner_end {
+                    scope = Scope {
+                        start: inner_start,
+                        end: inner_end,
+                    };
+                    descended = true;
+                    break;
+                }
+            }
+            if descended {
+                break;
+            }
+        }
+        if !descended {
+            return scope;
+        }
+    }
+}
+
+/// The byte offset of the line start of the outermost top-level command
+/// containing `offset` — where the extracted definition is inserted.
+fn top_level_command_start(
+    source: &str,
+    scope_commands: &[SegmentedCommand],
+    scope: Scope,
+    offset: u32,
+) -> u32 {
+    // A selection already at top level inserts before its own first command.
+    let anchor = if scope.start == 0 {
+        scope_commands
+            .iter()
+            .map(|command| command_span_offsets(source, command).0)
+            .filter(|start| *start <= offset)
+            .max()
+            .unwrap_or(offset)
+    } else {
+        segment_commands_with_offset(source, 0)
+            .into_iter()
+            .filter(|command| {
+                let (start, end) = command_span_offsets(source, command);
+                start <= offset && offset < end
+            })
+            .map(|command| command_span_offsets(source, &command).0)
+            .min()
+            .unwrap_or(offset)
+    };
+    line_start_of(source, anchor)
+}
+
+/// The byte offset of the start of the line containing `offset`.
+fn line_start_of(source: &str, offset: u32) -> u32 {
+    let index = (offset as usize).min(source.len());
+    u32::try_from(source[..index].rfind('\n').map_or(0, |at| at + 1)).unwrap_or(0)
+}
+
+/// The leading whitespace of the line containing `offset`.
+fn line_indent_at(source: &str, offset: u32) -> String {
+    let start = line_start_of(source, offset) as usize;
+    source[start..]
+        .chars()
+        .take_while(|c| *c == ' ' || *c == '\t')
+        .collect()
+}
+
+/// Render the generated proc definition.
+///
+/// A by-name parameter is spelled `<var>Name` and immediately re-bound with
+/// `upvar 1`, so the moved code keeps writing to the caller's variable under
+/// its original spelling and the body needs no rewriting at all.
+fn render_definition(
+    name: &str,
+    by_value: &[String],
+    by_name: &[String],
+    block: &str,
+    block_indent: &str,
+) -> String {
+    use std::fmt::Write as _;
+    let mut params: Vec<String> = by_value.to_vec();
+    params.extend(by_name.iter().map(|var| format!("{var}Name")));
+    let mut body = String::new();
+    for var in by_name {
+        let _ = writeln!(body, "    upvar 1 ${var}Name {var}");
+    }
+    for line in block.lines() {
+        let stripped = line.strip_prefix(block_indent).unwrap_or(line);
+        if stripped.trim().is_empty() {
+            body.push('\n');
+        } else {
+            let _ = writeln!(body, "    {}", stripped.trim_end());
+        }
+    }
+    format!("proc {name} {{{}}} {{\n{body}}}\n\n", params.join(" "))
+}
+
+/// Render the call that replaces the selection.
+///
+/// A by-value parameter is passed as `$var`; a by-name one is passed as the
+/// bare *name*, which is what `upvar` in the proc binds against.
+fn render_call(name: &str, by_value: &[String], by_name: &[String]) -> String {
+    let mut words = vec![name.to_string()];
+    words.extend(by_value.iter().map(|var| format!("${var}")));
+    words.extend(by_name.iter().cloned());
+    words.join(" ")
+}
+
+/// A proc name not already taken by a workspace symbol or a registry command.
+///
+/// The generated name is a placeholder the user renames straight away, but it
+/// must not *shadow* something in the meantime: defining `proc lsort {…}` by
+/// accident would silently replace the builtin for the rest of the file.
+fn unique_proc_name(analysis: &AnalysisResult, registry: &CommandRegistry) -> String {
+    let taken = |candidate: &str| {
+        registry.get(candidate).is_some()
+            || analysis
+                .all_procs
+                .values()
+                .any(|proc_def| proc_def.name == candidate)
+    };
+    if !taken(BASE_NAME) {
+        return BASE_NAME.to_string();
+    }
+    // Bounded rather than open-ended: the suffix search is over a placeholder
+    // the user renames immediately, so a file already holding this many
+    // `extracted_proc_N` procs needs a person to choose a name, not a longer
+    // search.  Falling back to the base name keeps the refactoring available;
+    // the rename that follows resolves the collision.
+    (2..=MAX_NAME_SUFFIX)
+        .map(|suffix| format!("{BASE_NAME}_{suffix}"))
+        .find(|candidate| !taken(candidate))
+        .unwrap_or_else(|| BASE_NAME.to_string())
+}
+
+/// Distinct `$name` / `${name}` references in `text`, array elements
+/// reduced to the array's own name.
+fn variable_references(text: &str) -> BTreeSet<String> {
+    let bytes = text.as_bytes();
+    let mut out = BTreeSet::new();
+    let mut index = 0usize;
+    while index < bytes.len() {
+        if bytes[index] != b'$' {
+            index += 1;
+            continue;
+        }
+        if bytes.get(index + 1) == Some(&b'{') {
+            if let Some(offset) = text.get(index + 2..).and_then(|rest| rest.find('}')) {
+                out.insert(text[index + 2..index + 2 + offset].to_string());
+                index = index + 2 + offset + 1;
+                continue;
+            }
+            index += 1;
+            continue;
+        }
+        let mut end = index + 1;
+        while end < bytes.len()
+            && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_' || bytes[end] == b':')
+        {
+            end += 1;
+        }
+        if end > index + 1 {
+            out.insert(text[index + 1..end].to_string());
+            index = end;
+        } else {
+            index += 1;
+        }
+    }
+    out
+}
+
+/// The variable names `command` names through a registry `VarRead` /
+/// `VarWrite` role — a use that carries no `$`, so the `$name` scan misses it.
+fn role_named_variables(command: &SegmentedCommand, registry: &CommandRegistry) -> Vec<String> {
+    let head = command.name();
+    let args: Vec<&str> = command.args().iter().map(String::as_str).collect();
+    let mut out = Vec::new();
+    for role in [ArgRole::VarRead, ArgRole::VarWrite] {
+        for index in registry.arg_indices_for_role(head, &args, role) {
+            if let Some(name) = args.get(index) {
+                out.push((*name).to_string());
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tcl_compiler::analyser::Analyser;
+
+    /// Run the transform over the byte range of `needle` in `src`.
+    fn at(src: &str, needle: &str) -> Option<Refactoring> {
+        let registry = super::super::test_registry();
+        let mut analyser = Analyser::new();
+        let analysis = analyser.analyse(src, "tcl9.0").clone();
+        let start = u32::try_from(src.find(needle).expect("needle in source")).unwrap();
+        let end = start + u32::try_from(needle.len()).unwrap();
+        extract_proc(src, (start, end), &analysis, &registry)
+    }
+
+    /// The rewritten document, or the refusal reason.
+    fn outcome(src: &str, needle: &str) -> Result<String, String> {
+        let refactoring = at(src, needle).expect("a selection to extract");
+        match &refactoring.disabled {
+            Some(reason) => Err(reason.clone()),
+            None => Ok(refactoring.apply(src)),
+        }
+    }
+
+    // -- TP: a pure selection with live-ins and no live-outs ---------------
+
+    #[test]
+    fn tp_extracts_a_read_only_selection_as_value_parameters() {
+        let src = "set x 5\nputs $x\nputs done\n";
+        let result = outcome(src, "puts $x").unwrap();
+        assert!(
+            result.contains("proc extracted_proc {x} {\n    puts $x\n}"),
+            "{result}"
+        );
+        assert!(result.contains("extracted_proc $x"), "{result}");
+    }
+
+    #[test]
+    fn tp_a_write_never_read_again_becomes_a_proc_local() {
+        // `tmp` is not used after the selection, so it is a genuine local:
+        // it becomes a proc local and stops leaking into the caller at all.
+        let src = "set tmp 1\nputs done\n";
+        let result = outcome(src, "set tmp 1").unwrap();
+        assert!(
+            result.contains("proc extracted_proc {} {\n    set tmp 1\n}"),
+            "{result}"
+        );
+        assert!(!result.contains("upvar"), "no upvar needed: {result}");
+    }
+
+    // -- TP: caller-frame writes survive via upvar -------------------------
+
+    #[test]
+    fn tp_a_write_read_after_the_selection_is_carried_by_upvar() {
+        // The issue's reproducer.  With a value parameter the original
+        // printed `after=1` and the refactored one printed `after=0`.
+        let src = "set x 0\nset x 1\nputs $x\nputs \"after=$x\"\n";
+        let result = outcome(src, "set x 1\nputs $x").unwrap();
+        assert!(
+            result.contains("upvar 1 $xName x"),
+            "the write must reach the caller's frame: {result}"
+        );
+        assert!(
+            result.contains("extracted_proc x\n"),
+            "the call passes the variable's *name*: {result}"
+        );
+        assert!(result.contains("puts \"after=$x\""), "{result}");
+    }
+
+    #[test]
+    fn tp_the_definition_lands_after_the_file_prologue() {
+        // Not at line 0: a definition inserted above `package require` would
+        // sit before the dialect/package setup it may depend on.
+        let src = "package require Tcl\nset x 5\nputs $x\n";
+        let result = outcome(src, "puts $x").unwrap();
+        let package_line = result.find("package require Tcl").unwrap();
+        let proc_line = result.find("proc extracted_proc").unwrap();
+        assert!(package_line < proc_line, "{result}");
+    }
+
+    #[test]
+    fn tp_the_generated_name_avoids_a_collision() {
+        let src = "proc extracted_proc {} {}\nset x 5\nputs $x\n";
+        let result = outcome(src, "puts $x").unwrap();
+        assert!(result.contains("proc extracted_proc_2 {x}"), "{result}");
+    }
+
+    // -- FP/TN: refusals that keep behaviour -------------------------------
+
+    #[test]
+    fn fp_refuses_a_selection_containing_return() {
+        let src = "proc f {} {\n    set x 1\n    return $x\n}\n";
+        let reason = outcome(src, "return $x").unwrap_err();
+        assert!(reason.contains("call frame"), "{reason}");
+    }
+
+    #[test]
+    fn fp_refuses_a_selection_containing_break() {
+        let src = "foreach i {1 2 3} {\n    break\n}\n";
+        let reason = outcome(src, "break").unwrap_err();
+        assert!(reason.contains("call frame"), "{reason}");
+    }
+
+    #[test]
+    fn fp_refuses_a_selection_containing_continue() {
+        let src = "foreach i {1 2 3} {\n    continue\n}\n";
+        let reason = outcome(src, "continue").unwrap_err();
+        assert!(reason.contains("call frame"), "{reason}");
+    }
+
+    #[test]
+    fn fp_refuses_a_selection_containing_global() {
+        let src = "proc f {} {\n    global config\n    puts $config\n}\n";
+        let reason = outcome(src, "global config").unwrap_err();
+        assert!(reason.contains("call frame"), "{reason}");
+    }
+
+    #[test]
+    fn fp_refuses_a_selection_containing_upvar() {
+        let src = "proc f {n} {\n    upvar 1 $n local\n}\n";
+        let reason = outcome(src, "upvar 1 $n local").unwrap_err();
+        assert!(reason.contains("call frame"), "{reason}");
+    }
+
+    #[test]
+    fn fp_refuses_a_computed_variable_write() {
+        let src = "set n counter\nset $n 1\nputs $counter\n";
+        let reason = outcome(src, "set $n 1").unwrap_err();
+        assert!(reason.contains("computed"), "{reason}");
+    }
+
+    #[test]
+    fn fp_refuses_an_array_element_write() {
+        let src = "set a(x) 1\nputs $a(x)\n";
+        let reason = outcome(src, "set a(x) 1").unwrap_err();
+        assert!(reason.contains("array element"), "{reason}");
+    }
+
+    #[test]
+    fn fp_refuses_a_selection_inside_a_namespace_eval() {
+        let src = "namespace eval app {\n    set x 1\n    puts $x\n}\n";
+        let reason = outcome(src, "puts $x").unwrap_err();
+        assert!(reason.contains("namespace"), "{reason}");
+    }
+
+    #[test]
+    fn tn_no_action_for_an_empty_selection() {
+        let registry = super::super::test_registry();
+        let mut analyser = Analyser::new();
+        let src = "set x 1\n";
+        let analysis = analyser.analyse(src, "tcl9.0").clone();
+        assert!(extract_proc(src, (0, 0), &analysis, &registry).is_none());
+    }
+
+    #[test]
+    fn tn_no_action_for_a_selection_covering_no_whole_command() {
+        // Half a word is not a command: nothing is offered rather than
+        // something wrong being offered.
+        let src = "set x 1\n";
+        assert!(at(src, "et x").is_none());
+    }
+
+    #[test]
+    fn tn_no_action_for_a_whitespace_only_selection() {
+        let src = "set x 1\n\n\nputs $x\n";
+        assert!(at(src, "\n\n\n").is_none());
+    }
+
+    // -- Unit-level helpers ------------------------------------------------
+
+    #[test]
+    fn variable_references_collects_bare_and_braced_names() {
+        let found = variable_references("puts $a ${b} $c_1");
+        assert_eq!(
+            found.into_iter().collect::<Vec<_>>(),
+            vec!["a".to_string(), "b".to_string(), "c_1".to_string()]
+        );
+    }
+}

--- a/rust/tcl-lsp-core/src/refactor/extract_variable.rs
+++ b/rust/tcl-lsp-core/src/refactor/extract_variable.rs
@@ -158,6 +158,7 @@ pub fn extract_variable(
         edits,
         kind: ActionKind::RefactorExtract,
         data_group: None,
+        disabled: None,
     })
 }
 

--- a/rust/tcl-lsp-core/src/refactor/if_to_switch.rs
+++ b/rust/tcl-lsp-core/src/refactor/if_to_switch.rs
@@ -261,6 +261,7 @@ pub fn if_to_switch(
         }],
         kind: ActionKind::RefactorRewrite,
         data_group: None,
+        disabled: None,
     })
 }
 

--- a/rust/tcl-lsp-core/src/refactor/inline_proc.rs
+++ b/rust/tcl-lsp-core/src/refactor/inline_proc.rs
@@ -1,0 +1,835 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Inline proc — replace a call with the proc's body, with its parameters
+//! bound to the call's arguments.
+//!
+//! # What Tcl actually does, and why a textual splice is not it
+//!
+//! `f {a b}` does not pass the four characters `{a b}` to `f`; it passes the
+//! three-character *value* `a b`, because the braces are the caller's quoting
+//! and are consumed by the parse.  Splicing the written word into the body
+//! therefore changes the value the body sees — the body's `$name` produced
+//! `a b` before and produces `{a b}` afterwards (issue #1199).  Nor is a
+//! parameter with no written argument simply absent: `proc f {{name world}}`
+//! called as `f` binds `name` to `world`, so an inlining that drops the
+//! parameter leaves the body reading an unset variable.
+//!
+//! Both are consequences of the same thing: inlining is a *binding* problem,
+//! not a text problem.  This transform therefore
+//!
+//! * performs real parameter binding — required parameters, defaults, and
+//!   the variadic `args` tail, with the same arity rules C Tcl applies;
+//! * computes each argument's **value**, not its spelling; and
+//! * refuses, with a plain-English reason, wherever the value cannot be
+//!   written back into the body's context without changing what it means.
+//!
+//! # What it refuses, and why
+//!
+//! Refusal is not failure — it is the correct answer whenever the rewrite
+//! would not preserve behaviour.  The reasons are surfaced on the code action
+//! (LSP's `disabled.reason`), so the editor greys the entry out and explains
+//! itself rather than silently offering nothing.
+//!
+//! | Refused | Because |
+//! |---|---|
+//! | The head does not resolve to a proc in this file | There is no body to inline. |
+//! | The body is not exactly one command | Splicing several commands into one caller word changes the parse; a multi-command body needs statement-level insertion this transform does not do. |
+//! | The body uses a frame-sensitive command (`upvar`, `uplevel`, `global`, `variable`, `return`, `break`, `continue`, `info level`, …) | Those read or write the *call frame*. Moving them into the caller's frame changes which variables they bind, what they return from, and what they break out of. Membership comes from the registry's own frame-sensitivity union, never a keyword list here. |
+//! | The body writes a variable | A proc's locals vanish when it returns; a caller's do not. Inlining a `set` leaks a variable into the caller and can clobber one of the same name. |
+//! | The call supplies too few or too many arguments | Tcl would raise `wrong # args`; inlining would silently not. |
+//! | The body reads `args` | `args` holds a *list* of the trailing values. Writing that list back into an arbitrary word context re-quotes it, and there is no spelling that is correct in every context. |
+//! | An argument's value is not a plain word | Only a value made of characters that are inert everywhere (no whitespace, quotes, braces, brackets, `$`, `\`, `;`, or `#`) can be written into the body verbatim and still mean the same thing. |
+//! | A parameter used inside an `expr` operand is bound to a non-numeric value | `expr {$n * 2}` with `n` bound to `abc` is a variable read; `expr {abc * 2}` is an invalid bareword. The `expr` positions come from the registry's `ArgRole::Expr`, not from knowing what `expr` is. |
+//! | A parameter used more than once is bound to a side-effecting argument | `f [next]` with the body reading `$x` twice would call `next` twice instead of once. |
+//!
+//! # Worked examples
+//!
+//! ```tcl
+//! proc double {x} { expr {$x * 2} }
+//! double 5                  ;# inlines to  expr {5 * 2}
+//!
+//! proc greet {{name world}} { puts $name }
+//! greet                     ;# inlines to  puts world   (the default binds)
+//!
+//! proc greet {name} { puts "hello $name" }
+//! greet {a b}               ;# refused: the value `a b` is not a plain word
+//! ```
+
+use tcl_compiler::analyser::AnalysisResult;
+use tcl_compiler::segmenter::segment_commands_with_offset;
+use tcl_lexer::{Token, TokenType};
+use tcl_registry::{ArgRole, CommandRegistry};
+
+use super::{RefactorEdit, Refactoring, command_span_offsets, find_command_at, token_end_offset};
+use crate::code_actions::ActionKind;
+
+/// Inline the proc called at byte offset `cursor`.
+///
+/// Returns `None` when the cursor is not on a call to a resolvable proc at
+/// all — there is nothing to offer.  Returns a [`Refactoring`] whose
+/// `disabled` reason is set when a call *is* found but cannot be inlined
+/// without changing behaviour: the action is still surfaced, greyed out, so
+/// the user learns why rather than wondering where it went.
+#[must_use]
+pub fn inline_proc(
+    source: &str,
+    cursor: u32,
+    analysis: &AnalysisResult,
+    registry: &CommandRegistry,
+) -> Option<Refactoring> {
+    let call = find_command_at(source, cursor, None, registry)?;
+    let head = call.name();
+    if head.is_empty() {
+        return None;
+    }
+    // Resolve the head exactly as the navigation providers do — the caller's
+    // namespace candidates, the registry builtin gate, then the deterministic
+    // simple-name fallback.  A namespace-blind `p.name == head` scan is the
+    // M1 drift class `cargo xtask resolution-drift` flags.
+    let head_off = call.span.start();
+    let namespace = crate::definition::namespace_context_at(
+        &analysis.global_scope,
+        head_off,
+        &analysis.namespace_overrides,
+    );
+    let proc_def = crate::definition::resolve_called_proc(
+        analysis,
+        source,
+        &namespace,
+        head,
+        head_off,
+        Some(registry),
+    )?;
+    let title = format!("Inline proc '{}'", proc_def.name);
+    let (call_start, call_end) = command_span_offsets(source, &call);
+
+    match plan_inline(source, &call, proc_def, registry) {
+        Ok(new_text) => Some(Refactoring {
+            title,
+            edits: vec![RefactorEdit {
+                start: call_start,
+                end: call_end,
+                new_text,
+            }],
+            kind: ActionKind::RefactorInline,
+            data_group: None,
+            disabled: None,
+        }),
+        Err(reason) => Some(Refactoring {
+            title,
+            edits: Vec::new(),
+            kind: ActionKind::RefactorInline,
+            data_group: None,
+            disabled: Some(reason),
+        }),
+    }
+}
+
+/// The inlined replacement text for `call`, or the reason it cannot be built.
+fn plan_inline(
+    source: &str,
+    call: &tcl_compiler::segmenter::SegmentedCommand,
+    proc_def: &tcl_compiler::analyser::ProcDef,
+    registry: &CommandRegistry,
+) -> Result<String, String> {
+    if proc_def.params_computed {
+        return Err(
+            "the proc's parameter list is computed at run time, so its formals are unknown"
+                .to_string(),
+        );
+    }
+    let body = single_command_body(source, proc_def, registry)?;
+    let bindings = bind_arguments(source, call, proc_def)?;
+    reject_frame_sensitive_body(&body, registry)?;
+    reject_body_variable_writes(&body, registry)?;
+    reject_args_reference(&body, proc_def)?;
+    substitute_bindings(&body, &bindings, registry)
+}
+
+/// One command's worth of proc body, re-segmented so its argument roles and
+/// variable references can be inspected.
+struct BodyCommand {
+    /// The body text, braces stripped and trimmed.
+    text: String,
+    /// The body's single command, with spans relative to `text`.
+    command: tcl_compiler::segmenter::SegmentedCommand,
+}
+
+/// Extract the proc's body and require it to be exactly one command.
+fn single_command_body(
+    source: &str,
+    proc_def: &tcl_compiler::analyser::ProcDef,
+    registry: &CommandRegistry,
+) -> Result<BodyCommand, String> {
+    let span = proc_def.body_span;
+    let raw = source
+        .get(span.start() as usize..span.end() as usize)
+        .unwrap_or("")
+        .trim();
+    // `body_span` may exclude the proc's closing `}` (the lexer's inner-end
+    // convention), so strip a trailing `}` only when it is the unbalanced
+    // *outer* brace — a greedy `trim_end_matches('}')` would eat an inner
+    // sub-expression brace (`expr {$n * 2}`) and leave unparseable text.
+    let inner = raw.strip_prefix('{').map_or(raw, str::trim_start);
+    let text = if inner.matches('}').count() > inner.matches('{').count() {
+        let trimmed = inner.trim_end();
+        trimmed.strip_suffix('}').unwrap_or(trimmed).trim()
+    } else {
+        inner.trim()
+    }
+    .to_string();
+    if text.is_empty() {
+        return Err("the proc body is empty".to_string());
+    }
+    let commands: Vec<_> = segment_commands_with_offset(&text, 0)
+        .into_iter()
+        .filter(|command| !command.name().is_empty())
+        .collect();
+    if commands.len() != 1 {
+        return Err(format!(
+            "the proc body is {} commands; inlining several commands into a \
+             single caller word would change how the caller parses",
+            commands.len()
+        ));
+    }
+    let command = commands.into_iter().next().expect("length checked above");
+    let _ = registry;
+    Ok(BodyCommand { text, command })
+}
+
+/// A parameter bound to the value the call gives it.
+struct Binding {
+    /// Parameter name as declared.
+    name: String,
+    /// The value the parameter receives, as a Tcl *value* — not the caller's
+    /// spelling of it.
+    value: String,
+    /// Whether producing that value runs code (a `[…]` substitution) or reads
+    /// a variable, so re-evaluating it more than once is observable.
+    evaluation_is_observable: bool,
+}
+
+/// Bind the call's arguments to the proc's formals, applying C Tcl's rules:
+/// positional parameters in order, declared defaults for the ones the call
+/// omits, and the variadic `args` tail collecting whatever is left.
+///
+/// Errors on an argument count C Tcl would reject (`wrong # args`): inlining
+/// must not turn a call that raises into one that quietly works.
+fn bind_arguments(
+    source: &str,
+    call: &tcl_compiler::segmenter::SegmentedCommand,
+    proc_def: &tcl_compiler::analyser::ProcDef,
+) -> Result<Vec<Binding>, String> {
+    let params = &proc_def.params;
+    let has_args_tail = params.last().is_some_and(|param| param.name == "args");
+    let fixed = if has_args_tail {
+        params.len() - 1
+    } else {
+        params.len()
+    };
+    let required = params
+        .iter()
+        .take(fixed)
+        .filter(|param| !param.has_default)
+        .count();
+    let supplied = call.argv.len().saturating_sub(1);
+    if supplied < required {
+        return Err(format!(
+            "the call passes {supplied} argument(s) but '{}' requires {required} — \
+             C Tcl would raise `wrong # args`",
+            proc_def.name
+        ));
+    }
+    if !has_args_tail && supplied > fixed {
+        return Err(format!(
+            "the call passes {supplied} argument(s) but '{}' accepts at most {fixed} — \
+             C Tcl would raise `wrong # args`",
+            proc_def.name
+        ));
+    }
+    let mut bindings = Vec::new();
+    for (index, param) in params.iter().take(fixed).enumerate() {
+        // No written argument means the declared default binds.  Only a
+        // parameter that *has* one can reach here — the required count was
+        // checked above — so an absent default is an unreachable empty value.
+        let (value, evaluation_is_observable) = match call.argv.get(index + 1) {
+            Some(&token) => argument_value(source, token)?,
+            None => (param.default_value.clone().unwrap_or_default(), false),
+        };
+        bindings.push(Binding {
+            name: param.name.clone(),
+            value,
+            evaluation_is_observable,
+        });
+    }
+    Ok(bindings)
+}
+
+/// The **value** a call argument denotes, plus whether producing it is
+/// observable (runs a command or reads a variable).
+///
+/// This is the step a textual splice skips.  A braced word `{a b}` denotes
+/// the value `a b`; a quoted word `"a b"` denotes `a b`; a bare word denotes
+/// itself.  A word carrying a live substitution has no statically-known
+/// value at all, and is reported as such so the caller can refuse.
+fn argument_value(source: &str, token: Token) -> Result<(String, bool), String> {
+    let start = token.span.start() as usize;
+    let end = token_end_offset(source, token) as usize;
+    let raw = source
+        .get(start..end)
+        .ok_or_else(|| "the call argument's source range is unreadable".to_string())?;
+    match token.kind {
+        // A braced word is a literal: its contents reach the command
+        // byte-for-byte, with no substitution applied.
+        TokenType::Str => Ok((
+            raw.strip_prefix('{')
+                .and_then(|rest| rest.strip_suffix('}'))
+                .unwrap_or(raw)
+                .to_string(),
+            false,
+        )),
+        TokenType::Var | TokenType::Cmd => Err(format!(
+            "the argument `{raw}` is substituted at run time, so its value is \
+             not known here"
+        )),
+        _ => {
+            if raw.starts_with('"') {
+                let inner = raw
+                    .strip_prefix('"')
+                    .and_then(|rest| rest.strip_suffix('"'))
+                    .unwrap_or(raw);
+                if inner.contains('$') || inner.contains('[') || inner.contains('\\') {
+                    return Err(format!(
+                        "the argument `{raw}` is substituted at run time, so its \
+                         value is not known here"
+                    ));
+                }
+                return Ok((inner.to_string(), false));
+            }
+            if raw.contains('$') || raw.contains('[') || raw.contains('\\') {
+                return Err(format!(
+                    "the argument `{raw}` is substituted at run time, so its value \
+                     is not known here"
+                ));
+            }
+            Ok((raw.to_string(), false))
+        }
+    }
+}
+
+/// Refuse a body whose command is frame-sensitive.
+///
+/// Membership comes from
+/// [`CommandRegistry::frame_sensitive_commands`] — the registry's own union of
+/// block terminators, control transfers, scope aliases, and barriers — so this
+/// never names a command.  Moving any of them out of the proc's frame changes
+/// what they return from, break out of, or bind against: `return` in an inlined
+/// body would return from the *caller*, and `upvar 1 x y` would alias the
+/// caller's caller instead of the caller.
+fn reject_frame_sensitive_body(
+    body: &BodyCommand,
+    registry: &CommandRegistry,
+) -> Result<(), String> {
+    let unsafe_heads = registry.frame_sensitive_commands();
+    let head = body.command.name();
+    if unsafe_heads.contains(&head) {
+        return Err(format!(
+            "the body calls '{head}', which acts on the call frame — running it \
+             in the caller's frame would change what it returns from, breaks out \
+             of, or binds against"
+        ));
+    }
+    // A frame-sensitive command nested in a `[…]` substitution inside an
+    // argument is just as frame-bound as one at the head.
+    for text in body.command.args() {
+        if let Some(inner) = nested_command_head(text)
+            && unsafe_heads.contains(&inner)
+        {
+            return Err(format!(
+                "the body evaluates '{inner}', which acts on the call frame — \
+                 running it in the caller's frame would change what it binds \
+                 against"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// The head word of a `[…]` command substitution embedded anywhere in `text`.
+fn nested_command_head(text: &str) -> Option<&str> {
+    let open = text.find('[')?;
+    let rest = text.get(open + 1..)?;
+    let head = rest
+        .split(|c: char| c.is_ascii_whitespace() || c == ']')
+        .next()?;
+    (!head.is_empty()).then_some(head)
+}
+
+/// Refuse a body that writes a variable.
+///
+/// A proc's locals disappear when it returns; the caller's do not.  Inlining
+/// `set total 0` therefore leaves `total` behind in the caller — and clobbers
+/// the caller's own `total` if it had one.  The written positions come from
+/// the registry's [`ArgRole::VarWrite`] role, so this covers `set`, `incr`,
+/// `lappend`, `append`, `dict set`, `lassign`, `regexp -inline`'s capture
+/// variables, and anything else a spec declares, without listing any of them.
+fn reject_body_variable_writes(
+    body: &BodyCommand,
+    registry: &CommandRegistry,
+) -> Result<(), String> {
+    let args: Vec<&str> = body.command.args().iter().map(String::as_str).collect();
+    let writes = registry.arg_indices_for_role(body.command.name(), &args, ArgRole::VarWrite);
+    if writes.is_empty() {
+        return Ok(());
+    }
+    Err(format!(
+        "the body assigns a variable ('{}' writes to '{}'), which would leak \
+         into — and could overwrite — a variable of the same name in the caller",
+        body.command.name(),
+        writes
+            .iter()
+            .filter_map(|index| args.get(*index))
+            .copied()
+            .collect::<Vec<_>>()
+            .join("', '")
+    ))
+}
+
+/// Refuse a body that reads the variadic `args` list.
+///
+/// `args` holds a *list* of the trailing argument values.  Writing that list
+/// back into the body's word context re-quotes it — braced in one place, split
+/// into several words in another — and there is no single spelling that is
+/// correct in every context, so this transform does not guess.  A proc that
+/// *declares* `args` but never reads it is fine: the binding simply has no
+/// occurrence to substitute.
+fn reject_args_reference(
+    body: &BodyCommand,
+    proc_def: &tcl_compiler::analyser::ProcDef,
+) -> Result<(), String> {
+    if proc_def.params.last().is_none_or(|p| p.name != "args") {
+        return Ok(());
+    }
+    if variable_references(&body.text)
+        .into_iter()
+        .any(|(name, _, _)| name == "args")
+    {
+        return Err(
+            "the body reads `args`, whose value is a list — there is no spelling \
+             of a list that means the same thing in every word context"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+/// Substitute each binding's value for its `$param` / `${param}` references,
+/// refusing wherever the value cannot be written into that position without
+/// changing what it means.
+fn substitute_bindings(
+    body: &BodyCommand,
+    bindings: &[Binding],
+    registry: &CommandRegistry,
+) -> Result<String, String> {
+    let references = variable_references(&body.text);
+    let expr_ranges = expr_argument_ranges(&body.command, registry);
+    let mut replacements: Vec<(usize, usize, String)> = Vec::new();
+    for binding in bindings {
+        let occurrences: Vec<&(String, usize, usize)> = references
+            .iter()
+            .filter(|(name, _, _)| *name == binding.name)
+            .collect();
+        if occurrences.is_empty() {
+            continue;
+        }
+        if occurrences.len() > 1 && binding.evaluation_is_observable {
+            return Err(format!(
+                "'{}' is used {} times in the body but its argument is evaluated \
+                 at run time — inlining would evaluate it {} times instead of once",
+                binding.name,
+                occurrences.len(),
+                occurrences.len()
+            ));
+        }
+        if !is_plain_word(&binding.value) {
+            return Err(format!(
+                "'{}' is bound to `{}`, which is not a plain word — writing it \
+                 into the body would change how the surrounding word is parsed",
+                binding.name, binding.value
+            ));
+        }
+        for (_, start, end) in occurrences {
+            // An `expr` operand is a different language: a bare word there is
+            // a function name or an error, not the string it spells.  The
+            // positions come from the registry's `ArgRole::Expr`, so this
+            // holds for every expression-taking command, not just `expr`.
+            if expr_ranges
+                .iter()
+                .any(|(from, to)| *start >= *from && *end <= *to)
+                && !is_expr_literal(&binding.value)
+            {
+                return Err(format!(
+                    "'{}' is used as an expression operand and is bound to `{}`, \
+                     which is not a number — `expr` reads a bare word as a \
+                     function name, not as the string it spells",
+                    binding.name, binding.value
+                ));
+            }
+            replacements.push((*start, *end, binding.value.clone()));
+        }
+    }
+    let mut out = body.text.clone();
+    replacements.sort_by_key(|(start, _, _)| std::cmp::Reverse(*start));
+    for (start, end, value) in replacements {
+        out.replace_range(start..end, &value);
+    }
+    Ok(out)
+}
+
+/// The byte ranges of `command`'s expression-role arguments, within the body
+/// text the command was segmented from.
+///
+/// Read off the registry's [`ArgRole::Expr`], so `expr`, `if`, `while`, and
+/// `for`'s condition are all covered without this module naming any of them.
+fn expr_argument_ranges(
+    command: &tcl_compiler::segmenter::SegmentedCommand,
+    registry: &CommandRegistry,
+) -> Vec<(usize, usize)> {
+    let args: Vec<&str> = command.args().iter().map(String::as_str).collect();
+    registry
+        .arg_indices_for_role(command.name(), &args, ArgRole::Expr)
+        .into_iter()
+        .filter_map(|index| {
+            // `arg_indices_for_role` is 0-based over the post-name arguments;
+            // the representative argv token sits one further along.
+            let token = command.argv.get(index + 1)?;
+            Some((token.span.start() as usize, token.span.end() as usize))
+        })
+        .collect()
+}
+
+/// `(name, start, end)` for every `$name` / `${name}` reference in `text`,
+/// where `start..end` covers the whole reference including the `$` and any
+/// braces.
+///
+/// Matching whole references rather than doing a `str::replace` is what keeps
+/// `$nn` intact when the parameter is `n`, and stops a `$name` embedded in a
+/// longer token being half-rewritten.
+fn variable_references(text: &str) -> Vec<(String, usize, usize)> {
+    let bytes = text.as_bytes();
+    let mut out = Vec::new();
+    let mut index = 0usize;
+    while index < bytes.len() {
+        if bytes[index] != b'$' {
+            index += 1;
+            continue;
+        }
+        if bytes.get(index + 1) == Some(&b'{') {
+            if let Some(offset) = text.get(index + 2..).and_then(|rest| rest.find('}')) {
+                let name = text[index + 2..index + 2 + offset].to_string();
+                out.push((name, index, index + 2 + offset + 1));
+                index = index + 2 + offset + 1;
+                continue;
+            }
+            index += 1;
+            continue;
+        }
+        let mut end = index + 1;
+        while end < bytes.len()
+            && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_' || bytes[end] == b':')
+        {
+            end += 1;
+        }
+        if end > index + 1 {
+            out.push((text[index + 1..end].to_string(), index, end));
+            index = end;
+        } else {
+            index += 1;
+        }
+    }
+    out
+}
+
+/// `true` when `value` can be written into any Tcl word position verbatim
+/// and still denote itself.
+///
+/// The permitted set is the characters that carry no meaning to the parser in
+/// any context: no whitespace (which would split the word), and none of
+/// `$ [ ] { } " \ ; #` (substitution, grouping, quoting, command separation,
+/// and comment introduction).  An empty value is excluded too — it needs
+/// quoting to survive as a word at all.
+fn is_plain_word(value: &str) -> bool {
+    !value.is_empty()
+        && value.chars().all(|c| {
+            !c.is_whitespace()
+                && !matches!(
+                    c,
+                    '$' | '[' | ']' | '{' | '}' | '"' | '\\' | ';' | '#' | '(' | ')'
+                )
+        })
+}
+
+/// `true` when `value` is a numeric literal `expr` reads as itself.
+///
+/// `expr` treats a bare non-numeric word as a function name (or an error), so
+/// only a value `expr` parses as a number can replace a variable reference in
+/// an expression operand.  Integer, real, and the `0x` / `0o` / `0b` radix
+/// prefixes are accepted, matching what `expr` itself parses.
+fn is_expr_literal(value: &str) -> bool {
+    let unsigned = value.strip_prefix(['-', '+']).unwrap_or(value);
+    if unsigned.is_empty() {
+        return false;
+    }
+    let radix = unsigned
+        .strip_prefix("0x")
+        .or_else(|| unsigned.strip_prefix("0X"))
+        .or_else(|| unsigned.strip_prefix("0o"))
+        .or_else(|| unsigned.strip_prefix("0O"))
+        .or_else(|| unsigned.strip_prefix("0b"))
+        .or_else(|| unsigned.strip_prefix("0B"));
+    if let Some(digits) = radix {
+        return !digits.is_empty() && digits.chars().all(|c| c.is_ascii_alphanumeric());
+    }
+    unsigned.parse::<f64>().is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tcl_compiler::analyser::Analyser;
+
+    /// Run the transform at the first occurrence of `needle` in `src`.
+    fn at(src: &str, needle: &str) -> Option<Refactoring> {
+        let registry = super::super::test_registry();
+        let mut analyser = Analyser::new();
+        let analysis = analyser.analyse(src, "tcl9.0").clone();
+        let cursor = u32::try_from(src.find(needle).expect("needle in source")).unwrap() + 1;
+        inline_proc(src, cursor, &analysis, &registry)
+    }
+
+    /// The rewritten document, or the refusal reason.
+    fn outcome(src: &str, needle: &str) -> Result<String, String> {
+        let refactoring = at(src, needle).expect("a call to inline");
+        match &refactoring.disabled {
+            Some(reason) => Err(reason.clone()),
+            None => Ok(refactoring.apply(src)),
+        }
+    }
+
+    // -- TP: binding is performed and the result is correct ---------------
+
+    #[test]
+    fn tp_inlines_a_literal_argument() {
+        let src = "proc double {x} {\n    expr {$x * 2}\n}\ndouble 5\n";
+        assert_eq!(
+            outcome(src, "double 5").unwrap(),
+            "proc double {x} {\n    expr {$x * 2}\n}\nexpr {5 * 2}\n"
+        );
+    }
+
+    #[test]
+    fn tp_binds_a_declared_default_when_the_call_omits_the_argument() {
+        // C Tcl 9.0.3 prints `hello world` for the original.  The old textual
+        // splice emitted `puts $name`, which errors on an unset variable.
+        let src = "proc greet {{name world}} {\n    puts $name\n}\ngreet\n";
+        assert_eq!(
+            outcome(src, "greet\n").unwrap(),
+            "proc greet {{name world}} {\n    puts $name\n}\nputs world\n"
+        );
+    }
+
+    #[test]
+    fn tp_a_written_argument_overrides_the_default() {
+        let src = "proc greet {{name world}} {\n    puts $name\n}\ngreet there\n";
+        assert_eq!(
+            outcome(src, "greet there").unwrap(),
+            "proc greet {{name world}} {\n    puts $name\n}\nputs there\n"
+        );
+    }
+
+    #[test]
+    fn tp_repeated_parameter_use_is_fine_for_a_literal() {
+        let src = "proc sq {n} {\n    expr {$n * $n}\n}\nsq 7\n";
+        assert_eq!(
+            outcome(src, "sq 7").unwrap(),
+            "proc sq {n} {\n    expr {$n * $n}\n}\nexpr {7 * 7}\n"
+        );
+    }
+
+    #[test]
+    fn tp_an_unread_args_tail_does_not_block_inlining() {
+        let src = "proc shout {word args} {\n    puts $word\n}\nshout hi extra\n";
+        assert_eq!(
+            outcome(src, "shout hi").unwrap(),
+            "proc shout {word args} {\n    puts $word\n}\nputs hi\n"
+        );
+    }
+
+    #[test]
+    fn tp_a_prefix_sharing_parameter_name_is_not_corrupted() {
+        // `$nn` must survive when the parameter is `n`.
+        let src = "proc f {n} {\n    puts $n$nn\n}\nf 1\n";
+        let result = outcome(src, "f 1\n").unwrap();
+        assert!(result.ends_with("puts 1$nn\n"), "{result}");
+    }
+
+    // -- FP: refusals that keep behaviour ---------------------------------
+
+    #[test]
+    fn fp_refuses_a_braced_argument_whose_value_is_not_a_plain_word() {
+        // The issue's second reproducer.  Original prints `hello a b`; the
+        // textual splice emitted `puts "hello {a b}"`, printing the braces.
+        let src = "proc greet {name} {\n    puts \"hello $name\"\n}\ngreet {a b}\n";
+        let reason = outcome(src, "greet {a b}").unwrap_err();
+        assert!(reason.contains("plain word"), "{reason}");
+    }
+
+    #[test]
+    fn fp_refuses_a_substituted_argument() {
+        let src = "proc double {x} {\n    expr {$x * 2}\n}\ndouble $n\n";
+        let reason = outcome(src, "double $n").unwrap_err();
+        assert!(reason.contains("substituted at run time"), "{reason}");
+    }
+
+    #[test]
+    fn fp_refuses_a_non_numeric_value_in_an_expression_operand() {
+        // `expr {abc * 2}` reads `abc` as a function name, not the string.
+        let src = "proc double {x} {\n    expr {$x * 2}\n}\ndouble abc\n";
+        let reason = outcome(src, "double abc").unwrap_err();
+        assert!(reason.contains("not a number"), "{reason}");
+    }
+
+    #[test]
+    fn fp_refuses_too_few_arguments() {
+        let src = "proc pair {a b} {\n    puts $a$b\n}\npair 1\n";
+        let reason = outcome(src, "pair 1\n").unwrap_err();
+        assert!(reason.contains("wrong # args"), "{reason}");
+    }
+
+    #[test]
+    fn fp_refuses_too_many_arguments() {
+        let src = "proc one {a} {\n    puts $a\n}\none 1 2\n";
+        let reason = outcome(src, "one 1 2").unwrap_err();
+        assert!(reason.contains("wrong # args"), "{reason}");
+    }
+
+    #[test]
+    fn fp_refuses_a_body_that_reads_args() {
+        let src = "proc all {args} {\n    puts $args\n}\nall 1 2\n";
+        let reason = outcome(src, "all 1 2").unwrap_err();
+        assert!(reason.contains("list"), "{reason}");
+    }
+
+    #[test]
+    fn fp_refuses_a_body_that_assigns_a_variable() {
+        // `total` would survive in the caller and clobber a same-named one.
+        let src = "proc reset {} {\n    set total 0\n}\nreset\n";
+        let reason = outcome(src, "reset\n").unwrap_err();
+        assert!(reason.contains("assigns a variable"), "{reason}");
+    }
+
+    #[test]
+    fn fp_refuses_a_body_using_upvar() {
+        let src = "proc bind {name} {\n    upvar 1 $name local\n}\nbind x\n";
+        let reason = outcome(src, "bind x\n").unwrap_err();
+        assert!(reason.contains("call frame"), "{reason}");
+    }
+
+    #[test]
+    fn fp_refuses_a_body_using_return() {
+        let src = "proc answer {} {\n    return 42\n}\nanswer\n";
+        let reason = outcome(src, "answer\n").unwrap_err();
+        assert!(reason.contains("call frame"), "{reason}");
+    }
+
+    #[test]
+    fn fp_refuses_a_body_using_global() {
+        let src = "proc grab {} {\n    global config\n}\ngrab\n";
+        let reason = outcome(src, "grab\n").unwrap_err();
+        assert!(reason.contains("call frame"), "{reason}");
+    }
+
+    #[test]
+    fn fp_refuses_a_multi_command_body() {
+        let src = "proc two {} {\n    puts a\n    puts b\n}\ntwo\n";
+        let reason = outcome(src, "two\n").unwrap_err();
+        assert!(reason.contains("commands"), "{reason}");
+    }
+
+    #[test]
+    fn fp_refuses_an_empty_body() {
+        let src = "proc nothing {} {}\nnothing\n";
+        let reason = outcome(src, "nothing\n").unwrap_err();
+        assert!(reason.contains("empty"), "{reason}");
+    }
+
+    #[test]
+    fn fp_refuses_a_computed_parameter_list() {
+        let src = "proc makeargs {} {return {a b}}\nproc p [makeargs] {\n    puts $a\n}\np 1 2\n";
+        let reason = outcome(src, "p 1 2").unwrap_err();
+        assert!(reason.contains("computed"), "{reason}");
+    }
+
+    // -- TN: nothing to offer ---------------------------------------------
+
+    #[test]
+    fn tn_no_action_on_a_builtin_call() {
+        assert!(at("puts hello\n", "puts").is_none());
+    }
+
+    #[test]
+    fn tn_no_action_on_an_unresolvable_head() {
+        assert!(at("frobnicate 1\n", "frobnicate").is_none());
+    }
+
+    #[test]
+    fn tn_no_action_outside_any_command() {
+        assert!(at("\n\n", "\n").is_none());
+    }
+
+    // -- Unit-level predicates --------------------------------------------
+
+    #[test]
+    fn plain_word_rejects_every_parser_significant_character() {
+        assert!(is_plain_word("abc"));
+        assert!(is_plain_word("1.5"));
+        assert!(is_plain_word("a-b_c.d/e"));
+        assert!(!is_plain_word(""));
+        for value in ["a b", "a$b", "a[b", "a{b", "a\"b", "a\\b", "a;b", "a#b"] {
+            assert!(!is_plain_word(value), "{value} must not be a plain word");
+        }
+    }
+
+    #[test]
+    fn expr_literal_accepts_what_expr_parses_as_a_number() {
+        for value in ["0", "42", "-7", "+7", "1.5", "1e3", "0xff", "0b1010"] {
+            assert!(is_expr_literal(value), "{value} is a number");
+        }
+        for value in ["abc", "", "-", "1a2"] {
+            assert!(!is_expr_literal(value), "{value} is not a number");
+        }
+    }
+
+    #[test]
+    fn variable_references_finds_whole_names_only() {
+        let found = variable_references("puts $n$nn ${n}x");
+        let names: Vec<&str> = found.iter().map(|(name, _, _)| name.as_str()).collect();
+        assert_eq!(names, vec!["n", "nn", "n"]);
+    }
+}

--- a/rust/tcl-lsp-core/src/refactor/inline_proc.rs
+++ b/rust/tcl-lsp-core/src/refactor/inline_proc.rs
@@ -154,7 +154,7 @@ fn plan_inline(
                 .to_string(),
         );
     }
-    let body = single_command_body(source, proc_def, registry)?;
+    let body = single_command_body(source, proc_def)?;
     let bindings = bind_arguments(source, call, proc_def)?;
     reject_frame_sensitive_body(&body, registry)?;
     reject_body_variable_writes(&body, registry)?;
@@ -175,7 +175,6 @@ struct BodyCommand {
 fn single_command_body(
     source: &str,
     proc_def: &tcl_compiler::analyser::ProcDef,
-    registry: &CommandRegistry,
 ) -> Result<BodyCommand, String> {
     let span = proc_def.body_span;
     let raw = source
@@ -209,7 +208,6 @@ fn single_command_body(
         ));
     }
     let command = commands.into_iter().next().expect("length checked above");
-    let _ = registry;
     Ok(BodyCommand { text, command })
 }
 

--- a/rust/tcl-lsp-core/src/refactor/inline_variable.rs
+++ b/rust/tcl-lsp-core/src/refactor/inline_variable.rs
@@ -130,6 +130,7 @@ pub fn inline_variable(
         edits: vec![delete, replace],
         kind: ActionKind::RefactorInline,
         data_group: None,
+        disabled: None,
     })
 }
 

--- a/rust/tcl-lsp-core/src/refactor/mod.rs
+++ b/rust/tcl-lsp-core/src/refactor/mod.rs
@@ -26,9 +26,13 @@
 //!
 //! Transforms:
 //!
+//! * [`extract_proc`] — move a run of commands into a new proc and call
+//!   it, carrying caller-frame writes through with `upvar`.
 //! * [`extract_variable`] — replace a selected expression with a named
 //!   `set` assignment.
 //! * [`inline_variable`] — inline a single-use `set` variable.
+//! * [`inline_proc`] — replace a call with the proc's body, with its
+//!   parameters bound to the call's argument *values*.
 //! * [`if_to_switch`] — convert an `if`/`elseif` equality chain to a
 //!   `switch`.
 //! * [`switch_to_dict`] — convert a constant-mapping `switch` to a
@@ -48,8 +52,10 @@
 
 mod brace_expr;
 mod datagroup;
+mod extract_proc;
 mod extract_variable;
 mod if_to_switch;
+mod inline_proc;
 mod inline_variable;
 mod switch_to_dict;
 
@@ -58,8 +64,10 @@ pub use datagroup::{
     DataGroupDefinition, data_group_tcl, extract_to_datagroup, extract_to_datagroup_from_if,
     extract_to_datagroup_from_switch,
 };
+pub use extract_proc::{extract_proc, extract_proc_rename_command};
 pub use extract_variable::extract_variable;
 pub use if_to_switch::if_to_switch;
+pub use inline_proc::inline_proc;
 pub use inline_variable::inline_variable;
 pub use switch_to_dict::switch_to_dict;
 
@@ -114,23 +122,39 @@ impl RefactorEdit {
 pub struct Refactoring {
     /// Title shown in the editor.
     pub title: String,
-    /// Edits, in byte-offset space.
+    /// Edits, in byte-offset space.  Empty when [`Self::disabled`] is set —
+    /// a refused refactoring has nothing to apply.
     pub edits: Vec<RefactorEdit>,
     /// LSP code-action kind dotted string (`refactor.extract`, …).
     pub kind: crate::code_actions::ActionKind,
     /// Generated data-group definition, when this is an
     /// extract-to-datagroup result.
     pub data_group: Option<DataGroupDefinition>,
+    /// Why this refactoring cannot be applied here, when it cannot.
+    ///
+    /// A transform that finds its subject but *cannot preserve behaviour* says
+    /// so rather than vanishing: the reason is surfaced as the code action's
+    /// LSP `disabled.reason`, so the editor greys the entry out and explains
+    /// itself.  Silently offering nothing leaves a user unable to tell "this
+    /// refactoring does not apply here" from "this refactoring is broken".
+    pub disabled: Option<String>,
 }
 
 impl Refactoring {
     /// Apply the edits to `source` bottom-to-top, returning the
     /// rewritten text.  Edits are sorted by descending start offset so
     /// an earlier edit never shifts a later one's coordinates.
+    ///
+    /// The sort key is `(start, end)`, not `start` alone: an insertion and a
+    /// replacement can legitimately share a start offset — extract-proc puts
+    /// the new definition at the line the selection begins on and replaces
+    /// that selection with a call — and ordering by start alone leaves which
+    /// of the two lands first up to the sort's stability, interleaving the two
+    /// texts.  Applying the wider edit first is the only order that composes.
     #[must_use]
     pub fn apply(&self, source: &str) -> String {
         let mut sorted: Vec<&RefactorEdit> = self.edits.iter().collect();
-        sorted.sort_by_key(|e| std::cmp::Reverse(e.start));
+        sorted.sort_by_key(|e| std::cmp::Reverse((e.start, e.end)));
         let mut result = source.to_owned();
         for edit in sorted {
             let start = (edit.start as usize).min(result.len());
@@ -524,6 +548,7 @@ mod tests {
             ],
             kind: crate::code_actions::ActionKind::RefactorRewrite,
             data_group: None,
+            disabled: None,
         };
         assert_eq!(r.apply("set x 42"), "let x 99");
     }

--- a/rust/tcl-lsp-core/src/refactor/switch_to_dict.rs
+++ b/rust/tcl-lsp-core/src/refactor/switch_to_dict.rs
@@ -103,6 +103,7 @@ pub fn switch_to_dict(
         }],
         kind: ActionKind::RefactorRewrite,
         data_group: None,
+        disabled: None,
     })
 }
 

--- a/rust/tcl-lsp-core/tests/code_actions_depth.rs
+++ b/rust/tcl-lsp-core/tests/code_actions_depth.rs
@@ -1078,7 +1078,13 @@ fn out_of_range_positions_never_panic() {
     let _ = code_actions(src, cursor(0, 9999), Some(&analysis));
     // The package-suggestion and context entry points must also be panic-safe.
     let reg = tcl_registry::CommandRegistry::build_default();
-    let _ = tcl_lsp_core::code_actions::package_require_actions(src, cursor(999, 999), &reg);
+    let _ = tcl_lsp_core::code_actions::package_require_actions(
+        src,
+        cursor(999, 999),
+        &reg,
+        Some(&analysis),
+        &[],
+    );
     let _ = context_diagnostic_actions(
         src,
         &[ContextDiagnostic {

--- a/rust/tcl-lsp-core/tests/code_actions_depth.rs
+++ b/rust/tcl-lsp-core/tests/code_actions_depth.rs
@@ -510,30 +510,37 @@ fn inline_single_command_proc_substitutes_args() {
 
 #[test]
 fn inline_declines_control_flow_body() {
-    // A proc whose body is a control-flow command (`return`) is NOT inlinable —
-    // the action declines. Negative control for the UNSAFE-keyword gate.
+    // A proc whose body is a control-flow command (`return`) is NOT inlinable:
+    // `return` acts on the call frame, so running it in the caller's frame
+    // would return from the *caller*.  The action is surfaced greyed out with
+    // that reason rather than silently omitted (issue #1199), so a user can
+    // tell "cannot be done here" from "is broken".
     let src = "proc f {} { return 1 }\nf\n";
     let analysis = analyse(src);
     let actions = code_actions(src, cursor(1, 0), Some(&analysis));
-    assert!(
-        find(&actions, "Inline proc").is_none(),
-        "control-flow body must not inline; got {:?}",
-        titles(&actions),
-    );
+    let inline = find(&actions, "Inline proc").expect("a refused inline action");
+    let reason = inline
+        .disabled
+        .as_deref()
+        .expect("a control-flow body must be refused, not applied");
+    assert!(reason.contains("call frame"), "{reason}");
+    assert!(inline.edits.is_empty(), "a refusal carries no edits");
 }
 
 #[test]
 fn inline_declines_multi_command_body() {
-    // A multi-command (multi-line) body is declined (the transform only inlines
-    // a single command).
+    // A multi-command body is refused with its reason: splicing several
+    // commands into one caller word changes how the caller parses.
     let src = "proc f {x} {\n    set y $x\n    puts $y\n}\nf 1\n";
     let analysis = analyse(src);
     let actions = code_actions(src, cursor(4, 0), Some(&analysis));
-    assert!(
-        find(&actions, "Inline proc").is_none(),
-        "multi-command body must not inline; got {:?}",
-        titles(&actions),
-    );
+    let inline = find(&actions, "Inline proc").expect("a refused inline action");
+    let reason = inline
+        .disabled
+        .as_deref()
+        .expect("a multi-command body must be refused, not applied");
+    assert!(reason.contains("commands"), "{reason}");
+    assert!(inline.edits.is_empty(), "a refusal carries no edits");
 }
 
 // FIXED: inline_proc_action no longer brace-truncates a body with a braced

--- a/rust/tcl-lsp-core/tests/lsp_lens_links_symbols.rs
+++ b/rust/tcl-lsp-core/tests/lsp_lens_links_symbols.rs
@@ -688,8 +688,12 @@ fn actions_catch_without_result_var_offers_capture_fixes() {
     //   set rc [catch {expr {1/0}} res]; list $rc $res -> 1 {divide by zero}
     //   (verified tclsh8.6 + tclsh9.0).
     // So `catch {expr {1/0}}` (no result var, at proc scope) is W302, and the
-    // provider offers the two synthetic capture quick-fixes that append
-    // ` result` / ` result opts` after the catch body.
+    // provider offers the two capture quick-fixes that append ` result` /
+    // ` result options` after the catch **body**.  The insertion anchor is the
+    // analyser's, computed from the argument tokens: the diagnostic itself
+    // spans only the `catch` keyword, so a provider reconstructing the point
+    // from the diagnostic's end writes the word before the body and turns the
+    // call into a catch of the script `result` (issue #1190).
     let src = "proc f {} {\n    catch {expr {1/0}}\n}\n";
     let analysis = analyse(src);
     // Sanity: the analyser actually flagged W302 here; otherwise this test
@@ -718,15 +722,26 @@ fn actions_catch_without_result_var_offers_capture_fixes() {
     assert!(
         actions
             .iter()
-            .any(|a| a.title == "Add catch result variable"),
+            .any(|a| a.title == "Add catch result variable(s)"),
         "missing ` result` variant; got {titles:?}",
     );
     assert!(
         actions
             .iter()
-            .any(|a| a.title == "Add catch result + options variables"),
-        "missing ` result opts` variant; got {titles:?}",
+            .any(|a| a.title == "Add catch result + options variable(s)"),
+        "missing ` result options` variant; got {titles:?}",
     );
+    // The anchor lands past the body's closing brace, so applying either
+    // action produces a well-formed `catch BODY result …`.
+    for action in actions.iter().filter(|a| a.title.contains("catch result")) {
+        let edit = &action.edits[0];
+        let line = src.lines().nth(edit.range.start_line as usize).unwrap();
+        assert_eq!(
+            &line[..edit.range.start_character as usize],
+            "    catch {expr {1/0}}",
+            "the insertion must sit after the body's closing brace: {edit:?}",
+        );
+    }
     // The fixes are quick-fixes and their edits are well-formed insertions.
     for a in actions.iter().filter(|a| a.title.contains("catch result")) {
         assert_eq!(a.kind, ActionKind::QuickFix);

--- a/rust/tcl-lsp-core/tests/lsp_lens_links_symbols.rs
+++ b/rust/tcl-lsp-core/tests/lsp_lens_links_symbols.rs
@@ -782,14 +782,17 @@ fn actions_extract_proc_on_selection_is_well_formed() {
         end_character: 0,
     };
     let actions = code_actions(src, sel, Some(&analysis));
+    // Select by *title*: extract-variable shares the `refactor.extract` kind,
+    // so a kind-only lookup picks whichever the provider happens to emit first.
     let extract = actions
         .iter()
-        .find(|a| a.kind == ActionKind::RefactorExtract)
+        .find(|a| a.title == "Extract selection into proc")
         .expect("an extract-proc refactor on a selection");
-    assert!(extract.title.contains("Extract"), "{:?}", extract.title);
+    assert_eq!(extract.kind, ActionKind::RefactorExtract);
+    assert!(extract.disabled.is_none(), "{extract:?}");
     assert!(edits_well_formed(extract), "malformed edits: {extract:?}");
-    // Two edits: insert the new proc at top-of-file, replace the selection
-    // with a call.
+    // Two edits: insert the new proc above the enclosing top-level command,
+    // and replace the selection with a call.
     assert_eq!(extract.edits.len(), 2, "{extract:?}");
     let proc_text = &extract.edits[0].new_text;
     assert!(
@@ -797,8 +800,12 @@ fn actions_extract_proc_on_selection_is_well_formed() {
         "first edit defines a proc: {proc_text:?}"
     );
     assert!(
-        proc_text.contains('x'),
-        "the referenced var `x` should become a parameter: {proc_text:?}",
+        proc_text.contains("{x}"),
+        "`x` is read but never written, so it is a value parameter: {proc_text:?}",
+    );
+    assert!(
+        !proc_text.contains("upvar"),
+        "nothing is written back, so no upvar plumbing is needed: {proc_text:?}",
     );
 }
 

--- a/rust/tcl-lsp-core/tests/lsp_providers.rs
+++ b/rust/tcl-lsp-core/tests/lsp_providers.rs
@@ -494,7 +494,7 @@ fn code_actions_catch_without_result_var_offers_fix() {
     // Both fixes are quickfix-kind insertions (empty replaced range).
     let result_fix: &CodeAction = actions
         .iter()
-        .find(|a| a.title == "Add catch result variable")
+        .find(|a| a.title == "Add catch result variable(s)")
         .unwrap_or_else(|| panic!("missing result fix; got {titles:?}"));
     assert_eq!(result_fix.kind, ActionKind::QuickFix);
     assert_eq!(result_fix.edits.len(), 1);
@@ -505,6 +505,11 @@ fn code_actions_catch_without_result_var_offers_fix() {
         (r.start_line, r.start_character),
         (r.end_line, r.end_character)
     );
+    // …and it lands *after the body*, not after the `catch` keyword: applying
+    // it must yield `catch { puts hi } result`, never
+    // `catch result { puts hi }` (issue #1190).
+    let column = r.start_character as usize;
+    assert_eq!(&src[..column], "catch { puts hi }", "range {r:?}");
 }
 
 #[test]

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -14504,6 +14504,14 @@ fn lift_code_actions(
             let data = a
                 .data_group_definition
                 .map(|def| serde_json::json!({ "data_group_definition": def }));
+            // A refactoring that found its subject but cannot preserve
+            // behaviour is surfaced *greyed out* with its reason, rather than
+            // silently omitted: LSP's `disabled.reason` is what the editor
+            // shows, and without it a user cannot tell "does not apply here"
+            // from "is broken" (issues #1199 / #1201).
+            let disabled = a
+                .disabled
+                .map(|reason| tower_lsp_server::ls_types::CodeActionDisabled { reason });
             CodeActionOrCommand::CodeAction(CodeAction {
                 title: a.title,
                 kind: Some(tower_lsp_server::ls_types::CodeActionKind::new(
@@ -14517,7 +14525,7 @@ fn lift_code_actions(
                 }),
                 command,
                 is_preferred: None,
-                disabled: None,
+                disabled,
                 data,
             })
         })

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -13597,8 +13597,18 @@ impl LanguageServer for Backend {
         let line_ending = self.resolved_edit_line_ending(&uri, doc.raw()).await;
         let actions = tokio::task::spawn_blocking(move || {
             let mut actions = core_code_actions::code_actions(&doc.text, range, Some(&analysis));
+            // The fuzzy package-suggestion path needs both the analysis (to
+            // prove the cursor is on an unresolved *command head* rather than
+            // on a comment, a string, or a data word) and the request's own
+            // diagnostics (the editor may be showing a W123 this analysis has
+            // not re-emitted).  Passing neither is what let it fire anywhere
+            // an identifier-shaped word appeared — issue #1191.
             actions.extend(core_code_actions::package_require_actions(
-                &doc.text, range, registry,
+                &doc.text,
+                range,
+                registry,
+                Some(&analysis),
+                &context_diags,
             ));
             actions.extend(core_code_actions::context_diagnostic_actions(
                 &doc.text,

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -377,6 +377,39 @@ const SEMANTIC_TOKENS_REFRESH_DEBOUNCE: std::time::Duration = std::time::Duratio
 /// workspace walk touches.
 const CLOSED_DIAG_BADGE_CAP: usize = 512;
 
+/// How many re-analyse-and-apply rounds `tcl-lsp.fixAllSafeIssues` runs.
+///
+/// Each round applies a batch of non-overlapping fixes and re-analyses, so a
+/// fix a previous edit unblocked (or a diagnostic a previous edit revealed)
+/// is picked up next time round.  The loop also stops early as soon as a
+/// round changes nothing, so this is the guard against a pathological
+/// oscillation — two fixes that keep undoing each other — not the normal
+/// exit.
+const FIX_ALL_MAX_PASSES: usize = 4;
+
+/// One fix selected for a `tcl-lsp.fixAllSafeIssues` pass.
+///
+/// A named struct rather than the tuple the selection used to build: the
+/// tuple's five same-typed fields were positional, and the apply loop indexed
+/// them (`f.0`, `f.2`) at the point where getting one wrong silently rewrites
+/// the wrong bytes.
+struct BulkFix {
+    /// Inclusive start byte offset of the replaced range.
+    start: u32,
+    /// Exclusive end byte offset of the replaced range.
+    end: u32,
+    /// Replacement text.
+    new_text: String,
+    /// The diagnostic code the fix came from, for the `applied` report.
+    code: String,
+    /// The fix's own description, for the `applied` report.
+    description: String,
+    /// The fix's safety class, for the `applied` report — always the
+    /// semantics-equivalent one here, reported so a caller can see *why* the
+    /// fix qualified rather than having to trust the command's name.
+    safety: &'static str,
+}
+
 /// What "still the current state" means for a diagnostics run at publish time,
 /// and therefore what the currency guard re-checks under the `documents` lock
 /// before delivering (`RUST_ISSUE_098`).
@@ -8596,9 +8629,34 @@ impl Backend {
         Some(serde_json::json!({ "events": events }))
     }
 
-    /// Handle `tcl-lsp.fixAllSafeIssues`: apply every non-overlapping safe
-    /// diagnostic fix iteratively until the source stabilises (a whitelist of
-    /// safe fix codes, applied over multiple passes).
+    /// Handle `tcl-lsp.fixAllSafeIssues`: apply every non-overlapping
+    /// **provably semantics-preserving** diagnostic fix, iteratively, until
+    /// the source stabilises.
+    ///
+    /// "Safe" is a property of the individual fix, read from the
+    /// [`FixSafety`](tcl_compiler::analyser::FixSafety) the emitter attached
+    /// to it — not of the diagnostic's code.  The command used to carry its
+    /// own whitelist of codes (`W100`, `W110`, …), which promised a guarantee
+    /// the implementation never established: the same code emits an
+    /// equivalent rewrite for one call and a behaviour-changing one for the
+    /// next.  Under C Tcl 9.0.3:
+    ///
+    /// ```tcl
+    /// set a {$x}; set x 3; set b 2
+    /// puts [expr $a + $b]          ;# 5 — W100's brace fix makes this an error
+    /// puts [expr {"1" == "01"}]    ;# 1 — W110's `eq` rewrite makes this 0
+    /// ```
+    ///
+    /// Both are valuable fixes — they are offered as their own named code
+    /// actions — but neither belongs in an unattended bulk pass (#1195).
+    ///
+    /// Per pass: re-analyse (so a fix whose proof depended on text an earlier
+    /// pass rewrote is re-derived rather than re-used), take each
+    /// diagnostic's first bulk-applicable fix, drop any whose span overlaps
+    /// one already chosen, and apply the rest from the end of the buffer
+    /// backwards so earlier offsets stay valid.  A diagnostic whose code the
+    /// user disabled is not analysed in the first place, so its fixes cannot
+    /// be applied here either.
     async fn fix_all_safe_issues_command(
         &self,
         args: &[serde_json::Value],
@@ -8622,54 +8680,32 @@ impl Backend {
         // unchanged to the other.
         let mut source = doc.raw().to_owned();
         let value = tokio::task::spawn_blocking(move || {
-            const SAFE: &[&str] = &["W100", "W105", "W108", "W110", "W201", "W304", "IRULE2001"];
             let mut applied: Vec<serde_json::Value> = Vec::new();
-            for _ in 0..4 {
+            for _ in 0..FIX_ALL_MAX_PASSES {
                 let mut analyser =
                     Self::configured_analyser(disabled.clone(), na_mode, extra.clone());
                 let analysis = analyser.analyse(&tcl_lexer::normalise_lone_cr(&source), &dialect);
-                // First fix per safe diagnostic, sorted by start offset.
-                let mut fixes: Vec<(u32, u32, String, String, String)> = Vec::new();
-                for d in &analysis.diagnostics {
-                    if !SAFE.contains(&d.code.as_str()) {
-                        continue;
-                    }
-                    if let Some(f) = d.fixes.first() {
-                        fixes.push((
-                            f.span.start(),
-                            f.span.end(),
-                            f.new_text.clone(),
-                            d.code.to_string(),
-                            f.description.clone(),
-                        ));
-                    }
-                }
-                fixes.sort_by_key(|f| f.0);
-                // Keep non-overlapping fixes in order.
-                let mut chosen: Vec<(u32, u32, String, String, String)> = Vec::new();
-                let mut last_end = 0u32;
-                for f in fixes {
-                    if f.0 >= last_end {
-                        last_end = f.1;
-                        chosen.push(f);
-                    }
-                }
+                let chosen = Self::bulk_applicable_fixes(&analysis);
                 if chosen.is_empty() {
                     break;
                 }
                 // Apply from the end so earlier byte offsets stay valid.
                 let mut new_source = source.clone();
-                for f in chosen.iter().rev() {
-                    let (s, e) = (f.0 as usize, f.1 as usize);
-                    if s <= e && e <= new_source.len() {
-                        new_source.replace_range(s..e, &f.2);
+                for fix in chosen.iter().rev() {
+                    let (start, end) = (fix.start as usize, fix.end as usize);
+                    if start <= end && end <= new_source.len() {
+                        new_source.replace_range(start..end, &fix.new_text);
                     }
                 }
                 if new_source == source {
                     break;
                 }
-                for f in &chosen {
-                    applied.push(serde_json::json!({ "code": f.3, "description": f.4 }));
+                for fix in &chosen {
+                    applied.push(serde_json::json!({
+                        "code": fix.code,
+                        "description": fix.description,
+                        "safety": fix.safety,
+                    }));
                 }
                 source = new_source;
             }
@@ -8682,6 +8718,54 @@ impl Backend {
             data: None,
         })?;
         Ok(Some(value))
+    }
+
+    /// The fixes one "Fix All Safe Issues" pass may apply to `analysis`:
+    /// every diagnostic's first [`FixSafety::is_bulk_applicable`] fix, in
+    /// ascending start order, with overlapping fixes dropped.
+    ///
+    /// Three filters, in order:
+    ///
+    /// 1. **Provably equivalent only.** A fix is taken only when its emitter
+    ///    classified *that instance* as semantics-preserving.  A diagnostic
+    ///    whose only fixes are behaviour-changing contributes nothing — its
+    ///    fixes stay available as individually-named code actions.
+    /// 2. **Non-empty edit.** A zero-width fix inserting nothing cannot make
+    ///    progress and would keep the pass loop spinning.
+    /// 3. **Non-overlapping.** Two fixes whose spans touch cannot both be
+    ///    applied against the same coordinate space; the earlier-starting one
+    ///    wins and the other is left for the next pass, where it is
+    ///    re-derived from the rewritten source (so a fix whose proof the
+    ///    first edit invalidated is simply not re-offered).
+    fn bulk_applicable_fixes(analysis: &tcl_compiler::analyser::AnalysisResult) -> Vec<BulkFix> {
+        let mut candidates: Vec<BulkFix> = analysis
+            .diagnostics
+            .iter()
+            .filter_map(|diag| {
+                let fix = diag
+                    .fixes
+                    .iter()
+                    .find(|fix| fix.safety.is_bulk_applicable())?;
+                (fix.span.end() > fix.span.start() || !fix.new_text.is_empty()).then(|| BulkFix {
+                    start: fix.span.start(),
+                    end: fix.span.end(),
+                    new_text: fix.new_text.clone(),
+                    code: diag.code.to_string(),
+                    description: fix.description.clone(),
+                    safety: fix.safety.as_str(),
+                })
+            })
+            .collect();
+        candidates.sort_by_key(|fix| (fix.start, fix.end));
+        let mut chosen: Vec<BulkFix> = Vec::new();
+        let mut last_end = 0u32;
+        for fix in candidates {
+            if fix.start >= last_end {
+                last_end = fix.end.max(fix.start);
+                chosen.push(fix);
+            }
+        }
+        chosen
     }
 
     /// Handle `tcl-lsp.getEffectiveConfig`: the resolved per-document config —
@@ -17116,6 +17200,7 @@ mod tests {
                 span: tcl_lexer::Span::new(0, 0),
                 new_text: format!("package require {pkg}\n"),
                 description: format!("Add 'package require {pkg}'"),
+                safety: tcl_compiler::analyser::FixSafety::BehaviourHardening,
             }],
         }
     }

--- a/rust/tcl-lsp-server/tests/e2e/code_actions.rs
+++ b/rust/tcl-lsp-server/tests/e2e/code_actions.rs
@@ -1147,6 +1147,91 @@ fn test_w120_no_insert_fix_when_require_present() {
     );
 }
 
+// The evidence-gated fuzzy package suggestion (issue #1191).
+//
+// This action changes what the interpreter loads and runs the package's
+// initialisation code, so the server must offer it only over a *command
+// head* that resolution could not satisfy. It used to fire on any
+// identifier-shaped word under the cursor, including one inside a comment or
+// a string.
+
+/// The quickfix titles the server offers at `position` in `source`, with the
+/// published diagnostics fed back as context — the exact flow an editor's
+/// lightbulb drives.
+fn quickfix_titles_at(source: &str, position: (u32, u32)) -> Vec<String> {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, source);
+    let actions = code_actions_only(
+        &mut lsp,
+        &uri,
+        range(position, position),
+        json!(diags),
+        &["quickfix"],
+    );
+    titles(&actions)
+}
+
+#[test]
+fn test_package_suggestion_offered_on_an_unresolved_command_head() {
+    // `http` names a registered package and `http::fetchall` resolves to
+    // nothing, so the suggestion is evidence-backed.
+    let offered = quickfix_titles_at("http::fetchall $url\n", (0, 3));
+    assert!(
+        offered.iter().any(|t| t == "Add 'package require http'"),
+        "{offered:?}"
+    );
+}
+
+#[test]
+fn test_package_suggestion_not_offered_inside_a_comment() {
+    let offered = quickfix_titles_at("# see http::fetchall for details\n", (0, 10));
+    assert!(
+        !offered
+            .iter()
+            .any(|t| t.starts_with("Add 'package require")),
+        "a comment is not a call site: {offered:?}"
+    );
+}
+
+#[test]
+fn test_package_suggestion_not_offered_inside_a_string() {
+    let offered = quickfix_titles_at("set example \"http::fetchall\"\n", (0, 16));
+    assert!(
+        !offered
+            .iter()
+            .any(|t| t.starts_with("Add 'package require")),
+        "quoted data is not a call site: {offered:?}"
+    );
+}
+
+#[test]
+fn test_package_suggestion_not_offered_on_an_argument_word() {
+    let offered = quickfix_titles_at("dict set docs command http::fetchall\n", (0, 25));
+    assert!(
+        !offered
+            .iter()
+            .any(|t| t.starts_with("Add 'package require")),
+        "an argument word is not a call site: {offered:?}"
+    );
+}
+
+#[test]
+fn test_package_suggestion_not_offered_on_a_local_definition() {
+    // The file defines the very command a package would provide, both at the
+    // `proc` name word and at the later call.
+    let source = "proc http::fetchall {url} {}\nhttp::fetchall http://x\n";
+    for position in [(0u32, 8u32), (1, 3)] {
+        let offered = quickfix_titles_at(source, position);
+        assert!(
+            !offered
+                .iter()
+                .any(|t| t.starts_with("Add 'package require")),
+            "locally defined at {position:?}: {offered:?}"
+        );
+    }
+}
+
 /// W123: the unknown-command did-you-mean suggestion carries a replacement
 /// fix covering exactly the misspelt head.
 #[test]

--- a/rust/tcl-lsp-server/tests/e2e/code_actions.rs
+++ b/rust/tcl-lsp-server/tests/e2e/code_actions.rs
@@ -508,6 +508,124 @@ fn test_extract_proc_snippets() {
     assert!(snippets.iter().any(|s| s.contains("extracted_proc $value")));
 }
 
+/// The `refactor.extract` actions named "Extract selection into proc" for a
+/// selection of `source`, requested through the real server.
+fn extract_proc_actions(lsp: &mut Lsp, uri: &str, from: (u32, u32), to: (u32, u32)) -> Vec<Value> {
+    let actions = code_actions_only(lsp, uri, range(from, to), json!([]), &["refactor.extract"]);
+    kinds(&actions, "refactor.extract")
+        .into_iter()
+        .filter(|a| action_title(a) == "Extract selection into proc")
+        .collect()
+}
+
+#[test]
+fn test_extract_proc_carries_a_caller_write_through_upvar() {
+    // Issue #1201's reproducer.  The original prints `1` then `after=1`; the
+    // old shape moved the `set x 1` into a proc *local*, so the caller kept
+    // its old value and printed `after=0`.  The generated proc now takes the
+    // variable by name and re-binds it with `upvar 1`, so the assignment
+    // lands back in the caller's frame.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, "set x 0\nset x 1\nputs $x\nputs \"after=$x\"\n");
+    let extract = extract_proc_actions(&mut lsp, &uri, (1, 0), (3, 0));
+    assert_eq!(extract.len(), 1, "{extract:?}");
+    let snippets = new_texts(&json!(extract));
+    assert!(
+        snippets.iter().any(|s| s.contains("upvar 1 $xName x")),
+        "the write must reach the caller's frame: {snippets:?}"
+    );
+    assert!(
+        snippets.iter().any(|s| s.trim_end() == "extracted_proc x"),
+        "the call passes the variable's name, not its value: {snippets:?}"
+    );
+}
+
+#[test]
+fn test_extract_proc_refuses_a_selection_containing_return() {
+    // `return` acts on the call frame: inside a new proc it would return from
+    // that proc rather than from the enclosing one.  Refused with a reason.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, "proc f {} {\n    set x 1\n    return $x\n}\n");
+    let extract = extract_proc_actions(&mut lsp, &uri, (2, 0), (3, 0));
+    assert_eq!(extract.len(), 1, "{extract:?}");
+    let reason = extract[0]
+        .get("disabled")
+        .and_then(|d| d.get("reason"))
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("expected a refusal reason: {:?}", extract[0]));
+    assert!(reason.contains("call frame"), "{reason}");
+}
+
+#[test]
+fn test_extract_proc_refuses_a_selection_inside_a_namespace_eval() {
+    // The extracted proc would be created in a different namespace from the
+    // one the moved code ran in.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, "namespace eval app {\n    set x 1\n    puts $x\n}\n");
+    let extract = extract_proc_actions(&mut lsp, &uri, (2, 0), (3, 0));
+    assert_eq!(extract.len(), 1, "{extract:?}");
+    let reason = extract[0]
+        .get("disabled")
+        .and_then(|d| d.get("reason"))
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("expected a refusal reason: {:?}", extract[0]));
+    assert!(reason.contains("namespace"), "{reason}");
+}
+
+#[test]
+fn test_inline_proc_binds_a_declared_default() {
+    // C Tcl 9 prints `hello world`: the omitted argument takes the parameter's
+    // declared default.  The old textual splice emitted `puts "hello $name"`,
+    // which errors on an unset variable (issue #1199).
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let source = "proc greet {{name world}} { puts $name }\ngreet\n";
+    lsp.open_ready(&uri, source);
+    let actions = code_actions_only(
+        &mut lsp,
+        &uri,
+        range((1, 1), (1, 1)),
+        json!([]),
+        &["refactor.inline"],
+    );
+    let inline = kinds(&actions, "refactor.inline");
+    assert_eq!(inline.len(), 1, "{actions:?}");
+    assert!(
+        new_texts(&json!(inline)).iter().any(|s| s == "puts world"),
+        "the default must bind: {inline:?}"
+    );
+}
+
+#[test]
+fn test_inline_proc_refuses_a_braced_argument_with_a_reason() {
+    // `greet {a b}` passes the *value* `a b`.  Splicing the written word made
+    // the body print the braces, so the transform refuses and explains.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "proc greet {name} { puts \"hello $name\" }\ngreet {a b}\n",
+    );
+    let actions = code_actions_only(
+        &mut lsp,
+        &uri,
+        range((1, 1), (1, 1)),
+        json!([]),
+        &["refactor.inline"],
+    );
+    let inline = kinds(&actions, "refactor.inline");
+    assert_eq!(inline.len(), 1, "{actions:?}");
+    let reason = inline[0]
+        .get("disabled")
+        .and_then(|d| d.get("reason"))
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("expected a refusal reason: {:?}", inline[0]));
+    assert!(reason.contains("plain word"), "{reason}");
+}
+
 #[test]
 fn test_extract_proc_attaches_rename_command() {
     let mut lsp = Lsp::tcl();
@@ -520,7 +638,13 @@ fn test_extract_proc_attaches_rename_command() {
         json!([]),
         &["refactor.extract"],
     );
-    let extract = kinds(&actions, "refactor.extract");
+    // The extract-*proc* action carries the rename; extract-variable shares
+    // the `refactor.extract` kind, so select by title rather than by index.
+    let extract: Vec<Value> = kinds(&actions, "refactor.extract")
+        .into_iter()
+        .filter(|a| action_title(a) == "Extract selection into proc")
+        .collect();
+    assert_eq!(extract.len(), 1, "{actions:?}");
     let cmd = extract[0].get("command").cloned().unwrap_or(Value::Null);
     assert!(!cmd.is_null());
     assert_eq!(
@@ -535,7 +659,10 @@ fn test_extract_proc_attaches_rename_command() {
     let line = args[0].as_i64().unwrap();
     let start = args[1].as_i64().unwrap();
     let end = args[2].as_i64().unwrap();
-    assert_eq!(line, 0);
+    // The definition is inserted above the selection (line 1), not at line 0:
+    // placing it at the top of the file would put it before any `package
+    // require` / `namespace` prologue (issue #1201).
+    assert_eq!(line, 1);
     assert_eq!(start, i64::try_from("proc ".len()).unwrap());
     assert_eq!(end, start + i64::try_from("extracted_proc".len()).unwrap());
 }
@@ -562,7 +689,12 @@ fn test_inline_proc_available() {
 }
 
 #[test]
-fn test_inline_proc_skips_returning_proc() {
+fn test_inline_proc_refuses_a_returning_proc_with_a_reason() {
+    // `return` acts on the call frame: inlined into the caller it would
+    // return from the *caller*, not from the proc.  The action is surfaced
+    // greyed out with LSP's `disabled.reason` rather than silently omitted,
+    // so the user can tell "cannot be done here" from "is broken"
+    // (issue #1199).
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
     lsp.open_ready(&uri, "proc wrap {x} { return $x }\nwrap value\n");
@@ -573,7 +705,18 @@ fn test_inline_proc_skips_returning_proc() {
         json!([]),
         &["refactor.inline"],
     );
-    assert!(kinds(&actions, "refactor.inline").is_empty());
+    let inline = kinds(&actions, "refactor.inline");
+    assert_eq!(inline.len(), 1, "{actions:?}");
+    let reason = inline[0]
+        .get("disabled")
+        .and_then(|d| d.get("reason"))
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("expected a refusal reason: {:?}", inline[0]));
+    assert!(reason.contains("call frame"), "{reason}");
+    assert!(
+        new_texts(&json!(inline)).is_empty(),
+        "a refused action carries no edits: {inline:?}"
+    );
 }
 
 // -- TestExprRefactorActions ---------------------------------------------

--- a/rust/tcl-lsp-server/tests/e2e/code_actions.rs
+++ b/rust/tcl-lsp-server/tests/e2e/code_actions.rs
@@ -218,23 +218,85 @@ fn test_w003_no_fix_when_operator_nested_in_larger_expression() {
     );
 }
 
+/// The W302 quick-fix actions the server offers for `source`.
+///
+/// The cursor sits on the `catch` keyword — where the diagnostic anchors and
+/// where an editor's lightbulb is invoked — which is precisely the position
+/// the broken anchor derived its (wrong) insertion point from.
+fn w302_actions(lsp: &mut Lsp, uri: &str, source: &str) -> Value {
+    let diags = lsp.open_ready(uri, source);
+    let w302 = with_code(&diags, "W302");
+    assert!(!w302.is_empty(), "expected a W302 diagnostic: {diags:?}");
+    code_actions_only(lsp, uri, range((0, 0), (0, 4)), json!(w302), &["quickfix"])
+}
+
 #[test]
-fn test_w302_adds_result_capture_actions() {
+fn test_w302_result_capture_action_applies_after_the_body() {
+    // Issue #1190: the actions used to insert the right text at the wrong
+    // place, producing `catch result {error oops}` — C Tcl then evaluates
+    // the script `result` (completion code 1, `invalid command name
+    // "result"`) and stores it in a variable named `error oops`.  Asserting
+    // the *applied document* is what catches that; the old assertions
+    // checked only the inserted string and that the range was zero-width,
+    // both of which the broken fix satisfied.
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
-    let diags = lsp.open_ready(&uri, "catch {error oops}\n");
-    let w302 = with_code(&diags, "W302");
-    assert!(!w302.is_empty());
-    let actions = code_actions_only(
-        &mut lsp,
-        &uri,
-        range((0, 0), (0, 4)),
-        json!(w302),
-        &["quickfix"],
+    let source = "catch {error oops}\n";
+    let actions = w302_actions(&mut lsp, &uri, source);
+    assert_fix_applies(
+        &actions,
+        source,
+        "Add catch result variable(s)",
+        "catch {error oops} result\n",
     );
-    let snippets = new_texts(&actions);
-    assert!(snippets.iter().any(|s| s == " result"));
-    assert!(snippets.iter().any(|s| s == " result opts"));
+    assert_fix_applies(
+        &actions,
+        source,
+        "Add catch result + options variable(s)",
+        "catch {error oops} result options\n",
+    );
+}
+
+#[test]
+fn test_w302_result_capture_action_applies_after_a_multiline_body() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let source = "catch {\n    error oops\n}\n";
+    let actions = w302_actions(&mut lsp, &uri, source);
+    assert_fix_applies(
+        &actions,
+        source,
+        "Add catch result variable(s)",
+        "catch {\n    error oops\n} result\n",
+    );
+}
+
+#[test]
+fn test_w302_result_capture_action_keeps_a_trailing_comment() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let source = "catch {error oops} ;# best effort\n";
+    let actions = w302_actions(&mut lsp, &uri, source);
+    assert_fix_applies(
+        &actions,
+        source,
+        "Add catch result variable(s)",
+        "catch {error oops} result ;# best effort\n",
+    );
+}
+
+#[test]
+fn test_w302_result_capture_action_does_not_overshoot_an_empty_body() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let source = "catch {}\n";
+    let actions = w302_actions(&mut lsp, &uri, source);
+    assert_fix_applies(
+        &actions,
+        source,
+        "Add catch result variable(s)",
+        "catch {} result\n",
+    );
 }
 
 #[test]

--- a/rust/tcl-lsp-server/tests/e2e/commands.rs
+++ b/rust/tcl-lsp-server/tests/e2e/commands.rs
@@ -48,21 +48,94 @@ fn source(result: &Value) -> &str {
 // -- TestDocumentTransforms ----------------------------------------------
 
 #[test]
-fn fix_all_safe_issues_clears_w100() {
+fn fix_all_safe_issues_braces_a_substitution_free_expression() {
+    // TP: nothing substitutes in `abs(-2)`, so `expr` receives the same
+    // string braced or not — the class of repair the bulk pass exists for.
+    // The assertion is on the returned *source*, not on the `applied` code
+    // list, so a fix that reports itself but rewrites the wrong bytes fails.
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
-    lsp.open_ready(&uri, "if $a { puts yes }\nset n [expr $x + 1]\n");
+    lsp.open_ready(&uri, "set n [expr abs(-2)]\n");
     let result = lsp.execute_command("tcl-lsp.fixAllSafeIssues", json!([uri]));
     assert!(!result.is_null());
-    assert!(
-        source(&result).contains("if {$a} { puts yes }"),
-        "{}",
-        source(&result)
-    );
+    assert_eq!(source(&result), "set n [expr {abs(-2)}]\n");
     assert_eq!(
         applied_codes(&result),
         std::collections::BTreeSet::from(["W100".to_owned()])
     );
+}
+
+#[test]
+fn fix_all_safe_issues_leaves_a_substituted_expression_alone() {
+    // FP, and the reason issue #1195 was filed.  Under C Tcl 9.0.3 this
+    // program prints `5`: `$a` substitutes to the string `$x`, and `expr`
+    // substitutes *that* to 3.  Bracing makes it an error, so the bulk pass
+    // must not do it — the individually-named "Brace expr for safety and
+    // performance" action still offers it.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "set a {$x}\nset x 3\nset b 2\nputs [expr $a + $b]\n";
+    lsp.open_ready(&uri, src);
+    let result = lsp.execute_command("tcl-lsp.fixAllSafeIssues", json!([uri]));
+    assert!(!result.is_null());
+    assert_eq!(source(&result), src, "the source must come back untouched");
+    assert!(!applied_codes(&result).contains("W100"), "{result:?}");
+}
+
+#[test]
+fn fix_all_safe_issues_leaves_a_numeric_string_comparison_alone() {
+    // FP: `expr {"1" == "01"}` is 1 (numeric coercion) and
+    // `expr {"1" eq "01"}` is 0 (string comparison).  W110's advice is
+    // sound; applying it unattended changes results.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "puts [expr {\"1\" == \"01\"}]\n";
+    lsp.open_ready(&uri, src);
+    let result = lsp.execute_command("tcl-lsp.fixAllSafeIssues", json!([uri]));
+    assert!(!result.is_null());
+    assert_eq!(source(&result), src);
+    assert!(!applied_codes(&result).contains("W110"), "{result:?}");
+}
+
+#[test]
+fn fix_all_safe_issues_reports_the_safety_class_it_applied() {
+    // The `applied` entries name *why* each fix qualified, so a caller need
+    // not trust the command's name for that.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, "set n [expr abs(-2)]\n");
+    let result = lsp.execute_command("tcl-lsp.fixAllSafeIssues", json!([uri]));
+    let applied = result.get("applied").and_then(Value::as_array).unwrap();
+    assert!(!applied.is_empty());
+    for entry in applied {
+        assert_eq!(
+            entry.get("safety").and_then(Value::as_str),
+            Some("semantics-equivalent"),
+            "{entry:?}"
+        );
+    }
+}
+
+#[test]
+fn fix_all_safe_issues_respects_a_disabled_diagnostic() {
+    // TN: a diagnostic the user turned off is never analysed, so its fixes
+    // cannot be applied in bulk either.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "set n [expr abs(-2)]\n";
+    lsp.apply_configuration_settle(
+        json!({ "diagnostics": { "W100": false } }),
+        &uri,
+        |config| {
+            config["disabled_diagnostics"]
+                .as_array()
+                .is_some_and(|codes| codes.iter().any(|code| code == "W100"))
+        },
+    );
+    lsp.open_ready(&uri, src);
+    let result = lsp.execute_command("tcl-lsp.fixAllSafeIssues", json!([uri]));
+    assert!(!result.is_null());
+    assert_eq!(source(&result), src);
 }
 
 #[test]

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -1372,6 +1372,62 @@ impl CommandRegistry {
         out
     }
 
+    /// The declared roles of the argument positions a call has **not**
+    /// filled — the optional trailing words a caller could still append.
+    ///
+    /// [`Self::arg_indices_for_role`] answers "what role does each supplied
+    /// argument play"; this answers the complementary question a
+    /// splice-a-trailing-word quick-fix needs: "what would the *next* words
+    /// mean if I added them".  Positions are returned in ascending order,
+    /// starting at `args.len()` and stopping at the spec's arity ceiling, and
+    /// only while the spec actually declares a role for the position — an
+    /// unlimited-arity command with no declared tail role yields nothing
+    /// rather than an unbounded run of `Value` slots.
+    ///
+    /// A subcommand-dispatching call resolves against the subcommand's own
+    /// role table (offset by the subcommand word), exactly as
+    /// [`Self::arg_indices_for_role`] does, so `chan gets`-shaped commands
+    /// answer for the right spec.  Dynamic
+    /// [`arg_role_resolver`](CommandSpec::arg_role_resolver) tables are
+    /// consulted with the supplied argument list, which is what a resolver
+    /// keyed on the *written* words can answer; positions the resolver does
+    /// not name are simply absent from the result.
+    #[must_use]
+    pub fn unfilled_trailing_roles(&self, name: &str, args: &[&str]) -> Vec<(usize, ArgRole)> {
+        let Some(spec) = self.get(name) else {
+            return Vec::new();
+        };
+        // Resolve against the subcommand when one dispatches, mirroring
+        // `arg_indices_for_role`: `sub_offset` is the number of leading words
+        // (the subcommand itself) the subcommand's own indices sit after.
+        let sub = (!spec.subcommands.is_empty())
+            .then(|| args.first().and_then(|word| spec.resolve_subcommand(word)))
+            .flatten();
+        let (static_roles, dynamic_roles, sub_offset) = match sub {
+            Some(sub) => (sub.arg_roles, sub.arg_role_resolver, 1usize),
+            None => (spec.arg_roles, spec.arg_role_resolver, 0usize),
+        };
+        let declared: Vec<(usize, ArgRole)> = match dynamic_roles {
+            Some(resolve) => resolve(args.get(sub_offset..).unwrap_or(&[]))
+                .into_iter()
+                .map(|(idx, role)| (idx as usize + sub_offset, role))
+                .collect(),
+            None => static_roles
+                .iter()
+                .map(|(idx, role)| (*idx as usize + sub_offset, *role))
+                .collect(),
+        };
+        let ceiling = usize::from(spec.arity.max);
+        (args.len()..ceiling)
+            .map_while(|position| {
+                declared
+                    .iter()
+                    .find(|(idx, _)| *idx == position)
+                    .map(|(_, role)| (position, *role))
+            })
+            .collect()
+    }
+
     /// [`Self::arg_indices_for_role`]`(name, args, `[`ArgRole::Body`]`)`,
     /// filtered to the indices whose [`BodyKind`] is
     /// [`Plain`](BodyKind::Plain) — a body that runs in the caller's own

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -1915,6 +1915,58 @@ impl std::fmt::Debug for CommandRegistry {
 
 #[cfg(test)]
 mod tests {
+    // -- unfilled_trailing_roles (issue #1190) ----------------------------
+    //
+    // The complement of `arg_indices_for_role`: what the *next* words would
+    // mean, which is the question a splice-a-trailing-argument quick fix asks.
+
+    #[test]
+    fn unfilled_trailing_roles_reports_the_optional_capture_variables() {
+        let reg = CommandRegistry::build_default();
+        // `catch {body}` leaves both `VarWrite` slots open.
+        assert_eq!(
+            reg.unfilled_trailing_roles("catch", &["{body}"]),
+            vec![(1, ArgRole::VarWrite), (2, ArgRole::VarWrite)]
+        );
+        // One supplied leaves one.
+        assert_eq!(
+            reg.unfilled_trailing_roles("catch", &["{body}", "res"]),
+            vec![(2, ArgRole::VarWrite)]
+        );
+        // Fully supplied leaves none.
+        assert!(
+            reg.unfilled_trailing_roles("catch", &["{body}", "res", "opts"])
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn unfilled_trailing_roles_stops_at_the_arity_ceiling() {
+        let reg = CommandRegistry::build_default();
+        // Every position past `catch`'s maximum of three is absent, however
+        // many are asked for.
+        let roles = reg.unfilled_trailing_roles("catch", &["{body}"]);
+        assert!(roles.iter().all(|(index, _)| *index < 3), "{roles:?}");
+    }
+
+    #[test]
+    fn unfilled_trailing_roles_is_empty_for_an_unknown_command() {
+        let reg = CommandRegistry::build_default();
+        assert!(
+            reg.unfilled_trailing_roles("no_such_command", &[])
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn unfilled_trailing_roles_stops_at_an_undeclared_position() {
+        let reg = CommandRegistry::build_default();
+        // `puts` declares no trailing role a caller could fill with a
+        // *known* meaning, so nothing is offered rather than an unbounded
+        // run of `Value` slots.
+        assert!(reg.unfilled_trailing_roles("puts", &["hello"]).is_empty());
+    }
+
     /// `SAFE_INTERP_HIDDEN` and `TRANSFERS_CONTROL` were the same bit.
     ///
     /// Both were spelled `1 << 61`, so the 65th trait silently aliased the

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -1953,3 +1953,52 @@ impl SubCommand {
             .map_or(&[], |(_, vs)| vs)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::CommandRegistry;
+
+    // -- optional_trailing_arg_names (issue #1190) ------------------------
+    //
+    // A quick fix that appends a documented optional argument learns both how
+    // many words it may append and what to call them from the synopsis, so a
+    // dialect whose form documents fewer words gets a narrower offer.
+
+    #[test]
+    fn optional_trailing_placeholders_takes_the_trailing_run() {
+        assert_eq!(
+            optional_trailing_placeholders("catch script ?resultVarName? ?optionsVarName?"),
+            vec!["resultVarName", "optionsVarName"]
+        );
+        // A required word terminates the run — these are the words a caller
+        // may append *without* also having to supply something in between.
+        assert_eq!(
+            optional_trailing_placeholders("cmd ?a? required ?b?"),
+            vec!["b"]
+        );
+        // No optional tail at all.
+        assert!(optional_trailing_placeholders("puts string").is_empty());
+        // A variadic tail is not a fixed slot list.
+        assert!(optional_trailing_placeholders("cmd ?arg ...?").is_empty());
+        assert!(optional_trailing_placeholders("cmd ?...?").is_empty());
+    }
+
+    #[test]
+    fn optional_trailing_arg_names_narrows_with_the_dialect() {
+        let registry = CommandRegistry::build_default();
+        let spec = registry.get("catch").expect("catch is a registry command");
+        // Tcl 8.5 onward documents `catch script ?resultVarName? ?optionsVarName?`.
+        assert_eq!(
+            spec.optional_trailing_arg_names(DialectSet::TCL90),
+            vec!["resultVarName", "optionsVarName"]
+        );
+        // Tcl 8.4's `catch script ?varName?` has no options dictionary, so a
+        // consumer running under that dialect never offers a word the release
+        // has no argument slot for.
+        assert_eq!(
+            spec.optional_trailing_arg_names(DialectSet::TCL84),
+            vec!["varName"]
+        );
+    }
+}

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -928,6 +928,29 @@ fn leading_option_word_count(options: &[OptionSpec], args: &[&str]) -> usize {
     i
 }
 
+/// The trailing run of `?placeholder?` words in a synopsis, `?` stripped.
+///
+/// A synopsis is a whitespace-separated word list whose optional arguments
+/// are wrapped in `?…?` (`catch script ?resultVarName? ?optionsVarName?`).
+/// Scanning from the right and stopping at the first word that is not so
+/// wrapped yields exactly the words a caller may append to a call that
+/// supplies every earlier word — the question a splice-a-trailing-argument
+/// quick-fix asks.  A variadic tail (`?arg ...?`, `?arg arg ...?`) is not a
+/// fixed slot list, so a placeholder containing whitespace or an ellipsis
+/// terminates the run rather than being offered as a name.
+fn optional_trailing_placeholders(synopsis: &'static str) -> Vec<&'static str> {
+    let mut names: Vec<&'static str> = synopsis
+        .split_whitespace()
+        .rev()
+        .map_while(|word| {
+            let inner = word.strip_prefix('?')?.strip_suffix('?')?;
+            (!inner.is_empty() && inner != "..." && !inner.contains("...")).then_some(inner)
+        })
+        .collect();
+    names.reverse();
+    names
+}
+
 impl CommandSpec {
     /// Default value for all fields — used with `..CommandSpec::DEFAULT`.
     pub const DEFAULT: Self = Self {
@@ -1046,6 +1069,41 @@ impl CommandSpec {
             .map(|f| f.synopsis)
             .chain(self.hover.iter().flat_map(|h| h.synopsis.iter().copied()))
             .find(|s| !s.is_empty())
+    }
+
+    /// The names of the optional trailing words the *dialect-applicable*
+    /// synopses document — the run of `?placeholder?` words at the end of a
+    /// [`Self::forms`] entry, with the `?` markers stripped.
+    ///
+    /// This is how a quick-fix that offers to *append* a documented optional
+    /// argument learns both how many words it may append and what to call
+    /// them, without the consumer knowing the command.  `catch script
+    /// ?resultVarName? ?optionsVarName?` yields
+    /// `["resultVarName", "optionsVarName"]`; the narrower Tcl 8.4 / iRules
+    /// form `catch script ?varName?` yields `["varName"]`, so a consumer
+    /// running under those dialects never offers the options-dictionary word
+    /// that release has no argument slot for.
+    ///
+    /// The widest applicable form wins, since a command may declare several
+    /// overlapping forms for one dialect and the widest documents every slot
+    /// the narrower ones do.  A form whose optional tail is interrupted by a
+    /// required word contributes only its trailing run: the words a caller
+    /// can append without also having to supply something in between.
+    ///
+    /// Returns an empty vector when the command declares no forms, none apply
+    /// to *dialect*, or the applicable ones end in a required word.
+    #[must_use]
+    pub fn optional_trailing_arg_names(&self, dialect: DialectSet) -> Vec<&'static str> {
+        self.forms
+            .iter()
+            .filter(|form| {
+                form.dialects
+                    .or(self.dialects)
+                    .is_none_or(|allowed| allowed.contains(dialect))
+            })
+            .map(|form| optional_trailing_placeholders(form.synopsis))
+            .max_by_key(Vec::len)
+            .unwrap_or_default()
     }
 
     /// Resolve a subcommand word to its [`SubCommand`], accepting a unique


### PR DESCRIPTION
## Summary

- W302 catch-result quick fixes anchor past the body; fix safety is classified into tiers and "Fix All Safe Issues" applies only proven-equivalent fixes (`bulk_applicable_fixes`); package-require code actions are gated on real command-head evidence; inline-proc binds arguments and extract-proc keeps caller writes; generated proc names compare qualified.
- Closes #1190, closes #1191, closes #1195, closes #1199, closes #1201.
- Rebase note: #1212 rewrote the fix-all loop to analyse the CR-normalised form of the raw buffer. This branch keeps that (`analyse(&normalise_lone_cr(&source))` over `doc.raw()`) while replacing the inline SAFE-list selection with `bulk_applicable_fixes`.

Part of the per-group PR series; independent of the other groups.

## Validation

- [x] On the group branch: full `cargo test -p tcl-lsp-server -p tcl-compiler`, clippy `-D warnings`, fmt — green at development time.
- [x] Rebased onto `rust` (post-#1212): `cargo check --workspace --all-targets` 0 errors; `cargo test -p tcl-lsp-server --test e2e -- fix_all code_action` — 89 passed, 0 failed.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? — Fix metadata gains a safety classification; diagnostic codes and severities unchanged.
- [x] If yes, I updated at least one relevant KCS note — `docs/kcs/kcs-qa-what-does-fix-all-safe-issues-apply.md` (new, user-facing QA note).
- [ ] If I added a new compiler KCS note, I linked it — n/a (not a compiler note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_