### PR TITLE
TclOO cluster: cross-file metaclass class index; MethodDef params_computed (#1019, #1276, #1277)

### DIFF
--- a/README.md
+++ b/README.md
@@ -898,6 +898,34 @@ private variable and method visibility (TIP 500), and property/configurable
 support (TIP 558).  The VM executes TclOO code with 85% native test
 conformance against the Tcl 9.0.3 oo.test suite.
 
+Classes made by a **user-defined metaclass** are modelled too, including
+when the metaclass lives in a different file — the shape Tk's
+`library/megawidget.tcl` and `library/iconlist.tcl` use:
+
+```tcl
+# megawidget.tcl
+oo::class create ::tk::Megawidget {
+    superclass oo::class
+    self method create {name superclasses body} {
+        next $name [list superclass ::tk::MegawidgetClass {*}$superclasses]\;$body
+    }
+}
+
+# iconlist.tcl -- names the metaclass and nothing else about it
+::tk::Megawidget create IconList FocusableWidget {
+    method GetSpecs {} { ... }
+}
+# Outline lists IconList and its methods; hover shows
+# IconList -> ::tk::MegawidgetClass -> FocusableWidget
+```
+
+The server reads the metaclass's own `create` override to find which
+argument is the class name, which is its body, and which superclasses the
+override splices in.  When any of that cannot be proved — a metaclass named
+by a runtime value, or one the workspace scan never saw — it records nothing
+and reports nothing rather than inventing a class from a command that merely
+looks similar (`interp create`, `image create`).
+
 ### Compiler pipeline
 
 The server lowers source to an intermediate representation, builds a

--- a/docs/design/tcloo-mro-lattice.md
+++ b/docs/design/tcloo-mro-lattice.md
@@ -157,7 +157,7 @@ than each re-deriving its own guess.
 |---|---|---|
 | `ClassDef::inheritance_unknown` | manufactured by a user metaclass whose `create` override could not be read, so the spliced superclass list is unknown (audit idx 96/97) | W308 abstains: an inherited method is not a missing one |
 | `ClassDef::member_set_incomplete` | the class body installs members the walk cannot read (audit idx 53) | W308 abstains: the member tables are a lower bound |
-| *no `ClassDef` at all* | `X create Name … Body` where `X`'s own definition is in another file (audit idx 97, multi-file half) | nothing is recorded, and nothing is diagnosed |
+| *no `ClassDef` at all* | `X create Name … Body` where `X` cannot be **proved** to be a metaclass — a dynamic head, or a name no workspace factory index carries (audit idx 97, multi-file half) | nothing is recorded, and nothing is diagnosed |
 
 ### Reflective member installation (`member_set_incomplete`)
 
@@ -202,27 +202,75 @@ answer until that state exists.
 
 ### Cross-file class factories
 
-Single-file, a user metaclass is fully resolved: `handle_oo_class_command`
-recognises a `create` call whose command is a recorded class reaching
-`oo::class` through its own superclass chain, reads the body/name argument
-positions off the `self method create` override, and splices the
-superclasses that override injects.  Tk's `library/megawidget.tcl`
-(`SimpleWidget`, `FocusableWidget`) is entirely covered.
+A user metaclass is resolved wherever it can be **proved** to be one, and
+abstained on wherever it cannot.  What changed with issue #1276 is only what
+counts as proof — never that proof is required.
 
-Across files it is not, and deliberately so.  The analyser is per-file, and
-a bare `::tk::Megawidget create IconList FocusableWidget {…}` in a file that
-never mentions `::tk::Megawidget`'s definition is syntactically
-indistinguishable from `interp create`, `image create`, or any ordinary proc
-that happens to take a script argument.  Recognising it on shape alone would
-invent classes out of unrelated commands — a wrong answer, and one that
-would then feed W308, the outline, and rename.  So nothing is recorded and
-nothing is diagnosed: `symbols` is empty for such a file, navigation returns
-no locations, and no false "unknown method" appears.
+**The fact, derived once.**  When a class is recorded, the walk asks whether
+that class is itself a factory (its superclass chain reaches a registry
+`IS_OO_METACLASS` command with a `TclOo` grammar) and, if so, stores a
+`ClassDef::factory` describing how it manufactures classes: per manufacturer
+subcommand, which creation argument is the new class's name, which is its
+body, and the prologue it splices — the last as a *template*
+(`FactoryWord::{Literal, CallerSplice}`) over the creation call's arguments,
+because `{*}$superclasses` is only resolvable per call.  The template is
+call-site independent by construction, which is exactly what lets one
+derivation serve every call site.
 
-Closing it needs the analyser to consult a *workspace* class index during
-the walk — the same seed the cross-document command-resolution lattice
-already builds after the fact — which is a larger change than the per-file
-walk this abstention lives in.
+**Same file.**  `Meta create Name …` looks the factory up in `all_classes`
+and resolves the template against its own arguments.  Tk's
+`library/megawidget.tcl` (`SimpleWidget`, `FocusableWidget`) is entirely
+covered, as before — the derivation simply moved from the call site to the
+declaration.
+
+**Across files.**  The host publishes a workspace **class factory index**
+(`ClassFactoryIndex`, qualified name → `ClassFactory`) and the walk consults
+it when the local class table misses.  In the LSP that index is built by the
+salsa graph — `ItemTree::class_factories` per file, merged by
+`project_class_factories`, compare-then-set onto
+`SourceFile::workspace_class_factories` at the end of the workspace scan and
+after each diagnostics publish — so it rides the same rails
+`external_call_sites` already runs on rather than a parallel mechanism.  An
+empty index is stored as `None`, so a workspace with no metaclass never
+moves the input off its default.
+
+`::tk::Megawidget create IconList FocusableWidget {…}` in a file that never
+mentions the metaclass's definition — Tk's own `library/iconlist.tcl` — is
+therefore recorded with the members it declares and the superclasses the
+manufacturer splices, matching `info class methods -private` / `info class
+superclasses` on tclsh 8.6.14 and 9.0.4.
+
+**What still abstains, and why it must.**
+
+- A **dynamic head** (`$meta create …`) names nothing statically.  No index
+  can prove what it is; the call is rejected before any lookup.
+- A name the index does not carry.  Nothing is recorded and nothing is
+  diagnosed — byte-for-byte the pre-#1276 behaviour, which is also every
+  single-file analysis and every host that has not enumerated a project.
+- A name that is only a **tail match**.  The lookup walks Tcl's own
+  current-namespace-then-global candidate order and takes an exact hit only,
+  so a global `Megawidget create …` never reaches `::tk::Megawidget`.  A
+  locally-written class of the same qualified name shadows the index, as the
+  interpreter would.
+- An **unreadable prologue** still yields `inheritance_unknown`, cross-file
+  exactly as same-file.  Additionally, a cross-document factory's literal
+  words carry tokens indexing the *metaclass's* document; they are re-homed
+  onto a token of the creation call, and an injected member whose registry
+  spec actually reads those tokens (a `retraction` member — `deletemethod` /
+  `renamemethod`) collapses the injection to unknown rather than being
+  applied against a substituted span.
+- A metaclass that is itself manufactured by a *third* file's metaclass
+  resolves only once the host's next sync round has published it.  The sync
+  is compare-then-set, so it stops as soon as the index stops moving; what
+  never happens is a round that adds an entry no file proved.
+
+**Per-item parity.**  The oracle travels with a deferred proc/method body
+(`analyse_proc_body_isolated`, keyed into `ItemBodyKey::body_env`), so a
+`Meta create …` inside a proc body is classified identically by the
+whole-file and per-item strategies.  This is asserted directly by
+`the_per_item_walk_agrees_with_the_whole_file_walk_cross_file`, and it
+earned its keep on the first run: without the propagation the per-item path
+silently dropped the class.
 
 ## What is deliberately *not* built
 

--- a/docs/design/tcloo-mro-lattice.md
+++ b/docs/design/tcloo-mro-lattice.md
@@ -145,6 +145,85 @@ The harness measures the marginal value of each layer:
 - **A3 +cross-file index** — resolve against a corpus-merged class index
   instead of the per-file one.
 
+## Abstentions on the class *definition* side
+
+The ⊤ taxonomy above is about the receiver — "which class is this object?".
+A second, independent family of abstentions is about the class itself —
+"what does this class contain, and is this even a class?".  Both are
+recorded on the `ClassDef` so every consumer abstains from one fact rather
+than each re-deriving its own guess.
+
+| flag / state | trigger | consumer effect |
+|---|---|---|
+| `ClassDef::inheritance_unknown` | manufactured by a user metaclass whose `create` override could not be read, so the spliced superclass list is unknown (audit idx 96/97) | W308 abstains: an inherited method is not a missing one |
+| `ClassDef::member_set_incomplete` | the class body installs members the walk cannot read (audit idx 53) | W308 abstains: the member tables are a lower bound |
+| *no `ClassDef` at all* | `X create Name … Body` where `X`'s own definition is in another file (audit idx 97, multi-file half) | nothing is recorded, and nothing is diagnosed |
+
+### Reflective member installation (`member_set_incomplete`)
+
+ticklecharts' `chart3D` builds its whole public surface by reflection:
+
+```tcl
+oo::class create ticklecharts::chart3D {
+    constructor {*}[info class constructor "ticklecharts::chart"]
+    foreach method {Render toHTML options get toJSON …} {
+        method $method {*}[ticklecharts::classDef "chart" $method]
+    }
+}
+```
+
+Tcl expands both shapes at definition time, so the members are entirely
+real — `info class methods ::ticklecharts::chart3D` lists all of them on
+9.0.4 and 8.6.16 alike.  What the analyser cannot do is *name* them: a
+`{*}` over a command substitution has no statically-known element list, and
+the installer loop's body is a script the member walk does not descend into.
+
+Two registry-driven signals set the flag (`Analyser::member_declaration_is_opaque`):
+
+- a **member** word (per the definer grammar) whose declaration arrives
+  through a `{*}` expansion that would not splice statically, or with a
+  computed word in one of its declaring roles (`Name` / `ParamList` /
+  `Body`);
+- a **non-member** word that either has no registry spec or declares an
+  `ArgRole::Body` argument — a script that can install members out of
+  sight (`foreach`, `if`, a helper proc).
+
+Neither signal names a command or a keyword.  What is recorded stays
+recorded: the readable members, the class itself, and its inheritance are
+all still modelled — the flag only says "there may be more", which is
+exactly the premise W308 needs to be sound.
+
+*Not* built: recovering the member *names* from a literal `foreach` list
+while leaving their signatures unknown.  It is tempting (the names really
+are static) but it buys an outline entry at the cost of a `MethodDef` whose
+parameter list is a fabrication, and every arity-shaped consumer would have
+to learn a second "unknown signature" state.  The abstention is the honest
+answer until that state exists.
+
+### Cross-file class factories
+
+Single-file, a user metaclass is fully resolved: `handle_oo_class_command`
+recognises a `create` call whose command is a recorded class reaching
+`oo::class` through its own superclass chain, reads the body/name argument
+positions off the `self method create` override, and splices the
+superclasses that override injects.  Tk's `library/megawidget.tcl`
+(`SimpleWidget`, `FocusableWidget`) is entirely covered.
+
+Across files it is not, and deliberately so.  The analyser is per-file, and
+a bare `::tk::Megawidget create IconList FocusableWidget {…}` in a file that
+never mentions `::tk::Megawidget`'s definition is syntactically
+indistinguishable from `interp create`, `image create`, or any ordinary proc
+that happens to take a script argument.  Recognising it on shape alone would
+invent classes out of unrelated commands — a wrong answer, and one that
+would then feed W308, the outline, and rename.  So nothing is recorded and
+nothing is diagnosed: `symbols` is empty for such a file, navigation returns
+no locations, and no false "unknown method" appears.
+
+Closing it needs the analyser to consult a *workspace* class index during
+the walk — the same seed the cross-document command-resolution lattice
+already builds after the fact — which is a larger change than the per-file
+walk this abstention lives in.
+
 ## What is deliberately *not* built
 
 - No second dataflow engine — the SSA type lattice is reused.

--- a/docs/kcs/kcs-issue-classes-made-by-a-class-factory-are-invisible.md
+++ b/docs/kcs/kcs-issue-classes-made-by-a-class-factory-are-invisible.md
@@ -11,7 +11,9 @@ all-editors, analyser
 
 A class, a method, or a proc that a real interpreter genuinely creates is
 absent from the document outline, and go-to-definition, find-references, and
-hover all return nothing at its call sites. Sometimes a `W308 Unknown
+hover all return nothing at its call sites. The class factory case has a
+cross-file variant: the outline is empty for a file that creates classes
+through a metaclass **declared in another file**. Sometimes a `W308 Unknown
 method` fires on a call that tclsh runs happily, or the outline shows a
 nonsense entry named after the unsubstituted source text (`${ptype}`,
 `@dynclass@1859`).
@@ -53,14 +55,25 @@ latter.
   [command registry](../design/compiler/command-registry.md). A class whose
   own superclass chain reaches one of them is *also* a class factory —
   that is TclOO language semantics, not per-command knowledge — so
-  `Analyser::user_metaclass_of_command` walks the recorded superclass chain
+  `Analyser::user_metaclass_of_class` walks the recorded superclass chain
   from the registry seed. Tk's `library/megawidget.tcl` is the canonical
   real user of the idiom.
 - **The factory's word layout.** A factory that overrides the manufacturer
   (`self method create {name superclasses body}`) changes where the body
   word sits — argument 3, not the builtin `create Name Body` argument 2 —
   and splices superclasses the caller never wrote. Both facts are read off
-  the override's own `next` call, never assumed.
+  the override's own `next` call, never assumed, and recorded **once** on
+  the metaclass's own `ClassDef::factory` rather than re-derived at each
+  creation call.
+- **The metaclass in another file.** Because the factory description is a
+  derived fact rather than a re-walk of local state, it can be published to
+  the rest of the workspace. The LSP merges every file's factories
+  (`ItemTree::class_factories` → `project_class_factories`) and sets the
+  result on each `SourceFile::workspace_class_factories`, so a file that
+  writes `::tk::Megawidget create IconList FocusableWidget {…}` and nothing
+  else — Tk's own `library/iconlist.tcl` — records the class it really
+  makes. Without an index entry the call stays unrecognised: it is
+  shape-identical to `interp create`.
 - **`{*}` expansion.** Tcl applies `{*}` while *parsing*, so a `{*}`-marked
   braced literal is not one word but the elements of the list it holds. The
   member grammar's fixed argument layout applies to those elements.
@@ -130,7 +143,27 @@ latter.
    the command is re-run per element and nothing does.
    `every_installer_spec_lands_on_a_live_redispatch_arm` fails the build
    for exactly that.
-11. **Re-dispatch must be idempotent per source site.** The ordinary body
+11. **A cross-file factory must be *proved*, never guessed.** The workspace
+   index narrows the abstention; it does not remove it. A dynamic head
+   (`$meta create …`) is rejected before any lookup. The name is resolved
+   through Tcl's own current-namespace-then-global candidate order and only
+   an exact candidate hit counts, so a global `Megawidget create …` never
+   reaches an indexed `::tk::Megawidget`. A locally-written class of the
+   same qualified name shadows the index, as the interpreter would. With no
+   entry, nothing is recorded and nothing is diagnosed.
+12. **A cross-document factory's literal spans are not the caller's.** They
+   index the *metaclass's* document, so they are re-homed onto a token of
+   the creation call — and an injected member whose registry spec actually
+   reads those tokens (`MemberSpec::retraction`) collapses the injection to
+   `inheritance_unknown` rather than being applied against a substituted
+   span.
+13. **The oracle must reach the per-item path too.** A `Meta create …`
+   inside a proc body is classified by the whole-file walk from the index,
+   so the isolated body pass must carry the same index or the two
+   strategies disagree about whether a class exists. It travels on
+   `analyse_proc_body_isolated` and is part of `ItemBodyKey::body_env` so
+   salsa cannot serve a stale verdict.
+14. **Re-dispatch must be idempotent per source site.** The ordinary body
    walk already covered the first element, so a site is visited twice under
    the loop variable's own key. One source site can never declare the same
    member twice, so `(objdefine_offset, member name)` is an exact
@@ -140,9 +173,11 @@ latter.
 ## File-path anchors
 
 - `rust/tcl-compiler/src/analyser/handlers.rs` —
-  `handle_oo_class_command`, `user_metaclass_of_command`,
+  `handle_oo_class_command`, `class_factory_for_command`,
+  `class_factory_of`, `user_metaclass_of_class`,
   `manufacturer_layout`, `manufacturer_word_positions`,
-  `manufacturer_injected_members`, `injected_member_from_group`,
+  `manufacturer_injected_template`, `injected_member_from_group`,
+  `template_injected_member`, `resolve_factory_member`,
   `prologue_pieces`, `literal_list_words`, `handle_oo_define_command`,
   `handle_oo_objdefine`, `record_object_methods`,
   `handle_foreach_command`, `simulate_remaining_foreach_iterations`,
@@ -155,7 +190,14 @@ latter.
 - `rust/tcl-compiler/src/analyser/commands.rs` —
   `resolve_dynamic_command_head`, `head_is_whole_word_variable`
 - `rust/tcl-compiler/src/analyser/types.rs` —
-  `ClassDef::inheritance_unknown`
+  `ClassDef::inheritance_unknown`, `ClassDef::factory`, `ClassFactory`,
+  `ClassFactoryIndex`, `AnalysisResult::class_factories`
+- `rust/tcl-compiler/src/analyser/per_item.rs` —
+  `analyse_proc_body_isolated` (the oracle travelling with a deferred body)
+- `rust/tcl-lsp-db/src/lib.rs` — `file_class_factories`,
+  `project_class_factories`, `SourceFile::workspace_class_factories`,
+  `ItemBodyKey::body_env`
+- `rust/tcl-lsp-server/src/lib.rs` — `sync_workspace_class_factories`
 - `rust/tcl-compiler/src/analyser/diagnostics/var_command.rs` —
   `has_external_super_or_mixin` (the W308 abstention)
 - `rust/tcl-registry/src/traits.rs` — `Traits::INSTALLS_NAMED_DEFINITION`,
@@ -209,11 +251,27 @@ latter.
 8. If a namespaced factory chain does not resolve, check the owner
    namespace the `superclass` word was written in, not just its bare and
    global spellings.
+9. If a *cross-file* factory call records nothing, check in order: is the
+   head literal? is the metaclass's file in the workspace scan? does
+   `project_class_factories` carry its qualified name? does the call's name
+   resolve to that exact qualified name under the enclosing namespace? Each
+   "no" is a deliberate abstention, not a bug.
 
 ## Test anchors
 
 - `rust/tcl-compiler/tests/analyser.rs` — the `class_factories` module
-  (26 TP/TN cases covering all four shapes plus their abstentions)
+  (TP/TN cases covering all four shapes plus their abstentions), including
+  `a_workspace_indexed_metaclass_creates_real_classes`,
+  `the_cross_file_result_matches_the_same_file_result`,
+  `the_per_item_walk_agrees_with_the_whole_file_walk_cross_file`,
+  `a_dynamic_metaclass_name_still_abstains`,
+  `a_metaclass_defined_in_another_file_abstains_rather_than_guessing`,
+  `a_workspace_metaclass_is_not_reached_by_a_same_tailed_bare_name`,
+  `a_local_metaclass_shadows_the_workspace_one`
+- `rust/tcl-lsp-server/src/lib.rs` —
+  `a_cross_file_metaclass_resolves_after_the_workspace_scan`,
+  `a_dynamic_metaclass_head_abstains_even_with_the_scan_index`,
+  `a_workspace_with_no_metaclass_never_sets_the_factory_oracle`
 - `rust/tcl-compiler/src/analyser/handlers.rs` —
   `every_installer_spec_lands_on_a_live_redispatch_arm`,
   `foreach_objdefine_records_per_object_facts_for_every_literal_element`,

--- a/rust/tcl-compiler/src/analyser/class_hierarchy.rs
+++ b/rust/tcl-compiler/src/analyser/class_hierarchy.rs
@@ -716,6 +716,7 @@ mod tests {
                 MethodDef {
                     name: (*m).to_string(),
                     params: Vec::new(),
+                    params_computed: false,
                     name_span: span(),
                     body_span: span(),
                     kind: "method".to_string(),
@@ -902,6 +903,7 @@ mod tests {
         cd.constructors.push(MethodDef {
             name: "<constructor>".to_string(),
             params: Vec::new(),
+            params_computed: false,
             name_span: span(),
             body_span,
             kind: "constructor".to_string(),
@@ -1068,6 +1070,7 @@ mod tests {
         cd.destructor = Some(MethodDef {
             name: "<destructor>".to_string(),
             params: Vec::new(),
+            params_computed: false,
             name_span: span(),
             body_span: NON_EMPTY_BODY,
             kind: "destructor".to_string(),

--- a/rust/tcl-compiler/src/analyser/class_lattice.rs
+++ b/rust/tcl-compiler/src/analyser/class_lattice.rs
@@ -1165,6 +1165,7 @@ mod tests {
                 MethodDef {
                     name: (*m).to_string(),
                     params: Vec::new(),
+                    params_computed: false,
                     name_span: Span::new(0, 0),
                     body_span: Span::new(0, 0),
                     kind: "method".into(),

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -628,6 +628,28 @@ impl Analyser {
     /// CFG/SSA value model rather than the walk's lexical map and marks the
     /// resulting invocation `indirect`.  Only the composite shapes M7
     /// explicitly skips are folded here.
+    /// The full command-resolution candidate list for a **folded** dynamic
+    /// head, or an empty list when the head was written literally (the
+    /// ordinary case, which `finalise_invocation_resolutions` rebuilds for
+    /// itself).  See the call site for why the folded case cannot be
+    /// rebuilt there.
+    fn folded_head_candidates(
+        &self,
+        head: &str,
+        folded: bool,
+        scope_path: &[usize],
+    ) -> Vec<String> {
+        if !folded {
+            return Vec::new();
+        }
+        let ns = self.command_resolution_namespace(scope_path);
+        let path: Vec<&str> = self
+            .namespace_paths
+            .get(&ns)
+            .map_or_else(Vec::new, |p| p.iter().map(String::as_str).collect());
+        crate::naming::command_resolution_candidates(&ns, &path, head)
+    }
+
     fn resolve_dynamic_command_head<'w>(
         &self,
         cmd_name: &'w str,
@@ -749,31 +771,41 @@ impl Analyser {
                 scope_path,
             );
             let resolved = self.resolve_command_qualified_name(&head, scope_path);
-            // Argument count for cross-file arity checking.  A `{*}`-
-            // expanded argument makes the runtime count unknown, so record `None`
-            // and let arity checking skip conservatively.
-            let arg_count = if arg_expand_in.iter().skip(1).copied().any(|e| e) {
-                None
-            } else {
-                Some(args.len())
-            };
+            let arg_count = call_arg_count(args, arg_expand_in);
             let resolved_cmd = resolved.clone();
+            // A folded head resolves to a real command, but its span is not
+            // the written name — `${ns}::setdef` spells only the tail — so it
+            // is a *reference*, never a rename target: overwriting the span
+            // would splice the new name over the substitution itself (the
+            // same class of corruption as issue #923 idx 95).
+            let folded = matches!(head, std::borrow::Cow::Owned(_));
+            // A folded head's *written* name (`${ns}::setdef`) is not the
+            // `{ns}::{name}` shape `finalise_invocation_resolutions` recovers
+            // the calling namespace from, so that pass cannot rebuild this
+            // call's candidate list — and without one it also cannot demote
+            // the walk's local-first guess to the global candidate Tcl really
+            // dispatches to.  `set ns tk; ${ns}::setdef …` inside `::tk` was
+            // left pinned to the non-existent `::tk::tk::setdef`, so
+            // find-references from `::tk::setdef`'s own declaration missed the
+            // call while go-to-definition (which re-resolves from the cursor)
+            // found it (issue #923 idx 54 residual).  The folded name *is*
+            // known here, so the list is built now and finalise settles
+            // against it instead of rebuilding.  The `namespace path` read
+            // here is the walk's current one: a path declared *later* in the
+            // file is not retro-applied to a folded head (every other
+            // walk-time resolution has the same horizon; finalise's own
+            // rebuild is what normally widens it).
+            let folded_candidates = self.folded_head_candidates(&head, folded, scope_path);
             self.result.command_invocations.push(
                 crate::signature_scan::types::SignatureCommandInvocation {
                     name: cmd_name.to_string(),
                     range: cmd_tok.span,
                     resolved_qualified_name: Some(resolved),
-                    resolution_candidates: Vec::new(),
+                    resolution_candidates: folded_candidates,
                     argc: arg_count,
                     callback_arity: None,
                     callback_baked_args: 0,
-                    // A folded head resolves to a real command, but its span
-                    // is not the written name — `${ns}::setdef` spells only
-                    // the tail — so it is a *reference*, never a rename
-                    // target: overwriting the span would splice the new name
-                    // over the substitution itself (the same class of
-                    // corruption as issue #923 idx 95).
-                    indirect: matches!(head, std::borrow::Cow::Owned(_)),
+                    indirect: folded,
                     rename_safe: true,
                     existence_probe: false,
                     is_mathfunc_call: false,
@@ -4337,6 +4369,18 @@ fn scan_nested_command_heads_at(text: &str, rec_depth: u32) -> Vec<(String, u32)
         }
     }
     out
+}
+
+/// The argument count a call site advertises for cross-file arity checking.
+///
+/// A `{*}`-expanded argument makes the runtime count unknown, so the answer
+/// is `None` and arity checking skips conservatively.
+fn call_arg_count(args: &[String], arg_expand_in: &[bool]) -> Option<usize> {
+    if arg_expand_in.iter().skip(1).copied().any(|e| e) {
+        None
+    } else {
+        Some(args.len())
+    }
 }
 
 /// Find the first command-head token in `text` (skipping

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -6772,6 +6772,43 @@ fn tcloo_method_arity_fires_and_stays_silent() {
 }
 
 #[test]
+fn tcloo_loop_installed_method_arity_abstains() {
+    // Issue #1277: a literal `foreach`-installed member's parameter list is
+    // deliberately never re-derived (`params_computed`), so a call of any
+    // arity must draw neither E002 nor E003 — tclsh 9.0.4 / 8.6.16 both
+    // agree `alpha` really does take any number of arguments (`args`), but
+    // even if it took none this must still abstain: the point is that the
+    // analyser never claims to know.
+    let src = |call: &str| {
+        format!(
+            "oo::class create Widget {{\n\
+                 foreach m {{alpha beta gamma}} {{ method $m {{args}} {{ return $args }} }}\n\
+             }}\n\
+             set f1 [Widget new]\n{call}\n"
+        )
+    };
+    assert_eq!(e00x_codes_for(&src("$f1 alpha")), Vec::<String>::new());
+    assert_eq!(
+        e00x_codes_for(&src("$f1 alpha 1 2 3 4 5")),
+        Vec::<String>::new()
+    );
+    // Non-vacuity: an *ordinary*, non-loop-installed method with the exact
+    // same call shape still fires — proving this test would catch a
+    // reversion of the fix (a fixed two-parameter method really does draw
+    // E002/E003 on the same harness).
+    let ordinary = |call: &str| {
+        format!(
+            "oo::class create Widget2 {{ method bar {{x y}} {{ return \"$x+$y\" }} }}\n\
+             set f1 [Widget2 new]\n{call}\n"
+        )
+    };
+    assert_eq!(
+        e00x_codes_for(&ordinary("$f1 bar 1")),
+        vec!["E002".to_owned()]
+    );
+}
+
+#[test]
 fn tcloo_method_with_default_and_trailing_args_is_unbounded() {
     // tclsh 9.0.4: `method baz {x {y 1} args}` accepts any count >= 1.
     let src = |call: &str| {

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -1865,7 +1865,7 @@ impl Analyser {
                 }) else {
                     continue;
                 };
-                let arity = crate::signature_scan::arity::arity_of(&ctor.params);
+                let arity = ctor.arity();
                 let arity = bump_arity(arity, cand.form.extra_leading_words());
                 let display_name = format!("{} {}", cand.class_name, cand.form.as_str());
                 if let Some(diag) = arity_verdict(
@@ -1957,7 +1957,7 @@ impl Analyser {
                 if method_def.kind == "forward" {
                     continue;
                 }
-                let arity = crate::signature_scan::arity::arity_of(&method_def.params);
+                let arity = method_def.arity();
                 if let Some(diag) = arity_verdict(
                     &cand.display_name,
                     arity,

--- a/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
@@ -641,7 +641,7 @@ impl Analyser {
         let mut arity = None;
         for _ in 0..MAX_HOPS {
             if method_def.kind != "forward" {
-                arity = Some(crate::signature_scan::arity::arity_of(&method_def.params));
+                arity = Some(method_def.arity());
                 break;
             }
             let Some((target, prepended)) = method_def.forward_target.as_ref() else {

--- a/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
@@ -382,14 +382,16 @@ impl Analyser {
                 }
             }
         }
-        // External superclass or mixin: a method might come from a class
-        // outside the current index.
+        // The class's method set cannot be enumerated — an external
+        // superclass or mixin, opaque metaclass-spliced inheritance, or
+        // members installed reflectively — so a method might exist that this
+        // index cannot see.
         if !found && has_local_class {
             found = class_names.iter().any(|cls| {
                 self.result
                     .all_classes
                     .get(cls)
-                    .is_some_and(|cd| self.has_external_super_or_mixin(cd))
+                    .is_some_and(|cd| self.method_set_unknowable(cd))
             });
         }
         // ``oo::objdefine`` adds per-instance methods we can't see at the
@@ -1805,23 +1807,45 @@ impl Analyser {
         if hierarchy.is_some_and(|h| h.method_target(class_name, "unknown").is_some()) {
             return true;
         }
-        // External superclass or mixin ⇒ skip W308.
-        self.has_external_super_or_mixin(cd)
+        // Unknowable method set (external base, opaque inheritance, or
+        // reflectively-installed members) ⇒ skip W308.
+        self.method_set_unknowable(cd)
     }
 
-    /// True when `cd` names a superclass **or mixin** that is not in the
-    /// local class index (the `TclOO` bases in [`OO_BASE`] excepted).
-    /// `TclOO` mixins contribute to the MRO exactly as superclasses do, so
-    /// an unresolvable name in either list means the class's callable
-    /// method set is unknowable and W308 must abstain.  Shared by
-    /// [`Self::w308_for_object_var`] and [`Self::validate_method_on_class`]
-    /// so the two escape hatches cannot drift.
-    fn has_external_super_or_mixin(&self, cd: &super::types::ClassDef) -> bool {
+    /// True when `cd`'s callable method set cannot be enumerated from what
+    /// the analyser recorded, so W308 must abstain rather than call a method
+    /// missing.  Three independent reasons, all "the tables are a lower
+    /// bound", never "this method does not exist":
+    ///
+    /// * a superclass **or mixin** outside the local class index (the
+    ///   `TclOO` bases in [`OO_BASE`] excepted) — `TclOO` mixins contribute
+    ///   to the MRO exactly as superclasses do, so an unresolvable name in
+    ///   either list hides an unknown set of inherited methods;
+    /// * [`ClassDef::inheritance_unknown`] — manufactured by a user
+    ///   metaclass whose `create` override could not be read, so the
+    ///   spliced superclass list itself is unknown (issue #923 idx 96/97);
+    /// * [`ClassDef::member_set_incomplete`] — the class's own body installs
+    ///   members reflectively (issue #923 idx 53).
+    ///
+    /// Shared by [`Self::w308_for_object_var`] and
+    /// [`Self::validate_method_on_class`] so the two escape hatches cannot
+    /// drift.
+    ///
+    /// [`ClassDef::inheritance_unknown`]: super::types::ClassDef::inheritance_unknown
+    /// [`ClassDef::member_set_incomplete`]: super::types::ClassDef::member_set_incomplete
+    fn method_set_unknowable(&self, cd: &super::types::ClassDef) -> bool {
         // A class manufactured by a user-defined metaclass whose `create`
         // override could not be read has an unknown superclass list, which is
         // the same situation as a superclass outside the index: a method it
         // inherits is not a method it is missing (issue #923 idx 96/97).
+        //
+        // A class whose own body installs members through reflection
+        // (`constructor {*}[info class constructor ::Base]`, `foreach m {…}
+        // { method $m … }`) is the same judgement one level in: the recorded
+        // member tables are a lower bound, so a method that is absent from
+        // them is not thereby missing from the class (issue #923 idx 53).
         cd.inheritance_unknown
+            || cd.member_set_incomplete
             || cd
                 .superclasses
                 .iter()

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -42,7 +42,7 @@ use crate::segmenter::SegmentedCommand;
 use crate::signature_scan::types::SignatureCommandAlias;
 
 use super::state::Analyser;
-use super::types::{DefinedSymbol, ProcDef};
+use super::types::{ClassDef, ClassFactory, DefinedSymbol, FactoryMember, FactoryWord, ProcDef};
 use super::utils::{param_name_spans_for_token, parse_param_list};
 
 /// The three per-proc facts [`Analyser::infer_proc_param_traits`] derives from
@@ -238,8 +238,10 @@ fn summarise_detail(description: &str) -> String {
 ///
 /// See [`Analyser::user_metaclass_of_command`].
 struct UserMetaclass {
-    /// Fully-qualified name of the factory class.
-    qualified: String,
+    /// The registry metaclass command at the root of the chain
+    /// (`oo::class`), whose definition-body grammar governs the bodies this
+    /// factory makes.
+    root_command: String,
     /// The root registry metaclass's definition-body grammar.
     grammar: &'static tcl_registry::definer::DefinitionBodyGrammar,
 }
@@ -462,26 +464,19 @@ fn matching_bracket(text: &str) -> Option<usize> {
     None
 }
 
-/// Resolve one prologue member statement from a manufacturer override into
-/// the member the creation call actually installs.
+/// Read one prologue member statement from a manufacturer override into the
+/// **call-site-independent template** the factory publishes.
 ///
-/// A literal word is kept with its own token (it lives in the
-/// manufacturer's body, which is where the reference genuinely is written).
-/// A `{*}$param` word splices the creation call's corresponding argument,
-/// whose literal list elements carry call-site tokens.  Anything else —
-/// a substitution with no statically-known value, or a `{*}` over one —
-/// yields `None`, and the caller abstains rather than inventing a
-/// superclass list.
-fn resolve_injected_member(
-    seg: &SegmentedCommand,
-    params: &[&str],
-    args: &[String],
-    arg_tokens: &[Token],
-) -> Option<InjectedMember> {
+/// A literal word is kept with its own token (it lives in the manufacturer's
+/// body, which is where the reference genuinely is written).  A `{*}$param`
+/// word becomes a [`FactoryWord::CallerSplice`] of the creation call's
+/// corresponding argument, resolved per call.  Anything else — a substitution
+/// with no statically-known value, or a `{*}` over one — yields `None`, and
+/// the caller abstains rather than inventing a superclass list.
+fn template_injected_member(seg: &SegmentedCommand, params: &[&str]) -> Option<FactoryMember> {
     let texts_in = seg.args();
     let tokens_in = seg.arg_tokens();
-    let mut member_words: Vec<String> = Vec::new();
-    let mut member_tokens: Vec<Token> = Vec::new();
+    let mut words: Vec<FactoryWord> = Vec::new();
     for (i, (text, tok)) in texts_in.iter().zip(tokens_in.iter()).enumerate() {
         let expanded = seg
             .expand_word
@@ -493,25 +488,85 @@ fn resolve_injected_member(
             let [name] = refs.as_slice() else {
                 return None;
             };
+            // Parameter `i` of the override binds argument `i + 1` of the
+            // call (argument 0 being the manufacturer subcommand itself).
             let arg_index = params.iter().position(|p| p == name)? + 1;
-            let call_tok = *arg_tokens.get(arg_index)?;
-            let call_text = args.get(arg_index)?;
-            for (element, element_tok) in literal_list_words(call_text, call_tok)? {
-                member_words.push(element);
-                member_tokens.push(element_tok);
-            }
+            words.push(FactoryWord::CallerSplice(arg_index));
             continue;
         }
         if crate::naming::is_dynamic_word(text) {
             return None;
         }
-        member_words.push(text.clone());
-        member_tokens.push(*tok);
+        words.push(FactoryWord::Literal {
+            text: text.clone(),
+            token: *tok,
+        });
     }
-    Some(InjectedMember {
-        texts: member_words,
-        argv: member_tokens,
-    })
+    Some(FactoryMember { words })
+}
+
+/// Resolve one injected-member template against the creation call that
+/// triggered it.
+///
+/// The literal words keep the tokens they were templated with; a
+/// [`FactoryWord::CallerSplice`] contributes the call argument's literal list
+/// elements, each with its own call-site token.  `None` when this call's
+/// argument is not a statically-known list — the caller then marks the
+/// class's inheritance unknown rather than claiming an injection it cannot
+/// spell.
+fn resolve_factory_member(
+    member: &FactoryMember,
+    args: &[String],
+    arg_tokens: &[Token],
+) -> Option<InjectedMember> {
+    let mut texts: Vec<String> = Vec::new();
+    let mut argv: Vec<Token> = Vec::new();
+    for word in &member.words {
+        match word {
+            FactoryWord::Literal { text, token } => {
+                texts.push(text.clone());
+                argv.push(*token);
+            }
+            FactoryWord::CallerSplice(arg_index) => {
+                let call_tok = *arg_tokens.get(*arg_index)?;
+                let call_text = args.get(*arg_index)?;
+                for (element, element_tok) in literal_list_words(call_text, call_tok)? {
+                    texts.push(element);
+                    argv.push(element_tok);
+                }
+            }
+        }
+    }
+    Some(InjectedMember { texts, argv })
+}
+
+/// The word layout a class factory's `args[0]` manufacturer imposes on this
+/// creation call, with its injected members resolved against the call's own
+/// arguments.
+///
+/// A subcommand the factory does not override runs the inherited `oo::class`
+/// manufacturer, so the builtin `create Name Body` layout applies with
+/// nothing injected.
+fn manufacturer_layout(
+    factory: &ClassFactory,
+    args: &[String],
+    arg_tokens: &[Token],
+) -> ManufacturerLayout {
+    let Some(spec) = factory.overrides.get(&args[0]) else {
+        return ManufacturerLayout::builtin();
+    };
+    let injected = spec.injected.as_ref().and_then(|members| {
+        members
+            .iter()
+            .map(|m| resolve_factory_member(m, args, arg_tokens))
+            .collect::<Option<Vec<_>>>()
+    });
+    ManufacturerLayout {
+        name_arg: spec.name_arg,
+        body_arg: spec.body_arg,
+        inheritance_unknown: injected.is_none(),
+        injected: injected.unwrap_or_default(),
+    }
 }
 
 /// Bundled arguments for [`Analyser::walk_proc_body_in_new_scope`] — kept
@@ -5343,42 +5398,48 @@ impl Analyser {
             .and_then(|s| s.definition_body)
     }
 
-    /// The word layout of `Meta create …` plus whatever members the
-    /// manufacturer injects into every class it makes.
+    /// The [`ClassFactory`] `class` publishes, when `class` is itself a
+    /// `TclOO` class factory — a class whose superclass chain reaches a
+    /// registry metaclass.
     ///
-    /// A user metaclass that does not override the manufacturer inherits
-    /// `oo::class`'s own `create Name Body` shape, so the builtin layout
-    /// applies unchanged.  One that *does* override it declares its own
-    /// shape in the override's parameter list, and that override is read
-    /// here rather than guessed: Tk's `self method create {name superclasses
-    /// body}` puts the body at argument 3, not 2, and splices a superclass
-    /// the caller never wrote (issue #923 idx 96/97).
-    fn manufacturer_layout(
-        &self,
-        meta: &UserMetaclass,
-        args: &[String],
-        arg_tokens: &[Token],
-    ) -> ManufacturerLayout {
-        // `args[0]` is the manufacturer subcommand this call actually used,
-        // so the override looked up is the one that will run.
-        let override_def = self
-            .result
-            .all_classes
-            .get(&meta.qualified)
-            .and_then(|class| class.class_methods.get(&args[0]));
-        let Some(override_def) = override_def else {
-            return ManufacturerLayout::builtin();
-        };
-        let positions = self.manufacturer_word_positions(override_def);
-        let (name_arg, body_arg) = positions.unwrap_or((1, 2));
-        let injected = positions
-            .and_then(|_| self.manufacturer_injected_members(meta, override_def, args, arg_tokens));
-        ManufacturerLayout {
-            name_arg,
-            body_arg,
-            inheritance_unknown: injected.is_none(),
-            injected: injected.unwrap_or_default(),
-        }
+    /// Derived **once, where the metaclass is written**, so every consumer
+    /// (this file's own `Meta create …` calls and, through the workspace
+    /// factory index, another file's) classifies a creation call from the
+    /// same proved fact instead of re-deriving it — or, cross-file,
+    /// abstaining for want of it (issue #1276).
+    ///
+    /// A user metaclass that does not override a manufacturer subcommand
+    /// inherits `oo::class`'s own `create Name Body` shape, so that
+    /// subcommand simply has no entry and the builtin layout applies.  One
+    /// that *does* override it declares its own shape in the override's
+    /// parameter list, and that override is read rather than guessed: Tk's
+    /// `self method create {name superclasses body}` puts the body at
+    /// argument 3, not 2, and splices a superclass the caller never wrote
+    /// (issue #923 idx 96/97).
+    fn class_factory_of(&self, qualified: &str, class: &ClassDef) -> Option<ClassFactory> {
+        let meta = self.user_metaclass_of_class(qualified, class)?;
+        let overrides = class
+            .class_methods
+            .iter()
+            .map(|(subcommand, override_def)| {
+                let positions = self.manufacturer_word_positions(override_def);
+                let (name_arg, body_arg) = positions.unwrap_or((1, 2));
+                let injected = positions
+                    .and_then(|_| self.manufacturer_injected_template(&meta, override_def));
+                (
+                    subcommand.clone(),
+                    super::types::ManufacturerSpec {
+                        name_arg,
+                        body_arg,
+                        injected,
+                    },
+                )
+            })
+            .collect();
+        Some(ClassFactory {
+            root_metaclass: meta.root_command,
+            overrides,
+        })
     }
 
     /// Which of the creation call's argument words carry the new class's
@@ -5446,7 +5507,7 @@ impl Analyser {
     }
 
     /// The definition-body members the manufacturer splices into every class
-    /// it makes, resolved against *this* call's arguments.
+    /// it makes, as a template over the creation call's arguments.
     ///
     /// Tk's `Megawidget` hands `next` a `[list superclass ::tk::MegawidgetClass
     /// {*}$superclasses]` prologue, so every class it makes really does
@@ -5456,8 +5517,9 @@ impl Analyser {
     /// `mixin`, `filter`, `export`, … — the grammar's `all_args_ref` set)
     /// are injected: they name existing entities, so every injected word
     /// keeps a real source span, either in the manufacturer's own body
-    /// (a literal it always splices) or in this call's arguments (a
-    /// `{*}$param` splice).
+    /// (a literal it always splices) or in the call's arguments (a
+    /// `{*}$param` splice, resolved per call by
+    /// [`resolve_factory_member`]).
     ///
     /// **Reading the whole prologue is a precondition, not a best effort.**
     /// The definition word `next` receives is scanned piece by piece, and
@@ -5473,13 +5535,11 @@ impl Analyser {
     /// *known-empty* injection for a prologue that was merely unreadable
     /// would claim the class has no superclass and let W308 fire on
     /// perfectly good inherited methods.
-    fn manufacturer_injected_members(
+    fn manufacturer_injected_template(
         &self,
         meta: &UserMetaclass,
         override_def: &super::types::MethodDef,
-        args: &[String],
-        arg_tokens: &[Token],
-    ) -> Option<Vec<InjectedMember>> {
+    ) -> Option<Vec<FactoryMember>> {
         let params: Vec<&str> = override_def
             .params
             .iter()
@@ -5504,7 +5564,7 @@ impl Analyser {
             .all_tokens
             .iter()
             .filter(|tok| tok.kind == TokenType::Cmd && tok.span.start() >= word_start);
-        let mut injected: Vec<InjectedMember> = Vec::new();
+        let mut injected: Vec<FactoryMember> = Vec::new();
         for piece in prologue_pieces(prologue) {
             match piece {
                 ProloguePiece::Separator => {}
@@ -5514,8 +5574,6 @@ impl Analyser {
                         meta,
                         *groups.next()?,
                         &params,
-                        args,
-                        arg_tokens,
                     )?);
                 }
                 // Literal prologue text, a read of something that is not a
@@ -5535,9 +5593,7 @@ impl Analyser {
         meta: &UserMetaclass,
         group: Token,
         params: &[&str],
-        args: &[String],
-        arg_tokens: &[Token],
-    ) -> Option<InjectedMember> {
+    ) -> Option<FactoryMember> {
         let registry = self.registry.as_ref()?;
         let sm = SourceMap::new(&self.source);
         let descended = descend_token(&sm, group, self.lexer_config());
@@ -5562,10 +5618,80 @@ impl Analyser {
             .first()
             .and_then(|keyword| meta.grammar.member(keyword))?;
         member.all_args_ref?;
-        resolve_injected_member(&seg, params, args, arg_tokens)
+        template_injected_member(&seg, params)
     }
 
-    /// The recorded class `cmd_name` names when that class is **itself a
+    /// The [`ClassFactory`] the command `cmd_name` names, when that command
+    /// is a user-defined `TclOO` metaclass — this file's own, else one the
+    /// **workspace factory index** proves is written in another document
+    /// (issue #1276).
+    ///
+    /// The cross-document tier is what closes the audit's multi-file half:
+    /// `::tk::Megawidget create IconList FocusableWidget {…}` in a file that
+    /// never mentions `::tk::Megawidget`'s definition is, on shape alone,
+    /// indistinguishable from `interp create` or `image create`, so the walk
+    /// used to record nothing at all.  With the index it is classified from
+    /// the metaclass's *own* declaration — its `create` override's parameter
+    /// list and prologue — exactly as the same-file case is.
+    ///
+    /// The abstention it narrows is **kept everywhere it was earned**:
+    ///
+    /// * a dynamic command word (`$meta create …`) names nothing statically
+    ///   and is rejected before any lookup;
+    /// * the name is resolved through Tcl's real current-namespace-then-global
+    ///   candidate order ([`crate::naming::bareword_resolution_candidates`]),
+    ///   and only an **exact** candidate hit counts — a same-tailed metaclass
+    ///   in an unrelated namespace never manufactures a class here, the same
+    ///   discipline [`super::class_hierarchy::resolve_class_name`] applies
+    ///   same-file;
+    /// * with no index entry, nothing is recorded and nothing is diagnosed,
+    ///   byte-for-byte as before.
+    ///
+    /// A cross-document factory's injected literals carry tokens that index
+    /// the *metaclass's* document, so they are re-homed onto a token of this
+    /// call ([`ClassFactory::resolve_in_other_document`]) — and an injection
+    /// whose member word actually reads those tokens (a `retraction` member,
+    /// registry data) collapses to "inheritance unknown" rather than being
+    /// applied against a substituted span.
+    fn class_factory_for_command(
+        &self,
+        cmd_name: &str,
+        arg_tokens: &[Token],
+        scope_path: &[usize],
+    ) -> Option<ClassFactory> {
+        if crate::naming::is_dynamic_word(cmd_name) {
+            return None;
+        }
+        let namespace = self.command_resolution_namespace(scope_path);
+        let candidates = crate::naming::bareword_resolution_candidates(&namespace, cmd_name);
+        // This file first: a locally-written metaclass shadows a workspace one
+        // under the same name, exactly as a local proc shadows a workspace
+        // proc for command resolution.
+        for candidate in &candidates {
+            if let Some(class) = self.result.all_classes.get(candidate) {
+                return class.factory.clone();
+            }
+        }
+        let index = self.workspace_class_factories.as_ref()?;
+        let foreign = candidates
+            .iter()
+            .find_map(|candidate| index.get(candidate))?;
+        // Tokens in the foreign factory index the metaclass's document. The
+        // creation call's own subcommand word (`create`) is the nearest real
+        // token in *this* document that the injected member genuinely came
+        // with, and it is guaranteed present — the caller has already checked
+        // `arg_tokens.len() >= 2`.
+        let elsewhere = *arg_tokens.first()?;
+        let grammar = self.definition_grammar(&foreign.root_metaclass)?;
+        Some(foreign.resolve_in_other_document(elsewhere, &|keyword| {
+            grammar
+                .member(keyword)
+                .is_some_and(|m| m.retraction.is_some())
+        }))
+    }
+
+    /// The registry metaclass at the root of `seed`'s superclass chain, when
+    /// `seed` (recorded, or being recorded, under `qualified`) is **itself a
     /// class factory** — a user-defined `TclOO` metaclass.
     ///
     /// A class is a factory when its (possibly indirect) superclass chain
@@ -5594,26 +5720,31 @@ impl Analyser {
     /// Chain walking is depth-bounded and visited-checked, so a cyclic
     /// `superclass` declaration (rejected by real Tcl, but writable in a
     /// half-edited buffer) terminates.
-    fn user_metaclass_of_command(
-        &self,
-        cmd_name: &str,
-        scope_path: &[usize],
-    ) -> Option<UserMetaclass> {
+    fn user_metaclass_of_class(&self, qualified: &str, seed: &ClassDef) -> Option<UserMetaclass> {
         let registry = self.registry.as_ref()?;
-        let qualified = self.resolve_command_qualified_name(cmd_name, scope_path);
-        if !self.result.all_classes.contains_key(&qualified) {
-            return None;
-        }
-        let tail_index = super::class_hierarchy::build_tail_index(self.result.all_classes.keys());
+        let seed_key = qualified.to_string();
+        let tail_index = super::class_hierarchy::build_tail_index(
+            self.result
+                .all_classes
+                .keys()
+                .chain(std::iter::once(&seed_key)),
+        );
         let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-        let mut queue: Vec<String> = vec![qualified.clone()];
+        let mut queue: Vec<String> = vec![seed_key.clone()];
         // Bounded by the recorded class count — every class is visited once.
         while let Some(class_qname) = queue.pop() {
             if !seen.insert(class_qname.clone()) {
                 continue;
             }
-            let Some(class) = self.result.all_classes.get(&class_qname) else {
-                continue;
+            // The seed is the class being recorded, which is not in
+            // `all_classes` until the walk that is asking finishes.
+            let class = if class_qname == qualified {
+                seed
+            } else {
+                let Some(class) = self.result.all_classes.get(&class_qname) else {
+                    continue;
+                };
+                class
             };
             for parent in &class.superclasses {
                 // The registry seed: `oo::class` and its siblings are named
@@ -5624,12 +5755,17 @@ impl Analyser {
                     && let Some(grammar) = spec.definition_body
                     && grammar.family == tcl_registry::definer::DefinerFamily::TclOo
                 {
-                    return Some(UserMetaclass { qualified, grammar });
+                    return Some(UserMetaclass {
+                        root_command: bare.to_string(),
+                        grammar,
+                    });
                 }
                 if let Some(next) = super::class_hierarchy::resolve_class_name(
                     parent,
                     &class_qname,
-                    |candidate| self.result.all_classes.contains_key(candidate),
+                    |candidate| {
+                        candidate == qualified || self.result.all_classes.contains_key(candidate)
+                    },
                     &tail_index,
                 ) {
                     queue.push(next);
@@ -5736,12 +5872,20 @@ impl Analyser {
         // propagates down the recorded superclass chain — the *seed* is still
         // registry data (`IS_OO_METACLASS`), only the inheritance step is
         // `TclOO` language semantics.
-        let user_metaclass = if registry_definer {
+        //
+        // The factory description is read off the metaclass's own recorded
+        // `ClassDef` — this file's, or, when the metaclass is written in
+        // another document, the workspace factory index the host supplied
+        // (issue #1276).  Either way it is a fact *proved where the metaclass
+        // was written*, never one inferred from this call's shape: with no
+        // such record `X create Name Supers Body` stays indistinguishable
+        // from `interp create` and the walk abstains, as before.
+        let user_factory = if registry_definer {
             None
         } else {
-            self.user_metaclass_of_command(cmd_name, scope_path)
+            self.class_factory_for_command(cmd_name, arg_tokens, scope_path)
         };
-        if !registry_definer && user_metaclass.is_none() {
+        if !registry_definer && user_factory.is_none() {
             return false;
         }
         // Where the name and body words sit, and what the manufacturer
@@ -5750,9 +5894,9 @@ impl Analyser {
         // *overrides* the manufacturer (`self method create {name superclasses
         // body} { next $name [list superclass Base {*}$superclasses];$body }`)
         // declares its own, read off the override.
-        let layout = match user_metaclass.as_ref() {
+        let layout = match user_factory.as_ref() {
             None => ManufacturerLayout::builtin(),
-            Some(meta) => self.manufacturer_layout(meta, args, arg_tokens),
+            Some(factory) => manufacturer_layout(factory, args, arg_tokens),
         };
         if layout.name_arg >= args.len() || layout.name_arg >= arg_tokens.len() {
             return false;
@@ -5786,9 +5930,10 @@ impl Analyser {
         // governed by the definition grammar of the registry metaclass at the
         // root of its superclass chain — the same `TclOO` grammar, reached
         // without naming it here.
-        let grammar = user_metaclass
-            .as_ref()
-            .map_or_else(|| self.definition_grammar(cmd_name), |m| Some(m.grammar));
+        let grammar = user_factory.as_ref().map_or_else(
+            || self.definition_grammar(cmd_name),
+            |factory| self.definition_grammar(&factory.root_metaclass),
+        );
         // Members the manufacturer itself injects (Tk's `Megawidget` splices
         // `superclass ::tk::MegawidgetClass` plus whatever the caller passed)
         // are applied through the *same* registry-grammar routing as a member
@@ -5821,6 +5966,12 @@ impl Analyser {
         // #1120). Drained here, after the whole body walk, so a class extended
         // by several `oo::define` blocks reports each block's own aborts once.
         self.emit_w315_definition_cannot_run(&mut class);
+        // Is the class we just recorded *itself* a class factory?  Answered
+        // here, once, so every later `ThisClass create …` — in this file or,
+        // via the workspace factory index, in another — reads a derived fact
+        // instead of re-walking the superclass chain and re-segmenting the
+        // manufacturer override per call site (issue #1276).
+        class.factory = self.class_factory_of(&qualified, &class);
         // Register globally and in the current scope, the same as
         // the proc registration path: ``result.all_classes`` is keyed
         // by the fully-qualified name; the per-scope
@@ -6031,6 +6182,11 @@ impl Analyser {
         // aborts are dropped rather than reported: a class created in another
         // file leaves this record with no member tables to judge against.
         self.emit_w315_definition_cannot_run(&mut class_def);
+        // `oo::define C { superclass oo::class }` turns an ordinary class into
+        // a factory, and `self method create …` changes the shape of the
+        // classes it makes, so the derived factory record is recomputed here
+        // exactly as it is on the creation path (issue #1276).
+        class_def.factory = self.class_factory_of(&qualified, &class_def);
         // Same dual-registration as ``oo::class create`` — keep
         // ``all_classes`` and the per-scope ``scope.classes`` in
         // sync.  ``oo::define`` may be redefining an existing

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -519,25 +519,28 @@ fn resolve_factory_member(
     args: &[String],
     arg_tokens: &[Token],
 ) -> Option<InjectedMember> {
-    let mut texts: Vec<String> = Vec::new();
-    let mut argv: Vec<Token> = Vec::new();
+    let mut member_words: Vec<String> = Vec::new();
+    let mut member_tokens: Vec<Token> = Vec::new();
     for word in &member.words {
         match word {
             FactoryWord::Literal { text, token } => {
-                texts.push(text.clone());
-                argv.push(*token);
+                member_words.push(text.clone());
+                member_tokens.push(*token);
             }
             FactoryWord::CallerSplice(arg_index) => {
                 let call_tok = *arg_tokens.get(*arg_index)?;
                 let call_text = args.get(*arg_index)?;
                 for (element, element_tok) in literal_list_words(call_text, call_tok)? {
-                    texts.push(element);
-                    argv.push(element_tok);
+                    member_words.push(element);
+                    member_tokens.push(element_tok);
                 }
             }
         }
     }
-    Some(InjectedMember { texts, argv })
+    Some(InjectedMember {
+        texts: member_words,
+        argv: member_tokens,
+    })
 }
 
 /// The word layout a class factory's `args[0]` manufacturer imposes on this
@@ -5729,11 +5732,11 @@ impl Analyser {
                 .keys()
                 .chain(std::iter::once(&seed_key)),
         );
-        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut visited: std::collections::HashSet<String> = std::collections::HashSet::new();
         let mut queue: Vec<String> = vec![seed_key.clone()];
         // Bounded by the recorded class count — every class is visited once.
         while let Some(class_qname) = queue.pop() {
-            if !seen.insert(class_qname.clone()) {
+            if !visited.insert(class_qname.clone()) {
                 continue;
             }
             // The seed is the class being recorded, which is not in

--- a/rust/tcl-compiler/src/analyser/item_tree.rs
+++ b/rust/tcl-compiler/src/analyser/item_tree.rs
@@ -145,6 +145,17 @@ pub struct Item {
 pub struct ItemTree {
     /// Items in stable [`ItemId`] order.
     pub items: Vec<Item>,
+    /// The user-defined `TclOO` **class factories** this file declares, keyed
+    /// by qualified name — what the workspace merges so *another* file's walk
+    /// can classify `Meta create Name …` (issue #1276).
+    ///
+    /// It rides on the item tree because that is already a structure-level,
+    /// per-file, memoised product of the same walk: publishing the factories
+    /// here costs no extra analysis pass, and a body edit that leaves the
+    /// metaclass's `create` override alone leaves this equal, so the
+    /// cross-file query early-cutoffs. Behind an `Arc` because the consumer
+    /// hands it straight to the analyser.
+    pub class_factories: std::sync::Arc<super::types::ClassFactoryIndex>,
 }
 
 /// The aggregate declaration sets the cross-item passes read: the firewall's
@@ -294,7 +305,10 @@ impl ItemTree {
         // Deterministic order so `ItemTree` value-equality is stable across the
         // analyser's non-deterministic `HashMap` iteration order.
         items.sort_by(|a, b| a.sig.id.cmp(&b.sig.id));
-        Self { items }
+        Self {
+            items,
+            class_factories: std::sync::Arc::new(result.class_factories()),
+        }
     }
 
     /// The signatures of every item, in stable [`ItemId`] order. This is the

--- a/rust/tcl-compiler/src/analyser/mod.rs
+++ b/rust/tcl-compiler/src/analyser/mod.rs
@@ -86,7 +86,8 @@ pub use snapshot::AnalyserSnapshot;
 pub use state::{Analyser, NonAsciiMode};
 pub use tcl_syntax::mro::{self, MroError, build_mro_map, tcloo_linearise};
 pub use types::{
-    AnalysisResult, ClassDef, CodeFix, DefinedSymbol, DefinitionAbortKind, Diagnostic, FixSafety,
+    AnalysisResult, ClassDef, ClassFactory, ClassFactoryIndex, CodeFix, DefinedSymbol,
+    DefinitionAbortKind, Diagnostic, FactoryMember, FactoryWord, FixSafety, ManufacturerSpec,
     MemberRetractionRecord, MemberSide, MethodDef, ObjectMemberState, ObjectMethodDef,
     ProcArgTrait, ProcDef, PropertyDef, QualifiedVarRef, RenamedMember, Scope, ScopeKind, Severity,
     StubFlags, UnknownProcInfo, VarDef, class_constructor_key, class_destructor_key,

--- a/rust/tcl-compiler/src/analyser/oo.rs
+++ b/rust/tcl-compiler/src/analyser/oo.rs
@@ -211,6 +211,121 @@ fn unwrap_wrapper_member<'a>(
     }
 }
 
+/// The `(var_idx, list_idx, body_idx)` post-head argument positions of a
+/// registry-declared "var/list pairs then a trailing body" loop command
+/// (`foreach`/`lmap`), when it has **exactly one** var/list pair — the only
+/// shape [`Analyser::record_loop_installed_members`] can read a member name
+/// off of. `None` for anything else: no [`tcl_registry::Traits::LOOP_LIST_HEADER`]
+/// trait, no single matching [`tcl_registry::repeated::RepeatedArgLayout`],
+/// or more (or fewer) than one pair — a multi-list `foreach` has no single
+/// variable a member's name word could unambiguously mean.
+fn loop_installer_pair(
+    spec: &'static tcl_registry::CommandSpec,
+    post_head: usize,
+) -> Option<(usize, usize, usize)> {
+    if !spec.traits.contains(tcl_registry::Traits::LOOP_LIST_HEADER) {
+        return None;
+    }
+    let [layout] = spec.repeated_args else {
+        return None;
+    };
+    if layout.role != ArgRole::LoopVarList || layout.stride != 2 || layout.exclude_trailing != 1 {
+        return None;
+    }
+    let var_indices = layout.indices(post_head);
+    let &[var_idx] = var_indices.as_slice() else {
+        return None;
+    };
+    Some((var_idx, var_idx + 1, post_head - 1))
+}
+
+/// Split a loop's literal list word into `(element, absolute source span)`
+/// pairs, or `None` when the word is not literal (a single brace/quote/bare
+/// token with no substitutions — same predicate the parameter-list literal
+/// check uses) or fails to parse as a Tcl list.
+fn literal_loop_elements(
+    list_word: &str,
+    list_tok: Token,
+    list_single_token: bool,
+) -> Option<Vec<(String, Span)>> {
+    if !crate::signature_scan::params::param_word_is_literal(list_tok.kind, list_single_token) {
+        return None;
+    }
+    let list_content_start = list_tok.span.start() + u32::from(list_tok.content_offset);
+    let mut members = Vec::new();
+    let mut pos = 0usize;
+    loop {
+        match tcl_syntax::list::find_element(list_word, pos) {
+            Ok(Some(el)) => {
+                let raw = &list_word[el.value.clone()];
+                let value = if el.literal {
+                    raw.to_string()
+                } else {
+                    tcl_lexer::backslash_subst(raw).into_owned()
+                };
+                let span = Span::new(
+                    list_content_start + u32::try_from(el.value.start).unwrap_or(0),
+                    list_content_start + u32::try_from(el.value.end).unwrap_or(0),
+                );
+                members.push((value, span));
+                pos = el.next;
+            }
+            Ok(None) => break,
+            // A malformed list is left exactly as opaque — no partial guess.
+            Err(_) => return None,
+        }
+    }
+    if members.is_empty() {
+        None
+    } else {
+        Some(members)
+    }
+}
+
+/// Whether a loop's body is exactly one member declaration (per `grammar`,
+/// unwrapped of any `self`/`private`) that names itself with exactly a
+/// reference to the loop variable `var_name` — `foreach`'s installer idiom.
+/// Returns the member's `(kind, body_span)` on a match; `None` for anything
+/// else (more than one statement, a fixed name, a name built from more than
+/// the bare variable, a non-`method`/`classmethod` member) — left exactly as
+/// opaque as before, not a partial guess.
+fn loop_installed_member_shape(
+    grammar: &DefinitionBodyGrammar,
+    body_word: &str,
+    body_content_start: u32,
+    lexer_config: tcl_lexer::LexerConfig,
+    var_name: &str,
+) -> Option<(&'static str, Span)> {
+    let inner_cmds = crate::segmenter::segment_commands_with_offset_and_config(
+        body_word,
+        body_content_start,
+        lexer_config,
+    );
+    let mut real_cmds = inner_cmds
+        .iter()
+        .filter(|c| !c.is_partial && !c.argv.is_empty());
+    let inner = real_cmds.next()?;
+    if real_cmds.next().is_some() {
+        return None; // more than one statement — not the simple installer shape
+    }
+    let (inner_keyword, inner_texts, inner_argv, _modifier) =
+        unwrap_wrapper_member(grammar, &inner.texts, &inner.argv)?;
+    let kind = match inner_keyword {
+        "method" => "method",
+        "classmethod" => "classmethod",
+        _ => return None,
+    };
+    let member = grammar.member(inner_keyword)?;
+    let name_idx = member.indices_for(ArgRole::Name).next()?;
+    let name_word = inner_texts.get(name_idx)?;
+    if crate::static_loops::simple_var_ref(name_word).as_deref() != Some(var_name) {
+        return None;
+    }
+    let body_idx = member.indices_for(ArgRole::Body).next()?;
+    let body_span = inner_argv.get(body_idx).map_or(inner.span, |t| t.span);
+    Some((kind, body_span))
+}
+
 /// The synthetic name for a nameless snit member (one with no
 /// [`ArgRole::Name`]): `<keyword>`, with a leading roleless option word
 /// (snit 1.x `onconfigure`/`oncget`'s `-option`) appended when present so the
@@ -408,6 +523,134 @@ impl Analyser {
         })
     }
 
+    /// Record the per-name members a **literal** loop-installer declares,
+    /// even though [`Self::member_declaration_is_opaque`] has already (and
+    /// correctly) marked the class's member set incomplete because of it
+    /// (issue #1277).
+    ///
+    /// `foreach m {alpha beta gamma} { method $m {args} {…} }` computes
+    /// each member's *name* from the loop variable, which is why the
+    /// ordinary member walk cannot read it — but the loop's own list is
+    /// written right there in the source, so the set of names it will bind
+    /// `$m` to really is knowable without running the program. This adds
+    /// what can honestly be said on top of the existing abstention; it
+    /// never narrows `member_set_incomplete` back to "complete", because
+    /// knowing three names is not the same as knowing them all (a sibling
+    /// `oo::define` elsewhere, or a second, unreadable installer in the
+    /// same body, could still add more).
+    ///
+    /// Deliberately narrow — every condition below is a bail, not a best
+    /// effort, and any miss just leaves the loop as opaque as it already
+    /// was:
+    ///
+    /// * the head word must be a registry-declared "var/list pairs then a
+    ///   trailing body" loop shape ([`tcl_registry::Traits::LOOP_LIST_HEADER`]
+    ///   plus exactly one [`tcl_registry::repeated::RepeatedArgLayout`]
+    ///   covering a var/list pair) — `foreach`/`lmap`, decided from registry
+    ///   data, never a keyword;
+    /// * exactly one var/list pair (a multi-list `foreach` has no single
+    ///   variable a member's name word could unambiguously mean);
+    /// * the loop variable is one bare name, not a multi-variable group
+    ///   (`foreach {a b} $list …`);
+    /// * the list word is a **literal** Tcl list (no `$`/`[`) that parses
+    ///   cleanly;
+    /// * the body is exactly one member declaration (per `grammar`, unwrapped
+    ///   of any `self`/`private`) whose `Name` argument is exactly a
+    ///   reference to the loop variable — anything else (a fixed name, a
+    ///   name built from more than the bare variable, more than one
+    ///   statement) is left unread, exactly as before this ran.
+    ///
+    /// The recorded member's parameter list is always `params_computed`
+    /// (never re-derived from the loop body's own written params, even when
+    /// they look literal): a reflective installer's signature can itself be
+    /// computed per iteration (`method $m {*}[classDef $m]`), so treating
+    /// one binding's `{args}` as representative of every other would be a
+    /// fabrication for the general shape this exists to cover.
+    fn record_loop_installed_members(
+        &self,
+        grammar: &DefinitionBodyGrammar,
+        cmd: &crate::segmenter::SegmentedCommand,
+        class_def: &mut ClassDef,
+    ) {
+        let Some(keyword) = cmd.texts.first().map(String::as_str) else {
+            return;
+        };
+        let Some(spec) = self.registry.and_then(|r| r.get(keyword)) else {
+            return;
+        };
+        // Post-head argument count (`texts` still carries the keyword at 0).
+        let post_head = cmd.texts.len().saturating_sub(1);
+        let Some((var_idx, list_idx, body_idx)) = loop_installer_pair(spec, post_head) else {
+            return;
+        };
+        let (Some(var_word), Some(list_word), Some(body_word)) = (
+            cmd.texts.get(var_idx + 1),
+            cmd.texts.get(list_idx + 1),
+            cmd.texts.get(body_idx + 1),
+        ) else {
+            return;
+        };
+        // The loop variable must be one bare name.
+        let Ok(var_names) = tcl_syntax::list::split_list(var_word) else {
+            return;
+        };
+        if var_names.len() != 1 {
+            return; // a multi-variable group — no single name a `$var` could mean
+        }
+        let var_name = &var_names[0];
+        if !crate::value_shapes::is_static_var_word(var_name) {
+            return;
+        }
+        let Some(list_tok) = cmd.argv.get(list_idx + 1) else {
+            return;
+        };
+        let list_single = cmd
+            .single_token_word
+            .get(list_idx + 1)
+            .copied()
+            .unwrap_or(false);
+        let Some(members) = literal_loop_elements(list_word, *list_tok, list_single) else {
+            return;
+        };
+        let Some(body_tok) = cmd.argv.get(body_idx + 1) else {
+            return;
+        };
+        let body_content_start = body_tok.span.start() + u32::from(body_tok.content_offset);
+        let Some((kind, body_span)) = loop_installed_member_shape(
+            grammar,
+            body_word,
+            body_content_start,
+            self.lexer_config(),
+            var_name,
+        ) else {
+            return;
+        };
+        for (name, name_span) in members {
+            let md = MethodDef {
+                visibility: default_visibility(grammar, &name),
+                name,
+                params: Vec::new(),
+                params_computed: true,
+                name_span,
+                body_span,
+                kind: kind.to_string(),
+                is_self_method: false,
+                doc: String::new(),
+                forward_target: None,
+            };
+            // A literal, directly-written declaration elsewhere in the class
+            // always outranks a name merely *inferred* from the loop's list —
+            // this only ever fills a gap, never overrides real data, however
+            // the two are ordered in the source.
+            let table = if kind == "classmethod" {
+                &mut class_def.class_methods
+            } else {
+                &mut class_def.methods
+            };
+            table.entry(md.name.clone()).or_insert(md);
+        }
+    }
+
     pub(super) fn record_member_command_references(
         &mut self,
         grammar: &DefinitionBodyGrammar,
@@ -530,6 +773,11 @@ impl Analyser {
             // (see [`ClassDef::member_set_incomplete`], issue #923 idx 53).
             if self.member_declaration_is_opaque(grammar, cmd, texts) {
                 class_def.member_set_incomplete = true;
+                // The class surface stays a lower bound either way — this
+                // only ever adds names on top of that abstention when the
+                // opaque command turns out to be a literal loop installer
+                // (issue #1277).
+                self.record_loop_installed_members(grammar, cmd, class_def);
             }
             // A wrapper member's bare *script-block* form (`self { method m …
             // }`, `private { … }`) declares exactly the members its block
@@ -1242,6 +1490,7 @@ impl Analyser {
         let method_def = MethodDef {
             name: name.clone(),
             params: params.clone(),
+            params_computed: false,
             name_span,
             body_span,
             kind: kind.to_string(),
@@ -2463,6 +2712,7 @@ fn apply_oo_forward(
         let md = MethodDef {
             name: name.clone(),
             params: Vec::new(),
+            params_computed: false,
             name_span: span,
             body_span: span,
             kind: "forward".to_string(),
@@ -2783,6 +3033,7 @@ fn extract_method_def(
     Some(MethodDef {
         name,
         params,
+        params_computed: false,
         name_span,
         body_span,
         kind: kind.to_string(),

--- a/rust/tcl-compiler/src/analyser/oo.rs
+++ b/rust/tcl-compiler/src/analyser/oo.rs
@@ -324,6 +324,90 @@ impl Analyser {
     /// `MemberRefKind::Method` member names methods of *this* class rather than
     /// commands, so the method-reference machinery handles it, not this path.  A
     /// dynamic word (`superclass $base`) names no static command and is skipped.
+    /// Whether one command of a definition body installs members this walk
+    /// cannot read, making the class's recorded member tables a lower bound
+    /// ([`super::types::ClassDef::member_set_incomplete`], issue #923 idx 53).
+    ///
+    /// Two shapes qualify, neither matched by keyword:
+    ///
+    /// * a **member** word whose declaration is supplied dynamically — a
+    ///   `{*}` expansion that survived [`splice_static_member_expansions`]
+    ///   (only a braced literal splices statically), or a computed word in
+    ///   one of the member's own declaring roles (`method $m …`). Tcl
+    ///   resolves both at definition time, so the members are real; the
+    ///   analyser simply cannot name them.
+    /// * a **non-member** word that either has no registry spec (a helper
+    ///   proc, or a class-installer command from another file) or declares
+    ///   an [`ArgRole::Body`] argument — a script the member walk does not
+    ///   descend into, so any `method` inside it is invisible
+    ///   (`foreach m {…} { method $m … }`, `if {…} { method x {} {…} }`).
+    ///
+    /// Registry data decides both halves: the definer grammar says what a
+    /// member word is and which of its arguments declare, and the command
+    /// spec says whether a word carries a script. Nothing here names a
+    /// command or a keyword.
+    ///
+    /// A comment line segments to no words at all and is skipped by the
+    /// caller, so it never reaches this test.
+    fn member_declaration_is_opaque(
+        &self,
+        grammar: &DefinitionBodyGrammar,
+        cmd: &crate::segmenter::SegmentedCommand,
+        texts: &[String],
+    ) -> bool {
+        let Some(keyword) = texts.first() else {
+            return false;
+        };
+        let Some(member) = grammar.member(keyword) else {
+            // Not a member word. Unknown to the registry, or script-taking:
+            // either way this command can install members out of sight.
+            // Roles come from the static table *and* the per-call resolver
+            // (`foreach`'s layout depends on how many var/list pairs it was
+            // given, so its `Body` index is only knowable from the words).
+            return self.registry.as_ref().is_some_and(|registry| {
+                registry.get(keyword).is_none_or(|spec| {
+                    let args: Vec<&str> = texts.iter().skip(1).map(String::as_str).collect();
+                    let resolved = spec
+                        .arg_role_resolver
+                        .map(|resolve| resolve(&args))
+                        .unwrap_or_default();
+                    spec.arg_roles
+                        .iter()
+                        .chain(resolved.iter())
+                        .any(|(_, role)| *role == ArgRole::Body)
+                })
+            });
+        };
+        // A `{*}` word the splicer would refuse — anything but a single
+        // braced literal, whose element list is the only one knowable
+        // without running the program.  Tested per word (not "did any
+        // splice happen"), so a command mixing a spliceable and an
+        // unspliceable expansion is still opaque.
+        if let Some(expand) = cmd.expand_word.as_ref()
+            && expand.iter().enumerate().any(|(i, &e)| {
+                e && !(cmd.argv.get(i).is_some_and(|t| t.kind == TokenType::Str)
+                    && cmd.single_token_word.get(i).copied().unwrap_or(false))
+            })
+        {
+            return true;
+        }
+        // A computed member **name** — `method $m …`, the installer-loop
+        // spelling — declares a member the walk cannot name.  `+ 1` because
+        // role indices are relative to the member's arguments while `texts`
+        // still carries the keyword at 0.
+        //
+        // Only the name word is tested.  A parameter list or body word is a
+        // *script*, and a script routinely contains `$` and `[` without being
+        // dynamic in the sense that matters here (`constructor {x} { set a
+        // $x }` is entirely readable); the `{*}` test above is what catches
+        // the genuinely reflected signature.
+        member.indices_for(ArgRole::Name).any(|idx| {
+            texts
+                .get(idx + 1)
+                .is_some_and(|w| crate::naming::is_dynamic_word(w))
+        })
+    }
+
     pub(super) fn record_member_command_references(
         &mut self,
         grammar: &DefinitionBodyGrammar,
@@ -441,6 +525,12 @@ impl Analyser {
             if let (Some(subcmd), Some(tok)) = (texts.first(), argv.first()) {
                 self.emit_w002_oo_member_disabled(grammar, subcmd, *tok, definer_disabled);
             }
+            // …and when it does abstain, say so on the record: the member
+            // tables become a lower bound, not the class's whole surface
+            // (see [`ClassDef::member_set_incomplete`], issue #923 idx 53).
+            if self.member_declaration_is_opaque(grammar, cmd, texts) {
+                class_def.member_set_incomplete = true;
+            }
             // A wrapper member's bare *script-block* form (`self { method m …
             // }`, `private { … }`) declares exactly the members its block
             // spells out — so rewrite each inner command into the equivalent
@@ -474,37 +564,13 @@ impl Analyser {
                     method_bodies.push(mb);
                 }
             }
-            match texts.first().map(String::as_str) {
-                Some("property") => {
-                    collect_property_accessor_bodies(texts, argv, &mut accessor_bodies);
-                }
-                Some(kw @ ("initialise" | "initialize")) => {
-                    // A class-level init script. It is *not* collected by
-                    // `collect_method_body` (which is restricted to the four
-                    // real method-bearing members) but it does need its own
-                    // per-class scope — see the `init_bodies` walk below.
-                    if let Some(body_idx) = grammar
-                        .member(kw)
-                        .and_then(|m| m.indices_for(ArgRole::Body).next())
-                        .map(|i| i + 1)
-                        && let (Some(body), Some(tok)) =
-                            (texts.get(body_idx), argv.get(body_idx).copied())
-                        && tok.kind == TokenType::Str
-                    {
-                        init_bodies.push(CollectedMethodBody {
-                            name: format!("<{kw}>"),
-                            params: Vec::new(),
-                            body_text: body.clone(),
-                            body_tok: tok,
-                            params_tok: None,
-                            // A class-level init script is not a method
-                            // frame at all — `self` raises there.
-                            class_side: true,
-                        });
-                    }
-                }
-                _ => {}
-            }
+            collect_class_level_bodies(
+                grammar,
+                texts,
+                argv,
+                &mut accessor_bodies,
+                &mut init_bodies,
+            );
         }
         // A bareword-callable-from-this-class fact, gathered before Phase 2
         // starts (so it's already populated by the time member-lookup
@@ -1606,6 +1672,47 @@ fn walk_unknown_stmt(stmt: &Statement, first_param: &str, info: &mut UnknownProc
         | Statement::Incr { .. }
         | Statement::ExprEval { .. }
         | Statement::Return { .. } => {}
+    }
+}
+
+/// Collect the two class-level (non-method) body kinds a definition body
+/// can carry: a `property`'s `-get`/`-set` accessor scripts, and an
+/// `initialise`/`initialize` block.
+///
+/// Neither is a method frame, so [`collect_method_body`] — restricted to the
+/// four real method-bearing members — does not see them, yet each needs its
+/// own scope in phase 2. Split out of `parse_oo_definition_body` purely to
+/// keep that walker within its line budget.
+fn collect_class_level_bodies(
+    grammar: &DefinitionBodyGrammar,
+    texts: &[String],
+    argv: &[Token],
+    accessor_bodies: &mut Vec<CollectedMethodBody>,
+    init_bodies: &mut Vec<CollectedMethodBody>,
+) {
+    match texts.first().map(String::as_str) {
+        Some("property") => collect_property_accessor_bodies(texts, argv, accessor_bodies),
+        Some(kw @ ("initialise" | "initialize")) => {
+            if let Some(body_idx) = grammar
+                .member(kw)
+                .and_then(|m| m.indices_for(ArgRole::Body).next())
+                .map(|i| i + 1)
+                && let (Some(body), Some(tok)) = (texts.get(body_idx), argv.get(body_idx).copied())
+                && tok.kind == TokenType::Str
+            {
+                init_bodies.push(CollectedMethodBody {
+                    name: format!("<{kw}>"),
+                    params: Vec::new(),
+                    body_text: body.clone(),
+                    body_tok: tok,
+                    params_tok: None,
+                    // A class-level init script is not a method frame at
+                    // all — `self` raises there.
+                    class_side: true,
+                });
+            }
+        }
+        _ => {}
     }
 }
 

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -245,6 +245,7 @@ impl Analyser {
     pub fn analyse_per_item(&mut self, source: &str, dialect: &str) -> AnalysisResult {
         let disabled = self.disabled_diagnostics.clone();
         let non_ascii = self.non_ascii_mode;
+        let factories = self.workspace_class_factories.clone();
         let empty_overlay = super::types::build_stub_overlay(&[]);
         let mut body_fn = |db: &DeferredBody| {
             analyse_proc_body_isolated(
@@ -253,6 +254,7 @@ impl Analyser {
                 &disabled,
                 non_ascii,
                 Some(empty_overlay.clone()),
+                factories.clone(),
             )
         };
         self.analyse_per_item_with(source, dialect, &mut body_fn)
@@ -1180,10 +1182,19 @@ pub fn analyse_proc_body_isolated<S: std::hash::BuildHasher>(
     disabled: &std::collections::HashSet<String, S>,
     non_ascii: super::state::NonAsciiMode,
     stub_overlay: Option<tcl_registry::stub_overlay::StubOverlay>,
+    workspace_class_factories: Option<std::sync::Arc<super::types::ClassFactoryIndex>>,
 ) -> BodyFragment {
     // Rebuild into the default-hasher set `Analyser` stores.
     let disabled: std::collections::HashSet<String> = disabled.iter().cloned().collect();
-    let mut a = Analyser::with_disabled_diagnostics(disabled).with_non_ascii_mode(non_ascii);
+    // The workspace factory oracle travels with the body: a `Meta create …`
+    // inside a proc body is classified by the whole-file walk, so it must be
+    // classified identically here or the two strategies diverge on a class
+    // (issue #1276; the same trap the ensemble-call-site and global-cell bugs
+    // fell into).  Gated by
+    // `the_per_item_walk_agrees_with_the_whole_file_walk_cross_file`.
+    let mut a = Analyser::with_disabled_diagnostics(disabled)
+        .with_non_ascii_mode(non_ascii)
+        .with_workspace_class_factories(workspace_class_factories);
     a.profile = tcl_dialect::DialectProfile::by_name(dialect);
     a.stub_overlay = stub_overlay;
     // Offset 0: the body content is the whole source; a synthetic `Str` body

--- a/rust/tcl-compiler/src/analyser/scope.rs
+++ b/rust/tcl-compiler/src/analyser/scope.rs
@@ -1211,10 +1211,19 @@ impl Analyser {
             let ns: String = match resolved.strip_suffix(suffix.as_str()) {
                 Some("") => "::".to_owned(),
                 Some(prefix) => prefix.to_owned(),
-                // Not the `{ns}::{name}` shape the walk produces (an unusual
-                // spelling); the settled name is then the sole candidate.
+                // Not the `{ns}::{name}` shape the walk produces.  A folded
+                // dynamic head (`${ns}::setdef`) is exactly this case — the
+                // written name is not the dispatched one — and the walk
+                // already recorded its candidate list from the *folded* name,
+                // so settle against that instead of discarding it (issue #923
+                // idx 54 residual: without this the local-first guess
+                // `::tk::tk::setdef` was never demoted to the global
+                // `::tk::setdef` the call really reaches, and find-references
+                // from the declaration missed the site).  An unusual spelling
+                // with no recorded candidates keeps the old behaviour: the
+                // settled name is the sole candidate.
                 None => {
-                    inv.resolution_candidates = vec![resolved];
+                    settle_prebuilt_candidates(inv, resolved, &known_ctx);
                     continue;
                 }
             };
@@ -1265,7 +1274,41 @@ impl Analyser {
         // last-write-wins across `if`/loop joins and discards the defining
         // literal's writable span).
     }
+}
 
+/// Settle an invocation whose candidate list was built at **walk** time
+/// rather than by [`Analyser::finalise_invocation_resolutions`] — a folded
+/// dynamic head, whose written name is not the dispatched one and so does
+/// not carry the `{ns}::{name}` shape the namespace recovery needs.
+///
+/// The first known candidate wins, exactly as
+/// [`crate::naming::resolve_command_with`] would.  With no recorded
+/// candidates this keeps the pre-existing behaviour: the settled name is the
+/// sole candidate (issue #923 idx 54 residual — before this, the walk's
+/// local-first guess `::tk::tk::setdef` was never demoted to the global
+/// `::tk::setdef` the call really reaches, so find-references from the
+/// declaration missed the site while go-to-definition found it).
+fn settle_prebuilt_candidates<A>(
+    inv: &mut crate::signature_scan::types::SignatureCommandInvocation,
+    resolved: String,
+    known_ctx: &KnownPredicateCtx<'_, A>,
+) {
+    if inv.resolution_candidates.is_empty() {
+        inv.resolution_candidates = vec![resolved];
+        return;
+    }
+    let call_off = inv.range.start();
+    if let Some(winner) = inv
+        .resolution_candidates
+        .iter()
+        .find(|c| known_ctx.known(c, call_off))
+        && *winner != resolved
+    {
+        inv.resolved_qualified_name = Some(winner.clone());
+    }
+}
+
+impl Analyser {
     /// Record a constant string assignment for `var_name` in the
     /// scope at `scope_path`.
     pub fn set_const_string(

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -774,6 +774,19 @@ pub struct Analyser {
     /// class (e.g. method-existence checks) are unaffected — only the opt-in
     /// cross-file re-analysis populates it.
     pub workspace_classes: std::collections::HashSet<String>,
+    /// Class **factories** — user-defined `TclOO` metaclasses — declared
+    /// elsewhere in the workspace, keyed by fully-qualified name.
+    ///
+    /// The per-file walk cannot tell `::tk::Megawidget create IconList
+    /// FocusableWidget {…}` from `interp create` without knowing that
+    /// `::tk::Megawidget` is a metaclass, so with no index it abstains and
+    /// records nothing (issue #1276).  Each entry is the factory description
+    /// the metaclass's *own* document derived
+    /// ([`super::types::ClassDef::factory`]), so the consuming walk classifies
+    /// the call from a proved fact rather than its shape.  `None` — the
+    /// default, and every single-file analysis — keeps the abstention exactly
+    /// as it was.
+    pub workspace_class_factories: Option<std::sync::Arc<super::types::ClassFactoryIndex>>,
     /// When `true` (the per-item shell walk), `handle_proc_command` / OO method
     /// walks record their body for separate analysis (`deferred_bodies`) instead
     /// of recursing into it immediately.  Set only for the shell pass; the
@@ -1138,6 +1151,7 @@ impl Analyser {
             non_ascii_mode: NonAsciiMode::Default,
             structure_only: false,
             workspace_classes: std::collections::HashSet::new(),
+            workspace_class_factories: None,
             defer_proc_bodies: false,
             structural_rebind: false,
             deferred_bodies: Vec::new(),
@@ -1210,6 +1224,22 @@ impl Analyser {
     #[must_use]
     pub fn with_workspace_classes(mut self, classes: std::collections::HashSet<String>) -> Self {
         self.workspace_classes = classes;
+        self
+    }
+
+    /// Supply the workspace's **class factory** index — the user-defined
+    /// `TclOO` metaclasses declared in other documents — so a
+    /// `::tk::Megawidget create IconList …` call whose metaclass lives in
+    /// another file is classified instead of abstained on (issue #1276).
+    ///
+    /// See [`Self::workspace_class_factories`]. The normal single-file
+    /// analysis leaves this `None`, which keeps the abstention intact.
+    #[must_use]
+    pub fn with_workspace_class_factories(
+        mut self,
+        factories: Option<std::sync::Arc<super::types::ClassFactoryIndex>>,
+    ) -> Self {
+        self.workspace_class_factories = factories;
         self
     }
 

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -539,7 +539,28 @@ pub struct MethodDef {
     pub name: String,
     /// Parameters parsed from the method's parameter list.
     /// Empty for ``destructor`` (no parameter slot in the syntax).
+    ///
+    /// Empty *and* [`Self::params_computed`] set means "unknown", not
+    /// "none" — see that field.
     pub params: Vec<ParamDef>,
+    /// The method's formals are unmodelled: either the parameter-list word
+    /// was itself computed, or — the case this field was added for
+    /// (issue #1277) — the *method* itself was installed by a literal
+    /// loop (`foreach m {alpha beta gamma} { method $m {args} {…} }`)
+    /// whose per-iteration name this walk can read off the loop's own
+    /// literal list, but whose per-iteration signature it deliberately
+    /// does not attempt to re-derive (a reflective installer's parameter
+    /// list can itself be computed per iteration — `method $m {*}[classDef
+    /// $m]` — so treating one iteration's literal `{args}` as
+    /// representative of every other would be a fabrication for the
+    /// general shape this exists to cover, even on the rare iteration
+    /// where it happens to be right).
+    ///
+    /// Mirrors [`crate::analyser::ProcDef::params_computed`] exactly: every
+    /// arity-shaped consumer must ask [`Self::arity`] rather than compute
+    /// one from [`Self::params`] directly, so the abstention cannot be
+    /// forgotten at one call site.
+    pub params_computed: bool,
     /// Source span of the name token.
     pub name_span: Span,
     /// Source span of the method body (braces excluded).
@@ -574,6 +595,27 @@ pub struct MethodDef {
     /// arity). `None` for every other kind, and for a `forward` whose
     /// target couldn't be parsed.
     pub forward_target: Option<(String, Vec<String>)>,
+}
+
+impl MethodDef {
+    /// The method's declared argument arity — or the **abstaining**
+    /// `0..unlimited` when its parameter list is unmodelled
+    /// ([`Self::params_computed`], issue #1277).
+    ///
+    /// Exactly [`ProcDef::arity`]'s contract, extended to `MethodDef`: every
+    /// arity consumer (`$obj method` call-site checking, `next`/`nextto`
+    /// dispatch) asks here rather than calling
+    /// [`crate::signature_scan::arity::arity_of`] on [`Self::params`]
+    /// directly, so a member whose name is all this walk could honestly
+    /// record never has its absent parameter list mistaken for a
+    /// zero-argument one.
+    #[must_use]
+    pub fn arity(&self) -> tcl_registry::Arity {
+        if self.params_computed {
+            return tcl_registry::Arity::new(0, tcl_registry::Arity::UNLIMITED);
+        }
+        crate::signature_scan::arity::arity_of(&self.params)
+    }
 }
 
 /// Stable composite key naming a class's instance method or class method:

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -1142,6 +1142,33 @@ pub struct ClassDef {
     /// they do for one whose superclass lives outside the workspace index —
     /// a method it inherits is not one it is missing (issue #923 idx 96/97).
     pub inheritance_unknown: bool,
+    /// `true` when the class's definition body installs members the analyser
+    /// could not read, so the recorded member tables are a **lower bound**
+    /// on what the class really has (issue #923 idx 53).
+    ///
+    /// Two shapes set it, both registry-driven rather than keyword-matched:
+    ///
+    /// * a recognised member word whose declaration is supplied through an
+    ///   unresolvable `{*}` expansion or a computed name —
+    ///   `constructor {*}[info class constructor ::Base]`,
+    ///   `method $m {*}[info class definition ::Base $m]` (the ticklecharts
+    ///   `chart3D` reflection idiom). Tcl expands these at definition time,
+    ///   so the members are entirely real; only their spelling is opaque.
+    /// * a body command that is **not** a member word and either has no
+    ///   registry spec at all (a helper proc that installs members) or takes
+    ///   a script argument the member walk does not descend into
+    ///   (`foreach m {…} { method $m … }`, `if {…} { method … }`).
+    ///
+    /// The class itself, and every member that *was* readable, stay fully
+    /// modelled — this only says "there may be more". Method-existence
+    /// checks (W308) must therefore abstain on such a class, exactly as they
+    /// do for [`Self::inheritance_unknown`]: a method installed by
+    /// reflection is not a method that is missing. tclsh 9.0.4 and 8.6.16
+    /// agree that `oo::class create C3 { constructor {*}[info class
+    /// constructor ::C] ; foreach m {options} { method $m {*}[info class
+    /// definition ::C $m] } }` yields `info class methods ::C3` → `options`,
+    /// and `[C3 new] options` really runs.
+    pub member_set_incomplete: bool,
 }
 
 impl Default for ClassDef {
@@ -1182,6 +1209,7 @@ impl Default for ClassDef {
             doc: String::new(),
             via_define: false,
             inheritance_unknown: false,
+            member_set_incomplete: false,
         }
     }
 }

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -1101,7 +1101,7 @@ fn rehome_member(
                     text: text.clone(),
                     token: elsewhere,
                 },
-                other => other.clone(),
+                splice @ FactoryWord::CallerSplice(_) => splice.clone(),
             })
             .collect(),
     })

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -1969,6 +1969,23 @@ pub struct AnalysisResult {
 }
 
 impl AnalysisResult {
+    /// Every **class factory** this document declares, keyed by qualified
+    /// name — the slice a host merges into the workspace factory index it
+    /// feeds back through
+    /// [`Analyser::with_workspace_class_factories`](super::Analyser::with_workspace_class_factories)
+    /// (issue #1276).
+    ///
+    /// A document that declares no user metaclass — nearly all of them —
+    /// contributes an empty map, so the merged index stays empty and every
+    /// consuming walk behaves exactly as it did before.
+    #[must_use]
+    pub fn class_factories(&self) -> ClassFactoryIndex {
+        self.all_classes
+            .iter()
+            .filter_map(|(qname, class)| Some((qname.clone(), class.factory.clone()?)))
+            .collect()
+    }
+
     /// The [`ClassHierarchy`](super::class_hierarchy::ClassHierarchy) for
     /// this result's classes, built once and cached.  Prefer this over
     /// calling [`build_class_hierarchy`](super::class_hierarchy::build_class_hierarchy)

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -22,9 +22,9 @@
 //! actually populates. Each handler fills in the variant fields of
 //! the records it owns as it walks.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
-use tcl_lexer::Span;
+use tcl_lexer::{Span, Token};
 
 use crate::signature_scan::types::{
     ParamDef, SignatureCommandAlias, SignatureCommandInvocation, SignatureNamespaceExport,
@@ -966,6 +966,147 @@ impl DefinitionAbort {
     }
 }
 
+/// One word of a definition-body member a class factory splices into every
+/// class it manufactures, as a **template** over the creation call's own
+/// arguments.
+///
+/// The template is call-site independent, which is the whole point: it is
+/// derived once, where the metaclass is written, and then resolved against
+/// each `Meta create …` call — including one in a different file, which is
+/// the only way the per-file walk can classify such a call at all
+/// (issue #1276).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum FactoryWord {
+    /// A word the manufacturer writes literally in its own body
+    /// (`superclass ::tk::MegawidgetClass`), with the token it occupies
+    /// **in the metaclass's own document**.
+    Literal {
+        /// The word's text.
+        text: String,
+        /// Its token in the defining document — usable only while resolving
+        /// a call in that same document (see
+        /// [`ClassFactory::resolve_in_other_document`]).
+        token: Token,
+    },
+    /// A `{*}$param` splice of the creation call's argument at this index
+    /// (argument 0 being the manufacturer subcommand itself), so the words
+    /// it contributes are the caller's own and carry the caller's tokens.
+    CallerSplice(usize),
+}
+
+/// One definition-body member a class factory injects, as a template.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FactoryMember {
+    /// Member keyword followed by its argument words.
+    pub words: Vec<FactoryWord>,
+}
+
+/// The word layout one manufacturer subcommand of a class factory imposes,
+/// plus what it splices into every body it makes.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ManufacturerSpec {
+    /// Argument index of the new class's name.
+    pub name_arg: usize,
+    /// Argument index of the new class's definition body.
+    pub body_arg: usize,
+    /// The members the manufacturer always injects, or `None` when its
+    /// prologue could not be read — the
+    /// [`ClassDef::inheritance_unknown`] case.
+    pub injected: Option<Vec<FactoryMember>>,
+}
+
+/// Workspace-wide class factories, keyed by fully-qualified metaclass name —
+/// what a host hands the analyser so a `Meta create …` call can be classified
+/// when `Meta` is written in another document (issue #1276).
+pub type ClassFactoryIndex = BTreeMap<String, ClassFactory>;
+
+/// How a user-defined `TclOO` metaclass manufactures classes.
+///
+/// Recorded on the metaclass's own [`ClassDef`] when it is written, so a
+/// `Meta create Name …` call anywhere — same file or, through the workspace
+/// factory index, another one — is classified from a fact that was *proved*
+/// at the definition rather than guessed from the call's shape (issue #1276).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub struct ClassFactory {
+    /// The registry metaclass command at the root of this factory's
+    /// superclass chain (`oo::class`), whose definition-body grammar governs
+    /// every body the factory makes.
+    pub root_metaclass: String,
+    /// Per manufacturer subcommand (`create` / `new` / …) word layout, for
+    /// the subcommands the factory **overrides**.  A subcommand with no entry
+    /// runs the inherited manufacturer, i.e. the builtin `create Name Body`
+    /// layout with nothing injected.
+    pub overrides: BTreeMap<String, ManufacturerSpec>,
+}
+
+impl ClassFactory {
+    /// The same factory with every literal word's token replaced by
+    /// `elsewhere` — what a **cross-document** consumer must use, because the
+    /// stored tokens index the metaclass's own document, not the caller's.
+    ///
+    /// A member whose registry spec *retracts* (`deletemethod` /
+    /// `renamemethod`) reads its argument tokens for real, so an injection
+    /// containing one cannot be resolved against a foreign document at all:
+    /// the whole injection collapses to `None` (inheritance unknown) rather
+    /// than being applied against a substituted span.  `retracts` is supplied
+    /// by the caller, which owns the registry lookup.
+    #[must_use]
+    pub fn resolve_in_other_document(
+        &self,
+        elsewhere: Token,
+        retracts: &dyn Fn(&str) -> bool,
+    ) -> Self {
+        let overrides = self
+            .overrides
+            .iter()
+            .map(|(sub, spec)| {
+                let injected = spec.injected.as_ref().and_then(|members| {
+                    members
+                        .iter()
+                        .map(|m| rehome_member(m, elsewhere, retracts))
+                        .collect::<Option<Vec<_>>>()
+                });
+                (sub.clone(), ManufacturerSpec { injected, ..*spec })
+            })
+            .collect();
+        Self {
+            root_metaclass: self.root_metaclass.clone(),
+            overrides,
+        }
+    }
+}
+
+/// One injected member's words re-homed onto `elsewhere`, or `None` when the
+/// member's own effect reads the tokens it would lose.
+fn rehome_member(
+    member: &FactoryMember,
+    elsewhere: Token,
+    retracts: &dyn Fn(&str) -> bool,
+) -> Option<FactoryMember> {
+    let keyword = match member.words.first() {
+        Some(FactoryWord::Literal { text, .. }) => text.as_str(),
+        // A member whose *keyword* is spliced from the caller is not a shape
+        // the prologue reader produces, and cannot be classified here.
+        _ => return None,
+    };
+    if retracts(keyword) {
+        return None;
+    }
+    Some(FactoryMember {
+        words: member
+            .words
+            .iter()
+            .map(|w| match w {
+                FactoryWord::Literal { text, .. } => FactoryWord::Literal {
+                    text: text.clone(),
+                    token: elsewhere,
+                },
+                other => other.clone(),
+            })
+            .collect(),
+    })
+}
+
 /// Class definition record.
 ///
 /// The structural fields (`superclasses`, `mixins`, `methods`,
@@ -1169,6 +1310,17 @@ pub struct ClassDef {
     /// definition ::C $m] } }` yields `info class methods ::C3` → `options`,
     /// and `[C3 new] options` really runs.
     pub member_set_incomplete: bool,
+    /// Present when this class is itself a **class factory** — a user-defined
+    /// `TclOO` metaclass whose superclass chain reaches `oo::class`.
+    ///
+    /// It describes how the factory manufactures classes (which creation
+    /// argument is the name, which is the body, what the manufacturer splices
+    /// into every body), derived once here rather than re-derived at each
+    /// `Meta create …` call.  Publishing it on the `ClassDef` is what lets a
+    /// *different file*'s walk classify `::tk::Megawidget create IconList …`
+    /// at all (issue #1276): without it, that call is indistinguishable from
+    /// `interp create` or `image create`.
+    pub factory: Option<ClassFactory>,
 }
 
 impl Default for ClassDef {
@@ -1210,6 +1362,7 @@ impl Default for ClassDef {
             via_define: false,
             inheritance_unknown: false,
             member_set_incomplete: false,
+            factory: None,
         }
     }
 }

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -5107,18 +5107,20 @@ mod class_factories {
         assert!(codes[0].contains("nosuch"), "{codes:?}");
     }
 
-    /// A user metaclass whose own definition is in **another file** cannot be
-    /// recognised: the analyser is per-file, and nothing in
-    /// `X create Name Supers Body` distinguishes a class factory from
-    /// `interp create`, `image create`, or any ordinary proc taking a script
-    /// argument.  Guessing would invent classes out of unrelated commands, so
-    /// the LSP abstains — records no class, and emits no diagnostic about the
-    /// members it therefore cannot see (issue #923 idx 97, the multi-file
-    /// half; Tk's own `library/iconlist.tcl` is exactly this shape).
+    /// A user metaclass whose own definition is in **another file** and whose
+    /// declaration the host never indexed cannot be recognised: the analyser
+    /// is per-file, and nothing in `X create Name Supers Body` distinguishes
+    /// a class factory from `interp create`, `image create`, or any ordinary
+    /// proc taking a script argument.  Guessing would invent classes out of
+    /// unrelated commands, so the LSP abstains — records no class, and emits
+    /// no diagnostic about the members it therefore cannot see (issue #923
+    /// idx 97, the multi-file half).
     ///
-    /// The single-file case — the metaclass and its products in one file, as
-    /// in Tk's `library/megawidget.tcl` — is fully resolved; see
-    /// `user_metaclass_creates_real_classes` above.
+    /// This is the **floor** the workspace factory index raises, not
+    /// replaces: with no index (every single-file analysis, and every host
+    /// that has not enumerated the project) the behaviour is unchanged.  The
+    /// resolving half is `a_workspace_indexed_metaclass_creates_real_classes`
+    /// below; Tk's own `library/iconlist.tcl` is that shape.
     #[test]
     fn a_metaclass_defined_in_another_file_abstains_rather_than_guessing() {
         let src = concat!(
@@ -5138,6 +5140,329 @@ mod class_factories {
                 .all(|d| d.code.to_string() != "W308" && d.code.to_string() != "W001"),
             "abstention must be silent, not a wrong answer: {:?}",
             r.diagnostics
+        );
+    }
+
+    // -- cross-file class factories (issue #1276) ------------------------
+    //
+    // Ground truth, byte-identical on tclsh 8.6.14 and 9.0.4, for the
+    // three-file shape below (`megawidget.tcl` / `base.tcl` /
+    // `iconlist.tcl`, each `source`d in turn):
+    //
+    //   info object isa class ::IconList          -> 1
+    //   info class superclasses ::IconList        -> ::tk::MegawidgetClass ::FocusableWidget
+    //   info class methods ::IconList -private    -> CreateHull GetSpecs
+    //   info class superclasses ::FocusableWidget -> ::tk::MegawidgetClass
+    //   [::IconList new] CreateHull               -> iconlist-hull/hull-from-FocusableWidget
+    //   [::IconList new] TraceOption a b          -> traced-from-MegawidgetClass
+    //
+    // i.e. the class, its members, its spliced superclass, and the `next`
+    // chain through the injected base are all real — the file that writes
+    // `::tk::Megawidget create IconList …` just cannot see any of it on its
+    // own.
+
+    /// The metaclass file of the three-file shape.
+    const META_FILE: &str = concat!(
+        "oo::class create ::tk::MegawidgetClass {\n",
+        "    method TraceOption {a b} { return traced-from-MegawidgetClass }\n",
+        "}\n",
+        "oo::class create ::tk::Megawidget {\n",
+        "    superclass oo::class\n",
+        "    self method create {name superclasses body} {\n",
+        "        next $name [list superclass ::tk::MegawidgetClass {*}$superclasses]\\;$body\n",
+        "    }\n",
+        "}\n",
+    );
+
+    /// The consumer file — Tk's `library/iconlist.tcl` shape, reduced.
+    const CONSUMER_FILE: &str = concat!(
+        "::tk::Megawidget create IconList FocusableWidget {\n",
+        "    method GetSpecs {} { return iconlist }\n",
+        "    method CreateHull {} { return hull }\n",
+        "}\n",
+    );
+
+    /// The workspace factory index `src` publishes — what a host merges and
+    /// hands back to a consumer document's analysis.
+    fn factories_of(src: &str) -> std::sync::Arc<tcl_compiler::analyser::ClassFactoryIndex> {
+        std::sync::Arc::new(analysis(src, "tcl9.0").class_factories())
+    }
+
+    /// Analyse `src` with `index` supplied as the workspace factory oracle.
+    fn analysis_with_factories(
+        src: &str,
+        index: &std::sync::Arc<tcl_compiler::analyser::ClassFactoryIndex>,
+    ) -> AnalysisResult {
+        Analyser::new()
+            .with_workspace_class_factories(Some(std::sync::Arc::clone(index)))
+            .analyse(src, "tcl9.0")
+    }
+
+    #[test]
+    fn a_metaclass_file_publishes_exactly_one_factory() {
+        // Non-vacuity floor for every test below: the index really carries
+        // `::tk::Megawidget` (and only it — `::tk::MegawidgetClass` is an
+        // ordinary class, not a factory), and the factory really describes
+        // the `{name superclasses body}` layout rather than the builtin one.
+        let index = factories_of(META_FILE);
+        assert_eq!(
+            index.keys().collect::<Vec<_>>(),
+            ["::tk::Megawidget"],
+            "{index:?}"
+        );
+        let spec = &index["::tk::Megawidget"].overrides["create"];
+        assert_eq!((spec.name_arg, spec.body_arg), (1, 3), "{spec:?}");
+        assert!(spec.injected.is_some(), "readable prologue: {spec:?}");
+    }
+
+    #[test]
+    fn a_workspace_indexed_metaclass_creates_real_classes() {
+        // TP — idx 97, the multi-file half.  The consumer file names
+        // `::tk::Megawidget` and nothing else about it; the index proves it
+        // is a factory, so the class, its members, and the superclasses the
+        // manufacturer splices all come out matching the tclsh oracle above.
+        let index = factories_of(META_FILE);
+        let r = analysis_with_factories(CONSUMER_FILE, &index);
+        let cd = r
+            .all_classes
+            .get("::IconList")
+            .unwrap_or_else(|| panic!("::IconList recorded: {:?}", r.all_classes.keys()));
+        let mut methods: Vec<&str> = cd.methods.keys().map(String::as_str).collect();
+        methods.sort_unstable();
+        assert_eq!(methods, ["CreateHull", "GetSpecs"], "{cd:?}");
+        assert_eq!(
+            cd.superclasses,
+            ["::tk::MegawidgetClass", "FocusableWidget"],
+            "{cd:?}"
+        );
+        assert!(!cd.inheritance_unknown, "{cd:?}");
+    }
+
+    #[test]
+    fn the_cross_file_result_matches_the_same_file_result() {
+        // The two tiers must describe the same class: concatenating the
+        // metaclass file with the consumer is the same program, so the
+        // recorded members / superclasses / opacity flags must agree
+        // field-for-field.  (Spans differ — the text is at a different
+        // offset — so the comparison is over the modelled facts.)
+        let index = factories_of(META_FILE);
+        let cross = analysis_with_factories(CONSUMER_FILE, &index);
+        let same = analysis(&format!("{META_FILE}{CONSUMER_FILE}"), "tcl9.0");
+        let a = &cross.all_classes["::IconList"];
+        let b = &same.all_classes["::IconList"];
+        assert_eq!(a.superclasses, b.superclasses, "{a:?}\n{b:?}");
+        assert_eq!(a.inheritance_unknown, b.inheritance_unknown);
+        assert_eq!(a.member_set_incomplete, b.member_set_incomplete);
+        let mut ma: Vec<&str> = a.methods.keys().map(String::as_str).collect();
+        let mut mb: Vec<&str> = b.methods.keys().map(String::as_str).collect();
+        ma.sort_unstable();
+        mb.sort_unstable();
+        assert_eq!(ma, mb);
+    }
+
+    #[test]
+    fn the_per_item_walk_agrees_with_the_whole_file_walk_cross_file() {
+        // The per-item (incremental) strategy defers proc / method bodies to
+        // an isolated second pass, and this campaign has already found two
+        // bugs where that path silently lost a fact the whole-file walk kept.
+        // A creation call at load level *and* one inside a proc body are both
+        // exercised, and the two strategies must produce identical results —
+        // asserted directly rather than assumed.
+        let index = factories_of(META_FILE);
+        let src = concat!(
+            "::tk::Megawidget create IconList FocusableWidget {\n",
+            "    method GetSpecs {} { return iconlist }\n",
+            "}\n",
+            "proc late {} {\n",
+            "    ::tk::Megawidget create Deferred FocusableWidget {\n",
+            "        method Inner {} { return inner }\n",
+            "    }\n",
+            "}\n",
+        );
+        let whole = analysis_with_factories(src, &index);
+        let per_item = Analyser::new()
+            .with_workspace_class_factories(Some(std::sync::Arc::clone(&index)))
+            .analyse_per_item(src, "tcl9.0");
+        for name in ["::IconList", "::Deferred"] {
+            assert!(
+                whole.all_classes.contains_key(name),
+                "{name} on the whole-file walk: {:?}",
+                whole.all_classes.keys().collect::<Vec<_>>()
+            );
+        }
+        assert_eq!(
+            whole.all_classes, per_item.all_classes,
+            "per-item and whole-file class tables must be identical"
+        );
+        assert_eq!(whole.diagnostics, per_item.diagnostics);
+    }
+
+    #[test]
+    fn a_dynamic_metaclass_name_still_abstains() {
+        // TN, the non-negotiable half — the command word is a runtime value,
+        // so *no* index can prove what it names.  The abstention is narrowed
+        // to provable names, never removed.
+        let index = factories_of(META_FILE);
+        let src = concat!(
+            "set meta ::tk::Megawidget\n",
+            "$meta create IconList FocusableWidget {\n",
+            "    method GetSpecs {} { return iconlist }\n",
+            "}\n",
+        );
+        let r = analysis_with_factories(src, &index);
+        assert!(
+            !r.all_classes.contains_key("::IconList"),
+            "a dynamic head proves nothing: {:?}",
+            r.all_classes.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn an_unindexed_metaclass_still_abstains() {
+        // TN — the index is populated, but with a different metaclass.  A
+        // name it does not carry stays exactly as unrecognised as it was
+        // before the index existed.
+        let index = factories_of(META_FILE);
+        let src = concat!(
+            "::some::OtherFactory create IconList FocusableWidget {\n",
+            "    method GetSpecs {} { return iconlist }\n",
+            "}\n",
+        );
+        let r = analysis_with_factories(src, &index);
+        assert!(
+            !r.all_classes.contains_key("::IconList"),
+            "{:?}",
+            r.all_classes.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn a_workspace_metaclass_is_not_reached_by_a_same_tailed_bare_name() {
+        // TN (cross-link guard, the #1063 precedent carried across files) —
+        // the index holds `::tk::Megawidget`; a *global* `Megawidget create …`
+        // names `::Megawidget`, which real Tcl does not resolve to it.
+        // Matching on the tail would manufacture a class the interpreter
+        // never makes.
+        let index = factories_of(META_FILE);
+        let src = concat!(
+            "Megawidget create IconList FocusableWidget {\n",
+            "    method GetSpecs {} { return iconlist }\n",
+            "}\n",
+        );
+        let r = analysis_with_factories(src, &index);
+        assert!(
+            !r.all_classes.contains_key("::IconList"),
+            "{:?}",
+            r.all_classes.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn a_bare_name_inside_the_metaclass_namespace_does_resolve() {
+        // TP — the mirror of the guard above: inside `namespace eval ::tk`,
+        // a bare `Megawidget` *is* `::tk::Megawidget` by Tcl's own
+        // current-namespace-then-global rule, so it resolves.  Without this
+        // the guard could be satisfied by never resolving anything.
+        let index = factories_of(META_FILE);
+        let src = concat!(
+            "namespace eval ::tk {\n",
+            "    Megawidget create IconList FocusableWidget {\n",
+            "        method GetSpecs {} { return iconlist }\n",
+            "    }\n",
+            "}\n",
+        );
+        let r = analysis_with_factories(src, &index);
+        assert!(
+            r.all_classes.contains_key("::tk::IconList"),
+            "{:?}",
+            r.all_classes.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn a_local_metaclass_shadows_the_workspace_one() {
+        // TN — a class of the same qualified name written *here* is what the
+        // interpreter would have; the index must not override it.  The local
+        // `::tk::Megawidget` is an ordinary class, so its `create` makes an
+        // instance and no `::IconList` class may appear.
+        let index = factories_of(META_FILE);
+        let src = concat!(
+            "oo::class create ::tk::Megawidget {\n",
+            "    method notafactory {} { return 1 }\n",
+            "}\n",
+            "::tk::Megawidget create IconList FocusableWidget {\n",
+            "    method GetSpecs {} { return iconlist }\n",
+            "}\n",
+        );
+        let r = analysis_with_factories(src, &index);
+        assert!(
+            !r.all_classes.contains_key("::IconList"),
+            "the local definition wins: {:?}",
+            r.all_classes.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn an_unreadable_cross_file_prologue_marks_inheritance_unknown() {
+        // Abstention preserved across the index: the factory's own prologue
+        // is built from a runtime value, so it publishes `injected: None` and
+        // the consumer records the class with its inheritance opaque —
+        // exactly what the same-file path does.
+        let meta = concat!(
+            "oo::class create ::ns::Meta {\n",
+            "    superclass oo::class\n",
+            "    self method create {name extra body} {\n",
+            "        next $name [list superclass [pickBase $extra]]\\;$body\n",
+            "    }\n",
+            "}\n",
+        );
+        let index = factories_of(meta);
+        assert!(
+            index["::ns::Meta"].overrides["create"].injected.is_none(),
+            "{index:?}"
+        );
+        let src = concat!(
+            "::ns::Meta create Widget somewhere {\n",
+            "    method m {} { return 1 }\n",
+            "}\n",
+        );
+        let cd = analysis_with_factories(src, &index)
+            .all_classes
+            .get("::Widget")
+            .cloned()
+            .expect("::Widget recorded");
+        assert!(cd.inheritance_unknown, "{cd:?}");
+        assert!(cd.superclasses.is_empty(), "{cd:?}");
+        assert!(cd.methods.contains_key("m"), "{cd:?}");
+    }
+
+    #[test]
+    fn a_cross_file_factory_keeps_method_checks_live_when_it_can() {
+        // FN guard — resolving cross-file must not blanket-suppress W308.
+        // `PlainMeta` injects nothing provably, so a method that exists
+        // nowhere on the manufactured class still warns.
+        let meta = concat!(
+            "oo::class create ::ns::PlainMeta {\n",
+            "    superclass oo::class\n",
+            "    self method create {name body} { next $name $body }\n",
+            "}\n",
+        );
+        let index = factories_of(meta);
+        let src = concat!(
+            "::ns::PlainMeta create PlainWidget {\n",
+            "    method own {} { return plain-own }\n",
+            "}\n",
+            "set w [PlainWidget new]\n",
+            "$w nosuchmethod\n",
+        );
+        let r = analysis_with_factories(src, &index);
+        assert!(
+            r.diagnostics.iter().any(|d| d.code.to_string() == "W308"),
+            "{:?}",
+            r.diagnostics
+                .iter()
+                .map(|d| d.code.to_string())
+                .collect::<Vec<_>>()
         );
     }
 

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -5034,9 +5034,16 @@ mod class_factories {
     fn a_foreach_member_installer_marks_the_member_set_incomplete() {
         // TP — idx 53's other half: the ticklecharts `chart3D` installer
         // loop.  `foreach` is not a member word and carries a script the
-        // member walk never descends into, so every `method` it installs is
-        // invisible; the class must say so.  tclsh 9.0.4 / 8.6.16: `info
-        // class methods ::C3` really lists `options` and `globalOptions`.
+        // member walk never descends into, so the class must say its member
+        // tables are a lower bound. tclsh 9.0.4 / 8.6.16: `info class
+        // methods ::C3` really lists `options` and `globalOptions`.
+        //
+        // Since issue #1277, the loop's own literal list means the two
+        // *names* are no longer invisible either (see
+        // `a_literal_foreach_installer_records_member_names_as_signature_unknown`
+        // below for the full positive case) — but the set stays incomplete
+        // regardless, because knowing these two names is not the same as
+        // knowing there could never be a third from elsewhere.
         let src = concat!(
             "oo::class create C3 {\n",
             "    foreach m {options globalOptions} {\n",
@@ -5047,6 +5054,93 @@ mod class_factories {
         );
         let cd = class(src, "::C3");
         assert!(cd.methods.contains_key("getType"), "{cd:?}");
+        assert!(cd.methods.contains_key("options"), "{cd:?}");
+        assert!(cd.methods.contains_key("globalOptions"), "{cd:?}");
+        assert!(cd.member_set_incomplete, "{cd:?}");
+    }
+
+    #[test]
+    fn a_literal_foreach_installer_records_member_names_as_signature_unknown() {
+        // TP — issue #1277's headline case: `foreach m {alpha beta gamma} {
+        // method $m {args} {…} }`. tclsh 9.0.4 / 8.6.16 both agree `alpha`,
+        // `beta`, `gamma` are real members of any arity (`args` — see the
+        // oracle transcript in the PR description); the walk can read their
+        // *names* off the loop's own literal list even though it still
+        // cannot say anything honest about their signatures.
+        let src = concat!(
+            "oo::class create C3 {\n",
+            "    foreach m {alpha beta gamma} {\n",
+            "        method $m {args} { return $args }\n",
+            "    }\n",
+            "    method getType {} { return c3 }\n",
+            "}\n",
+        );
+        let cd = class(src, "::C3");
+        for name in ["alpha", "beta", "gamma"] {
+            let md = cd
+                .methods
+                .get(name)
+                .unwrap_or_else(|| panic!("{name} recorded: {cd:?}"));
+            assert!(md.params.is_empty(), "{name}: {md:?}");
+            assert!(md.params_computed, "{name}: {md:?}");
+            // Abstains rather than validating against an invented
+            // parameter list (E002/E003/E005) — `arity()` reads as
+            // unbounded, not "zero args".
+            assert_eq!(
+                md.arity(),
+                tcl_registry::Arity::new(0, tcl_registry::Arity::UNLIMITED),
+                "{name}: {md:?}"
+            );
+        }
+        // A directly-written literal declaration is untouched by the loop.
+        let getter = cd.methods.get("getType").expect("getType recorded");
+        assert!(!getter.params_computed, "{getter:?}");
+        // The lower bound still holds even though three names are now known
+        // (the subtle half of the acceptance criteria: knowing three names
+        // is not knowing them all).
+        assert!(cd.member_set_incomplete, "{cd:?}");
+    }
+
+    #[test]
+    fn a_computed_foreach_member_name_still_abstains_entirely() {
+        // TN — the loop-installed name must be *exactly* a reference to the
+        // loop variable; anything else built from it (or a name that isn't
+        // the loop variable at all) is left exactly as opaque as before
+        // #1277, matching the pre-existing `method $someVar …` abstention.
+        let src = concat!(
+            "oo::class create C4 {\n",
+            "    set prefix pre\n",
+            "    foreach m {alpha beta} {\n",
+            "        method ${prefix}_$m {args} { return $args }\n",
+            "    }\n",
+            "    method getType {} { return c4 }\n",
+            "}\n",
+        );
+        let cd = class(src, "::C4");
+        assert!(cd.methods.contains_key("getType"), "{cd:?}");
+        assert!(!cd.methods.contains_key("alpha"), "{cd:?}");
+        assert!(!cd.methods.contains_key("pre_alpha"), "{cd:?}");
+        assert_eq!(cd.methods.len(), 1, "{cd:?}");
+        assert!(cd.member_set_incomplete, "{cd:?}");
+    }
+
+    #[test]
+    fn a_multi_pair_foreach_installer_still_abstains_entirely() {
+        // TN — two var/list pairs share one body; no single member `$var`
+        // word could unambiguously mean one pair over the other, so this is
+        // left exactly as opaque as any other unreadable installer.
+        let src = concat!(
+            "oo::class create C5 {\n",
+            "    foreach m {alpha beta} n {1 2} {\n",
+            "        method $m {args} { return $n }\n",
+            "    }\n",
+            "    method getType {} { return c5 }\n",
+            "}\n",
+        );
+        let cd = class(src, "::C5");
+        assert!(cd.methods.contains_key("getType"), "{cd:?}");
+        assert!(!cd.methods.contains_key("alpha"), "{cd:?}");
+        assert_eq!(cd.methods.len(), 1, "{cd:?}");
         assert!(cd.member_set_incomplete, "{cd:?}");
     }
 

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -5025,6 +5025,120 @@ mod class_factories {
         assert!(cd.methods.contains_key("getType"), "{cd:?}");
         assert!(!cd.methods.contains_key("options"), "{cd:?}");
         assert!(cd.constructors.is_empty(), "{cd:?}");
+        // …and the abstention is *recorded*, so the tables read as a lower
+        // bound rather than as the class's whole surface (issue #923 idx 53).
+        assert!(cd.member_set_incomplete, "{cd:?}");
+    }
+
+    #[test]
+    fn a_foreach_member_installer_marks_the_member_set_incomplete() {
+        // TP — idx 53's other half: the ticklecharts `chart3D` installer
+        // loop.  `foreach` is not a member word and carries a script the
+        // member walk never descends into, so every `method` it installs is
+        // invisible; the class must say so.  tclsh 9.0.4 / 8.6.16: `info
+        // class methods ::C3` really lists `options` and `globalOptions`.
+        let src = concat!(
+            "oo::class create C3 {\n",
+            "    foreach m {options globalOptions} {\n",
+            "        method $m {} { return $m }\n",
+            "    }\n",
+            "    method getType {} { return c3 }\n",
+            "}\n",
+        );
+        let cd = class(src, "::C3");
+        assert!(cd.methods.contains_key("getType"), "{cd:?}");
+        assert!(cd.member_set_incomplete, "{cd:?}");
+    }
+
+    #[test]
+    fn an_ordinary_class_body_keeps_a_complete_member_set() {
+        // TN — the flag is not a blanket "TclOO is hard" switch: a class
+        // whose body is nothing but readable member declarations (including
+        // the *statically spliceable* `{*}` form and a `self` wrapper block)
+        // still reports a complete member set, so W308 keeps its teeth.
+        let src = concat!(
+            "oo::class create Plain {\n",
+            "    superclass ::oo::object\n",
+            "    variable a b\n",
+            "    constructor {x} { set a $x }\n",
+            "    method {*}{spliced {} {return 1}}\n",
+            "    self { method make {} { return made } }\n",
+            "    method run {} { return $a }\n",
+            "    destructor { return }\n",
+            "}\n",
+        );
+        assert!(!class(src, "::Plain").member_set_incomplete);
+    }
+
+    #[test]
+    fn w308_abstains_on_a_class_whose_members_are_installed_reflectively() {
+        // TP — idx 53's user-visible wrong answer: `$c3 options` drew
+        // "Unknown method 'options'" on a call tclsh proves succeeds.  A
+        // class whose member tables are a lower bound cannot support a
+        // missing-method claim, so W308 must abstain — while the sibling
+        // class in the same file, whose body *is* fully readable, keeps
+        // being checked (the TN half, guarding against a blanket
+        // suppression).
+        let src = concat!(
+            "oo::class create Donor {\n",
+            "    method options {} { return 1 }\n",
+            "}\n",
+            "oo::class create C3 {\n",
+            "    constructor {*}[info class constructor ::Donor]\n",
+            "    foreach m {options} { method $m {*}[info class definition ::Donor $m] }\n",
+            "}\n",
+            "set c3 [C3 new]\n",
+            "$c3 options\n",
+            "set d [Donor new]\n",
+            "$d nosuch\n",
+        );
+        let r = analysis(src, "tcl9.0");
+        let codes: Vec<&str> = r
+            .diagnostics
+            .iter()
+            .filter(|d| d.code.to_string() == "W308")
+            .map(|d| d.message.as_str())
+            .collect();
+        assert_eq!(
+            codes.len(),
+            1,
+            "only the readable class draws W308: {codes:?}"
+        );
+        assert!(codes[0].contains("nosuch"), "{codes:?}");
+    }
+
+    /// A user metaclass whose own definition is in **another file** cannot be
+    /// recognised: the analyser is per-file, and nothing in
+    /// `X create Name Supers Body` distinguishes a class factory from
+    /// `interp create`, `image create`, or any ordinary proc taking a script
+    /// argument.  Guessing would invent classes out of unrelated commands, so
+    /// the LSP abstains — records no class, and emits no diagnostic about the
+    /// members it therefore cannot see (issue #923 idx 97, the multi-file
+    /// half; Tk's own `library/iconlist.tcl` is exactly this shape).
+    ///
+    /// The single-file case — the metaclass and its products in one file, as
+    /// in Tk's `library/megawidget.tcl` — is fully resolved; see
+    /// `user_metaclass_creates_real_classes` above.
+    #[test]
+    fn a_metaclass_defined_in_another_file_abstains_rather_than_guessing() {
+        let src = concat!(
+            "::Megawidget create IconList FocusableWidget {\n",
+            "    method GetSpecs {} { return \"iconlist+[next]\" }\n",
+            "}\n",
+        );
+        let r = analysis(src, "tcl9.0");
+        assert!(
+            !r.all_classes.contains_key("::IconList"),
+            "no class may be invented from an unknown command: {:?}",
+            r.all_classes.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .all(|d| d.code.to_string() != "W308" && d.code.to_string() != "W001"),
+            "abstention must be silent, not a wrong answer: {:?}",
+            r.diagnostics
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/completion.rs
+++ b/rust/tcl-lsp-core/src/completion.rs
@@ -2359,6 +2359,31 @@ mod tests {
     }
 
     #[test]
+    fn obj_method_completion_includes_a_literal_foreach_installed_method() {
+        // Issue #1277: the loop-installed names must be offered exactly
+        // like an ordinary written method — completion, like hover /
+        // definition / outline, reads the same `ClassDef::methods` table.
+        let src = concat!(
+            "oo::class create Widget {\n",
+            "    foreach m {alpha beta gamma} {\n",
+            "        method $m {args} { return $args }\n",
+            "    }\n",
+            "    method fetch {item} { return $item }\n",
+            "}\n",
+            "set d [Widget new]\n",
+            "$d \n",
+        );
+        let analysis = analyse(src);
+        let registry = CommandRegistry::build_default();
+        // Cursor after `$d ` on line 7.
+        let items = completions(src, 7, 3, &analysis, Some(&registry), None, "tcl9.0");
+        let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        for name in ["alpha", "beta", "gamma", "fetch"] {
+            assert!(labels.contains(&name), "{name} missing: {labels:?}");
+        }
+    }
+
+    #[test]
     fn obj_method_completion_excludes_class_side_methods() {
         // `classmethod build` is callable on the *class* command, not on an
         // instance.  `$obj ` completion must offer the instance method

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -6636,6 +6636,29 @@ mod tests {
     }
 
     #[test]
+    fn definition_resolves_a_literal_foreach_installed_method() {
+        // Issue #1277: `alpha` has no written `method alpha` word anywhere —
+        // its only textual appearance is inside the loop's own literal list
+        // — but go-to-definition must still land somewhere real rather than
+        // finding nothing, exactly as hover/outline/completion do.
+        let src = concat!(
+            "oo::class create Widget {\n",
+            "    foreach m {alpha beta gamma} {\n",
+            "        method $m {args} { return $args }\n",
+            "    }\n",
+            "}\n",
+            "set d [Widget new]\n",
+            "$d alpha\n",
+        );
+        let analysis = analyse(src);
+        // Line 6 `$d alpha` — `alpha` starts at col 3.
+        let locs = definition(src, 6, 3, &analysis);
+        assert_eq!(locs.len(), 1, "{locs:?}");
+        // The list `{alpha beta gamma}` is on line 1.
+        assert_eq!(locs[0].start_line, 1, "{locs:?}");
+    }
+
+    #[test]
     fn definition_resolves_obj_method_in_bracket() {
         // `[$d bark]` bracketed form.
         let src =

--- a/rust/tcl-lsp-core/src/document_symbols.rs
+++ b/rust/tcl-lsp-core/src/document_symbols.rs
@@ -1329,6 +1329,32 @@ mod tests {
     }
 
     #[test]
+    fn oo_literal_foreach_installed_methods_appear_in_the_outline() {
+        // Issue #1277: a literal `foreach`-installed member's *name* is
+        // statically knowable even though its signature is not, so it must
+        // still show up in `documentSymbol` alongside an ordinary method.
+        let source = concat!(
+            "oo::class create Widget {\n",
+            "    foreach m {alpha beta gamma} {\n",
+            "        method $m {args} { return $args }\n",
+            "    }\n",
+            "    method fetch {item} { return $item }\n",
+            "}\n",
+        );
+        let symbols = document_symbols(source, "tcl9.0");
+        let cls = &symbols[0];
+        let method_names: Vec<&str> = cls
+            .children
+            .iter()
+            .filter(|c| c.kind == SymbolKind::Method)
+            .map(|c| c.name.as_str())
+            .collect();
+        for name in ["alpha", "beta", "gamma", "fetch"] {
+            assert!(method_names.contains(&name), "{method_names:?}");
+        }
+    }
+
+    #[test]
     fn oo_class_constructor_emits_constructor_symbol() {
         let source = concat!(
             "oo::class create Dog {\n",

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -5442,6 +5442,28 @@ mod tests {
     }
 
     #[test]
+    fn obj_method_hover_fires_for_a_literal_foreach_installed_method() {
+        // Issue #1277: the member's name comes from the loop's own literal
+        // list, not a written `method NAME` word, but a call site must
+        // still resolve to a hover — go-to-definition and hover share the
+        // same member table this walk populates.
+        let src = concat!(
+            "oo::class create Widget {\n",
+            "    foreach m {alpha beta gamma} {\n",
+            "        method $m {args} { return $args }\n",
+            "    }\n",
+            "}\n",
+            "set d [Widget new]\n",
+            "$d alpha\n",
+        );
+        let analysis = analyse(src);
+        // Line 6 `$d alpha` — cursor on `alpha` (col 3).
+        let h = hover(src, 6, 3, &analysis, None).expect("hover");
+        assert!(h.value.contains("**method**"), "{}", h.value);
+        assert!(h.value.contains("::Widget::alpha"), "{}", h.value);
+    }
+
+    #[test]
     fn obj_method_hover_none_for_unknown_instance() {
         let src = "oo::class create Dog {\n    method bark {} {}\n}\n$x bark\n";
         let analysis = analyse(src);

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -3301,6 +3301,26 @@ fn class_member_hover_text(
             cursor_offset,
         )?)?;
     let qname = &class_def.qualified_name;
+    // The member's **own declaration** token — `method reopened {v} {…}`'s
+    // `reopened` — hovers as that member, wherever in the class the
+    // declaration was written (issue #1019 idx 16).  A class body is not a
+    // single lexical region: `oo::define Cls { … }` reopens the class and
+    // its members are just as much `Cls`'s own, so this hangs off
+    // `enclosing_class_at` (which already consults
+    // `AnalysisResult::class_body_spans`, the multi-span record) rather than
+    // any single `body_span`, and the reopening block behaves exactly like
+    // the creation block.  Declaration-site hover previously had no path at
+    // all — only *call* sites (`my m`, `$obj m`) and `link`-exposed
+    // barewords rendered — which left a class member the one declared
+    // symbol in the language that could not be hovered where it is
+    // declared, while `proc` and the class name itself both could.
+    //
+    // Gated on the cursor genuinely sitting inside the member's own
+    // `name_span`, so this never fires for a same-named word elsewhere in
+    // the body (those keep falling through to the tiers below).
+    if let Some(text) = member_declaration_hover_text(analysis, class_def, word, cursor_offset) {
+        return Some(text);
+    }
     if let Some(target) = class_def.linked_members.get(word) {
         let linked_note = if target == word {
             String::new()
@@ -3340,6 +3360,57 @@ fn class_member_hover_text(
         return Some(format!("**destructor** of `{qname}`"));
     }
     None
+}
+
+/// Hover text for a class member's **own declaration** name token, or
+/// `None` when the cursor is not sitting on one (issue #1019 idx 16).
+///
+/// Which member a name belongs to is
+/// [`crate::references::resolve_member_span`] — the very same
+/// method/classmethod/property disambiguation find-references uses, so
+/// hover and references can never disagree about *which* declaration a
+/// cursor is on when a name appears in more than one of a class's three
+/// independent member tables.  That helper falls back to the first
+/// candidate when the cursor is on no declaration at all (it is also used
+/// from call sites), so the containment test is re-applied here: a
+/// declaration hover must be anchored on the declaration.
+///
+/// The rendered summary is byte-identical to the call-site
+/// (`my m` / `$obj m`) rendering, including the MRO note, so hovering a
+/// method at its declaration and at a call site describe the same member
+/// the same way.
+fn member_declaration_hover_text(
+    analysis: &AnalysisResult,
+    class_def: &tcl_compiler::analyser::types::ClassDef,
+    word: &str,
+    cursor_offset: u32,
+) -> Option<String> {
+    use crate::references::MemberSel;
+    let (kind, span) = crate::references::resolve_member_span(class_def, word, cursor_offset)?;
+    if !(span.start() <= cursor_offset && cursor_offset <= span.end()) {
+        return None;
+    }
+    let qname = &class_def.qualified_name;
+    let note = |label: &str, m: &tcl_compiler::analyser::types::MethodDef| {
+        let suffix = oo_method_resolution_note(analysis, qname, &m.name)
+            .map_or(String::new(), |n| format!("  \n{n}"));
+        format!(
+            "**{label}** `{qname}::{name}` ({nparam} param(s)){suffix}",
+            name = m.name,
+            nparam = m.params.len(),
+        )
+    };
+    match kind {
+        MemberSel::Method => class_def.methods.get(word).map(|m| note("method", m)),
+        MemberSel::ClassMethod => class_def
+            .class_methods
+            .get(word)
+            .map(|m| note("classmethod", m)),
+        MemberSel::Property => class_def
+            .properties
+            .get(word)
+            .map(|p| format!("**property** `{qname}::{name}`", name = p.name)),
+    }
 }
 
 /// Hover text for a `$obj method` / `my method` call — `method` resolved
@@ -5228,6 +5299,93 @@ mod tests {
         let analysis = analyse(src);
         // Line 1, cursor on `nope` inside `my nope` (col 34).
         assert!(hover(src, 1, 34, &analysis, None).is_none());
+    }
+
+    // A class member's own declaration hovers as that member (issue #1019
+    // idx 16).  `proc` and the class name itself already hovered at their
+    // declarations; a method did not, which is what made the reopening-block
+    // half of idx 16 look like a block-specific bug rather than a missing
+    // feature — neither block hovered.
+
+    #[test]
+    fn member_declaration_hover_resolves_in_the_creation_block() {
+        // TP — the baseline: `method plain` hovers at its own name token.
+        let src = "oo::class create Foo {\n    method plain {a} { return $a }\n}\n";
+        let analysis = analyse(src);
+        // Line 1, col 13 — inside `plain`.
+        let h = hover(src, 1, 13, &analysis, None).expect("hover");
+        assert!(h.value.contains("**method**"), "{}", h.value);
+        assert!(h.value.contains("::Foo::plain"), "{}", h.value);
+        assert!(h.value.contains("1 param"), "{}", h.value);
+    }
+
+    #[test]
+    fn member_declaration_hover_resolves_in_a_reopening_oo_define_block() {
+        // TP — issue #1019 idx 16's own shape (SpiceGenTcl
+        // `generalClasses.tcl`: `oo::configurable create Parameter { … }`
+        // then a separate `oo::define Parameter { method <WriteProp-value>
+        // … }`).  tclsh 9.0.4 dispatches `$f reopened hi` to the reopened
+        // block's method, so it is every bit `Foo`'s own member and must
+        // hover identically to one written in the creation block.
+        let src = "oo::class create Foo {\n    method plain {} { return plain }\n}\noo::define Foo {\n    method reopened {val} { return $val }\n}\n";
+        let analysis = analyse(src);
+        // Line 4, col 13 — inside `reopened`, in the reopening block.
+        let h = hover(src, 4, 13, &analysis, None).expect("hover");
+        assert!(h.value.contains("**method**"), "{}", h.value);
+        assert!(h.value.contains("::Foo::reopened"), "{}", h.value);
+        assert!(h.value.contains("1 param"), "{}", h.value);
+    }
+
+    #[test]
+    fn member_declaration_hover_covers_classmethods_and_properties() {
+        // TP — the other two member tables render with their own labels.
+        let src = "oo::configurable create C {\n    property size\n    self method make {n} { return $n }\n}\n";
+        let analysis = analyse(src);
+        let prop = hover(src, 1, 15, &analysis, None).expect("property hover");
+        assert!(prop.value.contains("**property**"), "{}", prop.value);
+        assert!(prop.value.contains("::C::size"), "{}", prop.value);
+        let cm = hover(src, 2, 19, &analysis, None).expect("classmethod hover");
+        assert!(cm.value.contains("**classmethod**"), "{}", cm.value);
+        assert!(cm.value.contains("::C::make"), "{}", cm.value);
+    }
+
+    #[test]
+    fn member_declaration_hover_notes_an_override() {
+        // TP — the declaration renders the same MRO note a call site does,
+        // so the two descriptions of one member cannot disagree.
+        let src = "oo::class create Base {\n    method run {} { return base }\n}\noo::class create Derived {\n    superclass Base\n    method run {} { return derived }\n}\n";
+        let analysis = analyse(src);
+        let h = hover(src, 5, 12, &analysis, None).expect("hover");
+        assert!(h.value.contains("::Derived::run"), "{}", h.value);
+        assert!(h.value.contains("Base"), "MRO note expected: {}", h.value);
+    }
+
+    #[test]
+    fn member_declaration_hover_does_not_fire_on_a_same_named_word_elsewhere() {
+        // FP guard — only the declaration's own name token hovers as the
+        // member.  A same-spelled *data* word inside a method body is not a
+        // member reference, and must keep falling through the tier order
+        // (here: to nothing at all).
+        let src = "oo::class create Foo {\n    method plain {} { return plain }\n}\n";
+        let analysis = analyse(src);
+        // Line 1, col 30 — the bareword `plain` in `return plain`, which is
+        // a value, not a call (an un-linked sibling name is not callable —
+        // issue #923 idx 113).
+        assert!(hover(src, 1, 30, &analysis, None).is_none());
+    }
+
+    #[test]
+    fn member_declaration_hover_abstains_outside_a_class_body() {
+        // TN — a proc whose name happens to match a method of some class in
+        // the file must not borrow that class's member hover.
+        let src = "oo::class create Foo {\n    method plain {} { return 1 }\n}\nproc plain {} { return 2 }\n";
+        let analysis = analyse(src);
+        let h = hover(src, 3, 6, &analysis, None).expect("proc hover");
+        assert!(
+            !h.value.contains("**method**"),
+            "the proc, not Foo's method: {}",
+            h.value
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-core/tests/mathfunc_and_word_recognition.rs
+++ b/rust/tcl-lsp-core/tests/mathfunc_and_word_recognition.rs
@@ -618,6 +618,68 @@ proc callit {} {
     );
 }
 
+/// idx 54 residual (TP): find-references from a proc's own declaration must
+/// reach a `${ns}::name` call **inside that proc's own namespace**.
+///
+/// The walk records the local-first candidate (`::mypkg::mypkg::setdef` for
+/// a `${ns}::setdef` head folded to `mypkg::setdef` while inside `::mypkg`), and the
+/// post-walk settle recovers the calling namespace by stripping `::{name}`
+/// off it — which cannot work when `name` is the *written* head
+/// (`${ns}::setdef`) rather than the folded one.  The call therefore stayed
+/// pinned to a name that exists nowhere, and find-references missed it while
+/// go-to-definition (which re-resolves from the cursor) found it.
+///
+/// C Tcl ground truth: a qualified name resolves in the current namespace
+/// first, then global, so `mypkg::setdef` called from inside `::mypkg`
+/// reaches `::mypkg::setdef` — `::mypkg::mypkg::setdef` does not exist.
+#[test]
+fn tp_idx54_folded_head_settles_through_the_global_fallback() {
+    let src = "\
+namespace eval mypkg {}
+proc mypkg::setdef {opts key args} { return 1 }
+proc mypkg::literal {} {
+    mypkg::setdef opts a
+}
+proc mypkg::folded {} {
+    set ns \"mypkg\"
+    ${ns}::setdef opts a
+}
+";
+    let analysis = analyse(src);
+    let (line, col) = pos_of(src, "setdef {opts key args}");
+    let refs = tcl_lsp_core::references::references(src, "tcl8.6", line, col, &analysis, true);
+    let mut lines: Vec<u32> = refs.iter().map(|r| r.start_line).collect();
+    lines.sort_unstable();
+    assert_eq!(
+        lines,
+        vec![1, 3, 7],
+        "declaration + the literal call + the folded-head call: {refs:?}"
+    );
+}
+
+/// idx 54 residual FP guard: the settle must not invent a target.  A folded
+/// head naming a proc that exists in **neither** candidate namespace stays
+/// unresolved — no reference is attributed to the same-tailed proc in an
+/// unrelated namespace.
+#[test]
+fn fp_idx54_folded_head_does_not_borrow_an_unrelated_same_tail_proc() {
+    let src = "\
+namespace eval other {}
+proc other::setdef {a} { return 1 }
+namespace eval mypkg {}
+proc mypkg::folded {} {
+    set ns \"nowhere\"
+    ${ns}::setdef opts a
+}
+";
+    let analysis = analyse(src);
+    let (line, col) = pos_of(src, "setdef {a}");
+    let refs = tcl_lsp_core::references::references(src, "tcl8.6", line, col, &analysis, true);
+    let mut lines: Vec<u32> = refs.iter().map(|r| r.start_line).collect();
+    lines.sort_unstable();
+    assert_eq!(lines, vec![1], "declaration only: {refs:?}");
+}
+
 /// idx 54 TN — the colon grammar, pinned against C Tcl: a **single** colon is
 /// an ordinary name character, so it must never split a word.  Verified on
 /// tclsh 8.6 / 9.0 (`set a:b 42`, `proc p:q {x}`, `set arr(k:1) v`,

--- a/rust/tcl-lsp-core/tests/oo_mro_parity.rs
+++ b/rust/tcl-lsp-core/tests/oo_mro_parity.rs
@@ -578,14 +578,21 @@ Megawidget create IconList FocusableWidget {
     );
 }
 
-/// idx 53 (abstention): a class whose members are installed by *reflection*
-/// keeps its member tables as a lower bound, so the LSP answers nothing
-/// rather than answering wrongly.
+/// idx 53 (abstention) / issue #1277 (partial recovery): a class whose
+/// members are installed by *reflection* keeps its member tables as a lower
+/// bound, so W308 answers nothing rather than answering wrongly.
 ///
 /// tclsh 9.0.4 / 8.6.16 both prove the members are real (`info class methods
-/// ::C3` lists `options`; `[C3 new] options` runs), so a "no such method"
-/// answer would be a lie.  Navigation abstaining is the honest reading —
-/// what must never happen is the W308 that used to fire here.
+/// ::C3` lists `options`; `[C3 new] options` runs). Since issue #1277, the
+/// installer's `method $m …` names itself with exactly the loop variable
+/// bound to a **literal** list (`foreach m {options} { … }`), so the walk
+/// can honestly say where `options`'s name comes from — the list element
+/// itself — even though it still knows nothing about the method's
+/// parameter list (`{*}[info class definition ::Donor $m]` is itself
+/// computed, so the signature stays `params_computed`). Definition/hover
+/// now resolve to that honest source location instead of finding nothing;
+/// what must still never happen is the W308 that used to fire here, or an
+/// invented arity diagnostic on a call of any shape.
 #[test]
 fn idx53_reflectively_installed_members_abstain_instead_of_warning() {
     let src = "\
@@ -610,12 +617,22 @@ $c3 options
         outline_members(src).contains(&("C3".to_string(), "getType".to_string())),
         "the abstention must not erase what *was* readable",
     );
-    // And the abstention is an abstention: no wrong target is offered.
+    // The *name* is now honestly known (issue #1277) — go-to-definition
+    // lands on the loop's own literal list, line 5 (`foreach m {options}
+    // …`), not on a wrong or invented target.
     let t = trio_at(src, cursor_at_line(src, "$c3 options", "options"));
-    assert!(
-        t.definition.is_empty(),
-        "no location may be invented: {:?}",
+    assert_eq!(
+        start_lines(&t.definition),
+        vec![5],
+        "the name's one real source location, not an invented one: {:?}",
         t.definition
+    );
+    // …but the *signature* is still unknown: a call of any arity must not
+    // draw E002/E003.
+    assert!(
+        !diag_codes(src).iter().any(|c| c == "E002" || c == "E003"),
+        "an unmodelled signature must never be checked: {:?}",
+        diag_codes(src),
     );
 }
 

--- a/rust/tcl-lsp-core/tests/oo_mro_parity.rs
+++ b/rust/tcl-lsp-core/tests/oo_mro_parity.rs
@@ -402,3 +402,241 @@ fn initialize_block_variables_do_not_leak_between_sibling_classes() {
         "the two classes' declarations must not merge into one symbol",
     );
 }
+
+// ───────────── class factories and dynamically-installed members ─────────────
+//
+// Issue #923 idx 53 / 55 / 96 / 97 at the *LSP* surface.  The analyser-side
+// mechanics have their own matrix (`tcl-compiler/tests/analyser.rs`,
+// `mod class_factories`); these pin what the editor actually sees, which is
+// what those findings reported.
+
+/// Flatten an outline to `(container, member)` pairs, one per nested symbol.
+fn outline_members(source: &str) -> Vec<(String, String)> {
+    fn walk(
+        parent: &str,
+        syms: &[tcl_lsp_core::document_symbols::DocumentSymbol],
+        out: &mut Vec<(String, String)>,
+    ) {
+        for s in syms {
+            if !parent.is_empty() {
+                out.push((parent.to_string(), s.name.clone()));
+            }
+            walk(&s.name, &s.children, out);
+        }
+    }
+    let mut out = Vec::new();
+    walk(
+        "",
+        &tcl_lsp_core::document_symbols::document_symbols(source, D),
+        &mut out,
+    );
+    out
+}
+
+/// Diagnostic codes the analyser emits for `source`.
+fn diag_codes(source: &str) -> Vec<String> {
+    analyse(source)
+        .diagnostics
+        .iter()
+        .map(|d| d.code.to_string())
+        .collect()
+}
+
+/// idx 55 (TP): `foreach class {A B} { oo::define $class { method m … } }` —
+/// the ticklecharts `etsb.tcl` monkey-patch.  The target names come from a
+/// **literal** list, so each real class genuinely gains the method (tclsh
+/// 9.0.4 / 8.6.16: `[mychart::chart new] RenderTsb` answers
+/// `TSB:chart-json`).  The outline must hang it off the real classes — not a
+/// synthetic `@dynclass@…` key — and navigation must reach its declaration.
+#[test]
+fn idx55_a_literal_foreach_oo_define_installer_reaches_the_real_classes() {
+    let src = "\
+namespace eval mychart {}
+oo::class create mychart::chart {
+    method toJSON {} { return chart-json }
+}
+oo::class create mychart::chart3D {
+    method toJSON {} { return chart3d-json }
+}
+foreach class {mychart::chart mychart::chart3D} {
+    oo::define $class {
+        method RenderTsb {args} { return \"TSB:[my toJSON]\" }
+        export RenderTsb
+    }
+}
+set obj [mychart::chart new]
+$obj RenderTsb
+";
+    let members = outline_members(src);
+    for owner in ["chart", "chart3D"] {
+        assert!(
+            members.contains(&(owner.to_string(), "RenderTsb".to_string())),
+            "{owner} must own the injected method: {members:?}",
+        );
+    }
+    assert!(
+        members
+            .iter()
+            .all(|(owner, _)| !owner.contains("@dynclass@")),
+        "no synthetic key may leak into the outline: {members:?}",
+    );
+    let t = trio_at(src, cursor_at_line(src, "$obj RenderTsb", "RenderTsb"));
+    assert_eq!(start_lines(&t.definition), vec![9], "{:?}", t.definition);
+    assert!(t.hover.is_some_and(|h| h.contains("RenderTsb")));
+    assert!(
+        !diag_codes(src).contains(&"W308".to_string()),
+        "a method the class really has must not warn: {:?}",
+        diag_codes(src),
+    );
+}
+
+/// idx 96 (TP): a class made by a **user-defined metaclass** (Tk's
+/// `::tk::Megawidget`) is a real class, and the method it inherits from the
+/// superclass that metaclass splices in resolves like any other.
+///
+/// tclsh 9.0.4 / 8.6.14: `info class superclasses ::tk::SimpleWidget` →
+/// `::tk::MegawidgetClass`, and `my TraceOption` inside `CreateHull` really
+/// runs `::tk::MegawidgetClass`'s implementation.
+#[test]
+fn idx96_a_metaclass_made_class_resolves_its_spliced_inherited_method() {
+    let src = "\
+namespace eval ::tk {}
+oo::class create ::tk::Megawidget {
+    superclass ::oo::class
+    self method create {name superclasses body} {
+        next $name [list superclass ::tk::MegawidgetClass {*}$superclasses]\\;$body
+    }
+}
+oo::class create ::tk::MegawidgetClass {
+    method TraceOption {option method args} { return traced }
+}
+::tk::Megawidget create ::tk::SimpleWidget {} {
+    method CreateHull {} { my TraceOption -cursor UpdateCursorOption }
+}
+::tk::Megawidget create ::tk::FocusableWidget ::tk::SimpleWidget {
+    method CreateHull {} { my TraceOption -takefocus UpdateTakefocus }
+}
+";
+    let members = outline_members(src);
+    for owner in ["SimpleWidget", "FocusableWidget"] {
+        assert!(
+            members.contains(&(owner.to_string(), "CreateHull".to_string())),
+            "{owner} must be a class with its own members: {members:?}",
+        );
+    }
+    let t = trio_at(src, cursor_at_line(src, "-cursor", "TraceOption"));
+    assert_eq!(start_lines(&t.definition), vec![8], "{:?}", t.definition);
+    assert!(
+        t.hover
+            .is_some_and(|h| h.contains("::tk::MegawidgetClass::TraceOption")),
+        "hover must name the providing class",
+    );
+    // Both metaclass-made classes' call sites come back from the provider's
+    // own declaration.
+    assert_eq!(
+        start_lines(&t.references),
+        vec![8, 11, 14],
+        "{:?}",
+        t.references
+    );
+}
+
+/// idx 97 (TP): `next` inside a metaclass-made class walks the same
+/// linearisation the literal spelling would.
+///
+/// tclsh 9.0.4 / 8.6.14: `[IconList new] probe` → `GetSpecs
+/// iconlist+focusable+simple+base`, i.e. `IconList::GetSpecs`'s `next`
+/// reaches `FocusableWidget::GetSpecs`, skipping neither more nor less.
+#[test]
+fn idx97_next_resolves_through_a_metaclass_made_chain() {
+    let src = "\
+oo::class create Megawidget {
+    superclass oo::class
+    self method create {name superclasses body} {
+        next $name [list superclass MegawidgetClass {*}$superclasses]\\;$body
+    }
+}
+oo::class create MegawidgetClass {
+    method GetSpecs {} { return base }
+}
+Megawidget create SimpleWidget {} {
+    method GetSpecs {} { return \"simple+[next]\" }
+}
+Megawidget create FocusableWidget SimpleWidget {
+    method GetSpecs {} { return \"focusable+[next]\" }
+}
+Megawidget create IconList FocusableWidget {
+    method GetSpecs {} { return \"iconlist+[next]\" }
+}
+";
+    let t = trio_at(src, cursor_at_line(src, "iconlist+", "next"));
+    assert_eq!(
+        start_lines(&t.definition),
+        vec![13],
+        "`next` must reach FocusableWidget::GetSpecs: {:?}",
+        t.definition
+    );
+}
+
+/// idx 53 (abstention): a class whose members are installed by *reflection*
+/// keeps its member tables as a lower bound, so the LSP answers nothing
+/// rather than answering wrongly.
+///
+/// tclsh 9.0.4 / 8.6.16 both prove the members are real (`info class methods
+/// ::C3` lists `options`; `[C3 new] options` runs), so a "no such method"
+/// answer would be a lie.  Navigation abstaining is the honest reading —
+/// what must never happen is the W308 that used to fire here.
+#[test]
+fn idx53_reflectively_installed_members_abstain_instead_of_warning() {
+    let src = "\
+oo::class create Donor {
+    method options {} { return 1 }
+}
+oo::class create C3 {
+    constructor {*}[info class constructor ::Donor]
+    foreach m {options} { method $m {*}[info class definition ::Donor $m] }
+    method getType {} { return c3 }
+}
+set c3 [C3 new]
+$c3 options
+";
+    assert!(
+        !diag_codes(src).contains(&"W308".to_string()),
+        "a reflectively-installed method is not a missing one: {:?}",
+        diag_codes(src),
+    );
+    // The readable half of the class is still fully modelled.
+    assert!(
+        outline_members(src).contains(&("C3".to_string(), "getType".to_string())),
+        "the abstention must not erase what *was* readable",
+    );
+    // And the abstention is an abstention: no wrong target is offered.
+    let t = trio_at(src, cursor_at_line(src, "$c3 options", "options"));
+    assert!(
+        t.definition.is_empty(),
+        "no location may be invented: {:?}",
+        t.definition
+    );
+}
+
+/// idx 53 (FN guard): the abstention is scoped to the class that earns it.
+/// A sibling class in the same file whose body is fully readable keeps every
+/// method check.
+#[test]
+fn idx53_a_readable_sibling_class_keeps_its_method_checks() {
+    let src = "\
+oo::class create Donor {
+    method options {} { return 1 }
+}
+oo::class create C3 {
+    constructor {*}[info class constructor ::Donor]
+}
+set d [Donor new]
+$d nosuch
+";
+    assert!(
+        diag_codes(src).contains(&"W308".to_string()),
+        "the readable class must still warn: {:?}",
+        diag_codes(src),
+    );
+}

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -207,6 +207,21 @@ pub struct SourceFile {
     /// — untouched.
     #[returns(ref)]
     pub external_call_sites: Option<Arc<CallSiteEvidence>>,
+    /// The workspace's user-defined `TclOO` **class factories** (metaclasses),
+    /// keyed by qualified name — the oracle that lets this file's walk
+    /// classify `::tk::Megawidget create IconList …` when `::tk::Megawidget`
+    /// is written in another document (issue #1276).
+    ///
+    /// `None` means "no workspace view", and the walk abstains on every such
+    /// call exactly as it did before the index existed — the deliberate
+    /// pre-#1276 behaviour, which every standalone consumer keeps.
+    ///
+    /// Set by the server from [`project_class_factories`] (compare-then-set),
+    /// the same discipline [`Self::external_call_sites`] uses: an index that
+    /// does not move invalidates nothing, and almost no edit moves it, since
+    /// almost no document declares a metaclass.
+    #[returns(ref)]
+    pub workspace_class_factories: Option<Arc<tcl_compiler::analyser::ClassFactoryIndex>>,
 }
 
 impl SourceFile {
@@ -220,7 +235,7 @@ impl SourceFile {
         dialect: String,
         path: Option<String>,
     ) -> Self {
-        Self::with_call_site_evidence(db, text, dialect, path, None)
+        Self::with_call_site_evidence(db, text, dialect, path, None, None)
     }
 }
 
@@ -279,7 +294,8 @@ pub fn file_analysis(
         .with_non_ascii_mode(config.non_ascii_mode(db))
         .with_extra_commands(extra)
         .with_bigip_version(config.bigip_version(db).clone())
-        .with_file_path(file.path(db).clone());
+        .with_file_path(file.path(db).clone())
+        .with_workspace_class_factories(file.workspace_class_factories(db).clone());
     Arc::new(analyser.analyse(file.text(db), file.dialect(db)))
 }
 
@@ -356,6 +372,50 @@ pub fn project_proc_names(db: &dyn salsa::Database, project: Project) -> Arc<BTr
         names.extend(file_decls(db, file).procs.iter().cloned());
     }
     Arc::new(names)
+}
+
+/// The **class factories** one file declares — the user-defined `TclOO`
+/// metaclasses (`oo::class create Meta { superclass oo::class; self method
+/// create … }`) it publishes to the rest of the workspace (issue #1276).
+///
+/// Read straight off [`item_tree`], which every project file already
+/// computes for [`file_decls`] / [`project_proc_names`], so the factory index
+/// costs no extra analysis pass. Structure-level, like [`file_decls`]: a body
+/// edit that does not change a metaclass's `create` override leaves this
+/// equal, so it backdates and no cross-file query re-runs.
+///
+/// A file's own view is deliberately *local* — a factory whose metaclass is
+/// itself manufactured by a metaclass in a third file does not resolve, and
+/// the walk abstains on it. One hop is what the index proves; a fixpoint over
+/// the project is not, and guessing is the thing this whole area refuses to do.
+#[salsa::tracked]
+pub fn file_class_factories(
+    db: &dyn salsa::Database,
+    file: SourceFile,
+) -> Arc<tcl_compiler::analyser::ClassFactoryIndex> {
+    Arc::clone(&item_tree(db, file).class_factories)
+}
+
+/// The project-wide merge of every file's [`file_class_factories`] — the
+/// oracle the server sets on [`SourceFile::workspace_class_factories`].
+///
+/// Unordered, exactly as the workspace index's other cross-file facts are: a
+/// `source` graph can prove a load order, but nothing requires one here —
+/// a metaclass declaration either exists in the project or it does not.
+/// Later entries win on a duplicate qualified name, which cannot be told
+/// apart from the earlier one by anything the index knows.
+#[salsa::tracked]
+pub fn project_class_factories(
+    db: &dyn salsa::Database,
+    project: Project,
+) -> Arc<tcl_compiler::analyser::ClassFactoryIndex> {
+    let mut merged = tcl_compiler::analyser::ClassFactoryIndex::new();
+    for &file in project.files(db) {
+        for (qname, factory) in file_class_factories(db, file).iter() {
+            merged.insert(qname.clone(), factory.clone());
+        }
+    }
+    Arc::new(merged)
 }
 
 /// The project files this file pulls into its own interpreter — its resolved
@@ -1061,10 +1121,19 @@ pub struct ItemBodyKey<'db> {
     ///   body that moves in or out of a tracked safe interpreter between
     ///   edits gets re-analysed rather than serving a stale cached `W129`
     ///   verdict.
+    /// - `.2` — the workspace **class factory** oracle
+    ///   ([`SourceFile::workspace_class_factories`], issue #1276). A
+    ///   `Meta create …` inside a proc body is classified by the whole-file
+    ///   walk from this index, so the isolated body pass must see the same
+    ///   one or the two strategies disagree about whether a class exists.
+    ///   Part of the key for the usual reason: a metaclass appearing or
+    ///   changing shape elsewhere in the workspace must re-analyse the
+    ///   bodies whose creation calls it decides.
     #[returns(ref)]
     pub body_env: (
         Vec<(String, Vec<(String, String)>)>,
         Option<(bool, Vec<String>, Vec<String>)>,
+        Option<Arc<tcl_compiler::analyser::ClassFactoryIndex>>,
     ),
     #[returns(ref)]
     pub dialect: String,
@@ -1109,6 +1178,7 @@ pub fn item_body_analysis<'db>(db: &'db dyn TclDb, key: ItemBodyKey<'db>) -> Arc
         &disabled,
         key.non_ascii(db),
         Some(overlay),
+        key.body_env(db).2.clone(),
     ))
 }
 
@@ -2550,11 +2620,13 @@ pub fn file_analysis_incremental(
     let extra_commands: HashSet<String> = config.extra_commands(db).iter().cloned().collect();
     let dialect = file.dialect(db).clone();
     let text = file.text(db).clone();
+    let workspace_class_factories = file.workspace_class_factories(db).clone();
     let mut analyser = Analyser::with_disabled_diagnostics(disabled_vec.iter().cloned().collect())
         .with_non_ascii_mode(non_ascii)
         .with_extra_commands(extra_commands)
         .with_bigip_version(config.bigip_version(db).clone())
-        .with_file_path(file.path(db).clone());
+        .with_file_path(file.path(db).clone())
+        .with_workspace_class_factories(workspace_class_factories.clone());
 
     // Build the CFG/SSA tail's compilation unit with per-procedure lattices
     // memoised by `function_lattice`, and feed it through the analyser's
@@ -2580,7 +2652,11 @@ pub fn file_analysis_incremental(
             body.command_trust
                 .clone()
                 .map(|trust| (trust, body.oo_defining_class.clone())),
-            (body.ensemble_targets.clone(), body.safe_interp_ctx.clone()),
+            (
+                body.ensemble_targets.clone(),
+                body.safe_interp_ctx.clone(),
+                workspace_class_factories.clone(),
+            ),
             dialect.clone(),
             disabled_vec.clone(),
             non_ascii,

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -309,13 +309,24 @@ pub fn file_analysis(
 /// item set therefore *cannot* diverge from `analyse`. Slices 2–3 re-home this
 /// onto a cheap, independent CST extractor — guarded by the `file_decls` corpus
 /// gate + the `incremental == fresh` differential fuzzer + the full-rebuild
-/// fallback (item detection is config-independent, hence no `AnalyserConfig`).
+/// fallback (item detection is config-independent, hence no `AnalyserConfig`;
+/// the one cross-file input it does read, `SourceFile::workspace_class_factories`,
+/// is a property of the *file*, so the query key is unchanged).
 #[salsa::tracked]
 pub fn item_tree(db: &dyn salsa::Database, file: SourceFile) -> Arc<ItemTree> {
     // `structure_only` skips diagnostic emission (the dominant analyse cost)
     // while building the identical declaration/scope structure — a cheap,
     // non-divergent item extractor (gated by `file_decls_corpus`).
-    let mut analyser = Analyser::new().structure_only();
+    let mut analyser = Analyser::new()
+        .structure_only()
+        // The workspace class-factory oracle (issue #1276) is part of the
+        // *file's* input, not the analyser config, so the item tree stays a
+        // function of `SourceFile` alone. It has to be here: a class a
+        // cross-file metaclass manufactures is a declaration of this file, and
+        // leaving it out of the item tree would leave it out of `file_decls`
+        // too — so cross-file W123 would call `IconList` an unknown command
+        // while the full analysis, hover, and the outline all describe it.
+        .with_workspace_class_factories(file.workspace_class_factories(db).clone());
     let result = analyser.analyse(file.text(db), file.dialect(db));
     Arc::new(ItemTree::from_analysis(
         &result,
@@ -384,10 +395,12 @@ pub fn project_proc_names(db: &dyn salsa::Database, project: Project) -> Arc<BTr
 /// edit that does not change a metaclass's `create` override leaves this
 /// equal, so it backdates and no cross-file query re-runs.
 ///
-/// A file's own view is deliberately *local* — a factory whose metaclass is
-/// itself manufactured by a metaclass in a third file does not resolve, and
-/// the walk abstains on it. One hop is what the index proves; a fixpoint over
-/// the project is not, and guessing is the thing this whole area refuses to do.
+/// [`item_tree`] itself reads [`SourceFile::workspace_class_factories`], so a
+/// metaclass that is *itself* manufactured by another file's metaclass is
+/// picked up on the host's next sync round rather than needing a fixpoint
+/// here: the sync is compare-then-set, so it stops as soon as the index stops
+/// moving. What never happens is a *guess* — a round adds an entry only when
+/// some file proved it.
 #[salsa::tracked]
 pub fn file_class_factories(
     db: &dyn salsa::Database,
@@ -3140,7 +3153,7 @@ mod tests {
                 false,
                 Vec::new(),
                 None,
-                (Vec::new(), None),
+                (Vec::new(), None, None),
                 "tcl8.6".to_owned(),
                 Vec::new(),
                 NonAsciiMode::Default,
@@ -3163,7 +3176,7 @@ mod tests {
             false,
             Vec::new(),
             None,
-            (Vec::new(), None),
+            (Vec::new(), None, None),
             "tcl8.6".to_owned(),
             Vec::new(),
             NonAsciiMode::Default,

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -24597,6 +24597,168 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
+    /// The three-file Tk shape of issue #1276, written to a scratch workspace.
+    ///
+    /// Ground truth (tclsh 8.6.14 and 9.0.4 agree, `source`ing the three in
+    /// order): `::IconList` is a real class, `info class superclasses
+    /// ::IconList` is `::tk::MegawidgetClass ::FocusableWidget`, and
+    /// `info class methods ::IconList -private` is `CreateHull GetSpecs`.
+    fn write_metaclass_workspace(root: &std::path::Path) {
+        std::fs::write(
+            root.join("megawidget.tcl"),
+            concat!(
+                "oo::class create ::tk::MegawidgetClass {\n",
+                "    method TraceOption {a b} { return traced }\n",
+                "}\n",
+                "oo::class create ::tk::Megawidget {\n",
+                "    superclass oo::class\n",
+                "    self method create {name superclasses body} {\n",
+                "        next $name [list superclass ::tk::MegawidgetClass",
+                " {*}$superclasses]\\;$body\n",
+                "    }\n",
+                "}\n",
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("base.tcl"),
+            concat!(
+                "::tk::Megawidget create FocusableWidget {} {\n",
+                "    method CreateHull {} { return h }\n",
+                "}\n",
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("iconlist.tcl"),
+            concat!(
+                "::tk::Megawidget create IconList FocusableWidget {\n",
+                "    method GetSpecs {} { return iconlist }\n",
+                "    method CreateHull {} { return hull }\n",
+                "}\n",
+            ),
+        )
+        .unwrap();
+    }
+
+    /// The salsa analysis a scanned (unopened) workspace file resolves to.
+    async fn scanned_analysis(
+        backend: &Backend,
+        root: &std::path::Path,
+        name: &str,
+    ) -> Arc<AnalysisResult> {
+        let uri = Uri::from_file_path(root.join(name)).unwrap();
+        let db = backend.db.lock().await;
+        let files = backend.db_files.lock().await;
+        let file = *files.get(&uri).expect("scanned file is a salsa input");
+        let config = *backend.db_config.lock().await;
+        tcl_lsp_db::file_analysis_incremental(&*db, file, config)
+    }
+
+    #[tokio::test]
+    async fn a_cross_file_metaclass_resolves_after_the_workspace_scan() {
+        // TP — issue #1276, the whole point. `iconlist.tcl` names
+        // `::tk::Megawidget` and nothing else about it; the scan publishes the
+        // factory index and the file's own analysis then records the class the
+        // interpreter really makes, superclasses and members included.
+        let root = unique_scratch_dir("metaclass");
+        write_metaclass_workspace(&root);
+        let backend = test_backend();
+        *backend.workspace_folders.lock().await = vec![Uri::from_file_path(&root).unwrap()];
+        backend.scan_workspace_folders().await;
+
+        let analysis = scanned_analysis(&backend, &root, "iconlist.tcl").await;
+        let class = analysis
+            .all_classes
+            .get("::IconList")
+            .unwrap_or_else(|| panic!("::IconList: {:?}", analysis.all_classes.keys()));
+        let mut methods: Vec<&str> = class.methods.keys().map(String::as_str).collect();
+        methods.sort_unstable();
+        assert_eq!(methods, ["CreateHull", "GetSpecs"], "{class:?}");
+        assert_eq!(
+            class.superclasses,
+            ["::tk::MegawidgetClass", "FocusableWidget"],
+            "{class:?}"
+        );
+        assert!(!class.inheritance_unknown, "{class:?}");
+
+        // The outline is what the audit actually complained about: it was
+        // empty for this file.
+        let symbols = tcl_lsp_core::document_symbols::document_symbols_from_analysis(
+            &std::fs::read_to_string(root.join("iconlist.tcl")).unwrap(),
+            &analysis,
+        );
+        assert!(
+            symbols.iter().any(|s| s.name.contains("IconList")),
+            "outline names the class: {symbols:?}"
+        );
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[tokio::test]
+    async fn a_dynamic_metaclass_head_abstains_even_with_the_scan_index() {
+        // TN, the non-negotiable half — the index is populated and correct,
+        // but the creation call's head is a runtime value, so nothing about it
+        // is provable and no class may be invented.
+        let root = unique_scratch_dir("metaclass-dyn");
+        write_metaclass_workspace(&root);
+        std::fs::write(
+            root.join("dynamic.tcl"),
+            concat!(
+                "set meta ::tk::Megawidget\n",
+                "$meta create Invented FocusableWidget {\n",
+                "    method GetSpecs {} { return nope }\n",
+                "}\n",
+            ),
+        )
+        .unwrap();
+        let backend = test_backend();
+        *backend.workspace_folders.lock().await = vec![Uri::from_file_path(&root).unwrap()];
+        backend.scan_workspace_folders().await;
+
+        // Non-vacuity: the very same scan *does* resolve the provable file, so
+        // this abstention is not just "the index never arrived".
+        let resolved = scanned_analysis(&backend, &root, "iconlist.tcl").await;
+        assert!(resolved.all_classes.contains_key("::IconList"));
+
+        let analysis = scanned_analysis(&backend, &root, "dynamic.tcl").await;
+        assert!(
+            !analysis.all_classes.contains_key("::Invented"),
+            "a dynamic head proves nothing: {:?}",
+            analysis.all_classes.keys().collect::<Vec<_>>()
+        );
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[tokio::test]
+    async fn a_workspace_with_no_metaclass_never_sets_the_factory_oracle() {
+        // The no-op guarantee: an ordinary workspace must not acquire a new
+        // cross-file input at all, or every file in every project would be
+        // invalidated by a fact none of them use.
+        let root = unique_scratch_dir("metaclass-none");
+        std::fs::write(root.join("a.tcl"), "proc greet {n} { puts $n }\n").unwrap();
+        std::fs::write(
+            root.join("b.tcl"),
+            "oo::class create Dog { method bark {} {} }\n",
+        )
+        .unwrap();
+        let backend = test_backend();
+        *backend.workspace_folders.lock().await = vec![Uri::from_file_path(&root).unwrap()];
+        backend.scan_workspace_folders().await;
+
+        let db = backend.db.lock().await;
+        let files = backend.db_files.lock().await;
+        for (uri, file) in files.iter() {
+            assert!(
+                file.workspace_class_factories(&*db).is_none(),
+                "{uri:?} acquired a factory oracle it has no use for"
+            );
+        }
+        drop(files);
+        drop(db);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
     #[tokio::test]
     async fn scan_workspace_folders_skips_open_documents() {
         let root = unique_scratch_dir("scan-open");

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -1954,7 +1954,12 @@ async fn refresh_cross_file_evidence(
     slots: &Arc<Mutex<HashMap<Uri, DiagSlot>>>,
     uri: &Uri,
 ) {
-    let changed = sync_cross_file_evidence(handles).await;
+    let mut changed = sync_cross_file_evidence(handles).await;
+    for uri in sync_workspace_class_factories(handles).await {
+        if !changed.contains(&uri) {
+            changed.push(uri);
+        }
+    }
     // Re-analyse *this* document only when the refresh gave it evidence
     // that can actually change its result: a non-empty table means some
     // other file calls into it, which is what retracts a fold. Going
@@ -1966,7 +1971,7 @@ async fn refresh_cross_file_evidence(
     // decline, which can *add* a fold; not republishing leaves that as
     // a missing hint until the next edit, the safe direction.
     if changed.contains(uri)
-        && has_external_callers(&handles.db, &handles.db_files, uri).await
+        && refresh_can_change_result(&handles.db, &handles.db_files, uri).await
         && let Some(slot) = slots.lock().await.get_mut(uri)
     {
         slot.dirty = true;
@@ -2012,13 +2017,23 @@ async fn reschedule_peers(
     }
 }
 
-/// Whether `uri`'s cross-file evidence actually names a caller.
+/// Whether the cross-file refresh gave `uri` something that can actually
+/// change its own result.
 ///
-/// Distinguishes "the project has something to say about this file's
-/// procedures" from "the project was enumerated and had nothing to add" — the
-/// latter cannot change what the file folds, so it must not trigger a second,
-/// identical publish. Lock order is `db` → `db_files`.
-async fn has_external_callers(
+/// Two independent facts qualify, and both distinguish "the project has
+/// something to say about this file" from "the project was enumerated and had
+/// nothing to add" — the latter cannot change the file's analysis, so it must
+/// not trigger a second, identical publish:
+///
+/// * its **call-site evidence** names a caller (issue #977) — what retracts an
+///   interprocedural fold;
+/// * the workspace's **class-factory index** is non-empty (issue #1276) — a
+///   `Meta create Name …` in this file is recorded or abstained on depending
+///   on it, so a file that published before the index arrived published
+///   without the classes it manufactures.
+///
+/// Lock order is `db` → `db_files`.
+async fn refresh_can_change_result(
     db: &Mutex<tcl_lsp_db::TclDatabase>,
     db_files: &Mutex<HashMap<Uri, tcl_lsp_db::SourceFile>>,
     uri: &Uri,
@@ -2029,6 +2044,7 @@ async fn has_external_callers(
         f.external_call_sites(&*db)
             .as_ref()
             .is_some_and(|e| !e.is_empty())
+            || f.workspace_class_factories(&*db).is_some()
     })
 }
 
@@ -2143,6 +2159,74 @@ async fn sync_cross_file_evidence(handles: &EvidenceHandles) -> Vec<Uri> {
             continue;
         }
         file.set_external_call_sites(&mut *db).to(want);
+        changed.push(uri);
+    }
+    changed
+}
+
+/// Refresh every project file's [`tcl_lsp_db::SourceFile::workspace_class_factories`]
+/// — the workspace's user-defined `TclOO` metaclasses (issue #1276) — and
+/// report the URIs whose oracle actually moved.
+///
+/// One index serves every file: a metaclass is a project-wide declaration,
+/// not a per-file slice, and there is no per-file narrowing to make.  It is
+/// **empty for the overwhelming majority of workspaces**, and an empty index
+/// is stored as `None`, so the input never leaves its default and nothing is
+/// ever invalidated by it — a workspace with no metaclass behaves exactly as
+/// it did before the index existed.
+///
+/// Same shape as [`sync_cross_file_evidence`] and for the same reasons: the
+/// project-wide read runs on a cloned salsa snapshot inside `spawn_blocking`
+/// so the `db` mutex is held only for the short write section, cancellation
+/// is caught and reported as "nothing changed", and the write is
+/// compare-then-set against the *live* database rather than the snapshot.
+///
+/// Called from two places, because the answer must be in place before either
+/// consumer needs it: at the end of the workspace scan (so a document opened
+/// afterwards is analysed with the oracle on its very first pass) and after
+/// each diagnostics publish (so a metaclass added by an *edit* propagates).
+async fn sync_workspace_class_factories(handles: &EvidenceHandles) -> Vec<Uri> {
+    use salsa::Setter as _;
+    let (snapshot, files, project) = {
+        let db = handles.db.lock().await;
+        let db_files = handles.db_files.lock().await;
+        let db_project = handles.db_project.lock().await;
+        let Some(&project) = db_project.as_ref() else {
+            return Vec::new();
+        };
+        let files: Vec<(Uri, tcl_lsp_db::SourceFile)> =
+            db_files.iter().map(|(u, &f)| (u.clone(), f)).collect();
+        (db.clone(), files, project)
+    };
+    // `AssertUnwindSafe`: the closure only *reads* the database, and a
+    // cancellation unwind discards the whole `pending` list without applying
+    // anything, so no torn state can be observed afterwards.
+    let computed = tokio::task::spawn_blocking(move || {
+        salsa::Cancelled::catch(std::panic::AssertUnwindSafe(|| {
+            let index = tcl_lsp_db::project_class_factories(&snapshot, project);
+            let want = (!index.is_empty()).then_some(index);
+            let pending: Vec<(Uri, tcl_lsp_db::SourceFile)> = files
+                .into_iter()
+                .filter(|(_, file)| {
+                    file.workspace_class_factories(&snapshot).as_deref() != want.as_deref()
+                })
+                .collect();
+            (want, pending)
+        }))
+        .ok()
+    })
+    .await;
+    let Ok(Some((want, pending))) = computed else {
+        return Vec::new();
+    };
+    let mut db = handles.db.lock().await;
+    let mut changed = Vec::with_capacity(pending.len());
+    for (uri, file) in pending {
+        if file.workspace_class_factories(&*db).as_deref() == want.as_deref() {
+            continue;
+        }
+        file.set_workspace_class_factories(&mut *db)
+            .to(want.clone());
         changed.push(uri);
     }
     changed
@@ -4053,6 +4137,22 @@ impl Backend {
             let mut project = self.db_project.lock().await;
             Self::sync_db_project(&mut db, &files, &mut project);
         }
+    }
+
+    /// The workspace class-factory oracle this document is analysed under,
+    /// cloned out of the salsa db so a `spawn_blocking` analysis can carry it
+    /// (issue #1276).
+    ///
+    /// `None` when the document is not in the salsa db, which is the honest
+    /// answer — no workspace view — rather than a claim of one.  Lock order is
+    /// `db` → `db_files`, matching [`Self::db_set_source`].
+    async fn class_factories_for(
+        &self,
+        uri: &Uri,
+    ) -> Option<Arc<tcl_compiler::analyser::ClassFactoryIndex>> {
+        let db = self.db.lock().await;
+        let files = self.db_files.lock().await;
+        files.get(uri)?.workspace_class_factories(&*db).clone()
     }
 
     /// This document's cross-file call-site evidence, cloned out of the salsa
@@ -7189,6 +7289,11 @@ impl Backend {
         dialect: &str,
     ) -> Arc<AnalysisResult> {
         let workspace_classes = self.workspace_index.read().await.all_class_qnames();
+        // The class-factory oracle travels with the class-name set (issue
+        // #1276): without it this tier would not see a class the document
+        // manufactures through a cross-file metaclass at all, and a method
+        // lookup on one would miss where the cached tier resolves it.
+        let workspace_class_factories = self.class_factories_for(uri).await;
         let fingerprint = (
             document_fingerprint(source, dialect),
             class_set_fingerprint(&workspace_classes),
@@ -7208,6 +7313,7 @@ impl Backend {
             Arc::new(
                 tcl_compiler::analyser::Analyser::new()
                     .with_workspace_classes(workspace_classes)
+                    .with_workspace_class_factories(workspace_class_factories)
                     .analyse(&owned_source, &owned_dialect)
                     .clone(),
             )
@@ -11452,6 +11558,19 @@ impl Backend {
         // just batched in, which answer `file_decls` / `item_sigs` on demand)
         // until a request actually needs their deep analysis.
         self.spawn_workspace_warm();
+        // Publish the workspace's class-factory oracle *before* the readiness
+        // signal (issue #1276). A document opened after the scan must be
+        // analysed with it on its very first pass, or its outline and
+        // navigation come back empty for every class a cross-file metaclass
+        // manufactures — the exact symptom the issue reports — until some
+        // later edit happens to re-run the diagnostics worker.
+        sync_workspace_class_factories(&EvidenceHandles {
+            db: Arc::clone(&self.db),
+            db_files: Arc::clone(&self.db_files),
+            db_project: Arc::clone(&self.db_project),
+            workspace_index: Arc::clone(&self.workspace_index),
+        })
+        .await;
         // In-process readiness signal, released before the log line so a
         // handler waiting on it is not held up by a client round-trip.
         self.workspace_scan_ready.mark_complete();

--- a/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
+++ b/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
@@ -1429,7 +1429,7 @@ fn tn_a_not_yet_run_import_does_not_resolve_the_receiver() {
 /// in the `oo::class create` block **and** in a later `oo::define` block that
 /// reopens the same class.
 ///
-/// The reopening block is the SpiceGenTcl `generalClasses.tcl` shape
+/// The reopening block is the `SpiceGenTcl` `generalClasses.tcl` shape
 /// (`oo::configurable create Parameter { … }` followed by `oo::define
 /// Parameter { method <WriteProp-value> … }`).  Oracle, tclsh 9.0.4: the
 /// method the second block declares really is dispatchable on the class the

--- a/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
+++ b/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
@@ -1422,3 +1422,61 @@ fn tn_a_not_yet_run_import_does_not_resolve_the_receiver() {
         "a call written before its import must not resolve",
     );
 }
+
+// Issue #1019 idx 16 — a class member hovers at its own declaration.
+
+/// TP (end-to-end): hovering a method's own name token describes that method,
+/// in the `oo::class create` block **and** in a later `oo::define` block that
+/// reopens the same class.
+///
+/// The reopening block is the SpiceGenTcl `generalClasses.tcl` shape
+/// (`oo::configurable create Parameter { … }` followed by `oo::define
+/// Parameter { method <WriteProp-value> … }`).  Oracle, tclsh 9.0.4: the
+/// method the second block declares really is dispatchable on the class the
+/// first block created, so both declarations describe members of one class
+/// and must hover identically.
+///
+/// Before this, neither block hovered at a declaration at all — only call
+/// sites did — which made the reopening half look like a block-specific bug.
+#[test]
+fn tp_member_declaration_hovers_in_both_class_blocks() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        concat!(
+            "oo::class create Widget {\n",
+            "    method show {} { return shown }\n",
+            "}\n",
+            "oo::define Widget {\n",
+            "    method reopened {val} { return $val }\n",
+            "}\n",
+            "Widget create w\n",
+            "w reopened hi\n",
+        ),
+    );
+
+    let creation = hover_text(&lsp.hover(&uri, 1, 13));
+    assert!(
+        creation.contains("::Widget::show"),
+        "creation-block declaration must hover: {creation:?}"
+    );
+
+    let reopened = hover_text(&lsp.hover(&uri, 4, 13));
+    assert!(
+        reopened.contains("::Widget::reopened"),
+        "reopening-block declaration must hover: {reopened:?}"
+    );
+    assert!(
+        reopened.contains("1 param"),
+        "…with the member's real signature: {reopened:?}"
+    );
+
+    // The declaration and its call site describe the same member the same
+    // way — the asymmetry idx 16 reported is gone in both directions.
+    let call_site = hover_text(&lsp.hover(&uri, 7, 4));
+    assert_eq!(
+        reopened, call_site,
+        "declaration and call site must render identically",
+    );
+}


### PR DESCRIPTION
Closes #1276. Closes #1277.

Lands the #1019 TclOO cluster together with the two follow-ups it uncovered, since all three touch the same class/member model.

## #1019 TclOO findings

The cluster covers the tclOO group of the #923 differential audit: method resolution across mixins and superclasses, `oo::Helpers` members, member hover at a declaration, and a folded dynamic command head settling through the global fallback. Each finding is pinned at the tiers that apply to it, and the ones that remain abstentions are documented as abstentions with a test that holds them there, rather than left silently unhandled.

## #1276 — cross-file metaclasses were invisible

A class manufactured by a metaclass in *another* file did not exist as far as the walk was concerned: there was no workspace-level class index for it to consult, so resolution stopped at the file boundary.

A class factory is now derived once, at the point where the metaclass is written, and published through the workspace:

```
ItemTree::class_factories → project_class_factories → SourceFile::workspace_class_factories
```

`ClassDef` carries `factory: Option<ClassFactory>`, whose words are `FactoryWord::{Literal, CallerSplice}` so a factory that splices its caller's arguments is represented rather than guessed at.

**The parity test caught a real bug on its first run.** `analyse_proc_body_isolated` built a fresh `Analyser` with no oracle, so the deferred body silently dropped the class — per-item and whole-file analysis disagreed. This is the third instance of that same trap in this campaign, which is why the parity test exists. Fixed by threading the index into the deferred body and keying it into `ItemBodyKey::body_env`, widened to a 3-tuple because salsa's interned-struct `Hash` caps at 12 fields.

**Documented residual:** a metaclass itself manufactured by a *third* file's metaclass resolves only on the next sync round. It converges; it is not a fixpoint. Recorded rather than papered over.

## #1277 — `params_computed`

`MethodDef` can now say "signature unknown" instead of implying a signature it does not have, which lets literal `foreach`-installed member names be recorded without inventing parameter lists for them. Reflectively-installed members make the member set a lower bound rather than a claim of completeness.

## Gates

Full workspace on the combined tip, from clean: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo test --workspace --all-features` all clean — **16845 passed, 0 failed across 323 test binaries**.

Rebased onto current `rust` after #1286 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_