### PR TITLE
Bound the VS Code suite's waits on signals and make timeouts reject (#1274)

### DIFF
--- a/editors/vscode/src/test/codeActions.test.ts
+++ b/editors/vscode/src/test/codeActions.test.ts
@@ -18,7 +18,13 @@
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getDocUri, activate, waitForDiagnostics, pollUntil } from "./helper";
+import {
+  getDocUri,
+  activate,
+  waitForDiagnostics,
+  waitForCodeActions,
+  waitForProviderResult,
+} from "./helper";
 
 suite("Code Actions", () => {
   const docUri = getDocUri("diagnostics.tcl");
@@ -36,15 +42,13 @@ suite("Code Actions", () => {
     assert.ok(w100, "W100 diagnostic should be present");
 
     // Request code actions at the W100 range
-    const actions = (await pollUntil(
-      () => vscode.commands.executeCommand("vscode.executeCodeActionProvider", docUri, w100.range),
-      (r) =>
-        Array.isArray(r) &&
-        (r as vscode.CodeAction[]).some(
-          (a) => a.kind && a.kind.value === vscode.CodeActionKind.QuickFix.value,
-        ),
+    const actions = await waitForCodeActions(
+      docUri,
+      w100.range,
+      (actions) =>
+        actions.some((a) => a.kind && a.kind.value === vscode.CodeActionKind.QuickFix.value),
       { timeout: 10_000, label: "W100 quick fix" },
-    )) as vscode.CodeAction[];
+    );
 
     assert.ok(actions, "Code actions should not be null");
     assert.ok(actions.length > 0, "Should have at least one code action");
@@ -67,15 +71,15 @@ suite("Code Actions", () => {
     });
     assert.ok(w304, "W304 diagnostic should be present");
 
-    const actions = (await pollUntil(
-      () => vscode.commands.executeCommand("vscode.executeCodeActionProvider", docUri, w304.range),
-      (r) =>
-        Array.isArray(r) &&
-        (r as vscode.CodeAction[]).some(
+    const actions = await waitForCodeActions(
+      docUri,
+      w304.range,
+      (actions) =>
+        actions.some(
           (a) => typeof a.title === "string" && a.title.toLowerCase().includes("option terminator"),
         ),
       { timeout: 10_000, label: "W304 option terminator quick fix" },
-    )) as vscode.CodeAction[];
+    );
 
     const quickFix = actions.find(
       (a) => typeof a.title === "string" && a.title.toLowerCase().includes("option terminator"),
@@ -96,15 +100,12 @@ suite("Code Actions", () => {
     });
     assert.ok(t102, "T102 diagnostic should be present");
 
-    const actions = (await pollUntil(
-      () => vscode.commands.executeCommand("vscode.executeCodeActionProvider", docUri, t102.range),
-      (r) =>
-        Array.isArray(r) &&
-        (r as vscode.CodeAction[]).some(
-          (a) => typeof a.title === "string" && a.title.includes("--"),
-        ),
+    const actions = await waitForCodeActions(
+      docUri,
+      t102.range,
+      (actions) => actions.some((a) => typeof a.title === "string" && a.title.includes("--")),
       { timeout: 10_000, label: "T102 insert '--' quick fix" },
-    )) as vscode.CodeAction[];
+    );
 
     const quickFix = actions.find((a) => typeof a.title === "string" && a.title.includes("--"));
     assert.ok(quickFix, "Should provide an insert '--' quick fix for T102");
@@ -120,18 +121,16 @@ suite("Code Actions", () => {
     });
     assert.ok(w302, "W302 diagnostic should be present");
 
-    const actions = (await pollUntil(
-      () => vscode.commands.executeCommand("vscode.executeCodeActionProvider", docUri, w302.range),
-      (r) =>
-        Array.isArray(r) &&
-        (r as vscode.CodeAction[]).some(
+    const actions = await waitForCodeActions(
+      docUri,
+      w302.range,
+      (actions) =>
+        actions.some(
           (a) => typeof a.title === "string" && a.title.includes("catch result variable"),
         ) &&
-        (r as vscode.CodeAction[]).some(
-          (a) => typeof a.title === "string" && a.title.includes("result + options"),
-        ),
+        actions.some((a) => typeof a.title === "string" && a.title.includes("result + options")),
       { timeout: 10_000, label: "W302 catch result quick fixes" },
-    )) as vscode.CodeAction[];
+    );
 
     const resultFix = actions.find(
       (a) => typeof a.title === "string" && a.title.includes("catch result variable"),
@@ -153,16 +152,16 @@ suite("Code Actions", () => {
     });
     assert.ok(e100, "E100 diagnostic should be present");
 
-    const actions = (await pollUntil(
-      () => vscode.commands.executeCommand("vscode.executeCodeActionProvider", docUri, e100.range),
-      (r) =>
-        Array.isArray(r) &&
-        (r as vscode.CodeAction[]).some(
+    const actions = await waitForCodeActions(
+      docUri,
+      e100.range,
+      (actions) =>
+        actions.some(
           (a) =>
             typeof a.title === "string" && a.title.toLowerCase().includes("insert missing '['"),
         ),
       { timeout: 10_000, label: "E100 insert bracket quick fix" },
-    )) as vscode.CodeAction[];
+    );
 
     const quickFix = actions.find(
       (a) => typeof a.title === "string" && a.title.toLowerCase().includes("insert missing '['"),
@@ -189,15 +188,15 @@ suite("Code Actions", () => {
     });
     assert.ok(e102, "E102 diagnostic should be present");
 
-    const actions = (await pollUntil(
-      () => vscode.commands.executeCommand("vscode.executeCodeActionProvider", docUri, e102.range),
-      (r) =>
-        Array.isArray(r) &&
-        (r as vscode.CodeAction[]).some(
+    const actions = await waitForCodeActions(
+      docUri,
+      e102.range,
+      (actions) =>
+        actions.some(
           (a) => typeof a.title === "string" && a.title.toLowerCase().includes("remove extra '}'"),
         ),
       { timeout: 10_000, label: "E102 remove brace quick fix" },
-    )) as vscode.CodeAction[];
+    );
 
     const quickFix = actions.find(
       (a) => typeof a.title === "string" && a.title.toLowerCase().includes("remove extra '}'"),
@@ -215,20 +214,13 @@ suite("Code Actions", () => {
     );
     assert.ok(extraWords, "extra-words E004 diagnostic should be present");
 
-    const actions = (await pollUntil(
-      () =>
-        vscode.commands.executeCommand(
-          "vscode.executeCodeActionProvider",
-          e004Uri,
-          extraWords.range,
-        ),
-      (r) =>
-        Array.isArray(r) &&
-        (r as vscode.CodeAction[]).some(
-          (a) => typeof a.title === "string" && a.title.toLowerCase().includes("merge"),
-        ),
+    const actions = await waitForCodeActions(
+      e004Uri,
+      extraWords.range,
+      (actions) =>
+        actions.some((a) => typeof a.title === "string" && a.title.toLowerCase().includes("merge")),
       { timeout: 10_000, label: "E004 extra-words merge quick fix" },
-    )) as vscode.CodeAction[];
+    );
 
     const mergeFix = actions.find(
       (a) => typeof a.title === "string" && a.title.toLowerCase().includes("merge"),
@@ -246,20 +238,15 @@ suite("Code Actions", () => {
     );
     assert.ok(danglingElseif, "dangling-elseif E004 diagnostic should be present");
 
-    const actions = (await pollUntil(
-      () =>
-        vscode.commands.executeCommand(
-          "vscode.executeCodeActionProvider",
-          e004Uri,
-          danglingElseif.range,
-        ),
-      (r) =>
-        Array.isArray(r) &&
-        (r as vscode.CodeAction[]).some(
+    const actions = await waitForCodeActions(
+      e004Uri,
+      danglingElseif.range,
+      (actions) =>
+        actions.some(
           (a) => typeof a.title === "string" && a.title.toLowerCase().includes("remove"),
         ),
       { timeout: 10_000, label: "E004 dangling-clause remove quick fix" },
-    )) as vscode.CodeAction[];
+    );
 
     const removeFix = actions.find(
       (a) => typeof a.title === "string" && a.title.toLowerCase().includes("remove"),
@@ -310,15 +297,12 @@ suite("Code Actions", () => {
     });
     assert.ok(w004, "W004 diagnostic for -stride should be present");
 
-    const actions = (await pollUntil(
-      () => vscode.commands.executeCommand("vscode.executeCodeActionProvider", w004Uri, w004.range),
-      (r) =>
-        Array.isArray(r) &&
-        (r as vscode.CodeAction[]).some(
-          (a) => typeof a.title === "string" && a.title.includes("-stride"),
-        ),
+    const actions = await waitForCodeActions(
+      w004Uri,
+      w004.range,
+      (actions) => actions.some((a) => typeof a.title === "string" && a.title.includes("-stride")),
       { timeout: 10_000, label: "W004 remove-option quick fix" },
-    )) as vscode.CodeAction[];
+    );
 
     const removeFix = actions.find(
       (a) => typeof a.title === "string" && a.title.includes("-stride"),
@@ -347,23 +331,18 @@ suite("Code Actions", () => {
     });
     assert.ok(irule1005, "IRULE1005 diagnostic should be present");
 
-    const actions = (await pollUntil(
-      () =>
-        vscode.commands.executeCommand(
-          "vscode.executeCodeActionProvider",
-          irulesDocUri,
-          irule1005.range,
-        ),
-      (r) =>
-        Array.isArray(r) &&
-        (r as vscode.CodeAction[]).some(
+    const actions = await waitForCodeActions(
+      irulesDocUri,
+      irule1005.range,
+      (actions) =>
+        actions.some(
           (a) =>
             typeof a.title === "string" &&
             a.title.includes("collect") &&
             a.title.includes("CLIENT_ACCEPTED"),
         ),
       { timeout: 10_000, label: "IRULE1005 collect bootstrap quick fix" },
-    )) as vscode.CodeAction[];
+    );
 
     const collectFix = actions.find(
       (a) =>
@@ -394,15 +373,13 @@ suite("Code Actions", () => {
     // whole `puts $x` statement.
     assert.strictEqual(t101.range.start.character, t101.range.end.character - 2);
 
-    const actions = (await pollUntil(
-      () => vscode.commands.executeCommand("vscode.executeCodeActionProvider", t101Uri, t101.range),
-      (r) =>
-        Array.isArray(r) &&
-        (r as vscode.CodeAction[]).some(
-          (a) => typeof a.title === "string" && a.title.includes("strip CR/LF"),
-        ),
+    const actions = await waitForCodeActions(
+      t101Uri,
+      t101.range,
+      (actions) =>
+        actions.some((a) => typeof a.title === "string" && a.title.includes("strip CR/LF")),
       { timeout: 10_000, label: "T101 sanitise quick fix" },
-    )) as vscode.CodeAction[];
+    );
 
     const sanitiseFix = actions.find(
       (a) => typeof a.title === "string" && a.title.includes("strip CR/LF"),
@@ -428,16 +405,15 @@ suite("Code Actions", () => {
     });
     assert.ok(s100, "S100 diagnostic on line 7 should be present");
 
-    const actions = (await pollUntil(
-      () =>
-        vscode.commands.executeCommand("vscode.executeCodeActionProvider", shimmerUri, s100.range),
-      (r) =>
-        Array.isArray(r) &&
-        (r as vscode.CodeAction[]).some(
+    const actions = await waitForCodeActions(
+      shimmerUri,
+      s100.range,
+      (actions) =>
+        actions.some(
           (a) => typeof a.title === "string" && a.title === "Suppress S100 with a noqa comment",
         ),
       { timeout: 10_000, label: "S100 noqa suppress quick fix" },
-    )) as vscode.CodeAction[];
+    );
 
     const suppressFix = actions.find(
       (a) => typeof a.title === "string" && a.title === "Suppress S100 with a noqa comment",
@@ -479,11 +455,12 @@ suite("Code Actions", () => {
   test("offers 'package require' on an unresolved command head", async () => {
     await activate(packageContextUri);
     await waitForDiagnostics(packageContextUri, { minCount: 0 });
-    const titles = (await pollUntil(
+    const titles = await waitForProviderResult(
+      packageContextUri,
       () => quickFixTitlesAt(packageContextUri, 11, 3),
-      (t) => (t as string[]).some((title) => title.startsWith("Add 'package require")),
-      { timeout: 10_000, label: "package require suggestion" },
-    )) as string[];
+      (t) => t.some((title) => title.startsWith("Add 'package require")),
+      { timeout: 10_000, label: "the 'package require' suggestion on the call at 11:3" },
+    );
     assert.ok(
       titles.includes("Add 'package require http'"),
       `expected the http suggestion on the call, got: ${JSON.stringify(titles)}`,

--- a/editors/vscode/src/test/codeLens.test.ts
+++ b/editors/vscode/src/test/codeLens.test.ts
@@ -18,7 +18,7 @@
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { activate, getDocUri, pollUntil } from "./helper";
+import { activate, getDocUri, waitForProviderResult } from "./helper";
 
 suite("Code Lens", () => {
   const docUri = getDocUri("procs.tcl");
@@ -30,14 +30,17 @@ suite("Code Lens", () => {
     // fixed sleep.
     // executeCodeLensProvider's second argument is the number of lenses
     // to resolve; without it VS Code returns unresolved lenses (command=null).
-    const lenses = (await pollUntil(
-      () => vscode.commands.executeCommand("vscode.executeCodeLensProvider", docUri, 100),
-      (r) => {
-        const ls = r as vscode.CodeLens[] | undefined;
+    const lenses = await waitForProviderResult(
+      docUri,
+      () =>
+        vscode.commands.executeCommand("vscode.executeCodeLensProvider", docUri, 100) as Thenable<
+          vscode.CodeLens[] | undefined
+        >,
+      (ls) => {
         return !!ls && ls.filter((l) => l.command !== undefined).length >= 2;
       },
       { timeout: 10_000, label: "resolved code lenses" },
-    )) as vscode.CodeLens[] | undefined;
+    );
 
     assert.ok(lenses, "codeLens result should not be null");
     assert.ok(
@@ -65,10 +68,13 @@ suite("Code Lens", () => {
     await activate(refsUri);
     // Poll until the lenses for the proc-definition lines under test
     // (1, 5, 8) have all resolved their reference-count titles.
-    const lenses = (await pollUntil(
-      () => vscode.commands.executeCommand("vscode.executeCodeLensProvider", refsUri, 100),
-      (r) => {
-        const ls = r as vscode.CodeLens[] | undefined;
+    const lenses = await waitForProviderResult(
+      refsUri,
+      () =>
+        vscode.commands.executeCommand("vscode.executeCodeLensProvider", refsUri, 100) as Thenable<
+          vscode.CodeLens[] | undefined
+        >,
+      (ls) => {
         if (!ls) return false;
         const resolvedLines = new Set(
           ls
@@ -78,7 +84,7 @@ suite("Code Lens", () => {
         return [1, 5, 8].every((line) => resolvedLines.has(line));
       },
       { timeout: 10_000, label: "resolved code lenses for forward/namespaced calls" },
-    )) as vscode.CodeLens[] | undefined;
+    );
     assert.ok(lenses, "codeLens result should not be null");
 
     // Map each resolved lens to the line its proc name sits on.
@@ -119,10 +125,13 @@ suite("Code Lens", () => {
   test("reference count is correct for procs called from a bind callback in a nested namespace", async () => {
     const refsUri = getDocUri("issue923NestedNamespace.tcl");
     await activate(refsUri);
-    const lenses = (await pollUntil(
-      () => vscode.commands.executeCommand("vscode.executeCodeLensProvider", refsUri, 100),
-      (r) => {
-        const ls = r as vscode.CodeLens[] | undefined;
+    const lenses = await waitForProviderResult(
+      refsUri,
+      () =>
+        vscode.commands.executeCommand("vscode.executeCodeLensProvider", refsUri, 100) as Thenable<
+          vscode.CodeLens[] | undefined
+        >,
+      (ls) => {
         if (!ls) return false;
         const resolvedLines = new Set(
           ls
@@ -134,7 +143,7 @@ suite("Code Lens", () => {
         return [2, 5].every((line) => resolvedLines.has(line));
       },
       { timeout: 10_000, label: "resolved code lenses for issue #923 fixture" },
-    )) as vscode.CodeLens[] | undefined;
+    );
     assert.ok(lenses, "codeLens result should not be null");
 
     const titleByLine = new Map<number, string>();
@@ -178,17 +187,20 @@ suite("Code Lens", () => {
     // proc/class lenses do — `executeCodeLensProvider`'s resolveCount arg
     // drives VS Code to call `codeLens/resolve` itself, so poll until the
     // lenses on the member lines under test carry a resolved command.
-    const lenses = (await pollUntil(
-      () => vscode.commands.executeCommand("vscode.executeCodeLensProvider", refsUri, 100),
-      (r) => {
-        const ls = r as vscode.CodeLens[] | undefined;
+    const lenses = await waitForProviderResult(
+      refsUri,
+      () =>
+        vscode.commands.executeCommand("vscode.executeCodeLensProvider", refsUri, 100) as Thenable<
+          vscode.CodeLens[] | undefined
+        >,
+      (ls) => {
         if (!ls) return false;
         const resolvedLines = new Set(ls.filter((l) => l.command).map((l) => l.range.start.line));
         // `method get` on line 6, `method unused` on line 10.
         return [6, 10].every((line) => resolvedLines.has(line));
       },
       { timeout: 10_000, label: "resolved method code lenses" },
-    )) as vscode.CodeLens[] | undefined;
+    );
     assert.ok(lenses, "codeLens result should not be null");
 
     const commandByLine = new Map<number, vscode.Command>();
@@ -236,17 +248,20 @@ suite("Code Lens", () => {
   test("classmethod lens counts bare class-command dispatch and is clickable", async () => {
     const refsUri = getDocUri("codeLensClassmethodRefs.tcl");
     await activate(refsUri);
-    const lenses = (await pollUntil(
-      () => vscode.commands.executeCommand("vscode.executeCodeLensProvider", refsUri, 100),
-      (r) => {
-        const ls = r as vscode.CodeLens[] | undefined;
+    const lenses = await waitForProviderResult(
+      refsUri,
+      () =>
+        vscode.commands.executeCommand("vscode.executeCodeLensProvider", refsUri, 100) as Thenable<
+          vscode.CodeLens[] | undefined
+        >,
+      (ls) => {
         if (!ls) return false;
         const resolvedLines = new Set(ls.filter((l) => l.command).map((l) => l.range.start.line));
         // `classmethod make` on line 1, `classmethod idle` on line 5.
         return [1, 5].every((line) => resolvedLines.has(line));
       },
       { timeout: 10_000, label: "resolved classmethod code lenses" },
-    )) as vscode.CodeLens[] | undefined;
+    );
     assert.ok(lenses, "codeLens result should not be null");
 
     const commandByLine = new Map<number, vscode.Command>();
@@ -288,9 +303,11 @@ suite("Code Lens", () => {
   test("resolved lens invokes the showReferences command with locations", async () => {
     const refsUri = getDocUri("codeLensRefs.tcl");
     await activate(refsUri);
-    // Poll the provider (message passing) until the server has published its
-    // first batch of lenses, rather than sleeping on a fixed delay.
-    const lenses = await pollUntil(
+    // Re-pull the provider on every diagnostics publish (the server's own
+    // "I re-analysed this document" signal) until the first batch of lenses
+    // lands, rather than sleeping on a fixed delay.
+    const lenses = await waitForProviderResult(
+      refsUri,
       () =>
         vscode.commands.executeCommand("vscode.executeCodeLensProvider", refsUri, 100) as Thenable<
           vscode.CodeLens[] | undefined

--- a/editors/vscode/src/test/diagnostics.test.ts
+++ b/editors/vscode/src/test/diagnostics.test.ts
@@ -459,10 +459,11 @@ suite("Diagnostics", () => {
       // emits `[timing] deep diagnostics (uri=…, diags=0)` after every publish,
       // even for a clean file with the optimiser off.  `waitForDeepDiagnostics`
       // throws on timeout, so an analysis that silently never ran fails loudly
-      // instead of going green on a vacuous empty set — the failure mode a
-      // fixed-timeout `waitForDiagnostics(minCount: 1)` could never catch here,
-      // since a clean file never satisfies `minCount` and always falls through
-      // to its timer with an empty array.
+      // instead of going green on a vacuous empty set.  `waitForDiagnostics` is
+      // the wrong instrument here whatever its timeout does: a clean file never
+      // satisfies `minCount: 1`, so it can only ever burn the full deadline —
+      // proving nothing before, and failing a passing case now that it rejects.
+      // The marker is the only positive signal that the pass ran at all.
       await waitForDeepDiagnostics(cleanUri, { since });
       const diagnostics = vscode.languages.getDiagnostics(cleanUri);
 
@@ -699,15 +700,13 @@ suite("Diagnostics", () => {
       predicate: (diags) => diags.some((d) => codeOf(d) === "W123"),
     });
     const codes = diagnostics.map(codeOf);
-    // Re-assert the positive settle signal before the negative check: a
-    // `waitForDiagnostics` timeout resolves with the current (possibly empty)
-    // set rather than throwing, so without this the bare `!includes("W307")`
-    // would pass vacuously whenever analysis never settled.  The unknown
-    // classes `C`/`L` must surface W123 for this fixture.
-    assert.ok(
-      codes.includes("W123"),
-      `analysis must have settled (unknown-class C/L should surface W123), got [${codes}]`,
-    );
+    // The W123 predicate above is the settle signal for the negative check
+    // below: the unknown classes `C`/`L` must surface W123 for this fixture, so
+    // once it lands the absence of W307 is meaningful rather than "not analysed
+    // yet".  `waitForDiagnostics` rejects if it never lands (issue #1274), so
+    // the bare `!includes("W307")` can no longer pass vacuously against an
+    // unsettled set — this used to need a re-assertion here because the helper
+    // resolved leniently on timeout instead.
     assert.ok(
       !codes.includes("W307"),
       `dispatch over created object names must not fire W307, got [${codes}]`,

--- a/editors/vscode/src/test/helper.ts
+++ b/editors/vscode/src/test/helper.ts
@@ -19,7 +19,7 @@
 import * as vscode from "vscode";
 import * as path from "path";
 
-import { awaitSignal, bounded, scaledTimeout, sleep, WAIT_TIMEOUT_MARKER } from "./signal";
+import { awaitSignal, bounded, scaledTimeout, WAIT_TIMEOUT_MARKER } from "./signal";
 
 export { awaitSignal, bounded, loadFactor, scaledTimeout, sleep } from "./signal";
 
@@ -437,11 +437,8 @@ export async function waitForCodeActions(
   return waitForProviderResult<vscode.CodeAction[]>(
     uri,
     async () =>
-      ((await vscode.commands.executeCommand(
-        "vscode.executeCodeActionProvider",
-        uri,
-        range,
-      )) as vscode.CodeAction[] | undefined) ?? [],
+      ((await vscode.commands.executeCommand("vscode.executeCodeActionProvider", uri, range)) as
+        vscode.CodeAction[] | undefined) ?? [],
     predicate,
     {
       timeout: opts?.timeout,

--- a/editors/vscode/src/test/helper.ts
+++ b/editors/vscode/src/test/helper.ts
@@ -412,12 +412,21 @@ function isCancellation(error: unknown): boolean {
  *
  * Provider pulls have no completion event of their own — you ask, you get
  * whatever the server knows *now*.  What they do have is a signal for the
- * thing that actually changes the answer: the server re-analysing the
+ * thing that usually changes the answer: the server re-analysing the
  * document, which it announces by publishing diagnostics.  So this waits on
- * ``onDidChangeDiagnostics`` for *uri*, re-pulls on every publish, and keeps a
- * slow interval re-pull purely as a missed-event backstop — the same shape as
- * [`waitForDiagnostics`], and unlike [`pollUntil`], where the interval *is*
- * the mechanism.
+ * ``onDidChangeDiagnostics`` for *uri* and re-pulls on every publish.
+ *
+ * # Why the backstop here is tight, not slow
+ *
+ * Unlike [`waitForDiagnostics`], where the event *is* the thing being awaited
+ * and the interval is a pure missed-event net, a provider's readiness only
+ * *correlates* with the publish: the server can finish the work that changes
+ * this answer without publishing anything new.  So the interval is load-bearing
+ * here, and it stays at the 50ms cadence of the polling this replaced — the
+ * conversion must only ever be able to return *sooner* (when the publish wakes
+ * it), never later.  Widening it to the 500ms default would make the common
+ * case — analysis already done, the provider just needs asking again — ten
+ * times slower than the code it replaced.
  */
 export async function waitForProviderResult<T>(
   uri: vscode.Uri,
@@ -440,7 +449,7 @@ export async function waitForProviderResult<T>(
     probe: pull,
     predicate,
     timeout: opts?.timeout ?? 10_000,
-    backstopInterval: opts?.backstopInterval,
+    backstopInterval: opts?.backstopInterval ?? 50,
     describe: opts?.describe,
     retryProbeErrors: isCancellation,
   });

--- a/editors/vscode/src/test/helper.ts
+++ b/editors/vscode/src/test/helper.ts
@@ -386,6 +386,27 @@ export async function pollUntil<T>(
 }
 
 /**
+ * Whether an error is VS Code cancelling an in-flight request.
+ *
+ * VS Code cancels a pending provider request when the document or its
+ * diagnostics change underneath it. For a *wait*, that is not a failure — it
+ * means the answer would have been stale anyway, so ask again. Recognised
+ * structurally as well as by class, because the rejection crosses the
+ * extension-host RPC boundary and arrives as a plain ``Error`` named
+ * ``Canceled`` rather than a ``CancellationError`` instance.
+ */
+function isCancellation(error: unknown): boolean {
+  if (error instanceof vscode.CancellationError) return true;
+  if (!(error instanceof Error)) return false;
+  return (
+    error.name === "Canceled" ||
+    error.name === "CancellationError" ||
+    error.message === "Canceled" ||
+    error.message === "Cancelled"
+  );
+}
+
+/**
  * Wait for a language-feature provider pull (``vscode.executeCodeActionProvider``
  * and friends) to return a result satisfying *predicate*.
  *
@@ -421,6 +442,7 @@ export async function waitForProviderResult<T>(
     timeout: opts?.timeout ?? 10_000,
     backstopInterval: opts?.backstopInterval,
     describe: opts?.describe,
+    retryProbeErrors: isCancellation,
   });
 }
 

--- a/editors/vscode/src/test/helper.ts
+++ b/editors/vscode/src/test/helper.ts
@@ -19,17 +19,16 @@
 import * as vscode from "vscode";
 import * as path from "path";
 
+import { awaitSignal, bounded, scaledTimeout, sleep, WAIT_TIMEOUT_MARKER } from "./signal";
+
+export { awaitSignal, bounded, loadFactor, scaledTimeout, sleep } from "./signal";
+
 /**
  * Resolve a fixture file name to a URI.
  * e.g. getDocUri("simple.tcl") → file:///…/testFixture/simple.tcl
  */
 export function getDocUri(fileName: string): vscode.Uri {
   return vscode.Uri.file(path.resolve(__dirname, "../../testFixture", fileName));
-}
-
-/** Promisified setTimeout. */
-export function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 // ---------------------------------------------------------------------------
@@ -57,6 +56,12 @@ let _serverLogSubscribed = false;
 // its full timeout every time.
 let _serverLogTotalPushed = 0;
 
+// Waiters registered by `waitForServerLog`. The `window/logMessage`
+// notification *is* the signal a log-line wait is for, so an arriving line
+// wakes every waiter immediately rather than leaving them to notice it on
+// their next poll tick.
+const _serverLogWaiters = new Set<() => void>();
+
 async function _ensureServerLogSubscribed(): Promise<void> {
   if (_serverLogSubscribed) return;
   const ext = vscode.extensions.getExtension("bitwisecook.tcl-lsp");
@@ -70,14 +75,14 @@ async function _ensureServerLogSubscribed(): Promise<void> {
     if (_serverLog.length > _SERVER_LOG_MAX) {
       _serverLog.splice(0, _serverLog.length - _SERVER_LOG_MAX);
     }
+    for (const notify of _serverLogWaiters) notify();
   });
   _serverLogSubscribed = true;
 }
 
 /**
  * Resolve on the next ``onDidChangeDiagnostics`` event for *docUri*,
- * or on timeout.  Returns the current diagnostics for *docUri* either
- * way.
+ * returning the diagnostics that publish left in place.
  *
  * Use this when a test needs to observe a single server publish for a
  * URI — typically to assert that an empty publish arrived (no signal
@@ -88,13 +93,20 @@ async function _ensureServerLogSubscribed(): Promise<void> {
  * Register the listener **before** the action that triggers the
  * publish (e.g. ``activate(docUri)`` or an edit) so the event is not
  * missed.
+ *
+ * **Rejects** on timeout.  The whole point of this helper is the barrier —
+ * "a publish happened, so what you read next is not the previous test's
+ * set".  Resolving with the current diagnostics when the publish never
+ * arrived hands the caller exactly the stale set it exists to exclude, and
+ * every caller then asserts against it as if the barrier had held.
  */
 export function nextDiagnosticsPublish(
   docUri: vscode.Uri,
   opts?: { timeout?: number },
 ): Promise<vscode.Diagnostic[]> {
-  const timeout = opts?.timeout ?? 5_000;
-  return new Promise<vscode.Diagnostic[]>((resolve) => {
+  const base = opts?.timeout ?? 5_000;
+  const timeout = scaledTimeout(base);
+  return new Promise<vscode.Diagnostic[]>((resolve, reject) => {
     const disposable = vscode.languages.onDidChangeDiagnostics((e) => {
       if (e.uris.some((u) => u.toString() === docUri.toString())) {
         disposable.dispose();
@@ -104,7 +116,17 @@ export function nextDiagnosticsPublish(
     });
     const timer = setTimeout(() => {
       disposable.dispose();
-      resolve(vscode.languages.getDiagnostics(docUri));
+      reject(
+        new Error(
+          `${WAIT_TIMEOUT_MARKER}: timed out awaiting the next diagnostics publish for ` +
+            `${docUri.toString()}\n` +
+            `  waited ${timeout}ms (base ${base}ms, load-scaled)\n` +
+            `  no onDidChangeDiagnostics event named this URI, so anything read now is ` +
+            `the pre-action set this barrier exists to exclude.\n` +
+            `  currently published: ${vscode.languages.getDiagnostics(docUri).length} ` +
+            `diagnostic(s)`,
+        ),
+      );
     }, timeout);
   });
 }
@@ -146,8 +168,12 @@ function _sinceToIndex(since: number): number {
 /**
  * Wait until at least one server log line at or after ``opts.since``
  * (an absolute sequence number from ``getServerLogSize()``) matches
- * *predicate*, or the timeout expires.  Returns the matching line, or
- * ``null`` on timeout.
+ * *predicate*.  Returns the matching line; **rejects** on timeout.
+ *
+ * Signal-driven: the ``window/logMessage`` notification the server sends *is*
+ * the thing being waited on, so an arriving line wakes the wait immediately.
+ * The interval re-scan inside [`awaitSignal`] is only a missed-notification
+ * backstop.
  *
  * The default ``since`` is ``0``, which keeps the legacy behaviour of
  * searching the entire captured buffer.  Tests waiting for an event
@@ -156,21 +182,30 @@ function _sinceToIndex(since: number): number {
  */
 export async function waitForServerLog(
   predicate: (line: string) => boolean,
-  opts?: { timeout?: number; since?: number },
-): Promise<string | null> {
-  const timeout = opts?.timeout ?? 5_000;
+  opts?: { timeout?: number; since?: number; label?: string },
+): Promise<string> {
   const since = opts?.since ?? 0;
-  const start = Date.now();
-  while (Date.now() - start < timeout) {
+  const scan = (): string | null => {
     for (let i = _sinceToIndex(since); i < _serverLog.length; i++) {
       if (predicate(_serverLog[i])) return _serverLog[i];
     }
-    await sleep(50);
-  }
-  for (let i = _sinceToIndex(since); i < _serverLog.length; i++) {
-    if (predicate(_serverLog[i])) return _serverLog[i];
-  }
-  return null;
+    return null;
+  };
+  const hit = await awaitSignal<string | null>({
+    label: opts?.label ?? "a matching server log line",
+    subscribe: (notify) => {
+      _serverLogWaiters.add(notify);
+      return { dispose: () => _serverLogWaiters.delete(notify) };
+    },
+    probe: scan,
+    predicate: (line) => line !== null,
+    timeout: opts?.timeout ?? 5_000,
+    describe: () =>
+      `no match among the ${_serverLog.length - _sinceToIndex(since)} line(s) logged ` +
+      `since seq ${since} (${_serverLogTotalPushed} logged in total)`,
+  });
+  // `predicate` above admits only non-null, so this cannot be null.
+  return hit as string;
 }
 
 /**
@@ -197,16 +232,14 @@ export async function waitForDeepDiagnostics(
   opts?: { timeout?: number; since?: number },
 ): Promise<void> {
   const uri = docUri.toString();
-  const hit = await waitForServerLog(
+  await waitForServerLog(
     (line) => line.includes("[timing] deep diagnostics") && line.includes(`uri=${uri}`),
-    { since: opts?.since, timeout: opts?.timeout ?? 20_000 },
+    {
+      since: opts?.since,
+      timeout: opts?.timeout ?? 20_000,
+      label: `the server's deep-diagnostics marker for ${uri}`,
+    },
   );
-  if (hit === null) {
-    throw new Error(
-      `Timeout waiting for deep diagnostics on ${uri} ` +
-        `(since=${opts?.since ?? 0}, logSize=${_serverLog.length})`,
-    );
-  }
 }
 
 /**
@@ -233,16 +266,14 @@ export async function waitForMasterOffDiagnostics(
   opts?: { timeout?: number; since?: number },
 ): Promise<void> {
   const uri = docUri.toString();
-  const hit = await waitForServerLog(
+  await waitForServerLog(
     (line) => line.includes("[timing] diagnostics master-off") && line.includes(`uri=${uri}`),
-    { since: opts?.since, timeout: opts?.timeout ?? 10_000 },
+    {
+      since: opts?.since,
+      timeout: opts?.timeout ?? 10_000,
+      label: `the server's master-off diagnostics marker for ${uri}`,
+    },
   );
-  if (hit === null) {
-    throw new Error(
-      `Timeout waiting for master-off diagnostics on ${uri} ` +
-        `(since=${opts?.since ?? 0}, logSize=${_serverLog.length})`,
-    );
-  }
 }
 
 /**
@@ -271,63 +302,157 @@ export interface EffectiveConfig {
 }
 
 /**
- * Poll ``tcl-lsp.getEffectiveConfig`` until ``predicate`` returns true,
- * or until ``opts.timeout`` elapses.  Use this instead of ``sleep(N)``
- * after any ``tclLsp.*`` config change so tests wait on the server's
- * resolved state rather than the debounce timer or the
- * ``workspace/configuration`` round-trip.  Throws on timeout with the
+ * Poll ``tcl-lsp.getEffectiveConfig`` until ``predicate`` returns true.
+ * Use this instead of ``sleep(N)`` after any ``tclLsp.*`` config change so
+ * tests wait on the server's resolved state rather than the debounce timer
+ * or the ``workspace/configuration`` round-trip.  Throws on timeout with the
  * last-seen config snapshot in the message.
+ *
+ * **Deliberately polled** — see [`pollUntil`].  Configuration settling emits
+ * no client-visible event: ``onDidChangeConfiguration`` fires when *VS Code*
+ * accepts the new value, which is strictly before the server has pulled it
+ * via ``workspace/configuration`` and re-resolved the document, so waiting on
+ * it would answer a different question than the one asked here.  The server
+ * publishes no settle marker for a config pull either, so the only available
+ * signal is the resolved config itself.
  */
 export async function waitForEffectiveConfig(
   docUri: vscode.Uri,
   predicate: (cfg: EffectiveConfig) => boolean,
   opts?: { timeout?: number; label?: string },
 ): Promise<EffectiveConfig> {
-  const timeout = opts?.timeout ?? 5_000;
-  const deadline = Date.now() + timeout;
-  let last: EffectiveConfig | undefined;
-  while (Date.now() < deadline) {
-    last = (await vscode.commands.executeCommand(
-      "tcl-lsp.getEffectiveConfig",
-      docUri.toString(),
-    )) as EffectiveConfig | undefined;
-    if (last && predicate(last)) return last;
-    await sleep(50);
-  }
-  throw new Error(
-    `Timeout waiting for effective config${opts?.label ? ` (${opts.label})` : ""} ` +
-      `(last seen: ${JSON.stringify(last)})`,
+  return pollUntil(
+    () =>
+      vscode.commands.executeCommand("tcl-lsp.getEffectiveConfig", docUri.toString()) as Thenable<
+        EffectiveConfig | undefined
+      >,
+    (cfg): cfg is EffectiveConfig => cfg !== undefined && predicate(cfg),
+    {
+      timeout: opts?.timeout ?? 5_000,
+      label: `effective config${opts?.label ? ` (${opts.label})` : ""}`,
+    },
   );
 }
 
 /**
- * Poll ``fn`` every 50ms until ``predicate(result)`` returns true, or
- * until ``opts.timeout`` elapses.  Returns the first result that
- * satisfies the predicate.  Throws on timeout with the last-seen
- * result included in the message.
+ * Poll ``fn`` until ``predicate(result)`` returns true.  Returns the first
+ * result that satisfies the predicate.  Throws on timeout with the
+ * last-seen result and a machine-load verdict in the message.
  *
- * Useful for waiting on a VS Code command's response shape without
- * sleeping on wall-clock time — for example, polling
- * ``vscode.executeCodeLensProvider`` until the language server has
- * published its first batch of lenses.
+ * # Use this only where there is genuinely no signal to wait on
+ *
+ * Polling is the fallback, not the default (see [`awaitSignal`]'s module
+ * docs): it is slower than the work in the good case and says nothing useful
+ * in the bad one.  It is the right answer for exactly one situation — a
+ * ``vscode.commands.executeCommand`` pull whose readiness VS Code announces
+ * through no event at all, such as ``tcl-lsp.getEffectiveConfig`` (config
+ * settling) or the extension host's document registry.
+ *
+ * A provider pull whose readiness follows the server *re-analysing a
+ * document* — code actions, code lenses, symbols — does have a signal:
+ * ``onDidChangeDiagnostics`` is that publish. Use
+ * [`waitForProviderResult`] for those, which polls only as a
+ * missed-event backstop.
+ *
+ * The deadline is scaled by measured machine load, so a loaded container
+ * cannot manufacture a timeout out of a merely slow round-trip.
  */
+export async function pollUntil<T, U extends T>(
+  fn: () => Thenable<T> | T,
+  predicate: (value: T) => value is U,
+  opts?: { timeout?: number; interval?: number; label?: string },
+): Promise<U>;
+export async function pollUntil<T>(
+  fn: () => Thenable<T> | T,
+  predicate: (value: T) => boolean,
+  opts?: { timeout?: number; interval?: number; label?: string },
+): Promise<T>;
 export async function pollUntil<T>(
   fn: () => Thenable<T> | T,
   predicate: (value: T) => boolean,
   opts?: { timeout?: number; interval?: number; label?: string },
 ): Promise<T> {
-  const timeout = opts?.timeout ?? 5_000;
-  const interval = opts?.interval ?? 50;
-  const deadline = Date.now() + timeout;
-  let last: T | undefined;
-  while (Date.now() < deadline) {
-    last = await fn();
-    if (predicate(last)) return last;
-    await sleep(interval);
-  }
-  throw new Error(
-    `Timeout polling${opts?.label ? ` (${opts.label})` : ""} ` +
-      `(last seen: ${JSON.stringify(last)})`,
+  return awaitSignal<T>({
+    label: opts?.label ?? "a polled condition",
+    // No event exists for these callers — that is the whole reason this
+    // helper is separate from `awaitSignal`'s event-driven users. The
+    // subscription is a no-op and the backstop interval is the mechanism.
+    subscribe: () => ({ dispose: () => {} }),
+    probe: fn,
+    predicate,
+    timeout: opts?.timeout ?? 5_000,
+    backstopInterval: opts?.interval ?? 50,
+  });
+}
+
+/**
+ * Wait for a language-feature provider pull (``vscode.executeCodeActionProvider``
+ * and friends) to return a result satisfying *predicate*.
+ *
+ * Provider pulls have no completion event of their own — you ask, you get
+ * whatever the server knows *now*.  What they do have is a signal for the
+ * thing that actually changes the answer: the server re-analysing the
+ * document, which it announces by publishing diagnostics.  So this waits on
+ * ``onDidChangeDiagnostics`` for *uri*, re-pulls on every publish, and keeps a
+ * slow interval re-pull purely as a missed-event backstop — the same shape as
+ * [`waitForDiagnostics`], and unlike [`pollUntil`], where the interval *is*
+ * the mechanism.
+ */
+export async function waitForProviderResult<T>(
+  uri: vscode.Uri,
+  pull: () => Thenable<T> | T,
+  predicate: (value: T) => boolean,
+  opts?: {
+    timeout?: number;
+    label?: string;
+    backstopInterval?: number;
+    describe?: (value: T | undefined) => string;
+  },
+): Promise<T> {
+  const target = uri.toString();
+  return awaitSignal<T>({
+    label: opts?.label ?? `a provider result for ${target}`,
+    subscribe: (notify) =>
+      vscode.languages.onDidChangeDiagnostics((e) => {
+        if (e.uris.some((u) => u.toString() === target)) notify();
+      }),
+    probe: pull,
+    predicate,
+    timeout: opts?.timeout ?? 10_000,
+    backstopInterval: opts?.backstopInterval,
+    describe: opts?.describe,
+  });
+}
+
+/**
+ * [`waitForProviderResult`] specialised to ``vscode.executeCodeActionProvider``:
+ * wait until the code actions offered over *range* satisfy *predicate*.
+ */
+export async function waitForCodeActions(
+  uri: vscode.Uri,
+  range: vscode.Range,
+  predicate: (actions: vscode.CodeAction[]) => boolean,
+  opts?: { timeout?: number; label?: string },
+): Promise<vscode.CodeAction[]> {
+  return waitForProviderResult<vscode.CodeAction[]>(
+    uri,
+    async () =>
+      ((await vscode.commands.executeCommand(
+        "vscode.executeCodeActionProvider",
+        uri,
+        range,
+      )) as vscode.CodeAction[] | undefined) ?? [],
+    predicate,
+    {
+      timeout: opts?.timeout,
+      label: opts?.label ?? `code actions at ${range.start.line}:${range.start.character}`,
+      describe: (actions) =>
+        actions === undefined
+          ? "<never pulled>"
+          : actions.length === 0
+            ? "no code actions offered"
+            : `offered: ${actions.map((a) => a.title).join("; ")}`,
+    },
   );
 }
 
@@ -355,6 +480,18 @@ export async function waitForFeatureToggle(
  * ``didOpen`` the editor sends — the extension only mirrors it into the status
  * bar.  So this waits for the server to have drained that ``didOpen`` (via the
  * hover round trips below) rather than for a dialect notification.
+ *
+ * # Every step is bounded
+ *
+ * Each await here is already the right *shape* — it resolves when the work
+ * completes — but none of them carried a bound, so a wedged step could only be
+ * caught by mocha's 60s per-test timeout, which fires knowing nothing about
+ * which step was outstanding.  That is what issue #1274 recorded: two
+ * `shimmerPrecision` tests each hit the raw 60s timeout, a number no wait in
+ * their body could produce (``waitForDiagnostics`` bounds at 20s and would have
+ * failed the assertion long before), so the stall was inside this function and
+ * the log said nothing about where.  [`bounded`] wraps each step with a
+ * load-scaled deadline that names it.
  */
 export async function activate(docUri: vscode.Uri): Promise<vscode.TextDocument> {
   // Ensure the extension is activated first.
@@ -362,12 +499,22 @@ export async function activate(docUri: vscode.Uri): Promise<vscode.TextDocument>
   // initialise/initialised handshake -- the server is ready at that point.
   const ext = vscode.extensions.getExtension("bitwisecook.tcl-lsp");
   if (ext && !ext.isActive) {
-    await ext.activate();
+    // Cold start spawns the server binary and completes the LSP handshake, so
+    // it gets a larger budget than the per-document steps below.
+    await bounded(ext.activate(), "the tcl-lsp extension to activate (LSP handshake)", {
+      timeout: 60_000,
+    });
   }
   await _ensureServerLogSubscribed();
 
-  const doc = await vscode.workspace.openTextDocument(docUri);
-  await vscode.window.showTextDocument(doc);
+  const doc = await bounded(
+    vscode.workspace.openTextDocument(docUri),
+    `workspace.openTextDocument(${docUri.toString()})`,
+  );
+  await bounded(
+    vscode.window.showTextDocument(doc),
+    `window.showTextDocument(${docUri.toString()})`,
+  );
 
   // Mirror the detected dialect into the status bar, exactly as the
   // extension's onDidChangeActiveTextEditor handler does.  Purely cosmetic
@@ -384,16 +531,19 @@ export async function activate(docUri: vscode.Uri): Promise<vscode.TextDocument>
   // server's processing queue so we don't return until that ``didOpen`` has
   // been drained.  Two hovers — one to flush, one belt-and-braces —
   // eliminate the residual race we saw on macOS.
-  await vscode.commands.executeCommand(
-    "vscode.executeHoverProvider",
-    docUri,
-    new vscode.Position(0, 0),
-  );
-  await vscode.commands.executeCommand(
-    "vscode.executeHoverProvider",
-    docUri,
-    new vscode.Position(0, 0),
-  );
+  for (const attempt of [1, 2]) {
+    await bounded(
+      vscode.commands.executeCommand(
+        "vscode.executeHoverProvider",
+        docUri,
+        new vscode.Position(0, 0),
+      ),
+      `the server to drain didOpen for ${docUri.toString()} ` +
+        `(flush hover ${attempt} of 2)\n  a timeout here means the server accepted the ` +
+        `document but never answered a request queued behind it`,
+      { timeout: 30_000 },
+    );
+  }
 
   return doc;
 }
@@ -450,7 +600,8 @@ export async function activateViaWorkbench(docUri: vscode.Uri): Promise<vscode.T
  * Register **before** issuing the close so the event cannot be missed.
  */
 export function documentClosed(docUri: vscode.Uri, opts?: { timeout?: number }): Promise<void> {
-  const timeout = opts?.timeout ?? 20_000;
+  const base = opts?.timeout ?? 20_000;
+  const timeout = scaledTimeout(base);
   const uri = docUri.toString();
   return new Promise<void>((resolve, reject) => {
     const disposable = vscode.workspace.onDidCloseTextDocument((doc) => {
@@ -463,7 +614,8 @@ export function documentClosed(docUri: vscode.Uri, opts?: { timeout?: number }):
       disposable.dispose();
       reject(
         new Error(
-          `Timeout waiting for onDidCloseTextDocument on ${uri} — the document is ` +
+          `${WAIT_TIMEOUT_MARKER}: timed out awaiting onDidCloseTextDocument on ${uri} ` +
+            `after ${timeout}ms (base ${base}ms, load-scaled) — the document is ` +
             `still open despite its editor closing, so the server never received a ` +
             `textDocument/didClose (was it opened with activateViaWorkbench?)`,
         ),
@@ -473,15 +625,31 @@ export function documentClosed(docUri: vscode.Uri, opts?: { timeout?: number }):
 }
 
 /**
- * Poll for diagnostics on the given URI until ``minCount`` are available
- * or ``predicate`` returns truthy, whichever comes first.  Combines event
- * listening with periodic polling for robustness.
+ * Wait for diagnostics on the given URI to satisfy ``predicate`` (or to reach
+ * ``minCount`` entries), driven by ``onDidChangeDiagnostics`` — the server's
+ * own publish is the signal — with a 500ms re-read purely as a missed-event
+ * backstop.  **Rejects** on a load-scaled timeout.
  *
  * The deep-diagnostic pass (IRULE1005 and friends) is async and fires
  * *after* the initial batch of basic diagnostics, so a test that wants
  * a specific deep code should pass a ``predicate`` rather than a fixed
  * ``minCount`` — ``minCount`` alone returns as soon as enough basic
  * diagnostics arrive, before the deep pass has run.
+ *
+ * # Why the timeout rejects
+ *
+ * It used to resolve with ``getDiagnostics(uri)`` — whatever happened to be
+ * published when the clock ran out.  A test that timed out therefore carried
+ * on and asserted against a set the server had never finished producing.  For
+ * a positive assertion that surfaces as a confusing content failure; for a
+ * *negative* one ("no diagnostic of kind X on line N") an unanalysed, empty
+ * set satisfies it trivially and the test passes vacuously — the suite's
+ * strongest tests are precisely the negative ones (issue #1274).
+ *
+ * Callers that genuinely want "settle, then look" and cannot name what they
+ * are waiting for are asking a different question; those are the ones that
+ * should pass ``minCount: 0`` explicitly, which is satisfied immediately and
+ * so never reaches this timeout at all.
  */
 export async function waitForDiagnostics(
   uri: vscode.Uri,
@@ -491,58 +659,31 @@ export async function waitForDiagnostics(
     predicate?: (diags: vscode.Diagnostic[]) => boolean;
   },
 ): Promise<vscode.Diagnostic[]> {
-  const timeout = opts?.timeout ?? 20_000;
   const minCount = opts?.minCount ?? 1;
   const predicate = opts?.predicate;
+  const target = uri.toString();
 
-  const isReady = (diags: vscode.Diagnostic[]): boolean => {
-    if (predicate) {
-      return predicate(diags);
-    }
-    return diags.length >= minCount;
-  };
-
-  // Check immediately
-  const immediate = vscode.languages.getDiagnostics(uri);
-  if (isReady(immediate)) {
-    return immediate;
-  }
-
-  return new Promise<vscode.Diagnostic[]>((resolve) => {
-    let resolved = false;
-
-    const finish = (diags: vscode.Diagnostic[]) => {
-      if (resolved) return;
-      resolved = true;
-      clearTimeout(timer);
-      clearInterval(poller);
-      disposable.dispose();
-      resolve(diags);
-    };
-
-    // Timeout -- return whatever we have
-    const timer = setTimeout(() => {
-      finish(vscode.languages.getDiagnostics(uri));
-    }, timeout);
-
-    // Event-driven: listen for diagnostic changes
-    const disposable = vscode.languages.onDidChangeDiagnostics((e) => {
-      const changed = e.uris.some((u) => u.toString() === uri.toString());
-      if (changed) {
-        const diags = vscode.languages.getDiagnostics(uri);
-        if (isReady(diags)) {
-          finish(diags);
-        }
-      }
-    });
-
-    // Polling fallback: check every 500ms in case we missed an event
-    const poller = setInterval(() => {
-      const diags = vscode.languages.getDiagnostics(uri);
-      if (isReady(diags)) {
-        finish(diags);
-      }
-    }, 500);
+  return awaitSignal<vscode.Diagnostic[]>({
+    label: predicate
+      ? `diagnostics on ${target} to satisfy the test's predicate`
+      : `at least ${minCount} diagnostic(s) on ${target}`,
+    subscribe: (notify) =>
+      vscode.languages.onDidChangeDiagnostics((e) => {
+        if (e.uris.some((u) => u.toString() === target)) notify();
+      }),
+    probe: () => vscode.languages.getDiagnostics(uri),
+    predicate: (diags) => (predicate ? predicate(diags) : diags.length >= minCount),
+    timeout: opts?.timeout ?? 20_000,
+    describe: (diags) =>
+      diags === undefined || diags.length === 0
+        ? "no diagnostics published"
+        : diags
+            .map(
+              (d) =>
+                `${typeof d.code === "object" && d.code !== null ? d.code.value : d.code}@` +
+                `${d.range.start.line}:${d.range.start.character}`,
+            )
+            .join(", "),
   });
 }
 

--- a/editors/vscode/src/test/index.ts
+++ b/editors/vscode/src/test/index.ts
@@ -19,7 +19,9 @@
 import * as fs from "fs";
 import * as path from "path";
 import Mocha from "mocha";
+import * as vscode from "vscode";
 import { glob } from "glob";
+import { loadFactor, scaledTimeout } from "./signal";
 
 // Register a require hook so tsc-compiled output can load .md files at runtime.
 // (In production the esbuild bundle uses --loader:.md=text to inline them.)
@@ -27,16 +29,94 @@ require.extensions[".md"] = (mod: NodeJS.Module, filename: string) => {
   (mod as NodeJS.Module & { exports: unknown }).exports = fs.readFileSync(filename, "utf8");
 };
 
+/**
+ * What the heartbeat file records, so a hang is attributable from outside the
+ * extension host.
+ *
+ * The runner's launch-exit budget used to expire with nothing to say but a
+ * process list and "mocha never completed (likely hung)" — which names neither
+ * the test that stalled nor whether the server was still alive (issue #1274).
+ * The extension host is the only place that knows both, so it writes them down
+ * continuously and `runTest.ts` reads the last entry after the fact.
+ */
+interface Heartbeat {
+  /** When this heartbeat was written (ms since epoch). Its *age* at read time
+   *  is the evidence: a stale heartbeat means the extension host's event loop
+   *  itself stopped turning, which is a different fault from a test stuck in a
+   *  wait. */
+  at: number;
+  /** Tests currently between `test` and `test end` — normally exactly one. */
+  inFlight: Array<{ title: string; forMs: number }>;
+  completed: number;
+  failed: number;
+  /** Round-trip to the language server, taken only once a test has been in
+   *  flight long enough to be suspicious. `null` until then. */
+  server:
+    | null
+    | { responsive: true; roundTripMs: number }
+    | { responsive: false; reason: string; afterMs: number };
+  /** Measured machine load at the time of writing — the difference between "the
+   *  suite is wedged" and "the container is oversubscribed". */
+  loadFactor: number;
+}
+
+/** How often the heartbeat is refreshed. */
+const HEARTBEAT_INTERVAL_MS = 2_000;
+
+/** How long a single test may run before the heartbeat starts probing the
+ *  server on every tick. Below this a slow test is just a slow test. */
+const SERVER_PROBE_AFTER_MS = 20_000;
+
+/** Bound on the server probe itself, so the heartbeat can never become the
+ *  thing that hangs. */
+const SERVER_PROBE_TIMEOUT_MS = 5_000;
+
+/**
+ * Ask the language server a question that touches neither the document store
+ * nor the analyser, so what it times is the client → server → client path
+ * itself. Mirrors the native harness's `LatencyBudget` no-op probe.
+ */
+async function probeServer(): Promise<NonNullable<Heartbeat["server"]>> {
+  const started = Date.now();
+  try {
+    const answered = await Promise.race([
+      vscode.commands.executeCommand("tcl-lsp.getEffectiveConfig", "").then(() => true),
+      new Promise<false>((resolve) =>
+        setTimeout(() => resolve(false), scaledTimeout(SERVER_PROBE_TIMEOUT_MS)).unref(),
+      ),
+    ]);
+    return answered
+      ? { responsive: true, roundTripMs: Date.now() - started }
+      : {
+          responsive: false,
+          reason: "getEffectiveConfig did not answer",
+          afterMs: Date.now() - started,
+        };
+  } catch (err) {
+    return {
+      responsive: false,
+      reason: err instanceof Error ? err.message : String(err),
+      afterMs: Date.now() - started,
+    };
+  }
+}
+
 export async function run(): Promise<void> {
   // Written unconditionally when mocha's run() callback fires (pass or fail)
   // so runTest.ts's exit-timeout watchdog can tell "mocha finished cleanly,
   // the process just didn't exit" apart from "mocha never finished" (a hang).
   // Only the latter may be swallowed as success.
   const resultMarker = path.resolve(__dirname, "../../", ".vscode-test", "mocha-result.json");
+  const heartbeatMarker = path.resolve(__dirname, "../../", ".vscode-test", "mocha-heartbeat.json");
   const mocha = new Mocha({
     ui: "tdd",
     color: true,
-    timeout: 60_000, // LSP startup can be slow
+    // A per-test backstop, not a budget: every wait a test takes is itself
+    // bounded and load-scaled (see `signal.ts`), so a test that reaches this
+    // number has stalled somewhere with no bound of its own. Scaled by measured
+    // load for the same reason those waits are — the shimmer tests in #1274 hit
+    // a raw 60s each under ~9 concurrent build trees.
+    timeout: scaledTimeout(60_000),
   });
   if (process.env.MOCHA_GREP) {
     mocha.grep(process.env.MOCHA_GREP);
@@ -79,8 +159,58 @@ export async function run(): Promise<void> {
     mocha.addFile(path.resolve(testsRoot, f));
   }
 
+  fs.mkdirSync(path.dirname(heartbeatMarker), { recursive: true });
+  try {
+    fs.unlinkSync(heartbeatMarker);
+  } catch {
+    // No stale heartbeat to remove.
+  }
+
   return new Promise<void>((resolve, reject) => {
+    const inFlight = new Map<string, number>();
+    let completed = 0;
+    let failed = 0;
+    let lastServerProbe: Heartbeat["server"] = null;
+    let probeInFlight = false;
+
+    const writeHeartbeat = () => {
+      const now = Date.now();
+      const entries = [...inFlight.entries()].map(([title, startedAt]) => ({
+        title,
+        forMs: now - startedAt,
+      }));
+      const stalled = entries.some((e) => e.forMs >= SERVER_PROBE_AFTER_MS);
+      if (stalled && !probeInFlight) {
+        probeInFlight = true;
+        void probeServer().then((result) => {
+          lastServerProbe = result;
+          probeInFlight = false;
+        });
+      } else if (!stalled) {
+        lastServerProbe = null;
+      }
+      const beat: Heartbeat = {
+        at: now,
+        inFlight: entries,
+        completed,
+        failed,
+        server: lastServerProbe,
+        loadFactor: loadFactor(),
+      };
+      try {
+        fs.writeFileSync(heartbeatMarker, JSON.stringify(beat) + "\n", "utf8");
+      } catch {
+        // The heartbeat is diagnostics only — never fail a run over it.
+      }
+    };
+
+    // Unref'd: the heartbeat must never be the reason the host stays alive
+    // after the suite finishes.
+    const heartbeat = setInterval(writeHeartbeat, HEARTBEAT_INTERVAL_MS);
+    heartbeat.unref();
+
     const runner = mocha.run((failures) => {
+      clearInterval(heartbeat);
       restoreFixtureSettings();
       fs.mkdirSync(path.dirname(resultMarker), { recursive: true });
       fs.writeFileSync(resultMarker, JSON.stringify({ failures }) + "\n", "utf8");
@@ -90,9 +220,19 @@ export async function run(): Promise<void> {
         resolve();
       }
     });
+
+    runner.on("test", (test: Mocha.Test) => {
+      inFlight.set(test.fullTitle(), Date.now());
+      writeHeartbeat();
+    });
+    runner.on("test end", (test: Mocha.Test) => {
+      inFlight.delete(test.fullTitle());
+      completed++;
+    });
     // Log failure details so they are visible even when the VS Code test
     // host terminates before mocha prints its summary.
     runner.on("fail", (test: Mocha.Test, err: Error) => {
+      failed++;
       console.error(`\nFAIL: ${test.fullTitle()}`);
       console.error(`  ${err.message}`);
       if (err.stack) {

--- a/editors/vscode/src/test/issue1019ProcArgs.test.ts
+++ b/editors/vscode/src/test/issue1019ProcArgs.test.ts
@@ -32,6 +32,7 @@ import {
   getServerLogSize,
   waitForDeepDiagnostics,
   waitForDiagnostics,
+  waitForProviderResult,
 } from "./helper";
 
 function codeOf(d: vscode.Diagnostic): string {
@@ -122,19 +123,40 @@ suite("Issue #1019 idx 28 — cross-file mixin hover", () => {
   const deviceUri = getDocUri("issue1019Idx28Device.tcl");
   const libUri = getDocUri("issue1019Idx28Lib.tcl");
 
-  test("hover on `my <method>` names the provider in the sibling file", async () => {
-    await activate(libUri);
-    await activate(deviceUri);
-    // Cursor on `ArgsPreprocess` in the `my` dispatch (line 4).
-    const hovers = (await vscode.commands.executeCommand(
-      "vscode.executeHoverProvider",
-      deviceUri,
-      new vscode.Position(4, 20),
-    )) as vscode.Hover[];
-    const text = (hovers ?? [])
+  // Cursor on `ArgsPreprocess` in the `my` dispatch (line 4).
+  const dispatchPos = new vscode.Position(4, 20);
+
+  function hoverText(hovers: vscode.Hover[] | undefined): string {
+    return (hovers ?? [])
       .flatMap((h) => h.contents)
       .map((c) => (typeof c === "string" ? c : (c as vscode.MarkdownString).value))
       .join("\n");
+  }
+
+  test("hover on `my <method>` names the provider in the sibling file", async () => {
+    await activate(libUri);
+    await activate(deviceUri);
+    // Naming the provider needs the *sibling* file, so the answer only becomes
+    // correct once the workspace scan has surfaced it.  Sampling the provider
+    // once races that scan: the request is served from whatever the workspace
+    // knows at that instant, and an empty hover reads as a failure rather than
+    // as "not indexed yet".  Wait on the answer instead — the good case
+    // returns on the first probe, the bad case is bounded by the timeout.
+    const hovers = await waitForProviderResult<vscode.Hover[]>(
+      deviceUri,
+      () =>
+        vscode.commands.executeCommand(
+          "vscode.executeHoverProvider",
+          deviceUri,
+          dispatchPos,
+        ) as Thenable<vscode.Hover[]>,
+      (hs) => hoverText(hs).includes("::Idx28::Utility"),
+      {
+        label: "cross-file mixin hover naming ::Idx28::Utility",
+        describe: (hs) => hoverText(hs) || "<no hover>",
+      },
+    );
+    const text = hoverText(hovers);
     assert.ok(text.includes("ArgsPreprocess"), `hover must name the method, got: ${text}`);
     assert.ok(
       text.includes("::Idx28::Utility"),
@@ -145,11 +167,21 @@ suite("Issue #1019 idx 28 — cross-file mixin hover", () => {
   test("hover and go-to-definition agree about the provider", async () => {
     await activate(libUri);
     await activate(deviceUri);
-    const locations = (await vscode.commands.executeCommand(
-      "vscode.executeDefinitionProvider",
+    // Same cross-file scan dependency as the hover above.
+    const locations = await waitForProviderResult<vscode.Location[]>(
       deviceUri,
-      new vscode.Position(4, 20),
-    )) as vscode.Location[];
+      () =>
+        vscode.commands.executeCommand(
+          "vscode.executeDefinitionProvider",
+          deviceUri,
+          dispatchPos,
+        ) as Thenable<vscode.Location[]>,
+      (ls) => (ls ?? []).length > 0,
+      {
+        label: "cross-file definition for `my ArgsPreprocess`",
+        describe: (ls) => `${(ls ?? []).length} location(s)`,
+      },
+    );
     assert.ok(locations && locations.length > 0, "definition must resolve cross-file");
     assert.strictEqual(
       locations[0].uri.toString(),

--- a/editors/vscode/src/test/issue1019ProcArgs.test.ts
+++ b/editors/vscode/src/test/issue1019ProcArgs.test.ts
@@ -26,7 +26,13 @@
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getDocUri, activate, waitForDiagnostics } from "./helper";
+import {
+  getDocUri,
+  activate,
+  getServerLogSize,
+  waitForDeepDiagnostics,
+  waitForDiagnostics,
+} from "./helper";
 
 function codeOf(d: vscode.Diagnostic): string {
   return typeof d.code === "object" && d.code !== null ? String(d.code.value) : String(d.code);
@@ -164,13 +170,19 @@ suite("Issue #1019 idx 11 — a proc named after a package command", () => {
   const docUri = getDocUri("issue1019Idx11Argparse.tcl");
 
   test("fires neither W113 nor W120 nor an arity error (false case)", async () => {
+    // The document is clean, so there is no diagnostic to wait *for*.  Waiting
+    // out a deadline with a predicate that can never hold is the anti-pattern
+    // issue #1274 is about: it costs the full deadline on every run even when
+    // the server settled in milliseconds, and it proves nothing — an empty set
+    // satisfies all three negative assertions below whether analysis ran or
+    // not.  The server's deep-diagnostics marker is the actual signal that the
+    // pass completed for this URI, and it fires on a clean file too
+    // (`diags=0`), so this returns as soon as the work is done and throws if it
+    // never happens.
+    const since = getServerLogSize();
     await activate(docUri);
-    // The document is clean, so there is no diagnostic to wait *for*; give
-    // the server a settled window and assert on whatever it published.
-    const diags = await waitForDiagnostics(docUri, {
-      timeout: 8000,
-      predicate: () => false,
-    }).catch(() => vscode.languages.getDiagnostics(docUri));
+    await waitForDeepDiagnostics(docUri, { since });
+    const diags = vscode.languages.getDiagnostics(docUri);
     const seen = diags.map(codeOf);
     assert.ok(!seen.includes("W113"), `the proc shadows no built-in: ${seen.join(", ")}`);
     assert.ok(!seen.includes("W120"), `the file defines the command itself: ${seen.join(", ")}`);

--- a/editors/vscode/src/test/refactorActions.test.ts
+++ b/editors/vscode/src/test/refactorActions.test.ts
@@ -18,7 +18,13 @@
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { activate, getDocUri, pollUntil, setTestContent } from "./helper";
+import {
+  activate,
+  getDocUri,
+  setTestContent,
+  waitForCodeActions,
+  waitForProviderResult,
+} from "./helper";
 
 // Apply-the-edit refactoring tests.  Unlike codeActions.test.ts (which checks
 // that an action exists), these load source into a scratch document, request
@@ -54,18 +60,13 @@ suite("Refactor Actions (applied)", () => {
   }
 
   async function findAction(range: vscode.Range, titleNeedle: string): Promise<vscode.CodeAction> {
-    const found = await pollUntil(
-      async () => {
-        const actions = (await vscode.commands.executeCommand(
-          "vscode.executeCodeActionProvider",
-          docUri,
-          range,
-        )) as vscode.CodeAction[];
-        return (actions || []).find((a) => a.title.includes(titleNeedle));
-      },
-      (a) => a !== undefined,
-      { timeout: 10_000, label: titleNeedle },
+    const actions = await waitForCodeActions(
+      docUri,
+      range,
+      (as) => as.some((a) => a.title.includes(titleNeedle)),
+      { timeout: 10_000, label: `a code action titled "${titleNeedle}"` },
     );
+    const found = actions.find((a) => a.title.includes(titleNeedle));
     assert.ok(found, `code action "${titleNeedle}" not found`);
     return found;
   }
@@ -196,10 +197,14 @@ suite("Refactor Actions (applied)", () => {
     // selection while no applicable extract-proc action is.
     await loadScratch("proc f {} {\n    set x 1\n    return $x\n}\n");
     const range = new vscode.Range(new vscode.Position(2, 0), new vscode.Position(3, 0));
-    await pollUntil(
+    await waitForProviderResult(
+      docUri,
       () => actionTitles(range),
       (ts) => ts.some((t) => t.includes("Extract into variable")),
-      { timeout: 10_000, label: "extract-variable anchor" },
+      {
+        timeout: 10_000,
+        label: `the "Extract into variable" anchor action, proving analysis settled`,
+      },
     );
     const titles = await actionTitles(range);
     assert.ok(
@@ -230,10 +235,11 @@ suite("Refactor Actions (applied)", () => {
     // plain-word call site offers Inline proc, the braced one does not.
     await loadScratch('proc greet {name} { puts "hello $name" }\ngreet world\ngreet {a b}\n');
     const good = new vscode.Range(new vscode.Position(1, 0), new vscode.Position(1, 0));
-    await pollUntil(
+    await waitForProviderResult(
+      docUri,
       () => actionTitles(good),
       (ts) => ts.some((t) => t.includes("Inline proc")),
-      { timeout: 10_000, label: "inline-proc anchor" },
+      { timeout: 10_000, label: `the "Inline proc" anchor action, proving analysis settled` },
     );
     const bad = new vscode.Range(new vscode.Position(2, 0), new vscode.Position(2, 0));
     const titles = await actionTitles(bad);

--- a/editors/vscode/src/test/runTest.ts
+++ b/editors/vscode/src/test/runTest.ts
@@ -22,8 +22,85 @@ import * as os from "os";
 import * as crypto from "crypto";
 import { execSync } from "child_process";
 import { runTests } from "@vscode/test-electron";
+import { loadFactor, scaledTimeout } from "./signal";
 
 const DEFAULT_EXIT_TIMEOUT_MS = 180_000;
+
+/** Mirror of the `Heartbeat` the extension host writes in `index.ts`. */
+interface Heartbeat {
+  at: number;
+  inFlight: Array<{ title: string; forMs: number }>;
+  completed: number;
+  failed: number;
+  server:
+    | null
+    | { responsive: true; roundTripMs: number }
+    | { responsive: false; reason: string; afterMs: number };
+  loadFactor: number;
+}
+
+/**
+ * Turn "mocha never completed" into an attributable report: which tests were in
+ * flight, for how long, whether the language server was still answering, and
+ * whether the extension host's own event loop was still turning.
+ *
+ * Without this the launch-exit budget expiring printed a process list and a
+ * guess, which is what made issue #1274 need re-run archaeology rather than
+ * reading a log.
+ */
+function reportHang(heartbeatMarker: string): void {
+  let beat: Heartbeat;
+  try {
+    beat = JSON.parse(fs.readFileSync(heartbeatMarker, "utf8"));
+  } catch {
+    console.error(
+      "No heartbeat was ever written, so the suite hung before or during its first test " +
+        "(extension host failed to start, or `run()` never reached mocha.run).",
+    );
+    return;
+  }
+
+  const age = Date.now() - beat.at;
+  console.error("--- hang report (from the extension host's heartbeat) ---");
+  console.error(
+    `  heartbeat written ${age}ms ago; ${beat.completed} test(s) completed, ` +
+      `${beat.failed} failed; measured load factor ${beat.loadFactor.toFixed(1)}`,
+  );
+  if (beat.inFlight.length === 0) {
+    console.error(
+      "  no test was in flight — mocha had finished the last test but the run() " +
+        "callback never fired, or a root-level hook is stuck.",
+    );
+  } else {
+    for (const t of beat.inFlight) {
+      console.error(`  IN FLIGHT for ${t.forMs}ms: ${t.title}`);
+    }
+  }
+  if (beat.server === null) {
+    console.error(
+      "  server: not probed — no test had been in flight long enough to be suspicious " +
+        "when this heartbeat was written.",
+    );
+  } else if (beat.server.responsive) {
+    console.error(
+      `  server: RESPONSIVE (${beat.server.roundTripMs}ms round trip), so the stall is in ` +
+        "the test or the extension host, not a wedged server.",
+    );
+  } else {
+    console.error(
+      `  server: NOT RESPONDING after ${beat.server.afterMs}ms (${beat.server.reason}) — ` +
+        "the language server stopped answering, so suspect the server, not the test.",
+    );
+  }
+  if (age > 3 * 2_000) {
+    console.error(
+      `  the heartbeat itself is ${age}ms stale (it refreshes every 2000ms), so the ` +
+        "extension host's event loop stopped turning — a blocked main thread or a " +
+        "crashed host, not a test waiting on a promise.",
+    );
+  }
+  console.error("--- end hang report ---");
+}
 
 function parseExitTimeoutMs(): number {
   const raw = process.env.TCL_LSP_VSCODE_TEST_EXIT_TIMEOUT_MS;
@@ -82,11 +159,21 @@ async function main() {
   // means mocha never finished at all (a hang), which is never safe to treat
   // as success.
   const resultMarker = path.resolve(extensionDevelopmentPath, ".vscode-test", "mocha-result.json");
+  // index.ts refreshes this every couple of seconds with the in-flight tests and
+  // a server-liveness probe, so an expiring exit budget below can say *what* was
+  // stuck rather than only that something was.
+  const heartbeatMarker = path.resolve(
+    extensionDevelopmentPath,
+    ".vscode-test",
+    "mocha-heartbeat.json",
+  );
   cleanupStaleTestHosts(extensionDevelopmentPath, extensionTestsPath);
-  try {
-    fs.unlinkSync(resultMarker);
-  } catch {
-    // No stale marker to remove.
+  for (const marker of [resultMarker, heartbeatMarker]) {
+    try {
+      fs.unlinkSync(marker);
+    } catch {
+      // No stale marker to remove.
+    }
   }
 
   // The user-data dir's IPC lock file is a Unix domain socket
@@ -125,7 +212,18 @@ async function main() {
     // The workspace to open during tests
     const testWorkspace = path.resolve(extensionDevelopmentPath, "testFixture");
 
-    const timeoutMs = parseExitTimeoutMs();
+    // The launch-exit budget is a hang backstop, so it is scaled by measured
+    // machine load for the same reason every wait inside the suite is: on a
+    // container sharing itself with several build trees, a correct run is
+    // simply slower, and killing it manufactures a failure. See signal.ts.
+    const baseTimeoutMs = parseExitTimeoutMs();
+    const timeoutMs = scaledTimeout(baseTimeoutMs);
+    if (timeoutMs !== baseTimeoutMs) {
+      console.log(
+        `==> launch-exit budget ${timeoutMs}ms (base ${baseTimeoutMs}ms x measured load ` +
+          `factor ${loadFactor().toFixed(1)})`,
+      );
+    }
     const runPromise = runTests({
       extensionDevelopmentPath,
       extensionTestsPath,
@@ -151,9 +249,15 @@ async function main() {
     cleanupStaleTestHosts(extensionDevelopmentPath, extensionTestsPath);
     process.exit(0);
   } catch (err) {
+    const timedOut = err instanceof Error && err.message.includes("did not exit within");
+    if (timedOut) {
+      // Read the heartbeat *before* the cleanup below kills the host that
+      // writes it, so the age reported is the age at the moment of giving up.
+      reportHang(heartbeatMarker);
+    }
     emitProcessSnapshot(extensionDevelopmentPath, extensionTestsPath);
     cleanupStaleTestHosts(extensionDevelopmentPath, extensionTestsPath);
-    if (err instanceof Error && err.message.includes("did not exit within")) {
+    if (timedOut && err instanceof Error) {
       if (fs.existsSync(resultMarker)) {
         let failures: number | null = null;
         try {

--- a/editors/vscode/src/test/shimmerPrecision.test.ts
+++ b/editors/vscode/src/test/shimmerPrecision.test.ts
@@ -52,20 +52,22 @@ suite("Shimmer precision (S100 deep review)", () => {
 
   async function s100Diagnostics(): Promise<vscode.Diagnostic[]> {
     await activate(docUri);
-    const diags = await waitForDiagnostics(docUri, {
+    // The settle signal for this file: once *some* S100 has landed, the deep
+    // shimmer pass has run, so the absence of another S100 on the same publish
+    // is meaningful rather than "not analysed yet".  That matters most for the
+    // false-case tests below (lines 13/42/49), whose assertions are negative —
+    // an empty or S100-free set satisfies every `!linesWithCode(...).includes(N)`
+    // trivially.
+    //
+    // `waitForDiagnostics` rejects on timeout, so an unsettled analysis fails
+    // here with the helper's diagnostic (what was awaited, how long, what was
+    // last published) rather than returning a partial set for those negative
+    // assertions to pass vacuously against.  This function used to re-assert
+    // the predicate afterwards because the helper resolved leniently instead;
+    // that check is now unreachable by construction (issue #1274).
+    return waitForDiagnostics(docUri, {
       predicate: (d) => d.some((x) => codeOf(x) === "S100"),
     });
-    // `waitForDiagnostics` resolves (does NOT throw) on timeout, returning the
-    // current set.  Assert the "analysis ran" settle signal here, once, so a
-    // timeout fails loudly in the shared helper instead of letting the
-    // false-case tests below (lines 13/42/49) pass vacuously against a set that
-    // never received the deep shimmer pass — an empty/S100-free set trivially
-    // satisfies every `!linesWithCode(...).includes(N)` assertion.
-    assert.ok(
-      diags.some((d) => codeOf(d) === "S100"),
-      `shimmer analysis did not settle (no S100 published); got [${linesWithCode(diags, "S100")}]`,
-    );
-    return diags;
   }
 
   test("committed dict shimmered by lindex fires S100 with a tight span (true case)", async () => {
@@ -153,15 +155,13 @@ suite("Shimmer pure-literal suppression (issue #940)", () => {
     await activate(docUri);
     // The committed-dict case on line 12 is the "analysis ran" settle signal:
     // once its S100 lands, the absence of S100/S101 on the pure-literal lines
-    // is meaningful rather than a not-yet-analysed empty set.
-    const diags = await waitForDiagnostics(docUri, {
+    // is meaningful rather than a not-yet-analysed empty set.  The wait rejects
+    // if it never lands (issue #1274), so the follow-up assertion this function
+    // used to carry — guarding against the helper's old lenient timeout — is
+    // now unreachable.
+    return waitForDiagnostics(docUri, {
       predicate: (d) => d.some((x) => codeOf(x) === "S100" && x.range.start.line === 12),
     });
-    assert.ok(
-      linesWithCode(diags, "S100").includes(12),
-      `shimmer analysis did not settle (no committed-case S100); got [${linesWithCode(diags, "S100")}]`,
-    );
-    return diags;
   }
 
   test("braced list, empty {}, scalar, and dict literals do not shimmer", async () => {

--- a/editors/vscode/src/test/signal.ts
+++ b/editors/vscode/src/test/signal.ts
@@ -1,0 +1,428 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Message passing bounded by a timeout — the wait discipline for the VS Code
+//! suite.
+//!
+//! # The shape
+//!
+//! A test waits on the **actual signal** for the thing it is asserting, so the
+//! good case finishes the instant the work does, and a wall-clock deadline
+//! exists **only to bound the failure**. Polling with a long deadline gets
+//! neither property: it is slow when it works (the answer sits unread until the
+//! next tick) and useless as a bound when it does not (the deadline has to be
+//! generous enough to cover the slowest legitimate case, so it no longer says
+//! anything about a hang).
+//!
+//! [`awaitSignal`] is that shape, once: subscribe to the event, re-probe on
+//! every event, resolve as soon as the predicate holds, and **reject** on a
+//! bounded timeout with a message naming what was awaited, how long it waited
+//! and what it last saw. A slow interval re-probe stays inside the loop purely
+//! as a missed-event backstop — never as the primary mechanism.
+//!
+//! Rejecting matters as much as the event does. A wait that *resolves* on
+//! timeout hands the test whatever happened to be present, so a genuine hang
+//! surfaces as a confusing content assertion — or, when the assertion is a
+//! negative ("no diagnostic of kind X"), passes vacuously.
+//!
+//! # Deadlines are scaled by measured capacity, never widened
+//!
+//! This mirrors the native e2e harness (`rust/tcl-lsp-server/tests/e2e/common/
+//! mod.rs`): every deadline here is a *hang backstop*, not an assertion. A
+//! fixed wall-clock backstop is wrong in exactly one direction — on a machine
+//! the OS is giving a fraction of a core, a correct server misses it and a
+//! *content* test fails as a *timeout*. That is the failure mode issue #1274
+//! records: the VS Code suite stalled while ~9 agent build trees shared the
+//! container.
+//!
+//! So deadlines are multiplied by [`loadFactor`], a measured probe of how much
+//! capacity this process is actually getting. On an idle machine the factor is
+//! `1.0` and every deadline is exactly what it reads in the source; under
+//! contention it grows with the contention. The constants stay honest and a
+//! quiet machine keeps the tight bound.
+//!
+//! The cheap signal (run-queue oversubscription) is read up front; the
+//! expensive one (scheduling latency, which costs ~100ms to sample) is taken
+//! only **at the moment of giving up**, where its cost is irrelevant. If it
+//! finds the machine starved, the wait is extended and resumed rather than
+//! failed — a busy machine must not manufacture a failure. If it finds the
+//! machine healthy, that verdict goes in the failure message, so the next
+//! occurrence is attributable instead of needing re-run archaeology.
+
+import * as fs from "fs";
+import * as os from "os";
+
+/** Greppable marker every bounded-wait timeout carries, so a CI-log scan can
+ *  classify the failure without reading the prose. */
+export const WAIT_TIMEOUT_MARKER = "VSCODE-WAIT-TIMEOUT";
+
+/** Sleep length the scheduling probe samples. */
+const PROBE_SLEEP_MS = 20;
+
+/** Samples the scheduling probe takes (median wins, so one unlucky context
+ *  switch cannot skew the verdict). */
+const PROBE_SAMPLES = 5;
+
+/**
+ * How late a short sleep must wake before the scheduler counts as starving
+ * this process. Timer granularity alone puts a 20ms sleep a few percent over;
+ * anything at or beyond this multiple only happens when the OS cannot run this
+ * thread promptly.
+ */
+const STARVATION_RATIO = 2.5;
+
+/** How long a measured [`loadFactor`] stays valid before it is re-sampled. */
+const LOAD_FACTOR_TTL_MS = 1_000;
+
+/** Default deadline for [`awaitSignal`] when a caller does not name one. */
+export const DEFAULT_SIGNAL_TIMEOUT_MS = 20_000;
+
+/** Default missed-event backstop interval. Deliberately slow: it is a safety
+ *  net for a dropped event, not the mechanism. */
+export const DEFAULT_BACKSTOP_INTERVAL_MS = 500;
+
+/**
+ * How many times a wait may re-measure and extend itself before it gives up.
+ * Bounds the worst case at `base x cap x extensions` so a wait can never become
+ * unbounded, however loaded the machine claims to be.
+ */
+const MAX_EXTENSIONS = 3;
+
+/** Ceiling on the measured factor, so a pathological reading cannot turn a
+ *  bound into an eternity. */
+const MAX_LOAD_FACTOR = 8;
+
+/** Promisified setTimeout. */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Promisified setTimeout on an **unref'd** timer.
+ *
+ * For sleeps that outlive the await that started them — [`bounded`]'s guard
+ * keeps counting after its work has already won the race. A ref'd timer there
+ * would hold the event loop open after the last test finished, which is the
+ * "mocha completed but the runner never exited" half of issue #1274.
+ */
+function sleepDetached(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms).unref();
+  });
+}
+
+/**
+ * Run-queue oversubscription: runnable threads per usable CPU. `<=1.0` when
+ * there is a core available for every thread that wants one; `4.0` when four
+ * threads contend for every core — in which case CPU-bound work takes about
+ * four times as long, which is precisely the correction a backstop needs.
+ *
+ * Reads both numbers `/proc/loadavg` offers and takes the larger: the 1-minute
+ * average (which lags — it under-reports the start of a heavy suite) and the
+ * instantaneous runnable count from the `running/total` field (noisy but
+ * immediate). Falls back to `os.loadavg()` where `/proc` does not exist, and
+ * returns `0` on platforms that report no load average at all (Windows),
+ * leaving the sleep probe as the sole signal.
+ */
+function runQueuePressure(): number {
+  const cpus = Math.max(1, os.cpus().length);
+  let oneMinute = 0;
+  let runnable = 0;
+  try {
+    const fields = fs.readFileSync("/proc/loadavg", "utf8").trim().split(/\s+/);
+    oneMinute = Number(fields[0]);
+    runnable = Number((fields[3] ?? "").split("/")[0]);
+  } catch {
+    oneMinute = os.loadavg()[0];
+  }
+  if (!Number.isFinite(oneMinute)) oneMinute = 0;
+  if (!Number.isFinite(runnable)) runnable = 0;
+  return Math.max(oneMinute, runnable) / cpus;
+}
+
+/**
+ * Median of `PROBE_SAMPLES` short sleeps, as a multiple of the requested
+ * duration. `~1.0` when the event loop turns over on time; many-fold when it
+ * does not.
+ *
+ * Self-normalising by construction — a ratio of a measured wake against the
+ * duration we asked for — so it needs no calibrated "quiet machine" constant
+ * and means the same thing on every host. In the extension host it also
+ * catches a *busy event loop*, not just a busy CPU, which is the shape a
+ * starved test process actually takes here.
+ *
+ * Costs `PROBE_SAMPLES * PROBE_SLEEP_MS`, so it is only ever taken on the
+ * already-failing path.
+ */
+async function sleepDilation(): Promise<number> {
+  const ratios: number[] = [];
+  for (let i = 0; i < PROBE_SAMPLES; i++) {
+    const started = Date.now();
+    await sleep(PROBE_SLEEP_MS);
+    ratios.push((Date.now() - started) / PROBE_SLEEP_MS);
+  }
+  ratios.sort((a, b) => a - b);
+  return ratios[Math.floor(PROBE_SAMPLES / 2)];
+}
+
+let _loadFactorCache: { at: number; factor: number } | null = null;
+
+/**
+ * How much slower than an unloaded machine this process is currently being
+ * run, as a multiplier `>= 1.0`.
+ *
+ * The cheap half of the measurement: run-queue oversubscription only, so it
+ * costs one small file read and can sit on the hot path of every wait. Cached
+ * for [`LOAD_FACTOR_TTL_MS`]. The expensive scheduling-latency half is taken by
+ * [`measuredLoadFactor`] only when a wait is about to fail.
+ */
+export function loadFactor(): number {
+  const now = Date.now();
+  if (_loadFactorCache && now - _loadFactorCache.at < LOAD_FACTOR_TTL_MS) {
+    return _loadFactorCache.factor;
+  }
+  const factor = Math.min(MAX_LOAD_FACTOR, Math.max(1, runQueuePressure()));
+  _loadFactorCache = { at: now, factor };
+  return factor;
+}
+
+/**
+ * The full measurement — the maximum of two independent, calibration-free
+ * probes: scheduling latency ([`sleepDilation`]) and run-queue
+ * oversubscription ([`runQueuePressure`]). Either kind of starvation is
+ * caught: a cgroup CPU cap that throttles wakeups, or a machine with more
+ * runnable threads than cores.
+ *
+ * Costs ~100ms, so it is taken only when a wait has otherwise expired.
+ */
+export async function measuredLoadFactor(): Promise<{ factor: number; note: string }> {
+  const dilation = await sleepDilation();
+  const pressure = runQueuePressure();
+  const raw = Math.max(dilation, pressure, 1);
+  const factor = Math.min(MAX_LOAD_FACTOR, raw);
+  const starved = dilation >= STARVATION_RATIO || pressure >= STARVATION_RATIO;
+  const note = starved
+    ? `PROBE: CPU STARVATION CONFIRMED — a ${PROBE_SLEEP_MS}ms sleep is waking ` +
+      `${dilation.toFixed(1)}x late and the run queue is ${pressure.toFixed(1)}x ` +
+      `oversubscribed right now, so this test process is being denied CPU. The deadline ` +
+      `had already been stretched by the measured factor before it expired, so this is a ` +
+      `machine that got slower *during* the wait — or a genuinely wedged server.`
+    : `PROBE: could not confirm starvation — a ${PROBE_SLEEP_MS}ms sleep woke ` +
+      `${dilation.toFixed(1)}x late with the run queue ${pressure.toFixed(1)}x ` +
+      `oversubscribed, both within normal noise. The machine looks healthy *now* and the ` +
+      `deadline was already load-scaled, so suspect a real server hang or a predicate ` +
+      `that can never hold.`;
+  return { factor, note };
+}
+
+/**
+ * Scale a wall-clock hang backstop by the machine's measured capacity.
+ *
+ * See the module docs: backstops guard against a wedged server, and a starved
+ * runner must not be mistaken for one.
+ */
+export function scaledTimeout(baseMs: number): number {
+  return Math.round(baseMs * loadFactor());
+}
+
+/** Anything with a `dispose` — `vscode.Disposable`, a `Timeout`, a custom
+ *  unsubscribe. Structural so this module stays importable from plain Node
+ *  (`runTest.ts`), which has no `vscode` to import. */
+export interface Unsubscribe {
+  dispose(): void;
+}
+
+export interface AwaitSignalOptions<T> {
+  /** What is being awaited, in the failure message's own words. */
+  label: string;
+  /**
+   * Subscribe to the event that announces the awaited thing may have changed,
+   * calling `notify` each time. Returns the handle to unsubscribe with.
+   *
+   * This is the primary mechanism: `probe` is re-read on every `notify`, so the
+   * good case completes as soon as the signal arrives.
+   */
+  subscribe: (notify: () => void) => Unsubscribe;
+  /** Read the current state. Called once immediately, then on every signal and
+   *  on every backstop tick. */
+  probe: () => T | PromiseLike<T>;
+  /** Whether `probe`'s value satisfies the wait. */
+  predicate: (value: T) => boolean;
+  /** Base deadline in ms, before load scaling. */
+  timeout?: number;
+  /** Missed-event backstop interval in ms. */
+  backstopInterval?: number;
+  /** Render the last-seen value for the failure message. Defaults to JSON. */
+  describe?: (value: T | undefined) => string;
+}
+
+function defaultDescribe(value: unknown): string {
+  if (value === undefined) return "<never probed>";
+  try {
+    const json = JSON.stringify(value);
+    return json === undefined ? String(value) : json;
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Wait for `predicate` to hold over `probe`, woken by the event `subscribe`
+ * registers, bounded by a load-scaled deadline that **rejects**.
+ *
+ * The one wait shape this suite should use wherever an event exists. See the
+ * module docs for why.
+ *
+ * On expiry it re-measures the machine (see [`measuredLoadFactor`]); a starved
+ * machine buys an extension rather than a failure, up to `MAX_EXTENSIONS`, so
+ * the wait stays bounded either way.
+ */
+export async function awaitSignal<T>(opts: AwaitSignalOptions<T>): Promise<T> {
+  const base = opts.timeout ?? DEFAULT_SIGNAL_TIMEOUT_MS;
+  const backstop = opts.backstopInterval ?? DEFAULT_BACKSTOP_INTERVAL_MS;
+  const describe = opts.describe ?? defaultDescribe;
+  const started = Date.now();
+  let budget = scaledTimeout(base);
+  let extensions = 0;
+  let probes = 0;
+  let signals = 0;
+  let last: T | undefined;
+  let wake: (() => void) | null = null;
+
+  const subscription = opts.subscribe(() => {
+    signals++;
+    wake?.();
+  });
+
+  try {
+    for (;;) {
+      const signalsAtProbe = signals;
+      probes++;
+      last = await opts.probe();
+      if (opts.predicate(last)) return last;
+
+      // A signal that arrived *while* the probe was in flight refers to state
+      // the probe may not have seen — re-read at once rather than sleeping on
+      // an answer that is already stale.
+      if (signals !== signalsAtProbe) continue;
+
+      const remaining = started + budget - Date.now();
+      if (remaining <= 0) {
+        const { factor, note } = await measuredLoadFactor();
+        const wanted = Math.round(base * factor);
+        if (extensions < MAX_EXTENSIONS && wanted > budget) {
+          budget = wanted;
+          extensions++;
+          continue;
+        }
+        const waited = Date.now() - started;
+        throw new Error(
+          `${WAIT_TIMEOUT_MARKER}: timed out awaiting ${opts.label}\n` +
+            `  waited ${waited}ms (base ${base}ms x measured load factor ` +
+            `${factor.toFixed(1)}; ${extensions} extension(s); ${probes} probe(s), ` +
+            `${signals} signal(s))\n` +
+            `  last seen: ${describe(last)}\n` +
+            `  ${note}`,
+        );
+      }
+
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(finish, Math.min(remaining, backstop));
+        wake = finish;
+        function finish() {
+          clearTimeout(timer);
+          wake = null;
+          resolve();
+        }
+      });
+    }
+  } finally {
+    wake = null;
+    subscription.dispose();
+  }
+}
+
+/**
+ * Bound an otherwise-unbounded promise with a load-scaled deadline and a
+ * diagnostic rejection.
+ *
+ * Some awaits have no signal to wait on because they *are* the signal — a
+ * command round-trip to the server, `extension.activate()`, opening a
+ * document. They resolve when the work is done, which is the right shape
+ * already; what they lack is a bound. Without one the only backstop is mocha's
+ * per-test timeout, which is how issue #1274's stall became 60s per test and
+ * then a runner that never exited: the mocha timeout fires with no idea which
+ * await was outstanding.
+ *
+ * The underlying promise is left running on rejection — the test is failing
+ * anyway, and cancelling a VS Code command is not possible.
+ */
+export function bounded<T>(
+  work: PromiseLike<T>,
+  label: string,
+  opts?: { timeout?: number },
+): Promise<T> {
+  const base = opts?.timeout ?? DEFAULT_SIGNAL_TIMEOUT_MS;
+  const started = Date.now();
+  let settled = false;
+
+  const result = Promise.resolve(work);
+  result.then(
+    () => {
+      settled = true;
+    },
+    () => {
+      settled = true;
+    },
+  );
+
+  const guard = (async (): Promise<never> => {
+    let budget = scaledTimeout(base);
+    for (let extensions = 0; ; ) {
+      const remaining = started + budget - Date.now();
+      if (remaining > 0) await sleepDetached(remaining);
+      if (!settled) {
+        const { factor, note } = await measuredLoadFactor();
+        const wanted = Math.round(base * factor);
+        if (!settled) {
+          if (extensions < MAX_EXTENSIONS && wanted > budget) {
+            budget = wanted;
+            extensions++;
+            continue;
+          }
+          throw new Error(
+            `${WAIT_TIMEOUT_MARKER}: timed out awaiting ${label}\n` +
+              `  waited ${Date.now() - started}ms (base ${base}ms x measured load factor ` +
+              `${factor.toFixed(1)}; ${extensions} extension(s))\n` +
+              `  this await has no completion signal to wait on — it *is* the signal — so a ` +
+              `timeout here means the request never came back.\n` +
+              `  ${note}`,
+          );
+        }
+      }
+      // `work` already settled: retire without ever settling, so the race below
+      // is decided by `result` alone.
+      return new Promise<never>(() => {});
+    }
+  })();
+  // The guard is only ever consumed by the race below, which stops listening
+  // the moment `work` wins; keep a late rejection from going unhandled.
+  guard.catch(() => {});
+
+  return Promise.race([result, guard]);
+}

--- a/editors/vscode/src/test/signal.ts
+++ b/editors/vscode/src/test/signal.ts
@@ -393,7 +393,7 @@ export function bounded<T>(
 
   const guard = (async (): Promise<never> => {
     let budget = scaledTimeout(base);
-    for (let extensions = 0; ; ) {
+    for (let extensions = 0; ;) {
       const remaining = started + budget - Date.now();
       if (remaining > 0) await sleepDetached(remaining);
       if (!settled) {

--- a/editors/vscode/src/test/signal.ts
+++ b/editors/vscode/src/test/signal.ts
@@ -269,6 +269,18 @@ export interface AwaitSignalOptions<T> {
   backstopInterval?: number;
   /** Render the last-seen value for the failure message. Defaults to JSON. */
   describe?: (value: T | undefined) => string;
+  /**
+   * Which `probe` rejections mean "the state moved under you, ask again"
+   * rather than "the test has failed".
+   *
+   * A probe that pulls from a provider can be *cancelled* by VS Code when the
+   * document or its diagnostics change while the request is in flight — which
+   * is precisely when a signal-driven wait probes hardest. Treating that as a
+   * failure would make the wait flakier than the polling it replaced; it is
+   * information, not an error. Anything this returns false for is rethrown
+   * unchanged, so a real provider fault still fails the test immediately.
+   */
+  retryProbeErrors?: (error: unknown) => boolean;
 }
 
 function defaultDescribe(value: unknown): string {
@@ -301,6 +313,8 @@ export async function awaitSignal<T>(opts: AwaitSignalOptions<T>): Promise<T> {
   let extensions = 0;
   let probes = 0;
   let signals = 0;
+  let retriedProbes = 0;
+  let lastRetriedError: unknown;
   let last: T | undefined;
   let wake: (() => void) | null = null;
 
@@ -313,8 +327,16 @@ export async function awaitSignal<T>(opts: AwaitSignalOptions<T>): Promise<T> {
     for (;;) {
       const signalsAtProbe = signals;
       probes++;
-      last = await opts.probe();
-      if (opts.predicate(last)) return last;
+      let satisfied = false;
+      try {
+        last = await opts.probe();
+        satisfied = opts.predicate(last);
+      } catch (err) {
+        if (!opts.retryProbeErrors?.(err)) throw err;
+        retriedProbes++;
+        lastRetriedError = err;
+      }
+      if (satisfied) return last as T;
 
       // A signal that arrived *while* the probe was in flight refers to state
       // the probe may not have seen — re-read at once rather than sleeping on
@@ -331,12 +353,17 @@ export async function awaitSignal<T>(opts: AwaitSignalOptions<T>): Promise<T> {
           continue;
         }
         const waited = Date.now() - started;
+        const retried =
+          retriedProbes === 0
+            ? ""
+            : `\n  ${retriedProbes} probe(s) were retried after a recoverable error, last: ` +
+              `${lastRetriedError instanceof Error ? lastRetriedError.message : String(lastRetriedError)}`;
         throw new Error(
           `${WAIT_TIMEOUT_MARKER}: timed out awaiting ${opts.label}\n` +
             `  waited ${waited}ms (base ${base}ms x measured load factor ` +
             `${factor.toFixed(1)}; ${extensions} extension(s); ${probes} probe(s), ` +
             `${signals} signal(s))\n` +
-            `  last seen: ${describe(last)}\n` +
+            `  last seen: ${describe(last)}${retried}\n` +
             `  ${note}`,
         );
       }

--- a/editors/vscode/src/test/waitDiscipline.test.ts
+++ b/editors/vscode/src/test/waitDiscipline.test.ts
@@ -1,0 +1,268 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import {
+  activate,
+  awaitSignal,
+  bounded,
+  getDocUri,
+  loadFactor,
+  scaledTimeout,
+  waitForDiagnostics,
+} from "./helper";
+
+// Properties of the wait discipline itself (issue #1274).
+//
+// The suite's other tests assert what the server does; these assert what
+// happens when it *doesn't*. A stalled wait must fail at its bound with a
+// message naming what was awaited — never hang to mocha's per-test timeout,
+// and never resolve with a partial answer the test then asserts against.
+//
+// The bad-case tests are what make this a fix rather than a hope: they are the
+// deliberate stall, run on every CI run.
+
+/** Ceiling a wait with base deadline `base` may not exceed, whatever the load
+ *  factor claims. `signal.ts` caps the factor at 8x; the slack covers the
+ *  ~100ms scheduling probes taken on each of the (at most 3) extensions. */
+function boundCeiling(base: number): number {
+  return base * 8 + 4_000;
+}
+
+suite("Wait discipline (issue #1274)", () => {
+  const docUri = getDocUri("diagnostics.tcl");
+
+  test("a load-scaled deadline never tightens the deadline it is given", () => {
+    // Mirrors the native harness's `load_factor_never_tightens_a_barrier`.
+    // A busy machine may only ever *stretch* a hang backstop.
+    assert.ok(loadFactor() >= 1, `load factor must be >= 1, got ${loadFactor()}`);
+    for (const base of [1, 250, 5_000, 60_000]) {
+      assert.ok(
+        scaledTimeout(base) >= base,
+        `scaledTimeout(${base}) = ${scaledTimeout(base)} must not be below ${base}`,
+      );
+    }
+  });
+
+  test("awaitSignal resolves as soon as the signal fires, not on the next backstop tick", async () => {
+    // The good-case property: with a 10s backstop interval, a wait that only
+    // polled could not possibly return in under 10s. Waiting on the signal
+    // returns as soon as the work does.
+    let fire: (() => void) | undefined;
+    let ready = false;
+    const started = Date.now();
+    const waiter = awaitSignal<boolean>({
+      label: "a test signal",
+      subscribe: (notify) => {
+        fire = notify;
+        return { dispose: () => {} };
+      },
+      probe: () => ready,
+      predicate: (v) => v,
+      timeout: 30_000,
+      backstopInterval: 10_000,
+    });
+    setTimeout(() => {
+      ready = true;
+      fire?.();
+    }, 100);
+    assert.strictEqual(await waiter, true);
+    const elapsed = Date.now() - started;
+    assert.ok(elapsed < 5_000, `signal-driven wait took ${elapsed}ms; a poll would take 10000ms`);
+  });
+
+  test("awaitSignal rejects at its bound when the predicate can never hold", async () => {
+    const base = 1_000;
+    const started = Date.now();
+    let error: Error | undefined;
+    try {
+      await awaitSignal<number>({
+        label: "a condition that can never hold",
+        subscribe: () => ({ dispose: () => {} }),
+        probe: () => 41,
+        predicate: (v) => v === 42,
+        timeout: base,
+        backstopInterval: 50,
+        describe: (v) => `probe returned ${v}`,
+      });
+      assert.fail("awaitSignal resolved for a predicate that can never hold");
+    } catch (err) {
+      error = err as Error;
+    }
+    const elapsed = Date.now() - started;
+    assert.ok(error, "expected a rejection");
+    assert.ok(
+      error.message.includes("VSCODE-WAIT-TIMEOUT"),
+      `failure must carry the greppable marker: ${error.message}`,
+    );
+    assert.ok(
+      error.message.includes("a condition that can never hold"),
+      `failure must name what was awaited: ${error.message}`,
+    );
+    assert.ok(
+      error.message.includes("probe returned 41"),
+      `failure must report what was last seen: ${error.message}`,
+    );
+    assert.ok(
+      /PROBE: (CPU STARVATION CONFIRMED|could not confirm starvation)/.test(error.message),
+      `failure must carry a machine-load verdict: ${error.message}`,
+    );
+    assert.ok(
+      elapsed < boundCeiling(base),
+      `stall must fail at its bound; took ${elapsed}ms for a ${base}ms base`,
+    );
+  });
+
+  test("waitForDiagnostics rejects on timeout rather than resolving with a partial set", async () => {
+    // The defect this replaces: on timeout it used to resolve with
+    // `getDiagnostics(uri)`. The fixture below really does publish
+    // diagnostics, so a lenient timeout would return a *non-empty*, entirely
+    // plausible set — and a negative assertion over it ("no diagnostic of kind
+    // ZZZ999") would pass without the awaited analysis ever having happened.
+    await activate(docUri);
+    const base = 1_000;
+    const started = Date.now();
+    let error: Error | undefined;
+    try {
+      const diags = await waitForDiagnostics(docUri, {
+        timeout: base,
+        predicate: (ds) => ds.some((d) => String(d.code) === "ZZZ999-never-emitted"),
+      });
+      assert.fail(
+        `waitForDiagnostics resolved instead of rejecting, with ${diags.length} diagnostic(s) ` +
+          `the predicate never accepted`,
+      );
+    } catch (err) {
+      error = err as Error;
+    }
+    const elapsed = Date.now() - started;
+    assert.ok(error, "expected a rejection");
+    assert.ok(
+      error.message.includes("VSCODE-WAIT-TIMEOUT"),
+      `failure must carry the greppable marker: ${error.message}`,
+    );
+    assert.ok(
+      error.message.includes(docUri.toString()),
+      `failure must name the document awaited: ${error.message}`,
+    );
+    assert.ok(
+      elapsed < boundCeiling(base),
+      `stall must fail at its bound; took ${elapsed}ms for a ${base}ms base`,
+    );
+  });
+
+  test("awaitSignal retries a probe error the caller marks recoverable", async () => {
+    // VS Code cancels an in-flight provider request when the document or its
+    // diagnostics change underneath it — which is exactly when a signal-driven
+    // wait probes hardest. A cancellation means "that answer would have been
+    // stale, ask again", so it must not fail the test.
+    let calls = 0;
+    const value = await awaitSignal<string>({
+      label: "a provider that cancels before answering",
+      subscribe: () => ({ dispose: () => {} }),
+      probe: () => {
+        calls++;
+        if (calls < 3) {
+          const err = new Error("Canceled");
+          err.name = "Canceled";
+          throw err;
+        }
+        return "answered";
+      },
+      predicate: (v) => v === "answered",
+      timeout: 10_000,
+      backstopInterval: 20,
+      retryProbeErrors: (err) => err instanceof Error && err.name === "Canceled",
+    });
+    assert.strictEqual(value, "answered");
+    assert.strictEqual(calls, 3, "the cancelled probes must have been retried, not swallowed");
+  });
+
+  test("awaitSignal rethrows a probe error the caller does not mark recoverable", async () => {
+    await assert.rejects(
+      awaitSignal<string>({
+        label: "a provider that genuinely faults",
+        subscribe: () => ({ dispose: () => {} }),
+        probe: () => {
+          throw new Error("provider exploded");
+        },
+        predicate: () => true,
+        timeout: 10_000,
+        retryProbeErrors: (err) => err instanceof Error && err.name === "Canceled",
+      }),
+      /provider exploded/,
+      "a real provider fault must fail the test immediately, not wait out the deadline",
+    );
+  });
+
+  test("bounded rejects when the work it wraps never settles", async () => {
+    const base = 500;
+    const started = Date.now();
+    let error: Error | undefined;
+    try {
+      await bounded(new Promise<void>(() => {}), "a request that never comes back", {
+        timeout: base,
+      });
+      assert.fail("bounded resolved for a promise that never settles");
+    } catch (err) {
+      error = err as Error;
+    }
+    const elapsed = Date.now() - started;
+    assert.ok(error, "expected a rejection");
+    assert.ok(
+      error.message.includes("VSCODE-WAIT-TIMEOUT") &&
+        error.message.includes("a request that never comes back"),
+      `failure must name the bounded await: ${error.message}`,
+    );
+    assert.ok(
+      elapsed < boundCeiling(base),
+      `stall must fail at its bound; took ${elapsed}ms for a ${base}ms base`,
+    );
+  });
+
+  test("bounded lets its work win and adds no delay of its own", async () => {
+    const started = Date.now();
+    const value = await bounded(Promise.resolve("done"), "an already-settled promise", {
+      timeout: 30_000,
+    });
+    assert.strictEqual(value, "done");
+    assert.ok(
+      Date.now() - started < 1_000,
+      "bounded must not delay a promise that already settled",
+    );
+  });
+
+  test("a diagnostics wait returns on the publish event without waiting out a backstop", async () => {
+    // End-to-end version of the good-case property, against the real server:
+    // the document's diagnostics are already published by `activate`, so this
+    // must return on the immediate probe rather than on any interval.
+    await activate(docUri);
+    const started = Date.now();
+    const diags = await waitForDiagnostics(docUri, { minCount: 1, timeout: 20_000 });
+    assert.ok(diags.length >= 1, "the fixture publishes diagnostics");
+    assert.ok(
+      Date.now() - started < scaledTimeout(2_000),
+      `an already-satisfied wait must return immediately, took ${Date.now() - started}ms`,
+    );
+    assert.ok(
+      vscode.languages.getDiagnostics(docUri).length >= 1,
+      "sanity: the diagnostics really are published",
+    );
+  });
+});


### PR DESCRIPTION
Closes #1274.

TypeScript only — no Rust behaviour changes.

## The issue's diagnosis was incomplete, and the correction matters

#1274 (and my own analysis on it) blamed the shimmer tests' raw 60s mocha timeout. That is real but cannot be the mechanism: `waitForDiagnostics` bounds at 20s and those tests assert immediately after it, so **no wait in those test bodies can produce a 60s timeout**.

The stall was inside `activate()`, whose four awaits — `ext.activate()`, `openTextDocument`, `showTextDocument`, and two flush hovers — carried **no bound at all**. Mocha's 60s was their only backstop, and it fires knowing nothing about which step was outstanding. `activate()` is called by nearly every test in the suite, which is exactly why the victim moved between runs (shimmer twice, then signature help) while the symptom stayed identical.

Each step is now wrapped with a load-scaled deadline that names it.

A second premise also needed correcting: the pre-existing poll intervals were already 50ms and 500ms, so converting to events saves a few seconds suite-wide at best. **The defect was boundedness and correctness on timeout, not speed.**

## What changed

A shared await-the-signal helper (`signal.ts`): subscribe → resolve on predicate → reject on a bounded, load-scaled deadline with a diagnostic naming what was awaited, how long it waited, and what was last seen.

- `waitForDiagnostics` now **rejects** on timeout instead of resolving with partial results. The old behaviour meant a timed-out test carried on and asserted against whatever happened to be present — which passes *vacuously* for a negative assertion such as "expect no diagnostics of kind X".
- Code-action and code-lens pulls wait on the publish signal rather than polling blind.
- Deadlines scale by measured load, mirroring the Rust harness's `LatencyBudget` discipline.
- A hung runner now reports what was in flight.

## Evidence

**Bad case is bounded** (deliberate stall, actual output):

```
VSCODE-WAIT-TIMEOUT: timed out awaiting diagnostics on ...diagnostics.tcl to satisfy the test's predicate
  waited 13874ms (base 2000ms x measured load factor 6.6; 0 extension(s); 29 probe(s), 0 signal(s))
  last seen: W100@3:12, W101@6:5, W105@6:5, W302@9:0, ...
  PROBE: CPU STARVATION CONFIRMED — a 20ms sleep is waking 1.0x late and the run queue is 6.6x oversubscribed
```

It failed at its own bound, not at mocha's 60s or the runner's 180s budget.

**Hang report**, replacing the baseline's bare process list and "likely hung":

```
--- hang report (from the extension host's heartbeat) ---
  heartbeat written 629ms ago; 0 test(s) completed, 0 failed; measured load factor 7.5
  IN FLIGHT for 42450ms: HANG DEMO (temporary) a test that hangs with no bound of its own
  server: RESPONSIVE (3ms round trip), so the stall is in the test or the extension host, not a wedged server.
```

**Reproduction:** the #1274 *symptom* reproduces on unmodified `origin/rust` at load 24–32 — the 180s budget expires mid-suite with the issue's exact message, while the same baseline finishes in 169s at load ~11. The original shimmer hang was **not** reproduced, and no claim is made that it was.

**Good case: not measurably faster, reported honestly.** ABBA-paired ratios 0.975 / 1.056 / 0.967 / 1.031, order-balanced mean ≈ 1.007 — variance on a shared box (load 5–32) swamps the effect. The one real, load-independent win is a settle-window fix: **46,291ms → 308ms** for a single test, taking that suite from 54s to 8s.

## A test that depended on the lenient timeout — and got worse under load scaling

`issue1019ProcArgs.test.ts`, which landed in #1273 *after* this branch was cut, used `predicate: () => false` with an 8s deadline plus `.catch` as a deliberate settle window. It survived the stricter contract only via that `.catch`, but load-scaling stretched 8s to 46s. It now waits on the server's `[timing] deep diagnostics` marker, matching what `diagnostics.test.ts` already does for clean files.

This was found only by merging `origin/rust` into the branch before finishing. Without that, it would have landed as a 46-second-per-run regression.

Three other places re-asserted a predicate they had just awaited, purely to defend against the lenient timeout. None depended on it to pass; the now-unreachable guards are removed.

## Two bugs introduced and caught during the work

- `waitForProviderResult` inherited a 500ms backstop where the polling it replaced ran at 50ms — a 10× regression in the common case. Pinned to 50ms so the conversion can only ever return sooner.
- Waking on the diagnostics publish probes providers exactly when VS Code invalidates in-flight requests, surfacing a bare `Canceled` rejection. **This flake pre-exists on unmodified `origin/rust`.** Cancellation is now treated as "ask again" while real faults rethrow immediately.

## Deliberately still polling

About 100 `pollUntil` sites remain, documented as explicit choices — config settle and document-registry questions, where `onDidChangeConfiguration` answers a different question than "the server re-resolved this document". Polling is the honest mechanism where no signal exists; the point of this change is that it is no longer the *default*.

## Gates

`cargo fmt --all -- --check`, `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings` all clean (no Rust changes, run for safety); `tsc --noEmit`, `eslint`, `prettier --check` clean; `make test-ext` **807 passing, exit 0**. No `#[allow]`, no `any`, no disabled lint rules.

## For CI sizing

The 180s launch-exit budget is too tight for a loaded container independently of this fix — the unmodified baseline dies at load ~24 while passing in 169s at load ~11. It is now load-scaled, but the underlying headroom is worth knowing about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_