### PR TITLE
Source-graph run order for import lifecycle events (#1104, #1116)

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -83,11 +83,11 @@ surface.
 - [cross-file-command-resolution-lattice.md](cross-file-command-resolution-lattice.md)
   — the proposal for the cross-file resolution lattice: settling a call to its
   defining proc/class across the workspace index, sound by abstention.
-- [import-order-source-graph.md](import-order-source-graph.md) — design sketch
-  (unimplemented) for a load-order partial order derived from the `source` /
-  `package require` graph: which facts the analyser and index already record,
-  what the ordering relation needs, which wildcard-import abstentions it would
-  lift, and why no trivial subset exists below the resolver plumbing.
+- [import-order-source-graph.md](import-order-source-graph.md) — the load
+  order derived from the `source` graph (`tcl_lsp_core::source_graph::RunOrder`):
+  the relation both wildcard-import tiers rank cross-document lifecycle events
+  with, which abstentions it lifted, where it deliberately still abstains, and
+  what a `package require`-derived second phase would additionally need.
 - [name-resolution-tcl-version-and-c-source.md](name-resolution-tcl-version-and-c-source.md)
   — the version-sensitive resolution semantics (8.4→9.1), each fact pinned to a
   stable C-Tcl source permalink (`tclNamesp.c` / `tclVar.c`).

--- a/docs/design/contracts/command-resolution.md
+++ b/docs/design/contracts/command-resolution.md
@@ -216,10 +216,19 @@ not change the rule, and must not grow bespoke resolution logic. Every
   `in_effect` / `in_effect_within` order rule as the export snapshot, and it
   gates the **exact**-import link the same way it gates a glob lookup.
   Byte offsets order events only *within* one document, so a cross-file event
-  — an install as much as a removal — is passed unordered rather than compared
-  against an unrelated file's numbering. Removals then abstain toward
-  *keeping* the alias: one in another file revokes nothing, and one written
-  inside a proc/class body is conditional and is not published at all. The one
+  — an install as much as a removal — is ordered only where the **`source`
+  graph proves an order** (`tcl_lsp_core::source_graph::RunOrder`, issue #1104
+  item 3): sourcing a file inlines its whole body at the `source` statement's
+  position, so the DFS of the `source` forest is the run order and two events
+  in one tree reduce to positions in their deepest common document, where the
+  ordinary single-document rule applies. An export sourced *before* an import
+  counts; one sourced *after* it is not retroactive; a `namespace forget`
+  written beside a `source` revokes what that `source` installed (pinned, both
+  tiers and end-to-end). Everywhere else the order abstains — different trees,
+  a file reachable from two `source` sites or on a cycle, a `source` path the
+  host cannot prove statically — and removals then abstain toward *keeping*
+  the alias: one that cannot be ranked revokes nothing, and one written inside
+  a proc/class body is conditional and is not published at all. The one
   exception is **destroying the source command**, which is not a slot event on
   a timeline but the disappearance of the command object workspace-wide: it
   revokes a link regardless of where it is written.

--- a/docs/design/contracts/workspace-indexing.md
+++ b/docs/design/contracts/workspace-indexing.md
@@ -74,12 +74,29 @@ item 1): a bare call written before its own `namespace import` reaches nothing
 (oracle: first call `invalid command name`, post-import call works), so an
 install that has not run at the query point does not count.
 
-Ordering is per document on **both** sides of the comparison: an install
-whose document differs from the call's is passed unordered too, because a byte
-offset in the importing file and one in the calling file are unrelated numbers
-— comparing them let a `namespace forget` in the caller revoke a cross-file
+Ordering is the **`source`-graph run order**
+(`tcl_lsp_core::source_graph::RunOrder`, issue #1104 item 3).  A byte offset in
+the importing file and one in the calling file are unrelated numbers —
+comparing them let a `namespace forget` in the caller revoke a cross-file
 import purely because its local offset happened to be larger (issue #1116
-finding 1).  Unordered, the shared function keeps the alias.
+finding 1) — so two events in different documents are ordered only where a
+`source` path proves it.  Sourcing a file inlines its whole body at the
+`source` statement's position, so the DFS of the `source` forest *is* the run
+order: each point is lifted to its root-ward path of `source`-statement
+offsets, and the deepest document the two paths share is where the ordinary
+single-document rule applies.  The index builds the order once per
+`generation()` from the host's resolver (`WorkspaceIndex::set_source_resolver`;
+the index holds no URI ↔ path mapping of its own) over **literal** `source`
+targets only.
+
+The relation answers `None` — incomparable — for two documents in different
+trees, for a file reachable from two different `source` sites or on a cycle
+(Tcl tolerates re-sourcing, and a doubly-entered file has no unique position),
+for a computed `source $dir/x.tcl`, and for a host that installs no resolver.
+`None` folds to "abstain toward answering" in both decision functions: an
+unrankable install counts, an unrankable removal revokes nothing.  A workspace
+with no resolvable `source` edge therefore behaves exactly as it did before the
+order existed.
 
 Within one document the comparison is `in_effect_within` on **both** sides
 too, which is why `CallSite` carries the call's own `enclosing_body` span and
@@ -95,11 +112,23 @@ spans and call offsets rather than one `innermost_definition_body_span` per
 row, so the cost is `O((P + I) log (P + I))` per document instead of the
 `O(procs × invocations)` that kept the fact out of the index.
 
-Two further points are deliberate.  A removal in a **different document**
-from the call revokes nothing, the same unordered-event rule the `-clear`
-tombstones follow.  And **destroying** the source command is not treated as a
-slot event on a timeline at all — the command object is gone workspace-wide —
-so it revokes wherever it is written.
+Two further points are deliberate.  A removal the order cannot rank against
+the install revokes nothing, the same rule the `-clear` tombstones follow.  And
+**destroying** the source command is not treated as a slot event on a timeline
+at all — the command object is gone workspace-wide — so it revokes wherever it
+is written.
+
+Both decision functions are **latest-wins folds over a partial order**, not
+over a `u32` maximum: two events the gate admits still have to be ranked
+against each other, and a partial order has no `max`.  A pattern survives
+unless some tombstone is known to have run after it; an install survives unless
+some removal is.  "Known to have run after" is `has_run(a, b) == Some(false)` —
+the *same* relation the gate uses, so the gate and the ranking cannot mean
+different things.  One consequence needs no `source` edge at all: two events
+written in one *foreign* file are ranked against each other (a file's
+statements run consecutively), so a `namespace export p` followed by a
+`namespace export -clear` there revokes, where the old encoding could only call
+both "unordered" and kept the export.
 
 The **exact**-import link tier runs the same decision function with no call
 site (`WildcardImportIndex::link_alias_live`, issue #1116 finding 2): the
@@ -117,15 +146,16 @@ exact pattern is a fact about the source text, not about the command table, so
 an earlier import of either spelling makes a later non-`-force` import of the
 other install nothing (issue #1116 item 7 — asking each side only about its own
 kind made the rule directional).  A same-source re-import is a silent no-op,
-never a conflict, and two imports in different documents have no static load
-order and do not conflict at all.
+never a conflict, and two imports in different documents conflict only where
+the `source` order ranks one strictly before the other (issue #1116 item 6).
 
 "Earlier" is **load order**, not byte offset
 (`tcl_lsp_core::namespace_import::load_order`, shared with the same-document
 tier's slot-log fold): a load-level statement runs before every body of its
 file however far below it is written, a body-local one never counts as having
 run at load level, and within one tier the key degenerates to the offset
-comparison it replaces.  A raw offset test let a body-local import install over
+comparison it replaces.  Across documents it is the same key read at the two
+sites' deepest common document (`RunOrder::cmp_run`).  A raw offset test let a body-local import install over
 a top-level one written after it — oracle (8.6.14 / 9.0.4): with `proc p {}
 {namespace import ::B::x}` in `::dst` followed by a top-level `namespace import
 ::A::*`, `namespace origin ::dst::x` is `::A::x` and `::dst::p` raises `can't

--- a/docs/design/import-order-source-graph.md
+++ b/docs/design/import-order-source-graph.md
@@ -1,37 +1,48 @@
 # A load-order partial order from the `source` / `package require` graph
 
-Design sketch for the single remaining abstention shared by the whole
-wildcard-import gating family (#1104 item 3, #1116 items 3 and 6, and the
-cross-file half of every rule in
+The load order shared by the whole wildcard-import gating family (#1104 item
+3, #1116 items 3 and 6, and the cross-file half of every rule in
 [`contracts/command-resolution.md`](contracts/command-resolution.md)'s import
-section). **Nothing here is implemented.** This note records which facts the
-analyser and the index already hold, what a partial load order would need on
-top of them, which abstentions it would lift, and what it would cost.
+section).
 
-## 1. The abstention, stated once
+**Status: implemented.** `tcl_lsp_core::source_graph::RunOrder` is the
+relation §6 calls for; `WorkspaceIndex::run_order` builds it once per
+`generation()` from the host's resolver
+(`WorkspaceIndex::set_source_resolver`), and both wildcard-import tiers rank
+their events with it through the two shared decision functions. Sections 1–5
+below record the facts and the reasoning the design rests on; §6 is the shape
+that was built.
 
-Both LSP resolution tiers order import-lifecycle events by **byte offset
-within one document**, via
+## 1. The abstention, and what lifted it
+
+Both LSP resolution tiers used to order import-lifecycle events by **byte
+offset within one document**, via
 `tcl_compiler::analyser::indirection::in_effect_within`. Across documents
-they order nothing, because nothing in a Tcl source tree says which file runs
-first. Every cross-file event is therefore passed to the shared decision
-functions (`namespace_import::exported_at_import_site`,
-`namespace_import::alias_live_at`) with `at: None`, and those abstain toward
-*answering*:
+they ordered nothing, because nothing in a Tcl source tree says which file
+runs first in general. Every cross-file event was passed to the shared
+decision functions (`namespace_import::exported_at_import_site`,
+`namespace_import::alias_live_at`) with `at: None`, and those abstained
+toward *answering*:
 
-| Fact in another file | Today |
-|---|---|
-| `namespace export p` | counts (the import may resolve) |
-| `namespace export -clear` | revokes nothing |
-| `namespace import` (an install) | counts |
-| `namespace forget` | revokes nothing |
-| a second import of the same name | never conflicts (#1116 item 6) |
+| Fact in another file | Before | With the `source` order |
+|---|---|---|
+| `namespace export p` | counts (the import may resolve) | counts when the graph proves it ran first; **does not** when it proves it ran later |
+| `namespace export -clear` | revokes nothing | revokes when it provably ran between the export and the import |
+| `namespace import` (an install) | counts | counts, now as a fact |
+| `namespace forget` | revokes nothing | revokes when it provably ran before the call |
+| a second import of the same name | never conflicts (#1116 item 6) | conflicts when its site provably ran first (`cmp_run`) |
 
-Each row is one-directional leniency. The genuinely-sequenced idiom
-`source lib.tcl ; namespace forget ::lib::p` gets *both* halves wrong: the
-install from `lib.tcl` counts (right), and the forget beside it revokes
-nothing (wrong). One partial order fixes the whole table at once, which is
-why it is worth doing as one piece of work rather than five.
+Each old row was one-directional leniency. The genuinely-sequenced idiom
+`source lib.tcl ; namespace forget ::lib::p` got *both* halves wrong: the
+install from `lib.tcl` counted (right), and the forget beside it revoked
+nothing (wrong). One relation fixed the whole table at once, which is why it
+was worth doing as one piece of work rather than five.
+
+Everywhere the graph does **not** prove an order — different trees, a
+re-sourced file, a `source` cycle, a computed `source $dir/x.tcl`, or a host
+that installs no resolver — the old column still applies, unchanged and by
+construction: `RunOrder` answers `None`, and `None` folds to exactly the
+abstention `at: None` expressed.
 
 ## 2. What is already recorded
 
@@ -156,6 +167,22 @@ index's public shape) or the order is built lazily behind the same
 argument. The second is the smaller change and matches `live_command_links`'s
 existing pattern.
 
+**What was built:** the resolver is held *on the index* as a plain `fn`
+pointer (`WorkspaceIndex::set_source_resolver`, installed by the server's
+`new_workspace_index`), and the order is a `Derived<RunOrder>` view like the
+rest. Taking the resolver as a per-call argument would have meant threading it
+through every caller of `resolve_wildcard_import` and every derived view that
+builds a `WildcardImportIndex` — the order is consulted *inside* the per-call
+import walk, not at its entry point. A `fn` pointer rather than a boxed
+closure keeps the index `Debug + Clone + Default` with no manual impls, and
+the resolver is a pure function of `(parent uri, raw path)` in every host.
+
+An index with **no** resolver installed derives an empty order, and every
+tier then behaves byte-identically to the pre-#1104-item-3 code. That is the
+property the unit suite pins (`without_a_resolver_the_same_workspace_keeps_abstaining`),
+and it is why the change could land without re-baselining the existing
+cross-document tests.
+
 **A trivial subset was considered and rejected for this round.** "Same
 document `source a.tcl` written before an import of a namespace `a.tcl`
 declares" still needs (1) the raw path resolved to a URI, which only the
@@ -163,18 +190,19 @@ server can do, and (2) that resolution reaching into `exports_name_at` /
 `alias_live_at`, i.e. the whole plumbing above. There is no subset that is
 provable without the resolver, so the work does not decompose below §3.1.
 
-## 6. Direction if it is built
+## 6. The shape that was built
 
 Keep the discipline the family already has: **one** decision function per
-question, both tiers calling it. The order belongs behind a single predicate
-with the shape
+question, both tiers calling it. The order lives behind a single relation with
+the shape
 
 ```rust
-fn has_run(&self, event: (uri, at, enclosing_body), query: (uri, at, enclosing_body)) -> Option<bool>
+fn has_run(&self, event: RunPoint<'_>, query: RunPoint<'_>) -> Option<bool>
 ```
 
-— `None` meaning "no static order", which is what the existing `at: None`
-event encoding already expresses.
+— `None` meaning "no static order", which is what the old `at: None` event
+encoding expressed. `RunPoint` is the `(uri, at, enclosing_body)` triple every
+event and query point already carried as loose fields.
 
 ### 6.1 `has_run` alone is not enough — the fold needs *comparability*
 
@@ -203,8 +231,20 @@ fn cmp_run(&self, a: (uri, at, enclosing_body), b: (uri, at, enclosing_body)) ->
 ```
 
 with `None` — incomparable — folding to "abstain toward answering", the same
-direction `at: None` takes now. `has_run` is then `cmp_run(event, query)`
+direction `at: None` took. `has_run` is then `cmp_run(event, query)`
 against the existing body-leniency rule, so one relation serves both.
+
+**As implemented**, both are thin readings of one private projection,
+`RunOrder::common_frame(a, b) -> Option<(Placed, Placed)>`, which reduces two
+points to positions in their deepest common document. `has_run` then applies
+`indirection::in_effect_within` there and `cmp_run` applies
+`namespace_import::load_order` — the *same* two single-document rules the
+tiers used before, now with a wider domain. The folds do not use `cmp_run` at
+all: the leniency a removal needs is `has_run`'s, not `load_order`'s (a
+maybe-never-run body statement must not be counted as having definitely run
+*after* an install), so `ran_after(a, b)` is defined as
+`has_run(a, b) == Some(false)` and the strict `cmp_run` is reserved for the
+import-conflict rule, which inverts the sign — see `namespace_import::load_order`.
 
 ### 6.2 The shape that makes `cmp_run` total where it matters
 
@@ -230,6 +270,19 @@ This keeps the whole order behind one relation and needs no numeric flattening
 (no rank arithmetic to invalidate per generation): the paths are `O(depth)`,
 and depth is the `source` nesting of a real project.
 
-Every current caller then keeps its shape, the shared decision functions gain
+Every current caller keeps its shape, the shared decision functions gained
 their comparator instead of assuming one, and the abstention table in §1
-shrinks without a second rule appearing anywhere.
+shrank without a second rule appearing anywhere.
+
+Two implementation notes on the abstentions:
+
+- **Ambiguity is inherited.** A document below a re-sourced one has no unique
+  position either, so `RunOrder::build` propagates the mark down the tree
+  rather than only marking the doubly-entered file.
+- **Two events in one *foreign* file are ranked against each other even
+  though neither is ranked against the query.** A file's statements run
+  consecutively, so a `namespace export p` followed by a `namespace export
+  -clear` in one other file revokes — a precision win that needs no `source`
+  edge at all, and one the old one-`Option<u32>`-per-event encoding could not
+  express because it collapsed "which file" and "where in it" into a single
+  absent offset.

--- a/docs/design/import-order-source-graph.md
+++ b/docs/design/import-order-source-graph.md
@@ -163,11 +163,12 @@ regression that forced it). Adding a graph reachability query per event would
 put it straight back. The shape that fits is a **precomputed order** built
 once per `generation()`:
 
-- resolve every literal `source` edge once → `O(sources)` with the server's
-  resolver;
-- topologically order the DAG → `O(V + E)`;
-- store, per document, its position and the offsets at which each child is
-  entered, so the three cases in §3.2 are `O(1)` lookups.
+- resolve every `source` edge the host can place once → `O(sources)` with the
+  host's resolver;
+- walk each document to its root once → `O(V · depth)`, storing its root-ward
+  path of `source`-statement positions;
+- compare two events by walking those two paths — `O(depth)`, and depth is the
+  `source` nesting of a real project.
 
 The one thing that cannot be precomputed cheaply is the *server-supplied
 resolver*: `WorkspaceIndex` deliberately holds no filesystem knowledge, so
@@ -185,7 +186,10 @@ through every caller of `resolve_wildcard_import` and every derived view that
 builds a `WildcardImportIndex` — the order is consulted *inside* the per-call
 import walk, not at its entry point. A `fn` pointer rather than a boxed
 closure keeps the index `Debug + Clone + Default` with no manual impls, and
-the resolver is a pure function of `(parent uri, raw path)` in every host.
+the resolver is a pure function of `(parent uri, raw path, is_literal)` in
+every host — `WorkspaceIndex::SourceResolver`, the signature `source_seed_map`
+already took, so one host resolver serves both and the order inherits the M9
+tier's statically-foldable computed-path half for free.
 
 An index with **no** resolver installed derives an empty order, and every
 tier then behaves byte-identically to the pre-#1104-item-3 code. That is the

--- a/docs/design/import-order-source-graph.md
+++ b/docs/design/import-order-source-graph.md
@@ -132,17 +132,27 @@ lexical `.`/`..` folding, no filesystem access).
 
 ## 4. Which abstentions it lifts
 
-| Issue | Abstention | Lifted by |
+| Issue | Abstention | Status |
 |---|---|---|
-| #1104 item 3 | foreign `namespace export` patterns always count; foreign `-clear`s never revoke | §3.2 all three cases |
-| #1116 item 6 | two imports of one name in different files never conflict | §3.2, case 2 (the earlier file's import is known to have run) |
-| #1116 (finding 1 note) | `source lib.tcl ; namespace forget ::lib::p` — install counts, forget revokes nothing | §3.2, cases 2 and 3 together |
-| #1116 item 1 | in-document `-force` shadow with the export in another file | *not* lifted by ordering — it is an *observability* question, answered by the workspace tier's `observable_namespaces` |
+| #1104 item 3 | foreign `namespace export` patterns always count; foreign `-clear`s never revoke | **lifted** — `RunOrder::has_run`, all three §3.2 cases |
+| #1116 item 6 | two imports of one name in different files never conflict | **lifted** — `RunOrder::cmp_run` in `WildcardImportIndex::conflicting_alias_at` |
+| #1116 (finding 1 note) | `source lib.tcl ; namespace forget ::lib::p` — install counts, forget revokes nothing | **lifted** — §3.2 cases 2 and 3 together |
+| #1116 item 1 | in-document `-force` shadow with the export in another file | *not* lifted by ordering — it is an *observability* question, answered by the workspace tier's whole-program export view, which has to be threaded through `resolve_called_proc` |
 | #1116 item 4 | import-error control flow (a failed import aborts the rest of its script) | *not* lifted — a different model (intra-script abort), though it shares the "what has run" vocabulary |
 
 Note the two negatives. A load order says *when* a statement ran; it does not
 say whether a statement exists in a file nobody indexed, and it does not model
 a script aborting part-way. Those stay separate.
+
+**Measured reach.** Over the repository's Tcl corpora — Tcl 9.0.4's own
+`library/`, `samples/`, and the multi-file editor/CLI fixtures: 247 documents,
+19 `source` statements of which 3 resolve to an indexed document, 13 752 bare
+call sites — the order changes **0** resolutions. Real Tcl code overwhelmingly
+writes `source [file join $tcl_library init.tcl]`, whose `$tcl_library` no
+static fold can place, so no edge is built and the pre-existing abstention
+stands. The order is therefore a strict refinement that fires only where a
+load order is genuinely provable; the cases where it does fire are pinned by
+unit and end-to-end tests rather than by the corpus.
 
 ## 5. Cost, and why this is not a one-liner
 

--- a/docs/kcs/features/kcs-feature-definition.md
+++ b/docs/kcs/features/kcs-feature-definition.md
@@ -66,9 +66,20 @@ Ordering follows the same load-order rule renames and aliases do. An import
 written **inside a proc or method body** sees every top-level statement of its
 own file, wherever written — the file loads before any body runs — so an
 export further down the file still counts; an export written after the import
-*in that same body* does not. Ordering only exists inside one document; when
-the import and the export are in different files, nothing fixes which loads
-first, so navigation keeps answering rather than guessing a revocation.
+*in that same body* does not.
+
+Across files the order comes from `source`. Sourcing a file runs the whole of
+it at the `source` statement, so a file sourced earlier has finished before a
+file sourced later starts, and Go to Definition uses that: an export in a file
+sourced **before** the importing one counts, and one in a file sourced
+**after** it does not — the import ran first and bound nothing. A `namespace
+forget` written beside a `source` revokes what that `source` installed. Where
+no `source` path joins the two files, nothing fixes which loads first, and
+navigation keeps answering rather than guessing a revocation. The same applies
+when the order cannot be trusted: a file sourced from two different places has
+no single position, a `source` path built at run time (`source $dir/x.tcl`,
+unless it folds to a fixed path) names no file, and a `source` loop is not an
+order at all.
 
 A call written **before** its own `namespace import` reaches nothing, and Go to
 Definition says so: the import has not run yet, exactly as a `rename` written

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -4768,6 +4768,58 @@ mod tests {
         );
     }
 
