### PR TITLE
Beyond-caller frame effects through plain calls; command-table call-site exclusion; W212 FP (#1019)

### DIFF
--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -88,6 +88,10 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
   — a multi-word `eval`, `uplevel`, or `namespace eval` draws a false E002
   "wrong number of arguments", and a variable the call sets is still
   reported as read before it is set (W210).
+- [kcs-issue-uplevel-injected-variable-is-reported-unset.md](kcs-issue-uplevel-injected-variable-is-reported-unset.md)
+  — a variable a helper assigns in an outer frame with `uplevel` is reported
+  as read before it is set (W210), and the `[list set $varName …]` word that
+  does it is reported as a name/value confusion (W212).
 - [kcs-issue-always-true-condition-in-a-sourced-library-file.md](kcs-issue-always-true-condition-in-a-sourced-library-file.md)
   — I230 says a condition is always true in a library file whose procedure
   is really called with different values from another file.

--- a/docs/kcs/features/kcs-feature-references.md
+++ b/docs/kcs/features/kcs-feature-references.md
@@ -56,6 +56,14 @@ command's name, which keeps its own spelling when the target is renamed. When
 a name carries both a `rename` and an `interp alias`, the one written later is
 the one whose call sites are attributed.
 
+The reverse is true as well: a proc whose own name an alias has **taken
+over** loses those call sites. After `interp alias {} ::ttk::spinbox {}
+::tk::spinbox`, a later `::ttk::spinbox` call runs `::tk::spinbox`'s body, so
+it is not a reference to the `::ttk::spinbox` proc and a rename of that proc
+leaves it alone. A `proc` written *after* the alias takes the name back, and
+an alias installed inside another proc's body may never run, so neither of
+those drops a call site.
+
 A callback wrapped for its namespace — `trace add variable v w [namespace
 code [list Handler]]`, the idiom Tk's own `fontchooser.tcl` uses — is a
 reference to `Handler`, in the `[list …]`, braced, and bareword forms alike.

--- a/docs/kcs/features/kcs-feature-rename.md
+++ b/docs/kcs/features/kcs-feature-rename.md
@@ -55,6 +55,15 @@ updates every namespace's call sites together. For the full contract,
 see
 [resolution soundness](../../design/resolution-soundness-945.md).
 
+Rename follows the **command table**, not the spelling. A proc whose name
+an `interp alias` has taken over is dead under that name, so renaming it
+rewrites its header only: after `interp alias {} ::ttk::spinbox {}
+::tk::spinbox`, a `::ttk::spinbox` call runs `::tk::spinbox`'s body, and
+rewriting that call too would silently switch which body it invokes.
+Renaming the alias's *target* rewrites the target's header and the alias's
+own target word, and leaves the call site alone — it spells the alias's
+name, which does not change.
+
 Renaming a `TclOO` method rewrites the declaration plus every `my method`
 dispatch site (however deeply nested in `[…]` substitutions or same-frame
 control-flow / `eval` bodies — see [Find References](kcs-feature-references.md)),

--- a/docs/kcs/kcs-issue-uplevel-injected-variable-is-reported-unset.md
+++ b/docs/kcs/kcs-issue-uplevel-injected-variable-is-reported-unset.md
@@ -1,0 +1,106 @@
+# KCS: Why is a variable my helper sets through `uplevel` reported as unset?
+
+> **Audience:** User
+> **Type:** Issue
+
+## Applies to
+
+all-editors, diagnostic, analyser
+
+## Question
+
+My helper procedure assigns a variable in its caller's frame with
+`uplevel 1 [list set $varName $value]`. Why does the caller's read of that
+variable draw "read before set", and why is the `$varName` inside the
+`[list …]` reported as a name/value confusion?
+
+## Symptoms
+
+- A yellow squiggle reporting **`W210`** — "Variable 'answer' is read before
+  it is set" — on a read of a variable a helper really does assign, when the
+  helper is reached through one or more ordinary calls.
+- A yellow squiggle reporting **`W212`** — "'set' expects a variable name,
+  got substitution (`$varName`)" — on the `[list set $varName …]` word
+  itself.
+- The one-hop spelling (`helper` called directly from the frame it writes)
+  is quiet, while the same helper reached one call deeper is not.
+
+## Why
+
+Two independent causes, both about *whose* frame a write lands in.
+
+**`W210`.** A procedure that writes its caller's frame is summarised once,
+and every call site consults that summary. A level that lands on the direct
+caller (`upvar 1`, `uplevel 1`) is emphatically *not* transitive through an
+ordinary call — `worker`'s `upvar 1` reaches `wrapper`'s frame, not
+`wrapper`'s caller's — so the summary stopped there. But a level that lands
+*past* the caller travels one hop further along an ordinary call, and that
+hop was missing:
+
+```tcl
+proc setUp2  {var} { uplevel 2 [list set $var 99] }
+proc middle  {}    { setUp2 answer }
+proc outer   {}    { middle ; return $answer }
+puts [outer]        ;# -> 99, on tclsh 8.6 and 9.0 alike
+```
+
+`answer` is genuinely assigned in `outer`'s frame by a procedure `outer`
+never calls directly, so the read is not a read before set.
+
+**`W212`.** That check asks whether a variable-*name* word was spelled as a
+`$` substitution by mistake. Inside a `[list …]`-built script the question
+does not arise: `list` substitutes `$varName` in the **building** frame, so
+the script `uplevel` finally runs already carries the literal name the
+author meant. The substitution is the whole idiom, not a slip.
+
+## Answer
+
+Both false reports are fixed — no configuration change or workaround is
+needed. Update to a build containing the fix.
+
+To confirm the fix is present, put the three-frame example above in a file
+and check the Problems view. Before the fix: one `W210` on `return $answer`
+and one `W212` on the `[list set $var 99]` word. After the fix: nothing.
+
+## What still reports
+
+Neither check was switched off:
+
+```tcl
+proc setLocally {var} { set $var 99 }     ;# W212 — written by hand
+proc useIt {} { setLocally answer
+                return $answer }          ;# W210 — nothing reached this frame
+```
+
+`setLocally` assigns its *own* local, so `useIt`'s read really does fail
+(`can't read "answer": no such variable` under tclsh 8.6 and 9.0), and the
+directly written `set $var` really is the name/value shape `W212` exists
+for. `uplevel #0` (the global frame) and `uplevel 0` (the procedure's own
+frame) reach no caller either, so they silence nothing.
+
+## When the analyser stays quiet anyway
+
+A level the analyser cannot place — `uplevel [expr {[info level] - $n}] …`,
+the spelling `tcltest`-style output-capture helpers use — could be any
+frame, so the analyser assumes the write may have happened rather than
+reporting a read it cannot disprove. The same applies two ordinary calls out
+from an `uplevel 3`: the summary carries one hop, and widens beyond it.
+
+A writer materialised at run time is outside this entirely. A procedure
+built by `eval [subst {proc ::puts …}]` and then reached through a renamed
+built-in does not exist in the source the analyser reads, so a variable only
+that procedure assigns is still reported. Suppress it per line if you hit
+that shape.
+
+## How to suppress
+
+Add `# noqa: W210` or `# noqa: W212` at the end of the offending line, and
+please open an issue with the snippet.
+
+## Related
+
+- [KCS index](README.md)
+- [Glossary](../GLOSSARY.md)
+- [W210 — variable read before set](codes/kcs-diagnostic-w210-variable-read-before-set.md)
+- [W212 — substitution where a variable name is expected](codes/kcs-diagnostic-w212-variable-substitution-where-name-expected.md)
+- [Why does a multi-word `eval` report a wrong-argument-count error?](kcs-issue-false-diagnostics-inside-a-multi-word-eval.md)

--- a/editors/vscode/node_modules
+++ b/editors/vscode/node_modules
@@ -1,0 +1,1 @@
+/home/user/tcl-lsp/editors/vscode/node_modules

--- a/editors/vscode/node_modules
+++ b/editors/vscode/node_modules
@@ -1,1 +1,0 @@
-/home/user/tcl-lsp/editors/vscode/node_modules

--- a/editors/vscode/src/test/aliasTracking.test.ts
+++ b/editors/vscode/src/test/aliasTracking.test.ts
@@ -23,7 +23,13 @@ import { getDocUri, activate } from "./helper";
 // End-to-end coverage that an ``upvar`` alias is tracked as its own local
 // symbol over the wire: references and rename stay scoped to the alias name
 // (``alias_x``) and never bleed into the differently-named caller variable
-// (``caller_x``).  The fixture aliasTracking.tcl is:
+// (``caller_x``).
+//
+// This file is about ``upvar`` VARIABLE aliasing ONLY.  The unrelated
+// ``interp alias`` COMMAND aliasing (issue #923 audit idx 21 / idx 89) lives
+// in ``commandAliasTracking.test.ts``; nothing here covers it.
+//
+// The fixture aliasTracking.tcl is:
 //
 //   0: proc fixed {} {
 //   1:     upvar 1 caller_x alias_x
@@ -33,7 +39,7 @@ import { getDocUri, activate } from "./helper";
 //   5: }
 //   6: set caller_x 0
 //   7: fixed
-suite("Alias Tracking (upvar)", () => {
+suite("Alias Tracking (upvar variable aliases)", () => {
   const docUri = getDocUri("aliasTracking.tcl");
 
   test("references for an upvar alias stay within the proc", async () => {

--- a/editors/vscode/src/test/commandAliasTracking.test.ts
+++ b/editors/vscode/src/test/commandAliasTracking.test.ts
@@ -1,0 +1,202 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { getDocUri, activate } from "./helper";
+
+// End-to-end coverage of `interp alias` COMMAND aliasing over the wire
+// (issue #923 audit idx 21 and idx 89).
+//
+// This is the command-table half of aliasing.  `aliasTracking.test.ts` covers
+// the unrelated `upvar` VARIABLE aliasing and provides no coverage here.
+//
+// The fixture commandAliasTracking.tcl is pinned to real C Tcl — running it
+// under tclsh 9.0.4 and 8.6.16 prints, byte-identically:
+//
+//   hi
+//   hi
+//   classic tk::spinbox: .sb
+//
+// so (a) both `[sayHi]` calls really execute `greet`'s body, and (b) the
+// `::ttk::spinbox` proc on line 17 never runs — the alias on line 23 took its
+// name over for good.
+//
+//    8: proc greet {} {
+//   11: interp alias {} sayHi {} greet
+//   12: puts [sayHi]
+//   13: puts [sayHi]
+//   17: proc ::ttk::spinbox {w args} {
+//   20: proc ::tk::spinbox {w args} {
+//   23: interp alias {} ::ttk::spinbox {} ::tk::spinbox
+//   24: ::ttk::spinbox .sb
+
+const docUri = getDocUri("commandAliasTracking.tcl");
+
+/** Start lines of *locations*, sorted and deduplicated. */
+function startLines(locations: vscode.Location[]): number[] {
+  return [...new Set(locations.map((l) => l.range.start.line))].sort((a, b) => a - b);
+}
+
+/** Start lines of the edits *edit* carries for the fixture document. */
+function editLines(edit: vscode.WorkspaceEdit | undefined): number[] {
+  assert.ok(edit, "Expected a workspace edit");
+  const entry = edit.entries().find(([uri]) => uri.toString() === docUri.toString());
+  assert.ok(entry, "Expected edits for the fixture document");
+  return [...new Set(entry[1].map((e) => e.range.start.line))].sort((a, b) => a - b);
+}
+
+suite("Command Alias Tracking (interp alias)", () => {
+  test("references from an alias target include the call sites spelled through it", async () => {
+    await activate(docUri);
+
+    // Line 8, column 6 — the `greet` declaration.
+    const locations = (await vscode.commands.executeCommand(
+      "vscode.executeReferenceProvider",
+      docUri,
+      new vscode.Position(8, 6),
+    )) as vscode.Location[];
+
+    const lines = startLines(locations);
+    assert.ok(lines.includes(8), `The declaration must be reported: ${lines}`);
+    assert.ok(
+      lines.includes(12) && lines.includes(13),
+      `Both [sayHi] calls really run greet's body and must be reported: ${lines}`,
+    );
+  });
+
+  test("references from an alias call site resolve through to the target", async () => {
+    await activate(docUri);
+
+    // Line 12, column 6 — inside the `sayHi` call.
+    const locations = (await vscode.commands.executeCommand(
+      "vscode.executeReferenceProvider",
+      docUri,
+      new vscode.Position(12, 6),
+    )) as vscode.Location[];
+
+    const lines = startLines(locations);
+    assert.ok(lines.includes(8), `The target's declaration must be reported: ${lines}`);
+    assert.ok(
+      lines.includes(12) && lines.includes(13),
+      `Both alias call sites must be reported: ${lines}`,
+    );
+  });
+
+  test("rename of an alias target leaves the alias's own call sites alone", async () => {
+    await activate(docUri);
+
+    const edit = (await vscode.commands.executeCommand(
+      "vscode.executeDocumentRenameProvider",
+      docUri,
+      new vscode.Position(8, 6),
+      "salute",
+    )) as vscode.WorkspaceEdit | undefined;
+
+    const lines = editLines(edit);
+    assert.ok(lines.includes(8), `The declaration must be rewritten: ${lines}`);
+    assert.ok(
+      lines.includes(11),
+      `The alias's own TARGET word names greet and must be rewritten: ${lines}`,
+    );
+    assert.ok(
+      !lines.includes(12) && !lines.includes(13),
+      `A [sayHi] call names the ALIAS, which keeps its spelling: ${lines}`,
+    );
+  });
+
+  test("go-to-definition on a shadowed call reaches the alias target, not the displaced proc", async () => {
+    await activate(docUri);
+
+    // Line 24, column 2 — the `::ttk::spinbox .sb` call, which really runs
+    // `::tk::spinbox`'s body.
+    const locations = (await vscode.commands.executeCommand(
+      "vscode.executeDefinitionProvider",
+      docUri,
+      new vscode.Position(24, 2),
+    )) as (vscode.Location | vscode.LocationLink)[];
+
+    const lines = [
+      ...new Set(
+        locations.map((l) =>
+          "range" in l ? l.range.start.line : (l as vscode.LocationLink).targetRange.start.line,
+        ),
+      ),
+    ];
+    assert.deepStrictEqual(
+      lines,
+      [20],
+      `The call reaches ::tk::spinbox's declaration on line 20, got ${lines}`,
+    );
+  });
+
+  test("references from a proc an alias shadowed exclude the redirected call", async () => {
+    await activate(docUri);
+
+    // Line 17, column 12 — the displaced `::ttk::spinbox` declaration.
+    const locations = (await vscode.commands.executeCommand(
+      "vscode.executeReferenceProvider",
+      docUri,
+      new vscode.Position(17, 12),
+    )) as vscode.Location[];
+
+    const lines = startLines(locations);
+    assert.ok(
+      !lines.includes(24),
+      `Line 24 runs ::tk::spinbox's body, so it is not a reference to the ` +
+        `displaced proc: ${lines}`,
+    );
+  });
+
+  test("rename of a proc an alias shadowed does not rewrite the redirected call", async () => {
+    await activate(docUri);
+
+    const edit = (await vscode.commands.executeCommand(
+      "vscode.executeDocumentRenameProvider",
+      docUri,
+      new vscode.Position(17, 12),
+      "newname",
+    )) as vscode.WorkspaceEdit | undefined;
+
+    const lines = editLines(edit);
+    assert.deepStrictEqual(
+      lines,
+      [17],
+      `Rewriting line 24 too would change "classic tk::spinbox: .sb" into ` +
+        `"themed ttk::spinbox: .sb" — a rename that silently changes which ` +
+        `body runs. Got: ${lines}`,
+    );
+  });
+
+  test("references from the alias target still reach the redirected call", async () => {
+    await activate(docUri);
+
+    // Line 20, column 12 — the `::tk::spinbox` declaration, which the alias
+    // on line 23 redirects the line-24 call onto.
+    const locations = (await vscode.commands.executeCommand(
+      "vscode.executeReferenceProvider",
+      docUri,
+      new vscode.Position(20, 12),
+    )) as vscode.Location[];
+
+    const lines = startLines(locations);
+    assert.ok(lines.includes(20), `The declaration must be reported: ${lines}`);
+    assert.ok(lines.includes(23), `The alias's target word must be reported: ${lines}`);
+    assert.ok(lines.includes(24), `The redirected call site must be reported: ${lines}`);
+  });
+});

--- a/editors/vscode/src/test/diagnostics.test.ts
+++ b/editors/vscode/src/test/diagnostics.test.ts
@@ -211,6 +211,39 @@ suite("Diagnostics", () => {
     );
   });
 
+  test("W123 flags a rename whose source command does not exist", async () => {
+    // Issue #923 audit idx 5. `rename OLD NEW` requires OLD to resolve;
+    // tclsh 9.0.4 and 8.6.16 both abort the fixture at line 8 with
+    // `can't rename "definitelyNotDefinedAnywhere": command doesn't exist`,
+    // and the delete form (`rename X {}`, line 9) with `can't delete
+    // "totallyBogusCommand": command doesn't exist`. Both are guaranteed
+    // runtime errors, so both source words must be flagged — while the
+    // genuine `rename greet hail` on line 12 stays silent.
+    const renameUri = getDocUri("diagnostics-rename-nonexistent.tcl");
+    await activate(renameUri);
+    const diagnostics = await waitForDiagnostics(renameUri, { minCount: 1 });
+
+    const w123 = diagnostics.filter((d) => {
+      const code = typeof d.code === "object" ? d.code.value : d.code;
+      return code === "W123";
+    });
+    const lines = w123.map((d) => d.range.start.line).sort((a, b) => a - b);
+    assert.deepStrictEqual(
+      lines,
+      [8, 9],
+      `Expected W123 on both bogus rename sources and nowhere else, got ${lines}: ` +
+        `${w123.map((d) => d.message).join("; ")}`,
+    );
+    assert.ok(
+      w123.some((d) => d.message.includes("definitelyNotDefinedAnywhere")),
+      `Expected the rename form to be named, got: ${w123.map((d) => d.message).join("; ")}`,
+    );
+    assert.ok(
+      w123.some((d) => d.message.includes("totallyBogusCommand")),
+      `Expected the delete form to be named, got: ${w123.map((d) => d.message).join("; ")}`,
+    );
+  });
+
   test("W143 flags private ::tcl:: namespace calls only, and only fixes the legal rewrites", async () => {
     const privateUri = getDocUri("diagnostics-private-tcl-namespace.tcl");
     await activate(privateUri);

--- a/editors/vscode/src/test/nestedSelfRedefinition.test.ts
+++ b/editors/vscode/src/test/nestedSelfRedefinition.test.ts
@@ -1,0 +1,126 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { getDocUri, activate, waitForDiagnostics } from "./helper";
+
+// A nested, cross-namespace proc self-redefinition (issue #923 audit idx 45),
+// end to end in the editor.  The fixture nestedSelfRedefinition.tcl:
+//
+//   15: namespace eval ticklecharts {}
+//   16: proc ticklecharts::activate {bool} {
+//   17:     if {$bool} {
+//   18:         proc activate {bool} {puts "already activated"}
+//   19:         puts "activating for the first time"
+//   20:     }
+//   21: }
+//   22: ticklecharts::activate 1
+//   23: ticklecharts::activate 1
+//
+// tclsh 9.0.4 and 8.6.16 agree byte-for-byte: the calls print `activating for
+// the first time` then `already activated`, and afterwards `info commands
+// ::activate` is empty while `info commands ::ticklecharts::activate` reports
+// the command.  Both `proc` headers therefore declare ONE command, so a
+// reference or rename query from either must answer with the same call sites.
+//
+// The mirror shape (two verbatim-identical top-level declarations, idx 31) is
+// covered at the server tier; this is the namespace-aware half.
+
+/** Start lines of *locations*, sorted and deduplicated. */
+function startLines(locations: vscode.Location[]): number[] {
+  return [...new Set(locations.map((l) => l.range.start.line))].sort((a, b) => a - b);
+}
+
+/** The `code` string of a diagnostic, whatever shape VS Code hands us. */
+function codeOf(d: vscode.Diagnostic): string | undefined {
+  const code = typeof d.code === "object" && d.code !== null ? d.code.value : d.code;
+  return code === undefined ? undefined : String(code);
+}
+
+suite("Nested cross-namespace self-redefinition", () => {
+  const docUri = getDocUri("nestedSelfRedefinition.tcl");
+
+  // Line 16 col 20 is the `activate` of the outer `ticklecharts::activate`
+  // header; line 18 col 13 is the nested, unqualified one.
+  const declarations: [number, number, string][] = [
+    [16, 20, "outer"],
+    [18, 13, "nested"],
+  ];
+
+  for (const [line, character, which] of declarations) {
+    test(`references from the ${which} declaration reach both call sites`, async () => {
+      await activate(docUri);
+
+      const locations = (await vscode.commands.executeCommand(
+        "vscode.executeReferenceProvider",
+        docUri,
+        new vscode.Position(line, character),
+      )) as vscode.Location[];
+
+      const lines = startLines(locations);
+      assert.ok(
+        lines.includes(22) && lines.includes(23),
+        `Both callers of the one command must be reported from the ${which} ` +
+          `declaration, got ${lines}`,
+      );
+    });
+
+    test(`rename from the ${which} declaration rewrites both call sites`, async () => {
+      await activate(docUri);
+
+      const edit = (await vscode.commands.executeCommand(
+        "vscode.executeDocumentRenameProvider",
+        docUri,
+        new vscode.Position(line, character),
+        "enable",
+      )) as vscode.WorkspaceEdit | undefined;
+
+      assert.ok(edit, `Rename should succeed on the ${which} declaration`);
+      const entry = edit.entries().find(([uri]) => uri.toString() === docUri.toString());
+      assert.ok(entry, "Expected edits for the fixture document");
+      const lines = [...new Set(entry[1].map((e) => e.range.start.line))].sort((a, b) => a - b);
+      assert.ok(
+        lines.includes(22) && lines.includes(23),
+        `A rename that leaves a caller behind silently rebinds it to whichever ` +
+          `declaration was not renamed; got ${lines}`,
+      );
+    });
+  }
+
+  test("the unused-parameter hint names the fully-qualified command", async () => {
+    // The lowering bug this finding also carried named the nested proc as the
+    // global `::activate`; the nested `proc` really redefines
+    // `::ticklecharts::activate` (proved by `info commands` above).
+    await activate(docUri);
+    const diagnostics = await waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "W214"),
+    });
+    const w214 = diagnostics.filter((d) => codeOf(d) === "W214");
+    assert.ok(
+      w214.every((d) => d.message.includes("::ticklecharts::activate")),
+      `W214 must name the enclosing namespace's command, got: ${w214
+        .map((d) => d.message)
+        .join("; ")}`,
+    );
+    assert.ok(
+      w214.every((d) => !d.message.includes("'::activate'")),
+      `No global ::activate is ever created, got: ${w214.map((d) => d.message).join("; ")}`,
+    );
+  });
+});

--- a/editors/vscode/src/test/tkChildInterp.test.ts
+++ b/editors/vscode/src/test/tkChildInterp.test.ts
@@ -82,9 +82,7 @@ suite("Tk checks across child interpreters (TK1001 / TK1002)", () => {
     );
     assert.ok(
       diagnostics.some((d) => codeOf(d) === "TK1002" && d.message.includes(".childOnly")),
-      `The message must name the missing parent: ${diagnostics
-        .map((d) => d.message)
-        .join("; ")}`,
+      `The message must name the missing parent: ${diagnostics.map((d) => d.message).join("; ")}`,
     );
   });
 

--- a/editors/vscode/src/test/tkChildInterp.test.ts
+++ b/editors/vscode/src/test/tkChildInterp.test.ts
@@ -1,0 +1,107 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { getDocUri, activate, waitForDiagnostics } from "./helper";
+
+// Tk widget checks are keyed per interpreter (issue #923 audit idx 91), end
+// to end in the editor.
+//
+// `interp create child` gives the child its own command table and its own
+// widget hierarchy — verified on tclsh 9.0.4 and 8.6.16: a command created
+// inside `child eval { … }` is absent from the parent's `info commands`, and
+// vice versa.  So a `.top` in the child and a `.top` in the parent are two
+// unrelated widgets.
+//
+// tkChildInterp.tcl (cross-interpreter):
+//   19: child eval { frame .top; pack .top.a }
+//   20: frame .top
+//   21: grid .top.b            → NOT a geometry conflict, no TK1001
+//   22: frame .childOnly.deep  → parent never created, TK1002 fires
+//
+// tkChildInterpControl.tcl (single interpreter — the checks are narrowed,
+// not disabled):
+//   12: frame .top
+//   13: pack .top.a
+//   14: grid .top.b            → TK1001 fires
+//   15: frame .missing.child   → TK1002 fires
+
+/** The `code` string of a diagnostic, whatever shape VS Code hands us. */
+function codeOf(d: vscode.Diagnostic): string | undefined {
+  const code = typeof d.code === "object" && d.code !== null ? d.code.value : d.code;
+  return code === undefined ? undefined : String(code);
+}
+
+/** Start lines of the diagnostics in *diags* carrying *code*. */
+function linesWithCode(diags: vscode.Diagnostic[], code: string): number[] {
+  return diags.filter((d) => codeOf(d) === code).map((d) => d.range.start.line);
+}
+
+suite("Tk checks across child interpreters (TK1001 / TK1002)", () => {
+  const docUri = getDocUri("tkChildInterp.tcl");
+  const controlUri = getDocUri("tkChildInterpControl.tcl");
+
+  test("no TK1001 when the two geometry managers are in different interpreters", async () => {
+    await activate(docUri);
+    // The TK1002 on line 22 is the marker that the Tk checks ran at all.
+    const diagnostics = await waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "TK1002"),
+    });
+    assert.deepStrictEqual(
+      linesWithCode(diagnostics, "TK1001"),
+      [],
+      `The child's pack and the parent's grid manage two different '.top' ` +
+        `widgets: ${diagnostics.map((d) => `${codeOf(d)}@${d.range.start.line}`).join(", ")}`,
+    );
+  });
+
+  test("TK1002 fires for a parent-interpreter widget whose parent was never created", async () => {
+    await activate(docUri);
+    const diagnostics = await waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "TK1002"),
+    });
+    assert.ok(
+      linesWithCode(diagnostics, "TK1002").includes(22),
+      `'.childOnly.deep' has no parent: ${linesWithCode(diagnostics, "TK1002")}`,
+    );
+    assert.ok(
+      diagnostics.some((d) => codeOf(d) === "TK1002" && d.message.includes(".childOnly")),
+      `The message must name the missing parent: ${diagnostics
+        .map((d) => d.message)
+        .join("; ")}`,
+    );
+  });
+
+  test("both checks still fire inside a single interpreter", async () => {
+    await activate(controlUri);
+    const diagnostics = await waitForDiagnostics(controlUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "TK1001"),
+    });
+    assert.ok(
+      linesWithCode(diagnostics, "TK1001").length > 0,
+      `Mixing pack and grid in one interpreter is still a conflict: ${diagnostics
+        .map((d) => `${codeOf(d)}@${d.range.start.line}`)
+        .join(", ")}`,
+    );
+    assert.ok(
+      linesWithCode(diagnostics, "TK1002").includes(15),
+      `'.missing.child' still has no parent: ${linesWithCode(diagnostics, "TK1002")}`,
+    );
+  });
+});

