### PR TITLE
Gate rename on ensemble subcommand provenance; record deferred ensemble call sites (#1281, #1019)

### DIFF
--- a/editors/vscode/src/test/issue1281EnsembleRename.test.ts
+++ b/editors/vscode/src/test/issue1281EnsembleRename.test.ts
@@ -1,0 +1,120 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Issue #1281, editor-integration layer: an ensemble `-map` key must survive
+// a rename of the command it dispatches to, while a `-subcommands` entry —
+// which IS that command's tail — must follow it.
+//
+// This tier exists for the same reason issue #945 fault 1's does: the defect
+// is an edit that must *not* be in the set. A rename the user triggers from
+// the editor applies whatever comes back, unreviewed and in one keystroke, so
+// the assertion worth making through a real VS Code session is the negative
+// one — the dispatch line is absent from the entries the client would apply.
+// The deep TP/FP/TN coverage lives in the analyser, `tcl-lsp-core` and native
+// e2e suites (`rust/tcl-lsp-server/tests/e2e/issue1281_ensemble_rename.rs`),
+// including applying the emitted edits and running the result under tclsh
+// 8.6.14 / 9.0.4.
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { getDocUri, activate } from "./helper";
+
+async function renameEditLines(
+  docUri: vscode.Uri,
+  position: vscode.Position,
+  newName: string,
+): Promise<{ lines: number[]; texts: string[] }> {
+  const edit = (await vscode.commands.executeCommand(
+    "vscode.executeDocumentRenameProvider",
+    docUri,
+    position,
+    newName,
+  )) as vscode.WorkspaceEdit | undefined;
+  assert.ok(edit, "rename should return a workspace edit");
+  const entry = edit.entries().find(([uri]) => uri.toString() === docUri.toString());
+  assert.ok(entry, "should include edits for the fixture");
+  const [, textEdits] = entry;
+  return {
+    lines: textEdits.map((e) => e.range.start.line).sort((a, b) => a - b),
+    texts: textEdits.map((e) => e.newText),
+  };
+}
+
+suite("Issue #1281 ensemble rename provenance", () => {
+  test("renaming a -map target leaves the dispatch subcommand word alone", async () => {
+    const docUri = getDocUri("issue1281EnsembleMapRename.tcl");
+    await activate(docUri);
+
+    // `Show` in the `proc ::app::widget::Show` declaration (line 8, col 20).
+    const { lines, texts } = await renameEditLines(docUri, new vscode.Position(8, 20), "Display");
+
+    assert.ok(lines.includes(8), `the declaration follows the rename: ${JSON.stringify(lines)}`);
+    assert.ok(
+      lines.includes(9),
+      `the -map value names the target and must follow it: ${JSON.stringify(lines)}`,
+    );
+    assert.ok(
+      !lines.includes(10),
+      `the -map key is arbitrary — the dispatch word must not be rewritten: ${JSON.stringify(lines)}`,
+    );
+    assert.ok(
+      texts.every((t) => t.includes("Display")),
+      `every edit splices the new name: ${JSON.stringify(texts)}`,
+    );
+  });
+
+  test("renaming a -subcommands target still rewrites the dispatch word", async () => {
+    // The true negative for the gate above: the fix must not over-correct
+    // into never touching ensemble dispatch.
+    const docUri = getDocUri("issue1281EnsembleSubcommandsRename.tcl");
+    await activate(docUri);
+
+    // `alpha` in the `proc alpha` declaration (line 7, col 9).
+    const { lines } = await renameEditLines(docUri, new vscode.Position(7, 9), "beta");
+
+    assert.ok(lines.includes(7), `the declaration follows the rename: ${JSON.stringify(lines)}`);
+    assert.ok(
+      lines.includes(8),
+      `the -subcommands entry is the target's tail: ${JSON.stringify(lines)}`,
+    );
+    assert.ok(
+      lines.includes(10),
+      `the dispatch word must follow the target under -subcommands: ${JSON.stringify(lines)}`,
+    );
+  });
+
+  test("find-references still reports the -map dispatch site", async () => {
+    // The gate is a rename gate, not a reference rule — the dispatch site is
+    // a genuine reference under either provenance, and the editor surfaces it.
+    const docUri = getDocUri("issue1281EnsembleMapRename.tcl");
+    await activate(docUri);
+
+    const locations = (await vscode.commands.executeCommand(
+      "vscode.executeReferenceProvider",
+      docUri,
+      new vscode.Position(8, 20),
+    )) as vscode.Location[];
+    const lines = (locations ?? [])
+      .filter((l) => l.uri.toString() === docUri.toString())
+      .map((l) => l.range.start.line);
+    assert.ok(
+      lines.includes(10),
+      `the dispatch site stays a reference even though rename leaves it alone: ${JSON.stringify(lines)}`,
+    );
+  });
+});

--- a/editors/vscode/src/test/issue923NsPkgAudit.test.ts
+++ b/editors/vscode/src/test/issue923NsPkgAudit.test.ts
@@ -44,6 +44,10 @@ suite("Issue #923 audit: namespaces and packages", () => {
     }
   }
 
+  function codeOf(d: vscode.Diagnostic): string {
+    return typeof d.code === "object" && d.code !== null ? String(d.code.value) : String(d.code);
+  }
+
   function hoverText(hovers: vscode.Hover[]): string {
     return hovers
       .flatMap((h) => h.contents)
@@ -196,18 +200,29 @@ suite("Issue #923 audit: namespaces and packages", () => {
   // "{ $ns"` prints `{ ctx`, so the variable really is read and the `set`
   // before it is not a dead store.
   test("idx 64: an unmatched brace in a quoted string does not make the set a dead store", async () => {
-    // The trailing unbraced `expr` yields W100, proving analysis ran — the
-    // established way this suite asserts the *absence* of a code.
-    const src = 'set i923ns "ctx"\nputs "{ $i923ns"\nexpr 1 + 1\n';
+    // The trailing unbraced `expr` carries a substitution, so it yields W100 —
+    // the established way this suite proves analysis ran before asserting the
+    // *absence* of a code. It uses its own variables so the read under test is
+    // still only the one beside the unmatched brace.
+    const src =
+      'set i923ns "ctx"\n' +
+      'puts "{ $i923ns"\n' +
+      "set i923a 1\n" +
+      "set i923y [expr $i923a + 1]\n" +
+      "puts $i923y\n";
     await withContent(src, async () => {
-      const diags = await waitForDiagnostics(docUri, { minCount: 1, timeout: 20_000 });
-      const codeOf = (d: vscode.Diagnostic): string =>
-        typeof d.code === "object" && d.code !== null ? String(d.code.value) : String(d.code);
-      const codes = diags.map(codeOf);
-      assert.ok(codes.includes("W100"), `expected analysis to run (W100) in [${codes}]`);
-      assert.ok(
-        !codes.includes("W220") && !codes.includes("W211"),
-        `\`$i923ns\` is read after the unmatched \`{\`, so no dead-store hint may fire: [${codes}]`,
+      const diags = await waitForDiagnostics(docUri, {
+        timeout: 20_000,
+        predicate: (d) => d.some((x) => codeOf(x) === "W100"),
+      });
+      const dump = JSON.stringify(diags.map((d) => [d.range.start.line, codeOf(d)]));
+      const onSet = diags.filter(
+        (d) => d.range.start.line === 0 && ["W211", "W220"].includes(codeOf(d)),
+      );
+      assert.deepStrictEqual(
+        onSet.map(codeOf),
+        [],
+        `\`$i923ns\` is read after the unmatched \`{\`, so no dead-store hint may fire on its \`set\`: ${dump}`,
       );
     });
   });

--- a/editors/vscode/src/test/issue923NsPkgAudit.test.ts
+++ b/editors/vscode/src/test/issue923NsPkgAudit.test.ts
@@ -1,0 +1,331 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { getDocUri, activate, setTestContent, pollUntil, waitForDiagnostics } from "./helper";
+
+// Issue #923 differential audit — the namespaces and packages/autoindex/source
+// findings, at the editor tier. Every case below was verified against real
+// tclsh (8.6.16 and 9.0.4) before it was written; the oracle transcript is
+// quoted on each test. The tier matters because everything else about these
+// findings is pinned inside the server: a regression in the client-visible
+// wiring (positions, provider registration, the shapes VS Code asks for)
+// would not show up anywhere else.
+
+suite("Issue #923 audit: namespaces and packages", () => {
+  const docUri = getDocUri("issue923NsPkgAudit.tcl");
+  const libUri = getDocUri("issue923NsPkgAuditLib.tcl");
+
+  async function withContent<T>(content: string, body: () => Promise<T>): Promise<T> {
+    const doc = await activate(docUri);
+    const editor = await vscode.window.showTextDocument(doc);
+    const original = doc.getText();
+    try {
+      await setTestContent(editor, content);
+      return await body();
+    } finally {
+      await setTestContent(editor, original);
+    }
+  }
+
+  function hoverText(hovers: vscode.Hover[]): string {
+    return hovers
+      .flatMap((h) => h.contents)
+      .map((c) => (typeof c === "string" ? c : (c as vscode.MarkdownString).value))
+      .join("\n");
+  }
+
+  async function hoverAt(position: vscode.Position): Promise<string> {
+    const hovers = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeHoverProvider", docUri, position),
+      (r) => Array.isArray(r) && r.length > 0,
+      { timeout: 15_000, label: `hover at ${position.line}:${position.character}` },
+    )) as vscode.Hover[];
+    return hoverText(hovers);
+  }
+
+  // idx 85 — `namespace ensemble create -map` inside a proc declared with a
+  // fully-qualified name at top level. Oracle (tclsh 8.6.16 / 9.0.4): the
+  // script prints `shown`, so `::app::widget show` really dispatches to
+  // `::app::widget::Show`. Go-to-definition answered; find-references did not.
+  test("idx 85: an ensemble dispatch site is found from the declaration and from itself", async () => {
+    const src =
+      "namespace eval ::i923w::widget {\n" + // 0
+      "    variable state 0\n" + // 1
+      "}\n" + // 2
+      "proc ::i923w::widget::Setup {} {\n" + // 3
+      "    namespace ensemble create -map {\n" + // 4
+      "        show ::i923w::widget::Show\n" + // 5
+      "    }\n" + // 6
+      "}\n" + // 7
+      'proc ::i923w::widget::Show {} { puts "shown" }\n' + // 8
+      "::i923w::widget::Setup\n" + // 9
+      "puts [::i923w::widget show]\n"; // 10
+    await withContent(src, async () => {
+      const lineOf = (locs: vscode.Location[]): number[] =>
+        locs.map((l) => l.range.start.line).sort((a, b) => a - b);
+
+      // `Show` in its declaration on line 8 starts at column 22.
+      const fromDecl = (await pollUntil(
+        () =>
+          vscode.commands.executeCommand(
+            "vscode.executeReferenceProvider",
+            docUri,
+            new vscode.Position(8, 23),
+          ),
+        (r) => Array.isArray(r) && (r as vscode.Location[]).some((l) => l.range.start.line === 10),
+        { timeout: 15_000, label: "references from the ensemble target declaration" },
+      )) as vscode.Location[];
+      assert.ok(
+        lineOf(fromDecl).includes(10),
+        `the \`[::i923w::widget show]\` dispatch must be a reference: ${JSON.stringify(lineOf(fromDecl))}`,
+      );
+
+      // `show` in the dispatch on line 10 starts at column 22.
+      const fromCall = (await vscode.commands.executeCommand(
+        "vscode.executeReferenceProvider",
+        docUri,
+        new vscode.Position(10, 23),
+      )) as vscode.Location[];
+      assert.deepStrictEqual(
+        lineOf(fromCall),
+        lineOf(fromDecl),
+        "both query directions must return the same reference set",
+      );
+    });
+  });
+
+  // idx 3 / idx 4 — tcllib's `textutil::adjust` submodule reached through a
+  // wildcard import. Oracle (tclsh 8.6.16 / 9.0.4 with tcllib 2.0):
+  // `namespace origin adjust` -> `::textutil::adjust::adjust`.
+  test("idx 3/4: a wildcard-imported textutil submodule command hovers qualified", async () => {
+    const src =
+      "package require textutil::adjust\n" +
+      "namespace import textutil::adjust::*\n" +
+      'set wrapped [adjust "a long help string" -length 20]\n' +
+      'set final [indent $wrapped "  "]\n';
+    await withContent(src, async () => {
+      const adjust = await hoverAt(new vscode.Position(2, 14));
+      assert.ok(
+        adjust.includes("textutil::adjust::adjust"),
+        `bare \`adjust\` must hover as the three-segment submodule command: ${adjust}`,
+      );
+      const indent = await hoverAt(new vscode.Position(3, 12));
+      assert.ok(
+        indent.includes("textutil::adjust::indent"),
+        `bare \`indent\` must hover as \`textutil::adjust::indent\`: ${indent}`,
+      );
+    });
+  });
+
+  // idx 102 — hover on the `{file}` *parameter declaration* must not be
+  // misattributed to the builtin `file` command. Oracle (tclsh 8.6.16 /
+  // 9.0.4): the parameter deterministically drives which file is sourced.
+  test("idx 102: a parameter named after a builtin hovers as a variable", async () => {
+    const src =
+      "proc ::i923tk::SourceLibFile {file} {\n" +
+      "    namespace eval :: [list source [file join $::i923tk_library $file.tcl]]\n" +
+      "}\n";
+    await withContent(src, async () => {
+      // The `file` of the parameter list `{file}` on line 0 starts at col 29.
+      const decl = await hoverAt(new vscode.Position(0, 30));
+      assert.ok(decl.includes("Variable"), `the parameter declaration must be a variable: ${decl}`);
+      assert.ok(
+        !decl.includes("file dirname") && !decl.includes("file exists"),
+        `it must not be misattributed to the builtin \`file\` command: ${decl}`,
+      );
+    });
+  });
+
+  // idx 43 — `ticklecharts`' foreach-installed procs. Oracle (tclsh 8.6.16 /
+  // 9.0.4): `new elist {1 2 3}` prints `elist {1 2 3}`, so each literal loop
+  // element really becomes a callable command.
+  test("idx 43: foreach-installed procs are outlined by their real names", async () => {
+    const src =
+      "namespace eval i923tc {\n" +
+      "    namespace ensemble create -command ::i923new -subcommands {elist elist.n}\n" +
+      "}\n" +
+      "foreach ptype {elist elist.n} {\n" +
+      "    proc i923tc::${ptype} {args} [string map [list %P% $ptype] {\n" +
+      '        return "%P% $args"\n' +
+      "    }]\n" +
+      "}\n";
+    await withContent(src, async () => {
+      const symbols = (await pollUntil(
+        () => vscode.commands.executeCommand("vscode.executeDocumentSymbolProvider", docUri),
+        (r) => Array.isArray(r) && r.length > 0,
+        { timeout: 15_000, label: "document symbols for the foreach-installed procs" },
+      )) as vscode.DocumentSymbol[];
+      const names: string[] = [];
+      const walk = (items: vscode.DocumentSymbol[]): void => {
+        for (const s of items) {
+          names.push(s.name);
+          walk(s.children ?? []);
+        }
+      };
+      walk(symbols);
+      const dump = JSON.stringify(names);
+      for (const want of ["elist", "elist.n"]) {
+        assert.ok(names.includes(want), `the outline must list \`${want}\`: ${dump}`);
+      }
+      assert.ok(
+        !names.some((n) => n.includes("${ptype}")),
+        `the outline must not show the unsubstituted placeholder: ${dump}`,
+      );
+    });
+  });
+
+  // idx 64 — an unmatched literal `{` inside a double-quoted string does not
+  // stop substitution. Oracle (tclsh 8.6.16 / 9.0.4): `set ns "ctx"; puts
+  // "{ $ns"` prints `{ ctx`, so the variable really is read and the `set`
+  // before it is not a dead store.
+  test("idx 64: an unmatched brace in a quoted string does not make the set a dead store", async () => {
+    // The trailing unbraced `expr` yields W100, proving analysis ran — the
+    // established way this suite asserts the *absence* of a code.
+    const src = 'set i923ns "ctx"\nputs "{ $i923ns"\nexpr 1 + 1\n';
+    await withContent(src, async () => {
+      const diags = await waitForDiagnostics(docUri, { minCount: 1, timeout: 20_000 });
+      const codeOf = (d: vscode.Diagnostic): string =>
+        typeof d.code === "object" && d.code !== null ? String(d.code.value) : String(d.code);
+      const codes = diags.map(codeOf);
+      assert.ok(codes.includes("W100"), `expected analysis to run (W100) in [${codes}]`);
+      assert.ok(
+        !codes.includes("W220") && !codes.includes("W211"),
+        `\`$i923ns\` is read after the unmatched \`{\`, so no dead-store hint may fire: [${codes}]`,
+      );
+    });
+  });
+
+  // idx 41 — a computed `source` path must resolve to its real target, and
+  // must never be percent-encoded raw into a bogus `file://` URI. Oracle
+  // (tclsh 8.6.16 / 9.0.4): `set dir [file dirname [info script]]; source
+  // [file join $dir x.tcl]` loads the sibling beside the sourcing file.
+  test("idx 41: a computed source path resolves, an unfoldable one produces no link", async () => {
+    const src =
+      "set i923dir [file dirname [info script]]\n" +
+      "source [file join $i923dir issue923NsPkgAuditLib.tcl]\n" +
+      "source [file join $i923undeclared .. missing.tcl]\n";
+    await withContent(src, async () => {
+      const links = (await pollUntil(
+        () => vscode.commands.executeCommand("vscode.executeLinkProvider", docUri),
+        (r) => Array.isArray(r),
+        { timeout: 15_000, label: "document links" },
+      )) as vscode.DocumentLink[];
+      const dump = JSON.stringify(links.map((l) => [l.range.start.line, l.target?.toString()]));
+      const resolved = links.find((l) => l.range.start.line === 1);
+      assert.ok(resolved?.target, `the computed sibling path must produce a link: ${dump}`);
+      assert.ok(
+        resolved.target.fsPath.endsWith("issue923NsPkgAuditLib.tcl"),
+        `it must resolve to the real sibling file: ${dump}`,
+      );
+      assert.ok(
+        !links.some((l) => l.range.start.line === 2),
+        `an unfoldable computed path must produce no link at all: ${dump}`,
+      );
+      for (const l of links) {
+        const t = l.target?.toString() ?? "";
+        assert.ok(
+          !t.includes("%5B") && !t.includes("$") && !t.includes("["),
+          `no link may carry unevaluated substitution text: ${dump}`,
+        );
+      }
+    });
+  });
+
+  // idx 65 / 75 — a namespace variable whose declaration lives in a sibling
+  // document that never references this one. Oracle (tclsh 8.6.16 / 9.0.4,
+  // sourcing both): `puts $::i923audit::colors::i923auditPalette` prints
+  // `red green blue`, so the two files really populate one namespace.
+  test("idx 65/75: a cross-document namespace variable resolves both ways", async () => {
+    // Open the declaring document so the server holds both.
+    await activate(libUri);
+    const src = "puts $::i923audit::colors::i923auditPalette\n";
+    await withContent(src, async () => {
+      const defs = (await pollUntil(
+        () =>
+          vscode.commands.executeCommand(
+            "vscode.executeDefinitionProvider",
+            docUri,
+            new vscode.Position(0, 36),
+          ),
+        (r) => Array.isArray(r) && (r as vscode.Location[]).length > 0,
+        { timeout: 20_000, label: "cross-document namespace variable definition" },
+      )) as vscode.Location[];
+      assert.ok(
+        defs.some((d) => d.uri.fsPath.endsWith("issue923NsPkgAuditLib.tcl")),
+        `the sibling document's \`variable\` declaration must be the target: ${JSON.stringify(
+          defs.map((d) => [d.uri.fsPath, d.range.start.line]),
+        )}`,
+      );
+
+      const refs = (await pollUntil(
+        () =>
+          vscode.commands.executeCommand(
+            "vscode.executeReferenceProvider",
+            libUri,
+            new vscode.Position(5, 15),
+          ),
+        (r) =>
+          Array.isArray(r) &&
+          (r as vscode.Location[]).some((l) => l.uri.fsPath.endsWith("issue923NsPkgAudit.tcl")),
+        { timeout: 20_000, label: "cross-document namespace variable references" },
+      )) as vscode.Location[];
+      assert.ok(
+        refs.some((l) => l.uri.fsPath.endsWith("issue923NsPkgAudit.tcl")),
+        `find-references from the declaration must reach the consumer document: ${JSON.stringify(
+          refs.map((l) => [l.uri.fsPath, l.range.start.line]),
+        )}`,
+      );
+    });
+  });
+
+  // idx 44 — `${ns}::setdef`, where `ns` comes from `[namespace qualifiers
+  // [self class]]`. Oracle (tclsh 8.6.16 / 9.0.4): the constructor really
+  // dispatches to `::i923tc::setdef`, printing `id {-default hello}`.
+  test("idx 44: a folded ${ns}:: head navigates to its proc", async () => {
+    const src =
+      "namespace eval i923tc {}\n" +
+      "proc i923tc::setdef {d key args} { return 1 }\n" +
+      "oo::class create i923tc::dataset {\n" +
+      "    variable options\n" +
+      "    constructor {value} {\n" +
+      "        set ns [namespace qualifiers [self class]]\n" +
+      "        ${ns}::setdef options id -default $value\n" +
+      "    }\n" +
+      "}\n";
+    await withContent(src, async () => {
+      const defs = (await pollUntil(
+        () =>
+          vscode.commands.executeCommand(
+            "vscode.executeDefinitionProvider",
+            docUri,
+            new vscode.Position(6, 17),
+          ),
+        (r) => Array.isArray(r) && (r as vscode.Location[]).length > 0,
+        { timeout: 15_000, label: "definition through a folded ${ns}:: head" },
+      )) as vscode.Location[];
+      assert.ok(
+        defs.some((d) => d.range.start.line === 1),
+        `the \`\${ns}::setdef\` head must reach the proc declaration: ${JSON.stringify(
+          defs.map((d) => d.range.start.line),
+        )}`,
+      );
+    });
+  });
+});

--- a/editors/vscode/testFixture/issue1281EnsembleMapRename.tcl
+++ b/editors/vscode/testFixture/issue1281EnsembleMapRename.tcl
@@ -1,0 +1,11 @@
+# Issue #1281 — the ensemble `-map` key is an arbitrary name with no required
+# relationship to its target's tail, so renaming `::app::widget::Show` must
+# rewrite the declaration and the `-map` value but leave the dispatch word
+# `show` alone.
+#
+# tclsh 8.6.14 / 9.0.4, identical: `::app::widget show` prints "showing";
+# `::app::widget Show` is `unknown or ambiguous subcommand "Show": must be show`.
+namespace eval ::app::widget {}
+proc ::app::widget::Show {} { return "showing" }
+namespace ensemble create -command ::app::widget -map {show ::app::widget::Show}
+puts [::app::widget show]

--- a/editors/vscode/testFixture/issue1281EnsembleSubcommandsRename.tcl
+++ b/editors/vscode/testFixture/issue1281EnsembleSubcommandsRename.tcl
@@ -1,0 +1,11 @@
+# Issue #1281 — the `-subcommands` entry IS the target's tail, so renaming
+# `alpha` must rewrite the declaration, the `-subcommands` entry and the
+# dispatch word together.
+#
+# tclsh 8.6.14 / 9.0.4, identical: with the proc renamed to `beta` but the
+# entry left at `alpha`, `::app::widget alpha` is `invalid command name "alpha"`.
+namespace eval ::app::widget {
+    proc alpha {} { return "alpha!" }
+    namespace ensemble create -command ::app::widget -subcommands {alpha}
+}
+puts [::app::widget alpha]

--- a/editors/vscode/testFixture/issue923NsPkgAudit.tcl
+++ b/editors/vscode/testFixture/issue923NsPkgAudit.tcl
@@ -1,0 +1,9 @@
+# Issue #923 differential audit (namespaces / packages closeout): placeholder
+# fixture. `issue923NsPkgAudit.test.ts` replaces this content at runtime (via
+# setTestContent) with each specific repro snippet -- checking in one file per
+# tiny snippet would bloat the repo for no benefit. The one case that genuinely
+# needs a second document on disk (a cross-file namespace variable) uses the
+# committed `issue923NsPkgAuditLib.tcl` beside this file.
+proc issue923NsPkgAuditPlaceholder {} {
+    return 1
+}

--- a/editors/vscode/testFixture/issue923NsPkgAuditLib.tcl
+++ b/editors/vscode/testFixture/issue923NsPkgAuditLib.tcl
@@ -1,0 +1,7 @@
+# Issue #923 differential audit, findings idx 65 / 75: the *declaring* half of
+# a namespace whose consumer lives in a sibling document. Neither file
+# references the other; tclsh 9.0.4 and 8.6.16 both populate one real
+# `::i923audit::colors` namespace when both are sourced.
+namespace eval i923audit::colors {
+    variable i923auditPalette {red green blue}
+}

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -2542,11 +2542,10 @@ impl Analyser {
             else {
                 continue;
             };
-            if !self
-                .ensemble_record_offsets
-                .get(&cand.ensemble)
-                .is_some_and(|&off| off < cand.span.start())
-            {
+            let Some(&declared_at) = self.ensemble_record_offsets.get(&cand.ensemble) else {
+                continue;
+            };
+            if declared_at >= cand.span.start() {
                 continue;
             }
             self.push_command_reference_with_policy(cand.sub, cand.span, target, cand.argc, true);

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -809,6 +809,7 @@ impl Analyser {
                     rename_safe: true,
                     existence_probe: false,
                     is_mathfunc_call: false,
+                    ensemble_dispatch: None,
                 },
             );
 
@@ -970,6 +971,7 @@ impl Analyser {
                 rename_safe: true,
                 existence_probe: false,
                 is_mathfunc_call: false,
+                ensemble_dispatch: None,
             },
         );
     }
@@ -2119,6 +2121,7 @@ impl Analyser {
                     rename_safe: true,
                     existence_probe: false,
                     is_mathfunc_call: false,
+                    ensemble_dispatch: None,
                 },
             );
         }