+    /// FN guard pinning #1104's dynamic-export note — the export-side twin of
+    /// [`a_dynamic_forget_pattern_revokes_nothing`], and the same sign
+    /// argument.
+    ///
+    /// `namespace export $pat` really does export whatever `$pat` expands to,
+    /// but nothing static says what that is and the word is a *glob*. The
+    /// scanner therefore records no pattern at all
+    /// (`Analyser::handle_namespace_export` skips a word containing `$` or
+    /// `[`), so the import takes a snapshot that does not cover the name and
+    /// the resolver abstains. That is the safe direction here precisely
+    /// because the sign is inverted from the forget case: a *guessed export*
+    /// can only add names an import never took, inventing a definition the
+    /// program has no path to.
+    ///
+    /// The abstention costs a real answer, which is why it is pinned rather
+    /// than merely documented — a future change that starts guessing here
+    /// will fail this test, not silently start resolving.
+    #[test]
+    fn a_dynamic_export_pattern_exports_nothing() {
+        let dynamic = "set pat p\nnamespace eval src {\n    proc p {} { return P }\n    namespace export $pat\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
+        let analysis = analyse(dynamic);
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        assert!(
+            hit.is_none(),
+            "a dynamic export pattern must not be guessed into a covering export: {hit:?}"
+        );
+        // Control — the same source with the pattern written literally does
+        // export, so the difference is the substitution and nothing else.
+        let literal = dynamic.replace("namespace export $pat", "namespace export p");
+        let analysis = analyse(&literal);
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX)
+                .is_some_and(|p| p.qualified_name == "::src::p"),
+            "the literal spelling of the same export does resolve"
+        );
+    }
+
+    /// TN for the interaction the dynamic-export abstention has with a
+    /// tombstone (#1104's minor note): a `namespace export -clear` written
+    /// after a dynamic pattern leaves the snapshot empty either way, so the
+    /// unrecorded pattern costs nothing there — the abstention is only ever
+    /// visible *before* a clear, which the test above covers.
+    #[test]
+    fn a_clear_after_a_dynamic_export_is_still_empty() {
+        let src = "set pat p\nnamespace eval src {\n    proc p {} { return P }\n    namespace export $pat\n    namespace export -clear\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
+        let analysis = analyse(src);
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX).is_none(),
+            "a `-clear` after any export leaves nothing exported"
+        );
+    }
+
     #[test]
     fn a_simple_forget_pattern_removes_the_alias_too() {
         // TN — `Tcl_ForgetImport`'s unqualified branch: the pattern is matched

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -3238,6 +3238,11 @@ fn live_import_at(
     // Only the winning source's own installs order against its removals: an
     // import of the same name from a *different* namespace is a different
     // edge, and letting it out-date this edge's forget would resurrect it.
+    // The install carries its enclosing body, the removals do not — not an
+    // oversight: the fold reads a body span only off the point it is ranking
+    // *against* (`ran_after(removal, install)` asks whether the removal had run
+    // at the install), and a removal is never that point. Computing one per
+    // removal would be a body scan that decides nothing.
     let install_point = |at: u32| in_document_point(analysis, at);
     let removal_point = |at: u32| RunPoint {
         uri: IN_DOCUMENT_URI,
@@ -4817,6 +4822,44 @@ mod tests {
         assert!(
             proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX).is_none(),
             "a `-clear` after any export leaves nothing exported"
+        );
+    }
+
+    /// TP (both tiers agree): a `namespace forget` at the file's **load
+    /// level** runs before a body-local `namespace import`, which then
+    /// installs the alias — so a call in that body still resolves.
+    ///
+    /// The in-document twin of
+    /// `workspace_index::tests::a_body_local_exact_import_survives_a_top_level_forget`.
+    /// Ranking the two by raw offset said the forget "came later" and dropped
+    /// the alias; the load-order rule the shared fold now uses reads a removal
+    /// written outside the import's own body as having run before it, which is
+    /// what actually happens — the whole file loads, forget included, before
+    /// any body runs. Oracle (8.6.14 / 9.0.4): with `proc ::dst::setup {}
+    /// {namespace import ::src::* ; p}` and a top-level `namespace eval ::dst
+    /// {namespace forget ::src::p}` below it, `::dst::setup` returns `P` — the
+    /// forget ran during load, found nothing imported, and the import inside
+    /// the body then installed the alias the call reaches.
+    #[test]
+    fn a_load_level_forget_before_a_body_local_import_revokes_nothing() {
+        let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    proc setup {} { namespace import ::src::* ; p }\n}\nnamespace eval dst {\n    namespace forget ::src::p\n}\n";
+        let analysis = analyse(src);
+        let call =
+            u32::try_from(src.rfind("; p }").expect("call in source") + 2).expect("tiny source");
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", call);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::src::p"),
+            "the body-local import runs after the load-level forget and reinstalls: {hit:?}"
+        );
+        // FN guard — a forget written *inside that same body*, after the
+        // import, is an ordinary later statement and does revoke.
+        let inner = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    proc setup {} { namespace import ::src::* ; namespace forget ::src::p ; p }\n}\n";
+        let analysis = analyse(inner);
+        let call =
+            u32::try_from(inner.rfind("; p }").expect("call in source") + 2).expect("tiny source");
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, "dst", "p", call).is_none(),
+            "a forget in the same body before the call does revoke"
         );
     }
 

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -116,6 +116,7 @@ use tcl_compiler::analyser::indirection;
 use tcl_lexer::{LineIndex, Utf16Col};
 
 use crate::hover::{find_var_at_position, find_word_span_at_position};
+use crate::source_graph::{RunOrder, RunPoint};
 
 /// LSP `Range` analogue — line/character pairs in UTF-16 code
 /// units per the LSP spec.
@@ -3237,6 +3238,12 @@ fn live_import_at(
     // Only the winning source's own installs order against its removals: an
     // import of the same name from a *different* namespace is a different
     // edge, and letting it out-date this edge's forget would resurrect it.
+    let install_point = |at: u32| in_document_point(analysis, at);
+    let removal_point = |at: u32| RunPoint {
+        uri: IN_DOCUMENT_URI,
+        at,
+        enclosing_body: None,
+    };
     let mut log = events
         .iter()
         .filter_map(|ev| match *ev {
@@ -3247,30 +3254,58 @@ fn live_import_at(
                 .any(|&(i, _)| i == at)
                 .then_some(AliasEvent {
                     kind: AliasEventKind::Install,
-                    at: Some(at),
+                    at: install_point(at),
                 }),
             SlotEvent::Forget { at, source_ns: s } if forget_covers(s, source_ns) => {
                 Some(AliasEvent {
                     kind: AliasEventKind::Remove,
-                    at: Some(at),
+                    at: removal_point(at),
                 })
             }
             SlotEvent::Destroy { at, source_ns: s } if s == source_ns => Some(AliasEvent {
                 kind: AliasEventKind::Remove,
-                at: Some(at),
+                at: removal_point(at),
             }),
             SlotEvent::Declare { at } => Some(AliasEvent {
                 kind: AliasEventKind::Remove,
-                at: Some(at),
+                at: removal_point(at),
             }),
             _ => None,
         })
         .collect::<Vec<_>>()
         .into_iter();
-    crate::namespace_import::alias_live_at(&mut log, &|at| {
-        indirection::in_effect(analysis, at, call_off)
-    })
+    crate::namespace_import::alias_live_at(
+        &mut log,
+        &RunOrder::default(),
+        Some(in_document_point(analysis, call_off)),
+    )
     .then(|| source_ns.to_owned())
+}
+
+/// The document key every in-document import event carries.
+///
+/// This tier holds exactly one document, so the *identity* of the key is
+/// irrelevant — what matters is that every point shares it, which is what makes
+/// [`crate::source_graph::RunOrder`] fall through to the single-document rule
+/// ([`tcl_compiler::analyser::indirection::in_effect_within`]) without
+/// consulting any graph. The cross-document tier passes real URIs to the same
+/// functions, so the two cannot drift.
+/// The order the in-document tier passes with them: **empty**. One document
+/// needs no `source` graph — every point shares [`IN_DOCUMENT_URI`], so
+/// [`crate::source_graph::RunOrder`] answers from the single-document rule
+/// alone and never looks at an edge. Building it allocates nothing.
+const IN_DOCUMENT_URI: &str = "";
+
+/// An offset in the document being analysed, as a
+/// [`crate::source_graph::RunPoint`] — with the enclosing definition body the
+/// load-order rule needs, which is the only thing
+/// [`indirection::in_effect`] reads out of the analysis.
+fn in_document_point(analysis: &AnalysisResult, at: u32) -> RunPoint<'static> {
+    RunPoint {
+        uri: IN_DOCUMENT_URI,
+        at,
+        enclosing_body: analysis.innermost_definition_body_span(at),
+    }
 }
 
 /// Every [`SlotEvent`] bearing on `<importing_ns>::<word>` in this document,
@@ -3431,11 +3466,23 @@ pub(crate) fn exported_at_import(
         .map(|e| crate::namespace_import::ExportEvent {
             pattern: &e.pattern,
             clears: e.clears,
-            at: Some(e.range.start()),
+            // No enclosing-body span: the index stores none per export row
+            // either, so both tiers rank a `-clear` against a pattern by
+            // position alone. Symmetric, and the safe direction — a
+            // body-local export the tombstone cannot be proven to follow
+            // keeps the name exported.
+            at: RunPoint {
+                uri: IN_DOCUMENT_URI,
+                at: e.range.start(),
+                enclosing_body: None,
+            },
         });
-    crate::namespace_import::exported_at_import_site(&mut events, word, &|at| {
-        indirection::in_effect(analysis, at, import_at)
-    })
+    crate::namespace_import::exported_at_import_site(
+        &mut events,
+        word,
+        &RunOrder::default(),
+        in_document_point(analysis, import_at),
+    )
 }
 
 /// Whether the call at `call_off` in `namespace` reaches `def_qualified`

--- a/rust/tcl-lsp-core/src/namespace_import.rs
+++ b/rust/tcl-lsp-core/src/namespace_import.rs
@@ -71,17 +71,16 @@
 //! `WorkspaceCommandLink` an exact import produces is only live while this
 //! function admits it (`WorkspaceIndex::live_command_links`).
 //!
-//! What *is* tier-specific is the primitive
-//! "had this event already run when the import executed?", which the caller
-//! supplies as `visible`:
+//! The primitive "had this event already run when the import executed?" is no
+//! longer tier-specific either: both tiers hand these functions the workspace's
+//! [`crate::source_graph::RunOrder`] and the point being asked about, and the
+//! relation answers all three cases from the same rule:
 //!
-//! - Same document: `analyser::indirection::in_effect`, so a declaration
+//! - Same document: `analyser::indirection::in_effect_within`, so a declaration
 //!   inside a proc body is judged by the same load-order rule the rename /
-//!   alias timeline uses.
-//! - Cross-document, same file as the import:
-//!   `analyser::indirection::in_effect_within` — the *identical* rule, stated
-//!   over the two facts the index stores per row (the import's offset and the
-//!   innermost proc/class body containing it). A plain offset comparison is
+//!   alias timeline uses. (The in-document tier reaches it by giving every
+//!   event the document's own key; `in_effect(analysis, …)` is that same rule
+//!   with the body span read out of the analysis.) A plain offset comparison is
 //!   **not** good enough and was a real tier divergence (PR #1102 review): an
 //!   import written inside a body genuinely observes a top-level export
 //!   written later in the same file, because the whole file loads before any
@@ -89,13 +88,26 @@
 //!   setup {} {namespace import ::mymod::*}; proc run {} {helper}}` followed
 //!   by `namespace eval ::mymod {namespace export helper}`, then
 //!   `::app::setup; ::app::run` → `HELP`.
-//! - **Different file from the import: not ordered at all.** Which file loads
-//!   first is not a static fact, so such an event is passed with
-//!   [`ExportEvent::at`] `None`, and this module abstains toward the safer
-//!   side *for navigation*: an unordered pattern still counts (keep answering
-//!   go-to-definition / find-references, the pre-#1027 behaviour), while an
-//!   unordered `-clear` does **not** revoke anything (revoking on a guess
-//!   would silently drop real references).
+//! - **Different file from the import: ordered only where the `source` graph
+//!   proves an order** ([`crate::source_graph::RunOrder`], issue #1104 item
+//!   3). Sourcing a file inlines its whole body at the `source` statement's
+//!   position, so the DFS of the `source` forest *is* the run order and two
+//!   events in one tree are genuinely comparable. Everywhere else — different
+//!   trees, a re-sourced file, a `source` cycle — nothing is ordered and this
+//!   module abstains toward the safer side *for navigation*: an unrankable
+//!   pattern still counts (keep answering go-to-definition / find-references,
+//!   the pre-#1027 behaviour), while an unrankable `-clear` does **not**
+//!   revoke anything (revoking on a guess would silently drop real
+//!   references).
+//!
+//!   Two events written in the **same** foreign file were always ordered
+//!   against each other even before the graph existed — a file's statements
+//!   run consecutively — so a `namespace export p` followed by a `namespace
+//!   export -clear` in one other file now revokes, where the old
+//!   one-`Option<u32>`-per-event encoding could only say "unordered" about
+//!   both and kept the export. What stays unknown is where *this* import sits
+//!   relative to that file, and the pattern-versus-tombstone question does not
+//!   depend on it.
 //!
 //! # The edge has a lifetime, not just a birth
 //!
@@ -130,6 +142,7 @@
 //! Every one of those rows is oracle-confirmed byte-identically on tclsh
 //! 9.0.4 and 8.6.14; the transcripts sit on the individual items.
 
+use crate::source_graph::{RunOrder, RunPoint};
 use tcl_syntax::glob::string_match;
 
 /// One `namespace export` event as either tier sees it.
@@ -140,74 +153,92 @@ pub struct ExportEvent<'a> {
     pub pattern: &'a str,
     /// `true` for a `namespace export -clear` tombstone.
     pub clears: bool,