--- a/editors/vscode/src/test/uplevelIndirectSet.test.ts
+++ b/editors/vscode/src/test/uplevelIndirectSet.test.ts
@@ -1,0 +1,86 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { getDocUri, activate, waitForDiagnostics } from "./helper";
+
+// Caller-frame injection via `uplevel`, end to end in the editor
+// (issue #923 audit idx 24 and idx 38).
+//
+// uplevelIndirectSet.tcl prints `99`, `99`, `1 1 1` under tclsh 9.0.4 and
+// 8.6.16, so every variable it reads really is assigned first, and every
+// `$varName` in a `[list set …]` is the idiom rather than a name/value
+// confusion.  It carries one deliberate W214 marker so an empty
+// W210/W212 set cannot be mistaken for "analysis has not run yet".
+//
+// uplevelIndirectSetControl.tcl strips the frame-crossing part out, at which
+// point the same read genuinely fails (`can't read "answer": no such
+// variable`) and the `set $var` really is written by hand — so a suppression
+// that had gone too far shows up there as a *missing* diagnostic.
+
+/** The `code` string of a diagnostic, whatever shape VS Code hands us. */
+function codeOf(d: vscode.Diagnostic): string | undefined {
+  const code = typeof d.code === "object" && d.code !== null ? d.code.value : d.code;
+  return code === undefined ? undefined : String(code);
+}
+
+suite("Uplevel Indirect Assignment (W210 / W212)", () => {
+  const docUri = getDocUri("uplevelIndirectSet.tcl");
+  const controlUri = getDocUri("uplevelIndirectSetControl.tcl");
+
+  test("no W210 or W212 on any uplevel-injected assignment", async () => {
+    await activate(docUri);
+    // W214 on the marker proc is the signal that a full analysis ran.
+    const diagnostics = await waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "W214"),
+    });
+    const offenders = diagnostics
+      .filter((d) => codeOf(d) === "W210" || codeOf(d) === "W212")
+      .map((d) => `${codeOf(d)}@${d.range.start.line}: ${d.message}`);
+    assert.deepStrictEqual(
+      offenders,
+      [],
+      "uplevel-injected assignments are real assignments and their list-built " +
+        "name words are the idiom, so neither code may fire",
+    );
+  });
+
+  test("W210 and W212 still fire when nothing reaches an outer frame", async () => {
+    await activate(controlUri);
+    const diagnostics = await waitForDiagnostics(controlUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "W210"),
+    });
+
+    const w210Lines = diagnostics
+      .filter((d) => codeOf(d) === "W210")
+      .map((d) => d.range.start.line);
+    assert.ok(
+      w210Lines.includes(11),
+      `W210 belongs on the 'return $answer' read (line 11), got ${w210Lines.join(", ")}`,
+    );
+
+    const w212Lines = diagnostics
+      .filter((d) => codeOf(d) === "W212")
+      .map((d) => d.range.start.line);
+    assert.ok(
+      w212Lines.includes(7),
+      `W212 belongs on the written 'set $var' (line 7), got ${w212Lines.join(", ")}`,
+    );
+  });
+});

