### PR TITLE
Perf: document snapshot sharing, taint solver pruning, registry-driven Tk activation (#1184, #1187, #1188)

### DIFF
--- a/docs/design/compiler/taint-analysis.md
+++ b/docs/design/compiler/taint-analysis.md
@@ -74,12 +74,79 @@ Some commands transform taint colours:
 
 ### Interprocedural taint propagation
 
-`_solve_interprocedural_taints()` extends taint tracking across procedure
+`solve_interprocedural_taints` extends taint tracking across procedure
 boundaries using `ProcTaintSummary` objects:
 1. Analyse each procedure in isolation.
 2. For each call site, propagate caller taints into callee parameters.
 3. Propagate callee return taint back to the caller's result variable.
 4. Iterate until fixpoint.
+
+#### What a summary costs, and why (#1187)
+
+A summary is a **transfer function**, not a single value: a clean base return
+taint, plus — for each parameter — one return taint per colour basis, so a
+caller can ask "what comes back if I pass a value tainted *this* way?".  There
+are 15 bases, so inferring a summary the direct way is `1 + 15P` complete
+dataflow solves over the procedure's control-flow graph, for `P` parameters.
+That is the dominant cost of the whole pass: about 80% of `run_all_checks` on
+tcllib's `practcl.tcl`.
+
+Two prunes cut it down.  Both are **proofs that a solve would return a value
+already in hand**, not approximations, so summaries stay bit-identical — which
+is what lets the debug fixpoint guard and the `compiler_check` corpus
+differential keep validating the inference unchanged:
+
+- **Constant return** — `collect_return_taint` reads the taint map only through
+  `var_taint`, reachable only from `word_taint`'s three substitution branches, and
+  all three require the return word to contain a `$` or a `[`.  A procedure whose
+  executable returns are all value-less or all substitution-free therefore
+  returns `clean` whatever the map holds, so the whole summary is the clean one:
+  **0** solves instead of `1 + 15P`.  This is the common case in real Tcl — a
+  procedure that returns nothing, a literal, or a braced constant.
+- **Unread parameter** — `seed_entry_taints` skips a name that is not interned in
+  the SSA, so seeding a parameter the body never reads leaves the initial taint
+  map bit-identical to the clean base run's.  The scenario *is* `return_base`:
+  **0** solves instead of 15, per such parameter.
+
+What remains is `1 + 15 × (parameters actually read, in a procedure whose return
+value is substitution-bearing)`.  Collapsing that last `15×` needs a different
+representation — one multi-colour symbolic traversal carrying a
+per-`(parameter, basis)` dependency bitset — which changes what the solver
+computes rather than skipping work it can prove redundant, and is not attempted.
+
+Measured with `cargo run --release -p tcl-lsp-db --example tail_profile` on
+tcllib's `practcl.tcl` (8,463 lines, 116 functions), same machine, same binary:
+
+| phase | before | after |
+|---|---:|---:|
+| `solve_interprocedural_taints` (whole unit) | 211.5 ms | 143.4 ms |
+| `run_all_checks` | 260.1 ms | 155.9 ms |
+
+The taint solve keeps its place as the dominant phase (about 92% of
+`run_all_checks`); it is simply a third cheaper, and the checks tail as a whole
+drops 40%.
+
+#### Convergence
+
+`converge_summaries_with` drives the summary fixpoint from a dirty set: a
+procedure is re-inferred only when one of its callees' summaries moved.  The
+reverse call graph comes from two sources unioned — the declared
+`InterproceduralAnalysis::direct_calls`, plus `resolved_callees`, which scans the
+very CFG statements the inference resolves calls from and so supplies the edges
+`direct_calls` drops for a callee reached through a command substitution
+(`symbolNodeOf` in `set n [$t get [symbolNodeOf …] …]`, a self-call inside
+`[expr {[fib …]}]`).
+
+A missed edge is still not a wrong answer: the worklist is followed by an
+unconditional round-robin completion sweep that re-queues any procedure whose
+summary still moves, and the lattice is monotone over a finite domain, so the
+true least fixpoint is always reached.  **The sweep is deliberately retained.**
+Removing it would require *proving* the dependency graph complete, and neither
+source is: `direct_calls` misses nested substitutions, and `resolved_callees`
+scans CFG statements rather than the raw words `word_taint` recurses into.  An
+under-converged fixpoint is a taint **false negative** — a silently missed
+security diagnostic — which is a much worse failure than one extra `O(F)` sweep,
+now that the prunes above have made each inference cheap.
 
 ### Worked example — `HTTP::header value Host` → `HTTP::respond`
 

--- a/docs/design/rust/incremental-analysis.md
+++ b/docs/design/rust/incremental-analysis.md
@@ -187,10 +187,11 @@ variants, ordered by where the guard sits in the pass:
 | --- | --- |
 | `IncompleteScript` | unbalanced braces/quotes — the transient mid-typing state |
 | `StubDirective` | an inline `tcl-lsp: stub` overlay |
-| `TkActive` | Tk checks accumulate whole-file widget/geometry state |
+| `TkActive` | Tk checks accumulate whole-file widget/geometry state — the `tk` dialect at entry, or a walk-recorded `package require Tk` (#1188) |
 | `GhostRecovery` | ghost-token error recovery engaged |
 | `PartialCommand` | an unterminated command survived segmentation |
 | `ErrorDiagnostic` | an `E…` code — `analyse` ran recovery machinery |
+| `OversizedBody` | a deferred body exceeds `OVERSIZED_BODY_BYTES` — the isolated-body path is a pessimisation there (#1188) |
 | `DuplicateMethod` | one method qualified name defined twice |
 | `EnclosingContext` | a body links a qualified sub-namespace variable, or `namespace import`/`export`s from inside a body |
 | `DuplicateProcInBody` | a body defines an already-defined proc |
@@ -212,14 +213,14 @@ and `EnclosingContext` (11.1%). Note that `IncompleteScript` never fires on
 documents at rest but fires constantly *while typing*, so the live rate is worse
 than this at-rest figure.
 
-Two findings from that sweep are open, and both argue against widening the fast
-path before the cost model is understood:
+Two findings from that sweep drove the #1188 work below, and they had to be
+resolved *together* — fixing either alone makes things worse:
 
-- **`TkActive` is ~78% false positives.** The guard is three *independent*
+- **`TkActive` was ~78% false positives.** The guard was three *independent*
   substring tests (`package`, `require`, `Tk`, anywhere, comments included). 64
-  documents trip it, 14 genuinely `package require Tk`, and the other 50 emit no
-  Tk diagnostic at all — so tightening it to an adjacent `package require Tk` is
-  behaviour-preserving on this corpus.
+  documents tripped it, 14 genuinely `package require Tk`, and the other 50
+  emitted no Tk diagnostic at all — so tightening it to a real `package require
+  Tk` is behaviour-preserving on this corpus.
 - **…but tightening it exposes a scaling cliff.** On `fumagic/filetypes.tcl`
   (85k generated lines, one 71k-line body) the incremental path costs 139,010 ms
   against 5,312 ms for the plain whole-file walk — 26x slower, per keystroke.
@@ -227,6 +228,94 @@ path before the cost model is understood:
   standalone script takes 36,634 ms against 5,312 ms for the whole document
   containing it, so isolated analysis of a large body is ~7x more expensive than
   the identical content analysed in place.
+
+### Resolving both: registry-driven Tk activation + an oversized-body guard (#1188)
+
+**The gate is no longer a substring scan.** Tk activation has exactly two
+inputs, and they are now both taken from where the truth actually lives:
+
+- the `tk` dialect — decidable at entry, so a `wish` document short-circuits
+  before any work; and
+- a `package require Tk` — a *whole-file* fact, recorded during the walk by the
+  registry's `AnalyserHookId::PackageRequire` hook, which is the very fact
+  `flush_tk_geometry_diagnostics` gates the TK diagnostics on. The two therefore
+  cannot disagree, and a `-exact` flag, a version constraint, line
+  continuations, and `package require` inside a `namespace eval`, an `if`, or a
+  proc body all fall out of the ordinary command walk rather than needing a
+  bespoke scanner.
+
+Because the second input is only known after the walk, `analyse_per_item_with`
+checks it twice — once after the shell pass (which catches the top-level
+`package require Tk` of essentially every real Tk script, before the body pass
+is paid for) and once after the body pass (which makes it complete, since
+`graft_proc_body` merges the requires a body contributed). A genuinely-Tk
+document therefore pays one discarded per-item pass; that is the price of never
+paying a whole-file re-analysis, on every keystroke, for a document that merely
+*mentions* the word `Tk`.
+
+What remains a substring test is `tk_checks_could_apply`, and only as a
+performance precheck for the per-command accumulation: a sound *necessary*
+condition (`dialect == "tk" || source.contains("Tk")`) that can over-approximate
+freely, because everything the walk buffers is discarded unless the exact
+activation fact holds. The per-item path pins it to `false` outright — it
+accumulates no Tk state at all, since a Tk document's result is thrown away for
+a full re-analysis anyway.
+
+**Documented conservative limits.** A dynamic package name (`package require
+$p`) is recorded verbatim and so never matches; a `package` reached after a
+`rename`, or hidden in a safe interpreter, is not a resolvable `package
+require`. Both leave the checks off — matching the whole-file walk exactly, so
+per-item and full analysis still agree byte for byte. Separately,
+`::package require Tk` does **not** activate, because `resolve_analyser_hook_call`
+deliberately refuses a `::`-qualified spelling of a bareword global command
+(pinned by issue #923). That is a pre-existing false negative of the whole-file
+walk — `analyse` emits no TK diagnostic there either — not something this gate
+introduced; lifting the `::`-bareword guard would fix it, but it widens hook
+dispatch for *every* stamped command and belongs to its own change.
+
+**The cliff is guarded by body size, not by Tk.** `fill_deferred_bodies` hands
+off with `OversizedBody` when any deferred body exceeds `OVERSIZED_BODY_BYTES`
+(256 KiB), checked before any body is analysed so an oversized document pays
+only the shell pass that discovered it. 256 KiB is far above any hand-written
+procedure (~6,000 lines of ordinary Tcl); it exists to catch *generated*
+single-body files, which are the only place bodies that size occur and the only
+place the isolated-body path is a dramatic pessimisation. The guard is **per
+body, not per document**: a large file made of many ordinary procs is exactly
+the case per-body memoisation pays off for and stays on the fast path.
+
+Two of tcllib 2.0's 882 documents exceed it, both generated:
+`fumagic/filetypes.tcl` (one ~1.2 MB body) and the `i.map` variant of
+`textutil/wcswidth.tcl` (34,856 lines in three procedures, two of them ~2.2 MB).
+`wcswidth.tcl` did previously take the fast path, and its cold cost is roughly
+unchanged (999 ms for the whole-file walk, 1,153 ms through the guard) — but a
+*warm* edit there would have re-analysed a 2.2 MB body in isolation, half the
+document at the ~7x isolated-body penalty, so removing it from the incremental
+path is the right call for the case the path exists to serve.
+
+**Measured, tcllib 2.0 (882 documents, 460,103 lines, `tcl8.6`):**
+
+| guard | before: files / lines / ms | after: files / lines / ms |
+|---|---|---|
+| `tk-active` | 33 / 127,247 / 4,908 | 9 / 4,160 / 343 |
+| `oversized-body` | — | 2 / 119,897 / 5,135 |
+| `error-diagnostic` | 35 / 27,116 / 2,614 | 41 / 43,424 / 4,621 |
+| `enclosing-context` | 41 / 38,226 / 1,941 | 45 / 48,495 / 2,814 |
+
+`tk-active` drops from 27.7% of corpus lines to 0.9%: 24 of the 33 documents it
+claimed were false positives, `filetypes.tcl` and `practcl.tcl` among them.
+Neither reports `tk-active` any more — `filetypes.tcl` is caught by the
+oversized-body guard instead (`analyse` 3,427 ms vs 3,219 ms through the guard,
+so the guard costs nothing over the plain walk), and `practcl.tcl` turns out to
+trip `error-diagnostic`, which the Tk false positive had been masking.
+
+That masking is the honest cost of the change: a document whose *real* gate sits
+after the walk now pays a per-item pass before reaching it, where the entry-time
+Tk guess used to short-circuit. On `practcl.tcl` that is 883 ms against 345 ms
+for the whole-file walk. The corpus total moves 21,413 ms → 25,790 ms for the
+same reason. This is not a regression the Tk fix introduced so much as one it
+*revealed* — `error-diagnostic` and `enclosing-context` firing only after the
+full decomposition is a pre-existing property of those guards, and hoisting them
+is the natural follow-up.
 
 More broadly, the decomposition alone is close to break-even — over 210 sampled
 fast-path documents `analyse_per_item` is *slower* than `analyse` on 23% of

--- a/docs/design/rust/lsp-performance.md
+++ b/docs/design/rust/lsp-performance.md
@@ -243,6 +243,67 @@ snapshots is live at once (each warm clones its snapshot only after acquiring a
 permit), and each read is the cancellable per-item query, so a concurrent
 `set_text` unwinds them at a per-item boundary rather than waiting them out.
 
+### 9. Shared document snapshots (#1184)
+
+Every request handler works from a snapshot: `Backend::read_document` clones
+the `DocumentState` out of the store and drops the lock, so handlers can cross
+`.await` points and hand work to `spawn_blocking` without holding the mutex or
+serialising against each other. The snapshot was a **deep copy**: `text` was a
+`String` and `line_index` owned a `Box<[u32]>`, so each of the ~55
+`read_document` call sites copied the whole document plus four bytes per line,
+and many handlers then cloned `doc.text` *again* to move it into a worker.
+
+Both large fields are now shared handles — `text: Arc<str>`, and
+`LineIndex`'s backing store is an `Arc<[u32]>` — so a snapshot is two
+reference-count bumps. With `R` concurrent requests against a `B`-byte,
+`L`-line document, snapshot memory goes from `O(R × (B + 4L))` to
+`O(B + 4L + R)`. On the two corpus documents #1181 measures:
+
+| document | bytes | lines | old: copied per snapshot | new: copied per snapshot |
+|---|---:|---:|---:|---:|
+| `tcllib/modules/practcl/practcl.tcl` | 263,816 | 8,463 | ~291 KiB | nothing |
+| `tcllib/modules/fumagic/filetypes.tcl` | 1,320,164 | 85,040 | ~1.58 MiB | nothing |
+
+("Nothing" for the two large fields — two reference-count bumps. A snapshot
+still copies the short `dialect` and `language_id` strings, which are bounded by
+the dialect vocabulary rather than by document size.)
+
+A handler that snapshotted `filetypes.tcl` and then cloned `doc.text` for a
+worker transiently copied ~2.84 MiB; it now copies nothing. The two hottest
+consumers took the handle through rather than re-materialising a `String`:
+`analysis_for` (~30 call sites — and its common path is a cache hit that never
+reads the text at all) and `DiagJob`, the per-run diagnostics snapshot.
+
+**The ownership contract.** `DocumentState` is both the mutable owner of an
+open document and the immutable snapshot handed to readers, so sharing is only
+safe under three rules, all documented on the type:
+
+1. **Build-and-swap, never mutate in place.** `apply_content_change_indexed`
+   splices into a fresh buffer and `LineIndex::apply_edit` builds a fresh
+   `Vec`; each is then installed as a *new* handle. An outstanding snapshot
+   observes the revision it was taken at for its whole lifetime, which is what
+   lets an in-flight request finish against an older revision while the editor
+   keeps typing.
+2. **`text` and `line_index` are one snapshot, not two fields.** They are
+   installed together in the single place that replaces them, so no reader can
+   pair text from revision `N` with an index from revision `N-1` and resolve a
+   position against the wrong offsets.
+3. **Sharing is never mutable.** Nothing writes through an `Arc` a reader may
+   hold; the one component that legitimately rewrites a buffer (the fix-all
+   code action) takes its own owned copy.
+
+Closed on-disk files are unchanged: `read_document`'s disk fallback mints a
+fresh snapshot per read and does **not** install it in the open-document store,
+so a cross-file read cannot retain every file it ever touched.
+
+Pinned by `concurrent_snapshots_share_one_text_and_index_allocation` (32
+overlapping readers share one allocation),
+`an_edit_never_mutates_a_snapshot_an_in_flight_request_holds` (revision
+currency, text *and* index together),
+`reading_a_closed_on_disk_file_does_not_retain_it`, and, in `tcl-lexer`,
+`clone_shares_one_backing_allocation` /
+`apply_edit_leaves_outstanding_clones_on_the_old_revision`.
+
 ## Where the remaining cost is
 
 The ~1.3 s diagnostic latency on an 8.5k-line file is dominated by the
@@ -259,5 +320,8 @@ already resolved by the async-diagnostics work above.
 |---|---|
 | Python vs Rust table | historical — the dual-backend `bench_lsp_backends.py` harness was retired with Python; the table is preserved as the migration baseline |
 | analyser walk vs tail split; lattice costs | `cargo run --release -p tcl-compiler --example incr_experiments` |
+| per-edit tail split (analyser / checks / taint solve) | `cargo run --release -p tcl-lsp-db --example tail_profile` (`FILE=` picks the document) |
+| incremental-path fallback distribution | `cargo run --release -p tcl-compiler --example per_item_fallbacks` (`ROOT=` picks the corpus) |
+| document-snapshot sharing (#1184) | `cargo test -p tcl-lsp-server --lib -- concurrent_snapshots` and `cargo test -p tcl-lexer --lib line_index` |
 | heavy-edit interactive latency | edit + trivial-request timing via `.claude/skills/lsp-client` |
 | native lsp_e2e suite | `make test-rust` (runs `rust/tcl-lsp-server/tests/*_e2e.rs` via `cargo test`) |

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -54,6 +54,20 @@ use tcl_lexer::Token;
 use super::state::Analyser;
 use super::types::AnalysisResult;
 
+/// Largest proc / method body (in bytes of body text) the per-item
+/// decomposition will take on.  Above this the document falls back to a whole-
+/// file [`Analyser::analyse`] with [`PerItemFallback::OversizedBody`].
+///
+/// 256 KiB is deliberately far above any hand-written procedure — roughly
+/// 6,000 lines of ordinary Tcl — so no real code base loses the incremental
+/// path; it exists to catch *generated* single-body files, which are the only
+/// place bodies this size occur and the only place the isolated-body path is a
+/// dramatic pessimisation (see the call site in [`Analyser::fill_deferred_bodies`]).
+/// Two of tcllib 2.0's 882 documents are above it, and both are generated:
+/// `fumagic/filetypes.tcl` (one ~1.2 MB body) and the `i.map` variant of
+/// `textutil/wcswidth.tcl` (two ~2.2 MB bodies).
+const OVERSIZED_BODY_BYTES: usize = 256 * 1024;
+
 /// Why [`Analyser::analyse_per_item_with`] abandoned the incremental path and
 /// paid for a full whole-file walk.
 ///
@@ -72,6 +86,16 @@ pub enum PerItemFallback {
     StubDirective,
     /// Tk checks are live, and their whole-file state (created widgets,
     /// per-parent geometry) is not visible to an isolated body.
+    ///
+    /// Fires in two places, because Tk activation has two inputs of very
+    /// different cost (issue #1188): the `tk` dialect is known at entry and
+    /// short-circuits before any work, whereas a `package require Tk` is a
+    /// whole-file fact only the walk can establish, so it is checked *after*
+    /// the shell + body passes have filled `result.package_requires` via the
+    /// registry's `PackageRequire` hook.  The late check pays one wasted
+    /// per-item pass on a genuinely-Tk document — the price of never paying a
+    /// whole-file re-analysis, on every keystroke, for a document that merely
+    /// *mentions* the word `Tk`.
     TkActive,
     /// Ghost-token error recovery engaged.
     GhostRecovery,
@@ -80,6 +104,9 @@ pub enum PerItemFallback {
     /// An `E…` diagnostic was emitted — `analyse` would have run recovery
     /// machinery the per-item walk only partially reproduces.
     ErrorDiagnostic,
+    /// A deferred body is too large for the isolated-body decomposition to be
+    /// worth taking ([`OVERSIZED_BODY_BYTES`]).
+    OversizedBody,
     /// The same method qualified name is defined more than once.
     DuplicateMethod,
     /// A body declares a link to a qualified sub-namespace variable, or
@@ -105,6 +132,7 @@ impl PerItemFallback {
             Self::GhostRecovery => "ghost-recovery",
             Self::PartialCommand => "partial-command",
             Self::ErrorDiagnostic => "error-diagnostic",
+            Self::OversizedBody => "oversized-body",
             Self::DuplicateMethod => "duplicate-method",
             Self::EnclosingContext => "enclosing-context",
             Self::DuplicateProcInBody => "duplicate-proc-in-body",
@@ -220,6 +248,9 @@ impl Analyser {
         // also falls back to full analysis rather than diverge (a parent
         // created outside a proc would otherwise look missing inside it, and a
         // `pack`/`grid` conflict spanning a proc body would never flush).
+        // Only the *dialect* half of Tk activation is decidable here; the
+        // `package require Tk` half is a whole-file fact established by the
+        // walk, and is checked after the body pass below (issue #1188).
         //
         // Evaluated one gate at a time (rather than as one `||` chain) so the
         // telemetry can name which fired — these are checked in cheapest-first
@@ -227,7 +258,7 @@ impl Analyser {
         let entry_gate = if tcl_lexer::script_is_complete(source) {
             if source.contains("tcl-lsp: stub") {
                 Some(PerItemFallback::StubDirective)
-            } else if super::tk_checks::tk_possibly_active(source, dialect) {
+            } else if dialect == "tk" {
                 Some(PerItemFallback::TkActive)
             } else {
                 None
@@ -268,11 +299,30 @@ impl Analyser {
             self.body_scope_stack.pop();
         }
 
+        // Tk activation, first opportunity (issue #1188).  A `package require
+        // Tk` sits at the top level of essentially every real Tk script, and
+        // the shell pass has just walked the whole top level — including
+        // `namespace eval` and control-flow bodies — so checking here hands off
+        // before the body pass is paid for.  Repeated after the body pass,
+        // which is what makes the check *complete*; this one only makes the
+        // common case cheap.
+        if let Some(tk) = self.tk_activation_fallback(source, dialect) {
+            return tk;
+        }
+
         // --- pass 2: fill each deferred body ---
         // Returns `Err(fallback_result)` for the patterns the isolated-body
         // decomposition can't reproduce byte-for-byte.
         if let Err(fallback) = self.fill_deferred_bodies(source, dialect, body_fn) {
             return *fallback;
+        }
+
+        // Tk activation, completed.  `result.package_requires` is now the whole
+        // document's: `graft_proc_body` merged the requires each proc/method
+        // body contributed, so a `package require Tk` buried inside a body is
+        // caught here even though the shell pass could not see it.
+        if let Some(tk) = self.tk_activation_fallback(source, dialect) {
+            return tk;
         }
 
         // --- tail (cross-item passes; canonicalises order) ---
@@ -297,6 +347,32 @@ impl Analyser {
         result
     }
 
+    /// Hand off to a full [`Analyser::analyse`] if the walk so far has proved
+    /// the document is Tk — otherwise `None`, and the per-item path continues.
+    ///
+    /// The **exact** activation fact (issue #1188), read from
+    /// `result.package_requires`, which the registry's `PackageRequire` hook
+    /// populated during the walk — the very fact
+    /// [`Analyser::flush_tk_geometry_diagnostics`] gates the TK diagnostics on,
+    /// so the two can never disagree.  Tk's `TK100x` checks accumulate whole-file
+    /// state (created widgets, per-parent geometry) that an isolated proc body
+    /// cannot see, so a Tk document must be analysed whole.
+    ///
+    /// This replaced a pre-walk conjunction of three independent substring
+    /// searches (`package`, `require`, `Tk` — anywhere, in any order, comments
+    /// and generated data included).  That guess was ~78% false positives and
+    /// forced a whole-file re-analysis on every keystroke for a quarter of the
+    /// tcllib corpus's source lines.  Paying one discarded per-item pass on a
+    /// *genuinely* Tk document is the trade; the `tk` dialect, the other half
+    /// of activation, still short-circuits at entry for no cost at all.
+    fn tk_activation_fallback(&mut self, source: &str, dialect: &str) -> Option<AnalysisResult> {
+        if !self.has_tk_require() {
+            return None;
+        }
+        self.per_item_fallback = Some(PerItemFallback::TkActive);
+        Some(self.fresh_full_analyse(source, dialect))
+    }
+
     /// Per-item setup, mirroring `analyse`: record source/dialect, apply file +
     /// `noqa` suppressions, build the stub overlay, stash a dialect-aware
     /// registry + line offsets, and segment the source with recovery.  Returns
@@ -313,6 +389,17 @@ impl Analyser {
         self.profile = tcl_dialect::DialectProfile::by_name(dialect);
         self.result.dialect = dialect.to_string();
         self.result.library_versions = self.library_versions.clone();
+        self.tk_dialect = dialect == "tk";
+        // The per-item path deliberately accumulates **no** Tk state, unlike
+        // `analyse` / `analyse_chunked` / `analyse_commands`.  Everything the
+        // accumulation feeds is discarded unless Tk turns out to be active, and
+        // when it is active this walk's whole result is thrown away for a full
+        // re-analysis (see `analyse_per_item_with`) — so buffering here would
+        // only be wasted work, and leaving a stale `true` behind on a reused
+        // `Analyser` would let one document's widgets leak into the next one's
+        // flush.  Pinned explicitly rather than left to the constructor for
+        // exactly that reason.
+        self.tk_accumulation_enabled = false;
         let file_codes = super::utils::parse_file_suppression(source);
         for code in &file_codes {
             self.disabled_diagnostics.insert(code.clone());
@@ -381,6 +468,24 @@ impl Analyser {
         body_fn: &mut dyn FnMut(&DeferredBody) -> BodyFragment,
     ) -> Result<(), Box<AnalysisResult>> {
         let deferred = std::mem::take(&mut self.deferred_bodies);
+        // Scaling guard (issue #1188).  Analysing a body in isolation costs
+        // markedly more than analysing the identical content in place, and the
+        // gap widens with body size, so a single enormous body turns the
+        // incremental path into a large *pessimisation* — on tcllib's generated
+        // `fumagic/filetypes.tcl` (one ~1.2 MB body) the decomposition measured
+        // 26x the whole-file walk, per keystroke.  Nor could the memoisation
+        // above it repay that: re-analysing "one body" there *is* re-analysing
+        // the file.  Such a document should not take the path at all.
+        //
+        // Checked before any `body_fn` call, so an oversized body costs only
+        // the shell pass that discovered it.
+        let oversized_body = deferred
+            .iter()
+            .any(|db| db.body_text.len() > OVERSIZED_BODY_BYTES);
+        if oversized_body {
+            self.per_item_fallback = Some(PerItemFallback::OversizedBody);
+            return Err(Box::new(self.fresh_full_analyse(source, dialect)));
+        }
         // A **method** defined more than once (same qualified name) still forces a
         // fallback: method bodies fill their scope in place, so a genuine
         // duplicate would accumulate rather than last-definition-win.  (Distinct
@@ -1232,6 +1337,206 @@ mod tests {
         let want = Analyser::new().analyse(src, "tcl8.6");
         let got = Analyser::new().analyse_per_item(src, "tcl8.6");
         assert_eq!(got, want, "per_item != analyse for:\n{src}");
+    }
+
+    /// Which gate (if any) `analyse_per_item` tripped for `src`.
+    fn gate(src: &str, dialect: &str) -> Option<PerItemFallback> {
+        let mut a = Analyser::new();
+        let _ = a.analyse_per_item(src, dialect);
+        a.per_item_fallback
+    }
+
+    /// Assert that `src` reaches the incremental fast path — i.e. no gate
+    /// fired.  Also asserts byte-identity with the whole-file walk, so a
+    /// widened gate can never buy speed with a wrong answer.
+    fn fast_path(src: &str) {
+        assert_eq!(gate(src, "tcl8.6"), None, "expected fast path for:\n{src}");
+        eq(src);
+    }
+
+    /// Assert that `src` hands off to a full walk with `reason`, and that the
+    /// handed-off result still matches the whole-file walk exactly.
+    fn falls_back(src: &str, dialect: &str, reason: PerItemFallback) {
+        assert_eq!(gate(src, dialect), Some(reason), "gate for:\n{src}");
+        let want = Analyser::new().analyse(src, dialect);
+        let got = Analyser::new().analyse_per_item(src, dialect);
+        assert_eq!(got, want, "per_item != analyse for:\n{src}");
+    }
+
+    // Tk activation gate (issue #1188).  The gate decides whether a document
+    // abandons per-body memoisation for a whole-file walk on *every keystroke*,
+    // so both directions matter: a false positive is a large, permanent
+    // latency cost, and a false negative would silently drop TK diagnostics.
+
+    #[test]
+    fn tk_gate_tp_package_require_tk_hands_off() {
+        // True positive: the plain form.
+        falls_back(
+            "package require Tk\nframe .top\n",
+            "tcl8.6",
+            PerItemFallback::TkActive,
+        );
+    }
+
+    #[test]
+    fn tk_gate_tp_exact_versioned_and_continued_forms() {
+        // Still true positives: the `-exact` flag, a version constraint, and a
+        // backslash line continuation splitting the words. None of these is
+        // special-cased here — they all fall out of the ordinary
+        // registry-driven `package require` walk, which is the point of
+        // resolving activation from command facts rather than from a byte
+        // pattern. (A byte pattern would have to enumerate them.)
+        for src in [
+            "package require -exact Tk 8.6\nframe .top\n",
+            "package require Tk 8.6\nframe .top\n",
+            "package \\\n  require \\\n  Tk\nframe .top\n",
+        ] {
+            falls_back(src, "tcl8.6", PerItemFallback::TkActive);
+        }
+    }
+
+    #[test]
+    fn tk_gate_documented_limit_qualified_package_head_does_not_activate() {
+        // `::package require Tk` is the same command as `package require Tk`
+        // in real Tcl, but the analyser's hook dispatch deliberately refuses a
+        // `::`-qualified spelling of a *bareword* global command
+        // (`resolve_analyser_hook_call`, pinned by issue #923), so no
+        // `package_requires` entry is recorded and Tk never activates.
+        //
+        // This is a pre-existing limit of the whole-file walk, not something
+        // the #1188 gate introduced: `analyse` emits no TK diagnostic for this
+        // source either, so per-item and full analysis still agree byte for
+        // byte — the only change is that the document no longer pays a full
+        // re-analysis to reach the same answer. Lifting the `::`-bareword
+        // guard would fix a real false negative here, but it widens hook
+        // dispatch for *every* stamped command, so it belongs to its own
+        // change with its own differential run.
+        fast_path("::package require Tk\nframe .top.x\n");
+    }
+
+    #[test]
+    fn tk_gate_tp_tk_dialect_short_circuits_at_entry() {
+        // The `tk` dialect is decidable before any work, so it must hand off
+        // without paying a per-item pass first.
+        falls_back("frame .top\n", "tk", PerItemFallback::TkActive);
+    }
+
+    #[test]
+    fn tk_gate_tp_require_inside_a_body_is_still_caught() {
+        // A `package require Tk` the *shell* pass cannot see: only the merged
+        // body fragments reveal it, which is why the gate is checked again
+        // after the body pass.
+        falls_back(
+            "proc setup {} { package require Tk }\nsetup\nframe .top\n",
+            "tcl8.6",
+            PerItemFallback::TkActive,
+        );
+        // …and one inside a `namespace eval`, which the shell pass *does* walk.
+        falls_back(
+            "namespace eval ::ui { package require Tk }\nframe .top\n",
+            "tcl8.6",
+            PerItemFallback::TkActive,
+        );
+    }
+
+    #[test]
+    fn tk_gate_fp_three_words_scattered_across_unrelated_commands() {
+        // The exact shape that made this gate ~78% false positives: the words
+        // `package`, `require`, and `Tk` all occur, none of them as a
+        // `package require Tk` invocation.
+        fast_path(
+            "package require Tcl 8.6\n\
+             set doc \"Tcl/Tk script text executable\"\n\
+             proc render {x} { return $x }\n",
+        );
+    }
+
+    #[test]
+    fn tk_gate_fp_comments_strings_and_regexes_mentioning_tk() {
+        fast_path("# package require Tk\nproc p {} { set x 1 }\n");
+        fast_path("set s \"package require Tk\"\nproc p {} { set x 1 }\n");
+        fast_path("regexp {package require Tk} $line\nproc p {} { set x 1 }\n");
+    }
+
+    #[test]
+    fn tk_gate_fp_package_provide_tk_and_require_tcl() {
+        // `package provide Tk` declares this file *is* (part of) Tk; it does
+        // not load Tk into this interpreter, so it must not activate. Nor may
+        // `package require Tcl`, whatever else the file mentions.
+        fast_path("package provide Tk 8.6\nproc p {} { set x 1 }\n");
+        fast_path("package require Tcl 8.6\n# Tk not required here\n");
+        // `package present Tk` is a query, not a load.
+        fast_path("if {[catch {package present Tk}]} { set headless 1 }\n");
+    }
+
+    #[test]
+    fn tk_gate_tn_dynamic_package_name_does_not_activate() {
+        // The documented conservative limit: a computed package name is
+        // recorded verbatim, so it cannot match `Tk` and the checks stay off —
+        // exactly as on the whole-file path, which `eq` pins.
+        fast_path("set p Tk\npackage require $p\nproc q {} { set x 1 }\n");
+        fast_path("package require [pkgName]\n# Tk\n");
+    }
+
+    #[test]
+    fn tk_gate_tn_renamed_package_command_does_not_activate() {
+        // `package` renamed away, then a call through the new name: not a
+        // resolvable `package require`, so no activation — and, again, the
+        // per-item result still matches the whole-file walk exactly.
+        fast_path("rename package pkg\npkg require Tk\nproc q {} { set x 1 }\n");
+    }
+
+    #[test]
+    fn tk_gate_fn_conditional_require_still_activates() {
+        // A conditional load is still a load as far as the checks are
+        // concerned (the whole-file walk records it too), so the gate must not
+        // miss it.
+        falls_back(
+            "if {$gui} { package require Tk }\nframe .top\n",
+            "tcl8.6",
+            PerItemFallback::TkActive,
+        );
+    }
+
+    // Oversized-body guard (issue #1188).  Tightening the Tk gate exposed a
+    // known scaling cliff: analysing a body in isolation costs far more than
+    // analysing the same content in place, so a generated single-body document
+    // must not be handed to the decomposition just because it is now Tk-clean.
+
+    #[test]
+    fn oversized_body_hands_off_to_the_whole_file_walk() {
+        let huge = "    set x 1\n".repeat(OVERSIZED_BODY_BYTES / 10 + 16);
+        let src = format!("proc generated {{}} {{\n{huge}}}\n");
+        assert!(
+            src.len() > OVERSIZED_BODY_BYTES,
+            "fixture must be oversized"
+        );
+        falls_back(&src, "tcl8.6", PerItemFallback::OversizedBody);
+    }
+
+    #[test]
+    fn ordinary_large_body_stays_on_the_fast_path() {
+        // Well under the threshold: a big hand-written proc keeps its
+        // memoisation. The guard exists for generated files, not large ones.
+        let body = "    set x 1\n".repeat(1000);
+        let src = format!("proc big {{}} {{\n{body}}}\nproc other {{}} {{ set y 2 }}\n");
+        assert!(src.len() < OVERSIZED_BODY_BYTES, "fixture must be ordinary");
+        fast_path(&src);
+    }
+
+    #[test]
+    fn many_small_bodies_totalling_over_the_threshold_stay_fast() {
+        // The guard is per body, not per document: a document made of many
+        // ordinary procs is exactly the case per-body memoisation pays off
+        // for, however large the file gets.
+        use std::fmt::Write as _;
+        let body = "    set x 1\n".repeat(80);
+        let mut src = String::new();
+        for i in 0..400 {
+            let _ = write!(src, "proc p{i} {{}} {{\n{body}}}\n");
+        }
+        assert!(src.len() > OVERSIZED_BODY_BYTES, "fixture must be large");
+        fast_path(&src);
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -239,11 +239,13 @@ pub struct Analyser {
     pub regex_vars: HashSet<(Vec<usize>, String)>,
     /// iRules: enclosing ``when EVENT`` name.
     pub current_event: Option<String>,
-    /// Tk checks: whether this document could be Tk (the `tk` dialect, or
-    /// the source mentions `package` / `require` / `Tk`).  Set per walk by
-    /// the `analyse*` entry points; gates the per-command accumulation so
-    /// non-Tk files pay nothing.  See [`super::tk_checks::tk_possibly_active`].
-    pub(super) tk_possibly_active: bool,
+    /// Tk checks: whether the per-command widget/geometry accumulation is
+    /// worth running for this document.  A pure performance precheck
+    /// ([`super::tk_checks::tk_checks_could_apply`]) — a sound
+    /// over-approximation, never the activation decision, which is the exact
+    /// `tk` dialect / `package require Tk` fact resolved at flush time.  Set
+    /// per walk by the `analyse*` entry points so non-Tk files pay nothing.
+    pub(super) tk_accumulation_enabled: bool,
     /// Whether the ingest dialect string was literally `"tk"` (a wish
     /// shell). `tk` is a library over a Tcl base, not a catalog profile
     /// (dialect-profile-model.md §7.2), so its shell identity is recorded
@@ -889,7 +891,7 @@ impl Analyser {
             nondominating_consts: HashMap::new(),
             regex_vars: HashSet::new(),
             current_event: None,
-            tk_possibly_active: false,
+            tk_accumulation_enabled: false,
             tk_dialect: false,
             tk_pending_diags: Vec::new(),
             tk_created_widgets: HashSet::new(),
@@ -1088,7 +1090,7 @@ impl Analyser {
         self.profile = tcl_dialect::DialectProfile::by_name(dialect);
         self.result.dialect = dialect.to_string();
         self.result.library_versions = self.library_versions.clone();
-        self.tk_possibly_active = super::tk_checks::tk_possibly_active(source, dialect);
+        self.tk_accumulation_enabled = super::tk_checks::tk_checks_could_apply(source, dialect);
         self.tk_dialect = dialect == "tk";
         // Clear the per-run iRules file-profile memo so a reused analyser
         // instance recomputes it for the new source / dialect.
@@ -1467,7 +1469,7 @@ impl Analyser {
         self.profile = tcl_dialect::DialectProfile::by_name(dialect);
         self.result.dialect = dialect.to_string();
         self.result.library_versions = self.library_versions.clone();
-        self.tk_possibly_active = super::tk_checks::tk_possibly_active(source, dialect);
+        self.tk_accumulation_enabled = super::tk_checks::tk_checks_could_apply(source, dialect);
         self.tk_dialect = dialect == "tk";
         self.unresolved_commands_emitted = false;
 
@@ -1551,7 +1553,7 @@ impl Analyser {
         self.profile = tcl_dialect::DialectProfile::by_name(dialect);
         self.result.dialect = dialect.to_string();
         self.result.library_versions = self.library_versions.clone();
-        self.tk_possibly_active = super::tk_checks::tk_possibly_active(source, dialect);
+        self.tk_accumulation_enabled = super::tk_checks::tk_checks_could_apply(source, dialect);
         self.tk_dialect = dialect == "tk";
         self.unresolved_commands_emitted = false;
 

--- a/rust/tcl-compiler/src/analyser/tk_checks.rs
+++ b/rust/tcl-compiler/src/analyser/tk_checks.rs
@@ -33,13 +33,31 @@
 //! decide a `pack`/`grid` conflict, so it accumulates per-parent usage and
 //! is decided in the same flush.
 //!
-//! The per-command accumulation is itself gated on a cheap
-//! [`tk_possibly_active`] precheck (`tk` dialect, or the source mentions
-//! `package` / `require` / `Tk`).  The incremental per-item analysis
-//! path ([`Analyser::analyse_per_item_with`]) falls back to full
-//! [`Analyser::analyse`] when [`tk_possibly_active`] holds, so Tk's
+//! Two distinct questions are involved, and conflating them was issue #1188:
+//!
+//! - **Is Tk active?** — the authoritative, *exact* fact: the `tk` dialect, or
+//!   a `package require Tk` that the registry's
+//!   [`PackageRequire`](tcl_registry::hooks::AnalyserHookId::PackageRequire)
+//!   hook recorded into `result.package_requires` during the walk.  This is
+//!   [`Analyser::has_tk_require`] + `tk_dialect`, and it is the *only* gate on
+//!   whether any TK diagnostic is emitted.
+//! - **Is it worth accumulating?** — a pure performance precheck
+//!   ([`tk_checks_could_apply`]), run before the walk to skip the per-command
+//!   widget/geometry bookkeeping on a document that cannot possibly be Tk.
+//!   It is a deliberately loose *necessary* condition (over-approximating is
+//!   free: whatever it buffers is discarded by the flush unless the exact
+//!   activation fact holds), so it can never change a diagnostic.
+//!
+//! The incremental per-item analysis path
+//! ([`Analyser::analyse_per_item_with`]) falls back to full
+//! [`Analyser::analyse`] once Tk is **exactly** known to be active, so Tk's
 //! whole-file accumulator (which an isolated proc body cannot see) never
-//! diverges from full analysis.
+//! diverges from full analysis.  Before #1188 that fallback was driven by the
+//! precheck instead — three independent substring searches for `package`,
+//! `require`, and `Tk`, matching anywhere in the file including comments,
+//! strings, and generated data — which forced a whole-file re-analysis on
+//! every keystroke for 27.7% of the tcllib corpus's source lines, ~78% of them
+//! false positives.
 //!
 //! Diagnostic codes:
 //!
@@ -69,16 +87,28 @@ pub(super) struct TkGeometryUsage {
 /// Tk geometry-manager commands.
 const GEOMETRY_COMMANDS: &[&str] = &["pack", "grid", "place"];
 
-/// Cheap precheck for whether Tk diagnostics could apply to this document:
-/// the analysis dialect is `tk`, or the source mentions `package` /
-/// `require` / `Tk` (so a `package require Tk` — however the lexer splits
-/// its words — is not missed).  Used both to gate the per-command
-/// accumulation and to force the incremental per-item path back to full
-/// analysis for Tk documents.
+/// The package name whose presence activates the TK checks.  The single
+/// source of truth for both halves of the gate: the `package require` name
+/// [`Analyser::has_tk_require`] looks for, and the `CommandSpec`
+/// [`required_package`](tcl_registry::CommandSpec::required_package) that
+/// makes a registry command a Tk widget command
+/// ([`Analyser::is_widget_command`]).
+pub(super) const TK_PACKAGE: &str = "Tk";
+
+/// Cheap **necessary** condition for the per-command Tk accumulation to be
+/// worth running at all — *not* the activation decision (see the module docs).
+///
+/// Activation requires either the `tk` dialect or a statically-resolvable
+/// `package require Tk`, and the latter cannot exist in a source that never
+/// contains the literal package name.  So this is sound: it never returns
+/// `false` for a document that goes on to activate.  It over-approximates
+/// freely — a `Tk` inside a comment, a string, or generated data trips it —
+/// which costs only a registry lookup per command, because
+/// [`Analyser::flush_tk_geometry_diagnostics`] discards everything the walk
+/// buffered unless the exact activation fact holds.
 #[must_use]
-pub(super) fn tk_possibly_active(source: &str, dialect: &str) -> bool {
-    dialect == "tk"
-        || (source.contains("package") && source.contains("require") && source.contains("Tk"))
+pub(super) fn tk_checks_could_apply(source: &str, dialect: &str) -> bool {
+    dialect == "tk" || source.contains(TK_PACKAGE)
 }
 
 /// Return `true` if `name` is a Tk geometry-manager command.
@@ -133,7 +163,7 @@ impl Analyser {
     fn is_widget_command(&self, name: &str) -> bool {
         self.registry.is_some_and(|r| {
             r.get(name).is_some_and(|s| {
-                s.creates_instance_at.is_some() && s.required_package == Some("Tk")
+                s.creates_instance_at.is_some() && s.required_package == Some(TK_PACKAGE)
             })
         })
     }
@@ -151,7 +181,7 @@ impl Analyser {
         arg_tokens: &[Token],
         cmd_tok: Token,
     ) {
-        if !self.tk_possibly_active {
+        if !self.tk_accumulation_enabled {
             return;
         }
 
@@ -271,12 +301,39 @@ impl Analyser {
         }
     }
 
-    /// Whether the file declared `package require Tk`.
-    fn has_tk_require(&self) -> bool {
+    /// Whether the walk recorded a statically-resolvable `package require Tk`.
+    ///
+    /// The exact activation fact, and the *only* input (besides the `tk`
+    /// dialect) that decides whether a TK diagnostic is emitted.  It reads
+    /// `result.package_requires`, which is populated generically by
+    /// [`Analyser::handle_package_require`](super::state::Analyser) under the
+    /// registry's [`PackageRequire`](tcl_registry::hooks::AnalyserHookId::PackageRequire)
+    /// hook — so a `-exact` flag, a trailing version constraint, line
+    /// continuations, a `package require` nested in a `namespace eval` / `if` /
+    /// proc body, and comments, strings, and regexes that merely *mention* the
+    /// words are all handled by the ordinary command walk rather than by a
+    /// bespoke scanner here.
+    ///
+    /// Two documented limits, both inherited from the walk rather than added
+    /// here, so per-item and full analysis still agree exactly:
+    ///
+    /// - a **dynamic** name (`package require [set p]`) is recorded verbatim
+    ///   and cannot match; likewise a `package` reached after a `rename` or
+    ///   hidden in a safe interpreter is not a resolvable `package require`;
+    /// - `::package require Tk` does not match either, because
+    ///   `resolve_analyser_hook_call` deliberately refuses a `::`-qualified
+    ///   spelling of a bareword global command (pinned by issue #923), so no
+    ///   `package_requires` entry is recorded for it at all — a pre-existing
+    ///   false negative of the whole-file walk, not one this gate introduced.
+    ///
+    /// `pub(super)`: [`Analyser::analyse_per_item_with`](super::state::Analyser)
+    /// consults the same fact post-walk to decide whether the incremental path
+    /// must hand off to a full analysis (issue #1188).
+    pub(super) fn has_tk_require(&self) -> bool {
         self.result
             .package_requires
             .iter()
-            .any(|pr| pr.name == "Tk")
+            .any(|pr| pr.name == TK_PACKAGE)
     }
 
     /// Post-walk flush of all TK diagnostics.  Emits the buffered TK1002 /

--- a/rust/tcl-lexer/src/line_index.rs
+++ b/rust/tcl-lexer/src/line_index.rs
@@ -89,12 +89,25 @@ pub fn normalise_lone_cr(source: &str) -> Cow<'_, str> {
 /// `line_starts[i]` for `i > 0` is the byte immediately after the `i`-th
 /// `\n`. Offsets past the last newline resolve to the final line.
 ///
-/// Cheap to clone: the backing storage is a `Box<[u32]>`, so cloning
-/// is one allocation plus a byte copy. Future chunks may switch to
-/// `Arc<[u32]>` if genuine sharing turns up in profiles.
+/// **Free to clone**: the backing storage is an `Arc<[u32]>`, so a clone is a
+/// reference-count bump — no allocation, no byte copy — and every clone shares
+/// one allocation.
+///
+/// It was a `Box<[u32]>` (one allocation plus a byte copy per clone) until the
+/// sharing this anticipated turned up in profiles: `tcl-lsp-server`'s
+/// `read_document` hands every in-flight LSP request its own snapshot of the
+/// open document, so `R` concurrent requests against an `L`-line document each
+/// copied `4L` bytes of line index (issue #1184). `filetypes.tcl` alone is
+/// 85,040 lines — 332 KiB of index — per request.
+///
+/// Nothing here is shared *mutably*: every mutation ([`Self::apply_edit`])
+/// builds a fresh `Vec` and replaces the handle wholesale, so an outstanding
+/// clone keeps the pre-edit index it was given rather than observing a
+/// half-applied edit. That is what makes an in-flight request safe to finish
+/// against the revision it started on.
 #[derive(Debug, Clone)]
 pub struct LineIndex {
-    line_starts: Box<[u32]>,
+    line_starts: std::sync::Arc<[u32]>,
 }
 
 impl LineIndex {
@@ -134,7 +147,7 @@ impl LineIndex {
             }
         }
         Self {
-            line_starts: starts.into_boxed_slice(),
+            line_starts: starts.into(),
         }
     }
 
@@ -186,7 +199,7 @@ impl LineIndex {
             i += 1;
         }
         Self {
-            line_starts: starts.into_boxed_slice(),
+            line_starts: starts.into(),
         }
     }
 
@@ -237,7 +250,7 @@ impl LineIndex {
             next.push(u32::try_from(shifted).expect("shifted offset fits u32"));
             i += 1;
         }
-        self.line_starts = next.into_boxed_slice();
+        self.line_starts = next.into();
     }
 
     /// Whether `source` contains a *lone* `\r` — a `\r` not immediately
@@ -261,6 +274,20 @@ impl LineIndex {
             .iter()
             .enumerate()
             .any(|(i, &b)| b == b'\r' && bytes.get(i + 1) != Some(&b'\n'))
+    }
+
+    /// Whether `self` and `other` are clones sharing **one** backing
+    /// allocation, rather than two indices that merely hold equal offsets.
+    ///
+    /// This is the sharing contract itself, not a debugging aid: consumers that
+    /// hand one index to many concurrent readers ([`LineIndex`]'s own doc
+    /// comment, and `tcl-lsp-server`'s document snapshots — issue #1184) depend
+    /// on a clone costing a reference-count bump, and a silent regression to a
+    /// copy-per-clone is invisible to any equality-based assertion. Comparing
+    /// identity is the only way to pin it.
+    #[must_use]
+    pub fn shares_storage_with(&self, other: &Self) -> bool {
+        std::sync::Arc::ptr_eq(&self.line_starts, &other.line_starts)
     }
 
     /// Number of lines in the index. Always ≥ 1 for any `LineIndex`
@@ -939,5 +966,49 @@ mod tests {
             idx.position_at_utf16(7, src),
             Utf16Position::new(1, Utf16Col::new(0), 7)
         );
+    }
+    #[test]
+    fn clone_shares_one_backing_allocation() {
+        // The sharing contract (issue #1184): a clone is a reference-count
+        // bump, not a copy, so many concurrent readers of one document's index
+        // hold one allocation between them rather than one each.
+        let idx = LineIndex::new_lsp("a\nb\nc\n");
+        let snapshots: Vec<LineIndex> = (0..32).map(|_| idx.clone()).collect();
+        for snap in &snapshots {
+            assert!(
+                idx.shares_storage_with(snap),
+                "clone must share the original's storage"
+            );
+        }
+        // Two indices built independently are equal line-for-line but must NOT
+        // report sharing — otherwise the assertion above would be vacuous.
+        let independent = LineIndex::new_lsp("a\nb\nc\n");
+        assert_eq!(independent.line_count(), idx.line_count());
+        assert!(!idx.shares_storage_with(&independent));
+    }
+
+    #[test]
+    fn apply_edit_leaves_outstanding_clones_on_the_old_revision() {
+        // Build-and-swap, not mutate-in-place: an index handed to an in-flight
+        // reader before an edit must keep describing the text that reader was
+        // given, so it can never resolve a position against the wrong offsets.
+        let mut idx = LineIndex::new_lsp("one\ntwo\nthree\n");
+        let snapshot = idx.clone();
+        let before: Vec<u32> = (0..snapshot.line_count())
+            .map(|l| snapshot.line_start(u32::try_from(l).expect("small")))
+            .collect();
+
+        // Insert two lines at the very start of the document.
+        idx.apply_edit(0, 0, "zero\nhalf\n");
+
+        assert!(
+            !idx.shares_storage_with(&snapshot),
+            "an edit must install new storage, never write through the shared one"
+        );
+        let after: Vec<u32> = (0..snapshot.line_count())
+            .map(|l| snapshot.line_start(u32::try_from(l).expect("small")))
+            .collect();
+        assert_eq!(after, before, "the snapshot observed a mutation");
+        assert_eq!(idx.line_count(), snapshot.line_count() + 2);
     }
 }

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -20687,9 +20687,7 @@ mod tests {
         let uri = Uri::from_str("file:///oldmac.tcl").unwrap();
         let src = "# note \rset zz 1\nputs $zz\n";
         register(&backend, &uri, src).await;
-        backend
-            .db_set_source(&uri, src, "tcl8.6".to_owned())
-            .await;
+        backend.db_set_source(&uri, src, "tcl8.6".to_owned()).await;
         backend
             .publish_analyser_diagnostics(
                 uri.clone(),

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -134,27 +134,63 @@ use tower_lsp_server::ls_types::{
 use tower_lsp_server::{Client, LanguageServer};
 
 /// Document store value: source text + dialect string.
+///
+/// # Snapshot ownership and revision currency (issue #1184)
+///
+/// This type is both the **mutable owner** of an open document (under
+/// `Backend::documents`' mutex) and the **immutable snapshot** every request
+/// handler works from ([`Backend::read_document`] clones one out and drops the
+/// lock). Those two roles are what make the sharing rules below load-bearing:
+///
+/// * The large fields — `text` and the `line_index` built from it — are shared
+///   handles, so a clone is two reference-count bumps rather than a copy of the
+///   document and its index. With `R` concurrent requests against a `B`-byte,
+///   `L`-line document that is `O(B + 4L + R)` live bytes instead of
+///   `O(R × (B + 4L))`.
+/// * Every mutation is **build-and-swap**, never in place. A snapshot therefore
+///   observes the revision it was taken at, for its whole lifetime, and an
+///   in-flight request can safely finish against an older revision while the
+///   editor keeps typing.
+/// * `text` and `line_index` are **one snapshot**, not two fields: they must be
+///   installed together, so no reader can ever pair text from revision `N` with
+///   an index from revision `N-1` and resolve a position against the wrong
+///   offsets. [`apply_content_change_indexed`] is the single place that
+///   replaces them, and it replaces both.
+///
+/// Cloning is otherwise unchanged: `dialect` and `language_id` are short
+/// strings, and the rest is `Copy`.
 #[derive(Debug, Clone)]
 struct DocumentState {
-    /// The document's text **as analysis sees it**.
+    /// The document's text **as analysis sees it**, behind an [`Arc`] so a
+    /// snapshot handed to a request handler ([`Backend::read_document`]) is a
+    /// reference-count bump rather than a copy of the whole buffer (issue
+    /// #1184).
     ///
     /// Inside [`Backend::documents`] this is byte-for-byte what the client
     /// sent (the shadow buffer every incremental `didChange` splices into).
-    /// [`Backend::read_document`] hands out a copy whose lone `\r`s have been
-    /// rewritten to `\n` ([`tcl_lexer::normalise_lone_cr`]) and stashes the
-    /// client's bytes in `raw_text`, so every provider that re-lexes this
+    /// [`Backend::read_document`] hands out a snapshot whose lone `\r`s have
+    /// been rewritten to `\n` ([`tcl_lexer::normalise_lone_cr`]) and stashes
+    /// the client's bytes in `raw_text`, so every provider that re-lexes this
     /// field sees the same script `tclsh` would (a channel opened with
     /// `-translation auto` turns each `\r` into a command terminator before
     /// the parser runs) and lands on the same lines as the client. The
     /// rewrite is byte-length preserving, so spans and offsets are
     /// interchangeable between the two.
-    text: String,
+    ///
+    /// Mutated by build-and-swap, never in place: [`apply_content_change_indexed`]
+    /// splices into an owned `String` and installs a **new** `Arc`, so a
+    /// snapshot taken before the edit keeps the exact bytes it was given.
+    /// That, and not a lock, is what lets an in-flight request finish against
+    /// the revision it started on while the editor keeps typing — and it is
+    /// why `text` and `line_index` must only ever be replaced together (see
+    /// the type-level invariant on [`DocumentState`]).
+    text: Arc<str>,
     /// The client's exact bytes, when they differ from `text` — i.e. only for
     /// an old-Mac / mixed document handed out by [`Backend::read_document`].
     /// Read it via [`DocumentState::raw`] for anything that must see the real
     /// terminators: the W118 line-ending lint and the formatter (whose output
     /// EOL and whose replace range are both computed from the real document).
-    raw_text: Option<String>,
+    raw_text: Option<Arc<str>>,
     /// Persisted line-start index for `text`, built with the **LSP** EOL model
     /// ([`tcl_lexer::LineIndex::new_lsp`]) so the server's `(line, character)`
     /// coordinates match the client's (`\n`, `\r\n`, and lone `\r` all break a
@@ -200,7 +236,7 @@ impl DocumentState {
         let line_index = tcl_lexer::LineIndex::new_lsp(&text);
         let has_bare_cr = tcl_lexer::LineIndex::contains_bare_cr(&text);
         Self {
-            text,
+            text: text.into(),
             raw_text: None,
             line_index,
             has_bare_cr,
@@ -216,7 +252,7 @@ impl DocumentState {
         let line_index = tcl_lexer::LineIndex::new_lsp(&text);
         let has_bare_cr = tcl_lexer::LineIndex::contains_bare_cr(&text);
         Self {
-            text,
+            text: text.into(),
             raw_text: None,
             line_index,
             has_bare_cr,
@@ -249,7 +285,7 @@ impl DocumentState {
         if !self.has_bare_cr {
             return self;
         }
-        let normalised = tcl_lexer::normalise_lone_cr(&self.text).into_owned();
+        let normalised: Arc<str> = tcl_lexer::normalise_lone_cr(&self.text).into_owned().into();
         self.raw_text = Some(std::mem::replace(&mut self.text, normalised));
         self
     }
@@ -405,7 +441,10 @@ enum DiagCurrency {
 /// is somehow absent, in which case the run falls back to a direct `analyse`.
 #[derive(Clone)]
 struct DiagJob {
-    text: String,
+    /// The document snapshot's shared text handle — a reference-count bump, not
+    /// a copy of the buffer, so scheduling a diagnostics run for a large file
+    /// costs nothing in memory (issue #1184).
+    text: Arc<str>,
     dialect: String,
     /// The document's editor `language_id`, carried so the diagnostics worker
     /// can dispatch F5 dialect documents (iApp APL presentations are detected
@@ -3637,7 +3676,9 @@ fn class_set_fingerprint(classes: &std::collections::HashSet<String>) -> u64 {
 /// lift its spans to LSP ranges.
 struct ConsumerDoc {
     uri: Uri,
-    text: String,
+    /// Shares the document snapshot's text handle rather than copying the
+    /// buffer per candidate document (issue #1184).
+    text: Arc<str>,
     dialect: String,
     line_index: tcl_lexer::LineIndex,
 }
@@ -3722,14 +3763,20 @@ impl Backend {
     /// Create or update the salsa `SourceFile` input for `uri`.  Called by
     /// `did_open` / `did_change` so the query graph always reads current text.
     /// Lock order is always `db` → `db_files` → `db_tombstones` → `db_project`.
-    async fn db_set_source(&self, uri: &Uri, text: String, dialect: String) {
+    ///
+    /// Borrows the text rather than taking it by value: callers on the edit
+    /// path hold the document snapshot's shared `Arc<str>` and must not have to
+    /// own a separate copy of it.  The salsa `SourceFile::text` input is a
+    /// `String`, so exactly one copy is made here — the same single copy the
+    /// caller used to make before handing it over (issue #1184).
+    async fn db_set_source(&self, uri: &Uri, text: &str, dialect: String) {
         use salsa::Setter as _;
         // Salsa's `SourceFile.text` is the analyser's input, so it stores the
         // analysis form of the document (lone `\r` → `\n`) regardless of which
         // path — `didOpen`/`didChange`, a folder scan, a watched-file change —
         // produced it.  Doing it here rather than at each caller is what keeps
         // the interactive and background-indexing paths from disagreeing.
-        let text = tcl_lexer::normalise_lone_cr(&text).into_owned();
+        let text = tcl_lexer::normalise_lone_cr(text).into_owned();
         let mut db = self.db.lock().await;
         let mut files = self.db_files.lock().await;
         if let Some(&file) = files.get(uri) {
@@ -3931,7 +3978,7 @@ impl Backend {
         // Snapshot `(uri, language_id, current dialect)` first — the async
         // `dialect_for_open` calls lock `folder_dialects` / `default_dialect`,
         // so they must not run while the `documents` lock is held.
-        let snapshot: Vec<(Uri, String, String, String)> = {
+        let snapshot: Vec<(Uri, String, String, Arc<str>)> = {
             let docs = self.documents.lock().await;
             docs.iter()
                 .map(|(uri, doc)| {
@@ -3960,7 +4007,7 @@ impl Backend {
                 };
                 doc.dialect.clone_from(&new_dialect);
                 let text = doc.text.clone();
-                self.db_set_source(&uri, text, new_dialect.clone()).await;
+                self.db_set_source(&uri, &text, new_dialect.clone()).await;
                 self.workspace_index
                     .write()
                     .await
@@ -4184,10 +4231,17 @@ impl Backend {
     /// cache first; computes a fresh analysis when no entry
     /// exists.  Returns a shared `Arc` the caller can move into
     /// a `spawn_blocking` worker (providers deref it via `&`).
+    ///
+    /// `text` is the document snapshot's shared handle, not a copy: the
+    /// overwhelmingly common path is a cache hit, which never reads it at all,
+    /// and the cache-miss path moves the handle into the blocking worker and
+    /// analyses through a deref.  Taking `Arc<str>` is what keeps the ~30
+    /// `analysis_for` call sites from each copying the whole document per
+    /// request (issue #1184).
     async fn analysis_for(
         &self,
         uri: &Uri,
-        text: String,
+        text: Arc<str>,
         dialect: String,
     ) -> Arc<tcl_compiler::analyser::AnalysisResult> {
         if let Some(cached) = self.cached_analysis(uri).await {
@@ -5181,7 +5235,7 @@ impl Backend {
         // workspace_index lock) to preserve the global lock order.
         match &scanned {
             Some((_, text, dialect, _)) => {
-                self.db_set_source(uri, text.clone(), dialect.clone()).await;
+                self.db_set_source(uri, text, dialect.clone()).await;
             }
             // No readable on-disk copy (untitled / deleted) — drop it from the
             // project so a stale definition can't keep resolving cross-file.
@@ -5243,7 +5297,9 @@ impl Backend {
         let inputs = self.diag_inputs(uri, &dialect).await;
         let config = inputs.closed_file_config(uri).await;
         let job = DiagJob {
-            text,
+            // A closed file's text comes from the salsa input, not from an open
+            // snapshot, so this is where its shared handle is minted.
+            text: Arc::from(text),
             dialect,
             // A closed file carries no editor `language_id`; F5 model dialects are
             // routed by the resolved `dialect` + basename resolved above.
@@ -7071,7 +7127,7 @@ impl Backend {
             let doc = if u == current_uri.as_str() {
                 ConsumerDoc {
                     uri: current_uri.clone(),
-                    text: current_source.to_owned(),
+                    text: Arc::from(current_source),
                     dialect: current_dialect.to_owned(),
                     // The LSP EOL model, matching the `line_index` the sibling
                     // branch takes straight off the stored `DocumentState`.
@@ -8175,7 +8231,7 @@ impl Backend {
         // incoming-call results even though they are indexed for
         // every other cross-document feature.
         let mut open_uris: HashSet<Uri> = HashSet::new();
-        let mut docs: Vec<(Uri, String, String)> = {
+        let mut docs: Vec<(Uri, Arc<str>, String)> = {
             let store = self.documents.lock().await;
             store
                 .iter()
@@ -8615,7 +8671,10 @@ impl Backend {
         let (disabled, na_mode) = self.analyser_config().await;
         let extra: HashSet<String> = self.extra_commands.lock().await.iter().cloned().collect();
         let dialect = doc.dialect.clone();
-        // The fixed-up buffer is handed back to the client verbatim, so it
+        // The one place that legitimately owns a copy: fix-all *rewrites* the
+        // source in a loop, so it needs a mutable buffer of its own rather than
+        // a share of the immutable snapshot.  It copies from `raw()` because
+        // the fixed-up buffer is handed back to the client verbatim, so it
         // carries the document's real terminators; the analyser that locates
         // the fixes still sees the normalised form.  The rewrite is
         // byte-length preserving, so a fix span resolved against one applies
@@ -9907,7 +9966,7 @@ impl Backend {
     async fn full_diagnostics_for(
         &self,
         uri: &Uri,
-        text: String,
+        text: Arc<str>,
         dialect: String,
         language_id: &str,
     ) -> Vec<tower_lsp_server::ls_types::Diagnostic> {
@@ -9923,7 +9982,12 @@ impl Backend {
         // them on the push path: the parser sees the script `tclsh` would, the
         // W118 line-ending lint sees the real terminators, and the two agree
         // on every offset because the rewrite preserves byte length.
-        let analysis_text = tcl_lexer::normalise_lone_cr(&text).into_owned();
+        // In the overwhelmingly common no-bare-CR case the analysis form *is*
+        // the client buffer, so reuse its `Arc` rather than copying (#1184).
+        let analysis_text: Arc<str> = match tcl_lexer::normalise_lone_cr(&text) {
+            std::borrow::Cow::Borrowed(_) => text.clone(),
+            std::borrow::Cow::Owned(s) => s.into(),
+        };
         // F5 dialect dispatch: BIG-IP config / iApp APL
         // presentation documents have model-level validators, not the Tcl
         // analyser — mirror the push path's dispatch so a pull-mode editor
@@ -11211,7 +11275,7 @@ impl LanguageServer for Backend {
                 DocumentState::with_version(params.text_document.text, dialect, version)
                     .with_language_id(params.text_document.language_id.clone()),
             );
-            self.db_set_source(&uri, text.clone(), dialect_for_diags.clone())
+            self.db_set_source(&uri, &text, dialect_for_diags.clone())
                 .await;
             self.workspace_index
                 .write()
@@ -11264,7 +11328,11 @@ impl LanguageServer for Backend {
             let Some(entry) = docs.get_mut(&uri) else {
                 return;
             };
-            let mut text = std::mem::take(&mut entry.text);
+            // Build-and-swap, not mutate-in-place: each splice produces a fresh
+            // buffer and the shared handle is replaced wholesale at the end, so
+            // any snapshot already handed to an in-flight request keeps the
+            // exact revision it was taken at (issue #1184).
+            let mut text: Arc<str> = Arc::clone(&entry.text);
             // Patch the persisted `LineIndex` alongside each splice instead of
             // rebuilding it per edit / per position lookup.
             // Take it out, patch through the edit sequence, put it back.
@@ -11288,9 +11356,13 @@ impl LanguageServer for Backend {
                     &change.text,
                     &mut index,
                     &mut has_bare_cr,
-                );
+                )
+                .into();
             }
-            entry.text = text.clone();
+            // `text` and `line_index` are installed together — the snapshot
+            // invariant on `DocumentState`: no reader may ever pair text from
+            // this revision with an index from the previous one.
+            entry.text = Arc::clone(&text);
             entry.line_index = index;
             entry.has_bare_cr = has_bare_cr;
             entry.bump_revision(change_version);
@@ -11314,7 +11386,7 @@ impl LanguageServer for Backend {
             // the workspace already carries between publishes, and strictly less
             // misleading than the alternative (a mid-keystroke window where the
             // file contributes no procs, classes or call sites at all).
-            self.db_set_source(&uri, text, dialect.clone()).await;
+            self.db_set_source(&uri, &text, dialect.clone()).await;
             drop(docs);
             (dialect, language_id, dialect_hint_may_have_changed)
         };
@@ -11367,7 +11439,7 @@ impl LanguageServer for Backend {
                     // As above (#1149): the reschedule below republishes, and
                     // the publish re-indexes the document under its own
                     // currency check.
-                    self.db_set_source(&uri, text, new_dialect.clone()).await;
+                    self.db_set_source(&uri, &text, new_dialect.clone()).await;
                 }
                 self.reschedule_diagnostics(uri, new_dialect).await;
             }
@@ -12711,7 +12783,7 @@ impl LanguageServer for Backend {
                 // The raw buffer: `full_diagnostics_for` derives the analysis
                 // form itself, and W118 must see the real terminators.
                 &uri,
-                doc.raw().to_owned(),
+                doc.raw_text.clone().unwrap_or_else(|| doc.text.clone()),
                 doc.dialect.clone(),
                 &doc.language_id,
             )
@@ -12951,7 +13023,7 @@ impl LanguageServer for Backend {
         // as a JSON-RPC error.  The text goes in behind an `Arc` so the
         // convergence continuation below shares this buffer instead of taking a
         // second full-document copy (#1147).
-        let text: Arc<str> = Arc::from(doc.text.as_str());
+        let text: Arc<str> = Arc::clone(&doc.text);
         let dialect = doc.dialect.clone();
         let serve_text = Arc::clone(&text);
         let serve_dialect = dialect.clone();
@@ -17658,7 +17730,7 @@ mod tests {
         register(&backend, &uri, src).await;
 
         let off = backend
-            .full_diagnostics_for(&uri, src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&uri, Arc::from(src), "tcl8.6".to_owned(), "tcl")
             .await;
         assert!(
             !off.iter().any(|d| matches!(
@@ -17672,7 +17744,7 @@ mod tests {
             .apply_global_config(&serde_json::json!({ "diagnostics": { "W242": true } }))
             .await;
         let on = backend
-            .full_diagnostics_for(&uri, src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&uri, Arc::from(src), "tcl8.6".to_owned(), "tcl")
             .await;
         assert!(
             on.iter().any(|d| matches!(
@@ -19247,7 +19319,7 @@ mod tests {
         let src =
             "ltm rule /Common/r {\n  when HTTP_REQUEST {\n    pool /Common/no_such_pool\n  }\n}\n";
         let diags = backend
-            .full_diagnostics_for(&uri, src.to_owned(), "f5-bigip".to_owned(), "tcl-bigip")
+            .full_diagnostics_for(&uri, Arc::from(src), "f5-bigip".to_owned(), "tcl-bigip")
             .await;
         let codes = diag_codes(&diags);
         assert!(
@@ -19290,7 +19362,7 @@ mod tests {
         // Default-off: no XC codes surface.
         let backend = test_backend();
         let off = backend
-            .full_diagnostics_for(&uri, src.to_owned(), "f5-irules".to_owned(), "tcl-irule")
+            .full_diagnostics_for(&uri, Arc::from(src), "f5-irules".to_owned(), "tcl-irule")
             .await;
         assert!(
             !diag_codes(&off).iter().any(|c| c.starts_with("XC")),
@@ -19305,7 +19377,7 @@ mod tests {
                 .unwrap(),
         );
         let on = backend
-            .full_diagnostics_for(&uri, src.to_owned(), "f5-irules".to_owned(), "tcl-irule")
+            .full_diagnostics_for(&uri, Arc::from(src), "f5-irules".to_owned(), "tcl-irule")
             .await;
         assert!(
             diag_codes(&on).iter().any(|c| c == "XC100"),
@@ -19328,11 +19400,7 @@ mod tests {
         let b = Uri::from_str("file:///b.tcl").unwrap();
         // Track B (defines `proc helper`) so the `Project` input includes it.
         backend
-            .db_set_source(
-                &b,
-                "proc helper {x y} { return $x }\n".to_owned(),
-                "tcl8.6".to_owned(),
-            )
+            .db_set_source(&b, "proc helper {x y} { return $x }\n", "tcl8.6".to_owned())
             .await;
         // The `Project` input is now maintained with B.
         assert!(
@@ -19343,7 +19411,7 @@ mod tests {
 
         // crossFileResolution OFF: `helper` is unresolved in A → W123 present.
         let off = backend
-            .full_diagnostics_for(&a, a_src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&a, Arc::from(a_src), "tcl8.6".to_owned(), "tcl")
             .await;
         assert!(
             diag_codes(&off).iter().any(|c| c == "W123"),
@@ -19358,7 +19426,7 @@ mod tests {
                 .unwrap(),
         );
         let on = backend
-            .full_diagnostics_for(&a, a_src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&a, Arc::from(a_src), "tcl8.6".to_owned(), "tcl")
             .await;
         assert!(
             !diag_codes(&on).iter().any(|c| c == "W123"),
@@ -19393,7 +19461,7 @@ mod tests {
 
         // Toggle OFF: the single-document pass sees neither name.
         let off = backend
-            .full_diagnostics_for(&vector, vector_src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&vector, Arc::from(vector_src), "tcl8.6".to_owned(), "tcl")
             .await;
         let off_names: Vec<&str> = off
             .iter()
@@ -19413,7 +19481,7 @@ mod tests {
                 .unwrap(),
         );
         let on = backend
-            .full_diagnostics_for(&vector, vector_src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&vector, Arc::from(vector_src), "tcl8.6".to_owned(), "tcl")
             .await;
         let on_names: Vec<&str> = on
             .iter()
@@ -19451,7 +19519,7 @@ mod tests {
         let baseline = backend
             .full_diagnostics_for(
                 &outside,
-                src.to_owned(),
+                Arc::from(src),
                 "f5-irules".to_owned(),
                 "tcl-irule",
             )
@@ -19475,7 +19543,7 @@ mod tests {
 
         // POSITIVE: a doc *inside* the folder no longer reports IRULE4002.
         let suppressed = backend
-            .full_diagnostics_for(&inside, src.to_owned(), "f5-irules".to_owned(), "tcl-irule")
+            .full_diagnostics_for(&inside, Arc::from(src), "f5-irules".to_owned(), "tcl-irule")
             .await;
         assert!(
             !diag_codes(&suppressed).iter().any(|c| c == "IRULE4002"),
@@ -19489,7 +19557,7 @@ mod tests {
         let still_fires = backend
             .full_diagnostics_for(
                 &outside,
-                src.to_owned(),
+                Arc::from(src),
                 "f5-irules".to_owned(),
                 "tcl-irule",
             )
@@ -19536,7 +19604,7 @@ mod tests {
             *backend.package_resolver.write().await = resolver;
         }
         let unrefined = backend
-            .full_diagnostics_for(&uri, src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&uri, Arc::from(src), "tcl8.6".to_owned(), "tcl")
             .await;
         assert!(
             diag_codes(&unrefined).iter().any(|c| c == "W120"),
@@ -19571,7 +19639,7 @@ mod tests {
             *backend.package_resolver.write().await = resolver;
         }
         let refined = backend
-            .full_diagnostics_for(&uri, src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&uri, Arc::from(src), "tcl8.6".to_owned(), "tcl")
             .await;
         assert!(
             !diag_codes(&refined).iter().any(|c| c == "W120"),
@@ -19620,7 +19688,7 @@ mod tests {
         // default (off).
         let ok_src = "Rbc_ActiveLegend .g\nRbc_ZoomStack .g\n";
         let diags = backend
-            .full_diagnostics_for(&uri, ok_src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&uri, Arc::from(ok_src), "tcl8.6".to_owned(), "tcl")
             .await;
         assert!(
             !diag_codes(&diags).iter().any(|c| c == "W123"),
@@ -19631,7 +19699,7 @@ mod tests {
         // TP control: a typo the index does not declare stays flagged.
         let typo_src = "Rbc_ActveLegend .g\n";
         let typo = backend
-            .full_diagnostics_for(&uri, typo_src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&uri, Arc::from(typo_src), "tcl8.6".to_owned(), "tcl")
             .await;
         assert!(
             diag_codes(&typo).iter().any(|c| c == "W123"),
@@ -19643,7 +19711,7 @@ mod tests {
         // fires — suppression is driven by the database, not a name allowlist.
         *backend.package_resolver.write().await = PackageResolver::new();
         let empty = backend
-            .full_diagnostics_for(&uri, ok_src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&uri, Arc::from(ok_src), "tcl8.6".to_owned(), "tcl")
             .await;
         assert!(
             diag_codes(&empty).iter().any(|c| c == "W123"),
@@ -19683,7 +19751,7 @@ mod tests {
         // Control (FN would be a bug here): without an entry file requiring mylib,
         // the module inherits nothing, so `draw_widget` is genuinely unknown ⇒ W123.
         let unrefined = backend
-            .full_diagnostics_for(&util, util_src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&util, Arc::from(util_src), "tcl8.6".to_owned(), "tcl")
             .await;
         assert!(
             diag_codes(&unrefined).iter().any(|c| c == "W123"),
@@ -19709,7 +19777,7 @@ mod tests {
         // TN: the inherited `mylib` require makes `draw_widget` resolvable via the
         // package's implementation source ⇒ the W123 is refined away.
         let refined = backend
-            .full_diagnostics_for(&util, util_src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&util, Arc::from(util_src), "tcl8.6".to_owned(), "tcl")
             .await;
         assert!(
             !diag_codes(&refined).iter().any(|c| c == "W123"),
@@ -19747,7 +19815,7 @@ mod tests {
         // Control: with the entry file NOT indexed, util inherits nothing, so
         // the single-file W120 stands.
         let unrefined = backend
-            .full_diagnostics_for(&util, util_src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&util, Arc::from(util_src), "tcl8.6".to_owned(), "tcl")
             .await;
         assert!(
             diag_codes(&unrefined).iter().any(|c| c == "W120"),
@@ -19768,7 +19836,7 @@ mod tests {
                 .add_document(app.as_str(), &analysis);
         }
         let refined = backend
-            .full_diagnostics_for(&util, util_src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&util, Arc::from(util_src), "tcl8.6".to_owned(), "tcl")
             .await;
         assert!(
             !diag_codes(&refined).iter().any(|c| c == "W120"),
@@ -19820,7 +19888,7 @@ mod tests {
         }
         let other_src = "http::register foo 80 bar\n";
         let refined = backend
-            .full_diagnostics_for(&other, other_src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&other, Arc::from(other_src), "tcl8.6".to_owned(), "tcl")
             .await;
         assert!(
             !diag_codes(&refined).iter().any(|c| c == "W120"),
@@ -20585,9 +20653,7 @@ mod tests {
         // `y` is set but never read → W211.
         let src = "proc foo {} { set y 1 }\n";
         register(&backend, &uri, src).await;
-        backend
-            .db_set_source(&uri, src.to_owned(), "tcl8.6".to_owned())
-            .await;
+        backend.db_set_source(&uri, src, "tcl8.6".to_owned()).await;
         backend
             .publish_analyser_diagnostics(
                 uri.clone(),
@@ -20622,7 +20688,7 @@ mod tests {
         let src = "# note \rset zz 1\nputs $zz\n";
         register(&backend, &uri, src).await;
         backend
-            .db_set_source(&uri, src.to_owned(), "tcl8.6".to_owned())
+            .db_set_source(&uri, src, "tcl8.6".to_owned())
             .await;
         backend
             .publish_analyser_diagnostics(
@@ -20689,21 +20755,21 @@ mod tests {
         register(&backend, &uri, src).await;
         let doc = backend.read_document(&uri).await.expect("open document");
         // The provider-facing text has the lone `\r` rewritten…
-        assert_eq!(doc.text, "set a 1\nset b 2\r\nset c 3\n");
+        assert_eq!(&*doc.text, "set a 1\nset b 2\r\nset c 3\n");
         // …the formatter / W118 view keeps the client's exact bytes…
         assert_eq!(doc.raw(), src);
         // …the rewrite never changes the byte length, so spans are shared…
         assert_eq!(doc.text.len(), doc.raw().len());
         // …and the stored shadow buffer is untouched.
         assert_eq!(
-            backend.documents.lock().await.get(&uri).expect("doc").text,
+            &*backend.documents.lock().await.get(&uri).expect("doc").text,
             src,
         );
         // An LF document is handed out unchanged (and does not allocate).
         let plain = Uri::from_str("file:///plain.tcl").unwrap();
         register(&backend, &plain, "set a 1\n").await;
         let doc = backend.read_document(&plain).await.expect("open document");
-        assert_eq!(doc.text, "set a 1\n");
+        assert_eq!(&*doc.text, "set a 1\n");
         assert!(doc.raw_text.is_none());
     }
 
@@ -20783,7 +20849,7 @@ mod tests {
             .await;
         let docs = backend.documents.lock().await;
         let doc = docs.get(&uri).expect("did_open should store the document");
-        assert_eq!(doc.text, "set x 1\n");
+        assert_eq!(&*doc.text, "set x 1\n");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -20815,7 +20881,7 @@ mod tests {
             })
             .await;
         assert_eq!(
-            backend.documents.lock().await.get(&uri).expect("doc").text,
+            &*backend.documents.lock().await.get(&uri).expect("doc").text,
             "set y 2\n",
         );
     }
@@ -20954,9 +21020,7 @@ mod tests {
         }));
         let uri = Uri::from_file_path(&on_disk).unwrap();
         register(&backend, &uri, src).await;
-        backend
-            .db_set_source(&uri, src.to_owned(), "tcl8.6".to_owned())
-            .await;
+        backend.db_set_source(&uri, src, "tcl8.6".to_owned()).await;
 
         backend
             .did_close(DidCloseTextDocumentParams {
@@ -21138,11 +21202,7 @@ mod tests {
         let uri = Uri::from_file_path(&on_disk).unwrap();
         register(&backend, &uri, "proc foo {} { set y 1 }\n").await;
         backend
-            .db_set_source(
-                &uri,
-                "proc foo {} { set y 1 }\n".to_owned(),
-                "tcl8.6".to_owned(),
-            )
+            .db_set_source(&uri, "proc foo {} { set y 1 }\n", "tcl8.6".to_owned())
             .await;
 
         backend
@@ -21185,11 +21245,7 @@ mod tests {
         // must come from disk.
         register(&backend, &uri, "proc foo {} { return 1 }\n").await;
         backend
-            .db_set_source(
-                &uri,
-                "proc foo {} { return 1 }\n".to_owned(),
-                "tcl8.6".to_owned(),
-            )
+            .db_set_source(&uri, "proc foo {} { return 1 }\n", "tcl8.6".to_owned())
             .await;
 
         backend
@@ -21225,7 +21281,7 @@ mod tests {
         let uri = Uri::from_file_path(&on_disk).unwrap();
         register(&backend, &uri, clean).await;
         backend
-            .db_set_source(&uri, clean.to_owned(), "tcl8.6".to_owned())
+            .db_set_source(&uri, clean, "tcl8.6".to_owned())
             .await;
 
         backend
@@ -21258,11 +21314,7 @@ mod tests {
         let uri = Uri::from_file_path(&on_disk).unwrap();
         register(&backend, &uri, "proc foo {} { set y 1 }\n").await;
         backend
-            .db_set_source(
-                &uri,
-                "proc foo {} { set y 1 }\n".to_owned(),
-                "tcl8.6".to_owned(),
-            )
+            .db_set_source(&uri, "proc foo {} { set y 1 }\n", "tcl8.6".to_owned())
             .await;
         backend.pull_diag_cache.lock().await.insert(
             uri.clone(),
@@ -21301,11 +21353,7 @@ mod tests {
         let uri = Uri::from_file_path(&on_disk).unwrap();
         register(&backend, &uri, "proc foo {} { set y 1 }\n").await;
         backend
-            .db_set_source(
-                &uri,
-                "proc foo {} { set y 1 }\n".to_owned(),
-                "tcl8.6".to_owned(),
-            )
+            .db_set_source(&uri, "proc foo {} { set y 1 }\n", "tcl8.6".to_owned())
             .await;
         // A sentinel cache entry standing in for the open buffer's own published
         // set. The closed publish must leave it untouched (the doc is open).
@@ -21546,11 +21594,7 @@ mod tests {
         let uri = Uri::from_file_path(&on_disk).unwrap();
         // Prime the on-disk salsa source + a non-empty badge, as a prior close would.
         backend
-            .db_set_source(
-                &uri,
-                "proc foo {} { set y 1 }\n".to_owned(),
-                "tcl8.6".to_owned(),
-            )
+            .db_set_source(&uri, "proc foo {} { set y 1 }\n", "tcl8.6".to_owned())
             .await;
         backend.pull_diag_cache.lock().await.insert(
             uri.clone(),
@@ -21595,7 +21639,7 @@ mod tests {
         let backend = test_backend();
         let uri = Uri::from_file_path(&on_disk).unwrap();
         backend
-            .db_set_source(&uri, "set x 1\n".to_owned(), "tcl8.6".to_owned())
+            .db_set_source(&uri, "set x 1\n", "tcl8.6".to_owned())
             .await;
         backend.pull_diag_cache.lock().await.insert(
             uri.clone(),
@@ -21640,11 +21684,7 @@ mod tests {
         let backend = test_backend();
         let uri = Uri::from_file_path(&on_disk).unwrap();
         backend
-            .db_set_source(
-                &uri,
-                "proc foo {} { set y 1 }\n".to_owned(),
-                "tcl8.6".to_owned(),
-            )
+            .db_set_source(&uri, "proc foo {} { set y 1 }\n", "tcl8.6".to_owned())
             .await;
         backend.pull_diag_cache.lock().await.insert(
             uri.clone(),
@@ -21705,7 +21745,7 @@ mod tests {
             (&deleted_uri, "proc deleted_proc {} {}\n"),
         ] {
             backend
-                .db_set_source(uri, (*old_src).to_owned(), "tcl8.6".to_owned())
+                .db_set_source(uri, old_src, "tcl8.6".to_owned())
                 .await;
             let mut analyser = Analyser::new();
             let analysis = analyser.analyse(old_src, "tcl8.6").clone();
@@ -21789,7 +21829,7 @@ mod tests {
         let backend = test_backend();
         let uri = Uri::from_str("file:///retired.tcl").unwrap();
         backend
-            .db_set_source(&uri, "proc foo {} {}\n".to_owned(), "tcl8.6".to_owned())
+            .db_set_source(&uri, "proc foo {} {}\n", "tcl8.6".to_owned())
             .await;
         let first = *backend
             .db_files
@@ -21823,7 +21863,7 @@ mod tests {
         }
 
         backend
-            .db_set_source(&uri, "proc bar {} {}\n".to_owned(), "tcl8.6".to_owned())
+            .db_set_source(&uri, "proc bar {} {}\n", "tcl8.6".to_owned())
             .await;
         let second = *backend
             .db_files
@@ -21869,12 +21909,12 @@ mod tests {
         backend
             .db_set_source(
                 &lib,
-                "proc helper {mode} { return $mode }\n".to_owned(),
+                "proc helper {mode} { return $mode }\n",
                 "tcl8.6".to_owned(),
             )
             .await;
         backend
-            .db_set_source(&main, "helper dev\n".to_owned(), "tcl8.6".to_owned())
+            .db_set_source(&main, "helper dev\n", "tcl8.6".to_owned())
             .await;
         let handles = EvidenceHandles {
             db: Arc::clone(&backend.db),
@@ -21919,7 +21959,7 @@ mod tests {
         let backend = test_backend();
         let uri = Uri::from_file_path(&on_disk).unwrap();
         backend
-            .db_set_source(&uri, "proc foo {} {}\n".to_owned(), "tcl8.6".to_owned())
+            .db_set_source(&uri, "proc foo {} {}\n", "tcl8.6".to_owned())
             .await;
         let before = *backend
             .db_files
@@ -22273,7 +22313,7 @@ mod tests {
         let uri = Uri::from_str("file:///pull.tcl").unwrap();
         let src = "if {1} { set x 1 } else { set y 2 }\n";
         let full = backend
-            .full_diagnostics_for(&uri, src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&uri, Arc::from(src), "tcl8.6".to_owned(), "tcl")
             .await;
         let analyser_only = {
             let mut a = Analyser::new();
@@ -23014,7 +23054,7 @@ mod tests {
         {
             let mut docs = backend.documents.lock().await;
             let doc = docs.get_mut(&uri).unwrap();
-            doc.text = "set x 2\n".to_owned();
+            doc.text = Arc::from("set x 2\n");
             doc.bump_revision(1);
         }
 
@@ -23126,7 +23166,7 @@ mod tests {
         // The current document is at revision 2; its analysis lives in the
         // query database (set via the SourceFile input) and the workspace index.
         backend
-            .db_set_source(&uri, current_src.to_owned(), "tcl8.6".to_owned())
+            .db_set_source(&uri, current_src, "tcl8.6".to_owned())
             .await;
         {
             let mut doc =
@@ -23334,20 +23374,12 @@ mod tests {
             DocumentState::new("proc open_proc {} {}\n".to_owned(), "tcl8.6".to_owned()),
         );
         backend
-            .db_set_source(
-                &open_uri,
-                "proc open_proc {} {}\n".to_owned(),
-                "tcl8.6".to_owned(),
-            )
+            .db_set_source(&open_uri, "proc open_proc {} {}\n", "tcl8.6".to_owned())
             .await;
         // Never opened, but present in `db_files` — exactly the state a
         // workspace scan leaves an unopened file in after #1151.
         backend
-            .db_set_source(
-                &closed_uri,
-                "proc closed_proc {} {}\n".to_owned(),
-                "tcl8.6".to_owned(),
-            )
+            .db_set_source(&closed_uri, "proc closed_proc {} {}\n", "tcl8.6".to_owned())
             .await;
 
         Backend::warm_open_documents(
@@ -23543,7 +23575,7 @@ mod tests {
         let ok = backend
             .full_diagnostics_for(
                 &a,
-                "helper foo bar\n".to_owned(),
+                Arc::from("helper foo bar\n"),
                 "tcl8.6".to_owned(),
                 "tcl",
             )
@@ -23557,7 +23589,7 @@ mod tests {
         // Wrong arity (3 args to the 2-param proc) → E003 (too many) from the
         // disk-backed proc's arity signature.
         let bad = backend
-            .full_diagnostics_for(&a, "helper a b c\n".to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&a, Arc::from("helper a b c\n"), "tcl8.6".to_owned(), "tcl")
             .await;
         assert!(
             diag_codes(&bad).iter().any(|c| c == "E003"),
@@ -23592,7 +23624,7 @@ mod tests {
         let present = backend
             .full_diagnostics_for(
                 &a,
-                "helper foo bar\n".to_owned(),
+                Arc::from("helper foo bar\n"),
                 "tcl8.6".to_owned(),
                 "tcl",
             )
@@ -23610,7 +23642,7 @@ mod tests {
         let gone = backend
             .full_diagnostics_for(
                 &a,
-                "helper foo bar\n".to_owned(),
+                Arc::from("helper foo bar\n"),
                 "tcl8.6".to_owned(),
                 "tcl",
             )
@@ -23640,15 +23672,11 @@ mod tests {
         let a = Uri::from_str("file:///caller.tcl").unwrap();
         let b = Uri::from_str("file:///lib.tcl").unwrap();
         backend
-            .db_set_source(
-                &b,
-                "proc helper {x y} { return $x }\n".to_owned(),
-                "tcl8.6".to_owned(),
-            )
+            .db_set_source(&b, "proc helper {x y} { return $x }\n", "tcl8.6".to_owned())
             .await;
         // 3 args to a 2-param cross-file proc → E003, even with W123 disabled.
         let diags = backend
-            .full_diagnostics_for(&a, "helper a b c\n".to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&a, Arc::from("helper a b c\n"), "tcl8.6".to_owned(), "tcl")
             .await;
         let codes = diag_codes(&diags);
         assert!(
@@ -24377,6 +24405,151 @@ mod tests {
         assert_eq!(locs.len(), 1, "{locs:?}");
         assert_eq!(locs[0].uri, uri);
         assert_eq!(locs[0].range.start.line, 0);
+    }
+
+    // Document-snapshot sharing and revision currency (issue #1184).
+    //
+    // `read_document` hands every in-flight request its own `DocumentState`.
+    // Those snapshots must (a) share one allocation of the document text and
+    // line index rather than copying both per request, and (b) stay pinned to
+    // the revision they were taken at, so a request that overlaps an edit
+    // finishes against coherent text *and* index instead of a mixture.
+
+    /// A synthetic document whose text and line index are both far larger than
+    /// a pointer, so "the snapshot shared them" is a meaningful claim rather
+    /// than a coincidence of small allocations. Deliberately not corpus-sized:
+    /// `register` analyses it, and the property under test is pointer
+    /// identity, which does not get truer with more lines.
+    fn large_document_source() -> String {
+        use std::fmt::Write as _;
+        (0..300).fold(String::new(), |mut acc, i| {
+            let _ = writeln!(acc, "proc p{i} {{a b}} {{ return [expr {{$a + $b}}] }}");
+            acc
+        })
+    }
+
+    /// **TP** — concurrent reads of one open document share its storage.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_snapshots_share_one_text_and_index_allocation() {
+        let backend = Arc::new(test_backend());
+        let uri = Uri::from_str("file:///shared.tcl").unwrap();
+        let source = large_document_source();
+        register(&backend, &uri, &source).await;
+
+        // 32 overlapping readers, the concurrency the issue asks for.
+        let mut tasks = Vec::new();
+        for _ in 0..32 {
+            let backend = Arc::clone(&backend);
+            let uri = uri.clone();
+            tasks.push(tokio::spawn(async move {
+                backend.read_document(&uri).await.expect("open document")
+            }));
+        }
+        let mut snapshots = Vec::new();
+        for t in tasks {
+            snapshots.push(t.await.expect("reader task panicked"));
+        }
+
+        let owner = {
+            let docs = backend.documents.lock().await;
+            docs.get(&uri).expect("open document").clone()
+        };
+        for (i, snap) in snapshots.iter().enumerate() {
+            assert!(
+                Arc::ptr_eq(&owner.text, &snap.text),
+                "snapshot {i} copied the document text instead of sharing it"
+            );
+            assert!(
+                owner.line_index.shares_storage_with(&snap.line_index),
+                "snapshot {i} copied the line index instead of sharing it"
+            );
+        }
+        // One allocation, held by: the store, `owner`, and the 32 snapshots.
+        assert_eq!(Arc::strong_count(&owner.text), 34);
+        // …and every snapshot really does describe the whole document, so the
+        // sharing assertions above are not passing on an empty buffer.
+        assert_eq!(&*snapshots[0].text, source.as_str());
+    }
+
+    /// **FP** — editing while an older snapshot is alive must not mix
+    /// revisions: the in-flight reader keeps text *and* index from the
+    /// revision it was given, and they stay consistent with each other.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn an_edit_never_mutates_a_snapshot_an_in_flight_request_holds() {
+        let backend = Arc::new(test_backend());
+        let uri = Uri::from_str("file:///revisions.tcl").unwrap();
+        register(&backend, &uri, "set alpha 1\nset beta 2\n").await;
+
+        let before = backend.read_document(&uri).await.expect("open document");
+        let before_revision = before.revision;
+
+        backend
+            .did_change(DidChangeTextDocumentParams {
+                text_document: tower_lsp_server::ls_types::VersionedTextDocumentIdentifier {
+                    uri: uri.clone(),
+                    version: 2,
+                },
+                content_changes: vec![tower_lsp_server::ls_types::TextDocumentContentChangeEvent {
+                    range: Some(Range {
+                        start: pos(0, 0),
+                        end: pos(0, 0),
+                    }),
+                    range_length: None,
+                    text: "# a new leading comment line\n".to_owned(),
+                }],
+            })
+            .await;
+
+        // The old snapshot is untouched…
+        assert_eq!(&*before.text, "set alpha 1\nset beta 2\n");
+        assert_eq!(before.revision, before_revision);
+        // …and its index still describes *its own* text: line 1 starts at the
+        // `set beta` of the pre-edit buffer. A snapshot that had picked up the
+        // post-edit index would resolve line 1 to the wrong byte offset, which
+        // is precisely the corruption the one-snapshot invariant rules out.
+        let line1 = before.line_index.line_start(1) as usize;
+        assert_eq!(&before.text[line1..], "set beta 2\n");
+
+        // The live document did advance, on both fields together.
+        let after = backend.read_document(&uri).await.expect("open document");
+        assert!(after.text.starts_with("# a new leading comment line\n"));
+        assert!(after.revision > before_revision);
+        let after_line1 = after.line_index.line_start(1) as usize;
+        assert_eq!(&after.text[after_line1..], "set alpha 1\nset beta 2\n");
+        assert!(!Arc::ptr_eq(&before.text, &after.text));
+    }
+
+    /// **TN** — reading a closed on-disk file yields a snapshot but must not
+    /// install it in the open-document store, so a one-off cross-file read
+    /// cannot retain every file it ever touched.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reading_a_closed_on_disk_file_does_not_retain_it() {
+        let dir = std::env::temp_dir().join(format!(
+            "tcl-lsp-1184-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("ondisk.tcl");
+        std::fs::write(&path, "proc onDisk {} { return 1 }\n").expect("write fixture");
+
+        let backend = test_backend();
+        let uri = Uri::from_str(&format!("file://{}", path.display())).expect("uri");
+
+        assert!(backend.documents.lock().await.is_empty());
+        let snap = backend.read_document(&uri).await.expect("disk fallback");
+        assert_eq!(&*snap.text, "proc onDisk {} { return 1 }\n");
+        assert!(
+            backend.documents.lock().await.is_empty(),
+            "a disk read must not become a permanent open-document entry"
+        );
+        // Reading again is a fresh read, not a retained snapshot.
+        let again = backend.read_document(&uri).await.expect("disk fallback");
+        assert!(!Arc::ptr_eq(&snap.text, &again.text));
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// Register a document in the store and the workspace index.
@@ -27056,9 +27229,7 @@ mod tests {
         let backend = test_backend();
         let uri = Uri::from_str("file:///indexed.tcl").unwrap();
         let src = "set my_re \".*abc\"\nregexp $my_re $s\n";
-        backend
-            .db_set_source(&uri, src.to_owned(), "tcl9.0".to_owned())
-            .await;
+        backend.db_set_source(&uri, src, "tcl9.0".to_owned()).await;
         backend.documents.lock().await.insert(
             uri.clone(),
             DocumentState::new(src.to_owned(), "tcl9.0".to_owned()),
@@ -27698,7 +27869,7 @@ mod tests {
         register(&backend, &uri, src).await;
 
         let on = backend
-            .full_diagnostics_for(&uri, src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&uri, Arc::from(src), "tcl8.6".to_owned(), "tcl")
             .await;
         assert!(
             !on.is_empty(),
@@ -27711,7 +27882,7 @@ mod tests {
                 .unwrap(),
         );
         let off = backend
-            .full_diagnostics_for(&uri, src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&uri, Arc::from(src), "tcl8.6".to_owned(), "tcl")
             .await;
         assert!(
             off.is_empty(),
@@ -27730,7 +27901,7 @@ mod tests {
         register(&backend, &uri, src).await;
 
         let on = backend
-            .full_diagnostics_for(&uri, src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&uri, Arc::from(src), "tcl8.6".to_owned(), "tcl")
             .await;
         let codes = |ds: &[tower_lsp_server::ls_types::Diagnostic]| -> Vec<String> {
             ds.iter()
@@ -27755,7 +27926,7 @@ mod tests {
             .apply_global_config(&serde_json::json!({ "optimiser": { "enabled": false } }))
             .await;
         let off = backend
-            .full_diagnostics_for(&uri, src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&uri, Arc::from(src), "tcl8.6".to_owned(), "tcl")
             .await;
         let off_codes = codes(&off);
         assert!(
@@ -27779,7 +27950,7 @@ mod tests {
 
         // Default (120): no W111.
         let none = backend
-            .full_diagnostics_for(&uri, src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&uri, Arc::from(src), "tcl8.6".to_owned(), "tcl")
             .await;
         assert!(
             !none
@@ -27794,7 +27965,7 @@ mod tests {
             .await;
         assert_eq!(*backend.style_line_length.lock().await, 8);
         let some = backend
-            .full_diagnostics_for(&uri, src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .full_diagnostics_for(&uri, Arc::from(src), "tcl8.6".to_owned(), "tcl")
             .await;
         assert!(
             some.iter()
@@ -27888,9 +28059,7 @@ mod tests {
         // on disk — so drop the live document `register` seeded and stand the
         // rest of the old URI's per-URI state up as a real session would have.
         backend.documents.lock().await.remove(&old);
-        backend
-            .db_set_source(&old, src.to_owned(), "tcl8.6".to_owned())
-            .await;
+        backend.db_set_source(&old, src, "tcl8.6".to_owned()).await;
         let old_file = *backend
             .db_files
             .lock()

--- a/rust/tcl-lsp-server/tests/e2e/edit_tracking_stress.rs
+++ b/rust/tcl-lsp-server/tests/e2e/edit_tracking_stress.rs
@@ -45,6 +45,7 @@ use crate::common::helpers::*;
 use crate::common::{Lsp, Rng, scaled_timeout, unique_uri};
 
 use serde_json::{Value, json};
+use std::fmt::Write as _;
 use std::time::{Duration, Instant};
 
 // --------------------------------------------------------------------------- #
@@ -794,6 +795,65 @@ fn feature_requests_interleaved_with_edits() {
         lsp.document_symbols(&uri);
         lsp.semantic_tokens(&uri);
     }
+    let fresh = unique_uri("tcl");
+    let text = mirror.text.clone();
+    assert_buffer_equiv(&mut lsp, &uri, version, &fresh, &text);
+}
+
+#[test]
+fn every_snapshot_consumer_stays_correct_while_typing_a_large_document() {
+    // Issue #1184: request handlers no longer receive a deep copy of the
+    // document — they share one immutable text + line-index allocation, taken
+    // under the store lock and released before any `.await`. The sharing is
+    // only safe because each snapshot stays pinned to the revision it was taken
+    // at, so the property to pin here is that *every* major `read_document`
+    // consumer still resolves positions against the buffer it was given, on a
+    // document large enough that a stale index would land on the wrong line.
+    //
+    // The oracle is the same one this suite uses throughout: after the edit
+    // sequence the live buffer must behave identically to a freshly opened
+    // document holding the same final text. A snapshot that had picked up a
+    // half-applied edit — new text with an old line index, or vice versa —
+    // shows up as a token or symbol at the wrong position.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let mut src = String::new();
+    for i in 0..300 {
+        let _ = writeln!(
+            src,
+            "proc helper{i} {{a b}} {{\n    set total [expr {{$a + $b}}]\n    return $total\n}}"
+        );
+    }
+    lsp.open_ready(&uri, &src);
+    let mut mirror = TextMirror::new(&src);
+    let mut rng = Rng::new(1184);
+    let mut version = 1i64;
+
+    for round in 0..12 {
+        let edit = random_edit(&mirror, &mut rng);
+        mirror.apply(&edit);
+        version += 1;
+        lsp.change_document(&uri, version, json!([edit.as_content_change()]));
+        // Fan out across the snapshot consumers named in #1184's test matrix,
+        // rotating so each one lands at a different point in the edit stream.
+        lsp.semantic_tokens(&uri);
+        lsp.document_symbols(&uri);
+        match round % 4 {
+            0 => {
+                lsp.hover(&uri, 1, 8);
+            }
+            1 => {
+                lsp.completion(&uri, 1, 8);
+            }
+            2 => {
+                lsp.definition(&uri, 2, 12);
+            }
+            _ => {
+                lsp.references(&uri, 0, 5, true);
+            }
+        }
+    }
+
     let fresh = unique_uri("tcl");
     let text = mirror.text.clone();
     assert_buffer_equiv(&mut lsp, &uri, version, &fresh, &text);

--- a/rust/tcl-lsp-server/tests/e2e/tk_dialect.rs
+++ b/rust/tcl-lsp-server/tests/e2e/tk_dialect.rs
@@ -233,7 +233,7 @@ fn large_generated_non_tk_document_stays_clean_and_responsive() {
     // DEFAULT_TIMEOUT covers it (its doc comment is about exactly this test
     // shape).  Load scaling still applies on top.
     let codes: Vec<String> = lsp
-        .open_ready_timeout(&uri, &src, std::time::Duration::from_secs(180))
+        .open_ready_timeout(&uri, &src, std::time::Duration::from_mins(3))
         .iter()
         .filter_map(|d| d.get("code").and_then(serde_json::Value::as_str))
         .filter(|c| c.starts_with("TK"))

--- a/rust/tcl-lsp-server/tests/e2e/tk_dialect.rs
+++ b/rust/tcl-lsp-server/tests/e2e/tk_dialect.rs
@@ -227,7 +227,18 @@ fn large_generated_non_tk_document_stays_clean_and_responsive() {
         );
     }
     src.push_str("    return unknown\n}\n");
-    let codes = tk_codes(&mut lsp, &uri, &src);
+    // A full debug-build analysis of a 2000-branch proc is legitimately tens
+    // of seconds on a loaded two-core CI runner: pass the large-document
+    // backstop `open_ready_timeout` exists for instead of betting
+    // DEFAULT_TIMEOUT covers it (its doc comment is about exactly this test
+    // shape).  Load scaling still applies on top.
+    let codes: Vec<String> = lsp
+        .open_ready_timeout(&uri, &src, std::time::Duration::from_secs(180))
+        .iter()
+        .filter_map(|d| d.get("code").and_then(serde_json::Value::as_str))
+        .filter(|c| c.starts_with("TK"))
+        .map(str::to_owned)
+        .collect();
     assert!(codes.is_empty(), "{codes:?}");
     // Still serving: a completion resolves rather than timing out.
     let labels = completion_labels(&lsp.completion(&uri, 1, 7));

--- a/rust/tcl-lsp-server/tests/e2e/tk_dialect.rs
+++ b/rust/tcl-lsp-server/tests/e2e/tk_dialect.rs
@@ -33,6 +33,8 @@
 //! server. The Tk-availability gating is driven by `# tcl-dialect:` directives
 //! in ordinary `tcl`-language documents (not a `tk` language id).
 
+use std::fmt::Write as _;
+
 use crate::common::helpers::*;
 use crate::common::{Lsp, unique_uri};
 
@@ -104,4 +106,133 @@ fn ttk_widget_absent_in_iapps() {
         9,
     );
     assert!(!labels.contains("ttk::button"), "{labels:?}");
+}
+
+// -- Tk activation gating, end to end (issue #1188) ----------------------
+//
+// The gate decides whether a document abandons per-body memoisation for a
+// whole-file re-analysis on *every keystroke*, so it must be exactly right in
+// both directions: a false positive is a large, permanent latency cost, a false
+// negative silently drops the TK diagnostics.
+
+/// The TK diagnostic codes published for `src`.
+fn tk_codes(lsp: &mut Lsp, uri: &str, src: &str) -> Vec<String> {
+    lsp.open_ready(uri, src)
+        .iter()
+        .filter_map(|d| d.get("code").and_then(serde_json::Value::as_str))
+        .filter(|c| c.starts_with("TK"))
+        .map(str::to_owned)
+        .collect()
+}
+
+/// **FP** — a document that merely *mentions* `package`, `require`, and `Tk`
+/// (in a comment, in a string, and via `package require Tcl`) publishes no TK
+/// diagnostics, even though it is full of Tk-shaped commands.
+#[test]
+fn words_mentioning_tk_do_not_activate_tk_diagnostics() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let codes = tk_codes(
+        &mut lsp,
+        &uri,
+        "# tcl-dialect: tcl8.6\n\
+         package require Tcl 8.6\n\
+         set doc \"Tcl/Tk script text executable\"\n\
+         # a stray mention: package require Tk\n\
+         frame .outer.inner\n\
+         pack .top.a\n\
+         grid .top.b\n",
+    );
+    assert!(
+        codes.is_empty(),
+        "no TK diagnostic may fire without a real `package require Tk`: {codes:?}"
+    );
+}
+
+/// **FP** — `package provide Tk` declares this file *is* part of Tk; it does
+/// not load Tk into the interpreter, so it must not activate either.
+#[test]
+fn package_provide_tk_does_not_activate_tk_diagnostics() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let codes = tk_codes(
+        &mut lsp,
+        &uri,
+        "# tcl-dialect: tcl8.6\npackage provide Tk 8.6\nframe .outer.inner\n",
+    );
+    assert!(codes.is_empty(), "{codes:?}");
+}
+
+/// **TP** — a real `package require Tk` still publishes the checks that need
+/// whole-file state: TK1002's parent existence, and a TK1001 geometry conflict
+/// spanning a proc body, which an isolated body cannot see.
+#[test]
+fn real_package_require_tk_still_publishes_whole_file_tk_checks() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let codes = tk_codes(
+        &mut lsp,
+        &uri,
+        "# tcl-dialect: tcl8.6\n\
+         package require Tk\n\
+         frame .top\n\
+         frame .missing.child\n\
+         proc build {} {\n\
+         pack .top.a\n\
+         grid .top.b\n\
+         }\n",
+    );
+    assert!(
+        codes.iter().any(|c| c == "TK1002"),
+        "the non-existent parent must still be reported: {codes:?}"
+    );
+    assert!(
+        codes.iter().any(|c| c == "TK1001"),
+        "a pack/grid conflict inside a proc body must still flush: {codes:?}"
+    );
+}
+
+/// **FN** — a `package require Tk` reached only inside a procedure body is
+/// still a load, and must activate: the case the post-body half of the gate
+/// exists for.
+#[test]
+fn package_require_tk_inside_a_body_still_activates() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let codes = tk_codes(
+        &mut lsp,
+        &uri,
+        "# tcl-dialect: tcl8.6\n\
+         proc setup {} { package require Tk }\n\
+         setup\n\
+         frame .missing.child\n",
+    );
+    assert!(codes.iter().any(|c| c == "TK1002"), "{codes:?}");
+}
+
+/// **FP, at scale** — a large generated document with no `package require Tk`
+/// publishes no TK diagnostics and keeps answering requests: the `filetypes.tcl`
+/// shape that used to be forced onto a whole-file re-analysis, per keystroke,
+/// by the word `Tk` appearing in generated data.
+#[test]
+fn large_generated_non_tk_document_stays_clean_and_responsive() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let mut src = String::from("# tcl-dialect: tcl8.6\npackage require Tcl 8.6\n");
+    src.push_str("proc classify {kind} {\n");
+    for i in 0..2000 {
+        let _ = writeln!(
+            src,
+            "    if {{$kind eq \"k{i}\"}} {{ return \"Tcl/Tk script text executable\" }}"
+        );
+    }
+    src.push_str("    return unknown\n}\n");
+    let codes = tk_codes(&mut lsp, &uri, &src);
+    assert!(codes.is_empty(), "{codes:?}");
+    // Still serving: a completion resolves rather than timing out.
+    let labels = completion_labels(&lsp.completion(&uri, 1, 7));
+    assert!(
+        !labels.is_empty(),
+        "server stopped answering after the open"
+    );
 }


### PR DESCRIPTION
## Summary

- Document snapshots are shared (`Arc<str>`) instead of deep-copied per request; redundant dataflow solves are pruned from interprocedural taint summaries; Tk activation resolves from registry command facts instead of substring matching.
- Closes #1184, closes #1187, closes #1188.
- Rebase note: #1212 introduced CR normalisation at the `read_document` boundary (`text` = analysis form, `raw_text` = client bytes). This branch keeps that contract intact and moves both fields behind `Arc<str>`: `normalised_for_analysis` swaps in a new `Arc`, `full_diagnostics_for` reuses the client `Arc` when no bare CR is present, and the pull-diagnostics path clones the raw `Arc` instead of copying the buffer. #1212's new normalisation unit tests pass unchanged (asserting through `&*doc.text`).

Part of the per-group PR series; independent of the other groups. The Tk-interp-domains PR duplicates one 9-line test helper from this branch (disclosed there); whichever lands second folds the copies.

## Validation

- [x] On the group branch: full workspace tests, clippy `-D warnings`, fmt, plus before/after latency benchmarks via the lsp-client harness — green at development time.
- [x] Rebased onto `rust` (post-#1212): `cargo check -p tcl-lsp-server --tests` 0 errors; `cargo test -p tcl-lsp-server --lib` — 326 passed, 0 failed (includes #1212's CR-normalisation and read_document tests).

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? — Tk activation now derives from registry command facts (same activation decisions, sturdier evidence); taint fixpoint results are unchanged (pruning is solve-order only).
- [ ] If yes, I updated at least one relevant KCS note — behaviour-preserving; design docs updated in-tree where the mechanisms are described.
- [ ] If I added a new compiler KCS note, I linked it — n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_