### PR TITLE
Make the cross-file mathfunc suppression reachable by default; one diagnostic verdict for code actions (#1019)

### DIFF
--- a/docs/design/contracts/xdg-config.md
+++ b/docs/design/contracts/xdg-config.md
@@ -165,7 +165,7 @@ Toggle individual LSP features.  All default to `true`.
 | `callHierarchy` | Call hierarchy |
 | `documentLinks` | Document links |
 | `selectionRange` | Smart selection |
-| `crossFileResolution` | Cross-file W120/W123 suppression and cross-file E002/E003 arity — off by default (independent of `[xcDiagnostics]`, which is F5 XC Migration-specific) |
+| `crossFileResolution` | Cross-file W120/W123 suppression and cross-file E002/E003 arity — off by default (independent of `[xcDiagnostics]`, which is F5 XC Migration-specific). A workspace-injected `::tcl::mathfunc` override resolves without it: that namespace is one table per interpreter, so the suppression is a language fact, not a cross-file inference |
 
 ### `[formatting]`
 

--- a/docs/kcs/codes/kcs-diagnostic-w123-unresolved-command.md
+++ b/docs/kcs/codes/kcs-diagnostic-w123-unresolved-command.md
@@ -107,7 +107,7 @@ command name "Dog"`, so the old name is reported.
 ## Commands defined in another file
 
 The check reads one file at a time, so a `proc` that lives in a sibling
-file is not something it can see on its own. Two things make it visible.
+file is not something it can see on its own. Three things make it visible.
 
 Always on, needing no setting: a command an installed library auto-loads
 (`tclIndex`), and a command defined by a package the file `package
@@ -119,9 +119,8 @@ rules: `set auto_path {…}` contributes one directory per **list element**
 Windows `[info script]` resolves against its own directory, and a versioned
 `package require NAME 2.0` reads the release `package vsatisfies` would pick.
 
-Off by default, opt in with `tclLsp.features.crossFileResolution`: every
-`proc` and class the **workspace** defines, whether or not anything links
-the two files. Turn it on and this stops firing:
+Also always on: an `expr` math function the **workspace** defines. Nothing
+below is reported:
 
 ```tcl
 # helper.tcl
@@ -133,13 +132,29 @@ namespace eval tcl::mathfunc {
 proc angle {dp} { return [expr {Pi()}] }
 ```
 
-With the setting off, `Pi` is reported as unresolved even though Go to
-Definition and Find All References both resolve it to `helper.tcl` — the
-two disagree, and the offered quick fix ("did you mean `ni`?") would break
-working code if accepted. With it on, they agree.
+`expr` looks a function up in `::tcl::mathfunc`, which is one table per
+interpreter — so a workspace that defines `Pi` there defines the one `Pi`
+every `expr` in it can call, and there is no second project-local meaning to
+confuse it with. This one needs no setting for that reason. It is also why
+the match is exact: a `proc` named `Pi` in some *other* namespace is a
+different command, `expr {Pi()}` cannot reach it, and the report stands.
 
-A name nothing in the workspace defines is still reported, so turning the
-setting on removes false alarms without hiding real ones.
+Off by default, opt in with `tclLsp.features.crossFileResolution`: every
+`proc` and class the **workspace** defines, whether or not anything links
+the two files. This one is a setting because a workspace is not always one
+program — two unrelated scripts in the same folder each have their own
+`helper`, and a call to the wrong one is a real error worth reporting.
+
+A name nothing in the workspace defines is still reported either way, so
+neither removes real alarms.
+
+## The quick fix and the report always agree
+
+The "did you mean …?" quick fix is offered only for a report you can
+actually see. If any of the rules above resolved the name, the report is
+gone and so is its quick fix — accepting one would otherwise rewrite
+working code (`expr {Pi()}` into `expr {ni()}`, which is not valid Tcl at
+all).
 
 ## What a `proc unknown` changes
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3541,7 +3541,7 @@
               "null"
             ],
             "default": null,
-            "description": "Resolve diagnostics across the whole workspace: suppress \"unknown command\" (W120/W123) for a proc defined in another file, and report wrong-argument-count errors (E002/E003) for cross-file calls. Off by default (scans every workspace file); set true to enable. Independent of XC Migration diagnostics below.",
+            "description": "Resolve diagnostics across the whole workspace: suppress \"unknown command\" (W120/W123) for a proc defined in another file, and report wrong-argument-count errors (E002/E003) for cross-file calls. Off by default (scans every workspace file); set true to enable. An expr math function the workspace injects into ::tcl::mathfunc resolves without this setting, since that namespace is one table per interpreter. Independent of XC Migration diagnostics below.",
             "order": 27
           }
         }

--- a/editors/vscode/src/test/issue923Callbacks.test.ts
+++ b/editors/vscode/src/test/issue923Callbacks.test.ts
@@ -1,0 +1,164 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Issue #923 differential audit, findings idx 92 and idx 48, through a real
+// VS Code session.  The analyser and native lsp_e2e suites carry the deep
+// TP/FP/TN matrices; these prove the same answers arrive over the client's own
+// providers, which is the tier both findings were missing.
+//
+// idx 92 — `trace add variable S(size) write [namespace code [list Tracer]]`,
+// the shape Tk's own library/fontchooser.tcl writes.  Oracle, tclsh 8.6.16 and
+// 9.0.4:
+//
+//     TRACED: ::demo::S size write
+//     info: {write {::namespace inscope ::demo Tracer}}
+//     final S(size)=99
+//
+// The handler really is dispatched through the wrapped `[list …]` prefix, and
+// `trace remove` with the identical wrapper really does detach it — so both
+// sites are genuine references to the proc.
+//
+// idx 48 — a query anchored on a bare declaring token.  Oracle, tclsh 8.6.16
+// and 9.0.4: `set y 10; puts $y; puts $y` prints `10` twice, and
+// `foreach cmd {alpha beta}` prints `cmd is alpha` / `cmd is beta`.
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { activate, getDocUri, pollUntil } from "./helper";
+
+/** Reference start lines for the symbol at (line, character). */
+async function referenceLines(uri: vscode.Uri, line: number, character: number): Promise<number[]> {
+  const locations = (await vscode.commands.executeCommand(
+    "vscode.executeReferenceProvider",
+    uri,
+    new vscode.Position(line, character),
+  )) as vscode.Location[] | undefined;
+  return (locations ?? [])
+    .filter((l) => l.uri.fsPath === uri.fsPath)
+    .map((l) => l.range.start.line)
+    .sort((a, b) => a - b);
+}
+
+/** The reference-count lens title anchored on `line`, once resolved. */
+async function lensTitleOnLine(uri: vscode.Uri, line: number): Promise<string | undefined> {
+  const lenses = (await pollUntil(
+    () => vscode.commands.executeCommand("vscode.executeCodeLensProvider", uri, 100),
+    (r) => {
+      const ls = r as vscode.CodeLens[] | undefined;
+      return (
+        !!ls &&
+        ls.some(
+          (l) => l.range.start.line === line && l.command && typeof l.command.title === "string",
+        )
+      );
+    },
+    { timeout: 15_000, label: `resolved lens on line ${line}` },
+  )) as vscode.CodeLens[];
+  return lenses.find((l) => l.range.start.line === line)?.command?.title;
+}
+
+suite("Issue #923 idx 92: namespace-code-wrapped trace callbacks", () => {
+  const docUri = getDocUri("issue923NamespaceCodeCallback.tcl");
+
+  test("both trace sites are references to the wrapped handler", async () => {
+    await activate(docUri);
+    // `proc Idx92Tracer` is declared on line 5; the `trace add` wrapper sits on
+    // line 11 and the `trace remove` wrapper on line 15.
+    const fromDecl = await referenceLines(docUri, 5, 12);
+    assert.ok(
+      fromDecl.includes(11) && fromDecl.includes(15),
+      `idx 92: both [namespace code [list …]] sites must be references, got [${fromDecl}]`,
+    );
+
+    // Symmetry: the same query from one of the call sites answers identically.
+    const fromCallSite = await referenceLines(docUri, 11, 65);
+    assert.deepStrictEqual(
+      fromCallSite,
+      fromDecl,
+      `idx 92: a call-site-anchored query must match the declaration-anchored one`,
+    );
+  });
+
+  test("the reference lens counts each wrapped callback exactly once", async () => {
+    await activate(docUri);
+    const title = await lensTitleOnLine(docUri, 5);
+    assert.strictEqual(
+      title,
+      "2 references",
+      `idx 92: the trace add + trace remove sites are two references, not more \
+(the braced-callback double-count guard) — got "${title}"`,
+    );
+  });
+
+  test("the wrapped handler is an incoming call from both enclosing procs", async () => {
+    await activate(docUri);
+    const items = (await vscode.commands.executeCommand(
+      "vscode.prepareCallHierarchy",
+      docUri,
+      new vscode.Position(5, 12),
+    )) as vscode.CallHierarchyItem[] | undefined;
+    assert.ok(items && items.length > 0, "idx 92: prepareCallHierarchy returned nothing");
+    const incoming = (await vscode.commands.executeCommand(
+      "vscode.provideIncomingCalls",
+      items[0],
+    )) as vscode.CallHierarchyIncomingCall[] | undefined;
+    const callers = (incoming ?? []).map((c) => c.from.name).sort();
+    assert.ok(
+      callers.some((n) => n.includes("Idx92Setup")) &&
+        callers.some((n) => n.includes("Idx92Done")),
+      `idx 92: both enclosing procs must show as callers, got [${callers}]`,
+    );
+  });
+});
+
+suite("Issue #923 idx 48: bare declaring tokens as query anchors", () => {
+  const docUri = getDocUri("issue923BareDeclaration.tcl");
+
+  test("a `set` left-hand side answers exactly as a `$name` read does", async () => {
+    await activate(docUri);
+    // `set idx48Total 10` on line 3; `$idx48Total` reads on lines 4 and 5.
+    const fromDecl = await referenceLines(docUri, 3, 4);
+    const fromRead = await referenceLines(docUri, 4, 6);
+    assert.deepStrictEqual(
+      fromDecl,
+      fromRead,
+      `idx 48: the declaring token must not answer less than a read does`,
+    );
+    assert.ok(
+      fromDecl.includes(3) && fromDecl.includes(4) && fromDecl.includes(5),
+      `idx 48: all three occurrences expected, got [${fromDecl}]`,
+    );
+  });
+
+  test("a `foreach` loop variable answers exactly as its body read does", async () => {
+    await activate(docUri);
+    // `foreach idx48Cmd {alpha beta} {` on line 6; `$idx48Cmd` on line 7.
+    const fromDecl = await referenceLines(docUri, 6, 8);
+    const fromRead = await referenceLines(docUri, 7, 20);
+    assert.deepStrictEqual(
+      fromDecl,
+      fromRead,
+      `idx 48: the loop variable's declaring token must not answer less than \
+its body read does`,
+    );
+    assert.ok(
+      fromDecl.includes(6) && fromDecl.includes(7),
+      `idx 48: declaration and body read expected, got [${fromDecl}]`,
+    );
+  });
+});

--- a/editors/vscode/src/test/issue923Callbacks.test.ts
+++ b/editors/vscode/src/test/issue923Callbacks.test.ts
@@ -119,8 +119,7 @@ suite("Issue #923 idx 92: namespace-code-wrapped trace callbacks", () => {
     )) as vscode.CallHierarchyIncomingCall[] | undefined;
     const callers = (incoming ?? []).map((c) => c.from.name).sort();
     assert.ok(
-      callers.some((n) => n.includes("Idx92Setup")) &&
-        callers.some((n) => n.includes("Idx92Done")),
+      callers.some((n) => n.includes("Idx92Setup")) && callers.some((n) => n.includes("Idx92Done")),
       `idx 92: both enclosing procs must show as callers, got [${callers}]`,
     );
   });

--- a/editors/vscode/src/test/issue923Callbacks.test.ts
+++ b/editors/vscode/src/test/issue923Callbacks.test.ts
@@ -25,8 +25,8 @@
 // the shape Tk's own library/fontchooser.tcl writes.  Oracle, tclsh 8.6.16 and
 // 9.0.4:
 //
-//     TRACED: ::demo::S size write
 //     info: {write {::namespace inscope ::demo Tracer}}
+//     TRACED: ::demo::S size write
 //     final S(size)=99
 //
 // The handler really is dispatched through the wrapped `[list …]` prefix, and

--- a/editors/vscode/testFixture/issue923BareDeclaration.tcl
+++ b/editors/vscode/testFixture/issue923BareDeclaration.tcl
@@ -1,0 +1,9 @@
+# Issue #923 idx 48 — a query anchored on a bare declaring token (a `set`
+# left-hand side, a `foreach` loop variable) must answer exactly as a query
+# anchored on a later `$name` read of the same cell.
+set idx48Total 10
+puts $idx48Total
+puts $idx48Total
+foreach idx48Cmd {alpha beta} {
+    puts "cmd is $idx48Cmd"
+}

--- a/editors/vscode/testFixture/issue923NamespaceCodeCallback.tcl
+++ b/editors/vscode/testFixture/issue923NamespaceCodeCallback.tcl
@@ -1,0 +1,18 @@
+# Issue #923 idx 92 — Tk's fontchooser.tcl idiom: a trace whose handler is
+# wrapped in `[namespace code [list Tracer]]`.  Verified against tclsh 8.6.16
+# and 9.0.4 (see issue923Callbacks.test.ts for the recorded oracle output).
+namespace eval idx92 {
+    variable S
+    proc Idx92Tracer {args} {
+        return $args
+    }
+    proc Idx92Setup {} {
+        variable S
+        set S(size) 12
+        trace add variable S(size) write [namespace code [list Idx92Tracer]]
+    }
+    proc Idx92Done {} {
+        variable S
+        trace remove variable S(size) write [namespace code [list Idx92Tracer]]
+    }
+}

