### PR TITLE
Frame effects: dynamic-local upvar aliases, my/next dispatch widening, caller-frame upvar targets, uplevel #0 global writes (#1139, #1165, #1177, #1198)

### DIFF
--- a/docs/design/compiler/README.md
+++ b/docs/design/compiler/README.md
@@ -102,6 +102,10 @@ User-facing compiler troubleshooting and how-tos live in
   on WASM locals vs spill to the runtime frame.
 - [interprocedural-analysis.md](interprocedural-analysis.md) —
   ProcSummary construction.
+- [frame-effect-summaries.md](frame-effect-summaries.md) — the per-proc
+  caller-frame (`upvar`/`uplevel`) and global-frame (`uplevel #0`)
+  effect summaries, their named/opaque/empty lattice, the method-dispatch
+  widening, and the conservative limits.
 - [interprocedural-call-site-seeding.md](interprocedural-call-site-seeding.md)
   — how a procedure parameter is bound to a caller-uniform literal, which
   indirect calls (`$cmd args`, callback prefixes, `eval $script`) count as

--- a/docs/design/compiler/frame-effect-summaries.md
+++ b/docs/design/compiler/frame-effect-summaries.md
@@ -1,0 +1,115 @@
+# Frame-effect summaries: caller-frame and global-frame callee effects
+
+A Tcl procedure routinely writes variables that belong to *someone else's*
+frame: `upvar` aliases a caller-frame (or global) name into a local, and
+`uplevel` runs a whole script in the frame its level word selects. None of
+that shows up in the caller's own text, so a single-function analysis would
+fold, forward, or delete values a callee really rewrites.
+
+Two per-procedure summaries model this, both computed once per module in
+`rust/tcl-compiler/src/cfg_builder/` and consulted at every call site by
+`CfgBuilder::apply_upvar_invalidation`:
+
+| Summary | Module | Owns |
+|---|---|---|
+| `UpvarInfo` | `cfg_builder/upvar_info.rs` | effects on the **immediate caller's** frame (`upvar 1`, `uplevel 1`) |
+| `GlobalWriteInfo` | `cfg_builder/global_write_info.rs` | effects on **global/namespace** cells (`global`, `variable`, `upvar #0`, `uplevel #0`) |
+
+The frame table (pinned on tclsh 9.0.4 / 8.6.14, see `upvar_info.rs`'s module
+doc for transcripts):
+
+| written in the callee | frame written | which summary |
+|---|---|---|
+| `upvar 1 x y` / `upvar x y` | the caller | `UpvarInfo` named binding |
+| `upvar #0 g l` / `uplevel #0 {…}` | the global frame | `GlobalWriteInfo` |
+| `upvar 0 x y` / `uplevel 0 {…}` | the callee's own frame | neither (no cross-frame effect) |
+| `upvar 2 …` / `upvar $lvl …` / `uplevel 2 …` | further out / unknown | `UpvarInfo` opaque widening |
+
+## The lattice, per name
+
+Each summary answers "which names does a call to this procedure touch, in
+which frame?" at one of three precision levels, and every consumer must
+respect the ordering — a level may only ever be *widened*:
+
+1. **Named** — the effect is a known literal name (`literal_targets`,
+   `uplevel_literal_writes`, `GlobalWriteInfo::names`) or a name resolvable
+   from the call site's own arguments (`param_targets`,
+   `uplevel_param_writes`, `args_tail_upvar`). The call site widens exactly
+   those names (merged into the call's `defs`, so SCCP/O102 see a fresh
+   definition).
+2. **Opaque frame** — the effect is real but no name is enumerable
+   (`has_unresolvable_caller_target`, `caller_frame_opaque_writes/reads`,
+   `GlobalWriteInfo::opaque_global_frame`). The call site widens with a
+   `Statement::Barrier`, which SCCP, O102 load forwarding, O109/DSE, branch
+   folding, and the I230 existence fold all already treat as "anything may
+   have changed".
+3. **Empty** — no cross-frame effect; the call site is left alone.
+
+The abstention direction is fixed: a shape the analysis cannot read must land
+at level 2, never silently at level 3. Three shapes used to fall through and
+are now covered:
+
+- `upvar 1 x $dst` — a dynamic **local** side (issue #1165). The caller-side
+  name is still exactly `x`, so it lands at level 1 in the keyless
+  `uplevel_literal_writes` bucket (a `$param` source resolves through
+  `uplevel_param_writes`; anything else widens to level 2).
+- `uplevel #0 …` in a called procedure (issue #1198). A literal or
+  `[list set g …]`-constructed script contributes level-1 global names; a
+  dynamic script (`uplevel #0 $body`) sets `opaque_global_frame`, which is
+  transitive over the direct-call closure and becomes a barrier at every
+  call site — including calls embedded in command substitutions and in
+  `if`/`while`/frozen-loop conditions. This is what fixed the documented
+  O102 miscompile (`proc setter {} {uplevel #0 {set x 99}}; set x 5; setter;
+  puts $x` must print 99, not 5).
+- a dynamic write target inside a readable script body (`uplevel 1 {set $n
+  1}`, `uplevel #0 {set $n 1}`): `ssa::defs_of` drops such a target
+  entirely, so both body scans widen explicitly
+  (`script_has_dynamic_write_target`).
+
+## Method dispatch (`my` / `next`)
+
+A callee reached through `my`/`next` is a method, never in the upvar-procs
+table — the dispatch does not name its target. When the module's
+method-dispatch evidence is incomplete
+(`upvar_info::module_method_dispatch_evidence_is_incomplete`: any method body
+that can reach its caller's frame, or any redefined method), the method-body
+CFGs are built with synthetic level-2 entries for every registry command
+carrying `TCLOO_SELF_DISPATCH` / `TCLOO_NEXT_CHAIN` (issue #1177). The same
+evidence rule gates the optimiser's method-body constant propagation (issue
+#1097), so the two consumers cannot drift. `self` (`TCLOO_INTROSPECTION`)
+dispatches nothing and is excluded.
+
+## Conservative limits (all widen, none miscompile)
+
+- **Renames and aliases.** The summaries key on the command name as written;
+  a proc reached through `rename`/`interp alias`/a computed name is not
+  found, and the callee-side effect is missed. The dynamic-name barrier and
+  `command_binding` mutation tracking cover parts of this independently.
+- **`next` chain targeting.** A chained implementation's `upvar 1` skips the
+  calling implementation's frame entirely (tclsh 9.0.4: it lands in the
+  frame of whoever invoked the whole method). Widening the dispatch site is
+  sound for the calling body but does not model the one-frame-out effect;
+  per-chain precision needs the MRO work of issue #1164.
+- **Cross-file callees.** `detect_upvar_procs` and
+  `detect_global_write_procs` are single-`Module`; a callee defined in
+  another file contributes nothing (issue #1139's idx-59 residual).
+- **Absolute non-global levels** (`uplevel #2`) widen the calling function
+  through the caller-frame opaque path rather than being mapped to a
+  specific frame.
+- **Relative levels beyond the caller** (`upvar 2` in a callee of a callee)
+  widen only the direct caller's function; the effect is not composed
+  transitively through the call graph, so the grandparent frame relies on
+  the direct caller's own barrier.
+
+## Consumers
+
+- `CfgBuilder::apply_upvar_invalidation` — per-call-site defs widening +
+  barriers (direct calls, embedded `[…]` substitutions, condition
+  substitutions, `return [callee …]`).
+- `Function::caller_frame_barrier` / `alias_observed_vars` — whole-function
+  blindness and "a callee may observe this store" facts for O109/O126.
+- The LSP navigation half lives in `rust/tcl-lsp-core/src/caller_frame.rs`
+  (per-parameter and literal caller-frame bindings on
+  `ProcDef::caller_frame_params` / `caller_frame_literals`, issue #1139) —
+  same frame table, independent computation from source text in the
+  analyser (`analyser/param_traits.rs`).

--- a/docs/kcs/features/kcs-feature-hover.md
+++ b/docs/kcs/features/kcs-feature-hover.md
@@ -139,9 +139,17 @@ caller's frame. `upvar 0` aliases the callee's own local, `upvar #0` a global,
 and `upvar 2` the caller's caller — none of them creates anything where you
 are reading, so hover stays silent for those.
 
-Two further limits are deliberate. A callee that binds a *literal* caller-side
-name (`upvar 1 options options`) spells nothing at the call site, so there is
-no word to attribute the variable to and hover stays silent. And a `$`-led
+A callee that binds a *literal* caller-side name (`upvar 1 options options`)
+spells nothing at the call site, so the card names the callee itself and says
+the name is spelled in the callee's body; Go to Definition then reaches the
+call, which is where the variable comes to exist in this frame. A
+fully-qualified target (`upvar ::tk::FocusGrab($idx) data`) is not a
+caller-frame variable at all — it names one fixed global cell, which hover,
+Go to Definition, and Find References answer directly from the `upvar` word.
+
+Two limits are deliberate. A callee reached through `my`, `next`, or an
+object dispatch is a method the call never names statically, so its literal
+targets are not resolved yet and hover stays silent for them. And a `$`-led
 read that nothing binds shows **nothing at all** rather than falling back to a
 command or method of the same name: Tcl keeps variable names and command names
 in separate tables, so `$dataset` can never mean a method called `dataset`.

--- a/editors/vscode/src/test/hover.test.ts
+++ b/editors/vscode/src/test/hover.test.ts
@@ -80,4 +80,32 @@ suite("Hover", () => {
       `imported 'test' should hover as tcltest::test, got: ${hoverText}`,
     );
   });
+
+  // Issue #1139 (issue #923 audit idx 22): a callee that binds a literal
+  // caller-frame name in its own body (`upvar name name`) creates the
+  // variable in the calling frame with no call-site word to point at.
+  // Hovering the `$name` read must render the caller-frame card naming the
+  // creating callee instead of answering nothing.
+  test("hovers a literal upvar caller-frame read with the caller-frame card", async () => {
+    const uri = getDocUri("callerFrame.tcl");
+    await activate(uri);
+    // Line 9: `    set out $name` — position inside `name` (col 14).
+    const position = new vscode.Position(9, 14);
+
+    const hovers = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeHoverProvider", uri, position),
+      (r) => Array.isArray(r) && r.length > 0,
+      { timeout: 10_000, label: "hover for literal caller-frame read" },
+    )) as vscode.Hover[];
+
+    const hoverText = hovers
+      .flatMap((h) => h.contents)
+      .map((c) => (typeof c === "string" ? c : (c as { value: string }).value))
+      .join("\n");
+
+    assert.ok(
+      hoverText.includes("Caller-frame variable") && hoverText.includes("NameProcess"),
+      `expected the caller-frame card naming the callee, got: ${hoverText}`,
+    );
+  });
 });

--- a/editors/vscode/testFixture/callerFrame.tcl
+++ b/editors/vscode/testFixture/callerFrame.tcl
@@ -1,0 +1,11 @@
+# Caller-frame variable fixtures (issues #1139 / #923 idx 22).
+# The callee spells the caller-frame name literally in its own body,
+# so no call-site word carries it (tclsh 9.0.4: build returns W1).
+proc NameProcess {arguments object} {
+    upvar name name
+    set name W1
+}
+proc build {} {
+    NameProcess x obj
+    set out $name
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -5710,6 +5710,90 @@ fn info_exists_folds_true_not_false_for_method_parameter() {
     );
 }
 
