### PR TITLE
Final follow-ups: braced loop value words, member enumeration, namespace path entries, dynamic-name provenance, cross-document prefer-latest (#1260, #1263, #1261, #1262, #1253)

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3266,6 +3266,13 @@
             "default": false,
             "description": "Hide Tcl diagnostics (errors and warnings) for a file while it is shown only in a diff editor — a Git change in Source Control, 'Compare With…', or 'Compare with Saved'. Diagnostics in a diff are the underlying file's own full-file diagnostics (the analyser never runs on diff content), so they are shown by default; enable this to read changes without the analyser's noise. The file always keeps its diagnostics when it is also open in a normal editor. Purely a client-side display choice; the server keeps analysing. (Deliberately not under tclLsp.diagnostics.*, which is reserved for per-code on/off toggles.)",
             "order": 6
+          },
+          "tclLsp.packages.preferLatest": {
+            "scope": "resource",
+            "type": "boolean",
+            "default": false,
+            "description": "Start the modelled interpreter with ``package prefer latest`` already in force, as TCL_PKG_PREFER_LATEST in the environment (or, on Tcl 9.0+, an unstable build of Tcl itself) does. Neither is visible in the source tree, so it is a setting rather than an inference. Affects which release a ``package require`` navigates into when a prerelease and a stable version both satisfy it.",
+            "order": 7
           }
         }
       },

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -828,6 +828,14 @@ impl Analyser {
             // than an inert word (issue #1088).
             self.record_namespace_name_references(cmd_name, args, arg_tokens, scope_path);
 
+            // Record every *computed* variable-name argument (`set $n 2`,
+            // `variable $n`) with what the dominating-constant lattice
+            // proves about its value, so a post-analysis consumer can ask
+            // which cells the word can actually name (issue #1262).
+            self.record_dynamic_variable_name_sites(
+                cmd_name, args, arg_tokens, arg_single, scope_path,
+            );
+
             // Run the per-command syntactic checks on commands nested inside
             // ``[…]`` substitutions (bare-`Cmd` args *and* braced-expr args)
             // — the main walk never descends a substitution (it treats
@@ -2294,6 +2302,73 @@ impl Analyser {
                 span: tok.span,
                 declares,
             });
+        }
+    }
+
+    /// Record each computed variable-name argument as a
+    /// [`DynamicVariableNameSite`](super::types::DynamicVariableNameSite):
+    /// the word's span plus the name it provably evaluates to, when the
+    /// constant lattice dominates the site (issue #1262).
+    ///
+    /// Which argument of which command names a variable is the registry's
+    /// answer ([`tcl_registry::ArgRole::VarWrite`] /
+    /// [`tcl_registry::ArgRole::VarRead`]); whether the word is computed is
+    /// [`crate::dynamic_names::names_a_dynamic_variable`]'s.  No command name
+    /// is matched here.
+    ///
+    /// A **brace-quoted** word is skipped: `set {$n} 1` names the variable
+    /// literally called `$n` and substitutes nothing (tclsh 8.6.14: `set {$n}
+    /// v; info exists {$n}` -> 1 while `info exists n` -> 0).  The word text
+    /// alone cannot tell the two spellings apart, so the token kind decides —
+    /// the same authority `dynamic_names::scan_command` uses for the compiler
+    /// -side barrier.
+    ///
+    /// The resolution is [`Self::resolve_dynamic_word`]'s, which folds only
+    /// through values that **dominate** the site: a branch-conditional
+    /// binding, a parameter, or a `[…]` substitution yields `None`, which a
+    /// consumer must read as "could be anything".
+    fn record_dynamic_variable_name_sites(
+        &mut self,
+        cmd_name: &str,
+        args: &[String],
+        arg_tokens: &[Token],
+        arg_single: &[bool],
+        scope_path: &[usize],
+    ) {
+        let Some(registry) = self.registry else {
+            return;
+        };
+        let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
+        for (role, writes) in [(ArgRole::VarWrite, true), (ArgRole::VarRead, false)] {
+            for idx in registry.arg_indices_for_role(cmd_name, &arg_strs, role) {
+                let (Some(word), Some(tok)) = (args.get(idx), arg_tokens.get(idx)) else {
+                    continue;
+                };
+                if tok.kind == TokenType::Str
+                    || !crate::dynamic_names::names_a_dynamic_variable(word)
+                {
+                    continue;
+                }
+                // A word carrying both roles (a read-modify-write target)
+                // is one site, recorded under the write it also performs.
+                if self
+                    .result
+                    .dynamic_variable_names
+                    .iter()
+                    .any(|s| s.span == tok.span)
+                {
+                    continue;
+                }
+                let is_single = arg_single.get(idx).copied().unwrap_or(false);
+                let resolved = self.resolve_dynamic_word(word, Some(*tok), is_single, scope_path);
+                self.result.dynamic_variable_names.push(
+                    super::types::DynamicVariableNameSite {
+                        span: tok.span,
+                        resolved,
+                        writes,
+                    },
+                );
+            }
         }
     }
 

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -821,20 +821,9 @@ impl Analyser {
             // any arity check (it is introspected, not called).
             self.record_command_name_invocations(cmd_name, args, arg_tokens, scope_path);
 
-            // Record `ArgRole::NamespaceName` arguments (`namespace children
-            // ::tomato`, `namespace exists ns`, `namespace eval NS { … }`) as
-            // namespace occurrences, so a namespace name is a navigable
-            // symbol for go-to-definition / hover / find-references rather
-            // than an inert word (issue #1088).
-            self.record_namespace_name_references(cmd_name, args, arg_tokens, scope_path);
-
-            // Record every *computed* variable-name argument (`set $n 2`,
-            // `variable $n`) with what the dominating-constant lattice
-            // proves about its value, so a post-analysis consumer can ask
-            // which cells the word can actually name (issue #1262).
-            self.record_dynamic_variable_name_sites(
-                cmd_name, args, arg_tokens, arg_single, scope_path,
-            );
+            // The occurrence tables the registry's *argument roles* produce —
+            // namespace names and computed variable names.
+            self.record_arg_role_facts(cmd_name, args, arg_tokens, arg_single, scope_path);
 
             // Run the per-command syntactic checks on commands nested inside
             // ``[…]`` substitutions (bare-`Cmd` args *and* braced-expr args)
@@ -2229,6 +2218,28 @@ impl Analyser {
         }
     }
 
+    /// The per-command occurrence tables the registry's **argument roles**
+    /// produce, recorded together because they are the same walk over the same
+    /// role query:
+    ///
+    /// * [`tcl_registry::ArgRole::NamespaceName`] words → `namespace_refs`, so
+    ///   a namespace name is a navigable symbol rather than an inert word
+    ///   (issue #1088);
+    /// * computed [`tcl_registry::ArgRole::VarWrite`] /
+    ///   [`tcl_registry::ArgRole::VarRead`] words → `dynamic_variable_names`,
+    ///   with what the constant lattice proves about the value (issue #1262).
+    fn record_arg_role_facts(
+        &mut self,
+        cmd_name: &str,
+        args: &[String],
+        arg_tokens: &[Token],
+        arg_single: &[bool],
+        scope_path: &[usize],
+    ) {
+        self.record_namespace_name_references(cmd_name, args, arg_tokens, scope_path);
+        self.record_dynamic_variable_name_sites(cmd_name, args, arg_tokens, arg_single, scope_path);
+    }
+
     /// Record each [`tcl_registry::arg_role::ArgRole::NamespaceName`]
     /// argument as a [`NamespaceRef`](super::types::NamespaceRef): a word
     /// naming a namespace, which navigation must reach (issue #1088).
@@ -2361,13 +2372,13 @@ impl Analyser {
                 }
                 let is_single = arg_single.get(idx).copied().unwrap_or(false);
                 let resolved = self.resolve_dynamic_word(word, Some(*tok), is_single, scope_path);
