### PR TITLE
Cleanup: array-exists fold, dominator intervals, taint index reuse, braced-literal audit, boolean roles, formatter version range (#1239, #1250, #1251, #1252, #1256, #1257)

### DIFF
--- a/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
@@ -2548,7 +2548,7 @@ fn existence_query_vars(stmt: &crate::ir::Statement) -> Vec<String> {
         _ => &[],
     };
     for t in texts {
-        if let Some(v) = existence_query_in_text(t.trim()) {
+        if let Some((v, _command)) = existence_query_in_text(t.trim()) {
             out.push(v);
         }
     }

--- a/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
@@ -241,10 +241,16 @@ pub(super) fn collect_existence_guards(
             false_target,
             ..
         }) = &block.terminator
-            && let Some((var, negated)) = crate::expr_ast::existence_query_var(condition)
+            && let Some(query) = crate::expr_ast::existence_query_var(condition)
         {
-            let target = if negated { *false_target } else { *true_target };
-            guards.push((var, target));
+            // Either spelling proves the name is bound in the guarded region:
+            // `array exists X` implies `info exists X`.
+            let target = if query.negated {
+                *false_target
+            } else {
+                *true_target
+            };
+            guards.push((query.var, target));
         }
     }
     guards

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -2970,7 +2970,7 @@ impl Analyser {
             return;
         };
         let entries: Vec<String> = elements.iter().map(ToString::to_string).collect();
-        self.record_namespace_path_element_refs(&args[1], arg_tokens.get(1), &ns);
+        self.record_namespace_path_element_refs(&args[1], arg_tokens.get(1), braced, &ns);
         self.namespace_paths.insert(ns, entries);
     }
 