@@ -2168,6 +2171,45 @@ impl Analyser {
                 rename_safe: true,
                 existence_probe,
                 is_mathfunc_call: false,
+                ensemble_dispatch: None,
+            },
+        );
+    }
+
+    /// [`Self::push_command_reference`] for the **subcommand word** of an
+    /// `<ensemble> <sub> …` dispatch: an existence-probed reference to the
+    /// mapped target that also carries the mapping's provenance
+    /// ([`crate::signature_scan::types::SignatureCommandInvocation::ensemble_dispatch`],
+    /// issue #1281), so rename can tell a `-map` key — an arbitrary name it
+    /// must leave alone — from a `-subcommands` entry, which is the target's
+    /// own tail and has to move with it.
+    ///
+    /// A dedicated method rather than another parameter on
+    /// [`Self::push_command_reference_with_policy`]: every dispatch word is
+    /// existence-probed for the same reason (`make` is never independently
+    /// callable — issue #945 fault 9), so the two facts always travel
+    /// together and callers cannot pair them wrongly.
+    pub(in crate::analyser) fn push_ensemble_dispatch_reference(
+        &mut self,
+        written: String,
+        span: Span,
+        entry: &super::types::EnsembleSubcommandTarget,
+        argc: Option<usize>,
+    ) {
+        self.result.command_invocations.push(
+            crate::signature_scan::types::SignatureCommandInvocation {
+                name: written,
+                range: span,
+                resolved_qualified_name: Some(entry.target.clone()),
+                resolution_candidates: Vec::new(),
+                argc,
+                callback_arity: None,
+                callback_baked_args: 0,
+                indirect: false,
+                rename_safe: true,
+                existence_probe: true,
+                is_mathfunc_call: false,
+                ensemble_dispatch: Some(entry.provenance),
             },
         );
     }
@@ -2199,6 +2241,7 @@ impl Analyser {
                 rename_safe: true,
                 existence_probe: false,
                 is_mathfunc_call: true,
+                ensemble_dispatch: None,
             },
         );
     }
@@ -2495,14 +2538,14 @@ impl Analyser {
         span: Span,
         argc: Option<usize>,
     ) {
-        if let Some(target) = self
+        if let Some(entry) = self
             .result
             .ensemble_subcommand_targets
             .get(resolved_cmd)
             .and_then(|subs| subs.get(sub))
             .cloned()
         {
-            self.push_command_reference_with_policy(sub.to_owned(), span, target, argc, true);
+            self.push_ensemble_dispatch_reference(sub.to_owned(), span, &entry, argc);
             return;
         }
         // Nothing deferred yet means nothing can *become* visible before
@@ -2533,7 +2576,7 @@ impl Analyser {
     pub(super) fn flush_pending_ensemble_subcommand_invocations(&mut self) {
         let pending = std::mem::take(&mut self.pending_ensemble_subcommands);
         for cand in pending {
-            let Some(target) = self
+            let Some(entry) = self
                 .result
                 .ensemble_subcommand_targets
                 .get(&cand.ensemble)
@@ -2548,7 +2591,7 @@ impl Analyser {
             if declared_at >= cand.span.start() {
                 continue;
             }
-            self.push_command_reference_with_policy(cand.sub, cand.span, target, cand.argc, true);
+            self.push_ensemble_dispatch_reference(cand.sub, cand.span, &entry, cand.argc);
         }
     }
 
@@ -3231,6 +3274,7 @@ impl Analyser {
                     rename_safe: true,
                     existence_probe: false,
                     is_mathfunc_call: false,
+                    ensemble_dispatch: None,
                 },
             );
         }
@@ -3282,6 +3326,7 @@ impl Analyser {
                     rename_safe: true,
                     existence_probe: false,
                     is_mathfunc_call: false,
+                    ensemble_dispatch: None,
                 },
             );
         }

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -5518,9 +5518,6 @@ mod tests {
     /// drives which file is sourced, so the read is real.
     #[test]
     fn a_list_built_body_records_its_parameter_reads_923_idx102() {
-        let src = "proc ::app::SourceLibFile {file} {\n    \
-                   namespace eval :: [list source [file join $::app::lib_dir $file.tcl]]\n}\n";
-        let r = Analyser::new().analyse(src, "tcl8.6").clone();
         // The read lands on the *scope tree*'s copy of the parameter — the
         // binding the LSP's variable providers resolve through.
         fn find<'a>(
@@ -5532,6 +5529,9 @@ mod tests {
                 .get(name)
                 .or_else(|| scope.children.iter().find_map(|c| find(c, name)))
         }
+        let src = "proc ::app::SourceLibFile {file} {\n    \
+                   namespace eval :: [list source [file join $::app::lib_dir $file.tcl]]\n}\n";
+        let r = Analyser::new().analyse(src, "tcl8.6").clone();
         let param = find(&r.global_scope, "file")
             .expect("the `file` parameter must be recorded in the proc scope");
         // The recorded span covers the whole `$file` substitution, `$` included.

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -2446,16 +2446,10 @@ impl Analyser {
         if arg_expand_in.get(1).copied().unwrap_or(false) {
             return;
         }
-        let Some(sub_map) = self.result.ensemble_subcommand_targets.get(resolved_cmd) else {
-            return;
-        };
         let Some(sub) = args.first() else { return };
         if crate::naming::is_dynamic_word(sub) {
             return;
         }
-        let Some(target) = sub_map.get(sub).cloned() else {
-            return;
-        };
         let Some(tok) = arg_tokens_in.get(1) else {
             return;
         };
@@ -2472,7 +2466,91 @@ impl Analyser {
         } else {
             Some(args.len() - 1)
         };
-        self.push_command_reference_with_policy(sub.clone(), tok.span, target, sub_argc, true);
+        self.record_or_defer_ensemble_subcommand(resolved_cmd, sub, tok.span, sub_argc);
+    }
+
+    /// Record the existence-probed subcommand reference for
+    /// `<ensemble> <sub>` — now if the ensemble's map is already known,
+    /// else queued for [`Self::flush_pending_ensemble_subcommand_invocations`]
+    /// (issue #923 idx 85).
+    ///
+    /// The queue is filled **only** by the per-item shell pass. The
+    /// whole-file DFS walks each proc/method body at its definition point,
+    /// so its map already holds every ensemble a body declared earlier in
+    /// the file; the shell pass defers those bodies, so an ensemble created
+    /// inside `proc ::app::widget::Setup {…}` is invisible to it and every
+    /// later `::app::widget show` call site was silently dropped — leaving
+    /// find-references / rename / code-lens / call-hierarchy unable to
+    /// enumerate call sites that go-to-definition (an on-demand lookup
+    /// against the finished analysis) resolved perfectly well.
+    ///
+    /// The replay is gated on the ensemble's own recording preceding the
+    /// call site, which is exactly the visibility the whole-file DFS has —
+    /// so the two walk strategies produce identical `command_invocations`
+    /// (the `per_item == analyse` corpus gate holds).
+    fn record_or_defer_ensemble_subcommand(
+        &mut self,
+        resolved_cmd: &str,
+        sub: &str,
+        span: Span,
+        argc: Option<usize>,
+    ) {
+        if let Some(target) = self
+            .result
+            .ensemble_subcommand_targets
+            .get(resolved_cmd)
+            .and_then(|subs| subs.get(sub))
+            .cloned()
+        {
+            self.push_command_reference_with_policy(sub.to_owned(), span, target, argc, true);
+            return;
+        }
+        // Nothing deferred yet means nothing can *become* visible before
+        // this offset either, so there is no candidate to hold.
+        if !self.defer_proc_bodies || self.deferred_bodies.is_empty() {
+            return;
+        }
+        self.pending_ensemble_subcommands
+            .push(super::state::PendingEnsembleSubcommand {
+                ensemble: resolved_cmd.to_owned(),
+                sub: sub.to_owned(),
+                span,
+                argc,
+            });
+    }
+
+    /// Replay every [`Self::record_or_defer_ensemble_subcommand`] miss
+    /// against the finished `ensemble_subcommand_targets` map, once every
+    /// deferred body has been walked and grafted (issue #923 idx 85).
+    ///
+    /// A candidate counts only when the ensemble's own
+    /// `namespace ensemble create|configure` recording **precedes** the call
+    /// site — the whole-file DFS's visibility rule, reproduced here so the
+    /// per-item walk records the same invocation set. Where the ensemble's
+    /// name or its `-map` is dynamic nothing is recorded at all (the map
+    /// never gains the entry), so the abstention is inherited from the one
+    /// place that decides it rather than re-decided here.
+    pub(super) fn flush_pending_ensemble_subcommand_invocations(&mut self) {
+        let pending = std::mem::take(&mut self.pending_ensemble_subcommands);
+        for cand in pending {
+            let Some(target) = self
+                .result
+                .ensemble_subcommand_targets
+                .get(&cand.ensemble)
+                .and_then(|subs| subs.get(&cand.sub))
+                .cloned()
+            else {
+                continue;
+            };
+            if !self
+                .ensemble_record_offsets
+                .get(&cand.ensemble)
+                .is_some_and(|&off| off < cand.span.start())
+            {
+                continue;
+            }
+            self.push_command_reference_with_policy(cand.sub, cand.span, target, cand.argc, true);
+        }
     }
 
     /// Walk every argument's source slice for ``[cmd ...]``
@@ -3137,16 +3215,9 @@ impl Analyser {
             // `argc` here is "args after the head" (the subcommand word
             // included), so it shifts by one to become "args after the
             // subcommand word" — the same convention that function uses.
-            if let Some((sub, sub_span)) = sub_candidate
-                && let Some(target) = self
-                    .result
-                    .ensemble_subcommand_targets
-                    .get(&resolved)
-                    .and_then(|subs| subs.get(&sub))
-                    .cloned()
-            {
+            if let Some((sub, sub_span)) = sub_candidate {
                 let sub_argc = argc.map(|a| a.saturating_sub(1));
-                self.push_command_reference_with_policy(sub, sub_span, target, sub_argc, true);
+                self.record_or_defer_ensemble_subcommand(&resolved, &sub, sub_span, sub_argc);
             }
             self.result.command_invocations.push(
                 crate::signature_scan::types::SignatureCommandInvocation {

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -5501,4 +5501,70 @@ mod tests {
             r.diagnostics,
         );
     }
+
+    /// Issue #923 differential-audit finding idx 102 (fixed under #1138) —
+    /// [`Analyser::analyse_list_quoted_body`]'s *variable-reference*
+    /// recording, isolated at the analyser tier.
+    ///
+    /// `analyse_body`'s gate used to treat any non-`Str` body token as an
+    /// opaque barrier, so a script argument **built** with `list` — Tk's own
+    /// `library/tk.tcl` writes `namespace eval :: [list source [file join
+    /// $::tk_library $file.tcl]]` — never had `record_arg_var_reads` run
+    /// inside it and the enclosing proc's parameter looked unread from its
+    /// own scope.  Coverage for this lived only at the e2e / VS Code tiers,
+    /// testing through find-references and semantic tokens; nothing pinned
+    /// the analyser primitive that supplies them.
+    ///
+    /// Oracle (tclsh 8.6.16 and 9.0.4): the parameter deterministically
+    /// drives which file is sourced, so the read is real.
+    #[test]
+    fn a_list_built_body_records_its_parameter_reads_923_idx102() {
+        let src = "proc ::app::SourceLibFile {file} {\n    \
+                   namespace eval :: [list source [file join $::app::lib_dir $file.tcl]]\n}\n";
+        let r = Analyser::new().analyse(src, "tcl8.6").clone();
+        // The read lands on the *scope tree*'s copy of the parameter — the
+        // binding the LSP's variable providers resolve through.
+        fn find<'a>(
+            scope: &'a super::super::types::Scope,
+            name: &str,
+        ) -> Option<&'a super::super::types::VarDef> {
+            scope
+                .variables
+                .get(name)
+                .or_else(|| scope.children.iter().find_map(|c| find(c, name)))
+        }
+        let param = find(&r.global_scope, "file")
+            .expect("the `file` parameter must be recorded in the proc scope");
+        // The recorded span covers the whole `$file` substitution, `$` included.
+        let read_start = u32::try_from(src.find("$file.tcl").expect("the read is in the source"))
+            .expect("offset fits u32");
+        assert!(
+            param.references.iter().any(|s| s.start() == read_start),
+            "the `$file` read inside the list-built body must be recorded on the \
+             parameter (expected a reference at {read_start}): {:?}",
+            param.references,
+        );
+    }
+
+    /// TN control for the above — a body that is genuinely dynamic
+    /// (`[gen]`, not a statically known `list`-built command) stays the
+    /// opaque barrier it always was, so nothing inside it is attributed.
+    #[test]
+    fn a_dynamic_body_records_no_parameter_reads_923_idx102() {
+        let src = "proc ::app::Run {file} {\n    namespace eval :: [gen $file]\n}\n";
+        let r = Analyser::new().analyse(src, "tcl8.6").clone();
+        // The `$file` inside `[gen $file]` is a real argument read of the
+        // enclosing command substitution and is recorded once; what must not
+        // happen is the `[gen …]` body being *walked* as a script.
+        assert!(
+            !r.command_invocations
+                .iter()
+                .any(|i| i.name == "source" || i.name == "namespace eval"),
+            "a dynamic body must not be walked as a script: {:?}",
+            r.command_invocations
+                .iter()
+                .map(|i| i.name.as_str())
+                .collect::<Vec<_>>(),
+        );
+    }
 }

--- a/rust/tcl-compiler/src/analyser/diagnostics/const_dispatch.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/const_dispatch.rs
@@ -191,6 +191,7 @@ fn settle_one_site(
             rename_safe,
             existence_probe: false,
             is_mathfunc_call: false,
+            ensemble_dispatch: None,
         });
         for c in group {
             let Some(span) = c.literal_span else { continue };
@@ -208,6 +209,7 @@ fn settle_one_site(
                 rename_safe: true,
                 existence_probe: false,
                 is_mathfunc_call: false,
+                ensemble_dispatch: None,
             });
         }
     }

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -9100,6 +9100,7 @@ fn analyse_w123_package_require_gate_suppresses_when_recorded() {
             rename_safe: true,
             existence_probe: false,
             is_mathfunc_call: false,
+            ensemble_dispatch: None,
         });
     let registry = tcl_registry::CommandRegistry::build_default();
     a.emit_unresolved_command_diagnostics(&registry);

