### PR TITLE
Thread the whole-program export oracle through every resolve_called_proc consumer (#1116)

### DIFF
--- a/docs/design/contracts/command-resolution.md
+++ b/docs/design/contracts/command-resolution.md
@@ -183,7 +183,7 @@ not change the rule, and must not grow bespoke resolution logic. Every
     (`tcl_lsp_core::namespace_import::NamespaceExportOracle`, implemented by
     `WorkspaceIndex::export_snapshot`) rather than reading one file (issue
     #1116 item 1). Two programs whose importing document is *byte-identical*
-    disagree, decided entirely by another file (pinned, tclsh 8.6.16 + 9.0.4):
+    disagree, decided entirely by another file (pinned, tclsh 8.6.14 + 9.0.4):
     with `::src` holding `proc helper`, `proc other` and `namespace export
     other` in that document, a `-force` import of `::src::*` over a local
     `::app::helper` reaches `::src::helper` when some other file also declares

--- a/docs/design/contracts/command-resolution.md
+++ b/docs/design/contracts/command-resolution.md
@@ -176,6 +176,30 @@ not change the rule, and must not grow bespoke resolution logic. Every
     nothing" / "replaced what was there" halves are both modelled; the error's
     *control-flow* consequence (nothing after it in that script runs) is
     deliberately out of scope.
+
+    Whether a `-force` import deleted the local command is a **whole-program**
+    question even when everything else about it is local, so the
+    single-document tier takes a whole-program **export oracle**
+    (`tcl_lsp_core::namespace_import::NamespaceExportOracle`, implemented by
+    `WorkspaceIndex::export_snapshot`) rather than reading one file (issue
+    #1116 item 1). Two programs whose importing document is *byte-identical*
+    disagree, decided entirely by another file (pinned, tclsh 8.6.16 + 9.0.4):
+    with `::src` holding `proc helper`, `proc other` and `namespace export
+    other` in that document, a `-force` import of `::src::*` over a local
+    `::app::helper` reaches `::src::helper` when some other file also declares
+    `namespace eval ::src {namespace export helper}`, and the local
+    `::app::helper` when nothing does. The oracle's answer is three-valued
+    (`ExportVerdict`) and the two questions abstain in opposite directions:
+    "what does this call reach?" installs only on a proven export, "did
+    `-force` delete the local command?" installs on anything but a proven
+    *non*-export — answering with a command the import may have removed is
+    worse than answering nothing and letting the cross-document tier resolve
+    it. The oracle is **optional**: a host with no workspace index (the `tcl`
+    CLI, a single-document test, an unindexed buffer) keeps the document-only
+    rule, under which absence of an export is evidence only where that
+    document holds some export record for the namespace. It is carried as one
+    context (`tcl_lsp_core::definition::CallResolution`) through
+    `resolve_called_proc` and every provider that calls it, never as a global.
   - **Redefining the imported name ends the alias.** A `proc ::dst::p` written
     after the import silently recreates `::dst::p` as an ordinary command:
     no error, `::dst::p` runs the new body, `namespace origin ::dst::p`

--- a/docs/kcs/features/kcs-feature-definition.md
+++ b/docs/kcs/features/kcs-feature-definition.md
@@ -124,6 +124,19 @@ to the **source** instead — until a `proc` of that name is written, which
 silently takes the name back and sends navigation to the new local
 definition.
 
+Whether a `-force` import really did take the name away depends on the *whole
+project*, not on the file the import is written in. `namespace import -force
+::src::*` only replaces a local command for names `::src` actually exports, and
+that `namespace export` may live in a different file. Go to Definition uses
+every open file to decide: with the export somewhere in the project the bare
+call jumps to the source, and with nothing anywhere exporting the name the
+import binds nothing and the call stays on the local definition — the same two
+answers real Tcl gives, from two projects whose importing file is identical
+character for character. When the source namespace is in no open file at all —
+an installed package, say — nothing can be proven either way, and rather than
+answer with a definition the import may have removed, Go to Definition answers
+nothing.
+
 Imports chain. When `::A` imports `::B::*` and `::B` had imported `::C::*`
 (and re-exported), a bare call in `::A` runs `::C`'s body, and Go to Definition
 follows the whole chain to `::C`'s header — while a forget anywhere along it

--- a/rust/tcl-lsp-core/src/call_hierarchy.rs
+++ b/rust/tcl-lsp-core/src/call_hierarchy.rs
@@ -153,13 +153,8 @@ pub fn prepare_in_program(
     // (mirrors `references::proc_references` / `rename::rename_proc`) —
     // never a namespace-blind `p.name == word` first-`HashMap`-hit scan.
     let cursor_off = crate::definition::byte_offset_at(&line_index, source, line, character);
-    let proc_match = crate::definition::resolve_proc_target_at(
-        analysis,
-        source,
-        cursor_off,
-        &word,
-        resolution,
-    );
+    let proc_match =
+        crate::definition::resolve_proc_target_at(analysis, source, cursor_off, &word, resolution);
     if let Some((qname, proc_def)) = proc_match {
         return vec![item_for_proc(source, proc_def, qname, &line_index)];
     }
@@ -883,7 +878,8 @@ pub fn outgoing_calls_in_program(
     resolution: crate::definition::CallResolution<'_>,
 ) -> Vec<OutgoingCall> {
     let line_index = LineIndex::new(source);
-    let Some((_, source_proc)) = find_proc_for_item(source, analysis, item, &line_index, resolution)
+    let Some((_, source_proc)) =
+        find_proc_for_item(source, analysis, item, &line_index, resolution)
     else {
         // Not a proc — try a class method.
         return method_outgoing_calls(source, dialect, item, analysis, &line_index, resolution);

--- a/rust/tcl-lsp-core/src/call_hierarchy.rs
+++ b/rust/tcl-lsp-core/src/call_hierarchy.rs
@@ -121,6 +121,30 @@ pub fn prepare(
     character: u32,
     analysis: &AnalysisResult,
 ) -> Vec<CallHierarchyItem> {
+    prepare_in_program(
+        source,
+        line,
+        character,
+        analysis,
+        crate::definition::CallResolution::document_only(),
+    )
+}
+
+/// [`prepare`] with the caller's whole-program export view attached — the
+/// entry point a host with a workspace index should call.
+///
+/// Which proc a call edge points at is a call resolution, so a `namespace
+/// import -force` whose covering `namespace export` lives in another file
+/// changes the hierarchy (issue #1116 item 1). Without the oracle the graph
+/// would draw an edge to a definition go-to-definition refuses to open.
+#[must_use]
+pub fn prepare_in_program(
+    source: &str,
+    line: u32,
+    character: u32,
+    analysis: &AnalysisResult,
+    resolution: crate::definition::CallResolution<'_>,
+) -> Vec<CallHierarchyItem> {
     let line_index = LineIndex::new(source);
     let Some((word, _start, _end)) = find_word_span_at_position(source, line, character) else {
         return Vec::new();
@@ -134,7 +158,7 @@ pub fn prepare(
         source,
         cursor_off,
         &word,
-        crate::definition::CallResolution::document_only(),
+        resolution,
     );
     if let Some((qname, proc_def)) = proc_match {
         return vec![item_for_proc(source, proc_def, qname, &line_index)];
@@ -235,6 +259,7 @@ fn find_proc_for_item<'a>(
     analysis: &'a AnalysisResult,
     item: &CallHierarchyItem,
     line_index: &LineIndex,
+    resolution: crate::definition::CallResolution<'_>,
 ) -> Option<(&'a String, &'a ProcDef)> {
     if let Some(hit) = analysis
         .all_procs
@@ -253,13 +278,7 @@ fn find_proc_for_item<'a>(
         item.selection_range.start_line,
         item.selection_range.start_character,
     );
-    crate::definition::resolve_proc_target_at(
-        analysis,
-        source,
-        cursor_off,
-        &item.name,
-        crate::definition::CallResolution::document_only(),
-    )
+    crate::definition::resolve_proc_target_at(analysis, source, cursor_off, &item.name, resolution)
 }
 
 /// Build a [`CallHierarchyItem`] for a class method.
@@ -575,8 +594,34 @@ pub fn unresolved_outgoing_calls(
     item: &CallHierarchyItem,
     analysis: &AnalysisResult,
 ) -> Vec<UnresolvedOutgoingCall> {
+    unresolved_outgoing_calls_in_program(
+        source,
+        dialect,
+        item,
+        analysis,
+        crate::definition::CallResolution::document_only(),
+    )
+}
+
+/// [`unresolved_outgoing_calls`] with the caller's whole-program export view attached — the
+/// entry point a host with a workspace index should call.
+///
+/// Which proc a call edge points at is a call resolution, so a `namespace
+/// import -force` whose covering `namespace export` lives in another file
+/// changes the hierarchy (issue #1116 item 1). Without the oracle the graph
+/// would draw an edge to a definition go-to-definition refuses to open.
+#[must_use]
+pub fn unresolved_outgoing_calls_in_program(
+    source: &str,
+    dialect: &str,
+    item: &CallHierarchyItem,
+    analysis: &AnalysisResult,
+    resolution: crate::definition::CallResolution<'_>,
+) -> Vec<UnresolvedOutgoingCall> {
     let line_index = LineIndex::new(source);
-    if let Some((_, source_proc)) = find_proc_for_item(source, analysis, item, &line_index) {
+    if let Some((_, source_proc)) =
+        find_proc_for_item(source, analysis, item, &line_index, resolution)
+    {
         let mut by_head: std::collections::BTreeMap<String, (Option<String>, Vec<LspRange>)> =
             std::collections::BTreeMap::new();
         for inv in &analysis.command_invocations {
@@ -608,7 +653,7 @@ pub fn unresolved_outgoing_calls(
             )
             .collect();
     }
-    unresolved_method_outgoing_calls(source, dialect, item, analysis, &line_index)
+    unresolved_method_outgoing_calls(source, dialect, item, analysis, &line_index, resolution)
 }
 
 /// Method-body variant of [`unresolved_outgoing_calls`]: keeps
@@ -626,6 +671,7 @@ fn unresolved_method_outgoing_calls(
     item: &CallHierarchyItem,
     analysis: &AnalysisResult,
     line_index: &LineIndex,
+    resolution: crate::definition::CallResolution<'_>,
 ) -> Vec<UnresolvedOutgoingCall> {
     let Some((class_def, source_method)) = resolve_method_item(source, analysis, item, line_index)
     else {
@@ -652,7 +698,7 @@ fn unresolved_method_outgoing_calls(
             class_ns,
             &head,
             span.start(),
-            crate::definition::CallResolution::document_only(),
+            resolution,
         )
         .is_some()
         {
@@ -688,8 +734,33 @@ pub fn incoming_calls(
     item: &CallHierarchyItem,
     analysis: &AnalysisResult,
 ) -> Vec<IncomingCall> {
+    incoming_calls_in_program(
+        source,
+        dialect,
+        item,
+        analysis,
+        crate::definition::CallResolution::document_only(),
+    )
+}
+
+/// [`incoming_calls`] with the caller's whole-program export view attached — the
+/// entry point a host with a workspace index should call.
+///
+/// Which proc a call edge points at is a call resolution, so a `namespace
+/// import -force` whose covering `namespace export` lives in another file
+/// changes the hierarchy (issue #1116 item 1). Without the oracle the graph
+/// would draw an edge to a definition go-to-definition refuses to open.
+#[must_use]
+pub fn incoming_calls_in_program(
+    source: &str,
+    dialect: &str,
+    item: &CallHierarchyItem,
+    analysis: &AnalysisResult,
+    resolution: crate::definition::CallResolution<'_>,
+) -> Vec<IncomingCall> {
     let line_index = LineIndex::new(source);
-    let Some((target_qname, target_proc)) = find_proc_for_item(source, analysis, item, &line_index)
+    let Some((target_qname, target_proc)) =
+        find_proc_for_item(source, analysis, item, &line_index, resolution)
     else {
         // Not a proc — try a class method.
         return method_incoming_calls(source, dialect, item, analysis, &line_index);
@@ -787,10 +858,35 @@ pub fn outgoing_calls(
     item: &CallHierarchyItem,
     analysis: &AnalysisResult,
 ) -> Vec<OutgoingCall> {
+    outgoing_calls_in_program(
+        source,
+        dialect,
+        item,
+        analysis,
+        crate::definition::CallResolution::document_only(),
+    )
+}
+
+/// [`outgoing_calls`] with the caller's whole-program export view attached — the
+/// entry point a host with a workspace index should call.
+///
+/// Which proc a call edge points at is a call resolution, so a `namespace
+/// import -force` whose covering `namespace export` lives in another file
+/// changes the hierarchy (issue #1116 item 1). Without the oracle the graph
+/// would draw an edge to a definition go-to-definition refuses to open.
+#[must_use]
+pub fn outgoing_calls_in_program(
+    source: &str,
+    dialect: &str,
+    item: &CallHierarchyItem,
+    analysis: &AnalysisResult,
+    resolution: crate::definition::CallResolution<'_>,
+) -> Vec<OutgoingCall> {
     let line_index = LineIndex::new(source);
-    let Some((_, source_proc)) = find_proc_for_item(source, analysis, item, &line_index) else {
+    let Some((_, source_proc)) = find_proc_for_item(source, analysis, item, &line_index, resolution)
+    else {
         // Not a proc — try a class method.
-        return method_outgoing_calls(source, dialect, item, analysis, &line_index);
+        return method_outgoing_calls(source, dialect, item, analysis, &line_index, resolution);
     };
     let mut by_target: EdgeBuckets = EdgeBuckets::new();
     for inv in &analysis.command_invocations {
@@ -1034,6 +1130,7 @@ fn method_outgoing_calls(
     item: &CallHierarchyItem,
     analysis: &AnalysisResult,
     line_index: &LineIndex,
+    resolution: crate::definition::CallResolution<'_>,
 ) -> Vec<OutgoingCall> {
     let Some((class_def, source_method)) = resolve_method_item(source, analysis, item, line_index)
     else {
@@ -1092,7 +1189,7 @@ fn method_outgoing_calls(
             class_ns,
             &head,
             span.start(),
-            crate::definition::CallResolution::document_only(),
+            resolution,
         ) {
             let qname = &proc_def.qualified_name;
             let entry = by_target

--- a/rust/tcl-lsp-core/src/call_hierarchy.rs
+++ b/rust/tcl-lsp-core/src/call_hierarchy.rs
@@ -129,8 +129,13 @@ pub fn prepare(
     // (mirrors `references::proc_references` / `rename::rename_proc`) —
     // never a namespace-blind `p.name == word` first-`HashMap`-hit scan.
     let cursor_off = crate::definition::byte_offset_at(&line_index, source, line, character);
-    let proc_match =
-        crate::definition::resolve_proc_target_at(analysis, source, cursor_off, &word, None);
+    let proc_match = crate::definition::resolve_proc_target_at(
+        analysis,
+        source,
+        cursor_off,
+        &word,
+        crate::definition::CallResolution::document_only(),
+    );
     if let Some((qname, proc_def)) = proc_match {
         return vec![item_for_proc(source, proc_def, qname, &line_index)];
     }
@@ -248,7 +253,13 @@ fn find_proc_for_item<'a>(
         item.selection_range.start_line,
         item.selection_range.start_character,
     );
-    crate::definition::resolve_proc_target_at(analysis, source, cursor_off, &item.name, None)
+    crate::definition::resolve_proc_target_at(
+        analysis,
+        source,
+        cursor_off,
+        &item.name,
+        crate::definition::CallResolution::document_only(),
+    )
 }
 
 /// Build a [`CallHierarchyItem`] for a class method.
@@ -641,7 +652,7 @@ fn unresolved_method_outgoing_calls(
             class_ns,
             &head,
             span.start(),
-            None,
+            crate::definition::CallResolution::document_only(),
         )
         .is_some()
         {
@@ -1081,7 +1092,7 @@ fn method_outgoing_calls(
             class_ns,
             &head,
             span.start(),
-            None,
+            crate::definition::CallResolution::document_only(),
         ) {
             let qname = &proc_def.qualified_name;
             let entry = by_target

--- a/rust/tcl-lsp-core/src/caller_frame.rs
+++ b/rust/tcl-lsp-core/src/caller_frame.rs
@@ -244,7 +244,7 @@ pub(crate) fn caller_frame_bindings(
     analysis: &AnalysisResult,
     source: &str,
     dialect: &str,
-    registry: Option<&tcl_registry::CommandRegistry>,
+    resolution: crate::definition::CallResolution<'_>,
     cursor_off: u32,
     name: &str,
 ) -> Vec<CallerFrameBinding> {
@@ -265,7 +265,7 @@ pub(crate) fn caller_frame_bindings(
         analysis,
         source,
         dialect,
-        registry,
+        resolution,
         namespace: crate::definition::namespace_context_at(
             &analysis.global_scope,
             cursor_off,
@@ -284,7 +284,10 @@ struct BindingScan<'a> {
     analysis: &'a AnalysisResult,
     source: &'a str,
     dialect: &'a str,
-    registry: Option<&'a tcl_registry::CommandRegistry>,
+    /// The whole-program context every [`crate::definition::resolve_called_proc`]
+    /// in this scan is answered in — the builtin gate and, when the host has a
+    /// workspace index, the export oracle (issue #1116 item 1).
+    resolution: crate::definition::CallResolution<'a>,
     namespace: String,
     name: &'a str,
 }
@@ -354,7 +357,7 @@ fn bindings_from_call(
         &ctx.namespace,
         head_text,
         head.span.start(),
-        ctx.registry,
+        ctx.resolution,
     ) else {
         return;
     };
@@ -426,11 +429,11 @@ pub(crate) fn caller_frame_reference_spans(
     analysis: &AnalysisResult,
     source: &str,
     dialect: &str,
-    registry: Option<&tcl_registry::CommandRegistry>,
+    resolution: crate::definition::CallResolution<'_>,
     cursor_off: u32,
     name: &str,
 ) -> Vec<Span> {
-    let bindings = caller_frame_bindings(analysis, source, dialect, registry, cursor_off, name);
+    let bindings = caller_frame_bindings(analysis, source, dialect, resolution, cursor_off, name);
     if bindings.is_empty() {
         return Vec::new();
     }
@@ -545,11 +548,11 @@ pub(crate) fn binding_at_offset(
     analysis: &AnalysisResult,
     source: &str,
     dialect: &str,
-    registry: Option<&tcl_registry::CommandRegistry>,
+    resolution: crate::definition::CallResolution<'_>,
     cursor_off: u32,
     word: &str,
 ) -> Option<CallerFrameBinding> {
-    caller_frame_bindings(analysis, source, dialect, registry, cursor_off, word)
+    caller_frame_bindings(analysis, source, dialect, resolution, cursor_off, word)
         .into_iter()
         .filter(|b| b.param.is_some())
         .find(|b| cursor_off >= b.arg_span.start() && cursor_off <= b.arg_span.end())

--- a/rust/tcl-lsp-core/src/caller_frame.rs
+++ b/rust/tcl-lsp-core/src/caller_frame.rs
@@ -613,8 +613,14 @@ oo::class create chart {
     fn call_site_argument_binds_the_caller_frame_variable() {
         let analysis = analyse(IDX58);
         let read = offset_of(IDX58, "$dataset") + 1;
-        let bindings =
-            caller_frame_bindings(&analysis, IDX58, "tcl9.0", Some(reg()), read, "dataset");
+        let bindings = caller_frame_bindings(
+            &analysis,
+            IDX58,
+            "tcl9.0",
+            crate::definition::CallResolution::document_only().with_registry(reg()),
+            read,
+            "dataset",
+        );
         assert_eq!(bindings.len(), 1, "one binding call site: {bindings:?}");
         assert_eq!(bindings[0].param.as_deref(), Some("dts"));
         assert!(!bindings[0].read_only);
@@ -633,7 +639,15 @@ oo::class create chart {
         let analysis = analyse(src);
         let read = offset_of(src, "$thing") + 1;
         assert!(
-            caller_frame_bindings(&analysis, src, "tcl9.0", Some(reg()), read, "thing").is_empty()
+            caller_frame_bindings(
+                &analysis,
+                src,
+                "tcl9.0",
+                crate::definition::CallResolution::document_only().with_registry(reg()),
+                read,
+                "thing"
+            )
+            .is_empty()
         );
     }
 
@@ -646,7 +660,15 @@ oo::class create chart {
         let analysis = analyse(src);
         let read = offset_of(src, "$thing") + 1;
         assert!(
-            caller_frame_bindings(&analysis, src, "tcl9.0", Some(reg()), read, "thing").is_empty()
+            caller_frame_bindings(
+                &analysis,
+                src,
+                "tcl9.0",
+                crate::definition::CallResolution::document_only().with_registry(reg()),
+                read,
+                "thing"
+            )
+            .is_empty()
         );
     }
 
@@ -660,7 +682,15 @@ oo::class create chart {
         let analysis = analyse(src);
         let read = offset_of(src, "$shared") + 1;
         assert!(
-            caller_frame_bindings(&analysis, src, "tcl9.0", Some(reg()), read, "shared").is_empty()
+            caller_frame_bindings(
+                &analysis,
+                src,
+                "tcl9.0",
+                crate::definition::CallResolution::document_only().with_registry(reg()),
+                read,
+                "shared"
+            )
+            .is_empty()
         );
     }
 
@@ -670,8 +700,14 @@ oo::class create chart {
     fn reference_spans_cover_the_call_site_word_and_the_reads() {
         let analysis = analyse(IDX58);
         let read = offset_of(IDX58, "$dataset") + 1;
-        let spans =
-            caller_frame_reference_spans(&analysis, IDX58, "tcl9.0", Some(reg()), read, "dataset");
+        let spans = caller_frame_reference_spans(
+            &analysis,
+            IDX58,
+            "tcl9.0",
+            crate::definition::CallResolution::document_only().with_registry(reg()),
+            read,
+            "dataset",
+        );
         assert_eq!(spans.len(), 2, "call-site word + one read: {spans:?}");
         for span in &spans {
             assert_eq!(&IDX58[span.as_range()], "dataset");
@@ -704,8 +740,14 @@ oo::class create chart {
             );
             let analysis = analyse(&src);
             let read = offset_of(&src, "$shared") + 1;
-            let bindings =
-                caller_frame_bindings(&analysis, &src, "tcl9.0", Some(reg()), read, "shared");
+            let bindings = caller_frame_bindings(
+                &analysis,
+                &src,
+                "tcl9.0",
+                crate::definition::CallResolution::document_only().with_registry(reg()),
+                read,
+                "shared",
+            );
             assert!(
                 bindings.is_empty(),
                 "`upvar {level}` does not bind the caller's frame, so navigation \
@@ -721,8 +763,14 @@ oo::class create chart {
             );
             let analysis = analyse(&src);
             let read = offset_of(&src, "$shared") + 1;
-            let bindings =
-                caller_frame_bindings(&analysis, &src, "tcl9.0", Some(reg()), read, "shared");
+            let bindings = caller_frame_bindings(
+                &analysis,
+                &src,
+                "tcl9.0",
+                crate::definition::CallResolution::document_only().with_registry(reg()),
+                read,
+                "shared",
+            );
             assert_eq!(
                 bindings.len(),
                 1,
@@ -742,7 +790,15 @@ oo::class create chart {
         let analysis = analyse(src);
         let read = offset_of(src, "puts $shared") + 6;
         assert!(
-            caller_frame_bindings(&analysis, src, "tcl9.0", Some(reg()), read, "shared").is_empty()
+            caller_frame_bindings(
+                &analysis,
+                src,
+                "tcl9.0",
+                crate::definition::CallResolution::document_only().with_registry(reg()),
+                read,
+                "shared"
+            )
+            .is_empty()
         );
     }
 
@@ -769,8 +825,14 @@ oo::class create chart {
             let src = format!("{SETDEF}proc caller {{ok}} {{\n {body}\n}}\n");
             let analysis = analyse(&src);
             let read = offset_of(&src, "puts $shared") + 6;
-            let bindings =
-                caller_frame_bindings(&analysis, &src, "tcl9.0", Some(reg()), read, "shared");
+            let bindings = caller_frame_bindings(
+                &analysis,
+                &src,
+                "tcl9.0",
+                crate::definition::CallResolution::document_only().with_registry(reg()),
+                read,
+                "shared",
+            );
             assert_eq!(
                 bindings.len(),
                 1,
@@ -798,8 +860,14 @@ oo::class create chart {
             let src = format!("{SETDEF}proc caller {{}} {{\n {body}\n}}\n");
             let analysis = analyse(&src);
             let read = offset_of(&src, "puts $shared") + 6;
-            let bindings =
-                caller_frame_bindings(&analysis, &src, "tcl9.0", Some(reg()), read, "shared");
+            let bindings = caller_frame_bindings(
+                &analysis,
+                &src,
+                "tcl9.0",
+                crate::definition::CallResolution::document_only().with_registry(reg()),
+                read,
+                "shared",
+            );
             assert!(
                 bindings.is_empty(),
                 "a fresh-frame body's binding must not leak out — {body:?}: {bindings:?}"
@@ -835,7 +903,7 @@ oo::class create chart {
                 &analysis,
                 &src,
                 "tcl9.0",
-                Some(reg()),
+                crate::definition::CallResolution::document_only().with_registry(reg()),
                 call,
                 "shared",
             );
@@ -869,7 +937,14 @@ proc build {} {
     fn a_literal_upvar_target_binds_at_the_call_head() {
         let analysis = analyse(IDX22);
         let read = offset_of(IDX22, "$name") + 1;
-        let bindings = caller_frame_bindings(&analysis, IDX22, "tcl9.0", Some(reg()), read, "name");
+        let bindings = caller_frame_bindings(
+            &analysis,
+            IDX22,
+            "tcl9.0",
+            crate::definition::CallResolution::document_only().with_registry(reg()),
+            read,
+            "name",
+        );
         assert_eq!(bindings.len(), 1, "one binding call site: {bindings:?}");
         assert_eq!(bindings[0].param, None, "no call-site word carries it");
         assert!(!bindings[0].read_only, "the alias is written through");
@@ -891,8 +966,14 @@ proc build {} {
             );
             let analysis = analyse(&src);
             let read = offset_of(&src, "$name") + 1;
-            let bindings =
-                caller_frame_bindings(&analysis, &src, "tcl9.0", Some(reg()), read, "name");
+            let bindings = caller_frame_bindings(
+                &analysis,
+                &src,
+                "tcl9.0",
+                crate::definition::CallResolution::document_only().with_registry(reg()),
+                read,
+                "name",
+            );
             assert!(
                 bindings.is_empty(),
                 "`upvar {level}` does not bind the caller's frame: {bindings:?}"
@@ -910,8 +991,15 @@ proc build {} {
         let analysis = analyse(src);
         let read = offset_of(src, "$FocusGrab") + 1;
         assert!(
-            caller_frame_bindings(&analysis, src, "tcl9.0", Some(reg()), read, "FocusGrab")
-                .is_empty()
+            caller_frame_bindings(
+                &analysis,
+                src,
+                "tcl9.0",
+                crate::definition::CallResolution::document_only().with_registry(reg()),
+                read,
+                "FocusGrab"
+            )
+            .is_empty()
         );
     }
 
@@ -924,7 +1012,14 @@ proc build {} {
                    proc build {} { set name N0\n peekname }\n";
         let analysis = analyse(src);
         let call = offset_of(src, "peekname }");
-        let bindings = caller_frame_bindings(&analysis, src, "tcl9.0", Some(reg()), call, "name");
+        let bindings = caller_frame_bindings(
+            &analysis,
+            src,
+            "tcl9.0",
+            crate::definition::CallResolution::document_only().with_registry(reg()),
+            call,
+            "name",
+        );
         assert_eq!(bindings.len(), 1, "{bindings:?}");
         assert!(bindings[0].read_only, "{bindings:?}");
     }
@@ -952,8 +1047,14 @@ proc build {} {
                    proc caller {} {\n setdef shared\n # mentions $shared but inertly\n }\n";
         let analysis = analyse(src);
         let call = offset_of(src, "setdef shared") + 7;
-        let spans =
-            caller_frame_reference_spans(&analysis, src, "tcl9.0", Some(reg()), call, "shared");
+        let spans = caller_frame_reference_spans(
+            &analysis,
+            src,
+            "tcl9.0",
+            crate::definition::CallResolution::document_only().with_registry(reg()),
+            call,
+            "shared",
+        );
         assert_eq!(spans.len(), 1, "only the call-site word: {spans:?}");
     }
 }

--- a/rust/tcl-lsp-core/src/code_actions.rs
+++ b/rust/tcl-lsp-core/src/code_actions.rs
@@ -306,6 +306,24 @@ pub fn code_actions(
     range: LspRange,
     analysis: Option<&AnalysisResult>,
 ) -> Vec<CodeAction> {
+    code_actions_in_program(source, range, analysis, None)
+}
+
+/// [`code_actions`] with the caller's whole-program export view attached —
+/// the entry point a host with a workspace index should call.
+///
+/// The refactor engine's inline-proc transform substitutes the body of the
+/// proc the call reaches, so a `namespace import -force` whose covering
+/// `namespace export` lives in another file decides whether inlining the
+/// local same-named proc is a refactor or a behaviour change (issue #1116
+/// item 1).
+#[must_use]
+pub fn code_actions_in_program(
+    source: &str,
+    range: LspRange,
+    analysis: Option<&AnalysisResult>,
+    program: Option<crate::definition::ProgramExports<'_>>,
+) -> Vec<CodeAction> {
     let Some(analysis) = analysis else {
         return Vec::new();
     };
@@ -361,7 +379,9 @@ pub fn code_actions(
     actions.extend(ip_conversion_actions(source, range, &line_index));
     actions.extend(expr_rewrite_actions(source, range, &line_index));
     actions.extend(docstring_actions(source, range, analysis, &line_index));
-    actions.extend(extract_inline_actions(source, range, analysis, &line_index));
+    actions.extend(extract_inline_actions(
+        source, range, analysis, &line_index, program,
+    ));
 
     actions
 }
@@ -663,6 +683,34 @@ pub fn package_require_actions(
     analysis: Option<&AnalysisResult>,
     context_diagnostics: &[ContextDiagnostic],
 ) -> Vec<CodeAction> {
+    package_require_actions_in_program(
+        source,
+        range,
+        crate::definition::CallResolution::document_only().with_registry(registry),
+        analysis,
+        context_diagnostics,
+    )
+}
+
+/// [`package_require_actions`] with the caller's whole-program export view
+/// attached — the entry point a host with a workspace index should call.
+///
+/// Gate 4 ("nothing answers to this head") runs the shared call resolver, so
+/// it must run it with the same context go-to-definition uses or the two can
+/// disagree about whether a call is satisfied (issue #1116 item 1).
+///
+/// In practice the `-force` shadow cannot change this provider's answer: gate
+/// 3 only lets a *package-qualified* head through, and a `-force` import
+/// rewrites the meaning of a **bare** name in the importing namespace. The
+/// context is threaded anyway so the resolver call is not the odd one out.
+#[must_use]
+pub fn package_require_actions_in_program(
+    source: &str,
+    range: LspRange,
+    resolution: crate::definition::CallResolution<'_>,
+    analysis: Option<&AnalysisResult>,
+    context_diagnostics: &[ContextDiagnostic],
+) -> Vec<CodeAction> {
     // No analysis means no evidence, and evidence is the whole gate.
     let Some(analysis) = analysis else {
         return Vec::new();
@@ -674,7 +722,7 @@ pub fn package_require_actions(
     let Some(package) = missing_package_for_head_at(
         source,
         range,
-        registry,
+        resolution,
         analysis,
         context_diagnostics,
         &line_index,
@@ -705,11 +753,14 @@ pub fn package_require_actions(
 fn missing_package_for_head_at(
     source: &str,
     range: LspRange,
-    registry: &tcl_registry::CommandRegistry,
+    resolution: crate::definition::CallResolution<'_>,
     analysis: &AnalysisResult,
     context_diagnostics: &[ContextDiagnostic],
     line_index: &LineIndex,
 ) -> Option<String> {
+    let Some(registry) = resolution.registry else {
+        return None;
+    };
     let catalogue = package_catalogue(registry);
     for invocation in &analysis.command_invocations {
         let start = line_index.position_at_utf16(invocation.range.start(), source);
@@ -737,7 +788,7 @@ fn missing_package_for_head_at(
         // this name.  A corroborating unknown-command diagnostic from the
         // editor is accepted in place of the local resolver run, for the case
         // where the editor's view is fresher than the analysis in hand.
-        if !head_is_unresolved(source, analysis, registry, invocation)
+        if !head_is_unresolved(source, analysis, resolution, invocation)
             && !unresolved_diagnostic_covers(
                 head_range,
                 analysis,
@@ -804,9 +855,12 @@ fn package_named_by_namespace(head: &str, catalogue: &[String]) -> Option<String
 fn head_is_unresolved(
     source: &str,
     analysis: &AnalysisResult,
-    registry: &tcl_registry::CommandRegistry,
+    resolution: crate::definition::CallResolution<'_>,
     invocation: &tcl_compiler::signature_scan::types::SignatureCommandInvocation,
 ) -> bool {
+    let Some(registry) = resolution.registry else {
+        return false;
+    };
     if registry.get(&invocation.name).is_some() {
         return false;
     }
@@ -822,7 +876,7 @@ fn head_is_unresolved(
         &namespace,
         &invocation.name,
         head_off,
-        crate::definition::CallResolution::document_only().with_registry(registry),
+        resolution,
     )
     .is_none()
 }
@@ -1445,6 +1499,7 @@ fn extract_inline_actions(
     range: LspRange,
     analysis: &AnalysisResult,
     line_index: &LineIndex,
+    program: Option<crate::definition::ProgramExports<'_>>,
 ) -> Vec<CodeAction> {
     // Load the iRules dialect so `when`-body descent and the
     // `class match` / `class lookup` data-group form resolve.  Loading is
@@ -1456,7 +1511,14 @@ fn extract_inline_actions(
     registry.load_dialect(tcl_dialect::DialectSet::IRULES);
     let mut out = Vec::new();
     out.extend(refactor_engine_actions(
-        source, range, analysis, line_index, &registry,
+        source,
+        range,
+        analysis,
+        line_index,
+        crate::definition::CallResolution {
+            registry: Some(&registry),
+            program,
+        },
     ));
     out
 }
@@ -1474,9 +1536,12 @@ fn refactor_engine_actions(
     range: LspRange,
     analysis: &AnalysisResult,
     line_index: &LineIndex,
-    registry: &tcl_registry::CommandRegistry,
+    resolution: crate::definition::CallResolution<'_>,
 ) -> Vec<CodeAction> {
     use crate::refactor;
+    let Some(registry) = resolution.registry else {
+        return Vec::new();
+    };
     let mut out = Vec::new();
 
     let cursor = line_index.offset_at_utf16(
@@ -1507,7 +1572,7 @@ fn refactor_engine_actions(
     if let Some(r) = refactor::inline_variable(source, cursor, analysis, registry, line_index) {
         out.push(refactoring_to_action(&r, source, line_index));
     }
-    if let Some(r) = refactor::inline_proc(source, cursor, analysis, registry) {
+    if let Some(r) = refactor::inline_proc_in_program(source, cursor, analysis, resolution) {
         out.push(refactoring_to_action(&r, source, line_index));
     }
     if let Some(r) = refactor::if_to_switch(source, cursor, registry, line_index) {

--- a/rust/tcl-lsp-core/src/code_actions.rs
+++ b/rust/tcl-lsp-core/src/code_actions.rs
@@ -380,7 +380,11 @@ pub fn code_actions_in_program(
     actions.extend(expr_rewrite_actions(source, range, &line_index));
     actions.extend(docstring_actions(source, range, analysis, &line_index));
     actions.extend(extract_inline_actions(
-        source, range, analysis, &line_index, program,
+        source,
+        range,
+        analysis,
+        &line_index,
+        program,
     ));
 
     actions
@@ -758,9 +762,7 @@ fn missing_package_for_head_at(
     context_diagnostics: &[ContextDiagnostic],
     line_index: &LineIndex,
 ) -> Option<String> {
-    let Some(registry) = resolution.registry else {
-        return None;
-    };
+    let registry = resolution.registry?;
     let catalogue = package_catalogue(registry);
     for invocation in &analysis.command_invocations {
         let start = line_index.position_at_utf16(invocation.range.start(), source);

--- a/rust/tcl-lsp-core/src/code_actions.rs
+++ b/rust/tcl-lsp-core/src/code_actions.rs
@@ -822,7 +822,7 @@ fn head_is_unresolved(
         &namespace,
         &invocation.name,
         head_off,
-        Some(registry),
+        crate::definition::CallResolution::document_only().with_registry(registry),
     )
     .is_none()
 }

--- a/rust/tcl-lsp-core/src/code_lens.rs
+++ b/rust/tcl-lsp-core/src/code_lens.rs
@@ -131,6 +131,22 @@ pub fn code_lenses(
     let Some(analysis) = analysis else {
         return Vec::new();
     };
+    // The lens title is a reference *count*, so it has to agree with the peek
+    // it labels — and both must exclude a bare call a live `namespace import
+    // -force` shadows, a fact only whole-program export knowledge can settle
+    // (issue #1116 item 1). The workspace index this provider already
+    // receives is exactly that knowledge, so no extra parameter is needed;
+    // without one the counts stay document-only, as before.
+    let exports = workspace.map(crate::workspace_index::WorkspaceIndex::export_snapshot);
+    let resolution = match exports.as_deref() {
+        Some(oracle) => crate::definition::CallResolution::document_only().in_program(
+            crate::definition::ProgramExports {
+                uri: current_uri,
+                oracle,
+            },
+        ),
+        None => crate::definition::CallResolution::document_only(),
+    };
     let line_index = LineIndex::new(source);
     let mut lenses: Vec<CodeLens> = Vec::new();
 
@@ -142,13 +158,8 @@ pub fn code_lenses(
         // another namespace).  `proc_reference_spans` takes the resolved
         // proc directly, so iterating every proc here doesn't rebuild a
         // `LineIndex` or rescan the proc table per definition.
-        let mut count = crate::references::proc_reference_spans(
-            analysis,
-            crate::definition::CallResolution::document_only(),
-            qname,
-            proc_def,
-        )
-        .len();
+        let mut count =
+            crate::references::proc_reference_spans(analysis, resolution, qname, proc_def).len();
         if let Some(index) = workspace {
             count += index
                 .invocations_of(&proc_def.qualified_name, current_uri)
@@ -181,7 +192,7 @@ pub fn code_lenses(
     // inheritance chains (`oo::class create Sub { superclass
     // ClassName ... }`).
     for (qname, class_def) in &analysis.all_classes {
-        let mut count = count_class_references(qname, class_def, analysis);
+        let mut count = count_class_references(qname, class_def, analysis, resolution);
         if let Some(index) = workspace {
             count += index
                 .invocations_of(&class_def.qualified_name, current_uri)
@@ -453,22 +464,19 @@ fn count_class_references(
     qname: &str,
     class_def: &tcl_compiler::analyser::ClassDef,
     analysis: &AnalysisResult,
+    resolution: crate::definition::CallResolution<'_>,
 ) -> usize {
     // Derive the count from the *same* namespace-aware matching the peek
     // (Find All References) uses — `references::class_reference_spans` — so
     // the lens title and the peek can never drift (mirrors the proc lens's
     // `proc_reference_spans` reuse above).
-    crate::references::class_reference_spans(
-        analysis,
-        crate::definition::CallResolution::document_only(),
-        qname,
-        class_def,
-    )
-    .into_iter()
-    .filter(|span| {
-        !(span.start() <= class_def.name_span.start() && class_def.name_span.end() <= span.end())
-    })
-    .count()
+    crate::references::class_reference_spans(analysis, resolution, qname, class_def)
+        .into_iter()
+        .filter(|span| {
+            !(span.start() <= class_def.name_span.start()
+                && class_def.name_span.end() <= span.end())
+        })
+        .count()
 }
 
 #[cfg(test)]

--- a/rust/tcl-lsp-core/src/code_lens.rs
+++ b/rust/tcl-lsp-core/src/code_lens.rs
@@ -142,7 +142,13 @@ pub fn code_lenses(
         // another namespace).  `proc_reference_spans` takes the resolved
         // proc directly, so iterating every proc here doesn't rebuild a
         // `LineIndex` or rescan the proc table per definition.
-        let mut count = crate::references::proc_reference_spans(analysis, qname, proc_def).len();
+        let mut count = crate::references::proc_reference_spans(
+            analysis,
+            crate::definition::CallResolution::document_only(),
+            qname,
+            proc_def,
+        )
+        .len();
         if let Some(index) = workspace {
             count += index
                 .invocations_of(&proc_def.qualified_name, current_uri)
@@ -452,13 +458,17 @@ fn count_class_references(
     // (Find All References) uses — `references::class_reference_spans` — so
     // the lens title and the peek can never drift (mirrors the proc lens's
     // `proc_reference_spans` reuse above).
-    crate::references::class_reference_spans(analysis, qname, class_def)
-        .into_iter()
-        .filter(|span| {
-            !(span.start() <= class_def.name_span.start()
-                && class_def.name_span.end() <= span.end())
-        })
-        .count()
+    crate::references::class_reference_spans(
+        analysis,
+        crate::definition::CallResolution::document_only(),
+        qname,
+        class_def,
+    )
+    .into_iter()
+    .filter(|span| {
+        !(span.start() <= class_def.name_span.start() && class_def.name_span.end() <= span.end())
+    })
+    .count()
 }
 
 #[cfg(test)]

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -116,7 +116,96 @@ use tcl_compiler::analyser::indirection;
 use tcl_lexer::{LineIndex, Utf16Col};
 
 use crate::hover::{find_var_at_position, find_word_span_at_position};
+use crate::namespace_import::{ExportVerdict, NamespaceExportOracle};
 use crate::source_graph::{RunOrder, RunPoint};
+
+/// Whole-program export knowledge, paired with the URI of the document being
+/// resolved.
+///
+/// The two travel together because neither is usable alone: the oracle ranks
+/// the workspace's `namespace export` events against the *importing* statement,
+/// and that statement is a byte offset in a named document. Handed the wrong
+/// URI — or the placeholder one the document-only tier uses — an export
+/// written **after** the import in this very file becomes unrankable, which
+/// [`crate::namespace_import::exported_at_import_site`] reads as "in effect",
+/// silently reversing issue #1027's Direction B. Pairing them structurally
+/// makes that unrepresentable.
+#[derive(Clone, Copy)]
+pub struct ProgramExports<'a> {
+    /// The document being resolved, spelled as the workspace index knows it.
+    pub uri: &'a str,
+    /// The workspace's export records — typically
+    /// `crate::workspace_index::WorkspaceIndex::export_snapshot`.
+    pub oracle: &'a dyn NamespaceExportOracle,
+}
+
+/// Everything a call-site resolution consults **besides the document in front
+/// of it** — the context [`resolve_called_proc`] and its helpers carry.
+///
+/// Two facts, both optional, both meaning "keep the document-only answer" when
+/// absent:
+///
+/// * [`registry`](Self::registry) — the dialect's command registry, the
+///   builtin gate. A caller without one keeps the lenient behaviour; there is
+///   no builtin to protect.
+/// * [`program`](Self::program) — the whole-program export oracle. A caller
+///   without one (a single-document unit test, the `tcl` CLI, a buffer the
+///   workspace has not indexed) gets exactly the behaviour this tier had
+///   before issue #1116 item 1: an in-document export record decides, and its
+///   absence is read as evidence only where this document holds *some* export
+///   for the namespace.
+///
+/// One context rather than two more parameters at each of the fourteen
+/// [`resolve_called_proc`] call sites, and rather than a global: the facts are
+/// per-request, and a global would make a single-document unit test and a
+/// live server disagree about what "no workspace" means.
+#[derive(Clone, Copy, Default)]
+pub struct CallResolution<'a> {
+    /// The dialect's command registry, when the caller has one.
+    pub registry: Option<&'a tcl_registry::CommandRegistry>,
+    /// Whole-program export knowledge, when the caller has a workspace index.
+    pub program: Option<ProgramExports<'a>>,
+}
+
+impl<'a> CallResolution<'a> {
+    /// The document-only context: no registry, no oracle.
+    #[must_use]
+    pub const fn document_only() -> Self {
+        Self {
+            registry: None,
+            program: None,
+        }
+    }
+
+    /// This context with `registry` installed — how the providers add the
+    /// builtin gate to whatever whole-program view their caller handed them.
+    #[must_use]
+    pub const fn with_registry(self, registry: &'a tcl_registry::CommandRegistry) -> Self {
+        Self {
+            registry: Some(registry),
+            ..self
+        }
+    }
+
+    /// This context with whole-program export knowledge installed.
+    #[must_use]
+    pub const fn in_program(self, program: ProgramExports<'a>) -> Self {
+        Self {
+            program: Some(program),
+            ..self
+        }
+    }
+
+    /// The URI to stamp on this document's own run points — the real one when
+    /// a workspace view is attached, else the placeholder
+    /// [`IN_DOCUMENT_URI`].
+    const fn uri(self) -> &'a str {
+        match self.program {
+            Some(p) => p.uri,
+            None => IN_DOCUMENT_URI,
+        }
+    }
+}
 
 /// LSP `Range` analogue — line/character pairs in UTF-16 code
 /// units per the LSP spec.
@@ -153,6 +242,11 @@ pub(crate) fn utf16_len(text: &str) -> u32 {
 /// Returns an empty vector when no recognisable symbol is at
 /// the position or when the symbol's definition isn't in the
 /// current document.
+///
+/// Document-only: equivalent to [`definition_with`] with no whole-program
+/// view. A host that has a workspace index should call that instead — a
+/// `namespace import -force` whose export lives in another file is invisible
+/// here (see [`NamespaceExportOracle`]).
 #[must_use]
 pub fn definition(
     source: &str,
@@ -160,6 +254,25 @@ pub fn definition(
     character: u32,
     analysis: &AnalysisResult,
 ) -> Vec<LspRange> {
+    definition_with(source, line, character, analysis, None)
+}
+
+/// [`definition`] with the caller's whole-program export view attached.
+///
+/// `program` is `None` for a host with no workspace index (a single-document
+/// test, the `tcl` CLI), which reproduces [`definition`] exactly.
+#[must_use]
+pub fn definition_with(
+    source: &str,
+    line: u32,
+    character: u32,
+    analysis: &AnalysisResult,
+    program: Option<ProgramExports<'_>>,
+) -> Vec<LspRange> {
+    let view = CallResolution {
+        registry: None,
+        program,
+    };
     let line_index = LineIndex::new(source);
 
     let decl_byte_offset = byte_offset_at(&line_index, source, line, character);
@@ -214,7 +327,7 @@ pub fn definition(
                 "::",
                 target,
                 cursor_offset,
-                Some(tcl_registry::registry_for_dialect(&analysis.dialect)),
+                view.with_registry(tcl_registry::registry_for_dialect(&analysis.dialect)),
             )
         {
             return vec![span_to_range(source, &line_index, proc_def.name_span)];
@@ -277,7 +390,7 @@ pub fn definition(
     // alias written *after* this call site does not apply and the ordinary
     // resolution below still wins (tclsh: a `hello` before `rename greet
     // hello` is `invalid command name "hello"`).
-    if let Some(span) = indirect_definition_target(analysis, source, cursor_offset, &word) {
+    if let Some(span) = indirect_definition_target(analysis, view, source, cursor_offset, &word) {
         return vec![span_to_range(source, &line_index, span)];
     }
     // `Factory::make` — [incr Tcl]'s colon-qualified class-proc dispatch
@@ -304,7 +417,7 @@ pub fn definition(
             &namespace,
             &word,
             cursor_offset,
-            Some(tcl_registry::registry_for_dialect(&analysis.dialect)),
+            view.with_registry(tcl_registry::registry_for_dialect(&analysis.dialect)),
         )
     {
         // A proc redefined later in the document is two definitions sharing
@@ -352,6 +465,7 @@ pub fn definition(
 /// review, P2).
 fn indirect_definition_target(
     analysis: &AnalysisResult,
+    ctx: CallResolution<'_>,
     source: &str,
     cursor_off: u32,
     word: &str,
@@ -364,7 +478,7 @@ fn indirect_definition_target(
         "::",
         &hop.target,
         cursor_off,
-        Some(registry),
+        ctx.with_registry(registry),
     ) {
         let captured = analysis
             .proc_def_in_effect_at(&proc_def.qualified_name, hop.resolve_at)
@@ -515,7 +629,7 @@ fn caller_frame_definition(
         analysis,
         source,
         "",
-        Some(tcl_registry::registry_for_dialect("")),
+        CallResolution::document_only().with_registry(tcl_registry::registry_for_dialect("")),
         cursor_off,
         name,
     );
@@ -2797,11 +2911,12 @@ pub fn itcl_class_proc_target_at(
 /// (`tcl_lsp_core::workspace_index::WorkspaceIndex::resolve_wildcard_import`).
 fn proc_visible_via_wildcard_import<'a>(
     analysis: &'a AnalysisResult,
+    ctx: CallResolution<'_>,
     namespace: &str,
     word: &str,
     call_off: u32,
 ) -> Option<&'a tcl_compiler::analyser::ProcDef> {
-    let source_ns = wildcard_import_source_namespace(analysis, namespace, word, call_off)?;
+    let source_ns = wildcard_import_source_namespace(analysis, ctx, namespace, word, call_off)?;
     analysis
         .all_procs
         .get(&tcl_syntax::naming::qualify(&source_ns, word))
@@ -2830,6 +2945,7 @@ fn proc_visible_via_wildcard_import<'a>(
 /// resolver takes it from there.
 fn forced_import_shadows(
     analysis: &AnalysisResult,
+    ctx: CallResolution<'_>,
     namespace: &str,
     word: &str,
     call_off: u32,
@@ -2843,6 +2959,7 @@ fn forced_import_shadows(
         .map_or(&[][..], Vec::as_slice);
     import_hop(
         analysis,
+        ctx,
         namespace,
         path,
         word,
@@ -2865,6 +2982,7 @@ fn forced_import_shadows(
 #[must_use]
 pub fn forced_import_shadows_call(
     analysis: &AnalysisResult,
+    ctx: CallResolution<'_>,
     word: &str,
     resolution_candidates: &[String],
     call_off: u32,
@@ -2874,6 +2992,7 @@ pub fn forced_import_shadows_call(
     }
     live_import_over_candidates(
         analysis,
+        ctx,
         resolution_candidates.iter().map(String::as_str),
         word,
         call_off,
@@ -2887,54 +3006,102 @@ pub fn forced_import_shadows_call(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ImportQuery {
     /// "Which namespace does this call really reach?" Every import counts,
-    /// and the export gate is strict: a name the source did not export
-    /// installs nothing, so it must not resolve.
+    /// and the export gate is strict: only a proven export
+    /// ([`ExportVerdict::Exported`]) installs, because an unproven one gives
+    /// nothing to resolve *to*.
     Resolve,
     /// "Has a `namespace import -force` taken this name away from the
     /// importing namespace's own command table?" ([`forced_import_shadows`])
-    /// Only forced imports count, and the export gate abstains for a source
-    /// namespace whose export list this document cannot see
-    /// ([`namespace_exports_observable`]): `namespace import -force ::Lib::*`
-    /// deletes the local command whether or not `::Lib`'s export declaration
-    /// happens to live in *this* file, and answering with the deleted
-    /// definition would be worse than abstaining. The same "absence of an
-    /// export is evidence only where the exports are visible too" rule
-    /// `WorkspaceIndex::live_command_links` applies cross-document, over the
-    /// whole workspace's export records rather than one file's.
+    /// Only forced imports count, and the export gate abstains the other way:
+    /// everything but a proven [`ExportVerdict::NotExported`] counts as having
+    /// installed. `namespace import -force ::Lib::*` deletes the local command
+    /// whether or not anything here can see `::Lib`'s export declaration, and
+    /// answering with the deleted definition would be worse than abstaining.
+    /// The same "absence of an export is evidence only where the exports are
+    /// visible too" rule `WorkspaceIndex::live_command_links` applies
+    /// cross-document.
     ForcedShadow,
 }
 
-/// Whether this document can see `source_ns`'s **export list** — the only
-/// evidence that makes "`source_ns` did not export this name" a fact rather
-/// than a gap.
+impl ImportQuery {
+    /// Whether an import whose export gate returned `verdict` counts as having
+    /// installed, for this question.
+    ///
+    /// The two arms are the two abstention directions in one place, so neither
+    /// can drift: [`Resolve`](Self::Resolve) needs proof to answer,
+    /// [`ForcedShadow`](Self::ForcedShadow) needs proof to *stop* answering.
+    fn installs(self, verdict: ExportVerdict) -> bool {
+        match self {
+            ImportQuery::Resolve => verdict == ExportVerdict::Exported,
+            ImportQuery::ForcedShadow => verdict != ExportVerdict::NotExported,
+        }
+    }
+}
+
+/// Whether `source_ns` had exported `word` when the import at `import_at` ran,
+/// as everything available to this resolution can tell — the single decision
+/// both [`ImportQuery`] arms read, differing only in which way they abstain.
 ///
-/// The in-document twin of `WorkspaceIndex::observable_namespaces`, and the
-/// discriminator [`ImportQuery::ForcedShadow`] needs between "this namespace
-/// did not export the name" (a fact) and "this namespace's exports are in
-/// another file" (no information).
+/// Three sources of evidence, in order of authority:
 ///
-/// # Why exports, not definitions (issue #1116 item 1)
+/// 1. **This document's own export records.** A covering export that had run
+///    at the import is proof, and it is proof even when the workspace index is
+///    stale relative to the buffer being edited — which is why it is consulted
+///    first rather than left to the oracle.
+/// 2. **The whole-program oracle**, when one is attached. It sees every
+///    indexed file's exports, ranks them against this import with the `source`
+///    graph's run order, and may itself answer
+///    [`ExportVerdict::Unknown`].
+/// 3. **The document-only fallback**, when no oracle is attached: absence of
+///    an export is evidence exactly where this document holds *some* export
+///    record for `source_ns`, and no information otherwise.
 ///
-/// This used to answer "does this document hold a proc, a class, **or** an
-/// export of `source_ns`", mirroring the workspace-wide
-/// `observable_namespaces`. Cross-document that is right — the index really
-/// does hold every file. In *one* document it is not: a namespace can be
-/// perfectly visible here (its procs are in this file) while its `namespace
-/// export` sits in another, and then a `namespace import -force ::src::*`
-/// really did delete the local command that single-file go-to-definition went
-/// on answering with.
+/// # Why an oracle at all (issue #1116 item 1)
+///
+/// Step 3 is the whole problem. It is the in-document twin of
+/// `WorkspaceIndex::observable_namespaces`, and cross-document that framing is
+/// right — the index really does hold every file. In *one* document it is not:
+/// a namespace can be partly visible here (its procs, and some of its exports)
+/// while the one `namespace export` that covers this name sits in another
+/// file. The false-positive and the true-negative then have **byte-identical**
+/// single-document inputs and opposite correct answers (transcript on
+/// [`NamespaceExportOracle`]), so no rule reading only this document can
+/// separate them — hence the oracle, and hence its optionality: a caller with
+/// no workspace keeps step 3 exactly as it was.
+fn export_verdict(
+    analysis: &AnalysisResult,
+    ctx: CallResolution<'_>,
+    source_ns: &str,
+    word: &str,
+    import_at: u32,
+) -> ExportVerdict {
+    if exported_at_import(analysis, ctx, source_ns, word, import_at) {
+        return ExportVerdict::Exported;
+    }
+    if let Some(program) = ctx.program {
+        return program.oracle.exported_at(
+            source_ns,
+            word,
+            in_document_point(analysis, ctx, import_at),
+        );
+    }
+    if namespace_exports_observable(analysis, source_ns) {
+        ExportVerdict::NotExported
+    } else {
+        ExportVerdict::Unknown
+    }
+}
+
+/// Whether this document holds *any* `namespace export` record for
+/// `source_ns` — the document-only fallback [`export_verdict`] step 3 uses
+/// when no whole-program oracle is attached.
 ///
 /// The proposition being asserted is about the export list, so the evidence
-/// has to be the export list. A document that declares no export at all for
-/// `source_ns` knows nothing about what it exports, and
-/// [`ImportQuery::ForcedShadow`] abstains toward the shadow having fired
-/// (answering with a command the import deleted is worse than answering
-/// nothing and letting the cross-document resolver take over).
-///
-/// **Residual**: a document holding *some* of `source_ns`'s exports but not
-/// the one that covers this name still reads the gap as a fact. Narrowing
-/// that further needs the workspace index's whole-program view, which is
-/// exactly what the cross-document tier already applies.
+/// has to be the export list: a document that declares no export at all for
+/// `source_ns` knows nothing about what it exports. Its **residual** — a
+/// document holding some of `source_ns`'s exports but not the covering one
+/// still reads the gap as a fact — is precisely what the oracle removes when
+/// one is available, and what remains, deliberately, when one is not.
 fn namespace_exports_observable(analysis: &AnalysisResult, source_ns: &str) -> bool {
     let bare = source_ns.trim_start_matches("::");
     analysis
@@ -2979,6 +3146,7 @@ fn namespace_exports_observable(analysis: &AnalysisResult, source_ns: &str) -> b
 /// deleting an imported command deletes the commands imported *from* it).
 fn wildcard_import_source_namespace(
     analysis: &AnalysisResult,
+    ctx: CallResolution<'_>,
     namespace: &str,
     word: &str,
     call_off: u32,
@@ -3003,6 +3171,7 @@ fn wildcard_import_source_namespace(
         };
         let hop = import_hop(
             analysis,
+            ctx,
             &current,
             path,
             word,
@@ -3028,6 +3197,7 @@ fn wildcard_import_source_namespace(
 /// `path` entries) at `call_off`.
 fn import_hop<S: AsRef<str>>(
     analysis: &AnalysisResult,
+    ctx: CallResolution<'_>,
     namespace: &str,
     path: &[S],
     word: &str,
@@ -3037,6 +3207,7 @@ fn import_hop<S: AsRef<str>>(
     let candidates = tcl_syntax::naming::command_resolution_candidates(namespace, path, word);
     live_import_over_candidates(
         analysis,
+        ctx,
         candidates.iter().map(String::as_str),
         word,
         call_off,
@@ -3049,6 +3220,7 @@ fn import_hop<S: AsRef<str>>(
 /// resolution order.
 fn live_import_over_candidates<'c>(
     analysis: &AnalysisResult,
+    ctx: CallResolution<'_>,
     candidates: impl Iterator<Item = &'c str>,
     word: &str,
     call_off: u32,
@@ -3062,7 +3234,7 @@ fn live_import_over_candidates<'c>(
             continue;
         }
         let candidate_ns = if prefix.is_empty() { "::" } else { prefix };
-        if let Some(hop) = live_import_at(analysis, candidate_ns, word, call_off, query) {
+        if let Some(hop) = live_import_at(analysis, ctx, candidate_ns, word, call_off, query) {
             return Some(hop);
         }
     }
@@ -3174,13 +3346,14 @@ fn forget_covers(forget_source: Option<&str>, source_ns: &str) -> bool {
 /// lifecycle, are judged from the call.
 fn live_import_at(
     analysis: &AnalysisResult,
+    ctx: CallResolution<'_>,
     importing_ns: &str,
     word: &str,
     call_off: u32,
     query: ImportQuery,
 ) -> Option<String> {
     use crate::namespace_import::{AliasEvent, AliasEventKind};
-    let events = slot_events(analysis, importing_ns, word, query);
+    let events = slot_events(analysis, ctx, importing_ns, word, query);
     // Which imports actually install something: an unforced import onto a
     // slot the namespace already holds (a local declaration, or a live alias
     // from a *different* source) raises `already exists` and binds nothing.
@@ -3243,9 +3416,9 @@ fn live_import_at(
     // *against* (`ran_after(removal, install)` asks whether the removal had run
     // at the install), and a removal is never that point. Computing one per
     // removal would be a body scan that decides nothing.
-    let install_point = |at: u32| in_document_point(analysis, at);
+    let install_point = |at: u32| in_document_point(analysis, ctx, at);
     let removal_point = |at: u32| RunPoint {
-        uri: IN_DOCUMENT_URI,
+        uri: ctx.uri(),
         at,
         enclosing_body: None,
     };
@@ -3282,12 +3455,13 @@ fn live_import_at(
     crate::namespace_import::alias_live_at(
         &mut log,
         &RunOrder::default(),
-        Some(in_document_point(analysis, call_off)),
+        Some(in_document_point(analysis, ctx, call_off)),
     )
     .then(|| source_ns.to_owned())
 }
 
-/// The document key every in-document import event carries.
+/// The document key every in-document import event carries **when no
+/// workspace view is attached**.
 ///
 /// This tier holds exactly one document, so the *identity* of the key is
 /// irrelevant — what matters is that every point shares it, which is what makes
@@ -3299,15 +3473,23 @@ fn live_import_at(
 /// needs no `source` graph — every point shares [`IN_DOCUMENT_URI`], so
 /// [`crate::source_graph::RunOrder`] answers from the single-document rule
 /// alone and never looks at an edge. Building it allocates nothing.
+/// With a [`ProgramExports`] view attached the points carry the document's
+/// **real** URI instead, so the workspace's own order can rank a foreign
+/// export against them — and, just as importantly, can rank *this* document's
+/// exports against them by offset rather than shrugging.
 const IN_DOCUMENT_URI: &str = "";
 
 /// An offset in the document being analysed, as a
 /// [`crate::source_graph::RunPoint`] — with the enclosing definition body the
 /// load-order rule needs, which is the only thing
 /// [`indirection::in_effect`] reads out of the analysis.
-fn in_document_point(analysis: &AnalysisResult, at: u32) -> RunPoint<'static> {
+fn in_document_point<'a>(
+    analysis: &AnalysisResult,
+    ctx: CallResolution<'a>,
+    at: u32,
+) -> RunPoint<'a> {
     RunPoint {
-        uri: IN_DOCUMENT_URI,
+        uri: ctx.uri(),
         at,
         enclosing_body: analysis.innermost_definition_body_span(at),
     }
@@ -3352,6 +3534,7 @@ fn in_document_point(analysis: &AnalysisResult, at: u32) -> RunPoint<'static> {
 /// same rule, stated over the facts each tier holds.
 fn slot_events<'a>(
     analysis: &'a AnalysisResult,
+    ctx: CallResolution<'_>,
     importing_ns: &str,
     word: &str,
     query: ImportQuery,
@@ -3387,9 +3570,7 @@ fn slot_events<'a>(
             continue;
         }
         let at = imp.range.start();
-        if !exported_at_import(analysis, source_ns, word, at)
-            && (query == ImportQuery::Resolve || namespace_exports_observable(analysis, source_ns))
-        {
+        if !query.installs(export_verdict(analysis, ctx, source_ns, word, at)) {
             continue;
         }
         events.push(SlotEvent::Import {
@@ -3460,6 +3641,7 @@ fn slot_events<'a>(
 /// identical records — one decision, not two.
 pub(crate) fn exported_at_import(
     analysis: &AnalysisResult,
+    ctx: CallResolution<'_>,
     source_ns: &str,
     word: &str,
     import_at: u32,
@@ -3477,7 +3659,7 @@ pub(crate) fn exported_at_import(
             // body-local export the tombstone cannot be proven to follow
             // keeps the name exported.
             at: RunPoint {
-                uri: IN_DOCUMENT_URI,
+                uri: ctx.uri(),
                 at: e.range.start(),
                 enclosing_body: None,
             },
@@ -3486,7 +3668,7 @@ pub(crate) fn exported_at_import(
         &mut events,
         word,
         &RunOrder::default(),
-        in_document_point(analysis, import_at),
+        in_document_point(analysis, ctx, import_at),
     )
 }
 
@@ -3498,11 +3680,12 @@ pub(crate) fn exported_at_import(
 /// compares against the definition it is gathering references for.
 pub(crate) fn import_chain_target(
     analysis: &AnalysisResult,
+    ctx: CallResolution<'_>,
     namespace: &str,
     word: &str,
     call_off: u32,
 ) -> Option<String> {
-    wildcard_import_source_namespace(analysis, namespace, word, call_off)
+    wildcard_import_source_namespace(analysis, ctx, namespace, word, call_off)
 }
 
 /// Resolve a call `word` written in `namespace` to the proc it denotes:
@@ -3527,18 +3710,22 @@ pub(crate) fn import_chain_target(
 /// already applies to a *deletion* recorded inside a body — reused here
 /// rather than re-derived, so both agree on what "load-time" means.
 ///
-/// `registry`, when `Some`, supplies the builtin gate; `None` skips the gate
-/// (callers without a registry keep the lenient behaviour, including the
-/// nested-shadow one — there is no builtin to protect).
+/// `ctx` carries everything outside the document: its
+/// [`CallResolution::registry`], when `Some`, supplies the builtin gate
+/// (`None` skips it — callers without a registry keep the lenient behaviour,
+/// including the nested-shadow one, since there is no builtin to protect), and
+/// its [`CallResolution::program`], when `Some`, supplies the whole-program
+/// export oracle the `-force` shadow needs (issue #1116 item 1). Both absent
+/// is the document-only behaviour this resolver has always had.
 pub(crate) fn resolve_called_proc<'a>(
     analysis: &'a AnalysisResult,
     source: &str,
     namespace: &str,
     word: &str,
     call_off: u32,
-    registry: Option<&tcl_registry::CommandRegistry>,
+    ctx: CallResolution<'_>,
 ) -> Option<&'a tcl_compiler::analyser::ProcDef> {
-    let has_builtin = registry.is_some_and(|r| r.get(word).is_some());
+    let has_builtin = ctx.registry.is_some_and(|r| r.get(word).is_some());
     // A `namespace import -force` *replaces* a same-named command the
     // importing namespace already holds, so from its own position onward the
     // local definition is no longer what a bare call reaches (oracle on
@@ -3547,7 +3734,7 @@ pub(crate) fn resolve_called_proc<'a>(
     // import's source lives in another file, where answering with the local
     // definition would be the wrong answer and the cross-document resolver is
     // the one that can answer.
-    let forced_shadow = forced_import_shadows(analysis, namespace, word, call_off);
+    let forced_shadow = forced_import_shadows(analysis, ctx, namespace, word, call_off);
     if !forced_shadow && let Some(proc_def) = proc_visible_from_namespace(analysis, namespace, word)
     {
         let nested_shadow = has_builtin
@@ -3563,7 +3750,9 @@ pub(crate) fn resolve_called_proc<'a>(
     // priority tier (same nested-shadow gate) so an unconditional
     // top-level import still outranks a same-named builtin, matching how
     // an equivalent top-level `proc` redefinition already would.
-    if let Some(proc_def) = proc_visible_via_wildcard_import(analysis, namespace, word, call_off) {
+    if let Some(proc_def) =
+        proc_visible_via_wildcard_import(analysis, ctx, namespace, word, call_off)
+    {
         let nested_shadow = has_builtin
             && analysis.offset_is_inside_any_definition_body(proc_def.name_span.start());
         if !nested_shadow {
@@ -3582,7 +3771,14 @@ pub(crate) fn resolve_called_proc<'a>(
     let hit = fallback_proc_by_simple_name(analysis, source, word)?;
     // …and the lenient tail match must not smuggle back in the one answer the
     // import gate has just refused (issue #1104 item 2).
-    if only_route_is_a_dead_import(analysis, namespace, word, call_off, &hit.qualified_name) {
+    if only_route_is_a_dead_import(
+        analysis,
+        ctx,
+        namespace,
+        word,
+        call_off,
+        &hit.qualified_name,
+    ) {
         return None;
     }
     Some(hit)
@@ -3626,6 +3822,7 @@ pub(crate) fn resolve_called_proc<'a>(
 /// one whose import *does* resolve (which never reaches the fallback anyway).
 fn only_route_is_a_dead_import(
     analysis: &AnalysisResult,
+    ctx: CallResolution<'_>,
     namespace: &str,
     word: &str,
     call_off: u32,
@@ -3670,7 +3867,7 @@ fn only_route_is_a_dead_import(
             })
     });
     covered
-        && wildcard_import_source_namespace(analysis, namespace, word, call_off)
+        && wildcard_import_source_namespace(analysis, ctx, namespace, word, call_off)
             .is_none_or(|live| !same_namespace(&live, target_ns))
 }
 
@@ -3698,7 +3895,7 @@ pub(crate) fn resolve_proc_target_at<'a>(
     source: &str,
     cursor_off: u32,
     word: &str,
-    registry: Option<&tcl_registry::CommandRegistry>,
+    ctx: CallResolution<'_>,
 ) -> Option<(&'a String, &'a tcl_compiler::analyser::ProcDef)> {
     if let Some(hit) = analysis
         .all_procs
@@ -3749,7 +3946,7 @@ pub(crate) fn resolve_proc_target_at<'a>(
         cursor_off,
         &analysis.namespace_overrides,
     );
-    let proc_def = resolve_called_proc(analysis, source, &ns, word, cursor_off, registry)?;
+    let proc_def = resolve_called_proc(analysis, source, &ns, word, cursor_off, ctx)?;
     analysis.all_procs.get_key_value(&proc_def.qualified_name)
 }
 
@@ -3762,6 +3959,7 @@ pub(crate) fn resolve_proc_target_at<'a>(
 /// key equals `ClassDef::qualified_name`.
 pub(crate) fn resolve_class_target_at<'a>(
     analysis: &'a AnalysisResult,
+    ctx: CallResolution<'_>,
     cursor_off: u32,
     word: &str,
 ) -> Option<(&'a String, &'a tcl_compiler::analyser::ClassDef)> {
@@ -3799,7 +3997,7 @@ pub(crate) fn resolve_class_target_at<'a>(
     // callable bare — see [`proc_visible_via_wildcard_import`] for the full
     // rationale (issue #923 idx 18); classes never consult `namespace path`,
     // matching `bareword_resolution_candidates` above.
-    let source_ns = wildcard_import_source_namespace(analysis, &ns, word, cursor_off)?;
+    let source_ns = wildcard_import_source_namespace(analysis, ctx, &ns, word, cursor_off)?;
     analysis
         .all_classes
         .get_key_value(&tcl_syntax::naming::qualify(&source_ns, word))

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -2943,7 +2943,7 @@ fn proc_visible_via_wildcard_import<'a>(
 /// namespace defined in *another* file still deletes the local command, and
 /// answering with that local definition would be wrong; the cross-document
 /// resolver takes it from there.
-fn forced_import_shadows(
+pub(crate) fn forced_import_shadows(
     analysis: &AnalysisResult,
     ctx: CallResolution<'_>,
     namespace: &str,

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -5510,7 +5510,7 @@ mod tests {
     // The single document [`PARTLY_OBSERVABLE`] is the *same bytes* in every
     // test below. Only the program around it changes, and with it the correct
     // answer — which is the whole reason this tier needed an oracle. Oracle
-    // transcript (tclsh 8.6.16 and 9.0.4, byte-identical), the file loaded
+    // transcript (tclsh 8.6.14 and 9.0.4, byte-identical), the file loaded
     // from a two-line loader that does or does not also source an
     // `exports.tcl` holding `namespace eval ::src {namespace export helper}`:
     //

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -5528,10 +5528,12 @@ mod tests {
     /// namespace absent from it is [`ExportVerdict::Unknown`], one present
     /// answers from its listed names.
     ///
-    /// Deliberately position-blind — the *ordering* of a real workspace's
-    /// export events is `WorkspaceIndex`'s job and is pinned against it in
-    /// [`both_tiers_agree`]-style tests below. What this fixture isolates is
-    /// the three-way verdict itself.
+    /// Deliberately position-blind: what this fixture isolates is the
+    /// three-way verdict itself. Ordering a real workspace's export events
+    /// against an import site is `WorkspaceIndex`'s job, pinned against the
+    /// real snapshot in
+    /// [`the_real_oracle_does_not_resurrect_an_export_written_after_the_import`]
+    /// and in `workspace_index`'s own both-tiers tests.
     struct FakeExports(&'static [(&'static str, &'static [&'static str])]);
 
     impl NamespaceExportOracle for FakeExports {
@@ -5629,26 +5631,54 @@ mod tests {
     }
 
     #[test]
-    fn an_oracle_does_not_resurrect_an_export_written_after_the_import() {
-        // FP guard, issue #1027 Direction B under the oracle: the export that
-        // covers the name is in *this* document but written after the import,
-        // so it is not retroactive (oracle: `invalid command name`). The
-        // document's own export records are consulted first and rank by
-        // position, so the oracle is never asked to overrule them — and the
-        // real `WorkspaceIndex` oracle ranks its own rows against the import's
-        // real URI for the same reason (`ProgramExports::uri`).
+    fn the_real_oracle_does_not_resurrect_an_export_written_after_the_import() {
+        // FP guard, issue #1027 Direction B under the oracle, and the reason
+        // [`ProgramExports`] pairs the oracle with the document's **real**
+        // URI. The export covering the name is in this very document but
+        // written *after* the import, so it is not retroactive (oracle:
+        // `invalid command name "p"`). The workspace oracle holds that same
+        // row, tagged with the same URI, so it ranks it against the import by
+        // offset and answers `NotExported`. Handed a placeholder URI instead
+        // it could not rank the row at all, and
+        // `exported_at_import_site`'s abstain-toward-exported rule would have
+        // installed an import Tcl never made.
+        //
+        // Deliberately run against the real `WorkspaceIndex` snapshot rather
+        // than [`FakeExports`], which is position-blind by design.
         let src = "namespace eval src {\n    proc p {} { return SRC }\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval src {\n    namespace export p\n}\nnamespace eval dst {\n    p\n}\n";
         let analysis = analyse(src);
         let call = after_last(src, "    p\n");
+        let index = crate::workspace_index::WorkspaceIndex::from_documents([(
+            "file:///main.tcl",
+            &analysis,
+        )]);
+        let exports = index.export_snapshot();
         let ctx = DOC.in_program(ProgramExports {
             uri: "file:///main.tcl",
-            // The oracle answers `Exported` unconditionally — the strongest
-            // possible pressure toward the wrong answer.
-            oracle: &FakeExports(&[("src", &["p"])]),
+            oracle: exports.as_ref(),
         });
         assert!(
             proc_visible_via_wildcard_import(&analysis, ctx, "::dst", "p", call).is_none(),
             "an export written after the import must not install it retroactively",
+        );
+        // …and a *second* import written after the export does pick it up,
+        // so the guard above is the ordering rule and not a blanket refusal.
+        let src2 = format!("{src}namespace eval dst {{\n    namespace import ::src::*\n}}\n");
+        let analysis2 = analyse(&src2);
+        let index2 = crate::workspace_index::WorkspaceIndex::from_documents([(
+            "file:///main.tcl",
+            &analysis2,
+        )]);
+        let exports2 = index2.export_snapshot();
+        let ctx2 = DOC.in_program(ProgramExports {
+            uri: "file:///main.tcl",
+            oracle: exports2.as_ref(),
+        });
+        let after = u32::try_from(src2.len()).expect("tiny test source");
+        assert!(
+            proc_visible_via_wildcard_import(&analysis2, ctx2, "::dst", "p", after)
+                .is_some_and(|p| p.qualified_name == "::src::p"),
+            "each import site takes its own export snapshot",
         );
     }
 

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -288,6 +288,7 @@ pub fn definition_with(
             line,
             character,
             analysis,
+            resolution: view,
         },
     ) {
         return result;
@@ -494,6 +495,12 @@ struct DefCtx<'a> {
     line: u32,
     character: u32,
     analysis: &'a AnalysisResult,
+    /// The request's whole-program view, carried this far because the
+    /// caller-frame path resolves *call sites* to find the callee that
+    /// `upvar`s the name — a resolution the `-force` shadow can change
+    /// (issue #1116 item 1). Hover already threads it; dropping it here is
+    /// what made the two providers disagree on one cursor.
+    resolution: CallResolution<'a>,
 }
 
 /// The go-to-definition answers decided by the cursor's *position* alone,
@@ -532,6 +539,7 @@ fn position_definition(
         line,
         character,
         analysis,
+        resolution,
     } = ctx;
     // Resolved through the shared gate, not the raw character scan: a cursor
     // inside a brace-quoted variable-name word (`set {$n} 1`) is not a `$n`
@@ -557,7 +565,7 @@ fn position_definition(
         // the creating write, the nearest thing the frame has to a
         // declaration (issue #923 audit idx 58).
         return Some(caller_frame_definition(
-            source, line_index, analysis, cursor_off, &var_name,
+            source, line_index, analysis, resolution, cursor_off, &var_name,
         ));
     }
     let param_position = parameter_list_position_at(analysis, source, cursor_off);
@@ -622,6 +630,7 @@ fn caller_frame_definition(
     source: &str,
     line_index: &LineIndex,
     analysis: &AnalysisResult,
+    resolution: CallResolution<'_>,
     cursor_off: u32,
     name: &str,
 ) -> Vec<LspRange> {
@@ -629,7 +638,7 @@ fn caller_frame_definition(
         analysis,
         source,
         "",
-        CallResolution::document_only().with_registry(tcl_registry::registry_for_dialect("")),
+        resolution.with_registry(tcl_registry::registry_for_dialect("")),
         cursor_off,
         name,
     );

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -4153,6 +4153,11 @@ mod tests {
         a.analyse(source, "tcl8.6").clone()
     }
 
+    /// The document-only resolution context: no registry, no whole-program
+    /// export oracle. What every caller had before issue #1116 item 1, and
+    /// what a single-document test must keep getting.
+    const DOC: CallResolution<'static> = CallResolution::document_only();
+
     /// Regression coverage for issue #996: `variable_scope_extent`'s
     /// nested `innermost` fn and `linked_var_reference_spans`'s
     /// `collect_alias_spans`/`collect_shared_span_refs` all recurse once
@@ -4471,7 +4476,7 @@ mod tests {
         // visible, not the gate this test is proving.
         let src = "namespace eval Foo {\n    proc bar {} { return 1 }\n    proc other {} { return 2 }\n    namespace export bar\n}\nnamespace import ::Foo::*\nother\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "::", "other", u32::MAX);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "::", "other", u32::MAX);
         assert!(
             hit.is_none(),
             "an unexported sibling must stay unresolved through the wildcard import: {hit:?}"
@@ -4489,7 +4494,7 @@ mod tests {
         let analysis = analyse(src);
         let line_index = LineIndex::new(src);
         let cursor_off = byte_offset_at(&line_index, src, 5, 0);
-        let hit = resolve_class_target_at(&analysis, cursor_off, "Widget");
+        let hit = resolve_class_target_at(&analysis, DOC, cursor_off, "Widget");
         assert!(
             hit.is_some(),
             "must resolve Widget through the wildcard import"
@@ -4507,7 +4512,7 @@ mod tests {
         let analysis = analyse(src);
         let line_index = LineIndex::new(src);
         let cursor_off = byte_offset_at(&line_index, src, 6, 0);
-        let hit = resolve_class_target_at(&analysis, cursor_off, "Other");
+        let hit = resolve_class_target_at(&analysis, DOC, cursor_off, "Other");
         assert!(
             hit.is_none(),
             "an unexported sibling class must stay unresolved: {hit:?}"
@@ -4561,7 +4566,7 @@ mod tests {
         // and `info commands ::dst::*` still lists `::dst::p`.
         let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval src {\n    namespace export -clear\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::src::p"),
             "a `-clear` written after the import must not revoke it: {hit:?}"
@@ -4577,7 +4582,7 @@ mod tests {
         // p}; ::dst::p` → `invalid command name "::dst::p"`.
         let src = "namespace eval src {\n    proc p {} { return P }\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval src {\n    namespace export p\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX);
         assert!(
             hit.is_none(),
             "an export written after the import must not apply retroactively: {hit:?}"
@@ -4596,13 +4601,13 @@ mod tests {
             "proc p {} { return GLOBAL }\nnamespace eval dst {\n    namespace import ::p\n}\n";
         let analysis = analyse(ungated);
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX).is_none(),
+            proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX).is_none(),
             "an unexported global command installs nothing",
         );
         let gated = "proc p {} { return GLOBAL }\nnamespace export p\nnamespace eval dst {\n    namespace import ::p\n}\n";
         let analysis = analyse(gated);
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX)
+            proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX)
                 .is_some_and(|p| p.qualified_name == "::p"),
             "with the export it binds",
         );
@@ -4711,7 +4716,7 @@ mod tests {
         let src = "namespace eval src {\n    proc p {} { return P }\n    proc q {} { return Q }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval src {\n    namespace export -clear p q\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
         let analysis = analyse(src);
         for name in ["p", "q"] {
-            let hit = proc_visible_via_wildcard_import(&analysis, "dst", name, u32::MAX);
+            let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", name, u32::MAX);
             assert!(
                 hit.is_some(),
                 "the second import must see `{name}`: {hit:?}"
@@ -4727,7 +4732,7 @@ mod tests {
         // returns the empty list, and the later import binds no command.
         let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n    namespace export -clear\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX);
         assert!(
             hit.is_none(),
             "a `-clear` before the import leaves nothing exported: {hit:?}"
@@ -4742,11 +4747,11 @@ mod tests {
         let src = "namespace eval src {\n    proc a {} { return A }\n    proc p {} { return P }\n    namespace export a\n    namespace export -clear p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
         let analysis = analyse(src);
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX).is_some(),
+            proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX).is_some(),
             "the `-clear` call's own pattern survives it"
         );
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "dst", "a", u32::MAX).is_none(),
+            proc_visible_via_wildcard_import(&analysis, DOC, "dst", "a", u32::MAX).is_none(),
             "the pattern cleared by the same call must not survive"
         );
     }
@@ -4761,7 +4766,7 @@ mod tests {
         let analysis = analyse(src);
         for name in ["a", "b"] {
             assert!(
-                proc_visible_via_wildcard_import(&analysis, "dst", name, u32::MAX).is_some(),
+                proc_visible_via_wildcard_import(&analysis, DOC, "dst", name, u32::MAX).is_some(),
                 "`{name}` must stay exported — `namespace export` is additive"
             );
         }
@@ -4774,8 +4779,12 @@ mod tests {
         // `getX` (`::dst::setX` → `invalid command name`).
         let src = "namespace eval src {\n    proc getX {} { return GX }\n    proc setX {} { return SX }\n    namespace export get*\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
         let analysis = analyse(src);
-        assert!(proc_visible_via_wildcard_import(&analysis, "dst", "getX", u32::MAX).is_some());
-        assert!(proc_visible_via_wildcard_import(&analysis, "dst", "setX", u32::MAX).is_none());
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, DOC, "dst", "getX", u32::MAX).is_some()
+        );
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, DOC, "dst", "setX", u32::MAX).is_none()
+        );
     }
 
     #[test]
@@ -4788,7 +4797,7 @@ mod tests {
         let src = "namespace eval src {\n    namespace export p\n    proc p {} { return P }\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
         let analysis = analyse(src);
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX).is_some(),
+            proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX).is_some(),
             "`namespace export` names a pattern, not an existing command"
         );
     }
@@ -4806,7 +4815,7 @@ mod tests {
         // plain offset compare did not, which is what the review caught.
         let src = "namespace eval src {\n    proc p {} { return P }\n}\nnamespace eval dst {\n    proc setup {} { namespace import ::src::* }\n}\nnamespace eval src {\n    namespace export p\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::src::p"),
             "a body-local import observes a top-level export written later in \
@@ -4823,7 +4832,7 @@ mod tests {
         // p}}` then `::dst::setup` leaves `::dst::p` an invalid command name.
         let src = "namespace eval src {\n    proc p {} { return P }\n}\nnamespace eval dst {\n    proc setup {} { namespace import ::src::* ; namespace eval ::src { namespace export p } }\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX);
         assert!(
             hit.is_none(),
             "an export written after the import in the same body has not run \
@@ -4841,7 +4850,7 @@ mod tests {
         // Consuming both words as flags dropped the export entirely.
         let src = "namespace eval src {\n    proc -clear {} { return DC }\n    namespace export -clear -clear\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "-clear", u32::MAX);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "-clear", u32::MAX);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::src::-clear"),
             "the second `-clear` is an export pattern, not a second flag: {hit:?}"
@@ -4901,7 +4910,7 @@ mod tests {
         //   info commands ::dst::*                            → (empty)
         let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval dst {\n    namespace forget ::src::p\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX);
         assert!(
             hit.is_none(),
             "a forgotten alias must stop resolving after the forget: {hit:?}"
@@ -4915,7 +4924,7 @@ mod tests {
         let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\np\nnamespace eval dst {\n    namespace forget ::src::p\n}\n";
         let analysis = analyse(src);
         let call = at_first(src, "\np\n") + 1;
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", call);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", call);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::src::p"),
             "a call before the forget is unaffected by it: {hit:?}"
@@ -4930,7 +4939,7 @@ mod tests {
         let analysis = analyse(src);
         for name in ["p", "q"] {
             assert!(
-                proc_visible_via_wildcard_import(&analysis, "dst", name, u32::MAX).is_none(),
+                proc_visible_via_wildcard_import(&analysis, DOC, "dst", name, u32::MAX).is_none(),
                 "`{name}` must be forgotten by the glob pattern"
             );
         }
@@ -4956,7 +4965,7 @@ mod tests {
     fn a_dynamic_forget_pattern_revokes_nothing() {
         let dynamic = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval dst {\n    namespace forget ::src::$name\n}\n";
         let analysis = analyse(dynamic);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::src::p"),
             "a dynamic forget pattern must not revoke on a guess: {hit:?}"
@@ -4966,7 +4975,7 @@ mod tests {
         let literal = dynamic.replace("::src::$name", "::src::p");
         let analysis = analyse(&literal);
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX).is_none(),
+            proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX).is_none(),
             "the literal spelling of the same forget still revokes"
         );
     }
@@ -4992,7 +5001,7 @@ mod tests {
     fn a_dynamic_export_pattern_exports_nothing() {
         let dynamic = "set pat p\nnamespace eval src {\n    proc p {} { return P }\n    namespace export $pat\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
         let analysis = analyse(dynamic);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX);
         assert!(
             hit.is_none(),
             "a dynamic export pattern must not be guessed into a covering export: {hit:?}"
@@ -5002,7 +5011,7 @@ mod tests {
         let literal = dynamic.replace("namespace export $pat", "namespace export p");
         let analysis = analyse(&literal);
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX)
+            proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX)
                 .is_some_and(|p| p.qualified_name == "::src::p"),
             "the literal spelling of the same export does resolve"
         );
@@ -5018,7 +5027,7 @@ mod tests {
         let src = "set pat p\nnamespace eval src {\n    proc p {} { return P }\n    namespace export $pat\n    namespace export -clear\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
         let analysis = analyse(src);
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX).is_none(),
+            proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX).is_none(),
             "a `-clear` after any export leaves nothing exported"
         );
     }
@@ -5044,7 +5053,7 @@ mod tests {
         let analysis = analyse(src);
         let call =
             u32::try_from(src.rfind("; p }").expect("call in source") + 2).expect("tiny source");
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", call);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", call);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::src::p"),
             "the body-local import runs after the load-level forget and reinstalls: {hit:?}"
@@ -5056,7 +5065,7 @@ mod tests {
         let call =
             u32::try_from(inner.rfind("; p }").expect("call in source") + 2).expect("tiny source");
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "dst", "p", call).is_none(),
+            proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", call).is_none(),
             "a forget in the same body before the call does revoke"
         );
     }
@@ -5070,7 +5079,7 @@ mod tests {
         let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval dst {\n    namespace forget p\n}\n";
         let analysis = analyse(src);
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX).is_none(),
+            proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX).is_none(),
             "an unqualified forget pattern removes the alias too"
         );
     }
@@ -5082,7 +5091,7 @@ mod tests {
         // alias.
         let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval other {\n    proc p {} { return O }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval dst {\n    namespace forget ::other::p\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::src::p"),
             "a forget aimed at another source namespace revokes nothing: {hit:?}"
@@ -5096,7 +5105,7 @@ mod tests {
         // call works once more).
         let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval dst {\n    namespace forget ::src::p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::src::p"),
             "a later re-import reinstates the alias: {hit:?}"
@@ -5127,7 +5136,7 @@ mod tests {
         let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\np\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
         let analysis = analyse(src);
         let call = at_first(src, "\np\n") + 1;
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", call);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", call);
         assert!(
             hit.is_none(),
             "a call written before its own import reaches nothing: {hit:?}"
@@ -5135,7 +5144,7 @@ mod tests {
         // TP — the same call after the import does resolve.
         let after = after_last(src, "namespace import ::src::*\n}\n");
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "dst", "p", after)
+            proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", after)
                 .is_some_and(|p| p.qualified_name == "::src::p"),
         );
     }
@@ -5150,7 +5159,7 @@ mod tests {
         let src = "namespace eval src {\n    proc helper {} { return HELP }\n    namespace export helper\n}\nnamespace eval app {\n    proc run {} { helper }\n}\nnamespace eval app {\n    namespace import ::src::*\n}\n";
         let analysis = analyse(src);
         let call = at_first(src, "helper }");
-        let hit = proc_visible_via_wildcard_import(&analysis, "app", "helper", call);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "app", "helper", call);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::src::helper"),
             "a body-local call observes its own file's later top-level import: {hit:?}"
@@ -5166,12 +5175,12 @@ mod tests {
         let analysis = analyse(src);
         let first = at_first(src, "helper ;");
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "app", "helper", first).is_none(),
+            proc_visible_via_wildcard_import(&analysis, DOC, "app", "helper", first).is_none(),
             "the first call runs before the same body's import",
         );
         let second = after_last(src, "namespace import ::src::* ; ");
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "app", "helper", second)
+            proc_visible_via_wildcard_import(&analysis, DOC, "app", "helper", second)
                 .is_some_and(|p| p.qualified_name == "::src::helper"),
             "the second call runs after it",
         );
@@ -5187,11 +5196,11 @@ mod tests {
         let analysis = analyse(src);
         let before = at_first(src, "\np\n") + 1;
         assert!(
-            !forced_import_shadows(&analysis, "dst", "p", before),
+            !forced_import_shadows(&analysis, DOC, "dst", "p", before),
             "the shadow is not in effect before the forced import runs",
         );
         let after = after_last(src, "namespace import -force ::src::*\n}\n");
-        assert!(forced_import_shadows(&analysis, "dst", "p", after));
+        assert!(forced_import_shadows(&analysis, DOC, "dst", "p", after));
     }
 
     #[test]
@@ -5203,14 +5212,14 @@ mod tests {
         let src = "namespace eval A {\n    proc p {} { return A }\n    namespace export p\n}\nnamespace eval B {\n    proc p {} { return B }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::A::*\n}\np\nnamespace eval dst {\n    namespace import -force ::B::*\n}\n";
         let analysis = analyse(src);
         let call = at_first(src, "\np\n") + 1;
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", call);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", call);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::A::p"),
             "the call between the two imports takes the first edge: {hit:?}"
         );
         let after = after_last(src, "namespace import -force ::B::*\n}\n");
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "dst", "p", after)
+            proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", after)
                 .is_some_and(|p| p.qualified_name == "::B::p"),
             "…and a call after the forced re-import takes the second",
         );
@@ -5230,7 +5239,7 @@ mod tests {
         let src = "namespace eval src {\n    proc p {} { return SRC }\n    namespace export p\n}\nnamespace eval dst {\n    proc p {} { return LOCAL }\n}\nnamespace eval dst {\n    namespace import -force ::src::*\n}\nnamespace eval dst {\n    p\n}\n";
         let analysis = analyse(src);
         let call = after_last(src, "    p\n");
-        let hit = resolve_called_proc(&analysis, src, "::dst", "p", call, None);
+        let hit = resolve_called_proc(&analysis, src, "::dst", "p", call, DOC);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::src::p"),
             "a `-force` import replaces the local command: {hit:?}"
@@ -5246,11 +5255,11 @@ mod tests {
         let src = "namespace eval src {\n    proc p {} { return SRC }\n    namespace export p\n}\nnamespace eval dst {\n    proc p {} { return LOCAL }\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
         let analysis = analyse(src);
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX).is_none(),
+            proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX).is_none(),
             "a conflicting non-`-force` import installs nothing"
         );
         // …and the ordinary namespace lookup still answers the local.
-        let hit = resolve_called_proc(&analysis, src, "::dst", "p", u32::MAX, None);
+        let hit = resolve_called_proc(&analysis, src, "::dst", "p", u32::MAX, DOC);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::dst::p"),
             "the local definition survives the failed import: {hit:?}"
@@ -5274,7 +5283,7 @@ mod tests {
         let analysis = analyse(src);
         // TP — between the import and the redefinition, the alias is live.
         let between = at_first(src, "\np\n") + 1;
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", between);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", between);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::src::p"),
             "a later local definition is not a conflict at the import: {hit:?}"
@@ -5283,10 +5292,10 @@ mod tests {
         // ordinary namespace lookup answers.
         let after = after_last(src, "return LOCAL }");
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "dst", "p", after).is_none(),
+            proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", after).is_none(),
             "redefining the imported name ends the alias"
         );
-        let hit = resolve_called_proc(&analysis, src, "::dst", "p", after, None);
+        let hit = resolve_called_proc(&analysis, src, "::dst", "p", after, DOC);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::dst::p"),
             "after the redefinition the call reaches the local proc: {hit:?}"
@@ -5305,13 +5314,13 @@ mod tests {
         let analysis = analyse(src);
         let between = at_first(src, "namespace import -force")
             + u32::try_from("namespace import -force ::src::*".len()).expect("tiny");
-        let hit = resolve_called_proc(&analysis, src, "::dst", "p", between, None);
+        let hit = resolve_called_proc(&analysis, src, "::dst", "p", between, DOC);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::src::p"),
             "between the forced import and the redefinition the source wins: {hit:?}"
         );
         let after = after_last(src, "return LOCAL2 }");
-        let hit = resolve_called_proc(&analysis, src, "::dst", "p", after, None);
+        let hit = resolve_called_proc(&analysis, src, "::dst", "p", after, DOC);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::dst::p"),
             "the redefinition ends the forced shadow: {hit:?}"
@@ -5331,7 +5340,7 @@ mod tests {
         // won, resolving later calls to `::B::p`.
         let src = "namespace eval A {\n    proc p {} { return AP }\n    namespace export p\n}\nnamespace eval B {\n    proc p {} { return BP }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::A::*\n}\nnamespace eval dst {\n    namespace import ::B::*\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::A::p"),
             "the failed second import leaves the first alias in place: {hit:?}"
@@ -5344,7 +5353,7 @@ mod tests {
         // wins (oracle: `::dst::p` → BP, `namespace origin` → `::B::p`).
         let src = "namespace eval A {\n    proc p {} { return AP }\n    namespace export p\n}\nnamespace eval B {\n    proc p {} { return BP }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::A::*\n}\nnamespace eval dst {\n    namespace import -force ::B::*\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::B::p"),
             "a `-force` import replaces a live alias too: {hit:?}"
@@ -5369,7 +5378,7 @@ mod tests {
         // installed `::B` and then conflicted `::A` away.
         let src = "namespace eval A {\n    proc p {} { return AP }\n    namespace export p\n}\nnamespace eval B {\n    proc p {} { return BP }\n    namespace export p\n}\nnamespace eval dst {\n    proc runner {} { namespace import ::B::p }\n}\nnamespace eval dst {\n    namespace import ::A::*\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::A::p"),
             "the top-level import runs first and the body-local one installs \
@@ -5386,7 +5395,7 @@ mod tests {
         let src = "namespace eval A {\n    proc p {} { return AP }\n    namespace export p\n}\nnamespace eval B {\n    proc p {} { return BP }\n    namespace export p\n}\nnamespace eval dst {\n    proc q {} { namespace import ::A::* ; namespace import ::B::p }\n}\n";
         let analysis = analyse(src);
         let call = after_last(src, "namespace import ::B::p");
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", call);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", call);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::A::p"),
             "the second import of the same body installs nothing: {hit:?}"
@@ -5400,7 +5409,7 @@ mod tests {
         // makes the unforced `::B::*` import succeed (`origin` → `::B::p`).
         let src = "namespace eval A {\n    proc p {} { return AP }\n    namespace export p\n}\nnamespace eval B {\n    proc p {} { return BP }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::A::*\n}\nnamespace eval dst {\n    namespace forget ::A::p\n}\nnamespace eval dst {\n    namespace import ::B::*\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::B::p"),
             "after the forget the next unforced import installs: {hit:?}"
@@ -5415,7 +5424,7 @@ mod tests {
         // it would reinstall.
         let src = "namespace eval A {\n    proc p {} { return AP }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::A::*\n}\nnamespace eval dst {\n    namespace import ::A::*\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::A::p"),
             "a same-source re-import stays live: {hit:?}"
@@ -5430,7 +5439,7 @@ mod tests {
         let src = "namespace eval src {\n    proc p {} { return SRC }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
         let analysis = analyse(src);
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX).is_some(),
+            proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX).is_some(),
             "an unconflicted import still installs"
         );
     }
@@ -5443,7 +5452,7 @@ mod tests {
         let src = "namespace eval src {\n    proc p {} { return SRC }\n    namespace export p\n}\nnamespace eval dst {\n    proc p {} { return LOCAL }\n}\nnamespace eval dst {\n    namespace import -force ::src::*\n}\nnamespace eval dst {\n    namespace forget ::src::p\n}\nnamespace eval dst {\n    p\n}\n";
         let analysis = analyse(src);
         let call = after_last(src, "    p\n");
-        let hit = resolve_called_proc(&analysis, src, "::dst", "p", call, None);
+        let hit = resolve_called_proc(&analysis, src, "::dst", "p", call, DOC);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::dst::p"),
             "after the forget the local definition is what the call reaches: {hit:?}"
@@ -5466,12 +5475,12 @@ mod tests {
         let analysis = analyse(src);
         let call = after_last(src, "    helper\n");
         assert!(
-            forced_import_shadows(&analysis, "::app", "helper", call),
+            forced_import_shadows(&analysis, DOC, "::app", "helper", call),
             "a `-force` import of a namespace whose exports this file cannot \
              see must presume the shadow",
         );
         assert!(
-            resolve_called_proc(&analysis, src, "::app", "helper", call, None).is_none(),
+            resolve_called_proc(&analysis, src, "::app", "helper", call, DOC).is_none(),
             "…and the local definition the import deleted must not be the answer",
         );
     }
@@ -5486,11 +5495,160 @@ mod tests {
         let src = "namespace eval src {\n    proc helper {} { return SRC }\n    proc other {} { return O }\n    namespace export other\n}\nnamespace eval app {\n    proc helper {} { return LOCAL }\n}\nnamespace eval app {\n    namespace import -force ::src::*\n}\nnamespace eval app {\n    helper\n}\n";
         let analysis = analyse(src);
         let call = after_last(src, "    helper\n");
-        assert!(!forced_import_shadows(&analysis, "::app", "helper", call));
-        let hit = resolve_called_proc(&analysis, src, "::app", "helper", call, None);
+        assert!(!forced_import_shadows(
+            &analysis, DOC, "::app", "helper", call
+        ));
+        let hit = resolve_called_proc(&analysis, src, "::app", "helper", call, DOC);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::app::helper"),
             "the local definition survives an import that binds nothing: {hit:?}"
+        );
+    }
+
+    // Behaviour 2c — the whole-program export oracle (issue #1116 item 1).
+    //
+    // The single document [`PARTLY_OBSERVABLE`] is the *same bytes* in every
+    // test below. Only the program around it changes, and with it the correct
+    // answer — which is the whole reason this tier needed an oracle. Oracle
+    // transcript (tclsh 8.6.16 and 9.0.4, byte-identical), the file loaded
+    // from a two-line loader that does or does not also source an
+    // `exports.tcl` holding `namespace eval ::src {namespace export helper}`:
+    //
+    //   with exports.tcl:      call -> SRC     origin -> ::src::helper
+    //   without exports.tcl:   call -> LOCAL   origin -> ::app::helper
+
+    /// The pinned two-file shape's single document, byte-for-byte.
+    ///
+    /// `::src` is *partly* observable here: its procs and one of its exports
+    /// (`other`) are in this file. Whether it also exports `helper` is decided
+    /// somewhere this document cannot see.
+    const PARTLY_OBSERVABLE: &str = "namespace eval src {\n    proc helper {} { return SRC }\n    proc other {} { return O }\n    namespace export other\n}\nnamespace eval app {\n    proc helper {} { return LOCAL }\n}\nnamespace eval app {\n    namespace import -force ::src::*\n}\nnamespace eval app {\n    helper\n}\n";
+
+    /// A stand-in [`NamespaceExportOracle`] over an explicit table: a
+    /// namespace absent from it is [`ExportVerdict::Unknown`], one present
+    /// answers from its listed names.
+    ///
+    /// Deliberately position-blind — the *ordering* of a real workspace's
+    /// export events is `WorkspaceIndex`'s job and is pinned against it in
+    /// [`both_tiers_agree`]-style tests below. What this fixture isolates is
+    /// the three-way verdict itself.
+    struct FakeExports(&'static [(&'static str, &'static [&'static str])]);
+
+    impl NamespaceExportOracle for FakeExports {
+        fn exported_at(
+            &self,
+            source_ns: &str,
+            name: &str,
+            _import_site: RunPoint<'_>,
+        ) -> ExportVerdict {
+            let bare = source_ns.trim_start_matches("::");
+            match self.0.iter().find(|(ns, _)| *ns == bare) {
+                None => ExportVerdict::Unknown,
+                Some((_, names)) if names.contains(&name) => ExportVerdict::Exported,
+                Some(_) => ExportVerdict::NotExported,
+            }
+        }
+    }
+
+    /// [`PARTLY_OBSERVABLE`] resolved against `oracle`.
+    fn partly_observable_target(oracle: &dyn NamespaceExportOracle) -> Option<String> {
+        let analysis = analyse(PARTLY_OBSERVABLE);
+        let call = after_last(PARTLY_OBSERVABLE, "    helper\n");
+        let ctx = DOC.in_program(ProgramExports {
+            uri: "file:///main.tcl",
+            oracle,
+        });
+        let shadow = forced_import_shadows(&analysis, ctx, "::app", "helper", call);
+        let hit = resolve_called_proc(&analysis, PARTLY_OBSERVABLE, "::app", "helper", call, ctx);
+        // The two halves must not contradict: a live shadow means the local
+        // command is gone, so the resolver may never answer with it.
+        assert!(
+            !(shadow && hit.is_some_and(|p| p.qualified_name == "::app::helper")),
+            "shadow fired yet the resolver answered the deleted local command",
+        );
+        hit.map(|p| p.qualified_name.clone())
+    }
+
+    #[test]
+    fn a_forced_import_shadows_when_another_file_holds_the_covering_export() {
+        // TP (the bug, CRITICAL) — `::src` exports `helper` somewhere else in
+        // the program. The `-force` import therefore *did* delete
+        // `::app::helper`, and the call reaches `::src::helper` — which this
+        // document happens to hold, so the in-document tier can answer it
+        // outright. Before the oracle, the document-only rule read "this file
+        // has an export record for ::src and none of them covers helper" as a
+        // fact and kept answering the deleted local definition.
+        assert_eq!(
+            partly_observable_target(&FakeExports(&[("src", &["other", "helper"])])),
+            Some("::src::helper".to_owned()),
+        );
+    }
+
+    #[test]
+    fn a_forced_import_does_not_shadow_when_the_whole_program_exports_nothing() {
+        // TN, byte-identical input to the test above — nothing anywhere in the
+        // program exports `helper`, so the `-force` import binds only `other`
+        // and the local definition survives (oracle: LOCAL / ::app::helper).
+        // This is the case the pre-#1116 rule got right and must keep getting
+        // right; it is also the pinned true negative
+        // `a_forced_import_does_not_shadow_when_this_file_holds_the_export_list`
+        // covers without an oracle.
+        assert_eq!(
+            partly_observable_target(&FakeExports(&[("src", &["other"])])),
+            Some("::app::helper".to_owned()),
+        );
+    }
+
+    #[test]
+    fn a_forced_import_from_a_namespace_the_program_cannot_see_still_shadows() {
+        // TP / abstention — `::src` is in no indexed file (an installed
+        // package, a document outside the workspace), so the oracle answers
+        // `Unknown`. `-force` deletes the local command whether or not
+        // anything here can prove the export, and answering with a command the
+        // import may have removed is worse than answering nothing: the
+        // resolver abstains and the cross-document tier takes over.
+        assert_eq!(partly_observable_target(&FakeExports(&[])), None);
+    }
+
+    #[test]
+    fn the_same_document_without_an_oracle_keeps_the_document_only_answer() {
+        // FP guard on the plumbing itself: the oracle is *optional*. A caller
+        // with no workspace index — a single-document unit test, the `tcl`
+        // CLI, a buffer the workspace has not indexed — must get exactly the
+        // pre-#1116 answer rather than a panic or the abstention above.
+        let analysis = analyse(PARTLY_OBSERVABLE);
+        let call = after_last(PARTLY_OBSERVABLE, "    helper\n");
+        assert!(!forced_import_shadows(
+            &analysis, DOC, "::app", "helper", call
+        ));
+        let hit = resolve_called_proc(&analysis, PARTLY_OBSERVABLE, "::app", "helper", call, DOC);
+        assert_eq!(
+            hit.map(|p| p.qualified_name.clone()),
+            Some("::app::helper".to_owned()),
+        );
+    }
+
+    #[test]
+    fn an_oracle_does_not_resurrect_an_export_written_after_the_import() {
+        // FP guard, issue #1027 Direction B under the oracle: the export that
+        // covers the name is in *this* document but written after the import,
+        // so it is not retroactive (oracle: `invalid command name`). The
+        // document's own export records are consulted first and rank by
+        // position, so the oracle is never asked to overrule them — and the
+        // real `WorkspaceIndex` oracle ranks its own rows against the import's
+        // real URI for the same reason (`ProgramExports::uri`).
+        let src = "namespace eval src {\n    proc p {} { return SRC }\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval src {\n    namespace export p\n}\nnamespace eval dst {\n    p\n}\n";
+        let analysis = analyse(src);
+        let call = after_last(src, "    p\n");
+        let ctx = DOC.in_program(ProgramExports {
+            uri: "file:///main.tcl",
+            // The oracle answers `Exported` unconditionally — the strongest
+            // possible pressure toward the wrong answer.
+            oracle: &FakeExports(&[("src", &["p"])]),
+        });
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, ctx, "::dst", "p", call).is_none(),
+            "an export written after the import must not install it retroactively",
         );
     }
 
@@ -5507,7 +5665,7 @@ mod tests {
         //   info commands ::dst::* → (empty)
         let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nrename ::src::p {}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX);
         assert!(
             hit.is_none(),
             "the alias holds the command object, so deleting it kills the alias: {hit:?}"
@@ -5525,7 +5683,7 @@ mod tests {
         // lose a genuinely-live command here.
         let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nrename ::src::p ::src::pp\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", u32::MAX);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::src::p"),
             "a rename moves the origin but keeps the alias: {hit:?}"
@@ -5540,7 +5698,7 @@ mod tests {
         let analysis = analyse(src);
         let call = at_first(src, "\np\n") + 1;
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "dst", "p", call).is_some(),
+            proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", call).is_some(),
             "a call before the deletion still reaches the source"
         );
     }
@@ -5555,7 +5713,8 @@ mod tests {
         let src = "namespace eval src {\n    proc p {} { return FIRST }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval src {\n    proc p {} { return SECOND }\n}\ndst::p\n";
         let analysis = analyse(src);
         let call = after_last(src, "dst::p");
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", call).expect("alias");
+        let hit =
+            proc_visible_via_wildcard_import(&analysis, DOC, "dst", "p", call).expect("alias");
         let captured = analysis
             .proc_def_in_effect_at(&hit.qualified_name, call)
             .expect("definition in effect at the call");
@@ -5580,7 +5739,7 @@ mod tests {
         // nothing and navigation abstained.
         let src = "namespace eval C {\n    proc p {} { return CP }\n    namespace export p\n}\nnamespace eval B {\n    namespace import ::C::*\n    namespace export p\n}\nnamespace eval A {\n    namespace import ::B::*\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "A", "p", u32::MAX);
+        let hit = proc_visible_via_wildcard_import(&analysis, DOC, "A", "p", u32::MAX);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::C::p"),
             "the chain must follow ::A → ::B → ::C: {hit:?}"
@@ -5596,7 +5755,7 @@ mod tests {
         let src = "namespace eval C {\n    proc p {} { return CP }\n    namespace export p\n}\nnamespace eval B {\n    namespace import ::C::*\n    namespace export p\n}\nnamespace eval A {\n    namespace import ::B::*\n}\nnamespace eval B {\n    namespace forget ::C::p\n}\n";
         let analysis = analyse(src);
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "A", "p", u32::MAX).is_none(),
+            proc_visible_via_wildcard_import(&analysis, DOC, "A", "p", u32::MAX).is_none(),
             "a forget in the middle hop kills the outer alias too"
         );
     }
@@ -5609,7 +5768,7 @@ mod tests {
         let src = "namespace eval C {\n    proc p {} { return CP }\n    namespace export p\n}\nnamespace eval B {\n    namespace import ::C::*\n}\nnamespace eval A {\n    namespace import ::B::*\n}\n";
         let analysis = analyse(src);
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "A", "p", u32::MAX).is_none(),
+            proc_visible_via_wildcard_import(&analysis, DOC, "A", "p", u32::MAX).is_none(),
             "the middle hop must have exported the name for the chain to run"
         );
     }
@@ -5621,8 +5780,8 @@ mod tests {
         // `indirection::MAX_COMMAND_NAME_HOPS` and must simply abstain.
         let src = "namespace eval A {\n    namespace import ::B::*\n    namespace export *\n}\nnamespace eval B {\n    namespace import ::A::*\n    namespace export *\n}\n";
         let analysis = analyse(src);
-        assert!(proc_visible_via_wildcard_import(&analysis, "A", "p", u32::MAX).is_none());
-        assert!(proc_visible_via_wildcard_import(&analysis, "B", "p", u32::MAX).is_none());
+        assert!(proc_visible_via_wildcard_import(&analysis, DOC, "A", "p", u32::MAX).is_none());
+        assert!(proc_visible_via_wildcard_import(&analysis, DOC, "B", "p", u32::MAX).is_none());
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -153,6 +153,33 @@ pub fn hover(
     )
 }
 
+/// [`hover_with_profile`] with the caller's whole-program export view
+/// attached — the entry point a host with a workspace index should call.
+///
+/// `program` is `None` for a host without one, which reproduces
+/// [`hover_with_profile`] exactly. It matters because a `namespace import
+/// -force` whose covering `namespace export` lives in another file changes
+/// *which proc* the hovered call reaches (issue #1116 item 1).
+#[must_use]
+pub fn hover_in_program(
+    source: &str,
+    line: u32,
+    character: u32,
+    analysis: &AnalysisResult,
+    registry: Option<&CommandRegistry>,
+    profile: &'static tcl_dialect::DialectProfile,
+    program: Option<crate::definition::ProgramExports<'_>>,
+) -> Option<Hover> {
+    hover_impl(
+        source,
+        line,
+        character,
+        analysis,
+        crate::definition::CallResolution { registry, program },
+        profile,
+    )
+}
+
 /// Render the hover body for a proc or class that lives in **another**
 /// document, identified by its qualified name.
 ///
@@ -239,7 +266,7 @@ fn ensemble_subcommand_hover(
     line: u32,
     character: u32,
     analysis: &AnalysisResult,
-    registry: Option<&CommandRegistry>,
+    ctx: crate::definition::CallResolution<'_>,
 ) -> Option<Hover> {
     let (head, sub, is_dollar) =
         crate::definition::instance_method_at_cursor(source, line, character)?;
@@ -254,14 +281,8 @@ fn ensemble_subcommand_hover(
         &analysis.namespace_overrides,
     );
     let target = crate::definition::ensemble_subcommand_target(analysis, &namespace, &head, &sub)?;
-    let proc_def = crate::definition::resolve_called_proc(
-        analysis,
-        source,
-        "::",
-        target,
-        cursor_offset,
-        registry,
-    )?;
+    let proc_def =
+        crate::definition::resolve_called_proc(analysis, source, "::", target, cursor_offset, ctx)?;
     let text = format!(
         "**Ensemble subcommand** of `{head}`\n\n{}",
         proc_hover_text(proc_def)
@@ -331,7 +352,7 @@ fn proc_hover_at(
     source: &str,
     cursor_offset: u32,
     word: &str,
-    registry: Option<&CommandRegistry>,
+    ctx: crate::definition::CallResolution<'_>,
 ) -> Option<Hover> {
     // A proc's own declaration name (`proc greet …`) is an argument of
     // `proc`, so the head gate below would refuse it; it is answered here,
@@ -358,7 +379,7 @@ fn proc_hover_at(
         &namespace,
         word,
         cursor_offset,
-        registry,
+        ctx,
     )?;
     Some(Hover::markdown(proc_hover_text(proc_def)))
 }
@@ -385,9 +406,10 @@ fn variable_hover(
     character: u32,
     line_index: &tcl_lexer::LineIndex,
     analysis: &AnalysisResult,
-    registry: Option<&CommandRegistry>,
+    ctx: crate::definition::CallResolution<'_>,
     profile: &'static tcl_dialect::DialectProfile,
 ) -> Option<Hover> {
+    let registry = ctx.registry;
     let dialect = profile.availability_mask;
     // `$var` resolution sits at a position where `find_word_span_at_position`
     // would also match the unqualified name, but a `$`-led ref should
@@ -445,7 +467,7 @@ fn variable_hover(
             analysis,
             source,
             profile.name,
-            registry,
+            ctx,
             var_byte_offset,
             &var_name,
         );
@@ -491,12 +513,11 @@ fn variable_position_hover(
     character: u32,
     line_index: &tcl_lexer::LineIndex,
     analysis: &AnalysisResult,
-    registry: Option<&CommandRegistry>,
+    ctx: crate::definition::CallResolution<'_>,
     profile: &'static tcl_dialect::DialectProfile,
 ) -> PositionHover {
-    if let Some(hover) = variable_hover(
-        source, line, character, line_index, analysis, registry, profile,
-    ) {
+    if let Some(hover) = variable_hover(source, line, character, line_index, analysis, ctx, profile)
+    {
         return PositionHover::Answer(hover);
     }
     let cursor_offset = crate::definition::byte_offset_at(line_index, source, line, character);
@@ -554,6 +575,20 @@ pub fn hover_with_profile(
     registry: Option<&CommandRegistry>,
     profile: &'static tcl_dialect::DialectProfile,
 ) -> Option<Hover> {
+    hover_in_program(source, line, character, analysis, registry, profile, None)
+}
+
+/// The body of [`hover_with_profile`] / [`hover_in_program`], stated once over
+/// the [`crate::definition::CallResolution`] both build.
+fn hover_impl(
+    source: &str,
+    line: u32,
+    character: u32,
+    analysis: &AnalysisResult,
+    ctx: crate::definition::CallResolution<'_>,
+    profile: &'static tcl_dialect::DialectProfile,
+) -> Option<Hover> {
+    let registry = ctx.registry;
     let dialect = profile.availability_mask;
     // One index shared by the position conversions below.
     let line_index = tcl_lexer::LineIndex::new(source);
@@ -561,15 +596,7 @@ pub fn hover_with_profile(
     let cursor_offset = crate::definition::byte_offset_at(&line_index, source, line, character);
     // Everything the cursor's *position* decides, before any word-based
     // resolver runs. `Some` is definitive, including `Some(None)`.
-    match variable_position_hover(
-        source,
-        line,
-        character,
-        &line_index,
-        analysis,
-        registry,
-        profile,
-    ) {
+    match variable_position_hover(source, line, character, &line_index, analysis, ctx, profile) {
         PositionHover::Answer(hover) => return Some(hover),
         PositionHover::Abstain => return None,
         PositionHover::FallThrough => {}
@@ -637,7 +664,7 @@ pub fn hover_with_profile(
     // before the generic proc lookup below for the same reason as the
     // `$obj method` check above: `make` is never independently a command,
     // only the pair `widget make` dispatches.
-    if let Some(hover) = ensemble_subcommand_hover(source, line, character, analysis, registry) {
+    if let Some(hover) = ensemble_subcommand_hover(source, line, character, analysis, ctx) {
         return Some(hover);
     }
 
@@ -654,12 +681,12 @@ pub fn hover_with_profile(
     // builtin, this yields nothing and the registry hover below wins — a
     // proc in an unrelated namespace must not hijack builtin hover.  A
     // non-builtin word keeps the lenient (deterministic) tail fallback.
-    if let Some(hover) = proc_hover_at(analysis, source, cursor_offset, &word, registry) {
+    if let Some(hover) = proc_hover_at(analysis, source, cursor_offset, &word, ctx) {
         return Some(hover);
     }
 
     if let Some((_, class_def)) =
-        crate::definition::resolve_class_target_at(analysis, cursor_offset, &word)
+        crate::definition::resolve_class_target_at(analysis, ctx, cursor_offset, &word)
     {
         return Some(Hover::markdown(class_hover_text(analysis, class_def)));
     }

--- a/rust/tcl-lsp-core/src/implementation.rs
+++ b/rust/tcl-lsp-core/src/implementation.rs
@@ -79,9 +79,12 @@ pub fn implementation(
     // already resolves each written super/mixin owner-aware (the same
     // `normalise` the MRO builder uses) and unions super + mixin edges, so
     // it is the single source of truth `type_hierarchy::subtypes` shares.
-    if let Some((target_qname, _target)) =
-        crate::definition::resolve_class_target_at(analysis, cursor, &word)
-    {
+    if let Some((target_qname, _target)) = crate::definition::resolve_class_target_at(
+        analysis,
+        crate::definition::CallResolution::document_only(),
+        cursor,
+        &word,
+    ) {
         if let Some(subs) = analysis.class_hierarchy().subclasses.get(target_qname) {
             for sub_qname in subs {
                 if let Some(cd) = analysis.all_classes.get(sub_qname) {

--- a/rust/tcl-lsp-core/src/inlay_hints.rs
+++ b/rust/tcl-lsp-core/src/inlay_hints.rs
@@ -940,7 +940,17 @@ fn lookup_proc<'a>(
         cmd_off,
         &analysis.namespace_overrides,
     );
-    crate::definition::resolve_called_proc(analysis, source, &ns, name, cmd_off, registry)
+    crate::definition::resolve_called_proc(
+        analysis,
+        source,
+        &ns,
+        name,
+        cmd_off,
+        crate::definition::CallResolution {
+            registry,
+            program: None,
+        },
+    )
 }
 
 /// Walk a single segmented command, emit a hint per argument

--- a/rust/tcl-lsp-core/src/inlay_hints.rs
+++ b/rust/tcl-lsp-core/src/inlay_hints.rs
@@ -120,6 +120,43 @@ pub fn inlay_hints(
     type_hints: bool,
     parameter_hints: bool,
 ) -> Vec<InlayHint> {
+    inlay_hints_in_program(
+        source,
+        dialect,
+        range,
+        analysis,
+        crate::definition::CallResolution {
+            registry,
+            program: None,
+        },
+        type_hints,
+        parameter_hints,
+    )
+}
+
+/// [`inlay_hints`] with the caller's whole-program export view attached — the
+/// entry point a host with a workspace index should call.
+///
+/// The parameter-name hints are labelled from *the proc the call actually
+/// reaches*, so a `namespace import -force` whose covering `namespace export`
+/// lives in another file changes which parameter names are correct here
+/// (issue #1116 item 1).  Hinting the shadowed local proc's parameters over a
+/// call that runs the imported one is a wrong answer, not a missing one.
+///
+/// `resolution` carries the registry and the oracle together rather than as
+/// two parameters, which also keeps this entry point at the same arity as
+/// [`inlay_hints`].
+#[must_use]
+pub fn inlay_hints_in_program(
+    source: &str,
+    dialect: &str,
+    range: LspRange,
+    analysis: Option<&AnalysisResult>,
+    resolution: crate::definition::CallResolution<'_>,
+    type_hints: bool,
+    parameter_hints: bool,
+) -> Vec<InlayHint> {
+    let registry = resolution.registry;
     if !type_hints && !parameter_hints {
         return Vec::new();
     }
@@ -184,7 +221,7 @@ pub fn inlay_hints(
             // an unrelated namespace never captures the argument hints, and a
             // same-named builtin keeps its own hints unless a proc is visible.
             let cmd_off = seg.argv[0].span.start();
-            if let Some(proc_def) = lookup_proc(analysis, source, cmd_off, cmd_name, registry) {
+            if let Some(proc_def) = lookup_proc(analysis, source, cmd_off, cmd_name, resolution) {
                 emit_hints_for_call(source, seg, proc_def, &line_index, range, &mut out);
                 continue;
             }
@@ -933,24 +970,14 @@ fn lookup_proc<'a>(
     source: &str,
     cmd_off: u32,
     name: &str,
-    registry: Option<&CommandRegistry>,
+    resolution: crate::definition::CallResolution<'_>,
 ) -> Option<&'a ProcDef> {
     let ns = crate::definition::namespace_context_at(
         &analysis.global_scope,
         cmd_off,
         &analysis.namespace_overrides,
     );
-    crate::definition::resolve_called_proc(
-        analysis,
-        source,
-        &ns,
-        name,
-        cmd_off,
-        crate::definition::CallResolution {
-            registry,
-            program: None,
-        },
-    )
+    crate::definition::resolve_called_proc(analysis, source, &ns, name, cmd_off, resolution)
 }
 
 /// Walk a single segmented command, emit a hint per argument

--- a/rust/tcl-lsp-core/src/namespace_import.rs
+++ b/rust/tcl-lsp-core/src/namespace_import.rs
@@ -145,6 +145,81 @@
 use crate::source_graph::{RunOrder, RunPoint};
 use tcl_syntax::glob::string_match;
 
+/// What is known about "had `source_ns` exported this name when the import
+/// ran?" — three-valued, because *absence of an export record* is only
+/// evidence where the export records themselves are visible.
+///
+/// The distinction the single-document tier could not draw before issue #1116
+/// item 1: it saw one file, so "no export here" and "the export is in another
+/// file" were the same observation. Both consumers of a verdict abstain, but
+/// in opposite directions, because the questions are opposite:
+///
+/// | verdict | "what does this call reach?" | "did `-force` delete the local command?" |
+/// |---|---|---|
+/// | [`Exported`](Self::Exported) | the import installed — resolve through it | yes |
+/// | [`NotExported`](Self::NotExported) | it installed nothing — do not | no |
+/// | [`Unknown`](Self::Unknown) | do not resolve (no evidence to resolve *on*) | yes — answering with a command the import may have deleted is worse than answering nothing |
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExportVerdict {
+    /// A `namespace export` covering the name had run at the import site.
+    Exported,
+    /// The exporting namespace's export list is visible **and** nothing in it
+    /// covers the name at that point — a fact, not a gap.
+    NotExported,
+    /// Nothing can be said: the namespace's exports are somewhere this
+    /// answerer cannot see (another file, an installed package, a document
+    /// outside the workspace).
+    Unknown,
+}
+
+/// Whole-program export knowledge, as the *single-document* tier needs it.
+///
+/// # Why the in-document tier needs an oracle at all (issue #1116 item 1)
+///
+/// `namespace import -force` deletes the importing namespace's own command of
+/// that name — but only for names the source namespace actually exports. A
+/// document can hold the source namespace's procs, its importing namespace,
+/// the `-force` import and the call, and still not hold the one `namespace
+/// export` that decides the question. Two whole programs whose *single
+/// document* is byte-identical then disagree (tclsh 8.6.16 / 9.0.4, verbatim):
+///
+/// ```text
+/// # shared_main.tcl — identical in both programs
+/// namespace eval ::src { proc helper {} {return SRC}
+///                        proc other {} {return OTHER}
+///                        namespace export other }
+/// namespace eval ::app { proc helper {} {return LOCAL} }
+/// namespace eval ::app { namespace import -force ::src::* }
+/// namespace eval ::app { puts [helper] }
+///
+/// with `namespace eval ::src {namespace export helper}` sourced first:
+///     call -> SRC     origin -> ::src::helper
+/// without it:
+///     call -> LOCAL   origin -> ::app::helper
+/// ```
+///
+/// No rule reading only that document can separate those, so the decision has
+/// to import whole-program evidence. The oracle is that evidence and nothing
+/// else: it answers one question, at one point in the timeline, and is free to
+/// answer [`ExportVerdict::Unknown`].
+///
+/// Optional everywhere it is threaded — a caller with no workspace index (a
+/// single-document unit test, the `tcl` CLI, an unindexed buffer) supplies
+/// none and keeps the document-only rule, which is this trait's whole reason
+/// for returning a verdict rather than a `bool`.
+///
+/// Implemented by `crate::workspace_index::NamespaceExportSnapshot`.
+pub trait NamespaceExportOracle {
+    /// Had `source_ns` exported `name` by the time the `namespace import` at
+    /// `import_site` ran, as the whole program sees it?
+    ///
+    /// `import_site` carries the importing document's real URI, so the
+    /// implementation can rank the workspace's export events against it with
+    /// the `source`-graph run order — an export the graph proves runs *after*
+    /// this import is not retroactive, exactly as within one document.
+    fn exported_at(&self, source_ns: &str, name: &str, import_site: RunPoint<'_>) -> ExportVerdict;
+}
+
 /// One `namespace export` event as either tier sees it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ExportEvent<'a> {

--- a/rust/tcl-lsp-core/src/namespace_import.rs
+++ b/rust/tcl-lsp-core/src/namespace_import.rs
@@ -181,7 +181,7 @@ pub enum ExportVerdict {
 /// document can hold the source namespace's procs, its importing namespace,
 /// the `-force` import and the call, and still not hold the one `namespace
 /// export` that decides the question. Two whole programs whose *single
-/// document* is byte-identical then disagree (tclsh 8.6.16 / 9.0.4, verbatim):
+/// document* is byte-identical then disagree (tclsh 8.6.14 / 9.0.4, verbatim):
 ///
 /// ```text
 /// # shared_main.tcl — identical in both programs

--- a/rust/tcl-lsp-core/src/refactor/inline_proc.rs
+++ b/rust/tcl-lsp-core/src/refactor/inline_proc.rs
@@ -117,9 +117,7 @@ pub fn inline_proc_in_program(
     analysis: &AnalysisResult,
     resolution: crate::definition::CallResolution<'_>,
 ) -> Option<Refactoring> {
-    let Some(registry) = resolution.registry else {
-        return None;
-    };
+    let registry = resolution.registry?;
     let call = find_command_at(source, cursor, None, registry)?;
     let head = call.name();
     if head.is_empty() {
@@ -136,12 +134,7 @@ pub fn inline_proc_in_program(
         &analysis.namespace_overrides,
     );
     let proc_def = crate::definition::resolve_called_proc(
-        analysis,
-        source,
-        &namespace,
-        head,
-        head_off,
-        resolution,
+        analysis, source, &namespace, head, head_off, resolution,
     )?;
     let title = format!("Inline proc '{}'", proc_def.name);
     let (call_start, call_end) = command_span_offsets(source, &call);

--- a/rust/tcl-lsp-core/src/refactor/inline_proc.rs
+++ b/rust/tcl-lsp-core/src/refactor/inline_proc.rs
@@ -114,7 +114,7 @@ pub fn inline_proc(
         &namespace,
         head,
         head_off,
-        Some(registry),
+        crate::definition::CallResolution::document_only().with_registry(registry),
     )?;
     let title = format!("Inline proc '{}'", proc_def.name);
     let (call_start, call_end) = command_span_offsets(source, &call);

--- a/rust/tcl-lsp-core/src/refactor/inline_proc.rs
+++ b/rust/tcl-lsp-core/src/refactor/inline_proc.rs
@@ -93,6 +93,33 @@ pub fn inline_proc(
     analysis: &AnalysisResult,
     registry: &CommandRegistry,
 ) -> Option<Refactoring> {
+    inline_proc_in_program(
+        source,
+        cursor,
+        analysis,
+        crate::definition::CallResolution::document_only().with_registry(registry),
+    )
+}
+
+/// [`inline_proc`] with the caller's whole-program export view attached — the
+/// entry point a host with a workspace index should call.
+///
+/// Inlining substitutes *the body of the proc the call actually reaches*, so
+/// a `namespace import -force` whose covering `namespace export` lives in
+/// another file makes inlining the local same-named proc a behaviour change,
+/// not a refactor (issue #1116 item 1). With the oracle attached the head
+/// simply does not resolve locally and no action is offered — the safe
+/// answer, and the same one go-to-definition gives.
+#[must_use]
+pub fn inline_proc_in_program(
+    source: &str,
+    cursor: u32,
+    analysis: &AnalysisResult,
+    resolution: crate::definition::CallResolution<'_>,
+) -> Option<Refactoring> {
+    let Some(registry) = resolution.registry else {
+        return None;
+    };
     let call = find_command_at(source, cursor, None, registry)?;
     let head = call.name();
     if head.is_empty() {
@@ -114,7 +141,7 @@ pub fn inline_proc(
         &namespace,
         head,
         head_off,
-        crate::definition::CallResolution::document_only().with_registry(registry),
+        resolution,
     )?;
     let title = format!("Inline proc '{}'", proc_def.name);
     let (call_start, call_end) = command_span_offsets(source, &call);

--- a/rust/tcl-lsp-core/src/refactor/mod.rs
+++ b/rust/tcl-lsp-core/src/refactor/mod.rs
@@ -67,7 +67,7 @@ pub use datagroup::{
 pub use extract_proc::{extract_proc, extract_proc_rename_command};
 pub use extract_variable::extract_variable;
 pub use if_to_switch::if_to_switch;
-pub use inline_proc::inline_proc;
+pub use inline_proc::{inline_proc, inline_proc_in_program};
 pub use inline_variable::inline_variable;
 pub use switch_to_dict::switch_to_dict;
 

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -791,14 +791,19 @@ fn caller_frame_references(
         line_index,
         analysis,
         include_declaration,
+        resolution,
         ..
     } = *ctx;
+    // The caller's whole-program view, not a fresh document-only one: which
+    // proc a binding's call-site word reaches is itself a call resolution, so
+    // dropping the oracle here would let find-references disagree with
+    // go-to-definition on a `-force`-shadowed callee (issue #1116 item 1).
+    let resolution = resolution.with_registry(tcl_registry::registry_for_dialect(dialect));
     let bindings = crate::caller_frame::caller_frame_bindings(
         analysis,
         source,
         dialect,
-        crate::definition::CallResolution::document_only()
-            .with_registry(tcl_registry::registry_for_dialect(dialect)),
+        resolution,
         byte_offset,
         name,
     );
@@ -818,8 +823,7 @@ fn caller_frame_references(
         analysis,
         source,
         dialect,
-        crate::definition::CallResolution::document_only()
-            .with_registry(tcl_registry::registry_for_dialect(dialect)),
+        resolution,
         byte_offset,
         name,
     )
@@ -840,6 +844,7 @@ fn variable_references(ctx: &RefCtx<'_>) -> Option<Vec<LspRange>> {
         character,
         analysis,
         include_declaration,
+        resolution,
         ..
     } = *ctx;
     let byte_offset = crate::definition::byte_offset_at(line_index, source, line, character);
@@ -875,8 +880,7 @@ fn variable_references(ctx: &RefCtx<'_>) -> Option<Vec<LspRange>> {
         analysis,
         source,
         dialect,
-        crate::definition::CallResolution::document_only()
-            .with_registry(tcl_registry::registry_for_dialect(dialect)),
+        resolution.with_registry(tcl_registry::registry_for_dialect(dialect)),
         byte_offset,
         &find_word_span_at_position(source, line, character)
             .map(|(w, _, _)| w)

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -166,6 +166,7 @@ use crate::hover::find_word_span_at_position;
 #[must_use]
 pub(crate) fn proc_reference_spans(
     analysis: &AnalysisResult,
+    ctx: crate::definition::CallResolution<'_>,
     qname: &str,
     proc_def: &tcl_compiler::analyser::ProcDef,
 ) -> Vec<tcl_lexer::Span> {
@@ -174,9 +175,17 @@ pub(crate) fn proc_reference_spans(
         .command_invocations
         .iter()
         .filter(|inv| {
-            invocation_references_proc(analysis, inv, qname, proc_def)
+            (invocation_references_proc(analysis, inv, qname, proc_def)
+                && !forced_shadow_takes_the_call(
+                    analysis,
+                    ctx,
+                    inv,
+                    &proc_def.name,
+                    &proc_def.qualified_name,
+                ))
                 || invocation_references_via_wildcard_import(
                     analysis,
+                    ctx,
                     inv,
                     &proc_def.name,
                     &proc_def.qualified_name,
@@ -185,6 +194,49 @@ pub(crate) fn proc_reference_spans(
         })
         .map(|inv| inv.range)
         .collect()
+}
+
+/// Whether a live `namespace import -force` has taken this call away from the
+/// definition it would otherwise name.
+///
+/// The reference-side statement of the fact go-to-definition applies in
+/// `resolve_called_proc`: `-force` *replaces* the importing namespace's own
+/// command, so from the import onward a bare call does not reach the local
+/// definition and must not be listed among its references (issue #1116 item
+/// 1). Without it the two providers contradict each other on the very same
+/// cursor — definition jumps to the import's source while find-references
+/// still files the call under the definition the import deleted.
+///
+/// Narrow on purpose: it fires only for a call written in the *importing*
+/// namespace itself, spelled as the bare name, with the shadow live at that
+/// call. Everything else — a qualified call, a call in another namespace, a
+/// call before the import — is untouched, and the shared
+/// [`crate::definition::forced_import_shadows`] applies the whole ordered
+/// lifecycle (export snapshot, conflict, forget, redefinition) rather than a
+/// second copy of it.
+fn forced_shadow_takes_the_call(
+    analysis: &AnalysisResult,
+    ctx: crate::definition::CallResolution<'_>,
+    inv: &tcl_compiler::signature_scan::types::SignatureCommandInvocation,
+    def_name: &str,
+    def_qualified: &str,
+) -> bool {
+    if inv.name != def_name {
+        return false;
+    }
+    let owner = def_qualified
+        .trim_start_matches("::")
+        .rsplit_once("::")
+        .map_or("", |(ns, _)| ns);
+    let call_ns = crate::definition::namespace_context_at(
+        &analysis.global_scope,
+        inv.range.start(),
+        &analysis.namespace_overrides,
+    );
+    if call_ns.trim_start_matches("::") != owner {
+        return false;
+    }
+    crate::definition::forced_import_shadows(analysis, ctx, &call_ns, def_name, inv.range.start())
 }
 
 /// Every command name whose in-document `rename` / `interp alias` chain
@@ -330,6 +382,7 @@ fn invocation_references_via_indirection(
 #[must_use]
 fn invocation_references_via_wildcard_import(
     analysis: &AnalysisResult,
+    ctx: crate::definition::CallResolution<'_>,
     inv: &tcl_compiler::signature_scan::types::SignatureCommandInvocation,
     def_name: &str,
     def_qualified: &str,
@@ -346,14 +399,8 @@ fn invocation_references_via_wildcard_import(
         inv.range.start(),
         &analysis.namespace_overrides,
     );
-    crate::definition::import_chain_target(
-        analysis,
-        crate::definition::CallResolution::document_only(),
-        &call_ns,
-        def_name,
-        inv.range.start(),
-    )
-    .is_some_and(|source_ns| source_ns.trim_start_matches("::") == target_ns)
+    crate::definition::import_chain_target(analysis, ctx, &call_ns, def_name, inv.range.start())
+        .is_some_and(|source_ns| source_ns.trim_start_matches("::") == target_ns)
 }
 
 #[must_use]
@@ -475,6 +522,35 @@ pub fn references(
     analysis: &AnalysisResult,
     include_declaration: bool,
 ) -> Vec<LspRange> {
+    references_in_program(
+        source,
+        dialect,
+        line,
+        character,
+        analysis,
+        include_declaration,
+        None,
+    )
+}
+
+/// [`references`] with the caller's whole-program export view attached — the
+/// entry point a host with a workspace index should call.
+///
+/// `program` is `None` for a host without one, which reproduces [`references`]
+/// exactly. It matters because a `namespace import -force` whose covering
+/// `namespace export` lives in another file changes *which* definition a bare
+/// call is a reference to (issue #1116 item 1), and find-references has to
+/// answer that the same way go-to-definition does.
+#[must_use]
+pub fn references_in_program(
+    source: &str,
+    dialect: &str,
+    line: u32,
+    character: u32,
+    analysis: &AnalysisResult,
+    include_declaration: bool,
+    program: Option<crate::definition::ProgramExports<'_>>,
+) -> Vec<LspRange> {
     let line_index = LineIndex::new(source);
     let ctx = RefCtx {
         source,
@@ -484,6 +560,10 @@ pub fn references(
         character,
         analysis,
         include_declaration,
+        resolution: crate::definition::CallResolution {
+            registry: None,
+            program,
+        },
     };
 
     if let Some(out) = variable_references(&ctx) {
@@ -639,6 +719,7 @@ fn constructor_or_destructor_references(ctx: &RefCtx<'_>, word: &str) -> Option<
         character,
         analysis,
         include_declaration,
+        ..
     } = *ctx;
     if word != "constructor" && word != "destructor" {
         return None;
@@ -682,6 +763,10 @@ struct RefCtx<'a> {
     character: u32,
     analysis: &'a AnalysisResult,
     include_declaration: bool,
+    /// Everything outside this document that a call-site resolution may
+    /// consult — in practice the whole-program export oracle (issue #1116
+    /// item 1). Default (`document_only`) for a host with no workspace index.
+    resolution: crate::definition::CallResolution<'a>,
 }
 
 /// Build `decl + references` ranges for a variable at the cursor.
@@ -755,6 +840,7 @@ fn variable_references(ctx: &RefCtx<'_>) -> Option<Vec<LspRange>> {
         character,
         analysis,
         include_declaration,
+        ..
     } = *ctx;
     let byte_offset = crate::definition::byte_offset_at(line_index, source, line, character);
     // Resolved through the shared gate, not the raw character scan: the
@@ -836,6 +922,7 @@ fn variable_references(ctx: &RefCtx<'_>) -> Option<Vec<LspRange>> {
 #[must_use]
 pub(crate) fn class_reference_spans(
     analysis: &AnalysisResult,
+    ctx: crate::definition::CallResolution<'_>,
     qname: &str,
     class_def: &tcl_compiler::analyser::ClassDef,
 ) -> Vec<tcl_lexer::Span> {
@@ -844,9 +931,17 @@ pub(crate) fn class_reference_spans(
         .command_invocations
         .iter()
         .filter(|inv| {
-            invocation_references_class(analysis, inv, qname, class_def)
+            (invocation_references_class(analysis, inv, qname, class_def)
+                && !forced_shadow_takes_the_call(
+                    analysis,
+                    ctx,
+                    inv,
+                    &class_def.name,
+                    &class_def.qualified_name,
+                ))
                 || invocation_references_via_wildcard_import(
                     analysis,
+                    ctx,
                     inv,
                     &class_def.name,
                     &class_def.qualified_name,
@@ -893,7 +988,7 @@ fn class_references(ctx: &RefCtx<'_>, word: &str) -> Option<Vec<LspRange>> {
     // `class_reference_spans` (over `command_invocations`) already covers them,
     // in this document and, via the workspace index, across files.  Rename and
     // the code-lens count read the same collection, so the three never diverge.
-    for span in class_reference_spans(analysis, qname, class_def) {
+    for span in class_reference_spans(analysis, ctx.resolution, qname, class_def) {
         out.push(span_to_range(source, line_index, span));
     }
     dedup_ranges(&mut out);
@@ -929,7 +1024,7 @@ fn proc_references(ctx: &RefCtx<'_>, word: &str) -> Option<Vec<LspRange>> {
     if include_declaration {
         out.push(span_to_range(source, line_index, proc_def.name_span));
     }
-    for span in proc_reference_spans(analysis, qname, proc_def) {
+    for span in proc_reference_spans(analysis, ctx.resolution, qname, proc_def) {
         out.push(span_to_range(source, line_index, span));
     }
     dedup_ranges(&mut out);
@@ -974,7 +1069,7 @@ fn ensemble_subcommand_references(ctx: &RefCtx<'_>) -> Option<Vec<LspRange>> {
     if include_declaration {
         out.push(span_to_range(source, line_index, proc_def.name_span));
     }
-    for span in proc_reference_spans(analysis, qname, proc_def) {
+    for span in proc_reference_spans(analysis, ctx.resolution, qname, proc_def) {
         out.push(span_to_range(source, line_index, span));
     }
     dedup_ranges(&mut out);
@@ -994,6 +1089,7 @@ fn instance_method_references(ctx: &RefCtx<'_>) -> Option<Vec<LspRange>> {
         character,
         analysis,
         include_declaration,
+        ..
     } = *ctx;
     let (inst, method, is_dollar) =
         crate::definition::instance_method_at_cursor(source, line, character)?;
@@ -1067,6 +1163,7 @@ fn classmethod_call_site_references(ctx: &RefCtx<'_>) -> Option<Vec<LspRange>> {
         character,
         analysis,
         include_declaration,
+        ..
     } = *ctx;
     let (inst, method, is_dollar) =
         crate::definition::instance_method_at_cursor(source, line, character)?;
@@ -1110,6 +1207,7 @@ fn itcl_class_proc_references(ctx: &RefCtx<'_>) -> Option<Vec<LspRange>> {
         character,
         analysis,
         include_declaration,
+        ..
     } = *ctx;
     let (class_q, member) =
         crate::definition::itcl_class_proc_target_at(source, dialect, line, character, analysis)?;
@@ -1138,6 +1236,7 @@ fn class_member_references(ctx: &RefCtx<'_>, word: &str) -> Option<Vec<LspRange>
         character,
         analysis,
         include_declaration,
+        ..
     } = *ctx;
     let cursor_offset = crate::definition::byte_offset_at(line_index, source, line, character);
     let (decl_span, call_spans) =
@@ -3320,7 +3419,12 @@ pub fn document_highlights(
                 span_to_range(source, &line_index, class_def.name_span),
                 HighlightKind::Text,
             ));
-            for span in class_reference_spans(analysis, qname, class_def) {
+            for span in class_reference_spans(
+                analysis,
+                crate::definition::CallResolution::document_only(),
+                qname,
+                class_def,
+            ) {
                 out.push((
                     span_to_range(source, &line_index, span),
                     HighlightKind::Text,

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -3344,6 +3344,45 @@ pub enum HighlightKind {
     Text,
 }
 
+/// The class-name highlight set at the cursor, or `None` when the cursor is
+/// not on one — the class arm of [`document_highlights`], lifted out so the
+/// entry point stays a readable dispatch over symbol kinds.
+fn class_highlights(
+    source: &str,
+    line_index: &LineIndex,
+    analysis: &AnalysisResult,
+    line: u32,
+    character: u32,
+    word: &str,
+) -> Option<Vec<(LspRange, HighlightKind)>> {
+    let cursor_off = crate::definition::byte_offset_at(line_index, source, line, character);
+    // Declaration-span hit, else the namespace-aware candidate resolution —
+    // never a namespace-blind `c.name == word` first-hit scan (the M1
+    // wrong-symbol drift class).
+    let (qname, class_def) = crate::definition::resolve_class_target_at(
+        analysis,
+        crate::definition::CallResolution::document_only(),
+        cursor_off,
+        word,
+    )?;
+    // Non-variable symbols (procs / classes / methods) highlight as `Text` for
+    // both declaration and uses — only variables carry the Write/Read
+    // distinction.
+    let mut out = vec![(
+        span_to_range(source, line_index, class_def.name_span),
+        HighlightKind::Text,
+    )];
+    for span in class_reference_spans(
+        analysis,
+        crate::definition::CallResolution::document_only(),
+        qname,
+        class_def,
+    ) {
+        out.push((span_to_range(source, line_index, span), HighlightKind::Text));
+    }
+    Some(dedup_kinded(out))
+}
+
 /// Compute the document-highlight spans for the symbol at the
 /// cursor with read / write kinds.
 ///
@@ -3399,39 +3438,8 @@ pub fn document_highlights(
         return Vec::new();
     };
 
-    {
-        let cursor_off = crate::definition::byte_offset_at(&line_index, source, line, character);
-        // Declaration-span hit, else the namespace-aware candidate
-        // resolution — never a namespace-blind `c.name == word` first-hit
-        // scan (the M1 wrong-symbol drift class).
-        let class_match = crate::definition::resolve_class_target_at(
-            analysis,
-            crate::definition::CallResolution::document_only(),
-            cursor_off,
-            &word,
-        );
-        if let Some((qname, class_def)) = class_match {
-            let mut out = Vec::new();
-            // Non-variable symbols (procs / classes / methods) highlight as
-            // `Text` for both declaration and uses — only variables carry the
-            // Write/Read distinction.
-            out.push((
-                span_to_range(source, &line_index, class_def.name_span),
-                HighlightKind::Text,
-            ));
-            for span in class_reference_spans(
-                analysis,
-                crate::definition::CallResolution::document_only(),
-                qname,
-                class_def,
-            ) {
-                out.push((
-                    span_to_range(source, &line_index, span),
-                    HighlightKind::Text,
-                ));
-            }
-            return dedup_kinded(out);
-        }
+    if let Some(out) = class_highlights(source, &line_index, analysis, line, character, &word) {
+        return out;
     }
 
     {

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -976,12 +976,8 @@ fn class_references(ctx: &RefCtx<'_>, word: &str) -> Option<Vec<LspRange>> {
     // Declaration under the cursor, else namespace-aware resolution — never a
     // namespace-blind `c.name == word` scan (which from a call site could
     // surface an unrelated same-named class's reference set).
-    let (qname, class_def) = crate::definition::resolve_class_target_at(
-        analysis,
-        crate::definition::CallResolution::document_only(),
-        cursor_off,
-        word,
-    )?;
+    let (qname, class_def) =
+        crate::definition::resolve_class_target_at(analysis, ctx.resolution, cursor_off, word)?;
     let mut out = Vec::new();
     if include_declaration {
         out.push(span_to_range(source, line_index, class_def.name_span));
@@ -1017,12 +1013,17 @@ fn proc_references(ctx: &RefCtx<'_>, word: &str) -> Option<Vec<LspRange>> {
     // Declaration under the cursor, else C Tcl's namespace-aware call-site
     // resolution — never a namespace-blind `p.name == word` scan (which from a
     // call site could surface an unrelated same-named proc's reference set).
+    // The caller's whole-program view, not a fresh document-only one: the
+    // span pass below already filters with `ctx.resolution`, so resolving the
+    // *target* without it made this function disagree with itself — it would
+    // seed from the local definition a `-force` import deleted and then drop
+    // every span that definition owns (issue #1116 item 1).
     let (qname, proc_def) = crate::definition::resolve_proc_target_at(
         analysis,
         source,
         cursor_off,
         word,
-        crate::definition::CallResolution::document_only(),
+        ctx.resolution,
     )?;
     let mut out = Vec::new();
     if include_declaration {
@@ -3358,17 +3359,14 @@ fn class_highlights(
     line: u32,
     character: u32,
     word: &str,
+    resolution: crate::definition::CallResolution<'_>,
 ) -> Option<Vec<(LspRange, HighlightKind)>> {
     let cursor_off = crate::definition::byte_offset_at(line_index, source, line, character);
     // Declaration-span hit, else the namespace-aware candidate resolution —
     // never a namespace-blind `c.name == word` first-hit scan (the M1
     // wrong-symbol drift class).
-    let (qname, class_def) = crate::definition::resolve_class_target_at(
-        analysis,
-        crate::definition::CallResolution::document_only(),
-        cursor_off,
-        word,
-    )?;
+    let (qname, class_def) =
+        crate::definition::resolve_class_target_at(analysis, resolution, cursor_off, word)?;
     // Non-variable symbols (procs / classes / methods) highlight as `Text` for
     // both declaration and uses — only variables carry the Write/Read
     // distinction.
@@ -3376,12 +3374,7 @@ fn class_highlights(
         span_to_range(source, line_index, class_def.name_span),
         HighlightKind::Text,
     )];
-    for span in class_reference_spans(
-        analysis,
-        crate::definition::CallResolution::document_only(),
-        qname,
-        class_def,
-    ) {
+    for span in class_reference_spans(analysis, resolution, qname, class_def) {
         out.push((span_to_range(source, line_index, span), HighlightKind::Text));
     }
     Some(dedup_kinded(out))
@@ -3403,6 +3396,33 @@ pub fn document_highlights(
     line: u32,
     character: u32,
     analysis: &AnalysisResult,
+) -> Vec<(LspRange, HighlightKind)> {
+    document_highlights_in_program(
+        source,
+        dialect,
+        line,
+        character,
+        analysis,
+        crate::definition::CallResolution::document_only(),
+    )
+}
+
+/// [`document_highlights`] with the caller's whole-program export view
+/// attached — the entry point a host with a workspace index should call.
+///
+/// Highlighting is find-references narrowed to one document, so it must pick
+/// the same target: a bare call a live `namespace import -force` shadows is
+/// not an occurrence of the local definition, and which definition it *does*
+/// reach can only be settled with whole-program export knowledge (issue #1116
+/// item 1).
+#[must_use]
+pub fn document_highlights_in_program(
+    source: &str,
+    dialect: &str,
+    line: u32,
+    character: u32,
+    analysis: &AnalysisResult,
+    resolution: crate::definition::CallResolution<'_>,
 ) -> Vec<(LspRange, HighlightKind)> {
     let line_index = LineIndex::new(source);
 
@@ -3442,18 +3462,22 @@ pub fn document_highlights(
         return Vec::new();
     };
 
-    if let Some(out) = class_highlights(source, &line_index, analysis, line, character, &word) {
+    if let Some(out) = class_highlights(
+        source,
+        &line_index,
+        analysis,
+        line,
+        character,
+        &word,
+        resolution,
+    ) {
         return out;
     }
 
     {
         let cursor_off = crate::definition::byte_offset_at(&line_index, source, line, character);
         if let Some((qname, proc_def)) = crate::definition::resolve_proc_target_at(
-            analysis,
-            source,
-            cursor_off,
-            &word,
-            crate::definition::CallResolution::document_only(),
+            analysis, source, cursor_off, &word, resolution,
         ) {
             let mut out = Vec::new();
             out.push((

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -346,8 +346,14 @@ fn invocation_references_via_wildcard_import(
         inv.range.start(),
         &analysis.namespace_overrides,
     );
-    crate::definition::import_chain_target(analysis, &call_ns, def_name, inv.range.start())
-        .is_some_and(|source_ns| source_ns.trim_start_matches("::") == target_ns)
+    crate::definition::import_chain_target(
+        analysis,
+        crate::definition::CallResolution::document_only(),
+        &call_ns,
+        def_name,
+        inv.range.start(),
+    )
+    .is_some_and(|source_ns| source_ns.trim_start_matches("::") == target_ns)
 }
 
 #[must_use]
@@ -706,7 +712,8 @@ fn caller_frame_references(
         analysis,
         source,
         dialect,
-        Some(tcl_registry::registry_for_dialect(dialect)),
+        crate::definition::CallResolution::document_only()
+            .with_registry(tcl_registry::registry_for_dialect(dialect)),
         byte_offset,
         name,
     );
@@ -726,7 +733,8 @@ fn caller_frame_references(
         analysis,
         source,
         dialect,
-        Some(tcl_registry::registry_for_dialect(dialect)),
+        crate::definition::CallResolution::document_only()
+            .with_registry(tcl_registry::registry_for_dialect(dialect)),
         byte_offset,
         name,
     )
@@ -781,7 +789,8 @@ fn variable_references(ctx: &RefCtx<'_>) -> Option<Vec<LspRange>> {
         analysis,
         source,
         dialect,
-        Some(tcl_registry::registry_for_dialect(dialect)),
+        crate::definition::CallResolution::document_only()
+            .with_registry(tcl_registry::registry_for_dialect(dialect)),
         byte_offset,
         &find_word_span_at_position(source, line, character)
             .map(|(w, _, _)| w)
@@ -868,8 +877,12 @@ fn class_references(ctx: &RefCtx<'_>, word: &str) -> Option<Vec<LspRange>> {
     // Declaration under the cursor, else namespace-aware resolution — never a
     // namespace-blind `c.name == word` scan (which from a call site could
     // surface an unrelated same-named class's reference set).
-    let (qname, class_def) =
-        crate::definition::resolve_class_target_at(analysis, cursor_off, word)?;
+    let (qname, class_def) = crate::definition::resolve_class_target_at(
+        analysis,
+        crate::definition::CallResolution::document_only(),
+        cursor_off,
+        word,
+    )?;
     let mut out = Vec::new();
     if include_declaration {
         out.push(span_to_range(source, line_index, class_def.name_span));
@@ -905,8 +918,13 @@ fn proc_references(ctx: &RefCtx<'_>, word: &str) -> Option<Vec<LspRange>> {
     // Declaration under the cursor, else C Tcl's namespace-aware call-site
     // resolution — never a namespace-blind `p.name == word` scan (which from a
     // call site could surface an unrelated same-named proc's reference set).
-    let (qname, proc_def) =
-        crate::definition::resolve_proc_target_at(analysis, source, cursor_off, word, None)?;
+    let (qname, proc_def) = crate::definition::resolve_proc_target_at(
+        analysis,
+        source,
+        cursor_off,
+        word,
+        crate::definition::CallResolution::document_only(),
+    )?;
     let mut out = Vec::new();
     if include_declaration {
         out.push(span_to_range(source, line_index, proc_def.name_span));
@@ -3287,7 +3305,12 @@ pub fn document_highlights(
         // Declaration-span hit, else the namespace-aware candidate
         // resolution — never a namespace-blind `c.name == word` first-hit
         // scan (the M1 wrong-symbol drift class).
-        let class_match = crate::definition::resolve_class_target_at(analysis, cursor_off, &word);
+        let class_match = crate::definition::resolve_class_target_at(
+            analysis,
+            crate::definition::CallResolution::document_only(),
+            cursor_off,
+            &word,
+        );
         if let Some((qname, class_def)) = class_match {
             let mut out = Vec::new();
             // Non-variable symbols (procs / classes / methods) highlight as
@@ -3309,9 +3332,13 @@ pub fn document_highlights(
 
     {
         let cursor_off = crate::definition::byte_offset_at(&line_index, source, line, character);
-        if let Some((qname, proc_def)) =
-            crate::definition::resolve_proc_target_at(analysis, source, cursor_off, &word, None)
-        {
+        if let Some((qname, proc_def)) = crate::definition::resolve_proc_target_at(
+            analysis,
+            source,
+            cursor_off,
+            &word,
+            crate::definition::CallResolution::document_only(),
+        ) {
             let mut out = Vec::new();
             out.push((
                 span_to_range(source, &line_index, proc_def.name_span),

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -187,6 +187,32 @@ pub fn prepare_rename(
     character: u32,
     analysis: &AnalysisResult,
 ) -> Option<PrepareRename> {
+    prepare_rename_in_program(
+        source,
+        line,
+        character,
+        analysis,
+        crate::definition::CallResolution::document_only(),
+    )
+}
+
+/// [`prepare_rename`] with the caller's whole-program export view attached —
+/// the entry point a host with a workspace index should call.
+///
+/// A `namespace import -force` whose covering `namespace export` lives in
+/// another file changes *which* definition a bare call site denotes, so a
+/// rename started from that call must retarget with it (issue #1116 item 1).
+/// When the reached definition is not in this document the resolver answers
+/// `None` and the rename abstains — the safe outcome, and far better than
+/// rewriting the unrelated local proc the shadow deleted.
+#[must_use]
+pub fn prepare_rename_in_program(
+    source: &str,
+    line: u32,
+    character: u32,
+    analysis: &AnalysisResult,
+    resolution: crate::definition::CallResolution<'_>,
+) -> Option<PrepareRename> {
     let line_index = LineIndex::new(source);
     // A namespace name is renameable (issue #1114), and the check must come
     // first: the word resolvers below would otherwise anchor prepare on a
@@ -250,25 +276,18 @@ pub fn prepare_rename(
     // (which could seed the rename with an arbitrary same-named proc).
     let (word, _start, _end) = find_word_span_at_position(source, line, character)?;
     let word_off = crate::definition::byte_offset_at(&line_index, source, line, character);
-    if let Some((_, proc_def)) = crate::definition::resolve_proc_target_at(
-        analysis,
-        source,
-        word_off,
-        &word,
-        crate::definition::CallResolution::document_only(),
-    ) {
+    if let Some((_, proc_def)) =
+        crate::definition::resolve_proc_target_at(analysis, source, word_off, &word, resolution)
+    {
         return Some(PrepareRename {
             range: span_to_range(source, &line_index, proc_def.name_span),
             placeholder: proc_def.name.clone(),
         });
     }
     // Class?  Same resolution shape against `all_classes`.
-    if let Some((_, class_def)) = crate::definition::resolve_class_target_at(
-        analysis,
-        crate::definition::CallResolution::document_only(),
-        word_off,
-        &word,
-    ) {
+    if let Some((_, class_def)) =
+        crate::definition::resolve_class_target_at(analysis, resolution, word_off, &word)
+    {
         return Some(PrepareRename {
             range: span_to_range(source, &line_index, class_def.name_span),
             placeholder: class_def.name.clone(),
@@ -401,6 +420,42 @@ pub fn rename_with_diagnosis(
     analysis: &AnalysisResult,
     registry: Option<&CommandRegistry>,
 ) -> Result<Vec<TextEdit>, crate::rename_safety::RenameRefusal> {
+    rename_in_program(
+        source,
+        dialect,
+        line,
+        character,
+        new_name,
+        analysis,
+        crate::definition::CallResolution {
+            registry,
+            program: None,
+        },
+    )
+}
+
+/// [`rename_with_diagnosis`] with the caller's whole-program export view
+/// attached — the entry point a host with a workspace index should call.
+///
+/// A `namespace import -force` whose covering `namespace export` lives in
+/// another file changes *which* definition a bare call site denotes, so a
+/// rename started from that call must retarget with it (issue #1116 item 1).
+/// When the reached definition is not in this document the resolver answers
+/// `None` and the rename abstains — the safe outcome, and far better than
+/// rewriting the unrelated local proc the shadow deleted.
+///
+/// `resolution` carries the registry and the oracle together, which also keeps
+/// this entry point at [`rename_with_diagnosis`]'s arity.
+pub fn rename_in_program(
+    source: &str,
+    dialect: &str,
+    line: u32,
+    character: u32,
+    new_name: &str,
+    analysis: &AnalysisResult,
+    resolution: crate::definition::CallResolution<'_>,
+) -> Result<Vec<TextEdit>, crate::rename_safety::RenameRefusal> {
+    let registry = resolution.registry;
     // Shape gate first — applies to every rename target.
     if !is_safe_symbol_name(new_name) {
         return Ok(Vec::new());
@@ -441,7 +496,7 @@ pub fn rename_with_diagnosis(
         def_byte,
         new_name,
         analysis,
-        registry,
+        resolution,
         &line_index,
     ) {
         return Ok(edits);
@@ -452,7 +507,7 @@ pub fn rename_with_diagnosis(
         def_byte,
         new_name,
         analysis,
-        registry,
+        resolution,
         &line_index,
     ) {
         return Ok(edits);
@@ -1249,25 +1304,18 @@ fn rename_proc(
     cursor_off: u32,
     new_name: &str,
     analysis: &AnalysisResult,
-    registry: Option<&CommandRegistry>,
+    resolution: crate::definition::CallResolution<'_>,
     line_index: &LineIndex,
 ) -> Option<Vec<TextEdit>> {
+    let registry = resolution.registry;
     // Resolve the target the same way go-to-definition does: the proc whose
     // declaration covers the cursor, else C Tcl's namespace-aware call-site
     // resolution — never a namespace-blind `p.name == word` scan, which let a
     // rename from a bareword call site pick an arbitrary same-named proc in
     // another namespace and rewrite the wrong definition (matches
     // `references::references`).
-    let (qname, proc_def) = crate::definition::resolve_proc_target_at(
-        analysis,
-        source,
-        cursor_off,
-        word,
-        crate::definition::CallResolution {
-            registry,
-            program: None,
-        },
-    )?;
+    let (qname, proc_def) =
+        crate::definition::resolve_proc_target_at(analysis, source, cursor_off, word, resolution)?;
     if let Some(registry) = registry
         && is_builtin_command_name(new_name, registry)
     {
@@ -1348,18 +1396,15 @@ fn rename_class(
     cursor_off: u32,
     new_name: &str,
     analysis: &AnalysisResult,
-    registry: Option<&CommandRegistry>,
+    resolution: crate::definition::CallResolution<'_>,
     line_index: &LineIndex,
 ) -> Option<Vec<TextEdit>> {
+    let registry = resolution.registry;
     // Declaration under the cursor, else namespace-aware resolution — never a
     // namespace-blind `c.name == word` scan (which from a call site could
     // rename the wrong same-named class in another namespace).
-    let (qname, class_def) = crate::definition::resolve_class_target_at(
-        analysis,
-        crate::definition::CallResolution::document_only(),
-        cursor_off,
-        word,
-    )?;
+    let (qname, class_def) =
+        crate::definition::resolve_class_target_at(analysis, resolution, cursor_off, word)?;
     if let Some(registry) = registry
         && is_builtin_command_name(new_name, registry)
     {

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -455,7 +455,6 @@ pub fn rename_in_program(
     analysis: &AnalysisResult,
     resolution: crate::definition::CallResolution<'_>,
 ) -> Result<Vec<TextEdit>, crate::rename_safety::RenameRefusal> {
-    let registry = resolution.registry;
     // Shape gate first — applies to every rename target.
     if !is_safe_symbol_name(new_name) {
         return Ok(Vec::new());

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -250,18 +250,25 @@ pub fn prepare_rename(
     // (which could seed the rename with an arbitrary same-named proc).
     let (word, _start, _end) = find_word_span_at_position(source, line, character)?;
     let word_off = crate::definition::byte_offset_at(&line_index, source, line, character);
-    if let Some((_, proc_def)) =
-        crate::definition::resolve_proc_target_at(analysis, source, word_off, &word, None)
-    {
+    if let Some((_, proc_def)) = crate::definition::resolve_proc_target_at(
+        analysis,
+        source,
+        word_off,
+        &word,
+        crate::definition::CallResolution::document_only(),
+    ) {
         return Some(PrepareRename {
             range: span_to_range(source, &line_index, proc_def.name_span),
             placeholder: proc_def.name.clone(),
         });
     }
     // Class?  Same resolution shape against `all_classes`.
-    if let Some((_, class_def)) =
-        crate::definition::resolve_class_target_at(analysis, word_off, &word)
-    {
+    if let Some((_, class_def)) = crate::definition::resolve_class_target_at(
+        analysis,
+        crate::definition::CallResolution::document_only(),
+        word_off,
+        &word,
+    ) {
         return Some(PrepareRename {
             range: span_to_range(source, &line_index, class_def.name_span),
             placeholder: class_def.name.clone(),
@@ -1251,8 +1258,16 @@ fn rename_proc(
     // rename from a bareword call site pick an arbitrary same-named proc in
     // another namespace and rewrite the wrong definition (matches
     // `references::references`).
-    let (qname, proc_def) =
-        crate::definition::resolve_proc_target_at(analysis, source, cursor_off, word, registry)?;
+    let (qname, proc_def) = crate::definition::resolve_proc_target_at(
+        analysis,
+        source,
+        cursor_off,
+        word,
+        crate::definition::CallResolution {
+            registry,
+            program: None,
+        },
+    )?;
     if let Some(registry) = registry
         && is_builtin_command_name(new_name, registry)
     {
@@ -1339,8 +1354,12 @@ fn rename_class(
     // Declaration under the cursor, else namespace-aware resolution — never a
     // namespace-blind `c.name == word` scan (which from a call site could
     // rename the wrong same-named class in another namespace).
-    let (qname, class_def) =
-        crate::definition::resolve_class_target_at(analysis, cursor_off, word)?;
+    let (qname, class_def) = crate::definition::resolve_class_target_at(
+        analysis,
+        crate::definition::CallResolution::document_only(),
+        cursor_off,
+        word,
+    )?;
     if let Some(registry) = registry
         && is_builtin_command_name(new_name, registry)
     {

--- a/rust/tcl-lsp-core/src/signature_help.rs
+++ b/rust/tcl-lsp-core/src/signature_help.rs
@@ -103,6 +103,38 @@ pub fn signature_help(
     analysis: &AnalysisResult,
     registry: Option<&CommandRegistry>,
 ) -> Option<SignatureHelp> {
+    signature_help_in_program(
+        source,
+        line,
+        character,
+        analysis,
+        crate::definition::CallResolution {
+            registry,
+            program: None,
+        },
+    )
+}
+
+/// [`signature_help`] with the caller's whole-program export view attached —
+/// the entry point a host with a workspace index should call.
+///
+/// The signature rendered is *the reached proc's*, so a `namespace import
+/// -force` whose covering `namespace export` lives in another file changes
+/// which parameter list is correct at this call (issue #1116 item 1).  Showing
+/// the shadowed local proc's signature would mis-describe the call that
+/// actually runs.
+///
+/// `resolution` carries the registry and the oracle together — the same pair
+/// [`crate::definition::resolve_called_proc`] consumes.
+#[must_use]
+pub fn signature_help_in_program(
+    source: &str,
+    line: u32,
+    character: u32,
+    analysis: &AnalysisResult,
+    resolution: crate::definition::CallResolution<'_>,
+) -> Option<SignatureHelp> {
+    let registry = resolution.registry;
     let (command, args, active_param) = command_context_with_args(source, line, character)?;
     // Resolve the command from the namespace the cursor sits in, the way C
     // Tcl's own command resolution would (caller namespace, then global), so a
@@ -123,10 +155,7 @@ pub fn signature_help(
         &namespace,
         &command,
         cursor_off,
-        crate::definition::CallResolution {
-            registry,
-            program: None,
-        },
+        resolution,
     ) {
         return Some(proc_signature_help(proc_def, active_param));
     }

--- a/rust/tcl-lsp-core/src/signature_help.rs
+++ b/rust/tcl-lsp-core/src/signature_help.rs
@@ -117,9 +117,17 @@ pub fn signature_help(
         cursor_off,
         &analysis.namespace_overrides,
     );
-    if let Some(proc_def) =
-        lookup_proc(analysis, source, &namespace, &command, cursor_off, registry)
-    {
+    if let Some(proc_def) = lookup_proc(
+        analysis,
+        source,
+        &namespace,
+        &command,
+        cursor_off,
+        crate::definition::CallResolution {
+            registry,
+            program: None,
+        },
+    ) {
         return Some(proc_signature_help(proc_def, active_param));
     }
     let registry = registry?;
@@ -320,11 +328,11 @@ fn lookup_proc<'a>(
     namespace: &str,
     name: &str,
     call_off: u32,
-    registry: Option<&CommandRegistry>,
+    ctx: crate::definition::CallResolution<'_>,
 ) -> Option<&'a ProcDef> {
-    if let Some(proc_def) = crate::definition::resolve_called_proc(
-        analysis, source, namespace, name, call_off, registry,
-    ) {
+    if let Some(proc_def) =
+        crate::definition::resolve_called_proc(analysis, source, namespace, name, call_off, ctx)
+    {
         return Some(proc_def);
     }
     // Alias resolution.  When the cursor's command isn't a visible proc, check
@@ -337,7 +345,7 @@ fn lookup_proc<'a>(
         namespace,
         &resolved_target,
         call_off,
-        registry,
+        ctx,
     )
 }
 

--- a/rust/tcl-lsp-core/src/signature_help.rs
+++ b/rust/tcl-lsp-core/src/signature_help.rs
@@ -150,12 +150,7 @@ pub fn signature_help_in_program(
         &analysis.namespace_overrides,
     );
     if let Some(proc_def) = lookup_proc(
-        analysis,
-        source,
-        &namespace,
-        &command,
-        cursor_off,
-        resolution,
+        analysis, source, &namespace, &command, cursor_off, resolution,
     ) {
         return Some(proc_signature_help(proc_def, active_param));
     }

--- a/rust/tcl-lsp-core/src/type_hierarchy.rs
+++ b/rust/tcl-lsp-core/src/type_hierarchy.rs
@@ -66,9 +66,12 @@ pub fn prepare(
     // namespace-blind name scan that could seed the hierarchy from a same-named
     // class in another namespace.
     let cursor_off = crate::definition::byte_offset_at(&line_index, source, line, character);
-    if let Some((_, class_def)) =
-        crate::definition::resolve_class_target_at(analysis, cursor_off, &word)
-    {
+    if let Some((_, class_def)) = crate::definition::resolve_class_target_at(
+        analysis,
+        crate::definition::CallResolution::document_only(),
+        cursor_off,
+        &word,
+    ) {
         return vec![item_for(class_def, source, &line_index)];
     }
     Vec::new()

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -4130,7 +4130,7 @@ fn exported_at_site<'e>(
 /// [`crate::namespace_import::NamespaceExportOracle`] the single-document tier
 /// can borrow (issue #1116 item 1).
 ///
-/// Owned rather than a view borrowing [`WorkspaceIndex`] because the servers's
+/// Owned rather than a view borrowing [`WorkspaceIndex`] because the server's
 /// pure-CPU providers run on a blocking worker with the index lock released:
 /// the snapshot is taken under the lock and moved into the worker. It is a
 /// [`Derived`] view, so a whole generation's requests share one build.

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -7836,4 +7836,200 @@ mod tests {
         index.remove_document("file:///a.tcl");
         assert!(index.package_prefers().next().is_none());
     }
+
+    // Both tiers on the two-file `namespace import -force` shadow
+    // (issue #1116 item 1).
+    //
+    // `MAIN` below is one document, byte-for-byte identical in every test of
+    // this group. What changes is the *rest of the program*, and with it the
+    // correct answer — which is exactly why the single-document tier needed a
+    // whole-program export oracle. Oracle transcript (tclsh 8.6.16 and 9.0.4,
+    // byte-identical), running `MAIN` from a loader that does or does not also
+    // source the `namespace export helper`:
+    //
+    //   with the export sourced first: call -> SRC    origin -> ::src::helper
+    //   with nothing exporting it:     call -> LOCAL  origin -> ::app::helper
+
+    /// The pinned two-file shape's main document.
+    const MAIN: &str = "namespace eval src {\n    proc helper {} { return SRC }\n    proc other {} { return O }\n    namespace export other\n}\nnamespace eval app {\n    proc helper {} { return LOCAL }\n}\nnamespace eval app {\n    namespace import -force ::src::*\n}\nnamespace eval app {\n    helper\n}\n";
+
+    /// What each tier says about the `helper` call at the end of [`MAIN`],
+    /// given the rest of the program.
+    ///
+    /// Returns `(in-document target, cross-document target)`, where a tier's
+    /// "target" is the qualified name the call reaches: the local definition
+    /// when the `-force` import bound nothing, the import's source when it
+    /// did, and `None` when the tier cannot say. The two are computed
+    /// independently — the single-document resolver over `MAIN`'s own analysis
+    /// plus the index's export oracle, and the workspace's own
+    /// [`WorkspaceIndex::resolve_wildcard_import`] — so agreeing is a real
+    /// result and not a tautology.
+    fn both_tiers_on_main(others: &[(&str, &AnalysisResult)]) -> (Option<String>, Option<String>) {
+        let main = analyse(MAIN);
+        let mut index = WorkspaceIndex::new();
+        index.add_document("file:///main.tcl", &main);
+        for (uri, analysis) in others {
+            index.add_document(uri, analysis);
+        }
+        let call = u32::try_from(MAIN.rfind("    helper\n").expect("call present") + 4)
+            .expect("tiny test source");
+        let candidates =
+            tcl_syntax::naming::command_resolution_candidates("::app", &[] as &[String], "helper");
+
+        let exports = index.export_snapshot();
+        let in_document = crate::definition::resolve_called_proc(
+            &main,
+            MAIN,
+            "::app",
+            "helper",
+            call,
+            crate::definition::CallResolution::document_only().in_program(
+                crate::definition::ProgramExports {
+                    uri: "file:///main.tcl",
+                    oracle: exports.as_ref(),
+                },
+            ),
+        )
+        .map(|p| p.qualified_name.clone());
+
+        // The cross-document tier answers the import question; when no import
+        // is live the call reaches whatever the workspace defines under the
+        // first candidate, which is the local proc.
+        let cross_document = index
+            .resolve_wildcard_import(
+                "helper",
+                &candidates,
+                CallSite {
+                    uri: "file:///main.tcl",
+                    at: call,
+                    enclosing_body: main.innermost_definition_body_span(call),
+                },
+            )
+            .or_else(|| {
+                candidates
+                    .iter()
+                    .find(|c| index.defines_command(c))
+                    .cloned()
+            });
+        (in_document, cross_document)
+    }
+
+    #[test]
+    fn both_tiers_shadow_when_another_file_holds_the_covering_export() {
+        // TP (CRITICAL) — the export that decides it lives in `exports.tcl`.
+        // Oracle: SRC / `::src::helper`.
+        let exports = analyse("namespace eval src {\n    namespace export helper\n}\n");
+        let (in_document, cross_document) =
+            both_tiers_on_main(&[("file:///exports.tcl", &exports)]);
+        assert_eq!(in_document.as_deref(), Some("::src::helper"));
+        assert_eq!(
+            in_document, cross_document,
+            "the two tiers must reach the same command",
+        );
+    }
+
+    #[test]
+    fn both_tiers_keep_the_local_when_the_whole_program_exports_nothing() {
+        // TN, byte-identical `MAIN` — nothing anywhere exports `helper`, so
+        // the `-force` import binds only `other` and the local definition
+        // survives. Oracle: LOCAL / `::app::helper`.
+        let unrelated = analyse("namespace eval other {\n    proc q {} {}\n}\n");
+        let (in_document, cross_document) =
+            both_tiers_on_main(&[("file:///unrelated.tcl", &unrelated)]);
+        assert_eq!(in_document.as_deref(), Some("::app::helper"));
+        assert_eq!(
+            in_document, cross_document,
+            "the two tiers must reach the same command",
+        );
+    }
+
+    #[test]
+    fn both_tiers_shadow_when_the_source_namespace_is_wholly_in_another_file() {
+        // TP — the third oracle shape: `::src`'s procs *and* its export are
+        // elsewhere, so this document sees only the `-force` import and the
+        // local proc it deletes. Oracle: SRC / `::src::helper`.
+        let main = analyse(WHOLLY_FOREIGN);
+        let lib = analyse(
+            "namespace eval src {\n    proc helper {} { return SRC }\n    namespace export helper\n}\n",
+        );
+        let mut index = WorkspaceIndex::new();
+        index.add_document("file:///main.tcl", &main);
+        index.add_document("file:///lib.tcl", &lib);
+        let call = u32::try_from(WHOLLY_FOREIGN.rfind("    helper\n").expect("call present") + 4)
+            .expect("tiny test source");
+        let candidates =
+            tcl_syntax::naming::command_resolution_candidates("::app", &[] as &[String], "helper");
+        let exports = index.export_snapshot();
+        // In-document: the source is in no local table, so the resolver cannot
+        // *name* the target — but it must refuse to answer with the local
+        // definition the import deleted, which is the abstention the shadow
+        // gate exists for.
+        let ctx = crate::definition::CallResolution::document_only().in_program(
+            crate::definition::ProgramExports {
+                uri: "file:///main.tcl",
+                oracle: exports.as_ref(),
+            },
+        );
+        assert!(crate::definition::forced_import_shadows_call(
+            &main,
+            ctx,
+            "helper",
+            &candidates,
+            call,
+        ));
+        assert!(
+            crate::definition::resolve_called_proc(
+                &main,
+                WHOLLY_FOREIGN,
+                "::app",
+                "helper",
+                call,
+                ctx
+            )
+            .is_none(),
+            "the deleted local definition must not be the answer",
+        );
+        // …and the cross-document tier supplies the name.
+        assert_eq!(
+            index.resolve_wildcard_import(
+                "helper",
+                &candidates,
+                CallSite {
+                    uri: "file:///main.tcl",
+                    at: call,
+                    enclosing_body: main.innermost_definition_body_span(call),
+                },
+            ),
+            Some("::src::helper".to_owned()),
+        );
+    }
+
+    /// The `-force` shape whose source namespace is wholly in another file.
+    const WHOLLY_FOREIGN: &str = "namespace eval app {\n    proc helper {} { return LOCAL }\n}\nnamespace eval app {\n    namespace import -force ::src::*\n}\nnamespace eval app {\n    helper\n}\n";
+
+    #[test]
+    fn the_export_snapshot_answers_unknown_for_a_namespace_no_file_declares() {
+        // The abstention, stated directly on the oracle: `::msgcat` is an
+        // installed package, in no indexed document. Silence about its exports
+        // is not evidence that it exports nothing — the same rule
+        // `live_command_links` already applies to exact imports.
+        use crate::namespace_import::NamespaceExportOracle as _;
+        let app = analyse("namespace eval app {\n    namespace import -force ::msgcat::*\n}\n");
+        let index = WorkspaceIndex::from_documents([("file:///app.tcl", &app)]);
+        let snapshot = index.export_snapshot();
+        let site = RunPoint {
+            uri: "file:///app.tcl",
+            at: 0,
+            enclosing_body: None,
+        };
+        assert_eq!(
+            snapshot.exported_at("::msgcat", "mc", site),
+            ExportVerdict::Unknown,
+        );
+        // …while a namespace the workspace *can* see gives a real negative.
+        assert_eq!(
+            snapshot.exported_at("::app", "mc", site),
+            ExportVerdict::NotExported,
+        );
+    }
 }

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -7843,7 +7843,7 @@ mod tests {
     // `MAIN` below is one document, byte-for-byte identical in every test of
     // this group. What changes is the *rest of the program*, and with it the
     // correct answer — which is exactly why the single-document tier needed a
-    // whole-program export oracle. Oracle transcript (tclsh 8.6.16 and 9.0.4,
+    // whole-program export oracle. Oracle transcript (tclsh 8.6.14 and 9.0.4,
     // byte-identical), running `MAIN` from a loader that does or does not also
     // source the `namespace export helper`:
     //

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -76,6 +76,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use crate::namespace_import::ExportVerdict;
 use crate::source_graph::RunPoint;
 use crate::workspace_symbols::{
     IndexedWorkspaceSymbol, WorkspaceSymbolKind, matches_query, namespace_of,
@@ -1515,6 +1516,9 @@ pub struct WorkspaceIndex {
     /// without link-following — see
     /// [`WorkspaceIndex::invocations_by_settled_target`].
     settled_invocations: [Derived<SettledTargets>; 2],
+    /// The whole-program export oracle the single-document tier borrows — see
+    /// [`WorkspaceIndex::export_snapshot`].
+    export_snapshot: Derived<NamespaceExportSnapshot>,
     /// The `source`-path → document-URI resolver, when the host has installed
     /// one — see [`WorkspaceIndex::set_source_resolver`].
     source_resolver: Option<SourceResolver>,
@@ -1727,6 +1731,47 @@ impl WorkspaceIndex {
         })
     }
 
+    /// The whole-program export oracle the *single-document* tier consults
+    /// when deciding whether a `namespace import -force` really deleted the
+    /// importing namespace's own command (issue #1116 item 1).
+    ///
+    /// One document cannot answer that on its own: the `namespace export` that
+    /// decides it may live in another file, and two programs whose single
+    /// document is byte-identical then disagree — the transcript is on
+    /// [`crate::namespace_import::NamespaceExportOracle`]. This is the
+    /// whole-program evidence that closes the gap, and nothing more: it
+    /// answers one question and may answer
+    /// [`ExportVerdict::Unknown`].
+    ///
+    /// A [`Derived`] view, so it is built at most once per
+    /// [`Self::generation`]; the returned `Arc` is owned, so a caller may hold
+    /// it after releasing the index lock (which is how the server hands it to
+    /// its blocking providers).
+    #[must_use]
+    pub fn export_snapshot(&self) -> Arc<NamespaceExportSnapshot> {
+        self.export_snapshot.get_or_build(|| {
+            let mut exports_by_ns: std::collections::HashMap<
+                String,
+                Vec<WorkspaceNamespaceExport>,
+            > = std::collections::HashMap::new();
+            for exp in self.namespace_exports() {
+                exports_by_ns
+                    .entry(exp.ns.trim_start_matches("::").to_owned())
+                    .or_default()
+                    .push(exp.clone());
+            }
+            NamespaceExportSnapshot {
+                exports_by_ns,
+                observable: self
+                    .observable_namespaces()
+                    .into_iter()
+                    .map(str::to_owned)
+                    .collect(),
+                order: self.run_order(),
+            }
+        })
+    }
+
     /// Install the host's literal-`source`-path → document-URI resolver, so
     /// the index can build the [`crate::source_graph::RunOrder`] the
     /// import-lifecycle gates rank cross-document events with (issue #1104
@@ -1759,6 +1804,8 @@ impl WorkspaceIndex {
     pub fn set_source_resolver(&mut self, resolve: SourceResolver) {
         self.source_resolver = Some(resolve);
         self.run_order = Derived::default();
+        // The export snapshot captures the order, so it goes with it.
+        self.export_snapshot = Derived::default();
     }
 
     /// The `source`-graph load order over this workspace's documents, built at
@@ -1798,6 +1845,7 @@ impl WorkspaceIndex {
         self.defined_names = <[Derived<HashSet<String>>; 2]>::default();
         self.command_link_map = Derived::default();
         self.settled_invocations = <[Derived<SettledTargets>; 2]>::default();
+        self.export_snapshot = Derived::default();
         self.run_order = Derived::default();
     }
 
@@ -4047,24 +4095,81 @@ impl<'a> WildcardImportIndex<'a> {
     /// function abstains toward continuing to resolve.
     fn exports_name_at(&self, ns: &str, name: &str, site: ImportSite<'_>) -> bool {
         self.exports_by_ns.get(ns).is_some_and(|exports| {
-            let mut events = exports
-                .iter()
-                .map(|e| crate::namespace_import::ExportEvent {
-                    pattern: e.pattern.as_str(),
-                    clears: e.clears,
-                    at: RunPoint {
-                        uri: e.uri.as_str(),
-                        at: e.at,
-                        enclosing_body: None,
-                    },
-                });
-            crate::namespace_import::exported_at_import_site(
-                &mut events,
-                name,
-                &self.order,
-                site.point(),
-            )
+            exported_at_site(exports.iter().copied(), name, &self.order, site.point())
         })
+    }
+}
+
+/// [`crate::namespace_import::exported_at_import_site`] over a namespace's
+/// indexed export rows — the one place `WorkspaceNamespaceExport` is turned
+/// into an [`crate::namespace_import::ExportEvent`].
+///
+/// Shared by the per-call wildcard walk ([`WildcardImportIndex::exports_name_at`])
+/// and the standalone [`NamespaceExportSnapshot`] the single-document tier
+/// borrows, so the two cannot answer the same question differently.
+fn exported_at_site<'e>(
+    exports: impl Iterator<Item = &'e WorkspaceNamespaceExport>,
+    name: &str,
+    order: &crate::source_graph::RunOrder,
+    site: RunPoint<'_>,
+) -> bool {
+    let mut events = exports.map(|e| crate::namespace_import::ExportEvent {
+        pattern: e.pattern.as_str(),
+        clears: e.clears,
+        at: RunPoint {
+            uri: e.uri.as_str(),
+            at: e.at,
+            enclosing_body: None,
+        },
+    });
+    crate::namespace_import::exported_at_import_site(&mut events, name, order, site)
+}
+
+/// The workspace's `namespace export` records, plus the run order and the
+/// observable-namespace set needed to read them — an **owned**, self-contained
+/// [`crate::namespace_import::NamespaceExportOracle`] the single-document tier
+/// can borrow (issue #1116 item 1).
+///
+/// Owned rather than a view borrowing [`WorkspaceIndex`] because the servers's
+/// pure-CPU providers run on a blocking worker with the index lock released:
+/// the snapshot is taken under the lock and moved into the worker. It is a
+/// [`Derived`] view, so a whole generation's requests share one build.
+///
+/// It holds *only* what the export question needs. Everything else about an
+/// import — the conflict rule, the alias lifecycle, chain following — stays
+/// where it already is; this is not a second cross-document resolver.
+#[derive(Debug, Default)]
+pub struct NamespaceExportSnapshot {
+    /// Export rows by exporting namespace, `::`-stripped so the two spellings
+    /// an import pattern and an export record may carry still meet.
+    exports_by_ns: std::collections::HashMap<String, Vec<WorkspaceNamespaceExport>>,
+    /// The `::`-stripped namespaces the workspace can say anything about — the
+    /// discriminator between [`ExportVerdict::NotExported`] and
+    /// [`ExportVerdict::Unknown`], and the same set
+    /// [`WorkspaceIndex::live_command_links`] gates its own abstention on.
+    observable: HashSet<String>,
+    /// The `source`-graph load order, so an export the graph proves runs
+    /// *after* the import is not retroactive.
+    order: Arc<crate::source_graph::RunOrder>,
+}
+
+impl crate::namespace_import::NamespaceExportOracle for NamespaceExportSnapshot {
+    fn exported_at(&self, source_ns: &str, name: &str, import_site: RunPoint<'_>) -> ExportVerdict {
+        let ns = source_ns.trim_start_matches("::");
+        if !self.observable.contains(ns) {
+            // The namespace lives somewhere the workspace cannot see — an
+            // installed package, a file outside the project. Silence is not
+            // evidence, exactly as in `live_command_links`.
+            return ExportVerdict::Unknown;
+        }
+        let exported = self.exports_by_ns.get(ns).is_some_and(|exports| {
+            exported_at_site(exports.iter(), name, &self.order, import_site)
+        });
+        if exported {
+            ExportVerdict::Exported
+        } else {
+            ExportVerdict::NotExported
+        }
     }
 }
 

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -3329,10 +3329,29 @@ impl WorkspaceIndex {
         links: Option<&std::collections::HashMap<String, String>>,
         wci: &WildcardImportIndex<'_>,
     ) -> Option<String> {
-        if let Some(winner) = inv
-            .resolution_candidates
-            .iter()
-            .find(|c| defined.contains(c.trim_start_matches("::")))
+        let call = CallSite {
+            uri: &inv.uri,
+            at: inv.range.start(),
+            enclosing_body: inv.enclosing_body,
+        };
+        // A live `namespace import -force` has *replaced* the importing
+        // namespace's own command of this name, so no candidate naming that
+        // command may settle the call — it reaches the import's source, which
+        // the wildcard tier below resolves (issue #1116 item 1). The same rule
+        // `definition::resolve_called_proc` applies in-document, so without it
+        // find-references files the call under the definition the import
+        // deleted while go-to-definition jumps to the source.
+        //
+        // Only in the link-following view, matching the rule below: a glob
+        // import introduces no fixed link, so the direct-only view rename
+        // relies on does not see it in either direction.
+        let forced_shadow = links.is_some()
+            && wci.forced_shadow_over_candidates(&inv.name, &inv.resolution_candidates, call);
+        if !forced_shadow
+            && let Some(winner) = inv
+                .resolution_candidates
+                .iter()
+                .find(|c| defined.contains(c.trim_start_matches("::")))
         {
             let winner = winner.trim_start_matches("::");
             return Some(
@@ -3348,17 +3367,8 @@ impl WorkspaceIndex {
         // on — a call spelling the local imported name is not text-rewritten
         // just because its ultimate source is renamed.
         links?;
-        self.resolve_wildcard_import_indexed(
-            &inv.name,
-            &inv.resolution_candidates,
-            CallSite {
-                uri: &inv.uri,
-                at: inv.range.start(),
-                enclosing_body: inv.enclosing_body,
-            },
-            wci,
-        )
-        .map(|resolved| resolved.trim_start_matches("::").to_owned())
+        self.resolve_wildcard_import_indexed(&inv.name, &inv.resolution_candidates, call, wci)
+            .map(|resolved| resolved.trim_start_matches("::").to_owned())
     }
 
     /// The command name-link map (`::`-stripped `linked → immediate target`)
@@ -3741,6 +3751,13 @@ struct WildcardImportIndex<'a> {
     /// ordered wherever the graph proves an order and unrankable everywhere
     /// else (issue #1104 item 3).
     order: Arc<crate::source_graph::RunOrder>,
+    /// The `::`-stripped namespaces this workspace can say anything about —
+    /// [`WorkspaceIndex::observable_namespaces`]. Only
+    /// [`Self::forced_shadow_at`] reads it, and only to abstain the way the
+    /// single-document tier does: a `-force` import of a namespace no indexed
+    /// file declares deletes the local command whether or not the export can
+    /// be proven here.
+    observable: HashSet<&'a str>,
 }
 
 impl<'a> WildcardImportIndex<'a> {
@@ -3810,7 +3827,61 @@ impl<'a> WildcardImportIndex<'a> {
             deletions_by_name,
             declarations_by_qname,
             order: index.run_order(),
+            observable: index.observable_namespaces(),
         }
+    }
+
+    /// Whether a live `namespace import -force` in `ns` has taken `name` away
+    /// from `ns`'s own command table by the time the call at `call` runs — the
+    /// cross-document twin of `definition::forced_import_shadows`.
+    ///
+    /// `-force` is the one import that outranks a command the importing
+    /// namespace already holds, so it is the one case where a *defined*
+    /// candidate must not settle a call ([`WorkspaceIndex::settle_invocation`]).
+    /// No conflict check: a forced import never conflicts, which is what
+    /// `-force` means.
+    ///
+    /// The export gate abstains toward the shadow for a source namespace no
+    /// indexed file declares — the same direction the single-document tier
+    /// takes and the same one [`WorkspaceIndex::live_command_links`] takes for
+    /// exact imports. Answering with a command the import may have deleted is
+    /// worse than answering nothing.
+    fn forced_shadow_at(&self, ns: &str, name: &str, call: CallSite<'_>) -> bool {
+        self.imports_by_ns.get(ns).is_some_and(|imports| {
+            imports.iter().any(|imp| {
+                imp.forced
+                    && tcl_syntax::glob::string_match(&imp.tail_pattern, name)
+                    && (!self
+                        .observable
+                        .contains(imp.source_ns.trim_start_matches("::"))
+                        || self.exports_name_at(&imp.source_ns, name, imp.site()))
+                    && self.alias_live_at(ns, &imp.source_ns, name, imp.site(), call)
+            })
+        })
+    }
+
+    /// [`Self::forced_shadow_at`] over a call's own candidate list, in Tcl's
+    /// resolution order — the shape [`WorkspaceIndex::settle_invocation`] has
+    /// in hand.
+    fn forced_shadow_over_candidates(
+        &self,
+        name: &str,
+        resolution_candidates: &[String],
+        call: CallSite<'_>,
+    ) -> bool {
+        if name.contains("::") {
+            return false;
+        }
+        resolution_candidates.iter().any(|cand| {
+            cand.rsplit_once("::").is_some_and(|(prefix, tail)| {
+                tail == name
+                    && self.forced_shadow_at(
+                        if prefix.is_empty() { "::" } else { prefix },
+                        name,
+                        call,
+                    )
+            })
+        })
     }
 
     /// Every removal event bearing on the alias `importing_ns` took from
@@ -8006,6 +8077,58 @@ mod tests {
 
     /// The `-force` shape whose source namespace is wholly in another file.
     const WHOLLY_FOREIGN: &str = "namespace eval app {\n    proc helper {} { return LOCAL }\n}\nnamespace eval app {\n    namespace import -force ::src::*\n}\nnamespace eval app {\n    helper\n}\n";
+
+    #[test]
+    fn the_settled_call_moves_to_the_import_source_when_the_shadow_is_live() {
+        // The same fact on the *settle* path find-references reads (issue
+        // #1116 item 1): a candidate naming the command a `-force` import
+        // deleted must not settle the call, or find-references files it under
+        // a definition go-to-definition no longer answers with.
+        let exports = analyse("namespace eval src {\n    namespace export helper\n}\n");
+        let main = analyse(MAIN);
+        let index = WorkspaceIndex::from_documents([
+            ("file:///main.tcl", &main),
+            ("file:///exports.tcl", &exports),
+        ]);
+        assert_eq!(
+            index
+                .linked_invocations_of("::src::helper", "file:///exports.tcl")
+                .len(),
+            1,
+            "the shadowed call is a reference to the import source",
+        );
+        assert!(
+            index
+                .linked_invocations_of("::app::helper", "file:///exports.tcl")
+                .is_empty(),
+            "…and not to the command the import deleted",
+        );
+    }
+
+    #[test]
+    fn the_settled_call_stays_local_when_the_program_exports_nothing() {
+        // TN, byte-identical `MAIN` — with nothing exporting `helper` the
+        // import binds nothing and the call still belongs to the local proc.
+        let unrelated = analyse("namespace eval other {\n    proc q {} {}\n}\n");
+        let main = analyse(MAIN);
+        let index = WorkspaceIndex::from_documents([
+            ("file:///main.tcl", &main),
+            ("file:///unrelated.tcl", &unrelated),
+        ]);
+        assert_eq!(
+            index
+                .linked_invocations_of("::app::helper", "file:///unrelated.tcl")
+                .len(),
+            1,
+            "the surviving local definition owns the call",
+        );
+        assert!(
+            index
+                .linked_invocations_of("::src::helper", "file:///unrelated.tcl")
+                .is_empty(),
+            "…and an import that bound nothing creates no reference",
+        );
+    }
 
     #[test]
     fn the_export_snapshot_answers_unknown_for_a_namespace_no_file_declares() {

--- a/rust/tcl-lsp-core/tests/force_import_shadow_consumers.rs
+++ b/rust/tcl-lsp-core/tests/force_import_shadow_consumers.rs
@@ -1,0 +1,474 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Every consumer of `definition::resolve_called_proc` must agree about a call
+//! a live `namespace import -force` shadows (issue #1116 item 1).
+//!
+//! The whole point of that item is that no rule reading only [`MAIN`] can
+//! decide it: both directions below hand the providers **byte-identical**
+//! source and differ only in what a *sibling* document declares. So every test
+//! is a pair — shadowed and not shadowed — over the one fixture, and a
+//! threading bug that drops the oracle collapses the pair rather than moving
+//! one side, which is why each assertion pins *both* answers.
+//!
+//! C-Tcl proof — tclsh 8.6.14 and tclsh 9.0.4, both agreeing:
+//!
+//! ```text
+//! # prepended: namespace eval src { namespace export helper }
+//! helper 1 2   =>  SRC/1/2     ;# -force replaced ::helper
+//! # prepended: namespace eval other { proc q {} { puts Q } }
+//! helper 1 2   =>  LOCAL       ;# the import bound nothing
+//! ```
+//!
+//! `::src::helper` takes `{alpha beta}` and `::helper` takes `{args}`, and
+//! their bodies print different text, so *which* proc a provider picked is
+//! visible in its output — parameter labels, signature text, the item detail,
+//! the inlined body — and not only in a span.
+//!
+//! The call sits at global scope deliberately. A `-force` import rewrites a
+//! bare name in the *importing* namespace, and `::` is the one importing
+//! namespace whose call sites the inlay-hint segmenter reaches (it walks
+//! top-level commands and does not descend into `proc` or `namespace eval`
+//! bodies), so this is the one shape that puts every threaded consumer on the
+//! same cursor.
+
+use tcl_compiler::analyser::{Analyser, AnalysisResult};
+use tcl_lsp_core::definition::{CallResolution, LspRange, ProgramExports};
+use tcl_lsp_core::workspace_index::{NamespaceExportSnapshot, WorkspaceIndex};
+use tcl_registry::CommandRegistry;
+
+/// The document every test resolves against — identical in both directions.
+const MAIN: &str = "namespace eval src {\n    proc helper {alpha beta} { puts \"SRC/$alpha/$beta\" }\n    proc other {} { puts O }\n    namespace export other\n}\nproc helper {args} { puts LOCAL }\nnamespace import -force ::src::*\nhelper 1 2\n";
+
+/// The sibling that makes the `-force` import bind `helper` — the export the
+/// importing document cannot see.
+const SIBLING_SHADOWS: &str = "namespace eval src {\n    namespace export helper\n}\n";
+
+/// The sibling that does not: nothing in the program exports `helper`, so the
+/// import binds only `other` and the local definition survives. Issue #1116's
+/// pinned true negative.
+const SIBLING_INERT: &str = "namespace eval other {\n    proc q {} { puts Q }\n}\n";
+
+const MAIN_URI: &str = "file:///main.tcl";
+
+fn analyse(source: &str) -> AnalysisResult {
+    let mut a = Analyser::new();
+    a.analyse(source, "tcl8.6").clone()
+}
+
+fn reg() -> &'static CommandRegistry {
+    tcl_registry::registry_for_dialect("tcl8.6")
+}
+
+/// Byte offset of the `helper` call head.
+fn call_offset() -> u32 {
+    u32::try_from(MAIN.rfind("helper 1 2").expect("call present")).expect("tiny test source")
+}
+
+/// Zero-based line of that call (it is the only command on its line).
+fn call_line() -> u32 {
+    u32::try_from(MAIN[..call_offset() as usize].matches('\n').count()).expect("tiny test source")
+}
+
+/// The whole document, as an inlay-hint / code-action range.
+const WHOLE_FILE: LspRange = LspRange {
+    start_line: 0,
+    start_character: 0,
+    end_line: 999,
+    end_character: 0,
+};
+
+/// `MAIN` plus one sibling, indexed, with the export snapshot the server hands
+/// its providers.
+fn snapshot(sibling: &str) -> (AnalysisResult, std::sync::Arc<NamespaceExportSnapshot>) {
+    let main = analyse(MAIN);
+    let other = analyse(sibling);
+    let mut index = WorkspaceIndex::new();
+    index.add_document(MAIN_URI, &main);
+    index.add_document("file:///sibling.tcl", &other);
+    let exports = index.export_snapshot();
+    (main, exports)
+}
+
+fn program(exports: &NamespaceExportSnapshot) -> ProgramExports<'_> {
+    ProgramExports {
+        uri: MAIN_URI,
+        oracle: exports,
+    }
+}
+
+/// The resolution context a workspace-backed host hands every provider.
+fn resolution(exports: &NamespaceExportSnapshot) -> CallResolution<'_> {
+    CallResolution {
+        registry: Some(reg()),
+        program: Some(program(exports)),
+    }
+}
+
+/// Run `probe` against both siblings, returning `(shadowed, unshadowed)`.
+fn both_directions<T>(probe: impl Fn(&AnalysisResult, &NamespaceExportSnapshot) -> T) -> (T, T) {
+    let (main_s, exports_s) = snapshot(SIBLING_SHADOWS);
+    let shadowed = probe(&main_s, &exports_s);
+    let (main_i, exports_i) = snapshot(SIBLING_INERT);
+    let unshadowed = probe(&main_i, &exports_i);
+    (shadowed, unshadowed)
+}
+
+// ---------------------------------------------------------------------------
+// Go-to-definition — the surface the fix started from, asserted here against
+// the same fixture so a regression shows up beside the providers threaded to
+// match it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn definition_follows_the_shadow() {
+    let (shadowed, unshadowed) = both_directions(|analysis, exports| {
+        tcl_lsp_core::definition::definition_with(
+            MAIN,
+            call_line(),
+            0,
+            analysis,
+            Some(program(exports)),
+        )
+        .iter()
+        .map(|r| r.start_line)
+        .collect::<Vec<_>>()
+    });
+    let src_line = u32::try_from(
+        MAIN[..MAIN
+            .find("proc helper {alpha beta}")
+            .expect("src proc present")]
+            .matches('\n')
+            .count(),
+    )
+    .expect("tiny");
+    let local_line = u32::try_from(
+        MAIN[..MAIN.find("proc helper {args}").expect("local proc present")]
+            .matches('\n')
+            .count(),
+    )
+    .expect("tiny");
+    assert_eq!(shadowed, vec![src_line], "the import replaced ::helper");
+    assert_eq!(
+        unshadowed,
+        vec![local_line],
+        "the import bound nothing, so ::helper survives"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Inlay hints — the parameter labels name the reached proc's parameters.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inlay_hints_label_the_reached_proc_not_the_shadowed_local() {
+    let (shadowed, unshadowed) = both_directions(|analysis, exports| {
+        tcl_lsp_core::inlay_hints::inlay_hints_in_program(
+            MAIN,
+            "tcl8.6",
+            WHOLE_FILE,
+            Some(analysis),
+            resolution(exports),
+            false,
+            true,
+        )
+        .into_iter()
+        .map(|h| h.label)
+        .collect::<Vec<_>>()
+    });
+
+    // TP — the call runs `::src::helper {alpha beta}`, so those are the
+    // parameter names that belong on the arguments `1` and `2`.
+    assert!(
+        shadowed.iter().any(|l| l.contains("alpha")) && shadowed.iter().any(|l| l.contains("beta")),
+        "a live -force shadow must label the imported proc's parameters: {shadowed:?}"
+    );
+    // TN — the import bound nothing, so the variadic local `{args}` is reached
+    // and contributes no positional labels.
+    assert!(
+        !unshadowed
+            .iter()
+            .any(|l| l.contains("alpha") || l.contains("beta")),
+        "with no covering export the local proc is reached: {unshadowed:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Signature help — the rendered parameter list is the reached proc's.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn signature_help_describes_the_reached_proc_not_the_shadowed_local() {
+    let (shadowed, unshadowed) = both_directions(|analysis, exports| {
+        tcl_lsp_core::signature_help::signature_help_in_program(
+            MAIN,
+            call_line(),
+            8,
+            analysis,
+            resolution(exports),
+        )
+        .map(|h| h.signatures[0].label.clone())
+        .expect("signature help on a resolvable call")
+    });
+
+    assert!(
+        shadowed.contains("alpha") && shadowed.contains("beta"),
+        "a live -force shadow must render `::src::helper`'s signature: {shadowed:?}"
+    );
+    assert!(
+        unshadowed.contains("args") && !unshadowed.contains("alpha"),
+        "with no covering export the local `helper {{args}}` is correct: {unshadowed:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Call hierarchy — `prepare` roots the graph at a call resolution.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn call_hierarchy_prepare_roots_at_the_reached_proc() {
+    let (shadowed, unshadowed) = both_directions(|analysis, exports| {
+        tcl_lsp_core::call_hierarchy::prepare_in_program(
+            MAIN,
+            call_line(),
+            0,
+            analysis,
+            resolution(exports),
+        )
+        .into_iter()
+        .map(|i| i.detail.unwrap_or_default())
+        .collect::<Vec<_>>()
+    });
+
+    // The two procs differ in arity, which the item detail carries — so this
+    // pins *which* definition the hierarchy is rooted at, not merely that one
+    // was found.
+    assert_eq!(
+        shadowed,
+        vec!["(2 params)".to_owned()],
+        "a live -force shadow roots the hierarchy at `::src::helper {{alpha beta}}`"
+    );
+    assert_eq!(
+        unshadowed,
+        vec!["(1 params)".to_owned()],
+        "with no covering export it roots at the local `helper {{args}}`"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Inline-proc refactor — substituting the wrong body is a behaviour change.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inline_proc_inlines_the_reached_body_not_the_shadowed_local() {
+    let (shadowed, unshadowed) = both_directions(|analysis, exports| {
+        tcl_lsp_core::refactor::inline_proc_in_program(
+            MAIN,
+            call_offset(),
+            analysis,
+            resolution(exports),
+        )
+        .map(|r| {
+            r.edits
+                .iter()
+                .map(|e| e.new_text.clone())
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .expect("inline-proc offered on a resolvable call")
+    });
+
+    // TP — inlining the local body over a call that runs `::src::helper`
+    // would silently change what the program does.
+    assert!(
+        shadowed.contains("SRC/") && !shadowed.contains("LOCAL"),
+        "a live -force shadow must inline the imported body: {shadowed:?}"
+    );
+    // TN — the local proc really is what runs, so its body is the right one.
+    assert!(
+        unshadowed.contains("LOCAL") && !unshadowed.contains("SRC/"),
+        "with no covering export the local body is the right substitution: {unshadowed:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Code actions — the same refactor reached through the provider entry point,
+// which is the path the server actually takes.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn code_actions_offer_the_reached_body_for_inlining() {
+    let cursor = LspRange {
+        start_line: call_line(),
+        start_character: 0,
+        end_line: call_line(),
+        end_character: 0,
+    };
+    let (shadowed, unshadowed) = both_directions(|analysis, exports| {
+        tcl_lsp_core::code_actions::code_actions_in_program(
+            MAIN,
+            cursor,
+            Some(analysis),
+            Some(program(exports)),
+        )
+        .into_iter()
+        .filter(|a| a.title.starts_with("Inline proc"))
+        .flat_map(|a| a.edits.into_iter().map(|e| e.new_text))
+        .collect::<Vec<_>>()
+        .join("\n")
+    });
+
+    assert!(
+        shadowed.contains("SRC/") && !shadowed.contains("LOCAL"),
+        "a live -force shadow must offer the imported body: {shadowed:?}"
+    );
+    assert!(
+        unshadowed.contains("LOCAL") && !unshadowed.contains("SRC/"),
+        "with no covering export the local body is offered: {unshadowed:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The document-only tier must be untouched: a host with no workspace index
+// (the `tcl` CLI, a single-document test) keeps exactly its old behaviour.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn without_a_workspace_view_every_provider_keeps_the_document_only_answer() {
+    let analysis = analyse(MAIN);
+    let doc_only = CallResolution::document_only().with_registry(reg());
+
+    // `MAIN` holds an export record for `::src` (of `other`) but none for
+    // `helper`, which the document-only rule reads as "not exported" — so the
+    // import binds nothing and the local definition stands.
+    let sig = tcl_lsp_core::signature_help::signature_help_in_program(
+        MAIN,
+        call_line(),
+        8,
+        &analysis,
+        doc_only,
+    )
+    .expect("document-only signature help");
+    assert!(
+        sig.signatures[0].label.contains("args"),
+        "document-only resolution keeps the local proc: {:?}",
+        sig.signatures[0].label
+    );
+
+    let hints: Vec<String> = tcl_lsp_core::inlay_hints::inlay_hints_in_program(
+        MAIN,
+        "tcl8.6",
+        WHOLE_FILE,
+        Some(&analysis),
+        doc_only,
+        false,
+        true,
+    )
+    .into_iter()
+    .map(|h| h.label)
+    .collect();
+    assert!(
+        !hints.iter().any(|l| l.contains("alpha")),
+        "document-only resolution labels no imported parameters: {hints:?}"
+    );
+
+    assert_eq!(
+        tcl_lsp_core::call_hierarchy::prepare_in_program(MAIN, call_line(), 0, &analysis, doc_only)
+            .into_iter()
+            .map(|i| i.detail.unwrap_or_default())
+            .collect::<Vec<_>>(),
+        vec!["(1 params)".to_owned()],
+        "document-only resolution roots the hierarchy at the local proc"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The legacy entry points must be exactly their `_in_program` counterparts
+// with no view attached — otherwise the delegation quietly changed behaviour
+// for every existing caller (the `tcl` CLI and the single-document tests).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_legacy_entry_points_still_equal_the_document_only_program_view() {
+    let analysis = analyse(MAIN);
+    let doc_only = CallResolution::document_only().with_registry(reg());
+
+    assert_eq!(
+        tcl_lsp_core::signature_help::signature_help(MAIN, call_line(), 8, &analysis, Some(reg())),
+        tcl_lsp_core::signature_help::signature_help_in_program(
+            MAIN,
+            call_line(),
+            8,
+            &analysis,
+            doc_only
+        ),
+        "signature_help delegation changed nothing"
+    );
+
+    assert_eq!(
+        tcl_lsp_core::inlay_hints::inlay_hints(
+            MAIN,
+            "tcl8.6",
+            WHOLE_FILE,
+            Some(&analysis),
+            Some(reg()),
+            true,
+            true,
+        ),
+        tcl_lsp_core::inlay_hints::inlay_hints_in_program(
+            MAIN,
+            "tcl8.6",
+            WHOLE_FILE,
+            Some(&analysis),
+            doc_only,
+            true,
+            true,
+        ),
+        "inlay_hints delegation changed nothing"
+    );
+
+    assert_eq!(
+        tcl_lsp_core::call_hierarchy::prepare(MAIN, call_line(), 0, &analysis),
+        tcl_lsp_core::call_hierarchy::prepare_in_program(
+            MAIN,
+            call_line(),
+            0,
+            &analysis,
+            CallResolution::document_only()
+        ),
+        "call_hierarchy delegation changed nothing"
+    );
+
+    let cursor = LspRange {
+        start_line: call_line(),
+        start_character: 0,
+        end_line: call_line(),
+        end_character: 0,
+    };
+    assert_eq!(
+        tcl_lsp_core::code_actions::code_actions(MAIN, cursor, Some(&analysis))
+            .into_iter()
+            .map(|a| a.title)
+            .collect::<Vec<_>>(),
+        tcl_lsp_core::code_actions::code_actions_in_program(MAIN, cursor, Some(&analysis), None)
+            .into_iter()
+            .map(|a| a.title)
+            .collect::<Vec<_>>(),
+        "code_actions delegation changed nothing"
+    );
+}

--- a/rust/tcl-lsp-core/tests/force_import_shadow_consumers.rs
+++ b/rust/tcl-lsp-core/tests/force_import_shadow_consumers.rs
@@ -472,3 +472,87 @@ fn the_legacy_entry_points_still_equal_the_document_only_program_view() {
         "code_actions delegation changed nothing"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Rename — retargeting matters most here, because the edit is destructive.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rename_retargets_with_the_shadow() {
+    // Renaming from a `-force`-shadowed call must rewrite the definition that
+    // call *reaches*. Rewriting the local one the import deleted would rename
+    // an unrelated proc while leaving the call pointing where it always did.
+    let (shadowed, unshadowed) = both_directions(|analysis, exports| {
+        tcl_lsp_core::rename::rename_in_program(
+            MAIN,
+            "tcl8.6",
+            call_line(),
+            0,
+            "renamed",
+            analysis,
+            resolution(exports),
+        )
+        .expect("no refusal on a resolvable call")
+        .into_iter()
+        .map(|e| e.range.start_line)
+        .collect::<Vec<_>>()
+    });
+
+    let src_line = u32::try_from(
+        MAIN[..MAIN
+            .find("proc helper {alpha beta}")
+            .expect("src proc present")]
+            .matches('\n')
+            .count(),
+    )
+    .expect("tiny");
+    let local_line = u32::try_from(
+        MAIN[..MAIN.find("proc helper {args}").expect("local proc present")]
+            .matches('\n')
+            .count(),
+    )
+    .expect("tiny");
+
+    assert!(
+        shadowed.contains(&src_line) && !shadowed.contains(&local_line),
+        "a live -force shadow retargets the rename to `::src::helper`: {shadowed:?}"
+    );
+    assert!(
+        unshadowed.contains(&local_line) && !unshadowed.contains(&src_line),
+        "with no covering export the local definition is renamed: {unshadowed:?}"
+    );
+}
+
+#[test]
+fn prepare_rename_offers_the_reached_definition() {
+    let (shadowed, unshadowed) = both_directions(|analysis, exports| {
+        tcl_lsp_core::rename::prepare_rename_in_program(
+            MAIN,
+            call_line(),
+            0,
+            analysis,
+            resolution(exports),
+        )
+        .map(|p| p.range.start_line)
+    });
+    let src_line = u32::try_from(
+        MAIN[..MAIN
+            .find("proc helper {alpha beta}")
+            .expect("src proc present")]
+            .matches('\n')
+            .count(),
+    )
+    .expect("tiny");
+    let local_line = u32::try_from(
+        MAIN[..MAIN.find("proc helper {args}").expect("local proc present")]
+            .matches('\n')
+            .count(),
+    )
+    .expect("tiny");
+    assert_eq!(shadowed, Some(src_line), "prepare follows the shadow");
+    assert_eq!(
+        unshadowed,
+        Some(local_line),
+        "prepare keeps the local when nothing is imported"
+    );
+}

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -7033,14 +7033,25 @@ impl Backend {
         let text = doc.text.clone();
         let dialect = doc.dialect.clone();
         let analysis_for_worker = analysis.clone();
+        // Which definition a bare call is a reference *to* can turn on a
+        // `namespace export` in another file (issue #1116 item 1), so the
+        // single-document pass gets the same whole-program export view
+        // go-to-definition uses — or the two contradict each other on one
+        // cursor.
+        let exports = self.export_snapshot().await;
+        let uri_key = uri.as_str().to_owned();
         let ranges = tokio::task::spawn_blocking(move || {
-            core_references::references(
+            core_references::references_in_program(
                 &text,
                 &dialect,
                 position.line,
                 position.character,
                 &analysis_for_worker,
                 include_declaration,
+                Some(core_definition::ProgramExports {
+                    uri: &uri_key,
+                    oracle: exports.as_ref(),
+                }),
             )
         })
         .await

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -7718,6 +7718,65 @@ impl Backend {
     /// `Some(Err(..))` is a **refusal** carrying its own reason; `Some(Ok(..))`
     /// is a complete namespace-variable edit set.  Split out of
     /// [`Backend::rename`] so that handler stays inside the line budget.
+    /// The in-document rename tiers, run on the blocking pool with the
+    /// request's whole-program export view attached.
+    ///
+    /// `rename_in_program`, not `rename`: the in-document tiers carry their
+    /// own safety gate for the cursor positions the workspace gate cannot
+    /// resolve — an untracked `[$other X]` dispatch, an `export … X …`
+    /// bareword — and a refusal from them must reach the editor as an error
+    /// with its reason, exactly like the workspace gate's.  Flattening it to
+    /// an empty edit set would present the one hazard the gate exists to stop
+    /// as "nothing renameable here" and let the cross-document tier build
+    /// edits for it (issue #923 idx 79, verification pass).
+    ///
+    /// The export snapshot is what lets a rename started from a
+    /// `-force`-shadowed call retarget to the definition that call actually
+    /// reaches (issue #1116 item 1).
+    ///
+    /// Extracted from [`Self::rename`] to keep that entry point inside the
+    /// line budget.
+    async fn in_document_rename_edits(
+        &self,
+        uri: &Uri,
+        doc: &DocumentState,
+        analysis: &AnalysisResult,
+        registry: &'static tcl_registry::CommandRegistry,
+        pos: Position,
+        new_name: &str,
+    ) -> jsonrpc::Result<Vec<core_rename::TextEdit>> {
+        let text = doc.text.clone();
+        let dialect = doc.dialect.clone();
+        let analysis_for_worker = analysis.clone();
+        let new_name_worker = new_name.to_owned();
+        let exports = self.export_snapshot().await;
+        let uri_key = uri.as_str().to_owned();
+        tokio::task::spawn_blocking(move || {
+            core_rename::rename_in_program(
+                &text,
+                &dialect,
+                pos.line,
+                pos.character,
+                &new_name_worker,
+                &analysis_for_worker,
+                core_definition::CallResolution {
+                    registry: Some(registry),
+                    program: Some(core_definition::ProgramExports {
+                        uri: &uri_key,
+                        oracle: exports.as_ref(),
+                    }),
+                },
+            )
+        })
+        .await
+        .map_err(|err| jsonrpc::Error {
+            code: jsonrpc::ErrorCode::InternalError,
+            message: format!("rename worker panicked: {err}").into(),
+            data: None,
+        })?
+        .map_err(|refusal| rename_refusal_error(&refusal))
+    }
+
     async fn gated_rename_tiers(
         &self,
         uri: &Uri,
@@ -14806,46 +14865,9 @@ impl LanguageServer for Backend {
                 change_annotations: None,
             }));
         }
-        let text = doc.text.clone();
-        let dialect = doc.dialect.clone();
-        let analysis_for_worker = analysis.clone();
-        let new_name_worker = new_name.clone();
-        let registry_worker = registry;
-        // `rename_with_diagnosis`, not `rename`: the in-document tiers carry
-        // their own safety gate for the cursor positions the workspace gate
-        // above cannot resolve — an untracked `[$other X]` dispatch, an
-        // `export … X …` bareword — and a refusal from them must reach the
-        // editor as an error with its reason, exactly like the workspace
-        // gate's.  Flattening it to an empty edit set would present the one
-        // hazard the gate exists to stop as "nothing renameable here" and let
-        // the cross-document tier below build edits for it (issue #923 idx
-        // 79, verification pass).
-        let exports = self.export_snapshot().await;
-        let uri_key = uri.as_str().to_owned();
-        let edits = tokio::task::spawn_blocking(move || {
-            core_rename::rename_in_program(
-                &text,
-                &dialect,
-                pos.line,
-                pos.character,
-                &new_name_worker,
-                &analysis_for_worker,
-                core_definition::CallResolution {
-                    registry: Some(registry_worker),
-                    program: Some(core_definition::ProgramExports {
-                        uri: &uri_key,
-                        oracle: exports.as_ref(),
-                    }),
-                },
-            )
-        })
-        .await
-        .map_err(|err| jsonrpc::Error {
-            code: jsonrpc::ErrorCode::InternalError,
-            message: format!("rename worker panicked: {err}").into(),
-            data: None,
-        })?
-        .map_err(|refusal| rename_refusal_error(&refusal))?;
+        let edits = self
+            .in_document_rename_edits(&uri, &doc, &analysis, registry, pos, &new_name)
+            .await?;
         let mut changes: std::collections::HashMap<Uri, Vec<TextEdit>> =
             std::collections::HashMap::new();
         // An empty in-document result means the rename was *rejected*

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -14712,8 +14712,24 @@ impl LanguageServer for Backend {
             .await;
         let text = doc.text.clone();
         let analysis_for_worker = analysis.clone();
+        // A rename started from a `-force`-shadowed call must offer the
+        // definition that call reaches, not the local one the import deleted
+        // (issue #1116 item 1) — the same view definition uses.
+        let exports = self.export_snapshot().await;
+        let uri_key = uri.as_str().to_owned();
         let result = tokio::task::spawn_blocking(move || {
-            core_rename::prepare_rename(&text, pos.line, pos.character, &analysis_for_worker)
+            core_rename::prepare_rename_in_program(
+                &text,
+                pos.line,
+                pos.character,
+                &analysis_for_worker,
+                core_definition::CallResolution::document_only().in_program(
+                    core_definition::ProgramExports {
+                        uri: &uri_key,
+                        oracle: exports.as_ref(),
+                    },
+                ),
+            )
         })
         .await
         .map_err(|err| jsonrpc::Error {
@@ -14804,15 +14820,23 @@ impl LanguageServer for Backend {
         // hazard the gate exists to stop as "nothing renameable here" and let
         // the cross-document tier below build edits for it (issue #923 idx
         // 79, verification pass).
+        let exports = self.export_snapshot().await;
+        let uri_key = uri.as_str().to_owned();
         let edits = tokio::task::spawn_blocking(move || {
-            core_rename::rename_with_diagnosis(
+            core_rename::rename_in_program(
                 &text,
                 &dialect,
                 pos.line,
                 pos.character,
                 &new_name_worker,
                 &analysis_for_worker,
-                Some(registry_worker),
+                core_definition::CallResolution {
+                    registry: Some(registry_worker),
+                    program: Some(core_definition::ProgramExports {
+                        uri: &uri_key,
+                        oracle: exports.as_ref(),
+                    }),
+                },
             )
         })
         .await

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -8835,8 +8835,21 @@ impl Backend {
             let dialect = dialect.to_owned();
             let item = item.clone();
             let analysis = analysis.clone();
+            let exports = self.export_snapshot().await;
+            let uri_key = current_uri.as_str().to_owned();
             tokio::task::spawn_blocking(move || {
-                core_call_hierarchy::unresolved_outgoing_calls(&source, &dialect, &item, &analysis)
+                core_call_hierarchy::unresolved_outgoing_calls_in_program(
+                    &source,
+                    &dialect,
+                    &item,
+                    &analysis,
+                    core_definition::CallResolution::document_only().in_program(
+                        core_definition::ProgramExports {
+                            uri: &uri_key,
+                            oracle: exports.as_ref(),
+                        },
+                    ),
+                )
             })
             .await
             .unwrap_or_default()
@@ -13186,8 +13199,23 @@ impl LanguageServer for Backend {
         let analysis = self
             .analysis_for(&uri, doc.text.clone(), doc.dialect.clone())
             .await;
+        // A call edge is a call resolution, so the hierarchy needs the same
+        // export view definition uses (issue #1116 item 1).
+        let exports = self.export_snapshot().await;
+        let uri_key = uri.as_str().to_owned();
         let items = tokio::task::spawn_blocking(move || {
-            core_call_hierarchy::prepare(&doc.text, pos.line, pos.character, &analysis)
+            core_call_hierarchy::prepare_in_program(
+                &doc.text,
+                pos.line,
+                pos.character,
+                &analysis,
+                core_definition::CallResolution::document_only().in_program(
+                    core_definition::ProgramExports {
+                        uri: &uri_key,
+                        oracle: exports.as_ref(),
+                    },
+                ),
+            )
         })
         .await
         .map_err(|err| jsonrpc::Error {
@@ -13253,12 +13281,20 @@ impl LanguageServer for Backend {
         let doc_dialect = doc.dialect.clone();
         let local_item = core_item.clone();
         let local_analysis = analysis.clone();
+        let exports = self.export_snapshot().await;
+        let uri_key = uri.as_str().to_owned();
         let local = tokio::task::spawn_blocking(move || {
-            core_call_hierarchy::incoming_calls(
+            core_call_hierarchy::incoming_calls_in_program(
                 &doc_text,
                 &doc_dialect,
                 &local_item,
                 &local_analysis,
+                core_definition::CallResolution::document_only().in_program(
+                    core_definition::ProgramExports {
+                        uri: &uri_key,
+                        oracle: exports.as_ref(),
+                    },
+                ),
             )
         })
         .await
@@ -13332,12 +13368,20 @@ impl LanguageServer for Backend {
             .await;
         let local_uri = uri.clone();
         let local_analysis = analysis.clone();
+        let exports = self.export_snapshot().await;
+        let uri_key = uri.as_str().to_owned();
         let outgoing = tokio::task::spawn_blocking(move || {
-            core_call_hierarchy::outgoing_calls(
+            core_call_hierarchy::outgoing_calls_in_program(
                 &doc.text,
                 &doc.dialect,
                 &core_item,
                 &local_analysis,
+                core_definition::CallResolution::document_only().in_program(
+                    core_definition::ProgramExports {
+                        uri: &uri_key,
+                        oracle: exports.as_ref(),
+                    },
+                ),
             )
         })
         .await
@@ -14116,13 +14160,25 @@ impl LanguageServer for Backend {
         // (`inlayParameterHints`).  When the analyser surfaces an empty
         // all_procs map (no user procs in the document), the provider still
         // returns built-in hints from the registry.
+        // The parameter labels name the reached proc's parameters, so the
+        // hint provider needs the same whole-program export view definition
+        // and hover use — a `-force` shadow changes which proc that is
+        // (issue #1116 item 1).
+        let exports = self.export_snapshot().await;
+        let uri_key = uri.as_str().to_owned();
         let hints = tokio::task::spawn_blocking(move || {
-            core_inlay_hints::inlay_hints(
+            core_inlay_hints::inlay_hints_in_program(
                 &doc.text,
                 &doc.dialect,
                 range,
                 Some(&analysis),
-                Some(registry),
+                core_definition::CallResolution {
+                    registry: Some(registry),
+                    program: Some(core_definition::ProgramExports {
+                        uri: &uri_key,
+                        oracle: exports.as_ref(),
+                    }),
+                },
                 type_hints,
                 parameter_hints,
             )
@@ -14360,18 +14416,34 @@ impl LanguageServer for Backend {
         // / `package require` / `# noqa` / extracted `set` inserted into a
         // CRLF or old-Mac document keeps that document's terminators.
         let line_ending = self.resolved_edit_line_ending(&uri, doc.raw()).await;
+        // The inline-proc refactor substitutes the reached proc's body, so
+        // it needs the same export view definition uses (issue #1116 item 1).
+        let exports = self.export_snapshot().await;
+        let uri_key = uri.as_str().to_owned();
         let actions = tokio::task::spawn_blocking(move || {
-            let mut actions = core_code_actions::code_actions(&doc.text, range, Some(&analysis));
+            let program = core_definition::ProgramExports {
+                uri: &uri_key,
+                oracle: exports.as_ref(),
+            };
+            let mut actions = core_code_actions::code_actions_in_program(
+                &doc.text,
+                range,
+                Some(&analysis),
+                Some(program),
+            );
             // The fuzzy package-suggestion path needs both the analysis (to
             // prove the cursor is on an unresolved *command head* rather than
             // on a comment, a string, or a data word) and the request's own
             // diagnostics (the editor may be showing a W123 this analysis has
             // not re-emitted).  Passing neither is what let it fire anywhere
             // an identifier-shaped word appeared — issue #1191.
-            actions.extend(core_code_actions::package_require_actions(
+            actions.extend(core_code_actions::package_require_actions_in_program(
                 &doc.text,
                 range,
-                registry,
+                core_definition::CallResolution {
+                    registry: Some(registry),
+                    program: Some(program),
+                },
                 Some(&analysis),
                 &context_diags,
             ));
@@ -14918,13 +14990,24 @@ impl LanguageServer for Backend {
         let analysis = self
             .analysis_for(&uri, doc.text.clone(), doc.dialect.clone())
             .await;
+        // Same whole-program view as hover: the signature rendered is the
+        // reached proc's parameter list, which a `-force` shadow changes
+        // (issue #1116 item 1).
+        let exports = self.export_snapshot().await;
+        let uri_key = uri.as_str().to_owned();
         let result = tokio::task::spawn_blocking(move || {
-            core_sig::signature_help(
+            core_sig::signature_help_in_program(
                 &doc.text,
                 pos.line,
                 pos.character,
                 &analysis,
-                Some(registry),
+                core_definition::CallResolution {
+                    registry: Some(registry),
+                    program: Some(core_definition::ProgramExports {
+                        uri: &uri_key,
+                        oracle: exports.as_ref(),
+                    }),
+                },
             )
         })
         .await

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -5666,6 +5666,17 @@ impl Backend {
         }
     }
 
+    /// The workspace's `namespace export` records, as the whole-program
+    /// oracle the single-document providers consult (issue #1116 item 1).
+    ///
+    /// Taken under the index lock and returned owned, so it can be moved into
+    /// the `spawn_blocking` worker that runs the provider with the lock
+    /// released. It is a derived view of the index, built at most once per
+    /// index generation, so calling this per request costs an `Arc` clone.
+    async fn export_snapshot(&self) -> Arc<core_workspace_index::NamespaceExportSnapshot> {
+        self.workspace_index.read().await.export_snapshot()
+    }
+
     /// Shared helper for the goto-definition family — runs the
     /// pure-CPU `tcl_lsp_core::definition::definition` provider
     /// off the LSP event loop and returns the matched ranges.
@@ -5698,8 +5709,24 @@ impl Backend {
         }
         let text = doc.text.clone();
         let analysis_worker = Arc::clone(&analysis);
+        // The whole-program export view the in-document tier needs to decide
+        // whether a `namespace import -force` really deleted this file's own
+        // command of the name (issue #1116 item 1).  Snapshotted under the
+        // index lock and moved into the worker, which runs with the lock
+        // released.
+        let exports = self.export_snapshot().await;
+        let uri_key = uri.as_str().to_owned();
         let in_doc = tokio::task::spawn_blocking(move || {
-            core_definition::definition(&text, pos.line, pos.character, &analysis_worker)
+            core_definition::definition_with(
+                &text,
+                pos.line,
+                pos.character,
+                &analysis_worker,
+                Some(core_definition::ProgramExports {
+                    uri: &uri_key,
+                    oracle: exports.as_ref(),
+                }),
+            )
         })
         .await
         .map_err(|err| jsonrpc::Error {
@@ -6676,8 +6703,15 @@ impl Backend {
             // which the wildcard-import tier below resolves (issue #1103).
             // Applied here because this is a separate resolver from
             // `resolve_called_proc`, which already applies the same rule.
+            let exports = index.export_snapshot();
             let forced_shadow = core_definition::forced_import_shadows_call(
                 analysis,
+                core_definition::CallResolution::document_only().in_program(
+                    core_definition::ProgramExports {
+                        uri: uri.as_str(),
+                        oracle: exports.as_ref(),
+                    },
+                ),
                 &inv.name,
                 &inv.resolution_candidates,
                 offset_u32,
@@ -14938,14 +14972,20 @@ impl LanguageServer for Backend {
         }
         let text = doc.text.clone();
         let analysis_worker = Arc::clone(&analysis);
+        let exports = self.export_snapshot().await;
+        let uri_key = uri.as_str().to_owned();
         let result = tokio::task::spawn_blocking(move || {
-            core_hover::hover_with_profile(
+            core_hover::hover_in_program(
                 &text,
                 pos.line,
                 pos.character,
                 &analysis_worker,
                 Some(registry),
                 hover_profile,
+                Some(core_definition::ProgramExports {
+                    uri: &uri_key,
+                    oracle: exports.as_ref(),
+                }),
             )
         })
         .await

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -13138,17 +13138,29 @@ impl LanguageServer for Backend {
         let analysis = self
             .analysis_for(&uri, doc.text.clone(), doc.dialect.clone())
             .await;
+        // Highlighting is find-references narrowed to one document, so it
+        // takes the same whole-program export view (issue #1116 item 1) —
+        // otherwise a `-force`-shadowed call highlights as an occurrence of a
+        // definition go-to-definition refuses to open.
+        let exports = self.export_snapshot().await;
+        let uri_key = uri.as_str().to_owned();
         let entries = tokio::task::spawn_blocking(move || {
             // The kinded entry
             // point tags variable defining spans as `Write` and
             // their reads as `Read`; command-invocation heads
             // stay `Text`.
-            core_references::document_highlights(
+            core_references::document_highlights_in_program(
                 &doc.text,
                 &doc.dialect,
                 pos.line,
                 pos.character,
                 &analysis,
+                core_definition::CallResolution::document_only().in_program(
+                    core_definition::ProgramExports {
+                        uri: &uri_key,
+                        oracle: exports.as_ref(),
+                    },
+                ),
             )
         })
         .await

--- a/rust/tcl-lsp-server/tests/e2e/definition.rs
+++ b/rust/tcl-lsp-server/tests/e2e/definition.rs
@@ -983,3 +983,120 @@ fn a_computed_source_path_keeps_the_pre_graph_abstention_end_to_end() {
     );
     assert_eq!(locs[0].uri, mod_uri);
 }
+
+// Issue #1116 item 1 — the in-document `-force` shadow needs whole-program
+// export knowledge.
+//
+// `PARTLY_OBSERVABLE_MAIN` below is one document, byte-for-byte identical in
+// both tests of this pair. `::src` is *partly* observable in it: its procs and
+// one of its exports (`other`) are right there, while whether it also exports
+// `helper` is decided in another file. Oracle (tclsh 8.6.16 and 9.0.4,
+// byte-identical), loading this document with and without a sibling file
+// holding `namespace eval ::src {namespace export helper}`:
+//
+//   with it:     call -> SRC     origin -> ::src::helper
+//   without it:  call -> LOCAL   origin -> ::app::helper
+//
+// No rule reading only this document can separate those, which is why the
+// single-document resolver now takes a whole-program export oracle.
+//
+//  line 0  namespace eval src {
+//  line 1      proc helper {a b} { return SRC }
+//  line 2      proc other {} { return O }
+//  line 3      namespace export other
+//  line 4  }
+//  line 5  namespace eval app {
+//  line 6      proc helper {} { return LOCAL }
+//  line 7  }
+//  line 8  namespace eval app {
+//  line 9      namespace import -force ::src::*
+//  line 10 }
+//  line 11 namespace eval app {
+//  line 12     helper
+//  line 13 }
+const PARTLY_OBSERVABLE_MAIN: &str = "namespace eval src {\n    proc helper {a b} { return SRC }\n    proc other {} { return O }\n    namespace export other\n}\nnamespace eval app {\n    proc helper {} { return LOCAL }\n}\nnamespace eval app {\n    namespace import -force ::src::*\n}\nnamespace eval app {\n    helper\n}\n";
+
+#[test]
+fn a_forced_import_shadows_when_another_file_exports_the_name_end_to_end() {
+    // TP (CRITICAL) — with `::src`'s `namespace export helper` in a sibling
+    // file the `-force` import really did delete `::app::helper`, so the call
+    // reaches `::src::helper` (line 1), not the local one (line 6).
+    let mut lsp = Lsp::tcl();
+    let exports_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &exports_uri,
+        "namespace eval src {\n    namespace export helper\n}\n",
+    );
+    let main_uri = unique_uri("tcl");
+    lsp.open_ready(&main_uri, PARTLY_OBSERVABLE_MAIN);
+    let locs = locations(&lsp.definition(&main_uri, 12, 4));
+    assert_eq!(locs.len(), 1, "{locs:?}");
+    assert_eq!(locs[0].uri, main_uri);
+    assert_eq!(
+        start_line(&locs[0]),
+        1,
+        "the `-force` import replaced the local `helper`: {locs:?}"
+    );
+    // Hover reads the same resolution, so it must name the same proc — the
+    // parameter lists differ precisely so the two are distinguishable.
+    let hover = hover_text(&lsp.hover(&main_uri, 12, 4));
+    assert!(
+        hover.contains('a') && hover.contains('b'),
+        "hover must describe `::src::helper {{a b}}`: {hover:?}"
+    );
+}
+
+#[test]
+fn a_forced_import_of_an_unexported_name_keeps_the_local_end_to_end() {
+    // TN, byte-identical `main.tcl` — nothing in the program exports
+    // `helper`, so the `-force` import binds only `other` and the local
+    // definition (line 6) survives. The pinned true negative: this is the
+    // case the document-only rule got right and must keep getting right.
+    let mut lsp = Lsp::tcl();
+    let unrelated_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &unrelated_uri,
+        "namespace eval other {\n    proc q {} { return Q }\n}\n",
+    );
+    let main_uri = unique_uri("tcl");
+    lsp.open_ready(&main_uri, PARTLY_OBSERVABLE_MAIN);
+    let locs = locations(&lsp.definition(&main_uri, 12, 4));
+    assert_eq!(locs.len(), 1, "{locs:?}");
+    assert_eq!(locs[0].uri, main_uri);
+    assert_eq!(
+        start_line(&locs[0]),
+        6,
+        "an import that binds nothing leaves the local definition: {locs:?}"
+    );
+    let hover = hover_text(&lsp.hover(&main_uri, 12, 4));
+    assert!(
+        !hover.contains("a b"),
+        "hover must describe the local `helper {{}}`: {hover:?}"
+    );
+}
+
+#[test]
+fn a_forced_import_from_a_wholly_foreign_namespace_shadows_end_to_end() {
+    // TP — the third oracle shape: `::src`'s proc *and* its export are in
+    // another file, so this document holds only the `-force` import and the
+    // local proc it deletes. Oracle: SRC / `::src::helper`. Go-to-definition
+    // must leave this file rather than answer the deleted local definition.
+    let mut lsp = Lsp::tcl();
+    let lib_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &lib_uri,
+        "namespace eval src {\n    proc helper {} { return SRC }\n    namespace export helper\n}\n",
+    );
+    let main_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &main_uri,
+        "namespace eval app {\n    proc helper {} { return LOCAL }\n}\nnamespace eval app {\n    namespace import -force ::src::*\n}\nnamespace eval app {\n    helper\n}\n",
+    );
+    let locs = locations(&lsp.definition(&main_uri, 7, 4));
+    assert_eq!(locs.len(), 1, "{locs:?}");
+    assert_eq!(
+        locs[0].uri, lib_uri,
+        "the deleted local definition must not be the answer: {locs:?}"
+    );
+    assert_eq!(start_line(&locs[0]), 1);
+}

--- a/rust/tcl-lsp-server/tests/e2e/definition.rs
+++ b/rust/tcl-lsp-server/tests/e2e/definition.rs
@@ -990,7 +990,7 @@ fn a_computed_source_path_keeps_the_pre_graph_abstention_end_to_end() {
 // `PARTLY_OBSERVABLE_MAIN` below is one document, byte-for-byte identical in
 // both tests of this pair. `::src` is *partly* observable in it: its procs and
 // one of its exports (`other`) are right there, while whether it also exports
-// `helper` is decided in another file. Oracle (tclsh 8.6.16 and 9.0.4,
+// `helper` is decided in another file. Oracle (tclsh 8.6.14 and 9.0.4,
 // byte-identical), loading this document with and without a sibling file
 // holding `namespace eval ::src {namespace export helper}`:
 //

--- a/rust/tcl-lsp-server/tests/e2e/definition.rs
+++ b/rust/tcl-lsp-server/tests/e2e/definition.rs
@@ -1100,3 +1100,151 @@ fn a_forced_import_from_a_wholly_foreign_namespace_shadows_end_to_end() {
     );
     assert_eq!(start_line(&locs[0]), 1);
 }
+
+// ---------------------------------------------------------------------------
+// Issue #1116 item 1 — every provider the export oracle was threaded through,
+// end to end over the packaged server.
+//
+// `SHADOW_MAIN` is byte-identical in both directions; only the sibling
+// document differs, so these pin the server's *wiring* (does each provider
+// actually receive `export_snapshot()`?) rather than the core resolver, which
+// `tcl-lsp-core/tests/force_import_shadow_consumers.rs` covers.
+//
+// C-Tcl proof (tclsh 8.6.14 and tclsh 9.0.4 agreeing): with the sibling's
+// `namespace export helper` present, `helper 1 2` prints `SRC/1/2`; without
+// it, `LOCAL`.  The call is at global scope because that is the one importing
+// namespace whose call sites the inlay-hint segmenter reaches.
+// ---------------------------------------------------------------------------
+
+//  line 0  namespace eval src {
+//  line 1      proc helper {alpha beta} { puts "SRC/$alpha/$beta" }
+//  line 2      proc other {} { puts O }
+//  line 3      namespace export other
+//  line 4  }
+//  line 5  proc helper {args} { puts LOCAL }
+//  line 6  namespace import -force ::src::*
+//  line 7  helper 1 2
+const SHADOW_MAIN: &str = "namespace eval src {\n    proc helper {alpha beta} { puts \"SRC/$alpha/$beta\" }\n    proc other {} { puts O }\n    namespace export other\n}\nproc helper {args} { puts LOCAL }\nnamespace import -force ::src::*\nhelper 1 2\n";
+
+const SHADOW_SIBLING: &str = "namespace eval src {\n    namespace export helper\n}\n";
+const INERT_SIBLING: &str = "namespace eval other {\n    proc q {} { puts Q }\n}\n";
+
+/// Open `SHADOW_MAIN` alongside `sibling` and return the ready server plus the
+/// main document's URI.
+fn shadow_workspace(sibling: &str) -> (Lsp, String) {
+    shadow_workspace_on(Lsp::tcl(), sibling)
+}
+
+/// The same two-document workspace on a caller-supplied server — inlay hints
+/// are gated off by default, so that test needs `Lsp::inlay()`.
+fn shadow_workspace_on(mut lsp: Lsp, sibling: &str) -> (Lsp, String) {
+    lsp.open_ready(&unique_uri("tcl"), sibling);
+    let main_uri = unique_uri("tcl");
+    lsp.open_ready(&main_uri, SHADOW_MAIN);
+    (lsp, main_uri)
+}
+
+#[test]
+fn the_server_hands_definition_and_hover_the_same_shadow_answer() {
+    // TP — the sibling's export means `-force` really deleted `::helper`, so
+    // the call reaches `::src::helper` on line 1, not the local on line 5.
+    let (mut lsp, uri) = shadow_workspace(SHADOW_SIBLING);
+    let locs = locations(&lsp.definition(&uri, 7, 0));
+    assert_eq!(locs.len(), 1, "{locs:?}");
+    assert_eq!(start_line(&locs[0]), 1, "the import replaced ::helper");
+    let hover = hover_text(&lsp.hover(&uri, 7, 0));
+    assert!(
+        hover.contains("alpha") && hover.contains("beta"),
+        "hover must describe `::src::helper {{alpha beta}}`: {hover:?}"
+    );
+
+    // TN — byte-identical document, inert sibling: the local survives.
+    let (mut lsp, uri) = shadow_workspace(INERT_SIBLING);
+    let locs = locations(&lsp.definition(&uri, 7, 0));
+    assert_eq!(locs.len(), 1, "{locs:?}");
+    assert_eq!(start_line(&locs[0]), 5, "the import bound nothing");
+    let hover = hover_text(&lsp.hover(&uri, 7, 0));
+    assert!(
+        !hover.contains("alpha"),
+        "hover must describe the local `helper {{args}}`: {hover:?}"
+    );
+}
+
+#[test]
+fn the_server_hands_signature_help_the_shadow_answer() {
+    let (mut lsp, uri) = shadow_workspace(SHADOW_SIBLING);
+    let sig = serde_json::to_string(&lsp.signature_help(&uri, 7, 8)).unwrap_or_default();
+    assert!(
+        sig.contains("alpha") && sig.contains("beta"),
+        "a live -force shadow must render `::src::helper`'s signature: {sig}"
+    );
+
+    let (mut lsp, uri) = shadow_workspace(INERT_SIBLING);
+    let sig = serde_json::to_string(&lsp.signature_help(&uri, 7, 8)).unwrap_or_default();
+    assert!(
+        !sig.contains("alpha") && sig.contains("args"),
+        "with no covering export the local signature is correct: {sig}"
+    );
+}
+
+#[test]
+fn the_server_hands_inlay_hints_the_shadow_answer() {
+    let (mut lsp, uri) = shadow_workspace_on(Lsp::inlay(), SHADOW_SIBLING);
+    let hints = serde_json::to_string(&lsp.inlay_hints(&uri, (7, 0), (8, 0))).unwrap_or_default();
+    assert!(
+        hints.contains("alpha") && hints.contains("beta"),
+        "a live -force shadow must label the imported proc's params: {hints}"
+    );
+
+    let (mut lsp, uri) = shadow_workspace_on(Lsp::inlay(), INERT_SIBLING);
+    let hints = serde_json::to_string(&lsp.inlay_hints(&uri, (7, 0), (8, 0))).unwrap_or_default();
+    assert!(
+        !hints.contains("alpha"),
+        "with no covering export the variadic local proc is reached: {hints}"
+    );
+}
+
+#[test]
+fn the_server_hands_call_hierarchy_the_shadow_answer() {
+    // The two candidates differ in arity, which the item `detail` carries, so
+    // this pins *which* definition the hierarchy is rooted at.
+    let (mut lsp, uri) = shadow_workspace(SHADOW_SIBLING);
+    let items = serde_json::to_string(&lsp.prepare_call_hierarchy(&uri, 7, 0)).unwrap_or_default();
+    assert!(
+        items.contains("2 params"),
+        "a live -force shadow roots the hierarchy at `::src::helper`: {items}"
+    );
+
+    let (mut lsp, uri) = shadow_workspace(INERT_SIBLING);
+    let items = serde_json::to_string(&lsp.prepare_call_hierarchy(&uri, 7, 0)).unwrap_or_default();
+    assert!(
+        items.contains("1 params"),
+        "with no covering export it roots at the local `helper {{args}}`: {items}"
+    );
+}
+
+#[test]
+fn the_server_hands_code_actions_the_shadow_answer() {
+    // Inlining the wrong body is a behaviour change, not a refactor: the two
+    // bodies print different text, so the offered edit names the winner.
+    let range = serde_json::json!({
+        "start": { "line": 7, "character": 0 },
+        "end":   { "line": 7, "character": 0 },
+    });
+    let (mut lsp, uri) = shadow_workspace(SHADOW_SIBLING);
+    let actions =
+        serde_json::to_string(&lsp.code_actions(&uri, range.clone(), serde_json::json!([])))
+            .unwrap_or_default();
+    assert!(
+        actions.contains("SRC/") && !actions.contains("LOCAL"),
+        "a live -force shadow must offer the imported body for inlining: {actions}"
+    );
+
+    let (mut lsp, uri) = shadow_workspace(INERT_SIBLING);
+    let actions = serde_json::to_string(&lsp.code_actions(&uri, range, serde_json::json!([])))
+        .unwrap_or_default();
+    assert!(
+        actions.contains("LOCAL") && !actions.contains("SRC/"),
+        "with no covering export the local body is offered: {actions}"
+    );
+}

--- a/rust/tcl-lsp-server/tests/e2e/references.rs
+++ b/rust/tcl-lsp-server/tests/e2e/references.rs
@@ -684,3 +684,78 @@ fn references_do_not_reach_the_indirect_site_when_the_head_is_renamed() {
         "a renamed fold head must not manufacture a reference: {lines:?}"
     );
 }
+
+// Issue #1116 item 1 — find-references over the two-file `-force` shadow.
+//
+// The importing document is byte-identical in both tests; only the presence of
+// `namespace eval ::src {namespace export helper}` in a sibling file differs,
+// and with it which proc the bare `helper` call is a reference *to* (oracle
+// tclsh 8.6.16 / 9.0.4 — the transcript is on the matching definition tests).
+//
+//  line 0  namespace eval src {
+//  line 1      proc helper {a b} { return SRC }
+//  line 2      proc other {} { return O }
+//  line 3      namespace export other
+//  line 4  }
+//  line 5  namespace eval app {
+//  line 6      proc helper {} { return LOCAL }
+//  line 7  }
+//  line 8  namespace eval app {
+//  line 9      namespace import -force ::src::*
+//  line 10 }
+//  line 11 namespace eval app {
+//  line 12     helper
+//  line 13 }
+const FORCED_SHADOW_MAIN: &str = "namespace eval src {\n    proc helper {a b} { return SRC }\n    proc other {} { return O }\n    namespace export other\n}\nnamespace eval app {\n    proc helper {} { return LOCAL }\n}\nnamespace eval app {\n    namespace import -force ::src::*\n}\nnamespace eval app {\n    helper\n}\n";
+
+#[test]
+fn the_shadowed_call_references_the_import_source_when_another_file_exports_it() {
+    // TP — with the covering export in a sibling file the call on line 12 is a
+    // reference to `::src::helper` (line 1) and **not** to the local
+    // `::app::helper` (line 6), which the `-force` import deleted.
+    let mut lsp = Lsp::tcl();
+    let exports_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &exports_uri,
+        "namespace eval src {\n    namespace export helper\n}\n",
+    );
+    let main_uri = unique_uri("tcl");
+    lsp.open_ready(&main_uri, FORCED_SHADOW_MAIN);
+    // From the source declaration: the shadowed call is one of its references.
+    let from_src = start_lines(&lsp.references(&main_uri, 1, 9, false));
+    assert!(
+        from_src.contains(&12),
+        "the `-force`d call must reference the import source: {from_src:?}"
+    );
+    // From the deleted local declaration: it must not claim the call.
+    let from_local = start_lines(&lsp.references(&main_uri, 6, 9, false));
+    assert!(
+        !from_local.contains(&12),
+        "a command the import deleted has no call sites: {from_local:?}"
+    );
+}
+
+#[test]
+fn the_unshadowed_call_references_the_local_proc_when_nothing_exports_it() {
+    // TN, byte-identical `main.tcl` — nothing exports `helper`, the import
+    // binds only `other`, and the call on line 12 belongs to the local
+    // `::app::helper` on line 6.
+    let mut lsp = Lsp::tcl();
+    let unrelated_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &unrelated_uri,
+        "namespace eval other {\n    proc q {} { return Q }\n}\n",
+    );
+    let main_uri = unique_uri("tcl");
+    lsp.open_ready(&main_uri, FORCED_SHADOW_MAIN);
+    let from_local = start_lines(&lsp.references(&main_uri, 6, 9, false));
+    assert!(
+        from_local.contains(&12),
+        "the surviving local definition owns the call: {from_local:?}"
+    );
+    let from_src = start_lines(&lsp.references(&main_uri, 1, 9, false));
+    assert!(
+        !from_src.contains(&12),
+        "an import that bound nothing creates no reference: {from_src:?}"
+    );
+}

--- a/rust/tcl-lsp-server/tests/e2e/references.rs
+++ b/rust/tcl-lsp-server/tests/e2e/references.rs
@@ -690,7 +690,7 @@ fn references_do_not_reach_the_indirect_site_when_the_head_is_renamed() {
 // The importing document is byte-identical in both tests; only the presence of
 // `namespace eval ::src {namespace export helper}` in a sibling file differs,
 // and with it which proc the bare `helper` call is a reference *to* (oracle
-// tclsh 8.6.16 / 9.0.4 — the transcript is on the matching definition tests).
+// tclsh 8.6.14 / 9.0.4 — the transcript is on the matching definition tests).
 //
 //  line 0  namespace eval src {
 //  line 1      proc helper {a b} { return SRC }


### PR DESCRIPTION
Closes #1116.

This is item 1, the last open residual on that issue. Items 2, 3 and 7 were already fixed before this work; item 6 and the `source`-graph run order landed in #1272; item 5's abstention is pinned; item 4 is a deliberate documented note (modelling the *uncaught* import failure would make navigation delete definitions from an already-broken program, and the caught case needs no model since "installed nothing, everything else ran" is already correct).

## The problem

The in-document `namespace import -force` shadow cannot be decided in-document: the false positive and its pinned true negative have **byte-identical single-document inputs**, differing only in whether *another* file declares the export. It needs a whole-program export oracle threaded through `resolve_called_proc`.

## What existed, and what did not

The oracle infrastructure was already built — `CallResolution` / `ProgramExports`, `NamespaceExportOracle` / `ExportVerdict`, `WorkspaceIndex::export_snapshot`, and the three-valued in-document gate — and threaded through **go-to-definition, hover and find-references** plus the cross-document settle tier.

Everything else still resolved with `document_only()`. That was established by grepping every call site rather than assuming the threading was complete:

| Consumer | Was | Now |
|---|---|---|
| inlay hints | `program: None` | threaded |
| signature help | `program: None` | threaded |
| call hierarchy (prepare / incoming / outgoing / unresolved-outgoing) | `document_only()` ×4 | threaded |
| code actions → inline-proc | `document_only()` | threaded |
| inline-proc | `document_only()` | threaded |
| caller-frame (from definition) | built a **fresh** `document_only()`, discarding its caller's view | threaded via `DefCtx` |
| caller-frame (from references, 3 sites) | same leak | threaded via `RefCtx.resolution` |
| references' own **target** resolution | resolved the target document-only while filtering spans *with* the oracle — disagreed with itself | threaded |
| document highlights | document-only end to end | threaded |
| code lens | document-only counts against a threaded peek | builds the view from the `WorkspaceIndex` it already receives |
| **rename** / prepare-rename | document-only | threaded |

The references case is the sharpest: one provider using two different resolution views within a single query, so its target and its spans could disagree about the same fact.

## Deliberately not threaded

`implementation.rs` and `type_hierarchy.rs`. Their only resolver is `resolve_class_target_at`, which **never calls `forced_import_shadows`** — it uses the context solely for non-`-force` wildcard *class* imports, so it cannot produce an item-1 disagreement. Threading them would newly resolve cross-file wildcard class imports: a real but separate pre-existing gap needing its own oracle work and tests, and not something to smuggle in here.

`package_require_actions` is threaded for consistency but is documented as not shadow-reachable: its gate admits only package-qualified heads, and `-force` rewrites bare names.

## Oracle ground truth (tclsh 8.6.14 and 9.0.4, agreeing)

A sibling exporting the name makes `-force` replace the local definition; with no export the import binds nothing and the local wins.

**One correction the oracle forced:** a TclOO method body resolves bare commands **globally**, not in the class namespace — `namespace current` inside a method is `::oo::ObjNN`. So call hierarchy's two class-method resolve sites are threaded, but the shadow is *not observable* through them, and asserting one there would have pinned behaviour the oracle contradicts. Similarly, the inlay-hint segmenter only walks top-level commands, so its fixture places the call at global scope.

## Tests

`force_import_shadow_consumers.rs` — 10 tests over a byte-identical main document with two different siblings, asserting **which** proc won (arity and body text differ) rather than merely that something resolved: definition, inlay hints, signature help, call-hierarchy prepare, inline-proc, code actions, rename, prepare-rename, plus a document-only-tier regression guard and a legacy-entry-point equivalence guard.

Every directional test was **mutation-checked** by dropping the oracle at its call site and confirming the test fails.

Five new e2e tests drive the packaged server over JSON-RPC, pinning the wiring itself — that each provider actually receives `export_snapshot()`.

## Gates

`cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` passes with **zero `#[allow]` added** — two lints fixed in the code (`question_mark` via `?`, and `too_many_lines` on `LanguageServer::rename` by extracting `in_document_rename_edits`), with widened entry points taking `CallResolution` in place of the bare registry to keep argument counts down; `cargo check --workspace --all-targets` clean; `cargo test -p tcl-lsp-core` **2925 passed, 0 failed**; `cargo test -p tcl-lsp-server` **1709 passed, 0 failed** including 1328 e2e.

Rebased onto current `rust`: `git diff --diff-filter=D --name-only origin/rust HEAD` is empty, and #1273's rename gate plus #1272's source-graph work are confirmed intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_