### PR TITLE
Test infra: worktree cargo resolution, flaky diagnostics-timing e2e, lsp-client harness, parity-doc revalidation (#1111, #1135, #1136, #1189)

### DIFF
--- a/.claude/skills/lsp-client/SKILL.md
+++ b/.claude/skills/lsp-client/SKILL.md
@@ -56,15 +56,35 @@ All line/col arguments are **0-based**, matching the LSP protocol.
 `definition`, `references`, `diagnostics`, `code-actions`, `context`,
 `all`, `completion`, and `code-lens` wait for the server's background
 workspace scan to finish before
-proceeding (bounded by `--scan-timeout`, default 15s) — otherwise
-cross-file results (workspace variables, package tiers, cross-file
-definition/references, sibling-file completions, workspace-wide lens
-counts) are racy depending on scan timing (issue #1094).
+proceeding (bounded by `--scan-timeout`, default 30s — see below) —
+otherwise cross-file results (workspace variables, package tiers,
+cross-file definition/references, sibling-file completions,
+workspace-wide lens counts) are racy depending on scan timing (issue #1094).
 Other subcommands are single-file and unaffected. If you add a new
 cross-file check, call `client.wait_for_workspace_scan()` yourself before
 opening the document(s) it depends on — see the method's docstring in
 `lsp_client.py` for the exact signal it waits on and why waiting *before*
 `didOpen` matters for diagnostics specifically.
+
+**Multi-file helper (`--also-open`):** pass `--also-open FILE` (repeatable,
+any subcommand) to open one or more companion files before the main
+`<file>` argument — the first-class "open two files and assert" helper
+(issue #1111). Companion files open *after* the workspace-scan wait above
+and *before* `<file>`, so whichever subcommand you run sees them:
+
+```bash
+python3 .claude/skills/lsp-client/lsp_client.py --also-open lib.tcl \
+    definition consumer.tcl 3 10
+```
+
+(`--also-open`, like `--scan-timeout` and `--server-bin`, is a top-level
+option — it must come *before* the subcommand name, not after.)
+
+This opens `lib.tcl`, waits the usual workspace-scan barrier (since
+`definition` is a cross-file command), then opens `consumer.tcl` and asks
+for the definition at `3:10` — the pattern the docstring above used to ask
+callers to hand-roll with `wait_for_workspace_scan()` + two `open_document()`
+calls.
 
 ## Interpreting Output
 
@@ -243,6 +263,7 @@ python3 .claude/skills/lsp-client/lsp_client.py context tcl-lsp/samples/for_scre
 python3 .claude/skills/lsp-client/lsp_client.py all tcl-lsp/samples/for_screenshots/03-completions.tcl
 python3 .claude/skills/lsp-client/lsp_client.py bench tcl-lsp/samples/tcl/09_long_code.tcl --iterations 3
 python3 .claude/skills/lsp-client/lsp_client.py logs tcl-lsp/samples/tcl/09_long_code.tcl --timing-only
+python3 .claude/skills/lsp-client/lsp_client.py --also-open tcl-lsp/samples/tcl/lib.tcl definition tcl-lsp/samples/tcl/consumer.tcl 3 10
 ```
 
 $ARGUMENTS

--- a/.claude/skills/lsp-client/lsp_client.py
+++ b/.claude/skills/lsp-client/lsp_client.py
@@ -27,10 +27,18 @@ context/all/completion/code-lens touching more than one file's worth of
 state — workspace variables, package tiers, sibling-file completions,
 workspace-wide lens counts) wait out the server's background workspace scan
 first via `LspClient.wait_for_workspace_scan()` (bounded by --scan-timeout,
-default 15s) rather than racing it — see issue #1094 and that method's
+default 30s — measured/tuned per issue #1111) rather than racing it — see
+issue #1094 and that method's
 docstring for the exact server-side signal it waits on. Single-file
 subcommands (semantic-tokens, hover, format, ...) are unaffected and
 don't wait.
+
+Pass `--also-open FILE` (repeatable) to open one or more companion files
+before the main <file> argument — the first-class "open two files and
+assert" helper (issue #1111) for a cross-file check (a definition/reference
+in <file> resolving into FILE, a sibling-file completion, a workspace-wide
+lens count). Companion files are opened *after* the workspace-scan wait
+above and *before* <file>, so whichever subcommand you run sees them.
 
 Usage:
     python3 lsp_client.py semantic-tokens <file.tcl>
@@ -181,6 +189,14 @@ COMPLETION_KIND = {
 # (completion enumerates sibling-file procedures; lenses count
 # workspace-wide references), so they wait too — before `didOpen` via
 # `main()`, which is also sufficient for their per-request reads.
+#
+# Verified live (issue #1111) against a real `tcl-lsp-server` build (this
+# reasoning previously rested on code inspection only — no binary was
+# buildable in the sandbox that filed the issue): `--also-open` + `definition`
+# resolving a companion file's symbol on the *first* request of 20/20 freshly
+# spawned server processes, with no `--scan-timeout` override, confirms
+# waiting before `didOpen` sidesteps the race the comment above describes
+# rather than merely happening not to trigger it.
 CROSS_FILE_COMMANDS = {
     "definition",
     "references",
@@ -447,7 +463,7 @@ class LspClient:
                 messages.append(params.get("message", ""))
         return messages
 
-    def wait_for_workspace_scan(self, timeout: float = 15.0) -> str:
+    def wait_for_workspace_scan(self, timeout: float = 30.0) -> str:
         """Block until the server's initial background workspace scan completes.
 
         Cross-file navigation (`textDocument/definition`,
@@ -1671,12 +1687,36 @@ examples:
     parser.add_argument(
         "--scan-timeout",
         type=float,
-        default=15.0,
+        default=30.0,
         help=(
             "Seconds to wait for the background workspace scan to complete "
             "before cross-file subcommands (definition, references, "
             "diagnostics, code-actions, context, all) proceed. See "
-            "issue #1094. Default: 15.0."
+            "issue #1094. Default: 30.0 — tuned against a measured "
+            "worst-case scan (issue #1111): a workspace at "
+            "WORKSPACE_SCAN_FILE_CAP (2000 files) took ~12.3s unloaded / "
+            "~15.2s under 4-way CPU contention on a 4-core box in a *debug* "
+            "build (a `--release` build did the same scan in ~1.9s), so the "
+            "old 15.0s default left under 20% headroom over the unloaded "
+            "debug-build worst case and none at all once loaded. 30.0 keeps "
+            "roughly 2x headroom over the worst measured case and matches "
+            "the Rust e2e harness's own `DEFAULT_TIMEOUT`."
+        ),
+    )
+    parser.add_argument(
+        "--also-open",
+        action="append",
+        default=[],
+        metavar="FILE",
+        help=(
+            "Open an additional file (textDocument/didOpen) before <file> — "
+            "the first-class multi-file helper for asserting cross-file "
+            "behavior (e.g. a definition/reference in <file> that resolves "
+            "into FILE, or a sibling-file completion). Repeatable. Opened "
+            "after the workspace-scan wait (for a cross-file subcommand) and "
+            "before <file>, in the order given, so the request the "
+            "subcommand issues against <file> already sees every one of "
+            "them. See issue #1111."
         ),
     )
 
@@ -1865,6 +1905,18 @@ examples:
             # scan (issue #1094).
             if args.command in CROSS_FILE_COMMANDS:
                 client.wait_for_workspace_scan(timeout=args.scan_timeout)
+
+            # `--also-open FILE` (repeatable): the multi-file helper (issue
+            # #1111) — open every companion file *before* the main one, in
+            # the order given, after the scan wait above so a cross-file
+            # subcommand's request against `args.file` already sees them.
+            # Each open gets the same post-didOpen settle main() gives the
+            # primary file below, so a companion file's own diagnostics
+            # publish (which can itself touch workspace state a sibling-file
+            # completion/definition reads) has landed before we proceed.
+            for companion in args.also_open:
+                open_document(client, companion)
+                time.sleep(0.3)
 
             uri, content = open_document(client, args.file)
 

--- a/Makefile
+++ b/Makefile
@@ -866,32 +866,37 @@ check-rust: ensure-rust-deps ## Rust fmt-check + clippy on Zed extension and top
 	fi; \
 	if [ -f "$(ROOT)Cargo.toml" ]; then \
 		echo "==> Checking top-level Rust workspace (fmt + clippy)"; \
-		cd $(ROOT) && cargo fmt --all --check && \
-			cargo clippy --workspace --all-targets -- -D warnings; \
+		cd $(ROOT); \
+		cargo fmt --all --check; \
+		cargo clippy --workspace --all-targets -- -D warnings; \
 	fi; \
 	if [ -f "$(ZED_DIR)/Cargo.toml" ]; then \
 		echo "==> Checking Zed extension (fmt + clippy --target wasm32-wasip2 + host tests)"; \
-		cd $(ZED_DIR) && cargo fmt --all --check && \
-			cargo clippy --target wasm32-wasip2 --all-targets -- -D warnings && \
-			cargo test --lib; \
+		cd $(ZED_DIR); \
+		cargo fmt --all --check; \
+		cargo clippy --target wasm32-wasip2 --all-targets -- -D warnings; \
+		cargo test --lib; \
 	fi; \
 	if [ -f "$(EXPLORER_WASM_DIR)/Cargo.toml" ] && \
 			rustup target list --installed 2>/dev/null | grep -q wasm32-unknown-unknown; then \
 		echo "==> Checking tcl-explorer-wasm (fmt + clippy --target wasm32-unknown-unknown)"; \
-		cd $(EXPLORER_WASM_DIR) && cargo fmt --all --check && \
-			cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings; \
+		cd $(EXPLORER_WASM_DIR); \
+		cargo fmt --all --check; \
+		cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings; \
 	fi; \
 	if [ -f "$(ROOT)rust/tcl-vm-wasm/Cargo.toml" ] && \
 			rustup target list --installed 2>/dev/null | grep -q wasm32-unknown-unknown; then \
 		echo "==> Checking tcl-vm-wasm (fmt + clippy --target wasm32-unknown-unknown)"; \
-		cd $(ROOT)rust/tcl-vm-wasm && cargo fmt --all --check && \
-			cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings; \
+		cd $(ROOT)rust/tcl-vm-wasm; \
+		cargo fmt --all --check; \
+		cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings; \
 	fi; \
 	if [ -f "$(ROOT)rust/tcl-spec-studio-wasm/Cargo.toml" ] && \
 			rustup target list --installed 2>/dev/null | grep -q wasm32-unknown-unknown; then \
 		echo "==> Checking tcl-spec-studio-wasm (fmt + clippy --target wasm32-unknown-unknown)"; \
-		cd $(ROOT)rust/tcl-spec-studio-wasm && cargo fmt --all --check && \
-			cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings; \
+		cd $(ROOT)rust/tcl-spec-studio-wasm; \
+		cargo fmt --all --check; \
+		cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings; \
 	fi
 
 # Supply-chain audit for the Rust workspace: RustSec advisories, license

--- a/docs/design/rust/compiler-pipeline-parity.md
+++ b/docs/design/rust/compiler-pipeline-parity.md
@@ -9,9 +9,28 @@ which covers the command/event/object **registries**; this document covers the
 
 - **Python baseline (source of truth):** working tree on
   `claude/sleepy-goodall-pa351e` (mirrors `origin/main`), packages
-  `compiler/…`, `analyser/…`, `shared/…`.
+  `compiler/…`, `analyser/…`, `shared/…`. Python has since been **fully
+  retired** from this repository (see `AGENTS.md`) — the comparison below is a
+  historical snapshot, not a live moving target. Treat every row as "how the
+  since-removed Python implementation compared to Rust at the time it was
+  written", not as a description of a still-existing second implementation.
 - **Rust baseline (rewrite):** `rust/tcl-lexer`, `rust/tcl-syntax`,
   `rust/tcl-compiler`, `rust/tcl-bytecode` on the same tree.
+
+> **Snapshot date: 2026-06-19. Last revalidated: 2026-08-04, against `rust`
+> tip `efe3dd9566dfc593bf875e95a03d1b55fabbb95c`.** This document is a
+> point-in-time audit, not a live backlog — the Rust codebase has moved on
+> since 2026-06-19 and several rows below are now stale. The 2026-08-04 pass
+> (issue #1189) re-checked the memory-SSA section in full plus every
+> cross-cutting `complexity_guarded` reference and confirmed/corrected the
+> items marked **RESOLVED (2026-08-04 revalidation)** below, each with a
+> current code citation. Rows *not* carrying that marker have **not** been
+> re-verified since 2026-06-19 and may equally be stale — before relying on
+> any unmarked row, re-check it against current code (or current tests)
+> yourself. A gap confirmed still live in this pass has no separate GitHub
+> issue unless one is explicitly linked; do not assume the mere presence of a
+> gap here means it is tracked or scheduled — file an issue before treating it
+> as planned work.
 
 ## Scope and method
 
@@ -82,10 +101,19 @@ are soundness issues that should gate the default-off shim flips.
 
 **Cross-cutting themes (touch several subsystems):**
 
-1. **`complexity_guarded` skip is absent everywhere in Rust** (SSA §4, taint and
-   interprocedural §6). Python bails out of deep analysis on pathologically
-   large generated bodies; Rust analyses them unconditionally → runaway latency
-   **and** over-optimistic interproc summaries on adversarial input.
+1. ~~**`complexity_guarded` skip is absent everywhere in Rust**~~ **RESOLVED
+   (2026-08-04 revalidation, issue #1189).** `ssa.rs` now carries both halves
+   of the guard — `COMPLEXITY_GUARD_BLOCKS` (20,000 blocks, `is_complexity_guarded`)
+   and `DEEP_ANALYSIS_BODY_BYTES` (256 KiB, for block-light-but-byte-huge
+   bodies) — and `compilation_unit.rs::build_procedure_units` consults both
+   before building each proc's `FunctionUnit`: an oversized body gets
+   `FunctionUnit::trivial_guarded` (`compilation_unit.rs:618-637`) instead of
+   real SSA/taint/SCCP, with `complexity_guarded: true` set on the unit so
+   every per-proc consumer (`functions()`, interprocedural summarisation, …)
+   filters it out (`compilation_unit.rs:1661,1702,1734`) rather than
+   over-optimistically summarising it. Pinned by
+   `complexity_guard_skips_oversized_ssa` (`ssa.rs`) and
+   `complexity_guard_flags_byte_huge_proc` (`compilation_unit.rs`).
 2. **C1 byte-vs-UTF-16 columns** (already in `review-findings.md`) is *amplified*
    by re-derivation: positions resolve at ~29 independent `LineIndex` sites
    (§1, §2).
@@ -103,16 +131,18 @@ are soundness issues that should gate the default-off shim flips.
 **Genuine regressions, by kind** (full list in the
 [Consolidated gap register](#consolidated-prioritised-gap-register)):
 
-- *Correctness/soundness (should block the relevant shim flips):* the `${a\}b}`
-  braced-variable lexer scan (verified, §1); optimiser **O120** (string-compare
-  rewrite without a numeric-value proof) and **O114** (incr idiom without an
-  INT-type proof) drop soundness gates and can miscompile; **O108** ADCE is
-  over-aggressive; SCCP omits escaping-var widening and break-edge modelling
-  (false unreachable / unsound DCE on `while 1 {… break}`); memory-SSA upvar
-  transitive-merge and `IRUpFrame`-clobber divergences weaken may-alias; shimmer
-  severity (S100 emitted as Warning, not Information) and the phi-S101/expr-S100
-  code-string mislabels; the missing `DynamicNameLocal` param trait re-opens
-  call-by-name suppression false positives.
+- *Correctness/soundness (should block the relevant shim flips):* optimiser
+  **O120** (string-compare rewrite without a numeric-value proof) and **O114**
+  (incr idiom without an INT-type proof) drop soundness gates and can
+  miscompile; **O108** ADCE is over-aggressive; shimmer severity (S100 emitted
+  as Warning, not Information) and the phi-S101/expr-S100 code-string
+  mislabels. *(The `${a\}b}` braced-variable lexer scan was already fixed
+  and marked resolved in the original 2026-06-19 snapshot — §1 — but this
+  bullet was never updated to match. SCCP escaping-var widening, the
+  `while 1 {… break}` false-unreachable case, the memory-SSA upvar
+  transitive-merge, the `IRUpFrame` clobber, and the `DynamicNameLocal` param
+  trait are newly confirmed **RESOLVED** in the 2026-08-04 revalidation; see
+  §4-§6 for each's current-code citation.)*
 - *Capability gaps (Python feature, no/weak Rust):* the general proc inliner
   (`compiler/inlining/`, ~1900 LOC) is unported; `var_escape` is ported but
   **unwired** and missing the `pure_leaf` family; **snit** OO support is absent;
@@ -371,7 +401,7 @@ Python: `compiler/{ir,lowering,compilation_unit,command_binding,dialect_context,
 | `assigns_variable_at` tier | runtime.py:376 | spec.rs:94 (field unused in role path) | ❗ | Rust carries the field but no var-write consumer reads it. |
 | `resolve_arg_role_map` (multi-role) | runtime.py:1497 | param_traits.rs:421 | ❗ | Rust single-role over Body/Expr/VarWrite/VarRead only; OO-body/regexp-pattern special-casing + `_REWRITE_ALIASES` not found. |
 | command_binding lattice (name resolution) | command_binding.py | command_binding.rs | ✅ | BindingKind lattice — faithful port. |
-| CompilationUnit / FunctionUnit | compilation_unit.py:42-60 | compilation_unit.rs:101-308 | ⚠️ | Rust lacks `execution_intent`, `complexity_guarded`, `known_classes`. |
+| CompilationUnit / FunctionUnit | compilation_unit.py:42-60 | compilation_unit.rs:101-308 | ⚠️ | Rust lacks `execution_intent`, `known_classes`. `complexity_guarded` is **RESOLVED (2026-08-04)** — `FunctionUnit.complexity_guarded: bool` (compilation_unit.rs:256) exists and is set by `build_procedure_units`; see §4. |
 | **Taint build count** | once/fn (core_analyses.py:3977) | **2× top-level + every proc** (compilation_unit.rs:206,584,596) | ❗ | First intra-proc taint discarded; confirms the "2–3×" review finding. |
 | inline_uplevel | inline_uplevel.py | inline_uplevel.rs | ⚠️ | Same gates; Rust lacks the `redefined_procedures` guard; static path test-disabled. |
 | source_inliner / stdlib_prelude | source_inliner.py / stdlib_prelude.py | — | ❌ | No Rust equivalent (compile-time bundling for WASM self-containment). |
@@ -403,9 +433,10 @@ Python: `compiler/{ir,lowering,compilation_unit,command_binding,dialect_context,
    applied elsewhere, BODY/PATTERN/VAR_WRITE under-reported for
    `method`/`constructor`/`regexp`/`regsub`.
 9. Smaller field drops: `IRForeach.tokens`, `IRIncr.safe_on_uninit`,
-   `IRProcedure` inlining fields, `FunctionUnit.execution_intent`/
-   `complexity_guarded`, `CompilationUnit.known_classes`, inline_uplevel
-   `redefined_procedures`.
+   `IRProcedure` inlining fields, `FunctionUnit.execution_intent`,
+   `CompilationUnit.known_classes`, inline_uplevel `redefined_procedures`.
+   (`FunctionUnit.complexity_guarded` is **RESOLVED** — the field exists;
+   removed from this list 2026-08-04.)
 
 ### Rust-ahead / divergent-by-design
 - Typed `LoweringHookId` enum (24 variants) replacing name-string `match`;
@@ -463,12 +494,12 @@ complexity guard) and a few aliasing-merge divergences.
 | **Phi placement (semi-pruned, Briggs)** | ssa.py:974-998 | ssa.rs:487-525 | ✅ | Both semi-pruned — output-equivalent phi sets. |
 | Variable renaming / v0 read-before-set | ssa.py:1054-1143 | ssa.rs:1122-1305 | ✅ | Sorted → deterministic versions. |
 | `dom_in`/`dom_out` Euler-tour O(1) dominance | ssa.py:885-924 | absent | ⚠️ | Rust walks idom chain; perf-only. |
-| **SSA complexity guard** (skip huge bodies) | ssa.py:1008-1043 | absent | ❗ | No 20k-block/byte guard in Rust `build_ssa` or callers. |
-| `dynamic_target_name_reads` (`set $X v`) | ssa.py:247-261 | absent | ❗ | Dead-store/unused suppression divergence. |
+| **SSA complexity guard** (skip huge bodies) | ssa.py:1008-1043 | `COMPLEXITY_GUARD_BLOCKS`/`DEEP_ANALYSIS_BODY_BYTES` (ssa.rs:309-323), wired at compilation_unit.rs:962-970 | ✅ **RESOLVED (2026-08-04)** | Both the 20k-block and the 256 KiB body-byte half exist and gate `build_procedure_units` (a guarded proc gets `FunctionUnit::trivial_guarded`, not real SSA). Pinned by `complexity_guard_skips_oversized_ssa` / `complexity_guard_flags_byte_huge_proc`. |
+| `dynamic_target_name_reads` (`set $X v`) | ssa.py:247-261 | `is_dynamic_write_target` (ssa.rs:384) + analyser suppression (state.rs) | ✅ **RESOLVED (2026-08-04)**, different mechanism | Not a literal port of the Python SSA-layer read-set, but the same user-facing guarantee — `set $p 1` does not dead-store/unused-flag `p` — is implemented in the analyser walker and pinned by `dynamic_name_write_does_not_dead_store_the_name_var` (state.rs). |
 | MemoryLocationKind / MemoryOpKind | memory_ssa.py:40-126 | memory_ssa.rs:40-186 | ✅ | All variants 1:1. |
-| upvar/global/variable/ns-upvar detection | memory_ssa.py:195-233 | memory_ssa.rs:361-411 | ⚠️ | Rust dispatches on surface `command`, Python on `canonical_command`. |
-| **upvar transitive merge** | memory_ssa.py:303-311 | memory_ssa.rs:519-524 | ❗ | `upvar 1 x a; upvar 1 x b`: Python merges a&b; Rust keeps 2 → `may_alias` False in Rust. |
-| `IRUpFrame` clobber | memory_ssa.py:240-244 | absent in `is_clobber` | ❗ | Non-inlined `uplevel {…}` doesn't bump memory version. |
+| upvar/global/variable/ns-upvar detection | memory_ssa.py:195-233 | memory_ssa.rs:361-411 | ⚠️ | Rust dispatches on surface `command`, Python on `canonical_command`. Re-checked 2026-08-04: still true, unchanged; not observed to cause a divergence in practice (surface and canonical agree for the un-aliased `upvar`/`global`/`variable` spellings these detectors match). |
+| **upvar/global/variable transitive merge** | memory_ssa.py:303-311 | `compute_aliases` (memory_ssa.rs:533-593) | ✅ **RESOLVED (2026-08-04)** | `compute_aliases` was rewritten to a union-find over `MemoryLocation`: `upvar 1 x a; upvar 1 x b` now merges `a`/`b` into one alias set because both key off the shared caller-side node (memory_ssa.rs:545-555, comment explains the encoding). Pinned by `compute_aliases_merges_shared_caller_upvars`. The union-find is generic, so `global`/`variable` pairs get the same transitive treatment for free. |
+| `IRUpFrame` clobber | memory_ssa.py:240-244 | `is_clobber` (memory_ssa.rs:437-439) | ✅ **RESOLVED (2026-08-04)** | `Statement::Barrier { .. } \| Statement::UpFrame { .. } => true` — a non-inlined `uplevel {…}` bumps the memory version. Pinned by `build_memory_ssa_emits_clobber_for_upframe`. |
 | `eval`-origin IRBlock clobber | memory_ssa.py:245-254 | flattened (mod.rs:511) | ❗ | Rust more precise where enumerable; drops eval-barrier pessimism. |
 | DefKind/UseKind + 2-pass build + v0 lazy PARAMETER | def_use.py:26-236 | def_use.rs:24-272 | ✅ | Full structural parity. |
 | DataFlowGraph + 4 EdgeKinds + JSON `to_dict` | dataflow_graph.py:30-325 | dataflow_graph.rs | ✅ | All keys match; Rust sorts nodes. |
@@ -476,34 +507,38 @@ complexity guard) and a few aliasing-merge divergences.
 | Place model (7 PlaceKind, overlap, may_alias) | place.py:37-254 | place.rs:33-394 | ✅ | Faithful incl. 8D/8E precision. |
 | place_bridge read/write/alias extraction | place_bridge.py:49-341 | place_bridge.rs:46-734 | ✅ | Must-alias-kill / element-observed relocated into bridge. |
 | Natural-loop detection (back-edge + reverse flood) | loops.py:79-195 | loops.rs:82-166 | ✅ | Rust RPO-ordered (deterministic). |
-| `build_loop_forest` single source of truth | called by gvn/intervals/shimmer/core_analyses | loops.rs:112 (**0 prod callers**) | ❗ | Rust re-derives loop detection inline in 4 places. |
+| `build_loop_forest` single source of truth | called by gvn/intervals/shimmer/core_analyses | loops.rs:127 (production caller: `analyser/diagnostics/helpers.rs:876`) | ✅ **RESOLVED (2026-08-04)** | No longer dead code: `build_loop_entry_only_undef` (the W210 read-before-set loop-entry-only-undef suppression) calls it live, on the production diagnostics path. Still re-derived inline in other spots (not fully consolidated), but "0 prod callers" is no longer accurate. |
 | static `for` simulation (env, 4096 cap) | static_loops.py:254-305 | static_loops.rs:314-375 | ✅ | Same cap. |
-| static `for` raw-string-args entry | static_loops.py:219-251 | absent | ❌ | Rust only accepts pre-lowered IR. |
-| static-loop → SCCP/interval const-fold wiring | core_analyses.py:947-961 | absent | ❗ | `summarise_for_statement` exists but no SCCP caller. |
-| SCCP break-exit precompute (infinite-loop+break) | core_analyses.py:1345-1374 | absent | ❗ | Risk of false unreachable/unsound DCE on `while 1 {… break}`. |
+| static `for` raw-string-args entry | static_loops.py:219-251 | absent | ❌ | Rust only accepts pre-lowered IR. Not re-verified 2026-08-04. |
+| static-loop → SCCP/interval const-fold wiring | core_analyses.py:947-961 | absent | ❗ | `summarise_for_statement` exists but no SCCP caller. Not re-verified 2026-08-04. |
+| break/`while 1 {… break}` post-loop reachability | core_analyses.py:1345-1374 (SCCP break-exit precompute) | `escaping_loop_jumps` (cfg_builder/mod.rs:1913) wires a real `break_target` CFG edge (cfg_lower.rs:498-537) at CFG-construction time | ✅ **RESOLVED (2026-08-04)**, different mechanism | Rust does not port a Python-style SCCP break-exit precompute; instead the CFG builder gives `break` a genuine successor edge to the post-loop block whenever a break is reachable, so ordinary SCCP reachability propagation (no special-casing needed) marks the post-loop block executable. Pinned by `rch_while1_with_break_post_loop_is_reachable` (control: reachable) alongside `rch_while1_no_break_post_loop_is_dead` (a `while 1` with **no** break still correctly reports the post-loop block unreachable) in `tests/compiler_analysis_residual.rs`. |
 
 ### Gaps (Rust missing or weaker)
-1. **No SSA complexity guard** (`ssa.rs:1111` runs phi-placement + rename
-   unconditionally). Machine-generated mega-procs (a ~34k-block `filetypes.tcl`)
-   get full analysis instead of being skipped — latency, not crash.
+
+> Items 1, 3, 4, 5 below (SSA complexity guard, SCCP break-exit /
+> `while 1 {… break}`, upvar transitive-merge, `IRUpFrame` clobber) were
+> **RESOLVED** as of the 2026-08-04 revalidation (issue #1189) — see the
+> parity table above for the current-code citation and pinning test for each.
+> They are struck through here rather than deleted so the historical gap
+> numbering stays stable for cross-references.
+
+1. ~~**No SSA complexity guard**~~ **RESOLVED** — see parity table.
 2. **Static-loop summarisation not wired into SCCP/interval** —
    `summarise_for_statement` has **zero production callers**; compounded by
    `LoopNode` dropping the `IRFor`. Weaker constant propagation/bounds after a
-   counted `for`.
-3. **SCCP break-exit modelling absent** — potential false "unreachable" + unsound
-   DCE on `while 1 {… break}` (confirm Rust doesn't model break edges another
-   way).
-4. **upvar transitive-merge divergence** — `may_alias("a","b")` is False in Rust
-   for `upvar 1 x a; upvar 1 x b`; Rust code/test/doc-comment disagree. Weaker
-   GVN/DSE/copy-prop alias guards.
-5. **`IRUpFrame` not a clobber in Rust** — a non-inlined `uplevel 1 {…}` doesn't
-   bump the memory version; may-alias consumers can miss a caller-frame store.
+   counted `for`. *(Not re-verified 2026-08-04 — re-check before relying on
+   this.)*
+3. ~~**SCCP break-exit modelling absent**~~ **RESOLVED** (via a real CFG
+   `break_target` edge, not an SCCP-level precompute) — see parity table.
+4. ~~**upvar transitive-merge divergence**~~ **RESOLVED** — see parity table.
+5. ~~**`IRUpFrame` not a clobber in Rust**~~ **RESOLVED** — see parity table.
 6. **`break`/`continue` not gated on `faithful_exceptions`** — the codegen-path
    CFG gains goto edges Python leaves as fall-through; relevant to the
-   byte-identical-to-tclsh invariant.
+   byte-identical-to-tclsh invariant. *(Not re-verified 2026-08-04.)*
 7. `dataflow_graph_to_mermaid` missing (bounded: JSON `to_dict` present);
-   `dynamic_target_name_reads` not ported; static `for` raw-args entry missing;
-   `build_loop_forest` is dead code in Rust (4 inline re-derivations).
+   static `for` raw-args entry missing. *(`dynamic_target_name_reads` and
+   `build_loop_forest`-as-dead-code are **RESOLVED** — see parity table;
+   the remaining two items in this line were not re-verified 2026-08-04.)*
 
 ### Rust-ahead / divergent-by-design
 - `escaping_loop_jumps` recurses into `try` and stops at dead code (mod.rs:1090)
@@ -523,17 +558,30 @@ complexity guard) and a few aliasing-merge divergences.
   explicit sorting at output boundaries.
 
 ### Open questions for maintainer
-1. Is the absent SSA complexity guard intentional (does the analyser gate large
-   procs before `build_ssa`)?
+1. ~~Is the absent SSA complexity guard intentional?~~ **Answered (2026-08-04):**
+   it isn't absent — `is_complexity_guarded` + `DEEP_ANALYSIS_BODY_BYTES` gate
+   `build_procedure_units` before SSA is ever built for an oversized proc.
 2. Is the static-loop → SCCP/interval const-fold wiring planned? (`LoopNode`
-   would need to carry the `IRFor`.)
-3. Does Rust SCCP handle the break-into-infinite-loop exit edge another way?
-4. Should Rust match Python's single-set upvar merge (code/test/doc disagree)?
+   would need to carry the `IRFor`.) *(Not re-verified 2026-08-04.)*
+3. ~~Does Rust SCCP handle the break-into-infinite-loop exit edge another
+   way?~~ **Answered (2026-08-04):** yes — the CFG builder
+   (`escaping_loop_jumps` + `break_target`) gives `break` a real successor
+   edge to the post-loop block, so plain SCCP reachability propagation
+   handles it without any SCCP-level special-casing.
+4. ~~Should Rust match Python's single-set upvar merge?~~ **Answered
+   (2026-08-04):** it already does — `compute_aliases`'s union-find merges
+   `upvar 1 x a; upvar 1 x b` into one alias set.
 5. Should memory-SSA detection consult `canonical_command` instead of surface
-   `command`?
+   `command`? *(Re-checked 2026-08-04: still dispatches on surface `command`;
+   the maintainer question stands, though no concrete divergence was found in
+   this pass.)*
 6. Confirm codegen uses `build_cfg_codegen` so the un-gated break/continue goto
-   edges don't leak into emitted bytecode.
-7. Is `build_loop_forest` meant to become the Rust single source of truth?
+   edges don't leak into emitted bytecode. *(Not re-verified 2026-08-04.)*
+7. ~~Is `build_loop_forest` meant to become the Rust single source of
+   truth?~~ **Partially answered (2026-08-04):** it now has a real production
+   caller (`analyser/diagnostics/helpers.rs:876`), so it is no longer dead
+   code; whether it should also replace the *other* inline re-derivations is
+   still open.
 
 ## 5. Value/type analyses — type inference, SCCP, intervals, shapes, shimmer
 
@@ -553,7 +601,7 @@ Rust: `rust/tcl-compiler/src/{type_infer,types,analyses,value_shapes,intervals,i
 | **W232** | `string index` proven out-of-range | interval_bounds.py:463 | interval_bounds.rs:541 | ✅ | |
 | **W233** | Division/modulo by provably-zero divisor | interval_bounds.py:501 | DivZeroFinding interval_bounds.rs:642 (**DEAD**); emitted via diagnostics.rs:7275 (SCCP-only) | ❗ | Production path uses SCCP-constant-only; misses interval `[0,0]` divisors Python catches. |
 | **I230** | Constant branch / `info exists` fold | core_analyses.py:1563 | sccp.rs:480/548 | ✅/⚠️ | Records produced both; Rust existence-fold gate weaker, doesn't prune edges. |
-| **O107** | Unreachable block | executable_blocks | diagnostics.rs:5882 | ❗ | Rust SCCP lacks break-edge synthesis → false O107 for `while 1 {… break …}`. |
+| **O107** | Unreachable block | executable_blocks | diagnostics.rs:5882 | ✅ **RESOLVED (2026-08-04)** | The CFG builder gives `break` a real successor edge to the post-loop block (`escaping_loop_jumps`/`break_target`, §4), so ordinary SCCP reachability marks it executable — no false O107 for `while 1 {… break …}`. Pinned by `rch_while1_with_break_post_loop_is_reachable` / `rch_while1_no_break_post_loop_is_dead` (`tests/compiler_analysis_residual.rs`). |
 
 ### Parity table (selected)
 
@@ -584,9 +632,16 @@ Rust: `rust/tcl-compiler/src/{type_infer,types,analyses,value_shapes,intervals,i
 2. **Shimmer code-string bugs (observable).** `phi.rs:146` hardcodes "S101" ignoring `in_loop` (out-of-loop merge should be S100); `expr.rs:273,322` hardcode "S100" ignoring `in_loop` (in-loop expr shimmer should be S101).
 3. **Shimmer loop-invariant reclassification missing** (S101→S100 downgrade for loop-invariant single-target vars; the largest use-site heuristic, shimmer.py:270-456). Rust over-reports S101.
 4. **Shimmer `incr` amount not checked** (shimmer.py:564-606); Rust's Incr arm never inspects the amount.
-5. **SCCP break-edge reachability missing** → false O107 / unsound DCE for `while 1 {… break}` (Python core_analyses.py:1337-1374).
-6. **SCCP optimistic (Wegman–Zadeck) UNKNOWN deferral missing** (sccp.rs:444-456 opens both arms immediately); loses loop-carried-constant folding.
-7. **SCCP externally-mutable/escaping-var widening missing (soundness).** Python forces `::g`/escaping defs to OVERDEFINED (core_analyses.py:1308); Rust's `evaluate_def` has no such guard despite `escaping_var_names` existing.
+5. ~~**SCCP break-edge reachability missing**~~ **RESOLVED (2026-08-04)** —
+   see §4/O107 above (real CFG `break_target` edge, not an SCCP-level fix).
+6. **SCCP optimistic (Wegman–Zadeck) UNKNOWN deferral missing** (sccp.rs:444-456 opens both arms immediately); loses loop-carried-constant folding. *(Not re-verified 2026-08-04.)*
+7. ~~**SCCP externally-mutable/escaping-var widening missing (soundness).**~~
+   **RESOLVED (2026-08-04)** — `evaluate_def` (sccp.rs:300-335) now calls
+   `var_observability::analyse_var_observability(..).escaping_var_names()`
+   and forces every escaping/global/namespace/upvar-aliased/traced
+   definition to `Overdefined` before the fixpoint runs, with the same
+   soundness rationale Python used (`set ::g 5; mut; expr {$::g+1}` must not
+   fold through the opaque `mut` call).
 8. **SCCP interpolation folding + registry-driven cmd-subst folding narrower** (Rust hand-codes list/format/llength/string-length/expr only; no CONSTSET cartesian product; no FOLD_HINTS rename guard).
 9. **Type-prop scope-alias & TclOO object typing missing**; **expr-context literal typing & `~` typing wrong**; **W233 interval path bypassed**; **rendered-props ESC numeric escape rendering weaker** (W201 FNs); **`value_shapes.is_pure_var_ref` acceptance-set differs** (`is_braced_whole_name_array_ref` not ported).
 
@@ -608,7 +663,10 @@ Rust: `rust/tcl-compiler/src/{type_infer,types,analyses,value_shapes,intervals,i
 1. Shimmer severity + phi-S101/expr-S100 hardcodes — design simplification or port bugs?
 2. Loop-invariant S101→S100 downgrade and incr-amount check — deferred or overlooked?
 3. W233: is the SCCP-only divisor check deliberate (making `find_divide_by_zero` dead code)?
-4. SCCP break-edges / optimistic deferral / escaping-var widening — tracked simplifications or gaps? (`escaping_var_names` already exists but SCCP doesn't consume it.)
+4. ~~SCCP break-edges / escaping-var widening — tracked simplifications or
+   gaps?~~ **Answered (2026-08-04):** both are resolved — see items 5 and 7
+   above. The optimistic (Wegman–Zadeck) UNKNOWN-deferral half of this
+   question was not re-verified.
 5. Type-prop TclOO object typing & scope-alias OVERDEFINED — planned?
 6. expr-context literal typing (`0o`→INT, unknown→NUMERIC) and `~`→INT — distinct expr classifier needed?
 7. `value_shapes.is_pure_var_ref` acceptance-set — match Python (shared primitive across passes)?
@@ -666,7 +724,15 @@ Rust: `rust/tcl-compiler/src/{taint,taint_interproc,path_concat,uri_split,interp
 
 ### Gaps (Rust missing or weaker) — by severity
 1. **Taint lattice: `PATH_JOINED` (1<<15) and `CHANNEL` (1<<16) colours missing from the compiler mirror enum** (taint.rs stops at FQDN 1<<14). The registry defines both; `reg_colour` uses `from_bits_truncate`, so they're silently dropped. Breaks the W201 `PATH_JOINED` suppression arm. **Currently dormant** (no engine propagates these yet) but the lattice cannot represent them.
-2. **`complexity_guarded` skip absent in Rust (cross-cutting).** Python skips deep analysis for pathologically large bodies (`_api.py:127`, `interprocedural.py:1081`). **Zero** `complexity_guard` occurrences in Rust → runaway work and *over-optimistic* interproc summaries on adversarial input. (Same gap noted in §4 for SSA.)
+2. ~~**`complexity_guarded` skip absent in Rust (cross-cutting).**~~
+   **RESOLVED (2026-08-04)** — see §4's SSA-complexity-guard entry. The guard
+   is checked once, at `FunctionUnit` construction
+   (`compilation_unit.rs::build_procedure_units`), and a guarded proc's taint
+   is trivially empty (`FunctionUnit::trivial_guarded` sets
+   `taints: Arc::default()`) and is filtered out of every per-proc
+   interprocedural consumer (`compilation_unit.rs:1661,1702,1734`) — so taint
+   and interprocedural summarisation inherit the same skip as SSA, from one
+   wiring point, rather than needing their own separate guard.
 3. **var_escape not wired up.** No Rust `analyse_var_escape` orchestrator, no `CfgEscapeResult → ProcEscapeSummary` conversion; transfer functions reachable only from var_escape's own tests. Missing the entire `pure_leaf` family (`safe_to_inline`/`safe_to_dce`/`safe_for_frame_elision`) and its transitive IPA fixpoint.
 4. **var_escape precision regressions:** array-element narrowing (`set arr($k) v` spills all locals in Rust vs only `arr`); multi-command `[a; b]` cmd-subst fallback unported; value-embedded cmd-subst head not recorded as a callee (breaks interproc through `set x [::ns::Helper ...]`); `with_escapes` missing `CALLEE_UPVAR` reasons + interprocedural UNKNOWN barrier.
 5. **interprocedural precision:** constant-return/param-dependency derived textually vs Python's SSA/SCCP lattice; CFG-augmented upvar global-write 2nd pass missing; `can_fold_static_calls` doesn't consult `redefined_procedures`; `::call` indirection not seen through. (O103 fold recovered separately in `propagation.rs`, so end-to-end folding may still work.)
@@ -695,8 +761,10 @@ Rust: `rust/tcl-compiler/src/{taint,taint_interproc,path_concat,uri_split,interp
 2. Is **var_escape staged work** (no orchestrator, passes only exercised by tests)? Are `pure_leaf` + its IPA fixpoint deferred because Rust inlining/DCE consumers don't exist yet?
 3. **proc_fingerprint:** absence intentional because whole-unit interproc rebuild subsumes external-symbol invalidation, or a genuine incremental-correctness gap?
 4. **`PATH_JOINED`/`CHANNEL` colours:** extend the compiler mirror enum to the full 17-bit registry set, or keep registry-only until propagation lands?
-5. **`complexity_guarded`:** replicate the guard (taint + interproc) to avoid over-optimistic summaries / runaway work?
-6. **`DYNAMIC_NAME_LOCAL`:** add the variant and emit it (instead of `VarWrite`) for dynamic-name-local cases?
+5. ~~**`complexity_guarded`:** replicate the guard (taint + interproc)?~~
+   **Answered (2026-08-04):** yes, already done — see §4.
+6. ~~**`DYNAMIC_NAME_LOCAL`:** add the variant and emit it?~~ **Answered
+   (2026-08-04):** already done — see §8.
 7. **side_effects:** protocol-NS classifier, form resolution, structured trace-composition — planned or accepted gaps?
 8. **Registry trait fidelity** (var_escape slot resolution): do `FRAME_HASH_BUILTIN`/`INTROSPECTS_BY_NAME`/`TARGETS_VARIABLE_BY_NAME`/`DYNAMIC_EVAL_BODY` reproduce the Python frozensets exactly?
 
@@ -887,7 +955,7 @@ Rust: `rust/tcl-compiler/src/analyser/*`, `compiler_checks.rs`, `irules_checks.r
 | W211 | Variable set but never used | _diag_var_lifecycle.py | state.rs:362 | ✅ | See param-trait caveat below. |
 | W212 | `$x` where var name expected | checks/_style.py:1111 | state.rs:1983 | ✅ | |
 | W213 | Var may not exist — use `unset -nocomplain` | _analyser/_utils.py:167 | state.rs:1621 | ✅ | |
-| W214 | Unused proc parameter | _analyser/_utils.py:172 | state.rs:1775 | ⚠️ | `DynamicNameLocal` gap can shift verdicts on `set $p`. |
+| W214 | Unused proc parameter | _analyser/_utils.py:172 | state.rs:1775 | ✅ | `DynamicNameLocal` is implemented (see §8), so `set $p` verdicts match Python. |
 | W215 | Var name unreachable via `$`-subst | _analyser/_utils.py:177 | scope.rs:616 | ✅ | |
 | W216 | Broken brace-form array ref `${arr}(x)` | _analyser/_utils.py:182 | state.rs:1983 | ✅ | |
 | W220 | Dead store | _diag_var_lifecycle.py | state.rs:1640 | ✅ | |
@@ -967,14 +1035,14 @@ Rust: `rust/tcl-compiler/src/analyser/*`, `compiler_checks.rs`, `irules_checks.r
 | snit support | _oo.py:492-790 + class_names.py | — | ❌ | **Largest OO gap** — no snit handling in the Rust analyser. |
 | Signature discovery | analyser/signature_scan.py | signature_scan/* | ✅ | Full parity (proc/namespace/import/package/source/interp-alias/oo::class/itcl::class, conditional recursion, tcllib factory resolver). |
 | proc lookup / reference matching | analyser/proc_lookup.py | signature_help.rs:322 | ✅ | Identical 3-way name predicate. |
-| Param traits | proc_arg_traits.py (7 traits incl `DYNAMIC_NAME_LOCAL`) | param_traits.rs (6 traits) | ❗ | **Rust missing `DynamicNameLocal`** → over-suppresses W211/W214/dead-store on `set $p`/`scan`/`lassign`/`regsub` out-vars; can reintroduce the FPs PR #498/#499 fixed. Rust is dialect-aware (➕). |
+| Param traits | proc_arg_traits.py (7 traits incl `DYNAMIC_NAME_LOCAL`) | `ProcArgTrait` (analyser/types.rs, 8 variants incl. `DynamicNameLocal`) | ✅ **RESOLVED (2026-08-04)** | `DynamicNameLocal` is a real variant, deliberately distinct from `VarWrite`/`VarRead` (see the doc comment at its definition and PR #498/#499), and is emitted for `set $p 1`/`scan`/`lassign`/`regsub` callee-local dynamic-name uses in `param_traits.rs`. Pinned by `lassign_records_dynamic_name_local` and siblings in `param_traits.rs`. Rust is additionally dialect-aware (➕). |
 | Connection scope | connection_scope.py | connection_scope.rs | ⚠️ | Rust omits branch-condition v0 sweep. |
 | Event-ordering model | irules_flow.py:1545 `extract_event_order` | — | ❗ | Not ported (the 1002/1003/1004 checks themselves are at parity). |
 | Static names | irules_static_names.py (configurable) | inlined `GENERIC_STATIC_NAMES` | ⚠️ | Default-config equivalent; user patterns not plumbed. |
 
 ### Gaps (Rust missing or weaker)
 **Codes with NO Rust emitter (analyser-relevant):** E001, W125 (C41e5), IRULE1001 (high-impact, frequently-firing), IRULE5005 (C41d6), TK1001–1003, BIGIP6001–6011, IAPP7001–7003, XC100–301, W130–W134 (tclpkg, out of scope).
-**Weaker behaviour (emit but diverge):** IRULE1201/1202/5002/5004 (linear vs path-sensitive; dropped quick-fixes); IRULE4004 (narrower); param-trait `DynamicNameLocal` missing; snit unported; OO body walks (`oo::class new`, `initialise`, `property` accessors); connection_scope branch-condition sweep; event-ordering model; configurable name patterns.
+**Weaker behaviour (emit but diverge):** IRULE1201/1202/5002/5004 (linear vs path-sensitive; dropped quick-fixes); IRULE4004 (narrower); snit unported; connection_scope branch-condition sweep; event-ordering model; configurable name patterns. *(Param-trait `DynamicNameLocal` and the three OO-body-walk gaps this line used to list are **RESOLVED** — see the parity table above.)*
 
 ### Rust-ahead / divergent-by-design
 - Per-item incremental analysis (offset-stable item identity + per-body memoisation for salsa early-cutoff); no Python equivalent.
@@ -993,7 +1061,8 @@ Rust: `rust/tcl-compiler/src/analyser/*`, `compiler_checks.rs`, `irules_checks.r
 1. **Output-ordering oracle** — does the Python↔Rust differential test compare diagnostics as an unordered set or an ordered list? Rust sorts by position; if the oracle is ordered this is the one place strict byte-equivalence breaks for the ported codes.
 2. **Deferred-code roadmap** — E001, W125, IRULE5005, IRULE1001 are tagged deferred. Scheduled or dropped? IRULE1001 is a core, frequently-firing check.
 3. **F5 dialect subsystems** (TK/BIGIP/IAPP/XC ~30 codes) — intended to stay Python-only, or should the Rust analyser eventually emit them?
-4. **`ProcArgTrait::DynamicNameLocal`** — confirm intent to port; its absence reintroduces call-by-name suppression FPs.
+4. ~~**`ProcArgTrait::DynamicNameLocal`** — confirm intent to port.~~
+   **Answered (2026-08-04):** already ported — see the parity table above.
 5. **iRules path-sensitivity (C44)** — IRULE1201/1202/5002/5004 are linear MVPs; is the path-sensitive walker (and the dropped quick-fixes) on the roadmap?
 6. **snit support** — intended for the Rust analyser or out of scope?
 
@@ -1109,20 +1178,30 @@ not a decision.
 > intentionally-not-ported-and-benign; needs reconciliation, not a confirmed
 > regression. The authoritative live open-work set is maintained in
 > [`../../rust-rewrite.md`](../../rust-rewrite.md).
+>
+> **Revalidation (2026-08-04, issue #1189).** Re-checked against `rust` tip
+> `efe3dd9566dfc593bf875e95a03d1b55fabbb95c`: **#4, #5, #7, #8, and #11 are
+> RESOLVED** — code, tests, and (for #7/#8) doc comments now agree, with no
+> remaining conflict. #11 specifically: `ProcArgTrait::DynamicNameLocal`
+> (`analyser/types.rs`) is a genuine, distinct, tested variant — the 2026-06-19
+> note's "conflict" framing undersold it; it is not merely benign-by-omission,
+> it is actually implemented. See each row below and the memory-SSA / SSA /
+> SCCP sections (§4-§6) for the current-code citation. #1 (O120) was
+> re-checked and remains genuinely open — see its row.
 
 | # | Subsystem | Gap | Evidence | Disposition |
 |---|---|---|---|---|
 | 1 | Optimiser §7 | **O120** string-compare `==`→`eq` promotion fires on any `String` operand with **no non-numeric proof** → `$x == "1"` → `$x eq "1"` flips the result when `$x` is numeric | `streq_promote_node` (`optimiser/helpers/expr_simplify.rs:1040`, no `NumericCtx`); called `:408`/`:695`. Python gates both operands via `_is_provably_non_numeric_expr_node` (`_expr_simplify.py:484`) | Gate the promotion on provably-non-numeric operands (mirror Python's D5-O120). |
 | 2 | Optimiser §7 | **O114** incr idiom rewrites `set x [expr {$x+N}]`→`incr x N` gating only the literal, not `$x` numericity → suggests a rewrite that errors on float `$x` | pattern_recognition.rs:219 (no var gate) | Confirm whether Python gates the variable; add the gate if so. |
 | 3 | Optimiser §7 | **O108** ADCE treats every assignment as side-effect-free → can delete `set x [impureCmd]` | elimination.rs:740 | Verify against landed RHS-purity gate; restore if genuinely dropped. |
-| 4 | Value/SCCP §5 | SCCP omits **escaping-var widening** (`::g`/escaping names not forced OVERDEFINED) | sccp.rs `evaluate_def` (no guard; `escaping_var_names` lives in var_observability.rs, unused by SCCP) | Consult `escaping_var_names` in `evaluate_def`. |
-| 5 | Value/SCCP §5 | SCCP omits **break-edge reachability** → false O107 / unsound DCE on `while 1 {… break}` (already tracked as `fp_rch`, rust-rewrite.md:5037) | sccp.rs (no `break_exits`) | Port the break-exit precompute (core_analyses.py:1337). |
+| 4 | Value/SCCP §5 | ~~SCCP omits **escaping-var widening**~~ **RESOLVED (2026-08-04)** | `evaluate_def` (sccp.rs:300-335) now consults `var_observability::analyse_var_observability(..).escaping_var_names()` and forces every escaping def to `Overdefined` | Closed. |
+| 5 | Value/SCCP §5 | ~~SCCP omits **break-edge reachability**~~ **RESOLVED (2026-08-04)**, via a real CFG edge rather than an SCCP precompute | `escaping_loop_jumps`/`break_target` (cfg_builder); pinned by `rch_while1_with_break_post_loop_is_reachable` | Closed. |
 | 6 | Lexer §1 | ~~**`${a\}b}` / `${a{b}c}`** braced-var scan stops at first `}`~~ **DONE (FE-LEX, 2026-06-19)** — `parse_var` + `scan_dollar_brace` track inner-brace depth and consume `\X` (9.0.3 reference; verified against `tclsh9.0`) | lexer.rs `parse_var` | Landed; see history. |
-| 7 | Memory-SSA §4 | **upvar transitive-merge** divergence (`upvar 1 x a; upvar 1 x b` → `may_alias("a","b")` False); code/test/doc disagree | memory_ssa.rs:519 | Decide intended semantics; align code+test+doc. |
-| 8 | Memory-SSA §4 | **`IRUpFrame` not a clobber** → non-inlined `uplevel {…}` doesn't bump memory version | memory_ssa.rs `is_clobber` | Add `IRUpFrame` to the clobber set. |
-| 9 | Shimmer §5 | **S100 severity** emitted as Warning, not Information; **phi-S101 / expr-S100** code-strings ignore `in_loop` | compiler_checks.rs:113; phi.rs:146; expr.rs:273 | Map S100→Information; compute code from `in_loop`. |
-| 10 | Lowering §3 | dynamic `uplevel $body` lowers to generic **Call** not **Barrier** (no `_DYNAMIC_BARRIER_COMMANDS`, `uplevel_.rs` lacks `ArgRole::Body`) → downstream treats it as analysable | mod.rs:1397/1609 | Add a Body role / barrier fallback. |
-| 11 | Analyser §8 | **`DynamicNameLocal`** trait absent (**CONFLICT** — see reconciliation note; Rust marks the 4 out-var commands `VarWrite`, rust-rewrite.md:2019 calls it benign) | param_traits.rs:479-482 | Reconcile: does withholding `VarWrite` change caller-side W211/W214 suppression? |
+| 7 | Memory-SSA §4 | ~~**upvar transitive-merge** divergence~~ **RESOLVED (2026-08-04)** — `compute_aliases`'s union-find merges `upvar 1 x a; upvar 1 x b` into one alias set; code/test/doc now agree | memory_ssa.rs:533-593; `compute_aliases_merges_shared_caller_upvars` | Closed. |
+| 8 | Memory-SSA §4 | ~~**`IRUpFrame` not a clobber**~~ **RESOLVED (2026-08-04)** — `is_clobber` matches `Statement::Barrier { .. } \| Statement::UpFrame { .. }` | memory_ssa.rs:437-439; `build_memory_ssa_emits_clobber_for_upframe` | Closed. |
+| 9 | Shimmer §5 | **S100 severity** emitted as Warning, not Information; **phi-S101 / expr-S100** code-strings ignore `in_loop` | compiler_checks.rs:113; phi.rs:146; expr.rs:273 | Map S100→Information; compute code from `in_loop`. *(Not re-verified 2026-08-04.)* |
+| 10 | Lowering §3 | dynamic `uplevel $body` lowers to generic **Call** not **Barrier** (no `_DYNAMIC_BARRIER_COMMANDS`, `uplevel_.rs` lacks `ArgRole::Body`) → downstream treats it as analysable | mod.rs:1397/1609 | Add a Body role / barrier fallback. *(Not re-verified 2026-08-04.)* |
+| 11 | Analyser §8 | ~~**`DynamicNameLocal`** trait absent~~ **RESOLVED (2026-08-04)** — it is a real, tested `ProcArgTrait` variant, not merely a benign omission | analyser/types.rs (definition); param_traits.rs (emission + tests) | Closed. |
 | 12 | Value/type §5 | expr-context literal typing wrong (`0o`→INT/unknown→NUMERIC) and `~$double`→INT | type_infer.rs:128/197 | Use a distinct expr-context classifier. |
 
 ### P1 — Missing user-facing capability (a diagnostic or transform the user loses)
@@ -1147,7 +1226,7 @@ not a decision.
 
 | # | Subsystem | Gap | Evidence | Disposition |
 |---|---|---|---|---|
-| 26 | SSA §4 / Taint §6 | **`complexity_guarded` skip absent everywhere** → runaway work + over-optimistic interproc summaries on huge generated bodies | no `complexity_guard` in Rust tree | Port the guard (SSA + taint + interproc). |
+| 26 | SSA §4 / Taint §6 | ~~**`complexity_guarded` skip absent everywhere**~~ **RESOLVED (2026-08-04)** — `is_complexity_guarded` + `DEEP_ANALYSIS_BODY_BYTES` gate `FunctionUnit` construction; a guarded proc's taint/SSA/SCCP are all trivial and it is filtered from interprocedural summarisation | ssa.rs:309-323; compilation_unit.rs:618-637,962-970,1661,1702,1734 | Closed. |
 | 27 | IR/WASM §3,§7 | WASM-codegen passes unported: `IRInterpBoundary`+`passes/interp_boundaries.py`, `passes/dce.py`, `passes/gvn.py`, `source_inliner`, `stdlib_prelude` | absent | Expected while WASM codegen is in progress; track. |
 | 28 | Analyser §8 | Diagnostic **ordering**: Rust sorts by position, Python emits in order — confirm the differential oracle is set-based | diagnostics.rs:8747 | Confirm oracle semantics. |
 | 29 | IR §3 | Taint + CompilationUnit built **2–3×** per document (perf) | compilation_unit.rs:206,584,596 | Build once, share `&CompilationUnit`. |
@@ -1157,10 +1236,25 @@ not a decision.
 | 33 | Various §3,§6 | Smaller field/precision drops: `IRBlock.caller_scope`/`source_args`, `IRForeach.tokens`, `IRProcedure` inlining fields; `proc_fingerprint`; O103 namespace-chain/rename gating; side_effects protocol-NS classifier; var_refs read-before-set helpers; O106 missing from `OPT_CATEGORIES` | per-section | Triage individually. |
 
 ### Suggested sequencing
-1. **Before flipping `TCL_LSP_RUST_OPTIMISER`/`_GVN` default-on:** close P0 #1–#5 (the optimiser/SCCP soundness gates) and #18 (O128/O130/O104/O119).
-2. **Before retiring the Python analyser fallback:** close #6, #9, #11 (lexer brace-var, shimmer severity/codes, `DynamicNameLocal`) and decide #13–#17 (IRULE1001, deferred codes, F5 subsystems, snit).
-3. **Independent of flips:** #26 (`complexity_guarded`) and #28 (ordering-oracle confirmation) are low-effort, high-value robustness fixes.
-4. **WASM-path (#27, #20, #21):** sequence with the Rust WASM codegen work; out of the LSP critical path.
+
+> **2026-08-04 note:** #4, #5, #7, #8, #11, and #26 (referenced below as
+> already-closed prerequisites) are **RESOLVED** — see their rows above. The
+> sequencing below is otherwise as originally written and has not been
+> re-verified beyond those six items.
+
+1. **Before flipping `TCL_LSP_RUST_OPTIMISER`/`_GVN` default-on:** close the
+   remaining open P0 soundness gates — **#1** (O120, confirmed still open) and
+   **#18** (O128/O130/O104/O119). #4/#5 (the other former SCCP soundness
+   gates in this range) are already closed.
+2. **Before retiring the Python analyser fallback:** close #6, #9 (lexer
+   brace-var — already done — and shimmer severity/codes) and decide #13–#17
+   (IRULE1001, deferred codes, F5 subsystems, snit). #11 (`DynamicNameLocal`)
+   is already closed.
+3. **Independent of flips:** #28 (ordering-oracle confirmation) is a
+   low-effort, high-value robustness fix. #26 (`complexity_guarded`) is
+   already closed.
+4. **WASM-path (#27, #20, #21):** sequence with the Rust WASM codegen work;
+   out of the LSP critical path.
 
 ## Related
 - [`review-findings.md`](review-findings.md) — workspace-wide correctness /

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -16,6 +16,23 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+# Excluded from the main Cargo workspace (see the root Cargo.toml `exclude`
+# list): it is a standalone cdylib built for the Zed extension host, with its
+# own dependency set and Rust edition.
+#
+# The empty `[workspace]` table below is load-bearing (see the fuller comment
+# in `rust/tcl-spec-studio-wasm/Cargo.toml`, issue #1136): without it, cargo
+# walks up past this crate looking for a `[workspace]` ancestor, and inside a
+# git worktree nested under the main checkout's directory (this repo's
+# standard parallel-agent worktree layout) it finds the *main checkout's*
+# top-level `Cargo.toml` instead of stopping at this crate — the exclude-path
+# match then fails (it's relative to the wrong manifest) and cargo errors with
+# "current package believes it's in a workspace when it's not", which is
+# exactly what broke `make check-rust`'s Zed-extension step in every
+# worktree. An empty `[workspace]` table makes this manifest its own
+# workspace root so the search never escapes the worktree.
+[workspace]
+
 [package]
 name = "tcl-lsp-zed"
 # Source literal kept at 0.0.0-dev. The published Zed extension carries the

--- a/rust/bigip-query-wasm/Cargo.toml
+++ b/rust/bigip-query-wasm/Cargo.toml
@@ -29,6 +29,19 @@
 # generated glue trips the workspace `unsafe_code = "forbid"` lint. Built with
 # `cargo build --target wasm32-unknown-unknown` + `wasm-bindgen` (see the
 # Makefile target / build script), not plain `cargo`.
+#
+# The empty `[workspace]` table below is load-bearing (see the fuller comment
+# in `rust/tcl-spec-studio-wasm/Cargo.toml`, issue #1136): without it, cargo
+# walks up past this crate looking for a `[workspace]` ancestor, and inside a
+# git worktree nested under the main checkout's directory (this repo's
+# standard parallel-agent worktree layout) it finds the *main checkout's*
+# top-level `Cargo.toml` instead of stopping at this crate — the exclude-path
+# match then fails (it's relative to the wrong manifest) and cargo errors with
+# "current package believes it's in a workspace when it's not". An empty
+# `[workspace]` table makes this manifest its own workspace root so the search
+# never escapes the worktree.
+
+[workspace]
 
 [package]
 name = "bigip-query-wasm"

--- a/rust/bigip-report-gen/python/Cargo.toml
+++ b/rust/bigip-report-gen/python/Cargo.toml
@@ -29,6 +29,19 @@
 # "forbid"` lint would reject, and the extension links libpython, which the
 # other workspace crates must not require. Built with maturin, not `cargo`
 # directly (see pyproject.toml).
+#
+# The empty `[workspace]` table below is load-bearing (see the fuller comment
+# in `rust/tcl-spec-studio-wasm/Cargo.toml`, issue #1136): without it, cargo
+# walks up past this crate looking for a `[workspace]` ancestor, and inside a
+# git worktree nested under the main checkout's directory (this repo's
+# standard parallel-agent worktree layout) it finds the *main checkout's*
+# top-level `Cargo.toml` instead of stopping at this crate — the exclude-path
+# match then fails (it's relative to the wrong manifest) and cargo/maturin
+# errors with "current package believes it's in a workspace when it's not".
+# An empty `[workspace]` table makes this manifest its own workspace root so
+# the search never escapes the worktree.
+
+[workspace]
 
 [package]
 name = "bigip-report-gen-py"

--- a/rust/bigip-report-gen/wasm/Cargo.toml
+++ b/rust/bigip-report-gen/wasm/Cargo.toml
@@ -28,6 +28,19 @@
 # the same reasons as `bigip-query-wasm`: wasm-bindgen's generated glue trips
 # the workspace `unsafe_code = "forbid"` lint, and it targets wasm32 with its
 # own lockfile. Built with `build-wasm.sh` (cargo + wasm-bindgen + wasm-opt).
+#
+# The empty `[workspace]` table below is load-bearing (see the fuller comment
+# in `rust/tcl-spec-studio-wasm/Cargo.toml`, issue #1136): without it, cargo
+# walks up past this crate looking for a `[workspace]` ancestor, and inside a
+# git worktree nested under the main checkout's directory (this repo's
+# standard parallel-agent worktree layout) it finds the *main checkout's*
+# top-level `Cargo.toml` instead of stopping at this crate — the exclude-path
+# match then fails (it's relative to the wrong manifest) and cargo errors with
+# "current package believes it's in a workspace when it's not". An empty
+# `[workspace]` table makes this manifest its own workspace root so the search
+# never escapes the worktree.
+
+[workspace]
 
 [package]
 name = "bigip-report-wasm"

--- a/rust/tcl-explorer-wasm/Cargo.toml
+++ b/rust/tcl-explorer-wasm/Cargo.toml
@@ -22,6 +22,20 @@
 # targeting `wasm32-unknown-unknown`, and wasm-bindgen's generated glue
 # needs `unsafe`, which the workspace `unsafe_code = "forbid"` lint bans.
 # Built via `make explorer-wasm` (wasm-pack + wasm-opt); see the Makefile.
+#
+# The empty `[workspace]` table below is load-bearing (see the fuller comment
+# in `rust/tcl-spec-studio-wasm/Cargo.toml`, issue #1136): without it, cargo
+# walks up past this crate looking for a `[workspace]` ancestor, and inside a
+# git worktree nested under the main checkout's directory (this repo's
+# standard parallel-agent worktree layout) it finds the *main checkout's*
+# top-level `Cargo.toml` instead of stopping at this crate — the exclude-path
+# match then fails (it's relative to the wrong manifest) and cargo errors with
+# "current package believes it's in a workspace when it's not", which is
+# exactly what broke `make check-rust`'s tcl-explorer-wasm step in every
+# worktree. An empty `[workspace]` table makes this manifest its own
+# workspace root so the search never escapes the worktree.
+[workspace]
+
 [package]
 name = "tcl-explorer-wasm"
 # This crate is `exclude`d from the root workspace (see the comment above and

--- a/rust/tcl-lsp-server/tests/e2e/common/mod.rs
+++ b/rust/tcl-lsp-server/tests/e2e/common/mod.rs
@@ -1044,6 +1044,97 @@ impl Lsp {
         }
     }
 
+    /// Block until the server's `[timing] diagnostics master-off` marker for
+    /// `uri` is logged (searching entries at index `since` onward), then
+    /// return the diagnostics from the `publishDiagnostics` immediately
+    /// preceding it in the notification stream.
+    ///
+    /// This is the deterministic-barrier analogue of the VS Code extension
+    /// suite's `waitForMasterOffDiagnostics` + `getDiagnostics(docUri)`
+    /// (`editors/vscode/src/test/helper.ts`): the master switch
+    /// (`tclLsp.features.diagnostics = false`) publishes its empty set and
+    /// *then* logs this marker (`run_diagnostics_master_off` in
+    /// `tcl-lsp-server/src/lib.rs`), so the marker is proof the publish this
+    /// test cares about has already landed.
+    ///
+    /// Do **not** use [`Self::await_diagnostics_version`] for this: it
+    /// returns as soon as *any* `publishDiagnostics` for `uri`/`version`
+    /// matches, with no way to tell a publish computed under the old
+    /// (diagnostics-on) config from one computed under the new
+    /// (diagnostics-off) config apart — both carry the same document
+    /// version, because a config change never bumps it. A `didOpen`'s own
+    /// analysis can still have a later publish for that version in flight
+    /// (e.g. a converged/cross-file correction) when the config flips off;
+    /// if that stale publish lands in the buffer before the master-off one,
+    /// `await_diagnostics_version` returns the stale non-empty result
+    /// instead of waiting for the clear (issue #1135). Keying on the
+    /// marker — and reading only the publish that precedes it — closes that
+    /// window: this scans in one pass under the same lock used by the
+    /// condvar wait, so there is no gap between "the marker was observed"
+    /// and "the matching publish was read" for a later notification to land
+    /// in.
+    pub fn await_diagnostics_master_off(
+        &self,
+        uri: &str,
+        timeout: Duration,
+        since: usize,
+    ) -> Vec<Value> {
+        let needle_uri = format!("uri={uri}");
+        let deadline = Instant::now() + scaled_timeout(timeout);
+        let mut notes = self.shared.notifications.lock().unwrap();
+        loop {
+            let mut last_diags_before_marker: Option<Vec<Value>> = None;
+            for note in notes.iter().skip(since) {
+                match note.get("method").and_then(Value::as_str) {
+                    Some("textDocument/publishDiagnostics") => {
+                        let params = note.get("params").cloned().unwrap_or(Value::Null);
+                        if params.get("uri").and_then(Value::as_str) == Some(uri) {
+                            last_diags_before_marker = Some(
+                                params
+                                    .get("diagnostics")
+                                    .and_then(Value::as_array)
+                                    .cloned()
+                                    .unwrap_or_default(),
+                            );
+                        }
+                    }
+                    Some("window/logMessage") => {
+                        let msg = note
+                            .get("params")
+                            .and_then(|p| p.get("message"))
+                            .and_then(Value::as_str)
+                            .unwrap_or("");
+                        if msg.contains("diagnostics master-off") && msg.contains(&needle_uri) {
+                            return last_diags_before_marker.unwrap_or_else(|| {
+                                drop(notes);
+                                panic!(
+                                    "diagnostics master-off marker for {uri:?} logged with no \
+                                     preceding publishDiagnostics for it — the marker/publish \
+                                     ordering contract in `run_diagnostics_master_off` broke"
+                                )
+                            });
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                drop(notes);
+                panic!(
+                    "no diagnostics master-off marker for {uri:?} within {timeout:?}{}",
+                    latency_barrier_timeout_note()
+                );
+            }
+            let (guard, _) = self
+                .shared
+                .notify_cv
+                .wait_timeout(notes, remaining)
+                .unwrap();
+            notes = guard;
+        }
+    }
+
     /// Block until a `window/logMessage` whose text contains all `needles`
     /// (searching entries at index `since` onward). Returns the message text.
     pub fn await_log(&self, needles: &[&str], timeout: Duration, since: usize) -> String {

--- a/rust/tcl-lsp-server/tests/e2e/config.rs
+++ b/rust/tcl-lsp-server/tests/e2e/config.rs
@@ -31,7 +31,7 @@
 //! directions), so it is exercised explicitly here via a second
 //! `apply_configuration_settle` back to the enabled state.
 
-use crate::common::{Lsp, unique_uri};
+use crate::common::{Lsp, scaled_timeout, unique_uri};
 
 use serde_json::{Value, json};
 
@@ -392,7 +392,7 @@ fn diagnostic_severity_override_relevels_a_diagnostic() {
     // unchanged, only the published severity moves. Poll the deterministic pull
     // path until the re-pulled config takes effect.
     lsp.apply_configuration(json!({ "diagnosticSeverity": { "W211": "warning" } }));
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + scaled_timeout(Duration::from_secs(10));
     let mut diags = lsp.pull_diagnostics(&uri);
     while severity_of(&diags, "W211") != Some(2) && Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(100));
@@ -406,7 +406,7 @@ fn diagnostic_severity_override_relevels_a_diagnostic() {
 
     // Reset to default (empty override) and confirm it returns to Hint.
     lsp.apply_configuration(json!({ "diagnosticSeverity": {} }));
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + scaled_timeout(Duration::from_secs(10));
     let mut diags = lsp.pull_diagnostics(&uri);
     while severity_of(&diags, "W211") != Some(4) && Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(100));
@@ -432,7 +432,7 @@ fn diagnostic_severity_override_is_per_code() {
 
     // Override only W211 → error (1); W220 must keep its emitted Hint (4).
     lsp.apply_configuration(json!({ "diagnosticSeverity": { "W211": "error" } }));
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + scaled_timeout(Duration::from_secs(10));
     let mut diags = lsp.pull_diagnostics(&uri);
     while severity_of(&diags, "W211") != Some(1) && Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(100));

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -22,7 +22,7 @@
 //! advertises no pull provider, so these assert on the `publishDiagnostics` the
 //! server pushes after analysis, keyed by version.
 
-use crate::common::{Lsp, unique_uri};
+use crate::common::{Lsp, scaled_timeout, unique_uri};
 
 use serde_json::Value;
 use std::collections::BTreeSet;
@@ -2525,7 +2525,7 @@ fn autoload_library_command_not_unknown_issue_832() {
     // The package database is (re)built asynchronously at startup; poll the
     // deterministic pull path until it is live (W123 clears) or the deadline.
     let mut diags = lsp.pull_diagnostics(&uri);
-    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let deadline = std::time::Instant::now() + scaled_timeout(Duration::from_secs(15));
     while has_code(&diags, "W123") && std::time::Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(100));
         diags = lsp.pull_diagnostics(&uri);
@@ -2590,7 +2590,7 @@ fn autoload_library_command_go_to_definition_m8() {
 
     // The package database loads asynchronously at startup; poll (via the W123
     // clearing on the pull path) until it is live, then go-to-definition.
-    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let deadline = std::time::Instant::now() + scaled_timeout(Duration::from_secs(15));
     let mut diags = lsp.pull_diagnostics(&uri);
     while has_code(&diags, "W123") && std::time::Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(100));
@@ -2692,7 +2692,7 @@ fn guarded_pkg_child_diagnostics(dialect: &str, libdir: &std::path::Path) -> Vec
     // path is deterministic once it is live.  Poll until the answer stops
     // changing rather than assuming either outcome.
     let mut diags = lsp.pull_diagnostics(&child);
-    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let deadline = std::time::Instant::now() + scaled_timeout(Duration::from_secs(15));
     while std::time::Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(100));
         let next = lsp.pull_diagnostics(&child);
@@ -2825,7 +2825,7 @@ fn autoload_library_command_references_and_rename_m8() {
 
     // The package database loads asynchronously at startup; poll (via the W123
     // clearing on the pull path) until it is live.
-    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let deadline = std::time::Instant::now() + scaled_timeout(Duration::from_secs(15));
     let mut diags = lsp.pull_diagnostics(&uri);
     while has_code(&diags, "W123") && std::time::Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(100));
@@ -3816,7 +3816,7 @@ fn consumer_rename_resolves_through_a_real_workspace_folder_m8() {
 
     // The folder scan runs asynchronously; poll the rename until the library
     // edit appears (or the deadline), exactly like the editor test.
-    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let deadline = std::time::Instant::now() + scaled_timeout(Duration::from_secs(15));
     let mut lib_lines: Vec<i64> = Vec::new();
     while std::time::Instant::now() < deadline && lib_lines.is_empty() {
         let resp = lsp.request(

--- a/rust/tcl-lsp-server/tests/e2e/irules.rs
+++ b/rust/tcl-lsp-server/tests/e2e/irules.rs
@@ -27,7 +27,7 @@
 //! uncontaminated.
 
 use crate::common::helpers::*;
-use crate::common::{Lsp, unique_uri};
+use crate::common::{Lsp, scaled_timeout, unique_uri};
 
 use serde_json::{Value, json};
 use std::time::Duration;
@@ -1234,7 +1234,7 @@ const DEEP_MARKER: &str = "IRULE1006";
 fn deep_diags(lsp: &mut Lsp, source: &str) -> Vec<Value> {
     let uri = unique_uri("irule");
     lsp.open_ready_lang(&uri, source, "tcl-irule");
-    let deadline = std::time::Instant::now() + Duration::from_secs(25);
+    let deadline = std::time::Instant::now() + scaled_timeout(Duration::from_secs(25));
     let mut diags = Vec::new();
     while std::time::Instant::now() < deadline {
         diags = lsp.await_diagnostics_version(&uri, Some(1), Duration::from_secs(25));
@@ -1388,7 +1388,7 @@ fn when_body_is_analysed_under_irules() {
 fn diags_until(lsp: &mut Lsp, source: &str, marker: &str) -> Vec<Value> {
     let uri = unique_uri("irule");
     lsp.open_ready_lang(&uri, source, "tcl-irule");
-    let deadline = std::time::Instant::now() + Duration::from_secs(25);
+    let deadline = std::time::Instant::now() + scaled_timeout(Duration::from_secs(25));
     let mut diags = Vec::new();
     while std::time::Instant::now() < deadline {
         diags = lsp.await_diagnostics_version(&uri, Some(1), Duration::from_secs(25));

--- a/rust/tcl-lsp-server/tests/e2e/recovery.rs
+++ b/rust/tcl-lsp-server/tests/e2e/recovery.rs
@@ -45,7 +45,7 @@
 //! language-internal unit/differential/fuzz suites.
 
 use crate::common::helpers::*;
-use crate::common::{Lsp, unique_uri};
+use crate::common::{Lsp, scaled_timeout, unique_uri};
 
 use serde_json::{Value, json};
 use std::collections::BTreeSet;
@@ -817,7 +817,7 @@ fn package_required_library_command_recovers_the_tail() {
     // deterministic pull path until recovery reflects it or the deadline
     // (mirrors `autoload_library_command_not_unknown_issue_832`).
     let mut diags = lsp.pull_diagnostics(&uri);
-    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let deadline = std::time::Instant::now() + scaled_timeout(Duration::from_secs(15));
     while !diags.iter().any(|d| code_str(d) == "E001") && std::time::Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(100));
         diags = lsp.pull_diagnostics(&uri);
@@ -861,7 +861,7 @@ fn undefined_name_with_package_required_falls_back_honestly() {
         "package require mypkg\nset q {\n  aaa\nmypkg_helper 1; string\n",
     );
     let mut cdiags = lsp.pull_diagnostics(&control);
-    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let deadline = std::time::Instant::now() + scaled_timeout(Duration::from_secs(15));
     while !cdiags.iter().any(|d| code_str(d) == "E001") && std::time::Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(100));
         cdiags = lsp.pull_diagnostics(&control);

--- a/rust/tcl-lsp-server/tests/e2e/vscode_parity.rs
+++ b/rust/tcl-lsp-server/tests/e2e/vscode_parity.rs
@@ -397,10 +397,18 @@ fn test_diagnostics_master_switch_clears_all() {
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
     assert!(!lsp.open_ready(&uri, "catch {error e}\n").is_empty()); // non-empty by default
-    lsp.clear_notifications();
+    // A version-tagged `await_diagnostics_version` races here (issue #1135):
+    // the just-opened document's own analysis can still have a later publish
+    // for version 1 in flight (e.g. a converged correction), and a config
+    // change never bumps the document version, so that stale non-empty
+    // publish and the master-off empty one are indistinguishable by
+    // (uri, version) alone. Capture a cursor and key on the server's own
+    // `diagnostics master-off` marker instead — see
+    // `Lsp::await_diagnostics_master_off`.
+    let since = lsp.notification_cursor();
     lsp.apply_configuration(json!({ "features": { "diagnostics": false } }));
     assert_eq!(
-        lsp.await_diagnostics_version(&uri, Some(1), Duration::from_secs(15)),
+        lsp.await_diagnostics_master_off(&uri, Duration::from_secs(15), since),
         Vec::<Value>::new()
     );
 }

--- a/rust/tcl-spec-studio-wasm/Cargo.toml
+++ b/rust/tcl-spec-studio-wasm/Cargo.toml
@@ -23,6 +23,26 @@
 # wasm-bindgen's generated glue needs `unsafe`, which the workspace
 # `unsafe_code = "forbid"` lint bans, and it targets wasm32 with its own
 # lockfile. Built via `make spec-studio-wasm`; see build-wasm.sh.
+#
+# The empty `[workspace]` table below is load-bearing, not decorative: with
+# no workspace table of its own, cargo walks *up* the directory tree looking
+# for an ancestor manifest with `[workspace]` to attach to. That is normally
+# harmless because this crate's path is on the root workspace's `exclude`
+# list — except inside a git worktree checked out under the main checkout's
+# directory (e.g. `<main>/.claude/worktrees/<name>/rust/tcl-spec-studio-wasm`,
+# the standard layout for this repo's parallel agent worktrees): cargo keeps
+# walking past the worktree root and finds the *main checkout's* top-level
+# Cargo.toml. The exclude match is a path comparison relative to that
+# manifest's own directory, so the worktree-relative path
+# (`.claude/worktrees/<name>/rust/tcl-spec-studio-wasm`) does not match the
+# listed `rust/tcl-spec-studio-wasm`, and cargo errors with "current package
+# believes it's in a workspace when it's not" — `make check-rust` then fails
+# in every worktree, before and after any code change (issue #1136). An
+# empty `[workspace]` table makes this manifest a workspace root in its own
+# right, so the search never looks further up, in the main checkout or in
+# any worktree.
+[workspace]
+
 [package]
 name = "tcl-spec-studio-wasm"
 # This crate is `exclude`d from the root workspace, so it cannot inherit


### PR DESCRIPTION
## Summary

- Fixes cargo workspace resolution for standalone crates inside a git worktree; de-flakes the diagnostics-timing e2e tests (marker-keyed, load-scaled deadlines); extends the lsp-client harness (`--also-open`, republish-race verification, `--scan-timeout`); revalidates `compiler-pipeline-parity.md`'s memory-SSA/SCCP/complexity-guard claims.
- Closes #1111, closes #1135, closes #1136, closes #1189.

Part of the per-group PR series; independent of the other groups. Test/docs/tooling only — no server or compiler behaviour changes.

## Validation

- [x] On the group branch: affected e2e suites re-run 20× to confirm de-flaking; harness exercised live against the built server.
- [x] Rebased onto `rust` (post-#1212): `cargo check --workspace --all-targets` — 0 errors.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract? — No (tests, harness, and docs only).
- [ ] KCS note — n/a.
- [ ] Linked — n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_