### PR TITLE
Graft body-defined global cells; opaque-callee W210 abstention; my-dispatch caller frames (#1019)

### DIFF
--- a/editors/vscode/node_modules
+++ b/editors/vscode/node_modules
@@ -1,0 +1,1 @@
+/home/user/tcl-lsp/editors/vscode/node_modules

--- a/editors/vscode/node_modules
+++ b/editors/vscode/node_modules
@@ -1,1 +1,0 @@
-/home/user/tcl-lsp/editors/vscode/node_modules

--- a/editors/vscode/src/test/callerFrameCluster.test.ts
+++ b/editors/vscode/src/test/callerFrameCluster.test.ts
@@ -1,0 +1,176 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { getDocUri, activate, pollUntil, waitForDiagnostics } from "./helper";
+
+// Caller-frame injection through `upvar` (issue #923 audit cluster C1 —
+// idx 7, 22, 57, 58, 98; issue #1019), through the real editor surface.
+//
+// Every fact asserted here is pinned on tclsh 9.0.4 and 8.6.16, which agree;
+// the transcripts are quoted in `testFixture/callerFrameCluster.tcl` and in
+// the compiler-unit twins under `rust/tcl-compiler/tests/caller_frame_effects.rs`
+// / `rust/tcl-lsp-core/src/caller_frame.rs`.
+//
+// The value of this tier is that it exercises the *client-visible* result:
+// the extension's own hover / definition / reference plumbing on top of the
+// server, which the Rust e2e suite does not run.
+
+function hoverText(hovers: vscode.Hover[]): string {
+  return hovers
+    .flatMap((h) => h.contents)
+    .map((c) => (typeof c === "string" ? c : (c as { value: string }).value))
+    .join("\n");
+}
+
+async function hoverAt(uri: vscode.Uri, line: number, char: number, label: string) {
+  const hovers = (await pollUntil(
+    () =>
+      vscode.commands.executeCommand(
+        "vscode.executeHoverProvider",
+        uri,
+        new vscode.Position(line, char),
+      ),
+    (r) => Array.isArray(r) && r.length > 0,
+    { timeout: 10_000, label },
+  )) as vscode.Hover[];
+  return hoverText(hovers);
+}
+
+async function definitionsAt(uri: vscode.Uri, line: number, char: number) {
+  return (await vscode.commands.executeCommand(
+    "vscode.executeDefinitionProvider",
+    uri,
+    new vscode.Position(line, char),
+  )) as (vscode.Location | vscode.LocationLink)[];
+}
+
+function startLine(loc: vscode.Location | vscode.LocationLink): number {
+  return "range" in loc ? loc.range.start.line : loc.targetRange.start.line;
+}
+
+suite("Caller-frame variables (issue #923 audit cluster C1)", () => {
+  const docUri = getDocUri("callerFrameCluster.tcl");
+
+  // idx 58 — the wrong-kind conflation. `$dataset` is created by the
+  // callee's `upvar`; a sibling `method dataset {}` shares the name, and
+  // Tcl keeps variables and commands in disjoint namespaces, so the read
+  // can never denote the method.
+  test("a caller-frame read never resolves to a same-named method", async () => {
+    await activate(docUri);
+    // Line 14: `        set _dataset $dataset` — inside `dataset`.
+    const text = await hoverAt(docUri, 14, 24, "hover for the idx-58 caller-frame read");
+    assert.ok(
+      text.includes("Caller-frame variable") && text.includes("gridlayoutHasDataSetObj"),
+      `expected the caller-frame card naming the creating callee, got: ${text}`,
+    );
+    assert.ok(
+      !text.includes("method"),
+      `a $-led read must never render the same-named method's card, got: ${text}`,
+    );
+
+    const defs = await definitionsAt(docUri, 14, 24);
+    assert.strictEqual(defs.length, 1, `expected one definition, got ${defs.length}`);
+    assert.strictEqual(
+      startLine(defs[0]),
+      13,
+      "go-to-definition must reach the creating call site, not the method declaration",
+    );
+  });
+
+  // idx 98 — `upvar ::tk::FocusGrab($index) data` names one fixed global
+  // cell, so the `upvar` word and the sibling proc's own `$::tk::FocusGrab`
+  // read are the same variable. The whole-file analysis answered this while
+  // the live server's incremental analysis answered nothing for hover and
+  // definition; that residual is what this pins from the client side.
+  test("a fully-qualified upvar target hovers, defines and cross-references", async () => {
+    await activate(docUri);
+    // Line 24: `    upvar ::tk::FocusGrab($index) data` — inside FocusGrab.
+    // Line 30: `        set data2 $::tk::FocusGrab($index)` — same.
+    for (const [line, char] of [
+      [24, 20],
+      [30, 26],
+    ] as const) {
+      const text = await hoverAt(docUri, line, char, `hover for the idx-98 cell at ${line}`);
+      assert.ok(
+        text.includes("::tk::FocusGrab"),
+        `hover at ${line}:${char} must name the cell, got: ${text}`,
+      );
+      const defs = await definitionsAt(docUri, line, char);
+      assert.strictEqual(defs.length, 1, `expected one definition at ${line}:${char}`);
+      assert.strictEqual(
+        startLine(defs[0]),
+        24,
+        "the `upvar` otherVar word is where the cell comes to exist",
+      );
+    }
+
+    const refs = (await vscode.commands.executeCommand(
+      "vscode.executeReferenceProvider",
+      docUri,
+      new vscode.Position(30, 26),
+    )) as vscode.Location[];
+    const lines = refs.map((r) => r.range.start.line).sort((a, b) => a - b);
+    assert.deepStrictEqual(
+      lines,
+      [24, 29, 30, 31],
+      `otherVar word + info exists + read + unset, got: ${JSON.stringify(lines)}`,
+    );
+  });
+
+  // idx 22 — the callee is a *mixin* method the call site never names
+  // statically. The method-resolution-order walk (issues #1177 / #1164)
+  // resolves `my NameProcess` through the mixin, so the literal
+  // `upvar name name` target is now answerable.
+  test("a mixin method reached by `my` dispatch creates this frame's variable", async () => {
+    await activate(docUri);
+    // Line 48: `        puts "name=$name params=$params"` — inside `name`.
+    const text = await hoverAt(docUri, 48, 21, "hover for the idx-22 mixin-dispatch read");
+    assert.ok(
+      text.includes("Caller-frame variable") && text.includes("NameProcess"),
+      `expected the caller-frame card naming the resolved method, got: ${text}`,
+    );
+
+    const defs = await definitionsAt(docUri, 48, 21);
+    assert.strictEqual(defs.length, 1, `expected one definition, got ${defs.length}`);
+    assert.strictEqual(
+      startLine(defs[0]),
+      46,
+      "the `my NameProcess …` dispatch is where the variable comes to exist here",
+    );
+  });
+
+  // The whole fixture is legitimate Tcl whose every read is really bound at
+  // run time, so none of it may draw a read-before-set warning. This is the
+  // false-positive half of the cluster (idx 7 / 38 / 57 / 59) seen from the
+  // editor: a regression that resurrects any of those FPs shows up here.
+  test("none of the cluster's caller-frame reads draws W210", async () => {
+    await activate(docUri);
+    const diags = await waitForDiagnostics(docUri, {
+      timeout: 20_000,
+      predicate: () => true,
+    });
+    const w210 = diags.filter((d) => String(d.code) === "W210");
+    assert.strictEqual(
+      w210.length,
+      0,
+      `no read here is read-before-set, got: ${JSON.stringify(w210.map((d) => d.message))}`,
+    );
+  });
+});

--- a/editors/vscode/src/test/callerFrameCluster.test.ts
+++ b/editors/vscode/src/test/callerFrameCluster.test.ts
@@ -127,10 +127,16 @@ suite("Caller-frame variables (issue #923 audit cluster C1)", () => {
       new vscode.Position(30, 26),
     )) as vscode.Location[];
     const lines = refs.map((r) => r.range.start.line).sort((a, b) => a - b);
+    // The `upvar` otherVar word and the `data` alias it introduces (both
+    // line 24), the alias use (line 25), and the sibling proc's read
+    // (line 30) — Find-References unifies an alias with the cell it names.
+    // The bareword `info exists` / `unset` arguments are a separate anchor
+    // kind and are deliberately not claimed here; the compiler-library and
+    // lsp-e2e twins assert the same set, so the tiers agree about scope.
     assert.deepStrictEqual(
       lines,
-      [24, 29, 30, 31],
-      `otherVar word + info exists + read + unset, got: ${JSON.stringify(lines)}`,
+      [24, 24, 25, 30],
+      `expected the cell and its alias spans, got: ${JSON.stringify(lines)}`,
     );
   });
 

--- a/editors/vscode/testFixture/callerFrameCluster.tcl
+++ b/editors/vscode/testFixture/callerFrameCluster.tcl
@@ -1,0 +1,51 @@
+# Caller-frame injection cluster (issue #923 audit idx 7 / 22 / 57 / 58 / 98,
+# issue #1019).  Every claim below is pinned on tclsh 9.0.4 and 8.6.16, which
+# agree on all of it.
+#
+# idx 58 -- an out-parameter helper whose caller-frame variable happens to
+# share its name with an unrelated TclOO method.  `chart new` prints
+# `MY-SHARED-DATASET`; a `$`-led read can never denote a method.
+proc gridlayoutHasDataSetObj {dts} {
+    upvar 1 $dts dataset
+    set dataset MY-SHARED-DATASET
+}
+oo::class create chart {
+    constructor {} {
+        gridlayoutHasDataSetObj dataset
+        set _dataset $dataset
+        puts $_dataset
+    }
+    method dataset {} { return 1 }
+}
+
+# idx 98 -- `upvar ::tk::FocusGrab($index) data` names one fixed global cell,
+# so the sibling proc's own qualified accesses are the same variable.
+proc SetFocusGrab {grab focus} {
+    set index "$grab,$focus"
+    upvar ::tk::FocusGrab($index) data
+    lappend data one
+}
+proc RestoreFocusGrab {grab focus} {
+    set index "$grab,$focus"
+    if {[info exists ::tk::FocusGrab($index)]} {
+        set data2 $::tk::FocusGrab($index)
+        unset ::tk::FocusGrab($index)
+    }
+}
+
+# idx 22 -- the callee is a *mixin* method reached by `my NameProcess ...`.
+# `Widget new {-base 1}` prints `name=::oo::Obj24 params=-base 1`.
+oo::class create Utility {
+    method NameProcess {arguments object} {
+        upvar name name
+        set name $object
+    }
+}
+oo::class create Widget {
+    mixin Utility
+    constructor {arguments} {
+        my NameProcess $arguments [self object]
+        set params $arguments
+        puts "name=$name params=$params"
+    }
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -115,6 +115,91 @@ mod var_command;
 pub(in crate::analyser) mod version_gate;
 pub(in crate::analyser) mod widget_command;
 
+/// Whether a command head names something **this compilation unit can
+/// resolve** — a registry command the active dialect enables, or a
+/// definition the document makes itself.
+///
+/// The complement is what matters: a head this answers `false` for is a
+/// callee whose body is simply not here (the ticklecharts layout of issue
+/// #923 audit idx 59 — the helper in `utils.tcl`, the caller in
+/// `options.tcl`), so nothing in this unit can say whether it writes the
+/// caller's frame through `upvar`.
+/// [`crate::interprocedural::collect_opaque_callee_name_args`] turns that
+/// into the per-frame abstention the read-before-set emitters honour.
+///
+/// Resolution mirrors Tcl's own: an absolute head is looked up as written,
+/// a relative one may name a definition in any namespace this document
+/// declares (the leaf spellings), and the registry half goes through the
+/// dialect profile — exactly the availability query
+/// [`Analyser::build_w123_known_names`](super::state::Analyser) uses, so
+/// "unknown command" and "opaque callee" cannot disagree about the same
+/// head.  No command name appears here.
+struct UnitCommandResolver<'a> {
+    registry: &'a tcl_registry::CommandRegistry,
+    profile: tcl_dialect::DialectProfile,
+    /// Every spelling under which this document's own definitions —
+    /// procedures, classes, `interp alias` / `rename` targets, declared
+    /// stubs, and created object-instance commands — can be called.
+    defined: HashSet<String>,
+}
+
+impl UnitCommandResolver<'_> {
+    fn resolves(&self, command: &str) -> bool {
+        if self.defined.contains(command) {
+            return true;
+        }
+        let bare = command.trim_start_matches(':');
+        if self.defined.contains(bare) {
+            return true;
+        }
+        self.profile.resolve_command(self.registry, command).is_some()
+    }
+}
+
+impl Analyser {
+    /// Build the [`UnitCommandResolver`] for the document just walked.
+    fn unit_command_resolver<'a>(
+        &self,
+        registry: &'a tcl_registry::CommandRegistry,
+    ) -> UnitCommandResolver<'a> {
+        let mut defined: HashSet<String> = HashSet::new();
+        let mut add = |name: &str| {
+            let bare = name.trim_start_matches(':');
+            if bare.is_empty() {
+                return;
+            }
+            defined.insert(name.to_owned());
+            defined.insert(bare.to_owned());
+            if let Some(leaf) = bare.rsplit("::").next() {
+                defined.insert(leaf.to_owned());
+            }
+        };
+        for name in self.result.all_procs.keys() {
+            add(name);
+        }
+        for name in self.result.all_classes.keys() {
+            add(name);
+        }
+        for name in self.result.command_aliases.keys() {
+            add(name);
+        }
+        for name in self.result.renamed_commands.keys() {
+            add(name);
+        }
+        for stub in &self.result.stub_commands {
+            add(&stub.name);
+        }
+        for name in &self.result.created_instance_commands {
+            add(name);
+        }
+        UnitCommandResolver {
+            registry,
+            profile: tcl_dialect::DialectProfile::by_name(self.dialect()),
+            defined,
+        }
+    }
+}
+
 /// Which IR object owns the body the per-function dispatcher is running over.
 ///
 /// Supplied by the caller: every diagnostic loop iterates exactly one of the