@@ -2987,7 +2987,20 @@ impl Analyser {
     /// Silently does nothing when the word is not a braced/bare literal the
     /// span arithmetic can trust (`token` absent, or the element offsets fall
     /// outside it).
-    fn record_namespace_path_element_refs(&mut self, raw: &str, token: Option<&Token>, here: &str) {
+    ///
+    /// `word_braced` says whether the *whole* path word was brace-quoted. If
+    /// it was, no element substitutes however many `$`/`[` characters it
+    /// holds, so the per-element dynamism scan must be suppressed exactly as
+    /// the whole-word one already is (issue #1252) — otherwise `namespace
+    /// path {::$ns ::a}` records `::$ns` as a path entry but not as a
+    /// reference, and the same function disagrees with itself.
+    fn record_namespace_path_element_refs(
+        &mut self,
+        raw: &str,
+        token: Option<&Token>,
+        word_braced: bool,
+        here: &str,
+    ) {
         let Some(token) = token else { return };
         let base = token.span.start() + u32::from(token.content_offset);
         let mut scan = 0usize;
@@ -3000,7 +3013,7 @@ impl Analyser {
             let Some(text) = raw.get(start..end) else {
                 continue;
             };
-            if text.is_empty() || crate::naming::is_dynamic_word(text) {
+            if text.is_empty() || tcl_syntax::naming::word_is_dynamic(text, word_braced) {
                 continue;
             }
             let Ok(start_u32) = u32::try_from(start) else {
@@ -3618,8 +3631,11 @@ impl Analyser {
         // re-dispatches just `rename`/`proc` for every *additional* literal
         // element, since those are the only two commands go-to-definition/
         // references/rename need to see resolved here.
+        let list_braced = arg_tokens
+            .get(1)
+            .is_some_and(|tok| tok.kind == TokenType::Str);
         let literal_binding = (args.len() == 3)
-            .then(|| Self::literal_foreach_binding(&args[0], &args[1]))
+            .then(|| Self::literal_foreach_binding(&args[0], &args[1], list_braced))
             .flatten();
         if let Some((var, elements)) = &literal_binding
             && let Some(first) = elements.first()
@@ -3643,9 +3659,20 @@ impl Analyser {
     /// single plain identifier (not itself dynamic, not a multi-name list)
     /// bound to a Tcl-list-valued sequence of literal (non-dynamic)
     /// elements. Returns `(var, elements)`.
+    ///
+    /// `list_braced` says whether the value word was brace-quoted. Braces
+    /// suppress substitution across the whole word, so *every* element of a
+    /// braced list is literal however many `$`/`[` characters it holds — the
+    /// element text arrives with the braces stripped, and scanning it alone
+    /// made one odd element abstain from the whole simulation (issue #1252).
+    /// tclsh-proof (8.6.16 / 9.0.4):
+    ///   foreach n {aa {$b} cc} { puts $n }   ->  aa / $b / cc
+    /// i.e. the loop runs three times over literal values, and no read of
+    /// `b` happens at any point.
     fn literal_foreach_binding(
         var_list_text: &str,
         list_text: &str,
+        list_braced: bool,
     ) -> Option<(String, Vec<String>)> {
         let mut vars = var_list_text.split_whitespace();
         let var = vars.next()?;
@@ -3666,7 +3693,11 @@ impl Analyser {
             .into_iter()
             .map(std::borrow::Cow::into_owned)
             .collect();
-        if elements.is_empty() || elements.iter().any(|e| crate::naming::is_dynamic_word(e)) {
+        if elements.is_empty()
+            || elements
+                .iter()
+                .any(|e| tcl_syntax::naming::word_is_dynamic(e, list_braced))
+        {
             return None;
         }
         Some((var.to_owned(), elements))

--- a/rust/tcl-compiler/src/cfg.rs
+++ b/rust/tcl-compiler/src/cfg.rs
@@ -40,7 +40,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use tcl_lexer::Span;
 
 use crate::expr_ast::ExprNode;
@@ -355,9 +355,30 @@ impl Function {
     }
 
     /// Compute the predecessor map: block → set of predecessor blocks.
+    ///
+    /// O(V+E), and it allocates — a caller that needs the map more than once
+    /// should build it once and pass it down rather than re-deriving it
+    /// (issue #1251).
     #[must_use]
     pub fn predecessors(&self) -> HashMap<BlockId, HashSet<BlockId>> {
-        let mut preds: HashMap<BlockId, HashSet<BlockId>> = HashMap::new();
+        self.predecessor_map()
+    }
+
+    /// [`Self::predecessors`] keyed with `rustc-hash`, for the CFG-derived
+    /// indices that are built per analysis run: a [`BlockId`] is a dense `u32`
+    /// and needs no randomised hashing.
+    #[must_use]
+    pub fn predecessors_fx(&self) -> FxHashMap<BlockId, FxHashSet<BlockId>> {
+        self.predecessor_map()
+    }
+
+    /// The shared predecessor-map build, generic over the hasher so
+    /// [`Self::predecessors`] and [`Self::predecessors_fx`] stay one
+    /// implementation.
+    fn predecessor_map<S: std::hash::BuildHasher + Default>(
+        &self,
+    ) -> HashMap<BlockId, HashSet<BlockId, S>, S> {
+        let mut preds: HashMap<BlockId, HashSet<BlockId, S>, S> = HashMap::default();
         for id in self.blocks.keys() {
             preds.entry(*id).or_default();
         }

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -42,7 +42,7 @@ use crate::memory_ssa::{MemorySsaFunction, build_memory_ssa};
 use crate::rendered_properties::{RenderedValueProps, propagate_rendered_props};
 use crate::sccp::{SccpResult, sccp_with_extra_escaping};
 use crate::ssa::{SsaFunction, ValueKey, build_ssa};
-use crate::taint::{TaintLattice, propagate_taints};
+use crate::taint::{TaintGraph, TaintLattice, propagate_taints};
 use crate::type_infer::propagate_types;
 use crate::types::TypeLattice;
 use crate::unit_scope::{
@@ -648,9 +648,7 @@ impl FunctionUnit {
         );
         let rendered_props = propagate_rendered_props(&cfg, &ssa, &sccp, registry);
         let taints = propagate_taints(
-            &cfg,
-            &ssa,
-            &sccp,
+            &TaintGraph::new(&cfg, &ssa, &sccp),
             registry,
             Some(&rendered_props),
             None,
@@ -755,9 +753,7 @@ impl FunctionUnit {
         dialect: Option<&str>,
     ) -> HashMap<ValueKey, TaintLattice> {
         propagate_taints(
-            &self.cfg,
-            &self.ssa,
-            &self.sccp,
+            &TaintGraph::new(&self.cfg, &self.ssa, &self.sccp),
             registry,
             Some(&self.rendered_props),
             Some(ia),
@@ -1578,9 +1574,11 @@ impl CompilationUnit {
         // `interproc` immutably while each function unit re-runs
         // `propagate_taints`.
         self.top_level.taints = Arc::new(propagate_taints(
-            &self.top_level.cfg,
-            &self.top_level.ssa,
-            &self.top_level.sccp,
+            &TaintGraph::new(
+                &self.top_level.cfg,
+                &self.top_level.ssa,
+                &self.top_level.sccp,
+            ),
             registry,
             Some(&self.top_level.rendered_props),
             Some(&interproc),
@@ -1590,9 +1588,7 @@ impl CompilationUnit {
         ));
         for fu in self.procedures.values_mut() {
             fu.taints = Arc::new(propagate_taints(
-                &fu.cfg,
-                &fu.ssa,
-                &fu.sccp,
+                &TaintGraph::new(&fu.cfg, &fu.ssa, &fu.sccp),
                 registry,
                 Some(&fu.rendered_props),
                 Some(&interproc),

--- a/rust/tcl-compiler/src/gvn.rs
+++ b/rust/tcl-compiler/src/gvn.rs
@@ -1079,25 +1079,6 @@ pub fn find_redundancies(
 
 // Loop-invariant detection
 
-/// True when `ancestor` dominates `node` in `ssa.idom`.
-fn dominates(ssa: &SsaFunction, ancestor: BlockId, node: BlockId) -> bool {
-    if ancestor == node {
-        return true;
-    }
-    let mut curr = node;
-    loop {
-        match ssa.idom.get(&curr) {
-            Some(Some(parent)) => {
-                if *parent == ancestor {
-                    return true;
-                }
-                curr = *parent;
-            }
-            _ => return false,
-        }
-    }
-}
-
 /// Enumerate blocks reachable from `entry` via CFG edges.
 fn reachable_from(cfg: &CfgFunction, entry: BlockId) -> FxHashSet<BlockId> {
     let mut out = FxHashSet::default();
@@ -1197,6 +1178,11 @@ pub fn find_loop_invariants(
 ) -> Vec<RedundantComputation> {
     let executable = reachable_from(cfg, ssa.entry);
     let mut results: Vec<RedundantComputation> = Vec::new();
+    // One O(V) dominator-tree numbering serves every dominance query below.
+    // Walking the idom chain per query instead made this pass O(V²) on a wide
+    // CFG — a flat N-branch dispatch chain is one idom chain N blocks deep
+    // (issue #1250).
+    let dom = ssa.dominator_intervals();
 
     // Collect unique header → loop_blocks pairs via back-edge
     // detection: edge tail → succ where succ dominates tail. The
@@ -1221,7 +1207,7 @@ pub fn find_loop_invariants(
             if !executable.contains(&succ) {
                 continue;
             }
-            if !dominates(ssa, succ, *tail) {
+            if !dom.dominates(succ, *tail) {
                 continue;
             }
             let blocks = natural_loop_blocks(cfg, succ, *tail, &executable);
@@ -1250,7 +1236,7 @@ pub fn find_loop_invariants(
             // on some iterations (it sits behind a branch inside the loop),
             // so hoisting it changes *when* it runs. Only blocks that
             // dominate every latch are guaranteed to execute each iteration.
-            if !latches.iter().all(|latch| dominates(ssa, *bn, *latch)) {
+            if !latches.iter().all(|latch| dom.dominates(*bn, *latch)) {
                 continue;
             }
             let Some(ssa_block) = ssa.blocks.get(bn) else {
@@ -2964,10 +2950,42 @@ mod tests {
         ssa.idom.insert(entry, None);
         ssa.idom.insert(a, Some(entry));
         ssa.idom.insert(b, Some(a));
-        assert!(dominates(&ssa, entry, b));
-        assert!(dominates(&ssa, a, b));
-        assert!(!dominates(&ssa, b, a));
-        assert!(dominates(&ssa, b, b));
+        let dom = ssa.dominator_intervals();
+        assert!(dom.dominates(entry, b));
+        assert!(dom.dominates(a, b));
+        assert!(!dom.dominates(b, a));
+        assert!(dom.dominates(b, b));
+    }
+
+    #[test]
+    fn dominator_intervals_answer_siblings_and_unreachable() {
+        // Issue #1250: the interval index must give the same answers the idom
+        // chain walk gave — including "no", which is the case an interval
+        // scheme can get wrong if the numbering is off by one.
+        //
+        //   entry → a → { b, c },  d unreachable (no idom entry)
+        let mut cfg = Function::new("::top", "entry");
+        let entry = cfg.entry;
+        let a = cfg.intern_block("a");
+        let b = cfg.intern_block("b");
+        let c = cfg.intern_block("c");
+        let d = cfg.intern_block("d");
+        let mut ssa = SsaFunction::trivial(cfg.name.clone(), cfg.entry, cfg.block_names().to_vec());
+        ssa.idom.insert(entry, None);
+        ssa.idom.insert(a, Some(entry));
+        ssa.idom.insert(b, Some(a));
+        ssa.idom.insert(c, Some(a));
+        let dom = ssa.dominator_intervals();
+        for node in [a, b, c] {
+            assert!(dom.dominates(entry, node), "entry must dominate {node:?}");
+            assert!(dom.dominates(node, node), "{node:?} dominates itself");
+        }
+        assert!(dom.dominates(a, b) && dom.dominates(a, c));
+        assert!(!dom.dominates(b, c) && !dom.dominates(c, b));
+        assert!(!dom.dominates(b, a) && !dom.dominates(c, entry));
+        // A block outside the dominator forest dominates only itself.
+        assert!(dom.dominates(d, d));
+        assert!(!dom.dominates(entry, d) && !dom.dominates(d, entry));
     }
 
     #[test]

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -954,7 +954,8 @@ fn scan_defined_and_unset(cfg: &CfgFunction) -> (FxHashSet<String>, FxHashSet<&s
 /// cannot drift (they did, on method parameters — issue #1129).
 #[derive(Clone, Copy, Default)]
 pub struct ExistenceFrame<'a> {
-    /// The body's formal parameter names: bound on entry, so they exist.
+    /// The body's formal parameter names: bound on entry as scalars, so
+    /// they exist for `info exists` and never for `array exists`.
     /// Empty for the top level and for any body with no parameter list.
     pub params: &'a [String],
     /// Names auto-bound to out-of-frame *object* storage on entry — a
@@ -980,7 +981,8 @@ fn array_element_base(var: &str) -> Option<&str> {
 
 /// Fold `[info exists X]` / `[array exists X]`
 /// if-conditions into [`ConstantBranch`] entries for the
-/// false-positive-free cases — a parameter always exists (`true`); a
+/// false-positive-free cases — a parameter always exists, as a **scalar**
+/// (`info exists` → `true`, `array exists` → `false`, issue #1239); a
 /// never-defined non-parameter never exists (`false`); an element guard
 /// `X(elem)` on an array this body never touches never exists (`false`,
 /// issue #1173 — the guard is decided on the *array* name, with the same
@@ -1124,7 +1126,12 @@ pub fn existence_constant_branches(
         else {
             continue;
         };
-        let Some((var, negated)) = crate::expr_ast::existence_query_var(condition) else {
+        let Some(crate::expr_ast::ExistenceQuery {
+            var,
+            negated,
+            command,
+        }) = crate::expr_ast::existence_query_var(condition)
+        else {
             continue;
         };
         let exists = if let Some(base) = array_element_base(&var) {
@@ -1170,7 +1177,22 @@ pub fn existence_constant_branches(
                 if unset.contains(var.as_str()) || dynamic_names.destroys {
                     continue;
                 }
-                true
+                // Which constant depends on the spelling (issue #1239).  A
+                // parameter is bound as a *scalar* on entry — Tcl has no
+                // pass-an-array-by-value — so `array exists PARAM` is
+                // provably **false** where `info exists PARAM` is true.
+                // Nothing in a barrier-free body can turn the parameter into
+                // an array without first removing the scalar binding, and a
+                // literal `unset` / a dynamic destroy already abstained above
+                // (`set p(k) …` and `array set p …` on a live scalar are
+                // runtime errors, not conversions).
+                //
+                // tclsh-proof (8.6.16 / 9.0.4):
+                //   proc f {a} { if {[array exists a]} { puts yes } else { puts no } }
+                //   f 1                                        ;# → no
+                //   proc g {a} { array set a {x 1} }
+                //   g 1  ;# → can't set "a(x)": variable isn't array
+                matches!(command, crate::expr_ast::ExistenceCommand::Info)
             } else if !defined.contains(&var) {
                 // `set $switch {}` may have defined exactly this name — the
                 // argparse idiom the fold used to call unreachable.

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -338,6 +338,122 @@ impl SsaFunction {
             .position(|n| n == name)
             .map(|i| BlockId(u32::try_from(i).expect("block count fits in u32")))
     }
+
+    /// Build the O(1)-query dominance index for this function
+    /// ([`DominatorIntervals`]).  One O(V) walk; build it once per function
+    /// and reuse it for every query.
+    #[must_use]
+    pub fn dominator_intervals(&self) -> DominatorIntervals {
+        DominatorIntervals::build(self)
+    }
+}
+
+/// Dominator-tree DFS interval numbering: answers `dominates(a, b)` in O(1).
+///
+/// The straightforward answer walks `b`'s immediate-dominator chain looking
+/// for `a`, which is O(depth) with a hash lookup per hop — and on a flat
+/// N-branch dispatch chain the idom chain *is* the whole function, so a
+/// per-block-pair loop over it is O(V²) (issue #1250).  A pre-order DFS of
+/// the dominator tree instead assigns every block a half-open `[enter, exit)`
+/// interval that contains exactly its dominator-tree subtree, and `a`
+/// dominates `b` iff `b`'s interval nests inside `a`'s.
+///
+/// Blocks outside the dominator forest (unreachable, hence absent from
+/// `idom`) have no interval and dominate nothing but themselves — the same
+/// answer the chain walk gives, since it runs out of parents.
+#[derive(Debug, Clone, Default)]
+pub struct DominatorIntervals {
+    /// `(enter, exit)` per block, indexed by [`BlockId`]`.0`.  `None` for a
+    /// block the DFS never reached.
+    intervals: Vec<Option<(u32, u32)>>,
+}
+
+impl DominatorIntervals {
+    /// Number `ssa`'s dominator forest.
+    ///
+    /// Children are derived from `idom` rather than read off
+    /// [`SsaFunction::dominator_tree`], so the index is correct for any
+    /// function whose `idom` is populated (including hand-built test
+    /// fixtures that never ran the tree builder).
+    ///
+    /// The DFS starts at the entry block and then picks up any other root
+    /// (a block whose `idom` is `None`), so a forest with more than one root
+    /// is numbered in full rather than silently losing a component.
+    #[must_use]
+    fn build(ssa: &SsaFunction) -> Self {
+        let slots = ssa
+            .idom
+            .iter()
+            .flat_map(|(id, parent)| [Some(*id), *parent])
+            .flatten()
+            .map(|b| b.0 as usize + 1)
+            .chain(std::iter::once(ssa.block_names.len()))
+            .max()
+            .unwrap_or(0);
+        let mut intervals = vec![None; slots];
+        if ssa.idom.is_empty() {
+            return Self { intervals };
+        }
+        let mut children: Vec<Vec<BlockId>> = vec![Vec::new(); slots];
+        let mut roots: Vec<BlockId> = Vec::new();
+        for (id, parent) in &ssa.idom {
+            match parent {
+                Some(p) => children[p.0 as usize].push(*id),
+                None if *id != ssa.entry => roots.push(*id),
+                None => {}
+            }
+        }
+        for kids in &mut children {
+            kids.sort_unstable();
+        }
+        roots.sort_unstable();
+        if ssa.idom.contains_key(&ssa.entry) {
+            roots.insert(0, ssa.entry);
+        }
+
+        let mut counter: u32 = 0;
+        // Explicit stack of `(block, next child index)` — an iterative
+        // pre-order DFS, so a deep dominator chain cannot blow the stack.
+        let mut stack: Vec<(BlockId, usize)> = Vec::new();
+        for root in roots {
+            if intervals[root.0 as usize].is_some() {
+                continue;
+            }
+            intervals[root.0 as usize] = Some((counter, counter));
+            counter += 1;
+            stack.push((root, 0));
+            while let Some((node, child_idx)) = stack.pop() {
+                let kids = &children[node.0 as usize];
+                if child_idx < kids.len() {
+                    stack.push((node, child_idx + 1));
+                    let child = kids[child_idx];
+                    if intervals[child.0 as usize].is_none() {
+                        intervals[child.0 as usize] = Some((counter, counter));
+                        counter += 1;
+                        stack.push((child, 0));
+                    }
+                } else if let Some((_, exit)) = intervals[node.0 as usize].as_mut() {
+                    *exit = counter;
+                }
+            }
+        }
+        Self { intervals }
+    }
+
+    /// True when `ancestor` dominates `node` (a block dominates itself).
+    #[must_use]
+    pub fn dominates(&self, ancestor: BlockId, node: BlockId) -> bool {
+        if ancestor == node {
+            return true;
+        }
+        let (Some(Some((a_enter, a_exit))), Some(Some((n_enter, n_exit)))) = (
+            self.intervals.get(ancestor.0 as usize),
+            self.intervals.get(node.0 as usize),
+        ) else {
+            return false;
+        };
+        *a_enter <= *n_enter && *n_exit <= *a_exit
+    }
 }
 
 /// CFG block ceiling above which deep analysis (SSA / dataflow) is skipped.

--- a/rust/tcl-compiler/src/taint.rs
+++ b/rust/tcl-compiler/src/taint.rs
@@ -103,7 +103,7 @@ use std::collections::{HashMap, HashSet};
 use tcl_core_types::{DiagCode, DiagFamily};
 
 use bitflags::bitflags;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use tcl_dialect::DialectSet;
 use tcl_lexer::{Lexer, SourceMap, Span, TokenType, backslash_subst};
@@ -1091,6 +1091,43 @@ fn collect_global_reads(ssa: &SsaFunction) -> FxHashSet<String> {
     out
 }
 
+/// One function's CFG/SSA analyses plus the CFG-derived indices
+/// [`propagate_taints`] walks, built once and reused across every
+/// propagation over that function.
+///
+/// Both indices are pure functions of the CFG, so rebuilding them per
+/// propagation is wasted work — and it was not a small amount of it:
+/// [`crate::taint_interproc::infer_proc_summary`] runs one propagation for the
+/// baseline plus one per (parameter, basis) scenario, and the summary
+/// worklist re-infers a procedure whenever a callee's summary moves, so an
+/// O(V+E) predecessor map and an O(V+E) reverse-postorder were being rebuilt
+/// dozens of times per function (issue #1251).
+pub(crate) struct TaintGraph<'a> {
+    /// The function's CFG.
+    pub cfg: &'a CfgFunction,
+    /// Its SSA form.
+    pub ssa: &'a SsaFunction,
+    /// The SCCP result gating block/edge executability.
+    pub sccp: &'a SccpResult,
+    /// Predecessor map for the phi joins, `rustc-hash`-keyed.
+    preds: FxHashMap<BlockId, FxHashSet<BlockId>>,
+    /// Reverse-postorder block visit order for the fixpoint sweep.
+    order: Vec<BlockId>,
+}
+
+impl<'a> TaintGraph<'a> {
+    /// Build the per-function indices once.
+    pub fn new(cfg: &'a CfgFunction, ssa: &'a SsaFunction, sccp: &'a SccpResult) -> Self {
+        Self {
+            cfg,
+            ssa,
+            sccp,
+            preds: cfg.predecessors_fx(),
+            order: cfg_order(cfg),
+        }
+    }
+}
+
 /// Run intra-procedural taint propagation over one SSA function.
 ///
 /// Returns a map from `(variable_name, ssa_version)` to its taint
@@ -1120,15 +1157,8 @@ fn collect_global_reads(ssa: &SsaFunction) -> FxHashSet<String> {
 ///   full return-summary transfer (`apply_proc_return_summary`)
 ///   instead of the conservative single-passthrough rule.
 #[must_use]
-// `too_many_arguments`: the call sites live in `compilation_unit.rs` (another
-// subsystem) and pass these analyses positionally; bundling would require
-// editing those out-of-scope callers. The grouping is already minimal —
-// each argument is an independent analysis input.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn propagate_taints(
-    cfg: &CfgFunction,
-    ssa: &SsaFunction,
-    sccp: &SccpResult,
+    graph: &TaintGraph<'_>,
     registry: &CommandRegistry,
     rendered_props: Option<&HashMap<ValueKey, RenderedValueProps>>,
     interproc: Option<&InterproceduralAnalysis>,
@@ -1136,8 +1166,13 @@ pub(crate) fn propagate_taints(
     param_taints: Option<&HashMap<String, TaintLattice>>,
     taint_summaries: Option<&HashMap<String, crate::taint_interproc::ProcTaintSummary>>,
 ) -> HashMap<ValueKey, TaintLattice> {
-    let preds = cfg.predecessors();
-    let order = cfg_order(cfg);
+    let TaintGraph {
+        cfg,
+        ssa,
+        sccp,
+        preds,
+        order,
+    } = graph;
 
     // Precompute the set of known procedure names once so per-call
     // resolution in `interproc_call_taint` is O(1) rather than
@@ -1164,14 +1199,14 @@ pub(crate) fn propagate_taints(
     let mut changed = true;
     while changed {
         changed = false;
-        for bn in &order {
+        for bn in order {
             if !sccp.executable_blocks.contains(bn) {
                 continue;
             }
             let Some(ssa_block) = ssa.blocks.get(bn) else {
                 continue;
             };
-            changed |= propagate_phi_taints(&mut taints, ssa_block, *bn, &preds, sccp);
+            changed |= propagate_phi_taints(&mut taints, ssa_block, *bn, preds, sccp);
             changed |= propagate_statement_taints(&mut taints, ssa_block, ctx, ssa, rendered_props);
         }
     }
@@ -1265,7 +1300,7 @@ fn propagate_phi_taints(
     taints: &mut HashMap<ValueKey, TaintLattice>,
     ssa_block: &crate::ssa::SsaBlock,
     bn: BlockId,
-    preds: &HashMap<BlockId, HashSet<BlockId>>,
+    preds: &FxHashMap<BlockId, FxHashSet<BlockId>>,
     sccp: &SccpResult,
 ) -> bool {
     let mut changed = false;
@@ -3547,6 +3582,24 @@ mod tests {
         }
     }
 
+    /// Bare intra-procedural propagation with no optional inputs.
+    fn plain_taints(
+        cfg: &CfgFunction,
+        ssa: &SsaFunction,
+        sccp: &SccpResult,
+        registry: &CommandRegistry,
+    ) -> HashMap<ValueKey, TaintLattice> {
+        propagate_taints(
+            &TaintGraph::new(cfg, ssa, sccp),
+            registry,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+    }
+
     #[test]
     fn clean_and_tainted_constructors() {
         let c = TaintLattice::clean();
@@ -3756,7 +3809,7 @@ mod tests {
         );
 
         let sccp = simple_sccp(&[entry]);
-        let taints = propagate_taints(&cfg, &ssa, &sccp, &registry, None, None, None, None, None);
+        let taints = plain_taints(&cfg, &ssa, &sccp, &registry);
         assert!(
             taints.get(&(x, 1)).is_some_and(|t| t.is_tainted()),
             "gets stdin result should be tainted"
@@ -3841,7 +3894,7 @@ mod tests {
         );
 
         let sccp = simple_sccp(&[entry]);
-        let taints = propagate_taints(&cfg, &ssa, &sccp, &registry, None, None, None, None, None);
+        let taints = plain_taints(&cfg, &ssa, &sccp, &registry);
         let warnings = find_taint_warnings(
             &cfg,
             &ssa,
@@ -3919,7 +3972,7 @@ mod tests {
             },
         );
         let sccp = simple_sccp(&[entry]);
-        let taints = propagate_taints(&cfg, &ssa, &sccp, &registry, None, None, None, None, None);
+        let taints = plain_taints(&cfg, &ssa, &sccp, &registry);
         find_taint_warnings(
             &cfg,
             &ssa,
@@ -4084,7 +4137,7 @@ mod tests {
             },
         );
         let sccp = simple_sccp(&[entry]);
-        let taints = propagate_taints(&cfg, &ssa, &sccp, &registry, None, None, None, None, None);
+        let taints = plain_taints(&cfg, &ssa, &sccp, &registry);
         // The transform colour must have propagated to y.
         assert!(
             taints
@@ -4152,7 +4205,7 @@ mod tests {
             },
         );
         let sccp = simple_sccp(&[entry]);
-        let taints = propagate_taints(&cfg, &ssa, &sccp, &registry, None, None, None, None, None);
+        let taints = plain_taints(&cfg, &ssa, &sccp, &registry);
         find_destructive_file_warnings(&cfg, &ssa, &taints, &sccp.executable_blocks, &registry)
     }
 
@@ -4342,7 +4395,7 @@ mod tests {
         );
 
         let sccp = simple_sccp(&[entry]);
-        let taints = propagate_taints(&cfg, &ssa, &sccp, &registry, None, None, None, None, None);
+        let taints = plain_taints(&cfg, &ssa, &sccp, &registry);
         assert!(
             taints.get(&(x, 1)).is_none_or(|t| !t.is_tainted()),
             "constant assignment should not be tainted"
@@ -4428,7 +4481,7 @@ mod tests {
         );
 
         let sccp = simple_sccp(&[entry]);
-        let taints = propagate_taints(&cfg, &ssa, &sccp, &registry, None, None, None, None, None);
+        let taints = plain_taints(&cfg, &ssa, &sccp, &registry);
         let warnings = find_taint_warnings(
             &cfg,
             &ssa,
@@ -4526,7 +4579,7 @@ mod tests {
         );
 
         let sccp = simple_sccp(&[entry]);
-        let taints = propagate_taints(&cfg, &ssa, &sccp, &registry, None, None, None, None, None);
+        let taints = plain_taints(&cfg, &ssa, &sccp, &registry);
         let warnings = find_taint_warnings(
             &cfg,
             &ssa,

--- a/rust/tcl-compiler/src/taint_interproc.rs
+++ b/rust/tcl-compiler/src/taint_interproc.rs
@@ -48,7 +48,7 @@ use crate::compilation_unit::{CompilationUnit, FunctionUnit};
 use crate::interprocedural::resolve_call_target;
 use crate::naming::normalise_var_name;
 use crate::ssa::{SsaFunction, Symbol, ValueKey};
-use crate::taint::{TaintColour, TaintCtx, TaintLattice, propagate_taints, word_taint};
+use crate::taint::{TaintColour, TaintCtx, TaintGraph, TaintLattice, propagate_taints, word_taint};
 use crate::value_shapes::parse_command_substitution;
 
 // Basis lattices
@@ -320,7 +320,12 @@ fn collect_return_taint(
 
 /// Run intra-procedural taint propagation over `fu` with the given entry
 /// taints and summaries. A thin wrapper threading the common arguments.
+///
+/// `graph` carries the CFG-derived indices, built once by the caller: one
+/// summary inference runs this `1 + params × BASIS_ORDER` times and the
+/// indices are identical across all of them (issue #1251).
 fn run_propagation(
+    graph: &TaintGraph<'_>,
     fu: &FunctionUnit,
     registry: &CommandRegistry,
     interproc: Option<&crate::interprocedural::InterproceduralAnalysis>,
@@ -329,9 +334,7 @@ fn run_propagation(
     summaries: &HashMap<String, ProcTaintSummary>,
 ) -> HashMap<ValueKey, TaintLattice> {
     propagate_taints(
-        &fu.cfg,
-        &fu.ssa,
-        &fu.sccp,
+        graph,
         registry,
         Some(&fu.rendered_props),
         interproc,
@@ -435,12 +438,15 @@ pub fn infer_proc_summary(
     // Prune 1 — the return taint does not depend on the taint map at all, so
     // neither the clean base nor any of the `15P` seeded scenarios needs a
     // solve.  Every scenario is `clean`, which is exactly what
-    // `ProcTaintSummary::untainted` builds.
+    // `ProcTaintSummary::untainted` builds.  Checked before the index build
+    // below, so a constant-return procedure costs nothing at all.
     if return_taint_is_constant(fu) {
         return ProcTaintSummary::untainted(qname, params);
     }
 
-    let base_taints = run_propagation(fu, registry, interproc, dialect, None, summaries);
+    // One index build for the baseline propagation and every scenario below.
+    let graph = TaintGraph::new(&fu.cfg, &fu.ssa, &fu.sccp);
+    let base_taints = run_propagation(&graph, fu, registry, interproc, dialect, None, summaries);
     let ctx = return_ctx(fu, registry, interproc, dialect, known, summaries);
     let return_base = collect_return_taint(fu, &base_taints, ctx);
 
@@ -461,7 +467,15 @@ pub fn infer_proc_summary(
         for basis in BASIS_ORDER {
             let mut seed: HashMap<String, TaintLattice> = HashMap::new();
             seed.insert(param.clone(), basis_lattice(basis));
-            let seeded = run_propagation(fu, registry, interproc, dialect, Some(&seed), summaries);
+            let seeded = run_propagation(
+                &graph,
+                fu,
+                registry,
+                interproc,
+                dialect,
+                Some(&seed),
+                summaries,
+            );
             scenario_values.push(collect_return_taint(fu, &seeded, ctx));
         }
         by_param_basis.push((param.clone(), scenario_values));
@@ -959,6 +973,7 @@ pub fn solve_interprocedural_taints_with(
 
     // Top-level taints under the converged summaries.
     let top_taints = run_propagation(
+        &TaintGraph::new(&cu.top_level.cfg, &cu.top_level.ssa, &cu.top_level.sccp),
         &cu.top_level,
         registry,
         interproc,
@@ -999,13 +1014,29 @@ pub fn solve_interprocedural_taints_with(
         }
     }
 
+    // The entry-taint worklist re-propagates a procedure every time one of its
+    // callers' argument taints move, so its CFG-derived indices are built once
+    // per procedure and cached rather than once per dequeue (issue #1251).
+    let mut graphs: HashMap<String, TaintGraph<'_>> = HashMap::new();
+
     while let Some(qname) = queue.pop_front() {
         queued.remove(&qname);
         let Some(fu) = cu.procedures.get(&qname) else {
             continue;
         };
         let entry = entry_taints.get(&qname).cloned().unwrap_or_default();
-        let taints = run_propagation(fu, registry, interproc, dialect, Some(&entry), &summaries);
+        let graph = graphs
+            .entry(qname.clone())
+            .or_insert_with(|| TaintGraph::new(&fu.cfg, &fu.ssa, &fu.sccp));
+        let taints = run_propagation(
+            graph,
+            fu,
+            registry,
+            interproc,
+            dialect,
+            Some(&entry),
+            &summaries,
+        );
 
         let flows = resolve_call_flows(
             fu, &taints, registry, interproc, dialect, &known, &summaries,
@@ -1125,7 +1156,8 @@ mod tests {
         let proc = &cu.ir_module.procedures[target];
         let fu = &cu.procedures[target];
 
-        let base = run_propagation(fu, &reg, interproc, None, None, &summaries);
+        let graph = TaintGraph::new(&fu.cfg, &fu.ssa, &fu.sccp);
+        let base = run_propagation(&graph, fu, &reg, interproc, None, None, &summaries);
         let ctx = return_ctx(fu, &reg, interproc, None, &known, &summaries);
         let return_base = collect_return_taint(fu, &base, ctx);
         let mut by_param_basis = Vec::new();
@@ -1134,7 +1166,8 @@ mod tests {
             for basis in BASIS_ORDER {
                 let mut seed = HashMap::new();
                 seed.insert(param.clone(), basis_lattice(basis));
-                let seeded = run_propagation(fu, &reg, interproc, None, Some(&seed), &summaries);
+                let seeded =
+                    run_propagation(&graph, fu, &reg, interproc, None, Some(&seed), &summaries);
                 values.push(collect_return_taint(fu, &seeded, ctx));
             }
             by_param_basis.push((param.clone(), values));

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -5594,3 +5594,112 @@ mod const_dominated_namespace_eval {
         assert_eq!(scope_names(src), ["::app"]);
     }
 }
+
+// ===========================================================================
+// Issue #1252 — a brace-quoted word's *elements* are literal too.
+//
+// The IR/analyser word arrives with its braces already stripped, so scanning
+// the element text alone reports "dynamic" for content Tcl never substitutes.
+// #1245 fixed the whole-word question for `namespace path`; these are the two
+// remaining places that ask it per element with the token in hand.
+//
+// tclsh-proof (8.6.16 / 9.0.4):
+//   namespace eval x {}
+//   namespace eval {::$ns} {}
+//   namespace eval n { namespace path {::$ns ::x} ; namespace path }
+//     ->  {::$ns} ::x        (an entry literally named `::$ns`, no var read)
+//   foreach n {aa {$b} cc} { puts $n }
+//     ->  aa / $b / cc       (three literal iterations, no read of `b`)
+// ===========================================================================
+mod braced_word_elements_are_literal {
+    use super::*;
+
+    /// Namespace-reference source texts recorded for `src`.
+    fn ns_ref_texts(src: &str) -> Vec<String> {
+        let r = Analyser::new().analyse(src, "tcl9.0").clone();
+        let mut out: Vec<String> = r
+            .namespace_refs
+            .iter()
+            .map(|n| src[n.span.start() as usize..n.span.end() as usize].to_owned())
+            .collect();
+        out.sort();
+        out
+    }
+
+    /// Diagnostic codes emitted for `src`.
+    fn diag_codes(src: &str) -> Vec<String> {
+        Analyser::new()
+            .analyse(src, "tcl9.0")
+            .diagnostics
+            .iter()
+            .map(|d| d.code.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn tp_namespace_path_records_a_braced_dollar_element_as_a_reference() {
+        // The whole-word gate (#1245) already lets the path be *recorded*;
+        // the element-reference walk skipped the same word, so the function
+        // disagreed with itself. Both must now see `::$ns`.
+        let src = "namespace eval n { namespace path {::$ns ::x} }\n";
+        assert!(
+            ns_ref_texts(src).iter().any(|t| t == "::$ns"),
+            "the braced element is a namespace literally named `::$ns`; got {:?}",
+            ns_ref_texts(src)
+        );
+    }
+
+    #[test]
+    fn fp_namespace_path_still_skips_a_substituting_element() {
+        // FP guard: an unbraced path word does substitute, so its `$ns` names
+        // nothing static and must stay unrecorded.
+        let src = "namespace eval n { namespace path ::$ns }\n";
+        assert!(
+            !ns_ref_texts(src).iter().any(|t| t.contains('$')),
+            "a substituting path word must record no element reference; got {:?}",
+            ns_ref_texts(src)
+        );
+    }
+
+    #[test]
+    fn tn_namespace_path_literal_elements_unchanged() {
+        let src = "namespace eval n { namespace path {::x ::y} }\n";
+        let refs = ns_ref_texts(src);
+        assert!(refs.iter().any(|t| t == "::x"), "{refs:?}");
+        assert!(refs.iter().any(|t| t == "::y"), "{refs:?}");
+    }
+
+    #[test]
+    fn tp_foreach_simulation_survives_a_braced_dollar_element() {
+        // One odd element used to abstain from the whole simulation, so every
+        // proc the loop installs went missing and each call raised W123.
+        let src = "foreach n {aa {$b} cc} { proc $n {} {} }\naa\ncc\n";
+        assert!(
+            !diag_codes(src).iter().any(|c| c == "W123"),
+            "the braced element must not abstain the whole simulation; got {:?}",
+            diag_codes(src)
+        );
+    }
+
+    #[test]
+    fn fp_foreach_simulation_still_abstains_on_a_substituting_list() {
+        // FP guard: a quoted list word *does* substitute, so its elements are
+        // not knowable and the simulation must still decline.
+        let src = "foreach n \"aa $b cc\" { proc $n {} {} }\naa\n";
+        assert!(
+            diag_codes(src).iter().any(|c| c == "W123"),
+            "a substituting list word must still abstain; got {:?}",
+            diag_codes(src)
+        );
+    }
+
+    #[test]
+    fn tn_foreach_simulation_literal_elements_unchanged() {
+        let src = "foreach n {aa cc} { proc $n {} {} }\naa\ncc\n";
+        assert!(
+            !diag_codes(src).iter().any(|c| c == "W123"),
+            "{:?}",
+            diag_codes(src)
+        );
+    }
+}

--- a/rust/tcl-compiler/tests/core_analyses.rs
+++ b/rust/tcl-compiler/tests/core_analyses.rs
@@ -48,7 +48,8 @@
 //! The analyser is deliberately conservative in a few places — it leaves a value
 //! `Overdefined` (sound: never substitutes a wrong constant) rather than folding
 //! a registry command, and it folds an existence check only for the two
-//! false-positive-free cases (a parameter always exists → true; a never-defined
+//! false-positive-free cases (a parameter always exists, as a scalar →
+//! `info exists` true / `array exists` false; a never-defined
 //! local never exists → false), declining flow-sensitive must-define / narrowing
 //! precision. None of these is unsound (no case folds a check C-Tcl leaves
 //! dynamic, nor suppresses a genuine read-before-set), so each is asserted at the
@@ -1114,6 +1115,152 @@ mod provably_present_folds_true {
         // tclsh: `set X 1; unset X; info exists X` → 0.
         let src = "proc p {} { set X 1; unset X; if {[info exists X]} { puts a } else { puts b } }";
         assert!(!i230_messages(src).iter().any(|m| m.contains("always true")));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Issue #1239 — `array exists PARAM` is constant **false**, not constant true.
+//
+// A formal parameter is bound as a scalar on entry (Tcl has no
+// pass-an-array-by-value), so the two existence spellings disagree on it. The
+// fold used to collapse both into one query shape and report `true` for each,
+// which inverted I230's live-branch report and made O101 fold the arm that
+// actually runs.
+//
+// tclsh-proof (8.6.16 / 9.0.4):
+//   proc f {a} { if {[array exists a]} { puts yes } else { puts no } }
+//   f 1                       ;# → no
+//   proc g {a} { info exists a }
+//   g 1                       ;# → 1
+//   proc h {a} { array set a {x 1} }
+//   h 1                       ;# → can't set "a(x)": variable isn't array
+//   proc k {a} { unset a; array set a {x 1}; array exists a }
+//   k 1                       ;# → 1
+// ---------------------------------------------------------------------------
+mod array_exists_parameter_is_false {
+    use super::*;
+
+    /// The `ConstantBranch` values recorded for `::p`'s existence fold.
+    fn branch_values(src: &str) -> Vec<bool> {
+        let cu = build(src);
+        let fn_p = cu.procedures.get("::p").expect("::p lowered");
+        fn_p.sccp
+            .constant_branches
+            .iter()
+            .map(|b| b.value)
+            .collect()
+    }
+
+    #[test]
+    fn tp_array_exists_parameter_folds_false() {
+        // TP: the fold fires, with value false — the `else` arm is the live one.
+        let src = "proc p {a} { if {[array exists a]} { puts dead } else { puts runs } }";
+        assert!(
+            i230_messages(src)
+                .iter()
+                .any(|m| m.contains("always false")),
+            "expected an 'always false' I230; got {:?}",
+            i230_messages(src)
+        );
+        assert_eq!(branch_values(src), vec![false]);
+    }
+
+    #[test]
+    fn tp_negated_array_exists_parameter_folds_true() {
+        // `![array exists a]` on a parameter → always true.
+        let src = "proc p {a} { if {![array exists a]} { puts runs } else { puts dead } }";
+        assert!(
+            i230_messages(src).iter().any(|m| m.contains("always true")),
+            "expected an 'always true' I230; got {:?}",
+            i230_messages(src)
+        );
+        assert_eq!(branch_values(src), vec![true]);
+    }
+
+    #[test]
+    fn tp_o101_folds_the_dead_arm_not_the_live_one() {
+        // O101/DCE consumes the recorded branch: the taken target must be the
+        // `else` block, and the unreachable arm the `then` block.
+        let src = "proc p {a} { if {[array exists a]} { puts dead } else { puts runs } }";
+        let cu = build(src);
+        let fn_p = cu.procedures.get("::p").expect("::p lowered");
+        let branch = fn_p
+            .sccp
+            .constant_branches
+            .first()
+            .expect("a constant branch is recorded");
+        assert!(
+            !branch.taken_target.contains("then"),
+            "the then arm must not be the taken target; got {branch:?}"
+        );
+        assert!(
+            branch.not_taken_target.contains("then"),
+            "the then arm must be the dead target; got {branch:?}"
+        );
+    }
+
+    #[test]
+    fn fp_info_exists_parameter_still_folds_true() {
+        // FP guard: the `info` spelling is unchanged — a parameter exists.
+        let src = "proc p {a} { if {[info exists a]} { puts runs } else { puts dead } }";
+        assert!(
+            i230_messages(src).iter().any(|m| m.contains("always true")),
+            "the info spelling must still fold true; got {:?}",
+            i230_messages(src)
+        );
+        assert_eq!(branch_values(src), vec![true]);
+    }
+
+    #[test]
+    fn fp_array_exists_never_defined_local_still_folds_false() {
+        // FP guard: the never-defined direction is spelling-independent —
+        // absent is absent under both. tclsh: `array exists FOO` → 0.
+        let src = "proc p {} { if {[array exists FOO]} { puts dead } else { puts runs } }";
+        assert_eq!(branch_values(src), vec![false]);
+    }
+
+    #[test]
+    fn tn_unset_parameter_abstains() {
+        // TN: `unset a` removes the scalar binding, after which `array set a`
+        // legitimately makes `a` an array — the fold must abstain, as it
+        // already did for the `info` spelling.
+        for src in [
+            "proc p {a} { unset a; array set a {x 1}; if {[array exists a]} { puts x } else { puts y } }",
+            "proc p {a} { unset a; if {[array exists a]} { puts x } else { puts y } }",
+        ] {
+            assert!(
+                branch_values(src).is_empty(),
+                "an unset parameter must abstain; got {:?} for {src:?}",
+                i230_messages(src)
+            );
+        }
+    }
+
+    #[test]
+    fn tn_dynamic_destroy_abstains() {
+        // TN: `unset $n` can name the parameter, so the same abstention as the
+        // `info` spelling applies. tclsh 9.0.4 / 8.6.16:
+        //   proc f {p n} { unset $n; array set p {x 1}; array exists p }
+        //   f hello p  → 1
+        let src = "proc p {a n} { unset $n; if {[array exists a]} { puts x } else { puts y } }";
+        assert!(
+            branch_values(src).is_empty(),
+            "a dynamic destroy must abstain; got {:?}",
+            i230_messages(src)
+        );
+    }
+
+    #[test]
+    fn tn_array_parameter_with_upvar_alias_abstains() {
+        // TN: an `upvar`-bound local tracks the linked variable, which may well
+        // be an array — never folded either way, both spellings.
+        let src =
+            "proc p {name} { upvar 1 $name a; if {[array exists a]} { puts x } else { puts y } }";
+        assert!(
+            branch_values(src).is_empty(),
+            "an upvar alias must abstain; got {:?}",
+            i230_messages(src)
+        );
     }
 }
 

--- a/rust/tcl-lsp-core/src/completion.rs
+++ b/rust/tcl-lsp-core/src/completion.rs
@@ -527,6 +527,14 @@ fn context_aware_completions(
         if !values.is_empty() {
             return Some(arg_value_completions(values, partial));
         }
+        // A boolean-valued option has no enumerable `values` — Tcl accepts
+        // every spelling `abbrev::boolean_table` resolves, prefixes included,
+        // which a closed set cannot express. The registry says so with
+        // `ArgRole::Boolean` (issue #1256), and the vocabulary comes from the
+        // one place that models it.
+        if opt.value_is_boolean() {
+            return Some(boolean_value_completions(partial));
+        }
     }
     // Command-level positional arg-value completion — the
     // bareword value sets declared directly on the command
@@ -1817,6 +1825,35 @@ fn nth_word_on_line(source: &str, line: u32, n: usize) -> Option<String> {
 /// values (e.g. `string is <class>`), filtered by `partial`.
 fn arg_value_completions(values: &[tcl_registry::ArgValue], partial: &str) -> Vec<CompletionItem> {
     arg_value_completions_from(values.iter().collect(), partial)
+}
+
+/// Build completions for a value position the registry declares boolean
+/// (`ArgRole::Boolean`), filtered by `partial`.
+///
+/// The vocabulary is `tcl_registry::abbrev::BOOLEAN_KEYWORDS` — the same list
+/// `resolve_boolean` accepts, so completion, the formatter's canonical-boolean
+/// rewrite, and the analyser cannot disagree about what a boolean word is.
+fn boolean_value_completions(partial: &str) -> Vec<CompletionItem> {
+    let candidates: Vec<&&str> = tcl_registry::abbrev::BOOLEAN_KEYWORDS.iter().collect();
+    let FilteredCandidates { candidates, fuzzy } = filter_candidates(partial, candidates, |v| **v);
+    let mut items: Vec<CompletionItem> = candidates
+        .into_iter()
+        .map(|value| CompletionItem {
+            label: (*value).to_owned(),
+            insert_text: (*value).to_owned(),
+            kind: CompletionKind::EnumValue,
+            detail: Some("boolean".to_owned()),
+            sort_text: None,
+            is_snippet: false,
+            filter_text: None,
+            text_edit: None,
+            documentation: None,
+        })
+        .collect();
+    if fuzzy {
+        decorate_fuzzy_items(&mut items, partial);
+    }
+    items
 }
 
 fn arg_value_completions_from(

--- a/rust/tcl-lsp-core/src/formatting/config.rs
+++ b/rust/tcl-lsp-core/src/formatting/config.rs
@@ -31,6 +31,7 @@
 //! knobs affect a plain format pass.
 
 use tcl_lexer::LexerConfig;
+use tcl_registry::prelude::DialectSet;
 
 /// Where to place opening braces.  Only K&R is supported (the F5
 /// style-guide default); the enum exists so the field can grow.
@@ -227,6 +228,26 @@ pub struct FormatterConfig {
     /// ([`LexerConfig::default`]); set to [`LexerConfig::for_dialect`] to format
     /// a specific dialect.
     pub lexer_config: LexerConfig,
+    /// The document's resolved dialect name (`"tcl8.6"`, `"f5-irules"`, …),
+    /// or `None` when the caller does not know it.
+    ///
+    /// The formatter's entry points take a `&CommandRegistry`, which is
+    /// already dialect-specific, so the *table contents* were always right —
+    /// but nothing said which release, so no rewrite could reason about
+    /// spellings that differ across versions (issue #1257).  Set together
+    /// with [`Self::target_range`].
+    pub dialect: Option<String>,
+    /// The **range of releases** the document must stay correct across.
+    ///
+    /// Empty (the default) means "only the registry handed to the formatter"
+    /// — the pre-existing behaviour.  Set it to
+    /// [`tcl_registry::version_range::forward_range`] of the document's
+    /// dialect to make the version-range-aware rewrites apply: an
+    /// abbreviation is then expanded only when it resolves to the *same*
+    /// keyword in every release of the range, so a prefix that a later Tcl
+    /// makes ambiguous is left alone rather than expanded into one of its
+    /// candidates.
+    pub target_range: DialectSet,
 }
 
 impl Default for FormatterConfig {
@@ -260,6 +281,8 @@ impl Default for FormatterConfig {
             expand_abbreviations: true,
             boolean_form: BooleanForm::TrueFalse,
             lexer_config: LexerConfig::default(),
+            dialect: None,
+            target_range: DialectSet::empty(),
         }
     }
 }

--- a/rust/tcl-lsp-core/src/formatting/engine.rs
+++ b/rust/tcl-lsp-core/src/formatting/engine.rs
@@ -1225,11 +1225,19 @@ fn keyword_rewrites_for(
                     .any(|t| matches!(t.kind, TokenType::Var | TokenType::Cmd | TokenType::Expand))
         })
         .collect();
-    // The registry handed to the formatter is already the document's
-    // dialect pack, so no further dialect intersection is applied here;
-    // passing `None` keeps every declared keyword a candidate, which can only
-    // make a prefix *less* unique — the conservative direction.
-    super::keywords::rewrites_for_command(registry, None, config, &cmd.name, &words, &dynamic)
+    // The document's own release filters the candidate table, so a keyword a
+    // later Tcl adds is not counted against a prefix the target resolves
+    // uniquely.  The forward-compatibility half — "and it must still mean the
+    // same thing in every later release of the target range" — is enforced
+    // inside `rewrites_for_command` from `config.target_range` (issue #1257).
+    // With no dialect declared this falls back to `None`, the pre-#1257
+    // conservative direction: every declared keyword stays a candidate, which
+    // can only make a prefix *less* unique.
+    let dialect = config
+        .dialect
+        .as_deref()
+        .and_then(tcl_registry::prelude::DialectSet::parse);
+    super::keywords::rewrites_for_command(registry, dialect, config, &cmd.name, &words, &dynamic)
         .into_iter()
         .map(|r| (r.index + 1, r.text))
         .collect()

--- a/rust/tcl-lsp-core/src/formatting/keywords.rs
+++ b/rust/tcl-lsp-core/src/formatting/keywords.rs
@@ -41,13 +41,16 @@
 //! * Strict tables are never touched.
 //! * Command names are never touched: Tcl does not prefix-match them.
 //! * A dynamic word (`$sub`, `[pick]`, `{*}`-expanded) abstains.
-//! * A boolean word is rewritten **only** at a consumption site the registry
-//!   proves boolean. A value-definition site (`set flag yes`) keeps its
+//! * A boolean word is rewritten **only** where the registry declares
+//!   [`tcl_registry::ArgRole::Boolean`] — the word is consumed through
+//!   `Tcl_GetBooleanFromObj` and its bytes are never otherwise observable
+//!   (issue #1256). A value-definition site (`set flag yes`) keeps its
 //!   bytes, because `$flag` may later meet `eq "yes"`, a `switch` arm, or a
 //!   log line — `true` and `yes` are different strings even though both are
 //!   truthy.
-//! * `0`/`1` are also valid integers, so a site whose role is
-//!   numeric-or-boolean abstains rather than guess.
+//! * `0`/`1` are also valid integers, so a
+//!   [`tcl_registry::ArgRole::NumericOrBoolean`] position is a distinct
+//!   declared fact and abstains rather than guess.
 //!
 //! Both rewrites are idempotent: a canonical spelling resolves to itself, and
 //! the configured boolean form maps to itself.
@@ -196,7 +199,7 @@ pub(crate) fn rewrites_for_command(
         // a boolean and nothing else.
         if consumed == 1
             && config.boolean_form != BooleanForm::Preserve
-            && option_value_is_boolean(opt)
+            && opt.value_is_boolean()
             && touchable(i + 1)
             && let Some(value) = args.get(i + 1)
             && let Some(text) = canonical_boolean(value, config.boolean_form)
@@ -206,24 +209,6 @@ pub(crate) fn rewrites_for_command(
         i += 1 + consumed;
     }
     out
-}
-
-/// Whether this option's value is consumed *purely* as a boolean.
-///
-/// The signal is the option's own declared value set: a closed set that is
-/// exactly the boolean vocabulary. A set that also admits integers, or an
-/// open value, abstains — `0`/`1` are valid integers too, so a
-/// numeric-or-boolean site must not be rewritten.
-fn option_value_is_boolean(opt: &OptionSpec) -> bool {
-    let values = opt.value_values();
-    if values.is_empty() || opt.value_integer_domain().is_some() {
-        return false;
-    }
-    values
-        .iter()
-        .all(|v| tcl_registry::abbrev::resolve_boolean(v.value).is_some())
-        // A single-valued set is a literal keyword, not a boolean pair.
-        && values.len() >= 2
 }
 
 #[cfg(test)]

--- a/rust/tcl-lsp-core/src/formatting/keywords.rs
+++ b/rust/tcl-lsp-core/src/formatting/keywords.rs
@@ -56,7 +56,7 @@
 //! the configured boolean form maps to itself.
 
 use tcl_registry::CommandRegistry;
-use tcl_registry::abbrev::KeywordMatch;
+use tcl_registry::abbrev::PrefixMatching;
 use tcl_registry::hover::OptionSpec;
 use tcl_registry::prelude::DialectSet;
 
@@ -91,6 +91,117 @@ fn canonical_boolean(word: &str, form: BooleanForm) -> Option<String> {
     (target != word).then(|| target.to_owned())
 }
 
+/// Which keyword table of a command the version-range check should build.
+#[derive(Debug, Clone, Copy)]
+enum RangeTable<'a> {
+    /// The ensemble's subcommand words.
+    Subcommands,
+    /// The command's own option words (a command with no subcommands).
+    CommandOptions,
+    /// The named subcommand's option words.
+    SubcommandOptions(&'a str),
+}
+
+/// Whether `word` still resolves to `canonical` in **every** release of the
+/// document's target range (issue #1257).
+///
+/// The target release has already answered `Unique(canonical)` — this is the
+/// forward-compatibility half: a prefix unique today can become ambiguous
+/// when a later Tcl adds a keyword (`string cat` arrived in 8.6.2 and
+/// shortened what `string c…` could mean), and expanding it would rewrite
+/// source that a newer interpreter reads differently.
+///
+/// An empty range (the default, and every vendor dialect with no core version
+/// bit) means "no range was declared", so the target's own answer stands —
+/// the pre-existing behaviour. A release that no longer carries the command
+/// contributes an empty table, which can never vouch for the word, so the
+/// rewrite is abandoned.
+fn resolves_across_range(
+    config: &FormatterConfig,
+    cmd_name: &str,
+    scope: RangeTable<'_>,
+    word: &str,
+    canonical: &str,
+) -> bool {
+    let releases = tcl_registry::version_range::core_releases_in(config.target_range);
+    if releases.is_empty() {
+        return true;
+    }
+    let empty =
+        || tcl_registry::abbrev::KeywordTable::new(std::iter::empty(), PrefixMatching::Enabled);
+    let tables: Vec<_> = releases
+        .iter()
+        .map(|release| {
+            // Each release's table is filtered by *its own* dialect bit — a
+            // keyword added in 9.0 is a candidate in 9.0's table and not in
+            // 8.6's, which is what makes the range question meaningful.
+            let bits = DialectSet::parse(release);
+            let Some(spec) = tcl_registry::registry_for_dialect(release).get(cmd_name) else {
+                return empty();
+            };
+            match scope {
+                RangeTable::Subcommands => spec.subcommand_table(bits, None, None),
+                RangeTable::CommandOptions => spec.option_table(bits, None, None),
+                RangeTable::SubcommandOptions(name) => spec
+                    .subcommands
+                    .iter()
+                    .find(|s| s.name == name)
+                    .map_or_else(empty, |sub| sub.option_table(bits, None, None)),
+            }
+        })
+        .collect();
+    tcl_registry::abbrev::resolve_over_versions(&tables, word).unique() == Some(canonical)
+}
+
+/// The option table a command's leading subcommand word selects, and where the
+/// option scan starts.
+struct OptionScope {
+    /// The option specs to resolve `-option` words against.
+    options: &'static [OptionSpec],
+    /// The table's prefix-matching strictness.
+    prefix: PrefixMatching,
+    /// Which table the version-range check should rebuild per release.
+    range_table: RangeTable<'static>,
+    /// The first argument index the option scan looks at.
+    start: usize,
+}
+
+/// Resolve an ensemble's subcommand word, pushing its expansion rewrite when
+/// one applies, and return the option scope it selects.
+///
+/// `None` when the word is ambiguous or unknown — the formatter never guesses,
+/// and it cannot know which option table applies either.
+fn subcommand_scope(
+    spec: &tcl_registry::CommandSpec,
+    dialect: Option<DialectSet>,
+    config: &FormatterConfig,
+    cmd_name: &str,
+    word: &str,
+    out: &mut Vec<KeywordRewrite>,
+) -> Option<OptionScope> {
+    let canonical = spec
+        .resolve_subcommand_word(word, dialect, None, None)
+        .unique()?;
+    if config.expand_abbreviations
+        && canonical != word
+        && resolves_across_range(config, cmd_name, RangeTable::Subcommands, word, canonical)
+    {
+        out.push(KeywordRewrite {
+            index: 0,
+            text: canonical.to_owned(),
+        });
+    }
+    let sub = spec.subcommands.iter().find(|s| s.name == canonical);
+    Some(OptionScope {
+        options: sub.map_or(spec.options, |sub| sub.options),
+        prefix: sub.map_or(spec.prefix_matching, |sub| sub.prefix_matching),
+        range_table: sub.map_or(RangeTable::CommandOptions, |sub| {
+            RangeTable::SubcommandOptions(sub.name)
+        }),
+        start: 1,
+    })
+}
+
 /// Compute every keyword rewrite for one command invocation.
 ///
 /// `args` are the written argument words (after the command name).
@@ -118,37 +229,29 @@ pub(crate) fn rewrites_for_command(
     let mut out: Vec<KeywordRewrite> = Vec::new();
 
     // The subcommand word, and the option table it selects.
-    let mut options: &'static [OptionSpec] = spec.options;
-    let mut start = 0usize;
-    let mut sub_prefix = spec.prefix_matching;
-    if !spec.subcommands.is_empty() {
+    let scope = if spec.subcommands.is_empty() {
+        OptionScope {
+            options: spec.options,
+            prefix: spec.prefix_matching,
+            range_table: RangeTable::CommandOptions,
+            start: 0,
+        }
+    } else {
         if !touchable(0) {
             return out;
         }
-        let word = &args[0];
-        match spec.resolve_subcommand_word(word, dialect, None, None) {
-            KeywordMatch::Unique(canonical) => {
-                if config.expand_abbreviations && canonical != word {
-                    out.push(KeywordRewrite {
-                        index: 0,
-                        text: canonical.to_owned(),
-                    });
-                }
-                if let Some(sub) = spec.subcommands.iter().find(|s| s.name == canonical) {
-                    options = sub.options;
-                    sub_prefix = sub.prefix_matching;
-                }
-            }
+        match subcommand_scope(spec, dialect, config, cmd_name, &args[0], &mut out) {
+            Some(scope) => scope,
             // Ambiguous or unknown: the formatter never guesses, and it
             // cannot know which option table applies either.
-            KeywordMatch::Ambiguous(_) | KeywordMatch::Unknown => return out,
+            None => return out,
         }
-        start = 1;
-    }
+    };
 
-    if options.is_empty() {
+    if scope.options.is_empty() {
         return out;
     }
+    let options = scope.options;
     let table = tcl_registry::abbrev::KeywordTable::from_keywords(
         options
             .iter()
@@ -161,10 +264,10 @@ pub(crate) fn rewrites_for_command(
                         min_abbrev: opt.min_abbrev,
                     })
             }),
-        sub_prefix,
+        scope.prefix,
     );
 
-    let mut i = start;
+    let mut i = scope.start;
     while i < args.len() {
         let word = args[i].as_str();
         if word == "--" {
@@ -184,7 +287,10 @@ pub(crate) fn rewrites_for_command(
             i += 1;
             continue;
         };
-        if config.expand_abbreviations && canonical != word {
+        if config.expand_abbreviations
+            && canonical != word
+            && resolves_across_range(config, cmd_name, scope.range_table, word, canonical)
+        {
             out.push(KeywordRewrite {
                 index: i,
                 text: canonical.to_owned(),

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -1137,6 +1137,20 @@ fn option_hover_text(
     if opt.takes_value() && !opt.value_hint().is_empty() {
         let _ = write!(out, "\nTakes a `{}` value.\n", opt.value_hint());
     }
+    // A boolean-valued option accepts the whole boolean vocabulary, prefixes
+    // included — a fact the registry now declares (`ArgRole::Boolean`, issue
+    // #1256) rather than something a reader has to know.
+    if opt.value_is_boolean() {
+        let _ = write!(
+            out,
+            "\nAccepts any boolean spelling: {}.\n",
+            tcl_registry::abbrev::BOOLEAN_KEYWORDS
+                .iter()
+                .map(|k| format!("`{k}`"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
     // §5.2 profile gating: intersects membership + the version ceiling —
     // an inherited option on a vendor command counts as available under
     // that vendor's composed profile.

--- a/rust/tcl-lsp-core/src/minify.rs
+++ b/rust/tcl-lsp-core/src/minify.rs
@@ -1679,15 +1679,19 @@ fn command_word_runs(sm: &SourceMap, tokens: &[Token]) -> Vec<Vec<CommandWord>> 
 
 /// The core-Tcl registries for every release *after* `dialect`, so a prefix
 /// that a later Tcl makes ambiguous is never emitted.
+///
+/// The range and its packs come from
+/// [`tcl_registry::version_range`] — the one helper the formatter and the
+/// analyser share — rather than a release list kept here (issue #1257). The
+/// target's own pack is dropped because the caller already holds it and
+/// [`keyword_tables`] puts it first.
 fn later_core_registries(dialect: &str) -> Vec<&'static CommandRegistry> {
-    const CORE_ORDER: &[&str] = &["tcl8.4", "tcl8.5", "tcl8.6", "tcl9.0"];
-    let Some(pos) = CORE_ORDER.iter().position(|d| *d == dialect) else {
-        return Vec::new();
-    };
-    CORE_ORDER[pos + 1..]
-        .iter()
-        .map(|d| tcl_registry::registry_for_dialect(d))
-        .collect()
+    use tcl_registry::version_range::{forward_range, registries_over_range};
+    let mut packs = registries_over_range(forward_range(dialect));
+    if !packs.is_empty() {
+        packs.remove(0);
+    }
+    packs
 }
 
 /// Shorten every abbreviable keyword word of one command.

--- a/rust/tcl-lsp-core/tests/formatting_keywords.rs
+++ b/rust/tcl-lsp-core/tests/formatting_keywords.rs
@@ -260,3 +260,101 @@ fn a_dynamic_boolean_option_value_abstains() {
     let out = default_fmt("fconfigure $c -blocking $flag\n");
     assert!(out.contains("-blocking $flag"), "{out}");
 }
+
+// ---------------------------------------------------------------------------
+// Issue #1257 — the formatter config carries the document's dialect and target
+// version range, so a version-range-aware rewrite can apply it.
+//
+// tclsh ground truth: `string c` is unique in 8.5 (only `compare` starts with
+// `c`) but ambiguous in 8.6+, where `string cat` arrived —
+//   tclsh8.5: string c abc abc  -> 0
+//   tclsh8.6: string c abc abc  -> ambiguous subcommand "c": must be ...
+// so expanding `string c` to `string compare` in a file that may be run on
+// 8.6 changes what a newer interpreter does with the source.
+// ---------------------------------------------------------------------------
+
+/// Format `src` against `dialect`'s registry, with the target range set to
+/// that release and every later one.
+fn fmt_over_range(src: &str, dialect: &str) -> String {
+    let registry = tcl_registry::registry_for_dialect(dialect);
+    let config = FormatterConfig {
+        dialect: Some(dialect.to_owned()),
+        target_range: tcl_registry::version_range::forward_range(dialect),
+        ..FormatterConfig::default()
+    };
+    format_tcl(src, &config, registry)
+}
+
+/// Format `src` against `dialect`'s registry with no declared range — the
+/// pre-#1257 behaviour, kept as the control.
+fn fmt_no_range(src: &str, dialect: &str) -> String {
+    let registry = tcl_registry::registry_for_dialect(dialect);
+    format_tcl(src, &FormatterConfig::default(), registry)
+}
+
+#[test]
+fn the_default_config_declares_no_range() {
+    let cfg = FormatterConfig::default();
+    assert_eq!(cfg.dialect, None);
+    assert!(cfg.target_range.is_empty());
+    // No dialect and no range: every declared keyword stays a candidate, the
+    // pre-#1257 conservative direction. `string c` is ambiguous under that
+    // rule (8.6's `cat` is in the table whatever the target), so it is left
+    // alone — unchanged behaviour.
+    assert!(fmt_no_range("string c $a $b\n", "tcl8.5").contains("string c $a $b"));
+}
+
+#[test]
+fn a_prefix_ambiguous_later_in_the_range_is_not_expanded() {
+    // `info e` is unique in 8.4 — `exists` is the only `e…` subcommand — but
+    // `info errorstack` (9.0) collides at `e`. Declaring the range makes the
+    // 8.4 table precise *and* keeps the expansion off, because the whole
+    // range must agree.
+    //
+    // tclsh ground truth:
+    //   tclsh8.4: info e x        -> 0          (resolves to `info exists`)
+    //   tclsh9.0: info e x        -> ambiguous option "e": must be args, ...
+    let out = fmt_over_range("info e x\n", "tcl8.4");
+    assert!(out.contains("info e x"), "{out}");
+    assert!(!out.contains("info exists"), "{out}");
+}
+
+#[test]
+fn a_subcommand_a_later_release_removes_is_not_expanded() {
+    // `trace vd` is `vdelete` in 8.4/8.5 and the subcommand is gone in 9.0,
+    // so no spelling of it survives the whole range. Not expanded.
+    //
+    // tclsh ground truth:
+    //   tclsh8.5: trace vdelete x w handler   -> ok (deprecated form)
+    //   tclsh9.0: trace vdelete ...           -> unknown option "vdelete"
+    let out = fmt_over_range("trace vd x w handler\n", "tcl8.5");
+    assert!(out.contains("trace vd x w handler"), "{out}");
+    assert!(!out.contains("vdelete"), "{out}");
+}
+
+#[test]
+fn a_prefix_unique_across_the_whole_range_still_expands() {
+    // TN: `le` is `length` in every release from 8.5 on, so the range check
+    // does not cost the ordinary expansion.
+    for dialect in ["tcl8.5", "tcl8.6", "tcl9.0"] {
+        let out = fmt_over_range("string le $s\n", dialect);
+        assert!(out.contains("string length $s"), "{dialect} -> {out}");
+    }
+}
+
+#[test]
+fn an_option_prefix_is_checked_over_the_range_too() {
+    // The same rule applies to option words, not just subcommands.
+    let out = fmt_over_range("lsearch -noc $x $p\n", "tcl8.6");
+    assert!(out.contains("lsearch -nocase $x $p"), "{out}");
+}
+
+#[test]
+fn a_vendor_dialect_has_no_core_range_and_behaves_as_before() {
+    // `f5-irules` names a runtime, not a core release: the forward range is
+    // empty, so the handed registry stays the whole story.
+    let cfg_range = tcl_registry::version_range::forward_range("f5-irules");
+    assert!(cfg_range.is_empty());
+    let out = fmt_over_range("string le $s\n", "f5-irules");
+    assert!(out.contains("string length $s"), "{out}");
+}

--- a/rust/tcl-lsp-core/tests/formatting_keywords.rs
+++ b/rust/tcl-lsp-core/tests/formatting_keywords.rs
@@ -194,3 +194,69 @@ fn formatting_never_changes_a_range_it_was_not_asked_about() {
         "the second line is outside the range: {text}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #1256 — the boolean consumption site is a declared registry fact
+// (`ArgRole::Boolean`), not something inferred from an option's value set.
+//
+// tclsh-proof (8.6.16 / 9.0.4): the value's bytes are consumed and discarded,
+// so every spelling of the same truth value is interchangeable —
+//   set c [open /dev/null]
+//   chan configure $c -blocking yes ; chan configure $c -blocking   ;# -> 1
+//   chan configure $c -blocking off ; chan configure $c -blocking   ;# -> 0
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_declared_boolean_option_value_normalises() {
+    // Before the fact existed, the inference reached exactly two options in
+    // the whole registry (`tcltest::configure -limitconstraints`/
+    // `-singleproc`); every core boolean option was invisible to it.
+    for (src, want) in [
+        ("fconfigure $c -blocking yes\n", "-blocking true"),
+        ("fconfigure $c -blocking 0\n", "-blocking false"),
+        ("socket -server $cb -reuseaddr on 0\n", "-reuseaddr true"),
+        ("clock format $t -gmt 1\n", "-gmt true"),
+    ] {
+        let out = default_fmt(src);
+        assert!(out.contains(want), "{src} -> {out}");
+    }
+}
+
+#[test]
+fn the_configured_form_reaches_a_declared_boolean_option() {
+    for (form, want) in [
+        (BooleanForm::YesNo, "-blocking yes"),
+        (BooleanForm::OnOff, "-blocking on"),
+        (BooleanForm::ZeroOne, "-blocking 1"),
+    ] {
+        let config = FormatterConfig {
+            boolean_form: form,
+            ..FormatterConfig::default()
+        };
+        let out = fmt("fconfigure $c -blocking true\n", &config);
+        assert!(out.contains(want), "{form:?} -> {out}");
+    }
+}
+
+#[test]
+fn a_non_boolean_option_value_is_never_rewritten() {
+    // TN: `-translation` takes an enum, `-buffersize` a count. Neither is a
+    // boolean consumption site, so `binary`/`1` keep their bytes.
+    let out = default_fmt("fconfigure $c -translation binary -buffersize 1\n");
+    assert!(out.contains("-translation binary"), "{out}");
+    assert!(out.contains("-buffersize 1"), "{out}");
+}
+
+#[test]
+fn boolean_option_rewriting_is_idempotent() {
+    let once = default_fmt("fconfigure $c -blocking yes\n");
+    assert_eq!(once, default_fmt(&once));
+}
+
+#[test]
+fn a_dynamic_boolean_option_value_abstains() {
+    // FP guard: the value is a substitution, so there are no bytes to
+    // canonicalise.
+    let out = default_fmt("fconfigure $c -blocking $flag\n");
+    assert!(out.contains("-blocking $flag"), "{out}");
+}

--- a/rust/tcl-lsp-core/tests/hover_completion.rs
+++ b/rust/tcl-lsp-core/tests/hover_completion.rs
@@ -834,3 +834,53 @@ fn completion_proc_scope_still_qualifies_globals_in_every_dialect_m11() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Issue #1256 — completion and hover read the declared boolean argument role.
+//
+// tclsh (8.6.16 / 9.0.4): `fconfigure` / `chan configure -blocking` accepts
+// every boolean spelling and reports the canonical integer back —
+//   set c [open /dev/null]; fconfigure $c -blocking yes; fconfigure $c -blocking
+//     -> 1
+// so the whole boolean vocabulary is legal at the position; the registry now
+// declares that with `ArgRole::Boolean` rather than leaving it implicit.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn completion_offers_the_boolean_vocabulary_at_a_boolean_option_value() {
+    let src = "fconfigure $c -blocking \n";
+    let analysis = analyse(src);
+    let reg = registry();
+    let items = completions(src, 0, 24, &analysis, Some(&reg), None, "tcl8.6");
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    for want in ["true", "false", "yes", "no", "on", "off", "0", "1"] {
+        assert!(labels.contains(&want), "expected `{want}` in {labels:?}");
+    }
+    for it in &items {
+        assert_eq!(it.kind, CompletionKind::EnumValue, "{it:?}");
+    }
+}
+
+#[test]
+fn completion_filters_the_boolean_vocabulary_by_partial() {
+    let src = "fconfigure $c -blocking t\n";
+    let analysis = analyse(src);
+    let reg = registry();
+    let items = completions(src, 0, 25, &analysis, Some(&reg), None, "tcl8.6");
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(labels.contains(&"true"), "{labels:?}");
+    assert!(!labels.contains(&"false"), "filtered by `t`: {labels:?}");
+}
+
+#[test]
+fn hover_on_a_boolean_option_names_the_vocabulary() {
+    let src = "fconfigure $c -blocking yes\n";
+    let analysis = analyse(src);
+    let reg = registry();
+    let h = hover(src, 0, 16, &analysis, Some(&reg)).expect("option hover");
+    assert!(
+        h.value.contains("boolean") && h.value.contains("`yes`"),
+        "hover must name the boolean vocabulary: {}",
+        h.value
+    );
+}

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -12464,6 +12464,11 @@ impl LanguageServer for Backend {
         let formatting = self.resolved_formatting(&params.text_document.uri).await;
         let mut config = core_formatting::FormatterConfig {
             lexer_config: tcl_lexer::LexerConfig::for_dialect(&doc.dialect),
+            dialect: Some(doc.dialect.clone()),
+            // Version-range-aware rewrites (#1257): the document targets this
+            // release but may be run on a later one, so a spelling is only
+            // rewritten when it means the same thing across the whole range.
+            target_range: tcl_registry::version_range::forward_range(&doc.dialect),
             ..core_formatting::FormatterConfig::default()
         };
         if let Some(obj) = formatting.as_object() {
@@ -15470,6 +15475,11 @@ fn formatter_config_from(
         // `if {expr}{body}` (`}{` valid in TMM) is parsed and re-emitted as
         // `} {` rather than left unchanged by the stock-Tcl lexer.
         lexer_config: tcl_lexer::LexerConfig::for_dialect(dialect),
+        dialect: Some(dialect.to_owned()),
+        // Version-range-aware rewrites (#1257): the document targets this
+        // release but may be run on a later one, so a spelling is only
+        // rewritten when it means the same thing across the whole range.
+        target_range: tcl_registry::version_range::forward_range(dialect),
         ..Default::default()
     };
     if let Some(obj) = formatting.as_object() {

--- a/rust/tcl-registry/src/arg_role.rs
+++ b/rust/tcl-registry/src/arg_role.rs
@@ -164,6 +164,41 @@ pub enum ArgRole {
     /// role carries navigation identity only, the same split
     /// [`Self::CommandName`] / [`Self::CommandNameProbe`] draw for commands.
     NamespaceName,
+    /// A word consumed **purely as a boolean** — the command runs it through
+    /// `Tcl_GetBooleanFromObj` (or the Tcl-level equivalent) and its bytes
+    /// are never otherwise observable, so every accepted spelling of the same
+    /// truth value is interchangeable (issue #1256).
+    ///
+    /// That interchangeability is the whole point: it is what lets the
+    /// formatter's canonical-boolean rewrite turn `-strict yes` into
+    /// `-strict true` without changing behaviour, and what lets completion
+    /// and hover offer the boolean vocabulary
+    /// ([`crate::abbrev::BOOLEAN_KEYWORDS`]) at the position. Before this
+    /// role the fact had to be *inferred* from an option's declared value set
+    /// happening to enumerate the boolean words, which covered two options in
+    /// the whole registry.
+    ///
+    /// Stamp it only where the bytes truly do not escape. A value that is
+    /// stored and later compared as a string (`set flag yes` … `$flag eq
+    /// "yes"`), or echoed back by an introspection subcommand, is **not** in
+    /// this role — `true` and `yes` are different strings even though both
+    /// are truthy.
+    ///
+    /// tclsh-proof (8.6.16 / 9.0.4): `fconfigure $c -blocking` accepts every
+    /// spelling and reports back the canonical integer —
+    /// `chan configure $c -blocking yes; chan configure $c -blocking` → `1`,
+    /// and `-blocking tru` → `1` as well (prefix matching, per
+    /// [`crate::abbrev::boolean_table`]).
+    Boolean,
+    /// A word consumed as **either** a boolean or a number — `0` and `1` are
+    /// valid integers as well as booleans, so a consumer cannot tell which
+    /// language the author meant and must leave the bytes alone.
+    ///
+    /// Distinct from [`Self::Boolean`] precisely so a rewriting consumer
+    /// abstains here by construction rather than by a guess: the formatter's
+    /// canonical-boolean rewrite would turn a deliberate `1` into `true` at a
+    /// position where the command reads a count.
+    NumericOrBoolean,
 }
 
 impl ArgRole {
@@ -192,7 +227,22 @@ impl ArgRole {
         Self::CommandNameProbe,
         Self::LambdaLiteral,
         Self::NamespaceName,
+        Self::Boolean,
+        Self::NumericOrBoolean,
     ];
+
+    /// Whether a word in this role is consumed **purely as a boolean**, so
+    /// every accepted spelling of the same truth value is interchangeable.
+    ///
+    /// The one place that answers "is this word consumed as a boolean" —
+    /// the formatter's canonical-boolean rewrite, completion's value list,
+    /// and hover all read it, so they cannot drift apart. Deliberately
+    /// `false` for [`Self::NumericOrBoolean`]: that position also accepts an
+    /// integer, and `0`/`1` belong to both languages.
+    #[must_use]
+    pub const fn consumes_boolean(self) -> bool {
+        matches!(self, Self::Boolean)
+    }
 
     /// Whether an argument in this role carries **executable Tcl** that a
     /// consumer walking the code must descend into.
@@ -240,6 +290,8 @@ impl ArgRole {
             | Self::Channel
             | Self::Index
             | Self::NamespaceName
+            | Self::Boolean
+            | Self::NumericOrBoolean
             | Self::Keyword => false,
         }
     }
@@ -284,6 +336,8 @@ impl ArgRole {
             | Self::Channel
             | Self::Index
             | Self::NamespaceName
+            | Self::Boolean
+            | Self::NumericOrBoolean
             | Self::Keyword => false,
         }
     }
@@ -334,6 +388,8 @@ impl ArgRole {
             | Self::Channel
             | Self::Index
             | Self::NamespaceName
+            | Self::Boolean
+            | Self::NumericOrBoolean
             | Self::Keyword => false,
         }
     }

--- a/rust/tcl-registry/src/commands/stdlib/tcltest__configure.rs
+++ b/rust/tcl-registry/src/commands/stdlib/tcltest__configure.rs
@@ -124,23 +124,6 @@ const PRESERVECORE_LEVELS: &[ArgValue] = &[
     },
 ];
 
-/// Boolean values (`AcceptBoolean`) — the two canonical spellings; Tcl also
-/// accepts `true`/`false`/`yes`/`no`/`on`/`off`, so the set is not closed.
-const BOOL_VALUES: &[ArgValue] = &[
-    ArgValue {
-        value: "0",
-        detail: "off",
-        min_tcl: None,
-        code: None,
-    },
-    ArgValue {
-        value: "1",
-        detail: "on",
-        min_tcl: None,
-        code: None,
-    },
-];
-
 const OPTIONS: &[OptionSpec] = &[
     OptionSpec {
         name: "-verbose",
@@ -192,13 +175,13 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-limitconstraints",
-        value: OptionValue::enumerated(BOOL_VALUES, false, "boolean"),
+        value: OptionValue::boolean(),
         detail: "run only tests with the listed constraints",
         ..OptionSpec::DEFAULT
     },
     OptionSpec {
         name: "-singleproc",
-        value: OptionValue::enumerated(BOOL_VALUES, false, "boolean"),
+        value: OptionValue::boolean(),
         detail: "run all tests in one process rather than one per file",
         ..OptionSpec::DEFAULT
     },

--- a/rust/tcl-registry/src/commands/tcl/chan_.rs
+++ b/rust/tcl-registry/src/commands/tcl/chan_.rs
@@ -160,7 +160,7 @@ const INPUTMODE_VALUES: &[ArgValue] = &[
 static CONFIGURE_OPTIONS: &[OptionSpec] = &[
     OptionSpec {
         name: "-blocking",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Whether I/O on the channel may block the process indefinitely. Channels are blocking by default; nonblocking mode affects chan gets/read/puts/flush/close and requires the event loop (vwait/update) to drive it.",
         dialects: None,
         aliases: &[],
@@ -241,7 +241,7 @@ static CONFIGURE_OPTIONS: &[OptionSpec] = &[
     // channel driver, not to chan configure's own generic option set.
     OptionSpec {
         name: "-nodelay",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "TCP_NODELAY on a socket channel: disables Nagle's algorithm so small writes are sent immediately (Tcl 9.0+, TIP 344). Documented on socket(n).",
         dialects: Some(DialectSet::TCL90_PLUS),
         aliases: &[],
@@ -250,7 +250,7 @@ static CONFIGURE_OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-keepalive",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "SO_KEEPALIVE on a socket channel (Tcl 9.0+, TIP 344). Documented on socket(n).",
         dialects: Some(DialectSet::TCL90_PLUS),
         aliases: &[],
@@ -836,7 +836,7 @@ static SUBCOMMANDS: &[SubCommand] = &[
 const CMD_OPTIONS: &[OptionSpec] = &[
     OptionSpec {
         name: "-blocking",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Set blocking mode.",
         dialects: None,
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tcl/clock_.rs
+++ b/rust/tcl-registry/src/commands/tcl/clock_.rs
@@ -52,7 +52,7 @@ static FORMAT_OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-gmt",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Format in UTC instead of the local time zone; superseded by -timezone :UTC but still accepted.",
         dialects: None,
         aliases: &[],
@@ -113,7 +113,7 @@ static SCAN_OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-gmt",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Interpret the input as UTC instead of local time; superseded by -timezone :UTC but still accepted.",
         dialects: None,
         aliases: &[],
@@ -141,7 +141,7 @@ static SCAN_OPTIONS: &[OptionSpec] = &[
     // `-validate` is Tcl 9.0+ (TIP 688).
     OptionSpec {
         name: "-validate",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "When true (the default), an out-of-range field (e.g. day 31 in a 30-day month) raises an error; when false, it is clamped into range instead.",
         dialects: Some(DialectSet::TCL90_PLUS),
         aliases: &[],
@@ -156,7 +156,7 @@ static SCAN_OPTIONS: &[OptionSpec] = &[
 static ADD_OPTIONS: &[OptionSpec] = &[
     OptionSpec {
         name: "-gmt",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Do the arithmetic in UTC instead of the local time zone; superseded by -timezone :UTC but still accepted.",
         dialects: None,
         aliases: &[],
@@ -402,7 +402,7 @@ const CMD_OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-gmt",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Use GMT instead of local time.",
         dialects: None,
         aliases: &[],
@@ -436,7 +436,7 @@ const CMD_OPTIONS: &[OptionSpec] = &[
     // gate for the top-level (pre-subcommand-resolution) completion/hover path.
     OptionSpec {
         name: "-validate",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Validate date fields strictly (Tcl 9.0+).",
         dialects: Some(DialectSet::TCL90_PLUS),
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tcl/fconfigure_.rs
+++ b/rust/tcl-registry/src/commands/tcl/fconfigure_.rs
@@ -165,7 +165,7 @@ const INPUTMODE_VALUES: &[ArgValue] = &[
 const OPTIONS: &[OptionSpec] = &[
     OptionSpec {
         name: "-blocking",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Whether I/O on the channel may block the process indefinitely. Must be a proper boolean; channels are blocking by default. Placing a channel in nonblocking mode affects gets, read, puts, flush, and close, and requires an active Tcl event loop (vwait, or Tcl_DoOneEvent) to drive it.",
         dialects: None,
         aliases: &[],
@@ -246,7 +246,7 @@ const OPTIONS: &[OptionSpec] = &[
     // rather than to the generic option set.
     OptionSpec {
         name: "-nodelay",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "TCP_NODELAY on a socket channel (Tcl 9.0+, TIP 344): disables Nagle's algorithm so small writes are sent immediately instead of being coalesced and delayed. Boolean value. Documented on socket(n).",
         dialects: Some(DialectSet::TCL90_PLUS),
         aliases: &[],
@@ -255,7 +255,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-keepalive",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "SO_KEEPALIVE on a socket channel (Tcl 9.0+, TIP 344): enables periodic keepalive probes on an otherwise idle connection. Boolean value. Documented on socket(n).",
         dialects: Some(DialectSet::TCL90_PLUS),
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tcl/interp.rs
+++ b/rust/tcl-registry/src/commands/tcl/interp.rs
@@ -231,7 +231,7 @@ static SUBCOMMANDS: &[SubCommand] = &[
         options: const {
             &[OptionSpec {
                 name: "-frame",
-                value: OptionValue::value("boolean"),
+                value: OptionValue::boolean(),
                 detail: "Enable exact per-command file/line tracking for `info frame` in the target interpreter (slower execution). Given with no value, only reports the current setting. Once turned on, cannot be turned back off.",
                 dialects: None,
                 aliases: &[],

--- a/rust/tcl-registry/src/commands/tcl/namespace_.rs
+++ b/rust/tcl-registry/src/commands/tcl/namespace_.rs
@@ -78,7 +78,7 @@ static ENSEMBLE_CREATE_OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-prefixes",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Whether unambiguous subcommand prefixes are accepted (default: on).",
         dialects: None,
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tcl/socket_.rs
+++ b/rust/tcl-registry/src/commands/tcl/socket_.rs
@@ -59,7 +59,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-reuseaddr",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Server sockets only, Tcl 9.0+: whether the kernel may reuse the local address when no socket is actively listening on it (SO_REUSEADDR). True is the default on Windows; the default on other platforms is undocumented.",
         dialects: Some(DialectSet::TCL90_PLUS),
         aliases: &[],
@@ -68,7 +68,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-reuseport",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Server sockets only, Tcl 9.0+: whether multiple sockets may bind the same local address and port (SO_REUSEPORT). The default value is undocumented.",
         dialects: Some(DialectSet::TCL90_PLUS),
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tcllib/encoding_pkgs.rs
+++ b/rust/tcl-registry/src/commands/tcllib/encoding_pkgs.rs
@@ -87,7 +87,7 @@ const YENCODE_OPTS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-crc32",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Whether to append a CRC-32 trailer.",
         ..OptionSpec::DEFAULT
     },

--- a/rust/tcl-registry/src/commands/tcllib/misc_pkgs.rs
+++ b/rust/tcl-registry/src/commands/tcllib/misc_pkgs.rs
@@ -484,7 +484,7 @@ const BIBTEX_PARSE_OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-casesensitivestrings",
-        value: OptionValue::value("bool"),
+        value: OptionValue::boolean(),
         detail: "Treat @string macro names case-sensitively.",
         ..OptionSpec::DEFAULT
     },

--- a/rust/tcl-registry/src/commands/tcllib/smtp__sendmessage.rs
+++ b/rust/tcl-registry/src/commands/tcllib/smtp__sendmessage.rs
@@ -59,7 +59,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-usetls",
-        value: OptionValue::value("bool"),
+        value: OptionValue::boolean(),
         detail: "Whether to attempt STARTTLS negotiation.",
         ..OptionSpec::DEFAULT
     },

--- a/rust/tcl-registry/src/commands/tcllib/text_misc.rs
+++ b/rust/tcl-registry/src/commands/tcllib/text_misc.rs
@@ -88,7 +88,7 @@ const REGISTER_OPTS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-prohibitedBidi",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Whether to apply the bidirectional-text checks.",
         ..OptionSpec::DEFAULT
     },

--- a/rust/tcl-registry/src/commands/tk/event.rs
+++ b/rust/tcl-registry/src/commands/tk/event.rs
@@ -126,7 +126,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-focus",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Specifies the focus field for the event.",
         dialects: None,
         aliases: &[],
@@ -171,7 +171,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-override",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Specifies the override-redirect field.",
         dialects: None,
         aliases: &[],
@@ -216,7 +216,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-sendevent",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Specifies the send-event field.",
         dialects: None,
         aliases: &[],
@@ -261,7 +261,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-warp",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Specifies whether the screen pointer should be warped.",
         dialects: None,
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tk/font.rs
+++ b/rust/tcl-registry/src/commands/tk/font.rs
@@ -132,7 +132,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-underline",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Whether to draw an underline beneath the text.",
         dialects: None,
         aliases: &[],
@@ -141,7 +141,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-overstrike",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Whether to draw a horizontal line through the text.",
         dialects: None,
         aliases: &[],
@@ -215,7 +215,7 @@ const ATTRIBUTE_OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-underline",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Whether to draw an underline beneath the text.",
         dialects: None,
         aliases: &[],
@@ -224,7 +224,7 @@ const ATTRIBUTE_OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-overstrike",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Whether to draw a horizontal line through the text.",
         dialects: None,
         aliases: &[],
@@ -285,7 +285,7 @@ const ACTUAL_OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-underline",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Whether to draw an underline beneath the text.",
         dialects: None,
         aliases: &[],
@@ -294,7 +294,7 @@ const ACTUAL_OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-overstrike",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Whether to draw a horizontal line through the text.",
         dialects: None,
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tk/pack.rs
+++ b/rust/tcl-registry/src/commands/tk/pack.rs
@@ -96,7 +96,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-expand",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Specifies whether the slave should be expanded to consume extra space in its master.",
         dialects: None,
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tk/text.rs
+++ b/rust/tcl-registry/src/commands/tk/text.rs
@@ -522,7 +522,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-blockcursor",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Specifies a boolean that says whether the blinking insertion cursor should be drawn as a character-sized.",
         dialects: None,
         aliases: &[],
@@ -549,7 +549,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-insertunfocussed",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: ".",
         dialects: None,
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tk/tk_choosedirectory.rs
+++ b/rust/tcl-registry/src/commands/tk/tk_choosedirectory.rs
@@ -38,7 +38,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-mustexist",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Whether the user must select an existing directory.",
         dialects: None,
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tk/tk_getopenfile.rs
+++ b/rust/tcl-registry/src/commands/tk/tk_getopenfile.rs
@@ -65,7 +65,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-multiple",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Allow the user to select multiple files.",
         dialects: None,
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tk/tk_getsavefile.rs
+++ b/rust/tcl-registry/src/commands/tk/tk_getsavefile.rs
@@ -29,7 +29,7 @@ const SIDE_EFFECTS: &[SideEffect] = &[SideEffect {
 const OPTIONS: &[OptionSpec] = &[
     OptionSpec {
         name: "-confirmoverwrite",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Prompt for confirmation if the file already exists.",
         dialects: None,
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tk/ttk__combobox.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__combobox.rs
@@ -119,7 +119,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-exportselection",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Whether the selection is exported to the X selection.",
         dialects: None,
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tk/ttk__entry.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__entry.rs
@@ -101,7 +101,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-exportselection",
-        value: OptionValue::value("boolean"),
+        value: OptionValue::boolean(),
         detail: "Whether the selection is exported to the X selection.",
         dialects: None,
         aliases: &[],

--- a/rust/tcl-registry/src/hover.rs
+++ b/rust/tcl-registry/src/hover.rs
@@ -274,6 +274,41 @@ impl OptionValue {
         })
     }
 
+    /// A single value consumed **purely as a boolean** —
+    /// [`ArgRole::Boolean`], the first-class registry answer to "is this word
+    /// a boolean" (issue #1256).
+    ///
+    /// The value set is left open on purpose: Tcl accepts every spelling
+    /// [`crate::abbrev::boolean_table`] resolves, *including unique prefixes*
+    /// (`-blocking tru`), which a closed `values` list cannot express without
+    /// making the option-aware closed-value check reject legal code.
+    /// Completion and hover read the role and offer
+    /// [`crate::abbrev::BOOLEAN_KEYWORDS`] instead.
+    ///
+    /// Use [`Self::numeric_or_boolean`] for a position that also accepts a
+    /// count — `0`/`1` are valid integers, and a rewriting consumer must not
+    /// guess which language the author meant.
+    #[must_use]
+    pub const fn boolean() -> Self {
+        Self::Takes(OptionArg {
+            role: ArgRole::Boolean,
+            hint: "boolean",
+            ..OptionArg::DEFAULT
+        })
+    }
+
+    /// A single value accepted as **either** a boolean or a number
+    /// ([`ArgRole::NumericOrBoolean`]) — declared so a consumer abstains by
+    /// construction rather than by inference.
+    #[must_use]
+    pub const fn numeric_or_boolean(hint: &'static str) -> Self {
+        Self::Takes(OptionArg {
+            role: ArgRole::NumericOrBoolean,
+            hint,
+            ..OptionArg::DEFAULT
+        })
+    }
+
     /// A single expression value (argparse `-validate`).
     #[must_use]
     pub const fn expr() -> Self {
@@ -421,6 +456,23 @@ impl OptionSpec {
         match self.value {
             OptionValue::Flag => None,
             OptionValue::Takes(arg) => Some(arg.role),
+        }
+    }
+
+    /// Whether the option's value is consumed **purely as a boolean**, so
+    /// every accepted spelling of the same truth value is interchangeable.
+    ///
+    /// Reads the declared [`ArgRole::Boolean`] fact (issue #1256) — never
+    /// inferred from the value set, which only ever covered the handful of
+    /// options that happened to enumerate `true`/`false` and missed every
+    /// option declared with an open value or a bare hint.
+    /// [`ArgRole::NumericOrBoolean`] answers `false`: `0`/`1` are valid
+    /// integers there too.
+    #[must_use]
+    pub const fn value_is_boolean(&self) -> bool {
+        match self.value {
+            OptionValue::Flag => false,
+            OptionValue::Takes(arg) => arg.role.consumes_boolean(),
         }
     }
 

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -94,6 +94,7 @@ pub mod taint;
 pub mod traits;
 pub mod types;
 pub mod version;
+pub mod version_range;
 
 /// Convenience prelude for command spec files.
 ///

--- a/rust/tcl-registry/src/version_range.rs
+++ b/rust/tcl-registry/src/version_range.rs
@@ -1,0 +1,144 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Target version ranges, and the registry packs one spans (issue #1257).
+//!
+//! A document is written for a release, but it may be *run* on a later one.
+//! Anything that rewrites a word whose meaning depends on a keyword table has
+//! to reason over the whole range, not just the release in front of it: a
+//! prefix that is unique today can become ambiguous when a later Tcl adds a
+//! keyword (`string cat` arrived in 8.6.2 and shortened what `string c…`
+//! could mean).
+//!
+//! [`DialectSet`] is already the project's range type — a set of core-Tcl
+//! version bits — so this module is the small bridge from a range to the
+//! **registry packs** it spans, plus the one rule that turns a single target
+//! dialect into its forward-compatibility range.
+//!
+//! Consumers ask here rather than loading packs by dialect name themselves:
+//! the minifier's ad-hoc "every later core-Tcl registry" walk and the
+//! formatter's version-blind resolution were two copies of the same list, and
+//! a new core release had to be remembered in both.
+
+use tcl_dialect::DialectSet;
+
+use crate::CommandRegistry;
+use crate::cache::registry_for_dialect;
+
+/// Every core-Tcl release the registry ships a pack for, oldest first.
+///
+/// The single source of truth for release *order*. `DialectSet`'s bit order
+/// agrees with it by construction (see [`DialectSet::member_names`]); this
+/// list is what maps those bits back to loadable pack names.
+pub const CORE_TCL_RELEASES: &[&str] = &["tcl8.4", "tcl8.5", "tcl8.6", "tcl9.0", "tcl9.1"];
+
+/// The core-Tcl release names a target `range` spans, oldest first.
+///
+/// Non-core bits (`IRULES`, `TK`, `EXPECT`, …) contribute nothing: they are
+/// vendor gates, not releases on the core version axis, and the keyword
+/// tables that change between releases are the core ones.
+#[must_use]
+pub fn core_releases_in(range: DialectSet) -> Vec<&'static str> {
+    CORE_TCL_RELEASES
+        .iter()
+        .copied()
+        .filter(|name| {
+            DialectSet::parse(name).is_some_and(|bit| range.intersects(bit) && range.contains(bit))
+        })
+        .collect()
+}
+
+/// The registry packs a target `range` spans, oldest release first.
+///
+/// This is the answer to "what keyword tables does this document's target
+/// range span" — the one helper the formatter, the minifier, and the
+/// analyser share. An empty result means the range names no core release
+/// (a pure vendor dialect), and a caller should fall back to the single
+/// registry it was handed.
+#[must_use]
+pub fn registries_over_range(range: DialectSet) -> Vec<&'static CommandRegistry> {
+    core_releases_in(range)
+        .into_iter()
+        .map(registry_for_dialect)
+        .collect()
+}
+
+/// The forward-compatibility range for a document targeting `dialect`: that
+/// release and **every later** core-Tcl release.
+///
+/// This is the range a rewrite must be safe across, because a script written
+/// for 8.6 may well be run under 9.0. A vendor dialect with no core version
+/// bit (`f5-irules` names its own runtime, not a core release) yields the
+/// empty range — nothing to widen over, so a consumer keeps the single table
+/// it holds, which is the pre-existing conservative behaviour.
+#[must_use]
+pub fn forward_range(dialect: &str) -> DialectSet {
+    let Some(pos) = CORE_TCL_RELEASES.iter().position(|name| *name == dialect) else {
+        return DialectSet::empty();
+    };
+    CORE_TCL_RELEASES[pos..]
+        .iter()
+        .filter_map(|name| DialectSet::parse(name))
+        .fold(DialectSet::empty(), |acc, bit| acc | bit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_forward_range_is_the_target_and_every_later_release() {
+        assert_eq!(
+            core_releases_in(forward_range("tcl8.6")),
+            vec!["tcl8.6", "tcl9.0", "tcl9.1"]
+        );
+        assert_eq!(
+            core_releases_in(forward_range("tcl8.4")),
+            CORE_TCL_RELEASES.to_vec()
+        );
+        // The newest release has nothing after it — the range is itself.
+        assert_eq!(core_releases_in(forward_range("tcl9.1")), vec!["tcl9.1"]);
+    }
+
+    #[test]
+    fn a_vendor_dialect_has_no_core_range() {
+        // `f5-irules` names a runtime, not a core release: nothing to widen
+        // over, so the consumer keeps the single table it holds.
+        assert!(forward_range("f5-irules").is_empty());
+        assert!(registries_over_range(forward_range("f5-irules")).is_empty());
+        assert!(forward_range("nonsense").is_empty());
+    }
+
+    #[test]
+    fn an_explicit_range_maps_to_its_packs_oldest_first() {
+        let names = core_releases_in(DialectSet::TCL85_PLUS);
+        assert_eq!(names, vec!["tcl8.5", "tcl8.6", "tcl9.0", "tcl9.1"]);
+        assert_eq!(
+            registries_over_range(DialectSet::TCL85_PLUS).len(),
+            names.len()
+        );
+        assert!(core_releases_in(DialectSet::empty()).is_empty());
+    }
+
+    #[test]
+    fn a_mixed_range_keeps_only_the_core_releases() {
+        // A vendor bit alongside core bits contributes no pack of its own.
+        let range = DialectSet::TCL86 | DialectSet::TCL90 | DialectSet::IRULES;
+        assert_eq!(core_releases_in(range), vec!["tcl8.6", "tcl9.0"]);
+    }
+}

--- a/rust/tcl-registry/tests/registry_sweep.rs
+++ b/rust/tcl-registry/tests/registry_sweep.rs
@@ -1617,3 +1617,77 @@ fn sweep_lifecycle_seed_cases() {
         LifecycleState::NotIntroduced
     );
 }
+
+/// Issue #1256 — the boolean argument role is a declared registry fact, and
+/// the whole registry agrees about which options carry it.
+///
+/// Two invariants, both sweeping every command and subcommand option table in
+/// every known dialect:
+///
+/// 1. An option whose value hint says `boolean`/`bool` **must** declare
+///    `ArgRole::Boolean`. That is what stops a new boolean option from
+///    silently going back to being invisible to the consumers.
+/// 2. The reverse holds too: `value_is_boolean()` is `true` only for the
+///    declared role — the old inference from a closed value set is gone.
+///
+/// tclsh-proof (8.6.16 / 9.0.4): the role means the bytes are consumed and
+/// discarded, which is why every spelling is interchangeable —
+/// `chan configure $c -blocking yes; chan configure $c -blocking` → `1`, and
+/// `-blocking tru` is accepted identically (prefix matching).
+#[test]
+fn boolean_argument_role_is_declared_and_consistent() {
+    use tcl_registry::ArgRole;
+    use tcl_registry::hover::OptionSpec;
+
+    let mut declared = 0usize;
+    for dialect in [
+        "tcl8.4",
+        "tcl8.5",
+        "tcl8.6",
+        "tcl9.0",
+        "tcl9.1",
+        "f5-irules",
+    ] {
+        let reg = registry_for_dialect(dialect);
+        let names: Vec<String> = reg.command_names().map(str::to_owned).collect();
+        for name in &names {
+            let Some(spec) = reg.get(name) else { continue };
+            let mut sweep = |path: &str, options: &'static [OptionSpec]| {
+                for opt in options {
+                    let hint = opt.value_hint();
+                    if matches!(hint, "boolean" | "bool") {
+                        assert!(
+                            opt.value_is_boolean(),
+                            "{dialect} {path} {}: hint says `{hint}` but the option does not \
+                             declare ArgRole::Boolean — every boolean-valued option must carry \
+                             the fact (issue #1256)",
+                            opt.name
+                        );
+                    }
+                    if opt.value_is_boolean() {
+                        declared += 1;
+                        assert_eq!(
+                            opt.value_role(),
+                            Some(ArgRole::Boolean),
+                            "{dialect} {path} {}: value_is_boolean must mean the declared role",
+                            opt.name
+                        );
+                    }
+                }
+            };
+            sweep(spec.name, spec.options);
+            for sub in spec.subcommands {
+                sweep(&format!("{} {}", spec.name, sub.name), sub.options);
+            }
+        }
+    }
+    assert!(
+        declared > 0,
+        "the sweep must actually reach declared boolean options"
+    );
+    assert!(ArgRole::Boolean.consumes_boolean());
+    // A numeric-or-boolean position is deliberately NOT boolean: `0`/`1` are
+    // valid integers there, so a rewriting consumer must abstain.
+    assert!(!ArgRole::NumericOrBoolean.consumes_boolean());
+    assert!(!ArgRole::Value.consumes_boolean());
+}

--- a/rust/tcl-spec-studio/src/catalogue.rs
+++ b/rust/tcl-spec-studio/src/catalogue.rs
@@ -84,6 +84,14 @@ pub const ARG_ROLES: &[Variant] = &[
         "NamespaceName",
         "names a namespace (`namespace children ::ns`)",
     ),
+    v(
+        "Boolean",
+        "consumed as a boolean (`Tcl_GetBoolean` spellings)",
+    ),
+    v(
+        "NumericOrBoolean",
+        "consumed as a number or a boolean (`-validate 0`/`yes`)",
+    ),
 ];
 
 /// [`TclType`] — the intrep a value carries.
@@ -736,7 +744,9 @@ mod tests {
             | ArgRole::CommandName
             | ArgRole::CommandNameProbe
             | ArgRole::LambdaLiteral
-            | ArgRole::NamespaceName => true,
+            | ArgRole::NamespaceName
+            | ArgRole::Boolean
+            | ArgRole::NumericOrBoolean => true,
         }
     }
 

--- a/rust/tcl-syntax/src/expr/ast.rs
+++ b/rust/tcl-syntax/src/expr/ast.rs
@@ -678,39 +678,77 @@ pub fn expr_text(node: &ExprNode) -> String {
     }
 }
 
+/// Which command asked an existence question.
+///
+/// The two spellings are *not* interchangeable when the queried name is
+/// known to be a scalar: `info exists` answers "is this name bound",
+/// `array exists` answers "is this name bound **to an array**".  A consumer
+/// that folds the query to a constant has to know which one it is looking
+/// at (issue #1239).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExistenceCommand {
+    /// `info exists NAME` — true for any bound name, scalar or array.
+    Info,
+    /// `array exists NAME` — true only when `NAME` is bound to an array.
+    Array,
+}
+
+/// A recognised `[info exists X]` / `[array exists X]` existence query.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExistenceQuery {
+    /// The queried variable name, exactly as written.
+    pub var: String,
+    /// True for `![info exists X]` — the condition is the query's negation.
+    pub negated: bool,
+    /// Which of the two spellings asked.
+    pub command: ExistenceCommand,
+}
+
 /// Recognise an `[info exists X]` / `[array exists X]` existence-query
-/// condition, returning `(variable, negated)` where `negated` is true
-/// for `![info exists X]`.  Used to inject guarded-region
-/// read narrowing (`cfg_lower::lower_if`), suppress the existence-query
-/// word's W210 read, and fold the predicate to a constant (analyser I230).
+/// condition.  Used to inject guarded-region read narrowing
+/// (`cfg_lower::lower_if`), suppress the existence-query word's W210 read,
+/// and fold the predicate to a constant (analyser I230).
 ///
 /// Only the simple two-/three-word command-substitution form is matched
 /// (e.g. `[info exists name]`); anything embedded in a larger expression
 /// returns `None`.
 #[must_use]
-pub fn existence_query_var(node: &ExprNode) -> Option<(String, bool)> {
+pub fn existence_query_var(node: &ExprNode) -> Option<ExistenceQuery> {
     match node {
         ExprNode::Unary {
             op: UnaryOp::Not,
             operand,
-        } => existence_query_var(operand).map(|(v, neg)| (v, !neg)),
-        ExprNode::Command { text, .. } => existence_query_in_text(text).map(|v| (v, false)),
+        } => existence_query_var(operand).map(|q| ExistenceQuery {
+            negated: !q.negated,
+            ..q
+        }),
+        ExprNode::Command { text, .. } => {
+            existence_query_in_text(text).map(|(var, command)| ExistenceQuery {
+                var,
+                negated: false,
+                command,
+            })
+        }
         _ => None,
     }
 }
 
 /// Parse a bracketed command-substitution `text` (e.g. `"[info exists
-/// x]"`) and return the queried variable when it is exactly
-/// `info exists NAME` or `array exists NAME`.
+/// x]"`) and return the queried variable plus the spelling that asked, when
+/// it is exactly `info exists NAME` or `array exists NAME`.
 #[must_use]
-pub fn existence_query_in_text(text: &str) -> Option<String> {
+pub fn existence_query_in_text(text: &str) -> Option<(String, ExistenceCommand)> {
     let inner = text.strip_prefix('[')?.strip_suffix(']')?;
     let words: Vec<&str> = inner.split_whitespace().collect();
-    if words.len() == 3 && matches!(words[0], "info" | "array") && words[1] == "exists" {
-        Some(words[2].to_owned())
-    } else {
-        None
+    if words.len() != 3 || words[1] != "exists" {
+        return None;
     }
+    let command = match words[0] {
+        "info" => ExistenceCommand::Info,
+        "array" => ExistenceCommand::Array,
+        _ => return None,
+    };
+    Some((words[2].to_owned(), command))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- **#1239 — `array exists PARAM` folded constant-true.** `existence_query_in_text` collapsed `info exists` and `array exists` into one query shape, so the parameter rule applied to both and folded `true`. A parameter is bound as a **scalar** on entry, so the `array` spelling is provably `false` — I230 reported the live branch inverted and O101 folded the wrong arm. The query now reports which command asked (`ExistenceCommand::Info`/`Array`) and the parameter case folds on the spelling; the never-defined direction is unchanged (absent is absent under both).
- **#1250 — `gvn::dominates` O(V²).** One idom-chain walk per (block, block) pair, hashing a `BlockId` per hop; on a flat dispatch chain the idom chain is the whole function. New `SsaFunction::dominator_intervals()` numbers the dominator forest in one iterative pre-order DFS, making `dominates` an interval-nesting test on a dense `Vec`. Children are derived from `idom` (not `dominator_tree`) with every root seeded, so hand-built fixtures and multi-root forests stay correct. Debug `tcl diag`, best of 3: 250 0.38→0.36 s, 500 0.77→0.67, 1000 1.69→1.36, **2000 4.27→2.65 s**; per-doubling growth 2.5× → 1.95×.
- **#1251 — taint index rebuilds.** *Correction to the issue's diagnosis*: the rebuild was already outside `propagate_taints`' own fixpoint. The real cost is one level up — the predecessor map *and* the reverse-postorder are re-derived on every call, and `infer_proc_summary` calls it `1 + params × 15` times, the summary worklist re-calls that, and the entry-taint worklist re-propagates per dequeue. New `taint::TaintGraph` bundles CFG/SSA/SCCP with both indices, built once per inference and cached per procedure; `Function::predecessors_fx` adds Fx keying sharing one generic implementation. Bundling also retired a `too_many_arguments` allow. On top of #1250: **2000 2.65→2.15 s**, combined **4.27→2.15 s (~2.0×)**. The other 14 `predecessors()` sites were audited — all already once-per-pass.
- **#1252 — braced-literal audit.** Inventory correction: ~75 call sites, not ~30. **Two converted**, both real bugs: `record_namespace_path_element_refs` (the whole-word gate accepted the braced word, then the element walk re-scanned it, so `namespace path {::$ns ::a}` recorded `::$ns` as a path entry but not as a reference) and `literal_foreach_binding` (one braced element abstained from the whole per-iteration simulation, so `foreach n {aa {$b} cc} { proc $n {} {} }` installed none of the three procs and every call drew a W123 false positive). **Seven groups correct as-is**, including one where converting would be an active regression — `CommandName`/`Probe` recording, where `[abc]` is a glob character class, not a substitution. Full verdict table posted on the issue.
- **#1256 — boolean argument roles.** The formatter's inference reached **two options in the entire registry**. Added `ArgRole::Boolean` / `ArgRole::NumericOrBoolean` with `consumes_boolean()` as the single query, `OptionValue::boolean()`/`numeric_or_boolean()` to declare and `OptionSpec::value_is_boolean()` to read; 41 option declarations populated. Value sets stay open because Tcl accepts prefixes (`-blocking tru`). The formatter reads the fact, completion now offers the boolean vocabulary (previously nothing), hover names it, and a registry sweep fails if a boolean-hinted option lacks the role.
- **#1257 — formatter version range.** New `tcl_registry::version_range` is the shared helper: `CORE_TCL_RELEASES` (the release list existed twice and the minifier's copy was missing 9.1), plus `core_releases_in` / `registries_over_range` / `forward_range`. `FormatterConfig` gains `dialect` + `target_range`, populated by the server; expansion resolves against the document's own release **and** requires the same answer in every later release, and the minifier delegates to the same helper. Swept every ensemble prefix in every release to verify the precision half can never *gain* an expansion — zero cases — so this can only stop an unsafe expansion, never change safe output.

Filed en route: **#1260** — W210 false positive on a `$var` inside a braced `foreach`/`lmap` list word; root cause is `ir::ForeachIterator::list_arg` carrying no braced flag, unlike every other IR word that needs one. This contradicts an assumption in #1252's write-up, so it is called out rather than folded in.

#1256 and #1257 were the two recorded blockers on #1233, which can now proceed.

## Validation

- [x] `cargo fmt --check` clean; `cargo clippy -p tcl-compiler -p tcl-syntax -p tcl-registry -p tcl-lsp-core -p tcl-lsp-server --all-targets -- -D warnings` clean — no new `#[allow]`s, one removed.
- [x] Tests: tcl-compiler 8071 passed / 0 failed; registry+syntax+lsp-core 3868/0; tcl-lsp-server 1667/0; tcl-lsp-db and tcl-cli clean. `make xtask-check` all drift gates OK.
- [x] Branch already based on current `rust`; full diff reviewed against `origin/rust` and re-verified here (registry/syntax suites + drift gates green post-rebase).
- [x] Disk hit ENOSPC three times mid-run; only this worktree's build artefacts were freed and every affected suite was re-run from a clean relink, so no pass count above comes from a post-ENOSPC build.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? — Yes: `ExistenceQuery` carries the asking command, `ArgRole::Boolean`/`NumericOrBoolean` with `consumes_boolean()`, `FormatterConfig`'s dialect/target range, `SsaFunction::dominator_intervals()`, and `taint::TaintGraph`.
- [x] If yes, I updated at least one relevant KCS note — contract docs at each definition site; the existence-fold spelling rule and the boolean-role sweep are documented alongside their gates.
- [ ] If I added a new compiler KCS note, I linked it — n/a (existing notes extended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_