-                self.result.dynamic_variable_names.push(
-                    super::types::DynamicVariableNameSite {
+                self.result
+                    .dynamic_variable_names
+                    .push(super::types::DynamicVariableNameSite {
                         span: tok.span,
                         resolved,
                         writes,
-                    },
-                );
+                    });
             }
         }
     }

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/rbs.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/rbs.rs
@@ -1983,3 +1983,84 @@ fn issue_1237_quoted_use_still_keeps_the_variable_live() {
         codes(unmentioned, D)
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #1260 — a `$var` inside a **braced** `foreach` / `lmap` / `dict for`
+// value word is a literal list element, not a substitution.
+//
+// tclsh-proof (tclsh 8.6.14 — the only interpreter available in this
+// container):
+//
+//   foreach n {a $b c} { puts $n }          -> a / $b / c  (b undefined)
+//   dict for {k v} {a $b} { puts "$k=$v" }  -> a=$b        (b undefined)
+//
+// Braces are the only thing separating the literal spelling from the
+// substituting one, and the IR's `list_arg` stores the word's *content*, so
+// `ForeachIterator::list_braced` is what the CFG's synthetic loop-header call
+// carries the fact on.
+// ---------------------------------------------------------------------------
+
+/// #1260 FP — a braced value word reads nothing, at top level and inside a
+/// proc, for every loop that lowers to `Statement::Foreach`.
+#[test]
+fn issue_1260_braced_loop_value_word_is_not_a_read() {
+    for src in [
+        "foreach n {a $b c} { }\n",
+        "lmap n {a $b c} { }\n",
+        "proc p {} { foreach n {a $b c} { } }\n",
+        "proc p {} { lmap n {a $b c} { } }\n",
+        "dict for {k v} {a $b} { }\n",
+        "dict map {k v} {a $b} { }\n",
+        // Multi-group: the braced group stays quiet alongside a
+        // substituting one whose own read is satisfied.
+        "proc p {l} { foreach x {a $b c} y $l { } }\n",
+    ] {
+        assert!(
+            !fires(src, D, "W210"),
+            "#1260: a braced loop value word substitutes nothing; {src} emitted: {:?}",
+            codes(src, D)
+        );
+    }
+}
+
+/// #1260 TP — the substituting spellings of the same word must still fire.
+/// This is what separates "carry the braced flag" from "stop scanning the
+/// loop's value word".
+#[test]
+fn issue_1260_substituted_loop_value_word_still_fires() {
+    for src in [
+        "foreach n \"a $b c\" { }\n",
+        "foreach n $b { }\n",
+        "lmap n \"a $b c\" { }\n",
+        "proc p {} { foreach n \"a $b c\" { } }\n",
+        "proc p {} { foreach n $b { } }\n",
+        "dict for {k v} $b { }\n",
+    ] {
+        assert!(
+            fires(src, D, "W210"),
+            "#1260 TP: a substituted loop value word is a real read; {src} emitted: {:?}",
+            codes(src, D)
+        );
+    }
+}
+
+/// #1260 TN — the braced word still keeps the mentioned store *live*: the use
+/// is classified (`UseClass::Quoted`), not dropped, so W211/W220 must not
+/// resurrect on a variable whose only mention is inside the braced list. Same
+/// guard rail as `issue_1237_quoted_use_still_keeps_the_variable_live`.
+#[test]
+fn issue_1260_braced_loop_value_word_keeps_the_store_live() {
+    let src = "proc p {} { set x 1; foreach n {$x} { } }\n";
+    assert!(
+        !fires(src, D, "W211") && !fires(src, D, "W220"),
+        "#1260: a quoted mention keeps the store live; emitted: {:?}",
+        codes(src, D)
+    );
+    // TP control: with no mention of any kind the dead store is reported.
+    let unmentioned = "proc p {} { set x 1; foreach n {$y} { } }\n";
+    assert!(
+        fires(unmentioned, D, "W211") || fires(unmentioned, D, "W220"),
+        "#1260 TP: an unmentioned store is still dead; emitted: {:?}",
+        codes(unmentioned, D)
+    );
+}

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -2947,6 +2947,13 @@ impl Analyser {
             .get(1)
             .is_some_and(|tok| tok.kind == TokenType::Str);
         if tcl_syntax::naming::word_is_dynamic(&args[1], braced) {
+            // Record the abstention rather than merely staying silent: a
+            // consumer that has to be exhaustive about namespace occurrences
+            // (the namespace rename tier) cannot otherwise tell this document
+            // from one that declares no path at all (issue #1261).
+            if let Some(tok) = arg_tokens.get(1) {
+                self.result.namespace_path_computed.push(tok.span);
+            }
             return;
         }
         // The `namespace path` command-resolution tier is an 8.5 addition

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -1586,6 +1586,22 @@ pub struct AnalysisResult {
     /// namespace.  Consumed by command resolution so a bare call reaches a proc
     /// on the namespace path before falling through to global.
     pub namespace_paths: HashMap<String, Vec<String>>,
+    /// Spans of `namespace path` list words the analyser **could not** read
+    /// statically — `namespace path $paths`, `namespace path "$ns ::a"` — in
+    /// source order.
+    ///
+    /// [`Self::namespace_paths`] records only the resolvable declarations, so
+    /// its absence cannot tell "this document declares no path" from "this
+    /// document declares one whose entries are unknowable". A post-analysis
+    /// consumer that must be exhaustive about namespace occurrences — the
+    /// namespace rename tier, which rewrites each literal entry through the
+    /// per-element [`NamespaceRef`] rows — needs the difference: an entry it
+    /// cannot see is an entry it cannot rewrite (issue #1261).
+    ///
+    /// A *braced* word is not dynamic: braces suppress substitution, so
+    /// `namespace path {::$ns ::a}` names a namespace literally called
+    /// `::$ns` and is recorded as an ordinary literal path (issue #1245).
+    pub namespace_path_computed: Vec<Span>,
     /// `auto_path` mutations (``lappend auto_path …`` / ``set auto_path …``).
     pub auto_path_entries: Vec<AutoPathEntry>,
     /// Namespace-qualified variable occurrences, in source order — see

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -1614,6 +1614,11 @@ pub struct AnalysisResult {
     /// hover / find-references treat a namespace as a first-class symbol
     /// (issue #1088).
     pub namespace_refs: Vec<NamespaceRef>,
+    /// Variable-name argument words computed at run time, in source order —
+    /// see [`DynamicVariableNameSite`].  The per-site provenance a
+    /// post-analysis consumer needs to ask what a `$n` in a name position can
+    /// actually spell (issue #1262).
+    pub dynamic_variable_names: Vec<DynamicVariableNameSite>,
     /// Byte spans where command resolution is pinned to a namespace by
     /// runtime context rather than lexical nesting (issue #923 idx 116):
     /// `apply {{params} body ns}` runs `body` in `ns`, not the namespace
@@ -2010,6 +2015,47 @@ pub struct NamespaceRef {
     /// (`namespace eval`).  Go-to-definition answers with these; the
     /// reference set is everything else.
     pub declares: bool,
+}
+
+/// One variable-name argument whose word is **computed at run time** — a
+/// registry [`tcl_registry::ArgRole::VarWrite`] / [`tcl_registry::ArgRole::VarRead`]
+/// position holding a `$`/`[…]` substitution (`set $n 2`, `variable $n`,
+/// `namespace upvar ::ns $n local`) — together with what the analyser could
+/// prove about the value (issue #1262).
+///
+/// The proof is analyser *state*: `Scope::lookup_dominating_const_string`
+/// knows, while the walk is in progress, that the `$n` in `set n other; set
+/// $n 2` is `other` and can never be anything else at that site.  Nothing
+/// per-site survived into [`AnalysisResult`], so a post-analysis consumer —
+/// the namespace-variable rename gate, which has to be exhaustive about which
+/// cells a document can name — had only the word's own text to reason from
+/// and refused on every bare `$n`, which is a lone wildcard.
+///
+/// Recording the site is what lets that gate ask the *value* question as well
+/// as the textual one.  Abstain-toward-refuse is unchanged: a site whose
+/// resolution is [`None`] proves nothing, and a site the walk never reached
+/// leaves no row at all, so a consumer that only *narrows* on a
+/// [`Some`] resolution can never widen what it accepts.
+///
+/// A **brace-quoted** word is not here: `set {$n} 1` names the variable
+/// literally called `$n` and substitutes nothing (tclsh 8.6.14: `set {$n} v;
+/// info exists {$n}` -> 1 while `info exists n` -> 0), so it is not a dynamic
+/// name at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DynamicVariableNameSite {
+    /// Byte span of the name word as written.
+    pub span: Span,
+    /// The name the word evaluates to when every substitution in it has a
+    /// value that **dominates** this site — the straight-line constant
+    /// `Scope::lookup_dominating_const_string` proves.
+    ///
+    /// [`None`] when it does not: a branch-dependent binding, a parameter, a
+    /// command substitution, or any variable the constant lattice does not
+    /// track.  A consumer must treat `None` as "could be anything".
+    pub resolved: Option<String>,
+    /// `true` when the position **writes** the named variable
+    /// ([`tcl_registry::ArgRole::VarWrite`]), `false` when it reads it.
+    pub writes: bool,
 }
 
 /// One `CLASS create NAME` object-command binding, namespace-qualified.

--- a/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
+++ b/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
@@ -42,6 +42,45 @@ struct SwitchEscape<'a> {
     continue_target: &'a str,
 }
 
+/// Per-word token metadata for the synthetic loop-header call
+/// [`CfgBuilder::lower_foreach`] builds.
+///
+/// The only fact it carries is each value word's **brace-quoting**: `foreach n
+/// {a $b c} …` iterates the three literal elements `a`, `$b`, `c` and reads
+/// nothing, while `foreach n "a $b c" …` substitutes `$b` (tclsh 8.6.14 — the
+/// braced loop prints `a`, `$b`, `c` with `b` undefined throughout).  Both
+/// lower to the same `list_arg` *text*, so without this the read harvest saw a
+/// substitution in the braced word and drew a false `W210` (issue #1260).
+///
+/// Every span is the whole-command `span`: the iterator carries no per-word
+/// span, and the command span is exactly what the span-less consumers
+/// (`shimmer::use_site`'s `fallback_span`) already used.
+fn foreach_header_tokens(
+    fe_cmd: &str,
+    span: Span,
+    iterators: &[crate::ir::ForeachIterator],
+    list_args: &[String],
+) -> crate::ir::CommandTokens {
+    let mut argv_kinds = vec![tcl_lexer::TokenType::Esc];
+    argv_kinds.extend(iterators.iter().map(|it| {
+        if it.list_braced {
+            tcl_lexer::TokenType::Str
+        } else {
+            tcl_lexer::TokenType::Esc
+        }
+    }));
+    let mut argv_texts = vec![fe_cmd.to_owned()];
+    argv_texts.extend(list_args.iter().cloned());
+    crate::ir::CommandTokens {
+        argv: vec![span; iterators.len() + 1],
+        argv_texts,
+        argv_kinds,
+        single_token_word: vec![true; iterators.len() + 1],
+        all_tokens: Vec::new(),
+        expand_word: None,
+    }
+}
+
 /// A foldable always-true literal condition (`1`) for a rotated loop's
 /// synthetic entry-guard branch.  Span-less offsets (`0`) keep it distinct
 /// from any real source condition; SCCP folds it so the zero-iteration
@@ -390,36 +429,7 @@ impl CfgBuilder {
             (false, false) => "foreach",
         };
 
-        // Per-word token metadata for the synthetic argv below.  The only
-        // fact it carries is each value word's **brace-quoting**: `foreach n
-        // {a $b c} …` iterates the three literal elements `a`, `$b`, `c` and
-        // reads nothing, while `foreach n "a $b c" …` substitutes `$b`
-        // (tclsh 8.6.14 — the braced loop prints `a`, `$b`, `c` with `b`
-        // undefined throughout).  Both lower to the same `list_arg` *text*,
-        // so without this the read harvest saw a substitution in the braced
-        // word and drew a false `W210` (issue #1260).
-        //
-        // Every span is the whole-command span: the iterator carries no
-        // per-word span, and the command span is exactly what the span-less
-        // consumers (`shimmer::use_site`'s `fallback_span`) already used.
-        let mut argv_kinds = vec![tcl_lexer::TokenType::Esc];
-        argv_kinds.extend(iterators.iter().map(|it| {
-            if it.list_braced {
-                tcl_lexer::TokenType::Str
-            } else {
-                tcl_lexer::TokenType::Esc
-            }
-        }));
-        let mut argv_texts = vec![fe_cmd.to_owned()];
-        argv_texts.extend(list_args.iter().cloned());
-        let header_tokens = crate::ir::CommandTokens {
-            argv: vec![*span; iterators.len() + 1],
-            argv_texts,
-            argv_kinds,
-            single_token_word: vec![true; iterators.len() + 1],
-            all_tokens: Vec::new(),
-            expand_word: None,
-        };
+        let header_tokens = foreach_header_tokens(fe_cmd, *span, iterators, &list_args);
 
         // Synthetic def node for iteration variables (placed at the header for
         // the normal shape, or at the top of the body when rotated).

--- a/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
+++ b/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
@@ -390,6 +390,37 @@ impl CfgBuilder {
             (false, false) => "foreach",
         };
 
+        // Per-word token metadata for the synthetic argv below.  The only
+        // fact it carries is each value word's **brace-quoting**: `foreach n
+        // {a $b c} …` iterates the three literal elements `a`, `$b`, `c` and
+        // reads nothing, while `foreach n "a $b c" …` substitutes `$b`
+        // (tclsh 8.6.14 — the braced loop prints `a`, `$b`, `c` with `b`
+        // undefined throughout).  Both lower to the same `list_arg` *text*,
+        // so without this the read harvest saw a substitution in the braced
+        // word and drew a false `W210` (issue #1260).
+        //
+        // Every span is the whole-command span: the iterator carries no
+        // per-word span, and the command span is exactly what the span-less
+        // consumers (`shimmer::use_site`'s `fallback_span`) already used.
+        let mut argv_kinds = vec![tcl_lexer::TokenType::Esc];
+        argv_kinds.extend(iterators.iter().map(|it| {
+            if it.list_braced {
+                tcl_lexer::TokenType::Str
+            } else {
+                tcl_lexer::TokenType::Esc
+            }
+        }));
+        let mut argv_texts = vec![fe_cmd.to_owned()];
+        argv_texts.extend(list_args.iter().cloned());
+        let header_tokens = crate::ir::CommandTokens {
+            argv: vec![*span; iterators.len() + 1],
+            argv_texts,
+            argv_kinds,
+            single_token_word: vec![true; iterators.len() + 1],
+            all_tokens: Vec::new(),
+            expand_word: None,
+        };
+
         // Synthetic def node for iteration variables (placed at the header for
         // the normal shape, or at the top of the body when rotated).
         let var_def = Statement::Call {
@@ -401,7 +432,7 @@ impl CfgBuilder {
             reads: vec![],
             reads_own_defs: false,
             safe_on_uninit: false,
-            tokens: None,
+            tokens: Some(header_tokens),
             foreach_groups: Some(group_sizes),
         };
 
@@ -1039,6 +1070,7 @@ mod tests {
             iterators: vec![ForeachIterator {
                 vars: vec!["x".into()],
                 list_arg: "$list".into(),
+                list_braced: false,
             }],
             body: Script::new(),
             body_span: Span::new(20, 25),

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -2620,10 +2620,12 @@ mod tests {
                 ForeachIterator {
                     vars: vec!["a".into(), "b".into()],
                     list_arg: "L1".into(),
+                    list_braced: false,
                 },
                 ForeachIterator {
                     vars: vec!["c".into()],
                     list_arg: "L2".into(),
+                    list_braced: false,
                 },
             ],
             body,

--- a/rust/tcl-compiler/src/inlining/rename.rs
+++ b/rust/tcl-compiler/src/inlining/rename.rs
@@ -364,7 +364,15 @@ fn rewrite_binding_scope(stmt: &Statement, rename: &HashMap<String, String>) -> 
                 .iter()
                 .map(|it| crate::ir::ForeachIterator {
                     vars: it.vars.iter().map(|v| rename_local(v, rename)).collect(),
-                    list_arg: rewrite_value_string(&it.list_arg, rename),
+                    // A brace-quoted value word substitutes nothing, so a
+                    // `$v` inside it is literal text and must survive
+                    // inlining unrewritten (issue #1260).
+                    list_arg: if it.list_braced {
+                        it.list_arg.clone()
+                    } else {
+                        rewrite_value_string(&it.list_arg, rename)
+                    },
+                    list_braced: it.list_braced,
                 })
                 .collect(),
             body: rewrite_script(body, rename),

--- a/rust/tcl-compiler/src/ir.rs
+++ b/rust/tcl-compiler/src/ir.rs
@@ -282,6 +282,19 @@ pub struct ForeachIterator {
     pub vars: Vec<String>,
     /// Source text of the list argument.
     pub list_arg: String,
+    /// Whether the *list* word was a brace-string literal
+    /// (`foreach n {a $b c} …`). Braces suppress substitution, so a
+    /// `$b` inside such a word is a literal three-character list
+    /// element, not a read of `b` — tclsh 8.6.14: `foreach n {a $b c}
+    /// {puts $n}` prints `a`, `$b`, `c` with `b` undefined throughout.
+    ///
+    /// [`list_arg`](Self::list_arg) stores the word's *content* (braces
+    /// already stripped), which cannot tell `{$b}` from `$b`; this flag
+    /// is the same distinction [`Statement::AssignConst::braced`],
+    /// [`Statement::Return::braced`] and
+    /// [`CommandTokens::arg_is_braced_literal`] carry for their own
+    /// words (issue #1260).
+    pub list_braced: bool,
 }
 
 /// An IR statement — the building block of the compiler pipeline.
@@ -1413,6 +1426,7 @@ mod tests {
             iterators: vec![ForeachIterator {
                 vars: vec!["k".into(), "v".into()],
                 list_arg: "$dict".into(),
+                list_braced: false,
             }],
             body: Script::new(),
             body_span: Span::new(25, 28),

--- a/rust/tcl-compiler/src/ir_helpers.rs
+++ b/rust/tcl-compiler/src/ir_helpers.rs
@@ -777,6 +777,7 @@ mod tests {
             iterators: vec![ForeachIterator {
                 vars: vec!["k".into(), "v".into()],
                 list_arg: "$d".into(),
+                list_braced: false,
             }],
             body: Script::new(),
             body_span: Span::new(20, 25),

--- a/rust/tcl-compiler/src/lowering/mod.rs
+++ b/rust/tcl-compiler/src/lowering/mod.rs
@@ -2170,6 +2170,9 @@ impl<'r> Lowerer<'r> {
                 iterators: vec![ForeachIterator {
                     vars,
                     list_arg: args[2].clone(),
+                    // `array for {k v} {arr} …` — a braced array-name word
+                    // is a literal name, not a substitution (issue #1260).
+                    list_braced: Self::cmd_tokens(seg).arg_is_braced_literal(2),
                 }],
                 body,
                 body_span: body_tok.span,

--- a/rust/tcl-compiler/src/lowering/structured.rs
+++ b/rust/tcl-compiler/src/lowering/structured.rs
@@ -433,12 +433,20 @@ impl Lowerer<'_> {
             return Self::barrier(seg, "foreach with dynamic body");
         }
 
+        // The value word's brace-quoting is a fact only the tokens carry:
+        // `foreach n {a $b c}` iterates the three literal elements `a`,
+        // `$b`, `c` and reads nothing (tclsh 8.6.14), while `foreach n
+        // "a $b c"` substitutes. Both lower to the same `list_arg` text,
+        // so the flag is what downstream read-harvesting gates on
+        // (issue #1260).
+        let cmd_tokens = Self::cmd_tokens(seg);
         let mut iterators = Vec::new();
         for i in (0..body_idx).step_by(2) {
             let var_names = parse_param_names(&args[i]);
             iterators.push(ForeachIterator {
                 vars: var_names,
                 list_arg: args[i + 1].clone(),
+                list_braced: cmd_tokens.arg_is_braced_literal(i + 1),
             });
         }
 
@@ -477,7 +485,7 @@ impl Lowerer<'_> {
             raw_args: args.to_vec(),
             is_dict_iteration: false,
             is_array_iteration: false,
-            raw_tokens: Some(Self::cmd_tokens(seg)),
+            raw_tokens: Some(cmd_tokens),
         }
     }
 
@@ -561,9 +569,11 @@ impl Lowerer<'_> {
         // dataflow doesn't care: the lattice-propagation matters,
         // not the literal value.  See the type-level doc-comment
         // above for the runtime-semantics caveat.
+        let cmd_tokens = Self::cmd_tokens(seg);
         let iterators = vec![ForeachIterator {
             vars: parse_param_names(&args[0]),
             list_arg: args[1].clone(),
+            list_braced: cmd_tokens.arg_is_braced_literal(1),
         }];
 
         let body = self.lower_body_from_tok(&args[2], body_tok, namespace);
@@ -577,7 +587,7 @@ impl Lowerer<'_> {
             raw_args: args.to_vec(),
             is_dict_iteration: false,
             is_array_iteration: false,
-            raw_tokens: Some(Self::cmd_tokens(seg)),
+            raw_tokens: Some(cmd_tokens),
         }
     }
 
@@ -980,6 +990,10 @@ impl Lowerer<'_> {
                     iterators: vec![ForeachIterator {
                         vars: var_names,
                         list_arg: sub_args[1].clone(),
+                        // `dict for {k v} {a $b} …` iterates the literal
+                        // dictionary; the value word is `args[2]` in the
+                        // full argument list (issue #1260).
+                        list_braced: Self::cmd_tokens(seg).arg_is_braced_literal(2),
                     }],
                     body,
                     body_span: body_tok.map_or(seg.span, |t| t.span),

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -1792,7 +1792,7 @@ fn scan_command_words(
     // Whether the registry describes this command at all — the difference
     // between a braced word that is known **data** and one that is merely
     // *unclassified*. See [`braced_word_class`].
-    let described = registry.get(lookup).is_some();
+    let described = registry_describes(registry, lookup);
     for (idx, arg) in args.iter().enumerate() {
         if body_indices.contains(&idx) || name_role_braced.contains(&idx) {
             continue;
@@ -1812,6 +1812,27 @@ fn scan_command_words(
             };
         }
     }
+}
+
+/// Whether the registry describes `name` — accepting a space-joined
+/// *ensemble subcommand* spelling (`dict for`, `dict map`) as well as a plain
+/// command name.
+///
+/// The CFG's synthetic loop header names itself that way
+/// (`cfg_builder::cfg_lower::lower_foreach`), and `registry.get` keys only on
+/// whole command names, so a plain `get` would report a `dict for` header as
+/// *unclassified* and read its braced value word as a substitution.  Mirrors
+/// the base/sub split `shimmer::use_site::foreach_header_expected_type`
+/// already does for the same statement (issue #1260).
+fn registry_describes(registry: &CommandRegistry, name: &str) -> bool {
+    if registry.get(name).is_some() {
+        return true;
+    }
+    name.split_once(' ').is_some_and(|(base, sub)| {
+        registry
+            .get(base)
+            .is_some_and(|spec| spec.resolve_subcommand(sub).is_some())
+    })
 }
 
 /// One `(argument word, name found in it)` pair, with the facts
@@ -1979,6 +2000,18 @@ fn reads_in_stmt(
             iterators, body, ..
         } => {
             for it in iterators {
+                // `it.list_braced` is deliberately NOT consulted here. This
+                // walk feeds [`free_reads_in_script`], whose caller
+                // ([`switch_reads`]) merges everything into
+                // `ClassifiedUses::substituted` — the whole path drops
+                // [`UseClass`], so a name omitted here loses its *liveness*
+                // use too and resurrects W211/W220 on a store whose only
+                // mention is the braced word. The same collapse already
+                // keeps `puts {$y}` a read inside an opaque switch arm; the
+                // fix is to thread the classification through this walk, not
+                // to drop reads one statement kind at a time (issue #1260
+                // fixes the lowered path; the collapsed-arm residual is
+                // tracked separately).
                 reads.extend(scanner.scan_word(&it.list_arg, registry));
             }
             reads.extend(reads_in_script(body, scanner, registry));

--- a/rust/tcl-compiler/tests/pipeline_coverage.rs
+++ b/rust/tcl-compiler/tests/pipeline_coverage.rs
@@ -515,6 +515,7 @@ mod defs_from_ir_script_arms {
             iterators: vec![ForeachIterator {
                 vars: vec!["k".into(), "v".into()],
                 list_arg: "$d".into(),
+                list_braced: false,
             }],
             body: Script::from_statements(vec![assign("acc")]),
             body_span: Span::new(10, 19),

--- a/rust/tcl-lsp-core/src/namespace_rename.rs
+++ b/rust/tcl-lsp-core/src/namespace_rename.rs
@@ -59,9 +59,11 @@
 //! * a **computed** namespace word (`namespace eval $ns { … }`) that could
 //!   spell this namespace — there is no word to rewrite, and the value may be
 //!   this very name;
-//! * a `namespace path` entry naming it — the entry is one element inside a
-//!   list word the analyser records without a per-element span, so the tier
-//!   cannot rewrite it (tracked separately);
+//! * a `namespace path` word built from a **computed** value (`namespace path
+//!   $paths`) — its entries are unknowable, and any of them may be this
+//!   namespace.  A *literal* path list is rewritten, not refused: each of its
+//!   elements is recorded as a `NamespaceRef` at its own span, so the entry
+//!   moves through the ordinary edit path (issue #1261);
 //! * a **collision** with a namespace that already exists — the server's
 //!   half, since it is a workspace question.
 //!
@@ -321,21 +323,28 @@ fn namespace_rename_hazard(
     considered: &[Span],
     line_index: &LineIndex,
 ) -> Option<RenameRefusal> {
-    // A `namespace path {…}` entry naming the namespace.  The entry is one
-    // element of a list word the analyser records without a per-element span,
-    // so there is nothing to rewrite; leaving it behind would leave the
-    // path pointing at a namespace that no longer exists.
-    for entries in analysis.namespace_paths.values() {
-        if entries.iter().any(|entry| names_at_or_under(cell, entry)) {
-            return Some(RenameRefusal {
-                reason: format!(
-                    "cannot rename `{cell}`: a `namespace path` list names it, and the \
-                     entry is one element of a list word this rename cannot span, so the \
-                     path would keep naming a namespace that no longer exists."
-                ),
-                range: None,
-            });
-        }
+    // A `namespace path` word the analyser could not read as a literal list —
+    // `namespace path $paths`, `namespace path "$ns ::a"`.  Its entries are
+    // whatever the value turns out to be, which may include this namespace,
+    // and there is no element word to rewrite.  A *literal* list needs no
+    // arm here: each of its elements is recorded as a `NamespaceRef` at its
+    // own span, so the edit collector rewrites the ones naming the renamed
+    // cell like any other spelling (issue #1261).
+    if let Some(&span) = analysis.namespace_path_computed.first() {
+        let written = source
+            .get(span.start() as usize..span.end() as usize)
+            .unwrap_or("");
+        return Some(RenameRefusal::at(
+            format!(
+                "cannot rename `{cell}`: a `namespace path` is built from a value computed \
+                 at run time (`{written}`), whose entries may name this very namespace — \
+                 there is no element word to rewrite, so the path could keep naming a \
+                 namespace that no longer exists."
+            ),
+            source,
+            line_index,
+            Some(span),
+        ));
     }
     let registry = tcl_registry::registry_for_dialect(dialect);
     let mut hazard: Option<(Span, HazardKind)> = None;
@@ -606,13 +615,103 @@ mod tests {
         assert!(renamed(src, "::old", "new").is_ok());
     }
 
-    /// TP (refusal) — a `namespace path` entry naming it cannot be spanned.
+    /// TP, issue #1261 — a literal `namespace path` entry naming the
+    /// namespace is *rewritten*, not refused: each element carries its own
+    /// span, so the tier edits the element's segment like any other spelling.
+    ///
+    /// tclsh-proof (8.6.14) that the before/after programs agree: the source
+    /// below prints `P`, and the same script with `old` spelled `new`
+    /// throughout prints `P` too — while leaving the entry behind fails with
+    /// `namespace "::old" not found in "::"`.
     #[test]
-    fn tp_refuses_a_namespace_path_entry() {
+    fn tp_rewrites_a_namespace_path_entry() {
+        let src = "namespace eval ::old { proc p {} { return P } ; namespace export p }\n\
+                   namespace eval ::user { namespace path {::old}\n\
+                   \x20   proc use {} { return [p] } }\n\
+                   puts [::user::use]\n";
+        let out = renamed(src, "::old", "new").expect("a literal path entry is rewritable");
+        assert!(out.contains("namespace path {::new}"), "{out}");
+        assert!(out.contains("namespace eval ::new {"), "{out}");
+    }
+
+    /// TP — only the entries naming the renamed namespace move; siblings in
+    /// the same list word are left exactly as written.
+    #[test]
+    fn tp_rewrites_only_the_matching_namespace_path_entries() {
         let src = "namespace eval ::old { proc p {} {} }\n\
-                   namespace eval ::user { namespace path {::old} }\n";
-        let reason = renamed(src, "::old", "new").expect_err("a path entry must refuse");
-        assert!(reason.contains("namespace path"), "{reason}");
+                   namespace eval ::keep { proc q {} {} }\n\
+                   namespace eval ::user { namespace path {::keep ::old::deep ::other} }\n";
+        let out = renamed(src, "::old", "new").expect("rename");
+        assert!(
+            out.contains("namespace path {::keep ::new::deep ::other}"),
+            "{out}"
+        );
+    }
+
+    /// TP — a **relative** entry roots against the namespace the `namespace
+    /// path` runs in, and only the segment that spells the renamed namespace
+    /// moves.
+    ///
+    /// tclsh-proof (8.6.14): inside `namespace eval ::app`, `namespace path
+    /// {old}` echoes `::app::old` — the entry roots against the namespace the
+    /// command runs in, current-namespace-only (the same block written one
+    /// level deeper, in `::app::user`, fails `namespace "old" not found in
+    /// "::app::user"`).  So a rename of `::app::old` must rewrite the bare
+    /// `old` word.
+    #[test]
+    fn tp_rewrites_a_relatively_written_namespace_path_entry() {
+        let src = "namespace eval ::app {\n\
+                   \x20   namespace eval old { proc p {} {} }\n\
+                   \x20   namespace path {old}\n\
+                   }\n";
+        let out = renamed(src, "::app::old", "new").expect("rename");
+        assert!(out.contains("namespace path {new}"), "{out}");
+    }
+
+    /// TN — a path list that names nothing beneath the renamed namespace is
+    /// untouched and does not refuse.
+    #[test]
+    fn tn_an_unrelated_namespace_path_neither_moves_nor_refuses() {
+        let src = "namespace eval ::old { proc p {} {} }\n\
+                   namespace eval ::user { namespace path {::a ::b} }\n";
+        let out = renamed(src, "::old", "new").expect("an unrelated path must not refuse");
+        assert!(out.contains("namespace path {::a ::b}"), "{out}");
+    }
+
+    /// TP (refusal), issue #1261 — a `namespace path` built from a value
+    /// computed at run time still refuses: its entries are unknowable, any of
+    /// them may be this namespace, and there is no element word to rewrite.
+    #[test]
+    fn tp_refuses_a_computed_namespace_path() {
+        for src in [
+            "namespace eval ::old { proc p {} {} }\n\
+             namespace eval ::user { namespace path $paths }\n",
+            "namespace eval ::old { proc p {} {} }\n\
+             namespace eval ::user { namespace path \"$ns ::a\" }\n",
+        ] {
+            let reason = renamed(src, "::old", "new").expect_err("a computed path must refuse");
+            assert!(reason.contains("namespace path"), "{reason}");
+            assert!(reason.contains("computed at run time"), "{reason}");
+        }
+    }
+
+    /// TN — a **braced** `$`-spelled entry is not computed: braces suppress
+    /// substitution, so the word is a literal path list and the tier neither
+    /// refuses nor rewrites it.
+    ///
+    /// tclsh-proof (8.6.14): `namespace eval n { namespace path {::$ns ::a} }`
+    /// (with a namespace literally named `::$ns`) echoes `{::$ns} ::a` — the
+    /// entry is a name, never a variable read.
+    #[test]
+    fn tn_a_braced_dollar_entry_is_a_literal_path() {
+        let src = "namespace eval ::old { proc p {} {} }\n\
+                   namespace eval ::user { namespace path {::a ::b} }\n";
+        let analysis = analyse(src);
+        assert!(
+            analysis.namespace_path_computed.is_empty(),
+            "a braced literal list records no abstention",
+        );
+        assert!(renamed(src, "::old", "new").is_ok());
     }
 
     /// TP — import patterns follow the namespace.

--- a/rust/tcl-lsp-core/src/package_resolver.rs
+++ b/rust/tcl-lsp-core/src/package_resolver.rs
@@ -67,8 +67,8 @@ pub use tcl_dialect::PackagePrefer;
 /// interpreter-global selection rule [`PackageResolver::resolve_require`]
 /// needs (issue #1126 item 1).
 ///
-/// `package prefer` is a monotone latch: the default is
-/// [`PackagePrefer::Stable`], a `package prefer latest` raises it, and
+/// `package prefer` is a monotone latch: it starts at `default`, a
+/// `package prefer latest` raises it, and
 /// nothing lowers it again (`package prefer stable` afterwards is silently
 /// ineffective — transcript on
 /// [`tcl_compiler::signature_scan::types::SignaturePackagePrefer`]). So the
@@ -82,21 +82,39 @@ pub use tcl_dialect::PackagePrefer;
 /// runs), while a raise inside a body does not reach back to a top-level
 /// require.
 ///
-/// Two abstentions, both toward the interpreter default:
+/// A **conditional** raise (inside `if` / `catch` / `try`) is ignored — it may
+/// not run, and flipping the selection rule would move go-to-definition onto a
+/// different release of the package.  That abstention is toward `default`.
 ///
-/// * a **conditional** raise (inside `if` / `catch` / `try`) is ignored — it
-///   may not run, and flipping the selection rule would move go-to-definition
-///   onto a different release of the package;
-/// * a raise in **another document** is not seen at all. The state is
-///   interpreter-global, so a `package prefer latest` in a file sourced first
-///   really does change this file's answer, but which file runs first is not
-///   a static fact — the same abstention the import family records for every
-///   cross-file event (`docs/design/import-order-source-graph.md`).
+/// # What `default` carries (issue #1253)
+///
+/// The interpreter's own starting mode is not always `stable`:
+/// `TCL_PKG_PREFER_LATEST` in the environment makes it `latest`, and on 9.0+
+/// so does running an unstable build of Tcl itself (the registry's `prefer`
+/// subcommand detail documents both).  Neither is a fact about the source
+/// tree, so it is a caller-supplied input rather than an inference —
+/// [`PackagePrefer::Stable`] unless the workspace says otherwise.
+///
+/// It is also where a raise in **another document** arrives.  The state is
+/// interpreter-global, so a `package prefer latest` in a file that runs first
+/// really does change this file's answer; along the `source` graph "runs
+/// first" is a static fact, and
+/// [`WorkspaceIndex::source_ancestor_prefers_latest`](crate::workspace_index::WorkspaceIndex::source_ancestor_prefers_latest)
+/// answers it.  A raise reaching this file some *other* way (a load order no
+/// `source` edge records) is still unseen — the abstention the import family
+/// records for every cross-file event
+/// (`docs/design/import-order-source-graph.md`).
 #[must_use]
 pub fn package_prefer_at(
     analysis: &tcl_compiler::analyser::AnalysisResult,
     at: u32,
+    default: PackagePrefer,
 ) -> PackagePrefer {
+    // Monotone latch: once raised, nothing lowers it, so an inherited
+    // `latest` default is the answer whatever this document writes.
+    if default == PackagePrefer::Latest {
+        return PackagePrefer::Latest;
+    }
     let raised = analysis.package_prefer_latest.iter().any(|p| {
         !p.conditional
             && tcl_compiler::analyser::indirection::in_effect(analysis, p.range.start(), at)
@@ -104,7 +122,7 @@ pub fn package_prefer_at(
     if raised {
         PackagePrefer::Latest
     } else {
-        PackagePrefer::Stable
+        default
     }
 }
 

--- a/rust/tcl-lsp-core/src/package_resolver/tests.rs
+++ b/rust/tcl-lsp-core/src/package_resolver/tests.rs
@@ -648,7 +648,11 @@ fn package_prefer_state_is_ordered_against_the_require() {
     let src = "package prefer latest\npackage require w\n";
     let analysis = analyse(src);
     assert_eq!(
-        crate::package_resolver::package_prefer_at(&analysis, at(src, "package require"), PackagePrefer::Stable),
+        crate::package_resolver::package_prefer_at(
+            &analysis,
+            at(src, "package require"),
+            PackagePrefer::Stable
+        ),
         PackagePrefer::Latest,
     );
 
@@ -656,7 +660,11 @@ fn package_prefer_state_is_ordered_against_the_require() {
     let src = "package require w\npackage prefer latest\n";
     let analysis = analyse(src);
     assert_eq!(
-        crate::package_resolver::package_prefer_at(&analysis, at(src, "package require"), PackagePrefer::Stable),
+        crate::package_resolver::package_prefer_at(
+            &analysis,
+            at(src, "package require"),
+            PackagePrefer::Stable
+        ),
         PackagePrefer::Stable,
     );
 
@@ -666,7 +674,11 @@ fn package_prefer_state_is_ordered_against_the_require() {
     let src = "proc load {} {\n    package require w\n}\npackage prefer latest\n";
     let analysis = analyse(src);
     assert_eq!(
-        crate::package_resolver::package_prefer_at(&analysis, at(src, "    package require"), PackagePrefer::Stable),
+        crate::package_resolver::package_prefer_at(
+            &analysis,
+            at(src, "    package require"),
+            PackagePrefer::Stable
+        ),
         PackagePrefer::Latest,
     );
 
@@ -674,7 +686,11 @@ fn package_prefer_state_is_ordered_against_the_require() {
     let src = "if {$::tcl_platform(platform) eq \"unix\"} {\n    package prefer latest\n}\npackage require w\n";
     let analysis = analyse(src);
     assert_eq!(
-        crate::package_resolver::package_prefer_at(&analysis, at(src, "package require"), PackagePrefer::Stable),
+        crate::package_resolver::package_prefer_at(
+            &analysis,
+            at(src, "package require"),
+            PackagePrefer::Stable
+        ),
         PackagePrefer::Stable,
     );
 
@@ -687,7 +703,11 @@ fn package_prefer_state_is_ordered_against_the_require() {
     ] {
         let analysis = analyse(src);
         assert_eq!(
-            crate::package_resolver::package_prefer_at(&analysis, at(src, "package require"), PackagePrefer::Stable),
+            crate::package_resolver::package_prefer_at(
+                &analysis,
+                at(src, "package require"),
+                PackagePrefer::Stable
+            ),
             PackagePrefer::Stable,
             "{src}",
         );

--- a/rust/tcl-lsp-core/src/package_resolver/tests.rs
+++ b/rust/tcl-lsp-core/src/package_resolver/tests.rs
@@ -648,7 +648,7 @@ fn package_prefer_state_is_ordered_against_the_require() {
     let src = "package prefer latest\npackage require w\n";
     let analysis = analyse(src);
     assert_eq!(
-        crate::package_resolver::package_prefer_at(&analysis, at(src, "package require")),
+        crate::package_resolver::package_prefer_at(&analysis, at(src, "package require"), PackagePrefer::Stable),
         PackagePrefer::Latest,
     );
 
@@ -656,7 +656,7 @@ fn package_prefer_state_is_ordered_against_the_require() {
     let src = "package require w\npackage prefer latest\n";
     let analysis = analyse(src);
     assert_eq!(
-        crate::package_resolver::package_prefer_at(&analysis, at(src, "package require")),
+        crate::package_resolver::package_prefer_at(&analysis, at(src, "package require"), PackagePrefer::Stable),
         PackagePrefer::Stable,
     );
 
@@ -666,7 +666,7 @@ fn package_prefer_state_is_ordered_against_the_require() {
     let src = "proc load {} {\n    package require w\n}\npackage prefer latest\n";
     let analysis = analyse(src);
     assert_eq!(
-        crate::package_resolver::package_prefer_at(&analysis, at(src, "    package require")),
+        crate::package_resolver::package_prefer_at(&analysis, at(src, "    package require"), PackagePrefer::Stable),
         PackagePrefer::Latest,
     );
 
@@ -674,7 +674,7 @@ fn package_prefer_state_is_ordered_against_the_require() {
     let src = "if {$::tcl_platform(platform) eq \"unix\"} {\n    package prefer latest\n}\npackage require w\n";
     let analysis = analyse(src);
     assert_eq!(
-        crate::package_resolver::package_prefer_at(&analysis, at(src, "package require")),
+        crate::package_resolver::package_prefer_at(&analysis, at(src, "package require"), PackagePrefer::Stable),
         PackagePrefer::Stable,
     );
 
@@ -687,11 +687,56 @@ fn package_prefer_state_is_ordered_against_the_require() {
     ] {
         let analysis = analyse(src);
         assert_eq!(
-            crate::package_resolver::package_prefer_at(&analysis, at(src, "package require")),
+            crate::package_resolver::package_prefer_at(&analysis, at(src, "package require"), PackagePrefer::Stable),
             PackagePrefer::Stable,
             "{src}",
         );
     }
+}
+
+/// Issue #1253 item 2 — the interpreter's **starting** mode is an input, not
+/// a constant.  `TCL_PKG_PREFER_LATEST` in the environment (and, on 9.0+, an
+/// unstable build of Tcl itself) makes `latest` the default, which no reading
+/// of the source tree can discover; the workspace setting carries it.
+///
+/// The latch is monotone, so a `latest` default is the answer at every
+/// position — including above a raise, and including a document whose only
+/// `package prefer` is a conditional one the gate otherwise ignores.
+#[test]
+fn a_latest_default_holds_at_every_position() {
+    use tcl_compiler::analyser::Analyser;
+    let analyse = |src: &str| Analyser::new().analyse(src, "tcl");
+    let at = |src: &str, needle: &str| {
+        u32::try_from(src.find(needle).expect("needle")).expect("offset fits")
+    };
+    for src in [
+        "package require w\npackage prefer latest\n",
+        "package prefer stable\npackage require w\n",
+        "if {$::c} {\n    package prefer latest\n}\npackage require w\n",
+    ] {
+        let analysis = analyse(src);
+        assert_eq!(
+            crate::package_resolver::package_prefer_at(
+                &analysis,
+                at(src, "package require"),
+                PackagePrefer::Latest,
+            ),
+            PackagePrefer::Latest,
+            "{src}",
+        );
+    }
+    // TN control: the same documents answer `Stable` under the ordinary
+    // default — the parameter is the only thing that changed.
+    let src = "package require w\npackage prefer latest\n";
+    let analysis = analyse(src);
+    assert_eq!(
+        crate::package_resolver::package_prefer_at(
+            &analysis,
+            at(src, "package require"),
+            PackagePrefer::Stable,
+        ),
+        PackagePrefer::Stable,
+    );
 }
 
 /// Two providers whose versions compare **equal** both contribute their files

--- a/rust/tcl-lsp-core/src/rename_safety.rs
+++ b/rust/tcl-lsp-core/src/rename_safety.rs
@@ -703,11 +703,22 @@ fn slice(source: &str, span: Span) -> Option<&str> {
 /// really does reach the cell through `ns::bump v`).
 ///
 /// Abstain-toward-refuse is unchanged — the predicate answers "could spell it"
-/// for everything it cannot rule out, and a lone `$n` is a bare wildcard that
-/// rules nothing out.  The residual is a *value*-set fact this text-level
-/// bound cannot see: a `$n` whose dominating constant provably differs from
-/// the cell's tail still refuses, because no per-site constant-value record
-/// survives analysis for a post-analysis consumer to read.
+/// for everything it cannot rule out.
+///
+/// # Per-site value provenance (issue #1262)
+///
+/// A lone `$n` is a bare wildcard, so the text bound alone rules nothing out.
+/// The *value* set can: the analyser resolves each computed name word through
+/// the constant lattice that **dominates** it and carries the answer out on
+/// [`AnalysisResult::dynamic_variable_names`](tcl_compiler::analyser::AnalysisResult::dynamic_variable_names),
+/// so `namespace eval ::ns { variable v 1; proc p {} { set n other; set $n 2 } }`
+/// no longer refuses a rename of `::ns::v` — that `$n` is provably `other`.
+///
+/// Narrowing only ([`site_resolution_rules_out`]): a site whose resolution is
+/// branch-dependent or parameter-fed, and a site the walk never reached, keep
+/// refusing exactly as before.  The residual is everything the dominating
+/// -constant lattice does not track — a value from a `[…]` substitution, a
+/// caller-supplied parameter, an `upvar`-aliased name.
 #[must_use]
 pub fn namespace_variable_rename_hazard(
     source: &str,
@@ -743,10 +754,19 @@ pub fn namespace_variable_rename_hazard(
                 if !tcl_compiler::dynamic_names::dynamic_variable_word_can_spell(word, cell) {
                     continue;
                 }
-                if let Some(tok) = cmd.argv.get(idx + 1) {
-                    hazard = Some(tok.span);
-                    return;
+                let Some(tok) = cmd.argv.get(idx + 1) else {
+                    continue;
+                };
+                // …and neither is one whose *value* the analyser proved:
+                // `set n other; set $n 2` names `other` at that site, never
+                // this cell, however wildcard the text is (issue #1262).
+                // Narrowing only — a site with no recorded resolution, or one
+                // the analyser's walk never reached, keeps refusing.
+                if site_resolution_rules_out(analysis, tok.span, cell) {
+                    continue;
                 }
+                hazard = Some(tok.span);
+                return;
             }
         }
     };
@@ -763,6 +783,31 @@ pub fn namespace_variable_rename_hazard(
         line_index,
         Some(span),
     ))
+}
+
+/// Whether the analyser's per-site provenance proves the dynamic name word at
+/// `span` cannot spell `cell` (issue #1262).
+///
+/// The word's *text* bounds the names it can produce, but a bare `$n` is a
+/// lone wildcard and bounds nothing.  The analyser knows more while it walks:
+/// `Scope::lookup_dominating_const_string` resolves that `$n` to the constant
+/// that dominates the site, and
+/// [`AnalysisResult::dynamic_variable_names`](tcl_compiler::analyser::AnalysisResult::dynamic_variable_names)
+/// carries the answer out.  A resolved site is re-asked the same textual
+/// question with the substitution replaced by its value, so one rule decides
+/// "can this word spell this cell" for both.
+///
+/// One-directional by construction: `false` for a site with no row, and for a
+/// row whose resolution is `None` (branch-dependent, parameter-fed, or a `[…]`
+/// substitution).  A gate that only skips on `true` therefore never accepts
+/// more than the text-only bound did.
+fn site_resolution_rules_out(analysis: &AnalysisResult, span: Span, cell: &str) -> bool {
+    analysis.dynamic_variable_names.iter().any(|site| {
+        site.span == span
+            && site.resolved.as_deref().is_some_and(|resolved| {
+                !tcl_compiler::dynamic_names::dynamic_variable_word_can_spell(resolved, cell)
+            })
+    })
 }
 
 /// Refuse a **variable** rename whose target's name can only be written
@@ -1119,6 +1164,98 @@ mod tests {
                    }\n";
         let reason = var_hazard(src, "::ns::v").expect("`variable $n` really does reach the cell");
         assert!(reason.contains("computed at run time"), "{reason}");
+    }
+
+    // Issue #1262 — per-site *value* provenance.  The text bound cannot see
+    // what a lone `$n` holds; the analyser's dominating-constant lattice can,
+    // and now carries the answer out on `dynamic_variable_names`.
+
+    /// TN, the issue's own shape: a `$n` whose dominating constant is
+    /// provably a different name no longer refuses.
+    ///
+    /// tclsh-proof (8.6.14): `namespace eval ::ns {variable v 1; proc p {}
+    /// {set n other; set $n 2}}; ::ns::p; info exists ::ns::v` -> 1 and
+    /// `set ::ns::v` -> 1 — the write landed on `other`, never on `v`.
+    #[test]
+    fn tn_a_dominating_constant_name_no_longer_refuses() {
+        let src = "namespace eval ::ns {\n\
+                   \x20   variable v 1\n\
+                   \x20   proc p {} { set n other ; set $n 2 }\n\
+                   }\n";
+        assert_eq!(
+            var_hazard(src, "::ns::v"),
+            None,
+            "`$n` is provably `other` at that site",
+        );
+    }
+
+    /// TP control: the same shape whose constant **is** the cell's tail still
+    /// refuses — the provenance narrows, it does not disable.
+    #[test]
+    fn tp_a_dominating_constant_naming_the_cell_still_refuses() {
+        let src = "namespace eval ::ns {\n\
+                   \x20   variable v 1\n\
+                   \x20   proc p {} { set n v ; set $n 2 }\n\
+                   }\n";
+        let reason = var_hazard(src, "::ns::v").expect("`$n` is provably `v` at that site");
+        assert!(reason.contains("computed at run time"), "{reason}");
+    }
+
+    /// TP: a **branch-dependent** binding dominates nothing, so the site
+    /// resolves to `None` and the refusal stands.
+    ///
+    /// tclsh-proof (8.6.14): `namespace eval ::ns {variable v 1; proc p {c}
+    /// {set n other; if {$c} {set n v}; variable v; set $n 2}}; ::ns::p 1`
+    /// leaves `set ::ns::v` -> 2 — the conditional branch really does reach
+    /// the cell.
+    #[test]
+    fn tp_a_branch_dependent_constant_still_refuses() {
+        let src = "namespace eval ::ns {\n\
+                   \x20   variable v 1\n\
+                   \x20   proc p {c} { set n other ; if {$c} { set n v } ; variable v ; set $n 2 }\n\
+                   }\n";
+        let reason = var_hazard(src, "::ns::v").expect("a branch-dependent value proves nothing");
+        assert!(reason.contains("computed at run time"), "{reason}");
+    }
+
+    /// TP: a parameter-fed name proves nothing either — the caller chooses it.
+    #[test]
+    fn tp_a_parameter_fed_name_still_refuses() {
+        let src = "namespace eval ::ns {\n\
+                   \x20   variable v 1\n\
+                   \x20   proc p {n} { set $n 2 }\n\
+                   }\n";
+        let reason = var_hazard(src, "::ns::v").expect("a parameter proves nothing");
+        assert!(reason.contains("computed at run time"), "{reason}");
+    }
+
+    /// The provenance table itself: a resolvable site carries its value, an
+    /// unresolvable one carries `None`, and a **braced** name word — which
+    /// substitutes nothing — is not a dynamic site at all.
+    ///
+    /// tclsh-proof (8.6.14): `set {$n} v; info exists {$n}` -> 1 while
+    /// `info exists n` -> 0.
+    #[test]
+    fn the_provenance_table_records_each_site_once() {
+        let analysis = analyse(
+            "proc a {} { set n other ; set $n 2 }\n\
+             proc b {p} { set $p 2 }\n\
+             proc c {} { set {$n} 2 }\n",
+        );
+        let resolutions: Vec<Option<&str>> = analysis
+            .dynamic_variable_names
+            .iter()
+            .map(|s| s.resolved.as_deref())
+            .collect();
+        assert_eq!(
+            resolutions,
+            [Some("other"), None],
+            "one row per computed name word; a braced literal name is not one",
+        );
+        assert!(
+            analysis.dynamic_variable_names.iter().all(|s| s.writes),
+            "both sites are `set` targets",
+        );
     }
 
     // Issue #1121 review — a moved member's declaration site is the

--- a/rust/tcl-lsp-core/src/source_graph.rs
+++ b/rust/tcl-lsp-core/src/source_graph.rs
@@ -139,6 +139,97 @@ pub fn ancestor_requires<S: BuildHasher>(
     out
 }
 
+/// One `source` edge, with the execution-order facts a state question needs.
+///
+/// [`ancestor_requires`] only asks *whether* one file reaches another, so a
+/// bare `(parent, child)` pair is enough for it.  An **interpreter-state**
+/// question — "had this statement already run by the time the child loaded?"
+/// — additionally needs where in the parent the `source` sits, because a
+/// statement written after it has not run yet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceEdge {
+    /// The sourcing document's key.
+    pub parent: String,
+    /// The sourced document's key.
+    pub child: String,
+    /// Byte offset of the `source` statement in `parent`.
+    pub at: u32,
+    /// Span of the innermost proc/class body containing the `source`
+    /// statement in `parent`; `None` at load level.
+    pub enclosing_body: Option<tcl_lexer::Span>,
+}
+
+/// Whether the **interpreter-global** `package prefer latest` latch is already
+/// raised by the time `target` is loaded, given the raises recorded per
+/// document (issue #1253).
+///
+/// `package prefer` is a monotone latch on interpreter state, so a raise in a
+/// file that runs first really does change a later file's version selection.
+/// Which file runs first is not knowable in general — but along the `source`
+/// graph it is a static fact: `source CHILD` loads the whole child *at that
+/// statement*, so everything the parent already ran is in effect for it, and
+/// nothing the parent runs afterwards is.
+///
+/// `raises[node]` holds the offsets of that document's **unconditional**
+/// `package prefer latest` statements (a conditional one may not run, and the
+/// caller abstains toward the interpreter default by omitting it).
+///
+/// Two ways the latch is up when a node is entered:
+///
+/// * a parent raised it **before** the `source` statement — order-gated with
+///   [`tcl_compiler::analyser::indirection::in_effect_within`], so a raise at
+///   the parent's load level still counts for a `source` written inside one of
+///   its proc bodies (the whole file loads before any body runs);
+/// * a parent was **itself** entered with the latch up, in which case it was
+///   up for the parent's whole execution and so for every file it sources.
+///
+/// Cycles terminate on the visited set.  `target`'s *own* raises are not
+/// consulted — those are the single-document question
+/// (`package_resolver::package_prefer_at`), which is position-sensitive within
+/// the document.
+#[must_use]
+pub fn ancestor_prefer_latest_raised<S: BuildHasher>(
+    target: &str,
+    edges: &[SourceEdge],
+    raises: &HashMap<String, Vec<u32>, S>,
+) -> bool {
+    use tcl_compiler::analyser::indirection::in_effect_within;
+
+    let no_raises: Vec<u32> = Vec::new();
+    let raised_before = |node: &str, at: u32, body: Option<tcl_lexer::Span>| {
+        raises
+            .get(node)
+            .unwrap_or(&no_raises)
+            .iter()
+            .any(|&established| in_effect_within(established, at, body))
+    };
+    // Seed: every child whose parent had already raised the latch when it
+    // sourced them.
+    let mut entered_raised: HashSet<&str> = HashSet::new();
+    let mut stack: Vec<&str> = Vec::new();
+    for edge in edges {
+        if raised_before(&edge.parent, edge.at, edge.enclosing_body)
+            && entered_raised.insert(edge.child.as_str())
+        {
+            stack.push(edge.child.as_str());
+        }
+    }
+    // Propagate: a node entered with the latch up passes it to *every* file it
+    // sources, wherever the `source` sits — the latch was already up for the
+    // node's whole execution.
+    while let Some(node) = stack.pop() {
+        if node == target {
+            return true;
+        }
+        for edge in edges.iter().filter(|e| e.parent == node) {
+            if entered_raised.insert(edge.child.as_str()) {
+                stack.push(edge.child.as_str());
+            }
+        }
+    }
+    entered_raised.contains(target)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -224,5 +315,129 @@ mod tests {
         let edges = vec![("app".to_owned(), "lib".to_owned())];
         let requires = reqs(&[("app", &["Tk"])]);
         assert!(ancestor_requires("app", &edges, &requires).is_empty());
+    }
+
+    // ---------------------------------------------------------------------
+    // `package prefer latest` across the source graph (issue #1253 item 1).
+    //
+    // tclsh-proof (8.6.14) that the latch really is interpreter-global and
+    // crosses `source`:  with `lib.tcl` holding `puts [package prefer]`,
+    //
+    //   # app.tcl:  package prefer latest ; source lib.tcl
+    //   -> latest
+    //   # app.tcl:  source lib.tcl ; package prefer latest
+    //   -> stable
+    // ---------------------------------------------------------------------
+
+    fn edge(parent: &str, child: &str, at: u32) -> SourceEdge {
+        SourceEdge {
+            parent: parent.to_owned(),
+            child: child.to_owned(),
+            at,
+            enclosing_body: None,
+        }
+    }
+
+    fn raises(pairs: &[(&str, &[u32])]) -> HashMap<String, Vec<u32>> {
+        pairs
+            .iter()
+            .map(|(uri, offs)| ((*uri).to_owned(), offs.to_vec()))
+            .collect()
+    }
+
+    /// TP: a raise written **above** the `source` is in force in the child.
+    #[test]
+    fn a_raise_before_the_source_reaches_the_child() {
+        let edges = vec![edge("app", "lib", 30)];
+        assert!(ancestor_prefer_latest_raised(
+            "lib",
+            &edges,
+            &raises(&[("app", &[0])])
+        ));
+    }
+
+    /// TN: a raise written **below** the `source` has not run when the child
+    /// loads, so the child keeps the default.
+    #[test]
+    fn a_raise_after_the_source_does_not_reach_the_child() {
+        let edges = vec![edge("app", "lib", 0)];
+        assert!(!ancestor_prefer_latest_raised(
+            "lib",
+            &edges,
+            &raises(&[("app", &[30])])
+        ));
+    }
+
+    /// TP: the latch is transitive — once up on entry to a node it is up for
+    /// everything that node sources, wherever the `source` sits.
+    #[test]
+    fn the_latch_travels_the_whole_graph_once_raised() {
+        let edges = vec![edge("app", "mid", 30), edge("mid", "leaf", 0)];
+        assert!(ancestor_prefer_latest_raised(
+            "leaf",
+            &edges,
+            &raises(&[("app", &[0])])
+        ));
+    }
+
+    /// TN: a raise in a node the target is **not** reachable from changes
+    /// nothing — the graph, not the workspace, decides.
+    #[test]
+    fn an_unrelated_raise_does_not_reach_the_target() {
+        let edges = vec![edge("app", "lib", 30), edge("other", "sibling", 30)];
+        assert!(!ancestor_prefer_latest_raised(
+            "lib",
+            &edges,
+            &raises(&[("other", &[0])])
+        ));
+    }
+
+    /// TP: a `source` written inside a proc body still sees a raise written
+    /// later at the parent's load level — the whole file loads before any
+    /// body runs, the `in_effect_within` rule every other cross-document
+    /// ordering question uses.
+    #[test]
+    fn a_body_source_sees_a_later_load_level_raise() {
+        let edges = vec![SourceEdge {
+            parent: "app".to_owned(),
+            child: "lib".to_owned(),
+            at: 10,
+            enclosing_body: Some(tcl_lexer::Span::new(0, 20)),
+        }];
+        assert!(ancestor_prefer_latest_raised(
+            "lib",
+            &edges,
+            &raises(&[("app", &[30])])
+        ));
+        // …but a raise inside that same body, after the `source`, has not run.
+        assert!(!ancestor_prefer_latest_raised(
+            "lib",
+            &edges,
+            &raises(&[("app", &[15])])
+        ));
+    }
+
+    /// A cycle terminates, and the target is still answered.
+    #[test]
+    fn the_prefer_walk_tolerates_cycles() {
+        let edges = vec![edge("a", "b", 30), edge("b", "a", 0)];
+        assert!(ancestor_prefer_latest_raised(
+            "b",
+            &edges,
+            &raises(&[("a", &[0])])
+        ));
+        assert!(!ancestor_prefer_latest_raised("b", &edges, &raises(&[])));
+    }
+
+    /// TN: the target's *own* raises are not this question — that is the
+    /// position-sensitive single-document answer.
+    #[test]
+    fn the_targets_own_raise_is_not_an_ancestor_raise() {
+        let edges = vec![edge("app", "lib", 30)];
+        assert!(!ancestor_prefer_latest_raised(
+            "lib",
+            &edges,
+            &raises(&[("lib", &[0])])
+        ));
     }
 }

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -616,6 +616,36 @@ pub struct WorkspaceSource {
     /// namespace (M9), so the sourced document's definitions re-home under
     /// this namespace — see [`WorkspaceIndex::source_seed_map`].
     pub site_namespace: String,
+    /// Span of the innermost proc/class body containing the `source`
+    /// statement; `None` at load level.  See
+    /// [`WorkspaceGlobImport::enclosing_body`] — the same execution-order
+    /// fact, needed here so a cross-document interpreter-state question
+    /// ("had this statement already run when the child was loaded?") applies
+    /// the identical [`tcl_compiler::analyser::indirection::in_effect_within`]
+    /// rule the single-document tier does (issue #1253).
+    pub enclosing_body: Option<Span>,
+}
+
+/// One unconditional `package prefer latest` recorded in the index.
+///
+/// `package prefer` latches **interpreter-global** state, so a raise in a file
+/// that runs before this one really does change this one's version selection.
+/// Which file runs first is not knowable in general — but along the `source`
+/// graph it is: a file that `source`s another runs the sourcing statement
+/// before the sourced file loads at all.  See
+/// [`WorkspaceIndex::source_ancestor_prefers_latest`] (issue #1253).
+///
+/// Conditional raises (inside `if` / `catch` / `try`) are not recorded at all:
+/// they may not run, and the abstention is toward the interpreter default.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspacePackagePrefer {
+    /// Document containing the `package prefer latest` statement.
+    pub uri: String,
+    /// Byte offset of the `package` command word in `uri`'s source.
+    pub at: u32,
+    /// Span of the innermost proc/class body containing the raise; `None` at
+    /// load level.
+    pub enclosing_body: Option<Span>,
 }
 
 /// One `package require NAME` declaration recorded in the index.
@@ -933,6 +963,7 @@ struct DocumentRecords {
     invocations: Vec<WorkspaceInvocation>,
     sources: Vec<WorkspaceSource>,
     package_requires: Vec<WorkspacePackageRequire>,
+    package_prefers: Vec<WorkspacePackagePrefer>,
     command_links: Vec<WorkspaceCommandLink>,
     glob_imports: Vec<WorkspaceGlobImport>,
     namespace_exports: Vec<WorkspaceNamespaceExport>,
@@ -962,6 +993,7 @@ impl DocumentRecords {
             invocations,
             sources,
             package_requires,
+            package_prefers,
             command_links,
             glob_imports,
             namespace_exports,
@@ -978,6 +1010,7 @@ impl DocumentRecords {
         invocations.clear();
         sources.clear();
         package_requires.clear();
+        package_prefers.clear();
         command_links.clear();
         glob_imports.clear();
         namespace_exports.clear();
@@ -1154,12 +1187,28 @@ impl DocumentRecords {
                 site_namespace: target.site_namespace.clone(),
                 range: target.range,
                 is_literal: target.is_literal,
+                enclosing_body: analysis.innermost_definition_body_span(target.range.start()),
             });
         }
         for pr in &analysis.package_requires {
             self.package_requires.push(WorkspacePackageRequire {
                 uri: uri.to_owned(),
                 name: pr.name.clone(),
+            });
+        }
+        // Only the unconditional raises: a `package prefer latest` inside an
+        // `if` / `catch` / `try` may not run, and the cross-document tier
+        // abstains toward the interpreter default exactly as the
+        // single-document one does (issue #1253).
+        for prefer in analysis
+            .package_prefer_latest
+            .iter()
+            .filter(|p| !p.conditional)
+        {
+            self.package_prefers.push(WorkspacePackagePrefer {
+                uri: uri.to_owned(),
+                at: prefer.range.start(),
+                enclosing_body: analysis.innermost_definition_body_span(prefer.range.start()),
             });
         }
         for exp in &analysis.namespace_exports {
@@ -1862,6 +1911,11 @@ impl WorkspaceIndex {
         self.docs.iter().flat_map(|doc| doc.package_requires.iter())
     }
 
+    /// Every indexed unconditional `package prefer latest`.
+    pub fn package_prefers(&self) -> impl Iterator<Item = &WorkspacePackagePrefer> {
+        self.docs.iter().flat_map(|doc| doc.package_prefers.iter())
+    }
+
     /// The package names `uri` `package require`s, de-duplicated. Used to seed
     /// the workspace W120 refinement from an explicitly configured project
     /// entry file.
@@ -1907,6 +1961,52 @@ impl WorkspaceIndex {
                 .push(pr.name.clone());
         }
         crate::source_graph::ancestor_requires(target_uri, &edges, &requires)
+    }
+
+    /// Whether the interpreter-global `package prefer latest` latch is already
+    /// raised by the time `target_uri` is loaded, because a document that
+    /// (transitively) `source`s it raised it first (issue #1253).
+    ///
+    /// `resolve` maps a literal `source` path written in a document to the
+    /// child document's URI, exactly as for
+    /// [`Self::source_ancestor_package_requires`]; a `None` return drops that
+    /// edge, and only literal `source` targets are followed.
+    ///
+    /// The state is interpreter-global, so this is genuinely *this* document's
+    /// answer — it just is not a fact about this document's own text.  The
+    /// order rule and the two ways the latch can already be up live in
+    /// [`crate::source_graph::ancestor_prefer_latest_raised`].
+    #[must_use]
+    pub fn source_ancestor_prefers_latest(
+        &self,
+        target_uri: &str,
+        resolve: impl Fn(&str, &str) -> Option<String>,
+    ) -> bool {
+        // Nothing raises the latch anywhere: skip building the graph. This is
+        // the overwhelmingly common case (the default is `stable` and most
+        // workspaces never write `package prefer` at all), and it keeps a
+        // per-`package require` query free.
+        if self.package_prefers().next().is_none() {
+            return false;
+        }
+        let edges: Vec<crate::source_graph::SourceEdge> = self
+            .sources()
+            .filter(|s| s.is_literal)
+            .filter_map(|s| {
+                resolve(&s.uri, &s.raw_path).map(|child| crate::source_graph::SourceEdge {
+                    parent: s.uri.clone(),
+                    child,
+                    at: s.range.start(),
+                    enclosing_body: s.enclosing_body,
+                })
+            })
+            .collect();
+        let mut raises: std::collections::HashMap<String, Vec<u32>> =
+            std::collections::HashMap::new();
+        for p in self.package_prefers() {
+            raises.entry(p.uri.clone()).or_default().push(p.at);
+        }
+        crate::source_graph::ancestor_prefer_latest_raised(target_uri, &edges, &raises)
     }
 
     /// The **source-site namespace seeds** per sourced document (M9): for
@@ -7069,5 +7169,60 @@ mod tests {
                 .source_ancestor_package_requires("file:///proj/util.tcl", resolve)
                 .is_empty()
         );
+    }
+
+    /// Issue #1253 item 1 — `package prefer latest` is interpreter-global, and
+    /// along the `source` graph "ran first" is a static fact.
+    ///
+    /// tclsh-proof (8.6.14), with `lib.tcl` holding `puts [package prefer]`:
+    /// `app.tcl` written as `package prefer latest; source lib.tcl` prints
+    /// `latest`, and as `source lib.tcl; package prefer latest` prints
+    /// `stable`.
+    #[test]
+    fn source_ancestor_prefer_latest_crosses_documents() {
+        let resolve = |parent: &str, raw: &str| -> Option<String> {
+            let dir = parent.rsplit_once('/').map(|(d, _)| d)?;
+            Some(format!("{dir}/{raw}"))
+        };
+        let lib = analyse("package require w\n");
+
+        // TP — the raise runs before the `source`.
+        let app = analyse("package prefer latest\nsource lib.tcl\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///proj/app.tcl", &app),
+            ("file:///proj/lib.tcl", &lib),
+        ]);
+        assert!(index.source_ancestor_prefers_latest("file:///proj/lib.tcl", resolve));
+        // …and the entry file itself inherits nothing (its own raise is the
+        // position-sensitive single-document question).
+        assert!(!index.source_ancestor_prefers_latest("file:///proj/app.tcl", resolve));
+
+        // FP guard — the raise runs after the `source`.
+        let app = analyse("source lib.tcl\npackage prefer latest\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///proj/app.tcl", &app),
+            ("file:///proj/lib.tcl", &lib),
+        ]);
+        assert!(!index.source_ancestor_prefers_latest("file:///proj/lib.tcl", resolve));
+
+        // FP guard — a conditional raise is never recorded at all.
+        let app = analyse("if {$::c} { package prefer latest }\nsource lib.tcl\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///proj/app.tcl", &app),
+            ("file:///proj/lib.tcl", &lib),
+        ]);
+        assert!(index.package_prefers().next().is_none());
+        assert!(!index.source_ancestor_prefers_latest("file:///proj/lib.tcl", resolve));
+    }
+
+    /// The prefer rows drop with their document, like every other table.
+    #[test]
+    fn package_prefers_are_dropped_with_their_document() {
+        let a = analyse("package prefer latest\n");
+        let mut index = WorkspaceIndex::new();
+        index.add_document("file:///a.tcl", &a);
+        assert_eq!(index.package_prefers().count(), 1);
+        index.remove_document("file:///a.tcl");
+        assert!(index.package_prefers().next().is_none());
     }
 }

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -259,6 +259,122 @@ impl WorkspaceClass {
     }
 }
 
+/// Which receiver side a [`WorkspaceMethod`] is declared on — the same split
+/// [`WorkspaceClass::instance_method`] / [`WorkspaceClass::class_method`] make,
+/// named once so the member fold and the tombstone lookup agree on it.
+#[must_use]
+fn method_side(m: &WorkspaceMethod) -> MemberSide {
+    if m.kind == "classmethod" {
+        MemberSide::ClassObject
+    } else {
+        MemberSide::Instance
+    }
+}
+
+/// One member of a class as the **workspace** sees it: the declaring record's
+/// entry, keyed under the name the class actually dispatches it by once every
+/// cross-document retraction and arrival has been applied (issue #1263).
+///
+/// The raw [`WorkspaceClass::methods`] table is per-record and additive — it
+/// records what that record's own body declared and nothing else — so a member
+/// moved by a cross-file `oo::define ::C { renamemethod old new }` is still
+/// listed as `old` on the defining record and not listed at all on the stub.
+/// Resolving one name against the table already joined the two halves
+/// ([`WorkspaceIndex::dispatch_chain`], issue #1167); *listing* the table did
+/// not, so anything that enumerates a class's members (`workspace/symbol`, an
+/// outline, a member completion universe) showed the pre-rename name.
+///
+/// [`WorkspaceIndex::effective_members`] is the one place that fold happens,
+/// and the dispatch chain reads it too, so a single rule decides what a class's
+/// member set is.
+#[derive(Debug, Clone, Copy)]
+pub struct EffectiveMember<'a> {
+    /// The name the class dispatches this member under.
+    pub name: &'a str,
+    /// The record whose body, parameters and visibility define the member —
+    /// where a `renamemethod`'s *source* was declared, not where the rename is
+    /// written.
+    pub declaring: &'a WorkspaceClass,
+    /// The declaring record's own entry, still keyed under its declared
+    /// spelling.  Visibility travels with the body, so this is what a
+    /// visibility test must read.
+    pub method: &'a WorkspaceMethod,
+    /// Document holding the token that spells [`Self::name`] — the declaring
+    /// record's document normally, the retracting stub's when the member
+    /// arrived through a cross-file `renamemethod`.
+    pub name_uri: &'a str,
+    /// Byte span of that token, in [`Self::name_uri`]'s source.
+    pub name_span: Span,
+}
+
+/// Every cross-document member retraction in the workspace, keyed by the
+/// `(class qualified name, member name, side)` it removes and valued with the
+/// record that wrote it plus the retraction itself.  See
+/// [`WorkspaceIndex::retraction_index`].
+type RetractionIndex<'a> = std::collections::HashMap<
+    (&'a str, &'a str, MemberSide),
+    (&'a WorkspaceClass, &'a MemberRetractionRecord),
+>;
+
+/// Apply the workspace's retraction / arrival fold to one member `declaring`
+/// declares, yielding the name the class dispatches it under — or `None` when
+/// a cross-document `deletemethod` removed it outright (issue #1263).
+///
+/// The one place that decision is made; [`WorkspaceIndex::effective_members`]
+/// (and through it [`WorkspaceIndex::dispatch_chain`]) and the
+/// `workspace/symbol` member walk all route through it, so resolving a name
+/// and listing the member set can no longer disagree.
+///
+/// tclsh-proof (8.6.14), for the two arms:
+///
+/// ```tcl
+/// # a.tcl: oo::class create ::C { method old {} { return OLDBODY } }
+/// # b.tcl: oo::define ::C { renamemethod old new }
+/// info class methods ::C     ;# -> new         (arrival re-keys the member)
+/// [::C new] old              ;# -> unknown method "old"
+/// # with `deletemethod old` instead:
+/// info class methods ::C     ;# -> (empty)     (the member is gone)
+/// ```
+fn effective_member<'a>(
+    retractions: &RetractionIndex<'a>,
+    declaring: &'a WorkspaceClass,
+    method: &'a WorkspaceMethod,
+) -> Option<EffectiveMember<'a>> {
+    let side = method_side(method);
+    // A `deletemethod` / `renamemethod` in *another* document's `oo::define`
+    // stub really removes the member (issue #1101 review). The union is taken
+    // per class — a subclass cannot retract an inherited member (real Tcl:
+    // `method … does not exist`) — and the tombstone carries the side it
+    // removed from, so a `self deletemethod m` never touches the
+    // instance-side member.
+    let Some((stub, retraction)) = retractions.get(&(
+        declaring.qualified_name.as_str(),
+        method.name.as_str(),
+        side,
+    )) else {
+        return Some(EffectiveMember {
+            name: &method.name,
+            declaring,
+            method,
+            name_uri: &declaring.uri,
+            name_span: method.name_span,
+        });
+    };
+    // A `renamemethod old new` *moves* the member: the stub owns no
+    // `MethodDef` (the params / body / visibility stay on the declaring
+    // record), so the arrival re-keys this entry and the arrival word is the
+    // moved member's declaration site.  A plain `deletemethod` — and a
+    // `renamemethod old $new` whose destination is computed, which names
+    // nothing statically — records no arrival, and the member is simply gone.
+    Some(EffectiveMember {
+        name: retraction.arrival.as_deref()?,
+        declaring,
+        method,
+        name_uri: &stub.uri,
+        name_span: retraction.arrival_span?,
+    })
+}
+
 /// One method a class record directly defines, as indexed for cross-file
 /// dispatch (issue #945 faults 4 and 6).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -881,6 +997,7 @@ impl DocumentRecords {
         &self,
         lower_query: &str,
         limit: usize,
+        retractions: &RetractionIndex<'_>,
         out: &mut Vec<IndexedWorkspaceSymbol>,
     ) {
         for proc_def in &self.procs {
@@ -919,17 +1036,28 @@ impl DocumentRecords {
             }
             // Members carry the class's qualified name as their container, so
             // an editor renders them as `ClassName::methodName`.
+            //
+            // Enumerated through the workspace's member fold, not straight off
+            // this record's own table: a member a cross-file `oo::define ::C {
+            // renamemethod old new }` moved is declared here under `old` and
+            // dispatches as `new`, and one deleted the same way is not a
+            // member at all (issue #1263).  An arrived member's location is
+            // the arrival word in the retracting document, which is also what
+            // go-to-definition on the new name answers with.
             for method in &class_def.methods {
                 if out.len() >= limit {
                     return;
                 }
-                if matches_query(&method.name, lower_query) {
+                let Some(em) = effective_member(retractions, class_def, method) else {
+                    continue;
+                };
+                if matches_query(em.name, lower_query) {
                     out.push(IndexedWorkspaceSymbol {
-                        uri: class_def.uri.clone(),
-                        name: method.name.clone(),
+                        uri: em.name_uri.to_owned(),
+                        name: em.name.to_owned(),
                         container_name: Some(class_def.qualified_name.clone()),
                         kind: WorkspaceSymbolKind::Method,
-                        name_span: method.name_span,
+                        name_span: em.name_span,
                     });
                 }
             }
@@ -1849,11 +1977,15 @@ impl WorkspaceIndex {
     pub fn symbols_matching(&self, query: &str, limit: usize) -> Vec<IndexedWorkspaceSymbol> {
         let lower_query = query.to_lowercase();
         let mut out: Vec<IndexedWorkspaceSymbol> = Vec::new();
+        // Built once for the whole scan — the class-member walk needs the
+        // workspace's cross-document retractions, which no single document's
+        // records can answer for themselves (issue #1263).
+        let retractions = self.retraction_index();
         for doc in &self.docs {
             if out.len() >= limit {
                 break;
             }
-            doc.collect_symbols_matching(&lower_query, limit, &mut out);
+            doc.collect_symbols_matching(&lower_query, limit, &retractions, &mut out);
         }
         out
     }
@@ -2156,11 +2288,7 @@ impl WorkspaceIndex {
             // has to be a property of the workspace, not of when each document
             // happened to be indexed.  Document URI then source position is
             // that stable order (issue #1028).
-            let mut records: Vec<&WorkspaceClass> = self
-                .classes()
-                .filter(|c| c.qualified_name == class_q)
-                .collect();
-            records.sort_by_key(|c| (c.uri.as_str(), c.name_span.start(), c.name_span.end()));
+            let records = self.class_records(&class_q);
             // The class-level effective export union **for this side**: any
             // record exporting the name keeps it callable; explicit unexports
             // matter only when no record exports it.  The two sides never share
@@ -2172,74 +2300,139 @@ impl WorkspaceIndex {
             let any_unexports = records
                 .iter()
                 .any(|c| visibility_sets_for(c, side).1.iter().any(|e| e == method));
-            // A `deletemethod` / `renamemethod` in *another* document's
-            // `oo::define` stub really removes the member (issue #1101 review):
-            //   a.tcl  oo::class create ::C { method m {} {…} }
-            //   b.tcl  oo::define ::C { deletemethod m }
-            //   [::C new] m  ->  unknown method "m"     (9.0.4 / 8.6.14)
-            // so the whole chain for the name is empty, exactly as it is for a
-            // method no record defines. The union is taken per class — a
-            // subclass cannot retract an inherited member (real Tcl: `method …
-            // does not exist`), so a retraction never reaches past the record's
-            // own `class_q`. The tombstone carries the side it removed from, so
-            // a `self deletemethod m` never empties the instance chain and an
-            // unwrapped one never empties the class chain.
-            if records.iter().any(|c| {
-                c.retracted_members
-                    .iter()
-                    .any(|r| r.member == method && r.side == side)
-            }) {
-                continue;
-            }
-            // The **arrival** join (issue #1167): a cross-file `oo::define ::C
-            // { renamemethod old new }` moves the member without owning a
-            // `MethodDef` to move — the params / body / visibility live in the
-            // defining file's record.  So when nothing declares the name asked
-            // for, a stub's recorded arrival re-keys that other record's
-            // member and the defining record enters the chain under the new
-            // name.  Visibility travels with the *body*, not the new name's
-            // leading-capital default (oracle, tclsh 9.0.4 / 8.6.14:
-            // `oo::class create ::R4 {method Priv {} {…}; renamemethod Priv
-            // pub}` leaves `info class methods ::R4` empty while `-private`
-            // lists `pub`), so the source member's own record is what the
-            // visibility test below reads.
-            let arrived_from: Option<&str> =
-                records.iter().find_map(|c| c.arrival_source(method, side));
-            for record in records {
-                let lookup = |name: &str| match side {
-                    MemberSide::Instance => record.instance_method(name),
-                    // A stock `self method` is not inherited: the class object
-                    // that declared it is the only one whose command reaches it
-                    // (`Gadget make` against a parent's `self method make` ->
-                    // `unknown method "make"`, 8.6 / 9.0.4). An `ooutil`
-                    // `classmethod` shares the receiver kind but does propagate.
-                    MemberSide::ClassObject => record
-                        .class_method(name)
-                        .filter(|m| !m.is_self_method || record.qualified_name == receiver_class),
-                };
-                let declared = lookup(method).or_else(|| arrived_from.and_then(lookup));
-                let Some(m) = declared else {
+            // The class's member set — retractions applied, arrivals
+            // re-keyed — is decided once by [`Self::effective_members`]
+            // rather than here (issue #1263).  A `deletemethod`ed member is
+            // absent from it, so the chain for that name is empty exactly as
+            // it is for a method no record defines; a `renamemethod`ed one is
+            // present under its destination and absent under its source.
+            for em in self.effective_members(&class_q) {
+                if em.name != method || method_side(em.method) != side {
                     continue;
-                };
+                }
+                // A stock `self method` is not inherited: the class object
+                // that declared it is the only one whose command reaches it
+                // (`Gadget make` against a parent's `self method make` ->
+                // `unknown method "make"`, 8.6 / 9.0.4). An `ooutil`
+                // `classmethod` shares the receiver kind but does propagate.
+                if side == MemberSide::ClassObject
+                    && em.method.is_self_method
+                    && em.declaring.qualified_name != receiver_class
+                {
+                    continue;
+                }
                 // Effective export across the class's records: an explicit
                 // `export` anywhere wins, else an explicit `unexport`
                 // anywhere, else the definer's own effective state.  (True
-                // cross-file order is load-order; explicit-export-wins is
-                // the navigation-permissive reading.)
+                // cross-file order is load-order; explicit-export-wins is the
+                // navigation-permissive reading.)  Visibility travels with the
+                // *body*, not an arrival name's leading-capital default
+                // (oracle, tclsh 9.0.4 / 8.6.14: `oo::class create ::R4
+                // {method Priv {} {…}; renamemethod Priv pub}` leaves `info
+                // class methods ::R4` empty while `-private` lists `pub`), so
+                // the source member's own record is what this reads.
                 let exported = if any_exports {
                     true
                 } else if any_unexports {
                     false
                 } else {
-                    m.exported
+                    em.method.exported
                 };
                 let visible = match access {
-                    MethodAccess::External => exported && !m.private,
-                    MethodAccess::Internal => !m.private || class_q == receiver_class,
+                    MethodAccess::External => exported && !em.method.private,
+                    MethodAccess::Internal => !em.method.private || class_q == receiver_class,
                 };
                 if visible {
-                    out.push(record);
+                    out.push(em.declaring);
                 }
+            }
+        }
+        out
+    }
+
+    /// Every record of the class `class_q`, in the workspace's stable order.
+    ///
+    /// Several records of one class (its creation site plus every
+    /// `oo::define` stub, possibly spread over files) are all kept, and the
+    /// *first* is what go-to-definition answers with — so the order has to be
+    /// a property of the workspace, not of when each document happened to be
+    /// indexed.  Document URI then source position is that order (issue
+    /// #1028).
+    #[must_use]
+    pub fn class_records<'a>(&'a self, class_q: &str) -> Vec<&'a WorkspaceClass> {
+        let mut records: Vec<&WorkspaceClass> = self
+            .classes()
+            .filter(|c| c.qualified_name == class_q)
+            .collect();
+        records.sort_by_key(|c| (c.uri.as_str(), c.name_span.start(), c.name_span.end()));
+        records
+    }
+
+    /// The members of `class_q` as the workspace sees them: every record's own
+    /// declarations, with the class's cross-document retractions applied and
+    /// its arrivals re-keyed (issue #1263).  Both receiver sides, in
+    /// [`Self::class_records`] order then declaration order — filter on
+    /// [`EffectiveMember::method`]'s `kind` (via `WorkspaceClass`'s own
+    /// instance/class split) for one side.
+    ///
+    /// This is the single rule for "which members does this class have":
+    /// [`Self::dispatch_chain`] resolves one name against it and every
+    /// *enumeration* (`workspace/symbol`, an outline, a member completion
+    /// universe) lists it, so the two can no longer disagree.  Before this,
+    /// resolution joined the arrival channel and listing did not, so a member
+    /// moved by a cross-file `renamemethod` was still enumerated under its
+    /// pre-rename name.
+    ///
+    /// Inheritance is **not** applied: these are the class's own members.
+    /// Walk [`Self::class_linearisation`] for the inherited set.
+    ///
+    /// Carries the tombstone channel's unordered-cross-file caveat: true load
+    /// order is not knowable from the index, so a retraction recorded by any
+    /// record of the class applies to every record of it.
+    #[must_use]
+    pub fn effective_members<'a>(&'a self, class_q: &str) -> Vec<EffectiveMember<'a>> {
+        let retractions = self.retraction_index();
+        let mut out: Vec<EffectiveMember<'a>> = Vec::new();
+        for declaring in self.class_records(class_q) {
+            out.extend(
+                declaring
+                    .methods
+                    .iter()
+                    .filter_map(|method| effective_member(&retractions, declaring, method)),
+            );
+        }
+        out
+    }
+
+    /// Every cross-document member retraction in the workspace, keyed by the
+    /// `(class, member, side)` it removes — the lookup table the member fold
+    /// ([`effective_member`]) applies.
+    ///
+    /// Built once per query rather than rescanned per member: a retraction
+    /// recorded by *any* record of a class applies to every record of it, so
+    /// the naive form is a scan of the class's records per declared method,
+    /// which is quadratic in a workspace's class count on a path
+    /// (`workspace/symbol`) that runs per keystroke.  The map is empty in the
+    /// overwhelmingly common case — no document retracts anything — and the
+    /// walk is then exactly what it was before the fold existed.
+    ///
+    /// Ties are broken by the workspace's stable record order
+    /// ([`Self::class_records`]), so which stub an arrival is attributed to
+    /// does not depend on indexing order.
+    fn retraction_index(&self) -> RetractionIndex<'_> {
+        let mut records: Vec<&WorkspaceClass> = self
+            .classes()
+            .filter(|c| !c.retracted_members.is_empty())
+            .collect();
+        if records.is_empty() {
+            return RetractionIndex::default();
+        }
+        records.sort_by_key(|c| (c.uri.as_str(), c.name_span.start(), c.name_span.end()));
+        let mut out = RetractionIndex::default();
+        for c in records {
+            for r in &c.retracted_members {
+                out.entry((c.qualified_name.as_str(), r.member.as_str(), r.side))
+                    .or_insert((c, r));
             }
         }
         out
@@ -4153,6 +4346,128 @@ mod tests {
                 .classes()
                 .all(|c| c.retracted_members.iter().all(|r| r.arrival.is_none())),
             "a computed destination records no arrival",
+        );
+    }
+
+    /// TP, issue #1263: **enumeration** joins the arrival channel too.  The
+    /// defining record still declares the member as `old`, so the raw
+    /// `WorkspaceClass::methods` table (which `workspace/symbol` used to read
+    /// directly) advertised the pre-rename name after the resolution join had
+    /// already been fixed for `dispatch_chain` (#1167).
+    ///
+    /// tclsh-proof (8.6.14), sourcing both files:
+    ///
+    /// ```tcl
+    /// oo::class create ::C { method old {} { return OLDBODY } }
+    /// oo::define ::C { renamemethod old new }
+    /// info class methods ::C   ;# -> new
+    /// [::C new] old            ;# -> unknown method "old"
+    /// ```
+    #[test]
+    fn a_cross_file_arrival_re_keys_member_enumeration() {
+        let a = analyse("oo::class create ::C { method old {} { return 1 } }\n");
+        let b = analyse("oo::define ::C { renamemethod old new }\n");
+        let index = WorkspaceIndex::from_documents([("file:///a.tcl", &a), ("file:///b.tcl", &b)]);
+        assert_eq!(
+            index
+                .effective_members("::C")
+                .iter()
+                .map(|em| em.name)
+                .collect::<Vec<_>>(),
+            ["new"],
+            "the fold lists the member under the name the class dispatches it by",
+        );
+        // The body still lives in a.tcl; only the *name* moved.
+        let em = index.effective_members("::C");
+        let moved = em.first().expect("one member");
+        assert_eq!(moved.declaring.uri, "file:///a.tcl");
+        assert_eq!(moved.method.name, "old", "the declaring entry is untouched");
+        assert_eq!(
+            moved.name_uri, "file:///b.tcl",
+            "the arrival word is the moved member's declaration site",
+        );
+        // …and `workspace/symbol` offers the new name, not the old one.
+        let names: Vec<String> = index
+            .symbols_matching("", 100)
+            .into_iter()
+            .filter(|s| s.kind == WorkspaceSymbolKind::Method)
+            .map(|s| s.name)
+            .collect();
+        assert_eq!(names, ["new"], "the picker must not show the pre-rename name");
+    }
+
+    /// TN, issue #1263: a cross-file `deletemethod` removes the member from
+    /// enumeration outright — nothing arrives, so nothing is listed.
+    ///
+    /// tclsh-proof (8.6.14): `oo::class create ::C { method m {} {…} }` +
+    /// `oo::define ::C { deletemethod m }` leaves `info class methods ::C`
+    /// empty and `[::C new] m` erroring `unknown method "m"`.
+    #[test]
+    fn a_cross_file_deletion_drops_the_member_from_enumeration() {
+        let a = analyse("oo::class create ::C { method m {} { return 1 } }\n");
+        let b = analyse("oo::define ::C { deletemethod m }\n");
+        let index = WorkspaceIndex::from_documents([("file:///a.tcl", &a), ("file:///b.tcl", &b)]);
+        assert!(
+            index.effective_members("::C").is_empty(),
+            "a deleted member is not a member",
+        );
+        assert!(
+            index
+                .symbols_matching("m", 100)
+                .iter()
+                .all(|s| s.kind != WorkspaceSymbolKind::Method),
+            "the picker must not offer a deleted member",
+        );
+    }
+
+    /// TN, issue #1263: with no retraction anywhere, enumeration is exactly
+    /// each record's own table — the fold must not perturb the ordinary case,
+    /// including a member declared by a cross-file `oo::define` stub and one
+    /// on the class-object side.
+    #[test]
+    fn enumeration_without_a_retraction_is_the_declared_table() {
+        let a = analyse("oo::class create ::C { method one {} {}\n method two {} {} }\n");
+        let b = analyse("oo::define ::C { method three {} {}\n self method cm {} {} }\n");
+        let index = WorkspaceIndex::from_documents([("file:///a.tcl", &a), ("file:///b.tcl", &b)]);
+        assert_eq!(
+            index
+                .effective_members("::C")
+                .iter()
+                .map(|em| em.name)
+                .collect::<Vec<_>>(),
+            ["one", "two", "three", "cm"],
+            "record order then declaration order, unchanged",
+        );
+        assert!(
+            index
+                .effective_members("::C")
+                .iter()
+                .all(|em| em.name == em.method.name),
+            "no rename, so no re-keying",
+        );
+    }
+
+    /// TN, issue #1263: a `self renamemethod` moves the **class-object** side
+    /// only.  An identically-named instance method keeps its own name, which
+    /// is the same side-scoping the tombstone channel already enforces for
+    /// resolution (#1098 / #1119).
+    #[test]
+    fn a_cross_file_arrival_is_side_scoped_in_enumeration() {
+        let a = analyse(
+            "oo::class create ::C { method m {} { return 1 }\n self method m {} { return 2 } }\n",
+        );
+        let b = analyse("oo::define ::C { self renamemethod m cm }\n");
+        let index = WorkspaceIndex::from_documents([("file:///a.tcl", &a), ("file:///b.tcl", &b)]);
+        let mut listed: Vec<(&str, &str)> = index
+            .effective_members("::C")
+            .iter()
+            .map(|em| (em.name, em.method.kind.as_str()))
+            .collect();
+        listed.sort_unstable();
+        assert_eq!(
+            listed,
+            [("cm", "classmethod"), ("m", "method")],
+            "only the class-object member moved",
         );
     }
 

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -4493,7 +4493,11 @@ mod tests {
             .filter(|s| s.kind == WorkspaceSymbolKind::Method)
             .map(|s| s.name)
             .collect();
-        assert_eq!(names, ["new"], "the picker must not show the pre-rename name");
+        assert_eq!(
+            names,
+            ["new"],
+            "the picker must not show the pre-rename name"
+        );
     }
 
     /// TN, issue #1263: a cross-file `deletemethod` removes the member from

--- a/rust/tcl-lsp-server/src/config_ini.rs
+++ b/rust/tcl-lsp-server/src/config_ini.rs
@@ -221,6 +221,17 @@ pub fn settings_from_ini(content: &str, layer: Layer) -> Value {
         }
     }
 
+    // [packages]: `preferLatest` → the interpreter's starting `package prefer`
+    // mode (issue #1253).  A config-file key rather than an inference: the
+    // real inputs — `TCL_PKG_PREFER_LATEST` in the environment, or an unstable
+    // 9.0+ build of Tcl — belong to the interpreter the user runs, not to the
+    // server's own process or to the source tree.
+    if let Some(b) = section_value(&sections, "packages", "preferLatest").and_then(parse_bool) {
+        let mut packages = Map::new();
+        packages.insert("preferLatest".to_owned(), Value::Bool(b));
+        out.insert("packages".to_owned(), Value::Object(packages));
+    }
+
     // [features]: every key → bool.
     if let Some(section) = sections.iter().find(|s| s.name == "features") {
         let mut feat = Map::new();

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -3096,6 +3096,15 @@ pub struct Backend {
     /// `.tcl-lsp.ini [project]`) and discovery when building the package
     /// database.
     editor_library_paths: Mutex<Vec<String>>,
+    /// `tclLsp.packages.preferLatest` — the interpreter's **starting**
+    /// `package prefer` mode.
+    ///
+    /// C Tcl starts at `stable` unless `TCL_PKG_PREFER_LATEST` is set in the
+    /// environment (or, on 9.0+, the running Tcl is itself an unstable build).
+    /// Neither is a fact about the source tree, so it is carried as a setting
+    /// rather than inferred from the server's own environment — which is not
+    /// the environment the user's interpreter runs in (issue #1253).
+    package_prefer_latest_default: Mutex<bool>,
     /// User-declared extra command names (`tclLsp.extraCommands`) treated as
     /// known by the unknown-command (W123) check; mirrored onto the salsa
     /// `AnalyserConfig`.
@@ -3851,6 +3860,7 @@ impl Backend {
             rehoming_gate: Arc::new(tokio::sync::Mutex::new(())),
             discovered_tcl: Arc::new(std::sync::OnceLock::new()),
             editor_library_paths: Mutex::new(Vec::new()),
+            package_prefer_latest_default: Mutex::new(false),
             extra_commands: Mutex::new(Vec::new()),
             bigip_version: Mutex::new(None),
             generic_variable_patterns: Mutex::new(None),
@@ -6183,6 +6193,19 @@ impl Backend {
                 }
             }
         }
+        // The interpreter's `package prefer` state on entry to this document:
+        // the mode a file that (transitively) `source`s it already latched.
+        // The state is interpreter-global, and along the `source` graph "ran
+        // first" is a static fact, so a `package prefer latest` in the entry
+        // file really is in force here (issue #1253).
+        let inherited_prefer = {
+            let index = self.workspace_index.read().await;
+            if index.source_ancestor_prefers_latest(uri.as_str(), resolve_source_uri) {
+                tcl_lsp_core::package_resolver::PackagePrefer::Latest
+            } else {
+                self.default_package_prefer().await
+            }
+        };
         let files = {
             let resolver = self.package_resolver.read().await;
             let mut files: Vec<PathBuf> = Vec::new();
@@ -6199,8 +6222,11 @@ impl Backend {
                 // position**, so a document that raised the interpreter to
                 // `latest` above it navigates into the prerelease it really
                 // loads (issue #1126 item 1).
-                let prefer =
-                    tcl_lsp_core::package_resolver::package_prefer_at(analysis, req.range.start());
+                let prefer = tcl_lsp_core::package_resolver::package_prefer_at(
+                    analysis,
+                    req.range.start(),
+                    inherited_prefer,
+                );
                 for f in
                     resolver.resolve_require(&req.name, req.version.as_deref(), req.exact, prefer)
                 {
@@ -9676,6 +9702,26 @@ impl Backend {
             if changed {
                 self.scan_workspace_folders().await;
             }
+        }
+        // `tclLsp.packages.preferLatest` — the interpreter's starting
+        // `package prefer` mode. See the field doc for why this is a setting
+        // and not read off the server's own environment (issue #1253).
+        if let Some(flag) = cfg
+            .get("packages")
+            .and_then(|p| p.get("preferLatest"))
+            .and_then(serde_json::Value::as_bool)
+        {
+            *self.package_prefer_latest_default.lock().await = flag;
+        }
+    }
+
+    /// The interpreter's **starting** `package prefer` mode — the base
+    /// `package_prefer_at` latches up from (issue #1253).
+    async fn default_package_prefer(&self) -> tcl_lsp_core::package_resolver::PackagePrefer {
+        if *self.package_prefer_latest_default.lock().await {
+            tcl_lsp_core::package_resolver::PackagePrefer::Latest
+        } else {
+            tcl_lsp_core::package_resolver::PackagePrefer::Stable
         }
     }
 
@@ -21324,6 +21370,7 @@ mod tests {
             rehoming_gate: Arc::new(tokio::sync::Mutex::new(())),
             discovered_tcl: Arc::new(std::sync::OnceLock::new()),
             editor_library_paths: Mutex::new(Vec::new()),
+            package_prefer_latest_default: Mutex::new(false),
             extra_commands: Mutex::new(Vec::new()),
             bigip_version: Mutex::new(None),
             generic_variable_patterns: Mutex::new(None),
@@ -23039,6 +23086,7 @@ mod tests {
             "dialect": "tcl9.0",
             "style": { "nonAscii": "strict" },
             "diagnostics": { "W211": false },
+            "packages": { "preferLatest": true },
         });
         backend.apply_global_config(&cfg).await;
         assert!(!backend.feature_toggles.lock().await.is_enabled("hover"));
@@ -23060,6 +23108,18 @@ mod tests {
         assert_eq!(*backend.default_dialect.lock().await, "tcl9.0");
         assert_eq!(*backend.non_ascii_mode.lock().await, NonAsciiMode::Strict);
         assert!(backend.disabled_diagnostics.lock().await.contains("W211"));
+        // Issue #1253 item 2 — the interpreter's starting `package prefer`
+        // mode is a setting, since neither `TCL_PKG_PREFER_LATEST` nor an
+        // unstable 9.0+ build is visible in the source tree.
+        assert_eq!(
+            backend.default_package_prefer().await,
+            tcl_lsp_core::package_resolver::PackagePrefer::Latest,
+        );
+        // TN control: a fresh backend starts at the interpreter default.
+        assert_eq!(
+            test_backend().default_package_prefer().await,
+            tcl_lsp_core::package_resolver::PackagePrefer::Stable,
+        );
     }
 
     /// Fix #4 regression guard: the retired `features.inlayHints` alias must


### PR DESCRIPTION
## Summary

**Stacked on #1264** — three of these are direct follow-ups to its code, so this targets `claude/g17-rename` rather than `rust`. Merge #1264 first; GitHub will retarget this to `rust` automatically.

Every issue here was filed by an earlier group in this campaign while it worked.

- **#1260 — W210 false positive on a braced loop value word.** `ir::ForeachIterator` stored only the value word's *content*, so the CFG's synthetic loop-header `Statement::Call` (built with `tokens: None`) could not tell `{a $b c}` from `"a $b c"` and harvested `$b` as a substituted read. Added `ForeachIterator::list_braced`, populated at lowering from the shared `CommandTokens::arg_is_braced_literal`, and gave the synthetic header per-word token kinds built from it so the existing `UseClass::Quoted` classification applies — the use survives for liveness, it is simply no longer a *read*. Two supporting fixes on the same fact: `ssa::registry_describes` now accepts an ensemble spelling so the header's `dict for`/`dict map` name resolves as described (data) rather than unclassified, and `inlining::rename` no longer rewrites variable spellings inside a braced value word.
- **#1263 — arrived member missing from enumeration.** `WorkspaceClass::methods` is per-record and additive; resolution joined the arrival channel (#1167) but enumeration read the raw table. `WorkspaceIndex::effective_members` now folds the class's cross-document retractions and re-keys its arrivals once, and both `dispatch_chain` and the `workspace/symbol` member walk read it — one rule decides the member set. The retraction lookup is built once per query (`retraction_index`), since the naive fold is quadratic in workspace class count on a per-keystroke path.
- **#1261 — `namespace path` entries refused instead of rewritten.** The blanket refusal predated the per-element `NamespaceRef` spans the analyser now records, and pre-empted the edit collector that already sees them. Dropped the blanket arm; kept a refusal for a path word built from a computed value, recorded as `AnalysisResult::namespace_path_computed` rather than left as a silent absence — `namespace_paths` alone cannot distinguish "no path" from "unknowable path".
- **#1262 — dynamic variable-name provenance.** The per-site constant-value fact lived only in analyser state, and `rename_safety` is a post-analysis consumer with only the word's text, so a bare `$n` always refused. `AnalysisResult::dynamic_variable_names` now records each registry `VarWrite`/`VarRead` word that names a variable dynamically, with its dominating-constant resolution (`None` for branch-dependent, parameter-fed, or `[…]`-built). The gate re-asks the same textual can-spell question with the substitution replaced by its proven value — narrowing only, since a missing row or a `None` resolution refuses exactly as before.
- **#1253 — `package prefer latest` across documents, and the environment default.** The latch is interpreter-global and, along the `source` graph, "ran first" is a static fact: unconditional raises are indexed (`WorkspacePackagePrefer`), with `source_ancestor_prefers_latest` ordered by the shared `indirection::in_effect_within` so a `source` inside a proc body still sees a later load-level raise; conditional raises are never indexed. For the default, `package_prefer_at` now takes the interpreter's *starting* mode instead of hardcoding `stable`, carried by `tclLsp.packages.preferLatest` (and `[packages] preferLatest` in the INI layers) — the honest carrier, since `TCL_PKG_PREFER_LATEST` and an unstable 9.0+ build belong to the user's interpreter, not to the source tree and not to the server's process environment.

Filed en route: **#1266** — reads collapsed out of an opaque `switch` arm lose their `UseClass`, so a braced data word inside one still reads. Found while fixing #1260 and deliberately **not** patched by dropping the read: that trades the false positive for a false `W220` on `set x 1; switch … { a* { foreach n {$x} {} } }`, which was measured. The real fix threads `ClassifiedUses` through that walk; the rejected shortcut and its counter-example are recorded in the issue and in a comment at the site.

## Validation

- [x] `cargo test -p tcl-compiler -p tcl-lsp-core -p tcl-lsp-server` — 102 suites, all ok, 0 failures.
- [x] `cargo check --workspace --all-targets` clean (run explicitly: a recent group added enum variants and missed an exhaustive match in a crate it never built crate-by-crate).
- [x] `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean, no new `#[allow]`s; `make xtask-check` all drift gates OK.
- [x] Diff reviewed hunk-by-hunk against the stacked base; every file attributable to one of the five issues.
- [x] Oracle caveat: only tclsh **8.6.14** was available in the container, so new `tclsh-proof:` comments state 8.6.14 explicitly. Verified there: `foreach n {a $b c} {puts $n}` prints `a`/`$b`/`c` with `b` undefined; a relative `namespace path` entry roots current-namespace-only; `package prefer latest; source lib.tcl` → `latest` while the reverse order → `stable`.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? — Yes: `ForeachIterator::list_braced` and the synthetic loop-header's per-word token kinds, `AnalysisResult::dynamic_variable_names` and `namespace_path_computed`, `WorkspaceIndex::effective_members`, and the workspace prefer-latest index.
- [x] If yes, I updated at least one relevant KCS note — contract docs at each definition site, including why the #1266 shortcut is unsound.
- [ ] If I added a new compiler KCS note, I linked it — n/a (existing notes extended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_