### PR TITLE
Resolve command-head identity through the registry across all nine consumers; spec-studio field coverage gate (#1185, #1275)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4454,6 +4454,7 @@ version = "0.1.0"
 dependencies = [
  "serde_json",
  "tcl-compiler",
+ "tcl-core-types",
  "tcl-dialect",
  "tcl-lexer",
  "tcl-registry",

--- a/README.md
+++ b/README.md
@@ -412,6 +412,29 @@ set d [Pup new]
 $d fly                         ;# W308: unknown method 'fly' on ::Dog
 ```
 
+The **grammar** of a command follows its binding too. A statically
+visible `namespace import`, `interp alias`, `rename`, or a top-level
+`proc` that shadows a built-in re-points every registry-driven feature —
+highlighting, format-specifier hints, folding, formatting, minifying,
+go-to-declaration, the call graph, parameter-usage inference, and the
+iRules object-reference scan — at the command a head really names.
+Formatting is the visible one: a body-bearing command reached through a
+proven alias is expanded onto its own lines, and one whose name has been
+renamed away or taken over by a user `proc` is left exactly as written.
+Chains compose (`interp alias {} a {} format; rename a b` leaves `b`
+naming `format`), and the explicitly global spelling behaves identically
+to the bare one. Anything unprovable — a computed binding, an alias with
+pre-bound arguments, another interpreter's command table, a binding
+nested inside a body — abstains rather than guessing. See
+[the KCS note](docs/kcs/kcs-qa-does-the-server-follow-rename-and-interp-alias.md).
+
+```tcl
+rename if maybe
+maybe {$x} {puts a}            ;# left as written — `maybe` is not `if`'s grammar
+interp alias {} guard {} if
+guard {$x} {puts a}            ;# expanded like `if`, because it is `if`
+```
+
 W113 ("proc shadows a built-in") only fires for a genuine core
 built-in. A proc named after a command that is gated behind `package
 require` — a tcllib package, `argparse`, an `itcl`/TclOO helper, … — is

--- a/docs/design/compiler/command-registry.md
+++ b/docs/design/compiler/command-registry.md
@@ -1143,11 +1143,11 @@ dispatch, var-escape, and taint sinks reached through this pipeline are
 they resolve through the same registry lookup, but only after the
 canonical name has already been substituted in.
 
-### Semantic tokens resolve identity themselves (issue #1185)
+### The source-text consumers resolve identity themselves (issues #1185, #1275)
 
-The semantic-token walker is no longer part of this limitation. It resolves
-each head's **effective command identity** once, before any registry query,
-through `rust/tcl-lsp-core/src/head_identity.rs`:
+The source-text consumers are no longer part of this limitation. Each resolves
+its head's **effective command identity** once, before any registry query,
+through `rust/tcl-compiler/src/head_identity.rs`:
 
 ```rust
 enum HeadIdentity<'a> {
@@ -1169,6 +1169,14 @@ sources feed it:
 | `interp alias {} myfmt {} format` | `myfmt` and `::myfmt` -> `format` |
 | `rename format origfmt` | `origfmt` -> `format`, **and** `format` -> `Rebound` |
 | `proc format {args} {...}` | `format` -> `Rebound` |
+
+A binding **source** is read through the map before the registry, so chains
+compose: `interp alias {} a {} format; rename a b` leaves `b` naming `format`
+(tclsh 8.6.16 and 9.0.4, byte-identical: `b %08x 42` answers `0000002a` while
+`info commands a` answers empty), and `proc format {…} {…}; rename format
+myfmt` correctly leaves `myfmt` `Rebound` rather than inheriting the built-in's
+grammar. An alias always *takes over* the name it binds, because C Tcl lets one
+shadow an existing command outright.
 
 Both the bare and the explicitly `::`-qualified spelling of a bound name are
 recorded, and the *latest* fact at or before the call's byte offset wins, so a
@@ -1204,59 +1212,56 @@ each call site.
   nothing;
 - `unknown` fallback, traces, and computed heads -- nothing is inferred.
 
-The other source-text consumers below are still blind to rename/alias; the
-`HeadIdentityMap` is the shared pre-pass the "plausible future fix direction"
-note called for, and extending it to them is a matter of threading it through,
-not of inventing a mechanism.
+#### Positioned and unpositioned readers
 
-### The limitation is real for the other source-text, re-segmentation-based consumers
+`resolve(head, at)` answers for a head at a known byte offset. Several
+consumers re-lex a body out of its own *decoded* text — the formatter
+reformats `arg.text`, the minifier re-minifies a body slice, the call-graph
+and param-trait scans segment a body string at offset 0 — so no
+document-absolute offset exists at the point of the query. Those read
+`resolve_unpositioned(head)`, which folds *every* fact about the spelling and
+abstains (`Rebound`) unless they agree. A document that binds one name twice
+cannot be read without a position, and guessing one of the two bindings is
+exactly the fall-back-to-spelling this module exists to remove.
 
-The remaining blind spot is the consumers that never go through
-`Lowering`'s alias table at all: the ones that recognise a shape (a
-lambda literal, a body, a callback prefix) by re-parsing a segmented
-command's own raw head text directly against the registry, outside the
-IR-lowering pass and with no alias map available to them. This is
-precisely the set of consumers the #954/#999 fix taught
-`ArgRole::LambdaLiteral` awareness — semantic tokens, folding, formatting,
-minification, declaration scanning, the best-effort text-based
-interprocedural call-graph scanner (`tcl-compiler/src/interprocedural.rs`
-— distinct from the IR-based taint/SSA interprocedural analysis, which
-*is* on the alias-aware pipeline above), param-trait inference, and the
-iRules object-reference walker. The concrete, verified case is `apply`'s
-`ArgRole::LambdaLiteral` handling under `rename`/`interp alias`: see the
-"Failure modes" section of
-[the `apply`-lambda-body KCS note](../../kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md)
-for the reproduction and file-path anchors. The same gap applies to any
-other registry-keyed field (arg roles, `defines_command_at`, …) queried the
-same direct way by one of these consumers — `apply` is simply the instance
-that has been reproduced and written up (issue #1002); it is not evidence
-that taint or purity share it, since those two are demonstrably covered by
-the mechanism described above.
+`HeadWords { written, resolved }` carries both forms where the distinction
+matters. A **global command** lookup reads `resolved`; a **lexical** test reads
+`written`, because a class-body member sub-keyword (`method`, `constructor`) or
+a `$var` head is not a command binding at all — a top-level `rename method …`
+says nothing about the word inside an `oo::define`.
+
+#### Which consumers resolve, and how
+
+| Consumer | Reads | Notes |
+|---|---|---|
+| semantic tokens | positioned | issue #1185 |
+| inlay hints (format specifiers) | positioned | issue #1185 |
+| folding | positioned | body / lambda / clause-list roles |
+| the declaration scan | positioned | scope-alias grammar + body recursion |
+| the iRules object-ref walker | positioned | reference args, roles, `set` constant propagation |
+| the minifier's rename-barrier scan | positioned | the invocation carries its own range |
+| the minifier's keyword abbreviation | positioned | `base` makes a nested word's offset absolute |
+| the minifier's render path | unpositioned | re-minifies each body from its own slice |
+| formatting | unpositioned | re-lexes decoded `arg.text`; range formatting lexes a slice |
+| the call-graph scan (`interprocedural.rs`) | unpositioned | walks lowered statements and body text at offset 0 |
+| param-trait inference | unpositioned | scans a proc body from its own text |
+
+Range formatting builds the map from the **whole document**, not the selected
+slice, so a `rename` above the selection still governs it. The analyser builds
+it alongside its registry at the top of every entry point, so a per-proc
+param-trait scan reads the *document's* bindings while scanning a *body*.
 
 This is a different mechanism from issue #973, which is about the
 analyser's `known()` predicate (`scope.rs`) not gating an existence check
 (W123) on deletion — a single analyser-side predicate partially growing
-rename/alias-awareness for one diagnostic. The gap described here is a
-missing integration (the source-text consumers have no access to an alias
-table at all, static or otherwise), not a partial one.
+rename/alias-awareness for one diagnostic.
 
-**Fix direction** (done for semantic tokens in issue #1185, still open for
-the rest): give the source-text-based consumers the same kind of alias
-resolution the compiler's lowering pass already has, rather than inventing a
-new mechanism. `head_identity.rs` is that shared document-wide pre-pass, and
-the remaining consumers need it threaded through rather than reinvented. The
-`CommandAliasMap` pattern in
-`rust/tcl-compiler/src/alias.rs` is IR-lowering-specific (it's built while
-walking a `CompilationUnit`, and reads `self.aliases` accumulated so far in
-that walk); the source-text consumers operate on individually re-parsed
-segmented commands, often outside any compilation-unit walk, so reusing it
-directly is not a drop-in change — each consumer would need either its own
-document-wide alias scan pre-pass, or a shared one computed once and passed
-down to every consumer that currently calls `CommandRegistry::get` /
-`arg_indices_for_role` directly on raw head text. That is still a real,
-multi-consumer change (it touches every one of the source-text consumers
-listed above, not just `apply`'s), just a narrower one than rewriting
-`CommandRegistry::get` itself.
+**Still by spelling.** `CommandRegistry::get` itself is unchanged: it is a
+by-name lookup, and every consumer above resolves *before* calling it. A
+consumer added later that queries the registry on raw head text re-opens the
+gap for itself; the `apply`-lambda reproduction in the
+[`apply`-lambda-body KCS note](../../kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md)
+is what that looks like from the outside.
 
 ## Decision rule
 

--- a/docs/design/compiler/command-registry.md
+++ b/docs/design/compiler/command-registry.md
@@ -412,6 +412,61 @@ report a bogus Tcl 8.6 requirement. `record_dsl_format_sites` (W138) therefore
 gates on `FormatType::Sprintf` and leaves the other families alone rather than
 guessing.
 
+### HandleBindingSpec -- which argument becomes an object handle
+
+Some calls make a *variable* hold an object handle, with a second word of
+the same call saying what class the handle is. Two shapes recur:
+
+```tcl
+install axis using ::verticalAxis $win.a   ;# snit component install
+set     axis      [::verticalAxis $win.a]  ;# snit bare-word construction
+```
+
+Both used to be recognised by matching the command word in the LSP's
+handle scan. They are now registry data
+(`rust/tcl-registry/src/handle_binding.rs`):
+
+```rust
+pub struct HandleBindingSpec {
+    pub name_at: u8,                     // the variable that receives the handle
+    pub class_from: HandleClassSource,   // where the class is written
+    pub keyword: Option<HandleKeyword>,  // a literal word the layout requires
+}
+
+pub enum HandleClassSource {
+    Word(u8),               // the word *is* the class name (`install … using TYPE`)
+    ConstructionValue(u8),  // the word *contains* a construction (`set n [TYPE …]`)
+}
+```
+
+`HandleBindingSpec::resolve(args)` returns a `BoundHandle { name,
+class_word, class_source }` or `None`. It abstains rather than guesses: a
+missing keyword (`install a b c`, a user's own `install`), a call too short
+to carry both words, or a dynamic word all answer `None`.
+
+Where the descriptor hangs depends on whether the command is global:
+
+| Command | Home | Why |
+|---|---|---|
+| `set` | `CommandSpec::binds_handle` | a real global command; `CommandRegistry::handle_binding` resolves it through `get`, so `::set` answers identically |
+| snit `install` | `DefinitionBodyGrammar::member_body_commands` | the word exists **only** inside a snit member body -- a global spec would make a user's own `proc install` look like a built-in everywhere. `CommandRegistry::member_body_handle_bindings()` enumerates them once per document |
+
+The paired grammar flag `DefinitionBodyGrammar::bare_word_construction`
+says whether a family's *type command* constructs from a bare instance
+name (`$type $name`, snit(n)'s "The Type Command"). It is `true` for snit
+and `false` for `TclOO` / `[incr Tcl]`, and it replaced a
+`metaclass.starts_with("snit::")` spelling test in the scan.
+
+**Limits.** The descriptor covers a *fixed* pair of indices plus one
+optional literal keyword -- enough for both shapes above and for a
+comparable installer in another class system, and deliberately not a
+general option parser. snit's `installhull ?using TYPE …?` is **not**
+modelled: it binds the implicit `hull` component rather than a named
+variable, so it has no `name_at`, and adding it needs another variant
+rather than another row. `install NAME $widget` (a run-time-typed
+component) is likewise not modelled -- there is no static class word, so
+the scan abstains.
+
 ### ArgPresentation -- how a formatter lays an argument out
 
 `ArgRole` says what an argument **is**. `arg_presentation` (a
@@ -1077,9 +1132,75 @@ dispatch, var-escape, and taint sinks reached through this pipeline are
 they resolve through the same registry lookup, but only after the
 canonical name has already been substituted in.
 
-### The limitation is real for the source-text, re-segmentation-based consumers
+### Semantic tokens resolve identity themselves (issue #1185)
 
-The blind spot is the consumers that never go through
+The semantic-token walker is no longer part of this limitation. It resolves
+each head's **effective command identity** once, before any registry query,
+through `rust/tcl-lsp-core/src/head_identity.rs`:
+
+```rust
+enum HeadIdentity<'a> {
+    Command(&'a str),  // the registry name this spelling really invokes
+    Rebound,           // the binding was provably taken over -- no grammar applies
+}
+```
+
+`command_head_identities` scans the document's **top-level** statements once
+and records an offset-keyed fact per head spelling. Which commands mutate the
+command table is registry data (`CommandTableEffect`), and the argument shapes
+come from the compiler's own `alias.rs` detectors -- the same ones the
+IR-lowering pipeline uses -- so nothing here spells a command name. Four
+sources feed it:
+
+| Statement | Fact |
+|---|---|
+| `namespace import ::tcltest::*` | `test` -> `::tcltest::test` (issue #776) |
+| `interp alias {} myfmt {} format` | `myfmt` and `::myfmt` -> `format` |
+| `rename format origfmt` | `origfmt` -> `format`, **and** `format` -> `Rebound` |
+| `proc format {args} {...}` | `format` -> `Rebound` |
+
+Both the bare and the explicitly `::`-qualified spelling of a bound name are
+recorded, and the *latest* fact at or before the call's byte offset wins, so a
+binding never retroactively re-tags an earlier call:
+
+```tcl
+format {%08x} 42       ;# still the built-in -- specifier sub-tokens
+rename format origfmt
+origfmt {%08x} 42      ;# now the built-in
+format  {%08x} 42      ;# Rebound -- a plain string argument
+```
+
+`HeadIdentity::spec_name()` answers `""` for `Rebound`, which
+`CommandRegistry::get` never resolves -- so every registry query the walker
+already makes (`arg_indices_for_role`, `format_string_args`,
+`handle_binding`, ...) answers "unknown command" without a variant check at
+each call site.
+
+**Explicit limits.** The table is sound by abstention, and states nothing for:
+
+- a **dynamic** binding -- `rename $old new`, `interp alias {} $n {} eval`,
+  `interp alias {} n {} $t` (rejected by `is_dynamic_word`);
+- an alias with **pre-bound arguments** -- `interp alias {} pad {} format %08x`
+  shifts every index, so the target's layout cannot be reused; the name is
+  marked `Rebound` rather than aliased;
+- **another interpreter** -- a non-empty `srcPath` binds a name in a *child*
+  interpreter and states nothing here; a non-empty `targetPath` marks the name
+  `Rebound`. Hidden commands in a safe interpreter are invisible for the same
+  reason: this is a description of *this* document's command table;
+- a **conditional or nested** binding -- only top-level statements are scanned,
+  so a `rename` inside an `if` / proc / `eval`, and a `proc` inside
+  `namespace eval ::n` (which defines `::n::format`, not `::format`), state
+  nothing;
+- `unknown` fallback, traces, and computed heads -- nothing is inferred.
+
+The other source-text consumers below are still blind to rename/alias; the
+`HeadIdentityMap` is the shared pre-pass the "plausible future fix direction"
+note called for, and extending it to them is a matter of threading it through,
+not of inventing a mechanism.
+
+### The limitation is real for the other source-text, re-segmentation-based consumers
+
+The remaining blind spot is the consumers that never go through
 `Lowering`'s alias table at all: the ones that recognise a shape (a
 lambda literal, a body, a callback prefix) by re-parsing a segmented
 command's own raw head text directly against the registry, outside the
@@ -1108,10 +1229,12 @@ rename/alias-awareness for one diagnostic. The gap described here is a
 missing integration (the source-text consumers have no access to an alias
 table at all, static or otherwise), not a partial one.
 
-**Plausible future fix direction** (out of scope here — this note only
-records the limitation): give the source-text-based consumers the same
-kind of alias resolution the compiler's lowering pass already has, rather
-than inventing a new mechanism. The `CommandAliasMap` pattern in
+**Fix direction** (done for semantic tokens in issue #1185, still open for
+the rest): give the source-text-based consumers the same kind of alias
+resolution the compiler's lowering pass already has, rather than inventing a
+new mechanism. `head_identity.rs` is that shared document-wide pre-pass, and
+the remaining consumers need it threaded through rather than reinvented. The
+`CommandAliasMap` pattern in
 `rust/tcl-compiler/src/alias.rs` is IR-lowering-specific (it's built while
 walking a `CompilationUnit`, and reads `self.aliases` accumulated so far in
 that walk); the source-text consumers operate on individually re-parsed

--- a/docs/design/compiler/command-registry.md
+++ b/docs/design/compiler/command-registry.md
@@ -428,9 +428,14 @@ handle scan. They are now registry data
 
 ```rust
 pub struct HandleBindingSpec {
-    pub name_at: u8,                     // the variable that receives the handle
+    pub name_from: HandleName,           // which variable receives the handle
     pub class_from: HandleClassSource,   // where the class is written
     pub keyword: Option<HandleKeyword>,  // a literal word the layout requires
+}
+
+pub enum HandleName {
+    Word(u8),                 // the word at this index names the variable
+    Implicit(&'static str),   // a fixed variable the class system provides
 }
 
 pub enum HandleClassSource {
@@ -450,6 +455,7 @@ Where the descriptor hangs depends on whether the command is global:
 |---|---|---|
 | `set` | `CommandSpec::binds_handle` | a real global command; `CommandRegistry::handle_binding` resolves it through `get`, so `::set` answers identically |
 | snit `install` | `DefinitionBodyGrammar::member_body_commands` | the word exists **only** inside a snit member body -- a global spec would make a user's own `proc install` look like a built-in everywhere. `CommandRegistry::member_body_handle_bindings()` enumerates them once per document |
+| snit `installhull` | `DefinitionBodyGrammar::member_body_commands` (widget grammars only) | same reason, and only a `snit::widget` / `snit::widgetadaptor` has a hull, so it is absent from the plain `snit::type` grammar |
 
 The paired grammar flag `DefinitionBodyGrammar::bare_word_construction`
 says whether a family's *type command* constructs from a bare instance
@@ -457,15 +463,20 @@ name (`$type $name`, snit(n)'s "The Type Command"). It is `true` for snit
 and `false` for `TclOO` / `[incr Tcl]`, and it replaced a
 `metaclass.starts_with("snit::")` spelling test in the scan.
 
-**Limits.** The descriptor covers a *fixed* pair of indices plus one
-optional literal keyword -- enough for both shapes above and for a
+snit's `installhull using TYPE ?args…?` is the shape that forced
+`HandleName` to be an enum rather than an index. It binds the widget's
+**implicit** `hull` component, whose name appears nowhere in the call, so
+`HandleName::Implicit("hull")` supplies it from the descriptor. snit(n)
+documents a second form, `installhull $win`, which names an
+already-created widget and carries no static type word; the required
+`using` keyword makes `resolve` abstain on it.
+
+**Limits.** The descriptor covers a *fixed* pair of positions plus one
+optional literal keyword -- enough for the three shapes above and for a
 comparable installer in another class system, and deliberately not a
-general option parser. snit's `installhull ?using TYPE …?` is **not**
-modelled: it binds the implicit `hull` component rather than a named
-variable, so it has no `name_at`, and adding it needs another variant
-rather than another row. `install NAME $widget` (a run-time-typed
-component) is likewise not modelled -- there is no static class word, so
-the scan abstains.
+general option parser. `install NAME $widget` (a run-time-typed
+component) is not modelled -- there is no static class word, so the scan
+abstains.
 
 ### ArgPresentation -- how a formatter lays an argument out
 

--- a/docs/design/contracts/command-spec-studio.md
+++ b/docs/design/contracts/command-spec-studio.md
@@ -47,6 +47,47 @@ both directions. A field added to the registry without a schema entry fails
 the test by name — otherwise the studio would silently drop it, and a draft
 seeded from a real command would render back having lost behaviour.
 
+### Invariant: every `CommandSpec`-family field is surfaced or excluded
+
+The text scan above only reaches the two `DEFAULT` initialisers, and only
+compares against the schema. `coverage.rs` is the load-bearing gate: it makes
+the property a **build failure** rather than a test, and it reaches the whole
+family — the nested types a draft carries structurally (`OptionSpec`,
+`OptionArg`, `ArgValue`, `FormSpec`, `HoverSnippet`, `SideEffect`,
+`SetterConstraint`, `Arity`, `ArgTypeHint`, `Lifecycle`, `SubSubCommand`), the
+plain-data descriptors (`RepeatedArgLayout`, `HandleBindingSpec`,
+`HandleKeyword`, `SymbolDef`, `BytePayloadSpec`, `VersionedArgValue`), and the
+shared `&'static` descriptors (`DefinitionBodyGrammar`, `MemberBodyCommand`,
+`ObjectClassSpec`, `CaseListSpec`).
+
+Each covered type gets a pair:
+
+- a `witness_*` function holding an **exhaustive destructuring pattern with no
+  `..` rest**, so a field added to the registry type fails to compile there,
+  naming it (`error[E0027]: pattern does not mention field <name>`), and a
+  field removed fails too;
+- a `&[Field]` table saying where the studio surfaces each of those fields:
+  `Surface::Key` (a draft/schema key), `Surface::Keys` (a `Lifecycle`'s three
+  releases), `Surface::Expression` (rendered into the Rust expression a named
+  field holds), or `Surface::Excluded` **with a reason**.
+
+This is the field-level twin of the catalogue witnesses below, which use
+exhaustive `match`es so a new enum *variant* breaks the build.
+
+The tests then prove the claim: a `Key` entry must be both a schema key and a
+key the seeder writes (which, because `render_rs` walks the schema and the WASM
+`schema()` serialises it, is what carries a field through all four layers); an
+`Expression` entry's field name must appear in the literal a rendered spec
+emits; and no schema key may be left without a coverage entry.
+
+**Excluded by decision, not by accident.** The only exclusions today are the
+fields of `DefinitionBodyGrammar`, `MemberBodyCommand`, `ObjectClassSpec`, and
+`CaseListSpec`: each is a shared registry constant that many commands
+reference, so the studio's editor takes the *constant's path*
+(`Some(&definer::SNIT_GRAMMAR)`) and authoring a new grammar is an edit to the
+registry module that owns it. Every field is still listed, so adding one to a
+grammar is a stated decision rather than an oversight.
+
 ### Invariant: the catalogues cover every variant
 
 `catalogue` holds the registry's enum and bitflag vocabularies. Each catalogue
@@ -69,9 +110,11 @@ what makes the studio a *browser* of the registry as well as an editor.
 ### Fields that cannot round-trip
 
 Some fields hold a function pointer (`arg_role_resolver`, `const_fold`,
-`taint_sink_gate`, …) or a reference to a `&'static` descriptor
-(`definition_body`, `case_list`, `object_class`, …). Rust can observe that
-such a field is `Some`, but not recover the expression that set it.
+`taint_sink_gate`, …) or a reference to a **named** `&'static` descriptor the
+registry shares between commands (`definition_body`, `case_list`,
+`object_class`, `body_scope`, `frame_effect`, `bpf_op`, `event_requires`,
+`command_forms`). Rust can observe that such a field is `Some`, but not
+recover the expression — the constant's path — that set it.
 
 Seeding records those keys under `draft::UNRENDERABLE_KEY` (`__unrenderable`).
 The form warns about them and the renderer emits a `TODO` comment naming each
@@ -81,6 +124,18 @@ rendered file says what is missing.
 Those fields use `FieldKind::RustExpr`: the value is a string emitted
 verbatim, so it carries its own `Some(…)` and type path. The schema's `hint`
 shows the exact expression shape expected.
+
+A descriptor that is **plain data** is a different case and does round-trip.
+`repeated_args`, `binds_handle`, `byte_array_payload`, `defines_symbol`,
+`oo_context_facts`, and a subcommand's `versioned_arg_values` are still edited
+as one `RustExpr` field, but seeding renders them back out as **full struct
+literals** — every field spelled, never a defaulting constructor like
+`RepeatedArgLayout::strided` that would hide the ones it defaults. Drafting a
+command that sets one and re-rendering it therefore loses nothing, and the
+`Surface::Expression` half of `coverage.rs` is what keeps each literal
+complete: a new field on `HandleBindingSpec` breaks the destructuring, and a
+field the renderer forgets fails the test that looks for it in the emitted
+spec.
 
 One unrecoverable expression is not a top-level field. `OptionArity::Hook`
 holds a function pointer inside an *option row*, so it gets a `hook fn` text

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -115,6 +115,9 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
   which `f5` verb to pick for filter / find / rename tasks.
 - [kcs-qa-tcl-lsp-annotations.md](kcs-qa-tcl-lsp-annotations.md) — which
   `# tcl-lsp:` and `# noqa` comments the analyser understands.
+- [kcs-qa-does-the-server-follow-rename-and-interp-alias.md](kcs-qa-does-the-server-follow-rename-and-interp-alias.md)
+  — which command-rebinding statements the server follows, and what it
+  refuses to guess.
 - [kcs-qa-what-does-fix-all-safe-issues-apply.md](kcs-qa-what-does-fix-all-safe-issues-apply.md)
   — the four fix-safety classes, and why "Fix All Safe Issues" applies
   only the provably equivalent ones.

--- a/docs/kcs/features/kcs-feature-command-option-highlighting.md
+++ b/docs/kcs/features/kcs-feature-command-option-highlighting.md
@@ -108,9 +108,9 @@ There are two layers, most-precise first:
    named-object dispatch onto a *user*-defined `TclOO` class (`Foo create
    obj; obj method`, where the *object command* itself is the head — the
    registry-modelled shape above, including Tk widgets, does resolve; a
-   user class does not), and `$hull` (a Tk widget reference snit's own
-   `installhull` populates internally, not a literal constructor call this
-   feature's provenance scan can see). The receiver's class is found from a handle typed by
+   user class does not), and `installhull $win` (the already-created form,
+   which names no widget type — the `installhull using TYPE …` form does
+   resolve, typing the implicit `hull` component). The receiver's class is found from a handle typed by
    the SSA lattice — including a handle **retrieved from an object collection**:
    a `Pins` dict filled with `[Pin new]` in one method makes
    `[dict get $Pins $pin] configure -node …` resolve to `Pin` in another (issue
@@ -183,12 +183,13 @@ still highlighted by the object-method / generic passes above.
 - A `-option` on an unmodelled object method is highlighted by shape only, so
   an invalid switch is not distinguished from a valid one.
 - snit/itcl **`$self` / `$this` self-calls**, **named-constructor** objects
-  (`set o [foo create x]`), **installed components** (`install ax using Ax`), and
-  **bare-constructor components** (`set c [Type inst]`) all resolve, but `$hull`
-  (a Tk widget snit's own `installhull` sets internally) and a **bareword
-  named-object** command onto a *user*-defined class (`Foo create obj; obj
-  method`) are not yet provenance-tracked — they use the generic fallback
-  (`experiments/tcloo_diag/RESULTS.md`).
+  (`set o [foo create x]`), **installed components** (`install ax using Ax`),
+  the **implicit hull** (`installhull using TYPE …`), and
+  **bare-constructor components** (`set c [Type inst]`) all resolve, but
+  `installhull $win` (the already-created form, which names no widget type)
+  and a **bareword named-object** command onto a *user*-defined class
+  (`Foo create obj; obj method`) are not yet provenance-tracked — they use the
+  generic fallback (`experiments/tcloo_diag/RESULTS.md`).
 - A receiver whose class is only bound in *another file* (a cross-file instance
   variable, global, or parameter) is not tracked: object provenance is computed
   per file, so only the workspace class *hierarchy* crosses files today, not the

--- a/docs/kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md
+++ b/docs/kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md
@@ -380,21 +380,22 @@ differential audit's finding **idx 0** (georgtree/argparse), which found the
   never matched `apply`'s spec, and the direct call's `parameter` /
   `function` / `variable` split collapsed into one opaque `string` token.
 
-  **Fixed for the semantic-token consumer** by issue #1185: it now resolves a
-  head's effective command identity through
-  `rust/tcl-lsp-core/src/head_identity.rs` before any registry query, so a
-  statically visible `rename` / `interp alias` / `namespace import` — and a
-  built-in-shadowing top-level `proc`, in the other direction — is followed
-  (regression test: `apply_lambda_literals_survive_a_rename_or_alias` in
-  `semantic_tokens.rs`). Folding, formatting, minification, declaration
-  scanning, the text-based call-graph scanner, param-trait inference, and the
-  iRules object-reference walker still resolve raw head text and remain
-  exposed; the `HeadIdentityMap` is the shared pre-pass they need threading
-  through. This is a different mechanism from issue #973 (the analyser's
-  `known()` predicate in `scope.rs` not gating W123's existence check on
-  deletion). See the "Known limitations" note in
+  **Fixed** for the semantic-token and inlay-hint consumers by issue #1185,
+  and for the remaining seven by issue #1275. Each resolves a head's effective
+  command identity through `rust/tcl-compiler/src/head_identity.rs` before any
+  registry query, so a statically visible `rename` / `interp alias` /
+  `namespace import` — and a built-in-shadowing top-level `proc`, in the other
+  direction — is followed (regression test:
+  `apply_lambda_literals_survive_a_rename_or_alias` in `semantic_tokens.rs`,
+  with per-consumer tiers in `folding.rs`, `formatting/engine.rs`,
+  `minify.rs`, `declaration.rs`, `tcl-irules/src/walker.rs`,
+  `interprocedural.rs`, and `analyser/param_traits.rs`). This is a different
+  mechanism from issue #973 (the analyser's `known()` predicate in `scope.rs`
+  not gating W123's existence check on deletion). See the "Known limitations"
+  note in
   [the command registry design doc](../design/compiler/command-registry.md#known-limitations)
-  for the project-wide scope of the remaining exposure (issue #1002).
+  for which consumers read a positioned offset and which must abstain without
+  one.
 
 ## Triage checklist
 

--- a/docs/kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md
+++ b/docs/kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md
@@ -370,24 +370,31 @@ differential audit's finding **idx 0** (georgtree/argparse), which found the
   overclaims the fix — it deliberately does not, to keep the
   correctness-sensitive analyser conservative (see decision rule 4).
 - Renaming (`rename apply myapply`) or aliasing (`interp alias {} myapply {}
-  apply`) `apply` before calling it — `myapply {x {puts $x}} 5` — defeats
-  every `LambdaLiteral`-aware consumer above, even though real Tcl treats the
-  rename/alias as fully transparent and runs the lambda exactly as it would
-  under the literal name. Confirmed at HEAD: the direct call's semantic
-  tokens split `{x {puts $x}}` into a `parameter`, a `function`, and a
-  `variable` token; both the renamed and aliased forms instead emit one
-  opaque `string` token for the whole list, identical to what an
-  unregistered command's argument would get. All eight consumers resolve a
-  segmented command's head by exact literal string against
-  `CommandRegistry::get` (a plain by-name lookup — see
+  apply`) `apply` before calling it — `myapply {x {puts $x}} 5` — used to
+  defeat every `LambdaLiteral`-aware consumer above, even though real Tcl
+  treats the rename/alias as fully transparent and runs the lambda exactly as
+  it would under the literal name (tclsh 9.0.4 / 8.6.16: it prints `5`). All
+  eight consumers resolved a segmented command's head by exact literal string
+  against `CommandRegistry::get` (a plain by-name lookup — see
   `rust/tcl-registry/src/registry.rs`), so a renamed or aliased head simply
-  never matches `apply`'s spec. This is a different mechanism from issue
-  #973 (the analyser's `known()` predicate in `scope.rs` not gating W123's
-  existence check on deletion) — #973 is one analyser-side predicate
-  partially growing rename/alias-awareness; this registry-head lookup has
-  none at all, in any of the eight consumers. See the "Known limitations"
-  note in [the command registry design doc](../design/compiler/command-registry.md#known-limitations)
-  for the project-wide scope of this exposure (issue #1002).
+  never matched `apply`'s spec, and the direct call's `parameter` /
+  `function` / `variable` split collapsed into one opaque `string` token.
+
+  **Fixed for the semantic-token consumer** by issue #1185: it now resolves a
+  head's effective command identity through
+  `rust/tcl-lsp-core/src/head_identity.rs` before any registry query, so a
+  statically visible `rename` / `interp alias` / `namespace import` — and a
+  built-in-shadowing top-level `proc`, in the other direction — is followed
+  (regression test: `apply_lambda_literals_survive_a_rename_or_alias` in
+  `semantic_tokens.rs`). Folding, formatting, minification, declaration
+  scanning, the text-based call-graph scanner, param-trait inference, and the
+  iRules object-reference walker still resolve raw head text and remain
+  exposed; the `HeadIdentityMap` is the shared pre-pass they need threading
+  through. This is a different mechanism from issue #973 (the analyser's
+  `known()` predicate in `scope.rs` not gating W123's existence check on
+  deletion). See the "Known limitations" note in
+  [the command registry design doc](../design/compiler/command-registry.md#known-limitations)
+  for the project-wide scope of the remaining exposure (issue #1002).
 
 ## Triage checklist
 

--- a/docs/kcs/kcs-qa-does-the-server-follow-rename-and-interp-alias.md
+++ b/docs/kcs/kcs-qa-does-the-server-follow-rename-and-interp-alias.md
@@ -1,0 +1,93 @@
+# KCS: Does the language server follow `rename` and `interp alias`?
+
+> **Audience:** User
+> **Type:** Q&A
+
+## Applies to
+
+all-editors, tcl-lsp-cli
+
+## Answer
+
+Yes, for the bindings a file states unconditionally at its top level.
+
+Tcl resolves a command by its interpreter-level *binding*, not by the spelling
+used to invoke it. After
+
+```tcl
+interp alias {} myfmt {} format
+```
+
+`myfmt` **is** `format`, and after
+
+```tcl
+rename format origfmt
+```
+
+`origfmt` is `format` while `format` no longer exists at all. The server reads
+those statements and applies the real command's grammar to the name that now
+carries it, and withholds it from the name that no longer does.
+
+Four kinds of statement are followed:
+
+| Statement | Effect |
+|---|---|
+| `namespace import ::tcltest::*` | `test` is `::tcltest::test` |
+| `interp alias {} myfmt {} format` | `myfmt` is `format` |
+| `rename format origfmt` | `origfmt` is `format`; `format` is gone |
+| `proc format {args} {…}` | `format` is your procedure, not the built-in |
+
+Chains compose: after `interp alias {} a {} format` and then `rename a b`, `b`
+is `format`.
+
+The explicitly global spelling behaves identically to the bare one, so
+`::myfmt` and `myfmt` are the same command.
+
+### What changes as a result
+
+Everything that reads a command's grammar follows the binding: syntax
+highlighting, format-specifier hints, code folding, **formatting**, minifying,
+go-to-declaration, the call graph, parameter-usage inference, and — for
+iRules — which arguments name BIG-IP objects.
+
+Formatting is the most visible. Before this landed, a document that renamed a
+body-bearing command still had its calls laid out under the grammar of the
+command they no longer were:
+
+```tcl
+rename if maybe
+maybe {$x} {puts a}
+```
+
+The `maybe` call is now left exactly as written, because `maybe`'s argument is
+no longer the server's business — and a call to `if` through a proven alias is
+expanded onto its own lines exactly as `if` would be.
+
+### What the server will not guess
+
+It abstains — leaves the name alone, or applies no grammar at all — rather
+than guessing, whenever it cannot prove the binding:
+
+- a **computed** binding (`rename $old new`, `interp alias {} $n {} eval`);
+- an alias with **pre-bound arguments** (`interp alias {} pad {} format %08x`),
+  which shifts every argument position;
+- a binding in **another interpreter** (`interp alias slave …`), or a command
+  hidden in a safe one;
+- a binding that is **conditional or nested** — inside an `if`, a procedure, an
+  `eval`, or a `namespace eval` block — because it is not an unconditional
+  fact about the whole file;
+- anything reached through `unknown`, a trace, or a computed command name.
+
+It also abstains when a file binds the same name twice and the reader has no
+byte position to choose between them, which is the case for the formatter and
+the minifier's body rewriting.
+
+Bindings are also read **in source order**, so a call written before a `rename`
+still sees the original command.
+
+## Related
+
+- [Command registry design doc](../design/compiler/command-registry.md#known-limitations)
+  — the descriptor, the positioned/unpositioned split, and the per-consumer table.
+- [kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md](kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md)
+  — the reproduction this grew out of.

--- a/editors/vscode/src/test/semanticTokens.test.ts
+++ b/editors/vscode/src/test/semanticTokens.test.ts
@@ -834,4 +834,116 @@ suite("Semantic Tokens", () => {
       await setTestContent(editor, originalContent);
     }
   });
+  // Issue #1185: a command head's grammar follows its *effective command
+  // identity*, not its spelling — asserted end-to-end through the editor
+  // client on the decoded token stream, not just the server's encoder.
+  //
+  // The fixture is real, working Tcl: it runs clean on tclsh 9.0.4 and 8.6.16
+  // alike, printing `1`, `0000002a`, `0000002a`, `USER`.
+  test("command-head grammar follows effective identity (issue #1185)", async () => {
+    const uri = getDocUri("commandIdentityTokens.tcl");
+    const doc = await activate(uri);
+
+    const legend = (await vscode.commands.executeCommand(
+      "vscode.provideDocumentSemanticTokensLegend",
+      uri,
+    )) as vscode.SemanticTokensLegend;
+    assert.ok(legend, "expected a legend");
+
+    // The `rename`/alias-aware classification comes from the enriched tier,
+    // which races a coarse fast path on the first request (issue #829) —
+    // poll, as the regex-source test above does for the same reason.
+    let decoded: DecodedToken[] = [];
+    await pollUntil(
+      async () =>
+        (await vscode.commands.executeCommand(
+          "vscode.provideDocumentSemanticTokens",
+          uri,
+        )) as vscode.SemanticTokens,
+      (tokens) => {
+        decoded = decodeTokens(tokens, legend);
+        return decoded.some((t) => t.type === "formatSpec");
+      },
+      { timeout: 20_000, interval: 250, label: "enriched command-identity tokens" },
+    );
+
+    const textOf = (t: DecodedToken): string =>
+      doc.lineAt(t.line).text.substring(t.char, t.char + t.length);
+    /** 0-based line index of the first line whose text contains `needle`. */
+    const lineOf = (needle: string): number => {
+      for (let i = 0; i < doc.lineCount; i++) {
+        if (doc.lineAt(i).text.includes(needle)) return i;
+      }
+      assert.fail(`fixture has no line containing ${JSON.stringify(needle)}`);
+    };
+    const typesOnLine = (line: number): Set<string> =>
+      new Set(decoded.filter((t) => t.line === line).map((t) => t.type));
+    const wordsOnLine = (line: number, type: string): Set<string> =>
+      new Set(decoded.filter((t) => t.line === line && t.type === type).map(textOf));
+
+    // TP 1 — `::foreach {aa bb} …`: the explicitly global spelling classifies
+    // like the bare one, so its variable list declares both loop variables and
+    // the tail of the head is still a keyword.
+    const foreachLine = lineOf("::foreach {aa bb}");
+    const foreachVars = wordsOnLine(foreachLine, "variable");
+    for (const name of ["aa", "bb"]) {
+      assert.ok(
+        foreachVars.has(name),
+        `expected '${name}' as a variable token on '::foreach', got ${JSON.stringify([
+          ...foreachVars,
+        ])}`,
+      );
+    }
+    assert.ok(
+      wordsOnLine(foreachLine, "keyword").has("foreach"),
+      `expected '::foreach' to keep its keyword classification, got ${JSON.stringify([
+        ...typesOnLine(foreachLine),
+      ])}`,
+    );
+
+    // TP 2 — `::format {%08x} 42` and TP 3 — the aliased `myformat {%08x} 42`
+    // both surface printf conversion sub-tokens.
+    for (const needle of ["[::format {%08x}", "[myformat {%08x}"]) {
+      const line = lineOf(needle);
+      const types = typesOnLine(line);
+      assert.ok(
+        types.has("formatSpec") && types.has("formatPercent"),
+        `expected format conversion tokens on '${needle}', got ${JSON.stringify([...types])}`,
+      );
+    }
+
+    // TP 4 — `rename upvar myupvar` moves upvar's grammar onto the new name:
+    // the head keeps upvar's keyword classification and the call declares its
+    // local (`outer` names the *caller's* variable, so — exactly as for a
+    // literal `upvar` — it is not a declaration here).
+    const upvarLine = lineOf("myupvar 1 outer local");
+    assert.ok(
+      wordsOnLine(upvarLine, "keyword").has("myupvar"),
+      `expected the renamed 'myupvar' to inherit upvar's keyword classification, got ${JSON.stringify(
+        [...typesOnLine(upvarLine)],
+      )}`,
+    );
+    assert.ok(
+      wordsOnLine(upvarLine, "variable").has("local"),
+      `expected 'local' declared by the renamed upvar call, got ${JSON.stringify([
+        ...wordsOnLine(upvarLine, "variable"),
+      ])}`,
+    );
+
+    // FP guard — a top-level `proc scan` takes the built-in's name over, so
+    // `scan {%d} 7` gets no scan-format grammar and its argument stays a
+    // plain string.
+    const shadowedLine = lineOf("[scan {%d} 7]");
+    const shadowedTypes = typesOnLine(shadowedLine);
+    assert.ok(
+      !shadowedTypes.has("formatSpec") && !shadowedTypes.has("formatPercent"),
+      `a shadowed 'scan' must get no conversion tokens, got ${JSON.stringify([...shadowedTypes])}`,
+    );
+    assert.ok(
+      shadowedTypes.has("string"),
+      `expected the shadowed call's '{%d}' to stay a string, got ${JSON.stringify([
+        ...shadowedTypes,
+      ])}`,
+    );
+  });
 });

--- a/editors/vscode/src/test/semanticTokens.test.ts
+++ b/editors/vscode/src/test/semanticTokens.test.ts
@@ -834,6 +834,7 @@ suite("Semantic Tokens", () => {
       await setTestContent(editor, originalContent);
     }
   });
+
   // Issue #1185: a command head's grammar follows its *effective command
   // identity*, not its spelling — asserted end-to-end through the editor
   // client on the decoded token stream, not just the server's encoder.

--- a/editors/vscode/testFixture/commandIdentityTokens.tcl
+++ b/editors/vscode/testFixture/commandIdentityTokens.tcl
@@ -1,0 +1,27 @@
+# Issue #1185 — a command head's grammar follows its effective identity, not
+# its spelling.  Every line below is real, working Tcl (verified on tclsh
+# 9.0.4 and 8.6.16).
+#
+# 1. The explicitly global spelling resolves to the same command.
+::foreach {aa bb} {1 2} {
+    puts $aa
+}
+puts [::format {%08x} 42]
+
+# 2. A static `interp alias` makes the new name behave as the target.
+interp alias {} myformat {} format
+puts [myformat {%08x} 42]
+
+# 3. A static `rename` moves the identity to the new name …
+rename upvar myupvar
+proc reader {} {
+    myupvar 1 outer local
+    return $local
+}
+
+# 4. … and a top-level `proc` takes a built-in's name over entirely, so the
+#    shadowed spelling is an ordinary user command from here on.
+proc scan {args} {
+    return USER
+}
+puts [scan {%d} 7]

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -375,6 +375,7 @@ impl Analyser {
                 registry,
                 Some(self.dialect()),
                 crate::interprocedural::ObjectTypeMap::none(),
+                &self.head_identities,
             );
             crate::interprocedural::build_proc_index_from_summaries(&ia)
         };

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -1059,32 +1059,24 @@ impl Analyser {
                 std::collections::HashMap::new(),
             );
         };
-        let overlay = self.stub_overlay.as_ref();
         let param_names: Vec<&str> = params.iter().map(|p| p.name.as_str()).collect();
-        let config = self.lexer_config();
-        let caller_frame_params = super::param_traits::caller_frame_upvar_params(
-            &param_names,
-            body_text,
+        // One environment for all four scans, so the traits, the caller-frame
+        // params, and the caller-frame literals can never be derived from
+        // different views of the proc *or* of the document's command bindings
+        // (issue #1275).
+        let env = super::param_traits::TraitScanEnv {
             registry,
-            config,
-        );
+            stub_overlay: self.stub_overlay.as_ref(),
+            config: self.lexer_config(),
+            identities: &self.head_identities,
+        };
+        let caller_frame_params =
+            super::param_traits::caller_frame_upvar_params(&param_names, body_text, env);
         let caller_frame_literals =
-            super::param_traits::caller_frame_literal_targets(body_text, registry, config);
-        let shallow = super::param_traits::infer_param_traits_with_config(
-            &param_names,
-            body_text,
-            registry,
-            overlay,
-            config,
-        );
+            super::param_traits::caller_frame_literal_targets(body_text, env);
+        let shallow = super::param_traits::infer_param_traits(&param_names, body_text, env);
         let traits = if self.deep_param_traits {
-            let deep = super::param_traits::infer_param_traits_deep_with_config(
-                &param_names,
-                body_text,
-                registry,
-                overlay,
-                config,
-            );
+            let deep = super::param_traits::infer_param_traits_deep(&param_names, body_text, env);
             super::param_traits::merge_traits(shallow, deep)
         } else {
             shallow

--- a/rust/tcl-compiler/src/analyser/param_traits.rs
+++ b/rust/tcl-compiler/src/analyser/param_traits.rs
@@ -77,53 +77,14 @@ use tcl_lexer::{LexerConfig, TokenType};
 /// (parameters with no detected trait) are dropped from the
 /// returned map.
 ///
-/// `registry` is the **dialect-aware** command registry the
-/// caller already built (typically `Analyser::registry`).
-/// Building a fresh `CommandRegistry::build_default()` on every
-/// proc would both be expensive and miss dialect-specific
-/// `arg_role_resolver` / `arg_roles` (e.g. iRules `when` body
-/// detection) that the caller's registry already loaded.
-///
-/// `stub_overlay`, when `Some`, lets user-declared
-/// `# tcl-lsp: stub` commands participate in role-driven
-/// trait inference.  The overlay's
-/// [`StubOverlay::arg_indices_for_role`] return is unioned
-/// with the registry's at each call site, so a stub like
-/// `# tcl-lsp: stub my_eval {script:body}` causes a
-/// `my_eval $param` invocation to mark the parameter as
-/// `ProcArgTrait::Body`.
+/// `env` carries the dialect-aware registry, the document's
+/// `# tcl-lsp: stub` overlay, the dialect lexer configuration, and the
+/// document's proven command-identity facts — see [`TraitScanEnv`].
 #[must_use]
 pub fn infer_param_traits(
     params: &[&str],
     body_source: &str,
-    registry: &CommandRegistry,
-    stub_overlay: Option<&StubOverlay>,
-) -> HashMap<String, HashSet<ProcArgTrait>> {
-    infer_param_traits_with_config(
-        params,
-        body_source,
-        registry,
-        stub_overlay,
-        LexerConfig::default(),
-    )
-}
-
-/// Like [`infer_param_traits`] but with an explicit dialect
-/// [`LexerConfig`] for the body's re-segmentation.
-///
-/// `{*}` expansion (off for Tcl 8.4 / iRules) and the iRules `}{`
-/// ghost SEP change how the body splits into commands and words, which
-/// in turn changes which arguments resolve to a clean `$param` and thus
-/// which traits are inferred.  The analyser threads
-/// `Analyser::lexer_config()` here so trait inference honours the
-/// document's dialect rather than always assuming the Tcl-8.5+ default.
-#[must_use]
-pub fn infer_param_traits_with_config(
-    params: &[&str],
-    body_source: &str,
-    registry: &CommandRegistry,
-    stub_overlay: Option<&StubOverlay>,
-    config: LexerConfig,
+    env: TraitScanEnv<'_>,
 ) -> HashMap<String, HashSet<ProcArgTrait>> {
     if params.is_empty() || body_source.trim().is_empty() {
         return HashMap::new();
@@ -135,9 +96,10 @@ pub fn infer_param_traits_with_config(
 
     let ctx = ScanCtx {
         param_set: &param_set,
-        registry,
-        stub_overlay,
-        config,
+        registry: env.registry,
+        stub_overlay: env.stub_overlay,
+        config: env.config,
+        identities: env.identities,
     };
     scan_commands(body_source, &ctx, &mut traits, &mut aliases);
 
@@ -166,34 +128,12 @@ pub const MAX_DEPTH: u8 = 8;
 pub fn infer_param_traits_deep(
     params: &[&str],
     body_source: &str,
-    registry: &CommandRegistry,
-    stub_overlay: Option<&StubOverlay>,
+    env: TraitScanEnv<'_>,
 ) -> HashMap<String, HashSet<ProcArgTrait>> {
-    infer_param_traits_deep_with_config(
-        params,
-        body_source,
-        registry,
-        stub_overlay,
-        LexerConfig::default(),
-    )
+    infer_param_traits_deep_at_depth(params, body_source, env, 0)
 }
 
-/// Like [`infer_param_traits_deep`] but with an explicit dialect
-/// [`LexerConfig`] (see [`infer_param_traits_with_config`]).  The config
-/// is threaded into both the top-level scan and every recursive descent
-/// into a braced body argument.
-#[must_use]
-pub fn infer_param_traits_deep_with_config(
-    params: &[&str],
-    body_source: &str,
-    registry: &CommandRegistry,
-    stub_overlay: Option<&StubOverlay>,
-    config: LexerConfig,
-) -> HashMap<String, HashSet<ProcArgTrait>> {
-    infer_param_traits_deep_at_depth(params, body_source, registry, stub_overlay, config, 0)
-}
-
-/// [`infer_param_traits_deep_with_config`] with an explicit starting depth.
+/// [`infer_param_traits_deep`] with an explicit starting depth.
 ///
 /// The public entry points always start at `0`; `scan_deep`'s own `apply`
 /// (`ArgRole::LambdaLiteral`) handling calls this with `depth + 1` instead
@@ -209,9 +149,7 @@ pub fn infer_param_traits_deep_with_config(
 fn infer_param_traits_deep_at_depth(
     params: &[&str],
     body_source: &str,
-    registry: &CommandRegistry,
-    stub_overlay: Option<&StubOverlay>,
-    config: LexerConfig,
+    env: TraitScanEnv<'_>,
     depth: u8,
 ) -> HashMap<String, HashSet<ProcArgTrait>> {
     if params.is_empty() || body_source.trim().is_empty() || depth > MAX_DEPTH {
@@ -224,9 +162,10 @@ fn infer_param_traits_deep_at_depth(
 
     let ctx = ScanCtx {
         param_set: &param_set,
-        registry,
-        stub_overlay,
-        config,
+        registry: env.registry,
+        stub_overlay: env.stub_overlay,
+        config: env.config,
+        identities: env.identities,
     };
     scan_deep(body_source, &ctx, &mut traits, &mut aliases, depth);
 
@@ -283,6 +222,50 @@ struct ScanCtx<'p, 'r> {
     registry: &'r CommandRegistry,
     stub_overlay: Option<&'r StubOverlay>,
     config: LexerConfig,
+    /// The **document's** proven command-identity facts (issue #1275), so a
+    /// role, frame-effect, or structural handler is chosen by the command a
+    /// head *is* rather than the one it is spelled as.
+    ///
+    /// Read *unpositioned*: a proc body is segmented from its own text at
+    /// offset 0, so no document-absolute offset exists here.
+    identities: &'r crate::head_identity::HeadIdentityMap,
+}
+
+impl ScanCtx<'_, '_> {
+    /// One command head in both its forms.
+    fn head<'h>(&'h self, written: &'h str) -> crate::head_identity::HeadWords<'h> {
+        self.identities.head_words_unpositioned(written)
+    }
+}
+
+/// Everything a param-trait scan needs about the document it is scanning
+/// inside: the dialect-aware registry, the per-document `# tcl-lsp: stub`
+/// overlay, the dialect lexer configuration the body re-segments under, and
+/// the document's proven command-identity facts.
+///
+/// Bundled so the four public entry points share one parameter rather than
+/// four, and so adding a document-level fact does not re-open every signature.
+#[derive(Clone, Copy)]
+pub struct TraitScanEnv<'a> {
+    /// The caller's already-built, dialect-aware registry (typically
+    /// `Analyser::registry`).  Building a fresh `CommandRegistry::build_default()`
+    /// per proc would both be expensive and miss the dialect-specific
+    /// `arg_role_resolver` / `arg_roles` the caller's registry has loaded.
+    pub registry: &'a CommandRegistry,
+    /// The document's `# tcl-lsp: stub` overlay, when it declares any: a stub
+    /// like `# tcl-lsp: stub my_eval {script:body}` makes a `my_eval $param`
+    /// invocation mark the parameter `ProcArgTrait::Body`.
+    pub stub_overlay: Option<&'a StubOverlay>,
+    /// The dialect lexer configuration the body re-segments under.  `{*}`
+    /// expansion (off for Tcl 8.4 / iRules) and the iRules `}{` ghost SEP
+    /// change how a body splits into commands and words, which changes which
+    /// arguments resolve to a clean `$param`.
+    pub config: LexerConfig,
+    /// The document's proven command-identity facts — see
+    /// [`crate::head_identity`].  Pass
+    /// [`HeadIdentityMap::none()`](crate::head_identity::HeadIdentityMap::none)
+    /// when there is no document to scan.
+    pub identities: &'a crate::head_identity::HeadIdentityMap,
 }
 
 /// Mutable alias / value-copy state accumulated while scanning a proc body.
@@ -361,7 +344,7 @@ fn scan_commands_bounded<'p>(
         // a literal command name, not a param reference.
         let head_is_var = seg.argv.first().is_some_and(|t| t.kind == TokenType::Var);
         scan_command(
-            &seg.texts[0],
+            ctx.head(&seg.texts[0]),
             &cmd_args,
             &braced,
             head_is_var,
@@ -416,7 +399,7 @@ fn scan_deep<'p>(
         if seg.texts.is_empty() {
             continue;
         }
-        let cmd_name = &seg.texts[0];
+        let cmd_name = ctx.head(&seg.texts[0]).resolved;
         let cmd_args: Vec<&str> = seg.texts[1..].iter().map(String::as_str).collect();
         // Look up body args from both the registry (for built-in
         // commands) and the stub overlay (for user-declared
@@ -504,9 +487,12 @@ fn scan_deep<'p>(
             let lambda_traits = infer_param_traits_deep_at_depth(
                 &lambda_param_names,
                 body_text,
-                ctx.registry,
-                ctx.stub_overlay,
-                ctx.config,
+                TraitScanEnv {
+                    registry: ctx.registry,
+                    stub_overlay: ctx.stub_overlay,
+                    config: ctx.config,
+                    identities: ctx.identities,
+                },
                 depth + 1,
             );
             if lambda_traits.is_empty() {
@@ -609,7 +595,7 @@ fn resolve_arg_roles(
 }
 
 fn scan_command<'p>(
-    cmd_name: &str,
+    head: crate::head_identity::HeadWords<'_>,
     cmd_args: &[String],
     braced: &[bool],
     head_is_var: bool,
@@ -618,6 +604,11 @@ fn scan_command<'p>(
     aliases: &mut Aliases<'p>,
 ) {
     let param_set = ctx.param_set;
+    // The *written* spelling is what a `$param` head test reads (a `$cmd` head
+    // is a substitution, not a command binding); every registry query and
+    // structural handler below reads the resolved one (issue #1275).
+    let cmd_name = head.written;
+    let resolved = head.resolved;
     // A `$param` command *head* (`$cmd arg1 arg2`) means the param's value names
     // a command.  Only a genuine `$`-substitution head counts — a braced
     // `{$cmd}` is a literal command name.  Resolves value-copies, so
@@ -629,11 +620,14 @@ fn scan_command<'p>(
     {
         set.insert(ProcArgTrait::Command);
     }
-    apply_arg_role_traits(cmd_name, cmd_args, braced, ctx, traits, aliases);
-    apply_eval_traits(cmd_name, cmd_args, param_set, traits);
+    apply_arg_role_traits(resolved, cmd_args, braced, ctx, traits, aliases);
+    apply_eval_traits(resolved, cmd_args, param_set, traits);
 
-    // Per-command structural handlers.
-    match cmd_name {
+    // Per-command structural handlers.  Matched on the *resolved* head, so a
+    // proven alias or rename of `upvar` / `foreach` / `after` is handled like
+    // the command it is, and a spelling whose binding was provably taken over
+    // matches nothing.
+    match resolved {
         "upvar" => handle_upvar(cmd_args, ctx, traits, aliases),
         "namespace" if cmd_args.first().map(String::as_str) == Some("upvar") => {
             handle_namespace_upvar(cmd_args, param_set, traits, aliases);
@@ -663,7 +657,7 @@ fn scan_command<'p>(
 
     // Track writes through upvar aliases — ``set local …`` where
     // ``local`` was registered as an alias for some param.
-    if matches!(cmd_name, "set" | "incr" | "append" | "lappend")
+    if matches!(resolved, "set" | "incr" | "append" | "lappend")
         && !cmd_args.is_empty()
         && let Some(target) = aliases.upvar.get(cmd_args[0].as_str())
         && let Some(set) = traits.get_mut(target)
@@ -672,7 +666,7 @@ fn scan_command<'p>(
     }
 
     // foreach / lmap loop variables write through aliases.
-    if matches!(cmd_name, "foreach" | "lmap") && cmd_args.len() >= 3 {
+    if matches!(resolved, "foreach" | "lmap") && cmd_args.len() >= 3 {
         let remaining = &cmd_args[..cmd_args.len() - 1];
         let mut i = 0;
         while i < remaining.len() {
@@ -689,7 +683,7 @@ fn scan_command<'p>(
     // so a later `$n` in a name / command position resolves to `p`.  Any other
     // write to a tracked local invalidates the copy.  Recorded *after* the role
     // scan so this command's effect applies only to later commands.
-    match cmd_name {
+    match resolved {
         "set" if cmd_args.len() == 2 => {
             let target = cmd_args[0].as_str();
             if extract_var_name(&cmd_args[0]).is_none()
@@ -1004,22 +998,25 @@ fn handle_upvar<'p>(
 pub fn caller_frame_upvar_params(
     params: &[&str],
     body_source: &str,
-    registry: &CommandRegistry,
-    config: LexerConfig,
+    env: TraitScanEnv<'_>,
 ) -> HashSet<String> {
+    let registry = env.registry;
     let mut out = HashSet::new();
     if params.is_empty() || body_source.trim().is_empty() {
         return out;
     }
     let param_set: HashSet<&str> = params.iter().copied().collect();
-    for seg in &segment_commands_with_offset_and_config(body_source, 0, config) {
+    for seg in &segment_commands_with_offset_and_config(body_source, 0, env.config) {
         // Registry-driven recognition (`FrameArgLayout::AliasPairs`), the
         // same test `caller_frame_literal_targets` applies — never a
-        // spelled command name.
+        // spelled command name, and against the head's *resolved* identity so
+        // a proven alias or rename of `upvar` still counts (issue #1275).
         if seg.texts.first().is_none_or(|head| {
-            registry.frame_effect(head).is_none_or(|spec| {
-                spec.layout != tcl_registry::frame_effect::FrameArgLayout::AliasPairs
-            })
+            registry
+                .frame_effect(env.identities.resolve_unpositioned(head).spec_name())
+                .is_none_or(|spec| {
+                    spec.layout != tcl_registry::frame_effect::FrameArgLayout::AliasPairs
+                })
         }) {
             continue;
         }
@@ -1075,25 +1072,28 @@ pub fn caller_frame_upvar_params(
 #[must_use]
 pub fn caller_frame_literal_targets(
     body_source: &str,
-    registry: &CommandRegistry,
-    config: LexerConfig,
+    env: TraitScanEnv<'_>,
 ) -> HashMap<String, bool> {
     use tcl_registry::frame_effect::FrameArgLayout;
 
+    let registry = env.registry;
     let mut targets: HashMap<String, bool> = HashMap::new();
     if body_source.trim().is_empty() {
         return targets;
     }
     // local alias name → the caller-frame name it stands for.
     let mut alias_to_target: HashMap<String, String> = HashMap::new();
-    let segs = segment_commands_with_offset_and_config(body_source, 0, config);
+    let segs = segment_commands_with_offset_and_config(body_source, 0, env.config);
     for seg in &segs {
-        let Some(head) = seg.texts.first() else {
+        let Some(written) = seg.texts.first() else {
             continue;
         };
         // Registry-driven recognition: any command whose frame-effect
         // grammar is `otherVar myVar` alias pairs (`upvar`), never a
-        // spelled name.
+        // spelled name — and against the head's *resolved* identity, so a
+        // proven alias or rename of `upvar` still counts and a spelling whose
+        // binding was taken over does not (issue #1275).
+        let head = env.identities.resolve_unpositioned(written).spec_name();
         if registry
             .frame_effect(head)
             .is_none_or(|spec| spec.layout != FrameArgLayout::AliasPairs)
@@ -1118,9 +1118,10 @@ pub fn caller_frame_literal_targets(
         return targets;
     }
     for seg in &segs {
-        let Some(head) = seg.texts.first() else {
+        let Some(written) = seg.texts.first() else {
             continue;
         };
+        let head = env.identities.resolve_unpositioned(written).spec_name();
         let args: Vec<&str> = seg.texts.iter().skip(1).map(String::as_str).collect();
         for idx in registry.arg_indices_for_role(head, &args, ArgRole::VarWrite) {
             if let Some(word) = args.get(idx)
@@ -1344,7 +1345,29 @@ mod tests {
     /// stub overlay; tests that need one construct it inline.
     fn infer(params: &[&str], body: &str) -> HashMap<String, HashSet<ProcArgTrait>> {
         let registry = CommandRegistry::build_default();
-        infer_param_traits(params, body, &registry, None)
+        infer_param_traits(params, body, env_for(&registry, LexerConfig::default()))
+    }
+
+    /// A scan environment over `registry` with no stub overlay and no document
+    /// binding facts — what a bare-body unit test scans under.
+    fn env_for(registry: &CommandRegistry, config: LexerConfig) -> TraitScanEnv<'_> {
+        TraitScanEnv {
+            registry,
+            stub_overlay: None,
+            config,
+            identities: crate::head_identity::HeadIdentityMap::none(),
+        }
+    }
+
+    /// [`env_for`] with a stub overlay attached.
+    fn env_with_overlay<'a>(
+        registry: &'a CommandRegistry,
+        overlay: &'a StubOverlay,
+    ) -> TraitScanEnv<'a> {
+        TraitScanEnv {
+            stub_overlay: Some(overlay),
+            ..env_for(registry, LexerConfig::default())
+        }
     }
 
     #[test]
@@ -1377,8 +1400,11 @@ mod tests {
     #[test]
     fn eval_inside_apply_lambda_body_does_not_leak_to_unrelated_enclosing_param() {
         let registry = CommandRegistry::build_default();
-        let traits =
-            infer_param_traits_deep(&["body"], "apply {x {eval $body}} 1", &registry, None);
+        let traits = infer_param_traits_deep(
+            &["body"],
+            "apply {x {eval $body}} 1",
+            env_for(&registry, LexerConfig::default()),
+        );
         assert!(
             !traits
                 .get("body")
@@ -1396,8 +1422,11 @@ mod tests {
     #[test]
     fn eval_param_forwarded_into_apply_lambda_records_eval_trait() {
         let registry = CommandRegistry::build_default();
-        let traits =
-            infer_param_traits_deep(&["body"], "apply {x {eval $x}} $body", &registry, None);
+        let traits = infer_param_traits_deep(
+            &["body"],
+            "apply {x {eval $x}} $body",
+            env_for(&registry, LexerConfig::default()),
+        );
         assert_trait(&traits, "body", ProcArgTrait::Eval);
     }
 
@@ -1409,23 +1438,19 @@ mod tests {
         // `eval $p` (→ `p` is Eval) on 9.0 but `eval` of the single
         // composite word `{*}$p` (no clean `$p`, no trait) on 8.4.
         let registry = CommandRegistry::build_default();
-        let on = infer_param_traits_with_config(
+        let on = infer_param_traits(
             &["p"],
             "eval {*}$p",
-            &registry,
-            None,
-            LexerConfig::default(),
+            env_for(&registry, LexerConfig::default()),
         );
         assert!(
             on.get("p").is_some_and(|s| s.contains(&ProcArgTrait::Eval)),
             "9.0 expands `{{*}}` → eval $p → Eval: {on:?}",
         );
-        let off = infer_param_traits_with_config(
+        let off = infer_param_traits(
             &["p"],
             "eval {*}$p",
-            &registry,
-            None,
-            LexerConfig::for_dialect("tcl8.4"),
+            env_for(&registry, LexerConfig::for_dialect("tcl8.4")),
         );
         assert!(
             off.get("p")
@@ -1503,7 +1528,11 @@ mod tests {
             // variable.
             ("upvar 1 caller $n", false),
         ] {
-            let got = caller_frame_upvar_params(&params, body, &registry, LexerConfig::default());
+            let got = caller_frame_upvar_params(
+                &params,
+                body,
+                env_for(&registry, LexerConfig::default()),
+            );
             assert_eq!(
                 got.contains("n"),
                 expected,
@@ -1521,22 +1550,19 @@ mod tests {
         let registry = CommandRegistry::build_default();
         let got = caller_frame_literal_targets(
             "upvar name name\nset name W1",
-            &registry,
-            LexerConfig::default(),
+            env_for(&registry, LexerConfig::default()),
         );
         assert_eq!(got.get("name"), Some(&true), "written through the alias");
         // A body that only reads through the alias creates nothing.
         let got = caller_frame_literal_targets(
             "upvar name name\nreturn [string length $name]",
-            &registry,
-            LexerConfig::default(),
+            env_for(&registry, LexerConfig::default()),
         );
         assert_eq!(got.get("name"), Some(&false), "read-only alias");
         // Distinct local alias spelling still records the CALLER name.
         let got = caller_frame_literal_targets(
             "upvar 1 other mine\nset mine 1",
-            &registry,
-            LexerConfig::default(),
+            env_for(&registry, LexerConfig::default()),
         );
         assert_eq!(got.get("other"), Some(&true));
         assert!(!got.contains_key("mine"));
@@ -1559,7 +1585,8 @@ mod tests {
             "upvar 1 name $dst",
             "namespace upvar ::cfg name local; set local 1",
         ] {
-            let got = caller_frame_literal_targets(body, &registry, LexerConfig::default());
+            let got =
+                caller_frame_literal_targets(body, env_for(&registry, LexerConfig::default()));
             assert!(got.is_empty(), "{body:?} must record nothing, got {got:?}");
         }
     }
@@ -1576,7 +1603,8 @@ mod tests {
         let traits = infer(&["n"], body);
         assert_trait(&traits, "n", ProcArgTrait::VarWrite);
         assert!(
-            caller_frame_upvar_params(&["n"], body, &registry, LexerConfig::default()).is_empty(),
+            caller_frame_upvar_params(&["n"], body, env_for(&registry, LexerConfig::default()))
+                .is_empty(),
             "the level fact must reject what the trait alone accepts"
         );
     }
@@ -1594,8 +1622,7 @@ mod tests {
             caller_frame_upvar_params(
                 &["lvl", "v"],
                 "upvar $lvl $v local\nset local 1",
-                &registry,
-                LexerConfig::default()
+                env_for(&registry, LexerConfig::default())
             )
             .is_empty(),
             "a computed level names no statically-known frame"
@@ -1770,7 +1797,16 @@ mod tests {
             ],
         )]);
         let registry = CommandRegistry::build_default();
-        let traits = infer_param_traits(&["h"], "on_event click $h", &registry, Some(&overlay));
+        let traits = infer_param_traits(
+            &["h"],
+            "on_event click $h",
+            TraitScanEnv {
+                registry: &registry,
+                stub_overlay: Some(&overlay),
+                config: LexerConfig::default(),
+                identities: crate::head_identity::HeadIdentityMap::none(),
+            },
+        );
         assert_trait(&traits, "h", ProcArgTrait::Command);
     }
 
@@ -1929,7 +1965,7 @@ mod tests {
     /// Deep-pass helper that mirrors [`infer`] for ergonomics.
     fn infer_deep(params: &[&str], body: &str) -> HashMap<String, HashSet<ProcArgTrait>> {
         let registry = CommandRegistry::build_default();
-        infer_param_traits_deep(params, body, &registry, None)
+        infer_param_traits_deep(params, body, env_for(&registry, LexerConfig::default()))
     }
 
     #[test]
@@ -2027,7 +2063,7 @@ mod tests {
         // threshold happens to sit a little higher.
         let registry = CommandRegistry::build_default();
         let start = std::time::Instant::now();
-        let _ = infer_param_traits_deep(&["p"], &body, &registry, None);
+        let _ = infer_param_traits_deep(&["p"], &body, env_for(&registry, LexerConfig::default()));
         let elapsed = start.elapsed();
         assert!(
             elapsed < std::time::Duration::from_secs(2),
@@ -2141,7 +2177,16 @@ mod tests {
         // the `script` param.
         let overlay = make_overlay(vec![stub_sig("my_eval", &[("script", ArgRole::Body)])]);
         let registry = CommandRegistry::build_default();
-        let traits = infer_param_traits(&["script"], "my_eval $script", &registry, Some(&overlay));
+        let traits = infer_param_traits(
+            &["script"],
+            "my_eval $script",
+            TraitScanEnv {
+                registry: &registry,
+                stub_overlay: Some(&overlay),
+                config: LexerConfig::default(),
+                identities: crate::head_identity::HeadIdentityMap::none(),
+            },
+        );
         assert_trait(&traits, "script", ProcArgTrait::Body);
     }
 
@@ -2154,7 +2199,16 @@ mod tests {
             &[("varName", ArgRole::VarWrite), ("value", ArgRole::Value)],
         )]);
         let registry = CommandRegistry::build_default();
-        let traits = infer_param_traits(&["v"], "with_var $v 42", &registry, Some(&overlay));
+        let traits = infer_param_traits(
+            &["v"],
+            "with_var $v 42",
+            TraitScanEnv {
+                registry: &registry,
+                stub_overlay: Some(&overlay),
+                config: LexerConfig::default(),
+                identities: crate::head_identity::HeadIdentityMap::none(),
+            },
+        );
         // A stub `VarWrite` role on a bare `$v` substitution is the same
         // callee-local dynamic-name shape as `set $v …` — refined to
         // DynamicNameLocal (+ VarRead), not a caller-frame VarWrite.
@@ -2177,7 +2231,11 @@ mod tests {
         let body = "my_loop 5 { uplevel 1 $script }";
         // Sanity: without the overlay, the deep pass misses
         // the nested Eval because `my_loop` isn't recognised.
-        let no_overlay = infer_param_traits_deep(&["script"], body, &registry, None);
+        let no_overlay = infer_param_traits_deep(
+            &["script"],
+            body,
+            env_for(&registry, LexerConfig::default()),
+        );
         assert!(
             !no_overlay
                 .get("script")
@@ -2185,7 +2243,16 @@ mod tests {
             "without overlay, my_loop body shouldn't be recognised, got {no_overlay:?}",
         );
         // With the overlay, the recursion fires.
-        let with_overlay = infer_param_traits_deep(&["script"], body, &registry, Some(&overlay));
+        let with_overlay = infer_param_traits_deep(
+            &["script"],
+            body,
+            TraitScanEnv {
+                registry: &registry,
+                stub_overlay: Some(&overlay),
+                config: LexerConfig::default(),
+                identities: crate::head_identity::HeadIdentityMap::none(),
+            },
+        );
         assert_trait(&with_overlay, "script", ProcArgTrait::Eval);
     }
 
@@ -2201,8 +2268,7 @@ mod tests {
         let traits = infer_param_traits(
             &["items", "body"],
             "foreach x $items $body",
-            &registry,
-            Some(&overlay),
+            env_with_overlay(&registry, &overlay),
         );
         assert_trait(&traits, "items", ProcArgTrait::LoopList);
         assert_trait(&traits, "body", ProcArgTrait::Body);
@@ -2215,8 +2281,139 @@ mod tests {
         // entries.
         let registry = CommandRegistry::build_default();
         let body = "foreach x {1 2 3} $body";
-        let none = infer_param_traits(&["body"], body, &registry, None);
-        let empty = infer_param_traits(&["body"], body, &registry, Some(&StubOverlay::new()));
+        let none = infer_param_traits(&["body"], body, env_for(&registry, LexerConfig::default()));
+        let overlay = StubOverlay::new();
+        let empty = infer_param_traits(&["body"], body, env_with_overlay(&registry, &overlay));
         assert_eq!(none, empty);
+    }
+
+    /// Issue #1275 — trait inference must resolve a command head's *effective
+    /// identity*, not its written spelling.
+    ///
+    /// tclsh oracle (8.6.16 and 9.0.4, byte-identical): `interp alias {} run
+    /// {} eval` makes `run $body` evaluate `$body`; `rename eval run` moves it
+    /// and leaves `eval` gone; a top-level `proc eval …` takes the name over,
+    /// so `eval $body` no longer evaluates anything.
+    ///
+    /// The environment carries the *document's* facts while the scan reads a
+    /// *proc body*, which is exactly the shape the analyser threads.
+    fn traits_under(prelude: &str, body: &str) -> HashMap<String, HashSet<ProcArgTrait>> {
+        let registry = CommandRegistry::build_default();
+        let identities =
+            crate::head_identity::command_head_identities(prelude, "tcl8.6", &registry);
+        infer_param_traits(
+            &["body"],
+            body,
+            TraitScanEnv {
+                registry: &registry,
+                stub_overlay: None,
+                config: LexerConfig::default(),
+                identities: &identities,
+            },
+        )
+    }
+
+    fn is_eval(traits: &HashMap<String, HashSet<ProcArgTrait>>) -> bool {
+        traits
+            .get("body")
+            .is_some_and(|s| s.contains(&ProcArgTrait::Eval))
+    }
+
+    #[test]
+    fn param_traits_follow_an_aliased_head() {
+        assert!(is_eval(&traits_under(
+            "interp alias {} run {} eval\n",
+            "run $body"
+        )));
+        // The `::`-qualified spelling of the alias classifies alike.
+        assert!(is_eval(&traits_under(
+            "interp alias {} run {} eval\n",
+            "::run $body"
+        )));
+        // Guard: an unbound `run` evaluates nothing.
+        assert!(!is_eval(&traits_under("set y 1\n", "run $body")));
+    }
+
+    #[test]
+    fn param_traits_follow_a_renamed_head() {
+        assert!(is_eval(&traits_under("rename eval run\n", "run $body")));
+        assert!(
+            !is_eval(&traits_under("rename eval run\n", "eval $body")),
+            "a renamed-away `eval` must not keep the built-in's grammar"
+        );
+    }
+
+    #[test]
+    fn param_traits_abstain_for_a_builtin_shadowed_by_a_user_proc() {
+        assert!(
+            !is_eval(&traits_under("proc eval {s} { return $s }\n", "eval $body")),
+            "a user `proc eval` takes the name over; its argument is not a script"
+        );
+        // Guard: the unshadowed built-in still records the trait.
+        assert!(is_eval(&traits_under("set y 1\n", "eval $body")));
+    }
+
+    #[test]
+    fn param_traits_abstain_for_a_dynamic_binding() {
+        assert!(
+            !is_eval(&traits_under("rename $old run\n", "run $body")),
+            "a dynamic rename must not make `run` an evaluator"
+        );
+        assert!(
+            is_eval(&traits_under("rename $old run\n", "eval $body")),
+            "a dynamic rename must not take `eval`'s grammar away either"
+        );
+    }
+
+    /// The caller-frame scans read the resolved head too: `upvar`'s
+    /// `FrameArgLayout::AliasPairs` grammar belongs to the command a head is.
+    #[test]
+    fn caller_frame_scans_follow_the_resolved_head() {
+        let registry = CommandRegistry::build_default();
+        let env_of = |prelude: &str| {
+            crate::head_identity::command_head_identities(prelude, "tcl8.6", &registry)
+        };
+
+        let aliased = env_of("interp alias {} peek {} upvar\n");
+        let env = TraitScanEnv {
+            registry: &registry,
+            stub_overlay: None,
+            config: LexerConfig::default(),
+            identities: &aliased,
+        };
+        assert!(
+            caller_frame_upvar_params(&["v"], "peek 1 $v alias", env).contains("v"),
+            "an alias of `upvar` must bind the caller's frame like `upvar`"
+        );
+        assert!(
+            caller_frame_literal_targets("peek 1 name name\nset name W1", env).contains_key("name"),
+            "an alias of `upvar` must record its literal caller-frame target"
+        );
+
+        let shadowed = env_of("proc upvar {a b c} { return 1 }\n");
+        let env = TraitScanEnv {
+            identities: &shadowed,
+            ..env
+        };
+        assert!(
+            caller_frame_upvar_params(&["v"], "upvar 1 $v alias", env).is_empty(),
+            "a shadowed `upvar` binds no caller frame"
+        );
+        assert!(
+            caller_frame_literal_targets("upvar 1 name name\nset name W1", env).is_empty(),
+            "a shadowed `upvar` records no literal caller-frame target"
+        );
+
+        // Guard: with nothing bound, both scans fire on the built-in.
+        let none = crate::head_identity::HeadIdentityMap::none();
+        let env = TraitScanEnv {
+            identities: none,
+            ..env
+        };
+        assert!(caller_frame_upvar_params(&["v"], "upvar 1 $v alias", env).contains("v"));
+        assert!(
+            caller_frame_literal_targets("upvar 1 name name\nset name W1", env)
+                .contains_key("name")
+        );
     }
 }

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -661,6 +661,16 @@ pub struct Analyser {
     /// `None` outside an active analysis run.  Tied to the
     /// (single-threaded) analyser instance rather than a thread-local.
     pub stub_overlay: Option<tcl_registry::stub_overlay::StubOverlay>,
+    /// The document's statically proven command-identity facts
+    /// ([`crate::head_identity`]) — which registry command each head spelling
+    /// really names, folding in `namespace import`, `interp alias`, `rename`,
+    /// and a built-in-shadowing `proc`.  Rebuilt alongside
+    /// [`Self::registry`] at the top of every entry point so a per-proc
+    /// param-trait scan resolves a body's heads against the *document's*
+    /// bindings rather than their written spellings (issue #1275).  Empty
+    /// outside an active analysis run, and for the overwhelmingly common
+    /// document that binds nothing.
+    pub head_identities: crate::head_identity::HeadIdentityMap,
     /// Sorted byte offsets of every ``\n`` in [`Self::source`],
     /// precomputed at the top of [`Self::analyse`] /
     /// [`Self::analyse_chunked`] / [`Self::analyse_commands`] so
@@ -1098,6 +1108,7 @@ impl Analyser {
             recovery_known_commands: super::utils::RecoveryKnownCommands::default(),
             deep_param_traits: false,
             stub_overlay: None,
+            head_identities: crate::head_identity::HeadIdentityMap::default(),
             line_offsets: None,
             cached_line_index: tcl_lexer::LineIndex::new(""),
             cached_line_index_source_len: 0,
@@ -1314,6 +1325,11 @@ impl Analyser {
         // ``self`` so per-command handlers (registry-driven body
         // iteration in ``process_command``) reuse it.
         self.registry = Some(tcl_registry::cache::registry_for_profile(self.profile));
+        self.head_identities = crate::head_identity::command_head_identities_with_config(
+            source,
+            self.lexer_config(),
+            self.registry.expect("registry just stashed"),
+        );
         // Precompute the iRules file-profile stack (no-op off f5-irules) so
         // the per-command IRULE1001 hint can consult it without recomputing.
         self.compute_irules_file_profiles();
@@ -1668,6 +1684,11 @@ impl Analyser {
         // for the ``line_offsets`` index used by
         // ``apply_preceding_noqa``.
         self.registry = Some(tcl_registry::cache::registry_for_profile(self.profile));
+        self.head_identities = crate::head_identity::command_head_identities_with_config(
+            source,
+            self.lexer_config(),
+            self.registry.expect("registry just stashed"),
+        );
         self.recovery_known_commands = super::utils::recovery_known_commands(
             source,
             self.registry.expect("registry just stashed"),
@@ -1748,6 +1769,11 @@ impl Analyser {
         // ``process_command`` silently skips body recursion on
         // the incremental path.
         self.registry = Some(tcl_registry::cache::registry_for_profile(self.profile));
+        self.head_identities = crate::head_identity::command_head_identities_with_config(
+            source,
+            self.lexer_config(),
+            self.registry.expect("registry just stashed"),
+        );
         self.recovery_known_commands = super::utils::recovery_known_commands(
             source,
             self.registry.expect("registry just stashed"),

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -1563,11 +1563,19 @@ impl CompilationUnit {
         // Object-handle → class map (SSA/VTA-derived) so a `$g walk … -command
         // cb` instance-method callback becomes a call-graph / reachability edge.
         let object_types = crate::object_types::object_handle_classes(&self, registry);
+        // The unit's own proven command-identity facts, so the call-graph scan
+        // classifies a rebound head as the command it is (issue #1275).
+        let identities = crate::head_identity::command_head_identities_with_config(
+            &self.source,
+            tcl_lexer::LexerConfig::for_dialect(dialect.unwrap_or_default()),
+            registry,
+        );
         let interproc = crate::interprocedural::build_interprocedural_analysis(
             &self.ir_module,
             registry,
             dialect,
             crate::interprocedural::ObjectTypeMap(&object_types),
+            &identities,
         );
 
         // Re-run taint with the new summary + dialect. We borrow
@@ -1624,11 +1632,19 @@ impl CompilationUnit {
         taint_cb: &mut TaintCascadeCallback<'_>,
     ) -> Self {
         let object_types = crate::object_types::object_handle_classes(&self, registry);
+        // The unit's own proven command-identity facts, so the call-graph scan
+        // classifies a rebound head as the command it is (issue #1275).
+        let identities = crate::head_identity::command_head_identities_with_config(
+            &self.source,
+            tcl_lexer::LexerConfig::for_dialect(dialect.unwrap_or_default()),
+            registry,
+        );
         let interproc = crate::interprocedural::build_interprocedural_analysis(
             &self.ir_module,
             registry,
             dialect,
             crate::interprocedural::ObjectTypeMap(&object_types),
+            &identities,
         );
 
         // Top level is built fresh (no offset-0 lattice key), so its taint

--- a/rust/tcl-compiler/src/head_identity.rs
+++ b/rust/tcl-compiler/src/head_identity.rs
@@ -16,13 +16,13 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! Effective command identity for a command head (issue #1185).
+//! Effective command identity for a command head (issues #1185, #1275).
 //!
 //! Tcl resolves a command by its interpreter-level *binding*, not by the
 //! spelling used to invoke it.  Three statically visible statements move that
 //! binding, and this module turns the ones a document states unconditionally
 //! at top level into a small, offset-keyed table the source-text consumers
-//! (semantic tokens today) consult before they hand a head to the registry:
+//! consult before they hand a head to the registry:
 //!
 //! ```tcl
 //! namespace import ::tcltest::*   ;# `test`   now *is* `::tcltest::test`
@@ -64,16 +64,29 @@
 //!   `proc` inside `namespace eval ::n` defines `::n::format`, not `::format`
 //!   (tclsh 9.0.4: `::n::format q` → `ns:q`, global `format` untouched).
 //! * **`unknown` fallback and traces** — nothing is inferred from them.
+//!
+//! # Positioned and unpositioned readers
+//!
+//! [`HeadIdentityMap::resolve`] answers for a head at a known byte offset.
+//! Several consumers re-lex a body out of its own decoded text (the formatter
+//! reformats `arg.text`, the minifier re-minifies a body slice, the call-graph
+//! scan segments a body string at offset 0), so no absolute offset exists at
+//! the point of the query.  Those read
+//! [`HeadIdentityMap::resolve_unpositioned`], which considers *every* fact
+//! about the spelling at once and abstains ([`HeadIdentity::Rebound`]) unless
+//! they all agree — a document that binds a name twice cannot be read without
+//! a position, and guessing one of the two is exactly the fallback-to-spelling
+//! this module exists to remove.
 
+use crate::alias::{detect_interp_alias, detect_interp_alias_delete, detect_rename};
+use crate::segmenter::segment_commands_with_offset_and_config;
 use rustc_hash::FxHashMap;
-use tcl_compiler::alias::{detect_interp_alias, detect_interp_alias_delete, detect_rename};
-use tcl_compiler::segmenter::segment_commands_with_offset_and_config;
 use tcl_registry::{CommandRegistry, CommandTableEffect};
 use tcl_syntax::naming::is_dynamic_word;
 
 /// What a command head resolves to at one point in a document.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum HeadIdentity<'a> {
+pub enum HeadIdentity<'a> {
     /// The head names this registry command — the head text itself when no
     /// fact applies, or the effective target of a proven import / alias /
     /// rename.
@@ -93,7 +106,8 @@ impl<'a> HeadIdentity<'a> {
     /// consumer already makes (`arg_indices_for_role`, `format_string_args`,
     /// `handle_binding`, …) answers "not a known command" without that
     /// consumer testing the variant.
-    pub(crate) fn spec_name(self) -> &'a str {
+    #[must_use]
+    pub fn spec_name(self) -> &'a str {
         match self {
             Self::Command(name) => name,
             Self::Rebound => "",
@@ -101,7 +115,8 @@ impl<'a> HeadIdentity<'a> {
     }
 
     /// Whether the head's registry binding was provably taken over.
-    pub(crate) fn is_rebound(self) -> bool {
+    #[must_use]
+    pub fn is_rebound(self) -> bool {
         matches!(self, Self::Rebound)
     }
 }
@@ -125,15 +140,28 @@ struct HeadFact {
 /// (`namespace which -command ::myfmt` → `::myfmt`) and a consumer must not
 /// have to strip qualifiers itself.
 #[derive(Debug, Default)]
-pub(crate) struct HeadIdentityMap {
+pub struct HeadIdentityMap {
     facts: FxHashMap<String, Vec<HeadFact>>,
 }
 
+/// The shared empty map, for a consumer that has no document to scan (an
+/// IR-only caller, a unit-test harness).  Nothing is bound, so every head
+/// keeps its own spelling.
+static NO_IDENTITIES: std::sync::LazyLock<HeadIdentityMap> =
+    std::sync::LazyLock::new(HeadIdentityMap::default);
+
 impl HeadIdentityMap {
+    /// The empty map — no document, so no binding fact.
+    #[must_use]
+    pub fn none() -> &'static Self {
+        &NO_IDENTITIES
+    }
+
     /// Whether the document stated any binding fact at all — lets a caller
     /// skip per-head lookups entirely for the overwhelmingly common document
     /// that imports, aliases, and renames nothing.
-    pub(crate) fn is_empty(&self) -> bool {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
         self.facts.is_empty()
     }
 
@@ -142,7 +170,8 @@ impl HeadIdentityMap {
     /// The **latest** fact at or before `at` wins, so a document that renames a
     /// name and then rebinds it again reads correctly at every point between.
     /// With no applicable fact the head keeps its own spelling.
-    pub(crate) fn resolve<'a>(&'a self, head: &'a str, at: u32) -> HeadIdentity<'a> {
+    #[must_use]
+    pub fn resolve<'a>(&'a self, head: &'a str, at: u32) -> HeadIdentity<'a> {
         let Some(facts) = self.facts.get(head) else {
             return HeadIdentity::Command(head);
         };
@@ -150,6 +179,31 @@ impl HeadIdentityMap {
             return HeadIdentity::Command(head);
         };
         fact.target
+            .as_deref()
+            .map_or(HeadIdentity::Rebound, HeadIdentity::Command)
+    }
+
+    /// The effective identity of `head` when the call's byte offset is not
+    /// available — a body the consumer re-lexed out of its own decoded text.
+    ///
+    /// Every fact about the spelling is considered at once.  With none, the
+    /// head keeps its own spelling; with facts that all name the same target,
+    /// that target; otherwise [`HeadIdentity::Rebound`], because the reader
+    /// cannot tell which of two bindings is in force and the written spelling
+    /// is precisely the answer that must not be assumed.
+    #[must_use]
+    pub fn resolve_unpositioned<'a>(&'a self, head: &'a str) -> HeadIdentity<'a> {
+        let Some(facts) = self.facts.get(head) else {
+            return HeadIdentity::Command(head);
+        };
+        let Some(first) = facts.first() else {
+            return HeadIdentity::Command(head);
+        };
+        if facts.iter().any(|f| f.target != first.target) {
+            return HeadIdentity::Rebound;
+        }
+        first
+            .target
             .as_deref()
             .map_or(HeadIdentity::Rebound, HeadIdentity::Command)
     }
@@ -194,18 +248,31 @@ fn is_static_name(word: &str) -> bool {
 /// ([`CommandTableEffect`]) and the argument shapes come from the compiler's
 /// own detectors ([`detect_interp_alias`] / [`detect_rename`]) — the same ones
 /// the IR-lowering pipeline uses — so no command name is spelled here.
-pub(crate) fn command_head_identities(
+#[must_use]
+pub fn command_head_identities(
     source: &str,
     dialect: &str,
     registry: &CommandRegistry,
 ) -> HeadIdentityMap {
+    command_head_identities_with_config(
+        source,
+        tcl_lexer::LexerConfig::for_file_dialect(dialect),
+        registry,
+    )
+}
+
+/// [`command_head_identities`] with an explicit lexer configuration, for a
+/// consumer that already holds one (the formatter and the param-trait scan
+/// carry a [`tcl_lexer::LexerConfig`] rather than a dialect string).
+#[must_use]
+pub fn command_head_identities_with_config(
+    source: &str,
+    config: tcl_lexer::LexerConfig,
+    registry: &CommandRegistry,
+) -> HeadIdentityMap {
     // One top-level segmentation feeds both halves — the `namespace import`
     // scan and the command-table mutators.
-    let segments = segment_commands_with_offset_and_config(
-        source,
-        0,
-        tcl_lexer::LexerConfig::for_file_dialect(dialect),
-    );
+    let segments = segment_commands_with_offset_and_config(source, 0, config);
     let mut map = HeadIdentityMap::default();
     for (name, (qualified, offset)) in imported_command_aliases(&segments, registry) {
         map.record(&name, Some(qualified), offset);
@@ -247,15 +314,45 @@ fn record_rename(map: &mut HeadIdentityMap, args: &[String], at: u32, registry: 
     if let Some((old, new)) = detect_rename(args)
         && is_static_name(&new)
     {
-        // Only a target the registry actually models is worth aliasing; a
-        // rename of a user proc leaves `NEW` an ordinary unknown name, which is
-        // already what an absent fact produces.
-        if registry.get(&old).is_some() {
-            map.record_both_spellings(&new, Some(old.clone()), at);
+        // Only a source the registry models — directly or through an earlier
+        // fact — is worth aliasing; renaming an ordinary user proc leaves `NEW`
+        // an ordinary unknown name, which is already what an absent fact
+        // produces.  A *provably rebound* source is stated, though: it moves
+        // something the registry does not model onto `NEW`, and `NEW` must not
+        // then be read under the built-in's grammar.
+        let inherited = inherited_target(map, &old, at, registry);
+        if inherited.is_some() || map.resolve(&old, at).is_rebound() {
+            map.record_both_spellings(&new, inherited, at);
         }
     }
     // Either way the old name is gone from this point on.
     map.record_both_spellings(old, None, at);
+}
+
+/// The registry name `source` names at offset `at`, folding in any earlier
+/// fact so a **chain** of bindings composes.
+///
+/// Reading `source` through the map rather than straight off the registry is
+/// what makes `interp alias {} a {} format; rename a b` leave `b` naming
+/// `format` — the behaviour C Tcl has (tclsh 8.6.16 and 9.0.4, byte-identical:
+/// `b %08x 42` answers `0000002a` while `info commands a` answers empty).  The
+/// same read is what stops a chain inheriting a *broken* binding:
+/// `proc format {…} {…}; rename format myfmt` moves the **user proc**, so
+/// `myfmt` must not pick up the built-in's grammar.
+///
+/// `None` means "names nothing the registry models" — either a provably
+/// taken-over spelling or an ordinary unknown name.  The two callers differ in
+/// what they do with that, so the distinction stays at the call site.
+fn inherited_target(
+    map: &HeadIdentityMap,
+    source: &str,
+    at: u32,
+    registry: &CommandRegistry,
+) -> Option<String> {
+    match map.resolve(source, at) {
+        HeadIdentity::Rebound => None,
+        HeadIdentity::Command(name) => registry.get(name).map(|_| name.to_owned()),
+    }
 }
 
 /// `interp alias {} NEW {} TARGET ?arg…?` and its deletion form.
@@ -279,11 +376,15 @@ fn record_alias(map: &mut HeadIdentityMap, args: &[String], at: u32, registry: &
         return;
     };
     // Pre-bound arguments shift every index, so the target's layout cannot be
-    // reused; an unmodelled target has no layout to reuse either.  Both cases
-    // still *take over* the name, so mark it rebound rather than aliased.
+    // reused; a target that names nothing the registry models has no layout to
+    // reuse either.  Both cases still *take over* the name — C Tcl lets an
+    // alias shadow an existing command outright (tclsh 8.6.16 / 9.0.4:
+    // `proc myproc …; interp alias {} lindex {} myproc` makes `lindex {a b c}
+    // 1` answer `MINE`) — so the name is marked rebound rather than left alone.
+    // The target is read through the map, so a chain of bindings composes.
     let effective = prepended
         .is_empty()
-        .then(|| registry.get(&target).map(|_| target))
+        .then(|| inherited_target(map, &target, at, registry))
         .flatten();
     map.record_both_spellings(&qualified, effective, at);
 }
@@ -323,7 +424,7 @@ fn record_proc(map: &mut HeadIdentityMap, args: &[String], at: u32, registry: &C
 /// lets the registry-driven argument overrides see the real spec for an
 /// unqualified imported command.  Returns an empty map when nothing is imported.
 fn imported_command_aliases(
-    segments: &[tcl_compiler::segmenter::SegmentedCommand],
+    segments: &[crate::segmenter::SegmentedCommand],
     registry: &CommandRegistry,
 ) -> FxHashMap<String, (String, u32)> {
     let mut aliases: FxHashMap<String, (String, u32)> = FxHashMap::default();
@@ -600,6 +701,97 @@ mod tests {
         // … and after the `proc` takes the name back it is a user command,
         // even though `origfmt` is not itself a registry name.
         assert_eq!(map.resolve("origfmt", after_all), HeadIdentity::Rebound);
+    }
+
+    /// Issue #1275's "chained bindings do not compose" residual.
+    ///
+    /// tclsh oracle (8.6.16 and 9.0.4, byte-identical):
+    ///
+    /// ```tcl
+    /// interp alias {} a {} format ; rename a b ; b %08x 42   ;# 0000002a
+    /// info commands a                                        ;# (empty)
+    /// rename lindex li1 ; rename li1 li2 ; li2 {x y z} 2      ;# z
+    /// rename lsort mysort ; interp alias {} sorter {} mysort
+    /// sorter {c a b}                                          ;# a b c
+    /// ```
+    #[test]
+    fn chained_bindings_compose() {
+        // alias → rename
+        let src = "interp alias {} a {} format\nrename a b\n";
+        let map = map_for(src);
+        let end = u32::try_from(src.len()).unwrap_or(0);
+        assert_eq!(map.resolve("b", end), HeadIdentity::Command("format"));
+        assert_eq!(map.resolve("::b", end), HeadIdentity::Command("format"));
+        // The intermediate name is gone once the rename moves it.
+        assert_eq!(map.resolve("a", end), HeadIdentity::Rebound);
+
+        // rename → rename
+        let src = "rename lindex li1\nrename li1 li2\n";
+        let map = map_for(src);
+        let end = u32::try_from(src.len()).unwrap_or(0);
+        assert_eq!(map.resolve("li2", end), HeadIdentity::Command("lindex"));
+
+        // rename → alias
+        let src = "rename lsort mysort\ninterp alias {} sorter {} mysort\n";
+        let map = map_for(src);
+        let end = u32::try_from(src.len()).unwrap_or(0);
+        assert_eq!(map.resolve("sorter", end), HeadIdentity::Command("lsort"));
+    }
+
+    /// A chain must not inherit a *broken* binding: the rename moves the user
+    /// proc, not the built-in it shadowed, so the new name gets no grammar.
+    #[test]
+    fn a_chain_through_a_shadowed_builtin_stays_rebound() {
+        let src = "proc format {args} { return USER }\nrename format myfmt\n";
+        let map = map_for(src);
+        let end = u32::try_from(src.len()).unwrap_or(0);
+        assert_eq!(map.resolve("myfmt", end), HeadIdentity::Rebound);
+        assert_eq!(map.resolve("::myfmt", end), HeadIdentity::Rebound);
+    }
+
+    /// An alias whose target is an ordinary user proc still *takes over* the
+    /// name it binds — C Tcl lets an alias shadow an existing command
+    /// (tclsh 8.6.16 / 9.0.4: `proc myproc …; interp alias {} lindex {} myproc`
+    /// makes `lindex {a b c} 1` answer `MINE`).
+    #[test]
+    fn an_alias_over_a_builtin_rebinds_it() {
+        let src = "proc myproc {args} { return MINE }\ninterp alias {} lindex {} myproc\n";
+        let map = map_for(src);
+        let end = u32::try_from(src.len()).unwrap_or(0);
+        assert_eq!(map.resolve("lindex", end), HeadIdentity::Rebound);
+    }
+
+    #[test]
+    fn an_unpositioned_read_abstains_when_the_facts_disagree() {
+        // One fact — the unpositioned read matches the positioned one.
+        let src = "rename format origfmt\n";
+        let map = map_for(src);
+        assert_eq!(
+            map.resolve_unpositioned("origfmt"),
+            HeadIdentity::Command("format")
+        );
+        assert_eq!(map.resolve_unpositioned("format"), HeadIdentity::Rebound);
+        // A head nothing binds keeps its own spelling.
+        assert_eq!(
+            map.resolve_unpositioned("lindex"),
+            HeadIdentity::Command("lindex")
+        );
+
+        // Two facts that disagree — without a position, neither can be chosen.
+        let src = "rename format origfmt\nproc origfmt {args} { return 1 }\n";
+        let map = map_for(src);
+        assert_eq!(map.resolve_unpositioned("origfmt"), HeadIdentity::Rebound);
+    }
+
+    #[test]
+    fn the_shared_empty_map_binds_nothing() {
+        let map = HeadIdentityMap::none();
+        assert!(map.is_empty());
+        assert_eq!(map.resolve("format", 0), HeadIdentity::Command("format"));
+        assert_eq!(
+            map.resolve_unpositioned("format"),
+            HeadIdentity::Command("format")
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/head_identity.rs
+++ b/rust/tcl-compiler/src/head_identity.rs
@@ -121,6 +121,40 @@ impl<'a> HeadIdentity<'a> {
     }
 }
 
+/// A command head in its two forms — the spelling the source wrote, and the
+/// registry name that spelling effectively resolves to.
+///
+/// The two are the same for almost every head, and differ once the document
+/// rebinds a name.  Which of the two a test must read is a real distinction,
+/// not a convenience:
+///
+/// * a **global command** lookup reads [`Self::resolved`], so `::snit::type`,
+///   a proven alias of it, and the bare spelling all answer alike (and a
+///   rebound spelling answers nothing);
+/// * a **lexical** test reads [`Self::written`] — a class-body member
+///   sub-keyword (`method`, `constructor`) or a `$var` head is not a command
+///   binding at all, so a top-level `rename method …` says nothing about the
+///   word inside an `oo::define`.
+#[derive(Debug, Clone, Copy)]
+pub struct HeadWords<'a> {
+    /// The head exactly as the source spells it.
+    pub written: &'a str,
+    /// The registry name the spelling resolves to — empty when the head was
+    /// provably rebound, which every registry query then answers "unknown" for.
+    pub resolved: &'a str,
+}
+
+impl<'a> HeadWords<'a> {
+    /// A head with nothing proven about it: written and resolved alike.
+    #[must_use]
+    pub fn plain(written: &'a str) -> Self {
+        Self {
+            written,
+            resolved: written,
+        }
+    }
+}
+
 /// One binding fact about one head spelling.
 #[derive(Debug, Clone)]
 struct HeadFact {
@@ -206,6 +240,31 @@ impl HeadIdentityMap {
             .target
             .as_deref()
             .map_or(HeadIdentity::Rebound, HeadIdentity::Command)
+    }
+
+    /// `head` in both its forms, resolved at byte offset `at`.
+    #[must_use]
+    pub fn head_words<'a>(&'a self, head: &'a str, at: u32) -> HeadWords<'a> {
+        if self.facts.is_empty() {
+            return HeadWords::plain(head);
+        }
+        HeadWords {
+            written: head,
+            resolved: self.resolve(head, at).spec_name(),
+        }
+    }
+
+    /// `head` in both its forms, resolved without a position — see
+    /// [`Self::resolve_unpositioned`].
+    #[must_use]
+    pub fn head_words_unpositioned<'a>(&'a self, head: &'a str) -> HeadWords<'a> {
+        if self.facts.is_empty() {
+            return HeadWords::plain(head);
+        }
+        HeadWords {
+            written: head,
+            resolved: self.resolve_unpositioned(head).spec_name(),
+        }
     }
 
     /// Whether an *earlier* fact already gives `head` a registry identity at

--- a/rust/tcl-compiler/src/interprocedural.rs
+++ b/rust/tcl-compiler/src/interprocedural.rs
@@ -547,15 +547,27 @@ pub fn build_interprocedural_analysis(
         registry,
         dialect,
         identities,
-        &pure,
-        &effect_reads,
-        &effect_writes,
+        ProcFixpoints {
+            pure: &pure,
+            effect_reads: &effect_reads,
+            effect_writes: &effect_writes,
+        },
     );
 
     InterproceduralAnalysis {
         procedures,
         methods,
     }
+}
+
+/// The three per-procedure fixpoint results a method summary joins against —
+/// its callees' purity and effect sets.  Bundled so [`build_method_summaries`]
+/// keeps a small signature.
+#[derive(Clone, Copy)]
+struct ProcFixpoints<'a> {
+    pure: &'a HashMap<String, bool>,
+    effect_reads: &'a HashMap<String, EffectRegion>,
+    effect_writes: &'a HashMap<String, EffectRegion>,
 }
 
 /// Summarise `TclOO` method bodies into [`MethodSummary`] entries.
@@ -575,10 +587,13 @@ fn build_method_summaries(
     registry: &tcl_registry::CommandRegistry,
     dialect: Option<&str>,
     identities: &crate::head_identity::HeadIdentityMap,
-    pure: &HashMap<String, bool>,
-    effect_reads: &HashMap<String, EffectRegion>,
-    effect_writes: &HashMap<String, EffectRegion>,
+    procs: ProcFixpoints<'_>,
 ) -> HashMap<String, MethodSummary> {
+    let ProcFixpoints {
+        pure,
+        effect_reads,
+        effect_writes,
+    } = procs;
     if ir_module.methods.is_empty() {
         return HashMap::new();
     }
@@ -706,6 +721,7 @@ fn build_method_summaries(
 /// the primary [`crate::ir::MethodDef`] and once per retained replacement
 /// body (issue #1166) so the summary joins over every body a dispatch may
 /// run.
+#[derive(Clone, Copy)]
 struct MethodScan<'a> {
     mqname: &'a str,
     method_known: &'a HashSet<String>,
@@ -924,6 +940,7 @@ fn scan_all_procs(
 
 /// One procedure's local-facts scan, bundled so [`scan_proc`] keeps a small
 /// signature.
+#[derive(Clone, Copy)]
 struct ProcScan<'a> {
     qname: &'a str,
     proc: &'a crate::ir::Procedure,

--- a/rust/tcl-compiler/src/interprocedural.rs
+++ b/rust/tcl-compiler/src/interprocedural.rs
@@ -510,11 +510,19 @@ pub fn build_interprocedural_analysis(
     registry: &tcl_registry::CommandRegistry,
     dialect: Option<&str>,
     object_types: ObjectTypeMap<'_>,
+    identities: &crate::head_identity::HeadIdentityMap,
 ) -> InterproceduralAnalysis {
     let object_types = object_types.0;
     let known: HashSet<String> = ir_module.procedures.keys().cloned().collect();
 
-    let local = scan_all_procs(ir_module, &known, registry, dialect, object_types);
+    let local = scan_all_procs(
+        ir_module,
+        &known,
+        registry,
+        dialect,
+        object_types,
+        identities,
+    );
     let transitive_calls = compute_all_transitive_calls(&known, &local);
     let pure = fixpoint_pure(&local);
     let (effect_reads, effect_writes) = fixpoint_effects(&local);
@@ -538,6 +546,7 @@ pub fn build_interprocedural_analysis(
         &known,
         registry,
         dialect,
+        identities,
         &pure,
         &effect_reads,
         &effect_writes,
@@ -565,6 +574,7 @@ fn build_method_summaries(
     known: &HashSet<String>,
     registry: &tcl_registry::CommandRegistry,
     dialect: Option<&str>,
+    identities: &crate::head_identity::HeadIdentityMap,
     pure: &HashMap<String, bool>,
     effect_reads: &HashMap<String, EffectRegion>,
     effect_writes: &HashMap<String, EffectRegion>,
@@ -598,10 +608,13 @@ fn build_method_summaries(
         for body_def in std::iter::once(method).chain(replacements) {
             scan_method_body_facts(
                 body_def,
-                mqname,
-                &method_known,
-                registry,
-                dialect,
+                MethodScan {
+                    mqname,
+                    method_known: &method_known,
+                    registry,
+                    dialect,
+                    identities,
+                },
                 &mut facts,
                 &mut written_ivars,
             );
@@ -693,15 +706,27 @@ fn build_method_summaries(
 /// the primary [`crate::ir::MethodDef`] and once per retained replacement
 /// body (issue #1166) so the summary joins over every body a dispatch may
 /// run.
+struct MethodScan<'a> {
+    mqname: &'a str,
+    method_known: &'a HashSet<String>,
+    registry: &'a tcl_registry::CommandRegistry,
+    dialect: Option<&'a str>,
+    identities: &'a crate::head_identity::HeadIdentityMap,
+}
+
 fn scan_method_body_facts(
     body_def: &crate::ir::MethodDef,
-    mqname: &str,
-    method_known: &HashSet<String>,
-    registry: &tcl_registry::CommandRegistry,
-    dialect: Option<&str>,
+    scan: MethodScan<'_>,
     facts: &mut LocalFacts,
     written_ivars: &mut HashSet<String>,
 ) {
+    let MethodScan {
+        mqname,
+        method_known,
+        registry,
+        dialect,
+        identities,
+    } = scan;
     let params: HashSet<String> = body_def.params.iter().cloned().collect();
     let ctx = ScanCtx {
         caller: mqname,
@@ -711,6 +736,7 @@ fn scan_method_body_facts(
         params: &params,
         // Method bodies are not call-graph nodes; no object-type map needed.
         object_types: ObjectTypeMap::none().0,
+        identities,
     };
     scan_script(&body_def.body, ctx, facts, 0);
     // Fall-through exit is non-constant (O103); see `scan_proc`.
@@ -876,15 +902,36 @@ fn scan_all_procs(
     registry: &tcl_registry::CommandRegistry,
     dialect: Option<&str>,
     object_types: &HashMap<String, HashSet<String>>,
+    identities: &crate::head_identity::HeadIdentityMap,
 ) -> HashMap<String, LocalFacts> {
     let mut local: HashMap<String, LocalFacts> = HashMap::with_capacity(known.len());
     for (qname, proc) in &ir_module.procedures {
         local.insert(
             qname.clone(),
-            scan_proc(qname, proc, known, registry, dialect, object_types),
+            scan_proc(ProcScan {
+                qname,
+                proc,
+                known,
+                registry,
+                dialect,
+                object_types,
+                identities,
+            }),
         );
     }
     local
+}
+
+/// One procedure's local-facts scan, bundled so [`scan_proc`] keeps a small
+/// signature.
+struct ProcScan<'a> {
+    qname: &'a str,
+    proc: &'a crate::ir::Procedure,
+    known: &'a HashSet<String>,
+    registry: &'a tcl_registry::CommandRegistry,
+    dialect: Option<&'a str>,
+    object_types: &'a HashMap<String, HashSet<String>>,
+    identities: &'a crate::head_identity::HeadIdentityMap,
 }
 
 fn compute_all_transitive_calls(
@@ -1110,14 +1157,16 @@ impl Default for LocalFacts {
     }
 }
 
-fn scan_proc(
-    qname: &str,
-    proc: &crate::ir::Procedure,
-    known: &HashSet<String>,
-    registry: &tcl_registry::CommandRegistry,
-    dialect: Option<&str>,
-    object_types: &HashMap<String, HashSet<String>>,
-) -> LocalFacts {
+fn scan_proc(scan: ProcScan<'_>) -> LocalFacts {
+    let ProcScan {
+        qname,
+        proc,
+        known,
+        registry,
+        dialect,
+        object_types,
+        identities,
+    } = scan;
     let mut facts = LocalFacts {
         local_pure: true,
         ..LocalFacts::default()
@@ -1130,6 +1179,7 @@ fn scan_proc(
         dialect,
         params: &params,
         object_types,
+        identities,
     };
     scan_script(&proc.body, ctx, &mut facts, 0);
     // If the body can fall off the end, its implicit exit returns the
@@ -1159,6 +1209,16 @@ struct ScanCtx<'a> {
     /// -command cb` instance-method dispatch resolves its callback to a
     /// call-graph edge.  Empty when built without a `CompilationUnit`.
     object_types: &'a HashMap<String, HashSet<String>>,
+    /// The document's statically proven command-identity facts
+    /// ([`crate::head_identity`]), so a call's side-effect classification,
+    /// callback-prefix layout, and body / lambda / expression recursion are
+    /// chosen by the command a head *is* rather than the one it is spelled as
+    /// (issue #1275).
+    ///
+    /// Read *unpositioned*: this scan walks lowered `Statement::Call`s and
+    /// re-segments body text at offset 0, so no document-absolute offset
+    /// exists at the point of the query.  Empty for an IR-only caller.
+    identities: &'a crate::head_identity::HeadIdentityMap,
 }
 
 /// `depth` is the nesting level of `script` — see
@@ -1188,8 +1248,17 @@ fn scan_call_facts(command: &str, args: &[String], ctx: ScanCtx<'_>, facts: &mut
         known,
         registry,
         params,
+        identities,
         ..
     } = ctx;
+    // The head's *effective command identity* (issue #1275).  Every registry
+    // query below reads it, so a call through a proven `interp alias` /
+    // `rename` gets the target's traits, prefixes, and effect profile, and a
+    // spelling whose binding was provably taken over gets none of them.  The
+    // *written* head stays in use where the word is not a command binding at
+    // all: `resolve_internal_call` matches a procedure qname, and the
+    // instance-dispatch arm reads a `$receiver` variable out of it.
+    let resolved: &str = identities.resolve_unpositioned(command).spec_name();
     // Resolve internal-proc call targets first.  A command the registry marks
     // `INVOKES_USER_PROC` (the iRules `call PROC ?args?` form) invokes the
     // procedure its *first argument* names, so the edge goes there, not to the
@@ -1198,7 +1267,7 @@ fn scan_call_facts(command: &str, args: &[String], ctx: ScanCtx<'_>, facts: &mut
     // dialect where `call` is not the invoker, and would have missed any other
     // dialect's equivalent.
     let invokes_named_proc = registry
-        .get(command.strip_prefix("::").unwrap_or(command))
+        .get(resolved.strip_prefix("::").unwrap_or(resolved))
         .is_some_and(|spec| {
             spec.traits
                 .contains(tcl_registry::Traits::INVOKES_USER_PROC)
@@ -1218,7 +1287,7 @@ fn scan_call_facts(command: &str, args: &[String], ctx: ScanCtx<'_>, facts: &mut
     // rejects dynamic `$cb` / bracketed heads), mirroring the reference
     // extractor's bareword guard.
     let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
-    for (idx, _appended) in registry.command_prefixes(command, &arg_strs) {
+    for (idx, _appended) in registry.command_prefixes(resolved, &arg_strs) {
         if let Some(word) = args.get(idx).and_then(|a| command_prefix_head(registry, a))
             && is_plain_proc_name(&word)
             && let Some(target) = resolve_internal_call(&word, caller, known)
@@ -1273,7 +1342,7 @@ fn scan_call_facts(command: &str, args: &[String], ctx: ScanCtx<'_>, facts: &mut
         // drives the lexer above so `[cmd …]` / bodies tokenise correctly.)
         // This is why e.g. `log`/`puts` resolve to their LOG_IO/FILE_IO
         // hints — impure but region-free — even under a Tcl dialect.
-        let ci = classify_side_effects(registry, command, args, None, None);
+        let ci = classify_side_effects(registry, resolved, args, None, None);
         if ci.dynamic_barrier {
             facts.has_barrier = true;
             facts.local_pure = false;
@@ -1289,7 +1358,7 @@ fn scan_call_facts(command: &str, args: &[String], ctx: ScanCtx<'_>, facts: &mut
         if !ci.pure {
             facts.local_pure = false;
         }
-        if registry.get(command).is_none() {
+        if registry.get(resolved).is_none() {
             facts.has_unknown_calls = true;
             facts.local_pure = false;
         }
@@ -1813,7 +1882,10 @@ fn scan_source_for_calls(source: &str, ctx: ScanCtx<'_>, facts: &mut LocalFacts,
         return;
     }
     let ScanCtx {
-        registry, dialect, ..
+        registry,
+        dialect,
+        identities,
+        ..
     } = ctx;
     // Scan the call graph under the
     // document dialect so `{*}` (8.4 / iRules) and `}{` (iRules) tokenise
@@ -1830,14 +1902,22 @@ fn scan_source_for_calls(source: &str, ctx: ScanCtx<'_>, facts: &mut LocalFacts,
         if name.is_empty() {
             continue;
         }
+        // The head's effective identity, for every registry role query below
+        // (issue #1275).  `scan_call_facts` resolves it again for its own
+        // queries — it is also reached from the `Statement::Call` arm, which
+        // has no segmented command to hand it.
+        let resolved: &str = identities.resolve_unpositioned(name).spec_name();
         let texts = cmd.args();
         scan_call_facts(name, texts, ctx, facts);
         // Recurse into BODY-role args (e.g. `catch {p}` → `{p}` is
         // BODY).  The registry resolves the role using the same
         // logic as the top-level scanner.
         let arg_strs: Vec<&str> = texts.iter().map(String::as_str).collect();
-        let body_indices =
-            registry.arg_indices_for_role(name, &arg_strs, tcl_registry::arg_role::ArgRole::Body);
+        let body_indices = registry.arg_indices_for_role(
+            resolved,
+            &arg_strs,
+            tcl_registry::arg_role::ArgRole::Body,
+        );
         for idx in body_indices {
             if let Some(body_text) = texts.get(idx) {
                 scan_source_for_calls(body_text, ctx, facts, depth + 1);
@@ -1850,7 +1930,7 @@ fn scan_source_for_calls(source: &str, ctx: ScanCtx<'_>, facts: &mut LocalFacts,
         // edge to a non-existent proc and never reach the real body's own
         // calls at all (issue #954's call-graph sibling gap).
         let lambda_indices = registry.arg_indices_for_role(
-            name,
+            resolved,
             &arg_strs,
             tcl_registry::arg_role::ArgRole::LambdaLiteral,
         );
@@ -1898,8 +1978,11 @@ fn scan_source_for_calls(source: &str, ctx: ScanCtx<'_>, facts: &mut LocalFacts,
         // call buried in `return [expr {[fib …]}]` is missed, leaving the call
         // graph incomplete (which under-converged the interproc taint fixpoint
         // and panicked the diagnostic worker on the debug guard).
-        let expr_indices =
-            registry.arg_indices_for_role(name, &arg_strs, tcl_registry::arg_role::ArgRole::Expr);
+        let expr_indices = registry.arg_indices_for_role(
+            resolved,
+            &arg_strs,
+            tcl_registry::arg_role::ArgRole::Expr,
+        );
         for idx in expr_indices {
             if let Some(arg) = texts.get(idx) {
                 let inner = arg
@@ -2338,8 +2421,13 @@ mod tests {
     fn calls_of(src: &str, caller: &str, dialect: &str) -> Vec<String> {
         let registry = tcl_registry::registry_for_dialect(dialect);
         let ir = crate::lowering::lower_to_ir(src, registry);
-        let ia =
-            build_interprocedural_analysis(&ir, registry, Some(dialect), ObjectTypeMap::none());
+        let ia = build_interprocedural_analysis(
+            &ir,
+            registry,
+            Some(dialect),
+            ObjectTypeMap::none(),
+            crate::head_identity::HeadIdentityMap::none(),
+        );
         let mut calls: Vec<String> = ia
             .procedures
             .get(caller)
@@ -2458,6 +2546,7 @@ mod tests {
             dialect: None,
             params: &params,
             object_types: ObjectTypeMap::none().0,
+            identities: crate::head_identity::HeadIdentityMap::none(),
         };
 
         // A 3000-deep `ExprNode` tree (nested unary `!` over `$x`).
@@ -2639,7 +2728,16 @@ mod tests {
     fn build(source: &str) -> InterproceduralAnalysis {
         let registry = CommandRegistry::build_default();
         let cu = CompilationUnit::build_for(source, &registry, false);
-        build_interprocedural_analysis(&cu.ir_module, &registry, None, ObjectTypeMap::none())
+        // The document's own binding facts, exactly as
+        // `CompilationUnit::with_interprocedural` supplies them.
+        let identities = crate::head_identity::command_head_identities(source, "tcl8.6", &registry);
+        build_interprocedural_analysis(
+            &cu.ir_module,
+            &registry,
+            None,
+            ObjectTypeMap::none(),
+            &identities,
+        )
     }
 
     #[test]
@@ -3305,6 +3403,94 @@ mod tests {
             .join()
             .unwrap();
     }
+
+    /// Issue #1275 — the call-graph scan must resolve a command head's
+    /// *effective identity*, not its written spelling.
+    ///
+    /// `catch`'s argument carries `ArgRole::Body`, so the text scan descends
+    /// into it and records the calls inside as reachability edges.  Whether
+    /// `q` becomes an edge of `p` is therefore a clean witness that the body
+    /// role was resolved — and a missing edge is what makes a live proc look
+    /// dead (O124).
+    ///
+    /// The call sits inside a `[…]` substitution deliberately: a *statement*
+    /// `catch {…}` is turned into control-flow structure by lowering long
+    /// before this scan sees it, so only the value-context path exercises the
+    /// registry role query this issue is about.
+    ///
+    /// tclsh oracle (8.6.16 and 9.0.4, byte-identical): `interp alias {} guard
+    /// {} catch` makes `guard` run `catch`; `rename catch guard` moves it and
+    /// leaves `catch` gone; a top-level `proc catch …` takes the name over.
+    fn p_calls_q(prelude: &str, head: &str) -> bool {
+        let src = format!(
+            "{prelude}proc q {{}} {{ return 1 }}\nproc p {{}} {{ set z [{head} {{q}}] }}\n"
+        );
+        build(&src)
+            .procedures
+            .get("::p")
+            .is_some_and(|s| s.calls.iter().any(|c| c == "::q"))
+    }
+
+    #[test]
+    fn call_graph_follows_an_aliased_body_command() {
+        assert!(p_calls_q("interp alias {} guard {} catch\n", "guard"));
+        // The `::`-qualified spelling of the alias classifies alike.
+        assert!(p_calls_q("interp alias {} guard {} catch\n", "::guard"));
+        // Guard: an unbound `guard` carries no body argument to descend into.
+        assert!(!p_calls_q("set y 1\n", "guard"));
+    }
+
+    #[test]
+    fn call_graph_follows_a_renamed_body_command() {
+        assert!(p_calls_q("rename catch guard\n", "guard"));
+        assert!(
+            !p_calls_q("rename catch guard\n", "catch"),
+            "a renamed-away `catch` must not keep the built-in's body grammar"
+        );
+    }
+
+    #[test]
+    fn call_graph_abstains_for_a_builtin_shadowed_by_a_user_proc() {
+        assert!(
+            !p_calls_q("proc catch {s} { return 1 }\n", "catch"),
+            "a user `proc catch` takes the name over; its argument is a plain \
+             value word, not a script"
+        );
+        // Guard: the unshadowed built-in still descends.
+        assert!(p_calls_q("set y 1\n", "catch"));
+    }
+
+    #[test]
+    fn call_graph_abstains_for_a_dynamic_binding() {
+        assert!(
+            !p_calls_q("rename $old guard\n", "guard"),
+            "a dynamic rename must not give `guard` a body grammar"
+        );
+        assert!(
+            p_calls_q("rename $old guard\n", "catch"),
+            "a dynamic rename must not take `catch`'s body grammar away either"
+        );
+    }
+
+    /// The side-effect classification reads the resolved head too: a call
+    /// through a proven alias is a *known* command, so it no longer forces
+    /// `has_unknown_calls` (which alone makes a procedure permanently impure).
+    #[test]
+    fn side_effect_classification_follows_an_aliased_head() {
+        let unknown = |prelude: &str, head: &str| {
+            let src = format!("{prelude}proc p {{}} {{ {head} hi }}\n");
+            build(&src)
+                .procedures
+                .get("::p")
+                .is_some_and(|s| s.has_unknown_calls)
+        };
+        assert!(
+            !unknown("interp alias {} out {} puts\n", "out"),
+            "an alias of `puts` is a known command, not an unknown call"
+        );
+        // Guard: an unbound `out` is genuinely unknown.
+        assert!(unknown("set y 1\n", "out"));
+    }
 }
 
 #[cfg(test)]
@@ -3339,6 +3525,7 @@ mod effect_propagation_tests {
                 &reg,
                 Some("f5-irules"),
                 ObjectTypeMap::none(),
+                crate::head_identity::HeadIdentityMap::none(),
             );
             let s = ia.procedures.get("::p").expect("proc ::p in IA");
             assert!(
@@ -3350,8 +3537,13 @@ mod effect_propagation_tests {
 
         // Plain statement: nested arg effects are NOT propagated.
         let module = lower_to_ir("proc q {} { matchclass [HTTP::uri] equals $::l }", &reg);
-        let ia =
-            build_interprocedural_analysis(&module, &reg, Some("f5-irules"), ObjectTypeMap::none());
+        let ia = build_interprocedural_analysis(
+            &module,
+            &reg,
+            Some("f5-irules"),
+            ObjectTypeMap::none(),
+            crate::head_identity::HeadIdentityMap::none(),
+        );
         let s = ia.procedures.get("::q").expect("proc ::q in IA");
         assert!(
             !s.effect_reads.contains(EffectRegion::HTTP_STATE),

--- a/rust/tcl-compiler/src/lib.rs
+++ b/rust/tcl-compiler/src/lib.rs
@@ -113,6 +113,7 @@ pub mod execution_intent;
 pub use tcl_syntax::expr::ast as expr_ast;
 pub use tcl_syntax::expr::parser as expr_parser;
 pub mod gvn;
+pub mod head_identity;
 pub mod inline_uplevel;
 pub mod inlining;
 pub mod interprocedural;

--- a/rust/tcl-compiler/src/optimiser/manager.rs
+++ b/rust/tcl-compiler/src/optimiser/manager.rs
@@ -793,11 +793,17 @@ pub fn optimise_raw(
         tcl_lexer::LexerConfig::for_dialect(dialect.unwrap_or_default()),
     );
     let object_types = crate::object_types::object_handle_classes(&cu, registry);
+    let identities = crate::head_identity::command_head_identities_with_config(
+        &cu.source,
+        tcl_lexer::LexerConfig::for_dialect(dialect.unwrap_or_default()),
+        registry,
+    );
     let ia = build_interprocedural_analysis(
         &cu.ir_module,
         registry,
         dialect,
         crate::interprocedural::ObjectTypeMap(&object_types),
+        &identities,
     );
     cu.interproc = Some(ia);
     let mut ctx = build_pass_context(&cu, registry, dialect);

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -2976,6 +2976,7 @@ mod tests {
             &registry(),
             None,
             crate::interprocedural::ObjectTypeMap::none(),
+            crate::head_identity::HeadIdentityMap::none(),
         );
         assert!(
             ia.procedures.contains_key("::ns::inner"),
@@ -3015,6 +3016,7 @@ mod tests {
             &registry(),
             None,
             crate::interprocedural::ObjectTypeMap::none(),
+            crate::head_identity::HeadIdentityMap::none(),
         );
         assert!(
             ia.procedures.contains_key("::a::foo"),
@@ -3036,6 +3038,7 @@ mod tests {
             &registry(),
             None,
             crate::interprocedural::ObjectTypeMap::none(),
+            crate::head_identity::HeadIdentityMap::none(),
         );
         assert_eq!(
             resolve_proc_qname("foo", "::a::b::c", &ia2).as_deref(),
@@ -3062,6 +3065,7 @@ mod tests {
             &registry(),
             None,
             crate::interprocedural::ObjectTypeMap::none(),
+            crate::head_identity::HeadIdentityMap::none(),
         );
         assert!(ia.procedures.contains_key("::ns2::inner"));
         assert!(ia.procedures.contains_key("::ns::ns2::inner"));

--- a/rust/tcl-compiler/tests/inlining_interproc_residual.rs
+++ b/rust/tcl-compiler/tests/inlining_interproc_residual.rs
@@ -114,7 +114,13 @@ fn inlined(source: &str) -> Module {
 fn interproc(source: &str) -> InterproceduralAnalysis {
     let r = reg();
     let cu = CompilationUnit::build_for(source, &r, false);
-    build_interprocedural_analysis(&cu.ir_module, &r, None, ObjectTypeMap::none())
+    build_interprocedural_analysis(
+        &cu.ir_module,
+        &r,
+        None,
+        ObjectTypeMap::none(),
+        tcl_compiler::head_identity::HeadIdentityMap::none(),
+    )
 }
 
 /// Count statement-position calls to `command` in a flat statement list.
@@ -777,7 +783,13 @@ fn inline_module_with_no_procs_at_all_is_unchanged() {
 fn call_by_name_reads(source: &str, caller_qname: &str) -> HashSet<String> {
     let r = reg();
     let cu = CompilationUnit::build_for(source, &r, false);
-    let ia = build_interprocedural_analysis(&cu.ir_module, &r, None, ObjectTypeMap::none());
+    let ia = build_interprocedural_analysis(
+        &cu.ir_module,
+        &r,
+        None,
+        ObjectTypeMap::none(),
+        tcl_compiler::head_identity::HeadIdentityMap::none(),
+    );
     let index = build_proc_index_from_summaries(&ia);
     let fu = cu.function(caller_qname).expect("caller proc");
     collect_call_by_name_reads(&fu.cfg, &index)

--- a/rust/tcl-irules/src/walker.rs
+++ b/rust/tcl-irules/src/walker.rs
@@ -110,37 +110,79 @@ pub fn extract_irules_object_references(
 ) -> Vec<IrulesObjectReference> {
     let mut out = Vec::new();
     let mut scope = BindingScope::default();
-    walk(
+    // The document's statically proven command-identity facts
+    // ([`tcl_compiler::head_identity`]), computed once for the whole rule: a
+    // reference-bearing command reached through a proven `interp alias` /
+    // `rename` is still a reference, and a spelling whose binding was provably
+    // taken over is not (issue #1275).  Empty — and lookup-free — unless the
+    // rule binds something.
+    let identities = tcl_compiler::head_identity::command_head_identities_with_config(
         source,
-        source,
-        0,
+        LexerConfig::for_dialect("f5-irules"),
+        registry,
+    );
+    let ctx = WalkCtx {
+        full: source,
         rule_module,
         registry,
-        &mut scope,
-        &mut out,
-        0,
-    );
+        identities: &identities,
+    };
+    walk(&ctx, source, 0, &mut scope, &mut out, 0);
     out.sort_by(|a, b| {
         (a.range.start(), a.range.end(), &a.name).cmp(&(b.range.start(), b.range.end(), &b.name))
     });
     out
 }
 
-/// Segment `slice` (a substring of `full` starting at byte `base`) and collect
-/// references, recursing into body / expr / command-substitution arguments with
-/// child scopes. Token spans are absolute into `full`. `depth` is this call's
-/// nesting level — see [`MAX_WALK_DEPTH`].
-#[allow(clippy::too_many_arguments)] // one context threaded through a recursive walk
+/// Everything the object-reference walk needs that does not change as it
+/// recurses into nested bodies, lambdas, and `[…]` substitutions.
+struct WalkCtx<'a> {
+    /// The whole rule, so a nested slice's token spans stay absolute.
+    full: &'a str,
+    /// `"ltm"` / `"gtm"`, selecting the pool-kind family.
+    rule_module: Option<&'a str>,
+    /// The dialect registry the argument roles and clause-list shape come from.
+    registry: &'a CommandRegistry,
+    /// The rule's statically proven command-identity facts, so every head is
+    /// resolved to the command it *is* rather than the one it is spelled as
+    /// (issue #1275).
+    identities: &'a tcl_compiler::head_identity::HeadIdentityMap,
+}
+
+/// One segmented command's *effective* head — the registry name its spelling
+/// resolves to at its own byte offset, or the spelling itself when the rule
+/// binds nothing.  Empty for a head whose binding was provably taken over,
+/// which every table and registry lookup then answers "unknown" for.
+fn resolve_head<'a>(
+    identities: &'a tcl_compiler::head_identity::HeadIdentityMap,
+    cmd: &'a SegmentedCommand,
+) -> &'a str {
+    let written = cmd.name();
+    if identities.is_empty() {
+        return written;
+    }
+    let at = cmd.argv.first().map_or(0, |t| t.span.start());
+    identities.resolve(written, at).spec_name()
+}
+
+/// Segment `slice` (a substring of the rule starting at byte `base`) and
+/// collect references, recursing into body / expr / command-substitution
+/// arguments with child scopes. Token spans are absolute into `ctx.full`.
+/// `depth` is this call's nesting level — see [`MAX_WALK_DEPTH`].
 fn walk(
-    full: &str,
+    ctx: &WalkCtx<'_>,
     slice: &str,
     base: u32,
-    rule_module: Option<&str>,
-    registry: &CommandRegistry,
     scope: &mut BindingScope,
     out: &mut Vec<IrulesObjectReference>,
     depth: u32,
 ) {
+    let WalkCtx {
+        full,
+        rule_module,
+        registry,
+        identities,
+    } = *ctx;
     // Native-stack safety net — see `MAX_WALK_DEPTH`'s doc comment (issue
     // #996). Past the cap, stop descending — the references collected up
     // to this nesting level still stand.
@@ -155,10 +197,17 @@ fn walk(
         segment_commands_with_offset_and_config(slice, base, LexerConfig::for_dialect("f5-irules"))
     {
         let args: Vec<&str> = cmd.args().iter().map(String::as_str).collect();
+        // The head's *effective command identity*, resolved exactly as the
+        // semantic-token walk resolves it (issue #1275).  Every table and
+        // registry lookup below reads it, so `::pool`, a proven
+        // `interp alias {} p {} pool`, and a `rename pool p` all find the same
+        // object-reference argument, while a `pool` whose binding was provably
+        // taken over by a user `proc` finds none.
+        let head = resolve_head(identities, &cmd);
 
         // Resolve declared references *before* mutating the binding table, so a
         // same-command `set` re-bind doesn't leak into this call's refs.
-        for (argument_index, kinds) in resolve_object_ref_args(cmd.name(), &args, rule_module) {
+        for (argument_index, kinds) in resolve_object_ref_args(head, &args, rule_module) {
             if let Some((name, range)) = resolve_arg_value(full, &cmd, argument_index, scope) {
                 out.push(IrulesObjectReference {
                     name,
@@ -169,9 +218,9 @@ fn walk(
                 });
             }
         }
-        record_set_binding(full, &cmd, scope);
+        record_set_binding(full, head, &cmd, scope);
 
-        let body_indices = registry.arg_indices_for_role(cmd.name(), &args, ArgRole::Body);
+        let body_indices = registry.arg_indices_for_role(head, &args, ArgRole::Body);
         let mut recursed: HashSet<(u32, u32)> = HashSet::new();
         for body_idx in body_indices {
             let word_index = body_idx + 1;
@@ -180,7 +229,7 @@ fn walk(
                 && !inner_is_empty(full, tok)
             {
                 let mut child = scope.child();
-                recurse_token(full, tok, rule_module, registry, &mut child, out, depth + 1);
+                recurse_token(ctx, tok, &mut child, out, depth + 1);
                 if matches!(tok.kind, TokenType::Cmd) {
                     recursed.insert((tok.span.start(), tok.span.end()));
                 }
@@ -190,7 +239,7 @@ fn walk(
         // EXPR-role words (`if`/`while`/`expr` conditions) are braced/quoted
         // words whose `[…]` substitutions aren't separate `Cmd` tokens; recurse
         // into the expression text so refs nested in a condition are found.
-        let expr_indices = registry.arg_indices_for_role(cmd.name(), &args, ArgRole::Expr);
+        let expr_indices = registry.arg_indices_for_role(head, &args, ArgRole::Expr);
         for expr_idx in expr_indices {
             let word_index = expr_idx + 1;
             if let Some(tok) = cmd.argv.get(word_index)
@@ -198,7 +247,7 @@ fn walk(
                 && !inner_is_empty(full, tok)
             {
                 let mut child = scope.child();
-                recurse_token(full, tok, rule_module, registry, &mut child, out, depth + 1);
+                recurse_token(ctx, tok, &mut child, out, depth + 1);
             }
         }
 
@@ -215,7 +264,7 @@ fn walk(
         // a *fresh* call frame: it does not inherit the caller's `set`-bound
         // constants, only whatever its own actual arguments bind to its own
         // params (`lambda_frame_scope` builds exactly that).
-        for lambda_idx in registry.arg_indices_for_role(cmd.name(), &args, ArgRole::LambdaLiteral) {
+        for lambda_idx in registry.arg_indices_for_role(head, &args, ArgRole::LambdaLiteral) {
             let word_index = lambda_idx + 1;
             if let Some(tok) = cmd.argv.get(word_index)
                 && matches!(tok.kind, TokenType::Str)
@@ -227,16 +276,7 @@ fn walk(
                     && !inner.trim().is_empty()
                 {
                     let mut child = lambda_frame_scope(full, &cmd, lambda_idx, elems, scope);
-                    walk(
-                        full,
-                        inner,
-                        body_span.start(),
-                        rule_module,
-                        registry,
-                        &mut child,
-                        out,
-                        depth + 1,
-                    );
+                    walk(ctx, inner, body_span.start(), &mut child, out, depth + 1);
                 }
             }
         }
@@ -250,21 +290,13 @@ fn walk(
         // pool looked unreferenced, which is what `bigip-cleanup` decides
         // deletions from.  The clause-list shape is registry data
         // (`CommandSpec::case_list`), the same entry the token walker reads.
-        if let Some(spec) = registry.get(cmd.name()).and_then(|s| s.case_list)
+        if let Some(spec) = registry.get(head).and_then(|s| s.case_list)
             && let Some(tok) = case_list_word(&cmd, &args, spec)
             && !inner_is_empty(full, &tok)
         {
             for body in case_list_body_tokens(full, &tok, spec) {
                 let mut child = scope.child();
-                recurse_token(
-                    full,
-                    &body,
-                    rule_module,
-                    registry,
-                    &mut child,
-                    out,
-                    depth + 1,
-                );
+                recurse_token(ctx, &body, &mut child, out, depth + 1);
             }
         }
 
@@ -279,7 +311,7 @@ fn walk(
             }
             recursed.insert(key);
             let mut child = scope.child();
-            recurse_token(full, tok, rule_module, registry, &mut child, out, depth + 1);
+            recurse_token(ctx, tok, &mut child, out, depth + 1);
         }
     }
 }
@@ -392,28 +424,24 @@ fn inner_is_empty(full: &str, tok: &Token) -> bool {
 
 /// Recurse into a token's inner content (offset-adjusted to absolute spans).
 fn recurse_token(
-    full: &str,
+    ctx: &WalkCtx<'_>,
     tok: &Token,
-    rule_module: Option<&str>,
-    registry: &CommandRegistry,
     scope: &mut BindingScope,
     out: &mut Vec<IrulesObjectReference>,
     depth: u32,
 ) {
-    let (start, end) = content_range(full, tok);
+    let (start, end) = content_range(ctx.full, tok);
     if start >= end {
         return;
     }
-    let inner = &full[start..end];
+    let inner = &ctx.full[start..end];
     if inner.trim().is_empty() {
         return;
     }
     walk(
-        full,
+        ctx,
         inner,
         u32::try_from(start).unwrap_or(0),
-        rule_module,
-        registry,
         scope,
         out,
         depth,
@@ -513,8 +541,16 @@ fn resolve_arg_value(
 
 /// Record a `set <var> <literal>` constant binding, or widen on a non-literal
 /// RHS.
-fn record_set_binding(full: &str, cmd: &SegmentedCommand, scope: &mut BindingScope) {
-    if cmd.name() != "set" || cmd.args().len() < 2 {
+fn record_set_binding(
+    full: &str,
+    resolved_head: &str,
+    cmd: &SegmentedCommand,
+    scope: &mut BindingScope,
+) {
+    // The head is the *resolved* one, so `::set` and a proven alias / rename of
+    // it propagate constants exactly as the bare spelling does, and a `set`
+    // whose binding was provably taken over propagates none (issue #1275).
+    if resolved_head != "set" || cmd.args().len() < 2 {
         return;
     }
     let var = &cmd.args()[0];
@@ -559,6 +595,98 @@ mod tests {
         assert!(by_name.contains(&("class".to_owned(), "/Common/host_dg".to_owned())));
         assert!(by_name.contains(&("snatpool".to_owned(), "/Common/sp1".to_owned())));
         assert!(by_name.contains(&("pool".to_owned(), "/Common/web_pool".to_owned())));
+    }
+
+    /// Issue #1275 — the object-reference walk must resolve a command head's
+    /// *effective identity*, not its written spelling.
+    ///
+    /// This is not cosmetic for iRules: the reference graph is what
+    /// `bigip-cleanup` decides deletions from, so a pool reached only through
+    /// an aliased or renamed `pool` command must still count as referenced.
+    ///
+    /// tclsh oracle (8.6.16 and 9.0.4, byte-identical): `interp alias {} p {}
+    /// pool` makes `p` run `pool`; `rename pool p` moves it and leaves `pool`
+    /// gone; a top-level `proc pool …` takes the name over.
+    fn ref_names(source: &str) -> Vec<String> {
+        refs(source).into_iter().map(|r| r.name).collect()
+    }
+
+    /// A `when` body invoking `caller /Common/web_pool`, after `prelude`.
+    fn pool_rule(prelude: &str, caller: &str) -> String {
+        format!("{prelude}when HTTP_REQUEST {{\n    {caller} /Common/web_pool\n}}\n")
+    }
+
+    #[test]
+    fn object_refs_follow_an_aliased_command() {
+        assert_eq!(
+            ref_names(&pool_rule("interp alias {} p {} pool\n", "p")),
+            vec!["/Common/web_pool".to_owned()],
+        );
+        // The `::`-qualified spelling of the alias classifies alike.
+        assert_eq!(
+            ref_names(&pool_rule("interp alias {} p {} pool\n", "::p")),
+            vec!["/Common/web_pool".to_owned()],
+        );
+        // Guard: an unbound `p` names no BIG-IP object.
+        assert!(ref_names(&pool_rule("set y 1\n", "p")).is_empty());
+    }
+
+    #[test]
+    fn object_refs_follow_a_renamed_command() {
+        assert_eq!(
+            ref_names(&pool_rule("rename pool p\n", "p")),
+            vec!["/Common/web_pool".to_owned()],
+        );
+        // The old spelling is gone from the rename onwards.
+        assert!(
+            ref_names(&pool_rule("rename pool p\n", "pool")).is_empty(),
+            "a renamed-away `pool` must not keep the object-reference grammar"
+        );
+    }
+
+    #[test]
+    fn object_refs_abstain_for_a_command_shadowed_by_a_user_proc() {
+        assert!(
+            ref_names(&pool_rule("proc pool {args} { return 1 }\n", "pool")).is_empty(),
+            "a user `proc pool` takes the name over; its argument is not a pool name"
+        );
+        // Guard: the unshadowed command still resolves the reference.
+        assert_eq!(
+            ref_names(&pool_rule("set y 1\n", "pool")),
+            vec!["/Common/web_pool".to_owned()],
+        );
+    }
+
+    #[test]
+    fn object_refs_abstain_for_a_dynamic_binding() {
+        assert!(
+            ref_names(&pool_rule("rename $old p\n", "p")).is_empty(),
+            "a dynamic rename must not make `p` an object-reference command"
+        );
+        assert_eq!(
+            ref_names(&pool_rule("rename $old p\n", "pool")),
+            vec!["/Common/web_pool".to_owned()],
+            "a dynamic rename must not take `pool`'s grammar away either"
+        );
+    }
+
+    /// The `set`-constant propagation reads the resolved head too, so a pool
+    /// name bound through an aliased `set` still resolves.
+    #[test]
+    fn constant_propagation_follows_an_aliased_set() {
+        let source = "interp alias {} assign {} set\n\
+                      when HTTP_REQUEST {\n\
+                      assign p /Common/web_pool\n\
+                      pool $p\n\
+                      }\n";
+        assert_eq!(ref_names(source), vec!["/Common/web_pool".to_owned()]);
+        // Guard: without the alias, `assign` binds nothing and `$p` is unknown.
+        let source = "set y 1\n\
+                      when HTTP_REQUEST {\n\
+                      assign p /Common/web_pool\n\
+                      pool $p\n\
+                      }\n";
+        assert!(ref_names(source).is_empty());
     }
 
     /// Regression coverage for issue #996: `walk`/`recurse_token`'s mutual

--- a/rust/tcl-irules/src/walker.rs
+++ b/rust/tcl-irules/src/walker.rs
@@ -157,12 +157,8 @@ fn resolve_head<'a>(
     identities: &'a tcl_compiler::head_identity::HeadIdentityMap,
     cmd: &'a SegmentedCommand,
 ) -> &'a str {
-    let written = cmd.name();
-    if identities.is_empty() {
-        return written;
-    }
     let at = cmd.argv.first().map_or(0, |t| t.span.start());
-    identities.resolve(written, at).spec_name()
+    identities.head_words(cmd.name(), at).resolved
 }
 
 /// Segment `slice` (a substring of the rule starting at byte `base`) and

--- a/rust/tcl-lsp-core/src/declaration.rs
+++ b/rust/tcl-lsp-core/src/declaration.rs
@@ -207,13 +207,9 @@ fn collect_declarations_in_region(
         // and a spelling whose binding was provably taken over answers with
         // nothing, so no registry grammar is applied to it (issue #1275).
         let written = token_text(source, head_tok.span);
-        let head = if identities.is_empty() {
-            written
-        } else {
-            identities
-                .resolve(written, head_tok.span.start())
-                .spec_name()
-        };
+        let head = identities
+            .head_words(written, head_tok.span.start())
+            .resolved;
         // Argument tokens, excluding the command word — the coordinate
         // system the `var_scoping` index helpers expect.
         let arg_tokens = &cmd.argv[1..];

--- a/rust/tcl-lsp-core/src/declaration.rs
+++ b/rust/tcl-lsp-core/src/declaration.rs
@@ -79,12 +79,19 @@ pub fn declaration(
         visible.clone()
     };
 
+    // The document's proven command-identity facts, so a scoping statement is
+    // recognised by the command a head *is* rather than the one it is spelled
+    // as (issue #1275).  Empty — and lookup-free — unless the document binds
+    // something.
+    let identities =
+        tcl_compiler::head_identity::command_head_identities(source, dialect, registry);
     let scan = DeclScan {
         source,
         dialect,
         target,
         visible: &visible,
         registry,
+        identities: &identities,
         cursor,
     };
     let mut found = DeclSpans::default();
@@ -128,6 +135,12 @@ struct DeclScan<'a> {
     target: &'a str,
     visible: &'a [Span],
     registry: &'a CommandRegistry,
+    /// The document's statically proven command-identity facts
+    /// ([`tcl_compiler::head_identity`]): which registry command each head
+    /// spelling really names at each point in the file.  A head whose binding
+    /// was provably taken over resolves to nothing, so no scope-alias grammar
+    /// and no body recursion is applied to it.
+    identities: &'a tcl_compiler::head_identity::HeadIdentityMap,
     /// The cursor's byte offset. The analyser's scope tree does not model an
     /// `apply` lambda body as its own scope (it has no `proc`/`namespace
     /// eval`-style boundary), so `visible` never reflects it; recursing into
@@ -159,6 +172,7 @@ fn collect_declarations_in_region(
         scan.visible,
         scan.registry,
     );
+    let identities = scan.identities;
     let (mut start, mut end) = (region.start() as usize, region.end() as usize);
     if start >= end || end > source.len() {
         return;
@@ -187,7 +201,19 @@ fn collect_declarations_in_region(
         let Some(head_tok) = cmd.argv.first() else {
             continue;
         };
-        let head = token_text(source, head_tok.span);
+        // The head's *effective command identity*, resolved exactly as the
+        // semantic-token walk resolves it: a proven `interp alias` / `rename` /
+        // `namespace import` answers with the command the head really names,
+        // and a spelling whose binding was provably taken over answers with
+        // nothing, so no registry grammar is applied to it (issue #1275).
+        let written = token_text(source, head_tok.span);
+        let head = if identities.is_empty() {
+            written
+        } else {
+            identities
+                .resolve(written, head_tok.span.start())
+                .spec_name()
+        };
         // Argument tokens, excluding the command word — the coordinate
         // system the `var_scoping` index helpers expect.
         let arg_tokens = &cmd.argv[1..];
@@ -471,5 +497,128 @@ mod tests {
         let locs = declaration(src, 1, 2, "tcl8.6", &analysis, &reg());
         assert_eq!(locs.len(), 1, "{locs:?}");
         assert_eq!(locs[0].start_line, 0);
+    }
+
+    /// Issue #1275 — the declaration scan must resolve a command head's
+    /// *effective identity*, not its written spelling.
+    ///
+    /// tclsh oracle (8.6.16 and 9.0.4, byte-identical): `interp alias {} decl
+    /// {} upvar` makes `decl 1 other local` alias the caller's variable;
+    /// `rename upvar decl` does the same and leaves `upvar` gone; `proc upvar
+    /// …` takes the name over so the built-in's grammar no longer applies.
+    ///
+    /// The probe drives [`collect_declarations_in_region`] — the scan this
+    /// issue changed — rather than the public [`declaration`] entry point.
+    /// When the scan finds nothing, `declaration` falls back to plain
+    /// go-to-definition, which reads the **analyser's** own scope model: a
+    /// separate consumer that still resolves scope aliases by spelling, and
+    /// which therefore answers with the identical span and would mask every
+    /// abstention this test exists to pin.
+    fn scanned_declaration_lines(src: &str, target: &str) -> Vec<u32> {
+        let registry = reg();
+        let identities =
+            tcl_compiler::head_identity::command_head_identities(src, "tcl8.6", &registry);
+        let end = u32::try_from(src.len()).unwrap_or(0);
+        let scan = DeclScan {
+            source: src,
+            dialect: "tcl8.6",
+            target,
+            visible: &[],
+            registry: &registry,
+            identities: &identities,
+            cursor: end,
+        };
+        let mut found = DeclSpans::default();
+        collect_declarations_in_region(&scan, Span::new(0, end), 0, &mut found);
+        let line_index = LineIndex::new(src);
+        let mut lines: Vec<u32> = found
+            .spans
+            .iter()
+            .map(|s| line_index.line_at(s.start()))
+            .collect();
+        lines.sort_unstable();
+        lines
+    }
+
+    /// `proc wrap` whose body declares `local` through `declarator`, preceded
+    /// by `prelude`.  The declarator always lands on line `prelude_lines + 1`.
+    fn upvar_body(prelude: &str, declarator: &str) -> String {
+        format!(
+            "{prelude}proc wrap {{}} {{\n\
+             {declarator} 1 other local\n\
+             return $local\n\
+             }}\n"
+        )
+    }
+
+    #[test]
+    fn declaration_scan_follows_an_aliased_scoping_command() {
+        let src = upvar_body("interp alias {} decl {} upvar\n", "decl");
+        assert_eq!(scanned_declaration_lines(&src, "local"), vec![2]);
+        // The `::`-qualified spelling of the alias classifies alike.
+        let src = upvar_body("interp alias {} decl {} upvar\n", "::decl");
+        assert_eq!(scanned_declaration_lines(&src, "local"), vec![2]);
+        // Guard: an unbound `decl` declares nothing.
+        let src = upvar_body("set y 1\n", "decl");
+        assert!(scanned_declaration_lines(&src, "local").is_empty());
+    }
+
+    #[test]
+    fn declaration_scan_follows_a_renamed_scoping_command() {
+        let src = upvar_body("rename upvar decl\n", "decl");
+        assert_eq!(scanned_declaration_lines(&src, "local"), vec![2]);
+        // The old spelling is gone from the rename onwards.
+        let src = upvar_body("rename upvar decl\n", "upvar");
+        assert!(
+            scanned_declaration_lines(&src, "local").is_empty(),
+            "a renamed-away `upvar` must not keep the built-in's grammar"
+        );
+    }
+
+    #[test]
+    fn declaration_scan_abstains_for_a_builtin_shadowed_by_a_user_proc() {
+        let src = upvar_body("proc upvar {args} { return 1 }\n", "upvar");
+        assert!(
+            scanned_declaration_lines(&src, "local").is_empty(),
+            "a user `proc upvar` takes the name over; no scope-alias grammar applies"
+        );
+        // Guard: the unshadowed built-in still declares.
+        let src = upvar_body("set y 1\n", "upvar");
+        assert_eq!(scanned_declaration_lines(&src, "local"), vec![2]);
+    }
+
+    #[test]
+    fn declaration_scan_abstains_for_a_dynamic_binding() {
+        let src = upvar_body("rename $old decl\n", "decl");
+        assert!(
+            scanned_declaration_lines(&src, "local").is_empty(),
+            "a dynamic rename must not make `decl` a scoping statement"
+        );
+        let src = upvar_body("rename $old decl\n", "upvar");
+        assert_eq!(
+            scanned_declaration_lines(&src, "local"),
+            vec![2],
+            "a dynamic rename must not take `upvar`'s grammar away either"
+        );
+    }
+
+    /// The body recursion is registry-driven too: a `global` buried in an
+    /// aliased control-flow body is only reached if the alias resolves to the
+    /// command whose argument carries `ArgRole::Body`.
+    #[test]
+    fn declaration_scan_recurses_through_an_aliased_body_command() {
+        let src = "interp alias {} maybe {} if\n\
+                   proc p {} {\n\
+                   maybe {[info exists x]} { global x }\n\
+                   puts $x\n\
+                   }\n";
+        assert_eq!(scanned_declaration_lines(src, "x"), vec![2]);
+        // Guard: an unbound `maybe` carries no body argument to recurse into.
+        let src = "set y 1\n\
+                   proc p {} {\n\
+                   maybe {[info exists x]} { global x }\n\
+                   puts $x\n\
+                   }\n";
+        assert!(scanned_declaration_lines(src, "x").is_empty());
     }
 }

--- a/rust/tcl-lsp-core/src/folding.rs
+++ b/rust/tcl-lsp-core/src/folding.rs
@@ -374,15 +374,8 @@ fn resolve_head<'a>(
     identities: &'a tcl_compiler::head_identity::HeadIdentityMap,
     cmd: &'a tcl_compiler::segmenter::SegmentedCommand,
 ) -> HeadWords<'a> {
-    let written = cmd.name();
-    if identities.is_empty() {
-        return HeadWords::plain(written);
-    }
     let at = cmd.argv.first().map_or(0, |t| t.span.start());
-    HeadWords {
-        written,
-        resolved: identities.resolve(written, at).spec_name(),
-    }
+    identities.head_words(cmd.name(), at)
 }
 
 fn collect_body_folds(

--- a/rust/tcl-lsp-core/src/folding.rs
+++ b/rust/tcl-lsp-core/src/folding.rs
@@ -1659,9 +1659,9 @@ mod tests {
         );
         // The `::`-qualified spelling of the alias classifies alike.
         assert!(
-            body_fold_on_call_line(&format!(
-                "interp alias {{}} loop {{}} while\n::loop {{$x}} {{\n    puts a\n    puts b\n}}\n"
-            )),
+            body_fold_on_call_line(
+                "interp alias {} loop {} while\n::loop {$x} {\n    puts a\n    puts b\n}\n"
+            ),
             "`::loop` must fold exactly like `loop`"
         );
         // Guard: the same call with no alias folds nothing — `loop` is an

--- a/rust/tcl-lsp-core/src/folding.rs
+++ b/rust/tcl-lsp-core/src/folding.rs
@@ -44,7 +44,7 @@ use tcl_compiler::segmenter::segment_commands_with_offset_and_config;
 use tcl_lexer::{Lexer, LineIndex, TokenType};
 use tcl_registry::{ArgRole, CommandRegistry};
 
-use crate::oo_body::{is_member, member_body_indices, next_definition_grammar};
+use crate::oo_body::{HeadWords, is_member, member_body_indices, next_definition_grammar};
 use tcl_registry::definer::DefinitionBodyGrammar;
 
 /// LSP folding-range kind.
@@ -123,8 +123,11 @@ pub fn folding_ranges(
     );
     collect_comment_folds(source, &mut seen, &mut ranges);
     collect_continuation_folds(source, &line_index, &mut seen, &mut ranges);
+    let identities =
+        tcl_compiler::head_identity::command_head_identities(source, dialect, registry);
     let mut ctx = FoldCtx {
         registry,
+        identities: &identities,
         line_index: &line_index,
         original_source: source,
         seen: &mut seen,
@@ -340,6 +343,11 @@ fn collect_continuation_folds(
 /// vary per call — they stay as direct parameters.
 struct FoldCtx<'a> {
     registry: &'a CommandRegistry,
+    /// The document's statically proven command-identity facts, so a body-arg
+    /// role is resolved against the command a head *is* rather than the one it
+    /// is spelled as (issue #1275).  Empty — and lookup-free — for the
+    /// overwhelmingly common document that binds nothing.
+    identities: &'a tcl_compiler::head_identity::HeadIdentityMap,
     line_index: &'a LineIndex,
     original_source: &'a str,
     seen: &'a mut FxHashSet<(u32, u32)>,
@@ -355,6 +363,27 @@ struct FoldCtx<'a> {
 /// compiler analyser's `MAX_BODY_DEPTH` so deeply (but validly) nested code
 /// keeps full folding support. Real source never nests anywhere near this.
 const MAX_FOLD_DEPTH: tcl_core_types::RecursionLimit = tcl_core_types::RecursionLimit(256);
+
+/// One segmented command's head, as written and as it resolves.
+///
+/// The written spelling is sliced from the command itself; the resolved name
+/// comes from the document's [`HeadIdentityMap`](tcl_compiler::head_identity::HeadIdentityMap)
+/// at the head's own byte offset, so a binding never retroactively re-tags an
+/// earlier call.  A document that binds nothing skips the lookup entirely.
+fn resolve_head<'a>(
+    identities: &'a tcl_compiler::head_identity::HeadIdentityMap,
+    cmd: &'a tcl_compiler::segmenter::SegmentedCommand,
+) -> HeadWords<'a> {
+    let written = cmd.name();
+    if identities.is_empty() {
+        return HeadWords::plain(written);
+    }
+    let at = cmd.argv.first().map_or(0, |t| t.span.start());
+    HeadWords {
+        written,
+        resolved: identities.resolve(written, at).spec_name(),
+    }
+}
 
 fn collect_body_folds(
     body_source: &str,
@@ -379,6 +408,15 @@ fn collect_body_folds(
             continue;
         }
         let args_borrow: Vec<&str> = cmd.args().iter().map(String::as_str).collect();
+        // The head's *effective command identity*, resolved exactly as the
+        // semantic-token walk resolves it: a proven `interp alias` / `rename` /
+        // `namespace import` answers with the command the head really names, and
+        // a spelling whose binding was provably taken over answers with nothing,
+        // so no registry grammar is applied to it (issue #1275).  The member
+        // sub-keyword test below deliberately keeps the *written* spelling —
+        // `method` inside a class body is a lexical keyword, not a command
+        // binding a top-level `rename` could move.
+        let head = resolve_head(ctx.identities, cmd);
 
         // Outer definer commands (`oo::class`, `oo::define`, `snit::type`, …)
         // carry their body-arg shapes in the registry — `arg_indices_for_role`
@@ -387,10 +425,12 @@ fn collect_body_folds(
         // no `CommandSpec`; their body indices come from the enclosing
         // definition-body grammar ([`crate::oo_body`]).
         let body_indices: Vec<usize> = match oo_grammar {
-            Some(g) if is_member(g, cmd.name()) => member_body_indices(g, cmd.name(), &args_borrow),
+            Some(g) if is_member(g, head.written) => {
+                member_body_indices(g, head.written, &args_borrow)
+            }
             _ => ctx
                 .registry
-                .arg_indices_for_role(cmd.name(), &args_borrow, ArgRole::Body),
+                .arg_indices_for_role(head.resolved, &args_borrow, ArgRole::Body),
         };
 
         // A clause-list command (`switch … {pat body …}`, Expect's `expect
@@ -403,7 +443,7 @@ fn collect_body_folds(
         // walk names no command.
         let case_list = ctx
             .registry
-            .get(cmd.name())
+            .get(head.resolved)
             .and_then(|s| s.case_list)
             .and_then(|spec| {
                 tcl_syntax::case_list::clause_list_call(&args_borrow, &call_shape(spec))
@@ -413,8 +453,7 @@ fn collect_body_folds(
         // The grammar the recursion into THIS command's bodies should carry:
         // outer definer bodies switch to their grammar, member bodies switch
         // off, everything else inherits.
-        let next_grammar =
-            next_definition_grammar(cmd.name(), &args_borrow, oo_grammar, ctx.registry);
+        let next_grammar = next_definition_grammar(head, &args_borrow, oo_grammar, ctx.registry);
 
         for idx in body_indices {
             let arg_tokens = cmd.arg_tokens();
@@ -475,7 +514,7 @@ fn collect_body_folds(
             );
         }
 
-        collect_lambda_folds(cmd, &args_borrow, depth, ctx);
+        collect_lambda_folds(cmd, head.resolved, &args_borrow, depth, ctx);
     }
 }
 
@@ -487,13 +526,14 @@ fn collect_body_folds(
 /// the real body's own nested folds.
 fn collect_lambda_folds(
     cmd: &tcl_compiler::segmenter::SegmentedCommand,
+    resolved_head: &str,
     args: &[&str],
     depth: u32,
     ctx: &mut FoldCtx<'_>,
 ) {
     for idx in ctx
         .registry
-        .arg_indices_for_role(cmd.name(), args, ArgRole::LambdaLiteral)
+        .arg_indices_for_role(resolved_head, args, ArgRole::LambdaLiteral)
     {
         let arg_tokens = cmd.arg_tokens();
         let Some(&lambda_tok) = arg_tokens.get(idx) else {
@@ -1593,5 +1633,91 @@ mod tests {
                 r.end_line,
             );
         }
+    }
+
+    /// Issue #1275 — folding must resolve a command head's *effective
+    /// identity*, not its written spelling.
+    ///
+    /// `while`'s second word is `ArgRole::Body`; nothing else in the provider
+    /// folds it (the analyser's scope walk only covers `proc` / `namespace
+    /// eval` bodies), so a fold starting on the call's own line is a clean
+    /// witness that the body role was resolved.
+    ///
+    /// tclsh oracle (8.6.16 and 9.0.4, byte-identical): after `interp alias {}
+    /// loop {} while` a `loop` call runs `while`; after `rename while loop` the
+    /// same holds and `while` itself is gone (`info commands while` → empty);
+    /// after `proc while …` the call runs the user proc.
+    fn body_fold_on_call_line(source: &str) -> bool {
+        folding_ranges_default(source, "tcl8.6")
+            .iter()
+            .any(|r| r.kind == FoldKind::Region && r.start_line == 1)
+    }
+
+    const REBOUND_CALL: &str = "loop {$x} {\n    puts a\n    puts b\n}\n";
+    const WRITTEN_CALL: &str = "while {$x} {\n    puts a\n    puts b\n}\n";
+
+    #[test]
+    fn folding_folds_an_aliased_body_command() {
+        assert!(
+            body_fold_on_call_line(&format!(
+                "interp alias {{}} loop {{}} while\n{REBOUND_CALL}"
+            )),
+            "an alias of `while` must contribute `while`'s body fold"
+        );
+        // The `::`-qualified spelling of the alias classifies alike.
+        assert!(
+            body_fold_on_call_line(&format!(
+                "interp alias {{}} loop {{}} while\n::loop {{$x}} {{\n    puts a\n    puts b\n}}\n"
+            )),
+            "`::loop` must fold exactly like `loop`"
+        );
+        // Guard: the same call with no alias folds nothing — `loop` is an
+        // ordinary unknown command with no body argument.
+        assert!(
+            !body_fold_on_call_line(&format!("set y 1\n{REBOUND_CALL}")),
+            "an unbound `loop` has no body role"
+        );
+    }
+
+    #[test]
+    fn folding_folds_a_renamed_body_command_and_drops_the_old_name() {
+        assert!(
+            body_fold_on_call_line(&format!("rename while loop\n{REBOUND_CALL}")),
+            "`rename while loop` must move `while`'s body grammar to `loop`"
+        );
+        // … and the old spelling is gone from the rename onwards, so it must
+        // abstain rather than keep folding.
+        assert!(
+            !body_fold_on_call_line(&format!("rename while loop\n{WRITTEN_CALL}")),
+            "a renamed-away `while` must not keep the built-in's body grammar"
+        );
+    }
+
+    #[test]
+    fn folding_abstains_for_a_builtin_shadowed_by_a_user_proc() {
+        assert!(
+            !body_fold_on_call_line(&format!(
+                "proc while {{c b}} {{ return 1 }}\n{WRITTEN_CALL}"
+            )),
+            "a user `proc while` takes the name over; no registry body grammar applies"
+        );
+        // Guard: without the shadowing proc the very same call folds.
+        assert!(
+            body_fold_on_call_line(&format!("set y 1\n{WRITTEN_CALL}")),
+            "the unshadowed built-in still folds"
+        );
+    }
+
+    #[test]
+    fn folding_abstains_for_a_dynamic_binding() {
+        // `rename $old loop` proves nothing about either name.
+        assert!(
+            !body_fold_on_call_line(&format!("rename $old loop\n{REBOUND_CALL}")),
+            "a dynamic rename must not give `loop` a body grammar"
+        );
+        assert!(
+            body_fold_on_call_line(&format!("rename $old loop\n{WRITTEN_CALL}")),
+            "a dynamic rename must not take `while`'s body grammar away either"
+        );
     }
 }

--- a/rust/tcl-lsp-core/src/formatting/engine.rs
+++ b/rust/tcl-lsp-core/src/formatting/engine.rs
@@ -404,12 +404,10 @@ fn identify_body_args(
     // no document-absolute offset exists here.  `resolve_unpositioned` folds
     // every fact about the spelling and abstains when they disagree, rather
     // than falling back to the written name.
-    if !identities.is_empty() {
-        cmd.resolved_name = identities
-            .resolve_unpositioned(&cmd.name)
-            .spec_name()
-            .to_owned();
-    }
+    cmd.resolved_name = identities
+        .head_words_unpositioned(&cmd.name)
+        .resolved
+        .to_owned();
     let name = cmd.resolved_name.clone();
     // Post-name argument texts, owned so the immutable borrow of
     // `cmd.args` is released before the role-driven mutation below.

--- a/rust/tcl-lsp-core/src/formatting/engine.rs
+++ b/rust/tcl-lsp-core/src/formatting/engine.rs
@@ -110,6 +110,13 @@ struct CommentLine {
 /// A single Tcl command with its arguments, ready for reformatting.
 struct ParsedCommand {
     name: String,
+    /// The registry name [`Self::name`] effectively resolves to — the command
+    /// this call really *is* once the document's `namespace import` / `interp
+    /// alias` / `rename` / built-in-shadowing `proc` statements are folded in
+    /// (issue #1275).  Equal to [`Self::name`] until [`identify_body_args`]
+    /// resolves it, and empty for a head whose binding was provably taken over,
+    /// which every registry query then answers "unknown" for.
+    resolved_name: String,
     args: Vec<CommandArg>,
     preceding_comments: Vec<CommentLine>,
     preceding_blank_lines: usize,
@@ -267,6 +274,7 @@ fn parse_commands(
             .map(|a| a.text.clone())
             .unwrap_or_default();
         commands.push(ParsedCommand {
+            resolved_name: name.clone(),
             name,
             args: taken_args,
             preceding_comments: std::mem::take(pending_comments),
@@ -369,7 +377,11 @@ fn parse_commands(
 /// Because the lookup goes through the registry, the explicitly-global
 /// spellings (`::if`, `::for`, `::try`) resolve to the same grammar as their
 /// bare forms — a false negative the old literal name comparisons had.
-fn identify_body_args(cmd: &mut ParsedCommand, registry: &CommandRegistry) {
+fn identify_body_args(
+    cmd: &mut ParsedCommand,
+    registry: &CommandRegistry,
+    identities: &tcl_compiler::head_identity::HeadIdentityMap,
+) {
     // {*}-expanded command word: dynamic identity, skip.
     if cmd
         .args
@@ -380,7 +392,25 @@ fn identify_body_args(cmd: &mut ParsedCommand, registry: &CommandRegistry) {
         return;
     }
 
-    let name = cmd.name.clone();
+    // Resolve the head's *effective command identity* once, and let every
+    // registry-driven decision below — body / keyword / param-list / lambda
+    // roles, presentation, expression bracing, keyword rewrites, the traits —
+    // key off it (issue #1275).  Without this a document doing `rename format
+    // origfmt` or `interp alias {} myfmt {} format` was still laid out under
+    // the grammar of the command it no longer is.
+    //
+    // The read is *unpositioned*: this engine re-lexes each nested body out of
+    // its own decoded `arg.text`, and range formatting lexes a line slice, so
+    // no document-absolute offset exists here.  `resolve_unpositioned` folds
+    // every fact about the spelling and abstains when they disagree, rather
+    // than falling back to the written name.
+    if !identities.is_empty() {
+        cmd.resolved_name = identities
+            .resolve_unpositioned(&cmd.name)
+            .spec_name()
+            .to_owned();
+    }
+    let name = cmd.resolved_name.clone();
     // Post-name argument texts, owned so the immutable borrow of
     // `cmd.args` is released before the role-driven mutation below.
     let arg_texts: Vec<String> = cmd.args.iter().skip(1).map(|a| a.text.clone()).collect();
@@ -429,7 +459,7 @@ fn identify_body_args(cmd: &mut ParsedCommand, registry: &CommandRegistry) {
 fn identify_expr_args(cmd: &ParsedCommand, registry: &CommandRegistry) -> Vec<usize> {
     let arg_texts: Vec<&str> = cmd.args.iter().skip(1).map(|a| a.text.as_str()).collect();
     registry
-        .arg_indices_for_role(&cmd.name, &arg_texts, ArgRole::Expr)
+        .arg_indices_for_role(&cmd.resolved_name, &arg_texts, ArgRole::Expr)
         .into_iter()
         .map(|idx| idx + 1)
         .collect()
@@ -505,6 +535,7 @@ fn format_switch_body(
     body_text: &str,
     config: &FormatterConfig,
     registry: &CommandRegistry,
+    identities: &tcl_compiler::head_identity::HeadIdentityMap,
     indent_level: usize,
 ) -> String {
     let sm = SourceMap::new(body_text);
@@ -515,7 +546,7 @@ fn format_switch_body(
     };
 
     let elements = segment_switch_elements(&sm, tokens);
-    let lines = emit_switch_lines(&elements, &sm, config, registry, indent_level);
+    let lines = emit_switch_lines(&elements, &sm, config, registry, identities, indent_level);
     lines.join("\n")
 }
 
@@ -589,6 +620,7 @@ fn emit_switch_lines(
     sm: &SourceMap,
     config: &FormatterConfig,
     registry: &CommandRegistry,
+    identities: &tcl_compiler::head_identity::HeadIdentityMap,
     indent_level: usize,
 ) -> Vec<String> {
     let indent = config.make_indent(indent_level);
@@ -621,7 +653,7 @@ fn emit_switch_lines(
             if body.text == "-" {
                 lines.push(format!("{indent}{pattern_raw} -"));
             } else if body.is_braced {
-                let formatted = format_body(&body.text, config, registry, inner_level);
+                let formatted = format_body(&body.text, config, registry, identities, inner_level);
                 if formatted.trim().is_empty() {
                     lines.push(format!("{indent}{pattern_raw} {{}}"));
                 } else {
@@ -1237,10 +1269,17 @@ fn keyword_rewrites_for(
         .dialect
         .as_deref()
         .and_then(tcl_registry::prelude::DialectSet::parse);
-    super::keywords::rewrites_for_command(registry, dialect, config, &cmd.name, &words, &dynamic)
-        .into_iter()
-        .map(|r| (r.index + 1, r.text))
-        .collect()
+    super::keywords::rewrites_for_command(
+        registry,
+        dialect,
+        config,
+        &cmd.resolved_name,
+        &words,
+        &dynamic,
+    )
+    .into_iter()
+    .map(|r| (r.index + 1, r.text))
+    .collect()
 }
 
 /// Reconstruct a single command as formatted text.
@@ -1252,13 +1291,13 @@ fn reconstruct_command(
     indent: &str,
     indent_level: usize,
 ) -> String {
-    if cmd.name == "switch" {
+    if cmd.resolved_name == "switch" {
         return reconstruct_switch(sm, cmd, config, indent);
     }
 
     let expr_args = identify_expr_args(cmd, registry);
     let keyword_rewrites = keyword_rewrites_for(cmd, registry, config);
-    let spec_traits = registry.get(&cmd.name).map(|s| s.traits);
+    let spec_traits = registry.get(&cmd.resolved_name).map(|s| s.traits);
     let never_inline = spec_traits.is_some_and(|t| t.contains(Traits::NEVER_INLINE_BODY));
 
     let mut parts: Vec<String> = Vec::new();
@@ -1455,6 +1494,7 @@ pub(crate) fn format_body(
     source: &str,
     config: &FormatterConfig,
     registry: &CommandRegistry,
+    identities: &tcl_compiler::head_identity::HeadIdentityMap,
     indent_level: usize,
 ) -> String {
     // Native-stack safety net — see `MAX_FORMAT_DEPTH`'s doc comment
@@ -1488,19 +1528,19 @@ pub(crate) fn format_body(
             emit_comment_lines(comment, config, &indent, indent_level, &mut lines);
         }
 
-        identify_body_args(&mut commands[i], registry);
+        identify_body_args(&mut commands[i], registry, identities);
 
         // Switch needs its body formatted from arg.text via the
         // pattern/body splitter; other bodies recurse normally.
-        let is_switch = commands[i].name == "switch";
+        let is_switch = commands[i].resolved_name == "switch";
         let arg_count = commands[i].args.len();
         for a in 0..arg_count {
             if commands[i].args[a].kind == ArgKind::Body && commands[i].args[a].is_braced {
                 let body_text = commands[i].args[a].text.clone();
                 let formatted = if is_switch {
-                    format_switch_body(&body_text, config, registry, inner_level)
+                    format_switch_body(&body_text, config, registry, identities, inner_level)
                 } else {
-                    format_body(&body_text, config, registry, inner_level)
+                    format_body(&body_text, config, registry, identities, inner_level)
                 };
                 commands[i].args[a].formatted_body = Some(formatted);
             } else if commands[i].args[a].kind == ArgKind::LambdaLiteral
@@ -1518,7 +1558,7 @@ pub(crate) fn format_body(
                 // must be collapsed before the result is parsed as a script,
                 // exactly as Tcl's own list-then-script evaluation would
                 // (codex review of #954's follow-up).
-                let formatted = format_body(&body_text, config, registry, inner_level);
+                let formatted = format_body(&body_text, config, registry, identities, inner_level);
                 commands[i].args[a].formatted_body = Some(formatted);
             }
         }
@@ -1640,7 +1680,15 @@ pub(crate) fn trim_trailing_ws_preserving_literals(text: &str) -> String {
 /// formatted source out.
 #[must_use]
 pub fn format_tcl(source: &str, config: &FormatterConfig, registry: &CommandRegistry) -> String {
-    let mut result = format_body(source, config, registry, 0);
+    // The document's command-identity facts, computed once for the whole file
+    // (issue #1275).  Empty — and lookup-free — unless the document binds
+    // something.
+    let identities = tcl_compiler::head_identity::command_head_identities_with_config(
+        source,
+        config.lexer_config,
+        registry,
+    );
+    let mut result = format_body(source, config, registry, &identities, 0);
 
     if config.trim_trailing_whitespace {
         result = trim_trailing_ws_preserving_literals(&result);
@@ -2366,5 +2414,79 @@ mod tests {
             "proc a {} {\nreturn\n}\nproc b {} {\nreturn\n}\n",
             "proc a {} {\n    return\n}\n\nproc b {} {\n    return\n}\n",
         );
+    }
+    /// Issue #1275 — the formatter must lay a command out under the grammar
+    /// of the command it *is*, not the one it is spelled as.
+    ///
+    /// This is the user-visible half of the issue: an `ArgRole::Body` argument
+    /// is expanded onto its own lines, so a rebound body-bearing command that
+    /// resolved by spelling was formatted under a grammar it no longer had.
+    ///
+    /// tclsh oracle (8.6.16 and 9.0.4, byte-identical): `interp alias {} maybe
+    /// {} if` makes `maybe` run `if`; `rename if maybe` moves it and leaves
+    /// `if` gone; a top-level `proc if …` takes the name over.
+    fn body_was_expanded(src: &str) -> bool {
+        fmt(src).contains("{\n    puts a\n}")
+    }
+
+    #[test]
+    fn formatting_follows_an_aliased_body_command() {
+        assert!(body_was_expanded(
+            "interp alias {} maybe {} if\nmaybe {$x} {puts a}\n"
+        ));
+        // The `::`-qualified spelling of the alias classifies alike.
+        assert!(body_was_expanded(
+            "interp alias {} maybe {} if\n::maybe {$x} {puts a}\n"
+        ));
+        // Guard: an unbound `maybe` has no body argument, so its braced word
+        // is left exactly as written.
+        assert!(!body_was_expanded("set y 1\nmaybe {$x} {puts a}\n"));
+    }
+
+    #[test]
+    fn formatting_follows_a_renamed_body_command() {
+        assert!(body_was_expanded("rename if maybe\nmaybe {$x} {puts a}\n"));
+        // The old spelling is gone from the rename onwards.
+        assert!(
+            !body_was_expanded("rename if maybe\nif {$x} {puts a}\n"),
+            "a renamed-away `if` must not keep the built-in's layout"
+        );
+    }
+
+    #[test]
+    fn formatting_abstains_for_a_builtin_shadowed_by_a_user_proc() {
+        assert!(
+            !body_was_expanded("proc if {c b} { return 1 }\nif {$x} {puts a}\n"),
+            "a user `proc if` takes the name over; no registry layout applies"
+        );
+        // Guard: the unshadowed built-in still expands.
+        assert!(body_was_expanded("set y 1\nif {$x} {puts a}\n"));
+    }
+
+    #[test]
+    fn formatting_abstains_for_a_dynamic_binding() {
+        assert!(
+            !body_was_expanded("rename $old maybe\nmaybe {$x} {puts a}\n"),
+            "a dynamic rename must not give `maybe` a body layout"
+        );
+        assert!(
+            body_was_expanded("rename $old maybe\nif {$x} {puts a}\n"),
+            "a dynamic rename must not take `if`'s layout away either"
+        );
+    }
+
+    /// The clause-list layout is head-driven too: `switch`'s pattern/body
+    /// pairs are laid out by [`format_switch_body`], which the reconstruction
+    /// picks by the *resolved* head.
+    #[test]
+    fn formatting_follows_an_aliased_clause_list_command() {
+        let formatted = fmt("interp alias {} pick {} switch\npick $v {a {puts 1} b {puts 2}}\n");
+        assert!(
+            formatted.contains("a {\n        puts 1\n    }"),
+            "an alias of `switch` must get the clause-list layout; got:\n{formatted}"
+        );
+        // Guard: an unbound `pick` keeps its braced word verbatim.
+        let formatted = fmt("set y 1\npick $v {a {puts 1} b {puts 2}}\n");
+        assert!(!formatted.contains("a {\n        puts 1\n    }"));
     }
 }

--- a/rust/tcl-lsp-core/src/formatting/mod.rs
+++ b/rust/tcl-lsp-core/src/formatting/mod.rs
@@ -176,8 +176,16 @@ pub fn range_formatting(
     // against the whole document, not the slice, so a one-line selection in a
     // CRLF file is not re-emitted with `\n`.
     let line_ending = config.resolved_line_ending(source);
+    // The identity facts come from the **whole document**, not the slice: a
+    // `rename` above the selection still governs what the selected commands
+    // are (issue #1275).
+    let identities = tcl_compiler::head_identity::command_head_identities_with_config(
+        source,
+        config.lexer_config,
+        registry,
+    );
     let formatted_slice = finalise_slice(
-        &engine::format_body(&slice_text, config, registry, depth),
+        &engine::format_body(&slice_text, config, registry, &identities, depth),
         config,
         line_ending,
     );

--- a/rust/tcl-lsp-core/src/head_identity.rs
+++ b/rust/tcl-lsp-core/src/head_identity.rs
@@ -1,0 +1,459 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Effective command identity for a command head (issue #1185).
+//!
+//! Tcl resolves a command by its interpreter-level *binding*, not by the
+//! spelling used to invoke it.  Three statically visible statements move that
+//! binding, and this module turns the ones a document states unconditionally
+//! at top level into a small, offset-keyed table the source-text consumers
+//! (semantic tokens today) consult before they hand a head to the registry:
+//!
+//! ```tcl
+//! namespace import ::tcltest::*   ;# `test`   now *is* `::tcltest::test`
+//! interp alias {} myfmt {} format ;# `myfmt`  now *is* `format`
+//! rename format origfmt           ;# `origfmt` is `format`, and `format` is gone
+//! proc format {args} { … }        ;# `format` is a user proc, not the built-in
+//! ```
+//!
+//! Every fact carries the byte offset of the statement that established it and
+//! applies only to heads **at or after** it, so an alias cannot retroactively
+//! re-tag an earlier call and a `rename` correctly leaves the calls before it
+//! alone.  Verified against tclsh 9.0.4 and 8.6.16 (byte-identical): after
+//! `rename format origfmt; proc format {args} {return USER}`, `format x`
+//! answers `USER` and `origfmt %d 7` answers `7`.
+//!
+//! # What this deliberately does not do
+//!
+//! The table is **sound by abstention** — every shape it cannot prove leaves
+//! the head unchanged, and every shape that provably *breaks* a registry
+//! binding marks the head [`HeadIdentity::Rebound`] so no registry grammar is
+//! applied to it.  Specifically:
+//!
+//! * **Dynamic heads and dynamic bindings** — `rename $old new`,
+//!   `interp alias {} $n {} eval`, `interp alias {} n {} $t` — record nothing
+//!   ([`tcl_syntax::naming::is_dynamic_word`] rejects them), so a call through
+//!   the name keeps its literal identity rather than gaining a wrong one.
+//! * **Pre-bound alias arguments** — `interp alias {} pad {} format %08x`
+//!   shifts every argument index, so the layout cannot be reused; the alias
+//!   name is marked `Rebound` instead of aliased.
+//! * **Another interpreter** — a non-empty `srcPath` (`interp alias slave …`)
+//!   binds a name in a *child* interpreter and changes nothing here, so it
+//!   records nothing at all; a non-empty `targetPath` points at a command this
+//!   document cannot see, so the name is marked `Rebound`.  Hidden commands in
+//!   a safe interpreter are likewise invisible: this document's own command
+//!   table is what is being described.
+//! * **Conditional or nested bindings** — only *top-level* statements are
+//!   scanned.  A `rename` inside an `if` body, a proc, an `eval`, or a
+//!   `namespace eval` block is not an unconditional document-wide fact, and a
+//!   `proc` inside `namespace eval ::n` defines `::n::format`, not `::format`
+//!   (tclsh 9.0.4: `::n::format q` → `ns:q`, global `format` untouched).
+//! * **`unknown` fallback and traces** — nothing is inferred from them.
+
+use rustc_hash::FxHashMap;
+use tcl_compiler::alias::{detect_interp_alias, detect_interp_alias_delete, detect_rename};
+use tcl_compiler::segmenter::segment_commands_with_offset_and_config;
+use tcl_registry::{CommandRegistry, CommandTableEffect};
+use tcl_syntax::naming::is_dynamic_word;
+
+/// What a command head resolves to at one point in a document.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HeadIdentity<'a> {
+    /// The head names this registry command — the head text itself when no
+    /// fact applies, or the effective target of a proven import / alias /
+    /// rename.
+    Command(&'a str),
+    /// The head's binding was provably taken over by something the registry
+    /// does not model: a `rename` moved the built-in away, a user `proc`
+    /// redefined it, or an alias bound it to an unresolvable target.  No
+    /// registry grammar applies.
+    Rebound,
+}
+
+impl<'a> HeadIdentity<'a> {
+    /// The name to resolve registry grammar against.
+    ///
+    /// [`Self::Rebound`] answers with the empty string, which
+    /// [`CommandRegistry::get`] never resolves — so every registry query a
+    /// consumer already makes (`arg_indices_for_role`, `format_string_args`,
+    /// `handle_binding`, …) answers "not a known command" without that
+    /// consumer testing the variant.
+    pub(crate) fn spec_name(self) -> &'a str {
+        match self {
+            Self::Command(name) => name,
+            Self::Rebound => "",
+        }
+    }
+
+    /// Whether the head's registry binding was provably taken over.
+    pub(crate) fn is_rebound(self) -> bool {
+        matches!(self, Self::Rebound)
+    }
+}
+
+/// One binding fact about one head spelling.
+#[derive(Debug, Clone)]
+struct HeadFact {
+    /// Byte offset of the statement that established it; the fact applies to
+    /// heads at or after this offset only.
+    from: u32,
+    /// The registry name the head now resolves to, or `None` when the head was
+    /// rebound to something unmodelled.
+    target: Option<String>,
+}
+
+/// Every statically proven command-identity fact in one document, keyed by the
+/// head spelling as written.
+///
+/// Both the bare and the explicitly global spelling of a bound name are
+/// recorded, because C Tcl resolves them to the same command
+/// (`namespace which -command ::myfmt` → `::myfmt`) and a consumer must not
+/// have to strip qualifiers itself.
+#[derive(Debug, Default)]
+pub(crate) struct HeadIdentityMap {
+    facts: FxHashMap<String, Vec<HeadFact>>,
+}
+
+impl HeadIdentityMap {
+    /// Whether the document stated any binding fact at all — lets a caller
+    /// skip per-head lookups entirely for the overwhelmingly common document
+    /// that imports, aliases, and renames nothing.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.facts.is_empty()
+    }
+
+    /// The effective identity of `head` invoked at byte offset `at`.
+    ///
+    /// The **latest** fact at or before `at` wins, so a document that renames a
+    /// name and then rebinds it again reads correctly at every point between.
+    /// With no applicable fact the head keeps its own spelling.
+    pub(crate) fn resolve<'a>(&'a self, head: &'a str, at: u32) -> HeadIdentity<'a> {
+        let Some(facts) = self.facts.get(head) else {
+            return HeadIdentity::Command(head);
+        };
+        let Some(fact) = facts
+            .iter()
+            .filter(|f| f.from <= at)
+            .max_by_key(|f| f.from)
+        else {
+            return HeadIdentity::Command(head);
+        };
+        fact.target
+            .as_deref()
+            .map_or(HeadIdentity::Rebound, HeadIdentity::Command)
+    }
+
+    /// Whether an *earlier* fact already gives `head` a registry identity at
+    /// offset `at` — used to notice that a `proc` takes back a name a previous
+    /// `rename` / alias had bound to a built-in.
+    fn resolves_to_a_command(&self, head: &str, at: u32) -> bool {
+        matches!(self.resolve(head, at), HeadIdentity::Command(name) if name != head)
+    }
+
+    /// Record `head` → `target` (or a rebinding, with `target` `None`) from
+    /// byte offset `from`.
+    fn record(&mut self, head: &str, target: Option<String>, from: u32) {
+        if head.is_empty() {
+            return;
+        }
+        self.facts.entry(head.to_owned()).or_default().push(HeadFact {
+            from,
+            target,
+        });
+    }
+
+    /// Record a fact under both the written spelling and its explicitly global
+    /// twin, so `myfmt` and `::myfmt` classify alike.
+    fn record_both_spellings(&mut self, name: &str, target: Option<String>, from: u32) {
+        let bare = name.strip_prefix("::").unwrap_or(name);
+        self.record(bare, target.clone(), from);
+        self.record(&format!("::{bare}"), target, from);
+    }
+}
+
+/// Whether `word` is a name this scan may treat as a static command spelling.
+fn is_static_name(word: &str) -> bool {
+    !word.is_empty() && !is_dynamic_word(word) && !word.contains(char::is_whitespace)
+}
+
+/// Scan `source` for the top-level statements that move a command binding and
+/// build the document's [`HeadIdentityMap`].
+///
+/// `imports` is the already-computed `namespace import` alias table (bare name
+/// → `(qualified spec name, enabling offset)`); it is folded in here so every
+/// consumer asks one question rather than two.
+///
+/// Which commands mutate the command table is registry data
+/// ([`CommandTableEffect`]) and the argument shapes come from the compiler's
+/// own detectors ([`detect_interp_alias`] / [`detect_rename`]) — the same ones
+/// the IR-lowering pipeline uses — so no command name is spelled here.
+pub(crate) fn command_head_identities(
+    source: &str,
+    dialect: &str,
+    registry: &CommandRegistry,
+    imports: FxHashMap<String, (String, u32)>,
+) -> HeadIdentityMap {
+    let mut map = HeadIdentityMap::default();
+    for (name, (qualified, offset)) in imports {
+        map.record(&name, Some(qualified), offset);
+    }
+    for seg in segment_commands_with_offset_and_config(
+        source,
+        0,
+        tcl_lexer::LexerConfig::for_file_dialect(dialect),
+    ) {
+        let Some(head) = seg.texts.first() else {
+            continue;
+        };
+        let args = &seg.texts[1..];
+        let Some(effect) = registry.command_table_effect(head, args.first().map(String::as_str))
+        else {
+            continue;
+        };
+        let at = seg.argv[0].span.start();
+        match effect {
+            CommandTableEffect::RenamesCommands => record_rename(&mut map, args, at, registry),
+            CommandTableEffect::CreatesAliases => record_alias(&mut map, args, at, registry),
+            CommandTableEffect::DefinesProcedure => record_proc(&mut map, args, at, registry),
+        }
+    }
+    map
+}
+
+/// `rename OLD NEW` — `NEW` inherits `OLD`'s identity and `OLD` stops existing;
+/// `rename OLD {}` deletes `OLD` outright.
+fn record_rename(map: &mut HeadIdentityMap, args: &[String], at: u32, registry: &CommandRegistry) {
+    let Some(old) = args.first() else { return };
+    if !is_static_name(old) {
+        // `rename $old new` — the source is unknown, so neither half of the
+        // move can be stated.  Abstain entirely.
+        return;
+    }
+    if let Some((old, new)) = detect_rename(args)
+        && is_static_name(&new)
+    {
+        // Only a target the registry actually models is worth aliasing; a
+        // rename of a user proc leaves `NEW` an ordinary unknown name, which is
+        // already what an absent fact produces.
+        if registry.get(&old).is_some() {
+            map.record_both_spellings(&new, Some(old.clone()), at);
+        }
+    }
+    // Either way the old name is gone from this point on.
+    map.record_both_spellings(old, None, at);
+}
+
+/// `interp alias {} NEW {} TARGET ?arg…?` and its deletion form.
+fn record_alias(map: &mut HeadIdentityMap, args: &[String], at: u32, registry: &CommandRegistry) {
+    if let Some(deleted) = detect_interp_alias_delete(args) {
+        map.record_both_spellings(&deleted, None, at);
+        return;
+    }
+    let Some((qualified, target, prepended)) = detect_interp_alias(args) else {
+        // Not a current-interpreter creation: a foreign `srcPath` binds a name
+        // in a child interpreter (nothing changes here), and a dynamic name or
+        // target cannot be stated.  A *foreign target path* is the one shape
+        // worth marking rebound — the alias exists here but runs elsewhere.
+        if let (Some(src), Some(name), Some(tgt)) = (args.get(1), args.get(2), args.get(3))
+            && matches!(src.as_str(), "" | "{}")
+            && !matches!(tgt.as_str(), "" | "{}")
+            && is_static_name(name)
+        {
+            map.record_both_spellings(name, None, at);
+        }
+        return;
+    };
+    // Pre-bound arguments shift every index, so the target's layout cannot be
+    // reused; an unmodelled target has no layout to reuse either.  Both cases
+    // still *take over* the name, so mark it rebound rather than aliased.
+    let effective = prepended
+        .is_empty()
+        .then(|| registry.get(&target).map(|_| target))
+        .flatten();
+    map.record_both_spellings(&qualified, effective, at);
+}
+
+/// `proc NAME …` at top level — a user proc that shadows a registry built-in
+/// takes the name over (tclsh 9.0.4: after `proc format {args} {return USER}`,
+/// `format x` is `USER`).
+///
+/// Only a name that *would otherwise* resolve to a registry command is
+/// recorded — either directly, or through an earlier fact (a `proc origfmt`
+/// after `rename format origfmt` takes the moved built-in's name back).  Every
+/// other `proc` leaves the head an ordinary unknown name, which is already what
+/// an absent fact produces.
+fn record_proc(map: &mut HeadIdentityMap, args: &[String], at: u32, registry: &CommandRegistry) {
+    let Some(name) = args.first() else { return };
+    if !is_static_name(name) || name.contains("::") {
+        // A qualified `proc ::ns::format` defines a *different* command; only
+        // the global-namespace shadow is stated here.
+        return;
+    }
+    if registry.get(name).is_some() || map.resolves_to_a_command(name, at) {
+        map.record_both_spellings(name, None, at);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn map_for(src: &str) -> HeadIdentityMap {
+        let registry = tcl_registry::registry_for_dialect("tcl");
+        command_head_identities(src, "tcl", registry, FxHashMap::default())
+    }
+
+    /// Offset just past the first line of `src`, i.e. "after statement 1".
+    fn after_first_line(src: &str) -> u32 {
+        u32::try_from(src.find('\n').map_or(src.len(), |i| i + 1)).unwrap_or(0)
+    }
+
+    #[test]
+    fn static_rename_moves_the_identity_and_clears_the_old_name() {
+        let src = "rename format origfmt\norigfmt %d 7\nformat x\n";
+        let map = map_for(src);
+        let at = after_first_line(src);
+        assert_eq!(map.resolve("origfmt", at), HeadIdentity::Command("format"));
+        // The `::`-qualified spelling of the new name resolves alike.
+        assert_eq!(map.resolve("::origfmt", at), HeadIdentity::Command("format"));
+        // The old name is gone from the rename onwards …
+        assert_eq!(map.resolve("format", at), HeadIdentity::Rebound);
+        // … but calls *before* it still see the built-in.
+        let src = "format {%08x} 42\nrename format origfmt\n";
+        let map = map_for(src);
+        assert_eq!(map.resolve("format", 0), HeadIdentity::Command("format"));
+        assert_eq!(
+            map.resolve("format", after_first_line(src)),
+            HeadIdentity::Rebound
+        );
+    }
+
+    #[test]
+    fn interp_alias_aliases_only_the_argument_preserving_form() {
+        let src = "interp alias {} myfmt {} format\n";
+        let map = map_for(src);
+        let at = after_first_line(src);
+        assert_eq!(map.resolve("myfmt", at), HeadIdentity::Command("format"));
+        assert_eq!(map.resolve("::myfmt", at), HeadIdentity::Command("format"));
+
+        // Pre-bound arguments shift every index — the layout cannot be reused.
+        let src = "interp alias {} pad {} format %08x\n";
+        let map = map_for(src);
+        assert_eq!(map.resolve("pad", after_first_line(src)), HeadIdentity::Rebound);
+    }
+
+    #[test]
+    fn dynamic_bindings_abstain() {
+        for src in [
+            "rename $old myfmt\n",
+            "interp alias {} $n {} format\n",
+            "interp alias {} myfmt {} $t\n",
+        ] {
+            let map = map_for(src);
+            let at = after_first_line(src);
+            assert_eq!(
+                map.resolve("myfmt", at),
+                HeadIdentity::Command("myfmt"),
+                "dynamic binding must not state a fact: {src}"
+            );
+            // A dynamic `rename` must not claim the *old* name is gone either.
+            assert_eq!(map.resolve("format", at), HeadIdentity::Command("format"));
+        }
+    }
+
+    #[test]
+    fn a_child_interpreter_alias_changes_nothing_here() {
+        let src = "interp alias slave myfmt {} format\n";
+        let map = map_for(src);
+        assert!(map.is_empty(), "a foreign srcPath states no fact here");
+    }
+
+    #[test]
+    fn a_foreign_target_path_rebinds_without_aliasing() {
+        let src = "interp alias {} myfmt slave format\n";
+        let map = map_for(src);
+        assert_eq!(
+            map.resolve("myfmt", after_first_line(src)),
+            HeadIdentity::Rebound
+        );
+    }
+
+    #[test]
+    fn a_top_level_proc_shadows_the_builtin_it_names() {
+        let src = "proc format {args} { return USER }\n";
+        let map = map_for(src);
+        assert_eq!(
+            map.resolve("format", after_first_line(src)),
+            HeadIdentity::Rebound
+        );
+        // A proc that shadows nothing states nothing.
+        let src = "proc mything {args} { return 1 }\n";
+        assert!(map_for(src).is_empty());
+        // A qualified proc defines a different command entirely.
+        let src = "proc ::ns::format {args} { return 1 }\n";
+        assert!(map_for(src).is_empty());
+    }
+
+    #[test]
+    fn a_nested_binding_is_not_a_document_wide_fact() {
+        // Neither the conditional rename nor the namespaced proc is an
+        // unconditional top-level statement.
+        for src in [
+            "if {$x} { rename format origfmt }\n",
+            "namespace eval ::n { proc format {a} { return 1 } }\n",
+            "proc p {} { rename format origfmt }\n",
+        ] {
+            assert!(map_for(src).is_empty(), "nested binding leaked: {src}");
+        }
+    }
+
+    #[test]
+    fn a_qualified_mutator_head_states_the_same_fact() {
+        // C Tcl resolves `::rename` to `::rename` — the mutator's own spelling
+        // must not be a false negative either (issue #1185).
+        let src = "::rename format origfmt\n";
+        let map = map_for(src);
+        assert_eq!(
+            map.resolve("origfmt", after_first_line(src)),
+            HeadIdentity::Command("format")
+        );
+    }
+
+    #[test]
+    fn the_latest_applicable_fact_wins() {
+        let src = "rename format origfmt\norigfmt %d 7\nproc origfmt {args} { return 1 }\n";
+        let map = map_for(src);
+        let after_all = u32::try_from(src.len()).unwrap_or(0);
+        // Between the `rename` and the `proc`, `origfmt` *is* the built-in …
+        assert_eq!(
+            map.resolve("origfmt", after_first_line(src)),
+            HeadIdentity::Command("format")
+        );
+        // … and after the `proc` takes the name back it is a user command,
+        // even though `origfmt` is not itself a registry name.
+        assert_eq!(map.resolve("origfmt", after_all), HeadIdentity::Rebound);
+    }
+
+    #[test]
+    fn a_rebound_head_resolves_to_no_registry_spec() {
+        // The `Rebound` sentinel must be unresolvable, since that is what makes
+        // every registry query answer "unknown" without a variant check.
+        let registry = tcl_registry::registry_for_dialect("tcl");
+        assert!(registry.get(HeadIdentity::Rebound.spec_name()).is_none());
+    }
+}

--- a/rust/tcl-lsp-core/src/head_identity.rs
+++ b/rust/tcl-lsp-core/src/head_identity.rs
@@ -199,15 +199,18 @@ pub(crate) fn command_head_identities(
     dialect: &str,
     registry: &CommandRegistry,
 ) -> HeadIdentityMap {
-    let mut map = HeadIdentityMap::default();
-    for (name, (qualified, offset)) in imported_command_aliases(source, dialect, registry) {
-        map.record(&name, Some(qualified), offset);
-    }
-    for seg in segment_commands_with_offset_and_config(
+    // One top-level segmentation feeds both halves — the `namespace import`
+    // scan and the command-table mutators.
+    let segments = segment_commands_with_offset_and_config(
         source,
         0,
         tcl_lexer::LexerConfig::for_file_dialect(dialect),
-    ) {
+    );
+    let mut map = HeadIdentityMap::default();
+    for (name, (qualified, offset)) in imported_command_aliases(&segments, registry) {
+        map.record(&name, Some(qualified), offset);
+    }
+    for seg in &segments {
         let Some(head) = seg.texts.first() else {
             continue;
         };
@@ -320,15 +323,10 @@ fn record_proc(map: &mut HeadIdentityMap, args: &[String], at: u32, registry: &C
 /// lets the registry-driven argument overrides see the real spec for an
 /// unqualified imported command.  Returns an empty map when nothing is imported.
 fn imported_command_aliases(
-    source: &str,
-    dialect: &str,
+    segments: &[tcl_compiler::segmenter::SegmentedCommand],
     registry: &CommandRegistry,
 ) -> FxHashMap<String, (String, u32)> {
     let mut aliases: FxHashMap<String, (String, u32)> = FxHashMap::default();
-    // Cheap gate: `namespace import` is the only source of aliases.
-    if !source.contains("namespace") {
-        return aliases;
-    }
     // Wholesale imports (`ns::*`) and single-name imports (`ns::name`), each
     // tagged with the byte offset of its `namespace import` statement so an
     // alias only applies to heads at or after it (source order).  Only
@@ -337,11 +335,7 @@ fn imported_command_aliases(
     // global bare alias.
     let mut import_all: Vec<(String, u32)> = Vec::new();
     let mut import_one: Vec<(String, String, u32)> = Vec::new();
-    for seg in segment_commands_with_offset_and_config(
-        source,
-        0,
-        tcl_lexer::LexerConfig::for_file_dialect(dialect),
-    ) {
+    for seg in segments {
         if seg.texts.len() < 3 || seg.texts[0] != "namespace" || seg.texts[1] != "import" {
             continue;
         }

--- a/rust/tcl-lsp-core/src/head_identity.rs
+++ b/rust/tcl-lsp-core/src/head_identity.rs
@@ -190,10 +190,6 @@ fn is_static_name(word: &str) -> bool {
 /// Scan `source` for the top-level statements that move a command binding and
 /// build the document's [`HeadIdentityMap`].
 ///
-/// `imports` is the already-computed `namespace import` alias table (bare name
-/// → `(qualified spec name, enabling offset)`); it is folded in here so every
-/// consumer asks one question rather than two.
-///
 /// Which commands mutate the command table is registry data
 /// ([`CommandTableEffect`]) and the argument shapes come from the compiler's
 /// own detectors ([`detect_interp_alias`] / [`detect_rename`]) — the same ones
@@ -202,10 +198,9 @@ pub(crate) fn command_head_identities(
     source: &str,
     dialect: &str,
     registry: &CommandRegistry,
-    imports: FxHashMap<String, (String, u32)>,
 ) -> HeadIdentityMap {
     let mut map = HeadIdentityMap::default();
-    for (name, (qualified, offset)) in imports {
+    for (name, (qualified, offset)) in imported_command_aliases(source, dialect, registry) {
         map.record(&name, Some(qualified), offset);
     }
     for seg in segment_commands_with_offset_and_config(
@@ -305,13 +300,120 @@ fn record_proc(map: &mut HeadIdentityMap, args: &[String], at: u32, registry: &C
     }
 }
 
+/// Scan `source` for `namespace import` declarations and map each bare command
+/// name they bring into the global scope to its qualified registry spec name
+/// (`test` → `tcltest::test`, issue #776).
+///
+/// Recognises the two literal forms — `namespace import EXPORTING::*`
+/// (import-all) and `namespace import EXPORTING::name` (single) — matched
+/// against the registry's `is_namespace_exported` commands in the exporting
+/// namespace.  A bare name that already resolves to a global command is left
+/// alone (Tcl's own `namespace import` refuses to shadow an existing command
+/// without `-force`, and we must not mis-resolve a genuine builtin).  This is a
+/// highlighting-only convenience: it never changes which commands exist, only
+/// lets the registry-driven argument overrides see the real spec for an
+/// unqualified imported command.  Returns an empty map when nothing is imported.
+fn imported_command_aliases(
+    source: &str,
+    dialect: &str,
+    registry: &CommandRegistry,
+) -> FxHashMap<String, (String, u32)> {
+    let mut aliases: FxHashMap<String, (String, u32)> = FxHashMap::default();
+    // Cheap gate: `namespace import` is the only source of aliases.
+    if !source.contains("namespace") {
+        return aliases;
+    }
+    // Wholesale imports (`ns::*`) and single-name imports (`ns::name`), each
+    // tagged with the byte offset of its `namespace import` statement so an
+    // alias only applies to heads at or after it (source order).  Only
+    // top-level imports are seen — a `namespace import` nested inside a
+    // `namespace eval` body is not a top-level segment, so it never leaks a
+    // global bare alias.
+    let mut import_all: Vec<(String, u32)> = Vec::new();
+    let mut import_one: Vec<(String, String, u32)> = Vec::new();
+    for seg in segment_commands_with_offset_and_config(
+        source,
+        0,
+        tcl_lexer::LexerConfig::for_file_dialect(dialect),
+    ) {
+        if seg.texts.len() < 3 || seg.texts[0] != "namespace" || seg.texts[1] != "import" {
+            continue;
+        }
+        let import_off = seg.argv[0].span.start();
+        for pat in &seg.texts[2..] {
+            // Skip option flags (`-force`); computed patterns are left alone.
+            if pat.starts_with('-') {
+                continue;
+            }
+            if let Some(ns) = pat.strip_suffix("::*") {
+                import_all.push((ns.trim_start_matches(':').to_string(), import_off));
+            } else if let Some((ns, name)) = pat.rsplit_once("::") {
+                import_one.push((
+                    ns.trim_start_matches(':').to_string(),
+                    name.to_string(),
+                    import_off,
+                ));
+            }
+        }
+    }
+    if import_all.is_empty() && import_one.is_empty() {
+        return aliases;
+    }
+    // Record `name → (qualified, offset)`, keeping the *earliest* enabling
+    // import when several would produce the same alias.
+    let mut record = |name: String, qualified: String, off: u32| {
+        aliases
+            .entry(name)
+            .and_modify(|(_, o)| *o = (*o).min(off))
+            .or_insert((qualified, off));
+    };
+    // Import-all: every exported command in an imported namespace whose bare
+    // tail does not already name a global command.
+    if !import_all.is_empty() {
+        for name in registry.command_names() {
+            let Some((ns, tail)) = name.rsplit_once("::") else {
+                continue;
+            };
+            if tail.is_empty() || registry.get(tail).is_some() {
+                continue;
+            }
+            let ns = ns.trim_start_matches(':');
+            let Some(off) = import_all
+                .iter()
+                .filter(|(n, _)| n == ns)
+                .map(|(_, o)| *o)
+                .min()
+            else {
+                continue;
+            };
+            if registry.get(name).is_some_and(|s| s.is_namespace_exported) {
+                record(tail.to_string(), name.to_string(), off);
+            }
+        }
+    }
+    // Single-name imports.
+    for (ns, name, off) in &import_one {
+        if registry.get(name).is_some() {
+            continue;
+        }
+        let qualified = format!("{ns}::{name}");
+        if registry
+            .get(&qualified)
+            .is_some_and(|s| s.is_namespace_exported)
+        {
+            record(name.clone(), qualified, *off);
+        }
+    }
+    aliases
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn map_for(src: &str) -> HeadIdentityMap {
         let registry = tcl_registry::registry_for_dialect("tcl");
-        command_head_identities(src, "tcl", registry, FxHashMap::default())
+        command_head_identities(src, "tcl", registry)
     }
 
     /// Offset just past the first line of `src`, i.e. "after statement 1".

--- a/rust/tcl-lsp-core/src/head_identity.rs
+++ b/rust/tcl-lsp-core/src/head_identity.rs
@@ -229,6 +229,12 @@ pub(crate) fn command_head_identities(
 /// `rename OLD NEW` — `NEW` inherits `OLD`'s identity and `OLD` stops existing;
 /// `rename OLD {}` deletes `OLD` outright.
 fn record_rename(map: &mut HeadIdentityMap, args: &[String], at: u32, registry: &CommandRegistry) {
+    // `rename` takes exactly two arguments; any other arity is a `wrong # args`
+    // error that moves nothing, so a malformed call must state nothing rather
+    // than half a fact.
+    if args.len() != 2 {
+        return;
+    }
     let Some(old) = args.first() else { return };
     if !is_static_name(old) {
         // `rename $old new` — the source is unknown, so neither half of the
@@ -487,6 +493,52 @@ mod tests {
         assert!(map.is_empty(), "a foreign srcPath states no fact here");
     }
 
+    /// FP guard — a **safe / sub-interpreter** command table is not this
+    /// document's own, so hiding or exposing a command there states nothing
+    /// about a bare call here.
+    ///
+    /// tclsh-proof (9.0.4 / 8.6.16): `interp create -safe s; interp hide s
+    /// format` leaves the parent's `format %d 7` answering `7`, while
+    /// `s eval {format %d 7}` fails `invalid command name "format"`.
+    #[test]
+    fn a_safe_interpreters_hidden_command_states_nothing_here() {
+        for src in [
+            "interp create -safe s\n",
+            "interp hide s format\n",
+            "interp expose s format\n",
+            "interp invokehidden s format %d 7\n",
+        ] {
+            let map = map_for(src);
+            assert!(
+                map.is_empty(),
+                "a child interpreter's command table must state nothing here: {src}"
+            );
+        }
+    }
+
+    /// TN — a malformed call states nothing rather than half a fact.
+    #[test]
+    fn malformed_binding_calls_abstain() {
+        for src in [
+            // Arity too short for a rename / an alias creation.
+            "rename\n",
+            "rename format\n",
+            "interp alias\n",
+            "interp alias {}\n",
+            // Not the alias subcommand at all (`aliases` merely queries).
+            "interp aliases {}\n",
+            // `proc` with no name.
+            "proc\n",
+        ] {
+            let map = map_for(src);
+            assert_eq!(
+                map.resolve("format", u32::MAX),
+                HeadIdentity::Command("format"),
+                "a malformed binding must not disturb `format`: {src}"
+            );
+        }
+    }
+
     #[test]
     fn a_foreign_target_path_rebinds_without_aliasing() {
         let src = "interp alias {} myfmt slave format\n";
@@ -521,6 +573,9 @@ mod tests {
             "if {$x} { rename format origfmt }\n",
             "namespace eval ::n { proc format {a} { return 1 } }\n",
             "proc p {} { rename format origfmt }\n",
+            "eval { rename format origfmt }\n",
+            "uplevel #0 { rename format origfmt }\n",
+            "interp eval $child { rename format origfmt }\n",
         ] {
             assert!(map_for(src).is_empty(), "nested binding leaked: {src}");
         }

--- a/rust/tcl-lsp-core/src/head_identity.rs
+++ b/rust/tcl-lsp-core/src/head_identity.rs
@@ -146,11 +146,7 @@ impl HeadIdentityMap {
         let Some(facts) = self.facts.get(head) else {
             return HeadIdentity::Command(head);
         };
-        let Some(fact) = facts
-            .iter()
-            .filter(|f| f.from <= at)
-            .max_by_key(|f| f.from)
-        else {
+        let Some(fact) = facts.iter().filter(|f| f.from <= at).max_by_key(|f| f.from) else {
             return HeadIdentity::Command(head);
         };
         fact.target
@@ -171,10 +167,10 @@ impl HeadIdentityMap {
         if head.is_empty() {
             return;
         }
-        self.facts.entry(head.to_owned()).or_default().push(HeadFact {
-            from,
-            target,
-        });
+        self.facts
+            .entry(head.to_owned())
+            .or_default()
+            .push(HeadFact { from, target });
     }
 
     /// Record a fact under both the written spelling and its explicitly global
@@ -330,7 +326,10 @@ mod tests {
         let at = after_first_line(src);
         assert_eq!(map.resolve("origfmt", at), HeadIdentity::Command("format"));
         // The `::`-qualified spelling of the new name resolves alike.
-        assert_eq!(map.resolve("::origfmt", at), HeadIdentity::Command("format"));
+        assert_eq!(
+            map.resolve("::origfmt", at),
+            HeadIdentity::Command("format")
+        );
         // The old name is gone from the rename onwards …
         assert_eq!(map.resolve("format", at), HeadIdentity::Rebound);
         // … but calls *before* it still see the built-in.
@@ -354,7 +353,10 @@ mod tests {
         // Pre-bound arguments shift every index — the layout cannot be reused.
         let src = "interp alias {} pad {} format %08x\n";
         let map = map_for(src);
-        assert_eq!(map.resolve("pad", after_first_line(src)), HeadIdentity::Rebound);
+        assert_eq!(
+            map.resolve("pad", after_first_line(src)),
+            HeadIdentity::Rebound
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/inlay_hints.rs
+++ b/rust/tcl-lsp-core/src/inlay_hints.rs
@@ -544,7 +544,7 @@ fn regsub_short(c: char) -> Option<&'static str> {
 fn format_args(
     seg: &tcl_compiler::segmenter::SegmentedCommand,
     registry: &CommandRegistry,
-    identities: &crate::head_identity::HeadIdentityMap,
+    identities: &tcl_compiler::head_identity::HeadIdentityMap,
 ) -> Vec<(usize, tcl_registry::FormatType)> {
     let Some(head) = seg.texts.first() else {
         return Vec::new();
@@ -624,7 +624,8 @@ fn collect_format_string_hints(
     );
     // The document's proven command-identity facts, computed once for the
     // whole file (empty, and lookup-free, unless it binds something).
-    let identities = crate::head_identity::command_head_identities(source, dialect, registry);
+    let identities =
+        tcl_compiler::head_identity::command_head_identities(source, dialect, registry);
     for seg in &segments {
         for (idx, kind) in format_args(seg, registry, &identities) {
             let Some(tok) = seg.argv.get(idx) else {

--- a/rust/tcl-lsp-core/src/inlay_hints.rs
+++ b/rust/tcl-lsp-core/src/inlay_hints.rs
@@ -544,13 +544,22 @@ fn regsub_short(c: char) -> Option<&'static str> {
 fn format_args(
     seg: &tcl_compiler::segmenter::SegmentedCommand,
     registry: &CommandRegistry,
+    identities: &crate::head_identity::HeadIdentityMap,
 ) -> Vec<(usize, tcl_registry::FormatType)> {
     let Some(head) = seg.texts.first() else {
         return Vec::new();
     };
+    let Some(tok) = seg.argv.first() else {
+        return Vec::new();
+    };
+    // Resolve the head's *effective command identity* first, exactly as the
+    // semantic-token walk does, so a call through a proven `interp alias` /
+    // `rename` gets the target's format family and a `rename`d-away or
+    // `proc`-shadowed spelling gets none (issue #1185).
+    let resolved = identities.resolve(head, tok.span.start()).spec_name();
     let arg_texts: Vec<&str> = seg.texts[1..].iter().map(String::as_str).collect();
     registry
-        .format_string_args(head, &arg_texts)
+        .format_string_args(resolved, &arg_texts)
         .into_iter()
         // `+ 1` converts a post-head argument index into an `argv` index
         // (`argv[0]` is the command word).
@@ -613,8 +622,11 @@ fn collect_format_string_hints(
         0,
         tcl_lexer::LexerConfig::for_file_dialect(dialect),
     );
+    // The document's proven command-identity facts, computed once for the
+    // whole file (empty, and lookup-free, unless it binds something).
+    let identities = crate::head_identity::command_head_identities(source, dialect, registry);
     for seg in &segments {
-        for (idx, kind) in format_args(seg, registry) {
+        for (idx, kind) in format_args(seg, registry, &identities) {
             let Some(tok) = seg.argv.get(idx) else {
                 continue;
             };
@@ -1785,5 +1797,43 @@ mod tests {
         let names: Vec<&str> = labels.iter().map(|(_, l)| l.as_str()).collect();
         assert!(names.contains(&"grp1"), "{labels:?}");
         assert!(names.contains(&"grp2"), "{labels:?}");
+    }
+
+    /// Issue #1185: format hints follow the head's *effective command
+    /// identity*, so a proven `interp alias` / `rename` of a format-family
+    /// command hints like the original — and a spelling whose binding was
+    /// taken over hints not at all.
+    ///
+    /// tclsh-proof (9.0.4 / 8.6.16): `interp alias {} myfmt {} format;
+    /// myfmt "%d-%s" 1 two` -> `1-two`; after `proc format {args} {return
+    /// USER}`, `format "%d"` -> `USER`.
+    #[test]
+    fn format_hints_follow_the_effective_command_identity() {
+        let names_of =
+            |src: &str| -> Vec<String> { type_labels(src).into_iter().map(|(_, l)| l).collect() };
+        // TP — an aliased and a renamed head both hint like the original.
+        for src in [
+            "interp alias {} myfmt {} format\nmyfmt \"%d-%s\" 1 two\n",
+            "rename format myfmt\nmyfmt \"%d-%s\" 1 two\n",
+        ] {
+            let names = names_of(src);
+            assert!(
+                names.iter().any(|n| n == "int") && names.iter().any(|n| n == "str"),
+                "`{}` must hint like a direct format call, got {names:?}",
+                src.lines().next().unwrap_or_default()
+            );
+        }
+        // FP — a top-level `proc` that shadows the built-in takes the name
+        // over, so its `%d` is an ordinary string.
+        assert!(
+            names_of("proc format {args} { return USER }\nformat \"%d-%s\" 1 two\n").is_empty(),
+            "a shadowed `format` must not be hinted"
+        );
+        // TN — an unprovable binding states nothing, so the name stays an
+        // ordinary unknown command.
+        assert!(
+            names_of("interp alias {} myfmt {} $target\nmyfmt \"%d-%s\" 1 two\n").is_empty(),
+            "a dynamic alias target must not confer format hints"
+        );
     }
 }

--- a/rust/tcl-lsp-core/src/lib.rs
+++ b/rust/tcl-lsp-core/src/lib.rs
@@ -58,6 +58,7 @@ pub mod file_ops;
 pub mod folding;
 pub mod formatting;
 pub mod graphs;
+mod head_identity;
 pub mod hover;
 pub mod implementation;
 pub mod inert_text;

--- a/rust/tcl-lsp-core/src/lib.rs
+++ b/rust/tcl-lsp-core/src/lib.rs
@@ -58,7 +58,6 @@ pub mod file_ops;
 pub mod folding;
 pub mod formatting;
 pub mod graphs;
-mod head_identity;
 pub mod hover;
 pub mod implementation;
 pub mod inert_text;

--- a/rust/tcl-lsp-core/src/minify.rs
+++ b/rust/tcl-lsp-core/src/minify.rs
@@ -4541,11 +4541,11 @@ mod tests {
     /// its name; unbarred, it compacts to a single letter.
     #[test]
     fn rename_barriers_follow_the_resolved_head() {
-        let registry = CommandRegistry::build_default();
         const UPVAR_BODY: &str =
             "proc p {v} {\n    set local 1\n    upvar 1 $v alias\n    return $local\n}\n";
         const PEEK_BODY: &str =
             "proc p {v} {\n    set local 1\n    peek 1 $v alias\n    return $local\n}\n";
+        let registry = CommandRegistry::build_default();
         let minify = |src: &str| minify_tcl_aggressive(src, "tcl8.6", true, &registry).source;
         let barred = |src: &str| minify(src).contains("set local 1");
 

--- a/rust/tcl-lsp-core/src/minify.rs
+++ b/rust/tcl-lsp-core/src/minify.rs
@@ -700,11 +700,7 @@ impl<'a> MinifyEnv<'a> {
     where
         'a: 'h,
     {
-        if self.identities.is_empty() {
-            head
-        } else {
-            self.identities.resolve_unpositioned(head).spec_name()
-        }
+        self.identities.head_words_unpositioned(head).resolved
     }
 }
 
@@ -973,11 +969,7 @@ fn find_rename_barriers(
         // The invocation carries its own absolute offset, so this is the
         // positioned read.
         let written = inv.name.trim_start_matches(':');
-        let head = if identities.is_empty() {
-            written
-        } else {
-            identities.resolve(written, inv.range.start()).spec_name()
-        };
+        let head = identities.head_words(written, inv.range.start()).resolved;
         let Some(spec) = registry.get(head) else {
             continue;
         };
@@ -1824,13 +1816,9 @@ fn abbreviate_command(
     // when `myfmt` is not `format` would rewrite live text (issue #1275).
     // `base` makes the head's offset document-absolute even inside a
     // recursively-scanned braced word, so this is the positioned read.
-    let head_name = if identities.is_empty() {
-        head.text.as_str()
-    } else {
-        identities
-            .resolve(&head.text, base + head.token.span.start())
-            .spec_name()
-    };
+    let head_name = identities
+        .head_words(&head.text, base + head.token.span.start())
+        .resolved;
     let Some(spec) = registry.get(head_name) else {
         return;
     };

--- a/rust/tcl-lsp-core/src/minify.rs
+++ b/rust/tcl-lsp-core/src/minify.rs
@@ -514,7 +514,17 @@ impl MinifyResult {
 /// Minify a Tcl source string for the given dialect (default tier).
 #[must_use]
 pub fn minify_tcl(source: &str, dialect: &str, registry: &CommandRegistry) -> String {
-    minify_body(source, dialect, registry, 0)
+    let identities =
+        tcl_compiler::head_identity::command_head_identities(source, dialect, registry);
+    minify_body(
+        source,
+        MinifyEnv {
+            dialect,
+            registry,
+            identities: &identities,
+        },
+        0,
+    )
 }
 
 /// Aggressive minification: apply the compiler's optimiser
@@ -608,7 +618,19 @@ pub fn minify_tcl_aggressive_with(
     };
 
     // Phase 3: minify whitespace.
-    let minified = minify_body(&renamed, dialect, registry, 0);
+    // The identity facts come from the *renamed* text, which is what the
+    // recursion below actually sees.
+    let identities =
+        tcl_compiler::head_identity::command_head_identities(&renamed, dialect, registry);
+    let minified = minify_body(
+        &renamed,
+        MinifyEnv {
+            dialect,
+            registry,
+            identities: &identities,
+        },
+        0,
+    );
 
     MinifyResult {
         source: minified,
@@ -633,13 +655,63 @@ pub fn minify_tcl_compact(
     registry: &CommandRegistry,
 ) -> (String, SymbolMap) {
     let (renamed, symbol_map) = compact_names(source, dialect, isolated, registry);
-    let minified = minify_body(&renamed, dialect, registry, 0);
+    // The identity facts come from the *renamed* text, which is what the
+    // recursion below actually sees.
+    let identities =
+        tcl_compiler::head_identity::command_head_identities(&renamed, dialect, registry);
+    let minified = minify_body(
+        &renamed,
+        MinifyEnv {
+            dialect,
+            registry,
+            identities: &identities,
+        },
+        0,
+    );
     (minified, symbol_map)
+}
+
+/// The document-wide context every step of the minify recursion carries
+/// unchanged.
+///
+/// Bundled rather than passed as three parameters because the recursion is
+/// deep (`minify_body` → `render_command` → `reconstruct_raw` → `minify_body`)
+/// and one of its steps was already at the argument limit.
+#[derive(Clone, Copy)]
+struct MinifyEnv<'a> {
+    /// The document's dialect, for the lexer and the abbreviation tables.
+    dialect: &'a str,
+    /// The registry the argument roles and clause-list shapes come from.
+    registry: &'a CommandRegistry,
+    /// The document's statically proven command-identity facts
+    /// ([`tcl_compiler::head_identity`]), so a body / lambda / expression /
+    /// clause-list argument is recognised by the command a head *is* rather
+    /// than the one it is spelled as (issue #1275).
+    ///
+    /// Read *unpositioned*: this recursion re-minifies each nested body from
+    /// its own slice, segmented at offset 0, so no document-absolute offset
+    /// exists at the point of the query.
+    identities: &'a tcl_compiler::head_identity::HeadIdentityMap,
+}
+
+impl<'a> MinifyEnv<'a> {
+    /// The registry name a head spelling effectively resolves to.
+    fn resolve<'h>(&'h self, head: &'h str) -> &'h str
+    where
+        'a: 'h,
+    {
+        if self.identities.is_empty() {
+            head
+        } else {
+            self.identities.resolve_unpositioned(head).spec_name()
+        }
+    }
 }
 
 /// Minify a Tcl script body (top-level or inside braces). `depth` is this
 /// body's nesting level — see [`MAX_MINIFY_DEPTH`].
-fn minify_body(source: &str, dialect: &str, registry: &CommandRegistry, depth: u32) -> String {
+fn minify_body(source: &str, env: MinifyEnv<'_>, depth: u32) -> String {
+    let dialect = env.dialect;
     // Native-stack safety net — see `MAX_MINIFY_DEPTH`'s doc comment
     // (issue #996). Past the cap, leave this (deeply nested) body
     // unminified rather than recursing further, matching the existing
@@ -660,7 +732,7 @@ fn minify_body(source: &str, dialect: &str, registry: &CommandRegistry, depth: u
     // Render each command, abbreviating ensemble subcommands.
     let mut rendered: Vec<Vec<String>> = Vec::with_capacity(commands.len());
     for cmd_args in &commands {
-        let mut arg_strs = render_command(&sm, cmd_args, dialect, registry, depth);
+        let mut arg_strs = render_command(&sm, cmd_args, env, depth);
         if arg_strs.len() >= 2 {
             arg_strs[1] = abbreviated_subcommand(&arg_strs[0], &arg_strs[1], dialect);
         }
@@ -882,6 +954,7 @@ fn find_rename_barriers(
     source: &str,
     analysis: &AnalysisResult,
     registry: &CommandRegistry,
+    identities: &tcl_compiler::head_identity::HeadIdentityMap,
     include_global: bool,
 ) -> RenameBarriers {
     let mut out = RenameBarriers::default();
@@ -893,7 +966,18 @@ fn find_rename_barriers(
             out.procs = true;
             continue;
         }
-        let head = inv.name.trim_start_matches(':');
+        // The head's *effective command identity*: an observability trait
+        // belongs to the command a head really names.  A proven
+        // `interp alias {} peek {} upvar` still bars every variable scope, and
+        // a `proc upvar …` that takes the name over does not (issue #1275).
+        // The invocation carries its own absolute offset, so this is the
+        // positioned read.
+        let written = inv.name.trim_start_matches(':');
+        let head = if identities.is_empty() {
+            written
+        } else {
+            identities.resolve(written, inv.range.start()).spec_name()
+        };
         let Some(spec) = registry.get(head) else {
             continue;
         };
@@ -1159,7 +1243,9 @@ fn compact_names(
     let mut symbol_map = SymbolMap::default();
     let mut edits: Vec<Edit> = Vec::new();
 
-    let barriers = find_rename_barriers(source, &analysis, registry, isolated);
+    let identities =
+        tcl_compiler::head_identity::command_head_identities(source, dialect, registry);
+    let barriers = find_rename_barriers(source, &analysis, registry, &identities, isolated);
     let rmw_targets = rmw_target_var_names(source, dialect, registry);
     let builtin_names: FxHashSet<&str> = registry.command_names().collect();
 
@@ -1604,6 +1690,8 @@ fn alias_repeated_commands(
 /// Abstains on strict tables, dynamic and `{*}`-expanded words, and anything
 /// the registry does not resolve `Unique`.
 fn abbreviate_keywords(source: &str, dialect: &str, registry: &CommandRegistry) -> (String, usize) {
+    let identities =
+        tcl_compiler::head_identity::command_head_identities(source, dialect, registry);
     let mut edits: Vec<Edit> = Vec::new();
     let mut stack: Vec<(String, u32)> = vec![(source.to_owned(), 0)];
     let later = later_core_registries(dialect);
@@ -1623,7 +1711,16 @@ fn abbreviate_keywords(source: &str, dialect: &str, registry: &CommandRegistry) 
                     }
                 }
             }
-            abbreviate_command(&command, registry, &later, base, &mut edits);
+            abbreviate_command(
+                &command,
+                registry,
+                &later,
+                AbbrevSite {
+                    base,
+                    identities: &identities,
+                },
+                &mut edits,
+            );
         }
     }
     if edits.is_empty() {
@@ -1631,6 +1728,21 @@ fn abbreviate_keywords(source: &str, dialect: &str, registry: &CommandRegistry) 
     }
     let count = edits.len();
     (apply_edits(source, edits), count)
+}
+
+/// Where an abbreviation candidate sits, and what the document has proven
+/// about the command it belongs to.
+///
+/// Bundled so [`abbreviate_command`] keeps a small signature — the scan
+/// re-enters nested braced words with a shifted `base`, and both fields travel
+/// together.
+#[derive(Clone, Copy)]
+struct AbbrevSite<'a> {
+    /// Byte offset of the scanned slice within the whole document, so a head's
+    /// own span resolves to a document-absolute offset.
+    base: u32,
+    /// The document's proven command-identity facts.
+    identities: &'a tcl_compiler::head_identity::HeadIdentityMap,
 }
 
 /// One word of a command, with the token it came from.
@@ -1699,14 +1811,27 @@ fn abbreviate_command(
     words: &[CommandWord],
     registry: &CommandRegistry,
     later: &[&'static CommandRegistry],
-    base: u32,
+    site: AbbrevSite<'_>,
     edits: &mut Vec<Edit>,
 ) {
+    let AbbrevSite { base, identities } = site;
     let Some(head) = words.first() else { return };
     if head.dynamic || head.kind != TokenType::Esc {
         return;
     }
-    let Some(spec) = registry.get(&head.text) else {
+    // Which subcommands and options a head has is registry data about the
+    // command it *is*: abbreviating `myfmt`'s words under `format`'s tables
+    // when `myfmt` is not `format` would rewrite live text (issue #1275).
+    // `base` makes the head's offset document-absolute even inside a
+    // recursively-scanned braced word, so this is the positioned read.
+    let head_name = if identities.is_empty() {
+        head.text.as_str()
+    } else {
+        identities
+            .resolve(&head.text, base + head.token.span.start())
+            .spec_name()
+    };
+    let Some(spec) = registry.get(head_name) else {
         return;
     };
     let args = &words[1..];
@@ -1723,7 +1848,7 @@ fn abbreviate_command(
         else {
             return;
         };
-        let tables = keyword_tables(&head.text, TableScope::Subcommands, registry, later);
+        let tables = keyword_tables(head_name, TableScope::Subcommands, registry, later);
         if let Some(short) = shortest_spelling(&tables, canonical)
             && short.len() < word.text.len()
         {
@@ -1733,7 +1858,7 @@ fn abbreviate_command(
         start = 1;
     }
     let scope = subcommand.map_or(TableScope::CommandOptions, TableScope::SubcommandOptions);
-    let option_tables = keyword_tables(&head.text, scope, registry, later);
+    let option_tables = keyword_tables(head_name, scope, registry, later);
     if option_tables.iter().all(KeywordTable::is_empty) {
         return;
     }
@@ -2670,27 +2795,29 @@ fn parse_commands(source: &str, tokens: &[Token]) -> Vec<Vec<Arg>> {
 }
 
 /// Render one command's arguments to their minified string forms.
-fn render_command(
-    sm: &SourceMap,
-    cmd_args: &[Arg],
-    dialect: &str,
-    registry: &CommandRegistry,
-    depth: u32,
-) -> Vec<String> {
+fn render_command(sm: &SourceMap, cmd_args: &[Arg], env: MinifyEnv<'_>, depth: u32) -> Vec<String> {
+    let registry = env.registry;
     let cmd_name = cmd_args
         .first()
         .map(|a| token_text(sm, a))
         .unwrap_or_default();
+    // The head's *effective command identity*: which registry command the
+    // spelling really names once the document's `namespace import` / `interp
+    // alias` / `rename` / built-in-shadowing `proc` statements are folded in
+    // (issue #1275).  Without it a rebound command's body / lambda /
+    // expression / clause-list arguments were re-minified as the grammar of
+    // the command it no longer is.
+    let head = env.resolve(&cmd_name);
     let post: Vec<String> = cmd_args.iter().skip(1).map(|a| token_text(sm, a)).collect();
     let post_refs: Vec<&str> = post.iter().map(String::as_str).collect();
 
-    let body_indices = role_indices(registry, &cmd_name, &post_refs, ArgRole::Body);
-    let lambda_indices = role_indices(registry, &cmd_name, &post_refs, ArgRole::LambdaLiteral);
-    let expr_indices = role_indices(registry, &cmd_name, &post_refs, ArgRole::Expr);
+    let body_indices = role_indices(registry, head, &post_refs, ArgRole::Body);
+    let lambda_indices = role_indices(registry, head, &post_refs, ArgRole::LambdaLiteral);
+    let expr_indices = role_indices(registry, head, &post_refs, ArgRole::Expr);
     // The braced clause-list form of a registry `case_list` command
     // (`switch … { pat body … }`, Expect's `expect { … }`).  Registry
     // data, never a spelled command name (issue #1197).
-    let case_list_spec = registry.get(&cmd_name).and_then(|s| s.case_list);
+    let case_list_spec = registry.get(head).and_then(|s| s.case_list);
     let is_case_list = case_list_spec.is_some_and(|cl| is_case_list_form(cl, &post_refs));
 
     let mut out: Vec<String> = Vec::with_capacity(cmd_args.len());
@@ -2700,27 +2827,18 @@ fn render_command(
             let inner = sm.token_text(arg.tokens[0]);
             let minified = match case_list_spec {
                 Some(cl) if is_case_list && i == cmd_args.len() - 1 => {
-                    minify_case_list(inner, cl, dialect, registry, depth + 1)
+                    minify_case_list(inner, cl, env, depth + 1)
                 }
-                _ => minify_body(inner, dialect, registry, depth + 1),
+                _ => minify_body(inner, env, depth + 1),
             };
             out.push(format!("{{{minified}}}"));
         } else if lambda_indices.contains(&i) && single_braced {
-            out.push(minify_lambda_literal(
-                sm,
-                arg.tokens[0],
-                dialect,
-                registry,
-                depth + 1,
-            ));
+            out.push(minify_lambda_literal(sm, arg.tokens[0], env, depth + 1));
         } else if expr_indices.contains(&i) && single_braced {
             let inner = sm.token_text(arg.tokens[0]);
-            out.push(format!(
-                "{{{}}}",
-                compress_expr(inner, dialect, registry, depth + 1)
-            ));
+            out.push(format!("{{{}}}", compress_expr(inner, env, depth + 1)));
         } else {
-            out.push(reconstruct_arg(sm, arg, dialect, registry, depth));
+            out.push(reconstruct_arg(sm, arg, env, depth));
         }
     }
     out
@@ -2744,13 +2862,7 @@ fn render_command(
 /// puts\ hi}`'s real body is `puts hi`, not `puts\ hi`), and a multi-word
 /// parameter list (`apply {{x y} …}`) would otherwise lose the braces that
 /// group it into one list element.
-fn minify_lambda_literal(
-    sm: &SourceMap,
-    tok: Token,
-    dialect: &str,
-    registry: &CommandRegistry,
-    depth: u32,
-) -> String {
+fn minify_lambda_literal(sm: &SourceMap, tok: Token, env: MinifyEnv<'_>, depth: u32) -> String {
     let source = sm.source();
     let fallback = || format!("{{{}}}", sm.token_text(tok));
     let Some(elems) = split_lambda_literal_decoded(source, tok) else {
@@ -2759,7 +2871,7 @@ fn minify_lambda_literal(
     let Some(body) = elems.body.as_deref() else {
         return fallback();
     };
-    let minified_body = minify_body(body, dialect, registry, depth);
+    let minified_body = minify_body(body, env, depth);
     let mut parts = vec![
         tcl_syntax::list::list_element(&elems.params),
         tcl_syntax::list::list_element(&minified_body),
@@ -2811,8 +2923,7 @@ fn reconstruct_raw(
     sm: &SourceMap,
     tok: Token,
     next_tok: Option<Token>,
-    dialect: &str,
-    registry: &CommandRegistry,
+    env: MinifyEnv<'_>,
     in_quotes: bool,
     depth: u32,
 ) -> String {
@@ -2822,10 +2933,7 @@ fn reconstruct_raw(
         // emit it verbatim, not brace-wrapped as `{$}` (`RUST_ISSUE_103`).
         TokenType::Str if in_quotes => sm.text(tok.span).to_owned(),
         TokenType::Str => format!("{{{}}}", sm.token_text(tok)),
-        TokenType::Cmd => format!(
-            "[{}]",
-            minify_body(sm.token_text(tok), dialect, registry, depth + 1)
-        ),
+        TokenType::Cmd => format!("[{}]", minify_body(sm.token_text(tok), env, depth + 1)),
         TokenType::Var => {
             // Keep `${var}` when the next token would otherwise extend the
             // variable name.  Beyond name characters, `(` (array index) and `:`
@@ -2905,13 +3013,7 @@ fn utf8_len(b: u8) -> usize {
 }
 
 /// Rebuild the source text of an argument from its tokens.
-fn reconstruct_arg(
-    sm: &SourceMap,
-    arg: &Arg,
-    dialect: &str,
-    registry: &CommandRegistry,
-    depth: u32,
-) -> String {
+fn reconstruct_arg(sm: &SourceMap, arg: &Arg, env: MinifyEnv<'_>, depth: u32) -> String {
     let mut raw = String::new();
     for (idx, &tok) in arg.tokens.iter().enumerate() {
         // The next token within the *same* word can extend a preceding
@@ -2920,15 +3022,7 @@ fn reconstruct_arg(
         // are dropped), so the name-extension guard must see it in both cases
         // (RUST_ISSUE_039).
         let next = arg.tokens.get(idx + 1).copied();
-        raw.push_str(&reconstruct_raw(
-            sm,
-            tok,
-            next,
-            dialect,
-            registry,
-            arg.is_quoted,
-            depth,
-        ));
+        raw.push_str(&reconstruct_raw(sm, tok, next, env, arg.is_quoted, depth));
     }
     if arg.is_quoted && !can_strip_quotes(&raw) {
         format!("\"{raw}\"")
@@ -3037,8 +3131,7 @@ fn case_element_text<'s>(inner: &'s str, el: &CaseElement) -> &'s str {
 fn minify_case_list(
     inner: &str,
     cl: &tcl_registry::CaseListSpec,
-    dialect: &str,
-    registry: &CommandRegistry,
+    env: MinifyEnv<'_>,
     depth: u32,
 ) -> String {
     let Some(elements) = case_list_elements(inner) else {
@@ -3085,7 +3178,7 @@ fn minify_case_list(
         parts.push(case_element_text(inner, pattern).to_owned());
         if body.braced {
             let body_src = &inner[body.value.clone()];
-            let minified = minify_body(body_src, dialect, registry, depth);
+            let minified = minify_body(body_src, env, depth);
             parts.push(format!("{{{minified}}}"));
         } else {
             parts.push(case_element_text(inner, body).to_owned());
@@ -3110,13 +3203,8 @@ enum ExprTok {
 /// Remove unnecessary whitespace inside an `expr` body, keeping
 /// spaces only around word-operators and between adjacent word
 /// tokens. (no AST shrinking).
-fn strip_expr_whitespace(
-    text: &str,
-    dialect: &str,
-    registry: &CommandRegistry,
-    depth: u32,
-) -> String {
-    let toks = tokenise_expr(text, dialect, registry, depth);
+fn strip_expr_whitespace(text: &str, env: MinifyEnv<'_>, depth: u32) -> String {
+    let toks = tokenise_expr(text, env, depth);
     let rendered: Vec<String> = toks
         .iter()
         .filter_map(|t| match t {
@@ -3142,9 +3230,9 @@ fn strip_expr_whitespace(
 /// Compress and shrink an `expr` body: strip whitespace, then try
 /// AST transforms (De Morgan / comparison inversion / double
 /// negation) and keep whichever is shorter.
-fn compress_expr(text: &str, dialect: &str, registry: &CommandRegistry, depth: u32) -> String {
-    let compressed = strip_expr_whitespace(text, dialect, registry, depth);
-    let shrunk = shrink_expr_ast(&compressed, dialect, registry, depth);
+fn compress_expr(text: &str, env: MinifyEnv<'_>, depth: u32) -> String {
+    let compressed = strip_expr_whitespace(text, env, depth);
+    let shrunk = shrink_expr_ast(&compressed, env, depth);
     if shrunk.len() < compressed.len() {
         shrunk
     } else {
@@ -3153,8 +3241,8 @@ fn compress_expr(text: &str, dialect: &str, registry: &CommandRegistry, depth: u
 }
 
 /// AST-based expression shrinking.
-fn shrink_expr_ast(text: &str, dialect: &str, registry: &CommandRegistry, depth: u32) -> String {
-    let node = parse_expr(text, Some(dialect));
+fn shrink_expr_ast(text: &str, env: MinifyEnv<'_>, depth: u32) -> String {
+    let node = parse_expr(text, Some(env.dialect));
     if matches!(node, ExprNode::Raw { .. }) {
         return text.to_owned();
     }
@@ -3163,7 +3251,7 @@ fn shrink_expr_ast(text: &str, dialect: &str, registry: &CommandRegistry, depth:
         return text.to_owned();
     }
     let rendered = render_expr(&shrunk);
-    strip_expr_whitespace(&rendered, dialect, registry, depth)
+    strip_expr_whitespace(&rendered, env, depth)
 }
 
 /// The logical complement of a comparison / membership operator,
@@ -3346,12 +3434,7 @@ fn shrink_not(node: &ExprNode, operand: &ExprNode) -> ExprNode {
 
 /// Tokenise an `expr` body, with a catch-all so no character is
 /// dropped.
-fn tokenise_expr(
-    text: &str,
-    dialect: &str,
-    registry: &CommandRegistry,
-    nest_depth: u32,
-) -> Vec<ExprTok> {
+fn tokenise_expr(text: &str, env: MinifyEnv<'_>, nest_depth: u32) -> Vec<ExprTok> {
     let bytes = text.as_bytes();
     let n = bytes.len();
     let mut out = Vec::new();
@@ -3403,7 +3486,7 @@ fn tokenise_expr(
             let inner = &text[start + 1..end];
             out.push(ExprTok::Cmd(format!(
                 "[{}]",
-                minify_body(inner, dialect, registry, nest_depth + 1)
+                minify_body(inner, env, nest_depth + 1)
             )));
         } else if c == b'$' {
             let start = i;
@@ -4353,5 +4436,145 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Issue #1275 — minification must resolve a command head's *effective
+    /// identity*, not its written spelling.
+    ///
+    /// A body-role argument is re-minified as the script it is (comments
+    /// stripped, whitespace collapsed); an unrecognised command's braced word
+    /// is emitted verbatim.  That difference is the witness.
+    ///
+    /// tclsh oracle (8.6.16 and 9.0.4, byte-identical): `interp alias {} maybe
+    /// {} if` makes `maybe` run `if`; `rename if maybe` moves it and leaves
+    /// `if` gone; a top-level `proc if …` takes the name over.
+    fn body_was_minified(src: &str) -> bool {
+        !min(src).contains("# c")
+    }
+
+    const BODY_CALL: &str = " {$x} {\n    # c\n    puts a\n}\n";
+
+    #[test]
+    fn minify_follows_an_aliased_body_command() {
+        assert!(body_was_minified(&format!(
+            "interp alias {{}} maybe {{}} if\nmaybe{BODY_CALL}"
+        )));
+        // The `::`-qualified spelling of the alias classifies alike.
+        assert!(body_was_minified(&format!(
+            "interp alias {{}} maybe {{}} if\n::maybe{BODY_CALL}"
+        )));
+        // Guard: an unbound `maybe` has no body argument to descend into.
+        assert!(!body_was_minified(&format!("set y 1\nmaybe{BODY_CALL}")));
+    }
+
+    #[test]
+    fn minify_follows_a_renamed_body_command() {
+        assert!(body_was_minified(&format!(
+            "rename if maybe\nmaybe{BODY_CALL}"
+        )));
+        assert!(
+            !body_was_minified(&format!("rename if maybe\nif{BODY_CALL}")),
+            "a renamed-away `if` must not keep the built-in's body grammar"
+        );
+    }
+
+    #[test]
+    fn minify_abstains_for_a_builtin_shadowed_by_a_user_proc() {
+        assert!(
+            !body_was_minified(&format!("proc if {{c b}} {{return 1}}\nif{BODY_CALL}")),
+            "a user `proc if` takes the name over; its braced word is opaque data"
+        );
+        // Guard: the unshadowed built-in still descends.
+        assert!(body_was_minified(&format!("set y 1\nif{BODY_CALL}")));
+    }
+
+    #[test]
+    fn minify_abstains_for_a_dynamic_binding() {
+        assert!(
+            !body_was_minified(&format!("rename $old maybe\nmaybe{BODY_CALL}")),
+            "a dynamic rename must not give `maybe` a body grammar"
+        );
+        assert!(
+            body_was_minified(&format!("rename $old maybe\nif{BODY_CALL}")),
+            "a dynamic rename must not take `if`'s body grammar away either"
+        );
+    }
+
+    /// The aggressive tier's keyword-abbreviation phase reads the resolved
+    /// head too: the subcommand table it shortens against belongs to the
+    /// command the head *is*.
+    #[test]
+    fn keyword_abbreviation_follows_an_aliased_head() {
+        let registry = CommandRegistry::build_default();
+        let aliased = minify_tcl_aggressive(
+            "interp alias {} str {} string\nstr toupper $::env(HOME)\n",
+            "tcl8.6",
+            true,
+            &registry,
+        );
+        assert!(
+            aliased.source.contains("str tou "),
+            "an alias of `string` must abbreviate against `string`'s subcommand \
+             table; got {:?}",
+            aliased.source
+        );
+        // Guard: an unbound `str` has no subcommand table, so `toupper` is
+        // ordinary data and must survive untouched.
+        let unbound = minify_tcl_aggressive(
+            "set y 1\nstr toupper $::env(HOME)\n",
+            "tcl8.6",
+            true,
+            &registry,
+        );
+        assert!(
+            unbound.source.contains("str toupper"),
+            "{:?}",
+            unbound.source
+        );
+    }
+
+    /// The aggressive tier's rename-*barrier* scan reads the resolved head:
+    /// `upvar`'s "aliases the caller's frame" trait bars local-name compaction
+    /// in every scope, and that trait belongs to the command a head *is*.
+    ///
+    /// The witness is whether `set local 1` survives: barred, the local keeps
+    /// its name; unbarred, it compacts to a single letter.
+    #[test]
+    fn rename_barriers_follow_the_resolved_head() {
+        let registry = CommandRegistry::build_default();
+        const UPVAR_BODY: &str =
+            "proc p {v} {\n    set local 1\n    upvar 1 $v alias\n    return $local\n}\n";
+        const PEEK_BODY: &str =
+            "proc p {v} {\n    set local 1\n    peek 1 $v alias\n    return $local\n}\n";
+        let minify = |src: &str| minify_tcl_aggressive(src, "tcl8.6", true, &registry).source;
+        let barred = |src: &str| minify(src).contains("set local 1");
+
+        // Baseline: the built-in bars compaction.
+        assert!(barred(&format!("set y 1\n{UPVAR_BODY}")));
+
+        // A user `proc upvar` takes the name over, so the built-in's trait no
+        // longer applies and the local compacts.
+        assert!(
+            !barred(&format!("proc upvar {{a b c}} {{return 1}}\n{UPVAR_BODY}")),
+            "a shadowed `upvar` must not keep barring compaction"
+        );
+        // Likewise once the name has been renamed away.
+        assert!(
+            !barred(&format!("rename upvar peek\n{UPVAR_BODY}")),
+            "a renamed-away `upvar` must not keep barring compaction"
+        );
+        // An alias of `upvar` bars exactly as `upvar` does.
+        assert!(barred(&format!(
+            "interp alias {{}} peek {{}} upvar\n{PEEK_BODY}"
+        )));
+        // A dynamic rename proves nothing about either name.
+        assert!(
+            !barred(&format!("rename $old peek\n{PEEK_BODY}")),
+            "a dynamic rename must not make `peek` a barrier"
+        );
+        assert!(
+            barred(&format!("rename $old peek\n{UPVAR_BODY}")),
+            "a dynamic rename must not take `upvar`'s barrier away either"
+        );
     }
 }

--- a/rust/tcl-lsp-core/src/oo_body.rs
+++ b/rust/tcl-lsp-core/src/oo_body.rs
@@ -91,7 +91,42 @@ pub fn outer_definition_grammar(
     Some(grammar)
 }
 
-/// The grammar the recursion into `command`'s body arguments should carry,
+/// A command head in its two forms — the spelling the source wrote, and the
+/// registry name that spelling effectively resolves to.
+///
+/// The two are the same for almost every head, and differ once the document
+/// rebinds a name (`namespace import`, `interp alias`, `rename`, a built-in
+/// shadowing `proc` — see [`tcl_compiler::head_identity`]).  Which of the two a
+/// test must read is a real distinction, not a convenience:
+///
+/// * a **global command** lookup reads [`Self::resolved`], so `::snit::type`,
+///   a proven alias of it, and the bare spelling all answer alike (and a
+///   rebound spelling answers nothing);
+/// * a **lexical keyword** test reads [`Self::written`], because a member
+///   sub-keyword (`method`, `constructor`) exists only inside a definition
+///   body and is not a command binding at all — a top-level
+///   `rename method …` says nothing about the word inside an `oo::define`.
+#[derive(Debug, Clone, Copy)]
+pub struct HeadWords<'a> {
+    /// The head exactly as the source spells it.
+    pub written: &'a str,
+    /// The registry name the spelling resolves to — empty when the head was
+    /// provably rebound, which every registry query then answers "unknown" for.
+    pub resolved: &'a str,
+}
+
+impl<'a> HeadWords<'a> {
+    /// A head with nothing proven about it: written and resolved alike.
+    #[must_use]
+    pub fn plain(written: &'a str) -> Self {
+        Self {
+            written,
+            resolved: written,
+        }
+    }
+}
+
+/// The grammar the recursion into `head`'s body arguments should carry,
 /// given the enclosing grammar `cur` (`None` = not in a definition body).
 /// `args` excludes the command head.
 ///
@@ -102,12 +137,14 @@ pub fn outer_definition_grammar(
 ///   a member body drops out of it.
 #[must_use]
 pub fn next_definition_grammar(
-    command: &str,
+    head: HeadWords<'_>,
     args: &[&str],
     cur: Option<&'static DefinitionBodyGrammar>,
     registry: &CommandRegistry,
 ) -> Option<&'static DefinitionBodyGrammar> {
-    if let Some(g) = outer_definition_grammar(command, args, registry) {
+    let HeadWords { written, resolved } = head;
+    let command = written;
+    if let Some(g) = outer_definition_grammar(resolved, args, registry) {
         Some(g)
     } else if let Some(g) = cur.filter(|g| is_member(g, command)) {
         // A member command inside a definition body normally drops out of
@@ -559,22 +596,54 @@ mod tests {
         let tcloo = Some(&TCLOO_GRAMMAR);
         // Entering an outer (metaclass create) body switches on.
         assert!(
-            next_definition_grammar("oo::class", &["create", "C", "{b}"], None, &reg).is_some()
+            next_definition_grammar(
+                HeadWords::plain("oo::class"),
+                &["create", "C", "{b}"],
+                None,
+                &reg
+            )
+            .is_some()
         );
-        assert!(next_definition_grammar("snit::type", &["C", "{b}"], None, &reg).is_some());
-        // `oo::define` script form switches on; member form does not.
-        assert!(next_definition_grammar("oo::define", &["C", "{script}"], None, &reg).is_some());
         assert!(
-            next_definition_grammar("oo::define", &["C", "method", "m", "{}", "{b}"], None, &reg)
-                .is_none()
+            next_definition_grammar(HeadWords::plain("snit::type"), &["C", "{b}"], None, &reg)
+                .is_some()
+        );
+        // `oo::define` script form switches on; member form does not.
+        assert!(
+            next_definition_grammar(
+                HeadWords::plain("oo::define"),
+                &["C", "{script}"],
+                None,
+                &reg
+            )
+            .is_some()
+        );
+        assert!(
+            next_definition_grammar(
+                HeadWords::plain("oo::define"),
+                &["C", "method", "m", "{}", "{b}"],
+                None,
+                &reg
+            )
+            .is_none()
         );
         // A method body inside a class body switches off.
-        assert!(next_definition_grammar("method", &["m", "{}", "{b}"], tcloo, &reg).is_none());
+        assert!(
+            next_definition_grammar(HeadWords::plain("method"), &["m", "{}", "{b}"], tcloo, &reg)
+                .is_none()
+        );
         // Control flow inherits.
-        assert!(next_definition_grammar("if", &["{c}", "{b}"], tcloo, &reg).is_some());
-        assert!(next_definition_grammar("if", &["{c}", "{b}"], None, &reg).is_none());
+        assert!(
+            next_definition_grammar(HeadWords::plain("if"), &["{c}", "{b}"], tcloo, &reg).is_some()
+        );
+        assert!(
+            next_definition_grammar(HeadWords::plain("if"), &["{c}", "{b}"], None, &reg).is_none()
+        );
         // Inner commands at top level (no enclosing grammar) don't fire.
-        assert!(next_definition_grammar("method", &["m", "{}", "{b}"], None, &reg).is_none());
+        assert!(
+            next_definition_grammar(HeadWords::plain("method"), &["m", "{}", "{b}"], None, &reg)
+                .is_none()
+        );
     }
 
     #[test]
@@ -585,22 +654,45 @@ mod tests {
         // definition script — the block keeps the enclosing grammar so its
         // members (`method`, `variable`, …) are still recognised.
         assert!(
-            next_definition_grammar("private", &["{ method m {} {} }"], tcloo, &reg).is_some(),
+            next_definition_grammar(
+                HeadWords::plain("private"),
+                &["{ method m {} {} }"],
+                tcloo,
+                &reg
+            )
+            .is_some(),
             "private {{ … }} block keeps the class grammar",
         );
         assert!(
-            next_definition_grammar("self", &["{ method m {} {} }"], tcloo, &reg).is_some(),
+            next_definition_grammar(
+                HeadWords::plain("self"),
+                &["{ method m {} {} }"],
+                tcloo,
+                &reg
+            )
+            .is_some(),
             "self {{ … }} block keeps the class grammar",
         );
         // But the wrapper form that nests an inner member (`self method …`,
         // `private method …`) is an ordinary member body and drops out.
         assert!(
-            next_definition_grammar("self", &["method", "m", "{}", "{b}"], tcloo, &reg).is_none(),
+            next_definition_grammar(
+                HeadWords::plain("self"),
+                &["method", "m", "{}", "{b}"],
+                tcloo,
+                &reg
+            )
+            .is_none(),
             "self method … body is ordinary Tcl",
         );
         assert!(
-            next_definition_grammar("private", &["method", "m", "{}", "{b}"], tcloo, &reg)
-                .is_none(),
+            next_definition_grammar(
+                HeadWords::plain("private"),
+                &["method", "m", "{}", "{b}"],
+                tcloo,
+                &reg
+            )
+            .is_none(),
             "private method … body is ordinary Tcl",
         );
         // The block form only preserves grammar for a member that actually

--- a/rust/tcl-lsp-core/src/oo_body.rs
+++ b/rust/tcl-lsp-core/src/oo_body.rs
@@ -91,40 +91,7 @@ pub fn outer_definition_grammar(
     Some(grammar)
 }
 
-/// A command head in its two forms — the spelling the source wrote, and the
-/// registry name that spelling effectively resolves to.
-///
-/// The two are the same for almost every head, and differ once the document
-/// rebinds a name (`namespace import`, `interp alias`, `rename`, a built-in
-/// shadowing `proc` — see [`tcl_compiler::head_identity`]).  Which of the two a
-/// test must read is a real distinction, not a convenience:
-///
-/// * a **global command** lookup reads [`Self::resolved`], so `::snit::type`,
-///   a proven alias of it, and the bare spelling all answer alike (and a
-///   rebound spelling answers nothing);
-/// * a **lexical keyword** test reads [`Self::written`], because a member
-///   sub-keyword (`method`, `constructor`) exists only inside a definition
-///   body and is not a command binding at all — a top-level
-///   `rename method …` says nothing about the word inside an `oo::define`.
-#[derive(Debug, Clone, Copy)]
-pub struct HeadWords<'a> {
-    /// The head exactly as the source spells it.
-    pub written: &'a str,
-    /// The registry name the spelling resolves to — empty when the head was
-    /// provably rebound, which every registry query then answers "unknown" for.
-    pub resolved: &'a str,
-}
-
-impl<'a> HeadWords<'a> {
-    /// A head with nothing proven about it: written and resolved alike.
-    #[must_use]
-    pub fn plain(written: &'a str) -> Self {
-        Self {
-            written,
-            resolved: written,
-        }
-    }
-}
+pub use tcl_compiler::head_identity::HeadWords;
 
 /// The grammar the recursion into `head`'s body arguments should carry,
 /// given the enclosing grammar `cur` (`None` = not in a definition body).

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -2374,7 +2374,7 @@ fn insert_object_method_overrides(
     if let Some(hierarchy) = classes
         && let Some(cls) = candidates
             .iter()
-            .find(|c| user_class_provides_method(hierarchy, c, method))
+            .find(|c| user_class_provides_method(hierarchy, registry, c, method))
     {
         mark_method_word(seg, overrides);
         insert_user_configure_options(seg, hierarchy, cls, method, overrides);
@@ -2500,26 +2500,46 @@ fn collection_head_element_classes<'a>(
 /// ancestor), or it is an `TclOO` builtin every instance answers — `destroy`,
 /// or `configure` / `cget` on an `oo::configurable` receiver.  `hierarchy` is
 /// the local file's hierarchy or a workspace-merged project index.
-fn user_class_provides_method(hierarchy: &ClassHierarchy, class: &str, method: &str) -> bool {
+fn user_class_provides_method(
+    hierarchy: &ClassHierarchy,
+    registry: &CommandRegistry,
+    class: &str,
+    method: &str,
+) -> bool {
     if hierarchy.method_target(class, method).is_some() {
         return true;
     }
     match method {
         "destroy" => true,
-        "configure" | "cget" => class_is_configurable(hierarchy, class),
+        "configure" | "cget" => class_is_configurable(hierarchy, registry, class),
         _ => false,
     }
 }
 
-/// Whether `class` (or any class in its MRO) is `oo::configurable` or declares
-/// configurable properties — the classes whose `configure` / `cget` accept
-/// `-property` options.
-fn class_is_configurable(hierarchy: &ClassHierarchy, class: &str) -> bool {
+/// Whether `class` (or any class in its MRO) is created by a metaclass whose
+/// instances answer `configure` / `cget` against declared properties, or itself
+/// declares such properties.
+///
+/// The metaclass test is registry data
+/// ([`Traits::CONFIGURES_BY_PROPERTY`](tcl_registry::Traits::CONFIGURES_BY_PROPERTY)),
+/// not the `metaclass == "oo::configurable"` spelling comparison this used to
+/// make (issue #1275).  A metaclass the registry does not model answers
+/// `false`: abstention, so an unknown factory is never treated as configurable.
+/// tclsh 9.0.4: an `oo::configurable` instance answers `[$pt configure]` with
+/// its property dict, an `oo::class` one answers `unknown method "configure"`.
+fn class_is_configurable(
+    hierarchy: &ClassHierarchy,
+    registry: &CommandRegistry,
+    class: &str,
+) -> bool {
     class_mro(hierarchy, class).iter().any(|c| {
-        hierarchy
-            .classes
-            .get(c)
-            .is_some_and(|cd| cd.metaclass == "oo::configurable" || !cd.properties.is_empty())
+        hierarchy.classes.get(c).is_some_and(|cd| {
+            !cd.properties.is_empty()
+                || registry.get(&cd.metaclass).is_some_and(|spec| {
+                    spec.traits
+                        .contains(tcl_registry::prelude::Traits::CONFIGURES_BY_PROPERTY)
+                })
+        })
     })
 }
 
@@ -2716,6 +2736,7 @@ fn resolve_class_in_hierarchy(hierarchy: &ClassHierarchy, name: &str) -> Option<
 fn insert_self_method_overrides(
     seg: &tcl_compiler::segmenter::SegmentedCommand,
     classes: Option<&ClassHierarchy>,
+    registry: &CommandRegistry,
     enclosing_class: Option<&str>,
     overrides: &mut FxHashMap<u32, ArgOverride>,
 ) {
@@ -2742,7 +2763,7 @@ fn insert_self_method_overrides(
     let Some(class) = resolve_class_in_hierarchy(hierarchy, class_name) else {
         return;
     };
-    if !user_class_provides_method(hierarchy, &class, method) {
+    if !user_class_provides_method(hierarchy, registry, &class, method) {
         return;
     }
     mark_method_word(seg, overrides);
@@ -4762,7 +4783,13 @@ fn collect_script(
         merge_list_quoted_command_overrides(&seg, ctx, registry, deferred_role, &mut overrides);
         // `my method …` inside a class body resolves against the enclosing
         // class's MRO (the most common `TclOO` dispatch form).
-        insert_self_method_overrides(&seg, ctx.classes, ctx.enclosing_class, &mut overrides);
+        insert_self_method_overrides(
+            &seg,
+            ctx.classes,
+            registry,
+            ctx.enclosing_class,
+            &mut overrides,
+        );
         // Regex-source tracking: retag a `set` value word that feeds a regexp
         // pattern as a (substitution-aware) regex.
         mark_regex_source_words(&seg, ctx.regex_sources, &mut overrides);
@@ -7729,6 +7756,48 @@ mod tests {
     /// the Tk option database."  The second documented form, `installhull
     /// $win`, names an already-created widget and carries no static type word,
     /// so it must state nothing.
+    /// Issue #1275's third residual — `configure` / `cget` resolution must key
+    /// off registry data about the metaclass, not the `oo::configurable`
+    /// spelling.
+    ///
+    /// tclsh 9.0.4 oracle: an `oo::configurable create Point { property x y … }`
+    /// instance answers `[$pt configure]` with `-x 27 -y 0`, while an
+    /// `oo::class` instance answers `unknown method "configure": must be
+    /// destroy or m` for both `configure` and `cget`.
+    #[test]
+    fn configure_resolves_by_metaclass_trait_not_spelling() {
+        use tcl_compiler::analyser::Analyser;
+        use tcl_compiler::compilation_unit::CompilationUnit;
+        let registry = reg();
+        let resolves = |src: &str, line: u32| {
+            let cu = CompilationUnit::build_for(src, &registry, false);
+            let analysis = Analyser::new().analyse(src, "tcl9.0");
+            decode_semantic(&full_with_cu_and_analysis(
+                src,
+                "tcl9.0",
+                &registry,
+                Some(&cu),
+                Some(&analysis),
+            ))
+            .iter()
+            .any(|&(l, _, _, k, m)| l == line && k == TokenKind::Method as u32 && m == 0)
+        };
+        // A configurable class declaring no property of its own: only the
+        // metaclass fact can answer, and it must.
+        let src = "oo::configurable create Point {}\nset pt [Point new]\n$pt configure -x 1\n";
+        assert!(
+            resolves(src, 2),
+            "`configure` on an `oo::configurable` instance must resolve"
+        );
+        // A plain `oo::class` instance answers no `configure` at all.
+        let src =
+            "oo::class create Plain { method m {} {} }\nset p [Plain new]\n$p configure -x 1\n";
+        assert!(
+            !resolves(src, 2),
+            "`configure` on a plain `oo::class` instance must not resolve"
+        );
+    }
+
     #[test]
     fn snit_installhull_types_the_implicit_hull_component() {
         use tcl_compiler::analyser::Analyser;

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -4679,6 +4679,66 @@ fn emit_command_head(
 /// executed code, not a value that might or might not be invoked later, so
 /// list-quoted detection inside it is decided fresh at the next `[…]` hop
 /// rather than inherited.
+/// The head's *effective command identity*, resolved once so every
+/// registry-driven pass in [`collect_script`] keys off it (issue #1185).
+///
+/// Covers a command imported from an exported namespace (`namespace import
+/// tcltest::*` → `test` = `tcltest::test`, issue #776), a static `interp alias`
+/// / `rename`, and a top-level `proc` that shadows a built-in.  Facts are
+/// offset-keyed, so a binding never retroactively re-tags an earlier call, and
+/// a head with nothing proven about it keeps its own spelling.
+///
+/// The overwhelmingly common document binds nothing, so the lookup is skipped
+/// entirely rather than hashing every head in the file.
+fn head_identity_of<'a>(
+    ctx: ScriptCtx<'a>,
+    head_text: &'a str,
+    head_tok: Token,
+) -> tcl_compiler::head_identity::HeadIdentity<'a> {
+    if ctx.head_identities.is_empty() {
+        return tcl_compiler::head_identity::HeadIdentity::Command(head_text);
+    }
+    ctx.head_identities
+        .resolve(head_text, head_tok.span.start())
+}
+
+/// Emit the command-head token for a *static* head word — a resolvable command
+/// name, painted as a single function / keyword / namespace token.
+///
+/// A *computed* head — `$obj method …`, `[dict get …] method …`, `[Class new]
+/// method …`, a multi-fragment `chartV$node` — is not a command name we can
+/// resolve, so it must not be painted as one; the caller gates on
+/// [`head_is_computed`] and lets those tokens fall through to the ordinary
+/// argument path, where a `[…]` recurses into its inner script and a `$var`
+/// reads as a variable — an accurate picture of the runtime dispatch rather
+/// than a misleading command highlight (issue #797).
+fn emit_static_command_head(
+    ctx: ScriptCtx<'_>,
+    seg: &tcl_compiler::segmenter::SegmentedCommand,
+    identity: tcl_compiler::head_identity::HeadIdentity<'_>,
+    entries: &mut Vec<Entry>,
+) {
+    let Some(&head_tok) = seg.argv.first() else {
+        return;
+    };
+    emit_command_head(
+        ctx.line_index,
+        ctx.full_source,
+        CommandHead {
+            tok: head_tok,
+            text: &seg.texts[0],
+            resolved: identity.spec_name(),
+            rebound: identity.is_rebound(),
+        },
+        HeadContext {
+            oo_grammar: ctx.oo_grammar,
+            scoped_env: ctx.scoped_env,
+        },
+        ctx.registry,
+        entries,
+    );
+}
+
 fn collect_script(
     ctx: ScriptCtx<'_>,
     text: &str,
@@ -4691,7 +4751,6 @@ fn collect_script(
         return;
     }
     let full_source = ctx.full_source;
-    let line_index = ctx.line_index;
     let registry = ctx.registry;
     for seg in segment_commands_with_offset_and_config(
         text,
@@ -4705,50 +4764,11 @@ fn collect_script(
         // built-in carries the `defaultLibrary` modifier.
         let head_tok = seg.argv[0];
         let head_text = &seg.texts[0];
-        // Resolve the head's *effective command identity* once, and let every
-        // registry-driven pass below key off it (issue #1185).  This covers a
-        // command imported from an exported namespace (`namespace import
-        // tcltest::*` → `test` = `tcltest::test`, issue #776), a static
-        // `interp alias` / `rename`, and a top-level `proc` that shadows a
-        // built-in.  Facts are offset-keyed, so a binding never retroactively
-        // re-tags an earlier call, and a head with nothing proven about it
-        // keeps its own spelling.
-        // The overwhelmingly common document binds nothing, so skip the lookup
-        // entirely rather than hashing every head in the file.
-        let identity = if ctx.head_identities.is_empty() {
-            tcl_compiler::head_identity::HeadIdentity::Command(head_text.as_str())
-        } else {
-            ctx.head_identities
-                .resolve(head_text, head_tok.span.start())
-        };
+        let identity = head_identity_of(ctx, head_text, head_tok);
         let resolved_head: &str = identity.spec_name();
-        // A *static* head word is a resolvable command name: emit it as a
-        // single command-head token (function / keyword / namespace).  A
-        // *computed* head — `$obj method …`, `[dict get …] method …`,
-        // `[Class new] method …`, a multi-fragment `chartV$node` — is not a
-        // command name we can resolve, so it must not be painted as one.  Its
-        // tokens fall through to the ordinary argument path below, where a
-        // `[…]` recurses into its inner script (`dict get $Pins $pin`) and a
-        // `$var` reads as a variable — an accurate picture of the runtime
-        // dispatch rather than a misleading command highlight (issue #797).
         let computed_head = head_is_computed(&seg);
         if !computed_head {
-            emit_command_head(
-                line_index,
-                full_source,
-                CommandHead {
-                    tok: head_tok,
-                    text: head_text,
-                    resolved: resolved_head,
-                    rebound: identity.is_rebound(),
-                },
-                HeadContext {
-                    oo_grammar: ctx.oo_grammar,
-                    scoped_env: ctx.scoped_env,
-                },
-                registry,
-                entries,
-            );
+            emit_static_command_head(ctx, &seg, identity, entries);
         }
 
         // The command's argument words (head excluded), borrowed once as
@@ -4801,11 +4821,14 @@ fn collect_script(
         // on for their bare script form, not their member (`method …`) forms —
         // hence the args are consulted.  Command substitutions and expressions
         // always run in ordinary (non-definition) context (see `plain_ctx`).
+        // The outer-definer lookup reads the *resolved* head; the member
+        // sub-keyword test reads the written one (issue #1275).
+        let head_words = crate::oo_body::HeadWords {
+            written: head_text,
+            resolved: resolved_head,
+        };
         let next_oo = crate::oo_body::next_definition_grammar(
-            crate::oo_body::HeadWords {
-                written: head_text,
-                resolved: resolved_head,
-            },
+            head_words,
             &arg_texts,
             ctx.oo_grammar,
             registry,

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -5362,12 +5362,14 @@ fn augment_snit_handles(
             .into_iter()
             .collect();
     scan_snit_handles(
-        source,
+        &HandleScanCtx {
+            full_source: source,
+            dialect,
+            classes,
+            member_bindings: &member_bindings,
+        },
         source,
         0,
-        dialect,
-        classes,
-        &member_bindings,
         object_classes,
         0,
     );
@@ -5534,20 +5536,40 @@ fn bind_loop_vars_for_call(
     }
 }
 
+/// Everything an object-handle scan needs that does **not** change as the walk
+/// recurses into nested scripts — bundled so the recursive worker keeps a small
+/// signature.
+struct HandleScanCtx<'a> {
+    /// The whole document, for resolving a nested script's absolute span.
+    full_source: &'a str,
+    /// The document's dialect, for the lexer config and registry.
+    dialect: &'a str,
+    /// The class hierarchy (local, or workspace-merged in project mode), or
+    /// `None` when no analysis is available.
+    classes: Option<&'a ClassHierarchy>,
+    /// The member-body installers this dialect's definers inject, resolved once
+    /// per document (see
+    /// [`CommandRegistry::member_body_handle_bindings`](tcl_registry::CommandRegistry::member_body_handle_bindings)).
+    member_bindings: &'a FxHashMap<&'static str, tcl_registry::HandleBindingSpec>,
+}
+
 /// Recursive worker for [`augment_snit_handles`].
 fn scan_snit_handles(
-    full_source: &str,
+    ctx: &HandleScanCtx<'_>,
     text: &str,
     base_offset: u32,
-    dialect: &str,
-    classes: Option<&ClassHierarchy>,
-    member_bindings: &FxHashMap<&'static str, tcl_registry::HandleBindingSpec>,
     handles: &mut ObjectClassMap,
     depth: u32,
 ) {
     if MAX_TOKEN_RECURSION.exceeded(depth) {
         return;
     }
+    let HandleScanCtx {
+        full_source,
+        dialect,
+        classes,
+        member_bindings,
+    } = *ctx;
     let registry = tcl_registry::registry_for_dialect(dialect);
     for seg in segment_commands_with_offset_and_config(
         text,
@@ -5588,12 +5610,9 @@ fn scan_snit_handles(
             };
             if let Some((cstart, inner)) = inner_span {
                 scan_snit_handles(
-                    full_source,
+                    ctx,
                     inner,
                     u32::try_from(cstart).unwrap_or(0),
-                    dialect,
-                    classes,
-                    member_bindings,
                     handles,
                     depth + 1,
                 );

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -382,14 +382,35 @@ fn is_language_keyword_sub_keyword(name: &str) -> bool {
 /// of the non-command sub-keywords ([`is_language_keyword_sub_keyword`]); a
 /// `::`-qualified name is a `namespace`; everything else is a
 /// `function`.
-fn classify_command_head(name: &str, registry: &CommandRegistry) -> TokenKind {
-    let is_keyword = registry.get(name).is_some_and(|s| {
+///
+/// The keyword / operator tests run against the head's *effective identity*
+/// (`resolved`), so `interp alias {} myforeach {} foreach` makes `myforeach` a
+/// keyword and a `rename foreach ""` stops the bare spelling being one — issue
+/// #1185.  The `::`-qualified test stays on the written spelling: an imported
+/// bare `test` resolves to `tcltest::test` without becoming a namespace token.
+fn classify_command_head(head: CommandHead<'_>, registry: &CommandRegistry) -> TokenKind {
+    let CommandHead {
+        text: name,
+        resolved,
+        rebound,
+        ..
+    } = head;
+    // A head whose registry binding was provably taken over is an ordinary
+    // user command, whatever the built-in of the same spelling would have been.
+    if rebound {
+        return if name.contains("::") {
+            TokenKind::Namespace
+        } else {
+            TokenKind::Function
+        };
+    }
+    let is_keyword = registry.get(resolved).is_some_and(|s| {
         s.traits
             .contains(tcl_registry::prelude::Traits::LANGUAGE_KEYWORD)
     }) || is_language_keyword_sub_keyword(name);
     if is_keyword {
         TokenKind::Keyword
-    } else if is_operator_command(name, registry) {
+    } else if is_operator_command(resolved, registry) {
         // A bare operator used as a command head (`+ 3 4`, `tcl::mathop`
         // style).
         TokenKind::Operator
@@ -4037,15 +4058,15 @@ struct ScriptCtx<'a> {
     /// Def-site literal value words to highlight as regex (regex-source
     /// tracking), keyed by word start.  Empty when disabled.
     regex_sources: &'a FxHashMap<u32, Span>,
-    /// Bare command names imported into the global namespace via
-    /// `namespace import EXPORTING::*`, mapped to their qualified registry
-    /// spec name (`test` → `tcltest::test`) plus the byte offset of the
-    /// enabling `namespace import` statement.  Lets the registry-driven
-    /// overrides resolve an unqualified imported command to its spec (issue
-    /// #776) — but only for a head at or after the import, so an import cannot
-    /// retroactively re-tag an earlier same-named command.  Empty when the
-    /// document has no `namespace import`.
-    head_aliases: &'a FxHashMap<String, (String, u32)>,
+    /// The document's statically proven command-identity facts — which
+    /// registry command each head spelling really names at each point in the
+    /// file.  Folds together `namespace import` (`test` → `tcltest::test`,
+    /// issue #776), `interp alias`, static `rename`, and a top-level `proc`
+    /// that shadows a built-in (issue #1185).  Every fact is offset-keyed, so
+    /// a binding cannot retroactively re-tag an earlier call; every shape that
+    /// cannot be proven leaves the head alone.  Empty for a document that
+    /// binds nothing.  See [`crate::head_identity`].
+    head_identities: &'a crate::head_identity::HeadIdentityMap,
     /// Object-handle → class-name provenance for the whole document, so a
     /// `$var method …` dispatch can resolve the method's options through the
     /// registry's object-class model (issue #748).  Empty when no
@@ -4452,13 +4473,21 @@ struct HeadContext {
 }
 
 /// The command head being classified: its token, the source text, and the
-/// namespace-resolved name (an imported bare name resolves to its qualified
-/// registry spec).  Bundled so [`emit_command_head`] keeps a small signature.
+/// head's *effective command identity* — the registry name the spelling really
+/// resolves to at this point in the document (an imported bare name resolves
+/// to its qualified spec; a static `interp alias` / `rename` resolves to its
+/// target; a shadowed built-in resolves to nothing).  Bundled so
+/// [`emit_command_head`] keeps a small signature.
 #[derive(Clone, Copy)]
 struct CommandHead<'a> {
     tok: Token,
     text: &'a str,
+    /// The registry name to resolve grammar against — empty when the head was
+    /// rebound (see [`crate::head_identity::HeadIdentity::spec_name`]).
     resolved: &'a str,
+    /// Whether the head's registry binding was provably taken over by a
+    /// `rename` / alias / shadowing `proc` (issue #1185).
+    rebound: bool,
 }
 
 fn emit_command_head(
@@ -4473,6 +4502,7 @@ fn emit_command_head(
         tok: head_tok,
         text: head_text,
         resolved: resolved_head,
+        rebound,
     } = head;
     let HeadContext {
         oo_grammar,
@@ -4511,7 +4541,7 @@ fn emit_command_head(
         );
         return;
     }
-    let full_kind = classify_command_head(head_text, registry);
+    let full_kind = classify_command_head(head, registry);
     // Split any `…::name` head (namespace-qualified command or keyword) into a
     // namespace prefix + final-segment command token.
     if head_text.contains("::")
@@ -4525,7 +4555,9 @@ fn emit_command_head(
         // — the prefix is as much part of the built-in's name as the tail, which
         // already gets the modifier below, and a theme that dims stdlib names was
         // dimming only half of one (#898 §11).
-        let builtin_mods = if registry.get(head_text).is_some() {
+        // Resolved, not written: a `rename`d-away built-in must lose the
+        // modifier and a proven alias of one must gain it (issue #1185).
+        let builtin_mods = if registry.get(resolved_head).is_some() {
             MOD_DEFAULT_LIBRARY
         } else {
             0
@@ -4545,16 +4577,17 @@ fn emit_command_head(
         // language keyword (TclOO `oo::class` etc.), else function;
         // `defaultLibrary` when the full name is a registry built-in.
         let tail = &head_text[idx + 2..];
-        let is_keyword = registry.get(head_text).is_some_and(|s| {
-            s.traits
-                .contains(tcl_registry::prelude::Traits::LANGUAGE_KEYWORD)
-        }) || is_language_keyword_sub_keyword(tail);
+        let is_keyword = !rebound
+            && (registry.get(resolved_head).is_some_and(|s| {
+                s.traits
+                    .contains(tcl_registry::prelude::Traits::LANGUAGE_KEYWORD)
+            }) || is_language_keyword_sub_keyword(tail));
         let kind = if is_keyword {
             TokenKind::Keyword
         } else {
             TokenKind::Function
         };
-        let mods = if kind == TokenKind::Function && registry.get(head_text).is_some() {
+        let mods = if kind == TokenKind::Function && registry.get(resolved_head).is_some() {
             MOD_DEFAULT_LIBRARY
         } else {
             0
@@ -4627,18 +4660,22 @@ fn collect_script(
         // built-in carries the `defaultLibrary` modifier.
         let head_tok = seg.argv[0];
         let head_text = &seg.texts[0];
-        // Resolve an unqualified command imported from an exported namespace
-        // (`namespace import tcltest::*` → `test` = `tcltest::test`) to its
-        // qualified registry name, so the registry-driven overrides and the
-        // built-in modifier see the real spec (issue #776).  Only applies when
-        // the enabling import precedes this head in source order (an import
-        // cannot retroactively re-tag an earlier command); falls back to the
-        // literal head otherwise.
-        let resolved_head: &str = ctx
-            .head_aliases
-            .get(head_text)
-            .filter(|(_, import_off)| head_tok.span.start() >= *import_off)
-            .map_or(head_text.as_str(), |(qualified, _)| qualified.as_str());
+        // Resolve the head's *effective command identity* once, and let every
+        // registry-driven pass below key off it (issue #1185).  This covers a
+        // command imported from an exported namespace (`namespace import
+        // tcltest::*` → `test` = `tcltest::test`, issue #776), a static
+        // `interp alias` / `rename`, and a top-level `proc` that shadows a
+        // built-in.  Facts are offset-keyed, so a binding never retroactively
+        // re-tags an earlier call, and a head with nothing proven about it
+        // keeps its own spelling.
+        // The overwhelmingly common document binds nothing, so skip the lookup
+        // entirely rather than hashing every head in the file.
+        let identity = if ctx.head_identities.is_empty() {
+            crate::head_identity::HeadIdentity::Command(head_text.as_str())
+        } else {
+            ctx.head_identities.resolve(head_text, head_tok.span.start())
+        };
+        let resolved_head: &str = identity.spec_name();
         // A *static* head word is a resolvable command name: emit it as a
         // single command-head token (function / keyword / namespace).  A
         // *computed* head — `$obj method …`, `[dict get …] method …`,
@@ -4657,6 +4694,7 @@ fn collect_script(
                     tok: head_tok,
                     text: head_text,
                     resolved: resolved_head,
+                    rebound: identity.is_rebound(),
                 },
                 HeadContext {
                     oo_grammar: ctx.oo_grammar,
@@ -5365,19 +5403,29 @@ fn scan_loop_vars(
     }
 }
 
-/// Syntactic scan for snit object-handle bindings that the compiler CFG does not
+/// Syntactic scan for object-handle bindings that the compiler CFG does not
 /// surface, binding the handle variable to its class so a `$NAME method …`
 /// dispatch in a snit method body resolves.  snit method bodies are **not**
 /// lowered into the compiler CFG (only token-walked, like the `$self` path), so
 /// a source scan is how these classes reach the handle map — the same technique
-/// the loop-var scan uses.  Two shapes are recognised:
+/// the loop-var scan uses.
 ///
-/// - `install NAME using TYPE …` — a snit component install; and
-/// - `set NAME [TYPE inst …]` — snit's *bare-word* constructor (`$type $name`
-///   creates an instance), gated on `TYPE` being a **known snit-family class**
-///   (so we know bare construction is valid) whose first argument is **not a
-///   typemethod** (`info` / `destroy` / a declared `typemethod`), which would be
-///   a type-command call rather than a construction.
+/// Which calls bind a handle, and at which argument indices, is registry data
+/// ([`tcl_registry::HandleBindingSpec`], issue #1185) — the walker names no
+/// command, so `::set` and a provable alias of it bind exactly like `set`.  Two
+/// layouts exist today:
+///
+/// - `install NAME using TYPE …`, snit's component installer, declared on the
+///   snit definition-body grammar's
+///   [`member_body_commands`](tcl_registry::definer::DefinitionBodyGrammar::member_body_commands)
+///   because the word exists only inside a snit member body; and
+/// - `set NAME [TYPE inst …]`, whose value word may be a *bare-word*
+///   construction (`$type $name` creates an instance) — gated on `TYPE` being a
+///   visible class of a family whose grammar declares
+///   [`bare_word_construction`](tcl_registry::definer::DefinitionBodyGrammar::bare_word_construction),
+///   and whose first argument is **not** a typemethod (`info` / `destroy` / a
+///   declared `typemethod`), which would be a type-command call rather than a
+///   construction.
 ///
 /// Highlight-only and sound by abstention: the bare-constructor form only fires
 /// when `TYPE` is visible in the hierarchy (local, or workspace-merged in
@@ -5388,7 +5436,109 @@ fn augment_snit_handles(
     classes: Option<&ClassHierarchy>,
     object_classes: &mut ObjectClassMap,
 ) {
-    scan_snit_handles(source, source, 0, dialect, classes, object_classes, 0);
+    // The member-body installers this dialect's definers inject, resolved once
+    // per document rather than per segment.
+    let member_bindings: FxHashMap<&'static str, tcl_registry::HandleBindingSpec> =
+        tcl_registry::registry_for_dialect(dialect)
+            .member_body_handle_bindings()
+            .into_iter()
+            .collect();
+    scan_snit_handles(
+        source,
+        source,
+        0,
+        dialect,
+        classes,
+        &member_bindings,
+        object_classes,
+        0,
+    );
+}
+
+/// Bind one resolved [`BoundHandle`] into the handle map.
+///
+/// The two class sources are resolved differently and both abstain rather than
+/// guess: a [`HandleClassSource::Word`] is a type name used as written (only a
+/// static bareword qualifies), while a
+/// [`HandleClassSource::ConstructionValue`] must parse as a command
+/// substitution whose head is a visible class of a family that constructs by
+/// bare word.
+///
+/// [`BoundHandle`]: tcl_registry::BoundHandle
+/// [`HandleClassSource::Word`]: tcl_registry::HandleClassSource::Word
+/// [`HandleClassSource::ConstructionValue`]: tcl_registry::HandleClassSource::ConstructionValue
+fn bind_object_handle(
+    bound: &tcl_registry::BoundHandle<'_>,
+    classes: Option<&ClassHierarchy>,
+    registry: &CommandRegistry,
+    handles: &mut ObjectClassMap,
+) {
+    if bound.name.is_empty() || bound.name.contains(['$', '[', ' ']) {
+        return;
+    }
+    match bound.class_source {
+        tcl_registry::HandleClassSource::Word(_) => {
+            let type_name = bound.class_word;
+            if type_name.is_empty() || type_name.contains(['$', '[', ' ']) {
+                return;
+            }
+            let qualified = format!("::{}", type_name.trim_start_matches("::"));
+            handles
+                .entry(bound.name.to_owned())
+                .or_default()
+                .insert(qualified);
+        }
+        tcl_registry::HandleClassSource::ConstructionValue(_) => {
+            let Some(hierarchy) = classes else { return };
+            let Some((cmd, args)) =
+                tcl_compiler::value_shapes::parse_command_substitution(bound.class_word)
+            else {
+                return;
+            };
+            let Some(class) = resolve_class_in_hierarchy(hierarchy, &cmd) else {
+                return;
+            };
+            if !family_constructs_by_bare_word(hierarchy, registry, &class) {
+                return;
+            }
+            // A bare construction needs an instance-name argument that is not a
+            // (non-`create`) typemethod call on the type.
+            if !args
+                .first()
+                .is_some_and(|a| a == "create" || !class_declares_typemethod(hierarchy, registry, &class, a))
+            {
+                return;
+            }
+            handles
+                .entry(bound.name.to_owned())
+                .or_default()
+                .insert(class);
+        }
+    }
+}
+
+/// Whether `class`'s definer family constructs an instance from a **bare
+/// instance name** (`$type $name`), rather than only through an explicit
+/// `create` / `new`.
+///
+/// Registry data — the class's metaclass spec's definition-body grammar
+/// declares it ([`DefinitionBodyGrammar::bare_word_construction`]) — replacing
+/// the `metaclass.starts_with("snit::")` spelling test the scan used to make
+/// (issue #1185).  A class whose metaclass is not in the registry answers
+/// `false`: abstention, so an unknown factory is never treated as one.
+///
+/// [`DefinitionBodyGrammar::bare_word_construction`]: tcl_registry::definer::DefinitionBodyGrammar::bare_word_construction
+fn family_constructs_by_bare_word(
+    hierarchy: &ClassHierarchy,
+    registry: &CommandRegistry,
+    class: &str,
+) -> bool {
+    hierarchy
+        .classes
+        .get(class)
+        .and_then(|cd| registry.get(&cd.metaclass))
+        .and_then(|spec| spec.definition_body)
+        .is_some_and(|grammar| grammar.bare_word_construction)
 }
 
 /// Whether `name` is a type-command call (typemethod) on class `class` — one
@@ -5474,6 +5624,7 @@ fn scan_snit_handles(
     base_offset: u32,
     dialect: &str,
     classes: Option<&ClassHierarchy>,
+    member_bindings: &FxHashMap<&'static str, tcl_registry::HandleBindingSpec>,
     handles: &mut ObjectClassMap,
     depth: u32,
 ) {
@@ -5487,49 +5638,21 @@ fn scan_snit_handles(
         tcl_lexer::LexerConfig::for_file_dialect(dialect).at_depth(depth),
     ) {
         let texts = &seg.texts;
-        match texts.first().map(String::as_str) {
-            // `install NAME using TYPE ?args…?` — snit component installation.
-            // Only a static bareword NAME / TYPE qualify.
-            Some("install") if texts.len() >= 4 && texts[2] == "using" => {
-                let name = texts[1].as_str();
-                let type_name = texts[3].as_str();
-                if !name.is_empty()
-                    && !name.contains(['$', '[', ' '])
-                    && !type_name.is_empty()
-                    && !type_name.contains(['$', '[', ' '])
-                {
-                    let qualified = format!("::{}", type_name.trim_start_matches("::"));
-                    handles
-                        .entry(name.to_owned())
-                        .or_default()
-                        .insert(qualified);
-                }
+        if let Some(head) = texts.first() {
+            let args: Vec<&str> = texts[1..].iter().map(String::as_str).collect();
+            // The layout comes from the registry — `set`'s own
+            // `CommandSpec::binds_handle`, or the member-body installer the
+            // class system's definition-body grammar declares — so no command
+            // word is spelled here and `::set` binds exactly like `set`
+            // (issue #1185).
+            if let Some(binding) = member_bindings
+                .get(head.as_str())
+                .copied()
+                .or_else(|| registry.handle_binding(head).copied())
+                && let Some(bound) = binding.resolve(&args)
+            {
+                bind_object_handle(&bound, classes, registry, handles);
             }
-            // `set NAME [TYPE inst …]` — snit bare-word constructor.
-            Some("set") if texts.len() >= 3 => {
-                if let Some(hierarchy) = classes
-                    && !texts[1].is_empty()
-                    && !texts[1].contains(['$', '[', ' '])
-                    && let Some((cmd, args)) =
-                        tcl_compiler::value_shapes::parse_command_substitution(&texts[2])
-                    && let Some(class) = resolve_class_in_hierarchy(hierarchy, &cmd)
-                    && hierarchy
-                        .classes
-                        .get(&class)
-                        .is_some_and(|cd| cd.metaclass.starts_with("snit::"))
-                    // A bare construction needs an instance-name argument that is
-                    // not a (non-`create`) typemethod call on the type.
-                    && args
-                        .first()
-                        .is_some_and(|a| {
-                            a == "create"
-                                || !class_declares_typemethod(hierarchy, registry, &class, a)
-                        })
-                {
-                    handles.entry(texts[1].clone()).or_default().insert(class);
-                }
-            }
-            _ => {}
         }
         for (i, tok) in seg.argv.iter().enumerate() {
             if !seg.single_token_word.get(i).copied().unwrap_or(false) {
@@ -5553,6 +5676,7 @@ fn scan_snit_handles(
                     u32::try_from(cstart).unwrap_or(0),
                     dialect,
                     classes,
+                    member_bindings,
                     handles,
                     depth + 1,
                 );
@@ -5606,10 +5730,17 @@ fn collect_entries(
             .collect()
     });
 
-    // Bare-name aliases for commands imported from an exported namespace
-    // (`namespace import tcltest::*` → `test` = `tcltest::test`).  Empty (no
-    // lookups) unless the document actually imports something.
-    let head_aliases = imported_command_aliases(source, dialect, registry);
+    // The document's command-identity facts: bare-name aliases for commands
+    // imported from an exported namespace (`namespace import tcltest::*` →
+    // `test` = `tcltest::test`), plus every statically proven `interp alias` /
+    // `rename` / built-in-shadowing `proc` (issue #1185).  Empty (no lookups)
+    // unless the document actually binds something.
+    let head_identities = crate::head_identity::command_head_identities(
+        source,
+        dialect,
+        registry,
+        imported_command_aliases(source, dialect, registry),
+    );
 
     // Object-handle → class provenance (`set chart [ticklecharts::chart new]`
     // → `chart`), so a `$chart Xaxis -name …` dispatch resolves the method's
@@ -5652,7 +5783,7 @@ fn collect_entries(
         oo_grammar: None,
         scoped_env: None,
         regex_sources: &regex_sources,
-        head_aliases: &head_aliases,
+        head_identities: &head_identities,
         object_classes: &object_classes,
         object_collections: &object_collections,
         classes,
@@ -9276,14 +9407,55 @@ mod tests {
         assert_eq!(comments, 41, "expected one token per comment line");
     }
 
+    /// A `CommandHead` for a head with nothing bound about it — the written
+    /// spelling is its own identity.
+    fn plain_head(name: &str) -> CommandHead<'_> {
+        CommandHead {
+            tok: Token {
+                kind: TokenType::Esc,
+                span: tcl_lexer::Span::new(0, u32::try_from(name.len()).unwrap_or(0)),
+                content_offset: 0,
+                in_quote: false,
+            },
+            text: name,
+            resolved: name,
+            rebound: false,
+        }
+    }
+
     #[test]
     fn classify_command_head_picks_namespace_for_qualified() {
         assert_eq!(
-            classify_command_head("::myns::greet", &reg()),
+            classify_command_head(plain_head("::myns::greet"), &reg()),
             TokenKind::Namespace,
         );
-        assert_eq!(classify_command_head("greet", &reg()), TokenKind::Function);
-        assert_eq!(classify_command_head("if", &reg()), TokenKind::Keyword);
+        assert_eq!(
+            classify_command_head(plain_head("greet"), &reg()),
+            TokenKind::Function
+        );
+        assert_eq!(
+            classify_command_head(plain_head("if"), &reg()),
+            TokenKind::Keyword
+        );
+    }
+
+    /// The keyword / operator tests key off the head's *effective identity*,
+    /// so a proven alias of a keyword is a keyword and a rebound head is not
+    /// (issue #1185).
+    #[test]
+    fn classify_command_head_follows_the_effective_identity() {
+        let r = reg();
+        let aliased = CommandHead {
+            resolved: "foreach",
+            ..plain_head("myforeach")
+        };
+        assert_eq!(classify_command_head(aliased, &r), TokenKind::Keyword);
+        let rebound = CommandHead {
+            resolved: "",
+            rebound: true,
+            ..plain_head("foreach")
+        };
+        assert_eq!(classify_command_head(rebound, &r), TokenKind::Function);
     }
 
     // range variant
@@ -9788,6 +9960,143 @@ mod tests {
             kinds_only("puts {%08x}\n", &r),
             kinds_only("puts {plain}\n", &r)
         );
+    }
+
+    // Issue #1185 residual 1 — a head's *effective command identity* (a static
+    // `interp alias`, a `rename`, a shadowing top-level `proc`) drives the
+    // grammar, so calling a built-in through a proven alias classifies exactly
+    // like calling it directly, and calling a name whose binding was taken
+    // over does not.
+
+    /// TP — `interp alias {} myfmt {} format` makes `myfmt %08x 42` classify
+    /// exactly like `format %08x 42`.
+    ///
+    /// tclsh-proof (9.0.4 and 8.6.16, byte-identical): `interp alias {} myfmt
+    /// {} format; myfmt %08x 42` → `0000002a`.
+    #[test]
+    fn a_static_interp_alias_inherits_the_targets_grammar() {
+        let r = reg();
+        let bind = "interp alias {} myfmt {} format\n";
+        // The argument kinds of a direct `format` call — its head token is the
+        // one thing an aliased or qualified spelling legitimately differs in.
+        let direct = kinds_only("format {%08x} 42\n", &r);
+        let direct_args = &direct[1..];
+        for head in ["myfmt", "::myfmt"] {
+            let call = kinds_only(&format!("{bind}{head} {{%08x}} 42\n"), &r);
+            assert_eq!(
+                &call[call.len() - direct_args.len()..],
+                direct_args,
+                "`{head}` must classify its arguments like a direct `format` call"
+            );
+        }
+        // Without the alias the same call is an ordinary unknown command whose
+        // argument stays a plain string.
+        let unaliased = kinds_only("myfmt {%08x} 42\n", &r);
+        assert!(
+            unaliased.len() < direct.len(),
+            "an unbound name must not get format sub-tokens: {unaliased:?}"
+        );
+    }
+
+    /// TP — `rename foreach myforeach` moves the loop grammar (and the
+    /// keyword classification) onto the new name.
+    #[test]
+    fn a_static_rename_moves_the_grammar_to_the_new_name() {
+        let r = reg();
+        let bind = "rename upvar myupvar\n";
+        let direct = kinds_only("upvar 1 src local\n", &r);
+        let renamed = kinds_only(&format!("{bind}myupvar 1 src local\n"), &r);
+        let baseline = kinds_only(bind, &r);
+        assert_eq!(
+            &renamed[baseline.len()..],
+            &direct[..],
+            "a renamed call must classify like the original"
+        );
+    }
+
+    /// FP — a name whose binding was taken over gets **no** registry grammar:
+    /// after `rename format origfmt` the bare `format` is gone, and a top-level
+    /// `proc format` shadows the built-in outright.
+    ///
+    /// tclsh-proof (9.0.4 and 8.6.16): `rename format origfmt; proc format
+    /// {args} {return USER}; format x` → `USER`; `origfmt %d 7` → `7`.
+    #[test]
+    fn a_rebound_builtin_loses_its_grammar() {
+        let r = reg();
+        let direct = kinds_only("format {%08x} 42\n", &r);
+        for bind in [
+            "rename format origfmt\n",
+            "rename format {}\n",
+            "proc format {args} { return USER }\n",
+            "interp alias {} format {} myformatter\n",
+        ] {
+            let baseline = kinds_only(bind, &r);
+            let after = kinds_only(&format!("{bind}format {{%08x}} 42\n"), &r);
+            assert!(
+                after.len() - baseline.len() < direct.len(),
+                "`{}` must strip format's specifier sub-tokens, got {after:?}",
+                bind.trim()
+            );
+        }
+    }
+
+    /// FN guard — a binding only applies from its own statement onwards, so a
+    /// call *before* the `rename` still classifies as the built-in.
+    #[test]
+    fn a_binding_does_not_retroactively_retag_earlier_calls() {
+        let r = reg();
+        let direct = kinds_only("format {%08x} 42\n", &r);
+        let before = kinds_only("format {%08x} 42\nrename format origfmt\n", &r);
+        let rename_only = kinds_only("rename format origfmt\n", &r);
+        assert_eq!(
+            &before[..direct.len()],
+            &direct[..],
+            "the call before the rename must keep the built-in's grammar"
+        );
+        assert_eq!(&before[direct.len()..], &rename_only[..]);
+    }
+
+    /// TN — a binding the analyser cannot prove states nothing, so the head
+    /// keeps its literal identity rather than gaining a wrong one.
+    #[test]
+    fn unprovable_bindings_abstain() {
+        let r = reg();
+        let plain = kinds_only("myfmt {%08x} 42\n", &r);
+        for bind in [
+            // Dynamic alias target / name, dynamic rename source.
+            "interp alias {} myfmt {} $target\n",
+            "interp alias {} $n {} format\n",
+            "rename $old myfmt\n",
+            // Pre-bound arguments shift every index.
+            "interp alias {} myfmt {} format %08x\n",
+            // A child interpreter's command table is not this one's.
+            "interp alias slave myfmt {} format\n",
+            // Not an unconditional top-level statement.
+            "if {$x} { interp alias {} myfmt {} format }\n",
+        ] {
+            let baseline = kinds_only(bind, &r);
+            let after = kinds_only(&format!("{bind}myfmt {{%08x}} 42\n"), &r);
+            assert_eq!(
+                &after[baseline.len()..],
+                &plain[..],
+                "`{}` must not give `myfmt` a grammar",
+                bind.trim()
+            );
+        }
+    }
+
+    /// FP — a `proc` in another namespace, or one that shadows nothing, states
+    /// no fact: only a global-namespace redefinition of a built-in takes a name
+    /// over (tclsh 9.0.4: inside `namespace eval ::n`, `proc format` defines
+    /// `::n::format` and the global `format` is untouched).
+    #[test]
+    fn a_namespaced_proc_does_not_shadow_the_global_builtin() {
+        let r = reg();
+        let direct = kinds_only("format {%08x} 42\n", &r);
+        let bind = "namespace eval ::n { proc format {a} { return 1 } }\n";
+        let baseline = kinds_only(bind, &r);
+        let after = kinds_only(&format!("{bind}format {{%08x}} 42\n"), &r);
+        assert_eq!(&after[baseline.len()..], &direct[..]);
     }
 
     /// TN — a `{*}`-expanded (dynamic) head has no resolvable identity, so no

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -7721,6 +7721,57 @@ mod tests {
         );
     }
 
+    /// snit's `installhull using TYPE …` binds the widget's **implicit** hull
+    /// component, whose name appears nowhere in the call (issue #1275).
+    ///
+    /// VERIFIED against tcllib snit(n): "Given this form, `installhull` creates
+    /// the hull widget, and initializes any options delegated to the hull from
+    /// the Tk option database."  The second documented form, `installhull
+    /// $win`, names an already-created widget and carries no static type word,
+    /// so it must state nothing.
+    #[test]
+    fn snit_installhull_types_the_implicit_hull_component() {
+        use tcl_compiler::analyser::Analyser;
+        use tcl_compiler::compilation_unit::CompilationUnit;
+        let registry = reg();
+        let resolves = |src: &str| {
+            let cu = CompilationUnit::build_for(src, &registry, false);
+            let analysis = Analyser::new().analyse(src, "tcl9.0");
+            decode_semantic(&full_with_cu_and_analysis(
+                src,
+                "tcl9.0",
+                &registry,
+                Some(&cu),
+                Some(&analysis),
+            ))
+            .iter()
+            .any(|&(l, _, _, k, m)| l == 4 && k == TokenKind::Method as u32 && m == 0)
+        };
+        let src = "snit::widget frameish { method draw {} {} }\n\
+                   snit::widgetadaptor chart {\n\
+                   \x20   constructor {args} {\n\
+                   \x20     installhull using frameish\n\
+                   \x20     $hull draw\n\
+                   \x20   }\n\
+                   }\n";
+        assert!(
+            resolves(src),
+            "`installhull using frameish` must type the implicit `hull` component"
+        );
+        // The already-created form has no static type word — abstain.
+        let src = "snit::widget frameish { method draw {} {} }\n\
+                   snit::widgetadaptor chart {\n\
+                   \x20   constructor {args} {\n\
+                   \x20     installhull $win\n\
+                   \x20     $hull draw\n\
+                   \x20   }\n\
+                   }\n";
+        assert!(
+            !resolves(src),
+            "`installhull $win` states no class; `$hull draw` must not resolve"
+        );
+    }
+
     #[test]
     fn snit_bare_constructor_dispatch_resolves() {
         // snit's bare-word constructor `set eng [Engine ${selfns}::e]` (no

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -10011,6 +10011,33 @@ mod tests {
         assert_eq!(&after[baseline.len()..], &direct[..]);
     }
 
+    /// TP — `apply`'s `ArgRole::LambdaLiteral` reaches the renamed and aliased
+    /// spellings too, closing the failure mode written up in the
+    /// apply-lambda-body KCS note: a `[list …]`-quoted or directly-called
+    /// lambda under `rename apply myapply` used to collapse into one opaque
+    /// `string` token.
+    ///
+    /// tclsh-proof (9.0.4 / 8.6.16): `rename apply myapply; myapply {x {puts
+    /// $x}} 5` prints `5`, exactly as the literal call does.
+    #[test]
+    fn apply_lambda_literals_survive_a_rename_or_alias() {
+        let r = reg();
+        let direct = kinds_only("apply {x {puts $x}} 5\n", &r);
+        for bind in [
+            "rename apply myapply\n",
+            "interp alias {} myapply {} apply\n",
+        ] {
+            let baseline = kinds_only(bind, &r);
+            let bound = kinds_only(&format!("{bind}myapply {{x {{puts $x}}}} 5\n"), &r);
+            assert_eq!(
+                &bound[baseline.len()..],
+                &direct[..],
+                "`{}` must keep apply's lambda-literal split",
+                bind.trim()
+            );
+        }
+    }
+
     /// TN — a `{*}`-expanded (dynamic) head has no resolvable identity, so no
     /// grammar is applied to its arguments.
     #[test]

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -4775,7 +4775,10 @@ fn collect_script(
         // hence the args are consulted.  Command substitutions and expressions
         // always run in ordinary (non-definition) context (see `plain_ctx`).
         let next_oo = crate::oo_body::next_definition_grammar(
-            head_text,
+            crate::oo_body::HeadWords {
+                written: head_text,
+                resolved: resolved_head,
+            },
             &arg_texts,
             ctx.oo_grammar,
             registry,

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -2336,7 +2336,7 @@ fn insert_object_method_overrides(
             } else if let Some(cls) = user_constructor_class_of_head(head_text, classes) {
                 vec![cls]
             } else {
-                collection_head_element_classes(head_text, object_collections)
+                collection_head_element_classes(head_text, registry, object_collections)
                     .map(|s| s.iter().cloned().collect())
                     .unwrap_or_default()
             }
@@ -2458,17 +2458,41 @@ fn insert_registry_method_options(
 /// the object-collection map, or `None` when the head is not such a retrieval
 /// or the collection is not tracked.  Resolves the receiver of the issue-#797
 /// `[dict get $Pins $pin] configure -node …` dispatch.
+///
+/// Which calls retrieve an element, and from which argument, is registry data
+/// ([`tcl_registry::types::ReturnElements::ElementOf`], read through
+/// [`CommandRegistry::resolve_call`] exactly as the compiler's type inference
+/// reads it) — so `::lindex` and `::dict get` resolve like their bare
+/// spellings, and no command name is matched here (issue #1185).
 fn collection_head_element_classes<'a>(
     head_text: &str,
+    registry: &CommandRegistry,
     object_collections: &'a ObjectClassMap,
 ) -> Option<&'a std::collections::HashSet<String>> {
+    use tcl_registry::types::ReturnElements;
+
     let (cmd, args) = tcl_compiler::value_shapes::parse_command_substitution(head_text)?;
-    let coll = match (cmd.as_str(), args.as_slice()) {
-        ("dict", [sub, coll, _key]) if sub == "get" => coll,
-        ("lindex", [coll, _idx]) => coll,
-        _ => return None,
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let resolved =
+        registry.resolve_call(&cmd, &arg_refs, tcl_registry::dialects::DialectSet::empty())?;
+    let ReturnElements::ElementOf { container_arg } = resolved.return_elements()? else {
+        return None;
     };
-    object_collections.get(object_handle_name(coll)?)
+    // The fact's indices are relative to after the subcommand word when one
+    // matched (`dict get $d $k` counts from `$d`).
+    let elem_args = if resolved.sub.is_some() {
+        arg_refs.get(1..).unwrap_or(&[])
+    } else {
+        &arg_refs[..]
+    };
+    // Single-step retrieval only: exactly one index/key word after the
+    // container — a multi-level `dict get $d a b` yields an inner dict, not an
+    // element, so the fact does not apply.
+    let container_idx = usize::from(container_arg);
+    if elem_args.len() != container_idx + 2 {
+        return None;
+    }
+    object_collections.get(object_handle_name(elem_args.get(container_idx)?)?)
 }
 
 /// Whether a *user-defined* class provides `method` for an instance dispatch:
@@ -5196,113 +5220,6 @@ fn collect_expr(ctx: ScriptCtx<'_>, tok: Token, entries: &mut Vec<Entry>, depth:
 
 /// Walk the segmenter + comment scan and return raw
 /// [`Entry`] tuples sorted by position.  Shared by `full` and `range`.
-/// Scan `source` for `namespace import` declarations and map each bare command
-/// name they bring into the global scope to its qualified registry spec name
-/// (`test` → `tcltest::test`, issue #776).
-///
-/// Recognises the two literal forms — `namespace import EXPORTING::*`
-/// (import-all) and `namespace import EXPORTING::name` (single) — matched
-/// against the registry's `is_namespace_exported` commands in the exporting
-/// namespace.  A bare name that already resolves to a global command is left
-/// alone (Tcl's own `namespace import` refuses to shadow an existing command
-/// without `-force`, and we must not mis-resolve a genuine builtin).  This is a
-/// highlighting-only convenience: it never changes which commands exist, only
-/// lets the registry-driven argument overrides see the real spec for an
-/// unqualified imported command.  Returns an empty map when nothing is imported.
-fn imported_command_aliases(
-    source: &str,
-    dialect: &str,
-    registry: &CommandRegistry,
-) -> FxHashMap<String, (String, u32)> {
-    let mut aliases: FxHashMap<String, (String, u32)> = FxHashMap::default();
-    // Cheap gate: `namespace import` is the only source of aliases.
-    if !source.contains("namespace") {
-        return aliases;
-    }
-    // Wholesale imports (`ns::*`) and single-name imports (`ns::name`), each
-    // tagged with the byte offset of its `namespace import` statement so an
-    // alias only applies to heads at or after it (source order).  Only
-    // top-level imports are seen — a `namespace import` nested inside a
-    // `namespace eval` body is not a top-level segment, so it never leaks a
-    // global bare alias.
-    let mut import_all: Vec<(String, u32)> = Vec::new();
-    let mut import_one: Vec<(String, String, u32)> = Vec::new();
-    for seg in segment_commands_with_offset_and_config(
-        source,
-        0,
-        tcl_lexer::LexerConfig::for_file_dialect(dialect),
-    ) {
-        if seg.texts.len() < 3 || seg.texts[0] != "namespace" || seg.texts[1] != "import" {
-            continue;
-        }
-        let import_off = seg.argv[0].span.start();
-        for pat in &seg.texts[2..] {
-            // Skip option flags (`-force`); computed patterns are left alone.
-            if pat.starts_with('-') {
-                continue;
-            }
-            if let Some(ns) = pat.strip_suffix("::*") {
-                import_all.push((ns.trim_start_matches(':').to_string(), import_off));
-            } else if let Some((ns, name)) = pat.rsplit_once("::") {
-                import_one.push((
-                    ns.trim_start_matches(':').to_string(),
-                    name.to_string(),
-                    import_off,
-                ));
-            }
-        }
-    }
-    if import_all.is_empty() && import_one.is_empty() {
-        return aliases;
-    }
-    // Record `name → (qualified, offset)`, keeping the *earliest* enabling
-    // import when several would produce the same alias.
-    let mut record = |name: String, qualified: String, off: u32| {
-        aliases
-            .entry(name)
-            .and_modify(|(_, o)| *o = (*o).min(off))
-            .or_insert((qualified, off));
-    };
-    // Import-all: every exported command in an imported namespace whose bare
-    // tail does not already name a global command.
-    if !import_all.is_empty() {
-        for name in registry.command_names() {
-            let Some((ns, tail)) = name.rsplit_once("::") else {
-                continue;
-            };
-            if tail.is_empty() || registry.get(tail).is_some() {
-                continue;
-            }
-            let ns = ns.trim_start_matches(':');
-            let Some(off) = import_all
-                .iter()
-                .filter(|(n, _)| n == ns)
-                .map(|(_, o)| *o)
-                .min()
-            else {
-                continue;
-            };
-            if registry.get(name).is_some_and(|s| s.is_namespace_exported) {
-                record(tail.to_string(), name.to_string(), off);
-            }
-        }
-    }
-    // Single-name imports.
-    for (ns, name, off) in &import_one {
-        if registry.get(name).is_some() {
-            continue;
-        }
-        let qualified = format!("{ns}::{name}");
-        if registry
-            .get(&qualified)
-            .is_some_and(|s| s.is_namespace_exported)
-        {
-            record(name.clone(), qualified, *off);
-        }
-    }
-    aliases
-}
-
 /// Augment the object-handle map with loop variables that iterate an object
 /// collection — `dict for {k v} $coll {…}`, `dict map …`, `foreach v $coll {…}`,
 /// `lmap …` — so a `$v method …` dispatch in the loop body resolves like a
@@ -5735,12 +5652,7 @@ fn collect_entries(
     // `test` = `tcltest::test`), plus every statically proven `interp alias` /
     // `rename` / built-in-shadowing `proc` (issue #1185).  Empty (no lookups)
     // unless the document actually binds something.
-    let head_identities = crate::head_identity::command_head_identities(
-        source,
-        dialect,
-        registry,
-        imported_command_aliases(source, dialect, registry),
-    );
+    let head_identities = crate::head_identity::command_head_identities(source, dialect, registry);
 
     // Object-handle → class provenance (`set chart [ticklecharts::chart new]`
     // → `chart`), so a `$chart Xaxis -name …` dispatch resolves the method's

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -4089,8 +4089,8 @@ struct ScriptCtx<'a> {
     /// that shadows a built-in (issue #1185).  Every fact is offset-keyed, so
     /// a binding cannot retroactively re-tag an earlier call; every shape that
     /// cannot be proven leaves the head alone.  Empty for a document that
-    /// binds nothing.  See [`crate::head_identity`].
-    head_identities: &'a crate::head_identity::HeadIdentityMap,
+    /// binds nothing.  See [`tcl_compiler::head_identity`].
+    head_identities: &'a tcl_compiler::head_identity::HeadIdentityMap,
     /// Object-handle → class-name provenance for the whole document, so a
     /// `$var method …` dispatch can resolve the method's options through the
     /// registry's object-class model (issue #748).  Empty when no
@@ -4507,7 +4507,7 @@ struct CommandHead<'a> {
     tok: Token,
     text: &'a str,
     /// The registry name to resolve grammar against — empty when the head was
-    /// rebound (see [`crate::head_identity::HeadIdentity::spec_name`]).
+    /// rebound (see [`tcl_compiler::head_identity::HeadIdentity::spec_name`]).
     resolved: &'a str,
     /// Whether the head's registry binding was provably taken over by a
     /// `rename` / alias / shadowing `proc` (issue #1185).
@@ -4695,7 +4695,7 @@ fn collect_script(
         // The overwhelmingly common document binds nothing, so skip the lookup
         // entirely rather than hashing every head in the file.
         let identity = if ctx.head_identities.is_empty() {
-            crate::head_identity::HeadIdentity::Command(head_text.as_str())
+            tcl_compiler::head_identity::HeadIdentity::Command(head_text.as_str())
         } else {
             ctx.head_identities
                 .resolve(head_text, head_tok.span.start())
@@ -5671,7 +5671,8 @@ fn collect_entries(
     // `test` = `tcltest::test`), plus every statically proven `interp alias` /
     // `rename` / built-in-shadowing `proc` (issue #1185).  Empty (no lookups)
     // unless the document actually binds something.
-    let head_identities = crate::head_identity::command_head_identities(source, dialect, registry);
+    let head_identities =
+        tcl_compiler::head_identity::command_head_identities(source, dialect, registry);
 
     // Object-handle → class provenance (`set chart [ticklecharts::chart new]`
     // → `chart`), so a `$chart Xaxis -name …` dispatch resolves the method's

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -4673,7 +4673,8 @@ fn collect_script(
         let identity = if ctx.head_identities.is_empty() {
             crate::head_identity::HeadIdentity::Command(head_text.as_str())
         } else {
-            ctx.head_identities.resolve(head_text, head_tok.span.start())
+            ctx.head_identities
+                .resolve(head_text, head_tok.span.start())
         };
         let resolved_head: &str = identity.spec_name();
         // A *static* head word is a resolvable command name: emit it as a
@@ -5503,10 +5504,9 @@ fn bind_object_handle(
             }
             // A bare construction needs an instance-name argument that is not a
             // (non-`create`) typemethod call on the type.
-            if !args
-                .first()
-                .is_some_and(|a| a == "create" || !class_declares_typemethod(hierarchy, registry, &class, a))
-            {
+            if !args.first().is_some_and(|a| {
+                a == "create" || !class_declares_typemethod(hierarchy, registry, &class, a)
+            }) {
                 return;
             }
             handles

--- a/rust/tcl-lsp-server/tests/e2e/editor_features.rs
+++ b/rust/tcl-lsp-server/tests/e2e/editor_features.rs
@@ -514,6 +514,52 @@ fn test_formatting_qualified_control_flow_matches_bare_form() {
     }
 }
 
+/// Issue #1275 — the formatter lays a command out under the grammar of the
+/// command it **is**, not the one it is spelled as, end-to-end through the
+/// packaged server.
+///
+/// tclsh-proof, byte-identical on 8.6.16 and 9.0.4: after
+/// `interp alias {} guard {} if`, `guard {1} {puts a}` runs the `if`; after
+/// `rename if guard` the same holds and `if` is gone
+/// (`info commands if` → empty); after `proc if {c b} {…}` the call runs the
+/// user procedure.
+#[test]
+fn test_formatting_follows_effective_command_identity() {
+    let mut lsp = Lsp::tcl();
+    // A body-role argument is expanded onto its own lines; an unrecognised
+    // command's braced word is left exactly as written.  That difference is
+    // the witness.
+    let mut expanded = |src: &str| -> bool {
+        let uri = unique_uri("tcl");
+        lsp.open_ready(&uri, src);
+        // An already-normalised document yields no edit at all, which for
+        // these inputs means "left as written".
+        full_text(&lsp.formatting(&uri, 4, true))
+            .unwrap_or_else(|| src.to_owned())
+            .contains("{\n    puts a\n}")
+    };
+
+    // TP — an alias of `if`, and the `::`-qualified spelling of that alias.
+    assert!(expanded(
+        "interp alias {} guard {} if\nguard {$x} {puts a}\n"
+    ));
+    assert!(expanded(
+        "interp alias {} guard {} if\n::guard {$x} {puts a}\n"
+    ));
+    // TP — a renamed `if`.
+    assert!(expanded("rename if guard\nguard {$x} {puts a}\n"));
+
+    // FP guard — the vacated name must not keep the built-in's layout.
+    assert!(!expanded("rename if guard\nif {$x} {puts a}\n"));
+    // FP guard — a user `proc if` takes the name over.
+    assert!(!expanded("proc if {c b} { return 1 }\nif {$x} {puts a}\n"));
+    // TN — a dynamic binding proves nothing in either direction.
+    assert!(!expanded("rename $old guard\nguard {$x} {puts a}\n"));
+    assert!(expanded("rename $old guard\nif {$x} {puts a}\n"));
+    // Baseline — an unbound `guard` has no body argument at all.
+    assert!(!expanded("set y 1\nguard {$x} {puts a}\n"));
+}
+
 /// Issue #1186 — `for`'s `start` / `next` scripts stay on the header line
 /// (registry `ArgPresentation::InlineScript`) while only the body expands,
 /// and range formatting agrees with whole-document formatting.

--- a/rust/tcl-lsp-server/tests/e2e/semantic_tokens.rs
+++ b/rust/tcl-lsp-server/tests/e2e/semantic_tokens.rs
@@ -2073,3 +2073,103 @@ fn test_list_built_upvar_declares_its_local_like_the_literal_spelling() {
         "a value slot must not declare anything: {value_tokens:?}"
     );
 }
+
+/// Issue #1185: a command head's grammar follows its **effective command
+/// identity**, not its spelling — end-to-end through the packaged server.
+///
+/// tclsh-proof, byte-identical on 9.0.4 and 8.6.16: `interp alias {} myformat
+/// {} format; myformat %08x 42` → `0000002a`; `rename upvar myupvar` leaves
+/// `myupvar 1 outer local` a working `upvar`; `proc scan {args} {return USER};
+/// scan %d 7` → `USER`.
+#[test]
+fn test_command_identity_drives_argument_grammar() {
+    let mut lsp = Lsp::tcl();
+    let leg = legend(&lsp);
+    let mods = modifiers(&lsp);
+    let decl_bit = modifier_bit(&mods, "declaration");
+    let lib_bit = modifier_bit(&mods, "defaultLibrary");
+
+    let src = concat!(
+        "puts [::format {%08x} 42]\n",          // 0 — qualified spelling
+        "interp alias {} myformat {} format\n", // 1
+        "puts [myformat {%08x} 42]\n",          // 2 — aliased
+        "rename upvar myupvar\n",               // 3
+        "proc reader {} {\n",                   // 4
+        "    myupvar 1 outer local\n",          // 5 — renamed
+        "}\n",                                  // 6
+        "proc scan {args} { return USER }\n",   // 7
+        "puts [scan {%d} 7]\n",                 // 8 — shadowed
+    );
+    let uri = open_doc(&mut lsp, src);
+    let tokens = typed(&mut lsp, &leg, &uri);
+    let types_on = |line: i64| -> Vec<&str> {
+        tokens
+            .iter()
+            .filter(|t| t.line == line)
+            .map(|t| t.ttype.as_str())
+            .collect()
+    };
+
+    // TP — the qualified spelling and the alias both surface printf
+    // conversion sub-tokens, exactly as a bare `format` call does.
+    for line in [0, 2] {
+        let types = types_on(line);
+        assert!(
+            types.contains(&"formatSpec") && types.contains(&"formatPercent"),
+            "line {line} must carry format conversion tokens: {types:?}"
+        );
+    }
+
+    // TP — the renamed `upvar` keeps its keyword classification and still
+    // declares its local variable.
+    let head = tokens
+        .iter()
+        .find(|t| t.line == 5 && covered(src, t) == "myupvar")
+        .unwrap_or_else(|| panic!("no `myupvar` head token: {tokens:?}"));
+    assert_eq!(
+        head.ttype, "keyword",
+        "a renamed keyword stays a keyword: {head:?}"
+    );
+    let local = tokens
+        .iter()
+        .find(|t| t.line == 5 && covered(src, t) == "local")
+        .unwrap_or_else(|| panic!("no `local` token: {tokens:?}"));
+    assert_eq!(
+        (local.ttype.as_str(), local.modifiers & decl_bit != 0),
+        ("variable", true),
+        "the renamed upvar must still declare its local: {local:?}"
+    );
+
+    // FP — a top-level `proc scan` takes the built-in's name over: no scan
+    // grammar, no `defaultLibrary` modifier, and the `%d` word stays a string.
+    let types = types_on(8);
+    assert!(
+        !types.contains(&"formatSpec") && !types.contains(&"formatPercent"),
+        "a shadowed `scan` must get no conversion tokens: {types:?}"
+    );
+    let shadowed = tokens
+        .iter()
+        .find(|t| t.line == 8 && covered(src, t) == "scan")
+        .unwrap_or_else(|| panic!("no shadowed `scan` head token: {tokens:?}"));
+    assert_eq!(
+        shadowed.modifiers & lib_bit,
+        0,
+        "a shadowed built-in must lose `defaultLibrary`: {shadowed:?}"
+    );
+    assert!(
+        types.contains(&"string"),
+        "the shadowed call's `{{%d}}` stays a string: {types:?}"
+    );
+
+    // TN — an unprovable binding states nothing, so the name keeps its own
+    // (unknown-command) identity and its argument stays a plain string.
+    let dyn_src = "interp alias {} myfmt {} $target\nputs [myfmt {%08x} 42]\n";
+    let dyn_uri = open_doc(&mut lsp, dyn_src);
+    let dyn_tokens = typed(&mut lsp, &leg, &dyn_uri);
+    assert!(
+        !dyn_tokens
+            .iter()
+            .any(|t| t.line == 1 && t.ttype == "formatSpec"),
+        "a dynamic alias target must not confer format grammar: {dyn_tokens:?}"
+    );
+}

--- a/rust/tcl-registry/src/commands/tcl/oo_configurable.rs
+++ b/rust/tcl-registry/src/commands/tcl/oo_configurable.rs
@@ -41,6 +41,7 @@ pub fn spec() -> CommandSpec {
         // `oo::abstract` also match, which is why it carries
         // `NOT_PROC_FACTORY` too (see the rationale on `oo_abstract.rs`).
         traits: Traits::IS_OO_METACLASS
+            | Traits::CONFIGURES_BY_PROPERTY
             | Traits::LANGUAGE_KEYWORD
             | Traits::DEFINES_PROCEDURE
             | Traits::NOT_PROC_FACTORY,

--- a/rust/tcl-registry/src/commands/tcl/set_.rs
+++ b/rust/tcl-registry/src/commands/tcl/set_.rs
@@ -111,6 +111,12 @@ pub fn spec() -> CommandSpec {
         arity: Arity::new(1, 2),
         arg_role_resolver: Some(set_arg_roles),
         assigns_variable_at: Some(0),
+        // `set NAME [TYPE inst …]` — when the value word is a construction,
+        // `NAME` ends up holding an object handle.  Registry data so the
+        // object-handle scan resolves the layout for `::set` and a provable
+        // static alias/rename of `set` exactly as for the bare spelling,
+        // instead of matching the word `set` (issue #1185).
+        binds_handle: Some(&crate::handle_binding::SET_BINDS_HANDLE),
         return_type: Some(TclType::String),
         hover: Some(HoverSnippet {
             summary: "Read the value of a variable, or set it to a new value.",

--- a/rust/tcl-registry/src/definer.rs
+++ b/rust/tcl-registry/src/definer.rs
@@ -634,6 +634,44 @@ pub struct DefinitionBodyGrammar {
     /// distinguishing the two must keep them apart.  Empty for families with
     /// no such built-ins.
     pub builtin_type_methods: &'static [&'static str],
+
+    /// Commands this class system makes available **inside every member
+    /// body** and nowhere else — snit's `install NAME using TYPE …`.
+    ///
+    /// The command counterpart of [`Self::implicit_vars`], and deliberately
+    /// *not* a global [`crate::spec::CommandSpec`]: `install` is a snit
+    /// instance-namespace alias, so registering it globally would make a
+    /// user's own `proc install` look like a built-in everywhere.  A consumer
+    /// resolves the layout facts (today: [`MemberBodyCommand::binds_handle`])
+    /// from here, so no walker spells the keyword — issue #1185.  Empty for a
+    /// family that injects no such commands.
+    pub member_body_commands: &'static [MemberBodyCommand],
+
+    /// Whether invoking this family's **type command with a bare instance
+    /// name** constructs an instance — snit's `$type $name ?options…?`
+    /// shorthand for `$type create $name`, documented in snit(n)'s "The
+    /// Type Command" ("if the first argument is not a type method name, it
+    /// is assumed to be an instance name and `create` is implied").
+    ///
+    /// `false` for `TclOO` and [incr Tcl], whose class commands only
+    /// construct through an explicit `create` / `new` method.  A consumer
+    /// deciding whether `set w [Foo $win.a]` binds an object handle reads
+    /// this rather than testing the metaclass name for a `snit::` prefix.
+    pub bare_word_construction: bool,
+}
+
+/// One command a class system injects into every member body — see
+/// [`DefinitionBodyGrammar::member_body_commands`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MemberBodyCommand {
+    /// The command word as invoked inside a member body (`install`).
+    pub name: &'static str,
+    /// One-line description, for hover / completion.
+    pub detail: &'static str,
+    /// How the call binds a variable to an object handle, when it does —
+    /// `install NAME using TYPE …` makes `NAME` a handle of class `TYPE`.
+    /// `None` for an injected command that binds no handle.
+    pub binds_handle: Option<crate::handle_binding::HandleBindingSpec>,
 }
 
 impl DefinitionBodyGrammar {
@@ -650,6 +688,14 @@ impl DefinitionBodyGrammar {
     #[must_use]
     pub fn is_builtin_type_method(&self, name: &str) -> bool {
         self.builtin_type_methods.contains(&name)
+    }
+
+    /// The member-body command `name` names, if this family injects one (see
+    /// [`Self::member_body_commands`]).
+    #[must_use]
+    pub fn member_body_command(&self, name: &str) -> Option<&'static MemberBodyCommand> {
+        let idx = self.member_body_commands.iter().position(|c| c.name == name)?;
+        Some(&self.member_body_commands[idx])
     }
 
     /// Whether `keyword` is a recognised member sub-keyword.
@@ -778,6 +824,15 @@ pub const TCLOO_GRAMMAR: DefinitionBodyGrammar = DefinitionBodyGrammar {
     // TclOO's class-level surface is `oo::define`/`oo::objdefine`, not a set
     // of built-in typemethods on the class command.
     builtin_type_methods: &[],
+    // TclOO injects no extra *commands* into a method body — its helpers
+    // (`my` / `next` / `self` / `link` / `classvariable`) are real global
+    // commands in `::oo::Helpers` with their own specs, reached through
+    // `member_body_namespace_path` above.
+    member_body_commands: &[],
+    // `Foo $win.a` is not a construction in TclOO: a class command only
+    // constructs through `create` / `new` (tclsh 9.0.4: `::C x` →
+    // `unknown method "x"`).
+    bare_word_construction: false,
 };
 
 /// The `namespace path` a `TclOO` member body runs with — see
@@ -818,6 +873,22 @@ const SNIT_MEMBERS: &[MemberSpec] = &[
     MemberSpec::keyword_only("expose"),
 ];
 
+/// The commands snit injects into every member body — see
+/// [`DefinitionBodyGrammar::member_body_commands`].
+///
+/// VERIFIED against tcllib snit(n): `install` is available in any snit
+/// instance method / constructor and, in its `using` form, "creates the
+/// component using the specified command, and assigns the result to the
+/// component variable".  The bare `install NAME $widget` form binds a
+/// component whose class is only known at run time, so no
+/// [`MemberBodyCommand::binds_handle`] fires for it — abstention, not a
+/// guess.
+const SNIT_MEMBER_BODY_COMMANDS: &[MemberBodyCommand] = &[MemberBodyCommand {
+    name: "install",
+    detail: "install a snit component into its component variable",
+    binds_handle: Some(crate::handle_binding::SNIT_INSTALL_BINDS_HANDLE),
+}];
+
 /// The definition-body grammar for a plain snit `type`.  `implicit_vars` is
 /// the set snit injects into *every* member body; the widget definers carry
 /// [`SNIT_WIDGET_GRAMMAR`], whose `implicit_vars` add the `win` / `hull`
@@ -832,6 +903,10 @@ pub const SNIT_GRAMMAR: DefinitionBodyGrammar = DefinitionBodyGrammar {
     // snit(n): "Every snit type has the following type methods: create,
     // info, destroy."  `create` is left out — see the field's doc comment.
     builtin_type_methods: &["info", "destroy"],
+    member_body_commands: SNIT_MEMBER_BODY_COMMANDS,
+    // snit(n), "The Type Command": `$type name ?args?` with a non-typemethod
+    // first word is `$type create name ?args?`.
+    bare_word_construction: true,
 };
 
 /// The definition-body grammar for snit `widget` / `widgetadaptor`: the same
@@ -849,6 +924,10 @@ pub const SNIT_WIDGET_GRAMMAR: DefinitionBodyGrammar = DefinitionBodyGrammar {
     // snit(n): "Every snit type has the following type methods: create,
     // info, destroy."  `create` is left out — see the field's doc comment.
     builtin_type_methods: &["info", "destroy"],
+    member_body_commands: SNIT_MEMBER_BODY_COMMANDS,
+    // snit(n), "The Type Command": `$type name ?args?` with a non-typemethod
+    // first word is `$type create name ?args?`.
+    bare_word_construction: true,
 };
 
 // ---------------------------------------------------------------------------
@@ -899,6 +978,12 @@ pub const ITCL_GRAMMAR: DefinitionBodyGrammar = DefinitionBodyGrammar {
     // [incr Tcl] class commands expose `::itcl::class` introspection rather
     // than built-in typemethods on the class command itself.
     builtin_type_methods: &[],
+    member_body_commands: &[],
+    // itcl constructs through `ClassName objName` *at the class command* —
+    // but only via the documented `ClassName objName ?args?` form, which the
+    // handle scan reaches through `creates_instance_at`, not through this
+    // snit-specific bare-word shorthand.
+    bare_word_construction: false,
 };
 
 #[cfg(test)]

--- a/rust/tcl-registry/src/definer.rs
+++ b/rust/tcl-registry/src/definer.rs
@@ -892,6 +892,25 @@ const SNIT_MEMBER_BODY_COMMANDS: &[MemberBodyCommand] = &[MemberBodyCommand {
     binds_handle: Some(crate::handle_binding::SNIT_INSTALL_BINDS_HANDLE),
 }];
 
+/// The member-body commands a snit **widget** definer injects: `install`, plus
+/// the hull installer only a widget has.
+///
+/// VERIFIED against tcllib snit(n): `installhull` exists for `snit::widget` /
+/// `snit::widgetadaptor`, whose instances have a hull; a plain `snit::type`
+/// has none, so it is deliberately absent from [`SNIT_MEMBER_BODY_COMMANDS`].
+const SNIT_WIDGET_MEMBER_BODY_COMMANDS: &[MemberBodyCommand] = &[
+    MemberBodyCommand {
+        name: "install",
+        detail: "install a snit component into its component variable",
+        binds_handle: Some(crate::handle_binding::SNIT_INSTALL_BINDS_HANDLE),
+    },
+    MemberBodyCommand {
+        name: "installhull",
+        detail: "install the widget's hull component",
+        binds_handle: Some(crate::handle_binding::SNIT_INSTALLHULL_BINDS_HANDLE),
+    },
+];
+
 /// The definition-body grammar for a plain snit `type`.  `implicit_vars` is
 /// the set snit injects into *every* member body; the widget definers carry
 /// [`SNIT_WIDGET_GRAMMAR`], whose `implicit_vars` add the `win` / `hull`
@@ -927,7 +946,7 @@ pub const SNIT_WIDGET_GRAMMAR: DefinitionBodyGrammar = DefinitionBodyGrammar {
     // snit(n): "Every snit type has the following type methods: create,
     // info, destroy."  `create` is left out — see the field's doc comment.
     builtin_type_methods: &["info", "destroy"],
-    member_body_commands: SNIT_MEMBER_BODY_COMMANDS,
+    member_body_commands: SNIT_WIDGET_MEMBER_BODY_COMMANDS,
     // snit(n), "The Type Command": `$type name ?args?` with a non-typemethod
     // first word is `$type create name ?args?`.
     bare_word_construction: true,

--- a/rust/tcl-registry/src/definer.rs
+++ b/rust/tcl-registry/src/definer.rs
@@ -694,7 +694,10 @@ impl DefinitionBodyGrammar {
     /// [`Self::member_body_commands`]).
     #[must_use]
     pub fn member_body_command(&self, name: &str) -> Option<&'static MemberBodyCommand> {
-        let idx = self.member_body_commands.iter().position(|c| c.name == name)?;
+        let idx = self
+            .member_body_commands
+            .iter()
+            .position(|c| c.name == name)?;
         Some(&self.member_body_commands[idx])
     }
 

--- a/rust/tcl-registry/src/handle_binding.rs
+++ b/rust/tcl-registry/src/handle_binding.rs
@@ -39,6 +39,26 @@
 //! [`CommandSpec::binds_handle`]: crate::spec::CommandSpec::binds_handle
 //! [`MemberBodyCommand`]: crate::definer::MemberBodyCommand
 
+/// Which variable a call binds an object handle *to*.
+///
+/// Almost every installer names it in the call (`install NAME using TYPE …`),
+/// but a class system can also bind a variable it provides implicitly: snit's
+/// `installhull using TYPE …` installs the widget's **hull** component, whose
+/// name appears nowhere in the call (snit(n): "Given this form, `installhull`
+/// creates the hull widget"; the hull is reached as `$hull` inside any member
+/// body, which is why it is already one of the widget grammar's
+/// `implicit_vars`).  That is a different *kind* of binding, not another index,
+/// so it is a variant rather than a sentinel value in a `u8`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HandleName {
+    /// The word at this 0-based argument index (after the command name) names
+    /// the variable that receives the handle.
+    Word(u8),
+    /// The call binds a fixed variable the class system provides implicitly in
+    /// every member body — snit's `hull`.  Nothing in the call spells it.
+    Implicit(&'static str),
+}
+
 /// Where the **class** of a bound object handle is written in the call.
 ///
 /// Both variants name a 0-based argument index (after the command name); they
@@ -87,9 +107,8 @@ pub struct HandleKeyword {
 /// How one command binds a variable to an object handle.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HandleBindingSpec {
-    /// 0-based argument index (after the command name) of the word naming the
-    /// **variable** that receives the handle.
-    pub name_at: u8,
+    /// Which variable receives the handle.
+    pub name_from: HandleName,
     /// Where the handle's class is written.
     pub class_from: HandleClassSource,
     /// A literal keyword the layout requires, or `None` when the positional
@@ -126,7 +145,10 @@ impl HandleBindingSpec {
         {
             return None;
         }
-        let name = *args.get(self.name_at as usize)?;
+        let name = match self.name_from {
+            HandleName::Word(i) => *args.get(i as usize)?,
+            HandleName::Implicit(name) => name,
+        };
         let class_word = *args.get(self.class_from.index())?;
         Some(BoundHandle {
             name,
@@ -145,7 +167,7 @@ impl HandleBindingSpec {
 ///
 /// [`CommandSpec::binds_handle`]: crate::spec::CommandSpec::binds_handle
 pub const SET_BINDS_HANDLE: HandleBindingSpec = HandleBindingSpec {
-    name_at: 0,
+    name_from: HandleName::Word(0),
     class_from: HandleClassSource::ConstructionValue(1),
     keyword: None,
 };
@@ -157,10 +179,34 @@ pub const SET_BINDS_HANDLE: HandleBindingSpec = HandleBindingSpec {
 /// the resulting command in the component variable `NAME`, and takes the type
 /// command as the word after the literal `using`.
 pub const SNIT_INSTALL_BINDS_HANDLE: HandleBindingSpec = HandleBindingSpec {
-    name_at: 0,
+    name_from: HandleName::Word(0),
     class_from: HandleClassSource::Word(2),
     keyword: Some(HandleKeyword {
         at: 1,
+        word: "using",
+    }),
+};
+
+/// snit's `installhull using WIDGETTYPE ?args…?` — the hull installer
+/// available inside a `snit::widget` / `snit::widgetadaptor` member body.
+///
+/// VERIFIED against tcllib snit(n), which documents exactly two forms:
+///
+/// * `installhull using widgetType args...` — "Given this form, `installhull`
+///   creates the hull widget, and initializes any options delegated to the
+///   hull from the Tk option database."  The class is the word after `using`.
+/// * `installhull name` — "the hull widget has already been created; note that
+///   its name must be `$win`."  There is no static class word in that form, so
+///   the missing `using` keyword makes [`HandleBindingSpec::resolve`] abstain.
+///
+/// Unlike `install`, the variable it binds is not written in the call at all:
+/// it is the widget's implicit `hull` component, which is why this needs
+/// [`HandleName::Implicit`] rather than another `name_at` row (issue #1275).
+pub const SNIT_INSTALLHULL_BINDS_HANDLE: HandleBindingSpec = HandleBindingSpec {
+    name_from: HandleName::Implicit("hull"),
+    class_from: HandleClassSource::Word(1),
+    keyword: Some(HandleKeyword {
+        at: 0,
         word: "using",
     }),
 };
@@ -199,6 +245,26 @@ mod tests {
         );
         // The one-argument read form (`set x`) binds nothing.
         assert_eq!(spec.resolve(&["axis"]), None);
+    }
+
+    /// snit's hull installer binds the implicit `hull` component, so the
+    /// bound name comes from the descriptor rather than from any argument.
+    #[test]
+    fn installhull_binds_the_implicit_hull_component() {
+        let spec = SNIT_INSTALLHULL_BINDS_HANDLE;
+        assert_eq!(
+            spec.resolve(&["using", "ttk::frame", "-borderwidth", "2"]),
+            Some(BoundHandle {
+                name: "hull",
+                class_word: "ttk::frame",
+                class_source: HandleClassSource::Word(1),
+            })
+        );
+        // `installhull $win` — the already-created form has no static class
+        // word, so the missing keyword makes the layout abstain.
+        assert_eq!(spec.resolve(&["$win"]), None);
+        // A `using` with nothing after it is too short to carry a type word.
+        assert_eq!(spec.resolve(&["using"]), None);
     }
 
     #[test]

--- a/rust/tcl-registry/src/handle_binding.rs
+++ b/rust/tcl-registry/src/handle_binding.rs
@@ -1,0 +1,209 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Object-handle bindings — which argument of a call names a **variable that
+//! ends up holding an object handle**, and which argument says what class the
+//! handle is (issue #1185).
+//!
+//! Two call shapes recur across class systems, and both used to be recognised
+//! by matching the command word in the LSP's snit handle scan:
+//!
+//! ```tcl
+//! install axis using ::verticalAxis $win.a   ;# snit component install
+//! set axis [::verticalAxis $win.a]           ;# snit bare-word construction
+//! ```
+//!
+//! Describing them as registry *data* is what lets the scan resolve the same
+//! layout for every spelling C Tcl resolves to the same command — the bare
+//! word, the explicitly global `::set`, and a provable static alias or rename
+//! — without the walker naming a command.  Adding another binding shape (a
+//! different class system's component installer) is then a
+//! [`HandleBindingSpec`] hung off a [`CommandSpec::binds_handle`] or a
+//! [`MemberBodyCommand`], never a new arm in a walker.
+//!
+//! [`CommandSpec::binds_handle`]: crate::spec::CommandSpec::binds_handle
+//! [`MemberBodyCommand`]: crate::definer::MemberBodyCommand
+
+/// Where the **class** of a bound object handle is written in the call.
+///
+/// Both variants name a 0-based argument index (after the command name); they
+/// differ in whether that word *is* the class name or merely *contains* a
+/// construction of it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HandleClassSource {
+    /// The word at this index names the class directly — snit's
+    /// `install NAME using TYPE ?args…?`, whose `TYPE` word is the type
+    /// command itself.
+    Word(u8),
+    /// The word at this index is a **value** whose command substitution's head
+    /// names the class — `set NAME [TYPE inst …]`, snit's bare-word
+    /// constructor.  A consumer must parse the substitution out of the word
+    /// (and abstain when it is not one) before it has a class name, which is
+    /// why this is a distinct variant rather than another index.
+    ConstructionValue(u8),
+}
+
+impl HandleClassSource {
+    /// The argument index this source reads.
+    #[must_use]
+    pub const fn index(self) -> usize {
+        match self {
+            Self::Word(i) | Self::ConstructionValue(i) => i as usize,
+        }
+    }
+}
+
+/// A literal keyword word a binding layout requires, at a fixed argument
+/// index — snit's `using` in `install NAME using TYPE`.
+///
+/// Without the gate `install a b` would bind `a` to the class `b`; the keyword
+/// is the only thing that distinguishes the component-install form from any
+/// other two-word call, so it belongs in the descriptor rather than in a
+/// consumer's arity guess.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HandleKeyword {
+    /// 0-based argument index (after the command name) the word sits at.
+    pub at: u8,
+    /// The exact word required there.  Matched literally — these are fixed
+    /// syntax words, not abbreviation-matched ensemble subcommands.
+    pub word: &'static str,
+}
+
+/// How one command binds a variable to an object handle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HandleBindingSpec {
+    /// 0-based argument index (after the command name) of the word naming the
+    /// **variable** that receives the handle.
+    pub name_at: u8,
+    /// Where the handle's class is written.
+    pub class_from: HandleClassSource,
+    /// A literal keyword the layout requires, or `None` when the positional
+    /// shape alone identifies it.
+    pub keyword: Option<HandleKeyword>,
+}
+
+/// One call's resolved handle binding — the two words a consumer needs, sliced
+/// out of the argument list by [`HandleBindingSpec::resolve`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BoundHandle<'a> {
+    /// The word naming the variable that receives the handle.
+    pub name: &'a str,
+    /// The word the class is read from — a bare class name for
+    /// [`HandleClassSource::Word`], the whole value word for
+    /// [`HandleClassSource::ConstructionValue`] (the consumer parses the
+    /// substitution).
+    pub class_word: &'a str,
+    /// Which of the two shapes `class_word` is, so the consumer knows whether
+    /// to read it directly or parse a construction out of it.
+    pub class_source: HandleClassSource,
+}
+
+impl HandleBindingSpec {
+    /// Resolve this layout against one call's argument words (head excluded).
+    ///
+    /// Returns `None` when the call is too short or the required keyword is
+    /// absent — abstention, never a guess: `install $comp using $type` and a
+    /// user's own two-word `install` both fall through untouched.
+    #[must_use]
+    pub fn resolve<'a>(&self, args: &[&'a str]) -> Option<BoundHandle<'a>> {
+        if let Some(kw) = self.keyword
+            && args.get(kw.at as usize).copied() != Some(kw.word)
+        {
+            return None;
+        }
+        let name = *args.get(self.name_at as usize)?;
+        let class_word = *args.get(self.class_from.index())?;
+        Some(BoundHandle {
+            name,
+            class_word,
+            class_source: self.class_from,
+        })
+    }
+}
+
+/// `set NAME VALUE` — the variable at 0 receives whatever `VALUE` evaluates
+/// to, so a `[TYPE inst …]` construction there makes `NAME` an object handle.
+///
+/// Attached to `set`'s own [`CommandSpec::binds_handle`], which is what makes
+/// `::set` and a provable `rename set myset` classify identically to the bare
+/// spelling (issue #1185).
+///
+/// [`CommandSpec::binds_handle`]: crate::spec::CommandSpec::binds_handle
+pub const SET_BINDS_HANDLE: HandleBindingSpec = HandleBindingSpec {
+    name_at: 0,
+    class_from: HandleClassSource::ConstructionValue(1),
+    keyword: None,
+};
+
+/// snit's `install NAME using TYPE ?args…?` — the component installer
+/// available inside every snit member body.
+///
+/// VERIFIED against tcllib snit(n): `install` creates the component, stores
+/// the resulting command in the component variable `NAME`, and takes the type
+/// command as the word after the literal `using`.
+pub const SNIT_INSTALL_BINDS_HANDLE: HandleBindingSpec = HandleBindingSpec {
+    name_at: 0,
+    class_from: HandleClassSource::Word(2),
+    keyword: Some(HandleKeyword {
+        at: 1,
+        word: "using",
+    }),
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_needs_its_using_keyword() {
+        let spec = SNIT_INSTALL_BINDS_HANDLE;
+        assert_eq!(
+            spec.resolve(&["axis", "using", "verticalAxis", "$win.a"]),
+            Some(BoundHandle {
+                name: "axis",
+                class_word: "verticalAxis",
+                class_source: HandleClassSource::Word(2),
+            })
+        );
+        // No `using` word — a user's own `install a b c` binds nothing.
+        assert_eq!(spec.resolve(&["a", "b", "c"]), None);
+        // Too short to carry a type word.
+        assert_eq!(spec.resolve(&["axis", "using"]), None);
+    }
+
+    #[test]
+    fn set_binds_its_value_word() {
+        let spec = SET_BINDS_HANDLE;
+        assert_eq!(
+            spec.resolve(&["axis", "[verticalAxis $win.a]"]),
+            Some(BoundHandle {
+                name: "axis",
+                class_word: "[verticalAxis $win.a]",
+                class_source: HandleClassSource::ConstructionValue(1),
+            })
+        );
+        // The one-argument read form (`set x`) binds nothing.
+        assert_eq!(spec.resolve(&["axis"]), None);
+    }
+
+    #[test]
+    fn class_source_reports_its_index() {
+        assert_eq!(HandleClassSource::Word(2).index(), 2);
+        assert_eq!(HandleClassSource::ConstructionValue(1).index(), 1);
+    }
+}

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -71,6 +71,7 @@ pub mod event_facts;
 pub mod events;
 pub mod forms;
 pub mod frame_effect;
+pub mod handle_binding;
 pub mod hooks;
 pub mod hover;
 pub mod lifecycle;
@@ -120,6 +121,9 @@ pub mod prelude {
     pub use crate::events::EventRequires;
     pub use crate::forms::{CommandForm, SubCommandForm};
     pub use crate::frame_effect::{FrameArgLayout, FrameEffectSpec, FrameLevel, FrameLevelWord};
+    pub use crate::handle_binding::{
+        BoundHandle, HandleBindingSpec, HandleClassSource, HandleKeyword,
+    };
     pub use crate::hooks::{
         AnalyserHookId, ArgTypeHint, CodegenHookId, LoweringHookId, TclVersion,
         VersionedConstFoldFn, WasmCodegenHookId,
@@ -158,6 +162,7 @@ pub use dialects::{
     detect_dialect_directive, detect_dialect_from_source, dialect_from_extension,
 };
 pub use frame_effect::{FrameArgLayout, FrameEffectSpec, FrameLevel, FrameLevelWord};
+pub use handle_binding::{BoundHandle, HandleBindingSpec, HandleClassSource, HandleKeyword};
 pub use hover::ArgValue;
 pub use patterns::{FormatType, PatternType};
 pub use presentation::ArgPresentation;

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -122,7 +122,7 @@ pub mod prelude {
     pub use crate::forms::{CommandForm, SubCommandForm};
     pub use crate::frame_effect::{FrameArgLayout, FrameEffectSpec, FrameLevel, FrameLevelWord};
     pub use crate::handle_binding::{
-        BoundHandle, HandleBindingSpec, HandleClassSource, HandleKeyword,
+        BoundHandle, HandleBindingSpec, HandleClassSource, HandleKeyword, HandleName,
     };
     pub use crate::hooks::{
         AnalyserHookId, ArgTypeHint, CodegenHookId, LoweringHookId, TclVersion,
@@ -162,7 +162,9 @@ pub use dialects::{
     detect_dialect_directive, detect_dialect_from_source, dialect_from_extension,
 };
 pub use frame_effect::{FrameArgLayout, FrameEffectSpec, FrameLevel, FrameLevelWord};
-pub use handle_binding::{BoundHandle, HandleBindingSpec, HandleClassSource, HandleKeyword};
+pub use handle_binding::{
+    BoundHandle, HandleBindingSpec, HandleClassSource, HandleKeyword, HandleName,
+};
 pub use hover::ArgValue;
 pub use patterns::{FormatType, PatternType};
 pub use presentation::ArgPresentation;

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -1028,6 +1028,52 @@ impl CommandRegistry {
             .collect()
     }
 
+    /// How a call to `name` binds a variable to an **object handle**, when it
+    /// does — [`CommandSpec::binds_handle`], resolved through [`Self::get`] so
+    /// the explicitly global spelling (`::set`) answers identically to the
+    /// bare one (issue #1185).
+    ///
+    /// The member-body-only installers a class system injects (snit's
+    /// `install NAME using TYPE …`) are **not** here: they are not global
+    /// commands, and live on
+    /// [`crate::definer::DefinitionBodyGrammar::member_body_commands`] —
+    /// enumerate them with [`Self::member_body_handle_bindings`].
+    ///
+    /// [`CommandSpec::binds_handle`]: crate::spec::CommandSpec::binds_handle
+    #[must_use]
+    pub fn handle_binding(
+        &self,
+        name: &str,
+    ) -> Option<&'static crate::handle_binding::HandleBindingSpec> {
+        self.get(name).and_then(|spec| spec.binds_handle)
+    }
+
+    /// Every member-body command that binds an object handle, as
+    /// `(word, layout)` pairs collected from the definition-body grammars this
+    /// registry's definers carry.
+    ///
+    /// These words exist only inside a class system's member bodies (snit's
+    /// `install`), so they deliberately have no global `CommandSpec` — a
+    /// consumer builds a small lookup from this list once per document instead
+    /// of naming the keyword.  Deduplicated: the snit `type` and `widget`
+    /// grammars share one member-body command set.
+    #[must_use]
+    pub fn member_body_handle_bindings(
+        &self,
+    ) -> Vec<(&'static str, crate::handle_binding::HandleBindingSpec)> {
+        let mut out: Vec<_> = self
+            .by_name
+            .values()
+            .filter_map(|specs| specs.last())
+            .filter_map(|spec| spec.definition_body)
+            .flat_map(|grammar| grammar.member_body_commands.iter())
+            .filter_map(|cmd| cmd.binds_handle.map(|layout| (cmd.name, layout)))
+            .collect();
+        out.sort_unstable_by_key(|(name, _)| *name);
+        out.dedup_by_key(|(name, _)| *name);
+        out
+    }
+
     /// Whether `name` **writes or modifies** the variable named by its
     /// first argument (`set` / `append` / `lappend` / `incr` / `lset`):
     /// [`Traits::FIRST_ARG_VARNAME`] minus the destroy-only `unset`
@@ -1841,22 +1887,23 @@ impl CommandRegistry {
     /// the subcommand `first_arg` names (which wins), for the
     /// mutators `proc` / `rename` / `interp alias`.
     ///
-    /// `name` is matched against the spec's own spelling only: a
-    /// `::`-qualified head resolves no effect, mirroring the retired
-    /// per-consumer literal matches (`cmd_name != "rename"`), which
-    /// never matched a qualified spelling — callers that canonicalise
-    /// first (the command-binding lattice strips a leading `::`)
-    /// keep doing so before calling.  The subcommand word must match
-    /// exactly (no prefix abbreviation), as those matches also did.
+    /// `name` resolves through [`Self::get`], so the explicitly global
+    /// spellings answer identically to the bare ones — `::rename format
+    /// ::origfmt`, `::interp alias {} myfmt {} ::origfmt` and `::proc
+    /// ::greet {} {…}` all really do mutate the command table (tclsh 9.0.4
+    /// and 8.6.16, byte-identical; `namespace which -command ::rename` →
+    /// `::rename`).  Resolving only the bare spelling — as the retired
+    /// per-consumer literal matches (`cmd_name != "rename"`) did — made a
+    /// qualified mutator invisible to every binding consumer, the
+    /// false-negative class issue #1185 exists to close.  The subcommand
+    /// word must still match exactly (no prefix abbreviation), as those
+    /// matches also did.
     #[must_use]
     pub fn command_table_effect(
         &self,
         name: &str,
         first_arg: Option<&str>,
     ) -> Option<CommandTableEffect> {
-        if name.starts_with("::") {
-            return None;
-        }
         let spec = self.get(name)?;
         first_arg
             .and_then(|word| spec.subcommand(word))

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -853,6 +853,19 @@ pub struct CommandSpec {
     /// [`crate::scoped`].
     pub body_scope: Option<&'static crate::scoped::ScopedCommandEnv>,
 
+    /// Object-handle binding — `Some` when one of this command's arguments
+    /// names a **variable that ends up holding an object handle**, with
+    /// another argument saying which class (`set NAME [TYPE inst …]`).  The
+    /// handle scan reads the two indices (and any required keyword) from the
+    /// descriptor rather than matching the command word, so `::set` and a
+    /// provable static alias/rename of it bind exactly like the bare spelling
+    /// — issue #1185.  A member-body-only installer such as snit's `install`
+    /// carries the same descriptor on its
+    /// [`crate::definer::MemberBodyCommand`] instead, so it stays scoped to
+    /// the class system that provides it.  `None` = the command binds no
+    /// handle.  See [`crate::handle_binding`].
+    pub binds_handle: Option<&'static crate::handle_binding::HandleBindingSpec>,
+
     /// Object-factory instance-name argument — `Some(idx)` when this command
     /// creates an object *command* named by its `idx`-th argument (0-based,
     /// after the command name), of the class given by its own
@@ -1106,6 +1119,7 @@ impl CommandSpec {
         object_class: None,
         defines_symbol: None,
         body_scope: None,
+        binds_handle: None,
         creates_instance_at: None,
         defines_command_at: None,
         context_gate: None,

--- a/rust/tcl-registry/src/traits.rs
+++ b/rust/tcl-registry/src/traits.rs
@@ -361,6 +361,20 @@ declare_traits! {
     IrulesTopLevelOnly => IRULES_TOP_LEVEL_ONLY;
     /// `TclOO` metaclass (`oo::class`, `oo::abstract`).
     IsOoMetaclass => IS_OO_METACLASS;
+    /// A metaclass whose **instances** answer `configure` / `cget` against
+    /// declared properties — Tcl 9.0's `oo::configurable`.
+    ///
+    /// VERIFIED on tclsh 9.0.4: an `oo::configurable create Point { property x
+    /// y … }` instance answers `[$pt configure]` with `-x 27 -y 0`, while an
+    /// `oo::class` instance answers `unknown method "configure": must be
+    /// destroy or m` for both `configure` and `cget`.  A class created by a
+    /// *further* `oo::configurable` subclass answers too.
+    ///
+    /// The metaclasses all share one `definition_body` grammar, so this is a
+    /// per-command fact rather than a grammar flag — it replaces the
+    /// `metaclass == "oo::configurable"` spelling test the method-resolution
+    /// scan used to make (issue #1275).
+    ConfiguresByProperty => CONFIGURES_BY_PROPERTY;
 
     // Codegen/diagram
     /// Included in diagram extraction.

--- a/rust/tcl-registry/tests/analyser_hooks.rs
+++ b/rust/tcl-registry/tests/analyser_hooks.rs
@@ -290,7 +290,7 @@ fn command_table_effect_stamps_match_the_former_name_matches() {
     );
 
     // The resolver honours the subcommand-over-spec rule and the
-    // exact-spelling contract the retired matches had.
+    // exact-subcommand-spelling contract the retired matches had.
     assert_eq!(
         reg.command_table_effect("proc", Some("x")),
         Some(E::DefinesProcedure)
@@ -305,6 +305,25 @@ fn command_table_effect_stamps_match_the_former_name_matches() {
     );
     assert_eq!(reg.command_table_effect("interp", Some("aliases")), None);
     assert_eq!(reg.command_table_effect("interp", None), None);
-    // A `::`-qualified head never matched the retired literals.
-    assert_eq!(reg.command_table_effect("::rename", Some("old")), None);
+    // A `::`-qualified head resolves the same effect as the bare one
+    // (issue #1185): C Tcl resolves the explicitly global spelling to the
+    // same command, so `::rename format ::origfmt` / `::interp alias {}
+    // myfmt {} format` / `::proc ::greet {} {…}` really do mutate the
+    // command table — verified byte-identical on tclsh 9.0.4 and 8.6.16.
+    assert_eq!(
+        reg.command_table_effect("::rename", Some("old")),
+        Some(E::RenamesCommands)
+    );
+    assert_eq!(
+        reg.command_table_effect("::interp", Some("alias")),
+        Some(E::CreatesAliases)
+    );
+    assert_eq!(
+        reg.command_table_effect("::proc", Some("x")),
+        Some(E::DefinesProcedure)
+    );
+    // Still nothing for an unrelated qualified name or a non-mutating
+    // subcommand word.
+    assert_eq!(reg.command_table_effect("::interp", Some("aliases")), None);
+    assert_eq!(reg.command_table_effect("::puts", Some("x")), None);
 }

--- a/rust/tcl-registry/tests/registry_commands.rs
+++ b/rust/tcl-registry/tests/registry_commands.rs
@@ -2682,3 +2682,98 @@ fn only_namespace_eval_declares_a_namespace() {
         .collect();
     assert_eq!(declarers, vec!["namespace"]);
 }
+
+// ---------------------------------------------------------------------------
+// Object-handle bindings (issue #1185) — which argument of a call becomes a
+// handle, and of what class, is registry data rather than a walker's
+// command-name match.
+// ---------------------------------------------------------------------------
+
+/// `set` declares the handle-binding layout its value word implies, and the
+/// query resolves it through the same `get` path every other registry query
+/// uses — so `::set` answers identically to the bare spelling.
+#[test]
+fn set_declares_its_handle_binding_for_every_spelling() {
+    use tcl_registry::{BoundHandle, HandleClassSource};
+
+    let reg = CommandRegistry::build_default();
+    for spelling in ["set", "::set"] {
+        let layout = reg
+            .handle_binding(spelling)
+            .unwrap_or_else(|| panic!("`{spelling}` must declare a handle binding"));
+        assert_eq!(
+            layout.resolve(&["axis", "[verticalAxis $win.a]"]),
+            Some(BoundHandle {
+                name: "axis",
+                class_word: "[verticalAxis $win.a]",
+                class_source: HandleClassSource::ConstructionValue(1),
+            }),
+            "`{spelling}` must bind argument 0 from its value word"
+        );
+        // The one-argument read form binds nothing.
+        assert_eq!(layout.resolve(&["axis"]), None);
+    }
+    // A command with no such layout answers `None` — no guessing.
+    assert!(reg.handle_binding("puts").is_none());
+    assert!(reg.handle_binding("nosuchcommand").is_none());
+}
+
+/// snit's `install` is a **member-body** command, not a global one: it must
+/// carry its layout on the definition-body grammar and must NOT be registered
+/// as a global spec (which would make a user's own `proc install` look like a
+/// built-in everywhere).
+#[test]
+fn snit_install_is_a_member_body_binding_not_a_global_command() {
+    use tcl_registry::{BoundHandle, HandleClassSource};
+
+    let reg = CommandRegistry::build_default();
+    assert!(
+        reg.get("install").is_none(),
+        "`install` must not become a global command spec"
+    );
+
+    let bindings = reg.member_body_handle_bindings();
+    let (_, layout) = bindings
+        .iter()
+        .find(|(name, _)| *name == "install")
+        .unwrap_or_else(|| panic!("snit must declare an `install` handle binding: {bindings:?}"));
+    assert_eq!(
+        layout.resolve(&["axis", "using", "verticalAxis", "$win.a"]),
+        Some(BoundHandle {
+            name: "axis",
+            class_word: "verticalAxis",
+            class_source: HandleClassSource::Word(2),
+        })
+    );
+    // Without the `using` keyword the layout does not fire, so a user's own
+    // three-word `install` binds nothing.
+    assert_eq!(layout.resolve(&["a", "b", "c"]), None);
+    // The snit `type` and `widget` grammars share one command set — the query
+    // deduplicates rather than reporting the same word twice.
+    assert_eq!(
+        bindings.iter().filter(|(n, _)| *n == "install").count(),
+        1,
+        "member-body bindings must be deduplicated: {bindings:?}"
+    );
+}
+
+/// Whether a class family constructs from a **bare instance name** is a
+/// grammar fact, not a metaclass-name prefix test.
+#[test]
+fn bare_word_construction_is_declared_per_definer_family() {
+    use tcl_registry::definer::{ITCL_GRAMMAR, SNIT_GRAMMAR, SNIT_WIDGET_GRAMMAR, TCLOO_GRAMMAR};
+
+    // snit(n), "The Type Command": `$type name ?args?` implies `create`.
+    assert!(SNIT_GRAMMAR.bare_word_construction);
+    assert!(SNIT_WIDGET_GRAMMAR.bare_word_construction);
+    // tclsh 9.0.4: `oo::class create ::C {}; ::C x` -> `unknown method "x"`.
+    assert!(!TCLOO_GRAMMAR.bare_word_construction);
+    assert!(!ITCL_GRAMMAR.bare_word_construction);
+
+    // Only snit injects member-body commands today; the others inject none.
+    assert!(SNIT_GRAMMAR.member_body_command("install").is_some());
+    assert!(TCLOO_GRAMMAR.member_body_command("install").is_none());
+    assert!(ITCL_GRAMMAR.member_body_command("install").is_none());
+    // An unknown word is not a member-body command of any family.
+    assert!(SNIT_GRAMMAR.member_body_command("nosuchword").is_none());
+}

--- a/rust/tcl-registry/tests/registry_commands.rs
+++ b/rust/tcl-registry/tests/registry_commands.rs
@@ -2763,17 +2763,27 @@ fn snit_install_is_a_member_body_binding_not_a_global_command() {
 fn bare_word_construction_is_declared_per_definer_family() {
     use tcl_registry::definer::{ITCL_GRAMMAR, SNIT_GRAMMAR, SNIT_WIDGET_GRAMMAR, TCLOO_GRAMMAR};
 
-    // snit(n), "The Type Command": `$type name ?args?` implies `create`.
-    assert!(SNIT_GRAMMAR.bare_word_construction);
-    assert!(SNIT_WIDGET_GRAMMAR.bare_word_construction);
-    // tclsh 9.0.4: `oo::class create ::C {}; ::C x` -> `unknown method "x"`.
-    assert!(!TCLOO_GRAMMAR.bare_word_construction);
-    assert!(!ITCL_GRAMMAR.bare_word_construction);
-
-    // Only snit injects member-body commands today; the others inject none.
-    assert!(SNIT_GRAMMAR.member_body_command("install").is_some());
-    assert!(TCLOO_GRAMMAR.member_body_command("install").is_none());
-    assert!(ITCL_GRAMMAR.member_body_command("install").is_none());
-    // An unknown word is not a member-body command of any family.
-    assert!(SNIT_GRAMMAR.member_body_command("nosuchword").is_none());
+    // snit(n), "The Type Command": `$type name ?args?` implies `create`;
+    // tclsh 9.0.4: `oo::class create ::C {}; ::C x` -> `unknown method "x"`,
+    // so only the snit family constructs by bare word.
+    let families = [
+        ("snit::type", &SNIT_GRAMMAR, true),
+        ("snit::widget", &SNIT_WIDGET_GRAMMAR, true),
+        ("TclOO", &TCLOO_GRAMMAR, false),
+        ("itcl::class", &ITCL_GRAMMAR, false),
+    ];
+    for (name, grammar, expected) in families {
+        assert_eq!(
+            grammar.bare_word_construction, expected,
+            "{name}: bare_word_construction"
+        );
+        // Only snit injects member-body commands today; the others inject none.
+        assert_eq!(
+            grammar.member_body_command("install").is_some(),
+            expected,
+            "{name}: member-body `install`"
+        );
+        // An unknown word is not a member-body command of any family.
+        assert!(grammar.member_body_command("nosuchword").is_none());
+    }
 }

--- a/rust/tcl-spec-studio/Cargo.toml
+++ b/rust/tcl-spec-studio/Cargo.toml
@@ -34,5 +34,10 @@ tcl-compiler = { path = "../tcl-compiler" }
 tcl-lexer = { path = "../tcl-lexer" }
 serde_json = { version = "1", features = ["preserve_order"] }
 
+[dev-dependencies]
+# `SetterConstraint::code` is a real `DiagCode`, so the coverage gate needs the
+# type to build the witness constraint it seeds a draft from.
+tcl-core-types = { path = "../tcl-core-types" }
+
 [lints]
 workspace = true

--- a/rust/tcl-spec-studio/src/catalogue.rs
+++ b/rust/tcl-spec-studio/src/catalogue.rs
@@ -437,6 +437,10 @@ pub const TRAITS: &[Variant] = &[
         "iRules: valid only at the top level",
     ),
     v("IS_OO_METACLASS", "a TclOO metaclass factory"),
+    v(
+        "CONFIGURES_BY_PROPERTY",
+        "answers `configure`/`cget` from declared properties",
+    ),
     v("DIAGRAM_ACTION", "an action node in extracted diagrams"),
     v("NEEDS_START_CMD", "needs an explicit start command"),
     v("TAINT_SINK", "a taint sink"),

--- a/rust/tcl-spec-studio/src/catalogue.rs
+++ b/rust/tcl-spec-studio/src/catalogue.rs
@@ -197,6 +197,10 @@ pub const DEFINED_SYMBOL_KINDS: &[Variant] = &[
         "Matcher",
         "a custom result matcher (`tcltest::customMatch MODE command`)",
     ),
+    v(
+        "Event",
+        "an event handler named for its event (iRules `when EVENT { … }`)",
+    ),
 ];
 
 /// [`SideEffectTarget`] — what kind of state an effect touches.

--- a/rust/tcl-spec-studio/src/coverage.rs
+++ b/rust/tcl-spec-studio/src/coverage.rs
@@ -1326,6 +1326,37 @@ mod tests {
         );
     }
 
+    /// The `binds_handle` expression above, written as the Rust a rendered
+    /// module contains: an inline `&`-borrow of a constant struct literal,
+    /// inside a `fn` returning the spec.
+    ///
+    /// The point is that this *compiles*. `binds_handle` wants a `&'static`,
+    /// and only rvalue static promotion makes an inline literal satisfy it —
+    /// so if the renderer's chosen shape ever stopped being promotable, the
+    /// build breaks here rather than in the file an author downloads.
+    fn promoted_binding_spec() -> CommandSpec {
+        CommandSpec {
+            binds_handle: Some(&HandleBindingSpec {
+                name_at: 0,
+                class_from: HandleClassSource::Word(2),
+                keyword: Some(HandleKeyword {
+                    at: 1,
+                    word: "using",
+                }),
+            }),
+            ..CommandSpec::DEFAULT
+        }
+    }
+
+    #[test]
+    fn the_rendered_descriptor_expression_is_the_rust_that_compiles() {
+        assert_eq!(
+            draft::from_command_spec(&promoted_binding_spec())["binds_handle"],
+            draft::from_command_spec(&witness_spec())["binds_handle"],
+            "the promotable literal above and the rendered expression must be the same tokens"
+        );
+    }
+
     /// Every `Expression` entry's field name really appears in the literal the
     /// renderer emits — the mechanical half of the assertions above, so a new
     /// descriptor field that nobody wired into `draft.rs` fails here too.

--- a/rust/tcl-spec-studio/src/coverage.rs
+++ b/rust/tcl-spec-studio/src/coverage.rs
@@ -793,7 +793,7 @@ pub const REPEATED_ARG_LAYOUT: &[Field] = &[
 /// Compile-time witness for [`HANDLE_BINDING_SPEC`].
 pub fn witness_handle_binding_spec(spec: &HandleBindingSpec) {
     let HandleBindingSpec {
-        name_at: _,
+        name_from: _,
         class_from: _,
         keyword: _,
     } = spec;
@@ -801,7 +801,7 @@ pub fn witness_handle_binding_spec(spec: &HandleBindingSpec) {
 
 /// Where the studio surfaces each [`HandleBindingSpec`] field (issue #1185).
 pub const HANDLE_BINDING_SPEC: &[Field] = &[
-    f("name_at", Surface::Expression("binds_handle")),
+    f("name_from", Surface::Expression("binds_handle")),
     f("class_from", Surface::Expression("binds_handle")),
     f("keyword", Surface::Expression("binds_handle")),
 ];
@@ -972,7 +972,7 @@ mod tests {
     use serde_json::{Map, Value, json};
     use tcl_core_types::DiagCode;
     use tcl_registry::arg_role::ArgRole;
-    use tcl_registry::handle_binding::HandleClassSource;
+    use tcl_registry::handle_binding::{HandleClassSource, HandleName};
     use tcl_registry::hover::{FormKind, OptionArity, OptionValue};
     use tcl_registry::side_effects::{ConnectionSide, SideEffectTarget};
     use tcl_registry::symbol_def::DefinedSymbolKind;
@@ -1224,7 +1224,7 @@ mod tests {
     // `name:` in the expected text.
 
     const WITNESS_BINDING: HandleBindingSpec = HandleBindingSpec {
-        name_at: 0,
+        name_from: HandleName::Word(0),
         class_from: HandleClassSource::Word(2),
         keyword: Some(HandleKeyword {
             at: 1,
@@ -1291,7 +1291,8 @@ mod tests {
         assert_eq!(
             d["binds_handle"],
             json!(
-                "Some(&HandleBindingSpec { name_at: 0, class_from: HandleClassSource::Word(2), \
+                "Some(&HandleBindingSpec { name_from: HandleName::Word(0), \
+                 class_from: HandleClassSource::Word(2), \
                  keyword: Some(HandleKeyword { at: 1, word: \"using\" }) })"
             )
         );
@@ -1337,7 +1338,7 @@ mod tests {
     fn promoted_binding_spec() -> CommandSpec {
         CommandSpec {
             binds_handle: Some(&HandleBindingSpec {
-                name_at: 0,
+                name_from: HandleName::Word(0),
                 class_from: HandleClassSource::Word(2),
                 keyword: Some(HandleKeyword {
                     at: 1,
@@ -1407,7 +1408,9 @@ mod tests {
         );
         let source = render_rs::render(&draft::from_command_spec(spec));
         assert!(
-            source.contains("binds_handle: Some(&HandleBindingSpec { name_at: 0, "),
+            source.contains(
+                "binds_handle: Some(&HandleBindingSpec { name_from: HandleName::Word(0), "
+            ),
             "the live binding must render as a literal:\n{source}"
         );
     }

--- a/rust/tcl-spec-studio/src/coverage.rs
+++ b/rust/tcl-spec-studio/src/coverage.rs
@@ -1,0 +1,1395 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The field-coverage gate: every `CommandSpec`-family field is surfaced in
+//! the studio, or explicitly excluded.
+//!
+//! `CommandSpec` gains fields regularly — that is the registry's whole design
+//! (`AGENTS.md`: "extend `CommandSpec` … rather than teaching a consumer about
+//! the command by name").  A field the studio does not carry is **invisible in
+//! the web UI**: an author cannot see or set it, and a spec drafted there
+//! silently omits it.  Keeping the studio complete by hand is what let fields
+//! drift out of it unnoticed, so this module makes it a build failure instead.
+//!
+//! ## How the gate works
+//!
+//! Each covered type has a pair:
+//!
+//! - a `witness_*` function holding an **exhaustive destructuring pattern**
+//!   with no `..` rest — adding a field to the registry type fails to compile
+//!   there, naming it — `error[E0027]: pattern does not mention field <name>` —
+//!   and removing one fails too (`struct … has no field named …`);
+//! - a `&[Field]` table saying, for every one of those fields, **where** the
+//!   studio surfaces it — or why it is deliberately not surfaced.
+//!
+//! This is the field-level twin of [`crate::catalogue`]'s `covered_*`
+//! witnesses, which use exhaustive `match`es so a new enum *variant* breaks the
+//! build.
+//!
+//! ## What "surfaced" means
+//!
+//! The studio's four layers are chained, not independent:
+//!
+//! | layer | how a field reaches it |
+//! |-------|------------------------|
+//! | [`crate::schema`] | a [`crate::schema::FieldSchema`] entry keyed by the Rust field name |
+//! | [`crate::draft`] | the seeder writes that key, so a drafted command carries the value |
+//! | [`crate::render_rs`] | the renderer walks `schema::COMMAND_FIELDS`, so a schema key is emitted automatically |
+//! | `tcl-spec-studio-wasm` | `schema()` serialises the same table and the front-end builds its form from it, so a schema key gets a browser editor automatically |
+//!
+//! So a [`Surface::Key`] entry whose key is in the schema **and** in the
+//! default draft is carried by all four; the tests below check exactly that,
+//! and render a real spec to prove the value survives the round trip.
+//!
+//! ## Adding a field to `CommandSpec` (or any type below)
+//!
+//! 1. Add a [`crate::schema::FieldSchema`] entry for it in `src/schema.rs`.
+//! 2. Seed it in `src/draft.rs` so a drafted command carries it.
+//! 3. Add it to this module's destructuring pattern **and** its `&[Field]`
+//!    table.
+//!
+//! If the field genuinely should not be author-editable, skip 1–2 and record
+//! it as [`Surface::Excluded`] with the reason — an excluded field is a stated
+//! decision, not an oversight.
+
+use tcl_registry::arity::Arity;
+use tcl_registry::definer::{DefinitionBodyGrammar, MemberBodyCommand};
+use tcl_registry::handle_binding::{HandleBindingSpec, HandleKeyword};
+use tcl_registry::hooks::ArgTypeHint;
+use tcl_registry::hover::{ArgValue, FormSpec, HoverSnippet, OptionArg, OptionSpec};
+use tcl_registry::lifecycle::Lifecycle;
+use tcl_registry::repeated::RepeatedArgLayout;
+use tcl_registry::side_effects::SideEffect;
+use tcl_registry::spec::{
+    BytePayloadSpec, CaseListSpec, CommandSpec, ObjectClassSpec, SubCommand, SubSubCommand,
+    VersionedArgValue,
+};
+use tcl_registry::symbol_def::SymbolDef;
+use tcl_registry::taint::SetterConstraint;
+
+/// The three draft keys a [`Lifecycle`] is edited under.
+///
+/// One `Lifecycle` value, three independent releases in the form — the
+/// studio has always split it, and every surface (command, subcommand,
+/// option) uses the same three keys.
+pub const LIFECYCLE_KEYS: &[&str] = &[
+    "introduced_version",
+    "deprecated_version",
+    "retired_version",
+];
+
+/// Where the studio surfaces one registry field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Surface {
+    /// Edited under this draft key.
+    ///
+    /// For [`CommandSpec`] / [`SubCommand`] the key is also a
+    /// [`crate::schema`] key, which is what gives it an editor in the browser
+    /// and an emitted line in the rendered `.rs`.  For a nested type it is a
+    /// key of the JSON object the draft builds for that type (an option row,
+    /// a hover block, …), edited inside the parent field's row editor.
+    Key(&'static str),
+    /// Edited under several draft keys — a [`Lifecycle`]'s three releases.
+    Keys(&'static [&'static str]),
+    /// Rendered into the Rust expression the named draft key holds.
+    ///
+    /// The descriptor is plain data, so [`crate::draft`] writes it back out as
+    /// a full struct literal and it round-trips; the field has no picker of its
+    /// own because the whole descriptor is one `RustExpr` editor.
+    Expression(&'static str),
+    /// Deliberately not surfaced, with the reason.
+    Excluded(&'static str),
+}
+
+/// One registry field and where the studio surfaces it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Field {
+    /// The Rust field name.
+    pub name: &'static str,
+    /// Where the studio carries it.
+    pub surface: Surface,
+}
+
+const fn f(name: &'static str, surface: Surface) -> Field {
+    Field { name, surface }
+}
+
+/// The reason a `&'static` descriptor reference is not editable field by field.
+const NAMED_CONSTANT: &str = "the studio edits the whole descriptor as one Rust expression naming a shared \
+     registry constant (`Some(&definer::SNIT_GRAMMAR)`); authoring a new one is an edit \
+     to the registry module that owns it, not a form field";
+
+// ---------------------------------------------------------------------------
+// CommandSpec
+// ---------------------------------------------------------------------------
+
+/// Compile-time witness that [`COMMAND_SPEC`] accounts for every
+/// [`CommandSpec`] field.
+///
+/// The pattern below has **no `..` rest**: adding a field to `CommandSpec`
+/// fails to compile here with `error[E0027]: pattern does not mention field
+/// <name>`.  When that happens, surface the field — a `FieldSchema` entry in
+/// `src/schema.rs` plus a seeder line in `src/draft.rs` — and add it to the
+/// pattern and to [`COMMAND_SPEC`].  If it should not be author-editable, add
+/// it as [`Surface::Excluded`] with the reason instead.
+pub fn witness_command_spec(spec: &CommandSpec) {
+    // THE GATE.  Do NOT add `..` to silence this — that is the drift it exists
+    // to catch.  A new field belongs in FOUR places: `schema::COMMAND_FIELDS`
+    // (gives it a browser editor and a rendered `.rs` line), `draft.rs` (seeds
+    // it from a live spec), this pattern, and `COMMAND_SPEC` below.  If it must
+    // not be author-editable, add it here and to `COMMAND_SPEC` as
+    // `Surface::Excluded("why")` and skip the first two.
+    let CommandSpec {
+        name: _,
+        traits: _,
+        dialects: _,
+        arity: _,
+        arg_roles: _,
+        arg_role_resolver: _,
+        arg_presentation: _,
+        repeated_args: _,
+        frame_effect: _,
+        clause_shape_check: _,
+        command_prefixes: _,
+        command_prefix_resolver: _,
+        return_type: _,
+        var_write_typing: _,
+        return_elements: _,
+        var_elements_effect: _,
+        arg_types: _,
+        subcommands: _,
+        prefix_matching: _,
+        allow_unknown_subcommands: _,
+        default_form_first_word: _,
+        hover: _,
+        forms: _,
+        command_forms: _,
+        assigns_variable_at: _,
+        safe_on_uninit: _,
+        const_fold: _,
+        const_fold_versioned: _,
+        lowering_hook: _,
+        bpf_op: _,
+        codegen_hook: _,
+        inline_codegen_hook: _,
+        wasm_codegen_hook: _,
+        analyser_hook: _,
+        command_table_effect: _,
+        side_effects: _,
+        inferred_storage_type: _,
+        required_package: _,
+        excluded_events: _,
+        unsafe_command: _,
+        closed_value_args: _,
+        event_requires: _,
+        options: _,
+        reserved_trailing_words: _,
+        arg_values: _,
+        body_kind: _,
+        body_arg_implicit_args: _,
+        taint_output_sink: _,
+        taint_output_sink_subcommands: _,
+        taint_log_sink: _,
+        taint_network_sink_args: _,
+        taint_code_sink_args: _,
+        taint_interp_eval_subcommands: _,
+        taint_source: _,
+        taint_transform: _,
+        taint_double_encode_colour: _,
+        taint_sink_safe_colour: _,
+        taint_sink_gate: _,
+        credential_options: _,
+        sensitive_headers: _,
+        setter_constraints: _,
+        pattern_type: _,
+        format_string_type: _,
+        tcllib_package: _,
+        lifecycle: _,
+        warn_missing_import: _,
+        is_namespace_exported: _,
+        xc_translatable: _,
+        xc_operation: _,
+        deprecated_replacement: _,
+        deprecated_replacement_drop_in: _,
+        byte_array_payload: _,
+        byte_array_effect: _,
+        definition_body: _,
+        case_list: _,
+        object_class: _,
+        defines_symbol: _,
+        body_scope: _,
+        binds_handle: _,
+        creates_instance_at: _,
+        defines_command_at: _,
+        context_gate: _,
+        implementation_namespace: _,
+        oo_context_facts: _,
+    } = spec;
+}
+
+/// Where the studio surfaces each [`CommandSpec`] field, in
+/// `CommandSpec::DEFAULT` order.
+pub const COMMAND_SPEC: &[Field] = &[
+    f("name", Surface::Key("name")),
+    f("traits", Surface::Key("traits")),
+    f("dialects", Surface::Key("dialects")),
+    f("arity", Surface::Key("arity")),
+    f("arg_roles", Surface::Key("arg_roles")),
+    f("arg_role_resolver", Surface::Key("arg_role_resolver")),
+    f("arg_presentation", Surface::Key("arg_presentation")),
+    f("repeated_args", Surface::Key("repeated_args")),
+    f("frame_effect", Surface::Key("frame_effect")),
+    f("clause_shape_check", Surface::Key("clause_shape_check")),
+    f("command_prefixes", Surface::Key("command_prefixes")),
+    f(
+        "command_prefix_resolver",
+        Surface::Key("command_prefix_resolver"),
+    ),
+    f("return_type", Surface::Key("return_type")),
+    f("var_write_typing", Surface::Key("var_write_typing")),
+    f("return_elements", Surface::Key("return_elements")),
+    f("var_elements_effect", Surface::Key("var_elements_effect")),
+    f("arg_types", Surface::Key("arg_types")),
+    f("subcommands", Surface::Key("subcommands")),
+    f("prefix_matching", Surface::Key("prefix_matching")),
+    f(
+        "allow_unknown_subcommands",
+        Surface::Key("allow_unknown_subcommands"),
+    ),
+    f(
+        "default_form_first_word",
+        Surface::Key("default_form_first_word"),
+    ),
+    f("hover", Surface::Key("hover")),
+    f("forms", Surface::Key("forms")),
+    f("command_forms", Surface::Key("command_forms")),
+    f("assigns_variable_at", Surface::Key("assigns_variable_at")),
+    f("safe_on_uninit", Surface::Key("safe_on_uninit")),
+    f("const_fold", Surface::Key("const_fold")),
+    f("const_fold_versioned", Surface::Key("const_fold_versioned")),
+    f("lowering_hook", Surface::Key("lowering_hook")),
+    f("bpf_op", Surface::Key("bpf_op")),
+    f("codegen_hook", Surface::Key("codegen_hook")),
+    f("inline_codegen_hook", Surface::Key("inline_codegen_hook")),
+    f("wasm_codegen_hook", Surface::Key("wasm_codegen_hook")),
+    f("analyser_hook", Surface::Key("analyser_hook")),
+    f("command_table_effect", Surface::Key("command_table_effect")),
+    f("side_effects", Surface::Key("side_effects")),
+    f(
+        "inferred_storage_type",
+        Surface::Key("inferred_storage_type"),
+    ),
+    f("required_package", Surface::Key("required_package")),
+    f("excluded_events", Surface::Key("excluded_events")),
+    f("unsafe_command", Surface::Key("unsafe_command")),
+    f("closed_value_args", Surface::Key("closed_value_args")),
+    f("event_requires", Surface::Key("event_requires")),
+    f("options", Surface::Key("options")),
+    f(
+        "reserved_trailing_words",
+        Surface::Key("reserved_trailing_words"),
+    ),
+    f("arg_values", Surface::Key("arg_values")),
+    f("body_kind", Surface::Key("body_kind")),
+    f(
+        "body_arg_implicit_args",
+        Surface::Key("body_arg_implicit_args"),
+    ),
+    f("taint_output_sink", Surface::Key("taint_output_sink")),
+    f(
+        "taint_output_sink_subcommands",
+        Surface::Key("taint_output_sink_subcommands"),
+    ),
+    f("taint_log_sink", Surface::Key("taint_log_sink")),
+    f(
+        "taint_network_sink_args",
+        Surface::Key("taint_network_sink_args"),
+    ),
+    f("taint_code_sink_args", Surface::Key("taint_code_sink_args")),
+    f(
+        "taint_interp_eval_subcommands",
+        Surface::Key("taint_interp_eval_subcommands"),
+    ),
+    f("taint_source", Surface::Key("taint_source")),
+    f("taint_transform", Surface::Key("taint_transform")),
+    f(
+        "taint_double_encode_colour",
+        Surface::Key("taint_double_encode_colour"),
+    ),
+    f(
+        "taint_sink_safe_colour",
+        Surface::Key("taint_sink_safe_colour"),
+    ),
+    f("taint_sink_gate", Surface::Key("taint_sink_gate")),
+    f("credential_options", Surface::Key("credential_options")),
+    f("sensitive_headers", Surface::Key("sensitive_headers")),
+    f("setter_constraints", Surface::Key("setter_constraints")),
+    f("pattern_type", Surface::Key("pattern_type")),
+    f("format_string_type", Surface::Key("format_string_type")),
+    f("tcllib_package", Surface::Key("tcllib_package")),
+    f("lifecycle", Surface::Keys(LIFECYCLE_KEYS)),
+    f("warn_missing_import", Surface::Key("warn_missing_import")),
+    f(
+        "is_namespace_exported",
+        Surface::Key("is_namespace_exported"),
+    ),
+    f("xc_translatable", Surface::Key("xc_translatable")),
+    f("xc_operation", Surface::Key("xc_operation")),
+    f(
+        "deprecated_replacement",
+        Surface::Key("deprecated_replacement"),
+    ),
+    f(
+        "deprecated_replacement_drop_in",
+        Surface::Key("deprecated_replacement_drop_in"),
+    ),
+    f("byte_array_payload", Surface::Key("byte_array_payload")),
+    f("byte_array_effect", Surface::Key("byte_array_effect")),
+    f("definition_body", Surface::Key("definition_body")),
+    f("case_list", Surface::Key("case_list")),
+    f("object_class", Surface::Key("object_class")),
+    f("defines_symbol", Surface::Key("defines_symbol")),
+    f("body_scope", Surface::Key("body_scope")),
+    f("binds_handle", Surface::Key("binds_handle")),
+    f("creates_instance_at", Surface::Key("creates_instance_at")),
+    f("defines_command_at", Surface::Key("defines_command_at")),
+    f("context_gate", Surface::Key("context_gate")),
+    f(
+        "implementation_namespace",
+        Surface::Key("implementation_namespace"),
+    ),
+    f("oo_context_facts", Surface::Key("oo_context_facts")),
+];
+
+// ---------------------------------------------------------------------------
+// SubCommand
+// ---------------------------------------------------------------------------
+
+/// Compile-time witness that [`SUB_COMMAND`] accounts for every
+/// [`SubCommand`] field — see [`witness_command_spec`] for what to do when it
+/// stops compiling.
+pub fn witness_sub_command(sub: &SubCommand) {
+    // THE GATE — see `witness_command_spec`. No `..`, ever.
+    let SubCommand {
+        name: _,
+        traits: _,
+        arity: _,
+        detail: _,
+        synopsis: _,
+        hover: _,
+        arg_roles: _,
+        arg_role_resolver: _,
+        arg_presentation: _,
+        repeated_args: _,
+        command_prefixes: _,
+        command_prefix_resolver: _,
+        return_type: _,
+        var_write_typing: _,
+        return_elements: _,
+        var_elements_effect: _,
+        arg_types: _,
+        pure: _,
+        mutator: _,
+        const_fold: _,
+        const_fold_versioned: _,
+        lowering_hook: _,
+        codegen_hook: _,
+        inline_codegen_hook: _,
+        wasm_codegen_hook: _,
+        analyser_hook: _,
+        command_table_effect: _,
+        options: _,
+        min_abbrev: _,
+        prefix_matching: _,
+        arg_values: _,
+        versioned_arg_values: _,
+        subcommand_forms: _,
+        dialects: _,
+        lifecycle: _,
+        safe_on_uninit: _,
+        loop_list_header: _,
+        creates_scope_alias: _,
+        inferred_storage_type: _,
+        body_kind: _,
+        byte_array_effect: _,
+        closed_value_args: _,
+        arg_values_accept_prefix: _,
+        body_arg_implicit_args: _,
+        taint_transform: _,
+        taint_double_encode_colour: _,
+        taint_output_sink: _,
+        credential_arg: _,
+        sensitive_headers: _,
+        pattern_type: _,
+        format_string_type: _,
+        xc_operation: _,
+        side_effects: _,
+        destructive: _,
+        returns_path: _,
+        is_unescape: _,
+        cfg_rewrite_name: _,
+        sub_subcommands: _,
+        defines_command_at: _,
+        max_leading_option_words: _,
+    } = sub;
+}
+
+/// Where the studio surfaces each [`SubCommand`] field, in
+/// `SubCommand::DEFAULT` order.
+pub const SUB_COMMAND: &[Field] = &[
+    f("name", Surface::Key("name")),
+    f("traits", Surface::Key("traits")),
+    f("arity", Surface::Key("arity")),
+    f("detail", Surface::Key("detail")),
+    f("synopsis", Surface::Key("synopsis")),
+    f("hover", Surface::Key("hover")),
+    f("arg_roles", Surface::Key("arg_roles")),
+    f("arg_role_resolver", Surface::Key("arg_role_resolver")),
+    f("arg_presentation", Surface::Key("arg_presentation")),
+    f("repeated_args", Surface::Key("repeated_args")),
+    f("command_prefixes", Surface::Key("command_prefixes")),
+    f(
+        "command_prefix_resolver",
+        Surface::Key("command_prefix_resolver"),
+    ),
+    f("return_type", Surface::Key("return_type")),
+    f("var_write_typing", Surface::Key("var_write_typing")),
+    f("return_elements", Surface::Key("return_elements")),
+    f("var_elements_effect", Surface::Key("var_elements_effect")),
+    f("arg_types", Surface::Key("arg_types")),
+    f("pure", Surface::Key("pure")),
+    f("mutator", Surface::Key("mutator")),
+    f("const_fold", Surface::Key("const_fold")),
+    f("const_fold_versioned", Surface::Key("const_fold_versioned")),
+    f("lowering_hook", Surface::Key("lowering_hook")),
+    f("codegen_hook", Surface::Key("codegen_hook")),
+    f("inline_codegen_hook", Surface::Key("inline_codegen_hook")),
+    f("wasm_codegen_hook", Surface::Key("wasm_codegen_hook")),
+    f("analyser_hook", Surface::Key("analyser_hook")),
+    f("command_table_effect", Surface::Key("command_table_effect")),
+    f("options", Surface::Key("options")),
+    f("min_abbrev", Surface::Key("min_abbrev")),
+    f("prefix_matching", Surface::Key("prefix_matching")),
+    f("arg_values", Surface::Key("arg_values")),
+    f("versioned_arg_values", Surface::Key("versioned_arg_values")),
+    f("subcommand_forms", Surface::Key("subcommand_forms")),
+    f("dialects", Surface::Key("dialects")),
+    f("lifecycle", Surface::Keys(LIFECYCLE_KEYS)),
+    f("safe_on_uninit", Surface::Key("safe_on_uninit")),
+    f("loop_list_header", Surface::Key("loop_list_header")),
+    f("creates_scope_alias", Surface::Key("creates_scope_alias")),
+    f(
+        "inferred_storage_type",
+        Surface::Key("inferred_storage_type"),
+    ),
+    f("body_kind", Surface::Key("body_kind")),
+    f("byte_array_effect", Surface::Key("byte_array_effect")),
+    f("closed_value_args", Surface::Key("closed_value_args")),
+    f(
+        "arg_values_accept_prefix",
+        Surface::Key("arg_values_accept_prefix"),
+    ),
+    f(
+        "body_arg_implicit_args",
+        Surface::Key("body_arg_implicit_args"),
+    ),
+    f("taint_transform", Surface::Key("taint_transform")),
+    f(
+        "taint_double_encode_colour",
+        Surface::Key("taint_double_encode_colour"),
+    ),
+    f("taint_output_sink", Surface::Key("taint_output_sink")),
+    f("credential_arg", Surface::Key("credential_arg")),
+    f("sensitive_headers", Surface::Key("sensitive_headers")),
+    f("pattern_type", Surface::Key("pattern_type")),
+    f("format_string_type", Surface::Key("format_string_type")),
+    f("xc_operation", Surface::Key("xc_operation")),
+    f("side_effects", Surface::Key("side_effects")),
+    f("destructive", Surface::Key("destructive")),
+    f("returns_path", Surface::Key("returns_path")),
+    f("is_unescape", Surface::Key("is_unescape")),
+    f("cfg_rewrite_name", Surface::Key("cfg_rewrite_name")),
+    f("sub_subcommands", Surface::Key("sub_subcommands")),
+    f("defines_command_at", Surface::Key("defines_command_at")),
+    f(
+        "max_leading_option_words",
+        Surface::Key("max_leading_option_words"),
+    ),
+];
+
+// ---------------------------------------------------------------------------
+// The nested types a draft carries structurally.
+//
+// These have no `FieldSchema` entry of their own: they are edited inside the
+// row editor of the parent field that holds them (`options`, `hover`,
+// `side_effects`, …), so their draft keys are keys of the JSON object
+// `crate::draft` builds for the type.  Same gate, same rule — a new field on
+// any of them fails to compile until it is carried or excluded.
+// ---------------------------------------------------------------------------
+
+/// Compile-time witness for [`SUB_SUB_COMMAND`].
+pub fn witness_sub_sub_command(sub: &SubSubCommand) {
+    let SubSubCommand {
+        name: _,
+        detail: _,
+        synopsis: _,
+        dialects: _,
+    } = sub;
+}
+
+/// Where the studio surfaces each [`SubSubCommand`] field.
+pub const SUB_SUB_COMMAND: &[Field] = &[
+    f("name", Surface::Key("name")),
+    f("detail", Surface::Key("detail")),
+    f("synopsis", Surface::Key("synopsis")),
+    f("dialects", Surface::Key("dialects")),
+];
+
+/// Compile-time witness for [`OPTION_SPEC`].
+pub fn witness_option_spec(opt: &OptionSpec) {
+    let OptionSpec {
+        name: _,
+        value: _,
+        detail: _,
+        dialects: _,
+        aliases: _,
+        lifecycle: _,
+        min_abbrev: _,
+    } = opt;
+}
+
+/// Where the studio surfaces each [`OptionSpec`] field.
+pub const OPTION_SPEC: &[Field] = &[
+    f("name", Surface::Key("name")),
+    f("value", Surface::Key("value")),
+    f("detail", Surface::Key("detail")),
+    f("dialects", Surface::Key("dialects")),
+    f("aliases", Surface::Key("aliases")),
+    f("lifecycle", Surface::Keys(LIFECYCLE_KEYS)),
+    f("min_abbrev", Surface::Key("min_abbrev")),
+];
+
+/// Compile-time witness for [`OPTION_ARG`].
+pub fn witness_option_arg(arg: &OptionArg) {
+    let OptionArg {
+        arity: _,
+        role: _,
+        also_role: _,
+        body_kind: _,
+        values: _,
+        closed: _,
+        integer: _,
+        hint: _,
+        appended_arity: _,
+    } = arg;
+}
+
+/// Where the studio surfaces each [`OptionArg`] field — the keys of the
+/// `value` object inside an option row.
+pub const OPTION_ARG: &[Field] = &[
+    f("arity", Surface::Key("arity")),
+    f("role", Surface::Key("role")),
+    f("also_role", Surface::Key("also_role")),
+    f("body_kind", Surface::Key("body_kind")),
+    f("values", Surface::Key("values")),
+    f("closed", Surface::Key("closed")),
+    f("integer", Surface::Key("integer")),
+    f("hint", Surface::Key("hint")),
+    f("appended_arity", Surface::Key("appended_arity")),
+];
+
+/// Compile-time witness for [`ARG_VALUE`].
+pub fn witness_arg_value(value: &ArgValue) {
+    let ArgValue {
+        value: _,
+        detail: _,
+        min_tcl: _,
+        code: _,
+    } = value;
+}
+
+/// Where the studio surfaces each [`ArgValue`] field.
+pub const ARG_VALUE: &[Field] = &[
+    f("value", Surface::Key("value")),
+    f("detail", Surface::Key("detail")),
+    f("min_tcl", Surface::Key("min_tcl")),
+    f("code", Surface::Key("code")),
+];
+
+/// Compile-time witness for [`FORM_SPEC`].
+pub fn witness_form_spec(form: &FormSpec) {
+    let FormSpec {
+        kind: _,
+        synopsis: _,
+        dialects: _,
+    } = form;
+}
+
+/// Where the studio surfaces each [`FormSpec`] field.
+pub const FORM_SPEC: &[Field] = &[
+    f("kind", Surface::Key("kind")),
+    f("synopsis", Surface::Key("synopsis")),
+    f("dialects", Surface::Key("dialects")),
+];
+
+/// Compile-time witness for [`HOVER_SNIPPET`].
+pub fn witness_hover_snippet(hover: &HoverSnippet) {
+    let HoverSnippet {
+        summary: _,
+        synopsis: _,
+        snippet: _,
+        source: _,
+        examples: _,
+        return_value: _,
+    } = hover;
+}
+
+/// Where the studio surfaces each [`HoverSnippet`] field.
+pub const HOVER_SNIPPET: &[Field] = &[
+    f("summary", Surface::Key("summary")),
+    f("synopsis", Surface::Key("synopsis")),
+    f("snippet", Surface::Key("snippet")),
+    f("source", Surface::Key("source")),
+    f("examples", Surface::Key("examples")),
+    f("return_value", Surface::Key("return_value")),
+];
+
+/// Compile-time witness for [`SIDE_EFFECT`].
+pub fn witness_side_effect(effect: &SideEffect) {
+    let SideEffect {
+        target: _,
+        reads: _,
+        writes: _,
+        connection_side: _,
+        dialects: _,
+    } = effect;
+}
+
+/// Where the studio surfaces each [`SideEffect`] field.
+pub const SIDE_EFFECT: &[Field] = &[
+    f("target", Surface::Key("target")),
+    f("reads", Surface::Key("reads")),
+    f("writes", Surface::Key("writes")),
+    f("connection_side", Surface::Key("connection_side")),
+    f("dialects", Surface::Key("dialects")),
+];
+
+/// Compile-time witness for [`SETTER_CONSTRAINT`].
+pub fn witness_setter_constraint(constraint: &SetterConstraint) {
+    let SetterConstraint {
+        arg_index: _,
+        required_prefix: _,
+        code: _,
+        message: _,
+    } = constraint;
+}
+
+/// Where the studio surfaces each [`SetterConstraint`] field.
+pub const SETTER_CONSTRAINT: &[Field] = &[
+    f("arg_index", Surface::Key("arg_index")),
+    f("required_prefix", Surface::Key("required_prefix")),
+    f("code", Surface::Key("code")),
+    f("message", Surface::Key("message")),
+];
+
+/// Compile-time witness for [`ARITY`].
+pub fn witness_arity(arity: &Arity) {
+    let Arity {
+        min: _,
+        max: _,
+        step: _,
+        also_exact: _,
+    } = arity;
+}
+
+/// Where the studio surfaces each [`Arity`] field.
+pub const ARITY: &[Field] = &[
+    f("min", Surface::Key("min")),
+    f("max", Surface::Key("max")),
+    f("step", Surface::Key("step")),
+    f("also_exact", Surface::Key("also_exact")),
+];
+
+/// Compile-time witness for [`ARG_TYPE_HINT`].
+pub fn witness_arg_type_hint(hint: &ArgTypeHint) {
+    let ArgTypeHint {
+        expected: _,
+        shimmers: _,
+        transparent_from: _,
+    } = hint;
+}
+
+/// Where the studio surfaces each [`ArgTypeHint`] field.
+pub const ARG_TYPE_HINT: &[Field] = &[
+    f("expected", Surface::Key("expected")),
+    f("shimmers", Surface::Key("shimmers")),
+    f("transparent_from", Surface::Key("transparent_from")),
+];
+
+/// Compile-time witness for [`LIFECYCLE`].
+pub fn witness_lifecycle(lifecycle: &Lifecycle) {
+    let Lifecycle {
+        introduced: _,
+        deprecated: _,
+        retired: _,
+    } = lifecycle;
+}
+
+/// Where the studio surfaces each [`Lifecycle`] field.
+pub const LIFECYCLE: &[Field] = &[
+    f("introduced", Surface::Key("introduced_version")),
+    f("deprecated", Surface::Key("deprecated_version")),
+    f("retired", Surface::Key("retired_version")),
+];
+
+// ---------------------------------------------------------------------------
+// Plain-data descriptors.
+//
+// Each of these is reachable only through one `RustExpr` field, but is pure
+// data — so `crate::draft` renders it back out as a full struct literal and it
+// round-trips.  `Surface::Expression` names the field that carries it, and
+// `descriptor_literals_name_every_field` proves the rendered literal really
+// mentions each one.
+// ---------------------------------------------------------------------------
+
+/// Compile-time witness for [`REPEATED_ARG_LAYOUT`].
+pub fn witness_repeated_arg_layout(layout: &RepeatedArgLayout) {
+    let RepeatedArgLayout {
+        role: _,
+        start: _,
+        stride: _,
+        exclude_trailing: _,
+        optional_leading_word: _,
+    } = layout;
+}
+
+/// Where the studio surfaces each [`RepeatedArgLayout`] field.
+pub const REPEATED_ARG_LAYOUT: &[Field] = &[
+    f("role", Surface::Expression("repeated_args")),
+    f("start", Surface::Expression("repeated_args")),
+    f("stride", Surface::Expression("repeated_args")),
+    f("exclude_trailing", Surface::Expression("repeated_args")),
+    f(
+        "optional_leading_word",
+        Surface::Expression("repeated_args"),
+    ),
+];
+
+/// Compile-time witness for [`HANDLE_BINDING_SPEC`].
+pub fn witness_handle_binding_spec(spec: &HandleBindingSpec) {
+    let HandleBindingSpec {
+        name_at: _,
+        class_from: _,
+        keyword: _,
+    } = spec;
+}
+
+/// Where the studio surfaces each [`HandleBindingSpec`] field (issue #1185).
+pub const HANDLE_BINDING_SPEC: &[Field] = &[
+    f("name_at", Surface::Expression("binds_handle")),
+    f("class_from", Surface::Expression("binds_handle")),
+    f("keyword", Surface::Expression("binds_handle")),
+];
+
+/// Compile-time witness for [`HANDLE_KEYWORD`].
+pub fn witness_handle_keyword(keyword: &HandleKeyword) {
+    let HandleKeyword { at: _, word: _ } = keyword;
+}
+
+/// Where the studio surfaces each [`HandleKeyword`] field.
+pub const HANDLE_KEYWORD: &[Field] = &[
+    f("at", Surface::Expression("binds_handle")),
+    f("word", Surface::Expression("binds_handle")),
+];
+
+/// Compile-time witness for [`SYMBOL_DEF`].
+pub fn witness_symbol_def(def: &SymbolDef) {
+    let SymbolDef {
+        name_arg: _,
+        detail_arg: _,
+        requires_arg: _,
+        kind: _,
+    } = def;
+}
+
+/// Where the studio surfaces each [`SymbolDef`] field.
+pub const SYMBOL_DEF: &[Field] = &[
+    f("name_arg", Surface::Expression("defines_symbol")),
+    f("detail_arg", Surface::Expression("defines_symbol")),
+    f("requires_arg", Surface::Expression("defines_symbol")),
+    f("kind", Surface::Expression("defines_symbol")),
+];
+
+/// Compile-time witness for [`BYTE_PAYLOAD_SPEC`].
+pub fn witness_byte_payload_spec(spec: &BytePayloadSpec) {
+    let BytePayloadSpec {
+        replace_data_index: _,
+        message_flag_shift: _,
+    } = spec;
+}
+
+/// Where the studio surfaces each [`BytePayloadSpec`] field.
+pub const BYTE_PAYLOAD_SPEC: &[Field] = &[
+    f(
+        "replace_data_index",
+        Surface::Expression("byte_array_payload"),
+    ),
+    f(
+        "message_flag_shift",
+        Surface::Expression("byte_array_payload"),
+    ),
+];
+
+/// Compile-time witness for [`VERSIONED_ARG_VALUE`].
+pub fn witness_versioned_arg_value(gate: &VersionedArgValue) {
+    let VersionedArgValue {
+        index: _,
+        value: _,
+        lifecycle: _,
+    } = gate;
+}
+
+/// Where the studio surfaces each [`VersionedArgValue`] field.
+pub const VERSIONED_ARG_VALUE: &[Field] = &[
+    f("index", Surface::Expression("versioned_arg_values")),
+    f("value", Surface::Expression("versioned_arg_values")),
+    f("lifecycle", Surface::Expression("versioned_arg_values")),
+];
+
+// ---------------------------------------------------------------------------
+// Shared `&'static` descriptors.
+//
+// A grammar / class / clause-list descriptor is written once in the registry
+// module that owns it and referenced by every command that needs it, so the
+// studio's editor takes the *constant's path* rather than its contents.  Every
+// field is still listed here: the gate makes a new one a stated decision.
+// ---------------------------------------------------------------------------
+
+/// Compile-time witness for [`DEFINITION_BODY_GRAMMAR`].
+pub fn witness_definition_body_grammar(grammar: &DefinitionBodyGrammar) {
+    let DefinitionBodyGrammar {
+        family: _,
+        members: _,
+        implicit_vars: _,
+        member_body_namespace_path: _,
+        builtin_type_methods: _,
+        member_body_commands: _,
+        bare_word_construction: _,
+    } = grammar;
+}
+
+/// Where the studio surfaces each [`DefinitionBodyGrammar`] field.
+pub const DEFINITION_BODY_GRAMMAR: &[Field] = &[
+    f("family", Surface::Excluded(NAMED_CONSTANT)),
+    f("members", Surface::Excluded(NAMED_CONSTANT)),
+    f("implicit_vars", Surface::Excluded(NAMED_CONSTANT)),
+    f(
+        "member_body_namespace_path",
+        Surface::Excluded(NAMED_CONSTANT),
+    ),
+    f("builtin_type_methods", Surface::Excluded(NAMED_CONSTANT)),
+    f("member_body_commands", Surface::Excluded(NAMED_CONSTANT)),
+    f("bare_word_construction", Surface::Excluded(NAMED_CONSTANT)),
+];
+
+/// Compile-time witness for [`MEMBER_BODY_COMMAND`].
+pub fn witness_member_body_command(command: &MemberBodyCommand) {
+    let MemberBodyCommand {
+        name: _,
+        detail: _,
+        binds_handle: _,
+    } = command;
+}
+
+/// Where the studio surfaces each [`MemberBodyCommand`] field.
+pub const MEMBER_BODY_COMMAND: &[Field] = &[
+    f("name", Surface::Excluded(NAMED_CONSTANT)),
+    f("detail", Surface::Excluded(NAMED_CONSTANT)),
+    f("binds_handle", Surface::Excluded(NAMED_CONSTANT)),
+];
+
+/// Compile-time witness for [`OBJECT_CLASS_SPEC`].
+pub fn witness_object_class_spec(spec: &ObjectClassSpec) {
+    let ObjectClassSpec {
+        class_name: _,
+        instance_methods: _,
+        superclasses: _,
+        allow_unknown_methods: _,
+    } = spec;
+}
+
+/// Where the studio surfaces each [`ObjectClassSpec`] field.
+pub const OBJECT_CLASS_SPEC: &[Field] = &[
+    f("class_name", Surface::Excluded(NAMED_CONSTANT)),
+    f("instance_methods", Surface::Excluded(NAMED_CONSTANT)),
+    f("superclasses", Surface::Excluded(NAMED_CONSTANT)),
+    f("allow_unknown_methods", Surface::Excluded(NAMED_CONSTANT)),
+];
+
+/// Compile-time witness for [`CASE_LIST_SPEC`].
+pub fn witness_case_list_spec(spec: &CaseListSpec) {
+    let CaseListSpec {
+        subject_args: _,
+        regex_option: _,
+        value_options: _,
+        clause_flags: _,
+        clause_regex_flag: _,
+        clause_value_flags: _,
+        keyword_patterns: _,
+    } = spec;
+}
+
+/// Where the studio surfaces each [`CaseListSpec`] field.
+pub const CASE_LIST_SPEC: &[Field] = &[
+    f("subject_args", Surface::Excluded(NAMED_CONSTANT)),
+    f("regex_option", Surface::Excluded(NAMED_CONSTANT)),
+    f("value_options", Surface::Excluded(NAMED_CONSTANT)),
+    f("clause_flags", Surface::Excluded(NAMED_CONSTANT)),
+    f("clause_regex_flag", Surface::Excluded(NAMED_CONSTANT)),
+    f("clause_value_flags", Surface::Excluded(NAMED_CONSTANT)),
+    f("keyword_patterns", Surface::Excluded(NAMED_CONSTANT)),
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{draft, render_rs, schema};
+    use serde_json::{Map, Value, json};
+    use tcl_core_types::DiagCode;
+    use tcl_registry::arg_role::ArgRole;
+    use tcl_registry::handle_binding::HandleClassSource;
+    use tcl_registry::hover::{FormKind, OptionArity, OptionValue};
+    use tcl_registry::side_effects::{ConnectionSide, SideEffectTarget};
+    use tcl_registry::symbol_def::DefinedSymbolKind;
+
+    /// The draft keys a coverage entry claims; empty for an exclusion.
+    fn claimed(surface: Surface) -> Vec<&'static str> {
+        match surface {
+            Surface::Key(k) | Surface::Expression(k) => vec![k],
+            Surface::Keys(ks) => ks.to_vec(),
+            Surface::Excluded(_) => Vec::new(),
+        }
+    }
+
+    /// The keys of a JSON object, or a panic naming `what` when it is not one.
+    fn object_keys<'a>(what: &str, value: &'a Value) -> Vec<&'a str> {
+        value
+            .as_object()
+            .unwrap_or_else(|| panic!("{what} seeds a JSON object"))
+            .keys()
+            .map(String::as_str)
+            .collect()
+    }
+
+    /// Every `Key` / `Keys` entry names a key the seeded draft really holds.
+    fn assert_carried(what: &str, table: &[Field], keys: &[&str]) {
+        for field in table {
+            if matches!(field.surface, Surface::Excluded(_) | Surface::Expression(_)) {
+                continue;
+            }
+            for key in claimed(field.surface) {
+                assert!(
+                    keys.contains(&key),
+                    "{what}::{} claims draft key `{key}`, which the seeder never writes",
+                    field.name
+                );
+            }
+        }
+    }
+
+    /// Every `Key` / `Keys` entry names a schema field, so the browser renders
+    /// an editor for it and `render_rs` emits it.
+    fn assert_schema_has(
+        what: &str,
+        table: &[Field],
+        lookup: fn(&str) -> Option<&'static schema::FieldSchema>,
+    ) {
+        for field in table {
+            if matches!(field.surface, Surface::Excluded(_)) {
+                continue;
+            }
+            for key in claimed(field.surface) {
+                assert!(
+                    lookup(key).is_some(),
+                    "{what}::{} claims schema key `{key}`, which schema.rs does not declare",
+                    field.name
+                );
+            }
+        }
+    }
+
+    /// No schema field without a coverage entry — catches a schema key left
+    /// behind by a registry field that has since been removed.
+    fn assert_no_orphan_schema_keys(what: &str, table: &[Field], fields: &[schema::FieldSchema]) {
+        let claimed_keys: Vec<&str> = table.iter().flat_map(|f| claimed(f.surface)).collect();
+        for field in fields {
+            assert!(
+                claimed_keys.contains(&field.key),
+                "schema declares {what} field `{}` that no coverage entry claims — remove it \
+                 from schema.rs, or add back the registry field it stands for",
+                field.key
+            );
+        }
+    }
+
+    #[test]
+    fn command_spec_is_fully_surfaced() {
+        witness_command_spec(&CommandSpec::DEFAULT);
+        let drafted = draft::default_command_draft();
+        let keys: Vec<&str> = drafted.keys().map(String::as_str).collect();
+        assert_carried("CommandSpec", COMMAND_SPEC, &keys);
+        assert_schema_has("CommandSpec", COMMAND_SPEC, schema::command_field);
+        assert_no_orphan_schema_keys("CommandSpec", COMMAND_SPEC, schema::COMMAND_FIELDS);
+    }
+
+    #[test]
+    fn sub_command_is_fully_surfaced() {
+        witness_sub_command(&SubCommand::DEFAULT);
+        let drafted = draft::default_subcommand_draft();
+        let keys: Vec<&str> = drafted.keys().map(String::as_str).collect();
+        assert_carried("SubCommand", SUB_COMMAND, &keys);
+        assert_schema_has("SubCommand", SUB_COMMAND, schema::subcommand_field);
+        assert_no_orphan_schema_keys("SubCommand", SUB_COMMAND, schema::SUBCOMMAND_FIELDS);
+    }
+
+    /// A `SetterConstraint` to seed from — the type has no `DEFAULT`, and its
+    /// `code` is a real diagnostic code rather than a string.
+    const SETTER: SetterConstraint = SetterConstraint {
+        arg_index: 0,
+        required_prefix: "/",
+        code: DiagCode::Irule3101,
+        message: "",
+    };
+
+    /// The nested types have no `FieldSchema` of their own: each is edited
+    /// inside its parent field's row editor, so what has to hold is that the
+    /// draft's JSON object for the type carries a key per field.
+    #[test]
+    fn the_nested_row_types_are_fully_surfaced() {
+        witness_sub_sub_command(&SubSubCommand {
+            name: "",
+            detail: "",
+            synopsis: "",
+            dialects: None,
+        });
+        let sub_sub = draft::sub_subcommand(&SubSubCommand {
+            name: "",
+            detail: "",
+            synopsis: "",
+            dialects: None,
+        });
+        assert_carried(
+            "SubSubCommand",
+            SUB_SUB_COMMAND,
+            &object_keys("SubSubCommand", &sub_sub),
+        );
+
+        // An option row, with a value so the nested `OptionArg` object exists.
+        let opt = OptionSpec {
+            value: OptionValue::Takes(OptionArg {
+                arity: OptionArity::One,
+                ..OptionArg::DEFAULT
+            }),
+            ..OptionSpec::DEFAULT
+        };
+        witness_option_spec(&opt);
+        witness_option_arg(&OptionArg::DEFAULT);
+        let (row, _) = draft::option_spec(&opt);
+        assert_carried("OptionSpec", OPTION_SPEC, &object_keys("OptionSpec", &row));
+        assert_carried(
+            "OptionArg",
+            OPTION_ARG,
+            &object_keys("OptionArg", &row["value"]),
+        );
+
+        witness_arg_value(&ArgValue::DEFAULT);
+        let value = draft::arg_value(&ArgValue::DEFAULT);
+        assert_carried("ArgValue", ARG_VALUE, &object_keys("ArgValue", &value));
+
+        witness_form_spec(&FormSpec::DEFAULT);
+        let form = draft::form_spec(&FormSpec::DEFAULT);
+        assert_carried("FormSpec", FORM_SPEC, &object_keys("FormSpec", &form));
+
+        let snippet = HoverSnippet::brief("", &[], "");
+        witness_hover_snippet(&snippet);
+        let hover = draft::hover(Some(snippet));
+        assert_carried(
+            "HoverSnippet",
+            HOVER_SNIPPET,
+            &object_keys("HoverSnippet", &hover),
+        );
+
+        witness_side_effect(&SideEffect::DEFAULT);
+        let effect = draft::side_effect(&SideEffect::DEFAULT);
+        assert_carried(
+            "SideEffect",
+            SIDE_EFFECT,
+            &object_keys("SideEffect", &effect),
+        );
+
+        witness_setter_constraint(&SETTER);
+        let constraint = draft::setter_constraint(&SETTER);
+        assert_carried(
+            "SetterConstraint",
+            SETTER_CONSTRAINT,
+            &object_keys("SetterConstraint", &constraint),
+        );
+
+        witness_arity(&Arity::any());
+        let arity = draft::arity(Arity::any());
+        assert_carried("Arity", ARITY, &object_keys("Arity", &arity));
+
+        let hint = ArgTypeHint {
+            expected: None,
+            shimmers: false,
+            transparent_from: &[],
+        };
+        witness_arg_type_hint(&hint);
+        let hints = draft::arg_type_map(&[(0, hint)]);
+        assert_carried(
+            "ArgTypeHint",
+            ARG_TYPE_HINT,
+            &object_keys("ArgTypeHint", &hints[0]),
+        );
+
+        witness_lifecycle(&Lifecycle::UNSPECIFIED);
+        let mut life = Map::new();
+        draft::insert_lifecycle(&mut life, Lifecycle::UNSPECIFIED);
+        let life_keys: Vec<&str> = life.keys().map(String::as_str).collect();
+        assert_carried("Lifecycle", LIFECYCLE, &life_keys);
+    }
+
+    /// Every exclusion states a reason, and names a type whose fields really
+    /// are reached through one shared-constant editor.
+    #[test]
+    fn every_exclusion_carries_a_reason() {
+        witness_definition_body_grammar(&tcl_registry::definer::SNIT_GRAMMAR);
+        witness_member_body_command(
+            tcl_registry::definer::SNIT_GRAMMAR
+                .member_body_command("install")
+                .expect("snit injects `install` into every member body"),
+        );
+        witness_object_class_spec(&ObjectClassSpec {
+            class_name: "",
+            instance_methods: &[],
+            superclasses: &[],
+            allow_unknown_methods: false,
+        });
+        witness_case_list_spec(&CaseListSpec::SWITCH);
+        for (what, table) in [
+            ("DefinitionBodyGrammar", DEFINITION_BODY_GRAMMAR),
+            ("MemberBodyCommand", MEMBER_BODY_COMMAND),
+            ("ObjectClassSpec", OBJECT_CLASS_SPEC),
+            ("CaseListSpec", CASE_LIST_SPEC),
+        ] {
+            for field in table {
+                let Surface::Excluded(reason) = field.surface else {
+                    panic!("{what}::{} is not an exclusion", field.name);
+                };
+                assert!(!reason.is_empty(), "{what}::{} has no reason", field.name);
+            }
+            // The whole descriptor is one editor on some command field, so the
+            // schema must still offer a way to name it.
+            assert!(!table.is_empty(), "{what} has no coverage entries");
+        }
+        for key in ["definition_body", "object_class", "case_list", "body_scope"] {
+            assert!(
+                schema::command_field(key).is_some(),
+                "`{key}` must stay an editable field even though its descriptor is a constant"
+            );
+        }
+    }
+
+    // -- the plain-data descriptors really round-trip ------------------------
+    //
+    // Each literal below is written twice: once as Rust the compiler accepts,
+    // and once as the string the studio renders for it. If the two ever
+    // disagree the studio is emitting a spec that does not compile — and a
+    // descriptor field added without a renderer line shows up as a missing
+    // `name:` in the expected text.
+
+    const WITNESS_BINDING: HandleBindingSpec = HandleBindingSpec {
+        name_at: 0,
+        class_from: HandleClassSource::Word(2),
+        keyword: Some(HandleKeyword {
+            at: 1,
+            word: "using",
+        }),
+    };
+
+    const WITNESS_REPEAT: RepeatedArgLayout = RepeatedArgLayout {
+        role: ArgRole::VarWrite,
+        start: 1,
+        stride: 2,
+        exclude_trailing: 1,
+        optional_leading_word: true,
+    };
+
+    const WITNESS_SYMBOL: SymbolDef = SymbolDef {
+        name_arg: 0,
+        detail_arg: Some(1),
+        requires_arg: None,
+        kind: DefinedSymbolKind::Test,
+    };
+
+    const WITNESS_PAYLOAD: BytePayloadSpec = BytePayloadSpec {
+        replace_data_index: 3,
+        message_flag_shift: true,
+    };
+
+    const WITNESS_GATE: VersionedArgValue = VersionedArgValue {
+        index: 0,
+        value: "utf-8",
+        lifecycle: Lifecycle::UNSPECIFIED,
+    };
+
+    const WITNESS_SUBS: &[SubCommand] = &[SubCommand {
+        name: "encoding",
+        versioned_arg_values: &[WITNESS_GATE],
+        ..SubCommand::DEFAULT
+    }];
+
+    fn witness_spec() -> CommandSpec {
+        CommandSpec {
+            name: "witness",
+            repeated_args: &[WITNESS_REPEAT],
+            binds_handle: Some(&WITNESS_BINDING),
+            byte_array_payload: Some(WITNESS_PAYLOAD),
+            defines_symbol: Some(WITNESS_SYMBOL),
+            oo_context_facts: &[("class", OoContextFactWitness::FACT)],
+            subcommands: WITNESS_SUBS,
+            ..CommandSpec::DEFAULT
+        }
+    }
+
+    /// `OoContextFact` has one variant; naming it through a constant keeps the
+    /// witness readable next to the string it must render as.
+    struct OoContextFactWitness;
+    impl OoContextFactWitness {
+        const FACT: tcl_registry::spec::OoContextFact =
+            tcl_registry::spec::OoContextFact::DefiningClass;
+    }
+
+    #[test]
+    fn descriptor_literals_name_every_field() {
+        let d = draft::from_command_spec(&witness_spec());
+        assert_eq!(
+            d["binds_handle"],
+            json!(
+                "Some(&HandleBindingSpec { name_at: 0, class_from: HandleClassSource::Word(2), \
+                 keyword: Some(HandleKeyword { at: 1, word: \"using\" }) })"
+            )
+        );
+        assert_eq!(
+            d["repeated_args"],
+            json!(
+                "&[RepeatedArgLayout { role: ArgRole::VarWrite, start: 1, stride: 2, \
+                 exclude_trailing: 1, optional_leading_word: true }]"
+            )
+        );
+        assert_eq!(
+            d["defines_symbol"],
+            json!(
+                "Some(SymbolDef { name_arg: 0, detail_arg: Some(1), requires_arg: None, \
+                 kind: DefinedSymbolKind::Test })"
+            )
+        );
+        assert_eq!(
+            d["byte_array_payload"],
+            json!("Some(BytePayloadSpec { replace_data_index: 3, message_flag_shift: true })")
+        );
+        assert_eq!(
+            d["oo_context_facts"],
+            json!("&[(\"class\", OoContextFact::DefiningClass)]")
+        );
+        assert_eq!(
+            d["subcommands"][0]["versioned_arg_values"],
+            json!(
+                "&[VersionedArgValue { index: 0, value: \"utf-8\", lifecycle: Lifecycle { \
+                 introduced: None, deprecated: None, retired: None } }]"
+            )
+        );
+    }
+
+    /// Every `Expression` entry's field name really appears in the literal the
+    /// renderer emits — the mechanical half of the assertions above, so a new
+    /// descriptor field that nobody wired into `draft.rs` fails here too.
+    #[test]
+    fn every_expression_field_reaches_the_rendered_spec() {
+        let source = render_rs::render(&draft::from_command_spec(&witness_spec()));
+        for (what, table) in [
+            ("RepeatedArgLayout", REPEATED_ARG_LAYOUT),
+            ("HandleBindingSpec", HANDLE_BINDING_SPEC),
+            ("HandleKeyword", HANDLE_KEYWORD),
+            ("SymbolDef", SYMBOL_DEF),
+            ("BytePayloadSpec", BYTE_PAYLOAD_SPEC),
+            ("VersionedArgValue", VERSIONED_ARG_VALUE),
+        ] {
+            for field in table {
+                let Surface::Expression(key) = field.surface else {
+                    panic!("{what}::{} is not rendered as an expression", field.name);
+                };
+                assert!(
+                    schema::command_field(key).is_some() || schema::subcommand_field(key).is_some(),
+                    "{what}::{} names `{key}`, which is not a schema field",
+                    field.name
+                );
+                assert!(
+                    source.contains(&format!("{}: ", field.name)),
+                    "{what}::{} never reaches the rendered spec:\n{source}",
+                    field.name
+                );
+            }
+        }
+        // The whole point: a seeded descriptor renders instead of leaving a
+        // `TODO` for the author to retype.
+        assert!(
+            !source.contains("`binds_handle` is set on the source command"),
+            "binds_handle must round-trip, not be reported unrecoverable:\n{source}"
+        );
+    }
+
+    /// A descriptor the registry really declares survives the round trip —
+    /// `set`'s handle binding (issue #1185), seeded from the live registry.
+    #[test]
+    fn a_live_registry_binding_round_trips() {
+        let registry = tcl_registry::registry::CommandRegistry::build_default();
+        let spec = registry.get("set").expect("set is a core command");
+        assert!(
+            spec.binds_handle.is_some(),
+            "`set` declares the handle binding this test exists to round-trip"
+        );
+        let source = render_rs::render(&draft::from_command_spec(spec));
+        assert!(
+            source.contains("binds_handle: Some(&HandleBindingSpec { name_at: 0, "),
+            "the live binding must render as a literal:\n{source}"
+        );
+    }
+
+    /// Guard the imports the assertions above rely on staying meaningful.
+    #[test]
+    fn witness_constants_are_the_shapes_they_claim() {
+        assert_eq!(WITNESS_BINDING.class_from.index(), 2);
+        // start 1, stride 2, one trailing word excluded: 5 words cover 1 and 3.
+        assert_eq!(WITNESS_REPEAT.indices(5), vec![1, 3]);
+        assert_eq!(SETTER.code, DiagCode::Irule3101);
+        assert_eq!(FormKind::Default, FormSpec::DEFAULT.kind);
+        assert_eq!(ConnectionSide::None, SideEffect::DEFAULT.connection_side);
+        assert_eq!(SideEffectTarget::Unknown, SideEffect::DEFAULT.target);
+    }
+}

--- a/rust/tcl-spec-studio/src/draft.rs
+++ b/rust/tcl-spec-studio/src/draft.rs
@@ -947,6 +947,10 @@ fn command_advanced(d: &mut Draft, spec: &CommandSpec, lost: &mut Unrecovered) {
         lost.expr("body_scope", spec.body_scope.is_some()),
     );
     d.insert(
+        "binds_handle".into(),
+        lost.expr("binds_handle", spec.binds_handle.is_some()),
+    );
+    d.insert(
         "creates_instance_at".into(),
         opt_index(spec.creates_instance_at),
     );

--- a/rust/tcl-spec-studio/src/draft.rs
+++ b/rust/tcl-spec-studio/src/draft.rs
@@ -27,30 +27,45 @@
 //! ## Fields that cannot round-trip
 //!
 //! A handful of spec fields hold a function pointer (`arg_role_resolver`,
-//! `const_fold`, `taint_sink_gate`, …) or a reference to a `&'static`
-//! descriptor (`definition_body`, `case_list`, `object_class`, …). Rust can
-//! tell that such a field is set, but not recover the *expression* that set
-//! it. Seeding records those keys under [`UNRENDERABLE_KEY`] so the form can
-//! flag them and the renderer can emit a `TODO` rather than silently dropping
+//! `const_fold`, `taint_sink_gate`, …) or a reference to a **named** `&'static`
+//! descriptor the registry shares between commands (`definition_body`,
+//! `case_list`, `object_class`, `body_scope`, `frame_effect`, `bpf_op`,
+//! `event_requires`, `command_forms`). Rust can tell that such a field is set,
+//! but not recover the *expression* — the constant's path — that set it.
+//! Seeding records those keys under [`UNRENDERABLE_KEY`] so the form can flag
+//! them and the renderer can emit a `TODO` rather than silently dropping
 //! behaviour the source command had.
+//!
+//! A descriptor that is **plain data** is a different case and does round-trip:
+//! `repeated_args`, `binds_handle`, `byte_array_payload`, `defines_symbol`,
+//! `oo_context_facts`, and a subcommand's `versioned_arg_values` are rendered
+//! back out as full struct literals (every field spelled, never a defaulting
+//! constructor), so drafting and re-rendering a command that sets one loses
+//! nothing. [`crate::coverage`] is what keeps those literals complete.
 
 use serde_json::{Map, Value, json};
 use tcl_dialect::DialectSet;
 use tcl_registry::arg_role::{AppendedArity, ArgRole};
 use tcl_registry::arity::Arity;
+use tcl_registry::handle_binding::{HandleBindingSpec, HandleClassSource, HandleKeyword};
 use tcl_registry::hooks::ArgTypeHint;
 use tcl_registry::hover::{
     ArgValue, FormSpec, HoverSnippet, IntegerDomain, OptionArity, OptionSpec, OptionValue,
 };
 use tcl_registry::lifecycle::Lifecycle;
 use tcl_registry::presentation::ArgPresentation;
+use tcl_registry::repeated::RepeatedArgLayout;
 use tcl_registry::side_effects::SideEffect;
-use tcl_registry::spec::{CommandSpec, SubCommand, SubSubCommand};
+use tcl_registry::spec::{
+    BytePayloadSpec, CommandSpec, OoContextFact, SubCommand, SubSubCommand, VersionedArgValue,
+};
+use tcl_registry::symbol_def::SymbolDef;
 use tcl_registry::taint::{SetterConstraint, TaintColour};
 use tcl_registry::traits::Traits;
 use tcl_registry::types::{ReturnElements, VarElementsEffect, VarWriteTyping};
 
 use crate::catalogue;
+use crate::render_rs::rust_string;
 
 /// Draft key listing the fields a live spec sets but whose defining Rust
 /// expression could not be recovered. Absent (or empty) when everything
@@ -79,7 +94,7 @@ fn opt_str(value: Option<&'static str>) -> Value {
 /// every registry surface: `introduced_version`, `deprecated_version`, and
 /// `retired_version` (the last exclusive). `null` means the lifecycle never
 /// reached that state.
-fn insert_lifecycle(d: &mut Map<String, Value>, lifecycle: Lifecycle) {
+pub(crate) fn insert_lifecycle(d: &mut Map<String, Value>, lifecycle: Lifecycle) {
     d.insert("introduced_version".into(), opt_str(lifecycle.introduced));
     d.insert("deprecated_version".into(), opt_str(lifecycle.deprecated));
     d.insert("retired_version".into(), opt_str(lifecycle.retired));
@@ -125,7 +140,7 @@ fn taint(value: Option<TaintColour>) -> Value {
     }
 }
 
-fn arity(value: Arity) -> Value {
+pub(crate) fn arity(value: Arity) -> Value {
     json!({
         "min": value.min,
         "max": if value.is_unlimited() { Value::Null } else { json!(value.max) },
@@ -171,7 +186,7 @@ fn prefix_map(entries: &[(u8, AppendedArity)]) -> Value {
     )
 }
 
-fn arg_type_map(entries: &[(u8, ArgTypeHint)]) -> Value {
+pub(crate) fn arg_type_map(entries: &[(u8, ArgTypeHint)]) -> Value {
     Value::Array(
         entries
             .iter()
@@ -192,7 +207,7 @@ fn arg_type_map(entries: &[(u8, ArgTypeHint)]) -> Value {
     )
 }
 
-fn arg_value(value: &ArgValue) -> Value {
+pub(crate) fn arg_value(value: &ArgValue) -> Value {
     json!({
         "value": value.value,
         "detail": value.detail,
@@ -237,7 +252,7 @@ fn option_arity(value: OptionArity) -> (Value, bool) {
 }
 
 /// Draft form of an option, plus whether it round-tripped completely.
-fn option_spec(opt: &OptionSpec) -> (Value, bool) {
+pub(crate) fn option_spec(opt: &OptionSpec) -> (Value, bool) {
     let (value, complete) = match opt.value {
         OptionValue::Flag => (Value::Null, true),
         OptionValue::Takes(arg) => {
@@ -274,7 +289,7 @@ fn option_spec(opt: &OptionSpec) -> (Value, bool) {
     )
 }
 
-fn form_spec(form: &FormSpec) -> Value {
+pub(crate) fn form_spec(form: &FormSpec) -> Value {
     json!({
         "kind": catalogue::variant_name(&form.kind),
         "synopsis": form.synopsis,
@@ -282,7 +297,7 @@ fn form_spec(form: &FormSpec) -> Value {
     })
 }
 
-fn side_effect(effect: &SideEffect) -> Value {
+pub(crate) fn side_effect(effect: &SideEffect) -> Value {
     json!({
         "target": catalogue::variant_name(&effect.target),
         "reads": effect.reads,
@@ -292,7 +307,7 @@ fn side_effect(effect: &SideEffect) -> Value {
     })
 }
 
-fn setter_constraint(constraint: &SetterConstraint) -> Value {
+pub(crate) fn setter_constraint(constraint: &SetterConstraint) -> Value {
     json!({
         "arg_index": constraint.arg_index,
         "required_prefix": constraint.required_prefix,
@@ -301,7 +316,7 @@ fn setter_constraint(constraint: &SetterConstraint) -> Value {
     })
 }
 
-fn hover(value: Option<HoverSnippet>) -> Value {
+pub(crate) fn hover(value: Option<HoverSnippet>) -> Value {
     match value {
         None => Value::Null,
         Some(h) => json!({
@@ -315,7 +330,7 @@ fn hover(value: Option<HoverSnippet>) -> Value {
     }
 }
 
-fn sub_subcommand(sub: &SubSubCommand) -> Value {
+pub(crate) fn sub_subcommand(sub: &SubSubCommand) -> Value {
     json!({
         "name": sub.name,
         "detail": sub.detail,
@@ -373,6 +388,158 @@ fn var_elements_effect_expr(value: VarElementsEffect) -> String {
         VarElementsEffect::ListifiesDictValue => "ListifiesDictValue".to_owned(),
     };
     format!("Some(VarElementsEffect::{inner})")
+}
+
+/// The Rust expression for an `Option<u8>` field of a descriptor literal.
+fn opt_u8_expr(value: Option<u8>) -> String {
+    value.map_or_else(|| "None".to_owned(), |n| format!("Some({n})"))
+}
+
+/// The Rust expression for an `Option<&'static str>` field of a descriptor
+/// literal.
+fn opt_str_expr(value: Option<&'static str>) -> String {
+    value.map_or_else(
+        || "None".to_owned(),
+        |s| format!("Some({})", rust_string(s)),
+    )
+}
+
+/// The Rust expression for a [`Lifecycle`], spelled as a struct literal.
+///
+/// The literal names all three releases rather than chaining the
+/// `introduced_in(…).deprecated_from(…)` builders, so a release the type gains
+/// later cannot be dropped silently — [`crate::coverage`] checks the rendered
+/// text mentions every field.
+fn lifecycle_expr(value: Lifecycle) -> String {
+    format!(
+        "Lifecycle {{ introduced: {}, deprecated: {}, retired: {} }}",
+        opt_str_expr(value.introduced),
+        opt_str_expr(value.deprecated),
+        opt_str_expr(value.retired),
+    )
+}
+
+/// The Rust expression for one [`RepeatedArgLayout`].
+///
+/// Written as a full struct literal rather than one of the `every` / `strided`
+/// constructors: a constructor hides the fields it defaults, and hiding a field
+/// is exactly the drift this module exists to prevent.
+fn repeated_arg_layout_expr(layout: RepeatedArgLayout) -> String {
+    format!(
+        "RepeatedArgLayout {{ role: {}, start: {}, stride: {}, exclude_trailing: {}, optional_leading_word: {} }}",
+        catalogue::qualified_variant("ArgRole", &layout.role),
+        layout.start,
+        layout.stride,
+        layout.exclude_trailing,
+        layout.optional_leading_word,
+    )
+}
+
+/// The Rust expression for a `&'static [RepeatedArgLayout]` field.
+fn repeated_args_expr(layouts: &[RepeatedArgLayout]) -> String {
+    let items: Vec<String> = layouts
+        .iter()
+        .copied()
+        .map(repeated_arg_layout_expr)
+        .collect();
+    format!("&[{}]", items.join(", "))
+}
+
+/// The Rust expression for a [`HandleClassSource`].
+fn handle_class_source_expr(source: HandleClassSource) -> String {
+    match source {
+        HandleClassSource::Word(i) => format!("HandleClassSource::Word({i})"),
+        HandleClassSource::ConstructionValue(i) => {
+            format!("HandleClassSource::ConstructionValue({i})")
+        }
+    }
+}
+
+/// The Rust expression for a [`HandleKeyword`].
+fn handle_keyword_expr(keyword: HandleKeyword) -> String {
+    format!(
+        "HandleKeyword {{ at: {}, word: {} }}",
+        keyword.at,
+        rust_string(keyword.word)
+    )
+}
+
+/// The Rust expression for a [`HandleBindingSpec`] reference, wrapped in
+/// `Some(&…)`.
+///
+/// The whole descriptor is plain data (two indices, a fieldless-payload enum,
+/// and an optional keyword), so it round-trips: `&`-borrowing a constant struct
+/// literal promotes to the `&'static` the field wants (issue #1185).
+fn handle_binding_expr(spec: &HandleBindingSpec) -> String {
+    format!(
+        "Some(&HandleBindingSpec {{ name_at: {}, class_from: {}, keyword: {} }})",
+        spec.name_at,
+        handle_class_source_expr(spec.class_from),
+        spec.keyword.map_or_else(
+            || "None".to_owned(),
+            |k| format!("Some({})", handle_keyword_expr(k))
+        ),
+    )
+}
+
+/// The Rust expression for a [`BytePayloadSpec`], wrapped in `Some(…)`.
+fn byte_payload_expr(spec: BytePayloadSpec) -> String {
+    format!(
+        "Some(BytePayloadSpec {{ replace_data_index: {}, message_flag_shift: {} }})",
+        spec.replace_data_index, spec.message_flag_shift,
+    )
+}
+
+/// The Rust expression for a [`SymbolDef`], wrapped in `Some(…)`.
+fn symbol_def_expr(def: SymbolDef) -> String {
+    format!(
+        "Some(SymbolDef {{ name_arg: {}, detail_arg: {}, requires_arg: {}, kind: {} }})",
+        def.name_arg,
+        opt_u8_expr(def.detail_arg),
+        opt_u8_expr(def.requires_arg),
+        catalogue::qualified_variant("DefinedSymbolKind", &def.kind),
+    )
+}
+
+/// The Rust expression for a `&'static [(&'static str, OoContextFact)]` field.
+fn oo_context_facts_expr(facts: &[(&'static str, OoContextFact)]) -> String {
+    let items: Vec<String> = facts
+        .iter()
+        .map(|(word, fact)| {
+            format!(
+                "({}, {})",
+                rust_string(word),
+                catalogue::qualified_variant("OoContextFact", fact)
+            )
+        })
+        .collect();
+    format!("&[{}]", items.join(", "))
+}
+
+/// The Rust expression for a `&'static [VersionedArgValue]` field.
+fn versioned_arg_values_expr(gates: &[VersionedArgValue]) -> String {
+    let items: Vec<String> = gates
+        .iter()
+        .map(|gate| {
+            format!(
+                "VersionedArgValue {{ index: {}, value: {}, lifecycle: {} }}",
+                gate.index,
+                rust_string(gate.value),
+                lifecycle_expr(gate.lifecycle),
+            )
+        })
+        .collect();
+    format!("&[{}]", items.join(", "))
+}
+
+/// A draft value for a descriptor field: the rendered Rust expression when the
+/// field is set, `null` when it is at its default.
+///
+/// `null` is what the schema's `RustExpr` editor shows as "unset", and what the
+/// renderer reads as "leave it to `..DEFAULT`" — so an unset descriptor stays
+/// out of the emitted spec exactly as before.
+fn expr_or_null(set: bool, render: impl FnOnce() -> String) -> Value {
+    if set { json!(render()) } else { Value::Null }
 }
 
 /// Records the keys whose defining expression could not be recovered.
@@ -434,7 +601,9 @@ fn subcommand_identity(d: &mut Draft, sub: &SubCommand, lost: &mut Unrecovered) 
     );
     d.insert(
         "repeated_args".into(),
-        lost.expr("repeated_args", !sub.repeated_args.is_empty()),
+        expr_or_null(!sub.repeated_args.is_empty(), || {
+            repeated_args_expr(sub.repeated_args)
+        }),
     );
     d.insert(
         "arg_role_resolver".into(),
@@ -537,7 +706,9 @@ fn subcommand_rest(d: &mut Draft, sub: &SubCommand, lost: &mut Unrecovered) {
     d.insert("arg_values".into(), arg_value_map(sub.arg_values));
     d.insert(
         "versioned_arg_values".into(),
-        lost.expr("versioned_arg_values", !sub.versioned_arg_values.is_empty()),
+        expr_or_null(!sub.versioned_arg_values.is_empty(), || {
+            versioned_arg_values_expr(sub.versioned_arg_values)
+        }),
     );
     d.insert(
         "subcommand_forms".into(),
@@ -647,7 +818,9 @@ fn command_identity(d: &mut Draft, spec: &CommandSpec, lost: &mut Unrecovered) {
     );
     d.insert(
         "repeated_args".into(),
-        lost.expr("repeated_args", !spec.repeated_args.is_empty()),
+        expr_or_null(!spec.repeated_args.is_empty(), || {
+            repeated_args_expr(spec.repeated_args)
+        }),
     );
     d.insert(
         "arg_role_resolver".into(),
@@ -916,7 +1089,8 @@ fn command_advanced(d: &mut Draft, spec: &CommandSpec, lost: &mut Unrecovered) {
     );
     d.insert(
         "byte_array_payload".into(),
-        lost.expr("byte_array_payload", spec.byte_array_payload.is_some()),
+        spec.byte_array_payload
+            .map_or(Value::Null, |p| json!(byte_payload_expr(p))),
     );
     d.insert(
         "byte_array_effect".into(),
@@ -932,7 +1106,9 @@ fn command_advanced(d: &mut Draft, spec: &CommandSpec, lost: &mut Unrecovered) {
     );
     d.insert(
         "oo_context_facts".into(),
-        lost.expr("oo_context_facts", !spec.oo_context_facts.is_empty()),
+        expr_or_null(!spec.oo_context_facts.is_empty(), || {
+            oo_context_facts_expr(spec.oo_context_facts)
+        }),
     );
     d.insert(
         "object_class".into(),
@@ -940,7 +1116,8 @@ fn command_advanced(d: &mut Draft, spec: &CommandSpec, lost: &mut Unrecovered) {
     );
     d.insert(
         "defines_symbol".into(),
-        lost.expr("defines_symbol", spec.defines_symbol.is_some()),
+        spec.defines_symbol
+            .map_or(Value::Null, |s| json!(symbol_def_expr(s))),
     );
     d.insert(
         "body_scope".into(),
@@ -948,7 +1125,8 @@ fn command_advanced(d: &mut Draft, spec: &CommandSpec, lost: &mut Unrecovered) {
     );
     d.insert(
         "binds_handle".into(),
-        lost.expr("binds_handle", spec.binds_handle.is_some()),
+        spec.binds_handle
+            .map_or(Value::Null, |b| json!(handle_binding_expr(b))),
     );
     d.insert(
         "creates_instance_at".into(),

--- a/rust/tcl-spec-studio/src/draft.rs
+++ b/rust/tcl-spec-studio/src/draft.rs
@@ -47,7 +47,9 @@ use serde_json::{Map, Value, json};
 use tcl_dialect::DialectSet;
 use tcl_registry::arg_role::{AppendedArity, ArgRole};
 use tcl_registry::arity::Arity;
-use tcl_registry::handle_binding::{HandleBindingSpec, HandleClassSource, HandleKeyword};
+use tcl_registry::handle_binding::{
+    HandleBindingSpec, HandleClassSource, HandleKeyword, HandleName,
+};
 use tcl_registry::hooks::ArgTypeHint;
 use tcl_registry::hover::{
     ArgValue, FormSpec, HoverSnippet, IntegerDomain, OptionArity, OptionSpec, OptionValue,
@@ -445,6 +447,14 @@ fn repeated_args_expr(layouts: &[RepeatedArgLayout]) -> String {
     format!("&[{}]", items.join(", "))
 }
 
+/// The Rust expression for a [`HandleName`].
+fn handle_name_expr(name: HandleName) -> String {
+    match name {
+        HandleName::Word(i) => format!("HandleName::Word({i})"),
+        HandleName::Implicit(v) => format!("HandleName::Implicit({})", rust_string(v)),
+    }
+}
+
 /// The Rust expression for a [`HandleClassSource`].
 fn handle_class_source_expr(source: HandleClassSource) -> String {
     match source {
@@ -472,8 +482,8 @@ fn handle_keyword_expr(keyword: HandleKeyword) -> String {
 /// literal promotes to the `&'static` the field wants (issue #1185).
 fn handle_binding_expr(spec: &HandleBindingSpec) -> String {
     format!(
-        "Some(&HandleBindingSpec {{ name_at: {}, class_from: {}, keyword: {} }})",
-        spec.name_at,
+        "Some(&HandleBindingSpec {{ name_from: {}, class_from: {}, keyword: {} }})",
+        handle_name_expr(spec.name_from),
         handle_class_source_expr(spec.class_from),
         spec.keyword.map_or_else(
             || "None".to_owned(),

--- a/rust/tcl-spec-studio/src/lib.rs
+++ b/rust/tcl-spec-studio/src/lib.rs
@@ -31,12 +31,16 @@
 //!   the form, the draft model, and the renderer from a single table.
 //! - [`catalogue`] — the registry's enum and bitflag vocabularies, with
 //!   compile-time witnesses that they stay complete.
+//! - [`coverage`] — the same idea one level down: exhaustive *destructurings*
+//!   of the `CommandSpec` family, so a new registry **field** breaks the build
+//!   until it is surfaced in the studio (or explicitly excluded).
 //! - [`draft`] — the JSON draft model, and seeding a draft from a live spec.
 //! - [`render_rs`] — draft → registry `.rs` source, copyright banner included.
 //! - [`render_stub`] — draft → `# tcl-lsp: stub` block or `.tcl.stubs` file.
 //! - [`infer`] — Tcl package sources → draft specs, via the real analyser.
 
 pub mod catalogue;
+pub mod coverage;
 pub mod draft;
 pub mod infer;
 pub mod render_rs;

--- a/rust/tcl-spec-studio/src/render_rs.rs
+++ b/rust/tcl-spec-studio/src/render_rs.rs
@@ -54,7 +54,11 @@ pub const COPYRIGHT_BANNER: &str = "\
 // SPDX-License-Identifier: AGPL-3.0-or-later";
 
 /// Escape `s` as the body of a Rust double-quoted string literal.
-fn rust_string(s: &str) -> String {
+///
+/// Shared with [`crate::draft`], which renders the same literals when it seeds
+/// a descriptor field as a Rust expression — one escaper, so a `"` in a
+/// keyword word cannot compile in one path and not the other.
+pub(crate) fn rust_string(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 2);
     out.push('"');
     for ch in s.chars() {

--- a/rust/tcl-spec-studio/src/render_rs.rs
+++ b/rust/tcl-spec-studio/src/render_rs.rs
@@ -403,6 +403,45 @@ fn lifecycle_expr(entry: &Value) -> Option<String> {
     Some(expr)
 }
 
+/// What a schema field whose key is one of the three `Lifecycle` releases
+/// contributes to the emitted struct literal.
+enum LifecycleLine {
+    /// Not a release key — render the field the ordinary way.
+    Other,
+    /// The first release key: emit this text (empty when the draft declares no
+    /// release at all, leaving the field to `..DEFAULT`).
+    Emit(String),
+    /// A later release key — the first already accounted for it.
+    Skip,
+}
+
+/// Collapse the schema's three release keys back into the registry's one
+/// `lifecycle` field.
+///
+/// `CommandSpec` / `SubCommand` declare **one** `lifecycle` field; the form
+/// edits it as three independent releases (#1210). Walking the schema and
+/// emitting each key verbatim produced `introduced_version: Some("21.1.0"),` —
+/// a spec file that does not compile (`struct SubCommand has no field named
+/// introduced_version`), caught by rendering the registry back into itself.
+/// The line lands at the position of the first release key, so field order is
+/// unchanged.
+fn lifecycle_line(key: &str, draft: &Value, indent: &str) -> LifecycleLine {
+    let Some((first, rest)) = crate::coverage::LIFECYCLE_KEYS.split_first() else {
+        return LifecycleLine::Other;
+    };
+    if *first == key {
+        return LifecycleLine::Emit(
+            lifecycle_expr(draft)
+                .map(|expr| format!("{indent}lifecycle: {expr},\n"))
+                .unwrap_or_default(),
+        );
+    }
+    if rest.contains(&key) {
+        return LifecycleLine::Skip;
+    }
+    LifecycleLine::Other
+}
+
 fn option_expr(entry: &Value, indent: &str) -> String {
     let inner = format!("{indent}    ");
     let mut parts = vec![format!(
@@ -687,6 +726,16 @@ fn subcommand_literal(sub: &Value, default: &Draft, indent: &str) -> String {
     let inner = format!("{indent}    ");
     let mut lines: Vec<String> = Vec::new();
     for field in schema::SUBCOMMAND_FIELDS {
+        match lifecycle_line(field.key, sub, &inner) {
+            LifecycleLine::Emit(line) => {
+                if !line.is_empty() {
+                    lines.push(line.trim_end_matches('\n').to_owned());
+                }
+                continue;
+            }
+            LifecycleLine::Skip => continue,
+            LifecycleLine::Other => {}
+        }
         // Nested tables are inlined here rather than hoisted — a subcommand's
         // option list belongs with the subcommand that declares it.
         let value = sub.get(field.key).unwrap_or(&Value::Null);
@@ -869,7 +918,16 @@ pub fn render(draft: &Draft) -> String {
     out.push_str("/// Command spec for `");
     out.push_str(name);
     out.push_str("`.\npub fn spec() -> CommandSpec {\n    CommandSpec {\n");
+    let whole = Value::Object(draft.clone());
     for field in schema::COMMAND_FIELDS {
+        match lifecycle_line(field.key, &whole, "        ") {
+            LifecycleLine::Emit(line) => {
+                out.push_str(&line);
+                continue;
+            }
+            LifecycleLine::Skip => continue,
+            LifecycleLine::Other => {}
+        }
         let value = draft.get(field.key).unwrap_or(&Value::Null);
         let default_value = default.get(field.key).unwrap_or(&Value::Null);
         if let Some(expr) = field_expr(field, value, default_value, "        ") {
@@ -998,7 +1056,7 @@ mod tests {
     use serde_json::json;
     use tcl_registry::arg_role::ArgRole;
     use tcl_registry::arity::Arity;
-    use tcl_registry::spec::CommandSpec;
+    use tcl_registry::spec::{CommandSpec, SubCommand};
     use tcl_registry::traits::Traits;
     use tcl_registry::types::TclType;
 
@@ -1133,6 +1191,57 @@ mod tests {
             out.contains("//! `mycmd` — does a thing\n//! and keeps going.\n"),
             "{out}"
         );
+    }
+
+    /// The three release keys collapse back into the one `lifecycle` field the
+    /// registry declares — at the command level and inside a subcommand.
+    ///
+    /// Emitting the schema keys verbatim produced `introduced_version:
+    /// Some("21.1.0"),` inside a `SubCommand` literal, which is not a field:
+    /// the studio's advertised drop-in file did not compile. Found by
+    /// rendering `persist` back into `tcl-registry` and building it, per the
+    /// procedure in `tests/render_sweep.rs`.
+    #[test]
+    fn a_lifecycle_renders_as_one_field_not_three_keys() {
+        const SUBS: &[SubCommand] = &[SubCommand {
+            name: "add",
+            lifecycle: tcl_registry::lifecycle::Lifecycle::introduced_in("21.1.0"),
+            ..SubCommand::DEFAULT
+        }];
+        let spec = CommandSpec {
+            name: "persist",
+            lifecycle: tcl_registry::lifecycle::Lifecycle::introduced_in("11.0.0")
+                .deprecated_from("17.0.0")
+                .retired_from("21.0.0"),
+            subcommands: SUBS,
+            ..CommandSpec::DEFAULT
+        };
+        let out = render(&draft::from_command_spec(&spec));
+        assert!(
+            out.contains(
+                "lifecycle: Lifecycle::introduced_in(\"11.0.0\")\
+                 .deprecated_from(\"17.0.0\").retired_from(\"21.0.0\"),"
+            ),
+            "{out}"
+        );
+        assert!(
+            out.contains("lifecycle: Lifecycle::introduced_in(\"21.1.0\"),"),
+            "a subcommand's lifecycle must collapse too:\n{out}"
+        );
+        for key in crate::coverage::LIFECYCLE_KEYS {
+            assert!(
+                !out.contains(&format!("{key}:")),
+                "`{key}` is a form key, not a struct field — it must never reach the spec:\n{out}"
+            );
+        }
+    }
+
+    /// A command with no lifecycle emits nothing, leaving it to `..DEFAULT`.
+    #[test]
+    fn an_unspecified_lifecycle_emits_no_field() {
+        let mut d = draft::default_command_draft();
+        d.insert("name".into(), json!("mycmd"));
+        assert!(!render(&d).contains("lifecycle"));
     }
 
     #[test]

--- a/rust/tcl-spec-studio/src/schema.rs
+++ b/rust/tcl-spec-studio/src/schema.rs
@@ -915,6 +915,15 @@ pub const COMMAND_FIELDS: &[FieldSchema] = &[
         "Extra commands available only inside the command's body argument.",
     ),
     f(
+        "binds_handle",
+        "Binds handle",
+        ADVANCED,
+        FieldKind::RustExpr {
+            hint: "Some(&handle_binding::SET_BINDS_HANDLE)",
+        },
+        "Which argument becomes an object handle, and which says its class.",
+    ),
+    f(
         "creates_instance_at",
         "Creates instance at",
         SUBS,


### PR DESCRIPTION
Closes #1185.

## Scope correction

Much of what #1185 described was already done when this work started, so it was verified rather than redone:

- **No command-name switch remains for the format family in either consumer.** `inlay_hints.rs::format_args` already read `CommandRegistry::format_string_args`; its only mention of `format`/`scan`/`clock`/`binary`/`regsub` is a doc comment recording the retired match. Same for `semantic_tokens.rs::insert_format_overrides`.
- **`format_string_type` is populated, not dead API** — set by `commands/tcl/{format_,scan_,regsub_}.rs` plus two subcommands each in `clock_.rs`/`binary_.rs`, and consumed by `format_string_args`.
- **Loop-var lists, `upvar`, `global`/`variable`, `oo::define`/`objdefine`, snit built-in typemethods** all already flow from registry data, with `qualified_*_classify_like_the_bare_form` pinning the leading-`::` forms.

## What actually remained

**Effective command identity was never resolved.** `semantic_tokens.rs::collect_script` resolved a head only through `ctx.head_aliases`, populated solely by `imported_command_aliases` behind the cheap gate `if !source.contains("namespace")` — so `interp alias`, `rename`, and a built-in shadowed by a user `proc` were all invisible. `inlay_hints.rs` passed raw head text.

Three more of the same class were found by inspection:

- `CommandRegistry::command_table_effect` returned `None` for **any** `::`-qualified head, pinned by an assertion that `("::rename", Some("old"))` is `None`. Oracle: `::rename format ::origfmt`, `::interp alias {} myfmt {} format` and `::proc ::greet {} {…}` all work on tclsh 9.0.4 and 8.6.16.
- `collection_head_element_classes` matched `("dict", [sub, coll, _key]) if sub == "get"` and `("lindex", …)` by name.
- snit `install … using` was matched by spelling (`Some("install") if texts[2] == "using"`), with a second `Some("set")` arm re-deriving the assignment layout and a `cd.metaclass.starts_with("snit::")` family test.

## Design

**Registry** — new `handle_binding.rs`:

```rust
pub struct HandleBindingSpec { name_at: u8, class_from: HandleClassSource, keyword: Option<HandleKeyword> }
pub enum HandleClassSource { Word(u8), ConstructionValue(u8) }
```

`resolve(args)` abstains on a missing keyword, a short call, or a dynamic word. **Homes are chosen by scope:** `set` carries it on `CommandSpec::binds_handle` (a real global command, so `::set` answers through `get`), while snit's `install` carries it on `DefinitionBodyGrammar::member_body_commands` — deliberately *not* a global spec, which would make a user's own `proc install` look like a built-in everywhere. A paired `bare_word_construction` flag replaced the `starts_with("snit::")` test.

**LSP** — new `head_identity.rs`: `HeadIdentity::{Command(&str), Rebound}` plus an offset-keyed `HeadIdentityMap`. One top-level segmentation feeds `namespace import`, `interp alias`, `rename` and built-in-shadowing `proc`; which commands mutate the table comes from `CommandTableEffect`, and the argument shapes come from the compiler's own `alias.rs` detectors, so no command name is spelled. `spec_name()` answers `""` for `Rebound`, which `get` never resolves — so every existing registry query answers "unknown" without a variant check bolted onto each call site.

## Also in this PR: the spec-studio WebUI carries every field

An audit of all 84 `CommandSpec` and 60 `SubCommand` fields against `schema.rs`, `draft.rs`, the renderers and the WASM binding found **no missing fields** — but two real fidelity defects:

- **The renderer emitted `introduced_version: Some("21.1.0")`, which is not a struct field.** Every lifecycle-carrying spec authored through the WebUI rendered to Rust that does not compile. Found by rendering all 21 descriptor-carrying specs into a scratch module and building it.
- **Six descriptors were schema-listed but rendered as `TODO` and seeded as `null`** — `binds_handle`, `repeated_args`, `byte_array_payload`, `defines_symbol`, `oo_context_facts`, and `SubCommand::versioned_arg_values`. Drafting `set` in the WebUI silently **lost** its handle binding. All six now render as full struct literals with every field spelled, never via a `::strided(…)`-style constructor that hides what it defaults.
- `DefinedSymbolKind::Event` had drifted out of the catalogue when the iRules `when` handler symbol landed.

**And it is now enforced.** New `coverage.rs` covers 21 types, each with an exhaustive destructuring carrying no `..` rest, plus a per-field table declaring `Surface::Key`/`Keys`/`Expression`/`Excluded("reason")`. Verified by adding a scratch field and confirming the build fails:

```
error[E0027]: pattern does not mention field `scratch_gate_probe`
help: or always ignore missing fields here
```

Longhand rather than a macro deliberately: with `$field:ident` the pattern is hygiene-degraded and rustc falls back to "inaccessible fields", which does not name the field. Shared grammar constants (`DefinitionBodyGrammar` and friends) are recorded as explicit exclusions with reasons — authoring one is an edit to `definer.rs`, not a form field — and function-pointer fields keep the existing unrenderable treatment, since Rust cannot recover the defining expression.

## Tests

Registry: `set_declares_its_handle_binding_for_every_spelling`, `snit_install_is_a_member_body_binding_not_a_global_command` (asserts `reg.get("install").is_none()`), `bare_word_construction_is_declared_per_definer_family`, plus rewritten `::`-qualified `command_table_effect` assertions.

`head_identity`: 12 tests — rename move and old-name clearing, alias, dynamic abstention, child-interp, foreign target path, safe-interpreter hidden commands, malformed arity, nested/conditional bindings, qualified mutator head, latest-fact-wins, and the `Rebound` sentinel being unresolvable.

Semantic tokens: alias/rename/shadow TP+FP, non-retroactivity, unprovable-binding TN, namespaced-proc FP, and `apply_lambda_literals_survive_a_rename_or_alias`. Inlay hints: `format_hints_follow_the_effective_command_identity`. Native e2e: `test_command_identity_drives_argument_grammar`. VS Code: a decoded-token test over a new fixture, with assertions derived from the real encoder output rather than guessed.

Spec-studio went 47 → 61 lib tests, including one that writes the emitted `binds_handle` literal out as real Rust inside a function returning `CommandSpec`, proving the static promotion the round-trip depends on.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo check --workspace --all-targets` all clean; `cargo test -p tcl-registry -p tcl-spec-studio` 723 passed; `tcl-compiler` and `tcl-lsp-core` green; `tcl-lsp-server` 1296 passed; `make xtask-check` clean across all 10 drift gates with no generated artefacts changed. No `#[allow]` — `too_many_arguments` was fixed with a named `HandleScanCtx` and `assertions_on_constants` by table-driving the test.

Re-verified after rebasing onto current `rust`.

## Left for follow-up (filed)

- #1275 — seven other consumers still resolve raw head text and will disagree with these two after a rebinding; `HeadIdentityMap` is the shared pre-pass they need. That issue also carries snit `installhull`, non-composing chained bindings, and the `class_is_configurable` name comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_