--- a/editors/vscode/testFixture/commandAliasTracking.tcl
+++ b/editors/vscode/testFixture/commandAliasTracking.tcl
@@ -1,0 +1,25 @@
+# `interp alias` COMMAND aliasing (issue #923 audit idx 21 / idx 89).
+#
+# Verified on tclsh 9.0.4 and 8.6.16, byte-identical:
+#   * both `[sayHi]` calls print `hi` — they really run `greet`'s body;
+#   * `::ttk::spinbox .sb` prints `classic tk::spinbox: .sb`, so the
+#     `::ttk::spinbox` proc declared on line 17 is dead from line 23 onward.
+#
+# Line numbers are load-bearing for commandAliasTracking.test.ts.
+proc greet {} {
+    return hi
+}
+interp alias {} sayHi {} greet
+puts [sayHi]
+puts [sayHi]
+
+namespace eval ::ttk {}
+namespace eval ::tk {}
+proc ::ttk::spinbox {w args} {
+    puts "themed ttk::spinbox: $w $args"
+}
+proc ::tk::spinbox {w args} {
+    puts "classic tk::spinbox: $w $args"
+}
+interp alias {} ::ttk::spinbox {} ::tk::spinbox
+::ttk::spinbox .sb

--- a/editors/vscode/testFixture/diagnostics-rename-nonexistent.tcl
+++ b/editors/vscode/testFixture/diagnostics-rename-nonexistent.tcl
@@ -1,0 +1,13 @@
+# `rename OLD NEW` requires OLD to exist (issue #923 audit idx 5).
+#
+# tclsh 9.0.4 and 8.6.16 both abort this file at line 8 with
+#   can't rename "definitelyNotDefinedAnywhere": command doesn't exist
+# and, with that line removed, at line 9 with
+#   can't delete "totallyBogusCommand": command doesn't exist
+#
+# Line numbers are load-bearing for diagnostics.test.ts.
+rename definitelyNotDefinedAnywhere someAlias
+rename totallyBogusCommand {}
+
+proc greet {} { return hi }
+rename greet hail

--- a/editors/vscode/testFixture/nestedSelfRedefinition.tcl
+++ b/editors/vscode/testFixture/nestedSelfRedefinition.tcl
@@ -1,0 +1,24 @@
+# A nested, cross-namespace proc self-redefinition (issue #923 audit idx 45).
+#
+# The real corpus shape is nico-robert/ticklecharts: a qualified
+# `proc ticklecharts::activate` whose body declares an unqualified
+# `proc activate`, redefining the SAME command in the enclosing namespace.
+#
+# tclsh 9.0.4 and 8.6.16 agree byte-for-byte: the two calls print
+#   activating for the first time
+#   already activated
+# and afterwards `info commands ::activate` is empty while
+# `info commands ::ticklecharts::activate` reports the command — so both
+# `proc` headers below declare one and the same command, and a reference
+# query from either must answer with the same call sites.
+#
+# Line numbers are load-bearing for nestedSelfRedefinition.test.ts.
+namespace eval ticklecharts {}
+proc ticklecharts::activate {bool} {
+    if {$bool} {
+        proc activate {bool} {puts "already activated"}
+        puts "activating for the first time"
+    }
+}
+ticklecharts::activate 1
+ticklecharts::activate 1

--- a/editors/vscode/testFixture/tkChildInterp.tcl
+++ b/editors/vscode/testFixture/tkChildInterp.tcl
@@ -1,0 +1,23 @@
+# tcl-dialect: tcl8.6
+# Tk widget checks are per-interpreter (issue #923 audit idx 91).
+#
+# `interp create child` gives the child its own command table and its own
+# widget hierarchy, so a `.top` created inside `child eval { … }` is a
+# different, unrelated widget from the parent's `.top`.  Verified against
+# tclsh 9.0.4 and 8.6.16: a command created inside `child eval` is absent
+# from the parent's `info commands`, and vice versa.
+#
+# Two claims, one file:
+#   * line 19 packs `.top.a` in the CHILD and line 21 grids `.top.b` in the
+#     PARENT.  Two interpreters, two hierarchies — no TK1001 conflict.
+#   * line 22's `.childOnly.deep` names a widget whose parent `.childOnly`
+#     is never created anywhere — TK1002 must fire on it.
+#
+# Line numbers are load-bearing for tkChildInterp.test.ts.
+package require Tk
+interp create child
+load {} Tk child
+child eval { frame .top; pack .top.a }
+frame .top
+grid .top.b
+frame .childOnly.deep

--- a/editors/vscode/testFixture/tkChildInterpControl.tcl
+++ b/editors/vscode/testFixture/tkChildInterpControl.tcl
@@ -1,0 +1,16 @@
+# tcl-dialect: tcl8.6
+# TRUE-POSITIVE controls for tkChildInterp.tcl (issue #923 audit idx 91):
+# the per-interpreter keying narrows the Tk checks, it does not disable
+# them.
+#
+#   * lines 13-14 pack and grid siblings of the SAME `.top`, both in the
+#     parent interpreter — TK1001 must fire.
+#   * line 15's `.missing.child` has a parent nothing ever created — TK1002
+#     must fire.
+#
+# Line numbers are load-bearing for tkChildInterp.test.ts.
+package require Tk
+frame .top
+pack .top.a
+grid .top.b
+frame .missing.child

--- a/editors/vscode/testFixture/uplevelIndirectSet.tcl
+++ b/editors/vscode/testFixture/uplevelIndirectSet.tcl
@@ -1,0 +1,47 @@
+# Caller-frame injection via `uplevel` (issue #923 audit idx 24 / idx 38).
+#
+# Verified on tclsh 9.0.4 and 8.6.16, byte-identical — the file prints
+#   99
+#   99
+#   1 1 1
+# so every variable read below really is assigned before it is read, and
+# every `$varName` in a `[list set ...]` is the idiom rather than a
+# name/value confusion.  No W210 and no W212 may be reported anywhere.
+proc setInCaller {var} {
+    uplevel 1 [list set $var 99]
+}
+proc useIt {} {
+    setInCaller answer
+    return $answer
+}
+puts [useIt]
+
+proc setUp2 {var} {
+    uplevel 2 [list set $var 99]
+}
+proc middle {} {
+    setUp2 deepAnswer
+}
+proc outer {} {
+    middle
+    return $deepAnswer
+}
+puts [outer]
+
+proc NewArrays {varNames value} {
+    foreach varName $varNames {
+        uplevel 1 [list set $varName $value]
+    }
+}
+proc Qfrac2 {} {
+    NewArrays {rdiagArray acnormArray waArray} 1
+    return [list $rdiagArray $acnormArray $waArray]
+}
+puts [Qfrac2]
+
+# Marker: an unused parameter draws W214, unrelated to W210/W212.  The test
+# waits for it so "no W210/W212" cannot pass merely because analysis had not
+# finished yet.
+proc analysisRanMarker {unusedParam} {
+    return done
+}

--- a/editors/vscode/testFixture/uplevelIndirectSetControl.tcl
+++ b/editors/vscode/testFixture/uplevelIndirectSetControl.tcl
@@ -1,8 +1,8 @@
 # TRUE-POSITIVE control for uplevelIndirectSet.tcl (issue #923 audit idx 24).
 #
-# Nothing here reaches an outer frame, so tclsh 9.0.4 / 8.6.16 both abort:
-#   can't read "answer": no such variable
-# and the directly-written `set $var` on line 7 is exactly the name/value
+# Nothing reaches an outer frame, so `source`ing this and calling `useIt`
+# aborts on tclsh 9.0.4 and 8.6.16 alike: can't read "answer": no such
+# variable.  The directly-written `set $var` below is exactly the name/value
 # confusion W212 exists for.  W210 must fire on line 11, W212 on line 7.
 proc setLocally {var} {
     set $var 99

--- a/editors/vscode/testFixture/uplevelIndirectSetControl.tcl
+++ b/editors/vscode/testFixture/uplevelIndirectSetControl.tcl
@@ -1,0 +1,13 @@
+# TRUE-POSITIVE control for uplevelIndirectSet.tcl (issue #923 audit idx 24).
+#
+# Nothing here reaches an outer frame, so tclsh 9.0.4 / 8.6.16 both abort:
+#   can't read "answer": no such variable
+# and the directly-written `set $var` on line 7 is exactly the name/value
+# confusion W212 exists for.  W210 must fire on line 11, W212 on line 7.
+proc setLocally {var} {
+    set $var 99
+}
+proc useIt {} {
+    setLocally answer
+    return $answer
+}

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -84,6 +84,12 @@ struct DispatchSite<'a> {
     arg_expand_in: &'a [bool],
     cmd_tok: Token,
     scope_path: &'a [usize],
+    /// This command's words are pre-substituted `list` elements — see
+    /// [`super::state::AnalyserState::presubstituted_args`].  A `$word` here
+    /// was replaced by its value while the *building* frame ran, before the
+    /// script existed, so it is not the written-source shape any
+    /// substitution-vs-literal check is about.
+    presubstituted_args: bool,
 }
 
 /// One resolved analyser-hook dispatch: the hook the head resolved to, plus
@@ -930,6 +936,7 @@ impl Analyser {
                 arg_expand_in,
                 cmd_tok,
                 scope_path,
+                presubstituted_args,
             });
         } // end `if !self.structure_only`
 
@@ -1435,6 +1442,7 @@ impl Analyser {
             arg_expand_in,
             cmd_tok,
             scope_path,
+            presubstituted_args,
         } = *site;
         // W302 dispatches off the registry's own `AnalyserHookId::Catch`
         // stamp rather than the literal head text, so any spelling the
