### PR TITLE
Gate untargeted member renames; cross-file method hover; package-gated arity abstentions (#1019)

### DIFF
--- a/editors/vscode/src/test/issue1019ProcArgs.test.ts
+++ b/editors/vscode/src/test/issue1019ProcArgs.test.ts
@@ -1,0 +1,240 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Issue #1019 differential audit, `proc_args` group — the editor tier.
+//
+// The findings below were verified against tclsh 9.0.4 and 8.6.16 (which
+// agree byte-for-byte) and are pinned in the Rust unit and end-to-end tiers.
+// What these tests add is the property only the editor can show: that the
+// behaviour survives the real VS Code request path — including the one that
+// matters most, a *rename the editor must refuse* rather than silently apply.
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { getDocUri, activate, waitForDiagnostics } from "./helper";
+
+function codeOf(d: vscode.Diagnostic): string {
+  return typeof d.code === "object" && d.code !== null ? String(d.code.value) : String(d.code);
+}
+
+async function renameAt(
+  uri: vscode.Uri,
+  pos: vscode.Position,
+  newName: string,
+): Promise<vscode.WorkspaceEdit | undefined> {
+  return (await vscode.commands.executeCommand(
+    "vscode.executeDocumentRenameProvider",
+    uri,
+    pos,
+    newName,
+  )) as vscode.WorkspaceEdit | undefined;
+}
+
+// -- idx 79 ------------------------------------------------------------
+//
+// `$other` really holds an `Idx79Vector` at run time, but nothing in the
+// source *assigns* a constructor result to it, so no analysis can prove the
+// dispatch reaches `X` — nor prove it does not.  Renaming `X` and leaving
+// `[$other X]` behind makes both interpreters throw
+// `unknown method "X": must be Get, GetX or destroy`.
+//
+// The gate used to be reachable only from the method's own declaration.  VS
+// Code's rename gesture works from any occurrence of the symbol, so the two
+// positions below are the *common* ones — and they must refuse too.
+suite("Issue #1019 idx 79 — rename refuses an untracked dispatch", () => {
+  const docUri = getDocUri("issue1019Idx79Hazard.tcl");
+
+  // Cursor on the `X` of `[$other X]` (line 5) — the hazardous dispatch.
+  test("refuses when triggered from the untracked call site", async () => {
+    await activate(docUri);
+    await assert.rejects(
+      () => renameAt(docUri, new vscode.Position(5, 27), "GetX"),
+      "renaming from the untracked call site must be refused, not applied",
+    );
+  });
+
+  // Cursor on the `X` of `export X Get` (line 12).
+  test("refuses when triggered from the export bareword", async () => {
+    await activate(docUri);
+    await assert.rejects(
+      () => renameAt(docUri, new vscode.Position(12, 11), "GetX"),
+      "renaming from the export list must be refused, not applied",
+    );
+  });
+
+  // Cursor on the `X` of `method X` (line 10) — the direction that already
+  // worked, kept so a regression that loosened the gate shows up here too.
+  test("refuses when triggered from the declaration", async () => {
+    await activate(docUri);
+    await assert.rejects(
+      () => renameAt(docUri, new vscode.Position(10, 11), "GetX"),
+      "renaming from the declaration must be refused, not applied",
+    );
+  });
+
+  // TN control: a member the untracked receiver never names still renames.
+  // Over-refusal would make rename unusable on any class with an internal
+  // `$var method` helper.
+  test("still renames a member the untracked receiver never names", async () => {
+    await activate(docUri);
+    const edit = await renameAt(docUri, new vscode.Position(11, 11), "Fetch");
+    assert.ok(edit, "renaming `Get` must succeed");
+    const entries = edit.entries();
+    const found = entries.find(([uri]) => uri.toString() === docUri.toString());
+    assert.ok(found, "the document must be edited");
+    assert.ok(
+      found[1].length >= 2,
+      `declaration + export must both rename, got ${found[1].length} edits`,
+    );
+  });
+});
+
+// -- idx 28 ------------------------------------------------------------
+//
+// SpiceGenTcl's shape: the mixin and the class that mixes it in live in one
+// file, the device class calling `my ArgsPreprocess` in another.  Oracle
+// (9.0.4 / 8.6.16, sourcing both): `ArgsPreprocess dispatched via class:
+// ::Idx28::Utility` — the call genuinely reaches the mixin's method.
+//
+// Go-to-definition crossed the file boundary; hover answered nothing.
+suite("Issue #1019 idx 28 — cross-file mixin hover", () => {
+  const deviceUri = getDocUri("issue1019Idx28Device.tcl");
+  const libUri = getDocUri("issue1019Idx28Lib.tcl");
+
+  test("hover on `my <method>` names the provider in the sibling file", async () => {
+    await activate(libUri);
+    await activate(deviceUri);
+    // Cursor on `ArgsPreprocess` in the `my` dispatch (line 4).
+    const hovers = (await vscode.commands.executeCommand(
+      "vscode.executeHoverProvider",
+      deviceUri,
+      new vscode.Position(4, 20),
+    )) as vscode.Hover[];
+    const text = (hovers ?? [])
+      .flatMap((h) => h.contents)
+      .map((c) => (typeof c === "string" ? c : (c as vscode.MarkdownString).value))
+      .join("\n");
+    assert.ok(text.includes("ArgsPreprocess"), `hover must name the method, got: ${text}`);
+    assert.ok(
+      text.includes("::Idx28::Utility"),
+      `hover must name the providing class from the sibling file, got: ${text}`,
+    );
+  });
+
+  test("hover and go-to-definition agree about the provider", async () => {
+    await activate(libUri);
+    await activate(deviceUri);
+    const locations = (await vscode.commands.executeCommand(
+      "vscode.executeDefinitionProvider",
+      deviceUri,
+      new vscode.Position(4, 20),
+    )) as vscode.Location[];
+    assert.ok(locations && locations.length > 0, "definition must resolve cross-file");
+    assert.strictEqual(
+      locations[0].uri.toString(),
+      libUri.toString(),
+      "the declaration lives in the library file",
+    );
+  });
+});
+
+// -- idx 11 ------------------------------------------------------------
+//
+// A `proc` named after a *package-gated* registry command is the package's
+// own definition, not a redefinition of a built-in — and needs no `package
+// require` to make its name exist.  Oracle (9.0.4 / 8.6.16): `argparse` is
+// not a built-in (`invalid command name "argparse"` in a bare interpreter),
+// and the file prints `case0`.
+suite("Issue #1019 idx 11 — a proc named after a package command", () => {
+  const docUri = getDocUri("issue1019Idx11Argparse.tcl");
+
+  test("fires neither W113 nor W120 nor an arity error (false case)", async () => {
+    await activate(docUri);
+    // The document is clean, so there is no diagnostic to wait *for*; give
+    // the server a settled window and assert on whatever it published.
+    const diags = await waitForDiagnostics(docUri, {
+      timeout: 8000,
+      predicate: () => false,
+    }).catch(() => vscode.languages.getDiagnostics(docUri));
+    const seen = diags.map(codeOf);
+    assert.ok(!seen.includes("W113"), `the proc shadows no built-in: ${seen.join(", ")}`);
+    assert.ok(!seen.includes("W120"), `the file defines the command itself: ${seen.join(", ")}`);
+    assert.ok(!seen.includes("E002"), `the 0-argument call runs (\`case0\`): ${seen.join(", ")}`);
+  });
+
+  // TP control: redefining a real core built-in still warns — the exclusion
+  // is for package-gated names only, not a blanket one.
+  test("redefining a core built-in still fires W113 (true case)", async () => {
+    const builtinUri = getDocUri("procs.tcl");
+    await activate(builtinUri);
+    const doc = await vscode.workspace.openTextDocument(builtinUri);
+    const edit = new vscode.WorkspaceEdit();
+    edit.insert(builtinUri, new vscode.Position(0, 0), "proc lindex {a b} { return $a }\n");
+    await vscode.workspace.applyEdit(edit);
+    try {
+      const diags = await waitForDiagnostics(builtinUri, {
+        predicate: (d) => d.some((x) => codeOf(x) === "W113"),
+      });
+      assert.ok(
+        diags.some((d) => codeOf(d) === "W113"),
+        "`lindex` is a core built-in and must still be flagged",
+      );
+    } finally {
+      const undo = new vscode.WorkspaceEdit();
+      undo.delete(builtinUri, doc.lineAt(0).rangeIncludingLineBreak);
+      await vscode.workspace.applyEdit(undo);
+      await vscode.commands.executeCommand("workbench.action.closeActiveEditor");
+    }
+  });
+});
+
+// -- idx 104 -----------------------------------------------------------
+//
+// Tk's `library/tk.tcl` shape: a parameter named `destroy`, defaulting to the
+// literal `destroy`, beside a `destroy` command.  Oracle (9.0.4 / 8.6.16):
+// `$destroy` always reads the parameter, bare `destroy $grab` always calls
+// the command.
+suite("Issue #1019 idx 104 — a parameter shadowing a command", () => {
+  const docUri = getDocUri("issue1019Idx104Param.tcl");
+
+  test("the parameter's own name resolves to the parameter, not the proc", async () => {
+    await activate(docUri);
+    const locations = (await vscode.commands.executeCommand(
+      "vscode.executeDefinitionProvider",
+      docUri,
+      new vscode.Position(1, 38),
+    )) as vscode.Location[];
+    assert.ok(locations && locations.length > 0, "the parameter must resolve to something");
+    assert.strictEqual(
+      locations[0].range.start.line,
+      1,
+      "it must be the parameter's own binding on line 1, not `proc destroy` on line 0",
+    );
+  });
+
+  test("the real call in the body still reaches the proc (false-positive guard)", async () => {
+    await activate(docUri);
+    const locations = (await vscode.commands.executeCommand(
+      "vscode.executeDefinitionProvider",
+      docUri,
+      new vscode.Position(2, 44),
+    )) as vscode.Location[];
+    assert.ok(locations && locations.length > 0, "the bare call must resolve");
+    assert.strictEqual(locations[0].range.start.line, 0, "it must reach `proc destroy`");
+  });
+});

--- a/editors/vscode/testFixture/issue1019Idx104Param.tcl
+++ b/editors/vscode/testFixture/issue1019Idx104Param.tcl
@@ -1,0 +1,5 @@
+proc destroy {w} { return "destroying $w" }
+proc RestoreFocusGrab {grab focus {destroy destroy}} {
+    if {$destroy eq "destroy"} { return [destroy $grab] }
+    return $destroy
+}

--- a/editors/vscode/testFixture/issue1019Idx11Argparse.tcl
+++ b/editors/vscode/testFixture/issue1019Idx11Argparse.tcl
@@ -1,0 +1,5 @@
+proc ::argparse {args} {
+    if {[llength $args] == 0} { return case0 }
+    return [lindex $args 0]
+}
+puts [argparse]

--- a/editors/vscode/testFixture/issue1019Idx28Device.tcl
+++ b/editors/vscode/testFixture/issue1019Idx28Device.tcl
@@ -1,0 +1,8 @@
+namespace eval ::Idx28::Xyce {
+    oo::class create RModel {
+        superclass ::Idx28::Model
+        constructor {args} {
+            my ArgsPreprocess {defw r} {name type} type {*}$args
+        }
+    }
+}

--- a/editors/vscode/testFixture/issue1019Idx28Lib.tcl
+++ b/editors/vscode/testFixture/issue1019Idx28Lib.tcl
@@ -1,0 +1,8 @@
+namespace eval ::Idx28 {
+    oo::class create Utility {
+        method ArgsPreprocess {switches params supp args} { return ok }
+    }
+    oo::class create Model {
+        mixin Utility
+    }
+}

--- a/editors/vscode/testFixture/issue1019Idx79Hazard.tcl
+++ b/editors/vscode/testFixture/issue1019Idx79Hazard.tcl
@@ -1,0 +1,14 @@
+oo::class create Idx79Vector {
+    variable _x _y
+    constructor {args} {
+        if {[llength $args] == 1} {
+            set other [lindex $args 0]
+            set _x [$other X]
+        } else {
+            lassign $args _x _y
+        }
+    }
+    method X {} { return $_x }
+    method Get {} { return "$_x $_y" }
+    export X Get
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
@@ -997,6 +997,10 @@ impl Analyser {
         // is only sorted by `canonicalize_result_order`, which runs after this
         // emitter).  This keeps the result walk-strategy-independent, as the
         // tail already enforces for other order-sensitive collections.
+        // The document's own declarations, for the shadowing gate below —
+        // the same fact table the arity path's suppression is built from, so
+        // the two agree about what "this file defines that command" means.
+        let declared = super::validity::UserResolutionFacts::build(self);
         let mut best: HashMap<&str, &crate::signature_scan::types::SignatureCommandInvocation> =
             HashMap::new();
         for inv in &self.result.command_invocations {
@@ -1020,6 +1024,26 @@ impl Analyser {
             // in a tclpkg manifest is the entry-point directive, never the
             // Tk widget, so no `package require Tk` is missing.
             if self.is_scoped_command_resolved(&inv.name, inv.range) {
+                continue;
+            }
+            // The document defines the command itself — a `proc`, a class, an
+            // `interp alias`, a static `rename` target, an ensemble, or a
+            // declared stub. Then the name resolves to *that*, and no
+            // `package require` is missing however the registry happens to
+            // spell the same word. The real corpus case is the package's own
+            // implementation file: georgtree/argparse's `proc ::argparse
+            // {args}` beside its own uses was told to `package require
+            // argparse` — i.e. to require the very package it is
+            // (issue #923 idx 11, verification pass; the sibling W113
+            // false positive on the same declaration is gated by
+            // `is_package_gated_non_ambient`).
+            let candidates: Vec<String> = if inv.resolution_candidates.is_empty() {
+                crate::naming::bareword_resolution_candidates("", &inv.name)
+            } else {
+                inv.resolution_candidates.clone()
+            };
+            let bare = inv.name.rsplit("::").next().unwrap_or(&inv.name);
+            if declared.declares_any(&candidates, bare) {
                 continue;
             }
             best.entry(inv.name.as_str())

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -1627,9 +1627,12 @@ impl Analyser {
     ///
     /// `pending_arity` carries E002/E003 arity candidates, W004
     /// (dialect-invalid-option) candidates, and W001 (unknown-subcommand)
-    /// candidates (see its field doc); the resolution loop below never
-    /// inspects `diag.code`, so all three share the identical shadowing
-    /// suppression with no special-casing.
+    /// candidates (see its field doc); the *shadowing* suppression never
+    /// inspects `diag.code`, so all three share it with no special-casing.
+    /// The package-loaded gate below is the one exception, and it is scoped
+    /// to the arity verdicts because only they assert against the resolved
+    /// spec's own argument counts — see
+    /// [`Self::spec_is_an_unloaded_package_command`].
     pub fn flush_arity_diagnostics(&mut self) {
         if self.pending_arity.is_empty() && self.pending_user_call_arity.is_empty() {
             return;
@@ -1642,7 +1645,17 @@ impl Analyser {
             if facts.resolves_to_user(&cmd_name, &ns, enforce_order, call_off) {
                 continue;
             }
-            if self.spec_is_an_unloaded_package_command(&cmd_name) {
+            // Arity verdicts only — the *count* claim is the one that needs
+            // the spec to be the command actually being called. W001
+            // (unknown subcommand) and W004 (dialect-invalid option) share
+            // this queue but are claims about the *word the user wrote*
+            // against a name the registry knows, and they stay useful for a
+            // package the file has not required yet (`wm bogus` is still a
+            // typo whether or not `package require Tk` is present) — the two
+            // TP tests in `fp::sty` pin exactly that.
+            if matches!(diag.code, DiagCode::E002 | DiagCode::E003 | DiagCode::E005)
+                && self.spec_is_an_unloaded_package_command(&cmd_name)
+            {
                 continue;
             }
             self.result.diagnostics.push(diag);

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -406,7 +406,7 @@ fn qualify_candidates(ns: &str, cmd_name: &str) -> Vec<String> {
 /// fields (`pending_arity`, `result.diagnostics`, …) while iterating —
 /// borrowing through a whole-`&Analyser` build call would otherwise pin the
 /// borrow checker's view to "all of `self`" for the facts' lifetime.
-struct UserResolutionFacts {
+pub(super) struct UserResolutionFacts {
     /// Fully-qualified names that unconditionally denote a user command once
     /// declared anywhere in the file: `TclOO`/snit/itcl classes, `interp
     /// alias` names, and `namespace ensemble create` namespaces. Not
@@ -430,7 +430,7 @@ struct UserResolutionFacts {
 }
 
 impl UserResolutionFacts {
-    fn build(a: &Analyser) -> Self {
+    pub(super) fn build(a: &Analyser) -> Self {
         let mut non_proc_qnames: FxHashSet<String> = FxHashSet::default();
         non_proc_qnames.extend(a.result.all_classes.keys().cloned());
         non_proc_qnames.extend(a.result.command_aliases.keys().cloned());
@@ -501,6 +501,29 @@ impl UserResolutionFacts {
                     .rename_offsets
                     .get(c.as_str())
                     .is_some_and(|&off| !enforce_order || off < call_off)
+        }) || self.stub_names.contains(bare)
+    }
+
+    /// Whether **any** of an invocation's already-resolved command-resolution
+    /// candidates names a command this document itself declares — a proc, a
+    /// class, an `interp alias`, a static `rename` target, an ensemble
+    /// namespace, or a `# tcl-lsp: stub` name.
+    ///
+    /// The order-gated sibling ([`Self::resolves_to_user`]) answers "which
+    /// definition is in effect *at this call*", which is what a
+    /// wrong-arguments verdict needs. This one answers the weaker question
+    /// W120 asks — "does this file define the command at all" — for which
+    /// order is irrelevant: `package require` is a statement about what the
+    /// *file* needs loaded, and a file that defines the command needs nothing
+    /// loaded to make the name exist, whatever line the definition is on.
+    /// Deliberately permissive for the same reason the non-proc set is
+    /// (issue #923 idx 11, verification pass: `proc ::argparse {args}`
+    /// beside a call to it was told to `package require argparse`).
+    pub(super) fn declares_any(&self, candidates: &[String], bare: &str) -> bool {
+        candidates.iter().any(|c| {
+            self.non_proc_qnames.contains(c.as_str())
+                || self.proc_offsets.contains_key(c.as_str())
+                || self.rename_offsets.contains_key(c.as_str())
         }) || self.stub_names.contains(bare)
     }
 }
@@ -1516,6 +1539,63 @@ impl Analyser {
         }
     }
 
+    /// Whether `name` resolves to a registry command that only exists once a
+    /// `required_package` / `tcllib_package` is loaded, and this document
+    /// neither `package require`s nor `package provide`s it — with the
+    /// profile's ambient packages excluded, exactly as
+    /// [`Analyser::is_package_gated_non_ambient`] and the W120 emitter do.
+    ///
+    /// Such a call has **no proven identity**: the registry's `CommandSpec`
+    /// describes the package's command, but nothing in this document says
+    /// that package is what the name will resolve to at run time — which is
+    /// the very thing W120 is emitted to say. Asserting a hard arity *error*
+    /// against that spec while simultaneously warning that the package is not
+    /// loaded is self-contradictory, and it is wrong whenever the name is
+    /// actually supplied by something else: a proc defined in a file this one
+    /// `source`s, an `interp alias` set up by its host application.
+    ///
+    /// The real corpus case (issue #923 idx 11, verification pass) is
+    /// georgtree/argparse's own `proc ::argparse {args}`: a sibling file that
+    /// `source`s it and calls `argparse` with no arguments — which real tclsh
+    /// 9.0.4 / 8.6.16 both run happily, printing `case0` — was told
+    /// `Too few arguments for 'argparse': expected at least 1, got 0`,
+    /// resolved against the *package's* spec that this workspace never loads.
+    /// Whole-file `source`-graph knowledge is not available here (the analyser
+    /// is single-file by construction, see
+    /// [`Analyser::emit_missing_package_require_diagnostics`]), so the sound
+    /// answer is to abstain and let W120 carry the (retractable, warning-level)
+    /// report.
+    ///
+    /// The true positive is untouched: a document that *does* `package
+    /// require argparse` has proven the identity, W120 does not fire, and a
+    /// bad-arity call to it is still an error.
+    fn spec_is_an_unloaded_package_command(&self, name: &str) -> bool {
+        use tcl_registry::ProfileQueries;
+        let registry = tcl_registry::cache::registry_for_profile(self.profile);
+        let Some(pkg) = self
+            .profile
+            .resolve_command(registry, name)
+            .and_then(tcl_registry::CommandSpec::owning_package)
+        else {
+            return false;
+        };
+        if self.profile.is_ambient_package(pkg) {
+            return false;
+        }
+        !self
+            .result
+            .package_requires
+            .iter()
+            .map(|pr| pr.name.as_str())
+            .chain(
+                self.result
+                    .package_provides
+                    .iter()
+                    .map(|pp| pp.name.as_str()),
+            )
+            .any(|imported| imported == pkg)
+    }
+
     /// Post-walk flush of the [`Self::pending_arity`] / [`Self::pending_user_call_arity`]
     /// candidates collected by [`Self::emit_arity_diagnostics`] and
     /// [`Self::queue_user_call_arity_candidate`].
@@ -1560,6 +1640,9 @@ impl Analyser {
         for (cmd_name, ns, enforce_order, diag) in pending {
             let call_off = diag.span.start();
             if facts.resolves_to_user(&cmd_name, &ns, enforce_order, call_off) {
+                continue;
+            }
+            if self.spec_is_an_unloaded_package_command(&cmd_name) {
                 continue;
             }
             self.result.diagnostics.push(diag);

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -3413,7 +3413,7 @@ fn method_dispatch_hover(
 /// visible in the requesting document's own analysis. The real corpus shape
 /// is the opposite: `my ArgsPreprocess` in one file, the `mixin`/`superclass`
 /// that provides `ArgsPreprocess` in another (issue #923 idx 28 — the
-/// SpiceGenTcl `RModel` / `Utility` split). Go-to-definition and
+/// `SpiceGenTcl` `RModel` / `Utility` split). Go-to-definition and
 /// find-references already crossed that boundary through the workspace index;
 /// hover answered nothing, because `hover.rs` has no cross-document tier at
 /// all. Rather than grow one here — the index and the document store live in

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -3405,6 +3405,49 @@ fn method_dispatch_hover(
     ControlFlow::Continue(())
 }
 
+/// The one-line method summary for a dispatch whose **provider was resolved
+/// elsewhere** — the server's workspace tier, walking the same C-faithful
+/// linearisation `definition.rs`'s cross-file method tier walks.
+///
+/// [`method_dispatch_hover`] can only answer when the whole class chain is
+/// visible in the requesting document's own analysis. The real corpus shape
+/// is the opposite: `my ArgsPreprocess` in one file, the `mixin`/`superclass`
+/// that provides `ArgsPreprocess` in another (issue #923 idx 28 — the
+/// SpiceGenTcl `RModel` / `Utility` split). Go-to-definition and
+/// find-references already crossed that boundary through the workspace index;
+/// hover answered nothing, because `hover.rs` has no cross-document tier at
+/// all. Rather than grow one here — the index and the document store live in
+/// the server — the server resolves the provider and asks this function to
+/// render it, so both tiers emit the identical heading and MRO note.
+///
+/// `receiver_class_q` is the class the call dispatches *on*; `provider_q` the
+/// class the chain landed on. They differ exactly when the member is
+/// inherited, which is the note this renders — there is no `next`-chain
+/// lookup to do here, because the chain walk that produced `provider_q`
+/// already applied the visibility rule and the instance/class-side split.
+#[must_use]
+pub fn cross_document_method_hover(
+    receiver_class_q: &str,
+    provider_q: &str,
+    method_name: &str,
+    nparams: usize,
+    is_classmethod: bool,
+) -> Hover {
+    let label = if is_classmethod {
+        "classmethod"
+    } else {
+        "method"
+    };
+    let note = if provider_q == receiver_class_q {
+        String::new()
+    } else {
+        format!("  \n_inherited from `{provider_q}`_")
+    };
+    Hover::markdown(format!(
+        "**{label}** `{provider_q}::{method_name}` ({nparams} param(s)){note}"
+    ))
+}
+
 fn obj_method_hover_text(
     analysis: &AnalysisResult,
     class_q: &str,

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -492,6 +492,34 @@ pub fn rename_with_diagnosis(
     // Method rename — match `word` against any class's methods
     // / classmethods / properties at the cursor's byte offset.
     let cursor_offset = crate::definition::byte_offset_at(&line_index, source, line, character);
+    // The safety gate again, for the member *this* tier resolves.
+    //
+    // `pre_edit_refusal` can only speak for a cursor a trusted dispatch tier
+    // claims; this tier answers the rest — the method word inside an
+    // untracked `[$other X]`, the bareword in `export … X …` — and those are
+    // precisely the positions from which the idx-79 hazard used to emit a
+    // declaration-only edit set that breaks the program once applied. Asking
+    // the same question about the same member here makes the verdict
+    // independent of *which occurrence* the rename was triggered from
+    // (issue #923 idx 79, verification pass).
+    //
+    // It runs here rather than in `pre_edit_refusal` so the tier order is
+    // preserved exactly: a cursor an earlier tier claims (a local variable, a
+    // proc, a class) is renamed by that tier and never consulted about a
+    // same-spelled member.
+    if let Some((seed_class, method, is_classmethod)) =
+        untargeted_member_rename_target(analysis, &word, cursor_offset)
+        && let Some(refusal) = member_rename_hazard(
+            source,
+            dialect,
+            analysis,
+            (&seed_class, &method, is_classmethod),
+            new_name,
+            &line_index,
+        )
+    {
+        return Err(refusal);
+    }
     if let Some(edits) = rename_method(
         source,
         dialect,
@@ -572,7 +600,38 @@ fn method_rename_refusal(
 ) -> Option<crate::rename_safety::RenameRefusal> {
     let (seed_class, method, is_classmethod) =
         method_rename_target(source, line, character, analysis)?;
-    let family = override_family(analysis, &seed_class, &method);
+    member_rename_hazard(
+        source,
+        dialect,
+        analysis,
+        (&seed_class, &method, is_classmethod),
+        new_name,
+        line_index,
+    )
+}
+
+/// The safety verdict for renaming `method` on `seed_class`'s whole override
+/// family — the one call both member-rename gates make, so a hazard is a
+/// property of *which member the rename rewrites*, never of how the cursor
+/// happened to name it.
+///
+/// Split out of [`method_rename_refusal`] because that entry point can only
+/// speak for cursors a *trusted dispatch tier* resolves
+/// ([`method_rename_target`]: the member's own declaration name, a `my`
+/// dispatch, a tracked `$obj` / class-command dispatch). Every other position
+/// that still reaches a member — the untracked call site the gate exists to
+/// protect, an `export`/`unexport` bareword — is resolved by
+/// [`untargeted_member_rename_target`] instead and asked the same question
+/// here (issue #923 idx 79, verification pass).
+fn member_rename_hazard(
+    source: &str,
+    dialect: &str,
+    analysis: &AnalysisResult,
+    (seed_class, method, is_classmethod): (&str, &str, bool),
+    new_name: &str,
+    line_index: &LineIndex,
+) -> Option<crate::rename_safety::RenameRefusal> {
+    let family = override_family(analysis, seed_class, method);
     if family.is_empty() {
         return None;
     }
@@ -582,12 +641,47 @@ fn method_rename_refusal(
         analysis,
         crate::rename_safety::MethodRenameTarget {
             family: &family,
-            method: &method,
+            method,
             is_classmethod,
             new_name,
         },
         line_index,
     )
+}
+
+/// The member the **untargeted** member-rename tier ([`rename_method`]) would
+/// rewrite for a cursor at `cursor_offset`, or `None` when that tier declines
+/// the cursor.
+///
+/// This is deliberately the *same* resolution `rename_method` performs —
+/// "which class body encloses the cursor, and does `word` name one of its
+/// members" ([`crate::definition::enclosing_class_at`] +
+/// [`resolve_member_span`]) — and not a re-derivation. That tier answers
+/// exactly the cursor positions no trusted dispatch tier claims: the method
+/// name inside `[$untracked X]`, and the bareword in an `export … X …` list.
+/// Both of those used to reach `rename_method` with no hazard check at all,
+/// so the very shape [`crate::rename_safety`] refuses when the cursor sits on
+/// the declaration silently emitted a declaration-only edit set from one line
+/// away — applying it and running under tclsh 9.0.4 / 8.6.16 gives `unknown
+/// method "X"` at the untouched dispatch (issue #923 idx 79).
+///
+/// Restricted to `method` / `classmethod`: a *property* has no dispatch
+/// (see [`rename_method`]'s own property branch), so it has no dispatch
+/// hazard to check.
+#[must_use]
+pub fn untargeted_member_rename_target(
+    analysis: &AnalysisResult,
+    word: &str,
+    cursor_offset: u32,
+) -> Option<(String, String, bool)> {
+    let class_q = crate::definition::enclosing_class_at(analysis, cursor_offset)?;
+    let class_def = analysis.all_classes.get(class_q)?;
+    let (kind, _span) = resolve_member_span(class_def, word, cursor_offset)?;
+    match kind {
+        MemberSel::Method => Some((class_def.qualified_name.clone(), word.to_owned(), false)),
+        MemberSel::ClassMethod => Some((class_def.qualified_name.clone(), word.to_owned(), true)),
+        MemberSel::Property => None,
+    }
 }
 
 /// The variable-rename edits for a cursor that names one, or `None` when it

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -492,46 +492,65 @@ pub fn rename_with_diagnosis(
     // Method rename — match `word` against any class's methods
     // / classmethods / properties at the cursor's byte offset.
     let cursor_offset = crate::definition::byte_offset_at(&line_index, source, line, character);
-    // The safety gate again, for the member *this* tier resolves.
-    //
-    // `pre_edit_refusal` can only speak for a cursor a trusted dispatch tier
-    // claims; this tier answers the rest — the method word inside an
-    // untracked `[$other X]`, the bareword in `export … X …` — and those are
-    // precisely the positions from which the idx-79 hazard used to emit a
-    // declaration-only edit set that breaks the program once applied. Asking
-    // the same question about the same member here makes the verdict
-    // independent of *which occurrence* the rename was triggered from
-    // (issue #923 idx 79, verification pass).
-    //
-    // It runs here rather than in `pre_edit_refusal` so the tier order is
-    // preserved exactly: a cursor an earlier tier claims (a local variable, a
-    // proc, a class) is renamed by that tier and never consulted about a
-    // same-spelled member.
+    gated_untargeted_member_rename(
+        source,
+        dialect,
+        (&word, new_name),
+        analysis,
+        cursor_offset,
+        &line_index,
+    )
+    .map(Option::unwrap_or_default)
+}
+
+/// The **untargeted** member-rename tier, behind the safety gate — the last
+/// tier [`rename_with_diagnosis`] tries, and the one that answers every
+/// cursor position no trusted dispatch tier claims.
+///
+/// `Err` is a refusal, `Ok(None)` means the cursor names no member here.
+///
+/// The gate runs *here* rather than in [`pre_edit_refusal`] so the tier order
+/// is preserved exactly: a cursor an earlier tier claims (a local variable, a
+/// proc, a class) is renamed by that tier and never consulted about a
+/// same-spelled member. And it runs at all because `pre_edit_refusal` can
+/// only speak for a cursor [`method_rename_target`] resolves — the member's
+/// own declaration name, a `my` dispatch, a tracked `$obj` dispatch. The
+/// positions this tier owns (the method word inside an untracked `[$other
+/// X]`, the bareword in `export … X …`) are precisely the ones from which the
+/// idx-79 hazard used to emit a declaration-only edit set that breaks the
+/// program once applied. Asking the same question about the same member here
+/// makes the verdict independent of *which occurrence* the rename was
+/// triggered from (issue #923 idx 79, verification pass).
+fn gated_untargeted_member_rename(
+    source: &str,
+    dialect: &str,
+    (word, new_name): (&str, &str),
+    analysis: &AnalysisResult,
+    cursor_offset: u32,
+    line_index: &LineIndex,
+) -> Result<Option<Vec<TextEdit>>, crate::rename_safety::RenameRefusal> {
     if let Some((seed_class, method, is_classmethod)) =
-        untargeted_member_rename_target(analysis, &word, cursor_offset)
+        untargeted_member_rename_target(analysis, word, cursor_offset)
         && let Some(refusal) = member_rename_hazard(
             source,
             dialect,
             analysis,
             (&seed_class, &method, is_classmethod),
             new_name,
-            &line_index,
+            line_index,
         )
     {
         return Err(refusal);
     }
-    if let Some(edits) = rename_method(
+    Ok(rename_method(
         source,
         dialect,
-        &word,
+        word,
         new_name,
         analysis,
         cursor_offset,
-        &line_index,
-    ) {
-        return Ok(edits);
-    }
-    Ok(Vec::new())
+        line_index,
+    ))
 }
 
 /// The refusal for a cursor sitting on a **namespace name** — a word the
@@ -3869,7 +3888,7 @@ mod tests {
 
     /// The exact source the trigger-position tests share — the copy-
     /// constructor shape from nico-robert/tomato's `Vector3d.tcl`, with the
-    /// `export` list the finding's WorkspaceEdit also rewrote.
+    /// `export` list the finding's `WorkspaceEdit` also rewrote.
     ///
     /// Line/column map (0-based):
     ///   4  col 23 — the `X` inside `[$other X]`   (untracked call site)

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -3852,4 +3852,158 @@ mod tests {
         // partial set.
         assert!(rename(src, "tcl8.6", 6, 11, "GetX", &analysis, None).is_empty());
     }
+
+    // -- idx 79: the gate must not depend on the trigger position ---------
+    //
+    // The declaration-anchored refusal above was the *only* direction the
+    // gate covered.  A real editor's "rename symbol" gesture can be invoked
+    // from any occurrence, and from the two below the server used to return a
+    // live WorkspaceEdit rewriting only the declaration and the `export`
+    // word.  Applying that edit and running it (tclsh 9.0.4 and 8.6.16, byte
+    // identical):
+    //
+    //   unknown method "X": must be Get, GetX, Y, Z or destroy
+    //
+    // at the constructor's own `[$args X]`.  Every position that names the
+    // same member must therefore reach the same verdict.
+
+    /// The exact source the trigger-position tests share — the copy-
+    /// constructor shape from nico-robert/tomato's `Vector3d.tcl`, with the
+    /// `export` list the finding's WorkspaceEdit also rewrote.
+    ///
+    /// Line/column map (0-based):
+    ///   4  col 23 — the `X` inside `[$other X]`   (untracked call site)
+    ///   6  col 11 — the `X` of `method X`          (declaration)
+    ///   8  col 11 — the `X` in `export X Get`      (export bareword)
+    const IDX79_HAZARD: &str = "oo::class create Vector3d {\n\
+         \x20   variable _x _y\n\
+         \x20   constructor {args} {\n\
+         \x20       set other [lindex $args 0]\n\
+         \x20       set _x [$other X]\n\
+         \x20   }\n\
+         \x20   method X {} { return $_x }\n\
+         \x20   method Get {} { return \"$_x $_y\" }\n\
+         \x20   export X Get\n\
+         }\n";
+
+    /// The same class with **every** receiver tracked: `$v` is bound by
+    /// `Vector3d new`, so the reference scan rewrites its dispatch and there
+    /// is no hazard.  The true-negative control for the tests below — an
+    /// over-broad gate would refuse this too and make rename unusable.
+    ///
+    /// Line/column map (0-based):
+    ///   1  col 11 — the `X` of `method X`          (declaration)
+    ///   2  col 31 — the `X` inside `[my X]`        (`my` dispatch)
+    ///   3  col 11 — the `X` in `export X Get`      (export bareword)
+    ///   6  col  9 — the `X` inside `[$v X]`        (tracked `$obj` dispatch)
+    const IDX79_SAFE: &str = "oo::class create Vector3d {\n\
+         \x20   method X {} { return 1 }\n\
+         \x20   method Get {} { return [my X] }\n\
+         \x20   export X Get\n\
+         }\n\
+         set v [Vector3d new]\n\
+         puts [$v X]\n";
+
+    /// Every trigger position that reaches the hazardous member refuses —
+    /// declaration, untracked call site, and `export` bareword alike.
+    #[test]
+    fn fp_rename_refuses_the_untracked_receiver_from_every_trigger_position() {
+        let analysis = analyse(IDX79_HAZARD);
+        for (line, character, what) in [
+            (4, 23, "the untracked `[$other X]` call site"),
+            (6, 11, "the `method X` declaration"),
+            (8, 11, "the `export X Get` bareword"),
+        ] {
+            let err = rename_with_diagnosis(
+                IDX79_HAZARD,
+                "tcl8.6",
+                line,
+                character,
+                "GetX",
+                &analysis,
+                None,
+            )
+            .map_or_else(
+                |err| err,
+                |edits| panic!("{what} must refuse; it returned {edits:?} instead"),
+            );
+            assert!(
+                err.reason.contains("not tracked"),
+                "{what}: the refusal must name the untracked receiver, got {}",
+                err.reason
+            );
+            assert!(
+                rename(IDX79_HAZARD, "tcl8.6", line, character, "GetX", &analysis, None).is_empty(),
+                "{what} must never yield a partial edit set"
+            );
+        }
+    }
+
+    /// TN control: with every receiver tracked the rename still succeeds from
+    /// each of the same trigger positions, and the applied result rewrites
+    /// the declaration, the dispatches, *and* the export word together —
+    /// the property that makes the edit safe to run.
+    #[test]
+    fn fn_guard_a_fully_tracked_member_renames_from_every_trigger_position() {
+        let analysis = analyse(IDX79_SAFE);
+        for (line, character, what) in [
+            (1, 11, "the `method X` declaration"),
+            (2, 31, "the `my X` dispatch"),
+            (3, 11, "the `export X Get` bareword"),
+            (6, 9, "the tracked `[$v X]` call site"),
+        ] {
+            let edits =
+                rename_with_diagnosis(IDX79_SAFE, "tcl8.6", line, character, "GetX", &analysis, None)
+                    .unwrap_or_else(|err| panic!("{what} must not refuse: {}", err.reason));
+            let applied = apply_edits(IDX79_SAFE, &edits);
+            assert!(
+                applied.contains("method GetX {}"),
+                "{what}: declaration must rename: {applied}"
+            );
+            assert!(
+                applied.contains("[my GetX]"),
+                "{what}: the `my` dispatch must rename: {applied}"
+            );
+            assert!(
+                applied.contains("export GetX Get"),
+                "{what}: the export word must rename: {applied}"
+            );
+            assert!(
+                !applied.contains(" X]") && !applied.contains("method X "),
+                "{what}: no occurrence of the old name may survive: {applied}"
+            );
+        }
+    }
+
+    /// The resolution the gate piggy-backs on answers for exactly the
+    /// positions the untargeted tier claims, and abstains elsewhere — so
+    /// broadening the gate cannot start refusing renames an earlier tier owns.
+    #[test]
+    fn untargeted_member_target_answers_only_inside_the_class_body() {
+        let analysis = analyse(IDX79_HAZARD);
+        let line_index = LineIndex::new(IDX79_HAZARD);
+        let at = |line: u32, ch: u32| {
+            crate::definition::byte_offset_at(&line_index, IDX79_HAZARD, line, ch)
+        };
+        assert_eq!(
+            untargeted_member_rename_target(&analysis, "X", at(8, 11)),
+            Some(("::Vector3d".to_owned(), "X".to_owned(), false)),
+            "the export bareword names the member"
+        );
+        assert_eq!(
+            untargeted_member_rename_target(&analysis, "X", at(4, 23)),
+            Some(("::Vector3d".to_owned(), "X".to_owned(), false)),
+            "the untracked call site's method word names the member"
+        );
+        assert_eq!(
+            untargeted_member_rename_target(&analysis, "other", at(4, 18)),
+            None,
+            "a word that names no member of the enclosing class must abstain"
+        );
+        assert_eq!(
+            untargeted_member_rename_target(&analysis, "X", 0),
+            None,
+            "outside any class body there is no member to resolve"
+        );
+    }
 }

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -3933,7 +3933,16 @@ mod tests {
                 err.reason
             );
             assert!(
-                rename(IDX79_HAZARD, "tcl8.6", line, character, "GetX", &analysis, None).is_empty(),
+                rename(
+                    IDX79_HAZARD,
+                    "tcl8.6",
+                    line,
+                    character,
+                    "GetX",
+                    &analysis,
+                    None
+                )
+                .is_empty(),
                 "{what} must never yield a partial edit set"
             );
         }
@@ -3952,9 +3961,10 @@ mod tests {
             (3, 11, "the `export X Get` bareword"),
             (6, 9, "the tracked `[$v X]` call site"),
         ] {
-            let edits =
-                rename_with_diagnosis(IDX79_SAFE, "tcl8.6", line, character, "GetX", &analysis, None)
-                    .unwrap_or_else(|err| panic!("{what} must not refuse: {}", err.reason));
+            let edits = rename_with_diagnosis(
+                IDX79_SAFE, "tcl8.6", line, character, "GetX", &analysis, None,
+            )
+            .unwrap_or_else(|err| panic!("{what} must not refuse: {}", err.reason));
             let applied = apply_edits(IDX79_SAFE, &edits);
             assert!(
                 applied.contains("method GetX {}"),

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -8443,6 +8443,76 @@ impl Backend {
         Vec::new()
     }
 
+    /// Cross-file **hover** for a `TclOO` method dispatch: the same dispatch
+    /// entry [`Self::cross_file_method_definition`] jumps to, rendered as the
+    /// one-line summary the in-document hover renders (issue #923 idx 28).
+    ///
+    /// The in-document provider (`core_hover`'s `method_dispatch_hover`) is
+    /// MRO-aware, but only over `analysis.all_classes` — the classes *this*
+    /// document declares.  The finding's real corpus shape is cross-file:
+    /// `my ArgsPreprocess` in a device file, the `mixin` that provides it in
+    /// the library file.  Definition and references crossed that boundary
+    /// through the workspace index; hover returned nothing at all.
+    ///
+    /// Deliberately built on the *same* resolution and the *same* chain walk
+    /// as the definition tier — [`Self::resolve_method_target`] then
+    /// `method_dispatch_chain` / `class_method_dispatch_chain` — rather than
+    /// a parallel lookup, so hover can never name a provider the definition
+    /// jump would not land on.
+    async fn cross_file_method_hover(
+        &self,
+        uri: &Uri,
+        doc: &DocumentState,
+        analysis: &AnalysisResult,
+        pos: Position,
+    ) -> Option<CoreHover> {
+        let (class_q, method, is_classmethod, access) = self
+            .resolve_method_target(uri, &doc.text, &doc.dialect, analysis, pos)
+            .await?;
+        let chain: Vec<(String, String)> = {
+            let index = self.workspace_index.read().await;
+            if is_classmethod {
+                index.class_method_dispatch_chain(&class_q, &method, access)
+            } else {
+                index.method_dispatch_chain(&class_q, &method, access)
+            }
+            .into_iter()
+            .map(|wc| (wc.uri.clone(), wc.qualified_name.clone()))
+            .collect()
+        };
+        // The chain's first record is the dispatch entry; the rest is the
+        // `next` chain, which hover does not describe.
+        for (u, provider_q) in chain {
+            let Ok(parsed) = Uri::from_str(&u) else {
+                continue;
+            };
+            let Some(target_doc) = self.read_document(&parsed).await else {
+                continue;
+            };
+            let target_analysis = self
+                .analysis_for(&parsed, target_doc.text.clone(), target_doc.dialect.clone())
+                .await;
+            let Some(class_def) = target_analysis.all_classes.get(&provider_q) else {
+                continue;
+            };
+            let (a, b) = if is_classmethod {
+                (&class_def.class_methods, &class_def.methods)
+            } else {
+                (&class_def.methods, &class_def.class_methods)
+            };
+            if let Some(m) = a.get(&method).or_else(|| b.get(&method)) {
+                return Some(core_hover::cross_document_method_hover(
+                    &class_q,
+                    &provider_q,
+                    &m.name,
+                    m.params.len(),
+                    is_classmethod,
+                ));
+            }
+        }
+        None
+    }
+
     /// Add cross-document rename edits for the proc / class at
     /// `pos` into `changes`.  Resolves the symbol, asks the core
     /// rename provider for the namespace-aware sibling-document
@@ -14897,10 +14967,33 @@ impl LanguageServer for Backend {
             }
             return Ok(Some(lift_hover(hover)));
         }
-        // Nothing in this document explains the word.  A namespace-qualified
-        // variable whose declaration is in a sibling document is answered
-        // first — a `$var` site is never a command head, so it would never
-        // reach the tiers below (issue #923 idx 65 / 75 / 78).
+        // Nothing in this document explains the word.  A per-object
+        // visibility mask makes `$obj m` answer `unknown method` regardless
+        // of the class chain, so it is a *definitive* no-hover and must not
+        // fall through to the cross-file method tier — the same gate
+        // `compute_definition` applies ahead of its own (issue #1170).
+        if core_definition::object_masks_external_dispatch(
+            &analysis,
+            &doc.text,
+            pos.line,
+            pos.character,
+        ) {
+            return Ok(None);
+        }
+        // A `my method` / `$obj method` dispatch whose provider class lives
+        // in a sibling document (issue #923 idx 28).  Answered before the
+        // command-head tiers because a method-name token is never a command
+        // head — its head is `my` / `$obj` — so it would otherwise never
+        // reach any cross-document tier at all.
+        if let Some(hover) = self
+            .cross_file_method_hover(&uri, &doc, &analysis, pos)
+            .await
+        {
+            return Ok(Some(lift_hover(hover)));
+        }
+        // A namespace-qualified variable whose declaration is in a sibling
+        // document — a `$var` site is never a command head either, so it
+        // would never reach the tiers below (issue #923 idx 65 / 75 / 78).
         if let Some(hover) = self
             .cross_document_variable_hover(&uri, &doc.text, pos, &analysis)
             .await

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -14596,8 +14596,17 @@ impl LanguageServer for Backend {
         let analysis_for_worker = analysis.clone();
         let new_name_worker = new_name.clone();
         let registry_worker = registry;
+        // `rename_with_diagnosis`, not `rename`: the in-document tiers carry
+        // their own safety gate for the cursor positions the workspace gate
+        // above cannot resolve — an untracked `[$other X]` dispatch, an
+        // `export … X …` bareword — and a refusal from them must reach the
+        // editor as an error with its reason, exactly like the workspace
+        // gate's.  Flattening it to an empty edit set would present the one
+        // hazard the gate exists to stop as "nothing renameable here" and let
+        // the cross-document tier below build edits for it (issue #923 idx
+        // 79, verification pass).
         let edits = tokio::task::spawn_blocking(move || {
-            core_rename::rename(
+            core_rename::rename_with_diagnosis(
                 &text,
                 &dialect,
                 pos.line,
@@ -14612,7 +14621,8 @@ impl LanguageServer for Backend {
             code: jsonrpc::ErrorCode::InternalError,
             message: format!("rename worker panicked: {err}").into(),
             data: None,
-        })?;
+        })?
+        .map_err(|refusal| rename_refusal_error(&refusal))?;
         let mut changes: std::collections::HashMap<Uri, Vec<TextEdit>> =
             std::collections::HashMap::new();
         // An empty in-document result means the rename was *rejected*

--- a/rust/tcl-lsp-server/tests/e2e.rs
+++ b/rust/tcl-lsp-server/tests/e2e.rs
@@ -57,6 +57,8 @@ mod invariants;
 mod irules;
 #[path = "e2e/issue1001.rs"]
 mod issue1001;
+#[path = "e2e/issue1019_proc_args.rs"]
+mod issue1019_proc_args;
 #[path = "e2e/issue1088_namespace_symbols.rs"]
 mod issue1088_namespace_symbols;
 #[path = "e2e/issue1122_sticky_scroll.rs"]

--- a/rust/tcl-lsp-server/tests/e2e/issue1019_proc_args.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue1019_proc_args.rs
@@ -296,7 +296,7 @@ fn tp_next_in_a_constructor_resolves_to_the_superclass_constructor() {
     );
     // Control: the ordinary-method `next` on the same class still resolves to
     // the method, so the two forms are symmetric.
-    let method = lsp.definition(&uri, 7, 32);
+    let method = lsp.definition(&uri, 7, 34);
     assert_eq!(
         lines_in(&method, &uri),
         vec![2],

--- a/rust/tcl-lsp-server/tests/e2e/issue1019_proc_args.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue1019_proc_args.rs
@@ -1,0 +1,527 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Issue #1019 differential audit, `proc_args` group — the end-to-end tier.
+//!
+//! Findings idx 11 / 28 / 37 / 62 / 67 / 104.  Each of these was already
+//! fixed in the providers and covered by unit tests, but had no test at the
+//! wire tier — or, for idx 28, was fixed only for the single-file shape while
+//! the corpus shape is cross-file.  Every claim below is pinned against
+//! tclsh 9.0.4 and 8.6.16, which agree byte-for-byte; each test records the
+//! transcript it was written against.
+
+use crate::common::helpers::*;
+use crate::common::{Lsp, unique_uri};
+use serde_json::Value;
+
+/// The definition/reference target start lines that land in document `uri`.
+fn lines_in(result: &Value, uri: &str) -> Vec<i64> {
+    locations(result)
+        .iter()
+        .filter(|l| l.uri == uri)
+        .map(|l| {
+            l.range
+                .get("start")
+                .and_then(|s| s.get("line"))
+                .and_then(Value::as_i64)
+                .unwrap_or(-1)
+        })
+        .collect()
+}
+
+/// Every diagnostic code in `diags`, in wire order.
+fn codes(diags: &[Value]) -> Vec<String> {
+    diags
+        .iter()
+        .map(|d| {
+            d.get("code")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned()
+        })
+        .collect()
+}
+
+// -- idx 11: a proc named after a package-gated registry command ---------
+
+// FP guard.  georgtree/argparse's own implementation file defines `proc
+// ::argparse {args}` — the entry point of the `argparse` *package*, which the
+// registry also models as a command.  Neither W113 ("shadows built-in
+// command") nor W120 ("requires `package require argparse`") describes
+// anything real here: the proc *is* the package's definition, and nothing
+// needs loading to make the name exist.
+//
+// Oracle, tclsh 9.0.4 and 8.6.16 identically: `info commands argparse` is
+// empty in a bare interpreter and a bare `argparse` errors `invalid command
+// name "argparse"` — so it is not a built-in — while sourcing the file and
+// calling `argparse` with no arguments prints `case0`.
+#[test]
+fn fp_a_proc_named_after_a_package_gated_command_is_not_flagged() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc ::argparse {args} {\n\
+         \x20   if {[llength $args] == 0} { return case0 }\n\
+         \x20   return [lindex $args 0]\n\
+         }\n\
+         puts [argparse]\n",
+    );
+    let seen = codes(&diags);
+    assert!(
+        !seen.iter().any(|c| c == "W113"),
+        "the proc defines the package's own command; it shadows no built-in: {seen:?}"
+    );
+    assert!(
+        !seen.iter().any(|c| c == "W120"),
+        "the file defines `argparse` itself, so no `package require` is missing: {seen:?}"
+    );
+    assert!(
+        !seen.iter().any(|c| c == "E002" || c == "E003"),
+        "the 0-argument call runs (`case0`); no arity error may fire: {seen:?}"
+    );
+}
+
+// FP guard, the side discovery the verification pass found: the *consumer*
+// half.  A file that `source`s the definition above and calls `argparse` with
+// no arguments got a hard `E002 Too few arguments for 'argparse': expected at
+// least 1, got 0` — resolved against the *package's* spec, which this
+// workspace never loads.
+//
+// Oracle (9.0.4 / 8.6.16, running the pair): `case0`.  The call is correct.
+//
+// The analyser is single-file by construction, so it cannot see the sourced
+// definition; what it *can* see is that the package is not required here, and
+// a count assertion against a spec whose command is not proven to be the one
+// being called is exactly the false positive.  W120 still reports (as a
+// warning, and the workspace tier may retract it) — the arity error must not.
+#[test]
+fn fp_no_arity_error_for_a_package_command_the_document_never_loads() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "source helper.tcl\nputs [argparse]\n");
+    let seen = codes(&diags);
+    assert!(
+        !seen.iter().any(|c| c == "E002" || c == "E003"),
+        "no arity verdict may be asserted against an unloaded package's spec: {seen:?}"
+    );
+}
+
+// TP control for both guards above: with the package actually required, the
+// identity *is* proven, and a genuinely bad call is still an error.
+//
+// Oracle (9.0.4 / 8.6.16, with tcllib's argparse installed): `argparse`
+// with no arguments raises `wrong # args`.
+#[test]
+fn tp_arity_still_fires_for_a_package_command_the_document_requires() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "package require argparse\nputs [argparse]\n");
+    let seen = codes(&diags);
+    assert!(
+        seen.iter().any(|c| c == "E002"),
+        "a required package's spec is the command being called — arity must \
+         still be checked: {seen:?}"
+    );
+    assert!(
+        !seen.iter().any(|c| c == "W120"),
+        "the package is required, so W120 must not fire: {seen:?}"
+    );
+}
+
+// TP control for the W113 half: redefining a real core built-in still warns.
+// It is the *package-gated* exclusion that idx 11 added, not a blanket one.
+#[test]
+fn tp_redefining_a_core_builtin_still_fires_w113() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "proc lindex {a b} { return $a }\n");
+    assert!(
+        codes(&diags).iter().any(|c| c == "W113"),
+        "`lindex` is a core built-in: {:?}",
+        codes(&diags)
+    );
+}
+
+// -- idx 28: cross-file mixin / inherited method hover -------------------
+
+// TP.  SpiceGenTcl's shape: `Utility` (the mixin) and `Model` live in the
+// library file, `RModel` in the device file, and `RModel`'s constructor calls
+// `my ArgsPreprocess` — a two-hop `mixin` + `superclass` MRO dispatch that
+// crosses documents.
+//
+// Oracle (9.0.4 / 8.6.16, sourcing both files and instantiating `RModel`):
+// `ArgsPreprocess dispatched via class: ::Demo::Utility` — the call really
+// does reach `Utility`'s method.
+//
+// Go-to-definition already crossed the boundary; hover answered nothing at
+// all, because the in-document hover provider only knows the classes this
+// document declares.
+#[test]
+fn tp_cross_file_mixin_method_hover() {
+    let mut lsp = Lsp::tcl();
+    let lib = unique_uri("tcl");
+    lsp.open_ready(
+        &lib,
+        "namespace eval ::Demo {\n\
+         \x20   oo::class create Utility {\n\
+         \x20       method ArgsPreprocess {switches params supp args} { return ok }\n\
+         \x20   }\n\
+         \x20   oo::class create Model {\n\
+         \x20       mixin Utility\n\
+         \x20   }\n\
+         }\n",
+    );
+    let dev = unique_uri("tcl");
+    lsp.open_ready(
+        &dev,
+        "namespace eval ::Demo::Xyce {\n\
+         \x20   oo::class create RModel {\n\
+         \x20       superclass ::Demo::Model\n\
+         \x20       constructor {args} {\n\
+         \x20           my ArgsPreprocess {defw r} {name type} type {*}$args\n\
+         \x20       }\n\
+         \x20   }\n\
+         }\n",
+    );
+
+    // Cursor on `ArgsPreprocess` in the `my` dispatch.
+    let text = hover_text(&lsp.hover(&dev, 4, 20));
+    assert!(
+        text.contains("ArgsPreprocess"),
+        "hover must name the method it dispatches to, got {text:?}"
+    );
+    assert!(
+        text.contains("::Demo::Utility"),
+        "hover must name the *providing* class from the sibling document, got {text:?}"
+    );
+    assert!(
+        text.contains("inherited from"),
+        "the MRO note is the fact that makes the answer useful, got {text:?}"
+    );
+    // The hover and the definition jump must agree about the provider.
+    let def = lsp.definition(&dev, 4, 20);
+    assert_eq!(
+        lines_in(&def, &lib),
+        vec![2],
+        "definition must land on `Utility`'s declaration: {:?}",
+        locations(&def)
+    );
+}
+
+// TN control: a `my` dispatch of a method no class in the chain provides has
+// no cross-file answer to give.  Without this, "hover something, anything"
+// would pass the test above.
+#[test]
+fn tn_cross_file_hover_abstains_for_a_method_no_class_provides() {
+    let mut lsp = Lsp::tcl();
+    let lib = unique_uri("tcl");
+    lsp.open_ready(
+        &lib,
+        "namespace eval ::Demo {\n\
+         \x20   oo::class create Utility {\n\
+         \x20       method ArgsPreprocess {a} { return ok }\n\
+         \x20   }\n\
+         \x20   oo::class create Model {\n\
+         \x20       mixin Utility\n\
+         \x20   }\n\
+         }\n",
+    );
+    let dev = unique_uri("tcl");
+    lsp.open_ready(
+        &dev,
+        "namespace eval ::Demo::Xyce {\n\
+         \x20   oo::class create RModel {\n\
+         \x20       superclass ::Demo::Model\n\
+         \x20       constructor {args} {\n\
+         \x20           my NoSuchMember\n\
+         \x20       }\n\
+         \x20   }\n\
+         }\n",
+    );
+    let text = hover_text(&lsp.hover(&dev, 4, 20));
+    assert!(
+        !text.contains("ArgsPreprocess"),
+        "an unprovided member must not borrow a sibling's hover, got {text:?}"
+    );
+}
+
+// -- idx 37: `next` inside a constructor ---------------------------------
+
+// TP, the definition half (the arity half already has an e2e test).
+// `next` in a constructor dispatches to the superclass's *constructor*, which
+// is not in the class's method table at all — so it used to resolve to
+// nothing while the identical `next` in an ordinary method resolved fine.
+//
+// Oracle (9.0.4 / 8.6.16): `Base ctor n=5` then `Derived describe` — the
+// constructor `next` really does run `Base`'s constructor.
+#[test]
+fn tp_next_in_a_constructor_resolves_to_the_superclass_constructor() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "oo::class create Base {\n\
+         \x20   constructor {n} { puts \"Base ctor n=$n\" }\n\
+         \x20   method describe {} { return Base }\n\
+         }\n\
+         oo::class create Derived {\n\
+         \x20   superclass Base\n\
+         \x20   constructor {n} { next $n }\n\
+         \x20   method describe {} { return [next] }\n\
+         }\n",
+    );
+    // Cursor on the `next` inside `Derived`'s constructor.
+    let ctor = lsp.definition(&uri, 6, 23);
+    assert_eq!(
+        lines_in(&ctor, &uri),
+        vec![1],
+        "`next` in a constructor must resolve to `Base`'s constructor: {:?}",
+        locations(&ctor)
+    );
+    // Control: the ordinary-method `next` on the same class still resolves to
+    // the method, so the two forms are symmetric.
+    let method = lsp.definition(&uri, 7, 32);
+    assert_eq!(
+        lines_in(&method, &uri),
+        vec![2],
+        "`next` in a method must resolve to `Base`'s method: {:?}",
+        locations(&method)
+    );
+}
+
+// -- idx 62: a bare `[list procName ...]` command-prefix callback --------
+
+// TP.  ticklecharts' shape: a `trace add variable` write callback built with
+// a bare `[list procName baked args]` — no `namespace code` wrapper, and with
+// further baked arguments after the head, one of them a nested command
+// substitution.
+//
+// Oracle (9.0.4 / 8.6.16): the trace fires, printing
+// `onVersionWrite called: minversion=1.0.0 baseversion=0.9.0` — the callback
+// head really is `demo::onVersionWrite`.
+#[test]
+fn tp_references_reach_a_bare_list_built_trace_callback() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "namespace eval demo {\n\
+         \x20   variable echarts_version 0.9.0\n\
+         \x20   proc MINVER {} { return 1.0.0 }\n\
+         \x20   proc onVersionWrite {minv basev args} { return $minv }\n\
+         \x20   trace add variable echarts_version write \
+         [list demo::onVersionWrite [MINVER] $echarts_version]\n\
+         }\n",
+    );
+    // From the declaration: the callback head must be a reference.
+    let from_decl = lsp.references(&uri, 3, 10, true);
+    let decl_lines = lines_in(&from_decl, &uri);
+    assert!(
+        decl_lines.contains(&3),
+        "the declaration itself must be included: {decl_lines:?}"
+    );
+    assert!(
+        decl_lines.contains(&4),
+        "the `[list demo::onVersionWrite ...]` callback head must be a \
+         reference: {decl_lines:?}"
+    );
+    // And from the callback head itself, go-to-definition must land on the
+    // proc — the same relationship read the other way.
+    let def = lsp.definition(&uri, 4, 51);
+    assert_eq!(
+        lines_in(&def, &uri),
+        vec![3],
+        "the callback head must resolve to the proc: {:?}",
+        locations(&def)
+    );
+}
+
+// TN control: a `[list ...]` whose head names nothing resolves to nothing —
+// the mechanism reads the written head, it does not guess.
+#[test]
+fn tn_a_list_built_callback_head_that_names_nothing_resolves_to_nothing() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "namespace eval demo {\n\
+         \x20   variable v 1\n\
+         \x20   proc onWrite {args} { return 1 }\n\
+         \x20   trace add variable v write [list demo::notDefined $v]\n\
+         }\n",
+    );
+    let def = lsp.definition(&uri, 3, 40);
+    assert!(
+        locations(&def).is_empty(),
+        "an undefined callback head must resolve to nothing: {:?}",
+        locations(&def)
+    );
+}
+
+// -- idx 67: a qualified proc written outside its namespace block --------
+
+// TP.  pix's shape: `namespace eval ::pix { namespace eval svg {} }` opens the
+// namespaces, and `proc pix::svg::parse {...}` is written afterwards at the
+// top level.  The proc belongs to `::pix::svg` and must be shown there.
+//
+// Oracle (9.0.4 / 8.6.16): `namespace which -command pix::svg::parse` answers
+// `::pix::svg::parse`.
+#[test]
+fn tp_a_qualified_proc_nests_under_the_namespace_it_names() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "namespace eval ::pix {\n\
+         \x20   namespace eval svg {}\n\
+         }\n\
+         proc pix::svg::parse {svg} { return $svg }\n",
+    );
+    let symbols = lsp.document_symbols(&uri);
+    let flat = symbols.to_string();
+    assert!(
+        flat.contains("parse"),
+        "the proc must appear in the outline: {flat}"
+    );
+    // `parse` must be a *descendant* of the `::pix` namespace symbol, not a
+    // sibling of it at the top level.
+    let top = symbols.as_array().cloned().unwrap_or_default();
+    let top_names: Vec<String> = top
+        .iter()
+        .map(|s| {
+            s.get("name")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned()
+        })
+        .collect();
+    assert!(
+        !top_names.iter().any(|n| n == "parse"),
+        "`parse` must not float at the top level beside the namespace tree: {top_names:?}"
+    );
+    let pix = top
+        .iter()
+        .find(|s| {
+            s.get("name")
+                .and_then(Value::as_str)
+                .is_some_and(|n| n.contains("pix"))
+        })
+        .expect("the `::pix` namespace must be in the outline");
+    assert!(
+        pix.to_string().contains("parse"),
+        "`parse` must nest beneath `::pix`: {pix}"
+    );
+}
+
+// TN control (the finding's own auto-vivification refutation): a qualified
+// proc whose namespace was *never* opened must stay where it was written —
+// `proc` does not create the namespace, so there is nothing to nest under.
+#[test]
+fn tn_a_qualified_proc_whose_namespace_is_never_opened_stays_put() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, "proc never::opened::parse {svg} { return $svg }\n");
+    let symbols = lsp.document_symbols(&uri);
+    let top = symbols.as_array().cloned().unwrap_or_default();
+    assert!(
+        !top.iter().any(|s| s
+            .get("name")
+            .and_then(Value::as_str)
+            .is_some_and(|n| n.contains("never"))),
+        "no namespace symbol may be invented for an unopened namespace: {symbols}"
+    );
+}
+
+// -- idx 104: a parameter whose name shadows a command -------------------
+
+// TP.  Tk's `library/tk.tcl` shape: `proc ::tk::RestoreFocusGrab {grab focus
+// {destroy destroy}}` — the third parameter is named `destroy` and defaults
+// to the *literal* `destroy`, while a `destroy` command also exists.
+//
+// Oracle (9.0.4 / 8.6.16): `$destroy` always reads the local parameter and a
+// bare `destroy $grab` always calls the command — the two never mix.
+//
+// The hover half is covered by `parameter_default_literal_does_not_hover_923_idx104`;
+// this pins the definition and references half at the wire tier.
+#[test]
+fn tp_a_parameter_shadowing_a_proc_resolves_to_itself() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "proc destroy {w} { return \"destroying $w\" }\n\
+         proc RestoreFocusGrab {grab focus {destroy destroy}} {\n\
+         \x20   if {$destroy eq \"destroy\"} { return [destroy $grab] }\n\
+         \x20   return $destroy\n\
+         }\n",
+    );
+    // Cursor on the parameter's own declaration name.
+    let def = lsp.definition(&uri, 1, 36);
+    assert_eq!(
+        lines_in(&def, &uri),
+        vec![1],
+        "the parameter's own name must resolve to itself, not the same-named \
+         proc on line 0: {:?}",
+        locations(&def)
+    );
+    // References from the parameter reach both `$destroy` reads and never the
+    // proc's declaration.
+    let refs = lsp.references(&uri, 1, 36, true);
+    let ref_lines = lines_in(&refs, &uri);
+    assert!(
+        ref_lines.contains(&2) && ref_lines.contains(&3),
+        "both `$destroy` reads must be references: {ref_lines:?}"
+    );
+    assert!(
+        !ref_lines.contains(&0),
+        "the unrelated `proc destroy` must never be a reference to the \
+         parameter: {ref_lines:?}"
+    );
+}
+
+// TN control: the parameter's *default value* word is pure data — it names
+// nothing, so it must resolve to nothing rather than to the same-spelled
+// command.
+#[test]
+fn tn_a_parameter_default_literal_names_nothing() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "proc destroy {w} { return \"destroying $w\" }\n\
+         proc RestoreFocusGrab {grab focus {destroy destroy}} {\n\
+         \x20   return [destroy $grab]\n\
+         }\n",
+    );
+    // Cursor on the default-value word.
+    let def = lsp.definition(&uri, 1, 44);
+    assert!(
+        locations(&def).is_empty(),
+        "a parameter default literal is data, not a reference: {:?}",
+        locations(&def)
+    );
+    // FP guard: the *real* call in the body still resolves to the proc.
+    let call = lsp.definition(&uri, 2, 12);
+    assert_eq!(
+        lines_in(&call, &uri),
+        vec![0],
+        "the bare `destroy $grab` call must still reach the proc: {:?}",
+        locations(&call)
+    );
+}