@@ -415,7 +500,7 @@ impl Analyser {
         // `cross_event_vars` only reaches the dead-store / unused checks, so
         // fold the implicit set into `extra_known_defined` too — that is the
         // argument the W210 emitters consult (#955).
-        let top_level_known_defined: HashSet<String> = if pkgindex_implicit_vars.is_empty() {
+        let mut top_level_known_defined: HashSet<String> = if pkgindex_implicit_vars.is_empty() {
             globals_written.clone()
         } else {
             globals_written
@@ -424,6 +509,20 @@ impl Analyser {
                 .cloned()
                 .collect()
         };
+
+        // **W210 opaque-callee abstention (issue #923 audit idx 59).** A call
+        // to a command whose body this unit does not hold — the cross-file
+        // helper the finding was mined from — may create any caller-frame
+        // name it is handed, so the names it *spells* stop being provably
+        // unset here.  Per frame, and per name: everything else in the frame
+        // still reports.
+        let unit_commands = self.unit_command_resolver(registry);
+        let opaque_callee_defs = |fu: &crate::compilation_unit::FunctionUnit| {
+            crate::interprocedural::collect_opaque_callee_name_args(&fu.cfg, &|cmd: &str| {
+                unit_commands.resolves(cmd)
+            })
+        };
+        top_level_known_defined.extend(opaque_callee_defs(&cu.top_level));
 
         // Top-level first, then procedures in insertion order —
         // matches the iteration order of
@@ -443,8 +542,9 @@ impl Analyser {
             // ConnectionScope so dead-store / unused-variable
             // diagnostics suppress vars that may be read in a
             // different iRule event.
-            let (mut cross_event_vars, extra_known_defined) =
+            let (mut cross_event_vars, mut extra_known_defined) =
                 when_proc_cross_event_names(cu, qname);
+            extra_known_defined.extend(opaque_callee_defs(fu));
             // Suppress dead-store on caller-locals this
             // proc passes by name to an upvar callee.
             cross_event_vars.extend(crate::interprocedural::collect_call_by_name_reads(
@@ -477,7 +577,13 @@ impl Analyser {
             }
         }
 
-        self.emit_fresh_frame_body_diagnostics(cu, registry, &cbn_proc_index, &traced_globals);
+        self.emit_fresh_frame_body_diagnostics(
+            cu,
+            registry,
+            &cbn_proc_index,
+            &traced_globals,
+            &unit_commands,
+        );
 
         // Cross-function post-pass: resolve $var-as-command sites
         // collected during the walk.
@@ -522,6 +628,7 @@ impl Analyser {
         registry: &tcl_registry::CommandRegistry,
         cbn_proc_index: &crate::interprocedural::ProcIndex,
         traced_globals: &HashSet<String>,
+        unit_commands: &UnitCommandResolver<'_>,
     ) {
         for (qname, fu) in &cu.methods {
             let method_ir = cu.ir_module.methods.get(qname);
@@ -557,11 +664,15 @@ impl Analyser {
             // the IR here, so this family and the existence fold (I230 /
             // O100 / O101) cannot source the same fact from different maps
             // (issue #1174; that divergence shape was issue #1129).
-            let known_bound: HashSet<String> = fu.method_facts.as_deref().map_or_else(
+            let mut known_bound: HashSet<String> = fu.method_facts.as_deref().map_or_else(
                 HashSet::new,
                 crate::compilation_unit::MethodBodyFacts::known_bound_at_entry,
             );
             let mut cross_event_vars = known_bound.clone();
+            known_bound.extend(crate::interprocedural::collect_opaque_callee_name_args(
+                &fu.cfg,
+                &|cmd: &str| unit_commands.resolves(cmd),
+            ));
             cross_event_vars.extend(crate::interprocedural::collect_call_by_name_reads(
                 &fu.cfg,
                 cbn_proc_index,
@@ -587,9 +698,22 @@ impl Analyser {
         registry: &tcl_registry::CommandRegistry,
         cbn_proc_index: &crate::interprocedural::ProcIndex,
         traced_globals: &HashSet<String>,
+        unit_commands: &UnitCommandResolver<'_>,
     ) {
-        self.emit_method_body_diagnostics(cu, registry, cbn_proc_index, traced_globals);
-        self.emit_lambda_body_diagnostics(cu, registry, cbn_proc_index, traced_globals);
+        self.emit_method_body_diagnostics(
+            cu,
+            registry,
+            cbn_proc_index,
+            traced_globals,
+            unit_commands,
+        );
+        self.emit_lambda_body_diagnostics(
+            cu,
+            registry,
+            cbn_proc_index,
+            traced_globals,
+            unit_commands,
+        );
     }
 
     /// The same CFG/SSA dataflow family over an `apply` **lambda body**.
@@ -615,6 +739,7 @@ impl Analyser {
         registry: &tcl_registry::CommandRegistry,
         cbn_proc_index: &crate::interprocedural::ProcIndex,
         traced_globals: &HashSet<String>,
+        unit_commands: &UnitCommandResolver<'_>,
     ) {
         for qname in &cu.ir_module.lambda_body_units {
             let (Some(fu), Some(ir_proc)) =
@@ -622,8 +747,12 @@ impl Analyser {
             else {
                 continue;
             };
-            let known_bound: HashSet<String> = ir_proc.params.iter().cloned().collect();
+            let mut known_bound: HashSet<String> = ir_proc.params.iter().cloned().collect();
             let mut cross_event_vars = known_bound.clone();
+            known_bound.extend(crate::interprocedural::collect_opaque_callee_name_args(
+                &fu.cfg,
+                &|cmd: &str| unit_commands.resolves(cmd),
+            ));
             cross_event_vars.extend(crate::interprocedural::collect_call_by_name_reads(
                 &fu.cfg,
                 cbn_proc_index,

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -136,7 +136,7 @@ pub(in crate::analyser) mod widget_command;
 /// head.  No command name appears here.
 struct UnitCommandResolver<'a> {
     registry: &'a tcl_registry::CommandRegistry,
-    profile: tcl_dialect::DialectProfile,
+    profile: &'static tcl_dialect::DialectProfile,
     /// Every spelling under which this document's own definitions —
     /// procedures, classes, `interp alias` / `rename` targets, declared
     /// stubs, and created object-instance commands — can be called.
@@ -152,7 +152,8 @@ impl UnitCommandResolver<'_> {
         if self.defined.contains(bare) {
             return true;
         }
-        self.profile.resolve_command(self.registry, command).is_some()
+        tcl_registry::ProfileQueries::resolve_command(self.profile, self.registry, command)
+            .is_some()
     }
 }
 

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -2063,7 +2063,9 @@ mod tests {
     /// shell's global scope too.
     #[test]
     fn a_body_defined_hash_zero_global_survives_the_graft() {
-        fast_path("proc bump {} { upvar #0 counter c; incr c }\nproc show {} { puts $::counter }\n");
+        fast_path(
+            "proc bump {} { upvar #0 counter c; incr c }\nproc show {} { puts $::counter }\n",
+        );
     }
 
     /// TN — a body-local `upvar` whose target is frame-relative names no

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -930,6 +930,13 @@ impl Analyser {
         // any deferred body, so without this guard a later definition would
         // spuriously absorb the read.  Gate on the body token start (the proc
         // header precedes it, and no top-level command can fall inside the body).
+        // Replay the body's global-scope *definitions* first (issue #923 idx
+        // 98): a body that names a fixed cell (`upvar ::tk::FocusGrab($i)
+        // data`) is the only place that cell comes to exist, and the reads
+        // replayed below — plus the tail's
+        // `attach_qualified_var_references` — resolve against the shell's
+        // scope tree, which the fragment's own throwaway root never reaches.
+        self.replay_body_global_defs(frag.global_defs);
         self.replay_body_global_reads(frag.global_reads, db.body_tok.span.start(), delta);
         // Re-defer the body's would-be-W002 sites (already rebased by
         // `rebase_fragment`); the tail re-applies the shadow check against
@@ -1005,6 +1012,35 @@ impl Analyser {
     /// second time — a duplicate the whole-file walk never produces (its
     /// adjacent-duplicate collapse cannot catch the replay's non-adjacent
     /// twin).
+    /// Replay a grafted body's **global-scope definitions** on the shell's
+    /// real global scope, so a fixed cell an `upvar` `otherVar` word names
+    /// (`upvar ::tk::FocusGrab($i) data`, `upvar #0 counter c`) exists in
+    /// the document's scope tree exactly as the whole-file walk leaves it.
+    ///
+    /// Spans are already absolute ([`rebase_fragment_pending`] shifted
+    /// them).  The replay goes through the real
+    /// [`Analyser::define_var`](super::state::Analyser) — so a cell the
+    /// shell already owns keeps its first definition span and gains this
+    /// word as a reference, matching `analyse`'s own second-definition
+    /// handling — under `structural_rebind`, because the isolated body pass
+    /// already recorded this word's [`super::types::QualifiedVarRef`] (the
+    /// graft merged it) and already emitted its W215; doing either again
+    /// would double-count.
+    fn replay_body_global_defs(
+        &mut self,
+        global_defs: Vec<(String, tcl_lexer::Token, tcl_lexer::Span)>,
+    ) {
+        if global_defs.is_empty() {
+            return;
+        }
+        let was_structural = self.structural_rebind;
+        self.structural_rebind = true;
+        for (name, tok, span) in global_defs {
+            self.define_var(&name, tok, &[], false, Some(span));
+        }
+        self.structural_rebind = was_structural;
+    }
+
     fn replay_body_global_reads(
         &mut self,
         global_reads: Vec<(String, tcl_lexer::Span)>,
@@ -1046,6 +1082,14 @@ pub struct BodyFragment {
     /// Qualified (`::`/`static::`) reads that missed the isolated body's empty
     /// enclosing global scope; replayed on the shell's real globals at graft.
     global_reads: Vec<(String, tcl_lexer::Span)>,
+    /// Definitions the isolated body wrote **into its own root scope** — the
+    /// fixed, frame-independent cells an `upvar` `otherVar` word names
+    /// (`upvar ::tk::FocusGrab($i) data`, `upvar #0 counter c`).  The graft
+    /// merges the fragment's *proc* scope only, so these are replayed onto
+    /// the shell's real global scope; without that the cell never entered
+    /// the scope tree the navigation providers and
+    /// `attach_qualified_var_references` read (issue #923 audit idx 98).
+    global_defs: Vec<(String, tcl_lexer::Token, tcl_lexer::Span)>,
     /// W002 (disabled-in-dialect command) sites — always deferred (see
     /// [`super::state::Analyser::pending_disabled_commands`]), so this is
     /// simply the isolated body's own queue: `(command name, call-site
@@ -1163,6 +1207,10 @@ pub fn analyse_proc_body_isolated<S: std::hash::BuildHasher>(
     // Capture qualified (`::`/`static::`) reads that miss the (empty) enclosing
     // global scope, so the graft can replay them on the shell's real globals.
     a.capture_global_reads = Some(Vec::new());
+    // …and the write-side twin: a fixed global cell this body *defines*
+    // (`upvar ::ns::cell local`) must reach the shell's real global scope,
+    // not the throwaway root this isolated walk builds (issue #923 idx 98).
+    a.capture_global_defs = Some(Vec::new());
     // Seed the ensemble subcommand→target maps visible to this body (the
     // shell attached exactly the whole-file-DFS-visible, body-relevant
     // slice — see `DeferredBody::ensemble_targets`), so an
@@ -1263,6 +1311,7 @@ pub fn analyse_proc_body_isolated<S: std::hash::BuildHasher>(
         var_sites: a.var_command_sites,
         cmd_sites: a.cmd_command_sites,
         global_reads: a.capture_global_reads.unwrap_or_default(),
+        global_defs: a.capture_global_defs.unwrap_or_default(),
         disabled_commands: a.pending_disabled_commands,
         private_ns_calls: a.pending_w143,
         w304: a.pending_w304,
@@ -1812,6 +1861,10 @@ fn rebase_fragment_pending(frag: &mut BodyFragment, d: u32) {
     for (_, _, _, off) in &mut frag.instances {
         *off += d;
     }
+    for (_, tok, span) in &mut frag.global_defs {
+        tok.span = shift(tok.span, d);
+        *span = shift(*span, d);
+    }
     for off in frag.walk_alias_offsets.values_mut() {
         *off += d;
     }
@@ -1976,6 +2029,48 @@ mod tests {
         let want = Analyser::new().analyse(src, dialect);
         let got = Analyser::new().analyse_per_item(src, dialect);
         assert_eq!(got, want, "per_item != analyse for:\n{src}");
+    }
+
+    // -- Body-defined global cells (issue #923 audit idx 98) --
+
+    /// The Tk `SetFocusGrab` / `RestoreFocusGrab` shape: one proc names a
+    /// fixed global array cell through `upvar`'s `otherVar` word, a sibling
+    /// proc reaches the same cell by its own qualified spelling.
+    ///
+    /// The cell is defined *inside a deferred body*, so the isolated pass
+    /// wrote it into that body's throwaway root scope and the graft — which
+    /// merges the fragment's **proc** scope only — dropped it.  The
+    /// whole-file walk left it in the document's global scope, which is what
+    /// every navigation provider and `attach_qualified_var_references` read,
+    /// so hover / go-to-definition answered in the compiler library and
+    /// nothing at all in the live server.  `fast_path` pins both halves:
+    /// the document still takes the incremental path, and the result is
+    /// byte-identical to `analyse`.
+    #[test]
+    fn a_body_defined_global_cell_survives_the_graft() {
+        fast_path(
+            "proc SetFocusGrab {grab focus} {\n    set index \"$grab,$focus\"\n    \
+             upvar ::tk::FocusGrab($index) data\n    lappend data one\n}\n\
+             proc RestoreFocusGrab {grab focus} {\n    set index \"$grab,$focus\"\n    \
+             if {[info exists ::tk::FocusGrab($index)]} {\n        \
+             set data2 $::tk::FocusGrab($index)\n        \
+             unset ::tk::FocusGrab($index)\n    }\n}\n",
+        );
+    }
+
+    /// The `#0`-level spelling of the same fact: `upvar #0 counter c` names
+    /// the global `::counter` from any depth, so the cell must reach the
+    /// shell's global scope too.
+    #[test]
+    fn a_body_defined_hash_zero_global_survives_the_graft() {
+        fast_path("proc bump {} { upvar #0 counter c; incr c }\nproc show {} { puts $::counter }\n");
+    }
+
+    /// TN — a body-local `upvar` whose target is frame-relative names no
+    /// fixed cell, so nothing is captured and the graft is unchanged.
+    #[test]
+    fn a_caller_frame_upvar_defines_no_global_cell() {
+        fast_path("proc setdef {d} { upvar 1 $d dst; set dst 1 }\nproc build {} { setdef opts }\n");
     }
 
     // Tk activation gate (issue #1188).  The gate decides whether a document

--- a/rust/tcl-compiler/src/analyser/scope.rs
+++ b/rust/tcl-compiler/src/analyser/scope.rs
@@ -1798,6 +1798,16 @@ impl Analyser {
         // ref for a `::`-qualified parameter name.
         if !self.structural_rebind {
             self.record_qualified_var_ref(base_name, span, scope_path);
+            // Isolated per-item body: a definition landing in the body's own
+            // (throwaway) root scope is a fixed global cell the whole-file
+            // walk would have written into the *document's* global scope, so
+            // capture it for the graft to replay there — the write-side twin
+            // of `capture_global_reads` (issue #923 audit idx 98).
+            if scope_path.is_empty()
+                && let Some(captured) = self.capture_global_defs.as_mut()
+            {
+                captured.push((name.to_string(), tok, span));
+            }
         }
         // A `set arr(idx) …` definition records the element index on the array.
         let element = crate::naming::split_array_name_braced(name, braced_literal)

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -835,6 +835,25 @@ pub struct Analyser {
     /// def — one of the divergences the per-item path must reproduce.  `None` on
     /// the whole-file `analyse` path (reads resolve against the populated scope).
     pub(super) capture_global_reads: Option<Vec<(String, tcl_lexer::Span)>>,
+    /// The write-side twin of [`Self::capture_global_reads`].  When `Some`,
+    /// an isolated proc-body analysis (the per-item path) records every
+    /// variable the body defines **directly in the global scope** — a body
+    /// that names one fixed, frame-independent cell, which today means
+    /// `upvar`'s `otherVar` word (`upvar ::tk::FocusGrab($i) data`, `upvar
+    /// #0 counter c`; see
+    /// [`Analyser::handle_upvar_command`](super::state::Analyser)).
+    ///
+    /// The graft merges the fragment's *proc* scope, never its (throwaway)
+    /// root, so without this capture such a cell reached `all_variables` but
+    /// never the shell's scope tree — and the scope tree is what
+    /// `attach_qualified_var_references`, `replay_body_global_reads`, and
+    /// every LSP navigation provider read.  The result was the issue #923
+    /// audit idx 98 residual: the whole-file walk answered hover /
+    /// definition / references for the cell and the live server's
+    /// incremental walk answered nothing.  `None` on the whole-file
+    /// `analyse` path, where the body walk writes the real global scope
+    /// directly.
+    pub(super) capture_global_defs: Option<Vec<(String, tcl_lexer::Token, tcl_lexer::Span)>>,
     /// Deferred W002 (disabled-in-dialect command) diagnostics — both the
     /// whole-command form ([`Self::emit_w002_disabled_command`]) and the
     /// subcommand form embedded in
@@ -1125,6 +1144,7 @@ impl Analyser {
             minted_synthetic_names: std::collections::HashSet::new(),
             cu_override: None,
             capture_global_reads: None,
+            capture_global_defs: None,
             pending_disabled_commands: Vec::new(),
             pending_w143: Vec::new(),
             pending_w304: Vec::new(),

--- a/rust/tcl-compiler/src/interprocedural.rs
+++ b/rust/tcl-compiler/src/interprocedural.rs
@@ -287,13 +287,7 @@ fn add_call_by_name(cmd: &str, args: &[String], index: &ProcIndex, out: &mut Has
         // A substituted (`$x`) / array / non-name arg names a runtime
         // variable we can't identify — skip (preserve genuine FPs where
         // the caller passed a literal string, not a name).
-        if is_var
-            && !arg.is_empty()
-            && !arg.contains(['$', '['])
-            && arg
-                .chars()
-                .all(|c| c.is_alphanumeric() || c == '_' || c == ':')
-        {
+        if is_var && is_literal_var_name(arg) {
             out.insert(arg.clone());
         }
     }
@@ -357,6 +351,87 @@ pub fn collect_call_by_name_reads(
                 }
                 _ => {}
             }
+        }
+    }
+    out
+}
+
+/// Whether `word` is a plain, literal variable *name* — the only argument
+/// shape whose call-by-name meaning is knowable.
+///
+/// The same test [`add_call_by_name`] applies to a resolvable callee's
+/// name-role argument, factored out so the opaque-callee scan below cannot
+/// drift from it.
+fn is_literal_var_name(word: &str) -> bool {
+    !word.is_empty()
+        && !word.contains(['$', '['])
+        && word
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == ':')
+}
+
+/// Caller-frame names a call to an **opaque callee** — a command this
+/// compilation unit can resolve neither in the registry nor to any
+/// definition of its own — may create in the calling frame.
+///
+/// A Tcl procedure's `upvar 1 $param local` reaches the frame of whoever
+/// called it, so a helper defined in *another file* creates the caller's
+/// variable just as one defined here does.  C Tcl, tclsh 9.0.4 and 8.6.16
+/// (identical), for the ticklecharts layout the issue #923 audit idx 59
+/// finding was mined from — `setdef` in `utils.tcl`, the caller in
+/// `options.tcl`, tied together by a `pkgIndex.tcl`:
+///
+/// ```text
+/// proc demo::setdef {d key args} { upvar 1 $d _dict; … dict set _dict … }
+/// proc demo::build {items} { setdef options name …; dict get $options name }
+/// demo::build {a b c}   → {nothing str no} …   — `options` exists, unassigned here
+/// ```
+///
+/// The per-proc frame-effect summary ([`crate::cfg_builder::upvar_info`])
+/// is built from one module, so it holds nothing at all for such a callee
+/// and the read looked like `W210` read-before-set.  The honest answer is
+/// that this unit cannot tell: the callee's body is not here.  So each
+/// **literal, name-shaped argument word** of the call — the only words that
+/// could name a caller-frame variable — is reported as possibly-defined,
+/// and the read-before-set emitters abstain for exactly those names.
+///
+/// Deliberately narrow in three ways, so this is an abstention and not a
+/// blanket silence:
+///
+/// * only names the call **spells** are covered — an unrelated local read
+///   in the same frame still reports (its true-positive control lives in
+///   `tests/caller_frame_effects.rs`);
+/// * only *literal* words qualify — a `$x` / `[f]` argument names a
+///   variable nothing here can identify, the same abstention direction
+///   `is_plain_var_name` takes on the navigation side;
+/// * only *opaque* callees qualify — a registry command has a declared
+///   frame effect, and a procedure defined in this unit has a real summary
+///   which is trusted per-name (so a same-file helper without an `upvar`
+///   keeps its reads reporting).
+///
+/// `resolvable` answers "can this unit resolve that command head?", which
+/// the analyser supplies from the dialect profile plus its own definition
+/// tables — no command name appears here.
+#[must_use]
+pub fn collect_opaque_callee_name_args(
+    cfg: &crate::cfg::Function,
+    resolvable: &dyn Fn(&str) -> bool,
+) -> HashSet<String> {
+    use crate::ir::Statement;
+    let mut out = HashSet::new();
+    for block in cfg.blocks.values() {
+        for stmt in &block.statements {
+            let (Statement::Call { command, args, .. }
+            | Statement::Barrier { command, args, .. }) = stmt
+            else {
+                continue;
+            };
+            // A dynamic head (`$cmd …`) is handled by the dynamic-name
+            // barrier, not here; an empty head is not a call.
+            if command.is_empty() || command.contains(['$', '[']) || resolvable(command) {
+                continue;
+            }
+            out.extend(args.iter().filter(|a| is_literal_var_name(a)).cloned());
         }
     }
     out

--- a/rust/tcl-compiler/src/interprocedural.rs
+++ b/rust/tcl-compiler/src/interprocedural.rs
@@ -421,8 +421,8 @@ pub fn collect_opaque_callee_name_args(
     let mut out = HashSet::new();
     for block in cfg.blocks.values() {
         for stmt in &block.statements {
-            let (Statement::Call { command, args, .. }
-            | Statement::Barrier { command, args, .. }) = stmt
+            let (Statement::Call { command, args, .. } | Statement::Barrier { command, args, .. }) =
+                stmt
             else {
                 continue;
             };

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -252,6 +252,53 @@ mod opt_proc_definer {
         assert!(!fires(src, D, "E003"), "{:?}", codes(src, D));
     }
 
+    /// The **accepted trade-off**, pinned as a choice rather than left to
+    /// read as an oversight (issue #923 audit idx 99 verification).
+    ///
+    /// C Tcl does enforce a positional-argument bound for an `OptProc`, at
+    /// call time, from the parsed optlist — tclsh 9.0.4 and 8.6.16 agree
+    /// exactly:
+    ///
+    /// ```text
+    /// ::tcl::OptProc ::safe::loadTk {{child -tkAppName} {-use …} {-display …}} {…}
+    /// ::safe::loadTk interp1                       → OK (one positional arg)
+    /// ::safe::loadTk interp1 extraPositionalArg    → too many arguments
+    ///                                                (unexpected argument(s): …)
+    /// ```
+    ///
+    /// The definer installs `::proc $name args {…}`, so nothing in the
+    /// *declaration* bounds the call; reproducing the bound would mean
+    /// modelling `::tcl::OptKeyParse`'s runtime dispatch over the optlist
+    /// (flag descriptors, defaults, `-…` terminators).  Until that exists,
+    /// the choice is between a false E003 on every legitimate call — the
+    /// defect the audit found, `::safe::loadTk interp1` reported as "too
+    /// many arguments: expected at most 0" — and silence on a genuine
+    /// overflow.  Silence is the abstaining direction this whole cluster
+    /// takes, so the overflow goes unreported **on purpose**.
+    ///
+    /// The scope of that silence is what keeps it honest, so it is asserted
+    /// here too: an ordinary proc is still arity-checked
+    /// (`unrelated_proc_still_gets_real_arity_checked`), and this is a
+    /// definer-scoped abstention, not a retreat from arity checking.
+    #[test]
+    fn a_genuine_opt_proc_arity_overflow_is_deliberately_unreported() {
+        let src = "tcl::OptProc greet {child -use -display} { return $child }\n\
+                   greet interp1 extraPositionalArg\n";
+        assert!(
+            !fires(src, D, "E002") && !fires(src, D, "E003"),
+            "the overflow is real in C Tcl but deliberately not modelled here: {:?}",
+            codes(src, D)
+        );
+        // …and the legitimate call is silent for the same reason, which is
+        // the half the audit was actually about.
+        let ok = "tcl::OptProc greet {child -use -display} { return $child }\ngreet interp1\n";
+        assert!(
+            !fires(ok, D, "E002") && !fires(ok, D, "E003"),
+            "a legitimate OptProc call must never draw arity noise: {:?}",
+            codes(ok, D)
+        );
+    }
+
     #[test]
     fn optlist_flag_descriptor_dash_is_stripped_for_the_bound_local() {
         // TP — `::tcl::OptKeyParse` binds `-use`/`-display` as `use`/

--- a/rust/tcl-compiler/tests/caller_frame_effects.rs
+++ b/rust/tcl-compiler/tests/caller_frame_effects.rs
@@ -134,6 +134,76 @@ proc user {} {
     assert!(w210(src).contains("itemLegend1"), "got {:?}", w210(src));
 }
 
+// idx 59 — the same out-parameter helper, defined in ANOTHER FILE.
+
+/// The ticklecharts layout the finding was actually mined from: `setdef`
+/// lives in `utils.tcl`, the caller in `options.tcl`, and only a
+/// `pkgIndex.tcl` ties them together — so the caller's compilation unit
+/// holds no definition of `setdef` at all.  Reproduced here by simply
+/// omitting the helper, which is exactly what the caller's unit sees.
+///
+/// tclsh 9.0.4 / 8.6.16, running the real four-file layout:
+/// `demo::build {a b c}` → `{nothing str no} {nothing str no} {nothing str
+/// no}` — `options` is populated by the calls and never assigned in
+/// `build`'s own text before it is read.
+const CROSS_FILE_CALLER: &str = "\
+namespace eval demo {}
+proc demo::build {items} {
+    set opts {}
+    foreach item $items {
+        setdef options name -type str -default \"nothing\"
+        lappend opts [dict get $options name]
+        set options {}
+    }
+    return $opts
+}
+";
+
+#[test]
+fn idx59_a_callee_this_unit_cannot_see_may_write_the_names_it_is_handed() {
+    assert!(
+        !w210(CROSS_FILE_CALLER).contains("options"),
+        "a cross-file helper may create `options` through `upvar`; got {:?}",
+        w210(CROSS_FILE_CALLER),
+    );
+}
+
+#[test]
+fn idx59_control_a_name_the_opaque_call_never_spells_still_reports() {
+    // TP control — the abstention is per-name, not a blanket silence for the
+    // whole frame.  tclsh 9.0.4 / 8.6.16: `can't read "neverPassed"`.
+    let src = "\
+proc build {} {
+    setdef options name -default nothing
+    puts $neverPassed
+}
+";
+    assert!(w210(src).contains("neverPassed"), "got {:?}", w210(src));
+}
+
+#[test]
+fn idx59_control_a_substituted_argument_names_nothing_resolvable() {
+    // TP control — only a *literal* word can name a caller-frame variable
+    // this analysis can identify.  `setdef $key …` says nothing about
+    // `options`, so the read still reports (tclsh: `can't read "options"`).
+    let src = "\
+proc build {key} {
+    setdef $key name -default nothing
+    puts $options
+}
+";
+    assert!(w210(src).contains("options"), "got {:?}", w210(src));
+}
+
+#[test]
+fn idx59_control_a_registry_command_is_not_an_opaque_callee() {
+    // TN control — `puts` has a declared frame effect (none), so handing it
+    // a bareword proves nothing about a same-named local.  tclsh 9.0.4 /
+    // 8.6.16: `can't read "options"`.
+    let src = "proc build {} {\n puts options\n puts $options\n}\n";
+    assert!(w210(src).contains("options"), "got {:?}", w210(src));
+}
+
 // idx 38 — `uplevel <caller> [list set …]`, the tclopt `NewArrays` shape.
 
 #[test]

--- a/rust/tcl-lsp-core/src/caller_frame.rs
+++ b/rust/tcl-lsp-core/src/caller_frame.rs
@@ -278,11 +278,25 @@ pub(crate) fn caller_frame_bindings(
     if start >= end {
         return out;
     }
+    // Built once for the whole scan, not per command: the self-dispatch walk
+    // below resolves method-body heads through it, and a `rename` or
+    // `interp alias` in this document has to read the same way here as it does
+    // in every other consumer (issue #1275).
+    // Without a registry there is no way to know which commands mutate the
+    // command table, so there is no fact to record and the shared empty map is
+    // the honest answer.
+    let scanned_identities = resolution.registry.map(|registry| {
+        tcl_compiler::head_identity::command_head_identities(source, dialect, registry)
+    });
+    let identities = scanned_identities
+        .as_ref()
+        .unwrap_or_else(|| tcl_compiler::head_identity::HeadIdentityMap::none());
     let ctx = BindingScan {
         analysis,
         source,
         dialect,
         resolution,
+        identities,
         namespace: crate::definition::namespace_context_at(
             &analysis.global_scope,
             cursor_off,
@@ -305,6 +319,10 @@ struct BindingScan<'a> {
     /// in this scan is answered in — the builtin gate and, when the host has a
     /// workspace index, the export oracle (issue #1116 item 1).
     resolution: crate::definition::CallResolution<'a>,
+    /// The document's proven command-identity facts, built once per scan and
+    /// handed to every trait scan below so a rebound head resolves here the
+    /// same way it does everywhere else (issue #1275).
+    identities: &'a tcl_compiler::head_identity::HeadIdentityMap,
     namespace: String,
     name: &'a str,
 }
@@ -477,7 +495,7 @@ fn bindings_from_self_dispatch(
     out: &mut Vec<CallerFrameBinding>,
 ) {
     use tcl_compiler::analyser::param_traits::{
-        caller_frame_literal_targets, caller_frame_upvar_params, infer_param_traits_with_config,
+        TraitScanEnv, caller_frame_literal_targets, caller_frame_upvar_params, infer_param_traits,
     };
 
     let (Some(head), Some(head_text)) = (cmd.argv.first(), cmd.texts.first()) else {
@@ -487,7 +505,7 @@ fn bindings_from_self_dispatch(
         return;
     }
     let (Some(registry), Some(method)) = (
-        ctx.registry,
+        ctx.resolution.registry,
         cmd.texts.get(1).filter(|w| is_plain_var_name(w)),
     ) else {
         return;
@@ -508,9 +526,14 @@ fn bindings_from_self_dispatch(
     let Some(body) = method_body_text(ctx.source, md.body_span) else {
         return;
     };
-    let config = tcl_lexer::LexerConfig::for_dialect(ctx.dialect);
+    let env = TraitScanEnv {
+        registry,
+        stub_overlay: None,
+        config: tcl_lexer::LexerConfig::for_dialect(ctx.dialect),
+        identities: ctx.identities,
+    };
     let callee = format!("{provider_q}::{method}");
-    if let Some(written) = caller_frame_literal_targets(body, registry, config).get(ctx.name) {
+    if let Some(written) = caller_frame_literal_targets(body, env).get(ctx.name) {
         out.push(CallerFrameBinding {
             callee: callee.clone(),
             param: None,
@@ -523,11 +546,11 @@ fn bindings_from_self_dispatch(
     if param_names.is_empty() {
         return;
     }
-    let caller_frame_params = caller_frame_upvar_params(&param_names, body, registry, config);
+    let caller_frame_params = caller_frame_upvar_params(&param_names, body, env);
     if caller_frame_params.is_empty() {
         return;
     }
-    let traits = infer_param_traits_with_config(&param_names, body, registry, None, config);
+    let traits = infer_param_traits(&param_names, body, env);
     for (i, param) in param_names.iter().enumerate() {
         // `my <method> <arg>…` — the actual arguments start one word later
         // than a plain call's, because the method name is itself a word.
@@ -1167,8 +1190,14 @@ oo::class create Widget {
     fn a_mixin_method_reached_by_my_dispatch_binds_its_literal_target() {
         let analysis = analyse(MIXIN_SRC);
         let read = offset_of(MIXIN_SRC, "$name\"") + 1;
-        let bindings =
-            caller_frame_bindings(&analysis, MIXIN_SRC, "tcl9.0", Some(reg()), read, "name");
+        let bindings = caller_frame_bindings(
+            &analysis,
+            MIXIN_SRC,
+            "tcl9.0",
+            crate::definition::CallResolution::document_only().with_registry(reg()),
+            read,
+            "name",
+        );
         assert_eq!(bindings.len(), 1, "{bindings:?}");
         assert!(
             bindings[0].callee.contains("NameProcess"),
@@ -1190,8 +1219,15 @@ oo::class create Widget {
         let analysis = analyse(MIXIN_SRC);
         let read = offset_of(MIXIN_SRC, "$name\"") + 1;
         assert!(
-            caller_frame_bindings(&analysis, MIXIN_SRC, "tcl9.0", Some(reg()), read, "other")
-                .is_empty()
+            caller_frame_bindings(
+                &analysis,
+                MIXIN_SRC,
+                "tcl9.0",
+                crate::definition::CallResolution::document_only().with_registry(reg()),
+                read,
+                "other"
+            )
+            .is_empty()
         );
     }
 
@@ -1213,7 +1249,15 @@ oo::class create Widget {
         let analysis = analyse(src);
         let read = offset_of(src, "$name\"") + 1;
         assert!(
-            caller_frame_bindings(&analysis, src, "tcl9.0", Some(reg()), read, "name").is_empty()
+            caller_frame_bindings(
+                &analysis,
+                src,
+                "tcl9.0",
+                crate::definition::CallResolution::document_only().with_registry(reg()),
+                read,
+                "name"
+            )
+            .is_empty()
         );
     }
 
@@ -1241,7 +1285,15 @@ oo::class create Derived {
         let analysis = analyse(src);
         let read = offset_of(src, "$name\"") + 1;
         assert!(
-            caller_frame_bindings(&analysis, src, "tcl9.0", Some(reg()), read, "name").is_empty()
+            caller_frame_bindings(
+                &analysis,
+                src,
+                "tcl9.0",
+                crate::definition::CallResolution::document_only().with_registry(reg()),
+                read,
+                "name"
+            )
+            .is_empty()
         );
     }
 

--- a/rust/tcl-lsp-core/src/caller_frame.rs
+++ b/rust/tcl-lsp-core/src/caller_frame.rs
@@ -1215,8 +1215,14 @@ oo::class create Widget {
     }
 
     /// TN — `next` names no callee statically (it dispatches to whatever
-    /// follows *this* implementation in the MRO), so it stays abstaining
-    /// even when a superclass method would bind the name.
+    /// follows *this* implementation in the MRO), so it stays abstaining.
+    ///
+    /// And abstaining is the *right* answer here, not merely the safe one:
+    /// tclsh 9.0.4 and 8.6.16 both raise `can't read "name": no such
+    /// variable` for the source below.  `next`'s frame does not nest inside
+    /// the method that issued it, so `Base::init`'s `upvar 1` reaches
+    /// **past** `Derived::init` — claiming a binding here would have been a
+    /// wrong answer, not just an over-eager one.
     #[test]
     fn a_next_dispatch_binds_nothing() {
         let src = "\
@@ -1326,11 +1332,20 @@ mod caller_frame_navigation_tests {
     /// read.  Before the cell gained a `VarDef` at the `otherVar` word,
     /// every one of these anchors answered nothing (a silent miss).
     ///
-    /// The four references are: the `otherVar` word, the `info exists`
-    /// argument, the `$` read, and the `unset` argument.  A *bareword*
-    /// cursor on the `info exists` argument still abstains — barewords in
-    /// variable-role argument positions are a separate anchor kind — but
-    /// the occurrence itself is in the reference set.
+    /// The four references are the two spellings of the cell that this
+    /// document actually binds: the `upvar` `otherVar` word and the sibling
+    /// proc's `$::tk::FocusGrab($index)` read, plus the two occurrences of
+    /// the local alias `data` the `upvar` introduces for it — Find-
+    /// References unifies an alias with the cell it names.
+    ///
+    /// Deliberately asserted **by position**, not by count.  A count-only
+    /// assertion cannot tell those four apart from four other spans, and
+    /// this test's own earlier prose claimed a different four (the bareword
+    /// `info exists` / `unset` arguments) that the pass does not in fact
+    /// record: a *bareword* in a variable-role argument slot is a separate
+    /// anchor kind, and neither the cursor nor the reference set reaches it
+    /// yet.  That residual is real and stays visible here rather than being
+    /// asserted away.
     #[test]
     fn a_fully_qualified_upvar_target_navigates_from_word_and_read() {
         let src = "\
@@ -1372,10 +1387,12 @@ proc RestoreFocusGrab {grab focus} {
             let defs = crate::definition::definition(src, line, col, &analysis);
             assert_eq!(defs.len(), 1, "{label}: one definition: {defs:?}");
             let refs = crate::references::references(src, "tcl9.0", line, col, &analysis, true);
+            let lines: Vec<u32> = refs.iter().map(|r| r.start_line).collect();
             assert_eq!(
-                refs.len(),
-                4,
-                "{label}: otherVar word + info exists + read + unset: {refs:?}"
+                lines,
+                vec![2, 2, 3, 8],
+                "{label}: the `upvar` otherVar word and its `data` alias (line 2), \
+                 the alias use (line 3), and the sibling proc's read (line 8): {refs:?}"
             );
         }
     }

--- a/rust/tcl-lsp-core/src/caller_frame.rs
+++ b/rust/tcl-lsp-core/src/caller_frame.rs
@@ -1174,7 +1174,10 @@ oo::class create Widget {
             bindings[0].callee.contains("NameProcess"),
             "the card must name the resolved method: {bindings:?}"
         );
-        assert!(!bindings[0].read_only, "the method writes through the alias");
+        assert!(
+            !bindings[0].read_only,
+            "the method writes through the alias"
+        );
         // The binding span is the dispatch head — the point where the
         // variable comes to exist in this frame.
         assert_eq!(&MIXIN_SRC[bindings[0].arg_span.as_range()], "my");

--- a/rust/tcl-lsp-core/src/caller_frame.rs
+++ b/rust/tcl-lsp-core/src/caller_frame.rs
@@ -1390,12 +1390,16 @@ proc RestoreFocusGrab {grab focus} {
             let defs = crate::definition::definition(src, line, col, &analysis);
             assert_eq!(defs.len(), 1, "{label}: one definition: {defs:?}");
             let refs = crate::references::references(src, "tcl9.0", line, col, &analysis, true);
-            let lines: Vec<u32> = refs.iter().map(|r| r.start_line).collect();
+            let spans: Vec<(u32, u32)> = refs
+                .iter()
+                .map(|r| (r.start_line, r.start_character))
+                .collect();
             assert_eq!(
-                lines,
-                vec![2, 2, 3, 8],
-                "{label}: the `upvar` otherVar word and its `data` alias (line 2), \
-                 the alias use (line 3), and the sibling proc's read (line 8): {refs:?}"
+                spans,
+                vec![(2, 10), (8, 18), (2, 34), (3, 12)],
+                "{label}: the cell's own two spellings — the `upvar` otherVar word \
+                 and the sibling proc's read — then the two occurrences of the \
+                 `data` alias it introduces: {refs:?}"
             );
         }
     }

--- a/rust/tcl-lsp-core/src/caller_frame.rs
+++ b/rust/tcl-lsp-core/src/caller_frame.rs
@@ -87,14 +87,24 @@
 //! cell, which the analyser's `handle_upvar_command` now defines and links
 //! directly.
 //!
+//! # Methods reached by `my` dispatch (issue #923 audit idx 22)
+//!
+//! A callee reached through `my <method>` is a method the *call* never
+//! names — but the **method-resolution order** does, mixins included, and
+//! issues #1177 / #1164 have since landed that walk.
+//! [`bindings_from_self_dispatch`] therefore resolves the callee through
+//! [`crate::oo_dispatch::method_dispatch_provider`] — the single walk
+//! hover, go-to-definition, and find-references already share — and reads
+//! its frame effects from the resolved body.  That is the audit's real
+//! corpus shape: `SpiceGenTcl`'s `Utility::NameProcess` mixed into a class
+//! and invoked as `my NameProcess …`.
+//!
 //! # What it deliberately does not answer
 //!
-//! A callee reached through `my` / `next` / object dispatch is a method the
-//! call never names statically, so its literal targets cannot be resolved
-//! here yet — those reads keep the abstaining answer rather than a wrong
-//! one (the compiler-side dispatch widening of issue #1177 keeps the
-//! diagnostics honest in the meantime; per-callee method resolution
-//! composes with issue #1164's MRO work).
+//! `next` / `nextto` dispatch to whatever follows *this* implementation in
+//! the MRO, which the call site does not name, so those reads keep the
+//! abstaining answer rather than a wrong one (the compiler-side dispatch
+//! widening of issue #1177 keeps the diagnostics honest for them).
 
 use tcl_compiler::analyser::AnalysisResult;
 use tcl_compiler::analyser::types::ProcArgTrait;
@@ -254,7 +264,14 @@ pub(crate) fn caller_frame_bindings(
     // is the expensive part.  A document with no call-by-name procedure at all
     // — the overwhelming majority — can answer from the already-computed
     // per-proc facts without touching the source.
-    if name.is_empty() || !document_has_call_by_name_proc(analysis) {
+    // …and a document with no call-by-name procedure can still bind a
+    // caller-frame name through a **method** reached by `my` dispatch (issue
+    // #923 audit idx 22's real corpus shape), but only when the cursor is
+    // inside a class body — which is the cheap way to ask.
+    if name.is_empty()
+        || (!document_has_call_by_name_proc(analysis)
+            && crate::definition::enclosing_class_at(analysis, cursor_off).is_none())
+    {
         return out;
     }
     let (start, end) = enclosing_frame_region(&analysis.global_scope, cursor_off, source);
@@ -359,6 +376,7 @@ fn bindings_from_call(
         head.span.start(),
         ctx.resolution,
     ) else {
+        bindings_from_self_dispatch(ctx, cmd, out);
         return;
     };
     if proc_def.caller_frame_params.is_empty() && proc_def.caller_frame_literals.is_empty() {
@@ -414,6 +432,145 @@ fn bindings_from_call(
             read_only: !writes,
         });
     }
+}
+
+/// The bindings a **`TclOO` self-dispatch** call site contributes —
+/// `my NameProcess …`, the shape issue #923 audit idx 22 was actually mined
+/// from (`SpiceGenTcl`'s `Utility::NameProcess`, mixed into the class and
+/// invoked from its constructor).
+///
+/// tclsh 9.0.4 / 8.6.16, identical — the mixin's `upvar name name` really
+/// does create the *constructor's* `name`, which the constructor's own text
+/// never assigns:
+///
+/// ```text
+/// oo::class create Utility { method NameProcess {arguments object} {
+///     upvar name name; set name $object } }
+/// oo::class create Widget { mixin Utility
+///     constructor {arguments} { my NameProcess $arguments [self object]
+///         puts "name=$name" } }
+/// Widget new {-base 1}      → name=::oo::Obj24 …
+/// ```
+///
+/// The callee is a method the call never names statically, which is why
+/// this was deferred when `caller_frame.rs` landed.  It no longer is: the
+/// method-resolution-order walk (issues #1177 / #1164) resolves `my m`
+/// through mixins and superclasses, and
+/// [`crate::oo_dispatch::method_dispatch_provider`] is the *one* walk hover,
+/// go-to-definition, and find-references already share — so keying the
+/// frame-effect question on it cannot disagree with the answer those three
+/// give for the very same cursor.
+///
+/// The frame facts themselves are recomputed from the resolved method's
+/// body text through the same `param_traits` scans the analyser runs for a
+/// `proc` — a pure function of `(body, params, registry, dialect config)`
+/// — rather than cached on every `MethodDef`: this runs only on a
+/// navigation query that already failed the ordinary scope-chain lookup,
+/// for the `my`-headed calls of one frame.
+///
+/// `next` is deliberately excluded: it dispatches to whatever follows *this*
+/// implementation in the MRO, which the call site does not name, so it keeps
+/// the abstaining answer.
+fn bindings_from_self_dispatch(
+    ctx: &BindingScan<'_>,
+    cmd: &tcl_compiler::segmenter::SegmentedCommand,
+    out: &mut Vec<CallerFrameBinding>,
+) {
+    use tcl_compiler::analyser::param_traits::{
+        caller_frame_literal_targets, caller_frame_upvar_params, infer_param_traits_with_config,
+    };
+
+    let (Some(head), Some(head_text)) = (cmd.argv.first(), cmd.texts.first()) else {
+        return;
+    };
+    if !crate::definition::is_self_dispatch_keyword(head_text) {
+        return;
+    }
+    let (Some(registry), Some(method)) = (
+        ctx.registry,
+        cmd.texts.get(1).filter(|w| is_plain_var_name(w)),
+    ) else {
+        return;
+    };
+    let Some(class_q) = crate::definition::enclosing_class_at(ctx.analysis, head.span.start())
+    else {
+        return;
+    };
+    let Some((provider_q, md)) = crate::oo_dispatch::method_dispatch_provider(
+        ctx.analysis,
+        class_q,
+        method,
+        false,
+        crate::definition::MethodBucket::Instance,
+    ) else {
+        return;
+    };
+    let Some(body) = method_body_text(ctx.source, md.body_span) else {
+        return;
+    };
+    let config = tcl_lexer::LexerConfig::for_dialect(ctx.dialect);
+    let callee = format!("{provider_q}::{method}");
+    if let Some(written) = caller_frame_literal_targets(body, registry, config).get(ctx.name) {
+        out.push(CallerFrameBinding {
+            callee: callee.clone(),
+            param: None,
+            arg_span: head.span,
+            call_span: head.span,
+            read_only: !written,
+        });
+    }
+    let param_names: Vec<&str> = md.params.iter().map(|p| p.name.as_str()).collect();
+    if param_names.is_empty() {
+        return;
+    }
+    let caller_frame_params = caller_frame_upvar_params(&param_names, body, registry, config);
+    if caller_frame_params.is_empty() {
+        return;
+    }
+    let traits = infer_param_traits_with_config(&param_names, body, registry, None, config);
+    for (i, param) in param_names.iter().enumerate() {
+        // `my <method> <arg>…` — the actual arguments start one word later
+        // than a plain call's, because the method name is itself a word.
+        let (Some(arg_tok), Some(arg_text)) = (cmd.argv.get(i + 2), cmd.texts.get(i + 2)) else {
+            break;
+        };
+        if arg_text != ctx.name || !is_plain_var_name(arg_text) {
+            continue;
+        }
+        // Same two-fact rule as the plain-proc path: the trait says the
+        // value is used as a variable name, `caller_frame_params` says the
+        // alias lands one frame up (`upvar 1`, not `0` / `#0` / `2`).
+        if !caller_frame_params.contains(*param) {
+            continue;
+        }
+        let Some(traits) = traits.get(*param) else {
+            continue;
+        };
+        let writes = traits.contains(&ProcArgTrait::VarWrite);
+        let reads = traits.contains(&ProcArgTrait::VarRead);
+        if !writes && !reads {
+            continue;
+        }
+        out.push(CallerFrameBinding {
+            callee: callee.clone(),
+            param: Some((*param).to_string()),
+            arg_span: arg_tok.span,
+            call_span: head.span,
+            read_only: !writes,
+        });
+    }
+}
+
+/// A method body's *script* text, with the brace delimiters its recorded
+/// span may still carry stripped — the same correction
+/// [`enclosing_frame_region`] applies, and for the same reason: left in,
+/// every scan below reads the whole body as one braced word and finds no
+/// commands in it at all.
+fn method_body_text(source: &str, body_span: Span) -> Option<&str> {
+    let body = source.get(body_span.start() as usize..body_span.end() as usize)?;
+    let body = body.strip_prefix('{').unwrap_or(body);
+    let body = body.strip_suffix('}').unwrap_or(body);
+    (!body.trim().is_empty()).then_some(body)
 }
 
 /// Every span in the enclosing frame that refers to the caller-frame variable
@@ -979,6 +1136,104 @@ proc build {} {
                 "`upvar {level}` does not bind the caller's frame: {bindings:?}"
             );
         }
+    }
+
+    // -- `my <method>` dispatch, through a mixin (issue #923 audit idx 22) --
+
+    /// The `SpiceGenTcl` shape the audit actually reported: the callee is a
+    /// method of a **mixin**, reached by `my NameProcess …` from a
+    /// constructor that never assigns `name` itself.
+    ///
+    /// tclsh 9.0.4 / 8.6.16, identical: `Widget new {-base 1}` prints
+    /// `name=::oo::Obj24 params=-base 1` — the mixin's `upvar name name`
+    /// creates the constructor's `name`.
+    const MIXIN_SRC: &str = "\
+oo::class create Utility {
+    method NameProcess {arguments object} {
+        upvar name name
+        set name $object
+    }
+}
+oo::class create Widget {
+    mixin Utility
+    constructor {arguments} {
+        my NameProcess $arguments [self object]
+        puts \"name=$name\"
+    }
+}
+";
+
+    #[test]
+    fn a_mixin_method_reached_by_my_dispatch_binds_its_literal_target() {
+        let analysis = analyse(MIXIN_SRC);
+        let read = offset_of(MIXIN_SRC, "$name\"") + 1;
+        let bindings =
+            caller_frame_bindings(&analysis, MIXIN_SRC, "tcl9.0", Some(reg()), read, "name");
+        assert_eq!(bindings.len(), 1, "{bindings:?}");
+        assert!(
+            bindings[0].callee.contains("NameProcess"),
+            "the card must name the resolved method: {bindings:?}"
+        );
+        assert!(!bindings[0].read_only, "the method writes through the alias");
+        // The binding span is the dispatch head — the point where the
+        // variable comes to exist in this frame.
+        assert_eq!(&MIXIN_SRC[bindings[0].arg_span.as_range()], "my");
+    }
+
+    /// TP control — the abstention is per-name: a name the resolved method
+    /// never binds gets no binding, so the read keeps abstaining.
+    #[test]
+    fn a_mixin_method_binds_only_the_name_its_upvar_spells() {
+        let analysis = analyse(MIXIN_SRC);
+        let read = offset_of(MIXIN_SRC, "$name\"") + 1;
+        assert!(
+            caller_frame_bindings(&analysis, MIXIN_SRC, "tcl9.0", Some(reg()), read, "other")
+                .is_empty()
+        );
+    }
+
+    /// TN — a method with no caller-frame `upvar` binds nothing, exactly
+    /// like the plain-proc control.  tclsh 9.0.4: the constructor's `$name`
+    /// really does raise `can't read "name"`.
+    #[test]
+    fn a_mixin_method_without_an_upvar_binds_nothing() {
+        let src = "\
+oo::class create Utility {
+    method NameProcess {arguments object} { set name $object }
+}
+oo::class create Widget {
+    mixin Utility
+    constructor {arguments} { my NameProcess $arguments [self object]
+        puts \"name=$name\" }
+}
+";
+        let analysis = analyse(src);
+        let read = offset_of(src, "$name\"") + 1;
+        assert!(
+            caller_frame_bindings(&analysis, src, "tcl9.0", Some(reg()), read, "name").is_empty()
+        );
+    }
+
+    /// TN — `next` names no callee statically (it dispatches to whatever
+    /// follows *this* implementation in the MRO), so it stays abstaining
+    /// even when a superclass method would bind the name.
+    #[test]
+    fn a_next_dispatch_binds_nothing() {
+        let src = "\
+oo::class create Base {
+    method init {} { upvar name name; set name B }
+}
+oo::class create Derived {
+    superclass Base
+    method init {} { next
+        puts \"name=$name\" }
+}
+";
+        let analysis = analyse(src);
+        let read = offset_of(src, "$name\"") + 1;
+        assert!(
+            caller_frame_bindings(&analysis, src, "tcl9.0", Some(reg()), read, "name").is_empty()
+        );
     }
 
     /// TN — a `::`-qualified target names a fixed global/namespace cell,

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -4603,3 +4603,166 @@ fn itcl_method_bodies_are_analysed_end_to_end() {
         codes(&diags)
     );
 }
+
+// -- Caller-frame injection through `upvar` / `uplevel` (issue #923 audit
+//    cluster C1 — idx 7, 38, 57, 59; issue #1019) --
+//
+// The compiler-unit twins live in `tcl-compiler/tests/caller_frame_effects.rs`.
+// These pin the same facts through the **live server**, whose incremental
+// per-item analysis is a different code path from the whole-file walk those
+// tests drive — a regression confined to the diagnostic-publishing pipeline
+// would be invisible to them.
+
+/// idx 57 — the ticklecharts `setdef` / `estruct` out-parameter shape:
+/// `upvar 1 $name local` plus a write through the alias, called with a
+/// literal name.  tclsh 9.0.4 / 8.6.16: `things::estruct itemLegend1 tree1`
+/// leaves `itemLegend1` set in the caller.
+#[test]
+fn an_upvar_out_parameter_draws_no_false_read_before_set_end_to_end() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "namespace eval things {\n    proc estruct {name value} {\n        upvar 1 $name obj\n        set obj [dict create v $value]\n    }\n}\nproc build {} {\n    things::estruct itemLegend1 tree1\n    return [dict get $itemLegend1 v]\n}\n",
+    );
+    assert!(
+        !has_code(&diags, "W210"),
+        "the helper's upvar creates `itemLegend1` in build's frame: {:?}",
+        codes(&diags)
+    );
+}
+
+/// TP control for the test above — the suppression is per-name, so a local
+/// the helper never touches is still read-before-set (tclsh 9.0.4 / 8.6.16
+/// raise `can't read "neverSet"`).
+#[test]
+fn an_unrelated_local_still_draws_read_before_set_end_to_end() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc estruct {name value} {\n    upvar 1 $name obj\n    set obj $value\n}\nproc build {} {\n    estruct itemLegend1 tree1\n    return $neverSet\n}\n",
+    );
+    let hits = with_code(&diags, "W210");
+    assert_eq!(hits.len(), 1, "exactly one W210: {:?}", codes(&diags));
+    assert!(
+        message(&hits[0]).contains("neverSet"),
+        "and it must be the unrelated local: {:?}",
+        message(&hits[0])
+    );
+}
+
+/// idx 7 — `argparse` injects caller-frame locals from its own definition
+/// list, none of which the proc's own text assigns.  tclsh 9.0.4 / 8.6.16
+/// (argparse 0.5): `upvarProc p 1 2` prints `a=… b=1 c=2`.
+#[test]
+fn argparse_injected_locals_draw_no_false_read_before_set_end_to_end() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "package require argparse\nproc upvarProc {args} {\n    argparse {\n        {a -upvar}\n        b\n        c\n    }\n    puts \"a=$a b=$b c=$c\"\n}\n",
+    );
+    assert!(
+        !has_code(&diags, "W210"),
+        "argparse's DSL creates a/b/c in this very frame: {:?}",
+        codes(&diags)
+    );
+}
+
+/// idx 59 — the **cross-file** half, in the layout it was mined from:
+/// `setdef` lives in `utils.tcl`, the caller in `options.tcl`, and only a
+/// `pkgIndex.tcl` ties them together, so the caller's compilation unit
+/// holds no definition of `setdef` at all.  tclsh 9.0.4 / 8.6.16 running
+/// the real four-file layout: `demo::build {a b c}` returns
+/// `{nothing str no} {nothing str no} {nothing str no}`.
+#[test]
+fn a_cross_file_upvar_helper_draws_no_false_read_before_set_end_to_end() {
+    let root = std::env::temp_dir().join(format!(
+        "tcl-lsp-e2e-xfile-upvar-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos(),
+    ));
+    std::fs::create_dir_all(&root).expect("create workspace root");
+    std::fs::write(
+        root.join("utils.tcl"),
+        "namespace eval demo {}\nproc demo::setdef {d key args} {\n    upvar 1 $d _dict\n    dict set _dict $key $args\n}\n",
+    )
+    .expect("write utils.tcl");
+    let options = root.join("options.tcl");
+    let text = "proc demo::build {items} {\n    set opts {}\n    foreach item $items {\n        setdef options name -default nothing\n        lappend opts [dict get $options name]\n        set options {}\n    }\n    return $opts\n}\n";
+    std::fs::write(&options, text).expect("write options.tcl");
+
+    let mut lsp = Lsp::at_workspace_root(&root);
+    let uri = format!("file://{}", options.to_string_lossy());
+    let diags = lsp.open_ready(&uri, text);
+    assert!(
+        !has_code(&diags, "W210"),
+        "a helper this file cannot see may create `options` through upvar: {:?}",
+        codes(&diags)
+    );
+
+    // TP control, same session: a name the opaque call never spells is
+    // still read-before-set.
+    let control = root.join("control.tcl");
+    let control_text = "proc demo::build2 {} {\n    setdef options name -default nothing\n    return $neverPassed\n}\n";
+    std::fs::write(&control, control_text).expect("write control.tcl");
+    let control_uri = format!("file://{}", control.to_string_lossy());
+    let control_diags = lsp.open_ready(&control_uri, control_text);
+    let hits = with_code(&control_diags, "W210");
+    assert_eq!(
+        hits.len(),
+        1,
+        "exactly one W210: {:?}",
+        codes(&control_diags)
+    );
+    assert!(
+        message(&hits[0]).contains("neverPassed"),
+        "and it must be the name the call never spells: {:?}",
+        message(&hits[0])
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// idx 99 — the deliberate `tcl::OptProc` arity trade-off, pinned as a
+/// choice rather than left to look like an oversight.
+///
+/// The definer installs `::proc $name args {…}` at run time, so the
+/// declared optlist says nothing about how many *positional* arguments a
+/// call may pass; C Tcl enforces it from the parsed optlist at call time,
+/// which is a runtime fact this analysis does not model.  tclsh 9.0.4 /
+/// 8.6.16 do raise `too many arguments` for the overflow below — and we
+/// deliberately stay silent about it, because the only alternative on
+/// offer was the false E003 the audit found on *legitimate* calls.  Both
+/// halves are asserted so the asymmetry cannot drift unnoticed.
+#[test]
+fn opt_proc_arity_is_deliberately_unchecked_in_both_directions_end_to_end() {
+    let mut lsp = Lsp::tcl();
+    for call in ["greet interp1", "greet interp1 extraPositionalArg"] {
+        let uri = unique_uri("tcl");
+        let diags = lsp.open_ready(
+            &uri,
+            &format!(
+                "package require opt\n::tcl::OptProc greet {{child -use -display}} {{ return $child }}\n{call}\n"
+            ),
+        );
+        assert!(
+            !has_code(&diags, "E002") && !has_code(&diags, "E003"),
+            "OptProc calls draw no arity diagnostic either way — `{call}`: {:?}",
+            codes(&diags)
+        );
+    }
+    // TN control — an ordinary proc still gets real arity checking, so the
+    // silence above is scoped to the definer and not a global retreat.
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "proc plain {a} { return $a }\nplain 1 2\n");
+    assert!(
+        has_code(&diags, "E002") || has_code(&diags, "E003"),
+        "an ordinary proc must still be arity-checked: {:?}",
+        codes(&diags)
+    );
+}

--- a/rust/tcl-lsp-server/tests/e2e/navigation.rs
+++ b/rust/tcl-lsp-server/tests/e2e/navigation.rs
@@ -303,18 +303,24 @@ oo::class create Widget {
 }
 ";
 
+/// Character of the `name` inside `puts "name=$name params=$params"` on
+/// line 11 of [`MIXIN_DISPATCH_SRC`].
+fn mixin_read_column() -> u32 {
+    let at = MIXIN_DISPATCH_SRC
+        .lines()
+        .nth(11)
+        .and_then(|l| l.find("$name"))
+        .expect("the read");
+    u32::try_from(at).expect("column fits u32") + 2
+}
+
 #[test]
 fn hover_on_a_mixin_dispatch_caller_frame_read_names_the_creating_call() {
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
     lsp.open_ready(&uri, MIXIN_DISPATCH_SRC);
     // Line 11 — inside the `name` of `puts "name=$name params=$params"`.
-    let col = MIXIN_DISPATCH_SRC
-        .lines()
-        .nth(11)
-        .and_then(|l| l.find("$name"))
-        .expect("the read") as u32
-        + 2;
+    let col = mixin_read_column();
     let text = hover_text(&lsp.hover(&uri, 11, col));
     assert!(
         text.contains("Caller-frame variable") && text.contains("NameProcess"),
@@ -327,12 +333,7 @@ fn definition_on_a_mixin_dispatch_caller_frame_read_reaches_the_dispatch() {
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
     lsp.open_ready(&uri, MIXIN_DISPATCH_SRC);
-    let col = MIXIN_DISPATCH_SRC
-        .lines()
-        .nth(11)
-        .and_then(|l| l.find("$name"))
-        .expect("the read") as u32
-        + 2;
+    let col = mixin_read_column();
     let locs = locations(&lsp.definition(&uri, 11, col));
     assert_eq!(locs.len(), 1, "one definition: {locs:?}");
     assert_eq!(
@@ -348,12 +349,7 @@ fn references_on_a_mixin_dispatch_link_the_dispatch_and_the_read() {
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
     lsp.open_ready(&uri, MIXIN_DISPATCH_SRC);
-    let col = MIXIN_DISPATCH_SRC
-        .lines()
-        .nth(11)
-        .and_then(|l| l.find("$name"))
-        .expect("the read") as u32
-        + 2;
+    let col = mixin_read_column();
     let refs = start_lines(&lsp.references(&uri, 11, col, true));
     assert_eq!(
         refs.iter().copied().collect::<Vec<i64>>(),

--- a/rust/tcl-lsp-server/tests/e2e/navigation.rs
+++ b/rust/tcl-lsp-server/tests/e2e/navigation.rs
@@ -397,6 +397,15 @@ fn a_mixin_dispatch_without_an_upvar_still_abstains() {
 /// graft merged a fragment's proc scope only — so the cell never reached
 /// the scope tree the providers read.  A `references`-only assertion could
 /// not see that, which is exactly why this asserts all three.
+///
+/// Known residual, deliberately left visible rather than asserted away:
+/// the *bareword* `info exists` / `unset` arguments (lines 7 and 9) are
+/// not in the cell's reference set.  A bareword in a variable-role
+/// argument slot is a separate anchor kind on both sides — the cursor
+/// does not resolve there either — and the compiler-library twin
+/// (`tcl-lsp-core`'s `a_fully_qualified_upvar_target_navigates_from_word_and_read`)
+/// now asserts the same set by position, so the two tiers agree about
+/// exactly what is and is not covered.
 const FOCUS_GRAB_SRC: &str = "proc SetFocusGrab {grab focus} {\n    set index \"$grab,$focus\"\n    upvar ::tk::FocusGrab($index) data\n    lappend data one\n}\nproc RestoreFocusGrab {grab focus} {\n    set index \"$grab,$focus\"\n    if {[info exists ::tk::FocusGrab($index)]} {\n        set data2 $::tk::FocusGrab($index)\n        unset ::tk::FocusGrab($index)\n    }\n}\n";
 
 /// Line/character of each anchor: the `upvar` `otherVar` word (line 2) and
@@ -446,8 +455,16 @@ fn a_fully_qualified_upvar_target_cross_references_between_procs() {
         let refs = start_lines(&lsp.references(&uri, line, character, true));
         assert_eq!(
             refs.iter().copied().collect::<Vec<i64>>(),
-            vec![2, 7, 8, 9],
-            "otherVar word + info exists + read + unset, from {line}:{character}: {refs:?}"
+            vec![2, 3, 8],
+            "the `upvar` otherVar word and its `data` alias (line 2), the alias \
+             use (line 3), and the sibling proc's read (line 8), from \
+             {line}:{character}: {refs:?}"
+        );
+        // The cross-proc link is the point of the finding, so it is called
+        // out separately from the exact set above.
+        assert!(
+            refs.contains(&2) && refs.contains(&8),
+            "the read must link the upvar otherVar word across procs: {refs:?}"
         );
     }
 }

--- a/rust/tcl-lsp-server/tests/e2e/navigation.rs
+++ b/rust/tcl-lsp-server/tests/e2e/navigation.rs
@@ -369,12 +369,13 @@ fn a_mixin_dispatch_without_an_upvar_still_abstains() {
         &uri,
         "oo::class create Utility {\n    method NameProcess {arguments object} { set name $object }\n}\noo::class create Widget {\n    mixin Utility\n    constructor {arguments} {\n        my NameProcess $arguments [self object]\n        puts \"name=$name\"\n    }\n}\n",
     );
+    // Line 7 col 21 — inside the `name` of `puts "name=$name"`.
     assert!(
-        hover_text(&lsp.hover(&uri, 6, 22)).is_empty(),
+        hover_text(&lsp.hover(&uri, 7, 21)).is_empty(),
         "an unbound `$`-led read must draw no hover"
     );
     assert!(
-        locations(&lsp.definition(&uri, 6, 22)).is_empty(),
+        locations(&lsp.definition(&uri, 7, 21)).is_empty(),
         "…and no definition"
     );
 }

--- a/rust/tcl-lsp-server/tests/e2e/navigation.rs
+++ b/rust/tcl-lsp-server/tests/e2e/navigation.rs
@@ -280,33 +280,176 @@ fn references_on_a_literal_upvar_target_link_the_call_and_the_read() {
     );
 }
 
-/// Issue #923 audit idx 98: `upvar ::tk::FocusGrab($index) data` names one
-/// fixed global cell (level-independent), so the sibling proc's
-/// `$::tk::FocusGrab($index)` read and the `upvar` `otherVar` word now
-/// cross-reference — previously every anchor answered nothing.
-///
-/// Pinned at the parity point with a plain qualified write: the server's
-/// per-item incremental analysis merges a proc-body `set
-/// ::tk::FocusGrab($i) 1` to exactly the same answer (references link the
-/// write word and the `$` read; read-anchored hover/definition and the
-/// bareword `info exists` / `unset` occurrences are a known per-item
-/// residual shared by both spellings — the whole-file analysis pinned in
-/// `tcl-lsp-core`'s `caller_frame` tests answers all four anchors).
+// -- `my <method>` dispatch through a mixin (issue #923 audit idx 22) --
+
+/// The `SpiceGenTcl` shape the audit reported: the callee is a **mixin**'s
+/// method reached by `my NameProcess …`, and the constructor that reads
+/// `$name` never assigns it.  tclsh 9.0.4 / 8.6.16, identical: `Widget new
+/// {-base 1}` prints `name=::oo::Obj24 params=-base 1`.
+const MIXIN_DISPATCH_SRC: &str = "\
+oo::class create Utility {
+    method NameProcess {arguments object} {
+        upvar name name
+        set name $object
+    }
+}
+oo::class create Widget {
+    mixin Utility
+    constructor {arguments} {
+        my NameProcess $arguments [self object]
+        set params $arguments
+        puts \"name=$name params=$params\"
+    }
+}
+";
+
 #[test]
-fn a_fully_qualified_upvar_target_cross_references_between_procs() {
+fn hover_on_a_mixin_dispatch_caller_frame_read_names_the_creating_call() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, MIXIN_DISPATCH_SRC);
+    // Line 11 — inside the `name` of `puts "name=$name params=$params"`.
+    let col = MIXIN_DISPATCH_SRC
+        .lines()
+        .nth(11)
+        .and_then(|l| l.find("$name"))
+        .expect("the read") as u32
+        + 2;
+    let text = hover_text(&lsp.hover(&uri, 11, col));
+    assert!(
+        text.contains("Caller-frame variable") && text.contains("NameProcess"),
+        "the card must name the method the MRO resolves: {text:?}"
+    );
+}
+
+#[test]
+fn definition_on_a_mixin_dispatch_caller_frame_read_reaches_the_dispatch() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, MIXIN_DISPATCH_SRC);
+    let col = MIXIN_DISPATCH_SRC
+        .lines()
+        .nth(11)
+        .and_then(|l| l.find("$name"))
+        .expect("the read") as u32
+        + 2;
+    let locs = locations(&lsp.definition(&uri, 11, col));
+    assert_eq!(locs.len(), 1, "one definition: {locs:?}");
+    assert_eq!(
+        locs[0].range["start"]["line"].as_i64(),
+        Some(9),
+        "the `my NameProcess …` dispatch is where the variable comes to \
+         exist in this frame: {locs:?}"
+    );
+}
+
+#[test]
+fn references_on_a_mixin_dispatch_link_the_dispatch_and_the_read() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, MIXIN_DISPATCH_SRC);
+    let col = MIXIN_DISPATCH_SRC
+        .lines()
+        .nth(11)
+        .and_then(|l| l.find("$name"))
+        .expect("the read") as u32
+        + 2;
+    let refs = start_lines(&lsp.references(&uri, 11, col, true));
+    assert_eq!(
+        refs.iter().copied().collect::<Vec<i64>>(),
+        vec![9, 11],
+        "the dispatch and the read are one variable: {refs:?}"
+    );
+}
+
+/// TN — a mixin method with no caller-frame `upvar` creates nothing, so the
+/// read keeps abstaining rather than gaining a wrong answer.  tclsh 9.0.4:
+/// the constructor's `$name` raises `can't read "name"`.
+#[test]
+fn a_mixin_dispatch_without_an_upvar_still_abstains() {
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
     lsp.open_ready(
         &uri,
-        "proc SetFocusGrab {grab focus} {\n    set index \"$grab,$focus\"\n    upvar ::tk::FocusGrab($index) data\n    lappend data one\n}\nproc RestoreFocusGrab {grab focus} {\n    set index \"$grab,$focus\"\n    if {[info exists ::tk::FocusGrab($index)]} {\n        set data2 $::tk::FocusGrab($index)\n        unset ::tk::FocusGrab($index)\n    }\n}\n",
+        "oo::class create Utility {\n    method NameProcess {arguments object} { set name $object }\n}\noo::class create Widget {\n    mixin Utility\n    constructor {arguments} {\n        my NameProcess $arguments [self object]\n        puts \"name=$name\"\n    }\n}\n",
     );
-    // Line 8 col 26 — inside the `FocusGrab` of the
-    // `$::tk::FocusGrab($index)` read.
-    let refs = start_lines(&lsp.references(&uri, 8, 26, true));
     assert!(
-        refs.contains(&2) && refs.contains(&8),
-        "the read must link the upvar otherVar word across procs: {refs:?}"
+        hover_text(&lsp.hover(&uri, 6, 22)).is_empty(),
+        "an unbound `$`-led read must draw no hover"
     );
+    assert!(
+        locations(&lsp.definition(&uri, 6, 22)).is_empty(),
+        "…and no definition"
+    );
+}
+
+/// Issue #923 audit idx 98: `upvar ::tk::FocusGrab($index) data` names one
+/// fixed global cell (level-independent), so every occurrence of the cell —
+/// the `upvar` `otherVar` word, the sibling proc's `info exists` argument,
+/// its `$::tk::FocusGrab($index)` read, and its `unset` argument — is one
+/// variable.
+///
+/// Pinned through the **live server**, i.e. the incremental per-item
+/// analysis a real editor drives, and on all three navigation verbs.  The
+/// compiler library answered all four anchors from the whole-file walk
+/// while the server answered nothing for hover and go-to-definition,
+/// because the cell is defined *inside a deferred body* and the per-item
+/// graft merged a fragment's proc scope only — so the cell never reached
+/// the scope tree the providers read.  A `references`-only assertion could
+/// not see that, which is exactly why this asserts all three.
+const FOCUS_GRAB_SRC: &str = "proc SetFocusGrab {grab focus} {\n    set index \"$grab,$focus\"\n    upvar ::tk::FocusGrab($index) data\n    lappend data one\n}\nproc RestoreFocusGrab {grab focus} {\n    set index \"$grab,$focus\"\n    if {[info exists ::tk::FocusGrab($index)]} {\n        set data2 $::tk::FocusGrab($index)\n        unset ::tk::FocusGrab($index)\n    }\n}\n";
+
+/// Line/character of each anchor: the `upvar` `otherVar` word (line 2) and
+/// the `$::tk::FocusGrab($index)` read (line 8), both inside `FocusGrab`.
+const FOCUS_GRAB_ANCHORS: [(u32, u32); 2] = [(2, 20), (8, 26)];
+
+#[test]
+fn a_fully_qualified_upvar_target_hovers_from_word_and_read() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, FOCUS_GRAB_SRC);
+    for (line, character) in FOCUS_GRAB_ANCHORS {
+        let text = hover_text(&lsp.hover(&uri, line, character));
+        assert!(
+            text.contains("::tk::FocusGrab"),
+            "hover at {line}:{character} must name the cell: {text:?}"
+        );
+    }
+}
+
+#[test]
+fn a_fully_qualified_upvar_target_defines_from_word_and_read() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, FOCUS_GRAB_SRC);
+    for (line, character) in FOCUS_GRAB_ANCHORS {
+        let locs = locations(&lsp.definition(&uri, line, character));
+        assert_eq!(
+            locs.len(),
+            1,
+            "one definition at {line}:{character}: {locs:?}"
+        );
+        assert_eq!(
+            locs[0].range["start"]["line"].as_i64(),
+            Some(2),
+            "the `upvar` otherVar word is where the cell comes to exist: {locs:?}"
+        );
+    }
+}
+
+#[test]
+fn a_fully_qualified_upvar_target_cross_references_between_procs() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, FOCUS_GRAB_SRC);
+    for (line, character) in FOCUS_GRAB_ANCHORS {
+        let refs = start_lines(&lsp.references(&uri, line, character, true));
+        assert_eq!(
+            refs.iter().copied().collect::<Vec<i64>>(),
+            vec![2, 7, 8, 9],
+            "otherVar word + info exists + read + unset, from {line}:{character}: {refs:?}"
+        );
+    }
 }
 
 /// TN — an unbound `$`-led read abstains rather than resolving to a


### PR DESCRIPTION
Part of #1019 (upvar/uplevel cluster: idx 7, 22, 38, 57, 58, 59, 98, 99, 100). Does not close it — other clusters are still in flight.

## idx 98 — the fix existed in the library and never reached users

**Root cause.** `handle_upvar_command` defines the fixed cell (`upvar ::tk::FocusGrab($index) data`) in the **global** scope with `scope_path = &[]`. On the incremental path that write lands in the isolated body fragment's throwaway root, and `graft_proc_body` merges a fragment's *proc* scope only — so the cell never entered the document's scope tree, which is what `attach_qualified_var_references` and every navigation provider read. `all_variables` had it; the tree did not. That is why the unit tests passed while the live server returned nothing.

**Fix** reuses the existing per-item machinery rather than a parallel one: `capture_global_defs` is the write-side twin of the existing `capture_global_reads`, carried on `BodyFragment::global_defs`, rebased by `rebase_fragment_pending`, and replayed through the real `define_var` under `structural_rebind` so the fragment's already-merged `QualifiedVarRef` and W215 are not double-counted.

```
BEFORE:  hover -> "(no hover)"          AFTER:  hover -> **Variable** `::tk::FocusGrab`
         definition -> 0 locations              definition -> 1 location (3:10-3:33)
         references(3,20) -> 0 locations        references(3,20) -> 5 locations
```

**A pre-existing test was asserting the wrong thing.** The old unit test asserted `refs.len() == 4` and its prose claimed those four were the `otherVar` word, `info exists`, the read and `unset`. They are not — the real four (library and server agree exactly) are the cell's two spellings plus the two occurrences of the `data` alias. The count passed while the explanation was wrong, so a change in the set's composition would not have been noticed. Replaced with positional assertions at all three tiers, and the bareword `info exists`/`unset` anchor is now recorded as an explicit documented residual rather than an unexamined claim.

## idx 59 — cross-file, without weakening W210

The single-file qualified spelling was already fixed. For the cross-file half: a call whose head resolves to neither a dialect-enabled registry command nor any definition this document makes is *opaque*, and the literal name-shaped words it spells stop being provably unset in that frame. This is folded into `extra_known_defined`, which only the two W210 emitters consult — `defs`, liveness and SCCP are untouched, so the #1237/#1260 guard rail holds by construction rather than by care.

```
BEFORE: tcl diag options.tcl utils.tcl -> W210 Variable 'options' is read before it is set
AFTER:  only 2x W123 'setdef' + the two genuine W210s inside utils.tcl
```

Oracle: both interpreters print `{nothing str no} {nothing str no} {nothing str no}`. Controls still firing: a name the opaque call never spells, a substituted `$key` argument, a registry command, and a same-file helper with no `upvar`.

## idx 22 — fixed rather than abstained, because its blockers landed

The code documented this as deferred pending #1177/#1164. Both have since merged, so the blocking mechanism now exists: `oo_dispatch::method_dispatch_provider` already walks the MRO **including mixins** and is the single walk hover, definition and references share. `caller_frame::bindings_from_self_dispatch` keys the frame-effect question on it and recomputes the callee's facts from the resolved body using the same `param_traits` scans the analyser runs for a proc — no `MethodDef` churn, and it runs only on a query that already failed the scope lookup.

```
hover      -> **Caller-frame variable** `name`, created in this frame by `::Utility::NameProcess`
definition -> 1 location   references -> 2 locations
(before: "(no hover)", 0 locations, 0 locations)
```

**`next`/`nextto` stay abstaining, and that is now oracle-justified rather than merely safe.** Both interpreters raise `can't read "name"`: `next`'s frame does not nest inside the method that issued it, so a superclass `upvar 1` reaches *past* the issuing method. Claiming a binding there would have been wrong, not just eager. Pinned with the transcript.

## idx 99 — the silent-arity trade-off should stand

Both interpreters do raise `too many arguments` for `::safe::loadTk interp1 extraPositionalArg`. But `::tcl::OptProc` installs `::proc $name args {…}`, so nothing in the declaration bounds the call; reproducing that bound means modelling `::tcl::OptKeyParse`'s runtime optlist dispatch. The alternative on offer was the false E003 on *legitimate* calls that the audit originally found. The abstention is now definer-scoped and tested in both directions, with an ordinary-proc control proving arity checking has not retreated globally.

## Coverage

idx 7, 22, 57, 58, 59, 98 and 99 all gained coverage at the tiers they were missing; idx 100 was already TP+FP-guarded at all three and was re-verified rather than duplicated.

**Tier judged inapplicable:** no VS Code test for idx 99 — the trade-off is a diagnostic-emission fact with no editor-specific surface, and the e2e tier already drives the real server, so a VS Code copy would exercise VS Code's diagnostic plumbing, which several other suites already cover.

**Not touched:** the W212 false positive recorded under idx 38 is owned by a sibling change and was deliberately left alone here.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo check --workspace --all-targets` all clean; `cargo test -p tcl-compiler` 0 failures (~8000 tests); `cargo test -p tcl-lsp-core` 1761 passed; full lsp e2e 1307 passed, 0 failed; VS Code compiled and run under xvfb, 4 passing.

Re-verified after rebasing onto current `rust`, not only on the original base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_