@@ -1509,7 +1517,19 @@ impl Analyser {
         // TK1001 / TK1002 / TK1003 — Tk-dialect widget + geometry checks
         // (tk dialect only); the TK1001 conflict is flushed post-walk.
         self.emit_tk_checks(cmd_name, args, arg_tokens, cmd_tok);
-        self.emit_w212_name_vs_value(cmd_name, args, arg_tokens, scope_path);
+        // W212 asks whether a *written* variable-name word was spelled as a
+        // `$` substitution by mistake.  In a `list`-built script that
+        // question does not arise: `uplevel 1 [list set $var 99]` substitutes
+        // `$var` in the building frame, so the script `uplevel` finally runs
+        // already carries the literal name the user meant, and the
+        // substitution is the whole point of the idiom (tclsh 9.0.4 / 8.6.16:
+        // `proc setInCaller {var} {uplevel 1 [list set $var 99]}` /
+        // `proc useIt {} {setInCaller answer; return $answer}` prints `99`).
+        // Only the directly-written spelling (`set $var 99`) is the
+        // name/value confusion the code is about (issue #923 idx 24).
+        if !presubstituted_args {
+            self.emit_w212_name_vs_value(cmd_name, args, arg_tokens, scope_path);
+        }
         self.emit_w104_append_list(cmd_name, args, arg_tokens, arg_expand_in, cmd_tok);
         self.emit_w106_unbraced_switch_body(cmd_name, args, arg_tokens);
         self.emit_w311_encoding_mismatch(cmd_name, args, arg_tokens);
@@ -2846,6 +2866,12 @@ impl Analyser {
             arg_expand_in: arg_expand,
             cmd_tok,
             scope_path,
+            // A command written inside a `[…]` substitution is written
+            // source, with its own words: `$x` here really is a substitution
+            // the author typed. (The list-built path never reaches this
+            // walker — `process_command` skips the nested-substitution scan
+            // entirely when its words are pre-substituted.)
+            presubstituted_args: false,
         });
         self.dispatch_expr_arguments(&cmd_name, args, arg_tokens, cmd_tok);
         // W216 (broken brace-form array access, `${arr}(idx)` / `${arr($i)}`)

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -1433,6 +1433,29 @@ impl Analyser {
     ///   post-walk by [`Self::flush_arity_diagnostics`].
     /// - **W143** (direct call into a private `::tcl::` implementation
     ///   namespace) — dialect-independent, registry-driven.
+    /// The script-injection family — a script or command line built by
+    /// concatenating substituted words, which the interpreter then re-parses.
+    ///
+    /// Grouped out of [`Self::emit_dispatch_site_diagnostics`] because they
+    /// are one subject with one shared argument shape, and because that
+    /// dispatcher is at its line budget.
+    fn emit_injection_diagnostics(
+        &mut self,
+        cmd_name: &str,
+        args: &[String],
+        arg_tokens: &[Token],
+        arg_single: &[bool],
+    ) {
+        self.emit_w101_eval_string_concat(cmd_name, args, arg_tokens, arg_single);
+        self.emit_w102_subst_injection(cmd_name, args, arg_tokens);
+        self.emit_w103_open_pipeline(cmd_name, args, arg_tokens, arg_single);
+        self.emit_w300_source_variable(cmd_name, args, arg_tokens);
+        self.emit_w309_eval_subst_double_decode(cmd_name, args, arg_tokens);
+        self.emit_w301_uplevel_injection(cmd_name, args, arg_tokens, arg_single);
+        self.emit_w312_interp_eval_injection(cmd_name, args, arg_tokens, arg_single);
+        self.emit_w303_redos(cmd_name, args, arg_tokens);
+    }
+
     fn emit_dispatch_site_diagnostics(&mut self, site: &DispatchSite<'_>) {
         let DispatchSite {
             cmd_name,
@@ -1488,16 +1511,7 @@ impl Analyser {
         {
             self.emit_w142_context_gate(gate, args, cmd_tok);
         }
-        self.emit_w101_eval_string_concat(cmd_name, args, arg_tokens, arg_single);
-        // W102 / W103 / W300 / W301 / W309 / W312 security-injection
-        // checks.
-        self.emit_w102_subst_injection(cmd_name, args, arg_tokens);
-        self.emit_w103_open_pipeline(cmd_name, args, arg_tokens, arg_single);
-        self.emit_w300_source_variable(cmd_name, args, arg_tokens);
-        self.emit_w309_eval_subst_double_decode(cmd_name, args, arg_tokens);
-        self.emit_w301_uplevel_injection(cmd_name, args, arg_tokens, arg_single);
-        self.emit_w312_interp_eval_injection(cmd_name, args, arg_tokens, arg_single);
-        self.emit_w303_redos(cmd_name, args, arg_tokens);
+        self.emit_injection_diagnostics(cmd_name, args, arg_tokens, arg_single);
         self.emit_w306_literal_expected(cmd_name, args, arg_tokens);
         // W310 runs for every command (it scans args for credential
         // option flags), so it takes no cmd_name guard.

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -1410,29 +1410,6 @@ impl Analyser {
         }
     }
 
-    /// Dispatch-site diagnostic emitters, run from
-    /// [`Self::process_command`] before the early-returning handlers so
-    /// option-bearing / body-owning commands still get checked.
-    ///
-    /// - **W302** (`catch` without a result variable) — fires before
-    ///   the early-returning `handle_catch_command`.
-    /// - **W001** (unknown subcommand on a `SubcommandSig` command) —
-    ///   before `handle_namespace_eval_command` so `namespace foo` is
-    ///   flagged.
-    /// - **E004** (malformed `if`) — dispatched generically off the
-    ///   resolved spec's `clause_shape_check` hook, not off `cmd_name`,
-    ///   so `if` is the trigger today only because it is the one
-    ///   command carrying that hook.
-    /// - **W101** (`eval` with substituted args) — before body-walk
-    ///   dispatch so the `ArgRole::Body` recursion into the `eval`
-    ///   body still runs.
-    /// - **W304** (missing `--` option terminator) — driven by the
-    ///   registry's option-terminator profile.
-    /// - **W004** (option not available in the active dialect).
-    /// - **E002 / E003** (arity) — collected here and flushed
-    ///   post-walk by [`Self::flush_arity_diagnostics`].
-    /// - **W143** (direct call into a private `::tcl::` implementation
-    ///   namespace) — dialect-independent, registry-driven.
     /// The script-injection family — a script or command line built by
     /// concatenating substituted words, which the interpreter then re-parses.
     ///
@@ -1456,6 +1433,29 @@ impl Analyser {
         self.emit_w303_redos(cmd_name, args, arg_tokens);
     }
 
+    /// Dispatch-site diagnostic emitters, run from
+    /// [`Self::process_command`] before the early-returning handlers so
+    /// option-bearing / body-owning commands still get checked.
+    ///
+    /// - **W302** (`catch` without a result variable) — fires before
+    ///   the early-returning `handle_catch_command`.
+    /// - **W001** (unknown subcommand on a `SubcommandSig` command) —
+    ///   before `handle_namespace_eval_command` so `namespace foo` is
+    ///   flagged.
+    /// - **E004** (malformed `if`) — dispatched generically off the
+    ///   resolved spec's `clause_shape_check` hook, not off `cmd_name`,
+    ///   so `if` is the trigger today only because it is the one
+    ///   command carrying that hook.
+    /// - **W101** (`eval` with substituted args) — before body-walk
+    ///   dispatch so the `ArgRole::Body` recursion into the `eval`
+    ///   body still runs.
+    /// - **W304** (missing `--` option terminator) — driven by the
+    ///   registry's option-terminator profile.
+    /// - **W004** (option not available in the active dialect).
+    /// - **E002 / E003** (arity) — collected here and flushed
+    ///   post-walk by [`Self::flush_arity_diagnostics`].
+    /// - **W143** (direct call into a private `::tcl::` implementation
+    ///   namespace) — dialect-independent, registry-driven.
     fn emit_dispatch_site_diagnostics(&mut self, site: &DispatchSite<'_>) {
         let DispatchSite {
             cmd_name,

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/rbs.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/rbs.rs
@@ -2271,3 +2271,313 @@ fn issue_1266_braced_switch_pattern_is_not_a_read() {
         codes(live, D)
     );
 }
+
+// Issue #923 audit idx 24 / issue #1019 — a variable assigned indirectly in
+// an outer frame by `uplevel`.
+//
+// Every claim below is pinned on tclsh 9.0.4 and 8.6.16, byte-identical.
+// The three scripts print `99`, so the reads are not read-before-set:
+//
+//   proc setInCaller {var} { uplevel 1 [list set $var 99] }
+//   proc setInCallerPlain {var} { uplevel 1 set $var 99 }
+//   proc setUp2 {var} { uplevel 2 [list set $var 99] }
+//
+// driven respectively by `proc useIt {} {setInCaller answer; return $answer}`,
+// the same with `setInCallerPlain`, and by the two-frame chain
+// `proc middle {} {setUp2 answer}` / `proc outer {} {middle; return $answer}`.
+
+/// FP — the one-hop list-built spelling. Already silent before idx 24's fix;
+/// pinned here because nothing else locks it in.
+#[test]
+fn idx24_uplevel_one_list_built_set_is_not_read_before_set() {
+    let src = "\
+proc setInCaller {var} {
+    uplevel 1 [list set $var 99]
+}
+proc useIt {} {
+    setInCaller answer
+    return $answer
+}
+";
+    assert!(
+        !fires(src, D, "W210"),
+        "idx 24: `uplevel 1 [list set $var …]` defines the caller's variable; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+/// FP — the one-hop word-concatenated spelling (`uplevel 1 set $var 99`),
+/// which `uplevel` joins into the same script.
+#[test]
+fn idx24_uplevel_one_concatenated_set_is_not_read_before_set() {
+    let src = "\
+proc setInCaller {var} {
+    uplevel 1 set $var 99
+}
+proc useIt {} {
+    setInCaller answer
+    return $answer
+}
+";
+    assert!(
+        !fires(src, D, "W210"),
+        "idx 24: `uplevel 1 set $var …` defines the caller's variable; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+/// FP — the multi-frame shape idx 24 was still broken on: the writing proc is
+/// reached through an *ordinary* call, and its `uplevel 2` lands in that
+/// caller's caller.
+#[test]
+fn idx24_uplevel_two_reaches_through_a_plain_call() {
+    let src = "\
+proc setUp2 {var} {
+    uplevel 2 [list set $var 99]
+}
+proc middle {} {
+    setUp2 answer
+}
+proc outer {} {
+    middle
+    return $answer
+}
+";
+    assert!(
+        !fires(src, D, "W210"),
+        "idx 24: `uplevel 2` writes the plain caller's caller; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+/// FP — the same, with a literal braced body instead of a built list. The
+/// `UpFrame` arm used to drop every level but 1 outright.
+#[test]
+fn idx24_uplevel_two_literal_body_reaches_through_a_plain_call() {
+    let src = "\
+proc setUp2 {} {
+    uplevel 2 {set answer 99}
+}
+proc middle {} {
+    setUp2
+}
+proc outer {} {
+    middle
+    return $answer
+}
+";
+    assert!(
+        !fires(src, D, "W210"),
+        "idx 24: a literal `uplevel 2` body writes the plain caller's caller; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+/// FP — a level word nothing static can place (`uplevel [expr {[info level] -
+/// $lvl}] …`, the real corpus spelling) is the same unknown-frame case.
+#[test]
+fn idx24_uplevel_with_a_computed_level_is_not_read_before_set() {
+    let src = "\
+proc setInCaller {var lvl} {
+    uplevel [expr {[info level] - $lvl}] [list set $var 99]
+}
+proc useIt {} {
+    setInCaller answer 1
+    return $answer
+}
+";
+    assert!(
+        !fires(src, D, "W210"),
+        "idx 24: a computed uplevel level cannot be placed, so widen; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+/// TP control — with the `uplevel` gone, nothing assigns the caller's
+/// variable and W210 must still fire. Without this the FP arms above would
+/// pass just as well against a W210 that had been switched off.
+#[test]
+fn idx24_tp_without_the_uplevel_the_read_is_still_unset() {
+    let src = "\
+proc setInCaller {var} {
+    set $var 99
+}
+proc useIt {} {
+    setInCaller answer
+    return $answer
+}
+";
+    assert!(
+        fires(src, D, "W210"),
+        "idx 24 TP: a callee-local `set` never reaches the caller; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+/// TP control — a **level-1** effect is not transitive through a plain call.
+/// tclsh 9.0.4 / 8.6.16: `real_worker`'s `upvar 1` reaches `wrapper`'s frame,
+/// so the outermost caller really does get `can't read "a": no such
+/// variable`. This is the guard rail that keeps the new one-hop composition
+/// from degenerating into "any caller of any frame-crossing proc is silent".
+#[test]
+fn idx24_tp_level_one_does_not_propagate_through_a_plain_call() {
+    let src = "\
+proc worker {v} {
+    upvar 1 $v x
+    set x 1
+}
+proc wrapper {v} {
+    worker $v
+}
+proc caller {} {
+    wrapper a
+    return $a
+}
+";
+    assert!(
+        fires(src, D, "W210"),
+        "idx 24 TP: a level-1 upvar stops at the wrapper's own frame; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+/// TP control — `uplevel #0` is the global frame and `uplevel 0` the callee's
+/// own, so neither reaches a caller and neither may silence the read.
+#[test]
+fn idx24_tp_global_and_own_frame_levels_do_not_silence_the_caller() {
+    for level in ["#0", "0"] {
+        let src = format!(
+            "proc setSomewhere {{var}} {{\n    uplevel {level} [list set $var 99]\n}}\n\
+             proc useIt {{}} {{\n    setSomewhere answer\n    return $answer\n}}\n"
+        );
+        assert!(
+            fires(&src, D, "W210"),
+            "idx 24 TP: `uplevel {level}` never touches the caller's frame; emitted: {:?}",
+            codes(&src, D)
+        );
+    }
+}
+
+/// FP — W212 must not read the literal word `set` inside a `[list …]`-built
+/// script as a directly-written `set $var` name/value confusion. The
+/// substitution happens in the *building* frame and is the whole idiom.
+#[test]
+fn idx24_w212_does_not_fire_on_a_list_built_variable_name_word() {
+    let src = "proc setInCaller {var} {\n    uplevel 1 [list set $var 99]\n}\n";
+    assert!(
+        !fires(src, D, "W212"),
+        "idx 24: a list-built name word is pre-substituted, not a confusion; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+/// TP control — the directly-written spelling is exactly what W212 is for,
+/// and still fires.
+#[test]
+fn idx24_tp_w212_still_fires_on_a_directly_written_name_word() {
+    for src in [
+        "proc f {var} { set $var 1 }\n",
+        "proc f {} { set counter 1\n incr $countr }\n",
+    ] {
+        assert!(
+            fires(src, D, "W212"),
+            "idx 24 TP: a written `$` in a name position is still W212; {src} emitted: {:?}",
+            codes(src, D)
+        );
+    }
+}
+
+/// TN guard rail (#1237 / #1260 family) — widening a caller's frame must not
+/// cost a variable its liveness: a store the `uplevel`-written name later
+/// feeds must not resurface as a dead store (W220) or an unused variable
+/// (W211).
+#[test]
+fn idx24_widening_keeps_the_callers_own_stores_live() {
+    let src = "\
+proc setUp2 {var} {
+    uplevel 2 [list set $var 99]
+}
+proc middle {} {
+    setUp2 answer
+}
+proc outer {} {
+    set answer 0
+    middle
+    return $answer
+}
+";
+    assert!(
+        !fires(src, D, "W220") && !fires(src, D, "W211"),
+        "idx 24: the seeded store is read after the widened call; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+/// FP — the same W212 carve-out on the canonical caller-frame-injection
+/// idiom the `tclopt` corpus is built from (issue #923 audit idx 38): a
+/// `[list set $varName $value]` built inside a `foreach`, where **both**
+/// words are substitutions.
+///
+/// Oracle (tclsh 9.0.4 and 8.6.16): the script below prints `1 1 1`, so all
+/// three names really are materialised in `Qfrac2`'s frame.
+#[test]
+fn idx38_w212_does_not_fire_on_a_list_built_set_of_a_looped_name() {
+    let src = "\
+proc NewArrays {varNames value} {
+    foreach varName $varNames {
+        uplevel 1 [list set $varName $value]
+    }
+}
+proc Qfrac2 {} {
+    NewArrays {rdiagArray acnormArray waArray} 1
+    return [list $rdiagArray $acnormArray $waArray]
+}
+";
+    assert!(
+        !fires(src, D, "W212"),
+        "idx 38: `[list set $varName $value]` is the idiom, not a confusion; emitted: {:?}",
+        codes(src, D)
+    );
+    assert!(
+        !fires(src, D, "W210"),
+        "idx 38: the three names are materialised in the caller's frame; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+/// TP control for the shape above — with the `NewArrays` call removed
+/// nothing materialises the names and all three reads are genuinely unset
+/// (tclsh: `can't read "rdiagArray": no such variable`).
+#[test]
+fn idx38_tp_without_the_injection_call_the_reads_are_unset() {
+    let src = "\
+proc Qfrac2 {} {
+    return [list $rdiagArray $acnormArray $waArray]
+}
+";
+    assert!(
+        fires(src, D, "W210"),
+        "idx 38 TP: nothing writes those names; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+/// TP control for the W212 carve-out itself, in the *same* proc shape: a
+/// `set $varName $value` written directly into the loop body — no `list`
+/// builder, no deferred script — is exactly the name/value confusion the
+/// code exists for and must still fire.
+#[test]
+fn idx38_tp_w212_still_fires_on_a_directly_written_looped_name() {
+    let src = "\
+proc NewArrays {varNames value} {
+    foreach varName $varNames {
+        set $varName $value
+    }
+}
+";
+    assert!(
+        fires(src, D, "W212"),
+        "idx 38 TP: a written `$` in a name position is still W212; emitted: {:?}",
+        codes(src, D)
+    );
+}

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -1616,6 +1616,34 @@ pub fn detect_upvar_procs(module: &Module) -> HashMap<String, UpvarInfo> {
                 info.caller_frame_opaque_reads = true;
             }
         }
+        // The second one-hop composition: an **ordinary** call to a proc that
+        // reaches past its own caller lands in *this* proc's caller (issue
+        // #1019 / issue #923 idx 24).  Oracle, identical on tclsh 9.0.4 and
+        // 8.6.16: `proc setUp2 {var} {uplevel 2 [list set $var 99]}` /
+        // `proc middle {} {setUp2 answer}` / `proc outer {} {middle; return
+        // $answer}` — `outer` returns `99`, so `answer` really is assigned in
+        // a frame `middle` never names.  A level-**1** effect is emphatically
+        // not transitive this way (`detect_upvar_procs_does_not_propagate_
+        // through_a_plain_call_wrapper` pins the tclsh transcript), which is
+        // why only `beyond_caller_frame_effects` travels here.
+        //
+        // One hop, against the own-body summaries, for the same reason the
+        // forwarded-call composition above takes exactly one: it terminates
+        // by construction on any call graph, recursive or not.  A `uplevel 3`
+        // two plain calls out is left to the opaque-widening path.
+        for callee in &own_info.plain_calls {
+            if by_name
+                .get(callee.as_str())
+                .is_some_and(|(callee_info, _)| callee_info.beyond_caller_frame_effects)
+            {
+                info.caller_frame_opaque_writes = true;
+                info.caller_frame_opaque_reads = true;
+            }
+        }
+        // Composition input, not a caller-side effect — dropped so the
+        // published summaries (which are folded into every procedure's
+        // `function_lattice` memo key) carry only what a call site reads.
+        info.plain_calls.clear();
         composed.push((qname, info));
     }
 

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -41,7 +41,7 @@ use crate::ir_helpers::defs_from_ir_script;
 use crate::naming::normalise_var_name;
 
 use self::global_write_info::GlobalWriteInfo;
-use self::upvar_info::{UpvarInfo, collect_upvar_targets};
+use self::upvar_info::{FrameReach, UpvarInfo, collect_upvar_targets};
 
 /// Choose the [`CommandTokens`] for a "frozen" `while`/`for` runtime call.
 ///
@@ -1625,7 +1625,7 @@ pub fn detect_upvar_procs(module: &Module) -> HashMap<String, UpvarInfo> {
         // a frame `middle` never names.  A level-**1** effect is emphatically
         // not transitive this way (`detect_upvar_procs_does_not_propagate_
         // through_a_plain_call_wrapper` pins the tclsh transcript), which is
-        // why only `beyond_caller_frame_effects` travels here.
+        // why only a `FrameReach::PastTheCaller` summary travels here.
         //
         // One hop, against the own-body summaries, for the same reason the
         // forwarded-call composition above takes exactly one: it terminates
@@ -1634,7 +1634,9 @@ pub fn detect_upvar_procs(module: &Module) -> HashMap<String, UpvarInfo> {
         for callee in &own_info.plain_calls {
             if by_name
                 .get(callee.as_str())
-                .is_some_and(|(callee_info, _)| callee_info.beyond_caller_frame_effects)
+                .is_some_and(|(callee_info, _)| {
+                    callee_info.frame_reach == FrameReach::PastTheCaller
+                })
             {
                 info.caller_frame_opaque_writes = true;
                 info.caller_frame_opaque_reads = true;

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -2894,6 +2894,72 @@ mod tests {
         );
     }
 
+    /// Issue #1019 / issue #923 audit idx 24: the *other* half of the rule
+    /// the two tests above pin. A level-**1** effect stops at the wrapper's
+    /// own frame, but a level that lands past the callee's caller reaches
+    /// this proc's caller through an ordinary call, so the wrapper really
+    /// does become a caller-frame writer.
+    ///
+    /// Oracle, byte-identical on tclsh 9.0.4 and 8.6.16:
+    ///
+    /// ```tcl
+    /// proc setUp2 {var} { uplevel 2 [list set $var 99] }
+    /// proc middle {}    { setUp2 answer }
+    /// proc outer  {}    { middle ; return $answer }
+    /// puts [outer]        ;# -> 99
+    /// ```
+    #[test]
+    fn detect_upvar_procs_propagates_a_beyond_caller_effect_one_plain_hop() {
+        let module = lower_module(
+            "proc setUp2 {var} {\n             uplevel 2 [list set $var 99]\n             }\n             proc middle {} {\n             setUp2 answer\n             }",
+        );
+        let upvar_procs = detect_upvar_procs(&module);
+        let middle = upvar_procs
+            .get("middle")
+            .expect("a plain call to a beyond-caller writer registers the wrapper");
+        assert!(
+            middle.caller_frame_opaque_writes,
+            "setUp2's `uplevel 2` lands in middle's caller: {middle:?}"
+        );
+        assert!(
+            middle.caller_frame_opaque_reads,
+            "the same script may read there too: {middle:?}"
+        );
+    }
+
+    /// TN — `uplevel #0` (global) and `uplevel 0` (the callee's own frame)
+    /// reach no caller at all, so neither is a beyond-caller effect and
+    /// neither makes a plain-call wrapper one.
+    #[test]
+    fn detect_upvar_procs_does_not_propagate_a_global_or_own_frame_level() {
+        for level in ["#0", "0"] {
+            let module = lower_module(&format!(
+                "proc setSomewhere {{var}} {{\n                 uplevel {level} [list set $var 99]\n                 }}\n                 proc wrapper {{}} {{\n                 setSomewhere answer\n                 }}"
+            ));
+            let upvar_procs = detect_upvar_procs(&module);
+            assert!(
+                !upvar_procs.contains_key("wrapper"),
+                "`uplevel {level}` never touches a caller frame: {upvar_procs:?}"
+            );
+        }
+    }
+
+    /// The published summaries carry no composition bookkeeping — they are
+    /// folded into every procedure's `function_lattice` memo key, so only
+    /// what a call site actually reads may travel in them.
+    #[test]
+    fn detect_upvar_procs_publishes_no_plain_call_bookkeeping() {
+        let module = lower_module(
+            "proc setUp2 {var} {\n             uplevel 2 [list set $var 99]\n             }\n             proc middle {} {\n             setUp2 answer\n             }",
+        );
+        for (name, info) in detect_upvar_procs(&module) {
+            assert!(
+                info.plain_calls.is_empty(),
+                "{name} published composition input: {info:?}"
+            );
+        }
+    }
+
     #[test]
     fn prepare_cfg_context_registers_params_for_all_procs() {
         let module = lower_module("proc ::ns::p {a b} { upvar 1 $a x }\nproc q {c} {}");

--- a/rust/tcl-compiler/src/cfg_builder/upvar_info.rs
+++ b/rust/tcl-compiler/src/cfg_builder/upvar_info.rs
@@ -519,7 +519,8 @@ fn walk_stmt(
             ..
         } => match (*absolute, *frame_shift) {
             (false, 1) => record_upframe_body(body, info),
-            (true, 0) | (false, 0) => {}
+            // `uplevel #0` is the global frame, `uplevel 0` the callee's own.
+            (true | false, 0) => {}
             _ => widen_beyond_caller(info),
         },
         Statement::If {

--- a/rust/tcl-compiler/src/cfg_builder/upvar_info.rs
+++ b/rust/tcl-compiler/src/cfg_builder/upvar_info.rs
@@ -177,6 +177,39 @@ pub struct UpvarInfo {
     /// covers, so `detect_upvar_procs` registers the proc and its call
     /// sites widen.
     pub unnameable_local_aliases: BTreeSet<String>,
+    /// The proc reaches a frame **further out than its own caller** — an
+    /// `upvar 2` / `uplevel 2` / `uplevel #3`, or a level word this analysis
+    /// cannot place (`uplevel [expr {[info level] - $n}] …`).
+    ///
+    /// Distinct from [`Self::caller_frame_opaque_writes`], which is only ever
+    /// about the direct caller: a write two frames out lands in the frame of
+    /// whoever called *this proc's caller*, so it travels one hop further
+    /// along an **ordinary** call than a level-1 effect does.
+    /// [`super::detect_upvar_procs`] composes that hop; without it a
+    /// three-frame chain reads as a plain call chain and the outermost frame
+    /// draws a false `W210` on a variable that really is assigned.
+    ///
+    /// Oracle (tclsh 9.0.4 and 8.6.16, identical): with
+    /// `proc setUp2 {var} {uplevel 2 [list set $var 99]}`,
+    /// `proc middle {} {setUp2 answer}` and
+    /// `proc outer {} {middle; return $answer}`, `outer` returns `99` —
+    /// `answer` is genuinely set in `outer`'s frame by a proc `outer` never
+    /// calls directly. The level-1 spelling behaves the opposite way and is
+    /// pinned by `detect_upvar_procs_does_not_propagate_through_a_plain_call_wrapper`.
+    ///
+    /// Not part of [`Self::is_empty`]'s summary contract on its own: every
+    /// site that sets it also sets [`Self::caller_frame_opaque_writes`],
+    /// which `is_empty` already covers.
+    pub beyond_caller_frame_effects: bool,
+    /// Command names this proc invokes as **ordinary** calls (not through
+    /// `uplevel`), in body order and deduplicated.
+    ///
+    /// Only [`super::detect_upvar_procs`]'s one-hop composition reads it, to
+    /// find the callees whose [`Self::beyond_caller_frame_effects`] land in
+    /// this proc's caller. Like [`Self::unnameable_local_aliases`] it is
+    /// structural bookkeeping, not a caller-side effect, so it stays out of
+    /// [`Self::is_empty`].
+    pub plain_calls: BTreeSet<String>,
 }
 
 impl UpvarInfo {
@@ -452,6 +485,12 @@ fn walk_stmt(
     match stmt {
         Statement::Call { command, args, .. } | Statement::Barrier { command, args, .. } => {
             let Some(spec) = registry.frame_effect(command) else {
+                // An ordinary call. It shares values, not frames, so it
+                // contributes no caller-frame effect of its own — but a
+                // callee that reaches *past* its own caller reaches this
+                // proc's caller through it, which `detect_upvar_procs`
+                // composes one hop later.
+                info.plain_calls.insert(command.clone());
                 return;
             };
             match spec.layout {
@@ -469,17 +508,20 @@ fn walk_stmt(
         // `uplevel <level> {literal body}` — the lowering already proved the
         // body readable and inlined it here. Its writes land in the frame
         // `frame_shift`/`absolute` select, so only the caller-frame form
-        // contributes; every other level is a different frame.
+        // contributes directly; `#0` / `0` miss the caller entirely, and a
+        // deeper level lands past it (recorded so the one-hop composition in
+        // `detect_upvar_procs` can carry it out to the frame it really
+        // reaches).
         Statement::UpFrame {
             frame_shift,
             absolute,
             body,
             ..
-        } => {
-            if !*absolute && *frame_shift == 1 {
-                record_upframe_body(body, info);
-            }
-        }
+        } => match (*absolute, *frame_shift) {
+            (false, 1) => record_upframe_body(body, info),
+            (true, 0) | (false, 0) => {}
+            _ => widen_beyond_caller(info),
+        },
         Statement::If {
             clauses, else_body, ..
         } => {
@@ -531,6 +573,20 @@ fn walk_stmt(
     }
 }
 
+/// Record a frame effect that lands **past** the direct caller — an
+/// `upvar 2` / `uplevel 2` / `uplevel #3`, or a level word nothing static can
+/// place.
+///
+/// Two facts, not one. The caller-frame widening is what today's call-site
+/// resolution consumes (a write it cannot enumerate must not be trusted as
+/// absent), and the beyond-caller flag is what lets
+/// [`super::detect_upvar_procs`] carry the effect one hop further out along
+/// an ordinary call — the frame it actually reaches.
+fn widen_beyond_caller(info: &mut UpvarInfo) {
+    info.caller_frame_opaque_writes = true;
+    info.beyond_caller_frame_effects = true;
+}
+
 /// `upvar ?level? otherVar myVar …` — classify each pair against the frame
 /// the level word selects.
 fn record_upvar_call(
@@ -549,7 +605,7 @@ fn record_upvar_call(
         // dropping it would leave that write invisible where it lands, so
         // widen. See the module doc's frame table.
         if !level.is_global_frame() && !level.is_current_frame() {
-            info.caller_frame_opaque_writes = true;
+            widen_beyond_caller(info);
         }
         return;
     }
@@ -643,7 +699,7 @@ fn record_uplevel_call(
         // neither touches the caller; any other level does, somewhere this
         // summary cannot name.
         if !level.is_global_frame() && !level.is_current_frame() {
-            info.caller_frame_opaque_writes = true;
+            widen_beyond_caller(info);
             info.caller_frame_opaque_reads = true;
         }
         return;

--- a/rust/tcl-compiler/src/cfg_builder/upvar_info.rs
+++ b/rust/tcl-compiler/src/cfg_builder/upvar_info.rs
@@ -177,39 +177,53 @@ pub struct UpvarInfo {
     /// covers, so `detect_upvar_procs` registers the proc and its call
     /// sites widen.
     pub unnameable_local_aliases: BTreeSet<String>,
-    /// The proc reaches a frame **further out than its own caller** — an
-    /// `upvar 2` / `uplevel 2` / `uplevel #3`, or a level word this analysis
-    /// cannot place (`uplevel [expr {[info level] - $n}] …`).
-    ///
-    /// Distinct from [`Self::caller_frame_opaque_writes`], which is only ever
-    /// about the direct caller: a write two frames out lands in the frame of
-    /// whoever called *this proc's caller*, so it travels one hop further
-    /// along an **ordinary** call than a level-1 effect does.
-    /// [`super::detect_upvar_procs`] composes that hop; without it a
-    /// three-frame chain reads as a plain call chain and the outermost frame
-    /// draws a false `W210` on a variable that really is assigned.
-    ///
-    /// Oracle (tclsh 9.0.4 and 8.6.16, identical): with
-    /// `proc setUp2 {var} {uplevel 2 [list set $var 99]}`,
-    /// `proc middle {} {setUp2 answer}` and
-    /// `proc outer {} {middle; return $answer}`, `outer` returns `99` —
-    /// `answer` is genuinely set in `outer`'s frame by a proc `outer` never
-    /// calls directly. The level-1 spelling behaves the opposite way and is
-    /// pinned by `detect_upvar_procs_does_not_propagate_through_a_plain_call_wrapper`.
+    /// How far out of this proc's own frame its frame effects reach — see
+    /// [`FrameReach`].
     ///
     /// Not part of [`Self::is_empty`]'s summary contract on its own: every
-    /// site that sets it also sets [`Self::caller_frame_opaque_writes`],
-    /// which `is_empty` already covers.
-    pub beyond_caller_frame_effects: bool,
+    /// site that sets it past the caller also sets
+    /// [`Self::caller_frame_opaque_writes`], which `is_empty` already covers.
+    pub frame_reach: FrameReach,
     /// Command names this proc invokes as **ordinary** calls (not through
     /// `uplevel`), in body order and deduplicated.
     ///
     /// Only [`super::detect_upvar_procs`]'s one-hop composition reads it, to
-    /// find the callees whose [`Self::beyond_caller_frame_effects`] land in
+    /// find the callees whose [`FrameReach::PastTheCaller`] effects land in
     /// this proc's caller. Like [`Self::unnameable_local_aliases`] it is
     /// structural bookkeeping, not a caller-side effect, so it stays out of
     /// [`Self::is_empty`].
     pub plain_calls: BTreeSet<String>,
+}
+
+/// How far out of a procedure's own frame its `upvar` / `uplevel` effects
+/// reach, as far as the summary can tell.
+///
+/// A **level-1** effect (`upvar 1`, `uplevel 1`) writes the direct caller's
+/// frame and stops there: it is emphatically not transitive through an
+/// ordinary call, because the callee's caller *is* the wrapper
+/// (`detect_upvar_procs_does_not_propagate_through_a_plain_call_wrapper`
+/// pins the tclsh transcript). A level that lands **past** the direct caller
+/// travels one hop further along an ordinary call, and
+/// [`super::detect_upvar_procs`] composes that hop; without it a three-frame
+/// chain reads as a plain call chain and the outermost frame draws a false
+/// `W210` on a variable that really is assigned.
+///
+/// Oracle (tclsh 9.0.4 and 8.6.16, identical): with
+/// `proc setUp2 {var} {uplevel 2 [list set $var 99]}`,
+/// `proc middle {} {setUp2 answer}` and
+/// `proc outer {} {middle; return $answer}`, `outer` returns `99` — `answer`
+/// is genuinely set in `outer`'s frame by a proc `outer` never calls
+/// directly.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum FrameReach {
+    /// Nothing lands further out than the direct caller, so the summary's
+    /// other fields describe the whole effect.
+    #[default]
+    NoFurtherThanTheCaller,
+    /// At least one effect lands past the direct caller — an `upvar 2` /
+    /// `uplevel 2` / `uplevel #3`, or a level word nothing static can place
+    /// (`uplevel [expr {[info level] - $n}] …`).
+    PastTheCaller,
 }
 
 impl UpvarInfo {
@@ -585,7 +599,7 @@ fn walk_stmt(
 /// an ordinary call — the frame it actually reaches.
 fn widen_beyond_caller(info: &mut UpvarInfo) {
     info.caller_frame_opaque_writes = true;
-    info.beyond_caller_frame_effects = true;
+    info.frame_reach = FrameReach::PastTheCaller;
 }
 
 /// `upvar ?level? otherVar myVar …` — classify each pair against the frame

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -473,7 +473,78 @@ pub(crate) fn invocation_references_named(
     false
 }
 
+/// Whether the definition declared at `decl_off` under the name
+/// `def_qualified` has been **displaced from that name** by a `rename` /
+/// `interp alias` by the time the call at `call_off` runs — so a call
+/// spelling that name does not reach this definition at all.
+///
+/// The mirror of the forward hop go-to-definition takes
+/// (`definition::indirect_definition_target`): that one asks "where
+/// does this call site really land?", this one asks "is *this* declaration
+/// still what the name holds?". Both read the one indirection walk, so the
+/// two directions of navigation cannot disagree about the same document
+/// (issue #923 idx 89).
+///
+/// Oracle (tclsh 8.6.16 and 9.0.4, byte-identical):
+///
+/// ```tcl
+/// proc ::ttk::spinbox {w args} { puts "themed ttk::spinbox: $w $args" }
+/// proc ::tk::spinbox  {w args} { puts "classic tk::spinbox: $w $args" }
+/// interp alias {} ::ttk::spinbox {} ::tk::spinbox
+/// ::ttk::spinbox .sb          ;# -> classic tk::spinbox: .sb
+/// ```
+///
+/// The `::ttk::spinbox` proc body is unreachable under that name from the
+/// alias onward, so the call is not one of its references — and renaming it
+/// must not rewrite that word. Rewriting it (which is what the edit set did
+/// before this gate) turns the same script into `themed ttk::spinbox: .sb`:
+/// a rename that silently changes which body runs.
+///
+/// # Two ordering facts, both required
+///
+/// 1. **The binding must outrank the declaration.** A `proc` written *after*
+///    an `interp alias` on the same name replaces the alias — oracle:
+///    `interp alias {} greet {} target` then `proc greet {…}` then `greet`
+///    prints `greet body`, not `target body`. So a binding established
+///    before `decl_off` displaces nothing.
+/// 2. **The binding must be unconditional at the call.** A mutation written
+///    at top level has certainly run by the time anything else does; one
+///    written inside the *same* body as the call is in genuine statement
+///    order. A mutation sitting in some *other* proc's body only runs if
+///    that proc is ever called, which is not statically decidable — there
+///    the call site may still reach this declaration, so it stays in the
+///    reference set (and so in the rename edit set) rather than being
+///    silently dropped from an edit the user cannot inspect.
+#[must_use]
+fn definition_displaced_from_its_name(
+    analysis: &AnalysisResult,
+    def_qualified: &str,
+    decl_off: u32,
+    call_off: u32,
+) -> bool {
+    let canonical = tcl_syntax::naming::normalise_qualified_name(def_qualified);
+    let Some(hop) = tcl_compiler::analyser::indirection::walk(
+        analysis,
+        &canonical,
+        call_off,
+        &tcl_syntax::naming::normalise_qualified_name,
+    ) else {
+        return false;
+    };
+    if hop.target == canonical || hop.established < decl_off {
+        return false;
+    }
+    match analysis.innermost_definition_body_span(hop.established) {
+        None => true,
+        Some(body) => body.start() <= call_off && call_off < body.end(),
+    }
+}
+
 /// [`invocation_references_named`] specialised for a [`ProcDef`](tcl_compiler::analyser::ProcDef).
+///
+/// Gated by [`definition_displaced_from_its_name`]: a call written after an
+/// `interp alias` / `rename` that took this proc's own name over reaches the
+/// binding's target, not this proc (issue #923 idx 89).
 #[must_use]
 pub(crate) fn invocation_references_proc(
     analysis: &AnalysisResult,
@@ -481,6 +552,14 @@ pub(crate) fn invocation_references_proc(
     qname: &str,
     proc_def: &tcl_compiler::analyser::ProcDef,
 ) -> bool {
+    if definition_displaced_from_its_name(
+        analysis,
+        &proc_def.qualified_name,
+        proc_def.name_span.start(),
+        inv.range.start(),
+    ) {
+        return false;
+    }
     invocation_references_named(
         analysis,
         inv,
@@ -491,6 +570,10 @@ pub(crate) fn invocation_references_proc(
 }
 
 /// [`invocation_references_named`] specialised for a [`ClassDef`](tcl_compiler::analyser::ClassDef).
+///
+/// Same command-table gate as [`invocation_references_proc`] — a class
+/// command's name is an ordinary command-table slot and an `interp alias`
+/// takes it over just as thoroughly.
 #[must_use]
 pub(crate) fn invocation_references_class(
     analysis: &AnalysisResult,
@@ -498,6 +581,14 @@ pub(crate) fn invocation_references_class(
     qname: &str,
     class_def: &tcl_compiler::analyser::ClassDef,
 ) -> bool {
+    if definition_displaced_from_its_name(
+        analysis,
+        &class_def.qualified_name,
+        class_def.name_span.start(),
+        inv.range.start(),
+    ) {
+        return false;
+    }
     invocation_references_named(
         analysis,
         inv,

--- a/rust/tcl-lsp-core/tests/command_table_mutation.rs
+++ b/rust/tcl-lsp-core/tests/command_table_mutation.rs
@@ -291,6 +291,120 @@ fn tp_references_on_an_alias_target_reach_the_shadowing_call_site() {
     );
 }
 
+/// The other query direction of the same document — the one that was still
+/// wrong after the go-to-definition half of idx 89 landed.
+///
+/// Oracle (tclsh 9.0.4 and 8.6.16, byte-identical): the script prints
+/// `classic tk::spinbox: .sb -from 0 -to 100`, so `::ttk::spinbox`'s own
+/// body never runs and the call on the last line is not one of its
+/// references.
+#[test]
+fn tn_references_from_the_shadowed_original_exclude_the_redirected_call() {
+    let src = ALIAS_SHADOW_SRC;
+    assert_eq!(
+        refs(src)(2, 12),
+        vec![2],
+        "only the shadowed declaration itself — the alias took the name over"
+    );
+}
+
+/// The code lens on the shadowed proc must agree with Find All References:
+/// zero call sites, not one.  A separate assertion because `references()`
+/// dedupes by range while the lens counts `proc_reference_spans` raw.
+#[test]
+fn tn_lens_count_on_the_shadowed_original_is_zero() {
+    assert_eq!(lens_count(ALIAS_SHADOW_SRC, "::ttk::spinbox"), 0);
+    assert_eq!(
+        lens_count(ALIAS_SHADOW_SRC, "::tk::spinbox"),
+        2,
+        "the alias target word and the redirected call site"
+    );
+}
+
+/// Renaming the shadowed original must rewrite **only** its declaration.
+///
+/// Oracle: rewriting the call site too (what the edit set did before the
+/// gate) turns `classic tk::spinbox: .sb` into `themed ttk::spinbox: .sb`
+/// under both interpreters — the dead proc becomes live again under the new
+/// name and the alias stops being consulted. Renaming just the header keeps
+/// the original output.
+#[test]
+fn tn_rename_of_the_shadowed_original_does_not_touch_the_call_site() {
+    let src = ALIAS_SHADOW_SRC;
+    let analysis = analyse(src);
+    let edits = tcl_lsp_core::rename::rename(src, "tcl9.0", 2, 12, "newname", &analysis, None);
+    assert_eq!(
+        edits.iter().map(|e| e.range.start_line).collect::<Vec<_>>(),
+        vec![2],
+        "only the shadowed declaration is rewritten: {edits:?}"
+    );
+}
+
+/// The symmetric direction stays whole: renaming the alias *target* rewrites
+/// its declaration and the alias's own target word, and leaves the call
+/// site's spelling (the alias's name) alone.
+#[test]
+fn tp_rename_of_the_alias_target_rewrites_the_declaration_and_alias_word() {
+    let src = ALIAS_SHADOW_SRC;
+    let analysis = analyse(src);
+    let edits = tcl_lsp_core::rename::rename(src, "tcl9.0", 3, 12, "classicbox", &analysis, None);
+    assert_eq!(
+        edits.iter().map(|e| e.range.start_line).collect::<Vec<_>>(),
+        vec![3, 4],
+        "declaration plus the alias's target word: {edits:?}"
+    );
+}
+
+/// A `proc` written *after* an `interp alias` on the same name replaces the
+/// alias, so the gate must not fire there.
+///
+/// Oracle (9.0.4 / 8.6.16): `proc target …; interp alias {} greet {} target;
+/// proc greet …; greet` prints `greet body`.
+#[test]
+fn tn_a_proc_declared_after_the_alias_keeps_its_own_call_sites() {
+    let src = concat!(
+        "proc target {} { puts \"target body\" }\n",
+        "interp alias {} greet {} target\n",
+        "proc greet {} { puts \"greet body\" }\n",
+        "greet\n",
+    );
+    assert_eq!(
+        refs(src)(2, 6),
+        vec![2, 3],
+        "the later proc owns the name again, so the call is its reference"
+    );
+}
+
+/// A mutation sitting in *another* proc's body may or may not ever run, so
+/// the call site is not silently dropped from the reference (and rename)
+/// set — abstaining toward keeping the edit whole.
+#[test]
+fn tn_an_alias_installed_in_another_body_does_not_drop_the_call_site() {
+    let src = concat!(
+        "proc target {} { }\n",
+        "proc greet {} { }\n",
+        "proc install {} { interp alias {} greet {} target }\n",
+        "greet\n",
+    );
+    assert_eq!(
+        refs(src)(1, 6),
+        vec![1, 3],
+        "a conditional alias does not prove the call misses `greet`"
+    );
+}
+
+/// The idx 89 document, shared by the tests above so they all speak about
+/// exactly the same program (`f8/alias_shadow.tcl`, run under both
+/// interpreters).
+const ALIAS_SHADOW_SRC: &str = concat!(
+    "namespace eval ::ttk {}\n",
+    "namespace eval ::tk {}\n",
+    "proc ::ttk::spinbox {w args} { puts \"themed ttk::spinbox: $w $args\" }\n",
+    "proc ::tk::spinbox {w args} { puts \"classic tk::spinbox: $w $args\" }\n",
+    "interp alias {} ::ttk::spinbox {} ::tk::spinbox\n",
+    "::ttk::spinbox .sb -from 0 -to 100\n",
+);
+
 // proc self-redefinition (issue #923 idx 45)
 
 #[test]

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -26658,6 +26658,119 @@ mod tests {
         assert_eq!(consumer_edits[0].new_text, "ListToArray");
     }
 
+    /// idx 45 (differential-audit main audit wave): the *nested,
+    /// cross-namespace* self-redefinition the finding was actually mined
+    /// from — `nico-robert/ticklecharts`' `proc ticklecharts::activate`
+    /// whose body declares an unqualified `proc activate`.
+    ///
+    /// Distinct from idx 31's shape above (two verbatim-identical top-level
+    /// declarations in one namespace) in the half that matters: the inner
+    /// declaration is written *unqualified inside a qualified proc's body*,
+    /// so getting the cross-file caller back depends on the namespace
+    /// resolution of the fix, not only on keeping every physical
+    /// declaration's span.
+    ///
+    /// Oracle, byte-identical on tclsh 9.0.4 and 8.6.16: running `main.tcl`
+    /// prints `activating for the first time` then `already activated`, and
+    /// probing the command table afterwards reports `::ticklecharts::activate`
+    /// present with no global `::activate` at all — the nested `proc`
+    /// redefines the *same* command in the enclosing namespace.
+    #[tokio::test]
+    async fn cross_document_references_reach_caller_from_nested_self_redefinition() {
+        let backend = test_backend();
+        let lib = Uri::from_str("file:///lib45_refs.tcl").unwrap();
+        let consumer = Uri::from_str("file:///consumer45_refs.tcl").unwrap();
+        let lib_src = "namespace eval ticklecharts {}\n\
+                       proc ticklecharts::activate {bool} {\n\
+                       \x20if {$bool} {\n\
+                       \x20 proc activate {bool} {puts \"already activated\"}\n\
+                       \x20 puts \"activating for the first time\"\n\
+                       \x20}\n\
+                       }\n";
+        register(&backend, &lib, lib_src).await;
+        register(
+            &backend,
+            &consumer,
+            "ticklecharts::activate 1\nticklecharts::activate 1\n",
+        )
+        .await;
+        let analysis = {
+            let mut a = Analyser::new();
+            a.analyse(lib_src, "tcl8.6").clone()
+        };
+        // Both physical declarations must answer the same cross-file set:
+        // the OUTER header (line 1, on `activate` of `ticklecharts::activate`)
+        // and the NESTED one (line 3, on the bare `activate`).
+        for (line, character, which) in [(1u32, 20u32, "outer"), (3, 7, "nested")] {
+            let cross = backend
+                .cross_document_references(
+                    &lib,
+                    lib_src,
+                    &analysis,
+                    Position::new(line, character),
+                    false,
+                )
+                .await;
+            assert_eq!(
+                cross.len(),
+                2,
+                "both cross-file callers must be reached from the {which} \
+                 declaration: {cross:?}"
+            );
+            assert!(cross.iter().all(|l| l.uri == consumer), "{cross:?}");
+        }
+    }
+
+    /// The rename half of the same shape — the severe one. An edit set that
+    /// drops the cross-file callers leaves them bound to the old name while
+    /// the *other* declaration of the very same command is still lying
+    /// around under it.
+    #[tokio::test]
+    async fn cross_document_rename_reaches_caller_from_nested_self_redefinition() {
+        let backend = test_backend();
+        let lib = Uri::from_str("file:///lib45_rename.tcl").unwrap();
+        let consumer = Uri::from_str("file:///consumer45_rename.tcl").unwrap();
+        let lib_src = "namespace eval ticklecharts {}\n\
+                       proc ticklecharts::activate {bool} {\n\
+                       \x20if {$bool} {\n\
+                       \x20 proc activate {bool} {puts \"already activated\"}\n\
+                       \x20}\n\
+                       }\n";
+        register(&backend, &lib, lib_src).await;
+        register(
+            &backend,
+            &consumer,
+            "ticklecharts::activate 1\nticklecharts::activate 1\n",
+        )
+        .await;
+        let analysis = {
+            let mut a = Analyser::new();
+            a.analyse(lib_src, "tcl8.6").clone()
+        };
+        for (line, character, which) in [(1u32, 20u32, "outer"), (3, 7, "nested")] {
+            let mut changes: std::collections::HashMap<Uri, Vec<TextEdit>> =
+                std::collections::HashMap::new();
+            backend
+                .add_cross_document_rename_edits(
+                    &lib,
+                    lib_src,
+                    &analysis,
+                    Position::new(line, character),
+                    "enable",
+                    &mut changes,
+                )
+                .await;
+            let consumer_edits = changes.get(&consumer).cloned().unwrap_or_default();
+            assert_eq!(
+                consumer_edits.len(),
+                2,
+                "both cross-file callers must be rewritten from the {which} \
+                 declaration: {changes:?}"
+            );
+            assert!(consumer_edits.iter().all(|e| e.new_text == "enable"));
+        }
+    }
+
     /// Build an on-disk autoload library (`tclIndex` + defining file, like a
     /// `TCLLIBPATH` entry) whose `Rbc_Wire` also calls `Rbc_ActiveLegend`
     /// internally, and point the backend's package database at it.  Returns

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -26767,7 +26767,15 @@ mod tests {
                 "both cross-file callers must be rewritten from the {which} \
                  declaration: {changes:?}"
             );
-            assert!(consumer_edits.iter().all(|e| e.new_text == "enable"));
+            // The caller spells the command with its namespace qualifier, and
+            // rename preserves that qualifier rather than flattening the call
+            // to a bare name.
+            assert!(
+                consumer_edits
+                    .iter()
+                    .all(|e| e.new_text == "ticklecharts::enable"),
+                "the qualifier must be preserved: {consumer_edits:?}"
+            );
         }
     }
 

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -4766,3 +4766,230 @@ fn opt_proc_arity_is_deliberately_unchecked_in_both_directions_end_to_end() {
         codes(&diags)
     );
 }
+
+/// idx 5 (differential-audit): `rename OLD NEW` must validate that `OLD`
+/// resolves to a known command.
+///
+/// tclsh 9.0.4 and 8.6.16 both abort the script:
+/// `can't rename "definitelyNotDefinedAnywhere": command doesn't exist`
+/// (exit 1). The whole rename statement is a guaranteed runtime error, so
+/// the source word draws W123 end to end.
+#[test]
+fn w123_rename_of_a_nonexistent_command_is_published() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "rename definitelyNotDefinedAnywhere someAlias\n");
+    assert!(
+        has_code(&diags, "W123"),
+        "the rename source must be resolved like any other command word: {diags:?}"
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|d| message(d).contains("definitelyNotDefinedAnywhere")),
+        "the message names the missing command: {diags:?}"
+    );
+}
+
+/// The delete form of the same statement. tclsh: `can't delete
+/// "totallyBogusCommand": command doesn't exist` (exit 1) — `rename X {}`
+/// was the form the original fix nearly missed.
+#[test]
+fn w123_deleting_rename_of_a_nonexistent_command_is_published() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "rename totallyBogusCommand {}\nputs done\n");
+    assert!(
+        has_code(&diags, "W123"),
+        "`rename X {{}}` deletes X, so X must exist: {diags:?}"
+    );
+    assert_eq!(
+        on_line(&diags, "W123"),
+        [0].into_iter().collect::<BTreeSet<i64>>(),
+        "flagged at the rename statement, nowhere else: {diags:?}"
+    );
+}
+
+/// TN control for the two above: renaming a command that really does exist
+/// is silent, so the check is a resolution, not a blanket flag on `rename`.
+#[test]
+fn w123_rename_of_an_existing_command_is_silent() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc greet {} { return hi }\nrename greet hello\nrename puts _oldputs\n",
+    );
+    assert!(
+        !has_code(&diags, "W123"),
+        "a user proc and a builtin are both renameable: {diags:?}"
+    );
+}
+
+/// idx 24 (differential-audit): a variable assigned indirectly through
+/// `uplevel` in an outer frame is not read-before-set, however many ordinary
+/// call frames sit between the writer and the frame it writes.
+///
+/// Oracle (tclsh 9.0.4 and 8.6.16, byte-identical): the script below prints
+/// `99` — `answer` really is set in `outer`'s frame by a proc `outer` never
+/// calls directly.
+#[test]
+fn w210_not_published_for_a_multi_frame_uplevel_assignment() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc setUp2 {var} {\n    uplevel 2 [list set $var 99]\n}\n\
+         proc middle {} {\n    setUp2 answer\n}\n\
+         proc outer {} {\n    middle\n    return $answer\n}\n",
+    );
+    assert!(
+        !has_code(&diags, "W210"),
+        "`uplevel 2` writes the plain caller's caller: {diags:?}"
+    );
+}
+
+/// The one-hop spellings of the same idiom, both `[list …]`-built and
+/// word-concatenated. Silent before the multi-frame fix, pinned here because
+/// nothing else did.
+#[test]
+fn w210_not_published_for_a_single_hop_uplevel_assignment() {
+    for body in [
+        "uplevel 1 [list set $var 99]",
+        "uplevel 1 set $var 99",
+        "uplevel [expr {[info level] - 1}] [list set $var 99]",
+    ] {
+        let mut lsp = Lsp::tcl();
+        let uri = unique_uri("tcl");
+        let diags = lsp.open_ready(
+            &uri,
+            &format!(
+                "proc setInCaller {{var}} {{\n    {body}\n}}\n\
+                 proc useIt {{}} {{\n    setInCaller answer\n    return $answer\n}}\n"
+            ),
+        );
+        assert!(
+            !has_code(&diags, "W210"),
+            "`{body}` defines the caller's variable: {diags:?}"
+        );
+    }
+}
+
+/// TP control for both of the above: with the `uplevel` replaced by a
+/// callee-local `set`, nothing reaches the caller's frame and W210 must
+/// still be published.
+#[test]
+fn w210_still_published_when_nothing_writes_the_outer_frame() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc setInCaller {var} {\n    set $var 99\n}\n\
+         proc useIt {} {\n    setInCaller answer\n    return $answer\n}\n",
+    );
+    assert!(
+        has_code(&diags, "W210"),
+        "a callee-local `set` never reaches the caller: {diags:?}"
+    );
+}
+
+/// idx 24, second half: W212 must not read the literal word `set` inside a
+/// `[list …]`-built script as a directly-written `set $var` confusion — the
+/// substitution happens in the building frame and is the idiom itself.
+#[test]
+fn w212_not_published_for_a_list_built_variable_name_word() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc setInCaller {var} {\n    uplevel 1 [list set $var 99]\n}\n",
+    );
+    assert!(
+        !has_code(&diags, "W212"),
+        "a list-built name word is pre-substituted, not a confusion: {diags:?}"
+    );
+}
+
+/// TP control: the directly-written spelling is exactly what W212 is for.
+#[test]
+fn w212_still_published_for_a_directly_written_name_word() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "proc setInCaller {var} {\n    set $var 99\n}\n");
+    assert!(
+        has_code(&diags, "W212"),
+        "a written `$` in a name position is still W212: {diags:?}"
+    );
+}
+
+/// idx 38 (differential-audit): the canonical caller-frame-injection idiom
+/// the `tclopt` corpus is built from — a `[list set $varName $value]` built
+/// inside a `foreach`, with both words substituted.
+///
+/// Oracle (tclsh 9.0.4 and 8.6.16): the script prints `1 1 1`, so all three
+/// names really are materialised in `Qfrac2`'s frame. Neither the
+/// read-before-set nor the name/value check may fire.
+#[test]
+fn neither_w210_nor_w212_is_published_for_a_looped_list_built_injection() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc NewArrays {varNames value} {\n\
+         \x20   foreach varName $varNames {\n\
+         \x20       uplevel 1 [list set $varName $value]\n\
+         \x20   }\n\
+         }\n\
+         proc Qfrac2 {} {\n\
+         \x20   NewArrays {rdiagArray acnormArray waArray} 1\n\
+         \x20   return [list $rdiagArray $acnormArray $waArray]\n\
+         }\n",
+    );
+    assert!(
+        !has_code(&diags, "W212"),
+        "a list-built name word is the idiom, not a confusion: {diags:?}"
+    );
+    assert!(
+        !has_code(&diags, "W210"),
+        "the three names are materialised in the caller's frame: {diags:?}"
+    );
+}
+
+/// TP control: with the injecting call removed, nothing writes those names
+/// and all three reads are genuinely unset (tclsh: `can't read
+/// "rdiagArray": no such variable`).
+#[test]
+fn w210_still_published_without_the_injecting_call() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc Qfrac2 {} {\n\
+         \x20   return [list $rdiagArray $acnormArray $waArray]\n\
+         }\n",
+    );
+    assert!(
+        has_code(&diags, "W210"),
+        "nothing writes those names: {diags:?}"
+    );
+}
+
+/// TP control for the W212 carve-out in the same proc shape: the directly
+/// written `set $varName $value` is exactly the confusion the code is for.
+#[test]
+fn w212_still_published_for_a_directly_written_looped_name() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc NewArrays {varNames value} {\n\
+         \x20   foreach varName $varNames {\n\
+         \x20       set $varName $value\n\
+         \x20   }\n\
+         }\n",
+    );
+    assert!(
+        has_code(&diags, "W212"),
+        "a written `$` in a name position is still W212: {diags:?}"
+    );
+}

--- a/rust/tcl-lsp-server/tests/e2e/references.rs
+++ b/rust/tcl-lsp-server/tests/e2e/references.rs
@@ -540,6 +540,74 @@ fn references_from_an_alias_call_site_offer_the_targets_sites() {
     );
 }
 
+/// idx 89 (differential-audit): the query direction that was still wrong
+/// after go-to-definition was fixed — from the SHADOWED original proc's own
+/// declaration.
+///
+/// Oracle, byte-identical on tclsh 9.0.4 and 8.6.16: the script prints
+/// `classic tk::spinbox: .sb`, so `::ttk::spinbox`'s own body never runs
+/// from the alias onward and the call is not one of its references.
+#[test]
+fn references_from_a_shadowed_original_exclude_the_redirected_call() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, ALIAS_SHADOW_SRC);
+    // Line 2: cursor on the shadowed `::ttk::spinbox` declaration.
+    let lines = start_lines(&lsp.references(&uri, 2, 12, true));
+    assert_eq!(
+        lines,
+        vec![2],
+        "only its own declaration — the alias took the name over: {lines:?}"
+    );
+}
+
+/// The symmetric direction of the same document stays whole: the alias
+/// target's reference set still contains the redirected call site.
+#[test]
+fn references_from_the_alias_target_still_reach_the_redirected_call() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, ALIAS_SHADOW_SRC);
+    // Line 3: cursor on the `::tk::spinbox` declaration.
+    let lines = start_lines(&lsp.references(&uri, 3, 12, true));
+    assert!(lines.contains(&3), "decl missing: {lines:?}");
+    assert!(lines.contains(&4), "alias target word missing: {lines:?}");
+    assert!(lines.contains(&5), "redirected call missing: {lines:?}");
+}
+
+/// A punctuation-named alias — the corpus shape (`interp alias {} = {} expr`)
+/// the identifier-named tests above never exercise.
+///
+/// tclsh 9.0.4 / 8.6.16: `interp alias {} @ {} tally` then `@` really runs
+/// `tally`'s body.
+#[test]
+fn references_include_call_sites_spelled_through_a_punctuation_alias() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "proc tally {} { return 1 }\ninterp alias {} @ {} tally\nputs [@]\n",
+    );
+    let lines = start_lines(&lsp.references(&uri, 0, 6, true));
+    assert!(lines.contains(&0), "decl missing: {lines:?}");
+    assert!(
+        lines.contains(&2),
+        "the punctuation alias's call site must be reported: {lines:?}"
+    );
+}
+
+/// The idx 89 document, shared by the tests above.  Line 2 declares the proc
+/// the alias on line 4 displaces; line 5 is the call that really runs
+/// `::tk::spinbox`.
+const ALIAS_SHADOW_SRC: &str = concat!(
+    "namespace eval ::ttk {}\n",
+    "namespace eval ::tk {}\n",
+    "proc ::ttk::spinbox {w args} { puts \"themed ttk::spinbox: $w $args\" }\n",
+    "proc ::tk::spinbox {w args} { puts \"classic tk::spinbox: $w $args\" }\n",
+    "interp alias {} ::ttk::spinbox {} ::tk::spinbox\n",
+    "::ttk::spinbox .sb -from 0 -to 100\n",
+);
+
 /// idx 92 (differential-audit main audit wave): the `[namespace code [list
 /// ProcName]]` callback wrapper Tk's own `library/fontchooser.tcl` uses ten
 /// times. tclsh 9.0.4 and 8.6.16 both report the installed trace as

