### PR TITLE
Classified SSA uses, Tarjan loop detection, generated activation globs, per-entry-point BOM split (#1142, #1237, #1240, #1242, #1243, #1245)

### DIFF
--- a/docs/design/compiler/def-use-chains.md
+++ b/docs/design/compiler/def-use-chains.md
@@ -44,8 +44,8 @@ and in which frame, is the callee's business.
 
 | `UseClass` | Meaning | Who honours it |
 |---|---|---|
-| `SUBSTITUTED` | Substituted at this site, or evaluated by the callee in this same frame (an `ArgRole::Expr` / `ArgRole::Body` word) — a genuine read here | everyone |
-| `QUOTED` | Carried only by a brace-quoted word this site passes through verbatim | liveness / dead-store only |
+| `SUBSTITUTED` | A genuine read here | everyone |
+| `QUOTED` | Carried only by a brace-quoted word nothing evaluates in this frame | liveness / dead-store only |
 
 Liveness, W211, W220 and store elimination must assume a quoted word *may*
 be evaluated, so the use has to exist.  Read-before-set (W210 / W213) must
@@ -55,10 +55,28 @@ dropping the use resurrects `W211 set but never used` on `set a(k) 1; puts
 {$a(k)}`, and recording the name as a self-initialising def deletes the
 feeding store outright (issues #1142, #1237).
 
-Which roles keep a braced word `SUBSTITUTED` is registry data, not a
-command list: `ArgRole::braced_word_evaluated_in_frame` is the single
-answer, and an un-roled position — including every position of a command
-the registry does not describe — falls to `QUOTED`.
+### The three kinds of braced word
+
+A braced word is never read *at* the call site.  What it **is** decides the
+class, and the answer is registry data rather than a command list
+(`ssa::braced_word_class`):
+
+| Kind | Test | Example | Class |
+|---|---|---|---|
+| script, this frame | the position's `ArgRole` answers `braced_word_evaluated_in_frame` (`Body` / `Expr`) | `expr {$a + $b}`, `if {$c} …` | `SUBSTITUTED` |
+| data | the registry **describes** the command, and the role is not one of those | `puts {$y}`, `string match {$pat*} …`, `lsort -command {cmp $x}` | `QUOTED` |
+| unclassified | the registry does **not** describe the command | `mywrapper {puts $myf}` | `SUBSTITUTED`, unless the word `set`s the name itself → `QUOTED` |
+
+The unclassified row is the conservative one, and deliberately so: a user
+proc's braced argument may be a script, and a wrapper that hands it to an
+`uplevel`-ing worker runs it in *this* frame, where a free read of an unset
+name is a genuine error tclsh reproduces.  A name the word sets itself is
+that script's own local whichever frame it runs in — the shape an un-hooked
+definer body takes — so only that is demoted.  It is the `Statement::Call`
+twin of the analyser's `barrier_body_locally_sets`.
+
+A braced `return` value (`return {$y}`) is `QUOTED` on both the statement
+and the terminator read.
 
 ## Derivation from SSA
 

--- a/docs/design/compiler/def-use-chains.md
+++ b/docs/design/compiler/def-use-chains.md
@@ -28,7 +28,37 @@ UseSite
   statement_index: int
   variable: str             # for phi: the phi variable
   phi_version: int          # for phi: the phi's version
+  class: UseClass           # SUBSTITUTED | QUOTED
 ```
+
+## Use classification (`UseClass`)
+
+A use is **classified**, not merely present or absent, because the two
+families of consumer need opposite conservatism about the same word.
+
+Tcl substitutes `$name` in a bare or `"`-quoted word and never in a
+brace-quoted one: `puts {$y}` prints the two characters `$y` and reads
+nothing.  A braced word's contents may still be *evaluated* later — by
+`expr`, by `if`, by an `after` callback, by an unknown definer — but when,
+and in which frame, is the callee's business.
+
+| `UseClass` | Meaning | Who honours it |
+|---|---|---|
+| `SUBSTITUTED` | Substituted at this site, or evaluated by the callee in this same frame (an `ArgRole::Expr` / `ArgRole::Body` word) — a genuine read here | everyone |
+| `QUOTED` | Carried only by a brace-quoted word this site passes through verbatim | liveness / dead-store only |
+
+Liveness, W211, W220 and store elimination must assume a quoted word *may*
+be evaluated, so the use has to exist.  Read-before-set (W210 / W213) must
+assume it *may not* be, or may be evaluated in a frame that binds the name,
+so it skips `QUOTED` uses.  Filtering at either end breaks the other:
+dropping the use resurrects `W211 set but never used` on `set a(k) 1; puts
+{$a(k)}`, and recording the name as a self-initialising def deletes the
+feeding store outright (issues #1142, #1237).
+
+Which roles keep a braced word `SUBSTITUTED` is registry data, not a
+command list: `ArgRole::braced_word_evaluated_in_frame` is the single
+answer, and an un-roled position — including every position of a command
+the registry does not describe — falls to `QUOTED`.
 
 ## Derivation from SSA
 

--- a/docs/kcs/codes/kcs-diagnostic-w210-variable-read-before-set.md
+++ b/docs/kcs/codes/kcs-diagnostic-w210-variable-read-before-set.md
@@ -71,15 +71,32 @@ puts {set y 1; puts $y}  ;# prints the line; not flagged
 mydefiner ::a::b {optlist} {set y 1; return $y}   ;# not flagged
 ```
 
-That holds however the braced word is later used. `after 100 {puts $x}` may
-run its script much later, an unknown command may run its braced argument in
-a frame of its own, or it may never run it at all — none of which the
-analyser can decide, so it declines to call the mention a read.
+That holds for any command the analyser knows: `puts`, `string match`,
+`lsort -command`, and every other command in its registry say what each
+argument is, and none of them substitutes a braced one.
 
 Two shapes are the exception, because the command really does evaluate the
 braced word against *your* variables: an expression (`expr {$a + $b}`,
 `if {$a} …`) and a body that shares your frame (`if`, `while`, `foreach`,
 `catch`). Those are read normally and still flagged.
+
+A command the analyser does **not** know — one of your own procedures, or a
+definer from a library it has no description of — is the middle case. Its
+braced argument might be a script, and if the procedure passes it on to
+something that runs it with `uplevel`, it runs in your frame:
+
+```tcl
+proc wrapper {script} { real_worker $script }   ;# real_worker uplevels it
+wrapper { puts $myf }                            ;# flagged: myf is never set
+```
+
+so a read there is still reported. The exception is a name the braced word
+sets itself — that is the script's own variable whichever frame it ends up
+in, and it is not flagged:
+
+```tcl
+mydefiner ::a::b {optlist} { set y 1; return $y }   ;# not flagged
+```
 
 A braced mention does still count as *use* for
 [`W211`](kcs-diagnostic-w211-variable-set-not-used.md) and

--- a/docs/kcs/codes/kcs-diagnostic-w210-variable-read-before-set.md
+++ b/docs/kcs/codes/kcs-diagnostic-w210-variable-read-before-set.md
@@ -60,6 +60,32 @@ idioms for a single exact name: `[info vars X] ne ""`,
 (`info globals` is not used — it proves the *global* exists, not the bare-`$X`
 local — and glob patterns are not statically decidable.)
 
+## Braces are not substitution
+
+A word wrapped in braces is passed through exactly as written — Tcl performs
+no `$` substitution inside it — so the names it mentions are not read there:
+
+```tcl
+puts {$y}              ;# prints the two characters $y; not flagged
+puts {set y 1; puts $y}  ;# prints the line; not flagged
+mydefiner ::a::b {optlist} {set y 1; return $y}   ;# not flagged
+```
+
+That holds however the braced word is later used. `after 100 {puts $x}` may
+run its script much later, an unknown command may run its braced argument in
+a frame of its own, or it may never run it at all — none of which the
+analyser can decide, so it declines to call the mention a read.
+
+Two shapes are the exception, because the command really does evaluate the
+braced word against *your* variables: an expression (`expr {$a + $b}`,
+`if {$a} …`) and a body that shares your frame (`if`, `while`, `foreach`,
+`catch`). Those are read normally and still flagged.
+
+A braced mention does still count as *use* for
+[`W211`](kcs-diagnostic-w211-variable-set-not-used.md) and
+[`W220`](kcs-diagnostic-w220-dead-store.md): the text may be evaluated later,
+so the assignment feeding it is not reported dead.
+
 ## Variables set inside a loop
 
 A variable assigned inside a loop body and read *after* the loop is **not**

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -43,7 +43,7 @@
     "onChatParticipant:tcl-lsp.irule",
     "onChatParticipant:tcl-lsp.tcl",
     "onChatParticipant:tcl-lsp.tk",
-    "workspaceContains:**/*.{tcl,tk,itcl,tm,test,irul,irule,iapp,iappimpl}"
+    "workspaceContains:**/*.{[tT][cC][lL],[tT][kK],[iI][tT][cC][lL],[tT][mM],[iI][rR][uU][lL],[iI][rR][uU][lL][eE],[iI][aA][pP][pP],[iI][aA][pP][pP][iI][mM][pP][lL],[iI][mM][pP][lL],[eE][xX][pP],[aA][pP][lL],[tT][eE][sS][tT]}"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/rust/tcl-cli-support/src/input.rs
+++ b/rust/tcl-cli-support/src/input.rs
@@ -22,15 +22,15 @@
 use std::io::{IsTerminal, Read};
 use std::path::{Path, PathBuf};
 
-/// Source file extensions the CLI accepts.
+/// Source file extensions the CLI accepts — the registry's single list, shared
+/// with the LSP server's workspace scan and the VS Code activation glob.
 ///
 /// `test` is the standard `tcltest` suite-file extension — `tcl check
 /// path/to/tests/` skipped a project's whole test suite without it, the CLI
 /// twin of the workspace-scan gap in issue #923 differential-audit findings
-/// idx 10 / idx 27.
-const SOURCE_SUFFIXES: &[&str] = &[
-    "tcl", "tk", "itcl", "tm", "irul", "irule", "iapp", "iappimpl", "impl", "test",
-];
+/// idx 10 / idx 27. The CLI's own copy had additionally drifted from the
+/// server's by `exp` / `apl` (issue #1242).
+use tcl_registry::dialects::TCL_SOURCE_EXTENSIONS as SOURCE_SUFFIXES;
 
 /// Directory names skipped during recursive discovery.
 const SKIP_DIRECTORY_NAMES: &[&str] = &[

--- a/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
@@ -1180,6 +1180,15 @@ file; this call falls through to the 'unknown' handler."
             if matches!(use_site.kind, UseKind::PhiIncoming) {
                 continue;
             }
+            // A `UseClass::Quoted` use is carried only by a brace-quoted word
+            // the statement does not substitute (`puts {$y}` prints `$y` and
+            // reads nothing). The use exists so liveness stays conservative
+            // about a word that may be evaluated later; it is not a read
+            // here, so it can never be read-*before*-set (issues #1142,
+            // #1237).
+            if use_site.class == crate::ssa::UseClass::Quoted {
+                continue;
+            }
             // An after-loop read of a variable the loop body defines on every
             // iteration is not read-before-set (see
             // `UndefSuppression::loop_entry_only_undef`): we assume a may-run
@@ -1345,7 +1354,12 @@ file; this call falls through to the 'unknown' handler."
             let Some(cfg_block) = fu.cfg.blocks.get(&bn) else {
                 continue;
             };
-            let Some(crate::cfg::Terminator::Return { value, expr, .. }) = &cfg_block.terminator
+            let Some(crate::cfg::Terminator::Return {
+                value,
+                expr,
+                braced,
+                ..
+            }) = &cfg_block.terminator
             else {
                 continue;
             };
@@ -1368,8 +1382,11 @@ file; this call falls through to the 'unknown' handler."
             // substitutions + nested `[...]`) and any parsed expr. The
             // return value is a single already-extracted word, not a
             // script, so it scans in value-body mode.
+            // A **braced** value is literal — `return {$y}` returns the two
+            // characters `$y` and reads nothing — so it contributes no reads
+            // at all (`UseClass::Quoted`; issue #1237).
             let mut reads: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
-            if let Some(v) = value {
+            if let Some(v) = value.as_ref().filter(|_| !*braced) {
                 reads.extend(scanner.scan_word(v, registry));
             }
             if let Some(e) = expr {
@@ -1560,6 +1577,11 @@ file; this call falls through to the 'unknown' handler."
             };
             for (idx, s) in ssa_block.statements.iter().enumerate() {
                 for &sym in s.uses.keys() {
+                    // A quoted (unevaluated brace-word) mention is not a read
+                    // here — see `emit_read_before_set_diagnostics`.
+                    if s.quoted_uses.contains(&sym) {
+                        continue;
+                    }
                     let name = fu.ssa.var_name(sym);
                     if reported.contains(name) {
                         continue;

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/rbs.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/rbs.rs
@@ -1857,3 +1857,111 @@ fn issue_1078_braced_element_and_spaced_names_key_on_their_own_spelling() {
         codes(spaced, D)
     );
 }
+
+// Issues #1142 / #1237 — a braced word is data, not a script the call site
+// substitutes.  The SSA use is *classified* (`ssa::UseClass`) rather than
+// dropped: liveness keeps honouring it (the text may be evaluated later),
+// read-before-set does not.
+//
+// Oracle, tclsh 8.6.14:
+//
+//   puts {$y}                       -> $y          (y undefined; no error)
+//   puts {\n set y 1\n return $y\n} -> the literal three lines
+//   proc f {} { return {$y} }; f    -> $y
+//   catch {puts $y} m; set m        -> can't read "y": no such variable
+
+/// #1237 — a braced data argument reads nothing, so no `W210`.
+#[test]
+fn issue_1237_braced_data_argument_is_not_a_read() {
+    for src in [
+        "proc f {} { puts {$y} }\n",
+        "proc f {} { puts {\n    set y 1\n    return $y\n} }\n",
+        "proc f {} { return {$y} }\n",
+    ] {
+        assert!(
+            !fires(src, D, "W210"),
+            "#1237: a braced word performs no substitution; {src} emitted: {:?}",
+            codes(src, D)
+        );
+    }
+}
+
+/// #1142 — the generic half: an un-hooked / unknown definer's brace-shaped
+/// trailing argument is unclassifiable data, so it must not feed W210 either.
+/// The unknown-command hint stays: abstaining about the *body* says nothing
+/// about the *name*.
+#[test]
+fn issue_1142_unknown_definer_body_is_not_read_before_set() {
+    let src = "proc f {} { mydefiner ::foo::bar {optlist} {\n    set y 1\n    return $y\n} }\n";
+    assert!(
+        !fires(src, D, "W210"),
+        "#1142: an unknown command's braced argument must not be walked as a \
+script in this frame; emitted: {:?}",
+        codes(src, D)
+    );
+    assert!(
+        fires(src, D, "W123"),
+        "#1142: the unknown command itself is still reported; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+/// TN control — a **quoted** word really is substituted, so the genuine
+/// read-before-set survives.  This is the measurement that separates
+/// "classified use" from "stop scanning braced words".
+#[test]
+fn issue_1237_quoted_word_still_fires_w210() {
+    for src in [
+        "proc f {} { puts \"$y\" }\n",
+        "proc f {} { puts $y }\n",
+        "proc f {} { return \"$y\" }\n",
+    ] {
+        assert!(
+            fires(src, D, "W210"),
+            "#1237 TN: a substituted read must still fire; {src} emitted: {:?}",
+            codes(src, D)
+        );
+    }
+}
+
+/// FP guard — a braced word whose role has the callee evaluate it **in this
+/// frame** is a real read: `expr`'s expression and `if`'s condition/body both
+/// substitute against the caller's variables.
+#[test]
+fn issue_1237_in_frame_braced_roles_still_read() {
+    for src in [
+        "proc f {} { expr {$p + $q} }\n",
+        "proc f {} { if {$p} { puts hi } }\n",
+        "proc f {} { catch {puts $p} m }\n",
+    ] {
+        assert!(
+            fires(src, D, "W210"),
+            "#1237 FP guard: an Expr/Body-role braced word is evaluated in \
+this frame; {src} emitted: {:?}",
+            codes(src, D)
+        );
+    }
+}
+
+/// FP guard — the use itself must **survive**, classified: dropping it would
+/// resurrect `W211 set but never used` / `W220 never read` on a variable whose
+/// only mention is inside a braced word that may be evaluated later (a
+/// deferred callback, an `eval`, an unknown definer).  This is the guard rail
+/// that rules out the "skip the scan" shortcut, restated for a scalar
+/// alongside `w220_braced_literal_arg_is_not_a_read`'s array element.
+#[test]
+fn issue_1237_quoted_use_still_keeps_the_variable_live() {
+    let src = "proc f {} { set x 1; puts {$x} }\n";
+    assert!(
+        !fires(src, D, "W211") && !fires(src, D, "W220"),
+        "#1237: a quoted mention keeps the store live; emitted: {:?}",
+        codes(src, D)
+    );
+    // TP control: with no mention of any kind the dead store is reported.
+    let unmentioned = "proc f {} { set x 1; puts {$y} }\n";
+    assert!(
+        fires(unmentioned, D, "W211") || fires(unmentioned, D, "W220"),
+        "#1237 TP: an unmentioned store is still dead; emitted: {:?}",
+        codes(unmentioned, D)
+    );
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/rbs.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/rbs.rs
@@ -1887,21 +1887,39 @@ fn issue_1237_braced_data_argument_is_not_a_read() {
 }
 
 /// #1142 — the generic half: an un-hooked / unknown definer's brace-shaped
-/// trailing argument is unclassifiable data, so it must not feed W210 either.
-/// The unknown-command hint stays: abstaining about the *body* says nothing
-/// about the *name*.
+/// trailing argument carries no role information, so a `$y` in it that the
+/// same word `set`s is that body's own local, whichever frame the body ends up
+/// running in — never a read-before-set of the enclosing scope. The
+/// unknown-command hint stays: abstaining about the *body* says nothing about
+/// the *name*.
 #[test]
 fn issue_1142_unknown_definer_body_is_not_read_before_set() {
     let src = "proc f {} { mydefiner ::foo::bar {optlist} {\n    set y 1\n    return $y\n} }\n";
     assert!(
         !fires(src, D, "W210"),
-        "#1142: an unknown command's braced argument must not be walked as a \
-script in this frame; emitted: {:?}",
+        "#1142: an un-hooked definer body's own local is not read-before-set; \
+emitted: {:?}",
         codes(src, D)
     );
     assert!(
         fires(src, D, "W123"),
         "#1142: the unknown command itself is still reported; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+/// TN control for #1142 — a **free** read in an unclassified braced word (one
+/// nothing sets) is still a read: the word may be a script, and a wrapper that
+/// hands it to an `uplevel`-ing worker runs it in this frame, where tclsh
+/// errors on the unset name. Only a registry-*described* command's braced
+/// word (`puts {$y}`) is known data.
+#[test]
+fn issue_1142_unclassified_braced_word_free_read_still_fires() {
+    let src = "proc f {} { mywrapper {puts $notset} }\n";
+    assert!(
+        fires(src, D, "W210"),
+        "#1142 TN: an unclassified braced word may run in this frame; \
+emitted: {:?}",
         codes(src, D)
     );
 }

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -2931,7 +2931,21 @@ impl Analyser {
         if args.len() != 2 {
             return;
         }
-        if tcl_syntax::naming::is_dynamic_word(&args[1]) {
+        // The word arrives with its braces already stripped, so a text-only
+        // dynamism scan mistakes `namespace path {$ns ::a}` for a computed
+        // path and abstains from the whole command. Braces suppress
+        // substitution, so the token kind is the authority (issue #1245).
+        // tclsh-proof: tclsh8.6.14 —
+        //   set nn {::$ns}; namespace eval $nn {}; namespace eval a {}
+        //   namespace eval n { namespace path {::$ns ::a} }
+        //   namespace eval n { namespace path }   ->  {::$ns} ::a
+        // i.e. the entry is a namespace literally *named* `::$ns`; without
+        // that namespace existing the same line errors with
+        // `namespace "$ns" not found in "::n"` — never a variable read.
+        let braced = arg_tokens
+            .get(1)
+            .is_some_and(|tok| tok.kind == TokenType::Str);
+        if tcl_syntax::naming::word_is_dynamic(&args[1], braced) {
             return;
         }
         // The `namespace path` command-resolution tier is an 8.5 addition
@@ -7820,6 +7834,44 @@ mod tests {
             Some(&["inner".to_string()][..]),
             "each namespace path declaration replaces the whole path",
         );
+    }
+
+    /// #1245 — a **braced** path word is literal, not dynamic. The word
+    /// arrives with braces stripped, so a text-only dynamism scan sees the
+    /// `$` and abstains from the whole command; the token kind is the
+    /// authority.
+    ///
+    /// tclsh-proof: tclsh8.6.14 —
+    /// `set nn {::$ns}; namespace eval $nn {}; namespace eval a {}` then
+    /// `namespace eval n { namespace path {::$ns ::a} }` and
+    /// `namespace eval n { namespace path }` answers `{::$ns} ::a` — the
+    /// entry is a namespace literally *named* `::$ns`.
+    #[test]
+    fn handle_namespace_path_records_a_braced_dollar_bearing_word() {
+        let mut a = Analyser::new();
+        a.handle_namespace_path_command(
+            &["path".to_string(), "::$ns ::a".to_string()],
+            &[esc_tok(span(0, 4)), str_tok(span(5, 16))],
+            &[],
+        );
+        assert_eq!(
+            a.namespace_paths.get("::").map(Vec::as_slice),
+            Some(&["::$ns".to_string(), "::a".to_string()][..]),
+            "a braced word never substitutes, so its entries are literal names",
+        );
+    }
+
+    /// TN control — the same text **unbraced** really is a substitution, so
+    /// the command still abstains.
+    #[test]
+    fn handle_namespace_path_still_skips_an_unbraced_dollar_word() {
+        let mut a = Analyser::new();
+        a.handle_namespace_path_command(
+            &["path".to_string(), "$entries".to_string()],
+            &[esc_tok(span(0, 4)), Token::new(TokenType::Var, span(5, 13))],
+            &[],
+        );
+        assert!(a.namespace_paths.is_empty());
     }
 
     /// The query form (no list) and a dynamic list (`$var` / `[cmd]`)

--- a/rust/tcl-compiler/src/dataflow_graph.rs
+++ b/rust/tcl-compiler/src/dataflow_graph.rs
@@ -533,6 +533,7 @@ mod tests {
             uses: Map::new(),
             defs,
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         }
     }
 
@@ -668,6 +669,7 @@ mod tests {
             uses,
             defs: ydefs,
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         });
         ssa.blocks.insert(entry_id, entry);
 

--- a/rust/tcl-compiler/src/def_use.rs
+++ b/rust/tcl-compiler/src/def_use.rs
@@ -34,7 +34,7 @@
 use std::collections::HashMap;
 
 use crate::cfg::{Function as CfgFunction, Terminator};
-use crate::ssa::{SsaFunction, Version};
+use crate::ssa::{SsaFunction, UseClass, Version};
 
 /// How a variable definition was produced.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -82,6 +82,11 @@ pub struct UseSite {
     pub variable: String,
     /// For `PhiIncoming`: the phi's defined version.
     pub phi_version: Version,
+    /// Whether the name is carried only by a brace-quoted word this statement
+    /// does not substitute ([`UseClass::Quoted`]). The use is real for
+    /// liveness — the text may be evaluated later — but is not a read *here*,
+    /// so read-before-set must not claim it (issues #1142, #1237).
+    pub class: UseClass,
 }
 
 /// SSA value key: `(variable name, version)`.
@@ -237,6 +242,7 @@ pub fn build_def_use_chains(ssa: &SsaFunction, cfg: Option<&CfgFunction>) -> Def
                         statement_index: -1,
                         variable: phi_var.clone(),
                         phi_version: phi.version,
+                        class: UseClass::Substituted,
                     },
                 );
             }
@@ -246,6 +252,11 @@ pub fn build_def_use_chains(ssa: &SsaFunction, cfg: Option<&CfgFunction>) -> Def
         for (idx, stmt) in block.statements.iter().enumerate() {
             for (sym, ver) in &stmt.uses {
                 let key = (ssa.var_name(*sym).to_owned(), *ver);
+                let class = if stmt.quoted_uses.contains(sym) {
+                    UseClass::Quoted
+                } else {
+                    UseClass::Substituted
+                };
                 add_use(
                     &mut chains,
                     entry_name,
@@ -256,6 +267,7 @@ pub fn build_def_use_chains(ssa: &SsaFunction, cfg: Option<&CfgFunction>) -> Def
                         statement_index: i32::try_from(idx).unwrap_or(i32::MAX),
                         variable: String::new(),
                         phi_version: 0,
+                        class,
                     },
                 );
             }
@@ -272,16 +284,36 @@ pub fn build_def_use_chains(ssa: &SsaFunction, cfg: Option<&CfgFunction>) -> Def
     DefUseResult { chains }
 }
 
-/// Variable names a terminator reads: a `Branch` condition's vars, or a
-/// `return $x` value's reads.  The latter is recorded so an earlier
-/// overwritten store is a real dead store, not a "truly unused" var.
-fn terminator_read_vars(terminator: Option<&Terminator>) -> Vec<String> {
+/// Variable names a terminator reads, with each name's [`UseClass`]: a
+/// `Branch` condition's vars, or a `return $x` value's reads.  The latter is
+/// recorded so an earlier overwritten store is a real dead store, not a
+/// "truly unused" var.
+///
+/// A **braced** return value is literal — `return {$y}` returns the two
+/// characters `$y` — so its names are [`UseClass::Quoted`]: kept as uses (the
+/// string may still be `eval`-ed by the caller) but never a read here.
+/// tclsh-proof: tclsh8.6.14 — `proc f {} { return {$y} }; puts [f]` prints
+/// `$y` with `y` undefined.
+fn terminator_read_vars(terminator: Option<&Terminator>) -> Vec<(String, UseClass)> {
     match terminator {
-        Some(Terminator::Branch { condition, .. }) => {
-            condition.vars_element_qualified().into_iter().collect()
-        }
-        Some(Terminator::Return { value, expr, .. }) => {
-            let mut set: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        Some(Terminator::Branch { condition, .. }) => condition
+            .vars_element_qualified()
+            .into_iter()
+            .map(|n| (n, UseClass::Substituted))
+            .collect(),
+        Some(Terminator::Return {
+            value,
+            expr,
+            braced,
+            ..
+        }) => {
+            let mut set: std::collections::BTreeMap<String, UseClass> =
+                std::collections::BTreeMap::new();
+            let value_class = if *braced {
+                UseClass::Quoted
+            } else {
+                UseClass::Substituted
+            };
             if let Some(v) = value {
                 set.extend(
                     crate::var_refs::scan_var_ref_forms_braced(v)
@@ -290,12 +322,19 @@ fn terminator_read_vars(terminator: Option<&Terminator>) -> Vec<String> {
                         // reads the variable called `$n` — so its `$` must
                         // survive canonicalisation (issue #1078).
                         .map(|(n, braced)| {
-                            crate::naming::element_var_name_braced(&n, braced).to_string()
+                            (
+                                crate::naming::element_var_name_braced(&n, braced).to_string(),
+                                value_class,
+                            )
                         }),
                 );
             }
             if let Some(e) = expr {
-                set.extend(e.vars_element_qualified());
+                set.extend(
+                    e.vars_element_qualified()
+                        .into_iter()
+                        .map(|n| (n, UseClass::Substituted)),
+                );
             }
             set.into_iter().collect()
         }
@@ -346,7 +385,7 @@ fn add_terminator_uses(
     block: &crate::ssa::SsaBlock,
     cfg_block: &crate::cfg::Block,
 ) {
-    for var_name in terminator_read_vars(cfg_block.terminator.as_ref()) {
+    for (var_name, class) in terminator_read_vars(cfg_block.terminator.as_ref()) {
         let fanned: Vec<String> = ssa
             .var_names()
             .iter()
@@ -374,6 +413,7 @@ fn add_terminator_uses(
                     statement_index: -1,
                     variable: String::new(),
                     phi_version: 0,
+                    class,
                 },
             );
         }
@@ -443,6 +483,7 @@ mod tests {
             uses: HashMap::new(),
             defs,
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         }
     }
 
@@ -472,6 +513,7 @@ mod tests {
             uses: u,
             defs: d,
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         }
     }
 

--- a/rust/tcl-compiler/src/gvn.rs
+++ b/rust/tcl-compiler/src/gvn.rs
@@ -1996,6 +1996,7 @@ mod tests {
             uses: HashMap::new(),
             defs: HashMap::new(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         };
         let occurrences =
             statement_occurrences(&registry, &stmt_ssa, "entry", 0, None, &bare_ssa());
@@ -2016,6 +2017,7 @@ mod tests {
             uses: HashMap::new(),
             defs: HashMap::new(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         };
         assert!(
             statement_occurrences(&registry, &stmt_ssa, "entry", 0, None, &bare_ssa()).is_empty()
@@ -2072,6 +2074,7 @@ mod tests {
             uses,
             defs: Map::new(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         }
     }
 
@@ -2305,6 +2308,7 @@ mod tests {
             uses: HashMap::new(),
             defs: HashMap::new(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         };
         let occ = statement_occurrences(&registry, &stmt_ssa, "entry", 0, None, &bare_ssa());
         assert_eq!(occ.len(), 1);
@@ -2326,6 +2330,7 @@ mod tests {
             uses: HashMap::new(),
             defs: HashMap::new(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         };
         let occ = statement_occurrences(&registry, &stmt_ssa, "entry", 0, None, &bare_ssa());
         assert_eq!(occ.len(), 1);
@@ -2571,6 +2576,7 @@ mod tests {
             uses: Map::new(),
             defs,
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         });
         // llength $i — uses map tracks `i`, not `x`.
         let mut uses_i = Map::new();
@@ -2580,6 +2586,7 @@ mod tests {
             uses: uses_i,
             defs: Map::new(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         });
         ssa.blocks.insert(header, h);
         ssa.blocks.insert(body, b);

--- a/rust/tcl-compiler/src/memory_ssa.rs
+++ b/rust/tcl-compiler/src/memory_ssa.rs
@@ -932,6 +932,7 @@ mod tests {
                 uses: HashMap::new(),
                 defs: HashMap::new(),
                 may_defs: std::collections::HashSet::new(),
+                quoted_uses: std::collections::HashSet::new(),
             });
         }
         let entry = BlockId(0);
@@ -1059,6 +1060,7 @@ mod tests {
             uses: HashMap::new(),
             defs: HashMap::new(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         });
         let mut defs = HashMap::new();
         defs.insert(shared, 1);
@@ -1067,6 +1069,7 @@ mod tests {
             uses: HashMap::new(),
             defs,
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         });
         let mut uses = HashMap::new();
         uses.insert(shared, 1);
@@ -1075,6 +1078,7 @@ mod tests {
             uses,
             defs: HashMap::new(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         });
 
         ssa.blocks.insert(
@@ -1123,6 +1127,7 @@ mod tests {
             uses: HashMap::new(),
             defs: HashMap::new(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         });
         let mut defs1 = HashMap::new();
         defs1.insert(shared, 1);
@@ -1131,6 +1136,7 @@ mod tests {
             uses: HashMap::new(),
             defs: defs1,
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         });
         let mut uses = HashMap::new();
         uses.insert(shared, 1);
@@ -1141,6 +1147,7 @@ mod tests {
             uses,
             defs: defs2,
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         });
         ssa.blocks.insert(
             entry,

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -2112,6 +2112,7 @@ mod tests {
             uses: HashMap::new(),
             defs,
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         }
     }
 
@@ -2194,6 +2195,7 @@ mod tests {
             uses: HashMap::new(),
             defs,
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         });
         let mut values: HashMap<ValueKey, LatticeValue> = HashMap::new();
         let escaping: HashSet<String> = HashSet::new();
@@ -2403,6 +2405,7 @@ mod tests {
             uses,
             defs,
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         };
 
         let mut values = HashMap::new();
@@ -2457,6 +2460,7 @@ mod tests {
             uses,
             defs,
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         };
         let mut values = HashMap::new();
         values.insert(
@@ -2503,6 +2507,7 @@ mod tests {
             uses,
             defs,
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         }
     }
 
@@ -2642,6 +2647,7 @@ mod tests {
             uses: HashMap::new(),
             defs,
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         }
     }
 
@@ -2791,6 +2797,7 @@ mod tests {
             uses: HashMap::new(),
             defs,
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         }
     }
 

--- a/rust/tcl-compiler/src/shimmer/expr.rs
+++ b/rust/tcl-compiler/src/shimmer/expr.rs
@@ -48,7 +48,6 @@ use crate::ssa::{SsaFunction, Symbol, ValueKey};
 use crate::types::{TypeKind, TypeLattice};
 
 use super::ShimmerWarning;
-use super::graph::loop_body_blocks;
 use super::hints::is_uncommitted_first_conversion;
 
 /// Find expression-level shimmer warnings for a function.
@@ -68,10 +67,10 @@ pub(crate) fn find_expr_shimmers(
     executable_blocks: &HashSet<BlockId>,
     values: &HashMap<ValueKey, LatticeValue>,
     registry: &tcl_registry::CommandRegistry,
-    commit_facts: &super::commit::CommitFacts,
+    facts: &super::ShimmerFacts,
 ) -> Vec<ShimmerWarning> {
     let mut out = Vec::new();
-    let loop_blocks = loop_body_blocks(cfg);
+    let loop_blocks = &facts.loop_blocks;
     let commit_ctx = super::commit::CommitCtx {
         registry,
         ssa,
@@ -95,7 +94,7 @@ pub(crate) fn find_expr_shimmers(
         let mut seen: HashSet<(Span, String)> = HashSet::new();
         // The committed-intrep walker replays the commit transfer in step with
         // this walk, so each expr's operands see the state just before it.
-        let mut commit_walker = commit_facts.walker(&commit_ctx, block_id);
+        let mut commit_walker = facts.commit.walker(&commit_ctx, block_id);
 
         // 1. SSA statements: AssignExpr and ExprEval.
         for ss in &ssa_block.statements {
@@ -607,12 +606,15 @@ mod tests {
             types: &fu.types,
             values: &fu.sccp.values,
         };
-        let facts = super::super::commit::compute_commit_facts(
-            &fu.cfg,
-            &ctx,
-            &fu.sccp.executable_blocks,
-            &fu.sccp.executable_edges,
-        );
+        let facts = super::super::ShimmerFacts {
+            commit: super::super::commit::compute_commit_facts(
+                &fu.cfg,
+                &ctx,
+                &fu.sccp.executable_blocks,
+                &fu.sccp.executable_edges,
+            ),
+            loop_blocks: super::super::graph::loop_body_blocks(&fu.cfg),
+        };
         find_expr_shimmers(
             &fu.cfg,
             &fu.ssa,

--- a/rust/tcl-compiler/src/shimmer/graph.rs
+++ b/rust/tcl-compiler/src/shimmer/graph.rs
@@ -19,82 +19,156 @@
 //! CFG graph helpers for shimmer analysis.
 //!
 //! - [`loop_body_blocks`] — identify blocks that are part of a cycle.
-//! - [`blocks_reaching`] — reverse-reachability query.
 //! - [`build_successors`] — successor map from CFG terminators.
 
 use std::collections::{HashMap, HashSet};
 
-use crate::cfg::{Function as CfgFunction, Terminator};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::cfg::{BlockId, Function as CfgFunction, Terminator};
 
 /// Return the set of block names that are part of a loop body.
 ///
 /// A block is "in a loop" if it lies on a cycle: there exists a
 /// path from it back to itself via CFG successor edges.
+///
+/// That set is exactly the union of every **non-trivial** strongly-connected
+/// component plus every self-looping block, so one Tarjan pass answers it in
+/// O(V+E).  The previous formulation ran a fresh forward BFS from every block
+/// and a reverse-reachability BFS for each cycle block it found — O(V·(V+E)),
+/// which on a wide loop-free CFG is pure waste (every walk crosses the whole
+/// graph and finds nothing) and took ~69 s on a 2000-branch flat proc
+/// (issue #1240).
 #[must_use]
 pub fn loop_body_blocks(cfg: &CfgFunction) -> HashSet<String> {
-    let succs = build_successors(cfg);
-    let mut loop_blocks: HashSet<String> = HashSet::new();
-    for id in cfg.blocks.keys() {
-        let start = cfg.block_name(*id);
-        if loop_blocks.contains(start) {
-            continue;
-        }
-        let mut visited: HashSet<String> = HashSet::new();
-        let initial = succs.get(start).cloned().unwrap_or_default();
-        let mut frontier = initial;
-        let mut found = false;
-        while let Some(bn) = frontier.pop() {
-            if bn == *start {
-                found = true;
-                break;
-            }
-            if !visited.insert(bn.clone()) {
-                continue;
-            }
-            if let Some(next) = succs.get(&bn) {
-                frontier.extend(next.iter().cloned());
-            }
-        }
-        if found {
-            // A block is on the cycle iff it was visited on the
-            // forward BFS AND it can reach `start` — otherwise
-            // the BFS merely passed through it on a dead-end branch.
-            let reaching = blocks_reaching(&succs, start);
-            loop_blocks.insert(start.to_owned());
-            for name in visited {
-                if reaching.contains(&name) {
-                    loop_blocks.insert(name);
-                }
-            }
-        }
-    }
-    loop_blocks
+    cycle_block_ids(cfg)
+        .into_iter()
+        .map(|id| cfg.block_name(id).to_owned())
+        .collect()
 }
 
-/// Return the set of blocks that can reach `target` via `succs`.
-#[must_use]
-pub(crate) fn blocks_reaching(
-    succs: &HashMap<String, Vec<String>>,
-    target: &str,
-) -> HashSet<String> {
-    // Build reverse edges and BFS back from target.
-    let mut preds: HashMap<String, Vec<String>> = HashMap::new();
-    for (src, sx) in succs {
-        for dst in sx {
-            preds.entry(dst.clone()).or_default().push(src.clone());
+/// `block → successors`, keyed by [`BlockId`], over the same edge set
+/// [`build_successors`] exposes by name: `Goto` and `Branch` targets that are
+/// present in the CFG.  Keeping the graph walk on ids avoids the per-edge name
+/// clone the name-keyed map costs.
+fn successor_ids(cfg: &CfgFunction) -> FxHashMap<BlockId, Vec<BlockId>> {
+    let mut out: FxHashMap<BlockId, Vec<BlockId>> = FxHashMap::default();
+    for (id, block) in &cfg.blocks {
+        let mut s: Vec<BlockId> = Vec::new();
+        match &block.terminator {
+            Some(Terminator::Goto { target, .. }) if cfg.blocks.contains_key(target) => {
+                s.push(*target);
+            }
+            Some(Terminator::Branch {
+                true_target,
+                false_target,
+                ..
+            }) => {
+                if cfg.blocks.contains_key(true_target) {
+                    s.push(*true_target);
+                }
+                if cfg.blocks.contains_key(false_target) {
+                    s.push(*false_target);
+                }
+            }
+            _ => {}
+        }
+        out.insert(*id, s);
+    }
+    out
+}
+
+/// Bookkeeping for the iterative Tarjan walk in [`cycle_block_ids`].
+#[derive(Default)]
+struct TarjanState {
+    /// Discovery index per visited node.
+    index: FxHashMap<BlockId, u32>,
+    /// Lowest discovery index reachable from the node's subtree.
+    low: FxHashMap<BlockId, u32>,
+    /// Nodes currently on the SCC stack.
+    on_stack: FxHashSet<BlockId>,
+    /// The SCC stack itself.
+    stack: Vec<BlockId>,
+    /// Next discovery index to hand out.
+    next_index: u32,
+    /// Blocks found to lie on a cycle.
+    cycle: FxHashSet<BlockId>,
+}
+
+impl TarjanState {
+    /// Start a node: give it a discovery index and push it on the SCC stack.
+    fn discover(&mut self, node: BlockId) {
+        self.index.insert(node, self.next_index);
+        self.low.insert(node, self.next_index);
+        self.next_index += 1;
+        self.stack.push(node);
+        self.on_stack.insert(node);
+    }
+
+    /// Relax `node`'s low-link against `candidate`.
+    fn relax(&mut self, node: BlockId, candidate: u32) {
+        let low = self.low.entry(node).or_insert(candidate);
+        *low = (*low).min(candidate);
+    }
+
+    /// Close `node`: when it roots an SCC, pop the component and record its
+    /// members as cycle blocks if the component is non-trivial (more than one
+    /// member, or a single member with a self-edge).
+    fn close(&mut self, node: BlockId, has_self_edge: bool) {
+        if self.low.get(&node) != self.index.get(&node) {
+            return;
+        }
+        let mut members: Vec<BlockId> = Vec::new();
+        while let Some(popped) = self.stack.pop() {
+            self.on_stack.remove(&popped);
+            members.push(popped);
+            if popped == node {
+                break;
+            }
+        }
+        if members.len() > 1 || has_self_edge {
+            self.cycle.extend(members);
         }
     }
-    let mut visited: HashSet<String> = HashSet::new();
-    let mut frontier: Vec<String> = vec![target.to_owned()];
-    while let Some(bn) = frontier.pop() {
-        if !visited.insert(bn.clone()) {
+}
+
+/// Every block on a cycle, in one O(V+E) Tarjan strongly-connected-components
+/// pass.  Iterative (an explicit `(node, next edge)` stack) so a long CFG
+/// chain cannot blow the native stack.
+fn cycle_block_ids(cfg: &CfgFunction) -> FxHashSet<BlockId> {
+    let succs = successor_ids(cfg);
+    let mut state = TarjanState::default();
+    for &root in cfg.blocks.keys() {
+        if state.index.contains_key(&root) {
             continue;
         }
-        if let Some(ps) = preds.get(&bn) {
-            frontier.extend(ps.iter().cloned());
+        state.discover(root);
+        let mut call: Vec<(BlockId, usize)> = vec![(root, 0)];
+        while let Some(&(node, edge)) = call.last() {
+            let edges: &[BlockId] = succs.get(&node).map_or(&[], Vec::as_slice);
+            if edge < edges.len() {
+                call.last_mut().expect("frame just observed").1 += 1;
+                let next = edges[edge];
+                if let Some(&seen) = state.index.get(&next) {
+                    if state.on_stack.contains(&next) {
+                        state.relax(node, seen);
+                    }
+                } else {
+                    state.discover(next);
+                    call.push((next, 0));
+                }
+                continue;
+            }
+            call.pop();
+            let has_self_edge = edges.contains(&node);
+            state.close(node, has_self_edge);
+            if let Some(&(parent, _)) = call.last() {
+                let low = state.low.get(&node).copied().unwrap_or(u32::MAX);
+                state.relax(parent, low);
+            }
         }
     }
-    visited
+    state.cycle
 }
 
 /// Build a `block → successors` adjacency map from CFG terminators.
@@ -200,15 +274,131 @@ mod tests {
         assert!(loop_body_blocks(&f).is_empty());
     }
 
+    /// A block that merely *leads into* a loop, or that the loop leads out
+    /// to, is not itself on a cycle — the SCC boundary has to be exact, since
+    /// the S100/S101 split keys on it.
     #[test]
-    fn blocks_reaching_walks_predecessors() {
-        let mut succs: HashMap<String, Vec<String>> = HashMap::new();
-        succs.insert("a".into(), vec!["b".into()]);
-        succs.insert("b".into(), vec!["c".into()]);
-        succs.insert("c".into(), Vec::new());
-        let r = blocks_reaching(&succs, "c");
-        assert!(r.contains("a"));
-        assert!(r.contains("b"));
-        assert!(r.contains("c"));
+    fn loop_body_blocks_excludes_preheader_and_exit() {
+        // pre → head → body → head, head → exit
+        let mut f = Function::new("::top", "pre");
+        let pre = f.entry;
+        let head = block(&mut f, "head");
+        let body = block(&mut f, "body");
+        let exit = block(&mut f, "exit");
+        f.blocks.get_mut(&pre).unwrap().terminator = Some(goto(head));
+        f.blocks.get_mut(&head).unwrap().terminator = Some(branch(
+            ExprNode::Literal {
+                text: "1".into(),
+                start: 0,
+                end: 1,
+            },
+            body,
+            exit,
+        ));
+        f.blocks.get_mut(&body).unwrap().terminator = Some(goto(head));
+        f.blocks.get_mut(&exit).unwrap().terminator = Some(Terminator::Return {
+            value: None,
+            span: None,
+            expr: None,
+            braced: false,
+        });
+        let lb = loop_body_blocks(&f);
+        assert!(lb.contains("head"));
+        assert!(lb.contains("body"));
+        assert!(!lb.contains("pre"), "a preheader is not on the cycle");
+        assert!(!lb.contains("exit"), "an exit block is not on the cycle");
+    }
+
+    /// A block branching to itself is a one-member cycle: a trivial SCC with a
+    /// self-edge, which Tarjan must not discard along with the ordinary
+    /// singletons.
+    #[test]
+    fn loop_body_blocks_detects_self_loop() {
+        let mut f = Function::new("::top", "entry");
+        let entry = f.entry;
+        let exit = block(&mut f, "exit");
+        f.blocks.get_mut(&entry).unwrap().terminator = Some(branch(
+            ExprNode::Literal {
+                text: "1".into(),
+                start: 0,
+                end: 1,
+            },
+            entry,
+            exit,
+        ));
+        f.blocks.get_mut(&exit).unwrap().terminator = Some(Terminator::Return {
+            value: None,
+            span: None,
+            expr: None,
+            braced: false,
+        });
+        let lb = loop_body_blocks(&f);
+        assert!(lb.contains("entry"));
+        assert!(!lb.contains("exit"));
+    }
+
+    /// Two independent loops joined by a straight-line block: both cycles are
+    /// found, the joining block is not.
+    #[test]
+    fn loop_body_blocks_handles_two_disjoint_cycles() {
+        let mut f = Function::new("::top", "a");
+        let a = f.entry;
+        let mid = block(&mut f, "mid");
+        let c = block(&mut f, "c");
+        let done = block(&mut f, "done");
+        let cond = || ExprNode::Literal {
+            text: "1".into(),
+            start: 0,
+            end: 1,
+        };
+        f.blocks.get_mut(&a).unwrap().terminator = Some(branch(cond(), a, mid));
+        f.blocks.get_mut(&mid).unwrap().terminator = Some(goto(c));
+        f.blocks.get_mut(&c).unwrap().terminator = Some(branch(cond(), c, done));
+        f.blocks.get_mut(&done).unwrap().terminator = Some(Terminator::Return {
+            value: None,
+            span: None,
+            expr: None,
+            braced: false,
+        });
+        let lb = loop_body_blocks(&f);
+        assert!(lb.contains("a"));
+        assert!(lb.contains("c"));
+        assert!(!lb.contains("mid"));
+        assert!(!lb.contains("done"));
+    }
+
+    /// A wide, loop-free CFG — the shape issue #1240 measured — must come back
+    /// empty, and must do so without walking the graph once per block.
+    #[test]
+    fn loop_body_blocks_wide_acyclic_chain_is_empty() {
+        let mut f = Function::new("::top", "b0");
+        let mut prev = f.entry;
+        for i in 1..200 {
+            let next = block(&mut f, &format!("b{i}"));
+            let side = block(&mut f, &format!("s{i}"));
+            f.blocks.get_mut(&prev).unwrap().terminator = Some(branch(
+                ExprNode::Literal {
+                    text: "1".into(),
+                    start: 0,
+                    end: 1,
+                },
+                side,
+                next,
+            ));
+            f.blocks.get_mut(&side).unwrap().terminator = Some(Terminator::Return {
+                value: None,
+                span: None,
+                expr: None,
+                braced: false,
+            });
+            prev = next;
+        }
+        f.blocks.get_mut(&prev).unwrap().terminator = Some(Terminator::Return {
+            value: None,
+            span: None,
+            expr: None,
+            braced: false,
+        });
+        assert!(loop_body_blocks(&f).is_empty());
     }
 }

--- a/rust/tcl-compiler/src/shimmer/mod.rs
+++ b/rust/tcl-compiler/src/shimmer/mod.rs
@@ -199,8 +199,10 @@ pub(crate) fn find_shimmer_warnings(
         types,
         values,
     };
-    let commit_facts =
-        commit::compute_commit_facts(cfg, &commit_ctx, executable_blocks, executable_edges);
+    let facts = ShimmerFacts {
+        commit: commit::compute_commit_facts(cfg, &commit_ctx, executable_blocks, executable_edges),
+        loop_blocks: graph::loop_body_blocks(cfg),
+    };
     let mut out = Vec::new();
     out.extend(use_site::find_use_site_shimmers(
         cfg,
@@ -209,9 +211,15 @@ pub(crate) fn find_shimmer_warnings(
         executable_blocks,
         registry,
         values,
-        &commit_facts,
+        &facts,
     ));
-    out.extend(phi::find_phi_shimmers(cfg, ssa, types, executable_blocks));
+    out.extend(phi::find_phi_shimmers(
+        cfg,
+        ssa,
+        types,
+        executable_blocks,
+        &facts.loop_blocks,
+    ));
     out.extend(expr::find_expr_shimmers(
         cfg,
         ssa,
@@ -219,9 +227,24 @@ pub(crate) fn find_shimmer_warnings(
         executable_blocks,
         values,
         registry,
-        &commit_facts,
+        &facts,
     ));
     out
+}
+
+/// Per-function facts the three shimmer sub-passes share, each computed once
+/// per CFG rather than once per pass.
+///
+/// The committed-intrep dataflow is consumed by the use-site and expr
+/// detectors; the cycle-block set by all three (it decides the S100 / S101
+/// in-loop split).  Recomputing the latter per pass is what made a
+/// 2000-branch flat proc take ~69 s before the graph walk became a single
+/// Tarjan pass (issue #1240).
+pub(crate) struct ShimmerFacts {
+    /// Committed-intrep facts — see [`commit::compute_commit_facts`].
+    pub commit: commit::CommitFacts,
+    /// Every block that lies on a cycle — see [`graph::loop_body_blocks`].
+    pub loop_blocks: HashSet<String>,
 }
 
 /// Find every shimmer warning across a whole compilation unit.

--- a/rust/tcl-compiler/src/shimmer/phi.rs
+++ b/rust/tcl-compiler/src/shimmer/phi.rs
@@ -39,7 +39,6 @@ use crate::sccp::cfg_order;
 use crate::ssa::{Phi, SsaFunction, Symbol, ValueKey, Version};
 use crate::types::{TypeKind, TypeLattice, TypeShape};
 
-use super::graph::loop_body_blocks;
 use super::span::{def_range_map, phi_span};
 use super::thunking::{
     DefSpanLookup, destructure_foreach_blocks, empty_value_versions, per_loop_body_types,
@@ -238,22 +237,22 @@ pub(crate) fn find_phi_shimmers(
     ssa: &SsaFunction,
     types: &HashMap<ValueKey, TypeLattice>,
     executable_blocks: &HashSet<BlockId>,
+    loop_blocks: &HashSet<String>,
 ) -> Vec<ShimmerWarning> {
-    let loop_blocks = loop_body_blocks(cfg);
     let def_map = def_range_map(ssa);
     let empty_by_name = empty_value_versions(ssa);
     let destructure = destructure_foreach_blocks(cfg);
     // The phi pass uses the *function-wide* loop-body type map (unlike the
     // per-loop S102 thunking pass), built from the whole loop-block set.
     let loop_body_types =
-        per_loop_body_types("", &loop_blocks, &destructure, ssa, types, &empty_by_name);
+        per_loop_body_types("", loop_blocks, &destructure, ssa, types, &empty_by_name);
     let array_syms = super::thunking::array_element_symbols(cfg, ssa);
     let ctx = PhiCtx {
         cfg,
         ssa,
         types,
         empty_by_name: &empty_by_name,
-        loop_blocks: &loop_blocks,
+        loop_blocks,
         loop_body_types: &loop_body_types,
         def_map: &def_map,
         destructure: &destructure,
@@ -299,7 +298,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let warnings = find_phi_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let warnings = find_phi_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &crate::shimmer::graph::loop_body_blocks(&fu.cfg),
+        );
         // Both 1 and 2 are Int — no Shimmered phi expected.
         for w in &warnings {
             if w.command == "<phi>" {
@@ -322,7 +327,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::f").unwrap();
-        let warnings = find_phi_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let warnings = find_phi_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &crate::shimmer::graph::loop_body_blocks(&fu.cfg),
+        );
         assert!(
             !warnings.iter().any(|w| w.variable == "r"),
             "accumulator must not phi-shimmer: {warnings:?}"
@@ -334,7 +345,13 @@ mod tests {
     fn phi_shimmers_empty_source() {
         let cu = CompilationUnit::build_for("", &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let _ = find_phi_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let _ = find_phi_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &crate::shimmer::graph::loop_body_blocks(&fu.cfg),
+        );
     }
 
     /// Array elements collapse onto one SSA symbol, so a phi over `arr` merges
@@ -350,7 +367,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::f").unwrap();
-        let warnings = find_phi_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let warnings = find_phi_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &crate::shimmer::graph::loop_body_blocks(&fu.cfg),
+        );
         assert!(
             !warnings.iter().any(|w| w.variable == "arr"),
             "array-element conflation must not phi-shimmer: {warnings:?}"
@@ -367,7 +390,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let warnings = find_phi_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let warnings = find_phi_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &crate::shimmer::graph::loop_body_blocks(&fu.cfg),
+        );
         assert!(
             warnings.iter().any(|w| w.variable == "y"),
             "plain scalar merge must still phi-shimmer: {warnings:?}"
@@ -384,7 +413,13 @@ mod tests {
                    else { set v 7 }\n}\n";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let warnings = find_phi_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let warnings = find_phi_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &crate::shimmer::graph::loop_body_blocks(&fu.cfg),
+        );
         let w = warnings
             .iter()
             .find(|w| w.variable == "v" && w.in_loop)
@@ -414,7 +449,13 @@ mod tests {
         let src = "set cond [gets stdin]\nif {$cond} { set x 1 } else { set x \"hi\" }\nputs $x";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let warnings = find_phi_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let warnings = find_phi_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &crate::shimmer::graph::loop_body_blocks(&fu.cfg),
+        );
         let w = warnings
             .iter()
             .find(|w| w.variable == "x")
@@ -442,7 +483,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let warnings = find_phi_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let warnings = find_phi_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &crate::shimmer::graph::loop_body_blocks(&fu.cfg),
+        );
         let merge = warnings.iter().find(|w| w.variable == "x");
         assert!(
             merge.is_some(),

--- a/rust/tcl-compiler/src/shimmer/span.rs
+++ b/rust/tcl-compiler/src/shimmer/span.rs
@@ -117,6 +117,7 @@ mod tests {
                 d
             },
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         };
         let block = SsaBlock {
             name: "entry".to_owned(),

--- a/rust/tcl-compiler/src/shimmer/use_site.rs
+++ b/rust/tcl-compiler/src/shimmer/use_site.rs
@@ -48,7 +48,6 @@ use crate::ssa::{SsaFunction, Symbol, ValueKey};
 use crate::types::{TypeKind, TypeLattice};
 use crate::value_shapes::is_pure_var_ref;
 
-use super::graph::loop_body_blocks;
 use super::hints::{
     ShimmerExpectation, arg_shimmer_expectation, arg_shimmer_type, is_numeric_compatible,
     is_uncommitted_first_conversion,
@@ -70,13 +69,13 @@ pub(crate) fn find_use_site_shimmers(
     executable_blocks: &HashSet<BlockId>,
     registry: &CommandRegistry,
     values: &HashMap<ValueKey, LatticeValue>,
-    commit_facts: &super::commit::CommitFacts,
+    facts: &super::ShimmerFacts,
 ) -> Vec<ShimmerWarning> {
-    let loop_blocks = loop_body_blocks(cfg);
+    let loop_blocks = &facts.loop_blocks;
     let def_map = def_range_map(ssa);
     // Loop-invariance facts for the S101→S100 downgrade — only needed when
     // the function has at least one loop block.
-    let loop_facts = LoopFacts::compute(cfg, ssa, &loop_blocks, registry);
+    let loop_facts = LoopFacts::compute(cfg, ssa, loop_blocks, registry);
     // Array-base symbols are excluded (FP-SH-13): `normalise_var_name` strips
     // the `(key)` suffix, so `arr(a)` and `arr(b)` share one symbol / version
     // chain. Two individually-stable but different elements then look, at a
@@ -108,7 +107,7 @@ pub(crate) fn find_use_site_shimmers(
         // The committed-intrep walker replays the commit transfer function in
         // step with this walk, so each statement's checks see the state *just
         // before* it executes.
-        let mut commit_walker = commit_facts.walker(&commit_ctx, block_id);
+        let mut commit_walker = facts.commit.walker(&commit_ctx, block_id);
         for ss in &ssa_block.statements {
             let mut ctx = UseSiteCtx {
                 types,
@@ -797,12 +796,15 @@ mod tests {
             types: &fu.types,
             values: &fu.sccp.values,
         };
-        let facts = super::super::commit::compute_commit_facts(
-            &fu.cfg,
-            &ctx,
-            &fu.sccp.executable_blocks,
-            &fu.sccp.executable_edges,
-        );
+        let facts = super::super::ShimmerFacts {
+            commit: super::super::commit::compute_commit_facts(
+                &fu.cfg,
+                &ctx,
+                &fu.sccp.executable_blocks,
+                &fu.sccp.executable_edges,
+            ),
+            loop_blocks: super::super::graph::loop_body_blocks(&fu.cfg),
+        };
         find_use_site_shimmers(
             &fu.cfg,
             &fu.ssa,

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -115,6 +115,48 @@ pub struct SsaStatement {
     /// may-def (old type ⊔ written value); write-sensitive passes (shimmer
     /// oscillation, dead-store) must not count one as a real write.
     pub may_defs: HashSet<Symbol>,
+    /// The subset of [`Self::uses`] that are [`UseClass::Quoted`] — carried
+    /// only by a brace-quoted word this statement does not substitute. The
+    /// use is real for liveness (the text may be evaluated later) but is not
+    /// a read *here*, so read-before-set must ignore it. See [`UseClass`].
+    pub quoted_uses: HashSet<Symbol>,
+}
+
+/// How a statement consumes a variable reference.
+///
+/// Tcl substitutes `$name` in a bare or `"`-quoted word, and never in a
+/// brace-quoted one: `puts {$y}` prints the two characters `$y` and reads
+/// nothing (tclsh 9.0.4 / 8.6.16 agree, and `puts {$y}` succeeds with `y`
+/// undefined). A braced word's contents may still be *evaluated* — by
+/// `expr`, by `if`, by an `after` callback, by an unknown definer — but when
+/// and in which frame is the callee's business.
+///
+/// The two consumers of the use set need opposite conservatism about that
+/// word, which is why the use is classified rather than present-or-absent:
+///
+/// - liveness / dead-store (W211, W220, store elimination) must assume the
+///   word **may** be evaluated, so the use must exist;
+/// - read-before-set (W210) must assume it **may not** be, or may be
+///   evaluated in a frame that binds the name, so it must not claim the read.
+///
+/// Filtering at either end breaks the other: dropping the use resurrects
+/// `W211 set but never used` on `set a(k) 1; puts {$a(k)}`, and recording the
+/// name as a self-initialising def deletes the feeding store outright
+/// (issues #1142, #1237).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UseClass {
+    /// Substituted at this call site, or evaluated by the callee in this same
+    /// frame (an [`ArgRole::Expr`](tcl_registry::ArgRole::Expr) /
+    /// [`ArgRole::Body`](tcl_registry::ArgRole::Body) word). A genuine read,
+    /// here and now.
+    Substituted,
+    /// Carried only inside a brace-quoted word that this call site does not
+    /// substitute and whose role does not have the callee evaluate it in this
+    /// frame (see
+    /// [`ArgRole::braced_word_evaluated_in_frame`](tcl_registry::ArgRole::braced_word_evaluated_in_frame)).
+    /// Kept as a use so liveness stays conservative; ignored by
+    /// read-before-set.
+    Quoted,
 }
 
 /// A CFG basic block in SSA form.
@@ -1152,90 +1194,89 @@ pub(crate) fn structural_body_indices(
 ///
 /// Returns sorted variable names, excluding variables that are defined
 /// by this statement (unless they exhibit read-before-write semantics).
+///
+/// Names only, dropping the [`UseClass`] classification — use
+/// [`uses_of_classified`] when the caller must distinguish a substituted read
+/// from one carried by an unevaluated brace-quoted word.
 pub fn uses_of(
     stmt: &Statement,
     scanner: &mut VarReferenceScanner,
     registry: &CommandRegistry,
 ) -> Vec<String> {
-    let mut vars_found: BTreeSet<String> = BTreeSet::new();
+    uses_of_classified(stmt, scanner, registry)
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect()
+}
+
+/// The classified reads a statement scan accumulates: names substituted (or
+/// evaluated in this frame) by the statement, and names mentioned only inside
+/// a brace-quoted word it passes through verbatim.
+#[derive(Default)]
+struct ClassifiedUses {
+    substituted: BTreeSet<String>,
+    quoted: BTreeSet<String>,
+}
+
+/// [`uses_of`] with each name's [`UseClass`].
+///
+/// A name reached by both a substituted word and a brace-quoted one is
+/// [`UseClass::Substituted`] — the definite read wins.
+pub fn uses_of_classified(
+    stmt: &Statement,
+    scanner: &mut VarReferenceScanner,
+    registry: &CommandRegistry,
+) -> Vec<(String, UseClass)> {
+    let mut found = ClassifiedUses::default();
     let mut reads_own_def: BTreeSet<String> = BTreeSet::new();
 
     match stmt {
         Statement::ExprEval { expr, .. } => {
-            vars_found.extend(expr_vars_for(scanner, expr));
+            found.substituted.extend(expr_vars_for(scanner, expr));
         }
 
         Statement::AssignConst { .. }
         | Statement::AssignExpr { .. }
         | Statement::AssignValue { .. }
         | Statement::Incr { .. } => {
-            uses_in_assignment(stmt, scanner, registry, &mut vars_found, &mut reads_own_def);
+            uses_in_assignment(
+                stmt,
+                scanner,
+                registry,
+                &mut found.substituted,
+                &mut reads_own_def,
+            );
         }
 
         Statement::Call { .. } => {
-            uses_in_call(stmt, scanner, registry, &mut vars_found, &mut reads_own_def);
+            uses_in_call(stmt, scanner, registry, &mut found, &mut reads_own_def);
         }
 
-        Statement::Return { value, expr, .. } => {
-            if let Some(v) = value {
-                vars_found.extend(scanner.scan_word(v, registry));
-            }
-            if let Some(e) = expr {
-                vars_found.extend(expr_vars_for(scanner, e));
-            }
-        }
-
-        Statement::Barrier {
-            command,
-            canonical_command,
-            args,
-            tokens,
+        // A braced return value is literal: `proc f {} { return {$y} }`
+        // returns the two characters `$y` and reads nothing.
+        // tclsh-proof: tclsh8.6.14 — `proc f {} { return {$y} }; puts [f]`
+        // prints `$y` with `y` undefined.
+        Statement::Return {
+            value,
+            expr,
+            braced,
             ..
         } => {
-            scan_command_words(
-                command,
-                canonical_command.as_deref(),
-                args,
-                tokens.as_ref(),
-                scanner,
-                registry,
-                &mut vars_found,
-            );
-            // Scope-alias subcommands (`dict with` / `dict update` — any
-            // resolved subcommand with `creates_scope_alias`): the aliased
-            // variable name is a plain string, not a $-substitution, so
-            // scan_word misses it.
-            //
-            // The variable arg carries both VarRead and VarWrite roles.
-            // When barrier defs route through the registry, the same name
-            // appears in `defs` from the VarWrite query.  The closing
-            // filter at line ~553
-            // (`!defs.contains(v) || reads_own_def.contains(v)`) would
-            // then drop the var unless we mark it as reads-own-def here.
-            // Without this, a proc whose only reference to a parameter is
-            // `dict with $param {}` would produce a false unused-parameter
-            // diagnostic.
-            let creates_scope_alias = registry
-                .get(command)
-                .zip(args.first())
-                .and_then(|(spec, sub)| spec.resolve_subcommand(sub))
-                .is_some_and(|sub| sub.creates_scope_alias);
-            if creates_scope_alias {
-                let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
-                for idx in registry.arg_indices_for_role(
-                    command,
-                    &arg_strs,
-                    tcl_registry::ArgRole::VarWrite,
-                ) {
-                    let Some(word) = args.get(idx) else { continue };
-                    let alias_var = normalise_var_name(word);
-                    if !alias_var.is_empty() {
-                        let owned = alias_var.to_owned();
-                        vars_found.insert(owned.clone());
-                        reads_own_def.insert(owned);
-                    }
-                }
+            if let Some(v) = value {
+                let sink = if *braced {
+                    &mut found.quoted
+                } else {
+                    &mut found.substituted
+                };
+                sink.extend(scanner.scan_word(v, registry));
             }
+            if let Some(e) = expr {
+                found.substituted.extend(expr_vars_for(scanner, e));
+            }
+        }
+
+        Statement::Barrier { .. } => {
+            uses_in_barrier(stmt, scanner, registry, &mut found, &mut reads_own_def);
         }
 
         // A non-lowered (glob/regexp/fall-through) `switch` is kept opaque as a
@@ -1248,7 +1289,7 @@ pub fn uses_of(
             default_body,
             ..
         } => {
-            vars_found.extend(switch_reads(
+            found.substituted.extend(switch_reads(
                 subject,
                 arms,
                 default_body.as_ref(),
@@ -1276,10 +1317,82 @@ pub fn uses_of(
     let defs: HashSet<String> = defs_of_with_registry(stmt, Some(registry))
         .into_iter()
         .collect();
-    vars_found
+    // A name reached both ways is a definite read — the quoted mention adds
+    // nothing the substituted one does not already assert.
+    let ClassifiedUses {
+        substituted,
+        mut quoted,
+    } = found;
+    quoted.retain(|v| !substituted.contains(v));
+    substituted
         .into_iter()
-        .filter(|v| !v.is_empty() && (!defs.contains(v) || reads_own_def.contains(v)))
+        .map(|v| (v, UseClass::Substituted))
+        .chain(quoted.into_iter().map(|v| (v, UseClass::Quoted)))
+        .filter(|(v, _)| !v.is_empty() && (!defs.contains(v) || reads_own_def.contains(v)))
         .collect()
+}
+
+/// Variable reads of a [`Statement::Barrier`]: its head + non-body argument
+/// words, plus the scope-alias name a `dict with` / `dict update` unpacks.
+/// Extracted from [`uses_of_classified`].
+fn uses_in_barrier(
+    stmt: &Statement,
+    scanner: &mut VarReferenceScanner,
+    registry: &CommandRegistry,
+    found: &mut ClassifiedUses,
+    reads_own_def: &mut BTreeSet<String>,
+) {
+    let Statement::Barrier {
+        command,
+        canonical_command,
+        args,
+        tokens,
+        ..
+    } = stmt
+    else {
+        return;
+    };
+    scan_command_words(
+        command,
+        canonical_command.as_deref(),
+        args,
+        tokens.as_ref(),
+        scanner,
+        registry,
+        found,
+    );
+    // Scope-alias subcommands (`dict with` / `dict update` — any
+    // resolved subcommand with `creates_scope_alias`): the aliased
+    // variable name is a plain string, not a $-substitution, so
+    // scan_word misses it.
+    //
+    // The variable arg carries both VarRead and VarWrite roles.
+    // When barrier defs route through the registry, the same name
+    // appears in `defs` from the VarWrite query.  The closing
+    // filter in `uses_of_classified`
+    // (`!defs.contains(v) || reads_own_def.contains(v)`) would
+    // then drop the var unless we mark it as reads-own-def here.
+    // Without this, a proc whose only reference to a parameter is
+    // `dict with $param {}` would produce a false unused-parameter
+    // diagnostic.
+    let creates_scope_alias = registry
+        .get(command)
+        .zip(args.first())
+        .and_then(|(spec, sub)| spec.resolve_subcommand(sub))
+        .is_some_and(|sub| sub.creates_scope_alias);
+    if !creates_scope_alias {
+        return;
+    }
+    let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
+    for idx in registry.arg_indices_for_role(command, &arg_strs, tcl_registry::ArgRole::VarWrite) {
+        let Some(word) = args.get(idx) else { continue };
+        let alias_var = normalise_var_name(word);
+        if !alias_var.is_empty() {
+            let owned = alias_var.to_owned();
+            found.substituted.insert(owned.clone());
+            reads_own_def.insert(owned);
+        }
+    }
 }
 
 /// Variable reads of an assignment-style statement (`set` / `set =expr` /
@@ -1355,7 +1468,7 @@ fn uses_in_call(
     stmt: &Statement,
     scanner: &mut VarReferenceScanner,
     registry: &CommandRegistry,
-    vars_found: &mut BTreeSet<String>,
+    found: &mut ClassifiedUses,
     reads_own_def: &mut BTreeSet<String>,
 ) {
     let Statement::Call {
@@ -1378,8 +1491,9 @@ fn uses_in_call(
         tokens.as_ref(),
         scanner,
         registry,
-        vars_found,
+        found,
     );
+    let vars_found = &mut found.substituted;
     if let Some(value) =
         canonical_set_value(command, canonical_command.as_deref(), args, defs, registry)
     {
@@ -1519,9 +1633,9 @@ fn scan_command_words(
     tokens: Option<&CommandTokens>,
     scanner: &mut VarReferenceScanner,
     registry: &CommandRegistry,
-    vars_found: &mut BTreeSet<String>,
+    out: &mut ClassifiedUses,
 ) {
-    vars_found.extend(scanner.scan_word(command, registry));
+    out.substituted.extend(scanner.scan_word(command, registry));
     // Registry lookups use the canonical name when the lowering resolved one
     // (a bare `test` under `namespace import ::tcltest::*` canonicalises to
     // `tcltest::test`; the raw spelling alone is not a registry key).
@@ -1548,11 +1662,36 @@ fn scan_command_words(
                 .filter(|&i| t.arg_is_braced_literal(i))
                 .collect()
         });
+    // Positions whose brace-quoted word the callee still evaluates in *this*
+    // frame — `expr {$a + $b}`, `if {$c} …`. Registry-driven: the set is
+    // every `ArgRole` that answers `braced_word_evaluated_in_frame`, never a
+    // command name. An un-roled position (including every position of a
+    // command the registry does not describe) is absent, so its braced word
+    // is classified `Quoted`.
+    let in_frame_braced: std::collections::HashSet<usize> = {
+        let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
+        tcl_registry::ArgRole::ALL
+            .iter()
+            .filter(|role| role.braced_word_evaluated_in_frame())
+            .flat_map(|&role| registry.arg_indices_for_role(lookup, &arg_strs, role))
+            .collect()
+    };
     for (idx, arg) in args.iter().enumerate() {
         if body_indices.contains(&idx) || name_role_braced.contains(&idx) {
             continue;
         }
-        vars_found.extend(scanner.scan_word(arg, registry));
+        // Tcl substitutes nothing inside `{…}`: the names a braced word
+        // mentions are not read at this call site. They stay recorded as
+        // `Quoted` uses so liveness keeps assuming the text may be evaluated
+        // later, while read-before-set declines to claim the read (#1237).
+        let quoted =
+            !in_frame_braced.contains(&idx) && tokens.is_some_and(|t| t.arg_is_braced_literal(idx));
+        let sink = if quoted {
+            &mut out.quoted
+        } else {
+            &mut out.substituted
+        };
+        sink.extend(scanner.scan_word(arg, registry));
     }
 }
 
@@ -1974,6 +2113,82 @@ impl RenameWalk {
             .collect()
     }
 
+    /// Rename one statement's uses and defs into SSA form: look up each read's
+    /// current version (carrying its [`UseClass`] through to `quoted_uses`),
+    /// then push a fresh version for each def. Extracted from
+    /// [`Self::enter_block`].
+    fn rename_statement(
+        &mut self,
+        stmt: &Statement,
+        frame: &mut RenameFrame,
+        registry: &CommandRegistry,
+        elems: &ArrayElems,
+    ) -> SsaStatement {
+        let classified = uses_of_classified(stmt, &mut self.scanner, registry);
+        let class_of: HashMap<&str, UseClass> = classified
+            .iter()
+            .map(|(name, class)| (name.as_str(), *class))
+            .collect();
+        let uses_list: Vec<String> = classified.iter().map(|(name, _)| name.clone()).collect();
+        let mut uses_map: HashMap<Symbol, Version> = HashMap::new();
+        let mut quoted_uses: HashSet<Symbol> = HashSet::new();
+        // A base read (`$a($i)`, `array get a`) reads every known
+        // constant-keyed element — record their versions so the element chains
+        // are live. A fanned element inherits its base's class: reached only
+        // through a quoted base mention it is no more definite than that
+        // mention.
+        let fanned = expand_uses(&uses_list, &[], elems);
+        for var in uses_list.iter().chain(fanned.iter()) {
+            let v = self.top(var);
+            let sym = self.interner.intern(var);
+            if uses_map.insert(sym, v).is_some() {
+                continue;
+            }
+            let class = class_of.get(var.as_str()).copied().or_else(|| {
+                let base = &var[..var.find('(')?];
+                class_of.get(base).copied()
+            });
+            if class == Some(UseClass::Quoted) {
+                quoted_uses.insert(sym);
+            }
+        }
+
+        let direct_defs = defs_of_with_registry(stmt, Some(registry));
+        let expanded = expand_defs(&direct_defs, elems);
+        // A fanned element def is a *may*-write — the dynamic-key /
+        // whole-array write may have hit it: record a use of its prior version
+        // so type inference joins old and new rather than trusting the written
+        // value alone. (The base refresh of an element write is also a may-def,
+        // but reads nothing — an extra base use would make dead-store analysis
+        // see every element write as an observation of the whole array.)
+        for var in expanded
+            .iter()
+            .filter(|v| !direct_defs.contains(v) && v.contains('('))
+        {
+            let ver = self.top(var);
+            uses_map.entry(self.interner.intern(var)).or_insert(ver);
+        }
+        let mut defs_map: HashMap<Symbol, Version> = HashMap::new();
+        let mut may_defs: HashSet<Symbol> = HashSet::new();
+        for var in expanded {
+            let ver = self.push_new(&var);
+            frame.pushed_vars.push(var.clone());
+            let sym = self.interner.intern(&var);
+            defs_map.insert(sym, ver);
+            if !direct_defs.contains(&var) {
+                may_defs.insert(sym);
+            }
+        }
+
+        SsaStatement {
+            statement: stmt.clone(),
+            uses: uses_map,
+            defs: defs_map,
+            may_defs,
+            quoted_uses,
+        }
+    }
+
     /// Process one block on first visit: assign phi versions, record entry /
     /// exit versions, rename statement uses/defs, and seed successors' phi
     /// incoming edges. Extracted from [`build_ssa`]'s rename walk.
@@ -2018,58 +2233,8 @@ impl RenameWalk {
         if let Some(block) = func.blocks.get(&bn) {
             let stmts: Vec<Statement> = block.statements.clone();
             for stmt in &stmts {
-                let uses_list = uses_of(stmt, &mut self.scanner, registry);
-                let mut uses_map: HashMap<Symbol, Version> = HashMap::new();
-                for var in &uses_list {
-                    let v = self.top(var);
-                    uses_map.insert(self.interner.intern(var), v);
-                }
-                // A base read (`$a($i)`, `array get a`) reads every known
-                // constant-keyed element — record their versions so the
-                // element chains are live.
-                for var in expand_uses(&uses_list, &[], elems) {
-                    let v = self.top(&var);
-                    uses_map.entry(self.interner.intern(&var)).or_insert(v);
-                }
-
-                let direct_defs = defs_of_with_registry(stmt, Some(registry));
-                let expanded = expand_defs(&direct_defs, elems);
-                // A fanned element def is a *may*-write — the dynamic-key /
-                // whole-array write may have hit it: record a use of its
-                // prior version so type inference joins old and new rather
-                // than trusting the written value alone. (The base refresh
-                // of an element write is also a may-def, but reads nothing —
-                // an extra base use would make dead-store analysis see every
-                // element write as an observation of the whole array.)
-                for var in expanded
-                    .iter()
-                    .filter(|v| !direct_defs.contains(v) && v.contains('('))
-                {
-                    let ver = self.top(var);
-                    uses_map.entry(self.interner.intern(var)).or_insert(ver);
-                }
-                let mut defs_map: HashMap<Symbol, Version> = HashMap::new();
-                let mut may_defs: HashSet<Symbol> = HashSet::new();
-                for var in expanded {
-                    let ver = self.push_new(&var);
-                    frame.pushed_vars.push(var.clone());
-                    let sym = self.interner.intern(&var);
-                    defs_map.insert(sym, ver);
-                    if !direct_defs.contains(&var) {
-                        may_defs.insert(sym);
-                    }
-                }
-
-                self.out
-                    .stmt_infos
-                    .get_mut(&bn)
-                    .unwrap()
-                    .push(SsaStatement {
-                        statement: stmt.clone(),
-                        uses: uses_map,
-                        defs: defs_map,
-                        may_defs,
-                    });
+                let info = self.rename_statement(stmt, frame, registry, elems);
+                self.out.stmt_infos.get_mut(&bn).unwrap().push(info);
             }
         }
 
@@ -2309,6 +2474,7 @@ mod tests {
             uses: HashMap::new(),
             defs: HashMap::from([(Symbol(0), 1)]),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         };
         assert_eq!(stmt.defs[&Symbol(0)], 1);
         assert!(stmt.uses.is_empty());
@@ -3115,6 +3281,124 @@ mod tests {
         let uses = uses_of(&stmt, &mut scanner, &reg);
         assert!(uses.contains(&"a".to_string()));
         assert!(uses.contains(&"b".to_string()));
+    }
+
+    // UseClass classification (issues #1142 / #1237)
+
+    /// A `Call` whose argument words are `args`, with per-word token kinds
+    /// derived from the word text: `{…}` lexes to `Str` (brace-quoted, the one
+    /// form Tcl leaves wholly unsubstituted), everything else to `Esc`.
+    fn call_with_words(command: &str, args: &[&str]) -> Statement {
+        let words: Vec<String> = std::iter::once(command.to_owned())
+            .chain(args.iter().map(|a| (*a).to_owned()))
+            .collect();
+        let kinds: Vec<tcl_lexer::TokenType> = words
+            .iter()
+            .map(|w| {
+                if w.starts_with('{') && w.ends_with('}') {
+                    tcl_lexer::TokenType::Str
+                } else {
+                    tcl_lexer::TokenType::Esc
+                }
+            })
+            .collect();
+        let contents: Vec<String> = args
+            .iter()
+            .map(|a| {
+                a.strip_prefix('{')
+                    .and_then(|s| s.strip_suffix('}'))
+                    .unwrap_or(a)
+                    .to_owned()
+            })
+            .collect();
+        Statement::Call {
+            span: Span::new(0, 1),
+            command: command.to_owned(),
+            canonical_command: None,
+            args: contents,
+            defs: Vec::new(),
+            reads: Vec::new(),
+            reads_own_defs: false,
+            safe_on_uninit: false,
+            tokens: Some(crate::ir::CommandTokens {
+                argv: vec![Span::new(0, 1); words.len()],
+                argv_texts: words.clone(),
+                argv_kinds: kinds,
+                single_token_word: vec![true; words.len()],
+                all_tokens: Vec::new(),
+                expand_word: None,
+            }),
+            foreach_groups: None,
+        }
+    }
+
+    fn classify(stmt: &Statement, reg: &CommandRegistry, name: &str) -> Option<UseClass> {
+        let mut scanner = VarReferenceScanner::new(VarScanOptions::default());
+        uses_of_classified(stmt, &mut scanner, reg)
+            .into_iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, class)| class)
+    }
+
+    /// A braced word at a role the callee does **not** evaluate in this frame
+    /// is a `Quoted` use: still recorded (liveness must assume it may be
+    /// evaluated later) but not a read here.
+    /// tclsh-proof: tclsh8.6.14 — `puts {$y}` prints `$y` with `y` undefined.
+    #[test]
+    fn uses_of_classified_braced_data_word_is_quoted() {
+        let reg = default_registry();
+        let stmt = call_with_words("puts", &["{$y}"]);
+        assert_eq!(classify(&stmt, &reg, "y"), Some(UseClass::Quoted));
+    }
+
+    /// The same name in an unbraced word is a definite read.
+    #[test]
+    fn uses_of_classified_unbraced_word_is_substituted() {
+        let reg = default_registry();
+        let stmt = call_with_words("puts", &["$y"]);
+        assert_eq!(classify(&stmt, &reg, "y"), Some(UseClass::Substituted));
+    }
+
+    /// A braced `Expr`-role word really does substitute — `expr` evaluates it
+    /// against the caller's variables — so it stays `Substituted`.
+    #[test]
+    fn uses_of_classified_braced_expr_word_is_substituted() {
+        let reg = default_registry();
+        let stmt = call_with_words("expr", &["{$a + $b}"]);
+        assert_eq!(classify(&stmt, &reg, "a"), Some(UseClass::Substituted));
+        assert_eq!(classify(&stmt, &reg, "b"), Some(UseClass::Substituted));
+    }
+
+    /// A command the registry does not describe has no roles at all, so its
+    /// braced words are unclassifiable data — `Quoted`, never a read (#1142).
+    #[test]
+    fn uses_of_classified_unknown_command_braced_word_is_quoted() {
+        let reg = default_registry();
+        let stmt = call_with_words("mydefiner", &["::foo::bar", "{optlist}", "{return $y}"]);
+        assert_eq!(classify(&stmt, &reg, "y"), Some(UseClass::Quoted));
+    }
+
+    /// A name reached both ways in one statement is a definite read.
+    #[test]
+    fn uses_of_classified_substituted_wins_over_quoted() {
+        let reg = default_registry();
+        let stmt = call_with_words("puts", &["{$y}", "$y"]);
+        assert_eq!(classify(&stmt, &reg, "y"), Some(UseClass::Substituted));
+    }
+
+    /// A braced `return` value is literal.
+    /// tclsh-proof: tclsh8.6.14 — `proc f {} { return {$y} }; puts [f]` prints
+    /// `$y` with `y` undefined.
+    #[test]
+    fn uses_of_classified_braced_return_value_is_quoted() {
+        let reg = default_registry();
+        let stmt = Statement::Return {
+            span: Span::new(0, 15),
+            value: Some("$y".into()),
+            expr: None,
+            braced: true,
+        };
+        assert_eq!(classify(&stmt, &reg, "y"), Some(UseClass::Quoted));
     }
 
     // build_ssa tests

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -150,12 +150,11 @@ pub enum UseClass {
     /// [`ArgRole::Body`](tcl_registry::ArgRole::Body) word). A genuine read,
     /// here and now.
     Substituted,
-    /// Carried only inside a brace-quoted word that this call site does not
-    /// substitute and whose role does not have the callee evaluate it in this
-    /// frame (see
-    /// [`ArgRole::braced_word_evaluated_in_frame`](tcl_registry::ArgRole::braced_word_evaluated_in_frame)).
-    /// Kept as a use so liveness stays conservative; ignored by
-    /// read-before-set.
+    /// Carried only inside a brace-quoted word this call site does not
+    /// substitute and that nothing evaluates in this frame — see
+    /// [`braced_word_class`] for the three kinds a braced word falls into and
+    /// which of them land here. Kept as a use so liveness stays conservative;
+    /// ignored by read-before-set.
     Quoted,
 }
 
@@ -1665,9 +1664,7 @@ fn scan_command_words(
     // Positions whose brace-quoted word the callee still evaluates in *this*
     // frame — `expr {$a + $b}`, `if {$c} …`. Registry-driven: the set is
     // every `ArgRole` that answers `braced_word_evaluated_in_frame`, never a
-    // command name. An un-roled position (including every position of a
-    // command the registry does not describe) is absent, so its braced word
-    // is classified `Quoted`.
+    // command name.
     let in_frame_braced: std::collections::HashSet<usize> = {
         let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
         tcl_registry::ArgRole::ALL
@@ -1676,23 +1673,95 @@ fn scan_command_words(
             .flat_map(|&role| registry.arg_indices_for_role(lookup, &arg_strs, role))
             .collect()
     };
+    // Whether the registry describes this command at all — the difference
+    // between a braced word that is known **data** and one that is merely
+    // *unclassified*. See [`braced_word_class`].
+    let described = registry.get(lookup).is_some();
     for (idx, arg) in args.iter().enumerate() {
         if body_indices.contains(&idx) || name_role_braced.contains(&idx) {
             continue;
         }
-        // Tcl substitutes nothing inside `{…}`: the names a braced word
-        // mentions are not read at this call site. They stay recorded as
-        // `Quoted` uses so liveness keeps assuming the text may be evaluated
-        // later, while read-before-set declines to claim the read (#1237).
-        let quoted =
-            !in_frame_braced.contains(&idx) && tokens.is_some_and(|t| t.arg_is_braced_literal(idx));
-        let sink = if quoted {
-            &mut out.quoted
-        } else {
-            &mut out.substituted
-        };
-        sink.extend(scanner.scan_word(arg, registry));
+        let braced = tokens.is_some_and(|t| t.arg_is_braced_literal(idx));
+        for name in scanner.scan_word(arg, registry) {
+            let class = braced_word_class(&BracedWordSite {
+                braced,
+                evaluated_in_frame: in_frame_braced.contains(&idx),
+                described,
+                word: arg,
+                name: &name,
+            });
+            match class {
+                UseClass::Quoted => out.quoted.insert(name),
+                UseClass::Substituted => out.substituted.insert(name),
+            };
+        }
     }
+}
+
+/// One `(argument word, name found in it)` pair, with the facts
+/// [`braced_word_class`] decides on.
+struct BracedWordSite<'a> {
+    /// The word is a brace-quoted literal — Tcl substitutes nothing in it.
+    braced: bool,
+    /// The registry gives this position a role whose word the callee
+    /// re-evaluates in the *calling* frame (`Body` / `Expr`).
+    evaluated_in_frame: bool,
+    /// The registry has a `CommandSpec` for this command at all.
+    described: bool,
+    /// The word's text (braces already stripped).
+    word: &'a str,
+    /// The name the scan found inside it.
+    name: &'a str,
+}
+
+/// How this statement consumes `site.name`.
+///
+/// Tcl substitutes nothing inside `{…}`, so a braced word is never read *at*
+/// the call site. What the word then **is** falls into three kinds, and the
+/// answer differs per kind:
+///
+/// - **script, this frame** — `expr {$a + $b}`, `if {$c} …`: the callee
+///   re-evaluates the text where the caller's variables are in scope, so the
+///   name really is read here. [`UseClass::Substituted`].
+/// - **data** — a braced word of a command the registry *describes*, at a
+///   role that never evaluates it: `puts {$y}`, `string match {$pat*} …`,
+///   `lsort -command {cmp $x}`. The registry is the authority that nothing
+///   here evaluates the word in this frame, so there is no read.
+///   [`UseClass::Quoted`] (issue #1237).
+/// - **unclassified** — a braced word of a command the registry does *not*
+///   describe: a user proc, an unknown definer. It may be a script, and if it
+///   is it may run in this frame — a wrapper that hands it to an
+///   `uplevel`-ing worker does exactly that, and tclsh then errors on an
+///   unset name — so the read stands. **Unless** the word sets the name
+///   itself first: then the read is of that script's own local whichever
+///   frame it runs in, which is the shape an un-hooked definer body takes
+///   (issue #1142).
+fn braced_word_class(site: &BracedWordSite<'_>) -> UseClass {
+    if !site.braced || site.evaluated_in_frame {
+        return UseClass::Substituted;
+    }
+    if site.described || word_sets_name(site.word, site.name) {
+        return UseClass::Quoted;
+    }
+    UseClass::Substituted
+}
+
+/// True when `word`, read as a script, contains a top-level `set NAME …` for
+/// `name` — so a `$name` elsewhere in the same word reads that script's own
+/// local rather than a variable of the enclosing frame.
+///
+/// The `Call` twin of the analyser's `barrier_body_locally_sets`, which
+/// recovers the same fact for an opaque `Statement::Barrier` body. Segmenting
+/// is skipped unless the word plausibly holds a `set` at all.
+fn word_sets_name(word: &str, name: &str) -> bool {
+    if !word.contains("set") {
+        return false;
+    }
+    crate::segmenter::segment_commands(word)
+        .into_iter()
+        .filter(|seg| seg.texts.first().map(String::as_str) == Some("set"))
+        .filter_map(|seg| seg.texts.get(1).map(|w| normalise_var_name(w).to_owned()))
+        .any(|target| target == name)
 }
 
 /// Reads of a non-lowered (`-glob`/`-regexp`, or `-exact` with a fall-through
@@ -3369,13 +3438,28 @@ mod tests {
         assert_eq!(classify(&stmt, &reg, "b"), Some(UseClass::Substituted));
     }
 
-    /// A command the registry does not describe has no roles at all, so its
-    /// braced words are unclassifiable data — `Quoted`, never a read (#1142).
+    /// A command the registry does not describe carries no role information,
+    /// so its braced word is *unclassified*: it may be a script that runs in
+    /// this frame. A name the word sets itself is that script's own local —
+    /// the un-hooked definer shape (#1142) — so it is `Quoted`.
     #[test]
-    fn uses_of_classified_unknown_command_braced_word_is_quoted() {
+    fn uses_of_classified_unknown_definer_body_local_is_quoted() {
         let reg = default_registry();
-        let stmt = call_with_words("mydefiner", &["::foo::bar", "{optlist}", "{return $y}"]);
+        let stmt = call_with_words(
+            "mydefiner",
+            &["::foo::bar", "{optlist}", "{set y 1; return $y}"],
+        );
         assert_eq!(classify(&stmt, &reg, "y"), Some(UseClass::Quoted));
+    }
+
+    /// TN control — a name the unclassified word does **not** set stays a
+    /// read: a wrapper handing the word to an `uplevel`-ing worker really does
+    /// evaluate it in this frame, and tclsh errors on the unset name.
+    #[test]
+    fn uses_of_classified_unknown_command_free_read_stays_substituted() {
+        let reg = default_registry();
+        let stmt = call_with_words("wrapper", &["myf", "{puts $myf}"]);
+        assert_eq!(classify(&stmt, &reg, "myf"), Some(UseClass::Substituted));
     }
 
     /// A name reached both ways in one statement is a definite read.

--- a/rust/tcl-compiler/src/taint.rs
+++ b/rust/tcl-compiler/src/taint.rs
@@ -3742,6 +3742,7 @@ mod tests {
             uses: HashMap::new(),
             defs: [(x, 1u32)].into_iter().collect(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         };
         ssa.blocks.insert(
             entry,
@@ -3818,12 +3819,14 @@ mod tests {
             uses: HashMap::new(),
             defs: [(x, 1u32)].into_iter().collect(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         };
         let ssa_eval = SsaStatement {
             statement: eval_call,
             uses: [(x, 1u32)].into_iter().collect(),
             defs: HashMap::new(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         };
 
         ssa.blocks.insert(
@@ -3893,6 +3896,7 @@ mod tests {
             uses: HashMap::new(),
             defs: [(ssa.intern_var("x"), 1u32)].into_iter().collect(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         };
         let ssa_sink = SsaStatement {
             statement: sink,
@@ -3902,6 +3906,7 @@ mod tests {
                 .collect(),
             defs: HashMap::new(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         };
         ssa.blocks.insert(
             entry,
@@ -4052,18 +4057,21 @@ mod tests {
             uses: HashMap::new(),
             defs: [(x, 1u32)].into_iter().collect(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         };
         let ssa_s1 = SsaStatement {
             statement: s1,
             uses: [(x, 1u32)].into_iter().collect(),
             defs: [(y, 1u32)].into_iter().collect(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         };
         let ssa_s2 = SsaStatement {
             statement: s2,
             uses: [(y, 1u32)].into_iter().collect(),
             defs: HashMap::new(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         };
         ssa.blocks.insert(
             entry,
@@ -4172,6 +4180,7 @@ mod tests {
                 uses: [(ssa.intern_var("p"), 1u32)].into_iter().collect(),
                 defs: HashMap::new(),
                 may_defs: std::collections::HashSet::new(),
+                quoted_uses: std::collections::HashSet::new(),
             }]
         });
         let d = w.iter().find(|w| w.code == DiagCode::W313).expect("W313");
@@ -4205,12 +4214,14 @@ mod tests {
                 uses: [(base, 0u32)].into_iter().collect(),
                 defs: [(p, 1u32)].into_iter().collect(),
                 may_defs: std::collections::HashSet::new(),
+                quoted_uses: std::collections::HashSet::new(),
             };
             let s1 = SsaStatement {
                 statement: file_call(&["delete", "$p"]),
                 uses: [(p, 1u32)].into_iter().collect(),
                 defs: HashMap::new(),
                 may_defs: std::collections::HashSet::new(),
+                quoted_uses: std::collections::HashSet::new(),
             };
             vec![s0, s1]
         });
@@ -4241,6 +4252,7 @@ mod tests {
                     uses: HashMap::new(),
                     defs: HashMap::new(),
                     may_defs: std::collections::HashSet::new(),
+                    quoted_uses: std::collections::HashSet::new(),
                 }]
             })
             .is_empty()
@@ -4316,6 +4328,7 @@ mod tests {
             uses: HashMap::new(),
             defs: [(x, 1u32)].into_iter().collect(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         };
         ssa.blocks.insert(
             entry,
@@ -4393,12 +4406,14 @@ mod tests {
             uses: HashMap::new(),
             defs: [(pattern, 1u32)].into_iter().collect(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         };
         let ssa_regexp = SsaStatement {
             statement: regexp_call,
             uses: [(pattern, 1u32)].into_iter().collect(),
             defs: HashMap::new(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         };
 
         ssa.blocks.insert(
@@ -4489,12 +4504,14 @@ mod tests {
             uses: HashMap::new(),
             defs: [(pattern, 1u32)].into_iter().collect(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         };
         let ssa_regexp = SsaStatement {
             statement: regexp_call,
             uses: [(pattern, 1u32)].into_iter().collect(),
             defs: HashMap::new(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         };
 
         ssa.blocks.insert(

--- a/rust/tcl-compiler/src/type_infer.rs
+++ b/rust/tcl-compiler/src/type_infer.rs
@@ -1708,6 +1708,7 @@ mod tests {
             uses: HashMap::new(),
             defs: defs.iter().map(|&(n, v)| (ssa.intern_var(n), v)).collect(),
             may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
         }
     }
 

--- a/rust/tcl-lexer/src/lexer.rs
+++ b/rust/tcl-lexer/src/lexer.rs
@@ -269,6 +269,43 @@ impl LexerConfig {
             ..Self::from_grammar(grammar)
         }
     }
+
+    /// [`Self::for_dialect`] for the entry point that lexes a **whole file** —
+    /// the by-name twin of [`Self::for_file_grammar`].
+    ///
+    /// Every LSP provider that re-segments the raw document text has such an
+    /// entry point, and each must use this one rather than
+    /// [`Self::for_dialect`]: otherwise a leading mark lexes into the first
+    /// word, so the first command's semantic token spans the mark, its body
+    /// fold is lost (the marked name resolves to no registry command), and its
+    /// document links / inlay hints / references miss (issue #1243).
+    #[must_use]
+    pub fn for_file_dialect(dialect: &str) -> Self {
+        Self::for_file_grammar(tcl_dialect::DialectProfile::by_name(dialect).grammar)
+    }
+
+    /// This config demoted to a **nested** re-lex: identical, except a leading
+    /// byte-order mark is ordinary content again.
+    ///
+    /// A whole-file config may skip a mark at byte 0 because that is the
+    /// script's prologue; a mark at the head of a nested body slice, an `eval`
+    /// argument, or a VM string is data. A provider that threads one config
+    /// through its own body recursion calls this below the top level, so the
+    /// file rule cannot leak into a nested slice (issue #1243).
+    #[must_use]
+    pub fn nested(self) -> Self {
+        Self {
+            leading_bom: LeadingBom::Content,
+            ..self
+        }
+    }
+
+    /// [`Self::nested`] applied everywhere but the top level of a provider's
+    /// own body recursion — the shape those providers all want, stated once.
+    #[must_use]
+    pub fn at_depth(self, depth: u32) -> Self {
+        if depth == 0 { self } else { self.nested() }
+    }
 }
 
 /// Errors produced by the Tcl lexer.

--- a/rust/tcl-lsp-core/src/document_links.rs
+++ b/rust/tcl-lsp-core/src/document_links.rs
@@ -162,7 +162,7 @@ pub fn document_links_in_context(
     for seg in segment_commands_with_offset_and_config(
         source,
         0,
-        tcl_lexer::LexerConfig::for_dialect(dialect),
+        tcl_lexer::LexerConfig::for_file_dialect(dialect),
     ) {
         if seg.texts.is_empty() {
             continue;

--- a/rust/tcl-lsp-core/src/folding.rs
+++ b/rust/tcl-lsp-core/src/folding.rs
@@ -129,7 +129,7 @@ pub fn folding_ranges(
         original_source: source,
         seen: &mut seen,
         ranges: &mut ranges,
-        config: tcl_lexer::LexerConfig::for_dialect(dialect),
+        config: tcl_lexer::LexerConfig::for_file_dialect(dialect),
     };
     collect_body_folds(
         source, 0, 0, None, // top-level body is not inside a definition body
@@ -345,6 +345,8 @@ struct FoldCtx<'a> {
     seen: &'a mut FxHashSet<(u32, u32)>,
     ranges: &'a mut Vec<FoldingRange>,
     /// Dialect lexer config so body re-segmentation honours `{*}` / `}{`.
+    /// Whole-file lexer config; nested body slices take
+    /// [`tcl_lexer::LexerConfig::at_depth`] of it.
     config: tcl_lexer::LexerConfig,
 }
 
@@ -364,7 +366,14 @@ fn collect_body_folds(
     if MAX_FOLD_DEPTH.exceeded(depth) {
         return;
     }
-    let commands = segment_commands_with_offset_and_config(body_source, base_offset, ctx.config);
+    // The whole-file lexer rule (which may skip a leading byte-order mark)
+    // applies at the top level only — a mark at the head of a *nested* body
+    // slice is ordinary data (issue #1243).
+    let commands = segment_commands_with_offset_and_config(
+        body_source,
+        base_offset,
+        ctx.config.at_depth(depth),
+    );
     for cmd in &commands {
         if cmd.argv.is_empty() {
             continue;

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -3078,7 +3078,7 @@ fn infer_var_type_and_taint(
         tcl_compiler::compilation_unit::UnitBuildOptions {
             registry,
             defer_top_level: false,
-            config: tcl_lexer::LexerConfig::for_dialect(profile.name),
+            config: tcl_lexer::LexerConfig::for_file_dialect(profile.name),
             dialect: profile.name,
             external_call_sites: None,
         },

--- a/rust/tcl-lsp-core/src/inlay_hints.rs
+++ b/rust/tcl-lsp-core/src/inlay_hints.rs
@@ -169,7 +169,7 @@ pub fn inlay_hints(
         let segments = tcl_compiler::segmenter::segment_commands_with_offset_and_config(
             source,
             0,
-            tcl_lexer::LexerConfig::for_dialect(dialect),
+            tcl_lexer::LexerConfig::for_file_dialect(dialect),
         );
         for seg in &segments {
             if seg.texts.is_empty() || seg.argv.is_empty() {
@@ -574,7 +574,7 @@ fn collect_format_string_hints(
     let segments = tcl_compiler::segmenter::segment_commands_with_offset_and_config(
         source,
         0,
-        tcl_lexer::LexerConfig::for_dialect(dialect),
+        tcl_lexer::LexerConfig::for_file_dialect(dialect),
     );
     for seg in &segments {
         for (idx, kind) in format_args(seg, registry) {

--- a/rust/tcl-lsp-core/src/irules_context.rs
+++ b/rust/tcl-lsp-core/src/irules_context.rs
@@ -90,8 +90,11 @@ fn scan_when_context(
     depth: u32,
 ) -> Option<String> {
     let mut best = None;
-    let cmds =
-        segment_commands_with_offset_and_config(text, base, LexerConfig::for_dialect(dialect));
+    let cmds = segment_commands_with_offset_and_config(
+        text,
+        base,
+        LexerConfig::for_file_dialect(dialect).at_depth(depth),
+    );
     for cmd in &cmds {
         if cmd.texts.first().map(String::as_str) != Some("when") || cmd.texts.len() < 2 {
             continue;
@@ -144,8 +147,11 @@ fn collect_when_events(
     if MAX_WHEN_SCAN_DEPTH.exceeded(depth) {
         return;
     }
-    let cmds =
-        segment_commands_with_offset_and_config(text, base, LexerConfig::for_dialect(dialect));
+    let cmds = segment_commands_with_offset_and_config(
+        text,
+        base,
+        LexerConfig::for_file_dialect(dialect).at_depth(depth),
+    );
     for cmd in &cmds {
         if cmd.texts.first().map(String::as_str) == Some("when") && cmd.texts.len() >= 2 {
             out.push(cmd.texts[1].to_uppercase());

--- a/rust/tcl-lsp-core/src/namespace_symbol.rs
+++ b/rust/tcl-lsp-core/src/namespace_symbol.rs
@@ -1018,16 +1018,17 @@ mod tests {
     }
 
     #[test]
-    fn tn_a_braced_path_word_that_looks_dynamic_is_still_skipped() {
-        // TN / documented limit — braces suppress substitution, so tclsh
-        // reads `$ns` here as a *literal* namespace name.  The handler's
-        // whole-word dynamic gate predates the element split and skips the
-        // command outright; recording nothing is a miss, never a wrong span.
-        let src = "namespace path {$ns ::a}\n";
+    fn tp_a_braced_path_word_that_looks_dynamic_is_still_split() {
+        // TP — braces suppress substitution, so tclsh reads `$ns` here as a
+        // *literal* namespace name (verified on 8.6.14).  The whole-word
+        // dynamic gate used to read the de-braced text and skip the command
+        // outright (issue #1245); it now consults the token kind, so the
+        // elements are recorded at their own spans.
+        let src = "namespace eval ::a {}\nnamespace path {$ns ::a}\n";
         let analysis = analyse(src);
         assert!(
-            analysis.namespace_refs.is_empty(),
-            "{:?}",
+            !namespace_reference_spans(&analysis, "::a").is_empty(),
+            "a braced path word's literal elements are recorded: {:?}",
             analysis.namespace_refs,
         );
     }

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -3038,7 +3038,7 @@ fn definition_body_regions_naming(
     let commands = segment_commands_with_offset_and_config(
         source,
         0,
-        tcl_lexer::LexerConfig::for_dialect(dialect),
+        tcl_lexer::LexerConfig::for_file_dialect(dialect),
     );
     let qualified = tcl_syntax::naming::normalise_qualified_name(&class_def.qualified_name);
     let mut regions: Vec<(usize, usize)> = Vec::new();

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -4618,7 +4618,7 @@ fn collect_script(
     for seg in segment_commands_with_offset_and_config(
         text,
         base_offset,
-        tcl_lexer::LexerConfig::for_dialect(ctx.dialect),
+        tcl_lexer::LexerConfig::for_file_dialect(ctx.dialect).at_depth(depth),
     ) {
         if seg.argv.is_empty() {
             continue;
@@ -5191,7 +5191,7 @@ fn imported_command_aliases(
     for seg in segment_commands_with_offset_and_config(
         source,
         0,
-        tcl_lexer::LexerConfig::for_dialect(dialect),
+        tcl_lexer::LexerConfig::for_file_dialect(dialect),
     ) {
         if seg.texts.len() < 3 || seg.texts[0] != "namespace" || seg.texts[1] != "import" {
             continue;
@@ -5328,7 +5328,7 @@ fn scan_loop_vars(
     for seg in segment_commands_with_offset_and_config(
         text,
         base_offset,
-        tcl_lexer::LexerConfig::for_dialect(dialect),
+        tcl_lexer::LexerConfig::for_file_dialect(dialect).at_depth(depth),
     ) {
         let texts = &seg.texts;
         // `dict for {k v} $coll body` / `dict map {k v} $coll body` — the value
@@ -5447,7 +5447,7 @@ fn scan_snit_handles(
     for seg in segment_commands_with_offset_and_config(
         text,
         base_offset,
-        tcl_lexer::LexerConfig::for_dialect(dialect),
+        tcl_lexer::LexerConfig::for_file_dialect(dialect).at_depth(depth),
     ) {
         let texts = &seg.texts;
         match texts.first().map(String::as_str) {

--- a/rust/tcl-lsp-core/tests/folding.rs
+++ b/rust/tcl-lsp-core/tests/folding.rs
@@ -210,3 +210,51 @@ fn itcl_method_bodies_fold() {
         "the itcl `public method` body must fold: {r:?}",
     );
 }
+
+// Issue #1243 — a leading UTF-8 byte-order mark is a *file* prologue under
+// Tcl 9 (`source` strips it), but ordinary data at the head of a nested body
+// slice. Every provider that re-segments the raw document must draw that split
+// at its own top level.
+//
+// tclsh-proof: tclsh8.6.14 rejects a BOM'd first command
+// (`invalid command name "<BOM>proc"`), which is why the skip is Tcl 9 only.
+
+/// The first command of a BOM'd Tcl 9 file still gets its body fold: the mark
+/// must not lex into the command name (which would resolve to no registry
+/// command, so no `ArgRole::Body` and no fold).
+#[test]
+fn tcl9_leading_bom_does_not_suppress_the_first_body_fold() {
+    let registry = registry_for_dialect("tcl9.0");
+    let src = "\u{FEFF}proc greet {} {\n    return hi\n}\n";
+    let with_bom: Vec<FoldingRange> = folding_ranges(src, "tcl9.0", registry)
+        .into_iter()
+        .filter(|r| r.kind == FoldKind::Region)
+        .collect();
+    let plain: Vec<FoldingRange> = folding_ranges(&src["\u{FEFF}".len()..], "tcl9.0", registry)
+        .into_iter()
+        .filter(|r| r.kind == FoldKind::Region)
+        .collect();
+    assert_eq!(
+        with_bom, plain,
+        "a BOM'd Tcl 9 file folds exactly like the same file without the mark",
+    );
+    assert!(!with_bom.is_empty(), "the proc body is a region fold");
+}
+
+/// TN control — a mark at the head of a **nested** body is data, not a
+/// prologue, so the inner command keeps the mark in its name and draws no
+/// inner fold. The outer proc's own fold is unaffected.
+#[test]
+fn a_bom_inside_a_nested_body_is_data() {
+    let registry = registry_for_dialect("tcl9.0");
+    let src = "proc outer {} {\n    \u{FEFF}proc inner {} {\n        return 1\n    }\n}\n";
+    let regions: Vec<FoldingRange> = folding_ranges(src, "tcl9.0", registry)
+        .into_iter()
+        .filter(|r| r.kind == FoldKind::Region)
+        .collect();
+    assert_eq!(
+        regions.len(),
+        1,
+        "only the outer proc folds — the marked inner head is not `proc`; got {regions:?}",
+    );
+}

--- a/rust/tcl-lsp-core/tests/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/tests/semantic_tokens.rs
@@ -1697,3 +1697,63 @@ fn tn_a_dynamic_list_head_keeps_todays_behaviour() {
         "an unresolvable head must not produce a declaration: {b:?}"
     );
 }
+
+/// Issue #1243 — the first command of a BOM'd Tcl 9 file must be tokenised as
+/// if the mark were not there: it is the script prologue `source` strips, not
+/// part of the command name.
+///
+/// tclsh-proof: tclsh8.6.14 rejects a BOM'd first command
+/// (`invalid command name "<BOM>proc"`), which is why the skip is Tcl 9 only.
+#[test]
+fn tcl9_leading_bom_is_not_part_of_the_first_command_token() {
+    let src = "\u{FEFF}proc greet {} { return 1 }\n";
+    let toks = decode(src, "tcl9.0");
+    let head = toks
+        .iter()
+        .find(|t| t.line == 0 && t.ttype == "keyword")
+        .unwrap_or_else(|| panic!("no keyword token on line 0: {toks:?}"));
+    assert_eq!(
+        (head.character, head.length),
+        (1, u32::try_from("proc".len()).expect("fits")),
+        "the head token starts after the mark and spans `proc` alone: {toks:?}",
+    );
+    // The whole stream matches the mark-less file, shifted by the mark's one
+    // UTF-16 unit — nothing else about the tokenisation changes.
+    let plain = decode(&src["\u{FEFF}".len()..], "tcl9.0");
+    let shifted: Vec<(u32, u32, u32, &str, u32)> = plain
+        .iter()
+        .map(|t| {
+            (
+                t.line,
+                if t.line == 0 {
+                    t.character + 1
+                } else {
+                    t.character
+                },
+                t.length,
+                t.ttype.as_str(),
+                t.mods,
+            )
+        })
+        .collect();
+    let actual: Vec<(u32, u32, u32, &str, u32)> = toks
+        .iter()
+        .map(|t| (t.line, t.character, t.length, t.ttype.as_str(), t.mods))
+        .collect();
+    assert_eq!(actual, shifted, "BOM'd tokens = mark-less tokens, shifted");
+}
+
+/// TN control — Tcl 8.x's `source` does **not** strip the mark, so the first
+/// command really is named `<BOM>proc` there and must not be highlighted as
+/// the `proc` keyword.
+#[test]
+fn tcl86_leading_bom_stays_part_of_the_first_command_token() {
+    let src = "\u{FEFF}proc greet {} { return 1 }\n";
+    let toks = decode(src, "tcl8.6");
+    assert!(
+        !toks
+            .iter()
+            .any(|t| t.line == 0 && t.character == 1 && t.ttype == "keyword"),
+        "8.x keeps the mark in the command name: {toks:?}",
+    );
+}

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -17075,9 +17075,7 @@ fn is_skipped_scan_dir(path: &Path) -> bool {
 /// find-references / rename-safety silently missed them (finding idx 10 /
 /// idx 27) — even though opening the file directly worked fine, since that
 /// path doesn't go through this filter at all.
-const TCL_SOURCE_EXTENSIONS: &[&str] = &[
-    "tcl", "tk", "itcl", "tm", "irul", "irule", "iapp", "iappimpl", "impl", "exp", "apl", "test",
-];
+use tcl_registry::dialects::TCL_SOURCE_EXTENSIONS;
 
 /// `true` when `path` has a Tcl-family source extension the analyser
 /// can usefully index, so the startup workspace scan picks
@@ -17124,30 +17122,12 @@ fn tcl_source_glob() -> String {
 /// changes produced no watch event, so the index only caught up on the next
 /// full scan or an explicit open (issue #1215).
 ///
-/// Brace-expanding the casings (`{tcl,TCL}`) does not fix it — `Upper.Tcl` is
-/// neither — but a per-character class does, exactly and with no watcher
-/// noise: `[]` character ranges are part of the LSP `GlobPattern` grammar
-/// (and of VS Code's own glob matcher), so this stays one precise
-/// registration rather than a broad `**/*` watch filtered server-side.
-///
-/// The set is the same one [`is_tcl_source`] case-folds, so the watcher and
-/// the predicate now agree by construction.
+/// The set is the same one [`is_tcl_source`] case-folds, and the pattern is
+/// built by the registry so the VS Code activation glob
+/// (`cargo xtask gen-vscode-package`) is the same string by construction
+/// (issue #1242).
 fn tcl_source_watch_glob() -> String {
-    let alternatives: Vec<String> = TCL_SOURCE_EXTENSIONS
-        .iter()
-        .map(|ext| {
-            ext.chars()
-                .map(|c| {
-                    if c.is_ascii_alphabetic() {
-                        format!("[{}{}]", c.to_ascii_lowercase(), c.to_ascii_uppercase())
-                    } else {
-                        c.to_string()
-                    }
-                })
-                .collect::<String>()
-        })
-        .collect();
-    format!("**/*.{{{}}}", alternatives.join(","))
+    tcl_registry::dialects::tcl_source_glob_any_case()
 }
 
 /// Iteratively walk `root`, appending the paths of Tcl source

--- a/rust/tcl-lsp-server/tests/e2e/vscode_parity.rs
+++ b/rust/tcl-lsp-server/tests/e2e/vscode_parity.rs
@@ -319,14 +319,16 @@ fn test_folding_toggle_suppresses_ranges() {
             .is_some_and(|a| !a.is_empty())
     );
     // foldingRange is a plain request with nothing to block on, so it can race
-    // ahead of the async didChangeConfiguration apply. Don't poll the effective
-    // config — instead wait for the message that proves the toggle landed: a
-    // config change reschedules every open doc, so the server re-publishes this
-    // document's diagnostics *after* applying the config. Waiting for that
-    // publish orders the folding request behind the apply.
+    // ahead of the async didChangeConfiguration apply. The barrier is the
+    // effective config itself: `foldingRange` reads the same resolved config
+    // `getEffectiveConfig` reports, so once that reports the feature off, a
+    // later request cannot observe it on. (A version-1 republish is *not* a
+    // barrier here: under the coalesced config reload an early reschedule can
+    // publish before the pulled config lands.)
     lsp.clear_notifications();
-    lsp.apply_configuration(json!({ "features": { "folding": false } }));
-    lsp.await_diagnostics_version(&uri, Some(1), Duration::from_secs(15));
+    lsp.apply_configuration_settle(json!({ "features": { "folding": false } }), &uri, |c| {
+        c.get("features").and_then(|f| f.get("folding")) == Some(&Value::Bool(false))
+    });
     // `null`, never an empty array (issue #1122): VS Code's sticky-scroll
     // model provider accepts a non-null folding model as valid and terminal,
     // so an authoritative empty set would leave sticky scroll permanently

--- a/rust/tcl-registry/src/arg_role.rs
+++ b/rust/tcl-registry/src/arg_role.rs
@@ -287,6 +287,56 @@ impl ArgRole {
             | Self::Keyword => false,
         }
     }
+
+    /// Whether a **brace-quoted** word in this role is nonetheless evaluated —
+    /// as script or as an expression — in the **calling frame**, so a `$name`
+    /// written inside it is a genuine read at this call site.
+    ///
+    /// Tcl performs no substitution on a braced word: `puts {$y}` prints the
+    /// two characters `$y` and reads nothing (tclsh 9.0.4 / 8.6.16 agree).
+    /// Whether the *callee* then evaluates that text, and in whose frame, is
+    /// a per-role fact — which is exactly what this answers, and the one
+    /// place that answers it. `expr {$a + $b}` and `if {$c} {…}` re-evaluate
+    /// their braced word where the caller's variables are in scope, so the
+    /// names inside are read here and now. Everything else — a pattern, a
+    /// format string, a channel, a plain value, a deferred command prefix —
+    /// consumes the word as inert data, or evaluates it later, elsewhere, or
+    /// never.
+    ///
+    /// [`Self::LambdaLiteral`] is `false` on purpose: `apply {{} {puts $x}}`
+    /// runs in a **fresh** frame, so nothing inside it reads the caller's
+    /// `x` (tclsh 9.0.4 / 8.6.16: `set x 7; apply {{} {puts $x}}` errors
+    /// with `can't read "x": no such variable`).
+    ///
+    /// The match is exhaustive on purpose: a new role that carries
+    /// caller-frame code fails to compile until someone decides which side
+    /// it falls on.
+    #[must_use]
+    pub const fn braced_word_evaluated_in_frame(self) -> bool {
+        match self {
+            Self::Body | Self::Expr => true,
+            Self::LambdaLiteral
+            | Self::CommandPrefix
+            | Self::CommandName
+            | Self::CommandNameProbe
+            | Self::VarWrite
+            | Self::VarRead
+            | Self::LoopVarList
+            | Self::ParamList
+            | Self::Name
+            | Self::Pattern
+            | Self::Option
+            | Self::Value
+            | Self::Subcommand
+            | Self::OptionTerminator
+            | Self::FormatString
+            | Self::ScanFormat
+            | Self::Channel
+            | Self::Index
+            | Self::NamespaceName
+            | Self::Keyword => false,
+        }
+    }
 }
 
 /// How many arguments a command appends to a [`ArgRole::CommandPrefix`]
@@ -338,5 +388,38 @@ impl AppendedArity {
     #[must_use]
     pub const fn is_checkable(self) -> bool {
         !matches!(self, Self::Unknown)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ArgRole;
+
+    /// `braced_word_evaluated_in_frame` is the one answer to "does the callee
+    /// substitute this brace-quoted word against the *caller's* variables?".
+    /// Only the two roles that re-evaluate their word as caller-frame code say
+    /// yes; every other role consumes the word as data, defers it, or runs it
+    /// in a fresh frame.
+    ///
+    /// tclsh-proof: tclsh8.6.14 — `puts {$y}` prints `$y` with `y` undefined,
+    /// while `expr {$y}` errors with `can't read "y": no such variable`.
+    #[test]
+    fn braced_word_evaluated_in_frame_is_body_and_expr_only() {
+        let evaluated: Vec<ArgRole> = ArgRole::ALL
+            .iter()
+            .copied()
+            .filter(|r| r.braced_word_evaluated_in_frame())
+            .collect();
+        assert_eq!(evaluated, vec![ArgRole::Body, ArgRole::Expr]);
+    }
+
+    /// A lambda literal carries code, but in a **fresh** frame, so it must not
+    /// claim a read of the caller's variables.
+    /// tclsh-proof: tclsh8.6.14 — `set x 7; apply {{} {puts $x}}` errors with
+    /// `can't read "x": no such variable`.
+    #[test]
+    fn lambda_literal_is_script_bearing_but_not_caller_frame() {
+        assert!(ArgRole::LambdaLiteral.carries_script());
+        assert!(!ArgRole::LambdaLiteral.braced_word_evaluated_in_frame());
     }
 }

--- a/rust/tcl-registry/src/dialects.rs
+++ b/rust/tcl-registry/src/dialects.rs
@@ -314,6 +314,62 @@ pub fn detect_dialect_directive(source: &str) -> Option<&'static str> {
 /// signature line without scanning a large file.
 pub const DETECT_SCAN_BYTES: usize = 8192;
 
+/// Every filename extension that names a Tcl-family **source** file the
+/// toolchain indexes and analyses.
+///
+/// The single source of truth for that set. The LSP server's workspace scan,
+/// watched-file filter and rename filter read it; the `tcl` CLI's directory
+/// discovery reads it; and `cargo xtask gen-vscode-package` generates the VS
+/// Code extension's `workspaceContains` activation glob from it. Each of those
+/// used to keep its own list and two of the three had drifted — the activation
+/// glob named nine of the twelve (issue #1242).
+///
+/// Lower-case by convention; every consumer compares case-insensitively (a
+/// glob consumer folds case per character, since `workspaceContains` matches
+/// case-sensitively on Linux — issue #1215).
+///
+/// This is deliberately **not** the same question as
+/// [`dialect_from_extension`], which maps an extension to a *dialect* and
+/// covers vendor extensions (`.sdc`, `.do`, `.xdc`) that are Tcl but are not
+/// project source we index.
+pub const TCL_SOURCE_EXTENSIONS: &[&str] = &[
+    "tcl", "tk", "itcl", "tm", "irul", "irule", "iapp", "iappimpl", "impl", "exp", "apl", "test",
+];
+
+/// The `**/*.{…}` glob naming exactly [`TCL_SOURCE_EXTENSIONS`], written so it
+/// matches **any casing** — `**/*.{[tT][cC][lL],…}`.
+///
+/// Glob consumers that have no case-insensitivity option match against the
+/// platform file system: case-insensitively on Windows and macOS,
+/// case-**sensitively** on Linux. That is true of LSP
+/// `workspace/didChangeWatchedFiles` registrations (issue #1215) and of VS
+/// Code's `workspaceContains` activation events (issue #1242) alike, so both
+/// build their glob here.
+///
+/// Brace-expanding the casings (`{tcl,TCL}`) does not fix it — `Upper.Tcl` is
+/// neither — but a per-character class does, exactly and with no extra
+/// matches: `[]` ranges are part of the LSP `GlobPattern` grammar and of VS
+/// Code's own glob matcher, so this stays one precise pattern rather than a
+/// broad `**/*` filtered afterwards.
+#[must_use]
+pub fn tcl_source_glob_any_case() -> String {
+    let alternatives: Vec<String> = TCL_SOURCE_EXTENSIONS
+        .iter()
+        .map(|ext| {
+            ext.chars()
+                .map(|c| {
+                    if c.is_ascii_alphabetic() {
+                        format!("[{}{}]", c.to_ascii_lowercase(), c.to_ascii_uppercase())
+                    } else {
+                        c.to_string()
+                    }
+                })
+                .collect::<String>()
+        })
+        .collect();
+    format!("**/*.{{{}}}", alternatives.join(","))
+}
+
 /// The dialect implied by a filename extension, or `None` when the extension
 /// is generic (`.tcl`) or unknown — in which case content heuristics decide.
 #[must_use]

--- a/rust/tcl-syntax/src/naming.rs
+++ b/rust/tcl-syntax/src/naming.rs
@@ -1009,6 +1009,28 @@ pub fn is_dynamic_word(word: &str) -> bool {
     word.contains('$') || word.contains('[')
 }
 
+/// True when a word whose **token kind** is known carries a substitution.
+///
+/// A brace-quoted word never substitutes, so its content is literal by
+/// construction however many `$` or `[` characters it holds: in
+/// `namespace path {$ns ::a}` the first entry is a namespace literally named
+/// `$ns`.  [`is_dynamic_word`] alone re-scans the *reconstructed* content —
+/// braces already stripped — and so mistakes such a word for a dynamic one,
+/// making the whole command abstain (issue #1245).
+///
+/// Only braces suppress substitution: a `"…"`-quoted word does substitute, so
+/// it is scanned like a bare word.
+///
+/// ```
+/// use tcl_syntax::naming::word_is_dynamic;
+/// assert!(word_is_dynamic("$ns ::a", false));
+/// assert!(!word_is_dynamic("$ns ::a", true));
+/// ```
+#[must_use]
+pub fn word_is_dynamic(word: &str, braced_literal: bool) -> bool {
+    !braced_literal && is_dynamic_word(word)
+}
+
 /// The offset-keyed synthetic identity markers the analyser mints for
 /// constructs whose real name is a run-time fact: a dynamic
 /// `namespace eval $ns { … }` scope (`@dynns@<offset>`), a dynamic

--- a/rust/xtask/src/gen_vscode_package.rs
+++ b/rust/xtask/src/gen_vscode_package.rs
@@ -26,6 +26,11 @@
 //! hand-written sections (`General`, `Features`, `Runtime Validation`, `AI`, …)
 //! round-trip untouched and only the `Formatting — *` / `Diagnostics — *` /
 //! `Optimiser` sections change.
+//!
+//! The `workspaceContains:` activation glob is generated the same way, from
+//! `tcl_registry::dialects::TCL_SOURCE_EXTENSIONS` — the same list the server
+//! indexes and watches — so the manifest cannot drift from the extension set
+//! again (issue #1242).
 
 use std::process::ExitCode;
 
@@ -448,10 +453,45 @@ fn rebuild() -> Result<String> {
 
     groups.splice(first..=last, regenerated);
 
+    set_workspace_contains(&mut manifest)?;
+
     // Stock `serde_json` 2-space pretty-printing is byte-identical to the
     // committed manifest (a `to_string_pretty` round-trip is a no-op on the
     // hand-written sections), so no custom serialiser is needed.
     Ok(serde_json::to_string_pretty(&manifest)? + "\n")
+}
+
+/// The one `workspaceContains:` activation event, naming exactly the
+/// extensions the server indexes, case-folded per character.
+///
+/// `workspaceContains` decides whether the extension activates on a workspace
+/// **scan** — without it a workspace whose only Tcl files are `.impl` / `.exp`
+/// / `.apl`, or upper-cased on Linux, gets no index and no workspace symbols
+/// until a file is opened (`onLanguage:` covers only the opened-file path).
+fn workspace_contains_event() -> String {
+    format!(
+        "workspaceContains:{}",
+        tcl_registry::dialects::tcl_source_glob_any_case()
+    )
+}
+
+/// Replace the manifest's `workspaceContains:` activation event with the
+/// generated one, leaving the hand-written `onLanguage:` /
+/// `onChatParticipant:` entries in place and in order.
+fn set_workspace_contains(manifest: &mut Value) -> Result<()> {
+    let events = manifest
+        .get_mut("activationEvents")
+        .and_then(Value::as_array_mut)
+        .context("activationEvents is not an array")?;
+    let generated = Value::String(workspace_contains_event());
+    match events.iter().position(|e| {
+        e.as_str()
+            .is_some_and(|s| s.starts_with("workspaceContains:"))
+    }) {
+        Some(idx) => events[idx] = generated,
+        None => events.push(generated),
+    }
+    Ok(())
 }
 
 /// Write (or, with `check`, verify) the regenerated `package.json`.
@@ -752,6 +792,7 @@ fn fmt_group_docstrings() -> (&'static str, Vec<FmtSetting>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fmt::Write as _;
 
     /// Drift guard: the committed manifest's `tclLsp.*` sections must equal what
     /// the registries render (and every other section round-trips untouched).
@@ -765,6 +806,30 @@ mod tests {
             rebuild().expect("rebuild"),
             "{PACKAGE_JSON} generated sections are stale — run `cargo xtask gen-vscode-package`"
         );
+    }
+
+    /// The activation glob names **every** indexed extension, and does so
+    /// case-insensitively — the two ways the hand-written glob had drifted
+    /// (issue #1242: nine of twelve, single-cased).
+    #[test]
+    fn workspace_contains_event_covers_every_indexed_extension_in_any_case() {
+        let event = workspace_contains_event();
+        for ext in tcl_registry::dialects::TCL_SOURCE_EXTENSIONS {
+            let mut folded = String::new();
+            for c in ext.chars() {
+                let _ = write!(
+                    folded,
+                    "[{}{}]",
+                    c.to_ascii_lowercase(),
+                    c.to_ascii_uppercase()
+                );
+            }
+            assert!(
+                event.contains(&folded),
+                "activation glob omits {ext} (expected {folded}): {event}"
+            );
+        }
+        assert!(event.starts_with("workspaceContains:**/*.{"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **#1142 / #1237 — classified SSA uses.** Root cause for both: `ssa::scan_command_words` scanned every non-`Body` argument word's *de-braced* text, harvesting `$y` reads from words Tcl never substitutes — a false W210 on `puts {set y 1; return $y}` and inside an un-hooked definer's brace-shaped trailing argument (whose own `set` was never recorded as a def). The issue's two shortcut fixes are unsound because liveness and read-before-set need *opposite* conservatism about a braced word, so the fix is a classification carried through the whole use representation: `ssa::UseClass::{Substituted, Quoted}` on `SsaStatement.quoted_uses` and `def_use::UseSite.class`. Liveness/DSE honour every use; the W210/W213 emitters skip `Quoted` ones. The classification is registry data (`ssa::braced_word_class`), in three kinds: a script **evaluated in this frame** (the position's `ArgRole` answers the new `ArgRole::braced_word_evaluated_in_frame` — `Body`/`Expr` only; `LambdaLiteral` deliberately false, it runs in a fresh frame) is a real read; **data** at a role of a registry-described command is `Quoted`; an **unclassified** word (registry doesn't describe the command) stays `Substituted`, because a wrapper handing it to an `uplevel`-ing worker really does run it in this frame — three tclsh-verified true positives depend on that — *unless* the word `set`s the name itself, which makes it that script's own local whichever frame it runs in.
- **#1240 — shimmer loop detection.** `loop_body_blocks` ran a fresh forward BFS from every block plus a predecessor-rebuilding back-BFS per cycle block, `String`-keyed with per-edge clones, recomputed by four passes. Now one iterative Tarjan SCC pass keyed on `BlockId` (cycle blocks = non-trivial SCC members + self-loops — identical semantics, O(V+E)), shared across sub-passes via `ShimmerFacts`. Debug `tcl diag` on a flat N-branch proc: **250: 2.0 → 0.8 s; 500: 6.0 → 1.7 s; 1000: 21.3 → 3.8 s; 2000: 81.6 → 9.0 s**; it no longer appears in gdb samples.
- **#1242 — activation globs.** The hand-written `workspaceContains` glob named 9 of 12 extensions and matched case-sensitively. The list now lives once as `tcl_registry::dialects::TCL_SOURCE_EXTENSIONS` with the case-folding builder beside it; the server, the `tcl` CLI (whose copy had also drifted) and `cargo xtask gen-vscode-package` all read it, gated by a new drift test.
- **#1243 — BOM per entry point.** Only the analyser used `for_file_grammar`. `LexerConfig::for_file_dialect` + `nested()`/`at_depth(depth)` state the split once: whole-file entry points opt in (folding, semantic tokens and its scans, document links, inlay hints, references, hover's CU, the iRules `when` scan) and each depth-aware recursion demotes below depth 0 — a BOM in a nested body stays data.
- **#1245 — braced dynamic gate.** `handle_namespace_path_command` tested `is_dynamic_word(&args[1])`, but the IR word arrives de-braced, so `namespace path {$ns ::a}` looked computed and the command was skipped. New `naming::word_is_dynamic(text, braced_literal)` consults the token kind (tclsh-verified 8.6.14). The `tn_…_is_still_skipped` test #1248 added as a documented limit is inverted to a positive assertion here, since this removes that limit. Remaining `is_dynamic_word(&args[N])` sites audited in #1252.

**#1247 not reproducible** — `fp_depth::bug_dict_update_value_var::…` passes on this branch *and* on unmodified `origin/rust`; the report's base predates the fix. Left open pending the reporter's re-check.

Filed en route: #1250 (`gvn::find_loop_invariants`/`dominates` O(V²) — the residual after #1240), #1251 (`taint::propagate_taints` rebuilds predecessors inside its fixpoint), #1252 (audit remaining `is_dynamic_word` call sites).

## Validation

- [x] Group branch: `cargo test -p tcl-compiler -p tcl-syntax -p tcl-lsp-core` 94 suites 0 failures; `-p tcl-lsp-server` 1265 passed (two load-flakes that pass in isolation, one of which rust has since fixed by awaiting settlement); xtask/registry/lexer/cli-support clean; fmt clean; clippy `--all-targets` clean on every touched crate, no new `#[allow]`s; `make xtask-check` OK.
- [x] Rebased onto post-#1248/#1249 rust; one doc-block conflict in `analyser/handlers.rs` resolved in favour of rust's newer #1113 documentation, with #1245's token-kind gate preserved.
- [ ] Post-rebase suite delegated to CI — local disk is saturated by three parallel group builds; this session is subscribed and will drive any failure to green.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? — Yes: `ssa::UseClass` classification on every use site, `ArgRole::braced_word_evaluated_in_frame`, `ShimmerFacts` shared loop facts, `LexerConfig::for_file_dialect`/`at_depth`, `TCL_SOURCE_EXTENSIONS` as the single extension source.
- [x] If yes, I updated at least one relevant KCS note — contract docs at each definition site; the classification rationale is documented on `braced_word_class`.
- [ ] If I added a new compiler KCS note, I linked it — n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_