-    /// Byte offset of the event *when it is ordered relative to the import
-    /// site* — i.e. when both are in the same document. `None` when the two
-    /// sit in different files, whose relative load order is not a static
-    /// fact.
-    pub at: Option<u32>,
+    /// Where the event sits in the workspace's execution timeline. Ordering it
+    /// against anything else is [`RunOrder`]'s job — within one document
+    /// always, and across documents wherever the `source` graph proves a load
+    /// order (issue #1104 item 3).
+    pub at: RunPoint<'a>,
+}
+
+/// Whether `later` is **known** to have run strictly after `earlier`.
+///
+/// The one direction both folds below need, stated once over
+/// [`RunOrder::has_run`] so the gate ("had this run by the query point?") and
+/// the ranking ("which of these two ran later?") cannot mean different things.
+/// `has_run(later, earlier) == Some(false)` reads "at the moment `earlier`
+/// ran, `later` had not" — which is precisely "`later` came after".
+///
+/// Incomparable answers `false`: a removal that cannot be placed revokes
+/// nothing, the abstain-toward-answering direction this whole family takes.
+fn ran_after(order: &RunOrder, later: RunPoint<'_>, earlier: RunPoint<'_>) -> bool {
+    order.has_run(later, earlier) == Some(false)
+}
+
+/// Whether an event had already run at the query point, abstaining toward
+/// *yes* when the two have no static order.
+fn in_effect_at(order: &RunOrder, event: RunPoint<'_>, query: Option<RunPoint<'_>>) -> bool {
+    query.is_none_or(|q| order.has_run(event, q).unwrap_or(true))
 }
 
 /// Whether the source namespace exported `name` **at the point the import
 /// ran** — the per-import-site snapshot (issue #1027).
 ///
-/// `events` are that namespace's export events, in any order. `visible`
-/// decides, for an ordered event at the given offset, whether it had already
-/// run when the import executed; see the module docs for why that primitive is
-/// the caller's and everything else is not.
+/// `events` are that namespace's export events, in any order; `order` is the
+/// workspace's [`RunOrder`] and `import_site` the position of the import being
+/// judged.
 ///
-/// The rule, applied to the events `visible` admits:
+/// The rule, applied to the events in effect at `import_site`:
 ///
-/// 1. Take the latest visible `-clear` tombstone, if any.
-/// 2. `name` is exported when some visible pattern event *after* that
-///    tombstone glob-matches it (Tcl's own `Tcl_StringMatch` semantics, via
-///    [`tcl_syntax::glob::string_match`] — export patterns are glob patterns:
-///    `namespace export get*` exports `getX` and not `setX`, and
-///    `namespace export {p[ab]}` exports `pa`/`pb` and not `pc`,
-///    oracle-verified).
-/// 3. Failing that, an *unordered* pattern event (a different file from the
-///    import) may still match — unordered `-clear`s revoke nothing.
+/// `name` is exported when some visible pattern event glob-matches it (Tcl's
+/// own `Tcl_StringMatch` semantics, via [`tcl_syntax::glob::string_match`] —
+/// export patterns are glob patterns: `namespace export get*` exports `getX`
+/// and not `setX`, and `namespace export {p[ab]}` exports `pa`/`pb` and not
+/// `pc`, oracle-verified) and **no visible `-clear` tombstone is known to have
+/// run after it**.
+///
+/// That is a *latest-wins* rule stated over a partial order rather than a
+/// total one, which is what lets cross-document events participate at all
+/// (design §6.1): two events the gate admits still have to be ranked against
+/// each other, and a partial order has no `max`. A pattern survives unless
+/// some tombstone provably follows it, so an unrankable tombstone revokes
+/// nothing — the same abstention the old unordered encoding expressed, now
+/// stated once instead of as a special case.
 ///
 /// An export pattern is a name pattern, not a reference to a command, so
 /// nothing here requires the command to exist: `namespace export p` written
 /// before `proc p` still exports `p` (oracle-verified). Whether the command
 /// exists is the caller's own lookup, which it does afterwards.
 ///
