### PR TITLE
Registry-driven grammar: formatter/token consumers read registry facts, param-list literalness, format-string roles (#1107, #1186, #1196; most of #1185)

### DIFF
--- a/docs/design/compiler/command-registry.md
+++ b/docs/design/compiler/command-registry.md
@@ -123,6 +123,7 @@ class StringCommand(CommandDef):
 | `arg_roles` | `dict[int, ArgRole]` | `{}` | Static arg roles: `BODY`, `EXPR`, `VAR_NAME`, `VAR_READ`, `PATTERN`, etc. |
 | `arg_role_resolver` | `ArgRoleResolver \| None` | `None` | Dynamic arg-role resolution for variable-layout commands (if, try, switch) |
 | `arg_presentation` | `&[(u8, ArgPresentation)]` | `&[]` | Formatter layout override per argument index -- see [ArgPresentation](#argpresentation----how-a-formatter-lays-an-argument-out) |
+| `repeated_args` | `&[RepeatedArgLayout]` | `&[]` | Roles that recur at a fixed stride over the argument tail (`global a b c`, `foreach v l ... body`) |
 | `clause_shape_check` | `ClauseShapeChecker \| None` | `None` | Validates a clause-chain shape a plain `min..=max` arity can't express (if's `elseif`/`else` chain -- see `tcl_registry::clause_shape`); the compiler dispatches on the hook's presence, not the command name |
 | `arg_types` | `dict[int, ArgTypeHint]` | `{}` | Per-argument type expectations (e.g. `INT`, `LIST`).  Drives shimmer detection |
 | `return_type` | `TclType \| None` | `None` | Return type of the command |
@@ -343,6 +344,72 @@ role fails to compile until someone decides which side it falls on:
 `LOOP_VAR_LIST` is deliberately outside `names_variable()`: that word is a
 *list* of names, not one name, so a consumer must split it before it holds a
 variable name at all.
+
+### Repeated argument layouts -- unbounded regular tails
+
+`arg_roles` is a fixed index table and an `arg_role_resolver` is an opaque
+closure; neither is a good fit for the *regular, unbounded* argument tails a
+whole family of Tcl commands takes:
+
+```tcl
+global a b c                       ;# a name at every word
+variable n1 v1 n2 v2               ;# a name at every other word
+foreach v1 $l1 v2 $l2 { ... }      ;# a spec at every other word, body excluded
+namespace upvar ::ns o1 l1 o2 l2   ;# the local of each pair, after a fixed prefix
+dict update d k1 v1 k2 v2 { ... }  ;# the same, with the body excluded
+```
+
+Every consumer that needed one of these re-derived the stride from the
+command's *name* -- three separate copies in the semantic-token walk alone.
+`repeated_args: &[RepeatedArgLayout]` (on both `CommandSpec` and `SubCommand`)
+declares the layout as data instead:
+
+| Field | Meaning |
+|---|---|
+| `role` | the `ArgRole` assigned at each covered position |
+| `start` | first covered index (after the head, or after the subcommand word) |
+| `stride` | distance between covered positions (`1` = every word, `2` = every other) |
+| `exclude_trailing` | words at the *end* the layout does not cover (a trailing body) |
+| `optional_leading_word` | the command takes one optional leading word whose presence shows only in the argument count (`upvar`'s `?level?`); the group is then anchored to the end of the covered range |
+
+The layouts feed `CommandRegistry::arg_indices_for_role` alongside
+`arg_role_resolver` and `arg_roles`, **additively** -- so a spec can pin its
+leading words with `arg_roles` (`namespace upvar`'s leading namespace word)
+and still declare the repeating pair tail. A consumer therefore just asks
+"which arguments carry role X" and gets the whole answer.
+
+**Limits.** The layout is purely positional: it cannot express a stride that
+depends on a *word's value* (a switch that shifts the tail), which still needs
+an `arg_role_resolver`. `upvar` deliberately does **not** use one -- its
+`?level?` word is already modelled more precisely by `FrameEffectSpec`
+(`FrameArgLayout::AliasPairs` + `FrameLevelWord::ArityParity`, which is how C
+Tcl itself decides: `Tcl_UpvarObjCmd` tests `objc`, never the word's text).
+
+### Format strings -- family plus location
+
+Which words of a call carry a conversion / field string, and in which
+mini-language, is two registry facts read together through
+`CommandRegistry::format_string_args`:
+
+- **Where** -- the `ArgRole::FormatString` / `ArgRole::ScanFormat` positions of
+  the call. That covers a fixed index (`format`), a resolver-computed one
+  (`scan`, `regsub` past its switches), a subcommand-relative one
+  (`binary format`), and an **option value** (`clock format ... -format FMT`),
+  because `arg_indices_for_role` already resolves all four.
+- **Which language** -- `format_string_type` (`FormatType::Sprintf` / `Clock` /
+  `Binary` / `Regsub`), overridden by the subcommand's own when one dispatches.
+
+The `scan` flag on the returned `FormatStringArg` says which *direction* the
+word is written in: `format` and `scan` share the `Sprintf` family but not its
+conversion set, so a consumer must not infer one from the other.
+
+The family check is load-bearing for correctness, not decoration. `clock`'s
+field string, `binary`'s cursor spec, and `regsub`'s backreference template all
+sit at `FormatString`/`ScanFormat` positions, and none is a printf %-string --
+running the sprintf version gate over `clock format $t -format {%b}` would
+report a bogus Tcl 8.6 requirement. `record_dsl_format_sites` (W138) therefore
+gates on `FormatType::Sprintf` and leaves the other families alone rather than
+guessing.
 
 ### ArgPresentation -- how a formatter lays an argument out
 

--- a/docs/design/compiler/command-registry.md
+++ b/docs/design/compiler/command-registry.md
@@ -122,6 +122,7 @@ class StringCommand(CommandDef):
 |-------|------|---------|---------|
 | `arg_roles` | `dict[int, ArgRole]` | `{}` | Static arg roles: `BODY`, `EXPR`, `VAR_NAME`, `VAR_READ`, `PATTERN`, etc. |
 | `arg_role_resolver` | `ArgRoleResolver \| None` | `None` | Dynamic arg-role resolution for variable-layout commands (if, try, switch) |
+| `arg_presentation` | `&[(u8, ArgPresentation)]` | `&[]` | Formatter layout override per argument index -- see [ArgPresentation](#argpresentation----how-a-formatter-lays-an-argument-out) |
 | `clause_shape_check` | `ClauseShapeChecker \| None` | `None` | Validates a clause-chain shape a plain `min..=max` arity can't express (if's `elseif`/`else` chain -- see `tcl_registry::clause_shape`); the compiler dispatches on the hook's presence, not the command name |
 | `arg_types` | `dict[int, ArgTypeHint]` | `{}` | Per-argument type expectations (e.g. `INT`, `LIST`).  Drives shimmer detection |
 | `return_type` | `TclType \| None` | `None` | Return type of the command |
@@ -342,6 +343,65 @@ role fails to compile until someone decides which side it falls on:
 `LOOP_VAR_LIST` is deliberately outside `names_variable()`: that word is a
 *list* of names, not one name, so a consumer must split it before it holds a
 variable name at all.
+
+### ArgPresentation -- how a formatter lays an argument out
+
+`ArgRole` says what an argument **is**. `arg_presentation` (a
+`&'static [(u8, ArgPresentation)]` on both `CommandSpec` and `SubCommand`)
+says how a *formatter* should lay it out. The two are deliberately separate
+facts, because two arguments can share a semantic role and still want
+different presentation.
+
+`for start test next body` is the case that forced the split. All three of
+`start`, `next`, and `body` are Tcl scripts and carry `ArgRole::Body` --
+every analysis consumer must keep walking them. But conventional Tcl keeps
+`start` and `next` on the `for` header line and expands only `body`:
+
+```tcl
+for {set i 0} {$i < 3} {incr i} {
+    puts $i
+}
+```
+
+Erasing the semantic distinction would break the walkers; keeping a
+`name == "for"` branch in the formatter is exactly the command-specific
+knowledge the registry contract forbids. So `for` declares the layout
+preference as data instead:
+
+```rust
+arg_presentation: &[
+    (0, ArgPresentation::InlineScript),
+    (2, ArgPresentation::InlineScript),
+],
+```
+
+| Variant | Meaning |
+|---|---|
+| `BlockScript` | expanded onto its own indented lines, opening brace left on the command line (K&R). The **default** for every `Body` argument |
+| `InlineScript` | kept on the command's own line, however long -- `for`'s `start` / `next` |
+
+Only overrides are declared, so a spec with nothing unusual to say leaves
+the field empty. Consumers ask
+`CommandRegistry::arg_presentation(name, args, index)`, which resolves
+through the same `get` path as every other query -- so `::for` answers
+identically to `for` -- and returns `BlockScript` for a command the registry
+does not know.
+
+**Limits.** `ArgPresentation` describes layout preference only; it carries no
+line-width, alignment, or comment policy (those are `FormatterConfig`), and
+it cannot make a *non*-body argument expand. The enum is `#[non_exhaustive]`:
+it is the extension point for further presentation facts, and a consumer must
+keep working when a new variant arrives.
+
+**Structural keywords are not a presentation fact.** `if`'s `then` /
+`elseif` / `else` and `try`'s `on` / `trap` / `finally` already carry
+`ArgRole::Keyword` at the positions the C-Tcl-shaped clause walk puts them,
+so the formatter reads that role directly rather than scanning argument
+*values* for those words. The difference is observable: in
+`if {1} {a} else then` the trailing `then` sits in the else-branch **body**
+slot -- tclsh 8.6 and 9.0.4 run `a` and treat `then` as that branch's script
+-- so it is a body word, not a keyword, and only a positional answer gets
+that right.
 
 `Traits.BUILDS_COMMAND_PREFIX` (set on `list` only, not `concat`) marks a
 command whose result, when its own first argument is a literal command name,

--- a/rust/tcl-compiler/src/analyser/diagnostics/version_gate.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/version_gate.rs
@@ -525,51 +525,65 @@ impl Analyser {
         self.profile.effective_tcl_version(tcl_floor)
     }
 
-    /// Buffer format/scan %-string DSL uses at a dispatch site — the
-    /// registry marks the %-string argument positions with
-    /// [`ArgRole::FormatString`] / [`ArgRole::ScanFormat`], so no command
+    /// Buffer format/scan %-string DSL uses at a dispatch site — the registry
+    /// locates the format-string words *and* names the mini-language each is
+    /// written in ([`CommandRegistry::format_string_args`]), so no command
     /// name is matched here.
+    ///
+    /// The family check is load-bearing, not decoration: `clock`'s field
+    /// string, `binary`'s cursor spec, and `regsub`'s backreference template
+    /// all sit at [`ArgRole::FormatString`] / [`ArgRole::ScanFormat`]
+    /// positions too, and none of them is a printf %-string. Running the
+    /// sprintf version gate over `clock format $t -format {%b}` would report
+    /// a Tcl 8.6 requirement for a conversion that has nothing to do with
+    /// `format`'s `%b`. Only [`FormatType::Sprintf`] words are gated here;
+    /// the other families have no version-gated conversion table modelled
+    /// yet, so they are deliberately left alone rather than guessed at.
     ///
     /// [`ArgRole::FormatString`]: tcl_registry::arg_role::ArgRole
     /// [`ArgRole::ScanFormat`]: tcl_registry::arg_role::ArgRole
+    /// [`CommandRegistry::format_string_args`]: tcl_registry::CommandRegistry::format_string_args
+    /// [`FormatType::Sprintf`]: tcl_registry::patterns::FormatType
     pub(in crate::analyser) fn record_dsl_format_sites(
         &mut self,
         cmd_name: &str,
         args: &[String],
         arg_tokens: &[Token],
     ) {
-        use tcl_registry::arg_role::ArgRole;
+        use tcl_registry::patterns::FormatType;
         let Some(registry) = self.registry else {
             return;
         };
         let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
-        for (role, is_scan) in [(ArgRole::FormatString, false), (ArgRole::ScanFormat, true)] {
-            for idx in registry.arg_indices_for_role(cmd_name, &arg_strs, role) {
-                let (Some(fmt), Some(tok)) = (args.get(idx), arg_tokens.get(idx)) else {
-                    continue;
-                };
-                // A dynamic token's text is not the literal %-string.
-                if matches!(tok.kind, TokenType::Var | TokenType::Cmd) {
-                    continue;
+        for found in registry.format_string_args(cmd_name, &arg_strs) {
+            if found.kind != FormatType::Sprintf {
+                continue;
+            }
+            let (Some(fmt), Some(tok)) = (args.get(found.index), arg_tokens.get(found.index))
+            else {
+                continue;
+            };
+            // A dynamic token's text is not the literal %-string.
+            if matches!(tok.kind, TokenType::Var | TokenType::Cmd) {
+                continue;
+            }
+            if found.scan {
+                for (_, feature, min) in tcl_syntax::scan::version_gated_uses(fmt) {
+                    self.dsl_gate_sites.push(DslGateSite {
+                        span: tok.span,
+                        code: DiagCode::W138,
+                        what: format!("`scan` conversion {feature} in '{cmd_name}'"),
+                        min,
+                    });
                 }
-                if is_scan {
-                    for (_, feature, min) in tcl_syntax::scan::version_gated_uses(fmt) {
-                        self.dsl_gate_sites.push(DslGateSite {
-                            span: tok.span,
-                            code: DiagCode::W138,
-                            what: format!("`scan` conversion {feature} in '{cmd_name}'"),
-                            min,
-                        });
-                    }
-                } else {
-                    for use_ in tcl_syntax::format::version_gated_uses(fmt) {
-                        self.dsl_gate_sites.push(DslGateSite {
-                            span: tok.span,
-                            code: DiagCode::W138,
-                            what: format!("`format` conversion {} in '{cmd_name}'", use_.feature),
-                            min: use_.min,
-                        });
-                    }
+            } else {
+                for use_ in tcl_syntax::format::version_gated_uses(fmt) {
+                    self.dsl_gate_sites.push(DslGateSite {
+                        span: tok.span,
+                        code: DiagCode::W138,
+                        what: format!("`format` conversion {} in '{cmd_name}'", use_.feature),
+                        min: use_.min,
+                    });
                 }
             }
         }

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -1400,13 +1400,14 @@ impl Analyser {
         // tclsh 9.0.4 / 8.6.16 contradict (`proc makeargs {} {return {a b}}`;
         // `proc p [makeargs] {…}`; `info args p` → `a b`; `p 1 2` runs).
         //
-        // Literal ⟺ the word is a *single* `Str` (brace-quoted) or `Esc`
-        // (bareword / substitution-free quoted) token: any `$` / `[` splits
-        // the word into several tokens (or lexes it as `Var` / `Cmd`), which
-        // is exactly the "computed" case.  `proc r "m n" {…}` stays literal —
-        // tclsh really does declare `m` and `n` for it.
-        let params_computed = !(arg_single.get(1).copied().unwrap_or(true)
-            && matches!(arg_tokens[1].kind, TokenType::Str | TokenType::Esc));
+        // The literalness rule itself lives in
+        // `signature_scan::params::param_word_is_literal` — the one predicate
+        // this tier, the signature-scan tier, and the LSP's cursor classifier
+        // all share (issue #1107).
+        let params_computed = !crate::signature_scan::params::param_word_is_literal(
+            arg_tokens[1].kind,
+            arg_single.get(1).copied().unwrap_or(true),
+        );
         let params = if params_computed {
             Vec::new()
         } else {

--- a/rust/tcl-compiler/src/analyser/item_tree.rs
+++ b/rust/tcl-compiler/src/analyser/item_tree.rs
@@ -110,7 +110,18 @@ pub struct ItemSig {
     /// class qualified name for methods.
     pub namespace: String,
     /// Declared parameters (procs / methods; empty otherwise).
+    ///
+    /// Empty *and* [`Self::params_computed`] set means "unknown", not "none".
     pub params: Vec<ParamDef>,
+    /// The declaration's parameter-list word was **computed**, so its formals
+    /// are unmodelled ([`crate::analyser::ProcDef::params_computed`]).
+    ///
+    /// Carried on the signature — not just on the analyser record — because
+    /// the *cross-file* arity table is built from `ItemSig` alone. Without it,
+    /// `proc p [makeargs] {…}` reached the cross-file check as a proc with an
+    /// empty parameter list, i.e. "takes no arguments", and every call to it
+    /// from another file drew a false `E003` (issue #1107).
+    pub params_computed: bool,
     /// Source span of the name token (`Span::new(0, 0)` when the analyser
     /// record carries no name span — e.g. aliases / ensembles).
     pub name_span: Span,
@@ -203,6 +214,7 @@ impl ItemTree {
                     id: ItemId::new(ItemKind::Proc, qualified.clone()),
                     namespace: enclosing_namespace(qualified),
                     params: proc.params.clone(),
+                    params_computed: proc.params_computed,
                     name_span: proc.name_span,
                 },
                 body_span: Some(proc.body_span),
@@ -215,6 +227,7 @@ impl ItemTree {
                     id: ItemId::new(ItemKind::Class, qualified.clone()),
                     namespace: enclosing_namespace(qualified),
                     params: Vec::new(),
+                    params_computed: false,
                     name_span: class.name_span,
                 },
                 body_span: Some(class.body_span),
@@ -226,6 +239,7 @@ impl ItemTree {
                             id: ItemId::new(ItemKind::Method, key),
                             namespace: qualified.clone(),
                             params,
+                            params_computed: false,
                             name_span,
                         },
                         body_span: Some(body_span),
@@ -242,6 +256,7 @@ impl ItemTree {
                     id: ItemId::new(ItemKind::Alias, qualified.clone()),
                     namespace: enclosing_namespace(qualified),
                     params: Vec::new(),
+                    params_computed: false,
                     name_span: Span::new(0, 0),
                 },
                 body_span: None,
@@ -254,6 +269,7 @@ impl ItemTree {
                     id: ItemId::new(ItemKind::Ensemble, ns.clone()),
                     namespace: ns.clone(),
                     params: Vec::new(),
+                    params_computed: false,
                     name_span: Span::new(0, 0),
                 },
                 body_span: None,
@@ -268,6 +284,7 @@ impl ItemTree {
                     id: ItemId::new(ItemKind::Namespace, ns.clone()),
                     namespace: enclosing_namespace(ns),
                     params: Vec::new(),
+                    params_computed: false,
                     name_span: Span::new(0, 0),
                 },
                 body_span: None,

--- a/rust/tcl-compiler/src/signature_scan/factory.rs
+++ b/rust/tcl-compiler/src/signature_scan/factory.rs
@@ -157,7 +157,12 @@ pub(super) fn resolve_factory_defs(ctx: &mut ScanCtx) {
             SignatureProc {
                 name: simple,
                 qualified_name: emitted_q,
+                // A factory-emitted proc's formals come from the factory's own
+                // run-time arguments, so they are *unknown*, not *none* — an
+                // arity consumer must abstain rather than demand zero
+                // arguments (issue #1107).
                 params: Vec::new(),
+                params_computed: true,
                 name_range: cand.name_tok.span,
                 body_range: cand.body_tok.span,
             },
@@ -325,6 +330,7 @@ mod tests {
                     has_default: false,
                     default_value: None,
                 }],
+                params_computed: false,
                 name_range: Span::new(99, 102),
                 body_range: Span::new(110, 120),
             },

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -155,7 +155,21 @@ pub(super) fn emit_class(
 ///
 /// Body recursion (`scan_factory_candidates`) is **not** wired in:
 /// the proc is recorded, but its body is not walked.
-pub(super) fn handle_proc(texts: &[String], argv: &[Token], ns_prefix: &str, ctx: &mut ScanCtx) {
+///
+/// A **computed** parameter-list word (`proc p [makeargs] {…}`,
+/// `proc q $params {…}`) records no parameters and sets
+/// [`SignatureProc::params_computed`], so the cross-file arity check abstains
+/// instead of demanding the one bogus argument the unresolved word used to
+/// look like (issue #1107). The literalness rule is the shared
+/// [`super::params::param_word_is_literal`], so this tier and the analyser
+/// tier cannot disagree.
+pub(super) fn handle_proc(
+    texts: &[String],
+    argv: &[Token],
+    single_token_word: &[bool],
+    ns_prefix: &str,
+    ctx: &mut ScanCtx,
+) {
     if texts.len() < 4 {
         return;
     }
@@ -164,7 +178,15 @@ pub(super) fn handle_proc(texts: &[String], argv: &[Token], ns_prefix: &str, ctx
     let simple = qualified.rsplit("::").next().unwrap_or("").to_string();
     let name_range = argv[1].span;
     let body_range = argv[3].span;
-    let params = parse_param_list(&texts[2]);
+    let params_computed = !super::params::param_word_is_literal(
+        argv[2].kind,
+        single_token_word.get(2).copied().unwrap_or(true),
+    );
+    let params = if params_computed {
+        Vec::new()
+    } else {
+        parse_param_list(&texts[2])
+    };
     let param_names: Vec<String> = params.iter().map(|p| p.name.clone()).collect();
     ctx.result.procs.insert(
         qualified.clone(),
@@ -172,6 +194,7 @@ pub(super) fn handle_proc(texts: &[String], argv: &[Token], ns_prefix: &str, ctx
             name: simple,
             qualified_name: qualified.clone(),
             params,
+            params_computed,
             name_range,
             body_range,
         },
@@ -232,6 +255,9 @@ pub(super) fn handle_opt_proc(
             name: simple,
             qualified_name: qualified.clone(),
             params,
+            // The `opt` runtime always installs a plain literal `args`
+            // catch-all, so the recorded formals are known, not computed.
+            params_computed: false,
             name_range,
             body_range,
         },
@@ -753,7 +779,7 @@ mod tests {
         ];
         let argv = vec![token(0, 4), token(5, 9), token(10, 12), str_token(13, 35)];
         let mut ctx = ScanCtx::default();
-        handle_proc(&texts, &argv, "", &mut ctx);
+        handle_proc(&texts, &argv, &[true; 4], "", &mut ctx);
         assert_eq!(ctx.candidates.len(), 1);
     }
 
@@ -769,7 +795,7 @@ mod tests {
         // skipped.
         let argv = vec![token(0, 4), token(5, 9), token(10, 12), token(13, 23)];
         let mut ctx = ScanCtx::default();
-        handle_proc(&texts, &argv, "", &mut ctx);
+        handle_proc(&texts, &argv, &[true; 4], "", &mut ctx);
         assert!(ctx.candidates.is_empty());
     }
 
@@ -829,7 +855,7 @@ mod tests {
     fn handle_proc_records_bare_proc() {
         let (texts, argv) = proc_inputs("foo");
         let mut ctx = ScanCtx::default();
-        handle_proc(&texts, &argv, "", &mut ctx);
+        handle_proc(&texts, &argv, &[true; 4], "", &mut ctx);
         let proc = ctx.result.procs.get("::foo").expect("inserted");
         assert_eq!(proc.name, "foo");
         assert_eq!(proc.qualified_name, "::foo");
@@ -847,7 +873,7 @@ mod tests {
     fn handle_proc_under_namespace_indexes_qualified() {
         let (texts, argv) = proc_inputs("bar");
         let mut ctx = ScanCtx::default();
-        handle_proc(&texts, &argv, "ns::deep", &mut ctx);
+        handle_proc(&texts, &argv, &[true; 4], "ns::deep", &mut ctx);
         let proc = ctx.result.procs.get("::ns::deep::bar").expect("inserted");
         assert_eq!(proc.name, "bar");
         assert_eq!(ctx.proc_bodies[0].ns_prefix, "ns::deep");
@@ -857,7 +883,7 @@ mod tests {
     fn handle_proc_with_absolute_name_records_at_global() {
         let (texts, argv) = proc_inputs("::top::baz");
         let mut ctx = ScanCtx::default();
-        handle_proc(&texts, &argv, "outer", &mut ctx);
+        handle_proc(&texts, &argv, &[true; 4], "outer", &mut ctx);
         let proc = ctx.result.procs.get("::top::baz").expect("inserted");
         assert_eq!(proc.name, "baz");
         assert_eq!(proc.qualified_name, "::top::baz");
@@ -870,7 +896,7 @@ mod tests {
         let texts = vec!["proc".to_string(), "name".to_string()];
         let argv = vec![token(0, 4), token(5, 9)];
         let mut ctx = ScanCtx::default();
-        handle_proc(&texts, &argv, "", &mut ctx);
+        handle_proc(&texts, &argv, &[true; 4], "", &mut ctx);
         assert!(ctx.result.procs.is_empty());
         assert!(ctx.proc_bodies.is_empty());
     }

--- a/rust/tcl-compiler/src/signature_scan/params.rs
+++ b/rust/tcl-compiler/src/signature_scan/params.rs
@@ -25,10 +25,76 @@
 //! name and whose remainder is the optional default (`a`, `{name default}`, and
 //! the escaped forms such as `a\ b` — which Tcl reads as name `a` default `b`).
 
+use std::borrow::Cow;
+
 use tcl_lexer::backslash_subst;
 use tcl_syntax::list::{find_element, split_list};
 
 use super::types::ParamDef;
+
+/// Whether a routine's parameter-list **word** is *literal* — data Tcl passes
+/// through untouched — rather than **computed** from a run-time value.
+///
+/// This is the one predicate every tier shares (issue #1107): the analyser,
+/// the signature scanner, and the LSP's cursor classifier all decide
+/// "literal parameter list?" here, so they cannot drift apart about what a
+/// quoted or braced word means.
+///
+/// Literal ⟺ the word is a *single* [`TokenType::Str`] (brace-quoted) or
+/// [`TokenType::Esc`] (bareword, or a quoted word with no substitutions)
+/// token. Any `$` or `[` either lexes the word as [`TokenType::Var`] /
+/// [`TokenType::Cmd`] or splits it into several tokens, which is exactly the
+/// computed case.
+///
+/// Verified on tclsh 9.0.4 and 8.6.16:
+///
+/// ```tcl
+/// proc makeargs {} { return {a b} }
+/// proc p [makeargs] { … }   ;# computed — info args p → a b
+/// set params {x y}
+/// proc q $params { … }      ;# computed
+/// proc r "m n" { … }        ;# LITERAL — info args r → m n
+/// proc s {a {b 1}} { … }    ;# literal
+/// ```
+///
+/// `proc r "m n" {…}` is the case the position classifier used to get wrong:
+/// a substitution-free quoted word really does declare `m` and `n`.
+#[must_use]
+pub fn param_word_is_literal(kind: tcl_lexer::TokenType, single_token_word: bool) -> bool {
+    single_token_word && matches!(kind, tcl_lexer::TokenType::Str | tcl_lexer::TokenType::Esc)
+}
+
+/// [`param_word_is_literal`] decided from the parameter-list word's **raw
+/// source text**, for a consumer that holds source rather than a segmented
+/// command (the LSP's cursor-position classifier).
+///
+/// Rather than re-deriving the rule with a character scan — which is how the
+/// position classifier came to call the substitution-free quoted list
+/// `proc r "m n" {…}` computed, contradicting both the oracle and the
+/// analyser — this lexes `word` and applies the *same* token test. A word
+/// that does not lex at all (a stray delimiter mid-edit) is treated as
+/// computed: nothing about it can be trusted as a declaration.
+#[must_use]
+pub fn param_word_text_is_literal(word: &str) -> bool {
+    let Ok(tokens) = tcl_lexer::Lexer::new(word).tokenise_all() else {
+        return false;
+    };
+    let mut words = tokens.iter().filter(|t| {
+        !matches!(
+            t.kind,
+            tcl_lexer::TokenType::Sep
+                | tcl_lexer::TokenType::Eol
+                | tcl_lexer::TokenType::Eof
+                | tcl_lexer::TokenType::Comment
+        )
+    });
+    let Some(first) = words.next() else {
+        // An empty (or whitespace-only) word is the empty parameter list —
+        // literal, and declares nothing.
+        return true;
+    };
+    words.next().is_none() && param_word_is_literal(first.kind, true)
+}
 
 /// Parse a Tcl proc argument list string into [`ParamDef`] records.
 ///
@@ -161,55 +227,15 @@ fn parse_param_list_lenient(param_str: &str) -> Vec<ParamDef> {
 /// Collapse Tcl backslash-newline line continuations to a single space.
 ///
 /// A parameter list is a braced word, and Tcl collapses `\<newline>` (including
-/// `\<CR><LF>` and `\<CR>`) to one space at the command-parse level — before the
-/// value is ever list-parsed, and regardless of any surrounding braces. Every
-/// other backslash escape (`\}`, `\ `, …) is left intact for the list grammar
-/// to interpret, so the following byte is copied through verbatim.
-fn collapse_line_continuations(s: &str) -> String {
-    let bytes = s.as_bytes();
-    let n = bytes.len();
-    let mut out = String::with_capacity(n);
-    let mut i = 0;
-    while i < n {
-        if bytes[i] == b'\\' && i + 1 < n {
-            match bytes[i + 1] {
-                b'\r' if i + 2 < n && bytes[i + 2] == b'\n' => {
-                    out.push(' ');
-                    i += 3;
-                }
-                b'\n' | b'\r' => {
-                    out.push(' ');
-                    i += 2;
-                }
-                // Any other escape: copy the backslash through untouched and
-                // let the next iteration copy the escaped character (which may
-                // be multi-byte UTF-8) so the list grammar can handle it.
-                _ => {
-                    out.push('\\');
-                    i += 1;
-                }
-            }
-        } else {
-            // ASCII fast path plus correct handling of multi-byte UTF-8: copy
-            // the whole char starting at `i`.
-            let ch_len = utf8_char_len(bytes[i]);
-            let end = (i + ch_len).min(n);
-            out.push_str(&s[i..end]);
-            i = end;
-        }
-    }
-    out
-}
-
-/// Byte length of the UTF-8 character whose leading byte is `b`.
-#[inline]
-fn utf8_char_len(b: u8) -> usize {
-    match b {
-        0x00..=0x7f => 1,
-        0xc0..=0xdf => 2,
-        0xe0..=0xef => 3,
-        _ => 4,
-    }
+/// `\<CR><LF>` and `\<CR>`) — plus any spaces and tabs after the newline — to
+/// one space at the command-parse level, before the value is ever list-parsed
+/// and regardless of any surrounding braces. Every other backslash escape
+/// (`\}`, `\ `, …) is left intact for the list grammar to interpret.
+///
+/// That is exactly the shared brace-word pre-pass, so this delegates rather
+/// than carrying a second copy of the rule.
+fn collapse_line_continuations(s: &str) -> Cow<'_, str> {
+    tcl_syntax::backslash::collapse_brace_continuations_str(s)
 }
 
 /// Source spans of each parameter *name*, in declaration order, within the
@@ -416,6 +442,69 @@ fn split_first_whitespace(s: &str) -> Option<(&str, &str)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Issue #1107 — the two views of the literalness rule (from a lexed
+    /// token, and from raw source text) must agree on every shape, or the
+    /// analyser and the LSP's cursor classifier drift apart again.
+    #[test]
+    fn literalness_views_agree_and_match_the_oracle() {
+        // (word, literal?) — verified on tclsh 9.0.4 / 8.6.16.
+        let cases: &[(&str, bool)] = &[
+            // TP — literal lists.
+            ("{a b}", true),
+            ("{a {b 1} args}", true),
+            ("{}", true),
+            ("args", true),
+            (r#""m n""#, true), // `info args r` → `m n`
+            (r#""""#, true),
+            // TN — computed lists.
+            ("[makeargs]", false),
+            ("$params", false),
+            ("${params}", false),
+            (r#""$a $b""#, false),
+            ("a$b", false),
+            ("[a][b]", false),
+        ];
+        for &(word, expect_literal) in cases {
+            assert_eq!(
+                param_word_text_is_literal(word),
+                expect_literal,
+                "text view disagrees for {word:?}"
+            );
+            // The token view, fed the word as the real lexer sees it.
+            let tokens: Vec<tcl_lexer::Token> = tcl_lexer::Lexer::new(word)
+                .tokenise_all()
+                .expect("lexes")
+                .into_iter()
+                .filter(|t| {
+                    !matches!(
+                        t.kind,
+                        tcl_lexer::TokenType::Sep
+                            | tcl_lexer::TokenType::Eol
+                            | tcl_lexer::TokenType::Eof
+                    )
+                })
+                .collect();
+            let token_view = match tokens.as_slice() {
+                [] => true,
+                [only] => param_word_is_literal(only.kind, true),
+                _ => false,
+            };
+            assert_eq!(
+                token_view, expect_literal,
+                "token view disagrees for {word:?} (tokens {tokens:?})"
+            );
+        }
+    }
+
+    /// FP guard — a bare word containing a `"` that is *not* at word start is
+    /// ordinary literal text in Tcl (the quote is only special as the first
+    /// character of a word), so it must stay literal. The character scan this
+    /// replaced rejected any word containing a `"`.
+    #[test]
+    fn literalness_bare_word_with_interior_quote_is_literal() {
+        assert!(param_word_text_is_literal("a\"b"));
+    }
 
     #[test]
     fn empty_input_yields_no_params() {

--- a/rust/tcl-compiler/src/signature_scan/types.rs
+++ b/rust/tcl-compiler/src/signature_scan/types.rs
@@ -57,11 +57,44 @@ pub struct SignatureProc {
     /// Fully-qualified proc name with leading `::`.
     pub qualified_name: String,
     /// Parsed parameter list.
+    ///
+    /// Empty *and* [`Self::params_computed`] set means "unknown", not "none"
+    /// — see that field.
     pub params: Vec<ParamDef>,
+    /// The parameter-list word was **computed**, so the proc's formals are
+    /// unmodelled (issue #1107, the signature-scan twin of
+    /// [`crate::analyser::ProcDef::params_computed`]).
+    ///
+    /// `proc p [makeargs] {…}` / `proc q $params {…}` build the formal list at
+    /// definition time from a run-time value. Reading the unresolved word as a
+    /// one-parameter literal recorded a parameter literally named
+    /// `"[makeargs]"` and told the **cross-file** arity check the proc takes
+    /// exactly one argument — a false `E003` on code both interpreters run
+    /// (`proc makeargs {} {return {a b}}`; `proc p [makeargs] {…}`;
+    /// `info args p` → `a b`; `p 1 2` runs). Consumers must ask
+    /// [`Self::arity`] rather than computing an arity from `params`.
+    pub params_computed: bool,
     /// Source span of the name argument.
     pub name_range: Span,
     /// Source span of the body argument.
     pub body_range: Span,
+}
+
+impl SignatureProc {
+    /// The proc's declared argument arity — or the **abstaining**
+    /// `0..unlimited` when its parameter list was computed
+    /// ([`Self::params_computed`]).
+    ///
+    /// The signature-scan twin of [`crate::analyser::ProcDef::arity`]; both
+    /// tiers abstain identically so a cross-file arity check cannot be
+    /// stricter than the same-file one.
+    #[must_use]
+    pub fn arity(&self) -> tcl_registry::Arity {
+        if self.params_computed {
+            return tcl_registry::Arity::new(0, tcl_registry::Arity::UNLIMITED);
+        }
+        super::arity::arity_of(&self.params)
+    }
 }
 
 /// A class definition recorded by the signature scanner.

--- a/rust/tcl-compiler/src/signature_scan/walker.rs
+++ b/rust/tcl-compiler/src/signature_scan/walker.rs
@@ -153,7 +153,7 @@ pub(super) fn scan(
             _ => {
                 // Definer commands (the class systems, `proc`) dispatch on
                 // registry data, never a hardcoded name list.
-                if !dispatch_definer(head, texts, argv, ns_prefix, ctx) {
+                if !dispatch_definer(head, texts, argv, &cmd.single_token_word, ns_prefix, ctx) {
                     handlers::maybe_handle_import_wrapper(
                         head,
                         texts,
@@ -185,6 +185,7 @@ fn dispatch_definer(
     head: &str,
     texts: &[String],
     argv: &[Token],
+    single_token_word: &[bool],
     ns_prefix: &str,
     ctx: &mut ScanCtx,
 ) -> bool {
@@ -231,7 +232,7 @@ fn dispatch_definer(
         return true;
     }
     if spec.traits.contains(Traits::DEFINES_PROCEDURE) {
-        handlers::handle_proc(texts, argv, ns_prefix, ctx);
+        handlers::handle_proc(texts, argv, single_token_word, ns_prefix, ctx);
         return true;
     }
     false

--- a/rust/tcl-compiler/tests/signature_scan.rs
+++ b/rust/tcl-compiler/tests/signature_scan.rs
@@ -53,6 +53,59 @@ fn top_level_proc() {
     assert_eq!(param_names, ["name"]);
 }
 
+/// Issue #1107 — a **computed** parameter-list word records no formals and
+/// marks them unknown, so a cross-file arity consumer abstains instead of
+/// demanding the one bogus argument `"[makeargs]"` used to look like.
+///
+/// tclsh 9.0.4 / 8.6.16: with `proc makeargs {} {return {a b}}`,
+/// `proc p [makeargs] {…}` then `info args p` → `a b`, and `p 1 2` runs.
+#[test]
+fn computed_parameter_list_is_unknown_not_none() {
+    for (src, qname) in [
+        (
+            "proc makeargs {} { return {a b} }\nproc p [makeargs] { return 1 }",
+            "::p",
+        ),
+        ("set params {x y}\nproc q $params { return 1 }", "::q"),
+        ("proc r ${dyn} { return 1 }", "::r"),
+    ] {
+        let r = run(src);
+        let pd = r.procs.get(qname).expect("proc recorded");
+        assert!(
+            pd.params_computed,
+            "{qname} in {src:?} should be computed, params: {:?}",
+            pd.params
+        );
+        assert!(
+            pd.params.is_empty(),
+            "no formals may be invented: {:?}",
+            pd.params
+        );
+        let arity = pd.arity();
+        assert_eq!(arity.min, 0, "{qname}");
+        assert!(arity.is_unlimited(), "{qname} must abstain on arity");
+    }
+}
+
+/// TP / FP control for #1107 — every *literal* spelling still models its
+/// formals and still produces a real arity, including the substitution-free
+/// quoted list the position classifier used to call computed.
+#[test]
+fn literal_parameter_lists_still_record_formals() {
+    for (src, qname, names) in [
+        ("proc s {a b} {}", "::s", vec!["a", "b"]),
+        ("proc t args {}", "::t", vec!["args"]),
+        ("proc r \"m n\" {}", "::r", vec!["m", "n"]),
+        ("proc u {} {}", "::u", vec![]),
+    ] {
+        let r = run(src);
+        let pd = r.procs.get(qname).expect("proc recorded");
+        assert!(!pd.params_computed, "{src:?} is a literal list");
+        let got: Vec<&str> = pd.params.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(got, names, "{src:?}");
+    }
+}
+
 #[test]
 fn proc_in_namespace_eval() {
     let r = run("namespace eval math { proc add {a b} { return [+ $a $b] } }");

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -2040,24 +2040,16 @@ fn param_word_position(
     let Some(word) = source.get(word_start..word_end) else {
         return ParamListPosition::Outside;
     };
-    if param_word_is_literal(word) {
+    // The literalness rule is shared with the analyser and the signature-scan
+    // tier (issue #1107) so the three cannot disagree about a word. The local
+    // character scan this replaced called the substitution-free quoted list
+    // `proc r "m n" {…}` computed, while the analyser — correctly, per the
+    // oracle (`info args r` → `m n`) — treated it as literal.
+    if tcl_compiler::signature_scan::params::param_word_text_is_literal(word) {
         ParamListPosition::LiteralData
     } else {
         ParamListPosition::Computed
     }
-}
-
-/// Whether a parameter-list word is a literal — data Tcl passes through
-/// without substitution.
-///
-/// A braced word suppresses substitution outright.  A bare word substitutes,
-/// so it only counts as literal when it contains no substitution syntax at
-/// all; a quoted word never counts (its `$` / `[` are live).
-fn param_word_is_literal(word: &str) -> bool {
-    if word.starts_with('{') {
-        return true;
-    }
-    !word.contains(['$', '[', '"', '\\'])
 }
 
 /// Collect every variable name visible at `byte_offset` — the union

--- a/rust/tcl-lsp-core/src/formatting/engine.rs
+++ b/rust/tcl-lsp-core/src/formatting/engine.rs
@@ -345,7 +345,30 @@ fn parse_commands(
 
 // Body / expr / param-list argument identification
 
-/// Mark body / keyword / param-list arguments in place.
+/// Mark body / keyword / param-list arguments in place, entirely from
+/// registry data.
+///
+/// Every classification here comes from the command's spec, so no command
+/// name appears (issue #1186):
+///
+/// * **Bodies** are the [`ArgRole::Body`] positions the spec (or its dynamic
+///   resolver) reports — for `if` and `try` that is the C-Tcl-shaped clause
+///   walk, which knows where a body may legally sit and is the same walk that
+///   drives the E004 shape diagnostic.
+/// * **Block vs inline** comes from [`tcl_registry::ArgPresentation`]: a body
+///   argument is expanded onto its own lines unless the spec declares it
+///   `InlineScript`, which is how `for`'s `start` and
+///   `next` scripts stay on the header line.
+/// * **Structural keywords** are the [`ArgRole::Keyword`] positions the same
+///   resolvers report. That is *structural*, not textual: a data word that
+///   merely spells `else` is not a keyword unless the grammar puts a keyword
+///   there, and `if {1} {a} else then` correctly treats the trailing `then`
+///   as the else-branch body, not a keyword.
+/// * **Parameter lists** and **lambda literals** are their own roles.
+///
+/// Because the lookup goes through the registry, the explicitly-global
+/// spellings (`::if`, `::for`, `::try`) resolve to the same grammar as their
+/// bare forms — a false negative the old literal name comparisons had.
 fn identify_body_args(cmd: &mut ParsedCommand, registry: &CommandRegistry) {
     // {*}-expanded command word: dynamic identity, skip.
     if cmd
@@ -362,22 +385,17 @@ fn identify_body_args(cmd: &mut ParsedCommand, registry: &CommandRegistry) {
     // `cmd.args` is released before the role-driven mutation below.
     let arg_texts: Vec<String> = cmd.args.iter().skip(1).map(|a| a.text.clone()).collect();
 
-    // Formatter-specific `for` override: only the main body (arg 3)
-    // expands; init / next stay inline.
-    if name == "for" && arg_texts.len() >= 4 {
-        if cmd.args[4].is_braced {
-            cmd.args[4].kind = ArgKind::Body;
-        }
-        return;
-    }
-
     let refs: Vec<&str> = arg_texts.iter().map(String::as_str).collect();
     let body_indices = registry.arg_indices_for_role(&name, &refs, ArgRole::Body);
+    let keyword_indices = registry.arg_indices_for_role(&name, &refs, ArgRole::Keyword);
     let param_indices = registry.arg_indices_for_role(&name, &refs, ArgRole::ParamList);
     let lambda_indices = registry.arg_indices_for_role(&name, &refs, ArgRole::LambdaLiteral);
     for idx in body_indices {
         let actual = idx + 1; // +1 for the command-name slot.
-        if actual < cmd.args.len() && cmd.args[actual].is_braced {
+        if actual < cmd.args.len()
+            && cmd.args[actual].is_braced
+            && registry.arg_presentation(&name, &refs, idx).is_block()
+        {
             cmd.args[actual].kind = ArgKind::Body;
         }
     }
@@ -388,18 +406,13 @@ fn identify_body_args(cmd: &mut ParsedCommand, registry: &CommandRegistry) {
         }
     }
 
-    // Structural keywords.
-    if name == "if" {
-        for arg in cmd.args.iter_mut().skip(1) {
-            if matches!(arg.text.as_str(), "then" | "else" | "elseif") {
-                arg.kind = ArgKind::Keyword;
-            }
-        }
-    } else if name == "try" {
-        for arg in cmd.args.iter_mut().skip(1) {
-            if matches!(arg.text.as_str(), "finally" | "on" | "trap") {
-                arg.kind = ArgKind::Keyword;
-            }
+    // Structural keywords (`then` / `elseif` / `else`, `on` / `trap` /
+    // `finally`, `control::do`'s `while`/`until`) — by grammar position, not
+    // by word value.
+    for idx in keyword_indices {
+        let actual = idx + 1;
+        if actual < cmd.args.len() {
+            cmd.args[actual].kind = ArgKind::Keyword;
         }
     }
 
@@ -1930,6 +1943,133 @@ mod tests {
             "foreach i {1 2 3} {\nputs $i\n}\n",
             "foreach i {1 2 3} {\n    puts $i\n}\n",
         );
+    }
+
+    // Issue #1186 — the formatting engine holds no `if` / `try` / `for`
+    // name checks; every layout decision comes from the registry.
+
+    /// TP / FN — C Tcl resolves the absolute global spelling to the same
+    /// command (`namespace which -command ::if` → `::if`), so `::if`,
+    /// `::for`, and `::try` must format exactly like their bare forms. The
+    /// old `name == "if"` comparisons simply did not fire for them.
+    #[test]
+    fn qualified_control_flow_formats_like_the_bare_form() {
+        for (bare, qualified) in [
+            ("if {$x} then {\nputs yes\n} else {\nputs no\n}\n", "::if"),
+            ("for {set i 0} {$i < 3} {incr i} {\nputs $i\n}\n", "::for"),
+            (
+                "try {\nrisky\n} on error {msg opts} {\nputs $msg\n}\n",
+                "::try",
+            ),
+            ("while {$x} {\nincr x\n}\n", "::while"),
+        ] {
+            let head = bare.split_whitespace().next().expect("a head word");
+            let qualified_src = bare.replacen(head, qualified, 1);
+            let want = fmt(bare).replacen(head, qualified, 1);
+            assert_eq!(
+                fmt(&qualified_src),
+                want,
+                "{qualified} formatted differently from {head}"
+            );
+        }
+    }
+
+    /// TP — `for`'s `start` and `next` scripts stay inline while only `body`
+    /// expands. That preference is now registry data
+    /// (`arg_presentation: InlineScript`), not a formatter branch.
+    #[test]
+    fn for_keeps_start_and_next_inline() {
+        check(
+            "for {set i 0} {$i < 3} {incr i} {\nputs $i\n}\n",
+            "for {set i 0} {$i < 3} {incr i} {\n    puts $i\n}\n",
+        );
+    }
+
+    /// TP — every `if` clause shape: implicit and explicit `then`, repeated
+    /// `elseif`, and the bare implicit-else body.
+    #[test]
+    fn every_if_clause_shape_formats() {
+        check(
+            "if {$a} {\nx\n} elseif {$b} then {\ny\n} elseif {$c} {\nz\n} else {\nw\n}\n",
+            "if {$a} {\n    x\n} elseif {$b} then {\n    y\n} elseif {$c} {\n    z\n} else {\n    w\n}\n",
+        );
+        // Implicit else — the trailing bare body is still a body.
+        check(
+            "if {$a} {\nx\n} {\ny\n}\n",
+            "if {$a} {\n    x\n} {\n    y\n}\n",
+        );
+    }
+
+    /// TP — every `try` handler shape.
+    #[test]
+    fn every_try_handler_shape_formats() {
+        let out =
+            fmt("try {\na\n} on error {m o} {\nb\n} trap {POSIX} {m o} {\nc\n} finally {\nd\n}\n");
+        assert!(out.contains("} on error {m o} {"), "{out}");
+        assert!(out.contains("} trap {POSIX} {m o} {"), "{out}");
+        assert!(out.contains("} finally {"), "{out}");
+    }
+
+    /// FP guard — a *data* word that merely spells a keyword is not one. The
+    /// old scan matched by word value across every argument, so `puts else`
+    /// and `lappend l on trap` had their words retyped as keywords. The
+    /// registry answers by grammar position instead, so nothing fires for a
+    /// command whose spec declares no keyword there.
+    #[test]
+    fn keyword_lookalike_data_words_are_not_keywords() {
+        check("puts else\n", "puts else\n");
+        check("lappend l on trap finally\n", "lappend l on trap finally\n");
+        // A user proc named `if` in a *namespace* is a different command
+        // entirely — `ns::if` does not resolve to the built-in (only the
+        // absolute global `::if` does), so its braced argument is left as a
+        // plain word rather than reformatted as a control-flow body.
+        check("ns::if {$a} {\nx\n}\n", "ns::if {$a} {\nx\n}\n");
+    }
+
+    /// FP guard — `if {1} {a} else then`: the trailing `then` sits in the
+    /// else-branch **body** slot, so the grammar walk gives it the body role,
+    /// not `Keyword` (verified against tclsh 8.6 / 9.0.4, which run `a` and
+    /// treat `then` as the else-branch script). The old value-matching scan
+    /// retyped it as a keyword wherever it appeared.
+    #[test]
+    fn then_in_the_else_body_slot_is_not_a_keyword() {
+        let registry = CommandRegistry::build_default();
+        let keywords =
+            registry.arg_indices_for_role("if", &["1", "a", "else", "then"], ArgRole::Keyword);
+        assert_eq!(
+            keywords,
+            vec![2],
+            "only the real `else` at index 2 is a keyword"
+        );
+        // And formatting stays a fixed point over the shape.
+        let once = fmt("if {1} {a} else then\n");
+        assert_eq!(fmt(&once), once, "{once}");
+    }
+
+    /// TN — a dynamic command head (`{*}$cmd`) has no resolvable identity, so
+    /// the engine leaves it alone entirely.
+    #[test]
+    fn dynamic_head_is_left_alone() {
+        check(
+            "{*}$cmd {$x} {\nputs hi\n}\n",
+            "{*}$cmd {$x} {\nputs hi\n}\n",
+        );
+    }
+
+    /// TN — an incomplete/malformed clause must stay semantics-preserving and
+    /// idempotent rather than being reshaped into a guess.
+    #[test]
+    fn malformed_clauses_stay_stable_and_idempotent() {
+        for src in [
+            "if {$a}\n",
+            "if {$a} {\nx\n} elseif\n",
+            "try\n",
+            "for {set i 0} {$i < 3}\n",
+        ] {
+            let once = fmt(src);
+            let twice = fmt(&once);
+            assert_eq!(once, twice, "not idempotent for {src:?}:\n{once}\n{twice}");
+        }
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/formatting/engine.rs
+++ b/rust/tcl-lsp-core/src/formatting/engine.rs
@@ -187,42 +187,34 @@ fn reconstruct_arg(sm: &SourceMap, arg: &CommandArg, braced_vars: bool) -> Strin
     }
 }
 
-/// Normalise whitespace in a braced parameter list, joining
-/// top-level elements with single spaces.
+/// Re-render a parameter list's interior text with single-space separators,
+/// wrapped back in `{…}`.
+///
+/// A parameter list **is** a Tcl list, so it is parsed and re-rendered through
+/// the shared `tcl_syntax::list` implementation (`Tcl_SplitList` +
+/// `Tcl_Merge`) rather than scanned by hand. The hand-rolled scan this
+/// replaced split on whitespace and balanced braces only, so it silently
+/// changed a proc's **arity**: `proc f {a\<newline> b}` has two required
+/// parameters in C Tcl 9 (the backslash-newline is collapsed to a space by
+/// the script pre-pass *before* the word is list-parsed), but re-emitting the
+/// pieces joined by a space produced `{a\ b}` — one *optional* parameter `a`
+/// defaulting to `b` (issue #1196).
+///
+/// Two shared pieces do the work, in the order C Tcl applies them:
+///
+/// 1. [`tcl_syntax::backslash::collapse_brace_continuations_str`] — the
+///    script-level `\<newline>` pre-pass, which applies even inside braces.
+/// 2. [`tcl_syntax::list::normalise_spacing`] — the list split/merge.
+///
+/// A list that does not parse (an unmatched brace or quote — routine while a
+/// signature is being typed) has no canonical rendering, so the original text
+/// is preserved verbatim.
 fn normalise_param_list(text: &str) -> String {
-    let bytes = text.as_bytes();
-    let n = bytes.len();
-    let mut elements: Vec<&str> = Vec::new();
-    let mut i = 0;
-    while i < n {
-        match bytes[i] {
-            b' ' | b'\t' | b'\n' | b'\r' => {
-                i += 1;
-            }
-            b'{' => {
-                let start = i;
-                let mut level = 1;
-                i += 1;
-                while i < n && level > 0 {
-                    match bytes[i] {
-                        b'{' => level += 1,
-                        b'}' => level -= 1,
-                        _ => {}
-                    }
-                    i += 1;
-                }
-                elements.push(&text[start..i]);
-            }
-            _ => {
-                let start = i;
-                while i < n && !matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\r') {
-                    i += 1;
-                }
-                elements.push(&text[start..i]);
-            }
-        }
+    let collapsed = tcl_syntax::backslash::collapse_brace_continuations_str(text);
+    match tcl_syntax::list::normalise_spacing(&collapsed) {
+        Ok(rendered) => format!("{{{rendered}}}"),
+        Err(_) => format!("{{{text}}}"),
     }
-    format!("{{{}}}", elements.join(" "))
 }
 
 // Command parsing
@@ -1946,6 +1938,93 @@ mod tests {
             "proc f {a    b   c} {\nreturn\n}\n",
             "proc f {a b c} {\n    return\n}\n",
         );
+    }
+
+    /// Issue #1196 — the regression this fix exists for. C Tcl 9 collapses the
+    /// backslash-newline in a pre-pass *before* the parameter word is
+    /// list-parsed (even inside braces), so `proc f {a\<newline> b}` has the
+    /// two required parameters `a` and `b`:
+    ///
+    /// ```text
+    /// % proc f {a\
+    ///  b} {return}
+    /// % list [llength [info args f]] [info args f]
+    /// 2 {a b}
+    /// ```
+    ///
+    /// The old hand-rolled scanner emitted `{a\ b}` — one *optional*
+    /// parameter `a` defaulting to `b`, a silent arity change.
+    #[test]
+    fn param_list_backslash_newline_preserves_arity() {
+        let out = fmt("proc f {a\\\n b} {return}\n");
+        assert!(
+            out.starts_with("proc f {a b} {"),
+            "backslash-newline changed the parameter list:\n{out}"
+        );
+        assert!(
+            !out.contains(r"a\ b"),
+            "two parameters were fused into one defaulted parameter:\n{out}"
+        );
+        // The parsed signature agrees: two params, neither defaulted.
+        let params = tcl_compiler::signature_scan::params::parse_param_list("a b");
+        assert_eq!(params.len(), 2);
+        assert!(params.iter().all(|p| !p.has_default));
+    }
+
+    /// FP guard — an *escaped space* really is one element (parameter `a`
+    /// defaulting to `b`), and must stay one element. The renderer re-quotes
+    /// it canonically as `{a b}`, which C Tcl reads identically.
+    #[test]
+    fn param_list_escaped_space_stays_one_parameter() {
+        let out = fmt("proc f {a\\ b c} {return}\n");
+        assert!(
+            out.starts_with("proc f {{a b} c} {"),
+            "escaped-space spec lost its element identity:\n{out}"
+        );
+        let params = tcl_compiler::signature_scan::params::parse_param_list("{a b} c");
+        assert_eq!(params.len(), 2);
+        assert_eq!(params[0].name, "a");
+        assert_eq!(params[0].default_value.as_deref(), Some("b"));
+    }
+
+    /// TN — a parameter list that is not a well-formed Tcl list (mid-edit
+    /// unmatched brace) has no canonical rendering, so the source is
+    /// preserved verbatim rather than rewritten into something else.
+    #[test]
+    fn param_list_malformed_preserved_verbatim() {
+        // `a "b` is a brace-balanced word, so the formatter sees it as the
+        // parameter list — but it is not a well-formed *list* (unmatched
+        // quote), so there is nothing safe to re-render.
+        let out = fmt("proc f {a \"b} {return}\n");
+        assert!(
+            out.contains("{a \"b}"),
+            "malformed parameter list was rewritten:\n{out}"
+        );
+    }
+
+    /// Structure-preserving cases: defaults, nested braces, `args`, empty
+    /// defaults, and Unicode all survive a format round-trip, and formatting
+    /// is idempotent.
+    #[test]
+    fn param_list_shapes_round_trip_and_are_idempotent() {
+        for src in [
+            "proc f {a {b 1} c} {return}\n",
+            "proc f {args} {return}\n",
+            "proc f {{a {}} args} {return}\n",
+            "proc f {{opts {-x 1 -y 2}}} {return}\n",
+            "proc f {naïve {héllo wörld}} {return}\n",
+            "proc f {a\\\r\n b} {return}\n",
+        ] {
+            let once = fmt(src);
+            let twice = fmt(&once);
+            assert_eq!(once, twice, "not idempotent for {src:?}:\n{once}\n{twice}");
+        }
+        // Defaults keep their element boundaries.
+        assert!(fmt("proc f {a   {b 1}   c} {return}\n").starts_with("proc f {a {b 1} c} {"));
+        // A nested-brace default is one element, braces intact.
+        assert!(fmt("proc f {{opts {-x 1}}} {return}\n").starts_with("proc f {{opts {-x 1}}} {"));
+        // CRLF continuations behave exactly like LF ones.
+        assert!(fmt("proc f {a\\\r\n b} {return}\n").starts_with("proc f {a b} {"));
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/inlay_hints.rs
+++ b/rust/tcl-lsp-core/src/inlay_hints.rs
@@ -129,19 +129,20 @@ pub fn inlay_hints(
     let line_index = LineIndex::new(source);
     let mut out = Vec::new();
 
-    if type_hints {
-        if let Some(registry) = registry {
-            collect_type_hints(
-                source,
-                dialect,
-                analysis,
-                registry,
-                range,
-                &line_index,
-                &mut out,
-            );
-        }
-        collect_format_string_hints(source, dialect, range, &line_index, &mut out);
+    if type_hints && let Some(registry) = registry {
+        collect_type_hints(
+            source,
+            dialect,
+            analysis,
+            registry,
+            range,
+            &line_index,
+            &mut out,
+        );
+        // Format-string specifier labels are registry-driven too (which
+        // words carry a conversion string, and in which mini-language), so
+        // they need the registry the same way the type hints do.
+        collect_format_string_hints(source, dialect, registry, range, &line_index, &mut out);
     }
 
     if parameter_hints {
@@ -494,55 +495,30 @@ fn regsub_short(c: char) -> Option<&'static str> {
     })
 }
 
-/// Which format family a command's argument carries, plus the argv index
-/// of the format word.
-enum FormatArg {
-    Sprintf(usize),
-    Clock(usize),
-    Binary(usize),
-    Regsub(usize),
-}
-
-/// Resolve the argv index (and family) of the format/spec word a command
-/// carries, if any.
-fn format_arg(seg: &tcl_compiler::segmenter::SegmentedCommand) -> Option<FormatArg> {
-    let texts = &seg.texts;
-    let head = texts.first()?.as_str();
-    match head {
-        "format" if texts.len() >= 2 => Some(FormatArg::Sprintf(1)),
-        "scan" if texts.len() >= 3 => Some(FormatArg::Sprintf(2)),
-        "binary" if texts.len() >= 3 => match texts[1].as_str() {
-            "format" => Some(FormatArg::Binary(2)),
-            "scan" if texts.len() >= 4 => Some(FormatArg::Binary(3)),
-            _ => None,
-        },
-        "clock" if texts.len() >= 3 && matches!(texts[1].as_str(), "format" | "scan") => {
-            // The format string is the value of the `-format` option.
-            let i = (2..texts.len()).find(|&i| texts[i] == "-format")?;
-            (i + 1 < texts.len()).then(|| FormatArg::Clock(i + 1))
-        }
-        "regsub" if texts.len() >= 4 => {
-            // `regsub ?switches? exp string subSpec ?varName?` — skip option
-            // switches to find the pattern, then the subspec sits two words
-            // past it. /
-            // `regexp_pattern_index` for the no-registry common case.
-            let mut i = 1;
-            while i < texts.len() && texts[i].starts_with('-') && texts[i] != "--" {
-                if texts[i] == "-start" && i + 1 < texts.len() {
-                    i += 2;
-                } else {
-                    i += 1;
-                }
-            }
-            if i < texts.len() && texts[i] == "--" {
-                i += 1;
-            }
-            // `i` now indexes the pattern; the subSpec is two words later.
-            let subspec = i + 2;
-            (subspec < texts.len()).then_some(FormatArg::Regsub(subspec))
-        }
-        _ => None,
-    }
+/// The format-string words of one segmented command, as `(argv index,
+/// family)` pairs, resolved entirely from the registry.
+///
+/// This used to be a second, independent copy of the format-family dispatch
+/// the semantic-token walk carried — `match head { "format" => …, "scan" =>
+/// …, "binary" => …, "clock" => …, "regsub" => … }`, each re-deriving its own
+/// argument layout, and neither firing for the explicitly global spellings
+/// C Tcl resolves to the same commands (issue #1185). Both now read one
+/// registry answer, so they cannot drift.
+fn format_args(
+    seg: &tcl_compiler::segmenter::SegmentedCommand,
+    registry: &CommandRegistry,
+) -> Vec<(usize, tcl_registry::FormatType)> {
+    let Some(head) = seg.texts.first() else {
+        return Vec::new();
+    };
+    let arg_texts: Vec<&str> = seg.texts[1..].iter().map(String::as_str).collect();
+    registry
+        .format_string_args(head, &arg_texts)
+        .into_iter()
+        // `+ 1` converts a post-head argument index into an `argv` index
+        // (`argv[0]` is the command word).
+        .map(|f| (f.index + 1, f.kind))
+        .collect()
 }
 
 /// Byte range of a format word's *content* — the token span with one
@@ -590,6 +566,7 @@ fn push_format_hint(
 fn collect_format_string_hints(
     source: &str,
     dialect: &str,
+    registry: &CommandRegistry,
     range: LspRange,
     line_index: &LineIndex,
     out: &mut Vec<InlayHint>,
@@ -600,69 +577,69 @@ fn collect_format_string_hints(
         tcl_lexer::LexerConfig::for_dialect(dialect),
     );
     for seg in &segments {
-        let Some(found) = format_arg(seg) else {
-            continue;
-        };
-        let idx = match found {
-            FormatArg::Sprintf(i)
-            | FormatArg::Clock(i)
-            | FormatArg::Binary(i)
-            | FormatArg::Regsub(i) => i,
-        };
-        let Some(tok) = seg.argv.get(idx) else {
-            continue;
-        };
-        let Some((cstart, cend)) = format_content_range(source, tok.span) else {
-            continue;
-        };
-        let content = &source[cstart..cend];
-        match found {
-            FormatArg::Sprintf(_) => {
-                for m in SPRINTF_RE.captures_iter(content) {
-                    let whole = m.get(0).expect("group 0");
-                    let type_char = m
-                        .get(6)
-                        .and_then(|g| g.as_str().chars().next())
-                        .unwrap_or('%');
-                    if let Some(label) = sprintf_short(type_char) {
-                        push_format_hint(
-                            label,
-                            cstart + whole.end(),
-                            range,
-                            source,
-                            line_index,
-                            out,
-                        );
+        for (idx, kind) in format_args(seg, registry) {
+            let Some(tok) = seg.argv.get(idx) else {
+                continue;
+            };
+            let Some((cstart, cend)) = format_content_range(source, tok.span) else {
+                continue;
+            };
+            let content = &source[cstart..cend];
+            match kind {
+                tcl_registry::FormatType::Sprintf => {
+                    for m in SPRINTF_RE.captures_iter(content) {
+                        let whole = m.get(0).expect("group 0");
+                        let type_char = m
+                            .get(6)
+                            .and_then(|g| g.as_str().chars().next())
+                            .unwrap_or('%');
+                        if let Some(label) = sprintf_short(type_char) {
+                            push_format_hint(
+                                label,
+                                cstart + whole.end(),
+                                range,
+                                source,
+                                line_index,
+                                out,
+                            );
+                        }
                     }
                 }
-            }
-            FormatArg::Clock(_) => {
-                for m in CLOCK_RE.find_iter(content) {
-                    let letter = m.as_str().chars().last().unwrap_or('%');
-                    if let Some(label) = clock_short(letter) {
-                        push_format_hint(label, cstart + m.end(), range, source, line_index, out);
+                tcl_registry::FormatType::Clock => {
+                    for m in CLOCK_RE.find_iter(content) {
+                        let letter = m.as_str().chars().last().unwrap_or('%');
+                        if let Some(label) = clock_short(letter) {
+                            push_format_hint(
+                                label,
+                                cstart + m.end(),
+                                range,
+                                source,
+                                line_index,
+                                out,
+                            );
+                        }
                     }
                 }
-            }
-            FormatArg::Binary(_) => {
-                collect_binary_hints(content, cstart, range, source, line_index, out);
-            }
-            FormatArg::Regsub(_) => {
-                for m in REGSUB_RE.captures_iter(content) {
-                    let whole = m.get(0).expect("group 0");
-                    let ch = m
-                        .get(1)
-                        .and_then(|g| g.as_str().chars().next())
-                        .unwrap_or(' ');
-                    if let Some(label) = regsub_short(ch) {
-                        push_format_hint(
-                            label,
-                            cstart + whole.end(),
-                            range,
-                            source,
-                            line_index,
-                            out,
-                        );
+                tcl_registry::FormatType::Binary => {
+                    collect_binary_hints(content, cstart, range, source, line_index, out);
+                }
+                tcl_registry::FormatType::Regsub => {
+                    for m in REGSUB_RE.captures_iter(content) {
+                        let whole = m.get(0).expect("group 0");
+                        let ch = m
+                            .get(1)
+                            .and_then(|g| g.as_str().chars().next())
+                            .unwrap_or(' ');
+                        if let Some(label) = regsub_short(ch) {
+                            push_format_hint(
+                                label,
+                                cstart + whole.end(),
+                                range,
+                                source,
+                                line_index,
+                                out,
+                            );
+                        }
                     }
                 }
             }

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -1394,8 +1394,8 @@ fn special_arg_kinds(
         overrides.insert(tok.span.start(), ArgOverride::Kind(TokenKind::Event));
     }
 
-    insert_regex_overrides(seg, registry, head, &mut overrides);
-    insert_format_overrides(seg, &mut overrides);
+    insert_regex_overrides(seg, registry, head, arg_texts, &mut overrides);
+    insert_format_overrides(seg, registry, head, arg_texts, &mut overrides);
 
     // `proc NAME …` — the name argument is a function definition.  Procedure
     // definers come from the registry's `DEFINES_PROCEDURE` trait; a spec
@@ -1445,8 +1445,8 @@ fn special_arg_kinds(
     insert_role_overrides(seg, registry, head, arg_texts, &mut overrides);
     insert_oo_body_overrides(seg, oo_grammar, arg_texts, &mut overrides);
     insert_scoped_subcommand_overrides(seg, scoped_env, head, &mut overrides);
-    insert_multiname_var_overrides(seg, oo_grammar, &mut overrides);
-    insert_ref_var_overrides(seg, &mut overrides);
+    insert_multiname_var_overrides(seg, registry, head, arg_texts, oo_grammar, &mut overrides);
+    insert_ref_var_overrides(seg, registry, head, &mut overrides);
     insert_loop_var_overrides(seg, registry, head, arg_texts, &mut overrides);
     insert_param_list_overrides(seg, registry, head, arg_texts, &mut overrides);
     insert_var_role_overrides(
@@ -1462,15 +1462,17 @@ fn special_arg_kinds(
     overrides
 }
 
-/// Loop-variable specs → variable declarations.  Two sources feed
-/// [`ArgOverride::LoopVarList`] (whose [`collect_loop_var_list`] emits each
-/// name — a bareword or the elements of a braced list — as a variable):
+/// Loop-variable specs → variable declarations.
 ///
-/// * The registry's [`ArgRole::LoopVarList`] (`dict for {k v} …`,
-///   `dict map {k v} …`).
-/// * `foreach` / `lmap`, whose resolvers surface only the `Body` role, so their
-///   (possibly repeated) `v1 l1 ?v2 l2 …?` variable-spec positions — every
-///   other argument before the trailing body — are added here.
+/// Every position comes from the registry's [`ArgRole::LoopVarList`]
+/// ([`ArgOverride::LoopVarList`]'s [`collect_loop_var_list`] then emits each
+/// name — a bareword or the elements of a braced list — as a variable). That
+/// covers both the fixed shape (`dict for {k v} …`, `dict map {k v} …`) and
+/// the repeating one (`foreach v1 l1 ?v2 l2 …? body`, `lmap` likewise), whose
+/// stride and excluded trailing body are declared as a
+/// [`tcl_registry::RepeatedArgLayout`] on the spec rather than re-derived
+/// here from the command's name (issue #1185) — so the explicitly global
+/// `::foreach` is covered too, and a same-named user proc is not.
 ///
 /// Highlighting only: the loop bodies already resolve these reads via the
 /// analyser's scope tracking.
@@ -1481,25 +1483,14 @@ fn insert_loop_var_overrides(
     arg_texts: &[&str],
     overrides: &mut FxHashMap<u32, ArgOverride>,
 ) {
-    let mark = |pos: usize, overrides: &mut FxHashMap<u32, ArgOverride>| {
-        if let Some(tok) = seg.argv.get(pos)
+    // `i` indexes the argument words → `argv[i + 1]`.
+    for i in registry.arg_indices_for_role(head, arg_texts, tcl_registry::ArgRole::LoopVarList) {
+        if let Some(tok) = seg.argv.get(i + 1)
             && matches!(tok.kind, TokenType::Esc | TokenType::Str)
         {
             overrides
                 .entry(tok.span.start())
                 .or_insert(ArgOverride::LoopVarList);
-        }
-    };
-    // Registry-declared specs (`i` indexes the argument words → `argv[i + 1]`).
-    for i in registry.arg_indices_for_role(head, arg_texts, tcl_registry::ArgRole::LoopVarList) {
-        mark(i + 1, overrides);
-    }
-    // `foreach v1 l1 ?v2 l2 …? body` — specs at odd `seg.texts` indices
-    // (`v1` = texts[1], `v2` = texts[3], …) up to but excluding the trailing
-    // body.  Needs at least head + varlist + list + body.
-    if matches!(head, "foreach" | "lmap") && seg.texts.len() >= 4 {
-        for pos in (1..seg.texts.len() - 1).step_by(2) {
-            mark(pos, overrides);
         }
     }
 }
@@ -1539,47 +1530,50 @@ fn insert_param_list_overrides(
     }
 }
 
-/// Highlight the local-variable names bound by a by-reference command whose
-/// registry role marks only the leading (or no) target:
+/// Highlight the local-variable names bound by `upvar`'s
+/// `?level? otherVar localVar ?otherVar localVar ...?` pair tail.
 ///
-/// * `upvar ?level? otherVar localVar ?otherVar localVar ...?` — the *local*
-///   name of each pair.  A leading level word is present when the argument
-///   count is odd, so the first local sits at `seg.texts[3]` (level) or
-///   `seg.texts[2]` (no level), then every other word.
-/// * `namespace upvar ns otherVar localVar ?...?` — the local of each pair,
-///   starting at `seg.texts[4]`.
-/// * `dict update dictVar key varName ?key varName ...? body` — each `varName`
-///   (`seg.texts[4]`, `[6]`, …), excluding the trailing body.
+/// The sibling by-reference shapes — `namespace upvar ns o l ?o l?` and
+/// `dict update dictVar key varName ?key varName? body` — declare their pair
+/// tail as a [`tcl_registry::RepeatedArgLayout`] on their subcommand spec and
+/// are handled generically by [`insert_multiname_var_overrides`]'s
+/// `VarWrite` walk (issue #1185).
+///
+/// `upvar`'s own layout is not a [`tcl_registry::RepeatedArgLayout`] because
+/// the registry already models it more precisely: its
+/// [`tcl_registry::FrameEffectSpec`] declares
+/// [`FrameArgLayout::AliasPairs`] (other/local pairs) with
+/// [`FrameLevelWord::ArityParity`] (C Tcl reads the optional level word off
+/// the *argument count parity*, never off the word's text — `Tcl_UpvarObjCmd`
+/// tests `objc`; tclsh 9.0.4 / 8.6.14 agree).  This reads those two facts, so
+/// the explicitly global `::upvar` behaves like the bare form and a
+/// same-named user proc does not.
 ///
 /// Highlighting only: the analyser already scopes these locals.  A `$`-computed
 /// / array / quoted name is skipped.
 fn insert_ref_var_overrides(
     seg: &tcl_compiler::segmenter::SegmentedCommand,
+    registry: &CommandRegistry,
+    head: &str,
     overrides: &mut FxHashMap<u32, ArgOverride>,
 ) {
-    let sub = seg.texts.get(1).map(String::as_str);
-    let positions: Vec<usize> = match (seg.texts[0].as_str(), sub) {
-        ("upvar", _) => {
-            let n = seg.texts.len() - 1; // argument count
-            if n < 2 {
-                return;
-            }
-            // A level word (present iff the argument count is odd) shifts the
-            // first local from texts[2] to texts[3].
-            let start = if n % 2 == 1 { 3 } else { 2 };
-            (start..seg.texts.len()).step_by(2).collect()
-        }
-        ("namespace", Some("upvar")) if seg.texts.len() >= 5 => {
-            (4..seg.texts.len()).step_by(2).collect()
-        }
-        ("dict", Some("update")) if seg.texts.len() >= 6 => {
-            // varNames are the even words after `dict update dictVar key`, up to
-            // but excluding the trailing body.
-            (4..seg.texts.len() - 1).step_by(2).collect()
-        }
-        _ => return,
+    use tcl_registry::{FrameArgLayout, FrameLevelWord};
+    let Some(effect) = registry.get(head).and_then(|s| s.frame_effect) else {
+        return;
     };
-    for pos in positions {
+    if effect.layout != FrameArgLayout::AliasPairs
+        || effect.level_word != FrameLevelWord::ArityParity
+    {
+        return;
+    }
+    let n = seg.texts.len() - 1; // argument count
+    if n < 2 {
+        return;
+    }
+    // The level word is present exactly when the argument count is odd, and
+    // shifts the first local from texts[2] to texts[3].
+    let start = if n % 2 == 1 { 3 } else { 2 };
+    for pos in (start..seg.texts.len()).step_by(2) {
         if let Some(tok) = seg.argv.get(pos)
             && matches!(tok.kind, TokenType::Esc)
             && !tok.in_quote
@@ -1592,47 +1586,48 @@ fn insert_ref_var_overrides(
     }
 }
 
-/// Highlight the *trailing* name arguments of a multi-name variable-declaring
-/// command that the registry's single leading `VarWrite` role
-/// ([`insert_var_decl_overrides`], index 0) leaves as plain strings:
+/// Highlight the name arguments of a multi-name variable-declaring command —
+/// `global name ?name ...?` (every argument), `variable name ?value name
+/// value ...?` at namespace level (every *even* argument; the interleaved
+/// values are left alone).
 ///
-/// * `global name ?name ...?` — every argument is a declared variable.
-/// * `variable name ?value name value ...?` at namespace level — the name sits
-///   at every *even* argument position (0, 2, …); the interleaved values are
-///   left alone.  (A `variable` *inside a definition body* is a grammar member
-///   handled by [`insert_oo_body_overrides`], where `TclOO` declares every name
-///   and snit declares only the leading one.)
+/// The stride is registry data: each spec declares a
+/// [`tcl_registry::RepeatedArgLayout`] for its `VarWrite` tail, so this reads
+/// [`ArgRole::VarWrite`] positions and never names a command or re-derives a
+/// stride (issue #1185).  That also makes the explicitly global spellings
+/// (`::global`, `::variable`) behave like the bare ones.
+///
+/// A `variable` *inside a definition body* is a grammar member handled by
+/// [`insert_oo_body_overrides`] (where `TclOO` declares every name and snit
+/// only the leading one), so this steps aside whenever a definition-body
+/// grammar is in force.
 ///
 /// Highlighting only: the analyser already tracks every one of these names via
-/// the commands' lowering hooks (`global` / `variable`), so no diagnostic
-/// depends on this.  An array element (`arr(x)`), a `$`-computed name, or a
-/// quoted word is skipped so its inner `$var` sub-tokens survive.
+/// the commands' lowering hooks, so no diagnostic depends on this.  An array
+/// element (`arr(x)`), a `$`-computed name, or a quoted word is skipped so its
+/// inner `$var` sub-tokens survive.
 fn insert_multiname_var_overrides(
     seg: &tcl_compiler::segmenter::SegmentedCommand,
+    registry: &CommandRegistry,
+    head: &str,
+    arg_texts: &[&str],
     oo_grammar: Option<&'static DefinitionBodyGrammar>,
     overrides: &mut FxHashMap<u32, ArgOverride>,
 ) {
-    // Stride over the argument words (`seg.texts[1..]`): 1 = every word is a
-    // name, 2 = names at every other word (name/value pairs).
-    let stride = match seg.texts[0].as_str() {
-        "global" => 1,
-        // `variable` inside a definition body is a grammar member (handled
-        // elsewhere); at namespace level it is name/value pairs.
-        "variable" if oo_grammar.is_none() => 2,
-        _ => return,
-    };
-    let mut i = 1;
-    while i < seg.texts.len() {
-        if let Some(tok) = seg.argv.get(i)
+    if oo_grammar.is_some() {
+        return;
+    }
+    for i in registry.arg_indices_for_role(head, arg_texts, tcl_registry::ArgRole::VarWrite) {
+        let pos = i + 1;
+        if let Some(tok) = seg.argv.get(pos)
             && matches!(tok.kind, TokenType::Esc)
             && !tok.in_quote
-            && is_plain_var_name(&seg.texts[i])
+            && seg.texts.get(pos).is_some_and(|t| is_plain_var_name(t))
         {
             overrides
                 .entry(tok.span.start())
                 .or_insert(ArgOverride::VarDecl);
         }
-        i += stride;
     }
 }
 
@@ -1789,13 +1784,20 @@ fn insert_oo_member_overrides(
     }
 }
 
-/// Regex pattern / regsub-replacement overrides for a `pattern_type ==
-/// Regex` command (option-skipped first positional, and — for `regsub` —
-/// the replacement spec two words later).
+/// Regex-pattern overrides for a `pattern_type == Regex` command.
+///
+/// Both facts are registry data: the *language* from
+/// [`tcl_registry::CommandSpec::pattern_type`], and the *position* from the
+/// [`tcl_registry::ArgRole::Pattern`] role the spec's resolver reports —
+/// which is what shifts the pattern past a call's leading switches without
+/// this walker re-implementing option parsing (issue #1185). The paired
+/// `regsub` replacement template is claimed by
+/// [`insert_format_overrides`] through its own `FormatType::Regsub` family.
 fn insert_regex_overrides(
     seg: &tcl_compiler::segmenter::SegmentedCommand,
     registry: &CommandRegistry,
     head: &str,
+    arg_texts: &[&str],
     overrides: &mut FxHashMap<u32, ArgOverride>,
 ) {
     if !registry
@@ -1805,36 +1807,37 @@ fn insert_regex_overrides(
     {
         return;
     }
-    let args = &seg.texts[1..];
-    let mut idx = 0;
-    while idx < args.len() && args[idx].starts_with('-') && args[idx] != "--" {
-        if args[idx] == "-start" && idx + 1 < args.len() {
-            idx += 2;
-        } else {
+    // Sub-tokenise only the *literal* fragments of the pattern word as regex:
+    // in `"abc$var.*"` the `abc` / `.*` fragments are regex, but `$var` is
+    // variable interpolation Tcl resolves before `regexp` sees it (and
+    // `"[cmd]"` is command substitution, not a char class). Marking the
+    // literal fragments — not the whole word — leaves the `Var` / `Cmd`
+    // fragments to the default classifier, so they render as Tcl and never
+    // overlap the regex sub-tokens.
+    let declared = registry.arg_indices_for_role(head, arg_texts, tcl_registry::ArgRole::Pattern);
+    let positions: Vec<usize> = if declared.is_empty() {
+        // A `Regex` command whose spec does not (yet) declare where its
+        // pattern sits: fall back to the first positional word past the
+        // leading switches, the layout every stock regex command shares.
+        let mut idx = 0;
+        while idx < arg_texts.len() && arg_texts[idx].starts_with('-') && arg_texts[idx] != "--" {
+            if arg_texts[idx] == "-start" && idx + 1 < arg_texts.len() {
+                idx += 2;
+            } else {
+                idx += 1;
+            }
+        }
+        if idx < arg_texts.len() && arg_texts[idx] == "--" {
             idx += 1;
         }
-    }
-    if idx < args.len() && args[idx] == "--" {
-        idx += 1;
-    }
-    // `args[idx]` is the pattern; its whole-word span is `seg.argv[idx + 1]`
-    // (argv[0] is the command head).  Sub-tokenise only the *literal*
-    // fragments of the word as regex: in `"abc$var.*"` the `abc` / `.*`
-    // fragments are regex, but `$var` is variable interpolation Tcl resolves
-    // before `regexp` sees it (and `"[cmd]"` is command substitution, not a
-    // char class).  Marking the literal fragments — not the whole word —
-    // leaves the `Var` / `Cmd` fragments to the default classifier, so they
-    // render as Tcl and never overlap the regex sub-tokens.
-    if let Some(tok) = seg.argv.get(idx + 1) {
-        mark_literal_fragments(seg, tok.span, ArgOverride::RegexPattern, overrides);
-    }
-    // `regsub … exp string subSpec …` — the replacement spec sits two
-    // words after the pattern.  Same literal-fragment treatment (its
-    // backrefs are handled by the regsub-replacement scanner).
-    if head == "regsub"
-        && let Some(tok) = seg.argv.get(idx + 3)
-    {
-        mark_literal_fragments(seg, tok.span, ArgOverride::RegsubReplace, overrides);
+        vec![idx]
+    } else {
+        declared
+    };
+    for idx in positions {
+        if let Some(tok) = seg.argv.get(idx + 1) {
+            mark_literal_fragments(seg, tok.span, ArgOverride::RegexPattern, overrides);
+        }
     }
 }
 
@@ -1880,49 +1883,48 @@ fn mark_regex_source_words(
     }
 }
 
-/// Conversion-string overrides for the format families: `format`/`scan`
-/// (sprintf), `clock format/scan -format`, and `binary format/scan`.
+/// Conversion-string overrides for every format family the registry declares
+/// — sprintf (`format` / `scan`), `clock`'s field string (a fixed argument or
+/// the `-format` option value), `binary`'s cursor spec, and `regsub`'s
+/// replacement template.
+///
+/// Entirely registry-driven ([`CommandRegistry::format_string_args`]): the
+/// *position* comes from the [`tcl_registry::ArgRole::FormatString`] /
+/// `ScanFormat` roles the specs and resolvers declare, and the *family* from
+/// `format_string_type`. No command name appears here, so the explicitly
+/// global spellings (`::format`, `::clock`, …) — which the previous
+/// `match head { "format" => … }` silently missed — resolve identically, and
+/// a same-named user proc or a dynamic head simply declares no family and is
+/// left alone (issue #1185).
+///
+/// The `Regsub` family marks only the word's *literal* fragments, matching
+/// how the regex pattern beside it is treated: a `$var` inside a replacement
+/// template is variable interpolation Tcl performs before `regsub` sees it,
+/// not part of the template.
 fn insert_format_overrides(
     seg: &tcl_compiler::segmenter::SegmentedCommand,
+    registry: &CommandRegistry,
+    head: &str,
+    arg_texts: &[&str],
     overrides: &mut FxHashMap<u32, ArgOverride>,
 ) {
-    let head = &seg.texts[0];
-
-    // `format FMT …` (arg 1) / `scan STR FMT …` (arg 2) — the conversion
-    // string.  Command-name gated (the registry's `format_string_type`
-    // field is never populated).
-    let fmt_word = match head.as_str() {
-        "format" if seg.argv.len() >= 2 => Some(1),
-        "scan" if seg.argv.len() >= 3 => Some(2),
-        _ => None,
-    };
-    if let Some(w) = fmt_word
-        && let Some(tok) = seg.argv.get(w)
-    {
-        overrides.insert(tok.span.start(), ArgOverride::SprintfFormat);
-    }
-
-    // `clock format/scan … -format FMT` — the `-format` option value.
-    if head == "clock"
-        && seg.texts.len() >= 3
-        && matches!(seg.texts[1].as_str(), "format" | "scan")
-        && let Some(i) = (2..seg.texts.len()).find(|&i| seg.texts[i] == "-format")
-        && let Some(tok) = seg.argv.get(i + 1)
-    {
-        overrides.insert(tok.span.start(), ArgOverride::ClockFormat);
-    }
-
-    // `binary format FMT …` (arg 2) / `binary scan VAL FMT …` (arg 3).
-    if head == "binary" && seg.texts.len() >= 3 {
-        let bin_word = match seg.texts[1].as_str() {
-            "format" => Some(2),
-            "scan" if seg.texts.len() >= 4 => Some(3),
-            _ => None,
+    for found in registry.format_string_args(head, arg_texts) {
+        let Some(tok) = seg.argv.get(found.index + 1) else {
+            continue;
         };
-        if let Some(w) = bin_word
-            && let Some(tok) = seg.argv.get(w)
-        {
-            overrides.insert(tok.span.start(), ArgOverride::BinaryFormat);
+        match found.kind {
+            tcl_registry::FormatType::Sprintf => {
+                overrides.insert(tok.span.start(), ArgOverride::SprintfFormat);
+            }
+            tcl_registry::FormatType::Clock => {
+                overrides.insert(tok.span.start(), ArgOverride::ClockFormat);
+            }
+            tcl_registry::FormatType::Binary => {
+                overrides.insert(tok.span.start(), ArgOverride::BinaryFormat);
+            }
+            tcl_registry::FormatType::Regsub => {
+                mark_literal_fragments(seg, tok.span, ArgOverride::RegsubReplace, overrides);
+            }
         }
     }
 }
@@ -1949,15 +1951,22 @@ fn insert_format_overrides(
 /// name — never match; only a literal `-force`-style word does.
 ///
 /// [`OptionSpec`]: tcl_registry::OptionSpec
-/// Whether an option value's role is re-coloured by a later semantic-token pass
-/// (`insert_role_overrides` for `Body`/`Expr`, `insert_var_decl_overrides` for
-/// `VarWrite`).  Such values must not be claimed as `OptionValue` by the option
-/// pass, which runs first and would block the more specific role token.
+/// Whether an option value's role is re-coloured by another semantic-token
+/// pass (`insert_role_overrides` for `Body`/`Expr`, `insert_var_decl_overrides`
+/// for `VarWrite`, `insert_format_overrides` for a conversion string).  Such
+/// values must not be claimed as `OptionValue` by the option pass, which would
+/// block the more specific role token.
 fn role_claimed_by_token_pass(role: Option<tcl_registry::ArgRole>) -> bool {
     use tcl_registry::ArgRole;
     matches!(
         role,
-        Some(ArgRole::Body | ArgRole::Expr | ArgRole::VarWrite)
+        Some(
+            ArgRole::Body
+                | ArgRole::Expr
+                | ArgRole::VarWrite
+                | ArgRole::FormatString
+                | ArgRole::ScanFormat
+        )
     )
 }
 
@@ -2829,13 +2838,27 @@ fn insert_oo_define_keyword_overrides(
     registry: &CommandRegistry,
     overrides: &mut FxHashMap<u32, ArgOverride>,
 ) {
-    if !matches!(seg.texts[0].as_str(), "oo::define" | "oo::objdefine") {
+    let Some(spec) = registry.get(seg.texts[0].as_str()) else {
+        return;
+    };
+    // The *outer-call shape* — "argument 1 is the target, the member call
+    // starts at argument 2" — is what separates a definer-**extension**
+    // command from a definer that *creates* (`oo::class create Name ?body?`
+    // puts a class name at that position, not a member keyword). The
+    // registry already draws exactly that line with the `OoDefine` /
+    // `OoObjdefine` analyser hooks, so this dispatches on them rather than
+    // comparing spellings (issue #1185) — which also means the
+    // explicitly-global `::oo::define` resolves like the bare form.
+    if !matches!(
+        spec.analyser_hook,
+        Some(
+            tcl_registry::hooks::AnalyserHookId::OoDefine
+                | tcl_registry::hooks::AnalyserHookId::OoObjdefine
+        )
+    ) {
         return;
     }
-    let Some(grammar) = registry
-        .get(seg.texts[0].as_str())
-        .and_then(|s| s.definition_body)
-    else {
+    let Some(grammar) = spec.definition_body else {
         return;
     };
     let mut mark_keyword = |pos: usize| {
@@ -9564,6 +9587,127 @@ mod tests {
             failures.is_empty(),
             "semantic-token legend not fully handled:\n  {}",
             failures.join("\n  ")
+        );
+    }
+
+    // Issue #1185 — semantic tokens read command grammar from the registry,
+    // so the explicitly global spellings C Tcl resolves to the same commands
+    // (`namespace which -command ::format` → `::format`) are classified
+    // identically to their bare forms, and a same-named user proc is not.
+
+    /// The decoded token *kinds* of `src`, positions discarded.
+    fn kinds_only(src: &str, registry: &CommandRegistry) -> Vec<u32> {
+        decode_full(src, "tcl", registry)
+            .into_iter()
+            .map(|(_, _, _, kind, _)| kind)
+            .collect()
+    }
+
+    /// Assert that qualifying a command head with a leading `::` changes
+    /// nothing but the head itself: the qualified stream must *end with* the
+    /// bare stream's kinds (the qualified head contributes one extra
+    /// namespace-separator token at the front), so every argument is
+    /// classified identically.
+    fn assert_qualified_matches_bare(
+        bare: &str,
+        head: &str,
+        qualified: &str,
+        registry: &CommandRegistry,
+    ) {
+        let bare_kinds = kinds_only(bare, registry);
+        let qualified_kinds = kinds_only(&bare.replacen(head, qualified, 1), registry);
+        assert!(
+            qualified_kinds.len() >= bare_kinds.len(),
+            "{qualified} produced fewer tokens than {head}: \
+             {qualified_kinds:?} vs {bare_kinds:?}"
+        );
+        let tail = &qualified_kinds[qualified_kinds.len() - bare_kinds.len()..];
+        assert_eq!(
+            tail,
+            &bare_kinds[..],
+            "{qualified} classified its arguments differently from {head}"
+        );
+    }
+
+    #[test]
+    fn qualified_format_family_classifies_like_the_bare_form() {
+        let r = reg();
+        for (bare, head, qualified) in [
+            ("format {%08x} 42\n", "format", "::format"),
+            ("scan $s {%d %d} a b\n", "scan", "::scan"),
+            ("binary format c3 {1 2 3}\n", "binary", "::binary"),
+            ("binary scan $v c3 out\n", "binary", "::binary"),
+            ("clock format $t -format {%Y-%m-%d}\n", "clock", "::clock"),
+            ("clock scan $s -format {%Y}\n", "clock", "::clock"),
+            ("regsub -all e $s {[&]} out\n", "regsub", "::regsub"),
+        ] {
+            assert_qualified_matches_bare(bare, head, qualified, &r);
+        }
+    }
+
+    #[test]
+    fn qualified_grammar_commands_classify_like_the_bare_form() {
+        let r = reg();
+        for (bare, head, qualified) in [
+            ("foreach {a b} {1 2} { puts $a }\n", "foreach", "::foreach"),
+            ("lmap x $l { expr {$x} }\n", "lmap", "::lmap"),
+            ("upvar 1 src local\n", "upvar", "::upvar"),
+            ("upvar src local\n", "upvar", "::upvar"),
+            ("global aa bb cc\n", "global", "::global"),
+            ("variable x 1 y 2\n", "variable", "::variable"),
+            (
+                "oo::define C method m {args} { return $args }\n",
+                "oo::define",
+                "::oo::define",
+            ),
+            (
+                "oo::objdefine $o method m {} { return }\n",
+                "oo::objdefine",
+                "::oo::objdefine",
+            ),
+            (
+                "namespace upvar ::ns o1 l1 o2 l2\n",
+                "namespace",
+                "::namespace",
+            ),
+            ("dict update d k1 v1 k2 v2 { puts $v1 }\n", "dict", "::dict"),
+        ] {
+            assert_qualified_matches_bare(bare, head, qualified, &r);
+        }
+    }
+
+    /// FP guard — a user proc in another namespace that happens to share a
+    /// built-in's tail name does not inherit its grammar, and data words that
+    /// merely look like format strings are not painted as ones.
+    #[test]
+    fn same_named_user_command_does_not_inherit_grammar() {
+        let r = reg();
+        // `ns::format` is a different command; its argument stays a plain
+        // string, so no format-specifier sub-tokens appear.
+        let user = decode_full("ns::format {%08x} 42\n", "tcl", &r);
+        let builtin = decode_full("format {%08x} 42\n", "tcl", &r);
+        assert!(
+            builtin.len() > user.len(),
+            "the built-in must produce specifier sub-tokens the user proc does not:\n\
+             builtin={builtin:?}\nuser={user:?}"
+        );
+        // A data word that spells a format string is untouched.
+        assert_eq!(
+            kinds_only("puts {%08x}\n", &r),
+            kinds_only("puts {plain}\n", &r)
+        );
+    }
+
+    /// TN — a `{*}`-expanded (dynamic) head has no resolvable identity, so no
+    /// grammar is applied to its arguments.
+    #[test]
+    fn dynamic_head_gets_no_format_grammar() {
+        let r = reg();
+        let dynamic = decode_full("{*}$cmd {%08x} 42\n", "tcl", &r);
+        let builtin = decode_full("format {%08x} 42\n", "tcl", &r);
+        assert!(
+            dynamic.len() < builtin.len(),
+            "a dynamic head must not get format sub-tokens: {dynamic:?}"
         );
     }
 

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -637,7 +637,19 @@ fn w123_command(message: &str) -> Option<&str> {
 /// defaulted one raises the minimum past the defaulted ones, since a
 /// caller cannot supply a later position without also supplying every
 /// position before it).
-fn proc_arity(params: &[tcl_compiler::signature_scan::types::ParamDef]) -> (usize, usize) {
+/// A **computed** parameter list (`proc p [makeargs] {…}`, `proc q $params
+/// {…}`) declares an unknown number of formals, so this abstains with the
+/// fully-open `0..MAX` rather than reading the empty recorded list as "takes
+/// no arguments" — which drew a false cross-file `E003` on code both
+/// interpreters run (issue #1107). Same abstention rule as the same-file
+/// [`tcl_compiler::analyser::ProcDef::arity`].
+fn proc_arity(
+    params: &[tcl_compiler::signature_scan::types::ParamDef],
+    params_computed: bool,
+) -> (usize, usize) {
+    if params_computed {
+        return (0, usize::MAX);
+    }
     let arity = tcl_compiler::signature_scan::arity::arity_of(params);
     let max = if arity.is_unlimited() {
         usize::MAX
@@ -686,7 +698,7 @@ pub fn project_command_arities(
             {
                 let entry = acc.entry(tail.to_owned()).or_default();
                 if sig.id.kind == ItemKind::Proc {
-                    entry.0.push(proc_arity(&sig.params));
+                    entry.0.push(proc_arity(&sig.params, sig.params_computed));
                 } else {
                     entry.1 = true;
                 }
@@ -5631,6 +5643,66 @@ mod tests {
             arity_code("none 1\n"),
             e003(),
             "1 arg to a 0-param proc → too many"
+        );
+    }
+
+    /// Issue #1107 — a proc whose parameter-list word is **computed** has
+    /// unknown formals, so the *cross-file* arity check must abstain. Before
+    /// the fix the analyser correctly recorded no formals but `ItemSig` did
+    /// not carry the "unknown, not none" flag, so the cross-file table read
+    /// the empty list as "takes no arguments" and every call drew a false
+    /// `E003` — on code both tclsh 9.0.4 and 8.6.16 run
+    /// (`proc makeargs {} {return {a b}}`; `proc p [makeargs] {…}`;
+    /// `info args p` → `a b`; `p 1 2` → runs).
+    #[test]
+    fn cross_file_arity_abstains_for_computed_parameter_lists() {
+        let db = TclDatabase::default();
+        let cfg = AnalyserConfig::new(
+            &db,
+            Vec::new(),
+            NonAsciiMode::Default,
+            Vec::new(),
+            None,
+            None,
+        );
+        let b = SourceFile::new(
+            &db,
+            "proc makeargs {} { return {a b} }\n\
+             proc computed [makeargs] { return 1 }\n\
+             set params {x y}\n\
+             proc dollar $params { return 1 }\n\
+             proc literal {a b} { return 1 }\n"
+                .to_owned(),
+            "tcl8.6".to_owned(),
+            None,
+        );
+        let arity_code = |src: &str| -> Option<String> {
+            let a = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned(), None);
+            let proj = Project::new(&db, vec![a, b]);
+            project_diagnostics(&db, a, cfg, proj)
+                .iter()
+                .find(|d| d.code == DiagCode::E002 || d.code == DiagCode::E003)
+                .map(|d| d.code.to_string())
+        };
+        // FP guards — every call count is acceptable for an unknown signature.
+        for call in [
+            "computed\n",
+            "computed 1\n",
+            "computed 1 2\n",
+            "dollar 1 2\n",
+        ] {
+            assert_eq!(
+                arity_code(call),
+                None,
+                "computed parameter list must abstain, not draw an arity error for {call:?}"
+            );
+        }
+        // TP control — a literal list in the same file still checks arity.
+        assert_eq!(arity_code("literal 1 2\n"), None, "2 args → ok");
+        assert_eq!(
+            arity_code("literal 1 2 3\n"),
+            Some("E003".to_owned()),
+            "a literal list is still checked"
         );
     }
 

--- a/rust/tcl-lsp-server/tests/e2e/editor_features.rs
+++ b/rust/tcl-lsp-server/tests/e2e/editor_features.rs
@@ -472,6 +472,75 @@ fn test_already_formatted_is_stable() {
     }
 }
 
+/// Issue #1186 — the formatting engine consumes registry grammar, so the
+/// absolute global spellings C Tcl resolves to the same commands
+/// (`namespace which -command ::if` → `::if`) format identically to their
+/// bare forms. The old `name == "if"` / `"for"` / `"try"` comparisons did
+/// not fire for them at all.
+#[test]
+fn test_formatting_qualified_control_flow_matches_bare_form() {
+    let mut lsp = Lsp::tcl();
+    for (bare_src, head, qualified) in [
+        (
+            "if {$x} then {\nputs yes\n} else {\nputs no\n}\n",
+            "if",
+            "::if",
+        ),
+        (
+            "for {set i 0} {$i < 3} {incr i} {\nputs $i\n}\n",
+            "for",
+            "::for",
+        ),
+        (
+            "try {\nrisky\n} on error {msg opts} {\nputs $msg\n}\n",
+            "try",
+            "::try",
+        ),
+    ] {
+        let bare_uri = unique_uri("tcl");
+        lsp.open_ready(&bare_uri, bare_src);
+        let bare = full_text(&lsp.formatting(&bare_uri, 4, true)).expect("formatting edit");
+
+        let qualified_src = bare_src.replacen(head, qualified, 1);
+        let q_uri = unique_uri("tcl");
+        lsp.open_ready(&q_uri, &qualified_src);
+        let qualified_out = full_text(&lsp.formatting(&q_uri, 4, true)).expect("formatting edit");
+
+        assert_eq!(
+            qualified_out,
+            bare.replacen(head, qualified, 1),
+            "{qualified} formatted differently from {head}"
+        );
+    }
+}
+
+/// Issue #1186 — `for`'s `start` / `next` scripts stay on the header line
+/// (registry `ArgPresentation::InlineScript`) while only the body expands,
+/// and range formatting agrees with whole-document formatting.
+#[test]
+fn test_range_formatting_keeps_for_header_inline() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, "for {set i 0} {$i < 3} {incr i} {\nputs $i\n}\n");
+    let range = json!({
+        "start": { "line": 0, "character": 0 },
+        "end": { "line": 2, "character": 1 },
+    });
+    let edits = lsp.range_formatting(&uri, range, 4);
+    let arr = edits.as_array().cloned().unwrap_or_default();
+    let text: String = arr
+        .iter()
+        .filter_map(|e| e["newText"].as_str())
+        .collect::<Vec<_>>()
+        .join("");
+    if !text.is_empty() {
+        assert!(
+            text.contains("for {set i 0} {$i < 3} {incr i} {"),
+            "for header was split across lines: {text:?}"
+        );
+    }
+}
+
 /// Issue #1196 — formatting must never change a proc's arity. C Tcl 9
 /// collapses the backslash-newline in a pre-pass before the parameter word is
 /// list-parsed (even inside braces), so this proc has two required

--- a/rust/tcl-lsp-server/tests/e2e/editor_features.rs
+++ b/rust/tcl-lsp-server/tests/e2e/editor_features.rs
@@ -472,6 +472,47 @@ fn test_already_formatted_is_stable() {
     }
 }
 
+/// Issue #1196 — formatting must never change a proc's arity. C Tcl 9
+/// collapses the backslash-newline in a pre-pass before the parameter word is
+/// list-parsed (even inside braces), so this proc has two required
+/// parameters; the old formatter emitted `{a\ b}`, which is one *optional*
+/// parameter `a` defaulting to `b`.
+#[test]
+fn test_formatting_preserves_proc_arity_across_backslash_newline() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, "proc f {a\\\n b} {return}\n");
+    let formatted = full_text(&lsp.formatting(&uri, 4, true)).expect("formatting produced no edit");
+    assert!(
+        formatted.contains("proc f {a b} {"),
+        "arity-changing reflow: {formatted:?}"
+    );
+    assert!(
+        !formatted.contains("a\\ b"),
+        "two parameters fused into one defaulted parameter: {formatted:?}"
+    );
+}
+
+/// Issue #1196 — the same document formatted twice is a fixed point, and the
+/// escaped-space form (genuinely one element) keeps its identity.
+#[test]
+fn test_formatting_param_lists_are_idempotent() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, "proc f {a\\ b   {c 1}   d} {return}\n");
+    let once = full_text(&lsp.formatting(&uri, 4, true)).expect("formatting produced no edit");
+    assert!(
+        once.contains("proc f {{a b} {c 1} d} {"),
+        "escaped-space element lost: {once:?}"
+    );
+
+    let uri2 = unique_uri("tcl");
+    lsp.open_ready(&uri2, &once);
+    if let Some(twice) = full_text(&lsp.formatting(&uri2, 4, true)) {
+        assert_eq!(twice, once, "formatting is not idempotent");
+    }
+}
+
 #[test]
 fn test_range_formatting_returns_edits() {
     let mut lsp = Lsp::tcl();

--- a/rust/tcl-registry/src/arg_role.rs
+++ b/rust/tcl-registry/src/arg_role.rs
@@ -182,6 +182,8 @@ impl ArgRole {
         Self::Value,
         Self::Subcommand,
         Self::OptionTerminator,
+        Self::FormatString,
+        Self::ScanFormat,
         Self::Channel,
         Self::Index,
         Self::Keyword,

--- a/rust/tcl-registry/src/commands/tcl/binary_.rs
+++ b/rust/tcl-registry/src/commands/tcl/binary_.rs
@@ -196,6 +196,10 @@ static SUBCOMMANDS: &[SubCommand] = &[
         detail: "Build a binary string from Tcl values, laid out by a cursor-driven format specification.",
         synopsis: "binary format formatString ?arg ...?",
         pure: true,
+        // The cursor-driven field string: index 0 after the subcommand word,
+        // family `Binary` (#1185).
+        arg_roles: &[(0, ArgRole::FormatString)],
+        format_string_type: Some(FormatType::Binary),
         // S110 binary source: the return type marks the result a byte array —
         // tclsh 8.6.14-verified (`tcl::unsupported::representation
         // [binary format c* {1 2}]` → bytearray). Not stamped `Rebinarifies`:
@@ -261,6 +265,7 @@ static SUBCOMMANDS: &[SubCommand] = &[
             ),
         ],
         arg_role_resolver: Some(binary_scan_arg_roles),
+        format_string_type: Some(FormatType::Binary),
         ..SubCommand::DEFAULT
     },
 ];
@@ -272,8 +277,11 @@ static SUBCOMMANDS: &[SubCommand] = &[
 /// false-fire W210 on the unmodelled tail.  Mirrors the plain `scan`
 /// command's own resolver (`scan_arg_roles` in `scan_.rs`).
 fn binary_scan_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
-    (2..args.len())
-        .filter_map(|i| u8::try_from(i).ok().map(|i| (i, ArgRole::VarWrite)))
+    // Index 1 (after the `scan` subcommand word) is the field string itself;
+    // marking it `ScanFormat` is what lets the LSP locate it without naming
+    // `binary` (#1185).
+    std::iter::once((1u8, ArgRole::ScanFormat))
+        .chain((2..args.len()).filter_map(|i| u8::try_from(i).ok().map(|i| (i, ArgRole::VarWrite))))
         .collect()
 }
 

--- a/rust/tcl-registry/src/commands/tcl/clock_.rs
+++ b/rust/tcl-registry/src/commands/tcl/clock_.rs
@@ -35,7 +35,15 @@ const FORMS: &[FormSpec] = &[FormSpec {
 static FORMAT_OPTIONS: &[OptionSpec] = &[
     OptionSpec {
         name: "-format",
-        value: OptionValue::value("format"),
+        // The value is the `clock` field string, not a generic value: the
+        // `ArgRole::FormatString` role is what lets the LSP find it without
+        // naming `clock` (issue #1185); the *family* comes from the
+        // subcommand's `format_string_type`.
+        value: OptionValue::Takes(OptionArg {
+            role: ArgRole::FormatString,
+            hint: "format",
+            ..OptionArg::DEFAULT
+        }),
         detail: "strftime-style output format string (default \"%a %b %d %H:%M:%S %Z %Y\").",
         dialects: None,
         aliases: &[],
@@ -85,7 +93,13 @@ static SCAN_OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-format",
-        value: OptionValue::value("format"),
+        // As for `clock format` — the role locates the field string, the
+        // subcommand's `format_string_type` names its family.
+        value: OptionValue::Takes(OptionArg {
+            role: ArgRole::ScanFormat,
+            hint: "format",
+            ..OptionArg::DEFAULT
+        }),
         detail: "Explicit input format string for strict parsing; omitting it falls back to the deprecated free-form scanner.",
         dialects: Some(DialectSet::TCL85_PLUS),
         aliases: &[],
@@ -274,6 +288,11 @@ static SUBCOMMANDS: &[SubCommand] = &[
         detail: "Format a time value.",
         synopsis: "clock format timeVal ?-option value ...?",
         options: FORMAT_OPTIONS,
+        // Populates the previously-dead `format_string_type` field: the
+        // family of this call's format string. Paired with the
+        // `FormatString` / `ScanFormat` argument role that locates the
+        // word, it is the whole registry answer the LSP needs (#1185).
+        format_string_type: Some(FormatType::Clock),
         pure: true,
         return_type: Some(TclType::String),
         ..SubCommand::DEFAULT
@@ -321,6 +340,11 @@ static SUBCOMMANDS: &[SubCommand] = &[
         synopsis: "clock scan inputString ?-option value ...?",
         return_type: Some(TclType::Int),
         options: SCAN_OPTIONS,
+        // Populates the previously-dead `format_string_type` field: the
+        // family of this call's format string. Paired with the
+        // `FormatString` / `ScanFormat` argument role that locates the
+        // word, it is the whole registry answer the LSP needs (#1185).
+        format_string_type: Some(FormatType::Clock),
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/commands/tcl/dict.rs
+++ b/rust/tcl-registry/src/commands/tcl/dict.rs
@@ -437,6 +437,14 @@ static SUBCOMMANDS: &[SubCommand] = &[
         detail: "Map dictionary keys to variables, execute body, write back.",
         synopsis: "dict update dictionaryVariable key varName ?...? body",
         arg_role_resolver: Some(dict_last_arg_body),
+        // `dictionaryVariable key varName ?key varName ...? body` — each
+        // `varName` is a local the body sees, at every other index from 2
+        // (after the subcommand word), with the trailing body excluded
+        // (issue #1185).
+        repeated_args: &[RepeatedArgLayout {
+            exclude_trailing: 1,
+            ..RepeatedArgLayout::strided(ArgRole::VarWrite, 2, 2)
+        }],
         arg_types: &[(
             0,
             ArgTypeHint {

--- a/rust/tcl-registry/src/commands/tcl/dict.rs
+++ b/rust/tcl-registry/src/commands/tcl/dict.rs
@@ -440,10 +440,15 @@ static SUBCOMMANDS: &[SubCommand] = &[
         // `dictionaryVariable key varName ?key varName ...? body` — each
         // `varName` is a local the body sees, at every other index from 2
         // (after the subcommand word), with the trailing body excluded
-        // (issue #1185).
+        // (issue #1185).  `LoopVarList`, not `VarWrite`: the binding happens
+        // once before the body *and only when the key is present* (tclsh: an
+        // absent key leaves varName unset), so SSA must not model it as an
+        // unconditional def — the key-aware read-before-set harvester owns
+        // the conditional semantics, and a `VarWrite` def here both defeated
+        // its suppression and would hide the genuine absent-key warning.
         repeated_args: &[RepeatedArgLayout {
             exclude_trailing: 1,
-            ..RepeatedArgLayout::strided(ArgRole::VarWrite, 2, 2)
+            ..RepeatedArgLayout::strided(ArgRole::LoopVarList, 2, 2)
         }],
         arg_types: &[(
             0,

--- a/rust/tcl-registry/src/commands/tcl/for_.rs
+++ b/rust/tcl-registry/src/commands/tcl/for_.rs
@@ -53,6 +53,15 @@ pub fn spec() -> CommandSpec {
             (2, ArgRole::Body),
             (3, ArgRole::Body),
         ],
+        // `start` and `next` are genuine Tcl scripts — the semantic role above
+        // is correct and every analysis consumer must keep walking them — but
+        // a formatter keeps them on the `for` header line, expanding only the
+        // trailing `body`.  Declaring the preference here is what lets the
+        // formatting engine drop its `name == "for"` branch (issue #1186).
+        arg_presentation: &[
+            (0, ArgPresentation::InlineScript),
+            (2, ArgPresentation::InlineScript),
+        ],
         lowering_hook: Some(crate::hooks::LoweringHookId::For),
         return_type: Some(TclType::String),
         arg_types: &[(

--- a/rust/tcl-registry/src/commands/tcl/foreach_.rs
+++ b/rust/tcl-registry/src/commands/tcl/foreach_.rs
@@ -46,6 +46,16 @@ fn foreach_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
 }
 
 /// Command spec for `foreach`.
+/// `?varlist list?...` repeats before the trailing body: the variable specs
+/// sit at every other argument from 0, and the body — the last word — is
+/// excluded.  The role resolver marks that body; this declares the repeating
+/// head so no consumer has to re-derive the stride from the command's name
+/// (issue #1185).
+static REPEATED: &[RepeatedArgLayout] = &[RepeatedArgLayout {
+    exclude_trailing: 1,
+    ..RepeatedArgLayout::strided(ArgRole::LoopVarList, 0, 2)
+}];
+
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "foreach",
@@ -64,6 +74,7 @@ pub fn spec() -> CommandSpec {
         // "wrong # args").
         arity: Arity::stepped(3, Arity::UNLIMITED, 2),
         arg_role_resolver: Some(foreach_arg_roles),
+        repeated_args: REPEATED,
         // Index 0 here is a fixed key, not a real source-position argument
         // index: the CFG builder lowers a `foreach` header to a synthetic
         // `Statement::Call` whose `args` are *only* the list arguments (one

--- a/rust/tcl-registry/src/commands/tcl/format_.rs
+++ b/rust/tcl-registry/src/commands/tcl/format_.rs
@@ -608,6 +608,11 @@ pub fn spec() -> CommandSpec {
         // Index 0 is the %-string (the §6 argument-DSL rung: `%b` is
         // 8.6+, `%ll…u` is 9.0+).
         arg_roles: &[(0, ArgRole::FormatString)],
+        // The family of this command's format string; the
+        // `ArgRole::FormatString` role above locates the word. Together
+        // they are the whole registry answer, so the LSP's format
+        // highlighting and inlay hints name no command (#1185).
+        format_string_type: Some(FormatType::Sprintf),
         arity: Arity::at_least(1),
         return_type: Some(TclType::String),
         const_fold_versioned: Some(fold_format),

--- a/rust/tcl-registry/src/commands/tcl/global_.rs
+++ b/rust/tcl-registry/src/commands/tcl/global_.rs
@@ -55,6 +55,10 @@ const FORMS: &[FormSpec] = &[
 ];
 
 /// Command spec for `global`.
+/// `global name ?name ...?` declares *every* argument, not just the first:
+/// the unbounded tail a fixed index table cannot express (issue #1185).
+static REPEATED: &[RepeatedArgLayout] = &[RepeatedArgLayout::every(ArgRole::VarWrite, 0)];
+
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "global",
@@ -84,6 +88,7 @@ pub fn spec() -> CommandSpec {
         // synopsis text.
         arity: Arity::any(),
         arg_roles: &[(0, ArgRole::VarWrite)],
+        repeated_args: REPEATED,
         assigns_variable_at: Some(0),
         return_type: Some(TclType::String),
         side_effects: &[SideEffect {

--- a/rust/tcl-registry/src/commands/tcl/lmap_.rs
+++ b/rust/tcl-registry/src/commands/tcl/lmap_.rs
@@ -46,6 +46,16 @@ fn lmap_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
 }
 
 /// Command spec for `lmap`.
+/// `?varlist list?...` repeats before the trailing body: the variable specs
+/// sit at every other argument from 0, and the body — the last word — is
+/// excluded.  The role resolver marks that body; this declares the repeating
+/// head so no consumer has to re-derive the stride from the command's name
+/// (issue #1185).
+static REPEATED: &[RepeatedArgLayout] = &[RepeatedArgLayout {
+    exclude_trailing: 1,
+    ..RepeatedArgLayout::strided(ArgRole::LoopVarList, 0, 2)
+}];
+
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "lmap",
@@ -86,6 +96,7 @@ pub fn spec() -> CommandSpec {
         // `at_least(3)`, which missed the odd/even parity `foreach` enforces.
         arity: Arity::stepped(3, Arity::UNLIMITED, 2),
         arg_role_resolver: Some(lmap_arg_roles),
+        repeated_args: REPEATED,
         // See `foreach`'s identical comment — index 0 is a fixed key read by
         // `shimmer::use_site::foreach_header_expected_type`, not a real
         // source-position argument index.

--- a/rust/tcl-registry/src/commands/tcl/namespace_.rs
+++ b/rust/tcl-registry/src/commands/tcl/namespace_.rs
@@ -657,6 +657,10 @@ static SUBCOMMANDS: &[SubCommand] = &[
         // elsewhere (tclsh 9.0.4 / 8.6.16: inside `namespace eval ::rel`,
         // `namespace upvar kid v alias` binds `::rel::kid::v`).
         arg_roles: &[(0, ArgRole::NamespaceName)],
+        // `namespace upvar NS otherVar myVar ?otherVar myVar ...?` — the
+        // *local* name of each pair, from index 2 after the subcommand word
+        // (issue #1185).
+        repeated_args: &[RepeatedArgLayout::strided(ArgRole::VarWrite, 2, 2)],
         creates_scope_alias: true,
         dialects: Some(DialectSet::TCL85_PLUS),
         analyser_hook: Some(crate::hooks::AnalyserHookId::NamespaceUpvar),

--- a/rust/tcl-registry/src/commands/tcl/regsub_.rs
+++ b/rust/tcl-registry/src/commands/tcl/regsub_.rs
@@ -39,6 +39,7 @@ const FORMS: &[FormSpec] = &[FormSpec {
 /// with no dialect/version gating of its own.
 fn regsub_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
     let mut i = 0;
+    let mut has_command = false;
     while i < args.len() {
         let a = args[i];
         if a == "--" {
@@ -46,6 +47,7 @@ fn regsub_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
             break;
         }
         if a.starts_with('-') {
+            has_command |= a == "-command";
             i += 1;
             if a == "-start" && i < args.len() {
                 i += 1;
@@ -55,12 +57,27 @@ fn regsub_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
         break;
     }
     // exp (i), string (i+1), subSpec (i+2), varName (i+3).
-    let var_idx = i + 3;
-    (var_idx < args.len())
-        .then(|| u8::try_from(var_idx).ok().map(|v| (v, ArgRole::VarWrite)))
-        .flatten()
-        .into_iter()
-        .collect()
+    let mut roles: Vec<(u8, ArgRole)> = Vec::new();
+    let push = |roles: &mut Vec<(u8, ArgRole)>, idx: usize, role: ArgRole| {
+        if idx < args.len()
+            && let Ok(idx) = u8::try_from(idx)
+        {
+            roles.push((idx, role));
+        }
+    };
+    // The regular expression itself — the leading-option shift means a static
+    // slot cannot place it, which is why the LSP used to re-scan the options
+    // itself (issue #1185).
+    push(&mut roles, i, ArgRole::Pattern);
+    // The replacement template, whose `\&` / `\N` backreferences are the
+    // `FormatType::Regsub` mini-language.  With `-command` the same position
+    // is a callback prefix instead (handled by `regsub_command_prefixes`), so
+    // it carries no template role then.
+    if !has_command {
+        push(&mut roles, i + 2, ArgRole::FormatString);
+    }
+    push(&mut roles, i + 3, ArgRole::VarWrite);
+    roles
 }
 
 /// `regsub -command ?switches? exp string cmdPrefix ?varName?` (Tcl 9.0+, TIP
@@ -239,6 +256,9 @@ pub fn spec() -> CommandSpec {
         // pattern validation.
         pattern_type: Some(PatternType::Regex),
         arg_role_resolver: Some(regsub_arg_roles),
+        // The `subSpec` replacement template's own mini-language; the
+        // `ArgRole::FormatString` the resolver puts on that word locates it.
+        format_string_type: Some(FormatType::Regsub),
         command_prefix_resolver: Some(regsub_command_prefixes),
         forms: FORMS,
         analyser_hook: Some(crate::hooks::AnalyserHookId::RegexPatternCapture),

--- a/rust/tcl-registry/src/commands/tcl/scan_.rs
+++ b/rust/tcl-registry/src/commands/tcl/scan_.rs
@@ -245,6 +245,10 @@ pub fn spec() -> CommandSpec {
         forms: FORMS,
         side_effects: SIDE_EFFECTS,
         arg_role_resolver: Some(scan_arg_roles),
+        // `scan`'s conversion string is the same printf-style mini-language
+        // `format` writes; `scan_arg_roles` puts `ArgRole::ScanFormat` at the
+        // word (#1185).
+        format_string_type: Some(FormatType::Sprintf),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/tcl/variable_.rs
+++ b/rust/tcl-registry/src/commands/tcl/variable_.rs
@@ -78,6 +78,10 @@ const FORMS: &[FormSpec] = &[
 /// `variable` with `global`). Tcl 9.0's variable.html differs from 8.6's
 /// only in NAME-line capitalisation and doc-anchor formatting; Tcl 9.1's is
 /// byte-for-byte identical to 9.0's.
+/// `variable name ?value name value ...?` — the *name* sits at every even
+/// argument; the interleaved values are ordinary data (issue #1185).
+static REPEATED: &[RepeatedArgLayout] = &[RepeatedArgLayout::strided(ArgRole::VarWrite, 0, 2)];
+
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "variable",
@@ -115,6 +119,7 @@ pub fn spec() -> CommandSpec {
         // case; see FORMS above for the version-split synopsis text.
         arity: Arity::any(),
         arg_roles: &[(0, ArgRole::VarWrite)],
+        repeated_args: REPEATED,
         assigns_variable_at: Some(0),
         return_type: Some(TclType::String),
         side_effects: &[SideEffect {

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -74,6 +74,7 @@ pub mod hooks;
 pub mod hover;
 pub mod mathfunc;
 pub mod patterns;
+pub mod presentation;
 pub mod private_tcl_namespaces;
 pub mod profile_defaults;
 pub mod profile_queries;
@@ -123,6 +124,7 @@ pub mod prelude {
         OptionSpec, OptionValue, OptionValueHook, OptionValueOutcome,
     };
     pub use crate::patterns::{FormatType, PatternType};
+    pub use crate::presentation::ArgPresentation;
     pub use crate::scoped::{ScopedCommand, ScopedCommandEnv};
     pub use crate::side_effects::{ConnectionSide, SideEffect, SideEffectTarget, StorageType};
     pub use crate::spec::{
@@ -151,6 +153,7 @@ pub use dialects::{
 pub use frame_effect::{FrameArgLayout, FrameEffectSpec, FrameLevel, FrameLevelWord};
 pub use hover::ArgValue;
 pub use patterns::{FormatType, PatternType};
+pub use presentation::ArgPresentation;
 pub use profile_queries::{ProfileQueries, VendorSurface};
 pub use registry::{CommandRegistry, MethodDispatchKind, ResolvedCall, ResolvedTerminator};
 pub use spec::{

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -80,6 +80,7 @@ pub mod profile_defaults;
 pub mod profile_queries;
 pub mod profiles;
 pub mod registry;
+pub mod repeated;
 pub mod scoped;
 pub mod side_effects;
 pub mod snapshot;
@@ -125,6 +126,7 @@ pub mod prelude {
     };
     pub use crate::patterns::{FormatType, PatternType};
     pub use crate::presentation::ArgPresentation;
+    pub use crate::repeated::RepeatedArgLayout;
     pub use crate::scoped::{ScopedCommand, ScopedCommandEnv};
     pub use crate::side_effects::{ConnectionSide, SideEffect, SideEffectTarget, StorageType};
     pub use crate::spec::{
@@ -155,7 +157,10 @@ pub use hover::ArgValue;
 pub use patterns::{FormatType, PatternType};
 pub use presentation::ArgPresentation;
 pub use profile_queries::{ProfileQueries, VendorSurface};
-pub use registry::{CommandRegistry, MethodDispatchKind, ResolvedCall, ResolvedTerminator};
+pub use registry::{
+    CommandRegistry, FormatStringArg, MethodDispatchKind, ResolvedCall, ResolvedTerminator,
+};
+pub use repeated::RepeatedArgLayout;
 pub use spec::{
     BytePayloadSpec, CaseListSpec, CommandSpec, ContextGate, DefaultFormFirstWord, ObjectClassSpec,
     OoContextFact, SubCommand, SubSubCommand, VersionedArgValue,

--- a/rust/tcl-registry/src/presentation.rs
+++ b/rust/tcl-registry/src/presentation.rs
@@ -1,0 +1,73 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Presentation roles — how a *formatter* should lay an argument out.
+//!
+//! Distinct from [`crate::ArgRole`], which says what an argument **is**
+//! semantically. Two arguments can share a semantic role and still want
+//! different presentation: `for start test next body` has three script
+//! arguments ([`crate::ArgRole::Body`] at indices 0, 2, and 3), but only the
+//! trailing `body` is conventionally expanded onto its own indented lines —
+//! `start` and `next` stay on the `for` line:
+//!
+//! ```tcl
+//! for {set i 0} {$i < 3} {incr i} {
+//!     puts $i
+//! }
+//! ```
+//!
+//! Erasing the semantic distinction (calling `start` / `next` something other
+//! than `Body`) would break every analysis consumer that walks scripts, and
+//! keeping a `name == "for"` branch in the formatter is the command-specific
+//! knowledge the registry contract forbids. So the layout preference is its
+//! own registry fact, declared beside the roles it refines (issue #1186).
+//!
+//! Only *overrides* are declared. Every `Body` argument is a
+//! [`ArgPresentation::BlockScript`] by default, so a spec that has nothing
+//! unusual to say declares nothing.
+
+/// How a formatter should lay out one argument, refining its
+/// [`crate::ArgRole`].
+///
+/// `#[non_exhaustive]` on purpose: this is the extension point for future
+/// presentation facts (a keyword that must start a line, an argument list
+/// that wraps, …), and a consumer must keep working when one arrives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
+pub enum ArgPresentation {
+    /// A script expanded onto its own indented lines, with the opening brace
+    /// left on the command's line (K&R). The default for every
+    /// [`crate::ArgRole::Body`] argument.
+    #[default]
+    BlockScript,
+    /// A script kept **inline** on the command's own line, however long it
+    /// is. `for`'s `start` and `next` scripts: expanding them would turn a
+    /// one-line loop header into four lines and is not how any Tcl in the
+    /// wild is written.
+    InlineScript,
+}
+
+impl ArgPresentation {
+    /// Whether an argument in this presentation is expanded onto its own
+    /// lines. The one place that answers the question, so the formatter's
+    /// block decision cannot drift from the declaration.
+    #[must_use]
+    pub const fn is_block(self) -> bool {
+        matches!(self, Self::BlockScript)
+    }
+}

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -2778,10 +2778,22 @@ mod tests {
         // TP — each `dict update` varName, with the trailing body excluded.
         // Index 1 is the dictionary variable itself, which the subcommand
         // already declared (it is read on entry and written back after the
-        // body); the repeated layout adds the pair locals at 3 and 5.
+        // body).  The pair locals answer as `LoopVarList` — bound once
+        // before the body, and only when the key is present — NOT as
+        // `VarWrite`: an unconditional SSA def both defeated the key-aware
+        // read-before-set suppression and would hide the genuine
+        // absent-key warning.
         assert_eq!(
             vars("dict", &["update", "d", "k1", "v1", "k2", "v2", "{body}"]),
-            vec![1, 3, 5]
+            vec![1]
+        );
+        assert_eq!(
+            reg.arg_indices_for_role(
+                "dict",
+                &["update", "d", "k1", "v1", "k2", "v2", "{body}"],
+                ArgRole::LoopVarList
+            ),
+            vec![3, 5]
         );
         // TP — `foreach` / `lmap` variable specs, body excluded.
         for name in ["foreach", "lmap"] {

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -1380,6 +1380,58 @@ impl CommandRegistry {
         out
     }
 
+    /// How a formatter should **present** argument `index` of a call to
+    /// `name` — the layout fact that refines the argument's semantic
+    /// [`ArgRole`] (issue #1186).
+    ///
+    /// Returns the declared override, or [`ArgPresentation::BlockScript`]
+    /// (the default) when the spec says nothing. `for`'s `start` and `next`
+    /// scripts answer [`ArgPresentation::InlineScript`], which is how the
+    /// formatting engine keeps them on the header line without a
+    /// `name == "for"` branch.
+    ///
+    /// Resolves through [`Self::get`], so the explicitly-global spelling
+    /// `::for` answers identically to the bare `for` — the false negative
+    /// the formatter's literal name comparison had. A command the registry
+    /// does not know (a user proc, a dynamic head) answers the default,
+    /// which is what leaves such a call formatted like any other command.
+    ///
+    /// `args` is the post-name argument list, in the same shape
+    /// [`Self::arg_indices_for_role`] takes (subcommand first), so a
+    /// subcommand-dispatching call resolves against the subcommand's own
+    /// table with the same `+1` offset.
+    #[must_use]
+    pub fn arg_presentation(
+        &self,
+        name: &str,
+        args: &[&str],
+        index: usize,
+    ) -> crate::presentation::ArgPresentation {
+        use crate::presentation::ArgPresentation;
+        let Some(spec) = self.get(name) else {
+            return ArgPresentation::default();
+        };
+        // A dispatching subcommand owns the positions after its own word.
+        if !spec.subcommands.is_empty()
+            && let Some(sub) = args.first().and_then(|word| spec.resolve_subcommand(word))
+            && index > 0
+            && let Ok(sub_index) = u8::try_from(index - 1)
+        {
+            return sub
+                .arg_presentation
+                .iter()
+                .find(|(i, _)| *i == sub_index)
+                .map_or_else(ArgPresentation::default, |(_, p)| *p);
+        }
+        let Ok(idx) = u8::try_from(index) else {
+            return ArgPresentation::default();
+        };
+        spec.arg_presentation
+            .iter()
+            .find(|(i, _)| *i == idx)
+            .map_or_else(ArgPresentation::default, |(_, p)| *p)
+    }
+
     /// The declared roles of the argument positions a call has **not**
     /// filled — the optional trailing words a caller could still append.
     ///
@@ -2522,6 +2574,50 @@ mod tests {
         let kw = reg.arg_indices_for_role("try", &args, ArgRole::Keyword);
         // on@1, finally@5
         assert_eq!(kw, vec![1, 5], "{kw:?}");
+    }
+
+    /// Issue #1186 — `for`'s three script arguments share the semantic
+    /// [`ArgRole::Body`], and the *presentation* fact is what separates the
+    /// trailing body (block-expanded) from `start` / `next` (inline).
+    #[test]
+    fn for_declares_inline_presentation_for_start_and_next() {
+        use crate::presentation::ArgPresentation;
+        let reg = CommandRegistry::build_default();
+        let args = ["{set i 0}", "{$i < 3}", "{incr i}", "{puts $i}"];
+        // Semantics unchanged: all three scripts are still bodies.
+        assert_eq!(
+            reg.arg_indices_for_role("for", &args, ArgRole::Body),
+            vec![0, 2, 3]
+        );
+        // Presentation splits them.
+        assert_eq!(
+            reg.arg_presentation("for", &args, 0),
+            ArgPresentation::InlineScript
+        );
+        assert_eq!(
+            reg.arg_presentation("for", &args, 2),
+            ArgPresentation::InlineScript
+        );
+        assert_eq!(
+            reg.arg_presentation("for", &args, 3),
+            ArgPresentation::BlockScript
+        );
+        assert!(reg.arg_presentation("for", &args, 3).is_block());
+        // The absolute global spelling resolves to the same spec.
+        assert_eq!(
+            reg.arg_presentation("::for", &args, 0),
+            ArgPresentation::InlineScript
+        );
+        // A command with nothing to say answers the block default, and so
+        // does one the registry does not know at all.
+        assert_eq!(
+            reg.arg_presentation("while", &["{$x}", "{body}"], 1),
+            ArgPresentation::BlockScript
+        );
+        assert_eq!(
+            reg.arg_presentation("no::such::command", &["{a}"], 0),
+            ArgPresentation::BlockScript
+        );
     }
 
     // -- Option-value roles (Phase 1) ------------------------------------

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -193,6 +193,25 @@ fn all_dialect_command_names() -> &'static FxHashSet<&'static str> {
     })
 }
 
+/// Append the indices covered by `layouts` whose declared role equals `role`.
+///
+/// `tail_len` is the number of argument words the layouts index over (the
+/// whole post-head list, or the words after a subcommand word), and `offset`
+/// is added to each result to convert back into an absolute `args` index —
+/// the same `+1`-for-the-subcommand-word convention every other role source
+/// here uses.
+fn push_repeated_roles(
+    out: &mut Vec<usize>,
+    layouts: &[crate::repeated::RepeatedArgLayout],
+    tail_len: usize,
+    offset: usize,
+    role: ArgRole,
+) {
+    for layout in layouts.iter().filter(|l| l.role == role) {
+        out.extend(layout.indices(tail_len).into_iter().map(|i| i + offset));
+    }
+}
+
 /// Append the `args` indices consumed by value-taking options whose value role
 /// (primary or secondary) equals `role`.
 ///
@@ -1311,8 +1330,18 @@ impl CommandRegistry {
     /// Resolve argument indices for a given role.
     ///
     /// For subcommand-based commands (e.g. `dict create`), pass the
-    /// subcommand as the first element of `args`. This is the Rust
-    /// equivalent of `arg_indices_for_role()`.
+    /// subcommand as the first element of `args`.
+    ///
+    /// Three role sources feed this, in the order the registry contract
+    /// documents: a dynamic `arg_role_resolver`, the static `arg_roles`
+    /// table, and — for the unbounded regular tails a fixed table cannot
+    /// express — the [`RepeatedArgLayout`]s of
+    /// [`CommandSpec::repeated_args`] (issue #1185).  The repeated layouts
+    /// are *additive*: a spec may pin its leading words with `arg_roles`
+    /// (`namespace upvar`'s leading namespace word) and still declare the
+    /// repeating pair tail.
+    ///
+    /// [`RepeatedArgLayout`]: crate::repeated::RepeatedArgLayout
     #[must_use]
     pub fn arg_indices_for_role(&self, name: &str, args: &[&str], role: ArgRole) -> Vec<usize> {
         // `CommandPrefix` positions (with their appended arities) are owned by
@@ -1352,9 +1381,13 @@ impl CommandRegistry {
                         .map(|(i, _)| *i as usize + 1),
                 );
             }
+            // Repeated tails, over the words after the subcommand word.
+            push_repeated_roles(&mut out, sub.repeated_args, n.saturating_sub(1), 1, role);
             // Value-taking options on the subcommand (scan past the sub word).
             push_option_value_roles(&mut out, sub.options, args, 1, role);
             out.retain(|&idx| idx < n);
+            out.sort_unstable();
+            out.dedup();
             return out;
         }
 
@@ -1374,9 +1407,70 @@ impl CommandRegistry {
                     .map(|(i, _)| *i as usize),
             );
         }
+        // Repeated tails (`global a b c`, `upvar ?level? o l o l`).
+        push_repeated_roles(&mut out, spec.repeated_args, n, 0, role);
         // Value-taking options carry roles at their (dynamic) value positions.
         push_option_value_roles(&mut out, spec.options, args, 0, role);
         out.retain(|&idx| idx < n);
+        out.sort_unstable();
+        out.dedup();
+        out
+    }
+
+    /// The format-string words of **one concrete call**: which argument
+    /// positions carry a conversion / field string, and which mini-language
+    /// each is written in.
+    ///
+    /// The single registry answer to a question the LSP used to answer by
+    /// matching command spellings — `match head { "format" => …, "scan" =>
+    /// …, "clock" => …, "binary" => …, "regsub" => … }` in both the
+    /// semantic-token walk and the inlay-hint collector, each with its own
+    /// copy of the argument layout (issue #1185). It combines the two facts
+    /// the registry already models:
+    ///
+    /// * **Where** — the [`ArgRole::FormatString`] / [`ArgRole::ScanFormat`]
+    ///   positions of the call, resolved through
+    ///   [`Self::arg_indices_for_role`], so a fixed index (`format`), a
+    ///   resolver-computed one (`scan`, `regsub` past its switches), a
+    ///   subcommand-relative one (`binary format`), and an **option value**
+    ///   (`clock format … -format FMT`) all answer the same way.
+    /// * **Which language** — [`CommandSpec::format_string_type`], overridden
+    ///   by [`SubCommand::format_string_type`] when a subcommand dispatches
+    ///   (`clock format` ⇒ `Clock`, `binary scan` ⇒ `Binary`).
+    ///
+    /// Because the head is resolved through [`Self::get`], the explicitly
+    /// global spellings (`::format`, `::clock`, …) answer identically to the
+    /// bare ones — the false negative the spelling tests had. A command with
+    /// no declared family answers empty, so a same-named user proc, an
+    /// unknown command, or a dynamic head is never misread.
+    ///
+    /// `args` is the post-head argument list, subcommand first, the same
+    /// shape [`Self::arg_indices_for_role`] takes; returned indices are into
+    /// that list.
+    #[must_use]
+    pub fn format_string_args(&self, name: &str, args: &[&str]) -> Vec<FormatStringArg> {
+        let Some(spec) = self.get(name) else {
+            return Vec::new();
+        };
+        // A dispatching subcommand's family wins over the parent's.
+        let sub = (!spec.subcommands.is_empty())
+            .then(|| args.first().and_then(|word| spec.resolve_subcommand(word)))
+            .flatten();
+        let Some(kind) = sub
+            .and_then(|s| s.format_string_type)
+            .or(spec.format_string_type)
+        else {
+            return Vec::new();
+        };
+        let mut out: Vec<FormatStringArg> = Vec::new();
+        for (role, scan) in [(ArgRole::FormatString, false), (ArgRole::ScanFormat, true)] {
+            out.extend(
+                self.arg_indices_for_role(name, args, role)
+                    .into_iter()
+                    .map(|index| FormatStringArg { index, kind, scan }),
+            );
+        }
+        out.sort_by_key(|f| f.index);
         out
     }
 
@@ -1844,6 +1938,26 @@ pub struct ResolvedTerminator {
     /// `0` for every subcommand-scoped match (no subcommand currently
     /// needs the reservation) and for any form without one declared.
     pub reserved_trailing_words: usize,
+}
+
+/// One format-string word of a concrete call — the answer
+/// [`CommandRegistry::format_string_args`] returns.
+///
+/// The two facts a consumer needs are deliberately separate: `kind` names the
+/// mini-language (a `clock` field string and a `format` %-string share
+/// neither syntax nor version gates), while `scan` says which *direction* it
+/// is written in (`format` and `scan` share the `Sprintf` family but not its
+/// conversion set — `%b` is 8.6+ in both, `%p` is a `format`-only Tcl 9
+/// addition). Collapsing them would make a consumer guess one from the other.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FormatStringArg {
+    /// 0-based index into the post-head argument list.
+    pub index: usize,
+    /// Which mini-language the word is written in.
+    pub kind: crate::patterns::FormatType,
+    /// The word is a **scan**-direction spec ([`ArgRole::ScanFormat`]) rather
+    /// than a format-direction one ([`ArgRole::FormatString`]).
+    pub scan: bool,
 }
 
 /// Which `TclOO` method-context keyword a command word is — the answer
@@ -2574,6 +2688,123 @@ mod tests {
         let kw = reg.arg_indices_for_role("try", &args, ArgRole::Keyword);
         // on@1, finally@5
         assert_eq!(kw, vec![1, 5], "{kw:?}");
+    }
+
+    /// Issue #1185 — the format families answer from registry data alone:
+    /// the *position* from the `FormatString` / `ScanFormat` roles, the
+    /// *family* from `format_string_type` (previously never populated).
+    #[test]
+    fn format_string_args_cover_every_family() {
+        use crate::patterns::FormatType;
+        let reg = CommandRegistry::build_default();
+        let found = |name: &str, args: &[&str]| -> Vec<(usize, FormatType, bool)> {
+            reg.format_string_args(name, args)
+                .into_iter()
+                .map(|f| (f.index, f.kind, f.scan))
+                .collect()
+        };
+        // TP — a fixed argument index.
+        assert_eq!(
+            found("format", &["%d", "7"]),
+            vec![(0, FormatType::Sprintf, false)]
+        );
+        // TP — a resolver-computed index, scan direction.
+        assert_eq!(
+            found("scan", &["$s", "%d", "v"]),
+            vec![(1, FormatType::Sprintf, true)]
+        );
+        // TP — subcommand-relative indices.
+        assert_eq!(
+            found("binary", &["format", "c3", "$l"]),
+            vec![(1, FormatType::Binary, false)]
+        );
+        assert_eq!(
+            found("binary", &["scan", "$v", "c3", "out"]),
+            vec![(2, FormatType::Binary, true)]
+        );
+        // TP — an *option value* position, both directions.
+        assert_eq!(
+            found("clock", &["format", "$t", "-format", "%Y"]),
+            vec![(3, FormatType::Clock, false)]
+        );
+        assert_eq!(
+            found("clock", &["scan", "$s", "-format", "%Y"]),
+            vec![(3, FormatType::Clock, true)]
+        );
+        // TP — `regsub`'s replacement template, shifted past its switches.
+        assert_eq!(
+            found("regsub", &["-all", "--", "e", "$s", "X", "out"]),
+            vec![(4, FormatType::Regsub, false)]
+        );
+        // FN guard — the explicitly global spellings resolve identically.
+        assert_eq!(
+            found("::format", &["%d", "7"]),
+            found("format", &["%d", "7"])
+        );
+        assert_eq!(
+            found("::clock", &["format", "$t", "-format", "%Y"]),
+            found("clock", &["format", "$t", "-format", "%Y"])
+        );
+        // TN — a subcommand with no format string, and an unknown command.
+        assert!(found("binary", &["encode", "hex", "$d"]).is_empty());
+        assert!(found("clock", &["seconds"]).is_empty());
+        assert!(found("no::such::command", &["%d"]).is_empty());
+        assert!(found("puts", &["%d"]).is_empty());
+        // TN — `regsub -command` makes that position a callback, not a
+        // template, so it declares no replacement word.
+        assert!(
+            !found("regsub", &["-command", "--", "e", "$s", "cb"])
+                .iter()
+                .any(|(i, _, _)| *i == 3)
+        );
+    }
+
+    /// Issue #1185 — the repeated argument tails a fixed index table cannot
+    /// express now answer through the ordinary role query.
+    #[test]
+    fn repeated_layouts_answer_through_arg_indices_for_role() {
+        let reg = CommandRegistry::build_default();
+        let vars =
+            |name: &str, args: &[&str]| reg.arg_indices_for_role(name, args, ArgRole::VarWrite);
+        // TP — every argument of `global`.
+        assert_eq!(vars("global", &["a", "b", "c"]), vec![0, 1, 2]);
+        // TP — every *even* argument of `variable` (names, not values).
+        assert_eq!(vars("variable", &["x", "1", "y", "2"]), vec![0, 2]);
+        // TP — the local of each `namespace upvar` pair, past the namespace.
+        assert_eq!(
+            vars("namespace", &["upvar", "::ns", "o1", "l1", "o2", "l2"]),
+            vec![3, 5]
+        );
+        // TP — each `dict update` varName, with the trailing body excluded.
+        // Index 1 is the dictionary variable itself, which the subcommand
+        // already declared (it is read on entry and written back after the
+        // body); the repeated layout adds the pair locals at 3 and 5.
+        assert_eq!(
+            vars("dict", &["update", "d", "k1", "v1", "k2", "v2", "{body}"]),
+            vec![1, 3, 5]
+        );
+        // TP — `foreach` / `lmap` variable specs, body excluded.
+        for name in ["foreach", "lmap"] {
+            assert_eq!(
+                reg.arg_indices_for_role(
+                    name,
+                    &["{a b}", "$l1", "c", "$l2", "{body}"],
+                    ArgRole::LoopVarList
+                ),
+                vec![0, 2],
+                "{name}"
+            );
+        }
+        // FN guard — the explicitly global spellings resolve identically.
+        assert_eq!(vars("::global", &["a", "b"]), vars("global", &["a", "b"]));
+        // TN — a command with no repeated tail is unaffected.
+        assert_eq!(vars("puts", &["a", "b"]), Vec::<usize>::new());
+        // FP guard — a short call names nothing it should not.
+        assert_eq!(vars("global", &[]), Vec::<usize>::new());
+        assert_eq!(
+            reg.arg_indices_for_role("foreach", &["{body}"], ArgRole::LoopVarList),
+            Vec::<usize>::new()
+        );
     }
 
     /// Issue #1186 — `for`'s three script arguments share the semantic

--- a/rust/tcl-registry/src/repeated.rs
+++ b/rust/tcl-registry/src/repeated.rs
@@ -1,0 +1,189 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Repeated argument-role layouts — a role that recurs at a fixed stride.
+//!
+//! A family of Tcl commands takes an unbounded, *regular* argument tail: a
+//! name at every word (`global a b c`), a name at every other word
+//! (`variable n v n v`), a name/value pair after a fixed prefix
+//! (`namespace upvar NS o l o l`), or a repeating group with a trailing body
+//! excluded (`foreach v1 l1 v2 l2 body`, `dict update d k v k v body`).
+//!
+//! Neither [`crate::CommandSpec::arg_roles`] (a fixed index table) nor an
+//! `arg_role_resolver` closure is a good fit: the table cannot express an
+//! unbounded tail, and a closure per command is data the registry cannot
+//! inspect, document, serialise, or exhaustively test. Every LSP consumer
+//! that needed one of these layouts therefore re-derived it by hand from the
+//! command's *name* — three separate copies of the stride arithmetic in the
+//! semantic-token walk alone (issue #1185).
+//!
+//! [`RepeatedArgLayout`] is that layout as data. It feeds
+//! [`crate::CommandRegistry::arg_indices_for_role`] like any other role
+//! source, so a consumer asking "which arguments are variable names" simply
+//! gets the right answer for `global` without knowing what `global` is.
+
+use crate::arg_role::ArgRole;
+
+/// A role that recurs at a fixed stride over a command's argument tail.
+///
+/// Indices are 0-based over the **post-head** argument list, and — for a
+/// layout declared on a [`crate::SubCommand`] — over the words *after* the
+/// subcommand word, matching every other per-subcommand index in the
+/// registry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RepeatedArgLayout {
+    /// The role assigned at each covered position.
+    pub role: ArgRole,
+    /// First covered index.
+    pub start: u8,
+    /// Distance between covered positions. `1` covers every word from
+    /// `start`; `2` covers every other one (the name of a name/value pair).
+    pub stride: u8,
+    /// How many words at the **end** of the argument list the layout does
+    /// not cover — the trailing body of `foreach` / `dict update`.
+    pub exclude_trailing: u8,
+    /// The command accepts one *optional* leading word before `start` whose
+    /// presence is signalled by nothing but the argument count — `upvar`'s
+    /// `?level?`.
+    ///
+    /// When set, the repeating group is anchored to the **end** of the
+    /// covered range rather than to `start`, so the layout shifts right by
+    /// one exactly when the count says the optional word was supplied.
+    /// `upvar a b` (2 words, no level) binds the local at index 1;
+    /// `upvar 1 a b` (3 words, a level) binds it at index 2 — and both are
+    /// the same declaration.
+    pub optional_leading_word: bool,
+}
+
+impl RepeatedArgLayout {
+    /// A default-shaped layout: every word from `start`, nothing excluded,
+    /// no optional leading word.
+    #[must_use]
+    pub const fn every(role: ArgRole, start: u8) -> Self {
+        Self {
+            role,
+            start,
+            stride: 1,
+            exclude_trailing: 0,
+            optional_leading_word: false,
+        }
+    }
+
+    /// A layout covering every `stride`th word from `start`.
+    #[must_use]
+    pub const fn strided(role: ArgRole, start: u8, stride: u8) -> Self {
+        Self {
+            role,
+            start,
+            stride,
+            exclude_trailing: 0,
+            optional_leading_word: false,
+        }
+    }
+
+    /// The covered argument indices for a call supplying `arg_count` words.
+    ///
+    /// Returns an empty vector for a degenerate declaration (`stride == 0`)
+    /// or a call too short to reach `start`, so a caller never has to
+    /// pre-check either.
+    #[must_use]
+    pub fn indices(self, arg_count: usize) -> Vec<usize> {
+        let stride = usize::from(self.stride);
+        if stride == 0 {
+            return Vec::new();
+        }
+        let start = usize::from(self.start);
+        let end = arg_count.saturating_sub(usize::from(self.exclude_trailing));
+        if end <= start {
+            return Vec::new();
+        }
+        // The optional leading word is invisible except in the count: anchor
+        // the group to the last covered slot and read the shift back off it.
+        let shift = if self.optional_leading_word {
+            (end - start - 1) % stride
+        } else {
+            0
+        };
+        (start + shift..end).step_by(stride).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_word_covers_the_whole_tail() {
+        // `global a b c`
+        let l = RepeatedArgLayout::every(ArgRole::VarWrite, 0);
+        assert_eq!(l.indices(3), vec![0, 1, 2]);
+        assert_eq!(l.indices(0), Vec::<usize>::new());
+    }
+
+    #[test]
+    fn strided_covers_name_value_pairs() {
+        // `variable n v n v`
+        let l = RepeatedArgLayout::strided(ArgRole::VarWrite, 0, 2);
+        assert_eq!(l.indices(4), vec![0, 2]);
+        // A trailing odd name with no value is still a name.
+        assert_eq!(l.indices(5), vec![0, 2, 4]);
+        assert_eq!(l.indices(1), vec![0]);
+    }
+
+    #[test]
+    fn excluded_trailing_body_is_not_covered() {
+        // `foreach v1 l1 v2 l2 body` — specs at 0, 2; the body at 4 is not.
+        let l = RepeatedArgLayout {
+            exclude_trailing: 1,
+            ..RepeatedArgLayout::strided(ArgRole::LoopVarList, 0, 2)
+        };
+        assert_eq!(l.indices(5), vec![0, 2]);
+        assert_eq!(l.indices(3), vec![0]);
+        // Head + body only: nothing to cover, and no panic.
+        assert_eq!(l.indices(1), Vec::<usize>::new());
+        assert_eq!(l.indices(0), Vec::<usize>::new());
+    }
+
+    #[test]
+    fn optional_leading_word_shifts_by_the_argument_count() {
+        // `upvar ?level? other local ?other local ...?`
+        let l = RepeatedArgLayout {
+            optional_leading_word: true,
+            ..RepeatedArgLayout::strided(ArgRole::VarWrite, 1, 2)
+        };
+        // No level: locals at 1, 3.
+        assert_eq!(l.indices(2), vec![1]);
+        assert_eq!(l.indices(4), vec![1, 3]);
+        // A level word shifts everything one right: locals at 2, 4.
+        assert_eq!(l.indices(3), vec![2]);
+        assert_eq!(l.indices(5), vec![2, 4]);
+        // Too short to name anything.
+        assert_eq!(l.indices(1), Vec::<usize>::new());
+    }
+
+    #[test]
+    fn degenerate_declarations_are_inert() {
+        let zero_stride = RepeatedArgLayout {
+            stride: 0,
+            ..RepeatedArgLayout::every(ArgRole::VarWrite, 0)
+        };
+        assert_eq!(zero_stride.indices(4), Vec::<usize>::new());
+        let past_end = RepeatedArgLayout::every(ArgRole::VarWrite, 9);
+        assert_eq!(past_end.indices(4), Vec::<usize>::new());
+    }
+}

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -36,6 +36,7 @@ use crate::hooks::{
 };
 use crate::hover::{ArgValue, FormSpec, HoverSnippet, OptionSpec};
 use crate::patterns::{FormatType, PatternType};
+use crate::presentation::ArgPresentation;
 use crate::side_effects::{SideEffect, StorageType};
 use crate::symbol_def::SymbolDef;
 use crate::taint::{SetterConstraint, TaintColour};
@@ -368,6 +369,21 @@ pub struct CommandSpec {
 
     /// Dynamic argument role resolver (for variable-layout commands).
     pub arg_role_resolver: Option<ArgRoleResolver>,
+
+    /// Formatter **presentation** overrides, keyed by 0-based argument index
+    /// — how an argument should be *laid out*, as distinct from what
+    /// [`Self::arg_roles`] says it *is* (issue #1186).
+    ///
+    /// Only overrides are declared: every [`ArgRole::Body`] argument is an
+    /// [`ArgPresentation::BlockScript`] by default, so a spec with nothing
+    /// unusual to say leaves this empty. `for` declares its `start` (0) and
+    /// `next` (2) scripts [`ArgPresentation::InlineScript`], which is what
+    /// keeps `for {set i 0} {$i < 3} {incr i} { … }` on one header line
+    /// without the formatter having to know the command's name.
+    ///
+    /// See [`crate::presentation`] for why this is a separate fact rather
+    /// than a different [`ArgRole`].
+    pub arg_presentation: &'static [(u8, ArgPresentation)],
 
     /// How the command crosses stack frames — which argument is the level
     /// word, which arguments name variables in the selected frame, and
@@ -969,6 +985,7 @@ impl CommandSpec {
         arity: Arity::any(),
         arg_roles: &[],
         arg_role_resolver: None,
+        arg_presentation: &[],
         frame_effect: None,
         clause_shape_check: None,
         command_prefixes: &[],
@@ -1444,6 +1461,11 @@ pub struct SubCommand {
     /// Dynamic argument role resolver.
     pub arg_role_resolver: Option<ArgRoleResolver>,
 
+    /// Formatter presentation overrides (after the subcommand word) — the
+    /// subcommand-level twin of [`CommandSpec::arg_presentation`]. Empty
+    /// means every body argument is laid out as a block, the default.
+    pub arg_presentation: &'static [(u8, ArgPresentation)],
+
     /// Static command-prefix positions + appended arities (after the
     /// subcommand word), e.g. `trace add variable`'s callback.
     pub command_prefixes: &'static [(u8, crate::arg_role::AppendedArity)],
@@ -1712,6 +1734,7 @@ impl SubCommand {
         hover: None,
         arg_roles: &[],
         arg_role_resolver: None,
+        arg_presentation: &[],
         command_prefixes: &[],
         command_prefix_resolver: None,
         return_type: None,

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -37,6 +37,7 @@ use crate::hooks::{
 use crate::hover::{ArgValue, FormSpec, HoverSnippet, OptionSpec};
 use crate::patterns::{FormatType, PatternType};
 use crate::presentation::ArgPresentation;
+use crate::repeated::RepeatedArgLayout;
 use crate::side_effects::{SideEffect, StorageType};
 use crate::symbol_def::SymbolDef;
 use crate::taint::{SetterConstraint, TaintColour};
@@ -384,6 +385,16 @@ pub struct CommandSpec {
     /// See [`crate::presentation`] for why this is a separate fact rather
     /// than a different [`ArgRole`].
     pub arg_presentation: &'static [(u8, ArgPresentation)],
+
+    /// Repeated argument-role layouts — a role that recurs at a fixed
+    /// stride over the argument tail (`global a b c`, `variable n v n v`,
+    /// `foreach v1 l1 v2 l2 body`, `upvar ?level? o l o l`).
+    ///
+    /// Folded into [`crate::CommandRegistry::arg_indices_for_role`] alongside
+    /// [`Self::arg_roles`] and [`Self::arg_role_resolver`], so a consumer
+    /// asking which arguments carry a role gets the unbounded tail without
+    /// knowing the command (issue #1185). See [`crate::repeated`].
+    pub repeated_args: &'static [RepeatedArgLayout],
 
     /// How the command crosses stack frames — which argument is the level
     /// word, which arguments name variables in the selected frame, and
@@ -986,6 +997,7 @@ impl CommandSpec {
         arg_roles: &[],
         arg_role_resolver: None,
         arg_presentation: &[],
+        repeated_args: &[],
         frame_effect: None,
         clause_shape_check: None,
         command_prefixes: &[],
@@ -1466,6 +1478,11 @@ pub struct SubCommand {
     /// means every body argument is laid out as a block, the default.
     pub arg_presentation: &'static [(u8, ArgPresentation)],
 
+    /// Repeated argument-role layouts (after the subcommand word) — the
+    /// subcommand-level twin of [`CommandSpec::repeated_args`]
+    /// (`namespace upvar NS o l o l`, `dict update d k v k v body`).
+    pub repeated_args: &'static [RepeatedArgLayout],
+
     /// Static command-prefix positions + appended arities (after the
     /// subcommand word), e.g. `trace add variable`'s callback.
     pub command_prefixes: &'static [(u8, crate::arg_role::AppendedArity)],
@@ -1735,6 +1752,7 @@ impl SubCommand {
         arg_roles: &[],
         arg_role_resolver: None,
         arg_presentation: &[],
+        repeated_args: &[],
         command_prefixes: &[],
         command_prefix_resolver: None,
         return_type: None,

--- a/rust/tcl-spec-studio/src/catalogue.rs
+++ b/rust/tcl-spec-studio/src/catalogue.rs
@@ -112,6 +112,18 @@ pub const BODY_KINDS: &[Variant] = &[
     ),
 ];
 
+/// [`ArgPresentation`] — how a formatter lays an argument out.
+pub const ARG_PRESENTATIONS: &[Variant] = &[
+    v(
+        "BlockScript",
+        "expanded onto its own indented lines (the default for a body argument)",
+    ),
+    v(
+        "InlineScript",
+        "kept on the command's own line — `for`'s start / next scripts",
+    ),
+];
+
 /// [`StorageType`] — the container a written variable is inferred to hold.
 pub const STORAGE_TYPES: &[Variant] = &[
     v("Dict", "the target variable holds a dict"),
@@ -1028,6 +1040,7 @@ mod tests {
             ARG_ROLES,
             TCL_TYPES,
             BODY_KINDS,
+            ARG_PRESENTATIONS,
             STORAGE_TYPES,
             BYTE_ARRAY_EFFECTS,
             COMMAND_TABLE_EFFECTS,

--- a/rust/tcl-spec-studio/src/draft.rs
+++ b/rust/tcl-spec-studio/src/draft.rs
@@ -42,6 +42,7 @@ use tcl_registry::hooks::ArgTypeHint;
 use tcl_registry::hover::{
     ArgValue, FormSpec, HoverSnippet, IntegerDomain, OptionArity, OptionSpec, OptionValue,
 };
+use tcl_registry::presentation::ArgPresentation;
 use tcl_registry::side_effects::SideEffect;
 use tcl_registry::spec::{CommandSpec, SubCommand, SubSubCommand};
 use tcl_registry::taint::{SetterConstraint, TaintColour};
@@ -137,6 +138,15 @@ fn role_map(entries: &[(u8, ArgRole)]) -> Value {
         entries
             .iter()
             .map(|(i, role)| json!({ "index": i, "role": catalogue::variant_name(role) }))
+            .collect(),
+    )
+}
+
+fn presentation_map(entries: &[(u8, ArgPresentation)]) -> Value {
+    Value::Array(
+        entries
+            .iter()
+            .map(|(i, p)| json!({ "index": i, "presentation": catalogue::variant_name(p) }))
             .collect(),
     )
 }
@@ -405,6 +415,10 @@ fn subcommand_identity(d: &mut Draft, sub: &SubCommand, lost: &mut Unrecovered) 
     d.insert("hover".into(), hover(sub.hover));
     d.insert("arg_roles".into(), role_map(sub.arg_roles));
     d.insert(
+        "arg_presentation".into(),
+        presentation_map(sub.arg_presentation),
+    );
+    d.insert(
         "arg_role_resolver".into(),
         lost.expr("arg_role_resolver", sub.arg_role_resolver.is_some()),
     );
@@ -605,6 +619,10 @@ fn command_identity(d: &mut Draft, spec: &CommandSpec, lost: &mut Unrecovered) {
     d.insert("dialects".into(), dialects(spec.dialects));
     d.insert("arity".into(), arity(spec.arity));
     d.insert("arg_roles".into(), role_map(spec.arg_roles));
+    d.insert(
+        "arg_presentation".into(),
+        presentation_map(spec.arg_presentation),
+    );
     d.insert(
         "arg_role_resolver".into(),
         lost.expr("arg_role_resolver", spec.arg_role_resolver.is_some()),

--- a/rust/tcl-spec-studio/src/draft.rs
+++ b/rust/tcl-spec-studio/src/draft.rs
@@ -419,6 +419,10 @@ fn subcommand_identity(d: &mut Draft, sub: &SubCommand, lost: &mut Unrecovered) 
         presentation_map(sub.arg_presentation),
     );
     d.insert(
+        "repeated_args".into(),
+        lost.expr("repeated_args", !sub.repeated_args.is_empty()),
+    );
+    d.insert(
         "arg_role_resolver".into(),
         lost.expr("arg_role_resolver", sub.arg_role_resolver.is_some()),
     );
@@ -622,6 +626,10 @@ fn command_identity(d: &mut Draft, spec: &CommandSpec, lost: &mut Unrecovered) {
     d.insert(
         "arg_presentation".into(),
         presentation_map(spec.arg_presentation),
+    );
+    d.insert(
+        "repeated_args".into(),
+        lost.expr("repeated_args", !spec.repeated_args.is_empty()),
     );
     d.insert(
         "arg_role_resolver".into(),

--- a/rust/tcl-spec-studio/src/render_rs.rs
+++ b/rust/tcl-spec-studio/src/render_rs.rs
@@ -239,6 +239,20 @@ fn role_map_expr(values: &[Value]) -> String {
     format!("&[{}]", items.join(", "))
 }
 
+fn presentation_map_expr(values: &[Value]) -> String {
+    let items: Vec<String> = values
+        .iter()
+        .map(|entry| {
+            format!(
+                "({}, ArgPresentation::{})",
+                as_u64(&entry["index"]),
+                as_str(&entry["presentation"])
+            )
+        })
+        .collect();
+    format!("&[{}]", items.join(", "))
+}
+
 fn prefix_map_expr(values: &[Value]) -> String {
     let items: Vec<String> = values
         .iter()
@@ -580,6 +594,7 @@ fn field_expr(field: &FieldSchema, value: &Value, default: &Value, indent: &str)
         FieldKind::Arity => arity_expr(value),
         FieldKind::RoleMap => role_map_expr(as_array(value)),
         FieldKind::PrefixMap => prefix_map_expr(as_array(value)),
+        FieldKind::PresentationMap => presentation_map_expr(as_array(value)),
         FieldKind::ArgTypeMap => arg_type_map_expr(as_array(value), indent),
         FieldKind::ArgValueMap => arg_value_map_expr(as_array(value), indent),
         FieldKind::Options => "OPTIONS".to_owned(),

--- a/rust/tcl-spec-studio/src/schema.rs
+++ b/rust/tcl-spec-studio/src/schema.rs
@@ -299,6 +299,15 @@ pub const COMMAND_FIELDS: &[FieldSchema] = &[
         "Formatter layout override per 0-based argument index; body arguments are block-expanded unless declared inline.",
     ),
     f(
+        "repeated_args",
+        "Repeated argument layouts",
+        ADVANCED,
+        FieldKind::RustExpr {
+            hint: "&[RepeatedArgLayout::strided(ArgRole::VarWrite, 0, 2)]",
+        },
+        "Roles that recur at a fixed stride over the argument tail (`global a b c`, `variable n v n v`).",
+    ),
+    f(
         "frame_effect",
         "Frame effect",
         ADVANCED,
@@ -988,6 +997,15 @@ pub const SUBCOMMAND_FIELDS: &[FieldSchema] = &[
         ARGS,
         FieldKind::PresentationMap,
         "Formatter layout override per index, counted after the subcommand word.",
+    ),
+    f(
+        "repeated_args",
+        "Repeated argument layouts",
+        ADVANCED,
+        FieldKind::RustExpr {
+            hint: "&[RepeatedArgLayout::strided(ArgRole::VarWrite, 1, 2)]",
+        },
+        "Roles that recur at a fixed stride over the tail, counted after the subcommand word.",
     ),
     f(
         "command_prefixes",

--- a/rust/tcl-spec-studio/src/schema.rs
+++ b/rust/tcl-spec-studio/src/schema.rs
@@ -76,6 +76,8 @@ pub enum FieldKind {
     RoleMap,
     /// `&'static [(u8, AppendedArity)]` — command-prefix positions.
     PrefixMap,
+    /// `&'static [(u8, ArgPresentation)]` — formatter layout overrides.
+    PresentationMap,
     /// `&'static [(u8, ArgTypeHint)]`.
     ArgTypeMap,
     /// `&'static [(u8, &'static [ArgValue])]`.
@@ -123,6 +125,7 @@ impl FieldKind {
             Self::Arity => "arity",
             Self::RoleMap => "roleMap",
             Self::PrefixMap => "prefixMap",
+            Self::PresentationMap => "presentationMap",
             Self::ArgTypeMap => "argTypeMap",
             Self::ArgValueMap => "argValueMap",
             Self::Options => "options",
@@ -287,6 +290,13 @@ pub const COMMAND_FIELDS: &[FieldSchema] = &[
             hint: "Some(my_resolver)",
         },
         "Callback assigning roles from the actual argument list; wins over `arg_roles`.",
+    ),
+    f(
+        "arg_presentation",
+        "Argument presentation",
+        ARGS,
+        FieldKind::PresentationMap,
+        "Formatter layout override per 0-based argument index; body arguments are block-expanded unless declared inline.",
     ),
     f(
         "frame_effect",
@@ -973,6 +983,13 @@ pub const SUBCOMMAND_FIELDS: &[FieldSchema] = &[
         "Callback assigning roles from the actual argument list.",
     ),
     f(
+        "arg_presentation",
+        "Argument presentation",
+        ARGS,
+        FieldKind::PresentationMap,
+        "Formatter layout override per index, counted after the subcommand word.",
+    ),
+    f(
         "command_prefixes",
         "Command-prefix positions",
         ARGS,
@@ -1394,6 +1411,7 @@ pub fn catalogues() -> Value {
         "argRole": entries(catalogue::ARG_ROLES),
         "tclType": entries(catalogue::TCL_TYPES),
         "bodyKind": entries(catalogue::BODY_KINDS),
+        "argPresentation": entries(catalogue::ARG_PRESENTATIONS),
         "storageType": entries(catalogue::STORAGE_TYPES),
         "byteArrayEffect": entries(catalogue::BYTE_ARRAY_EFFECTS),
         "commandTableEffect": entries(catalogue::COMMAND_TABLE_EFFECTS),

--- a/rust/tcl-spec-studio/web/src/editors.ts
+++ b/rust/tcl-spec-studio/web/src/editors.ts
@@ -52,6 +52,7 @@ export const STRUCTURAL_KINDS = new Set([
   "optIndexList",
   "flagSet",
   "roleMap",
+  "presentationMap",
   "prefixMap",
   "argTypeMap",
   "argValueMap",
@@ -604,6 +605,34 @@ export function makeEditors(ctx: EditorContext): Record<string, Editor> {
         },
         set,
         "role",
+      ),
+
+    presentationMap: (_kind, value, set) =>
+      rowList<Json>(
+        asArray(value),
+        () => ({ index: 0, presentation: "BlockScript" }),
+        (item, _i, update, remove) => {
+          const row = asRecord(item);
+          return el("div", { class: "row" }, [
+            labelled(
+              "index",
+              numberInput(asNumber(row.index) ?? 0, (n) =>
+                update({ index: n ?? 0, presentation: row.presentation ?? "BlockScript" }),
+              ),
+            ),
+            labelled(
+              "presentation",
+              catalogueSelect(
+                { tag: "enum", catalogue: "argPresentation" },
+                asString(row.presentation),
+                (presentation) => update({ index: row.index ?? 0, presentation }),
+              ),
+            ),
+            removeButton(remove),
+          ]);
+        },
+        set,
+        "presentation",
       ),
 
     prefixMap: (_kind, value, set) =>

--- a/rust/tcl-syntax/src/list.rs
+++ b/rust/tcl-syntax/src/list.rs
@@ -600,6 +600,39 @@ where
     out
 }
 
+/// Re-render `s` as a canonical Tcl list: the same elements, separated by
+/// exactly one space, each re-quoted by the shared list-element encoder.
+///
+/// This is `Tcl_SplitList` followed by `Tcl_Merge` — the only way to
+/// re-space a list without changing what it *is*. A hand-rolled scan that
+/// splits on whitespace and balanced braces gets the escaped forms wrong:
+/// `a\ b` is **one** element (the escaped space is data), `{a b}` is one
+/// element whose braces are structure, and a `"a b"` element is one element
+/// too. Losing any of those changes the list's length, which for a `proc`
+/// parameter list is a change of arity (issue #1196).
+///
+/// Returns `Err` for input that is not a well-formed list (an unmatched brace
+/// or quote, junk after a closing delimiter). A caller that is reformatting
+/// source must then preserve the original text verbatim rather than guess.
+///
+/// Note that Tcl's `\<newline>` line-continuation collapse happens in a
+/// *pre-pass* over the script, before any word is list-parsed — even inside
+/// braces. A caller holding raw source text must run
+/// [`crate::backslash::collapse_brace_continuations_str`] over it first, or
+/// the backslash will be read as escaping the newline *inside* an element.
+///
+/// ```
+/// use tcl_syntax::list::normalise_spacing;
+/// assert_eq!(normalise_spacing("a    b   c").unwrap(), "a b c");
+/// // Structure is preserved, not flattened.
+/// assert_eq!(normalise_spacing("a  {b 1}  c").unwrap(), "a {b 1} c");
+/// assert_eq!(normalise_spacing(r"a\ b  c").unwrap(), r"{a b} c");
+/// assert!(normalise_spacing("a {b").is_err());
+/// ```
+pub fn normalise_spacing(s: &str) -> Result<String, ListError> {
+    Ok(join_list(split_list(s)?))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -610,6 +643,40 @@ mod tests {
             .into_iter()
             .map(Cow::into_owned)
             .collect()
+    }
+
+    #[test]
+    fn normalise_spacing_preserves_element_count_and_structure() {
+        // TP — plain whitespace runs collapse.
+        assert_eq!(normalise_spacing("a    b\t\tc").unwrap(), "a b c");
+        // TP — a braced element keeps its braces (one element, not two).
+        assert_eq!(normalise_spacing("a   {b 1}   c").unwrap(), "a {b 1} c");
+        // TP — an escaped space is data: one element, re-quoted as a brace.
+        assert_eq!(normalise_spacing(r"a\ b c").unwrap(), r"{a b} c");
+        // TP — a quoted element is one element, re-quoted canonically.
+        assert_eq!(normalise_spacing(r#""a b" c"#).unwrap(), "{a b} c");
+        // TN — malformed input has no canonical rendering.
+        assert!(normalise_spacing("a {b").is_err());
+        assert!(normalise_spacing(r#"a "b"#).is_err());
+        // FP guard — empty and whitespace-only lists stay empty.
+        assert_eq!(normalise_spacing("").unwrap(), "");
+        assert_eq!(normalise_spacing("  \n ").unwrap(), "");
+    }
+
+    #[test]
+    fn normalise_spacing_is_idempotent() {
+        for src in [
+            "a b c",
+            "a {b 1} c",
+            r"a\ b c",
+            "{} a",
+            "args",
+            "{a {b c} d}",
+        ] {
+            let once = normalise_spacing(src).expect("well-formed");
+            let twice = normalise_spacing(&once).expect("well-formed");
+            assert_eq!(once, twice, "not idempotent for {src:?}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **#1196**: the formatter changed proc arity on backslash-newline parameter lists — it now runs C Tcl's exact order (script-level continuation collapse, then `Tcl_SplitList`/`Tcl_Merge` spacing normalisation via a shared `tcl_syntax::list::normalise_spacing`); malformed lists pass through verbatim. Closes #1196.
- **#1107**: signature-scan stub and `ParamListPosition::Computed` disagreed on literalness — one shared predicate now serves both views (token- and text-based, with an agreement test). This surfaced a live bug: the cross-file arity table read a computed param list as "takes no arguments", drawing a false cross-file E003; `proc_arity` now abstains on computed lists. Closes #1107.
- **#1186**: the formatter hardcoded `if`/`try`/`for` layout — keywords now come from positional `ArgRole::Keyword`, and block-vs-inline is a new registry fact (`ArgPresentation` with Spec Studio schema/draft/render/editor support); `for` declares its `start`/`next` scripts inline. Closes #1186.
- **#1185** (most of it): semantic tokens and inlay hints stop matching command spellings — format/scan-string positions resolve through a new `CommandRegistry::format_string_args` (populated `format_string_type` for format/scan/clock/binary/regsub), repeated-argument strides come from a new `RepeatedArgLayout` descriptor, `upvar` dispatches on its `FrameEffectSpec`, `oo::define`/`objdefine` on their analyser hooks; every `::`-qualified spelling now classifies like the bare form. Found en route: W138 treated every `FormatString` role as a printf %-string — now gated on `FormatType::Sprintf` (would have mis-flagged `clock format`). Remaining (left open on #1185): `interp alias`/static-`rename` effective-identity resolution and a VS Code decoded-token test; four residual name-matches listed in the issue thread.
- Not included: #1142 (root cause pinned and documented on the issue; both shortcut fixes are provably unsound — needs a classified SSA use, follow-up #1237) and #1210 (untouched).

## Validation

- [x] On the group branch: `cargo test` over tcl-registry, tcl-spec-studio, tcl-syntax, tcl-compiler (incl. the per-item parity gate), tcl-lsp-db, tcl-lsp-core (lib + integration suites), tcl-lsp-server e2e (1250); `make xtask-check`; fmt + clippy `-D warnings` over every touched crate, no new allows.
- [x] Rebased onto post-series `rust`: workspace check 0 errors; registry/syntax suites and the per-item parity gate green; spec-studio web `npm run typecheck` + prettier clean.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? — Yes: new registry facts (`ArgPresentation`, `RepeatedArgLayout`, populated `format_string_type`, `regsub` `ArgRole::Pattern`), computed-param arity abstention, W138 gated on `FormatType::Sprintf`.
- [x] If yes, I updated at least one relevant KCS note — `docs/design/compiler/command-registry.md` (new fact families) and the formatter/token design notes in-tree.
- [ ] If I added a new compiler KCS note, I linked it — n/a (existing docs extended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_