### PR TITLE
Compiler explorer: WASM module types section, isolated pane renders, Compile button (#1182, #1183)

### DIFF
--- a/docs/design/contracts/wasm-explorer-view.md
+++ b/docs/design/contracts/wasm-explorer-view.md
@@ -4,30 +4,45 @@
 
 The compiler explorer renders the output of `wasm_codegen_module` as a
 per-instruction interactive disassembly.  The JSON shape that
-`tooling/cli/serialise.py` produces and
+[`rust/tcl-explorer`](../../../rust/tcl-explorer) produces and
 that [`rust/tcl-cli/gui/explorer-core.js`](../../../rust/tcl-cli/gui/explorer-core.js)
-consumes is fixed by this contract.  Both the standalone web panel
-(`tooling/explorer/static/index.html`) and the VS Code webview
-(`editors/vscode/src/compilerExplorerHtml.ts`) read the same shape.
+consumes is fixed by this contract.  Both the standalone web GUI
+([`rust/tcl-cli/gui/index.html`](../../../rust/tcl-cli/gui/index.html), served
+by `tcl explore --serve` and published to GitHub Pages) and the VS Code webview
+([`editors/vscode/src/compilerExplorerHtml.ts`](../../../editors/vscode/src/compilerExplorerHtml.ts))
+read the same shape.
 
 ## Producer
 
-- `compiler/codegen/wasm/_ir.py`
-  — `WasmModule.to_explorer_json()` returns a list of function entries
-  (plus a synthetic module header).  Each instruction carries a decoded
-  target (`call` → function name, `br` / `br_if` → matching structural
-  open/close), a source range, an indent level, and an explorer label.
-- `tooling/cli/serialise.py` —
-  `_serialise_wasm` calls `to_explorer_json()`, attaches a WAT text
-  snippet per entry for legacy consumers, and returns the list as
+- [`rust/tcl-explorer/src/wasm_explorer.rs`](../../../rust/tcl-explorer/src/wasm_explorer.rs)
+  — `wasm_to_explorer_json(&WasmModule, &LineIndex, source)` returns a list
+  of function entries (plus a synthetic module header).  Each instruction
+  carries a decoded target (`call` → function name, `br` / `br_if` → matching
+  structural open/close), a source range, an indent level, and an explorer
+  label.
+- [`rust/tcl-explorer/src/serialise.rs`](../../../rust/tcl-explorer/src/serialise.rs)
+  — `serialise_wasm` calls it, attaches the full WAT `text` on the module
+  header for the TUI / legacy consumers, and returns the list as
   `data.wasm` / `data.wasmOptimised`.
+- [`rust/tcl-explorer-wasm`](../../../rust/tcl-explorer-wasm) — the
+  `wasm-bindgen` facade the browser worker calls (`compile`, plus `meta` for
+  the dialect list, which needs no compile).
 
 ## Module header entry
 
 The first entry in each list is always the synthetic module header.
 `instrCount` is fixed at 0 so tab badge totals (summed over entries)
 don't double-count body instructions; the real total is available as
-`totalInstrCount`.
+`totalInstrCount`, and `functionCount` is the number of defined functions
+(i.e. the entry count minus this header).
+
+`types` is the module's type section as the binary/WAT serialiser emits it —
+import signatures first (interned when the import is registered), then any
+further defined-function signature.  Producers must compute it with
+`WasmModule::type_section()` rather than reading the private `types` field:
+defined-function signatures are only interned when the module is actually
+serialised, so a not-yet-emitted module under-reports otherwise.
+Every `imports[].typeIdx` indexes into this list.
 
 ```jsonc
 {
@@ -40,6 +55,7 @@ don't double-count body instructions; the real total is available as
   "sourceRange": null,
   "instrCount": 0,
   "totalInstrCount": 32,
+  "functionCount": 4,
   "instructions": [],
   "imports": [
     {"module": "tcl", "name": "tcl_obj_get_int", "typeIdx": 0, "funcIdx": 0}
@@ -146,6 +162,45 @@ hint on every `br` / `br_if` that lands on its matching close.
 The shape above is additive.  Consumers that don't understand a new
 field must ignore it; producers must never repurpose an existing field
 name with a different type.  When fields change meaning, rename them.
+
+## Consumer resilience
+
+Producer and consumer ship in the same binary but are versioned by hand, and
+a published GUI can outlive the payload it was built against (GitHub Pages
+serves a cached `explorer-core.js`).  Two rules keep a mismatch survivable —
+both were learned from issues #1182 / #1183, where a module header that had
+lost its `types` array made `renderWasmModuleHeader` throw, blanked the WASM
+tab, and left the compile spinner throbbing forever:
+
+1. **Renderers treat every list as optional.**  Read `entry.foo || []`, never
+   `entry.foo.length`.  A field the producer has not caught up with must
+   degrade to "0 of those", not to a `TypeError`.
+2. **Rendering is isolated per pane.**  Both consumers drive their render
+   pipeline through `runRenderSteps` (in `explorer-core.js`): a step that
+   throws reports the error inside its own pane, the remaining panes still
+   render, and `renderAll` itself never throws — so the caller's spinner and
+   status light always settle, whatever a renderer did.
+
+Limitation: this makes a contract drift *visible and non-fatal*, not
+harmless.  A pane fed a payload missing data it genuinely needs will render
+that data as absent (or show the error in place of its content); only the
+producer-side tests
+(`rust/tcl-explorer/src/wasm_explorer.rs::module_header_carries_every_contract_field`)
+assert the payload is complete.
+
+## Tests
+
+- `rust/tcl-explorer/src/wasm_explorer.rs` (unit) — the module header carries
+  every contract field, and `types` covers imports plus defined functions.
+- `rust/tcl-compiler/src/codegen/wasm/ir.rs` (unit) — `type_section()`
+  predicts the type table `to_bytes` emits.
+- `rust/tcl-cli/tests/explorer_gui.rs` (integration) — drives the shipped GUI
+  in headless Chromium against a real payload and asserts the WASM tab
+  renders, the spinner stops, and no pane errors.  Skips with a printed
+  reason when node/Playwright are unavailable; set `TCL_EXPLORER_GUI_TEST=1`
+  to make a missing toolchain a failure instead.
+- `editors/vscode/src/test/compilerExplorerWebview.test.ts` — the generated
+  webview HTML keeps the isolation wiring and the optional-list guards.
 
 ## Related
 

--- a/docs/kcs/features/kcs-feature-compiler-explorer.md
+++ b/docs/kcs/features/kcs-feature-compiler-explorer.md
@@ -22,6 +22,9 @@ VS Code, JetBrains, tcl-lsp CLI
 
 - **VS Code**: Open a Tcl file and run `Tcl: Open in Tcl Compiler Explorer` from the command palette or press Ctrl+Alt+E. The panel shows bytecode disassembly side-by-side with the source, and updates live as you edit.
 - **JetBrains**: Right-click a Tcl/iRule file in the editor or project view and choose `Open In Tcl Compiler Explorer`, or open the `Tcl Compiler Explorer` tool window. The panel tracks the active editor and recompiles when you open or switch to a different Tcl file.
+- **Standalone GUI** (`tcl explore --serve`, or the published web build): type in the editor pane and it recompiles automatically after a short pause. Press Ctrl+Enter (⌘+Enter on macOS) or click **Compile** in the toolbar to recompile immediately — useful after switching dialect, or to re-run a compile whose source has not changed. The dialect dropdown is filled as soon as the WebAssembly module finishes loading, before any compile has run.
+
+If a single output tab cannot render a result, that tab shows the reason and the rest of the panel still renders — a broken pane no longer blanks the panel or leaves the compile throbber spinning.
 
 ## Operational context
 

--- a/editors/vscode/src/compilerExplorer.ts
+++ b/editors/vscode/src/compilerExplorer.ts
@@ -97,6 +97,7 @@ export function openCompilerExplorer(): void {
       filename?: string;
       lineno?: number;
       colno?: number;
+      panes?: string[];
     }) => {
       console.log(`[compiler-explorer] webview message: ${msg.type}`);
       if (msg.type === "ready") {
@@ -127,6 +128,11 @@ export function openCompilerExplorer(): void {
         if (msg.stack) {
           console.error(msg.stack);
         }
+      } else if (msg.type === "renderError") {
+        // One or more panes threw while rendering a result. The webview
+        // still shows the other tabs and clears its spinner; surface the
+        // detail here so the failure is diagnosable rather than silent.
+        console.error(`[compiler-explorer] pane render failure: ${msg.message ?? "unknown"}`);
       } else if (msg.type === "scriptError") {
         console.error(
           `[compiler-explorer] webview script error: ${msg.message ?? "unknown"} (${msg.filename ?? ""}:${msg.lineno ?? 0}:${msg.colno ?? 0})`,

--- a/editors/vscode/src/compilerExplorerHtml.ts
+++ b/editors/vscode/src/compilerExplorerHtml.ts
@@ -1135,12 +1135,24 @@ window.addEventListener('message', function(event) {
       compile();
       break;
     case 'result':
-      data = msg.data;
-      compiledSource = lastSource;
-      compiledDialect = lastDialect;
-      renderAll();
-      $('#spinner').style.display = 'none';
-      updateStatusLight();
+      try {
+        data = msg.data;
+        compiledSource = lastSource;
+        compiledDialect = lastDialect;
+        const failures = renderAll();
+        if (failures && failures.length && vscodeApi) {
+          vscodeApi.postMessage({
+            type: 'renderError',
+            panes: failures.map(f => f.name),
+            message: failures.map(f => f.name + ': ' + (f.error && f.error.message || f.error)).join('; '),
+          });
+        }
+      } finally {
+        // The spinner must stop whatever the renderers did — a stuck
+        // throbber is indistinguishable from a hung compile (issue #1183).
+        $('#spinner').style.display = 'none';
+        updateStatusLight();
+      }
       break;
     case 'error':
       showError(msg.data && msg.data.error || 'Unknown error', msg.data && msg.data.traceback);
@@ -1218,22 +1230,29 @@ function updateStatusLight() {
 }
 
 // Consumer hooks: renderAll / updateBadges
+//
+// Every step runs in isolation (runRenderSteps, from explorer-core.js): a
+// renderer that throws reports the failure in its own pane while the other
+// tabs still render, and renderAll itself never throws — so the caller's
+// spinner always settles (issues #1182 / #1183).
 function renderAll() {
-  renderStats();
-  renderIR();
-  renderCfgPre();
-  renderCfgPost();
-  renderInterproc();
-  renderTypes();
-  renderOpt();
-  renderGvn();
-  renderShimmer();
-  renderTaint();
-  renderIrulesFlow();
-  renderCallouts();
-  renderAsm();
-  renderWasm();
-  updateBadges();
+  return runRenderSteps([
+    { name: 'Stats', run: renderStats },
+    { name: 'IR', pane: '#pane-ir', run: renderIR },
+    { name: 'CFG', pane: '#pane-cfg-pre', run: renderCfgPre },
+    { name: 'SSA+Analysis', pane: '#pane-cfg-post', run: renderCfgPost },
+    { name: 'Interproc', pane: '#pane-interproc', run: renderInterproc },
+    { name: 'Types', pane: '#pane-types', run: renderTypes },
+    { name: 'Optimisations', pane: '#pane-opt', run: renderOpt },
+    { name: 'GVN', pane: '#pane-gvn', run: renderGvn },
+    { name: 'Shimmer', pane: '#pane-shimmer', run: renderShimmer },
+    { name: 'Taint', pane: '#pane-taint', run: renderTaint },
+    { name: 'iRules Flow', pane: '#pane-irules-flow', run: renderIrulesFlow },
+    { name: 'Callouts', pane: '#pane-callouts', run: renderCallouts },
+    { name: 'Tcl ASM', pane: '#pane-asm', run: renderAsm },
+    { name: 'WASM', pane: '#pane-wasm', run: renderWasm },
+    { name: 'badges', run: updateBadges },
+  ]);
 }
 
 function updateBadges() {

--- a/editors/vscode/src/test/compilerExplorerWebview.test.ts
+++ b/editors/vscode/src/test/compilerExplorerWebview.test.ts
@@ -1,0 +1,102 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as assert from "assert";
+import { getWebviewHtml } from "../compilerExplorerHtml";
+
+/**
+ * Regression guards for the compiler-explorer webview shell (issues
+ * #1182 / #1183).
+ *
+ * A renderer that threw used to abort the whole `result` handler: the
+ * remaining tabs never rendered and the compile spinner was never hidden,
+ * so the panel throbbed forever with no clue why. The webview now runs each
+ * pane through `runRenderSteps` (from the shared `explorer-core.js`) and
+ * clears the spinner in a `finally`.
+ *
+ * The webview body only exists as generated HTML, so assert on that rather
+ * than trying to reach into a live panel's DOM.
+ *
+ * `explorer-core.js` is inlined as a base64 `data:` URI (the webview CSP
+ * forbids external scripts), so `inlinedCoreJs` decodes it back out.
+ */
+function inlinedCoreJs(html: string): string {
+  const sources = [...html.matchAll(/src="data:text\/javascript;base64,([^"]+)"/g)].map((m) =>
+    Buffer.from(m[1], "base64").toString("utf8"),
+  );
+  const core = sources.find((s) => s.includes("function renderDisassembly"));
+  assert.ok(core, "the webview must inline explorer-core.js");
+  return core;
+}
+
+suite("Compiler Explorer webview", () => {
+  const html = getWebviewHtml();
+  const core = inlinedCoreJs(html);
+
+  test("bundles the shared explorer-core render-isolation helper", () => {
+    assert.ok(
+      core.includes("function runRenderSteps"),
+      "the webview must bundle explorer-core.js's runRenderSteps helper",
+    );
+  });
+
+  test("renderAll runs every pane through runRenderSteps", () => {
+    const renderAll = html.slice(html.indexOf("function renderAll()"));
+    assert.ok(renderAll.length > 0, "renderAll must be defined in the webview");
+    const body = renderAll.slice(0, renderAll.indexOf("\n}"));
+    assert.ok(
+      body.includes("runRenderSteps"),
+      `renderAll must delegate to runRenderSteps, got:\n${body}`,
+    );
+    for (const pane of ["#pane-ir", "#pane-wasm", "#pane-asm", "#pane-taint"]) {
+      assert.ok(body.includes(pane), `renderAll must own ${pane}`);
+    }
+  });
+
+  test("the spinner is cleared in a finally so a render failure cannot wedge it", () => {
+    const handler = html.slice(html.indexOf("case 'result':"));
+    const caseBody = handler.slice(0, handler.indexOf("case 'error':"));
+    assert.ok(
+      /\}\s*finally\s*\{/.test(caseBody),
+      `the result handler must clear the spinner in a finally block, got:\n${caseBody}`,
+    );
+    assert.ok(
+      caseBody.includes("$('#spinner').style.display = 'none'"),
+      "the result handler must hide the spinner",
+    );
+  });
+
+  test("render failures are reported to the extension host", () => {
+    assert.ok(
+      html.includes("'renderError'") || html.includes('"renderError"'),
+      "pane render failures must be posted back to the extension host",
+    );
+  });
+
+  test("the module header renderer tolerates a missing contract field", () => {
+    // `entry.types` was absent from the payload for a while; reading it
+    // unguarded took the whole WASM tab (and the spinner) down.
+    const header = core.slice(core.indexOf("function renderWasmModuleHeader"));
+    for (const guard of ["entry.imports || []", "entry.types || []", "entry.dataSegments || []"]) {
+      assert.ok(
+        header.includes(guard),
+        `renderWasmModuleHeader must default its lists to empty arrays (${guard})`,
+      );
+    }
+  });
+});

--- a/rust/tcl-cli/gui/explorer-core.js
+++ b/rust/tcl-cli/gui/explorer-core.js
@@ -34,7 +34,9 @@
 //   setupOptItemDiffScroll(pane)     — wires opt-item click to scroll diff
 //   renderShimmer()                  — renders the shimmer pane
 //   renderIrulesFlow()               — renders the iRules flow pane
-//   renderAll()                      — calls all render functions
+//   renderAll()                      — calls all render functions (drive it
+//                                      through runRenderSteps so one broken
+//                                      pane cannot abort the rest)
 //   updateBadges()                   — updates tab badge counts
 
 // Utility
@@ -52,6 +54,41 @@ function setStatus(state) {
 function showError(msg, tb) {
   var pane = $('#pane-ir');
   pane.innerHTML = '<div class="error-box">' + esc(msg) + (tb ? '\n\n' + esc(tb) : '') + '</div>';
+}
+
+// Run a render pipeline so one broken renderer cannot take the whole GUI
+// down with it.
+//
+// ``steps`` is a list of ``{name, pane, run}``: ``run`` is the renderer,
+// ``pane`` the optional selector of the pane it owns.  A throwing step gets
+// its error reported *in its own pane* (so a tab shows why it is empty
+// instead of just being empty), the remaining steps still run, and the
+// caller always gets control back — before this existed, a `TypeError` in
+// the WASM renderer skipped every later step *and* the caller's
+// `spinner.style.display = 'none'`, so the throbber span forever
+// (issues #1182 / #1183).
+//
+// Returns the list of ``{name, error}`` failures (empty on success).
+function runRenderSteps(steps) {
+  var failures = [];
+  for (var i = 0; i < steps.length; i++) {
+    var step = steps[i];
+    try {
+      step.run();
+    } catch (err) {
+      failures.push({ name: step.name, error: err });
+      if (typeof console !== 'undefined' && console.error) {
+        console.error('explorer: ' + step.name + ' failed to render', err);
+      }
+      var pane = step.pane ? $(step.pane) : null;
+      if (pane) {
+        pane.innerHTML = '<div class="error-box">' + esc(step.name + ' failed to render: '
+          + (err && err.message ? err.message : String(err)))
+          + (err && err.stack ? '\n\n' + esc(err.stack) : '') + '</div>';
+      }
+    }
+  }
+  return failures;
 }
 
 // Hover highlighting helpers
@@ -1265,12 +1302,20 @@ function renderAsmInstruction(ins, entry) {
        + '</span></div>';
 }
 
+// The synthetic ``(module)`` entry.  Every list it reads is optional: a
+// producer that predates a contract field (or one that legitimately has no
+// data segments) must not take the whole pane down with it — a single
+// missing array used to throw mid-render, leaving the WASM tab blank and
+// the compile spinner stuck (issues #1182 / #1183).
 function renderWasmModuleHeader(entry) {
+  var imports = entry.imports || [];
+  var types = entry.types || [];
+  var dataSegments = entry.dataSegments || [];
   var html = '<div class="wasm-module">';
-  html += '<div class="wasm-func-header">(module) <span class="wasm-comment">' + entry.imports.length + ' imports, ' + entry.types.length + ' types, ' + entry.dataSegments.length + ' data segments</span></div>';
-  if (entry.imports.length) {
-    html += '<details class="wasm-module-details"><summary>imports (' + entry.imports.length + ')</summary>';
-    for (var imp of entry.imports) {
+  html += '<div class="wasm-func-header">(module) <span class="wasm-comment">' + imports.length + ' imports, ' + types.length + ' types, ' + dataSegments.length + ' data segments</span></div>';
+  if (imports.length) {
+    html += '<details class="wasm-module-details"><summary>imports (' + imports.length + ')</summary>';
+    for (var imp of imports) {
       html += '<div class="wasm-import-entry">';
       html += '<span class="wasm-idx">' + imp.funcIdx + '</span>';
       html += '<span class="wasm-mnemonic">import</span> ';
@@ -1280,9 +1325,25 @@ function renderWasmModuleHeader(entry) {
     }
     html += '</details>';
   }
-  if (entry.dataSegments.length) {
-    html += '<details class="wasm-module-details"><summary>data segments (' + entry.dataSegments.length + ')</summary>';
-    for (var seg of entry.dataSegments) {
+  if (types.length) {
+    html += '<details class="wasm-module-details"><summary>types (' + types.length + ')</summary>';
+    for (var i = 0; i < types.length; i++) {
+      var t = types[i];
+      var params = (t.params || []).map(function(p) { return '(param ' + esc(p) + ')'; }).join(' ');
+      var results = (t.results || []).map(function(r) { return '(result ' + esc(r) + ')'; }).join(' ');
+      var sig = [params, results].filter(Boolean).join(' ');
+      html += '<div class="wasm-import-entry">'
+            + '<span class="wasm-idx">' + (t.index !== undefined ? t.index : i) + '</span>'
+            + '<span class="wasm-mnemonic">type</span> '
+            + '<span class="wasm-operand">$t' + (t.index !== undefined ? t.index : i) + '</span> '
+            + '<span class="wasm-comment">; (func' + (sig ? ' ' + sig : '') + ')</span>'
+            + '</div>';
+    }
+    html += '</details>';
+  }
+  if (dataSegments.length) {
+    html += '<details class="wasm-module-details"><summary>data segments (' + dataSegments.length + ')</summary>';
+    for (var seg of dataSegments) {
       html += '<div class="wasm-import-entry"><span class="wasm-idx">' + seg.offset + '</span><span class="wasm-comment">; ' + seg.size + ' bytes</span></div>';
     }
     html += '</details>';

--- a/rust/tcl-cli/gui/index.html
+++ b/rust/tcl-cli/gui/index.html
@@ -86,6 +86,19 @@ body {
   outline: none;
 }
 .toolbar select:focus { border-color: var(--accent); }
+.compile-btn {
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 3px 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  cursor: pointer;
+  outline: none;
+}
+.compile-btn:hover { border-color: var(--accent); color: var(--accent); }
+.compile-btn:focus-visible { border-color: var(--accent); }
 .toolbar .status-msg {
   font-size: 11px;
   color: var(--yellow);
@@ -930,6 +943,7 @@ textarea#source::selection { background: rgba(137, 180, 250, 0.3); }
     <select id="dialect">
       <option value="tcl8.6" selected>Tcl 8.6</option>
     </select>
+    <button id="compileBtn" class="compile-btn" type="button" title="Recompile the current source">Compile</button>
     <div class="spinner" id="spinner"></div>
     <span class="status-msg" id="statusMsg">Loading compiler...</span>
     <div class="stats" id="stats"></div>
@@ -1051,20 +1065,37 @@ worker.onmessage = function(e) {
       $('#statusMsg').style.display = 'none';
       $('#emptyState').textContent = 'Enter Tcl code and press ' + shortcutKey + '+Enter';
       setStatus('synced');
-      // Auto-compile if there's content
+      // The dialect list needs no compile, so fill the dropdown as soon as
+      // the module loads rather than leaving the hard-coded tcl8.6 fallback
+      // up until a first result lands.
+      populateDialectOptions(msg.meta && msg.meta.dialects);
+      // Auto-compile if there's content.
       if (pendingCompile || textarea.value.trim()) {
         pendingCompile = false;
         compile();
       }
       break;
     case 'result':
-      data = msg.data;
-      compiledSource = lastSource;
-      compiledDialect = lastDialect;
-      populateDialectOptions(data && data.meta && data.meta.dialects);
-      renderAll();
-      $('#spinner').style.display = 'none';
-      updateStatusLight();
+      try {
+        data = msg.data;
+        compiledSource = lastSource;
+        compiledDialect = lastDialect;
+        populateDialectOptions(data && data.meta && data.meta.dialects);
+        const failures = renderAll();
+        if (failures && failures.length) {
+          $('#statusMsg').style.display = '';
+          $('#statusMsg').textContent = failures.length + ' pane'
+            + (failures.length === 1 ? '' : 's') + ' failed to render: '
+            + failures.map(f => f.name).join(', ');
+        } else {
+          $('#statusMsg').style.display = 'none';
+        }
+      } finally {
+        // The spinner must stop whatever the renderers did — a stuck
+        // throbber is indistinguishable from a hung compile (issue #1183).
+        $('#spinner').style.display = 'none';
+        updateStatusLight();
+      }
       break;
     case 'error':
       showError(msg.error, msg.traceback);
@@ -1072,6 +1103,14 @@ worker.onmessage = function(e) {
       setStatus('dirty');
       break;
   }
+};
+
+// A worker that dies (WASM OOM, an uncaught init failure) never answers, so
+// clear the spinner and say so rather than throbbing forever.
+worker.onerror = function(err) {
+  showError('Compiler worker failed: ' + (err && err.message ? err.message : String(err)));
+  $('#spinner').style.display = 'none';
+  setStatus('dirty');
 };
 
 // Editor
@@ -1112,8 +1151,7 @@ textarea.addEventListener('keydown', e => {
   }
   if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
     e.preventDefault();
-    lastSource = '';          // force recompile even if source unchanged
-    compile();
+    forceCompile();           // recompile even if source unchanged
   }
 });
 
@@ -1135,9 +1173,14 @@ updateIrulesTabVisibility();
 
 $('#dialect').addEventListener('change', () => {
   updateIrulesTabVisibility();
-  lastSource = '';  // force recompile
-  compile();
+  forceCompile();
 });
+
+// Explicit re-compile — the debounce and the "source unchanged" guard both
+// make it easy to end up looking at a stale result (e.g. after switching
+// dialect while the module was still loading), so give the user a button
+// that always recompiles what is in the editor (issue #1183).
+$('#compileBtn').addEventListener('click', () => forceCompile());
 
 // Tabs
 $('#tabBar').addEventListener('click', e => {
@@ -1206,17 +1249,29 @@ function compile() {
   const dialect = $('#dialect').value;
   if (!source.trim()) return;
   if (source === lastSource && dialect === lastDialect) return;
-  lastSource = source;
-  lastDialect = dialect;
 
   if (!workerReady) {
+    // Remember that work is owed, but do NOT record this as the compiled
+    // source: the `ready` handler calls compile() again, and a poisoned
+    // lastSource made that call short-circuit, so anything typed while the
+    // WASM module was still loading was never compiled at all.
     pendingCompile = true;
     return;
   }
 
+  lastSource = source;
+  lastDialect = dialect;
   $('#spinner').style.display = 'block';
   setStatus('compiling');
   worker.postMessage({ type: 'compile', source, dialect });
+}
+
+// Force a compile even when the source and dialect are unchanged.
+function forceCompile() {
+  lastSource = '';
+  lastDialect = '';
+  clearTimeout(compileTimer);
+  compile();
 }
 
 function updateStatusLight() {
@@ -1230,34 +1285,42 @@ function updateStatusLight() {
 }
 
 // Consumer hooks: renderAll / updateBadges
+//
+// Every step runs in isolation (see runRenderSteps in explorer-core.js): a
+// renderer that throws reports the failure in its own pane and the rest of
+// the tabs still render.  renderAll never throws, so the caller's spinner
+// and status light always settle.
 function renderAll() {
-  updateIrulesTabVisibility();
-  renderStats();
-  renderIR();
-  renderCst();
-  renderSegments();
-  renderStructuralIndex();
-  renderSourceMap();
-  renderCfgPre();
-  renderCfgPost();
-  renderLoops();
-  renderInterproc();
-  renderTypes();
-  renderIntervals();
-  renderBounds();
-  renderRendered();
-  renderDataFlow();
-  renderOpt();
-  renderOptimiserPasses();
-  renderGvn();
-  renderShimmer();
-  renderTaint();
-  renderIrulesFlow();
-  renderEventOrder();
-  renderCallouts();
-  renderAsm();
-  renderWasm();
-  updateBadges();
+  const steps = [
+    { name: 'tab visibility', run: updateIrulesTabVisibility },
+    { name: 'Stats', pane: null, run: renderStats },
+    { name: 'IR', pane: '#pane-ir', run: renderIR },
+    { name: 'CST', pane: '#pane-cst', run: renderCst },
+    { name: 'Segments', pane: '#pane-segments', run: renderSegments },
+    { name: 'Structural Index', pane: '#pane-structural-index', run: renderStructuralIndex },
+    { name: 'Source Map', pane: '#pane-source-map', run: renderSourceMap },
+    { name: 'CFG', pane: '#pane-cfg-pre', run: renderCfgPre },
+    { name: 'SSA+Analysis', pane: '#pane-cfg-post', run: renderCfgPost },
+    { name: 'Loops', pane: '#pane-loops', run: renderLoops },
+    { name: 'Interproc', pane: '#pane-interproc', run: renderInterproc },
+    { name: 'Types', pane: '#pane-types', run: renderTypes },
+    { name: 'Intervals', pane: '#pane-intervals', run: renderIntervals },
+    { name: 'Bounds', pane: '#pane-bounds', run: renderBounds },
+    { name: 'Rendered', pane: '#pane-rendered', run: renderRendered },
+    { name: 'Data Flow', pane: '#pane-dataflow', run: renderDataFlow },
+    { name: 'Optimisations', pane: '#pane-opt', run: renderOpt },
+    { name: 'Optimiser Passes', pane: '#pane-optimiser-passes', run: renderOptimiserPasses },
+    { name: 'GVN', pane: '#pane-gvn', run: renderGvn },
+    { name: 'Shimmer', pane: '#pane-shimmer', run: renderShimmer },
+    { name: 'Taint', pane: '#pane-taint', run: renderTaint },
+    { name: 'iRules Flow', pane: '#pane-irules-flow', run: renderIrulesFlow },
+    { name: 'Event Order', pane: '#pane-event-order', run: renderEventOrder },
+    { name: 'Callouts', pane: '#pane-callouts', run: renderCallouts },
+    { name: 'Tcl ASM', pane: '#pane-asm', run: renderAsm },
+    { name: 'WASM', pane: '#pane-wasm', run: renderWasm },
+    { name: 'badges', run: updateBadges },
+  ];
+  return runRenderSteps(steps);
 }
 
 function updateBadges() {

--- a/rust/tcl-cli/gui/worker.js
+++ b/rust/tcl-cli/gui/worker.js
@@ -28,12 +28,16 @@
  * `index.html`'s `new Worker('worker.js')` and `explorer-core.js` are
  * unchanged.
  *
- * Protocol (unchanged from the Pyodide worker):
+ * Protocol (unchanged from the Pyodide worker, plus `ready.meta`):
  *   main → worker:  { type: "compile", source: string, dialect: string }
  *   worker → main:  { type: "result", data: <serialised JSON> }
  *   worker → main:  { type: "error", error: string, traceback?: string }
- *   worker → main:  { type: "ready" }
+ *   worker → main:  { type: "ready", meta?: <serialised meta JSON> }
  *   worker → main:  { type: "status", message: string }
+ *
+ * `ready.meta` carries the explorer `meta` block (dialect list, view table,
+ * severities). It needs no compile, so the GUI can fill its dialect dropdown
+ * as soon as the module loads instead of waiting for a first result.
  */
 
 /* global importScripts, wasm_bindgen */
@@ -52,7 +56,18 @@ async function init() {
   await wasm_bindgen(baseUrl + "tcl_explorer_wasm_bg.wasm");
 
   ready = true;
-  postMessage({ type: "ready" });
+  postMessage({ type: "ready", meta: readMeta() });
+}
+
+// The `meta` block, or null when the module predates the `meta` export (the
+// GUI then keeps its hard-coded dialect fallback until the first result).
+function readMeta() {
+  if (typeof wasm_bindgen.meta !== "function") return null;
+  try {
+    return JSON.parse(wasm_bindgen.meta());
+  } catch {
+    return null;
+  }
 }
 
 function compile(source, dialect) {

--- a/rust/tcl-cli/tests/explorer_gui.rs
+++ b/rust/tcl-cli/tests/explorer_gui.rs
@@ -1,0 +1,199 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Headless smoke test for the compiler-explorer web GUI (`gui/`).
+//!
+//! The GUI is shipped source (`index.html`, `explorer-core.js`, `worker.js`)
+//! that no Rust test otherwise exercises, so a producer/consumer mismatch in
+//! the explorer contract could only be caught by opening a browser. Issues
+//! #1182 / #1183 were exactly that: the `(module)` header stopped carrying
+//! `types`, `renderWasmModuleHeader` threw a `TypeError` mid-render, the WASM
+//! tab stayed blank, and — because the throw skipped the rest of the message
+//! handler — the compile spinner span forever.
+//!
+//! This test produces a real contract payload in-process (the same
+//! `serialise_result` the WASM facade calls) and drives the shipped GUI in
+//! headless Chromium via `tests/gui/explorer-gui-smoke.mjs`.
+//!
+//! It needs `node` plus a Playwright install; without them it prints why and
+//! passes, so a plain `cargo test` on a machine with no browser stack is not
+//! blocked. Point it at a non-default install with:
+//!
+//! * `TCL_EXPLORER_PLAYWRIGHT` — module specifier / path for `playwright`
+//!   (default: `playwright`, resolved from the driver's own directory),
+//! * `TCL_EXPLORER_CHROMIUM` — Chromium executable to launch,
+//! * `TCL_EXPLORER_GUI_TEST=1` — fail instead of skipping when the toolchain
+//!   is missing (set this in CI once the browser stack is installed).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// True when the harness must fail rather than skip on a missing toolchain.
+fn strict() -> bool {
+    std::env::var("TCL_EXPLORER_GUI_TEST").is_ok_and(|v| v != "0" && !v.is_empty())
+}
+
+/// Report a missing prerequisite: fail under `TCL_EXPLORER_GUI_TEST`, else
+/// print and skip.
+fn skip(reason: &str) {
+    assert!(!strict(), "explorer GUI smoke test cannot run: {reason}");
+    println!("skipping explorer GUI smoke test: {reason}");
+}
+
+/// Resolve the `playwright` module the driver should import, honouring
+/// `TCL_EXPLORER_PLAYWRIGHT` and falling back to a global npm install (the
+/// driver's own `node_modules` lookup handles a local install).
+fn playwright_specifier() -> Option<String> {
+    if let Ok(explicit) = std::env::var("TCL_EXPLORER_PLAYWRIGHT") {
+        return Some(explicit);
+    }
+    let global_root = Command::new("npm")
+        .args(["root", "-g"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+    let root = String::from_utf8(global_root.stdout).ok()?;
+    let candidate = Path::new(root.trim()).join("playwright/index.mjs");
+    candidate.is_file().then(|| candidate.display().to_string())
+}
+
+#[test]
+fn gui_renders_the_wasm_tab_and_settles_the_spinner() {
+    if Command::new("node").arg("--version").output().is_err() {
+        skip("`node` is not on PATH");
+        return;
+    }
+    let Some(playwright) = playwright_specifier() else {
+        skip("playwright is not installed (npm i -g playwright)");
+        return;
+    };
+
+    // The payload the WASM facade would return for this source.
+    let source = "proc add {a b} {\n    return [expr {$a + $b}]\n}\nputs [add 1 2]\n";
+    let result = tcl_explorer::run_pipeline(source, "tcl8.6");
+    let payload = serde_json::to_string(&tcl_explorer::serialise_result(&result))
+        .expect("explorer payload serialises");
+
+    let out_dir = PathBuf::from(env!("CARGO_TARGET_TMPDIR"));
+    std::fs::create_dir_all(&out_dir).expect("create target tmp dir");
+    let payload_path = out_dir.join("explorer-gui-payload.json");
+    std::fs::write(&payload_path, &payload).expect("write payload");
+
+    let driver = manifest_dir().join("tests/gui/explorer-gui-smoke.mjs");
+    let gui = manifest_dir().join("gui");
+    let mut cmd = Command::new("node");
+    cmd.arg(&driver)
+        .arg(&gui)
+        .arg(&payload_path)
+        .env("TCL_EXPLORER_PLAYWRIGHT", playwright);
+    if let Ok(chromium) = std::env::var("TCL_EXPLORER_CHROMIUM") {
+        cmd.env("TCL_EXPLORER_CHROMIUM", chromium);
+    }
+    let output = cmd.output().expect("spawn node driver");
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    if !output.status.success() {
+        // A missing browser binary is an environment problem, not a
+        // regression — skip unless the harness is running in strict mode.
+        if !strict()
+            && (stderr.contains("Executable doesn't exist")
+                || stderr.contains("browserType.launch")
+                || stderr.contains("ERR_MODULE_NOT_FOUND"))
+        {
+            skip(&format!("browser unavailable: {}", stderr.trim()));
+            return;
+        }
+        panic!("explorer GUI driver failed:\n{stderr}");
+    }
+
+    let report: Value =
+        serde_json::from_slice(&output.stdout).expect("driver prints a JSON report");
+    let first = &report["first"];
+
+    assert_eq!(
+        report["pageErrors"].as_array().map(Vec::len),
+        Some(0),
+        "the GUI raised uncaught errors while rendering: {}",
+        report["pageErrors"]
+    );
+    assert_eq!(
+        first["errorBoxes"].as_array().map(Vec::len),
+        Some(0),
+        "a pane reported a render failure: {}",
+        first["errorBoxes"]
+    );
+
+    // Issue #1183: the throbber must stop once a result is in.
+    assert_eq!(
+        first["spinnerDisplay"], "none",
+        "the compile spinner never stopped"
+    );
+    assert_eq!(first["statusLight"], "status-light synced");
+
+    // Issue #1182: the WASM tab must actually show a disassembly.
+    assert_eq!(
+        first["wasmModuleHeaders"], 1,
+        "the (module) header did not render"
+    );
+    assert!(
+        first["wasmFunctions"].as_u64().unwrap_or(0) >= 2,
+        "expected the top level plus ::add in the WASM tab, got {}",
+        first["wasmFunctions"]
+    );
+    assert!(
+        first["wasmInstructions"].as_u64().unwrap_or(0) > 0,
+        "the WASM tab rendered no instructions"
+    );
+    let wasm_text = first["wasmText"].as_str().unwrap_or_default();
+    assert!(
+        wasm_text.contains("(module)") && wasm_text.contains("types"),
+        "the module header is missing its import/type summary: {wasm_text}"
+    );
+    // The Tcl ASM tab shares the renderer — keep it honest too.
+    assert!(
+        first["asmFunctions"].as_u64().unwrap_or(0) >= 2,
+        "the Tcl ASM tab did not render"
+    );
+
+    // Issue #1183: the dropdown must list every dialect before the first
+    // result, and the toolbar must offer an explicit Compile button.
+    let dialects = first["dialects"].as_array().expect("dialect list");
+    assert!(
+        dialects.len() > 1 && dialects.iter().any(|d| d == "tcl9.0"),
+        "the dialect dropdown was not populated: {dialects:?}"
+    );
+    assert_eq!(first["hasCompileButton"], true, "no Compile button");
+
+    // The Compile button forces a recompile of unchanged source.
+    let before = report["compilesBeforeButton"]
+        .as_u64()
+        .expect("compile count");
+    let after = report["compilesAfterButton"]
+        .as_u64()
+        .expect("compile count");
+    assert_eq!(
+        after,
+        before + 1,
+        "clicking Compile did not trigger a fresh compile ({before} -> {after})"
+    );
+}

--- a/rust/tcl-cli/tests/gui/explorer-gui-smoke.mjs
+++ b/rust/tcl-cli/tests/gui/explorer-gui-smoke.mjs
@@ -1,0 +1,170 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/*
+ * Headless smoke test for the compiler-explorer GUI (`rust/tcl-cli/gui/`).
+ *
+ * Driven by `rust/tcl-cli/tests/explorer_gui.rs`, which compiles a Tcl
+ * snippet with the real explorer pipeline and hands the resulting contract
+ * JSON to this script:
+ *
+ *     node explorer-gui-smoke.mjs <gui-dir> <payload.json>
+ *
+ * The script serves a copy of the GUI over loopback with a stub in place of
+ * `tcl_explorer_wasm.js` (so no `wasm-pack` build is needed — the stub
+ * returns the payload the Rust side just produced, which is byte-identical
+ * to what `tcl-explorer-wasm`'s `compile` would return), drives it in
+ * headless Chromium, and prints a JSON report on stdout. Everything else —
+ * `index.html`, `explorer-core.js`, `worker.js` — is the shipped code.
+ *
+ * It asserts what issues #1182 / #1183 got wrong:
+ *   - the WASM tab actually renders a disassembly,
+ *   - the compile spinner stops,
+ *   - the dialect dropdown is populated before the first result,
+ *   - typing before the WASM module is ready still produces a compile,
+ *   - the Compile button forces a recompile,
+ *   - no uncaught page errors along the way.
+ */
+
+import { createServer } from 'node:http';
+import { readFile, mkdtemp, cp, writeFile, rm } from 'node:fs/promises';
+import { join, extname } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const [guiDir, payloadPath] = process.argv.slice(2);
+if (!guiDir || !payloadPath) {
+  console.error('usage: explorer-gui-smoke.mjs <gui-dir> <payload.json>');
+  process.exit(2);
+}
+
+const playwrightModule = process.env.TCL_EXPLORER_PLAYWRIGHT ?? 'playwright';
+const { chromium } = await import(playwrightModule);
+const launchOptions = process.env.TCL_EXPLORER_CHROMIUM
+  ? { executablePath: process.env.TCL_EXPLORER_CHROMIUM }
+  : {};
+
+const payload = await readFile(payloadPath, 'utf8');
+const root = await mkdtemp(join(tmpdir(), 'explorer-gui-smoke-'));
+await cp(guiDir, root, { recursive: true });
+
+// `wasm-pack --target no-modules` defines a global `wasm_bindgen` init
+// function with `compile` / `meta` attached; stub exactly that surface.
+const meta = JSON.stringify(JSON.parse(payload).meta ?? {});
+await writeFile(
+  join(root, 'tcl_explorer_wasm.js'),
+  `self.__PAYLOAD = ${JSON.stringify(payload)};\n` +
+    `self.__META = ${JSON.stringify(meta)};\n` +
+    'self.__COMPILES = 0;\n' +
+    'self.wasm_bindgen = function () { return Promise.resolve(); };\n' +
+    'self.wasm_bindgen.meta = function () { return self.__META; };\n' +
+    'self.wasm_bindgen.compile = function () { self.__COMPILES += 1; return self.__PAYLOAD; };\n',
+);
+await writeFile(join(root, 'tcl_explorer_wasm_bg.wasm'), '');
+// Mermaid is vendored by `make explorer-wasm` and not checked in; the GUI
+// only uses it for the iRules event-flow diagram, so a stub keeps the page
+// free of unrelated load errors.
+await writeFile(
+  join(root, 'mermaid.min.js'),
+  'globalThis.mermaid={initialize(){},render(){return Promise.resolve({svg:""})}};',
+);
+await writeFile(join(root, 'build_info.json'), '{"version":"smoke-test"}');
+
+const MIME = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.json': 'application/json',
+  '.wasm': 'application/wasm',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+};
+const server = createServer(async (req, res) => {
+  const name = decodeURIComponent(req.url.split('?')[0]).replace(/^\/+/, '') || 'index.html';
+  if (name.includes('..')) {
+    res.writeHead(400);
+    res.end('bad path');
+    return;
+  }
+  try {
+    const body = await readFile(join(root, name));
+    res.writeHead(200, { 'content-type': MIME[extname(name)] ?? 'application/octet-stream' });
+    res.end(body);
+  } catch {
+    res.writeHead(404);
+    res.end('not found');
+  }
+});
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const base = `http://127.0.0.1:${server.address().port}/`;
+
+const SOURCE = 'proc add {a b} {\n    return [expr {$a + $b}]\n}\nputs [add 1 2]\n';
+const pageErrors = [];
+const browser = await chromium.launch(launchOptions);
+let report;
+try {
+  const page = await browser.newPage();
+  page.on('pageerror', (err) => pageErrors.push(err.stack || String(err)));
+
+  await page.goto(base);
+  // Deliberately type *before* the worker signals ready: a compile queued
+  // during module load must still happen (it used to be dropped, leaving
+  // the GUI blank forever).
+  await page.fill('#source', SOURCE);
+  await page.waitForFunction(() => !!window.data, null, { timeout: 30_000 });
+
+  const afterFirst = await snapshot(page);
+
+  // The Compile button must force a fresh compile even though neither the
+  // source nor the dialect changed.
+  const before = await compileCount(page);
+  await page.click('#compileBtn');
+  let after = before;
+  for (let i = 0; i < 100 && after === before; i += 1) {
+    await page.waitForTimeout(100);
+    after = await compileCount(page);
+  }
+
+  report = {
+    ok: true,
+    first: afterFirst,
+    compilesBeforeButton: before,
+    compilesAfterButton: after,
+    pageErrors,
+  };
+} finally {
+  await browser.close();
+  server.close();
+  await rm(root, { recursive: true, force: true });
+}
+
+console.log(JSON.stringify(report, null, 2));
+
+async function snapshot(page) {
+  return page.evaluate(() => {
+    const wasm = document.querySelector('#pane-wasm');
+    const asm = document.querySelector('#pane-asm');
+    return {
+      spinnerDisplay: getComputedStyle(document.querySelector('#spinner')).display,
+      statusLight: document.querySelector('#statusLight').className,
+      wasmText: wasm.textContent.replace(/\s+/g, ' ').trim().slice(0, 400),
+      wasmModuleHeaders: wasm.querySelectorAll('.wasm-module').length,
+      wasmFunctions: wasm.querySelectorAll('.wasm-function').length,
+      wasmInstructions: wasm.querySelectorAll('.wasm-instr').length,
+      asmFunctions: asm.querySelectorAll('.wasm-function').length,
+      errorBoxes: Array.from(document.querySelectorAll('.error-box')).map((e) =>
+        e.textContent.slice(0, 200),
+      ),
+      dialects: Array.from(document.querySelectorAll('#dialect option')).map((o) => o.value),
+      hasCompileButton: !!document.querySelector('#compileBtn'),
+    };
+  });
+}
+
+// The worker owns the stub, so read its counter through a round-trip-free
+// worker evaluation.
+async function compileCount(page) {
+  const workers = page.workers();
+  if (!workers.length) return null;
+  return workers[0].evaluate(() => self.__COMPILES);
+}

--- a/rust/tcl-compiler/src/codegen/wasm/ir.rs
+++ b/rust/tcl-compiler/src/codegen/wasm/ir.rs
@@ -427,6 +427,41 @@ impl WasmModule {
         func_idx
     }
 
+    /// The module's type section — every interned function signature in
+    /// type-index order, as `(params, results)` pairs.
+    ///
+    /// This is what [`Self::to_bytes`] / [`Self::to_wat`] emit, computed
+    /// without mutating the module: import signatures are interned eagerly by
+    /// [`Self::add_import`], while defined-function signatures are only
+    /// interned when the module is serialised, so reading `self.types`
+    /// directly would under-report on a module that has not been emitted yet.
+    #[must_use]
+    pub fn type_section(&self) -> Vec<(Vec<ValType>, Vec<ValType>)> {
+        let mut types = self.types.clone();
+        for func in &self.functions {
+            let sig = (func.params.clone(), func.results.clone());
+            if !types.contains(&sig) {
+                types.push(sig);
+            }
+        }
+        types
+    }
+
+    /// Intern every defined function's signature into the type section.
+    ///
+    /// Both serialisers need the type section to cover the defined functions
+    /// (imports are interned by [`Self::add_import`] at registration time).
+    fn intern_function_types(&mut self) {
+        let sigs: Vec<(Vec<ValType>, Vec<ValType>)> = self
+            .functions
+            .iter()
+            .map(|f| (f.params.clone(), f.results.clone()))
+            .collect();
+        for (params, results) in &sigs {
+            self.intern_type(params, results);
+        }
+    }
+
     /// Intern a function signature, returning its type-section index.
     fn intern_type(&mut self, params: &[ValType], results: &[ValType]) -> usize {
         if let Some(idx) = self
@@ -453,14 +488,7 @@ impl WasmModule {
     #[must_use]
     pub fn to_bytes(&mut self) -> Vec<u8> {
         // Register every defined function's signature first.
-        let sigs: Vec<(Vec<ValType>, Vec<ValType>)> = self
-            .functions
-            .iter()
-            .map(|f| (f.params.clone(), f.results.clone()))
-            .collect();
-        for (params, results) in &sigs {
-            self.intern_type(params, results);
-        }
+        self.intern_function_types();
 
         let mut sections: Vec<u8> = Vec::new();
 
@@ -611,14 +639,7 @@ impl WasmModule {
     /// Render a human-readable WAT representation.
     #[must_use]
     pub fn to_wat(&mut self) -> String {
-        let sigs: Vec<(Vec<ValType>, Vec<ValType>)> = self
-            .functions
-            .iter()
-            .map(|f| (f.params.clone(), f.results.clone()))
-            .collect();
-        for (params, results) in &sigs {
-            self.intern_type(params, results);
-        }
+        self.intern_function_types();
 
         let mut lines: Vec<String> = vec!["(module".to_owned()];
 
@@ -874,6 +895,28 @@ mod tests {
         );
         // Two distinct signatures => two types.
         assert_eq!(m.types.len(), 2);
+    }
+
+    #[test]
+    fn type_section_matches_the_emitted_type_table() {
+        // `type_section()` is the non-mutating view the explorer reads before
+        // anything has serialised the module. It must already agree with the
+        // table `to_bytes` ends up interning, or the explorer's `(module)`
+        // header under-reports the module's types (issue #1182).
+        let mut m = sample_module();
+        let before = m.type_section();
+        assert_eq!(
+            before.len(),
+            2,
+            "import signature + defined-function signature"
+        );
+        let _ = m.to_bytes();
+        assert_eq!(
+            before, m.types,
+            "type_section() must predict the emitted type section exactly"
+        );
+        // Idempotent: serialising again neither grows nor reorders the table.
+        assert_eq!(m.type_section(), m.types);
     }
 
     #[test]

--- a/rust/tcl-explorer-wasm/src/lib.rs
+++ b/rust/tcl-explorer-wasm/src/lib.rs
@@ -36,6 +36,19 @@ pub fn start() {
     console_error_panic_hook::set_once();
 }
 
+/// The explorer's `meta` block (dialect list, view-tab table, severity
+/// vocabulary) as JSON, without compiling anything.
+///
+/// The GUI needs the dialect list to populate its dropdown *before* the
+/// first compile — otherwise the dropdown shows only the hard-coded
+/// `tcl8.6` fallback until a compile happens to land (issue #1183).
+#[wasm_bindgen]
+#[must_use]
+pub fn meta() -> String {
+    serde_json::to_string(&tcl_explorer::serialise_meta())
+        .unwrap_or_else(|e| format!(r#"{{"error":"serialise failed: {e}"}}"#))
+}
+
 /// Compile `source` for `dialect` and return the explorer contract JSON.
 ///
 /// On a serialisation failure it returns a JSON `{"error": ...}` object

--- a/rust/tcl-explorer/src/serialise.rs
+++ b/rust/tcl-explorer/src/serialise.rs
@@ -203,27 +203,24 @@ fn serialise_children(stmt: &Statement, li: &LineIndex, source: &str) -> Option<
 /// explorer shape (`wasm_explorer::wasm_to_explorer_json` — resolved `call`
 /// targets, paired `br`/`br_if` targets, block-pairing indices, per-instruction
 /// ranges). The synthetic `(module)` entry additionally carries the full WAT
-/// `text` and the module-wide counts the TUI `wasm` view renders, so both the
-/// text renderer and the web GUI read one shape.
+/// `text`, so both the text renderer and the web GUI read one shape; the
+/// module-wide counts (`functionCount` / `totalInstrCount`) and the type
+/// section come from `wasm_to_explorer_json` itself.
 fn serialise_wasm(module: &Module, source: &str) -> Value {
     use tcl_compiler::codegen::wasm::wasm_codegen_module;
 
     let mut wasm = wasm_codegen_module(module, source);
-    let total_instr: usize = wasm.functions.iter().map(|f| f.body.len()).sum();
-    let function_count = wasm.functions.len();
     let wat = wasm.to_wat();
 
     // Rich per-instruction entries (module header first, then functions).
     let li = LineIndex::new(source);
     let mut entries = crate::wasm_explorer::wasm_to_explorer_json(&wasm, &li, source);
 
-    // Augment the synthetic `(module)` header with the WAT text + counts the
-    // TUI renderer needs (it reads `text` on the module entry and
+    // Augment the synthetic `(module)` header with the WAT text the TUI
+    // renderer reads (it reads `text` on the module entry and
     // `name`/`instrCount` on each function entry, both already present).
     if let Some(Value::Object(header)) = entries.first_mut() {
         header.insert("text".to_owned(), Value::String(wat));
-        header.insert("functionCount".to_owned(), json!(function_count));
-        header.insert("totalInstrCount".to_owned(), json!(total_instr));
     }
     Value::Array(entries)
 }

--- a/rust/tcl-explorer/src/wasm_explorer.rs
+++ b/rust/tcl-explorer/src/wasm_explorer.rs
@@ -48,11 +48,12 @@ use crate::formatters::range_dict;
 const BLOCK_VOID: u8 = 0x40;
 
 /// Build the structured explorer entries for `module`: a synthetic `(module)`
-/// header carrying imports + data segments, followed by one entry per function
-/// with its resolved instruction stream.
+/// header carrying imports, types + data segments, followed by one entry per
+/// function with its resolved instruction stream.
 #[must_use]
 pub fn wasm_to_explorer_json(module: &WasmModule, li: &LineIndex, source: &str) -> Vec<Value> {
     let num_imports = module.imports.len();
+    let total_instr: usize = module.functions.iter().map(|f| f.body.len()).sum();
 
     let module_header = json!({
         "name": "(module)",
@@ -63,6 +64,8 @@ pub fn wasm_to_explorer_json(module: &WasmModule, li: &LineIndex, source: &str) 
         "locals": [],
         "sourceRange": Value::Null,
         "instrCount": 0,
+        "totalInstrCount": total_instr,
+        "functionCount": module.functions.len(),
         "instructions": [],
         "imports": module
             .imports
@@ -73,6 +76,19 @@ pub fn wasm_to_explorer_json(module: &WasmModule, li: &LineIndex, source: &str) 
                 "name": imp.name,
                 "typeIdx": imp.type_idx,
                 "funcIdx": i,
+            }))
+            .collect::<Vec<_>>(),
+        // The type section as the module would emit it — see the
+        // `types` field of docs/design/contracts/wasm-explorer-view.md.
+        // Omitting it broke the GUI's module header outright (issue #1182).
+        "types": module
+            .type_section()
+            .iter()
+            .enumerate()
+            .map(|(index, (params, results))| json!({
+                "index": index,
+                "params": params.iter().map(|p| p.wat_name()).collect::<Vec<_>>(),
+                "results": results.iter().map(|r| r.wat_name()).collect::<Vec<_>>(),
             }))
             .collect::<Vec<_>>(),
         "dataSegments": module
@@ -552,6 +568,82 @@ mod tests {
             entries[1]["instrCount"],
             entries[1]["instructions"].as_array().unwrap().len()
         );
+    }
+
+    /// Issue #1182: the GUI's `renderWasmModuleHeader` reads
+    /// `entry.imports.length`, `entry.types.length` and
+    /// `entry.dataSegments.length` unconditionally, so every field the
+    /// contract (`docs/design/contracts/wasm-explorer-view.md`) declares on
+    /// the `(module)` header must actually be emitted as an array. A missing
+    /// `types` threw a `TypeError` mid-render, which left the WASM tab empty
+    /// *and* wedged the compile spinner (issue #1183).
+    #[test]
+    fn module_header_carries_every_contract_field() {
+        let entries = wasm_entries("proc add {a b} { expr {$a + $b} }\nputs [add 1 2]");
+        let header = &entries[0];
+        assert_eq!(header["kind"], "module");
+        for field in ["imports", "types", "dataSegments", "instructions"] {
+            assert!(
+                header[field].is_array(),
+                "module header field `{field}` must be an array, got {}",
+                header[field]
+            );
+        }
+        for field in ["instrCount", "totalInstrCount", "functionCount"] {
+            assert!(
+                header[field].is_u64(),
+                "module header field `{field}` must be a number, got {}",
+                header[field]
+            );
+        }
+        // The header's counters describe the whole module, not the (empty)
+        // header body: `instrCount` stays 0 so tab badges don't double-count.
+        assert_eq!(header["instrCount"], 0);
+        let total: u64 = entries
+            .iter()
+            .skip(1)
+            .map(|f| f["instrCount"].as_u64().unwrap())
+            .sum();
+        assert_eq!(header["totalInstrCount"].as_u64().unwrap(), total);
+        assert_eq!(
+            header["functionCount"].as_u64().unwrap(),
+            entries.len() as u64 - 1
+        );
+    }
+
+    #[test]
+    fn module_types_cover_imports_and_defined_functions() {
+        // Every import's `typeIdx` must index into the emitted `types` list,
+        // and each type entry carries WAT type names the GUI can print.
+        let entries = wasm_entries("proc add {a b} { expr {$a + $b} }\nputs [add 1 2]");
+        let header = &entries[0];
+        let types = header["types"].as_array().unwrap();
+        assert!(!types.is_empty(), "a module with imports has types");
+        for (i, t) in types.iter().enumerate() {
+            assert_eq!(t["index"].as_u64().unwrap(), i as u64);
+            assert!(t["params"].is_array());
+            assert!(t["results"].is_array());
+            for name in t["params"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .chain(t["results"].as_array().unwrap())
+            {
+                assert!(
+                    ["i32", "i64", "f32", "f64"].contains(&name.as_str().unwrap()),
+                    "unexpected WAT type name {name}"
+                );
+            }
+        }
+        for imp in header["imports"].as_array().unwrap() {
+            let idx = usize::try_from(imp["typeIdx"].as_u64().unwrap()).unwrap();
+            assert!(
+                idx < types.len(),
+                "import {} points at type {idx}, but only {} types are emitted",
+                imp["name"],
+                types.len()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- The compiler explorer's WASM target emits a module types section; pane renders are isolated so a failed pane can't blank its neighbours (spinner resilience); an explicit Compile button replaces the lost-compile-on-edit behaviour.
- Closes #1182, closes #1183.

Part of the per-group PR series; independent of the other groups. Explorer tooling only — no LSP server or compiler-analysis behaviour changes.

## Validation

- [x] On the group branch: explorer test suite plus manual verification of the WASM tab against `tcl explore` output — green at development time.
- [x] Rebased onto `rust` (post-#1212): `cargo check --workspace --all-targets` — 0 errors.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract? — No (explorer presentation and WASM emission tooling).
- [ ] KCS note — n/a.
- [ ] Linked — n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_