### PR TITLE
Navigation: namespace reference identities, resolved indirect heads, command-position gate, document-tier model agreement (#1113, #1133, #1137, #1140)

### DIFF
--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -1137,7 +1137,9 @@ impl Analyser {
             Hook::OoDefine => {
                 self.handle_oo_define_command(cmd_name, args, arg_tokens, arg_single, scope_path)
             }
-            Hook::NamespaceEval => self.handle_namespace_eval_command(args, arg_tokens, scope_path),
+            Hook::NamespaceEval => {
+                self.handle_namespace_eval_command(args, arg_tokens, arg_single, scope_path)
+            }
             // uplevel #0 { body } — opens a global-frame child scope so
             // the body's locals don't leak into the enclosing proc's
             // variable set.  Only the `#0` form is consumed; other
@@ -1255,7 +1257,7 @@ impl Analyser {
                 false
             }
             Hook::NamespacePath => {
-                self.handle_namespace_path_command(args, scope_path);
+                self.handle_namespace_path_command(args, arg_tokens, scope_path);
                 false
             }
             Hook::NamespaceUnknown => {

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -2304,9 +2304,7 @@ impl Analyser {
                 )
             })
             .flatten()
-            .filter(|resolved| {
-                !resolved.is_empty() && !crate::naming::is_dynamic_word(resolved)
-            });
+            .filter(|resolved| !resolved.is_empty() && !crate::naming::is_dynamic_word(resolved));
         if let (Some(resolved), Some(tok)) = (resolved_dynamic.as_deref(), arg_tokens.get(1)) {
             // The word is also the block's declaring occurrence of that
             // namespace, which is what lets navigation reach it from a
@@ -2974,12 +2972,7 @@ impl Analyser {
     /// Silently does nothing when the word is not a braced/bare literal the
     /// span arithmetic can trust (`token` absent, or the element offsets fall
     /// outside it).
-    fn record_namespace_path_element_refs(
-        &mut self,
-        raw: &str,
-        token: Option<&Token>,
-        here: &str,
-    ) {
+    fn record_namespace_path_element_refs(&mut self, raw: &str, token: Option<&Token>, here: &str) {
         let Some(token) = token else { return };
         let base = token.span.start() + u32::from(token.content_offset);
         let mut scan = 0usize;
@@ -7637,7 +7630,11 @@ mod tests {
         let mut a = Analyser::new();
         a.handle_namespace_path_command(&["path".to_string()], &[], &[]);
         a.handle_namespace_path_command(&["path".to_string(), "$entries".to_string()], &[], &[]);
-        a.handle_namespace_path_command(&["path".to_string(), "[current_path]".to_string()], &[], &[]);
+        a.handle_namespace_path_command(
+            &["path".to_string(), "[current_path]".to_string()],
+            &[],
+            &[],
+        );
         assert!(a.namespace_paths.is_empty());
     }
 

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -2954,7 +2954,7 @@ impl Analyser {
             // accept either; record nothing rather than half of one.
             return;
         };
-        let entries: Vec<String> = elements.iter().map(|e| e.to_string()).collect();
+        let entries: Vec<String> = elements.iter().map(ToString::to_string).collect();
         self.record_namespace_path_element_refs(&args[1], arg_tokens.get(1), &ns);
         self.namespace_paths.insert(ns, entries);
     }

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -2082,6 +2082,29 @@ impl Analyser {
             }
             _ => "::".to_string(),
         };
+        // That element is also a first-class *reference* to the namespace it
+        // names, not merely a semantic input (issue #1113 item 4): it sits
+        // inside an `ArgRole::LambdaLiteral` word, which no whole-word role
+        // reaches, so the identity is recorded here, where the element has
+        // already been split. Non-declaring — `apply` looks the namespace up,
+        // it does not create it (tclsh 8.6.16 / 9.0.4: `apply {{} {} ::nope}`
+        // fails `namespace "::nope" not found`).
+        if let Some((ns_tok, ns_text)) = elements.get(2)
+            && body_ns != "::"
+            && !crate::naming::is_dynamic_word(ns_text)
+        {
+            let span = tcl_lexer::Span::new(
+                ns_tok.span.start() + u32::from(ns_tok.content_offset),
+                ns_tok.span.end(),
+            );
+            if span.start() < span.end() {
+                self.result.namespace_refs.push(super::types::NamespaceRef {
+                    qualified_name: body_ns.clone(),
+                    span,
+                    declares: false,
+                });
+            }
+        }
 
         let params = parse_param_list(params_text);
         let body_text: std::sync::Arc<str> = std::sync::Arc::from(body_text);
@@ -2215,6 +2238,7 @@ impl Analyser {
         &mut self,
         args: &[String],
         arg_tokens: &[Token],
+        arg_single: &[bool],
         scope_path: &[usize],
     ) -> bool {
         if args.len() < 2 {
@@ -2260,13 +2284,49 @@ impl Analyser {
         // the same written text). Mirrors `interp eval`'s dynamic-path
         // handling a few hooks below, which is conservatively isolated the
         // same way rather than merged by raw text.
-        let scope_name = if crate::naming::is_dynamic_word(&ns_name) {
-            match arg_tokens.get(1) {
+        //
+        // A computed target whose value is **constant-dominated** is not
+        // dynamic in any way that matters: `set ns ::app; namespace eval $ns
+        // { … }` creates `::app` on every run, so the block's procs really do
+        // home to `::app::…` and the block really is a declaring site for
+        // `::app`. That case is settled through the same identity-resolution
+        // helper the command head (issue #923 idx 44), `source`, `rename`, and
+        // `oo::define`'s target word already use — one lattice answers "what
+        // does this word name" everywhere, and its dominance requirement keeps
+        // a branch-conditional binding out (issue #1113 item 3).
+        let resolved_dynamic = crate::naming::is_dynamic_word(&ns_name)
+            .then(|| {
+                self.resolve_dynamic_word(
+                    &ns_name,
+                    arg_tokens.get(1).copied(),
+                    arg_single.get(1).copied().unwrap_or(false),
+                    scope_path,
+                )
+            })
+            .flatten()
+            .filter(|resolved| {
+                !resolved.is_empty() && !crate::naming::is_dynamic_word(resolved)
+            });
+        if let (Some(resolved), Some(tok)) = (resolved_dynamic.as_deref(), arg_tokens.get(1)) {
+            // The word is also the block's declaring occurrence of that
+            // namespace, which is what lets navigation reach it from a
+            // `namespace children ::app` elsewhere — the whole-word role scan
+            // in `record_namespace_name_refs` skips dynamic words, so the
+            // identity is recorded here, where it has just been settled.
+            let here = self.command_resolution_namespace(scope_path);
+            self.result.namespace_refs.push(super::types::NamespaceRef {
+                qualified_name: crate::naming::qualify(&here, resolved),
+                span: tok.span,
+                declares: true,
+            });
+        }
+        let scope_name = match resolved_dynamic {
+            Some(resolved) => resolved,
+            None if crate::naming::is_dynamic_word(&ns_name) => match arg_tokens.get(1) {
                 Some(tok) => self.mint_synthetic_offset_name("@dynns@", tok.span.start()),
                 None => ns_name.clone(),
-            }
-        } else {
-            ns_name
+            },
+            None => ns_name,
         };
 
         let path = scope_path.to_vec();
@@ -2854,7 +2914,22 @@ impl Analyser {
     /// [`tcl_registry::hooks::AnalyserHookId::NamespacePath`] (stamped
     /// on `namespace`'s `path` subcommand); `args[0]` is still the
     /// subcommand word.
-    pub fn handle_namespace_path_command(&mut self, args: &[String], scope_path: &[usize]) {
+    ///
+    /// The argument is a *list* of namespace names inside one word, so each
+    /// element is additionally recorded as a
+    /// [`NamespaceRef`](super::types::NamespaceRef) at its own source span
+    /// (issue #1113 item 2). Whole-word `ArgRole`s cannot express that — the
+    /// word as a whole is not one namespace name — so the split happens here,
+    /// where the semantics are already modelled, using the shared Tcl list
+    /// grammar rather than a second scanner. That is also what makes a braced
+    /// element (`namespace path {{my ns} ::b}`) come out right, which the
+    /// previous `split_whitespace` did not.
+    pub fn handle_namespace_path_command(
+        &mut self,
+        args: &[String],
+        arg_tokens: &[Token],
+        scope_path: &[usize],
+    ) {
         if args.len() != 2 {
             return;
         }
@@ -2876,8 +2951,62 @@ impl Analyser {
             return;
         }
         let ns = self.command_resolution_namespace(scope_path);
-        let entries = args[1].split_whitespace().map(str::to_string).collect();
+        let Ok(elements) = tcl_syntax::list::split_list(&args[1]) else {
+            // A malformed list (an unbalanced brace) is not a path Tcl would
+            // accept either; record nothing rather than half of one.
+            return;
+        };
+        let entries: Vec<String> = elements.iter().map(|e| e.to_string()).collect();
+        self.record_namespace_path_element_refs(&args[1], arg_tokens.get(1), &ns);
         self.namespace_paths.insert(ns, entries);
+    }
+
+    /// Record one [`NamespaceRef`](super::types::NamespaceRef) per element of
+    /// a `namespace path {…}` list, at the element's own source span.
+    ///
+    /// Non-declaring: a path entry *refers* to a namespace, it does not
+    /// create one (tclsh 8.6.16 / 9.0.4: `namespace path ::nope` fails
+    /// `namespace "::nope" not found`, so the name must already exist).
+    /// Rooting follows the ordinary relative rule — a relative entry is
+    /// current-namespace-relative only, which is what
+    /// `command_resolution_candidates` already assumes.
+    ///
+    /// Silently does nothing when the word is not a braced/bare literal the
+    /// span arithmetic can trust (`token` absent, or the element offsets fall
+    /// outside it).
+    fn record_namespace_path_element_refs(
+        &mut self,
+        raw: &str,
+        token: Option<&Token>,
+        here: &str,
+    ) {
+        let Some(token) = token else { return };
+        let base = token.span.start() + u32::from(token.content_offset);
+        let mut scan = 0usize;
+        while let Ok(Some(el)) = tcl_syntax::list::find_element(raw, scan) {
+            let (start, end) = (el.value.start, el.value.end);
+            if el.next <= scan {
+                break;
+            }
+            scan = el.next;
+            let Some(text) = raw.get(start..end) else {
+                continue;
+            };
+            if text.is_empty() || crate::naming::is_dynamic_word(text) {
+                continue;
+            }
+            let Ok(start_u32) = u32::try_from(start) else {
+                continue;
+            };
+            let Ok(end_u32) = u32::try_from(end) else {
+                continue;
+            };
+            self.result.namespace_refs.push(super::types::NamespaceRef {
+                qualified_name: crate::naming::qualify(here, text),
+                span: tcl_lexer::Span::new(base + start_u32, base + end_u32),
+                declares: false,
+            });
+        }
     }
 
     /// Handle `uplevel #0 { body }`: the script runs in the global
@@ -7488,12 +7617,12 @@ mod tests {
     #[test]
     fn handle_namespace_path_records_and_replaces() {
         let mut a = Analyser::new();
-        a.handle_namespace_path_command(&["path".to_string(), "::u ::v".to_string()], &[]);
+        a.handle_namespace_path_command(&["path".to_string(), "::u ::v".to_string()], &[], &[]);
         assert_eq!(
             a.namespace_paths.get("::").map(Vec::as_slice),
             Some(&["::u".to_string(), "::v".to_string()][..]),
         );
-        a.handle_namespace_path_command(&["path".to_string(), "inner".to_string()], &[]);
+        a.handle_namespace_path_command(&["path".to_string(), "inner".to_string()], &[], &[]);
         assert_eq!(
             a.namespace_paths.get("::").map(Vec::as_slice),
             Some(&["inner".to_string()][..]),
@@ -7506,9 +7635,9 @@ mod tests {
     #[test]
     fn handle_namespace_path_skips_query_and_dynamic_forms() {
         let mut a = Analyser::new();
-        a.handle_namespace_path_command(&["path".to_string()], &[]);
-        a.handle_namespace_path_command(&["path".to_string(), "$entries".to_string()], &[]);
-        a.handle_namespace_path_command(&["path".to_string(), "[current_path]".to_string()], &[]);
+        a.handle_namespace_path_command(&["path".to_string()], &[], &[]);
+        a.handle_namespace_path_command(&["path".to_string(), "$entries".to_string()], &[], &[]);
+        a.handle_namespace_path_command(&["path".to_string(), "[current_path]".to_string()], &[], &[]);
         assert!(a.namespace_paths.is_empty());
     }
 
@@ -7524,7 +7653,7 @@ mod tests {
                 crate::analyser::types::ScopeKind::Namespace,
                 "outer",
             ));
-        a.handle_namespace_path_command(&["path".to_string(), "::helpers".to_string()], &[0]);
+        a.handle_namespace_path_command(&["path".to_string(), "::helpers".to_string()], &[], &[0]);
         assert_eq!(
             a.namespace_paths.get("::outer").map(Vec::as_slice),
             Some(&["::helpers".to_string()][..]),
@@ -8568,6 +8697,7 @@ mod tests {
                 str_tok(span(19, 35)),
             ],
             &[],
+            &[],
         );
         assert!(handled);
         assert_eq!(a.result.global_scope.children.len(), 1);
@@ -8588,6 +8718,7 @@ mod tests {
                 esc_tok(span(15, 18)),
                 str_tok(span(19, 35)),
             ],
+            &[],
             &[],
         );
         assert_eq!(
@@ -8617,6 +8748,7 @@ mod tests {
                 str_tok(span(21, 37)),
             ],
             &[],
+            &[],
         );
         assert_eq!(a.result.global_scope.children[0].name, "@dynns@15");
     }
@@ -8633,6 +8765,7 @@ mod tests {
                 esc_tok(span(15, 18)),
                 str_tok(span(19, 35)),
             ],
+            &[],
             &[],
         );
         assert_eq!(a.result.global_scope.children[0].name, "ns1");

--- a/rust/tcl-compiler/src/analyser/mod.rs
+++ b/rust/tcl-compiler/src/analyser/mod.rs
@@ -77,9 +77,10 @@ pub use item_tree::{FileDecls, Item, ItemId, ItemKind, ItemSig, ItemTree};
 // core light) can share it. Re-exported here so `tcl_compiler::analyser::…`
 // callers are unchanged.
 pub use scope::{
-    VariableAliasLink, command_resolution_namespace_at, innermost_scope_is_oo_method_frame,
-    innermost_scope_reaches_oo_helpers, lookup_var_by_qualified_name, lookup_var_in_namespace,
-    namespace_variables, qualified_name_for_var_decl, variable_alias_links,
+    VariableAliasLink, command_resolution_namespace_at, implicit_command_namespace_path_at,
+    innermost_scope_is_oo_method_frame, innermost_scope_reaches_oo_helpers,
+    lookup_var_by_qualified_name, lookup_var_in_namespace, namespace_variables,
+    qualified_name_for_var_decl, variable_alias_links,
 };
 pub use snapshot::AnalyserSnapshot;
 pub use state::{Analyser, NonAsciiMode};

--- a/rust/tcl-compiler/src/analyser/scope.rs
+++ b/rust/tcl-compiler/src/analyser/scope.rs
@@ -1228,7 +1228,10 @@ impl Analyser {
             let declared_path: &[String] = paths.get(&ns).map_or(&[], Vec::as_slice);
             let (search_ns, search_path): (&str, Vec<&str>) = match implicit_path.split_first() {
                 Some((first, rest)) => (first, rest.to_vec()),
-                None => (ns.as_str(), declared_path.iter().map(String::as_str).collect()),
+                None => (
+                    ns.as_str(),
+                    declared_path.iter().map(String::as_str).collect(),
+                ),
             };
             // Record the full ordered candidate list so a cross-document
             // consumer can re-settle this call against a *workspace-wide*

--- a/rust/tcl-compiler/src/analyser/scope.rs
+++ b/rust/tcl-compiler/src/analyser/scope.rs
@@ -1059,6 +1059,22 @@ impl Analyser {
         reachable
     }
 
+    /// The implicit `namespace path` each recorded call site carries, indexed
+    /// alongside `command_invocations`.
+    ///
+    /// Computed up front, before [`Self::finalise_invocation_resolutions`]
+    /// borrows that vector mutably, because the lookup reads the scope tree
+    /// living on the same `result`.
+    fn implicit_invocation_namespace_paths(&self) -> Vec<&'static [&'static str]> {
+        self.result
+            .command_invocations
+            .iter()
+            .map(|inv| {
+                implicit_command_namespace_path_at(&self.result.global_scope, inv.range.start())
+            })
+            .collect()
+    }
+
     pub(super) fn finalise_invocation_resolutions(&mut self) {
         // Populate the per-dialect builtin-name cache before splitting field
         // borrows below (`builtin_command_names` needs `&mut self`).
@@ -1091,18 +1107,7 @@ impl Analyser {
         // const-dispatch / variable-command passes' `Self::fact_live_for_call`
         // calls reuse the same map instead of rebuilding it.
         self.reachable_call_offsets = self.compute_reachable_call_offsets();
-        // The implicit `namespace path` each call site carries, indexed
-        // alongside `command_invocations`. Computed before the mutable borrow
-        // of that vector below, since the lookup reads the scope tree that
-        // lives on the same `result`.
-        let implicit_paths: Vec<&'static [&'static str]> = self
-            .result
-            .command_invocations
-            .iter()
-            .map(|inv| {
-                implicit_command_namespace_path_at(&self.result.global_scope, inv.range.start())
-            })
-            .collect();
+        let implicit_paths = self.implicit_invocation_namespace_paths();
         let renamed_away = self.renamed_away_builtin_names();
         let deleted_commands = &self.deleted_commands;
         let rename_offsets = &self.rename_offsets;

--- a/rust/tcl-compiler/src/analyser/scope.rs
+++ b/rust/tcl-compiler/src/analyser/scope.rs
@@ -261,6 +261,36 @@ pub fn innermost_scope_reaches_oo_helpers(root: &Scope, byte_offset: u32) -> boo
     innermost_oo_frame(root, byte_offset, |child| child.oo_global_resolution)
 }
 
+/// The **implicit `namespace path`** a bare command word written at
+/// `byte_offset` resolves through — the namespaces Tcl searches after the
+/// frame's own current namespace and before global, without anyone having
+/// written a `namespace path` command.
+///
+/// Empty everywhere except a `TclOO` object frame, where the path is
+/// registry data
+/// ([`tcl_registry::definer::TCLOO_MEMBER_BODY_NAMESPACE_PATH`]) rather than
+/// a namespace name spelled in this crate.  [`Scope::oo_global_resolution`]
+/// — the flag [`innermost_scope_reaches_oo_helpers`] reads — is precisely
+/// "this frame resolves like a `TclOO` member body", so the two facts are
+/// one lookup and cannot drift apart.
+///
+/// This is the single recording site for the path (issue #1137 idx 51): the
+/// analyser folds it into every affected invocation's
+/// `resolution_candidates`, so a cross-document consumer walking that list
+/// finds a `proc ::oo::Helpers::NAME` declared in *another* file without
+/// growing its own lenient fallback.
+#[must_use]
+pub fn implicit_command_namespace_path_at(
+    root: &Scope,
+    byte_offset: u32,
+) -> &'static [&'static str] {
+    if innermost_scope_reaches_oo_helpers(root, byte_offset) {
+        tcl_registry::definer::TCLOO_MEMBER_BODY_NAMESPACE_PATH
+    } else {
+        &[]
+    }
+}
+
 /// Whether the innermost scope containing `byte_offset` is a real `TclOO`
 /// **method invocation** — the *callability* half of the `oo::Helpers`
 /// scoping rule, and the counterpart to
@@ -1061,6 +1091,18 @@ impl Analyser {
         // const-dispatch / variable-command passes' `Self::fact_live_for_call`
         // calls reuse the same map instead of rebuilding it.
         self.reachable_call_offsets = self.compute_reachable_call_offsets();
+        // The implicit `namespace path` each call site carries, indexed
+        // alongside `command_invocations`. Computed before the mutable borrow
+        // of that vector below, since the lookup reads the scope tree that
+        // lives on the same `result`.
+        let implicit_paths: Vec<&'static [&'static str]> = self
+            .result
+            .command_invocations
+            .iter()
+            .map(|inv| {
+                implicit_command_namespace_path_at(&self.result.global_scope, inv.range.start())
+            })
+            .collect();
         let renamed_away = self.renamed_away_builtin_names();
         let deleted_commands = &self.deleted_commands;
         let rename_offsets = &self.rename_offsets;
@@ -1089,7 +1131,8 @@ impl Analyser {
             deleted_commands,
             reachable_call_offsets,
         };
-        for inv in &mut result.command_invocations {
+        for (idx, inv) in result.command_invocations.iter_mut().enumerate() {
+            let implicit_path = implicit_paths.get(idx).copied().unwrap_or(&[]);
             // Absolute names are exact — the sole candidate is the name itself.
             // `None` means a background scan that skipped the scope walk; leave
             // its (empty) candidate list untouched.
@@ -1170,18 +1213,34 @@ impl Analyser {
                     continue;
                 }
             };
-            let path: &[String] = paths.get(&ns).map_or(&[], Vec::as_slice);
+            // A frame carrying an *implicit* `namespace path` (a `TclOO`
+            // member body's `::oo::Helpers`, registry data — see
+            // [`implicit_command_namespace_path_at`]) searches that path
+            // between its own current namespace and global.  That current
+            // namespace is the object's (`::oo::ObjN`) and has no static
+            // spelling, so the walk substitutes global for it — which, left
+            // alone, would put the *global* candidate ahead of the path one
+            // and invert Tcl's order (tclsh 8.6.16 / 9.0.4: with both
+            // `::callback` and `::oo::Helpers::callback` defined, a bare
+            // `callback` in a method body reaches the latter).  The
+            // unspellable slot is therefore dropped and the implicit path
+            // takes its place at the head of the search.
+            let declared_path: &[String] = paths.get(&ns).map_or(&[], Vec::as_slice);
+            let (search_ns, search_path): (&str, Vec<&str>) = match implicit_path.split_first() {
+                Some((first, rest)) => (first, rest.to_vec()),
+                None => (ns.as_str(), declared_path.iter().map(String::as_str).collect()),
+            };
             // Record the full ordered candidate list so a cross-document
             // consumer can re-settle this call against a *workspace-wide*
             // existence check — the local-first guess below only sees this
             // file, so a call resolving (via `namespace path`) to a proc
             // defined in another file cannot settle correctly here.
             inv.resolution_candidates =
-                crate::naming::command_resolution_candidates(&ns, path, &inv.name);
+                crate::naming::command_resolution_candidates(search_ns, &search_path, &inv.name);
             let call_off = inv.range.start();
             let known_here = |c: &str| known_ctx.known(c, call_off);
             if let Some(winner) =
-                crate::naming::resolve_command_with(&ns, path, &inv.name, &known_here)
+                crate::naming::resolve_command_with(search_ns, &search_path, &inv.name, &known_here)
                 && winner != resolved
             {
                 inv.resolved_qualified_name = Some(winner);

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -5395,3 +5395,204 @@ mod leading_bom {
         );
     }
 }
+
+// ===========================================================================
+// A TclOO member body's implicit `namespace path` — issue #1137 idx 51.
+//
+// tclsh 8.6.16 and 9.0.4, inside `oo::class create C { method m {} { … } }`:
+//     namespace current -> ::oo::ObjN        namespace path -> ::oo::Helpers
+// so a bare word is looked up in the object namespace, then `::oo::Helpers`,
+// then global. The documented "TclOO Tricks" idiom installs helpers directly
+// (`proc ::oo::Helpers::callback {…} {…}`) and calls them bare from method
+// bodies — which is what nico-robert/ticklecharts does, with the helper in
+// `utils.tcl` and the calls in `esnap.tcl`.
+//
+// The candidate list is where that path belongs: `resolve_workspace_symbols`
+// (the one cross-file resolver) walks it, so recording it once here fixes
+// definition, references, rename, call hierarchy, and W123 together, across
+// files, instead of each consumer growing its own lenient fallback.
+// ===========================================================================
+mod oo_helpers_namespace_path {
+    use super::Analyser;
+
+    fn candidates_for(src: &str, dialect: &str, name: &str) -> Vec<String> {
+        Analyser::new()
+            .analyse(src, dialect)
+            .command_invocations
+            .iter()
+            .find(|inv| inv.name == name)
+            .map(|inv| inv.resolution_candidates.clone())
+            .unwrap_or_default()
+    }
+
+    fn resolution_of(src: &str, dialect: &str, name: &str) -> Option<String> {
+        Analyser::new()
+            .analyse(src, dialect)
+            .command_invocations
+            .iter()
+            .find(|inv| inv.name == name)
+            .and_then(|inv| inv.resolved_qualified_name.clone())
+    }
+
+    #[test]
+    fn tp_a_method_body_call_carries_the_helpers_candidate_first() {
+        // TP — `::oo::Helpers::callback` must be a candidate, and must rank
+        // ahead of the global one: with both defined, real Tcl reaches the
+        // helper.
+        let src = "oo::class create C {\n    method Go {} {\n        callback Read\n    }\n}\n";
+        assert_eq!(
+            candidates_for(src, "tcl9.0", "callback"),
+            ["::oo::Helpers::callback", "::callback"],
+        );
+    }
+
+    #[test]
+    fn tp_the_same_holds_for_a_constructor_body() {
+        let src = "oo::class create C {\n    constructor {} {\n        callback Read\n    }\n}\n";
+        assert_eq!(
+            candidates_for(src, "tcl9.0", "callback"),
+            ["::oo::Helpers::callback", "::callback"],
+        );
+    }
+
+    #[test]
+    fn tp_a_helper_declared_in_the_same_file_settles_the_call_onto_it() {
+        // TP — with the helper present the call settles on it, not on a
+        // phantom `::callback`.
+        let src = "proc ::oo::Helpers::callback {m args} { return $m }\noo::class create C {\n    method Go {} {\n        callback Read\n    }\n}\n";
+        assert_eq!(
+            resolution_of(src, "tcl9.0", "callback").as_deref(),
+            Some("::oo::Helpers::callback"),
+        );
+    }
+
+    #[test]
+    fn fp_a_top_level_call_gets_no_helpers_candidate() {
+        // FP guard — `::oo::Helpers` is on a *method body's* namespace path
+        // only. tclsh raises `invalid command name` for a bare `callback`
+        // at the top level, so the candidate must not appear there.
+        let src = "proc ::oo::Helpers::callback {m args} { return $m }\ncallback Read\n";
+        assert_eq!(candidates_for(src, "tcl9.0", "callback"), ["::callback"]);
+    }
+
+    #[test]
+    fn fp_an_apply_lambda_inside_a_method_loses_the_path() {
+        // FP guard — `apply` runs its body in the global namespace, so the
+        // object context (and its path) is gone. tclsh 9.0.4 raises
+        // `invalid command name "link"` for exactly this shape.
+        let src = "oo::class create C {\n    method Go {} {\n        apply {{} { callback Read }}\n    }\n}\n";
+        assert_eq!(candidates_for(src, "tcl9.0", "callback"), ["::callback"]);
+    }
+
+    #[test]
+    fn tn_a_snit_method_body_gets_no_helpers_candidate() {
+        // TN — snit member bodies run in the type namespace with no
+        // injected path; only the TclOO grammar declares one.
+        let src = "snit::type T {\n    method Go {} {\n        callback Read\n    }\n}\n";
+        let cands = candidates_for(src, "tcl9.0", "callback");
+        assert!(
+            !cands.iter().any(|c| c.starts_with("::oo::Helpers")),
+            "snit gets no TclOO helper path: {cands:?}",
+        );
+    }
+
+    #[test]
+    fn tn_an_ordinary_builtin_still_settles_globally_from_a_method_body() {
+        // TN — the extra candidate must not divert an ordinary call: `puts`
+        // has no `::oo::Helpers` member, so it still reaches `::puts`.
+        let src = "oo::class create C {\n    method Go {} {\n        puts hi\n    }\n}\n";
+        assert_eq!(
+            resolution_of(src, "tcl9.0", "puts").as_deref(),
+            Some("::puts"),
+        );
+    }
+}
+
+// ===========================================================================
+// A constant-dominated computed `namespace eval` target — issue #1113 item 3.
+//
+// `set ns ::app; namespace eval $ns { … }` creates `::app` on every run, so
+// the block's procs really do home to `::app::…`.  The word is settled by the
+// same identity-resolution helper the command head (idx 44), `source`,
+// `rename`, and `oo::define`'s target already use, so its dominance rule —
+// a branch-conditional binding proves nothing — applies here unchanged.
+// Anything it cannot settle keeps the per-site `@dynns@` domain.
+// ===========================================================================
+mod const_dominated_namespace_eval {
+    use super::Analyser;
+
+    fn proc_names(src: &str) -> Vec<String> {
+        let mut names: Vec<String> = Analyser::new()
+            .analyse(src, "tcl9.0")
+            .all_procs
+            .keys()
+            .cloned()
+            .collect();
+        names.sort();
+        names
+    }
+
+    fn scope_names(src: &str) -> Vec<String> {
+        Analyser::new()
+            .analyse(src, "tcl9.0")
+            .global_scope
+            .children
+            .iter()
+            .map(|c| c.name.clone())
+            .collect()
+    }
+
+    #[test]
+    fn tp_a_constant_target_homes_the_blocks_procs_to_the_real_namespace() {
+        let src = "set ns ::app\nnamespace eval $ns {\n    proc go {} { return 1 }\n}\n";
+        assert_eq!(proc_names(src), ["::app::go"]);
+        assert_eq!(scope_names(src), ["::app"]);
+    }
+
+    #[test]
+    fn tp_the_word_is_recorded_as_a_declaring_occurrence() {
+        // Navigation's half: the `$ns` word is where `::app` is created, so
+        // it is the answer a `namespace children ::app` elsewhere jumps to.
+        let src = "set ns ::app\nnamespace eval $ns { proc go {} { return 1 } }\n";
+        let r = Analyser::new().analyse(src, "tcl9.0").clone();
+        let decls: Vec<&str> = r
+            .namespace_refs
+            .iter()
+            .filter(|n| n.declares && n.qualified_name == "::app")
+            .map(|n| &src[n.span.start() as usize..n.span.end() as usize])
+            .collect();
+        assert_eq!(decls, ["$ns"], "{:?}", r.namespace_refs);
+    }
+
+    #[test]
+    fn fp_a_branch_conditional_binding_keeps_the_synthetic_domain() {
+        // FP guard — the dominance rule.  Which namespace this creates is a
+        // run-time question, so claiming either would be a wrong answer.
+        let src = "set ns ::a\nif {$c} { set ns ::b }\nnamespace eval $ns {\n    proc go {} { return 1 }\n}\n";
+        assert!(
+            proc_names(src).iter().all(|n| n.contains("@dynns@")),
+            "{:?}",
+            proc_names(src),
+        );
+    }
+
+    #[test]
+    fn tn_a_parameter_target_keeps_the_synthetic_domain() {
+        // TN — the irc.tcl per-connection idiom the synthetic domain exists
+        // for: nothing constant reaches `$n`, so each occurrence stays its
+        // own scope.
+        let src = "proc mk {n} {\n    namespace eval $n {\n        proc go {} { return 1 }\n    }\n}\n";
+        let names = proc_names(src);
+        assert!(
+            names.iter().any(|n| n.contains("@dynns@")),
+            "{names:?}",
+        );
+    }
+
+    #[test]
+    fn tn_a_literal_target_is_unchanged() {
+        let src = "namespace eval ::app {\n    proc go {} { return 1 }\n}\n";
+        assert_eq!(proc_names(src), ["::app::go"]);
+        assert_eq!(scope_names(src), ["::app"]);
+    }
+}

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -5584,7 +5584,7 @@ mod const_dominated_namespace_eval {
         let src =
             "proc mk {n} {\n    namespace eval $n {\n        proc go {} { return 1 }\n    }\n}\n";
         let names = proc_names(src);
-        assert!(names.iter().any(|n| n.contains("@dynns@")), "{names:?}",);
+        assert!(names.iter().any(|n| n.contains("@dynns@")), "{names:?}");
     }
 
     #[test]

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -5581,12 +5581,10 @@ mod const_dominated_namespace_eval {
         // TN — the irc.tcl per-connection idiom the synthetic domain exists
         // for: nothing constant reaches `$n`, so each occurrence stays its
         // own scope.
-        let src = "proc mk {n} {\n    namespace eval $n {\n        proc go {} { return 1 }\n    }\n}\n";
+        let src =
+            "proc mk {n} {\n    namespace eval $n {\n        proc go {} { return 1 }\n    }\n}\n";
         let names = proc_names(src);
-        assert!(
-            names.iter().any(|n| n.contains("@dynns@")),
-            "{names:?}",
-        );
+        assert!(names.iter().any(|n| n.contains("@dynns@")), "{names:?}",);
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -243,6 +243,14 @@ pub fn definition(
     {
         return vec![span_to_range(source, &line_index, *span)];
     }
+    // An **already-resolved indirect head** the analyser settled — a
+    // `${ns}::setdef` whose `$ns` is a constant, a constant `$cmd` dispatch —
+    // is asked before every name-based path below: the span does not carry
+    // the written command name, so the bareword lookup can only ever answer
+    // with a coincidentally same-named decoy (issue #1133).
+    if let Some(span) = resolved_indirect_head_target(analysis, cursor_offset) {
+        return vec![span_to_range(source, &line_index, span)];
+    }
     // Otherwise it is a CALL — resolve namespace-aware, following C Tcl's
     // command resolution (`Tcl_FindCommand`, `tclNamesp.c`): the caller's
     // namespace first, then the global namespace; an absolute `::`-prefixed
@@ -284,14 +292,20 @@ pub fn definition(
     if let Some(span) = itcl_class_proc_declaration(analysis, &namespace, &word) {
         return vec![span_to_range(source, &line_index, span)];
     }
-    if let Some(proc_def) = resolve_called_proc(
-        analysis,
-        source,
-        &namespace,
-        &word,
-        cursor_offset,
-        Some(tcl_registry::registry_for_dialect(&analysis.dialect)),
-    ) {
+    // …and only when the cursor's word really is the enclosing command's
+    // head. Without this the pure text scan let an ordinary *argument*
+    // resolve as a command name (issue #1137 idx 50) — see
+    // [`offset_is_command_head`] for the gate and its one documented limit.
+    if offset_is_command_head(analysis, cursor_offset)
+        && let Some(proc_def) = resolve_called_proc(
+            analysis,
+            source,
+            &namespace,
+            &word,
+            cursor_offset,
+            Some(tcl_registry::registry_for_dialect(&analysis.dialect)),
+        )
+    {
         // A proc redefined later in the document is two definitions sharing
         // one name; the call reaches whichever was in effect where it is
         // written, not unconditionally the last (issue #923 idx 45).
@@ -454,8 +468,18 @@ fn position_definition(
     if let Some(cell) =
         crate::namespace_symbol::namespace_cell_at_offset(source, analysis, cursor_off)
     {
+        let mut spans = crate::namespace_symbol::namespace_declaration_spans(analysis, &cell);
+        if spans.is_empty() {
+            // Nothing declares it outright, but a deeper block may create it
+            // as a parent (`namespace eval ::p::q::r {}` really creates
+            // `::p::q`).  The answer is that word's covering prefix — the
+            // sub-range spelling exactly this namespace — never the whole
+            // word, which names a different one (issue #1113 item 1).
+            spans =
+                crate::namespace_symbol::namespace_implicit_parent_spans(source, analysis, &cell);
+        }
         return Some(
-            crate::namespace_symbol::namespace_declaration_spans(analysis, &cell)
+            spans
                 .into_iter()
                 .map(|span| span_to_range(source, line_index, span))
                 .collect(),
@@ -1496,6 +1520,145 @@ pub(crate) fn ensemble_subcommand_target<'a>(
         .find_map(|cand| analysis.ensemble_subcommand_targets.get(&cand))
         .and_then(|subs| subs.get(sub))
         .map(String::as_str)
+}
+
+/// The proc whose **own declaration name token** covers `cursor_off`.
+///
+/// The `greet` of `proc greet {…} {…}` is an *argument* of `proc`, never a
+/// command head, so a provider gated on head position
+/// ([`offset_is_command_head`]) must answer it here instead. Declaration
+/// sites are consulted after `all_procs` so a declaration a later same-named
+/// `proc` displaced still resolves — to whichever definition currently wins
+/// the name, the same rule `resolve_proc_target_at` applies (issue #923
+/// idx 31 / idx 45).
+#[must_use]
+pub(crate) fn proc_declaration_at(
+    analysis: &AnalysisResult,
+    cursor_off: u32,
+) -> Option<&tcl_compiler::analyser::ProcDef> {
+    let covers = |span: tcl_lexer::Span| span.start() <= cursor_off && cursor_off < span.end();
+    if let Some(proc_def) = analysis.all_procs.values().find(|p| covers(p.name_span)) {
+        return Some(proc_def);
+    }
+    let (qualified, _) = analysis
+        .proc_declaration_sites
+        .iter()
+        .find(|(_, span)| covers(*span))?;
+    analysis.all_procs.get(qualified)
+}
+
+/// The command invocation the analyser recorded whose **head token** covers
+/// `cursor_off`, if any.
+///
+/// The one place definition / hover ask "is this position a command head at
+/// all, and what did the resolution machinery decide it names?".  Recorded
+/// invocations are the analyser's own answer: an entry exists exactly because
+/// the analyser walked that word *as a command name*, in a region it proved
+/// was live script — so it is a far stronger statement than the pure text
+/// word-boundary scan ([`crate::hover::find_word_span_at_position`]) the
+/// bareword fallbacks otherwise run on.
+#[must_use]
+pub(crate) fn invocation_head_at(
+    analysis: &AnalysisResult,
+    cursor_off: u32,
+) -> Option<&tcl_compiler::signature_scan::types::SignatureCommandInvocation> {
+    analysis
+        .command_invocations
+        .iter()
+        .filter(|inv| inv.range.start() <= cursor_off && cursor_off < inv.range.end())
+        .min_by_key(|inv| inv.range.end() - inv.range.start())
+}
+
+/// Whether the word at `cursor_off` occupies its enclosing command's **head**
+/// position — i.e. whether resolving it as a command name can be right at all.
+///
+/// Issue #1137 idx 50: `definition()` / `hover()` used to hand whatever word
+/// the text scan returned straight to [`resolve_called_proc`], so an ordinary
+/// *argument* that happened to share a proc's name resolved onto that proc —
+/// a wrong answer, not an abstention (`return [$types(callback:$tag) jsondump
+/// $huddle_object]` resolved the ensemble subcommand `jsondump` onto the very
+/// proc containing the call, and the reduced control `anotherproc dump`
+/// reproduces it with no indirection at all).
+///
+/// The gate is the analyser's recorded invocation set, not a second text
+/// scan, so it agrees with find-references / rename / call-hierarchy by
+/// construction — those already key off the same records.
+///
+/// **Deliberate limit.** A word inside a *braced argument of an unregistered
+/// command* (`mycustom { helper }`) is not recorded, because nothing proves
+/// that brace holds script rather than data, so the gate reads it as "not a
+/// command head" and the provider abstains.  That is the honest answer: the
+/// call may never happen.  Registry-known script arguments (`if`, `foreach`,
+/// `switch` arms, `try`, `catch`, `eval`, `uplevel`, `namespace eval`,
+/// `apply` bodies, `oo::define` member bodies, command-prefix callbacks such
+/// as `lsort -command cb`, and `{*}`-expanded constant heads) *are* recorded
+/// and keep resolving.
+#[must_use]
+pub(crate) fn offset_is_command_head(analysis: &AnalysisResult, cursor_off: u32) -> bool {
+    invocation_head_at(analysis, cursor_off).is_some()
+}
+
+/// The declaration span an **already-resolved indirect** command head at
+/// `cursor_off` reaches, or `None` when no such head covers the cursor.
+///
+/// Issue #1133: the analyser resolves `set ns ::tc; ${ns}::setdef` to
+/// `::tc::setdef` and records it as a `command_invocations` entry with
+/// `indirect: true`, but `definition()` never consulted the entry and fell
+/// through to the bareword lookup, which answered an unrelated same-named
+/// `::other::setdef`.  The span does not carry the written command name, so
+/// there is nothing for a text scan to resolve — the recorded resolution is
+/// the only correct answer, and it must win.  The same record settles a
+/// constant `$cmd` head (`set cmd greet; $cmd`), which the text scan can
+/// likewise never resolve.
+///
+/// Abstains — rather than blocking the ordinary fallback — whenever the
+/// indirect entry is *unresolved* (`resolved_qualified_name` is `None`, or it
+/// names nothing this document declares): an unknown indirection is no reason
+/// to withhold an answer the bareword path can still give.
+fn resolved_indirect_head_target(
+    analysis: &AnalysisResult,
+    cursor_off: u32,
+) -> Option<tcl_lexer::Span> {
+    if let Some(proc_def) = resolved_indirect_head_proc(analysis, cursor_off) {
+        return Some(proc_def.name_span);
+    }
+    let resolved = resolved_indirect_head_name(analysis, cursor_off)?;
+    analysis
+        .all_classes
+        .get(resolved)
+        .map(|class_def| class_def.name_span)
+}
+
+/// The qualified name an already-resolved indirect head at `cursor_off`
+/// settled on — the shared first half of [`resolved_indirect_head_target`]
+/// and [`resolved_indirect_head_proc`].
+fn resolved_indirect_head_name(analysis: &AnalysisResult, cursor_off: u32) -> Option<&str> {
+    analysis
+        .command_invocations
+        .iter()
+        .filter(|inv| {
+            inv.indirect && inv.range.start() <= cursor_off && cursor_off < inv.range.end()
+        })
+        .min_by_key(|inv| inv.range.end() - inv.range.start())?
+        .resolved_qualified_name
+        .as_deref()
+}
+
+/// The `ProcDef` an already-resolved indirect head at `cursor_off` reaches —
+/// the hover-side twin of [`resolved_indirect_head_target`] (issue #1133), so
+/// hover and go-to-definition answer the same indirection from one record.
+#[must_use]
+pub(crate) fn resolved_indirect_head_proc(
+    analysis: &AnalysisResult,
+    cursor_off: u32,
+) -> Option<&tcl_compiler::analyser::ProcDef> {
+    let resolved = resolved_indirect_head_name(analysis, cursor_off)?;
+    let proc_def = analysis.all_procs.get(resolved)?;
+    Some(
+        analysis
+            .proc_def_in_effect_at(&proc_def.qualified_name, cursor_off)
+            .unwrap_or(proc_def),
+    )
 }
 
 /// Compute the byte offset of a 0-based LSP `(line, character)`
@@ -6128,5 +6291,144 @@ mod tests {
         assert_eq!(locs.len(), 1, "{locs:?}");
         assert_eq!(locs[0].start_line, 0, "{locs:?}");
         assert_eq!(locs[0].start_character, 15, "{locs:?}");
+    }
+
+    // Command-position gate + resolved-indirect-head preference —
+    // issues #1137 idx 50 and #1133. Both land on the same seam: the
+    // "otherwise it is a CALL" fallback, which used to hand whatever word
+    // the text scan returned straight to `resolve_called_proc`.
+
+    #[test]
+    fn fp_argument_word_sharing_a_procs_name_is_not_resolved_as_a_command() {
+        // FP guard — issue #1137 idx 50, the reduced control with zero
+        // indirection. `dump` is the *first argument* of `anotherproc`, not
+        // a command; tclsh never looks it up as one, so answering with the
+        // same-named proc is a wrong answer, not a miss. Must abstain.
+        let src = "proc anotherproc {a b} { return $a }\nproc dump {x} { return $x }\nproc caller {} {\n    return [anotherproc dump 5]\n}\n";
+        let analysis = analyse(src);
+        // Line 3: `    return [anotherproc dump 5]` — cursor on `dump`.
+        let locs = definition(src, 3, 24, &analysis);
+        assert!(
+            locs.is_empty(),
+            "an argument word must not resolve as a command: {locs:?}"
+        );
+    }
+
+    #[test]
+    fn tp_the_head_beside_that_argument_still_resolves() {
+        // TP — the very same call's real head must keep resolving, so the
+        // gate above narrows nothing it should not.
+        let src = "proc anotherproc {a b} { return $a }\nproc dump {x} { return $x }\nproc caller {} {\n    return [anotherproc dump 5]\n}\n";
+        let analysis = analyse(src);
+        // Line 3, col 12 — inside `anotherproc`.
+        let locs = definition(src, 3, 12, &analysis);
+        assert_eq!(locs.len(), 1, "{locs:?}");
+        assert_eq!(locs[0].start_line, 0, "{locs:?}");
+    }
+
+    #[test]
+    fn tn_a_command_head_in_every_registry_known_script_argument_still_resolves() {
+        // TN — the gate reads the analyser's recorded invocations, which
+        // cover every registry-declared script argument. A call written in
+        // an `if` body, a `switch` arm, a `foreach` body, and a command
+        // -prefix callback must all still resolve.
+        let src = "proc helper {} {}\nif {1} {\n    helper\n}\nswitch x {\n    a { helper }\n}\nforeach i {1} {\n    helper\n}\nlsort -command helper {1 2}\n";
+        let analysis = analyse(src);
+        for (line, col) in [(2, 4), (5, 8), (8, 4), (10, 15)] {
+            let locs = definition(src, line, col, &analysis);
+            assert_eq!(locs.len(), 1, "line {line} col {col}: {locs:?}");
+            assert_eq!(locs[0].start_line, 0, "line {line} col {col}: {locs:?}");
+        }
+    }
+
+    #[test]
+    fn tp_resolved_indirect_head_wins_over_a_same_named_decoy() {
+        // TP — issue #1133. The analyser settles `set ns ::tc;
+        // ${ns}::setdef` to `::tc::setdef` and records it as an `indirect`
+        // invocation. Before this fix `definition()` ignored the record and
+        // fell through to the bareword lookup, which answered the unrelated
+        // `::other::setdef`.
+        let src = "namespace eval ::tc { proc setdef {} { return 1 } }\nnamespace eval ::other { proc setdef {} { return 2 } }\nset ns ::tc\n${ns}::setdef\n";
+        let analysis = analyse(src);
+        // Line 3, col 7 — inside the `${ns}::setdef` head word.
+        let locs = definition(src, 3, 7, &analysis);
+        assert_eq!(locs.len(), 1, "{locs:?}");
+        assert_eq!(
+            locs[0].start_line, 0,
+            "must reach ::tc::setdef (line 0), not the ::other decoy (line 1): {locs:?}"
+        );
+    }
+
+    #[test]
+    fn tn_a_bare_dollar_cmd_head_still_answers_the_variable_it_reads() {
+        // TN / documented limit — a whole-word `$cmd` head *is* a variable
+        // read, and the position tier answers that first (it is asked long
+        // before any command resolution). The indirect-head preference
+        // therefore covers the spellings whose word is not itself a bare
+        // variable reference — `${ns}::setdef`, a dispatch-table literal —
+        // and deliberately leaves the plain `$cmd` cursor on its variable.
+        let src = "proc greet {} { return hi }\nset cmd greet\n$cmd\n";
+        let analysis = analyse(src);
+        let locs = definition(src, 2, 1, &analysis);
+        assert_eq!(locs.len(), 1, "{locs:?}");
+        assert_eq!(
+            locs[0].start_line, 1,
+            "a `$cmd` cursor answers the variable declaration: {locs:?}"
+        );
+    }
+
+    #[test]
+    fn fn_unresolved_indirect_head_does_not_block_the_bareword_fallback() {
+        // FP guard for the preference itself — an indirect head the
+        // analyser could NOT settle must not suppress an answer the
+        // ordinary path can still give. Here the neighbouring plain call
+        // still resolves.
+        let src = "proc greet {} { return hi }\nset cmd $env(WHATEVER)\n$cmd\ngreet\n";
+        let analysis = analyse(src);
+        let locs = definition(src, 3, 0, &analysis);
+        assert_eq!(locs.len(), 1, "{locs:?}");
+        assert_eq!(locs[0].start_line, 0, "{locs:?}");
+    }
+
+    #[test]
+    fn tn_a_proc_declaration_name_still_resolves_to_itself() {
+        // TN — a declaration's own name token is an *argument* of `proc`,
+        // so the head gate would refuse it; the declaration-site check runs
+        // first and must keep answering.
+        let src = "proc greet {name} { puts $name }\n";
+        let analysis = analyse(src);
+        let locs = definition(src, 0, 6, &analysis);
+        assert_eq!(locs.len(), 1, "{locs:?}");
+        assert_eq!(locs[0].start_line, 0, "{locs:?}");
+    }
+
+    #[test]
+    fn tp_definition_on_an_implicit_parent_namespace_answers_the_covering_prefix() {
+        // Issue #1113 item 1 — `namespace eval ::p::q::r {}` really creates
+        // `::p::q` (tclsh 8.6.16 / 9.0.4: `namespace exists ::p::q` is 1),
+        // but the name is written nowhere on its own.  The answer is the
+        // prefix of the deeper word that spells exactly it.
+        let src = "namespace eval ::p::q::r {}\nnamespace children ::p::q\n";
+        let analysis = analyse(src);
+        // Line 1, col 20 — inside the `::p::q` reference.
+        let locs = definition(src, 1, 20, &analysis);
+        assert_eq!(locs.len(), 1, "{locs:?}");
+        assert_eq!(locs[0].start_line, 0, "{locs:?}");
+        assert_eq!(locs[0].start_character, 15, "{locs:?}");
+        assert_eq!(
+            locs[0].end_character, 21,
+            "the answer must stop at `::p::q`, not cover `::p::q::r`: {locs:?}",
+        );
+    }
+
+    #[test]
+    fn tn_a_declared_namespace_still_answers_its_own_block() {
+        // TN — the implicit fallback only runs when nothing declares the
+        // namespace outright.
+        let src = "namespace eval ::p::q {}\nnamespace eval ::p::q::r {}\nnamespace children ::p::q\n";
+        let analysis = analyse(src);
+        let locs = definition(src, 2, 20, &analysis);
+        assert_eq!(locs.len(), 1, "{locs:?}");
+        assert_eq!(locs[0].start_line, 0, "{locs:?}");
     }
 }

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -6425,7 +6425,8 @@ mod tests {
     fn tn_a_declared_namespace_still_answers_its_own_block() {
         // TN — the implicit fallback only runs when nothing declares the
         // namespace outright.
-        let src = "namespace eval ::p::q {}\nnamespace eval ::p::q::r {}\nnamespace children ::p::q\n";
+        let src =
+            "namespace eval ::p::q {}\nnamespace eval ::p::q::r {}\nnamespace children ::p::q\n";
         let analysis = analyse(src);
         let locs = definition(src, 2, 20, &analysis);
         assert_eq!(locs.len(), 1, "{locs:?}");

--- a/rust/tcl-lsp-core/src/document_links.rs
+++ b/rust/tcl-lsp-core/src/document_links.rs
@@ -333,7 +333,7 @@ fn substitute_constants(
         let (name, next) = if bytes.get(i + 1) == Some(&b'{') {
             match text[i + 2..].find('}') {
                 Some(rel) => (&text[i + 2..i + 2 + rel], i + 2 + rel + 1),
-                None => (&text[i + 1..i + 1], i + 1),
+                None => ("", i + 1),
             }
         } else {
             let mut j = i + 1;

--- a/rust/tcl-lsp-core/src/document_links.rs
+++ b/rust/tcl-lsp-core/src/document_links.rs
@@ -28,9 +28,16 @@
 //! * `package require <pkg>` resolution — needs a package
 //!   index (Tcl's `auto_path` / pkgIndex.tcl scan) — is not
 //!   done.
-//! * Variable-interpolated paths (`source [file join $dir
-//!   init.tcl]`) — require resolving the variable's value —
-//!   are not done.
+//! * Computed paths are resolved through the **source graph's own**
+//!   path evaluator
+//!   ([`tcl_compiler::auto_path_eval::evaluate_auto_path_expr`]) — the
+//!   `[file dirname [info script]]` / `[file join …]` idioms — plus a
+//!   single-`set` copy propagation for the `source [file join $dir …]`
+//!   shape.  Anything outside that subset produces **no link at all**:
+//!   a `source` argument whose reconstructed text still carries `$` or
+//!   `[` is never treated as a literal path (issue #1140 idx 41 — doing
+//!   so percent-encoded the raw Tcl text into a syntactically valid but
+//!   semantically bogus `file://` URI).
 //! * Workspace-folder enumeration that lets a `source` link
 //!   resolve across multiple roots is not done; the single
 //!   `workspace_root` parameter is sufficient for the
@@ -68,6 +75,27 @@ pub struct DocumentLink {
     pub tooltip: Option<String>,
 }
 
+/// Everything a link needs to turn a `source` argument into a filesystem
+/// path: where relative paths anchor, what `~` expands to, and what the
+/// document's own `[info script]` would answer.
+///
+/// A struct rather than three more positional parameters so adding the next
+/// contextual fact doesn't change every call site (and doesn't trip
+/// `clippy::too_many_arguments`).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LinkContext<'a> {
+    /// Directory relative paths resolve against — typically the document's
+    /// own enclosing directory.  `None` leaves relative paths unresolvable,
+    /// so only absolute ones produce links.
+    pub workspace_root: Option<&'a str>,
+    /// `$HOME`, for `~/…` expansion.  `None` leaves `~` paths unresolved.
+    pub home: Option<&'a str>,
+    /// The document's own filesystem path — what `[info script]` answers
+    /// while it is being sourced.  `None` makes every `[info script]`-based
+    /// computed path abstain rather than guess.
+    pub script_path: Option<&'a str>,
+}
+
 /// Compute document links for a document.
 ///
 /// `workspace_root`, when `Some`, is the directory used to
@@ -99,8 +127,37 @@ pub fn document_links_with_home(
     workspace_root: Option<&str>,
     home: Option<&str>,
 ) -> Vec<DocumentLink> {
+    document_links_in_context(
+        source,
+        dialect,
+        &LinkContext {
+            workspace_root,
+            home,
+            script_path: None,
+        },
+    )
+}
+
+/// The full-context entry point — the one the server calls, since only it
+/// knows the document's own filesystem path (needed to evaluate the
+/// `[file dirname [info script]]` idiom).
+#[must_use]
+pub fn document_links_in_context(
+    source: &str,
+    dialect: &str,
+    ctx: &LinkContext<'_>,
+) -> Vec<DocumentLink> {
+    let LinkContext {
+        workspace_root,
+        home,
+        script_path,
+    } = *ctx;
     let line_index = LineIndex::new(source);
     let mut links = Vec::new();
+    // Constant single-assignment `set` map for the `set dir [file dirname
+    // [info script]] … source [file join $dir x.tcl]` idiom (issue #1140
+    // idx 41), built once per request.
+    let constants = constant_path_vars(source, dialect, script_path);
 
     for seg in segment_commands_with_offset_and_config(
         source,
@@ -170,18 +227,13 @@ pub fn document_links_with_home(
         // to the literal-path resolver below so tilde
         // expansion / `workspace_root` anchoring stays
         // consistent.
-        let path_owned = if let Some(joined) = literal_file_join(path.as_str()) {
-            joined
-        } else {
-            // Skip non-literal paths (variable substitution /
-            // command substitution / multi-token).  The
-            // `single_token_word[idx]` is `false` for those.
-            if let Some(&single) = seg.single_token_word.get(idx)
-                && !single
-            {
-                continue;
-            }
-            path.clone()
+        let Some(path_owned) = resolve_source_argument(
+            path.as_str(),
+            seg.single_token_word.get(idx).copied(),
+            script_path,
+            &constants,
+        ) else {
+            continue;
         };
         let Some(target) = resolve_path(&path_owned, workspace_root, home) else {
             continue;
@@ -206,6 +258,144 @@ pub fn document_links_with_home(
     }
 
     links
+}
+
+/// Whether `text` still carries an unevaluated substitution — a `$`
+/// variable reference or a `[` command substitution.
+///
+/// The abstention test at the heart of issue #1140 idx 41: such a word is
+/// **not** a path, however syntactically valid a URI percent-encoding it
+/// would produce.  `single_token_word` cannot answer this — it only
+/// distinguishes "one token" from "several concatenated tokens" within a
+/// word, and a whole-word `[file join …]` or a bare `$var` is exactly one
+/// token, so the old fall-through treated both as literals.
+fn carries_substitution(text: &str) -> bool {
+    text.contains('$') || text.contains('[')
+}
+
+/// The path a `source` argument denotes, or `None` when it cannot be
+/// resolved and the provider must emit no link.
+///
+/// Three tiers, strongest first:
+///
+/// 1. A plain literal — no `$`, no `[`, and a single word.
+/// 2. The literal `[file join a b c]` shorthand ([`literal_file_join`]).
+/// 3. The **source graph's own** path evaluator
+///    ([`tcl_compiler::auto_path_eval::evaluate_auto_path_expr`], the same
+///    one `resolve_source_edge` uses for the M9 namespace-rehoming source
+///    graph), after substituting any single-assignment `set` constants the
+///    document establishes — which is what carries the corpus idiom
+///    `set dir [file dirname [info script]]; source [file join $dir x.tcl]`.
+///
+/// Anything else abstains.  A multi-token word (`$dir/x.tcl` spliced from
+/// several tokens) abstains too, for the same reason.
+fn resolve_source_argument(
+    path: &str,
+    single_token_word: Option<bool>,
+    script_path: Option<&str>,
+    constants: &std::collections::HashMap<String, String>,
+) -> Option<String> {
+    if !carries_substitution(path) {
+        // Genuinely literal — but still only when the word is one token, so
+        // a spliced multi-token word never masquerades as a path.
+        if single_token_word == Some(false) {
+            return None;
+        }
+        return Some(path.to_owned());
+    }
+    if let Some(joined) = literal_file_join(path) {
+        return Some(joined);
+    }
+    let substituted = substitute_constants(path, constants);
+    tcl_compiler::auto_path_eval::evaluate_auto_path_expr(&substituted, script_path)
+}
+
+/// Replace every `$name` / `${name}` occurrence in `text` whose name is in
+/// `constants`, leaving unknown ones in place (so the evaluator abstains on
+/// them, as it must).
+fn substitute_constants(text: &str, constants: &std::collections::HashMap<String, String>) -> String {
+    if constants.is_empty() || !text.contains('$') {
+        return text.to_owned();
+    }
+    let bytes = text.as_bytes();
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if bytes[i] != b'$' {
+            let ch_len = text[i..].chars().next().map_or(1, char::len_utf8);
+            out.push_str(&text[i..i + ch_len]);
+            i += ch_len;
+            continue;
+        }
+        let (name, next) = if bytes.get(i + 1) == Some(&b'{') {
+            match text[i + 2..].find('}') {
+                Some(rel) => (&text[i + 2..i + 2 + rel], i + 2 + rel + 1),
+                None => (&text[i + 1..i + 1], i + 1),
+            }
+        } else {
+            let mut j = i + 1;
+            while j < bytes.len() && (bytes[j].is_ascii_alphanumeric() || bytes[j] == b'_') {
+                j += 1;
+            }
+            (&text[i + 1..j], j)
+        };
+        match constants.get(name) {
+            Some(value) if !name.is_empty() => {
+                out.push_str(value);
+                i = next;
+            }
+            _ => {
+                out.push('$');
+                i += 1;
+            }
+        }
+    }
+    out
+}
+
+/// Path-valued variables the document assigns **exactly once** at its top
+/// level, mapped to their evaluated values.
+///
+/// Deliberately narrow: a name written by more than one `set` is dropped
+/// entirely rather than guessed at (last-write-wins would be wrong for a
+/// `source` between the two), and only values the shared path evaluator can
+/// fold are kept, so nothing here can invent a target.  `set` is located by
+/// the segmenter's own words, and its value word must itself be resolvable —
+/// a literal or a `[file …]` expression.
+fn constant_path_vars(
+    source: &str,
+    dialect: &str,
+    script_path: Option<&str>,
+) -> std::collections::HashMap<String, String> {
+    use std::collections::HashMap;
+    let mut seen: HashMap<String, Option<String>> = HashMap::new();
+    for seg in segment_commands_with_offset_and_config(
+        source,
+        0,
+        tcl_lexer::LexerConfig::for_dialect(dialect),
+    ) {
+        if seg.texts.len() != 3 || seg.texts[0] != "set" {
+            continue;
+        }
+        let name = seg.texts[1].clone();
+        if name.contains('$') || name.contains('[') || name.contains("::") {
+            continue;
+        }
+        let raw = seg.texts[2].as_str();
+        let value = if carries_substitution(raw) {
+            tcl_compiler::auto_path_eval::evaluate_auto_path_expr(raw, script_path)
+        } else {
+            Some(raw.to_owned())
+        };
+        // A second assignment to the same name poisons it: which value a
+        // later `source` sees is a flow question this provider does not ask.
+        seen.entry(name)
+            .and_modify(|slot| *slot = None)
+            .or_insert(value);
+    }
+    seen.into_iter()
+        .filter_map(|(name, value)| value.map(|v| (name, v)))
+        .collect()
 }
 
 /// Try to interpret `arg` as a literal `[file join …]`

--- a/rust/tcl-lsp-core/src/document_links.rs
+++ b/rust/tcl-lsp-core/src/document_links.rs
@@ -313,7 +313,10 @@ fn resolve_source_argument(
 /// Replace every `$name` / `${name}` occurrence in `text` whose name is in
 /// `constants`, leaving unknown ones in place (so the evaluator abstains on
 /// them, as it must).
-fn substitute_constants(text: &str, constants: &std::collections::HashMap<String, String>) -> String {
+fn substitute_constants(
+    text: &str,
+    constants: &std::collections::HashMap<String, String>,
+) -> String {
     if constants.is_empty() || !text.contains('$') {
         return text.to_owned();
     }

--- a/rust/tcl-lsp-core/src/document_symbols.rs
+++ b/rust/tcl-lsp-core/src/document_symbols.rs
@@ -195,7 +195,101 @@ pub fn document_symbols_from_analysis(
         return Vec::new();
     }
     let line_index = LineIndex::new(source);
-    scope_symbols(source, &analysis.global_scope, &line_index, 0)
+    let mut rehomed: Vec<(String, DocumentSymbol)> = Vec::new();
+    let mut ctx = SymbolCtx {
+        rehomed: &mut rehomed,
+    };
+    let mut symbols = scope_symbols(
+        source,
+        &analysis.global_scope,
+        &line_index,
+        ScopePos {
+            depth: 0,
+            namespace: "::",
+        },
+        &mut ctx,
+    );
+    // A proc written with a qualified name outside any `namespace eval` block
+    // (`proc pix::svg::parse {…} {…}` at file top level) really lands in the
+    // namespace its own name spells — tclsh, and this LSP's own hover /
+    // definition / references, all agree on `::pix::svg::parse`. The outline
+    // used to place it lexically, contradicting the very same response's
+    // `Namespace pix > svg` tree (issue #1140 idx 67). Home each one under
+    // the namespace node its qualified name names; a namespace this document
+    // never opens has no node, so the symbol stays where it was written.
+    for (home, symbol) in rehomed {
+        if let Some(unplaced) = place_under_namespace(&mut symbols, "::", &home, symbol) {
+            symbols.push(unplaced);
+        }
+    }
+    symbols
+}
+
+/// Enclosing namespace of a fully-qualified name (`"::ns::foo"` → `"::ns"`,
+/// `"::foo"` → `"::"`) — the same pure-string rule
+/// `ItemTree::from_analysis` uses, so the outline and the item tree agree
+/// about where a definition lives.
+fn enclosing_namespace(qualified: &str) -> String {
+    match qualified.rsplit_once("::") {
+        Some((prefix, _)) if !prefix.is_empty() => prefix.to_string(),
+        _ => "::".to_string(),
+    }
+}
+
+/// Join a namespace prefix with a child namespace name as written, honouring
+/// the absolute-reset rule (`namespace eval ::a { namespace eval ::b {…} }`
+/// creates `::b`, not `::a::b`).
+fn join_namespace(prefix: &str, name: &str) -> String {
+    if name.starts_with("::") {
+        name.to_string()
+    } else if prefix == "::" {
+        format!("::{name}")
+    } else {
+        format!("{prefix}::{name}")
+    }
+}
+
+/// Insert `symbol` under the namespace node named `home`, descending
+/// `symbols` (whose own qualified prefix is `prefix`).  Returns `Some(symbol)`
+/// unchanged when no such namespace node exists.
+fn place_under_namespace(
+    symbols: &mut Vec<DocumentSymbol>,
+    prefix: &str,
+    home: &str,
+    symbol: DocumentSymbol,
+) -> Option<DocumentSymbol> {
+    let mut carried = symbol;
+    for node in symbols.iter_mut() {
+        if node.kind != SymbolKind::Namespace {
+            continue;
+        }
+        let qualified = join_namespace(prefix, &node.name);
+        if qualified == home {
+            node.children.push(carried);
+            return None;
+        }
+        match place_under_namespace(&mut node.children, &qualified, home, carried) {
+            None => return None,
+            Some(back) => carried = back,
+        }
+    }
+    Some(carried)
+}
+
+/// Per-walk state [`scope_symbols`] threads through the scope tree.
+struct SymbolCtx<'a> {
+    /// Procs whose semantic home namespace differs from the scope they were
+    /// lexically written in, paired with that home (issue #1140 idx 67).
+    rehomed: &'a mut Vec<(String, DocumentSymbol)>,
+}
+
+/// Where in the scope tree [`scope_symbols`] currently is.
+#[derive(Clone, Copy)]
+struct ScopePos<'a> {
+    /// Recursion depth, bounded by `MAX_SCOPE_WALK_DEPTH`.
+    depth: u32,
+    /// The `::`-rooted qualified namespace this scope's definitions home to.
+    namespace: &'a str,
 }
 
 fn span_to_range(source: &str, line_index: &LineIndex, span: Span) -> LineRange {
@@ -382,8 +476,10 @@ fn scope_symbols(
     source: &str,
     scope: &Scope,
     line_index: &LineIndex,
-    depth: u32,
+    pos: ScopePos<'_>,
+    ctx: &mut SymbolCtx<'_>,
 ) -> Vec<DocumentSymbol> {
+    let ScopePos { depth, namespace } = pos;
     if crate::MAX_SCOPE_WALK_DEPTH.exceeded(depth) {
         return Vec::new();
     }
@@ -398,7 +494,17 @@ fn scope_symbols(
     let mut proc_pairs: Vec<(&String, &ProcDef)> = scope.procs.iter().collect();
     proc_pairs.sort_by_key(|(_, pd)| pd.name_span.start());
     for (_, proc_def) in proc_pairs {
-        symbols.push(proc_symbol(source, proc_def, scope, line_index, depth));
+        let symbol = proc_symbol(source, proc_def, scope, line_index, depth, ctx);
+        // Only a namespace-level definition can be re-homed: a proc nested
+        // inside another proc's body belongs under that proc in the outline
+        // whatever its qualified name spells, because that is where the user
+        // wrote — and reads — it.
+        let home = enclosing_namespace(&proc_def.qualified_name);
+        if matches!(scope.kind, ScopeKind::Global | ScopeKind::Namespace) && home != namespace {
+            ctx.rehomed.push((home, symbol));
+        } else {
+            symbols.push(symbol);
+        }
     }
 
     if matches!(scope.kind, ScopeKind::Global | ScopeKind::Namespace) {
@@ -438,7 +544,17 @@ fn scope_symbols(
             && let Some(span) = child.body_span
         {
             let body_range = span_to_range(source, line_index, span);
-            let child_syms = scope_symbols(source, child, line_index, depth + 1);
+            let child_ns = join_namespace(namespace, &child.name);
+            let child_syms = scope_symbols(
+                source,
+                child,
+                line_index,
+                ScopePos {
+                    depth: depth + 1,
+                    namespace: &child_ns,
+                },
+                ctx,
+            );
             // `selectionRange` is "the range that should be selected and
             // revealed when this symbol is picked" — the *name*, exactly as
             // `proc_symbol` does.  A namespace used to answer its whole body
@@ -594,6 +710,7 @@ fn proc_symbol(
     scope: &Scope,
     line_index: &LineIndex,
     depth: u32,
+    ctx: &mut SymbolCtx<'_>,
 ) -> DocumentSymbol {
     // Find the proc's body scope to recurse into for nested definitions by its
     // body span, which is identical between the `ProcDef` and its `Scope`.
@@ -601,13 +718,25 @@ fn proc_symbol(
     // proc, because the proc scope is keyed by the qualified name
     // (`ns::outer`) while `proc_def.name` is the bare tail (`outer`) — issue
     // 185.
+    let body_namespace = enclosing_namespace(&proc_def.qualified_name);
     let child_symbols: Vec<DocumentSymbol> = scope
         .children
         .iter()
         .find(|child| {
             matches!(child.kind, ScopeKind::Proc) && child.body_span == Some(proc_def.body_span)
         })
-        .map(|child| scope_symbols(source, child, line_index, depth + 1))
+        .map(|child| {
+            scope_symbols(
+                source,
+                child,
+                line_index,
+                ScopePos {
+                    depth: depth + 1,
+                    namespace: &body_namespace,
+                },
+                ctx,
+            )
+        })
         .unwrap_or_default();
 
     let body_range = span_to_range(source, line_index, proc_def.body_span);
@@ -1972,4 +2101,79 @@ mod tests {
             }
         }
     }
+
+    // Namespace-resolved proc homing (issue #1140 idx 67).
+
+    #[test]
+    fn tp_a_qualified_proc_written_outside_its_namespace_block_nests_under_it() {
+        // TP — issue #1140 idx 67, the nico-robert/pix shape reduced: the
+        // `namespace eval` blocks have already closed when the qualified
+        // `proc` is written, yet tclsh puts it at `::pix::svg::parse` and
+        // this LSP's own hover / definition / references all say so. The
+        // outline used to contradict them by placing it at top level.
+        let src = concat!(
+            "namespace eval ::pix {\n",
+            "    namespace eval svg {\n",
+            "    }\n",
+            "}\n",
+            "proc pix::svg::parse {a} {\n",
+            "    return $a\n",
+            "}\n",
+        );
+        let symbols = document_symbols(src, "tcl8.6");
+        assert_eq!(names(&symbols), vec!["::pix"], "{symbols:#?}");
+        let svg = find(&symbols, "svg").expect("svg namespace node");
+        assert_eq!(
+            names(&svg.children),
+            vec!["parse"],
+            "the proc must nest under `pix > svg`: {symbols:#?}",
+        );
+    }
+
+    #[test]
+    fn tn_a_proc_written_inside_its_namespace_block_still_nests_lexically() {
+        // TN — the ordinary case must be untouched: lexical and semantic
+        // home agree, so nothing moves.
+        let src = "namespace eval ::a {\n    proc caller {} {\n        return 1\n    }\n}\n";
+        let symbols = document_symbols(src, "tcl8.6");
+        let a = find(&symbols, "::a").expect("namespace node");
+        assert_eq!(names(&a.children), vec!["caller"], "{symbols:#?}");
+    }
+
+    #[test]
+    fn tn_an_unqualified_top_level_proc_stays_at_top_level() {
+        // TN — a plain `proc greet` homes to `::`, which is the scope it was
+        // written in, so it is not re-homed anywhere.
+        let src = "proc greet {} { return 1 }\n";
+        let symbols = document_symbols(src, "tcl8.6");
+        assert_eq!(names(&symbols), vec!["greet"], "{symbols:#?}");
+    }
+
+    #[test]
+    fn fp_a_qualified_proc_whose_namespace_is_never_opened_stays_where_written() {
+        // FP guard — re-homing must never invent a namespace node. With no
+        // `namespace eval ::nowhere` in the document there is nothing to
+        // nest under, so the symbol keeps its written position.
+        let src = "proc nowhere::helper {} { return 1 }\n";
+        let symbols = document_symbols(src, "tcl8.6");
+        assert_eq!(names(&symbols), vec!["helper"], "{symbols:#?}");
+    }
+
+    #[test]
+    fn fp_a_proc_nested_in_another_procs_body_is_never_re_homed() {
+        // FP guard — a `proc` written inside another proc's body belongs
+        // under that proc in the outline, whatever its qualified name
+        // spells: that is where the reader finds it.
+        let src = concat!(
+            "namespace eval ::ns {\n}\n",
+            "proc outer {} {\n",
+            "    proc ns::inner {} { return 1 }\n",
+            "}\n",
+        );
+        let symbols = document_symbols(src, "tcl8.6");
+        let outer = find(&symbols, "outer").expect("outer proc node");
+        assert_eq!(names(&outer.children), vec!["inner"], "{symbols:#?}");
+    }
+
+
 }

--- a/rust/tcl-lsp-core/src/document_symbols.rs
+++ b/rust/tcl-lsp-core/src/document_symbols.rs
@@ -2171,6 +2171,4 @@ mod tests {
         let outer = find(&symbols, "outer").expect("outer proc node");
         assert_eq!(names(&outer.children), vec!["inner"], "{symbols:#?}");
     }
-
-
 }

--- a/rust/tcl-lsp-core/src/document_symbols.rs
+++ b/rust/tcl-lsp-core/src/document_symbols.rs
@@ -253,7 +253,7 @@ fn join_namespace(prefix: &str, name: &str) -> String {
 /// `symbols` (whose own qualified prefix is `prefix`).  Returns `Some(symbol)`
 /// unchanged when no such namespace node exists.
 fn place_under_namespace(
-    symbols: &mut Vec<DocumentSymbol>,
+    symbols: &mut [DocumentSymbol],
     prefix: &str,
     home: &str,
     symbol: DocumentSymbol,
@@ -268,10 +268,7 @@ fn place_under_namespace(
             node.children.push(carried);
             return None;
         }
-        match place_under_namespace(&mut node.children, &qualified, home, carried) {
-            None => return None,
-            Some(back) => carried = back,
-        }
+        carried = place_under_namespace(&mut node.children, &qualified, home, carried)?;
     }
     Some(carried)
 }

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -317,6 +317,15 @@ fn math_function_hover(
 /// namespace first (consulting `analysis.namespace_overrides` ahead of the
 /// ordinary lexical walk, issue #923 idx 116), then the global namespace.
 /// Extracted from [`hover_with_profile`] to keep it within the line budget.
+/// Gated on the cursor's word actually occupying the enclosing command's
+/// head position (issue #1137 idx 50): hover shared `definition()`'s
+/// text-scan fallback, so an ordinary *argument* that happened to share a
+/// proc's name rendered that proc's documentation. See
+/// [`crate::definition::offset_is_command_head`].
+///
+/// An already-resolved **indirect** head (a constant `${ns}::cmd` / `$cmd`,
+/// issue #1133) is answered from the analyser's own resolution, since the
+/// span carries no written command name for the bareword lookup to use.
 fn proc_hover_at(
     analysis: &AnalysisResult,
     source: &str,
@@ -324,6 +333,20 @@ fn proc_hover_at(
     word: &str,
     registry: Option<&CommandRegistry>,
 ) -> Option<Hover> {
+    // A proc's own declaration name (`proc greet …`) is an argument of
+    // `proc`, so the head gate below would refuse it; it is answered here,
+    // mirroring how `definition()` consults `proc_declaration_sites` before
+    // its own call resolution.
+    if let Some(proc_def) = crate::definition::proc_declaration_at(analysis, cursor_offset) {
+        return Some(Hover::markdown(proc_hover_text(proc_def)));
+    }
+    if let Some(proc_def) = crate::definition::resolved_indirect_head_proc(analysis, cursor_offset)
+    {
+        return Some(Hover::markdown(proc_hover_text(proc_def)));
+    }
+    if !crate::definition::offset_is_command_head(analysis, cursor_offset) {
+        return None;
+    }
     let namespace = crate::definition::namespace_context_at(
         &analysis.global_scope,
         cursor_offset,
@@ -5201,5 +5224,47 @@ mod tests {
         // Line 1 — cursor on the `greet foo` call site (col 0).
         let call = hover(src, 1, 0, &analysis, None).expect("hover on call site");
         assert_eq!(decl.value, call.value, "decl and call site must agree");
+    }
+
+    // Hover shares `definition()`'s command-resolution seam, so it shares
+    // both of its fixes — issue #1137 idx 50 (the command-position gate)
+    // and issue #1133 (the resolved-indirect-head preference).
+
+    #[test]
+    fn fp_argument_word_sharing_a_procs_name_does_not_hover_that_proc() {
+        // FP guard — issue #1137 idx 50: `dump` is `anotherproc`'s first
+        // argument, never a command, so rendering `proc ::dump`'s signature
+        // there was a wrong answer.
+        let src = "proc anotherproc {a b} { return $a }\nproc dump {x} { return $x }\nproc caller {} {\n    return [anotherproc dump 5]\n}\n";
+        let analysis = analyse(src);
+        let h = hover(src, 3, 24, &analysis, None);
+        assert!(
+            h.is_none_or(|hv| !hv.value.contains("proc ::dump")),
+            "an argument word must not hover as a command"
+        );
+    }
+
+    #[test]
+    fn tp_the_command_head_beside_that_argument_still_hovers() {
+        // TP — the gate must not cost the real head its hover.
+        let src = "proc anotherproc {a b} { return $a }\nproc dump {x} { return $x }\nproc caller {} {\n    return [anotherproc dump 5]\n}\n";
+        let analysis = analyse(src);
+        let h = hover(src, 3, 12, &analysis, None).expect("hover on the call head");
+        assert!(h.value.contains("proc ::anotherproc"), "{}", h.value);
+    }
+
+    #[test]
+    fn tp_resolved_indirect_head_hovers_the_command_it_reaches() {
+        // TP — issue #1133, hover's half: the `${ns}::setdef` head carries
+        // no written command name, so only the analyser's own resolution
+        // can answer, and it must not lose to a same-named decoy.
+        let src = "namespace eval ::tc { proc setdef {a} { return $a } }\nnamespace eval ::other { proc setdef {b c} { return $b } }\nset ns ::tc\n${ns}::setdef\n";
+        let analysis = analyse(src);
+        let h = hover(src, 3, 7, &analysis, None).expect("hover on the indirect head");
+        assert!(
+            h.value.contains("::tc::setdef"),
+            "must describe ::tc::setdef, not the ::other decoy: {}",
+            h.value
+        );
     }
 }

--- a/rust/tcl-lsp-core/src/namespace_symbol.rs
+++ b/rust/tcl-lsp-core/src/namespace_symbol.rs
@@ -676,7 +676,10 @@ mod tests {
             "an implicit parent is not a declaration",
         );
         assert_eq!(
-            texts(src, &namespace_implicit_parent_spans(src, &analysis, "::p::q")),
+            texts(
+                src,
+                &namespace_implicit_parent_spans(src, &analysis, "::p::q")
+            ),
             vec!["::p::q"],
             "the prefix, not the whole `::p::q::r` word",
         );
@@ -690,9 +693,7 @@ mod tests {
             texts(src, &namespace_declaration_spans(&analysis, "::p::q::r")),
             vec!["::p::q::r"],
         );
-        assert!(
-            namespace_implicit_parent_spans(src, &analysis, "::p::q::r").is_empty(),
-        );
+        assert!(namespace_implicit_parent_spans(src, &analysis, "::p::q::r").is_empty(),);
     }
 
     #[test]
@@ -1110,7 +1111,8 @@ mod tests {
     fn fp_a_branch_conditional_target_declares_nothing() {
         // FP guard — which namespace the block creates is a run-time
         // question, so no declaration may be claimed for either candidate.
-        let src = "set ns ::a\nif {$c} { set ns ::b }\nnamespace eval $ns { proc go {} { return 1 } }\n";
+        let src =
+            "set ns ::a\nif {$c} { set ns ::b }\nnamespace eval $ns { proc go {} { return 1 } }\n";
         let analysis = analyse(src);
         assert!(namespace_declaration_spans(&analysis, "::a").is_empty());
         assert!(namespace_declaration_spans(&analysis, "::b").is_empty());

--- a/rust/tcl-lsp-core/src/namespace_symbol.rs
+++ b/rust/tcl-lsp-core/src/namespace_symbol.rs
@@ -70,12 +70,20 @@
 //!
 //! * A namespace created only **implicitly**, as a parent (`namespace eval
 //!   ::p::q::r {}` creates `::p` and `::p::q` too, both interpreters), has no
-//!   declaring site of its own.  Asking for `::p::q` answers nothing rather
-//!   than jumping into the middle of the `::p::q::r` word, which is not that
-//!   namespace's name.
-//! * A **computed** target (`namespace eval $ns { … }`) names no static
-//!   namespace and is never recorded, so it neither answers nor pollutes
-//!   another namespace's reference set.
+//!   declaring site of its own.  It is answered separately, by
+//!   [`namespace_implicit_parent_spans`], with the *covering prefix* of the
+//!   deepest written name — the sub-range spelling exactly that namespace,
+//!   never the whole word, which names a different one — and hover words it
+//!   as "implicitly created by" rather than "declared by" (issue #1113
+//!   item 1).  A prefix that is not written at all (inside `namespace eval
+//!   ::p`, the word `q::r` spells no `::p`) still answers nothing.
+//! * A **computed** target (`namespace eval $ns { … }`) is recorded only when
+//!   its value is constant-dominated — `set ns ::app; namespace eval $ns
+//!   { … }` creates `::app` on every run, so the `$ns` word is that
+//!   namespace's declaring site (issue #1113 item 3).  A branch-conditional
+//!   or parameter-fed target proves nothing and is recorded nowhere, so it
+//!   neither answers nor pollutes another namespace's reference set.  A
+//!   computed word in *reference* position stays unrecorded either way.
 //! * Inert text is excluded: a `namespace exists ::x` that is really comment
 //!   prose or a braced data word is not code, so it must not resolve
 //!   (issue #923 idx 24).  Here that falls out of the model rather than
@@ -199,6 +207,87 @@ pub fn namespace_declaration_spans(analysis: &AnalysisResult, cell: &str) -> Vec
         .collect()
 }
 
+/// The sites that create `cell` **implicitly**, as the parent of a deeper
+/// declared namespace — `namespace eval ::p::q::r {}` really does create
+/// `::p` and `::p::q` on both interpreters (`namespace exists ::p::q` is `1`
+/// straight after), but neither name is written as a name of its own.
+///
+/// The answer is the **covering prefix** of the deepest written name: the
+/// leading sub-range of that `namespace eval`'s name word which spells
+/// `cell`, so the span is real source text naming exactly this namespace and
+/// nothing more — never the whole word, which names a different namespace
+/// (issue #1113 item 1).
+///
+/// Empty when `cell` is declared outright (the declaration is the better
+/// answer and [`namespace_declaration_spans`] already gives it), and empty
+/// when the prefix is not written either: inside `namespace eval ::p`, the
+/// word of `namespace eval q::r` spells only `q::r`, so `::p` has no covering
+/// prefix here and the honest answer is nothing at all.
+#[must_use]
+pub fn namespace_implicit_parent_spans(
+    source: &str,
+    analysis: &AnalysisResult,
+    cell: &str,
+) -> Vec<Span> {
+    let wanted = normalise_namespace(cell);
+    if wanted.is_empty() {
+        // The global namespace is created by the interpreter, not by any
+        // block, so it has no implicit site either.
+        return Vec::new();
+    }
+    let wanted_depth = wanted.split("::").count();
+    analysis
+        .namespace_refs
+        .iter()
+        .filter(|r| r.declares)
+        .filter_map(|r| {
+            let declared = normalise_namespace(&r.qualified_name);
+            // Strict descendant only — an exact match is a real declaration.
+            declared
+                .strip_prefix(wanted)
+                .filter(|rest| rest.starts_with("::"))?;
+            covering_prefix_span(source, r.span, declared, wanted_depth)
+        })
+        .collect()
+}
+
+/// The leading sub-range of the name word at `span` that spells the first
+/// `wanted_depth` segments of `declared`.
+///
+/// The word may be written relatively (`namespace eval q::r` inside `::p`
+/// declares `::p::q::r` from two written segments), so the written text
+/// covers only the *last* N segments of the qualified name; a prefix shorter
+/// than that offset is not written here at all and yields `None`.
+fn covering_prefix_span(
+    source: &str,
+    span: Span,
+    declared: &str,
+    wanted_depth: usize,
+) -> Option<Span> {
+    let text = source.get(span.start() as usize..span.end() as usize)?;
+    let rooted = text.starts_with("::");
+    let written = text.trim_start_matches("::");
+    let written_depth = written.split("::").count();
+    let declared_depth = declared.split("::").count();
+    // How many leading segments of `declared` this word does not spell.
+    let unwritten = declared_depth.checked_sub(written_depth)?;
+    let take = wanted_depth.checked_sub(unwritten)?;
+    if take == 0 || take > written_depth {
+        return None;
+    }
+    // Byte offset of the end of the `take`-th written segment.
+    let mut end = 0usize;
+    for (i, segment) in written.split("::").take(take).enumerate() {
+        if i > 0 {
+            end += 2;
+        }
+        end += segment.len();
+    }
+    let lead = u32::try_from(usize::from(rooted) * 2).ok()?;
+    let end = u32::try_from(end).ok()?;
+    Some(Span::new(span.start(), span.start() + lead + end))
+}
+
 /// Every **non-declaring** occurrence of `cell` in this document, in source
 /// order — the reference set find-references reports when the declarations
 /// are not asked for.
@@ -245,6 +334,11 @@ pub struct NamespaceFacts {
     pub declarations: usize,
     /// Occurrences that are not declarations.
     pub references: usize,
+    /// Deeper `namespace eval` blocks that create this namespace **only as a
+    /// parent** — `namespace eval ::p::q::r {}` for `::p::q` (issue #1113
+    /// item 1).  Counted separately because it is a weaker statement than a
+    /// declaration and hover must not word the two alike.
+    pub implicit_declarations: usize,
     /// How many documents contributed — `1` for a single-document tally.
     pub documents: usize,
 }
@@ -256,6 +350,7 @@ impl NamespaceFacts {
         Self {
             declarations: self.declarations + other.declarations,
             references: self.references + other.references,
+            implicit_declarations: self.implicit_declarations + other.implicit_declarations,
             documents: self.documents + other.documents,
         }
     }
@@ -274,10 +369,25 @@ pub fn namespace_facts(analysis: &AnalysisResult, cell: &str) -> NamespaceFacts 
                 if row.declares { (d + 1, r) } else { (d, r + 1) }
             },
         );
+    // Deeper blocks that create `cell` only as a parent.  Pure name
+    // arithmetic, so the workspace tier can fold in its own rows the same
+    // way without needing any document's text.
+    let wanted = normalise_namespace(cell);
+    let implicit_declarations = analysis
+        .namespace_refs
+        .iter()
+        .filter(|r| r.declares && !wanted.is_empty())
+        .filter(|r| {
+            normalise_namespace(&r.qualified_name)
+                .strip_prefix(wanted)
+                .is_some_and(|rest| rest.starts_with("::"))
+        })
+        .count();
     NamespaceFacts {
         declarations,
         references,
-        documents: usize::from(declarations + references > 0),
+        implicit_declarations,
+        documents: usize::from(declarations + references + implicit_declarations > 0),
     }
 }
 
@@ -297,7 +407,24 @@ pub fn namespace_facts(analysis: &AnalysisResult, cell: &str) -> NamespaceFacts 
 #[must_use]
 pub fn namespace_hover_markdown(cell: &str, facts: NamespaceFacts) -> Option<String> {
     if facts.declarations == 0 {
-        return None;
+        // Nothing declares it outright — but a deeper block may still create
+        // it as a parent, which is a real answer and a differently-worded one
+        // (issue #1113 item 1).
+        if facts.implicit_declarations == 0 {
+            return None;
+        }
+        let blocks = if facts.implicit_declarations == 1 {
+            "1 deeper `namespace eval` block".to_owned()
+        } else {
+            format!(
+                "{} deeper `namespace eval` blocks",
+                facts.implicit_declarations,
+            )
+        };
+        return Some(format!(
+            "**Namespace** `{cell}`\n\nImplicitly created by {blocks}; {} other reference(s)",
+            facts.references,
+        ));
     }
     let blocks = if facts.declarations == 1 {
         "1 `namespace eval` block".to_owned()
@@ -499,34 +626,125 @@ mod tests {
         assert!(namespace_reference_spans(&analysis, "::mypkg").is_empty());
     }
 
-    // TN: a **computed** target names no static namespace, so it is recorded
-    // nowhere and cannot be mistaken for a literal one.
+    // A **computed** target is recorded only when its value is
+    // constant-dominated (issue #1113 item 3): `set ns ::mypkg` then
+    // `namespace eval $ns {}` creates `::mypkg` on every run, so the `$ns`
+    // word of the *declaring* command is that namespace's declaring site.
+    // A reference-position `$ns` (`namespace children $ns`) is still
+    // recorded nowhere — reading a variable is not writing a name, and the
+    // whole-word role scan skips dynamic words.
     #[test]
-    fn tn_computed_namespace_target_is_not_recorded() {
+    fn tp_only_the_constant_computed_declaration_is_recorded() {
         let src = "set ns ::mypkg\nnamespace eval $ns {}\nnamespace children $ns\n";
         let analysis = analyse(src);
+        assert_eq!(
+            texts(src, &namespace_declaration_spans(&analysis, "::mypkg")),
+            vec!["$ns"],
+            "{:?}",
+            analysis.namespace_refs,
+        );
         assert!(
-            analysis.namespace_refs.is_empty(),
-            "a `$ns` target names nothing statically: {:?}",
+            namespace_reference_spans(&analysis, "::mypkg").is_empty(),
+            "a computed *reference* still names nothing statically: {:?}",
             analysis.namespace_refs,
         );
     }
 
-    // TN: a namespace that exists only as an **implicit parent** has no
-    // declaring site of its own.  `namespace eval ::p::q::r {}` really does
-    // create `::p` and `::p::q` (both interpreters), but neither name is
-    // written anywhere, so definition abstains rather than jumping into the
-    // middle of another namespace's name word.
     #[test]
-    fn tn_implicit_parent_namespace_has_no_declaration_site() {
+    fn tn_a_computed_target_with_no_constant_value_is_recorded_nowhere() {
+        let src = "proc mk {ns} { namespace eval $ns {} }\n";
+        let analysis = analyse(src);
+        assert!(
+            analysis.namespace_refs.is_empty(),
+            "a parameter target names nothing statically: {:?}",
+            analysis.namespace_refs,
+        );
+    }
+
+    // A namespace that exists only as an **implicit parent** has no declaring
+    // site of its own — `namespace eval ::p::q::r {}` really does create
+    // `::p` and `::p::q` (both interpreters), but neither name is written as
+    // a name of its own.  The answer is the covering prefix of the deepest
+    // written name, never the whole word (issue #1113 item 1).
+    #[test]
+    fn tp_implicit_parent_answers_with_the_covering_prefix() {
         let src = "namespace eval ::p::q::r {}\nnamespace children ::p::q\n";
         let analysis = analyse(src);
         assert_eq!(cell_at(src, "::p::q\n").as_deref(), Some("::p::q"));
-        assert!(namespace_declaration_spans(&analysis, "::p::q").is_empty());
+        assert!(
+            namespace_declaration_spans(&analysis, "::p::q").is_empty(),
+            "an implicit parent is not a declaration",
+        );
+        assert_eq!(
+            texts(src, &namespace_implicit_parent_spans(src, &analysis, "::p::q")),
+            vec!["::p::q"],
+            "the prefix, not the whole `::p::q::r` word",
+        );
+        assert_eq!(
+            texts(src, &namespace_implicit_parent_spans(src, &analysis, "::p")),
+            vec!["::p"],
+        );
+        // The declared namespace itself keeps its exact declaration and gains
+        // no implicit site.
         assert_eq!(
             texts(src, &namespace_declaration_spans(&analysis, "::p::q::r")),
             vec!["::p::q::r"],
         );
+        assert!(
+            namespace_implicit_parent_spans(src, &analysis, "::p::q::r").is_empty(),
+        );
+    }
+
+    #[test]
+    fn tp_a_relatively_written_name_still_yields_the_written_prefix() {
+        // Only the segments actually written can be answered with: inside
+        // `::outer`, the word of `namespace eval a::b` spells `a::b`, so
+        // `::outer::a` is covered by its first segment…
+        let src = "namespace eval ::outer {\n    namespace eval a::b {}\n}\n";
+        let analysis = analyse(src);
+        assert_eq!(
+            texts(
+                src,
+                &namespace_implicit_parent_spans(src, &analysis, "::outer::a")
+            ),
+            vec!["a"],
+        );
+        // …while `::outer` itself is not spelled in that word at all, so it
+        // gets no implicit site from it — its own block declares it anyway.
+        assert_eq!(
+            texts(src, &namespace_declaration_spans(&analysis, "::outer")),
+            vec!["::outer"],
+        );
+    }
+
+    #[test]
+    fn fp_an_unrelated_namespace_gets_no_implicit_site() {
+        // FP guard — prefix matching is segment-wise, so `::pq` must not be
+        // read as a parent of `::p::q::r`.
+        let src = "namespace eval ::p::q::r {}\n";
+        let analysis = analyse(src);
+        assert!(namespace_implicit_parent_spans(src, &analysis, "::pq").is_empty());
+        assert!(namespace_implicit_parent_spans(src, &analysis, "::q").is_empty());
+    }
+
+    #[test]
+    fn tn_the_global_namespace_has_no_implicit_site() {
+        // TN — `::` is created by the interpreter, not by any block.
+        let src = "namespace eval ::p::q {}\n";
+        let analysis = analyse(src);
+        assert!(namespace_implicit_parent_spans(src, &analysis, "::").is_empty());
+    }
+
+    #[test]
+    fn tp_hover_labels_an_implicitly_created_namespace_differently() {
+        let src = "namespace eval ::p::q::r {}\nnamespace children ::p::q\n";
+        let analysis = analyse(src);
+        let text = namespace_hover_text(&analysis, "::p::q").expect("hover");
+        assert!(text.contains("Implicitly created by"), "{text}");
+        assert!(text.contains("1 deeper `namespace eval` block"), "{text}");
+        // …and a really-declared namespace keeps the stronger wording.
+        let declared = namespace_hover_text(&analysis, "::p::q::r").expect("hover");
+        assert!(declared.contains("Declared by"), "{declared}");
     }
 
     // FN guard: `namespace inscope` must **not** be treated as a declaration —
@@ -657,6 +875,7 @@ mod tests {
         let one = NamespaceFacts {
             declarations: 1,
             references: 2,
+            implicit_declarations: 0,
             documents: 1,
         };
         let text = namespace_hover_markdown("::mypkg", one).expect("hover");
@@ -667,6 +886,7 @@ mod tests {
         let many = NamespaceFacts {
             declarations: 3,
             references: 4,
+            implicit_declarations: 0,
             documents: 2,
         };
         let text = namespace_hover_markdown("::mypkg", many).expect("hover");
@@ -691,6 +911,7 @@ mod tests {
             NamespaceFacts {
                 declarations: 2,
                 references: 1,
+                implicit_declarations: 0,
                 documents: 2,
             },
         );
@@ -715,5 +936,183 @@ mod tests {
         assert!(text.contains("`::mypkg`"), "{text}");
         assert!(text.contains("2 `namespace eval` blocks"), "{text}");
         assert!(text.contains("1 other reference(s)"), "{text}");
+    }
+
+    // `namespace path {::a ::b}` — issue #1113 item 2.  The argument is a
+    // *list* of namespace names inside one word, so no whole-word `ArgRole`
+    // can mark it; each element is recorded at its own span by the analyser's
+    // `namespace path` handler, using the shared Tcl list grammar.
+
+    #[test]
+    fn tp_each_namespace_path_element_is_its_own_reference() {
+        let src = "namespace eval ::a {}\n\
+                   namespace eval ::b {}\n\
+                   namespace path {::a ::b}\n";
+        let analysis = analyse(src);
+        assert_eq!(
+            texts(src, &namespace_reference_spans(&analysis, "::a")),
+            vec!["::a"],
+        );
+        assert_eq!(
+            texts(src, &namespace_reference_spans(&analysis, "::b")),
+            vec!["::b"],
+        );
+        // …and a cursor on the second element names that namespace, so
+        // go-to-definition reaches its declaring block.
+        let off = u32::try_from(src.rfind("::b").expect("found")).expect("offset fits u32");
+        assert_eq!(
+            namespace_cell_at_offset(src, &analysis, off).as_deref(),
+            Some("::b"),
+        );
+        assert_eq!(
+            texts(src, &namespace_declaration_spans(&analysis, "::b")),
+            vec!["::b"],
+        );
+    }
+
+    #[test]
+    fn tp_a_relative_path_element_roots_against_the_declaring_namespace() {
+        // The path entry follows the ordinary relative rule, which is what
+        // `command_resolution_candidates` already assumes.
+        let src = "namespace eval ::outer {\n\
+                   \x20   namespace eval helpers {}\n\
+                   \x20   namespace path helpers\n\
+                   }\n";
+        let analysis = analyse(src);
+        assert_eq!(
+            texts(
+                src,
+                &namespace_reference_spans(&analysis, "::outer::helpers")
+            ),
+            vec!["helpers"],
+        );
+    }
+
+    #[test]
+    fn tp_a_braced_path_element_gets_the_element_span_not_the_word() {
+        // A braced element (`{my ns}`) is exactly what the old
+        // `split_whitespace` split could not express — it made two bogus
+        // entries.  The list grammar keeps it one name.
+        let src = "namespace path {{my ns} ::b}\n";
+        let analysis = analyse(src);
+        assert_eq!(
+            texts(src, &namespace_reference_spans(&analysis, "::my ns")),
+            vec!["my ns"],
+        );
+    }
+
+    #[test]
+    fn fp_a_path_word_carrying_substitution_records_nothing() {
+        // FP guard — the whole word substitutes, so no element has a span
+        // whose text is a namespace name.  The handler's existing
+        // dynamic-word gate rejects the command before the split, which is
+        // the conservative answer and the one this test pins.
+        let src = "namespace eval ::a {}\nnamespace path [concat $extra ::a]\n";
+        let analysis = analyse(src);
+        assert!(
+            namespace_reference_spans(&analysis, "::a").is_empty(),
+            "a computed path claims no element spans: {:?}",
+            analysis.namespace_refs,
+        );
+    }
+
+    #[test]
+    fn tn_a_braced_path_word_that_looks_dynamic_is_still_skipped() {
+        // TN / documented limit — braces suppress substitution, so tclsh
+        // reads `$ns` here as a *literal* namespace name.  The handler's
+        // whole-word dynamic gate predates the element split and skips the
+        // command outright; recording nothing is a miss, never a wrong span.
+        let src = "namespace path {$ns ::a}\n";
+        let analysis = analyse(src);
+        assert!(
+            analysis.namespace_refs.is_empty(),
+            "{:?}",
+            analysis.namespace_refs,
+        );
+    }
+
+    #[test]
+    fn fp_a_whole_word_dynamic_path_records_nothing_at_all() {
+        let src = "namespace path $entries\n";
+        let analysis = analyse(src);
+        assert!(
+            analysis.namespace_refs.is_empty(),
+            "{:?}",
+            analysis.namespace_refs,
+        );
+    }
+
+    // `apply {{x} {…} ::ns}`'s third list element — issue #1113 item 4.  The
+    // analyser already models its *semantics* (`namespace_overrides`); this
+    // is its reference identity, which sits inside an
+    // `ArgRole::LambdaLiteral` word no whole-word role reaches.
+
+    #[test]
+    fn tp_an_apply_lambdas_namespace_element_is_a_reference() {
+        let src = "namespace eval ::ns {}\napply {{x} { return $x } ::ns} 1\n";
+        let analysis = analyse(src);
+        assert_eq!(
+            texts(src, &namespace_reference_spans(&analysis, "::ns")),
+            vec!["::ns"],
+        );
+        let off = u32::try_from(src.rfind("::ns").expect("found")).expect("offset fits u32");
+        assert_eq!(
+            namespace_cell_at_offset(src, &analysis, off).as_deref(),
+            Some("::ns"),
+        );
+    }
+
+    #[test]
+    fn fp_a_two_element_lambda_records_no_namespace_reference() {
+        // FP guard — the element is optional; a two-element lambda runs in
+        // `::` and names nothing.
+        let src = "apply {{x} { return $x }} 1\n";
+        let analysis = analyse(src);
+        assert!(
+            analysis.namespace_refs.is_empty(),
+            "{:?}",
+            analysis.namespace_refs,
+        );
+    }
+
+    #[test]
+    fn fp_a_dynamic_lambda_namespace_element_records_nothing() {
+        let src = "apply [list {x} { return $x } $ns] 1\n";
+        let analysis = analyse(src);
+        assert!(
+            analysis.namespace_refs.is_empty(),
+            "{:?}",
+            analysis.namespace_refs,
+        );
+    }
+
+    // A constant-dominated computed target — issue #1113 item 3.  `set ns
+    // ::app; namespace eval $ns { … }` creates `::app` on every run, so the
+    // `$ns` word is a declaring occurrence and navigation reaches it.
+
+    #[test]
+    fn tp_a_constant_computed_target_is_a_declaring_site() {
+        let src = "set ns ::app\nnamespace eval $ns { proc go {} { return 1 } }\nnamespace children ::app\n";
+        let analysis = analyse(src);
+        assert_eq!(
+            texts(src, &namespace_declaration_spans(&analysis, "::app")),
+            vec!["$ns"],
+        );
+        // …and the reference in `namespace children ::app` reaches it.
+        let off = u32::try_from(src.rfind("::app").expect("found")).expect("offset fits u32");
+        assert_eq!(
+            namespace_cell_at_offset(src, &analysis, off).as_deref(),
+            Some("::app"),
+        );
+    }
+
+    #[test]
+    fn fp_a_branch_conditional_target_declares_nothing() {
+        // FP guard — which namespace the block creates is a run-time
+        // question, so no declaration may be claimed for either candidate.
+        let src = "set ns ::a\nif {$c} { set ns ::b }\nnamespace eval $ns { proc go {} { return 1 } }\n";
+        let analysis = analyse(src);
+        assert!(namespace_declaration_spans(&analysis, "::a").is_empty());
+        assert!(namespace_declaration_spans(&analysis, "::b").is_empty());
     }
 }

--- a/rust/tcl-lsp-core/tests/lsp_lens_links_symbols.rs
+++ b/rust/tcl-lsp-core/tests/lsp_lens_links_symbols.rs
@@ -644,6 +644,85 @@ fn links_source_uri_is_percent_encoded() {
     }
 }
 
+// Computed `source` paths — issue #1140 idx 41. The provider used to fall
+// through to treating the *raw unevaluated Tcl text* as a literal path, then
+// percent-encode it onto the workspace root, producing a syntactically valid
+// but semantically bogus `file://` URI. It now resolves what the source
+// graph's own evaluator can resolve, and emits nothing otherwise.
+
+fn links_in(src: &str, script_path: &str) -> Vec<DocumentLink> {
+    let root = script_path.rsplit_once('/').map_or("/", |(dir, _)| dir);
+    tcl_lsp_core::document_links::document_links_in_context(
+        src,
+        "tcl8.6",
+        &tcl_lsp_core::document_links::LinkContext {
+            workspace_root: Some(root),
+            home: None,
+            script_path: Some(script_path),
+        },
+    )
+}
+
+#[test]
+fn fp_a_computed_source_path_never_produces_a_fabricated_target() {
+    // FP guard — the exact georgtree/tclopt shape. Whatever else happens,
+    // no link may carry the raw Tcl text percent-encoded into its URI.
+    let src = "source [file join $undeclared .. pkgfile.tcl]\n";
+    let links = links_in(src, "/proj/test/all_codeCoverage.tcl");
+    assert!(
+        links.iter().all(|l| !l.target.contains("%5B")
+            && !l.target.contains('$')
+            && !l.target.contains('[')),
+        "no link may encode unevaluated Tcl text: {links:?}",
+    );
+}
+
+#[test]
+fn fp_a_bare_variable_source_path_produces_no_link() {
+    // FP guard — a whole-word `$var` is exactly one token, which is why the
+    // old `single_token_word` test let it through as a "literal".
+    let src = "source $dir\n";
+    assert!(links_in(src, "/proj/a.tcl").is_empty());
+}
+
+#[test]
+fn tp_info_script_based_paths_resolve_through_the_source_graph_evaluator() {
+    // TP — `[file dirname [info script]]` is what the source graph already
+    // evaluates for the M9 rehoming edges; the link provider consumes the
+    // same evaluator instead of growing a second one.
+    let src = "source [file join [file dirname [info script]] lib helper.tcl]\n";
+    let links = links_in(src, "/proj/test/all.tcl");
+    assert_eq!(links.len(), 1, "{links:?}");
+    assert_eq!(links[0].target, "file:///proj/test/lib/helper.tcl");
+}
+
+#[test]
+fn tp_a_single_set_constant_propagates_into_the_join() {
+    // TP — the corpus idiom: one `set dir …` then `source [file join $dir …]`.
+    let src = "set dir [file dirname [info script]]\nsource [file join $dir sub other.tcl]\n";
+    let links = links_in(src, "/proj/test/all.tcl");
+    assert_eq!(links.len(), 1, "{links:?}");
+    assert_eq!(links[0].target, "file:///proj/test/sub/other.tcl");
+}
+
+#[test]
+fn fp_a_variable_assigned_twice_is_not_propagated() {
+    // FP guard — which value a later `source` sees is a flow question this
+    // provider does not ask, so a re-assigned name is dropped entirely
+    // rather than guessed at.
+    let src = "set dir /one\nset dir /two\nsource [file join $dir x.tcl]\n";
+    assert!(links_in(src, "/proj/a.tcl").is_empty());
+}
+
+#[test]
+fn tn_a_plain_literal_path_still_links() {
+    // TN — the ordinary case is untouched.
+    let src = "source helper.tcl\n";
+    let links = links_in(src, "/proj/a.tcl");
+    assert_eq!(links.len(), 1, "{links:?}");
+    assert_eq!(links[0].target, "file:///proj/helper.tcl");
+}
+
 // NOTE on BIG-IP-specific extraction: this provider keys on the vanilla Tcl
 // `source` / `package require` commands. It has no BIG-IP-config-specific link
 // extraction (e.g. `include`/`source` of a tmsh config fragment) — those would

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -13555,15 +13555,31 @@ impl LanguageServer for Backend {
         // relative `source <path>` arguments resolve.  When
         // the URI isn't a `file://` URL we leave the workspace
         // root unset and only absolute paths surface as links.
+        let doc_path = uri
+            .to_file_path()
+            .and_then(|p| p.to_str().map(str::to_owned));
         let workspace_root = uri
             .to_file_path()
             .and_then(|p| p.parent().map(std::path::Path::to_path_buf))
             .and_then(|p| p.to_str().map(str::to_owned));
+        // The document's own path is what `[info script]` answers while it is
+        // being sourced, so a computed `source [file dirname [info script]]`
+        // path resolves through the same evaluator the source graph uses
+        // instead of being fabricated from raw text (issue #1140 idx 41).
+        let home = std::env::var("HOME").ok();
         // Pure-CPU segmentation on a worker so a parser panic is contained
         // as a JSON-RPC error.
         let (text, dialect) = (doc.text.clone(), doc.dialect.clone());
         let links = tokio::task::spawn_blocking(move || {
-            core_document_links::document_links(&text, &dialect, workspace_root.as_deref())
+            core_document_links::document_links_in_context(
+                &text,
+                &dialect,
+                &core_document_links::LinkContext {
+                    workspace_root: workspace_root.as_deref(),
+                    home: home.as_deref(),
+                    script_path: doc_path.as_deref(),
+                },
+            )
         })
         .await
         .map_err(|err| jsonrpc::Error {

--- a/rust/tcl-lsp-server/tests/e2e.rs
+++ b/rust/tcl-lsp-server/tests/e2e.rs
@@ -61,6 +61,8 @@ mod issue1001;
 mod issue1088_namespace_symbols;
 #[path = "e2e/issue1122_sticky_scroll.rs"]
 mod issue1122_sticky_scroll;
+#[path = "e2e/issue1137_call_site_resolution.rs"]
+mod issue1137_call_site_resolution;
 #[path = "e2e/issue1214_uri_canonicalisation.rs"]
 mod issue1214_uri_canonicalisation;
 #[path = "e2e/issue923_class_refs.rs"]

--- a/rust/tcl-lsp-server/tests/e2e/issue1137_call_site_resolution.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue1137_call_site_resolution.rs
@@ -1,0 +1,259 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! End-to-end coverage for the call-site resolution seam shared by
+//! `textDocument/definition` and `textDocument/hover` — issues #1137
+//! (command-position gate + the `::oo::Helpers` cross-file path), #1133
+//! (an already-resolved indirect head must beat a same-named decoy), and
+//! the document-tier providers of #1140 that answer the same questions.
+//!
+//! The unifying property under test is **self-consistency**: every provider
+//! in one response must agree about what a given span names, and none may
+//! answer from a text guess where the analyser has already decided.
+
+use serde_json::Value;
+
+use crate::common::{Lsp, unique_uri};
+
+/// The corpus shape from issue #1137 idx 50, reduced to its mechanism: an
+/// argument word that happens to share a proc's name, beside a real call
+/// head. `dump` is data; tclsh never looks it up as a command.
+const ARGUMENT_DECOY: &str = concat!(
+    "proc anotherproc {a b} { return $a }\n",
+    "proc dump {x} { return $x }\n",
+    "proc caller {} {\n",
+    "    return [anotherproc dump 5]\n",
+    "}\n",
+);
+
+/// Issue #1133: a constant-dominated indirect head beside a same-named decoy.
+const INDIRECT_HEAD: &str = concat!(
+    "namespace eval ::tc { proc setdef {a} { return $a } }\n",
+    "namespace eval ::other { proc setdef {b c} { return $b } }\n",
+    "set ns ::tc\n",
+    "${ns}::setdef\n",
+);
+
+fn locations(result: &Value) -> Vec<(u32, u32)> {
+    let Some(items) = result.as_array() else {
+        return Vec::new();
+    };
+    items
+        .iter()
+        .filter_map(|loc| {
+            let range = loc.get("range").or_else(|| loc.get("targetSelectionRange"))?;
+            Some((
+                u32::try_from(range["start"]["line"].as_u64()?).ok()?,
+                u32::try_from(range["start"]["character"].as_u64()?).ok()?,
+            ))
+        })
+        .collect()
+}
+
+fn hover_text(result: &Value) -> String {
+    result
+        .get("contents")
+        .and_then(|c| c.get("value"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_owned()
+}
+
+#[test]
+fn definition_abstains_on_an_argument_that_shares_a_procs_name() {
+    // FP guard — issue #1137 idx 50. Before the command-position gate the
+    // final text-scan fallback resolved `dump` onto `proc ::dump`, an answer
+    // no run of the program could produce.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, ARGUMENT_DECOY);
+    let result = lsp.definition(&uri, 3, 24);
+    assert!(
+        locations(&result).is_empty(),
+        "an argument word must not resolve as a command: {result}",
+    );
+}
+
+#[test]
+fn hover_abstains_on_the_same_argument() {
+    // The two providers share the seam, so they must share the abstention —
+    // the defect was visible as hover and definition agreeing on a wrong
+    // answer.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, ARGUMENT_DECOY);
+    let text = hover_text(&lsp.hover(&uri, 3, 24));
+    assert!(
+        !text.contains("proc ::dump"),
+        "hover must not describe an argument as a command: {text}",
+    );
+}
+
+#[test]
+fn definition_and_hover_still_answer_the_real_head_beside_it() {
+    // TP — the gate must cost the genuine call head nothing.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, ARGUMENT_DECOY);
+    assert_eq!(
+        locations(&lsp.definition(&uri, 3, 12)),
+        vec![(0, 5)],
+        "the call head must still resolve",
+    );
+    let text = hover_text(&lsp.hover(&uri, 3, 12));
+    assert!(text.contains("anotherproc"), "hover on the head: {text}");
+}
+
+#[test]
+fn definition_prefers_a_resolved_indirect_head_over_a_same_named_decoy() {
+    // TP — issue #1133. The analyser settles `${ns}::setdef` to
+    // `::tc::setdef`; the provider used to ignore that and answer with
+    // `::other::setdef`, which the call can never reach.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, INDIRECT_HEAD);
+    assert_eq!(
+        locations(&lsp.definition(&uri, 3, 7)),
+        vec![(0, 27)],
+        "must reach ::tc::setdef on line 0, not the ::other decoy on line 1",
+    );
+}
+
+#[test]
+fn hover_agrees_with_definition_on_the_indirect_head() {
+    // Self-consistency: the two providers describe the same command.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, INDIRECT_HEAD);
+    let text = hover_text(&lsp.hover(&uri, 3, 7));
+    assert!(
+        text.contains("::tc::setdef"),
+        "hover must describe the resolved target: {text}",
+    );
+}
+
+#[test]
+fn a_bare_helper_call_in_a_method_body_resolves_across_files() {
+    // TP — issue #1137 idx 51, the ticklecharts layout: the helper is
+    // installed into `::oo::Helpers` in one file and called bare from a
+    // method body in another. A method body's `namespace path` is
+    // unconditionally `::oo::Helpers` (tclsh 8.6.16 / 9.0.4), so this is a
+    // real cross-file reference; before the candidate-list fix the one
+    // cross-file resolver could never see it.
+    let root = std::env::temp_dir().join(format!(
+        "tcl-lsp-e2e-oohelpers-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos(),
+    ));
+    std::fs::create_dir_all(&root).expect("create workspace root");
+    std::fs::write(
+        root.join("utils.tcl"),
+        "proc ::oo::Helpers::callback {method args} {\n    return [list my $method {*}$args]\n}\n",
+    )
+    .expect("write utils.tcl");
+    let esnap = root.join("esnap.tcl");
+    std::fs::write(
+        &esnap,
+        "oo::class create Snap {\n    method Start {} {\n        return [callback ReadBrowser]\n    }\n    method ReadBrowser {} { return 1 }\n}\n",
+    )
+    .expect("write esnap.tcl");
+
+    let mut lsp = Lsp::at_workspace_root(&root);
+    let uri = format!("file://{}", esnap.to_string_lossy());
+    lsp.open_ready(&uri, &std::fs::read_to_string(&esnap).expect("read"));
+    let result = lsp.definition(&uri, 2, 17);
+    let targets = result.as_array().cloned().unwrap_or_default();
+    assert!(
+        targets.iter().any(|loc| {
+            loc.get("uri")
+                .or_else(|| loc.get("targetUri"))
+                .and_then(Value::as_str)
+                .is_some_and(|u| u.ends_with("utils.tcl"))
+        }),
+        "the bare `callback` call must reach ::oo::Helpers::callback in utils.tcl: {result}",
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn document_symbol_homes_a_qualified_proc_where_hover_says_it_lives() {
+    // Issue #1140 idx 67 — the outline used to contradict hover inside the
+    // very same session: hover said `::pix::svg::parse`, the outline showed
+    // a bare top-level `parse` disconnected from the `pix > svg` tree.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let text = concat!(
+        "namespace eval ::pix {\n",
+        "    namespace eval svg {\n",
+        "    }\n",
+        "}\n",
+        "proc pix::svg::parse {a} {\n",
+        "    return $a\n",
+        "}\n",
+    );
+    lsp.open_ready(&uri, text);
+
+    let hover = hover_text(&lsp.hover(&uri, 4, 15));
+    assert!(
+        hover.contains("::pix::svg::parse"),
+        "hover baseline: {hover}",
+    );
+
+    let symbols = lsp.document_symbols(&uri);
+    let pix = symbols
+        .as_array()
+        .and_then(|top| top.first())
+        .cloned()
+        .unwrap_or(Value::Null);
+    assert_eq!(pix["name"], "::pix", "{symbols}");
+    let svg = &pix["children"][0];
+    assert_eq!(svg["name"], "svg", "{symbols}");
+    assert_eq!(
+        svg["children"][0]["name"], "parse",
+        "the outline must agree with hover: {symbols}",
+    );
+}
+
+
+#[test]
+fn document_link_never_fabricates_a_target_for_a_computed_source_path() {
+    // Issue #1140 idx 41 — the provider percent-encoded the raw unevaluated
+    // Tcl text and joined it onto the workspace directory, yielding a
+    // syntactically valid but semantically bogus `file://` URI.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "source [file join $undeclared .. pkgfile.tcl]\nsource $other\n",
+    );
+    let links = lsp.document_links(&uri);
+    let bogus = links
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|l| l.get("target").and_then(Value::as_str))
+        .find(|t| t.contains("%5B") || t.contains('$') || t.contains('['));
+    assert!(
+        bogus.is_none(),
+        "no link may encode unevaluated Tcl text: {links}",
+    );
+}

--- a/rust/tcl-lsp-server/tests/e2e/issue1137_call_site_resolution.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue1137_call_site_resolution.rs
@@ -56,7 +56,9 @@ fn locations(result: &Value) -> Vec<(u32, u32)> {
     items
         .iter()
         .filter_map(|loc| {
-            let range = loc.get("range").or_else(|| loc.get("targetSelectionRange"))?;
+            let range = loc
+                .get("range")
+                .or_else(|| loc.get("targetSelectionRange"))?;
             Some((
                 u32::try_from(range["start"]["line"].as_u64()?).ok()?,
                 u32::try_from(range["start"]["character"].as_u64()?).ok()?,
@@ -232,7 +234,6 @@ fn document_symbol_homes_a_qualified_proc_where_hover_says_it_lives() {
         "the outline must agree with hover: {symbols}",
     );
 }
-
 
 #[test]
 fn document_link_never_fabricates_a_target_for_a_computed_source_path() {

--- a/rust/tcl-lsp-server/tests/e2e/vscode_parity.rs
+++ b/rust/tcl-lsp-server/tests/e2e/vscode_parity.rs
@@ -343,7 +343,14 @@ fn test_optimiser_toggle_suppresses_o_codes() {
     assert!(codes(&base).iter().any(|c| c.starts_with('O')));
     lsp.clear_notifications();
     lsp.apply_configuration(json!({ "optimiser": { "enabled": false } }));
-    let diags = lsp.await_diagnostics_version(&uri, Some(1), Duration::from_secs(15));
+    // Await convergence, not the first version-1 republish: the coalesced
+    // config reload (#1213) may reschedule once on the inline settings before
+    // the pulled config lands, so an early republish can still carry the old
+    // profile's O-codes. The toggle is proven by the *latest* publish going
+    // O-free within the window; a broken toggle times out here instead.
+    let diags = lsp.await_diagnostics_settled(&uri, Duration::from_secs(15), |diags| {
+        !codes(diags).iter().any(|c| c.starts_with('O'))
+    });
     assert!(!codes(&diags).iter().any(|c| c.starts_with('O')));
 }
 

--- a/rust/tcl-registry/src/definer.rs
+++ b/rust/tcl-registry/src/definer.rs
@@ -440,6 +440,24 @@ pub struct DefinitionBodyGrammar {
     /// `type` / `selfns` / `options`, a widget's `win` / `hull`).  Consumed by
     /// the analyser's read-before-set / stray-dispatch suppression.
     pub implicit_vars: &'static [&'static str],
+    /// The **implicit `namespace path`** every member body of this class
+    /// system runs with — namespaces a bare command word resolves through
+    /// after the body's own current namespace and before global, exactly as
+    /// a written `namespace path` would.
+    ///
+    /// `TclOO` puts `::oo::Helpers` there unconditionally (tclsh 8.6.16 and
+    /// 9.0.4: inside any method body `namespace path` is `::oo::Helpers`, so
+    /// a bare `callback` reaches `::oo::Helpers::callback` — the documented
+    /// "TclOO Tricks" idiom — before `::callback`).  snit and itcl member
+    /// bodies run in the type / class namespace with no injected path, so
+    /// theirs is empty.
+    ///
+    /// This is the data half of [`crate::Traits::TclooMethodContext`]: that
+    /// trait says *which words* only resolve in such a frame, this says
+    /// *where* a frame looks.  Consumed by the analyser's invocation
+    /// candidate-list finalisation (issue #1137), so no consumer spells
+    /// `::oo::Helpers` itself.
+    pub member_body_namespace_path: &'static [&'static str],
 }
 
 impl DefinitionBodyGrammar {
@@ -567,7 +585,16 @@ pub const TCLOO_GRAMMAR: DefinitionBodyGrammar = DefinitionBodyGrammar {
     family: DefinerFamily::TclOo,
     members: TCLOO_MEMBERS,
     implicit_vars: &[],
+    member_body_namespace_path: TCLOO_MEMBER_BODY_NAMESPACE_PATH,
 };
+
+/// The `namespace path` a `TclOO` member body runs with — see
+/// [`DefinitionBodyGrammar::member_body_namespace_path`].
+///
+/// Exposed on its own so a consumer holding only the analyser's
+/// "this frame resolves like a `TclOO` method body" flag (rather than the
+/// whole grammar) still reads the path from registry data.
+pub const TCLOO_MEMBER_BODY_NAMESPACE_PATH: &[&str] = &["::oo::Helpers"];
 
 // ---------------------------------------------------------------------------
 // snit — `snit::type` / `snit::widget` / `snit::widgetadaptor` bodies.
@@ -608,6 +635,7 @@ pub const SNIT_GRAMMAR: DefinitionBodyGrammar = DefinitionBodyGrammar {
     family: DefinerFamily::Snit,
     members: SNIT_MEMBERS,
     implicit_vars: &["self", "selfns", "type", "options"],
+    member_body_namespace_path: &[],
 };
 
 // ---------------------------------------------------------------------------
@@ -654,6 +682,7 @@ pub const ITCL_GRAMMAR: DefinitionBodyGrammar = DefinitionBodyGrammar {
     family: DefinerFamily::Itcl,
     members: ITCL_MEMBERS,
     implicit_vars: &["this"],
+    member_body_namespace_path: &[],
 };
 
 #[cfg(test)]

--- a/rust/tcl-registry/src/definer.rs
+++ b/rust/tcl-registry/src/definer.rs
@@ -448,7 +448,7 @@ pub struct DefinitionBodyGrammar {
     /// `TclOO` puts `::oo::Helpers` there unconditionally (tclsh 8.6.16 and
     /// 9.0.4: inside any method body `namespace path` is `::oo::Helpers`, so
     /// a bare `callback` reaches `::oo::Helpers::callback` — the documented
-    /// "TclOO Tricks" idiom — before `::callback`).  snit and itcl member
+    /// "`TclOO` Tricks" idiom — before `::callback`).  snit and itcl member
     /// bodies run in the type / class namespace with no injected path, so
     /// theirs is empty.
     ///


### PR DESCRIPTION
## Summary

- **#1113** (all four sub-items): `namespace path {::a ::b}` elements now split with the shared Tcl list grammar and each records its own `NamespaceRef`; the `apply` lambda's namespace element gets a reference identity at the already-split site; constant-dominated `namespace eval $ns { … }` targets settle through `resolve_dynamic_word` (same identity resolution `source`/`rename`/`oo::define` use) so their procs home to the real namespace, while genuinely dynamic targets keep the per-site `@dynns@` domain; implicit parents (`namespace eval ::p::q::r` creating `::p::q`) answer definition via the covering prefix of the deeper written name, worded "implicitly created by" in hover. Cross-document implicit parents filed as #1246.
- **#1133**: `definition()` never consulted the `indirect` invocation entry the analyser had already resolved and fell through to the bareword lookup, answering a same-named decoy. A resolved indirect head is now preferred ahead of every name-based path (hover too); an unresolved one doesn't block the fallback.
- **#1137**: the "otherwise it is a CALL" fallback handed the text scan's word to `resolve_called_proc` with no command-position check, so arguments resolved as commands — now gated on the analyser's recorded invocation set. And a TclOO member body's implicit `::oo::Helpers` lookup path is now registry data (`DefinitionBodyGrammar::member_body_namespace_path`) folded in at the single candidate-recording site, so definition/references/rename/call-hierarchy/W123 all see it, cross-file included (the documented "TclOO Tricks" helper idiom).
- **#1140**: `documentLink` no longer percent-encodes raw Tcl into bogus `file://` targets — computed `source` paths resolve through the source graph's `auto_path_eval` plus single-`set` copy propagation and abstain otherwise, with `[info script]` anchored to the document path; `documentSymbol` homes each namespace-level proc under the namespace its `qualified_name` spells instead of the lexical scope tree (never inventing nodes, never re-homing procs nested in proc bodies).

Recovered from a stalled session and re-reviewed: its uncommitted work was triaged — navigation portions kept/extended/tested, its independent #1216/#1218 drafts dropped in favour of the versions already merged via #1244, scratch probes deleted. Issues filed en route: #1245 (`is_dynamic_word` on reconstructed braced words), #1246 (cross-document implicit parents), #1247 (pre-existing W210 regression on `dict update` value-vars, reproduced at the branch base).

## Validation

- [x] On the group branch (pre-rebase): `cargo test -p tcl-lsp-core` 2752 passed / 0 failed; `-p tcl-lsp-server` 1622 passed / 0 failed (11 new e2e); `-p tcl-compiler` 7894 passed / 1 failed — the failure is pre-existing at the branch base and filed as #1247; fmt clean; clippy `-D warnings` clean over touched crates, no new `#[allow]`s.
- [x] Rebased onto post-#1244 rust as six cherry-picks; four conflicts resolved (two test-module insertion unions, one semantic union in `document_symbols.rs` keeping both #1244's name-span `selectionRange` and this branch's namespace threading, one rejected resurrection of a superseded helper from the dropped draft).
- [x] Post-rebase `cargo check -p tcl-compiler -p tcl-lsp-core` clean; full suite delegated to CI (local disk saturated by parallel group builds) — this session is subscribed and will drive any failure to green.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? — Yes: `NamespaceRef` identities for path/lambda/implicit-parent elements, `DefinitionBodyGrammar::member_body_namespace_path` registry fact, constant-dominated dynamic namespace settlement.
- [x] If yes, I updated at least one relevant KCS note — contract docs updated at the definition sites; analyser test modules document the tclsh oracles.
- [ ] If I added a new compiler KCS note, I linked it — n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_