### PR TITLE
Package-tier precision: prefer-latest state, duplicate-provider unions, exact patch-level decisions (#1126; survey items on #1104/#1116)

### DIFF
--- a/docs/design/contracts/package-loading.md
+++ b/docs/design/contracts/package-loading.md
@@ -99,10 +99,11 @@ per-dialect spec packs, never as name-matching in a consumer (see
     `[file join $dir x]`, quoted, and braced path forms are handled
     structurally — not by regex. The differential tests verify the output
     against a real `tclsh`.
-12. `resolve_require(name, version, exact)` (and its `resolve(name, version)`
-    shorthand) returns the implementation files of the single declaration
-    C Tcl's `SelectPackage` would evaluate; `select_provider(…)` returns that
-    whole declaration. The selection rule is
+12. `resolve_require(name, version, exact, prefer)` (and its
+    `resolve(name, version)` shorthand, which takes the default `prefer`)
+    returns the implementation files of the declaration C Tcl's
+    `SelectPackage` would evaluate; `select_provider(…)` returns that whole
+    declaration. The selection rule is
     `tcl_dialect::select_package_version`, a port of `generic/tclPkg.c`, and
     is the *only* version-comparison code in the workspace — the bytecode VM's
     `package vcompare` / `vsatisfies` / `require`, the `pkgIndex.tcl` guard
@@ -131,20 +132,31 @@ per-dialect spec packs, never as name-matching in a consumer (see
       without the alpha padding — so `-exact 2.0` accepts `2.0.0` (it compares
       equal) and rejects `2.0a1`.
 
-    Two bounds, both deliberate and both documented at
+    Two further rules, both documented at
     `PackageResolver::resolve_require`:
 
-    - **`package prefer` state is not tracked.** A document that raises the
-      interpreter preference to `latest` changes the answer only when the best
-      acceptable version is a prerelease *and* a stable one is also
-      acceptable; the state is interpreter-global and evaluation-order
-      dependent, so the default is pinned rather than guessed.
+    - **`package prefer` state is tracked per document** (#1126). `package
+      prefer latest` raises the interpreter's selection mode, and
+      `package_resolver::package_prefer_at(analysis, at)` reports the mode in
+      force at a given `package require`, ordered by
+      `indirection::in_effect` — the same "had this statement already run?"
+      rule the import family uses. The state is a **monotone latch**: the
+      default is `stable`, `package prefer stable` is a no-op from the default
+      and silently ineffective after a raise, so "has a raise already run" is
+      the whole state and only the raise is recorded
+      (`AnalysisResult::package_prefer_latest`). A *conditional* raise and a
+      raise in another document both abstain toward the default — the latter
+      for the same reason every cross-file event abstains, no static load
+      order.
     - **Two providers whose versions compare equal.** C Tcl collapses them
-      into one `ifneeded` entry keeping the *last*-sourced script, and the
-      source order is `glob` order — filesystem order, machine-dependent.
-      This keeps the first-discovered provider (discovery sorts
-      subdirectories by name), which is deterministic and lets a
-      workspace-local copy listed first shadow an installed one.
+      into one `ifneeded` entry keeping the *first*'s version string and the
+      *last*-sourced script, and the source order is `glob` order —
+      filesystem order, machine-dependent. `select_provider` therefore keeps
+      the first-discovered declaration (discovery sorts subdirectories by
+      name), which is deterministic and is the one whose version string C Tcl
+      reports; `resolve_require` returns the **union** of the equal-comparing
+      providers' files, because which script survives is unknowable and
+      naming every candidate file beats betting on a filesystem order.
 
     The comparator's per-pair oracle is pinned as a corpus, not regenerated at
     run time: `rust/tcl-dialect/tests/data/package_version_oracle.txt` (the

--- a/docs/design/import-order-source-graph.md
+++ b/docs/design/import-order-source-graph.md
@@ -174,7 +174,62 @@ fn has_run(&self, event: (uri, at, enclosing_body), query: (uri, at, enclosing_b
 ```
 
 — `None` meaning "no static order", which is what the existing `at: None`
-event encoding already expresses. Every current caller then keeps its shape:
-`ExportEvent::at` / `AliasEvent::at` become `Some(_)` in strictly more cases,
-the shared decision functions are untouched, and the abstention table in §1
+event encoding already expresses.
+
+### 6.1 `has_run` alone is not enough — the fold needs *comparability*
+
+That predicate answers the gate, but it is only half of what the shared
+decision functions do, and the other half is why `ExportEvent::at` /
+`AliasEvent::at` cannot simply "become `Some(_)` in more cases".
+
+Both functions are **latest-wins folds**, not filters:
+
+- `namespace_import::exported_at_import_site` keeps two running maxima — the
+  latest visible `-clear` and the latest visible matching pattern — and
+  answers `latest_match > cleared_through`;
+- `namespace_import::alias_live_at` does the same with the latest install and
+  the latest removal.
+
+Both maxima are over a *single* `u32` because every ordered event today lives
+in one document. Two events in different documents that `has_run` both admits
+still have to be ranked against **each other**, and a partial order gives no
+`max`. Feeding cross-document events into the current fold with their own
+file's offsets is exactly the bug PR #1115's finding 1 removed (a forget
+revoking an import because its local offset happened to be larger). So the
+event key has to change shape, not just its `Option`-ness: the order needs
+
+```rust
+fn cmp_run(&self, a: (uri, at, enclosing_body), b: (uri, at, enclosing_body)) -> Option<Ordering>
+```
+
+with `None` — incomparable — folding to "abstain toward answering", the same
+direction `at: None` takes now. `has_run` is then `cmp_run(event, query)`
+against the existing body-leniency rule, so one relation serves both.
+
+### 6.2 The shape that makes `cmp_run` total where it matters
+
+A `source` graph is not merely a partial order over documents — it is a
+**flattened execution sequence**, which is what makes the comparison
+tractable. Sourcing a file inlines its whole body at the `source` statement's
+position, so the DFS of the source forest *is* the run order, and two events
+are comparable whenever they sit in one tree:
+
+- lift each event to its root-ward path `[(root, at₀), (child₁, at₁), …]`,
+  where `atᵢ` is the offset of the `source` statement that entered the next
+  document;
+- take the deepest common document, and compare the two paths' next entries
+  there with the rule already in use for one document
+  (`indirection::in_effect_within` for gating, `namespace_import::load_order`
+  for conflicts);
+- abstain (`None`) when the two events have different roots, when any edge on
+  either path fails the §3.3 soundness gates, or when a document is reachable
+  by two paths — a re-sourced file has no unique position and must not get
+  one.
+
+This keeps the whole order behind one relation and needs no numeric flattening
+(no rank arithmetic to invalidate per generation): the paths are `O(depth)`,
+and depth is the `source` nesting of a real project.
+
+Every current caller then keeps its shape, the shared decision functions gain
+their comparator instead of assuming one, and the abstention table in §1
 shrinks without a second rule appearing anywhere.

--- a/docs/kcs/features/kcs-feature-definition.md
+++ b/docs/kcs/features/kcs-feature-definition.md
@@ -207,14 +207,17 @@ approximately:
   navigates into 2.3, whichever directory was scanned first. With 1.2 and
   1.3b1 it navigates into **1.2** — a prerelease loses to a stable release,
   which is what `package prefer` defaults to. A document that raises the
-  preference with `package prefer latest` is not tracked, so navigation keeps
-  the default answer there.
+  preference with `package prefer latest` above the require gets the other
+  answer: navigation follows it into 1.3b1, exactly as the interpreter would.
+  A raise written below a top-level require, one inside an `if` / `catch`, or
+  one in another file leaves the default in place.
 
   Two providers declaring the *same* version are the one case with no answer
   to match: real Tcl keeps whichever `pkgIndex.tcl` its `glob` sourced last,
-  and that is filesystem order. Navigation takes the first provider in
-  search-path order instead, so it is at least the same on every machine —
-  list a workspace-local copy first and it shadows the installed one.
+  and that is filesystem order. Navigation reads **both** copies rather than
+  betting on one, so the definition is found in whichever really loaded; the
+  release it *reports* is the first provider in search-path order, which is at
+  least the same on every machine.
 
 ### Caller-frame variables
 

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -1240,6 +1240,10 @@ impl Analyser {
                 self.handle_package_provide(cmd_tok, args);
                 false
             }
+            Hook::PackagePrefer => {
+                self.handle_package_prefer(cmd_tok, args);
+                false
+            }
             Hook::Source => {
                 self.handle_source_command(args, arg_tokens, arg_single, scope_path);
                 false

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -5202,6 +5202,39 @@ impl Analyser {
             });
     }
 
+    /// Record ``package prefer latest`` — the one form of ``package
+    /// prefer`` that changes the interpreter's version-selection rule
+    /// (issue #1126 item 1).
+    ///
+    /// ``package prefer`` with no argument is a query, and ``package
+    /// prefer stable`` never changes anything: it is a no-op from the
+    /// default and silently ineffective once ``latest`` has been set
+    /// (see [`crate::signature_scan::types::SignaturePackagePrefer`]
+    /// for the transcript), so neither is recorded and the state is
+    /// the monotone "has a raise already run".
+    ///
+    /// A non-literal mode word (``package prefer $mode``) is skipped
+    /// rather than guessed at — flipping the selection rule on a
+    /// substitution would silently move go-to-definition onto a
+    /// different release of a package.
+    ///
+    /// Dispatched via
+    /// [`tcl_registry::hooks::AnalyserHookId::PackagePrefer`] (stamped
+    /// on `package`'s `prefer` subcommand).  See
+    /// [`Self::handle_package_require`] for the `cmd_tok` anchoring
+    /// convention.
+    pub fn handle_package_prefer(&mut self, cmd_tok: Token, args: &[String]) {
+        if args.len() < 2 || args[1] != "latest" {
+            return;
+        }
+        self.result.package_prefer_latest.push(
+            crate::signature_scan::types::SignaturePackagePrefer {
+                range: cmd_tok.span,
+                conditional: self.conditional_depth > 0,
+            },
+        );
+    }
+
     /// Resolve a command alias to `(target_cmd, effective_args)`.
     ///
     /// Returns `(cmd_name, args)` unchanged if no alias matches;
@@ -11409,6 +11442,34 @@ mod tests {
         let p = &r.package_requires[0];
         assert_eq!(p.name, "-exact");
         assert!(!p.exact);
+    }
+
+    /// `package prefer latest` is recorded; every other spelling of the
+    /// subcommand changes no state and is not (issue #1126 item 1).
+    #[test]
+    fn analyse_records_package_prefer_latest() {
+        let mut a = crate::analyser::Analyser::new();
+        // TP — the one transition that exists.
+        let r = a.analyse("package prefer latest", "tcl");
+        assert_eq!(r.package_prefer_latest.len(), 1);
+        assert!(!r.package_prefer_latest[0].conditional);
+        // TP — inside a guarded branch the record carries `conditional`, so a
+        // consumer can refuse to flip the selection rule on it.
+        let r = a.analyse("catch {package prefer latest}", "tcl");
+        assert_eq!(r.package_prefer_latest.len(), 1);
+        assert!(r.package_prefer_latest[0].conditional);
+        // TN — `stable` is a no-op from the default and silently ineffective
+        // afterwards; the bare form is a query; a dynamic mode word is not
+        // guessed at.
+        for src in [
+            "package prefer stable",
+            "package prefer",
+            "package prefer $mode",
+            "package prefer [mode]",
+        ] {
+            let r = a.analyse(src, "tcl");
+            assert!(r.package_prefer_latest.is_empty(), "{src}");
+        }
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -850,6 +850,9 @@ impl Analyser {
             .extend(r.command_invocations);
         self.result.package_requires.extend(r.package_requires);
         self.result.package_provides.extend(r.package_provides);
+        self.result
+            .package_prefer_latest
+            .extend(r.package_prefer_latest);
         self.result.source_targets.extend(r.source_targets);
         self.result.namespace_imports.extend(r.namespace_imports);
         self.result.namespace_exports.extend(r.namespace_exports);
@@ -1444,6 +1447,9 @@ fn rebase_fragment(frag: &mut BodyFragment, d: u32, line_delta: i32) {
         x.range = shift(x.range, d);
     }
     for x in &mut r.package_provides {
+        x.range = shift(x.range, d);
+    }
+    for x in &mut r.package_prefer_latest {
         x.range = shift(x.range, d);
     }
     for x in &mut r.source_targets {

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -28,7 +28,8 @@ use tcl_lexer::Span;
 
 use crate::signature_scan::types::{
     ParamDef, SignatureCommandAlias, SignatureCommandInvocation, SignatureNamespaceExport,
-    SignatureNamespaceForget, SignatureNamespaceImport, SignaturePackageRequire, SignatureSource,
+    SignatureNamespaceForget, SignatureNamespaceImport, SignaturePackagePrefer,
+    SignaturePackageRequire, SignatureSource,
 };
 
 pub use tcl_core_types::DiagCode;
@@ -1438,6 +1439,11 @@ pub struct AnalysisResult {
     pub package_requires: Vec<SignaturePackageRequire>,
     /// Package provide records (``package provide NAME ?VERSION?``).
     pub package_provides: Vec<PackageProvide>,
+    /// ``package prefer latest`` records — the interpreter-global
+    /// version-selection mode raises, in source order (issue #1126
+    /// item 1).  See [`SignaturePackagePrefer`] for why only the
+    /// raise to `latest` is a record.
+    pub package_prefer_latest: Vec<SignaturePackagePrefer>,
     /// True when a non-literal ``package require`` / ``load`` /
     /// ``auto_path`` mutation has been seen — downstream W123
     /// emission suppresses unknown-command diagnostics under this

--- a/rust/tcl-compiler/src/signature_scan/types.rs
+++ b/rust/tcl-compiler/src/signature_scan/types.rs
@@ -142,6 +142,40 @@ pub struct SignaturePackageRequire {
     pub conditional: bool,
 }
 
+/// A `package prefer latest` invocation — the one form of `package
+/// prefer` that changes anything (issue #1126 item 1).
+///
+/// `package prefer` sets the interpreter-global rule `package
+/// require` uses to choose between the highest acceptable version
+/// and the highest acceptable **stable** one.  Only the raise to
+/// `latest` is recorded, because it is the only transition that
+/// exists:
+///
+/// * the default is `stable`, so `package prefer stable` from the
+///   default changes nothing;
+/// * `latest` is sticky — the manpage says an attempt to set it back
+///   is silently ineffective, and the interpreter agrees.
+///
+// tclsh-proof: on tclsh8.6 (8.6.14) `package prefer` → `stable`;
+// `package prefer latest` → `latest`; a following `package prefer
+// stable` returns `latest` with no error, and `package prefer` still
+// answers `latest`.
+///
+/// So the state at any point is the monotone predicate "has a
+/// `package prefer latest` already run", which is why this record
+/// carries no mode field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignaturePackagePrefer {
+    /// Source span of the `package` command word, matching
+    /// [`SignaturePackageRequire::range`]'s anchoring.
+    pub range: Span,
+    /// `true` when the call is inside a guarded branch (an
+    /// `if`/`elseif`/`else` body, a `catch` script, or a
+    /// `try`/`on`/`trap`/`finally` clause), so a consumer can refuse
+    /// to flip the selection rule on a statement that may not run.
+    pub conditional: bool,
+}
+
 /// A `source` invocation recorded by the signature scanner.
 ///
 /// `is_literal` is `true` when the path argument contains no `$` or

--- a/rust/tcl-dialect/src/lib.rs
+++ b/rust/tcl-dialect/src/lib.rs
@@ -53,7 +53,7 @@ pub use library::{LibraryPin, LibraryVersion, LibraryVersionOverrides, VersionKe
 pub use profile::DialectProfile;
 pub use version::{
     PackagePrefer, TclVersion, Ternary, compare_versions, exact_requirement,
-    requirement_names_patch_level, select_package_version, version_is_stable, version_satisfies,
+    select_package_version, version_is_stable, version_satisfies,
 };
 
 /// Crate version string.

--- a/rust/tcl-dialect/src/version.rs
+++ b/rust/tcl-dialect/src/version.rs
@@ -110,33 +110,57 @@ impl TclVersion {
             .any(|r| version_satisfies(self.version_string(), r.as_ref()))
     }
 
-    /// [`Self::satisfies_any`], but [`Ternary::Inert`] when the answer depends
-    /// on a **patch level** this enum does not model.
+    /// [`Self::satisfies_any`], but [`Ternary::Inert`] when the answer really
+    /// does depend on a **patch level** this enum does not model.
     ///
-    /// `version_string` is `major.minor`, so a requirement naming a third
-    /// component is compared against `9.0` rather than the real `9.0.4`:
-    /// `vsatisfies 9.0.1-` reads as *unsatisfied* even though every shipped
-    /// 9.0 release from 9.0.1 on satisfies it.  That is the one direction that
-    /// turns into a false "this package cannot load" downstream, so a caller
-    /// that can abstain must, rather than take the wrong answer
-    /// ([`requirement_names_patch_level`]).
+    /// [`TclVersion`] names a release *line*, not a build: `V9_0` stands for
+    /// every `9.0.x` the user might be running.  So the honest question is not
+    /// "does `9.0` satisfy this requirement" but "does **every** member of the
+    /// line satisfy it, **none** of them, or some" — a requirement's satisfying
+    /// set is a version interval (`package(n)`: `min` … `max`), and so is a
+    /// release line, so the three answers are decided by two endpoint tests
+    /// plus one containment test (issue #1126 item 3):
+    ///
+    /// | line vs requirement interval | answer |
+    /// |---|---|
+    /// | line ⊆ requirement | [`Ternary::Yes`] |
+    /// | line ∩ requirement = ∅ | [`Ternary::No`] |
+    /// | otherwise | [`Ternary::Inert`] |
+    ///
+    /// This replaces the earlier "any bound with three components is
+    /// undecidable" rule, which abstained on requirements the line's *major*
+    /// alone settles.  Both directions gained precision, and both are
+    /// oracle-checked — `package vsatisfies` takes the candidate version as an
+    /// argument, so one interpreter answers for every line, and
+    /// `tests/data/package_version_oracle.txt` pins the operator itself
+    /// byte-identical on 8.6.14 and 9.0.4:
+    ///
+    // tclsh-proof: `package vsatisfies 8.6.14 9.0.1` → 0, and so does every
+    // other 8.6.x — no member of the 8.6 line can reach a 9.0 bound.
+    /// * `9.0.1` against `V8_6` was `Inert`, is now `No` — no 8.6.x reaches a
+    ///   9.0 bound however the patch level lands.
+    // tclsh-proof: `package vsatisfies 8.6.14 8.6-8.6` → 0 while
+    // `package vsatisfies 8.6 8.6-8.6` → 1: the degenerate (`-exact`) range
+    // accepts only the bound itself, so a patch release of the line fails it.
+    /// * `8.6-8.6` (what `package require -exact 8.6` builds) against `V8_6`
+    ///   was `Yes`, is now `Inert` — `-exact 8.6` accepts `8.6`/`8.6.0` and
+    ///   rejects `8.6.14`, so which it is depends on the running build.
     ///
     /// The OR short-circuits exactly as `package vsatisfies` does: a
-    /// two-component requirement that *is* satisfied settles the whole test
-    /// [`Ternary::Yes`] however many patch-level requirements sit beside it.
-    /// Abstention is deliberately coarse — `9.0.1-` is undecidable even for a
-    /// target the `major.minor` comparison alone would settle (8.6 cannot
-    /// satisfy it) — because "conditional" is the safe direction and the
-    /// precision is not worth a second comparison rule.
+    /// requirement the whole line satisfies settles the test [`Ternary::Yes`]
+    /// however many undecidable ones sit beside it, and `No` is only reached
+    /// when every requirement is refused by every member of the line.
+    ///
+    /// An empty `requirements` list is [`Ternary::No`], matching
+    /// [`Self::satisfies_any`].
     #[must_use]
     pub fn satisfies_any_ternary<S: AsRef<str>>(self, requirements: &[S]) -> Ternary {
         let mut undecidable = false;
         for requirement in requirements {
-            let requirement = requirement.as_ref();
-            if requirement_names_patch_level(requirement) {
-                undecidable = true;
-            } else if version_satisfies(self.version_string(), requirement) {
-                return Ternary::Yes;
+            match self.satisfies_ternary(requirement.as_ref()) {
+                Ternary::Yes => return Ternary::Yes,
+                Ternary::Inert => undecidable = true,
+                Ternary::No => {}
             }
         }
         if undecidable {
@@ -145,26 +169,63 @@ impl TclVersion {
             Ternary::No
         }
     }
+
+    /// One requirement of [`Self::satisfies_any_ternary`], evaluated over the
+    /// whole release line rather than against a single version string.
+    ///
+    /// The line is the closed interval `[M.m, M.m.PATCH_CEILING]`
+    /// ([`PATCH_CEILING`]); `M.m` and `M.m.0` are the same version to the
+    /// comparator (trailing zero components are not significant), so the low
+    /// endpoint is the line's first release.
+    ///
+    /// A requirement's satisfying set is an interval too, which is what makes
+    /// two endpoint tests sufficient for the `Yes` / `Inert` split: if both
+    /// ends of the line satisfy it, so does everything between them.  When
+    /// *neither* end does, the requirement interval is either entirely outside
+    /// the line or strictly inside it, and the discriminator is whether the
+    /// requirement's own **min bound** — always the first version its interval
+    /// admits — falls within the line.
+    ///
+    /// A malformed requirement is [`Ternary::No`], the same conservative
+    /// reading [`version_satisfies`] takes (real Tcl raises instead).
+    fn satisfies_ternary(self, requirement: &str) -> Ternary {
+        let low = self.version_string();
+        let high = format!("{low}.{PATCH_CEILING}");
+        match (
+            version_satisfies(low, requirement),
+            version_satisfies(&high, requirement),
+        ) {
+            (true, true) => Ternary::Yes,
+            (false, false) => {
+                let min = requirement
+                    .split_once('-')
+                    .map_or(requirement, |(min, _)| min);
+                if ParsedVersion::parse(min).is_some()
+                    && compare_versions(min, low) != core::cmp::Ordering::Less
+                    && compare_versions(min, &high) != core::cmp::Ordering::Greater
+                {
+                    // The requirement admits only versions inside this line —
+                    // some patch releases satisfy it, the endpoints do not.
+                    Ternary::Inert
+                } else {
+                    Ternary::No
+                }
+            }
+            _ => Ternary::Inert,
+        }
+    }
 }
 
-/// Whether a `package vsatisfies` requirement names a patch level — three or
-/// more dotted components in either bound (`9.0.1`, `9.0.1-`, `8.6-9.0.2`).
+/// The patch component standing in for "the last release this `major.minor`
+/// line will ever carry", the upper endpoint
+/// [`TclVersion::satisfies_ternary`] tests.
 ///
-/// [`TclVersion`] models `major.minor` releases only, so such a requirement
-/// cannot be evaluated against it faithfully; see
-/// [`TclVersion::satisfies_any_ternary`].
-#[must_use]
-pub fn requirement_names_patch_level(requirement: &str) -> bool {
-    let requirement = requirement.trim();
-    let (lo, hi) = match requirement.split_once('-') {
-        Some((lo, hi)) => (lo.trim(), hi.trim()),
-        None => (requirement, ""),
-    };
-    [lo, hi]
-        .into_iter()
-        .filter(|bound| !bound.is_empty())
-        .any(|bound| bound.split('.').count() >= 3)
-}
+/// Version components compare by digit count first and are never parsed into a
+/// fixed integer width ([`Segment::cmp`]), so a twenty-digit component is
+/// simply larger than every component any requirement or release realistically
+/// writes — including the deeper components of a four-part version
+/// (`8.6.16.2` orders below `8.6.<ceiling>` at the third component).
+const PATCH_CEILING: &str = "99999999999999999999";
 
 // ---------------------------------------------------------------------------
 // The package version comparator — a port of C Tcl's `generic/tclPkg.c`.
@@ -612,7 +673,7 @@ impl Ternary {
 
 #[cfg(test)]
 mod tests {
-    use super::{TclVersion, Ternary};
+    use super::{TclVersion, Ternary, exact_requirement};
 
     #[test]
     fn from_dialect_maps_every_versioned_tcl() {
@@ -695,23 +756,84 @@ mod tests {
         assert!(!TclVersion::V9_0.satisfies_any::<&str>(&[]));
     }
 
-    /// A requirement naming a patch level is undecidable against a
-    /// `major.minor`-only release model.
+    /// TP — a requirement the members of a release line genuinely disagree
+    /// about is undecidable, and only then.
     ///
     /// Oracle (`tclsh9.0`, `[package provide Tcl]` = 9.0.4):
     /// `vsatisfies 9.0.4 9.0.1` = 1, `vsatisfies 9.0.4 9.0.1-` = 1,
     /// `vsatisfies 9.0.4 9.0.9-` = 0 — two shipped 9.0 releases disagree, so
     /// the honest answer for the enum's `9.0` is neither.
     #[test]
-    fn a_patch_level_requirement_is_undecidable() {
-        for requirement in ["9.0.1", "9.0.1-", "9.0-9.0.2", "8.6.0"] {
-            assert!(
-                super::requirement_names_patch_level(requirement),
-                "{requirement}"
-            );
+    fn a_patch_level_requirement_the_line_disagrees_about_is_undecidable() {
+        for requirement in ["9.0.1", "9.0.1-", "9.0-9.0.2"] {
             assert_eq!(
                 TclVersion::V9_0.satisfies_any_ternary(&[requirement]),
                 Ternary::Inert,
+                "{requirement}"
+            );
+        }
+    }
+
+    /// TN — a patch-level requirement the line's *major/minor* already settles
+    /// is decided, not abstained on (issue #1126 item 3).
+    ///
+    /// Oracle (`tclsh8.6`, `[package provide Tcl]` = 8.6.14): `vsatisfies
+    /// 8.6.14 9.0.1` = 0, `vsatisfies 8.6.14 8.6.0` = 1 — and no 8.6.x
+    /// disagrees with either, because the bound sits outside the line in one
+    /// case and below all of it in the other.
+    #[test]
+    fn a_patch_level_requirement_outside_the_line_still_decides() {
+        for requirement in ["9.0.1", "9.0.1-", "9.0.0-9.0.2", "8.7.0"] {
+            assert_eq!(
+                TclVersion::V8_6.satisfies_any_ternary(&[requirement]),
+                Ternary::No,
+                "{requirement}"
+            );
+        }
+        for requirement in ["8.6.0", "8.6.0-", "8.5.1-", "8.6.0-8.7"] {
+            assert_eq!(
+                TclVersion::V8_6.satisfies_any_ternary(&[requirement]),
+                Ternary::Yes,
+                "{requirement}"
+            );
+        }
+    }
+
+    /// FP guard — the degenerate `V-V` range `package require -exact V`
+    /// builds is *not* satisfied by the whole line.
+    ///
+    /// Oracle: `vsatisfies 8.6 8.6-8.6` = 1 but `vsatisfies 8.6.14 8.6-8.6` =
+    /// 0 (the exact form is compared unpadded), so which answer a build gives
+    /// depends on its patch level and the line as a whole abstains — where the
+    /// old `major.minor`-only comparison answered a flat `Yes`.
+    #[test]
+    fn an_exact_requirement_on_the_line_abstains() {
+        assert_eq!(
+            TclVersion::V8_6.satisfies_any_ternary(&[exact_requirement("8.6")]),
+            Ternary::Inert,
+        );
+        // …while an exact requirement naming a *different* line is still a
+        // decided `No`.
+        assert_eq!(
+            TclVersion::V8_6.satisfies_any_ternary(&[exact_requirement("9.0")]),
+            Ternary::No,
+        );
+        // TP — an exact requirement naming one patch release of this line is
+        // undecidable: that build satisfies it, its siblings do not.
+        assert_eq!(
+            TclVersion::V8_6.satisfies_any_ternary(&[exact_requirement("8.6.14")]),
+            Ternary::Inert,
+        );
+    }
+
+    /// TN — a malformed requirement is refused rather than abstained on, the
+    /// same conservative reading [`super::version_satisfies`] takes.
+    #[test]
+    fn a_malformed_requirement_is_not_satisfied() {
+        for requirement in ["", "x", "1-2-3", " 8.6", "8.6.", "8.6c1"] {
+            assert_eq!(
+                TclVersion::V8_6.satisfies_any_ternary(&[requirement]),
+                Ternary::No,
                 "{requirement}"
             );
         }
@@ -722,10 +844,6 @@ mod tests {
     #[test]
     fn two_component_requirements_still_decide() {
         for requirement in ["8.5", "8.5-", "8.5-9.0", "9-", "9"] {
-            assert!(
-                !super::requirement_names_patch_level(requirement),
-                "{requirement}"
-            );
             assert_ne!(
                 TclVersion::V9_0.satisfies_any_ternary(&[requirement]),
                 Ternary::Inert,
@@ -736,11 +854,20 @@ mod tests {
             TclVersion::V9_0.satisfies_any_ternary(&["9.0.1", "9"]),
             Ternary::Yes,
         );
+        // Both requirements name the 9 line, which no 8.6.x reaches — so the
+        // OR is a decided `No`, not the abstention the old three-component
+        // rule produced (issue #1126 item 3).
         assert_eq!(
             TclVersion::V8_6.satisfies_any_ternary(&["9.0.1", "9"]),
-            Ternary::Inert,
+            Ternary::No,
         );
         assert_eq!(TclVersion::V8_6.satisfies_any_ternary(&["9"]), Ternary::No);
+        // …and an undecidable requirement beside a refused one still carries
+        // the whole test to `Inert`.
+        assert_eq!(
+            TclVersion::V8_6.satisfies_any_ternary(&["8.6.14-", "9"]),
+            Ternary::Inert,
+        );
     }
 
     /// Per-rule TP/FP/TN/FN for the four requirement forms, issue #1090.

--- a/rust/tcl-dialect/src/version.rs
+++ b/rust/tcl-dialect/src/version.rs
@@ -97,17 +97,22 @@ impl TclVersion {
         }
     }
 
-    /// Does this release satisfy *any* of `requirements` — the answer
-    /// `package vsatisfies [package provide Tcl] REQ ?REQ …?` gives?
+    /// Does this release **definitely** satisfy any of `requirements` — the
+    /// answer `package vsatisfies [package provide Tcl] REQ ?REQ …?` gives on
+    /// every build of the release line?
+    ///
+    /// The decided half of [`Self::satisfies_any_ternary`]: a requirement the
+    /// line's builds disagree about ([`Ternary::Inert`]) is `false` here, so
+    /// this never claims more than the ternary does.  A caller that needs to
+    /// tell "no" from "cannot say" — every consumer that abstains — must ask
+    /// the ternary.
     ///
     /// An empty `requirements` list is `false`: real `package vsatisfies`
     /// rejects it as a wrong-argument-count error, and no caller here has a
     /// meaningful "satisfies nothing" question to ask.
     #[must_use]
     pub fn satisfies_any<S: AsRef<str>>(self, requirements: &[S]) -> bool {
-        requirements
-            .iter()
-            .any(|r| version_satisfies(self.version_string(), r.as_ref()))
+        self.satisfies_any_ternary(requirements) == Ternary::Yes
     }
 
     /// [`Self::satisfies_any`], but [`Ternary::Inert`] when the answer really

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -4686,6 +4686,41 @@ mod tests {
         }
     }
 
+    /// FN guard pinning issue #1116 item 5: a **dynamic** forget pattern
+    /// revokes nothing, so the alias keeps resolving.
+    ///
+    /// `namespace forget ::src::$name` really does remove the alias when
+    /// `$name` is `p` (oracle for the literal spelling is
+    /// [`Self::a_forget_after_the_import_stops_resolving_the_alias`]) — but
+    /// nothing static says what `$name` holds, and the pattern is a *glob*, so
+    /// a guess would have to be either "revokes `p`" or "revokes everything".
+    /// Both silently drop references the program still has, which is the one
+    /// direction this family never takes: a removal that cannot be proved is
+    /// not applied. The literal prefix (`::src::`) narrows the *source* but
+    /// not the name, so it decides nothing on its own.
+    ///
+    /// The scanner-side twin of this abstention is
+    /// `signature_scan::handlers::handle_namespace_forget_skips_dynamic_patterns`;
+    /// this pins the consequence a consumer actually sees.
+    #[test]
+    fn a_dynamic_forget_pattern_revokes_nothing() {
+        let dynamic = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval dst {\n    namespace forget ::src::$name\n}\n";
+        let analysis = analyse(dynamic);
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::src::p"),
+            "a dynamic forget pattern must not revoke on a guess: {hit:?}"
+        );
+        // Control — the same source with the pattern written literally does
+        // revoke, so the difference is the substitution and nothing else.
+        let literal = dynamic.replace("::src::$name", "::src::p");
+        let analysis = analyse(&literal);
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX).is_none(),
+            "the literal spelling of the same forget still revokes"
+        );
+    }
+
     #[test]
     fn a_simple_forget_pattern_removes_the_alias_too() {
         // TN — `Tcl_ForgetImport`'s unqualified branch: the pattern is matched

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -4690,8 +4690,8 @@ mod tests {
     /// revokes nothing, so the alias keeps resolving.
     ///
     /// `namespace forget ::src::$name` really does remove the alias when
-    /// `$name` is `p` (oracle for the literal spelling is
-    /// [`Self::a_forget_after_the_import_stops_resolving_the_alias`]) — but
+    /// `$name` is `p` (oracle for the literal spelling is on
+    /// `a_forget_after_the_import_stops_resolving_the_alias`) — but
     /// nothing static says what `$name` holds, and the pattern is a *glob*, so
     /// a guess would have to be either "revokes `p`" or "revokes everything".
     /// Both silently drop references the program still has, which is the one

--- a/rust/tcl-lsp-core/src/package_resolver.rs
+++ b/rust/tcl-lsp-core/src/package_resolver.rs
@@ -61,6 +61,53 @@ use std::path::{Path, PathBuf};
 
 use tcl_lexer::{Lexer, Token, TokenType};
 
+pub use tcl_dialect::PackagePrefer;
+
+/// The `package prefer` mode in force at `at` in `analysis` — the
+/// interpreter-global selection rule [`PackageResolver::resolve_require`]
+/// needs (issue #1126 item 1).
+///
+/// `package prefer` is a monotone latch: the default is
+/// [`PackagePrefer::Stable`], a `package prefer latest` raises it, and
+/// nothing lowers it again (`package prefer stable` afterwards is silently
+/// ineffective — transcript on
+/// [`tcl_compiler::signature_scan::types::SignaturePackagePrefer`]). So the
+/// whole state is "has a raise already run at this point", and the answer
+/// needs no fold over an ordered log — just one existence test.
+///
+/// Ordering is [`tcl_compiler::analyser::indirection::in_effect`], the rule
+/// every other "had this statement already run?" question in the resolver
+/// family uses: a top-level raise counts for a `package require` written
+/// anywhere in a proc body of the same file (the file loads before any body
+/// runs), while a raise inside a body does not reach back to a top-level
+/// require.
+///
+/// Two abstentions, both toward the interpreter default:
+///
+/// * a **conditional** raise (inside `if` / `catch` / `try`) is ignored — it
+///   may not run, and flipping the selection rule would move go-to-definition
+///   onto a different release of the package;
+/// * a raise in **another document** is not seen at all. The state is
+///   interpreter-global, so a `package prefer latest` in a file sourced first
+///   really does change this file's answer, but which file runs first is not
+///   a static fact — the same abstention the import family records for every
+///   cross-file event (`docs/design/import-order-source-graph.md`).
+#[must_use]
+pub fn package_prefer_at(
+    analysis: &tcl_compiler::analyser::AnalysisResult,
+    at: u32,
+) -> PackagePrefer {
+    let raised = analysis.package_prefer_latest.iter().any(|p| {
+        !p.conditional
+            && tcl_compiler::analyser::indirection::in_effect(analysis, p.range.start(), at)
+    });
+    if raised {
+        PackagePrefer::Latest
+    } else {
+        PackagePrefer::Stable
+    }
+}
+
 /// Metadata for one `package ifneeded` declaration discovered in a
 /// `pkgIndex.tcl`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -829,11 +876,12 @@ impl PackageResolver {
 
     /// Resolve a `package require NAME ?VERSION?` to its implementation files.
     ///
-    /// Shorthand for [`Self::resolve_require`] with `exact` false; see there
-    /// for the selection rule and its oracle.
+    /// Shorthand for [`Self::resolve_require`] with `exact` false and the
+    /// interpreter's default `package prefer` mode; see there for the
+    /// selection rule and its oracle.
     #[must_use]
     pub fn resolve(&self, name: &str, version: Option<&str>) -> Vec<PathBuf> {
-        self.resolve_require(name, version, false)
+        self.resolve_require(name, version, false, PackagePrefer::default())
     }
 
     /// Resolve a `package require ?-exact? NAME ?VERSION?` to its
@@ -844,7 +892,10 @@ impl PackageResolver {
     /// The selection is [`tcl_dialect::select_package_version`], a port of C
     /// Tcl's `SelectPackage`: among the providers satisfying the requirement,
     /// the **highest** version wins, preferring the highest *stable* one
-    /// (`package prefer`'s default on 8.6.14 and 9.0.4 alike).
+    /// unless `prefer` says otherwise ([`PackagePrefer::Stable`] is the
+    /// interpreter default on 8.6.14 and 9.0.4 alike; the caller derives the
+    /// mode in force at its own `package require` with
+    /// [`package_prefer_at`]).
     ///
     /// | Written | Means | picks, from 1.5 + 2.3 |
     /// |---------|-------|-----------------------|
@@ -862,27 +913,38 @@ impl PackageResolver {
     /// `-exact` with no version is `package require -exact NAME`, which real
     /// Tcl rejects as a syntax error; it is treated here as unconstrained.
     ///
-    /// Two deliberate bounds, both verified against the interpreters:
-    ///
-    /// * **`package prefer` is not tracked.** A document may raise the
-    ///   interpreter's preference to `latest`, which changes the answer only
-    ///   when the best acceptable version is a prerelease and a stable one is
-    ///   also acceptable (`1.2` + `1.3b1` loads 1.2 by default, 1.3b1 under
-    ///   `package prefer latest`). The state is interpreter-global and
-    ///   order-of-evaluation dependent, so this pins the default rather than
-    ///   guessing at it.
-    /// * **Two providers whose versions compare *equal*.** C Tcl collapses
-    ///   them into one `ifneeded` entry, keeping the first registration's
-    ///   version string and the *last* one's script — and the registration
-    ///   order is `glob` order, i.e. filesystem order, so which script that is
-    ///   varies by machine. This keeps the first-discovered provider (with
-    ///   discovery sorted by name), which is deterministic; a workspace-local
-    ///   copy listed first therefore still shadows an installed one.
+    /// **Equal-comparing duplicate providers contribute every one of their
+    /// files** (issue #1126 item 2). C Tcl collapses two `package ifneeded`
+    /// registrations whose versions compare equal (`1.0` / `1.0.0`, `5` /
+    /// `0005`) into one entry, keeping the *first* registration's version
+    /// string and the *last* one's script — and the registration order is
+    /// `glob` order, i.e. filesystem order, so which script that is varies by
+    /// machine and no oracle can pin it. [`Self::select_provider`] keeps the
+    /// first-discovered provider, which is deterministic and is also the one
+    /// whose version string C Tcl reports; this returns the union of the
+    /// equal-comparing providers' files, in discovery order, because the
+    /// question it answers is "which files may hold this package's
+    /// definitions" and the honest answer names all of them rather than
+    /// betting on a filesystem order. Navigation then finds a symbol in
+    /// whichever copy really loaded, instead of silently missing it half the
+    /// time.
     #[must_use]
-    pub fn resolve_require(&self, name: &str, version: Option<&str>, exact: bool) -> Vec<PathBuf> {
-        self.select_provider(name, version, exact)
-            .map(|info| info.source_files.clone())
-            .unwrap_or_default()
+    pub fn resolve_require(
+        &self,
+        name: &str,
+        version: Option<&str>,
+        exact: bool,
+        prefer: PackagePrefer,
+    ) -> Vec<PathBuf> {
+        let mut files: Vec<PathBuf> = Vec::new();
+        for info in self.select_providers(name, version, exact, prefer) {
+            for file in &info.source_files {
+                if !files.contains(file) {
+                    files.push(file.clone());
+                }
+            }
+        }
+        files
     }
 
     /// The single `package ifneeded` declaration a
@@ -890,14 +952,43 @@ impl PackageResolver {
     /// when no scanned provider is acceptable.  The full-fidelity form of
     /// [`Self::resolve_require`], for a caller that needs the chosen release's
     /// version or index file rather than just its sources.
+    ///
+    /// With several providers whose versions compare *equal*, this is the
+    /// **first-discovered** one — the entry whose version string C Tcl keeps
+    /// when it collapses them (see [`Self::resolve_require`] for why the file
+    /// list is nonetheless the union).
     #[must_use]
     pub fn select_provider(
         &self,
         name: &str,
         version: Option<&str>,
         exact: bool,
+        prefer: PackagePrefer,
     ) -> Option<&PackageInfo> {
-        let infos = self.packages.get(name)?;
+        self.select_providers(name, version, exact, prefer)
+            .into_iter()
+            .next()
+    }
+
+    /// Every provider of `name` whose version compares **equal** to the one
+    /// `package require ?-exact? NAME ?VERSION?` selects, in discovery order —
+    /// the first is the one C Tcl reports the version of, and the set is what
+    /// its collapsed `ifneeded` entry could be running.
+    ///
+    /// Empty when no scanned provider is acceptable (which includes the
+    /// "constraint no provider satisfies" case — never a silent fallback to
+    /// some other release).
+    #[must_use]
+    fn select_providers(
+        &self,
+        name: &str,
+        version: Option<&str>,
+        exact: bool,
+        prefer: PackagePrefer,
+    ) -> Vec<&PackageInfo> {
+        let Some(infos) = self.packages.get(name) else {
+            return Vec::new();
+        };
         let requirement = version.map(|v| {
             if exact {
                 tcl_dialect::exact_requirement(v)
@@ -907,12 +998,24 @@ impl PackageResolver {
         });
         let requirements: Vec<&str> = requirement.as_deref().into_iter().collect();
         let versions: Vec<&str> = infos.iter().map(|i| i.version.as_str()).collect();
-        let chosen = tcl_dialect::select_package_version(
-            &versions,
-            &requirements,
-            tcl_dialect::PackagePrefer::default(),
-        )?;
-        infos.get(chosen)
+        let Some(chosen) = tcl_dialect::select_package_version(&versions, &requirements, prefer)
+        else {
+            return Vec::new();
+        };
+        let chosen_version = versions[chosen];
+        infos
+            .iter()
+            .filter(|info| {
+                // Acceptable in its own right — an unparseable version string
+                // is skipped by `SelectPackage` and must not be dragged in by
+                // the lenient comparison `compare_versions` falls back to for
+                // one.
+                tcl_dialect::select_package_version(&[info.version.as_str()], &requirements, prefer)
+                    .is_some()
+                    && tcl_dialect::compare_versions(&info.version, chosen_version)
+                        == core::cmp::Ordering::Equal
+            })
+            .collect()
     }
 
     /// Whether the scanned paths know how to provide `name`.

--- a/rust/tcl-lsp-core/src/package_resolver/reachability/tests.rs
+++ b/rust/tcl-lsp-core/src/package_resolver/reachability/tests.rs
@@ -387,9 +387,8 @@ fn a_dynamic_lambda_is_not_descended() {
     assert!(availabilities(src, V90).is_empty());
 }
 
-/// A requirement naming a **patch level** cannot be evaluated against the
-/// two-component release model, so the guard abstains instead of deciding it
-/// wrongly.
+/// A requirement the members of a release *line* disagree about abstains —
+/// and only then (issue #1126 item 3).
 ///
 /// Oracle (`tclsh9.0`, `[package provide Tcl]` = 9.0.4):
 ///
@@ -399,13 +398,17 @@ fn a_dynamic_lambda_is_not_descended() {
 /// vsatisfies 9.0.4 9.0.9- = 0
 /// ```
 ///
-/// `TclVersion::V9_0`'s `version_string` is `9.0`, which compares *below*
-/// `9.0.1` — so evaluating the requirement would report the guard as failing
-/// on a real 9.0.4 and mark the package `Unavailable`, the one direction that
-/// makes W123 fire falsely on its commands.  Two shipped 9.0 releases disagree
-/// about `9.0.9-`, so "conditional" is the only honest answer.
+/// `TclVersion::V9_0` stands for every 9.0.x, and two shipped 9.0 releases
+/// disagree about `9.0.1`, so deciding it either way would be a guess: taking
+/// it as failed would mark the package `Unavailable` on a real 9.0.4 — the one
+/// direction that makes W123 fire falsely on its commands.
+///
+/// The *same* requirement against 8.6 is not a guess at all: no 8.6.x reaches
+/// a 9.0 bound, so the guard is decidably false there
+/// ([`tcl_dialect::TclVersion::satisfies_any_ternary`] evaluates the whole
+/// line, not its first release).
 #[test]
-fn a_patch_level_requirement_leaves_the_declaration_conditional() {
+fn a_patch_level_requirement_the_line_disagrees_about_stays_conditional() {
     for requirement in ["9.0.1", "9.0.1-", "9.0-9.0.2"] {
         let src = format!(
             "if {{![package vsatisfies [package provide Tcl] {requirement}]}} {{return}}\n\
@@ -414,18 +417,18 @@ fn a_patch_level_requirement_leaves_the_declaration_conditional() {
         assert_eq!(
             only(&src, V90),
             Availability::Conditional,
-            "a patch-level requirement must abstain: {requirement}",
+            "the 9.0 line disagrees about {requirement}, so it must abstain",
         );
         assert_eq!(
             only(&src, V86),
-            Availability::Conditional,
-            "a patch-level requirement must abstain: {requirement}",
+            Availability::Unavailable,
+            "no 8.6.x satisfies {requirement}, so the guard is decided",
         );
     }
 }
 
 /// TN for the same rule: a requirement that *is* satisfiable two-component
-/// still settles the whole `vsatisfies` OR, however many patch-level
+/// still settles the whole `vsatisfies` OR, however many undecidable
 /// requirements sit beside it — real `package vsatisfies` is an OR.
 #[test]
 fn a_satisfied_two_component_requirement_still_decides_beside_a_patch_level_one() {
@@ -434,8 +437,13 @@ fn a_satisfied_two_component_requirement_still_decides_beside_a_patch_level_one(
     // 9.0 satisfies the bare `9`, so the guard is decided true regardless of
     // the undecidable `9.0.1`.
     assert_eq!(only(src, V90), Availability::Available);
-    // 8.6 satisfies neither the bare `9` nor (decidably) `9.0.1`.
-    assert_eq!(only(src, V86), Availability::Conditional);
+    // 8.6 satisfies neither the bare `9` nor `9.0.1` — and both refusals are
+    // decided, so the whole OR is.
+    assert_eq!(only(src, V86), Availability::Unavailable);
+    // …while an undecidable requirement beside a refused one still abstains.
+    let mixed = "if {![package vsatisfies [package provide Tcl] 8.6.14- 9]} {return}\n\
+                 package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n";
+    assert_eq!(only(mixed, V86), Availability::Conditional);
 }
 
 /// Control — the two-component matrix this module already decided is

--- a/rust/tcl-lsp-core/src/package_resolver/tests.rs
+++ b/rust/tcl-lsp-core/src/package_resolver/tests.rs
@@ -489,17 +489,17 @@ fn exact_require_selects_that_release_or_nothing() {
     // TP — the exact release is present, so it is the one selected, where the
     // ranged reading of the same version would have taken 2.3.
     assert_eq!(
-        all.resolve_require("widget", Some("2.0"), true),
+        all.resolve_require("widget", Some("2.0"), true, PackagePrefer::default()),
         impl_of("v2")
     );
     assert_eq!(
-        all.resolve_require("widget", Some("2.0"), false),
+        all.resolve_require("widget", Some("2.0"), false, PackagePrefer::default()),
         impl_of("v3")
     );
     // TP — the trailing-zero spelling of the same release still satisfies
     // `-exact` (`package vcompare 2.0 2.0.0` is 0).
     assert_eq!(
-        all.resolve_require("widget", Some("2.0.0"), true),
+        all.resolve_require("widget", Some("2.0.0"), true, PackagePrefer::default()),
         impl_of("v2"),
     );
 
@@ -510,12 +510,12 @@ fn exact_require_selects_that_release_or_nothing() {
     without_exact.scan_path(&root.join("v3"));
     assert!(
         without_exact
-            .resolve_require("widget", Some("2.0"), true)
+            .resolve_require("widget", Some("2.0"), true, PackagePrefer::default())
             .is_empty(),
         "`-exact 2.0` must not resolve 2.3",
     );
     assert_eq!(
-        without_exact.resolve_require("widget", Some("2.0"), false),
+        without_exact.resolve_require("widget", Some("2.0"), false, PackagePrefer::default()),
         impl_of("v3"),
         "the ranged form still resolves 2.3, so the difference is the flag",
     );
@@ -526,18 +526,21 @@ fn exact_require_selects_that_release_or_nothing() {
     alpha_only.scan_path(&root.join("v4"));
     assert!(
         alpha_only
-            .resolve_require("widget", Some("2.0"), true)
+            .resolve_require("widget", Some("2.0"), true, PackagePrefer::default())
             .is_empty(),
     );
     assert_eq!(
-        alpha_only.resolve_require("widget", Some("2.0"), false),
+        alpha_only.resolve_require("widget", Some("2.0"), false, PackagePrefer::default()),
         impl_of("v4"),
     );
 
     // TN — `-exact` with no version is `package require -exact NAME`, a
     // syntax error in real Tcl; treated as unconstrained, so it picks the
     // best release rather than nothing.
-    assert_eq!(all.resolve_require("widget", None, true), impl_of("v3"));
+    assert_eq!(
+        all.resolve_require("widget", None, true, PackagePrefer::default()),
+        impl_of("v3")
+    );
 }
 
 /// An unconstrained require picks the highest **stable** release, which is
@@ -586,6 +589,158 @@ fn unconstrained_require_prefers_the_highest_stable_release() {
     );
 }
 
+/// `package prefer latest` flips the same corpus onto the prerelease
+/// (issue #1126 item 1).
+///
+// tclsh-proof: tclsh8.6 (8.6.14), with both registered by hand —
+//   package ifneeded widget 1.2   {package provide widget 1.2}
+//   package ifneeded widget 1.3b1 {package provide widget 1.3b1}
+//   package require widget          → 1.2
+// and with `package prefer latest` evaluated first → 1.3b1.
+// `package prefer` itself answers `stable` by default, `latest` after the
+// raise, and a following `package prefer stable` returns `latest` with no
+// error — the latch never falls back.
+#[test]
+fn prefer_latest_selects_the_prerelease() {
+    let td = TempDir::new("preferlatest");
+    let root = td.path();
+    for (dir, ver) in [("s", "1.2"), ("u", "1.3b1")] {
+        let pkg_dir = root.join(dir);
+        let file = format!("w{dir}.tcl");
+        write(&pkg_dir.join(&file), "proc w {} {}\n");
+        write(
+            &pkg_dir.join("pkgIndex.tcl"),
+            &format!("package ifneeded w {ver} [list source [file join $dir {file}]]\n"),
+        );
+    }
+    let mut both = PackageResolver::new();
+    both.scan_path(root);
+    // TP — the raise moves the answer onto the prerelease.
+    assert_eq!(
+        both.resolve_require("w", None, false, PackagePrefer::Latest),
+        vec![root.join("u").join("wu.tcl")],
+    );
+    // FP guard — the default is untouched.
+    assert_eq!(
+        both.resolve_require("w", None, false, PackagePrefer::Stable),
+        vec![root.join("s").join("ws.tcl")],
+    );
+    // TN — with no prerelease in the acceptable set the mode changes nothing.
+    let mut stable_only = PackageResolver::new();
+    stable_only.scan_path(&root.join("s"));
+    assert_eq!(
+        stable_only.resolve_require("w", None, false, PackagePrefer::Latest),
+        stable_only.resolve_require("w", None, false, PackagePrefer::Stable),
+    );
+}
+
+/// `package_prefer_at` reads the document's own raise, ordered against the
+/// `package require` that asks (issue #1126 item 1).
+#[test]
+fn package_prefer_state_is_ordered_against_the_require() {
+    use tcl_compiler::analyser::Analyser;
+    let analyse = |src: &str| Analyser::new().analyse(src, "tcl");
+    let at = |src: &str, needle: &str| {
+        u32::try_from(src.find(needle).expect("needle")).expect("offset fits")
+    };
+
+    // TP — a raise above the require is in effect.
+    let src = "package prefer latest\npackage require w\n";
+    let analysis = analyse(src);
+    assert_eq!(
+        crate::package_resolver::package_prefer_at(&analysis, at(src, "package require")),
+        PackagePrefer::Latest,
+    );
+
+    // FP guard — a raise written *below* a top-level require has not run yet.
+    let src = "package require w\npackage prefer latest\n";
+    let analysis = analyse(src);
+    assert_eq!(
+        crate::package_resolver::package_prefer_at(&analysis, at(src, "package require")),
+        PackagePrefer::Stable,
+    );
+
+    // TP — …but a require inside a proc body *does* see a raise written
+    // later at load level, because the whole file loads before any body runs
+    // (the `in_effect` rule the import family already shares).
+    let src = "proc load {} {\n    package require w\n}\npackage prefer latest\n";
+    let analysis = analyse(src);
+    assert_eq!(
+        crate::package_resolver::package_prefer_at(&analysis, at(src, "    package require")),
+        PackagePrefer::Latest,
+    );
+
+    // FP guard — a conditional raise is not taken as a fact.
+    let src = "if {$::tcl_platform(platform) eq \"unix\"} {\n    package prefer latest\n}\npackage require w\n";
+    let analysis = analyse(src);
+    assert_eq!(
+        crate::package_resolver::package_prefer_at(&analysis, at(src, "package require")),
+        PackagePrefer::Stable,
+    );
+
+    // TN — `package prefer stable` and the query form change nothing; a
+    // dynamic mode word is skipped rather than guessed at.
+    for src in [
+        "package prefer stable\npackage require w\n",
+        "package prefer\npackage require w\n",
+        "package prefer $mode\npackage require w\n",
+    ] {
+        let analysis = analyse(src);
+        assert_eq!(
+            crate::package_resolver::package_prefer_at(&analysis, at(src, "package require")),
+            PackagePrefer::Stable,
+            "{src}",
+        );
+    }
+}
+
+/// Two providers whose versions compare **equal** both contribute their files
+/// (issue #1126 item 2).
+///
+// tclsh-proof: tclsh8.6 (8.6.14) —
+//   package ifneeded w 1.0   {puts A}
+//   package ifneeded w 1.0.0 {puts B}
+//   package versions w   → 1.0        (one entry, the *first* version string)
+//   package ifneeded w 1.0 → puts B   (the *last* script)
+// The registration order is `glob` order, i.e. filesystem order, so which
+// script survives is machine-dependent and cannot be pinned.
+#[test]
+fn equal_comparing_providers_all_contribute_their_files() {
+    let td = TempDir::new("dupe");
+    let root = td.path();
+    for (dir, ver) in [("a", "1.0"), ("b", "1.0.0"), ("c", "0.9")] {
+        let pkg_dir = root.join(dir);
+        let file = format!("w{dir}.tcl");
+        write(&pkg_dir.join(&file), "proc w {} {}\n");
+        write(
+            &pkg_dir.join("pkgIndex.tcl"),
+            &format!("package ifneeded w {ver} [list source [file join $dir {file}]]\n"),
+        );
+    }
+    let mut resolver = PackageResolver::new();
+    resolver.scan_path(root);
+    // TP — `1.0` and `1.0.0` are one release to `package vcompare`, so both
+    // copies are indexed; discovery order (sorted by directory name) puts the
+    // one whose version string C Tcl keeps first.
+    assert_eq!(
+        resolver.resolve("w", None),
+        vec![root.join("a").join("wa.tcl"), root.join("b").join("wb.tcl"),],
+    );
+    // FP guard — a *lower* release is not dragged in with them.
+    assert_eq!(
+        resolver
+            .select_provider("w", None, false, PackagePrefer::default())
+            .map(|i| i.version.as_str()),
+        Some("1.0"),
+    );
+    // FP guard — a constraint that only the lower release satisfies still
+    // answers just that one.
+    assert_eq!(
+        resolver.resolve_require("w", Some("0.9"), true, PackagePrefer::default()),
+        vec![root.join("c").join("wc.tcl")],
+    );
+}
+
 /// `select_provider` reports the whole chosen declaration, not just its files
 /// — the version actually selected and the `pkgIndex.tcl` that declared it.
 #[test]
@@ -603,13 +758,21 @@ fn select_provider_reports_the_chosen_declaration() {
     let mut resolver = PackageResolver::new();
     resolver.scan_path(root);
     let chosen = resolver
-        .select_provider("p", None, false)
+        .select_provider("p", None, false, PackagePrefer::default())
         .expect("a provider");
     assert_eq!(chosen.version, "2.3");
     assert_eq!(chosen.pkg_index_path, root.join("b").join("pkgIndex.tcl"));
     // TN — nothing acceptable, and an unknown package, both answer `None`.
-    assert!(resolver.select_provider("p", Some("9.9"), false).is_none());
-    assert!(resolver.select_provider("absent", None, false).is_none());
+    assert!(
+        resolver
+            .select_provider("p", Some("9.9"), false, PackagePrefer::default())
+            .is_none()
+    );
+    assert!(
+        resolver
+            .select_provider("absent", None, false, PackagePrefer::default())
+            .is_none()
+    );
 }
 
 #[test]
@@ -694,16 +857,18 @@ fn transitive_closure_pulls_in_tk_through_a_wrapper_package() {
 }
 
 /// Two providers declaring versions that compare *equal*: the first scanned
-/// wins, deterministically.
+/// is the selected declaration, deterministically — while the *files* are the
+/// union of both (issue #1126 item 2, and
+/// [`super::PackageResolver::resolve_require`]'s doc).
 ///
 /// Real Tcl collapses them into one `package ifneeded` entry — first
 /// registration's version string, last registration's script — and the
 /// registration order is `glob` order, i.e. filesystem order, which differs
 /// per machine (verified: on this container `glob -directory … -join *
-/// pkgIndex.tcl` returned `b` before `a`). There is no stable oracle to match,
-/// so this pins the deterministic choice instead: discovery order, which sorts
-/// subdirectories by name, so a workspace-local copy listed first shadows an
-/// equally-versioned installed one.
+/// pkgIndex.tcl` returned `b` before `a`). There is no stable oracle for
+/// *which script survives*, so navigation reads both copies rather than
+/// betting; the deterministic half — which declaration is "the" one, and so
+/// which version string is reported — stays discovery order, sorted by name.
 #[test]
 fn resolver_first_provider_wins() {
     // Two providers of the same package: the first scanned keeps the head.
@@ -723,7 +888,19 @@ fn resolver_first_provider_wins() {
     let mut resolver = PackageResolver::new();
     resolver.scan_path(&first);
     resolver.scan_path(&second);
-    assert_eq!(resolver.resolve("dup", None), vec![first.join("dup.tcl")]);
+    assert_eq!(
+        resolver
+            .select_provider("dup", None, false, PackagePrefer::default())
+            .map(|i| i.pkg_index_path.clone()),
+        Some(first.join("pkgIndex.tcl")),
+        "the first-scanned declaration is the one C Tcl reports the version of",
+    );
+    assert_eq!(
+        resolver.resolve("dup", None),
+        vec![first.join("dup.tcl"), second.join("dup.tcl")],
+        "…and both copies are indexed, because which script survives is a \
+         filesystem-order fact",
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -6098,7 +6098,15 @@ impl Backend {
                 // the scan happened to read first.  `-exact` is carried
                 // through, so `package require -exact widget 2.0` navigates
                 // into 2.0 or nothing at all — never into 2.3 (issue #1090).
-                for f in resolver.resolve_require(&req.name, req.version.as_deref(), req.exact) {
+                // The `package prefer` mode is taken **at this require's own
+                // position**, so a document that raised the interpreter to
+                // `latest` above it navigates into the prerelease it really
+                // loads (issue #1126 item 1).
+                let prefer =
+                    tcl_lsp_core::package_resolver::package_prefer_at(analysis, req.range.start());
+                for f in
+                    resolver.resolve_require(&req.name, req.version.as_deref(), req.exact, prefer)
+                {
                     if !files.contains(&f) {
                         files.push(f);
                     }

--- a/rust/tcl-registry/src/commands/tcl/package_.rs
+++ b/rust/tcl-registry/src/commands/tcl/package_.rs
@@ -135,6 +135,11 @@ static SUBCOMMANDS: &[SubCommand] = &[
         return_type: Some(TclType::String),
         arg_values: &[(0, PREFER_VALUES)],
         closed_value_args: &[0],
+        // The setter form writes interpreter-global state that every later
+        // `package require` in *any* file reads — which release it selects
+        // when the best acceptable version is a prerelease (issue #1126
+        // item 1).
+        analyser_hook: Some(crate::hooks::AnalyserHookId::PackagePrefer),
         // Added in Tcl 8.5 (TIP 268).
         dialects: Some(DialectSet::TCL85_PLUS),
         ..SubCommand::DEFAULT

--- a/rust/tcl-registry/src/hooks.rs
+++ b/rust/tcl-registry/src/hooks.rs
@@ -392,6 +392,12 @@ pub enum AnalyserHookId {
     /// `package provide name ?version?` — records the provided
     /// package (stamped on `package`'s `provide` subcommand).
     PackageProvide,
+    /// `package prefer ?latest|stable?` — records the interpreter's
+    /// version-selection mode change (stamped on `package`'s `prefer`
+    /// subcommand), which decides whether a later `package require`
+    /// takes the highest acceptable version or the highest acceptable
+    /// *stable* one (issue #1126 item 1).
+    PackagePrefer,
     /// `source ?-encoding enc? fileName` — records the source target.
     Source,
     /// `append varName ?value ...?` — read-modify-write variable

--- a/rust/tcl-registry/tests/analyser_hooks.rs
+++ b/rust/tcl-registry/tests/analyser_hooks.rs
@@ -153,6 +153,10 @@ fn analyser_hook_stamps_match_the_former_guard_list() {
         // handle_package_command matched `args[0]` require / provide.
         ("package", "require", H::PackageRequire),
         ("package", "provide", H::PackageProvide),
+        // Post-dates the former guard list: `package prefer latest` raises
+        // the interpreter's selection mode, which provider selection reads
+        // at the require's own offset (issue #1126).
+        ("package", "prefer", H::PackagePrefer),
         ("source", "", H::Source),
         ("append", "", H::Append),
         // `lappend` additionally feeds the `lappend auto_path …` arm.

--- a/rust/tcl-spec-studio/src/catalogue.rs
+++ b/rust/tcl-spec-studio/src/catalogue.rs
@@ -360,6 +360,7 @@ pub const ANALYSER_HOOKS: &[Variant] = &[
     v("OoObjdefine", "oo::objdefine"),
     v("PackageRequire", "package require"),
     v("PackageProvide", "package provide"),
+    v("PackagePrefer", "package prefer"),
     v("Source", "source"),
     v("Append", "append"),
     v("Lappend", "lappend"),
@@ -1005,6 +1006,7 @@ mod tests {
             | AnalyserHookId::OoObjdefine
             | AnalyserHookId::PackageRequire
             | AnalyserHookId::PackageProvide
+            | AnalyserHookId::PackagePrefer
             | AnalyserHookId::Source
             | AnalyserHookId::Append
             | AnalyserHookId::Lappend


### PR DESCRIPTION
## Summary

**#1126 — all three items fixed.**

- **`package prefer latest` state**: nothing recorded the interpreter's selection-mode raise, so provider selection always used the default. New registry hook `AnalyserHookId::PackagePrefer` on `package prefer` → `AnalysisResult::package_prefer_latest`, threaded into `PackageResolver::resolve_require`/`select_provider`, with the mode derived at the require's own offset via `analyser::indirection::in_effect`. No event log is needed: `package prefer` is a monotone latch (tclsh-proved — `stable` after `latest` returns `latest`, no error), so only the raise is a record.
- **Duplicate providers under `glob` order**: which collapsed `ifneeded` script survives is filesystem order and unpinnable, and the old code bet on one provider's files. `select_provider` still answers first-discovered (the version string C Tcl keeps, tclsh-proved), while `resolve_require` now returns the **union** of equal-comparing providers' files, so navigation finds the symbol in whichever copy loaded. The undecidable half is stated rather than guessed.
- **Patch-level `TclVersion` abstention**: "three or more dotted components ⇒ undecidable" was a syntactic proxy. `satisfies_any_ternary` now evaluates each requirement over the whole release line `[M.m, M.m.<ceiling>]` — two endpoint tests plus a min-bound containment test decide Yes/No/Inert exactly; `requirement_names_patch_level` is deleted and `satisfies_any` delegates so bool and ternary cannot diverge. Both directions gained: `9.0.1` vs 8.6 was Inert → **No**; `8.6-8.6` (`-exact 8.6`) vs 8.6 was Yes → **Inert**, a real false positive.

**#1104 / #1116 — surveyed, remaining items justified on the issues (staying open).** `docs/design/import-order-source-graph.md` gains §6.1/§6.2 with a correction to the existing plan: a `has_run(event, query) -> Option<bool>` predicate is *not* sufficient, because `exported_at_import_site` and `alias_live_at` are latest-wins folds over two `u32` maxima — cross-document events must be ranked against each other, so the key must be `cmp_run(a, b) -> Option<Ordering>`. §6.2 records why that is tractable (a `source` graph is a flattened execution sequence; lift each event to its root-ward path and compare at the deepest common document). #1116 item 5 (dynamic forget) is confirmed correct as an abstention and now pinned by a test with the literal spelling as control.

Filed en route: #1253 (`package prefer latest` does not cross documents; `TCL_PKG_PREFER_LATEST` default unmodelled).

## Validation

- [x] Group branch: `cargo test -p tcl-compiler -p tcl-lsp-core -p tcl-lsp-server` all green (5231 + 1687 lib tests plus every integration/e2e suite); `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean over the six touched crates, no new `#[allow]`s; `make xtask-check` all sub-gates OK (registry changed, so required).
- [x] Rebased onto post-#1249 rust: clean, zero conflicts; `cargo check -p tcl-dialect -p tcl-compiler -p tcl-lsp-core` clean post-rebase.
- [ ] Full post-rebase suite delegated to CI — local runners shared with parallel group builds; this session is subscribed and will drive any failure to green.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? — Yes: `AnalyserHookId::PackagePrefer` and `AnalysisResult::package_prefer_latest`, `resolve_require`'s union return for equal-comparing providers, and the exact ternary semantics of `satisfies_any_ternary` (with `requirement_names_patch_level` removed).
- [x] If yes, I updated at least one relevant KCS note — contract/KCS docs updated with the package-tier changes, plus `docs/design/import-order-source-graph.md` §6.1/§6.2.
- [ ] If I added a new compiler KCS note, I linked it — n/a (existing notes extended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_