### PR TITLE
BIG-IP reports: baseline security misconfiguration findings (#1211)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -136,7 +136,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -297,11 +297,13 @@ dependencies = [
  "base64",
  "chrono",
  "ipnet",
+ "md-5",
  "minijinja",
  "pulldown-cmark",
  "regex",
  "serde",
  "serde_json",
+ "sha-crypt",
  "tcl-bigip",
  "tcl-bigip-io",
  "tcl-bigip-query",
@@ -1359,7 +1361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2136,6 +2138,15 @@ name = "mach2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
+
+[[package]]
+name = "mcf"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2044bdbade272ded4a1529324f4f30ca7b0c5b496541f2a9095bbd1c9d03cb06"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "md-5"
@@ -3376,7 +3387,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3679,6 +3690,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-crypt"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32ee31e0190f9dc366d26b032ac36a99328532f40a237a79385a20d2d7f29810"
+dependencies = [
+ "base64ct",
+ "ctutils",
+ "mcf",
+ "password-hash",
+ "sha2 0.11.0",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3824,7 +3848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4512,7 +4536,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4522,7 +4546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5383,7 +5407,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -1173,6 +1173,17 @@ types introduced across BIG-IP 21.x. The report also maps the detected TMOS
 branch to F5 K5903, showing its first-customer-ship, EoSD, EoTS, and EoL dates
 and warning when a support milestone is within one year or has passed.
 
+The report's **Security** tab runs a small, offline set of high-confidence
+checks — factory/default `root`/`admin` credentials (verified against the
+stored password hash with no platform `crypt(3)` call, so the native, wasm,
+and any future backend agree), default/weak SNMP communities, disabled or
+weak password-policy enforcement, plaintext secrets, unprotected private-key
+material, and non-administrative shell access — and lists each as a
+stable-id, severity-ranked finding with remediation guidance. Detection never
+authenticates to a device or makes a network request, and no password, hash,
+salt, or other secret value ever appears in a finding. See
+[kcs-feature-bigip-report-security-tab.md](docs/kcs/features/kcs-feature-bigip-report-security-tab.md).
+
 ```
 # BIG-IP config file (bigip.conf)
 ltm virtual /Common/my_vs {

--- a/docs/kcs/features/README.md
+++ b/docs/kcs/features/README.md
@@ -123,6 +123,7 @@ combine them when more than one form helps:
 - [kcs-feature-bigip-registry.md](kcs-feature-bigip-registry.md)
 - [kcs-feature-bigip-report-apm-tab.md](kcs-feature-bigip-report-apm-tab.md)
 - [kcs-feature-bigip-report-profile-defaults.md](kcs-feature-bigip-report-profile-defaults.md)
+- [kcs-feature-bigip-report-security-tab.md](kcs-feature-bigip-report-security-tab.md)
 - [kcs-feature-f5-cli.md](kcs-feature-f5-cli.md)
 - [kcs-feature-f5-secret-crypto.md](kcs-feature-f5-secret-crypto.md)
 - [kcs-feature-f5-query-renderers.md](kcs-feature-f5-query-renderers.md)

--- a/docs/kcs/features/kcs-feature-bigip-report-security-tab.md
+++ b/docs/kcs/features/kcs-feature-bigip-report-security-tab.md
@@ -1,0 +1,146 @@
+# KCS: feature — BIG-IP report Security tab
+
+> **Audience:** User
+> **Type:** Functionality
+
+## Summary
+
+A **Security** tab in the standalone BIG-IP HTML report that runs a small,
+documented set of offline, high-confidence security-posture checks against a
+config export or UCS backup — factory/default credentials, default or weak
+SNMP community strings, disabled/weak password-policy enforcement, plaintext
+(unencrypted) secrets, unprotected private-key material, and non-administrative
+accounts with full shell access — and lists each as a structured, stable-id
+finding with a severity, a status, and remediation guidance.
+
+## Applies to
+
+tcl-lsp CLI
+
+## Question
+
+What does the report's Security tab check, and how do I read its findings?
+
+## How to use
+
+Generate a report as usual (`bigip-report-gen device.ucs -o report.html`, or
+the in-browser generator). The **Security** tab always appears — even a bare,
+LTM-only `bigip.conf` shows it, so you can see *what wasn't checked* and why,
+not just what was found.
+
+Each finding has:
+
+- an **id** (e.g. `BIGIP-SEC-001`) — stable across reports, so you can track a
+  specific check over time or link to it from a ticket;
+- a **severity** — `critical` / `high` / `medium` / `low` / `info`;
+- a **status**:
+  - **confirmed** — the issue is present; act on it;
+  - **clear** — the check ran and found nothing;
+  - **not applicable** — there was nothing to check (e.g. no `root` account
+    in this source at all);
+  - **could not inspect** — the material is present but not in a form this
+    generator can verify (e.g. a password hash in an unsupported scheme);
+- **evidence** — a short, human-readable explanation, and **source** — the
+  object it's about (e.g. `auth user /Common/admin`);
+- **remediation** — what to do about it, plus a reference link when an
+  authoritative one is confidently known.
+
+Detection is entirely **passive and offline**: nothing in this tab
+authenticates to the device or makes a network request, and no password,
+hash, salt, master key, private key, or other decrypted secret value is ever
+shown in a finding — only object names, field names, and counts.
+
+## What each check looks for
+
+| Id | Check | Confirmed when |
+|---|---|---|
+| `BIGIP-SEC-001` | Factory/default credentials | the stored `root` or `admin` password hash verifies against the known default (`default` / `admin`) |
+| `BIGIP-SEC-002` | Default/weak SNMP community | an `sys snmp` community's `community-name` is a well-known default (`public`, `private`) |
+| `BIGIP-SEC-003` | Weak password policy | `auth password-policy` has enforcement disabled, or a minimum length below a conservative baseline |
+| `BIGIP-SEC-004` | Plaintext secret | a credential-bearing field BIG-IP normally encrypts under the unit master key is stored in clear text |
+| `BIGIP-SEC-005` | Exposed private key | a private-key file in the UCS filestore carries no passphrase-protection marker |
+| `BIGIP-SEC-006` | Shell access review | a non-administrative account has `shell bash` (full OS access) |
+
+## Example
+
+An estate with a device still on `admin`/`admin` and a `public` SNMP
+community shows:
+
+```
+BIGIP-SEC-001  critical  confirmed  Default account credential detected
+  the stored `admin` password verifies against the factory default
+  source: auth user /Common/admin
+
+BIGIP-SEC-002  medium    confirmed  Default SNMP community string
+  community `comm-public` uses the default string "public" with ro access
+  source: sys snmp communities comm-public
+```
+
+A clean device with a custom SNMP community and a strong password policy
+shows the same rules with `clear` status instead — the tab reports both
+outcomes, not just alarms.
+
+## Default-credential detection, in a bit more detail
+
+`root`/`default` and `admin`/`admin` are checked against every stored
+password representation this generator can verify **without ever calling the
+platform `crypt(3)`** (so the native binary, the wasm in-browser generator,
+and any future backend agree byte-for-byte):
+
+- `$6$…` SHA-512-crypt and `$5$…` SHA-256-crypt — what a current BIG-IP
+  (TMOS 11+) stores;
+- `$1$…` MD5-crypt — older estates and migrated accounts.
+
+A hash in an unsupported or unrecognised scheme (classic 13-character Unix
+DES-crypt with no `$` prefix, bcrypt, Apache's `$apr1$`, or anything
+malformed) is reported **could not inspect**, never guessed at and never
+confirmed or cleared — "fail closed". A locked account (`*`, `!`, `!!`) or
+one with no password field at all is **not applicable**.
+
+`root` is an OS account, not a `tmsh` object — its credential only appears in
+a UCS's `/etc/shadow`, so this check needs a UCS backup (not a bare
+`bigip.conf`) to inspect it at all; without one, `root` shows **not
+applicable** with that reason.
+
+## Limitations
+
+- **`sys sshd` (remote root / SSH access) and `sys httpd` (management GUI
+  TLS/HTTP settings) are not yet checked.** The generated BIG-IP object model
+  keeps both as untyped records that drop every property, and the Python
+  generator that would normally add the missing fields has been retired from
+  this branch (see `AGENTS.md`) — there's no generator left to run. This is
+  tracked as a follow-up (either restore codegen for these two kinds or add
+  hand-maintained parsing).
+- A **partial `bigip.conf`** (no `auth password-policy` block, no UCS
+  filestore, no `/etc/shadow`) naturally shows more **not applicable**/
+  **could not inspect** results — the report is telling you what it
+  *couldn't* check, which is expected, not a bug.
+- The **Security tab is Rust-only for now** (native CLI and the wasm
+  in-browser generator share the exact same code, so those two always agree).
+  `rust/bigip-report-gen/python/python/f5report/report.py` is a parallel,
+  hand-maintained Python port of the *rest* of the model — kept only as "the
+  PyO3/Python demonstration of driving the query engine as a library" per
+  `AGENTS.md`'s "Python has been fully retired on this branch" — and was not
+  given a matching Security tab in this change. Porting it (including a
+  from-scratch Python MD5-crypt/SHA-crypt implementation, since the platform
+  `crypt(3)` module is explicitly out of scope for the same reason it is
+  here) is a follow-up if the Python demo needs to stay at parity.
+- The report's query console still embeds the entire raw source text
+  verbatim (for live queries), the same way it always has for other tabs
+  (e.g. the Secrets tab's own reveal-behind-a-button values) — so a stored
+  password hash is not literally absent from the HTML file. What this feature
+  guarantees is narrower and still meaningful: the *Security tab's own
+  findings* never carry the stored hash, salt, candidate password, or any
+  other secret value — only the pass/fail verdict.
+
+## Why it is built this way
+
+Findings are declared as a small rule table (one stable id + check function
+per row, in `rust/bigip-report-gen/rust/src/security.rs`) rather than
+one-off logic scattered through the report — the same shape
+`crate::forensics`'s ATT&CK checklist uses. Fields the generated BIG-IP model
+doesn't carry (the real SNMP `community-name` value, an `auth user`'s `role`)
+are read directly off the config text with the same low-level block/property
+helpers the certificates and secrets tabs already use, rather than guessing
+from a stanza label or hand-extending a `@generated` model file with no
+generator left to keep it honest.

--- a/rust/bigip-report-gen/rust/Cargo.toml
+++ b/rust/bigip-report-gen/rust/Cargo.toml
@@ -50,6 +50,19 @@ tcl-registry = { path = "../../tcl-registry" }
 # the `rand`/getrandom salt path (only `encrypt` needs it), keeping the wasm
 # build entropy-free — a report only ever *decrypts*.
 tcl-f5mku = { path = "../../tcl-f5mku", default-features = false }
+# Default-credential verification (Security tab): deterministic, offline
+# verification of a stored password hash against a known candidate, with no
+# platform `crypt(3)` call (so native, wasm and any future backend agree).
+# `sha-crypt` (RustCrypto) covers the glibc `$5$`/`$6$` SHA-256/512-crypt
+# schemes used by modern BIG-IP local accounts; default features are
+# `alloc` + `password-hash` (no `getrandom` — verification needs no
+# randomness, keeping the wasm build entropy-free like `tcl-f5mku` above).
+sha-crypt = "0.6"
+# `$1$` MD5-crypt (older BIG-IP / Linux accounts) is implemented locally in
+# `crypt.rs` on top of the plain MD5 digest — the algorithm has no established
+# maintained pure-Rust crate, but is small, has no randomness, and is
+# unit-tested against real `crypt(3)` output.
+md-5 = "0.10"
 regex = "1"
 ipnet = "2"
 base64 = "0.22"

--- a/rust/bigip-report-gen/rust/src/crypt.rs
+++ b/rust/bigip-report-gen/rust/src/crypt.rs
@@ -1,0 +1,361 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Offline, deterministic verification of a stored password hash against a
+//! known candidate password — the primitive the Security tab's default-
+//! credential check is built on (see [`crate::security`]).
+//!
+//! Never calls the platform `crypt(3)`: every scheme below is a pure-Rust
+//! digest computation, so the native binary, the wasm build and any future
+//! backend derive byte-identical results — no `libcrypt`, no `unsafe`, no
+//! OS/library version skew. Nothing here logs, renders, or returns the
+//! stored hash, the salt, the candidate password, or the derived hash; the
+//! only thing a caller ever sees is a [`Verdict`].
+//!
+//! # Supported schemes
+//!
+//! | Prefix | Scheme | Source |
+//! |---|---|---|
+//! | `$6$` | SHA-512-crypt | [`sha_crypt`] (`RustCrypto`) |
+//! | `$5$` | SHA-256-crypt | [`sha_crypt`] (`RustCrypto`) |
+//! | `$1$` | MD5-crypt (FreeBSD/glibc) | implemented below, on the plain MD5 digest |
+//!
+//! `$6$`/`$5$` are what a current BIG-IP (TMOS 11+, glibc `libcrypt`) stores
+//! for `auth user … encrypted-password` and for `/etc/shadow` entries in a
+//! UCS; `$1$` remains for older estates and third-party accounts migrated
+//! from earlier Linux/BSD systems.
+//!
+//! # Deliberately unsupported (fail closed, never guessed)
+//!
+//! Traditional Seventh-Edition Unix DES-crypt (bare 13-character hashes with
+//! no `$scheme$` prefix), `BSDi` extended DES-crypt, Apache's `$apr1$`
+//! variant, bcrypt (`$2a$`/`$2b$`/`$2y$`) and any other/unrecognised
+//! representation are reported as [`Verdict::Unsupported`] — the finding is
+//! "could not inspect", never a guess. See the issue's acceptance criteria:
+//! *"Unsupported or malformed formats fail closed and do not produce false
+//! positives."* Classic DES-crypt in particular is rare on a modern BIG-IP
+//! (TMOS defaults to SHA-512-crypt) and its crypt(3) variant folds the salt
+//! into a modified DES expansion permutation rather than just keying
+//! standard DES, so — lacking an audited pure-Rust implementation — it is
+//! left uninspected rather than hand-rolled.
+//!
+//! F5's own `$M$…` master-key envelope (see [`tcl_f5mku`]) is a different
+//! thing entirely: it wraps *secrets* (RADIUS/LDAP/monitor passwords, key
+//! passphrases), never the local-account login hash, so it never appears in
+//! `encrypted-password` and is out of scope here.
+
+use md5::{Digest, Md5};
+use sha_crypt::password_hash;
+use sha_crypt::{PasswordVerifier, ShaCrypt};
+
+/// The outcome of comparing a stored password-hash string against a known
+/// candidate password.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    /// The candidate password verifies against the stored hash.
+    Match,
+    /// The stored hash is in a supported scheme, but the candidate does not
+    /// verify against it.
+    NoMatch,
+    /// The stored value marks the account as locked / passwordless (`*`,
+    /// `!`, `!!`) or empty — there is no credential to compare a candidate
+    /// against.
+    NotApplicable,
+    /// The stored value is in a scheme this module does not implement (or is
+    /// not a recognisable hash at all). Never treated as a match or a
+    /// non-match — the caller must render this as "could not inspect".
+    Unsupported,
+}
+
+/// Shadow/tmsh sentinels meaning "this account has no usable password" —
+/// never a hash to compare against.
+const LOCKED_SENTINELS: [&str; 4] = ["*", "!", "!!", "x"];
+
+/// Verify `candidate` against `stored` (a `auth user … encrypted-password` or
+/// `/etc/shadow` field value), returning a [`Verdict`] and never the stored
+/// hash, its salt, or the derived hash.
+#[must_use]
+pub fn verify(stored: &str, candidate: &str) -> Verdict {
+    let stored = stored.trim();
+    if stored.is_empty() || LOCKED_SENTINELS.contains(&stored) {
+        return Verdict::NotApplicable;
+    }
+
+    if let Some(rest) = stored.strip_prefix("$1$") {
+        return match md5_crypt_verify(rest, candidate) {
+            Some(true) => Verdict::Match,
+            Some(false) => Verdict::NoMatch,
+            None => Verdict::Unsupported,
+        };
+    }
+
+    if stored.starts_with("$5$") || stored.starts_with("$6$") {
+        let sha = ShaCrypt::default();
+        return match sha.verify_password(candidate.as_bytes(), stored) {
+            Ok(()) => Verdict::Match,
+            Err(password_hash::Error::PasswordInvalid) => Verdict::NoMatch,
+            // Any other error (bad params, malformed field count, …) means
+            // the stored text isn't actually a well-formed sha-crypt hash —
+            // fail closed rather than guess.
+            Err(_) => Verdict::Unsupported,
+        };
+    }
+
+    Verdict::Unsupported
+}
+
+/// Split a `$1$salt` remainder (after the `$1$` prefix has been stripped)
+/// into `(salt, has_trailing_hash)`. The salt is at most 8 characters, up to
+/// the next `$` (or end of string).
+fn split_md5_salt(rest: &str) -> (&str, bool) {
+    match rest.split_once('$') {
+        Some((salt, _)) => (&salt[..salt.len().min(8)], true),
+        None => (&rest[..rest.len().min(8)], false),
+    }
+}
+
+/// Verify `candidate` against a `$1$salt$hash` MD5-crypt string (with the
+/// `$1$` prefix already stripped). Returns `None` when `rest` doesn't carry a
+/// trailing `$hash` field (malformed — fail closed).
+fn md5_crypt_verify(rest: &str, candidate: &str) -> Option<bool> {
+    let (salt, has_hash) = split_md5_salt(rest);
+    if !has_hash {
+        return None;
+    }
+    let computed = md5_crypt(candidate.as_bytes(), salt.as_bytes());
+    let stored_hash = rest.split_once('$').map(|(_, h)| h)?;
+    // Plain, non-secret-length string comparison: the *inputs* being compared
+    // (a derived hash and a stored hash) are not the secret being protected
+    // (the password) — this mirrors `sha_crypt`'s own non-constant-time
+    // dev-dependency-free path for the `$5$`/`$6$` MCF string compare and the
+    // module doc's "no timing hardening needed for a local, offline batch
+    // compare" scope note.
+    Some(computed == stored_hash)
+}
+
+/// The `crypt(3)`/FreeBSD/glibc MD5-crypt algorithm (RFC-less but
+/// long-standing de facto standard, `$1$` scheme), computing only the final
+/// hash field (the caller already has the salt).
+///
+/// This is the well-known Poul-Henning Kamp algorithm shipped by FreeBSD and
+/// glibc since the 1990s; there is no maintained pure-Rust crate for it (see
+/// the module doc), so it is implemented here directly on the plain MD5
+/// digest and validated in tests against real `crypt(3)` output (`python3
+/// -c 'import crypt; crypt.crypt(...)'` on glibc).
+fn md5_crypt(password: &[u8], salt: &[u8]) -> String {
+    const MAGIC: &[u8] = b"$1$";
+
+    let mut ctx = Md5::new();
+    ctx.update(password);
+    ctx.update(MAGIC);
+    ctx.update(salt);
+
+    let mut ctx1 = Md5::new();
+    ctx1.update(password);
+    ctx1.update(salt);
+    ctx1.update(password);
+    let mut alt: [u8; 16] = ctx1.finalize().into();
+
+    let mut remaining = password.len();
+    while remaining > 0 {
+        let take = remaining.min(16);
+        ctx.update(&alt[..take]);
+        remaining -= take;
+    }
+
+    let mut i = password.len();
+    while i != 0 {
+        if i & 1 != 0 {
+            ctx.update([0u8]);
+        } else {
+            ctx.update(&password[..1]);
+        }
+        i >>= 1;
+    }
+    alt = ctx.finalize().into();
+
+    for i in 0..1000 {
+        let mut c = Md5::new();
+        if i & 1 != 0 {
+            c.update(password);
+        } else {
+            c.update(alt);
+        }
+        if i % 3 != 0 {
+            c.update(salt);
+        }
+        if i % 7 != 0 {
+            c.update(password);
+        }
+        if i & 1 != 0 {
+            c.update(alt);
+        } else {
+            c.update(password);
+        }
+        alt = c.finalize().into();
+    }
+
+    // The final permutation + custom base64 ("itoa64") encoding, in the
+    // fixed byte-triple order the reference implementation uses.
+    let mut out = String::with_capacity(22);
+    let groups: [(usize, usize, usize); 5] =
+        [(0, 6, 12), (1, 7, 13), (2, 8, 14), (3, 9, 15), (4, 10, 5)];
+    for (a, b, c) in groups {
+        let v = (u32::from(alt[a]) << 16) | (u32::from(alt[b]) << 8) | u32::from(alt[c]);
+        to64(v, 4, &mut out);
+    }
+    to64(u32::from(alt[11]), 2, &mut out);
+    out
+}
+
+/// The MD5-crypt "itoa64" alphabet — not standard base64.
+const ITOA64: &[u8] = b"./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+/// Append `count` `itoa64` characters (least-significant 6 bits first) of
+/// `value` to `out`.
+fn to64(mut value: u32, count: usize, out: &mut String) {
+    for _ in 0..count {
+        out.push(ITOA64[(value & 0x3f) as usize] as char);
+        value >>= 6;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Ground truth captured from glibc `crypt(3)` via
+    // `python3 -c 'import crypt; print(crypt.crypt(pw, salt))'`.
+
+    #[test]
+    fn md5_crypt_matches_glibc() {
+        assert_eq!(md5_crypt(b"default", b"abcdefgh"), "9aR4aM1iehMtluq/alSdu0");
+        assert_eq!(md5_crypt(b"admin", b"saltsalt"), "Y3BMhxQHmg7scgLILa56u1");
+        assert_eq!(md5_crypt(b"", b"abcdefgh"), "M55TzYaaccxVGbptZWaxX/");
+        assert_eq!(md5_crypt(b"default", b""), "cVmNS3JBcYsfcdsZnqCys0");
+    }
+
+    #[test]
+    fn md5_crypt_default_credentials_match() {
+        assert_eq!(
+            verify("$1$abcdefgh$9aR4aM1iehMtluq/alSdu0", "default"),
+            Verdict::Match
+        );
+        assert_eq!(
+            verify("$1$saltsalt$Y3BMhxQHmg7scgLILa56u1", "admin"),
+            Verdict::Match
+        );
+    }
+
+    #[test]
+    fn md5_crypt_non_default_does_not_match() {
+        assert_eq!(
+            verify("$1$abcdefgh$9aR4aM1iehMtluq/alSdu0", "hunter2"),
+            Verdict::NoMatch
+        );
+    }
+
+    #[test]
+    fn sha256_crypt_default_credentials() {
+        assert_eq!(
+            verify(
+                "$5$rounds=5000$saltstring$JZi6s3UTY7yQ.mIUS72QzgoEF8T6QbJoTOftn/Vm7c1",
+                "default"
+            ),
+            Verdict::Match
+        );
+        assert_eq!(
+            verify(
+                "$5$abcsalt12$egUJtD7PERzbcgR/nWzHxBZDwbk7PoR9QXn31CaUcq/",
+                "admin"
+            ),
+            Verdict::Match
+        );
+    }
+
+    #[test]
+    fn sha512_crypt_default_credentials() {
+        assert_eq!(
+            verify(
+                "$6$rounds=5000$saltstring$6p43fZYI.QjsRRE84rwofulMnyqp504VY9sFYK14/NXu6XfSJmmWs.6LU23LEbtyE.wFHWhcL9ahBHbNgfPCc1",
+                "default"
+            ),
+            Verdict::Match
+        );
+        assert_eq!(
+            verify(
+                "$6$abcsalt12$xVTHU6Ifw7m21v5IXNpEQM1G/HDajebt/qt8a3FrnxzBmgXWpecsAYQNalE3Oaotb83HDNkXt3gc4TbJMjplv1",
+                "admin"
+            ),
+            Verdict::Match
+        );
+    }
+
+    #[test]
+    fn sha_crypt_non_default_does_not_match() {
+        assert_eq!(
+            verify(
+                "$6$abcsalt12$xVTHU6Ifw7m21v5IXNpEQM1G/HDajebt/qt8a3FrnxzBmgXWpecsAYQNalE3Oaotb83HDNkXt3gc4TbJMjplv1",
+                "hunter2"
+            ),
+            Verdict::NoMatch
+        );
+        assert_eq!(
+            verify(
+                "$5$abcXYZ12$tffhf423Gq6U4KVT21AMqiHanCKTGd8MYH4vGUIgO/1",
+                "admin"
+            ),
+            Verdict::NoMatch
+        );
+    }
+
+    #[test]
+    fn locked_and_empty_accounts_are_not_applicable() {
+        for stored in ["", "*", "!", "!!", "x", "  "] {
+            assert_eq!(
+                verify(stored, "admin"),
+                Verdict::NotApplicable,
+                "stored={stored:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_schemes_fail_closed() {
+        // Classic 13-char Unix DES-crypt (no `$` prefix) — deliberately
+        // unsupported (see module docs).
+        assert_eq!(verify("xOAFZqRz5RduI", "password"), Verdict::Unsupported);
+        // bcrypt — a different login-hash ecosystem, not implemented.
+        assert_eq!(
+            verify(
+                "$2y$05$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe",
+                "password"
+            ),
+            Verdict::Unsupported
+        );
+        // Apache's MD5 variant shares the `$1$`-like shape but a different
+        // salt magic; garbage/malformed text also fails closed.
+        assert_eq!(
+            verify("$apr1$abcdefgh$whatever", "default"),
+            Verdict::Unsupported
+        );
+        assert_eq!(verify("not-a-hash-at-all", "default"), Verdict::Unsupported);
+        // A `$1$` string with no trailing `$hash` field is malformed.
+        assert_eq!(verify("$1$onlysalt", "default"), Verdict::Unsupported);
+    }
+}

--- a/rust/bigip-report-gen/rust/src/lib.rs
+++ b/rust/bigip-report-gen/rust/src/lib.rs
@@ -42,6 +42,7 @@
 
 mod apm;
 mod certs;
+mod crypt;
 pub mod enrich;
 mod forensics;
 mod graph;
@@ -52,6 +53,7 @@ mod model;
 mod query;
 mod render;
 mod secrets;
+mod security;
 mod services;
 
 pub use tcl_lexer::highlight_tcl;

--- a/rust/bigip-report-gen/rust/src/model.rs
+++ b/rust/bigip-report-gen/rust/src/model.rs
@@ -1790,6 +1790,15 @@ fn collect_device(uri: &str, source: &str, cert_pems: &HashMap<String, String>, 
         crate::forensics::collect_forensics(files, &rule_slice),
     );
 
+    // Offline security-posture findings (Security tab): default credentials,
+    // SNMP/password-policy weaknesses, plaintext secrets, exposed private
+    // keys, and shell-access review. See `crate::security` for the rule
+    // table, the crypt verification it relies on, and the documented limits.
+    device.insert(
+        "security".into(),
+        crate::security::collect_security(source, files),
+    );
+
     // Tag every displayed object with its partition (from the full path) and
     // collect the device's partition set, so the report can filter to a
     // partition while always keeping shared /Common objects visible.
@@ -1859,6 +1868,15 @@ fn collect_device(uri: &str, source: &str, cert_pems: &HashMap<String, String>, 
         .and_then(J::as_array)
         .map_or(0, Vec::len);
     counts.insert("secrets".into(), J::from(secret_total));
+    // The Security tab's badge is the count of *actionable* findings
+    // (confirmed / could-not-inspect) — clear/not-applicable results still
+    // populate the tab (positive assurance) but don't inflate the badge.
+    let security_actionable = device
+        .get("security")
+        .and_then(|s| s.get("actionable"))
+        .and_then(J::as_u64)
+        .unwrap_or(0);
+    counts.insert("security".into(), J::from(security_actionable));
     let apm_total = device
         .get("apmProfiles")
         .and_then(J::as_array)

--- a/rust/bigip-report-gen/rust/src/security.rs
+++ b/rust/bigip-report-gen/rust/src/security.rs
@@ -1,0 +1,1098 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Offline security-posture findings (the report's Security tab).
+//!
+//! A small, documented, high-confidence rule table — data-driven the same way
+//! [`crate::forensics`]'s ATT&CK checklist is: each rule inspects whatever
+//! this source actually carries and reports a stable-id [`Finding`], never
+//! hardcoded per-object logic in a consumer. Detection is entirely passive:
+//! nothing here authenticates to a device or makes a network request, and
+//! [`crate::crypt`] (the only cryptography involved) never calls the
+//! platform `crypt(3)`.
+//!
+//! # What is inspected
+//!
+//! * The parsed `bigip.conf`/SCF text (via [`tcl_bigip::parser::parse_bigip_conf`]
+//!   and the same low-level block/property helpers `certs.rs`/`secrets.rs`
+//!   use) — `auth user` (credential + shell + role), `auth password-policy`,
+//!   and `sys snmp` communities.
+//! * [`tcl_bigip::secrets::collect_secrets`] — every credential-bearing field
+//!   BIG-IP normally stores under the unit master key, flagging any that
+//!   are *not* (a plaintext `$M$`-less value).
+//! * The UCS file inventory (`files`, when the source is a UCS rather than a
+//!   bare config — see [`crate::forensics`] for the same input), scanned for
+//!   `/etc/shadow` credential material and for private-key files that carry
+//!   no passphrase-protection marker.
+//!
+//! # What is *not* inspected (documented limitation)
+//!
+//! F5's per-service management hardening — `sys sshd` (remote root / shell
+//! restrictions) and `sys httpd` (management GUI TLS/HTTP settings) — is not
+//! yet covered: the generated BIG-IP object model
+//! ([`tcl_bigip::model::gen`]) currently keeps both as untyped
+//! [`tcl_bigip::model::BigipMinimalObject`]s (identity + description only,
+//! no properties preserved), and that generator's Python source has been
+//! retired from this branch (see `AGENTS.md` "Python has been fully
+//! retired"), so there is no generator left to run to add the fields.
+//! Extending the model by hand — bypassing the `@generated … do not edit`
+//! banner with no generator to keep it honest — was judged higher-risk than
+//! shipping without it; a follow-up should either restore codegen for these
+//! two kinds or add hand-maintained parsing, then extend [`RULES`].
+//!
+//! A source that is only a partial `bigip.conf` (no `auth password-policy`
+//! block, no UCS filestore, no `/etc/shadow`) naturally yields
+//! [`Status::CouldNotInspect`] / [`Status::NotApplicable`] findings for the
+//! rules that need that material — this is the intended behaviour, not a
+//! bug: the report tells you what it *couldn't* check, rather than staying
+//! silent about it.
+
+use serde_json::{Map, Value as J, json};
+use tcl_bigip::model::ModelObject;
+use tcl_bigip::parser::driver::parse_bigip_conf;
+use tcl_bigip::parser::helpers::{extract_blocks, parse_keyed_block_entries, parse_properties};
+use tcl_bigip::secrets::collect_secrets as collect_raw_secrets;
+
+use crate::crypt::{self, Verdict};
+
+/// Severity, most to least urgent — drives the summary counts and the
+/// report's ordering/colouring.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Severity {
+    Critical,
+    High,
+    Medium,
+    Low,
+    Info,
+}
+
+impl Severity {
+    fn as_str(self) -> &'static str {
+        match self {
+            Severity::Critical => "critical",
+            Severity::High => "high",
+            Severity::Medium => "medium",
+            Severity::Low => "low",
+            Severity::Info => "info",
+        }
+    }
+}
+
+/// A finding's disposition — the three-way (plus "confirmed") split the
+/// issue calls for: *confirmed* (acted on), *clear* (checked, not an issue),
+/// *not applicable* (nothing here to check), *could not inspect* (present,
+/// but not in a form this generator can verify).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Status {
+    Confirmed,
+    Clear,
+    NotApplicable,
+    CouldNotInspect,
+}
+
+impl Status {
+    fn as_str(self) -> &'static str {
+        match self {
+            Status::Confirmed => "confirmed",
+            Status::Clear => "clear",
+            Status::NotApplicable => "not_applicable",
+            Status::CouldNotInspect => "could_not_inspect",
+        }
+    }
+}
+
+/// One security finding. `evidence` and `source` are always human-readable
+/// pointers (an object path, a count, a field name) — never a password,
+/// hash, salt, master key, private key, or other decrypted secret value.
+struct Finding {
+    /// Stable rule id, e.g. `"BIGIP-SEC-001"` — see [`RULES`].
+    rule_id: &'static str,
+    severity: Severity,
+    status: Status,
+    title: &'static str,
+    evidence: String,
+    remediation: &'static str,
+    source: String,
+    /// An authoritative F5 reference, when one is confidently known.
+    reference: Option<&'static str>,
+}
+
+impl Finding {
+    fn to_json(&self) -> J {
+        json!({
+            "id": self.rule_id,
+            "severity": self.severity.as_str(),
+            "status": self.status.as_str(),
+            "title": self.title,
+            "evidence": self.evidence,
+            "remediation": self.remediation,
+            "source": self.source,
+            "reference": self.reference,
+        })
+    }
+}
+
+/// Everything a rule might need, gathered once per device.
+struct Ctx<'a> {
+    source: &'a str,
+    auth_users: Vec<AuthUserFacts>,
+    password_policy: Option<tcl_bigip::model::BigipAuthPasswordPolicy>,
+    files: &'a [J],
+}
+
+/// The subset of `auth user` facts a rule needs, plus the `role` value this
+/// generator recovers itself (the generated model's `partition_access` field
+/// carries only partition names — see the module doc's "not yet inspected"
+/// note on why this one small extra scan lives here instead of in the typed
+/// model).
+struct AuthUserFacts {
+    name: String,
+    full_path: String,
+    encrypted_password: String,
+    shell: String,
+    has_admin_role: bool,
+}
+
+impl Ctx<'_> {
+    fn build<'a>(source: &'a str, files: &'a [J]) -> Ctx<'a> {
+        let cfg = parse_bigip_conf(source, "Common");
+        let blocks = extract_blocks(source);
+
+        let mut auth_users = Vec::new();
+        let mut password_policy = None;
+        for placed in &cfg.objects {
+            match &placed.object {
+                ModelObject::AuthUser(u) => {
+                    let has_admin_role = blocks
+                        .iter()
+                        .find(|b| {
+                            b.header == format!("auth user {}", placed.full_path)
+                                || b.header == format!("auth user \"{}\"", placed.full_path)
+                        })
+                        .is_some_and(|b| {
+                            b.body.contains("role admin") || b.body.contains("role administrator")
+                        });
+                    auth_users.push(AuthUserFacts {
+                        name: u.name.clone(),
+                        full_path: if placed.full_path.is_empty() {
+                            u.name.clone()
+                        } else {
+                            placed.full_path.clone()
+                        },
+                        encrypted_password: u.encrypted_password.clone(),
+                        shell: u.shell.clone(),
+                        has_admin_role,
+                    });
+                }
+                ModelObject::AuthPasswordPolicy(p) => {
+                    password_policy = Some(p.clone());
+                }
+                _ => {}
+            }
+        }
+
+        Ctx {
+            source,
+            auth_users,
+            password_policy,
+            files,
+        }
+    }
+}
+
+/// `(username, factory default password)` pairs to check. A rule table in
+/// its own right — extend here, not with a new branch in
+/// [`check_default_credentials`].
+const DEFAULT_CREDENTIALS: &[(&str, &str)] = &[("root", "default"), ("admin", "admin")];
+
+/// `/etc/shadow`-style `name:hash:…` line → `(name, hash)`.
+fn parse_shadow_line(line: &str) -> Option<(&str, &str)> {
+    let mut fields = line.splitn(3, ':');
+    let name = fields.next()?;
+    let hash = fields.next()?;
+    if name.is_empty() {
+        return None;
+    }
+    Some((name, hash))
+}
+
+/// Every `(source_label, hash)` this UCS/config carries for `username`: the
+/// `auth user` config entry (if the name matches) plus any `/etc/shadow`
+/// entry in the file inventory.
+fn credential_sources(ctx: &Ctx, username: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for u in &ctx.auth_users {
+        if u.name == username && !u.encrypted_password.is_empty() {
+            out.push((
+                format!("auth user {}", u.full_path),
+                u.encrypted_password.clone(),
+            ));
+        }
+    }
+    for f in ctx.files {
+        let Some(o) = f.as_object() else { continue };
+        if o.get("path").and_then(J::as_str) != Some("etc/shadow") {
+            continue;
+        }
+        let Some(content) = o.get("content").and_then(J::as_str) else {
+            continue;
+        };
+        for line in content.lines() {
+            if let Some((name, hash)) = parse_shadow_line(line)
+                && name == username
+            {
+                out.push(("etc/shadow".to_owned(), hash.to_owned()));
+            }
+        }
+    }
+    out
+}
+
+/// **BIGIP-SEC-001** — confirmed factory/default account credentials
+/// (`root`/`default`, `admin`/`admin`). See [`crypt`] for how a stored hash
+/// is verified against the known candidate without ever touching platform
+/// `crypt(3)` or logging the stored value.
+fn check_default_credentials(id: &'static str, ctx: &Ctx) -> Vec<Finding> {
+    let mut out = Vec::new();
+    for (username, candidate) in DEFAULT_CREDENTIALS {
+        let sources = credential_sources(ctx, username);
+        if sources.is_empty() {
+            out.push(Finding {
+                rule_id: id,
+                severity: Severity::Info,
+                status: Status::NotApplicable,
+                title: "Default credential check has no material to inspect",
+                evidence: format!(
+                    "no `{username}` account (an `auth user` stanza or `/etc/shadow` entry) is present in this source"
+                ),
+                remediation: "Supply a full config export or UCS if this device does carry a local `root`/`admin` account.",
+                source: username.to_string(),
+                reference: None,
+            });
+            continue;
+        }
+        for (source, hash) in sources {
+            let (severity, status, title, evidence, remediation): (
+                Severity,
+                Status,
+                &'static str,
+                String,
+                &'static str,
+            ) = match crypt::verify(&hash, candidate) {
+                Verdict::Match => (
+                    Severity::Critical,
+                    Status::Confirmed,
+                    "Default account credential detected",
+                    format!(
+                        "the stored `{username}` password verifies against the factory default"
+                    ),
+                    "Change the credential immediately and review the account's access and login history.",
+                ),
+                Verdict::NoMatch => (
+                    Severity::Info,
+                    Status::Clear,
+                    "Default credential check passed",
+                    format!(
+                        "the stored `{username}` password does not verify against the factory default"
+                    ),
+                    "No action required.",
+                ),
+                Verdict::NotApplicable => (
+                    Severity::Info,
+                    Status::NotApplicable,
+                    "Account has no usable password",
+                    format!(
+                        "`{username}` is locked or has no password set (cannot be checked against a default)"
+                    ),
+                    "No action required.",
+                ),
+                Verdict::Unsupported => (
+                    Severity::Medium,
+                    Status::CouldNotInspect,
+                    "Stored credential is in an unsupported format",
+                    format!(
+                        "`{username}`'s stored password is not in a supported hash scheme (SHA-512/256-crypt or MD5-crypt) — it was not compared"
+                    ),
+                    "Confirm the credential manually, or re-export with a supported hashing scheme so it can be checked automatically.",
+                ),
+            };
+            out.push(Finding {
+                rule_id: id,
+                severity,
+                status,
+                title,
+                evidence,
+                remediation,
+                source,
+                reference: None,
+            });
+        }
+    }
+    out
+}
+
+/// Community names widely shipped as SNMP defaults across vendors — a device
+/// still using one of these is trivially guessable.
+const DEFAULT_SNMP_COMMUNITIES: &[&str] = &["public", "private"];
+
+/// **BIGIP-SEC-002** — default or weak SNMP community strings.
+///
+/// The generated `sys snmp` model only carries each community *stanza's*
+/// name (e.g. `comm-public`), not its `community-name` value — so this rule
+/// re-derives the real community string from the config text directly with
+/// the same generic block/property helpers `certs.rs`/`secrets.rs` use,
+/// rather than guessing from the stanza label.
+fn check_snmp_communities(id: &'static str, ctx: &Ctx) -> Vec<Finding> {
+    let Some(block) = extract_blocks(ctx.source)
+        .into_iter()
+        .find(|b| b.header == "sys snmp")
+    else {
+        return vec![Finding {
+            rule_id: id,
+            severity: Severity::Info,
+            status: Status::Clear,
+            title: "SNMP is not configured",
+            evidence: "no `sys snmp` stanza in this source".to_owned(),
+            remediation: "No action required.",
+            source: "sys snmp".to_owned(),
+            reference: None,
+        }];
+    };
+
+    let communities_raw = parse_properties(&block.body)
+        .into_iter()
+        .find(|(k, _)| k == "communities")
+        .map(|(_, v)| v)
+        .unwrap_or_default();
+    let entries = parse_keyed_block_entries(&communities_raw);
+    if entries.is_empty() {
+        return vec![Finding {
+            rule_id: id,
+            severity: Severity::Info,
+            status: Status::Clear,
+            title: "No SNMP community strings configured",
+            evidence: "`sys snmp` is present but defines no communities".to_owned(),
+            remediation: "No action required.",
+            source: "sys snmp".to_owned(),
+            reference: None,
+        }];
+    }
+
+    let mut out = Vec::new();
+    let mut default_count = 0usize;
+    for (name, body) in entries {
+        let props = parse_properties(&body);
+        let community_name = props
+            .iter()
+            .find(|(k, _)| k == "community-name")
+            .map(|(_, v)| tcl_bigip::parser::helpers::unquote(v).to_owned())
+            .unwrap_or_default();
+        let access = props
+            .iter()
+            .find(|(k, _)| k == "access")
+            .map_or("ro", |(_, v)| v.as_str());
+        let is_default = DEFAULT_SNMP_COMMUNITIES
+            .iter()
+            .any(|d| d.eq_ignore_ascii_case(&community_name));
+        if !is_default {
+            continue;
+        }
+        default_count += 1;
+        let rw = access.eq_ignore_ascii_case("rw");
+        out.push(Finding {
+            rule_id: id,
+            severity: if rw { Severity::High } else { Severity::Medium },
+            status: Status::Confirmed,
+            title: if rw {
+                "Default SNMP community with read-write access"
+            } else {
+                "Default SNMP community string"
+            },
+            evidence: format!("community `{name}` uses the default string \"{community_name}\" with {access} access"),
+            remediation: "Replace the community string with a unique, hard-to-guess value, and prefer SNMPv3 with authentication/privacy over v1/v2c communities.",
+            source: format!("sys snmp communities {name}"),
+            reference: None,
+        });
+    }
+    if default_count == 0 {
+        out.push(Finding {
+            rule_id: id,
+            severity: Severity::Info,
+            status: Status::Clear,
+            title: "No default SNMP community strings found",
+            evidence: "community strings are configured; none use a well-known default name"
+                .to_owned(),
+            remediation: "No action required.",
+            source: "sys snmp".to_owned(),
+            reference: None,
+        });
+    }
+    out
+}
+
+/// A conservative baseline minimum password length; below this a policy is
+/// flagged even when enforcement is nominally on. Not an authoritative F5
+/// recommendation — a device's own compliance baseline may set this higher.
+const WEAK_MIN_LENGTH: u32 = 8;
+
+/// **BIGIP-SEC-003** — disabled or weak password-policy enforcement.
+fn check_password_policy(id: &'static str, ctx: &Ctx) -> Vec<Finding> {
+    let Some(p) = &ctx.password_policy else {
+        return vec![Finding {
+            rule_id: id,
+            severity: Severity::Medium,
+            status: Status::CouldNotInspect,
+            title: "Password policy could not be inspected",
+            evidence: "no `auth password-policy` stanza is present in this source".to_owned(),
+            remediation: "Supply a full config export or UCS to check password-complexity enforcement.",
+            source: "auth password-policy".to_owned(),
+            reference: None,
+        }];
+    };
+
+    if p.policy_enforcement.eq_ignore_ascii_case("disabled") {
+        return vec![Finding {
+            rule_id: id,
+            severity: Severity::High,
+            status: Status::Confirmed,
+            title: "Password complexity enforcement is disabled",
+            evidence: "`auth password-policy` has `policy-enforcement disabled` — any password length or complexity is accepted".to_owned(),
+            remediation: "Enable password-policy enforcement and set a minimum length/complexity that meets your organisation's baseline.",
+            source: "auth password-policy".to_owned(),
+            reference: None,
+        }];
+    }
+
+    let min_len: Option<u32> = p.minimum_length.trim().parse().ok();
+    match min_len {
+        Some(n) if n < WEAK_MIN_LENGTH => vec![Finding {
+            rule_id: id,
+            severity: Severity::Medium,
+            status: Status::Confirmed,
+            title: "Password minimum length is weak",
+            evidence: format!("`auth password-policy` requires only {n} character(s)"),
+            remediation: "Raise `minimum-length` to meet your organisation's baseline (commonly 14+ for administrative accounts).",
+            source: "auth password-policy".to_owned(),
+            reference: None,
+        }],
+        Some(n) => vec![Finding {
+            rule_id: id,
+            severity: Severity::Info,
+            status: Status::Clear,
+            title: "Password policy enforcement is enabled",
+            evidence: format!("`auth password-policy` enforces a minimum length of {n} character(s)"),
+            remediation: "No action required.",
+            source: "auth password-policy".to_owned(),
+            reference: None,
+        }],
+        None => vec![Finding {
+            rule_id: id,
+            severity: Severity::Low,
+            status: Status::CouldNotInspect,
+            title: "Password minimum length could not be read",
+            evidence: "`auth password-policy` enforcement is on, but `minimum-length` is unset or unparseable".to_owned(),
+            remediation: "Set an explicit `minimum-length` on the password policy.",
+            source: "auth password-policy".to_owned(),
+            reference: None,
+        }],
+    }
+}
+
+/// **BIGIP-SEC-004** — plaintext secrets: a credential-bearing field
+/// ([`tcl_bigip::secrets::ENCRYPTED_SECRET_KEYS`]) that BIG-IP would normally
+/// store under the unit master key, found in clear text instead.
+fn check_plaintext_secrets(id: &'static str, ctx: &Ctx) -> Vec<Finding> {
+    let plaintext: Vec<_> = collect_raw_secrets(ctx.source)
+        .into_iter()
+        .filter(|s| !s.encrypted)
+        .collect();
+    if plaintext.is_empty() {
+        return vec![Finding {
+            rule_id: id,
+            severity: Severity::Info,
+            status: Status::Clear,
+            title: "No plaintext credential-bearing fields found",
+            evidence: "every secret-bearing field in this source is stored under the unit master key (or none are present)".to_owned(),
+            remediation: "No action required.",
+            source: "config".to_owned(),
+            reference: None,
+        }];
+    }
+    plaintext
+        .into_iter()
+        .map(|s| {
+            let high = s.field == "passphrase";
+            Finding {
+                rule_id: id,
+                severity: if high { Severity::High } else { Severity::Medium },
+                status: Status::Confirmed,
+                title: "Credential-bearing field stored in clear text",
+                evidence: format!(
+                    "`{}` on `{}` is not encrypted under the unit master key",
+                    s.field, s.object
+                ),
+                remediation: "Re-apply the value through `tmsh`/the GUI so BIG-IP re-encrypts it under the unit master key (`f5mku`), or rotate it if this config was hand-authored and never applied to a device.",
+                source: s.object.clone(),
+                reference: None,
+            }
+        })
+        .collect()
+}
+
+/// PEM markers that indicate a private key IS passphrase-protected — the
+/// value BIG-IP writes for an encrypted `PKCS#1`/legacy key (`Proc-Type: 4,
+/// ENCRYPTED`) or a `PKCS#8` `EncryptedPrivateKeyInfo` block.
+const ENCRYPTED_KEY_MARKERS: &[&str] = &["Proc-Type: 4,ENCRYPTED", "BEGIN ENCRYPTED PRIVATE KEY"];
+
+/// **BIGIP-SEC-005** — plaintext (non-passphrase-protected) private key
+/// material in the UCS filestore. Never reads or reports the key content
+/// itself — only whether a passphrase marker is present.
+fn check_exposed_private_keys(id: &'static str, ctx: &Ctx) -> Vec<Finding> {
+    if ctx.files.is_empty() {
+        return vec![Finding {
+            rule_id: id,
+            severity: Severity::Info,
+            status: Status::NotApplicable,
+            title: "Private-key material could not be inspected",
+            evidence: "no UCS filestore was supplied (a bare config export carries no key files)"
+                .to_owned(),
+            remediation: "Supply a UCS backup to check for unprotected private-key material.",
+            source: "UCS filestore".to_owned(),
+            reference: None,
+        }];
+    }
+
+    let mut out = Vec::new();
+    let mut key_files = 0usize;
+    for f in ctx.files {
+        let Some(o) = f.as_object() else { continue };
+        let path = o.get("path").and_then(J::as_str).unwrap_or("");
+        let Some(content) = o.get("content").and_then(J::as_str) else {
+            continue;
+        };
+        if !content.contains("PRIVATE KEY-----") {
+            continue;
+        }
+        key_files += 1;
+        let protected = ENCRYPTED_KEY_MARKERS.iter().any(|m| content.contains(m));
+        if !protected {
+            out.push(Finding {
+                rule_id: id,
+                severity: Severity::High,
+                status: Status::Confirmed,
+                title: "Unencrypted private key in the archive",
+                evidence: format!("`{path}` carries private-key material with no passphrase-protection marker"),
+                remediation: "Re-key with a passphrase-protected private key, and restrict who can pull UCS backups from this device.",
+                source: path.to_owned(),
+                reference: None,
+            });
+        }
+    }
+    if out.is_empty() {
+        let evidence = if key_files == 0 {
+            "no private-key files were found in the archive".to_owned()
+        } else {
+            format!("{key_files} private-key file(s) found, all passphrase-protected")
+        };
+        out.push(Finding {
+            rule_id: id,
+            severity: Severity::Info,
+            status: Status::Clear,
+            title: "No unprotected private-key material found",
+            evidence,
+            remediation: "No action required.",
+            source: "UCS filestore".to_owned(),
+            reference: None,
+        });
+    }
+    out
+}
+
+/// **BIGIP-SEC-006** — a local account with full bash shell access but no
+/// administrator role. Informational: the built-in `admin` account
+/// shipping with `shell bash` is normal and is not flagged; this looks for
+/// the less-common case of a lesser-privileged account also carrying full
+/// OS shell access.
+fn check_shell_access(id: &'static str, ctx: &Ctx) -> Vec<Finding> {
+    let flagged: Vec<_> = ctx
+        .auth_users
+        .iter()
+        .filter(|u| u.shell == "bash" && !u.has_admin_role)
+        .collect();
+    if flagged.is_empty() {
+        return vec![Finding {
+            rule_id: id,
+            severity: Severity::Info,
+            status: Status::Clear,
+            title: "No non-administrative account has shell access",
+            evidence: "every `auth user` with `shell bash` also carries an admin role".to_owned(),
+            remediation: "No action required.",
+            source: "auth user".to_owned(),
+            reference: None,
+        }];
+    }
+    flagged
+        .into_iter()
+        .map(|u| Finding {
+            rule_id: id,
+            severity: Severity::Low,
+            status: Status::Confirmed,
+            title: "Non-administrative account has full shell access",
+            evidence: format!("`{}` has `shell bash` without an admin role", u.name),
+            remediation: "Set `shell tmsh` unless this account genuinely needs OS-level access, and review why it was granted.",
+            source: u.full_path.clone(),
+            reference: None,
+        })
+        .collect()
+}
+
+/// One entry in the rule table: a stable id plus the function that produces
+/// this rule's findings from the gathered [`Ctx`]. Extend the report's
+/// Security coverage by adding a row here — never by adding a new
+/// `match`/`if` branch to [`collect_security`] itself.
+struct SecurityRule {
+    id: &'static str,
+    check: fn(&'static str, &Ctx) -> Vec<Finding>,
+}
+
+const RULES: &[SecurityRule] = &[
+    SecurityRule {
+        id: "BIGIP-SEC-001",
+        check: check_default_credentials,
+    },
+    SecurityRule {
+        id: "BIGIP-SEC-002",
+        check: check_snmp_communities,
+    },
+    SecurityRule {
+        id: "BIGIP-SEC-003",
+        check: check_password_policy,
+    },
+    SecurityRule {
+        id: "BIGIP-SEC-004",
+        check: check_plaintext_secrets,
+    },
+    SecurityRule {
+        id: "BIGIP-SEC-005",
+        check: check_exposed_private_keys,
+    },
+    SecurityRule {
+        id: "BIGIP-SEC-006",
+        check: check_shell_access,
+    },
+];
+
+/// Run every [`RULES`] entry against `source` (this device's SCF/config
+/// text) and `files` (its UCS file inventory, empty for a bare config —
+/// see [`crate::forensics::collect_forensics`] for the same shape), and
+/// return `{findings: [...], counts: {critical, high, medium, low, info},
+/// actionable}` for the report's Security tab.
+///
+/// `actionable` counts findings whose `status` is `confirmed` or
+/// `could_not_inspect` — the ones worth a human's attention; `clear` and
+/// `not_applicable` findings are still returned (for the "we checked, no
+/// forgotten defaults were found" states the issue's acceptance criteria
+/// asks the report to distinguish) but never inflate the review count.
+#[must_use]
+pub fn collect_security(source: &str, files: &[J]) -> J {
+    let ctx = Ctx::build(source, files);
+    let mut findings = Vec::new();
+    for rule in RULES {
+        findings.extend((rule.check)(rule.id, &ctx));
+    }
+
+    let mut counts: Map<String, J> = Map::new();
+    for sev in [
+        Severity::Critical,
+        Severity::High,
+        Severity::Medium,
+        Severity::Low,
+        Severity::Info,
+    ] {
+        let n = findings.iter().filter(|f| f.severity == sev).count();
+        counts.insert(sev.as_str().into(), J::from(n));
+    }
+    let actionable = findings
+        .iter()
+        .filter(|f| matches!(f.status, Status::Confirmed | Status::CouldNotInspect))
+        .count();
+
+    json!({
+        "findings": findings.iter().map(Finding::to_json).collect::<Vec<_>>(),
+        "counts": counts,
+        "actionable": actionable,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sec(source: &str) -> J {
+        collect_security(source, &[])
+    }
+    fn sec_with_files(source: &str, files: &[J]) -> J {
+        collect_security(source, files)
+    }
+
+    fn findings_for<'a>(model: &'a J, rule_id: &str) -> Vec<&'a J> {
+        model["findings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|f| f["id"] == rule_id)
+            .collect()
+    }
+
+    fn statuses<'a>(findings: &[&'a J]) -> Vec<&'a str> {
+        findings
+            .iter()
+            .map(|f| f["status"].as_str().unwrap())
+            .collect()
+    }
+
+    // ---- BIGIP-SEC-001: default credentials ----------------------------
+
+    #[test]
+    fn true_positive_default_admin_password_is_confirmed() {
+        // admin/admin, SHA-512-crypt.
+        let m = sec(
+            "auth user /Common/admin {\n    encrypted-password $6$abcsalt12$xVTHU6Ifw7m21v5IXNpEQM1G/HDajebt/qt8a3FrnxzBmgXWpecsAYQNalE3Oaotb83HDNkXt3gc4TbJMjplv1\n}\n",
+        );
+        let f = findings_for(&m, "BIGIP-SEC-001");
+        assert!(
+            f.iter()
+                .any(|x| x["status"] == "confirmed" && x["severity"] == "critical"),
+            "{f:?}"
+        );
+    }
+
+    #[test]
+    fn false_positive_guard_non_default_admin_password_is_clear() {
+        // A real (non-default) password must never be reported as confirmed.
+        let m = sec(
+            "auth user /Common/admin {\n    encrypted-password $6$abcsalt12$VE9mg4.EMW/6CgwAVZO84sWEJUut.3QT0a8eCMuNdhzUkUSRRprlIxSXEdBnv7bEzDyJu76xurILc4Ccw9Yn61\n}\n",
+        );
+        let f = findings_for(&m, "BIGIP-SEC-001");
+        assert!(
+            f.iter()
+                .any(|x| x["source"] == "auth user /Common/admin" && x["status"] == "clear"),
+            "{f:?}"
+        );
+        assert!(
+            !f.iter().any(|x| x["status"] == "confirmed"),
+            "a non-default password must never be confirmed: {f:?}"
+        );
+    }
+
+    #[test]
+    fn true_negative_no_admin_user_present_is_not_applicable() {
+        let m = sec("ltm pool /Common/p { }\n");
+        let f = findings_for(&m, "BIGIP-SEC-001");
+        assert_eq!(statuses(&f), vec!["not_applicable", "not_applicable"]);
+    }
+
+    #[test]
+    fn false_negative_now_caught_root_default_via_shadow_file() {
+        // `root` never appears as an `auth user` stanza — it's an OS account
+        // only visible via the UCS `/etc/shadow`. Before UCS-inventory support
+        // this would be a false negative (silently unchecked); now it's caught.
+        let files = vec![json!({
+            "path": "etc/shadow",
+            "content": "root:$6$abcsalt12$xVTHU6Ifw7m21v5IXNpEQM1G/HDajebt/qt8a3FrnxzBmgXWpecsAYQNalE3Oaotb83HDNkXt3gc4TbJMjplv1:19000:0:99999:7:::\n",
+        })];
+        let m = sec_with_files("ltm pool /Common/p { }\n", &files);
+        let f = findings_for(&m, "BIGIP-SEC-001");
+        // Not "root/default" — this shadow line's hash is the admin/admin
+        // vector reused for a different user, so it must NOT verify against
+        // "default"; assert instead that the source is inspected at all
+        // (status is confirmed/clear, not not_applicable) now that a shadow
+        // entry exists.
+        let root = f
+            .iter()
+            .find(|x| x["source"] == "etc/shadow")
+            .expect("root shadow entry inspected");
+        assert_ne!(root["status"], "not_applicable");
+    }
+
+    #[test]
+    fn shadow_root_default_password_confirmed() {
+        let files = vec![json!({
+            "path": "etc/shadow",
+            "content": "root:$6$rounds=5000$saltstring$6p43fZYI.QjsRRE84rwofulMnyqp504VY9sFYK14/NXu6XfSJmmWs.6LU23LEbtyE.wFHWhcL9ahBHbNgfPCc1:19000:0:99999:7:::\n",
+        })];
+        let m = sec_with_files("ltm pool /Common/p { }\n", &files);
+        let f = findings_for(&m, "BIGIP-SEC-001");
+        assert!(
+            f.iter()
+                .any(|x| x["source"] == "etc/shadow" && x["status"] == "confirmed"),
+            "{f:?}"
+        );
+    }
+
+    #[test]
+    fn malformed_and_unsupported_hash_formats_fail_closed() {
+        // Classic DES-crypt (no `$` prefix) — must never be confirmed/clear,
+        // only "could not inspect". `root` has no credential source at all in
+        // this source, so it stays "not applicable"; only the `admin` result
+        // (this fixture's actual subject) matters here.
+        let m = sec("auth user /Common/admin {\n    encrypted-password xOAFZqRz5RduI\n}\n");
+        let f = findings_for(&m, "BIGIP-SEC-001");
+        let admin = f
+            .iter()
+            .find(|x| x["source"] == "auth user /Common/admin")
+            .expect("admin credential inspected");
+        assert_eq!(admin["status"], "could_not_inspect");
+        assert!(
+            !f.iter()
+                .any(|x| x["status"] == "confirmed" || x["status"] == "clear"),
+            "an unsupported format must never be confirmed or clear: {f:?}"
+        );
+    }
+
+    #[test]
+    fn locked_account_is_not_applicable_not_confirmed() {
+        let m = sec("auth user /Common/admin {\n    encrypted-password !!\n}\n");
+        let f = findings_for(&m, "BIGIP-SEC-001");
+        let admin = f
+            .iter()
+            .find(|x| x["source"] == "auth user /Common/admin")
+            .expect("admin credential inspected");
+        assert_eq!(admin["status"], "not_applicable");
+        assert!(!f.iter().any(|x| x["status"] == "confirmed"));
+    }
+
+    #[test]
+    fn missing_credential_material_is_not_applicable() {
+        let m = sec("auth user /Common/opsUser {\n    shell tmsh\n}\n");
+        let f = findings_for(&m, "BIGIP-SEC-001");
+        // Neither root nor admin present at all.
+        assert_eq!(statuses(&f), vec!["not_applicable", "not_applicable"]);
+    }
+
+    #[test]
+    fn no_secret_values_leak_into_the_model() {
+        let m = sec(
+            "auth user /Common/admin {\n    encrypted-password $6$abcsalt12$xVTHU6Ifw7m21v5IXNpEQM1G/HDajebt/qt8a3FrnxzBmgXWpecsAYQNalE3Oaotb83HDNkXt3gc4TbJMjplv1\n}\n",
+        );
+        let dump = serde_json::to_string(&m).unwrap();
+        assert!(
+            !dump.contains("$6$"),
+            "stored hash must never appear in the model: {dump}"
+        );
+        assert!(
+            !dump.contains("abcsalt12"),
+            "salt must never appear in the model: {dump}"
+        );
+    }
+
+    // ---- BIGIP-SEC-002: SNMP communities --------------------------------
+
+    #[test]
+    fn true_positive_default_snmp_community_rw_is_high() {
+        let m = sec(
+            "sys snmp {\n    communities {\n        c1 {\n            community-name public\n            access rw\n        }\n    }\n}\n",
+        );
+        let f = findings_for(&m, "BIGIP-SEC-002");
+        assert!(
+            f.iter()
+                .any(|x| x["status"] == "confirmed" && x["severity"] == "high"),
+            "{f:?}"
+        );
+    }
+
+    #[test]
+    fn true_positive_default_snmp_community_ro_is_medium() {
+        let m = sec(
+            "sys snmp {\n    communities {\n        c1 {\n            community-name private\n            access ro\n        }\n    }\n}\n",
+        );
+        let f = findings_for(&m, "BIGIP-SEC-002");
+        assert!(
+            f.iter()
+                .any(|x| x["status"] == "confirmed" && x["severity"] == "medium"),
+            "{f:?}"
+        );
+    }
+
+    #[test]
+    fn false_positive_guard_custom_community_name_is_clear() {
+        // A stanza *label* that looks default (e.g. "comm-public") must not
+        // trip the rule when the actual `community-name` value is custom.
+        let m = sec(
+            "sys snmp {\n    communities {\n        comm-public {\n            community-name a-real-secret-string\n            access ro\n        }\n    }\n}\n",
+        );
+        let f = findings_for(&m, "BIGIP-SEC-002");
+        assert_eq!(statuses(&f), vec!["clear"]);
+        let dump = serde_json::to_string(&f).unwrap();
+        assert!(
+            !dump.contains("a-real-secret-string"),
+            "custom community string must not be echoed: {dump}"
+        );
+    }
+
+    #[test]
+    fn true_negative_no_snmp_configured() {
+        let m = sec("ltm pool /Common/p { }\n");
+        let f = findings_for(&m, "BIGIP-SEC-002");
+        assert_eq!(statuses(&f), vec!["clear"]);
+    }
+
+    // ---- BIGIP-SEC-003: password policy ---------------------------------
+
+    #[test]
+    fn true_positive_password_policy_disabled() {
+        let m = sec("auth password-policy {\n    policy-enforcement disabled\n}\n");
+        let f = findings_for(&m, "BIGIP-SEC-003");
+        assert!(
+            f.iter()
+                .any(|x| x["status"] == "confirmed" && x["severity"] == "high"),
+            "{f:?}"
+        );
+    }
+
+    #[test]
+    fn true_positive_min_length_weak() {
+        let m = sec(
+            "auth password-policy {\n    policy-enforcement enabled\n    minimum-length 6\n}\n",
+        );
+        let f = findings_for(&m, "BIGIP-SEC-003");
+        assert!(f.iter().any(|x| x["status"] == "confirmed"), "{f:?}");
+    }
+
+    #[test]
+    fn false_positive_guard_strong_policy_is_clear() {
+        let m = sec(
+            "auth password-policy {\n    policy-enforcement enabled\n    minimum-length 14\n}\n",
+        );
+        let f = findings_for(&m, "BIGIP-SEC-003");
+        assert_eq!(statuses(&f), vec!["clear"]);
+    }
+
+    #[test]
+    fn missing_password_policy_could_not_inspect() {
+        let m = sec("ltm pool /Common/p { }\n");
+        let f = findings_for(&m, "BIGIP-SEC-003");
+        assert_eq!(statuses(&f), vec!["could_not_inspect"]);
+    }
+
+    // ---- BIGIP-SEC-004: plaintext secrets --------------------------------
+
+    #[test]
+    fn true_positive_plaintext_secret_detected() {
+        let m = sec("ltm monitor https /Common/mon {\n    password clearpw\n}\n");
+        let f = findings_for(&m, "BIGIP-SEC-004");
+        assert!(f.iter().any(|x| x["status"] == "confirmed"), "{f:?}");
+        let dump = serde_json::to_string(&f).unwrap();
+        assert!(
+            !dump.contains("clearpw"),
+            "the plaintext value must never be echoed: {dump}"
+        );
+    }
+
+    #[test]
+    fn false_positive_guard_encrypted_secret_is_clear() {
+        let m = sec(
+            "auth radius-server /Common/r {\n    secret $M$mn$9uYx+bTjLD8YSGZAUEfFwHvpSDwZsL25kZxdn5NZmCI=\n}\n",
+        );
+        let f = findings_for(&m, "BIGIP-SEC-004");
+        assert_eq!(statuses(&f), vec!["clear"]);
+    }
+
+    // ---- BIGIP-SEC-005: exposed private keys -----------------------------
+
+    #[test]
+    fn true_positive_unprotected_private_key() {
+        let files = vec![json!({
+            "path": "config/ssl/ssl.key/x.key",
+            "content": "-----BEGIN RSA PRIVATE KEY-----\nMII...\n-----END RSA PRIVATE KEY-----\n",
+        })];
+        let m = sec_with_files("ltm pool /Common/p { }\n", &files);
+        let f = findings_for(&m, "BIGIP-SEC-005");
+        assert!(
+            f.iter()
+                .any(|x| x["status"] == "confirmed" && x["severity"] == "high"),
+            "{f:?}"
+        );
+    }
+
+    #[test]
+    fn false_positive_guard_passphrase_protected_key_is_clear() {
+        let files = vec![json!({
+            "path": "config/ssl/ssl.key/x.key",
+            "content": "-----BEGIN RSA PRIVATE KEY-----\nProc-Type: 4,ENCRYPTED\nDEK-Info: AES-256-CBC,ABCDEF\n\nMII...\n-----END RSA PRIVATE KEY-----\n",
+        })];
+        let m = sec_with_files("ltm pool /Common/p { }\n", &files);
+        let f = findings_for(&m, "BIGIP-SEC-005");
+        assert_eq!(statuses(&f), vec!["clear"]);
+    }
+
+    #[test]
+    fn no_ucs_files_is_not_applicable() {
+        let m = sec("ltm pool /Common/p { }\n");
+        let f = findings_for(&m, "BIGIP-SEC-005");
+        assert_eq!(statuses(&f), vec!["not_applicable"]);
+    }
+
+    // ---- BIGIP-SEC-006: shell access --------------------------------------
+
+    #[test]
+    fn true_positive_non_admin_bash_shell_flagged() {
+        let m = sec(
+            "auth user /Common/opsUser {\n    partition-access {\n        Common {\n            role manager\n        }\n    }\n    shell bash\n}\n",
+        );
+        let f = findings_for(&m, "BIGIP-SEC-006");
+        assert!(f.iter().any(|x| x["status"] == "confirmed"), "{f:?}");
+    }
+
+    #[test]
+    fn false_positive_guard_admin_bash_shell_not_flagged() {
+        let m = sec(
+            "auth user /Common/admin {\n    partition-access {\n        all-partitions {\n            role admin\n        }\n    }\n    shell bash\n}\n",
+        );
+        let f = findings_for(&m, "BIGIP-SEC-006");
+        assert_eq!(statuses(&f), vec!["clear"]);
+    }
+
+    #[test]
+    fn false_positive_guard_tmsh_shell_not_flagged() {
+        let m = sec(
+            "auth user /Common/opsUser {\n    partition-access {\n        Common {\n            role manager\n        }\n    }\n    shell tmsh\n}\n",
+        );
+        let f = findings_for(&m, "BIGIP-SEC-006");
+        assert_eq!(statuses(&f), vec!["clear"]);
+    }
+
+    // ---- overall model shape ----------------------------------------------
+
+    #[test]
+    fn counts_reflect_severities() {
+        let m = sec(
+            "auth user /Common/admin {\n    encrypted-password $6$abcsalt12$xVTHU6Ifw7m21v5IXNpEQM1G/HDajebt/qt8a3FrnxzBmgXWpecsAYQNalE3Oaotb83HDNkXt3gc4TbJMjplv1\n}\n",
+        );
+        assert!(m["counts"]["critical"].as_u64().unwrap() >= 1);
+        assert!(m["actionable"].as_u64().unwrap() >= 1);
+    }
+
+    #[test]
+    fn model_is_json_serialisable() {
+        let m = sec(
+            "auth user /Common/admin {\n    encrypted-password $6$abc$def\n}\nsys snmp {\n    communities {\n        c { community-name public }\n    }\n}\nauth password-policy {\n    policy-enforcement disabled\n}\n",
+        );
+        serde_json::to_string(&m).expect("model serialises");
+    }
+}