--- a/rust/tcl-lsp-server/tests/e2e/references.rs
+++ b/rust/tcl-lsp-server/tests/e2e/references.rs
@@ -556,7 +556,7 @@ fn references_from_a_shadowed_original_exclude_the_redirected_call() {
     let lines = start_lines(&lsp.references(&uri, 2, 12, true));
     assert_eq!(
         lines,
-        vec![2],
+        [2].into_iter().collect::<std::collections::BTreeSet<i64>>(),
         "only its own declaration — the alias took the name over: {lines:?}"
     );
 }

--- a/rust/tcl-lsp-server/tests/e2e/rename.rs
+++ b/rust/tcl-lsp-server/tests/e2e/rename.rs
@@ -670,6 +670,72 @@ fn rename_does_not_rewrite_call_sites_that_go_through_an_alias() {
     );
 }
 
+/// idx 89 (differential-audit): renaming the proc an `interp alias` has
+/// displaced must rewrite **only** its own header.
+///
+/// Oracle, byte-identical on tclsh 9.0.4 and 8.6.16. The document prints
+/// `classic tk::spinbox: .sb -from 0 -to 100`. Rewriting the header *and*
+/// the call site to `::ttk::newname` — the edit set this produced before the
+/// fix — changes that to `themed ttk::spinbox: .sb -from 0 -to 100`: the
+/// dead proc becomes live again under the new name and the untouched alias
+/// stops being consulted. Rewriting the header alone keeps the original
+/// output. A rename that silently changes which body runs is the worst
+/// answer available, so this is asserted as an exact edit set, not a
+/// containment.
+#[test]
+fn rename_of_an_alias_shadowed_proc_leaves_the_redirected_call_alone() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, ALIAS_SHADOW_SRC);
+    // Line 2: cursor on the shadowed `::ttk::spinbox` declaration.
+    let result = lsp.rename(&uri, 2, 12, "newname");
+    let edits = rename_edits(&result);
+    let for_uri = edits.get(&uri).cloned().unwrap_or_default();
+    let lines: Vec<i64> = for_uri
+        .iter()
+        .filter_map(|e| e["range"]["start"]["line"].as_i64())
+        .collect();
+    assert_eq!(
+        lines,
+        vec![2],
+        "only the displaced header may be rewritten: {for_uri:?}"
+    );
+}
+
+/// The symmetric direction: renaming the alias's *target* rewrites its
+/// declaration and the alias's own target word, and leaves the call site
+/// (which spells the alias's name) untouched.
+#[test]
+fn rename_of_the_alias_target_rewrites_the_declaration_and_the_alias_word() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, ALIAS_SHADOW_SRC);
+    // Line 3: cursor on the `::tk::spinbox` declaration.
+    let result = lsp.rename(&uri, 3, 12, "classicbox");
+    let edits = rename_edits(&result);
+    let for_uri = edits.get(&uri).cloned().unwrap_or_default();
+    let mut lines: Vec<i64> = for_uri
+        .iter()
+        .filter_map(|e| e["range"]["start"]["line"].as_i64())
+        .collect();
+    lines.sort_unstable();
+    assert_eq!(
+        lines,
+        vec![3, 4],
+        "declaration plus the alias's target word: {for_uri:?}"
+    );
+}
+
+/// The idx 89 document, shared by the two tests above.
+const ALIAS_SHADOW_SRC: &str = concat!(
+    "namespace eval ::ttk {}\n",
+    "namespace eval ::tk {}\n",
+    "proc ::ttk::spinbox {w args} { puts \"themed ttk::spinbox: $w $args\" }\n",
+    "proc ::tk::spinbox {w args} { puts \"classic tk::spinbox: $w $args\" }\n",
+    "interp alias {} ::ttk::spinbox {} ::tk::spinbox\n",
+    "::ttk::spinbox .sb -from 0 -to 100\n",
+);
+
 /// idx 45 (differential-audit main audit wave): rename issued from the
 /// declaration a later same-named `proc` displaced must still reach every
 /// call site — the displaced header declares the same command, so a partial