--- a/rust/tcl-lsp-core/src/code_actions.rs
+++ b/rust/tcl-lsp-core/src/code_actions.rs
@@ -260,10 +260,10 @@ fn push_brace_expr_refactors(
     actions: &mut Vec<CodeAction>,
     source: &str,
     range: LspRange,
-    analysis: &AnalysisResult,
+    diagnostics: &[tcl_compiler::analyser::Diagnostic],
     line_index: &LineIndex,
 ) {
-    for diag in &analysis.diagnostics {
+    for diag in diagnostics {
         if diag.code != DiagCode::W100 {
             continue;
         }
@@ -300,13 +300,24 @@ fn push_brace_expr_refactors(
 /// already computed.  When `None`, returns an empty vector
 /// (preserves the stub call shape for callers that haven't
 /// yet plumbed analysis through).
+///
+/// `diagnostics` is the **published** diagnostic set — the one the host has
+/// decided this document actually shows, after whatever workspace refinement
+/// it applies (the LSP server's package / auto-load / cross-file W120 and W123
+/// passes).  It is a separate argument from `analysis` precisely because it is
+/// *not* `analysis.diagnostics`: reading the analyser's raw set here is what
+/// let the server offer a "did you mean 'ni'?" rewrite over a cross-file
+/// `Pi()` call whose diagnostic it had already suppressed (issue #923 idx 80).
+/// A host with no workspace knowledge passes `&analysis.diagnostics`, which is
+/// then the same set by definition.
 #[must_use]
 pub fn code_actions(
     source: &str,
     range: LspRange,
     analysis: Option<&AnalysisResult>,
+    diagnostics: &[tcl_compiler::analyser::Diagnostic],
 ) -> Vec<CodeAction> {
-    code_actions_in_program(source, range, analysis, None)
+    code_actions_in_program(source, range, analysis, diagnostics, None)
 }
 
 /// [`code_actions`] with the caller's whole-program export view attached —
@@ -317,11 +328,17 @@ pub fn code_actions(
 /// `namespace export` lives in another file decides whether inlining the
 /// local same-named proc is a refactor or a behaviour change (issue #1116
 /// item 1).
+///
+/// `diagnostics` carries the same published-set meaning as in [`code_actions`]:
+/// the two arguments answer different questions — `program` decides what a call
+/// *reaches*, `diagnostics` decides what the document is *showing* — so a host
+/// with a workspace index needs to supply both.
 #[must_use]
 pub fn code_actions_in_program(
     source: &str,
     range: LspRange,
     analysis: Option<&AnalysisResult>,
+    diagnostics: &[tcl_compiler::analyser::Diagnostic],
     program: Option<crate::definition::ProgramExports<'_>>,
 ) -> Vec<CodeAction> {
     let Some(analysis) = analysis else {
@@ -330,9 +347,9 @@ pub fn code_actions_in_program(
     let line_index = LineIndex::new(source);
     let mut actions = Vec::new();
 
-    push_brace_expr_refactors(&mut actions, source, range, analysis, &line_index);
+    push_brace_expr_refactors(&mut actions, source, range, diagnostics, &line_index);
 
-    for diag in &analysis.diagnostics {
+    for diag in diagnostics {
         let diag_start = line_index.position_at_utf16(diag.span.start(), source);
         let diag_end = line_index.position_at_utf16(diag.span.end(), source);
         let diag_range = LspRange {
@@ -2141,7 +2158,7 @@ mod tests {
 
     #[test]
     fn empty_actions_when_analysis_is_none() {
-        assert!(code_actions("set x 1\n", whole_document_range("set x 1\n"), None).is_empty());
+        assert!(code_actions("set x 1\n", whole_document_range("set x 1\n"), None, &[]).is_empty());
     }
 
     #[test]
@@ -2162,7 +2179,12 @@ mod tests {
                 safety: tcl_compiler::analyser::FixSafety::RequiresReview,
             }],
         });
-        let actions = code_actions("set x 1\n", whole_document_range("set x 1\n"), Some(&r));
+        let actions = code_actions(
+            "set x 1\n",
+            whole_document_range("set x 1\n"),
+            Some(&r),
+            &r.diagnostics,
+        );
         let qf: Vec<&CodeAction> = actions
             .iter()
             .filter(|a| a.kind == ActionKind::QuickFix)
@@ -2196,7 +2218,7 @@ mod tests {
             end_line: 99,
             end_character: 10,
         };
-        assert!(code_actions("set x 1\n", far_range, Some(&r)).is_empty());
+        assert!(code_actions("set x 1\n", far_range, Some(&r), &r.diagnostics).is_empty());
     }
 
     #[test]
@@ -2214,7 +2236,12 @@ mod tests {
                 safety: tcl_compiler::analyser::FixSafety::RequiresReview,
             }],
         });
-        let actions = code_actions("set x 1\n", whole_document_range("set x 1\n"), Some(&r));
+        let actions = code_actions(
+            "set x 1\n",
+            whole_document_range("set x 1\n"),
+            Some(&r),
+            &r.diagnostics,
+        );
         let qf: Vec<&CodeAction> = actions
             .iter()
             .filter(|a| a.kind == ActionKind::QuickFix)
@@ -2233,6 +2260,7 @@ mod tests {
             "set x 1\nputs $x\n",
             whole_document_range("set x 1\nputs $x\n"),
             Some(&analysis),
+            &analysis.diagnostics,
         );
         // No diagnostic fixes → no quick-fix actions (range-based refactors
         // like extract-proc may still be offered for the selection).
@@ -2265,7 +2293,12 @@ mod tests {
                 },
             ],
         });
-        let actions = code_actions("set x 1\n", whole_document_range("set x 1\n"), Some(&r));
+        let actions = code_actions(
+            "set x 1\n",
+            whole_document_range("set x 1\n"),
+            Some(&r),
+            &r.diagnostics,
+        );
         let titles: Vec<&str> = actions
             .iter()
             .filter(|a| a.kind == ActionKind::QuickFix)
@@ -2290,7 +2323,12 @@ mod tests {
     fn inline_outcome(src: &str, call_line: u32) -> Result<String, String> {
         let mut analyser = Analyser::new();
         let analysis = analyser.analyse(src, "tcl8.6").clone();
-        let actions = code_actions(src, line_range(call_line), Some(&analysis));
+        let actions = code_actions(
+            src,
+            line_range(call_line),
+            Some(&analysis),
+            &analysis.diagnostics,
+        );
         let action = actions
             .iter()
             .find(|a| a.title.starts_with("Inline proc "))
@@ -2345,7 +2383,12 @@ mod tests {
             "expected W213 from {:?}",
             analysis.diagnostics,
         );
-        let actions = code_actions(src, whole_document_range(src), Some(&analysis));
+        let actions = code_actions(
+            src,
+            whole_document_range(src),
+            Some(&analysis),
+            &analysis.diagnostics,
+        );
         let nocomplain = actions
             .iter()
             .find(|a| a.title == "Add '-nocomplain' to unset");
@@ -2368,7 +2411,12 @@ mod tests {
         let src = "proc foo {} { unset xs }\n";
         let mut a = Analyser::new();
         let analysis = a.analyse(src, "tcl8.6").clone();
-        let actions = code_actions(src, whole_document_range(src), Some(&analysis));
+        let actions = code_actions(
+            src,
+            whole_document_range(src),
+            Some(&analysis),
+            &analysis.diagnostics,
+        );
         let act = actions
             .iter()
             .find(|a| a.title == "Add '-nocomplain' to unset")
@@ -2428,10 +2476,15 @@ mod tests {
             "expected W302 from {:?}",
             analysis.diagnostics,
         );
-        code_actions(src, whole_document_range(src), Some(&analysis))
-            .into_iter()
-            .filter(|action| action.title.starts_with("Add catch"))
-            .collect()
+        code_actions(
+            src,
+            whole_document_range(src),
+            Some(&analysis),
+            &analysis.diagnostics,
+        )
+        .into_iter()
+        .filter(|action| action.title.starts_with("Add catch"))
+        .collect()
     }
 
     #[test]
@@ -2518,7 +2571,12 @@ mod tests {
             "expected W120 from {:?}",
             analysis.diagnostics,
         );
-        let actions = code_actions(src, whole_document_range(src), Some(&analysis));
+        let actions = code_actions(
+            src,
+            whole_document_range(src),
+            Some(&analysis),
+            &analysis.diagnostics,
+        );
         let add = actions
             .iter()
             .find(|a| a.title.starts_with("Add 'package require"));
@@ -2952,7 +3010,7 @@ mod tests {
             end_line: 0,
             end_character: 27,
         };
-        let actions = code_actions(src, range, Some(&analysis));
+        let actions = code_actions(src, range, Some(&analysis), &analysis.diagnostics);
         assert!(
             actions.iter().any(|a| {
                 a.kind == ActionKind::RefactorExtract && a.title.to_lowercase().contains("variable")
@@ -2974,7 +3032,7 @@ mod tests {
             end_line: 0,
             end_character: 16,
         };
-        let mut actions = code_actions(src, range, Some(&analysis));
+        let mut actions = code_actions(src, range, Some(&analysis), &analysis.diagnostics);
         assert!(
             actions
                 .iter()
@@ -3033,7 +3091,7 @@ mod tests {
             end_line: 0,
             end_character: 0,
         };
-        let actions = code_actions(src, cursor, Some(&analysis));
+        let actions = code_actions(src, cursor, Some(&analysis), &analysis.diagnostics);
         assert!(
             actions
                 .iter()
@@ -3059,7 +3117,7 @@ mod tests {
             end_line: 2,
             end_character: 8,
         };
-        let actions = code_actions(src, cursor, Some(&analysis));
+        let actions = code_actions(src, cursor, Some(&analysis), &analysis.diagnostics);
         assert!(
             actions
                 .iter()
@@ -3078,7 +3136,7 @@ mod tests {
             end_line: 0,
             end_character: 0,
         };
-        let actions = code_actions(src, cursor, Some(&analysis));
+        let actions = code_actions(src, cursor, Some(&analysis), &analysis.diagnostics);
         let dg = actions
             .iter()
             .find(|a| a.title.to_lowercase().contains("data-group"))

--- a/rust/tcl-lsp-core/tests/code_actions_depth.rs
+++ b/rust/tcl-lsp-core/tests/code_actions_depth.rs
@@ -269,12 +269,7 @@ fn invert_comparison_flips_equality_operator() {
     let src = "if {$a == $b} { puts hi }\n";
     let analysis = analyse(src);
     // `if {` is 4 chars; `$a == $b` spans cols 4..12.
-    let actions = code_actions(
-        src,
-        selection(0, 4, 12),
-        Some(&analysis),
-        &analysis.diagnostics,
-    );
+    let actions = code_actions(src, selection(0, 4, 12), Some(&analysis), &analysis.diagnostics);
     let inv = find(&actions, "Invert comparison").expect("an invert-comparison rewrite");
     assert_eq!(inv.kind, ActionKind::RefactorRewrite, "{inv:?}");
     assert_eq!(inv.edits.len(), 1);
@@ -299,12 +294,7 @@ fn invert_comparison_flips_relational_operator() {
     let src = "while {$a <= $b} { incr a }\n";
     let analysis = analyse(src);
     // `while {` is 7 chars; `$a <= $b` spans cols 7..15.
-    let actions = code_actions(
-        src,
-        selection(0, 7, 15),
-        Some(&analysis),
-        &analysis.diagnostics,
-    );
+    let actions = code_actions(src, selection(0, 7, 15), Some(&analysis), &analysis.diagnostics);
     let inv = find(&actions, "Invert comparison").expect("an invert-comparison rewrite");
     assert_eq!(
         inv.edits[0].new_text, "$a > $b",
@@ -324,12 +314,7 @@ fn invert_comparison_flips_tip461_string_ordering_operator() {
     let src = "if {$a lt $b} { puts hi }\n";
     let analysis = analyse(src);
     // `if {` is 4 chars; `$a lt $b` spans cols 4..12.
-    let actions = code_actions(
-        src,
-        selection(0, 4, 12),
-        Some(&analysis),
-        &analysis.diagnostics,
-    );
+    let actions = code_actions(src, selection(0, 4, 12), Some(&analysis), &analysis.diagnostics);
     let inv = find(&actions, "Invert comparison").expect("an invert-comparison rewrite");
     assert_eq!(
         inv.edits[0].new_text, "$a ge $b",
@@ -345,12 +330,7 @@ fn invert_comparison_absent_without_top_level_operator() {
     let src = "puts $value\n";
     let analysis = analyse(src);
     // Select `$value` (cols 5..11).
-    let actions = code_actions(
-        src,
-        selection(0, 5, 11),
-        Some(&analysis),
-        &analysis.diagnostics,
-    );
+    let actions = code_actions(src, selection(0, 5, 11), Some(&analysis), &analysis.diagnostics);
     assert!(
         find(&actions, "Invert comparison").is_none(),
         "no comparison operator -> no inversion; got {:?}",
@@ -382,12 +362,7 @@ fn demorgan_reverse_collapses_disjunction_of_negations() {
     let src = "if {!$a || !$b} { puts hi }\n";
     let analysis = analyse(src);
     // `if {` is 4 chars; `!$a || !$b` spans cols 4..14.
-    let actions = code_actions(
-        src,
-        selection(0, 4, 14),
-        Some(&analysis),
-        &analysis.diagnostics,
-    );
+    let actions = code_actions(src, selection(0, 4, 14), Some(&analysis), &analysis.diagnostics);
     let dm = find(&actions, "De Morgan").expect("a reverse-direction De Morgan rewrite");
     assert_eq!(dm.kind, ActionKind::RefactorRewrite);
     assert!(edits_well_formed(dm) && edits_in_bounds(dm, src), "{dm:?}");
@@ -414,12 +389,7 @@ fn demorgan_forward_recognises_irules_word_operators() {
     let src = "if {!($a and $b)} { puts hi }\n";
     let analysis = analyse_dialect(src, "f5-irules");
     // `if {` is 4 chars; `!($a and $b)` spans cols 4..16.
-    let actions = code_actions(
-        src,
-        selection(0, 4, 16),
-        Some(&analysis),
-        &analysis.diagnostics,
-    );
+    let actions = code_actions(src, selection(0, 4, 16), Some(&analysis), &analysis.diagnostics);
     let dm =
         find(&actions, "De Morgan").expect("a forward-direction word-operator De Morgan rewrite");
     assert_eq!(dm.kind, ActionKind::RefactorRewrite);
@@ -440,12 +410,7 @@ fn demorgan_reverse_recognises_irules_word_operators() {
     let src = "if {not $a or not $b} { puts hi }\n";
     let analysis = analyse_dialect(src, "f5-irules");
     // `if {` is 4 chars; `not $a or not $b` spans cols 4..20.
-    let actions = code_actions(
-        src,
-        selection(0, 4, 20),
-        Some(&analysis),
-        &analysis.diagnostics,
-    );
+    let actions = code_actions(src, selection(0, 4, 20), Some(&analysis), &analysis.diagnostics);
     let dm =
         find(&actions, "De Morgan").expect("a reverse-direction word-operator De Morgan rewrite");
     assert_eq!(
@@ -1046,12 +1011,7 @@ fn multi_action_position_offers_several_families() {
     let analysis = analyse(src);
     // Select the literal `192.168.0.1` (cols 7..18); the start cursor (col 7)
     // also sits on the literal for the IP refactor.
-    let actions = code_actions(
-        src,
-        selection(0, 7, 18),
-        Some(&analysis),
-        &analysis.diagnostics,
-    );
+    let actions = code_actions(src, selection(0, 7, 18), Some(&analysis), &analysis.diagnostics);
     let kinds: std::collections::BTreeSet<&str> = actions.iter().map(|a| a.kind.as_str()).collect();
     assert!(
         kinds.len() >= 2,
@@ -1081,12 +1041,7 @@ fn caller_only_filter_can_select_a_single_kind() {
     // invertible comparison selection.
     let src = "if {$a == $b} { puts hi }\n";
     let analysis = analyse(src);
-    let actions = code_actions(
-        src,
-        selection(0, 4, 12),
-        Some(&analysis),
-        &analysis.diagnostics,
-    );
+    let actions = code_actions(src, selection(0, 4, 12), Some(&analysis), &analysis.diagnostics);
     let only_rewrites: Vec<&CodeAction> = actions
         .iter()
         .filter(|a| a.kind == ActionKind::RefactorRewrite)
@@ -1114,12 +1069,7 @@ fn out_of_range_positions_never_panic() {
     let src = "set x 1\nputs $x\n";
     let analysis = analyse(src);
     // Cursor far past the last line.
-    let _ = code_actions(
-        src,
-        cursor(999, 999),
-        Some(&analysis),
-        &analysis.diagnostics,
-    );
+    let _ = code_actions(src, cursor(999, 999), Some(&analysis), &analysis.diagnostics);
     // A range straddling beyond the buffer.
     let _ = code_actions(
         src,

--- a/rust/tcl-lsp-core/tests/code_actions_depth.rs
+++ b/rust/tcl-lsp-core/tests/code_actions_depth.rs
@@ -201,7 +201,7 @@ fn w115_continued_comment_offers_per_line_conversion() {
     //   comment, so semantics are unchanged.
     let src = "# header part \\\nmore text\nset x 1\n";
     let analysis = analyse(src);
-    let actions = code_actions(src, cursor(0, 0), Some(&analysis));
+    let actions = code_actions(src, cursor(0, 0), Some(&analysis), &analysis.diagnostics);
     let conv = find(&actions, "per-line comments")
         .expect("a per-line-comment conversion on the continued comment");
     assert_eq!(conv.kind, ActionKind::QuickFix, "{conv:?}");
@@ -232,7 +232,7 @@ fn w115_no_conversion_on_plain_comment() {
     // offers no conversion. Negative control for the direct-shape gate.
     let src = "# just a comment\nset x 1\n";
     let analysis = analyse(src);
-    let actions = code_actions(src, cursor(0, 0), Some(&analysis));
+    let actions = code_actions(src, cursor(0, 0), Some(&analysis), &analysis.diagnostics);
     assert!(
         find(&actions, "per-line comments").is_none(),
         "plain comment must not offer the conversion; got {:?}",
@@ -247,7 +247,7 @@ fn w115_no_conversion_on_continued_code_line() {
     // the corruption the provider's own comment warns against.
     let src = "set x \\\n5\nputs $x\n";
     let analysis = analyse(src);
-    let actions = code_actions(src, cursor(0, 0), Some(&analysis));
+    let actions = code_actions(src, cursor(0, 0), Some(&analysis), &analysis.diagnostics);
     assert!(
         find(&actions, "per-line comments").is_none(),
         "continued code line must not be commented out; got {:?}",
@@ -269,7 +269,12 @@ fn invert_comparison_flips_equality_operator() {
     let src = "if {$a == $b} { puts hi }\n";
     let analysis = analyse(src);
     // `if {` is 4 chars; `$a == $b` spans cols 4..12.
-    let actions = code_actions(src, selection(0, 4, 12), Some(&analysis));
+    let actions = code_actions(
+        src,
+        selection(0, 4, 12),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     let inv = find(&actions, "Invert comparison").expect("an invert-comparison rewrite");
     assert_eq!(inv.kind, ActionKind::RefactorRewrite, "{inv:?}");
     assert_eq!(inv.edits.len(), 1);
@@ -294,7 +299,12 @@ fn invert_comparison_flips_relational_operator() {
     let src = "while {$a <= $b} { incr a }\n";
     let analysis = analyse(src);
     // `while {` is 7 chars; `$a <= $b` spans cols 7..15.
-    let actions = code_actions(src, selection(0, 7, 15), Some(&analysis));
+    let actions = code_actions(
+        src,
+        selection(0, 7, 15),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     let inv = find(&actions, "Invert comparison").expect("an invert-comparison rewrite");
     assert_eq!(
         inv.edits[0].new_text, "$a > $b",
@@ -314,7 +324,12 @@ fn invert_comparison_flips_tip461_string_ordering_operator() {
     let src = "if {$a lt $b} { puts hi }\n";
     let analysis = analyse(src);
     // `if {` is 4 chars; `$a lt $b` spans cols 4..12.
-    let actions = code_actions(src, selection(0, 4, 12), Some(&analysis));
+    let actions = code_actions(
+        src,
+        selection(0, 4, 12),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     let inv = find(&actions, "Invert comparison").expect("an invert-comparison rewrite");
     assert_eq!(
         inv.edits[0].new_text, "$a ge $b",
@@ -330,7 +345,12 @@ fn invert_comparison_absent_without_top_level_operator() {
     let src = "puts $value\n";
     let analysis = analyse(src);
     // Select `$value` (cols 5..11).
-    let actions = code_actions(src, selection(0, 5, 11), Some(&analysis));
+    let actions = code_actions(
+        src,
+        selection(0, 5, 11),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     assert!(
         find(&actions, "Invert comparison").is_none(),
         "no comparison operator -> no inversion; got {:?}",
@@ -344,7 +364,7 @@ fn invert_comparison_absent_on_empty_selection() {
     // cursor (start == end) offers neither De Morgan nor invert.
     let src = "if {$a == $b} { puts hi }\n";
     let analysis = analyse(src);
-    let actions = code_actions(src, cursor(0, 8), Some(&analysis));
+    let actions = code_actions(src, cursor(0, 8), Some(&analysis), &analysis.diagnostics);
     assert!(
         find(&actions, "Invert comparison").is_none() && find(&actions, "De Morgan").is_none(),
         "no expr rewrites without a selection; got {:?}",
@@ -362,7 +382,12 @@ fn demorgan_reverse_collapses_disjunction_of_negations() {
     let src = "if {!$a || !$b} { puts hi }\n";
     let analysis = analyse(src);
     // `if {` is 4 chars; `!$a || !$b` spans cols 4..14.
-    let actions = code_actions(src, selection(0, 4, 14), Some(&analysis));
+    let actions = code_actions(
+        src,
+        selection(0, 4, 14),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     let dm = find(&actions, "De Morgan").expect("a reverse-direction De Morgan rewrite");
     assert_eq!(dm.kind, ActionKind::RefactorRewrite);
     assert!(edits_well_formed(dm) && edits_in_bounds(dm, src), "{dm:?}");
@@ -389,7 +414,12 @@ fn demorgan_forward_recognises_irules_word_operators() {
     let src = "if {!($a and $b)} { puts hi }\n";
     let analysis = analyse_dialect(src, "f5-irules");
     // `if {` is 4 chars; `!($a and $b)` spans cols 4..16.
-    let actions = code_actions(src, selection(0, 4, 16), Some(&analysis));
+    let actions = code_actions(
+        src,
+        selection(0, 4, 16),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     let dm =
         find(&actions, "De Morgan").expect("a forward-direction word-operator De Morgan rewrite");
     assert_eq!(dm.kind, ActionKind::RefactorRewrite);
@@ -410,7 +440,12 @@ fn demorgan_reverse_recognises_irules_word_operators() {
     let src = "if {not $a or not $b} { puts hi }\n";
     let analysis = analyse_dialect(src, "f5-irules");
     // `if {` is 4 chars; `not $a or not $b` spans cols 4..20.
-    let actions = code_actions(src, selection(0, 4, 20), Some(&analysis));
+    let actions = code_actions(
+        src,
+        selection(0, 4, 20),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     let dm =
         find(&actions, "De Morgan").expect("a reverse-direction word-operator De Morgan rewrite");
     assert_eq!(
@@ -435,7 +470,7 @@ fn ipv6_mapped_literal_offers_ipv4_conversion() {
     let src = "set ip ::ffff:10.0.0.1\n";
     let analysis = analyse(src);
     // Cursor inside the literal (after `set ip `, col ~12).
-    let actions = code_actions(src, cursor(0, 12), Some(&analysis));
+    let actions = code_actions(src, cursor(0, 12), Some(&analysis), &analysis.diagnostics);
     let conv = find(&actions, "IPv4 address").expect("an IPv6-mapped -> IPv4 refactor");
     assert_eq!(conv.kind, ActionKind::Refactor);
     assert_eq!(conv.edits.len(), 1);
@@ -456,7 +491,7 @@ fn ipv6_mapped_with_cidr_preserves_suffix() {
     // -> `10.0.0.0/24`.
     let src = "set net ::ffff:10.0.0.0/24\n";
     let analysis = analyse(src);
-    let actions = code_actions(src, cursor(0, 14), Some(&analysis));
+    let actions = code_actions(src, cursor(0, 14), Some(&analysis), &analysis.diagnostics);
     let conv = find(&actions, "IPv4 address").expect("a mapped -> v4 conversion");
     assert_eq!(
         conv.edits[0].new_text, "10.0.0.0/24",
@@ -471,7 +506,7 @@ fn ip_conversion_absent_on_non_ip_word() {
     // offers no IP conversion. (`set` itself is hex-free word text.)
     let src = "set greeting hello\n";
     let analysis = analyse(src);
-    let actions = code_actions(src, cursor(0, 14), Some(&analysis));
+    let actions = code_actions(src, cursor(0, 14), Some(&analysis), &analysis.diagnostics);
     assert!(
         find(&actions, "IPv4 address").is_none() && find(&actions, "IPv6-mapped").is_none(),
         "no IP literal at cursor -> no conversion; got {:?}",
@@ -493,7 +528,7 @@ fn inline_single_command_proc_substitutes_args() {
     //   inlined `puts bob` prints `bob` too (verified 8.6 + 9.0).
     let src = "proc greet {who} { puts $who }\ngreet bob\n";
     let analysis = analyse(src);
-    let actions = code_actions(src, cursor(1, 0), Some(&analysis));
+    let actions = code_actions(src, cursor(1, 0), Some(&analysis), &analysis.diagnostics);
     let inline = find(&actions, "Inline proc").expect("an inline-proc action at the call");
     assert_eq!(inline.kind, ActionKind::RefactorInline, "{inline:?}");
     assert_eq!(inline.edits.len(), 1);
@@ -517,7 +552,7 @@ fn inline_declines_control_flow_body() {
     // tell "cannot be done here" from "is broken".
     let src = "proc f {} { return 1 }\nf\n";
     let analysis = analyse(src);
-    let actions = code_actions(src, cursor(1, 0), Some(&analysis));
+    let actions = code_actions(src, cursor(1, 0), Some(&analysis), &analysis.diagnostics);
     let inline = find(&actions, "Inline proc").expect("a refused inline action");
     let reason = inline
         .disabled
@@ -533,7 +568,7 @@ fn inline_declines_multi_command_body() {
     // commands into one caller word changes how the caller parses.
     let src = "proc f {x} {\n    set y $x\n    puts $y\n}\nf 1\n";
     let analysis = analyse(src);
-    let actions = code_actions(src, cursor(4, 0), Some(&analysis));
+    let actions = code_actions(src, cursor(4, 0), Some(&analysis), &analysis.diagnostics);
     let inline = find(&actions, "Inline proc").expect("a refused inline action");
     let reason = inline
         .disabled
@@ -557,7 +592,7 @@ fn inline_declines_multi_command_body() {
 fn inline_braced_expr_body_keeps_closing_brace() {
     let src = "proc double {n} { expr {$n * 2} }\ndouble 5\n";
     let analysis = analyse(src);
-    let actions = code_actions(src, cursor(1, 0), Some(&analysis));
+    let actions = code_actions(src, cursor(1, 0), Some(&analysis), &analysis.diagnostics);
     let inline = find(&actions, "Inline proc").expect("an inline-proc action");
     assert_eq!(
         inline.edits[0].new_text, "expr {5 * 2}",
@@ -588,7 +623,7 @@ fn switch_to_dict_offered_for_uniform_assignment_switch() {
         "}\n",
     );
     let analysis = analyse(src);
-    let actions = code_actions(src, cursor(0, 0), Some(&analysis));
+    let actions = code_actions(src, cursor(0, 0), Some(&analysis), &analysis.diagnostics);
     let dict = find(&actions, "dict").expect("a switch->dict conversion at the switch cursor");
     assert!(
         dict.title.to_lowercase().contains("dict"),
@@ -611,7 +646,7 @@ fn switch_to_dict_absent_at_inert_cursor() {
     // offered (the refactor self-gates on `find_command_at(.., "switch")`).
     let src = "set x 1\nputs $x\n";
     let analysis = analyse(src);
-    let actions = code_actions(src, cursor(0, 4), Some(&analysis));
+    let actions = code_actions(src, cursor(0, 4), Some(&analysis), &analysis.diagnostics);
     assert!(
         find(&actions, "dict").is_none(),
         "no switch at cursor -> no dict conversion; got {:?}",
@@ -1011,7 +1046,12 @@ fn multi_action_position_offers_several_families() {
     let analysis = analyse(src);
     // Select the literal `192.168.0.1` (cols 7..18); the start cursor (col 7)
     // also sits on the literal for the IP refactor.
-    let actions = code_actions(src, selection(0, 7, 18), Some(&analysis));
+    let actions = code_actions(
+        src,
+        selection(0, 7, 18),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     let kinds: std::collections::BTreeSet<&str> = actions.iter().map(|a| a.kind.as_str()).collect();
     assert!(
         kinds.len() >= 2,
@@ -1041,7 +1081,12 @@ fn caller_only_filter_can_select_a_single_kind() {
     // invertible comparison selection.
     let src = "if {$a == $b} { puts hi }\n";
     let analysis = analyse(src);
-    let actions = code_actions(src, selection(0, 4, 12), Some(&analysis));
+    let actions = code_actions(
+        src,
+        selection(0, 4, 12),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     let only_rewrites: Vec<&CodeAction> = actions
         .iter()
         .filter(|a| a.kind == ActionKind::RefactorRewrite)
@@ -1069,7 +1114,12 @@ fn out_of_range_positions_never_panic() {
     let src = "set x 1\nputs $x\n";
     let analysis = analyse(src);
     // Cursor far past the last line.
-    let _ = code_actions(src, cursor(999, 999), Some(&analysis));
+    let _ = code_actions(
+        src,
+        cursor(999, 999),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     // A range straddling beyond the buffer.
     let _ = code_actions(
         src,
@@ -1080,9 +1130,10 @@ fn out_of_range_positions_never_panic() {
             end_character: 50,
         },
         Some(&analysis),
+        &analysis.diagnostics,
     );
     // Column far past the line end on a valid line.
-    let _ = code_actions(src, cursor(0, 9999), Some(&analysis));
+    let _ = code_actions(src, cursor(0, 9999), Some(&analysis), &analysis.diagnostics);
     // The package-suggestion and context entry points must also be panic-safe.
     let reg = tcl_registry::CommandRegistry::build_default();
     let _ = tcl_lsp_core::code_actions::package_require_actions(
@@ -1108,14 +1159,14 @@ fn empty_and_whitespace_documents_never_panic() {
     // offer nothing.
     for src in ["", "   ", "\n", "   \n\t\n", "\n\n\n"] {
         let analysis = analyse(src);
-        let actions = code_actions(src, cursor(0, 0), Some(&analysis));
+        let actions = code_actions(src, cursor(0, 0), Some(&analysis), &analysis.diagnostics);
         assert!(
             actions.is_empty(),
             "empty/whitespace doc {src:?} should offer nothing; got {:?}",
             titles(&actions),
         );
         // Whole-document range too.
-        let actions = code_actions(src, whole(src), Some(&analysis));
+        let actions = code_actions(src, whole(src), Some(&analysis), &analysis.diagnostics);
         assert!(actions.is_empty(), "{src:?} -> {:?}", titles(&actions));
     }
 }
@@ -1126,7 +1177,7 @@ fn inert_statement_offers_nothing() {
     // quick-fix and no range refactor (broad negative control).
     let src = "set x 1\n";
     let analysis = analyse(src);
-    let actions = code_actions(src, cursor(0, 4), Some(&analysis));
+    let actions = code_actions(src, cursor(0, 4), Some(&analysis), &analysis.diagnostics);
     assert!(
         actions.is_empty(),
         "inert position should offer nothing; got {:?}",
@@ -1147,7 +1198,7 @@ fn every_emitted_action_is_structurally_sound() {
         "greet bob\n",
     );
     let analysis = analyse(src);
-    let actions = code_actions(src, whole(src), Some(&analysis));
+    let actions = code_actions(src, whole(src), Some(&analysis), &analysis.diagnostics);
     assert!(
         !actions.is_empty(),
         "expected at least one action over the document",

--- a/rust/tcl-lsp-core/tests/code_actions_depth.rs
+++ b/rust/tcl-lsp-core/tests/code_actions_depth.rs
@@ -269,7 +269,12 @@ fn invert_comparison_flips_equality_operator() {
     let src = "if {$a == $b} { puts hi }\n";
     let analysis = analyse(src);
     // `if {` is 4 chars; `$a == $b` spans cols 4..12.
-    let actions = code_actions(src, selection(0, 4, 12), Some(&analysis), &analysis.diagnostics);
+    let actions = code_actions(
+        src,
+        selection(0, 4, 12),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     let inv = find(&actions, "Invert comparison").expect("an invert-comparison rewrite");
     assert_eq!(inv.kind, ActionKind::RefactorRewrite, "{inv:?}");
     assert_eq!(inv.edits.len(), 1);
@@ -294,7 +299,12 @@ fn invert_comparison_flips_relational_operator() {
     let src = "while {$a <= $b} { incr a }\n";
     let analysis = analyse(src);
     // `while {` is 7 chars; `$a <= $b` spans cols 7..15.
-    let actions = code_actions(src, selection(0, 7, 15), Some(&analysis), &analysis.diagnostics);
+    let actions = code_actions(
+        src,
+        selection(0, 7, 15),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     let inv = find(&actions, "Invert comparison").expect("an invert-comparison rewrite");
     assert_eq!(
         inv.edits[0].new_text, "$a > $b",
@@ -314,7 +324,12 @@ fn invert_comparison_flips_tip461_string_ordering_operator() {
     let src = "if {$a lt $b} { puts hi }\n";
     let analysis = analyse(src);
     // `if {` is 4 chars; `$a lt $b` spans cols 4..12.
-    let actions = code_actions(src, selection(0, 4, 12), Some(&analysis), &analysis.diagnostics);
+    let actions = code_actions(
+        src,
+        selection(0, 4, 12),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     let inv = find(&actions, "Invert comparison").expect("an invert-comparison rewrite");
     assert_eq!(
         inv.edits[0].new_text, "$a ge $b",
@@ -330,7 +345,12 @@ fn invert_comparison_absent_without_top_level_operator() {
     let src = "puts $value\n";
     let analysis = analyse(src);
     // Select `$value` (cols 5..11).
-    let actions = code_actions(src, selection(0, 5, 11), Some(&analysis), &analysis.diagnostics);
+    let actions = code_actions(
+        src,
+        selection(0, 5, 11),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     assert!(
         find(&actions, "Invert comparison").is_none(),
         "no comparison operator -> no inversion; got {:?}",
@@ -362,7 +382,12 @@ fn demorgan_reverse_collapses_disjunction_of_negations() {
     let src = "if {!$a || !$b} { puts hi }\n";
     let analysis = analyse(src);
     // `if {` is 4 chars; `!$a || !$b` spans cols 4..14.
-    let actions = code_actions(src, selection(0, 4, 14), Some(&analysis), &analysis.diagnostics);
+    let actions = code_actions(
+        src,
+        selection(0, 4, 14),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     let dm = find(&actions, "De Morgan").expect("a reverse-direction De Morgan rewrite");
     assert_eq!(dm.kind, ActionKind::RefactorRewrite);
     assert!(edits_well_formed(dm) && edits_in_bounds(dm, src), "{dm:?}");
@@ -389,7 +414,12 @@ fn demorgan_forward_recognises_irules_word_operators() {
     let src = "if {!($a and $b)} { puts hi }\n";
     let analysis = analyse_dialect(src, "f5-irules");
     // `if {` is 4 chars; `!($a and $b)` spans cols 4..16.
-    let actions = code_actions(src, selection(0, 4, 16), Some(&analysis), &analysis.diagnostics);
+    let actions = code_actions(
+        src,
+        selection(0, 4, 16),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     let dm =
         find(&actions, "De Morgan").expect("a forward-direction word-operator De Morgan rewrite");
     assert_eq!(dm.kind, ActionKind::RefactorRewrite);
@@ -410,7 +440,12 @@ fn demorgan_reverse_recognises_irules_word_operators() {
     let src = "if {not $a or not $b} { puts hi }\n";
     let analysis = analyse_dialect(src, "f5-irules");
     // `if {` is 4 chars; `not $a or not $b` spans cols 4..20.
-    let actions = code_actions(src, selection(0, 4, 20), Some(&analysis), &analysis.diagnostics);
+    let actions = code_actions(
+        src,
+        selection(0, 4, 20),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     let dm =
         find(&actions, "De Morgan").expect("a reverse-direction word-operator De Morgan rewrite");
     assert_eq!(
@@ -1011,7 +1046,12 @@ fn multi_action_position_offers_several_families() {
     let analysis = analyse(src);
     // Select the literal `192.168.0.1` (cols 7..18); the start cursor (col 7)
     // also sits on the literal for the IP refactor.
-    let actions = code_actions(src, selection(0, 7, 18), Some(&analysis), &analysis.diagnostics);
+    let actions = code_actions(
+        src,
+        selection(0, 7, 18),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     let kinds: std::collections::BTreeSet<&str> = actions.iter().map(|a| a.kind.as_str()).collect();
     assert!(
         kinds.len() >= 2,
@@ -1041,7 +1081,12 @@ fn caller_only_filter_can_select_a_single_kind() {
     // invertible comparison selection.
     let src = "if {$a == $b} { puts hi }\n";
     let analysis = analyse(src);
-    let actions = code_actions(src, selection(0, 4, 12), Some(&analysis), &analysis.diagnostics);
+    let actions = code_actions(
+        src,
+        selection(0, 4, 12),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     let only_rewrites: Vec<&CodeAction> = actions
         .iter()
         .filter(|a| a.kind == ActionKind::RefactorRewrite)
@@ -1069,7 +1114,12 @@ fn out_of_range_positions_never_panic() {
     let src = "set x 1\nputs $x\n";
     let analysis = analyse(src);
     // Cursor far past the last line.
-    let _ = code_actions(src, cursor(999, 999), Some(&analysis), &analysis.diagnostics);
+    let _ = code_actions(
+        src,
+        cursor(999, 999),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     // A range straddling beyond the buffer.
     let _ = code_actions(
         src,

--- a/rust/tcl-lsp-core/tests/command_prefix_integration.rs
+++ b/rust/tcl-lsp-core/tests/command_prefix_integration.rs
@@ -639,3 +639,99 @@ fn struct_tree_walkproc_trailing_prefix_is_recorded() {
         "`myT walkproc … onN` must form a build→onN call-graph edge; got {g}"
     );
 }
+
+/// Issue #923 differential audit, finding idx 47 — the `trace` idiom Tk's own
+/// `etrace.tcl` writes verbatim: `trace add variable V write [list handler
+/// baked…]`.  The general `[list HEAD …]` mechanism is covered above via
+/// `lsort -command`; this pins the trace-specific spelling, whose head sits in
+/// a `write`-op argument rather than an option value, so a future narrowing of
+/// `extract_list_quoted_prefix_head` back to the option-value shape fails here.
+///
+/// Oracle — tclsh 8.6.16 and 9.0.4, writing the traced variable:
+///
+/// ```text
+/// initial: 1
+/// onVersionWrite fired: minlevel=1.0.0 baseline=1 args=::demo::version {} write
+/// final: 42
+/// ```
+///
+/// The handler really is invoked, solely through the trace's `[list …]`
+/// command prefix, so the site is a real reference to it.
+#[test]
+fn trace_add_variable_write_list_prefix_is_a_reference() {
+    let src = "namespace eval demo {\n\
+               \x20   variable version 1\n\
+               \x20   proc onVersionWrite {minlevel baseline args} { return $args }\n\
+               \x20   trace add variable version write [list demo::onVersionWrite 1.0.0 $version]\n\
+               }\n";
+    let mut a = tcl_compiler::analyser::Analyser::new();
+    let r = a.analyse(src, "tcl9.0");
+
+    let inv = r
+        .command_invocations
+        .iter()
+        .find(|i| i.name.ends_with("onVersionWrite") && i.callback_arity.is_some())
+        .unwrap_or_else(|| {
+            panic!(
+                "the trace's [list …] handler must be recorded as a command-prefix \
+                 invocation; got {:?}",
+                r.command_invocations
+                    .iter()
+                    .map(|i| i.name.as_str())
+                    .collect::<Vec<_>>()
+            )
+        });
+    assert_eq!(
+        inv.callback_baked_args, 2,
+        "`1.0.0` and `$version` are baked before Tcl appends name/index/op"
+    );
+    let head_text = &src[inv.range.start() as usize..inv.range.end() as usize];
+    assert_eq!(
+        head_text, "demo::onVersionWrite",
+        "the recorded span must cover exactly the written head word"
+    );
+
+    // The reference surfaces every command_invocations-fed consumer reads:
+    // find-references anchored at the declaration must reach the trace site.
+    let decl_line = 2;
+    let refs = tcl_lsp_core::references::references(src, "tcl9.0", decl_line, 9, &r, true);
+    assert!(
+        refs.iter().any(|rg| rg.start_line == 3),
+        "find-references from the proc declaration must include the \
+         `trace add variable … write [list …]` call site on line 3; got {refs:?}"
+    );
+
+    // …and the call graph carries the edge, attributed to the enclosing scope.
+    let reg = CommandRegistry::build_default();
+    let g = graphs::call_graph(src, &reg, "tcl9.0");
+    assert!(
+        g["edges"]
+            .as_array()
+            .expect("edges array")
+            .iter()
+            .any(|e| e["callee"]
+                .as_str()
+                .unwrap_or("")
+                .contains("onVersionWrite")),
+        "the trace handler must be a call-graph callee; got {g}"
+    );
+}
+
+/// FP guard for the same shape: a *dynamic* head inside the trace's
+/// `[list …]` names no static command and must stay unrecorded, so the
+/// trace-specific path inherits the general mechanism's discipline rather
+/// than relaxing it.
+#[test]
+fn trace_add_variable_write_list_prefix_with_a_dynamic_head_is_not_recorded() {
+    let mut a = tcl_compiler::analyser::Analyser::new();
+    let r = a.analyse(
+        "proc arm {cb} {\n    variable v\n    trace add variable v write [list $cb 1]\n}\n",
+        "tcl9.0",
+    );
+    assert!(
+        !r.command_invocations
+            .iter()
+            .any(|i| i.callback_arity.is_some()),
+        "a `[list $cb …]` trace handler is a runtime value, not a static reference"
+    );
+}

--- a/rust/tcl-lsp-core/tests/docstring.rs
+++ b/rust/tcl-lsp-core/tests/docstring.rs
@@ -418,6 +418,7 @@ fn generate_stub_text(source: &str, proc_name: &str) -> Option<String> {
         source,
         cursor(u32::try_from(line).unwrap(), 0),
         Some(&analysis),
+        &analysis.diagnostics,
     );
     find(&actions, &format!("Generate docstring for '{proc_name}'"))
         .map(|a| a.edits[0].new_text.clone())
@@ -456,7 +457,7 @@ fn generate_stub_action_is_source_kind() {
     // editor-level producer, not a quick-fix).
     let src = "proc greet {name} { puts $name }\n";
     let analysis = analyse(src);
-    let actions = code_actions(src, cursor(0, 0), Some(&analysis));
+    let actions = code_actions(src, cursor(0, 0), Some(&analysis), &analysis.diagnostics);
     let act = find(&actions, "Generate docstring for 'greet'").expect("generate action");
     assert_eq!(act.kind, ActionKind::Source, "{act:?}");
 }
@@ -527,7 +528,7 @@ fn generate_stub_skipped_for_documented_proc() {
     let src = "# Existing doc\nproc foo {} { puts hi }\n";
     let analysis = analyse(src);
     // Cursor on the proc declaration line (line 1).
-    let actions = code_actions(src, cursor(1, 0), Some(&analysis));
+    let actions = code_actions(src, cursor(1, 0), Some(&analysis), &analysis.diagnostics);
     assert!(
         find(&actions, "Generate docstring for 'foo'").is_none(),
         "documented proc must not be offered a stub; got titles {:?}",
@@ -542,7 +543,7 @@ fn generate_stub_offered_for_undocumented_proc() {
     // documented/undocumented partition of `insert_docstring_stubs`.
     let src = "proc bar {} { puts bye }\n";
     let analysis = analyse(src);
-    let actions = code_actions(src, cursor(0, 0), Some(&analysis));
+    let actions = code_actions(src, cursor(0, 0), Some(&analysis), &analysis.diagnostics);
     assert!(
         find(&actions, "Generate docstring for 'bar'").is_some(),
         "undocumented proc should be offered a stub; got titles {:?}",
@@ -557,13 +558,13 @@ fn generate_stub_multiple_procs_each_offered_on_their_line() {
     // per-cursor-line, so each proc is offered a stub on its own line.)
     let src = "proc foo {} { puts hi }\nproc bar {} { puts bye }\n";
     let analysis = analyse(src);
-    let foo = code_actions(src, cursor(0, 0), Some(&analysis));
+    let foo = code_actions(src, cursor(0, 0), Some(&analysis), &analysis.diagnostics);
     assert!(
         find(&foo, "Generate docstring for 'foo'").is_some(),
         "foo offered on its line: {:?}",
         foo.iter().map(|a| &a.title).collect::<Vec<_>>(),
     );
-    let bar = code_actions(src, cursor(1, 0), Some(&analysis));
+    let bar = code_actions(src, cursor(1, 0), Some(&analysis), &analysis.diagnostics);
     assert!(
         find(&bar, "Generate docstring for 'bar'").is_some(),
         "bar offered on its line: {:?}",
@@ -580,7 +581,7 @@ fn generate_stub_absent_when_cursor_off_declaration_line() {
     let src = "set marker 1\nproc qux {z} { puts $z }\n";
     let analysis = analyse(src);
     // Cursor on line 0 (the `set marker` line), NOT the proc line.
-    let actions = code_actions(src, cursor(0, 0), Some(&analysis));
+    let actions = code_actions(src, cursor(0, 0), Some(&analysis), &analysis.diagnostics);
     assert!(
         find(&actions, "Generate docstring for 'qux'").is_none(),
         "off-declaration-line cursor must not offer the stub; got {:?}",

--- a/rust/tcl-lsp-core/tests/force_import_shadow_consumers.rs
+++ b/rust/tcl-lsp-core/tests/force_import_shadow_consumers.rs
@@ -324,6 +324,7 @@ fn code_actions_offer_the_reached_body_for_inlining() {
             MAIN,
             cursor,
             Some(analysis),
+            &analysis.diagnostics,
             Some(program(exports)),
         )
         .into_iter()
@@ -461,14 +462,25 @@ fn the_legacy_entry_points_still_equal_the_document_only_program_view() {
         end_character: 0,
     };
     assert_eq!(
-        tcl_lsp_core::code_actions::code_actions(MAIN, cursor, Some(&analysis))
-            .into_iter()
-            .map(|a| a.title)
-            .collect::<Vec<_>>(),
-        tcl_lsp_core::code_actions::code_actions_in_program(MAIN, cursor, Some(&analysis), None)
-            .into_iter()
-            .map(|a| a.title)
-            .collect::<Vec<_>>(),
+        tcl_lsp_core::code_actions::code_actions(
+            MAIN,
+            cursor,
+            Some(&analysis),
+            &analysis.diagnostics
+        )
+        .into_iter()
+        .map(|a| a.title)
+        .collect::<Vec<_>>(),
+        tcl_lsp_core::code_actions::code_actions_in_program(
+            MAIN,
+            cursor,
+            Some(&analysis),
+            &analysis.diagnostics,
+            None
+        )
+        .into_iter()
+        .map(|a| a.title)
+        .collect::<Vec<_>>(),
         "code_actions delegation changed nothing"
     );
 }

--- a/rust/tcl-lsp-core/tests/lsp_lens_links_symbols.rs
+++ b/rust/tcl-lsp-core/tests/lsp_lens_links_symbols.rs
@@ -791,12 +791,7 @@ fn actions_catch_without_result_var_offers_capture_fixes() {
         .lines()
         .nth(1)
         .map_or(0, |l| u32::try_from(l.len()).unwrap_or(0));
-    let actions = code_actions(
-        src,
-        selection(1, 0, line2_len),
-        Some(&analysis),
-        &analysis.diagnostics,
-    );
+    let actions = code_actions(src, selection(1, 0, line2_len), Some(&analysis), &analysis.diagnostics);
     let titles: Vec<&str> = actions.iter().map(|a| a.title.as_str()).collect();
     assert!(
         titles.iter().any(|t| t.contains("catch result")),

--- a/rust/tcl-lsp-core/tests/lsp_lens_links_symbols.rs
+++ b/rust/tcl-lsp-core/tests/lsp_lens_links_symbols.rs
@@ -791,7 +791,12 @@ fn actions_catch_without_result_var_offers_capture_fixes() {
         .lines()
         .nth(1)
         .map_or(0, |l| u32::try_from(l.len()).unwrap_or(0));
-    let actions = code_actions(src, selection(1, 0, line2_len), Some(&analysis), &analysis.diagnostics);
+    let actions = code_actions(
+        src,
+        selection(1, 0, line2_len),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     let titles: Vec<&str> = actions.iter().map(|a| a.title.as_str()).collect();
     assert!(
         titles.iter().any(|t| t.contains("catch result")),

--- a/rust/tcl-lsp-core/tests/lsp_lens_links_symbols.rs
+++ b/rust/tcl-lsp-core/tests/lsp_lens_links_symbols.rs
@@ -743,7 +743,7 @@ fn edits_well_formed(action: &CodeAction) -> bool {
 #[test]
 fn actions_none_without_analysis() {
     // `analysis = None` -> the diagnostic-driven path produces nothing.
-    let actions = code_actions("proc f {} { return }\n", cursor(0, 0), None);
+    let actions = code_actions("proc f {} { return }\n", cursor(0, 0), None, &[]);
     assert!(actions.is_empty(), "{actions:?}");
 }
 
@@ -753,7 +753,7 @@ fn actions_none_at_inert_position() {
     // quick-fix and no range refactor.
     let src = "set x 1\n";
     let analysis = analyse(src);
-    let actions = code_actions(src, cursor(0, 4), Some(&analysis));
+    let actions = code_actions(src, cursor(0, 4), Some(&analysis), &analysis.diagnostics);
     assert!(
         actions.is_empty(),
         "inert position should offer nothing; got {actions:?}"
@@ -791,7 +791,12 @@ fn actions_catch_without_result_var_offers_capture_fixes() {
         .lines()
         .nth(1)
         .map_or(0, |l| u32::try_from(l.len()).unwrap_or(0));
-    let actions = code_actions(src, selection(1, 0, line2_len), Some(&analysis));
+    let actions = code_actions(
+        src,
+        selection(1, 0, line2_len),
+        Some(&analysis),
+        &analysis.diagnostics,
+    );
     let titles: Vec<&str> = actions.iter().map(|a| a.title.as_str()).collect();
     assert!(
         titles.iter().any(|t| t.contains("catch result")),
@@ -860,7 +865,7 @@ fn actions_extract_proc_on_selection_is_well_formed() {
         end_line: 3,
         end_character: 0,
     };
-    let actions = code_actions(src, sel, Some(&analysis));
+    let actions = code_actions(src, sel, Some(&analysis), &analysis.diagnostics);
     // Select by *title*: extract-variable shares the `refactor.extract` kind,
     // so a kind-only lookup picks whichever the provider happens to emit first.
     let extract = actions
@@ -897,7 +902,7 @@ fn actions_ipv4_literal_offers_ipv6_mapped_conversion() {
     let src = "set ip 192.168.0.1\n";
     let analysis = analyse(src);
     // Cursor inside the IPv4 literal (after `set ip `, col ~9).
-    let actions = code_actions(src, cursor(0, 9), Some(&analysis));
+    let actions = code_actions(src, cursor(0, 9), Some(&analysis), &analysis.diagnostics);
     let conv = actions
         .iter()
         .find(|a| a.title.contains("IPv6-mapped"))
@@ -921,7 +926,7 @@ fn actions_demorgan_rewrite_on_expression_selection() {
     // Select the `!($a && $b)` substring. `if {` is 4 chars; the expr starts
     // at col 4 and is 11 chars long.
     let sel = selection(0, 4, 4 + 11);
-    let actions = code_actions(src, sel, Some(&analysis));
+    let actions = code_actions(src, sel, Some(&analysis), &analysis.diagnostics);
     let dm = actions
         .iter()
         .find(|a| a.title.contains("De Morgan"))
@@ -944,7 +949,7 @@ fn actions_generate_docstring_for_undocumented_proc() {
     // real parameters as `@param` lines.
     let src = "proc greet {name greeting} {\n    return \"$greeting $name\"\n}\n";
     let analysis = analyse(src);
-    let actions = code_actions(src, cursor(0, 6), Some(&analysis));
+    let actions = code_actions(src, cursor(0, 6), Some(&analysis), &analysis.diagnostics);
     let doc = actions
         .iter()
         .find(|a| a.title.contains("Generate docstring"))
@@ -976,7 +981,7 @@ fn actions_edits_are_always_well_formed() {
         end_line: 3,
         end_character: 0,
     };
-    let actions = code_actions(src, whole, Some(&analysis));
+    let actions = code_actions(src, whole, Some(&analysis), &analysis.diagnostics);
     assert!(
         !actions.is_empty(),
         "expected at least one action over the document"

--- a/rust/tcl-lsp-core/tests/lsp_providers.rs
+++ b/rust/tcl-lsp-core/tests/lsp_providers.rs
@@ -465,7 +465,7 @@ fn whole_line(line: u32) -> LspRange {
 
 #[test]
 fn code_actions_none_analysis_is_empty() {
-    assert!(code_actions("catch { puts hi }\n", whole_line(0), None).is_empty());
+    assert!(code_actions("catch { puts hi }\n", whole_line(0), None, &[]).is_empty());
 }
 
 #[test]
@@ -485,7 +485,7 @@ fn code_actions_catch_without_result_var_offers_fix() {
         "expected a W302 diagnostic; got {:?}",
         analysis.diagnostics,
     );
-    let actions = code_actions(src, whole_line(0), Some(&analysis));
+    let actions = code_actions(src, whole_line(0), Some(&analysis), &analysis.diagnostics);
     let titles: Vec<&str> = actions.iter().map(|a| a.title.as_str()).collect();
     assert!(
         titles.iter().any(|t| t.contains("result")),
@@ -518,7 +518,7 @@ fn code_actions_catch_with_result_var_offers_no_w302_fix() {
     // silent-swallow, so no W302 and no catch-result quick-fix.
     let src = "catch { puts hi } result\n";
     let analysis = analyse(src);
-    let actions = code_actions(src, whole_line(0), Some(&analysis));
+    let actions = code_actions(src, whole_line(0), Some(&analysis), &analysis.diagnostics);
     assert!(
         !actions.iter().any(|a| a.title.contains("catch result")),
         "no catch-result fix expected; got {:?}",
@@ -544,7 +544,7 @@ fn code_actions_unset_possibly_undef_offers_nocomplain() {
     // The W213 diag is on line 0 (narrowed to the `xs` variable word); the
     // whole-line request range still overlaps it and the `unset` keyword.
     let (l, _c) = pos_of(src, "unset", 1);
-    let actions = code_actions(src, whole_line(l), Some(&analysis));
+    let actions = code_actions(src, whole_line(l), Some(&analysis), &analysis.diagnostics);
     let nocomplain = actions
         .iter()
         .find(|a| a.title.contains("-nocomplain"))
@@ -565,7 +565,7 @@ fn code_actions_clean_script_outside_diag_offers_no_quickfix() {
     // (refactor/source actions may still appear, but no `quickfix`).
     let src = "set x 1\nset y 2\n";
     let analysis = analyse(src);
-    let actions = code_actions(src, whole_line(0), Some(&analysis));
+    let actions = code_actions(src, whole_line(0), Some(&analysis), &analysis.diagnostics);
     assert!(
         !actions.iter().any(|a| a.kind == ActionKind::QuickFix),
         "no quick-fix expected on a clean line; got {:?}",
@@ -577,7 +577,7 @@ fn code_actions_clean_script_outside_diag_offers_no_quickfix() {
 fn code_actions_degenerate_inputs_do_not_panic() {
     for src in ["", "   ", "\n", "catch {"] {
         let analysis = analyse(src);
-        let _ = code_actions(src, whole_line(0), Some(&analysis));
+        let _ = code_actions(src, whole_line(0), Some(&analysis), &analysis.diagnostics);
     }
 }
 

--- a/rust/tcl-lsp-core/tests/mathfunc_and_word_recognition.rs
+++ b/rust/tcl-lsp-core/tests/mathfunc_and_word_recognition.rs
@@ -400,16 +400,13 @@ fn tp_reference_lens_counts_the_mathfunc_override_and_the_global_proc_apart() {
     let analysis = analyse(SWEEP);
     let lenses = tcl_lsp_core::code_lens::code_lenses(SWEEP, "tcl8.6", Some(&analysis), None, "");
     let title_for = |qname: &str| {
-        lenses
-            .iter()
-            .find(|lens| lens.qname == qname)
-            .map(|lens| lens.command_title.clone())
-            .unwrap_or_else(|| {
-                panic!(
-                    "no lens for {qname}; got {:?}",
-                    lenses.iter().map(|l| &l.qname).collect::<Vec<_>>()
-                )
-            })
+        let Some(lens) = lenses.iter().find(|lens| lens.qname == qname) else {
+            panic!(
+                "no lens for {qname}; got {:?}",
+                lenses.iter().map(|l| &l.qname).collect::<Vec<_>>()
+            )
+        };
+        lens.command_title.clone()
     };
     assert_eq!(
         title_for("::ns::tcl::mathfunc::f"),

--- a/rust/tcl-lsp-core/tests/mathfunc_and_word_recognition.rs
+++ b/rust/tcl-lsp-core/tests/mathfunc_and_word_recognition.rs
@@ -389,6 +389,41 @@ fn tp_references_are_symmetric_at_a_mathfunc_call_site() {
     );
 }
 
+/// TP: the reference-count **lens** — the fourth surface fed by the same
+/// `proc_reference_spans` substrate — agrees with the symmetric reference set
+/// above: exactly one call site for the override (`f(2)`), and exactly one for
+/// the unrelated global `proc f` (`puts [f 1]`).  The two must not be pooled:
+/// tclsh 9.0.4 / 8.6.16 print `200` for `ns::use` and `GLOBAL` for `f 1`, so
+/// they are two different commands that merely share a tail.
+#[test]
+fn tp_reference_lens_counts_the_mathfunc_override_and_the_global_proc_apart() {
+    let analysis = analyse(SWEEP);
+    let lenses = tcl_lsp_core::code_lens::code_lenses(SWEEP, "tcl8.6", Some(&analysis), None, "");
+    let title_for = |qname: &str| {
+        lenses
+            .iter()
+            .find(|lens| lens.qname == qname)
+            .map(|lens| lens.command_title.clone())
+            .unwrap_or_else(|| {
+                panic!(
+                    "no lens for {qname}; got {:?}",
+                    lenses.iter().map(|l| &l.qname).collect::<Vec<_>>()
+                )
+            })
+    };
+    assert_eq!(
+        title_for("::ns::tcl::mathfunc::f"),
+        "1 reference",
+        "the `f(2)` application is the override's one call site",
+    );
+    assert_eq!(
+        title_for("::f"),
+        "1 reference",
+        "`puts [f 1]` is the global proc's one call site, and the expr \
+         application is not one of them",
+    );
+}
+
 /// TP: call hierarchy and linked-editing — the other two consumers that ride
 /// on `resolve_proc_target_at` — reach the override from the call site too.
 #[test]

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -2583,10 +2583,11 @@ async fn run_deep_diagnostics(
         Vec::new()
     };
     // idx 80: the workspace's own definitions, as the cross-file
-    // unknown-command refinement's known-name set — only when the toggle is
-    // on, and read from the index's own derived-set cache, so this is an `Arc`
-    // clone rather than a walk of every indexed symbol.
-    let workspace_known_names = if inputs.cross_file_resolution {
+    // unknown-command refinement's known-name set — read whenever a W123
+    // survived (both refinement tiers need it, and the always-on one is not
+    // gated on the toggle), and read from the index's own derived-set cache, so
+    // this is an `Arc` clone rather than a walk of every indexed symbol.
+    let workspace_known_names = if analyser_diags.iter().any(|d| d.code == DiagCode::W123) {
         Some(inputs.workspace_index.read().await.command_names())
     } else {
         None
@@ -2600,6 +2601,7 @@ async fn run_deep_diagnostics(
             package_resolver: inputs.package_resolver,
             registry: inputs.registry,
             workspace_known_names,
+            cross_file_resolution: inputs.cross_file_resolution,
         },
         lift_inputs,
     )
@@ -2690,16 +2692,22 @@ struct LiftInputs<'a> {
     xc_diagnostics: bool,
 }
 
-/// The three workspace-wide inputs the W120 / W123 refinements resolve
-/// against, grouped so [`refine_and_lift_diagnostics`] takes them as one
-/// parameter: the requires this document inherits (#804), the package
-/// database (#723 / #832), and — when `crossFileResolution` is on — the
-/// workspace index's own command names (issue #923 idx 80).
+/// The workspace-wide inputs the W120 / W123 refinements resolve against,
+/// grouped so [`refine_and_lift_diagnostics`] takes them as one parameter: the
+/// requires this document inherits (#804), the package database (#723 / #832),
+/// and the workspace index's own command names (issue #923 idx 80).
 struct RefinementInputs<'a> {
     inherited_requires: &'a [String],
     package_resolver: &'a Arc<RwLock<PackageResolver>>,
     registry: &'static CommandRegistry,
+    /// The workspace index's memoised command names — read whenever this
+    /// document has a W123 to refine, because
+    /// [`refine_workspace_index_w123`]'s always-on math-function tier needs
+    /// them too, not only its `crossFileResolution`-gated project tier.
     workspace_known_names: Option<Arc<HashSet<String>>>,
+    /// Whether `crossFileResolution` is on, i.e. whether the *project* tier of
+    /// [`refine_workspace_index_w123`] applies on top of its always-on tier.
+    cross_file_resolution: bool,
 }
 
 /// Refine the analyser's single-file W120 against the workspace package
@@ -2736,9 +2744,14 @@ async fn refine_and_lift_diagnostics(
     )
     .await;
     // idx 80: and any W123 the *workspace index* resolves — a proc / class in a
-    // sibling document.  Opt-in via `crossFileResolution` (`None` when off).
-    let analyser_diags =
-        refine_workspace_index_w123(analyser_diags, refinement.workspace_known_names.as_deref());
+    // sibling document.  Its math-function tier is always on; its whole-project
+    // tier is opt-in via `crossFileResolution`.
+    let analyser_diags = refine_workspace_index_w123(
+        analyser_diags,
+        analysis.as_ref(),
+        refinement.workspace_known_names.as_deref(),
+        refinement.cross_file_resolution,
+    );
 
     let analysis_lifts = Arc::clone(analysis);
     let lift_text = inputs.text.to_owned();
@@ -10838,15 +10851,6 @@ impl Backend {
             .await;
         let registry = self.registry_for_dialect(&dialect).await;
 
-        // Cross-file: the project's proc arities, so the
-        // pull path resolves cross-file W123 / emits the cross-file arity error
-        // exactly as the push path does.  Only gathered when `crossFileResolution`
-        // is enabled.  Computed inside `spawn_blocking`: on a cold cache (or after a
-        // signature change) this tracked query can demand `item_sigs` / `item_tree`
-        // for every project file — now the *whole* workspace — so it must not run
-        // on the async event-loop thread and stall other LSP traffic.
-        let cross_file_on = self.cross_file_resolution_enabled(uri).await;
-        let project_arities = self.project_arities_if(cross_file_on).await;
         let compiler_diags = self
             .compiler_diagnostics_for(uri, &analysis_text, &dialect, registry)
             .await;
@@ -10854,29 +10858,12 @@ impl Backend {
         // XC100-301 translatability lints — independent toggle, f5-irules only.
         let xc_on = self.xc_diagnostics_enabled(uri).await;
         let xc_for_irules = dialect == "f5-irules" && xc_on;
-        // Cross-file resolution — W123 suppression + E002/E003 arity,
-        // matching the push path.  Arity keys off `unresolved_command_sites`, which
-        // the analyser records regardless of the W123 toggle, so disabling W123
-        // does not also silence cross-file arity.
-        let analyser_diags = match &project_arities {
-            Some(arities) => tcl_lsp_db::apply_cross_file_resolution(
-                &analysis.diagnostics,
-                &analysis.unresolved_command_sites,
-                &analysis.command_invocations,
-                arities,
-                |code| disabled.contains(code),
-            ),
-            None => analysis.diagnostics.clone(),
-        };
+        // Cross-file resolution + the workspace W120 / W123 refinements,
+        // matching the push path — and shared verbatim with
+        // `textDocument/codeAction`, which lifts its quick-fixes from this
+        // exact set (see `published_analyser_diagnostics`).
         let analyser_diags = self
-            .refine_pull_analyser_diagnostics(
-                uri,
-                analyser_diags,
-                &analysis,
-                &dialect,
-                registry,
-                cross_file_on,
-            )
+            .published_analyser_diagnostics(uri, &analysis, &dialect, registry, &disabled)
             .await;
         let style_line_length = self.resolved_style_line_length(uri).await;
         let severity_overrides = self.resolved_severity_overrides(uri).await;
@@ -10923,8 +10910,9 @@ impl Backend {
     ///   that an entry file / `source` ancestor already required.
     /// * **#832 W123** — a command the package database resolves (auto-loaded
     ///   library command, or an available package's defined command).
-    /// * **idx 80 W123** — a command the workspace index resolves, when
-    ///   `crossFileResolution` is on.
+    /// * **idx 80 W123** — a command the workspace index resolves: always for
+    ///   an `expr` math-function call site, and for any name at all when
+    ///   `crossFileResolution` is on (see [`refine_workspace_index_w123`]).
     ///
     /// The inherited-requires walk and the workspace-index read are both
     /// gated on there being something to refine, so a clean document pays
@@ -10962,12 +10950,74 @@ impl Backend {
             dialect,
         )
         .await;
-        let workspace_known_names = if cross_file_on {
+        // Read whenever a W123 survived, not only when the toggle is on: the
+        // math-function tier of the refinement below is always on.
+        let workspace_known_names = if analyser_diags.iter().any(|d| d.code == DiagCode::W123) {
             Some(self.workspace_index.read().await.command_names())
         } else {
             None
         };
-        refine_workspace_index_w123(analyser_diags, workspace_known_names.as_deref())
+        refine_workspace_index_w123(
+            analyser_diags,
+            analysis,
+            workspace_known_names.as_deref(),
+            cross_file_on,
+        )
+    }
+
+    /// The analyser diagnostics this document actually **publishes**: the
+    /// analyser's own set put through every workspace pass the diagnostics
+    /// pipeline applies — cross-file resolution when `crossFileResolution` is
+    /// on, then the #723/#804 W120 and #832 / idx-80 W123 refinements.
+    ///
+    /// This is the single answer both diagnostic-consuming surfaces must use.
+    /// `textDocument/diagnostic` publishes it; `textDocument/codeAction` lifts
+    /// quick-fixes from it.  Having code actions read `analysis.diagnostics`
+    /// instead is what let the server offer "Replace with 'ni'" over a
+    /// perfectly good cross-file `Pi()` call *whose diagnostic it had already
+    /// decided to suppress* — a quick-fix that rewrites working code into a
+    /// syntax error (tclsh 8.6.16 / 9.0.4: `expr {ni() / acos(-1.0)}` →
+    /// `missing operand`).  One function, one verdict, so the two surfaces
+    /// cannot drift apart again.
+    async fn published_analyser_diagnostics(
+        &self,
+        uri: &Uri,
+        analysis: &AnalysisResult,
+        dialect: &str,
+        registry: &'static CommandRegistry,
+        disabled: &HashSet<String>,
+    ) -> Vec<tcl_compiler::analyser::Diagnostic> {
+        // Cross-file: the project's proc arities, so the pull path resolves
+        // cross-file W123 / emits the cross-file arity error exactly as the
+        // push path does.  Only gathered when `crossFileResolution` is enabled.
+        // Computed inside `spawn_blocking` (see `project_arities_if`): on a cold
+        // cache this tracked query can demand `item_sigs` / `item_tree` for
+        // every project file, so it must not run on the async event-loop thread
+        // and stall other LSP traffic.
+        let cross_file_on = self.cross_file_resolution_enabled(uri).await;
+        let project_arities = self.project_arities_if(cross_file_on).await;
+        // Arity keys off `unresolved_command_sites`, which the analyser records
+        // regardless of the W123 toggle, so disabling W123 does not also
+        // silence cross-file arity.
+        let analyser_diags = match &project_arities {
+            Some(arities) => tcl_lsp_db::apply_cross_file_resolution(
+                &analysis.diagnostics,
+                &analysis.unresolved_command_sites,
+                &analysis.command_invocations,
+                arities,
+                |code| disabled.contains(code),
+            ),
+            None => analysis.diagnostics.clone(),
+        };
+        self.refine_pull_analyser_diagnostics(
+            uri,
+            analyser_diags,
+            analysis,
+            dialect,
+            registry,
+            cross_file_on,
+        )
+        .await
     }
 
     /// Compute and publish diagnostics synchronously (awaited).  Used by the
@@ -14464,10 +14514,25 @@ impl LanguageServer for Backend {
         // requested range, plus fuzzy `package require`
         // suggestions for the word at the cursor.  Run on a worker.
         let registry = self.registry_for_dialect(&doc.dialect).await;
-        // The resolved per-check disabled set — the same one baked into the
-        // analyser build above — so the compiler-checks code-action path does
-        // not re-surface a quick-fix for a diagnostic the user disabled.
-        let (disabled_codes, _) = self.analyser_config().await;
+        // The resolved per-check disabled set — the same one the diagnostics
+        // path resolves for this document (folder overrides included) — so the
+        // compiler-checks code-action path does not re-surface a quick-fix for
+        // a diagnostic the user disabled.
+        let (disabled_codes, ..) = self.resolved_analysis_settings(&uri).await;
+        // The analyser diagnostics this document actually publishes.  Code
+        // actions lift their quick-fixes from this set, never from the
+        // analyser's raw one, so a W123 the workspace refinements decided to
+        // suppress can never leave a "did you mean…?" rewrite behind
+        // (issue #923 idx 80).
+        let published = self
+            .published_analyser_diagnostics(
+                &uri,
+                &analysis,
+                &doc.dialect,
+                registry,
+                &disabled_codes,
+            )
+            .await;
         // Lift the request-context diagnostics (the editor sends the ones it
         // currently shows) so context-driven quick-fixes — e.g. the iRules
         // taint encode-wrap fixes — can act on them even when the analyser
@@ -14496,10 +14561,14 @@ impl LanguageServer for Backend {
                 uri: &uri_key,
                 oracle: exports.as_ref(),
             };
+            // Both views are needed here: `program` decides what an inlined
+            // call reaches (#1116 item 1), `published` decides which
+            // diagnostics this document is actually showing (#1019 idx 80).
             let mut actions = core_code_actions::code_actions_in_program(
                 &doc.text,
                 range,
                 Some(&analysis),
+                &published,
                 Some(program),
             );
             // The fuzzy package-suggestion path needs both the analysis (to
@@ -16952,8 +17021,7 @@ fn refine_w123_diagnostics(
 }
 
 /// Drop every W123 whose command the **workspace index** defines — a proc or
-/// class in a sibling document, in any of the three name forms a call site may
-/// spell.
+/// class in a sibling document — in two tiers with very different confidence.
 ///
 /// The analyser's own known-name set (`build_w123_known_names`) is
 /// single-document by construction, so a command whose `proc` lives in another
@@ -16964,16 +17032,47 @@ fn refine_w123_diagnostics(
 /// would have rewritten it to the unrelated `ni` operator, breaking working
 /// code (issue #923 differential-audit finding idx 80).
 ///
-/// Gated on `crossFileResolution` — `names` is `None` when the toggle is off,
-/// and the function is then a no-op.  Unlike the package / auto-load
-/// refinements (which are always on, because a library command is ambient like
-/// a builtin), this one *is* the cross-file inference the toggle governs.
+/// # Tier 1 — the interpreter-global tier, always on
 ///
-/// Cost is one hash lookup per surviving W123: `names` is the
+/// An `expr` math-function application (`Pi()`) does not dispatch through the
+/// caller's own namespace the way an ordinary bareword does: it dispatches
+/// through `::tcl::mathfunc::<name>`, a single slot the *language* owns, one
+/// per interpreter.  A workspace that injects `::tcl::mathfunc::Pi` anywhere
+/// therefore defines the one and only `Pi` every `expr` in that workspace can
+/// call — there is no project-scoped second meaning of expr function `Pi` the
+/// way every project has its own `helper`.  Suppressing the W123 for such a
+/// call is a statement about the language, not a cross-file guess, so it needs
+/// no opt-in.
+///
+/// The match runs the call's **own** `resolution_candidates` — the
+/// `Tcl_FindCommand` priority order `finalise_invocation_resolutions` already
+/// settled for that exact site, recorded precisely so "a cross-document
+/// consumer can re-settle this call against a workspace-wide existence check"
+/// — against the index's names.  Every candidate is fully qualified by
+/// `command_resolution_candidates`' own contract, so this can only ever match
+/// the index's *qualified* entries; the bare tails
+/// [`insert_qualified_and_tail`](tcl_compiler::analyser::utils::insert_qualified_and_tail)
+/// also puts in `names` are unreachable from here.
+///
+/// # Tier 2 — the project tier, opt-in via `crossFileResolution`
+///
+/// Any W123 whose bare name the workspace index carries in *any* of its three
+/// name forms.  This is the genuine cross-file inference — it treats the whole
+/// workspace as one program — and it is deliberately lossy: matching a bare
+/// tail resolves nothing, so a `proc ::clay::define::current_class` in one file
+/// silences a bare `current_class` call that Tcl would never route there.
+/// Measured over tcllib 2.0 (790 files, 450 W123s) that tail match silences 396
+/// of them, 197 of which no `Tcl_FindCommand` candidate of the call site
+/// justifies — which is why it stays behind the toggle while tier 1 does not.
+///
+/// Cost is one hash lookup per surviving W123 plus, only when the document has
+/// math-function call sites at all, one pass over them: `names` is the
 /// generation-keyed memo, so nothing is walked or rebuilt here.
 fn refine_workspace_index_w123(
     diags: Vec<tcl_compiler::analyser::Diagnostic>,
+    analysis: &AnalysisResult,
     names: Option<&HashSet<String>>,
+    project_tier: bool,
 ) -> Vec<tcl_compiler::analyser::Diagnostic> {
     let Some(names) = names.filter(|n| !n.is_empty()) else {
         return diags;
@@ -16981,11 +17080,32 @@ fn refine_workspace_index_w123(
     if !diags.iter().any(|d| d.code == DiagCode::W123) {
         return diags;
     }
+    // Tier 1: the spans of every math-function call site the workspace does
+    // define, keyed the way a diagnostic's own span is (the analyser raises the
+    // W123 at exactly the invocation's range).
+    let mathfunc_spans: HashSet<(u32, u32)> = analysis
+        .command_invocations
+        .iter()
+        .filter(|inv| {
+            inv.is_mathfunc_call
+                && inv
+                    .resolution_candidates
+                    .iter()
+                    .any(|candidate| names.contains(candidate.as_str()))
+        })
+        .map(|inv| (inv.range.start(), inv.range.end()))
+        .collect();
     diags
         .into_iter()
         .filter(|d| {
-            d.code != DiagCode::W123
-                || !w123_command_name(&d.message).is_some_and(|name| names.contains(name))
+            if d.code != DiagCode::W123 {
+                return true;
+            }
+            if mathfunc_spans.contains(&(d.span.start(), d.span.end())) {
+                return false;
+            }
+            !(project_tier
+                && w123_command_name(&d.message).is_some_and(|name| names.contains(name)))
         })
         .collect()
 }
@@ -20510,9 +20630,10 @@ mod tests {
 
     /// Issue #923 idx 80 — TP + TN: a `tcl::mathfunc` proc declared in a
     /// sibling document makes a bare `Pi()` inside `expr` resolvable
-    /// cross-file, so W123 must not fire on it once `crossFileResolution` is
-    /// on — and must still fire on a genuinely undefined name in the same
-    /// document, and on `Pi()` while the toggle is off.
+    /// cross-file, so W123 must not fire on it — **with the toggle at its
+    /// default (off) as well as on**, because `::tcl::mathfunc::Pi` is one
+    /// interpreter-wide slot, not a project-scoped name — and must still fire
+    /// on a genuinely undefined name in the same document either way.
     ///
     /// tclsh 9.0.4 / 8.6.16 oracle: sourcing the two files and calling the
     /// consumer prints `3.141592653589793` — `Pi()` really does dispatch to
@@ -20532,7 +20653,9 @@ mod tests {
                           proc tomato::v::A {} { return [expr {Pi()}] }\n\
                           proc tomato::v::B {} { return [NeverDefinedAnywhere] }\n";
 
-        // Toggle OFF: the single-document pass sees neither name.
+        // Toggle OFF — the default a real editor session gets: the
+        // math-function tier is not the toggle's to gate, so `Pi` already
+        // resolves through the workspace index here.
         let off = backend
             .full_diagnostics_for(&vector, Arc::from(vector_src), "tcl8.6".to_owned(), "tcl")
             .await;
@@ -20542,8 +20665,14 @@ mod tests {
             .filter_map(|d| w123_command_name(&d.message))
             .collect();
         assert!(
-            off_names.contains(&"Pi"),
-            "with the toggle off the cross-file Pi stays unknown, got: {off_names:?}",
+            !off_names.contains(&"Pi"),
+            "the workspace defines ::tcl::mathfunc::Pi, and an `expr` function \
+             call has no project-scoped second meaning — W123 must not fire on \
+             it under the default configuration, got: {off_names:?}",
+        );
+        assert!(
+            off_names.contains(&"NeverDefinedAnywhere"),
+            "TP control with the toggle off, got: {off_names:?}",
         );
 
         // Toggle ON: `Pi` resolves through the workspace index; the undefined
@@ -20569,6 +20698,61 @@ mod tests {
         assert!(
             on_names.contains(&"NeverDefinedAnywhere"),
             "a genuinely undefined command must still draw W123, got: {on_names:?}",
+        );
+    }
+
+    /// Issue #923 idx 80, the precision control for the always-on tier: it
+    /// matches the call site's own `Tcl_FindCommand` candidates, never a bare
+    /// tail.  A sibling `proc ::helpers::Pi` puts the tail `Pi` into the
+    /// workspace index without putting `::tcl::mathfunc::Pi` there, and
+    /// `expr {Pi()}` cannot reach it — tclsh 9.0.4 / 8.6.16 with only
+    /// `::helpers::Pi` defined: `invalid command name "tcl::mathfunc::Pi"` —
+    /// so the W123 must survive by default.  Enabling `crossFileResolution`
+    /// opts into exactly that looser, tail-matching inference and does silence
+    /// it: the two tiers are what tell the cases apart.
+    #[tokio::test]
+    async fn cross_file_mathfunc_w123_needs_the_qualified_definition_not_a_tail() {
+        let backend = test_backend();
+        let helper = Uri::from_str("file:///decoy.tcl").unwrap();
+        let vector = Uri::from_str("file:///consumer.tcl").unwrap();
+        register(
+            &backend,
+            &helper,
+            "namespace eval helpers {\n    proc Pi {} { return 3.14159 }\n}\n",
+        )
+        .await;
+        let vector_src = "proc consume {} { return [expr {Pi()}] }\n";
+
+        let off = backend
+            .full_diagnostics_for(&vector, Arc::from(vector_src), "tcl8.6".to_owned(), "tcl")
+            .await;
+        let off_names: Vec<&str> = off
+            .iter()
+            .filter(|d| matches!(&d.code, Some(tower_lsp_server::ls_types::NumberOrString::String(c)) if c == "W123"))
+            .filter_map(|d| w123_command_name(&d.message))
+            .collect();
+        assert!(
+            off_names.contains(&"Pi"),
+            "`::helpers::Pi` is not `::tcl::mathfunc::Pi`; `expr {{Pi()}}` cannot \
+             reach it, so the W123 must stand, got: {off_names:?}",
+        );
+
+        backend.feature_toggles.lock().await.apply(
+            serde_json::json!({ "crossFileResolution": true })
+                .as_object()
+                .unwrap(),
+        );
+        let on = backend
+            .full_diagnostics_for(&vector, Arc::from(vector_src), "tcl8.6".to_owned(), "tcl")
+            .await;
+        let on_names: Vec<&str> = on
+            .iter()
+            .filter(|d| matches!(&d.code, Some(tower_lsp_server::ls_types::NumberOrString::String(c)) if c == "W123"))
+            .filter_map(|d| w123_command_name(&d.message))
+            .collect();
+        assert!(
+            !on_names.contains(&"Pi"),
+            "the opt-in project tier matches bare tails by design, got: {on_names:?}",
         );
     }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -2583,11 +2583,14 @@ async fn run_deep_diagnostics(
         Vec::new()
     };
     // idx 80: the workspace's own definitions, as the cross-file
-    // unknown-command refinement's known-name set — read whenever a W123
-    // survived (both refinement tiers need it, and the always-on one is not
-    // gated on the toggle), and read from the index's own derived-set cache, so
-    // this is an `Arc` clone rather than a walk of every indexed symbol.
-    let workspace_known_names = if analyser_diags.iter().any(|d| d.code == DiagCode::W123) {
+    // unknown-command refinement's known-name set — demanded only when it can
+    // change this document's verdict (see `needs_workspace_command_names`), and
+    // read from the index's own derived-set cache.
+    let workspace_known_names = if needs_workspace_command_names(
+        &analyser_diags,
+        &analysis,
+        inputs.cross_file_resolution,
+    ) {
         Some(inputs.workspace_index.read().await.command_names())
     } else {
         None
@@ -10950,13 +10953,15 @@ impl Backend {
             dialect,
         )
         .await;
-        // Read whenever a W123 survived, not only when the toggle is on: the
-        // math-function tier of the refinement below is always on.
-        let workspace_known_names = if analyser_diags.iter().any(|d| d.code == DiagCode::W123) {
-            Some(self.workspace_index.read().await.command_names())
-        } else {
-            None
-        };
+        // Demanded whenever the refinement below can change a verdict, which
+        // is no longer only when the toggle is on: its math-function tier is
+        // always on.
+        let workspace_known_names =
+            if needs_workspace_command_names(&analyser_diags, analysis, cross_file_on) {
+                Some(self.workspace_index.read().await.command_names())
+            } else {
+                None
+            };
         refine_workspace_index_w123(
             analyser_diags,
             analysis,
@@ -17067,7 +17072,8 @@ fn refine_w123_diagnostics(
 ///
 /// Cost is one hash lookup per surviving W123 plus, only when the document has
 /// math-function call sites at all, one pass over them: `names` is the
-/// generation-keyed memo, so nothing is walked or rebuilt here.
+/// generation-keyed memo, so nothing is walked or rebuilt here.  Callers decide
+/// whether to demand that memo at all — see [`needs_workspace_command_names`].
 fn refine_workspace_index_w123(
     diags: Vec<tcl_compiler::analyser::Diagnostic>,
     analysis: &AnalysisResult,
@@ -17108,6 +17114,29 @@ fn refine_workspace_index_w123(
                 && w123_command_name(&d.message).is_some_and(|name| names.contains(name)))
         })
         .collect()
+}
+
+/// Whether [`refine_workspace_index_w123`] can change anything for this
+/// document, i.e. whether its `names` argument is worth demanding.
+///
+/// The set is a per-index-generation memo, but the *first* call after any
+/// document is indexed walks every proc and class in the workspace — so on a
+/// large project, demanding it for every analysis would put that walk on the
+/// keystroke path. It is only ever consulted for a W123, and then only by the
+/// always-on tier (which needs an `expr` math-function call site to match
+/// against) or the opt-in project tier. A document with neither pays nothing,
+/// exactly as it did before the always-on tier existed.
+fn needs_workspace_command_names(
+    diags: &[tcl_compiler::analyser::Diagnostic],
+    analysis: &AnalysisResult,
+    project_tier: bool,
+) -> bool {
+    diags.iter().any(|d| d.code == DiagCode::W123)
+        && (project_tier
+            || analysis
+                .command_invocations
+                .iter()
+                .any(|inv| inv.is_mathfunc_call))
 }
 
 /// Apply the issue-#832 workspace W123 refinement to `analyser_diags`: resolve

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -12044,6 +12044,88 @@ async fn log_range_convergence_settled(
         .await;
 }
 
+/// The dialect-specific code actions, appended to the generic Tcl set.
+///
+/// BIG-IP `.conf`/`.scf` gets the rename-partition / rename-object /
+/// extract-rule actions: the generic Tcl code-action path yields nothing
+/// useful on a non-Tcl config, so these extend rather than replace it —
+/// mirroring the references / document-links BIG-IP routing.  iRules
+/// additionally gets the `# Profiles:` header source action.
+fn push_dialect_code_actions(
+    actions: &mut Vec<core_code_actions::CodeAction>,
+    source: &str,
+    range: core_definition::LspRange,
+    uri_str: &str,
+    dialect: &str,
+    analysis: &tcl_compiler::analyser::AnalysisResult,
+    registry: &tcl_registry::CommandRegistry,
+) {
+    if Backend::is_bigip_dialect(dialect) {
+        actions.extend(core_code_actions::bigip_code_actions(
+            source, range, uri_str,
+        ));
+    }
+    if dialect == "f5-irules"
+        && let Some(a) = core_code_actions::profiles_action(source, analysis, registry)
+    {
+        actions.push(a);
+    }
+}
+
+/// The context-diagnostic actions, plus the fuzzy `package require`
+/// suggestion.
+///
+/// That suggestion needs both the analysis — to prove the cursor is on an
+/// unresolved *command head* rather than on a comment, a string, or a data
+/// word — and the request's own diagnostics, since the editor may be showing a
+/// W123 this analysis has not re-emitted.  Passing neither is what let it fire
+/// anywhere an identifier-shaped word appeared (issue #1191).
+fn push_context_code_actions(
+    actions: &mut Vec<core_code_actions::CodeAction>,
+    source: &str,
+    range: core_definition::LspRange,
+    registry: &tcl_registry::CommandRegistry,
+    program: core_definition::ProgramExports<'_>,
+    analysis: &tcl_compiler::analyser::AnalysisResult,
+    context_diags: &[core_code_actions::ContextDiagnostic],
+) {
+    actions.extend(core_code_actions::package_require_actions_in_program(
+        source,
+        range,
+        core_definition::CallResolution {
+            registry: Some(registry),
+            program: Some(program),
+        },
+        Some(analysis),
+        context_diags,
+    ));
+    actions.extend(core_code_actions::context_diagnostic_actions(
+        source,
+        context_diags,
+    ));
+}
+
+/// The compiler-check quick-fixes: the iRules control-flow fixes (IRULE5002
+/// unguarded drop / IRULE5004 `DNS::return`) plus the shimmer-family
+/// noqa-suppress action (S100/S101/S102/S110).
+///
+/// Every dialect's checks are lowered here, not just iRules' — a plain-Tcl
+/// document's checks simply carry no IRULE-family fixes.
+fn push_check_code_actions(
+    actions: &mut Vec<core_code_actions::CodeAction>,
+    source: &str,
+    range: core_definition::LspRange,
+    checks: &tcl_lsp_db::CompilerDiagnostics,
+    disabled_codes: &std::collections::HashSet<String>,
+) {
+    actions.extend(core_code_actions::check_diagnostic_actions(
+        source,
+        range,
+        &checks.checks,
+        disabled_codes,
+    ));
+}
+
 impl LanguageServer for Backend {
     async fn initialize(&self, params: InitializeParams) -> jsonrpc::Result<InitializeResult> {
         self.apply_workspace_folders(&params).await;
@@ -14566,9 +14648,8 @@ impl LanguageServer for Backend {
                 uri: &uri_key,
                 oracle: exports.as_ref(),
             };
-            // Both views are needed here: `program` decides what an inlined
-            // call reaches (#1116 item 1), `published` decides which
-            // diagnostics this document is actually showing (#1019 idx 80).
+            // `program` decides what an inlined call reaches (#1116 item 1);
+            // `published` decides what this document shows (#1019 idx 80).
             let mut actions = core_code_actions::code_actions_in_program(
                 &doc.text,
                 range,
@@ -14576,47 +14657,24 @@ impl LanguageServer for Backend {
                 &published,
                 Some(program),
             );
-            // The fuzzy package-suggestion path needs both the analysis (to
-            // prove the cursor is on an unresolved *command head* rather than
-            // on a comment, a string, or a data word) and the request's own
-            // diagnostics (the editor may be showing a W123 this analysis has
-            // not re-emitted).  Passing neither is what let it fire anywhere
-            // an identifier-shaped word appeared — issue #1191.
-            actions.extend(core_code_actions::package_require_actions_in_program(
+            push_context_code_actions(
+                &mut actions,
                 &doc.text,
                 range,
-                core_definition::CallResolution {
-                    registry: Some(registry),
-                    program: Some(program),
-                },
-                Some(&analysis),
+                registry,
+                program,
+                &analysis,
                 &context_diags,
-            ));
-            actions.extend(core_code_actions::context_diagnostic_actions(
+            );
+            push_dialect_code_actions(
+                &mut actions,
                 &doc.text,
-                &context_diags,
-            ));
-            // BIG-IP `.conf`/`.scf`: the dialect-specific rename-partition /
-            // rename-object / extract-rule actions (`tcl-lsp-core::bigip_code_actions`).
-            // The generic Tcl code-action path above yields nothing useful on a
-            // non-Tcl config, so extend rather than replace — mirroring the
-            // references / document-links BIG-IP routing.
-            if Backend::is_bigip_dialect(&dialect) {
-                actions.extend(core_code_actions::bigip_code_actions(
-                    &doc.text, range, &uri_str,
-                ));
-            }
-            // iRules-only: the `# Profiles:` header source action.
-            if dialect == "f5-irules"
-                && let Some(a) = core_code_actions::profiles_action(&doc.text, &analysis, registry)
-            {
-                actions.push(a);
-            }
-            // Compiler-check quick-fixes: the iRules control-flow fixes
-            // (IRULE5002 unguarded drop / IRULE5004 DNS::return) plus the
-            // shimmer-family noqa-suppress action (S100/S101/S102/S110) —
-            // every dialect's checks are lowered here, not just iRules'; a
-            // plain-Tcl document's checks simply carry no IRULE-family fixes.
+                range,
+                &uri_str,
+                &dialect,
+                &analysis,
+                registry,
+            );
             let checks = tcl_lsp_db::compiler_check_diagnostics_uncached(
                 &doc.text,
                 registry,
@@ -14624,12 +14682,7 @@ impl LanguageServer for Backend {
                 generic_patterns.as_deref(),
                 evidence.as_deref(),
             );
-            actions.extend(core_code_actions::check_diagnostic_actions(
-                &doc.text,
-                range,
-                &checks.checks,
-                &disabled_codes,
-            ));
+            push_check_code_actions(&mut actions, &doc.text, range, &checks, &disabled_codes);
             actions
         })
         .await

--- a/rust/tcl-lsp-server/tests/e2e.rs
+++ b/rust/tcl-lsp-server/tests/e2e.rs
@@ -71,6 +71,8 @@ mod issue1214_uri_canonicalisation;
 mod issue923_class_refs;
 #[path = "e2e/issue923_crossdoc.rs"]
 mod issue923_crossdoc;
+#[path = "e2e/issue923_idx80_mathfunc.rs"]
+mod issue923_idx80_mathfunc;
 #[path = "e2e/issue945.rs"]
 mod issue945;
 #[path = "e2e/issue954_followup.rs"]

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -4245,6 +4245,61 @@ fn issue_968_version_gated_math_function_dual_fires_end_to_end() {
     );
 }
 
+/// Issue #923 idx 103 — the **plain-command** spelling of a math function,
+/// `tcl::mathfunc::isinf`, which is a real, directly-callable, version-gated
+/// command and not only an `expr` production. The registry now carries it, so
+/// the generic per-dispatch-site availability check fires for free; this pins
+/// that it really reaches the wire, which the registry-level unit test
+/// (`mathfunc_command_spellings_are_registered_and_gated`) cannot show.
+///
+/// Oracle:
+///
+/// ```text
+/// $ tclsh8.6 -c 'set r [tcl::mathfunc::isinf 1.0]'
+/// invalid command name "tcl::mathfunc::isinf"     (exit 1)
+/// $ tclsh9.0 -c 'puts [tcl::mathfunc::isinf 1.0]'
+/// 0                                                (exit 0)
+/// ```
+#[test]
+fn issue_923_idx103_plain_command_mathfunc_is_dialect_gated_end_to_end() {
+    let mut lsp = Lsp::tcl();
+    let src = "set r [tcl::mathfunc::isinf 1.0]\n";
+
+    let uri86 = unique_uri("idx103-86");
+    let diags86 = lsp.open_ready_lang(&uri86, src, "tcl8.6");
+    assert!(
+        has_code(&diags86, "W002"),
+        "`isinf` arrived in 9.0; calling `tcl::mathfunc::isinf` under an 8.6 \
+         document is a real `invalid command name` and must draw W002: {:?}",
+        codes(&diags86)
+    );
+    assert!(
+        diags86
+            .iter()
+            .any(|d| code_str(d).as_deref() == Some("W002")
+                && message(d).contains("tcl::mathfunc::isinf")),
+        "the W002 must name the qualified command it gated: {diags86:?}",
+    );
+
+    let uri90 = unique_uri("idx103-90");
+    let diags90 = lsp.open_ready_lang(&uri90, src, "tcl9.0");
+    assert!(
+        !has_code(&diags90, "W002") && !has_code(&diags90, "W123"),
+        "under tcl9.0 the same call is valid and must be clean: {:?}",
+        codes(&diags90)
+    );
+
+    // TN control: the `expr` spelling of the same function is gated
+    // identically, so the two spellings cannot drift apart.
+    let uri_expr = unique_uri("idx103-expr86");
+    let diags_expr = lsp.open_ready_lang(&uri_expr, "set r [expr {isinf(1.0)}]\n", "tcl8.6");
+    assert!(
+        has_code(&diags_expr, "W002"),
+        "the expr spelling must stay gated too: {:?}",
+        codes(&diags_expr)
+    );
+}
+
 /// The VS Code extension contributes *undotted* version-pinned language ids
 /// (`tcl84` … `tcl91`) — a dotted id cannot carry a `configurationDefaults`
 /// override (issue #1122). The server must resolve them to the same dialects

--- a/rust/tcl-lsp-server/tests/e2e/issue923_idx80_mathfunc.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue923_idx80_mathfunc.rs
@@ -334,5 +334,5 @@ fn cross_file_resolution_on_clears_a_plain_proc_w123_and_its_quick_fix() {
         "the diagnostic is suppressed, so its quick-fix must be too: {at_call:?}",
     );
     let at_unknown = action_titles(&lsp.code_actions(&caller, caret(1, 4), json!([])));
-    assert!(has_replace_fix(&at_unknown), "TP control: {at_unknown:?}",);
+    assert!(has_replace_fix(&at_unknown), "TP control: {at_unknown:?}");
 }

--- a/rust/tcl-lsp-server/tests/e2e/issue923_idx80_mathfunc.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue923_idx80_mathfunc.rs
@@ -137,8 +137,11 @@ fn default_config_clears_w123_for_a_cross_file_mathfunc() {
     let vector = unique_uri("tcl");
     lsp.open_ready(&vector, VECTOR);
 
+    // The fast tier publishes no W120/W123 at all, so a batch carrying the
+    // control's W123 is necessarily a deep-pass batch with the workspace
+    // refinements applied — the only state worth asserting on.
     let diags = lsp.await_diagnostics_settled(&vector, Duration::from_secs(20), |d| {
-        !w123_names(d).is_empty()
+        w123_names(d).iter().any(|n| n == "NeverDefinedAnywhere")
     });
     let names = w123_names(&diags);
     assert!(
@@ -168,7 +171,7 @@ fn default_config_offers_no_command_rewrite_over_a_cross_file_mathfunc() {
     let vector = unique_uri("tcl");
     lsp.open_ready(&vector, VECTOR);
     lsp.await_diagnostics_settled(&vector, Duration::from_secs(20), |d| {
-        !w123_names(d).is_empty()
+        w123_names(d).iter().any(|n| n == "NeverDefinedAnywhere")
     });
 
     let at_pi = titles_at_pi(&mut lsp, &vector);
@@ -212,7 +215,7 @@ fn workspace_scan_clears_w123_for_a_cross_file_mathfunc() {
     let vector = format!("file://{}", vector_path.to_string_lossy());
     lsp.open_ready(&vector, VECTOR);
     let diags = lsp.await_diagnostics_settled(&vector, Duration::from_secs(30), |d| {
-        !w123_names(d).is_empty()
+        w123_names(d).iter().any(|n| n == "NeverDefinedAnywhere")
     });
     let names = w123_names(&diags);
     assert!(
@@ -245,8 +248,11 @@ fn cross_file_resolution_on_keeps_the_mathfunc_verdict_and_the_action_agrees() {
     lsp.open_ready(&helper, HELPER);
     let vector = unique_uri("tcl");
     lsp.open_ready(&vector, VECTOR);
+    // The fast tier publishes no W120/W123 at all, so a batch carrying the
+    // control's W123 is necessarily a deep-pass batch with the workspace
+    // refinements applied — the only state worth asserting on.
     let diags = lsp.await_diagnostics_settled(&vector, Duration::from_secs(20), |d| {
-        !w123_names(d).is_empty()
+        w123_names(d).iter().any(|n| n == "NeverDefinedAnywhere")
     });
     let names = w123_names(&diags);
     assert!(
@@ -300,7 +306,7 @@ fn cross_file_resolution_on_clears_a_plain_proc_w123_and_its_quick_fix() {
     let src = "renderReport 1 2\nnoSuchCommandAnywhere 1\n";
     lsp.open_ready(&caller, src);
     let diags = lsp.await_diagnostics_settled(&caller, Duration::from_secs(20), |d| {
-        !w123_names(d).is_empty()
+        w123_names(d).iter().any(|n| n == "noSuchCommandAnywhere")
     });
     let names = w123_names(&diags);
     assert!(

--- a/rust/tcl-lsp-server/tests/e2e/issue923_idx80_mathfunc.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue923_idx80_mathfunc.rs
@@ -1,0 +1,322 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Issue #923 differential audit, finding idx 80 — a `tcl::mathfunc` override
+//! injected in one file and applied by an `expr` in a sibling file.
+//!
+//! Two surfaces had to be brought into agreement, and only the real protocol
+//! shows it: the existing in-process unit test hand-populated the workspace
+//! index and called `full_diagnostics_for` directly, so it saw neither the
+//! `workspace/configuration` handshake (which decides `crossFileResolution`)
+//! nor `textDocument/codeAction` at all — and `codeAction` was still offering
+//! `Replace with 'ni'` over working code even when the diagnostic had already
+//! been suppressed.
+//!
+//! Oracle — tclsh 8.6.16 and 9.0.4, sourcing `helper.tcl` then `vector.tcl`:
+//!
+//! ```text
+//! AngleBetween(-1.0) => 3.141592653589793
+//! NegateX(7) => -7.0
+//! ```
+//!
+//! `Pi()` / `Inv()` really do dispatch cross-file to `::tcl::mathfunc::Pi` /
+//! `::tcl::mathfunc::Inv`.  Accepting the quick-fix breaks that outright — both
+//! releases reject the rewritten form:
+//!
+//! ```text
+//! $ tclsh9.0 -c 'puts [expr {ni() / acos(-1.0)}]'
+//! missing operand at _@_
+//! in expression "_@_ni() / acos(-1.0)"
+//! ```
+//!
+//! and a name nothing defines is a genuine error on both, which is what the
+//! true-positive controls below pin:
+//!
+//! ```text
+//! invalid command name "tcl::mathfunc::NeverDefinedAnywhere"
+//! ```
+
+use crate::common::{Lsp, unique_uri};
+use serde_json::{Value, json};
+use std::time::Duration;
+
+/// The `::tcl::mathfunc` injection every test here resolves against.
+const HELPER: &str = "namespace eval ::tcl::mathfunc {\n\
+                      \x20   proc Pi {} { return 3.141592653589793 }\n\
+                      \x20   proc Inv {x} { return [expr {-1.0 * $x}] }\n\
+                      }\n";
+
+/// The consumer: `Pi()` on line 2, `Inv($x)` on line 5, and a math function
+/// nothing anywhere defines on line 8 (the true-positive control).
+const VECTOR: &str = "namespace eval tomato::vector {}\n\
+                      proc tomato::vector::AngleBetween {c} {\n\
+                      \x20   return [expr {acos($c) * (Pi() / acos(-1.0))}]\n\
+                      }\n\
+                      proc tomato::vector::NegateX {x} {\n\
+                      \x20   return [expr {Inv($x)}]\n\
+                      }\n\
+                      proc tomato::vector::Broken {} {\n\
+                      \x20   return [expr {NeverDefinedAnywhere()}]\n\
+                      }\n";
+
+/// The names W123 reports, in source order.
+fn w123_names(diags: &[Value]) -> Vec<String> {
+    diags
+        .iter()
+        .filter(|d| d.get("code").and_then(Value::as_str) == Some("W123"))
+        .filter_map(|d| {
+            d.get("message")
+                .and_then(Value::as_str)
+                .and_then(|m| m.split('\'').nth(1))
+                .map(ToOwned::to_owned)
+        })
+        .collect()
+}
+
+/// Every code-action title the server offers over `range`.
+fn action_titles(actions: &Value) -> Vec<String> {
+    actions
+        .as_array()
+        .map(|list| {
+            list.iter()
+                .filter_map(|a| a.get("title").and_then(Value::as_str))
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// A one-character range on `line` at `ch` — a caret, the way an editor asks.
+fn caret(line: u32, ch: u32) -> Value {
+    json!({
+        "start": { "line": line, "character": ch },
+        "end": { "line": line, "character": ch + 1 },
+    })
+}
+
+/// Titles offered at the `Pi()` call site (line 2) of [`VECTOR`].
+fn titles_at_pi(lsp: &mut Lsp, uri: &str) -> Vec<String> {
+    action_titles(&lsp.code_actions(uri, caret(2, 32), json!([])))
+}
+
+/// Titles offered at the genuinely-undefined call site (line 8) of [`VECTOR`].
+fn titles_at_undefined(lsp: &mut Lsp, uri: &str) -> Vec<String> {
+    action_titles(&lsp.code_actions(uri, caret(8, 20), json!([])))
+}
+
+/// Whether any offered title is a "did you mean…?" command rewrite.
+fn has_replace_fix(titles: &[String]) -> bool {
+    titles.iter().any(|t| t.starts_with("Replace with"))
+}
+
+/// **The reported bug, out of the box.** Default configuration — nothing
+/// opted into, `crossFileResolution` left at its documented default of off —
+/// and the two files joined only by living in the same workspace, exactly as
+/// a `pkgIndex.tcl`-only project is. `Pi()` and `Inv()` must draw no W123,
+/// and the name nothing defines must still draw one.
+#[test]
+fn default_config_clears_w123_for_a_cross_file_mathfunc() {
+    let mut lsp = Lsp::tcl();
+    let helper = unique_uri("tcl");
+    lsp.open_ready(&helper, HELPER);
+    let vector = unique_uri("tcl");
+    lsp.open_ready(&vector, VECTOR);
+
+    let diags = lsp.await_diagnostics_settled(&vector, Duration::from_secs(20), |d| {
+        !w123_names(d).is_empty()
+    });
+    let names = w123_names(&diags);
+    assert!(
+        !names.iter().any(|n| n == "Pi" || n == "Inv"),
+        "a `::tcl::mathfunc` override defined in a sibling document is the one \
+         `Pi`/`Inv` every `expr` in the workspace can call; W123 must not fire \
+         on it under the default configuration, got: {names:?}",
+    );
+    assert!(
+        names.iter().any(|n| n == "NeverDefinedAnywhere"),
+        "TP control: a math function nothing defines is a real error \
+         (tclsh: `invalid command name \"tcl::mathfunc::NeverDefinedAnywhere\"`) \
+         and must still draw W123, got: {names:?}",
+    );
+}
+
+/// **The harmful half.** `textDocument/codeAction` must reach the same verdict
+/// as the diagnostics it lifts from: no unresolved-command rewrite over the
+/// working `Pi()` call, and — the control that proves the mechanism is still
+/// alive, not merely switched off — the offer still stands where the name
+/// really is unknown.
+#[test]
+fn default_config_offers_no_command_rewrite_over_a_cross_file_mathfunc() {
+    let mut lsp = Lsp::tcl();
+    let helper = unique_uri("tcl");
+    lsp.open_ready(&helper, HELPER);
+    let vector = unique_uri("tcl");
+    lsp.open_ready(&vector, VECTOR);
+    lsp.await_diagnostics_settled(&vector, Duration::from_secs(20), |d| {
+        !w123_names(d).is_empty()
+    });
+
+    let at_pi = titles_at_pi(&mut lsp, &vector);
+    assert!(
+        !has_replace_fix(&at_pi),
+        "accepting a `Replace with …` over `Pi()` rewrites working code into a \
+         parse error (tclsh 8.6.16 / 9.0.4: `missing operand`); offered: {at_pi:?}",
+    );
+    let at_undefined = titles_at_undefined(&mut lsp, &vector);
+    assert!(
+        has_replace_fix(&at_undefined),
+        "TP control: the unresolved-command quick-fix must still be offered \
+         where the name really is unknown, offered: {at_undefined:?}",
+    );
+}
+
+/// The same shape driven through a **real workspace scan**: the two files sit
+/// on disk, joined only by a `pkgIndex.tcl`, and the server discovers the
+/// sibling itself rather than being handed it by a `didOpen`.
+#[test]
+fn workspace_scan_clears_w123_for_a_cross_file_mathfunc() {
+    let root = std::env::temp_dir().join(format!(
+        "tcl-lsp-e2e-idx80-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos(),
+    ));
+    std::fs::create_dir_all(&root).expect("create workspace root");
+    std::fs::write(root.join("helper.tcl"), HELPER).expect("write helper.tcl");
+    std::fs::write(
+        root.join("pkgIndex.tcl"),
+        "package ifneeded tomato 1.0 [list source [file join $dir helper.tcl]]\n",
+    )
+    .expect("write pkgIndex.tcl");
+    let vector_path = root.join("vector.tcl");
+    std::fs::write(&vector_path, VECTOR).expect("write vector.tcl");
+
+    let mut lsp = Lsp::at_workspace_root(&root);
+    let vector = format!("file://{}", vector_path.to_string_lossy());
+    lsp.open_ready(&vector, VECTOR);
+    let diags = lsp.await_diagnostics_settled(&vector, Duration::from_secs(30), |d| {
+        !w123_names(d).is_empty()
+    });
+    let names = w123_names(&diags);
+    assert!(
+        !names.iter().any(|n| n == "Pi" || n == "Inv"),
+        "the scan indexed helper.tcl; W123 must not fire on the cross-file \
+         math functions, got: {names:?}",
+    );
+    assert!(
+        names.iter().any(|n| n == "NeverDefinedAnywhere"),
+        "TP control through the scan path, got: {names:?}",
+    );
+    let titles = titles_at_pi(&mut lsp, &vector);
+    assert!(
+        !has_replace_fix(&titles),
+        "code actions must agree with the scan-informed diagnostics: {titles:?}",
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Opting into `crossFileResolution` changes nothing about the math-function
+/// verdict — it was never the toggle's to decide — and code actions still
+/// agree with diagnostics in that state too.
+#[test]
+fn cross_file_resolution_on_keeps_the_mathfunc_verdict_and_the_action_agrees() {
+    let mut lsp = Lsp::with_config(json!({
+        "features": { "linkedEditingRange": true, "crossFileResolution": true }
+    }));
+    let helper = unique_uri("tcl");
+    lsp.open_ready(&helper, HELPER);
+    let vector = unique_uri("tcl");
+    lsp.open_ready(&vector, VECTOR);
+    let diags = lsp.await_diagnostics_settled(&vector, Duration::from_secs(20), |d| {
+        !w123_names(d).is_empty()
+    });
+    let names = w123_names(&diags);
+    assert!(
+        !names.iter().any(|n| n == "Pi" || n == "Inv"),
+        "got: {names:?}",
+    );
+    assert!(
+        names.iter().any(|n| n == "NeverDefinedAnywhere"),
+        "TP control with the toggle on, got: {names:?}",
+    );
+    let at_pi = titles_at_pi(&mut lsp, &vector);
+    assert!(!has_replace_fix(&at_pi), "offered: {at_pi:?}");
+    let at_undefined = titles_at_undefined(&mut lsp, &vector);
+    assert!(
+        has_replace_fix(&at_undefined),
+        "TP control: offered: {at_undefined:?}",
+    );
+}
+
+/// The **project tier**, which stays opt-in: an ordinary bareword call to a
+/// proc in a sibling document. It draws W123 by default (a workspace is not
+/// automatically one program — a bare `helper` in an unrelated script is a
+/// real error), and the quick-fix is offered because the diagnostic is.
+#[test]
+fn a_plain_cross_file_proc_call_still_draws_w123_by_default() {
+    let mut lsp = Lsp::tcl();
+    let lib = unique_uri("tcl");
+    lsp.open_ready(&lib, "proc renderReport {a b} { return [list $a $b] }\n");
+    let caller = unique_uri("tcl");
+    let diags = lsp.open_ready(&caller, "renderReport 1 2\n");
+    assert!(
+        w123_names(&diags).iter().any(|n| n == "renderReport"),
+        "the project tier is opt-in; without it a cross-file bareword call is \
+         still unknown, got: {:?}",
+        w123_names(&diags),
+    );
+}
+
+/// …and with `crossFileResolution` on, **both** surfaces move together: the
+/// W123 clears and so does its quick-fix. This is the pairing the old code
+/// could not express — diagnostics consulted the workspace, code actions did
+/// not.
+#[test]
+fn cross_file_resolution_on_clears_a_plain_proc_w123_and_its_quick_fix() {
+    let mut lsp = Lsp::with_config(json!({
+        "features": { "linkedEditingRange": true, "crossFileResolution": true }
+    }));
+    let lib = unique_uri("tcl");
+    lsp.open_ready(&lib, "proc renderReport {a b} { return [list $a $b] }\n");
+    let caller = unique_uri("tcl");
+    let src = "renderReport 1 2\nnoSuchCommandAnywhere 1\n";
+    lsp.open_ready(&caller, src);
+    let diags = lsp.await_diagnostics_settled(&caller, Duration::from_secs(20), |d| {
+        !w123_names(d).is_empty()
+    });
+    let names = w123_names(&diags);
+    assert!(
+        !names.iter().any(|n| n == "renderReport"),
+        "the sibling document defines it, got: {names:?}",
+    );
+    assert!(
+        names.iter().any(|n| n == "noSuchCommandAnywhere"),
+        "TP control: got: {names:?}",
+    );
+
+    let at_call = action_titles(&lsp.code_actions(&caller, caret(0, 4), json!([])));
+    assert!(
+        !has_replace_fix(&at_call),
+        "the diagnostic is suppressed, so its quick-fix must be too: {at_call:?}",
+    );
+    let at_unknown = action_titles(&lsp.code_actions(&caller, caret(1, 4), json!([])));
+    assert!(has_replace_fix(&at_unknown), "TP control: {at_unknown:?}",);
+}

--- a/rust/tcl-lsp-server/tests/e2e/issue923_idx80_mathfunc.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue923_idx80_mathfunc.rs
@@ -61,8 +61,13 @@ const HELPER: &str = "namespace eval ::tcl::mathfunc {\n\
                       \x20   proc Inv {x} { return [expr {-1.0 * $x}] }\n\
                       }\n";
 
-/// The consumer: `Pi()` on line 2, `Inv($x)` on line 5, and a math function
-/// nothing anywhere defines on line 8 (the true-positive control).
+/// The consumer: `Pi()` on line 2, `Inv($x)` on line 5, a math function nothing
+/// anywhere defines on line 8, and — on line 10 — an unknown command *close
+/// enough to a real one to attract a suggestion*, which is the true-positive
+/// control the code-action half needs. A quick-fix only exists where the
+/// analyser found a "did you mean…?" candidate, so a control has to be a
+/// near-miss (`puta` → `puts`); an arbitrary long name draws the W123 but
+/// carries no fix, and asserting on its absence would prove nothing.
 const VECTOR: &str = "namespace eval tomato::vector {}\n\
                       proc tomato::vector::AngleBetween {c} {\n\
                       \x20   return [expr {acos($c) * (Pi() / acos(-1.0))}]\n\
@@ -72,7 +77,8 @@ const VECTOR: &str = "namespace eval tomato::vector {}\n\
                       }\n\
                       proc tomato::vector::Broken {} {\n\
                       \x20   return [expr {NeverDefinedAnywhere()}]\n\
-                      }\n";
+                      }\n\
+                      puta hi\n";
 
 /// The names W123 reports, in source order.
 fn w123_names(diags: &[Value]) -> Vec<String> {
@@ -114,9 +120,11 @@ fn titles_at_pi(lsp: &mut Lsp, uri: &str) -> Vec<String> {
     action_titles(&lsp.code_actions(uri, caret(2, 30), json!([])))
 }
 
-/// Titles offered at the genuinely-undefined call site (line 8) of [`VECTOR`].
+/// Titles offered at [`VECTOR`]'s line-10 `puta` call — a name nothing
+/// defines, one edit from the real `puts`, so the unresolved-command quick-fix
+/// genuinely exists there.
 fn titles_at_undefined(lsp: &mut Lsp, uri: &str) -> Vec<String> {
-    action_titles(&lsp.code_actions(uri, caret(8, 20), json!([])))
+    action_titles(&lsp.code_actions(uri, caret(10, 1), json!([])))
 }
 
 /// Whether any offered title is a "did you mean…?" command rewrite.
@@ -272,6 +280,14 @@ fn cross_file_resolution_on_keeps_the_mathfunc_verdict_and_the_action_agrees() {
     );
 }
 
+/// The sibling proc the project-tier tests call across files, and the caller
+/// that calls it. Both names are one edit from the real `puts` so the
+/// unresolved-command quick-fix genuinely exists for each: `putz` is defined
+/// next door (line 0), `puta` is defined nowhere (line 1, the control that
+/// must never be suppressed).
+const CROSS_FILE_LIB: &str = "proc putz {a} { return $a }\n";
+const CROSS_FILE_CALLER: &str = "putz hi\nputa hi\n";
+
 /// The **project tier**, which stays opt-in: an ordinary bareword call to a
 /// proc in a sibling document. It draws W123 by default (a workspace is not
 /// automatically one program — a bare `helper` in an unrelated script is a
@@ -280,21 +296,21 @@ fn cross_file_resolution_on_keeps_the_mathfunc_verdict_and_the_action_agrees() {
 fn a_plain_cross_file_proc_call_still_draws_w123_by_default() {
     let mut lsp = Lsp::tcl();
     let lib = unique_uri("tcl");
-    lsp.open_ready(&lib, "proc renderReport {a b} { return [list $a $b] }\n");
+    lsp.open_ready(&lib, CROSS_FILE_LIB);
     let caller = unique_uri("tcl");
-    // The second call is the settle marker: nothing anywhere defines it, so a
-    // batch carrying its W123 is a deep-pass batch with the refinements run.
-    lsp.open_ready(&caller, "renderReport 1 2\nnoSuchCommandAnywhere 1\n");
+    // `puta` is the settle marker: nothing anywhere defines it, so a batch
+    // carrying its W123 is a deep-pass batch with the refinements run.
+    lsp.open_ready(&caller, CROSS_FILE_CALLER);
     let diags = lsp.await_diagnostics_settled(&caller, Duration::from_secs(20), |d| {
-        w123_names(d).iter().any(|n| n == "noSuchCommandAnywhere")
+        w123_names(d).iter().any(|n| n == "puta")
     });
     assert!(
-        w123_names(&diags).iter().any(|n| n == "renderReport"),
+        w123_names(&diags).iter().any(|n| n == "putz"),
         "the project tier is opt-in; without it a cross-file bareword call is \
          still unknown, got: {:?}",
         w123_names(&diags),
     );
-    let at_call = action_titles(&lsp.code_actions(&caller, caret(0, 4), json!([])));
+    let at_call = action_titles(&lsp.code_actions(&caller, caret(0, 1), json!([])));
     assert!(
         has_replace_fix(&at_call),
         "…and the quick-fix is offered because the diagnostic is: {at_call:?}",
@@ -311,28 +327,27 @@ fn cross_file_resolution_on_clears_a_plain_proc_w123_and_its_quick_fix() {
         "features": { "linkedEditingRange": true, "crossFileResolution": true }
     }));
     let lib = unique_uri("tcl");
-    lsp.open_ready(&lib, "proc renderReport {a b} { return [list $a $b] }\n");
+    lsp.open_ready(&lib, CROSS_FILE_LIB);
     let caller = unique_uri("tcl");
-    let src = "renderReport 1 2\nnoSuchCommandAnywhere 1\n";
-    lsp.open_ready(&caller, src);
+    lsp.open_ready(&caller, CROSS_FILE_CALLER);
     let diags = lsp.await_diagnostics_settled(&caller, Duration::from_secs(20), |d| {
-        w123_names(d).iter().any(|n| n == "noSuchCommandAnywhere")
+        w123_names(d).iter().any(|n| n == "puta")
     });
     let names = w123_names(&diags);
     assert!(
-        !names.iter().any(|n| n == "renderReport"),
+        !names.iter().any(|n| n == "putz"),
         "the sibling document defines it, got: {names:?}",
     );
     assert!(
-        names.iter().any(|n| n == "noSuchCommandAnywhere"),
+        names.iter().any(|n| n == "puta"),
         "TP control: got: {names:?}",
     );
 
-    let at_call = action_titles(&lsp.code_actions(&caller, caret(0, 4), json!([])));
+    let at_call = action_titles(&lsp.code_actions(&caller, caret(0, 1), json!([])));
     assert!(
         !has_replace_fix(&at_call),
         "the diagnostic is suppressed, so its quick-fix must be too: {at_call:?}",
     );
-    let at_unknown = action_titles(&lsp.code_actions(&caller, caret(1, 4), json!([])));
+    let at_unknown = action_titles(&lsp.code_actions(&caller, caret(1, 1), json!([])));
     assert!(has_replace_fix(&at_unknown), "TP control: {at_unknown:?}");
 }

--- a/rust/tcl-lsp-server/tests/e2e/issue923_idx80_mathfunc.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue923_idx80_mathfunc.rs
@@ -282,12 +282,22 @@ fn a_plain_cross_file_proc_call_still_draws_w123_by_default() {
     let lib = unique_uri("tcl");
     lsp.open_ready(&lib, "proc renderReport {a b} { return [list $a $b] }\n");
     let caller = unique_uri("tcl");
-    let diags = lsp.open_ready(&caller, "renderReport 1 2\n");
+    // The second call is the settle marker: nothing anywhere defines it, so a
+    // batch carrying its W123 is a deep-pass batch with the refinements run.
+    lsp.open_ready(&caller, "renderReport 1 2\nnoSuchCommandAnywhere 1\n");
+    let diags = lsp.await_diagnostics_settled(&caller, Duration::from_secs(20), |d| {
+        w123_names(d).iter().any(|n| n == "noSuchCommandAnywhere")
+    });
     assert!(
         w123_names(&diags).iter().any(|n| n == "renderReport"),
         "the project tier is opt-in; without it a cross-file bareword call is \
          still unknown, got: {:?}",
         w123_names(&diags),
+    );
+    let at_call = action_titles(&lsp.code_actions(&caller, caret(0, 4), json!([])));
+    assert!(
+        has_replace_fix(&at_call),
+        "…and the quick-fix is offered because the diagnostic is: {at_call:?}",
     );
 }
 

--- a/rust/tcl-lsp-server/tests/e2e/issue923_idx80_mathfunc.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue923_idx80_mathfunc.rs
@@ -111,7 +111,7 @@ fn caret(line: u32, ch: u32) -> Value {
 
 /// Titles offered at the `Pi()` call site (line 2) of [`VECTOR`].
 fn titles_at_pi(lsp: &mut Lsp, uri: &str) -> Vec<String> {
-    action_titles(&lsp.code_actions(uri, caret(2, 32), json!([])))
+    action_titles(&lsp.code_actions(uri, caret(2, 30), json!([])))
 }
 
 /// Titles offered at the genuinely-undefined call site (line 8) of [`VECTOR`].

--- a/rust/tcl-lsp-server/tests/e2e/references.rs
+++ b/rust/tcl-lsp-server/tests/e2e/references.rs
@@ -92,6 +92,71 @@ fn find_references_from_catch_resultvar_bareword_include_the_original_declaratio
     );
 }
 
+/// Issue #923 idx 48 — the two declaring tokens the finding actually named,
+/// which the e2e tier covered only by proxy (a proc parameter, a `catch`
+/// result variable): a `set` left-hand side and a `foreach` loop variable.
+/// The query anchored on the bare declaring word must return exactly what the
+/// same query anchored on a `$name` read returns; anything less is the
+/// asymmetry the finding reported.
+///
+/// Oracle — tclsh 8.6.16 and 9.0.4: `set y 10; puts $y; puts $y` prints
+/// `10` twice, so all three tokens name one cell.
+#[test]
+fn find_references_from_a_set_lhs_bareword_matches_the_read_anchored_query() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "set y 10\nputs $y\nputs $y\n";
+    lsp.open_ready(&uri, src);
+
+    // Anchored on the bare `y` of `set y 10` (line 0, col 4).
+    let from_decl = starts(&lsp.references(&uri, 0, 4, true));
+    // Anchored on the `$y` read (line 1, col 6).
+    let from_read = starts(&lsp.references(&uri, 1, 6, true));
+    assert_eq!(
+        from_decl, from_read,
+        "the declaring token and a read of the same variable must answer \
+         identically; decl: {from_decl:?} read: {from_read:?}",
+    );
+    let lines: std::collections::BTreeSet<i64> = from_decl.iter().map(|(l, _)| *l).collect();
+    assert!(
+        lines.contains(&0) && lines.contains(&1) && lines.contains(&2),
+        "all three occurrences must be present: {from_decl:?}",
+    );
+}
+
+/// The `foreach` loop-variable half of idx 48, in the shape `etsb.tcl` writes:
+/// the loop variable is declared bare and then read through `${cmd}` inside a
+/// `subst`ed proc body and a trace's `[list …]` prefix.
+///
+/// Oracle — tclsh 8.6.16 and 9.0.4: prints `cmd is alpha` / `cmd is beta`.
+#[test]
+fn find_references_from_a_foreach_loop_variable_bareword_declaration() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "set tracecmds {alpha beta}\nforeach cmd $tracecmds {\n    puts \"cmd is $cmd\"\n}\n";
+    lsp.open_ready(&uri, src);
+
+    // Anchored on the bare loop variable `cmd` (line 1, col 8).
+    let from_decl = starts(&lsp.references(&uri, 1, 8, true));
+    // Anchored on the `$cmd` read inside the body (line 2, col 19).
+    let from_read = starts(&lsp.references(&uri, 2, 19, true));
+    assert_eq!(
+        from_decl, from_read,
+        "decl: {from_decl:?} read: {from_read:?}",
+    );
+    let lines: std::collections::BTreeSet<i64> = from_decl.iter().map(|(l, _)| *l).collect();
+    assert!(
+        lines.contains(&1) && lines.contains(&2),
+        "the declaration and the body read must both be present: {from_decl:?}",
+    );
+    // The `$tracecmds` list word is a different variable and must not be
+    // dragged in.
+    assert!(
+        !from_decl.contains(&(1, 12)),
+        "the list word is not a reference to the loop variable: {from_decl:?}",
+    );
+}
+
 #[test]
 fn find_qualified_proc_call_sites() {
     let mut lsp = Lsp::tcl();

--- a/rust/tcl-mcp/src/tools.rs
+++ b/rust/tcl-mcp/src/tools.rs
@@ -830,8 +830,15 @@ fn code_actions(args: &Value) -> Value {
         end_line: arg_u32(args, "end_line"),
         end_character: arg_u32(args, "end_character"),
     };
-    let actions: Vec<Value> = tcl_lsp_core::code_actions::code_actions(source, range, Some(&analysis))
-        .iter()
+    // The MCP tool analyses one standalone source string with no workspace
+    // behind it, so the analyser's own diagnostics *are* the published set.
+    let actions: Vec<Value> = tcl_lsp_core::code_actions::code_actions(
+        source,
+        range,
+        Some(&analysis),
+        &analysis.diagnostics,
+    )
+    .iter()
         .map(|a| {
             let mut obj = json!({ "title": a.title, "kind": a.kind.as_str() });
             let m = obj.as_object_mut().expect("json object");


### PR DESCRIPTION
Part of #1019 (mathop/tracing cluster: idx 30, 47, 48, 80, 81, 92, 103). Does not close it — other clusters are still in flight.

Six of the seven findings re-verified as **already correct** and gained the regression tests they were missing. idx 80 was the one still broken, and it had two halves.

## idx 80, half one: the fix was unreachable by default

The cross-file mathfunc W123 false positive reproduced **under the default configuration**, because the analyser fix sat behind `crossFileResolution`, which defaults off.

`refine_workspace_index_w123` is now split into two tiers:

- **Always on:** an `expr` math-function call site whose *own* `resolution_candidates` — the `Tcl_FindCommand` order the analyser already recorded — match a workspace-indexed name. `::tcl::mathfunc` is one table per interpreter, so a workspace defining `Pi` there defines the only `Pi` any `expr` can call. That is a language fact, not a cross-file guess.
- **Still opt-in:** the bare-tail whole-project match. Left behind the toggle deliberately — over tcllib 2.0 (790 files, 450 W123s) it silences 396, of which 197 have no candidate to justify them.

The precision control proves the tiers are distinct: defining `::helpers::Pi` puts the tail `Pi` in the index but **not** `::tcl::mathfunc::Pi`, so the W123 must survive by default. It does.

## idx 80, half two: two surfaces disagreeing about the same fact

`textDocument/codeAction` never consulted the toggle or cross-file knowledge at all, so it kept offering the "Replace with `ni`" quick-fix even when diagnostics were clean.

That quick-fix is not merely noisy. Oracle, identical on 8.6 and 9.0:

```
expr {ni() / acos(-1.0)}   ->  missing operand
```

Applying the offered fix rewrites working code into a syntax error.

Fixed structurally rather than by duplicating the check: `published_analyser_diagnostics()` is now the single verdict, `textDocument/diagnostic` publishes it, and `textDocument/codeAction` lifts its quick-fixes from it. `code_actions()` gained an explicit `diagnostics` parameter separate from `analysis`, so reading the raw analyser set is no longer reachable by accident.

## Oracle verification

`tclsh8.6` and `tclsh9.0`, identical on both:

| Check | Result |
|---|---|
| Sibling `::tcl::mathfunc::Pi`, then `expr {Pi()}` | `3.141592653589793` — suppression correct |
| `expr {ni() / acos(-1.0)}` | `missing operand` — the quick-fix breaks working code |
| Only `::helpers::Pi` defined, `expr {Pi()}` | `invalid command name "tcl::mathfunc::Pi"` — tail match must not suppress |
| idx 92 `[namespace code [list Tracer]]` trace | fires as recorded |

## The six already-correct findings

- **idx 30** — mathfunc call-site reference asymmetry and the bare-call false positive are both fixed; `definition.rs` special-cases an expr-mathfunc call site before bareword fallback and excludes `tcl::mathfunc`-namespaced procs from bare resolution.
- **idx 47** — `trace add variable ... write [list procName ...]` is recorded as a real reference via `extract_list_quoted_prefix_head`.
- **idx 48** — a bare declaring token (`set x`, `foreach x`) resolves for hover, references, definition and rename, matching usage-anchored queries.
- **idx 81** — all 26 built-in expr math functions no longer draw false W123.
- **idx 92** — `[namespace code [list Tracer]]` trace-callback references are found symmetrically, with a no-double-count guard.
- **idx 103** — `tcl::mathfunc::isinf` in its plain-command spelling gets W002 dialect gating.

Sibling surfaces were checked rather than assumed: wherever references was fixed, code-lens, call-hierarchy and rename agree, verified by direct JSON-RPC calls.

## Tests

| Finding | Unit | e2e | VS Code |
|---|---|---|---|
| idx 30 | ✔ (+ bare-call TN) | — | lens pin |
| idx 47 | ✔ (trace literal + dynamic-head FP guard) | — | — |
| idx 48 | ✔ | ✔ | ✔ 2 |
| **idx 80** | ✔ 2 (incl. tail-precision control) | ✔ **6** | — |
| idx 92 | ✔ | ✔ | ✔ 3 |
| idx 103 | ✔ | ✔ (8.6 W002 / 9.0 clean) | — |

The six idx-80 e2e tests cover default-config diagnostics, the code-action half, a real on-disk workspace scan, and toggle-on agreement between the two surfaces. Quick-fix absence assertions use a **near-miss** name (`puta` → `puts`) so that asserting the fix is *not* offered actually proves something rather than passing because no fix would ever have been suggested.

One accuracy fix to a recorded oracle: the idx 92 VS Code test listed its three output lines in the wrong emission order — the driver prints `info:` before the trace fires. The lines were verbatim correct; the order was not.

## Gates

`cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo check --workspace --all-targets` clean; `cargo test -p tcl-lsp-core` 1794 plus 32 suites, 0 failed; `cargo test -p tcl-mcp` 16; `cargo test -p tcl-lsp-server --lib` 347; `cargo test -p tcl-lsp-server --test e2e` **1327 passed, 0 failed**; `make test-ext` **803 passing, 0 failing**.

No `#[allow(...)]`, and no `if cmd_name == "..."` — the fix dispatches off pre-existing analyser data (`is_mathfunc_call`, `resolution_candidates`). `tcl-compiler` is untouched.

Rebased onto current `rust` and re-verified there: `git diff --diff-filter=D --name-only origin/rust HEAD` is empty, the post-rebase stat is byte-identical to the pre-rebase merge-base stat, and #1273's artifacts all survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_