--- a/rust/bigip-report-gen/rust/tests/report.rs
+++ b/rust/bigip-report-gen/rust/tests/report.rs
@@ -496,6 +496,59 @@ fn no_forensics_tab_without_files() {
 }
 
 #[test]
+fn security_tab_flags_default_admin_credential() {
+    // admin/admin, SHA-512-crypt — the flagship default-credential check.
+    //
+    // The *finding* itself never carries the stored hash/salt/candidate (see
+    // `security::tests::no_secret_values_leak_into_the_model` for that
+    // property, checked directly against `collect_security`'s own JSON). This
+    // test can't repeat that assertion against the full rendered document: the
+    // report deliberately re-embeds the entire raw source text verbatim
+    // elsewhere (`configText`, for the in-browser query console) — same as it
+    // always has for `secrets.rs`'s own values — so the hash legitimately
+    // appears in the page regardless of what the Security tab does with it.
+    let scf = "auth user /Common/admin {\n    encrypted-password $6$abcsalt12$xVTHU6Ifw7m21v5IXNpEQM1G/HDajebt/qt8a3FrnxzBmgXWpecsAYQNalE3Oaotb83HDNkXt3gc4TbJMjplv1\n}\n";
+    let opts = RenderOptions {
+        title: "Security".into(),
+        generated_at: String::new(),
+        embed_console: false,
+        ..Default::default()
+    };
+    let html = build_report(&[("x.conf".to_string(), scf.to_string())], &opts).expect("render");
+    assert!(
+        html.contains("data-panel=\"security\""),
+        "security tab/panel present"
+    );
+    assert!(
+        html.contains("BIGIP-SEC-001"),
+        "default-credential rule id embedded"
+    );
+    assert!(
+        html.contains("critical") && html.contains("confirmed"),
+        "confirmed critical finding embedded"
+    );
+}
+
+#[test]
+fn security_tab_present_even_with_no_findings_to_confirm() {
+    // A bare config with nothing to check still shows the tab (positive
+    // assurance / documented limitation), never an alarming false positive.
+    let opts = RenderOptions {
+        title: "Security".into(),
+        generated_at: String::new(),
+        embed_console: false,
+        ..Default::default()
+    };
+    let sources = vec![("x.conf".to_string(), "ltm pool /Common/p { }\n".to_string())];
+    let html = build_report(&sources, &opts).expect("render");
+    assert!(html.contains("data-panel=\"security\""));
+    assert!(
+        !html.contains("\"status\":\"confirmed\""),
+        "nothing confirmed for a bare LTM-only config"
+    );
+}
+
+#[test]
 fn console_can_be_disabled() {
     let sources = vec![load("lab-device-01.ucs")];
     let opts = RenderOptions {

--- a/rust/bigip-report-gen/templates/report.html.j2
+++ b/rust/bigip-report-gen/templates/report.html.j2
@@ -209,6 +209,7 @@
     <button class="tab" data-panel="dataGroups">Data Groups <span class="n">{{ d.counts.dataGroups }}</span></button>
     <button class="tab" data-panel="profiles">Profiles <span class="n">{{ d.counts.profiles }}</span></button>
     <button class="tab" data-panel="certificates">SSL Certificates <span class="n">{{ d.counts.certificates }}</span></button>
+    <button class="tab" data-panel="security">Security{% if d.counts.security %} <span class="n">{{ d.counts.security }}</span>{% endif %}</button>
     {% if d.counts.secrets %}<button class="tab" data-panel="secrets">Secrets <span class="n">{{ d.counts.secrets }}</span></button>{% endif %}
     {% if d.counts.apmProfiles %}<button class="tab" data-panel="apm">APM <span class="n">{{ d.counts.apmProfiles }}</span></button>{% endif %}
     {% if d.counts.gtm %}<button class="tab" data-panel="gtm">GTM / DNS <span class="n">{{ d.counts.gtm }}</span></button>{% endif %}
@@ -471,6 +472,37 @@
     </div>
     {% else %}
     <p class="hint">No <code>sys file ssl-cert</code> objects in this config. A UCS backup or a full config save (<code>tmsh save sys config</code>) includes them; a partial <code>bigip.conf</code> that only defines LTM objects may not.</p>
+    {% endif %}
+  </div>
+
+  {#: ---------------- Security ---------------- :#}
+  <div class="panel" data-panel="security">
+    <p class="lm-field-note">A small, high-confidence set of offline security-posture checks — factory/default credentials, SNMP and password-policy weaknesses, plaintext secrets, unprotected private-key material, and shell-access review. Detection is entirely passive: nothing here authenticates to the device or makes a network request, and no password, hash, salt, master key, private key or decrypted secret value is ever shown. <b>Confirmed</b> findings need action; <b>clear</b> means the check ran and found nothing; <b>not applicable</b> means there was nothing to check (e.g. no such account); <b>could not inspect</b> means the material is present but not in a form this generator can verify (see each finding's remediation). A partial <code>bigip.conf</code> with no UCS filestore will show more "not applicable"/"could not inspect" results — this is expected, not a bug.</p>
+    <div class="security-summary">
+      {% for sev in ['critical', 'high', 'medium', 'low', 'info'] %}
+      {% if d.security.counts[sev] %}<span class="tag {% if sev in ['critical', 'high'] %}red{% elif sev == 'medium' %}amber{% else %}blue{% endif %}">{{ d.security.counts[sev] }} {{ sev }}</span>{% endif %}
+      {% endfor %}
+    </div>
+    {% if d.security.findings %}
+    <div class="tablewrap">
+    <table class="grid security-grid">
+      <thead><tr><th>Finding</th><th>Severity</th><th>Status</th><th>Evidence</th><th>Source</th><th>Remediation</th></tr></thead>
+      <tbody>
+      {% for f in d.security.findings %}
+      <tr class="searchable" data-search="{{ f.id }} {{ f.title }} {{ f.source }}">
+        <td class="mono small">{{ f.id }}<div>{{ f.title }}</div></td>
+        <td><span class="tag {% if f.severity in ['critical', 'high'] %}red{% elif f.severity == 'medium' %}amber{% else %}blue{% endif %}">{{ f.severity }}</span></td>
+        <td><span class="tag {% if f.status == 'confirmed' %}red{% elif f.status == 'clear' %}green{% else %}amber{% endif %}">{{ f.status | replace('_', ' ') }}</span></td>
+        <td class="small">{{ f.evidence }}</td>
+        <td class="mono small">{{ f.source }}</td>
+        <td class="small">{{ f.remediation }}{% if f.reference %} <a href="{{ f.reference }}">Reference</a>{% endif %}</td>
+      </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    </div>
+    {% else %}
+    <p class="hint">No security findings were produced for this source.</p>
     {% endif %}
   </div>
 


### PR DESCRIPTION
## Summary

- Adds baseline BIG-IP security misconfiguration findings to the report generator, covering the checks scoped in the issue.
- Closes #1211.

Part of the per-group PR series; independent of the other groups. Builds on the BIG-IP 21.1 report defaults already on `rust` (#1206).

## Validation

- [x] On the group branch: report-generation suites and fixture diffs — green at development time.
- [x] Rebased onto `rust` (post-#1212): `cargo check --workspace --all-targets` — 0 errors.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract? — No (report content only).
- [ ] KCS note — n/a.
- [ ] Linked — n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_