### PR DESCRIPTION
Part of #1019 — the rename/alias cluster, plus the W212 false positive it exposed.

## idx 24 — beyond-caller frame effects

`uplevel` at a level beyond the immediate caller was not propagated through plain calls, so a variable a helper creates two frames up was invisible to everything downstream. Frame effects now compose through plain calls, and the one-hop composition is unit-pinned in its own right rather than only observed through a diagnostic.

The W212 false positive falls out of the same work: a name word built with `list` is not a literal variable name, and W212 no longer fires on one.

## idx 89 — command-table removal

A call site the command table has taken away from a proc is now excluded from that proc's references, rather than being reported against a proc that no longer answers to the name.

## idx 5 / 21 / 38 / 45 / 91

Each is pinned at the tiers that actually apply to it, rather than blanket-covered:

- **idx 5** — `rename OLD NEW` validates that `OLD` resolves to a known command. Oracle: tclsh 9.0.4 and 8.6.16 both abort with `can't rename "definitelyNotDefinedAnywhere": command doesn't exist`.
- **idx 45** — a rename keeps the caller's namespace qualifier.
- **idx 91** — the Tk interpreter-domain behaviour gets its VS Code tier.

The control fixture for idx 24 now says precisely how its abort is observed, so a future reader does not have to infer the mechanism from the assertion.

## Verification

Every behaviour asserted here was checked against tclsh 9.0.4 and 8.6.16, which agree byte-for-byte, and is pinned at the unit, LSP end-to-end and VS Code tiers as each finding warrants.

## Gates

Full workspace from clean: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo test --workspace --all-features` all clean — **17038 passed, 0 failed**.

Rebased onto current `rust`. The e2e `diagnostics.rs` conflict was a pure end-of-file append on both sides (227 insertions, no deletions), resolved by keeping both sets of tests; verified by compiling and running the suite rather than by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRcKhqHNLCBDFg3iMPB5mV)_