### PR TITLE
Keep the UseClass of reads collapsed out of an opaque switch arm (#1266, #1247)

### DIFF
--- a/docs/design/compiler/def-use-chains.md
+++ b/docs/design/compiler/def-use-chains.md
@@ -78,6 +78,31 @@ twin of the analyser's `barrier_body_locally_sets`.
 A braced `return` value (`return {$y}`) is `QUOTED` on both the statement
 and the terminator read.
 
+### Collapsed bodies keep their classification
+
+Almost every script in a Tcl file is *lowered* into ordinary CFG blocks
+before SSA runs, so the classification above is derived once, per word, at
+the statement that owns it.  The one exception is a non-lowered `switch`
+(`-glob` / `-regexp`, or `-exact` with a fall-through arm): its arms stay
+inside a single opaque `Statement::Switch`, and `ssa::switch_reads` recovers
+the names they read so a variable used only in an arm is not reported unused.
+
+That recovery walk (`switch_reads` → `free_reads_in_script` →
+`reads_in_script` → `reads_in_stmt`) carries the **same `ClassifiedUses`
+pair** the lowered path produces, rather than a bare name set (issue #1266).
+Collapsing to names alone made every brace-quoted data word inside an arm a
+substituted read, so `switch -glob $z { a* { puts {$b} } }` drew a false
+W210 that the identical body outside an arm did not.
+
+The classification has to be *threaded*, not dropped: omitting the name
+instead would take its liveness use with it and resurrect a false
+`W220 assignment never read` on `set x 1; switch -glob $z { a* { foreach n
+{$x} {} } }` — the guard rail issues #1237 and #1260 established.  The
+braced loop value word (`ForeachIterator::list_braced`) is the only extra
+input the walk needs beyond what `uses_of_classified` already answers,
+because a `Statement::Foreach` inside an opaque arm is walked here rather
+than lowered.
+
 ## Derivation from SSA
 
 1. **Pass 1 — definitions**: Walk every block.  For each phi node,

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/rbs.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/rbs.rs
@@ -2064,3 +2064,210 @@ fn issue_1260_braced_loop_value_word_keeps_the_store_live() {
         codes(unmentioned, D)
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #1266 — a read collapsed out of an **opaque** `switch` arm keeps its
+// `UseClass`.
+//
+// A non-lowered `switch` (`-glob` / `-regexp`, or `-exact` with a
+// fall-through arm) keeps its arms as one opaque CFG statement, so those arm
+// bodies are the only scripts that reach SSA un-lowered. `ssa::switch_reads`
+// collected them through `free_reads_in_script` / `reads_in_script` as a bare
+// name set and merged the lot into `ClassifiedUses::substituted`, so every
+// brace-quoted DATA word inside an arm was seen as a *substituted* read and
+// drew a false W210 — while the identical spelling outside an arm is
+// correctly quiet, because the lowered path classifies it `UseClass::Quoted`
+// and the W210 emitter skips a quoted use.
+//
+// The walk now threads `ClassifiedUses` end to end, so an arm body is
+// classified exactly as the same script would be when lowered.
+//
+// tclsh-proof (tclsh 9.0.4, the interpreter available in this container; the
+// issue reports the same on 8.6.14):
+//
+//   proc f {z} { switch -glob $z { a* { foreach n {a $b c} {puts $n} } } }
+//   f abc                                     -> a / $b / c   (b undefined)
+//   proc f {z} { switch -glob $z { a* { puts {$b} } } };  f abc -> $b
+//   proc f {z} { switch $z { a - b { puts {$q} } } };     f b   -> $q
+//   proc f {z} { switch -regexp $z { a.* { puts {$b} } default { puts {$c} } } }
+//   f zz                                      -> $c
+//   proc f {z} { set x 1; switch -glob $z { a* { foreach n {$x} {puts $n} } } }
+//   f abc                                     -> $x   (the literal two chars)
+//   proc f {z} { switch -glob $z { a* { puts $b } } }
+//   f abc                    -> can't read "b": no such variable
+// ---------------------------------------------------------------------------
+
+/// #1266 FP — a braced data word inside an opaque arm substitutes nothing, in
+/// every arm shape that keeps the `switch` opaque and at every nesting depth
+/// the collapsed walk descends.
+#[test]
+fn issue_1266_braced_data_word_in_opaque_switch_arm_is_not_a_read() {
+    for src in [
+        // The two spellings named on the issue.
+        "proc f {z} { switch -glob $z { a* { foreach n {a $b c} {} } } }\n",
+        "proc f {z} { switch -glob $z { a* { puts {$b} } } }\n",
+        // -regexp keeps it opaque too, and the default body is walked by the
+        // same helper as an arm body.
+        "proc f {z} { switch -regexp $z { a.* { puts {$b} } } }\n",
+        "proc f {z} { switch -regexp $z { a.* { } default { puts {$b} } } }\n",
+        // -exact stays opaque when an arm falls through.
+        "proc f {z} { switch $z { a - b { puts {$q} } } }\n",
+        // Structured statements inside an arm are walked by `reads_in_stmt`,
+        // not lowered — each recursion must carry the classification.
+        "proc f {z} { switch -glob $z { a* { if {1} { puts {$b} } } } }\n",
+        "proc f {z} { switch -glob $z { a* { if {0} { } else { puts {$b} } } } }\n",
+        "proc f {z} { switch -glob $z { a* { while {[incr i] < 2} { puts {$b} } } } }\n",
+        "proc f {z} { switch -glob $z { a* { for {set i 0} {$i < 1} {incr i} { puts {$b} } } } }\n",
+        "proc f {z} { switch -glob $z { a* { catch { puts {$b} } m } } }\n",
+        "proc f {z} { switch -glob $z { a* { try { puts {$b} } finally { puts {$c} } } } }\n",
+        // A nested opaque switch inside an opaque arm.
+        "proc f {z} { switch -glob $z { a* { switch -glob $z { c* { puts {$b} } } } } }\n",
+        // Every `Statement::Foreach` value word, including a multi-group call.
+        "proc f {z} { switch -glob $z { a* { foreach n {a $b c} m {$d} {} } } }\n",
+        "proc f {z} { switch -glob $z { a* { lmap n {a $b c} {} } } }\n",
+        // A braced `return` value is literal in an arm exactly as outside one.
+        "proc f {z} { switch -glob $z { a* { return {$b} } } }\n",
+    ] {
+        assert!(
+            !fires(src, D, "W210"),
+            "#1266: a braced word inside an opaque switch arm substitutes nothing; \
+{src} emitted: {:?}",
+            codes(src, D)
+        );
+    }
+}
+
+/// #1266 TP — the substituting spellings of the same words inside an opaque
+/// arm must still fire. This is what separates "classify the arm's reads"
+/// from "stop collecting them".
+#[test]
+fn issue_1266_substituted_word_in_opaque_switch_arm_still_fires() {
+    for src in [
+        "proc f {z} { switch -glob $z { a* { puts $b } } }\n",
+        "proc f {z} { switch -glob $z { a* { foreach n \"a $b c\" {} } } }\n",
+        "proc f {z} { switch -glob $z { a* { foreach n $b {} } } }\n",
+        "proc f {z} { switch -glob $z { a* { if {$b} { } } } }\n",
+        "proc f {z} { switch -glob $z { a* { return $b } } }\n",
+        "proc f {z} { switch -regexp $z { a.* { } default { puts $b } } }\n",
+        "proc f {z} { switch $z { a - b { puts $q } } }\n",
+    ] {
+        assert!(
+            fires(src, D, "W210"),
+            "#1266 TP: a substituted word inside an opaque switch arm is a real read; \
+{src} emitted: {:?}",
+            codes(src, D)
+        );
+    }
+}
+
+/// #1266 TN / guard rail — the classification must be *threaded*, never
+/// dropped. The naive fix (omitting the name from `reads_in_script`) was
+/// rejected in #1260 precisely because a dropped name loses its **liveness**
+/// use as well, resurrecting a false W211/W220 on a store whose only mention
+/// is the braced word. Same guard rail as
+/// `issue_1237_quoted_use_still_keeps_the_variable_live` and
+/// `issue_1260_braced_loop_value_word_keeps_the_store_live`, now inside an
+/// opaque arm.
+#[test]
+fn issue_1266_quoted_arm_mention_keeps_the_store_live() {
+    for src in [
+        "proc p {z} { set x 1; switch -glob $z { a* { foreach n {$x} {} } } }\n",
+        "proc p {z} { set x 1; switch -glob $z { a* { puts {$x} } } }\n",
+        "proc p {z} { set x 1; switch -glob $z { a* { if {1} { puts {$x} } } } }\n",
+        "proc p {z} { set x 1; switch -regexp $z { a.* { } default { puts {$x} } } }\n",
+        "proc p {z} { set x 1; switch $z { a - b { puts {$x} } } }\n",
+    ] {
+        assert!(
+            !fires(src, D, "W211") && !fires(src, D, "W220"),
+            "#1266: a quoted mention inside an opaque arm keeps the store live; \
+{src} emitted: {:?}",
+            codes(src, D)
+        );
+    }
+    // TP control: with no mention of any kind the dead store is still reported.
+    for unmentioned in [
+        "proc p {z} { set x 1; switch -glob $z { a* { foreach n {$y} {} } } }\n",
+        "proc p {z} { set x 1; switch -glob $z { a* { puts {$y} } } }\n",
+    ] {
+        assert!(
+            fires(unmentioned, D, "W211") || fires(unmentioned, D, "W220"),
+            "#1266 TP: an unmentioned store is still dead; {unmentioned} emitted: {:?}",
+            codes(unmentioned, D)
+        );
+    }
+}
+
+/// #1266 FN guard — the whole point is that an opaque arm agrees with the
+/// lowered path. A plain `-exact` `switch` with no fall-through lowers its
+/// arms into ordinary CFG blocks; the `-glob` spelling of the same body must
+/// produce the same verdict, braced and substituted alike.
+#[test]
+fn issue_1266_opaque_arm_agrees_with_the_lowered_path() {
+    for (lowered, opaque) in [
+        (
+            "proc f {z} { switch $z { a { puts {$b} } } }\n",
+            "proc f {z} { switch -glob $z { a* { puts {$b} } } }\n",
+        ),
+        (
+            "proc f {z} { switch $z { a { puts $b } } }\n",
+            "proc f {z} { switch -glob $z { a* { puts $b } } }\n",
+        ),
+        (
+            "proc f {z} { switch $z { a { foreach n {a $b c} {} } } }\n",
+            "proc f {z} { switch -glob $z { a* { foreach n {a $b c} {} } } }\n",
+        ),
+        (
+            "proc p {z} { set x 1; switch $z { a { foreach n {$x} {} } } }\n",
+            "proc p {z} { set x 1; switch -glob $z { a* { foreach n {$x} {} } } }\n",
+        ),
+    ] {
+        for code in ["W210", "W211", "W220"] {
+            assert_eq!(
+                fires(lowered, D, code),
+                fires(opaque, D, code),
+                "#1266: {code} must agree between the lowered arm ({lowered}) \
+and the opaque one ({opaque}); {:?} vs {:?}",
+                codes(lowered, D),
+                codes(opaque, D)
+            );
+        }
+    }
+}
+
+/// #1266 — the same collapse covered the arm **patterns**, which the
+/// canonical single-braced `{pat body …}` block also carries literally.
+///
+/// tclsh 9.0.4: `proc f {z} { switch -glob $z { $a* { puts hit } default {
+/// puts miss } } }` prints `hit` for `f {$a}` and `miss` for `f zz`, with `a`
+/// undefined throughout — the pattern matched the two literal characters
+/// `$a`. Supplied as separate words the pattern *does* substitute, and the
+/// lowered `-exact` path already classified its patterns this way, so this is
+/// the same lowered-vs-opaque parity gap.
+#[test]
+fn issue_1266_braced_switch_pattern_is_not_a_read() {
+    for src in [
+        "proc f {z} { switch -glob $z { $a* { } } }\n",
+        "proc f {z} { switch -regexp $z { $a.* { } } }\n",
+        "proc f {z} { switch $z { $a - b { } } }\n",
+    ] {
+        assert!(
+            !fires(src, D, "W210"),
+            "#1266: a pattern in the braced arm block is literal; {src} emitted: {:?}",
+            codes(src, D)
+        );
+    }
+    // TP — patterns supplied as separate words really do substitute.
+    let words = "proc f {z} { switch -glob -- $z $a* { } }\n";
+    assert!(
+        fires(words, D, "W210"),
+        "#1266 TP: a separate-word pattern substitutes; emitted: {:?}",
+        codes(words, D)
+    );
+    // TN guard rail — the quoted pattern still keeps the store live.
+    let live = "proc p {z} { set x 1; switch -glob $z { $x* { } } }\n";
+    assert!(
+        !fires(live, D, "W211") && !fires(live, D, "W220"),
+        "#1266: a quoted pattern mention keeps the store live; emitted: {:?}",
+        codes(live, D)
+    );
+}

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -1333,6 +1333,33 @@ struct ClassifiedUses {
     quoted: BTreeSet<String>,
 }
 
+impl ClassifiedUses {
+    /// Absorb another scan's two halves, keeping each name in its own bucket.
+    /// A name that is substituted *somewhere* stays substituted — the final
+    /// `quoted.retain` in [`uses_of_classified`] resolves the overlap once,
+    /// at the top, so intermediate merges never have to.
+    fn merge(&mut self, other: ClassifiedUses) {
+        self.substituted.extend(other.substituted);
+        self.quoted.extend(other.quoted);
+    }
+
+    /// Absorb a classified name list (as [`uses_of_classified`] returns it).
+    fn merge_classified(&mut self, uses: impl IntoIterator<Item = (String, UseClass)>) {
+        for (name, class) in uses {
+            match class {
+                UseClass::Substituted => self.substituted.insert(name),
+                UseClass::Quoted => self.quoted.insert(name),
+            };
+        }
+    }
+
+    /// Drop every name a collapsed body defines itself, from both halves.
+    fn remove_defs(&mut self, defs: &HashSet<String>) {
+        self.substituted.retain(|v| !defs.contains(v));
+        self.quoted.retain(|v| !defs.contains(v));
+    }
+}
+
 /// [`uses_of`] with each name's [`UseClass`].
 ///
 /// A name reached by both a substituted word and a brace-quoted one is
@@ -1402,12 +1429,14 @@ pub fn uses_of_classified(
             subject,
             arms,
             default_body,
+            patterns_braced,
             ..
         } => {
-            found.substituted.extend(switch_reads(
+            found.merge(switch_reads(
                 subject,
                 arms,
                 default_body.as_ref(),
+                *patterns_braced,
                 scanner,
                 registry,
             ));
@@ -1904,22 +1933,44 @@ fn word_sets_name(word: &str, name: &str) -> bool {
 /// Reads of a non-lowered (`-glob`/`-regexp`, or `-exact` with a fall-through
 /// arm) `switch` kept opaque in a CFG block: the subject word, every arm
 /// pattern, and the *free* reads of each arm/default body.
+///
+/// The arm bodies are the *only* scripts in the pipeline that reach SSA
+/// un-lowered, so this walk is the one place a `UseClass` would otherwise be
+/// invented rather than derived. It is threaded through instead (issue
+/// #1266): a brace-quoted data word inside an arm keeps the same
+/// [`UseClass::Quoted`] it would carry had the arm been lowered, so
+/// read-before-set skips it while liveness still honours it.
 fn switch_reads(
     subject: &str,
     arms: &[crate::ir::SwitchArm],
     default_body: Option<&crate::ir::Script>,
+    patterns_braced: bool,
     scanner: &mut VarReferenceScanner,
     registry: &CommandRegistry,
-) -> BTreeSet<String> {
-    let mut reads = scanner.scan_word(subject, registry);
+) -> ClassifiedUses {
+    let mut reads = ClassifiedUses {
+        substituted: scanner.scan_word(subject, registry),
+        quoted: BTreeSet::new(),
+    };
     for arm in arms {
-        reads.extend(scanner.scan_word(&arm.pattern, registry));
+        // A pattern from the canonical single braced `{pat body …}` block is a
+        // literal list element — tclsh 9.0.4: `proc f {z} {switch -glob $z
+        // {$a* {puts hit} default {puts miss}}}; f {$a}` prints `hit` with `a`
+        // undefined. Supplied as separate words (`switch $s $pat {body}`) the
+        // pattern does substitute. Same classification the lowered `-exact`
+        // path already applies to its patterns.
+        let pattern_sink = if patterns_braced {
+            &mut reads.quoted
+        } else {
+            &mut reads.substituted
+        };
+        pattern_sink.extend(scanner.scan_word(&arm.pattern, registry));
         if let Some(body) = &arm.body {
-            reads.extend(free_reads_in_script(body, scanner, registry));
+            reads.merge(free_reads_in_script(body, scanner, registry));
         }
     }
     if let Some(db) = default_body {
-        reads.extend(free_reads_in_script(db, scanner, registry));
+        reads.merge(free_reads_in_script(db, scanner, registry));
     }
     reads
 }
@@ -1932,57 +1983,62 @@ fn free_reads_in_script(
     script: &crate::ir::Script,
     scanner: &mut VarReferenceScanner,
     registry: &CommandRegistry,
-) -> BTreeSet<String> {
+) -> ClassifiedUses {
     let mut defs: HashSet<String> = crate::ir_helpers::defs_from_ir_script(script)
         .into_iter()
         .collect();
     defs.extend(collapsed_extra_defs(script, registry, 0));
-    reads_in_script(script, scanner, registry)
-        .into_iter()
-        .filter(|v| !defs.contains(v))
-        .collect()
+    let mut reads = reads_in_script(script, scanner, registry);
+    reads.remove_defs(&defs);
+    reads
 }
 
-/// Recursively collect variable reads from an un-lowered IR script.
+/// Recursively collect classified variable reads from an un-lowered IR script.
 fn reads_in_script(
     script: &crate::ir::Script,
     scanner: &mut VarReferenceScanner,
     registry: &CommandRegistry,
-) -> BTreeSet<String> {
-    let mut reads = BTreeSet::new();
+) -> ClassifiedUses {
+    let mut reads = ClassifiedUses::default();
     for stmt in &script.statements {
-        reads.extend(reads_in_stmt(stmt, scanner, registry));
+        reads.merge(reads_in_stmt(stmt, scanner, registry));
     }
     reads
 }
 
-/// Variable reads of a single statement, recursing into nested bodies. Leaf
-/// reads come from [`uses_of`] (which resolves a nested `Statement::Switch` via
-/// [`switch_reads`]); structured statements are walked here because they are
-/// not lowered inside an opaque switch arm.
+/// Classified variable reads of a single statement, recursing into nested
+/// bodies. Leaf reads come from [`uses_of_classified`] (which resolves a
+/// nested `Statement::Switch` via [`switch_reads`]); structured statements are
+/// walked here because they are not lowered inside an opaque switch arm.
+///
+/// Every context this walk adds by hand — an `if`/`while`/`for` condition, a
+/// loop's value word, a nested body — is one the enclosing frame really does
+/// evaluate, so it is [`UseClass::Substituted`]; the single exception is a
+/// **braced** loop value word, which is literal list text (issue #1260).
 fn reads_in_stmt(
     stmt: &Statement,
     scanner: &mut VarReferenceScanner,
     registry: &CommandRegistry,
-) -> BTreeSet<String> {
-    let mut reads: BTreeSet<String> = uses_of(stmt, scanner, registry).into_iter().collect();
+) -> ClassifiedUses {
+    let mut reads = ClassifiedUses::default();
+    reads.merge_classified(uses_of_classified(stmt, scanner, registry));
     match stmt {
         Statement::If {
             clauses, else_body, ..
         } => {
             for clause in clauses {
-                reads.extend(vars_in_expr(&clause.condition));
-                reads.extend(reads_in_script(&clause.body, scanner, registry));
+                reads.substituted.extend(vars_in_expr(&clause.condition));
+                reads.merge(reads_in_script(&clause.body, scanner, registry));
             }
             if let Some(eb) = else_body {
-                reads.extend(reads_in_script(eb, scanner, registry));
+                reads.merge(reads_in_script(eb, scanner, registry));
             }
         }
         Statement::While {
             condition, body, ..
         } => {
-            reads.extend(vars_in_expr(condition));
-            reads.extend(reads_in_script(body, scanner, registry));
+            reads.substituted.extend(vars_in_expr(condition));
+            reads.merge(reads_in_script(body, scanner, registry));
         }
         Statement::For {
             init,
@@ -1991,33 +2047,33 @@ fn reads_in_stmt(
             body,
             ..
         } => {
-            reads.extend(reads_in_script(init, scanner, registry));
-            reads.extend(vars_in_expr(condition));
-            reads.extend(reads_in_script(next, scanner, registry));
-            reads.extend(reads_in_script(body, scanner, registry));
+            reads.merge(reads_in_script(init, scanner, registry));
+            reads.substituted.extend(vars_in_expr(condition));
+            reads.merge(reads_in_script(next, scanner, registry));
+            reads.merge(reads_in_script(body, scanner, registry));
         }
         Statement::Foreach {
             iterators, body, ..
         } => {
             for it in iterators {
-                // `it.list_braced` is deliberately NOT consulted here. This
-                // walk feeds [`free_reads_in_script`], whose caller
-                // ([`switch_reads`]) merges everything into
-                // `ClassifiedUses::substituted` — the whole path drops
-                // [`UseClass`], so a name omitted here loses its *liveness*
-                // use too and resurrects W211/W220 on a store whose only
-                // mention is the braced word. The same collapse already
-                // keeps `puts {$y}` a read inside an opaque switch arm; the
-                // fix is to thread the classification through this walk, not
-                // to drop reads one statement kind at a time (issue #1260
-                // fixes the lowered path; the collapsed-arm residual is
-                // tracked separately).
-                reads.extend(scanner.scan_word(&it.list_arg, registry));
+                // A braced value word is literal list text — `foreach n {a $b
+                // c}` iterates the three characters `$b`, it does not read
+                // `b` (issue #1260). The name is still *recorded*, as
+                // `Quoted`: dropping it here would take its liveness use with
+                // it and resurrect a false W220 on a store whose only mention
+                // is that word (the #1237 guard rail). Classifying is what
+                // separates the two.
+                let sink = if it.list_braced {
+                    &mut reads.quoted
+                } else {
+                    &mut reads.substituted
+                };
+                sink.extend(scanner.scan_word(&it.list_arg, registry));
             }
-            reads.extend(reads_in_script(body, scanner, registry));
+            reads.merge(reads_in_script(body, scanner, registry));
         }
         Statement::Catch { body, .. } => {
-            reads.extend(reads_in_script(body, scanner, registry));
+            reads.merge(reads_in_script(body, scanner, registry));
         }
         Statement::Try {
             body,
@@ -2025,12 +2081,12 @@ fn reads_in_stmt(
             finally_body,
             ..
         } => {
-            reads.extend(reads_in_script(body, scanner, registry));
+            reads.merge(reads_in_script(body, scanner, registry));
             for handler in handlers {
-                reads.extend(reads_in_script(&handler.body, scanner, registry));
+                reads.merge(reads_in_script(&handler.body, scanner, registry));
             }
             if let Some(fb) = finally_body {
-                reads.extend(reads_in_script(fb, scanner, registry));
+                reads.merge(reads_in_script(fb, scanner, registry));
             }
         }
         _ => {}
@@ -3632,6 +3688,125 @@ mod tests {
             braced: true,
         };
         assert_eq!(classify(&stmt, &reg, "y"), Some(UseClass::Quoted));
+    }
+
+    /// Build a one-arm opaque `switch` around `body`, with `pattern` as the
+    /// arm's pattern and the canonical braced arm block.
+    fn opaque_switch(subject: &str, pattern: &str, body: crate::ir::Script) -> Statement {
+        Statement::Switch {
+            span: Span::new(0, 40),
+            subject: subject.into(),
+            subject_span: Span::new(0, 1),
+            arms: vec![crate::ir::SwitchArm {
+                pattern: pattern.into(),
+                pattern_span: Span::new(0, 1),
+                body: Some(body),
+                body_span: Some(Span::new(0, 1)),
+                fallthrough: false,
+            }],
+            default_body: None,
+            default_span: None,
+            mode: crate::ir::SwitchMode::Glob,
+            nocase: false,
+            raw_args: Vec::new(),
+            patterns_braced: true,
+        }
+    }
+
+    /// Issue #1266 — an arm body is the one script that reaches SSA
+    /// un-lowered, and its reads must arrive classified exactly as the same
+    /// word would be outside the arm. A braced data word is `Quoted`.
+    /// tclsh-proof: tclsh 9.0.4 — `proc f {z} { switch -glob $z { a* { puts
+    /// {$b} } } }; f abc` prints `$b` with `b` undefined.
+    #[test]
+    fn uses_of_classified_opaque_switch_arm_braced_data_word_is_quoted() {
+        let reg = default_registry();
+        let mut body = crate::ir::Script::new();
+        body.statements.push(call_with_words("puts", &["{$y}"]));
+        let stmt = opaque_switch("$z", "a*", body);
+        assert_eq!(classify(&stmt, &reg, "y"), Some(UseClass::Quoted));
+        // The subject is a genuine read of this frame.
+        assert_eq!(classify(&stmt, &reg, "z"), Some(UseClass::Substituted));
+    }
+
+    /// TP control — the substituting spelling of the same arm word stays a
+    /// definite read, so the classification is threaded, not dropped.
+    #[test]
+    fn uses_of_classified_opaque_switch_arm_unbraced_word_is_substituted() {
+        let reg = default_registry();
+        let mut body = crate::ir::Script::new();
+        body.statements.push(call_with_words("puts", &["$y"]));
+        let stmt = opaque_switch("$z", "a*", body);
+        assert_eq!(classify(&stmt, &reg, "y"), Some(UseClass::Substituted));
+    }
+
+    /// Issue #1266 — a `Statement::Foreach` inside an opaque arm is walked by
+    /// `reads_in_stmt` rather than lowered, so `ForeachIterator::list_braced`
+    /// (#1260) is the extra fact that walk needs: a braced value word is
+    /// literal list text, recorded `Quoted` so liveness still honours it.
+    #[test]
+    fn uses_of_classified_opaque_switch_arm_braced_foreach_list_is_quoted() {
+        let reg = default_registry();
+        let mut body = crate::ir::Script::new();
+        body.statements.push(Statement::Foreach {
+            span: Span::new(0, 20),
+            iterators: vec![crate::ir::ForeachIterator {
+                vars: vec!["n".into()],
+                list_arg: "a $y c".into(),
+                list_braced: true,
+            }],
+            body: crate::ir::Script::new(),
+            body_span: Span::new(0, 1),
+            is_lmap: false,
+            raw_args: Vec::new(),
+            is_dict_iteration: false,
+            is_array_iteration: false,
+            raw_tokens: None,
+        });
+        let stmt = opaque_switch("$z", "a*", body);
+        assert_eq!(classify(&stmt, &reg, "y"), Some(UseClass::Quoted));
+    }
+
+    /// TP control for the loop value word — the substituting spelling is a
+    /// definite read even inside an opaque arm.
+    #[test]
+    fn uses_of_classified_opaque_switch_arm_substituted_foreach_list_is_substituted() {
+        let reg = default_registry();
+        let mut body = crate::ir::Script::new();
+        body.statements.push(Statement::Foreach {
+            span: Span::new(0, 20),
+            iterators: vec![crate::ir::ForeachIterator {
+                vars: vec!["n".into()],
+                list_arg: "a $y c".into(),
+                list_braced: false,
+            }],
+            body: crate::ir::Script::new(),
+            body_span: Span::new(0, 1),
+            is_lmap: false,
+            raw_args: Vec::new(),
+            is_dict_iteration: false,
+            is_array_iteration: false,
+            raw_tokens: None,
+        });
+        let stmt = opaque_switch("$z", "a*", body);
+        assert_eq!(classify(&stmt, &reg, "y"), Some(UseClass::Substituted));
+    }
+
+    /// Issue #1266 — a pattern from the canonical braced arm block is a
+    /// literal list element; supplied as separate words it substitutes.
+    #[test]
+    fn uses_of_classified_switch_pattern_class_follows_patterns_braced() {
+        let reg = default_registry();
+        let braced = opaque_switch("$z", "$p*", crate::ir::Script::new());
+        assert_eq!(classify(&braced, &reg, "p"), Some(UseClass::Quoted));
+        let mut worded = opaque_switch("$z", "$p*", crate::ir::Script::new());
+        if let Statement::Switch {
+            patterns_braced, ..
+        } = &mut worded
+        {
+            *patterns_braced = false;
+        }
+        assert_eq!(classify(&worded, &reg, "p"), Some(UseClass::Substituted));
     }
 
     // build_ssa tests

--- a/rust/tcl-compiler/tests/fp_depth.rs
+++ b/rust/tcl-compiler/tests/fp_depth.rs
@@ -1200,4 +1200,117 @@ mod bug_dict_update_value_var {
             codes(src, D)
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Issue #1247 depth: the FP above was re-introduced once by a registry
+    // change and caught only by the single assertion above. The mechanism is
+    // worth pinning from every side it can break from, because the harvester
+    // has three independent moving parts: the *role* the registry gives the
+    // value-var word, the *pair stride* the harvester walks, and the *dict
+    // value* it resolves (SCCP version, or the same-block literal `set`).
+    //
+    // The registry half is pinned in `tcl-registry`'s
+    // `repeated_layouts_answer_through_arg_indices_for_role`: `dict update`'s
+    // pair locals answer `ArgRole::LoopVarList`, never `ArgRole::VarWrite`.
+    // The re-introduction was exactly that role being `VarWrite`, which makes
+    // SSA model an unconditional def of the value-var at the barrier; the def
+    // lands in `UndefSuppression::explicitly_defined`, whose `!contains`
+    // clause then gates off `dict_with_known_keys` in `suppresses_strict`.
+    // The tests below pin the same invariant from the *behaviour* side, so
+    // the two layers cannot drift apart silently.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dict_update_value_var_is_not_an_unconditional_definition() {
+        // Second angle on the same root cause. `dict update` binds the
+        // value-var *conditionally* (only when the key is present), so it is
+        // not an assignment the analyser owns. Were the value-var modelled as
+        // an unconditional SSA def, this body — which never reads `v` — would
+        // become a dead store and draw W211/W220.
+        // tclsh: `set d {k 5}; dict update d k v {}` assigns nothing the user
+        // wrote; the binding is the command's own doing.
+        let src = "proc f {} { set d {k 5}; dict update d k v { } }\n";
+        assert!(
+            !fires(src, D, "W211") && !fires(src, D, "W220"),
+            "a `dict update` value-var is not a user store and must not be reported \
+dead; emitted {:?}",
+            codes(src, D)
+        );
+    }
+
+    #[test]
+    fn dict_update_absent_key_in_a_non_empty_dict_fires_w210() {
+        // TP that the empty-dict control cannot reach: the dict HAS keys, just
+        // not this one. A harvester that suppressed every value-var whenever
+        // the dict resolved to *any* literal would still pass the empty-dict
+        // control and fail here.
+        // tclsh: `set d {k 5}; dict update d q w {info exists w}` → 0.
+        let src = "proc f {} { set d {k 5}; dict update d q w { puts $w } }\n";
+        assert!(
+            fires(src, D, "W210"),
+            "an absent key leaves the value-var unset; must fire W210; emitted {:?}",
+            codes(src, D)
+        );
+    }
+
+    #[test]
+    fn dict_update_resolves_each_pair_independently() {
+        // Per-pair precision, pinned as two one-variable reads of the same
+        // two-pair call so the verdict is unambiguous without inspecting spans.
+        // tclsh: `set d {k 5}; dict update d k v q w {list [info exists v] \
+        // [info exists w]}` → `1 0`.
+        let present = "proc f {} { set d {k 5}; dict update d k v q w { puts $v } }\n";
+        assert!(
+            !fires(present, D, "W210"),
+            "the present key's value-var is bound; emitted {:?}",
+            codes(present, D)
+        );
+        let absent = "proc f {} { set d {k 5}; dict update d k v q w { puts $w } }\n";
+        assert!(
+            fires(absent, D, "W210"),
+            "the absent key's value-var is unset; must fire W210; emitted {:?}",
+            codes(absent, D)
+        );
+    }
+
+    #[test]
+    fn dict_update_binds_the_value_var_not_the_key_word() {
+        // Stride/parity pin. `dict update` binds `v`, NOT `k` — the key word
+        // is data. A harvester that walked the pairs off by one would suppress
+        // `$k` (and expose `$v`), which the key-present test alone cannot
+        // detect. This is also what separates `dict update` from `dict with`,
+        // where the KEY is what the body sees.
+        // tclsh: `set d {k 5}; dict update d k v {info exists k}` → 0.
+        let src = "proc f {} { set d {k 5}; dict update d k v { puts $k } }\n";
+        assert!(
+            fires(src, D, "W210"),
+            "`dict update` does not bind the key word; must fire W210; emitted {:?}",
+            codes(src, D)
+        );
+    }
+
+    #[test]
+    fn dict_update_harvests_keys_through_the_sccp_version() {
+        // The harvester prefers the SCCP CONST of the SPECIFIC version the
+        // `dict update` statement reads, falling back to a same-block literal
+        // `set`. Every test above exercises the fallback (a literal `set` in
+        // the same block); these two pin the SCCP branch, where the only
+        // truth source is an interprocedurally propagated caller argument.
+        // tclsh: `proc f {d} {dict update d k v {info exists v}}`
+        //        → `f {k 5}` = 1, `f {}` = 0.
+        let present = "proc f {d} { dict update d k v { puts $v } }\nproc g {} { f {k 5} }\n";
+        assert!(
+            !fires(present, D, "W210"),
+            "an interprocedurally-propagated key-present literal binds the value-var; \
+emitted {:?}",
+            codes(present, D)
+        );
+        let absent = "proc f {d} { dict update d k v { puts $v } }\nproc g {} { f {} }\n";
+        assert!(
+            fires(absent, D, "W210"),
+            "an interprocedurally-propagated empty literal leaves the value-var unset; \
+must fire W210; emitted {:?}",
+            codes(absent, D)
+        );
+    }
 }


### PR DESCRIPTION
Closes #1266. Closes #1247.

## #1266 — reads collapsed out of an opaque `switch` arm lost their `UseClass`

**Root cause.** A non-lowered `switch` (`-glob` / `-regexp`, or `-exact` with a fall-through arm) keeps its arms in one opaque `Statement::Switch`, so arm bodies are the only scripts that reach SSA un-lowered. `switch_reads` → `free_reads_in_script` → `reads_in_script` → `reads_in_stmt` returned a bare `BTreeSet<String>`: `reads_in_stmt` called `uses_of`, which discards the classification at the top, and the `Statement::Switch` arm of `uses_of_classified` merged the whole set into `ClassifiedUses::substituted`. Every brace-quoted **data** word inside an arm therefore looked like a substituted read, producing false `W210`s that the lowered path does not produce.

**Fix.** All four walk functions now return the `ClassifiedUses` pair end to end, and the `Statement::Switch` arm merges each half into its matching bucket (new private `ClassifiedUses::merge` / `merge_classified` / `remove_defs`). `ForeachIterator::list_braced` is the one extra input `Statement::Foreach` needs, since a `foreach` inside an opaque arm is walked here rather than lowered. Nothing is dropped, so the guard rail from #1237/#1260 — that a name removed from the read set also loses its liveness use and resurrects a false `W220` — holds by construction rather than by care.

**Also fixed, same parity gap.** Arm **patterns**. `Statement::Switch` already carried `patterns_braced` but `switch_reads` ignored it. A pattern in the canonical braced `{pat body …}` block is literal, and the lowered `-exact` path was already silent on `switch $z { $a { } }` — so `switch -glob $z { $a* {} }` was the same lowered-versus-opaque disagreement. Separate-word patterns (`switch -glob -- $z $a* {}`) still substitute and still fire.

## #1247 — does not reproduce; the regression was never on `rust`

`fp_depth.rs::bug_dict_update_value_var::*` is green on `rust` and always has been. The commit the issue cites, `91f209c11`, is **not an ancestor of `rust`** — it is a merge of an agent integration branch with `767c51de3`. Verified directly: `91f209c11` is red, its merge-base `767c51de3` is green, and every mainline commit after it is green.

The red side-branch state came from that branch's copy of the repeated-argument work declaring `dict update`'s pair locals as `ArgRole::VarWrite`. The mechanism, confirmed by re-applying `VarWrite` to today's tree and watching the test flip red, then reverting: `VarWrite` at the value-var index makes SSA model an unconditional def of `v` at the barrier; `build_undef_suppression` then puts every def with `version > 0` into `explicitly_defined`; and `suppresses_strict` checks `!explicitly_defined.contains(name)` *before* it honours `dict_with_known_keys`, gating off the key-aware suppression that `harvest_dict_with_suppression` had just computed. The properly-landed version of that work declares `ArgRole::LoopVarList` instead, which is why mainline was never affected.

No behaviour change is needed, so this adds regression coverage instead.

## Tests

**#1266** — 5 unit pins in `ssa.rs` on the classification itself (braced/unbraced arm word, braced/unbraced `foreach` value word inside an arm, pattern class following `patterns_braced`, and the subject staying `Substituted`), plus 5 behaviour tests in `fp/rbs.rs`: the false-positive across 15 spellings, the true-positive control across 7, the #1237/#1260 liveness guard rail inside an arm, an FN guard asserting the opaque `-glob` arm and the lowered `-exact` arm agree on `W210`/`W211`/`W220`, and the braced-pattern case with its separate-word true-positive control.

With `ssa.rs` stashed, 3 of the 5 `rbs.rs` tests fail and the two guard-rail/true-positive tests pass either way — they are load-bearing.

**#1247** — 5 tests in `fp_depth.rs` covering the parts the single existing assertion left cold: the value-var is not a user store (no `W211`/`W220` when unread); an absent key in a *non-empty* dict still fires, which the empty-dict control cannot distinguish from "no keys at all"; per-pair precision in one two-pair call; stride/parity, separating it from `dict with`; and the SCCP-version branch of the harvester reached through an interprocedural caller literal, where every pre-existing test only reached the same-block `AssignConst` fallback. Re-applying `VarWrite` turns 3 of these red.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` (0 warnings), and `cargo check --workspace --all-targets` all clean; `cargo test -p tcl-compiler` passes all 39 test binaries. No `#[allow(...)]` and no command-name matching — the pattern-literalness fact comes from the existing `patterns_braced` field and the `dict update` role is registry data.

Oracle premises were checked against tclsh 9.0.4; `tclsh8.6` was not available in the build container, and none of these constructs changed between 8.6 and 9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_