### PR TITLE
Registry sweep: a conditionally-bound local never carries an unconditional-def ArgRole (#1278)

### DIFF
--- a/rust/tcl-registry/src/commands/tcl/dict.rs
+++ b/rust/tcl-registry/src/commands/tcl/dict.rs
@@ -448,6 +448,7 @@ static SUBCOMMANDS: &[SubCommand] = &[
         // its suppression and would hide the genuine absent-key warning.
         repeated_args: &[RepeatedArgLayout {
             exclude_trailing: 1,
+            conditional_binding: true,
             ..RepeatedArgLayout::strided(ArgRole::LoopVarList, 2, 2)
         }],
         arg_types: &[(

--- a/rust/tcl-registry/src/repeated.rs
+++ b/rust/tcl-registry/src/repeated.rs
@@ -68,6 +68,34 @@ pub struct RepeatedArgLayout {
     /// `upvar 1 a b` (3 words, a level) binds it at index 2 — and both are
     /// the same declaration.
     pub optional_leading_word: bool,
+    /// Whether the local this position names is bound only when a runtime
+    /// **data** condition holds — a dict/array key actually being present —
+    /// rather than unconditionally whenever the statement executes.
+    ///
+    /// `dict update dictVar key varName …` binds `varName` only if `key` is
+    /// present in the dict at that moment (tclsh: an absent key leaves
+    /// `varName` unset); a plain `global`/`variable`/`upvar`/`namespace
+    /// upvar` local, by contrast, is bound whenever the statement runs at
+    /// all — it does not depend on the *content* of anything, only on the
+    /// statement not erroring.
+    ///
+    /// This is the fact
+    /// `repeated_arg_layouts_never_pair_conditional_binding_with_an_ssa_def_role`
+    /// (`tcl-registry/tests/registry_sweep.rs`) checks against
+    /// [`ArgRole`]: every generic write-detection site the compiler has
+    /// (`tcl-compiler`'s `ssa::defs_of_with_registry`, `var_scoping`,
+    /// `cfg_builder`, `lowering`, `ir_helpers`) resolves "does this argument
+    /// write a variable" through `ArgRole::VarWrite` alone — none of them
+    /// consult any other role — so `VarWrite` is read everywhere as "this
+    /// position unconditionally defines the named variable when the
+    /// statement executes". A `conditional_binding: true` layout must never
+    /// use it: doing so is exactly the mechanism that produced the `dict
+    /// update` W210 false positive investigated for issue #1247/#1278 —
+    /// `VarWrite` fed an unconditional SSA def, which pre-empted the
+    /// key-aware suppression `harvest_dict_with_suppression`
+    /// (`tcl-compiler/src/analyser/diagnostics/helpers.rs`) had already
+    /// computed for the very same read.
+    pub conditional_binding: bool,
 }
 
 impl RepeatedArgLayout {
@@ -81,6 +109,7 @@ impl RepeatedArgLayout {
             stride: 1,
             exclude_trailing: 0,
             optional_leading_word: false,
+            conditional_binding: false,
         }
     }
 
@@ -93,6 +122,7 @@ impl RepeatedArgLayout {
             stride,
             exclude_trailing: 0,
             optional_leading_word: false,
+            conditional_binding: false,
         }
     }
 

--- a/rust/tcl-registry/tests/registry_sweep.rs
+++ b/rust/tcl-registry/tests/registry_sweep.rs
@@ -1691,3 +1691,103 @@ fn boolean_argument_role_is_declared_and_consistent() {
     assert!(!ArgRole::NumericOrBoolean.consumes_boolean());
     assert!(!ArgRole::Value.consumes_boolean());
 }
+
+/// A conditionally-bound local must never carry an `ArgRole` SSA models as
+/// an unconditional definition — issue #1278, prompted by the investigation
+/// that closed #1247.
+///
+/// #1247 reported a W210 false positive on a `dict update` value-var. It did
+/// not reproduce on `rust` (the commit it cited was on an unmerged
+/// integration branch), but the mechanism is real: that branch declared
+/// `dict update`'s pair locals `ArgRole::VarWrite`. `VarWrite` at a
+/// `repeated_args` position feeds every generic "does this argument write a
+/// variable" site the compiler has — established by reading each one's own
+/// `arg_indices_for_role` call: `tcl-compiler`'s `ssa::defs_of_with_registry`
+/// (the `Statement::Barrier` arm `dict update`/`dict with` lower to),
+/// `var_scoping` (twice — the `global`/`variable`/`upvar`-family scope-alias
+/// walk), `cfg_builder::builtin_write_defs_from_text`, `lowering`'s
+/// registry-driven default-call def extractor and its `trace`/`vwait`
+/// resolvers, and `ir_helpers`'s `defs_from_expr` / `defs_from_body_script`
+/// / deletion-safety scans. Every one of those asks for `ArgRole::VarWrite`
+/// specifically; none asks for `LoopVarList` or any other role. So
+/// `VarWrite` is, by construction of the compiler's own def-use code (not by
+/// assumption here), the one role SSA treats as an **unconditional**
+/// definition of the position it is declared at — a def with `version > 0`
+/// that `build_undef_suppression`
+/// (`tcl-compiler/src/analyser/diagnostics/helpers.rs`) puts straight into
+/// `explicitly_defined`, which `suppresses_strict` checks *before* it
+/// honours the key-aware `dict_with_known_keys` suppression
+/// `harvest_dict_with_suppression` computed for the very same read — so an
+/// absent-key read that should be suppressed draws W210 instead.
+///
+/// [`RepeatedArgLayout::conditional_binding`] is the registry's declared
+/// counterpart: `true` marks a position whose local is bound only when a
+/// runtime *data* condition holds (a dict/array key actually being present),
+/// not merely whenever the statement executes — `dict update dictVar key
+/// varName` binds `varName` only if `key` is in the dict (tclsh: an absent
+/// key leaves it unset). This sweep asserts the invariant over **every**
+/// `repeated_args` declaration in every dialect's registry: no command name
+/// appears in the check, only the two declared fields, so the next command
+/// whose layout gets this wrong fails here — pointing at the offending
+/// declaration — rather than surfacing four layers away as a diagnostic
+/// false positive. `dict update` (`conditional_binding: true`, `LoopVarList`)
+/// is the one positive control that currently exercises the `true` arm;
+/// `foreach`/`lmap`'s loop-var lists, `global`/`variable`'s repeated names,
+/// and the `upvar`/`namespace upvar` local layouts are positive controls for
+/// the untouched (`conditional_binding: false`) arm — they use `VarWrite` /
+/// `LoopVarList` freely because their bindings really are unconditional
+/// (aliasing/assignment that depends on the statement running, never on a
+/// key or element being present).
+#[test]
+fn repeated_arg_layouts_never_pair_conditional_binding_with_an_ssa_def_role() {
+    use tcl_registry::RepeatedArgLayout;
+
+    // Every `ArgRole` the compiler's own def-use code queries when deciding
+    // "does this argument position define a variable" — see the doc comment
+    // above for the exhaustive list of call sites this was read from. Only
+    // `VarWrite` is ever asked for; extending this list requires reading a
+    // new unconditional-def call site into existence first, not guessing.
+    const SSA_UNCONDITIONAL_DEF_ROLES: &[ArgRole] = &[ArgRole::VarWrite];
+
+    let mut conditional_layouts_checked = 0usize;
+
+    for &dialect in LOADABLE_DIALECTS {
+        let reg = registry_for_dialect(dialect);
+        let names: Vec<String> = reg.command_names().map(str::to_owned).collect();
+        for name in &names {
+            let Some(spec) = reg.get(name) else { continue };
+
+            let mut layouts: Vec<(String, &'static [RepeatedArgLayout])> =
+                vec![(spec.name.to_owned(), spec.repeated_args)];
+            for sub in spec.subcommands {
+                layouts.push((format!("{} {}", spec.name, sub.name), sub.repeated_args));
+            }
+
+            for (path, repeated) in layouts {
+                for layout in repeated {
+                    if !layout.conditional_binding {
+                        continue;
+                    }
+                    conditional_layouts_checked += 1;
+                    assert!(
+                        !SSA_UNCONDITIONAL_DEF_ROLES.contains(&layout.role),
+                        "{dialect} {path}: repeated_args layout at start {} declares \
+                         conditional_binding: true (its local is bound only when a runtime \
+                         data condition holds) but role {:?} is one SSA models as an \
+                         unconditional def — this reproduces the issue #1247 W210 \
+                         false-positive mechanism (issue #1278); use a role SSA does not \
+                         treat as a definite def instead",
+                        layout.start,
+                        layout.role,
+                    );
+                }
+            }
+        }
+    }
+
+    assert!(
+        conditional_layouts_checked > 0,
+        "the sweep must actually reach a `conditional_binding: true` layout \
+         (dict update's pair locals) — otherwise the assertion above is vacuous"
+    );
+}

--- a/rust/tcl-spec-studio/src/coverage.rs
+++ b/rust/tcl-spec-studio/src/coverage.rs
@@ -1303,7 +1303,8 @@ mod tests {
             d["repeated_args"],
             json!(
                 "&[RepeatedArgLayout { role: ArgRole::VarWrite, start: 1, stride: 2, \
-                 exclude_trailing: 1, optional_leading_word: true }]"
+                 exclude_trailing: 1, optional_leading_word: true, \
+                 conditional_binding: false }]"
             )
         );
         assert_eq!(

--- a/rust/tcl-spec-studio/src/coverage.rs
+++ b/rust/tcl-spec-studio/src/coverage.rs
@@ -775,6 +775,7 @@ pub fn witness_repeated_arg_layout(layout: &RepeatedArgLayout) {
         stride: _,
         exclude_trailing: _,
         optional_leading_word: _,
+        conditional_binding: _,
     } = layout;
 }
 
@@ -788,6 +789,7 @@ pub const REPEATED_ARG_LAYOUT: &[Field] = &[
         "optional_leading_word",
         Surface::Expression("repeated_args"),
     ),
+    f("conditional_binding", Surface::Expression("repeated_args")),
 ];
 
 /// Compile-time witness for [`HANDLE_BINDING_SPEC`].
@@ -1238,6 +1240,7 @@ mod tests {
         stride: 2,
         exclude_trailing: 1,
         optional_leading_word: true,
+        conditional_binding: false,
     };
 
     const WITNESS_SYMBOL: SymbolDef = SymbolDef {

--- a/rust/tcl-spec-studio/src/draft.rs
+++ b/rust/tcl-spec-studio/src/draft.rs
@@ -428,12 +428,14 @@ fn lifecycle_expr(value: Lifecycle) -> String {
 /// is exactly the drift this module exists to prevent.
 fn repeated_arg_layout_expr(layout: RepeatedArgLayout) -> String {
     format!(
-        "RepeatedArgLayout {{ role: {}, start: {}, stride: {}, exclude_trailing: {}, optional_leading_word: {} }}",
+        "RepeatedArgLayout {{ role: {}, start: {}, stride: {}, exclude_trailing: {}, \
+         optional_leading_word: {}, conditional_binding: {} }}",
         catalogue::qualified_variant("ArgRole", &layout.role),
         layout.start,
         layout.stride,
         layout.exclude_trailing,
         layout.optional_leading_word,
+        layout.conditional_binding,
     )
 }
 


### PR DESCRIPTION
Closes #1278.

Adds a registry sweep asserting that a `RepeatedArgLayout` never pairs a conditionally-bound local with an `ArgRole` that promises an unconditional SSA definition.

## The invariant

`ArgRole::VarWrite` is the sole SSA-unconditional-def role — established by reading all seven of its call sites, not by assumption. If a layout binds its local only conditionally, carrying `VarWrite` tells SSA the variable is definitely defined when it may not be, and downstream passes are entitled to believe it.

`dict update` is exactly that shape: its locals exist only if the key is present. `RepeatedArgLayout` therefore grows a `conditional_binding: bool`, set true for `dict update`, and the sweep fails the build if any layout ever pairs `conditional_binding: true` with an unconditional-def role.

This is a sweep over the whole registry rather than a test of one command, so a *future* spec that gets the pairing wrong is caught when it is authored.

## Non-vacuity

Checked by reverting `dict update`'s role back to `VarWrite` and confirming the sweep fails. It is not asserting a condition that no data can violate.

## The coverage gate caught the WebUI half

Adding `conditional_binding` to `RepeatedArgLayout` broke the spec-studio field-coverage gate at compile time:

```
error[E0027]: pattern does not mention field `conditional_binding`
```

That is precisely what the gate exists for: without it, a layout authored through the WebUI would have come back with the conditional binding silently dropped and the round trip would have looked clean. The field is now carried in the studio's coverage table alongside the rest of `repeated_args`.

## Gates

Full workspace clean: fmt, clippy `-D warnings` with `--all-features`, and the test suite. Rebased onto current `rust` and re-checked after today's merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_