+#[test]
+fn info_exists_does_not_fold_upvar_defined_local_across_my_dispatch() {
+    // FP guard (issue #1177) — the callee reached via `my` is a method,
+    // never in the upvar-procs table, so its `upvar 1 $refvar ref`
+    // caller-frame definition was invisible and the guard folded always
+    // false.  Oracle (tclsh 9.0.4 and 8.6.14): after `my Reference?
+    // $lookup ref` returns true, `[info exists ref]` in the caller is 1;
+    // on a miss, 0 — live code either way, so the fold must abstain.
+    let codes = codes_for(
+        "oo::class create Formatter {\n \
+         method Reference? {lookup refvar} {\n upvar 1 $refvar ref\n \
+         if {$lookup eq \"x\"} { set ref 1; return 1 }\n return 0\n }\n \
+         method ResolvableReference? {lookup} {\n \
+         my Reference? $lookup ref\n \
+         if {[info exists ref]} { puts hi }\n }\n}\n",
+    );
+    assert!(
+        !codes.contains(&"I230".to_string()),
+        "an upvar-defined local across a `my` dispatch must not fold; got {codes:?}",
+    );
+}
+
+#[test]
+fn info_exists_does_not_fold_upvar_defined_local_across_next_dispatch() {
+    // Abstention guard (issue #1177), `next`-chain shape.  `next` names no
+    // target at all, so which implementation runs — and which frame its
+    // `upvar 1` lands in — needs MRO modelling this analysis does not do
+    // (issue #1164).  Oracle (tclsh 9.0.4): the chained implementation's
+    // `upvar 1` actually SKIPS the calling implementation's frame and
+    // lands in the frame of whoever invoked the whole method
+    // (`in-sub:0`, `global:1` for a top-level `[Sub new] probe`) — so a
+    // per-chain answer is provable only with the chain in hand.  Until
+    // then the fold must abstain rather than claim either constant.
+    let codes = codes_for(
+        "oo::class create Base {\n \
+         method probe {} { upvar 1 status status\n set status ok\n return 1 }\n}\n\
+         oo::class create Sub {\n superclass Base\n \
+         method probe {} {\n next\n \
+         if {[info exists status]} { puts hi }\n }\n}\n",
+    );
+    assert!(
+        !codes.contains(&"I230".to_string()),
+        "an upvar-defined local across a `next` dispatch must not fold; got {codes:?}",
+    );
+}
+
+#[test]
+fn info_exists_still_folds_across_my_when_no_method_reaches_the_caller_frame() {
+    // TN guard (issue #1177) — the widening is evidence-gated, not a
+    // blanket "no folds near `my`": when no method in the module can reach
+    // its caller's frame, a dispatch cannot create locals here, so a
+    // never-set non-instance local still folds always false (tclsh 9.0.4 /
+    // 8.6.14: `[info exists zzz]` is 0 after `my Helper`).
+    let codes = codes_for(
+        "oo::class create C {\n \
+         method Helper {} { return 1 }\n \
+         method m {} {\n my Helper\n \
+         if {[info exists zzz]} { puts hi }\n }\n}\n",
+    );
+    assert!(
+        codes.contains(&"I230".to_string()),
+        "with complete dispatch evidence the fold must survive; got {codes:?}",
+    );
+}
+
+#[test]
+fn read_after_my_dispatch_to_an_upvar_sibling_draws_no_read_before_set() {
+    // The W210 face of the same evidence rule (issue #1177): `$ref` after
+    // the dispatch is genuinely defined on the hit path — tclsh 9.0.4 /
+    // 8.6.14 run it to completion.
+    let codes = codes_for(
+        "oo::class create Formatter {\n \
+         method Reference? {lookup refvar} {\n upvar 1 $refvar ref\n \
+         set ref 1\n return 1\n }\n \
+         method ResolvableReference? {lookup} {\n \
+         my Reference? $lookup ref\n \
+         return $ref\n }\n}\n",
+    );
+    assert!(
+        !codes.contains(&"W210".to_string()),
+        "a `my` dispatch to an upvar sibling defines the local; got {codes:?}",
+    );
+}
+
 /// Every I230 message emitted for `src`, in emission order.
 fn i230_messages(src: &str) -> Vec<String> {
     let mut a = Analyser::new();

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -1669,8 +1669,7 @@ impl Analyser {
             return false;
         }
 
-        let raw_name = &args[0];
-        let name_tok = arg_tokens[0];
+        let (raw_name, name_tok) = (&args[0], arg_tokens[0]);
         let resolved_name = self
             .resolve_dynamic_word(
                 raw_name,
@@ -1684,7 +1683,6 @@ impl Analyser {
         let simple = crate::naming::key_tail(&qualified).to_string();
         let name_span = name_tok.span;
         let body_tok = arg_tokens[2];
-        let body_span = body_tok.span;
 
         self.emit_w113_proc_shadows_builtin(&resolved_name, &qualified, name_span);
         self.emit_w314_no_absolute_name(raw_name, name_span);
@@ -1716,7 +1714,7 @@ impl Analyser {
             // one.
             params_computed: false,
             name_span,
-            body_span,
+            body_span: body_tok.span,
             doc,
             param_traits,
             caller_frame_params,
@@ -1741,7 +1739,7 @@ impl Analyser {
                     .expect("scope_path resolved when registering proc must still resolve");
                 let mut child =
                     super::types::Scope::new(super::types::ScopeKind::Proc, scope_name.clone());
-                child.body_span = Some(body_span);
+                child.body_span = Some(body_tok.span);
                 parent.children.push(child);
                 parent.children.len() - 1
             };

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -45,6 +45,17 @@ use super::state::Analyser;
 use super::types::{DefinedSymbol, ProcDef};
 use super::utils::{param_name_spans_for_token, parse_param_list};
 
+/// The three per-proc facts [`Analyser::infer_proc_param_traits`] derives from
+/// one view of a proc body: the per-parameter trait map, the caller-frame
+/// parameter names ([`super::types::ProcDef::caller_frame_params`]), and the
+/// literal caller-frame targets
+/// ([`super::types::ProcDef::caller_frame_literals`], name → written-through-alias).
+type ProcParamFacts = (
+    std::collections::HashMap<String, std::collections::HashSet<super::types::ProcArgTrait>>,
+    std::collections::HashSet<String>,
+    std::collections::HashMap<String, bool>,
+);
+
 /// Tcl *library* procedures (defined in init.tcl / auto.tcl / history.tcl /
 /// package.tcl / word.tcl) that are script-defined and documented as
 /// user-replaceable — redefining one is the supported overlay idiom, not
@@ -1040,11 +1051,7 @@ impl Analyser {
         &self,
         params: &[crate::signature_scan::types::ParamDef],
         body_text: &str,
-    ) -> (
-        std::collections::HashMap<String, std::collections::HashSet<super::types::ProcArgTrait>>,
-        std::collections::HashSet<String>,
-        std::collections::HashMap<String, bool>,
-    ) {
+    ) -> ProcParamFacts {
         let Some(registry) = self.registry else {
             return (
                 std::collections::HashMap::new(),

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -4074,12 +4074,7 @@ impl Analyser {
                     // `otherVar` (at `i - 1`) names the cell; `args[i]` is an
                     // independent local spelling.  Renaming the cell must
                     // rewrite the former, never the latter.
-                    self.set_var_link_target(
-                        &args[i],
-                        scope_path,
-                        target.clone(),
-                        other_tok.span,
-                    );
+                    self.set_var_link_target(&args[i], scope_path, target.clone(), other_tok.span);
                     // The fixed cell itself gets a definition at the
                     // `otherVar` word (issue #923 audit idx 98 / issue
                     // #1139): `upvar ::tk::FocusGrab($index) data` is the

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -1030,9 +1030,12 @@ impl Analyser {
     /// [`ProcDef::caller_frame_params`](super::types::ProcDef::caller_frame_params)
     /// — the strictly narrower "this parameter's value names a variable in the
     /// *immediate caller's* frame" fact, which the trait map alone cannot
-    /// answer because it records no frame level.  Computed here, from the same
-    /// body text and the same dialect config, so the two can never be derived
-    /// from different views of the proc.
+    /// answer because it records no frame level — and
+    /// [`ProcDef::caller_frame_literals`](super::types::ProcDef::caller_frame_literals),
+    /// the literal caller-frame names the body spells itself (`upvar 1 name
+    /// name`, issue #1139).  Computed here, from the same
+    /// body text and the same dialect config, so the three can never be
+    /// derived from different views of the proc.
     fn infer_proc_param_traits(
         &self,
         params: &[crate::signature_scan::types::ParamDef],
@@ -1040,11 +1043,13 @@ impl Analyser {
     ) -> (
         std::collections::HashMap<String, std::collections::HashSet<super::types::ProcArgTrait>>,
         std::collections::HashSet<String>,
+        std::collections::HashMap<String, bool>,
     ) {
         let Some(registry) = self.registry else {
             return (
                 std::collections::HashMap::new(),
                 std::collections::HashSet::new(),
+                std::collections::HashMap::new(),
             );
         };
         let overlay = self.stub_overlay.as_ref();
@@ -1056,6 +1061,8 @@ impl Analyser {
             registry,
             config,
         );
+        let caller_frame_literals =
+            super::param_traits::caller_frame_literal_targets(body_text, registry, config);
         let shallow = super::param_traits::infer_param_traits_with_config(
             &param_names,
             body_text,
@@ -1075,7 +1082,7 @@ impl Analyser {
         } else {
             shallow
         };
-        (traits, caller_frame_params)
+        (traits, caller_frame_params, caller_frame_literals)
     }
 
     /// **W113** — a `proc` name shadows a built-in command.
@@ -1432,7 +1439,8 @@ impl Analyser {
         }
 
         let body_text = &args[2];
-        let (param_traits, caller_frame_params) = self.infer_proc_param_traits(&params, body_text);
+        let (param_traits, caller_frame_params, caller_frame_literals) =
+            self.infer_proc_param_traits(&params, body_text);
 
         let proc = ProcDef {
             name: simple,
@@ -1444,6 +1452,7 @@ impl Analyser {
             doc,
             param_traits,
             caller_frame_params,
+            caller_frame_literals,
         };
 
         // Register globally and in the current scope. ``scope.procs``
@@ -1688,7 +1697,7 @@ impl Analyser {
         combined_params.extend(opt_locals.iter().cloned());
 
         let body_text = &args[2];
-        let (param_traits, caller_frame_params) =
+        let (param_traits, caller_frame_params, caller_frame_literals) =
             self.infer_proc_param_traits(&combined_params, body_text);
 
         let proc = ProcDef {
@@ -1704,6 +1713,7 @@ impl Analyser {
             doc,
             param_traits,
             caller_frame_params,
+            caller_frame_literals,
         };
 
         self.register_proc_definition(&qualified, &proc, name_span);
@@ -4064,7 +4074,23 @@ impl Analyser {
                     // `otherVar` (at `i - 1`) names the cell; `args[i]` is an
                     // independent local spelling.  Renaming the cell must
                     // rewrite the former, never the latter.
-                    self.set_var_link_target(&args[i], scope_path, target, other_tok.span);
+                    self.set_var_link_target(
+                        &args[i],
+                        scope_path,
+                        target.clone(),
+                        other_tok.span,
+                    );
+                    // The fixed cell itself gets a definition at the
+                    // `otherVar` word (issue #923 audit idx 98 / issue
+                    // #1139): `upvar ::tk::FocusGrab($index) data` is the
+                    // only place the array ever comes to exist, so without
+                    // a `VarDef` for `::tk::FocusGrab` every occurrence —
+                    // this word, a sibling proc's `$::tk::FocusGrab($idx)`
+                    // read, its `info exists` / `unset` — answered nothing.
+                    // Defined in the GLOBAL scope: both qualifying
+                    // spellings (a `::`-qualified target, any target at
+                    // `#0`) name a cell reachable from everywhere.
+                    self.define_var(&target, *other_tok, &[], false, None);
                 }
             }
             i += 2;
@@ -9811,6 +9837,7 @@ mod tests {
                 doc: String::new(),
                 param_traits: std::collections::HashMap::new(),
                 caller_frame_params: std::collections::HashSet::new(),
+                caller_frame_literals: std::collections::HashMap::new(),
             },
         );
         let resolved = a.resolve_proc_call("a::b", &[]);
@@ -9839,6 +9866,7 @@ mod tests {
                     doc: String::new(),
                     param_traits: std::collections::HashMap::new(),
                     caller_frame_params: std::collections::HashSet::new(),
+                    caller_frame_literals: std::collections::HashMap::new(),
                 },
             );
         }

--- a/rust/tcl-compiler/src/analyser/param_traits.rs
+++ b/rust/tcl-compiler/src/analyser/param_traits.rs
@@ -1013,7 +1013,14 @@ pub fn caller_frame_upvar_params(
     }
     let param_set: HashSet<&str> = params.iter().copied().collect();
     for seg in &segment_commands_with_offset_and_config(body_source, 0, config) {
-        if seg.texts.first().map(String::as_str) != Some("upvar") {
+        // Registry-driven recognition (`FrameArgLayout::AliasPairs`), the
+        // same test `caller_frame_literal_targets` applies — never a
+        // spelled command name.
+        if seg.texts.first().is_none_or(|head| {
+            registry
+                .frame_effect(head)
+                .is_none_or(|spec| spec.layout != tcl_registry::frame_effect::FrameArgLayout::AliasPairs)
+        }) {
             continue;
         }
         let (level, pairs) = upvar_level_and_pairs(&seg.texts[1..], registry);
@@ -1031,6 +1038,110 @@ pub fn caller_frame_upvar_params(
         }
     }
     out
+}
+
+/// The **literal caller-frame targets** a proc body binds through `upvar` —
+/// caller-frame names the callee spells in its *own* text, with no call-site
+/// argument word to key on (`upvar 1 name name`, issue #923 audit idx 22 /
+/// issue #1139).  Returns `caller_name → written-through-alias`.
+///
+/// Strictly the complement of [`caller_frame_upvar_params`]: that fact keys
+/// on a `$param` **source** (the name arrives from the call site); this one
+/// keys on a *literal* source (the name is fixed by the callee).  tclsh
+/// 9.0.4 / 8.6.14, identical: with `proc np {} {upvar name name; set name
+/// W1}`, a caller running `np; puts $name` prints `W1` — `name` exists in
+/// the caller's frame although the caller never assigns it and no call-site
+/// word spells it.
+///
+/// Exclusions, each the abstaining direction:
+///
+/// * a non-caller frame level (`upvar 0` / `#0` / `2` / `$lvl`) — a
+///   different frame entirely, see [`caller_frame_upvar_params`]'s table;
+/// * a `::`-qualified source (`upvar 1 ::ns::x local`) — a fixed global/
+///   namespace cell, level-independent, already linked by the analyser's
+///   `handle_upvar_command` `otherVar` link (issue #923 idx 98);
+/// * an array element or any substituted/computed source — not a plain
+///   caller-frame scalar name this scan can claim;
+/// * a dynamic **local** side — with no alias name, the write-through scan
+///   below has nothing to match, so the pair contributes nothing here (the
+///   compiler-side summary still widens the call site, issue #1165).
+///
+/// The write-through upgrade mirrors [`record_upvar_pairs`]'s rule for
+/// params: a later registry-declared `VarWrite` on the alias local (`set
+/// name …`, `lassign … name`) marks the caller name as *created* by a call;
+/// an alias only ever read leaves it `false` (a referencing call site, not a
+/// creating one).  Only the top-level command scan is walked, matching the
+/// shallow trait pass exactly.
+#[must_use]
+pub fn caller_frame_literal_targets(
+    body_source: &str,
+    registry: &CommandRegistry,
+    config: LexerConfig,
+) -> HashMap<String, bool> {
+    use tcl_registry::frame_effect::FrameArgLayout;
+
+    let mut targets: HashMap<String, bool> = HashMap::new();
+    if body_source.trim().is_empty() {
+        return targets;
+    }
+    // local alias name → the caller-frame name it stands for.
+    let mut alias_to_target: HashMap<String, String> = HashMap::new();
+    let segs = segment_commands_with_offset_and_config(body_source, 0, config);
+    for seg in &segs {
+        let Some(head) = seg.texts.first() else {
+            continue;
+        };
+        // Registry-driven recognition: any command whose frame-effect
+        // grammar is `otherVar myVar` alias pairs (`upvar`), never a
+        // spelled name.
+        if registry
+            .frame_effect(head)
+            .is_none_or(|spec| spec.layout != FrameArgLayout::AliasPairs)
+        {
+            continue;
+        }
+        let (level, pairs) = upvar_level_and_pairs(&seg.texts[1..], registry);
+        if !level.is_caller_frame() {
+            continue;
+        }
+        let mut i = 0;
+        while i + 1 < pairs.len() {
+            let (src, dst) = (&pairs[i], &pairs[i + 1]);
+            i += 2;
+            if is_literal_caller_frame_name(src) && is_plain_local_name(dst) {
+                targets.entry(src.clone()).or_insert(false);
+                alias_to_target.insert(dst.clone(), src.clone());
+            }
+        }
+    }
+    if alias_to_target.is_empty() {
+        return targets;
+    }
+    for seg in &segs {
+        let Some(head) = seg.texts.first() else {
+            continue;
+        };
+        let args: Vec<&str> = seg.texts.iter().skip(1).map(String::as_str).collect();
+        for idx in registry.arg_indices_for_role(head, &args, ArgRole::VarWrite) {
+            if let Some(word) = args.get(idx)
+                && let Some(caller_name) = alias_to_target.get(*word)
+            {
+                targets.insert(caller_name.clone(), true);
+            }
+        }
+    }
+    targets
+}
+
+/// A plain caller-frame scalar name: no substitution, no bracket, no
+/// namespace qualifier, no array element.  Anything else is either a
+/// different cell (`::`-qualified) or unknowable, and abstains.
+fn is_literal_caller_frame_name(word: &str) -> bool {
+    !word.is_empty()
+        && !word.contains("::")
+        && word
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 /// `namespace upvar namespace ?otherVar myVar ...?` — the pairs alias namespace
@@ -1400,6 +1511,58 @@ mod tests {
                 expected,
                 "{body:?} -> {got:?} (expected caller-frame param: {expected})"
             );
+        }
+    }
+
+    /// Issue #1139: the literal-target fact — `upvar 1 name name` binds the
+    /// caller's `name`, written through the alias when the body assigns it.
+    /// tclsh 9.0.4: `proc np {} {upvar name name; set name W1}` then
+    /// `np; puts $name` prints `W1` in the caller.
+    #[test]
+    fn caller_frame_literal_targets_records_written_and_read_only() {
+        let registry = CommandRegistry::build_default();
+        let got = caller_frame_literal_targets(
+            "upvar name name\nset name W1",
+            &registry,
+            LexerConfig::default(),
+        );
+        assert_eq!(got.get("name"), Some(&true), "written through the alias");
+        // A body that only reads through the alias creates nothing.
+        let got = caller_frame_literal_targets(
+            "upvar name name\nreturn [string length $name]",
+            &registry,
+            LexerConfig::default(),
+        );
+        assert_eq!(got.get("name"), Some(&false), "read-only alias");
+        // Distinct local alias spelling still records the CALLER name.
+        let got = caller_frame_literal_targets(
+            "upvar 1 other mine\nset mine 1",
+            &registry,
+            LexerConfig::default(),
+        );
+        assert_eq!(got.get("other"), Some(&true));
+        assert!(!got.contains_key("mine"));
+    }
+
+    /// The exclusions: non-caller levels, `::`-qualified cells, array
+    /// elements, substituted sources, dynamic locals, `namespace upvar`.
+    #[test]
+    fn caller_frame_literal_targets_excludes_other_frames_and_cells() {
+        let registry = CommandRegistry::build_default();
+        for body in [
+            "upvar 0 name name; set name 1",
+            "upvar #0 name name; set name 1",
+            "upvar 2 name name; set name 1",
+            "upvar $lvl name name; set name 1",
+            "upvar 1 ::tk::FocusGrab($i) data; set data 1",
+            "upvar 1 ::ns::cell local; set local 1",
+            "upvar 1 arr(k) local; set local 1",
+            "upvar 1 $src local; set local 1",
+            "upvar 1 name $dst",
+            "namespace upvar ::cfg name local; set local 1",
+        ] {
+            let got = caller_frame_literal_targets(body, &registry, LexerConfig::default());
+            assert!(got.is_empty(), "{body:?} must record nothing, got {got:?}");
         }
     }
 

--- a/rust/tcl-compiler/src/analyser/param_traits.rs
+++ b/rust/tcl-compiler/src/analyser/param_traits.rs
@@ -1017,9 +1017,9 @@ pub fn caller_frame_upvar_params(
         // same test `caller_frame_literal_targets` applies — never a
         // spelled command name.
         if seg.texts.first().is_none_or(|head| {
-            registry
-                .frame_effect(head)
-                .is_none_or(|spec| spec.layout != tcl_registry::frame_effect::FrameArgLayout::AliasPairs)
+            registry.frame_effect(head).is_none_or(|spec| {
+                spec.layout != tcl_registry::frame_effect::FrameArgLayout::AliasPairs
+            })
         }) {
             continue;
         }
@@ -1139,9 +1139,7 @@ pub fn caller_frame_literal_targets(
 fn is_literal_caller_frame_name(word: &str) -> bool {
     !word.is_empty()
         && !word.contains("::")
-        && word
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_')
+        && word.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 /// `namespace upvar namespace ?otherVar myVar ...?` — the pairs alias namespace

--- a/rust/tcl-compiler/src/analyser/snapshot.rs
+++ b/rust/tcl-compiler/src/analyser/snapshot.rs
@@ -192,6 +192,7 @@ mod tests {
             doc: String::new(),
             param_traits: std::collections::HashMap::new(),
             caller_frame_params: std::collections::HashSet::new(),
+            caller_frame_literals: std::collections::HashMap::new(),
         }
     }
 

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -467,6 +467,15 @@ pub struct ProcDef {
     /// trait alone.  Populated by
     /// [`super::param_traits::caller_frame_upvar_params`].
     pub caller_frame_params: std::collections::HashSet<String>,
+    /// **Literal** caller-frame names this proc binds in its immediate
+    /// caller's frame — spelled in the proc's *own* body (`upvar 1 name
+    /// name`), so no call-site argument word carries them (issue #923 audit
+    /// idx 22 / issue #1139).  `name → written-through-alias`: `true` means
+    /// a call *creates* the variable in the calling frame, `false` that it
+    /// only reads it.  Populated by
+    /// [`super::param_traits::caller_frame_literal_targets`]; empty when
+    /// the body binds none.
+    pub caller_frame_literals: std::collections::HashMap<String, bool>,
 }
 
 impl ProcDef {

--- a/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
+++ b/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
@@ -84,7 +84,7 @@ impl CfgBuilder {
                 // 122) — in the condition writes result variables; record
                 // them as defs so a read in the guarded body is not
                 // flagged read-before-set (W210).
-                let cond_defs = self.condition_out_vars(&clause.condition);
+                let (cond_defs, opaque_global) = self.condition_out_vars(&clause.condition);
                 self.block_mut(&dispatch).statements.push(Statement::Call {
                     span: *span,
                     command: "<cond>".into(),
@@ -97,6 +97,19 @@ impl CfgBuilder {
                     tokens: None,
                     foreach_groups: None,
                 });
+                // A condition-embedded callee that runs an unreadable
+                // script at the global frame (issue #1198) clobbers names
+                // no def list can enumerate — widen with a barrier.
+                if opaque_global {
+                    self.block_mut(&dispatch).statements.push(Statement::Barrier {
+                        span: *span,
+                        reason: "condition runs an unreadable script at the global frame".into(),
+                        command: "<global-frame-script>".into(),
+                        canonical_command: None,
+                        args: Vec::new(),
+                        tokens: None,
+                    });
+                }
             }
 
             let then_block = self.new_block("if_then");
@@ -286,7 +299,7 @@ impl CfgBuilder {
         // them as defs in the header so a read in the body is not flagged
         // read-before-set (W210).
         if expr_has_command(condition) {
-            let cond_defs = self.condition_out_vars(condition);
+            let (cond_defs, opaque_global) = self.condition_out_vars(condition);
             self.block_mut(&header).statements.push(Statement::Call {
                 span: *condition_span,
                 command: "<cond>".into(),
@@ -299,6 +312,18 @@ impl CfgBuilder {
                 tokens: None,
                 foreach_groups: None,
             });
+            // See `lower_if`: an unreadable global-frame script in the
+            // condition (issue #1198) widens with a barrier.
+            if opaque_global {
+                self.block_mut(&header).statements.push(Statement::Barrier {
+                    span: *condition_span,
+                    reason: "condition runs an unreadable script at the global frame".into(),
+                    command: "<global-frame-script>".into(),
+                    canonical_command: None,
+                    args: Vec::new(),
+                    tokens: None,
+                });
+            }
         }
 
         let body_id = self.bid(&body_block);

--- a/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
+++ b/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
@@ -101,14 +101,17 @@ impl CfgBuilder {
                 // script at the global frame (issue #1198) clobbers names
                 // no def list can enumerate — widen with a barrier.
                 if opaque_global {
-                    self.block_mut(&dispatch).statements.push(Statement::Barrier {
-                        span: *span,
-                        reason: "condition runs an unreadable script at the global frame".into(),
-                        command: "<global-frame-script>".into(),
-                        canonical_command: None,
-                        args: Vec::new(),
-                        tokens: None,
-                    });
+                    self.block_mut(&dispatch)
+                        .statements
+                        .push(Statement::Barrier {
+                            span: *span,
+                            reason: "condition runs an unreadable script at the global frame"
+                                .into(),
+                            command: "<global-frame-script>".into(),
+                            canonical_command: None,
+                            args: Vec::new(),
+                            tokens: None,
+                        });
                 }
             }
 

--- a/rust/tcl-compiler/src/cfg_builder/global_write_info.rs
+++ b/rust/tcl-compiler/src/cfg_builder/global_write_info.rs
@@ -57,18 +57,28 @@ use crate::naming::normalise_var_name;
 use crate::var_observability::{State, stmt_gen};
 
 /// Per-proc summary: the outer-scope (global/namespace) variable names a
-/// proc's body writes while aliased via `global` / `variable` / `upvar #0`.
+/// proc's body writes while aliased via `global` / `variable` / `upvar #0`,
+/// or through a script it runs **at the global frame** (`uplevel #0 …`,
+/// issue #1198).
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct GlobalWriteInfo {
     /// Literal outer-scope names this proc's body writes.
     pub names: BTreeSet<String>,
+    /// The proc runs a script at the **global frame** that this analysis
+    /// cannot read — `uplevel #0 $body`, `uplevel #0 [list set $v 1]` with
+    /// an unresolvable target, or a global-frame script whose write target
+    /// is not a plain literal.  Any global/namespace name may be written
+    /// *or read* there, so a call site must widen to an opaque barrier
+    /// instead of trusting [`Self::names`] (issue #1198 — before this,
+    /// O102 forwarded a stale global constant straight across the call).
+    pub opaque_global_frame: bool,
 }
 
 impl GlobalWriteInfo {
     /// True when the proc's body writes no outer-scope name.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.names.is_empty()
+        self.names.is_empty() && !self.opaque_global_frame
     }
 }
 
@@ -152,6 +162,13 @@ pub fn detect_global_write_procs(module: &Module) -> HashMap<String, GlobalWrite
                         changed = true;
                     }
                 }
+                // An opaque global-frame script is transitive the same way
+                // the names are: a caller of `setter` clobbers whatever
+                // `setter`'s `uplevel #0 $body` clobbers (issue #1198).
+                if source_summary.opaque_global_frame && !target_summary.opaque_global_frame {
+                    target_summary.opaque_global_frame = true;
+                    changed = true;
+                }
             }
         }
     }
@@ -185,9 +202,153 @@ fn own_body_global_writes(
     let mut renamed_aliases: HashMap<String, String> = HashMap::new();
     accumulate_state(body, &mut state, &mut renamed_aliases, registry);
 
-    let mut names = BTreeSet::new();
-    collect_write_targets(body, &state, &renamed_aliases, &mut names);
-    GlobalWriteInfo { names }
+    let mut info = GlobalWriteInfo::default();
+    collect_write_targets(body, &state, &renamed_aliases, &mut info.names);
+    collect_global_frame_effects(body, registry, &mut info);
+    info
+}
+
+/// Pass 3 (issue #1198): the writes a proc performs by running a script **at
+/// the global frame** — `uplevel #0 {…}` (lowered to [`Statement::UpFrame`]
+/// with `absolute` set and shift `0`) and `uplevel #0 [list CMD …]` /
+/// `uplevel #0 $body` (still a plain call/barrier statement).  These need no
+/// `global`/`variable` declaration at all, so the flag-state passes above
+/// cannot see them — before this pass, `proc setter {} {uplevel #0 {set x
+/// 99}}` summarised as writing nothing and O102 forwarded the caller's stale
+/// `x` straight across `setter` (tclsh 9.0.3/9.0.4: prints `99`, the
+/// optimised program printed `5`).
+///
+/// A literal write target goes into [`GlobalWriteInfo::names`]; anything
+/// unreadable (a dynamic script, an unresolvable constructed target, a
+/// non-literal name) widens [`GlobalWriteInfo::opaque_global_frame`], which
+/// the call site turns into an opaque barrier.  Frame targeting mirrors
+/// [`super::upvar_info`]'s table exactly: only the **global** frame lands
+/// here — caller-relative levels are the caller-frame summary's business,
+/// and `uplevel 0` stays in the callee's own frame.
+fn collect_global_frame_effects(
+    script: &Script,
+    registry: &tcl_registry::CommandRegistry,
+    info: &mut GlobalWriteInfo,
+) {
+    use tcl_registry::frame_effect::{FrameArgLayout, FrameLevel};
+
+    for stmt in &script.statements {
+        match stmt {
+            Statement::UpFrame {
+                absolute: true,
+                frame_shift: 0,
+                body,
+                ..
+            } => {
+                for name in crate::ir_helpers::defs_from_ir_script(body) {
+                    record_global_frame_write(&name, info);
+                }
+                // A dynamic write target (`set $n 1`) contributes **no**
+                // def at all — `ssa::defs_of` drops it — so it must widen
+                // here explicitly or the write would go unrecorded.
+                if script_has_dynamic_write_target(body) {
+                    info.opaque_global_frame = true;
+                }
+            }
+            Statement::Call { command, args, .. } | Statement::Barrier { command, args, .. } => {
+                let Some(spec) = registry.frame_effect(command) else {
+                    continue;
+                };
+                if spec.layout != FrameArgLayout::ScriptInSelectedFrame {
+                    continue;
+                }
+                let refs: Vec<&str> = args.iter().map(String::as_str).collect();
+                let (level, rest) = spec.resolve(&refs);
+                if level != FrameLevel::Absolute(0) {
+                    continue;
+                }
+                // `uplevel` concat-joins the remaining words into one script;
+                // a single constructed-list word is the readable case, same
+                // as the caller-frame summary's rule.
+                if let [single] = rest
+                    && record_constructed_global_body(single, registry, info)
+                {
+                    continue;
+                }
+                info.opaque_global_frame = true;
+            }
+            _ => {}
+        }
+        for body in nested_bodies(stmt) {
+            collect_global_frame_effects(body, registry, info);
+        }
+    }
+}
+
+/// Whether any statement in `script` (recursively) assigns through a
+/// **dynamic** write target (`set $n 1`, `set ${tok}(k) 1`) — a write
+/// [`crate::ssa::defs_of`] cannot name and therefore silently drops, which
+/// a frame-effect summary must widen on instead.  Shared with
+/// [`super::upvar_info`]'s inlined-`uplevel`-body scan, which has the
+/// identical blind spot one frame nearer.
+pub(super) fn script_has_dynamic_write_target(script: &Script) -> bool {
+    script.statements.iter().any(|stmt| {
+        let own = match stmt {
+            Statement::AssignConst {
+                name, name_braced, ..
+            }
+            | Statement::AssignExpr {
+                name, name_braced, ..
+            }
+            | Statement::AssignValue {
+                name, name_braced, ..
+            }
+            | Statement::Incr {
+                name, name_braced, ..
+            } => crate::ssa::is_dynamic_write_target(name, *name_braced),
+            _ => false,
+        };
+        own || nested_bodies(stmt)
+            .into_iter()
+            .any(script_has_dynamic_write_target)
+    })
+}
+
+/// Record one global-frame write target: a plain literal name is
+/// enumerable, anything else widens.
+fn record_global_frame_write(name: &str, info: &mut GlobalWriteInfo) {
+    let name = normalise_var_name(name);
+    if !name.is_empty() && !name.contains(['$', '[', '{', '"', ' ']) {
+        info.names.insert(name.to_owned());
+    } else {
+        info.opaque_global_frame = true;
+    }
+}
+
+/// Read a `uplevel #0 [list CMD ARG…]` body word, recording the global names
+/// the constructed command writes.  Returns `false` when the word is not a
+/// readable constructed list, so the caller widens.  The list grammar is
+/// [`super::upvar_info::constructed_script_words`] — shared with the
+/// caller-frame summary so the two cannot drift.
+fn record_constructed_global_body(
+    word: &str,
+    registry: &tcl_registry::CommandRegistry,
+    info: &mut GlobalWriteInfo,
+) -> bool {
+    let Some(constructed) = super::upvar_info::constructed_script_words(word, registry) else {
+        return false;
+    };
+    let Some((command, cargs)) = constructed.split_first() else {
+        return false;
+    };
+    if registry.get(command).is_none() {
+        // A user proc run at the global frame: its own frame effects land
+        // there under names this per-proc walk cannot resolve — widen.
+        return false;
+    }
+    let arg_refs: Vec<&str> = cargs.iter().map(String::as_str).collect();
+    for idx in registry.arg_indices_for_role(command, &arg_refs, tcl_registry::ArgRole::VarWrite) {
+        let Some(target) = arg_refs.get(idx) else {
+            continue;
+        };
+        record_global_frame_write(target, info);
+    }
+    true
 }
 
 fn accumulate_state(
@@ -498,6 +659,71 @@ mod tests {
         let info = detect_global_write_procs(&m);
         assert!(info.get("::a").unwrap().names.contains("x"));
         assert!(info.get("::b").unwrap().names.contains("x"));
+    }
+
+    #[test]
+    fn uplevel_hash_zero_literal_body_records_global_writes() {
+        // Issue #1198 — `uplevel #0 {set x 99}` needs no `global`
+        // declaration at all (tclsh 9.0.3/9.0.4: the caller-visible `x`
+        // really is 99 afterwards).
+        let m = module("proc ::setter {} { uplevel #0 { set x 99 } }");
+        let info = detect_global_write_procs(&m);
+        assert!(info.get("::setter").unwrap().names.contains("x"));
+        assert!(!info.get("::setter").unwrap().opaque_global_frame);
+    }
+
+    #[test]
+    fn uplevel_hash_zero_constructed_list_records_global_writes() {
+        // `uplevel #0 [list set k 77]` — tclsh 9.0.4: the global `k` is 77.
+        let m = module("proc ::s3 {} { uplevel #0 [list set k 77] }");
+        let info = detect_global_write_procs(&m);
+        assert!(info.get("::s3").unwrap().names.contains("k"));
+        assert!(!info.get("::s3").unwrap().opaque_global_frame);
+    }
+
+    #[test]
+    fn uplevel_hash_zero_dynamic_script_is_opaque() {
+        // `uplevel #0 $body` — any global may be written or read.
+        let m = module("proc ::s2 {body} { uplevel #0 $body }");
+        let info = detect_global_write_procs(&m);
+        assert!(info.get("::s2").unwrap().opaque_global_frame);
+        assert!(!info.get("::s2").unwrap().is_empty());
+    }
+
+    #[test]
+    fn uplevel_hash_zero_opaqueness_is_transitive() {
+        let m = module(
+            "proc ::s2 {body} { uplevel #0 $body }\nproc ::outer {body} { s2 $body }",
+        );
+        let info = detect_global_write_procs(&m);
+        assert!(info.get("::outer").unwrap().opaque_global_frame);
+    }
+
+    #[test]
+    fn uplevel_hash_zero_non_writing_script_stays_empty() {
+        // TN — a global-frame script that writes nothing (`uplevel #0
+        // [list puts hi]`) contributes neither names nor opaqueness.
+        let m = module("proc ::shout {} { uplevel #0 [list puts hi] }");
+        let info = detect_global_write_procs(&m);
+        assert!(info.get("::shout").unwrap().is_empty());
+    }
+
+    #[test]
+    fn uplevel_caller_frame_is_not_a_global_write() {
+        // TN — `uplevel 1 {set n 1}` writes the *caller's* frame, which is
+        // `upvar_info`'s business, not this summary's.
+        let m = module("proc ::p {} { uplevel 1 { set n 1 } }");
+        let info = detect_global_write_procs(&m);
+        assert!(info.get("::p").unwrap().is_empty());
+    }
+
+    #[test]
+    fn uplevel_hash_zero_dynamic_write_target_in_literal_body_is_opaque() {
+        // `uplevel #0 {set $n 1}` — the body is readable but the written
+        // name is not.
+        let m = module("proc ::p {n} { uplevel #0 \"set $n 1\" }");
+        let info = detect_global_write_procs(&m);
+        assert!(info.get("::p").unwrap().opaque_global_frame);
     }
 
     #[test]

--- a/rust/tcl-compiler/src/cfg_builder/global_write_info.rs
+++ b/rust/tcl-compiler/src/cfg_builder/global_write_info.rs
@@ -692,9 +692,7 @@ mod tests {
 
     #[test]
     fn uplevel_hash_zero_opaqueness_is_transitive() {
-        let m = module(
-            "proc ::s2 {body} { uplevel #0 $body }\nproc ::outer {body} { s2 $body }",
-        );
+        let m = module("proc ::s2 {body} { uplevel #0 $body }\nproc ::outer {body} { s2 $body }");
         let info = detect_global_write_procs(&m);
         assert!(info.get("::outer").unwrap().opaque_global_frame);
     }

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -340,111 +340,22 @@ impl CfgBuilder {
     /// ([`Self::init_written_names`]) can ask what a statement writes without
     /// recording the statement twice.
     fn upvar_invalidated(&self, mut stmt: Statement) -> Vec<Statement> {
-        // 0. A callee whose `upvar` caller-side name is unresolvable
-        //    (`upvar 1 $computed x`) can write ANY caller variable, and a
-        //    callee that runs an unreadable script at the global frame
-        //    (`uplevel #0 $body`, issue #1198) can write or read ANY
-        //    global/namespace name — no per-name def list is sound for
-        //    either, so widen the call site with an opaque barrier after
-        //    the call (SCCP/propagation widen every tracked value at a
+        // 0. A callee whose caller-frame effect cannot be enumerated per
+        //    name widens the call site with an opaque barrier after the
+        //    call (SCCP/propagation widen every tracked value at a
         //    `Statement::Barrier`), instead of trusting the
         //    under-approximate `caller_side_defs` / `names`.
-        if let Statement::Call { command, span, .. } = &stmt {
-            let unresolvable_upvar = self
-                .upvar_procs
-                .get(command.as_str())
-                .is_some_and(|info| info.has_unresolvable_caller_target);
-            let opaque_global = self
-                .global_write_procs
-                .get(command.as_str())
-                .is_some_and(|info| info.opaque_global_frame);
-            if unresolvable_upvar || opaque_global {
-                let reason = if unresolvable_upvar {
-                    format!("{command} upvar-aliases a dynamic caller variable")
-                } else {
-                    format!("{command} runs an unreadable script at the global frame")
-                };
-                let barrier = Statement::Barrier {
-                    span: *span,
-                    reason,
-                    command: command.clone(),
-                    canonical_command: None,
-                    args: Vec::new(),
-                    tokens: None,
-                };
-                return vec![stmt, barrier];
-            }
+        if let Some(barrier) = self.opaque_call_barrier(&stmt) {
+            return vec![stmt, barrier];
         }
 
-        // 1. Direct-call extras: command is a known upvar proc / a proc that
-        //    writes outer-scope names.  Extras are merged as DEFS only; the
-        //    "the callee may also *read* the aliased cell" half is recorded
-        //    on [`crate::cfg::Function::alias_observed_vars`] by
-        //    [`Self::record_alias_observed`] (a read here would fabricate
-        //    read-before-set uses — a false W210 — for the pure out-param
-        //    shape).
-        let direct_extras: Vec<String> = match &stmt {
-            Statement::Call { command, args, .. } => {
-                let mut extras = self
-                    .upvar_procs
-                    .get(command.as_str())
-                    .map(|info| {
-                        let params: &[String] = self
-                            .proc_params
-                            .get(command.as_str())
-                            .map_or(&[][..], Vec::as_slice);
-                        info.caller_side_defs(args, params)
-                    })
-                    .unwrap_or_default();
-                if let Some(info) = self.global_write_procs.get(command.as_str()) {
-                    for name in &info.names {
-                        if !extras.contains(name) {
-                            extras.push(name.clone());
-                        }
-                    }
-                }
-                extras
-            }
-            _ => Vec::new(),
-        };
+        // 1. Direct-call extras: command is a known upvar proc / a proc
+        //    that writes outer-scope names.
+        let direct_extras = self.direct_call_extras(&stmt);
 
         // 2. Embedded-substitution extras: walk text for
         //    `[upvar_proc arg]` / `[global_write_proc arg]` substitutions.
-        let texts: Vec<&str> = match &stmt {
-            Statement::AssignValue { value, .. } if value.contains('[') => vec![value.as_str()],
-            Statement::Call { args, .. } => args
-                .iter()
-                .filter(|a| a.contains('['))
-                .map(String::as_str)
-                .collect(),
-            _ => Vec::new(),
-        };
-        let mut embedded_extras: Vec<String> = Vec::new();
-        let mut embedded_opaque_global = false;
-        for text in texts {
-            for d in self.upvar_defs_from_text(text) {
-                if !embedded_extras.contains(&d) {
-                    embedded_extras.push(d);
-                }
-            }
-            let (global_defs, opaque) = self.global_write_defs_from_text(text);
-            embedded_opaque_global |= opaque;
-            for d in global_defs {
-                if !embedded_extras.contains(&d) {
-                    embedded_extras.push(d);
-                }
-            }
-            // A var-mutating builtin inside a command substitution
-            // (`set y [append x b]`, `[incr x]`, `[lset l …]`) writes its target
-            // variable as a side effect; record it so copy / constant
-            // propagation (O100) does not propagate a stale value past the
-            // mutation (FP-OPT-06).
-            for d in Self::builtin_write_defs_from_text(text) {
-                if !embedded_extras.contains(&d) {
-                    embedded_extras.push(d);
-                }
-            }
-        }
+        let (embedded_extras, embedded_opaque_global) = self.embedded_subst_extras(&stmt);
 
         if direct_extras.is_empty() && embedded_extras.is_empty() && !embedded_opaque_global {
             return vec![stmt];
@@ -508,6 +419,117 @@ impl CfgBuilder {
         }
         out.push(stmt);
         out
+    }
+
+    /// The opaque widening barrier for a direct call whose callee's
+    /// caller-frame effect has no sound per-name def list: a callee whose
+    /// `upvar` caller-side name is unresolvable (`upvar 1 $computed x`) can
+    /// write ANY caller variable, and a callee that runs an unreadable
+    /// script at the global frame (`uplevel #0 $body`, issue #1198) can
+    /// write or read ANY global/namespace name.
+    fn opaque_call_barrier(&self, stmt: &Statement) -> Option<Statement> {
+        let Statement::Call { command, span, .. } = stmt else {
+            return None;
+        };
+        let unresolvable_upvar = self
+            .upvar_procs
+            .get(command.as_str())
+            .is_some_and(|info| info.has_unresolvable_caller_target);
+        let opaque_global = self
+            .global_write_procs
+            .get(command.as_str())
+            .is_some_and(|info| info.opaque_global_frame);
+        if !unresolvable_upvar && !opaque_global {
+            return None;
+        }
+        let reason = if unresolvable_upvar {
+            format!("{command} upvar-aliases a dynamic caller variable")
+        } else {
+            format!("{command} runs an unreadable script at the global frame")
+        };
+        Some(Statement::Barrier {
+            span: *span,
+            reason,
+            command: command.clone(),
+            canonical_command: None,
+            args: Vec::new(),
+            tokens: None,
+        })
+    }
+
+    /// The direct-call half of [`Self::upvar_invalidated`]: the caller-side
+    /// names a known upvar proc / global-writing proc defines at this call.
+    /// Extras are merged as DEFS only; the "the callee may also *read* the
+    /// aliased cell" half is recorded on
+    /// [`crate::cfg::Function::alias_observed_vars`] by
+    /// [`Self::record_alias_observed`] (a read here would fabricate
+    /// read-before-set uses — a false W210 — for the pure out-param shape).
+    fn direct_call_extras(&self, stmt: &Statement) -> Vec<String> {
+        let Statement::Call { command, args, .. } = stmt else {
+            return Vec::new();
+        };
+        let mut extras = self
+            .upvar_procs
+            .get(command.as_str())
+            .map(|info| {
+                let params: &[String] = self
+                    .proc_params
+                    .get(command.as_str())
+                    .map_or(&[][..], Vec::as_slice);
+                info.caller_side_defs(args, params)
+            })
+            .unwrap_or_default();
+        if let Some(info) = self.global_write_procs.get(command.as_str()) {
+            for name in &info.names {
+                if !extras.contains(name) {
+                    extras.push(name.clone());
+                }
+            }
+        }
+        extras
+    }
+
+    /// The embedded-substitution half of [`Self::upvar_invalidated`]: the
+    /// caller-side defs contributed by `[…]` substitutions in the
+    /// statement's argument words (or an assignment's value), plus whether
+    /// any embedded callee runs an unreadable script at the global frame.
+    fn embedded_subst_extras(&self, stmt: &Statement) -> (Vec<String>, bool) {
+        let texts: Vec<&str> = match stmt {
+            Statement::AssignValue { value, .. } if value.contains('[') => vec![value.as_str()],
+            Statement::Call { args, .. } => args
+                .iter()
+                .filter(|a| a.contains('['))
+                .map(String::as_str)
+                .collect(),
+            _ => Vec::new(),
+        };
+        let mut embedded_extras: Vec<String> = Vec::new();
+        let mut embedded_opaque_global = false;
+        for text in texts {
+            for d in self.upvar_defs_from_text(text) {
+                if !embedded_extras.contains(&d) {
+                    embedded_extras.push(d);
+                }
+            }
+            let (global_defs, opaque) = self.global_write_defs_from_text(text);
+            embedded_opaque_global |= opaque;
+            for d in global_defs {
+                if !embedded_extras.contains(&d) {
+                    embedded_extras.push(d);
+                }
+            }
+            // A var-mutating builtin inside a command substitution
+            // (`set y [append x b]`, `[incr x]`, `[lset l …]`) writes its
+            // target variable as a side effect; record it so copy / constant
+            // propagation (O100) does not propagate a stale value past the
+            // mutation (FP-OPT-06).
+            for d in Self::builtin_write_defs_from_text(text) {
+                if !embedded_extras.contains(&d) {
+                    embedded_extras.push(d);
+                }
+            }
+        }
+        (embedded_extras, embedded_opaque_global)
     }
 
     /// Every command word a statement invokes: its own head, plus the head

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -341,26 +341,39 @@ impl CfgBuilder {
     /// recording the statement twice.
     fn upvar_invalidated(&self, mut stmt: Statement) -> Vec<Statement> {
         // 0. A callee whose `upvar` caller-side name is unresolvable
-        //    (`upvar 1 $computed x`) can write ANY caller variable — no
-        //    per-name def list is sound, so widen the call site with an
-        //    opaque barrier after the call (SCCP/propagation widen every
-        //    tracked value at a `Statement::Barrier`), instead of trusting
-        //    the under-approximate `caller_side_defs`.
-        if let Statement::Call { command, span, .. } = &stmt
-            && self
+        //    (`upvar 1 $computed x`) can write ANY caller variable, and a
+        //    callee that runs an unreadable script at the global frame
+        //    (`uplevel #0 $body`, issue #1198) can write or read ANY
+        //    global/namespace name — no per-name def list is sound for
+        //    either, so widen the call site with an opaque barrier after
+        //    the call (SCCP/propagation widen every tracked value at a
+        //    `Statement::Barrier`), instead of trusting the
+        //    under-approximate `caller_side_defs` / `names`.
+        if let Statement::Call { command, span, .. } = &stmt {
+            let unresolvable_upvar = self
                 .upvar_procs
                 .get(command.as_str())
-                .is_some_and(|info| info.has_unresolvable_caller_target)
-        {
-            let barrier = Statement::Barrier {
-                span: *span,
-                reason: format!("{command} upvar-aliases a dynamic caller variable"),
-                command: command.clone(),
-                canonical_command: None,
-                args: Vec::new(),
-                tokens: None,
-            };
-            return vec![stmt, barrier];
+                .is_some_and(|info| info.has_unresolvable_caller_target);
+            let opaque_global = self
+                .global_write_procs
+                .get(command.as_str())
+                .is_some_and(|info| info.opaque_global_frame);
+            if unresolvable_upvar || opaque_global {
+                let reason = if unresolvable_upvar {
+                    format!("{command} upvar-aliases a dynamic caller variable")
+                } else {
+                    format!("{command} runs an unreadable script at the global frame")
+                };
+                let barrier = Statement::Barrier {
+                    span: *span,
+                    reason,
+                    command: command.clone(),
+                    canonical_command: None,
+                    args: Vec::new(),
+                    tokens: None,
+                };
+                return vec![stmt, barrier];
+            }
         }
 
         // 1. Direct-call extras: command is a known upvar proc / a proc that
@@ -407,13 +420,16 @@ impl CfgBuilder {
             _ => Vec::new(),
         };
         let mut embedded_extras: Vec<String> = Vec::new();
+        let mut embedded_opaque_global = false;
         for text in texts {
             for d in self.upvar_defs_from_text(text) {
                 if !embedded_extras.contains(&d) {
                     embedded_extras.push(d);
                 }
             }
-            for d in self.global_write_defs_from_text(text) {
+            let (global_defs, opaque) = self.global_write_defs_from_text(text);
+            embedded_opaque_global |= opaque;
+            for d in global_defs {
                 if !embedded_extras.contains(&d) {
                     embedded_extras.push(d);
                 }
@@ -430,9 +446,25 @@ impl CfgBuilder {
             }
         }
 
-        if direct_extras.is_empty() && embedded_extras.is_empty() {
+        if direct_extras.is_empty() && embedded_extras.is_empty() && !embedded_opaque_global {
             return vec![stmt];
         }
+
+        // 2b. An embedded call to a proc that runs an unreadable script at
+        //     the global frame (`set y [setter]` where `setter` does
+        //     `uplevel #0 $body`, issue #1198): no def list can enumerate
+        //     what it clobbers, so prepend an opaque barrier — the same
+        //     program-order position the synthetic `<upvar-invalidate>`
+        //     uses, so the host statement's own reads already see the
+        //     widened state.
+        let opaque_barrier = embedded_opaque_global.then(|| Statement::Barrier {
+            span: stmt.span(),
+            reason: "embedded call runs an unreadable script at the global frame".to_owned(),
+            command: "<global-frame-script>".to_owned(),
+            canonical_command: None,
+            args: Vec::new(),
+            tokens: None,
+        });
 
         // 3. Merge into the host statement when it's a Call.
         if let Statement::Call { defs, .. } = &mut stmt {
@@ -446,15 +478,22 @@ impl CfgBuilder {
                     defs.push(d);
                 }
             }
-            return vec![stmt];
+            return match opaque_barrier {
+                Some(barrier) => vec![barrier, stmt],
+                None => vec![stmt],
+            };
         }
 
         // 4. Non-Call host (e.g. AssignValue) with embedded extras —
         //    emit a synthetic `<upvar-invalidate>` Call before the
         //    host so the affected vars are invalidated in
         //    program order.
+        let mut out = Vec::new();
+        if let Some(barrier) = opaque_barrier {
+            out.push(barrier);
+        }
         if !embedded_extras.is_empty() {
-            let synthetic = Statement::Call {
+            out.push(Statement::Call {
                 span: stmt.span(),
                 command: "<upvar-invalidate>".to_string(),
                 canonical_command: None,
@@ -465,11 +504,10 @@ impl CfgBuilder {
                 safe_on_uninit: false,
                 tokens: None,
                 foreach_groups: None,
-            };
-            return vec![synthetic, stmt];
+            });
         }
-
-        vec![stmt]
+        out.push(stmt);
+        out
     }
 
     /// Every command word a statement invokes: its own head, plus the head
@@ -598,15 +636,27 @@ impl CfgBuilder {
     /// [`Self::upvar_defs_from_text`], for the same soundness reason: a
     /// global write reached via `set y [mutate]` is just as real as one
     /// reached via a bare `mutate` statement.
-    fn global_write_defs_from_text(&self, text: &str) -> Vec<String> {
-        self.global_write_defs_from_text_bounded(text, 0)
+    ///
+    /// The second return is `true` when any embedded callee's summary
+    /// carries [`GlobalWriteInfo::opaque_global_frame`] (`uplevel #0 $body`,
+    /// issue #1198) — no def list can enumerate that, so the caller must
+    /// widen with an opaque barrier.
+    fn global_write_defs_from_text(&self, text: &str) -> (Vec<String>, bool) {
+        let mut opaque = false;
+        let defs = self.global_write_defs_from_text_bounded(text, 0, &mut opaque);
+        (defs, opaque)
     }
 
     /// [`Self::global_write_defs_from_text`], recursing into a nested
     /// `[...]` the same way [`Self::upvar_defs_from_text_bounded`] does
     /// (issue #923 idx 122) — see its doc for the wrapping-command shape
     /// this recovers.
-    fn global_write_defs_from_text_bounded(&self, text: &str, depth: u32) -> Vec<String> {
+    fn global_write_defs_from_text_bounded(
+        &self,
+        text: &str,
+        depth: u32,
+        opaque: &mut bool,
+    ) -> Vec<String> {
         use tcl_lexer::{Lexer, SourceMap, TokenType};
 
         if self.global_write_procs.is_empty()
@@ -632,6 +682,7 @@ impl CfgBuilder {
             if let Some(cmd) = words.first()
                 && let Some(info) = self.global_write_procs.get(cmd.as_str())
             {
+                *opaque |= info.opaque_global_frame;
                 for name in &info.names {
                     if !defs.contains(name) {
                         defs.push(name.clone());
@@ -641,7 +692,7 @@ impl CfgBuilder {
             // See `upvar_defs_from_text_bounded`'s identical step: `inner`
             // still carries any bracket nested inside it, so recurse on
             // the raw text rather than the (bracket-stripped) word list.
-            for d in self.global_write_defs_from_text_bounded(inner, depth + 1) {
+            for d in self.global_write_defs_from_text_bounded(inner, depth + 1, opaque) {
                 if !defs.contains(&d) {
                     defs.push(d);
                 }
@@ -665,12 +716,17 @@ impl CfgBuilder {
     /// though the condition's own command substitution (including the
     /// upvar write) completes before the body ever runs
     /// (tclsh9.0/8.6-verified).
-    fn condition_out_vars(&self, condition: &ExprNode) -> Vec<String> {
+    /// The second return is `true` when a condition-embedded callee runs an
+    /// unreadable script at the global frame (issue #1198): the caller must
+    /// then push an opaque barrier alongside the `<cond>` defs, because no
+    /// def list can enumerate what the condition's evaluation clobbers.
+    fn condition_out_vars(&self, condition: &ExprNode) -> (Vec<String>, bool) {
         // The CFG builder carries no registry handle (see the module note at
         // `registry_derived_cfg_classes`); the write-role answer is core Tcl in
         // every dialect, so the cached default registry is the right source.
         let registry = tcl_registry::cache::registry_for_dialect("tcl8.6");
         let mut out = crate::ir_helpers::condition_command_out_vars(condition, registry);
+        let mut opaque = false;
         let mut cmds = Vec::new();
         crate::ir_helpers::collect_expr_commands(condition, &mut cmds);
         for cmd_text in &cmds {
@@ -679,13 +735,47 @@ impl CfgBuilder {
                     out.push(d);
                 }
             }
-            for d in self.global_write_defs_from_text(cmd_text) {
+            let (global_defs, cmd_opaque) = self.global_write_defs_from_text(cmd_text);
+            opaque |= cmd_opaque;
+            for d in global_defs {
                 if !out.contains(&d) {
                     out.push(d);
                 }
             }
         }
-        out
+        (out, opaque)
+    }
+
+    /// Push the `<cond>` synthetic call (and, when the condition's embedded
+    /// callees demand it, an opaque barrier) for a condition that contains
+    /// command substitutions — the shared tail of `lower_if`, `lower_while`,
+    /// and the frozen-loop barrier.
+    fn push_condition_effects(&mut self, condition: &ExprNode, span: Span, block: &str) {
+        let (cond_defs, opaque) = self.condition_out_vars(condition);
+        if !cond_defs.is_empty() {
+            self.block_mut(block).statements.push(Statement::Call {
+                span,
+                command: "<cond>".into(),
+                canonical_command: None,
+                args: Vec::new(),
+                defs: cond_defs,
+                reads: Vec::new(),
+                reads_own_defs: false,
+                safe_on_uninit: false,
+                tokens: None,
+                foreach_groups: None,
+            });
+        }
+        if opaque {
+            self.block_mut(block).statements.push(Statement::Barrier {
+                span,
+                reason: "condition runs an unreadable script at the global frame".into(),
+                command: "<global-frame-script>".into(),
+                canonical_command: None,
+                args: Vec::new(),
+                tokens: None,
+            });
+        }
     }
 
     /// Scan *text* for `[command_substitution]` tokens whose head is a builtin
@@ -974,21 +1064,7 @@ impl CfgBuilder {
         span: Span,
         current: &str,
     ) {
-        let cond_defs = self.condition_out_vars(condition);
-        if !cond_defs.is_empty() {
-            self.block_mut(current).statements.push(Statement::Call {
-                span,
-                command: "<cond>".into(),
-                canonical_command: None,
-                args: Vec::new(),
-                defs: cond_defs,
-                reads: Vec::new(),
-                reads_own_defs: false,
-                safe_on_uninit: false,
-                tokens: None,
-                foreach_groups: None,
-            });
-        }
+        self.push_condition_effects(condition, span, current);
         self.block_mut(current).statements.push(Statement::Barrier {
             span,
             reason: format!("frozen {command} (cmd-subst condition)"),

--- a/rust/tcl-compiler/src/cfg_builder/upvar_info.rs
+++ b/rust/tcl-compiler/src/cfg_builder/upvar_info.rs
@@ -380,48 +380,11 @@ pub fn reaches_caller_frame(body: &Script, params: &[String]) -> bool {
     !info.is_empty() || !info.unnameable_local_aliases.is_empty()
 }
 
-/// Whether the module supplies **incomplete evidence** about what a `my` /
-/// `next` / object dispatch out of a method body can do to that body's frame
-/// — the whole-module gate shared by the optimiser's method-body propagation
-/// barrier (issue #1097) and the CFG builder's method-dispatch widening
-/// (issue #1177).
-///
-/// A *proc* callee is modelled per call site through
-/// [`super::detect_upvar_procs`]'s table; a **method** reached through `my`,
-/// `next`, or an object dispatch is never in that table, because the
-/// dispatch does not name its target statically.  So the answer has to come
-/// from whole-module evidence, and the governing rule is: *when the evidence
-/// is incomplete, widen to abstention.*  Two sources make it incomplete:
-///
-/// * a method body that can reach its caller's frame
-///   ([`reaches_caller_frame`] — `upvar` whatever the dynamism of either
-///   side, an `uplevel` script, an unplaceable level);
-/// * a redefined method (the lowering keeps only the *first* body, so the
-///   replacement is invisible to every scan — including this one).
-///
-/// Scoped to the whole module rather than per class on purpose: `my`
-/// dispatches along the MRO and through mixins, so a caller-frame-reaching
-/// method in *any* class is potentially reachable from a method body whose
-/// class relationship this analysis does not compute (oracle for the mixin
-/// shape, tclsh 9.0.4 / 8.6.16: a `Utility` mixin's `method NameProcess
-/// {args obj} {upvar 1 name name; …}` reached via `my NameProcess …` really
-/// does create `name` in the calling constructor's frame).  Per-callee
-/// precision through the member tables / MRO composes later (issue #1164).
-#[must_use]
-pub fn module_method_dispatch_evidence_is_incomplete(module: &crate::ir::Module) -> bool {
-    if !module.redefined_methods.is_empty() {
-        return true;
-    }
-    module
-        .methods
-        .values()
-        .any(|m| reaches_caller_frame(&m.body, &m.params))
-}
-
 /// The synthetic frame-effect entries that widen every `TclOO` self-dispatch
-/// site (`my …`, `next` / `nextto`) in a **method-body** CFG, used when
-/// [`module_method_dispatch_evidence_is_incomplete`] says a dispatch may
-/// reach the calling method's frame (issue #1177).
+/// site (`my …`, `next` / `nextto`) in a **method-body** CFG, used for
+/// exactly the methods the per-method dispatch barrier bars
+/// (`crate::optimiser::method_barrier` — a dispatch surface that meets a
+/// caller-frame-reaching or unanalysable class; issues #1177, #1164).
 ///
 /// Each entry maps a dispatch keyword to a summary with
 /// [`UpvarInfo::has_unresolvable_caller_target`] set — the call site then

--- a/rust/tcl-compiler/src/cfg_builder/upvar_info.rs
+++ b/rust/tcl-compiler/src/cfg_builder/upvar_info.rs
@@ -131,14 +131,17 @@ pub struct UpvarInfo {
     /// [`Self::caller_side_defs`] under-approximates and the call site must
     /// widen to an opaque caller-frame clobber instead of trusting it.
     pub has_unresolvable_caller_target: bool,
-    /// Literal caller-frame names the proc writes through an `uplevel`
-    /// script that runs in the caller's frame — `uplevel 1 {set n 1}` and
-    /// `uplevel 1 [list set n 1]`.  Unlike `upvar`, no local alias is
-    /// created, so these have no key to hang off.
+    /// Literal caller-frame names the proc may write with **no nameable
+    /// local alias** to key on: an `uplevel` script that runs in the
+    /// caller's frame (`uplevel 1 {set n 1}`, `uplevel 1 [list set n 1]`),
+    /// and an `upvar` pair whose *local* side is dynamic (`upvar 1 n $dst`
+    /// — the alias still targets exactly the caller's `n`, whatever local
+    /// name it lands under; issue #1165).
     pub uplevel_literal_writes: BTreeSet<String>,
     /// Parameter names whose **value** names a caller-frame variable the
-    /// proc writes through an `uplevel` script — `uplevel 1 [list set
-    /// $varName …]`.  Resolved at the call site against the actual argument
+    /// proc may write without a nameable local alias — `uplevel 1 [list set
+    /// $varName …]`, and `upvar 1 $varName $dst` with a dynamic local side
+    /// (issue #1165).  Resolved at the call site against the actual argument
     /// passed for that parameter, exactly like [`Self::param_targets`].
     pub uplevel_param_writes: BTreeSet<String>,
     /// `uplevel <caller frame> [list CMD ARG…]` sites whose `CMD` is not a
@@ -163,13 +166,16 @@ pub struct UpvarInfo {
     /// wholly-dynamic pair records its source word verbatim.
     ///
     /// Deliberately *not* part of [`Self::is_empty`]'s summary contract, and
-    /// no caller-side resolver reads it: the maps above answer "which
-    /// caller-frame name does my local `x` alias?", and a dynamic local side
-    /// gives that question no key to hang off (the caller-side path widens
-    /// through `crate::dynamic_names` instead).  It exists for the strictly
+    /// no caller-side resolver reads it: it exists for the strictly
     /// structural question [`reaches_caller_frame`] asks — "can this body
     /// reach its caller's frame at all?" — where an alias nobody can name
-    /// counts every bit as much as a nameable one.
+    /// counts every bit as much as a nameable one.  The *caller-side effect*
+    /// of such a pair is carried separately (issue #1165): a literal source
+    /// goes into [`Self::uplevel_literal_writes`], a `$param` source into
+    /// [`Self::uplevel_param_writes`], and anything else widens through
+    /// [`Self::has_unresolvable_caller_target`] — all of which `is_empty`
+    /// covers, so `detect_upvar_procs` registers the proc and its call
+    /// sites widen.
     pub unnameable_local_aliases: BTreeSet<String>,
 }
 
@@ -354,16 +360,12 @@ fn resolve_frame_args(spec: FrameEffectSpec, args: &[String]) -> (FrameLevel, &[
 ///
 /// The strictly structural counterpart to [`collect_upvar_targets`], which
 /// answers the richer question "*which* caller-frame names, through which
-/// local?" and therefore drops what it cannot name.  Two shapes are dropped
-/// there and must not be dropped here:
-///
-/// * `upvar 1 $src b` — a dynamic **source**.  When `src` is a parameter this
-///   lands in `param_targets`; otherwise it sets
-///   `has_unresolvable_caller_target`.  Both are already visible through
-///   [`UpvarInfo::is_empty`].
-/// * `upvar 1 x $dst` — a dynamic **local**, which the summary skips outright
-///   because it has no key to file the alias under.  That is the gap
-///   [`UpvarInfo::unnameable_local_aliases`] closes.
+/// local?".  Since issue #1165 every alias pair contributes to a bucket
+/// [`UpvarInfo::is_empty`] covers — a dynamic **source** lands in
+/// `param_targets` or sets `has_unresolvable_caller_target`, and a dynamic
+/// **local** (`upvar 1 x $dst`) files its caller-side name in the keyless
+/// write buckets (or widens).  [`UpvarInfo::unnameable_local_aliases`] is
+/// kept as the purely structural record of the dynamic-local pairs.
 ///
 /// A dynamic name makes an alias *more* dangerous, never exempt, so this
 /// deliberately reads the whole summary rather than any one bucket.
@@ -376,6 +378,76 @@ fn resolve_frame_args(spec: FrameEffectSpec, args: &[String]) -> (FrameLevel, &[
 pub fn reaches_caller_frame(body: &Script, params: &[String]) -> bool {
     let info = collect_upvar_targets(body, params);
     !info.is_empty() || !info.unnameable_local_aliases.is_empty()
+}
+
+/// Whether the module supplies **incomplete evidence** about what a `my` /
+/// `next` / object dispatch out of a method body can do to that body's frame
+/// — the whole-module gate shared by the optimiser's method-body propagation
+/// barrier (issue #1097) and the CFG builder's method-dispatch widening
+/// (issue #1177).
+///
+/// A *proc* callee is modelled per call site through
+/// [`super::detect_upvar_procs`]'s table; a **method** reached through `my`,
+/// `next`, or an object dispatch is never in that table, because the
+/// dispatch does not name its target statically.  So the answer has to come
+/// from whole-module evidence, and the governing rule is: *when the evidence
+/// is incomplete, widen to abstention.*  Two sources make it incomplete:
+///
+/// * a method body that can reach its caller's frame
+///   ([`reaches_caller_frame`] — `upvar` whatever the dynamism of either
+///   side, an `uplevel` script, an unplaceable level);
+/// * a redefined method (the lowering keeps only the *first* body, so the
+///   replacement is invisible to every scan — including this one).
+///
+/// Scoped to the whole module rather than per class on purpose: `my`
+/// dispatches along the MRO and through mixins, so a caller-frame-reaching
+/// method in *any* class is potentially reachable from a method body whose
+/// class relationship this analysis does not compute (oracle for the mixin
+/// shape, tclsh 9.0.4 / 8.6.16: a `Utility` mixin's `method NameProcess
+/// {args obj} {upvar 1 name name; …}` reached via `my NameProcess …` really
+/// does create `name` in the calling constructor's frame).  Per-callee
+/// precision through the member tables / MRO composes later (issue #1164).
+#[must_use]
+pub fn module_method_dispatch_evidence_is_incomplete(module: &crate::ir::Module) -> bool {
+    if !module.redefined_methods.is_empty() {
+        return true;
+    }
+    module
+        .methods
+        .values()
+        .any(|m| reaches_caller_frame(&m.body, &m.params))
+}
+
+/// The synthetic frame-effect entries that widen every `TclOO` self-dispatch
+/// site (`my …`, `next` / `nextto`) in a **method-body** CFG, used when
+/// [`module_method_dispatch_evidence_is_incomplete`] says a dispatch may
+/// reach the calling method's frame (issue #1177).
+///
+/// Each entry maps a dispatch keyword to a summary with
+/// [`UpvarInfo::has_unresolvable_caller_target`] set — the call site then
+/// widens with an opaque barrier, exactly like a call to a proc whose
+/// `upvar` target is unresolvable: the defs-based diagnostics (W210, the
+/// I230 existence fold) abstain instead of treating the dispatch as a
+/// no-op.  The keywords come from the registry's method-dispatch traits
+/// ([`tcl_registry::Traits::TCLOO_SELF_DISPATCH`] /
+/// [`tcl_registry::Traits::TCLOO_NEXT_CHAIN`]), never from spelled names;
+/// `self` ([`tcl_registry::Traits::TCLOO_INTROSPECTION`]) dispatches
+/// nothing and is deliberately excluded.
+#[must_use]
+pub fn oo_dispatch_widening_entries(registry: &CommandRegistry) -> Vec<(String, UpvarInfo)> {
+    let widened = UpvarInfo {
+        has_unresolvable_caller_target: true,
+        ..UpvarInfo::default()
+    };
+    let mut names: Vec<&str> =
+        registry.commands_with_trait(tcl_registry::Traits::TCLOO_SELF_DISPATCH);
+    names.extend(registry.commands_with_trait(tcl_registry::Traits::TCLOO_NEXT_CHAIN));
+    names.sort_unstable();
+    names.dedup();
+    names
+        .into_iter()
+        .map(|name| (name.to_owned(), widened.clone()))
+        .collect()
 }
 
 /// Collect the per-proc frame-effect summary from a proc body.
@@ -442,7 +514,7 @@ fn walk_stmt(
             ..
         } => {
             if !*absolute && *frame_shift == 1 {
-                record_upframe_body(&body.statements, info);
+                record_upframe_body(body, info);
             }
         }
         Statement::If {
@@ -522,27 +594,51 @@ fn record_upvar_call(
     while i + 1 < rest.len() {
         let (src, dst) = (rest[i].as_str(), rest[i + 1].as_str());
         i += 2;
-        if !is_literal_name(dst) {
-            // Dynamic destination — can't classify.  Caller-side
-            // analysis falls back to the dynamic-barrier path.  The alias
-            // is still real, so record the structural fact for
-            // [`reaches_caller_frame`]; the resolvable buckets, and
-            // therefore every existing consumer, are untouched.
+        let dst_is_literal = is_literal_name(dst);
+        if !dst_is_literal {
+            // Dynamic destination (`upvar 1 x $dst`) — there is no local
+            // key to file the alias under, so the per-local maps cannot
+            // carry it.  The alias is still real: record the structural
+            // fact for [`reaches_caller_frame`], and classify the CALLER
+            // side below so call sites still widen the right caller name
+            // (issue #1165 — before this, such a proc read as summary-empty
+            // and `p x` left the caller's `x` foldable to a stale constant;
+            // tclsh 9.0.4 / 8.6.16: `proc p {dst} {upvar 1 x $dst; set $dst
+            // 2}; proc c {} {set x 1; p x; puts $x}` prints 2).
             info.unnameable_local_aliases.insert(src.to_string());
-            continue;
         }
         if is_literal_name(src) {
-            // `upvar 1 caller_x x` — literal source.
-            info.literal_targets
-                .insert(dst.to_string(), src.to_string());
+            if dst_is_literal {
+                // `upvar 1 caller_x x` — literal source, literal local.
+                info.literal_targets
+                    .insert(dst.to_string(), src.to_string());
+            } else {
+                // `upvar 1 caller_x $dst` — the caller-side name is still
+                // exactly `caller_x`; only the local key is unknowable, so
+                // it lands in the keyless bucket.
+                info.uplevel_literal_writes.insert(src.to_string());
+            }
         } else if let Some(param) = is_dollar_param_ref(src) {
             // `upvar 1 $param x` — substitution-driven, gated on
             // the param existing on the proc.
             if param == "args" {
-                info.args_tail_upvar.push(dst.to_string());
+                if dst_is_literal {
+                    info.args_tail_upvar.push(dst.to_string());
+                } else {
+                    // `upvar 1 $args $dst` — no positional local to pair
+                    // the tail against; widen.
+                    info.has_unresolvable_caller_target = true;
+                }
             } else if params.iter().any(|p| p == param) {
-                info.param_targets
-                    .insert(dst.to_string(), param.to_string());
+                if dst_is_literal {
+                    info.param_targets
+                        .insert(dst.to_string(), param.to_string());
+                } else {
+                    // `upvar 1 $param $dst` — the caller-side name is the
+                    // parameter's value, resolvable at the call site; only
+                    // the local key is missing.
+                    info.uplevel_param_writes.insert(param.to_string());
+                }
             } else {
                 // `$foo` where `foo` isn't a param — the caller-side name
                 // depends on runtime state; the callee can clobber any
@@ -553,7 +649,7 @@ fn record_upvar_call(
             }
         } else {
             // Fully dynamic source (`upvar 1 [pick] x`, `upvar 1 a($i) x`,
-            // …) — same widening as above.
+            // …) — same widening as above, whatever the local side.
             info.has_unresolvable_caller_target = true;
         }
     }
@@ -607,16 +703,51 @@ fn record_uplevel_call(
 /// A body statement whose target is *not* a plain literal name means the
 /// body writes somewhere this summary cannot name, so widen — the same
 /// direction the constructed-list path takes.
-fn record_upframe_body(stmts: &[Statement], info: &mut UpvarInfo) {
-    for stmt in stmts {
-        for name in crate::ssa::defs_of(stmt) {
-            if is_literal_name(&name) {
-                info.uplevel_literal_writes.insert(name);
-            } else {
-                info.caller_frame_opaque_writes = true;
-            }
+fn record_upframe_body(body: &Script, info: &mut UpvarInfo) {
+    for name in crate::ir_helpers::defs_from_ir_script(body) {
+        if is_literal_name(&name) {
+            info.uplevel_literal_writes.insert(name);
+        } else {
+            info.caller_frame_opaque_writes = true;
         }
     }
+    // A dynamic write target (`uplevel 1 {set $n 1}`) contributes NO def
+    // at all — `ssa::defs_of` drops it — so it must widen here explicitly
+    // or the caller-frame write would go unrecorded (tclsh 9.0.4 /
+    // 8.6.16: the caller's variable named by the value of its own `n`
+    // really is written).
+    if super::global_write_info::script_has_dynamic_write_target(body) {
+        info.caller_frame_opaque_writes = true;
+    }
+}
+
+/// The constructed words of a `[list CMD ARG…]` script body word —
+/// `Some(words)` (command first) when *word* is a single `[builder …]`
+/// substitution whose builder the registry marks
+/// [`ReturnElements::ListOfArgs`](tcl_registry::ReturnElements) `{ from: 0 }`
+/// and whose constructed command word is a plain literal; `None` otherwise,
+/// so the caller widens.  Shared by the caller-frame summary here and the
+/// global-frame summary in [`super::global_write_info`] (`uplevel #0 [list
+/// set g …]`, issue #1198) so the two read the same list grammar.
+pub(super) fn constructed_script_words(
+    word: &str,
+    registry: &CommandRegistry,
+) -> Option<Vec<String>> {
+    let inner = word.strip_prefix('[').and_then(|w| w.strip_suffix(']'))?;
+    let words = super::words_from_text(inner);
+    let (builder, constructed) = words.split_first()?;
+    if !registry.get(builder).is_some_and(|spec| {
+        matches!(
+            spec.return_elements,
+            Some(tcl_registry::ReturnElements::ListOfArgs { from: 0 })
+        )
+    }) {
+        return None;
+    }
+    if !constructed.first().is_some_and(|c| is_literal_name(c)) {
+        return None;
+    }
+    Some(constructed.to_vec())
 }
 
 /// Read a `[list CMD ARG…]` body word, recording the caller-frame names the
@@ -632,27 +763,12 @@ fn record_constructed_body(
     registry: &CommandRegistry,
     info: &mut UpvarInfo,
 ) -> bool {
-    let Some(inner) = word.strip_prefix('[').and_then(|w| w.strip_suffix(']')) else {
+    let Some(constructed) = constructed_script_words(word, registry) else {
         return false;
     };
-    let words = super::words_from_text(inner);
-    let Some((builder, constructed)) = words.split_first() else {
-        return false;
-    };
-    if !registry.get(builder).is_some_and(|spec| {
-        matches!(
-            spec.return_elements,
-            Some(tcl_registry::ReturnElements::ListOfArgs { from: 0 })
-        )
-    }) {
-        return false;
-    }
     let Some((command, cargs)) = constructed.split_first() else {
         return false;
     };
-    if !is_literal_name(command) {
-        return false;
-    }
     let arg_refs: Vec<&str> = cargs.iter().map(String::as_str).collect();
     if registry.get(command).is_some() {
         // A registry command: its own `VarWrite` roles say which words name
@@ -684,7 +800,7 @@ fn record_constructed_body(
     // reaches *this* proc's caller, one frame further out than a plain call
     // would (issue #1019), but only the module-wide pass can resolve it.
     info.uplevel_forwarded_calls
-        .push((command.clone(), constructed[1..].to_vec()));
+        .push((command.clone(), cargs.to_vec()));
     true
 }
 
@@ -988,11 +1104,54 @@ mod tests {
     }
 
     #[test]
-    fn dynamic_destination_skipped() {
+    fn dynamic_destination_with_literal_source_still_names_the_caller_var() {
+        // Issue #1165 — `upvar 1 x $dst` aliases exactly the caller's `x`;
+        // only the local key is dynamic.  The summary must not read as
+        // empty (tclsh 9.0.4 / 8.6.16: `proc p {dst} {upvar 1 x $dst; set
+        // $dst 2}; proc c {} {set x 1; p x; puts $x}` prints 2, so a call
+        // site that kept `x = 1` foldable would miscompile).
         let body = lower("upvar 1 caller_x $local");
         let info = collect_upvar_targets(&body, &[]);
-        // Destination `$local` is dynamic — can't classify.
-        assert!(info.is_empty());
+        assert!(!info.is_empty(), "got {info:?}");
+        assert!(
+            info.uplevel_literal_writes.contains("caller_x"),
+            "got {info:?}"
+        );
+        assert!(!info.has_unresolvable_caller_target, "got {info:?}");
+        // The structural record survives for `reaches_caller_frame`.
+        assert!(info.unnameable_local_aliases.contains("caller_x"));
+        // And the call-site resolver surfaces the caller-side name.
+        assert_eq!(info.caller_side_defs(&[], &[]), vec!["caller_x"]);
+    }
+
+    #[test]
+    fn dynamic_destination_with_param_source_resolves_at_the_call_site() {
+        // Issue #1165 — `upvar 1 $name $dst`: the caller-side name is the
+        // value passed for `name`, exactly like `param_targets`.
+        let body = lower("upvar 1 $name $local");
+        let info = collect_upvar_targets(&body, &["name".to_string()]);
+        assert!(info.uplevel_param_writes.contains("name"), "got {info:?}");
+        assert!(!info.has_unresolvable_caller_target, "got {info:?}");
+        let defs = info.caller_side_defs(&["target".to_string()], &["name".to_string()]);
+        assert_eq!(defs, vec!["target"]);
+    }
+
+    #[test]
+    fn dynamic_destination_with_dynamic_source_widens() {
+        // Issue #1165 — both sides dynamic: the callee can clobber any
+        // caller variable, so the summary must widen, not stay empty.
+        for src in [
+            "upvar 1 [pick] $local",
+            "upvar 1 $notparam $local",
+            "upvar 1 $args $local",
+        ] {
+            let body = lower(src);
+            let info = collect_upvar_targets(&body, &["args".to_string()]);
+            assert!(
+                info.has_unresolvable_caller_target,
+                "{src} must widen; got {info:?}"
+            );
+        }
     }
 
     #[test]

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -1328,30 +1328,33 @@ impl CompilationUnit {
         // and every defs-based check treated the dispatch as a no-op — a
         // false always-false I230 on `info exists` of an upvar-defined local
         // (oracle, tclsh 9.0.4 / 8.6.14: after `my Reference? $lookup ref`
-        // returns true, `[info exists ref]` in the caller is 1).  When the
-        // module's method-dispatch evidence is incomplete, widen every
-        // dispatch site in method bodies through synthetic frame-effect
-        // entries — same abstention rule as the optimiser's propagation
-        // barrier, consumed through the same per-call-site machinery procs
+        // returns true, `[info exists ref]` in the caller is 1).  Widen the
+        // dispatch sites of exactly the methods whose reachable dispatch
+        // surface meets a caller-frame-reaching (or unanalysable) class —
+        // the same per-method barrier the optimiser's propagation gate
+        // consumes, so the two stay one evidence rule — through synthetic
+        // frame-effect entries fed to the per-call-site machinery procs
         // already use.
-        let upvar_procs = {
+        let dispatch_barrier = crate::optimiser::method_barrier::compute(ir_module, registry);
+        let widened_upvar_procs = {
             let mut map = upvar_procs.clone();
-            if crate::cfg_builder::upvar_info::module_method_dispatch_evidence_is_incomplete(
-                ir_module,
-            ) {
-                map.extend(crate::cfg_builder::upvar_info::oo_dispatch_widening_entries(registry));
-            }
+            map.extend(crate::cfg_builder::upvar_info::oo_dispatch_widening_entries(registry));
             map
         };
         ir_module
             .methods
             .iter()
             .map(|(mqname, method)| {
+                let method_upvar_procs = if dispatch_barrier.allows_locals(mqname) {
+                    upvar_procs
+                } else {
+                    &widened_upvar_procs
+                };
                 let cfg = crate::cfg_builder::build_cfg_function_with_upvars(
                     mqname,
                     &method.body,
                     true,
-                    upvar_procs.clone(),
+                    method_upvar_procs.clone(),
                     proc_params.clone(),
                     global_write_procs.clone(),
                 );

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -1322,6 +1322,29 @@ impl CompilationUnit {
         }
         let (upvar_procs, proc_params, global_write_procs) =
             cfg_context.expect("cfg_context computed when methods are present");
+        // Issue #1177: a callee reached via `my` / `next` is a method, never
+        // in the upvar-procs table (the dispatch does not name its target),
+        // so its `upvar 1 $refvar …` caller-frame definition was invisible
+        // and every defs-based check treated the dispatch as a no-op — a
+        // false always-false I230 on `info exists` of an upvar-defined local
+        // (oracle, tclsh 9.0.4 / 8.6.14: after `my Reference? $lookup ref`
+        // returns true, `[info exists ref]` in the caller is 1).  When the
+        // module's method-dispatch evidence is incomplete, widen every
+        // dispatch site in method bodies through synthetic frame-effect
+        // entries — same abstention rule as the optimiser's propagation
+        // barrier, consumed through the same per-call-site machinery procs
+        // already use.
+        let upvar_procs = {
+            let mut map = upvar_procs.clone();
+            if crate::cfg_builder::upvar_info::module_method_dispatch_evidence_is_incomplete(
+                ir_module,
+            ) {
+                map.extend(crate::cfg_builder::upvar_info::oo_dispatch_widening_entries(
+                    registry,
+                ));
+            }
+            map
+        };
         ir_module
             .methods
             .iter()

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -1339,9 +1339,7 @@ impl CompilationUnit {
             if crate::cfg_builder::upvar_info::module_method_dispatch_evidence_is_incomplete(
                 ir_module,
             ) {
-                map.extend(crate::cfg_builder::upvar_info::oo_dispatch_widening_entries(
-                    registry,
-                ));
+                map.extend(crate::cfg_builder::upvar_info::oo_dispatch_widening_entries(registry));
             }
             map
         };

--- a/rust/tcl-compiler/src/optimiser/method_barrier.rs
+++ b/rust/tcl-compiler/src/optimiser/method_barrier.rs
@@ -78,18 +78,17 @@ use std::collections::{HashMap, HashSet};
 
 use tcl_registry::{ArgRole, CommandRegistry, Traits};
 
-use crate::compilation_unit::CompilationUnit;
-use crate::ir::{Script, Statement};
+use crate::ir::{Module as IrModule, Script, Statement};
 
 /// The computed barrier: which methods may propagate their private locals.
-pub(super) struct MethodDispatchBarrier {
+pub(crate) struct MethodDispatchBarrier {
     bar_all: bool,
     barred: HashSet<String>,
 }
 
 impl MethodDispatchBarrier {
     /// Whether `method_qname`'s provably-local variables may propagate.
-    pub(super) fn allows_locals(&self, method_qname: &str) -> bool {
+    pub(crate) fn allows_locals(&self, method_qname: &str) -> bool {
         !self.bar_all && !self.barred.contains(method_qname)
     }
 
@@ -131,8 +130,7 @@ impl DispatchFacts {
 }
 
 /// Compute the per-method barrier for `cu` — see the module doc.
-pub(super) fn compute(cu: &CompilationUnit, registry: &CommandRegistry) -> MethodDispatchBarrier {
-    let ir = &cu.ir_module;
+pub(crate) fn compute(ir: &IrModule, registry: &CommandRegistry) -> MethodDispatchBarrier {
     if ir.oo_evidence.dynamic_target || ir.oo_evidence.dynamic_class_relations {
         return MethodDispatchBarrier::bar_all();
     }
@@ -174,9 +172,9 @@ pub(super) fn compute(cu: &CompilationUnit, registry: &CommandRegistry) -> Metho
         .collect();
 
     // Per-proc dispatch facts, closed over the proc call graph.
-    let proc_facts = proc_dispatch_facts(cu, registry, &comp_of);
-    let method_facts = method_dispatch_facts(cu, registry, &comp_of, &proc_facts);
-    let comp_out = component_dispatch_closure(cu, &comp_of, &method_facts);
+    let proc_facts = proc_dispatch_facts(ir, registry, &comp_of);
+    let method_facts = method_dispatch_facts(ir, registry, &comp_of, &proc_facts);
+    let comp_out = component_dispatch_closure(ir, &comp_of, &method_facts);
 
     // Bar each method whose reachable dispatch surface meets a bad class.
     let mut barred: HashSet<String> = HashSet::new();
@@ -202,12 +200,11 @@ pub(super) fn compute(cu: &CompilationUnit, registry: &CommandRegistry) -> Metho
 /// Direct dispatch facts per method, including every retained replacement
 /// body (the live body is one of them, so the union is the sound answer).
 fn method_dispatch_facts<'a>(
-    cu: &'a CompilationUnit,
+    ir: &'a IrModule,
     registry: &CommandRegistry,
     comp_of: &HashMap<String, usize>,
     proc_facts: &HashMap<&str, DispatchFacts>,
 ) -> HashMap<&'a str, DispatchFacts> {
-    let ir = &cu.ir_module;
     let mut method_facts: HashMap<&str, DispatchFacts> = HashMap::new();
     for (qname, m) in &ir.methods {
         let own_comp = comp_of.get(m.class_name.as_str()).copied();
@@ -240,11 +237,10 @@ fn method_dispatch_facts<'a>(
 /// Component-level dispatch closure: dispatching into a component also
 /// reaches everything its methods dispatch to.
 fn component_dispatch_closure(
-    cu: &CompilationUnit,
+    ir: &IrModule,
     comp_of: &HashMap<String, usize>,
     method_facts: &HashMap<&str, DispatchFacts>,
 ) -> Vec<DispatchFacts> {
-    let ir = &cu.ir_module;
     let comp_count = comp_of.values().copied().max().map_or(0, |m| m + 1);
     let mut comp_out: Vec<DispatchFacts> = vec![DispatchFacts::default(); comp_count];
     for (qname, m) in &ir.methods {
@@ -336,11 +332,10 @@ fn uf_find(parent: &mut [usize], i: usize) -> usize {
 /// (a proc that calls a proc that dispatches `$obj m` dispatches it too,
 /// on behalf of whoever called it).
 fn proc_dispatch_facts<'a>(
-    cu: &'a CompilationUnit,
+    ir: &'a IrModule,
     registry: &CommandRegistry,
     comp_of: &HashMap<String, usize>,
 ) -> HashMap<&'a str, DispatchFacts> {
-    let ir = &cu.ir_module;
     // Direct facts + direct proc callees per proc.
     let mut facts: HashMap<&str, DispatchFacts> = HashMap::new();
     let mut callees: HashMap<&str, HashSet<String>> = HashMap::new();

--- a/rust/tcl-compiler/src/optimiser/mod.rs
+++ b/rust/tcl-compiler/src/optimiser/mod.rs
@@ -55,7 +55,7 @@ pub mod end_offset;
 pub mod expr_simplify;
 pub mod helpers;
 pub mod manager;
-mod method_barrier;
+pub(crate) mod method_barrier;
 pub mod pattern_recognition;
 pub mod profiles;
 pub mod propagation;

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -920,6 +920,57 @@ fn oo_frame_for(
     })
 }
 
+/// Whether the module supplies **incomplete evidence** about what a `my` /
+/// `next` / object dispatch out of a method body can do to that body's private
+/// locals — the whole-module gate on method-body variable propagation (issue
+/// #1097, hardened by the #1096/#1097 review's three findings).
+///
+/// A *proc* callee is modelled per call site: the CFG builder widens the
+/// caller's defs at every call to a name in
+/// [`crate::cfg_builder::detect_upvar_procs`]'s table, and method CFGs are
+/// built with that table threaded in.  A **method** reached through `my`,
+/// `next`, or an object dispatch is not in that table and cannot be, because
+/// the dispatch never names its target.  So the barrier has to be answered
+/// from whole-module evidence instead, and the governing rule is: *when the
+/// evidence is incomplete, widen to abstention.*  Two sources make it
+/// incomplete:
+///
+/// * **A method body that can reach its caller's frame.**
+///   [`reaches_caller_frame`](crate::cfg_builder::upvar_info::reaches_caller_frame)
+///   is the complete structural query — it counts an `upvar` alias whatever
+///   the dynamism of either side of the pair, an `uplevel` script running in
+///   the caller, and any level it cannot place.  It is deliberately *not*
+///   `var_observability`'s per-variable alias lattice: that route
+///   (`upvar_local_declaration_indices`) skips a pair when either side starts
+///   with `$`, so `method helper {src} {upvar 1 $src b; set b 2}` — which
+///   mutates its caller's variable on every call — read as "no caller-frame
+///   alias".  A dynamic name makes an alias *more* dangerous, never exempt.
+///   Oracle (identical on tclsh 9.0.4 and 8.6.14): that helper, called from
+///   `method m {} {set x 1; set src x; my helper $src; puts $x}`, prints `2`.
+///
+/// * **A method that was redefined.**  The lowering keeps the *first* body and
+///   records only the name in [`crate::ir::Module::redefined_methods`], so a
+///   replacement body is invisible to every scan above — including the
+///   caller-frame query, which would be inspecting the wrong body.  An
+///   initially-empty helper later redefined as `{upvar 1 x y; set y 2}` is
+///   otherwise undetectable.  Oracle (9.0.4 and 8.6.14): prints `2`.
+///
+///   Scoped to the whole module rather than to the redefined method's own
+///   class on purpose: `my` dispatches along the MRO, so a replaced method in
+///   a *superclass* is reachable from a subclass's body, and a per-class kill
+///   switch would miss exactly that.  Redefinition is rare, so the precision
+///   cost is small and the soundness argument does not depend on an MRO the
+///   optimiser does not compute here.
+///
+/// Flow-insensitive and whole-module for the same reason
+/// [`crate::command_binding::ModuleCommandMutations::trusts`] is: the dispatch
+/// order between methods is not statically known.
+fn method_dispatch_evidence_is_incomplete(cu: &CompilationUnit) -> bool {
+    // Shared with the CFG builder's method-dispatch widening (issue #1177) —
+    // one evidence rule, two consumers, so they cannot drift.
+    crate::cfg_builder::upvar_info::module_method_dispatch_evidence_is_incomplete(&cu.ir_module)
+}
+
 /// The method-local constants a method body may propagate, or an empty map
 /// when it may propagate none (issue #1097).
 ///

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -920,57 +920,6 @@ fn oo_frame_for(
     })
 }
 
-/// Whether the module supplies **incomplete evidence** about what a `my` /
-/// `next` / object dispatch out of a method body can do to that body's private
-/// locals — the whole-module gate on method-body variable propagation (issue
-/// #1097, hardened by the #1096/#1097 review's three findings).
-///
-/// A *proc* callee is modelled per call site: the CFG builder widens the
-/// caller's defs at every call to a name in
-/// [`crate::cfg_builder::detect_upvar_procs`]'s table, and method CFGs are
-/// built with that table threaded in.  A **method** reached through `my`,
-/// `next`, or an object dispatch is not in that table and cannot be, because
-/// the dispatch never names its target.  So the barrier has to be answered
-/// from whole-module evidence instead, and the governing rule is: *when the
-/// evidence is incomplete, widen to abstention.*  Two sources make it
-/// incomplete:
-///
-/// * **A method body that can reach its caller's frame.**
-///   [`reaches_caller_frame`](crate::cfg_builder::upvar_info::reaches_caller_frame)
-///   is the complete structural query — it counts an `upvar` alias whatever
-///   the dynamism of either side of the pair, an `uplevel` script running in
-///   the caller, and any level it cannot place.  It is deliberately *not*
-///   `var_observability`'s per-variable alias lattice: that route
-///   (`upvar_local_declaration_indices`) skips a pair when either side starts
-///   with `$`, so `method helper {src} {upvar 1 $src b; set b 2}` — which
-///   mutates its caller's variable on every call — read as "no caller-frame
-///   alias".  A dynamic name makes an alias *more* dangerous, never exempt.
-///   Oracle (identical on tclsh 9.0.4 and 8.6.14): that helper, called from
-///   `method m {} {set x 1; set src x; my helper $src; puts $x}`, prints `2`.
-///
-/// * **A method that was redefined.**  The lowering keeps the *first* body and
-///   records only the name in [`crate::ir::Module::redefined_methods`], so a
-///   replacement body is invisible to every scan above — including the
-///   caller-frame query, which would be inspecting the wrong body.  An
-///   initially-empty helper later redefined as `{upvar 1 x y; set y 2}` is
-///   otherwise undetectable.  Oracle (9.0.4 and 8.6.14): prints `2`.
-///
-///   Scoped to the whole module rather than to the redefined method's own
-///   class on purpose: `my` dispatches along the MRO, so a replaced method in
-///   a *superclass* is reachable from a subclass's body, and a per-class kill
-///   switch would miss exactly that.  Redefinition is rare, so the precision
-///   cost is small and the soundness argument does not depend on an MRO the
-///   optimiser does not compute here.
-///
-/// Flow-insensitive and whole-module for the same reason
-/// [`crate::command_binding::ModuleCommandMutations::trusts`] is: the dispatch
-/// order between methods is not statically known.
-fn method_dispatch_evidence_is_incomplete(cu: &CompilationUnit) -> bool {
-    // Shared with the CFG builder's method-dispatch widening (issue #1177) —
-    // one evidence rule, two consumers, so they cannot drift.
-    crate::cfg_builder::upvar_info::module_method_dispatch_evidence_is_incomplete(&cu.ir_module)
-}
-
 /// The method-local constants a method body may propagate, or an empty map
 /// when it may propagate none (issue #1097).
 ///

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -1020,7 +1020,7 @@ fn run_oo_method_folds(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
     // anyway.
     let barrier = ctx
         .registry
-        .map(|registry| super::method_barrier::compute(cu, registry));
+        .map(|registry| super::method_barrier::compute(&cu.ir_module, registry));
     // Sorted so the emitted rewrite order is deterministic across runs
     // (`ir_module.methods` is a `HashMap`).
     let mut qnames: Vec<&String> = cu.ir_module.methods.keys().collect();

--- a/rust/tcl-compiler/src/taint_interproc.rs
+++ b/rust/tcl-compiler/src/taint_interproc.rs
@@ -674,6 +674,15 @@ fn update_entry(
 /// convergence *and* an injected memo's correctness at once — a stale memo entry
 /// trips the same assertion a missed call-graph edge would.
 ///
+/// Append `val` to `map[key]`, deduplicated — the caller-edge insert for the
+/// reverse call graph in [`converge_summaries_with`].
+fn push_unique_edge<'a>(map: &mut HashMap<&'a str, Vec<&'a str>>, key: &'a str, val: &'a str) {
+    let entry = map.entry(key).or_default();
+    if !entry.contains(&val) {
+        entry.push(val);
+    }
+}
+
 /// `registry` and `dialect` feed only the debug-only round-robin guard below, so
 /// in a release build (where `debug_assertions` is off and the guard is compiled
 /// out) they are genuinely unused.
@@ -702,16 +711,10 @@ pub fn converge_summaries_with(
     // `callers[Q]` = procedures that directly call `Q`; when `Q`'s summary changes
     // its callers are re-queued. Without a call graph, re-queue everything.
     let callers: Option<HashMap<&str, Vec<&str>>> = interproc.map(|ia| {
-        fn add<'a>(map: &mut HashMap<&'a str, Vec<&'a str>>, callee: &'a str, from: &'a str) {
-            let entry = map.entry(callee).or_default();
-            if !entry.contains(&from) {
-                entry.push(from);
-            }
-        }
         let mut map: HashMap<&str, Vec<&str>> = HashMap::new();
         for (caller, summary) in &ia.procedures {
             for callee in &summary.direct_calls {
-                add(&mut map, callee.as_str(), caller.as_str());
+                push_unique_edge(&mut map, callee.as_str(), caller.as_str());
             }
         }
         for qname in &proc_names {
@@ -722,7 +725,7 @@ pub fn converge_summaries_with(
                 // `resolved_callees` returns owned names; the map borrows from
                 // `known`'s keys, which outlive it and hold the same strings.
                 if let Some(interned) = known.get(&callee) {
-                    add(&mut map, interned.as_str(), qname.as_str());
+                    push_unique_edge(&mut map, interned.as_str(), qname.as_str());
                 }
             }
         }

--- a/rust/tcl-compiler/tests/optimiser_coverage.rs
+++ b/rust/tcl-compiler/tests/optimiser_coverage.rs
@@ -582,6 +582,66 @@ fn o102_upvar_aliased_variable_blocks_forward() {
 }
 
 #[test]
+fn o102_upvar_dynamic_local_alias_blocks_forward() {
+    // TP (issue #1165): `upvar 1 x $dst` has a dynamic *local* side, so the
+    // per-local alias maps cannot key it — but the caller-side name is the
+    // literal `x`, and the callee really does rewrite it. tclsh 9.0.4:
+    // prints `2`, so folding the later `$x` read to the stale `1` would be
+    // a silent miscompile.
+    let src = "proc p {dst} {\n    upvar 1 x $dst\n    set $dst 2\n}\nproc c {} {\n    set x 1\n    p x\n    puts $x\n}\nc\n";
+    let out = optimised(src, TCL);
+    assert!(
+        !out.contains("puts 1"),
+        "the caller's x must not fold across `p x`: {out}"
+    );
+}
+
+#[test]
+fn o102_upvar_dynamic_local_alias_param_source_blocks_forward() {
+    // TP (issue #1165): `upvar 1 $name $dst` — both the caller-side name
+    // (the value of `name`) and the local key are call-site data, but the
+    // caller-side name IS resolvable from the argument. tclsh 9.0.4:
+    // prints `9`.
+    let src = "proc r {name dst} {\n    upvar 1 $name $dst\n    set $dst 9\n}\nproc c3 {} {\n    set t 0\n    r t alias\n    puts $t\n}\nc3\n";
+    let out = optimised(src, TCL);
+    assert!(
+        !out.contains("puts 0"),
+        "the caller's t must not fold across `r t alias`: {out}"
+    );
+}
+
+#[test]
+fn o102_upvar_dynamic_local_alias_does_not_block_unrelated_forward() {
+    // FP guard (issue #1165): the widening is per-name — an unrelated
+    // local `y` in the same caller must still forward. tclsh 9.0.4: prints
+    // `5` then `2`.
+    let src = "proc p {dst} {\n    upvar 1 x $dst\n    set $dst 2\n}\nproc c4 {} {\n    set x 1\n    set y 5\n    p x\n    puts $y\n    puts $x\n}\nc4\n";
+    let out = optimised(src, TCL);
+    assert!(
+        out.contains("puts 5") || out.contains("puts $y"),
+        "y is untouched by p and may fold: {out}"
+    );
+    assert!(
+        !out.contains("puts 1"),
+        "x must still not fold across the call: {out}"
+    );
+}
+
+#[test]
+fn o102_upvar_zero_dynamic_local_is_callee_own_frame_and_still_forwards() {
+    // TN (issue #1165): `upvar 0 own $dst` aliases the *callee's own*
+    // frame — no caller effect, so the caller's constant still forwards.
+    // tclsh 9.0.4: prints `3` (the caller's x is untouched).
+    let src = "proc q {dst} {\n    upvar 0 own $dst\n    set $dst 7\n}\nproc c2 {} {\n    set x 3\n    q alias\n    puts $x\n}\nc2\n";
+    let out = optimised(src, TCL);
+    assert!(
+        out.contains("puts 3") || out.contains("puts $x"),
+        "an own-frame alias must not block the caller's forward: {out}"
+    );
+    assert!(!out.contains("puts 7"), "never the callee's value: {out}");
+}
+
+#[test]
 fn o102_pure_intervening_call_is_still_forwarded() {
     // TN / precision guard: the fix must not be so conservative that a
     // provably pure intervening call (no side effects, registry `pure:
@@ -622,17 +682,94 @@ fn o102_unregistered_proc_call_between_def_and_use_still_forwards() {
 }
 
 #[test]
-fn o102_uplevel_hash_zero_in_called_proc_is_a_known_gap() {
-    // Documented, deliberate scope limitation (see `run_load_forwarding`'s
-    // doc comment): `uplevel #0` inside a *called* proc can rewrite a
-    // caller-visible variable with no trace and no memory-SSA alias
-    // recorded against the *caller's* function unit, so this specific
-    // shape is not yet caught. tclsh: prints `99`; the optimiser still
-    // (incorrectly) forwards `5`. Asserting the current, known-wrong
-    // behaviour here — rather than silently leaving it uncovered — so a
-    // future fix flips this assertion instead of a fix regressing
-    // silently past an absent test.
+fn o102_uplevel_hash_zero_in_called_proc_kills_the_stale_global() {
+    // TP (issue #1198) — the formerly known-wrong gap, now fixed: `uplevel
+    // #0 {set x 99}` inside a *called* proc rewrites the caller-visible
+    // global, so the earlier literal must not forward across the call.
+    // tclsh 9.0.3/9.0.4: prints `99`; the optimiser used to (incorrectly)
+    // emit `puts 5`. The callee's global-frame write is now part of its
+    // `GlobalWriteInfo` summary and widens the call site's defs.
     let src = "proc setter {} {\n    uplevel #0 {\n        set x 99\n    }\n}\nset x 5\nsetter\nputs $x\n";
+    let out = optimised(src, TCL);
+    assert!(
+        !out.contains("puts 5"),
+        "the stale global 5 must not forward across `setter`: {out}"
+    );
+    assert!(out.contains("puts $x"), "the read must survive: {out}");
+}
+
+#[test]
+fn o102_uplevel_hash_zero_list_built_script_kills_the_stale_global() {
+    // TP (issue #1198) — the list-built spelling: `uplevel #0 [list set k
+    // 77]` names its command and target statically. tclsh 9.0.4: prints
+    // `77`.
+    let src = "proc s3 {} {\n    uplevel #0 [list set k 77]\n}\nset k 5\ns3\nputs $k\n";
+    let out = optimised(src, TCL);
+    assert!(
+        !out.contains("puts 5"),
+        "the stale global 5 must not forward across `s3`: {out}"
+    );
+}
+
+#[test]
+fn o102_uplevel_hash_zero_through_a_call_chain_kills_the_stale_global() {
+    // TP (issue #1198) — nested call chain: `outer` calls `setter`; the
+    // global-frame write is transitive through the direct-call closure.
+    // tclsh 9.0.4: prints `99`.
+    let src = "proc setter {} {\n    uplevel #0 {\n        set g2 99\n    }\n}\nproc outer {} {\n    setter\n}\nset g2 5\nouter\nputs $g2\n";
+    let out = optimised(src, TCL);
+    assert!(
+        !out.contains("puts 5"),
+        "the stale global 5 must not forward across `outer`: {out}"
+    );
+}
+
+#[test]
+fn o102_uplevel_hash_zero_dynamic_script_widens_every_global() {
+    // TP (issue #1198) — `uplevel #0 $body` is an unreadable script at the
+    // global frame: no name is enumerable, so the call site must widen to
+    // an opaque barrier. tclsh 9.0.4: prints `42`.
+    let src = "proc s2 {body} {\n    uplevel #0 $body\n}\nset h 5\ns2 {set h 42}\nputs $h\n";
+    let out = optimised(src, TCL);
+    assert!(
+        !out.contains("puts 5"),
+        "the stale global 5 must not forward across `s2`: {out}"
+    );
+}
+
+#[test]
+fn o102_uplevel_hash_zero_embedded_substitution_widens_too() {
+    // TP (issue #1198) — the same callee reached through a command
+    // substitution (`set y [s2 …]`) instead of a bare statement.
+    let src = "proc s2 {body} {\n    uplevel #0 $body\n}\nset h 5\nset y [s2 {set h 42}]\nputs $h\n";
+    let out = optimised(src, TCL);
+    assert!(
+        !out.contains("puts 5"),
+        "the stale global 5 must not forward across `[s2 …]`: {out}"
+    );
+}
+
+#[test]
+fn o102_uplevel_hash_zero_unrelated_global_still_forwards() {
+    // FP guard (issue #1198) — a *literal* global-frame write is per-name:
+    // `setter` writes only `x`, so the untouched `y` still forwards.
+    // tclsh 9.0.4: prints `7` then `99`.
+    let src = "proc setter {} {\n    uplevel #0 {\n        set x 99\n    }\n}\nset x 5\nset y 7\nsetter\nputs $y\nputs $x\n";
+    let out = optimised(src, TCL);
+    assert!(
+        out.contains("puts 7") || out.contains("puts $y"),
+        "y is untouched by setter and may fold: {out}"
+    );
+    assert!(!out.contains("puts 5"), "x must not fold: {out}");
+}
+
+#[test]
+fn o102_uplevel_hash_zero_non_writing_script_still_forwards() {
+    // TN (issue #1198) — a global-frame script that writes no variable
+    // (`uplevel #0 [list puts hi]`) has no global effect at all, so the
+    // caller's constant still forwards. tclsh 9.0.4: prints `hi` then `5`.
+    let src = "proc shout {} {\n    uplevel #0 [list puts hi]\n}\nset x 5\nshout\nputs $x\n";
+    assert!(opt_fires(src, TCL, "O102"));
     assert!(optimised(src, TCL).contains("puts 5"));
 }
 

--- a/rust/tcl-compiler/tests/optimiser_coverage.rs
+++ b/rust/tcl-compiler/tests/optimiser_coverage.rs
@@ -741,7 +741,8 @@ fn o102_uplevel_hash_zero_dynamic_script_widens_every_global() {
 fn o102_uplevel_hash_zero_embedded_substitution_widens_too() {
     // TP (issue #1198) — the same callee reached through a command
     // substitution (`set y [s2 …]`) instead of a bare statement.
-    let src = "proc s2 {body} {\n    uplevel #0 $body\n}\nset h 5\nset y [s2 {set h 42}]\nputs $h\n";
+    let src =
+        "proc s2 {body} {\n    uplevel #0 $body\n}\nset h 5\nset y [s2 {set h 42}]\nputs $h\n";
     let out = optimised(src, TCL);
     assert!(
         !out.contains("puts 5"),

--- a/rust/tcl-lsp-core/src/caller_frame.rs
+++ b/rust/tcl-lsp-core/src/caller_frame.rs
@@ -73,15 +73,28 @@
 //! build0           ;# → 0 — `upvar 0` aliased p0's OWN local, nothing here
 //! ```
 //!
-//! # What it deliberately does not answer
+//! # Literal caller-frame targets (issue #1139)
 //!
 //! A callee that binds a **literal** caller-side name (`upvar 1 name name`,
-//! issue #923 audit idx 22/98) spells that name nowhere at the call site, so
-//! there is no argument word to key on and no span to navigate to.  Resolving
-//! it needs a per-proc *literal caller-frame target* fact on
-//! [`ProcDef`](tcl_compiler::analyser::ProcDef) — the summary's
-//! `literal_targets` bucket — which the analyser does not yet record.  Those
-//! reads keep the abstaining answer above rather than a wrong one.
+//! issue #923 audit idx 22) spells that name nowhere at the call site, so
+//! there is no argument word to key on.  The analyser records those names
+//! per proc on
+//! [`ProcDef::caller_frame_literals`](tcl_compiler::analyser::ProcDef::caller_frame_literals),
+//! and [`caller_frame_bindings`] answers for them with the *call-head word*
+//! as the binding span — the point where the variable comes to exist in
+//! this frame.  A fully-qualified target (`upvar ::tk::FocusGrab($i) data`,
+//! idx 98) is not a caller-frame variable at all: it names one fixed global
+//! cell, which the analyser's `handle_upvar_command` now defines and links
+//! directly.
+//!
+//! # What it deliberately does not answer
+//!
+//! A callee reached through `my` / `next` / object dispatch is a method the
+//! call never names statically, so its literal targets cannot be resolved
+//! here yet — those reads keep the abstaining answer rather than a wrong
+//! one (the compiler-side dispatch widening of issue #1177 keeps the
+//! diagnostics honest in the meantime; per-callee method resolution
+//! composes with issue #1164's MRO work).
 
 use tcl_compiler::analyser::AnalysisResult;
 use tcl_compiler::analyser::types::ProcArgTrait;
@@ -121,11 +134,17 @@ pub(crate) fn substituted_var_read_at(
 pub(crate) struct CallerFrameBinding {
     /// Qualified name of the callee whose `upvar` creates the variable.
     pub callee: String,
-    /// The callee parameter whose *value* names the variable.
-    pub param: String,
+    /// The callee parameter whose *value* names the variable — or `None`
+    /// when the callee spells the name **literally in its own body**
+    /// (`upvar 1 name name`, issue #923 audit idx 22 / issue #1139), so no
+    /// call-site word carries it at all.
+    pub param: Option<String>,
     /// Span of the call-site word that names it — `dataset` in
     /// `gridlayoutHasDataSetObj dataset`.  This is both the creating write
-    /// (go-to-definition's target) and a reference to the variable.
+    /// (go-to-definition's target) and a reference to the variable.  For a
+    /// literal-target binding ([`Self::param`] `None`) there is no such
+    /// word, so this is the call's command-head word — the point where the
+    /// variable comes to exist in this frame.
     pub arg_span: Span,
     /// Span of the call's command-head word.
     pub call_span: Span,
@@ -210,10 +229,9 @@ fn is_plain_var_name(word: &str) -> bool {
 /// a caller-frame variable — the cheap pre-filter for
 /// [`caller_frame_bindings`]'s source scan.
 fn document_has_call_by_name_proc(analysis: &AnalysisResult) -> bool {
-    analysis
-        .all_procs
-        .values()
-        .any(|proc_def| !proc_def.caller_frame_params.is_empty())
+    analysis.all_procs.values().any(|proc_def| {
+        !proc_def.caller_frame_params.is_empty() || !proc_def.caller_frame_literals.is_empty()
+    })
 }
 
 /// Every call in the frame enclosing `cursor_off` that binds `name` in that
@@ -340,8 +358,23 @@ fn bindings_from_call(
     ) else {
         return;
     };
-    if proc_def.caller_frame_params.is_empty() {
+    if proc_def.caller_frame_params.is_empty() && proc_def.caller_frame_literals.is_empty() {
         return;
+    }
+    // A literal caller-frame target (`upvar 1 name name`, issue #1139): the
+    // callee spells the name in its own body, so the *call itself* is the
+    // binding — no argument word to key on.  The command-head word stands in
+    // as the binding span: it is the point where the variable comes to exist
+    // in this frame (tclsh 9.0.4 / 8.6.14: `proc np {} {upvar name name;
+    // set name W1}` then `np; puts $name` prints `W1`).
+    if let Some(written) = proc_def.caller_frame_literals.get(ctx.name) {
+        out.push(CallerFrameBinding {
+            callee: proc_def.qualified_name.clone(),
+            param: None,
+            arg_span: head.span,
+            call_span: head.span,
+            read_only: !written,
+        });
     }
     for (i, param) in proc_def.params.iter().enumerate() {
         let (Some(arg_tok), Some(arg_text)) = (cmd.argv.get(i + 1), cmd.texts.get(i + 1)) else {
@@ -372,7 +405,7 @@ fn bindings_from_call(
         }
         out.push(CallerFrameBinding {
             callee: proc_def.qualified_name.clone(),
-            param: param.name.clone(),
+            param: Some(param.name.clone()),
             arg_span: arg_tok.span,
             call_span: head.span,
             read_only: !writes,
@@ -502,6 +535,11 @@ fn substituted_read_spans(
 /// The bareword half of the idiom — `gridlayoutHasDataSetObj dataset` — is a
 /// creating write, so hover, go-to-definition, and find-references must all
 /// answer for it exactly as they do for the `$dataset` reads it feeds.
+///
+/// A **literal-target** binding is deliberately excluded: its `arg_span` is
+/// the call's command-head word, and a bare cursor on the command name must
+/// keep resolving as the *command* (definition/references of the proc), not
+/// silently become a variable.
 #[must_use]
 pub(crate) fn binding_at_offset(
     analysis: &AnalysisResult,
@@ -513,6 +551,7 @@ pub(crate) fn binding_at_offset(
 ) -> Option<CallerFrameBinding> {
     caller_frame_bindings(analysis, source, dialect, registry, cursor_off, word)
         .into_iter()
+        .filter(|b| b.param.is_some())
         .find(|b| cursor_off >= b.arg_span.start() && cursor_off <= b.arg_span.end())
 }
 
@@ -574,7 +613,7 @@ oo::class create chart {
         let bindings =
             caller_frame_bindings(&analysis, IDX58, "tcl9.0", Some(reg()), read, "dataset");
         assert_eq!(bindings.len(), 1, "one binding call site: {bindings:?}");
-        assert_eq!(bindings[0].param, "dts");
+        assert_eq!(bindings[0].param.as_deref(), Some("dts"));
         assert!(!bindings[0].read_only);
         assert_eq!(
             &IDX58[bindings[0].arg_span.as_range()],
@@ -805,6 +844,89 @@ oo::class create chart {
         }
     }
 
+    /// The literal-target shape of issue #923 audit idx 22 / issue #1139,
+    /// proc form: the callee spells the caller-frame name in its **own**
+    /// body (`upvar name name`), so no call-site word carries it.
+    ///
+    /// tclsh 9.0.4: `proc NameProcess {arguments object} {upvar name name;
+    /// set name W1}` then `proc build {} {NameProcess x obj; return $name}`
+    /// — `build` returns `W1`.
+    const IDX22: &str = "\
+proc NameProcess {arguments object} {
+    upvar name name
+    set name W1
+}
+proc build {} {
+    NameProcess x obj
+    set out $name
+}
+";
+
+    #[test]
+    fn a_literal_upvar_target_binds_at_the_call_head() {
+        let analysis = analyse(IDX22);
+        let read = offset_of(IDX22, "$name") + 1;
+        let bindings =
+            caller_frame_bindings(&analysis, IDX22, "tcl9.0", Some(reg()), read, "name");
+        assert_eq!(bindings.len(), 1, "one binding call site: {bindings:?}");
+        assert_eq!(bindings[0].param, None, "no call-site word carries it");
+        assert!(!bindings[0].read_only, "the alias is written through");
+        assert_eq!(
+            &IDX22[bindings[0].arg_span.as_range()],
+            "NameProcess",
+            "the binding span is the call-head word"
+        );
+    }
+
+    /// TN — the literal fact is level-gated exactly like the param fact:
+    /// only `upvar 1` (or the omitted level) binds this frame.
+    #[test]
+    fn a_literal_target_at_a_non_caller_level_binds_nothing() {
+        for level in ["0", "#0", "2", "$lvl"] {
+            let src = format!(
+                "proc np {{}} {{ upvar {level} name name; set name 1 }}\n\
+                 proc build {{}} {{ np\n puts $name }}\n"
+            );
+            let analysis = analyse(&src);
+            let read = offset_of(&src, "$name") + 1;
+            let bindings =
+                caller_frame_bindings(&analysis, &src, "tcl9.0", Some(reg()), read, "name");
+            assert!(
+                bindings.is_empty(),
+                "`upvar {level}` does not bind the caller's frame: {bindings:?}"
+            );
+        }
+    }
+
+    /// TN — a `::`-qualified target names a fixed global/namespace cell,
+    /// not a caller-frame variable; the analyser's `otherVar` link owns it
+    /// (issue #923 idx 98).
+    #[test]
+    fn a_qualified_literal_target_is_not_a_caller_frame_binding() {
+        let src = "proc np {} { upvar 1 ::tk::FocusGrab(x) data; set data 1 }\n\
+                   proc build {} { np\n puts $FocusGrab }\n";
+        let analysis = analyse(src);
+        let read = offset_of(src, "$FocusGrab") + 1;
+        assert!(
+            caller_frame_bindings(&analysis, src, "tcl9.0", Some(reg()), read, "FocusGrab")
+                .is_empty()
+        );
+    }
+
+    /// A callee that only *reads* through the literal alias references the
+    /// variable without creating it (tclsh 9.0.4: `proc peekname {} {upvar
+    /// name name; return [info exists name]}` creates nothing).
+    #[test]
+    fn a_read_only_literal_target_is_a_reference_not_a_creation() {
+        let src = "proc peekname {} { upvar name name; return [string length $name] }\n\
+                   proc build {} { set name N0\n peekname }\n";
+        let analysis = analyse(src);
+        let call = offset_of(src, "peekname }") ;
+        let bindings = caller_frame_bindings(&analysis, src, "tcl9.0", Some(reg()), call, "name");
+        assert_eq!(bindings.len(), 1, "{bindings:?}");
+        assert!(bindings[0].read_only, "{bindings:?}");
+    }
+
     /// The parity helper itself, over the pinned table.
     #[test]
     fn dollar_escape_parity_matches_c_tcl() {
@@ -837,6 +959,68 @@ oo::class create chart {
 #[cfg(test)]
 mod caller_frame_navigation_tests {
     use tcl_compiler::analyser::Analyser;
+
+    /// Issue #923 audit idx 98, re-measured for issue #1139: `upvar
+    /// ::tk::FocusGrab($index) data` names a fixed, fully-qualified global
+    /// cell (level-independent — tclsh-verified in the audit), so the array
+    /// must hover, define, and cross-reference from both the `upvar`
+    /// `otherVar` word and a sibling proc's `$::tk::FocusGrab($index)`
+    /// read.  Before the cell gained a `VarDef` at the `otherVar` word,
+    /// every one of these anchors answered nothing (a silent miss).
+    ///
+    /// The four references are: the `otherVar` word, the `info exists`
+    /// argument, the `$` read, and the `unset` argument.  A *bareword*
+    /// cursor on the `info exists` argument still abstains — barewords in
+    /// variable-role argument positions are a separate anchor kind — but
+    /// the occurrence itself is in the reference set.
+    #[test]
+    fn a_fully_qualified_upvar_target_navigates_from_word_and_read() {
+        let src = "\
+proc SetFocusGrab {grab focus} {
+    set index \"$grab,$focus\"
+    upvar ::tk::FocusGrab($index) data
+    lappend data one
+}
+proc RestoreFocusGrab {grab focus} {
+    set index \"$grab,$focus\"
+    if {[info exists ::tk::FocusGrab($index)]} {
+        set data2 $::tk::FocusGrab($index)
+        unset ::tk::FocusGrab($index)
+    }
+}
+";
+        let analysis = Analyser::new().analyse(src, "tcl9.0").clone();
+        for (label, needle, extra) in [
+            ("upvar-othervar", "upvar ::tk::FocusGrab", 8usize),
+            ("read", "$::tk::FocusGrab($index)", 3usize),
+        ] {
+            let off = src.find(needle).unwrap() + extra;
+            let line = u32::try_from(src[..off].matches('\n').count()).unwrap();
+            let line_start = src[..off].rfind('\n').map_or(0, |i| i + 1);
+            let col = u32::try_from(off - line_start).unwrap();
+            let hover = crate::hover::hover(
+                src,
+                line,
+                col,
+                &analysis,
+                Some(tcl_registry::registry_for_dialect("tcl9.0")),
+            )
+            .unwrap_or_else(|| panic!("{label}: expected a hover"));
+            assert!(
+                hover.value.contains("::tk::FocusGrab"),
+                "{label}: the card must name the cell: {}",
+                hover.value
+            );
+            let defs = crate::definition::definition(src, line, col, &analysis);
+            assert_eq!(defs.len(), 1, "{label}: one definition: {defs:?}");
+            let refs = crate::references::references(src, "tcl9.0", line, col, &analysis, true);
+            assert_eq!(
+                refs.len(),
+                4,
+                "{label}: otherVar word + info exists + read + unset: {refs:?}"
+            );
+        }
+    }
 
     /// The idx-58 shape: `$dataset` is created by the callee's `upvar`, and a
     /// sibling `TclOO` **method** happens to share the name.
@@ -1049,6 +1233,120 @@ proc caller {} {
         assert!(
             without.iter().any(|r| r.start_line == peek_line),
             "the read-only call site must be retained: {without:?}"
+        );
+    }
+
+    /// Issue #1139 (idx 22's literal-target residual), provider level: a
+    /// callee that binds `upvar name name` creates `name` in this frame,
+    /// with no call-site word to point at — hover / go-to-definition /
+    /// find-references must answer from the call itself instead of the
+    /// former silent miss.
+    #[test]
+    fn navigation_resolves_a_literal_upvar_target_to_the_creating_call() {
+        let src = "\
+proc NameProcess {arguments object} {
+    upvar name name
+    set name W1
+}
+proc build {} {
+    NameProcess x obj
+    set out $name
+}
+";
+        let analysis = Analyser::new().analyse(src, "tcl9.0").clone();
+        let line =
+            u32::try_from(src.lines().position(|l| l.contains("set out $name")).unwrap()).unwrap();
+        let col = u32::try_from(
+            src.lines()
+                .nth(line as usize)
+                .unwrap()
+                .find("$name")
+                .unwrap()
+                + 2,
+        )
+        .unwrap();
+        let hover = crate::hover::hover(
+            src,
+            line,
+            col,
+            &analysis,
+            Some(tcl_registry::registry_for_dialect("tcl9.0")),
+        )
+        .expect("caller-frame hover for a literal target");
+        assert!(
+            hover.value.contains("Caller-frame variable"),
+            "expected a caller-frame card: {}",
+            hover.value
+        );
+        assert!(
+            hover.value.contains("NameProcess"),
+            "the card must name the creating callee: {}",
+            hover.value
+        );
+        let locs = crate::definition::definition(src, line, col, &analysis);
+        assert_eq!(locs.len(), 1, "one definition: {locs:?}");
+        let call_line = u32::try_from(
+            src.lines()
+                .position(|l| l.contains("NameProcess x obj"))
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            locs[0].start_line, call_line,
+            "definition must reach the creating call: {locs:?}"
+        );
+        let refs = crate::references::references(src, "tcl9.0", line, col, &analysis, true);
+        assert!(
+            refs.iter().any(|r| r.start_line == call_line),
+            "the creating call is part of the reference set: {refs:?}"
+        );
+        assert!(
+            refs.iter().any(|r| r.start_line == line),
+            "the read is part of the reference set: {refs:?}"
+        );
+    }
+
+    /// A bare cursor on the callee's command word keeps resolving as the
+    /// **command**, never as the variable its literal `upvar` creates.
+    #[test]
+    fn the_call_head_word_still_navigates_as_a_command() {
+        let src = "\
+proc NameProcess {arguments object} {
+    upvar name name
+    set name W1
+}
+proc build {} {
+    NameProcess x obj
+    set out $name
+}
+";
+        let analysis = Analyser::new().analyse(src, "tcl9.0").clone();
+        let call_line = u32::try_from(
+            src.lines()
+                .position(|l| l.contains("NameProcess x obj"))
+                .unwrap(),
+        )
+        .unwrap();
+        let col = u32::try_from(
+            src.lines()
+                .nth(call_line as usize)
+                .unwrap()
+                .find("NameProcess")
+                .unwrap()
+                + 2,
+        )
+        .unwrap();
+        let locs = crate::definition::definition(src, call_line, col, &analysis);
+        assert_eq!(locs.len(), 1, "one definition: {locs:?}");
+        let def_line = u32::try_from(
+            src.lines()
+                .position(|l| l.contains("proc NameProcess"))
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            locs[0].start_line, def_line,
+            "the command word must reach the proc definition: {locs:?}"
         );
     }
 

--- a/rust/tcl-lsp-core/src/caller_frame.rs
+++ b/rust/tcl-lsp-core/src/caller_frame.rs
@@ -866,8 +866,7 @@ proc build {} {
     fn a_literal_upvar_target_binds_at_the_call_head() {
         let analysis = analyse(IDX22);
         let read = offset_of(IDX22, "$name") + 1;
-        let bindings =
-            caller_frame_bindings(&analysis, IDX22, "tcl9.0", Some(reg()), read, "name");
+        let bindings = caller_frame_bindings(&analysis, IDX22, "tcl9.0", Some(reg()), read, "name");
         assert_eq!(bindings.len(), 1, "one binding call site: {bindings:?}");
         assert_eq!(bindings[0].param, None, "no call-site word carries it");
         assert!(!bindings[0].read_only, "the alias is written through");
@@ -921,7 +920,7 @@ proc build {} {
         let src = "proc peekname {} { upvar name name; return [string length $name] }\n\
                    proc build {} { set name N0\n peekname }\n";
         let analysis = analyse(src);
-        let call = offset_of(src, "peekname }") ;
+        let call = offset_of(src, "peekname }");
         let bindings = caller_frame_bindings(&analysis, src, "tcl9.0", Some(reg()), call, "name");
         assert_eq!(bindings.len(), 1, "{bindings:?}");
         assert!(bindings[0].read_only, "{bindings:?}");
@@ -1254,8 +1253,12 @@ proc build {} {
 }
 ";
         let analysis = Analyser::new().analyse(src, "tcl9.0").clone();
-        let line =
-            u32::try_from(src.lines().position(|l| l.contains("set out $name")).unwrap()).unwrap();
+        let line = u32::try_from(
+            src.lines()
+                .position(|l| l.contains("set out $name"))
+                .unwrap(),
+        )
+        .unwrap();
         let col = u32::try_from(
             src.lines()
                 .nth(line as usize)

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -2962,12 +2962,24 @@ fn caller_frame_hover_text(
     } else {
         "created in this frame by"
     };
-    format!(
-        "**Caller-frame variable** `{name}`\n\n\
-         {verb} `{}`, through its `{}` parameter's `upvar`.\n\n\
-         The name is passed at the call site, so this frame never assigns it directly.",
-        binding.callee, binding.param
-    )
+    match &binding.param {
+        Some(param) => format!(
+            "**Caller-frame variable** `{name}`\n\n\
+             {verb} `{}`, through its `{param}` parameter's `upvar`.\n\n\
+             The name is passed at the call site, so this frame never assigns it directly.",
+            binding.callee
+        ),
+        // A literal target (`upvar 1 name name`, issue #1139): the callee
+        // spells the name in its own body, so nothing at the call site
+        // carries it.
+        None => format!(
+            "**Caller-frame variable** `{name}`\n\n\
+             {verb} `{}`, whose own `upvar` names it literally.\n\n\
+             The name is spelled in the callee's body, so neither this frame \
+             nor the call site ever writes it directly.",
+            binding.callee
+        ),
+    }
 }
 
 fn var_hover_text(var_def: &VarDef, type_info: Option<&str>, taint_info: Option<&str>) -> String {

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -1962,6 +1962,79 @@ fn bang_equals_string_condition_folds() {
     }
 }
 
+// Issue #1177: a method callee reached via `my` is invisible to the
+// caller's upvar context, so its `upvar 1 $refvar ref` caller-frame
+// definition read as a no-op and `[info exists ref]` in the calling method
+// folded always false. Oracle (tclsh 9.0.4 / 8.6.14): after `my Reference?
+// $lookup ref` returns true the guard is 1; on a miss, 0 — live code, so
+// the fold must abstain.
+
+#[test]
+fn info_exists_after_my_dispatch_to_an_upvar_sibling_does_not_fire_i230() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "oo::class create Formatter {\n    method Reference? {lookup refvar} {\n        upvar 1 $refvar ref\n        if {$lookup eq \"x\"} { set ref 1; return 1 }\n        return 0\n    }\n    method ResolvableReference? {lookup} {\n        my Reference? $lookup ref\n        if {[info exists ref]} { puts hi }\n    }\n}\n";
+    let diags = lsp.open_ready(&uri, src);
+    assert!(
+        !has_code(&diags, "I230"),
+        "an upvar-defined local across a `my` dispatch must not fold: {:?}",
+        codes(&diags)
+    );
+}
+
+/// TN control for the dispatch widening: with no caller-frame-reaching
+/// method anywhere in the module, a never-set non-instance local still
+/// folds always false after a `my` call (tclsh 9.0.4 / 8.6.14:
+/// `[info exists zzz]` is 0).
+#[test]
+fn info_exists_still_fires_i230_when_no_method_reaches_the_caller_frame() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "oo::class create C {\n    method Helper {} { return 1 }\n    method m {} {\n        my Helper\n        if {[info exists zzz]} { puts hi }\n    }\n}\n";
+    let diags = lsp.open_ready(&uri, src);
+    assert!(
+        has_code(&diags, "I230"),
+        "with complete dispatch evidence the fold must survive: {:?}",
+        codes(&diags)
+    );
+}
+
+// Issue #1198: O102 forwarded a stale global across a called proc's
+// `uplevel #0` write. `setter`'s `uplevel #0 {set x 99}` needs no `global`
+// declaration, so the interprocedural summary missed the global-frame
+// write and the optimiser rewrote `puts $x` to `puts 5` where tclsh
+// 9.0.3/9.0.4 prints 99. O102 is `constant_folding` category, outside the
+// default `readability` profile — opt into `standard` so it can surface.
+
+#[test]
+fn o102_does_not_forward_a_global_across_a_callees_uplevel_hash_zero_write() {
+    let mut lsp = Lsp::with_config(serde_json::json!({ "optimiser": { "profile": "standard" } }));
+    let uri = unique_uri("tcl");
+    let src = "proc setter {} {\n    uplevel #0 {\n        set x 99\n    }\n}\nset x 5\nsetter\nputs $x\n";
+    let diags = lsp.open_ready(&uri, src);
+    assert!(
+        !has_code(&diags, "O102"),
+        "the callee's `uplevel #0` write makes the forward unsound: {:?}",
+        codes(&diags)
+    );
+}
+
+/// TN control for the global-frame effect summary: a callee whose
+/// `uplevel #0` script writes no variable has no global effect, so the
+/// caller's constant still forwards (tclsh 9.0.4: prints `hi` then `5`).
+#[test]
+fn o102_still_fires_when_the_callees_uplevel_hash_zero_writes_nothing() {
+    let mut lsp = Lsp::with_config(serde_json::json!({ "optimiser": { "profile": "standard" } }));
+    let uri = unique_uri("tcl");
+    let src = "proc shout {} {\n    uplevel #0 [list puts hi]\n}\nset x 5\nshout\nputs $x\n";
+    let diags = lsp.open_ready(&uri, src);
+    assert!(
+        has_code(&diags, "O102"),
+        "a non-writing global-frame script must not block forwarding: {:?}",
+        codes(&diags)
+    );
+}
+
 // -- TestI230InterproceduralCallSiteSeedingE2E ---------------------------
 // Issue #969: "Condition '$count & 1' is always false" fired on a genuinely
 // alternating parity check. Root cause: the interprocedural param-constant

--- a/rust/tcl-lsp-server/tests/e2e/navigation.rs
+++ b/rust/tcl-lsp-server/tests/e2e/navigation.rs
@@ -226,7 +226,7 @@ fn references_link_the_call_site_word_and_the_caller_frame_read() {
 
 // -- Literal caller-frame targets (issue #923 audit idx 22 / issue #1139) --
 
-/// The SpiceGenTcl shape, minimised to its proc half: the callee spells the
+/// The `SpiceGenTcl` shape, minimised to its proc half: the callee spells the
 /// caller-frame name **in its own body** (`upvar name name`), so no
 /// call-site word carries it.  tclsh 9.0.4: `build` returns `W1`.
 const LITERAL_TARGET_SRC: &str = "\

--- a/rust/tcl-lsp-server/tests/e2e/navigation.rs
+++ b/rust/tcl-lsp-server/tests/e2e/navigation.rs
@@ -224,6 +224,91 @@ fn references_link_the_call_site_word_and_the_caller_frame_read() {
     assert!(!from_read.contains(&9), "{from_read:?}");
 }
 
+// -- Literal caller-frame targets (issue #923 audit idx 22 / issue #1139) --
+
+/// The SpiceGenTcl shape, minimised to its proc half: the callee spells the
+/// caller-frame name **in its own body** (`upvar name name`), so no
+/// call-site word carries it.  tclsh 9.0.4: `build` returns `W1`.
+const LITERAL_TARGET_SRC: &str = "\
+proc NameProcess {arguments object} {
+    upvar name name
+    set name W1
+}
+proc build {} {
+    NameProcess x obj
+    set out $name
+}
+";
+
+#[test]
+fn hover_on_a_literal_upvar_target_read_names_the_creating_call() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, LITERAL_TARGET_SRC);
+    // Line 6 col 15 — inside the `name` of `set out $name`.
+    let text = hover_text(&lsp.hover(&uri, 6, 15));
+    assert!(
+        text.contains("Caller-frame variable") && text.contains("NameProcess"),
+        "expected the caller-frame card naming the callee: {text:?}"
+    );
+}
+
+#[test]
+fn definition_on_a_literal_upvar_target_read_reaches_the_creating_call() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, LITERAL_TARGET_SRC);
+    let locs = locations(&lsp.definition(&uri, 6, 15));
+    assert_eq!(locs.len(), 1, "one definition: {locs:?}");
+    assert_eq!(
+        locs[0].range["start"]["line"].as_i64(),
+        Some(5),
+        "the creating call is the nearest thing to a declaration: {locs:?}"
+    );
+}
+
+#[test]
+fn references_on_a_literal_upvar_target_link_the_call_and_the_read() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, LITERAL_TARGET_SRC);
+    let from_read = start_lines(&lsp.references(&uri, 6, 15, true));
+    assert_eq!(
+        from_read.iter().copied().collect::<Vec<i64>>(),
+        vec![5, 6],
+        "the creating call and the read are one variable: {from_read:?}"
+    );
+}
+
+/// Issue #923 audit idx 98: `upvar ::tk::FocusGrab($index) data` names one
+/// fixed global cell (level-independent), so the sibling proc's
+/// `$::tk::FocusGrab($index)` read and the `upvar` `otherVar` word now
+/// cross-reference — previously every anchor answered nothing.
+///
+/// Pinned at the parity point with a plain qualified write: the server's
+/// per-item incremental analysis merges a proc-body `set
+/// ::tk::FocusGrab($i) 1` to exactly the same answer (references link the
+/// write word and the `$` read; read-anchored hover/definition and the
+/// bareword `info exists` / `unset` occurrences are a known per-item
+/// residual shared by both spellings — the whole-file analysis pinned in
+/// `tcl-lsp-core`'s `caller_frame` tests answers all four anchors).
+#[test]
+fn a_fully_qualified_upvar_target_cross_references_between_procs() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "proc SetFocusGrab {grab focus} {\n    set index \"$grab,$focus\"\n    upvar ::tk::FocusGrab($index) data\n    lappend data one\n}\nproc RestoreFocusGrab {grab focus} {\n    set index \"$grab,$focus\"\n    if {[info exists ::tk::FocusGrab($index)]} {\n        set data2 $::tk::FocusGrab($index)\n        unset ::tk::FocusGrab($index)\n    }\n}\n",
+    );
+    // Line 8 col 26 — inside the `FocusGrab` of the
+    // `$::tk::FocusGrab($index)` read.
+    let refs = start_lines(&lsp.references(&uri, 8, 26, true));
+    assert!(
+        refs.contains(&2) && refs.contains(&8),
+        "the read must link the upvar otherVar word across procs: {refs:?}"
+    );
+}
+
 /// TN — an unbound `$`-led read abstains rather than resolving to a
 /// coincidentally same-named method.  This is the wrong-kind conflation the
 /// audit confirmed: Tcl's variable and command namespaces are disjoint.


### PR DESCRIPTION
## Summary

- **#1165**: `upvar 1 x $dst` (dynamic local name) was invisible to `detect_upvar_procs`, so callers of such procs never widened. Frame-effect summaries now record dynamic-local upvar aliases and global-frame `uplevel` scripts.
- **#1177**: method callees reached via `my`/`next` were invisible to the caller's upvar context (info-exists FP on upvar-defined locals in method bodies). Dispatch sites in method-body CFGs now widen when any method in the module can reach its caller's frame; the evidence rule is shared with the propagation gate so the two consumers cannot drift.
- **#1139**: caller-frame `upvar` targets the call site never spells — the `literal_targets` residual of the frame-effect summary. Literal and fully-qualified upvar targets now resolve for navigation and definitions.
- **#1198**: O102 forwarded stale globals across a called proc's `uplevel #0` write. Root cause: such writes need no `global`/`variable` declaration, so `GlobalWriteInfo` never recorded them and load-forwarding carried the caller's stale global-literal snapshot across the call (the optimiser rewrote `puts $x` to `puts 5` where tclsh 9.0.3/9.0.4 prints 99). Fix: literal `uplevel #0` bodies and constructed `uplevel #0 [list set g …]` contribute per-name global writes to the callee's summary; dynamic scripts/targets set a transitive `opaque_global_frame` flag that becomes a `Statement::Barrier` at every call-site position, consumed uniformly by SCCP, O102, O109/DSE, and branch folding.

Found en route, filed separately: #1240 (`loop_body_blocks` is O(V·E) per pass — quadratic on branch-heavy procs, pre-existing at base).

## Validation

- [x] On the group branch (pre-rebase base): `cargo test -p tcl-compiler -p tcl-lsp-core -p tcl-lsp-server` — 7862 + 2665 + 1584 passed, 0 failed; `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean over the three crates, no new `#[allow]`s.
- [x] Rebased onto post-#1238 rust; two textual conflicts resolved (an added function beside shifted context in `optimiser/propagation.rs`; a superseded local helper in `taint_interproc.rs` replaced by the hoisted `push_unique_edge`).
- [ ] Post-rebase suite delegated to CI — local runners are saturated by parallel group builds; this session is subscribed to the PR and will drive any failure to green.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? — Yes: `GlobalWriteInfo` gains uplevel-#0-derived per-name global writes and a transitive `opaque_global_frame` effect surfacing as `Statement::Barrier`; frame-effect summaries gain dynamic-local alias and global-frame-script facts.
- [x] If yes, I updated at least one relevant KCS note — frame-effect/analysis design notes updated in-tree with the new facts.
- [ ] If I added a new compiler KCS note, I linked it — n/a (existing notes extended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_