-/// Single pass, no sort, no allocation — "some matching pattern sits after the
-/// latest `-clear`" is decided by comparing the *latest matching* pattern's
-/// offset with the latest tombstone's, which needs only two running maxima.
-/// This runs inside the cross-document find-references loop, once per
-/// candidate import per invocation, where the workspace tier already had to
-/// hoist an index out (see
+/// One pass to collect the visible events, then an `O(patterns × clears)`
+/// check over them — both sets are a namespace's own `namespace export`
+/// statements, so in practice one or two of each, and the `Vec`s stay
+/// unallocated when nothing is visible. This runs inside the cross-document
+/// find-references loop, once per candidate import per invocation, where the
+/// workspace tier already had to hoist an index out (see
 /// `WorkspaceIndex::resolve_wildcard_import_indexed`) to keep that path off
 /// the profiler.
 #[must_use]
 pub fn exported_at_import_site(
     events: &mut dyn Iterator<Item = ExportEvent<'_>>,
     name: &str,
-    visible: &dyn Fn(u32) -> bool,
+    order: &RunOrder,
+    import_site: RunPoint<'_>,
 ) -> bool {
-    // Latest visible tombstone, and the latest visible pattern event that
-    // matches `name`.
-    let mut cleared_through: Option<u32> = None;
-    let mut latest_match: Option<u32> = None;
-    let mut unordered_match = false;
+    let mut patterns: Vec<RunPoint<'_>> = Vec::new();
+    let mut clears: Vec<RunPoint<'_>> = Vec::new();
     for ev in events {
-        let Some(at) = ev.at else {
-            unordered_match |= !ev.clears && string_match(ev.pattern, name);
-            continue;
-        };
-        if !visible(at) {
+        if !in_effect_at(order, ev.at, Some(import_site)) {
             continue;
         }
         if ev.clears {
-            cleared_through = cleared_through.max(Some(at));
+            clears.push(ev.at);
         } else if string_match(ev.pattern, name) {
-            latest_match = latest_match.max(Some(at));
+            patterns.push(ev.at);
         }
     }
-    let ordered_match =
-        latest_match.is_some_and(|m| cleared_through.is_none_or(|cleared| m > cleared));
-    ordered_match || unordered_match
+    patterns
+        .iter()
+        .any(|&p| !clears.iter().any(|&c| ran_after(order, c, p)))
 }
 
 /// The **load-order** position of a statement in its own document: `false`
@@ -285,14 +316,12 @@ pub enum AliasEventKind {
 /// ordered, append-only log and read by the same "latest visible event wins"
 /// rule.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct AliasEvent {
+pub struct AliasEvent<'a> {
     /// What the event does.
     pub kind: AliasEventKind,
-    /// Byte offset of the event *when it is ordered relative to the query
-    /// point* — i.e. when both are in the same document. `None` when the two
-    /// sit in different files, whose relative load order is not a static
-    /// fact.
-    pub at: Option<u32>,
+    /// Where the event sits in the workspace's execution timeline; ordered
+    /// against the query point and against the other events by [`RunOrder`].
+    pub at: RunPoint<'a>,
 }
 
 /// Whether the importing namespace still holds a live imported alias at the
@@ -328,25 +357,29 @@ pub struct AliasEvent {
 ///
 /// # The rule
 ///
-/// Symmetric with [`exported_at_import_site`], and for the same reason: the
-/// latest in-effect [`AliasEventKind::Remove`] wins over every install before
-/// it, and an install *after* that removal reinstates the alias (a re-import
-/// after a forget genuinely does — oracle: re-running `namespace import
-/// ::src::*` after a `namespace forget` makes the bare call work again).
-/// Unordered events — from a different file, where no static load order
-/// exists — abstain toward *answering*: an unordered install counts, an
-/// unordered removal revokes nothing, exactly as an unordered `-clear` does
-/// not revoke an export.
+/// Symmetric with [`exported_at_import_site`], and for the same reason: an
+/// install survives unless some in-effect [`AliasEventKind::Remove`] is *known*
+/// to have run after it, and an install after a removal reinstates the alias (a
+/// re-import after a forget genuinely does — oracle: re-running `namespace
+/// import ::src::*` after a `namespace forget` makes the bare call work again).
+/// Events the [`RunOrder`] cannot rank abstain toward *answering*: an
+/// unrankable install counts, an unrankable removal revokes nothing, exactly as
+/// an unrankable `-clear` does not revoke an export.
 ///
-/// # What `in_effect` gates
+/// # What the order gates
 ///
-/// `in_effect` decides, for an ordered event at the given offset, whether it
-/// had already run at the query point — and it is applied to **every** ordered
-/// event, install and removal alike. Both tiers pass the order-gating
-/// primitive they already use for the export snapshot
-/// ([`tcl_compiler::analyser::indirection::in_effect`] /
-/// [`tcl_compiler::analyser::indirection::in_effect_within`]), so "has run by
-/// here" cannot mean two things.
+/// [`RunOrder::has_run`] decides, for each event, whether it had already run at
+/// `query` — and it is applied to **every** event, install and removal alike.
+/// Both tiers pass the same relation, so "has run by here" cannot mean two
+/// things; within one document it *is*
+/// [`tcl_compiler::analyser::indirection::in_effect_within`], the primitive the
+/// `rename` / `interp alias` timeline uses.
+///
+/// `query` is `None` for a caller with no query point of its own — the
+/// whole-index liveness mask over exact import links
+/// (`WildcardImportIndex::link_alias_live`), which asks "does this alias exist
+/// for navigation at all". Every event then counts as having run, and the only
+/// ordering left is each removal's position relative to the install.
 ///
 /// Gating the *install* is what makes a bare call written **before** its own
 /// `namespace import` stop resolving through it (issue #1104 item 1). Oracle
@@ -362,115 +395,170 @@ pub struct AliasEvent {
 /// That gate is *not* a plain offset comparison, and must not be reduced to
 /// one: a call inside a proc body is not ordered against a top-level import of
 /// the same file at all, because the whole file loads — running every
-/// top-level statement, imports included — before any body runs. `in_effect` /
-/// `in_effect_within` already state exactly that rule, which is why both tiers
-/// pass one of them rather than `at < call_off`. A tier that compared offsets
-/// alone would drop every proc body calling a name imported further down its
-/// own file — the overwhelmingly common shape in real code.
+/// top-level statement, imports included — before any body runs.
+/// [`RunOrder::has_run`] states exactly that rule, which is why both tiers pass
+/// it rather than `at < call_off`. A tier that compared offsets alone would
+/// drop every proc body calling a name imported further down its own file —
+/// the overwhelmingly common shape in real code.
 ///
 /// With no install in effect the answer is `false`: nothing had put the alias
 /// there yet. Callers that have already proven an import matches (pattern,
 /// export snapshot, conflict rule) pass it as an [`AliasEventKind::Install`].
 ///
-/// Single pass, two running maxima, no allocation — the same shape and the
-/// same cost as [`exported_at_import_site`], which it runs beside.
+/// The same shape and the same cost as [`exported_at_import_site`], which it
+/// runs beside: one pass to collect the visible events, then an
+/// `O(installs × removals)` check over two sets that hold a handful of
+/// elements each.
 #[must_use]
 pub fn alias_live_at(
-    events: &mut dyn Iterator<Item = AliasEvent>,
-    in_effect: &dyn Fn(u32) -> bool,
+    events: &mut dyn Iterator<Item = AliasEvent<'_>>,
+    order: &RunOrder,
+    query: Option<RunPoint<'_>>,
 ) -> bool {
-    let mut installed: Option<u32> = None;
-    let mut removed: Option<u32> = None;
-    let mut unordered_install = false;
+    let mut installs: Vec<RunPoint<'_>> = Vec::new();
+    let mut removals: Vec<RunPoint<'_>> = Vec::new();
     for ev in events {
-        let Some(at) = ev.at else {
-            unordered_install |= ev.kind == AliasEventKind::Install;
-            continue;
-        };
-        if !in_effect(at) {
+        if !in_effect_at(order, ev.at, query) {
             continue;
         }
         match ev.kind {
-            AliasEventKind::Install => installed = installed.max(Some(at)),
-            AliasEventKind::Remove => removed = removed.max(Some(at)),
+            AliasEventKind::Install => installs.push(ev.at),
+            AliasEventKind::Remove => removals.push(ev.at),
         }
     }
-    let ordered_live = installed.is_some_and(|i| removed.is_none_or(|r| i > r));
-    ordered_live || unordered_install
+    installs
+        .iter()
+        .any(|&i| !removals.iter().any(|&r| ran_after(order, r, i)))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::source_graph::SourceEdge;
 
-    fn ev(pattern: &str, at: u32) -> ExportEvent<'_> {
-        ExportEvent {
-            pattern,
-            clears: false,
-            at: Some(at),
+    /// The document every ordered event in these tests lives in — the
+    /// single-document case both tiers spend almost all their time in.
+    const DOC: &str = "file:///dst.tcl";
+    /// A second document with no `source` path to [`DOC`]: unrankable.
+    const OTHER: &str = "file:///other.tcl";
+
+    fn at(uri: &str, off: u32) -> RunPoint<'_> {
+        RunPoint {
+            uri,
+            at: off,
+            enclosing_body: None,
         }
     }
 
-    fn clear(at: u32) -> ExportEvent<'static> {
+    fn ev(pattern: &str, off: u32) -> ExportEvent<'_> {
+        ExportEvent {
+            pattern,
+            clears: false,
+            at: at(DOC, off),
+        }
+    }
+
+    fn clear(off: u32) -> ExportEvent<'static> {
         ExportEvent {
             pattern: "",
             clears: true,
-            at: Some(at),
+            at: at(DOC, off),
         }
     }
 
-    fn unordered(pattern: &str) -> ExportEvent<'_> {
+    fn foreign(pattern: &str) -> ExportEvent<'_> {
         ExportEvent {
             pattern,
             clears: false,
-            at: None,
+            at: at(OTHER, 0),
         }
     }
 
-    /// `visible` for an import at `import_at`: plain textual order.
-    fn before(import_at: u32) -> impl Fn(u32) -> bool {
-        move |at| at <= import_at
+    /// No `source` statement anywhere — the workspace shape that must behave
+    /// exactly as the pre-#1104-item-3 tiers did.
+    fn unlinked() -> RunOrder {
+        RunOrder::default()
     }
 
     #[test]
     fn export_before_import_is_visible() {
         let mut evs = [ev("p", 10)].into_iter();
-        assert!(exported_at_import_site(&mut evs, "p", &before(20)));
+        assert!(exported_at_import_site(
+            &mut evs,
+            "p",
+            &unlinked(),
+            at(DOC, 20)
+        ));
     }
 
     #[test]
     fn direction_b_export_after_import_is_not_retroactive() {
         // `namespace export p` at 30, import at 20 → not yet exported.
         let mut evs = [ev("p", 30)].into_iter();
-        assert!(!exported_at_import_site(&mut evs, "p", &before(20)));
+        assert!(!exported_at_import_site(
+            &mut evs,
+            "p",
+            &unlinked(),
+            at(DOC, 20)
+        ));
     }
 
     #[test]
     fn direction_a_clear_after_import_does_not_revoke() {
         // export p @10, import @20, `-clear` @30.
         let mut evs = [ev("p", 10), clear(30)].into_iter();
-        assert!(exported_at_import_site(&mut evs, "p", &before(20)));
+        assert!(exported_at_import_site(
+            &mut evs,
+            "p",
+            &unlinked(),
+            at(DOC, 20)
+        ));
     }
 
     #[test]
     fn clear_before_import_does_revoke() {
         let mut evs = [ev("p", 10), clear(15)].into_iter();
-        assert!(!exported_at_import_site(&mut evs, "p", &before(20)));
+        assert!(!exported_at_import_site(
+            &mut evs,
+            "p",
+            &unlinked(),
+            at(DOC, 20)
+        ));
     }
 
     #[test]
     fn clear_then_add_on_the_same_call_keeps_the_new_pattern() {
         // `namespace export a b; namespace export -clear p` → exactly `p`.
-        let mut evs = [ev("a", 5), ev("b", 7), clear(20), ev("p", 27)].into_iter();
-        assert!(exported_at_import_site(&mut evs.clone(), "p", &before(40)));
-        assert!(!exported_at_import_site(&mut evs, "a", &before(40)));
+        let evs = [ev("a", 5), ev("b", 7), clear(20), ev("p", 27)];
+        assert!(exported_at_import_site(
+            &mut evs.into_iter(),
+            "p",
+            &unlinked(),
+            at(DOC, 40)
+        ));
+        assert!(!exported_at_import_site(
+            &mut evs.into_iter(),
+            "a",
+            &unlinked(),
+            at(DOC, 40)
+        ));
     }
 
     #[test]
     fn exports_are_additive_across_calls() {
-        let mut evs = [ev("a", 5), ev("b", 20)].into_iter();
-        assert!(exported_at_import_site(&mut evs.clone(), "a", &before(40)));
-        assert!(exported_at_import_site(&mut evs, "b", &before(40)));
+        let evs = [ev("a", 5), ev("b", 20)];
+        assert!(exported_at_import_site(
+            &mut evs.into_iter(),
+            "a",
+            &unlinked(),
+            at(DOC, 40)
+        ));
+        assert!(exported_at_import_site(
+            &mut evs.into_iter(),
+            "b",
+            &unlinked(),
+            at(DOC, 40)
+        ));
     }
 
     #[test]
@@ -480,23 +568,27 @@ mod tests {
         assert!(exported_at_import_site(
             &mut events.into_iter(),
             "p",
-            &before(20)
+            &unlinked(),
+            at(DOC, 20)
         ));
         assert!(!exported_at_import_site(
             &mut events.into_iter(),
             "q",
-            &before(20)
+            &unlinked(),
+            at(DOC, 20)
         ));
         // Second import at 50: both.
         assert!(exported_at_import_site(
             &mut events.into_iter(),
             "p",
-            &before(50)
+            &unlinked(),
+            at(DOC, 50)
         ));
         assert!(exported_at_import_site(
             &mut events.into_iter(),
             "q",
-            &before(50)
+            &unlinked(),
+            at(DOC, 50)
         ));
     }
 
@@ -506,58 +598,269 @@ mod tests {
         assert!(exported_at_import_site(
             &mut events.into_iter(),
             "getX",
-            &before(20)
+            &unlinked(),
+            at(DOC, 20)
         ));
         assert!(!exported_at_import_site(
             &mut events.into_iter(),
             "setX",
-            &before(20)
+            &unlinked(),
+            at(DOC, 20)
         ));
         let cc = [ev("p[ab]", 10)];
         assert!(exported_at_import_site(
             &mut cc.into_iter(),
             "pa",
-            &before(20)
+            &unlinked(),
+            at(DOC, 20)
         ));
         assert!(!exported_at_import_site(
             &mut cc.into_iter(),
             "pc",
-            &before(20)
+            &unlinked(),
+            at(DOC, 20)
         ));
     }
 
     #[test]
-    fn unordered_pattern_counts_and_unordered_clear_does_not_revoke() {
-        // Export declared in another file: ordering unknown, so it still
-        // resolves…
-        let mut evs = [unordered("p")].into_iter();
-        assert!(exported_at_import_site(&mut evs, "p", &before(0)));
-        // …and a `-clear` from another file cannot silently drop it.
+    fn an_unrankable_pattern_counts_and_an_unrankable_clear_does_not_revoke() {
+        // Export declared in another file with no `source` path to this one:
+        // ordering unknown, so it still resolves…
+        let mut evs = [foreign("p")].into_iter();
+        assert!(exported_at_import_site(
+            &mut evs,
+            "p",
+            &unlinked(),
+            at(DOC, 0)
+        ));
+        // …and a `-clear` from a *third* file cannot silently drop it.
         let mut evs = [
-            unordered("p"),
+            foreign("p"),
             ExportEvent {
                 pattern: "",
                 clears: true,
-                at: None,
+                at: at("file:///third.tcl", 0),
             },
         ]
         .into_iter();
-        assert!(exported_at_import_site(&mut evs, "p", &before(0)));
+        assert!(exported_at_import_site(
+            &mut evs,
+            "p",
+            &unlinked(),
+            at(DOC, 0)
+        ));
     }
 
     #[test]
-    fn an_ordered_clear_does_not_revoke_an_unordered_export() {
+    fn an_ordered_clear_does_not_revoke_an_unrankable_export() {
         // The `-clear` is ordered before the import, but the surviving
         // pattern comes from a file whose load order is unknown — it may well
         // have run after. Navigation keeps answering.
-        let mut evs = [clear(5), unordered("p")].into_iter();
-        assert!(exported_at_import_site(&mut evs, "p", &before(20)));
+        let mut evs = [clear(5), foreign("p")].into_iter();
+        assert!(exported_at_import_site(
+            &mut evs,
+            "p",
+            &unlinked(),
+            at(DOC, 20)
+        ));
+    }
+
+    /// TN, issue #1104 item 3. Two export events written in **one** other file
+    /// were always ordered against each other — a file's statements run
+    /// consecutively — even though where that file sits relative to this
+    /// import is unknown. The old one-`Option<u32>`-per-event encoding could
+    /// only call both "unordered" and kept the export.
+    #[test]
+    fn a_clear_revokes_a_pattern_written_above_it_in_the_same_foreign_file() {
+        let evs = [
+            ExportEvent {
+                pattern: "p",
+                clears: false,
+                at: at(OTHER, 10),
+            },
+            ExportEvent {
+                pattern: "",
+                clears: true,
+                at: at(OTHER, 30),
+            },
+        ];
+        assert!(!exported_at_import_site(
+            &mut evs.into_iter(),
+            "p",
+            &unlinked(),
+            at(DOC, 0)
+        ));
+        // …and the other way round the pattern survives, as it must.
+        let evs = [
+            ExportEvent {
+                pattern: "",
+                clears: true,
+                at: at(OTHER, 10),
+            },
+            ExportEvent {
+                pattern: "p",
+                clears: false,
+                at: at(OTHER, 30),
+            },
+        ];
+        assert!(exported_at_import_site(
+            &mut evs.into_iter(),
+            "p",
+            &unlinked(),
+            at(DOC, 0)
+        ));
     }
 
     #[test]
     fn no_events_means_not_exported() {
         let mut evs = [].into_iter();
-        assert!(!exported_at_import_site(&mut evs, "p", &before(20)));
+        assert!(!exported_at_import_site(
+            &mut evs,
+            "p",
+            &unlinked(),
+            at(DOC, 20)
+        ));
+    }
+
+    // ---- the `source` graph orders what the file boundary did not ---------
+
+    /// The two documents the sourced-order tests use, and the order that
+    /// sequences them: `app.tcl` sources `exp.tcl` and then `imp.tcl`.
+    fn sourced_order() -> RunOrder {
+        RunOrder::build(&[
+            SourceEdge {
+                parent: "file:///app.tcl".to_owned(),
+                child: "file:///exp.tcl".to_owned(),
+                at: 10,
+                enclosing_body: None,
+            },
+            SourceEdge {
+                parent: "file:///app.tcl".to_owned(),
+                child: DOC.to_owned(),
+                at: 20,
+                enclosing_body: None,
+            },
+        ])
+    }
+
+    /// TP (issue #1104 item 3): a `namespace export` in a file the entry point
+    /// sources **before** the importing file counts, as it always did — but
+    /// now as a *fact* rather than an abstention.
+    #[test]
+    fn an_export_in_an_earlier_sourced_file_counts() {
+        let mut evs = [ExportEvent {
+            pattern: "p",
+            clears: false,
+            at: at("file:///exp.tcl", 5),
+        }]
+        .into_iter();
+        assert!(exported_at_import_site(
+            &mut evs,
+            "p",
+            &sourced_order(),
+            at(DOC, 0)
+        ));
+    }
+
+    /// TN (CRITICAL, issue #1104 item 3): the same export in a file sourced
+    /// **after** the importing one has not run when the import executes, so it
+    /// exports nothing to it. This is the leniency the source graph removes.
+    #[test]
+    fn an_export_in_a_later_sourced_file_is_not_retroactive() {
+        // Reverse the order: imp.tcl at 10, exp.tcl at 20.
+        let order = RunOrder::build(&[
+            SourceEdge {
+                parent: "file:///app.tcl".to_owned(),
+                child: DOC.to_owned(),
+                at: 10,
+                enclosing_body: None,
+            },
+            SourceEdge {
+                parent: "file:///app.tcl".to_owned(),
+                child: "file:///exp.tcl".to_owned(),
+                at: 20,
+                enclosing_body: None,
+            },
+        ]);
+        let mut evs = [ExportEvent {
+            pattern: "p",
+            clears: false,
+            at: at("file:///exp.tcl", 5),
+        }]
+        .into_iter();
+        assert!(!exported_at_import_site(&mut evs, "p", &order, at(DOC, 0)));
+    }
+
+    /// TN: a `-clear` in an earlier-sourced file now revokes an export from a
+    /// file sourced before *it* — the second row of #1104 item 3's table.
+    #[test]
+    fn a_clear_in_a_later_sourced_file_revokes_an_earlier_export() {
+        let order = RunOrder::build(&[
+            SourceEdge {
+                parent: "file:///app.tcl".to_owned(),
+                child: "file:///exp.tcl".to_owned(),
+                at: 10,
+                enclosing_body: None,
+            },
+            SourceEdge {
+                parent: "file:///app.tcl".to_owned(),
+                child: "file:///clr.tcl".to_owned(),
+                at: 20,
+                enclosing_body: None,
+            },
+            SourceEdge {
+                parent: "file:///app.tcl".to_owned(),
+                child: DOC.to_owned(),
+                at: 30,
+                enclosing_body: None,
+            },
+        ]);
+        let evs = [
+            ExportEvent {
+                pattern: "p",
+                clears: false,
+                at: at("file:///exp.tcl", 5),
+            },
+            ExportEvent {
+                pattern: "",
+                clears: true,
+                at: at("file:///clr.tcl", 5),
+            },
+        ];
+        assert!(!exported_at_import_site(
+            &mut evs.into_iter(),
+            "p",
+            &order,
+            at(DOC, 0)
+        ));
+        // …and with the import sourced *between* the two, the snapshot it took
+        // still holds — the `-clear` had not run yet.
+        let order = RunOrder::build(&[
+            SourceEdge {
+                parent: "file:///app.tcl".to_owned(),
+                child: "file:///exp.tcl".to_owned(),
+                at: 10,
+                enclosing_body: None,
+            },
+            SourceEdge {
+                parent: "file:///app.tcl".to_owned(),
+                child: DOC.to_owned(),
+                at: 20,
+                enclosing_body: None,
+            },
+            SourceEdge {
+                parent: "file:///app.tcl".to_owned(),
+                child: "file:///clr.tcl".to_owned(),
+                at: 30,
+                enclosing_body: None,
+            },
+        ]);
+        assert!(exported_at_import_site(
+            &mut evs.into_iter(),
+            "p",
+            &order,
+            at(DOC, 0)
+        ));
     }
 
     // ---- load order, for the conflict rule --------------------------------
@@ -594,59 +897,57 @@ mod tests {
 
     // ---- the import edge's own lifecycle (issue #1103) -------------------
 
-    fn install(at: u32) -> AliasEvent {
+    fn install(off: u32) -> AliasEvent<'static> {
         AliasEvent {
             kind: AliasEventKind::Install,
-            at: Some(at),
+            at: at(DOC, off),
         }
     }
 
-    fn remove(at: u32) -> AliasEvent {
+    fn remove(off: u32) -> AliasEvent<'static> {
         AliasEvent {
             kind: AliasEventKind::Remove,
-            at: Some(at),
+            at: at(DOC, off),
         }
     }
 
-    fn unordered_event(kind: AliasEventKind) -> AliasEvent {
-        AliasEvent { kind, at: None }
-    }
-
-    /// `in_effect` for a call at `call_at`: plain textual order.
-    fn ran_before(call_at: u32) -> impl Fn(u32) -> bool {
-        move |at| at < call_at
+    fn unrankable(kind: AliasEventKind) -> AliasEvent<'static> {
+        AliasEvent {
+            kind,
+            at: at(OTHER, 0),
+        }
     }
 
     #[test]
     fn an_import_with_no_removal_is_live() {
         let mut evs = [install(10)].into_iter();
-        assert!(alias_live_at(&mut evs, &ran_before(20)));
+        assert!(alias_live_at(&mut evs, &unlinked(), Some(at(DOC, 20))));
     }
 
     #[test]
     fn nothing_installed_means_no_alias() {
         let mut evs = [remove(10)].into_iter();
-        assert!(!alias_live_at(&mut evs, &ran_before(20)));
+        assert!(!alias_live_at(&mut evs, &unlinked(), Some(at(DOC, 20))));
     }
 
     #[test]
     fn a_forget_after_the_import_kills_the_alias() {
         // import @10, `namespace forget` @15, call @20.
         let mut evs = [install(10), remove(15)].into_iter();
-        assert!(!alias_live_at(&mut evs, &ran_before(20)));
+        assert!(!alias_live_at(&mut evs, &unlinked(), Some(at(DOC, 20))));
     }
 
     #[test]
     fn a_forget_after_the_call_leaves_it_alive() {
         // import @10, call @20, `namespace forget` @30 — the call runs first.
         let mut evs = [install(10), remove(30)].into_iter();
-        assert!(alias_live_at(&mut evs, &ran_before(20)));
+        assert!(alias_live_at(&mut evs, &unlinked(), Some(at(DOC, 20))));
     }
 
     #[test]
     fn a_re_import_after_a_forget_reinstates_the_alias() {
         let mut evs = [install(10), remove(15), install(17)].into_iter();
-        assert!(alias_live_at(&mut evs, &ran_before(20)));
+        assert!(alias_live_at(&mut evs, &unlinked(), Some(at(DOC, 20))));
     }
 
     #[test]
@@ -654,7 +955,7 @@ mod tests {
         // Two forgets; the alias is dead from the first one that follows the
         // last install.
         let mut evs = [install(10), remove(12), remove(15)].into_iter();
-        assert!(!alias_live_at(&mut evs, &ran_before(20)));
+        assert!(!alias_live_at(&mut evs, &unlinked(), Some(at(DOC, 20))));
     }
 
     #[test]
@@ -663,55 +964,102 @@ mod tests {
         // import` reaches nothing (oracle in the function's docs), so an
         // install at 30 with the call at 20 does not install here.
         let mut evs = [install(30)].into_iter();
-        assert!(!alias_live_at(&mut evs, &ran_before(20)));
+        assert!(!alias_live_at(&mut evs, &unlinked(), Some(at(DOC, 20))));
         // The earlier install is the one that counts, and a removal between
         // the two still kills it.
         let mut evs = [install(5), install(30)].into_iter();
-        assert!(alias_live_at(&mut evs, &ran_before(20)));
+        assert!(alias_live_at(&mut evs, &unlinked(), Some(at(DOC, 20))));
         let mut evs = [install(5), remove(10), install(30)].into_iter();
-        assert!(!alias_live_at(&mut evs, &ran_before(20)));
+        assert!(!alias_live_at(&mut evs, &unlinked(), Some(at(DOC, 20))));
     }
 
     #[test]
     fn a_body_local_call_observes_a_later_top_level_install() {
-        // The install gate is `in_effect`, not `at < call_off`: a call inside
-        // a proc body at 20 sees a top-level import at 30, because the whole
-        // file loads before any body runs. Modelled here by the predicate the
-        // real callers pass.
-        let body = tcl_lexer::Span::new(15, 25);
+        // The install gate is the load-order rule, not `at < call_off`: a call
+        // inside a proc body at 20 sees a top-level import at 30, because the
+        // whole file loads before any body runs.
+        let call = RunPoint {
+            uri: DOC,
+            at: 20,
+            enclosing_body: Some(tcl_lexer::Span::new(15, 25)),
+        };
         let mut evs = [install(30)].into_iter();
-        assert!(alias_live_at(&mut evs, &|at| {
-            tcl_compiler::analyser::indirection::in_effect_within(at, 20, Some(body))
-        }));
+        assert!(alias_live_at(&mut evs, &unlinked(), Some(call)));
         // …but an install written inside that same body after the call is an
         // ordinary later statement of the running script.
         let mut evs = [install(22)].into_iter();
-        assert!(!alias_live_at(&mut evs, &|at| {
-            tcl_compiler::analyser::indirection::in_effect_within(at, 20, Some(body))
-        }));
+        assert!(!alias_live_at(&mut evs, &unlinked(), Some(call)));
     }
 
     #[test]
-    fn an_unordered_removal_revokes_nothing() {
-        // A `namespace forget` in another file: no static load order, so
-        // navigation keeps answering rather than dropping a real alias.
-        let mut evs = [install(10), unordered_event(AliasEventKind::Remove)].into_iter();
-        assert!(alias_live_at(&mut evs, &ran_before(20)));
+    fn an_unrankable_removal_revokes_nothing() {
+        // A `namespace forget` in another file with no `source` path to this
+        // one: no static load order, so navigation keeps answering rather than
+        // dropping a real alias.
+        let mut evs = [install(10), unrankable(AliasEventKind::Remove)].into_iter();
+        assert!(alias_live_at(&mut evs, &unlinked(), Some(at(DOC, 20))));
     }
 
     #[test]
-    fn an_unordered_install_counts() {
-        let mut evs = [unordered_event(AliasEventKind::Install)].into_iter();
-        assert!(alias_live_at(&mut evs, &ran_before(20)));
+    fn an_unrankable_install_counts() {
+        let mut evs = [unrankable(AliasEventKind::Install)].into_iter();
+        assert!(alias_live_at(&mut evs, &unlinked(), Some(at(DOC, 20))));
         // …and survives an ordered removal, for the same reason an ordered
-        // `-clear` cannot revoke an unordered export.
-        let mut evs = [unordered_event(AliasEventKind::Install), remove(5)].into_iter();
-        assert!(alias_live_at(&mut evs, &ran_before(20)));
+        // `-clear` cannot revoke an unrankable export.
+        let mut evs = [unrankable(AliasEventKind::Install), remove(5)].into_iter();
+        assert!(alias_live_at(&mut evs, &unlinked(), Some(at(DOC, 20))));
     }
 
     #[test]
     fn no_events_at_all_means_no_alias() {
         let mut evs = [].into_iter();
-        assert!(!alias_live_at(&mut evs, &ran_before(20)));
+        assert!(!alias_live_at(&mut evs, &unlinked(), Some(at(DOC, 20))));
+    }
+
+    /// TP: with no query point every event counts as having run, and the only
+    /// ordering left is the removal's position relative to the install — the
+    /// whole-index liveness mask over exact import links.
+    #[test]
+    fn without_a_query_point_only_the_install_removal_order_matters() {
+        let mut evs = [install(10), remove(30)].into_iter();
+        assert!(!alias_live_at(&mut evs, &unlinked(), None));
+        let mut evs = [install(30), remove(10)].into_iter();
+        assert!(alias_live_at(&mut evs, &unlinked(), None));
+        // A removal that cannot be ranked against the install revokes nothing.
+        let mut evs = [install(10), unrankable(AliasEventKind::Remove)].into_iter();
+        assert!(alias_live_at(&mut evs, &unlinked(), None));
+    }
+
+    /// TN (CRITICAL, #1104 item 3 / #1116 item 6): `source lib.tcl` followed
+    /// by `namespace forget ::lib::p` beside it — the genuinely-sequenced
+    /// idiom that got *both* halves of the abstention wrong. The install from
+    /// `lib.tcl` counts (it always did), and now the forget written after the
+    /// `source` revokes it.
+    #[test]
+    fn a_forget_after_the_source_statement_revokes_the_sourced_install() {
+        let order = RunOrder::build(&[SourceEdge {
+            parent: "file:///app.tcl".to_owned(),
+            child: "file:///lib.tcl".to_owned(),
+            at: 10,
+            enclosing_body: None,
+        }]);
+        let install_in_lib = AliasEvent {
+            kind: AliasEventKind::Install,
+            at: at("file:///lib.tcl", 5),
+        };
+        let forget_in_app = AliasEvent {
+            kind: AliasEventKind::Remove,
+            at: at("file:///app.tcl", 20),
+        };
+        let call = at("file:///app.tcl", 30);
+        let mut evs = [install_in_lib, forget_in_app].into_iter();
+        assert!(!alias_live_at(&mut evs, &order, Some(call)));
+        // …and a call written *between* the two still resolves.
+        let mut evs = [install_in_lib, forget_in_app].into_iter();
+        assert!(alias_live_at(
+            &mut evs,
+            &order,
+            Some(at("file:///app.tcl", 15))
+        ));
     }
 }

--- a/rust/tcl-lsp-core/src/source_graph.rs
+++ b/rust/tcl-lsp-core/src/source_graph.rs
@@ -230,6 +230,273 @@ pub fn ancestor_prefer_latest_raised<S: BuildHasher>(
     entered_raised.contains(target)
 }
 
+/// One statement's position in the workspace's **execution timeline**: the
+/// document it is written in, its byte offset there, and the innermost
+/// proc/class body containing it (`None` at load level).
+///
+/// The three facts every import-lifecycle event and every query point already
+/// carries, named once so [`RunOrder`] can take a pair of them rather than six
+/// loose arguments.  Within one document the triple is exactly what
+/// [`tcl_compiler::analyser::indirection::in_effect_within`] and
+/// [`crate::namespace_import::load_order`] read; across documents it is what
+/// [`RunOrder`] lifts onto the `source` forest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RunPoint<'a> {
+    /// Document the statement is written in.
+    pub uri: &'a str,
+    /// Byte offset of the statement within `uri`.
+    pub at: u32,
+    /// Span of the innermost proc/class body containing it; `None` at load
+    /// level.
+    pub enclosing_body: Option<tcl_lexer::Span>,
+}
+
+/// A position inside **one** document — what [`RunOrder`] reduces a pair of
+/// [`RunPoint`]s to once it has found their deepest common document.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Placed {
+    /// Byte offset within the common document.
+    pub at: u32,
+    /// Enclosing proc/class body of that offset, in the same document.
+    pub enclosing_body: Option<tcl_lexer::Span>,
+}
+
+/// The **load order the `source` graph proves** — the single relation both
+/// wildcard-import tiers rank cross-document events with (issue #1104 item 3,
+/// #1116 item 6; design in `docs/design/import-order-source-graph.md` §6).
+///
+/// # Why an order exists at all
+///
+/// Nothing in a Tcl source tree says which of two files runs first, which is
+/// why every cross-document import-lifecycle event was passed *unordered* and
+/// the shared decision functions abstained toward answering: a foreign
+/// `namespace export` counted, a foreign `namespace export -clear` revoked
+/// nothing, a foreign `namespace forget` revoked nothing.  A `source`
+/// statement is the exception — it is an ordinary statement of the sourcing
+/// file that runs the whole sourced file *at that point*, so the DFS of the
+/// `source` forest **is** the run order, and two statements in one tree are
+/// genuinely comparable.
+///
+/// # The relation
+///
+/// Each point is lifted to its root-ward key: the offsets of the `source`
+/// statements that entered each document down the path, then the point's own
+/// offset.  Two keys are compared element-wise; the first index where they
+/// differ is their **deepest common document**, and there the existing
+/// single-document rules apply unchanged —
+/// [`tcl_compiler::analyser::indirection::in_effect_within`] for
+/// [`Self::has_run`], [`crate::namespace_import::load_order`] for
+/// [`Self::cmp_run`].  One relation, both questions, so the gate and the
+/// conflict rule cannot drift (design §6.1: a `has_run` predicate alone is not
+/// enough — the folds rank events against *each other*, and a partial order
+/// has no `max`).
+///
+/// # Where it abstains, deliberately
+///
+/// `None` — incomparable — everywhere the order is not a *fact*, which the
+/// callers fold to the same "abstain toward answering" direction `at: None`
+/// took before:
+///
+/// - the two documents sit in **different trees** (no `source` path joins
+///   them) — the overwhelmingly common case, and exactly today's behaviour;
+/// - either document is **ambiguous**: reachable by two different `source`
+///   statements, or on a `source` cycle.  Tcl tolerates re-sourcing a file, so
+///   a document with two entry points has no unique position and must not be
+///   given one;
+/// - either document is unknown to the graph.
+///
+/// Two points in the **same** document never consult the graph at all: they
+/// were already ordered, by the same rule, before this type existed.  A
+/// workspace with no resolvable `source` edge therefore behaves byte-identically
+/// to the pre-#1104-item-3 tiers.
+///
+/// Only *literal*, resolvable `source` targets become edges — the caller
+/// filters those — because `source $dir/x.tcl` sequences nothing.  A `source`
+/// written inside a proc body is kept and judged by `in_effect_within` like
+/// any other body-local statement, the same leniency
+/// [`ancestor_prefer_latest_raised`] already applies to the same edges.
+#[derive(Debug, Clone, Default)]
+pub struct RunOrder {
+    /// Root-ward path of every document the graph knows: root-first positions
+    /// of the `source` statements that enter the next document down.  Empty
+    /// for a root.
+    paths: HashMap<String, Vec<Placed>>,
+    /// Root document of every keyed document (itself, for a root).
+    root_of: HashMap<String, String>,
+    /// Documents with no unique position — re-sourced from two sites, or on a
+    /// cycle.  Every cross-document comparison touching one abstains.
+    ambiguous: HashSet<String>,
+}
+
+impl RunOrder {
+    /// Build the order from the workspace's resolved `source` edges.
+    ///
+    /// `edges` are `(parent, child)` with the parent-side position of the
+    /// `source` statement; the caller has already dropped non-literal and
+    /// unresolvable targets.  A child entered from two distinct sites — or from
+    /// itself — is marked ambiguous, as is everything below it and every
+    /// document on a cycle.
+    #[must_use]
+    pub fn build(edges: &[SourceEdge]) -> Self {
+        let mut parent_of: HashMap<&str, (&str, Placed)> = HashMap::new();
+        let mut ambiguous: HashSet<String> = HashSet::new();
+        let mut documents: HashSet<&str> = HashSet::new();
+        for edge in edges {
+            documents.insert(edge.parent.as_str());
+            documents.insert(edge.child.as_str());
+            let entry = Placed {
+                at: edge.at,
+                enclosing_body: edge.enclosing_body,
+            };
+            if edge.parent == edge.child {
+                ambiguous.insert(edge.child.clone());
+                continue;
+            }
+            match parent_of.entry(edge.child.as_str()) {
+                std::collections::hash_map::Entry::Vacant(slot) => {
+                    slot.insert((edge.parent.as_str(), entry));
+                }
+                std::collections::hash_map::Entry::Occupied(slot) => {
+                    // A second, different entry site: no unique position.
+                    if *slot.get() != (edge.parent.as_str(), entry) {
+                        ambiguous.insert(edge.child.clone());
+                    }
+                }
+            }
+        }
+        let mut paths: HashMap<String, Vec<Placed>> = HashMap::new();
+        let mut root_of: HashMap<String, String> = HashMap::new();
+        for &doc in &documents {
+            let mut chain: Vec<Placed> = Vec::new();
+            let mut seen: HashSet<&str> = HashSet::new();
+            let mut cursor = doc;
+            let root = loop {
+                if !seen.insert(cursor) {
+                    // A `source` cycle: no document on it has a position.
+                    for &node in &seen {
+                        ambiguous.insert(node.to_owned());
+                    }
+                    break None;
+                }
+                match parent_of.get(cursor) {
+                    Some(&(parent, entry)) => {
+                        chain.push(entry);
+                        cursor = parent;
+                    }
+                    None => break Some(cursor),
+                }
+            };
+            let Some(root) = root else { continue };
+            // Built child-first; the key is read root-first.
+            chain.reverse();
+            paths.insert(doc.to_owned(), chain);
+            root_of.insert(doc.to_owned(), root.to_owned());
+        }
+        // Ambiguity is inherited: a document below an ambiguous one has no
+        // unique position either.
+        let inherited: Vec<String> = paths
+            .keys()
+            .filter(|doc| {
+                let mut cursor = doc.as_str();
+                while let Some(&(parent, _)) = parent_of.get(cursor) {
+                    if ambiguous.contains(parent) {
+                        return true;
+                    }
+                    cursor = parent;
+                }
+                false
+            })
+            .cloned()
+            .collect();
+        ambiguous.extend(inherited);
+        Self {
+            paths,
+            root_of,
+            ambiguous,
+        }
+    }
+
+    /// Whether the statement at `event` had already run when the statement at
+    /// `query` ran; `None` when the two have no static order.
+    ///
+    /// The gating question — the leniency is
+    /// [`tcl_compiler::analyser::indirection::in_effect_within`]'s, applied in
+    /// the two points' deepest common document: a statement at the load level
+    /// of some document counts as having run for a query inside one of that
+    /// document's proc bodies, however far below it is written, because the
+    /// whole file loads before any body runs.
+    #[must_use]
+    pub fn has_run(&self, event: RunPoint<'_>, query: RunPoint<'_>) -> Option<bool> {
+        let (e, q) = self.common_frame(event, query)?;
+        Some(tcl_compiler::analyser::indirection::in_effect_within(
+            e.at,
+            q.at,
+            q.enclosing_body,
+        ))
+    }
+
+    /// Which of two statements ran first under the **strict** "did this
+    /// definitely already run" order ([`crate::namespace_import::load_order`]);
+    /// `None` when they are incomparable.
+    ///
+    /// The ranking question the latest-wins folds and the import-conflict rule
+    /// need.  Deliberately *not* [`Self::has_run`]'s leniency: a conflict
+    /// cancels an install, so counting a maybe-never-run body statement as
+    /// having run would invent conflicts and drop aliases the program really
+    /// has — the reasoning on [`crate::namespace_import::load_order`].
+    #[must_use]
+    pub fn cmp_run(&self, a: RunPoint<'_>, b: RunPoint<'_>) -> Option<std::cmp::Ordering> {
+        use crate::namespace_import::load_order;
+        let (pa, pb) = self.common_frame(a, b)?;
+        Some(
+            load_order(pa.at, pa.enclosing_body.is_some())
+                .cmp(&load_order(pb.at, pb.enclosing_body.is_some())),
+        )
+    }
+
+    /// Both points as positions in their deepest common document — the single
+    /// projection [`Self::has_run`] and [`Self::cmp_run`] share, so the gate
+    /// and the conflict rule read one relation and differ only in which
+    /// single-document rule they then apply.
+    fn common_frame(&self, a: RunPoint<'_>, b: RunPoint<'_>) -> Option<(Placed, Placed)> {
+        let own = |p: RunPoint<'_>| Placed {
+            at: p.at,
+            enclosing_body: p.enclosing_body,
+        };
+        // Same document: already ordered, and ordered without the graph — a
+        // re-sourced or cyclic file still sequences its own statements.
+        if a.uri == b.uri {
+            return Some((own(a), own(b)));
+        }
+        if self.ambiguous.contains(a.uri) || self.ambiguous.contains(b.uri) {
+            return None;
+        }
+        // Different trees have no order at all — the common case, and exactly
+        // the pre-source-graph behaviour.
+        if self.root_of.get(a.uri)? != self.root_of.get(b.uri)? {
+            return None;
+        }
+        let path_a = self.paths.get(a.uri)?;
+        let path_b = self.paths.get(b.uri)?;
+        for depth in 0..path_a.len().min(path_b.len()) {
+            if path_a[depth] != path_b[depth] {
+                return Some((path_a[depth], path_b[depth]));
+            }
+        }
+        // One path is a prefix of the other: the shallower point's own
+        // document holds the `source` statement that entered the deeper one's
+        // branch, so that statement is the deeper point's position there.
+        Some(match path_a.len().cmp(&path_b.len()) {
+            std::cmp::Ordering::Less => (own(a), path_b[path_a.len()]),
+            std::cmp::Ordering::Greater => (path_a[path_b.len()], own(b)),
+            // Equal-length shared paths with different URIs cannot happen: a
+            // path entry identifies the `source` statement, which identifies
+            // the document it entered.
+            std::cmp::Ordering::Equal => return None,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -439,5 +706,226 @@ mod tests {
             &edges,
             &raises(&[("lib", &[0])])
         ));
+    }
+
+    // ---------------------------------------------------------------------
+    // The `source`-graph load order (issue #1104 item 3, #1116 item 6).
+    //
+    // Oracle for the whole shape, byte-identical on tclsh 8.6.14 and 9.0.4 —
+    // `source` inlines the sourced file's whole body at the `source`
+    // statement's position, so the DFS of the source forest is the run order:
+    //
+    //   # src.tcl:  namespace eval ::src { proc p {} {return P} }
+    //   # exp.tcl:  namespace eval ::src { namespace export p }
+    //   # imp.tcl:  namespace eval ::dst { namespace import ::src::* }
+    //
+    //   # app.tcl:  source src.tcl ; source exp.tcl ; source imp.tcl
+    //   ::dst::p   -> P                       (export ran before the import)
+    //   # app.tcl:  source src.tcl ; source imp.tcl ; source exp.tcl
+    //   ::dst::p   -> invalid command name "::dst::p"   (it did not)
+    // ---------------------------------------------------------------------
+
+    fn point(uri: &str, at: u32) -> RunPoint<'_> {
+        RunPoint {
+            uri,
+            at,
+            enclosing_body: None,
+        }
+    }
+
+    fn body_point(uri: &str, at: u32, body: (u32, u32)) -> RunPoint<'_> {
+        RunPoint {
+            uri,
+            at,
+            enclosing_body: Some(tcl_lexer::Span::new(body.0, body.1)),
+        }
+    }
+
+    /// TP: two files sourced by one parent are ordered by their `source`
+    /// statements — everything in the first has run when the second loads.
+    #[test]
+    fn siblings_are_ordered_by_their_source_statements() {
+        let order = RunOrder::build(&[edge("app", "exp", 10), edge("app", "imp", 20)]);
+        assert_eq!(
+            order.has_run(point("exp", 999), point("imp", 0)),
+            Some(true),
+            "exp.tcl is sourced first, so all of it has run when imp.tcl loads",
+        );
+        assert_eq!(
+            order.has_run(point("imp", 0), point("exp", 999)),
+            Some(false),
+            "…and nothing in imp.tcl has run while exp.tcl is still loading",
+        );
+    }
+
+    /// TP: a parent statement written above the `source` has run inside the
+    /// child; one written below has not.
+    #[test]
+    fn a_parent_statement_is_ordered_against_the_child_body() {
+        let order = RunOrder::build(&[edge("app", "lib", 50)]);
+        assert_eq!(order.has_run(point("app", 10), point("lib", 5)), Some(true));
+        assert_eq!(
+            order.has_run(point("app", 90), point("lib", 5)),
+            Some(false)
+        );
+        // …and the child's own statements have run for a parent statement
+        // written below the `source`.
+        assert_eq!(order.has_run(point("lib", 5), point("app", 90)), Some(true));
+        assert_eq!(
+            order.has_run(point("lib", 5), point("app", 10)),
+            Some(false)
+        );
+    }
+
+    /// TP: the leniency at the common document is `in_effect_within`'s — a
+    /// child sourced from a parent's load level has run for a query inside
+    /// one of that parent's proc bodies, however far below the `source` is
+    /// written.
+    #[test]
+    fn a_body_local_query_observes_a_later_top_level_source() {
+        let order = RunOrder::build(&[edge("app", "lib", 900)]);
+        assert_eq!(
+            order.has_run(point("lib", 5), body_point("app", 10, (0, 20))),
+            Some(true),
+            "the whole file loads — sourcing lib.tcl included — before any body runs",
+        );
+        // …but a `source` written inside that same body, after the query,
+        // is an ordinary later statement of the running script.
+        let order = RunOrder::build(&[SourceEdge {
+            parent: "app".to_owned(),
+            child: "lib".to_owned(),
+            at: 15,
+            enclosing_body: Some(tcl_lexer::Span::new(0, 20)),
+        }]);
+        assert_eq!(
+            order.has_run(point("lib", 5), body_point("app", 10, (0, 20))),
+            Some(false),
+        );
+    }
+
+    /// TP: a grandchild is ordered against a sibling of its parent, through
+    /// the deepest common document.
+    #[test]
+    fn a_grandchild_is_ordered_through_the_common_document() {
+        // app sources exp @10, then mid @20; mid sources leaf @5.
+        let order = RunOrder::build(&[
+            edge("app", "exp", 10),
+            edge("app", "mid", 20),
+            edge("mid", "leaf", 5),
+        ]);
+        assert_eq!(
+            order.has_run(point("exp", 999), point("leaf", 0)),
+            Some(true)
+        );
+        assert_eq!(
+            order.has_run(point("leaf", 0), point("exp", 999)),
+            Some(false)
+        );
+    }
+
+    /// TN: documents in different trees have no order — the pre-source-graph
+    /// behaviour, and what an unrelated pair of files still gets.
+    #[test]
+    fn different_trees_are_incomparable() {
+        let order = RunOrder::build(&[edge("app", "lib", 10), edge("other", "helper", 10)]);
+        assert_eq!(order.has_run(point("lib", 0), point("helper", 0)), None);
+        assert_eq!(order.cmp_run(point("lib", 0), point("helper", 0)), None);
+    }
+
+    /// TN: an empty graph orders nothing across documents…
+    #[test]
+    fn an_empty_graph_orders_nothing_across_documents() {
+        let order = RunOrder::default();
+        assert_eq!(order.has_run(point("a", 0), point("b", 0)), None);
+        // …and a document the graph has never heard of is equally unordered.
+        let order = RunOrder::build(&[edge("app", "lib", 10)]);
+        assert_eq!(order.has_run(point("lib", 0), point("stray", 0)), None);
+    }
+
+    /// TP: two statements in the *same* document stay ordered regardless of
+    /// the graph — the rule that predates this type, unchanged.
+    #[test]
+    fn one_document_is_ordered_without_the_graph() {
+        let order = RunOrder::default();
+        assert_eq!(order.has_run(point("a", 10), point("a", 20)), Some(true));
+        assert_eq!(order.has_run(point("a", 20), point("a", 10)), Some(false));
+        // Even for a re-sourced file, whose cross-document position abstains.
+        let order = RunOrder::build(&[edge("app", "lib", 10), edge("other", "lib", 10)]);
+        assert_eq!(
+            order.has_run(point("lib", 10), point("lib", 20)),
+            Some(true)
+        );
+    }
+
+    /// TN (CRITICAL): a file reachable from two different `source` sites has
+    /// no unique position, so every cross-document comparison touching it
+    /// abstains — Tcl tolerates re-sourcing, and inventing an order would
+    /// silently drop references.
+    #[test]
+    fn a_re_sourced_document_has_no_position() {
+        let order = RunOrder::build(&[edge("app", "lib", 10), edge("app", "lib", 90)]);
+        assert_eq!(order.has_run(point("lib", 0), point("app", 50)), None);
+        // Two different parents, same story.
+        let order = RunOrder::build(&[edge("app", "lib", 10), edge("tool", "lib", 10)]);
+        assert_eq!(order.has_run(point("lib", 0), point("app", 50)), None);
+    }
+
+    /// TN: the ambiguity is inherited — a document below a re-sourced one has
+    /// no unique position either.
+    #[test]
+    fn ambiguity_is_inherited_by_descendants() {
+        let order = RunOrder::build(&[
+            edge("app", "lib", 10),
+            edge("app", "lib", 90),
+            edge("lib", "deep", 5),
+        ]);
+        assert_eq!(order.has_run(point("deep", 0), point("app", 50)), None);
+    }
+
+    /// TN: a `source` cycle gives nothing on it a position, and terminates.
+    #[test]
+    fn a_source_cycle_abstains() {
+        let order = RunOrder::build(&[edge("a", "b", 10), edge("b", "a", 10)]);
+        assert_eq!(order.has_run(point("a", 0), point("b", 0)), None);
+        // A self-`source` likewise.
+        let order = RunOrder::build(&[edge("a", "a", 10), edge("a", "b", 20)]);
+        assert_eq!(order.has_run(point("b", 0), point("a", 50)), None);
+    }
+
+    /// `cmp_run` is the strict order: a body-local statement never counts as
+    /// having run at another document's load level, where `has_run`'s
+    /// leniency says it may have.
+    #[test]
+    fn cmp_run_is_strict_where_has_run_is_lenient() {
+        let order = RunOrder::build(&[edge("app", "lib", 900)]);
+        let body_stmt = body_point("app", 10, (0, 20));
+        // Lenient: the body statement is treated as having run for a query in
+        // the sourced child (the body may have been entered).
+        assert_eq!(order.has_run(body_stmt, point("lib", 5)), Some(true));
+        // Strict: it is *not* known to have run before the child loaded.
+        assert_eq!(
+            order.cmp_run(body_stmt, point("lib", 5)),
+            Some(std::cmp::Ordering::Greater),
+            "a body-local statement sorts after every load-level one",
+        );
+        // Two load-level statements in different files rank by their `source`
+        // statements, which is genuine execution order.
+        let order = RunOrder::build(&[edge("app", "one", 10), edge("app", "two", 20)]);
+        assert_eq!(
+            order.cmp_run(point("one", 999), point("two", 0)),
+            Some(std::cmp::Ordering::Less),
+        );
+    }
+
+    /// Nothing runs before itself, at either level — what keeps an import
+    /// from conflicting with itself once the order spans documents.
+    #[test]
+    fn a_point_does_not_precede_itself() {
+        let order = RunOrder::build(&[edge("app", "lib", 10)]);
+        assert_eq!(
+            order.cmp_run(point("lib", 7), point("lib", 7)),
+            Some(std::cmp::Ordering::Equal),
+        );
+        assert_eq!(order.has_run(point("lib", 7), point("lib", 7)), Some(false));
     }
 }

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -1517,7 +1517,7 @@ pub struct WorkspaceIndex {
     settled_invocations: [Derived<SettledTargets>; 2],
     /// The `source`-path → document-URI resolver, when the host has installed
     /// one — see [`WorkspaceIndex::set_source_resolver`].
-    source_resolver: Option<fn(&str, &str) -> Option<String>>,
+    source_resolver: Option<fn(&str, &str, bool) -> Option<String>>,
     /// The `source`-graph load order derived from it — see
     /// [`WorkspaceIndex::run_order`].
     run_order: Derived<crate::source_graph::RunOrder>,
@@ -1735,13 +1735,18 @@ impl WorkspaceIndex {
     /// [`Self::generation`].
     ///
     /// A plain `fn` pointer rather than a boxed closure: the resolver is a
-    /// pure function of `(parent uri, raw path)` in every host, and a `fn`
-    /// keeps the index `Debug + Clone + Default` with no manual impls.
+    /// pure function of `(parent uri, raw path, is_literal)` in every host, and
+    /// a `fn` keeps the index `Debug + Clone + Default` with no manual impls.
+    /// The signature is [`Self::source_seed_map`]'s, so one host resolver
+    /// serves both — including its statically-foldable computed-path tier
+    /// (`[file join [file dirname [info script]] x.tcl]`), which is as provable
+    /// as a literal and is the idiom real multi-file projects actually write.
+    /// A path the host cannot prove returns `None` and sequences nothing.
     ///
     /// **Without a resolver the order is empty**, and both tiers behave
     /// exactly as they did before the `source` graph existed — every
     /// cross-document event unrankable, every same-document one ordered.
-    pub fn set_source_resolver(&mut self, resolve: fn(&str, &str) -> Option<String>) {
+    pub fn set_source_resolver(&mut self, resolve: fn(&str, &str, bool) -> Option<String>) {
         self.source_resolver = Some(resolve);
         self.run_order = Derived::default();
     }
@@ -1750,9 +1755,9 @@ impl WorkspaceIndex {
     /// most once per [`Self::generation`].
     ///
     /// Empty when no resolver is installed (see [`Self::set_source_resolver`])
-    /// or when no `source` statement resolves. Only **literal** targets become
-    /// edges: `source $dir/x.tcl` names no document statically and sequences
-    /// nothing.
+    /// or when no `source` statement resolves. A target the resolver cannot
+    /// place — `source $dir/x.tcl` with `$dir` unknown — names no document
+    /// statically and sequences nothing.
     fn run_order(&self) -> Arc<crate::source_graph::RunOrder> {
         self.run_order.get_or_build(|| {
             let Some(resolve) = self.source_resolver else {
@@ -1760,13 +1765,14 @@ impl WorkspaceIndex {
             };
             let edges: Vec<crate::source_graph::SourceEdge> = self
                 .sources()
-                .filter(|s| s.is_literal)
                 .filter_map(|s| {
-                    resolve(&s.uri, &s.raw_path).map(|child| crate::source_graph::SourceEdge {
-                        parent: s.uri.clone(),
-                        child,
-                        at: s.range.start(),
-                        enclosing_body: s.enclosing_body,
+                    resolve(&s.uri, &s.raw_path, s.is_literal).map(|child| {
+                        crate::source_graph::SourceEdge {
+                            parent: s.uri.clone(),
+                            child,
+                            at: s.range.start(),
+                            enclosing_body: s.enclosing_body,
+                        }
                     })
                 })
                 .collect();
@@ -5448,10 +5454,18 @@ mod tests {
 
     /// The server's URI resolver, in miniature: a literal path resolved
     /// against the sourcing document's directory.
-    fn test_resolve(parent_uri: &str, raw_path: &str) -> Option<String> {
+    fn test_resolve(parent_uri: &str, raw_path: &str, is_literal: bool) -> Option<String> {
         let parent = parent_uri.strip_prefix("file://")?;
         let dir = std::path::Path::new(parent).parent()?;
-        let child = crate::source_graph::resolve_under(dir, raw_path);
+        // The server's two tiers, in miniature: a literal resolves directly, a
+        // computed path only when it folds statically — anything else names no
+        // document and sequences nothing.
+        let raw = if is_literal {
+            raw_path.to_owned()
+        } else {
+            tcl_compiler::auto_path_eval::evaluate_auto_path_expr(raw_path, Some(parent))?
+        };
+        let child = crate::source_graph::resolve_under(dir, &raw);
         Some(format!("file://{}", child.display()))
     }
 
@@ -5623,8 +5637,6 @@ mod tests {
             ("file:///p/imp.tcl", &imp),
             ("file:///p/app.tcl", &app),
         ]);
-        let src = std::fs::read_to_string("/dev/null").ok();
-        let _ = src;
         // A call written after the forget no longer resolves…
         let after = index.resolve_wildcard_import(
             "helper",
@@ -5635,7 +5647,8 @@ mod tests {
             after.is_none(),
             "a forget written after the `source` that installed the alias must revoke it: {after:?}",
         );
-        // …while one written before it still does.
+        // …and a call written *above* every `source` statement has no alias
+        // yet either — the install has not run at that point.
         assert_eq!(
             index
                 .resolve_wildcard_import(
@@ -5645,7 +5658,87 @@ mod tests {
                 )
                 .as_deref(),
             None,
-            "and a call above every `source` statement has no alias yet either",
+        );
+        // TP: with the forget removed, the same call site after the sources
+        // does resolve — so the assertion above is the forget's doing and not
+        // an accident of the graph.
+        let app_no_forget = analyse("source mod.tcl\nsource exp.tcl\nsource imp.tcl\n");
+        let index = sourced_index([
+            ("file:///p/mod.tcl", &mod_doc),
+            ("file:///p/exp.tcl", &exp),
+            ("file:///p/imp.tcl", &imp),
+            ("file:///p/app.tcl", &app_no_forget),
+        ]);
+        assert_eq!(
+            index
+                .resolve_wildcard_import(
+                    "helper",
+                    &["::app::helper".to_string(), "::helper".to_string()],
+                    call_at("file:///p/app.tcl", u32::MAX),
+                )
+                .as_deref(),
+            Some("::mymod::helper"),
+        );
+    }
+
+    #[test]
+    fn a_cross_file_import_conflict_is_decided_by_the_source_order() {
+        // TP (CRITICAL), issue #1116 item 6 — two imports of one name from
+        // different sources, in different files. Without an order neither
+        // conflicts and the later one silently installs; with one, the file
+        // sourced first owns the name and the second import raises `can't
+        // import command "helper": already exists` and installs nothing.
+        //
+        // Oracle (8.6.14 / 9.0.4), with the two importers in separate files
+        // sourced in this order:
+        //   namespace origin ::app::helper  ->  ::first::helper
+        let first = analyse(
+            "namespace eval ::first { proc helper {} { return F }\n namespace export helper }\n",
+        );
+        let second = analyse(
+            "namespace eval ::second { proc helper {} { return S }\n namespace export helper }\n",
+        );
+        let imp_a = analyse("namespace eval ::app { namespace import ::first::* }\n");
+        let imp_b = analyse("namespace eval ::app { namespace import ::second::* }\n");
+        let app =
+            analyse("source first.tcl\nsource second.tcl\nsource impa.tcl\nsource impb.tcl\n");
+        let docs = [
+            ("file:///p/first.tcl", &first),
+            ("file:///p/second.tcl", &second),
+            ("file:///p/impa.tcl", &imp_a),
+            ("file:///p/impb.tcl", &imp_b),
+            ("file:///p/app.tcl", &app),
+        ];
+        assert_eq!(
+            sourced_index(docs)
+                .resolve_wildcard_import(
+                    "helper",
+                    &["::app::helper".to_string(), "::helper".to_string()],
+                    call_from("file:///p/caller.tcl"),
+                )
+                .as_deref(),
+            Some("::first::helper"),
+            "the import sourced first owns the name; the second conflicts and installs nothing",
+        );
+        // Swap the two `source` lines and the winner swaps with them.
+        let app =
+            analyse("source first.tcl\nsource second.tcl\nsource impb.tcl\nsource impa.tcl\n");
+        let docs = [
+            ("file:///p/first.tcl", &first),
+            ("file:///p/second.tcl", &second),
+            ("file:///p/impa.tcl", &imp_a),
+            ("file:///p/impb.tcl", &imp_b),
+            ("file:///p/app.tcl", &app),
+        ];
+        assert_eq!(
+            sourced_index(docs)
+                .resolve_wildcard_import(
+                    "helper",
+                    &["::app::helper".to_string(), "::helper".to_string()],
+                    call_from("file:///p/caller.tcl"),
+                )
+                .as_deref(),
+            Some("::second::helper"),
         );
     }
 

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -76,6 +76,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use crate::source_graph::RunPoint;
 use crate::workspace_symbols::{
     IndexedWorkspaceSymbol, WorkspaceSymbolKind, matches_query, namespace_of,
 };
@@ -1514,6 +1515,12 @@ pub struct WorkspaceIndex {
     /// without link-following — see
     /// [`WorkspaceIndex::invocations_by_settled_target`].
     settled_invocations: [Derived<SettledTargets>; 2],
+    /// The `source`-path → document-URI resolver, when the host has installed
+    /// one — see [`WorkspaceIndex::set_source_resolver`].
+    source_resolver: Option<fn(&str, &str) -> Option<String>>,
+    /// The `source`-graph load order derived from it — see
+    /// [`WorkspaceIndex::run_order`].
+    run_order: Derived<crate::source_graph::RunOrder>,
 }
 
 /// A whole-index **derived view**: a value that is a pure function of the
@@ -1710,6 +1717,63 @@ impl WorkspaceIndex {
         })
     }
 
+    /// Install the host's literal-`source`-path → document-URI resolver, so
+    /// the index can build the [`crate::source_graph::RunOrder`] the
+    /// import-lifecycle gates rank cross-document events with (issue #1104
+    /// item 3).
+    ///
+    /// The index deliberately holds no URI ↔ filesystem-path mapping of its
+    /// own — that is the host's knowledge, and every other `source`-graph
+    /// consumer already takes the same closure per call
+    /// ([`Self::source_ancestor_package_requires`],
+    /// [`Self::source_ancestor_prefers_latest`], [`Self::source_seed_map`]).
+    /// The order, though, is consulted *inside* the per-call import walk,
+    /// where a per-call resolver argument would have to be threaded through
+    /// every caller of `resolve_wildcard_import` and every derived view that
+    /// builds a `WildcardImportIndex`. Holding it here instead lets the order
+    /// be a [`Derived`] view like the rest, built at most once per
+    /// [`Self::generation`].
+    ///
+    /// A plain `fn` pointer rather than a boxed closure: the resolver is a
+    /// pure function of `(parent uri, raw path)` in every host, and a `fn`
+    /// keeps the index `Debug + Clone + Default` with no manual impls.
+    ///
+    /// **Without a resolver the order is empty**, and both tiers behave
+    /// exactly as they did before the `source` graph existed — every
+    /// cross-document event unrankable, every same-document one ordered.
+    pub fn set_source_resolver(&mut self, resolve: fn(&str, &str) -> Option<String>) {
+        self.source_resolver = Some(resolve);
+        self.run_order = Derived::default();
+    }
+
+    /// The `source`-graph load order over this workspace's documents, built at
+    /// most once per [`Self::generation`].
+    ///
+    /// Empty when no resolver is installed (see [`Self::set_source_resolver`])
+    /// or when no `source` statement resolves. Only **literal** targets become
+    /// edges: `source $dir/x.tcl` names no document statically and sequences
+    /// nothing.
+    fn run_order(&self) -> Arc<crate::source_graph::RunOrder> {
+        self.run_order.get_or_build(|| {
+            let Some(resolve) = self.source_resolver else {
+                return crate::source_graph::RunOrder::default();
+            };
+            let edges: Vec<crate::source_graph::SourceEdge> = self
+                .sources()
+                .filter(|s| s.is_literal)
+                .filter_map(|s| {
+                    resolve(&s.uri, &s.raw_path).map(|child| crate::source_graph::SourceEdge {
+                        parent: s.uri.clone(),
+                        child,
+                        at: s.range.start(),
+                        enclosing_body: s.enclosing_body,
+                    })
+                })
+                .collect();
+            crate::source_graph::RunOrder::build(&edges)
+        })
+    }
+
     /// Note a mutation: bump the generation and drop every derived cache.
     fn invalidate(&mut self) {
         self.generation = self.generation.wrapping_add(1);
@@ -1718,6 +1782,7 @@ impl WorkspaceIndex {
         self.defined_names = <[Derived<HashSet<String>>; 2]>::default();
         self.command_link_map = Derived::default();
         self.settled_invocations = <[Derived<SettledTargets>; 2]>::default();
+        self.run_order = Derived::default();
     }
 
     /// The command name-links that are actually installed — every `interp
@@ -3607,6 +3672,11 @@ struct WildcardImportIndex<'a> {
     /// finding 3), which is a question about where the declaration sits, not
     /// merely whether one exists.
     declarations_by_qname: std::collections::HashMap<&'a str, Vec<(&'a str, u32)>>,
+    /// The workspace's `source`-graph load order — the relation every
+    /// decision below ranks its events with, so a cross-document event is
+    /// ordered wherever the graph proves an order and unrankable everywhere
+    /// else (issue #1104 item 3).
+    order: Arc<crate::source_graph::RunOrder>,
 }
 
 impl<'a> WildcardImportIndex<'a> {
@@ -3675,6 +3745,7 @@ impl<'a> WildcardImportIndex<'a> {
             forgets_by_ns,
             deletions_by_name,
             declarations_by_qname,
+            order: index.run_order(),
         }
     }
 
@@ -3701,9 +3772,8 @@ impl<'a> WildcardImportIndex<'a> {
         importing_ns: &'e str,
         source_ns: &'e str,
         name: &'e str,
-        ordered_in: &'e str,
-        destroy_at: impl Fn(&WorkspaceCommandDeletion) -> Option<u32> + 'e,
-    ) -> impl Iterator<Item = crate::namespace_import::AliasEvent> + 'e {
+        destroy_point: impl Fn(&'e WorkspaceCommandDeletion) -> RunPoint<'e> + 'e,
+    ) -> impl Iterator<Item = crate::namespace_import::AliasEvent<'e>> + 'e {
         use crate::namespace_import::{AliasEvent, AliasEventKind};
         let forgets = self
             .forgets_by_ns
@@ -3718,7 +3788,11 @@ impl<'a> WildcardImportIndex<'a> {
             })
             .map(move |f| AliasEvent {
                 kind: AliasEventKind::Remove,
-                at: (f.uri == ordered_in).then_some(f.at),
+                at: RunPoint {
+                    uri: f.uri.as_str(),
+                    at: f.at,
+                    enclosing_body: None,
+                },
             });
         // A `proc` / class declaration of the *imported* name recreates it as
         // an ordinary command and ends the alias (oracle on
@@ -3729,9 +3803,13 @@ impl<'a> WildcardImportIndex<'a> {
             .map(Vec::as_slice)
             .unwrap_or_default()
             .iter()
-            .map(move |(uri, at)| AliasEvent {
+            .map(move |&(uri, at)| AliasEvent {
                 kind: AliasEventKind::Remove,
-                at: (*uri == ordered_in).then_some(*at),
+                at: RunPoint {
+                    uri,
+                    at,
+                    enclosing_body: None,
+                },
             });
         let qualified = tcl_syntax::naming::qualify(source_ns, name);
         let deletions = self
@@ -3742,7 +3820,7 @@ impl<'a> WildcardImportIndex<'a> {
             .iter()
             .map(move |d| AliasEvent {
                 kind: AliasEventKind::Remove,
-                at: destroy_at(d),
+                at: destroy_point(d),
             });
         forgets.chain(redefinitions).chain(deletions)
     }
@@ -3782,17 +3860,17 @@ impl<'a> WildcardImportIndex<'a> {
         use crate::namespace_import::{AliasEvent, AliasEventKind};
         let install = std::iter::once(AliasEvent {
             kind: AliasEventKind::Install,
-            at: (install_at.uri == call.uri).then_some(install_at.at),
+            at: install_at.point(),
         });
         let mut events =
             install.chain(
-                self.removal_events(importing_ns, source_ns, name, call.uri, |d| {
-                    (d.uri == call.uri).then_some(d.at)
+                self.removal_events(importing_ns, source_ns, name, |d| RunPoint {
+                    uri: d.uri.as_str(),
+                    at: d.at,
+                    enclosing_body: None,
                 }),
             );
-        crate::namespace_import::alias_live_at(&mut events, &|at| {
-            tcl_compiler::analyser::indirection::in_effect_within(at, call.at, call.enclosing_body)
-        })
+        crate::namespace_import::alias_live_at(&mut events, &self.order, Some(call.point()))
     }
 
     /// Whether `ns` already holds a live alias for `name` from a namespace
@@ -3849,13 +3927,11 @@ impl<'a> WildcardImportIndex<'a> {
         name: &str,
         site: ImportSite<'_>,
     ) -> bool {
-        use crate::namespace_import::load_order;
         let call = CallSite {
             uri: site.uri,
             at: site.at,
             enclosing_body: site.enclosing_body,
         };
-        let here = load_order(site.at, site.enclosing_body.is_some());
         let mut earlier = self
             .imports_by_ns
             .get(ns)
@@ -3874,8 +3950,7 @@ impl<'a> WildcardImportIndex<'a> {
                     .map(|(uri, gate)| (gate.source_ns.as_str(), gate.site(uri))),
             );
         earlier.any(|(other_source, other_site)| {
-            other_site.uri == site.uri
-                && load_order(other_site.at, other_site.enclosing_body.is_some()) < here
+            self.order.cmp_run(other_site.point(), site.point()) == Some(std::cmp::Ordering::Less)
                 && !ns_eq(other_source, source_ns)
                 && self.exports_name_at(other_source, name, other_site)
                 && self.alias_live_at(ns, other_source, name, other_site, call)
@@ -3912,16 +3987,20 @@ impl<'a> WildcardImportIndex<'a> {
         use crate::namespace_import::{AliasEvent, AliasEventKind};
         let install = std::iter::once(AliasEvent {
             kind: AliasEventKind::Install,
-            at: Some(gate.at),
+            at: gate.site(uri).point(),
         });
-        let mut events = install.chain(self.removal_events(
-            importing_ns,
-            &gate.source_ns,
-            &gate.name,
-            uri,
-            |_| Some(u32::MAX),
-        ));
-        crate::namespace_import::alias_live_at(&mut events, &|_| true)
+        // The destruction is passed in the *import's* document at `u32::MAX`
+        // so it ranks after every install wherever it was written: the command
+        // object is gone workspace-wide and no load order brings it back.
+        let mut events =
+            install.chain(
+                self.removal_events(importing_ns, &gate.source_ns, &gate.name, |_| RunPoint {
+                    uri,
+                    at: u32::MAX,
+                    enclosing_body: None,
+                }),
+            );
+        crate::namespace_import::alias_live_at(&mut events, &self.order, None)
     }
 
     /// Whether `ns` (`::`-rooted) had exported the unqualified `name` **as of
@@ -3947,15 +4026,18 @@ impl<'a> WildcardImportIndex<'a> {
                 .map(|e| crate::namespace_import::ExportEvent {
                     pattern: e.pattern.as_str(),
                     clears: e.clears,
-                    at: (e.uri == site.uri).then_some(e.at),
+                    at: RunPoint {
+                        uri: e.uri.as_str(),
+                        at: e.at,
+                        enclosing_body: None,
+                    },
                 });
-            crate::namespace_import::exported_at_import_site(&mut events, name, &|at| {
-                tcl_compiler::analyser::indirection::in_effect_within(
-                    at,
-                    site.at,
-                    site.enclosing_body,
-                )
-            })
+            crate::namespace_import::exported_at_import_site(
+                &mut events,
+                name,
+                &self.order,
+                site.point(),
+            )
         })
     }
 }
@@ -4001,6 +4083,18 @@ struct ImportSite<'a> {
     enclosing_body: Option<Span>,
 }
 
+impl<'a> ImportSite<'a> {
+    /// This site as the workspace-wide execution-timeline point
+    /// [`crate::source_graph::RunOrder`] ranks events by.
+    fn point(self) -> RunPoint<'a> {
+        RunPoint {
+            uri: self.uri,
+            at: self.at,
+            enclosing_body: self.enclosing_body,
+        }
+    }
+}
+
 /// Where the **call** being resolved sits: the document and the offset of its
 /// command-head token.
 ///
@@ -4035,6 +4129,18 @@ pub struct CallSite<'a> {
     /// Span of the innermost proc/class **body** containing the call, within
     /// `uri`; `None` when the call sits at load level.
     pub enclosing_body: Option<Span>,
+}
+
+impl<'a> CallSite<'a> {
+    /// This call as the workspace-wide execution-timeline point
+    /// [`crate::source_graph::RunOrder`] ranks events against.
+    fn point(self) -> RunPoint<'a> {
+        RunPoint {
+            uri: self.uri,
+            at: self.at,
+            enclosing_body: self.enclosing_body,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -1517,11 +1517,21 @@ pub struct WorkspaceIndex {
     settled_invocations: [Derived<SettledTargets>; 2],
     /// The `source`-path → document-URI resolver, when the host has installed
     /// one — see [`WorkspaceIndex::set_source_resolver`].
-    source_resolver: Option<fn(&str, &str, bool) -> Option<String>>,
+    source_resolver: Option<SourceResolver>,
     /// The `source`-graph load order derived from it — see
     /// [`WorkspaceIndex::run_order`].
     run_order: Derived<crate::source_graph::RunOrder>,
 }
+
+/// The host's `source`-path → document-URI resolver: `(sourcing document's
+/// URI, the path word as written, whether that word is a plain literal)` to
+/// the sourced document's URI, or `None` for a path the host cannot place.
+///
+/// `WorkspaceIndex` holds no URI ↔ filesystem-path mapping of its own, so this
+/// is how the `source`-graph load order gets its edges — see
+/// [`WorkspaceIndex::set_source_resolver`].  The signature is
+/// [`WorkspaceIndex::source_seed_map`]'s, so one host resolver serves both.
+pub type SourceResolver = fn(&str, &str, bool) -> Option<String>;
 
 /// A whole-index **derived view**: a value that is a pure function of the
 /// index's contents, built at most once per [`WorkspaceIndex::generation`] and
@@ -1746,7 +1756,7 @@ impl WorkspaceIndex {
     /// **Without a resolver the order is empty**, and both tiers behave
     /// exactly as they did before the `source` graph existed — every
     /// cross-document event unrankable, every same-document one ordered.
-    pub fn set_source_resolver(&mut self, resolve: fn(&str, &str, bool) -> Option<String>) {
+    pub fn set_source_resolver(&mut self, resolve: SourceResolver) {
         self.source_resolver = Some(resolve);
         self.run_order = Derived::default();
     }
@@ -3985,24 +3995,34 @@ impl<'a> WildcardImportIndex<'a> {
     ///   reinstalls — oracle).
     /// - One in another document has no static load order and revokes
     ///   nothing, exactly as in [`Self::alias_live_at`].
-    /// - A destroyed source command revokes regardless: the command object is
-    ///   gone workspace-wide (oracle: `rename ::src::p {}` makes `::dst::p`
-    ///   an `invalid command name` and empties `info commands ::dst::*`), so
-    ///   it is passed at [`u32::MAX`] — later than any install.
+    /// - A destroyed source command revokes regardless, and is **not** put on
+    ///   the timeline at all: the command object is gone workspace-wide
+    ///   (oracle: `rename ::src::p {}` makes `::dst::p` an `invalid command
+    ///   name` and empties `info commands ::dst::*`) and no load order brings
+    ///   it back, so with no query point to order anything against it is
+    ///   decided before the fold runs.  Encoding it as an event at `u32::MAX`
+    ///   instead would be wrong for a **body-local** import gate: the
+    ///   load-order rule reads a removal written outside the import's own body
+    ///   as having run *before* it — right for a `namespace forget`, which the
+    ///   import then undoes, and exactly backwards for a destruction the
+    ///   import cannot undo.
     fn link_alias_live(&self, importing_ns: &str, gate: &WorkspaceImportGate, uri: &str) -> bool {
         use crate::namespace_import::{AliasEvent, AliasEventKind};
+        if self
+            .deletions_by_name
+            .contains_key(tcl_syntax::naming::qualify(&gate.source_ns, &gate.name).as_str())
+        {
+            return false;
+        }
         let install = std::iter::once(AliasEvent {
             kind: AliasEventKind::Install,
             at: gate.site(uri).point(),
         });
-        // The destruction is passed in the *import's* document at `u32::MAX`
-        // so it ranks after every install wherever it was written: the command
-        // object is gone workspace-wide and no load order brings it back.
         let mut events =
             install.chain(
-                self.removal_events(importing_ns, &gate.source_ns, &gate.name, |_| RunPoint {
-                    uri,
-                    at: u32::MAX,
+                self.removal_events(importing_ns, &gate.source_ns, &gate.name, |d| RunPoint {
+                    uri: d.uri.as_str(),
+                    at: d.at,
                     enclosing_body: None,
                 }),
             );
@@ -6604,6 +6624,70 @@ mod tests {
         assert_eq!(
             index.resolve_command_target("::app::helper"),
             "::mymod::helper"
+        );
+    }
+
+    #[test]
+    fn a_destroyed_source_kills_a_body_local_exact_import_link() {
+        // TN (CRITICAL): the destruction is not a timeline event — the command
+        // object is gone workspace-wide and no load order brings it back — so
+        // it must revoke however the import is written. A **body-local**
+        // import gate is the case that separates the two encodings: the
+        // load-order rule reads a removal written outside the import's own
+        // body as having run before it, which is right for a `namespace
+        // forget` (the import then undoes it) and backwards for a destruction
+        // the import cannot undo. Oracle: `rename ::mymod::helper {}` makes
+        // `::app::helper` an `invalid command name` and empties `info commands
+        // ::app::*`.
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse(
+            "namespace eval ::app {\n    proc setup {} { namespace import ::mymod::helper }\n}\nrename ::mymod::helper {}\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        assert_eq!(
+            index.resolve_command_target("::app::helper"),
+            "::app::helper",
+            "destroying the source command revokes the link wherever the import sits"
+        );
+        assert!(!index.workspace_command_exists("::app::helper"));
+        // …and the top-level spelling of the same import, for the control.
+        let app = analyse(
+            "namespace eval ::app {\n    namespace import ::mymod::helper\n}\nrename ::mymod::helper {}\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        assert_eq!(
+            index.resolve_command_target("::app::helper"),
+            "::app::helper"
+        );
+    }
+
+    #[test]
+    fn a_body_local_exact_import_survives_a_top_level_forget() {
+        // FN guard for the row above, and the reason the destruction cannot
+        // simply be encoded as "a removal at `u32::MAX`": a `namespace forget`
+        // at the file's load level runs *before* a body-local import, which
+        // then reinstalls the alias. Oracle: `::app::setup` followed by
+        // `namespace origin ::app::helper` answers `::mymod::helper`.
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse(
+            "namespace eval ::app {\n    proc setup {} { namespace import ::mymod::helper }\n}\nnamespace eval ::app { namespace forget ::mymod::helper }\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        assert_eq!(
+            index.resolve_command_target("::app::helper"),
+            "::mymod::helper",
+            "a load-level forget runs before the body-local import that reinstalls it"
         );
     }
 

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -5430,6 +5430,225 @@ mod tests {
         assert_eq!(resolved.as_deref(), Some("::mymod::helper"));
     }
 
+    // ---- the `source` graph orders what the file boundary did not --------
+    //
+    // Issue #1104 item 3 / #1116 item 6. Sourcing a file inlines its whole
+    // body at the `source` statement's position, so the DFS of the source
+    // forest *is* the run order. Oracle for every case below, byte-identical
+    // on tclsh 8.6.14 and 9.0.4 — with
+    //
+    //   # exp.tcl:  namespace eval ::mymod { namespace export helper }
+    //   # imp.tcl:  namespace eval ::app   { namespace import ::mymod::* }
+    //   # mod.tcl:  namespace eval ::mymod { proc helper {} {return HELP} }
+    //
+    //   # app.tcl:  source mod.tcl; source exp.tcl; source imp.tcl
+    //   ::app::helper   ->  HELP
+    //   # app.tcl:  source mod.tcl; source imp.tcl; source exp.tcl
+    //   ::app::helper   ->  invalid command name "::app::helper"
+
+    /// The server's URI resolver, in miniature: a literal path resolved
+    /// against the sourcing document's directory.
+    fn test_resolve(parent_uri: &str, raw_path: &str) -> Option<String> {
+        let parent = parent_uri.strip_prefix("file://")?;
+        let dir = std::path::Path::new(parent).parent()?;
+        let child = crate::source_graph::resolve_under(dir, raw_path);
+        Some(format!("file://{}", child.display()))
+    }
+
+    /// An index over `documents` with the `source`-path resolver installed —
+    /// the shape the real server builds ([`WorkspaceIndex::set_source_resolver`]).
+    fn sourced_index<'a>(
+        documents: impl IntoIterator<Item = (&'a str, &'a AnalysisResult)>,
+    ) -> WorkspaceIndex {
+        let mut index = WorkspaceIndex::new();
+        index.set_source_resolver(test_resolve);
+        for (uri, analysis) in documents {
+            index.add_document(uri, analysis);
+        }
+        index
+    }
+
+    /// The three module documents every source-order test below shares.
+    fn import_order_modules() -> (AnalysisResult, AnalysisResult, AnalysisResult) {
+        (
+            analyse("namespace eval ::mymod { proc helper {} { return HELP } }\n"),
+            analyse("namespace eval ::mymod { namespace export helper }\n"),
+            analyse("namespace eval ::app { namespace import ::mymod::* }\n"),
+        )
+    }
+
+    #[test]
+    fn an_export_sourced_before_the_import_resolves() {
+        // TP: `app.tcl` sources the export before the import, so the import
+        // really did see it — the same answer as before, but now as a proved
+        // order rather than an abstention.
+        let (mod_doc, exp, imp) = import_order_modules();
+        let app = analyse("source mod.tcl\nsource exp.tcl\nsource imp.tcl\n");
+        let index = sourced_index([
+            ("file:///p/mod.tcl", &mod_doc),
+            ("file:///p/exp.tcl", &exp),
+            ("file:///p/imp.tcl", &imp),
+            ("file:///p/app.tcl", &app),
+        ]);
+        assert_eq!(
+            index
+                .resolve_wildcard_import(
+                    "helper",
+                    &["::app::helper".to_string(), "::helper".to_string()],
+                    call_from("file:///p/caller.tcl"),
+                )
+                .as_deref(),
+            Some("::mymod::helper"),
+        );
+    }
+
+    #[test]
+    fn an_export_sourced_after_the_import_is_not_retroactive() {
+        // FP guard (CRITICAL), issue #1104 item 3 — the whole point of the
+        // order. The import runs first, `::mymod` has exported nothing yet,
+        // so real Tcl installs no alias at all. Byte-identical documents to
+        // the test above; only `app.tcl`'s two `source` lines swap.
+        let (mod_doc, exp, imp) = import_order_modules();
+        let app = analyse("source mod.tcl\nsource imp.tcl\nsource exp.tcl\n");
+        let index = sourced_index([
+            ("file:///p/mod.tcl", &mod_doc),
+            ("file:///p/exp.tcl", &exp),
+            ("file:///p/imp.tcl", &imp),
+            ("file:///p/app.tcl", &app),
+        ]);
+        let resolved = index.resolve_wildcard_import(
+            "helper",
+            &["::app::helper".to_string(), "::helper".to_string()],
+            call_from("file:///p/caller.tcl"),
+        );
+        assert!(
+            resolved.is_none(),
+            "an export sourced after the import cannot apply retroactively: {resolved:?}",
+        );
+    }
+
+    #[test]
+    fn without_a_resolver_the_same_workspace_keeps_abstaining() {
+        // TN for the deployment shape: an index with no `source` resolver
+        // installed holds the pre-#1104-item-3 behaviour exactly — the
+        // foreign export counts and the import resolves, whichever way the
+        // `source` statements are written.
+        let (mod_doc, exp, imp) = import_order_modules();
+        let app = analyse("source mod.tcl\nsource imp.tcl\nsource exp.tcl\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///p/mod.tcl", &mod_doc),
+            ("file:///p/exp.tcl", &exp),
+            ("file:///p/imp.tcl", &imp),
+            ("file:///p/app.tcl", &app),
+        ]);
+        assert_eq!(
+            index
+                .resolve_wildcard_import(
+                    "helper",
+                    &["::app::helper".to_string(), "::helper".to_string()],
+                    call_from("file:///p/caller.tcl"),
+                )
+                .as_deref(),
+            Some("::mymod::helper"),
+        );
+    }
+
+    #[test]
+    fn a_re_sourced_export_file_keeps_abstaining() {
+        // TN (CRITICAL): `exp.tcl` is sourced twice, so it has no unique
+        // position and the order must not invent one — Tcl tolerates
+        // re-sourcing, and guessing would silently drop a real alias. Falls
+        // back to the pre-graph abstention: the export counts.
+        let (mod_doc, exp, imp) = import_order_modules();
+        let app = analyse("source mod.tcl\nsource imp.tcl\nsource exp.tcl\nsource exp.tcl\n");
+        let index = sourced_index([
+            ("file:///p/mod.tcl", &mod_doc),
+            ("file:///p/exp.tcl", &exp),
+            ("file:///p/imp.tcl", &imp),
+            ("file:///p/app.tcl", &app),
+        ]);
+        assert_eq!(
+            index
+                .resolve_wildcard_import(
+                    "helper",
+                    &["::app::helper".to_string(), "::helper".to_string()],
+                    call_from("file:///p/caller.tcl"),
+                )
+                .as_deref(),
+            Some("::mymod::helper"),
+        );
+    }
+
+    #[test]
+    fn a_computed_source_path_orders_nothing() {
+        // TN: `source $dir/exp.tcl` names no document statically, so the edge
+        // is dropped and the export goes back to being unrankable — the
+        // deliberate abstention, not an accident of path resolution.
+        let (mod_doc, exp, imp) = import_order_modules();
+        let app = analyse(
+            "set dir [file dirname [info script]]\nsource mod.tcl\nsource imp.tcl\nsource $dir/exp.tcl\n",
+        );
+        let index = sourced_index([
+            ("file:///p/mod.tcl", &mod_doc),
+            ("file:///p/exp.tcl", &exp),
+            ("file:///p/imp.tcl", &imp),
+            ("file:///p/app.tcl", &app),
+        ]);
+        assert_eq!(
+            index
+                .resolve_wildcard_import(
+                    "helper",
+                    &["::app::helper".to_string(), "::helper".to_string()],
+                    call_from("file:///p/caller.tcl"),
+                )
+                .as_deref(),
+            Some("::mymod::helper"),
+        );
+    }
+
+    #[test]
+    fn a_forget_written_after_the_source_revokes_the_sourced_import() {
+        // TP (CRITICAL), the `source lib.tcl ; namespace forget ::lib::p`
+        // idiom #1104 item 3 and #1116 called out by name: the install from
+        // the sourced file counts (it always did) *and* the forget beside the
+        // `source` now revokes it. Oracle: `::app::helper` is an `invalid
+        // command name` after the forget.
+        let (mod_doc, exp, imp) = import_order_modules();
+        let app = analyse(
+            "source mod.tcl\nsource exp.tcl\nsource imp.tcl\nnamespace eval ::app { namespace forget ::mymod::helper }\n",
+        );
+        let index = sourced_index([
+            ("file:///p/mod.tcl", &mod_doc),
+            ("file:///p/exp.tcl", &exp),
+            ("file:///p/imp.tcl", &imp),
+            ("file:///p/app.tcl", &app),
+        ]);
+        let src = std::fs::read_to_string("/dev/null").ok();
+        let _ = src;
+        // A call written after the forget no longer resolves…
+        let after = index.resolve_wildcard_import(
+            "helper",
+            &["::app::helper".to_string(), "::helper".to_string()],
+            call_at("file:///p/app.tcl", u32::MAX),
+        );
+        assert!(
+            after.is_none(),
+            "a forget written after the `source` that installed the alias must revoke it: {after:?}",
+        );
+        // …while one written before it still does.
+        assert_eq!(
+            index
+                .resolve_wildcard_import(
+                    "helper",
+                    &["::app::helper".to_string(), "::helper".to_string()],
+                    call_at("file:///p/app.tcl", 0),
+                )
+                .as_deref(),
+            None,
+            "and a call above every `source` statement has no alias yet either",
+        );
+    }
+
     #[test]
     fn resolve_wildcard_import_ignores_a_same_file_export_written_after_the_import() {
         // FP guard (CRITICAL), direction B, cross-document — the import and

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -16797,12 +16797,15 @@ fn resolve_source_uri(parent_uri: &str, raw_path: &str) -> Option<String> {
 /// The index holds no URI ↔ filesystem-path mapping of its own, so the
 /// `source`-graph load order its import-lifecycle gates rank cross-document
 /// events with ([`tcl_lsp_core::source_graph::RunOrder`], issue #1104 item 3)
-/// can only be built once the host hands it [`resolve_source_uri`]. Every
+/// can only be built once the host hands it [`resolve_source_edge`] — the same
+/// resolver the M9 re-homing pass uses, so its statically-foldable
+/// computed-path tier (`[file join [file dirname [info script]] x.tcl]`, the
+/// idiom real multi-file projects write) sequences the order too. Every
 /// index this server builds goes through here so none of them can silently
 /// end up with an empty order and answer a different question from the rest.
 fn new_workspace_index() -> core_workspace_index::WorkspaceIndex {
     let mut index = core_workspace_index::WorkspaceIndex::new();
-    index.set_source_resolver(resolve_source_uri);
+    index.set_source_resolver(resolve_source_edge);
     index
 }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -3850,7 +3850,7 @@ impl Backend {
             non_ascii_mode: Mutex::new(NonAsciiMode::Default),
             disabled_diagnostics: Mutex::new(default_disabled_set()),
             severity_overrides: Mutex::new(HashMap::new()),
-            workspace_index: Arc::new(RwLock::new(core_workspace_index::WorkspaceIndex::new())),
+            workspace_index: Arc::new(RwLock::new(new_workspace_index())),
             package_resolver: Arc::new(RwLock::new(PackageResolver::new())),
             recovery_names: Arc::new(Mutex::new(RecoveryNameCache::default())),
             workspace_scan_gate: tokio::sync::Mutex::new(()),
@@ -11138,7 +11138,7 @@ impl Backend {
         if unindexed.is_empty() {
             return Vec::new();
         }
-        let mut pending = core_workspace_index::WorkspaceIndex::new();
+        let mut pending = new_workspace_index();
         for uri in &unindexed {
             if let Some(analysis) = self.cached_analysis(uri).await {
                 pending.add_document(uri.as_str(), &analysis);
@@ -16791,6 +16791,21 @@ fn resolve_source_uri(parent_uri: &str, raw_path: &str) -> Option<String> {
     canonical_file_uri(&child).map(|u| u.as_str().to_owned())
 }
 
+/// A [`core_workspace_index::WorkspaceIndex`] with this server's
+/// `source`-path resolver installed.
+///
+/// The index holds no URI ↔ filesystem-path mapping of its own, so the
+/// `source`-graph load order its import-lifecycle gates rank cross-document
+/// events with ([`tcl_lsp_core::source_graph::RunOrder`], issue #1104 item 3)
+/// can only be built once the host hands it [`resolve_source_uri`]. Every
+/// index this server builds goes through here so none of them can silently
+/// end up with an empty order and answer a different question from the rest.
+fn new_workspace_index() -> core_workspace_index::WorkspaceIndex {
+    let mut index = core_workspace_index::WorkspaceIndex::new();
+    index.set_source_resolver(resolve_source_uri);
+    index
+}
+
 /// [`resolve_source_uri`] extended with the M9 stage-9.2 computed-path tier:
 /// a literal resolves as before; a computed path is statically folded through
 /// [`tcl_compiler::auto_path_eval::evaluate_auto_path_expr`] (`[file join …]`
@@ -21360,7 +21375,7 @@ mod tests {
             non_ascii_mode: Mutex::new(NonAsciiMode::Default),
             disabled_diagnostics: Mutex::new(default_disabled_set()),
             severity_overrides: Mutex::new(HashMap::new()),
-            workspace_index: Arc::new(RwLock::new(core_workspace_index::WorkspaceIndex::new())),
+            workspace_index: Arc::new(RwLock::new(new_workspace_index())),
             package_resolver: Arc::new(RwLock::new(PackageResolver::new())),
             recovery_names: Arc::new(Mutex::new(RecoveryNameCache::default())),
             workspace_scan_gate: tokio::sync::Mutex::new(()),

--- a/rust/tcl-lsp-server/tests/e2e/definition.rs
+++ b/rust/tcl-lsp-server/tests/e2e/definition.rs
@@ -823,3 +823,163 @@ fn opt_proc_call_site_resolves_to_its_declaration_end_to_end() {
         "must resolve to the tcl::OptProc declaration (line 1): {locs:?}"
     );
 }
+
+// -- the `source` graph orders what the file boundary did not (issue #1104
+//    item 3, #1116 item 6) --
+//
+// Sourcing a file inlines its whole body at the `source` statement's
+// position, so the DFS of the `source` forest *is* the run order and an
+// import in one file is genuinely ordered against an export in another.
+// Oracle, byte-identical on tclsh 8.6.14 and 9.0.4, with
+//
+//   # mod.tcl: namespace eval Lib { proc bar {} {return 1} }
+//   # exp.tcl: namespace eval Lib { namespace export bar }
+//   # imp.tcl: namespace import ::Lib::*
+//
+//   # app.tcl: source mod.tcl; source exp.tcl; source imp.tcl
+//   bar   -> 1
+//   # app.tcl: source mod.tcl; source imp.tcl; source exp.tcl
+//   bar   -> invalid command name "bar"
+
+/// The four documents the source-order end-to-end tests share, under one
+/// directory so the relative `source` literals resolve against each other.
+fn source_order_uris(tag: &str) -> (String, String, String, String) {
+    let dir = format!("file:///e2e/order_{}_{tag}", std::process::id());
+    (
+        format!("{dir}/mod.tcl"),
+        format!("{dir}/exp.tcl"),
+        format!("{dir}/imp.tcl"),
+        format!("{dir}/app.tcl"),
+    )
+}
+
+#[test]
+fn an_export_sourced_before_the_import_resolves_end_to_end() {
+    // TP: the export's file is sourced first, so the import really did see
+    // it and the bare call jumps into mod.tcl.
+    let mut lsp = Lsp::tcl();
+    let (mod_uri, exp_uri, imp_uri, app_uri) = source_order_uris("tp");
+    lsp.open_ready(
+        &mod_uri,
+        "namespace eval Lib {\n    proc bar {} { return 1 }\n}\n",
+    );
+    lsp.open_ready(
+        &exp_uri,
+        "namespace eval Lib {\n    namespace export bar\n}\n",
+    );
+    lsp.open_ready(&imp_uri, "namespace import ::Lib::*\n");
+    lsp.open_ready(
+        &app_uri,
+        "source mod.tcl\nsource exp.tcl\nsource imp.tcl\nbar\n",
+    );
+    let locs = locations(&lsp.definition(&app_uri, 3, 0));
+    assert_eq!(locs.len(), 1, "{locs:?}");
+    assert_eq!(locs[0].uri, mod_uri, "must jump into mod.tcl");
+    assert_eq!(start_line(&locs[0]), 1, "proc bar is declared on line 1");
+}
+
+#[test]
+fn an_export_sourced_after_the_import_does_not_resolve_end_to_end() {
+    // FP guard (CRITICAL): identical documents, only app.tcl's two `source`
+    // lines swapped. The import now runs before `::Lib` has exported
+    // anything, so real Tcl installs no alias and the bare call is an
+    // `invalid command name` — go-to-definition must find nothing.
+    let mut lsp = Lsp::tcl();
+    let (mod_uri, exp_uri, imp_uri, app_uri) = source_order_uris("fp");
+    lsp.open_ready(
+        &mod_uri,
+        "namespace eval Lib {\n    proc bar {} { return 1 }\n}\n",
+    );
+    lsp.open_ready(
+        &exp_uri,
+        "namespace eval Lib {\n    namespace export bar\n}\n",
+    );
+    lsp.open_ready(&imp_uri, "namespace import ::Lib::*\n");
+    lsp.open_ready(
+        &app_uri,
+        "source mod.tcl\nsource imp.tcl\nsource exp.tcl\nbar\n",
+    );
+    let result = lsp.definition(&app_uri, 3, 0);
+    assert!(
+        locations(&result).is_empty(),
+        "an export sourced after the import cannot apply retroactively: {result:?}"
+    );
+}
+
+#[test]
+fn find_references_agrees_with_the_source_order() {
+    // The two tiers must agree on the LSP surfaces, not only in the
+    // resolver: with the export sourced first, `proc bar`'s references
+    // include the bare call in app.tcl; with it sourced last, they do not.
+    let mut lsp = Lsp::tcl();
+    let (mod_uri, exp_uri, imp_uri, app_uri) = source_order_uris("refs");
+    lsp.open_ready(
+        &mod_uri,
+        "namespace eval Lib {\n    proc bar {} { return 1 }\n}\n",
+    );
+    lsp.open_ready(
+        &exp_uri,
+        "namespace eval Lib {\n    namespace export bar\n}\n",
+    );
+    lsp.open_ready(&imp_uri, "namespace import ::Lib::*\n");
+    lsp.open_ready(
+        &app_uri,
+        "source mod.tcl\nsource exp.tcl\nsource imp.tcl\nbar\n",
+    );
+    let refs = locations(&lsp.references(&mod_uri, 1, 9, false));
+    assert!(
+        refs.iter().any(|l| l.uri == app_uri),
+        "the bare call reached through the sourced import is a reference: {refs:?}"
+    );
+
+    let mut lsp = Lsp::tcl();
+    let (mod_uri, exp_uri, imp_uri, app_uri) = source_order_uris("refs_fp");
+    lsp.open_ready(
+        &mod_uri,
+        "namespace eval Lib {\n    proc bar {} { return 1 }\n}\n",
+    );
+    lsp.open_ready(
+        &exp_uri,
+        "namespace eval Lib {\n    namespace export bar\n}\n",
+    );
+    lsp.open_ready(&imp_uri, "namespace import ::Lib::*\n");
+    lsp.open_ready(
+        &app_uri,
+        "source mod.tcl\nsource imp.tcl\nsource exp.tcl\nbar\n",
+    );
+    let refs = locations(&lsp.references(&mod_uri, 1, 9, false));
+    assert!(
+        !refs.iter().any(|l| l.uri == app_uri),
+        "a call the import never bound is not a reference: {refs:?}"
+    );
+}
+
+#[test]
+fn a_computed_source_path_keeps_the_pre_graph_abstention_end_to_end() {
+    // TN for the deliberate abstention: `source $dir/exp.tcl` names no
+    // document statically, so no edge is built and the export goes back to
+    // being unrankable — which keeps answering, the pre-#1104-item-3
+    // behaviour. Same document text as the FP guard above otherwise.
+    let mut lsp = Lsp::tcl();
+    let (mod_uri, exp_uri, imp_uri, app_uri) = source_order_uris("computed");
+    lsp.open_ready(
+        &mod_uri,
+        "namespace eval Lib {\n    proc bar {} { return 1 }\n}\n",
+    );
+    lsp.open_ready(
+        &exp_uri,
+        "namespace eval Lib {\n    namespace export bar\n}\n",
+    );
+    lsp.open_ready(&imp_uri, "namespace import ::Lib::*\n");
+    lsp.open_ready(
+        &app_uri,
+        "set dir /nowhere\nsource mod.tcl\nsource imp.tcl\nsource $dir/exp.tcl\nbar\n",
+    );
+    let locs = locations(&lsp.definition(&app_uri, 4, 0));
+    assert_eq!(
+        locs.len(),
+        1,
+        "an unprovable `source` path must not be given an order: {locs:?}"
+    );
+    assert_eq!(locs[0].uri, mod_uri);
+}


### PR DESCRIPTION
Closes #1104. Advances #1116 (item 6 fixed, item 5 pinned, item 4 recommended for closure as a note; item 1 remains — see below).

## Scope correction

Both issues were written before the #1176 / #1115 review round landed. Checking the live code first: **#1104 items 1 and 2, and #1116 items 2, 3 and 7, were already fixed on `rust`**, and #1116 item 5 already had its test. What was genuinely open was the thing both issues are blocked on — the `source`-graph run order — plus three deliberate abstentions and one plumbing item. This builds the order rather than redoing landed work.

## The order (#1104 item 3, #1116 item 6)

`tcl_lsp_core::source_graph::RunOrder` implements §6.1/§6.2 of `docs/design/import-order-source-graph.md`. Each event's `(uri, at, enclosing_body)` is lifted to its root-ward path of `source`-statement offsets, and two events reduce to positions in their deepest common document, where the *existing* single-document rules apply — `in_effect_within` for `has_run`, `namespace_import::load_order` for `cmp_run`. One projection (`common_frame`) answers both questions, so the ordering gate and the conflict rule cannot drift apart.

Both shared folds were rewritten from `Option<u32>` maxima into latest-wins folds over the partial order: a pattern survives unless a tombstone is *known* to have run after it, and an install survives unless a removal is. Incomparable folds to "abstain toward answering", which means the previous `at: None` special case disappeared rather than a second rule being added beside it.

**Precision that needs no `source` edge:** two events in a single *foreign* file are now ranked against each other, since a file's statements run consecutively. So `namespace export p` followed by `namespace export -clear` in one other file now revokes. The old encoding collapsed "which file" and "where in it" into a single absent offset and could only call both unordered.

**Cross-file live-alias conflicts (#1116 item 6):** `conflicting_alias_at` now ranks the two import sites with `cmp_run` instead of a same-document `load_order` compare. The file sourced first owns the name, and the winner swaps when the two `source` lines swap.

The resolver is widened to the statically-foldable computed paths (`[file join [file dirname [info script]] x.tcl]`), because a literal-only gate would leave the feature unreachable in real projects. A path that cannot be proven still returns `None`.

## A bug introduced and fixed within the change

Porting `link_alias_live`'s destruction sentinel into the new fold was wrong for a body-local exact-import gate: the load-order rule reads a removal written outside the import's own body as having run *before* it, which is right for a `namespace forget` (the import then undoes it) and backwards for a destruction the import cannot undo. A destroyed source command is not a timeline event at all, so it is now decided before the fold. Both directions are pinned.

## Corpus measurement

Two indexes over the same documents — one with the `source` resolver installed, one without — diffing `resolve_wildcard_import` at every bare call site, over Tcl 9.0.4's `library/` and `samples/` plus the multi-file editor and CLI fixtures.

```
documents:            247
`source` statements:  19  (3 resolving to an indexed document)
bare call sites:      13 752
resolution differed:  0   (lost 0, gained 0)
```

Read honestly: the order changes nothing on the available corpora, because real Tcl writes `source [file join $tcl_library init.tcl]` and no static fold can place `$tcl_library`. That is the **no-op property** this change needed to demonstrate — a strict refinement that fires only where a load order is provable, with 13 752 call sites confirming it costs nothing elsewhere. It is **not** evidence the mechanism fires; that comes from the unit and e2e tests.

## Deliberate abstentions, now pinned rather than incidental

- **Dynamic export patterns** (`namespace export $pat`) stay abstaining, with the post-`-clear` interaction covered — a `-clear` empties the snapshot either way, so the unrecorded pattern costs nothing there.
- **Dynamic forget patterns** were already abstaining; their export-side twin now has a matching test so the pair reads as one deliberate rule.
- **#1116 item 4, import-error control flow** — recommended for closure as a note. The unmodelled half is the *uncaught* failure, which aborts the rest of its script; modelling it would make navigation delete definitions from an already-broken program, the one direction this family never takes. The caught case needs no model, since "installed nothing, everything else ran" is already exactly right.

## Tests

+12 in `tcl-lsp-core` (1775 → 1787): 12 `RunOrder` relation tests, 5 fold tests, 6 workspace-tier tests, 4 in-document tests, plus 5 lsp e2e tests covering **both** definition and references, so the two tiers are shown to agree on the LSP surface rather than only in the resolver.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo check --workspace --all-targets` all clean; `cargo test -p tcl-lsp-core` passes with zero failures across 34 test binaries; lsp e2e passes 1300; the remaining `tcl-lsp-server` targets pass 381. No `#[allow(...)]` — the one `type_complexity` hit was resolved with a named `SourceResolver` alias.

Re-verified after rebasing onto current `rust` (post #1270/#1271), not only on the original base.

## Not done

**#1116 item 1** — the in-document `-force` shadow. The false positive and its pinned true negative have byte-identical single-document inputs, differing only in whether *another* file declares the export, so no in-document rule can decide it. The fix is threading a whole-program export oracle through `resolve_called_proc` (~10 external call sites across definition, hover, inlay hints, call hierarchy, code actions, signature help, caller-frame and inline-proc). That is plumbing of a different shape and is left for its own change rather than half-landed here, so #1116 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_