### PR TITLE
BPF-Tcl: registry-described IR contracts, kernel codegen, typed event schemas (#1202, #1203, #1204)

### DIFF
--- a/docs/design/compiler/ebpf-backend.md
+++ b/docs/design/compiler/ebpf-backend.md
@@ -1,7 +1,9 @@
 # BPF-Tcl eBPF backend architecture and production roadmap
 
 > **Status:** Experimental multi-target backend, kernel codegen landed
-> 2026-08-04 (issue #1203).
+> 2026-08-04 (issue #1203). Event framework, handler composition, typed
+> ring-buffer records, and the loader/link lifecycle model landed 2026-08-04
+> (issue #1204).
 > The default target runs under the bundled `rbpf` harness. The explicit
 > `kernel-xdp` and `kernel-socket` targets emit Linux-loadable objects with real
 > `struct xdp_md` / `struct __sk_buff` context lowering, verifier-safe packet
@@ -9,8 +11,15 @@
 > the objects with `readelf`/`llvm-objdump` and an in-repo verifier model;
 > genuine kernel `bpf()` load and `BPF_PROG_TEST_RUN` acceptance is gated behind
 > an `#[ignore]`d privileged test (`rust/bpf-tcl/tests/kernel_load.rs`), since
-> loading needs root and a live kernel. Live attachment (links/pins) remains
-> issue #1204 work.
+> loading needs root and a live kernel. The event framework adds a typed,
+> registry-described event schema (XDP, socket filter, and schema-described TC /
+> cgroup families), explicit `next`-based handler composition, a versioned
+> userspace record ABI with ring-buffer transport and loss accounting, and a
+> loader/link lifecycle state machine (plan → load → test-run → attach → status →
+> detach, with rollback and resource ownership). The lifecycle is modelled and
+> unit-tested deterministically in userspace over a `ModelKernel`; real
+> attachment (`bpf()` links/pins on a live interface or cgroup) is gated behind
+> `#[ignore]`d privileged tests (`rust/bpf-tcl/tests/kernel_attach.rs`).
 
 ## Purpose
 
@@ -159,7 +168,9 @@ kernel), so a maintainer re-runs it on a Linux host — see
 
 ## Layer 2: typed low-level language and BPF-IR
 
-The low-level language is deliberately closed. Its 25 registered commands are:
+The low-level language is deliberately closed. Its 26 registered commands are
+(the 26th, `next`, is the explicit non-terminal composition outcome — issue
+#1204):
 
 | Group | Commands | Meaning |
 |---|---|---|
@@ -169,6 +180,7 @@ The low-level language is deliberately closed. Its 25 registered commands are:
 | Control flow | `if`, `loop` | Branch, or expand a literal-count loop up to 64 iterations before CFG construction. |
 | Socket verdicts | `accept`, `drop` | Return an accepted byte count or zero. |
 | XDP verdicts | `pass`, `drop`, `tx` | Return `XDP_PASS`, `XDP_DROP`, or `XDP_TX`. |
+| Composition | `next` | Explicit non-terminal continuation: end a path without a decision so the next handler in priority order runs (issue #1204). |
 | Framework | `when`, `profile`, `field`, `template`, `use`, `allow`, `deny`, `attach` | Declare handlers and expand policy/configuration conveniences. |
 
 Expressions support signed integer arithmetic, bitwise operations, shifts, and
@@ -223,23 +235,105 @@ The framework processes declarations in this order:
 8. apply matching `attach` metadata; and
 9. sort programs by ascending priority and event name.
 
-### Events handled today
+### The event schema (issue #1204)
 
-| Event | Alias | Input available to the program | Valid explicit verdicts | Targets |
-|---|---|---|---|---|
-| `SOCKET_FILTER` | `SOCKET` | Packet bytes and length (`__sk_buff` on the kernel) | `accept ?N?`, `drop` | `rbpf` simulator; `--target kernel-socket` emits a loadable object (accepted byte count / `0`). |
-| `XDP` | — | Packet bytes and length (`xdp_md` on the kernel) | `pass`, `drop`, `tx` | `rbpf` simulator; `--target kernel-xdp` emits a loadable object (XDP action number). |
+Every event is a **typed registry contract** — a `BpfEventSpec` in
+`tcl-registry/src/bpf_op.rs`, resolved by `bpf-tcl-ir::event` — not a
+string-match arm. Each spec carries: canonical name + aliases; Linux program
+type and ELF `SEC(...)` convention; a typed context (`struct` name + readable
+fixed-offset fields with byte order); a permitted-capability set (packet read,
+map read/write, ring-buffer output, context read); the verdict algebra
+(permitted terminal verdicts + a **default verdict** applied when no handler
+terminates); the `attach` parameter schema; minimum kernel / BTF / `bpf_link`
+requirements; the output kind (packet decision, userspace record, or both); and
+a codegen-readiness flag. `check` prints the resolved contract for each handler.
 
-There are no TC, cgroup, tracepoint, kprobe, uprobe, perf-event, LSM, socket-op,
-or syscall events. There is no event-specific metadata such as interface index,
-queue, process ID, user ID, cgroup, socket tuple, tracepoint fields, or return
-value. There is also no ring buffer or perf buffer for sending records to
-userspace.
+| Event | Alias | Context | Verdicts (+`next`) | Default | Codegen |
+|---|---|---|---|---|---|
+| `SOCKET_FILTER` | `SOCKET` | `__sk_buff` | `accept ?N?`, `drop` | `accept` | ready (`--target kernel-socket`) |
+| `XDP` | — | `xdp_md` | `pass`, `drop`, `tx` | `pass` | ready (`--target kernel-xdp`) |
+| `TC_INGRESS` | `TC` | `__sk_buff` | `pass`, `drop` | `pass` | schema-described |
+| `TC_EGRESS` | — | `__sk_buff` | `pass`, `drop` | `pass` | schema-described |
+| `CGROUP_CONNECT4` | — | `bpf_sock_addr` | `pass`, `drop` | `pass` | schema-described |
+| `CGROUP_BIND4` | — | `bpf_sock_addr` | `pass`, `drop` | `pass` | schema-described |
 
-Multiple handlers are separate programs. Priority currently controls only
-their order in the `BpfModule` and CLI program indexes; it does not generate a
-dispatcher, program array, tail-call chain, or link ordering. An external
-loader therefore cannot yet preserve the apparent multi-handler semantics.
+The TC and cgroup events are *fully described* (context, capabilities, verdict
+algebra, attach params, kernel requirements) but their codegen (SCHED_CLS /
+CGROUP_SOCK_ADDR lowering) is sequenced for a later change. A `when TC_INGRESS`
+handler resolves its schema and is rejected with a **precise** "registry-described
+but its codegen is not yet implemented" diagnostic — never treated as an unknown
+event. Tracepoints/kprobes/uprobes and LSM remain out of the schema until typed
+ring-buffer records (now available, see below) and stronger deployment
+guarantees are wired to codegen.
+
+### Handler composition
+
+Multiple `when EVENT priority N { … }` handlers of one event compose into an
+ordered **handler chain** (`bpf-tcl-ir::compose`) with explicit, tested
+semantics:
+
+- **lower priority numbers run first** (F5-inspired), event name as a stable
+  tiebreaker;
+- **a terminal verdict stops the chain** — the first `accept`/`drop`/`pass`/`tx`
+  decides;
+- **continuation is explicit** — a handler continues only by ending a path with
+  `next`, which lowers to a reserved continuation sentinel return
+  (`CONTINUE_SENTINEL`);
+- **each event declares its default** — if every handler yields `next`, the
+  event's `default_verdict` applies;
+- **ambiguous composition is rejected** — two handlers of one event sharing a
+  priority have no deterministic order and are a hard `AmbiguousComposition`
+  error ("sorting independent object files is not sufficient").
+
+These are the *source* semantics. The *deployment* semantics are a **verified
+program chain**: each handler is compiled independently, and the chain is
+evaluated by running the handlers in priority order and classifying each one's
+return value with `Outcome::classify` — a dispatcher expressed in the loader
+rather than fused into one object. Because the rules are pure over the
+per-handler outcomes, composition is deterministic and unit-tested in userspace
+(`bpf-tcl/tests/composition.rs` runs a two-handler deny/audit chain under `rbpf`).
+
+### Userspace event channel
+
+Observability events emit **typed records** to userspace rather than a verdict.
+`bpf-tcl-ir::ringbuf` defines a versioned record ABI (a fixed 16-byte
+little-endian header carrying magic, ABI version, event type, payload length,
+and a sequence number, followed by the schema's fields packed at their declared
+widths and byte order), a `RecordSchema` generated from an event's context
+fields, a bounded `RingBuffer` transport with explicit **loss accounting**
+(records that do not fit are dropped whole and counted — the same
+lossy-but-counted contract as the kernel `BPF_MAP_TYPE_RINGBUF` under
+back-pressure), and a structured JSON/text consumer. A consumer rejects a record
+whose magic or version it does not recognise, so the transport can evolve
+without silently misreading old records
+(`bpf-tcl/tests/observability.rs` exercises the whole producer → ring buffer →
+JSON consumer path).
+
+### Loader and link lifecycle
+
+`bpf-tcl-ir::loader` models the deployment state machine
+`plan → load → test-run → attach → status → detach`:
+
+- `DeploymentPlan::from_module` builds a plan from a compiled module, giving each
+  program a **unique, ownership-labelled pin path** under
+  `/sys/fs/bpf/bpftcl/<deployment>/`;
+- `load` verifier-loads every program (atomic: a partial failure unloads
+  everything already loaded);
+- `test-run` runs a supported program through `BPF_PROG_TEST_RUN` before any live
+  attach (dry-run is the obvious path);
+- `attach` creates a pinned link per program (a partial failure rolls back only
+  the links created in that call and stays in `Loaded`);
+- `detach` removes **only** this deployment's owned resources and **refuses to
+  touch a pin owned by anything else**;
+- `status` reports the live programs, links, and pins.
+
+Every kernel effect goes through the `KernelOps` trait. The lifecycle is
+unit-tested deterministically over a `ModelKernel` (rollback, ownership refusal,
+out-of-order rejection, no-leak cleanup) with **no kernel required**; the CLI
+`plan` subcommand renders a dry-run plan. Real `bpf()`-syscall attachment is
+exercised only by the `#[ignore]`d privileged tests
+(`bpf-tcl/tests/kernel_attach.rs`), which run inside a disposable network
+namespace that is torn down unconditionally so nothing leaks onto the host.
 
 ## Profiles, templates, capabilities, and deployment metadata
 
@@ -277,12 +371,38 @@ verifier model (real `bpf()` acceptance is gated behind an `#[ignore]`d test):
    declared byte order on both the rbpf and kernel paths (verified against
    Ethernet/IPv4/TCP fixtures under the simulator). *(Resolved.)*
 
-### Remaining production blocker
+### Event framework and loader (issue #1204) — modelled
 
-1. **No loader or attachment lifecycle.** `attach xdp eth0` does not create a
-   BPF link, configure an interface, pin maps, detach cleanly, or roll back a
-   partial deployment. This — plus handler composition and userspace event
-   channels — is [issue #1204](https://github.com/bitwisecook/tcl-lsp/issues/1204).
+These were the subject of [issue #1204](https://github.com/bitwisecook/tcl-lsp/issues/1204).
+The registry event schema, handler composition, typed ring-buffer records, and
+the loader/link lifecycle **state machine** are implemented and tested
+deterministically in userspace; genuine kernel attachment is gated behind
+`#[ignore]`d privileged tests (this environment has no kernel):
+
+1. **Typed registry event schema.** Events are declared by `BpfEventSpec` data
+   (context, capabilities, verdict algebra + default, attach params, kernel/BTF
+   requirements, output kind), not command/event-name branches. TC ingress/egress
+   and cgroup connect/bind are described; their codegen is sequenced next.
+   *(Resolved for schema; TC/cgroup codegen pending.)*
+2. **Composition with documented source + deployment semantics.** Priority
+   ordering, terminal-verdict stop, explicit `next` continuation, per-event
+   default, and ambiguous-priority rejection are documented and tested; the
+   deployment semantics are a verified per-handler program chain evaluated in
+   priority order. *(Resolved.)*
+3. **Loader/link lifecycle state machine.** `plan`/`load`/`test-run`/`attach`/
+   `status`/`detach` with atomic rollback, ownership-labelled unique pin paths,
+   and refusal to touch foreign pins — modelled over `KernelOps`/`ModelKernel`
+   and unit-tested for no-leak cleanup. *(Resolved as a model; real `bpf()`
+   attach is `#[ignore]`d.)*
+4. **Versioned userspace record ABI.** Typed, schema-generated records with a
+   versioned header, ring-buffer transport, and observable loss accounting.
+   *(Resolved.)*
+
+**Remaining production blocker.** TC / cgroup / tracepoint codegen and a
+privileged real-kernel loader are not yet implemented — the compiler emits only
+XDP and socket-filter objects, and live attach/link creation requires the
+gated privileged path. Wiring the modelled lifecycle to real `bpf()` syscalls
+(and the described TC/cgroup families to codegen) is the follow-up.
 
 ### Low-layer correctness and maintainability
 
@@ -320,25 +440,27 @@ The items in this section were the subject of
    key/value size, capacity, concurrency) with capacity and array-range
    enforcement in the simulator. *(Resolved.)*
 
-### Framework limitations
+### Remaining framework limitations
 
-1. **Priority has no deployment semantics.** It sorts independent artefacts but
-   does not define how their verdicts compose or how later handlers run.
-2. **One global profile, policy, and attach declaration constrain mixed-event
-   files.** Event-specific context and deployment settings need scoped config.
-3. **Fixed packet profiles do not parse protocols.** VLAN tags, variable IPv4
+1. **Scoped configuration is not yet implemented.** Profiles, capability policy,
+   and `attach` are still one-per-file globals. Event/handler scopes (so a
+   mixed-event file can give each event its own context and deployment settings)
+   remain a follow-up; ambiguous *composition* (duplicate priorities) is already
+   rejected.
+2. **Fixed packet profiles do not parse protocols.** VLAN tags, variable IPv4
    header length, fragments, IPv6 extension headers, and tunnels invalidate
    hard-coded transport offsets.
-4. **Events are a two-arm string match.** There is no schema that pairs an event
-   with context type, allowed helpers, attachment parameters, fields, return
-   convention, and minimum kernel capability.
-5. **No userspace event channel exists.** Observability programs need typed
-   records and ring-buffer/perf-buffer delivery, not packet verdicts.
-6. **Privileged kernel-load tests are gated, not automated.** Rootless tests
-   cover the verifier model, structural ELF/BTF/relocation validation, and
-   network-byte-order fixtures, but genuine `bpf()` load + `BPF_PROG_TEST_RUN`
-   acceptance is `#[ignore]`d (needs root and a live kernel) and there is no
-   loader/link-lifecycle or live-namespace test yet.
+3. **TC / cgroup / trace codegen is not implemented.** These events are
+   schema-described (context, verdicts, attach params, kernel requirements) and
+   compose/plan/record correctly, but the compiler cannot yet emit SCHED_CLS,
+   CGROUP_SOCK_ADDR, or tracepoint/kprobe programs — a `when TC_INGRESS` handler
+   is rejected with a precise "codegen pending" diagnostic.
+4. **Privileged load / attach tests are gated, not automated.** Rootless tests
+   cover the verifier model, structural ELF/BTF/relocation validation,
+   network-byte-order fixtures, composition, ring-buffer records, and the loader
+   state machine over a `ModelKernel`; genuine `bpf()` load, `BPF_PROG_TEST_RUN`,
+   and link attachment are `#[ignore]`d (need root and a live kernel) and run
+   inside disposable namespaces that clean up unconditionally.
 
 ## Real-world use cases
 

--- a/docs/design/compiler/ebpf-backend.md
+++ b/docs/design/compiler/ebpf-backend.md
@@ -1,9 +1,16 @@
 # BPF-Tcl eBPF backend architecture and production roadmap
 
-> **Status:** Experimental dual-target backend, audited 2026-08-01.
+> **Status:** Experimental multi-target backend, kernel codegen landed
+> 2026-08-04 (issue #1203).
 > The default target runs under the bundled `rbpf` harness. The explicit
-> `kernel-xdp` target now verifier-loads and test-runs map-free, verdict-only
-> XDP handlers; packet access, maps, and live attachment remain future work.
+> `kernel-xdp` and `kernel-socket` targets emit Linux-loadable objects with real
+> `struct xdp_md` / `struct __sk_buff` context lowering, verifier-safe packet
+> bounds proofs, BTF-defined maps, and map relocations. Rootless tests validate
+> the objects with `readelf`/`llvm-objdump` and an in-repo verifier model;
+> genuine kernel `bpf()` load and `BPF_PROG_TEST_RUN` acceptance is gated behind
+> an `#[ignore]`d privileged test (`rust/bpf-tcl/tests/kernel_load.rs`), since
+> loading needs root and a live kernel. Live attachment (links/pins) remains
+> issue #1204 work.
 
 ## Purpose
 
@@ -26,14 +33,14 @@ flowchart TB
     TclIR["Shared Tcl front-end<br/>lexer → command IR → CFG"]
     BpfIR["BPF-IR<br/>typed slots, blocks, loads, map ops,<br/>branches, typed verdict"]
     Codegen["eBPF codegen<br/>stack-machine lowering, jumps,<br/>raw bytes, disassembly, ELF wrapper"]
-    Rbpf["Current target<br/>rbpf FixedMbuff userspace VM"]
-    Kernel["Current kernel-xdp slice<br/>map-free verdict-only XDP"]
-    Production["Required production expansion<br/>context ABI, verifier proofs,<br/>maps/relocations, loader and links"]
+    Rbpf["Simulator target<br/>rbpf FixedMbuff userspace VM"]
+    Kernel["Kernel targets<br/>kernel-xdp (xdp_md) /<br/>kernel-socket (__sk_buff):<br/>context lowering, verifier proofs,<br/>BTF maps + relocations"]
+    Loader["Loader and links<br/>attach lifecycle, pins,<br/>handler composition (issue #1204)"]
 
     Source --> Framework --> Core --> TclIR --> BpfIR --> Codegen
     Codegen --> Rbpf
     Codegen --> Kernel
-    Kernel -. incomplete .-> Production
+    Kernel -. future .-> Loader
 ```
 
 The important boundary is BPF-IR. Framework conveniences must expand into
@@ -45,42 +52,77 @@ framework.
 ## Layer 1: low-level eBPF code generation
 
 `bpf-tcl-codegen/src/ebpf/` implements an instruction encoder, a two-pass block
-layout, a disassembler, and a hand-written ELF64 relocatable-object writer.
+layout, a disassembler, a hand-written ELF64 relocatable-object writer, a BTF
+writer, and an in-repo verifier model.
 
-The default `rbpf` emitter uses a simple and predictable strategy:
+There are three execution ABIs, selected by [`TargetAbi`](../../../rust/bpf-tcl-codegen/src/ebpf/emit.rs)
+and requested on the CLI with `--target`:
 
-1. `r1` points to an `rbpf` metadata buffer containing 64-bit `data` and
-   `data_end` pointers at offsets 0 and 8.
-2. The prologue copies those pointers into callee-saved `r6` and `r7`.
-3. Every BPF-IR slot owns one eight-byte eBPF stack location.
-4. Each instruction reloads operands into scratch registers, computes the
-   result, and writes it back to the stack.
-5. A second pass resolves block IDs to signed 16-bit relative jumps.
-6. Map operations call userspace helper IDs 1 and 2 with map indexes and
-   integer keys and values passed by value.
+| Target | Context | Packet `data`/`data_end` | Map ABI |
+|---|---|---|---|
+| `rbpf` (default) | `rbpf` metadata buffer | 64-bit words at ctx+0 / ctx+8 | by-value userspace helper ids 1/2/3 |
+| `kernel-xdp` | `struct xdp_md` | 32-bit fields at ctx+0 / ctx+4 | BTF-defined maps + `bpf_map_*` helpers |
+| `kernel-socket` | `struct __sk_buff` | 32-bit fields at ctx+76 / ctx+80 | BTF-defined maps + `bpf_map_*` helpers |
 
-This is a good reference backend: the mapping from BPF-IR to instructions is
-easy to inspect, deterministic, and covered end to end under `rbpf`. Its packet
-and map operations are not a Linux-kernel ABI:
+All three share one lowering strategy:
 
-- XDP's real context is `struct xdp_md`, whose `data` and `data_end` fields are
-  32-bit offsets in the context, not 64-bit pointers at offsets 0 and 8.
-- A socket filter receives `struct __sk_buff`; it does not share the XDP direct
-  packet-access ABI.
-- Packet loads have no emitted `data_end` proof before dereference. The `rbpf`
-  VM bounds-checks them at execution time, but the kernel verifier would reject
-  them.
-- Map helpers need map file descriptors or BTF-defined maps, pointer arguments,
-  helper-compatible value lifetimes, and ELF relocations. The current ELF
-  writer rejects every object containing a map.
-- The ELF writer records a conventional program section and GPL licence, but
-  `attach` is metadata only and there is no loader.
+1. A prologue loads `data` into callee-saved `r6` and `data_end` into `r7` (a
+   verdict-only kernel program that never touches the packet skips the prologue
+   entirely).
+2. Every BPF-IR slot owns one eight-byte eBPF stack location.
+3. Each instruction reloads operands into scratch registers, computes, and
+   writes back to the stack.
+4. A second pass resolves block IDs to signed 16-bit relative jumps and records
+   map-fd relocations.
 
-The explicit `kernel-xdp` ABI omits the simulator prologue and currently accepts
-only map-free XDP programs that do not read packet context. This verdict-only
-slice produces kernel-loadable ELF. Default `bpf-tcl compile --emit elf`
-remains an `rbpf` object for `readelf` and `llvm-objdump`; kernel objects must
-be requested with `--target kernel-xdp`. Neither target performs live
+**Context and packet access.** Under a kernel target the prologue reads the
+32-bit `data`/`data_end` context fields, which the verifier rewrites into a
+`PTR_TO_PACKET` / `PTR_TO_PACKET_END`. Every packet load emits a dominating
+bounds proof before the dereference:
+
+```text
+r2 = r6                 ; r6 holds the packet pointer (data)
+r2 += off + width       ; one past the field
+if r2 <= r7 goto +2     ; in bounds → skip the OOB return
+r0 = <oob verdict>; exit
+r2 = *(width *)(r6 + off)
+```
+
+Because the compared register (`r2 = r6 + C`) and the load base (`r6`) share a
+packet-pointer id, proving `r6 + C <= data_end` teaches the verifier that
+`r6 + off` (with `off < C`) is in bounds — the canonical direct-packet-access
+idiom. The out-of-bounds verdict is the program type's drop value
+(`XDP_DROP` / socket `0`). Multi-byte fields are converted with `BPF_END`
+according to the field's declared byte order.
+
+**Maps.** A kernel map operation spills its integer key (and, for a store, its
+value) into stack scratch cells above the slot region, loads the map file
+descriptor with a pseudo `ld_imm64` (`src = BPF_PSEUDO_MAP_FD`, immediate zero),
+and calls `bpf_map_lookup_elem` / `bpf_map_update_elem`. Each pseudo map-fd load
+is recorded as a relocation the ELF writer emits against the map's symbol, so
+libbpf patches in the real fd at load time. A lookup result is null-checked
+before its value is read.
+
+**BTF-defined maps and relocations.** The ELF writer emits a BTF-defined `.maps`
+section (each map a global object symbol over a zero-filled struct variable), a
+`.BTF` section describing each map's type/key-size/value-size/max-entries via the
+array-encoded libbpf form, and a `.rel<prog>` section with one `R_BPF_64_64`
+entry per map-fd load. `map_flags`, per-CPU map types, and array vs hash all flow
+from the typed `MapDef`. `readelf` and `llvm-objdump` parse the object, and the
+relocations name the map symbols.
+
+**Verifier model.** `verifier.rs` is a rootless structural checker of the safety
+invariants the kernel verifier enforces on our own output: exit reachability,
+correct context-field prologue, a dominating `data_end` proof before every
+packet dereference, a relocation for every pseudo map-fd load, and in-range stack
+accesses. It is *not* the kernel verifier — genuine `bpf()` acceptance is a
+separate `#[ignore]`d privileged test — but it catches a codegen regression that
+would make the kernel reject a program, without needing root.
+
+The `rbpf` simulator target is unchanged: `data`/`data_end` are 64-bit metadata
+words and map helpers pass keys/values by value. `bpf-tcl compile --emit elf`
+defaults to the `rbpf` object for inspection; kernel objects are requested with
+`--target kernel-xdp` or `--target kernel-socket`. No target performs live
 attachment.
 
 ### Linux verifier experiment
@@ -98,13 +140,22 @@ invalid bpf_context access off=0 size=8
 This isolated the first production blocker precisely: ELF structure was not the
 problem. The `rbpf` context prologue is invalid for `struct xdp_md`.
 
-The first fix introduced a separate `kernel-xdp` target and made it reject all
-context and map operations until their verifier-safe lowering exists. A
-five-instruction `pass` handler was then accepted by the Linux 6.17 verifier
-with a stack depth of eight bytes. `BPF_PROG_TEST_RUN` over a 64-byte synthetic
-frame returned `2` (`XDP_PASS`) in 232 ns. Neither experiment attached to an
-interface, and the temporary pins, objects, packets, logs, and copied tool were
-removed from the host.
+The first fix (issue #1205) introduced a separate `kernel-xdp` target as a
+map-free, verdict-only vertical slice. A five-instruction `pass` handler was
+accepted by the Linux 6.17 verifier with a stack depth of eight bytes, and
+`BPF_PROG_TEST_RUN` over a 64-byte synthetic frame returned `2` (`XDP_PASS`) in
+232 ns. Neither experiment attached to an interface, and the temporary pins,
+objects, packets, logs, and copied tool were removed from the host.
+
+Issue #1203 then made context access, packet loads, and maps real for both a
+`kernel-xdp` (`struct xdp_md`) and a `kernel-socket` (`struct __sk_buff`) target,
+with dominating verifier bounds proofs, BTF-defined maps, and `R_BPF_64_64`
+relocations. That kernel codegen is validated in this repository structurally
+(`readelf`/`llvm-objdump`) and against the in-repo verifier model; the privileged
+`bpf()` load + `BPF_PROG_TEST_RUN` acceptance for the packet-access and map
+programs is written but gated behind `#[ignore]` (it needs root and a live
+kernel), so a maintainer re-runs it on a Linux host — see
+`rust/bpf-tcl/tests/kernel_load.rs`.
 
 ## Layer 2: typed low-level language and BPF-IR
 
@@ -174,10 +225,10 @@ The framework processes declarations in this order:
 
 ### Events handled today
 
-| Event | Alias | Input available to the program | Valid explicit verdicts | Current execution |
+| Event | Alias | Input available to the program | Valid explicit verdicts | Targets |
 |---|---|---|---|---|
-| `SOCKET_FILTER` | `SOCKET` | Synthetic packet bytes and length | `accept ?N?`, `drop` | `rbpf` userspace VM; result is an accepted byte count. |
-| `XDP` | — | The same synthetic packet model | `pass`, `drop`, `tx` | `rbpf` userspace VM; result is an XDP action number. |
+| `SOCKET_FILTER` | `SOCKET` | Packet bytes and length (`__sk_buff` on the kernel) | `accept ?N?`, `drop` | `rbpf` simulator; `--target kernel-socket` emits a loadable object (accepted byte count / `0`). |
+| `XDP` | — | Packet bytes and length (`xdp_md` on the kernel) | `pass`, `drop`, `tx` | `rbpf` simulator; `--target kernel-xdp` emits a loadable object (XDP action number). |
 
 There are no TC, cgroup, tracepoint, kprobe, uprobe, perf-event, LSM, socket-op,
 or syscall events. There is no event-specific metadata such as interface index,
@@ -204,25 +255,34 @@ loader therefore cannot yet preserve the apparent multi-handler semantics.
 
 ## Verified design issues
 
-### Production blockers
+### Kernel codegen (issue #1203) — resolved
 
-1. **The kernel target is only a verdict-only vertical slice.** It intentionally
-   rejects context access and maps. XDP context lowering and a separate socket-
-   filter ABI still need to be implemented.
-2. **No verifier-visible packet bounds checks.** Source can guard `pktlen`
-   manually, but the emitted pointer arithmetic and load do not express the
-   proof required by the kernel verifier.
-3. **No kernel maps or relocations.** Map kind, key/value sizes, and capacity
-   are metadata in the simulator; capacity is not enforced. ELF rejects maps.
-4. **Kernel-target packet fields need a kernel context ABI.** The BPF-IR and
-   the rbpf target now interpret multi-byte fields in the declared byte order
-   (built-in profiles default to network order, matching real headers), but the
-   *kernel* XDP/socket-filter context lowering that consumes this is issue
-   #1203 work. On the rbpf target this is resolved; on the kernel target it is
-   pending.
-5. **No loader or attachment lifecycle.** `attach xdp eth0` does not create a
+These were the subject of [issue #1203](https://github.com/bitwisecook/tcl-lsp/issues/1203)
+and are now **implemented**, validated structurally and against the in-repo
+verifier model (real `bpf()` acceptance is gated behind an `#[ignore]`d test):
+
+1. **Explicit target ABIs with separate context lowering.** `rbpf`, `kernel-xdp`
+   (`struct xdp_md`), and `kernel-socket` (`struct __sk_buff`) each own their
+   context field offsets, prologue, and helper ABI. *(Resolved.)*
+2. **Verifier-visible packet bounds checks.** Every packet load emits a
+   dominating `data + off + width <= data_end` proof against the packet pointer,
+   using the shared-id direct-packet-access idiom, and takes the program type's
+   drop verdict on a short packet. *(Resolved.)*
+3. **Kernel maps and relocations.** Kernel targets emit BTF-defined `.maps`, a
+   `.BTF` section, and `R_BPF_64_64` relocations for each pseudo map-fd load;
+   map ops lower to `bpf_map_lookup_elem`/`bpf_map_update_elem` with
+   stack-resident keys/values and null checks. Map kind, key/value size,
+   capacity, and per-CPU concurrency flow from the typed `MapDef`. *(Resolved.)*
+4. **Network-byte-order fields.** Multi-byte loads convert with `BPF_END` per the
+   declared byte order on both the rbpf and kernel paths (verified against
+   Ethernet/IPv4/TCP fixtures under the simulator). *(Resolved.)*
+
+### Remaining production blocker
+
+1. **No loader or attachment lifecycle.** `attach xdp eth0` does not create a
    BPF link, configure an interface, pin maps, detach cleanly, or roll back a
-   partial deployment.
+   partial deployment. This — plus handler composition and userspace event
+   channels — is [issue #1204](https://github.com/bitwisecook/tcl-lsp/issues/1204).
 
 ### Low-layer correctness and maintainability
 
@@ -274,9 +334,11 @@ The items in this section were the subject of
    convention, and minimum kernel capability.
 5. **No userspace event channel exists.** Observability programs need typed
    records and ring-buffer/perf-buffer delivery, not packet verdicts.
-6. **Kernel tests cover only the first verdict-only program.** There is no
-   automated privileged verifier gate, loader/link-lifecycle,
-   network-byte-order, packet-access, map, or live namespace test yet.
+6. **Privileged kernel-load tests are gated, not automated.** Rootless tests
+   cover the verifier model, structural ELF/BTF/relocation validation, and
+   network-byte-order fixtures, but genuine `bpf()` load + `BPF_PROG_TEST_RUN`
+   acceptance is `#[ignore]`d (needs root and a live kernel) and there is no
+   loader/link-lifecycle or live-namespace test yet.
 
 ## Real-world use cases
 
@@ -287,13 +349,15 @@ The items in this section were the subject of
 - Prototype profiles, templates, capability policies, and bounded state logic.
 - Inspect deterministic assembly and structurally valid ELF sections.
 
-### Useful with the current kernel target
+### Useful with the current kernel targets
 
-- Verifier-load and test-run map-free, verdict-only XDP policies.
-- Exercise the full source-to-kernel-object path without attaching to a live
-  interface.
-- Establish a fail-closed target boundary: unsupported packet or map semantics
-  are diagnosed instead of being emitted with the simulator ABI.
+- Emit libbpf-loadable XDP and socket-filter objects with real context access,
+  verifier-safe packet bounds proofs, and BTF-defined maps.
+- Build allow/deny packet filters and map-backed packet/flow counters, then
+  inspect them with `readelf` / `llvm-objdump` and load them with a maintainer's
+  privileged `bpf()` gate.
+- Exercise the full source-to-kernel-object path — context, packet reads, maps,
+  relocations — without attaching to a live interface.
 
 ### Enabled by a production XDP/socket-filter target
 

--- a/docs/design/compiler/ebpf-backend.md
+++ b/docs/design/compiler/ebpf-backend.md
@@ -108,13 +108,13 @@ removed from the host.
 
 ## Layer 2: typed low-level language and BPF-IR
 
-The low-level language is deliberately closed. Its 24 registered commands are:
+The low-level language is deliberately closed. Its 25 registered commands are:
 
 | Group | Commands | Meaning |
 |---|---|---|
 | Typed scalars | `setint`, `seti32`, `setu32` | Evaluate integer expressions and commit a 64-, signed 32-, or unsigned 32-bit value. |
-| Packet context | `setbuf`, `pktlen`, `load8`, `load16`, `load32` | Bind the packet, inspect its length, and read fixed-width fields at constant offsets. |
-| State | `map`, `map_get`, `map_set` | Declare and access userspace-emulated integer-to-integer maps. |
+| Packet context | `setbuf`, `pktlen`, `load8`, `load16`, `load32` | Bind the packet, inspect its length, and read fixed-width fields at constant offsets (with an optional `be`/`le`/`native` byte-order word). |
+| State | `map`, `map_get`, `map_has`, `map_set` | Declare and access userspace-emulated integer-to-integer maps; `map_has` distinguishes a missing key from a stored zero. |
 | Control flow | `if`, `loop` | Branch, or expand a literal-count loop up to 64 iterations before CFG construction. |
 | Socket verdicts | `accept`, `drop` | Return an accepted byte count or zero. |
 | XDP verdicts | `pass`, `drop`, `tx` | Return `XDP_PASS`, `XDP_DROP`, or `XDP_TX`. |
@@ -125,13 +125,38 @@ numeric comparisons. Dynamic Tcl values, strings, command substitution,
 procedures, namespaces, coroutines, event loops, native `while`/`for`, file or
 socket I/O, and arbitrary commands are rejected.
 
-BPF-IR is a typed three-address CFG over mutable slots. It models constants,
-copies, integer operations, context pointer/length acquisition, packet loads,
-map access, branches, and verdict returns. Types currently distinguish an
-integer from a packet-context pointer; widths are attached to load operations.
-This narrow waist is the right place to add target-independent guarantees such
-as checked packet ranges, byte order, map schemas, and event-context field
-access.
+**The registry is the source of truth.** Every command spec in `tcl-registry`
+carries a typed `BpfOpSpec` descriptor (`bpf_op` field) describing the core
+operation or framework declaration it stands for — scalar width, packet-load
+width, map role, verdict family and its compatible program types, and an
+effect classification (packet read, map read/write, termination). The BPF-Tcl
+front-end (`bpf-tcl-ir`) and its capability policy dispatch on this descriptor,
+never on the command name. Adding a verb is a registry edit; a new command
+without a descriptor fails the registry drift test rather than being silently
+mishandled.
+
+BPF-IR is a typed three-address CFG over mutable slots. It models constants
+(including full 64-bit values via `lddw`), copies, integer operations, context
+pointer/length acquisition, **checked** packet loads, map access, branches, and
+verdict returns. A packet load (`Inst::Load`) carries a constant byte range,
+width, byte order (`Native`/`Big`/`Little`), and an explicit out-of-bounds
+action, so the failure semantics of a short packet are stated in the IR rather
+than implied by a target's runtime. Maps carry a typed schema (kind, key/value
+size, capacity, concurrency). After lowering, a liveness-based allocator
+(`bpf-tcl-ir/src/alloc.rs`) re-colours the virtual slots so values with disjoint
+live ranges share a stack slot, computes the exact zero-init set (only the
+slots read before every write), and enforces the 64-slot / 512-byte cap
+*after* reuse — reporting stack pressure with the source span of the first
+value that no longer fits.
+
+### Integer semantics
+
+BPF-Tcl integers are signed 64-bit, but `/` and `%` follow eBPF's **signed
+truncated-toward-zero** division (`BPF_SDIV` / `BPF_SMOD`), *not* Tcl's floor
+division. The two agree for same-sign operands and diverge only when exactly
+one operand is negative (`-7 / 2` is `-3` here, `-4` in Tcl). This narrower,
+verifier-native contract is deliberate and documented; the front-end does not
+silently pretend to be Tcl. `>>` is arithmetic (sign-preserving).
 
 ## Layer 3: framework and event model
 
@@ -189,36 +214,51 @@ loader therefore cannot yet preserve the apparent multi-handler semantics.
    proof required by the kernel verifier.
 3. **No kernel maps or relocations.** Map kind, key/value sizes, and capacity
    are metadata in the simulator; capacity is not enforced. ELF rejects maps.
-4. **Packet fields are native-endian.** Multi-byte network fields are compared
-   in host order. Existing tests deliberately use little-endian synthetic
-   bytes, so realistic network-order packets expose the mismatch.
+4. **Kernel-target packet fields need a kernel context ABI.** The BPF-IR and
+   the rbpf target now interpret multi-byte fields in the declared byte order
+   (built-in profiles default to network order, matching real headers), but the
+   *kernel* XDP/socket-filter context lowering that consumes this is issue
+   #1203 work. On the rbpf target this is resolved; on the kernel target it is
+   pending.
 5. **No loader or attachment lifecycle.** `attach xdp eth0` does not create a
    BPF link, configure an interface, pin maps, detach cleanly, or roll back a
    partial deployment.
 
 ### Low-layer correctness and maintainability
 
-1. **The registry does not describe lowering.** BPF command specs contain
-   names and arities, while `bpf-tcl-ir` matches command names again. Adding a
-   verb can make registry, lowering, capability policy, and documentation drift.
-   A typed BPF lowering descriptor or hook ID should make the registry the
-   command source of truth.
-2. **Malformed framework syntax can be accepted.** A non-integer priority
-   silently becomes 500, extra `when` header words can be ignored, and
-   non-`field` statements inside a user profile are dropped. This is tracked as
-   `RUST_ISSUE_063`.
-3. **The IR cannot state byte order or checked ranges.** `Load` carries only a
-   pointer, width, and constant offset. It cannot distinguish host/network
-   order or prove what failure verdict to use when the packet is short.
-4. **Integer semantics are only partly Tcl-like.** Signed BPF division
-   truncates towards zero, while Tcl integer division is floor division. Large
-   constants are rejected because the emitter only creates 32-bit immediates.
-5. **Stack allocation is intentionally naive.** Every temporary receives a
-   permanent eight-byte slot, all slots are zeroed, and there is no liveness-
-   based reuse. Unrolled handlers can hit the 64-slot limit well before the
-   instruction limit.
-6. **Map absence is conflated with zero.** `map_get` returns zero for a missing
-   key, so callers cannot distinguish absence from a stored zero.
+The items in this section were the subject of
+[issue #1202](https://github.com/bitwisecook/tcl-lsp/issues/1202) and are now
+**resolved**; they are kept here as a record of the contract each one settled.
+
+1. **The registry describes lowering.** Every BPF command spec carries a typed
+   `BpfOpSpec` descriptor; `bpf-tcl-ir` and the capability policy dispatch on
+   it, never on the command name. A registry drift test proves the command set,
+   lowering dispatch, and capability classification stay complete and
+   consistent. *(Resolved.)*
+2. **Malformed framework syntax is rejected.** A `when` header must be exactly
+   `when EVENT { body }` or `when EVENT priority N { body }` — a non-integer or
+   substituted priority, an unknown header keyword, or a substituted event is a
+   span-anchored error, never silently normalised. A user `profile` body accepts
+   only `field` declarations; anything else is rejected rather than dropped
+   (`RUST_ISSUE_063`). A handler path that reaches the end without an explicit
+   verdict is a `MissingVerdict` error, never a silent drop. *(Resolved.)*
+3. **The IR states byte order and checked ranges.** `Inst::Load` carries a
+   constant range, width, byte order (`Native`/`Big`/`Little`), and an explicit
+   out-of-bounds action. The rbpf emitter proves `base + off + width <=
+   data_end` before every dereference and takes the declared verdict on a short
+   packet, and converts multi-byte fields with `BPF_END`. *(Resolved.)*
+4. **Integer semantics are documented.** `/` and `%` are eBPF signed
+   truncated-toward-zero division, a documented narrower contract than Tcl floor
+   division (see *Integer semantics* above). Full 64-bit constants materialise
+   with `lddw`. *(Resolved.)*
+5. **Stack allocation reuses slots.** A liveness-based allocator re-colours
+   virtual slots for disjoint live ranges, zeroes only the slots read before
+   every write, and reports stack pressure with source context after reuse.
+   *(Resolved.)*
+6. **Map absence is distinguishable from zero.** `map_has` reports key presence
+   (1/0) independently of the stored value, and maps carry a typed schema (kind,
+   key/value size, capacity, concurrency) with capacity and array-range
+   enforcement in the simulator. *(Resolved.)*
 
 ### Framework limitations
 

--- a/docs/kcs/features/README.md
+++ b/docs/kcs/features/README.md
@@ -144,3 +144,4 @@ combine them when more than one form helps:
 - [kcs-feature-claude-code-skills.md](kcs-feature-claude-code-skills.md)
 - [kcs-feature-tcl-pkg.md](kcs-feature-tcl-pkg.md)
 - [kcs-feature-tcl-venv.md](kcs-feature-tcl-venv.md)
+- [kcs-feature-bpf-tcl.md](kcs-feature-bpf-tcl.md)

--- a/docs/kcs/features/kcs-feature-bpf-tcl.md
+++ b/docs/kcs/features/kcs-feature-bpf-tcl.md
@@ -1,0 +1,77 @@
+# KCS: feature — BPF-Tcl low-level packet language
+
+> **Audience:** User
+> **Type:** Functionality
+
+## Summary
+
+BPF-Tcl is a small, statically typed packet-programming language with Tcl
+syntax that compiles to eBPF and runs under a userspace simulator (with a
+verdict-only kernel-XDP slice).
+
+## Applies to
+
+tcl-lsp CLI
+
+## Question
+
+What does BPF-Tcl do, and how do I write a typed packet handler?
+
+## How to use
+
+Write a `.bpftcl` file. Each `when EVENT { … }` block (or
+`when EVENT priority N { … }`) is one program. Inside a handler you bind the
+packet with `setbuf`, read its length with `pktlen`, read fixed-offset fields
+with `load8` / `load16` / `load32`, keep state in a `map`, and end every path
+with an explicit verdict — `accept` / `drop` for a socket filter, or
+`pass` / `drop` / `tx` for XDP. Build the CLI with `make rust-clis` (the
+binary is `bpf-tcl`), then run `bpf-tcl check FILE`, `bpf-tcl compile FILE`,
+or `bpf-tcl run FILE --packet HEX`.
+
+Key contracts to know:
+
+- **The header is strict.** A `when` header must be exactly `when EVENT { … }`
+  or `when EVENT priority N { … }`. A non-integer priority, an unknown header
+  word, or a substituted event is an error — never silently normalised.
+- **Every path needs a verdict.** A handler path that reaches the end without
+  a verdict is rejected; the compiler never inserts one for you.
+- **Byte order is explicit.** Multi-byte fields default to network order
+  (big-endian), matching real headers. Override with a trailing `be`, `le`, or
+  `native` word on a `load*` verb or a profile `field`. `native` is a
+  compatibility mode for synthetic host-order test packets only.
+- **Maps are typed.** `map NAME hash|array KEYSZ VALSZ MAX ?shared|percpu?`.
+  `map_get` reads a value (0 when absent); `map_has` reports whether the key is
+  present, so you can tell a missing key from a stored zero. A `hash` map
+  enforces its capacity; an `array` map is preallocated and zero-filled.
+- **Integer division is truncated, not floored.** `/` and `%` follow eBPF
+  signed truncated-toward-zero division, which diverges from Tcl floor division
+  only when exactly one operand is negative.
+
+### Example
+
+```tcl
+# Drop TCP traffic to port 22, accept everything else.
+profile ipv4_tcp
+
+when SOCKET_FILTER priority 100 {
+    ip_proto proto
+    if {$proto != 6} { accept }
+    tcp_dport dport
+    if {$dport == 22} { drop }
+    accept
+}
+```
+
+```sh
+bpf-tcl check drop-ssh.bpftcl
+bpf-tcl run   drop-ssh.bpftcl --packet 00...   # simulate over a hex packet
+```
+
+## Limits
+
+The default target is the userspace `rbpf` simulator. The explicit
+`kernel-xdp` target (`--target kernel-xdp`) currently compiles only map-free,
+verdict-only XDP handlers; kernel packet access, kernel maps, and live
+attachment are follow-on work. See
+[`docs/design/compiler/ebpf-backend.md`](../../design/compiler/ebpf-backend.md)
+for the full architecture and roadmap.

--- a/docs/kcs/features/kcs-feature-bpf-tcl.md
+++ b/docs/kcs/features/kcs-feature-bpf-tcl.md
@@ -6,8 +6,9 @@
 ## Summary
 
 BPF-Tcl is a small, statically typed packet-programming language with Tcl
-syntax that compiles to eBPF and runs under a userspace simulator (with a
-verdict-only kernel-XDP slice).
+syntax that compiles to eBPF and runs under a userspace simulator, and also
+emits Linux-loadable XDP and socket-filter objects with real context access,
+bounds-checked packet reads, and maps.
 
 ## Applies to
 
@@ -26,7 +27,10 @@ with `load8` / `load16` / `load32`, keep state in a `map`, and end every path
 with an explicit verdict — `accept` / `drop` for a socket filter, or
 `pass` / `drop` / `tx` for XDP. Build the CLI with `make rust-clis` (the
 binary is `bpf-tcl`), then run `bpf-tcl check FILE`, `bpf-tcl compile FILE`,
-or `bpf-tcl run FILE --packet HEX`.
+or `bpf-tcl run FILE --packet HEX`. `bpf-tcl compile FILE --emit elf` writes an
+ELF object; add `--target kernel-xdp` or `--target kernel-socket` for a
+Linux-loadable object (the default `--target rbpf` is a simulator artefact for
+inspection).
 
 Key contracts to know:
 
@@ -70,8 +74,13 @@ bpf-tcl run   drop-ssh.bpftcl --packet 00...   # simulate over a hex packet
 ## Limits
 
 The default target is the userspace `rbpf` simulator. The explicit
-`kernel-xdp` target (`--target kernel-xdp`) currently compiles only map-free,
-verdict-only XDP handlers; kernel packet access, kernel maps, and live
-attachment are follow-on work. See
+`kernel-xdp` and `kernel-socket` targets (`--target kernel-xdp` /
+`--target kernel-socket`) emit Linux-loadable objects with `struct xdp_md` /
+`struct __sk_buff` context access, verifier-safe packet bounds proofs, and
+BTF-defined maps with relocations. The emitted objects are validated in the test
+suite with `readelf`/`llvm-objdump` and an in-repo verifier model; the actual
+`bpf()` kernel load needs root and a live kernel, so it runs behind an
+`#[ignore]`d test (`rust/bpf-tcl/tests/kernel_load.rs`). Live attachment
+(links, pins, interface configuration) is still follow-on work. See
 [`docs/design/compiler/ebpf-backend.md`](../../design/compiler/ebpf-backend.md)
 for the full architecture and roadmap.

--- a/rust/bpf-tcl-codegen/src/ebpf/btf.rs
+++ b/rust/bpf-tcl-codegen/src/ebpf/btf.rs
@@ -1,0 +1,320 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! A minimal BTF (BPF Type Format) writer for libbpf-compatible BTF-defined
+//! maps.
+//!
+//! libbpf reads a map's kind, key/value sizes, capacity, and flags from a BTF
+//! description of a struct variable in the `.maps` section. Each map is a
+//! variable of an anonymous struct whose members are pointers to arrays whose
+//! element counts encode the numeric properties:
+//!
+//! ```c
+//! struct {
+//!     int (*type)[BPF_MAP_TYPE_HASH];   // map type number
+//!     int (*key_size)[K];               // key size in bytes
+//!     int (*value_size)[V];             // value size in bytes
+//!     int (*max_entries)[M];            // capacity
+//! } name SEC(".maps");
+//! ```
+//!
+//! This is the array-encoded (`key_size` / `value_size`) form of libbpf's
+//! BTF-defined map definition, chosen so we do not need to synthesise precise
+//! key/value BTF types — the sizes are all libbpf needs for integer maps.
+//!
+//! The `.maps` section itself is zero-filled; libbpf takes the definition
+//! entirely from this BTF, driven by a global object symbol per map (see the
+//! ELF writer).
+
+use bpf_tcl_ir::MapConcurrency;
+use bpf_tcl_ir::ir::{MapDef, MapKind};
+
+/// Bytes occupied by one map's struct variable in the `.maps` section (four
+/// 8-byte pointer members).
+pub const MAP_STRUCT_SIZE: u32 = 32;
+
+// BTF header.
+const BTF_MAGIC: u16 = 0xeb9f;
+const BTF_VERSION: u8 = 1;
+const BTF_HDR_LEN: u32 = 24;
+
+// BTF type kinds (`info` bits 24..=28).
+const KIND_INT: u32 = 1;
+const KIND_PTR: u32 = 2;
+const KIND_ARRAY: u32 = 3;
+const KIND_STRUCT: u32 = 4;
+const KIND_VAR: u32 = 14;
+const KIND_DATASEC: u32 = 15;
+
+/// `BTF_INT_SIGNED` in the top byte of the int encoding word.
+const INT_SIGNED: u32 = 1 << 24;
+
+/// `BTF_VAR_GLOBAL_ALLOCATED` linkage.
+const VAR_GLOBAL: u32 = 1;
+
+/// `BPF_MAP_TYPE_*` numbers used by BTF-defined maps.
+const MAP_TYPE_HASH: u32 = 1;
+const MAP_TYPE_ARRAY: u32 = 2;
+const MAP_TYPE_PERCPU_HASH: u32 = 5;
+const MAP_TYPE_PERCPU_ARRAY: u32 = 6;
+
+/// The `BPF_MAP_TYPE_*` number for a declared map.
+fn map_type_number(def: &MapDef) -> u32 {
+    match (def.kind, def.concurrency) {
+        (MapKind::Hash, MapConcurrency::Shared) => MAP_TYPE_HASH,
+        (MapKind::Array, MapConcurrency::Shared) => MAP_TYPE_ARRAY,
+        (MapKind::Hash, MapConcurrency::PerCpu) => MAP_TYPE_PERCPU_HASH,
+        (MapKind::Array, MapConcurrency::PerCpu) => MAP_TYPE_PERCPU_ARRAY,
+    }
+}
+
+/// A growable BTF string table (NUL-led, NUL-terminated entries).
+struct BtfStrings {
+    buf: Vec<u8>,
+}
+
+impl BtfStrings {
+    fn new() -> Self {
+        Self { buf: vec![0] }
+    }
+
+    fn add(&mut self, s: &str) -> u32 {
+        let off = u32::try_from(self.buf.len()).unwrap_or(0);
+        self.buf.extend_from_slice(s.as_bytes());
+        self.buf.push(0);
+        off
+    }
+}
+
+/// A BTF type-section accumulator that tracks the next type id.
+struct BtfTypes {
+    buf: Vec<u8>,
+    next_id: u32,
+}
+
+impl BtfTypes {
+    fn new() -> Self {
+        // Type id 0 is the implicit `void`; real ids start at 1.
+        Self {
+            buf: Vec::new(),
+            next_id: 1,
+        }
+    }
+
+    fn info(kind: u32, vlen: u32) -> u32 {
+        (kind << 24) | (vlen & 0xffff)
+    }
+
+    fn push_word(&mut self, w: u32) {
+        self.buf.extend_from_slice(&w.to_le_bytes());
+    }
+
+    fn header(&mut self, name_off: u32, info: u32, size_or_type: u32) {
+        self.push_word(name_off);
+        self.push_word(info);
+        self.push_word(size_or_type);
+    }
+
+    /// A signed 32-bit `int`.
+    fn int(&mut self, name_off: u32) -> u32 {
+        let id = self.next_id;
+        self.header(name_off, Self::info(KIND_INT, 0), 4);
+        self.push_word(INT_SIGNED | 32);
+        self.next_id += 1;
+        id
+    }
+
+    /// `int[nelems]` (element and index type both `int_id`).
+    fn array(&mut self, int_id: u32, nelems: u32) -> u32 {
+        let id = self.next_id;
+        self.header(0, Self::info(KIND_ARRAY, 0), 0);
+        self.push_word(int_id); // element type
+        self.push_word(int_id); // index type
+        self.push_word(nelems);
+        self.next_id += 1;
+        id
+    }
+
+    /// `type *` (pointer to type id `to`).
+    fn ptr(&mut self, to: u32) -> u32 {
+        let id = self.next_id;
+        self.header(0, Self::info(KIND_PTR, 0), to);
+        self.next_id += 1;
+        id
+    }
+
+    /// An anonymous struct with the given `(name_off, member_type)` members.
+    fn struct_type(&mut self, members: &[(u32, u32)]) -> u32 {
+        let id = self.next_id;
+        let vlen = u32::try_from(members.len()).unwrap_or(0);
+        self.header(0, Self::info(KIND_STRUCT, vlen), MAP_STRUCT_SIZE);
+        let mut bit_off = 0u32;
+        for (name_off, ty) in members {
+            self.push_word(*name_off);
+            self.push_word(*ty);
+            self.push_word(bit_off);
+            bit_off += 64; // one 8-byte pointer per member
+        }
+        self.next_id += 1;
+        id
+    }
+
+    /// A global `VAR` of type id `ty`.
+    fn var(&mut self, name_off: u32, ty: u32) -> u32 {
+        let id = self.next_id;
+        self.header(name_off, Self::info(KIND_VAR, 0), ty);
+        self.push_word(VAR_GLOBAL);
+        self.next_id += 1;
+        id
+    }
+
+    /// A `DATASEC` listing `(var_id, offset, size)` entries.
+    fn datasec(&mut self, name_off: u32, total_size: u32, vars: &[(u32, u32, u32)]) -> u32 {
+        let id = self.next_id;
+        let vlen = u32::try_from(vars.len()).unwrap_or(0);
+        self.header(name_off, Self::info(KIND_DATASEC, vlen), total_size);
+        for (var_id, offset, size) in vars {
+            self.push_word(*var_id);
+            self.push_word(*offset);
+            self.push_word(*size);
+        }
+        self.next_id += 1;
+        id
+    }
+}
+
+/// Build the `.BTF` section bytes describing every map in `maps`.
+///
+/// Returns an empty vector when there are no maps (no BTF section is emitted in
+/// that case).
+#[must_use]
+pub fn build_btf(maps: &[MapDef]) -> Vec<u8> {
+    if maps.is_empty() {
+        return Vec::new();
+    }
+
+    let mut strings = BtfStrings::new();
+    let mut types = BtfTypes::new();
+
+    let int_name = strings.add("int");
+    let type_name = strings.add("type");
+    let key_size_name = strings.add("key_size");
+    let value_size_name = strings.add("value_size");
+    let max_entries_name = strings.add("max_entries");
+    let maps_sec_name = strings.add(".maps");
+
+    let int_id = types.int(int_name);
+
+    // A distinct `int (*)[N]` pointer per array length used by any member.
+    let mut ptr_for_len: std::collections::HashMap<u32, u32> = std::collections::HashMap::new();
+    let mut ptr_to_array = |types: &mut BtfTypes, nelems: u32| -> u32 {
+        *ptr_for_len.entry(nelems).or_insert_with(|| {
+            let arr = types.array(int_id, nelems.max(1));
+            types.ptr(arr)
+        })
+    };
+
+    // A struct + var per map, gathering the section var-info as we go.
+    let mut var_infos: Vec<(u32, u32, u32)> = Vec::with_capacity(maps.len());
+    for (i, def) in maps.iter().enumerate() {
+        let type_ptr = ptr_to_array(&mut types, map_type_number(def));
+        let key_ptr = ptr_to_array(&mut types, def.key_size);
+        let value_ptr = ptr_to_array(&mut types, def.value_size);
+        let max_ptr = ptr_to_array(&mut types, def.max_entries);
+        let struct_id = types.struct_type(&[
+            (type_name, type_ptr),
+            (key_size_name, key_ptr),
+            (value_size_name, value_ptr),
+            (max_entries_name, max_ptr),
+        ]);
+        let var_name = strings.add(&def.name);
+        let var_id = types.var(var_name, struct_id);
+        let offset = u32::try_from(i).unwrap_or(0) * MAP_STRUCT_SIZE;
+        var_infos.push((var_id, offset, MAP_STRUCT_SIZE));
+    }
+
+    let total = u32::try_from(maps.len()).unwrap_or(0) * MAP_STRUCT_SIZE;
+    types.datasec(maps_sec_name, total, &var_infos);
+
+    encode_btf(&types.buf, &strings.buf)
+}
+
+/// Prepend the BTF header to the type and string sections.
+fn encode_btf(type_bytes: &[u8], str_bytes: &[u8]) -> Vec<u8> {
+    let type_len = u32::try_from(type_bytes.len()).unwrap_or(0);
+    let str_len = u32::try_from(str_bytes.len()).unwrap_or(0);
+    let mut out = Vec::with_capacity(BTF_HDR_LEN as usize + type_bytes.len() + str_bytes.len());
+    out.extend_from_slice(&BTF_MAGIC.to_le_bytes());
+    out.push(BTF_VERSION);
+    out.push(0); // flags
+    out.extend_from_slice(&BTF_HDR_LEN.to_le_bytes());
+    out.extend_from_slice(&0u32.to_le_bytes()); // type_off
+    out.extend_from_slice(&type_len.to_le_bytes());
+    out.extend_from_slice(&type_len.to_le_bytes()); // str_off (immediately after types)
+    out.extend_from_slice(&str_len.to_le_bytes());
+    out.extend_from_slice(type_bytes);
+    out.extend_from_slice(str_bytes);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bpf_tcl_ir::compile_module;
+
+    fn maps_of(src: &str) -> Vec<MapDef> {
+        compile_module(src).expect("compiles").programs[0]
+            .program
+            .maps
+            .clone()
+    }
+
+    #[test]
+    fn empty_maps_produce_no_btf() {
+        assert!(build_btf(&[]).is_empty());
+    }
+
+    #[test]
+    fn btf_header_is_well_formed() {
+        let maps = maps_of("when XDP { map m hash 8 8 16\n pass }\n");
+        let btf = build_btf(&maps);
+        assert!(btf.len() > BTF_HDR_LEN as usize);
+        assert_eq!(u16::from_le_bytes([btf[0], btf[1]]), BTF_MAGIC);
+        assert_eq!(btf[2], BTF_VERSION);
+        let hdr_len = u32::from_le_bytes(btf[4..8].try_into().unwrap());
+        assert_eq!(hdr_len, BTF_HDR_LEN);
+        // The map name appears in the string section.
+        assert!(btf.windows(2).any(|w| w == b"m\0"));
+        assert!(
+            btf.windows(6).any(|w| w == b".maps\0"),
+            "the datasec name is present"
+        );
+    }
+
+    #[test]
+    fn btf_encodes_type_and_str_lengths_consistently() {
+        let maps = maps_of("when XDP { map a array 4 8 4\n map b hash 2 4 8\n pass }\n");
+        let btf = build_btf(&maps);
+        let type_len = u32::from_le_bytes(btf[12..16].try_into().unwrap()) as usize;
+        let str_off = u32::from_le_bytes(btf[16..20].try_into().unwrap()) as usize;
+        let str_len = u32::from_le_bytes(btf[20..24].try_into().unwrap()) as usize;
+        // Header + types + strings accounts for the whole buffer.
+        assert_eq!(str_off, type_len);
+        assert_eq!(btf.len(), BTF_HDR_LEN as usize + type_len + str_len);
+    }
+}

--- a/rust/bpf-tcl-codegen/src/ebpf/disasm.rs
+++ b/rust/bpf-tcl-codegen/src/ebpf/disasm.rs
@@ -71,6 +71,16 @@ fn one(i: Insn) -> String {
                 _ => raw(i),
             }
         }
+        0x00 if i.op == 0x18 => {
+            // Wide-immediate load (`lddw`): a pseudo map-fd load carries the
+            // map source register; its immediate is patched by a relocation.
+            if i.src == crate::ebpf::insn::PSEUDO_MAP_FD {
+                format!("r{d} = map_fd(reloc)")
+            } else {
+                format!("r{d} = lddw(imm={})", i.imm)
+            }
+        }
+        0x00 if i.op == 0x00 => format!("<lddw high imm={}>", i.imm),
         0x01 => format!("r{d} = *({} *)(r{s} {:+})", sz(i.op), i.off),
         0x03 => format!("*({} *)(r{d} {:+}) = r{s}", sz(i.op), i.off),
         0x02 => format!("*({} *)(r{d} {:+}) = {}", sz(i.op), i.off, i.imm),

--- a/rust/bpf-tcl-codegen/src/ebpf/elf.rs
+++ b/rust/bpf-tcl-codegen/src/ebpf/elf.rs
@@ -20,26 +20,25 @@
 //!
 //! Produces a standards-valid `ET_REL` / `EM_BPF` ELF64 (little-endian) the way
 //! `clang -target bpf` does — written by hand, no LLVM — so a program can be
-//! inspected and disassembled with the usual tools (`readelf`, `llvm-objdump`).
-//! The object carries:
-//!   * a program section named for the program type (`xdp` / `socket`, the
-//!     libbpf `SEC(...)` conventions) holding the instruction bytes,
-//!   * a `license` section (`"GPL"`),
-//!   * a `.symtab`/`.strtab` with a section symbol plus a global `STT_FUNC`
-//!     symbol for the program entry, and
-//!   * a `.shstrtab`.
+//! inspected and disassembled with the usual tools (`readelf`, `llvm-objdump`)
+//! and loaded by libbpf.
 //!
-//! Scope: the instruction stream is our eBPF encoded for the `rbpf` execution
-//! ABI (the `data`/`data_end` metadata-buffer prologue, by-value map helpers),
-//! so the object is structurally a real BPF ELF but not yet wired to the kernel
-//! ctx/map ABI. Maps therefore need relocations against a `maps` section under
-//! the kernel ABI, which is a follow-up; for now a program that declares maps is
-//! rejected by the ELF writer. A `TargetAbi::Kernel` codegen flavor (correct ctx
-//! offsets + map ABI) is the next increment and makes the object load under
-//! libbpf.
+//! Two layouts:
+//!
+//!   * **map-free** — a program section named for the program type
+//!     (`xdp` / `socket`), a `license` section (`"GPL"`), a `.symtab`/`.strtab`
+//!     with a section symbol and a global `STT_FUNC` program symbol, and a
+//!     `.shstrtab`. This is the six-section object the audited kernel-XDP slice
+//!     already loaded.
+//!   * **with maps** (kernel targets only) — additionally a BTF-defined `.maps`
+//!     section, a `.BTF` section describing each map, a `.rel<prog>` relocation
+//!     section patching each pseudo map-fd `ld_imm64`, a `.maps` section symbol,
+//!     and a global `STT_OBJECT` symbol per map. libbpf resolves each relocation
+//!     to the created map's file descriptor at load time.
 
 use bpf_tcl_ir::ir::ProgType;
 
+use crate::ebpf::btf::{MAP_STRUCT_SIZE, build_btf};
 use crate::ebpf::emit::EbpfObject;
 
 // ELF identification / header constants.
@@ -55,42 +54,50 @@ const EM_BPF: u16 = 247;
 const SHT_PROGBITS: u32 = 1;
 const SHT_SYMTAB: u32 = 2;
 const SHT_STRTAB: u32 = 3;
+const SHT_REL: u32 = 9;
+const SHF_WRITE: u64 = 0x1;
 const SHF_ALLOC: u64 = 0x2;
 const SHF_EXECINSTR: u64 = 0x4;
 
 // Symbol binding / type.
 const STB_GLOBAL: u8 = 1;
+const STT_OBJECT: u8 = 1;
 const STT_FUNC: u8 = 2;
 const STT_SECTION: u8 = 3;
+
+/// `R_BPF_64_64` — the relocation the loader applies to a pseudo map-fd
+/// `ld_imm64`, rewriting its immediate to the created map's file descriptor.
+const R_BPF_64_64: u32 = 1;
 
 // Fixed sizes (ELF64).
 const EHDR_SIZE: u64 = 64;
 const SHDR_SIZE: usize = 64;
 const SYM_SIZE: usize = 24;
-/// Index of the first global symbol (NULL + the section symbol are local).
-const FIRST_GLOBAL_SYM: u32 = 2;
+const REL_SIZE: usize = 16;
 
-// Section indices in the object we emit (NULL, prog, license, symtab, strtab,
-// shstrtab).
+// Map-free section indices (NULL, prog, license, symtab, strtab, shstrtab).
 const SEC_PROG: u16 = 1;
 const SEC_STRTAB: u16 = 4;
 const SEC_SHSTRTAB: u16 = 5;
 const SEC_COUNT: u16 = 6;
+/// Index of the first global symbol in the map-free layout.
+const FIRST_GLOBAL_SYM: u32 = 2;
 
 /// An error from the ELF writer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ElfError {
-    /// The program declares maps, which need the kernel map ABI + relocations
-    /// (a follow-up increment); the ELF writer can't yet emit them.
-    MapsUnsupported,
+    /// A program declaring maps was emitted for the userspace `rbpf` simulator
+    /// ABI, which has no kernel map file descriptors. Emit maps with a kernel
+    /// target (`--target kernel-xdp` / `kernel-socket`) instead.
+    MapsNeedKernelTarget,
 }
 
 impl std::fmt::Display for ElfError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ElfError::MapsUnsupported => write!(
+            ElfError::MapsNeedKernelTarget => write!(
                 f,
-                "ELF output does not yet support maps (needs the kernel map ABI)"
+                "maps in an ELF object need a kernel target (use --target kernel-xdp or kernel-socket)"
             ),
         }
     }
@@ -145,11 +152,27 @@ fn section_name(prog_type: ProgType) -> &'static str {
     }
 }
 
+/// Write `obj` as an `EM_BPF` `ET_REL` ELF64 object, with the program entry
+/// exported as `prog_name`.
+///
+/// # Errors
+/// [`ElfError::MapsNeedKernelTarget`] if a program declaring maps was emitted
+/// for the userspace `rbpf` simulator ABI (no kernel map fds exist there).
+pub fn write_object(obj: &EbpfObject, prog_name: &str) -> Result<Vec<u8>, ElfError> {
+    if obj.maps.is_empty() {
+        return Ok(write_map_free(obj, prog_name));
+    }
+    if !obj.target_abi.is_kernel() {
+        return Err(ElfError::MapsNeedKernelTarget);
+    }
+    Ok(write_with_maps(obj, prog_name))
+}
+
 /// The computed offset/size of one laid-out section (file offset, byte size).
 type SecLoc = (u64, u64);
 
-/// Everything `section_headers` needs: the five section-name offsets plus each
-/// data section's laid-out location.
+/// The map-free six-section layout (unchanged from the original writer, so its
+/// section indices and symbol table stay stable for existing consumers).
 struct Layout {
     names: [u32; 5],
     prog: SecLoc,
@@ -159,17 +182,7 @@ struct Layout {
     shstrtab: SecLoc,
 }
 
-/// Write `obj` as an `EM_BPF` `ET_REL` ELF64 object, with the program entry
-/// exported as `prog_name`.
-///
-/// # Errors
-/// [`ElfError::MapsUnsupported`] if the program declares any map.
-pub fn write_object(obj: &EbpfObject, prog_name: &str) -> Result<Vec<u8>, ElfError> {
-    if !obj.maps.is_empty() {
-        return Err(ElfError::MapsUnsupported);
-    }
-
-    // Section-header name table and the program-symbol name table.
+fn write_map_free(obj: &EbpfObject, prog_name: &str) -> Vec<u8> {
     let mut shstr = StrTab::new();
     let names = [
         shstr.add(section_name(obj.prog_type)),
@@ -180,9 +193,8 @@ pub fn write_object(obj: &EbpfObject, prog_name: &str) -> Result<Vec<u8>, ElfErr
     ];
     let mut strtab = StrTab::new();
     let prog_size = obj.raw.len() as u64;
-    let symtab = build_symtab(strtab.add(prog_name), prog_size);
+    let symtab = build_map_free_symtab(strtab.add(prog_name), prog_size);
 
-    // Lay out section data after the ELF header, tracking each section's offset.
     let mut data = Vec::new();
     let prog_off = EHDR_SIZE + data.len() as u64;
     data.extend_from_slice(&obj.raw);
@@ -198,7 +210,7 @@ pub fn write_object(obj: &EbpfObject, prog_name: &str) -> Result<Vec<u8>, ElfErr
     align(&mut data, 8);
     let shoff = EHDR_SIZE + data.len() as u64;
 
-    let secs = section_headers(&Layout {
+    let secs = map_free_section_headers(&Layout {
         names,
         prog: (prog_off, prog_size),
         license: (license_off, 4),
@@ -209,17 +221,17 @@ pub fn write_object(obj: &EbpfObject, prog_name: &str) -> Result<Vec<u8>, ElfErr
 
     let cap = usize::try_from(shoff).unwrap_or(0) + usize::from(SEC_COUNT) * SHDR_SIZE;
     let mut out = Vec::with_capacity(cap);
-    write_ehdr(&mut out, shoff);
+    write_ehdr(&mut out, shoff, SEC_COUNT, SEC_SHSTRTAB);
     out.extend_from_slice(&data);
     for s in &secs {
         s.encode(&mut out);
     }
-    Ok(out)
+    out
 }
 
-/// Build the symbol table bytes: NULL, the program section symbol (local), then
-/// the global `STT_FUNC` for the entry.
-fn build_symtab(prog_sym_name: u32, prog_size: u64) -> Vec<u8> {
+/// Build the map-free symbol table: NULL, the program section symbol (local),
+/// then the global `STT_FUNC` for the entry.
+fn build_map_free_symtab(prog_sym_name: u32, prog_size: u64) -> Vec<u8> {
     let mut t = Vec::with_capacity(3 * SYM_SIZE);
     Sym {
         name: 0,
@@ -248,9 +260,8 @@ fn build_symtab(prog_sym_name: u32, prog_size: u64) -> Vec<u8> {
     t
 }
 
-/// Build the six section headers (NULL, prog, license, .symtab, .strtab,
-/// .shstrtab) from the laid-out [`Layout`].
-fn section_headers(l: &Layout) -> [Shdr; 6] {
+/// Build the six map-free section headers.
+fn map_free_section_headers(l: &Layout) -> [Shdr; 6] {
     [
         Shdr::null(),
         Shdr {
@@ -281,7 +292,7 @@ fn section_headers(l: &Layout) -> [Shdr; 6] {
             flags: 0,
             offset: l.symtab.0,
             size: l.symtab.1,
-            link: u32::from(SEC_STRTAB), // strings live in .strtab
+            link: u32::from(SEC_STRTAB),
             info: FIRST_GLOBAL_SYM,
             align: 8,
             entsize: SYM_SIZE as u64,
@@ -311,6 +322,265 @@ fn section_headers(l: &Layout) -> [Shdr; 6] {
     ]
 }
 
+// Section indices in the map-carrying layout: NULL(0), prog(1), .maps(2),
+// .BTF(3), .rel<prog>(4), license(5), .symtab(6), .strtab(7), .shstrtab(8).
+const M_PROG: u16 = 1;
+const M_MAPS: u16 = 2;
+const M_SYMTAB: u16 = 6;
+const M_STRTAB: u16 = 7;
+const M_SHSTRTAB: u16 = 8;
+const M_SEC_COUNT: u16 = 9;
+
+/// The named-section offsets for the map-carrying layout (`.shstrtab` entries).
+struct MapNames {
+    prog: u32,
+    maps: u32,
+    btf: u32,
+    rel: u32,
+    license: u32,
+    symtab: u32,
+    strtab: u32,
+    shstrtab: u32,
+}
+
+fn write_with_maps(obj: &EbpfObject, prog_name: &str) -> Vec<u8> {
+    let n_maps = obj.maps.len();
+    let maps_size = u32::try_from(n_maps).unwrap_or(0) * MAP_STRUCT_SIZE;
+    let btf = build_btf(&obj.maps);
+
+    let mut shstr = StrTab::new();
+    let rel_name = format!(".rel{}", section_name(obj.prog_type));
+    let names = MapNames {
+        prog: shstr.add(section_name(obj.prog_type)),
+        maps: shstr.add(".maps"),
+        btf: shstr.add(".BTF"),
+        rel: shstr.add(&rel_name),
+        license: shstr.add("license"),
+        symtab: shstr.add(".symtab"),
+        strtab: shstr.add(".strtab"),
+        shstrtab: shstr.add(".shstrtab"),
+    };
+
+    // Symbol table: NULL, prog section sym, .maps section sym (locals), then a
+    // global object symbol per map, then the global program FUNC.
+    let mut strtab = StrTab::new();
+    let map_sym_base = 3u32; // first global symbol index
+    let mut symtab = Vec::new();
+    encode_local_syms(&mut symtab);
+    let mut map_names: Vec<u32> = Vec::with_capacity(n_maps);
+    for def in &obj.maps {
+        map_names.push(strtab.add(&def.name));
+    }
+    for (i, name) in map_names.iter().enumerate() {
+        Sym {
+            name: *name,
+            info: (STB_GLOBAL << 4) | STT_OBJECT,
+            shndx: M_MAPS,
+            value: u64::from(u32::try_from(i).unwrap_or(0) * MAP_STRUCT_SIZE),
+            size: u64::from(MAP_STRUCT_SIZE),
+        }
+        .encode(&mut symtab);
+    }
+    let prog_size = obj.raw.len() as u64;
+    Sym {
+        name: strtab.add(prog_name),
+        info: (STB_GLOBAL << 4) | STT_FUNC,
+        shndx: M_PROG,
+        value: 0,
+        size: prog_size,
+    }
+    .encode(&mut symtab);
+
+    let relocs = encode_relocs(obj, map_sym_base);
+
+    // Lay out section data after the ELF header.
+    let mut data = Vec::new();
+    let prog_off = EHDR_SIZE + data.len() as u64;
+    data.extend_from_slice(&obj.raw);
+    align(&mut data, 8);
+    let maps_off = EHDR_SIZE + data.len() as u64;
+    data.extend(std::iter::repeat_n(0u8, maps_size as usize));
+    align(&mut data, 8);
+    let btf_off = EHDR_SIZE + data.len() as u64;
+    data.extend_from_slice(&btf);
+    align(&mut data, 8);
+    let rel_off = EHDR_SIZE + data.len() as u64;
+    data.extend_from_slice(&relocs);
+    let license_off = EHDR_SIZE + data.len() as u64;
+    data.extend_from_slice(b"GPL\0");
+    align(&mut data, 8);
+    let symtab_off = EHDR_SIZE + data.len() as u64;
+    data.extend_from_slice(&symtab);
+    let strtab_off = EHDR_SIZE + data.len() as u64;
+    data.extend_from_slice(&strtab.buf);
+    let shstrtab_off = EHDR_SIZE + data.len() as u64;
+    data.extend_from_slice(&shstr.buf);
+    align(&mut data, 8);
+    let shoff = EHDR_SIZE + data.len() as u64;
+
+    let first_global = map_sym_base;
+    let secs = maps_section_headers(
+        &names,
+        &[
+            (prog_off, prog_size),
+            (maps_off, u64::from(maps_size)),
+            (btf_off, btf.len() as u64),
+            (rel_off, relocs.len() as u64),
+            (license_off, 4),
+            (symtab_off, symtab.len() as u64),
+            (strtab_off, strtab.buf.len() as u64),
+            (shstrtab_off, shstr.buf.len() as u64),
+        ],
+        first_global,
+    );
+
+    let cap = usize::try_from(shoff).unwrap_or(0) + usize::from(M_SEC_COUNT) * SHDR_SIZE;
+    let mut out = Vec::with_capacity(cap);
+    write_ehdr(&mut out, shoff, M_SEC_COUNT, M_SHSTRTAB);
+    out.extend_from_slice(&data);
+    for s in &secs {
+        s.encode(&mut out);
+    }
+    out
+}
+
+/// NULL + the two local section symbols (prog, .maps).
+fn encode_local_syms(out: &mut Vec<u8>) {
+    Sym {
+        name: 0,
+        info: 0,
+        shndx: 0,
+        value: 0,
+        size: 0,
+    }
+    .encode(out);
+    Sym {
+        name: 0,
+        info: STT_SECTION,
+        shndx: M_PROG,
+        value: 0,
+        size: 0,
+    }
+    .encode(out);
+    Sym {
+        name: 0,
+        info: STT_SECTION,
+        shndx: M_MAPS,
+        value: 0,
+        size: 0,
+    }
+    .encode(out);
+}
+
+/// Encode the `SHT_REL` entries: one per pseudo map-fd load, at the load's byte
+/// offset, referencing the map's global object symbol.
+fn encode_relocs(obj: &EbpfObject, map_sym_base: u32) -> Vec<u8> {
+    let mut out = Vec::with_capacity(obj.relocations.len() * REL_SIZE);
+    for r in &obj.relocations {
+        let r_offset = u64::from(r.insn_index) * 8;
+        let sym = map_sym_base + r.map_index;
+        let r_info = (u64::from(sym) << 32) | u64::from(R_BPF_64_64);
+        out.extend_from_slice(&r_offset.to_le_bytes());
+        out.extend_from_slice(&r_info.to_le_bytes());
+    }
+    out
+}
+
+fn maps_section_headers(names: &MapNames, locs: &[SecLoc; 8], first_global: u32) -> [Shdr; 9] {
+    let [prog, maps, btf, rel, license, symtab, strtab, shstrtab] = *locs;
+    [
+        Shdr::null(),
+        Shdr {
+            name: names.prog,
+            kind: SHT_PROGBITS,
+            flags: SHF_ALLOC | SHF_EXECINSTR,
+            offset: prog.0,
+            size: prog.1,
+            link: 0,
+            info: 0,
+            align: 8,
+            entsize: 0,
+        },
+        Shdr {
+            name: names.maps,
+            kind: SHT_PROGBITS,
+            flags: SHF_ALLOC | SHF_WRITE,
+            offset: maps.0,
+            size: maps.1,
+            link: 0,
+            info: 0,
+            align: 8,
+            entsize: 0,
+        },
+        Shdr {
+            name: names.btf,
+            kind: SHT_PROGBITS,
+            flags: 0,
+            offset: btf.0,
+            size: btf.1,
+            link: 0,
+            info: 0,
+            align: 4,
+            entsize: 0,
+        },
+        Shdr {
+            name: names.rel,
+            kind: SHT_REL,
+            flags: 0,
+            offset: rel.0,
+            size: rel.1,
+            link: u32::from(M_SYMTAB),
+            info: u32::from(M_PROG),
+            align: 8,
+            entsize: REL_SIZE as u64,
+        },
+        Shdr {
+            name: names.license,
+            kind: SHT_PROGBITS,
+            flags: SHF_ALLOC,
+            offset: license.0,
+            size: license.1,
+            link: 0,
+            info: 0,
+            align: 1,
+            entsize: 0,
+        },
+        Shdr {
+            name: names.symtab,
+            kind: SHT_SYMTAB,
+            flags: 0,
+            offset: symtab.0,
+            size: symtab.1,
+            link: u32::from(M_STRTAB),
+            info: first_global,
+            align: 8,
+            entsize: SYM_SIZE as u64,
+        },
+        Shdr {
+            name: names.strtab,
+            kind: SHT_STRTAB,
+            flags: 0,
+            offset: strtab.0,
+            size: strtab.1,
+            link: 0,
+            info: 0,
+            align: 1,
+            entsize: 0,
+        },
+        Shdr {
+            name: names.shstrtab,
+            kind: SHT_STRTAB,
+            flags: 0,
+            offset: shstrtab.0,
+            size: shstrtab.1,
+            link: 0,
+            info: 0,
+            align: 1,
+            entsize: 0,
+        },
+    ]
+}
+
 /// Pad `v` with zero bytes up to a multiple of `to`.
 fn align(v: &mut Vec<u8>, to: usize) {
     while !v.len().is_multiple_of(to) {
@@ -319,7 +589,7 @@ fn align(v: &mut Vec<u8>, to: usize) {
 }
 
 /// Write the 64-byte ELF header.
-fn write_ehdr(out: &mut Vec<u8>, shoff: u64) {
+fn write_ehdr(out: &mut Vec<u8>, shoff: u64, shnum: u16, shstrndx: u16) {
     out.extend_from_slice(&ELF_MAGIC);
     out.push(ELFCLASS64);
     out.push(ELFDATA2LSB);
@@ -336,8 +606,8 @@ fn write_ehdr(out: &mut Vec<u8>, shoff: u64) {
     out.extend_from_slice(&0u16.to_le_bytes()); // e_phentsize
     out.extend_from_slice(&0u16.to_le_bytes()); // e_phnum
     out.extend_from_slice(&64u16.to_le_bytes()); // e_shentsize = sizeof(Elf64_Shdr)
-    out.extend_from_slice(&SEC_COUNT.to_le_bytes()); // e_shnum
-    out.extend_from_slice(&SEC_SHSTRTAB.to_le_bytes()); // e_shstrndx
+    out.extend_from_slice(&shnum.to_le_bytes()); // e_shnum
+    out.extend_from_slice(&shstrndx.to_le_bytes()); // e_shstrndx
 }
 
 /// One ELF section header, ready to encode.
@@ -385,12 +655,17 @@ impl Shdr {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ebpf::emit::emit_program;
+    use crate::ebpf::emit::{TargetAbi, emit_program, emit_program_for_target};
     use bpf_tcl_ir::compile_module;
 
     fn obj_for(src: &str) -> EbpfObject {
         let m = compile_module(src).expect("compiles");
         emit_program(&m.programs[0].program).expect("emits")
+    }
+
+    fn kernel_obj(src: &str, target: TargetAbi) -> EbpfObject {
+        let m = compile_module(src).expect("compiles");
+        emit_program_for_target(&m.programs[0].program, target).expect("emits")
     }
 
     fn le16(b: &[u8], o: usize) -> u16 {
@@ -439,7 +714,6 @@ mod tests {
         let raw_len = obj.raw.len();
         let o = write_object(&obj, "xdp").unwrap();
 
-        // Walk the section headers to find the symbol table.
         let shoff = le64(&o, 40);
         let mut symtab: Option<(usize, usize)> = None;
         for i in 0..usize::from(SEC_COUNT) {
@@ -451,25 +725,68 @@ mod tests {
         let (off, size) = symtab.expect("symtab present");
         assert_eq!(size, 3 * SYM_SIZE);
 
-        // Symbol #2 is the global FUNC for the program entry.
         let s2 = off + 2 * SYM_SIZE;
-        assert_eq!(o[s2 + 4], (STB_GLOBAL << 4) | STT_FUNC); // st_info
-        assert_eq!(le16(&o, s2 + 6), SEC_PROG); // st_shndx
-        assert_eq!(le64(&o, s2 + 16), raw_len); // st_size == program bytes
+        assert_eq!(o[s2 + 4], (STB_GLOBAL << 4) | STT_FUNC);
+        assert_eq!(le16(&o, s2 + 6), SEC_PROG);
+        assert_eq!(le64(&o, s2 + 16), raw_len);
     }
 
     #[test]
-    fn maps_are_rejected() {
+    fn rbpf_maps_need_a_kernel_target() {
         let src = "when SOCKET_FILTER { map m hash 8 8 8\n map_set m {0} {1}\n accept }\n";
         let err = write_object(&obj_for(src), "socket_filter").unwrap_err();
-        assert_eq!(err, ElfError::MapsUnsupported);
+        assert_eq!(err, ElfError::MapsNeedKernelTarget);
     }
 
     #[test]
     fn section_count_and_shstrndx_consistent() {
         let o = write_object(&obj_for("when XDP { drop }\n"), "xdp").unwrap();
-        // e_shoff points within the file, and there are exactly SEC_COUNT headers.
         let shoff = le64(&o, 40);
         assert_eq!(o.len(), shoff + usize::from(SEC_COUNT) * 64);
+    }
+
+    #[test]
+    fn kernel_map_object_has_maps_btf_and_reloc_sections() {
+        let obj = kernel_obj(
+            "when XDP {\n map hits array 4 8 4\n setint k 0\n map_get n hits {$k}\n pass }\n",
+            TargetAbi::KernelXdp,
+        );
+        let o = write_object(&obj, "xdp").unwrap();
+        assert_eq!(le16(&o, 60), M_SEC_COUNT); // e_shnum
+        assert_eq!(le16(&o, 62), M_SHSTRTAB);
+        assert!(contains(&o, b".maps\0"));
+        assert!(contains(&o, b".BTF\0"));
+        assert!(contains(&o, b".relxdp\0"));
+        assert!(contains(&o, b"hits\0"));
+
+        // Walk to the SHT_REL section and confirm one entry pointing at the
+        // program's map-fd load and the map's global object symbol.
+        let shoff = le64(&o, 40);
+        let mut rel: Option<(usize, usize, u32)> = None;
+        for i in 0..usize::from(M_SEC_COUNT) {
+            let sh = shoff + i * 64;
+            if le32(&o, sh + 4) == SHT_REL {
+                rel = Some((le64(&o, sh + 24), le64(&o, sh + 32), le32(&o, sh + 44)));
+            }
+        }
+        let (off, size, info_sec) = rel.expect("rel section present");
+        assert_eq!(size, REL_SIZE, "exactly one relocation");
+        assert_eq!(info_sec, u32::from(M_PROG), "rel targets the prog section");
+        let r_offset = le64(&o, off);
+        assert_eq!(
+            r_offset,
+            obj.relocations[0].insn_index as usize * 8,
+            "reloc offset is the map-fd load byte offset"
+        );
+        let sym = le32(&o, off + 12); // high word of r_info = symbol index
+        assert_eq!(sym, 3, "references the first global (map) symbol");
+    }
+
+    #[test]
+    fn kernel_map_free_object_uses_the_compact_layout() {
+        // A kernel object with no maps still uses the six-section layout.
+        let obj = kernel_obj("when XDP { pass }\n", TargetAbi::KernelXdp);
+        let o = write_object(&obj, "xdp").unwrap();
+        assert_eq!(le16(&o, 60), SEC_COUNT);
     }
 }

--- a/rust/bpf-tcl-codegen/src/ebpf/emit.rs
+++ b/rust/bpf-tcl-codegen/src/ebpf/emit.rs
@@ -33,15 +33,18 @@
 
 use std::collections::HashMap;
 
-use bpf_tcl_ir::ir::{Block, BpfProgram, CmpOp, Inst, IntBinOp, MapDef, ProgType, Term, UnOp};
-use bpf_tcl_ir::ty::Width;
+use bpf_tcl_ir::ir::{
+    Block, BpfProgram, CmpOp, Inst, IntBinOp, MapDef, OobAction, ProgType, Term, UnOp,
+};
+use bpf_tcl_ir::ty::{ByteOrder, Width};
 use bpf_tcl_ir::{BpfDiag, BpfError};
 use tcl_lexer::Span;
 
 use crate::ebpf::insn::{
-    ADD, AND, ARSH, DIV, Insn, JEQ, JNE, JSGE, JSGT, JSLE, JSLT, LSH, MOD, MUL, OR, R0, R1, R2, R3,
-    R6, R7, R10, SUB, SZ_B, SZ_DW, SZ_H, SZ_W, XOR, alu64_imm, alu64_reg, alu64_reg_off, call,
-    exit, ja, jmp_imm, jmp_reg, ldx, mov64_imm, mov64_reg, neg64, st_imm, stx,
+    ADD, AND, ARSH, DIV, Insn, JEQ, JLE, JNE, JSGE, JSGT, JSLE, JSLT, LSH, MOD, MUL, OR, R0, R1,
+    R2, R3, R6, R7, R10, SUB, SZ_B, SZ_DW, SZ_H, SZ_W, XOR, alu64_imm, alu64_reg, alu64_reg_off,
+    bswap_be, bswap_le, call, exit, ja, jmp_imm, jmp_reg, lddw, ldx, mov64_imm, mov64_reg, neg64,
+    st_imm, stx,
 };
 
 /// Packet `data` pointer (loaded from the metadata buffer; callee-saved).
@@ -58,6 +61,8 @@ const DATA_END_OFF: i16 = 8;
 const MAP_GET_ID: i32 = 1;
 /// Helper id for `map_set`.
 const MAP_SET_ID: i32 = 2;
+/// Helper id for `map_has` (key-presence test).
+const MAP_HAS_ID: i32 = 3;
 
 /// The execution ABI an emitted instruction stream targets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -119,10 +124,13 @@ impl EbpfObject {
 }
 
 /// A not-yet-laid-out instruction. Block jumps carry a target block id resolved
-/// to a relative offset in a second pass. Every variant is exactly one slot, so
-/// the pending index equals the final instruction index.
+/// to a relative offset in a second pass. A `Pending` may expand to more than
+/// one instruction (`Wide` is two), so pending-index and instruction-index are
+/// distinct — a prefix sum maps between them.
 enum Pending {
     Ins(Insn),
+    /// A two-instruction wide-immediate load (`lddw`).
+    Wide([Insn; 2]),
     /// `ja <block>`
     Ja(u32),
     /// `if reg != 0 goto <block>`
@@ -130,6 +138,16 @@ enum Pending {
         reg: u8,
         target: u32,
     },
+}
+
+impl Pending {
+    /// How many machine instructions this pending item expands to.
+    fn len(&self) -> usize {
+        match self {
+            Pending::Wide(_) => 2,
+            _ => 1,
+        }
+    }
 }
 
 /// Stack offset of a slot: slot `i` lives at `[r10 - 8*(i+1)]`.
@@ -167,10 +185,11 @@ pub fn emit_program_for_target(
         pend.push(Pending::Ins(ldx(SZ_DW, RPTR, R1, DATA_OFF)));
         pend.push(Pending::Ins(ldx(SZ_DW, REND, R1, DATA_END_OFF)));
     }
-    // Zero every slot so no value is read before it is written (verifier "init
-    // before read").
-    for i in 0..prog.num_slots {
-        pend.push(Pending::Ins(st_imm(SZ_DW, R10, slot_off(i), 0)));
+    // Zero only the slots that may be read before being written (the
+    // liveness-based zero-init set), not every slot — blanket zeroing wastes
+    // instructions and verifier state. `assign_slots` computed this set.
+    for slot in &prog.zero_init {
+        pend.push(Pending::Ins(st_imm(SZ_DW, R10, slot_off(slot.0), 0)));
     }
 
     // Lay out the entry block first, then the rest in id order.
@@ -184,26 +203,44 @@ pub fn emit_program_for_target(
         }
     }
 
+    // `block_start` keys are *pending* indices; converted to instruction
+    // indices via the prefix sum below.
     let mut block_start: HashMap<u32, usize> = HashMap::new();
     for block in &order {
         block_start.insert(block.id.0, pend.len());
         for inst in &block.insts {
-            emit_inst(inst, &mut pend)?;
+            emit_inst(inst, target_abi, &mut pend)?;
         }
         emit_term(&block.term, &mut pend);
     }
 
-    // Resolve block jumps to relative offsets.
-    let mut insns = Vec::with_capacity(pend.len());
-    for (idx, p) in pend.iter().enumerate() {
-        let insn = match p {
-            Pending::Ins(i) => *i,
-            Pending::Ja(target) => ja(rel_off(idx, block_start[target])?),
-            Pending::JmpNeZero { reg, target } => {
-                jmp_imm(JNE, *reg, 0, rel_off(idx, block_start[target])?)
+    // Prefix sum: instruction index at which each pending item begins.
+    let mut insn_index_of: Vec<usize> = Vec::with_capacity(pend.len() + 1);
+    let mut acc = 0usize;
+    for p in &pend {
+        insn_index_of.push(acc);
+        acc += p.len();
+    }
+    insn_index_of.push(acc);
+    let block_insn_start = |pend_idx: usize| -> usize { insn_index_of[pend_idx] };
+
+    // Resolve block jumps to relative offsets in instruction units.
+    let mut insns = Vec::with_capacity(acc);
+    for (pend_idx, p) in pend.iter().enumerate() {
+        let here = insn_index_of[pend_idx];
+        match p {
+            Pending::Ins(i) => insns.push(*i),
+            Pending::Wide(pair) => insns.extend_from_slice(pair),
+            Pending::Ja(target) => {
+                insns.push(ja(rel_off(here, block_insn_start(block_start[target]))?));
             }
-        };
-        insns.push(insn);
+            Pending::JmpNeZero { reg, target } => insns.push(jmp_imm(
+                JNE,
+                *reg,
+                0,
+                rel_off(here, block_insn_start(block_start[target]))?,
+            )),
+        }
     }
     Ok(EbpfObject::assemble(
         target_abi,
@@ -236,7 +273,9 @@ fn validate_target(prog: &BpfProgram, target_abi: TargetAbi) -> Result<(), BpfEr
             Inst::CtxPtr { span, .. } => (Some("`setbuf`"), *span),
             Inst::CtxLen { span, .. } => (Some("`pktlen`"), *span),
             Inst::Load { span, .. } => (Some("packet loads"), *span),
-            Inst::MapGet { span, .. } | Inst::MapSet { span, .. } => (Some("map access"), *span),
+            Inst::MapGet { span, .. } | Inst::MapHas { span, .. } | Inst::MapSet { span, .. } => {
+                (Some("map access"), *span)
+            }
             _ => (None, Span::empty(0)),
         };
         if let Some(operation) = unsupported {
@@ -264,17 +303,17 @@ fn rel_off(from: usize, to: usize) -> Result<i16, BpfError> {
     })
 }
 
-fn emit_inst(inst: &Inst, pend: &mut Vec<Pending>) -> Result<(), BpfError> {
+fn emit_inst(inst: &Inst, target_abi: TargetAbi, pend: &mut Vec<Pending>) -> Result<(), BpfError> {
     match inst {
-        Inst::Const { dst, val, span } => {
-            let imm = i32::try_from(*val).map_err(|_| {
-                BpfError::new(
-                    BpfDiag::BadInt,
-                    *span,
-                    format!("constant {val} is out of 32-bit range (a v1 limitation)"),
-                )
-            })?;
-            pend.push(Pending::Ins(mov64_imm(R1, imm)));
+        Inst::Const { dst, val, .. } => {
+            // A value fitting a sign-extended 32-bit immediate uses the single
+            // `mov`; a full 64-bit constant uses the two-instruction `lddw`
+            // (`RUST_ISSUE_172`: large constants must materialise correctly).
+            if let Ok(imm) = i32::try_from(*val) {
+                pend.push(Pending::Ins(mov64_imm(R1, imm)));
+            } else {
+                pend.push(Pending::Wide(lddw(R1, *val)));
+            }
             pend.push(Pending::Ins(stx(SZ_DW, R10, R1, slot_off(dst.0))));
         }
         Inst::Copy { dst, src, .. } => {
@@ -321,29 +360,19 @@ fn emit_inst(inst: &Inst, pend: &mut Vec<Pending>) -> Result<(), BpfError> {
             pend.push(Pending::Ins(alu64_reg(SUB, R1, RPTR)));
             pend.push(Pending::Ins(stx(SZ_DW, R10, R1, slot_off(dst.0))));
         }
-        Inst::Load {
-            dst,
-            width,
-            ptr,
-            off,
-            span,
-        } => {
-            let off16 = i16::try_from(*off).map_err(|_| {
-                BpfError::new(
-                    BpfDiag::BadInt,
-                    *span,
-                    "load offset out of range (must fit in 16 bits)",
-                )
-            })?;
-            pend.push(Pending::Ins(ldx(SZ_DW, R1, R10, slot_off(ptr.0))));
-            pend.push(Pending::Ins(ldx(width_size(*width), R2, R1, off16)));
-            pend.push(Pending::Ins(stx(SZ_DW, R10, R2, slot_off(dst.0))));
-        }
+        load @ Inst::Load { .. } => emit_load(load, target_abi, pend)?,
         Inst::MapGet { dst, map, key, .. } => {
             // r1 = map index, r2 = key; r0 = map_get(...); store r0.
             pend.push(Pending::Ins(mov64_imm(R1, map_imm(*map))));
             pend.push(Pending::Ins(ldx(SZ_DW, R2, R10, slot_off(key.0))));
             pend.push(Pending::Ins(call(MAP_GET_ID)));
+            pend.push(Pending::Ins(stx(SZ_DW, R10, R0, slot_off(dst.0))));
+        }
+        Inst::MapHas { dst, map, key, .. } => {
+            // r1 = map index, r2 = key; r0 = map_has(...) (1 present / 0 absent).
+            pend.push(Pending::Ins(mov64_imm(R1, map_imm(*map))));
+            pend.push(Pending::Ins(ldx(SZ_DW, R2, R10, slot_off(key.0))));
+            pend.push(Pending::Ins(call(MAP_HAS_ID)));
             pend.push(Pending::Ins(stx(SZ_DW, R10, R0, slot_off(dst.0))));
         }
         Inst::MapSet { map, key, val, .. } => {
@@ -354,6 +383,79 @@ fn emit_inst(inst: &Inst, pend: &mut Vec<Pending>) -> Result<(), BpfError> {
             pend.push(Pending::Ins(call(MAP_SET_ID)));
         }
     }
+    Ok(())
+}
+
+/// Emit a checked packet load honouring its byte order and out-of-bounds
+/// action. Under the rbpf metadata-buffer ABI the callee-saved `r7` holds
+/// `data_end`, so the load first proves the field lies inside the packet:
+///
+/// ```text
+///   r2 = base                       ; the bound packet pointer
+///   r2 += off + width               ; one past the field
+///   if r2 <= r7 goto +2             ; in bounds → skip the OOB return
+///   r0 = <oob verdict>; exit        ; short packet → take the OOB action
+///   r2 = *(width *)(base + off)      ; the load itself
+///   r2 = bswap(r2)                   ; byte-order conversion (multi-byte only)
+///   store r2
+/// ```
+///
+/// This is the verifier-safe shape (a dominating `ptr + off + width <=
+/// data_end` check before the dereference), so a short packet returns the
+/// declared verdict instead of trapping in the simulator.
+fn emit_load(load: &Inst, target_abi: TargetAbi, pend: &mut Vec<Pending>) -> Result<(), BpfError> {
+    let Inst::Load {
+        dst,
+        width,
+        ptr,
+        off,
+        order,
+        oob,
+        span,
+    } = load
+    else {
+        return Err(BpfError::new(
+            BpfDiag::Internal,
+            Span::empty(0),
+            "emit_load called with a non-load instruction",
+        ));
+    };
+    let (dst, width, ptr, off, order, oob, span) = (*dst, *width, *ptr, *off, *order, *oob, *span);
+    let off16 = i16::try_from(off).map_err(|_| {
+        BpfError::new(
+            BpfDiag::BadInt,
+            span,
+            "load offset out of range (must fit in 16 bits)",
+        )
+    })?;
+    // Only the rbpf simulator target reaches codegen with a packet load; the
+    // kernel-XDP slice rejects context access in `validate_target`. When a
+    // kernel context ABI lands it emits its own proof against `xdp_md`.
+    debug_assert_eq!(target_abi, TargetAbi::RbpfFixedMbuff);
+    let field_end = i32::try_from(width.bytes()).unwrap_or(0) + off;
+    let OobAction::ReturnVerdict(verdict) = oob;
+    let vimm = i32::try_from(verdict).unwrap_or(0);
+
+    // Bounds proof: r2 = base + field_end; if r2 <= data_end skip the return.
+    pend.push(Pending::Ins(ldx(SZ_DW, R2, R10, slot_off(ptr.0))));
+    pend.push(Pending::Ins(alu64_imm(ADD, R2, field_end)));
+    pend.push(Pending::Ins(jmp_reg(JLE, R2, R7, 2)));
+    pend.push(Pending::Ins(mov64_imm(R0, vimm)));
+    pend.push(Pending::Ins(exit()));
+
+    // The load itself, from the original base pointer.
+    pend.push(Pending::Ins(ldx(SZ_DW, R1, R10, slot_off(ptr.0))));
+    pend.push(Pending::Ins(ldx(width_size(width), R2, R1, off16)));
+    // Byte-order conversion (a single-byte field needs none).
+    if width != Width::B8 {
+        let bits = i32::try_from(width.bytes()).unwrap_or(0) * 8;
+        match order {
+            ByteOrder::Big => pend.push(Pending::Ins(bswap_be(R2, bits))),
+            ByteOrder::Little => pend.push(Pending::Ins(bswap_le(R2, bits))),
+            ByteOrder::Native => {}
+        }
+    }
+    pend.push(Pending::Ins(stx(SZ_DW, R10, R2, slot_off(dst.0))));
     Ok(())
 }
 
@@ -382,15 +484,19 @@ fn emit_term(term: &Term, pend: &mut Vec<Pending>) {
 
 /// Map an [`IntBinOp`] to its eBPF ALU opcode plus the instruction `off` field.
 ///
-/// Tcl integers are signed 64-bit — the CFG lowers comparisons to signed jumps
-/// (`JSLT`, …) and uses sign-extending moves — so `/`, `%`, and `>>` must use the
-/// **signed** eBPF ops. `BPF_SDIV` / `BPF_SMOD` are encoded as `DIV` / `MOD` with
-/// `off == 1`; the plain unsigned `DIV` / `MOD` (off 0) reinterpret a negative
-/// operand as a huge unsigned value, giving a catastrophically wrong result
-/// silently (`RUST_ISSUE_031`). `>>` likewise lowers to the arithmetic
-/// (sign-preserving) `ARSH`, not the logical `RSH`, so `-8 >> 1` is `-4` as Tcl
-/// requires rather than a huge positive (`RUST_ISSUE_062` / `097`). Every other
-/// op keeps `off == 0`.
+/// **Integer-semantics contract.** BPF-Tcl integers are signed 64-bit, but
+/// `/` and `%` follow eBPF's **signed truncated-toward-zero** division
+/// (`BPF_SDIV` / `BPF_SMOD`), *not* Tcl's floor division. The two agree for
+/// operands of the same sign and diverge only when exactly one operand is
+/// negative: `-7 / 2` is `-3` here (truncation) where Tcl yields `-4` (floor),
+/// and `-7 % 2` is `-1` here where Tcl yields `1`. This narrower, verifier-
+/// native contract is deliberate and documented (issue #1202); the front-end
+/// does not silently pretend to be Tcl. `BPF_SDIV` / `BPF_SMOD` are encoded as
+/// `DIV` / `MOD` with `off == 1`; the plain unsigned forms (off 0) reinterpret
+/// a negative operand as a huge unsigned value, giving a catastrophically
+/// wrong result (`RUST_ISSUE_031`). `>>` lowers to the arithmetic
+/// (sign-preserving) `ARSH`, not the logical `RSH`, so `-8 >> 1` is `-4`
+/// (`RUST_ISSUE_062` / `097`). Every other op keeps `off == 0`.
 fn bin_alu(op: IntBinOp) -> (u8, i16) {
     match op {
         IntBinOp::Add => (ADD, 0),
@@ -453,7 +559,10 @@ mod tests {
         let obj = emit_program_for_target(&module.programs[0].program, TargetAbi::KernelXdp)
             .expect("emits for the kernel");
         assert_eq!(obj.target_abi, TargetAbi::KernelXdp);
-        assert_eq!(obj.insns.len(), 5);
+        // No prologue and no slot zeroing (the `pass` verdict's slot is
+        // written before it is read, so the liveness-based zero-init set is
+        // empty): `mov r1,2; stx; ldx r0; exit` — four instructions.
+        assert_eq!(obj.insns.len(), 4);
         assert_ne!(obj.insns[0], ldx(SZ_DW, R6, R1, 0));
         assert_eq!(obj.insns.last().unwrap().op, 0x95);
     }

--- a/rust/bpf-tcl-codegen/src/ebpf/emit.rs
+++ b/rust/bpf-tcl-codegen/src/ebpf/emit.rs
@@ -18,18 +18,27 @@
 
 //! BPF-IR → eBPF bytecode. A deliberately simple v1 codegen: every value lives
 //! in its own stack slot, and each instruction loads its operands into scratch
-//! registers, computes, and stores back. No register allocation, no calls.
+//! registers, computes, and stores back. No register allocation, no calls
+//! except map helpers.
 //!
-//! The default calling convention uses rbpf's `EbpfVmFixedMbuff`: `r1` is a
-//! metadata buffer whose first two
-//! 64-bit words are the packet `data` pointer (offset 0) and `data_end` pointer
-//! (offset 8). The prologue loads them into the callee-saved `r6` (`data`) and
-//! `r7` (`data_end`) so they survive the whole program; the packet length is
-//! `data_end - data`.
+//! Three execution ABIs share this backend (see [`TargetAbi`]):
 //!
-//! The explicit kernel-XDP target is a separate ABI. Its initial vertical slice
-//! supports map-free verdict-only programs and rejects context access until
-//! verifier-safe `xdp_md` lowering exists.
+//! - `RbpfFixedMbuff` — the userspace [`rbpf`](https://docs.rs/rbpf) simulator.
+//!   `r1` is a metadata buffer whose first two 64-bit words are the packet
+//!   `data` and `data_end` pointers (offsets 0 and 8). Map helpers pass the map
+//!   index and integer key/value by value.
+//! - `KernelXdp` — Linux `BPF_PROG_TYPE_XDP`. `r1` is `struct xdp_md`; `data`
+//!   and `data_end` are 32-bit context fields the verifier rewrites into a
+//!   packet pointer / packet-end pointer.
+//! - `KernelSocketFilter` — Linux `BPF_PROG_TYPE_SOCKET_FILTER`. `r1` is
+//!   `struct __sk_buff`; direct packet access reads `data` / `data_end` at their
+//!   `__sk_buff` offsets.
+//!
+//! Both kernel targets emit real map ABIs: a `ld_imm64` pseudo map-fd load
+//! (relocated by libbpf against the map symbol), a stack-resident key/value, and
+//! `bpf_map_lookup_elem` / `bpf_map_update_elem` helper calls. Both emit a
+//! dominating `data + off + width <= data_end` proof before every packet
+//! dereference, so the kernel verifier accepts the load.
 
 use std::collections::HashMap;
 
@@ -41,38 +50,37 @@ use bpf_tcl_ir::{BpfDiag, BpfError};
 use tcl_lexer::Span;
 
 use crate::ebpf::insn::{
-    ADD, AND, ARSH, DIV, Insn, JEQ, JLE, JNE, JSGE, JSGT, JSLE, JSLT, LSH, MOD, MUL, OR, R0, R1,
-    R2, R3, R6, R7, R10, SUB, SZ_B, SZ_DW, SZ_H, SZ_W, XOR, alu64_imm, alu64_reg, alu64_reg_off,
-    bswap_be, bswap_le, call, exit, ja, jmp_imm, jmp_reg, lddw, ldx, mov64_imm, mov64_reg, neg64,
-    st_imm, stx,
+    ADD, AND, ARSH, DIV, FN_MAP_LOOKUP, FN_MAP_UPDATE, Insn, JEQ, JLE, JNE, JSGE, JSGT, JSLE, JSLT,
+    LSH, MOD, MUL, OR, PSEUDO_MAP_FD, R0, R1, R2, R3, R4, R6, R7, R10, SUB, SZ_B, SZ_DW, SZ_H,
+    SZ_W, XOR, alu64_imm, alu64_reg, alu64_reg_off, bswap_be, bswap_le, call, exit, ja, jmp_imm,
+    jmp_reg, lddw, lddw_src, ldx, mov64_imm, mov64_reg, neg64, st_imm, stx,
 };
 
-/// Packet `data` pointer (loaded from the metadata buffer; callee-saved).
+/// Packet `data` pointer (callee-saved). Under rbpf it is a 64-bit metadata
+/// word; under a kernel target it is the verifier's `PTR_TO_PACKET`.
 const RPTR: u8 = R6;
 /// Packet `data_end` pointer (callee-saved).
 const REND: u8 = R7;
 
-/// Offset in the metadata buffer (r1) holding the `data` pointer.
-const DATA_OFF: i16 = 0;
-/// Offset in the metadata buffer (r1) holding the `data_end` pointer.
-const DATA_END_OFF: i16 = 8;
+/// Helper id for the rbpf simulator's by-value `map_get`.
+const RBPF_MAP_GET_ID: i32 = 1;
+/// Helper id for the rbpf simulator's by-value `map_set`.
+const RBPF_MAP_SET_ID: i32 = 2;
+/// Helper id for the rbpf simulator's by-value `map_has`.
+const RBPF_MAP_HAS_ID: i32 = 3;
 
-/// Helper id for `map_get` (must match the run harness registration).
-const MAP_GET_ID: i32 = 1;
-/// Helper id for `map_set`.
-const MAP_SET_ID: i32 = 2;
-/// Helper id for `map_has` (key-presence test).
-const MAP_HAS_ID: i32 = 3;
+/// The maximum eBPF stack, in bytes (`MAX_BPF_STACK`).
+const MAX_STACK: i32 = 512;
 
 /// The execution ABI an emitted instruction stream targets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TargetAbi {
     /// The userspace `rbpf::EbpfVmFixedMbuff` metadata-buffer ABI.
     RbpfFixedMbuff,
-    /// Linux `BPF_PROG_TYPE_XDP`. The first vertical slice supports map-free,
-    /// verdict-only programs; context access is rejected until its verifier
-    /// proof lowering lands.
+    /// Linux `BPF_PROG_TYPE_XDP` (`struct xdp_md` context).
     KernelXdp,
+    /// Linux `BPF_PROG_TYPE_SOCKET_FILTER` (`struct __sk_buff` context).
+    KernelSocketFilter,
 }
 
 impl TargetAbi {
@@ -82,12 +90,62 @@ impl TargetAbi {
         match self {
             Self::RbpfFixedMbuff => "rbpf",
             Self::KernelXdp => "kernel-xdp",
+            Self::KernelSocketFilter => "kernel-socket",
+        }
+    }
+
+    /// Whether this target emits a Linux-kernel-loadable ABI (kernel context
+    /// fields, verifier proofs, pointer-based map helpers).
+    #[must_use]
+    pub const fn is_kernel(self) -> bool {
+        !matches!(self, Self::RbpfFixedMbuff)
+    }
+
+    /// The context layout: `data` / `data_end` field offsets and the load width
+    /// used to read them.
+    const fn ctx_layout(self) -> CtxLayout {
+        match self {
+            // The rbpf metadata buffer holds two 64-bit pointers.
+            Self::RbpfFixedMbuff => CtxLayout {
+                data_off: 0,
+                data_end_off: 8,
+                load_size: SZ_DW,
+            },
+            // `struct xdp_md { __u32 data; __u32 data_end; … }`.
+            Self::KernelXdp => CtxLayout {
+                data_off: 0,
+                data_end_off: 4,
+                load_size: SZ_W,
+            },
+            // `struct __sk_buff`: `data` at byte 76, `data_end` at byte 80.
+            Self::KernelSocketFilter => CtxLayout {
+                data_off: 76,
+                data_end_off: 80,
+                load_size: SZ_W,
+            },
         }
     }
 }
 
+/// The `data` / `data_end` context field offsets and the width used to read them.
+struct CtxLayout {
+    data_off: i16,
+    data_end_off: i16,
+    load_size: u8,
+}
+
+/// A relocation the ELF writer must emit: at instruction `insn_index`, a pseudo
+/// `ld_imm64` needs its immediate patched to map `map_index`'s file descriptor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MapReloc {
+    /// Instruction index of the `ld_imm64` (its byte offset is `index * 8`).
+    pub insn_index: u32,
+    /// The declared map this instruction references.
+    pub map_index: u32,
+}
+
 /// A compiled eBPF object: the instruction array plus its raw little-endian
-/// byte encoding (exactly what `rbpf` executes).
+/// byte encoding (exactly what `rbpf` executes or a loader submits).
 #[derive(Debug, Clone)]
 pub struct EbpfObject {
     /// The context/helper ABI this instruction stream targets.
@@ -98,8 +156,11 @@ pub struct EbpfObject {
     pub insns: Vec<Insn>,
     /// The flattened little-endian bytes (`insns.len() * 8`).
     pub raw: Vec<u8>,
-    /// Declared maps (so the run harness can size its map store).
+    /// Declared maps (so the run harness can size its map store and the ELF
+    /// writer can emit their definitions).
     pub maps: Vec<MapDef>,
+    /// Map file-descriptor relocations (kernel targets only).
+    pub relocations: Vec<MapReloc>,
 }
 
 impl EbpfObject {
@@ -108,6 +169,7 @@ impl EbpfObject {
         prog_type: ProgType,
         insns: Vec<Insn>,
         maps: Vec<MapDef>,
+        relocations: Vec<MapReloc>,
     ) -> Self {
         let mut raw = Vec::with_capacity(insns.len() * 8);
         for i in &insns {
@@ -119,6 +181,7 @@ impl EbpfObject {
             insns,
             raw,
             maps,
+            relocations,
         }
     }
 }
@@ -131,6 +194,11 @@ enum Pending {
     Ins(Insn),
     /// A two-instruction wide-immediate load (`lddw`).
     Wide([Insn; 2]),
+    /// A pseudo map-fd load into `r1` (two instructions), recorded as a
+    /// relocation against `map`.
+    MapFd {
+        map: u32,
+    },
     /// `ja <block>`
     Ja(u32),
     /// `if reg != 0 goto <block>`
@@ -144,7 +212,7 @@ impl Pending {
     /// How many machine instructions this pending item expands to.
     fn len(&self) -> usize {
         match self {
-            Pending::Wide(_) => 2,
+            Pending::Wide(_) | Pending::MapFd { .. } => 2,
             _ => 1,
         }
     }
@@ -156,7 +224,34 @@ fn slot_off(slot: u32) -> i16 {
     -i16::try_from((slot + 1) * 8).unwrap_or(i16::MAX)
 }
 
-/// Emit an eBPF object for a typed program.
+/// The emit-time context threaded through the per-instruction lowering: the
+/// target ABI plus the layout facts a kernel map helper needs (where the
+/// scratch key/value cells live above the slot region).
+#[derive(Clone, Copy)]
+struct EmitCtx {
+    target: TargetAbi,
+    /// Stack offset of the scratch cell holding a map key.
+    map_key_off: i16,
+    /// Stack offset of the scratch cell holding a map value.
+    map_value_off: i16,
+}
+
+impl EmitCtx {
+    fn new(target: TargetAbi, num_slots: u32) -> Self {
+        // The slot region occupies `[r10 - 8*num_slots .. r10]`. The map
+        // key/value scratch cells sit just above it.
+        let base = -(i32::try_from(num_slots).unwrap_or(0) * 8);
+        let map_key_off = i16::try_from(base - 8).unwrap_or(i16::MIN);
+        let map_value_off = i16::try_from(base - 16).unwrap_or(i16::MIN);
+        Self {
+            target,
+            map_key_off,
+            map_value_off,
+        }
+    }
+}
+
+/// Emit an eBPF object for a typed program (the rbpf simulator ABI).
 ///
 /// # Errors
 /// Returns a [`BpfError`] for v1 codegen limits (constant out of 32-bit range,
@@ -175,16 +270,11 @@ pub fn emit_program_for_target(
     target_abi: TargetAbi,
 ) -> Result<EbpfObject, BpfError> {
     validate_target(prog, target_abi)?;
+    let ctx = EmitCtx::new(target_abi, prog.num_slots);
     let mut pend: Vec<Pending> = Vec::new();
 
-    // The rbpf target exposes `data` / `data_end` as two 64-bit metadata words.
-    // A verdict-only kernel-XDP program does not touch its context, so it needs
-    // no prologue. Kernel context access is rejected by `validate_target` until
-    // correct `xdp_md` loads and verifier proofs are implemented.
-    if target_abi == TargetAbi::RbpfFixedMbuff {
-        pend.push(Pending::Ins(ldx(SZ_DW, RPTR, R1, DATA_OFF)));
-        pend.push(Pending::Ins(ldx(SZ_DW, REND, R1, DATA_END_OFF)));
-    }
+    emit_prologue(prog, target_abi, &mut pend);
+
     // Zero only the slots that may be read before being written (the
     // liveness-based zero-init set), not every slot — blanket zeroing wastes
     // instructions and verifier state. `assign_slots` computed this set.
@@ -209,7 +299,7 @@ pub fn emit_program_for_target(
     for block in &order {
         block_start.insert(block.id.0, pend.len());
         for inst in &block.insts {
-            emit_inst(inst, target_abi, &mut pend)?;
+            emit_inst(inst, ctx, &mut pend)?;
         }
         emit_term(&block.term, &mut pend);
     }
@@ -224,13 +314,21 @@ pub fn emit_program_for_target(
     insn_index_of.push(acc);
     let block_insn_start = |pend_idx: usize| -> usize { insn_index_of[pend_idx] };
 
-    // Resolve block jumps to relative offsets in instruction units.
+    // Resolve block jumps to relative offsets and record map-fd relocations.
     let mut insns = Vec::with_capacity(acc);
+    let mut relocations = Vec::new();
     for (pend_idx, p) in pend.iter().enumerate() {
         let here = insn_index_of[pend_idx];
         match p {
             Pending::Ins(i) => insns.push(*i),
             Pending::Wide(pair) => insns.extend_from_slice(pair),
+            Pending::MapFd { map } => {
+                relocations.push(MapReloc {
+                    insn_index: u32::try_from(here).unwrap_or(u32::MAX),
+                    map_index: *map,
+                });
+                insns.extend_from_slice(&lddw_src(R1, PSEUDO_MAP_FD, 0));
+            }
             Pending::Ja(target) => {
                 insns.push(ja(rel_off(here, block_insn_start(block_start[target]))?));
             }
@@ -247,44 +345,76 @@ pub fn emit_program_for_target(
         prog.prog_type,
         insns,
         prog.maps.clone(),
+        relocations,
     ))
 }
 
+/// Emit the context prologue that leaves `data` in `r6` and `data_end` in `r7`.
+///
+/// A verdict-only kernel program (no packet or context access) needs no
+/// prologue at all; the rbpf simulator always loads the metadata buffer.
+fn emit_prologue(prog: &BpfProgram, target: TargetAbi, pend: &mut Vec<Pending>) {
+    let needs_ctx = target == TargetAbi::RbpfFixedMbuff || program_uses_context(prog);
+    if !needs_ctx {
+        return;
+    }
+    let layout = target.ctx_layout();
+    pend.push(Pending::Ins(ldx(
+        layout.load_size,
+        RPTR,
+        R1,
+        layout.data_off,
+    )));
+    pend.push(Pending::Ins(ldx(
+        layout.load_size,
+        REND,
+        R1,
+        layout.data_end_off,
+    )));
+}
+
+/// Whether any instruction reads the packet context (so the prologue is needed).
+fn program_uses_context(prog: &BpfProgram) -> bool {
+    prog.blocks.iter().flat_map(|b| &b.insts).any(|inst| {
+        matches!(
+            inst,
+            Inst::CtxPtr { .. } | Inst::CtxLen { .. } | Inst::Load { .. }
+        )
+    })
+}
+
 fn validate_target(prog: &BpfProgram, target_abi: TargetAbi) -> Result<(), BpfError> {
-    if target_abi == TargetAbi::RbpfFixedMbuff {
+    if !target_abi.is_kernel() {
         return Ok(());
     }
-    if prog.prog_type != ProgType::Xdp {
+    let expected = match target_abi {
+        TargetAbi::KernelXdp => ProgType::Xdp,
+        TargetAbi::KernelSocketFilter => ProgType::SocketFilter,
+        TargetAbi::RbpfFixedMbuff => return Ok(()),
+    };
+    if prog.prog_type != expected {
         return Err(BpfError::new(
             BpfDiag::OutOfSubset,
             Span::empty(0),
-            "the `kernel-xdp` target only accepts `when XDP` programs",
+            format!(
+                "the `{}` target only accepts `{}` programs",
+                target_abi.as_str(),
+                match expected {
+                    ProgType::Xdp => "when XDP",
+                    ProgType::SocketFilter => "when SOCKET_FILTER",
+                }
+            ),
         ));
     }
+    // The kernel map helpers spill the key and value into two scratch cells
+    // above the slot region; guard the 512-byte stack.
     if !prog.maps.is_empty() {
-        return Err(BpfError::new(
-            BpfDiag::OutOfSubset,
-            prog.maps[0].span,
-            "the first `kernel-xdp` target slice is map-free (kernel map relocations are not implemented yet)",
-        ));
-    }
-    for inst in prog.blocks.iter().flat_map(|block| &block.insts) {
-        let (unsupported, span) = match inst {
-            Inst::CtxPtr { span, .. } => (Some("`setbuf`"), *span),
-            Inst::CtxLen { span, .. } => (Some("`pktlen`"), *span),
-            Inst::Load { span, .. } => (Some("packet loads"), *span),
-            Inst::MapGet { span, .. } | Inst::MapHas { span, .. } | Inst::MapSet { span, .. } => {
-                (Some("map access"), *span)
-            }
-            _ => (None, Span::empty(0)),
-        };
-        if let Some(operation) = unsupported {
+        let used = i32::try_from(prog.num_slots).unwrap_or(i32::MAX) * 8 + 16;
+        if used > MAX_STACK {
             return Err(BpfError::new(
                 BpfDiag::OutOfSubset,
-                span,
-                format!(
-                    "{operation} is not available in the first `kernel-xdp` target slice; only map-free, verdict-only handlers are kernel-loadable"
-                ),
+                prog.maps[0].span,
+                "program uses too much stack for kernel map key/value scratch (exceeds 512 bytes)",
             ));
         }
     }
@@ -303,7 +433,7 @@ fn rel_off(from: usize, to: usize) -> Result<i16, BpfError> {
     })
 }
 
-fn emit_inst(inst: &Inst, target_abi: TargetAbi, pend: &mut Vec<Pending>) -> Result<(), BpfError> {
+fn emit_inst(inst: &Inst, ctx: EmitCtx, pend: &mut Vec<Pending>) -> Result<(), BpfError> {
     match inst {
         Inst::Const { dst, val, .. } => {
             // A value fitting a sign-extended 32-bit immediate uses the single
@@ -360,54 +490,36 @@ fn emit_inst(inst: &Inst, target_abi: TargetAbi, pend: &mut Vec<Pending>) -> Res
             pend.push(Pending::Ins(alu64_reg(SUB, R1, RPTR)));
             pend.push(Pending::Ins(stx(SZ_DW, R10, R1, slot_off(dst.0))));
         }
-        load @ Inst::Load { .. } => emit_load(load, target_abi, pend)?,
-        Inst::MapGet { dst, map, key, .. } => {
-            // r1 = map index, r2 = key; r0 = map_get(...); store r0.
-            pend.push(Pending::Ins(mov64_imm(R1, map_imm(*map))));
-            pend.push(Pending::Ins(ldx(SZ_DW, R2, R10, slot_off(key.0))));
-            pend.push(Pending::Ins(call(MAP_GET_ID)));
-            pend.push(Pending::Ins(stx(SZ_DW, R10, R0, slot_off(dst.0))));
-        }
-        Inst::MapHas { dst, map, key, .. } => {
-            // r1 = map index, r2 = key; r0 = map_has(...) (1 present / 0 absent).
-            pend.push(Pending::Ins(mov64_imm(R1, map_imm(*map))));
-            pend.push(Pending::Ins(ldx(SZ_DW, R2, R10, slot_off(key.0))));
-            pend.push(Pending::Ins(call(MAP_HAS_ID)));
-            pend.push(Pending::Ins(stx(SZ_DW, R10, R0, slot_off(dst.0))));
-        }
-        Inst::MapSet { map, key, val, .. } => {
-            // r1 = map index, r2 = key, r3 = value; map_set(...).
-            pend.push(Pending::Ins(mov64_imm(R1, map_imm(*map))));
-            pend.push(Pending::Ins(ldx(SZ_DW, R2, R10, slot_off(key.0))));
-            pend.push(Pending::Ins(ldx(SZ_DW, R3, R10, slot_off(val.0))));
-            pend.push(Pending::Ins(call(MAP_SET_ID)));
-        }
+        load @ Inst::Load { .. } => emit_load(load, pend)?,
+        Inst::MapGet { dst, map, key, .. } => emit_map_get(ctx, *dst, *map, *key, pend),
+        Inst::MapHas { dst, map, key, .. } => emit_map_has(ctx, *dst, *map, *key, pend),
+        Inst::MapSet { map, key, val, .. } => emit_map_set(ctx, *map, *key, *val, pend),
     }
     Ok(())
 }
 
 /// Emit a checked packet load honouring its byte order and out-of-bounds
-/// action. Under the rbpf metadata-buffer ABI the callee-saved `r7` holds
-/// `data_end`, so the load first proves the field lies inside the packet:
+/// action. `r6` holds the packet `data` pointer and `r7` holds `data_end`, so
+/// the load first proves the field lies inside the packet:
 ///
 /// ```text
-///   r2 = base                       ; the bound packet pointer
-///   r2 += off + width               ; one past the field
-///   if r2 <= r7 goto +2             ; in bounds → skip the OOB return
-///   r0 = <oob verdict>; exit        ; short packet → take the OOB action
-///   r2 = *(width *)(base + off)      ; the load itself
-///   r2 = bswap(r2)                   ; byte-order conversion (multi-byte only)
+///   r2 = r6                          ; the packet pointer
+///   r2 += off + width                ; one past the field
+///   if r2 <= r7 goto +2              ; in bounds → skip the OOB return
+///   r0 = <oob verdict>; exit         ; short packet → take the OOB action
+///   r2 = *(width *)(r6 + off)         ; the load itself (r6 still `data`)
+///   r2 = bswap(r2)                    ; byte-order conversion (multi-byte only)
 ///   store r2
 /// ```
 ///
-/// This is the verifier-safe shape (a dominating `ptr + off + width <=
-/// data_end` check before the dereference), so a short packet returns the
-/// declared verdict instead of trapping in the simulator.
-fn emit_load(load: &Inst, target_abi: TargetAbi, pend: &mut Vec<Pending>) -> Result<(), BpfError> {
+/// This is the verifier-safe shape: the compared register (`r2 = r6 + C`) and
+/// the load base (`r6`) share a packet-pointer id, so proving `r6 + C <=
+/// data_end` teaches the verifier that `r6 + off` (with `off < C`) is in bounds.
+fn emit_load(load: &Inst, pend: &mut Vec<Pending>) -> Result<(), BpfError> {
     let Inst::Load {
         dst,
         width,
-        ptr,
+        ptr: _,
         off,
         order,
         oob,
@@ -420,7 +532,7 @@ fn emit_load(load: &Inst, target_abi: TargetAbi, pend: &mut Vec<Pending>) -> Res
             "emit_load called with a non-load instruction",
         ));
     };
-    let (dst, width, ptr, off, order, oob, span) = (*dst, *width, *ptr, *off, *order, *oob, *span);
+    let (dst, width, off, order, oob, span) = (*dst, *width, *off, *order, *oob, *span);
     let off16 = i16::try_from(off).map_err(|_| {
         BpfError::new(
             BpfDiag::BadInt,
@@ -428,24 +540,19 @@ fn emit_load(load: &Inst, target_abi: TargetAbi, pend: &mut Vec<Pending>) -> Res
             "load offset out of range (must fit in 16 bits)",
         )
     })?;
-    // Only the rbpf simulator target reaches codegen with a packet load; the
-    // kernel-XDP slice rejects context access in `validate_target`. When a
-    // kernel context ABI lands it emits its own proof against `xdp_md`.
-    debug_assert_eq!(target_abi, TargetAbi::RbpfFixedMbuff);
     let field_end = i32::try_from(width.bytes()).unwrap_or(0) + off;
     let OobAction::ReturnVerdict(verdict) = oob;
     let vimm = i32::try_from(verdict).unwrap_or(0);
 
-    // Bounds proof: r2 = base + field_end; if r2 <= data_end skip the return.
-    pend.push(Pending::Ins(ldx(SZ_DW, R2, R10, slot_off(ptr.0))));
+    // Bounds proof: r2 = data + field_end; if r2 <= data_end skip the return.
+    pend.push(Pending::Ins(mov64_reg(R2, RPTR)));
     pend.push(Pending::Ins(alu64_imm(ADD, R2, field_end)));
-    pend.push(Pending::Ins(jmp_reg(JLE, R2, R7, 2)));
+    pend.push(Pending::Ins(jmp_reg(JLE, R2, REND, 2)));
     pend.push(Pending::Ins(mov64_imm(R0, vimm)));
     pend.push(Pending::Ins(exit()));
 
-    // The load itself, from the original base pointer.
-    pend.push(Pending::Ins(ldx(SZ_DW, R1, R10, slot_off(ptr.0))));
-    pend.push(Pending::Ins(ldx(width_size(width), R2, R1, off16)));
+    // The load itself, from the original packet pointer (still `data`).
+    pend.push(Pending::Ins(ldx(width_size(width), R2, RPTR, off16)));
     // Byte-order conversion (a single-byte field needs none).
     if width != Width::B8 {
         let bits = i32::try_from(width.bytes()).unwrap_or(0) * 8;
@@ -462,6 +569,104 @@ fn emit_load(load: &Inst, target_abi: TargetAbi, pend: &mut Vec<Pending>) -> Res
 /// A small map index as a 32-bit immediate.
 fn map_imm(map: u32) -> i32 {
     i32::try_from(map).unwrap_or(0)
+}
+
+/// `dst = map_get(map, key)`.
+fn emit_map_get(
+    ctx: EmitCtx,
+    dst: bpf_tcl_ir::ir::SlotId,
+    map: u32,
+    key: bpf_tcl_ir::ir::SlotId,
+    pend: &mut Vec<Pending>,
+) {
+    if !ctx.target.is_kernel() {
+        // rbpf: r1 = map index, r2 = key by value; r0 = map_get(...); store r0.
+        pend.push(Pending::Ins(mov64_imm(R1, map_imm(map))));
+        pend.push(Pending::Ins(ldx(SZ_DW, R2, R10, slot_off(key.0))));
+        pend.push(Pending::Ins(call(RBPF_MAP_GET_ID)));
+        pend.push(Pending::Ins(stx(SZ_DW, R10, R0, slot_off(dst.0))));
+        return;
+    }
+    emit_kernel_lookup(ctx, map, key, pend);
+    // r0 = value pointer or NULL. Default the result to 0 (absent), then load
+    // the value when present. r1 holds the result so a following store works.
+    pend.push(Pending::Ins(mov64_imm(R1, 0)));
+    pend.push(Pending::Ins(jmp_imm(JEQ, R0, 0, 1)));
+    pend.push(Pending::Ins(ldx(SZ_DW, R1, R0, 0)));
+    pend.push(Pending::Ins(stx(SZ_DW, R10, R1, slot_off(dst.0))));
+}
+
+/// `dst = map_has(map, key)` — 1 when present, 0 when absent.
+fn emit_map_has(
+    ctx: EmitCtx,
+    dst: bpf_tcl_ir::ir::SlotId,
+    map: u32,
+    key: bpf_tcl_ir::ir::SlotId,
+    pend: &mut Vec<Pending>,
+) {
+    if !ctx.target.is_kernel() {
+        pend.push(Pending::Ins(mov64_imm(R1, map_imm(map))));
+        pend.push(Pending::Ins(ldx(SZ_DW, R2, R10, slot_off(key.0))));
+        pend.push(Pending::Ins(call(RBPF_MAP_HAS_ID)));
+        pend.push(Pending::Ins(stx(SZ_DW, R10, R0, slot_off(dst.0))));
+        return;
+    }
+    emit_kernel_lookup(ctx, map, key, pend);
+    // r1 = (r0 != NULL) ? 1 : 0.
+    pend.push(Pending::Ins(mov64_imm(R1, 0)));
+    pend.push(Pending::Ins(jmp_imm(JEQ, R0, 0, 1)));
+    pend.push(Pending::Ins(mov64_imm(R1, 1)));
+    pend.push(Pending::Ins(stx(SZ_DW, R10, R1, slot_off(dst.0))));
+}
+
+/// `map_set(map, key, val)`.
+fn emit_map_set(
+    ctx: EmitCtx,
+    map: u32,
+    key: bpf_tcl_ir::ir::SlotId,
+    val: bpf_tcl_ir::ir::SlotId,
+    pend: &mut Vec<Pending>,
+) {
+    if !ctx.target.is_kernel() {
+        pend.push(Pending::Ins(mov64_imm(R1, map_imm(map))));
+        pend.push(Pending::Ins(ldx(SZ_DW, R2, R10, slot_off(key.0))));
+        pend.push(Pending::Ins(ldx(SZ_DW, R3, R10, slot_off(val.0))));
+        pend.push(Pending::Ins(call(RBPF_MAP_SET_ID)));
+        return;
+    }
+    // Spill key and value into their stack scratch cells.
+    pend.push(Pending::Ins(ldx(SZ_DW, R1, R10, slot_off(key.0))));
+    pend.push(Pending::Ins(stx(SZ_DW, R10, R1, ctx.map_key_off)));
+    pend.push(Pending::Ins(ldx(SZ_DW, R1, R10, slot_off(val.0))));
+    pend.push(Pending::Ins(stx(SZ_DW, R10, R1, ctx.map_value_off)));
+    // bpf_map_update_elem(map, &key, &value, BPF_ANY).
+    pend.push(Pending::MapFd { map });
+    pend.push(Pending::Ins(mov64_reg(R2, R10)));
+    pend.push(Pending::Ins(alu64_imm(ADD, R2, i32::from(ctx.map_key_off))));
+    pend.push(Pending::Ins(mov64_reg(R3, R10)));
+    pend.push(Pending::Ins(alu64_imm(
+        ADD,
+        R3,
+        i32::from(ctx.map_value_off),
+    )));
+    pend.push(Pending::Ins(mov64_imm(R4, 0)));
+    pend.push(Pending::Ins(call(FN_MAP_UPDATE)));
+}
+
+/// Emit the shared prefix of a kernel map lookup: spill the key to its scratch
+/// cell and call `bpf_map_lookup_elem(map, &key)`, leaving the result in `r0`.
+fn emit_kernel_lookup(
+    ctx: EmitCtx,
+    map: u32,
+    key: bpf_tcl_ir::ir::SlotId,
+    pend: &mut Vec<Pending>,
+) {
+    pend.push(Pending::Ins(ldx(SZ_DW, R1, R10, slot_off(key.0))));
+    pend.push(Pending::Ins(stx(SZ_DW, R10, R1, ctx.map_key_off)));
+    pend.push(Pending::MapFd { map });
+    pend.push(Pending::Ins(mov64_reg(R2, R10)));
+    pend.push(Pending::Ins(alu64_imm(ADD, R2, i32::from(ctx.map_key_off))));
+    pend.push(Pending::Ins(call(FN_MAP_LOOKUP)));
 }
 
 fn emit_term(term: &Term, pend: &mut Vec<Pending>) {
@@ -542,6 +747,11 @@ mod tests {
         emit_program(&module.programs[0].program).expect("emits")
     }
 
+    fn emit_kernel(src: &str, target: TargetAbi) -> EbpfObject {
+        let module = compile_module(src).expect("compiles");
+        emit_program_for_target(&module.programs[0].program, target).expect("emits for the kernel")
+    }
+
     #[test]
     fn accept_all_ends_in_exit() {
         let obj = emit_src("when SOCKET_FILTER { setbuf pkt ctx\n accept }\n");
@@ -554,33 +764,103 @@ mod tests {
     }
 
     #[test]
-    fn kernel_xdp_verdict_only_has_no_rbpf_context_prologue() {
-        let module = compile_module("when XDP { pass }\n").expect("compiles");
-        let obj = emit_program_for_target(&module.programs[0].program, TargetAbi::KernelXdp)
-            .expect("emits for the kernel");
+    fn kernel_xdp_verdict_only_has_no_context_prologue() {
+        let obj = emit_kernel("when XDP { pass }\n", TargetAbi::KernelXdp);
         assert_eq!(obj.target_abi, TargetAbi::KernelXdp);
-        // No prologue and no slot zeroing (the `pass` verdict's slot is
-        // written before it is read, so the liveness-based zero-init set is
-        // empty): `mov r1,2; stx; ldx r0; exit` — four instructions.
+        // No prologue and no slot zeroing: `mov r1,2; stx; ldx r0; exit`.
         assert_eq!(obj.insns.len(), 4);
         assert_ne!(obj.insns[0], ldx(SZ_DW, R6, R1, 0));
         assert_eq!(obj.insns.last().unwrap().op, 0x95);
     }
 
     #[test]
-    fn kernel_xdp_rejects_context_access_until_proof_lowering_exists() {
-        let module = compile_module("when XDP { setbuf packet ctx\n pass }\n").expect("compiles");
+    fn kernel_xdp_reads_xdp_md_context_fields() {
+        // `struct xdp_md`: data at byte 0, data_end at byte 4, both 32-bit.
+        let obj = emit_kernel(
+            "when XDP { setbuf p ctx\n load16 dport p 36\n pass }\n",
+            TargetAbi::KernelXdp,
+        );
+        assert_eq!(obj.insns[0], ldx(SZ_W, R6, R1, 0)); // r6 = data (u32)
+        assert_eq!(obj.insns[1], ldx(SZ_W, R7, R1, 4)); // r7 = data_end (u32)
+    }
+
+    #[test]
+    fn kernel_socket_reads_sk_buff_context_fields() {
+        // `struct __sk_buff`: data at byte 76, data_end at byte 80.
+        let obj = emit_kernel(
+            "when SOCKET_FILTER { setbuf p ctx\n load16 dport p 2\n accept }\n",
+            TargetAbi::KernelSocketFilter,
+        );
+        assert_eq!(obj.insns[0], ldx(SZ_W, R6, R1, 76));
+        assert_eq!(obj.insns[1], ldx(SZ_W, R7, R1, 80));
+    }
+
+    #[test]
+    fn kernel_packet_load_has_dominating_bounds_proof() {
+        let obj = emit_kernel(
+            "when XDP { setbuf p ctx\n load16 dport p 36\n pass }\n",
+            TargetAbi::KernelXdp,
+        );
+        // The load `*(u16*)(r6 + 36)` (op 0x69) must be preceded by a
+        // `if r2 <= r7 goto +N` (JLE reg, op 0xbd) comparing against data_end.
+        let load_pos = obj
+            .insns
+            .iter()
+            .position(|i| i.op == (SZ_H | 0x61) && i.src == R6 && i.off == 36)
+            .expect("a u16 packet load from r6+36");
+        let has_proof = obj.insns[..load_pos]
+            .iter()
+            .any(|i| i.op == (JLE | 0x0d) && i.src == REND);
+        assert!(
+            has_proof,
+            "load must be dominated by a data_end bounds check"
+        );
+    }
+
+    #[test]
+    fn kernel_map_lookup_emits_pseudo_fd_and_helper_call() {
+        let obj = emit_kernel(
+            "when XDP {\n map hits array 4 8 4\n setint k 0\n map_get n hits {$k}\n pass }\n",
+            TargetAbi::KernelXdp,
+        );
+        // One relocation for the single map-fd load.
+        assert_eq!(obj.relocations.len(), 1);
+        assert_eq!(obj.relocations[0].map_index, 0);
+        // The relocated instruction is a pseudo ld_imm64 (src = PSEUDO_MAP_FD).
+        let reloc_at = obj.relocations[0].insn_index as usize;
+        assert_eq!(obj.insns[reloc_at].src, PSEUDO_MAP_FD);
+        // A bpf_map_lookup_elem call (helper id 1) is present.
+        assert!(
+            obj.insns
+                .iter()
+                .any(|i| i.op == 0x85 && i.imm == FN_MAP_LOOKUP)
+        );
+    }
+
+    #[test]
+    fn kernel_map_update_emits_update_helper() {
+        let obj = emit_kernel(
+            "when XDP {\n map hits array 4 8 4\n setint k 0\n map_set hits {$k} {7}\n pass }\n",
+            TargetAbi::KernelXdp,
+        );
+        assert!(
+            obj.insns
+                .iter()
+                .any(|i| i.op == 0x85 && i.imm == FN_MAP_UPDATE)
+        );
+    }
+
+    #[test]
+    fn kernel_target_rejects_wrong_program_type() {
+        let module = compile_module("when SOCKET_FILTER { accept }\n").expect("compiles");
         let err = emit_program_for_target(&module.programs[0].program, TargetAbi::KernelXdp)
-            .expect_err("context ABI is not implemented");
+            .expect_err("socket filter is not an XDP program");
         assert_eq!(err.code, BpfDiag::OutOfSubset);
-        assert!(err.msg.contains("verdict-only"));
     }
 
     #[test]
     fn drop_is_mov0_exit() {
         let obj = emit_src("drop\n");
-        // Somewhere a `mov r0, <slot>` then exit; verify it ends exit and the
-        // verdict load targets r0.
         let n = obj.insns.len();
         assert_eq!(obj.insns[n - 1].op, 0x95); // exit
         assert_eq!(obj.insns[n - 2].dst, R0); // ldx r0, [r10-..]

--- a/rust/bpf-tcl-codegen/src/ebpf/insn.rs
+++ b/rust/bpf-tcl-codegen/src/ebpf/insn.rs
@@ -70,6 +70,19 @@ pub const DW: u8 = 0x18;
 // (`K`) bit clear it converts to little-endian; the `X` bit selects big-endian.
 pub const END: u8 = 0xd0;
 
+/// `BPF_PSEUDO_MAP_FD` — the `src_reg` value of a `ld_imm64` whose immediate is
+/// a map file descriptor. libbpf rewrites such an instruction's immediate to the
+/// real map fd at load time, driven by an ELF relocation against the map symbol.
+pub const PSEUDO_MAP_FD: u8 = 1;
+
+// ── kernel helper ids (`BPF_FUNC_*` from the UAPI helper table) ──────────────
+/// `bpf_map_lookup_elem(map, key) -> value_ptr_or_null`.
+pub const FN_MAP_LOOKUP: i32 = 1;
+/// `bpf_map_update_elem(map, key, value, flags) -> 0/err`.
+pub const FN_MAP_UPDATE: i32 = 2;
+/// `bpf_map_delete_elem(map, key) -> 0/err`.
+pub const FN_MAP_DELETE: i32 = 3;
+
 // ── ALU / JMP source ────────────────────────────────────────────────────────
 pub const K: u8 = 0x00; // immediate
 pub const X: u8 = 0x08; // src register
@@ -123,6 +136,7 @@ pub const R3: u8 = 3;
 pub const R4: u8 = 4;
 pub const R6: u8 = 6;
 pub const R7: u8 = 7;
+pub const R8: u8 = 8;
 pub const R10: u8 = 10;
 
 // ── builders ───────────────────────────────────────────────────────────────
@@ -284,13 +298,22 @@ pub fn call(helper_id: i32) -> Insn {
 /// 32 bits ride in the first instruction's `imm`, the high 32 bits in the
 /// second's; the second instruction has a zero opcode by convention.
 pub fn lddw(dst: u8, imm: i64) -> [Insn; 2] {
+    lddw_src(dst, 0, imm)
+}
+
+/// `dst = <pseudo imm64>` — a wide-immediate load with an explicit `src_reg`.
+///
+/// A `src_reg` of [`PSEUDO_MAP_FD`] marks the immediate as a map file
+/// descriptor placeholder (zero here), to be rewritten by libbpf from a
+/// relocation against the map symbol.
+pub fn lddw_src(dst: u8, src: u8, imm: i64) -> [Insn; 2] {
     let lo = (imm & 0xffff_ffff) as i32;
     let hi = ((imm >> 32) & 0xffff_ffff) as i32;
     [
         Insn {
             op: LD | IMM | DW,
             dst,
-            src: 0,
+            src,
             off: 0,
             imm: lo,
         },

--- a/rust/bpf-tcl-codegen/src/ebpf/insn.rs
+++ b/rust/bpf-tcl-codegen/src/ebpf/insn.rs
@@ -53,11 +53,22 @@ impl Insn {
 }
 
 // ── instruction classes (low 3 bits) ───────────────────────────────────────
+pub const LD: u8 = 0x00;
 pub const LDX: u8 = 0x01;
 pub const ST: u8 = 0x02;
 pub const STX: u8 = 0x03;
+pub const ALU: u8 = 0x04; // 32-bit ALU (used only for the byte-order ops)
 pub const JMP: u8 = 0x05;
 pub const ALU64: u8 = 0x07;
+
+// ── load mode: 64-bit immediate (`lddw`) ────────────────────────────────────
+pub const IMM: u8 = 0x00;
+pub const DW: u8 = 0x18;
+
+// ── byte-order (BPF_END) ────────────────────────────────────────────────────
+// The `BPF_END` operation converts a register's byte order. With the source
+// (`K`) bit clear it converts to little-endian; the `X` bit selects big-endian.
+pub const END: u8 = 0xd0;
 
 // ── ALU / JMP source ────────────────────────────────────────────────────────
 pub const K: u8 = 0x00; // immediate
@@ -92,9 +103,13 @@ pub const ARSH: u8 = 0xc0;
 // ── JMP operations (high nibble) ───────────────────────────────────────────
 pub const JA: u8 = 0x00;
 pub const JEQ: u8 = 0x10;
+/// Unsigned greater-than.
+pub const JGT: u8 = 0x20;
 pub const JNE: u8 = 0x50;
 pub const JSGT: u8 = 0x60;
 pub const JSGE: u8 = 0x70;
+/// Unsigned less-than-or-equal.
+pub const JLE: u8 = 0xb0;
 pub const JSLT: u8 = 0xc0;
 pub const JSLE: u8 = 0xd0;
 pub const EXIT: u8 = 0x90;
@@ -105,6 +120,7 @@ pub const R0: u8 = 0;
 pub const R1: u8 = 1;
 pub const R2: u8 = 2;
 pub const R3: u8 = 3;
+pub const R4: u8 = 4;
 pub const R6: u8 = 6;
 pub const R7: u8 = 7;
 pub const R10: u8 = 10;
@@ -261,5 +277,54 @@ pub fn call(helper_id: i32) -> Insn {
         src: 0,
         off: 0,
         imm: helper_id,
+    }
+}
+
+/// `dst = imm64` — the two-instruction wide immediate load (`lddw`). The low
+/// 32 bits ride in the first instruction's `imm`, the high 32 bits in the
+/// second's; the second instruction has a zero opcode by convention.
+pub fn lddw(dst: u8, imm: i64) -> [Insn; 2] {
+    let lo = (imm & 0xffff_ffff) as i32;
+    let hi = ((imm >> 32) & 0xffff_ffff) as i32;
+    [
+        Insn {
+            op: LD | IMM | DW,
+            dst,
+            src: 0,
+            off: 0,
+            imm: lo,
+        },
+        Insn {
+            op: 0,
+            dst: 0,
+            src: 0,
+            off: 0,
+            imm: hi,
+        },
+    ]
+}
+
+/// `dst = bswap<width>(dst)` selecting host↔big-endian (`bpf_htobe*`). `width`
+/// is 16, 32, or 64. Encoded as `BPF_ALU | BPF_X | BPF_END` (the X bit selects
+/// the big-endian direction), with the width in the immediate.
+pub fn bswap_be(dst: u8, width: i32) -> Insn {
+    Insn {
+        op: ALU | X | END,
+        dst,
+        src: 0,
+        off: 0,
+        imm: width,
+    }
+}
+
+/// `dst = bswap<width>(dst)` selecting host↔little-endian (`bpf_htole*`).
+/// Encoded as `BPF_ALU | BPF_K | BPF_END`.
+pub fn bswap_le(dst: u8, width: i32) -> Insn {
+    Insn {
+        op: ALU | K | END,
+        dst,
+        src: 0,
+        off: 0,
+        imm: width,
     }
 }

--- a/rust/bpf-tcl-codegen/src/ebpf/mod.rs
+++ b/rust/bpf-tcl-codegen/src/ebpf/mod.rs
@@ -19,12 +19,15 @@
 //! Direct eBPF bytecode backend: BPF-IR → eBPF instructions, encoded by our own
 //! 64-bit instruction model (no assembler, no LLVM in the compile path).
 
+pub mod btf;
 pub mod disasm;
 pub mod elf;
 pub mod emit;
 pub mod insn;
+pub mod verifier;
 
 pub use disasm::disasm;
 pub use elf::{ElfError, write_object};
-pub use emit::{EbpfObject, TargetAbi, emit_program, emit_program_for_target};
+pub use emit::{EbpfObject, MapReloc, TargetAbi, emit_program, emit_program_for_target};
 pub use insn::Insn;
+pub use verifier::{VerifyError, verify};

--- a/rust/bpf-tcl-codegen/src/ebpf/verifier.rs
+++ b/rust/bpf-tcl-codegen/src/ebpf/verifier.rs
@@ -1,0 +1,256 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! An in-repo verifier *model*: a structural check of the safety properties the
+//! Linux kernel verifier enforces, applied to our emitted kernel objects.
+//!
+//! This is **not** the kernel verifier — it does not run in a container without
+//! privilege, and it does not model register range tracking in full. It is a
+//! sound checker of the invariants our own codegen must maintain, so a codegen
+//! regression that would make the kernel reject a program is caught in a
+//! rootless test:
+//!
+//! - the program terminates in `exit` (no fall-through off the end);
+//! - the context prologue reads `data` / `data_end` at the target's field
+//!   offsets and width;
+//! - every packet dereference is dominated by a `data_end` bounds proof;
+//! - every pseudo map-fd `ld_imm64` has a matching relocation; and
+//! - every stack access lies within the 512-byte frame.
+//!
+//! Genuine kernel-verifier acceptance is asserted separately, behind an
+//! `#[ignore]`d privileged test (see `tests/kernel_load.rs`).
+
+use crate::ebpf::emit::{EbpfObject, TargetAbi};
+use crate::ebpf::insn::{Insn, PSEUDO_MAP_FD, R1, R6, R7, R10};
+
+/// A property the verifier model found violated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerifyError {
+    /// The program does not end in an `exit` instruction.
+    NoExit,
+    /// The context prologue does not read `data`/`data_end` correctly.
+    BadContextPrologue,
+    /// A packet load at this instruction index has no dominating `data_end`
+    /// bounds proof.
+    UnprovenPacketLoad(usize),
+    /// A pseudo map-fd load at this instruction index has no relocation.
+    MissingRelocation(usize),
+    /// A stack access at this instruction index is outside the 512-byte frame.
+    StackOutOfRange(usize),
+}
+
+const CLASS_MASK: u8 = 0x07;
+const LDX: u8 = 0x01;
+const STX: u8 = 0x03;
+const ST: u8 = 0x02;
+const LD: u8 = 0x00;
+const JMP: u8 = 0x05;
+const DW_MODE: u8 = 0x18; // LD | IMM | DW low bits for a wide load
+const EXIT_OP: u8 = 0x95;
+const JMP_X: u8 = 0x08; // register-source jump
+
+/// Verify an emitted kernel object against the model. Returns every violation
+/// found (empty when the object satisfies the model).
+///
+/// A non-kernel (`rbpf`) object is not modelled here — the userspace VM has its
+/// own load-time checks — so it always verifies clean.
+#[must_use]
+pub fn verify(obj: &EbpfObject) -> Vec<VerifyError> {
+    if !obj.target_abi.is_kernel() {
+        return Vec::new();
+    }
+    let mut errors = Vec::new();
+    check_exit(&obj.insns, &mut errors);
+    check_prologue(obj, &mut errors);
+    check_map_fd_relocations(obj, &mut errors);
+    check_stack_accesses(&obj.insns, &mut errors);
+    check_packet_loads(&obj.insns, &mut errors);
+    errors
+}
+
+fn check_exit(insns: &[Insn], errors: &mut Vec<VerifyError>) {
+    if insns.last().map(|i| i.op) != Some(EXIT_OP) {
+        errors.push(VerifyError::NoExit);
+    }
+}
+
+/// The prologue (when present) reads `data` into `r6` and `data_end` into `r7`
+/// from `r1` at the target's field offsets. A verdict-only program has no
+/// prologue and no packet access, so an absent prologue is only an error when
+/// the program actually dereferences the packet.
+fn check_prologue(obj: &EbpfObject, errors: &mut Vec<VerifyError>) {
+    let insns = &obj.insns;
+    let uses_packet = insns
+        .iter()
+        .any(|i| i.op & CLASS_MASK == LDX && i.src == R6);
+    if !uses_packet {
+        return;
+    }
+    let (data_off, data_end_off) = match obj.target_abi {
+        TargetAbi::KernelXdp => (0i16, 4i16),
+        TargetAbi::KernelSocketFilter => (76, 80),
+        TargetAbi::RbpfFixedMbuff => return,
+    };
+    let ok = insns.len() >= 2
+        && insns[0].op & CLASS_MASK == LDX
+        && insns[0].dst == R6
+        && insns[0].src == R1
+        && insns[0].off == data_off
+        && insns[1].op & CLASS_MASK == LDX
+        && insns[1].dst == R7
+        && insns[1].src == R1
+        && insns[1].off == data_end_off;
+    if !ok {
+        errors.push(VerifyError::BadContextPrologue);
+    }
+}
+
+/// Every pseudo map-fd `ld_imm64` (a wide load with `src == PSEUDO_MAP_FD`) must
+/// have a relocation recorded at its index.
+fn check_map_fd_relocations(obj: &EbpfObject, errors: &mut Vec<VerifyError>) {
+    for (i, insn) in obj.insns.iter().enumerate() {
+        let is_wide_load = insn.op & CLASS_MASK == LD && insn.op & DW_MODE == DW_MODE;
+        if is_wide_load && insn.src == PSEUDO_MAP_FD {
+            let has_reloc = obj.relocations.iter().any(|r| r.insn_index as usize == i);
+            if !has_reloc {
+                errors.push(VerifyError::MissingRelocation(i));
+            }
+        }
+    }
+}
+
+/// Stack accesses (base `r10`) must land within `[-512, 0)`.
+fn check_stack_accesses(insns: &[Insn], errors: &mut Vec<VerifyError>) {
+    for (i, insn) in insns.iter().enumerate() {
+        let class = insn.op & CLASS_MASK;
+        let base = match class {
+            LDX => insn.src,
+            STX | ST => insn.dst,
+            _ => continue,
+        };
+        if base == R10 && (insn.off >= 0 || insn.off < -512) {
+            errors.push(VerifyError::StackOutOfRange(i));
+        }
+    }
+}
+
+/// Every packet dereference (`ldx` from `r6`, past the prologue) must be
+/// dominated by a `data_end` comparison. The emitter places the proof
+/// immediately before the load — `if (data + off + width) <= data_end goto` — so
+/// the model requires a register-source jump comparing against `r7` in the four
+/// instructions preceding the load.
+fn check_packet_loads(insns: &[Insn], errors: &mut Vec<VerifyError>) {
+    for (i, insn) in insns.iter().enumerate() {
+        // The prologue's `r6 = *(u32*)(r1+..)` reads from r1, not r6; a packet
+        // load reads from r6.
+        if insn.op & CLASS_MASK != LDX || insn.src != R6 {
+            continue;
+        }
+        let window_start = i.saturating_sub(4);
+        let proven = insns[window_start..i]
+            .iter()
+            .any(|w| w.op & CLASS_MASK == JMP && w.op & JMP_X != 0 && w.src == R7);
+        if !proven {
+            errors.push(VerifyError::UnprovenPacketLoad(i));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ebpf::emit::emit_program_for_target;
+    use bpf_tcl_ir::compile_module;
+
+    fn kernel(src: &str, target: TargetAbi) -> EbpfObject {
+        let m = compile_module(src).expect("compiles");
+        emit_program_for_target(&m.programs[0].program, target).expect("emits")
+    }
+
+    #[test]
+    fn verdict_only_xdp_verifies() {
+        let obj = kernel("when XDP { pass }\n", TargetAbi::KernelXdp);
+        assert_eq!(verify(&obj), Vec::new());
+    }
+
+    #[test]
+    fn xdp_packet_read_verifies() {
+        let obj = kernel(
+            "when XDP { setbuf p ctx\n load16 dport p 36\n if {$dport == 22} { drop }\n pass }\n",
+            TargetAbi::KernelXdp,
+        );
+        assert_eq!(verify(&obj), Vec::new());
+    }
+
+    #[test]
+    fn socket_packet_read_verifies() {
+        let obj = kernel(
+            "when SOCKET_FILTER { setbuf p ctx\n load16 v p 2\n accept {$v} }\n",
+            TargetAbi::KernelSocketFilter,
+        );
+        assert_eq!(verify(&obj), Vec::new());
+    }
+
+    #[test]
+    fn map_program_verifies_with_relocations() {
+        let obj = kernel(
+            "when XDP {\n map hits array 4 8 4\n setint k 0\n map_get n hits {$k}\n\
+             setint n1 {$n + 1}\n map_set hits {$k} {$n1}\n pass }\n",
+            TargetAbi::KernelXdp,
+        );
+        assert_eq!(verify(&obj), Vec::new());
+    }
+
+    #[test]
+    fn a_packet_load_without_a_proof_is_flagged() {
+        // Corrupt an emitted object: turn the dominating bounds check into a
+        // no-op so the following packet load is left unproven.
+        let mut obj = kernel(
+            "when XDP { setbuf p ctx\n load16 dport p 36\n pass }\n",
+            TargetAbi::KernelXdp,
+        );
+        // Find the JLE-against-r7 proof and neutralise it.
+        for insn in &mut obj.insns {
+            if insn.op & CLASS_MASK == JMP && insn.op & JMP_X != 0 && insn.src == R7 {
+                insn.op = 0x07; // an ALU op, no longer a data_end compare
+                break;
+            }
+        }
+        let errors = verify(&obj);
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, VerifyError::UnprovenPacketLoad(_))),
+            "a load with its proof removed must be flagged: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn a_missing_relocation_is_flagged() {
+        let mut obj = kernel(
+            "when XDP { map hits array 4 8 4\n setint k 0\n map_get n hits {$k}\n pass }\n",
+            TargetAbi::KernelXdp,
+        );
+        obj.relocations.clear();
+        assert!(
+            verify(&obj)
+                .iter()
+                .any(|e| matches!(e, VerifyError::MissingRelocation(_)))
+        );
+    }
+}

--- a/rust/bpf-tcl-ir/src/alloc.rs
+++ b/rust/bpf-tcl-ir/src/alloc.rs
@@ -1,0 +1,421 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Liveness-based stack-slot allocation.
+//!
+//! Lowering hands every value its own virtual slot; this pass computes slot
+//! liveness over the block graph and re-colours the virtual slots so values
+//! with disjoint live ranges share one 8-byte stack slot. It also computes
+//! the *zero-init set*: the slots that may be read on some path before every
+//! write — the only slots a target must zero at entry (blanket zeroing of
+//! every slot is both wasted instructions and wasted verifier state).
+//!
+//! Two virtual slots may share a physical slot only when they never live at
+//! the same time **and** have the same [`Ty`] (so `slot_types` stays
+//! meaningful). The 512-byte eBPF stack limit (64 slots × 8 bytes) is
+//! enforced *after* reuse, target-independently, with the source span of the
+//! first value that no longer fits.
+
+use std::collections::HashMap;
+
+use tcl_lexer::Span;
+
+use crate::diag::{BpfDiag, BpfError};
+use crate::ir::{BpfProgram, Inst, SlotId, Term};
+use crate::ty::Ty;
+
+/// 64 slots × 8 bytes = the 512-byte eBPF stack.
+pub const MAX_SLOTS: usize = 64;
+
+/// A dense per-slot bit set.
+#[derive(Clone, PartialEq, Eq)]
+struct SlotSet {
+    bits: Vec<bool>,
+}
+
+impl SlotSet {
+    fn new(n: usize) -> Self {
+        Self {
+            bits: vec![false; n],
+        }
+    }
+
+    fn insert(&mut self, s: SlotId) -> bool {
+        let i = s.0 as usize;
+        let was = self.bits[i];
+        self.bits[i] = true;
+        !was
+    }
+
+    fn remove(&mut self, s: SlotId) {
+        self.bits[s.0 as usize] = false;
+    }
+
+    fn contains(&self, s: SlotId) -> bool {
+        self.bits[s.0 as usize]
+    }
+
+    fn union_with(&mut self, other: &Self) -> bool {
+        let mut changed = false;
+        for (a, b) in self.bits.iter_mut().zip(&other.bits) {
+            if *b && !*a {
+                *a = true;
+                changed = true;
+            }
+        }
+        changed
+    }
+
+    fn iter(&self) -> impl Iterator<Item = SlotId> + '_ {
+        self.bits
+            .iter()
+            .enumerate()
+            .filter(|(_, b)| **b)
+            .map(|(i, _)| SlotId(u32::try_from(i).unwrap_or(u32::MAX)))
+    }
+}
+
+/// The slot an instruction defines, if any.
+fn inst_def(inst: &Inst) -> Option<SlotId> {
+    match inst {
+        Inst::Const { dst, .. }
+        | Inst::Copy { dst, .. }
+        | Inst::Bin { dst, .. }
+        | Inst::Un { dst, .. }
+        | Inst::Cmp { dst, .. }
+        | Inst::CtxPtr { dst, .. }
+        | Inst::CtxLen { dst, .. }
+        | Inst::Load { dst, .. }
+        | Inst::MapGet { dst, .. }
+        | Inst::MapHas { dst, .. } => Some(*dst),
+        Inst::MapSet { .. } => None,
+    }
+}
+
+/// The slots an instruction reads.
+fn inst_uses(inst: &Inst, mut f: impl FnMut(SlotId)) {
+    match inst {
+        Inst::Const { .. } | Inst::CtxPtr { .. } | Inst::CtxLen { .. } => {}
+        Inst::Copy { src, .. } => f(*src),
+        Inst::Bin { a, b, .. } | Inst::Cmp { a, b, .. } => {
+            f(*a);
+            f(*b);
+        }
+        Inst::Un { a, .. } => f(*a),
+        Inst::Load { ptr, .. } => f(*ptr),
+        Inst::MapGet { key, .. } | Inst::MapHas { key, .. } => f(*key),
+        Inst::MapSet { key, val, .. } => {
+            f(*key);
+            f(*val);
+        }
+    }
+}
+
+/// The slots a terminator reads.
+fn term_uses(term: &Term, mut f: impl FnMut(SlotId)) {
+    match term {
+        Term::Goto { .. } => {}
+        Term::BranchNz { cond, .. } => f(*cond),
+        Term::Return { verdict, .. } => f(*verdict),
+    }
+}
+
+/// The span of an instruction (for diagnostics).
+fn inst_span(inst: &Inst) -> Span {
+    match inst {
+        Inst::Const { span, .. }
+        | Inst::Copy { span, .. }
+        | Inst::Bin { span, .. }
+        | Inst::Un { span, .. }
+        | Inst::Cmp { span, .. }
+        | Inst::CtxPtr { span, .. }
+        | Inst::CtxLen { span, .. }
+        | Inst::Load { span, .. }
+        | Inst::MapGet { span, .. }
+        | Inst::MapHas { span, .. }
+        | Inst::MapSet { span, .. } => *span,
+    }
+}
+
+/// Rewrite every slot reference in an instruction through `map`.
+fn remap_inst(inst: &mut Inst, map: &[SlotId]) {
+    let m = |s: &mut SlotId| *s = map[s.0 as usize];
+    match inst {
+        Inst::Const { dst, .. } | Inst::CtxPtr { dst, .. } | Inst::CtxLen { dst, .. } => m(dst),
+        Inst::Copy { dst, src, .. } => {
+            m(dst);
+            m(src);
+        }
+        Inst::Bin { dst, a, b, .. } | Inst::Cmp { dst, a, b, .. } => {
+            m(dst);
+            m(a);
+            m(b);
+        }
+        Inst::Un { dst, a, .. } => {
+            m(dst);
+            m(a);
+        }
+        Inst::Load { dst, ptr, .. } => {
+            m(dst);
+            m(ptr);
+        }
+        Inst::MapGet { dst, key, .. } | Inst::MapHas { dst, key, .. } => {
+            m(dst);
+            m(key);
+        }
+        Inst::MapSet { key, val, .. } => {
+            m(key);
+            m(val);
+        }
+    }
+}
+
+fn remap_term(term: &mut Term, map: &[SlotId]) {
+    match term {
+        Term::Goto { .. } => {}
+        Term::BranchNz { cond, .. } => *cond = map[cond.0 as usize],
+        Term::Return { verdict, .. } => *verdict = map[verdict.0 as usize],
+    }
+}
+
+/// Per-block liveness facts.
+struct BlockFacts {
+    /// Slots read before any write in this block (upward-exposed uses).
+    upward: SlotSet,
+    /// Slots written in this block.
+    def: SlotSet,
+    live_in: SlotSet,
+    live_out: SlotSet,
+    /// Successor block ids.
+    succs: Vec<u32>,
+}
+
+/// Re-colour `prog`'s virtual slots with liveness-based reuse, compute the
+/// zero-init set, and enforce the 64-slot / 512-byte stack cap.
+///
+/// # Errors
+/// [`BpfDiag::StackOverflow`] when even after reuse the program needs more
+/// than [`MAX_SLOTS`] slots; the span points at the first value that does not
+/// fit and the message reports the raw and allocated counts.
+pub fn assign_slots(prog: &mut BpfProgram) -> Result<(), BpfError> {
+    let n = prog.slot_types.len();
+    prog.raw_slot_count = u32::try_from(n).unwrap_or(u32::MAX);
+    if n == 0 {
+        prog.num_slots = 0;
+        prog.zero_init = Vec::new();
+        return Ok(());
+    }
+
+    let facts = solve_liveness(prog, n);
+    // Zero-init set: slots live into the entry block (some path reads them
+    // before writing).
+    let entry_zero: Vec<SlotId> = facts
+        .get(&prog.entry.0)
+        .map_or_else(|| SlotSet::new(n), |f| f.live_in.clone())
+        .iter()
+        .collect();
+    let interferes = build_interference(prog, &facts, &entry_zero, n);
+    let colouring = colour(prog, &interferes, n)?;
+
+    // Rewrite the program with the physical colours.
+    for block in &mut prog.blocks {
+        for inst in &mut block.insts {
+            remap_inst(inst, &colouring.of);
+        }
+        remap_term(&mut block.term, &colouring.of);
+    }
+    let mut zero: Vec<SlotId> = entry_zero
+        .iter()
+        .map(|s| colouring.of[s.0 as usize])
+        .collect();
+    zero.sort_unstable_by_key(|s| s.0);
+    zero.dedup();
+    prog.zero_init = zero;
+    prog.num_slots = u32::try_from(colouring.types.len()).unwrap_or(u32::MAX);
+    prog.slot_types = colouring.types;
+    Ok(())
+}
+
+/// Compute per-block gen/def and solve the backwards live-in/live-out
+/// fixpoint (`live_in = upward ∪ (live_out − def)`).
+fn solve_liveness(prog: &BpfProgram, n: usize) -> HashMap<u32, BlockFacts> {
+    let mut facts: HashMap<u32, BlockFacts> = HashMap::new();
+    for block in &prog.blocks {
+        let mut upward = SlotSet::new(n);
+        let mut def = SlotSet::new(n);
+        for inst in &block.insts {
+            inst_uses(inst, |s| {
+                if !def.contains(s) {
+                    upward.insert(s);
+                }
+            });
+            if let Some(d) = inst_def(inst) {
+                def.insert(d);
+            }
+        }
+        term_uses(&block.term, |s| {
+            if !def.contains(s) {
+                upward.insert(s);
+            }
+        });
+        let succs = match &block.term {
+            Term::Goto { target, .. } => vec![target.0],
+            Term::BranchNz { t, f, .. } => vec![t.0, f.0],
+            Term::Return { .. } => Vec::new(),
+        };
+        facts.insert(
+            block.id.0,
+            BlockFacts {
+                upward,
+                def,
+                live_in: SlotSet::new(n),
+                live_out: SlotSet::new(n),
+                succs,
+            },
+        );
+    }
+
+    let block_ids: Vec<u32> = prog.blocks.iter().map(|b| b.id.0).collect();
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for id in block_ids.iter().rev() {
+            let succ_ins: Vec<SlotSet> = facts[id]
+                .succs
+                .iter()
+                .filter_map(|s| facts.get(s).map(|f| f.live_in.clone()))
+                .collect();
+            let fact = facts.get_mut(id).expect("fact exists");
+            for si in &succ_ins {
+                if fact.live_out.union_with(si) {
+                    changed = true;
+                }
+            }
+            let mut live_in = fact.upward.clone();
+            for s in fact.live_out.iter() {
+                if !fact.def.contains(s) {
+                    live_in.insert(s);
+                }
+            }
+            if live_in != fact.live_in {
+                fact.live_in = live_in;
+                changed = true;
+            }
+        }
+    }
+    facts
+}
+
+/// Build the slot interference graph: a def interferes with everything live
+/// after it, and all zero-init slots mutually interfere (they are all
+/// notionally defined together at entry).
+fn build_interference(
+    prog: &BpfProgram,
+    facts: &HashMap<u32, BlockFacts>,
+    entry_zero: &[SlotId],
+    n: usize,
+) -> Vec<SlotSet> {
+    let mut interferes = vec![SlotSet::new(n); n];
+    let add_edge = |g: &mut Vec<SlotSet>, a: SlotId, b: SlotId| {
+        if a != b {
+            g[a.0 as usize].insert(b);
+            g[b.0 as usize].insert(a);
+        }
+    };
+    for block in &prog.blocks {
+        let mut live = facts[&block.id.0].live_out.clone();
+        term_uses(&block.term, |s| {
+            live.insert(s);
+        });
+        for inst in block.insts.iter().rev() {
+            if let Some(d) = inst_def(inst) {
+                for l in live.iter() {
+                    add_edge(&mut interferes, d, l);
+                }
+                live.remove(d);
+            }
+            inst_uses(inst, |s| {
+                live.insert(s);
+            });
+        }
+    }
+    for (i, a) in entry_zero.iter().enumerate() {
+        for b in &entry_zero[i + 1..] {
+            add_edge(&mut interferes, *a, *b);
+        }
+    }
+    interferes
+}
+
+/// The result of greedy colouring: the physical slot each virtual slot maps
+/// to, and the type of each physical slot.
+struct Colouring {
+    of: Vec<SlotId>,
+    types: Vec<Ty>,
+}
+
+/// Greedy colouring in virtual-slot order; a colour may only be shared by
+/// slots of the same type. Fails when more than [`MAX_SLOTS`] colours are
+/// needed, pointing at the first value that no longer fits.
+fn colour(prog: &BpfProgram, interferes: &[SlotSet], n: usize) -> Result<Colouring, BpfError> {
+    let mut of: Vec<SlotId> = Vec::with_capacity(n);
+    let mut types: Vec<Ty> = Vec::new();
+    let mut first_overflow: Option<SlotId> = None;
+    for (v, &ty) in prog.slot_types.iter().enumerate() {
+        let mut taken = vec![false; types.len()];
+        for neigh in interferes[v].iter() {
+            let ni = neigh.0 as usize;
+            if ni < v {
+                taken[of[ni].0 as usize] = true;
+            }
+        }
+        let picked = (0..types.len())
+            .find(|&c| !taken[c] && types[c] == ty)
+            .unwrap_or_else(|| {
+                types.push(ty);
+                types.len() - 1
+            });
+        if picked >= MAX_SLOTS && first_overflow.is_none() {
+            first_overflow = Some(SlotId(u32::try_from(v).unwrap_or(u32::MAX)));
+        }
+        of.push(SlotId(u32::try_from(picked).unwrap_or(u32::MAX)));
+    }
+
+    if let Some(over) = first_overflow {
+        // Source span for the overflowing value: the first instruction that
+        // defines it.
+        let span = prog
+            .blocks
+            .iter()
+            .flat_map(|b| &b.insts)
+            .find(|i| inst_def(i) == Some(over))
+            .map_or_else(|| Span::empty(0), inst_span);
+        return Err(BpfError::new(
+            BpfDiag::StackOverflow,
+            span,
+            format!(
+                "program needs {} stack slots even after liveness-based reuse \
+                 ({n} values before reuse; the 512-byte eBPF stack holds {MAX_SLOTS}) \
+                 — split the handler, or shrink the unrolled `loop`/`use` \
+                 expansion that defines this value",
+                types.len(),
+            ),
+        ));
+    }
+    Ok(Colouring { of, types })
+}

--- a/rust/bpf-tcl-ir/src/capability.rs
+++ b/rust/bpf-tcl-ir/src/capability.rs
@@ -23,12 +23,11 @@
 //! body (after `use`/field/loop expansion), so a template or profile field
 //! cannot smuggle a forbidden operation past the policy.
 //!
-//! The policy governs the *capability-bearing* verbs — packet access
-//! (`load8`/`load16`/`load32`/`pktlen`) and map access (`map_get`/`map_set`) —
-//! plus the verdicts (`accept`/`drop`/`pass`/`tx`). Everything else (`setint`
-//! and friends, `setbuf`, the `map` declaration, and `if`) is structural and
-//! always permitted, including the `setbuf __pkt ctx` the field expansion
-//! injects.
+//! Which verbs the policy governs is **registry data**: every BPF-Tcl command
+//! spec carries a typed [`BpfOpSpec`](tcl_registry::bpf_op::BpfOpSpec) whose
+//! effect classification says whether the verb is *gated* (touches the packet
+//! or a map — `BpfEffects::is_gated`) or a *verdict*
+//! (`BpfEffects::is_verdict`). This module never names a command:
 //!
 //! - `deny X …` forbids each `X` wherever it appears (default-allow otherwise),
 //!   and may name a verdict (a profile that inspects but never drops).
@@ -37,21 +36,20 @@
 //! - A verb in both `allow` and `deny` is denied (deny wins).
 
 use tcl_compiler::{Script, Statement};
+use tcl_registry::registry::CommandRegistry;
 
 use crate::diag::{BpfDiag, BpfError};
 
-/// The gated verbs an `allow` list restricts (packet + map access).
-const GATED: &[&str] = &["load8", "load16", "load32", "pktlen", "map_get", "map_set"];
-/// The verdicts — always permitted unless explicitly `deny`d.
-const VERDICTS: &[&str] = &["accept", "drop", "pass", "tx"];
-
-fn is_gated(cmd: &str) -> bool {
-    GATED.contains(&cmd)
+/// Whether `cmd`'s registry descriptor marks it gated (packet/map access).
+fn is_gated(cmd: &str, registry: &CommandRegistry) -> bool {
+    registry.bpf_op(cmd).is_some_and(|op| op.effects.is_gated())
 }
 
 /// Is `cmd` something `allow`/`deny` may name (a gated verb or a verdict)?
-fn is_governable(cmd: &str) -> bool {
-    is_gated(cmd) || VERDICTS.contains(&cmd)
+fn is_governable(cmd: &str, registry: &CommandRegistry) -> bool {
+    registry
+        .bpf_op(cmd)
+        .is_some_and(|op| op.effects.is_gated() || op.effects.is_verdict())
 }
 
 /// A capability policy collected from a file's top-level `allow`/`deny` decls.
@@ -65,14 +63,15 @@ pub struct CapabilityPolicy {
 }
 
 impl CapabilityPolicy {
-    /// Does this policy permit `cmd`?
+    /// Does this policy permit `cmd`? `gated` is the verb's registry effect
+    /// classification (see [`is_gated`]).
     #[must_use]
-    pub fn permits(&self, cmd: &str) -> bool {
+    pub fn permits(&self, cmd: &str, gated: bool) -> bool {
         if self.deny.iter().any(|d| d == cmd) {
             return false;
         }
         if let Some(allow) = &self.allow
-            && is_gated(cmd)
+            && gated
         {
             return allow.iter().any(|a| a == cmd);
         }
@@ -91,7 +90,10 @@ impl CapabilityPolicy {
 ///
 /// # Errors
 /// A bad arity, or a verb that is not capability-governable (likely a typo).
-pub fn collect_policy(top_level: &Script) -> Result<CapabilityPolicy, BpfError> {
+pub fn collect_policy(
+    top_level: &Script,
+    registry: &CommandRegistry,
+) -> Result<CapabilityPolicy, BpfError> {
     let mut policy = CapabilityPolicy::default();
     for stmt in &top_level.statements {
         let Statement::Call {
@@ -118,14 +120,14 @@ pub fn collect_policy(top_level: &Script) -> Result<CapabilityPolicy, BpfError> 
             ));
         }
         for verb in args {
-            if !is_governable(verb) {
+            if !is_governable(verb, registry) {
                 return Err(BpfError::new(
                     BpfDiag::CapabilityDenied,
                     *span,
                     format!(
                         "`{verb}` is not a capability-governable command \
                          (governable: {})",
-                        governable_list()
+                        governable_list(registry)
                     ),
                 ));
             }
@@ -139,9 +141,14 @@ pub fn collect_policy(top_level: &Script) -> Result<CapabilityPolicy, BpfError> 
     Ok(policy)
 }
 
-fn governable_list() -> String {
-    let mut all: Vec<&str> = GATED.iter().chain(VERDICTS.iter()).copied().collect();
+/// Every governable verb name, from the registry descriptors (sorted).
+fn governable_list(registry: &CommandRegistry) -> String {
+    let mut all: Vec<&str> = registry
+        .command_names()
+        .filter(|name| is_governable(name, registry))
+        .collect();
     all.sort_unstable();
+    all.dedup();
     all.join(", ")
 }
 
@@ -150,14 +157,22 @@ fn governable_list() -> String {
 ///
 /// # Errors
 /// [`BpfDiag::CapabilityDenied`] at the offending command's span.
-pub fn check_policy(script: &Script, policy: &CapabilityPolicy) -> Result<(), BpfError> {
+pub fn check_policy(
+    script: &Script,
+    policy: &CapabilityPolicy,
+    registry: &CommandRegistry,
+) -> Result<(), BpfError> {
     if policy.is_unrestricted() {
         return Ok(());
     }
-    check_script(script, policy)
+    check_script(script, policy, registry)
 }
 
-fn check_script(script: &Script, policy: &CapabilityPolicy) -> Result<(), BpfError> {
+fn check_script(
+    script: &Script,
+    policy: &CapabilityPolicy,
+    registry: &CommandRegistry,
+) -> Result<(), BpfError> {
     for stmt in &script.statements {
         match stmt {
             Statement::Call {
@@ -167,7 +182,7 @@ fn check_script(script: &Script, policy: &CapabilityPolicy) -> Result<(), BpfErr
                 ..
             } => {
                 let cmd = canonical_command.as_deref().unwrap_or(command.as_str());
-                if !policy.permits(cmd) {
+                if !policy.permits(cmd, is_gated(cmd, registry)) {
                     return Err(BpfError::new(
                         BpfDiag::CapabilityDenied,
                         *span,
@@ -179,10 +194,10 @@ fn check_script(script: &Script, policy: &CapabilityPolicy) -> Result<(), BpfErr
                 clauses, else_body, ..
             } => {
                 for c in clauses {
-                    check_script(&c.body, policy)?;
+                    check_script(&c.body, policy, registry)?;
                 }
                 if let Some(b) = else_body {
-                    check_script(b, policy)?;
+                    check_script(b, policy, registry)?;
                 }
             }
             _ => {}

--- a/rust/bpf-tcl-ir/src/compose.rs
+++ b/rust/bpf-tcl-ir/src/compose.rs
@@ -1,0 +1,246 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Handler composition (issue #1204).
+//!
+//! Multiple `when EVENT priority N { … }` blocks for the same event compose
+//! into one **handler chain** with explicit, testable semantics:
+//!
+//! 1. **Lower priority numbers run first.** The chain is evaluated in ascending
+//!    priority order (F5-inspired), with the event name as a stable tiebreaker.
+//! 2. **A terminal verdict stops evaluation.** The first handler that returns a
+//!    terminal verdict (`accept`/`drop`/`pass`/`tx`) decides the packet; later
+//!    handlers do not run.
+//! 3. **Continuation is explicit.** A handler continues to the next only by
+//!    ending its path with the non-terminal `next` outcome, which lowers to the
+//!    reserved [`crate::ir::CONTINUE_SENTINEL`] return value.
+//! 4. **Each event declares its default.** If every handler on a path yields
+//!    `next`, the event's [`default_verdict`](tcl_registry::bpf_op::BpfEventSpec::default_verdict)
+//!    applies.
+//!
+//! These are the *source* semantics. The *deployment* semantics are a verified
+//! program chain: each handler is compiled independently, and the chain is
+//! evaluated by running the handlers in order and interpreting each one's return
+//! value with [`classify_outcome`] — a dispatcher expressed in the loader rather
+//! than fused into one eBPF object. This module is the backend-agnostic model of
+//! that chain; the actual per-handler execution (rbpf, or the kernel) lives in
+//! the harness that owns a run engine. Because the rules are pure over the
+//! per-handler outcomes, the composition is deterministic and unit-testable in
+//! userspace without a kernel.
+
+use crate::ir::{BpfModule, CONTINUE_SENTINEL};
+
+/// A single handler's outcome once run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// The handler ended with `next` (the continuation sentinel) — evaluation
+    /// proceeds to the next handler.
+    Continue,
+    /// The handler returned a terminal verdict with this value (an XDP/TC action
+    /// number, or a socket-filter accepted byte count / `0` drop).
+    Terminal(i64),
+}
+
+impl Outcome {
+    /// Classify a raw handler return value (the low 32 bits of `r0`). The
+    /// reserved continuation sentinel maps to [`Outcome::Continue`]; every other
+    /// value is a terminal verdict.
+    #[must_use]
+    pub fn classify(run_result: u64) -> Self {
+        let low = run_result & 0xffff_ffff;
+        if low == (CONTINUE_SENTINEL as u64 & 0xffff_ffff) {
+            Outcome::Continue
+        } else {
+            // Sign-extend the 32-bit action back to i64 for display parity with
+            // the verdict formatting (all real verdicts are small non-negative).
+            Outcome::Terminal(i64::from(low as u32))
+        }
+    }
+}
+
+/// The classification of a raw handler return value (free function form of
+/// [`Outcome::classify`], for callers that prefer it).
+#[must_use]
+pub fn classify_outcome(run_result: u64) -> Outcome {
+    Outcome::classify(run_result)
+}
+
+/// The result of evaluating a handler chain over one packet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChainResult {
+    /// The handler at `index` (into the chain, priority order) returned a
+    /// terminal verdict; that value is the decision.
+    Decided {
+        /// Index of the deciding handler within the chain.
+        index: usize,
+        /// The terminal verdict value it returned.
+        verdict: i64,
+    },
+    /// Every handler yielded `next`; the event's default verdict applies.
+    Default,
+}
+
+/// Evaluate a handler chain's composition rules over the per-handler outcomes,
+/// which must already be in ascending-priority order.
+///
+/// Returns [`ChainResult::Decided`] for the first terminal outcome, or
+/// [`ChainResult::Default`] when every handler continued.
+#[must_use]
+pub fn compose(outcomes: &[Outcome]) -> ChainResult {
+    for (index, outcome) in outcomes.iter().enumerate() {
+        if let Outcome::Terminal(verdict) = outcome {
+            return ChainResult::Decided {
+                index,
+                verdict: *verdict,
+            };
+        }
+    }
+    ChainResult::Default
+}
+
+/// One event's ordered handler chain, projected from a compiled [`BpfModule`].
+#[derive(Debug, Clone)]
+pub struct EventChain {
+    /// Canonical/declared event name shared by every handler in the chain.
+    pub event: String,
+    /// Indices into [`BpfModule::programs`] for this event's handlers, already
+    /// in ascending-priority order (the module is pre-sorted).
+    pub handler_indices: Vec<usize>,
+    /// Each handler's declared priority, parallel to `handler_indices`.
+    pub priorities: Vec<u32>,
+}
+
+impl EventChain {
+    /// The number of handlers in the chain.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.handler_indices.len()
+    }
+
+    /// Whether the chain has no handlers.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.handler_indices.is_empty()
+    }
+}
+
+/// Project a compiled module into per-event handler chains. Handlers keep the
+/// module's ascending-priority order; events appear in first-seen order.
+///
+/// Two handlers of the same event at the *same* priority are a composition
+/// hazard — their relative order is decided only by the event-name tiebreaker,
+/// which is identical here, so the source order is not preserved deterministically
+/// across edits. [`ambiguous_priorities`] flags that so the front-end can reject
+/// it (issue #1204: "sorting independent object files is not sufficient").
+#[must_use]
+pub fn event_chains(module: &BpfModule) -> Vec<EventChain> {
+    let mut chains: Vec<EventChain> = Vec::new();
+    for (index, decl) in module.programs.iter().enumerate() {
+        if let Some(chain) = chains.iter_mut().find(|c| c.event == decl.event) {
+            chain.handler_indices.push(index);
+            chain.priorities.push(decl.priority);
+        } else {
+            chains.push(EventChain {
+                event: decl.event.clone(),
+                handler_indices: vec![index],
+                priorities: vec![decl.priority],
+            });
+        }
+    }
+    chains
+}
+
+/// Report any event whose chain has two handlers sharing one priority — an
+/// ambiguous, non-deterministic composition order. Returns `(event, priority)`
+/// pairs.
+#[must_use]
+pub fn ambiguous_priorities(module: &BpfModule) -> Vec<(String, u32)> {
+    let mut clashes = Vec::new();
+    for chain in event_chains(module) {
+        let mut seen = chain.priorities.clone();
+        seen.sort_unstable();
+        for pair in seen.windows(2) {
+            if pair[0] == pair[1]
+                && !clashes
+                    .iter()
+                    .any(|(e, p)| e == &chain.event && *p == pair[0])
+            {
+                clashes.push((chain.event.clone(), pair[0]));
+            }
+        }
+    }
+    clashes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn continuation_sentinel_classifies_as_continue() {
+        assert_eq!(
+            Outcome::classify(CONTINUE_SENTINEL as u64),
+            Outcome::Continue
+        );
+        // Upper bits ignored: the kernel only defines the low 32.
+        assert_eq!(Outcome::classify(0xdead_0000_ffff_ffff), Outcome::Continue);
+    }
+
+    #[test]
+    fn real_verdicts_classify_as_terminal() {
+        assert_eq!(Outcome::classify(0), Outcome::Terminal(0)); // socket drop
+        assert_eq!(Outcome::classify(2), Outcome::Terminal(2)); // XDP_PASS
+        assert_eq!(Outcome::classify(1500), Outcome::Terminal(1500)); // accept 1500
+    }
+
+    #[test]
+    fn first_terminal_wins_and_stops_the_chain() {
+        // priority order: continue, then a drop, then an (unreached) pass.
+        let outcomes = [
+            Outcome::Continue,
+            Outcome::Terminal(1),
+            Outcome::Terminal(2),
+        ];
+        assert_eq!(
+            compose(&outcomes),
+            ChainResult::Decided {
+                index: 1,
+                verdict: 1
+            }
+        );
+    }
+
+    #[test]
+    fn all_continue_falls_through_to_default() {
+        let outcomes = [Outcome::Continue, Outcome::Continue];
+        assert_eq!(compose(&outcomes), ChainResult::Default);
+        assert_eq!(compose(&[]), ChainResult::Default);
+    }
+
+    #[test]
+    fn a_leading_terminal_short_circuits() {
+        let outcomes = [Outcome::Terminal(1), Outcome::Continue];
+        assert_eq!(
+            compose(&outcomes),
+            ChainResult::Decided {
+                index: 0,
+                verdict: 1
+            }
+        );
+    }
+}

--- a/rust/bpf-tcl-ir/src/diag.rs
+++ b/rust/bpf-tcl-ir/src/diag.rs
@@ -56,6 +56,11 @@ pub enum BpfDiag {
     StrayTopLevel,
     /// Too many values for the 512-byte eBPF stack.
     StackOverflow,
+    /// A handler path can fall off the end without an explicit verdict.
+    MissingVerdict,
+    /// A malformed `map` declaration (bad kind, size, capacity, or
+    /// concurrency word), or a map access incompatible with the declaration.
+    BadMap,
     /// An internal invariant failure (a compiler bug, not user error).
     Internal,
 }
@@ -79,6 +84,8 @@ impl BpfDiag {
             BpfDiag::CapabilityDenied => "BPF012",
             BpfDiag::BadAttach => "BPF013",
             BpfDiag::StrayTopLevel => "BPF014",
+            BpfDiag::MissingVerdict => "BPF015",
+            BpfDiag::BadMap => "BPF016",
             BpfDiag::Internal => "BPF999",
         }
     }

--- a/rust/bpf-tcl-ir/src/diag.rs
+++ b/rust/bpf-tcl-ir/src/diag.rs
@@ -61,6 +61,9 @@ pub enum BpfDiag {
     /// A malformed `map` declaration (bad kind, size, capacity, or
     /// concurrency word), or a map access incompatible with the declaration.
     BadMap,
+    /// Two handlers of the same event share a priority — an ambiguous, non
+    /// deterministic composition order (issue #1204).
+    AmbiguousComposition,
     /// An internal invariant failure (a compiler bug, not user error).
     Internal,
 }
@@ -86,6 +89,7 @@ impl BpfDiag {
             BpfDiag::StrayTopLevel => "BPF014",
             BpfDiag::MissingVerdict => "BPF015",
             BpfDiag::BadMap => "BPF016",
+            BpfDiag::AmbiguousComposition => "BPF017",
             BpfDiag::Internal => "BPF999",
         }
     }

--- a/rust/bpf-tcl-ir/src/event.rs
+++ b/rust/bpf-tcl-ir/src/event.rs
@@ -38,19 +38,34 @@ pub fn event_spec(event: &str) -> Option<&'static BpfEventSpec> {
     lookup_bpf_event(event)
 }
 
-/// Resolve an event name (as written in `when <EVENT> …`) to a program type.
-/// Case-insensitive. Returns `None` for unknown events.
+/// Resolve an event name to a *codegen-ready* IR program type. Case-insensitive.
+/// Returns `None` for an unknown event **or** an event whose codegen is still
+/// pending (TC, cgroup) — the front-end distinguishes the two so it can give a
+/// precise diagnostic (see [`event_is_described`]).
 #[must_use]
 pub fn event_to_prog_type(event: &str) -> Option<ProgType> {
-    event_spec(event).map(|spec| prog_type_of(spec.prog_type))
+    event_spec(event).and_then(|spec| prog_type_of(spec.prog_type))
 }
 
-/// Map the registry's dependency-free program-type enum onto the IR's.
+/// Whether `event` resolves to a registry-described event whose codegen is not
+/// yet implemented (a schema-only contract). `false` for unknown or ready
+/// events.
 #[must_use]
-pub fn prog_type_of(pt: BpfEventProgType) -> ProgType {
+pub fn event_is_described(event: &str) -> bool {
+    event_spec(event).is_some_and(|spec| !spec.is_codegen_ready())
+}
+
+/// Map the registry's dependency-free program-type enum onto the IR's, for the
+/// codegen-ready targets. `None` for events the IR has no lowering for yet.
+#[must_use]
+pub fn prog_type_of(pt: BpfEventProgType) -> Option<ProgType> {
     match pt {
-        BpfEventProgType::SocketFilter => ProgType::SocketFilter,
-        BpfEventProgType::Xdp => ProgType::Xdp,
+        BpfEventProgType::SocketFilter => Some(ProgType::SocketFilter),
+        BpfEventProgType::Xdp => Some(ProgType::Xdp),
+        BpfEventProgType::TcIngress
+        | BpfEventProgType::TcEgress
+        | BpfEventProgType::CgroupInet4Connect
+        | BpfEventProgType::CgroupInet4Bind => None,
     }
 }
 
@@ -58,4 +73,10 @@ pub fn prog_type_of(pt: BpfEventProgType) -> ProgType {
 #[must_use]
 pub fn known_event_names() -> Vec<&'static str> {
     tcl_registry::bpf_op::bpf_event_names()
+}
+
+/// The canonical names of events that currently compile to a program.
+#[must_use]
+pub fn codegen_ready_event_names() -> Vec<&'static str> {
+    tcl_registry::bpf_op::codegen_ready_event_names()
 }

--- a/rust/bpf-tcl-ir/src/event.rs
+++ b/rust/bpf-tcl-ir/src/event.rs
@@ -19,19 +19,43 @@
 //! The BPF-native event space. Inspired by F5's `when <EVENT>` shape, but a
 //! whole separate namespace — these events map to eBPF program types / attach
 //! points, not F5 iRules events.
+//!
+//! The event table itself is **registry data**
+//! ([`tcl_registry::bpf_op::BPF_EVENTS`]): each event pairs its name and
+//! aliases with a program type, ELF section convention, and verdict set.
+//! This module only maps the registry's dependency-free descriptor onto the
+//! IR's [`ProgType`] — adding an event is a registry edit, not a new match
+//! arm here.
+
+use tcl_registry::bpf_op::{BpfEventProgType, BpfEventSpec, lookup_bpf_event};
 
 use crate::ir::ProgType;
+
+/// Resolve an event name (as written in `when <EVENT> …`) to its registry
+/// spec. Case-insensitive, aliases included. `None` for unknown events.
+#[must_use]
+pub fn event_spec(event: &str) -> Option<&'static BpfEventSpec> {
+    lookup_bpf_event(event)
+}
 
 /// Resolve an event name (as written in `when <EVENT> …`) to a program type.
 /// Case-insensitive. Returns `None` for unknown events.
 #[must_use]
 pub fn event_to_prog_type(event: &str) -> Option<ProgType> {
-    match event.to_ascii_uppercase().as_str() {
-        "SOCKET_FILTER" | "SOCKET" => Some(ProgType::SocketFilter),
-        "XDP" => Some(ProgType::Xdp),
-        _ => None,
+    event_spec(event).map(|spec| prog_type_of(spec.prog_type))
+}
+
+/// Map the registry's dependency-free program-type enum onto the IR's.
+#[must_use]
+pub fn prog_type_of(pt: BpfEventProgType) -> ProgType {
+    match pt {
+        BpfEventProgType::SocketFilter => ProgType::SocketFilter,
+        BpfEventProgType::Xdp => ProgType::Xdp,
     }
 }
 
-/// The known event names, for diagnostics and help text.
-pub const KNOWN_EVENTS: &[&str] = &["SOCKET_FILTER", "XDP"];
+/// The canonical event names, for diagnostics and help text.
+#[must_use]
+pub fn known_event_names() -> Vec<&'static str> {
+    tcl_registry::bpf_op::bpf_event_names()
+}

--- a/rust/bpf-tcl-ir/src/frontend.rs
+++ b/rust/bpf-tcl-ir/src/frontend.rs
@@ -30,12 +30,13 @@ use tcl_compiler::ir::CommandTokens;
 use tcl_compiler::lowering::lower_to_ir;
 use tcl_compiler::{Script, Statement};
 use tcl_lexer::Span;
+use tcl_registry::bpf_op::{BpfDeclKind, BpfOpKind};
 use tcl_registry::registry::CommandRegistry;
 
 use crate::capability::{CapabilityPolicy, check_policy, collect_policy};
 use crate::deploy::resolve_attach;
 use crate::diag::{BpfDiag, BpfError};
-use crate::event::{KNOWN_EVENTS, event_to_prog_type};
+use crate::event::{event_to_prog_type, known_event_names};
 use crate::ir::{BpfModule, BpfProgramDecl, ProgType};
 use crate::lower::lower_function;
 use crate::profile::{BpfProfileSpec, collect_profile, expand_fields};
@@ -61,7 +62,7 @@ pub fn compile_module(source: &str) -> Result<BpfModule, BpfError> {
     // Reusable parameterised handlers a `use` site can splice in.
     let templates = collect_templates(&module.top_level, &registry)?;
     // The capability policy that sandboxes each handler's operations.
-    let policy = collect_policy(&module.top_level)?;
+    let policy = collect_policy(&module.top_level, &registry)?;
 
     let mut programs = Vec::new();
     let mut saw_when = false;
@@ -69,12 +70,16 @@ pub fn compile_module(source: &str) -> Result<BpfModule, BpfError> {
     for stmt in &module.top_level.statements {
         if let Statement::Call {
             command,
+            canonical_command,
             args,
             tokens,
             span,
             ..
         } = stmt
-            && command == "when"
+            && decl_kind(
+                canonical_command.as_deref().unwrap_or(command.as_str()),
+                &registry,
+            ) == Some(BpfDeclKind::When)
         {
             saw_when = true;
             programs.push(lower_when_decl(
@@ -99,9 +104,12 @@ pub fn compile_module(source: &str) -> Result<BpfModule, BpfError> {
             let is_when = matches!(
                 stmt,
                 Statement::Call { command, canonical_command, .. }
-                    if canonical_command.as_deref().unwrap_or(command.as_str()) == "when"
+                    if decl_kind(
+                        canonical_command.as_deref().unwrap_or(command.as_str()),
+                        &registry,
+                    ) == Some(BpfDeclKind::When)
             );
-            if !is_when && !is_decl(stmt) {
+            if !is_when && !is_decl(stmt, &registry) {
                 let (name, span) = stray_stmt_info(stmt);
                 return Err(BpfError::new(
                     BpfDiag::StrayTopLevel,
@@ -118,7 +126,7 @@ pub fn compile_module(source: &str) -> Result<BpfModule, BpfError> {
     // No framework envelope: treat the top level (minus profile/field decls) as a
     // single anonymous SOCKET_FILTER program (the raw-DSL path, handy for tests).
     if !saw_when {
-        let body = strip_decls(&module.top_level);
+        let body = strip_decls(&module.top_level, &registry);
         if !body.statements.is_empty() {
             let used = expand_uses(&body, &templates)?;
             let unrolled = unroll_loops(&used, &registry)?;
@@ -126,9 +134,9 @@ pub fn compile_module(source: &str) -> Result<BpfModule, BpfError> {
                 Some(p) => expand_fields(&unrolled, p)?,
                 None => unrolled,
             };
-            check_policy(&expanded, &policy)?;
+            check_policy(&expanded, &policy, &registry)?;
             let cfg = build_cfg_function("main", &expanded, false);
-            let program = lower_function(&cfg, ProgType::SocketFilter)?;
+            let program = lower_function(&cfg, ProgType::SocketFilter, &registry)?;
             programs.push(BpfProgramDecl {
                 event: "SOCKET_FILTER".to_owned(),
                 priority: 500,
@@ -153,6 +161,10 @@ pub fn compile_module(source: &str) -> Result<BpfModule, BpfError> {
     Ok(BpfModule { programs })
 }
 
+/// The default handler priority when the `when` header names none
+/// (F5-inspired: lower runs first).
+const DEFAULT_PRIORITY: u32 = 500;
+
 fn lower_when_decl(
     args: &[String],
     tokens: Option<&CommandTokens>,
@@ -162,36 +174,78 @@ fn lower_when_decl(
     templates: &[TemplateDef],
     policy: &CapabilityPolicy,
 ) -> Result<BpfProgramDecl, BpfError> {
-    if args.len() < 2 {
-        return Err(BpfError::new(
-            BpfDiag::BadArity,
-            call_span,
-            "`when` expects: when EVENT ?priority N? { body }",
-        ));
-    }
+    // The span of header word `i`, falling back to the whole call.
+    let word_span = |i: usize| {
+        tokens
+            .and_then(|t| t.argv.get(i).copied())
+            .unwrap_or(call_span)
+    };
+
+    // Accept exactly `when EVENT { body }` or `when EVENT priority N { body }`
+    // — nothing else. A malformed header must never be silently normalised
+    // (`RUST_ISSUE_063`: `when XDP priority nope { … }` used to become
+    // priority 500 with no diagnostic).
+    let priority = match args.len() {
+        2 => DEFAULT_PRIORITY,
+        4 => {
+            if args[1] != "priority" {
+                return Err(BpfError::new(
+                    BpfDiag::BadArity,
+                    word_span(1),
+                    format!(
+                        "unknown `when` header keyword `{}` — the only supported \
+                         forms are `when EVENT {{ body }}` and \
+                         `when EVENT priority N {{ body }}`",
+                        args[1]
+                    ),
+                ));
+            }
+            if !is_literal_word(&args[2]) {
+                return Err(BpfError::new(
+                    BpfDiag::BadArity,
+                    word_span(2),
+                    "the `when` priority must be a literal (no substitutions)",
+                ));
+            }
+            args[2].parse::<u32>().map_err(|_| {
+                BpfError::new(
+                    BpfDiag::BadArity,
+                    word_span(2),
+                    format!(
+                        "invalid `when` priority `{}` — must be a non-negative \
+                         integer literal",
+                        args[2]
+                    ),
+                )
+            })?
+        }
+        _ => {
+            return Err(BpfError::new(
+                BpfDiag::BadArity,
+                call_span,
+                "`when` expects: when EVENT { body }  or  when EVENT priority N { body }",
+            ));
+        }
+    };
 
     let event = args[0].clone();
+    if !is_literal_word(&event) {
+        return Err(BpfError::new(
+            BpfDiag::BadEvent,
+            word_span(0),
+            "the `when` event must be a literal name (no substitutions)",
+        ));
+    }
     let prog_type = event_to_prog_type(&event).ok_or_else(|| {
-        let espan = tokens
-            .and_then(|t| t.argv.first().copied())
-            .unwrap_or(call_span);
         BpfError::new(
             BpfDiag::BadEvent,
-            espan,
+            word_span(0),
             format!(
                 "unknown BPF event `{event}` (known: {})",
-                KNOWN_EVENTS.join(", ")
+                known_event_names().join(", ")
             ),
         )
     })?;
-
-    let mut priority = 500u32;
-    if args.len() >= 4
-        && args[1] == "priority"
-        && let Ok(p) = args[2].parse::<u32>()
-    {
-        priority = p;
-    }
 
     let body_idx = args.len() - 1;
     let body_text = &args[body_idx];
@@ -208,9 +262,9 @@ fn lower_when_decl(
         Some(p) => expand_fields(&unrolled, p).map_err(|e| e.offset(source_base))?,
         None => unrolled,
     };
-    check_policy(&expanded, policy).map_err(|e| e.offset(source_base))?;
+    check_policy(&expanded, policy, registry).map_err(|e| e.offset(source_base))?;
     let cfg = build_cfg_function(&format!("::bpf::{event}"), &expanded, false);
-    let program = lower_function(&cfg, prog_type).map_err(|e| e.offset(source_base))?;
+    let program = lower_function(&cfg, prog_type, registry).map_err(|e| e.offset(source_base))?;
 
     Ok(BpfProgramDecl {
         event,
@@ -221,13 +275,22 @@ fn lower_when_decl(
     })
 }
 
-/// Remove top-level `profile`/`field`/`template`/`allow`/`deny`/`attach`
-/// declarations (metadata, macro definitions, or policy — not executable code).
-fn strip_decls(script: &Script) -> Script {
+/// Whether a `when` header word is a plain literal — no variable or command
+/// substitution. The header is static configuration; dynamic events or
+/// priorities cannot exist in a verifier-shaped program.
+fn is_literal_word(word: &str) -> bool {
+    !word.contains('$') && !word.contains('[')
+}
+
+/// Remove top-level `profile`/`template`/`allow`/`deny`/`attach` declarations
+/// (metadata, macro definitions, or policy — not executable code). A stray
+/// `field` outside a `profile` body is deliberately *not* stripped: it flows
+/// into lowering, which rejects it with a pointer to where fields belong.
+fn strip_decls(script: &Script, registry: &CommandRegistry) -> Script {
     let kept = script
         .statements
         .iter()
-        .filter(|s| !is_decl(s))
+        .filter(|s| !is_decl(s, registry))
         .cloned()
         .collect();
     Script::from_statements(kept)
@@ -253,14 +316,41 @@ fn stray_stmt_info(stmt: &Statement) -> (String, Span) {
     }
 }
 
-fn is_decl(stmt: &Statement) -> bool {
+/// The framework-declaration kind of a command name, from its registry
+/// descriptor.
+fn decl_kind(cmd: &str, registry: &CommandRegistry) -> Option<BpfDeclKind> {
+    match registry.bpf_op(cmd).map(|op| op.kind) {
+        Some(BpfOpKind::Framework(decl)) => Some(decl),
+        _ => None,
+    }
+}
+
+/// Whether a top-level statement is a consumed framework declaration.
+/// Deliberately excluded: `field` (only meaningful inside a `profile` body,
+/// so a top-level one is a stray that lowering rejects), `use` (an expansion
+/// site, spliced in place by `expand_uses`, not a stripped declaration), and
+/// `when` (handled separately).
+fn is_decl(stmt: &Statement, registry: &CommandRegistry) -> bool {
+    let Statement::Call {
+        command,
+        canonical_command,
+        ..
+    } = stmt
+    else {
+        return false;
+    };
     matches!(
-        stmt,
-        Statement::Call { command, canonical_command, .. }
-            if matches!(
-                canonical_command.as_deref().unwrap_or(command.as_str()),
-                "profile" | "field" | "template" | "allow" | "deny" | "attach"
-            )
+        decl_kind(
+            canonical_command.as_deref().unwrap_or(command.as_str()),
+            registry,
+        ),
+        Some(
+            BpfDeclKind::Profile
+                | BpfDeclKind::Template
+                | BpfDeclKind::Allow
+                | BpfDeclKind::Deny
+                | BpfDeclKind::Attach
+        )
     )
 }
 
@@ -343,5 +433,69 @@ mod tests {
         let module = compile_module(src).expect("port filter should compile");
         assert_eq!(module.programs.len(), 1);
         assert!(module.programs[0].program.blocks.len() >= 3);
+    }
+
+    /// Registry/lowering drift gate (issue #1202 acceptance criterion): every
+    /// BPF-dialect command carries a typed `bpf_op` descriptor, and the
+    /// lowerer/capability policy dispatch on that descriptor — never on a
+    /// command-name switch. This walks the *actual* registered BPF command set
+    /// and proves each command is describable, so a newly registered command
+    /// without a descriptor fails here rather than being silently mishandled.
+    #[test]
+    fn every_registered_bpf_command_has_a_descriptor() {
+        use tcl_registry::bpf_op::BpfOpKind;
+        let mut registry = CommandRegistry::build_default();
+        registry.load_bpf();
+        let bpf_names: Vec<&str> = registry
+            .command_names()
+            .filter(|n| registry.bpf_op(n).is_some())
+            .collect();
+        assert!(
+            bpf_names.len() >= 25,
+            "expected the full BPF command surface, found {}",
+            bpf_names.len()
+        );
+        for name in bpf_names {
+            let op = registry.bpf_op(name).expect("descriptor present");
+            // The classification the capability policy relies on must be
+            // internally consistent: a verdict terminates, a gated op has a
+            // packet/map effect, and the two are disjoint.
+            match op.kind {
+                BpfOpKind::Verdict(_) => assert!(
+                    op.effects.is_verdict() && !op.effects.is_gated(),
+                    "{name} is a verdict but misclassified"
+                ),
+                BpfOpKind::PacketLoad { .. }
+                | BpfOpKind::PacketLen
+                | BpfOpKind::MapGet
+                | BpfOpKind::MapHas
+                | BpfOpKind::MapSet => assert!(
+                    op.effects.is_gated(),
+                    "{name} accesses packet/map but is not gated"
+                ),
+                _ => {}
+            }
+        }
+    }
+
+    /// Every event resolvable through the registry maps to a program type, and
+    /// the framework front-end accepts a handler for it — proving the event
+    /// space is registry-described end to end (no string-match arm).
+    #[test]
+    fn every_registry_event_compiles_a_handler() {
+        for event in tcl_registry::bpf_op::BPF_EVENTS {
+            assert!(
+                crate::event::event_to_prog_type(event.name).is_some(),
+                "event {} has no program type",
+                event.name
+            );
+            let verdict = match event.prog_type {
+                tcl_registry::bpf_op::BpfEventProgType::SocketFilter => "accept",
+                tcl_registry::bpf_op::BpfEventProgType::Xdp => "pass",
+            };
+            let src = format!("when {} {{ {verdict} }}\n", event.name);
+            compile_module(&src)
+                .unwrap_or_else(|e| panic!("event {} handler failed: {e}", event.name));
+        }
     }
 }

--- a/rust/bpf-tcl-ir/src/frontend.rs
+++ b/rust/bpf-tcl-ir/src/frontend.rs
@@ -158,7 +158,28 @@ pub fn compile_module(source: &str) -> Result<BpfModule, BpfError> {
             .then_with(|| a.event.cmp(&b.event))
     });
 
-    Ok(BpfModule { programs })
+    let module = BpfModule { programs };
+
+    // Handler composition (issue #1204): two handlers of the *same* event at the
+    // *same* priority have no deterministic order — the priority sort cannot
+    // distinguish them and the event-name tiebreaker is identical. That is an
+    // ambiguous composition; reject it rather than emit a non-deterministic
+    // chain ("sorting independent object files is not sufficient").
+    if let Some((event, priority)) = crate::compose::ambiguous_priorities(&module)
+        .into_iter()
+        .next()
+    {
+        return Err(BpfError::new(
+            BpfDiag::AmbiguousComposition,
+            Span::empty(0),
+            format!(
+                "two `when {event}` handlers share priority {priority}; give each a \
+                 distinct priority so their composition order is deterministic"
+            ),
+        ));
+    }
+
+    Ok(module)
 }
 
 /// The default handler priority when the `when` header names none
@@ -236,16 +257,7 @@ fn lower_when_decl(
             "the `when` event must be a literal name (no substitutions)",
         ));
     }
-    let prog_type = event_to_prog_type(&event).ok_or_else(|| {
-        BpfError::new(
-            BpfDiag::BadEvent,
-            word_span(0),
-            format!(
-                "unknown BPF event `{event}` (known: {})",
-                known_event_names().join(", ")
-            ),
-        )
-    })?;
+    let prog_type = resolve_event_prog_type(&event, word_span(0))?;
 
     let body_idx = args.len() - 1;
     let body_text = &args[body_idx];
@@ -273,6 +285,36 @@ fn lower_when_decl(
         attach: None,
         source_base,
     })
+}
+
+/// Resolve a `when` event name to a codegen-ready IR program type, or a precise
+/// diagnostic: a registry-described-but-not-yet-compilable event (TC, cgroup) is
+/// distinguished from a genuinely unknown one.
+fn resolve_event_prog_type(event: &str, span: Span) -> Result<ProgType, BpfError> {
+    if let Some(pt) = event_to_prog_type(event) {
+        return Ok(pt);
+    }
+    if crate::event::event_is_described(event) {
+        // A real event — say so precisely rather than claiming it is unknown —
+        // but the compiler cannot lower it yet.
+        return Err(BpfError::new(
+            BpfDiag::BadEvent,
+            span,
+            format!(
+                "BPF event `{event}` is registry-described but its codegen is not \
+                 yet implemented; compilable events: {}",
+                crate::event::codegen_ready_event_names().join(", ")
+            ),
+        ));
+    }
+    Err(BpfError::new(
+        BpfDiag::BadEvent,
+        span,
+        format!(
+            "unknown BPF event `{event}` (known: {})",
+            known_event_names().join(", ")
+        ),
+    ))
 }
 
 /// Whether a `when` header word is a plain literal — no variable or command
@@ -421,6 +463,47 @@ mod tests {
     }
 
     #[test]
+    fn described_but_uncompilable_event_is_rejected_precisely() {
+        // TC is a registry-described event whose codegen is not ready — the
+        // message must say so, not "unknown event".
+        let err = compile_module("when TC_INGRESS { pass }\n").unwrap_err();
+        assert_eq!(err.code, BpfDiag::BadEvent);
+        assert!(
+            err.msg.contains("codegen") && err.msg.contains("TC_INGRESS"),
+            "precise described-event message: {}",
+            err.msg
+        );
+    }
+
+    #[test]
+    fn next_is_a_valid_handler_outcome() {
+        // A handler may end a path with `next` (explicit continuation).
+        let src = "when XDP { setbuf p ctx\n pktlen n p\n if {$n < 20} { next }\n pass }\n";
+        let module = compile_module(src).expect("next compiles");
+        assert_eq!(module.programs.len(), 1);
+    }
+
+    #[test]
+    fn two_handlers_sharing_a_priority_are_ambiguous() {
+        // Same event, same explicit priority -> non-deterministic composition.
+        let src = "when XDP priority 10 { pass }\nwhen XDP priority 10 { drop }\n";
+        let err = compile_module(src).unwrap_err();
+        assert_eq!(err.code, BpfDiag::AmbiguousComposition);
+    }
+
+    #[test]
+    fn two_handlers_with_distinct_priorities_compose() {
+        let src = "when XDP priority 10 { next }\nwhen XDP priority 20 { pass }\n";
+        let module = compile_module(src).expect("distinct priorities compose");
+        // Lower priority first.
+        assert_eq!(module.programs[0].priority, 10);
+        assert_eq!(module.programs[1].priority, 20);
+        let chains = crate::compose::event_chains(&module);
+        assert_eq!(chains.len(), 1);
+        assert_eq!(chains[0].handler_indices, vec![0, 1]);
+    }
+
+    #[test]
     fn port_filter_compiles() {
         let src = "when SOCKET_FILTER {\n\
                    setbuf pkt ctx\n\
@@ -478,24 +561,45 @@ mod tests {
         }
     }
 
-    /// Every event resolvable through the registry maps to a program type, and
-    /// the framework front-end accepts a handler for it — proving the event
-    /// space is registry-described end to end (no string-match arm).
+    /// Every codegen-ready event resolvable through the registry maps to a
+    /// program type and the framework front-end compiles a handler for it —
+    /// proving the event space is registry-described end to end (no
+    /// string-match arm). Schema-described-but-not-ready events (TC, cgroup)
+    /// resolve their spec and are rejected with a *precise* diagnostic, never
+    /// treated as unknown.
     #[test]
-    fn every_registry_event_compiles_a_handler() {
+    fn every_registry_event_is_handled_by_its_schema() {
         for event in tcl_registry::bpf_op::BPF_EVENTS {
-            assert!(
-                crate::event::event_to_prog_type(event.name).is_some(),
-                "event {} has no program type",
-                event.name
-            );
-            let verdict = match event.prog_type {
-                tcl_registry::bpf_op::BpfEventProgType::SocketFilter => "accept",
-                tcl_registry::bpf_op::BpfEventProgType::Xdp => "pass",
-            };
-            let src = format!("when {} {{ {verdict} }}\n", event.name);
-            compile_module(&src)
-                .unwrap_or_else(|e| panic!("event {} handler failed: {e}", event.name));
+            if event.is_codegen_ready() {
+                assert!(
+                    crate::event::event_to_prog_type(event.name).is_some(),
+                    "ready event {} has no program type",
+                    event.name
+                );
+                // Its default verdict's verb is a valid handler body.
+                let verb = event.default_verdict.verb();
+                let src = format!("when {} {{ {verb} }}\n", event.name);
+                compile_module(&src)
+                    .unwrap_or_else(|e| panic!("event {} handler failed: {e}", event.name));
+            } else {
+                assert!(
+                    crate::event::event_is_described(event.name),
+                    "non-ready event {} should be described",
+                    event.name
+                );
+                let src = format!(
+                    "when {} {{ {} }}\n",
+                    event.name,
+                    event.default_verdict.verb()
+                );
+                let err = compile_module(&src).expect_err("described event must not compile yet");
+                assert_eq!(err.code, BpfDiag::BadEvent);
+                assert!(
+                    err.msg.contains("codegen"),
+                    "described-event message should mention codegen: {}",
+                    err.msg
+                );
+            }
         }
     }
 }

--- a/rust/bpf-tcl-ir/src/ir.rs
+++ b/rust/bpf-tcl-ir/src/ir.rs
@@ -22,7 +22,7 @@
 
 use tcl_lexer::Span;
 
-use crate::ty::{Ty, Width};
+use crate::ty::{ByteOrder, Ty, Width};
 
 /// A mutable storage slot (a typed local). Lowered to a fixed stack location by
 /// the backend; slots are mutable like C locals, so control flow needs no phi.
@@ -158,7 +158,20 @@ pub enum Inst {
         /// Source span.
         span: Span,
     },
-    /// `dst = load<width>(ptr + off)` (bounds-checked by the runtime/verifier).
+    /// `dst = load<width>(ptr + off)` — a checked packet read.
+    ///
+    /// The contract every target must honour:
+    ///
+    /// - The load touches the constant byte range `off .. off + width.bytes()`
+    ///   relative to the packet start (the range a dominating bounds proof
+    ///   must cover — there is no dynamic-offset form yet).
+    /// - No static in-bounds proof is attached: the **target** must emit a
+    ///   dominating `ptr + off + width <= data_end` check (or equivalent)
+    ///   before the dereference.
+    /// - When the packet is too short, the program takes the explicit
+    ///   [`OobAction`] — it never reads out of bounds and never traps.
+    /// - Multi-byte results are interpreted per [`ByteOrder`] and
+    ///   zero-extended to 64 bits.
     Load {
         /// Destination slot.
         dst: SlotId,
@@ -168,11 +181,16 @@ pub enum Inst {
         ptr: SlotId,
         /// Byte offset.
         off: i32,
+        /// How the loaded bytes are interpreted.
+        order: ByteOrder,
+        /// What happens when `off + width` exceeds the packet.
+        oob: OobAction,
         /// Source span.
         span: Span,
     },
     /// `dst = map_get(map, key)` — the value for `key`, or `0` if absent (the
-    /// null case is folded to zero by the helper).
+    /// null case is folded to zero by the helper). Use [`Inst::MapHas`] to
+    /// distinguish a missing key from a stored zero.
     MapGet {
         /// Destination slot.
         dst: SlotId,
@@ -183,7 +201,19 @@ pub enum Inst {
         /// Source span.
         span: Span,
     },
-    /// `map_set(map, key, val)` — store `val` for `key`.
+    /// `dst = map_has(map, key)` — 1 when `key` is present, 0 when absent.
+    MapHas {
+        /// Destination slot.
+        dst: SlotId,
+        /// Map index.
+        map: u32,
+        /// Key slot.
+        key: SlotId,
+        /// Source span.
+        span: Span,
+    },
+    /// `map_set(map, key, val)` — store `val` for `key`. Fails silently (the
+    /// stored state is unchanged) when a hash map is at capacity.
     MapSet {
         /// Map index.
         map: u32,
@@ -194,6 +224,16 @@ pub enum Inst {
         /// Source span.
         span: Span,
     },
+}
+
+/// What an out-of-bounds packet read does. Attached to every [`Inst::Load`]
+/// so the failure semantics are explicit in the IR rather than implied by a
+/// target's runtime behaviour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OobAction {
+    /// Terminate the program immediately with this verdict value (the
+    /// program type's drop verdict in v1).
+    ReturnVerdict(i64),
 }
 
 /// How a basic block ends.
@@ -246,26 +286,94 @@ pub enum ProgType {
     Xdp,
 }
 
+/// The kind of a declared map.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MapKind {
+    /// `BPF_MAP_TYPE_HASH` — sparse; a key is absent until stored.
+    Hash,
+    /// `BPF_MAP_TYPE_ARRAY` — preallocated and zero-filled; the key is an
+    /// index (`0 .. max_entries`, key size fixed at 4 bytes) and every
+    /// in-range key is always present.
+    Array,
+}
+
+impl MapKind {
+    /// Parse the DSL map-kind word.
+    #[must_use]
+    pub fn parse(word: &str) -> Option<Self> {
+        match word {
+            "hash" => Some(MapKind::Hash),
+            "array" => Some(MapKind::Array),
+            _ => None,
+        }
+    }
+
+    /// Stable display spelling.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            MapKind::Hash => "hash",
+            MapKind::Array => "array",
+        }
+    }
+}
+
+/// The declared concurrency model of a map.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MapConcurrency {
+    /// One value per key, shared by every invocation (the default). Updates
+    /// from concurrent invocations race — last write wins; there is no
+    /// atomic read-modify-write in v1.
+    #[default]
+    Shared,
+    /// One value per key **per CPU** (`BPF_MAP_TYPE_PERCPU_*`). Declared for
+    /// the kernel target; the single-threaded rbpf harness runs it exactly
+    /// like [`MapConcurrency::Shared`].
+    PerCpu,
+}
+
+impl MapConcurrency {
+    /// Parse the DSL concurrency word.
+    #[must_use]
+    pub fn parse(word: &str) -> Option<Self> {
+        match word {
+            "shared" => Some(MapConcurrency::Shared),
+            "percpu" => Some(MapConcurrency::PerCpu),
+            _ => None,
+        }
+    }
+}
+
 /// A declared BPF map. In v1 maps are integer-keyed, integer-valued (`key` and
-/// `value` are passed by value to the map helpers); the declared sizes are kept
-/// as metadata.
+/// `value` are passed by value to the map helpers); key/value sizes must be
+/// 1, 2, 4, or 8 bytes so a value fits one register.
 #[derive(Debug, Clone)]
 pub struct MapDef {
     /// Map name as written.
     pub name: String,
     /// Dense map index (0-based, in declaration order).
     pub index: u32,
-    /// Declared key size in bytes.
+    /// Map kind (validated at declaration).
+    pub kind: MapKind,
+    /// Declared key size in bytes (1, 2, 4, or 8; exactly 4 for an array).
     pub key_size: u32,
-    /// Declared value size in bytes.
+    /// Declared value size in bytes (1, 2, 4, or 8).
     pub value_size: u32,
-    /// Declared maximum entries.
+    /// Declared maximum entries (enforced: a hash update on a full map with
+    /// a new key fails; an array key is valid only below this bound).
     pub max_entries: u32,
+    /// Declared concurrency model.
+    pub concurrency: MapConcurrency,
     /// Source span of the declaration.
     pub span: Span,
 }
 
 /// A complete, typed, verifier-shaped program.
+///
+/// Slots are allocated by the liveness-based allocator
+/// ([`crate::alloc::assign_slots`]): values with disjoint live ranges share a
+/// stack slot, and `zero_init` lists exactly the slots that may be read
+/// before every write (the only ones a target needs to zero at entry).
 #[derive(Debug, Clone)]
 pub struct BpfProgram {
     /// Program type / attach point.
@@ -274,10 +382,16 @@ pub struct BpfProgram {
     pub entry: BlockId,
     /// All blocks, sorted by [`BlockId`].
     pub blocks: Vec<Block>,
-    /// Number of slots; each occupies 8 bytes of stack.
+    /// Number of allocated slots; each occupies 8 bytes of stack.
     pub num_slots: u32,
     /// Type of each slot, indexed by [`SlotId`].
     pub slot_types: Vec<Ty>,
+    /// Number of values the program computed with *before* liveness-based
+    /// slot reuse (diagnostic metadata for `check` output).
+    pub raw_slot_count: u32,
+    /// Slots that may be read on some path before they are written — the
+    /// target must zero-initialise exactly these at entry. Sorted, deduped.
+    pub zero_init: Vec<SlotId>,
     /// Declared maps, indexed by [`MapDef::index`].
     pub maps: Vec<MapDef>,
 }

--- a/rust/bpf-tcl-ir/src/ir.rs
+++ b/rust/bpf-tcl-ir/src/ir.rs
@@ -24,6 +24,17 @@ use tcl_lexer::Span;
 
 use crate::ty::{ByteOrder, Ty, Width};
 
+/// The reserved return value a handler yields for the `next` outcome — the
+/// explicit, non-terminal continuation of handler composition (issue #1204).
+///
+/// It is the 32-bit all-ones sentinel (`-1` as a signed 32-bit action), a value
+/// no real verdict uses: socket-filter accept counts are non-negative byte
+/// counts and `0` drops; XDP actions are `0..=4`; TC actions are small
+/// non-negative constants. The composition evaluator
+/// ([`crate::compose`]) reads a run result equal to this (masked to 32 bits) as
+/// "continue to the next handler"; every other value is a terminal decision.
+pub const CONTINUE_SENTINEL: i64 = 0xffff_ffff;
+
 /// A mutable storage slot (a typed local). Lowered to a fixed stack location by
 /// the backend; slots are mutable like C locals, so control flow needs no phi.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/rust/bpf-tcl-ir/src/lib.rs
+++ b/rust/bpf-tcl-ir/src/lib.rs
@@ -28,27 +28,36 @@
 
 pub mod alloc;
 pub mod capability;
+pub mod compose;
 pub mod deploy;
 pub mod diag;
 pub mod event;
 pub mod frontend;
 pub mod ir;
+pub mod loader;
 pub mod lower;
 pub mod profile;
+pub mod ringbuf;
 pub mod template;
 pub mod ty;
 pub mod unroll;
 
 pub use capability::CapabilityPolicy;
+pub use compose::{ChainResult, EventChain, Outcome, ambiguous_priorities, compose, event_chains};
 pub use deploy::collect_attach;
 pub use diag::{BpfDiag, BpfError};
+pub use event::{event_is_described, event_spec, event_to_prog_type, known_event_names};
 pub use frontend::compile_module;
 pub use ir::{
-    AttachSpec, BpfModule, BpfProgram, BpfProgramDecl, MapConcurrency, MapDef, MapKind, OobAction,
-    ProgType,
+    AttachSpec, BpfModule, BpfProgram, BpfProgramDecl, CONTINUE_SENTINEL, MapConcurrency, MapDef,
+    MapKind, OobAction, ProgType,
+};
+pub use loader::{
+    Deployment, DeploymentPlan, DeploymentStatus, KernelOps, LoaderError, ModelKernel, State,
 };
 pub use lower::lower_function;
 pub use profile::{BpfProfileSpec, FieldDef};
+pub use ringbuf::{DecodedRecord, RecordHeader, RecordSchema, RingBuffer};
 pub use template::TemplateDef;
 pub use ty::ByteOrder;
 pub use unroll::unroll_loops;

--- a/rust/bpf-tcl-ir/src/lib.rs
+++ b/rust/bpf-tcl-ir/src/lib.rs
@@ -26,6 +26,7 @@
 //! [`ir::BpfProgram`] is the shared waist consumed by the codegen backends.
 #![forbid(unsafe_code)]
 
+pub mod alloc;
 pub mod capability;
 pub mod deploy;
 pub mod diag;
@@ -42,8 +43,12 @@ pub use capability::CapabilityPolicy;
 pub use deploy::collect_attach;
 pub use diag::{BpfDiag, BpfError};
 pub use frontend::compile_module;
-pub use ir::{AttachSpec, BpfModule, BpfProgram, BpfProgramDecl, ProgType};
+pub use ir::{
+    AttachSpec, BpfModule, BpfProgram, BpfProgramDecl, MapConcurrency, MapDef, MapKind, OobAction,
+    ProgType,
+};
 pub use lower::lower_function;
 pub use profile::{BpfProfileSpec, FieldDef};
 pub use template::TemplateDef;
+pub use ty::ByteOrder;
 pub use unroll::unroll_loops;

--- a/rust/bpf-tcl-ir/src/loader.rs
+++ b/rust/bpf-tcl-ir/src/loader.rs
@@ -1,0 +1,740 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The loader and link lifecycle (issue #1204).
+//!
+//! A deployment moves through an explicit state machine —
+//! `plan → load → (test-run) → attach → status → detach` — with atomic
+//! rollback on partial failure and strict resource ownership. Every kernel
+//! effect goes through the [`KernelOps`] trait, so the whole lifecycle is
+//! **modelled and unit-tested deterministically in userspace** without a kernel
+//! (this container has none). A real `bpf()`-syscall implementation of
+//! [`KernelOps`] is the only part that needs root, and is exercised only by the
+//! `#[ignore]`d privileged integration tests.
+//!
+//! # Resource ownership
+//!
+//! Every pin this loader creates lives under a unique, ownership-labelled path:
+//!
+//! ```text
+//! /sys/fs/bpf/bpftcl/<deployment>/<program>
+//! ```
+//!
+//! `<deployment>` is the caller's deployment name. The loader **only** removes
+//! resources whose pin path is under its own `PIN_ROOT/<deployment>/` prefix and
+//! whose recorded owner label matches — it refuses to replace or delete a pin
+//! owned by anything else (issue #1204: "refuse to replace unrelated
+//! links/pins", "remove only resources owned by the deployment"). A `load` that
+//! fails partway cleans up every resource it created before returning, so a
+//! failed deployment leaves no orphan maps, programs, links, or pins.
+
+use crate::ir::{AttachSpec, BpfModule, ProgType};
+
+/// The pin filesystem root every deployment's resources live under.
+pub const PIN_ROOT: &str = "/sys/fs/bpf/bpftcl";
+
+/// The lifecycle state of a deployment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum State {
+    /// Planned only — nothing has touched the kernel.
+    Planned,
+    /// Programs verifier-loaded and maps created; not attached.
+    Loaded,
+    /// Links created and pinned; the deployment is live.
+    Attached,
+    /// Detached — all owned resources removed.
+    Detached,
+}
+
+/// A loader error. Every fallible lifecycle step returns this.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LoaderError {
+    /// A step was called from a state it is not valid in.
+    BadState {
+        /// The step attempted.
+        step: &'static str,
+        /// The current state.
+        state: State,
+    },
+    /// The kernel (or the model) rejected a program at verifier load.
+    VerifierRejected(String),
+    /// `BPF_PROG_TEST_RUN` is not supported for this program type.
+    TestRunUnsupported(ProgType),
+    /// Attaching a link failed.
+    AttachFailed(String),
+    /// A pin path is owned by a different deployment — refused.
+    ForeignPin {
+        /// The contested pin path.
+        path: String,
+        /// The recorded owner.
+        owner: String,
+    },
+    /// The deployment has no compiled programs to load.
+    Empty,
+}
+
+impl core::fmt::Display for LoaderError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            LoaderError::BadState { step, state } => {
+                write!(f, "cannot `{step}` from state {state:?}")
+            }
+            LoaderError::VerifierRejected(m) => write!(f, "verifier rejected program: {m}"),
+            LoaderError::TestRunUnsupported(pt) => {
+                write!(f, "BPF_PROG_TEST_RUN unsupported for {pt:?}")
+            }
+            LoaderError::AttachFailed(m) => write!(f, "attach failed: {m}"),
+            LoaderError::ForeignPin { path, owner } => {
+                write!(f, "refusing to touch pin {path} owned by `{owner}`")
+            }
+            LoaderError::Empty => write!(f, "deployment has no programs to load"),
+        }
+    }
+}
+
+impl std::error::Error for LoaderError {}
+
+/// A planned program within a deployment (the unit of load/attach).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedProgram {
+    /// The event/handler name.
+    pub event: String,
+    /// Its program type.
+    pub prog_type: ProgType,
+    /// Handler priority (composition order).
+    pub priority: u32,
+    /// The deployment target, if any.
+    pub attach: Option<AttachSpec>,
+    /// The unique, ownership-labelled pin path this program is pinned at.
+    pub pin: String,
+}
+
+/// A whole deployment plan derived from a compiled module + a deployment name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeploymentPlan {
+    /// The deployment name — the ownership label baked into every pin path.
+    pub name: String,
+    /// The planned programs, in the module's composition order.
+    pub programs: Vec<PlannedProgram>,
+}
+
+impl DeploymentPlan {
+    /// Build a plan from a compiled module. Each program gets a unique
+    /// ownership-labelled pin path under `PIN_ROOT/<name>/`.
+    #[must_use]
+    pub fn from_module(name: &str, module: &BpfModule) -> Self {
+        let mut programs = Vec::with_capacity(module.programs.len());
+        for (i, decl) in module.programs.iter().enumerate() {
+            // The index disambiguates two handlers of the same event so pins
+            // never collide within a deployment.
+            let pin = format!("{PIN_ROOT}/{name}/{}_{i}", decl.event.to_ascii_lowercase());
+            programs.push(PlannedProgram {
+                event: decl.event.clone(),
+                prog_type: decl.program.prog_type,
+                priority: decl.priority,
+                attach: decl.attach.clone(),
+                pin,
+            });
+        }
+        DeploymentPlan {
+            name: name.to_owned(),
+            programs,
+        }
+    }
+
+    /// Whether the plan owns `pin` — it is under this deployment's prefix.
+    #[must_use]
+    pub fn owns_pin(&self, pin: &str) -> bool {
+        pin.starts_with(&format!("{PIN_ROOT}/{}/", self.name))
+    }
+}
+
+/// A handle to a loaded program in the (modelled or real) kernel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProgHandle(pub u32);
+
+/// A handle to an attached link.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LinkHandle(pub u32);
+
+/// The kernel operations the lifecycle drives. A real implementation issues
+/// `bpf()` syscalls (needs root); [`ModelKernel`] simulates them deterministically
+/// for userspace tests.
+pub trait KernelOps {
+    /// Verifier-load one program; returns its handle or a rejection reason.
+    ///
+    /// # Errors
+    /// The verifier (or model) rejected the program.
+    fn load_program(&mut self, prog: &PlannedProgram) -> Result<ProgHandle, LoaderError>;
+
+    /// Run a loaded program through `BPF_PROG_TEST_RUN` over `packet`; returns
+    /// the verdict value.
+    ///
+    /// # Errors
+    /// Test-run is unsupported for the program type, or failed.
+    fn test_run(&mut self, prog: ProgHandle, packet: &[u8]) -> Result<u64, LoaderError>;
+
+    /// Create + pin a link for a loaded program at `pin`, recording `owner`.
+    ///
+    /// # Errors
+    /// The pin is owned by someone else, or the attach failed.
+    fn attach_link(
+        &mut self,
+        prog: ProgHandle,
+        pin: &str,
+        owner: &str,
+    ) -> Result<LinkHandle, LoaderError>;
+
+    /// Remove a link and its pin, but only if the pin's recorded owner matches
+    /// `owner`.
+    ///
+    /// # Errors
+    /// The pin is owned by someone else.
+    fn detach_link(&mut self, link: LinkHandle, pin: &str, owner: &str) -> Result<(), LoaderError>;
+
+    /// Remove a loaded (but unattached) program.
+    fn unload_program(&mut self, prog: ProgHandle);
+
+    /// The owner recorded for a pin, if it exists.
+    fn pin_owner(&self, pin: &str) -> Option<String>;
+}
+
+/// A live deployment driving the state machine over a [`KernelOps`] backend.
+#[derive(Debug)]
+pub struct Deployment<K: KernelOps> {
+    plan: DeploymentPlan,
+    kernel: K,
+    state: State,
+    loaded: Vec<(usize, ProgHandle)>,
+    links: Vec<(usize, LinkHandle, String)>,
+}
+
+impl<K: KernelOps> Deployment<K> {
+    /// Begin a deployment from a plan and a kernel backend, in [`State::Planned`].
+    #[must_use]
+    pub fn new(plan: DeploymentPlan, kernel: K) -> Self {
+        Deployment {
+            plan,
+            kernel,
+            state: State::Planned,
+            loaded: Vec::new(),
+            links: Vec::new(),
+        }
+    }
+
+    /// The current lifecycle state.
+    #[must_use]
+    pub fn state(&self) -> State {
+        self.state
+    }
+
+    /// The plan being deployed.
+    #[must_use]
+    pub fn plan(&self) -> &DeploymentPlan {
+        &self.plan
+    }
+
+    /// Borrow the kernel backend (e.g. to inspect the [`ModelKernel`] in tests).
+    #[must_use]
+    pub fn kernel(&self) -> &K {
+        &self.kernel
+    }
+
+    /// Verifier-load every program and create maps, without attaching. On any
+    /// rejection, unload everything already loaded (atomic: all-or-nothing).
+    ///
+    /// # Errors
+    /// [`LoaderError::Empty`] with no programs, or the first verifier rejection
+    /// (after cleaning up).
+    pub fn load(&mut self) -> Result<(), LoaderError> {
+        if self.state != State::Planned {
+            return Err(LoaderError::BadState {
+                step: "load",
+                state: self.state,
+            });
+        }
+        if self.plan.programs.is_empty() {
+            return Err(LoaderError::Empty);
+        }
+        for (i, prog) in self.plan.programs.iter().enumerate() {
+            match self.kernel.load_program(prog) {
+                Ok(handle) => self.loaded.push((i, handle)),
+                Err(e) => {
+                    // Roll back the partial load — remove every program we made.
+                    for (_, h) in self.loaded.drain(..) {
+                        self.kernel.unload_program(h);
+                    }
+                    return Err(e);
+                }
+            }
+        }
+        self.state = State::Loaded;
+        Ok(())
+    }
+
+    /// Run one loaded program (by plan index) through `BPF_PROG_TEST_RUN`.
+    ///
+    /// # Errors
+    /// Wrong state, unknown index, or test-run failure.
+    pub fn test_run(&mut self, program_index: usize, packet: &[u8]) -> Result<u64, LoaderError> {
+        if self.state != State::Loaded && self.state != State::Attached {
+            return Err(LoaderError::BadState {
+                step: "test-run",
+                state: self.state,
+            });
+        }
+        let handle = self
+            .loaded
+            .iter()
+            .find(|(i, _)| *i == program_index)
+            .map(|(_, h)| *h)
+            .ok_or(LoaderError::Empty)?;
+        self.kernel.test_run(handle, packet)
+    }
+
+    /// Attach every loaded program via a pinned link. On any failure, detach
+    /// every link already created in this call (rollback) and stay in
+    /// [`State::Loaded`], leaving unrelated host state untouched.
+    ///
+    /// # Errors
+    /// Wrong state, a foreign pin, or an attach failure (after rollback).
+    pub fn attach(&mut self) -> Result<(), LoaderError> {
+        if self.state != State::Loaded {
+            return Err(LoaderError::BadState {
+                step: "attach",
+                state: self.state,
+            });
+        }
+        let owner = self.plan.name.clone();
+        let planned: Vec<(usize, ProgHandle, String)> = self
+            .loaded
+            .iter()
+            .map(|(i, h)| (*i, *h, self.plan.programs[*i].pin.clone()))
+            .collect();
+        for (i, handle, pin) in planned {
+            match self.kernel.attach_link(handle, &pin, &owner) {
+                Ok(link) => self.links.push((i, link, pin)),
+                Err(e) => {
+                    // Roll back links created in this attach call only.
+                    for (_, link, pin) in self.links.drain(..) {
+                        let _ = self.kernel.detach_link(link, &pin, &owner);
+                    }
+                    return Err(e);
+                }
+            }
+        }
+        self.state = State::Attached;
+        Ok(())
+    }
+
+    /// Detach and remove **only** this deployment's owned resources: every
+    /// pinned link, then every loaded program. Never touches a pin owned by
+    /// something else.
+    ///
+    /// # Errors
+    /// A pin turned out to be foreign (should not happen for owned pins).
+    pub fn detach(&mut self) -> Result<(), LoaderError> {
+        if self.state != State::Attached && self.state != State::Loaded {
+            return Err(LoaderError::BadState {
+                step: "detach",
+                state: self.state,
+            });
+        }
+        let owner = self.plan.name.clone();
+        for (_, link, pin) in self.links.drain(..) {
+            debug_assert!(self.plan.owns_pin(&pin));
+            self.kernel.detach_link(link, &pin, &owner)?;
+        }
+        for (_, handle) in self.loaded.drain(..) {
+            self.kernel.unload_program(handle);
+        }
+        self.state = State::Detached;
+        Ok(())
+    }
+
+    /// A snapshot of the deployment's live resources for `status` output.
+    #[must_use]
+    pub fn status(&self) -> DeploymentStatus {
+        DeploymentStatus {
+            name: self.plan.name.clone(),
+            state: self.state,
+            loaded: self.loaded.len(),
+            attached: self.links.len(),
+            pins: self.links.iter().map(|(_, _, pin)| pin.clone()).collect(),
+        }
+    }
+}
+
+/// A `status` snapshot of a deployment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeploymentStatus {
+    /// Deployment name / ownership label.
+    pub name: String,
+    /// Current lifecycle state.
+    pub state: State,
+    /// Number of loaded programs.
+    pub loaded: usize,
+    /// Number of attached (pinned) links.
+    pub attached: usize,
+    /// The owned pin paths currently live.
+    pub pins: Vec<String>,
+}
+
+/// A deterministic in-memory model of the kernel BPF object space, for
+/// userspace tests of the lifecycle. It records loaded programs, pin ownership,
+/// and links, and can be configured to inject a verifier rejection or attach
+/// failure at a chosen program index (to exercise rollback).
+#[derive(Debug, Default)]
+pub struct ModelKernel {
+    next_prog: u32,
+    next_link: u32,
+    /// pin path -> owner label.
+    pins: std::collections::BTreeMap<String, String>,
+    /// loaded program handle -> its program type.
+    live_progs: std::collections::BTreeMap<u32, ProgTypeKey>,
+    /// Program index at which `load_program` should fail (verifier reject).
+    fail_load_at_call: Option<usize>,
+    /// Attach call ordinal at which `attach_link` should fail.
+    fail_attach_at_call: Option<usize>,
+    load_calls: usize,
+    attach_calls: usize,
+    /// Program types that support test-run.
+    test_runnable: std::collections::BTreeSet<ProgTypeKey>,
+}
+
+/// A hashable key for [`ProgType`] (which is `Copy` but not `Ord`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct ProgTypeKey(u8);
+
+impl From<ProgType> for ProgTypeKey {
+    fn from(pt: ProgType) -> Self {
+        ProgTypeKey(match pt {
+            ProgType::SocketFilter => 0,
+            ProgType::Xdp => 1,
+        })
+    }
+}
+
+impl ModelKernel {
+    /// A model where every program type supports test-run and nothing fails.
+    #[must_use]
+    pub fn new() -> Self {
+        let mut test_runnable = std::collections::BTreeSet::new();
+        test_runnable.insert(ProgTypeKey::from(ProgType::SocketFilter));
+        test_runnable.insert(ProgTypeKey::from(ProgType::Xdp));
+        ModelKernel {
+            test_runnable,
+            ..ModelKernel::default()
+        }
+    }
+
+    /// Configure a verifier rejection at the given (0-based) load call.
+    #[must_use]
+    pub fn failing_load_at(mut self, call: usize) -> Self {
+        self.fail_load_at_call = Some(call);
+        self
+    }
+
+    /// Configure an attach failure at the given (0-based) attach call.
+    #[must_use]
+    pub fn failing_attach_at(mut self, call: usize) -> Self {
+        self.fail_attach_at_call = Some(call);
+        self
+    }
+
+    /// Pre-seed a pin owned by someone else (to test foreign-pin refusal).
+    #[must_use]
+    pub fn with_foreign_pin(mut self, pin: &str, owner: &str) -> Self {
+        self.pins.insert(pin.to_owned(), owner.to_owned());
+        self
+    }
+
+    /// Configure the model so that the given program type does **not** support
+    /// `BPF_PROG_TEST_RUN` (e.g. cgroup hooks in a real kernel).
+    #[must_use]
+    pub fn without_test_run_for(mut self, pt: ProgType) -> Self {
+        self.test_runnable.remove(&ProgTypeKey::from(pt));
+        self
+    }
+
+    /// The number of pins currently recorded (owned by anyone).
+    #[must_use]
+    pub fn pin_count(&self) -> usize {
+        self.pins.len()
+    }
+
+    /// The number of loaded programs still live.
+    #[must_use]
+    pub fn live_program_count(&self) -> usize {
+        self.live_progs.len()
+    }
+
+    /// Whether a pin exists.
+    #[must_use]
+    pub fn has_pin(&self, pin: &str) -> bool {
+        self.pins.contains_key(pin)
+    }
+}
+
+impl KernelOps for ModelKernel {
+    fn load_program(&mut self, prog: &PlannedProgram) -> Result<ProgHandle, LoaderError> {
+        let call = self.load_calls;
+        self.load_calls += 1;
+        if self.fail_load_at_call == Some(call) {
+            return Err(LoaderError::VerifierRejected(format!(
+                "modelled rejection loading `{}`",
+                prog.event
+            )));
+        }
+        let id = self.next_prog;
+        self.next_prog += 1;
+        self.live_progs
+            .insert(id, ProgTypeKey::from(prog.prog_type));
+        Ok(ProgHandle(id))
+    }
+
+    fn test_run(&mut self, prog: ProgHandle, _packet: &[u8]) -> Result<u64, LoaderError> {
+        let Some(&ty) = self.live_progs.get(&prog.0) else {
+            return Err(LoaderError::Empty);
+        };
+        if !self.test_runnable.contains(&ty) {
+            // Map the key back for the error; both current types are runnable,
+            // so this only fires if a model is configured to disallow one.
+            let pt = if ty == ProgTypeKey::from(ProgType::Xdp) {
+                ProgType::Xdp
+            } else {
+                ProgType::SocketFilter
+            };
+            return Err(LoaderError::TestRunUnsupported(pt));
+        }
+        // The model returns a fixed sentinel; real verdicts come from the rbpf
+        // harness in the bpf-tcl crate, not the lifecycle model.
+        Ok(0)
+    }
+
+    fn attach_link(
+        &mut self,
+        prog: ProgHandle,
+        pin: &str,
+        owner: &str,
+    ) -> Result<LinkHandle, LoaderError> {
+        let call = self.attach_calls;
+        self.attach_calls += 1;
+        // Refuse to overwrite a pin owned by someone else.
+        if let Some(existing) = self.pins.get(pin)
+            && existing != owner
+        {
+            return Err(LoaderError::ForeignPin {
+                path: pin.to_owned(),
+                owner: existing.clone(),
+            });
+        }
+        if self.fail_attach_at_call == Some(call) {
+            return Err(LoaderError::AttachFailed(format!(
+                "modelled attach failure for prog {}",
+                prog.0
+            )));
+        }
+        let id = self.next_link;
+        self.next_link += 1;
+        self.pins.insert(pin.to_owned(), owner.to_owned());
+        Ok(LinkHandle(id))
+    }
+
+    fn detach_link(
+        &mut self,
+        _link: LinkHandle,
+        pin: &str,
+        owner: &str,
+    ) -> Result<(), LoaderError> {
+        match self.pins.get(pin) {
+            Some(existing) if existing == owner => {
+                self.pins.remove(pin);
+                Ok(())
+            }
+            Some(existing) => Err(LoaderError::ForeignPin {
+                path: pin.to_owned(),
+                owner: existing.clone(),
+            }),
+            None => Ok(()),
+        }
+    }
+
+    fn unload_program(&mut self, prog: ProgHandle) {
+        self.live_progs.remove(&prog.0);
+    }
+
+    fn pin_owner(&self, pin: &str) -> Option<String> {
+        self.pins.get(pin).cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compile_module;
+
+    fn plan(name: &str, src: &str) -> DeploymentPlan {
+        let module = compile_module(src).expect("compiles");
+        DeploymentPlan::from_module(name, &module)
+    }
+
+    const TWO_XDP: &str = "when XDP priority 10 { pass }\nwhen XDP priority 20 { pass }\n";
+
+    #[test]
+    fn pin_paths_are_unique_and_ownership_labelled() {
+        let p = plan("deploy-a", TWO_XDP);
+        assert_eq!(p.programs.len(), 2);
+        assert!(
+            p.programs[0]
+                .pin
+                .starts_with("/sys/fs/bpf/bpftcl/deploy-a/")
+        );
+        assert_ne!(p.programs[0].pin, p.programs[1].pin);
+        assert!(p.owns_pin(&p.programs[0].pin));
+        assert!(!p.owns_pin("/sys/fs/bpf/bpftcl/other/xdp_0"));
+    }
+
+    #[test]
+    fn full_lifecycle_load_attach_detach_leaks_nothing() {
+        let mut d = Deployment::new(plan("d1", TWO_XDP), ModelKernel::new());
+        assert_eq!(d.state(), State::Planned);
+        d.load().unwrap();
+        assert_eq!(d.state(), State::Loaded);
+        assert_eq!(d.kernel().live_program_count(), 2);
+        d.attach().unwrap();
+        assert_eq!(d.state(), State::Attached);
+        assert_eq!(d.kernel().pin_count(), 2);
+        let status = d.status();
+        assert_eq!(status.attached, 2);
+        assert_eq!(status.pins.len(), 2);
+        d.detach().unwrap();
+        assert_eq!(d.state(), State::Detached);
+        // Every owned resource removed.
+        assert_eq!(d.kernel().pin_count(), 0);
+        assert_eq!(d.kernel().live_program_count(), 0);
+    }
+
+    #[test]
+    fn partial_load_failure_rolls_back_every_program() {
+        // Fail the second load; the first must be cleaned up (all-or-nothing).
+        let mut d = Deployment::new(plan("d2", TWO_XDP), ModelKernel::new().failing_load_at(1));
+        let err = d.load().unwrap_err();
+        assert!(matches!(err, LoaderError::VerifierRejected(_)));
+        assert_eq!(d.state(), State::Planned);
+        assert_eq!(d.kernel().live_program_count(), 0, "no orphan programs");
+    }
+
+    #[test]
+    fn partial_attach_failure_rolls_back_links_and_stays_loaded() {
+        let mut d = Deployment::new(plan("d3", TWO_XDP), ModelKernel::new().failing_attach_at(1));
+        d.load().unwrap();
+        let err = d.attach().unwrap_err();
+        assert!(matches!(err, LoaderError::AttachFailed(_)));
+        assert_eq!(d.state(), State::Loaded, "attach failure returns to Loaded");
+        assert_eq!(d.kernel().pin_count(), 0, "no orphan pins after rollback");
+        // Programs remain loaded (rollback is of the attach, not the load).
+        assert_eq!(d.kernel().live_program_count(), 2);
+        // Recovery: detach cleans up the still-loaded programs.
+        d.detach().unwrap();
+        assert_eq!(d.kernel().live_program_count(), 0);
+    }
+
+    #[test]
+    fn refuses_to_attach_over_a_foreign_pin() {
+        let p = plan("d4", "when XDP { pass }\n");
+        let foreign = p.programs[0].pin.clone();
+        let mut d = Deployment::new(
+            p,
+            ModelKernel::new().with_foreign_pin(&foreign, "someone-else"),
+        );
+        d.load().unwrap();
+        let err = d.attach().unwrap_err();
+        assert!(matches!(err, LoaderError::ForeignPin { .. }));
+        // The foreign pin is untouched.
+        assert_eq!(
+            d.kernel().pin_owner(&foreign).as_deref(),
+            Some("someone-else")
+        );
+    }
+
+    #[test]
+    fn detach_never_removes_a_foreign_pin() {
+        // A deployment whose plan pin collides with a foreign owner: detach must
+        // refuse rather than delete someone else's pin.
+        let p = plan("d5", "when XDP { pass }\n");
+        let pin = p.programs[0].pin.clone();
+        let mut kernel = ModelKernel::new();
+        // Manually simulate: our link exists but the pin is owned by another.
+        kernel = kernel.with_foreign_pin(&pin, "intruder");
+        let mut d = Deployment::new(p, kernel);
+        d.load().unwrap();
+        // Attach refuses (foreign pin), so nothing of ours is attached.
+        assert!(d.attach().is_err());
+        // Detach the loaded-only deployment: it has no owned links, and must not
+        // remove the intruder's pin.
+        d.detach().unwrap();
+        assert_eq!(d.kernel().pin_owner(&pin).as_deref(), Some("intruder"));
+    }
+
+    #[test]
+    fn out_of_order_steps_are_rejected() {
+        let mut d = Deployment::new(plan("d6", TWO_XDP), ModelKernel::new());
+        // attach before load
+        assert!(matches!(
+            d.attach().unwrap_err(),
+            LoaderError::BadState { .. }
+        ));
+        // test-run before load
+        assert!(matches!(
+            d.test_run(0, &[]).unwrap_err(),
+            LoaderError::BadState { .. }
+        ));
+    }
+
+    #[test]
+    fn test_run_returns_a_value_for_supported_types() {
+        let mut d = Deployment::new(plan("tr", "when XDP { pass }\n"), ModelKernel::new());
+        d.load().unwrap();
+        assert!(d.test_run(0, &[0u8; 64]).is_ok());
+    }
+
+    #[test]
+    fn test_run_rejects_unsupported_program_types() {
+        let mut d = Deployment::new(
+            plan("tr2", "when XDP { pass }\n"),
+            ModelKernel::new().without_test_run_for(ProgType::Xdp),
+        );
+        d.load().unwrap();
+        assert!(matches!(
+            d.test_run(0, &[]).unwrap_err(),
+            LoaderError::TestRunUnsupported(ProgType::Xdp)
+        ));
+    }
+
+    #[test]
+    fn empty_module_cannot_load() {
+        // A module with no compiled programs.
+        let plan = DeploymentPlan {
+            name: "empty".to_owned(),
+            programs: Vec::new(),
+        };
+        let mut d = Deployment::new(plan, ModelKernel::new());
+        assert_eq!(d.load().unwrap_err(), LoaderError::Empty);
+    }
+}

--- a/rust/bpf-tcl-ir/src/lower.rs
+++ b/rust/bpf-tcl-ir/src/lower.rs
@@ -19,27 +19,54 @@
 //! Typed lowering: a Tcl front-end CFG ([`tcl_compiler::cfg::Function`]) → typed
 //! [`BpfProgram`], rejecting anything outside the DSL subset with span-anchored
 //! diagnostics. This is where "typed Tcl, not dynamic Tcl" is *enforced*.
+//!
+//! Dispatch is **registry-described**: every BPF-Tcl command's spec carries a
+//! typed [`BpfOpSpec`](tcl_registry::bpf_op::BpfOpSpec) descriptor (scalar
+//! width, packet-load width, map role, verdict family + compatible program
+//! types), and this lowerer matches on the descriptor — never on the command
+//! name — so registry, lowering, capability policy, and documentation cannot
+//! drift (issue #1202).
 
 use std::collections::HashMap;
 
 use tcl_compiler::cfg::{Block as CfgBlock, Function, Terminator};
 use tcl_compiler::{BinOp, ExprNode, Statement, UnaryOp, parse_expr};
 use tcl_lexer::Span;
+use tcl_registry::bpf_op::{
+    BpfDeclKind, BpfOpKind, BpfProgTypeSet, BpfScalarWidth, BpfVerdictKind,
+};
+use tcl_registry::registry::CommandRegistry;
 
+use crate::alloc::assign_slots;
 use crate::diag::{BpfDiag, BpfError};
 use crate::ir::{
-    Block, BlockId, BpfProgram, CmpOp, Inst, IntBinOp, MapDef, ProgType, SlotId, Term, UnOp,
+    Block, BlockId, BpfProgram, CmpOp, Inst, IntBinOp, MapConcurrency, MapDef, MapKind, OobAction,
+    ProgType, SlotId, Term, UnOp,
 };
-use crate::ty::{Region, Ty, Width};
+use crate::ty::{ByteOrder, Region, Ty, Width};
 
-/// 64 slots × 8 bytes = the 512-byte eBPF stack.
-const MAX_SLOTS: usize = 64;
+/// Guard against runaway macro/loop expansion during lowering. The *real*
+/// stack cap (64 slots / 512 bytes) is enforced after liveness-based slot
+/// reuse by [`crate::alloc::assign_slots`]; this raw cap only exists so a
+/// pathological expansion fails fast instead of allocating without bound.
+const MAX_RAW_SLOTS: usize = 4096;
 
 /// Lower a single CFG function to a typed [`BpfProgram`] of the given type.
 ///
+/// `registry` must have the BPF dialect loaded (its `BpfOpSpec` descriptors
+/// drive all command dispatch). Slot allocation (liveness-based reuse + the
+/// 512-byte stack cap) runs as part of lowering, so the returned program is
+/// ready for any codegen target.
+///
 /// # Errors
-/// Returns a [`BpfError`] for any construct outside the typed DSL subset.
-pub fn lower_function(func: &Function, prog_type: ProgType) -> Result<BpfProgram, BpfError> {
+/// Returns a [`BpfError`] for any construct outside the typed DSL subset, a
+/// handler path with no explicit verdict, or a program that exceeds the eBPF
+/// stack even after slot reuse.
+pub fn lower_function(
+    func: &Function,
+    prog_type: ProgType,
+    registry: &CommandRegistry,
+) -> Result<BpfProgram, BpfError> {
     // v1 supports no loops; reject any back-edge up front. Bounded loops are a
     // planned follow-on.
     if let Some(span) = first_loop_span(func) {
@@ -51,6 +78,7 @@ pub fn lower_function(func: &Function, prog_type: ProgType) -> Result<BpfProgram
     }
     let mut l = Lowerer {
         func,
+        registry,
         prog_type,
         env: HashMap::new(),
         slot_types: Vec::new(),
@@ -78,18 +106,25 @@ pub fn lower_function(func: &Function, prog_type: ProgType) -> Result<BpfProgram
     let mut blocks: Vec<Block> = l.lowered.into_values().collect();
     blocks.sort_by_key(|b| b.id.0);
     let num_slots = u32::try_from(l.slot_types.len()).unwrap_or(u32::MAX);
-    Ok(BpfProgram {
+    let mut program = BpfProgram {
         prog_type,
         entry,
         blocks,
         num_slots,
         slot_types: l.slot_types,
+        raw_slot_count: num_slots,
+        zero_init: Vec::new(),
         maps: l.map_defs,
-    })
+    };
+    assign_slots(&mut program)?;
+    Ok(program)
 }
 
 struct Lowerer<'f> {
     func: &'f Function,
+    /// The command registry (with the BPF dialect loaded) whose `BpfOpSpec`
+    /// descriptors drive all command dispatch.
+    registry: &'f CommandRegistry,
     /// Program type — selects verdict semantics (`accept`/`drop` vs `pass`/`tx`).
     prog_type: ProgType,
     /// Typed symbol table: variable name → (stable slot, type). Function-global
@@ -107,11 +142,14 @@ struct Lowerer<'f> {
 
 impl Lowerer<'_> {
     fn fresh_slot(&mut self, ty: Ty, span: Span) -> Result<SlotId, BpfError> {
-        if self.slot_types.len() >= MAX_SLOTS {
+        if self.slot_types.len() >= MAX_RAW_SLOTS {
             return Err(BpfError::new(
                 BpfDiag::StackOverflow,
                 span,
-                "program needs more than 64 values (the 512-byte eBPF stack is exceeded)",
+                format!(
+                    "program computes more than {MAX_RAW_SLOTS} values — \
+                     shrink the unrolled `loop`/`use` expansion"
+                ),
             ));
         }
         let id = SlotId(u32::try_from(self.slot_types.len()).unwrap_or(u32::MAX));
@@ -148,8 +186,13 @@ impl Lowerer<'_> {
         id
     }
 
-    /// Pre-scan every block for `map` declarations so `map_get`/`map_set` can
-    /// resolve names regardless of ordering.
+    /// The registry descriptor for a command, if it is a BPF-Tcl command.
+    fn bpf_op(&self, cmd: &str) -> Option<&'static tcl_registry::bpf_op::BpfOpSpec> {
+        self.registry.bpf_op(cmd)
+    }
+
+    /// Pre-scan every block for `map` declarations so `map_get`/`map_set`/
+    /// `map_has` can resolve names regardless of ordering.
     fn collect_maps(&mut self) -> Result<(), BpfError> {
         let func = self.func;
         for block in func.blocks.values() {
@@ -161,9 +204,11 @@ impl Lowerer<'_> {
                     span,
                     ..
                 } = stmt
-                    && canonical_command.as_deref().unwrap_or(command.as_str()) == "map"
                 {
-                    self.declare_map(args, *span)?;
+                    let cmd = canonical_command.as_deref().unwrap_or(command.as_str());
+                    if self.bpf_op(cmd).map(|op| op.kind) == Some(BpfOpKind::MapDeclare) {
+                        self.declare_map(args, *span)?;
+                    }
                 }
             }
         }
@@ -171,35 +216,77 @@ impl Lowerer<'_> {
     }
 
     fn declare_map(&mut self, args: &[String], span: Span) -> Result<(), BpfError> {
-        // map NAME hash KEYSZ VALSZ MAX  (the kind word is metadata in v1)
-        if args.len() != 5 {
-            return Err(arity(span, "map", "NAME hash KEYSZ VALSZ MAX"));
+        // map NAME hash|array KEYSZ VALSZ MAX ?shared|percpu?
+        if args.len() < 5 || args.len() > 6 {
+            return Err(arity(
+                span,
+                "map",
+                "NAME hash|array KEYSZ VALSZ MAX ?shared|percpu?",
+            ));
         }
         let name = args[0].clone();
         if self.map_index.contains_key(&name) {
             return Err(BpfError::new(
-                BpfDiag::TypeMismatch,
+                BpfDiag::BadMap,
                 span,
                 format!("map `{name}` is already declared"),
             ));
         }
-        let key_size = parse_u32(&args[2]).ok_or_else(|| {
-            BpfError::new(BpfDiag::BadInt, span, "map key size must be an integer")
+        let kind = MapKind::parse(&args[1]).ok_or_else(|| {
+            BpfError::new(
+                BpfDiag::BadMap,
+                span,
+                format!("unknown map kind `{}` (want hash or array)", args[1]),
+            )
         })?;
-        let value_size = parse_u32(&args[3]).ok_or_else(|| {
-            BpfError::new(BpfDiag::BadInt, span, "map value size must be an integer")
+        let key_size = parse_size(&args[2]).ok_or_else(|| {
+            BpfError::new(
+                BpfDiag::BadMap,
+                span,
+                "map key size must be 1, 2, 4, or 8 bytes (keys are passed by value)",
+            )
         })?;
-        let max_entries = parse_u32(&args[4]).ok_or_else(|| {
-            BpfError::new(BpfDiag::BadInt, span, "map max-entries must be an integer")
+        let value_size = parse_size(&args[3]).ok_or_else(|| {
+            BpfError::new(
+                BpfDiag::BadMap,
+                span,
+                "map value size must be 1, 2, 4, or 8 bytes (values are passed by value)",
+            )
         })?;
+        if kind == MapKind::Array && key_size != 4 {
+            return Err(BpfError::new(
+                BpfDiag::BadMap,
+                span,
+                "an array map's key is a 4-byte index (declare key size 4)",
+            ));
+        }
+        let max_entries = parse_u32(&args[4]).filter(|m| *m >= 1).ok_or_else(|| {
+            BpfError::new(
+                BpfDiag::BadMap,
+                span,
+                "map max-entries must be a positive integer",
+            )
+        })?;
+        let concurrency = match args.get(5) {
+            None => MapConcurrency::default(),
+            Some(word) => MapConcurrency::parse(word).ok_or_else(|| {
+                BpfError::new(
+                    BpfDiag::BadMap,
+                    span,
+                    format!("unknown map concurrency `{word}` (want shared or percpu)"),
+                )
+            })?,
+        };
         let index = u32::try_from(self.map_defs.len()).unwrap_or(u32::MAX);
         self.map_index.insert(name.clone(), index);
         self.map_defs.push(MapDef {
             name,
             index,
+            kind,
             key_size,
             value_size,
             max_entries,
+            concurrency,
             span,
         });
         Ok(())
@@ -237,6 +324,28 @@ impl Lowerer<'_> {
         Ok(None)
     }
 
+    fn lower_map_has(
+        &mut self,
+        args: &[String],
+        span: Span,
+        insts: &mut Vec<Inst>,
+    ) -> Result<Option<Term>, BpfError> {
+        // map_has DST NAME {KEY}
+        if args.len() != 3 {
+            return Err(arity(span, "map_has", "DST NAME {KEY}"));
+        }
+        let map = self.resolve_map(&args[1], span)?;
+        let key = self.lower_expr(&parse_expr(&args[2], None), insts, span)?;
+        let dst = self.var_slot(&args[0], Ty::Int, span)?;
+        insts.push(Inst::MapHas {
+            dst,
+            map,
+            key,
+            span,
+        });
+        Ok(None)
+    }
+
     fn lower_map_set(
         &mut self,
         args: &[String],
@@ -262,12 +371,13 @@ impl Lowerer<'_> {
     fn lower_load(
         &mut self,
         cmd: &str,
+        width_bits: u8,
         args: &[String],
         span: Span,
         insts: &mut Vec<Inst>,
     ) -> Result<Option<Term>, BpfError> {
-        if args.len() != 3 {
-            return Err(arity(span, cmd, "DST SRC OFFSET"));
+        if args.len() < 3 || args.len() > 4 {
+            return Err(arity(span, cmd, "DST SRC OFFSET ?be|le|native?"));
         }
         let ptr = self.expect_ctx_ptr(&args[1], span)?;
         let off_i64 = parse_int(&args[2]).ok_or_else(|| {
@@ -279,9 +389,26 @@ impl Lowerer<'_> {
         })?;
         let off = i32::try_from(off_i64)
             .map_err(|_| BpfError::new(BpfDiag::BadInt, span, "load offset out of range"))?;
-        let width = match cmd {
-            "load8" => Width::B8,
-            "load16" => Width::B16,
+        if off < 0 {
+            return Err(BpfError::new(
+                BpfDiag::BadInt,
+                span,
+                "load offset must be non-negative",
+            ));
+        }
+        let order = match args.get(3) {
+            None => ByteOrder::Native,
+            Some(word) => ByteOrder::parse(word).ok_or_else(|| {
+                BpfError::new(
+                    BpfDiag::OutOfSubset,
+                    span,
+                    format!("unknown byte order `{word}` (want be, le, or native)"),
+                )
+            })?,
+        };
+        let width = match width_bits {
+            8 => Width::B8,
+            16 => Width::B16,
             _ => Width::B32,
         };
         let dst = self.var_slot(&args[0], Ty::Int, span)?;
@@ -290,29 +417,42 @@ impl Lowerer<'_> {
             width,
             ptr,
             off,
+            order,
+            oob: OobAction::ReturnVerdict(self.drop_verdict()),
             span,
         });
         Ok(None)
     }
 
-    /// Lower a verdict command (`accept`/`drop`/`pass`/`tx`), validated against
-    /// the program type, into a `Return`.
+    /// Lower a verdict command, validated against the program type, into a
+    /// `Return`.
     fn lower_verdict(
         &mut self,
         cmd: &str,
+        kind: BpfVerdictKind,
+        prog_types: BpfProgTypeSet,
         args: &[String],
         span: Span,
         insts: &mut Vec<Inst>,
     ) -> Result<Option<Term>, BpfError> {
-        let verdict = match cmd {
-            "accept" => {
-                if self.prog_type != ProgType::SocketFilter {
-                    return Err(BpfError::new(
-                        BpfDiag::OutOfSubset,
-                        span,
-                        "`accept` is a socket-filter verdict; use `pass`/`drop`/`tx` for XDP",
-                    ));
-                }
+        let compatible = match prog_types {
+            BpfProgTypeSet::All => true,
+            BpfProgTypeSet::SocketFilterOnly => self.prog_type == ProgType::SocketFilter,
+            BpfProgTypeSet::XdpOnly => self.prog_type == ProgType::Xdp,
+        };
+        if !compatible {
+            let hint = match self.prog_type {
+                ProgType::SocketFilter => "use `accept`/`drop` for socket filters",
+                ProgType::Xdp => "use `pass`/`drop`/`tx` for XDP",
+            };
+            return Err(BpfError::new(
+                BpfDiag::OutOfSubset,
+                span,
+                format!("`{cmd}` is not a valid verdict for this program type; {hint}"),
+            ));
+        }
+        let verdict = match kind {
+            BpfVerdictKind::Accept => {
                 if args.is_empty() {
                     let dst = self.fresh_slot(Ty::Int, span)?;
                     insts.push(Inst::CtxLen { dst, span });
@@ -320,29 +460,20 @@ impl Lowerer<'_> {
                 } else if args.len() == 1 {
                     self.lower_expr(&parse_expr(&args[0], None), insts, span)?
                 } else {
-                    return Err(arity(span, "accept", "?N?"));
+                    return Err(arity(span, cmd, "?N?"));
                 }
             }
-            "pass" | "tx" => {
-                if self.prog_type != ProgType::Xdp {
-                    return Err(BpfError::new(
-                        BpfDiag::OutOfSubset,
-                        span,
-                        format!(
-                            "`{cmd}` is an XDP verdict; use `accept`/`drop` for socket filters"
-                        ),
-                    ));
-                }
+            BpfVerdictKind::Pass | BpfVerdictKind::Tx => {
                 if !args.is_empty() {
                     return Err(arity(span, cmd, "(no arguments)"));
                 }
-                let val = if cmd == "pass" { 2 } else { 3 };
+                let val = if kind == BpfVerdictKind::Pass { 2 } else { 3 };
                 self.const_slot(val, span, insts)?
             }
             // `drop` is valid for both; the value differs by program type.
-            _ => {
+            BpfVerdictKind::Drop => {
                 if !args.is_empty() {
-                    return Err(arity(span, "drop", "(no arguments)"));
+                    return Err(arity(span, cmd, "(no arguments)"));
                 }
                 let val = self.drop_verdict();
                 self.const_slot(val, span, insts)?
@@ -423,8 +554,8 @@ impl Lowerer<'_> {
         Ok(succs)
     }
 
-    /// Lower one statement. Returns `Some(term)` for `accept`/`drop` (which
-    /// terminate the block early), `None` otherwise.
+    /// Lower one statement. Returns `Some(term)` for a verdict (which
+    /// terminates the block early), `None` otherwise.
     fn lower_stmt(
         &mut self,
         stmt: &Statement,
@@ -467,15 +598,15 @@ impl Lowerer<'_> {
         }
     }
 
-    /// Truncate a computed value `tmp` into `dst` to the named integer width:
-    /// `seti32` sign-extends the low 32 bits (`(v << 32) >> 32`, arithmetic), so
-    /// a value overflowing 32 bits becomes its signed 32-bit truncation; `setu32`
-    /// zeroes the high half (`v & ((1 << 32) - 1)`, the mask computed because a
-    /// bare `0xFFFFFFFF` immediate exceeds the v1 32-bit const limit); `setint`
-    /// keeps the full 64-bit value (`RUST_ISSUE_172`).
+    /// Truncate a computed value `tmp` into `dst` to the descriptor's integer
+    /// width: [`BpfScalarWidth::I32SignExtended`] sign-extends the low 32 bits
+    /// (`(v << 32) >> 32`, arithmetic), so a value overflowing 32 bits becomes
+    /// its signed 32-bit truncation; [`BpfScalarWidth::U32ZeroExtended`] zeroes
+    /// the high half (`v & 0xFFFF_FFFF`); [`BpfScalarWidth::I64`] keeps the
+    /// full 64-bit value (`RUST_ISSUE_172`).
     fn emit_width_set(
         &mut self,
-        cmd: &str,
+        width: BpfScalarWidth,
         tmp: SlotId,
         dst: SlotId,
         insts: &mut Vec<Inst>,
@@ -486,8 +617,8 @@ impl Lowerer<'_> {
             insts.push(Inst::Const { dst: s, val, span });
             Ok(s)
         };
-        match cmd {
-            "seti32" => {
+        match width {
+            BpfScalarWidth::I32SignExtended => {
                 let sh = konst(self, 32)?;
                 let hi = self.fresh_slot(Ty::Int, span)?;
                 insts.push(Inst::Bin {
@@ -505,25 +636,8 @@ impl Lowerer<'_> {
                     span,
                 });
             }
-            "setu32" => {
-                let one = konst(self, 1)?;
-                let sh = konst(self, 32)?;
-                let hi = self.fresh_slot(Ty::Int, span)?;
-                insts.push(Inst::Bin {
-                    dst: hi,
-                    op: IntBinOp::Shl,
-                    a: one,
-                    b: sh,
-                    span,
-                });
-                let mask = self.fresh_slot(Ty::Int, span)?;
-                insts.push(Inst::Bin {
-                    dst: mask,
-                    op: IntBinOp::Sub,
-                    a: hi,
-                    b: one,
-                    span,
-                });
+            BpfScalarWidth::U32ZeroExtended => {
+                let mask = konst(self, 0xFFFF_FFFF)?;
                 insts.push(Inst::Bin {
                     dst,
                     op: IntBinOp::And,
@@ -532,7 +646,7 @@ impl Lowerer<'_> {
                     span,
                 });
             }
-            _ => insts.push(Inst::Copy {
+            BpfScalarWidth::I64 => insts.push(Inst::Copy {
                 dst,
                 src: tmp,
                 span,
@@ -548,21 +662,39 @@ impl Lowerer<'_> {
         span: Span,
         insts: &mut Vec<Inst>,
     ) -> Result<Option<Term>, BpfError> {
-        match cmd {
-            "setint" | "seti32" | "setu32" => {
+        let Some(op) = self.bpf_op(cmd) else {
+            if is_concurrency_command(cmd) {
+                return Err(BpfError::new(
+                    BpfDiag::OutOfSubset,
+                    span,
+                    format!(
+                        "`{cmd}`: concurrency is not supported on the eBPF backend \
+                         (no coroutines, threads, or event loop — an eBPF program is a \
+                         single bounded run to a verdict)"
+                    ),
+                ));
+            }
+            return Err(BpfError::new(
+                BpfDiag::UnknownCommand,
+                span,
+                format!("unknown BPF-Tcl command `{cmd}`"),
+            ));
+        };
+        match op.kind {
+            BpfOpKind::ScalarSet(width) => {
                 if args.len() != 2 {
                     return Err(arity(span, cmd, "NAME {EXPR}"));
                 }
                 let expr = parse_expr(&args[1], None);
                 let tmp = self.lower_expr(&expr, insts, span)?;
                 let dst = self.var_slot(&args[0], Ty::Int, span)?;
-                self.emit_width_set(cmd, tmp, dst, insts, span)?;
+                self.emit_width_set(width, tmp, dst, insts, span)?;
                 Ok(None)
             }
-            "setbuf" => {
+            BpfOpKind::BindPacket => {
                 // `setbuf NAME ctx` or `setbuf NAME = ctx`.
                 if args.is_empty() {
-                    return Err(arity(span, "setbuf", "NAME ctx"));
+                    return Err(arity(span, cmd, "NAME ctx"));
                 }
                 if !args.iter().any(|a| a == "ctx") {
                     return Err(BpfError::new(
@@ -575,39 +707,35 @@ impl Lowerer<'_> {
                 insts.push(Inst::CtxPtr { dst, span });
                 Ok(None)
             }
-            "load8" | "load16" | "load32" => self.lower_load(cmd, args, span, insts),
-            "pktlen" => {
+            BpfOpKind::PacketLoad { width_bits } => {
+                self.lower_load(cmd, width_bits, args, span, insts)
+            }
+            BpfOpKind::PacketLen => {
                 if args.len() != 2 {
-                    return Err(arity(span, "pktlen", "DST SRC"));
+                    return Err(arity(span, cmd, "DST SRC"));
                 }
                 self.expect_ctx_ptr(&args[1], span)?;
                 let dst = self.var_slot(&args[0], Ty::Int, span)?;
                 insts.push(Inst::CtxLen { dst, span });
                 Ok(None)
             }
-            "accept" | "drop" | "pass" | "tx" => self.lower_verdict(cmd, args, span, insts),
-            // `map NAME hash KEYSZ VALSZ MAX` is a declaration, collected up front.
-            "map" => Ok(None),
-            "map_get" => self.lower_map_get(args, span, insts),
-            "map_set" => self.lower_map_set(args, span, insts),
-            "loop" => Err(BpfError::new(
+            BpfOpKind::Verdict(kind) => {
+                self.lower_verdict(cmd, kind, op.prog_types, args, span, insts)
+            }
+            // A `map` declaration was collected up front.
+            BpfOpKind::MapDeclare => Ok(None),
+            BpfOpKind::MapGet => self.lower_map_get(args, span, insts),
+            BpfOpKind::MapHas => self.lower_map_has(args, span, insts),
+            BpfOpKind::MapSet => self.lower_map_set(args, span, insts),
+            BpfOpKind::LoopMacro => Err(BpfError::new(
                 BpfDiag::OutOfSubset,
                 span,
                 "`loop` must appear at the handler/loop top level, not nested inside `if` (v1)",
             )),
-            other if is_concurrency_command(other) => Err(BpfError::new(
+            BpfOpKind::Framework(decl) => Err(BpfError::new(
                 BpfDiag::OutOfSubset,
                 span,
-                format!(
-                    "`{other}`: concurrency is not supported on the eBPF backend \
-                     (no coroutines, threads, or event loop — an eBPF program is a \
-                     single bounded run to a verdict)"
-                ),
-            )),
-            other => Err(BpfError::new(
-                BpfDiag::UnknownCommand,
-                span,
-                format!("unknown BPF-Tcl command `{other}`"),
+                framework_in_handler_message(cmd, decl),
             )),
         }
     }
@@ -751,33 +879,49 @@ impl Lowerer<'_> {
                     vec![tname, fname],
                 ))
             }
-            // A fall-through with no explicit verdict defaults to the program's
-            // `drop` value (0 for socket filters, XDP_DROP for XDP).
+            // Control reaches the end of the handler with no explicit
+            // verdict. Never synthesize one silently — this is a hard error
+            // (issue #1202: "define whether verdict-less handlers are an
+            // error … never synthesize it silently").
             Some(Terminator::Return { span, .. }) => {
-                let sp = span.unwrap_or_else(|| Span::empty(0));
-                let val = self.drop_verdict();
-                let dst = self.const_slot(val, sp, insts)?;
-                Ok((
-                    Term::Return {
-                        verdict: dst,
-                        span: sp,
-                    },
-                    Vec::new(),
-                ))
+                Err(self.missing_verdict(span.unwrap_or_else(|| Span::empty(0))))
             }
-            None => {
-                let sp = Span::empty(0);
-                let val = self.drop_verdict();
-                let dst = self.const_slot(val, sp, insts)?;
-                Ok((
-                    Term::Return {
-                        verdict: dst,
-                        span: sp,
-                    },
-                    Vec::new(),
-                ))
-            }
+            None => Err(self.missing_verdict(Span::empty(0))),
         }
+    }
+
+    fn missing_verdict(&self, span: Span) -> BpfError {
+        let verdicts = match self.prog_type {
+            ProgType::SocketFilter => "`accept`/`drop`",
+            ProgType::Xdp => "`pass`/`drop`/`tx`",
+        };
+        BpfError::new(
+            BpfDiag::MissingVerdict,
+            span,
+            format!(
+                "control can reach the end of the handler without a verdict — \
+                 end every path with an explicit verdict ({verdicts})"
+            ),
+        )
+    }
+}
+
+/// The diagnostic for a framework declaration reaching the typed lowering
+/// (i.e. written inside a handler body where it has no meaning).
+fn framework_in_handler_message(cmd: &str, decl: BpfDeclKind) -> String {
+    match decl {
+        BpfDeclKind::Field => format!(
+            "`{cmd}` declarations belong inside a `profile NAME {{ … }}` body, \
+             not in a handler"
+        ),
+        BpfDeclKind::Use => format!(
+            "`{cmd}` could not be expanded here — template expansion happens \
+             before lowering, so this `use` is malformed or out of place"
+        ),
+        _ => format!(
+            "`{cmd}` is a framework declaration — it must appear at the file \
+             top level, not inside a handler"
+        ),
     }
 }
 
@@ -822,7 +966,9 @@ fn arity(span: Span, cmd: &str, usage: &str) -> BpfError {
 /// is a single bounded run to a verdict), so they earn a specific `OutOfSubset`
 /// diagnostic rather than the generic "unknown command". (The event loop —
 /// `after`/`vwait`/`update` — is rejected earlier by the typed front-end as an
-/// out-of-subset construct.)
+/// out-of-subset construct.)  This is a diagnostics nicety over commands the
+/// BPF registry deliberately does *not* describe, not per-command lowering
+/// knowledge.
 fn is_concurrency_command(cmd: &str) -> bool {
     matches!(
         cmd,
@@ -890,6 +1036,11 @@ fn parse_int(text: &str) -> Option<i64> {
 /// Parse a non-negative integer literal into a `u32`.
 fn parse_u32(s: &str) -> Option<u32> {
     parse_int(s).and_then(|v| u32::try_from(v).ok())
+}
+
+/// Parse a by-value map key/value size: 1, 2, 4, or 8 bytes.
+fn parse_size(s: &str) -> Option<u32> {
+    parse_u32(s).filter(|v| matches!(v, 1 | 2 | 4 | 8))
 }
 
 /// The span of some loop in `func`, if it contains a cycle (back-edge).

--- a/rust/bpf-tcl-ir/src/lower.rs
+++ b/rust/bpf-tcl-ir/src/lower.rs
@@ -478,6 +478,15 @@ impl Lowerer<'_> {
                 let val = self.drop_verdict();
                 self.const_slot(val, span, insts)?
             }
+            // `next` — the explicit non-terminal continuation. The handler
+            // returns the reserved continuation sentinel; the composition model
+            // reads it as "run the next handler" (issue #1204).
+            BpfVerdictKind::Next => {
+                if !args.is_empty() {
+                    return Err(arity(span, cmd, "(no arguments)"));
+                }
+                self.const_slot(crate::ir::CONTINUE_SENTINEL, span, insts)?
+            }
         };
         Ok(Some(Term::Return { verdict, span }))
     }

--- a/rust/bpf-tcl-ir/src/profile.rs
+++ b/rust/bpf-tcl-ir/src/profile.rs
@@ -29,6 +29,16 @@
 //! (`profile NAME { field … }`). Offsets assume an Ethernet(14) + IPv4(20,
 //! no options) + L4 layout. Other facets (templates, capability, deployment)
 //! layer onto this same `BpfProfileSpec` in later increments.
+//!
+//! Multi-byte fields are read in **network order** (big-endian) by default —
+//! the order real Ethernet/IP/TCP/UDP headers use — so `tcp_dport dport`
+//! matches a realistic packet on a little-endian host. A user field may
+//! opt out with an explicit trailing `le`/`native` word
+//! (`field NAME OFFSET WIDTHBITS ?be|le|native?`); `native` exists only as a
+//! temporary compatibility mode for synthetic host-order test packets.
+//!
+//! A user profile body may contain **only** `field` declarations — anything
+//! else is rejected rather than silently dropped (`RUST_ISSUE_063`).
 
 use tcl_compiler::ir::IfClause;
 use tcl_compiler::lowering::lower_to_ir;
@@ -37,6 +47,7 @@ use tcl_lexer::Span;
 use tcl_registry::registry::CommandRegistry;
 
 use crate::diag::{BpfDiag, BpfError};
+use crate::ty::ByteOrder;
 
 /// A named header field at a fixed packet offset.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -47,6 +58,8 @@ pub struct FieldDef {
     pub offset: i32,
     /// Width in bits (8, 16, or 32).
     pub width_bits: u8,
+    /// How the field's bytes are interpreted (default: network order).
+    pub order: ByteOrder,
 }
 
 /// A profile: a named bundle of header fields (+ later facets).
@@ -71,6 +84,8 @@ fn field(name: &str, offset: i32, width_bits: u8) -> FieldDef {
         name: name.to_owned(),
         offset,
         width_bits,
+        // Built-in profiles describe real network headers: network order.
+        order: ByteOrder::Big,
     }
 }
 
@@ -184,35 +199,65 @@ fn parse_user_profile(
     let module = lower_to_ir(body, registry);
     let mut fields = Vec::new();
     for stmt in &module.top_level.statements {
-        if let Statement::Call {
+        let Statement::Call {
             command,
             canonical_command,
             args,
             span,
             ..
         } = stmt
-            && canonical_command.as_deref().unwrap_or(command.as_str()) == "field"
-        {
-            // field NAME OFFSET WIDTHBITS
-            if args.len() != 3 {
-                return Err(BpfError::new(
-                    BpfDiag::BadProfile,
-                    *span,
-                    "`field` expects: field NAME OFFSET WIDTHBITS",
-                ));
-            }
-            let offset = args[1].parse::<i32>().map_err(|_| {
-                BpfError::new(BpfDiag::BadInt, *span, "field offset must be an integer")
-            })?;
-            let width_bits = parse_width(&args[2]).ok_or_else(|| {
+        else {
+            // A profile body is a pure declaration list — reject any control
+            // flow or assignment rather than dropping it (RUST_ISSUE_063).
+            return Err(BpfError::new(
+                BpfDiag::BadProfile,
+                stmt.span(),
+                "only `field` declarations are allowed inside a `profile` body",
+            ));
+        };
+        let cmd = canonical_command.as_deref().unwrap_or(command.as_str());
+        if cmd != "field" {
+            return Err(BpfError::new(
+                BpfDiag::BadProfile,
+                *span,
+                format!(
+                    "only `field` declarations are allowed inside a `profile` \
+                     body; `{cmd}` would be silently dropped"
+                ),
+            ));
+        }
+        // field NAME OFFSET WIDTHBITS ?be|le|native?
+        if args.len() < 3 || args.len() > 4 {
+            return Err(BpfError::new(
+                BpfDiag::BadProfile,
+                *span,
+                "`field` expects: field NAME OFFSET WIDTHBITS ?be|le|native?",
+            ));
+        }
+        let offset = args[1].parse::<i32>().map_err(|_| {
+            BpfError::new(BpfDiag::BadInt, *span, "field offset must be an integer")
+        })?;
+        let width_bits = parse_width(&args[2]).ok_or_else(|| {
+            BpfError::new(
+                BpfDiag::BadProfile,
+                *span,
+                "field width must be 8, 16, or 32",
+            )
+        })?;
+        let order = match args.get(3) {
+            // Network order is the default: real headers are big-endian.
+            None => ByteOrder::Big,
+            Some(word) => ByteOrder::parse(word).ok_or_else(|| {
                 BpfError::new(
                     BpfDiag::BadProfile,
                     *span,
-                    "field width must be 8, 16, or 32",
+                    format!("unknown field byte order `{word}` (want be, le, or native)"),
                 )
-            })?;
-            fields.push(field(&args[0], offset, width_bits));
-        }
+            })?,
+        };
+        let mut f = field(&args[0], offset, width_bits);
+        f.order = order;
+        fields.push(f);
     }
     Ok(BpfProfileSpec {
         name: name.to_owned(),
@@ -274,9 +319,14 @@ fn expand_script(
                         16 => "load16",
                         _ => "load32",
                     };
+                    let order = match f.order {
+                        ByteOrder::Big => "be",
+                        ByteOrder::Little => "le",
+                        ByteOrder::Native => "native",
+                    };
                     out.push(synth_call(
                         load,
-                        &[&args[0], "__pkt", &f.offset.to_string()],
+                        &[&args[0], "__pkt", &f.offset.to_string(), order],
                         *span,
                     ));
                 } else {

--- a/rust/bpf-tcl-ir/src/ringbuf.rs
+++ b/rust/bpf-tcl-ir/src/ringbuf.rs
@@ -1,0 +1,540 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Typed kernel→userspace event records and their ring-buffer transport
+//! (issue #1204's userspace event channel).
+//!
+//! Observability events (tracepoints, kprobes, …) do not return a packet
+//! verdict; they emit **records** to userspace. This module defines a
+//! **versioned record ABI**, a **record schema** generated from an event's
+//! typed context fields, a bounded **ring-buffer transport** with explicit
+//! loss accounting and back-pressure behaviour, and a **structured consumer**
+//! that renders records as JSON or text.
+//!
+//! # Wire ABI
+//!
+//! Every record on the wire is a fixed [`RecordHeader`] followed by the field
+//! payload. All multi-byte header integers are **little-endian** (the ABI's
+//! fixed transport order, independent of any field's own declared byte order).
+//! The header is versioned: a consumer rejects a record whose magic or version
+//! it does not recognise, so the transport can evolve without silently
+//! misreading old records.
+//!
+//! ```text
+//! offset  size  field
+//! 0       4     magic      = RECORD_MAGIC ("BTR1" little-endian)
+//! 4       2     abi_version = RECORD_ABI_VERSION
+//! 6       2     event_type  (registry event index)
+//! 8       4     payload_len (bytes of field payload following the header)
+//! 12      4     seq         (monotonic per-stream sequence number)
+//! = 16-byte header, then `payload_len` bytes of packed fields.
+//! ```
+//!
+//! # Back-pressure and record drops
+//!
+//! The [`RingBuffer`] is bounded by a byte capacity. When a record does not
+//! fit, it is **dropped** (never truncated or partially written) and the
+//! [`RingBuffer::dropped`] counter is incremented — the same lossy-but-counted
+//! behaviour as the kernel `BPF_MAP_TYPE_RINGBUF` reserve failing under
+//! back-pressure. A consumer therefore always sees whole records, and can
+//! observe exactly how many were lost.
+
+use tcl_registry::bpf_op::{BpfCtxField, BpfEventSpec, BpfFieldOrder};
+
+/// Magic that prefixes every record: ASCII `"BTR1"` read little-endian.
+pub const RECORD_MAGIC: u32 = u32::from_le_bytes(*b"BTR1");
+
+/// The record ABI version. Bumped on any incompatible header/payload change.
+pub const RECORD_ABI_VERSION: u16 = 1;
+
+/// The fixed record header size in bytes.
+pub const HEADER_LEN: usize = 16;
+
+/// A record's fixed, versioned header (little-endian on the wire).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RecordHeader {
+    /// Always [`RECORD_MAGIC`].
+    pub magic: u32,
+    /// Always [`RECORD_ABI_VERSION`] for records this build produces.
+    pub abi_version: u16,
+    /// Registry event index (`BPF_EVENTS[event_type]`).
+    pub event_type: u16,
+    /// Length of the field payload that follows the header.
+    pub payload_len: u32,
+    /// Monotonic per-stream sequence number (lets a consumer detect gaps).
+    pub seq: u32,
+}
+
+impl RecordHeader {
+    /// Serialize to the fixed 16-byte little-endian header.
+    #[must_use]
+    pub fn to_bytes(self) -> [u8; HEADER_LEN] {
+        let mut out = [0u8; HEADER_LEN];
+        out[0..4].copy_from_slice(&self.magic.to_le_bytes());
+        out[4..6].copy_from_slice(&self.abi_version.to_le_bytes());
+        out[6..8].copy_from_slice(&self.event_type.to_le_bytes());
+        out[8..12].copy_from_slice(&self.payload_len.to_le_bytes());
+        out[12..16].copy_from_slice(&self.seq.to_le_bytes());
+        out
+    }
+
+    /// Parse a header, validating magic and version.
+    ///
+    /// # Errors
+    /// [`RecordError::Truncated`] if fewer than [`HEADER_LEN`] bytes,
+    /// [`RecordError::BadMagic`] / [`RecordError::UnsupportedVersion`] on a
+    /// header this build does not recognise.
+    pub fn parse(bytes: &[u8]) -> Result<Self, RecordError> {
+        if bytes.len() < HEADER_LEN {
+            return Err(RecordError::Truncated);
+        }
+        let magic = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        if magic != RECORD_MAGIC {
+            return Err(RecordError::BadMagic(magic));
+        }
+        let abi_version = u16::from_le_bytes(bytes[4..6].try_into().unwrap());
+        if abi_version != RECORD_ABI_VERSION {
+            return Err(RecordError::UnsupportedVersion(abi_version));
+        }
+        Ok(RecordHeader {
+            magic,
+            abi_version,
+            event_type: u16::from_le_bytes(bytes[6..8].try_into().unwrap()),
+            payload_len: u32::from_le_bytes(bytes[8..12].try_into().unwrap()),
+            seq: u32::from_le_bytes(bytes[12..16].try_into().unwrap()),
+        })
+    }
+}
+
+/// A record decode/validation error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecordError {
+    /// Fewer bytes than the header (or declared payload) needs.
+    Truncated,
+    /// The leading magic did not match [`RECORD_MAGIC`].
+    BadMagic(u32),
+    /// The header's ABI version is not one this build understands.
+    UnsupportedVersion(u16),
+    /// The payload length did not match the schema's fixed record size.
+    PayloadSizeMismatch {
+        /// Bytes the schema expects.
+        expected: usize,
+        /// Bytes the header declared.
+        found: usize,
+    },
+}
+
+impl core::fmt::Display for RecordError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            RecordError::Truncated => write!(f, "record is truncated"),
+            RecordError::BadMagic(m) => write!(f, "bad record magic {m:#010x}"),
+            RecordError::UnsupportedVersion(v) => {
+                write!(f, "unsupported record ABI version {v}")
+            }
+            RecordError::PayloadSizeMismatch { expected, found } => {
+                write!(
+                    f,
+                    "payload size mismatch: expected {expected}, found {found}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for RecordError {}
+
+/// The byte width of a field in a record payload.
+#[must_use]
+fn field_bytes(width_bits: u16) -> usize {
+    (width_bits as usize).div_ceil(8)
+}
+
+/// A typed record schema derived from an event's context fields. The payload is
+/// each field packed to its declared width and byte order, in field order, with
+/// no padding (a stable, self-describing layout).
+#[derive(Debug, Clone)]
+pub struct RecordSchema {
+    /// The registry event index this schema describes.
+    pub event_type: u16,
+    /// The event's canonical name (for the JSON/text consumer).
+    pub event_name: &'static str,
+    /// The fields, in payload order.
+    pub fields: &'static [BpfCtxField],
+}
+
+impl RecordSchema {
+    /// Build the schema for a registry event, given its index.
+    #[must_use]
+    pub fn for_event(event_type: u16, spec: &'static BpfEventSpec) -> Self {
+        RecordSchema {
+            event_type,
+            event_name: spec.name,
+            fields: spec.context.fields,
+        }
+    }
+
+    /// The fixed payload size in bytes.
+    #[must_use]
+    pub fn payload_len(&self) -> usize {
+        self.fields.iter().map(|f| field_bytes(f.width_bits)).sum()
+    }
+
+    /// The whole record size (header + payload).
+    #[must_use]
+    pub fn record_len(&self) -> usize {
+        HEADER_LEN + self.payload_len()
+    }
+
+    /// Encode one record from field values (one per schema field, in order).
+    /// A value wider than its field is truncated to the field width.
+    ///
+    /// # Panics
+    /// If `values.len()` does not equal the number of schema fields.
+    #[must_use]
+    pub fn encode(&self, seq: u32, values: &[u64]) -> Vec<u8> {
+        assert_eq!(
+            values.len(),
+            self.fields.len(),
+            "encode expects one value per field"
+        );
+        let payload_len = self.payload_len();
+        let header = RecordHeader {
+            magic: RECORD_MAGIC,
+            abi_version: RECORD_ABI_VERSION,
+            event_type: self.event_type,
+            payload_len: u32::try_from(payload_len).unwrap_or(u32::MAX),
+            seq,
+        };
+        let mut out = Vec::with_capacity(HEADER_LEN + payload_len);
+        out.extend_from_slice(&header.to_bytes());
+        for (field, &value) in self.fields.iter().zip(values) {
+            pack_field(&mut out, field, value);
+        }
+        out
+    }
+
+    /// Decode one record's field values, validating the header and payload size
+    /// against this schema.
+    ///
+    /// # Errors
+    /// A header/version/size validation error.
+    pub fn decode(&self, bytes: &[u8]) -> Result<DecodedRecord, RecordError> {
+        let header = RecordHeader::parse(bytes)?;
+        let payload = &bytes[HEADER_LEN..];
+        let expected = self.payload_len();
+        if header.payload_len as usize != expected || payload.len() < expected {
+            return Err(RecordError::PayloadSizeMismatch {
+                expected,
+                found: header.payload_len as usize,
+            });
+        }
+        let mut values = Vec::with_capacity(self.fields.len());
+        let mut off = 0usize;
+        for field in self.fields {
+            let n = field_bytes(field.width_bits);
+            values.push(unpack_field(&payload[off..off + n], field));
+            off += n;
+        }
+        Ok(DecodedRecord { header, values })
+    }
+
+    /// Render a decoded record as a single-line JSON object.
+    #[must_use]
+    pub fn to_json(&self, record: &DecodedRecord) -> String {
+        use core::fmt::Write as _;
+        let mut s = String::new();
+        let _ = write!(
+            s,
+            "{{\"event\":\"{}\",\"seq\":{},\"fields\":{{",
+            self.event_name, record.header.seq
+        );
+        for (i, (field, value)) in self.fields.iter().zip(&record.values).enumerate() {
+            if i > 0 {
+                s.push(',');
+            }
+            let _ = write!(s, "\"{}\":{value}", field.name);
+        }
+        s.push_str("}}");
+        s
+    }
+
+    /// Render a decoded record as a compact text line.
+    #[must_use]
+    pub fn to_text(&self, record: &DecodedRecord) -> String {
+        use core::fmt::Write as _;
+        let mut s = format!("{} seq={}", self.event_name, record.header.seq);
+        for (field, value) in self.fields.iter().zip(&record.values) {
+            let _ = write!(s, " {}={value}", field.name);
+        }
+        s
+    }
+}
+
+/// Pack one field value into the buffer at its declared width and byte order.
+fn pack_field(out: &mut Vec<u8>, field: &BpfCtxField, value: u64) {
+    let n = field_bytes(field.width_bits);
+    let le = value.to_le_bytes();
+    match field.order {
+        // Host order: little-endian on this build's little-endian reference.
+        BpfFieldOrder::Host => out.extend_from_slice(&le[..n]),
+        // Network order: big-endian — take the low `n` bytes, most-significant
+        // first.
+        BpfFieldOrder::Network => {
+            for i in (0..n).rev() {
+                out.push(le[i]);
+            }
+        }
+    }
+}
+
+/// Unpack one field value from `n` bytes at its declared byte order.
+fn unpack_field(bytes: &[u8], field: &BpfCtxField) -> u64 {
+    let mut v = 0u64;
+    match field.order {
+        BpfFieldOrder::Host => {
+            for (i, &b) in bytes.iter().enumerate() {
+                v |= u64::from(b) << (8 * i);
+            }
+        }
+        BpfFieldOrder::Network => {
+            for &b in bytes {
+                v = (v << 8) | u64::from(b);
+            }
+        }
+    }
+    v
+}
+
+/// A record decoded against its schema.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedRecord {
+    /// The validated header.
+    pub header: RecordHeader,
+    /// Field values, in schema order.
+    pub values: Vec<u64>,
+}
+
+/// A bounded, lossy-but-counted userspace ring buffer.
+///
+/// Records are appended whole. When one does not fit the remaining capacity it
+/// is dropped and [`RingBuffer::dropped`] is incremented — modelling
+/// `BPF_MAP_TYPE_RINGBUF` reserve failures under back-pressure. Draining with
+/// [`RingBuffer::drain`] frees the whole capacity again.
+#[derive(Debug, Clone)]
+pub struct RingBuffer {
+    capacity: usize,
+    buf: Vec<u8>,
+    /// Record boundaries: byte length of each queued record, in order.
+    lengths: Vec<usize>,
+    dropped: u64,
+    delivered: u64,
+}
+
+impl RingBuffer {
+    /// Create a ring buffer with `capacity` bytes of record storage.
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        RingBuffer {
+            capacity,
+            buf: Vec::new(),
+            lengths: Vec::new(),
+            dropped: 0,
+            delivered: 0,
+        }
+    }
+
+    /// Append a whole record. Returns `true` if it was stored, `false` if it was
+    /// dropped for lack of capacity (and `dropped` was incremented).
+    pub fn push(&mut self, record: &[u8]) -> bool {
+        if record.len() > self.capacity || self.buf.len() + record.len() > self.capacity {
+            self.dropped = self.dropped.saturating_add(1);
+            return false;
+        }
+        self.buf.extend_from_slice(record);
+        self.lengths.push(record.len());
+        true
+    }
+
+    /// Drain every queued record, returning them in FIFO order and freeing the
+    /// buffer. Increments `delivered` by the number returned.
+    pub fn drain(&mut self) -> Vec<Vec<u8>> {
+        let mut out = Vec::with_capacity(self.lengths.len());
+        let mut off = 0usize;
+        for &len in &self.lengths {
+            out.push(self.buf[off..off + len].to_vec());
+            off += len;
+        }
+        self.delivered = self.delivered.saturating_add(out.len() as u64);
+        self.buf.clear();
+        self.lengths.clear();
+        out
+    }
+
+    /// The number of records dropped for lack of capacity (loss accounting).
+    #[must_use]
+    pub fn dropped(&self) -> u64 {
+        self.dropped
+    }
+
+    /// The number of records drained to a consumer over this buffer's life.
+    #[must_use]
+    pub fn delivered(&self) -> u64 {
+        self.delivered
+    }
+
+    /// The number of records currently queued.
+    #[must_use]
+    pub fn queued(&self) -> usize {
+        self.lengths.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tcl_registry::bpf_op::lookup_bpf_event;
+
+    fn schema(name: &str) -> RecordSchema {
+        let spec = lookup_bpf_event(name).expect("event exists");
+        let idx = tcl_registry::bpf_op::BPF_EVENTS
+            .iter()
+            .position(|e| e.name == spec.name)
+            .unwrap();
+        RecordSchema::for_event(u16::try_from(idx).unwrap(), spec)
+    }
+
+    #[test]
+    fn header_round_trips_and_validates() {
+        let h = RecordHeader {
+            magic: RECORD_MAGIC,
+            abi_version: RECORD_ABI_VERSION,
+            event_type: 3,
+            payload_len: 12,
+            seq: 42,
+        };
+        let bytes = h.to_bytes();
+        assert_eq!(RecordHeader::parse(&bytes).unwrap(), h);
+    }
+
+    #[test]
+    fn bad_magic_and_version_are_rejected() {
+        let mut bytes = RecordHeader {
+            magic: RECORD_MAGIC,
+            abi_version: RECORD_ABI_VERSION,
+            event_type: 0,
+            payload_len: 0,
+            seq: 0,
+        }
+        .to_bytes();
+        bytes[0] ^= 0xff;
+        assert!(matches!(
+            RecordHeader::parse(&bytes),
+            Err(RecordError::BadMagic(_))
+        ));
+
+        let mut bytes = RecordHeader {
+            magic: RECORD_MAGIC,
+            abi_version: RECORD_ABI_VERSION + 1,
+            event_type: 0,
+            payload_len: 0,
+            seq: 0,
+        }
+        .to_bytes();
+        // Fix magic (to_bytes already wrote it) — flip only version.
+        bytes[4] = 99;
+        assert!(matches!(
+            RecordHeader::parse(&bytes),
+            Err(RecordError::UnsupportedVersion(99))
+        ));
+    }
+
+    #[test]
+    fn record_round_trips_field_values_in_declared_order() {
+        // CGROUP_CONNECT4 has user_ip4 (net,32), user_port (net,32), family (host,32).
+        let s = schema("CGROUP_CONNECT4");
+        let values = [0x0100_007f, 22, 2]; // 127.0.0.1, port 22, AF_INET
+        let bytes = s.encode(7, &values);
+        assert_eq!(bytes.len(), s.record_len());
+        let decoded = s.decode(&bytes).expect("decodes");
+        assert_eq!(decoded.header.seq, 7);
+        assert_eq!(decoded.values, values.to_vec());
+    }
+
+    #[test]
+    fn network_order_field_is_big_endian_on_the_wire() {
+        let s = schema("CGROUP_CONNECT4");
+        // user_port = 22 network order -> big-endian 0x00000016 in payload.
+        let bytes = s.encode(0, &[0, 22, 2]);
+        let payload = &bytes[HEADER_LEN..];
+        // user_ip4 occupies the first 4 bytes; user_port the next 4.
+        assert_eq!(&payload[4..8], &[0x00, 0x00, 0x00, 0x16]);
+    }
+
+    #[test]
+    fn json_and_text_render_named_fields() {
+        let s = schema("CGROUP_CONNECT4");
+        let bytes = s.encode(1, &[10, 20, 2]);
+        let rec = s.decode(&bytes).unwrap();
+        let json = s.to_json(&rec);
+        assert!(json.contains("\"event\":\"CGROUP_CONNECT4\""));
+        assert!(json.contains("\"user_ip4\":10"));
+        assert!(json.contains("\"user_port\":20"));
+        let text = s.to_text(&rec);
+        assert!(text.starts_with("CGROUP_CONNECT4 seq=1"));
+        assert!(text.contains("family=2"));
+    }
+
+    #[test]
+    fn ring_buffer_counts_drops_under_back_pressure() {
+        let s = schema("CGROUP_CONNECT4");
+        let rec = s.encode(0, &[0, 0, 0]);
+        // Room for exactly one record.
+        let mut rb = RingBuffer::new(rec.len());
+        assert!(rb.push(&rec));
+        assert!(!rb.push(&rec)); // full -> dropped
+        assert_eq!(rb.dropped(), 1);
+        assert_eq!(rb.queued(), 1);
+        let drained = rb.drain();
+        assert_eq!(drained.len(), 1);
+        assert_eq!(rb.delivered(), 1);
+        // After draining, capacity is free again.
+        assert!(rb.push(&rec));
+        assert_eq!(rb.dropped(), 1);
+    }
+
+    #[test]
+    fn oversized_record_is_dropped_not_truncated() {
+        let mut rb = RingBuffer::new(8);
+        assert!(!rb.push(&[0u8; 16]));
+        assert_eq!(rb.dropped(), 1);
+        assert_eq!(rb.queued(), 0);
+    }
+
+    #[test]
+    fn payload_size_mismatch_is_detected() {
+        let s = schema("CGROUP_CONNECT4");
+        let mut bytes = s.encode(0, &[0, 0, 0]);
+        // Corrupt the declared payload_len.
+        bytes[8] = 0xff;
+        assert!(matches!(
+            s.decode(&bytes),
+            Err(RecordError::PayloadSizeMismatch { .. })
+        ));
+    }
+}

--- a/rust/bpf-tcl-ir/src/ty.rs
+++ b/rust/bpf-tcl-ir/src/ty.rs
@@ -55,3 +55,43 @@ pub enum Width {
     /// 32-bit (4 bytes).
     B32,
 }
+
+impl Width {
+    /// The width in bytes.
+    #[must_use]
+    pub fn bytes(self) -> u32 {
+        match self {
+            Width::B8 => 1,
+            Width::B16 => 2,
+            Width::B32 => 4,
+        }
+    }
+}
+
+/// How the bytes of a multi-byte packet field are interpreted.
+///
+/// `Native` is the host order of whatever executes the program — an explicit,
+/// temporary compatibility mode for synthetic test packets. Real network
+/// headers are `Big` (network order); profile fields default to it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ByteOrder {
+    /// Host byte order (compatibility mode; not meaningful for real packets).
+    Native,
+    /// Big-endian — network order.
+    Big,
+    /// Little-endian.
+    Little,
+}
+
+impl ByteOrder {
+    /// Parse the DSL byte-order word (`be`, `le`, `native`).
+    #[must_use]
+    pub fn parse(word: &str) -> Option<Self> {
+        match word {
+            "be" | "big" => Some(ByteOrder::Big),
+            "le" | "little" => Some(ByteOrder::Little),
+            "native" => Some(ByteOrder::Native),
+            _ => None,
+        }
+    }
+}

--- a/rust/bpf-tcl/src/lib.rs
+++ b/rust/bpf-tcl/src/lib.rs
@@ -106,13 +106,34 @@ fn cmd_check(args: &[String]) -> ExitCode {
                     .attach
                     .as_ref()
                     .map_or_else(String::new, |a| format!(", attach {} {}", a.kind, a.target));
+                // Show slot reuse when the liveness allocator saved any: N
+                // physical slots reused from M computed values.
+                let reuse = if d.program.raw_slot_count > d.program.num_slots {
+                    format!(" (reused from {})", d.program.raw_slot_count)
+                } else {
+                    String::new()
+                };
                 println!(
-                    "  when {} (priority {}, {} slots, {} blocks{attach})",
+                    "  when {} (priority {}, {} slots{reuse}, {} bytes stack, {} blocks{attach})",
                     d.event,
                     d.priority,
                     d.program.num_slots,
+                    d.program.num_slots * 8,
                     d.program.blocks.len()
                 );
+                if !d.program.maps.is_empty() {
+                    for m in &d.program.maps {
+                        println!(
+                            "    map {} ({} key={}B val={}B max={} {:?})",
+                            m.name,
+                            m.kind.as_str(),
+                            m.key_size,
+                            m.value_size,
+                            m.max_entries,
+                            m.concurrency
+                        );
+                    }
+                }
             }
             ExitCode::SUCCESS
         }

--- a/rust/bpf-tcl/src/lib.rs
+++ b/rust/bpf-tcl/src/lib.rs
@@ -65,7 +65,7 @@ fn usage() {
     eprintln!(
         "usage:\n  \
          bpf-tcl check   <file.bpftcl>\n  \
-         bpf-tcl compile <file.bpftcl> [--target rbpf|kernel-xdp] [--emit asm|hex|raw|elf] [--program N] [-o OUT]\n  \
+         bpf-tcl compile <file.bpftcl> [--target rbpf|kernel-xdp|kernel-socket] [--emit asm|hex|raw|elf] [--program N] [-o OUT]\n  \
          bpf-tcl run     <file.bpftcl> --packet <HEX> [--program N] [--repeat N]"
     );
 }
@@ -163,8 +163,11 @@ fn cmd_compile(args: &[String]) -> ExitCode {
                 target_abi = match value.as_str() {
                     "rbpf" => TargetAbi::RbpfFixedMbuff,
                     "kernel-xdp" => TargetAbi::KernelXdp,
+                    "kernel-socket" | "kernel-socket-filter" => TargetAbi::KernelSocketFilter,
                     other => {
-                        eprintln!("compile: unknown --target `{other}` (want rbpf|kernel-xdp)");
+                        eprintln!(
+                            "compile: unknown --target `{other}` (want rbpf|kernel-xdp|kernel-socket)"
+                        );
                         return ExitCode::FAILURE;
                     }
                 };

--- a/rust/bpf-tcl/src/lib.rs
+++ b/rust/bpf-tcl/src/lib.rs
@@ -31,7 +31,9 @@ use std::process::ExitCode;
 use bpf_tcl_codegen::ebpf::{
     EbpfObject, TargetAbi, disasm, emit_program, emit_program_for_target, write_object,
 };
-use bpf_tcl_ir::{BpfError, BpfProgramDecl, ProgType, compile_module};
+use bpf_tcl_ir::{
+    BpfError, BpfModule, BpfProgramDecl, DeploymentPlan, ProgType, compile_module, event_chains,
+};
 use tcl_lexer::SourceMap;
 
 /// CLI entry point.
@@ -45,6 +47,7 @@ pub fn run(args: impl Iterator<Item = String>) -> ExitCode {
         Some("check") => cmd_check(&rest),
         Some("compile") => cmd_compile(&rest),
         Some("run") => cmd_run(&rest),
+        Some("plan") => cmd_plan(&rest),
         Some("help" | "-h" | "--help") => {
             usage();
             ExitCode::SUCCESS
@@ -66,7 +69,8 @@ fn usage() {
         "usage:\n  \
          bpf-tcl check   <file.bpftcl>\n  \
          bpf-tcl compile <file.bpftcl> [--target rbpf|kernel-xdp|kernel-socket] [--emit asm|hex|raw|elf] [--program N] [-o OUT]\n  \
-         bpf-tcl run     <file.bpftcl> --packet <HEX> [--program N] [--repeat N]"
+         bpf-tcl run     <file.bpftcl> --packet <HEX> [--program N] [--repeat N]\n  \
+         bpf-tcl plan    <file.bpftcl> [--name NAME]   (loader dry-run: programs, pins, attach targets, kernel features)"
     );
 }
 
@@ -134,7 +138,19 @@ fn cmd_check(args: &[String]) -> ExitCode {
                         );
                     }
                 }
+                // The resolved event contract (registry-described schema).
+                if let Some(spec) = bpf_tcl_ir::event::event_spec(&d.event) {
+                    println!(
+                        "    event contract: ctx={} caps=[{}] default={} output={} kernel={}",
+                        spec.context.struct_name,
+                        spec.capability_names().join(","),
+                        spec.default_verdict.verb(),
+                        spec.output_label(),
+                        spec.kernel_summary(),
+                    );
+                }
             }
+            print_composition(&m);
             ExitCode::SUCCESS
         }
         Err(e) => {
@@ -142,6 +158,109 @@ fn cmd_check(args: &[String]) -> ExitCode {
             ExitCode::FAILURE
         }
     }
+}
+
+/// Print the resolved handler-composition chains: per event, the handlers in
+/// ascending-priority (run-first) order.
+fn print_composition(module: &BpfModule) {
+    let chains = event_chains(module);
+    let has_multi = chains.iter().any(|c| c.len() > 1);
+    if !has_multi {
+        return;
+    }
+    println!("composition:");
+    for chain in chains {
+        if chain.len() < 2 {
+            continue;
+        }
+        let order = chain
+            .priorities
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(" -> ");
+        println!(
+            "  {} chain ({} handlers, priority {order}; lower runs first, terminal verdict stops)",
+            chain.event,
+            chain.len()
+        );
+    }
+}
+
+fn cmd_plan(args: &[String]) -> ExitCode {
+    let mut path: Option<String> = None;
+    let mut name = "bpftcl".to_string();
+    let mut it = args.iter();
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--name" => {
+                let Some(value) = it.next() else {
+                    eprintln!("plan: --name expects a deployment name");
+                    return ExitCode::FAILURE;
+                };
+                name.clone_from(value);
+            }
+            other => {
+                if path.is_none() {
+                    path = Some(other.to_string());
+                } else {
+                    eprintln!("plan: unexpected argument `{other}`");
+                    return ExitCode::FAILURE;
+                }
+            }
+        }
+    }
+    let Some(path) = path else {
+        eprintln!("plan: missing <file.bpftcl>");
+        return ExitCode::FAILURE;
+    };
+    let src = match read_source(&path) {
+        Ok(s) => s,
+        Err(c) => return c,
+    };
+    let module = match compile_module(&src) {
+        Ok(m) => m,
+        Err(e) => {
+            print_error(&path, &src, &e);
+            return ExitCode::FAILURE;
+        }
+    };
+    let plan = DeploymentPlan::from_module(&name, &module);
+    println!(
+        "deployment `{}` (dry-run; no kernel state is touched)",
+        plan.name
+    );
+    println!("{} program(s):", plan.programs.len());
+    for (i, prog) in plan.programs.iter().enumerate() {
+        let attach = prog
+            .attach
+            .as_ref()
+            .map_or_else(|| "none".to_owned(), |a| format!("{} {}", a.kind, a.target));
+        let kernel = bpf_tcl_ir::event::event_spec(&prog.event)
+            .map_or_else(String::new, |s| format!(", kernel {}", s.kernel_summary()));
+        println!(
+            "  #{i} {} (priority {}, {:?}), attach {attach}{kernel}",
+            prog.event, prog.priority, prog.prog_type
+        );
+        println!("     pin: {}", prog.pin);
+        let maps = &module.programs[i].program.maps;
+        for map in maps {
+            println!(
+                "     map {} ({} key={}B val={}B max={})",
+                map.name,
+                map.kind.as_str(),
+                map.key_size,
+                map.value_size,
+                map.max_entries
+            );
+        }
+    }
+    println!(
+        "next: `load` (verifier-load, no attach) → `test-run` → `attach` (create links/pins) \
+         → `status` → `detach`. These require a privileged loader on a live kernel; the lifecycle \
+         state machine is modelled and tested in `bpf-tcl-ir::loader`."
+    );
+    ExitCode::SUCCESS
 }
 
 fn cmd_compile(args: &[String]) -> ExitCode {

--- a/rust/bpf-tcl/src/run.rs
+++ b/rust/bpf-tcl/src/run.rs
@@ -26,16 +26,52 @@
 //! test thread gets its own, so parallel tests don't interfere. A real kernel
 //! uses map fds; this is test/run scaffolding. Map keys and values are passed
 //! by value (v1 maps are integer→integer).
+//!
+//! The emulation honours the declared map schema: an **array** map is
+//! preallocated and zero-filled (every in-range key is present from the
+//! start, out-of-range keys are ignored), a **hash** map is sparse and
+//! enforces `max_entries` (an update introducing a new key when the map is
+//! full is dropped, matching `bpf_map_update_elem`'s `E2BIG`). `map_has`
+//! reports presence so a caller can tell a missing key from a stored zero.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
 
 use bpf_tcl_codegen::ebpf::EbpfObject;
+use bpf_tcl_ir::{MapDef, MapKind};
 use rbpf::EbpfVmFixedMbuff;
 
+/// One emulated map: its declared schema plus its live contents.
+struct EmuMap {
+    kind: MapKind,
+    max_entries: u32,
+    store: HashMap<u64, u64>,
+}
+
+impl EmuMap {
+    fn new(def: &MapDef) -> Self {
+        let mut store = HashMap::new();
+        // An array map is preallocated and zero-filled.
+        if def.kind == MapKind::Array {
+            for k in 0..u64::from(def.max_entries) {
+                store.insert(k, 0);
+            }
+        }
+        Self {
+            kind: def.kind,
+            max_entries: def.max_entries,
+            store,
+        }
+    }
+
+    fn key_in_range(&self, key: u64) -> bool {
+        self.kind != MapKind::Array || key < u64::from(self.max_entries)
+    }
+}
+
 thread_local! {
-    /// One emulated map (key → value) per declared map, indexed by map index.
-    static MAPS: RefCell<Vec<HashMap<u64, u64>>> = const { RefCell::new(Vec::new()) };
+    /// One emulated map per declared map, indexed by map index.
+    static MAPS: RefCell<Vec<EmuMap>> = const { RefCell::new(Vec::new()) };
 }
 
 /// Helper id 1: `bpf_map_lookup`-style. `r0 = MAPS[map][key]` or 0 if absent.
@@ -43,20 +79,43 @@ fn map_get_helper(map: u64, key: u64, _: u64, _: u64, _: u64) -> u64 {
     let Ok(idx) = usize::try_from(map) else {
         return 0;
     };
-    MAPS.with_borrow(|m| m.get(idx).and_then(|t| t.get(&key)).copied().unwrap_or(0))
+    MAPS.with_borrow(|m| {
+        m.get(idx)
+            .and_then(|t| t.store.get(&key))
+            .copied()
+            .unwrap_or(0)
+    })
 }
 
-/// Helper id 2: `bpf_map_update`-style. `MAPS[map][key] = val`.
+/// Helper id 2: `bpf_map_update`-style. `MAPS[map][key] = val`, subject to the
+/// map's capacity and (for arrays) key range.
 fn map_set_helper(map: u64, key: u64, val: u64, _: u64, _: u64) -> u64 {
     let Ok(idx) = usize::try_from(map) else {
         return 0;
     };
     MAPS.with_borrow_mut(|m| {
         if let Some(t) = m.get_mut(idx) {
-            t.insert(key, val);
+            if !t.key_in_range(key) {
+                return;
+            }
+            let new_key = !t.store.contains_key(&key);
+            // A hash map at capacity rejects a brand-new key (E2BIG).
+            if new_key && t.kind == MapKind::Hash && t.store.len() >= t.max_entries as usize {
+                return;
+            }
+            t.store.insert(key, val);
         }
     });
     0
+}
+
+/// Helper id 3: `bpf_map_lookup`-presence. `r0 = 1` when `key` is present,
+/// else `0` — the way to distinguish a missing key from a stored zero.
+fn map_has_helper(map: u64, key: u64, _: u64, _: u64, _: u64) -> u64 {
+    let Ok(idx) = usize::try_from(map) else {
+        return 0;
+    };
+    MAPS.with_borrow(|m| u64::from(m.get(idx).is_some_and(|t| t.store.contains_key(&key))))
 }
 
 /// Run an emitted socket-filter program once over `packet`, returning the
@@ -69,8 +128,8 @@ pub fn run_socket_filter(obj: &EbpfObject, packet: &mut [u8]) -> Result<u64, Str
 }
 
 /// Run an emitted program `times` times over `packet` (sharing one map store),
-/// returning the last verdict and the final state of every emulated map. Useful
-/// for asserting stateful map behaviour (e.g. a counter).
+/// returning the last verdict and the final contents of every emulated map.
+/// Useful for asserting stateful map behaviour (e.g. a counter).
 ///
 /// # Errors
 /// Returns rbpf's load/verify/run error rendered as a string.
@@ -89,7 +148,7 @@ fn run_with_maps(
 ) -> Result<(u64, Vec<HashMap<u64, u64>>), String> {
     MAPS.with_borrow_mut(|m| {
         m.clear();
-        m.resize(obj.maps.len(), HashMap::new());
+        m.extend(obj.maps.iter().map(EmuMap::new));
     });
 
     // Copy the program so the VM's lifetime stays local and unifies with the
@@ -104,9 +163,11 @@ fn run_with_maps(
             .map_err(|e| e.to_string())?;
         vm.register_helper(2, map_set_helper)
             .map_err(|e| e.to_string())?;
+        vm.register_helper(3, map_has_helper)
+            .map_err(|e| e.to_string())?;
         last = vm.execute_program(packet).map_err(|e| e.to_string())?;
     }
 
-    let maps = MAPS.with_borrow(Clone::clone);
+    let maps = MAPS.with_borrow(|m| m.iter().map(|t| t.store.clone()).collect());
     Ok((last, maps))
 }

--- a/rust/bpf-tcl/tests/composition.rs
+++ b/rust/bpf-tcl/tests/composition.rs
@@ -1,0 +1,148 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Handler composition, executed end to end (issue #1204).
+//!
+//! Two `when XDP` handlers compose deterministically: an early "deny" handler
+//! terminates on a blocked port, while an "audit" handler continues with `next`
+//! and lets a later handler decide. Each handler is compiled independently and
+//! run under the `rbpf` harness; the per-handler outcomes feed the pure
+//! composition model ([`bpf_tcl_ir::compose`]) — the verified-program-chain
+//! deployment semantics, run in userspace without a kernel.
+
+use bpf_tcl::run::run_socket_filter;
+use bpf_tcl_codegen::ebpf::emit_program;
+use bpf_tcl_ir::{ChainResult, Outcome, compile_module, compose, event_chains};
+
+/// XDP action numbers (as the codegen emits them).
+const XDP_DROP: i64 = 1;
+const XDP_PASS: i64 = 2;
+
+/// Build a 40-byte frame whose 16-bit big-endian field at offset 36 is `dport`.
+fn frame_with_dport(dport: u16) -> Vec<u8> {
+    let mut p = vec![0u8; 40];
+    p[36] = (dport >> 8) as u8;
+    p[37] = (dport & 0xff) as u8;
+    p
+}
+
+/// Run every handler of the (single-event) module over `packet` in chain order,
+/// classify each outcome, and compose them into a final decision.
+fn run_chain(src: &str, packet: &[u8]) -> ChainResult {
+    let module = compile_module(src).expect("compiles");
+    let chains = event_chains(&module);
+    assert_eq!(chains.len(), 1, "test fixtures use a single event");
+    let mut outcomes = Vec::new();
+    for &idx in &chains[0].handler_indices {
+        let obj = emit_program(&module.programs[idx].program).expect("emits");
+        let mut pkt = packet.to_vec();
+        let r0 = run_socket_filter(&obj, &mut pkt).expect("runs");
+        outcomes.push(Outcome::classify(r0));
+    }
+    compose(&outcomes)
+}
+
+/// The composed chain: handler 0 (priority 10) denies port 22 and otherwise
+/// continues; handler 1 (priority 20) passes everything.
+const DENY_THEN_AUDIT: &str = "\
+when XDP priority 10 {
+  setbuf p ctx
+  pktlen n p
+  if {$n < 38} { next }
+  load16 dport p 36 be
+  if {$dport == 22} { drop }
+  next
+}
+when XDP priority 20 {
+  setbuf p ctx
+  pass
+}
+";
+
+#[test]
+fn early_deny_handler_terminates_the_chain() {
+    // Port 22 is blocked: the priority-10 handler drops and the chain stops
+    // there — the audit handler never decides.
+    let result = run_chain(DENY_THEN_AUDIT, &frame_with_dport(22));
+    assert_eq!(
+        result,
+        ChainResult::Decided {
+            index: 0,
+            verdict: XDP_DROP
+        }
+    );
+}
+
+#[test]
+fn continuation_reaches_the_later_handler() {
+    // Port 80 is allowed: the priority-10 handler yields `next`, so the
+    // priority-20 audit handler decides (pass).
+    let result = run_chain(DENY_THEN_AUDIT, &frame_with_dport(80));
+    assert_eq!(
+        result,
+        ChainResult::Decided {
+            index: 1,
+            verdict: XDP_PASS
+        }
+    );
+}
+
+#[test]
+fn all_next_falls_through_to_the_event_default() {
+    // Both handlers continue: composition yields Default, and the event schema
+    // says XDP defaults to pass.
+    let src = "\
+when XDP priority 10 { next }
+when XDP priority 20 { next }
+";
+    let result = run_chain(src, &frame_with_dport(80));
+    assert_eq!(result, ChainResult::Default);
+
+    let default = bpf_tcl_ir::event::event_spec("XDP")
+        .unwrap()
+        .default_verdict;
+    assert_eq!(default.verb(), "pass");
+}
+
+#[test]
+fn composition_order_is_priority_not_source_order() {
+    // Declared audit-first in source, but priority puts deny first; a blocked
+    // port must still be denied by the lower-priority handler.
+    let src = "\
+when XDP priority 20 {
+  setbuf p ctx
+  pass
+}
+when XDP priority 10 {
+  setbuf p ctx
+  pktlen n p
+  if {$n < 38} { next }
+  load16 dport p 36 be
+  if {$dport == 22} { drop }
+  next
+}
+";
+    let result = run_chain(src, &frame_with_dport(22));
+    assert_eq!(
+        result,
+        ChainResult::Decided {
+            index: 0,
+            verdict: XDP_DROP
+        }
+    );
+}

--- a/rust/bpf-tcl/tests/hardening.rs
+++ b/rust/bpf-tcl/tests/hardening.rs
@@ -1,0 +1,252 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Issue #1202 hardening: strict framework grammar, proof-bearing packet
+//! reads, typed maps with capacity and missing-vs-zero, full-width constants,
+//! and the liveness-based slot allocator. TP/FP/TN/FN coverage: each malformed
+//! input is rejected (true positive), each well-formed counterpart still
+//! compiles and runs (true negative / false-positive guard).
+
+use std::fmt::Write as _;
+
+use bpf_tcl::run::{run_socket_filter, run_socket_filter_repeated};
+use bpf_tcl_codegen::ebpf::emit_program;
+use bpf_tcl_ir::{BpfDiag, MapKind, compile_module};
+
+fn run(src: &str, packet: &mut [u8]) -> u64 {
+    let module = compile_module(src).expect("compiles");
+    let obj = emit_program(&module.programs[0].program).expect("emits");
+    run_socket_filter(&obj, packet).expect("runs")
+}
+
+// ── strict `when` header grammar (RUST_ISSUE_063) ───────────────────────────
+
+#[test]
+fn when_non_integer_priority_is_rejected_not_silently_500() {
+    // TP: `priority nope` used to become priority 500 with no diagnostic.
+    let err = compile_module("when XDP priority nope { pass }\n").unwrap_err();
+    assert_eq!(err.code, BpfDiag::BadArity);
+    assert!(err.msg.contains("priority"), "{}", err.msg);
+}
+
+#[test]
+fn when_unknown_header_keyword_is_rejected() {
+    // TP: an extra header word is not silently ignored.
+    let err = compile_module("when XDP badword 3 { pass }\n").unwrap_err();
+    assert_eq!(err.code, BpfDiag::BadArity);
+}
+
+#[test]
+fn when_substituted_event_is_rejected() {
+    let err = compile_module("when $ev { pass }\n").unwrap_err();
+    assert_eq!(err.code, BpfDiag::BadEvent);
+}
+
+#[test]
+fn when_well_formed_priority_still_compiles() {
+    // TN: the supported form is untouched.
+    let module = compile_module("when XDP priority 10 { pass }\n").expect("compiles");
+    assert_eq!(module.programs[0].priority, 10);
+}
+
+// ── verdict-less handlers are an error, never a silent drop ─────────────────
+
+#[test]
+fn missing_verdict_on_a_path_is_rejected() {
+    // TP: the `if` true-branch drops, but the fall-through has no verdict.
+    let err = compile_module("when XDP { setint x 1\n if {$x == 1} { drop } }\n").unwrap_err();
+    assert_eq!(err.code, BpfDiag::MissingVerdict);
+}
+
+#[test]
+fn every_path_terminated_compiles() {
+    // TN: both branches carry a verdict.
+    compile_module("when XDP { setint x 1\n if {$x == 1} { drop } else { pass } }\n")
+        .expect("compiles");
+}
+
+// ── full-width constants (RUST_ISSUE_172) ───────────────────────────────────
+
+#[test]
+fn full_width_64bit_constant_materialises() {
+    // A constant beyond 32 bits used to be rejected; now it uses `lddw`.
+    let mut pkt = vec![0u8; 8];
+    let v = run(
+        "when SOCKET_FILTER { setint x {0x1122334455}\n accept {$x} }\n",
+        &mut pkt,
+    );
+    assert_eq!(v, 0x11_2233_4455);
+}
+
+// ── network-order packet reads ──────────────────────────────────────────────
+
+#[test]
+fn big_endian_load_reads_network_order() {
+    // `load16 … be` reads a network-order field: bytes 0x00 0x16 → 22.
+    let mut pkt = vec![0u8; 40];
+    pkt[36] = 0x00;
+    pkt[37] = 0x16;
+    let src = "when SOCKET_FILTER {\n\
+        setbuf pkt ctx\n\
+        pktlen len pkt\n\
+        if {$len < 38} { drop }\n\
+        load16 dport pkt 36 be\n\
+        if {$dport == 22} { drop }\n\
+        accept\n}\n";
+    assert_eq!(run(src, &mut pkt), 0); // dropped: dport == 22
+}
+
+#[test]
+fn short_packet_takes_the_out_of_bounds_verdict() {
+    // The checked load proves `off + width <= data_end`; a short packet takes
+    // the drop verdict instead of trapping.
+    let mut pkt = vec![0u8; 4]; // far too short for a load at offset 36
+    let src = "when SOCKET_FILTER {\n\
+        setbuf pkt ctx\n\
+        load16 dport pkt 36 be\n\
+        accept\n}\n";
+    assert_eq!(run(src, &mut pkt), 0); // drop (OOB)
+}
+
+#[test]
+fn unknown_byte_order_word_is_rejected() {
+    let err =
+        compile_module("when SOCKET_FILTER { setbuf p ctx\n load16 d p 0 middle\n accept }\n")
+            .unwrap_err();
+    assert_eq!(err.code, BpfDiag::OutOfSubset);
+}
+
+// ── typed maps: kinds, capacity, missing vs zero ────────────────────────────
+
+#[test]
+fn map_kinds_are_type_checked() {
+    // TP: an unknown kind is rejected.
+    let err = compile_module("when SOCKET_FILTER { map m tree 8 8 4\n accept }\n").unwrap_err();
+    assert_eq!(err.code, BpfDiag::BadMap);
+    // TN: hash and array both parse.
+    let m =
+        compile_module("when SOCKET_FILTER { map h hash 8 8 4\n map a array 4 8 4\n accept }\n")
+            .expect("compiles");
+    let maps = &m.programs[0].program.maps;
+    assert_eq!(maps[0].kind, MapKind::Hash);
+    assert_eq!(maps[1].kind, MapKind::Array);
+}
+
+#[test]
+fn array_map_requires_a_four_byte_key() {
+    let err = compile_module("when SOCKET_FILTER { map a array 8 8 4\n accept }\n").unwrap_err();
+    assert_eq!(err.code, BpfDiag::BadMap);
+}
+
+#[test]
+fn odd_value_size_is_rejected() {
+    let err = compile_module("when SOCKET_FILTER { map m hash 8 3 4\n accept }\n").unwrap_err();
+    assert_eq!(err.code, BpfDiag::BadMap);
+}
+
+#[test]
+fn map_has_distinguishes_missing_from_stored_zero() {
+    // Store a zero under key 7; `map_has` still reports it present, while a
+    // never-written key 9 reads absent.
+    let src = "when SOCKET_FILTER {\n\
+        map m hash 8 8 8\n\
+        map_set m {7} {0}\n\
+        map_has present m {7}\n\
+        map_has absent m {9}\n\
+        setint r {$present * 10 + $absent}\n\
+        accept {$r}\n}\n";
+    let mut pkt = vec![0u8; 8];
+    // present=1, absent=0  →  10
+    assert_eq!(run(src, &mut pkt), 10);
+}
+
+#[test]
+fn hash_map_capacity_is_enforced() {
+    // A hash map with room for one entry: the second distinct key's update is
+    // dropped, so only the first key persists.
+    let src = "when SOCKET_FILTER {\n\
+        map m hash 8 8 1\n\
+        map_set m {1} {100}\n\
+        map_set m {2} {200}\n\
+        accept\n}\n";
+    let module = compile_module(src).expect("compiles");
+    let obj = emit_program(&module.programs[0].program).expect("emits");
+    let mut pkt = vec![0u8; 8];
+    let (_, maps) = run_socket_filter_repeated(&obj, &mut pkt, 1).expect("runs");
+    assert_eq!(maps[0].get(&1).copied(), Some(100));
+    assert_eq!(maps[0].get(&2), None, "over-capacity key must be dropped");
+}
+
+#[test]
+fn array_map_is_zero_filled_and_present() {
+    // An array element is present (value 0) before any store.
+    let src = "when SOCKET_FILTER {\n\
+        map a array 4 8 4\n\
+        map_has p a {2}\n\
+        accept {$p}\n}\n";
+    let mut pkt = vec![0u8; 8];
+    assert_eq!(run(src, &mut pkt), 1);
+}
+
+// ── liveness-based slot allocation ──────────────────────────────────────────
+
+#[test]
+fn slot_reuse_shrinks_the_stack() {
+    // Many short-lived temporaries in sequence: with liveness-based reuse the
+    // allocated slot count is far below the number of values computed.
+    let mut body = String::from("when SOCKET_FILTER {\n");
+    for i in 0..40 {
+        let _ = writeln!(body, "setint t{i} {{ {i} + 1 }}");
+    }
+    body.push_str("accept\n}\n");
+    let module = compile_module(&body).expect("compiles");
+    let prog = &module.programs[0].program;
+    assert!(
+        prog.raw_slot_count > prog.num_slots,
+        "reuse should shrink slots: raw {} allocated {}",
+        prog.raw_slot_count,
+        prog.num_slots
+    );
+    assert!(
+        prog.num_slots <= 64,
+        "allocated slots must fit the stack: {}",
+        prog.num_slots
+    );
+}
+
+#[test]
+fn stack_pressure_is_reported_with_source_context() {
+    // A handler that keeps 200 values simultaneously live (each used in the
+    // final sum) cannot fit the 64-slot stack even after reuse.
+    let mut body = String::from("when SOCKET_FILTER {\n");
+    for i in 0..200 {
+        let _ = writeln!(body, "setint v{i} {i}");
+    }
+    body.push_str("setint acc 0\n");
+    for i in 0..200 {
+        let _ = writeln!(body, "setint acc {{ $acc + $v{i} }}");
+    }
+    body.push_str("accept {$acc}\n}\n");
+    let err = compile_module(&body).unwrap_err();
+    assert_eq!(err.code, BpfDiag::StackOverflow);
+    assert!(
+        err.msg.contains("reuse"),
+        "message mentions reuse: {}",
+        err.msg
+    );
+}

--- a/rust/bpf-tcl/tests/kernel_attach.rs
+++ b/rust/bpf-tcl/tests/kernel_attach.rs
@@ -1,0 +1,200 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Privileged loader / link-lifecycle acceptance tests (issue #1204).
+//! **These do not run by default.**
+//!
+//! Attaching a program to an interface or cgroup calls the `bpf()` syscall and
+//! configures live kernel networking state, which needs `CAP_BPF`/`CAP_NET_ADMIN`
+//! (root in practice) and a live Linux kernel — none of which exist in the
+//! sandbox the rest of the suite runs in. So these are marked `#[ignore]`; run
+//! them by hand on a Linux host:
+//!
+//! ```text
+//! sudo -E cargo test -p bpf-tcl --test kernel_attach -- --ignored --nocapture
+//! ```
+//!
+//! Every test is **hermetic and self-cleaning**: it builds a *disposable*
+//! network namespace (or an isolated test cgroup), does its work inside, and
+//! unconditionally tears the namespace/cgroup down at the end — so it cannot
+//! leak links, pins, maps, or interfaces onto the host, and never touches a
+//! real host interface. When the required tooling or privilege is missing, the
+//! test **skips** with a printed reason rather than failing.
+//!
+//! The lifecycle *logic* (plan → load → test-run → attach → status → detach,
+//! with rollback and ownership) is covered deterministically in userspace by the
+//! `bpf-tcl-ir::loader` unit tests over a `ModelKernel`; these privileged tests
+//! confirm the modelled contract against a real kernel.
+
+use std::process::Command;
+
+use bpf_tcl_codegen::ebpf::{TargetAbi, emit_program_for_target, write_object};
+use bpf_tcl_ir::{DeploymentPlan, compile_module, event_spec};
+
+fn tool_present(name: &str) -> bool {
+    Command::new(name)
+        .arg("-V")
+        .output()
+        .is_ok_and(|o| o.status.success() || !o.stdout.is_empty() || !o.stderr.is_empty())
+}
+
+fn is_root() -> bool {
+    Command::new("id")
+        .arg("-u")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .is_some_and(|s| s.trim() == "0")
+}
+
+/// A disposable network namespace that deletes itself (and everything inside it
+/// — veth pairs, XDP/TC attachments) on drop. Cleanup is unconditional so a
+/// panicking test still leaves the host clean.
+struct DisposableNetns {
+    name: String,
+}
+
+impl DisposableNetns {
+    fn new(name: &str) -> Option<Self> {
+        let ok = Command::new("ip")
+            .args(["netns", "add", name])
+            .status()
+            .is_ok_and(|s| s.success());
+        ok.then(|| DisposableNetns {
+            name: name.to_owned(),
+        })
+    }
+
+    /// Run `ip -n <ns> …`, returning success.
+    fn ip(&self, args: &[&str]) -> bool {
+        let mut full = vec!["-n", &self.name];
+        full.extend_from_slice(args);
+        Command::new("ip")
+            .args(&full)
+            .status()
+            .is_ok_and(|s| s.success())
+    }
+}
+
+impl Drop for DisposableNetns {
+    fn drop(&mut self) {
+        // Deleting the namespace tears down every veth and every attachment in
+        // it — the whole point of using a namespace for isolation.
+        let _ = Command::new("ip")
+            .args(["netns", "del", &self.name])
+            .status();
+    }
+}
+
+#[test]
+#[ignore = "needs root + iproute2 + a live kernel; run with --ignored on a Linux host"]
+fn xdp_attach_detach_in_a_disposable_namespace_leaks_nothing() {
+    if !is_root() {
+        eprintln!("skip: XDP attach needs root/CAP_NET_ADMIN");
+        return;
+    }
+    if !tool_present("ip") {
+        eprintln!("skip: iproute2 (`ip`) unavailable");
+        return;
+    }
+    let src = "when XDP { setbuf p ctx\n pass }\n";
+    let module = compile_module(src).expect("compiles");
+    let plan = DeploymentPlan::from_module("bpftcl-test", &module);
+    // Ownership-labelled pin path — detach must remove only this.
+    eprintln!("plan pin: {}", plan.programs[0].pin);
+
+    let Some(ns) = DisposableNetns::new("bpftcl-xdp-test") else {
+        eprintln!("skip: could not create a disposable netns");
+        return;
+    };
+    // A veth pair inside the namespace gives us an interface to attach to that
+    // is destroyed with the namespace.
+    assert!(ns.ip(&[
+        "link", "add", "veth0", "type", "veth", "peer", "name", "veth1"
+    ]));
+
+    // Write the kernel object and attach it to veth0 with `ip link … xdpgeneric`.
+    let obj = emit_program_for_target(&module.programs[0].program, TargetAbi::KernelXdp)
+        .expect("object emits");
+    let bytes = write_object(&obj, "xdp").expect("elf writes");
+    let mut obj_path = std::env::temp_dir();
+    obj_path.push(format!("bpftcl-xdp-{}.o", std::process::id()));
+    std::fs::write(&obj_path, bytes).expect("write object");
+
+    let attached = ns.ip(&[
+        "link",
+        "set",
+        "dev",
+        "veth0",
+        "xdpgeneric",
+        "obj",
+        obj_path.to_str().unwrap(),
+        "sec",
+        "xdp",
+    ]);
+    if !attached {
+        let _ = std::fs::remove_file(&obj_path);
+        eprintln!("skip: xdpgeneric attach unsupported on this host");
+        return;
+    }
+
+    // Detach explicitly (the namespace drop would also remove it, but the
+    // deployment owns the detach in production).
+    let detached = ns.ip(&["link", "set", "dev", "veth0", "xdpgeneric", "off"]);
+    assert!(detached, "detach should succeed");
+    let _ = std::fs::remove_file(&obj_path);
+    // `ns` drops here, deleting the namespace and proving nothing leaks.
+}
+
+#[test]
+#[ignore = "TC codegen is registry-described but not yet implemented (issue #1204)"]
+fn tc_ingress_scenario_is_described_and_pending() {
+    // The TC event is a typed registry contract today; its codegen (SCHED_CLS)
+    // is sequenced for a later change. This test documents the intended isolated
+    // scenario — a TC classifier marking/redirecting traffic in a disposable
+    // namespace with a veth pair — and asserts the schema contract that a real
+    // implementation must satisfy, so it fails loudly if the schema regresses.
+    let spec = event_spec("TC_INGRESS").expect("TC_INGRESS described");
+    assert_eq!(spec.context.struct_name, "__sk_buff");
+    assert!(!spec.is_codegen_ready(), "TC codegen still pending");
+    assert!(
+        compile_module("when TC_INGRESS { pass }\n").is_err(),
+        "TC does not compile yet"
+    );
+    eprintln!(
+        "skip: TC ingress codegen pending; when implemented, attach a SCHED_CLS \
+         program to a veth in a disposable netns and assert cleanup"
+    );
+}
+
+#[test]
+#[ignore = "cgroup codegen is registry-described but not yet implemented (issue #1204)"]
+fn cgroup_connect_scenario_is_described_and_pending() {
+    // The cgroup connect/bind events are typed registry contracts; codegen
+    // (CGROUP_SOCK_ADDR) is pending. A real implementation attaches to an
+    // isolated test cgroup under /sys/fs/cgroup and denies a chosen connect
+    // target, then removes the attachment and the cgroup.
+    let spec = event_spec("CGROUP_CONNECT4").expect("CGROUP_CONNECT4 described");
+    assert_eq!(spec.context.struct_name, "bpf_sock_addr");
+    assert!(spec.context_field("user_port").is_some());
+    assert!(!spec.is_codegen_ready(), "cgroup codegen still pending");
+    eprintln!(
+        "skip: cgroup connect codegen pending; when implemented, attach to an \
+         isolated test cgroup, deny one connect target, then detach + rmdir the cgroup"
+    );
+}

--- a/rust/bpf-tcl/tests/kernel_codegen.rs
+++ b/rust/bpf-tcl/tests/kernel_codegen.rs
@@ -1,0 +1,338 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Kernel-target codegen: the verifier *model* over emitted XDP / socket-filter
+//! objects, structural cross-checks of the map/BTF/relocation ELF against the
+//! system toolchain (`readelf`, `llvm-objdump`), and network-byte-order packet
+//! fixtures executed under the userspace simulator.
+//!
+//! These tests are rootless: the structural ones skip gracefully when a tool is
+//! unavailable, and the verifier-model / byte-order ones need no kernel at all.
+//! Genuine kernel `bpf()` load and `BPF_PROG_TEST_RUN` acceptance lives in
+//! `tests/kernel_load.rs`, gated behind `#[ignore]`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use bpf_tcl::run::run_socket_filter;
+use bpf_tcl_codegen::ebpf::{
+    EbpfObject, TargetAbi, emit_program, emit_program_for_target, verify, write_object,
+};
+use bpf_tcl_ir::compile_module;
+
+fn kernel_obj(src: &str, target: TargetAbi) -> EbpfObject {
+    let m = compile_module(src).expect("compiles");
+    emit_program_for_target(&m.programs[0].program, target).expect("emits for the kernel")
+}
+
+fn rbpf_obj(src: &str) -> EbpfObject {
+    let m = compile_module(src).expect("compiles");
+    emit_program(&m.programs[0].program).expect("emits")
+}
+
+fn has_tool(name: &str) -> bool {
+    Command::new(name)
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+fn write_tmp(tag: &str, bytes: &[u8]) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!("bpftcl-k-{tag}-{}.o", std::process::id()));
+    std::fs::write(&p, bytes).expect("write temp object");
+    p
+}
+
+// The map-counting XDP source used across several structural tests: a per-CPU
+// packet counter plus a bounds-checked TCP destination-port drop.
+const XDP_MAP_FILTER: &str = "when XDP {\n\
+    map hits array 4 8 4\n\
+    setbuf p ctx\n\
+    setint k 0\n\
+    map_get n hits {$k}\n\
+    setint n1 {$n + 1}\n\
+    map_set hits {$k} {$n1}\n\
+    load16 dport p 36 be\n\
+    if {$dport == 22} { drop }\n\
+    pass\n}\n";
+
+#[test]
+fn verifier_model_accepts_xdp_map_filter() {
+    let obj = kernel_obj(XDP_MAP_FILTER, TargetAbi::KernelXdp);
+    assert_eq!(verify(&obj), Vec::new(), "the model must accept the object");
+    // Two map-fd loads (one for the get, one for the set), each relocated.
+    assert_eq!(obj.relocations.len(), 2);
+}
+
+#[test]
+fn verifier_model_accepts_socket_filter_length_verdict() {
+    // A socket filter that accepts a byte count read from the packet.
+    let obj = kernel_obj(
+        "when SOCKET_FILTER {\n\
+         setbuf p ctx\n\
+         pktlen len p\n\
+         if {$len < 20} { drop }\n\
+         accept {$len}\n}\n",
+        TargetAbi::KernelSocketFilter,
+    );
+    assert_eq!(verify(&obj), Vec::new());
+}
+
+#[test]
+fn readelf_accepts_kernel_map_object() {
+    if !has_tool("readelf") {
+        eprintln!("skip: readelf unavailable");
+        return;
+    }
+    let obj = kernel_obj(XDP_MAP_FILTER, TargetAbi::KernelXdp);
+    let elf = write_object(&obj, "xdp").expect("elf");
+    let path = write_tmp("readelf-maps", &elf);
+
+    let hdr = Command::new("readelf")
+        .arg("-h")
+        .arg(&path)
+        .output()
+        .unwrap();
+    let header = String::from_utf8_lossy(&hdr.stdout);
+    assert!(
+        header.contains("BPF") && header.contains("REL"),
+        "EM_BPF REL:\n{header}"
+    );
+
+    let secs = Command::new("readelf")
+        .arg("-S")
+        .arg(&path)
+        .output()
+        .unwrap();
+    let sections = String::from_utf8_lossy(&secs.stdout);
+    for needle in [".maps", ".BTF", ".relxdp", "xdp", ".symtab"] {
+        assert!(
+            sections.contains(needle),
+            "section {needle} present:\n{sections}"
+        );
+    }
+
+    let rel = Command::new("readelf")
+        .arg("-r")
+        .arg(&path)
+        .output()
+        .unwrap();
+    let relocs = String::from_utf8_lossy(&rel.stdout);
+    assert!(
+        relocs.contains("R_BPF_64_64"),
+        "map relocations present:\n{relocs}"
+    );
+    assert!(
+        relocs.contains("hits"),
+        "relocation names the map:\n{relocs}"
+    );
+
+    let syms = Command::new("readelf")
+        .arg("-s")
+        .arg(&path)
+        .output()
+        .unwrap();
+    let symbols = String::from_utf8_lossy(&syms.stdout);
+    assert!(
+        symbols.contains("OBJECT") && symbols.contains("hits"),
+        "map symbol:\n{symbols}"
+    );
+    assert!(
+        symbols.contains("FUNC") && symbols.contains("xdp"),
+        "program symbol:\n{symbols}"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn llvm_objdump_disassembles_kernel_map_object() {
+    if !has_tool("llvm-objdump") {
+        eprintln!("skip: llvm-objdump unavailable");
+        return;
+    }
+    let obj = kernel_obj(XDP_MAP_FILTER, TargetAbi::KernelXdp);
+    let insn_count = obj.insns.len();
+    let elf = write_object(&obj, "xdp").expect("elf");
+    let path = write_tmp("objdump-maps", &elf);
+
+    let out = Command::new("llvm-objdump")
+        .arg("-dr")
+        .arg(&path)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "llvm-objdump should succeed");
+    let dump = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        dump.contains("elf64-bpf"),
+        "recognised as elf64-bpf:\n{dump}"
+    );
+    // Every emitted instruction disassembles (a wide load counts once but spans
+    // two 8-byte slots, so count listed instruction indices).
+    let count = dump
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim_start();
+            trimmed.split_once(':').is_some_and(|(idx, _)| {
+                !idx.is_empty() && idx.bytes().all(|byte| byte.is_ascii_hexdigit())
+            })
+        })
+        .count();
+    assert_eq!(
+        count, insn_count,
+        "disassembled {count} of {insn_count} instructions"
+    );
+    assert!(dump.contains("call"), "a helper call is present:\n{dump}");
+    assert!(
+        dump.contains("hits"),
+        "reloc against the map is shown:\n{dump}"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn socket_filter_kernel_object_names_socket_section() {
+    if !has_tool("readelf") {
+        eprintln!("skip: readelf unavailable");
+        return;
+    }
+    let obj = kernel_obj(
+        "when SOCKET_FILTER {\n map seen hash 4 4 64\n setint k 0\n\
+         map_set seen {$k} {1}\n accept }\n",
+        TargetAbi::KernelSocketFilter,
+    );
+    let elf = write_object(&obj, "flt").expect("elf");
+    let path = write_tmp("sock-sec", &elf);
+    let secs = Command::new("readelf")
+        .arg("-S")
+        .arg(&path)
+        .output()
+        .unwrap();
+    let sections = String::from_utf8_lossy(&secs.stdout);
+    assert!(
+        sections.contains("socket"),
+        "socket program section:\n{sections}"
+    );
+    assert!(
+        sections.contains(".relsocket"),
+        "socket relocation section:\n{sections}"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+// Network-byte-order fixtures. The emitted kernel object cannot run in this
+// container, but the shared BPF-IR byte-order lowering (BPF_END) is identical on
+// the rbpf and kernel paths, so exercising it under the simulator proves the
+// `be` / `le` field interpretation the kernel object inherits.
+
+/// A realistic Ethernet + IPv4 + TCP frame with a chosen TCP destination port.
+fn eth_ip_tcp_frame(dst_port: u16) -> Vec<u8> {
+    let mut pkt = vec![0u8; 54];
+    // Ethernet: EtherType 0x0800 (IPv4) in network order at offset 12.
+    pkt[12] = 0x08;
+    pkt[13] = 0x00;
+    // IPv4 total length (network order) at offset 16: 40 bytes.
+    pkt[16] = 0x00;
+    pkt[17] = 0x28;
+    // TCP destination port (network order) at offset 36.
+    pkt[34 + 2] = (dst_port >> 8) as u8;
+    pkt[34 + 3] = (dst_port & 0xff) as u8;
+    pkt
+}
+
+#[test]
+fn network_order_16bit_ethertype_matches_fixture() {
+    // `load16 … be` reads the big-endian EtherType and yields host-order 0x0800.
+    let obj = rbpf_obj(
+        "when SOCKET_FILTER {\n\
+         setbuf p ctx\n\
+         load16 et p 12 be\n\
+         if {$et == 2048} { accept 1 }\n\
+         drop\n}\n",
+    );
+    let mut frame = eth_ip_tcp_frame(80);
+    assert_eq!(
+        run_socket_filter(&obj, &mut frame).unwrap(),
+        1,
+        "0x0800 == 2048"
+    );
+}
+
+#[test]
+fn network_order_16bit_tcp_port_drop() {
+    let obj = rbpf_obj(
+        "when SOCKET_FILTER {\n\
+         setbuf p ctx\n\
+         load16 dport p 36 be\n\
+         if {$dport == 22} { drop }\n\
+         accept 1\n}\n",
+    );
+    let mut ssh = eth_ip_tcp_frame(22);
+    assert_eq!(
+        run_socket_filter(&obj, &mut ssh).unwrap(),
+        0,
+        "port 22 drops"
+    );
+    let mut http = eth_ip_tcp_frame(80);
+    assert_eq!(
+        run_socket_filter(&obj, &mut http).unwrap(),
+        1,
+        "port 80 accepts"
+    );
+}
+
+#[test]
+fn network_order_32bit_field_roundtrips() {
+    // Store a 32-bit network-order value and read it back big-endian.
+    let obj = rbpf_obj(
+        "when SOCKET_FILTER {\n\
+         setbuf p ctx\n\
+         load32 word p 12 be\n\
+         accept {$word}\n}\n",
+    );
+    let mut pkt = vec![0u8; 20];
+    // Big-endian 0x0800_0000 at offset 12 → host value 0x08000000 = 134217728.
+    pkt[12] = 0x08;
+    pkt[13] = 0x00;
+    pkt[14] = 0x00;
+    pkt[15] = 0x00;
+    let verdict = run_socket_filter(&obj, &mut pkt).unwrap();
+    assert_eq!(verdict & 0xffff_ffff, 0x0800_0000, "big-endian 32-bit read");
+}
+
+#[test]
+fn little_endian_16bit_differs_from_big_endian() {
+    // The same two bytes read `le` vs `be` give byte-swapped host values.
+    let be = rbpf_obj("when SOCKET_FILTER { setbuf p ctx\n load16 v p 0 be\n accept {$v} }\n");
+    let le = rbpf_obj("when SOCKET_FILTER { setbuf p ctx\n load16 v p 0 le\n accept {$v} }\n");
+    let mut pkt = vec![0x12u8, 0x34, 0, 0];
+    assert_eq!(run_socket_filter(&be, &mut pkt).unwrap() & 0xffff, 0x1234);
+    let mut pkt2 = vec![0x12u8, 0x34, 0, 0];
+    assert_eq!(run_socket_filter(&le, &mut pkt2).unwrap() & 0xffff, 0x3412);
+}
+
+#[test]
+fn rbpf_map_object_still_runs() {
+    // The userspace simulator target is untouched by the kernel work.
+    let obj = rbpf_obj(
+        "when SOCKET_FILTER {\n map m hash 8 8 8\n map_set m {7} {99}\n\
+         map_get v m {7}\n accept {$v} }\n",
+    );
+    let mut pkt = vec![0u8; 8];
+    assert_eq!(run_socket_filter(&obj, &mut pkt).unwrap(), 99);
+}

--- a/rust/bpf-tcl/tests/kernel_load.rs
+++ b/rust/bpf-tcl/tests/kernel_load.rs
@@ -1,0 +1,163 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Privileged kernel-verifier acceptance tests. **These do not run by default.**
+//!
+//! Loading a real BPF program calls the `bpf()` syscall, which needs
+//! `CAP_BPF`/root and a live Linux kernel — neither is available in the sandbox
+//! the rest of the suite runs in, so these are marked `#[ignore]`. Run them by
+//! hand on a Linux host with `bpftool` installed:
+//!
+//! ```text
+//! sudo -E cargo test -p bpf-tcl --test kernel_load -- --ignored --nocapture
+//! ```
+//!
+//! Each test:
+//!   * emits a kernel object with the real ABI (`--target kernel-xdp` /
+//!     `kernel-socket`), writes it under `/tmp`;
+//!   * asks `bpftool prog loadall` to submit it to the verifier, capturing the
+//!     full verifier log on failure; and
+//!   * unconditionally removes every pin and temporary file it created — it
+//!     never attaches to a live interface.
+//!
+//! When `bpftool` is missing or the caller is unprivileged, the test **skips**
+//! with a printed reason rather than failing, so `--ignored` on an unsuitable
+//! host is harmless. A verifier *rejection* is a real failure.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use bpf_tcl_codegen::ebpf::{TargetAbi, emit_program_for_target, write_object};
+use bpf_tcl_ir::compile_module;
+
+fn tool_present(name: &str) -> bool {
+    Command::new(name)
+        .arg("version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+fn is_root() -> bool {
+    // Rootless is the common case in CI; a non-privileged loadall fails cleanly.
+    Command::new("id")
+        .arg("-u")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .is_some_and(|s| s.trim() == "0")
+}
+
+fn write_object_file(src: &str, target: TargetAbi, sym: &str, tag: &str) -> PathBuf {
+    let module = compile_module(src).expect("source compiles");
+    let obj = emit_program_for_target(&module.programs[0].program, target).expect("object emits");
+    let bytes = write_object(&obj, sym).expect("elf writes");
+    let mut p = std::env::temp_dir();
+    p.push(format!("bpftcl-load-{tag}-{}.o", std::process::id()));
+    std::fs::write(&p, bytes).expect("write object");
+    p
+}
+
+/// Ask the verifier to accept `obj_path`, pinning under `pin_dir`; returns the
+/// verifier log. Cleans up the pin directory and object afterwards.
+fn verifier_accepts(obj_path: &Path, pin_dir: &Path) -> Result<String, String> {
+    let out = Command::new("bpftool")
+        .args(["-d", "prog", "loadall"])
+        .arg(obj_path)
+        .arg(pin_dir)
+        .output()
+        .map_err(|e| format!("bpftool failed to spawn: {e}"))?;
+    let log = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // Best-effort cleanup: remove every pin and the object.
+    let _ = std::fs::remove_dir_all(pin_dir);
+    let _ = std::fs::remove_file(obj_path);
+    if out.status.success() {
+        Ok(log)
+    } else {
+        Err(log)
+    }
+}
+
+fn run_load_case(src: &str, target: TargetAbi, sym: &str, tag: &str) {
+    if !tool_present("bpftool") {
+        eprintln!("skip: bpftool unavailable (install linux-tools to run this test)");
+        return;
+    }
+    if !is_root() {
+        eprintln!("skip: kernel load needs root/CAP_BPF");
+        return;
+    }
+    let obj = write_object_file(src, target, sym, tag);
+    let mut pin = std::env::temp_dir();
+    pin.push(format!("bpftcl-pin-{tag}-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&pin);
+    match verifier_accepts(&obj, &pin) {
+        Ok(log) => eprintln!("verifier accepted {tag}:\n{log}"),
+        Err(log) => panic!("verifier rejected {tag}:\n{log}"),
+    }
+}
+
+#[test]
+#[ignore = "needs root + bpftool + a live kernel; run with --ignored on a Linux host"]
+fn kernel_xdp_pass_loads() {
+    run_load_case(
+        "when XDP { pass }\n",
+        TargetAbi::KernelXdp,
+        "xdp",
+        "xdp-pass",
+    );
+}
+
+#[test]
+#[ignore = "needs root + bpftool + a live kernel; run with --ignored on a Linux host"]
+fn kernel_xdp_bounded_packet_read_loads() {
+    run_load_case(
+        "when XDP {\n setbuf p ctx\n load16 dport p 36 be\n\
+         if {$dport == 22} { drop }\n pass }\n",
+        TargetAbi::KernelXdp,
+        "xdp",
+        "xdp-portfilter",
+    );
+}
+
+#[test]
+#[ignore = "needs root + bpftool + a live kernel; run with --ignored on a Linux host"]
+fn kernel_xdp_map_counter_loads() {
+    run_load_case(
+        "when XDP {\n map hits array 4 8 4\n setint k 0\n\
+         map_get n hits {$k}\n setint n1 {$n + 1}\n map_set hits {$k} {$n1}\n pass }\n",
+        TargetAbi::KernelXdp,
+        "xdp",
+        "xdp-mapcounter",
+    );
+}
+
+#[test]
+#[ignore = "needs root + bpftool + a live kernel; run with --ignored on a Linux host"]
+fn kernel_socket_filter_length_loads() {
+    run_load_case(
+        "when SOCKET_FILTER {\n setbuf p ctx\n pktlen len p\n\
+         if {$len < 20} { drop }\n accept {$len} }\n",
+        TargetAbi::KernelSocketFilter,
+        "flt",
+        "sock-len",
+    );
+}

--- a/rust/bpf-tcl/tests/loader_lifecycle.rs
+++ b/rust/bpf-tcl/tests/loader_lifecycle.rs
@@ -1,0 +1,69 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The loader lifecycle driven from a real compiled module (issue #1204), over
+//! the deterministic `ModelKernel`. Real `bpf()`-syscall attachment is exercised
+//! only by the `#[ignore]`d `kernel_attach` tests; this proves the
+//! plan → load → test-run → attach → status → detach state machine and its
+//! ownership/cleanup guarantees end to end without a kernel.
+
+use bpf_tcl_ir::{Deployment, DeploymentPlan, ModelKernel, State, compile_module};
+
+const CHAIN: &str = "when XDP priority 10 { setbuf p ctx\n pass }\nwhen XDP priority 20 { pass }\n";
+
+#[test]
+fn full_lifecycle_from_a_compiled_module_leaves_no_residue() {
+    let module = compile_module(CHAIN).expect("compiles");
+    let plan = DeploymentPlan::from_module("lifecycle", &module);
+    let mut d = Deployment::new(plan, ModelKernel::new());
+
+    // plan -> load
+    assert_eq!(d.state(), State::Planned);
+    d.load().expect("verifier-load");
+    assert_eq!(d.state(), State::Loaded);
+
+    // test-run each program before any live attach (non-destructive default).
+    for i in 0..2 {
+        d.test_run(i, &[0u8; 64]).expect("test-run");
+    }
+
+    // attach -> status
+    d.attach().expect("attach");
+    assert_eq!(d.state(), State::Attached);
+    let status = d.status();
+    assert_eq!(status.attached, 2);
+    assert!(status.pins.iter().all(|p| p.contains("/bpftcl/lifecycle/")));
+    assert_eq!(d.kernel().pin_count(), 2);
+
+    // detach removes only our resources.
+    d.detach().expect("detach");
+    assert_eq!(d.state(), State::Detached);
+    assert_eq!(d.kernel().pin_count(), 0);
+    assert_eq!(d.kernel().live_program_count(), 0);
+}
+
+#[test]
+fn two_deployments_use_disjoint_ownership_labelled_pins() {
+    let module = compile_module("when XDP { pass }\n").expect("compiles");
+    let a = DeploymentPlan::from_module("alpha", &module);
+    let b = DeploymentPlan::from_module("beta", &module);
+    assert_ne!(a.programs[0].pin, b.programs[0].pin);
+    assert!(a.owns_pin(&a.programs[0].pin));
+    assert!(!a.owns_pin(&b.programs[0].pin));
+    assert!(!b.owns_pin(&a.programs[0].pin));
+}

--- a/rust/bpf-tcl/tests/observability.rs
+++ b/rust/bpf-tcl/tests/observability.rs
@@ -1,0 +1,81 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The userspace event channel end to end (issue #1204): a producer encodes
+//! typed records against a schema-generated ABI, a bounded ring buffer transports
+//! them with loss accounting under back-pressure, and a structured consumer
+//! renders each record as JSON — the shape a tracepoint/observability family will
+//! use once its codegen lands.
+
+use bpf_tcl_ir::event_spec;
+use bpf_tcl_ir::ringbuf::{RECORD_ABI_VERSION, RecordSchema, RingBuffer};
+
+fn connect4_schema() -> RecordSchema {
+    let spec = event_spec("CGROUP_CONNECT4").expect("event exists");
+    let idx = tcl_registry_index("CGROUP_CONNECT4");
+    RecordSchema::for_event(idx, spec)
+}
+
+/// Resolve an event's index in the registry table (the record header's
+/// `event_type`) without depending on the registry crate directly.
+fn tcl_registry_index(name: &str) -> u16 {
+    // The schema helper on `RecordSchema` needs the index; derive it from the
+    // known event ordering exposed through bpf-tcl-ir's known-event names.
+    let idx = bpf_tcl_ir::known_event_names()
+        .iter()
+        .position(|n| *n == name)
+        .expect("event listed");
+    u16::try_from(idx).expect("event index fits u16")
+}
+
+#[test]
+fn producer_to_json_consumer_stream_with_versioned_abi() {
+    let schema = connect4_schema();
+    // A bounded channel with room for two records.
+    let mut rb = RingBuffer::new(schema.record_len() * 2);
+
+    // Producer: three connect events (127.0.0.1:22, :80, :443).
+    let events = [
+        (0x0100_007f_u64, 22_u64, 2_u64),
+        (0x0100_007f, 80, 2),
+        (0x0100_007f, 443, 2),
+    ];
+    for (seq, (ip, port, fam)) in events.iter().enumerate() {
+        let rec = schema.encode(u32::try_from(seq).unwrap(), &[*ip, *port, *fam]);
+        rb.push(&rec);
+    }
+    // The third does not fit — it is dropped and counted, never truncated.
+    assert_eq!(rb.dropped(), 1);
+
+    // Consumer: drain and render each whole record as JSON.
+    let lines: Vec<String> = rb
+        .drain()
+        .iter()
+        .map(|bytes| {
+            let rec = schema.decode(bytes).expect("valid record");
+            assert_eq!(rec.header.abi_version, RECORD_ABI_VERSION);
+            schema.to_json(&rec)
+        })
+        .collect();
+
+    assert_eq!(lines.len(), 2);
+    assert!(lines[0].contains("\"event\":\"CGROUP_CONNECT4\""));
+    assert!(lines[0].contains("\"user_port\":22"));
+    assert!(lines[1].contains("\"user_port\":80"));
+    assert_eq!(rb.delivered(), 2);
+}

--- a/rust/bpf-tcl/tests/profiles.rs
+++ b/rust/bpf-tcl/tests/profiles.rs
@@ -53,8 +53,9 @@ const SSH_FILTER: &str = "profile ipv4_tcp\n\
 fn ipv4_tcp_drops_ssh() {
     let mut pkt = frame();
     pkt[23] = 6; // IPPROTO_TCP
-    pkt[36] = 0x16; // dport 22, native-endian
-    pkt[37] = 0x00;
+    // dport 22 in network order (big-endian), as a real TCP header carries it.
+    pkt[36] = 0x00;
+    pkt[37] = 0x16;
     assert_eq!(run(SSH_FILTER, &mut pkt), 1); // XDP_DROP
 }
 
@@ -62,8 +63,9 @@ fn ipv4_tcp_drops_ssh() {
 fn ipv4_tcp_passes_http() {
     let mut pkt = frame();
     pkt[23] = 6; // IPPROTO_TCP
-    pkt[36] = 0x50; // dport 80
-    pkt[37] = 0x00;
+    // dport 80 in network order.
+    pkt[36] = 0x00;
+    pkt[37] = 0x50;
     assert_eq!(run(SSH_FILTER, &mut pkt), 2); // XDP_PASS
 }
 
@@ -74,9 +76,20 @@ fn ipv4_tcp_passes_non_tcp() {
     assert_eq!(run(SSH_FILTER, &mut pkt), 2); // XDP_PASS
 }
 
-/// A user-defined profile declaring its own field (`field NAME OFFSET WIDTH`).
+/// A user-defined profile declaring its own field. A bare `field` defaults to
+/// network order (big-endian), matching real headers.
 const USER_PROFILE: &str = "profile myproto {\n\
         field http_alt 36 16\n\
+    }\n\
+    when XDP {\n\
+        http_alt port\n\
+        if {$port == 8080} { drop }\n\
+        pass\n\
+    }\n";
+
+/// A user field that opts into little-endian order with an explicit word.
+const USER_PROFILE_LE: &str = "profile myproto {\n\
+        field http_alt 36 16 le\n\
     }\n\
     when XDP {\n\
         http_alt port\n\
@@ -87,17 +100,36 @@ const USER_PROFILE: &str = "profile myproto {\n\
 #[test]
 fn user_profile_field_drops() {
     let mut pkt = frame();
-    pkt[36] = 0x90; // 8080 = 0x1f90, native-endian
-    pkt[37] = 0x1f;
+    // 8080 = 0x1f90 in network order.
+    pkt[36] = 0x1f;
+    pkt[37] = 0x90;
     assert_eq!(run(USER_PROFILE, &mut pkt), 1); // XDP_DROP
 }
 
 #[test]
 fn user_profile_field_passes() {
     let mut pkt = frame();
-    pkt[36] = 0x50; // 80
-    pkt[37] = 0x00;
+    pkt[36] = 0x00; // 80 in network order
+    pkt[37] = 0x50;
     assert_eq!(run(USER_PROFILE, &mut pkt), 2); // XDP_PASS
+}
+
+#[test]
+fn user_profile_little_endian_field() {
+    // The same value, little-endian bytes, matched by an `le` field.
+    let mut pkt = frame();
+    pkt[36] = 0x90; // 8080 = 0x1f90, little-endian
+    pkt[37] = 0x1f;
+    assert_eq!(run(USER_PROFILE_LE, &mut pkt), 1); // XDP_DROP
+}
+
+#[test]
+fn profile_body_rejects_non_field_statement() {
+    // A user profile body is a pure declaration list — a stray command is
+    // rejected, not silently dropped (RUST_ISSUE_063).
+    let src = "profile p { field a 0 16\n setint x 5 }\nwhen XDP { pass }\n";
+    let err = compile_module(src).unwrap_err();
+    assert_eq!(err.code, BpfDiag::BadProfile);
 }
 
 #[test]

--- a/rust/tcl-registry/src/bpf_op.rs
+++ b/rust/tcl-registry/src/bpf_op.rs
@@ -95,6 +95,12 @@ pub enum BpfScalarWidth {
 }
 
 /// A verdict family member.
+///
+/// Every variant except [`BpfVerdictKind::Next`] is **terminal**: it ends the
+/// handler and, under handler composition (issue #1204), stops the chain. `Next`
+/// is the sole **non-terminal** outcome — an explicit "continue to the next
+/// handler" that the composition model recognises (see
+/// [`BpfVerdictKind::is_terminal`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BpfVerdictKind {
     /// Socket filter `accept ?N?` — accept N bytes (defaults to whole packet).
@@ -105,6 +111,33 @@ pub enum BpfVerdictKind {
     Pass,
     /// XDP `tx` — `XDP_TX`.
     Tx,
+    /// `next` — the explicit, non-terminal continuation outcome. The handler
+    /// returns without a decision so the next handler in priority order runs;
+    /// if every handler yields `next`, the event's declared default verdict
+    /// applies. Valid in every program type.
+    Next,
+}
+
+impl BpfVerdictKind {
+    /// Whether returning this verdict ends handler-chain evaluation. Every
+    /// verdict is terminal except [`BpfVerdictKind::Next`] (an explicit
+    /// continuation).
+    #[must_use]
+    pub const fn is_terminal(self) -> bool {
+        !matches!(self, Self::Next)
+    }
+
+    /// The DSL verb that produces this verdict.
+    #[must_use]
+    pub const fn verb(self) -> &'static str {
+        match self {
+            Self::Accept => "accept",
+            Self::Drop => "drop",
+            Self::Pass => "pass",
+            Self::Tx => "tx",
+            Self::Next => "next",
+        }
+    }
 }
 
 /// A framework declaration kind — a statement consumed by the front-end
@@ -227,17 +260,158 @@ impl BpfOpSpec {
 }
 
 /// The eBPF program type an event maps to. The registry keeps its own small
-/// enum so descriptor data stays dependency-free; `bpf-tcl-ir` maps it onto
-/// its IR `ProgType`.
+/// enum so descriptor data stays dependency-free; `bpf-tcl-ir` maps the
+/// codegen-ready variants onto its IR `ProgType`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BpfEventProgType {
     /// `BPF_PROG_TYPE_SOCKET_FILTER`.
     SocketFilter,
     /// `BPF_PROG_TYPE_XDP`.
     Xdp,
+    /// `BPF_PROG_TYPE_SCHED_CLS` on the ingress hook (`__sk_buff`).
+    TcIngress,
+    /// `BPF_PROG_TYPE_SCHED_CLS` on the egress hook (`__sk_buff`).
+    TcEgress,
+    /// `BPF_PROG_TYPE_CGROUP_SOCK_ADDR`, `connect4` attach (`bpf_sock_addr`).
+    CgroupInet4Connect,
+    /// `BPF_PROG_TYPE_CGROUP_SOCK_ADDR`, `bind4` attach (`bpf_sock_addr`).
+    CgroupInet4Bind,
 }
 
-/// A registry-described BPF event: the contract behind `when <EVENT> …`.
+/// How far the compiler backend supports an event today. Every event is fully
+/// *described* by its schema; only [`BpfCodegen::Ready`] events currently lower
+/// to a compiled program (issue #1203's XDP and socket-filter targets). The
+/// rest are declared contracts whose codegen is sequenced for a later change —
+/// the front-end resolves the schema and reports a precise "described, codegen
+/// pending" diagnostic rather than an "unknown event".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BpfCodegen {
+    /// The event lowers to a compiled program on at least one target.
+    Ready,
+    /// The event is schema-described; its codegen is not yet implemented.
+    Described,
+}
+
+/// The kernel context object a handler of an event receives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BpfContext {
+    /// The C context struct name (`xdp_md`, `__sk_buff`, `bpf_sock_addr`).
+    pub struct_name: &'static str,
+    /// The typed, fixed-offset fields a handler may read from the context.
+    pub fields: &'static [BpfCtxField],
+}
+
+/// The byte order a context or packet field is read in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BpfFieldOrder {
+    /// Host byte order (a scalar the kernel already presents natively).
+    Host,
+    /// Network byte order (big-endian on the wire; needs a byte swap on LE).
+    Network,
+}
+
+/// One readable, fixed-layout field of an event's context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BpfCtxField {
+    /// Field name as a handler would refer to it.
+    pub name: &'static str,
+    /// Byte offset within the context struct.
+    pub offset: u16,
+    /// Field width in bits (8, 16, 32, or 64).
+    pub width_bits: u16,
+    /// Byte order the field is interpreted in.
+    pub order: BpfFieldOrder,
+    /// One-line description.
+    pub description: &'static str,
+}
+
+/// The helper/access capabilities a handler of an event is permitted to use.
+/// A registry-described allowlist: a handler that needs a capability its event
+/// does not grant is a schema violation, checkable without naming a command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BpfEventCaps(u16);
+
+impl BpfEventCaps {
+    /// No capabilities beyond returning a verdict.
+    pub const NONE: Self = Self(0);
+    /// May read packet bytes / length.
+    pub const PKT_READ: Self = Self(1);
+    /// May read map values.
+    pub const MAP_READ: Self = Self(1 << 1);
+    /// May write map values.
+    pub const MAP_WRITE: Self = Self(1 << 2);
+    /// May emit records to a userspace ring buffer.
+    pub const RINGBUF_OUTPUT: Self = Self(1 << 3);
+    /// May read the event's typed context fields.
+    pub const CTX_READ: Self = Self(1 << 4);
+
+    /// The union of two capability sets.
+    #[must_use]
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    /// Whether every bit of `other` is present.
+    #[must_use]
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
+
+/// The kind of value an `attach` parameter carries. Drives validation of an
+/// event's attachment parameter schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BpfAttachParamKind {
+    /// A network interface name (`eth0`, `lo`) — resolved to an ifindex.
+    Interface,
+    /// A cgroup v2 directory path (`/sys/fs/cgroup/…`).
+    CgroupPath,
+    /// A traffic-control direction word (`ingress`/`egress`), fixed by the event.
+    Direction,
+}
+
+/// One parameter an event's `attach` declaration accepts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BpfAttachParam {
+    /// Parameter name (documentation/diagnostics).
+    pub name: &'static str,
+    /// The kind of value it carries.
+    pub kind: BpfAttachParamKind,
+    /// Whether the parameter is mandatory.
+    pub required: bool,
+    /// One-line description.
+    pub description: &'static str,
+}
+
+/// What an event's program produces: a packet decision (a verdict), userspace
+/// records (ring-buffer entries), or both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BpfEventOutput {
+    /// Returns a packet verdict only.
+    PacketDecision,
+    /// Emits typed userspace records only (observability events).
+    UserspaceRecord,
+    /// Both a packet decision and userspace records.
+    Both,
+}
+
+/// The minimum kernel / BTF requirements to load and attach an event's program.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BpfKernelReq {
+    /// Minimum kernel major version.
+    pub min_major: u8,
+    /// Minimum kernel minor version.
+    pub min_minor: u8,
+    /// Whether the event needs kernel BTF to attach (CO-RE / typed links).
+    pub requires_btf: bool,
+    /// Whether a first-class `bpf_link` attach is available (vs. a
+    /// type-specific fallback such as netlink `tc` or `setsockopt`).
+    pub bpf_link: bool,
+}
+
+/// A registry-described BPF event: the full typed contract behind
+/// `when <EVENT> …`. This is the single source of event truth — the compiler,
+/// loader, and documentation read it and never branch on an event name.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BpfEventSpec {
     /// Canonical event name (as documented).
@@ -248,20 +422,214 @@ pub struct BpfEventSpec {
     pub prog_type: BpfEventProgType,
     /// The libbpf `SEC(...)` section convention for emitted ELF objects.
     pub elf_section: &'static str,
-    /// Verdicts a handler of this event may return.
+    /// The typed context a handler receives.
+    pub context: BpfContext,
+    /// Helper/access capabilities a handler is permitted to use.
+    pub capabilities: BpfEventCaps,
+    /// Terminal verdicts a handler of this event may return (the verdict
+    /// algebra). `next` (the non-terminal continuation) is always permitted
+    /// and is *not* listed here.
     pub verdicts: &'static [BpfVerdictKind],
+    /// The verdict applied when no handler in the chain terminates.
+    pub default_verdict: BpfVerdictKind,
+    /// The `attach` parameter schema.
+    pub attach_params: &'static [BpfAttachParam],
+    /// Minimum kernel / BTF requirements.
+    pub kernel: BpfKernelReq,
+    /// Whether the program emits packet decisions, userspace records, or both.
+    pub output: BpfEventOutput,
+    /// How far compiler codegen supports this event today.
+    pub codegen: BpfCodegen,
     /// One-line description for help/diagnostics.
     pub description: &'static str,
 }
 
-/// Every BPF event the framework recognises, in documentation order.
+impl BpfEventSpec {
+    /// Whether this event currently lowers to a compiled program.
+    #[must_use]
+    pub const fn is_codegen_ready(self) -> bool {
+        matches!(self.codegen, BpfCodegen::Ready)
+    }
+
+    /// Whether `verb` names a verdict this event permits (terminal verdicts
+    /// from the schema, plus the always-available non-terminal `next`).
+    #[must_use]
+    pub fn permits_verdict(&self, verb: &str) -> bool {
+        if verb == BpfVerdictKind::Next.verb() {
+            return true;
+        }
+        self.verdicts.iter().any(|v| v.verb() == verb)
+    }
+
+    /// Resolve a named context field.
+    #[must_use]
+    pub fn context_field(&self, name: &str) -> Option<&'static BpfCtxField> {
+        self.context.fields.iter().find(|f| f.name == name)
+    }
+
+    /// The permitted-capability names, for `check`/help output.
+    #[must_use]
+    pub fn capability_names(&self) -> Vec<&'static str> {
+        let mut out = Vec::new();
+        for (bit, name) in [
+            (BpfEventCaps::PKT_READ, "pkt-read"),
+            (BpfEventCaps::MAP_READ, "map-read"),
+            (BpfEventCaps::MAP_WRITE, "map-write"),
+            (BpfEventCaps::RINGBUF_OUTPUT, "ringbuf"),
+            (BpfEventCaps::CTX_READ, "ctx-read"),
+        ] {
+            if self.capabilities.contains(bit) {
+                out.push(name);
+            }
+        }
+        out
+    }
+
+    /// A stable label for the event's output kind.
+    #[must_use]
+    pub fn output_label(&self) -> &'static str {
+        match self.output {
+            BpfEventOutput::PacketDecision => "packet-decision",
+            BpfEventOutput::UserspaceRecord => "userspace-record",
+            BpfEventOutput::Both => "packet-decision+userspace-record",
+        }
+    }
+
+    /// A one-line kernel-requirement summary (`>=5.6, BTF, bpf_link`).
+    #[must_use]
+    pub fn kernel_summary(&self) -> String {
+        let mut s = format!(">={}.{}", self.kernel.min_major, self.kernel.min_minor);
+        if self.kernel.requires_btf {
+            s.push_str(", BTF");
+        }
+        s.push_str(if self.kernel.bpf_link {
+            ", bpf_link"
+        } else {
+            ", type-specific attach"
+        });
+        s
+    }
+}
+
+/// The Ethernet/IPv4/TCP `__sk_buff` metadata fields a socket-filter / TC
+/// handler can read directly (a small, safe subset — the packet body is read
+/// with `load8/16/32`).
+const SK_BUFF_FIELDS: &[BpfCtxField] = &[
+    BpfCtxField {
+        name: "len",
+        offset: 0,
+        width_bits: 32,
+        order: BpfFieldOrder::Host,
+        description: "total packet length in bytes",
+    },
+    BpfCtxField {
+        name: "protocol",
+        offset: 16,
+        width_bits: 32,
+        order: BpfFieldOrder::Network,
+        description: "L3 protocol (network byte order)",
+    },
+    BpfCtxField {
+        name: "ifindex",
+        offset: 24,
+        width_bits: 32,
+        order: BpfFieldOrder::Host,
+        description: "interface index the packet arrived on / leaves by",
+    },
+    BpfCtxField {
+        name: "mark",
+        offset: 20,
+        width_bits: 32,
+        order: BpfFieldOrder::Host,
+        description: "skb mark (readable/settable fwmark)",
+    },
+];
+
+/// The `xdp_md` metadata fields.
+const XDP_MD_FIELDS: &[BpfCtxField] = &[
+    BpfCtxField {
+        name: "ingress_ifindex",
+        offset: 12,
+        width_bits: 32,
+        order: BpfFieldOrder::Host,
+        description: "interface index the frame arrived on",
+    },
+    BpfCtxField {
+        name: "rx_queue_index",
+        offset: 16,
+        width_bits: 32,
+        order: BpfFieldOrder::Host,
+        description: "RX queue index",
+    },
+];
+
+/// The `bpf_sock_addr` fields a cgroup connect/bind hook inspects.
+const SOCK_ADDR_FIELDS: &[BpfCtxField] = &[
+    BpfCtxField {
+        name: "user_ip4",
+        offset: 4,
+        width_bits: 32,
+        order: BpfFieldOrder::Network,
+        description: "destination/bind IPv4 address (network byte order)",
+    },
+    BpfCtxField {
+        name: "user_port",
+        offset: 24,
+        width_bits: 32,
+        order: BpfFieldOrder::Network,
+        description: "destination/bind port (network byte order, low 16 bits)",
+    },
+    BpfCtxField {
+        name: "family",
+        offset: 0,
+        width_bits: 32,
+        order: BpfFieldOrder::Host,
+        description: "address family (AF_INET)",
+    },
+];
+
+const IFACE_PARAM: &[BpfAttachParam] = &[BpfAttachParam {
+    name: "interface",
+    kind: BpfAttachParamKind::Interface,
+    required: true,
+    description: "network interface to attach to",
+}];
+
+const CGROUP_PARAM: &[BpfAttachParam] = &[BpfAttachParam {
+    name: "cgroup",
+    kind: BpfAttachParamKind::CgroupPath,
+    required: true,
+    description: "cgroup v2 directory the policy applies to",
+}];
+
+/// Every BPF event the framework recognises, in documentation order. The first
+/// two are codegen-ready (issue #1203); TC and cgroup are schema-described with
+/// codegen sequenced for a later change (issue #1204's event framework).
 pub const BPF_EVENTS: &[BpfEventSpec] = &[
     BpfEventSpec {
         name: "SOCKET_FILTER",
         aliases: &["SOCKET"],
         prog_type: BpfEventProgType::SocketFilter,
         elf_section: "socket",
+        context: BpfContext {
+            struct_name: "__sk_buff",
+            fields: SK_BUFF_FIELDS,
+        },
+        capabilities: BpfEventCaps::PKT_READ
+            .union(BpfEventCaps::MAP_READ)
+            .union(BpfEventCaps::MAP_WRITE)
+            .union(BpfEventCaps::CTX_READ),
         verdicts: &[BpfVerdictKind::Accept, BpfVerdictKind::Drop],
+        default_verdict: BpfVerdictKind::Accept,
+        attach_params: IFACE_PARAM,
+        kernel: BpfKernelReq {
+            min_major: 3,
+            min_minor: 19,
+            requires_btf: false,
+            bpf_link: false,
+        },
+        output: BpfEventOutput::PacketDecision,
+        codegen: BpfCodegen::Ready,
         description: "socket filter: verdict is the number of bytes to accept (0 drops)",
     },
     BpfEventSpec {
@@ -269,12 +637,135 @@ pub const BPF_EVENTS: &[BpfEventSpec] = &[
         aliases: &[],
         prog_type: BpfEventProgType::Xdp,
         elf_section: "xdp",
+        context: BpfContext {
+            struct_name: "xdp_md",
+            fields: XDP_MD_FIELDS,
+        },
+        capabilities: BpfEventCaps::PKT_READ
+            .union(BpfEventCaps::MAP_READ)
+            .union(BpfEventCaps::MAP_WRITE)
+            .union(BpfEventCaps::CTX_READ),
         verdicts: &[
             BpfVerdictKind::Pass,
             BpfVerdictKind::Drop,
             BpfVerdictKind::Tx,
         ],
+        default_verdict: BpfVerdictKind::Pass,
+        attach_params: IFACE_PARAM,
+        kernel: BpfKernelReq {
+            min_major: 4,
+            min_minor: 8,
+            requires_btf: false,
+            bpf_link: true,
+        },
+        output: BpfEventOutput::PacketDecision,
+        codegen: BpfCodegen::Ready,
         description: "XDP ingress: verdict is an XDP action (PASS/DROP/TX)",
+    },
+    BpfEventSpec {
+        name: "TC_INGRESS",
+        aliases: &["TC"],
+        prog_type: BpfEventProgType::TcIngress,
+        elf_section: "tc",
+        context: BpfContext {
+            struct_name: "__sk_buff",
+            fields: SK_BUFF_FIELDS,
+        },
+        capabilities: BpfEventCaps::PKT_READ
+            .union(BpfEventCaps::MAP_READ)
+            .union(BpfEventCaps::MAP_WRITE)
+            .union(BpfEventCaps::CTX_READ),
+        // TC classifier verdicts reuse pass/drop naming (TC_ACT_OK / TC_ACT_SHOT).
+        verdicts: &[BpfVerdictKind::Pass, BpfVerdictKind::Drop],
+        default_verdict: BpfVerdictKind::Pass,
+        attach_params: IFACE_PARAM,
+        kernel: BpfKernelReq {
+            min_major: 6,
+            min_minor: 6,
+            requires_btf: true,
+            bpf_link: true,
+        },
+        output: BpfEventOutput::PacketDecision,
+        codegen: BpfCodegen::Described,
+        description: "TC ingress classifier: verdict is a TC action (OK/SHOT)",
+    },
+    BpfEventSpec {
+        name: "TC_EGRESS",
+        aliases: &[],
+        prog_type: BpfEventProgType::TcEgress,
+        elf_section: "tc",
+        context: BpfContext {
+            struct_name: "__sk_buff",
+            fields: SK_BUFF_FIELDS,
+        },
+        capabilities: BpfEventCaps::PKT_READ
+            .union(BpfEventCaps::MAP_READ)
+            .union(BpfEventCaps::MAP_WRITE)
+            .union(BpfEventCaps::CTX_READ),
+        verdicts: &[BpfVerdictKind::Pass, BpfVerdictKind::Drop],
+        default_verdict: BpfVerdictKind::Pass,
+        attach_params: IFACE_PARAM,
+        kernel: BpfKernelReq {
+            min_major: 6,
+            min_minor: 6,
+            requires_btf: true,
+            bpf_link: true,
+        },
+        output: BpfEventOutput::PacketDecision,
+        codegen: BpfCodegen::Described,
+        description: "TC egress classifier: verdict is a TC action (OK/SHOT)",
+    },
+    BpfEventSpec {
+        name: "CGROUP_CONNECT4",
+        aliases: &[],
+        prog_type: BpfEventProgType::CgroupInet4Connect,
+        elf_section: "cgroup/connect4",
+        context: BpfContext {
+            struct_name: "bpf_sock_addr",
+            fields: SOCK_ADDR_FIELDS,
+        },
+        capabilities: BpfEventCaps::MAP_READ
+            .union(BpfEventCaps::MAP_WRITE)
+            .union(BpfEventCaps::CTX_READ),
+        // A cgroup sock_addr hook returns 1 (allow) or 0 (deny); modelled with
+        // pass = allow, drop = deny.
+        verdicts: &[BpfVerdictKind::Pass, BpfVerdictKind::Drop],
+        default_verdict: BpfVerdictKind::Pass,
+        attach_params: CGROUP_PARAM,
+        kernel: BpfKernelReq {
+            min_major: 4,
+            min_minor: 17,
+            requires_btf: true,
+            bpf_link: true,
+        },
+        output: BpfEventOutput::PacketDecision,
+        codegen: BpfCodegen::Described,
+        description: "cgroup IPv4 connect policy: verdict allows (pass) or denies (drop) the connect",
+    },
+    BpfEventSpec {
+        name: "CGROUP_BIND4",
+        aliases: &[],
+        prog_type: BpfEventProgType::CgroupInet4Bind,
+        elf_section: "cgroup/bind4",
+        context: BpfContext {
+            struct_name: "bpf_sock_addr",
+            fields: SOCK_ADDR_FIELDS,
+        },
+        capabilities: BpfEventCaps::MAP_READ
+            .union(BpfEventCaps::MAP_WRITE)
+            .union(BpfEventCaps::CTX_READ),
+        verdicts: &[BpfVerdictKind::Pass, BpfVerdictKind::Drop],
+        default_verdict: BpfVerdictKind::Pass,
+        attach_params: CGROUP_PARAM,
+        kernel: BpfKernelReq {
+            min_major: 4,
+            min_minor: 17,
+            requires_btf: true,
+            bpf_link: true,
+        },
+        output: BpfEventOutput::PacketDecision,
+        codegen: BpfCodegen::Described,
+        description: "cgroup IPv4 bind policy: verdict allows (pass) or denies (drop) the bind",
     },
 ];
 
@@ -294,6 +785,16 @@ pub fn lookup_bpf_event(name: &str) -> Option<&'static BpfEventSpec> {
 #[must_use]
 pub fn bpf_event_names() -> Vec<&'static str> {
     BPF_EVENTS.iter().map(|e| e.name).collect()
+}
+
+/// The canonical names of events that currently lower to a compiled program.
+#[must_use]
+pub fn codegen_ready_event_names() -> Vec<&'static str> {
+    BPF_EVENTS
+        .iter()
+        .filter(|e| e.is_codegen_ready())
+        .map(|e| e.name)
+        .collect()
 }
 
 #[cfg(test)]
@@ -340,6 +841,72 @@ mod tests {
             );
             assert!(!e.elf_section.is_empty());
             assert!(!e.description.is_empty());
+        }
+    }
+
+    #[test]
+    fn tc_and_cgroup_events_are_schema_described() {
+        // Issue #1204: TC ingress/egress and cgroup connect/bind exist as typed
+        // registry contracts, resolvable by name/alias.
+        for name in ["TC_INGRESS", "TC_EGRESS", "CGROUP_CONNECT4", "CGROUP_BIND4"] {
+            let e = lookup_bpf_event(name).unwrap_or_else(|| panic!("{name} missing"));
+            assert_eq!(
+                e.codegen,
+                BpfCodegen::Described,
+                "{name} should be described"
+            );
+            assert!(!e.context.fields.is_empty(), "{name} has no context fields");
+            assert!(!e.attach_params.is_empty(), "{name} has no attach params");
+        }
+        assert_eq!(lookup_bpf_event("tc").map(|e| e.name), Some("TC_INGRESS"));
+    }
+
+    #[test]
+    fn every_event_has_a_consistent_verdict_algebra() {
+        for e in BPF_EVENTS {
+            // The default verdict must be one the event actually permits, and
+            // must be terminal (a chain cannot default to "continue").
+            assert!(
+                e.verdicts.contains(&e.default_verdict),
+                "{}: default verdict not in its verdict set",
+                e.name
+            );
+            assert!(
+                e.default_verdict.is_terminal(),
+                "{}: default verdict must be terminal",
+                e.name
+            );
+            // `next` is always permitted and never listed as a terminal verdict.
+            assert!(e.permits_verdict("next"), "{} must permit next", e.name);
+            assert!(
+                !e.verdicts.contains(&BpfVerdictKind::Next),
+                "{}: next must not be listed as terminal",
+                e.name
+            );
+            // Context reads imply the CTX_READ capability.
+            assert!(
+                e.capabilities.contains(BpfEventCaps::CTX_READ),
+                "{}: context fields need CTX_READ",
+                e.name
+            );
+        }
+    }
+
+    #[test]
+    fn codegen_ready_events_are_exactly_xdp_and_socket_filter() {
+        assert_eq!(codegen_ready_event_names(), vec!["SOCKET_FILTER", "XDP"]);
+    }
+
+    #[test]
+    fn next_is_the_only_non_terminal_verdict() {
+        assert!(!BpfVerdictKind::Next.is_terminal());
+        for v in [
+            BpfVerdictKind::Accept,
+            BpfVerdictKind::Drop,
+            BpfVerdictKind::Pass,
+            BpfVerdictKind::Tx,
+        ] {
+            assert!(v.is_terminal(), "{v:?} should be terminal");
         }
     }
 }

--- a/rust/tcl-registry/src/bpf_op.rs
+++ b/rust/tcl-registry/src/bpf_op.rs
@@ -1,0 +1,345 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Typed BPF-Tcl lowering descriptors and event schemas.
+//!
+//! Every BPF-Tcl command spec carries a [`BpfOpSpec`] describing *what the
+//! command is* to the BPF-Tcl compiler: which typed core operation it lowers
+//! to, what effects it has (packet read, map read/write, termination), and
+//! which program types its verdicts are compatible with.  The BPF-Tcl
+//! front-end (`bpf-tcl-ir`) dispatches on this descriptor — never on the
+//! command name — so the registry, lowering, capability policy, and generated
+//! documentation cannot drift (issue #1202).
+//!
+//! The same module carries the [`BpfEventSpec`] table: the BPF-native event
+//! space `when <EVENT> …` resolves against (issue #1204's registry-described
+//! events).  Each event pairs a name and aliases with its program type, ELF
+//! section convention, verdict set, and default verdict.
+
+/// Effect classification for a BPF-Tcl operation.  Consumed by the
+/// capability (`allow`/`deny`) policy: an operation with any effect bit set
+/// is *gated*; a terminating operation is a *verdict*.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BpfEffects(u8);
+
+impl BpfEffects {
+    /// No effects — a structural operation (`setint`, `setbuf`, `map` decl).
+    pub const NONE: Self = Self(0);
+    /// Reads packet bytes or packet length.
+    pub const PKT_READ: Self = Self(1);
+    /// Reads a map value.
+    pub const MAP_READ: Self = Self(1 << 1);
+    /// Writes a map value.
+    pub const MAP_WRITE: Self = Self(1 << 2);
+    /// Terminates the program with a verdict.
+    pub const TERMINATES: Self = Self(1 << 3);
+
+    /// The union of two effect sets.
+    #[must_use]
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    /// Whether every bit of `other` is present in `self`.
+    #[must_use]
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+
+    /// Whether any bit of `other` is present in `self`.
+    #[must_use]
+    pub const fn intersects(self, other: Self) -> bool {
+        self.0 & other.0 != 0
+    }
+
+    /// Whether this operation touches the packet or a map — the set the
+    /// `allow` capability list restricts.
+    #[must_use]
+    pub const fn is_gated(self) -> bool {
+        self.intersects(Self(
+            Self::PKT_READ.0 | Self::MAP_READ.0 | Self::MAP_WRITE.0,
+        ))
+    }
+
+    /// Whether this operation is a verdict (terminates the program).
+    #[must_use]
+    pub const fn is_verdict(self) -> bool {
+        self.contains(Self::TERMINATES)
+    }
+}
+
+/// The scalar width a `set*` verb commits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BpfScalarWidth {
+    /// Full 64-bit value (`setint`).
+    I64,
+    /// Sign-extended low 32 bits (`seti32`).
+    I32SignExtended,
+    /// Zero-extended low 32 bits (`setu32`).
+    U32ZeroExtended,
+}
+
+/// A verdict family member.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BpfVerdictKind {
+    /// Socket filter `accept ?N?` — accept N bytes (defaults to whole packet).
+    Accept,
+    /// `drop` — 0 for a socket filter, `XDP_DROP` for XDP.
+    Drop,
+    /// XDP `pass` — `XDP_PASS`.
+    Pass,
+    /// XDP `tx` — `XDP_TX`.
+    Tx,
+}
+
+/// A framework declaration kind — a statement consumed by the front-end
+/// *before* core lowering (it never reaches BPF-IR).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BpfDeclKind {
+    /// `when EVENT ?priority N? { body }` — an event handler.
+    When,
+    /// `profile NAME ?{ field … }?` — the packet-layout profile.
+    Profile,
+    /// `field NAME OFFSET WIDTHBITS ?ORDER?` — a profile field (only valid
+    /// inside a `profile` body).
+    Field,
+    /// `template NAME {params} {body}` — a parameterised macro.
+    Template,
+    /// `use NAME k=v …` — a template expansion site.
+    Use,
+    /// `allow CMD …` — capability allowlist.
+    Allow,
+    /// `deny CMD …` — capability denylist.
+    Deny,
+    /// `attach KIND TARGET` — deployment metadata.
+    Attach,
+}
+
+/// Which program types an operation is valid in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BpfProgTypeSet {
+    /// Valid in every program type.
+    All,
+    /// Socket filters only (`accept`).
+    SocketFilterOnly,
+    /// XDP only (`pass`, `tx`).
+    XdpOnly,
+}
+
+/// What a BPF-Tcl command *is* — the typed core operation or framework
+/// declaration it stands for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BpfOpKind {
+    /// `setint`/`seti32`/`setu32 NAME {EXPR}` — evaluate and commit a scalar.
+    ScalarSet(BpfScalarWidth),
+    /// `setbuf NAME ctx` — bind the packet buffer.
+    BindPacket,
+    /// `loadN DST SRC OFFSET ?be|le|native?` — fixed-offset packet load.
+    PacketLoad {
+        /// Load width in bits (8, 16, or 32).
+        width_bits: u8,
+    },
+    /// `pktlen DST SRC` — the packet length.
+    PacketLen,
+    /// `map NAME hash|array KEYSZ VALSZ MAX ?shared|percpu?` — declaration.
+    MapDeclare,
+    /// `map_get DST NAME {KEY}` — value for key (0 when absent).
+    MapGet,
+    /// `map_set NAME {KEY} {VAL}` — store a value.
+    MapSet,
+    /// `map_has DST NAME {KEY}` — 1 when the key is present, else 0
+    /// (distinguishes a missing key from a stored zero).
+    MapHas,
+    /// A terminating verdict.
+    Verdict(BpfVerdictKind),
+    /// `loop N VAR { body }` — bounded loop, unrolled before CFG construction.
+    LoopMacro,
+    /// A framework declaration consumed before core lowering.
+    Framework(BpfDeclKind),
+}
+
+/// The registry-owned lowering contract for one BPF-Tcl command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BpfOpSpec {
+    /// The operation this command lowers to.
+    pub kind: BpfOpKind,
+    /// Effect classification (drives the capability policy).
+    pub effects: BpfEffects,
+    /// Program types the operation is valid in.
+    pub prog_types: BpfProgTypeSet,
+}
+
+impl BpfOpSpec {
+    /// A structural core operation: no effects, valid everywhere.
+    #[must_use]
+    pub const fn structural(kind: BpfOpKind) -> Self {
+        Self {
+            kind,
+            effects: BpfEffects::NONE,
+            prog_types: BpfProgTypeSet::All,
+        }
+    }
+
+    /// A gated core operation with the given effects, valid everywhere.
+    #[must_use]
+    pub const fn gated(kind: BpfOpKind, effects: BpfEffects) -> Self {
+        Self {
+            kind,
+            effects,
+            prog_types: BpfProgTypeSet::All,
+        }
+    }
+
+    /// A verdict for the given program-type set.
+    #[must_use]
+    pub const fn verdict(kind: BpfVerdictKind, prog_types: BpfProgTypeSet) -> Self {
+        Self {
+            kind: BpfOpKind::Verdict(kind),
+            effects: BpfEffects::TERMINATES,
+            prog_types,
+        }
+    }
+
+    /// A framework declaration.
+    #[must_use]
+    pub const fn framework(decl: BpfDeclKind) -> Self {
+        Self {
+            kind: BpfOpKind::Framework(decl),
+            effects: BpfEffects::NONE,
+            prog_types: BpfProgTypeSet::All,
+        }
+    }
+}
+
+/// The eBPF program type an event maps to. The registry keeps its own small
+/// enum so descriptor data stays dependency-free; `bpf-tcl-ir` maps it onto
+/// its IR `ProgType`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BpfEventProgType {
+    /// `BPF_PROG_TYPE_SOCKET_FILTER`.
+    SocketFilter,
+    /// `BPF_PROG_TYPE_XDP`.
+    Xdp,
+}
+
+/// A registry-described BPF event: the contract behind `when <EVENT> …`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BpfEventSpec {
+    /// Canonical event name (as documented).
+    pub name: &'static str,
+    /// Accepted aliases (case-insensitive, like the canonical name).
+    pub aliases: &'static [&'static str],
+    /// The program type handlers of this event compile to.
+    pub prog_type: BpfEventProgType,
+    /// The libbpf `SEC(...)` section convention for emitted ELF objects.
+    pub elf_section: &'static str,
+    /// Verdicts a handler of this event may return.
+    pub verdicts: &'static [BpfVerdictKind],
+    /// One-line description for help/diagnostics.
+    pub description: &'static str,
+}
+
+/// Every BPF event the framework recognises, in documentation order.
+pub const BPF_EVENTS: &[BpfEventSpec] = &[
+    BpfEventSpec {
+        name: "SOCKET_FILTER",
+        aliases: &["SOCKET"],
+        prog_type: BpfEventProgType::SocketFilter,
+        elf_section: "socket",
+        verdicts: &[BpfVerdictKind::Accept, BpfVerdictKind::Drop],
+        description: "socket filter: verdict is the number of bytes to accept (0 drops)",
+    },
+    BpfEventSpec {
+        name: "XDP",
+        aliases: &[],
+        prog_type: BpfEventProgType::Xdp,
+        elf_section: "xdp",
+        verdicts: &[
+            BpfVerdictKind::Pass,
+            BpfVerdictKind::Drop,
+            BpfVerdictKind::Tx,
+        ],
+        description: "XDP ingress: verdict is an XDP action (PASS/DROP/TX)",
+    },
+];
+
+/// Resolve an event name or alias (case-insensitive) to its spec.
+#[must_use]
+pub fn lookup_bpf_event(name: &str) -> Option<&'static BpfEventSpec> {
+    let upper = name.to_ascii_uppercase();
+    BPF_EVENTS.iter().find(|e| {
+        e.name == upper
+            || e.aliases
+                .iter()
+                .any(|a| a.eq_ignore_ascii_case(upper.as_str()))
+    })
+}
+
+/// The canonical event names, for diagnostics and help text.
+#[must_use]
+pub fn bpf_event_names() -> Vec<&'static str> {
+    BPF_EVENTS.iter().map(|e| e.name).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn effects_classification() {
+        assert!(BpfEffects::PKT_READ.is_gated());
+        assert!(BpfEffects::MAP_READ.is_gated());
+        assert!(BpfEffects::MAP_WRITE.is_gated());
+        assert!(!BpfEffects::TERMINATES.is_gated());
+        assert!(BpfEffects::TERMINATES.is_verdict());
+        assert!(!BpfEffects::NONE.is_gated());
+        assert!(!BpfEffects::NONE.is_verdict());
+        assert!(
+            BpfEffects::PKT_READ
+                .union(BpfEffects::TERMINATES)
+                .is_verdict()
+        );
+    }
+
+    #[test]
+    fn event_lookup_accepts_aliases_case_insensitively() {
+        assert_eq!(
+            lookup_bpf_event("socket").map(|e| e.name),
+            Some("SOCKET_FILTER")
+        );
+        assert_eq!(
+            lookup_bpf_event("socket_filter").map(|e| e.name),
+            Some("SOCKET_FILTER")
+        );
+        assert_eq!(lookup_bpf_event("xdp").map(|e| e.name), Some("XDP"));
+        assert_eq!(lookup_bpf_event("wat"), None);
+    }
+
+    #[test]
+    fn every_event_declares_a_drop_verdict_and_a_section() {
+        for e in BPF_EVENTS {
+            assert!(
+                e.verdicts.contains(&BpfVerdictKind::Drop),
+                "{} must allow drop",
+                e.name
+            );
+            assert!(!e.elf_section.is_empty());
+            assert!(!e.description.is_empty());
+        }
+    }
+}

--- a/rust/tcl-registry/src/commands/bpf/allow.rs
+++ b/rust/tcl-registry/src/commands/bpf/allow.rs
@@ -21,10 +21,12 @@
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::framework(BpfDeclKind::Allow);
     CommandSpec {
         name: "allow",
         dialects: Some(DialectSet::BPF),
         arity: Arity::at_least(1),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/attach.rs
+++ b/rust/tcl-registry/src/commands/bpf/attach.rs
@@ -22,10 +22,12 @@
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::framework(BpfDeclKind::Attach);
     CommandSpec {
         name: "attach",
         dialects: Some(DialectSet::BPF),
         arity: Arity::exact(2),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/deny.rs
+++ b/rust/tcl-registry/src/commands/bpf/deny.rs
@@ -21,10 +21,12 @@
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::framework(BpfDeclKind::Deny);
     CommandSpec {
         name: "deny",
         dialects: Some(DialectSet::BPF),
         arity: Arity::at_least(1),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/drop.rs
+++ b/rust/tcl-registry/src/commands/bpf/drop.rs
@@ -20,10 +20,12 @@
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::verdict(BpfVerdictKind::Drop, BpfProgTypeSet::All);
     CommandSpec {
         name: "drop",
         dialects: Some(DialectSet::BPF),
         arity: Arity::exact(0),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/field.rs
+++ b/rust/tcl-registry/src/commands/bpf/field.rs
@@ -17,14 +17,18 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 //! `field` — declare a header field inside a `profile` body
-//! (`field NAME OFFSET WIDTHBITS`).
+//! (`field NAME OFFSET WIDTHBITS ?be|le|native?`; the byte order defaults to
+//! `be` — network order).
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::framework(BpfDeclKind::Field);
     CommandSpec {
         name: "field",
         dialects: Some(DialectSet::BPF),
-        arity: Arity::exact(3),
+        // NAME OFFSET WIDTHBITS ?be|le|native?
+        arity: Arity::new(3, 4),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/load16.rs
+++ b/rust/tcl-registry/src/commands/bpf/load16.rs
@@ -16,14 +16,20 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! `load16` — load a 16-bit value from the packet (`load16 DST SRC OFFSET`).
+//! `load16` — load a 16-bit value from the packet (`load16 DST SRC OFFSET ?be|le|native?`).
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::gated(
+        BpfOpKind::PacketLoad { width_bits: 16 },
+        BpfEffects::PKT_READ,
+    );
     CommandSpec {
         name: "load16",
         dialects: Some(DialectSet::BPF),
-        arity: Arity::exact(3),
+        // DST SRC OFFSET ?be|le|native?
+        arity: Arity::new(3, 4),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/load32.rs
+++ b/rust/tcl-registry/src/commands/bpf/load32.rs
@@ -16,14 +16,20 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! `load32` — load a 32-bit value from the packet (`load32 DST SRC OFFSET`).
+//! `load32` — load a 32-bit value from the packet (`load32 DST SRC OFFSET ?be|le|native?`).
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::gated(
+        BpfOpKind::PacketLoad { width_bits: 32 },
+        BpfEffects::PKT_READ,
+    );
     CommandSpec {
         name: "load32",
         dialects: Some(DialectSet::BPF),
-        arity: Arity::exact(3),
+        // DST SRC OFFSET ?be|le|native?
+        arity: Arity::new(3, 4),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/load8.rs
+++ b/rust/tcl-registry/src/commands/bpf/load8.rs
@@ -16,14 +16,20 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! `load8` — load an 8-bit value from the packet (`load8 DST SRC OFFSET`).
+//! `load8` — load an 8-bit value from the packet (`load8 DST SRC OFFSET ?be|le|native?`).
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::gated(
+        BpfOpKind::PacketLoad { width_bits: 8 },
+        BpfEffects::PKT_READ,
+    );
     CommandSpec {
         name: "load8",
         dialects: Some(DialectSet::BPF),
-        arity: Arity::exact(3),
+        // DST SRC OFFSET ?be|le|native?
+        arity: Arity::new(3, 4),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/loop_.rs
+++ b/rust/tcl-registry/src/commands/bpf/loop_.rs
@@ -20,10 +20,12 @@
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::structural(BpfOpKind::LoopMacro);
     CommandSpec {
         name: "loop",
         dialects: Some(DialectSet::BPF),
         arity: Arity::exact(3),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/map.rs
+++ b/rust/tcl-registry/src/commands/bpf/map.rs
@@ -16,14 +16,18 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! `map` — declare a BPF map (`map NAME hash KEYSZ VALSZ MAX`).
+//! `map` — declare a BPF map
+//! (`map NAME hash|array KEYSZ VALSZ MAX ?shared|percpu?`).
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::structural(BpfOpKind::MapDeclare);
     CommandSpec {
         name: "map",
         dialects: Some(DialectSet::BPF),
-        arity: Arity::exact(5),
+        // NAME hash|array KEYSZ VALSZ MAX ?shared|percpu?
+        arity: Arity::new(5, 6),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/map_get.rs
+++ b/rust/tcl-registry/src/commands/bpf/map_get.rs
@@ -20,10 +20,12 @@
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::gated(BpfOpKind::MapGet, BpfEffects::MAP_READ);
     CommandSpec {
         name: "map_get",
         dialects: Some(DialectSet::BPF),
         arity: Arity::exact(3),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/map_has.rs
+++ b/rust/tcl-registry/src/commands/bpf/map_has.rs
@@ -16,16 +16,17 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! `accept` — accept the packet, optionally a byte count (`accept ?N?`).
+//! `map_has` — key-presence test (`map_has DST NAME {KEY}`): `DST` becomes 1
+//! when the key is present, 0 when absent — the way to distinguish a missing
+//! key from a stored zero (`map_get` folds both to 0).
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
-    const OP: BpfOpSpec =
-        BpfOpSpec::verdict(BpfVerdictKind::Accept, BpfProgTypeSet::SocketFilterOnly);
+    const OP: BpfOpSpec = BpfOpSpec::gated(BpfOpKind::MapHas, BpfEffects::MAP_READ);
     CommandSpec {
-        name: "accept",
+        name: "map_has",
         dialects: Some(DialectSet::BPF),
-        arity: Arity::new(0, 1),
+        arity: Arity::exact(3),
         bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }

--- a/rust/tcl-registry/src/commands/bpf/map_set.rs
+++ b/rust/tcl-registry/src/commands/bpf/map_set.rs
@@ -20,10 +20,12 @@
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::gated(BpfOpKind::MapSet, BpfEffects::MAP_WRITE);
     CommandSpec {
         name: "map_set",
         dialects: Some(DialectSet::BPF),
         arity: Arity::exact(3),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/mod.rs
+++ b/rust/tcl-registry/src/commands/bpf/mod.rs
@@ -40,6 +40,7 @@ mod setbuf;
 // Layer 2 — maps.
 mod map;
 mod map_get;
+mod map_has;
 mod map_set;
 // Layer 2 — verdicts.
 mod accept;
@@ -78,6 +79,7 @@ pub fn bpf_command_specs() -> Vec<CommandSpec> {
         pktlen::spec(),
         map::spec(),
         map_get::spec(),
+        map_has::spec(),
         map_set::spec(),
         accept::spec(),
         drop::spec(),
@@ -103,16 +105,30 @@ mod tests {
     #[test]
     fn all_bpf_commands_present_and_tagged() {
         let specs = bpf_command_specs();
-        assert_eq!(specs.len(), 24);
+        assert_eq!(specs.len(), 25);
         let names: Vec<&str> = specs.iter().map(|s| s.name).collect();
         for n in [
             "setint", "seti32", "setu32", "setbuf", "load8", "load16", "load32", "pktlen", "map",
-            "map_get", "map_set", "accept", "drop", "pass", "tx", "loop", "when", "profile",
-            "field", "template", "use", "allow", "deny", "attach",
+            "map_get", "map_has", "map_set", "accept", "drop", "pass", "tx", "loop", "when",
+            "profile", "field", "template", "use", "allow", "deny", "attach",
         ] {
             assert!(names.contains(&n), "missing `{n}`");
         }
         assert!(specs.iter().all(|s| s.dialects == Some(DialectSet::BPF)));
+    }
+
+    #[test]
+    fn every_bpf_command_carries_a_typed_lowering_descriptor() {
+        // Issue #1202: the registry is the source of truth for BPF lowering —
+        // a BPF-dialect spec without a `bpf_op` descriptor cannot be lowered
+        // and must never exist.
+        for spec in bpf_command_specs() {
+            assert!(
+                spec.bpf_op.is_some(),
+                "BPF command `{}` has no bpf_op descriptor",
+                spec.name
+            );
+        }
     }
 
     #[test]

--- a/rust/tcl-registry/src/commands/bpf/mod.rs
+++ b/rust/tcl-registry/src/commands/bpf/mod.rs
@@ -45,6 +45,7 @@ mod map_set;
 // Layer 2 — verdicts.
 mod accept;
 mod drop;
+mod next;
 mod pass;
 mod tx;
 // Control flow.
@@ -83,6 +84,7 @@ pub fn bpf_command_specs() -> Vec<CommandSpec> {
         map_set::spec(),
         accept::spec(),
         drop::spec(),
+        next::spec(),
         pass::spec(),
         tx::spec(),
         loop_::spec(),
@@ -105,12 +107,12 @@ mod tests {
     #[test]
     fn all_bpf_commands_present_and_tagged() {
         let specs = bpf_command_specs();
-        assert_eq!(specs.len(), 25);
+        assert_eq!(specs.len(), 26);
         let names: Vec<&str> = specs.iter().map(|s| s.name).collect();
         for n in [
             "setint", "seti32", "setu32", "setbuf", "load8", "load16", "load32", "pktlen", "map",
-            "map_get", "map_has", "map_set", "accept", "drop", "pass", "tx", "loop", "when",
-            "profile", "field", "template", "use", "allow", "deny", "attach",
+            "map_get", "map_has", "map_set", "accept", "drop", "next", "pass", "tx", "loop",
+            "when", "profile", "field", "template", "use", "allow", "deny", "attach",
         ] {
             assert!(names.contains(&n), "missing `{n}`");
         }

--- a/rust/tcl-registry/src/commands/bpf/next.rs
+++ b/rust/tcl-registry/src/commands/bpf/next.rs
@@ -1,0 +1,39 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! `next` — the explicit, non-terminal continuation outcome for handler
+//! composition (issue #1204). A handler that ends a path with `next` yields no
+//! decision, so the next handler in priority order runs; if every handler on a
+//! path yields `next`, the event's declared default verdict applies.
+//!
+//! `next` is a verdict for lowering purposes (it ends the handler's program by
+//! returning a reserved continuation sentinel), but the composition model reads
+//! that sentinel as "continue the chain" rather than a packet decision. It is
+//! valid in every program type.
+use crate::prelude::*;
+
+pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::verdict(BpfVerdictKind::Next, BpfProgTypeSet::All);
+    CommandSpec {
+        name: "next",
+        dialects: Some(DialectSet::BPF),
+        arity: Arity::exact(0),
+        bpf_op: Some(&OP),
+        ..CommandSpec::DEFAULT
+    }
+}

--- a/rust/tcl-registry/src/commands/bpf/pass.rs
+++ b/rust/tcl-registry/src/commands/bpf/pass.rs
@@ -20,10 +20,12 @@
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::verdict(BpfVerdictKind::Pass, BpfProgTypeSet::XdpOnly);
     CommandSpec {
         name: "pass",
         dialects: Some(DialectSet::BPF),
         arity: Arity::exact(0),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/pktlen.rs
+++ b/rust/tcl-registry/src/commands/bpf/pktlen.rs
@@ -20,10 +20,12 @@
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::gated(BpfOpKind::PacketLen, BpfEffects::PKT_READ);
     CommandSpec {
         name: "pktlen",
         dialects: Some(DialectSet::BPF),
         arity: Arity::exact(2),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/profile.rs
+++ b/rust/tcl-registry/src/commands/bpf/profile.rs
@@ -20,11 +20,13 @@
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::framework(BpfDeclKind::Profile);
     CommandSpec {
         name: "profile",
         dialects: Some(DialectSet::BPF),
         // `profile NAME`  or  `profile NAME { body }`
         arity: Arity::new(1, 2),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/setbuf.rs
+++ b/rust/tcl-registry/src/commands/bpf/setbuf.rs
@@ -20,11 +20,13 @@
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::structural(BpfOpKind::BindPacket);
     CommandSpec {
         name: "setbuf",
         dialects: Some(DialectSet::BPF),
         // `setbuf NAME ctx` or `setbuf NAME = ctx`.
         arity: Arity::new(2, 3),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/seti32.rs
+++ b/rust/tcl-registry/src/commands/bpf/seti32.rs
@@ -20,10 +20,13 @@
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec =
+        BpfOpSpec::structural(BpfOpKind::ScalarSet(BpfScalarWidth::I32SignExtended));
     CommandSpec {
         name: "seti32",
         dialects: Some(DialectSet::BPF),
         arity: Arity::exact(2),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/setint.rs
+++ b/rust/tcl-registry/src/commands/bpf/setint.rs
@@ -20,10 +20,12 @@
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::structural(BpfOpKind::ScalarSet(BpfScalarWidth::I64));
     CommandSpec {
         name: "setint",
         dialects: Some(DialectSet::BPF),
         arity: Arity::exact(2),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/setu32.rs
+++ b/rust/tcl-registry/src/commands/bpf/setu32.rs
@@ -20,10 +20,13 @@
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec =
+        BpfOpSpec::structural(BpfOpKind::ScalarSet(BpfScalarWidth::U32ZeroExtended));
     CommandSpec {
         name: "setu32",
         dialects: Some(DialectSet::BPF),
         arity: Arity::exact(2),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/template.rs
+++ b/rust/tcl-registry/src/commands/bpf/template.rs
@@ -21,10 +21,12 @@
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::framework(BpfDeclKind::Template);
     CommandSpec {
         name: "template",
         dialects: Some(DialectSet::BPF),
         arity: Arity::exact(3),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/tx.rs
+++ b/rust/tcl-registry/src/commands/bpf/tx.rs
@@ -20,10 +20,12 @@
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::verdict(BpfVerdictKind::Tx, BpfProgTypeSet::XdpOnly);
     CommandSpec {
         name: "tx",
         dialects: Some(DialectSet::BPF),
         arity: Arity::exact(0),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/use_.rs
+++ b/rust/tcl-registry/src/commands/bpf/use_.rs
@@ -20,11 +20,13 @@
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::framework(BpfDeclKind::Use);
     CommandSpec {
         name: "use",
         dialects: Some(DialectSet::BPF),
         // `use NAME` plus zero or more `key=value` bindings.
         arity: Arity::at_least(1),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/bpf/when.rs
+++ b/rust/tcl-registry/src/commands/bpf/when.rs
@@ -24,11 +24,13 @@
 use crate::prelude::*;
 
 pub fn spec() -> CommandSpec {
+    const OP: BpfOpSpec = BpfOpSpec::framework(BpfDeclKind::When);
     CommandSpec {
         name: "when",
         dialects: Some(DialectSet::BPF),
         // EVENT BODY  |  EVENT priority N BODY
         arity: Arity::new(2, 4),
+        bpf_op: Some(&OP),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -55,6 +55,7 @@ pub mod arity;
 pub mod base_objects;
 pub mod bigip;
 pub mod body_kind;
+pub mod bpf_op;
 pub mod byte_array_effect;
 pub mod cache;
 pub mod clause_shape;
@@ -98,6 +99,10 @@ pub mod prelude {
     pub use crate::arg_role::{AppendedArity, ArgRole};
     pub use crate::arity::Arity;
     pub use crate::body_kind::BodyKind;
+    pub use crate::bpf_op::{
+        BpfDeclKind, BpfEffects, BpfOpKind, BpfOpSpec, BpfProgTypeSet, BpfScalarWidth,
+        BpfVerdictKind,
+    };
     pub use crate::byte_array_effect::ByteArrayEffect;
     pub use crate::clause_shape::{ClauseShapeChecker, ClauseShapeError};
     pub use crate::command_table::CommandTableEffect;

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -451,6 +451,14 @@ impl CommandRegistry {
             .and_then(|v| v.last())
     }
 
+    /// The typed BPF-Tcl lowering descriptor for `name`, when `name` is a
+    /// BPF-dialect command (see [`crate::bpf_op`]).  The BPF-Tcl front-end
+    /// dispatches on this — never on the command name.
+    #[must_use]
+    pub fn bpf_op(&self, name: &str) -> Option<&'static crate::bpf_op::BpfOpSpec> {
+        self.get(name).and_then(|s| s.bpf_op)
+    }
+
     /// Look up a command spec filtered by dialect, picking the
     /// **most-specific** visible spec (`best_visible` — §5.3's single
     /// selection rule).

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -474,6 +474,15 @@ pub struct CommandSpec {
     /// Lowering hook ID (index into compiler's dispatch table).
     pub lowering_hook: Option<LoweringHookId>,
 
+    /// Typed BPF-Tcl lowering descriptor — `Some` on every command of the
+    /// BPF dialect, describing the core operation or framework declaration
+    /// the command stands for (scalar width, packet-load width, map role,
+    /// verdict family + compatible program types, effect classification).
+    /// The BPF-Tcl front-end (`bpf-tcl-ir`) and its capability policy
+    /// dispatch on this descriptor, never on the command name — see
+    /// [`crate::bpf_op`].  `None` for every non-BPF command.
+    pub bpf_op: Option<&'static crate::bpf_op::BpfOpSpec>,
+
     /// `TclVM` bytecode codegen hook ID — picks the per-command
     /// emitter inside `tcl_compiler::codegen::emitter::bytecoded`
     /// (the path that matches C Tcl 9's bytecode output).
@@ -957,6 +966,7 @@ impl CommandSpec {
         const_fold: None,
         const_fold_versioned: None,
         lowering_hook: None,
+        bpf_op: None,
         codegen_hook: None,
         inline_codegen_hook: None,
         wasm_codegen_hook: None,

--- a/rust/tcl-spec-studio/src/draft.rs
+++ b/rust/tcl-spec-studio/src/draft.rs
@@ -613,6 +613,7 @@ fn command_identity(d: &mut Draft, spec: &CommandSpec, lost: &mut Unrecovered) {
         "frame_effect".into(),
         lost.expr("frame_effect", spec.frame_effect.is_some()),
     );
+    d.insert("bpf_op".into(), lost.expr("bpf_op", spec.bpf_op.is_some()));
     d.insert(
         "clause_shape_check".into(),
         lost.expr("clause_shape_check", spec.clause_shape_check.is_some()),

--- a/rust/tcl-spec-studio/src/schema.rs
+++ b/rust/tcl-spec-studio/src/schema.rs
@@ -489,6 +489,15 @@ pub const COMMAND_FIELDS: &[FieldSchema] = &[
         "Per-command WASM emitter. No specialisations exist yet.",
     ),
     f(
+        "bpf_op",
+        "BPF-Tcl lowering descriptor",
+        HOOKS,
+        FieldKind::RustExpr {
+            hint: "Some(&bpf_op::XDP_PASS)",
+        },
+        "Typed BPF-Tcl lowering descriptor; the BPF front-end dispatches on this, never on the command name.",
+    ),
+    f(
         "analyser_hook",
         "Analyser hook",
         HOOKS,

--- a/samples/bpf-tcl/README.md
+++ b/samples/bpf-tcl/README.md
@@ -1,10 +1,14 @@
 # BPF-Tcl userspace demos
 
-These demos exercise both backend targets that exist today. The default `rbpf`
+These demos exercise the backend targets that exist today. The default `rbpf`
 target executes real eBPF instructions over synthetic packet bytes in a
-userspace virtual machine. The explicit `kernel-xdp` target supports a small,
-map-free, verdict-only XDP subset that the Linux kernel can verifier-load and
-test-run.
+userspace virtual machine. The explicit `kernel-xdp` (`struct xdp_md`) and
+`kernel-socket` (`struct __sk_buff`) targets emit Linux-loadable objects with
+real context access, verifier-safe packet bounds proofs, and BTF-defined maps
+with relocations (issue #1203). The map-free verdict-only XDP demo below is
+verifier-loaded and test-run end to end; the packet-access and map objects are
+validated structurally here and load on a real kernel behind the `#[ignore]`d
+`rust/bpf-tcl/tests/kernel_load.rs` gate.
 
 The clean-room instructions and full script were validated on Ubuntu 26.04
 with Rust 1.97.0, GNU `readelf`, and LLVM 21.

--- a/samples/bpf-tcl/README.md
+++ b/samples/bpf-tcl/README.md
@@ -162,6 +162,43 @@ not mounted, mount it once with:
 sudo mount -t bpf bpf /sys/fs/bpf
 ```
 
+## Handler composition and the loader plan (issue #1204)
+
+Multiple `when EVENT priority N { … }` handlers for one event compose into an
+ordered chain. Lower priority numbers run first; the first handler that returns a
+terminal verdict (`accept`/`drop`/`pass`/`tx`) decides, and a handler continues
+to the next only by ending a path with the explicit non-terminal `next` outcome.
+If every handler yields `next`, the event's default verdict applies. Two handlers
+of one event that share a priority are rejected as an ambiguous composition.
+
+```sh
+target/debug/bpf-tcl check samples/bpf-tcl/compose-deny-audit.bpftcl
+```
+
+`check` prints the resolved event contract per handler (context struct, permitted
+capabilities, default verdict, output kind, kernel requirements) and, for a
+multi-handler event, the composition chain in run order.
+
+`plan` is the loader dry-run. It shows each program's type, priority, deployment
+target, ownership-labelled pin path, maps, and kernel requirements — without
+touching any kernel state:
+
+```sh
+target/debug/bpf-tcl plan samples/bpf-tcl/compose-deny-audit.bpftcl --name demo
+```
+
+The rest of the loader/link lifecycle (`load` → `test-run` → `attach` →
+`status` → `detach`, with atomic rollback and resource ownership) is modelled and
+unit-tested deterministically in `bpf-tcl-ir::loader` over a `ModelKernel`. Real
+`bpf()`-syscall attachment needs a live kernel plus `CAP_BPF` / `CAP_NET_ADMIN`
+(root in practice) and is exercised only by the `#[ignore]`d privileged tests in
+`rust/bpf-tcl/tests/kernel_attach.rs`, which run inside a disposable network
+namespace torn down unconditionally so nothing leaks onto the host:
+
+```sh
+sudo -E cargo test -p bpf-tcl --test kernel_attach -- --ignored --nocapture
+```
+
 ## Compile a `.bpftcl` file
 
 `check` runs the framework expansion and typed lowering without emitting an

--- a/samples/bpf-tcl/README.md
+++ b/samples/bpf-tcl/README.md
@@ -90,8 +90,13 @@ The script builds `bpf-tcl`, then demonstrates:
 5. emitted eBPF assembly; and
 6. a map-free `EM_BPF` ELF object inspected with `readelf` when available.
 
-The XDP marker example uses an 8-bit field at byte zero, avoiding the current
-native-endian limitation for multi-byte network fields.
+Multi-byte packet fields are read in the declared byte order. Built-in and
+user profile fields default to network order (big-endian), matching real
+Ethernet/IP/TCP/UDP headers, so a `tcp_dport` comparison works against a
+realistic packet on a little-endian host. A `load8`/`load16`/`load32` verb or a
+`field` declaration may override the order with a trailing `be`, `le`, or
+`native` word; `native` is a compatibility mode for synthetic host-order test
+packets only.
 
 ## Run one example
 

--- a/samples/bpf-tcl/compose-deny-audit.bpftcl
+++ b/samples/bpf-tcl/compose-deny-audit.bpftcl
@@ -1,0 +1,34 @@
+# Handler composition (issue #1204): two XDP handlers compose deterministically.
+#
+# Priority 10 (the "deny" handler) runs first. It drops traffic to TCP port 22
+# and otherwise yields `next` — the explicit, non-terminal continuation — so the
+# chain proceeds. Priority 20 (the "audit" handler) counts every surviving packet
+# in a shared array map and lets it pass.
+#
+# Because a terminal verdict stops the chain, a blocked port is decided by the
+# deny handler alone; everything else is decided by the audit handler. If both
+# handlers yielded `next`, the XDP event's default verdict (pass) would apply.
+#
+#   bpf-tcl check samples/bpf-tcl/compose-deny-audit.bpftcl
+#   bpf-tcl plan  samples/bpf-tcl/compose-deny-audit.bpftcl --name demo
+
+attach xdp eth0
+
+when XDP priority 10 {
+  setbuf p ctx
+  pktlen n p
+  if {$n < 38} { next }
+  load16 dport p 36 be
+  if {$dport == 22} { drop }
+  next
+}
+
+when XDP priority 20 {
+  setbuf p ctx
+  map seen array 4 8 4
+  setint k 0
+  map_get c seen {$k}
+  setint c1 {$c + 1}
+  map_set seen {$k} {$c1}
+  pass
+}

--- a/samples/bpf-tcl/xdp-kernel-portcount.bpftcl
+++ b/samples/bpf-tcl/xdp-kernel-portcount.bpftcl
@@ -1,0 +1,26 @@
+# A kernel-loadable XDP filter with a BTF-defined map and a bounds-checked
+# packet read. Compile it for the kernel with:
+#
+#   bpf-tcl compile samples/bpf-tcl/xdp-kernel-portcount.bpftcl \
+#       --target kernel-xdp --emit elf --program 0 -o /tmp/portcount.o
+#
+# The emitted object carries a `.maps` section, a `.BTF` description of the
+# array map, and `R_BPF_64_64` relocations for the map-fd loads, so libbpf can
+# create the map and patch its file descriptor. The 16-bit TCP destination-port
+# read at offset 36 is emitted with a dominating `data_end` bounds proof, so the
+# kernel verifier accepts it; a short packet takes XDP_PASS.
+when XDP {
+    map dropped array 4 8 1
+
+    setbuf p ctx
+    load16 dport p 36 be
+
+    if {$dport == 22} {
+        setint k 0
+        map_get n dropped {$k}
+        setint n1 {$n + 1}
+        map_set dropped {$k} {$n1}
+        drop
+    }
+    pass
+}


### PR DESCRIPTION
## Summary

- Hardens the BPF-IR contracts with registry-described lowering; adds kernel XDP/socket-filter codegen with maps, BTF, relocations, and verifier tests; adds typed event schemas, handler composition, ring-buffer records, and loader/link lifecycle management.
- Closes #1202, closes #1203, closes #1204.

Part of the per-group PR series; independent of the other groups. Extends the BPF-Tcl XDP target that landed on `rust` in #1205.

## Validation

- [x] On the group branch: BPF codegen and verifier test suites, clippy `-D warnings`, fmt — green at development time.
- [x] Rebased onto `rust` (post-#1212): `cargo check --workspace --all-targets` — 0 errors.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? — BPF-IR lowering contracts are now registry-described (BPF target only; Tcl analysis contracts untouched).
- [x] If yes, I updated at least one relevant KCS note — BPF target design docs updated in-tree with the contract descriptions.
- [ ] If I added a new compiler KCS note, I linked it — n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_