--- a/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
@@ -1755,6 +1755,7 @@ impl Analyser {
                 rename_safe: true,
                 existence_probe: false,
                 is_mathfunc_call: false,
+                ensemble_dispatch: None,
             });
         }
         self.result.command_invocations.extend(new_invocations);

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -9585,6 +9585,142 @@ mod tests {
         );
     }
 
+    // Issue #923 idx 85, the *call-site* half.  Everything above pins the
+    // ensemble's own declaration (where the `-map`/`-subcommands` targets
+    // home to); these pin the downstream `<ensemble> <sub>` dispatch sites,
+    // which is what find-references / rename / code-lens / call-hierarchy
+    // enumerate.  Oracle — tclsh 8.6.16 and 9.0.4 both print
+    // `shown` then `configured:-x 1` for `VIAPROC_SRC`, so
+    // `::app::widget show` really does dispatch to `::app::widget::Show`.
+
+    /// The finding's exact shape: `namespace ensemble create -map` inside a
+    /// proc declared with a fully-qualified name at top level, with no
+    /// enclosing `namespace eval`, and the dispatch call sites written after
+    /// it — one nested in a `[…]` substitution, one at the top level.
+    const VIAPROC_SRC: &str = "namespace eval ::app::widget {\n    \
+         variable state 0\n\
+         }\n\
+         proc ::app::widget::Setup {} {\n    \
+         namespace ensemble create -map {\n        \
+         show      ::app::widget::Show\n        \
+         configure ::app::widget::Configure\n    \
+         }\n\
+         }\n\
+         proc ::app::widget::Show {} { puts \"shown\" }\n\
+         proc ::app::widget::Configure {args} { puts \"configured:$args\" }\n\
+         ::app::widget::Setup\n\
+         puts [::app::widget show]\n\
+         ::app::widget configure -x 1\n";
+
+    /// Every `(written name, resolved name)` pair recorded as an
+    /// existence-probed reference — the shape
+    /// `record_ensemble_subcommand_invocation` gives a subcommand word.
+    fn probe_refs(r: &super::super::types::AnalysisResult) -> Vec<(String, String)> {
+        r.command_invocations
+            .iter()
+            .filter(|i| i.existence_probe)
+            .map(|i| {
+                (
+                    i.name.clone(),
+                    i.resolved_qualified_name.clone().unwrap_or_default(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn ensemble_call_sites_resolve_when_the_ensemble_is_created_in_a_qualified_proc_923_idx85() {
+        let r = Analyser::new().analyse(VIAPROC_SRC, "tcl8.6").clone();
+        let probes = probe_refs(&r);
+        assert!(
+            probes.contains(&("show".to_owned(), "::app::widget::Show".to_owned())),
+            "the `[::app::widget show]` dispatch must be a reference to Show: {probes:?}",
+        );
+        assert!(
+            probes.contains(&("configure".to_owned(), "::app::widget::Configure".to_owned())),
+            "the top-level `::app::widget configure` dispatch must be a reference \
+             to Configure: {probes:?}",
+        );
+    }
+
+    #[test]
+    fn per_item_records_the_same_ensemble_call_sites_as_the_whole_file_walk_923_idx85() {
+        // The regression that shipped: the per-item shell pass defers
+        // `::app::widget::Setup`'s body, so the ensemble map was still empty
+        // when the two call sites below it were walked and neither
+        // subcommand reference was ever recorded — go-to-definition (an
+        // on-demand lookup against the finished analysis) still answered,
+        // find-references could not.  Comparing the two walk strategies
+        // directly is the assertion that cannot drift.
+        let whole = Analyser::new().analyse(VIAPROC_SRC, "tcl8.6").clone();
+        let per_item = Analyser::new().analyse_per_item(VIAPROC_SRC, "tcl8.6");
+        assert_eq!(
+            probe_refs(&per_item),
+            probe_refs(&whole),
+            "per-item must record the same ensemble dispatch references as the \
+             whole-file walk",
+        );
+        assert!(
+            probe_refs(&per_item)
+                .iter()
+                .any(|(_, res)| res == "::app::widget::Show"),
+            "and both must actually find Show's call site: {:?}",
+            probe_refs(&per_item),
+        );
+    }
+
+    #[test]
+    fn a_dynamic_ensemble_map_records_no_call_site_reference_923_idx85() {
+        // TN — deliberate abstention.  `-map [list …]` is not a literal
+        // list, so no `subcommand -> target` fact exists at all; the
+        // dispatch site must stay unattributed rather than being guessed
+        // at from the surrounding text.  Both walk strategies abstain.
+        let src = "proc ::app::widget::Setup {} {\n    \
+                   namespace ensemble create -map [list show ::app::widget::Show]\n\
+                   }\n\
+                   proc ::app::widget::Show {} {}\n\
+                   ::app::widget::Setup\n\
+                   ::app::widget show\n";
+        for r in [
+            Analyser::new().analyse(src, "tcl8.6").clone(),
+            Analyser::new().analyse_per_item(src, "tcl8.6"),
+        ] {
+            assert!(
+                !probe_refs(&r)
+                    .iter()
+                    .any(|(_, res)| res == "::app::widget::Show"),
+                "a dynamic -map must not attribute the dispatch site: {:?}",
+                probe_refs(&r),
+            );
+        }
+    }
+
+    #[test]
+    fn an_ensemble_call_site_above_its_declaration_is_not_attributed_923_idx85() {
+        // TN — the whole-file DFS walks a proc body at its *definition*
+        // point, so a dispatch written above the proc that creates the
+        // ensemble sees no map.  The deferred replay reproduces that
+        // visibility rule rather than widening it, which is what keeps the
+        // two walk strategies byte-identical.
+        let src = "proc ::app::widget::Show {} {}\n\
+                   ::app::widget show\n\
+                   proc ::app::widget::Setup {} {\n    \
+                   namespace ensemble create -map {show ::app::widget::Show}\n\
+                   }\n";
+        for r in [
+            Analyser::new().analyse(src, "tcl8.6").clone(),
+            Analyser::new().analyse_per_item(src, "tcl8.6"),
+        ] {
+            assert!(
+                !probe_refs(&r)
+                    .iter()
+                    .any(|(_, res)| res == "::app::widget::Show"),
+                "a dispatch above the declaration must not be attributed: {:?}",
+                probe_refs(&r),
+            );
+        }
+    }
+
     // `namespace ensemble configure` (issue #923 idx 84): the real
     // `tk/library/systray.tcl` idiom splices new subcommands onto a
     // *pre-existing* ensemble via `configure`, not `create` — previously

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -9637,7 +9637,10 @@ mod tests {
             "the `[::app::widget show]` dispatch must be a reference to Show: {probes:?}",
         );
         assert!(
-            probes.contains(&("configure".to_owned(), "::app::widget::Configure".to_owned())),
+            probes.contains(&(
+                "configure".to_owned(),
+                "::app::widget::Configure".to_owned()
+            )),
             "the top-level `::app::widget configure` dispatch must be a reference \
              to Configure: {probes:?}",
         );

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -3493,6 +3493,12 @@ impl Analyser {
     /// (issue #923 idx 106) — a distinct field from `ensemble_command_maps`
     /// above, serving navigation rather than the safe-interpreter gate.
     ///
+    /// The navigation entry is tagged
+    /// [`EnsembleSubcommandProvenance::Map`](crate::signature_scan::types::EnsembleSubcommandProvenance::Map)
+    /// (issue #1281): a `-map` key is an arbitrary name, so a consumer that
+    /// *rewrites* the subcommand word — rename — must leave it alone, unlike
+    /// the `-subcommands` sibling below whose entry is the target's own tail.
+    ///
     /// A `-map` target is a command name **or a command prefix** in real
     /// Tcl (tclsh 8.6.14-verified: `-map {go {string length}}` dispatches
     /// `myens go hello` to `string length hello`) — the command actually
@@ -3579,7 +3585,14 @@ impl Analyser {
                     .ensemble_subcommand_targets
                     .entry(key.to_owned())
                     .or_default()
-                    .insert(sub.clone(), resolved.clone());
+                    .insert(
+                        sub.clone(),
+                        super::types::EnsembleSubcommandTarget {
+                            target: resolved.clone(),
+                            provenance:
+                                crate::signature_scan::types::EnsembleSubcommandProvenance::Map,
+                        },
+                    );
                 self.ensemble_record_offsets
                     .insert(key.to_owned(), tok.span.start());
             }
@@ -3593,6 +3606,12 @@ impl Analyser {
     /// [`AnalysisResult::ensemble_subcommand_targets`] — the `-subcommands`
     /// sibling of [`Self::record_ensemble_map_targets`]'s issue #923 idx 106
     /// fix (same one-directional-only gap, same fix shape).
+    ///
+    /// Tagged
+    /// [`EnsembleSubcommandProvenance::Subcommands`](crate::signature_scan::types::EnsembleSubcommandProvenance::Subcommands)
+    /// (issue #1281): here the subcommand word *is* the target's tail — the
+    /// ensemble derives `<ns>::<name>` from it — so renaming the target must
+    /// rewrite the entry and the dispatch word with it.
     fn record_ensemble_subcommands(
         &mut self,
         list_text: &str,
@@ -3610,7 +3629,14 @@ impl Analyser {
                     .ensemble_subcommand_targets
                     .entry(key.to_owned())
                     .or_default()
-                    .insert(elem.clone(), resolved.clone());
+                    .insert(
+                        elem.clone(),
+                        super::types::EnsembleSubcommandTarget {
+                            target: resolved.clone(),
+                            provenance: crate::signature_scan::types::
+                                EnsembleSubcommandProvenance::Subcommands,
+                        },
+                    );
                 self.ensemble_record_offsets
                     .insert(key.to_owned(), tok.span.start());
             }
@@ -9855,6 +9881,111 @@ mod tests {
             !resolved.contains(&"::myens::foo"),
             "must not record a spurious command reference from splitting \
              the dynamic expression's own text: {resolved:?}",
+        );
+    }
+
+    #[test]
+    fn ensemble_subcommand_targets_record_which_option_declared_them() {
+        // Issue #1281: the two options bind the subcommand word to its
+        // target in opposite ways, so the recorded fact has to say which one
+        // wrote it. Oracle (tclsh 8.6.14 / 9.0.4, identical): with `-map
+        // {show ::app::widget::Show}` the call `::app::widget Show` is
+        // `unknown or ambiguous subcommand "Show": must be show` — the key is
+        // arbitrary; with `-subcommands {alpha}` the ensemble derives
+        // `::app::widget::alpha` from the entry, and a `-subcommands {alpha}`
+        // whose proc is named `beta` is `invalid command name "alpha"`.
+        use crate::signature_scan::types::EnsembleSubcommandProvenance;
+
+        let mut a = Analyser::new();
+        let map_src = "namespace eval ::app::widget {}\n\
+                       proc ::app::widget::Show {} {}\n\
+                       namespace ensemble create -command ::app::widget \
+                       -map {show ::app::widget::Show}\n";
+        let r = a.analyse(map_src, "tcl8.6");
+        let entry = r
+            .ensemble_subcommand_targets
+            .get("::app::widget")
+            .and_then(|subs| subs.get("show"))
+            .expect("the literal -map pair is recorded");
+        assert_eq!(entry.target, "::app::widget::Show");
+        assert_eq!(
+            entry.provenance,
+            EnsembleSubcommandProvenance::Map,
+            "a -map pair must be tagged as such",
+        );
+
+        let mut a = Analyser::new();
+        let sub_src = "namespace eval ::app::widget {\n    \
+                       proc alpha {} {}\n    \
+                       namespace ensemble create -command ::app::widget \
+                       -subcommands {alpha}\n\
+                       }\n";
+        let r = a.analyse(sub_src, "tcl8.6");
+        let entry = r
+            .ensemble_subcommand_targets
+            .get("::app::widget")
+            .and_then(|subs| subs.get("alpha"))
+            .expect("the literal -subcommands entry is recorded");
+        assert_eq!(entry.target, "::app::widget::alpha");
+        assert_eq!(
+            entry.provenance,
+            EnsembleSubcommandProvenance::Subcommands,
+            "a -subcommands entry must be tagged as such",
+        );
+    }
+
+    #[test]
+    fn ensemble_dispatch_call_sites_carry_their_mapping_provenance() {
+        // The dispatch word's own invocation record carries the provenance
+        // (issue #1281), because only the recording site knows *this span* is
+        // a subcommand word: a `-map {Show ::app::widget::Show}` whose key
+        // happens to equal the target's tail is textually indistinguishable
+        // from an ordinary bare call to the target, so a consumer that
+        // re-derived the fact by name would gate the wrong spans.
+        use crate::signature_scan::types::EnsembleSubcommandProvenance;
+
+        let mut a = Analyser::new();
+        let map_src = "namespace eval ::app::widget {}\n\
+                       proc ::app::widget::Show {} {}\n\
+                       namespace ensemble create -command ::app::widget \
+                       -map {show ::app::widget::Show}\n\
+                       ::app::widget show\n";
+        let r = a.analyse(map_src, "tcl8.6");
+        let tagged: Vec<(&str, Option<EnsembleSubcommandProvenance>)> = r
+            .command_invocations
+            .iter()
+            .filter(|i| i.resolved_qualified_name.as_deref() == Some("::app::widget::Show"))
+            .map(|i| (i.name.as_str(), i.ensemble_dispatch))
+            .collect();
+        assert!(
+            tagged.contains(&("show", Some(EnsembleSubcommandProvenance::Map))),
+            "the dispatch word is tagged with the -map provenance: {tagged:?}",
+        );
+        assert!(
+            tagged
+                .iter()
+                .any(|(name, prov)| *name == "::app::widget::Show" && prov.is_none()),
+            "the -map *value* is an ordinary reference, not a dispatch word — \
+             it carries the target's own name and rename must rewrite it: {tagged:?}",
+        );
+
+        let mut a = Analyser::new();
+        let sub_src = "namespace eval ::app::widget {\n    \
+                       proc alpha {} {}\n    \
+                       namespace ensemble create -command ::app::widget \
+                       -subcommands {alpha}\n\
+                       }\n\
+                       ::app::widget alpha\n";
+        let r = a.analyse(sub_src, "tcl8.6");
+        let tagged: Vec<(&str, Option<EnsembleSubcommandProvenance>)> = r
+            .command_invocations
+            .iter()
+            .filter(|i| i.resolved_qualified_name.as_deref() == Some("::app::widget::alpha"))
+            .map(|i| (i.name.as_str(), i.ensemble_dispatch))
+            .collect();
+        assert!(
+            tagged.contains(&("alpha", Some(EnsembleSubcommandProvenance::Subcommands))),
+            "the dispatch word is tagged with the -subcommands provenance: {tagged:?}",
         );
     }
 

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -209,8 +209,13 @@ pub struct DeferredBody {
     /// [`Analyser::fill_deferred_bodies`]; empty at construction.  The
     /// isolated pass seeds its own result map from this, so an
     /// `<ensemble> <sub> …` call inside the body records the same
-    /// existence-probed subcommand invocation the whole-file walk does.
-    pub ensemble_targets: Vec<(String, Vec<(String, String)>)>,
+    /// existence-probed subcommand invocation the whole-file walk does —
+    /// provenance included, so the body's dispatch words carry the same
+    /// `-map`/`-subcommands` tag rename gates on (issue #1281).
+    pub ensemble_targets: Vec<(
+        String,
+        Vec<(String, super::types::EnsembleSubcommandTarget)>,
+    )>,
     /// Mirrors [`super::types::Scope::oo_defining_class`] for the isolated
     /// rebuild: the fully-qualified defining class when this is an
     /// instance-side `TclOO` method body of a statically-named class,
@@ -583,12 +588,17 @@ impl Analyser {
         // unrelated ensemble edit re-keys no body. Canonically sorted so
         // the snapshot can key `tcl-lsp-db`'s `ItemBodyKey`.
         if !self.result.ensemble_subcommand_targets.is_empty() {
-            let mut all: Vec<(&String, &std::collections::HashMap<String, String>)> =
-                self.result.ensemble_subcommand_targets.iter().collect();
+            let mut all: Vec<(
+                &String,
+                &std::collections::HashMap<String, super::types::EnsembleSubcommandTarget>,
+            )> = self.result.ensemble_subcommand_targets.iter().collect();
             all.sort_by_key(|(k, _)| *k);
             for db in &mut deferred {
                 let body_start = db.body_tok.span.start();
-                let visible: Vec<(String, Vec<(String, String)>)> = all
+                let visible: Vec<(
+                    String,
+                    Vec<(String, super::types::EnsembleSubcommandTarget)>,
+                )> = all
                     .iter()
                     .filter(|(k, _)| {
                         self.ensemble_record_offsets
@@ -597,7 +607,7 @@ impl Analyser {
                             && db.body_text.contains(crate::naming::key_tail(k))
                     })
                     .map(|(k, subs)| {
-                        let mut inner: Vec<(String, String)> =
+                        let mut inner: Vec<(String, super::types::EnsembleSubcommandTarget)> =
                             subs.iter().map(|(s, t)| (s.clone(), t.clone())).collect();
                         inner.sort();
                         ((*k).clone(), inner)
@@ -1760,8 +1770,8 @@ fn rebase_result_names(r: &mut AnalysisResult, fix: &impl Fn(&mut String)) {
     fix_string_keys(&mut r.rename_offsets, fix);
     fix_string_keys(&mut r.ensemble_subcommand_targets, fix);
     for subs in r.ensemble_subcommand_targets.values_mut() {
-        for target in subs.values_mut() {
-            fix(target);
+        for entry in subs.values_mut() {
+            fix(&mut entry.target);
         }
     }
     for imp in &mut r.namespace_imports {

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -920,6 +920,11 @@ impl Analyser {
             .extend(frag.instance_class_sites);
         self.pending_var_literal_checks
             .extend(frag.var_literal_checks);
+        // Ensembles declared *inside* this body: the shell needs their
+        // absolute recording offsets to apply the whole-file DFS visibility
+        // rule when it replays the call sites it deferred (issue #923 idx
+        // 85). `rebase_fragment_pending` has already shifted them.
+        self.ensemble_record_offsets.extend(frag.ensemble_offsets);
         // Replay the body's qualified global reads against the shell's real
         // global scope (rebased to the body's position): a `$::g` read lands as
         // a reference on the enclosing `::g` exactly as a whole-file walk would.
@@ -1155,6 +1160,13 @@ pub struct BodyFragment {
     /// resolution (see
     /// [`super::state::Analyser::pending_var_literal_checks`]).
     var_literal_checks: Vec<(tcl_core_types::DiagCode, String, Token)>,
+    /// Where inside this body each ensemble the body declares was recorded
+    /// (`super::state::Analyser::ensemble_record_offsets`), body-relative.
+    /// The graft rebases these to absolute and merges them into the shell so
+    /// the tail's `flush_pending_ensemble_subcommand_invocations` can apply
+    /// the whole-file DFS's "declaration precedes the call site" visibility
+    /// rule to an ensemble created inside a proc body (issue #923 idx 85).
+    ensemble_offsets: std::collections::HashMap<String, u32>,
     /// Every offset-keyed synthetic identity the isolated pass minted
     /// (`@dynns@<off>` / `@dynclass@<off>` / `@autoname@<off>`), with
     /// **body-relative** offsets — the whole fragment is body-relative, so
@@ -1336,6 +1348,7 @@ pub fn analyse_proc_body_isolated<S: std::hash::BuildHasher>(
         instance_class_sites: a.pending_instance_class_sites,
         widget_sites: a.widget_dispatch_sites,
         var_literal_checks: a.pending_var_literal_checks,
+        ensemble_offsets: a.ensemble_record_offsets,
         minted_synthetics: a.minted_synthetic_names,
     }
 }
@@ -1812,6 +1825,7 @@ fn rebase_pending_names(frag: &mut BodyFragment, fix: &impl Fn(&mut String)) {
     for site in &mut frag.const_dispatches {
         fix(&mut site.ns);
     }
+    fix_string_keys(&mut frag.ensemble_offsets, fix);
     fix_string_keys(&mut frag.walk_aliases, fix);
     for (target, _) in frag.walk_aliases.values_mut() {
         fix(target);
@@ -1875,6 +1889,9 @@ fn rebase_fragment_pending(frag: &mut BodyFragment, d: u32) {
     for (_, tok, span) in &mut frag.global_defs {
         tok.span = shift(tok.span, d);
         *span = shift(*span, d);
+    }
+    for off in frag.ensemble_offsets.values_mut() {
+        *off += d;
     }
     for off in frag.walk_alias_offsets.values_mut() {
         *off += d;

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -80,6 +80,37 @@ pub(super) struct PendingInstanceClassSite {
     pub target_name: String,
 }
 
+/// One `<ensemble> <subcommand> …` call site the shell pass could not
+/// resolve yet (issue #923 idx 85), held until every deferred proc/method
+/// body has been walked.
+///
+/// The whole-file DFS walks a proc body at its *definition* point, so a
+/// `namespace ensemble create -map` written inside `proc ::app::widget::Setup`
+/// is on the books long before a top-level `::app::widget show` further down
+/// the file. The per-item shell pass defers that body, so the identical call
+/// site is walked while `ensemble_subcommand_targets` is still empty and the
+/// subcommand reference is silently never recorded — go-to-definition
+/// (an on-demand lookup against the *finished* analysis) answered, but
+/// find-references / rename / code-lens / call-hierarchy (which enumerate
+/// recorded invocations) could not. Deferring the miss and replaying it in
+/// [`Analyser::flush_pending_ensemble_subcommand_invocations`] restores the
+/// whole-file result exactly.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct PendingEnsembleSubcommand {
+    /// The ensemble's own resolved command name — the
+    /// [`super::types::AnalysisResult::ensemble_subcommand_targets`] key the
+    /// walk would have looked up, computed exactly as the immediate path
+    /// computes it so the replay cannot resolve differently.
+    pub ensemble: String,
+    /// The static subcommand word.
+    pub sub: String,
+    /// The subcommand word's span — the reference this records.
+    pub span: Span,
+    /// Arguments *after* the consumed subcommand word (`None` when any is
+    /// `{*}`-expanded), the same convention the immediate path uses.
+    pub argc: Option<usize>,
+}
+
 /// One W315 candidate from an `oo::objdefine` walk (issue #1170), held
 /// until the whole document is walked so
 /// [`Analyser::flush_objdefine_abort_diagnostics`] can consult
@@ -532,6 +563,13 @@ pub struct Analyser {
     /// visibility the whole-file DFS gives a body walked at its definition
     /// point.  Never merged into the result.
     pub(super) ensemble_record_offsets: HashMap<String, u32>,
+    /// `<ensemble> <subcommand> …` call sites the **shell pass** met before
+    /// the ensemble that maps them was known, replayed against the finished
+    /// map by [`Self::flush_pending_ensemble_subcommand_invocations`]
+    /// (issue #923 idx 85). Only the shell pass fills this: the whole-file
+    /// DFS and the isolated body pass both resolve at walk time against a
+    /// map that already holds everything their own walk order could see.
+    pub(super) pending_ensemble_subcommands: Vec<PendingEnsembleSubcommand>,
     /// `namespace ensemble create|configure ... -map {sub target ...}`
     /// subcommand-to-target maps, keyed by the ensemble's own qualified
     /// command name (`-command NAME`, or the enclosing namespace's own
@@ -1124,6 +1162,7 @@ impl Analyser {
             prefixless_ensembles: HashSet::new(),
             ensemble_command_maps: HashMap::new(),
             ensemble_record_offsets: HashMap::new(),
+            pending_ensemble_subcommands: Vec::new(),
             objdefined_vars: HashSet::new(),
             objdefine_bindings: HashMap::new(),
             objdefine_abort_candidates: Vec::new(),
@@ -2065,6 +2104,12 @@ impl Analyser {
     }
 
     pub(super) fn run_diagnostic_emitters(&mut self, source: &str) {
+        // Replay the `<ensemble> <subcommand>` call sites the shell pass met
+        // before the deferred body that declares the ensemble was walked
+        // (issue #923 idx 85) — before `finalise_invocation_resolutions`, so
+        // the replayed invocations go through exactly the same settlement
+        // the walk-time ones do. A no-op on every other entry point.
+        self.flush_pending_ensemble_subcommand_invocations();
         // Settle every invocation's `resolved_qualified_name` with Tcl's
         // existence-checked two-step rule now that the walk has recorded
         // every definition in the file (a local candidate defined later in

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -106,6 +106,27 @@ pub struct Diagnostic {
     pub fixes: Vec<CodeFix>,
 }
 
+/// One statically recorded `namespace ensemble` subcommand: the command it
+/// dispatches to, plus **how** the ensemble bound the two together
+/// (issue #1281).
+///
+/// The value half of
+/// [`AnalysisResult::ensemble_subcommand_targets`]'s inner map. Navigation
+/// (`definition` / `hover` / `references`) only wants [`Self::target`]; a
+/// source-rewriting consumer (rename) has to read [`Self::provenance`] as
+/// well, because the subcommand word is the target's own tail under
+/// `-subcommands` and an arbitrary key under `-map`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EnsembleSubcommandTarget {
+    /// The resolved, qualified command name the subcommand dispatches to
+    /// (`::app::widget::Show`). For a `-map` target that is a command
+    /// *prefix* (`-map {go {string length}}`) this is the prefix's head —
+    /// the command actually invoked.
+    pub target: String,
+    /// Which option declared the mapping.
+    pub provenance: crate::signature_scan::types::EnsembleSubcommandProvenance,
+}
+
 /// One same-file user-call arity candidate, buffered during the command
 /// walk for post-walk resolution against same-file procs / `TclOO`
 /// forwards / `interp alias` / static `rename` targets — the set the
@@ -1760,7 +1781,13 @@ pub struct AnalysisResult {
     /// `-subcommands` list — a dynamic value (`-map $var`) leaves the
     /// ensemble's entry absent entirely, so a lookup against it correctly
     /// abstains rather than guessing.
-    pub ensemble_subcommand_targets: HashMap<String, HashMap<String, String>>,
+    ///
+    /// Each entry carries the **provenance** of its mapping
+    /// ([`EnsembleSubcommandTarget::provenance`], issue #1281) — `-map` binds
+    /// an arbitrary key to a target, `-subcommands` derives the target from
+    /// the name — because a consumer that rewrites the subcommand word
+    /// (rename) is only correct for one of the two.
+    pub ensemble_subcommand_targets: HashMap<String, HashMap<String, EnsembleSubcommandTarget>>,
     /// Namespace import records.
     pub namespace_imports: Vec<SignatureNamespaceImport>,
     /// Namespace `forget` records — the removal half of the import edge's

--- a/rust/tcl-compiler/src/auto_path_eval.rs
+++ b/rust/tcl-compiler/src/auto_path_eval.rs
@@ -56,6 +56,29 @@
 //! path (`C:` or `C:foo`, resolved against a per-drive working directory only
 //! the running process knows) is outside the subset and abstains, like any
 //! other unsupported shape.
+//!
+//! # A relative result stays relative
+//!
+//! `lappend auto_path lib` / `set v helper.tcl; source $v` fold to a path
+//! with no root.  Tcl resolves such a path against the **interpreter's
+//! working directory at run time** (oracle, tclsh 8.6.16 and 9.0.4:
+//! `cd other; tclsh ../sub/main.tcl` where `main.tcl` does
+//! `set v helper.tcl; source $v` loads `other/helper.tcl`, *not*
+//! `sub/helper.tcl` — `[info script]` plays no part), which is a fact no
+//! static analysis can know.
+//!
+//! This evaluator therefore returns such a result **relative**, normalised
+//! but unanchored, and each caller applies the base it actually has — the
+//! sourcing document's directory for the source graph
+//! (`source_graph::resolve_source_target`), the workspace root for document
+//! links (`document_links::resolve_path`), the analysed file's own directory
+//! for the package database. It deliberately does **not** absolutise against
+//! the *analysing process's* current directory: the language server's launch
+//! directory is an editor artefact with no relationship to the user's
+//! program, so anchoring on it makes the same file resolve differently
+//! depending on how the editor happened to be started, and makes a computed
+//! path disagree with the literal path right beside it (which every caller
+//! already anchors on its own base).
 
 use crate::analyser::types::{AutoPathEntry, AutoPathForm};
 
@@ -109,10 +132,13 @@ pub fn evaluate_auto_path_entry(entry: &AutoPathEntry, info_script: Option<&str>
         .collect()
 }
 
-/// Fold one already-substituted path *value* (a `~` expansion plus
-/// absolutisation), abstaining on a drive-relative path.  The shared tail of
+/// Fold one already-substituted path *value* (a `~` expansion plus lexical
+/// normalisation), abstaining on a drive-relative path.  The shared tail of
 /// [`evaluate_auto_path_expr`] and the per-element path of
 /// [`evaluate_auto_path_entry`].
+///
+/// A rootless value stays rootless — see the module docs' "A relative result
+/// stays relative".
 fn fold_path_value(value: &str) -> Option<String> {
     let value = value.trim();
     if value.is_empty() {
@@ -124,12 +150,17 @@ fn fold_path_value(value: &str) -> Option<String> {
         // process knows.  Outside the subset — abstain rather than guess.
         return None;
     }
-    Some(abspath(&expanded))
+    Some(normalise_path_value(&expanded))
 }
 
-/// Resolve `raw` (a `lappend auto_path` argument) to an absolute path,
+/// Resolve `raw` (a `lappend auto_path` argument) to a normalised path,
 /// substituting `info_script` for `[info script]` (the filesystem path
 /// of the file being analysed — what Tcl itself would report).
+///
+/// The result is absolute whenever the expression is anchored — by
+/// `[info script]`, by a literal root, or by `~` — and **relative**
+/// otherwise, for the caller to anchor (see the module docs' "A relative
+/// result stays relative").
 ///
 /// Returns `None` when any part of the expression is outside the
 /// supported subset.
@@ -153,8 +184,9 @@ pub fn evaluate_auto_path_expr(raw: &str, info_script: Option<&str>) -> Option<S
         .map(to_tcl_slash_form)
         .filter(|p| !is_drive_relative(p));
     let result = eval(&node, info_script.as_deref())?;
-    // Expand `~` and make absolute (collapsing `..`) so the parent-dir
-    // idiom resolves to a real directory.
+    // Expand `~` and normalise (collapsing `..`) so the parent-dir idiom
+    // resolves to a real directory.  A rootless result is left for the
+    // caller to anchor.
     fold_path_value(&result)
 }
 
@@ -226,11 +258,6 @@ fn root_len(p: &str) -> Option<usize> {
         return Some(2 + host + 1 + share);
     }
     p.starts_with('/').then_some(1)
-}
-
-/// Whether `p` (slash form) is an absolute path in any of the three roots.
-fn is_absolute(p: &str) -> bool {
-    root_len(p).is_some()
 }
 
 /// Split `text` into `[` / `]` / word tokens.  Brace groups are kept
@@ -331,7 +358,7 @@ fn parse(tokens: &[String], mut pos: usize) -> (Option<Node>, usize) {
     (Some(Node::Lit(tok.clone())), pos + 1)
 }
 
-/// Evaluate a parsed node to a path string (pre-`abspath`).
+/// Evaluate a parsed node to a path string (pre-normalisation).
 fn eval(node: &Node, info_script: Option<&str>) -> Option<String> {
     match node {
         Node::Lit(value) => {
@@ -380,21 +407,32 @@ fn eval(node: &Node, info_script: Option<&str>) -> Option<String> {
 /// The root clamp is what makes the Windows shapes come out right:
 /// `C:/x` → `C:/` (not the drive-relative `C:`), and
 /// `//server/share/dir` → `//server/share` (not `//server`).
+///
+/// A rootless single-component path has `.` for its directory, exactly as
+/// tclsh 8.6.16 / 9.0.4 answer `file dirname helper.tcl` — not the empty
+/// string, and emphatically not the analysing process's working directory.
 fn path_dirname(p: &str) -> String {
     let root = root_len(p).unwrap_or(0);
+    let head_or_dot = |head: &str| {
+        if head.is_empty() {
+            ".".to_owned()
+        } else {
+            head.to_owned()
+        }
+    };
     if p.len() <= root {
-        return p[..root].to_owned();
+        return head_or_dot(&p[..root]);
     }
     let Some(idx) = p[root..].rfind('/') else {
-        // No separator past the root: the head is the root, or empty for a
-        // relative path (`abspath` then supplies the working directory).
-        return p[..root].to_owned();
+        // No separator past the root: the head is the root, or `.` for a
+        // single-component relative path.
+        return head_or_dot(&p[..root]);
     };
     let head = &p[..root + idx];
     if head.len() <= root {
-        return p[..root].to_owned();
+        return head_or_dot(&p[..root]);
     }
-    head.trim_end_matches('/').to_owned()
+    head_or_dot(head.trim_end_matches('/'))
 }
 
 /// `file join` in slash form — a later *absolute* component resets the
@@ -449,19 +487,17 @@ fn expanduser(p: &str) -> String {
     p.to_owned()
 }
 
-/// Absolutise `p` (slash form) against the current working directory when it
-/// has no root, then normalise (`.` / `..` / repeated separators).
-fn abspath(p: &str) -> String {
-    let joined = if is_absolute(p) {
-        p.to_owned()
-    } else {
-        let cwd = std::env::current_dir()
-            .ok()
-            .and_then(|c| c.to_str().map(to_tcl_slash_form))
-            .unwrap_or_else(|| "/".to_owned());
-        path_join(&[cwd, p.to_owned()])
-    };
-    normpath(&joined)
+/// Normalise `p` (slash form) — collapse `.`, `..` and repeated separators
+/// — **without** anchoring a rootless path anywhere.
+///
+/// An unanchored relative result is Tcl's own "resolve against the
+/// interpreter's run-time working directory" (module docs), which is not
+/// statically knowable; absolutising it against the *analysing process's*
+/// working directory would substitute an unrelated editor artefact for it.
+/// The caller — which knows the sourcing document, the workspace root, or
+/// both — anchors it instead.
+fn normalise_path_value(p: &str) -> String {
+    normpath(p)
 }
 
 /// Path normalisation in slash form — collapse `.`, `..` and repeated
@@ -511,8 +547,9 @@ fn normpath(p: &str) -> String {
 mod tests {
     use super::*;
 
-    // Absolute `info_script` keeps `abspath` deterministic (it reduces
-    // to `normpath`, independent of the test's cwd).
+    // Absolute `info_script` keeps the fold rooted; a rootless fold result
+    // is returned relative (see the module docs), never anchored on the
+    // analysing process's working directory.
 
     #[test]
     fn dirname_of_info_script() {
@@ -546,6 +583,60 @@ mod tests {
             )
             .as_deref(),
             Some("/proj"),
+        );
+    }
+
+    /// TP (issue #923 idx 73) — the exact idiom `pix` writes: three nested
+    /// `file dirname`s around `[info script]`, one level deeper than the
+    /// two-level form the other tests use.  `examples/user.tcl` reaching the
+    /// repo root two directories up is what makes the package resolvable
+    /// when the workspace root is scoped below it.
+    #[test]
+    fn triple_nested_dirname_is_the_pix_idiom() {
+        assert_eq!(
+            evaluate_auto_path_expr(
+                "[file dirname [file dirname [file dirname [info script]]]]",
+                Some("/proj/lib/examples/user.tcl"),
+            )
+            .as_deref(),
+            Some("/proj"),
+        );
+    }
+
+    /// The analysing process's working directory must never influence a
+    /// fold.  A rootless expression stays rootless (its caller anchors it);
+    /// running the same fold from two different directories must not change
+    /// the answer.
+    ///
+    /// Oracle (tclsh 8.6.16 / 9.0.4): `set v helper.tcl; source $v` inside
+    /// `sub/main.tcl` run as `cd other && tclsh ../sub/main.tcl` loads
+    /// `other/helper.tcl` — resolution is against the interpreter's *run
+    /// time* working directory, which a language server cannot know and must
+    /// not substitute its own launch directory for.
+    #[test]
+    fn a_rootless_fold_stays_relative_and_ignores_the_process_cwd() {
+        assert_eq!(
+            evaluate_auto_path_expr("helper.tcl", None).as_deref(),
+            Some("helper.tcl"),
+        );
+        assert_eq!(
+            evaluate_auto_path_expr("[file join lib pkg]", None).as_deref(),
+            Some("lib/pkg"),
+        );
+        // `..` still collapses lexically without a root to ascend past.
+        // (tclsh returns the uncollapsed text `lib/../other`; this evaluator
+        // normalises deliberately — see `normalise_path_value` — because its
+        // consumers compare and scan directories rather than print them, and
+        // the two name the same directory.)
+        assert_eq!(
+            evaluate_auto_path_expr("[file join lib .. other]", None).as_deref(),
+            Some("other"),
+        );
+        // `file dirname` of a single-component relative path is `.` in tclsh
+        // 8.6/9.0 — not the process's working directory.
+        assert_eq!(
+            evaluate_auto_path_expr("[file dirname helper.tcl]", None).as_deref(),
+            Some("."),
         );
     }
 
@@ -636,7 +727,11 @@ mod tests {
         assert_eq!(path_dirname("/a/b/c"), "/a/b");
         assert_eq!(path_dirname("/a"), "/");
         assert_eq!(path_dirname("/"), "/");
-        assert_eq!(path_dirname("a"), "");
+        // A rootless single component: `.`, exactly as tclsh 8.6.16 / 9.0.4
+        // answer `file dirname a` — the empty string this used to return had
+        // to be rescued by absolutising against the process's own working
+        // directory, which is not something a language server may assume.
+        assert_eq!(path_dirname("a"), ".");
         assert_eq!(path_join(&["/a/b".into(), "..".into()]), "/a/b/..");
         assert_eq!(path_join(&["/a".into(), "/b".into()]), "/b");
         assert_eq!(normpath("/a/b/../c"), "/a/c");

--- a/rust/tcl-compiler/src/signature_scan/types.rs
+++ b/rust/tcl-compiler/src/signature_scan/types.rs
@@ -414,6 +414,38 @@ pub struct SignatureAutoPathEntry {
     pub range: Span,
 }
 
+/// How a `namespace ensemble` subcommand got its name — the option that
+/// declared it (issue #1281).
+///
+/// The two options bind the subcommand word to its target in opposite ways,
+/// and a consumer that **rewrites source text** has to tell them apart
+/// (tclsh 8.6.14 / 9.0.4, identical):
+///
+/// - `-map {show ::app::widget::Show}` — the key is an *arbitrary* name with
+///   no required relationship to the target. `::app::widget show` runs
+///   `::app::widget::Show`, and `::app::widget Show` is `unknown or ambiguous
+///   subcommand "Show": must be show`. Renaming the target therefore must
+///   **not** touch the subcommand word; the pairing lives in the `-map`
+///   value, which is a separate reference the rename does rewrite.
+/// - `-subcommands {alpha}` — the entry *is* the target's tail; the ensemble
+///   derives `::app::widget::alpha` from it. Leaving the word behind when the
+///   proc is renamed gives `invalid command name "alpha"`, so renaming the
+///   target **must** rewrite the dispatch word (and the `-subcommands` entry)
+///   along with the declaration.
+///
+/// A dynamic value (`-map [list …]`) records no mapping at all, so it has no
+/// provenance to carry and every consumer abstains — see
+/// [`crate::analyser::types::AnalysisResult::ensemble_subcommand_targets`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum EnsembleSubcommandProvenance {
+    /// Declared by `-map {sub target …}`: the subcommand word is arbitrary
+    /// and independent of the target's name.
+    Map,
+    /// Declared by `-subcommands {name …}`: the subcommand word *is* the
+    /// target command's tail.
+    Subcommands,
+}
+
 /// A single command invocation recorded by the signature scanner.
 ///
 /// One record per command in the source — populated for every
@@ -513,6 +545,26 @@ pub struct SignatureCommandInvocation {
     /// the generic one-hop suffix-strip, which would otherwise misparse
     /// `tcl::mathfunc` as if it were the calling namespace.
     pub is_mathfunc_call: bool,
+    /// `Some(provenance)` when this record is the **subcommand word** of an
+    /// `<ensemble> <sub> …` dispatch (issue #923 idx 106 / idx 85), carrying
+    /// the option that declared the mapping; `None` for every other
+    /// invocation, including the `-map` target and the `-subcommands` entry
+    /// inside the ensemble declaration itself (those spans *do* carry the
+    /// target's own name and are ordinary references).
+    ///
+    /// The flag rides on the invocation rather than being re-derived from
+    /// [`crate::analyser::types::AnalysisResult::ensemble_subcommand_targets`]
+    /// by name at the consumer, because only the recording site knows *this
+    /// span* is a dispatch word: a `-map {Show ::app::widget::Show}` whose
+    /// key happens to equal the target's tail makes a name-based test
+    /// indistinguishable from an ordinary bare call to the target.
+    ///
+    /// Navigation consumers (references, go-to-definition, call hierarchy)
+    /// ignore it — a dispatch site is a genuine reference under either
+    /// provenance. Rename reads it: see
+    /// [`EnsembleSubcommandProvenance`] for the oracle that says why a `-map`
+    /// dispatch word must survive a rename of its target unchanged.
+    pub ensemble_dispatch: Option<EnsembleSubcommandProvenance>,
 }
 
 /// The full result returned by `extract_signatures`.

--- a/rust/tcl-compiler/src/signature_scan/walker.rs
+++ b/rust/tcl-compiler/src/signature_scan/walker.rs
@@ -121,6 +121,7 @@ pub(super) fn scan(
                 rename_safe: true,
                 existence_probe: false,
                 is_mathfunc_call: false,
+                ensemble_dispatch: None,
             });
         // Record command-prefix callback heads (`lsort -command cb`, `trace
         // add … cb`, …) as their own invocations so background-scanned files
@@ -278,6 +279,7 @@ fn record_command_prefix_invocations(cmd: &SegmentedCommand, head: &str, ctx: &m
                 rename_safe: true,
                 existence_probe: false,
                 is_mathfunc_call: false,
+                ensemble_dispatch: None,
             });
     }
 }

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -1746,7 +1746,7 @@ pub(crate) fn ensemble_subcommand_target<'a>(
         .into_iter()
         .find_map(|cand| analysis.ensemble_subcommand_targets.get(&cand))
         .and_then(|subs| subs.get(sub))
-        .map(String::as_str)
+        .map(|entry| entry.target.as_str())
 }
 
 /// The proc whose **own declaration name token** covers `cursor_off`.

--- a/rust/tcl-lsp-core/src/document_links.rs
+++ b/rust/tcl-lsp-core/src/document_links.rs
@@ -644,6 +644,100 @@ mod tests {
         assert!(links.is_empty(), "{links:?}");
     }
 
+    // Issue #1140 / #923 idx 41 — computed `source` paths, exercised through
+    // the code path a real editor takes: `workspace_root = Some(...)` *and*
+    // `script_path = Some(...)`.  The pre-existing `dynamic_path_produces_no
+    // _link` above passes `None` for both, which short-circuits `resolve_path`
+    // on `let root = workspace_root?` before the fix's `carries_substitution`
+    // gate is reached at all — so it never covered the bug.
+
+    /// TP — the positive side nothing pinned before: the corpus idiom
+    /// `set dir [file dirname [info script]]; source [file join $dir x.tcl]`
+    /// resolves to the **correct** target, not merely to no bogus one.
+    ///
+    /// Oracle (tclsh 8.6.16 / 9.0.4): running `/proj/test/caller.tcl` loads
+    /// `/proj/test/helper.tcl`, since `[info script]` is the sourcing file.
+    #[test]
+    fn a_computed_source_path_resolves_to_its_real_target_923_idx41() {
+        let src = "set dir [file dirname [info script]]\nsource [file join $dir helper.tcl]\n";
+        let links = document_links_in_context(
+            src,
+            "tcl",
+            &LinkContext {
+                workspace_root: Some("/proj"),
+                home: None,
+                script_path: Some("/proj/test/caller.tcl"),
+            },
+        );
+        assert_eq!(links.len(), 1, "expected exactly one link: {links:?}");
+        assert_eq!(
+            links[0].target, "file:///proj/test/helper.tcl",
+            "the computed path must resolve against `[info script]`'s own \
+             directory: {links:?}",
+        );
+    }
+
+    /// TN — the same shape wrapped in `file normalize`, which is outside the
+    /// evaluator's supported subset, so `dir` cannot be constant-propagated.
+    /// The whole expression must abstain rather than fall through to
+    /// percent-encoding its own raw text into a `file://` URI (the original
+    /// bug: `file:///proj/%5Bfile%20join%20$dir%20helper.tcl%5D`).
+    #[test]
+    fn an_unfoldable_computed_source_path_produces_no_link_923_idx41() {
+        for src in [
+            "set dir [file normalize [file dirname [info script]]]\n\
+             source [file join $dir helper.tcl]\n",
+            "source [file join $undeclared .. pkgfile.tcl]\n",
+            "source $other\n",
+        ] {
+            let links = document_links_in_context(
+                src,
+                "tcl",
+                &LinkContext {
+                    workspace_root: Some("/proj"),
+                    home: None,
+                    script_path: Some("/proj/test/caller.tcl"),
+                },
+            );
+            assert!(
+                links.is_empty(),
+                "an unresolvable computed path must produce no link at all, \
+                 got {links:?} for {src:?}",
+            );
+        }
+    }
+
+    /// A computed path that folds to a *relative* result is anchored by this
+    /// provider on `workspace_root`, exactly as the literal path beside it —
+    /// never on the language server process's own working directory.
+    ///
+    /// Tcl resolves such a path against the interpreter's run-time working
+    /// directory (tclsh 8.6.16 / 9.0.4: `cd other && tclsh ../sub/main.tcl`
+    /// with `set v helper.tcl; source $v` loads `other/helper.tcl`), which is
+    /// unknowable statically; what must never happen is the two spellings
+    /// disagreeing, or the answer depending on how the editor was launched.
+    #[test]
+    fn a_relative_computed_source_path_anchors_like_the_literal_beside_it_923_idx41() {
+        let ctx = LinkContext {
+            workspace_root: Some("/proj"),
+            home: None,
+            script_path: Some("/proj/test/caller.tcl"),
+        };
+        let literal = document_links_in_context("source helper.tcl\n", "tcl", &ctx);
+        let computed = document_links_in_context(
+            "set v helper.tcl\nsource [file join $v]\n",
+            "tcl",
+            &ctx,
+        );
+        assert_eq!(literal.len(), 1, "{literal:?}");
+        assert_eq!(computed.len(), 1, "{computed:?}");
+        assert_eq!(
+            computed[0].target, literal[0].target,
+            "a computed relative path must anchor exactly like the literal one",
+        );
+        assert_eq!(literal[0].target, "file:///proj/helper.tcl");
+    }
+
     #[test]
     fn double_dash_terminator_skipped() {
         let src = "source -- /tmp/x.tcl\n";

--- a/rust/tcl-lsp-core/src/document_links.rs
+++ b/rust/tcl-lsp-core/src/document_links.rs
@@ -724,11 +724,8 @@ mod tests {
             script_path: Some("/proj/test/caller.tcl"),
         };
         let literal = document_links_in_context("source helper.tcl\n", "tcl", &ctx);
-        let computed = document_links_in_context(
-            "set v helper.tcl\nsource [file join $v]\n",
-            "tcl",
-            &ctx,
-        );
+        let computed =
+            document_links_in_context("set v helper.tcl\nsource [file join $v]\n", "tcl", &ctx);
         assert_eq!(literal.len(), 1, "{literal:?}");
         assert_eq!(computed.len(), 1, "{computed:?}");
         assert_eq!(

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -4215,6 +4215,75 @@ mod tests {
         );
     }
 
+    /// Issue #923 idx 85 — the ensemble is created by
+    /// `namespace ensemble create -map` inside a proc declared with a
+    /// fully-qualified name at top level, with no enclosing `namespace eval`,
+    /// so it homes to `::app::widget`. Both reference directions must reach
+    /// the dispatch call site: from the mapped target's declaration, and from
+    /// the call site itself.
+    ///
+    /// Oracle (tclsh 8.6.16 and 9.0.4, identical): the script prints `shown`,
+    /// so `::app::widget show` really does dispatch to `::app::widget::Show`.
+    ///
+    /// Go-to-definition already answered this (it resolves on demand against
+    /// the finished analysis); references enumerate recorded invocations, and
+    /// the invocation was missing. The analyser fix is what supplies it — this
+    /// pins that the reference provider consumes it from both cursor
+    /// positions and returns the *same* answer for each.
+    #[test]
+    fn ensemble_subcommand_references_reach_the_call_site_through_a_qualified_proc_923_idx85() {
+        let src = "namespace eval ::app::widget {\n    variable state 0\n}\n\
+                   proc ::app::widget::Setup {} {\n    \
+                   namespace ensemble create -map {\n        \
+                   show      ::app::widget::Show\n    }\n}\n\
+                   proc ::app::widget::Show {} { puts \"shown\" }\n\
+                   ::app::widget::Setup\n\
+                   puts [::app::widget show]\n";
+        let analysis = analyse(src);
+        // Line 8 is `proc ::app::widget::Show …`; `Show` starts at column 20.
+        let from_decl = references(src, "tcl", 8, 21, &analysis, true);
+        // Line 10 is `puts [::app::widget show]`; `show` starts at column 20.
+        let from_call = references(src, "tcl", 10, 21, &analysis, true);
+        let lines = |refs: &[LspRange]| -> Vec<u32> {
+            let mut l: Vec<u32> = refs.iter().map(|r| r.start_line).collect();
+            l.sort_unstable();
+            l
+        };
+        assert!(
+            lines(&from_decl).contains(&10),
+            "the `::app::widget show` dispatch is missing from the declaration's \
+             reference set: {from_decl:?}",
+        );
+        assert!(
+            lines(&from_decl).contains(&8),
+            "the declaration itself is missing: {from_decl:?}",
+        );
+        assert_eq!(
+            lines(&from_call),
+            lines(&from_decl),
+            "both query directions must agree: {from_call:?} vs {from_decl:?}",
+        );
+    }
+
+    /// TN for the above — a `-map` built by `[list …]` is not a literal
+    /// mapping, so no `show -> ::app::widget::Show` fact exists and the
+    /// dispatch site must stay unattributed rather than guessed at.
+    #[test]
+    fn a_dynamic_ensemble_map_yields_no_call_site_reference_923_idx85() {
+        let src = "proc ::app::widget::Setup {} {\n    \
+                   namespace ensemble create -map [list show ::app::widget::Show]\n}\n\
+                   proc ::app::widget::Show {} {}\n\
+                   ::app::widget::Setup\n\
+                   ::app::widget show\n";
+        let analysis = analyse(src);
+        // Cursor on `Show` in its declaration (line 3, column 20).
+        let refs = references(src, "tcl", 3, 21, &analysis, true);
+        assert!(
+            !refs.iter().any(|r| r.start_line == 5),
+            "a dynamic -map must not manufacture a navigation edge: {refs:?}",
+        );
+    }
+
     #[test]
     fn method_references_include_next_dispatch() {
         // `Sub::greet`'s body invokes the super via `next`; that dispatch is a

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -1291,6 +1291,47 @@ fn rename_var(
     edits
 }
 
+/// Whether this call site is an ensemble **dispatch word whose spelling the
+/// rename must not touch** — the `show` of `::app::widget show` when the
+/// ensemble bound it with `-map {show ::app::widget::Show}` (issue #1281).
+///
+/// A `-map` key is an arbitrary name with no required relationship to the
+/// target it dispatches to (tclsh 8.6.14 / 9.0.4: with that map,
+/// `::app::widget show` runs the proc and `::app::widget Show` is `unknown or
+/// ambiguous subcommand "Show": must be show`).  So renaming
+/// `::app::widget::Show` → `Display` must rewrite the declaration and the
+/// `-map` *value* — a separate reference this same loop rewrites, because its
+/// span really does carry the target's name — while leaving the dispatch word
+/// alone.  Rewriting it is the corruption the issue reports: the map still
+/// says `show`, and the edited call names a subcommand that does not exist.
+///
+/// A `-subcommands {alpha}` entry is the opposite case and is deliberately
+/// **not** gated: there the subcommand word *is* the target's tail, the
+/// ensemble derives `::app::widget::alpha` from it, and leaving it behind
+/// gives `invalid command name "alpha"` — so it must be rewritten with the
+/// declaration, which is what the ungated path already does.
+///
+/// This reads the per-site provenance the analyser recorded, not a name
+/// comparison against `ensemble_subcommand_targets`: a `-map {Show
+/// ::app::widget::Show}` whose key happens to equal the target's tail is
+/// textually indistinguishable from an ordinary bare call to the target, and
+/// only the recording site knows which one this span is.
+///
+/// Find-references, code-lens counts and call-hierarchy are untouched by this
+/// — a dispatch site is a genuine reference under either provenance, and the
+/// gate lives here (in the two rename loops) rather than in
+/// [`crate::references::invocation_references_proc`], which all of them
+/// share.
+#[must_use]
+fn ensemble_map_dispatch_word(
+    ensemble_dispatch: Option<tcl_compiler::signature_scan::types::EnsembleSubcommandProvenance>,
+) -> bool {
+    matches!(
+        ensemble_dispatch,
+        Some(tcl_compiler::signature_scan::types::EnsembleSubcommandProvenance::Map)
+    )
+}
+
 /// Proc-rename path — declaration name span + every matching
 /// call site.  Namespace-aware: the declaration keeps its
 /// prefix; call sites pick the rewrite that matches the form
@@ -1362,6 +1403,11 @@ fn rename_proc(
         // `$cmd` head, M7) — rewriting it would splice the new name over
         // unrelated text.  References still report it; rename must not.
         if inv.indirect {
+            continue;
+        }
+        // A `-map` key is an arbitrary name the target's rename does not
+        // change — see [`ensemble_map_dispatch_word`].
+        if ensemble_map_dispatch_word(inv.ensemble_dispatch) {
             continue;
         }
         // Use the *same* invocation-matching rule as Find-All-References so a
@@ -1441,6 +1487,11 @@ fn rename_class(
         // Indirect sites (M7) are references, never rename targets — the span
         // does not carry the written name.
         if inv.indirect {
+            continue;
+        }
+        // A `-map` key is an arbitrary name the target's rename does not
+        // change — see [`ensemble_map_dispatch_word`].
+        if ensemble_map_dispatch_word(inv.ensemble_dispatch) {
             continue;
         }
         // Use the *same* invocation-matching rule as Find-All-References so a
@@ -1651,6 +1702,13 @@ pub fn cross_document_symbol_edits(
         // Indirect sites (constant `$cmd` heads, M7) are references, never
         // rename targets — their span is not the written name.
         if inv.indirect {
+            continue;
+        }
+        // The cross-document half of the same `-map` gate the in-document
+        // rename applies — see [`ensemble_map_dispatch_word`].  An ensemble
+        // declared in one document and dispatched from another is exactly the
+        // shape issue #923 idx 85 widened the recording to reach.
+        if ensemble_map_dispatch_word(inv.ensemble_dispatch) {
             continue;
         }
         let replacement =
@@ -2072,6 +2130,135 @@ mod tests {
         result
     }
 
+    /// Issue #1281 — the `-map` half. Renaming the target must rewrite the
+    /// declaration and the `-map` *value* and leave the subcommand word
+    /// alone.
+    ///
+    /// Oracle (tclsh 8.6.14 / 9.0.4, identical): with `-map {show
+    /// ::app::widget::Show}`, `::app::widget show` runs the proc and
+    /// `::app::widget Show` is `unknown or ambiguous subcommand "Show": must
+    /// be show` — the key is arbitrary, so the applied edit set must keep
+    /// spelling it `show`.
+    #[test]
+    fn renaming_a_map_target_does_not_rewrite_the_subcommand_word_1281() {
+        let src = "namespace eval ::app::widget {}\n\
+                   proc ::app::widget::Show {} { return \"showing\" }\n\
+                   namespace ensemble create -command ::app::widget \
+                   -map {show ::app::widget::Show}\n\
+                   puts [::app::widget show]\n";
+        let analysis = analyse(src);
+        // Cursor on the `Show` of the declaration (line 1, col 20).
+        let edits = rename(src, "tcl", 1, 20, "Display", &analysis, None);
+        let applied = apply_edits(src, &edits);
+        assert!(
+            applied.contains("proc ::app::widget::Display {}"),
+            "the declaration must be renamed: {applied}"
+        );
+        assert!(
+            applied.contains("-map {show ::app::widget::Display}"),
+            "the -map value names the target and must follow it: {applied}"
+        );
+        assert!(
+            applied.contains("puts [::app::widget show]"),
+            "the -map key is arbitrary and must be left alone: {applied}"
+        );
+    }
+
+    /// Issue #1281 — the `-subcommands` half, and the true negative for the
+    /// gate above: the fix must not over-correct into never rewriting an
+    /// ensemble dispatch word.
+    ///
+    /// Oracle (tclsh 8.6.14 / 9.0.4, identical): a `-subcommands {alpha}`
+    /// ensemble whose proc has been renamed to `beta` answers
+    /// `invalid command name "alpha"` — the entry *is* the target's tail, so
+    /// it and the dispatch word must move with the declaration.
+    #[test]
+    fn renaming_a_subcommands_target_still_rewrites_the_subcommand_word_1281() {
+        let src = "namespace eval ::app::widget {\n    \
+                   proc alpha {} { return \"alpha!\" }\n    \
+                   namespace ensemble create -command ::app::widget \
+                   -subcommands {alpha}\n\
+                   }\n\
+                   puts [::app::widget alpha]\n";
+        let analysis = analyse(src);
+        // Cursor on the `alpha` of the declaration (line 1, col 9).
+        let edits = rename(src, "tcl", 1, 9, "beta", &analysis, None);
+        let applied = apply_edits(src, &edits);
+        assert!(
+            applied.contains("proc beta {}"),
+            "the declaration must be renamed: {applied}"
+        );
+        assert!(
+            applied.contains("-subcommands {beta}"),
+            "the -subcommands entry is the target's tail: {applied}"
+        );
+        assert!(
+            applied.contains("puts [::app::widget beta]"),
+            "the dispatch word must follow the target under -subcommands: {applied}"
+        );
+    }
+
+    /// Issue #1281 — the gate is a *rename* gate, not a reference rule. Both
+    /// dispatch sites stay in find-references (they are genuine references
+    /// under either provenance); only the emitted edit sets differ. The two
+    /// share `invocation_references_proc`, so this is the assertion that
+    /// stops the hazard being "fixed" by weakening references.
+    #[test]
+    fn find_references_still_reports_both_ensemble_dispatch_sites_1281() {
+        let map_src = "namespace eval ::app::widget {}\n\
+                       proc ::app::widget::Show {} { return \"showing\" }\n\
+                       namespace ensemble create -command ::app::widget \
+                       -map {show ::app::widget::Show}\n\
+                       puts [::app::widget show]\n";
+        let analysis = analyse(map_src);
+        let refs = crate::references::references(map_src, "tcl", 1, 20, &analysis, false);
+        assert!(
+            refs.iter().any(|r| r.start_line == 3),
+            "the -map dispatch site is a reference: {refs:?}"
+        );
+
+        let sub_src = "namespace eval ::app::widget {\n    \
+                       proc alpha {} { return \"alpha!\" }\n    \
+                       namespace ensemble create -command ::app::widget \
+                       -subcommands {alpha}\n\
+                       }\n\
+                       puts [::app::widget alpha]\n";
+        let analysis = analyse(sub_src);
+        let refs = crate::references::references(sub_src, "tcl", 1, 9, &analysis, false);
+        assert!(
+            refs.iter().any(|r| r.start_line == 4),
+            "the -subcommands dispatch site is a reference: {refs:?}"
+        );
+    }
+
+    /// Issue #1281 — a dynamically built `-map` records no mapping at all, so
+    /// the dispatch word is never attributed to the target and no rename can
+    /// rewrite it. The abstention is inherited from the recording site rather
+    /// than re-decided in rename.
+    #[test]
+    fn a_dynamic_map_leaves_the_dispatch_word_unattributed_1281() {
+        let src = "namespace eval ::app::widget {}\n\
+                   proc ::app::widget::Show {} { return \"showing\" }\n\
+                   set m [list show ::app::widget::Show]\n\
+                   namespace ensemble create -command ::app::widget -map $m\n\
+                   puts [::app::widget show]\n";
+        let analysis = analyse(src);
+        assert!(
+            analysis
+                .ensemble_subcommand_targets
+                .get("::app::widget")
+                .is_none_or(std::collections::HashMap::is_empty),
+            "a dynamic -map records no mapping: {:?}",
+            analysis.ensemble_subcommand_targets,
+        );
+        let edits = rename(src, "tcl", 1, 20, "Display", &analysis, None);
+        let applied = apply_edits(src, &edits);
+        assert!(
+            applied.contains("puts [::app::widget show]"),
+            "an unattributed dispatch word must not be rewritten: {applied}"
+        );
+    }
+
     #[test]
     fn rename_rewrites_a_method_return_captured_dispatch_site() {
         // Issue #994 C5b / #1143: `b` is typed only by the object-type
@@ -2329,6 +2516,96 @@ mod tests {
             cross_document_symbol_edits("::mymod::helper", "helper2", &index, "file:///caller.tcl");
         assert_eq!(edits.len(), 1, "{edits:?}");
         assert_eq!(edits[0].uri, "file:///mymod.tcl");
+    }
+
+    /// Issue #1281 — the class-rename tier carries the same gate. A `-map`
+    /// target can name a class command just as easily as a proc
+    /// (`-map {make ::Widget}` dispatches `widget make` to `::Widget`), and
+    /// `rename_class` gathers call sites through the same invocation loop, so
+    /// leaving it ungated would move the corruption one tier over.
+    #[test]
+    fn renaming_a_class_used_as_a_map_target_does_not_rewrite_the_subcommand_word_1281() {
+        let src = "oo::class create ::Widget { method draw {} {} }\n\
+                   namespace ensemble create -command ::app -map {make ::Widget}\n\
+                   ::app make\n";
+        let analysis = analyse(src);
+        // Cursor on the `::Widget` of the class declaration (line 0, col 17).
+        let edits = rename(src, "tcl", 0, 17, "Panel", &analysis, None);
+        let applied = apply_edits(src, &edits);
+        // (The class tier's own qualifier handling writes the short form
+        // here; the identity is the same command at global level. What this
+        // test is about is the two words below.)
+        assert!(
+            applied.contains("oo::class create Panel"),
+            "the class declaration must be renamed: {applied}"
+        );
+        assert!(
+            applied.contains("-map {make ::Panel}"),
+            "the -map value names the class and must follow it: {applied}"
+        );
+        assert!(
+            applied.contains("::app make\n"),
+            "the -map key is arbitrary and must be left alone: {applied}"
+        );
+    }
+
+    /// Issue #1281, cross-document half: the workspace edit path
+    /// ([`cross_document_symbol_edits`], which `workspace_symbol_rename_edits`
+    /// drives over *every* document) gathers the same invocation records, so
+    /// it needs the same provenance gate — otherwise the corruption simply
+    /// moves from the in-document tier to the workspace one.
+    ///
+    /// The `-subcommands` half is the control: the identical shape, sharing
+    /// the identical path, does rewrite its dispatch word — so the `-map`
+    /// verdict below is the gate at work, not a path that never reaches the
+    /// site.
+    #[test]
+    fn cross_document_symbol_edits_apply_the_ensemble_map_gate_1281() {
+        use crate::workspace_index::WorkspaceIndex;
+
+        let map_lib = analyse(
+            "namespace eval ::app::widget {}\n\
+             proc ::app::widget::Show {} { return \"showing\" }\n\
+             namespace ensemble create -command ::app::widget \
+             -map {show ::app::widget::Show}\n\
+             puts [::app::widget show]\n",
+        );
+        let index = WorkspaceIndex::from_documents([("file:///lib.tcl", &map_lib)]);
+        let edits = cross_document_symbol_edits(
+            "::app::widget::Show",
+            "Display",
+            &index,
+            "file:///caller.tcl",
+        );
+        assert!(
+            edits.iter().all(|e| e.new_text != "Display"),
+            "the -map key is arbitrary — no bare-tail edit may target the \
+             dispatch word: {edits:?}",
+        );
+        assert!(
+            edits.iter().any(|e| e.new_text == "::app::widget::Display"),
+            "the declaration and the -map value must still be rewritten: {edits:?}",
+        );
+
+        let sub_lib = analyse(
+            "namespace eval ::app::widget {\n    \
+             proc alpha {} { return \"alpha!\" }\n    \
+             namespace ensemble create -command ::app::widget -subcommands {alpha}\n\
+             }\n\
+             puts [::app::widget alpha]\n",
+        );
+        let index = WorkspaceIndex::from_documents([("file:///lib.tcl", &sub_lib)]);
+        let edits = cross_document_symbol_edits(
+            "::app::widget::alpha",
+            "beta",
+            &index,
+            "file:///caller.tcl",
+        );
+        assert!(
+            edits.iter().filter(|e| e.new_text == "beta").count() >= 2,
+            "a -subcommands entry and its dispatch word must both follow the \
+             target through the same path: {edits:?}",
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -455,6 +455,16 @@ pub struct WorkspaceInvocation {
     /// the rename providers must abstain for the whole symbol rather than
     /// leave the site dispatching the old name (issue #945 fault 1).
     pub rename_safe: bool,
+    /// `Some(provenance)` when this site is the **subcommand word** of an
+    /// `<ensemble> <sub> …` dispatch, mirroring
+    /// [`tcl_compiler::signature_scan::types::SignatureCommandInvocation::ensemble_dispatch`]
+    /// (issue #1281) so the cross-document rename path applies the same gate
+    /// the in-document one does: a `-map` key is an arbitrary name, so it
+    /// must survive a rename of its target unchanged; a `-subcommands` entry
+    /// is the target's tail and must follow it.  References report the site
+    /// either way.
+    pub ensemble_dispatch:
+        Option<tcl_compiler::signature_scan::types::EnsembleSubcommandProvenance>,
     /// Span of the innermost proc/class **body** containing this call site,
     /// within [`Self::uri`]; `None` when the call sits at load level.
     ///
@@ -1179,6 +1189,7 @@ impl DocumentRecords {
                 range: inv.range,
                 indirect: inv.indirect,
                 rename_safe: inv.rename_safe,
+                ensemble_dispatch: inv.ensemble_dispatch,
                 enclosing_body,
             });
         }

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -1144,7 +1144,13 @@ pub struct ItemBodyKey<'db> {
     ///   bodies whose creation calls it decides.
     #[returns(ref)]
     pub body_env: (
-        Vec<(String, Vec<(String, String)>)>,
+        Vec<(
+            String,
+            Vec<(
+                String,
+                tcl_compiler::analyser::types::EnsembleSubcommandTarget,
+            )>,
+        )>,
         Option<(bool, Vec<String>, Vec<String>)>,
         Option<Arc<tcl_compiler::analyser::ClassFactoryIndex>>,
     ),

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -17723,6 +17723,15 @@ fn extend_resolver_with_document_auto_paths(
 /// (`C:\repo\user.tcl`, which is what `Uri::to_file_path` yields there)
 /// resolving against its own directory.  It returns slash form, which
 /// `PathBuf` accepts on every host.
+///
+/// A `lappend auto_path lib` folds to a **relative** directory: Tcl resolves
+/// it against the interpreter's run-time working directory, which no static
+/// analysis knows (tclsh 8.6.16 / 9.0.4-verified), so the evaluator returns
+/// it unanchored rather than pinning it to the language server's own launch
+/// directory — an editor artefact unrelated to the user's program. This is
+/// the caller that owns the closest base the editor actually has: the
+/// analysed document's own directory, which is what the run-from-its-own
+/// -directory convention every relocatable Tcl project uses makes true.
 fn document_auto_path_dirs(uri: &Uri, analysis: &AnalysisResult) -> Vec<PathBuf> {
     if analysis.auto_path_entries.is_empty() {
         return Vec::new();
@@ -17741,7 +17750,10 @@ fn document_auto_path_dirs(uri: &Uri, analysis: &AnalysisResult) -> Vec<PathBuf>
             if dirs.len() >= DOCUMENT_AUTO_PATH_DIR_CAP {
                 break;
             }
-            let dir = PathBuf::from(folded);
+            // Anchor a rootless fold on the document's own directory (see
+            // this function's doc comment); an already-rooted one passes
+            // through unchanged.
+            let dir = tcl_lsp_core::source_graph::resolve_source_target(&file_path, &folded);
             if !dirs.contains(&dir) {
                 dirs.push(dir);
             }

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -21265,6 +21265,97 @@ mod tests {
         );
     }
 
+    /// Issue #923 idx 73 — the depth `pix` itself writes: **three** nested
+    /// `file dirname`s, reaching two directories above the analysed file.
+    /// The committed tests are one level shallower, and the evaluator is
+    /// recursive, so this is about the layout rather than the arithmetic: a
+    /// deeply-nested `examples/subdir/user.tcl` whose package lives at the
+    /// repo root, with the workspace root scoped to the leaf directory.
+    ///
+    /// Oracle (tclsh 9.0.4 and 8.6.16, this exact layout): running
+    /// `examples/demos/user.tcl` prints `loaded:foo.png`.
+    #[tokio::test]
+    async fn a_triple_nested_dirname_auto_path_feeds_the_package_database() {
+        let ws = TmpWs::new("autopath-triple");
+        ws.write(
+            "reporoot/pkgIndex.tcl",
+            "package ifneeded mypix 1.0 [list source [file join $dir mypix.tcl]]\n",
+        );
+        ws.write(
+            "reporoot/mypix.tcl",
+            "package provide mypix 1.0\nproc ::mypix::readImage {path} { return \"loaded:$path\" }\n",
+        );
+        ws.write(
+            "reporoot/examples/demos/user.tcl",
+            "lappend auto_path [file dirname [file dirname [file dirname [info script]]]]\n\
+             package require mypix\n\
+             puts [::mypix::readImage foo.png]\n",
+        );
+
+        let backend = test_backend();
+        // Root is the leaf `demos/` directory — two levels below the package.
+        let narrow_root = Uri::from_file_path(ws.0.join("reporoot/examples/demos")).unwrap();
+        *backend.workspace_folders.lock().await = vec![narrow_root];
+        backend.scan_workspace_folders().await;
+        assert!(
+            backend.package_resolver.read().await.provides("mypix"),
+            "a triple-nested `[file dirname …]` auto_path entry must reach the \
+             repo-root package directory",
+        );
+    }
+
+    /// Issue #923 idx 41's incidental finding: a *relative* `auto_path` entry
+    /// (`lappend auto_path lib`) resolves against the interpreter's working
+    /// directory at run time, which no static analysis knows — so it must be
+    /// anchored on the analysed document's own directory, never on the
+    /// language server process's launch directory (an editor artefact).
+    ///
+    /// Oracle (tclsh 8.6.16 / 9.0.4): `cd reporoot && tclsh main.tcl` loads
+    /// `reporoot/lib`'s package; the same file run from elsewhere would not.
+    /// The document's directory is the closest base an editor has, and — as
+    /// this test proves by construction — it is a base the *server's* own
+    /// working directory is not.
+    #[tokio::test]
+    async fn a_relative_auto_path_entry_anchors_on_the_document_not_the_server_cwd() {
+        let ws = TmpWs::new("autopath-relative");
+        ws.write(
+            "reporoot/lib/pkgIndex.tcl",
+            "package ifneeded relpix 1.0 [list source [file join $dir relpix.tcl]]\n",
+        );
+        ws.write(
+            "reporoot/lib/relpix.tcl",
+            "package provide relpix 1.0\nproc ::relpix::go {} { return ok }\n",
+        );
+        ws.write(
+            "reporoot/main.tcl",
+            "lappend auto_path lib\npackage require relpix\nputs [::relpix::go]\n",
+        );
+
+        let main_uri = Uri::from_file_path(ws.0.join("reporoot/main.tcl")).unwrap();
+        let main_src = std::fs::read_to_string(ws.0.join("reporoot/main.tcl")).expect("read");
+        let analysis = tcl_compiler::analyser::Analyser::new()
+            .analyse(&main_src, "tcl8.6")
+            .clone();
+        assert_eq!(
+            document_auto_path_dirs(&main_uri, &analysis),
+            vec![ws.0.join("reporoot/lib")],
+            "`lappend auto_path lib` must resolve against the document's own \
+             directory; the server process's working directory is not a fact \
+             about the user's program",
+        );
+
+        // And it really does make the package resolvable, with the workspace
+        // root scoped to the document's directory only.
+        let backend = test_backend();
+        let root = Uri::from_file_path(ws.0.join("reporoot")).unwrap();
+        *backend.workspace_folders.lock().await = vec![root];
+        backend.scan_workspace_folders().await;
+        assert!(
+            backend.package_resolver.read().await.provides("relpix"),
+            "the relative auto_path entry must put `reporoot/lib` on the search path",
+        );
+    }
+
     /// Issue #1090 — end to end across documents: which *release* of a
     /// multi-version package go-to-definition lands in.
     ///

--- a/rust/tcl-lsp-server/tests/e2e.rs
+++ b/rust/tcl-lsp-server/tests/e2e.rs
@@ -67,6 +67,8 @@ mod issue1122_sticky_scroll;
 mod issue1137_call_site_resolution;
 #[path = "e2e/issue1214_uri_canonicalisation.rs"]
 mod issue1214_uri_canonicalisation;
+#[path = "e2e/issue1281_ensemble_rename.rs"]
+mod issue1281_ensemble_rename;
 #[path = "e2e/issue923_class_refs.rs"]
 mod issue923_class_refs;
 #[path = "e2e/issue923_crossdoc.rs"]

--- a/rust/tcl-lsp-server/tests/e2e/definition.rs
+++ b/rust/tcl-lsp-server/tests/e2e/definition.rs
@@ -1248,3 +1248,69 @@ fn the_server_hands_code_actions_the_shadow_answer() {
         "with no covering export the local body is offered: {actions}"
     );
 }
+
+/// Issue #923 differential-audit finding idx 43 — `ticklecharts`' `etypes.tcl`
+/// shape: a `namespace ensemble create -command ::new -subcommands {…}` whose
+/// implementing procs are installed by a `foreach` loop through a substituted
+/// name (`proc ticklecharts::${ptype} …`).
+///
+/// Oracle (tclsh 9.0.4 and 8.6.16, identical): `new elist {1 2 3}` prints
+/// `elist {1 2 3}` and `new edict {k v}` prints `edict {k v}`, so every
+/// literal loop element really does become a callable command.
+///
+/// The analyser's `all_procs` table is pinned by a unit test; nothing checked
+/// that the LSP-facing consumers (go-to-definition, diagnostics, the outline)
+/// read it correctly for a loop-generated name — which is where all three of
+/// the finding's reported symptoms lived.
+#[test]
+fn foreach_generated_ensemble_subcommands_navigate_and_outline_923_idx43() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = concat!(
+        "namespace eval ticklecharts {\n", // 0
+        "    namespace ensemble create -command ::new -subcommands {elist elist.n edict}\n", // 1
+        "}\n",                             // 2
+        "foreach ptype {elist elist.n} {\n", // 3
+        "    proc ticklecharts::${ptype} {args} [string map [list %P% $ptype] {\n", // 4
+        "        return \"%P% $args\"\n",  // 5
+        "    }]\n",                        // 6
+        "}\n",                             // 7
+        "proc ticklecharts::edict {args} { return \"edict $args\" }\n", // 8
+    );
+    lsp.open_ready(&uri, src);
+
+    // 1. Go-to-definition on `elist` inside the `-subcommands` list (line 1,
+    //    column 60) lands on the one physical `proc` statement that backs it.
+    let def = locations(&lsp.definition(&uri, 1, 60));
+    assert_eq!(
+        def.iter().map(start_line).collect::<Vec<_>>(),
+        vec![4],
+        "`elist` in -subcommands must reach the foreach-installed proc: {def:?}",
+    );
+
+    // 2. No false "unknown command" for a name only the loop creates.
+    let diags = lsp.pull_diagnostics(&uri);
+    assert!(
+        !diags.iter().any(|d| {
+            d.get("code").and_then(Value::as_str) == Some("W123")
+                && d.get("message")
+                    .and_then(Value::as_str)
+                    .is_some_and(|m| m.contains("elist"))
+        }),
+        "a loop-installed proc must not draw W123: {diags:?}",
+    );
+
+    // 3. The outline names the real per-literal procs, not the unsubstituted
+    //    `${ptype}` placeholder.
+    let symbols = serde_json::to_string(&lsp.document_symbols(&uri)).expect("symbols json");
+    for want in ["elist", "elist.n"] {
+        assert!(
+            symbols.contains(&format!("\"{want}\"")),
+            "the outline must list `{want}`: {symbols}",
+        );
+    }
+    assert!(
+        !symbols.contains("${ptype}"),
+        "the outline must not show the unsubstituted placeholder: {symbols}",
+    );
+}

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -2919,6 +2919,180 @@ fn patch_level_guarded_pkgindex_suppresses_w123() {
     let _ = std::fs::remove_dir_all(&libdir);
 }
 
+/// TN (issue #923 differential-audit finding idx 42) — the shape
+/// `georgtree/tclopt`'s real `pkgIndex.tcl.in` has: a TEA-style version
+/// branch whose **both** arms declare the same `package ifneeded`. The
+/// package is available whichever arm runs, so flagging its commands is a
+/// false positive.
+///
+/// The e2e tier previously only covered the *early-return* guard (#1017);
+/// the both-arms shape was pinned only by a `package_resolver::reachability`
+/// unit test, so a regression in how the server's diagnostics pipeline
+/// consumes that module would not have been caught here.
+///
+/// Oracle (tclsh 8.6.16 and 9.0.4, `TCLLIBPATH` pointing at the fixture):
+/// `package require mypkg` succeeds and `mypkgHello` returns `hi` on both,
+/// exactly as for a flat unguarded index.
+#[test]
+fn both_arms_of_a_version_branch_declaring_the_package_suppress_w123_923_idx42() {
+    let libdir = pkg_libdir_with_index(
+        "if {[package vsatisfies [package provide Tcl] 9-]} {\n\
+         \x20   package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n\
+         } else {\n\
+         \x20   package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n\
+         }\n",
+    );
+    for dialect in ["tcl8.6", "tcl9.0"] {
+        let diags = guarded_pkg_child_diagnostics(dialect, &libdir);
+        assert!(
+            !has_code(&diags, "W123"),
+            "{dialect}: a package declared in every arm of a version branch is \
+             always available and must suppress W123, got: {:?}",
+            codes(&diags),
+        );
+    }
+    let _ = std::fs::remove_dir_all(&libdir);
+}
+
+/// TP control for the above — the same both-arms index, but the sourced file
+/// does not define the called command. The suppression must be
+/// *command-specific* (the package resolved, this command genuinely is not in
+/// it), not a blanket "package involved, stay quiet".
+#[test]
+fn a_command_absent_from_a_branch_declared_package_still_fires_w123_923_idx42() {
+    let libdir = pkg_libdir_with_index(
+        "if {[package vsatisfies [package provide Tcl] 9-]} {\n\
+         \x20   package ifneeded mypkg 1.0 [list source [file join $dir other.tcl]]\n\
+         } else {\n\
+         \x20   package ifneeded mypkg 1.0 [list source [file join $dir other.tcl]]\n\
+         }\n",
+    );
+    // `other.tcl` exists but defines something else entirely.
+    std::fs::write(
+        libdir.join("mypkg").join("other.tcl"),
+        "proc somethingElse {} { return hi }\n",
+    )
+    .expect("write other.tcl");
+    let diags = guarded_pkg_child_diagnostics("tcl9.0", &libdir);
+    assert!(
+        has_code(&diags, "W123"),
+        "a command the resolved package does not provide must still be flagged, got: {:?}",
+        codes(&diags),
+    );
+    let _ = std::fs::remove_dir_all(&libdir);
+}
+
+/// TN (issue #923 differential-audit finding idx 72) — a package whose
+/// `pkgIndex.tcl` only `load`s a binary extension has **no** companion `.tcl`
+/// file at all (`pix`'s real shape). Such a declaration is still a real,
+/// known package: treating it as unknowable made the whole document's W120
+/// "requires `package require …`" diagnostics vanish, including ones about
+/// entirely unrelated packages.
+///
+/// The two committed regression tests for this call `parse_pkg_index` /
+/// `refine_w120_diagnostics` directly; this drives the same fact through the
+/// real server, a real on-disk library scan and the pull-diagnostics path.
+#[test]
+fn a_load_only_package_does_not_suppress_unrelated_w120s_923_idx72() {
+    use std::sync::atomic::Ordering;
+    let libdir = std::env::temp_dir().join(format!(
+        "tcl-lsp-e2e-loadonlypkg-{}-{}",
+        std::process::id(),
+        GUARDED_PKG_N.fetch_add(1, Ordering::Relaxed)
+    ));
+    let pkgdir = libdir.join("testpix");
+    std::fs::create_dir_all(&pkgdir).expect("mk testpix lib dir");
+    // Deliberately the *only* file in the directory — no companion `.tcl`.
+    std::fs::write(
+        pkgdir.join("pkgIndex.tcl"),
+        "package ifneeded testpix 0.8 \
+         [list apply {dir {load [file join $dir libtestpix.so] Pix}} $dir]\n",
+    )
+    .expect("write pkgIndex.tcl");
+
+    let mut lsp = Lsp::with_config(serde_json::json!({
+        "libraryPaths": [ libdir.to_string_lossy() ],
+    }));
+    let baseline_uri = unique_uri("tcl");
+    lsp.open_ready(&baseline_uri, "http::register https 443 ::tls::socket\n");
+    let baseline = lsp.pull_diagnostics(&baseline_uri);
+    assert!(
+        has_code(&baseline, "W120"),
+        "baseline: an `http::register` with no `package require http` must draw \
+         W120, got: {:?}",
+        codes(&baseline),
+    );
+
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "package require testpix\nhttp::register https 443 ::tls::socket\n",
+    );
+    // The package database loads asynchronously; poll until the answer settles.
+    let mut diags = lsp.pull_diagnostics(&uri);
+    let deadline = std::time::Instant::now() + scaled_timeout(Duration::from_secs(15));
+    while std::time::Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(100));
+        let next = lsp.pull_diagnostics(&uri);
+        if codes(&next) == codes(&diags) {
+            diags = next;
+            break;
+        }
+        diags = next;
+    }
+    assert!(
+        has_code(&diags, "W120"),
+        "requiring a load-only package must not silence an unrelated W120, got: {:?}",
+        codes(&diags),
+    );
+    let _ = std::fs::remove_dir_all(&libdir);
+}
+
+/// TN (issue #923 differential-audit finding idx 64) — an unmatched literal
+/// `{` inside a *double-quoted* string does not stop substitution, so the
+/// `$ns` beside it is a genuine read and the `set` before it is not a dead
+/// store.
+///
+/// Oracle (tclsh 8.6.16 and 9.0.4): `set ns "ctx"; puts "{ $ns"` prints
+/// `{ ctx` — the variable really is read. W220 fired anyway, on the exact
+/// shape `pix`'s `pixdoc.tcl` uses to emit generated `namespace eval`
+/// preambles. Pinned at the analyser's own `fires()` helper (FP-DS-13) but
+/// never through the server's publish path until now.
+#[test]
+fn an_unmatched_brace_in_a_quoted_string_keeps_the_read_923_idx64() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, "set ns \"ctx\"\nputs \"{ $ns\"\n");
+    let diags = lsp.pull_diagnostics(&uri);
+    assert!(
+        !has_code(&diags, "W220"),
+        "`$ns` after an unmatched `{{` in a quoted string is a real read, got: {:?}",
+        codes(&diags),
+    );
+
+    // The fuller shape the finding came from: an if/elseif namespace remap
+    // feeding a generated `namespace eval` preamble.
+    let uri2 = unique_uri("tcl");
+    lsp.open_ready(
+        &uri2,
+        "set fp [open /tmp/genned.tcl w]\n\
+         foreach name {paths image} {\n\
+         \x20   if {$name eq \"paths\"} { set ns path } elseif {$name eq \"image\"} \
+         { set ns img } else { set ns other }\n\
+         \x20   set preamble \"Docs for $name\"\n\
+         \x20   puts $fp \"namespace eval ::pix {\\n    namespace eval $ns {\\n\
+         \x20       variable _ruff_preamble $preamble\\n    }\\n}\"\n\
+         }\n\
+         close $fp\n",
+    );
+    let diags2 = lsp.pull_diagnostics(&uri2);
+    assert!(
+        !has_code(&diags2, "W220"),
+        "the generated-preamble idiom must draw no dead-store warning, got: {:?}",
+        codes(&diags2),
+    );
+}
+
 /// Per-call counter for the autoload references/rename fixture dir.
 static AUTOLOAD_REFS_N: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 

--- a/rust/tcl-lsp-server/tests/e2e/hover.rs
+++ b/rust/tcl-lsp-server/tests/e2e/hover.rs
@@ -845,3 +845,93 @@ fn parameter_default_literal_does_not_hover_923_idx104() {
     let text = hover(&mut lsp, &uri, 2, 5);
     assert!(text.contains("destroy"), "hover: {text:?}");
 }
+
+/// Issue #923 differential-audit findings idx 3 / idx 4 — tcllib's
+/// `textutil::adjust` submodule. `package require textutil::adjust` followed
+/// by `namespace import textutil::adjust::*` makes bare `adjust` / `indent`
+/// callable, and they are the *three*-segment commands
+/// `::textutil::adjust::adjust` / `::textutil::adjust::indent` — distinct
+/// from the two-segment `textutil::adjust` / `textutil::indent` flattened
+/// aliases the umbrella `textutil` package creates.
+///
+/// Oracle (tclsh 8.6.16 and 9.0.4, tcllib 2.0 on `auto_path`):
+/// `namespace origin adjust` → `::textutil::adjust::adjust` and
+/// `namespace origin indent` → `::textutil::adjust::indent`.
+///
+/// Coverage was split between registry-table unit tests (naming and gating)
+/// and a generic `resolve_imported_command` e2e test using `tcltest`; nothing
+/// tied the two together for this pair, so a regression in either layer's
+/// interaction would have gone unseen. The idiom is real corpus code
+/// (`argparse.tcl` buries both inside an `if`, as here).
+#[test]
+fn a_wildcard_imported_textutil_submodule_command_hovers_qualified_923_idx3_idx4() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        concat!(
+            "proc buildHelp {args} {\n",
+            "    if {[llength $args]} {\n",
+            "        package require textutil::adjust\n",
+            "        namespace import textutil::adjust::*\n",
+            "        set wrapped [adjust \"a long help string\" -length 20]\n",
+            "        set final [indent $wrapped \"  \"]\n",
+            "        puts $final\n",
+            "    }\n",
+            "}\n",
+        ),
+    );
+    // Line 4, `adjust` starts at column 21.
+    let adjust = hover(&mut lsp, &uri, 4, 22);
+    assert!(
+        adjust.contains("textutil::adjust::adjust"),
+        "bare imported `adjust` must hover as the three-segment submodule \
+         command, not the umbrella alias: {adjust:?}",
+    );
+    // Line 5, `indent` starts at column 19.
+    let indent = hover(&mut lsp, &uri, 5, 20);
+    assert!(
+        indent.contains("textutil::adjust::indent"),
+        "bare imported `indent` must hover as `textutil::adjust::indent`: \
+         {indent:?}",
+    );
+}
+
+/// Issue #923 differential-audit finding idx 102, its *secondary* claim —
+/// hover on the `{file}` **parameter declaration** token must report a
+/// variable, never the built-in `file` command's documentation.
+///
+/// The primary claim (the `$file` read inside the `[list source [file join
+/// …]]` body resolving at all) is pinned by
+/// `references_reach_a_parameter_read_inside_a_list_built_namespace_body`;
+/// nothing guarded this half, which is fixed only as a by-product of the
+/// read being classified as a variable reference before any registry lookup
+/// happens — precisely the kind of thing a later refactor reintroduces.
+///
+/// Oracle (tclsh 8.6.16 and 9.0.4): the parameter genuinely drives which file
+/// is sourced, so it is a variable at both ends.
+#[test]
+fn hover_on_a_parameter_named_after_a_builtin_is_a_variable_923_idx102() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "proc ::tk::SourceLibFile {file} {\n    namespace eval :: [list source [file join $::tk_library $file.tcl]]\n}\n",
+    );
+    // Line 0, the `file` of the parameter list `{file}` — column 25.
+    let decl = hover(&mut lsp, &uri, 0, 26);
+    assert!(
+        decl.contains("Variable"),
+        "the `{{file}}` parameter declaration must hover as a variable: {decl:?}",
+    );
+    assert!(
+        !decl.contains("file dirname") && !decl.contains("file exists"),
+        "it must not be misattributed to the builtin `file` command: {decl:?}",
+    );
+    // And the read inside the list-built body agrees.
+    let read = hover(&mut lsp, &uri, 1, 62);
+    assert!(
+        read.contains("Variable"),
+        "the `$file` read must hover as the same variable: {read:?}",
+    );
+}

--- a/rust/tcl-lsp-server/tests/e2e/issue1281_ensemble_rename.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue1281_ensemble_rename.rs
@@ -1,0 +1,242 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Issue #1281 — renaming an ensemble `-map` target must not rewrite the
+//! **subcommand word** at the dispatch site, while a `-subcommands` target
+//! must still rewrite it.
+//!
+//! Every case here **applies** the emitted `WorkspaceEdit` back onto the
+//! source and asserts the exact resulting program text, because the bug is
+//! invisible at the "some edits came back" layer: the pre-fix edit set looked
+//! complete and confident, and only the applied result — run under a real
+//! `tclsh` — showed it had broken the dispatch.
+//!
+//! Oracle for every expected text below (tclsh 8.6.14 and 9.0.4, identical):
+//!
+//! ```tcl
+//! # -map: the key is arbitrary, unrelated to the target's tail
+//! namespace eval ::app::widget {}
+//! proc ::app::widget::Show {} { return "showing" }
+//! namespace ensemble create -command ::app::widget -map {show ::app::widget::Show}
+//! puts [::app::widget show]     ;# -> showing
+//! puts [::app::widget Show]     ;# -> unknown or ambiguous subcommand "Show": must be show
+//!
+//! # -subcommands: the entry IS the target's tail
+//! namespace eval ::app::widget {
+//!     proc beta {} { return "alpha!" }
+//!     namespace ensemble create -command ::app::widget -subcommands {alpha}
+//! }
+//! puts [::app::widget alpha]    ;# -> invalid command name "alpha"
+//! ```
+//!
+//! So a `-map` rename that rewrites `show` produces `::app::widget Display`
+//! against a map that still says `show` (the reported corruption), and a
+//! `-subcommands` rename that *doesn't* rewrite `alpha` produces an ensemble
+//! whose entry names a proc that no longer exists.
+
+use crate::common::helpers::*;
+use crate::common::{Lsp, unique_uri};
+
+use serde_json::Value;
+
+/// Apply **every** edit the rename returned for `uri` to `source`, rightmost
+/// first so earlier ranges stay valid — the whole edit set, not a
+/// hand-picked one, since the hazard is an edit that should not be in it.
+fn apply_all(edits: &[Value], source: &str) -> String {
+    fn offset(source: &str, pos: &Value) -> usize {
+        let line = usize::try_from(pos["line"].as_u64().unwrap()).unwrap();
+        let character = usize::try_from(pos["character"].as_u64().unwrap()).unwrap();
+        let line_start: usize = source.split_inclusive('\n').take(line).map(str::len).sum();
+        line_start + character
+    }
+    let mut resolved: Vec<(usize, usize, String)> = edits
+        .iter()
+        .map(|e| {
+            let rng = &e["range"];
+            (
+                offset(source, &rng["start"]),
+                offset(source, &rng["end"]),
+                e["newText"].as_str().unwrap_or_default().to_owned(),
+            )
+        })
+        .collect();
+    resolved.sort_by_key(|e| std::cmp::Reverse(e.0));
+    let mut out = source.to_owned();
+    for (start, end, new_text) in resolved {
+        out = format!("{}{}{}", &out[..start], new_text, &out[end..]);
+    }
+    out
+}
+
+/// The rename edit set for `uri`, applied to `src`.
+fn renamed_source(lsp: &mut Lsp, uri: &str, src: &str, pos: (u32, u32), new_name: &str) -> String {
+    let result = lsp.rename(uri, pos.0, pos.1, new_name);
+    let edits = rename_edits(&result);
+    apply_all(&edits.get(uri).cloned().unwrap_or_default(), src)
+}
+
+const MAP_SRC: &str = concat!(
+    "namespace eval ::app::widget {}\n",
+    "proc ::app::widget::Show {} { return \"showing\" }\n",
+    "namespace ensemble create -command ::app::widget -map {show ::app::widget::Show}\n",
+    "puts [::app::widget show]\n",
+    "puts [::app::widget::Show]\n",
+);
+
+const SUBCOMMANDS_SRC: &str = concat!(
+    "namespace eval ::app::widget {\n",
+    "    proc alpha {} { return \"alpha!\" }\n",
+    "    namespace ensemble create -command ::app::widget -subcommands {alpha}\n",
+    "}\n",
+    "puts [::app::widget alpha]\n",
+);
+
+#[test]
+fn renaming_a_map_target_leaves_the_dispatch_word_alone_end_to_end() {
+    // The reported bug. Renaming `::app::widget::Show` → `Display` must
+    // rewrite the declaration and the `-map` *value* (that span really does
+    // carry the target's name) and must leave the `show` of
+    // `::app::widget show` untouched. Applied, the program still prints
+    // `showing` twice under tclsh 8.6.14 / 9.0.4; the pre-fix edit set turned
+    // line 3 into `puts [::app::widget Display]`, which errors with
+    // `unknown or ambiguous subcommand "Display": must be show`.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, MAP_SRC);
+    // Cursor on the `Show` of the `proc ::app::widget::Show` declaration.
+    let out = renamed_source(&mut lsp, &uri, MAP_SRC, (1, 20), "Display");
+    assert_eq!(
+        out,
+        concat!(
+            "namespace eval ::app::widget {}\n",
+            "proc ::app::widget::Display {} { return \"showing\" }\n",
+            "namespace ensemble create -command ::app::widget -map {show ::app::widget::Display}\n",
+            "puts [::app::widget show]\n",
+            "puts [::app::widget::Display]\n",
+        ),
+        "the -map key is arbitrary and must survive the target's rename",
+    );
+}
+
+#[test]
+fn renaming_a_map_target_from_the_dispatch_site_leaves_the_dispatch_word_alone_end_to_end() {
+    // Same verdict from the other trigger position — the gate must not depend
+    // on *which* occurrence the rename was invoked from (the discipline the
+    // idx 79 verification pass established for the member-rename hazard).
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, MAP_SRC);
+    // Cursor on the `show` dispatch word of `puts [::app::widget show]`.
+    let out = renamed_source(&mut lsp, &uri, MAP_SRC, (3, 20), "Display");
+    assert!(
+        out.contains("puts [::app::widget show]\n"),
+        "the dispatch word must be intact however the rename was triggered: {out}",
+    );
+    assert!(
+        !out.contains("::app::widget Display"),
+        "the -map key must never become the target's new name: {out}",
+    );
+}
+
+#[test]
+fn renaming_a_subcommands_target_still_rewrites_the_dispatch_word_end_to_end() {
+    // The true negative: the fix must not over-correct into never touching
+    // ensemble dispatch. With `-subcommands`, the word IS the target's tail,
+    // so the declaration, the `-subcommands` entry and the dispatch word all
+    // move together — applied, the program still prints `alpha!` under
+    // tclsh 8.6.14 / 9.0.4. Leaving the word behind would be
+    // `invalid command name "alpha"`.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, SUBCOMMANDS_SRC);
+    // Cursor on the `alpha` of the `proc alpha` declaration.
+    let out = renamed_source(&mut lsp, &uri, SUBCOMMANDS_SRC, (1, 9), "beta");
+    assert_eq!(
+        out,
+        concat!(
+            "namespace eval ::app::widget {\n",
+            "    proc beta {} { return \"alpha!\" }\n",
+            "    namespace ensemble create -command ::app::widget -subcommands {beta}\n",
+            "}\n",
+            "puts [::app::widget beta]\n",
+        ),
+        "a -subcommands entry is the target's own tail and must follow it",
+    );
+}
+
+#[test]
+fn renaming_a_subcommands_target_from_the_dispatch_site_rewrites_it_too_end_to_end() {
+    // The `-subcommands` half of the trigger-position independence check.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, SUBCOMMANDS_SRC);
+    // Cursor on the `alpha` dispatch word of `puts [::app::widget alpha]`.
+    let out = renamed_source(&mut lsp, &uri, SUBCOMMANDS_SRC, (4, 20), "beta");
+    assert!(
+        out.contains("puts [::app::widget beta]\n"),
+        "the -subcommands dispatch word must be rewritten from here too: {out}",
+    );
+}
+
+#[test]
+fn find_references_reports_the_dispatch_site_under_both_provenances_end_to_end() {
+    // The gate is a *rename* gate. A dispatch site is a genuine reference
+    // either way, so find-references must keep reporting it — the two share
+    // `invocation_references_proc`, which is exactly why fixing rename by
+    // weakening the reference rule would have been the easy wrong fix.
+    let mut lsp = Lsp::tcl();
+    let map_uri = unique_uri("tcl");
+    lsp.open_ready(&map_uri, MAP_SRC);
+    let map_refs = start_lines(&lsp.references(&map_uri, 1, 20, false));
+    assert!(
+        map_refs.contains(&3),
+        "the -map dispatch site is still a reference: {map_refs:?}",
+    );
+
+    let sub_uri = unique_uri("tcl");
+    lsp.open_ready(&sub_uri, SUBCOMMANDS_SRC);
+    let sub_refs = start_lines(&lsp.references(&sub_uri, 1, 9, false));
+    assert!(
+        sub_refs.contains(&4),
+        "the -subcommands dispatch site is still a reference: {sub_refs:?}",
+    );
+}
+
+#[test]
+fn a_dynamic_map_keeps_its_dispatch_word_unattributed_end_to_end() {
+    // The abstention the issue asks to preserve: a `-map` built from a
+    // variable records no mapping at all, so the dispatch word is never
+    // attributed to the target and rename cannot rewrite it — the same answer
+    // the `-map` gate gives, reached by never having the fact rather than by
+    // discarding it. (References agrees: it reports only the declaration.)
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = concat!(
+        "namespace eval ::app::widget {}\n",
+        "proc ::app::widget::Show {} { return \"showing\" }\n",
+        "set m [list show ::app::widget::Show]\n",
+        "namespace ensemble create -command ::app::widget -map $m\n",
+        "puts [::app::widget show]\n",
+    );
+    lsp.open_ready(&uri, src);
+    let out = renamed_source(&mut lsp, &uri, src, (1, 20), "Display");
+    assert!(
+        out.contains("puts [::app::widget show]\n"),
+        "a dynamic map leaves the dispatch word unattributed: {out}",
+    );
+}

--- a/rust/tcl-lsp-server/tests/e2e/issue923_crossdoc.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue923_crossdoc.rs
@@ -241,3 +241,111 @@ fn tn_plain_argument_word_does_not_resolve_to_a_sibling_class() {
         locations(&def),
     );
 }
+
+// TP (idx 44): `${ns}::setdef` inside a TclOO constructor, where `ns` comes
+// from `[namespace qualifiers [self class]]`, reaching a proc declared in a
+// **sibling document**.
+//
+// The same mechanic is already pinned single-file (issue #1132), but idx 44's
+// real corpus (`ticklecharts`) splits it across files — the utility proc in
+// `utils.tcl`, the class in `dataset.tcl` — which is the tier a
+// workspace-index regression would break without touching the single-file
+// tests at all.
+//
+// Oracle (tclsh 9.0.4 and 8.6.16, sourcing both files): prints
+// `resolved options dict = id {-default hello}`, proving `${ns}::setdef`
+// genuinely dispatches to `::ticklecharts::setdef`.
+#[test]
+fn tp_cross_file_folded_namespace_head_reaches_its_proc_923_idx44() {
+    let mut lsp = Lsp::tcl();
+    let utils = unique_uri("tcl");
+    lsp.open_ready(
+        &utils,
+        "namespace eval ticklecharts {}\n\
+         proc ticklecharts::setdef {d key args} {\n\
+         \x20   upvar 1 $d dict\n\
+         \x20   dict set dict $key $args\n\
+         \x20   return [dict get $dict]\n\
+         }\n",
+    );
+    let dataset = unique_uri("tcl");
+    lsp.open_ready(
+        &dataset,
+        "oo::class create ticklecharts::dataset {\n\
+         \x20   variable options\n\
+         \x20   constructor {value} {\n\
+         \x20       set ns [namespace qualifiers [self class]]\n\
+         \x20       ${ns}::setdef options id -default $value\n\
+         \x20   }\n\
+         }\n",
+    );
+
+    // Go-to-definition from the constructor's `${ns}::setdef` head (line 4;
+    // `setdef` sits inside the `${ns}::setdef` word).
+    let def = lsp.definition(&dataset, 4, 17);
+    assert_eq!(
+        lines_in(&def, &utils),
+        vec![1],
+        "the `${{ns}}::setdef` head must reach the sibling document's proc: {:?}",
+        locations(&def),
+    );
+
+    // And the reverse direction: references from that declaration reach the
+    // constructor's call site.
+    let refs = lsp.references(&utils, 1, 20, true);
+    assert!(
+        !lines_in(&refs, &dataset).is_empty(),
+        "find-references from the declaration must reach the cross-file \
+         constructor call site: {:?}",
+        locations(&refs),
+    );
+}
+
+// TP (idx 19), *unit-level* companion to
+// `tp_cross_file_superclass_through_split_nested_namespace`: the split /
+// nested `namespace eval ::Outer { namespace eval Inner::Sub { … } }` shape
+// must give the class its full `::Outer::Inner::Sub::Foo` qualified name in a
+// single document too — the fact the cross-document tier consumes. A
+// regression that mis-homed the class would break every cross-file query
+// built on it, and this pins the cause rather than one symptom.
+//
+// Oracle (tclsh 9.0.4 / 8.6.16): the two-file program prints `42`, so
+// `::Outer::Inner::Sub::Foo` is the real command name.
+#[test]
+fn tp_split_nested_namespace_eval_homes_the_class_fully_923_idx19() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "namespace eval ::Outer {\n\
+         \x20   namespace eval Inner::Sub {\n\
+         \x20       namespace export Foo\n\
+         \x20   }\n\
+         }\n\
+         namespace eval ::Outer::Inner::Sub {\n\
+         \x20   oo::class create Foo {\n\
+         \x20       method show {} { return 1 }\n\
+         \x20   }\n\
+         }\n\
+         oo::class create Baz {\n\
+         \x20   superclass ::Outer::Inner::Sub::Foo\n\
+         }\n",
+    );
+    // `superclass ::Outer::Inner::Sub::Foo` (line 11): the argument starts at
+    // column 15, so its `Foo` tail sits at column 36.
+    let def = lsp.definition(&uri, 11, 37);
+    assert_eq!(
+        lines_in(&def, &uri),
+        vec![6],
+        "the superclass argument must reach the class the split/nested \
+         `namespace eval` declares: {:?}",
+        locations(&def),
+    );
+    // Hover names the fully-qualified command, which is what proves the
+    // homing rather than a same-tail-name coincidence.
+    let hover = crate::common::helpers::hover_text(&lsp.hover(&uri, 6, 22));
+    assert!(
+        hover.contains("::Outer::Inner::Sub::Foo"),
+        "hover must name the fully-qualified class: {hover:?}",
+    );
+}

--- a/rust/tcl-lsp-server/tests/e2e/references.rs
+++ b/rust/tcl-lsp-server/tests/e2e/references.rs
@@ -28,7 +28,8 @@
 #![allow(clippy::cast_possible_truncation)]
 
 use crate::common::helpers::*;
-use crate::common::{Lsp, unique_uri};
+use crate::common::{Lsp, scaled_timeout, unique_uri};
+use std::time::Duration;
 
 // -- TestProcReferences --------------------------------------------------
 
@@ -758,4 +759,166 @@ fn the_unshadowed_call_references_the_local_proc_when_nothing_exports_it() {
         !from_src.contains(&12),
         "an import that bound nothing creates no reference: {from_src:?}"
     );
+}
+
+/// Issue #923 differential-audit finding idx 85 — the audit's exact shape:
+/// `namespace ensemble create -map` inside a proc declared with a
+/// fully-qualified name at top level, with no enclosing `namespace eval`, so
+/// the ensemble homes to `::app::widget`.
+///
+/// Oracle (tclsh 8.6.16 and 9.0.4, identical): the script prints `shown` then
+/// `configured:-x 1`, so `::app::widget show` really does dispatch to
+/// `::app::widget::Show`, statically determinable from the `-map` literal.
+///
+/// Go-to-definition and hover answered this correctly all along — they
+/// resolve on demand against the finished analysis. Find-references
+/// enumerates *recorded* invocations, and the live server (which always
+/// analyses incrementally, deferring proc bodies) never recorded one for the
+/// dispatch site, so both reference directions silently under-reported. This
+/// drives the same surface the audit did, and pins that the two directions
+/// agree.
+#[test]
+fn ensemble_dispatch_call_sites_are_found_from_both_directions_923_idx85() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = concat!(
+        "namespace eval ::app::widget {\n",                            // 0
+        "    variable state 0\n",                                      // 1
+        "}\n",                                                         // 2
+        "proc ::app::widget::Setup {} {\n",                            // 3
+        "    namespace ensemble create -map {\n",                      // 4
+        "        show      ::app::widget::Show\n",                     // 5
+        "        configure ::app::widget::Configure\n",                // 6
+        "    }\n",                                                     // 7
+        "}\n",                                                         // 8
+        "proc ::app::widget::Show {} { puts \"shown\" }\n",            // 9
+        "proc ::app::widget::Configure {args} { puts \"c:$args\" }\n", // 10
+        "::app::widget::Setup\n",                                      // 11
+        "puts [::app::widget show]\n",                                 // 12
+        "::app::widget configure -x 1\n",                              // 13
+    );
+    lsp.open_ready(&uri, src);
+
+    // Sanity: go-to-definition on the dispatch site already worked, and is the
+    // answer references must agree with.
+    let def = start_lines(&lsp.definition(&uri, 12, 21));
+    assert!(
+        def.contains(&9),
+        "baseline: `show` must resolve to `proc ::app::widget::Show`: {def:?}",
+    );
+
+    // Direction 1 — from the mapped target's own declaration (line 9, `Show`
+    // starts at column 20).
+    let from_decl = start_lines(&lsp.references(&uri, 9, 21, true));
+    assert!(
+        from_decl.contains(&12),
+        "the `[::app::widget show]` dispatch is missing from the declaration's \
+         reference set: {from_decl:?}",
+    );
+    assert!(
+        from_decl.contains(&9) && from_decl.contains(&5),
+        "the declaration and the -map target text must both be present: {from_decl:?}",
+    );
+
+    // Direction 2 — from the dispatch call site itself (line 12, `show`
+    // starts at column 20).
+    let from_call = start_lines(&lsp.references(&uri, 12, 21, true));
+    assert_eq!(
+        from_call, from_decl,
+        "both query directions must return the same reference set",
+    );
+
+    // And the sibling subcommand written as a plain top-level command (not
+    // nested in a `[…]` substitution) resolves the same way.
+    let configure_refs = start_lines(&lsp.references(&uri, 10, 21, true));
+    assert!(
+        configure_refs.contains(&13),
+        "the top-level `::app::widget configure` dispatch is missing: \
+         {configure_refs:?}",
+    );
+}
+
+/// TN for the above — a `-map` built with `[list …]` is not a literal
+/// mapping, so no `subcommand -> target` fact exists and the dispatch site
+/// must stay unattributed. A deliberate abstention, not an oversight: the
+/// mapping is genuinely dynamic and guessing would manufacture a navigation
+/// edge (and, through rename, an edit) that may not exist at run time.
+#[test]
+fn a_dynamically_mapped_ensemble_dispatch_is_not_attributed_923_idx85() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        concat!(
+            "proc ::app::widget::Setup {} {\n",
+            "    namespace ensemble create -map [list show ::app::widget::Show]\n",
+            "}\n",
+            "proc ::app::widget::Show {} {}\n",
+            "::app::widget::Setup\n",
+            "::app::widget show\n",
+        ),
+    );
+    let refs = start_lines(&lsp.references(&uri, 3, 21, true));
+    assert!(
+        !refs.contains(&5),
+        "a dynamic -map must not manufacture a navigation edge: {refs:?}",
+    );
+}
+
+/// Issue #923 differential-audit finding idx 27 — a `.test` file that is
+/// never opened in the editor and is reached only through a dynamic
+/// `glob`+`source` loop the analyser correctly abstains on. `.test` had been
+/// missing from the Tcl source-extension set, so the background workspace
+/// scan never indexed it and its call sites were invisible.
+///
+/// Oracle (tclsh 9.0.4): `source lib.tcl; cd test; source all_codeCoverage.tcl`
+/// prints `hello from greet` — the `.test` file's bare `greet` call really
+/// runs. Committed coverage stops at `collect_tcl_files` / `is_tcl_source`,
+/// one layer below the references handler; this drives the whole pipeline.
+#[test]
+fn find_references_reaches_an_unopened_tcltest_file_923_idx27() {
+    let root = std::env::temp_dir().join(format!(
+        "tcl-lsp-e2e-idx27-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos(),
+    ));
+    std::fs::create_dir_all(root.join("test")).expect("create workspace root");
+    let lib = root.join("lib.tcl");
+    std::fs::write(&lib, "proc greet {} { puts \"hello from greet\" }\n").expect("write lib.tcl");
+    // Mirrors SpiceGenTcl's all_codeCoverage.tcl: a glob + source loop with no
+    // literal source edge into the `.test` file at all.
+    std::fs::write(
+        root.join("test").join("all_codeCoverage.tcl"),
+        "set testFiles [glob -directory [file dirname [info script]] *.test]\n\
+         foreach file $testFiles { source $file }\n",
+    )
+    .expect("write all_codeCoverage.tcl");
+    std::fs::write(
+        root.join("test").join("a.test"),
+        "# never opened in the editor\ngreet\n",
+    )
+    .expect("write a.test");
+
+    let mut lsp = Lsp::at_workspace_root(&root);
+    let uri = format!("file://{}", lib.to_string_lossy());
+    lsp.open_ready(&uri, &std::fs::read_to_string(&lib).expect("read"));
+
+    // The workspace index is built asynchronously; poll until the `.test`
+    // call site appears, or the budget runs out.
+    let deadline = std::time::Instant::now() + scaled_timeout(Duration::from_secs(20));
+    let mut refs = locations(&lsp.references(&uri, 0, 6, true));
+    while std::time::Instant::now() < deadline && !refs.iter().any(|l| l.uri.ends_with("a.test")) {
+        std::thread::sleep(Duration::from_millis(150));
+        refs = locations(&lsp.references(&uri, 0, 6, true));
+    }
+    assert!(
+        refs.iter().any(|l| l.uri.ends_with("a.test")),
+        "the bare `greet` call in the un-opened .test file must be a reference: \
+         {refs:?}",
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
 }


### PR DESCRIPTION
Closes #1281. Part of #1019 (namespaces and packages/source clusters) — does not close it.

The two are deliberately in one PR: the #1019 idx 85 fix **widens** the #1281 hazard by extending ensemble call-site recording to a new shape, so shipping the recording without the gate would put more documents at risk of a rename that corrupts working code.

## #1281 — renaming an ensemble `-map` target corrupted the dispatch

`rename_proc` used the same `invocation_references_proc` rule as find-references, so renaming a `-map` **target** also rewrote the **subcommand word** at the dispatch site. A `-map` key is an arbitrary name with no required relationship to its target, so the result was a call that no longer resolves.

A blanket exclusion would have been wrong, and the oracle says why — identical on tclsh 8.6.14 and 9.0.4:

```
-map, key differs from target tail   ->  Show ran
-map, calling the target's tail      ->  unknown or ambiguous subcommand "Show": must be show
-subcommands, calling the tail       ->  alpha ran
-subcommands, proc renamed to beta   ->  invalid command name "alpha"
```

With `-subcommands` the subcommand word **is** the target's tail, so rename *should* rewrite it. The two shapes genuinely differ, so the mapping now carries provenance.

**Where it lives:** a new `EnsembleSubcommandProvenance { Map, Subcommands }`, recorded per site — `record_ensemble_map_targets` tags `Map`, `record_ensemble_subcommands` tags `Subcommands` — and carried on the dispatch word's own invocation record. Per-site rather than re-derived by name, because a `-map {Show ::app::widget::Show}` whose key happens to equal the target's tail is textually indistinguishable from an ordinary bare call; only the recording site knows which span is a dispatch word.

**How rename gates:** one helper applied in all three edit-gathering loops (`rename_proc`, `rename_class`, `cross_document_symbol_edits`). `Map` skips the span; `Subcommands` is unchanged. The `-map` **value** remains an ordinary reference and is still rewritten — that is what keeps the ensemble bound after the rename. Find-references reports the dispatch site under both provenances; only the rename edit set differs.

### Validated by applying the edit and running the result

Server → `WorkspaceEdit` → files on disk → run under both interpreters:

```
-map, rename Show -> Display
  before: tclsh8.6 rc=0 'showing/showing'   tclsh9.0 rc=0 'showing/showing'
  edits:  3 (declaration, -map value, direct call) — dispatch word untouched
  after:  tclsh8.6 rc=0 'showing/showing'   tclsh9.0 rc=0 'showing/showing'   IDENTICAL

-subcommands, rename alpha -> beta
  edits:  3 (declaration, -subcommands entry, dispatch word)
  after:  tclsh8.6 rc=0 'alpha!'   tclsh9.0 rc=0 'alpha!'                     IDENTICAL

the bug, with the gate compiled out:
  after:  puts [::app::widget Display]
          rc=1 'unknown or ambiguous subcommand "Display": must be show'      DIFFERENT
  and the -subcommands direction is unchanged with the gate off, proving the
  gate is -map-specific rather than a blanket exclusion.
```

## #1019 idx 85 — ensemble references never reached the call sites

**The evidence's lead was wrong, productively.** `ensemble_subcommand_references` and `ensemble_subcommand_target` are both fine. The bug is walk order, and only under incremental analysis:

- whole-file DFS: records `name=show resolved=::app::widget::Show` — correct.
- `analyse_per_item` (what the live server always runs): those invocations are **absent**.

The whole-file walk visits a proc body at its definition point, so a `namespace ensemble create -map` inside `proc ::app::widget::Setup` is on the books before the call sites below it. The per-item shell pass defers proc bodies, so it met `puts [::app::widget show]` while the target table was still empty and dropped the record silently. Go-to-definition still answered because it resolves on demand; find-references enumerates *recorded* invocations, and there was nothing to enumerate.

Fixed by queueing the miss into `pending_ensemble_subcommands` and replaying it before `finalise_invocation_resolutions`, gated on the ensemble's recording offset preceding the call site — exactly the visibility the whole-file DFS has, which is what keeps the two strategies byte-identical.

## The `auto_path` computed-path anchor was wrong

Oracle, identical on both interpreters: with `sub/main.tcl` containing `set v helper.tcl; source $v`, running `cd other && tclsh ../sub/main.tcl` loads **`other/helper.tcl`**. Tcl resolves a rootless path against the interpreter's working directory at run time; `[info script]` plays no part.

Our semantics were right but the input was an unrelated fact — the *language server's* launch directory, which no user program has any relationship to. Symptoms: the same file resolved differently depending on how the editor was started, and a computed `source` path disagreed with a literal path written beside it. The evaluator now returns a rootless result relative and unanchored, and each caller applies the base it already applies to literals.

## Tests

Provenance recording and the dispatch tag at the analyser tier; the `-map` skip, the `-subcommands` rewrite (true negative), references under both provenances, the dynamic-map abstention, the class tier, and the cross-document gate with its control at the core tier; 6 e2e tests applying the *whole* edit set and asserting exact post-rename text; and a VS Code tier following the repo's existing precedent for "must NOT be edited" hazards (`issue945.test.ts`), since an editor rename applies the returned set unreviewed in one keystroke.

Non-vacuity was proved by compiling the gate out: exactly the two `-map` tests fail and the rest pass. A first cross-document e2e attempt was **dropped after discovering it would have been vacuous** — cross-document ensemble dispatch is not recorded at all, and its `-subcommands` control failed — and replaced with a `WorkspaceIndex`-driven unit test whose control proves the path is live.

Plus the #1019 coverage: idx 85's strategy-equivalence assertion (per-item records the same call sites as the whole-file walk), and e2e/VS Code tests for idx 3, 4, 19, 27, 41, 42, 43, 44, 64, 65, 72, 73, 75, 102.

## Composition with the existing rename hazard gates

- The untargeted-member-rename refusal (#1019 idx 79) is a whole-rename refusal decided before any tier runs, over TclOO members. This is a per-span filter inside the tiers' invocation loops, over command invocations. Tier order and refusal semantics are untouched, and no new refusal is introduced.
- The `rename_safe` provenance gate still runs first and still refuses when an indirect dispatch has unwritable contributors. A `-map` dispatch word does not make the rename unsound — the map value carries the binding and is rewritten — so it is a skipped span, not an abstention.
- The alias-shadowing reference rule (idx 89) is untouched; this gate is an independent `continue` in the same loop, so the emitted set is the intersection of both filters and find-references, code-lens counts and call-hierarchy see no change.

## Gates

`cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean (no `allow` added; one real `sort_by_key` fix); `cargo check --workspace --all-targets` clean; `cargo test -p tcl-compiler` 5323 lib plus 29 suites, 0 failed; `cargo test -p tcl-lsp-core -p tcl-lsp-db` 1804 plus suites, 0 failed; `cargo test -p tcl-lsp-server` 13 suites including e2e at 1336 passed, 0 failed; VS Code 807 passing.

Two VS Code failures in the recorded run are wall-clock convergence tests on a container at load average ~14 (a sibling test took 42.9s where it is normally sub-second). Confirmed not caused by this change by re-running both against a server built from a branch without these commits, where they fail identically. That load sensitivity is tracked in #1274.

Rebased onto current `rust`; one conflict in `e2e/definition.rs` where both sides appended tests, resolved by keeping both.

## Recorded residual

The dynamic-map case abstains as required, but the rename also leaves the `[list show ::app::widget::Show]` element unrewritten. That word is not recorded as a reference either, so rename and find-references agree — a pre-existing dynamic-indirection gap, symmetric across both providers and outside this issue's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_