--- a/rust/tcl-lsp-server/tests/e2e/rename_safety.rs
+++ b/rust/tcl-lsp-server/tests/e2e/rename_safety.rs
@@ -811,3 +811,148 @@ fn fp_namespace_rename_refuses_a_collision_with_an_existing_namespace() {
         "the refusal must name the collision, got {err}",
     );
 }
+
+// -- idx 79: the gate must hold from EVERY trigger position -------------
+//
+// The declaration-anchored refusal above was the only direction covered, and
+// it is the one position a real editor's "rename symbol" gesture is *least*
+// likely to be used from.  Triggering the identical rename from the untracked
+// call site the gate exists for, or from the `export` bareword, returned a
+// live WorkspaceEdit rewriting only the declaration and the export word.
+//
+// Applying that edit and running the file (tclsh 9.0.4 and 8.6.16, byte
+// identical, rc=1):
+//
+//   unknown method "X": must be Get, GetX, Y, Z or destroy
+//       while executing
+//   "$args X"
+//
+// at the copy-constructor's own dispatch.  Every position that names the same
+// member must reach the same verdict.
+
+/// The idx-79 hazard shape, shared by the trigger-position tests.
+///
+/// Line/column map (0-based):
+///   5  col 23 — the `X` inside `[$other X]`   (untracked call site)
+///   10 col 11 — the `X` of `method X`          (declaration)
+///   12 col 11 — the `X` in `export X Get`      (export bareword)
+const IDX79_HAZARD: &str = "oo::class create Vector3d {\n\
+     \x20   variable _x _y\n\
+     \x20   constructor {args} {\n\
+     \x20       if {[llength $args] == 1} {\n\
+     \x20           set other [lindex $args 0]\n\
+     \x20           set _x [$other X]\n\
+     \x20       } else {\n\
+     \x20           lassign $args _x _y\n\
+     \x20       }\n\
+     \x20   }\n\
+     \x20   method X {} { return $_x }\n\
+     \x20   method Get {} { return \"$_x $_y\" }\n\
+     \x20   export X Get\n\
+     }\n";
+
+#[test]
+fn fp_rename_refuses_the_untracked_receiver_from_the_call_site_trigger() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, IDX79_HAZARD);
+    // Cursor on the `X` of `[$other X]` — the dispatch itself.
+    let err = lsp.rename_error(&uri, 5, 23, "GetX");
+    let message = err
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        message.contains("not tracked"),
+        "renaming from the untracked call site must refuse with the reason, got {err}"
+    );
+}
+
+#[test]
+fn fp_rename_refuses_the_untracked_receiver_from_the_export_bareword_trigger() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, IDX79_HAZARD);
+    // Cursor on the `X` of `export X Get`.
+    let err = lsp.rename_error(&uri, 12, 11, "GetX");
+    let message = err
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        message.contains("not tracked"),
+        "renaming from the export bareword must refuse with the reason, got {err}"
+    );
+}
+
+#[test]
+fn fp_rename_refuses_the_untracked_receiver_from_the_declaration_trigger() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, IDX79_HAZARD);
+    let err = lsp.rename_error(&uri, 10, 11, "GetX");
+    let message = err
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        message.contains("not tracked"),
+        "renaming from the declaration must refuse with the reason, got {err}"
+    );
+}
+
+/// The invariant itself, stated once: for one hazardous member, no trigger
+/// position may answer with edits.  A gate reachable from only some of the
+/// symbol's occurrences is not a gate — this is the test that fails if a
+/// future tier is added that bypasses it.
+#[test]
+fn fp_rename_verdict_is_the_same_from_every_occurrence_of_a_hazardous_member() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, IDX79_HAZARD);
+    for (line, ch, what) in [
+        (5u32, 23u32, "the untracked `[$other X]` call site"),
+        (10, 11, "the `method X` declaration"),
+        (12, 11, "the `export X Get` bareword"),
+    ] {
+        let result = lsp.rename(&uri, line, ch, "GetX");
+        assert!(
+            rename_edits(&result).is_empty(),
+            "{what} must never yield an edit set: {result}"
+        );
+    }
+}
+
+/// TN control, the other half of the invariant: with every receiver tracked
+/// the rename succeeds from all four trigger shapes, and each answer rewrites
+/// the declaration, the `my` dispatch, the `$obj` dispatch and the export
+/// word together.
+///
+/// Oracle (9.0.4 / 8.6.16, before and after applying the complete edit):
+/// `1` — the renamed class still runs.
+#[test]
+fn fn_guard_a_fully_tracked_member_renames_from_every_trigger_position() {
+    let source = "oo::class create Vector3d {\n\
+         \x20   method X {} { return 1 }\n\
+         \x20   method Get {} { return [my X] }\n\
+         \x20   export X Get\n\
+         }\n\
+         set v [Vector3d new]\n\
+         puts [$v X]\n";
+    for (line, ch, what) in [
+        (1u32, 11u32, "the `method X` declaration"),
+        (2, 31, "the `[my X]` dispatch"),
+        (3, 11, "the `export X Get` bareword"),
+        (6, 9, "the tracked `[$v X]` call site"),
+    ] {
+        let mut lsp = Lsp::tcl();
+        let uri = unique_uri("tcl");
+        lsp.open_ready(&uri, source);
+        let result = lsp.rename(&uri, line, ch, "GetX");
+        let texts = all_texts(&result);
+        assert!(
+            texts.iter().filter(|t| *t == "GetX").count() >= 4,
+            "{what}: declaration + `my` + `$obj` + export must all rename, got {texts:?}"
+        );
+    }
+}

--- a/rust/tcl-lsp-server/tests/e2e/rename_safety.rs
+++ b/rust/tcl-lsp-server/tests/e2e/rename_safety.rs
@@ -833,7 +833,7 @@ fn fp_namespace_rename_refuses_a_collision_with_an_existing_namespace() {
 /// The idx-79 hazard shape, shared by the trigger-position tests.
 ///
 /// Line/column map (0-based):
-///   5  col 23 — the `X` inside `[$other X]`   (untracked call site)
+///   5  col 27 — the `X` inside `[$other X]`   (untracked call site)
 ///   10 col 11 — the `X` of `method X`          (declaration)
 ///   12 col 11 — the `X` in `export X Get`      (export bareword)
 const IDX79_HAZARD: &str = "oo::class create Vector3d {\n\
@@ -857,7 +857,7 @@ fn fp_rename_refuses_the_untracked_receiver_from_the_call_site_trigger() {
     let uri = unique_uri("tcl");
     lsp.open_ready(&uri, IDX79_HAZARD);
     // Cursor on the `X` of `[$other X]` — the dispatch itself.
-    let err = lsp.rename_error(&uri, 5, 23, "GetX");
+    let err = lsp.rename_error(&uri, 5, 27, "GetX");
     let message = err
         .get("message")
         .and_then(Value::as_str)
@@ -911,14 +911,23 @@ fn fp_rename_verdict_is_the_same_from_every_occurrence_of_a_hazardous_member() {
     let uri = unique_uri("tcl");
     lsp.open_ready(&uri, IDX79_HAZARD);
     for (line, ch, what) in [
-        (5u32, 23u32, "the untracked `[$other X]` call site"),
+        (5u32, 27u32, "the untracked `[$other X]` call site"),
         (10, 11, "the `method X` declaration"),
         (12, 11, "the `export X Get` bareword"),
     ] {
-        let result = lsp.rename(&uri, line, ch, "GetX");
+        // `rename_error` is the only way to read this: a refusal travels as a
+        // JSON-RPC *error*, and the plain `rename` helper panics on one.  That
+        // asymmetry is the point — a refusal must never be mistakable for an
+        // ordinary empty answer.
+        let err = lsp.rename_error(&uri, line, ch, "GetX");
         assert!(
-            rename_edits(&result).is_empty(),
-            "{what} must never yield an edit set: {result}"
+            !err.is_null(),
+            "{what} must answer a refusal, not an edit set"
+        );
+        assert_eq!(
+            err.get("code").and_then(Value::as_i64),
+            Some(-32600),
+            "{what}: the refusal must be an invalid-request error: {err}"
         );
     }
 }


### PR DESCRIPTION
Part of #1019 (proc_args cluster: idx 11, 28, 37, 62, 67, 78, 79, 104). Does not close it — the other clusters are still in flight.

## idx 79 (high) — a rename that silently breaks running code

**Root cause.** `method_rename_refusal` resolved the cursor through `method_rename_target`, which only answers for trusted tiers: a declaration span, `my`, a tracked `$obj`, or a classmethod. An **untracked call site** or an `export` bareword resolved to `None`, so `pre_edit_refusal` was skipped entirely and execution fell through to `rename_method()`, which had no hazard check at all. The existing regression test could not catch this because it only ever anchors the cursor on the declaration — the one position that was already safe.

**Fix.** A new `untargeted_member_rename_target()` performs the *same* resolution `rename_method` does, and `member_rename_hazard()` — extracted from `method_rename_refusal` so both gates ask one function rather than two that can drift — runs against it immediately before the untargeted tier. Placing it there rather than in `pre_edit_refusal` preserves tier order exactly, so a cursor an earlier tier legitimately claims (variable, proc, class) is never consulted about a same-spelled member. Server-side, `Backend::rename` now routes through `rename_with_diagnosis` and maps the error through `rename_refusal_error`, so a refusal reaches the editor as a JSON-RPC error instead of being flattened into "nothing renameable here".

**Evidence.** All three trigger positions now return an identical `-32600` refusal:

```
callsite   (10,25) -> cannot rename `X`: ... receiver whose class is not tracked ...
exportword (31,15) -> (identical)
declaration(27,11) -> (identical)
```

The true negative was validated the same way the bug was originally found — by applying the emitted edits and running the result. A fully-tracked class renamed from all four positions produced 4 edits each, byte-identical outputs, and under both interpreters:

```
tclsh9.0: Get: 7 9 / X: 7  rc=0     tclsh8.6: Get: 7 9 / X: 7  rc=0   (identical to pre-rename)
```

## idx 28 — cross-file method hover

`Backend::cross_file_method_hover` is built on the *same* `resolve_method_target` + `method_dispatch_chain` walk `cross_file_method_definition` already uses, rendering through a new `core_hover::cross_document_method_hover`. It is wired ahead of the command-head tiers (a method token is never a command head) and behind the same `object_masks_external_dispatch` gate `compute_definition` applies, so hover and definition cannot disagree.

One correction to the verification record that produced this ticket: the "cross-file `$obj` hover fails" observation was **workspace-index warmup flakiness in the one-shot CLI probe**, not a product gap — results flip between runs, and both `my` and `$obj` shapes pass reliably through the e2e and VS Code harnesses, which wait for readiness.

## idx 11 side-discovery — two false positives, one root cause

Both come from a registry `CommandSpec` for a package-gated command being treated as the identity of a call the document does not actually get from that package.

1. **W120 on a locally-defined command** (same-file, never previously reported): `proc ::argparse {args}` beside its own call was told to `package require argparse` — to require the very package it *is*. `emit_missing_package_require_diagnostics` had no shadowing gate, unlike the arity path. Added `UserResolutionFacts::declares_any`, an order-agnostic sibling of the existing `resolves_to_user` reusing the same fact table.
2. **E002 on a cross-file consumer**: a file that `source`s the definition and calls `argparse` with 0 args drew a hard error against the package spec's `min 1`. The analyser is single-file by construction, but it *can* see that the package is not loaded — and asserting an arity error while simultaneously warning the package is missing is self-contradictory. `spec_is_an_unloaded_package_command()` makes the arity verdicts abstain, scoped to E002/E003/E005 only; W001/W004 share `pending_arity` and remain valid without a `package require`, which two true-positive tests caught and are the reason for the scoping.

```
impl.tcl     (proc ::argparse + own call)   -> 0 diagnostics      (was W113 + W120)
caller.tcl   (source + argparse)            -> W120 only          (was E002 + W120)
required.tcl (package require + argparse)   -> E002 fires         TRUE POSITIVE preserved
tp_w113.tcl  (proc lindex)                  -> W113 fires         TRUE POSITIVE preserved
```

Oracle: both interpreters print `case0` for the 0-arg call, so it is correct. The residual W120 on the consumer is deliberate — a warning the always-on workspace tier can retract, not an error.

## Coverage

New tests span unit, lsp-e2e and VS Code tiers: idx 79 gets 3 unit (all-positions refusal, all-positions true negative with applied text, target-resolution scope), 5 e2e and 4 VS Code; idx 11, 28, 37, 62, 67 and 104 each gain e2e coverage, with VS Code tests for 11, 28 and 104.

**Tiers judged inapplicable, with reasoning:** no VS Code test for idx 37, 62, 67 or 78. For those the VS Code client is a thin pass-through — `executeDefinitionProvider` / `executeReferenceProvider` / `executeDocumentSymbolProvider` return the server payload unchanged, so a VS Code test would assert the same bytes the e2e test already does and add only harness flakiness. VS Code coverage was added where the editor path is itself load-bearing: idx 79 (a rename **refusal** must surface as a rejection rather than a silent no-op, which only the real client proves), idx 28 (markdown hover rendering), idx 11 (diagnostic code and severity delivery), idx 104 (definition against a shadowing name).

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo check --workspace --all-targets` all clean — clippy's `too_many_lines` was resolved by extracting `gated_untargeted_member_rename`, not suppressed. `cargo test -p tcl-compiler` 5303 passed; `cargo test -p tcl-lsp-core` all suites passed; `cargo test -p tcl-lsp-server` 1314 e2e passed; VS Code compiled and run under xvfb against the Rust server, 10 passing.

Re-verified after rebasing onto current `rust`, not only on the original base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_