### PR TITLE
Cross-file metaclass chains resolve to a fixpoint; VS Code suite bounded by progress (#1293, #1294, #1295, #1296)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,7 +191,7 @@ The project uses GNU Make. Key targets:
 | `make prep-pr`     | Pre-PR formatting + fast checks: auto-formats code, runs codegen, lint/typecheck, and `test-rust`. Run the heavier suites (`test-ext`, `runtime-rust-test`, `test-emacs`) separately before opening a PR — see "Before opening a PR" below. |
 | `make test`        | Run all tests — Rust workspace + VS Code extension + Rust runtime port (`test-rust test-ext runtime-rust-test`) |
 | `make test-rust`   | `cargo test --workspace --all-features` — includes the native lsp_e2e suite (`rust/tcl-lsp-server/tests/*_e2e.rs`); skip with `SKIP_TEST_RUST=1` |
-| `make test-ext`    | VS Code extension integration tests (xvfb on headless Linux) |
+| `make test-ext`    | VS Code extension integration tests — the single-root suite **and** the multi-root (`test:multi-folder`) suite (xvfb on headless Linux) |
 | `make lint-py`     | `ruff format --check` + `ruff check` over every tracked `.py` (versions pinned in the Makefile) |
 | `make format-py`   | `ruff format` over every tracked `.py` |
 | `make typecheck-py`| `ty` + `pyright` over every tracked `.py`.  Builds `.venv-typecheck`, which installs `f5report` (maturin-compiling the native `_engine`) plus pytest, so both checkers resolve every import for real.  Sublime host APIs are declared by stubs under `typings/`. |
@@ -408,7 +408,7 @@ make runtime-rust-test                           # the standalone runtime/rust c
   --workspace --all-features`, including the native lsp_e2e suite
   `rust/tcl-lsp-server/tests/*_e2e.rs`)
 - **check-rust** — Rust lint/typecheck
-- **test-ext** — VS Code extension integration tests
+- **test-ext** — VS Code extension integration tests, single-root and multi-root
 - **test-emacs** — Emacs eglot integration tests
 - **runtime-rust-test** — the leak round-trip + parse/eval unit suite for
   the standalone `runtime/rust` crate

--- a/Makefile
+++ b/Makefile
@@ -502,7 +502,7 @@ check-report-assets: build-report-assets ## Verify committed report dist/ + f5re
 		rust/bigip-report-gen/python/python/f5report/vendor \
 		|| { echo "ERROR: report assets are stale — run 'make build-report-assets' and commit the result"; exit 1; }
 
-test-ext: ## Run VS Code extension integration tests; skip with SKIP_TEST_EXT=1
+test-ext: ## Run VS Code extension integration tests (single-root + multi-root); skip with SKIP_TEST_EXT=1
 	@# Single-shell recipe so SKIP_TEST_EXT=1 truly bypasses everything
 	@# (compile + xvfb install + test host).  Without ``set -eu`` the
 	@# early ``exit 0`` would only end its own recipe-line shell and
@@ -538,6 +538,12 @@ test-ext: ## Run VS Code extension integration tests; skip with SKIP_TEST_EXT=1
 		fi; \
 	else \
 		cd "$(EXT_DIR)" && "$(NPM)" test; \
+	fi; \
+	echo "==> Running multi-root VS Code extension tests"; \
+	if [[ "$$(uname -s)" == "Linux" && -z "$${DISPLAY:-}" ]]; then \
+		cd "$(EXT_DIR)" && xvfb-run -a "$(NPM)" run test:multi-folder; \
+	else \
+		cd "$(EXT_DIR)" && "$(NPM)" run test:multi-folder; \
 	fi
 
 # Coverage targets (reports go to tmp/coverage/, which is gitignored)

--- a/docs/design/contracts/config-precedence.md
+++ b/docs/design/contracts/config-precedence.md
@@ -190,10 +190,29 @@ Documented in
 [`kcs-qa-how-tcl-lsp-loads-configuration.md`](../../kcs/kcs-qa-how-tcl-lsp-loads-configuration.md)
 under "How to figure out where a setting is coming from". The
 canonical mechanism is the `tcl-lsp.getEffectiveConfig` command
-(`server/commands.py:on_get_effective_config`),
+(`rust/tcl-lsp-server/src/lib.rs::get_effective_config_command`),
 which returns the resolved per-folder values the analyser will use
 for a given URI. The server also logs `Loaded user config from <path>`
 and `Loaded project config from <path>` on every load.
+
+**Contract: every value the command reports for a URI resolves through
+the same chain the code acting on that URI uses.** The command is not a
+dump of process-global state — it answers "what is in effect *here*",
+and a client is entitled to treat it as a barrier: once it reports a
+value, a request issued afterwards is answered under that value.
+
+The `features` map broke that contract until issue #1295. Each provider
+gate (`Backend::feature_enabled` and its default-off siblings) consults
+the deepest workspace folder containing the URI before falling back to
+the process-global toggles, but the command reported the global map
+alone. In a multi-root workspace a folder-scoped
+`tclLsp.features.*` override was therefore invisible in the report while
+being fully in effect in the behaviour, and a client polling the command
+to know a toggle had landed was waiting on a different fact from the one
+the provider would act on. Both now go through
+`Backend::resolved_feature_toggles`, which is the single place the
+folder-over-global overlay is performed — a folder overrides exactly the
+keys it sets and leaves the rest of the global set alone.
 
 ## Related
 

--- a/docs/design/tcloo-mro-lattice.md
+++ b/docs/design/tcloo-mro-lattice.md
@@ -259,10 +259,47 @@ superclasses` on tclsh 8.6.14 and 9.0.4.
   spec actually reads those tokens (a `retraction` member — `deletemethod` /
   `renamemethod`) collapses the injection to unknown rather than being
   applied against a substituted span.
-- A metaclass that is itself manufactured by a *third* file's metaclass
-  resolves only once the host's next sync round has published it.  The sync
-  is compare-then-set, so it stops as soon as the index stops moving; what
-  never happens is a round that adds an entry no file proved.
+**Chained metaclasses — why the publish is a fixpoint.**  `item_tree` reads
+`SourceFile::workspace_class_factories`, and `project_class_factories` is
+built out of `item_tree`, so the merge is a function of the very input the
+host computes from it.  One publish is therefore exactly **one link of the
+metaclass chain deep**: `MetaA` is provable with no index at all, but the
+file holding `MetaA create MetaB` proves `MetaB` only on a round whose
+published index already names `MetaA`.  `sync_workspace_class_factories`
+consequently *iterates* — recompute, compare-then-set, repeat — and stops as
+soon as a round moves nothing (issue #1296).  Publishing once left every
+class the deeper metaclass manufactures unknown, which presented as a
+three-level cross-file chain resolving to nothing from a call site.
+
+The loop is bounded, not merely expected to converge:
+
+- A round adds an entry only when some file **proved** it — never a guess —
+  so the normal case is monotone growth over a set bounded by the project's
+  literal creation calls.  Only statically resolved qualified names can enter
+  it, so a computed creation (`oo::class create ${ns}::class …`, tcllib's
+  `oo::dialect`) or a computed `oo::define` contributes nothing to any round
+  and cannot make the sequence oscillate.
+- A cyclic declaration (`A` made by `B` made by `A`) proves neither link, so
+  it settles empty on the first round.
+- `CLASS_FACTORY_SYNC_ROUNDS` caps the loop regardless.  Hitting the cap logs
+  and publishes what has been proved so far, which is still a sound — if
+  possibly incomplete — index.
+- A round a concurrent edit cancelled published nothing and learned nothing,
+  so it is retried rather than mistaken for the fixpoint; the cap bounds that
+  too.
+- A workspace with **no** metaclass computes an empty index, stored as
+  `None`, so it settles in one round that writes nothing and invalidates
+  nothing — the common case pays for none of this.
+
+Two supporting behaviours keep the extra rounds off the user's critical
+path.  A `SourceFile` created for an arriving document is **seeded** with the
+oracle the rest of the project already carries, so its *first* published
+analysis already reflects the workspace's metaclasses instead of publishing a
+class-less result for a later round to repair.  And each round's invalidated
+peers are rescheduled **as that round lands**, so the confirming round — the
+slowest one, since it recomputes every item tree through the input the
+previous round moved — never sits in front of a republish an earlier round
+already earned.
 
 **Per-item parity.**  The oracle travels with a deferred proc/method body
 (`analyse_proc_body_isolated`, keyed into `ItemBodyKey::body_env`), so a

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -107,6 +107,12 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
 - [kcs-issue-reconstruct-a-stress-test-failure.md](kcs-issue-reconstruct-a-stress-test-failure.md)
   — a stress-test suite run failed and you want to reconstruct it from
   the `STRESS_FAILURE:` reproduction bundle.
+- [kcs-issue-vscode-test-timed-out-on-didopen.md](kcs-issue-vscode-test-timed-out-on-didopen.md)
+  — a VS Code extension test timed out draining `didOpen`, and you want to
+  tell a wedged server apart from one wedged document.
+- [kcs-issue-vscode-test-runner-reports-false-hang.md](kcs-issue-vscode-test-runner-reports-false-hang.md)
+  — `make test-ext` reports "mocha never completed (likely hung)" on a run
+  that actually passed every test.
 
 ## Q&A
 

--- a/docs/kcs/kcs-issue-classes-made-by-a-class-factory-are-invisible.md
+++ b/docs/kcs/kcs-issue-classes-made-by-a-class-factory-are-invisible.md
@@ -163,7 +163,16 @@ latter.
    strategies disagree about whether a class exists. It travels on
    `analyse_proc_body_isolated` and is part of `ItemBodyKey::body_env` so
    salsa cannot serve a stale verdict.
-14. **Re-dispatch must be idempotent per source site.** The ordinary body
+14. **The workspace index is a fixpoint, not one pass.** The query that
+   collects a file's factories reads the very index the host publishes from
+   it, so a metaclass manufactured by another file's metaclass is provable
+   only on a round whose index already names its maker. One publish is
+   therefore one link deep. The host iterates until a round moves nothing
+   (issue #1296); termination holds because a round writes only what some
+   file proved, a declaration cycle proves neither of its halves, and the
+   loop is capped regardless. A workspace with no metaclass settles in one
+   round that writes nothing.
+15. **Re-dispatch must be idempotent per source site.** The ordinary body
    walk already covered the first element, so a site is visited twice under
    the loop variable's own key. One source site can never declare the same
    member twice, so `(objdefine_offset, member name)` is an exact
@@ -256,6 +265,22 @@ latter.
    `project_class_factories` carry its qualified name? does the call's name
    resolve to that exact qualified name under the enclosing namespace? Each
    "no" is a deliberate abstention, not a bug.
+10. Chain **depth** across files is not a reason for a "no" at step 9. A
+    metaclass that is itself manufactured by a *third* file's metaclass is
+    proved one link per publish round, so the host iterates the publish to a
+    fixpoint (issue #1296). If `project_class_factories` is missing a
+    qualified name you can see being created, the question is whether some
+    file *proved* it, not how deep it sits — a round adds an entry only on
+    proof, never on a guess. Before the fixpoint landed this presented as a
+    three-level cross-file chain resolving to nothing from a call site while
+    `documentSymbol` on the declaring file reported the class correctly,
+    which is the partial-resolution shape that makes it easy to miss.
+11. If the class resolves but a *handle* bound from it does not, the
+    construction form is the thing to look at, not the factory. A handle
+    bound by calling the class command itself — dispatched through the
+    metaclass's `unknown` method, as every Tk megawidget is
+    (`::tk::IconList .il`) — is a separate, open gap: issue #1303. `create`
+    and `new` on the same class bind the handle correctly.
 
 ## Test anchors
 

--- a/docs/kcs/kcs-issue-classes-made-by-a-class-factory-are-invisible.md
+++ b/docs/kcs/kcs-issue-classes-made-by-a-class-factory-are-invisible.md
@@ -292,7 +292,22 @@ latter.
   `a_dynamic_metaclass_name_still_abstains`,
   `a_metaclass_defined_in_another_file_abstains_rather_than_guessing`,
   `a_workspace_metaclass_is_not_reached_by_a_same_tailed_bare_name`,
-  `a_local_metaclass_shadows_the_workspace_one`
+  `a_local_metaclass_shadows_the_workspace_one`, and — for the chained case
+  (issue #1296) —
+  `a_second_link_metaclass_publishes_a_factory_once_the_first_is_indexed`,
+  `the_third_link_records_the_class_and_its_members`,
+  `oo_define_after_the_fact_extends_a_chained_factory_made_class`,
+  `an_unproved_second_link_still_abstains`
+- `rust/tcl-lsp-db/tests/class_factory_fixpoint.rs` — the publish loop itself:
+  `a_cross_file_three_level_chain_converges_and_records_the_class`,
+  `a_single_publish_is_one_link_deep` (the regression, asserted directly),
+  `a_chain_deeper_than_three_still_converges`,
+  `a_cycle_terminates_and_proves_nothing`,
+  `a_workspace_with_no_metaclass_costs_no_extra_round`
+- `rust/tcl-lsp-server/tests/e2e/issue1296_metaclass_chain.rs` — the ticket
+  end to end, plus the five-level, edit-path, and abstention cases
+- `editors/vscode/src/test/issue1296MetaclassChain.test.ts` — the same
+  through a real VS Code session
 - `rust/tcl-lsp-server/src/lib.rs` —
   `a_cross_file_metaclass_resolves_after_the_workspace_scan`,
   `a_dynamic_metaclass_head_abstains_even_with_the_scan_index`,

--- a/docs/kcs/kcs-issue-vscode-test-runner-reports-false-hang.md
+++ b/docs/kcs/kcs-issue-vscode-test-runner-reports-false-hang.md
@@ -1,0 +1,75 @@
+# KCS: `make test-ext` reports "mocha never completed (likely hung)" on a green run
+
+> **Audience:** Contributor
+> **Type:** Issue
+
+## Applies to
+
+VS Code
+
+## Question
+
+`make test-ext` (or `npm test` under `editors/vscode`) exits 1 with `mocha
+never completed (likely hung)`, but the log shows every test passed — how do
+you tell a genuine hang apart from a run that was simply slow?
+
+## Symptoms
+
+- The run prints test results with `0 failed` (or a full green summary), then
+  ends with `VS Code test runner did not exit within <N>ms after launch` or
+  `mocha did not complete. Treating as failure.`
+- The failure looks intermittent — it happens on some runs and not others,
+  or only under load (several build trees, CI runners, or agent sessions
+  sharing the machine).
+- A run that fails this way and is simply re-run often passes.
+
+## Answer
+
+This was issue #1293: the watchdog used to be a single flat wall-clock
+budget (`180_000`ms from launch to process exit) with no idea whether the
+suite was still working. Once the suite's own honest runtime grew past that
+budget (846 tests, ~190s), a fully green run raced its own successful exit
+and lost.
+
+The watchdog (`editors/vscode/src/test/runnerWatchdog.ts`) now bounds
+**lack of progress**, not elapsed time. It reads the heartbeat file the
+extension host writes every 2s
+(`.vscode-test/mocha-heartbeat.json`, or
+`.vscode-test/mocha-heartbeat-multifolder.json` for `test:multi-folder`) and
+gives up only when `completed + failed` and the in-flight test title have not
+moved for the no-progress window. A run that is still completing tests, or
+still failing tests, or has just moved on to a new in-flight test, is never
+killed however long it has taken. A generous absolute ceiling remains as a
+backstop for a run that never stalls but also never finishes.
+
+1. Read the message after `--- watchdog report ---`. It names which of three
+   things happened:
+   - **`no test completed for Ns (last progress: N completed, M failed, in
+     flight: <title>)`** — a genuine stall. `<title>` names the test that was
+     stuck; the heartbeat's server-probe line says whether the language
+     server was still answering (suspect the test/extension host) or not
+     (suspect the server).
+   - **`absolute ceiling reached while still completing tests`** — the run
+     was still making progress but took far longer than the generous
+     ceiling allows. This is never reported as "likely hung"; check whether
+     the suite has grown, or the machine was extremely loaded (the message
+     includes the measured load factor).
+   - **`no heartbeat file was ever written`** — the extension host failed to
+     start, or `run()` never reached `mocha.run`. Look earlier in the log
+     for an activation error, not at the watchdog itself.
+2. If the verdict is the ceiling one and the suite has genuinely grown, the
+   fix is usually a bigger no-progress window or ceiling, not a special
+   case — see the env vars below.
+3. To stretch (or, at `0`, disable) the absolute ceiling for one run:
+   `TCL_LSP_VSCODE_TEST_EXIT_TIMEOUT_MS=<ms>`. To stretch (or disable) just
+   the no-progress window: `TCL_LSP_VSCODE_TEST_NO_PROGRESS_TIMEOUT_MS=<ms>`.
+   Both are base values — they are still scaled by measured machine load
+   the same way every other wait in the suite is (see
+   `editors/vscode/src/test/signal.ts`).
+
+## Related
+
+- [KCS index](README.md)
+- [Glossary](../GLOSSARY.md)
+- [a VS Code test timed out draining `didOpen`](kcs-issue-vscode-test-timed-out-on-didopen.md)
+  — a different, per-test wait timeout with its own three-way verdict.

--- a/docs/kcs/kcs-issue-vscode-test-timed-out-on-didopen.md
+++ b/docs/kcs/kcs-issue-vscode-test-timed-out-on-didopen.md
@@ -1,0 +1,61 @@
+# KCS: a VS Code test timed out waiting for the server to drain didOpen
+
+> **Audience:** Contributor
+> **Type:** Issue
+
+## Applies to
+
+VS Code
+
+## Question
+
+A VS Code extension test failed with `timed out awaiting the server to drain
+didOpen`, and you want to know whether the server was wedged, one document was
+wedged, or the machine was simply slow.
+
+## Symptoms
+
+- One or more tests fail with a `VSCODE-WAIT-TIMEOUT` message naming
+  `the server to drain didOpen for <file> (flush hover 1 of 2)`.
+- The message says the machine looked healthy: `PROBE: could not confirm
+  starvation`.
+- Often several consecutive tests on the *same* fixture fail and the rest of
+  the suite is unaffected.
+
+## Answer
+
+Read the `LIVENESS:` line that follows the probe note. The wait asks three
+independent questions before it gives up, and the verdict names which of them
+answered:
+
+1. **`SERVER WEDGED`** — the server did not answer even a request that touches
+   no document. The fault is the server process or the connection, not the
+   test. Look for a panic or a deadlock in the server log; the stuck test is a
+   symptom, not the cause.
+2. **`DOCUMENT PIPELINE WEDGED`** — the server answers a document-free request
+   but no document request at all. Document intake is stuck for every document,
+   so suspect the shared intake path rather than anything the failing test did.
+3. **`THIS DOCUMENT'S QUEUE WEDGED`** — another document answers and this one
+   still does not. The stall is specific to this document — the hypothesis
+   [issue #1294](https://github.com/bitwisecook/tcl-lsp/issues/1294) was filed
+   to test. A run that reports this verdict is the evidence that ticket asked
+   for; attach the whole failure block to it.
+4. **`REQUEST DROPPED, NOT WEDGED`** — a retry of the same request on the same
+   document answered. The queue is draining and the original request was lost
+   or merely slower than its budget, so treat it as a latency problem, not a
+   hang.
+
+Each line below the verdict reports how long that question took, so a verdict
+of "answered after 3900ms" on a 4000ms budget reads as a slow machine rather
+than a healthy one, even when the starvation probe cannot confirm it.
+
+If the verdict is missing entirely, the failing wait is not one that carries a
+liveness probe. Add one at the call site with
+`serverLivenessDiagnostic(docUri)` (`editors/vscode/src/test/helper.ts`), which
+is the `diagnose` hook `bounded` accepts.
+
+## Related
+
+- [KCS index](../README.md)
+- [Glossary](../../GLOSSARY.md)
+- [kcs-issue-lsp-features-are-missing.md](kcs-issue-lsp-features-are-missing.md)

--- a/docs/kcs/kcs-issue-vscode-test-timed-out-on-didopen.md
+++ b/docs/kcs/kcs-issue-vscode-test-timed-out-on-didopen.md
@@ -56,6 +56,6 @@ is the `diagnose` hook `bounded` accepts.
 
 ## Related
 
-- [KCS index](../README.md)
-- [Glossary](../../GLOSSARY.md)
+- [KCS index](README.md)
+- [Glossary](../GLOSSARY.md)
 - [kcs-issue-lsp-features-are-missing.md](kcs-issue-lsp-features-are-missing.md)

--- a/editors/vscode/src/test/commandExecution.test.ts
+++ b/editors/vscode/src/test/commandExecution.test.ts
@@ -28,7 +28,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
-import { activate, getDocUri } from "./helper";
+import { activate, getDocUri, scaledTimeout } from "./helper";
 
 interface TclLspApi {
   getClient(): LanguageClient;
@@ -51,7 +51,7 @@ suite("LSP Command Execution", () => {
   const docUri = getDocUri("simple.tcl");
 
   suiteSetup(async function () {
-    this.timeout(60_000);
+    this.timeout(scaledTimeout(60_000));
     await activate(docUri);
   });
 
@@ -99,7 +99,7 @@ suite("LSP Command Execution", () => {
   // -- minifyDocument semantic guarantees (issues #1192-#1194, #1197) ----------
 
   test("minifyDocument preserves switch # arms, proc names, and array keys", async function () {
-    this.timeout(30_000);
+    this.timeout(scaledTimeout(30_000));
     const semUri = getDocUri("minifySemantics.tcl");
     await activate(semUri);
     // Default tier: `#` inside a braced switch case list is a PATTERN (the

--- a/editors/vscode/src/test/commands.test.ts
+++ b/editors/vscode/src/test/commands.test.ts
@@ -18,7 +18,7 @@
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { activate, getDocUri } from "./helper";
+import { activate, getDocUri, scaledTimeout } from "./helper";
 
 suite("Command Registration", () => {
   const allCommands = [
@@ -62,7 +62,7 @@ suite("Command Registration", () => {
   let registeredCommands: string[];
 
   suiteSetup(async function () {
-    this.timeout(60_000);
+    this.timeout(scaledTimeout(60_000));
     // Ensure the extension is activated before querying commands.
     await activate(getDocUri("simple.tcl"));
     registeredCommands = await vscode.commands.getCommands(true);

--- a/editors/vscode/src/test/configSettings.test.ts
+++ b/editors/vscode/src/test/configSettings.test.ts
@@ -30,6 +30,7 @@ import {
   waitForEffectiveConfig,
   waitForFeatureToggle,
   waitForMasterOffDiagnostics,
+  waitForProviderResult,
   setTestContent,
 } from "./helper";
 
@@ -1026,58 +1027,73 @@ suite("Configuration Settings", () => {
     );
   });
 
+  /** Length of a selection range's parent chain — the depth our AST-aware
+   *  provider contributes and VS Code's fallback does not. */
+  const chainDepth = (ranges: readonly vscode.SelectionRange[] | undefined): number => {
+    let depth = 0;
+    let range: vscode.SelectionRange | undefined = ranges?.[0];
+    while (range) {
+      depth++;
+      range = range.parent;
+    }
+    return depth;
+  };
+
+  const selectionRangesAt = async (
+    docUri: vscode.Uri,
+    pos: vscode.Position,
+  ): Promise<vscode.SelectionRange[]> =>
+    ((await vscode.commands.executeCommand("vscode.executeSelectionRangeProvider", docUri, [
+      pos,
+    ])) as vscode.SelectionRange[] | undefined) ?? [];
+
   test("disabling features.selectionRange removes LSP selection ranges", async () => {
     const docUri = getDocUri("procs.tcl");
     await activate(docUri);
     const pos = new vscode.Position(3, 8);
 
     // Baseline: our LSP provides nested selection ranges (proc body → proc → file)
-    const before = (await pollUntil(
-      () => vscode.commands.executeCommand("vscode.executeSelectionRangeProvider", docUri, [pos]),
-      (r) => Array.isArray(r) && r.length > 0,
+    const before = await waitForProviderResult(
+      docUri,
+      () => selectionRangesAt(docUri, pos),
+      (r) => r.length > 0,
       { timeout: 10_000, label: "selection ranges before disable (feature)" },
-    )) as vscode.SelectionRange[];
-    assert.ok(before && before.length > 0, "Selection ranges should work by default");
-    // Our provider returns deeply nested ranges (parent chain)
-    const depthBefore = (() => {
-      let d = 0;
-      let r: vscode.SelectionRange | undefined = before[0];
-      while (r) {
-        d++;
-        r = r.parent;
-      }
-      return d;
-    })();
+    );
+    assert.ok(before.length > 0, "Selection ranges should work by default");
+    const depthBefore = chainDepth(before);
 
     const config = vscode.workspace.getConfiguration("tclLsp.features");
     try {
       await config.update("selectionRange", false, undefined);
       await waitForFeatureToggle(docUri, "selectionRange", false);
 
-      const after = (await vscode.commands.executeCommand(
-        "vscode.executeSelectionRangeProvider",
+      // Wait on the *result*, not on a single sample of it.  The toggle
+      // barrier above says the server's effective config has moved; it does
+      // not say a request issued now has been answered under the new config,
+      // and there is no event that announces that transition.  Sampling once
+      // is what made this test fail with the depth unchanged (issue #1295) —
+      // and because the wait rejects rather than resolving, a feature toggle
+      // that genuinely never takes effect fails here loudly and
+      // deterministically instead of passing whenever the sample happens to
+      // land late.  VS Code's own word/bracket fallback may still answer, so
+      // the assertion is on the depth collapsing, not on an empty result.
+      const after = await waitForProviderResult(
         docUri,
-        [pos],
-      )) as vscode.SelectionRange[];
-      // VS Code may still provide basic selection ranges, but our deeply
-      // nested AST-aware ranges should be gone or much shallower.
-      if (after && after.length > 0) {
-        const depthAfter = (() => {
-          let d = 0;
-          let r: vscode.SelectionRange | undefined = after[0];
-          while (r) {
-            d++;
-            r = r.parent;
-          }
-          return d;
-        })();
-        assert.ok(
-          depthAfter < depthBefore,
-          `Selection range depth should decrease when disabled (before=${depthBefore}, after=${depthAfter})`,
-        );
-      }
+        () => selectionRangesAt(docUri, pos),
+        (r) => chainDepth(r) < depthBefore,
+        {
+          timeout: 10_000,
+          label: `selection range depth to drop below ${depthBefore} after disabling the feature`,
+          describe: (r) => `depth ${chainDepth(r)} (${r?.length ?? 0} range(s))`,
+        },
+      );
+      assert.ok(
+        chainDepth(after) < depthBefore,
+        `Selection range depth should decrease when disabled (before=${depthBefore}, after=${chainDepth(after)})`,
+      );
     } finally {
       await config.update("selectionRange", undefined, undefined);
+      await waitForFeatureToggle(docUri, "selectionRange", true);
     }
   });
 

--- a/editors/vscode/src/test/extensionActivation.test.ts
+++ b/editors/vscode/src/test/extensionActivation.test.ts
@@ -19,7 +19,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
-import { activate, getDocUri } from "./helper";
+import { activate, getDocUri, scaledTimeout } from "./helper";
 
 interface TclLspApi {
   getClient(): LanguageClient;
@@ -29,7 +29,7 @@ suite("Extension Activation", () => {
   let ext: vscode.Extension<TclLspApi>;
 
   suiteSetup(async function () {
-    this.timeout(60_000);
+    this.timeout(scaledTimeout(60_000));
     ext = vscode.extensions.getExtension("bitwisecook.tcl-lsp")!;
     assert.ok(ext, "Extension should be installed");
     if (!ext.isActive) {

--- a/editors/vscode/src/test/helper.ts
+++ b/editors/vscode/src/test/helper.ts
@@ -19,7 +19,13 @@
 import * as vscode from "vscode";
 import * as path from "path";
 
-import { awaitSignal, bounded, scaledTimeout, WAIT_TIMEOUT_MARKER } from "./signal";
+import {
+  awaitSignal,
+  bounded,
+  scaledTimeout,
+  WAIT_TIMEOUT_MARKER,
+  type TimeoutDiagnostic,
+} from "./signal";
 
 export { awaitSignal, bounded, loadFactor, scaledTimeout, sleep } from "./signal";
 
@@ -569,11 +575,164 @@ export async function activate(docUri: vscode.Uri): Promise<vscode.TextDocument>
       `the server to drain didOpen for ${docUri.toString()} ` +
         `(flush hover ${attempt} of 2)\n  a timeout here means the server accepted the ` +
         `document but never answered a request queued behind it`,
-      { timeout: 30_000 },
+      { timeout: 30_000, diagnose: serverLivenessDiagnostic(docUri) },
     );
   }
 
   return doc;
+}
+
+/** Fixture the liveness probe asks about — a document no test drives, so a
+ *  hover on it can never be queued behind another test's edits. */
+const LIVENESS_PROBE_FIXTURE = "livenessProbe.tcl";
+
+/** Per-question ceiling inside [`serverLivenessDiagnostic`]. Short by design:
+ *  the caller has already waited its whole budget, so a question that has not
+ *  answered in this long has answered "no". */
+const LIVENESS_PROBE_BUDGET_MS = 4_000;
+
+/** How one liveness question went. */
+export interface ProbeOutcome {
+  answered: boolean;
+  afterMs: number;
+  /** Why it failed, when it failed by throwing rather than by timing out. */
+  detail?: string;
+}
+
+/** The three independent questions [`serverLivenessDiagnostic`] asks. */
+export interface LivenessOutcomes {
+  /** A request that touches no document at all. */
+  transport: ProbeOutcome;
+  /** The same kind of request, on a document no test drives. */
+  otherDocument: ProbeOutcome;
+  /** The stalled document's own request, tried once more. */
+  retry: ProbeOutcome;
+}
+
+/**
+ * Turn three probe outcomes into the verdict — kept separate from the asking so
+ * the classification is a pure function with no server, no timing and no VS
+ * Code behind it, and can therefore be pinned by tests for every branch.
+ *
+ * Ordered most-general fault first: a server that answers nothing subsumes a
+ * pipeline that answers nothing, which subsumes one document being stuck.
+ */
+export function classifyLiveness(outcomes: LivenessOutcomes): string {
+  if (!outcomes.transport.answered) {
+    return (
+      "SERVER WEDGED — the server did not even answer a request that touches no document, " +
+      "so the fault is the server (or the connection), not this document."
+    );
+  }
+  if (!outcomes.otherDocument.answered) {
+    return (
+      "DOCUMENT PIPELINE WEDGED — the server answers a document-free request but no " +
+      "document hover, so intake is stuck for every document, not just this one."
+    );
+  }
+  if (outcomes.retry.answered) {
+    return (
+      "REQUEST DROPPED, NOT WEDGED — a retry of the same request on the same document " +
+      "answered, so the queue is draining and the original request was lost or merely " +
+      "slower than its budget."
+    );
+  }
+  return (
+    "THIS DOCUMENT'S QUEUE WEDGED — another document answers but this one still does " +
+    "not, so the stall is specific to this document (issue #1294's hypothesis)."
+  );
+}
+
+/**
+ * Ask one question with a hard, short bound, reporting how it went rather than
+ * throwing. Never rejects — this runs on an already-failing path.
+ */
+async function probeOutcome(
+  work: () => Thenable<unknown>,
+  budgetMs: number,
+): Promise<ProbeOutcome> {
+  const started = Date.now();
+  try {
+    const answered = await Promise.race([
+      Promise.resolve(work()).then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), budgetMs).unref()),
+    ]);
+    return { answered, afterMs: Date.now() - started };
+  } catch (err) {
+    return {
+      answered: false,
+      afterMs: Date.now() - started,
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Separate "the server is wedged" from "this document's queue is wedged" after
+ * a wait on *stalledUri* has already expired.
+ *
+ * This is the gap issue #1294 records. Four consecutive waits on one fixture's
+ * ``didOpen`` drain expired with the machine measurably healthy, and the
+ * evidence could say only that the request never came back — not whether the
+ * server was answering *anything*. Three cheap questions separate the cases:
+ *
+ * 1. ``getEffectiveConfig`` for the stalled document — a request that touches
+ *    neither the analyser nor the document's work queue, so it answers whenever
+ *    the client → server → client path itself is alive.
+ * 2. A hover on a **different** document, which no test drives. Answering means
+ *    the document pipeline as a whole is draining, so whatever is stuck is
+ *    specific to *this* document.
+ * 3. A retry of the same request on the stalled document, which distinguishes a
+ *    permanently wedged queue from a request that was simply dropped.
+ *
+ * Every question is separately bounded and none may throw: the test is already
+ * failing, and a diagnostic that hangs turns an attributable failure into an
+ * unattributable one.
+ */
+export function serverLivenessDiagnostic(stalledUri: vscode.Uri): TimeoutDiagnostic {
+  return async () => {
+    const budget = scaledTimeout(LIVENESS_PROBE_BUDGET_MS);
+    const other = getDocUri(LIVENESS_PROBE_FIXTURE);
+    // Asked concurrently: the three questions are independent, and running
+    // them in series would make the whole diagnostic cost three budgets — which
+    // on a loaded machine is long enough for `bounded`'s own cap to truncate
+    // the answer, exactly when the answer is most wanted.
+    const [transport, otherDoc, retry] = await Promise.all([
+      probeOutcome(
+        () => vscode.commands.executeCommand("tcl-lsp.getEffectiveConfig", stalledUri.toString()),
+        budget,
+      ),
+      probeOutcome(
+        () =>
+          vscode.commands.executeCommand(
+            "vscode.executeHoverProvider",
+            other,
+            new vscode.Position(0, 0),
+          ),
+        budget,
+      ),
+      probeOutcome(
+        () =>
+          vscode.commands.executeCommand(
+            "vscode.executeHoverProvider",
+            stalledUri,
+            new vscode.Position(0, 0),
+          ),
+        budget,
+      ),
+    ]);
+
+    const describe = (name: string, p: ProbeOutcome) =>
+      `${name} ${p.answered ? "answered" : "did NOT answer"} after ${p.afterMs}ms` +
+      (p.detail ? ` (${p.detail})` : "");
+
+    return (
+      `LIVENESS: ${classifyLiveness({ transport, otherDocument: otherDoc, retry })}\n` +
+      `    ${describe("document-free getEffectiveConfig", transport)}\n` +
+      `    ${describe(`hover on ${LIVENESS_PROBE_FIXTURE} (a different document)`, otherDoc)}\n` +
+      `    ${describe("hover retried on the stalled document", retry)}`
+    );
+  };
 }
 
 /**

--- a/editors/vscode/src/test/index.ts
+++ b/editors/vscode/src/test/index.ts
@@ -19,9 +19,10 @@
 import * as fs from "fs";
 import * as path from "path";
 import Mocha from "mocha";
-import * as vscode from "vscode";
 import { glob } from "glob";
-import { loadFactor, scaledTimeout } from "./signal";
+import { scaledTimeout } from "./signal";
+import { createHeartbeatWriter, MOCHA_TEST_TIMEOUT_BASE_MS } from "./runnerWatchdog";
+import { probeServer } from "./serverProbe";
 
 // Register a require hook so tsc-compiled output can load .md files at runtime.
 // (In production the esbuild bundle uses --loader:.md=text to inline them.)
@@ -29,83 +30,11 @@ require.extensions[".md"] = (mod: NodeJS.Module, filename: string) => {
   (mod as NodeJS.Module & { exports: unknown }).exports = fs.readFileSync(filename, "utf8");
 };
 
-/**
- * What the heartbeat file records, so a hang is attributable from outside the
- * extension host.
- *
- * The runner's launch-exit budget used to expire with nothing to say but a
- * process list and "mocha never completed (likely hung)" — which names neither
- * the test that stalled nor whether the server was still alive (issue #1274).
- * The extension host is the only place that knows both, so it writes them down
- * continuously and `runTest.ts` reads the last entry after the fact.
- */
-interface Heartbeat {
-  /** When this heartbeat was written (ms since epoch). Its *age* at read time
-   *  is the evidence: a stale heartbeat means the extension host's event loop
-   *  itself stopped turning, which is a different fault from a test stuck in a
-   *  wait. */
-  at: number;
-  /** Tests currently between `test` and `test end` — normally exactly one. */
-  inFlight: Array<{ title: string; forMs: number }>;
-  completed: number;
-  failed: number;
-  /** Round-trip to the language server, taken only once a test has been in
-   *  flight long enough to be suspicious. `null` until then. */
-  server:
-    | null
-    | { responsive: true; roundTripMs: number }
-    | { responsive: false; reason: string; afterMs: number };
-  /** Measured machine load at the time of writing — the difference between "the
-   *  suite is wedged" and "the container is oversubscribed". */
-  loadFactor: number;
-}
-
-/** How often the heartbeat is refreshed. */
-const HEARTBEAT_INTERVAL_MS = 2_000;
-
-/** How long a single test may run before the heartbeat starts probing the
- *  server on every tick. Below this a slow test is just a slow test. */
-const SERVER_PROBE_AFTER_MS = 20_000;
-
-/** Bound on the server probe itself, so the heartbeat can never become the
- *  thing that hangs. */
-const SERVER_PROBE_TIMEOUT_MS = 5_000;
-
-/**
- * Ask the language server a question that touches neither the document store
- * nor the analyser, so what it times is the client → server → client path
- * itself. Mirrors the native harness's `LatencyBudget` no-op probe.
- */
-async function probeServer(): Promise<NonNullable<Heartbeat["server"]>> {
-  const started = Date.now();
-  try {
-    const answered = await Promise.race([
-      vscode.commands.executeCommand("tcl-lsp.getEffectiveConfig", "").then(() => true),
-      new Promise<false>((resolve) =>
-        setTimeout(() => resolve(false), scaledTimeout(SERVER_PROBE_TIMEOUT_MS)).unref(),
-      ),
-    ]);
-    return answered
-      ? { responsive: true, roundTripMs: Date.now() - started }
-      : {
-          responsive: false,
-          reason: "getEffectiveConfig did not answer",
-          afterMs: Date.now() - started,
-        };
-  } catch (err) {
-    return {
-      responsive: false,
-      reason: err instanceof Error ? err.message : String(err),
-      afterMs: Date.now() - started,
-    };
-  }
-}
-
 export async function run(): Promise<void> {
   // Written unconditionally when mocha's run() callback fires (pass or fail)
-  // so runTest.ts's exit-timeout watchdog can tell "mocha finished cleanly,
-  // the process just didn't exit" apart from "mocha never finished" (a hang).
-  // Only the latter may be swallowed as success.
+  // so runTest.ts's watchdog (runnerWatchdog.ts) can tell "mocha finished
+  // cleanly, the process just didn't exit" apart from "mocha never finished"
+  // (a hang). Only the latter may be swallowed as success.
   const resultMarker = path.resolve(__dirname, "../../", ".vscode-test", "mocha-result.json");
   const heartbeatMarker = path.resolve(__dirname, "../../", ".vscode-test", "mocha-heartbeat.json");
   const mocha = new Mocha({
@@ -115,8 +44,10 @@ export async function run(): Promise<void> {
     // bounded and load-scaled (see `signal.ts`), so a test that reaches this
     // number has stalled somewhere with no bound of its own. Scaled by measured
     // load for the same reason those waits are — the shimmer tests in #1274 hit
-    // a raw 60s each under ~9 concurrent build trees.
-    timeout: scaledTimeout(60_000),
+    // a raw 60s each under ~9 concurrent build trees. `runnerWatchdog.ts`'s
+    // no-progress window is itself derived from this same constant, so the
+    // two cannot drift out of the relationship it depends on.
+    timeout: scaledTimeout(MOCHA_TEST_TIMEOUT_BASE_MS),
   });
   if (process.env.MOCHA_GREP) {
     mocha.grep(process.env.MOCHA_GREP);
@@ -159,58 +90,11 @@ export async function run(): Promise<void> {
     mocha.addFile(path.resolve(testsRoot, f));
   }
 
-  fs.mkdirSync(path.dirname(heartbeatMarker), { recursive: true });
-  try {
-    fs.unlinkSync(heartbeatMarker);
-  } catch {
-    // No stale heartbeat to remove.
-  }
+  const heartbeatWriter = createHeartbeatWriter({ heartbeatMarker, probeServer });
 
   return new Promise<void>((resolve, reject) => {
-    const inFlight = new Map<string, number>();
-    let completed = 0;
-    let failed = 0;
-    let lastServerProbe: Heartbeat["server"] = null;
-    let probeInFlight = false;
-
-    const writeHeartbeat = () => {
-      const now = Date.now();
-      const entries = [...inFlight.entries()].map(([title, startedAt]) => ({
-        title,
-        forMs: now - startedAt,
-      }));
-      const stalled = entries.some((e) => e.forMs >= SERVER_PROBE_AFTER_MS);
-      if (stalled && !probeInFlight) {
-        probeInFlight = true;
-        void probeServer().then((result) => {
-          lastServerProbe = result;
-          probeInFlight = false;
-        });
-      } else if (!stalled) {
-        lastServerProbe = null;
-      }
-      const beat: Heartbeat = {
-        at: now,
-        inFlight: entries,
-        completed,
-        failed,
-        server: lastServerProbe,
-        loadFactor: loadFactor(),
-      };
-      try {
-        fs.writeFileSync(heartbeatMarker, JSON.stringify(beat) + "\n", "utf8");
-      } catch {
-        // The heartbeat is diagnostics only — never fail a run over it.
-      }
-    };
-
-    // Unref'd: the heartbeat must never be the reason the host stays alive
-    // after the suite finishes.
-    const heartbeat = setInterval(writeHeartbeat, HEARTBEAT_INTERVAL_MS);
-    heartbeat.unref();
-
     const runner = mocha.run((failures) => {
-      clearInterval(heartbeat);
+      heartbeatWriter.stop();
       restoreFixtureSettings();
       fs.mkdirSync(path.dirname(resultMarker), { recursive: true });
       fs.writeFileSync(resultMarker, JSON.stringify({ failures }) + "\n", "utf8");
@@ -221,18 +105,12 @@ export async function run(): Promise<void> {
       }
     });
 
-    runner.on("test", (test: Mocha.Test) => {
-      inFlight.set(test.fullTitle(), Date.now());
-      writeHeartbeat();
-    });
-    runner.on("test end", (test: Mocha.Test) => {
-      inFlight.delete(test.fullTitle());
-      completed++;
-    });
+    runner.on("test", (test: Mocha.Test) => heartbeatWriter.onTestStart(test.fullTitle()));
+    runner.on("test end", (test: Mocha.Test) => heartbeatWriter.onTestEnd(test.fullTitle()));
     // Log failure details so they are visible even when the VS Code test
     // host terminates before mocha prints its summary.
     runner.on("fail", (test: Mocha.Test, err: Error) => {
-      failed++;
+      heartbeatWriter.onFail();
       console.error(`\nFAIL: ${test.fullTitle()}`);
       console.error(`  ${err.message}`);
       if (err.stack) {

--- a/editors/vscode/src/test/issue1296MetaclassChain.test.ts
+++ b/editors/vscode/src/test/issue1296MetaclassChain.test.ts
@@ -1,0 +1,120 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Issue #1296, editor-integration layer: a class made by a cross-file
+// metaclass that was itself made by *another* file's metaclass must resolve
+// from a call site.
+//
+// The workspace class-factory index (issue #1276) is computed from a query
+// that reads the index, so one publish only advances the metaclass chain by a
+// single link. Four documents — `MetaA`, `MetaA create MetaB`,
+// `MetaB create Widget`, and a call on `Widget`'s method — need three, and
+// go-to-definition on the method came back empty. The server now drives the
+// publish to a fixpoint.
+//
+// This tier exists because the fault is *when* the answer arrives, not only
+// what it is: the index converges across several debounced publishes, and a
+// real client asks its provider whenever it likes. The deep TP/FP/TN coverage
+// lives in the salsa (`rust/tcl-lsp-db/tests/class_factory_fixpoint.rs`),
+// analyser (`rust/tcl-compiler/tests/analyser.rs`, `mod class_factories`), and
+// native e2e (`rust/tcl-lsp-server/tests/e2e/issue1296_metaclass_chain.rs`)
+// suites.
+//
+// C-Tcl ground truth (tclsh 8.6.16 and 9.0.4, identical), sourcing the four
+// fixtures in order: `info class methods ::MC::Widget` -> `go`, and
+// `puts [$w go]` -> `went`. So the definition request has a real answer.
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { activate, getDocUri, waitForProviderResult } from "./helper";
+
+/** The chain's documents, outermost metaclass first. */
+const CHAIN = ["issue1296MetaA.tcl", "issue1296MetaB.tcl", "issue1296Widget.tcl"];
+
+/** `go` in `puts [$w go]` — line 1, character 10 of the call fixture. */
+const CALL_SITE = new vscode.Position(1, 10);
+
+async function definitionsAt(
+  docUri: vscode.Uri,
+  position: vscode.Position,
+): Promise<vscode.Location[]> {
+  const result = (await vscode.commands.executeCommand(
+    "vscode.executeDefinitionProvider",
+    docUri,
+    position,
+  )) as (vscode.Location | vscode.LocationLink)[] | undefined;
+  return (result ?? []).map((item) =>
+    "targetUri" in item
+      ? new vscode.Location(item.targetUri, item.targetSelectionRange ?? item.targetRange)
+      : item,
+  );
+}
+
+suite("Issue #1296 chained cross-file metaclass", () => {
+  test("a method on a class made by a twice-removed metaclass resolves", async () => {
+    // Open every link of the chain, then the call site, so the workspace the
+    // server publishes its factory index over is the ticket's exact one.
+    for (const name of CHAIN) {
+      await activate(getDocUri(name));
+    }
+    const callUri = getDocUri("issue1296Call.tcl");
+    await activate(callUri);
+
+    // The index converges over a few debounced publishes, so wait on the
+    // *result* rather than sampling once — `waitForProviderResult` re-probes on
+    // this document's diagnostics events with a bounded backstop, and fails at
+    // its bound if the answer genuinely never arrives.
+    const found = await waitForProviderResult(
+      callUri,
+      () => definitionsAt(callUri, CALL_SITE),
+      (locations) => locations.length > 0,
+      {
+        label: "`$w go` resolving through the chained metaclass",
+        timeout: 30_000,
+        describe: (locations) => `saw ${JSON.stringify((locations ?? []).map((l) => l.uri.path))}`,
+      },
+    );
+
+    assert.strictEqual(found.length, 1, `exactly one target: ${JSON.stringify(found)}`);
+    assert.ok(
+      found[0].uri.toString().endsWith("issue1296Widget.tcl"),
+      `the target is the document that writes the class: ${found[0].uri.toString()}`,
+    );
+    assert.strictEqual(
+      found[0].range.start.line,
+      0,
+      `and the method's own line: ${JSON.stringify(found[0].range)}`,
+    );
+  });
+
+  test("a metaclass nothing proves still resolves to nothing", async () => {
+    // TN. Nothing in the workspace shows `::U::Meta` manufactures classes, so
+    // `::U::Widget` is not a class and its supposed method has no declaration.
+    // Guessing one would be worse than abstaining, and this is the assertion
+    // that stops the fixpoint being "widened" into inventing entries.
+    const docUri = getDocUri("issue1296Unproved.tcl");
+    await activate(docUri);
+
+    const found = await definitionsAt(docUri, new vscode.Position(3, 10));
+    assert.strictEqual(
+      found.length,
+      0,
+      `no file proves \`::U::Meta\` is a class factory: ${JSON.stringify(found)}`,
+    );
+  });
+});

--- a/editors/vscode/src/test/issue996.test.ts
+++ b/editors/vscode/src/test/issue996.test.ts
@@ -32,7 +32,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
-import { getDocUri, activate, waitForDiagnostics } from "./helper";
+import { getDocUri, activate, waitForDiagnostics, scaledTimeout } from "./helper";
 
 interface TclLspApi {
   getClient(): LanguageClient;
@@ -72,7 +72,7 @@ suite("Issue #996 deep nesting survival", () => {
   });
 
   test("formatting the deeply nested document returns edits, not a hang", async function () {
-    this.timeout(30_000);
+    this.timeout(scaledTimeout(30_000));
     await activate(docUri);
     const edits = (await vscode.commands.executeCommand(
       "vscode.executeFormatDocumentProvider",
@@ -83,7 +83,7 @@ suite("Issue #996 deep nesting survival", () => {
   });
 
   test("tcl-lsp.minifyDocument on the deeply nested document returns a result", async function () {
-    this.timeout(30_000);
+    this.timeout(scaledTimeout(30_000));
     await activate(docUri);
     const result = (await execLspCommand(
       "tcl-lsp.minifyDocument",

--- a/editors/vscode/src/test/multiFolder/index.ts
+++ b/editors/vscode/src/test/multiFolder/index.ts
@@ -18,15 +18,39 @@
 
 // Mocha entry point for the multi-folder workspace test suite.
 // Picks up only ``*.test.js`` files under ``out/test/multiFolder/``.
+import * as fs from "fs";
 import * as path from "path";
 import Mocha from "mocha";
 import { glob } from "glob";
+import { scaledTimeout } from "../signal";
+import { createHeartbeatWriter, MOCHA_TEST_TIMEOUT_BASE_MS } from "../runnerWatchdog";
+import { probeServer } from "../serverProbe";
 
 export async function run(): Promise<void> {
+  // Written unconditionally when mocha's run() callback fires (pass or fail),
+  // and refreshed every couple of seconds while it runs — the same contract
+  // `index.ts` gives the single-folder suite (see `runnerWatchdog.ts`). This
+  // suite used to write neither, so its own runner (`runMultiFolderTest.ts`)
+  // had no progress evidence and — worse — treated its own launch-exit
+  // timeout as success, which could silently pass a hung multi-folder run.
+  const resultMarker = path.resolve(
+    __dirname,
+    "../../../",
+    ".vscode-test",
+    "mocha-result-multifolder.json",
+  );
+  const heartbeatMarker = path.resolve(
+    __dirname,
+    "../../../",
+    ".vscode-test",
+    "mocha-heartbeat-multifolder.json",
+  );
   const mocha = new Mocha({
     ui: "tdd",
     color: true,
-    timeout: 60_000,
+    // Same backstop and provenance as the single-folder suite's — see
+    // `index.ts`'s matching comment.
+    timeout: scaledTimeout(MOCHA_TEST_TIMEOUT_BASE_MS),
   });
 
   const testsRoot = path.resolve(__dirname);
@@ -36,15 +60,24 @@ export async function run(): Promise<void> {
     mocha.addFile(path.resolve(testsRoot, f));
   }
 
+  const heartbeatWriter = createHeartbeatWriter({ heartbeatMarker, probeServer });
+
   return new Promise<void>((resolve, reject) => {
     const runner = mocha.run((failures) => {
+      heartbeatWriter.stop();
+      fs.mkdirSync(path.dirname(resultMarker), { recursive: true });
+      fs.writeFileSync(resultMarker, JSON.stringify({ failures }) + "\n", "utf8");
       if (failures > 0) {
         reject(new Error(`${failures} test(s) failed.`));
       } else {
         resolve();
       }
     });
+
+    runner.on("test", (test: Mocha.Test) => heartbeatWriter.onTestStart(test.fullTitle()));
+    runner.on("test end", (test: Mocha.Test) => heartbeatWriter.onTestEnd(test.fullTitle()));
     runner.on("fail", (test: Mocha.Test, err: Error) => {
+      heartbeatWriter.onFail();
       console.error(`\nFAIL: ${test.fullTitle()}`);
       console.error(`  ${err.message}`);
       if (err.stack) {

--- a/editors/vscode/src/test/progressiveDiagnostics.test.ts
+++ b/editors/vscode/src/test/progressiveDiagnostics.test.ts
@@ -19,7 +19,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import * as fs from "fs";
-import { getDocUri, activate, waitForDiagnostics } from "./helper";
+import { getDocUri, activate, waitForDiagnostics, scaledTimeout } from "./helper";
 
 // Issue #844: diagnostics are progressive. On a large document the server
 // publishes a workspace-independent *fast tier* (the analyser's syntax /
@@ -73,7 +73,16 @@ suite("Progressive diagnostics (#844)", () => {
   });
 
   test("a large file surfaces the complete deep tier, fast tier first", async function () {
-    this.timeout(60_000);
+    // A per-test backstop must outlast the sum of the bounded waits inside the
+    // test, or it fires first and reports "Timeout of Nms exceeded" — naming
+    // neither the wait that was outstanding nor why, which is the failure shape
+    // issue #1274 set out to remove. This test's waits are `activate` (up to
+    // 60s for a cold LSP handshake, plus its two 30s didOpen drains) followed
+    // by the 50s deep-tier wait below, so 60s could not cover them even on an
+    // idle machine. Load-scaled for the same reason every other bound here is:
+    // it used to be a raw `60_000`, and a loaded container turned a correct run
+    // into an unattributable timeout.
+    this.timeout(scaledTimeout(150_000));
 
     // Capture the sequence of diagnostic publishes for this URI. Registered
     // before `activate` (which sends `didOpen`) so no publish is missed — a

--- a/editors/vscode/src/test/progressiveDiagnostics.test.ts
+++ b/editors/vscode/src/test/progressiveDiagnostics.test.ts
@@ -20,6 +20,7 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import * as fs from "fs";
 import { getDocUri, activate, waitForDiagnostics, scaledTimeout } from "./helper";
+import { MAX_TEST_TIMEOUT_BASE_MS } from "./runnerWatchdog";
 
 // Issue #844: diagnostics are progressive. On a large document the server
 // publishes a workspace-independent *fast tier* (the analyser's syntax /
@@ -82,7 +83,7 @@ suite("Progressive diagnostics (#844)", () => {
     // idle machine. Load-scaled for the same reason every other bound here is:
     // it used to be a raw `60_000`, and a loaded container turned a correct run
     // into an unattributable timeout.
-    this.timeout(scaledTimeout(150_000));
+    this.timeout(scaledTimeout(MAX_TEST_TIMEOUT_BASE_MS));
 
     // Capture the sequence of diagnostic publishes for this URI. Registered
     // before `activate` (which sends `didOpen`) so no publish is missed — a

--- a/editors/vscode/src/test/runMultiFolderTest.ts
+++ b/editors/vscode/src/test/runMultiFolderTest.ts
@@ -20,40 +20,26 @@
 // per-folder configuration tests can verify VS Code accepts and applies
 // folder-level tclLsp.* settings (issue #230).
 import * as path from "path";
-import { execSync } from "child_process";
-import { runTests } from "@vscode/test-electron";
-
-const DEFAULT_EXIT_TIMEOUT_MS = 180_000;
-
-function parseExitTimeoutMs(): number {
-  const raw = process.env.TCL_LSP_VSCODE_TEST_EXIT_TIMEOUT_MS;
-  if (!raw) return DEFAULT_EXIT_TIMEOUT_MS;
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_EXIT_TIMEOUT_MS;
-  return Math.floor(parsed);
-}
-
-function escapeSingleQuotes(text: string): string {
-  return text.split("'").join("'\"'\"'");
-}
-
-function cleanupStaleTestHosts(extensionDevelopmentPath: string, extensionTestsPath: string): void {
-  try {
-    const escapedDevPath = escapeSingleQuotes(extensionDevelopmentPath);
-    const escapedTestsPath = escapeSingleQuotes(extensionTestsPath);
-    execSync(
-      `pkill -f 'extensionDevelopmentPath=${escapedDevPath}' || true; pkill -f 'extensionTestsPath=${escapedTestsPath}' || true`,
-      { stdio: "ignore" },
-    );
-  } catch {
-    /* best-effort */
-  }
-}
+import * as fs from "fs";
+import { runWatchedSuite } from "./runnerWatchdog";
 
 async function main() {
   const extensionDevelopmentPath = path.resolve(__dirname, "../../");
   const extensionTestsPath = path.resolve(__dirname, "./multiFolder/index");
-  cleanupStaleTestHosts(extensionDevelopmentPath, extensionTestsPath);
+  // multiFolder/index.ts writes these the same way index.ts does for the
+  // single-folder suite (see runnerWatchdog.ts's createHeartbeatWriter) —
+  // distinct filenames so a full `make test-ext` run (both suites,
+  // sequentially) never has one runner's markers mistaken for the other's.
+  const resultMarker = path.resolve(
+    extensionDevelopmentPath,
+    ".vscode-test",
+    "mocha-result-multifolder.json",
+  );
+  const heartbeatMarker = path.resolve(
+    extensionDevelopmentPath,
+    ".vscode-test",
+    "mocha-heartbeat-multifolder.json",
+  );
 
   // Open the multi-root .code-workspace fixture so VS Code is in
   // multi-folder mode and folder-level .vscode/settings.json files are
@@ -68,9 +54,8 @@ async function main() {
   const userDataDir = path.resolve(extensionDevelopmentPath, ".vscode-test", "user-data");
   const userSettingsFile = path.resolve(userDataDir, "User", "settings.json");
   try {
-    const { writeFileSync, mkdirSync } = require("fs");
-    mkdirSync(path.dirname(userSettingsFile), { recursive: true });
-    writeFileSync(userSettingsFile, "{}\n", "utf8");
+    fs.mkdirSync(path.dirname(userSettingsFile), { recursive: true });
+    fs.writeFileSync(userSettingsFile, "{}\n", "utf8");
   } catch {
     /* best-effort */
   }
@@ -82,7 +67,6 @@ async function main() {
   // (issue #407), ``tclLsp.style.nonAscii``, and ``tclLsp.diagnostics.W111``
   // values to exercise the per-folder resolution path.
   try {
-    const { writeFileSync, mkdirSync } = require("fs");
     const projA = path.resolve(
       extensionDevelopmentPath,
       "testFixtureMultiFolder",
@@ -95,9 +79,9 @@ async function main() {
       "proj-b",
       ".vscode",
     );
-    mkdirSync(projA, { recursive: true });
-    mkdirSync(projB, { recursive: true });
-    writeFileSync(
+    fs.mkdirSync(projA, { recursive: true });
+    fs.mkdirSync(projB, { recursive: true });
+    fs.writeFileSync(
       path.resolve(projA, "settings.json"),
       JSON.stringify(
         {
@@ -113,7 +97,7 @@ async function main() {
       ) + "\n",
       "utf8",
     );
-    writeFileSync(
+    fs.writeFileSync(
       path.resolve(projB, "settings.json"),
       JSON.stringify(
         {
@@ -136,7 +120,7 @@ async function main() {
     // reads the seed text.
     for (const folder of ["proj-a", "proj-b"]) {
       for (const name of ["extra.tcl", "race.tcl"]) {
-        writeFileSync(
+        fs.writeFileSync(
           path.resolve(extensionDevelopmentPath, "testFixtureMultiFolder", folder, name),
           "# placeholder — each test replaces this through the editor\n",
           "utf8",
@@ -147,37 +131,13 @@ async function main() {
     /* best-effort */
   }
 
-  const timeoutMs = parseExitTimeoutMs();
-  try {
-    const runPromise = runTests({
-      extensionDevelopmentPath,
-      extensionTestsPath,
-      launchArgs: [codeWorkspace, "--disable-extensions"],
-    });
-
-    if (timeoutMs <= 0) {
-      await runPromise;
-      return;
-    }
-
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      setTimeout(() => {
-        reject(new Error(`VS Code test runner did not exit within ${timeoutMs}ms after launch.`));
-      }, timeoutMs).unref();
-    });
-
-    await Promise.race([runPromise, timeoutPromise]);
-    cleanupStaleTestHosts(extensionDevelopmentPath, extensionTestsPath);
-    process.exit(0);
-  } catch (err) {
-    cleanupStaleTestHosts(extensionDevelopmentPath, extensionTestsPath);
-    if (err instanceof Error && err.message.includes("did not exit within")) {
-      console.warn("Multi-folder VS Code tests completed but runner did not exit; continuing.");
-      process.exit(0);
-    }
-    console.error("Failed to run multi-folder tests:", err);
-    process.exit(1);
-  }
+  await runWatchedSuite({
+    extensionDevelopmentPath,
+    extensionTestsPath,
+    launchArgs: [codeWorkspace, "--disable-extensions"],
+    heartbeatMarker,
+    resultMarker,
+  });
 }
 
 main();

--- a/editors/vscode/src/test/runTest.ts
+++ b/editors/vscode/src/test/runTest.ts
@@ -20,161 +20,24 @@ import * as path from "path";
 import * as fs from "fs";
 import * as os from "os";
 import * as crypto from "crypto";
-import { execSync } from "child_process";
-import { runTests } from "@vscode/test-electron";
-import { loadFactor, scaledTimeout } from "./signal";
-
-const DEFAULT_EXIT_TIMEOUT_MS = 180_000;
-
-/** Mirror of the `Heartbeat` the extension host writes in `index.ts`. */
-interface Heartbeat {
-  at: number;
-  inFlight: Array<{ title: string; forMs: number }>;
-  completed: number;
-  failed: number;
-  server:
-    | null
-    | { responsive: true; roundTripMs: number }
-    | { responsive: false; reason: string; afterMs: number };
-  loadFactor: number;
-}
-
-/**
- * Turn "mocha never completed" into an attributable report: which tests were in
- * flight, for how long, whether the language server was still answering, and
- * whether the extension host's own event loop was still turning.
- *
- * Without this the launch-exit budget expiring printed a process list and a
- * guess, which is what made issue #1274 need re-run archaeology rather than
- * reading a log.
- */
-function reportHang(heartbeatMarker: string): void {
-  let beat: Heartbeat;
-  try {
-    beat = JSON.parse(fs.readFileSync(heartbeatMarker, "utf8"));
-  } catch {
-    console.error(
-      "No heartbeat was ever written, so the suite hung before or during its first test " +
-        "(extension host failed to start, or `run()` never reached mocha.run).",
-    );
-    return;
-  }
-
-  const age = Date.now() - beat.at;
-  console.error("--- hang report (from the extension host's heartbeat) ---");
-  console.error(
-    `  heartbeat written ${age}ms ago; ${beat.completed} test(s) completed, ` +
-      `${beat.failed} failed; measured load factor ${beat.loadFactor.toFixed(1)}`,
-  );
-  if (beat.inFlight.length === 0) {
-    console.error(
-      "  no test was in flight — mocha had finished the last test but the run() " +
-        "callback never fired, or a root-level hook is stuck.",
-    );
-  } else {
-    for (const t of beat.inFlight) {
-      console.error(`  IN FLIGHT for ${t.forMs}ms: ${t.title}`);
-    }
-  }
-  if (beat.server === null) {
-    console.error(
-      "  server: not probed — no test had been in flight long enough to be suspicious " +
-        "when this heartbeat was written.",
-    );
-  } else if (beat.server.responsive) {
-    console.error(
-      `  server: RESPONSIVE (${beat.server.roundTripMs}ms round trip), so the stall is in ` +
-        "the test or the extension host, not a wedged server.",
-    );
-  } else {
-    console.error(
-      `  server: NOT RESPONDING after ${beat.server.afterMs}ms (${beat.server.reason}) — ` +
-        "the language server stopped answering, so suspect the server, not the test.",
-    );
-  }
-  if (age > 3 * 2_000) {
-    console.error(
-      `  the heartbeat itself is ${age}ms stale (it refreshes every 2000ms), so the ` +
-        "extension host's event loop stopped turning — a blocked main thread or a " +
-        "crashed host, not a test waiting on a promise.",
-    );
-  }
-  console.error("--- end hang report ---");
-}
-
-function parseExitTimeoutMs(): number {
-  const raw = process.env.TCL_LSP_VSCODE_TEST_EXIT_TIMEOUT_MS;
-  if (!raw) {
-    return DEFAULT_EXIT_TIMEOUT_MS;
-  }
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    return DEFAULT_EXIT_TIMEOUT_MS;
-  }
-  return Math.floor(parsed);
-}
-
-function escapeDoubleQuotes(text: string): string {
-  return text.split('"').join('\\"');
-}
-
-function escapeSingleQuotes(text: string): string {
-  return text.split("'").join("'\"'\"'");
-}
-
-function emitProcessSnapshot(extensionDevelopmentPath: string, extensionTestsPath: string): void {
-  try {
-    const escapedDevPath = escapeDoubleQuotes(extensionDevelopmentPath);
-    const escapedTestsPath = escapeDoubleQuotes(extensionTestsPath);
-    const pattern = `extensionDevelopmentPath=${escapedDevPath}|extensionTestsPath=${escapedTestsPath}|node ./out/test/runTest.js`;
-    const cmd = `ps -axo pid,ppid,etime,command | grep -E "${pattern}"`;
-    const output = execSync(cmd, { encoding: "utf8" });
-    if (output.trim()) {
-      console.error("Potentially stuck VS Code test processes:");
-      console.error(output.trimEnd());
-    }
-  } catch {
-    // Snapshot is best-effort only.
-  }
-}
-
-function cleanupStaleTestHosts(extensionDevelopmentPath: string, extensionTestsPath: string): void {
-  try {
-    const escapedDevPath = escapeSingleQuotes(extensionDevelopmentPath);
-    const escapedTestsPath = escapeSingleQuotes(extensionTestsPath);
-    execSync(
-      `pkill -f 'extensionDevelopmentPath=${escapedDevPath}' || true; pkill -f 'extensionTestsPath=${escapedTestsPath}' || true`,
-      { stdio: "ignore" },
-    );
-  } catch {
-    // Cleanup is best-effort only.
-  }
-}
+import { runWatchedSuite } from "./runnerWatchdog";
 
 async function main() {
   const extensionDevelopmentPath = path.resolve(__dirname, "../../");
   const extensionTestsPath = path.resolve(__dirname, "./index");
   // index.ts writes this unconditionally when mocha's run() callback fires,
-  // pass or fail — its *absence* after the exit-timeout watchdog fires below
-  // means mocha never finished at all (a hang), which is never safe to treat
-  // as success.
+  // pass or fail — its *absence* after the watchdog gives up (see
+  // runnerWatchdog.ts) means mocha never finished at all (a hang), which is
+  // never safe to treat as success.
   const resultMarker = path.resolve(extensionDevelopmentPath, ".vscode-test", "mocha-result.json");
   // index.ts refreshes this every couple of seconds with the in-flight tests and
-  // a server-liveness probe, so an expiring exit budget below can say *what* was
-  // stuck rather than only that something was.
+  // a server-liveness probe, so the watchdog can say *what* was stuck (or that
+  // nothing was) rather than only that something was.
   const heartbeatMarker = path.resolve(
     extensionDevelopmentPath,
     ".vscode-test",
     "mocha-heartbeat.json",
   );
-  cleanupStaleTestHosts(extensionDevelopmentPath, extensionTestsPath);
-  for (const marker of [resultMarker, heartbeatMarker]) {
-    try {
-      fs.unlinkSync(marker);
-    } catch {
-      // No stale marker to remove.
-    }
-  }
 
   // The user-data dir's IPC lock file is a Unix domain socket
   // (`<dir>/<version>-main.sock`), whose path is capped at ~107 bytes by
@@ -201,91 +64,26 @@ async function main() {
   // subsequent runs.
   const userSettingsFile = path.resolve(userDataDir, "User", "settings.json");
   try {
-    const { writeFileSync, mkdirSync } = require("fs");
-    mkdirSync(path.dirname(userSettingsFile), { recursive: true });
-    writeFileSync(userSettingsFile, "{}\n", "utf8");
+    fs.mkdirSync(path.dirname(userSettingsFile), { recursive: true });
+    fs.writeFileSync(userSettingsFile, "{}\n", "utf8");
   } catch {
     // Best-effort; if we can't clear it the tests may see stale config.
   }
 
-  try {
-    // The workspace to open during tests
-    const testWorkspace = path.resolve(extensionDevelopmentPath, "testFixture");
+  // The workspace to open during tests
+  const testWorkspace = path.resolve(extensionDevelopmentPath, "testFixture");
 
-    // The launch-exit budget is a hang backstop, so it is scaled by measured
-    // machine load for the same reason every wait inside the suite is: on a
-    // container sharing itself with several build trees, a correct run is
-    // simply slower, and killing it manufactures a failure. See signal.ts.
-    const baseTimeoutMs = parseExitTimeoutMs();
-    const timeoutMs = scaledTimeout(baseTimeoutMs);
-    if (timeoutMs !== baseTimeoutMs) {
-      console.log(
-        `==> launch-exit budget ${timeoutMs}ms (base ${baseTimeoutMs}ms x measured load ` +
-          `factor ${loadFactor().toFixed(1)})`,
-      );
-    }
-    const runPromise = runTests({
-      extensionDevelopmentPath,
-      extensionTestsPath,
-      launchArgs: [
-        testWorkspace,
-        "--disable-extensions", // Disable other extensions
-        `--user-data-dir=${userDataDir}`,
-      ],
-    });
-
-    if (timeoutMs <= 0) {
-      await runPromise;
-      return;
-    }
-
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      setTimeout(() => {
-        reject(new Error(`VS Code test runner did not exit within ${timeoutMs}ms after launch.`));
-      }, timeoutMs).unref();
-    });
-
-    await Promise.race([runPromise, timeoutPromise]);
-    cleanupStaleTestHosts(extensionDevelopmentPath, extensionTestsPath);
-    process.exit(0);
-  } catch (err) {
-    const timedOut = err instanceof Error && err.message.includes("did not exit within");
-    if (timedOut) {
-      // Read the heartbeat *before* the cleanup below kills the host that
-      // writes it, so the age reported is the age at the moment of giving up.
-      reportHang(heartbeatMarker);
-    }
-    emitProcessSnapshot(extensionDevelopmentPath, extensionTestsPath);
-    cleanupStaleTestHosts(extensionDevelopmentPath, extensionTestsPath);
-    if (timedOut && err instanceof Error) {
-      if (fs.existsSync(resultMarker)) {
-        let failures: number | null = null;
-        try {
-          failures = JSON.parse(fs.readFileSync(resultMarker, "utf8")).failures;
-        } catch {
-          // Unparseable marker -- treat like a failure below.
-        }
-        if (failures === 0) {
-          console.warn(
-            "VS Code tests completed successfully but the runner did not exit; continuing after cleanup.",
-          );
-          process.exit(0);
-        }
-        console.error(
-          `VS Code tests reported ${failures ?? "an unknown number of"} failure(s) before the runner timeout cleanup.`,
-        );
-        process.exit(1);
-      }
-      // No marker at all means mocha's run() callback never fired -- the
-      // suite was still mid-run (hung, or just slower than the watchdog)
-      // when we killed it. That is never safe to report as success: it has
-      // silently skipped every test after the point it got stuck.
-      console.error(`${err.message} -- mocha never completed (likely hung). Treating as failure.`);
-      process.exit(1);
-    }
-    console.error("Failed to run tests:", err);
-    process.exit(1);
-  }
+  await runWatchedSuite({
+    extensionDevelopmentPath,
+    extensionTestsPath,
+    launchArgs: [
+      testWorkspace,
+      "--disable-extensions", // Disable other extensions
+      `--user-data-dir=${userDataDir}`,
+    ],
+    heartbeatMarker,
+    resultMarker,
+  });
 }
 
 main();

--- a/editors/vscode/src/test/runnerWatchdog.test.ts
+++ b/editors/vscode/src/test/runnerWatchdog.test.ts
@@ -25,6 +25,7 @@ import {
   DEFAULT_ABSOLUTE_CEILING_MS,
   DEFAULT_NEVER_STARTED_GRACE_MS,
   DEFAULT_NO_PROGRESS_TIMEOUT_MS,
+  MAX_TEST_TIMEOUT_BASE_MS,
   describeWatchdogVerdict,
   evaluateWatchdog,
   Heartbeat,
@@ -68,9 +69,14 @@ suite("runnerWatchdog: evaluateWatchdog (issue #1293)", () => {
     // future default that breaks one reintroduces a specific failure mode, so
     // they are asserted rather than left to the prose.
     assert.ok(
-      DEFAULT_NO_PROGRESS_TIMEOUT_MS > MOCHA_TEST_TIMEOUT_BASE_MS,
-      "the no-progress window must exceed mocha's own per-test backstop, or every " +
-        "mocha-timeout-recovered test would be flagged as a stall before mocha resolves it",
+      MAX_TEST_TIMEOUT_BASE_MS >= MOCHA_TEST_TIMEOUT_BASE_MS,
+      "the per-test ceiling must be at least the suite default it is a ceiling on",
+    );
+    assert.ok(
+      DEFAULT_NO_PROGRESS_TIMEOUT_MS > MAX_TEST_TIMEOUT_BASE_MS,
+      "the no-progress window must exceed the longest a single test may run before mocha " +
+        "kills it — not merely the suite default. Otherwise the watchdog kills the whole " +
+        "run before mocha can kill the one test, losing the per-test attribution",
     );
     assert.ok(
       DEFAULT_NEVER_STARTED_GRACE_MS < DEFAULT_NO_PROGRESS_TIMEOUT_MS,

--- a/editors/vscode/src/test/runnerWatchdog.test.ts
+++ b/editors/vscode/src/test/runnerWatchdog.test.ts
@@ -1,0 +1,262 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Pure decision-function tests for the watchdog (issue #1293). `evaluateWatchdog`
+// does no I/O, so this file needs no `vscode` API — see `runnerWatchdog.ts`'s
+// module docs for why that matters (it must be callable, and testable, outside
+// the extension host, the same reason `signal.ts` has no `vscode` import).
+import * as assert from "assert";
+import {
+  DEFAULT_ABSOLUTE_CEILING_MS,
+  DEFAULT_NEVER_STARTED_GRACE_MS,
+  DEFAULT_NO_PROGRESS_TIMEOUT_MS,
+  describeWatchdogVerdict,
+  evaluateWatchdog,
+  Heartbeat,
+  MOCHA_TEST_TIMEOUT_BASE_MS,
+  WatchdogConfig,
+  WatchdogObservation,
+} from "./runnerWatchdog";
+
+/** The project defaults, unscaled (as if the load factor were exactly 1, which
+ *  is what the pure function reasons about; scaling happens in
+ *  `runWatchedSuite` before the config reaches it).
+ *
+ *  Taken from the exported constants rather than repeated as literals, so a
+ *  change to a default is checked against these properties instead of quietly
+ *  leaving them testing a config the product no longer uses. */
+const CONFIG: WatchdogConfig = {
+  ceilingMs: DEFAULT_ABSOLUTE_CEILING_MS,
+  noProgressWindowMs: DEFAULT_NO_PROGRESS_TIMEOUT_MS,
+  neverStartedGraceMs: DEFAULT_NEVER_STARTED_GRACE_MS,
+};
+
+function beat(overrides: Partial<Heartbeat> = {}): Heartbeat {
+  return {
+    at: Date.now(),
+    inFlight: [],
+    completed: 0,
+    failed: 0,
+    server: null,
+    loadFactor: 1,
+    ...overrides,
+  };
+}
+
+function obs(atMs: number, heartbeat: Heartbeat | null): WatchdogObservation {
+  return { atMs, heartbeat };
+}
+
+suite("runnerWatchdog: evaluateWatchdog (issue #1293)", () => {
+  test("the default bounds keep the relationships their rationale depends on", () => {
+    // Each of these is an argument made in a doc comment on the constant. A
+    // future default that breaks one reintroduces a specific failure mode, so
+    // they are asserted rather than left to the prose.
+    assert.ok(
+      DEFAULT_NO_PROGRESS_TIMEOUT_MS > MOCHA_TEST_TIMEOUT_BASE_MS,
+      "the no-progress window must exceed mocha's own per-test backstop, or every " +
+        "mocha-timeout-recovered test would be flagged as a stall before mocha resolves it",
+    );
+    assert.ok(
+      DEFAULT_NEVER_STARTED_GRACE_MS < DEFAULT_NO_PROGRESS_TIMEOUT_MS,
+      "a host that never started must be reported before the progress bound could fire",
+    );
+    assert.ok(
+      DEFAULT_ABSOLUTE_CEILING_MS > 4 * DEFAULT_NO_PROGRESS_TIMEOUT_MS,
+      "the ceiling is a backstop, not the primary bound — it must sit well above the " +
+        "window that actually detects wedges",
+    );
+    // The regression itself: the suite's own honest runtime (~190s for 846
+    // tests) must be nowhere near the ceiling. The old budget was 180s, which
+    // sat *below* it — that is issue #1293.
+    assert.ok(
+      DEFAULT_ABSOLUTE_CEILING_MS > 4 * 190_000,
+      "the ceiling must leave a green run room to grow, not hug its current runtime",
+    );
+  });
+
+  test("a green-but-slow suite past the old 180s budget is never killed", () => {
+    // The ticket's TP->TN fix: 846 tests each taking ~225ms averages out to
+    // ~190s total, well past the old flat 180_000ms budget. Simulate a
+    // heartbeat every 2s (HEARTBEAT_INTERVAL_MS) with `completed` climbing
+    // steadily the whole way, and assert the watchdog never gives up.
+    const history: WatchdogObservation[] = [];
+    let verdict = null;
+    for (let atMs = 0, completed = 0; atMs <= 190_000; atMs += 2_000, completed += 9) {
+      const h = beat({ completed, inFlight: [{ title: `test #${completed}`, forMs: 200 }] });
+      history.push(obs(atMs, h));
+      verdict = evaluateWatchdog(history, atMs, CONFIG);
+      assert.strictEqual(
+        verdict,
+        null,
+        `must not give up at ${atMs}ms while completed=${completed} is still advancing`,
+      );
+    }
+  });
+
+  test("a genuinely wedged suite is killed with the stalled verdict", () => {
+    // completed/failed/in-flight title all frozen from t=0 onward -- a real
+    // wedge, not a slow-but-live run.
+    const frozen = beat({
+      completed: 40,
+      failed: 0,
+      inFlight: [{ title: "wedged test", forMs: 0 }],
+    });
+    const history: WatchdogObservation[] = [obs(0, frozen)];
+    for (let atMs = 2_000; atMs < CONFIG.noProgressWindowMs; atMs += 2_000) {
+      history.push(obs(atMs, frozen));
+      assert.strictEqual(
+        evaluateWatchdog(history, atMs, CONFIG),
+        null,
+        `must not give up before the no-progress window elapses (at ${atMs}ms)`,
+      );
+    }
+    const giveUpAt = CONFIG.noProgressWindowMs;
+    history.push(obs(giveUpAt, frozen));
+    const verdict = evaluateWatchdog(history, giveUpAt, CONFIG);
+    assert.ok(verdict, "must give up once the no-progress window elapses");
+    assert.strictEqual(verdict?.kind, "stalled");
+    if (verdict?.kind === "stalled") {
+      assert.strictEqual(verdict.lastHeartbeat.completed, 40);
+      assert.ok(verdict.noProgressForMs >= CONFIG.noProgressWindowMs);
+    }
+  });
+
+  test("a host that never wrote a heartbeat is killed promptly with the never-started verdict", () => {
+    const history: WatchdogObservation[] = [];
+    for (let atMs = 0; atMs < CONFIG.neverStartedGraceMs; atMs += 2_000) {
+      history.push(obs(atMs, null));
+      assert.strictEqual(
+        evaluateWatchdog(history, atMs, CONFIG),
+        null,
+        `must not give up before the never-started grace elapses (at ${atMs}ms)`,
+      );
+    }
+    history.push(obs(CONFIG.neverStartedGraceMs, null));
+    const verdict = evaluateWatchdog(history, CONFIG.neverStartedGraceMs, CONFIG);
+    assert.ok(verdict, "must give up once the never-started grace elapses");
+    assert.strictEqual(verdict?.kind, "never-started");
+    // Promptly: well before the absolute ceiling, and before the no-progress
+    // window too -- there is no progress evidence to have "not progressed".
+    assert.ok(CONFIG.neverStartedGraceMs < CONFIG.noProgressWindowMs);
+    assert.ok(CONFIG.neverStartedGraceMs < CONFIG.ceilingMs);
+  });
+
+  test("progress via `failed` advancing only (every test failing, but running) is not a stall", () => {
+    const history: WatchdogObservation[] = [];
+    let verdict = null;
+    for (let atMs = 0, failed = 0; atMs <= 100_000; atMs += 2_000, failed++) {
+      const h = beat({
+        completed: failed,
+        failed,
+        inFlight: [{ title: `failing #${failed}`, forMs: 50 }],
+      });
+      history.push(obs(atMs, h));
+      verdict = evaluateWatchdog(history, atMs, CONFIG);
+      assert.strictEqual(
+        verdict,
+        null,
+        `must treat rising failed count as progress (at ${atMs}ms)`,
+      );
+    }
+  });
+
+  test("an in-flight title changing with `completed` static is treated as progress", () => {
+    // A single very long-running test suite (e.g. one slow test after
+    // another, none individually finishing inside the sampling window) --
+    // completed never moves, but the in-flight title does every tick.
+    const titles = ["test A", "test B", "test C", "test D", "test E"];
+    const history: WatchdogObservation[] = [];
+    let verdict = null;
+    for (let i = 0; i < titles.length; i++) {
+      const atMs = i * 30_000; // less than the 90s window between each change
+      const h = beat({ completed: 0, inFlight: [{ title: titles[i], forMs: 1_000 }] });
+      history.push(obs(atMs, h));
+      verdict = evaluateWatchdog(history, atMs, CONFIG);
+      assert.strictEqual(
+        verdict,
+        null,
+        `an in-flight title change must count as progress (at ${atMs}ms, title=${titles[i]})`,
+      );
+    }
+  });
+
+  test("the absolute ceiling fires while still progressing, with the ceiling verdict -- never 'likely hung'", () => {
+    // completed keeps climbing (so the stall check never fires) but the run
+    // simply takes longer than the generous ceiling allows.
+    const history: WatchdogObservation[] = [];
+    let verdict = null;
+    for (let atMs = 0, completed = 0; atMs < CONFIG.ceilingMs; atMs += 2_000, completed++) {
+      const h = beat({ completed, inFlight: [{ title: `test #${completed}`, forMs: 200 }] });
+      history.push(obs(atMs, h));
+      verdict = evaluateWatchdog(history, atMs, CONFIG);
+      assert.strictEqual(verdict, null, `must not give up before the ceiling (at ${atMs}ms)`);
+    }
+    const finalCompleted = history.length;
+    const lastHeartbeat = beat({
+      completed: finalCompleted,
+      inFlight: [{ title: `test #${finalCompleted}`, forMs: 200 }],
+    });
+    history.push(obs(CONFIG.ceilingMs, lastHeartbeat));
+    verdict = evaluateWatchdog(history, CONFIG.ceilingMs, CONFIG);
+    assert.ok(verdict, "must give up once the ceiling is reached");
+    assert.strictEqual(verdict?.kind, "ceiling");
+    if (verdict) {
+      const message = describeWatchdogVerdict(verdict);
+      assert.ok(
+        !/likely hung/i.test(message),
+        `a ceiling verdict while still progressing must not say "likely hung": ${message}`,
+      );
+      assert.ok(
+        message.includes("absolute ceiling reached while still completing tests"),
+        `ceiling wording must be explicit about which bound fired: ${message}`,
+      );
+    }
+  });
+
+  test("a stalled verdict never-started never applies once a heartbeat has ever been seen", () => {
+    // A host that started, made progress, then genuinely wedged must be
+    // reported as "stalled", not misclassified as "never-started" just
+    // because the most recent poll happened to race a missing/corrupt read.
+    const live = beat({ completed: 5, inFlight: [{ title: "ok", forMs: 100 }] });
+    const history: WatchdogObservation[] = [obs(0, live), obs(2_000, live)];
+    const noisyMiss = obs(4_000, null); // one dropped read shouldn't reset anything
+    history.push(noisyMiss);
+    const atMs = CONFIG.noProgressWindowMs + 4_000;
+    history.push(obs(atMs, live));
+    const verdict = evaluateWatchdog(history, atMs, CONFIG);
+    assert.strictEqual(verdict?.kind, "stalled");
+  });
+
+  test("stalled verdict message names the in-flight test and progress counts", () => {
+    const wedged = beat({
+      completed: 12,
+      failed: 2,
+      inFlight: [{ title: "shimmerPrecision suite", forMs: 95_000 }],
+    });
+    const history: WatchdogObservation[] = [obs(0, wedged), obs(CONFIG.noProgressWindowMs, wedged)];
+    const verdict = evaluateWatchdog(history, CONFIG.noProgressWindowMs, CONFIG);
+    assert.strictEqual(verdict?.kind, "stalled");
+    assert.ok(verdict, "expected a verdict");
+    const message = describeWatchdogVerdict(verdict);
+    assert.ok(message.includes("12 completed"), message);
+    assert.ok(message.includes("2 failed"), message);
+    assert.ok(message.includes("shimmerPrecision suite"), message);
+    assert.ok(!/likely hung/i.test(message), message);
+  });
+});

--- a/editors/vscode/src/test/runnerWatchdog.ts
+++ b/editors/vscode/src/test/runnerWatchdog.ts
@@ -1,0 +1,714 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The launch-to-exit watchdog shared by `runTest.ts` and `runMultiFolderTest.ts`.
+//!
+//! # Progress, not elapsed time
+//!
+//! The old bound was a flat wall-clock budget (`DEFAULT_EXIT_TIMEOUT_MS =
+//! 180_000`): the runner gave up 180s after launch, whatever was happening.
+//! Issue #1293 is that the suite's own honest runtime (~190s for 846 tests)
+//! grew past that budget, so a fully green run raced its own successful exit
+//! and lost — reported as "mocha never completed (likely hung)" with zero
+//! failures.
+//!
+//! The fix is to bound *lack of progress*, not elapsed time: a run that is
+//! still completing tests is not hung however long it has taken; a run whose
+//! `completed + failed` count and in-flight test title have not moved for
+//! [`DEFAULT_NO_PROGRESS_TIMEOUT_MS`] is. The wall-clock ceiling
+//! ([`DEFAULT_ABSOLUTE_CEILING_MS`]) stays only as a generous backstop for a
+//! run that never stalls but also never finishes.
+//!
+//! This module holds the *pure* half of that decision ([`evaluateWatchdog`]) —
+//! it does no I/O, so it is directly unit-testable with a synthetic sequence
+//! of observations and a clock — plus the I/O half ([`runWatchedSuite`],
+//! [`createHeartbeatWriter`]) that both runners share instead of each keeping
+//! their own copy. Free of `import "vscode"` for the same reason `signal.ts`
+//! is: the pure decision function must be callable (and testable) outside the
+//! extension host.
+
+import * as fs from "fs";
+import * as path from "path";
+import { execSync } from "child_process";
+import { downloadAndUnzipVSCode, runTests } from "@vscode/test-electron";
+import { loadFactor, scaledTimeout } from "./signal";
+
+/**
+ * What the heartbeat file records, so a hang is attributable from outside the
+ * extension host.
+ *
+ * The runner's watchdog used to give up with nothing to say but a process
+ * list and "mocha never completed (likely hung)" — which named neither the
+ * test that stalled nor whether the server was still alive (issue #1274).
+ * The extension host is the only place that knows both, so it writes them
+ * down continuously and this module reads the last entry after the fact.
+ */
+export interface Heartbeat {
+  /** When this heartbeat was written (ms since epoch). Its *age* at read time
+   *  is the evidence: a stale heartbeat means the extension host's event loop
+   *  itself stopped turning, which is a different fault from a test stuck in a
+   *  wait. */
+  at: number;
+  /** Tests currently between `test` and `test end` — normally exactly one. */
+  inFlight: Array<{ title: string; forMs: number }>;
+  completed: number;
+  failed: number;
+  /** Round-trip to the language server, taken only once a test has been in
+   *  flight long enough to be suspicious. `null` until then. */
+  server:
+    | null
+    | { responsive: true; roundTripMs: number }
+    | { responsive: false; reason: string; afterMs: number };
+  /** Measured machine load at the time of writing — the difference between "the
+   *  suite is wedged" and "the container is oversubscribed". */
+  loadFactor: number;
+}
+
+/** How often the heartbeat is refreshed by [`createHeartbeatWriter`], and the
+ *  unit the staleness check in [`reportWatchdogVerdict`] is expressed against. */
+export const HEARTBEAT_INTERVAL_MS = 2_000;
+
+/** How long a single test may run before the heartbeat starts probing the
+ *  server on every tick. Below this a slow test is just a slow test. */
+export const SERVER_PROBE_AFTER_MS = 20_000;
+
+/** Bound on the server probe itself, so the heartbeat can never become the
+ *  thing that hangs. */
+export const SERVER_PROBE_TIMEOUT_MS = 5_000;
+
+/**
+ * Mocha's own per-test backstop (base, before load scaling) — both `index.ts`'s
+ * mocha `timeout:` and [`DEFAULT_NO_PROGRESS_TIMEOUT_MS`] below are derived from
+ * this single constant so the two cannot drift apart.
+ */
+export const MOCHA_TEST_TIMEOUT_BASE_MS = 60_000;
+
+/**
+ * Base no-progress window (before load scaling): how long `completed + failed`
+ * may sit unchanged, with the in-flight test title also unchanged, before the
+ * watchdog calls it a stall.
+ *
+ * Must exceed [`MOCHA_TEST_TIMEOUT_BASE_MS`]: mocha kills a single stuck test
+ * at that bound, and `completed + failed` advances the instant it does (the
+ * `fail` event fires). A window at or below the mocha timeout would flag
+ * *every* mocha-timeout-recovered test as a stall in the moment before mocha's
+ * own backstop resolves it — mistaking the cure for the disease. 1.5x leaves a
+ * full half of an extra mocha timeout as slack for the heartbeat's own
+ * [`HEARTBEAT_INTERVAL_MS`] write cadence and the round trip of mocha's `fail`
+ * handler, so one unlucky stuck test never trips this — while a *second*,
+ * consecutive one (a genuine wedge, not a single flaky test) still does well
+ * before the old flat 180s budget would have.
+ */
+export const DEFAULT_NO_PROGRESS_TIMEOUT_MS = MOCHA_TEST_TIMEOUT_BASE_MS * 1.5;
+
+/**
+ * Base absolute ceiling (before load scaling): bounds a run that never stalls
+ * (by the definition above) but also never finishes.
+ *
+ * Deliberately generous. The old fixed 180s budget *was* the bug this module
+ * fixes — it sat below the suite's own honest runtime (~190s for 846 tests),
+ * so a fully green run raced its own successful exit. Progress-based
+ * detection above is now the primary bound; this ceiling only needs to catch
+ * a pathological case that keeps nudging `completed` without ever reaching
+ * the end, so it can afford to sit an order of magnitude above a normal green
+ * run rather than hugging it the way the old constant did.
+ */
+export const DEFAULT_ABSOLUTE_CEILING_MS = 900_000;
+
+/**
+ * Base grace period (before load scaling) before "no heartbeat file was ever
+ * written" becomes its own verdict.
+ *
+ * Distinct from the no-progress window: there is no progress to have stalled
+ * yet, and distinct from the ceiling: waiting out a 15-minute ceiling to
+ * notice the extension host never started would make every genuine launch
+ * failure slow to report for no reason.
+ *
+ * It has to cover everything between `runTests` starting and the extension
+ * host reaching `run()`: Electron start-up, extension-host boot, and mocha
+ * registering the compiled test files. [`createHeartbeatWriter`] writes its
+ * first beat synchronously, so nothing after that point is inside this window
+ * — a suite that is merely slow to start is bounded by the no-progress window
+ * instead, which is the bound that understands progress.
+ *
+ * It does **not** have to cover downloading VS Code itself, which
+ * [`runWatchedSuite`] does before starting the clock: a cold `.vscode-test`
+ * fetches ~150MB, and no grace period derived from start-up cost could
+ * honestly bound that.
+ */
+export const DEFAULT_NEVER_STARTED_GRACE_MS = 60_000;
+
+/** Escape hatch that sets the absolute ceiling (base, pre-load-scaling). Was
+ *  the *only* budget before issue #1293; now progress detection is primary
+ *  and this only stretches (or, at `0`, disables) the backstop. */
+export const CEILING_ENV_VAR = "TCL_LSP_VSCODE_TEST_EXIT_TIMEOUT_MS";
+
+/** Escape hatch that sets the no-progress window (base, pre-load-scaling). At
+ *  `0` the stall check is disabled and only the ceiling (and never-started
+ *  grace) still bound the run. */
+export const NO_PROGRESS_ENV_VAR = "TCL_LSP_VSCODE_TEST_NO_PROGRESS_TIMEOUT_MS";
+
+function parseMsEnvVar(varName: string, fallback: number): number {
+  const raw = process.env[varName];
+  if (!raw) {
+    return fallback;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback;
+  }
+  return Math.floor(parsed);
+}
+
+/** Read the absolute-ceiling escape hatch. `0` means "no ceiling" (the
+ *  watchdog is disabled entirely — see [`runWatchedSuite`]). */
+export function parseExitTimeoutMs(): number {
+  return parseMsEnvVar(CEILING_ENV_VAR, DEFAULT_ABSOLUTE_CEILING_MS);
+}
+
+/** Read the no-progress-window escape hatch. `0` disables just the stall
+ *  check, leaving the ceiling (and never-started grace) active. */
+export function parseNoProgressTimeoutMs(): number {
+  return parseMsEnvVar(NO_PROGRESS_ENV_VAR, DEFAULT_NO_PROGRESS_TIMEOUT_MS);
+}
+
+export function escapeDoubleQuotes(text: string): string {
+  return text.split('"').join('\\"');
+}
+
+export function escapeSingleQuotes(text: string): string {
+  return text.split("'").join("'\"'\"'");
+}
+
+export function cleanupStaleTestHosts(
+  extensionDevelopmentPath: string,
+  extensionTestsPath: string,
+): void {
+  try {
+    const escapedDevPath = escapeSingleQuotes(extensionDevelopmentPath);
+    const escapedTestsPath = escapeSingleQuotes(extensionTestsPath);
+    execSync(
+      `pkill -f 'extensionDevelopmentPath=${escapedDevPath}' || true; pkill -f 'extensionTestsPath=${escapedTestsPath}' || true`,
+      { stdio: "ignore" },
+    );
+  } catch {
+    // Cleanup is best-effort only.
+  }
+}
+
+export function emitProcessSnapshot(
+  extensionDevelopmentPath: string,
+  extensionTestsPath: string,
+): void {
+  try {
+    const escapedDevPath = escapeDoubleQuotes(extensionDevelopmentPath);
+    const escapedTestsPath = escapeDoubleQuotes(extensionTestsPath);
+    const pattern = `extensionDevelopmentPath=${escapedDevPath}|extensionTestsPath=${escapedTestsPath}|node ./out/test/runTest.js`;
+    const cmd = `ps -axo pid,ppid,etime,command | grep -E "${pattern}"`;
+    const output = execSync(cmd, { encoding: "utf8" });
+    if (output.trim()) {
+      console.error("Potentially stuck VS Code test processes:");
+      console.error(output.trimEnd());
+    }
+  } catch {
+    // Snapshot is best-effort only.
+  }
+}
+
+/** Safe read of a heartbeat file: `null` covers both "does not exist yet" and
+ *  "unreadable/corrupt" — both mean "no progress evidence at this instant". */
+export function readHeartbeat(heartbeatMarker: string): Heartbeat | null {
+  try {
+    return JSON.parse(fs.readFileSync(heartbeatMarker, "utf8")) as Heartbeat;
+  } catch {
+    return null;
+  }
+}
+
+/** One sample the watchdog took while racing the suite: the heartbeat file's
+ *  contents (or `null` if unreadable) at a known elapsed time. */
+export interface WatchdogObservation {
+  /** Milliseconds since the watchdog started (i.e. since launch). */
+  atMs: number;
+  heartbeat: Heartbeat | null;
+}
+
+export interface WatchdogConfig {
+  /** Load-scaled absolute ceiling in ms. `Infinity` disables it. */
+  ceilingMs: number;
+  /** Load-scaled no-progress window in ms. `Infinity` disables the stall check. */
+  noProgressWindowMs: number;
+  /** Load-scaled grace period in ms before "never started" fires. */
+  neverStartedGraceMs: number;
+}
+
+export type WatchdogVerdict =
+  | { kind: "never-started" }
+  | { kind: "stalled"; noProgressForMs: number; lastHeartbeat: Heartbeat }
+  | { kind: "ceiling"; lastHeartbeat: Heartbeat };
+
+/** The progress signal: `completed + failed` advancing, or the in-flight test
+ *  title(s) changing. *Not* heartbeat freshness — a test stuck on a promise
+ *  still refreshes the heartbeat every [`HEARTBEAT_INTERVAL_MS`], so freshness
+ *  alone would never catch a genuine stall. */
+function progressKey(beat: Heartbeat): string {
+  return `${beat.completed}|${beat.failed}|${beat.inFlight.map((t) => t.title).join(",")}`;
+}
+
+/**
+ * The pure decision: given everything observed so far and the current clock,
+ * should the watchdog give up, and with which verdict?
+ *
+ * No I/O, no timers — a deterministic fold over `history`, so it is directly
+ * unit-testable with a synthetic timeline. `nowMs` is separate from the last
+ * observation's `atMs` so a caller can ask "should we give up *now*" even when
+ * the most recent read is a little stale.
+ *
+ * Priority order matters: never-started is checked first (there is no
+ * progress to have stalled, so the stall check would never fire on its own),
+ * then stalled, then the ceiling — so "ceiling reached" only fires for a run
+ * that was genuinely still making progress, never for one that had already
+ * stopped (that is reported as a stall instead, however far past the ceiling
+ * it also happens to be).
+ */
+export function evaluateWatchdog(
+  history: readonly WatchdogObservation[],
+  nowMs: number,
+  config: WatchdogConfig,
+): WatchdogVerdict | null {
+  let lastHeartbeat: Heartbeat | null = null;
+  let lastProgressKey: string | null = null;
+  let lastProgressAtMs = 0;
+  let everHadHeartbeat = false;
+
+  for (const obs of history) {
+    if (obs.heartbeat === null) {
+      continue;
+    }
+    everHadHeartbeat = true;
+    lastHeartbeat = obs.heartbeat;
+    const key = progressKey(obs.heartbeat);
+    if (lastProgressKey === null || key !== lastProgressKey) {
+      lastProgressKey = key;
+      lastProgressAtMs = obs.atMs;
+    }
+  }
+
+  if (!everHadHeartbeat) {
+    return nowMs >= config.neverStartedGraceMs ? { kind: "never-started" } : null;
+  }
+
+  const noProgressForMs = nowMs - lastProgressAtMs;
+  if (noProgressForMs >= config.noProgressWindowMs) {
+    return { kind: "stalled", noProgressForMs, lastHeartbeat: lastHeartbeat as Heartbeat };
+  }
+
+  if (nowMs >= config.ceilingMs) {
+    return { kind: "ceiling", lastHeartbeat: lastHeartbeat as Heartbeat };
+  }
+
+  return null;
+}
+
+/**
+ * The one-line summary of why the watchdog gave up. Written so `failed == 0`
+ * and progress that was genuinely advancing never gets called "likely hung" —
+ * that flat wording (with no distinction between a stall and a slow-but-live
+ * run) is what made issue #1293 need re-run archaeology instead of a log line.
+ */
+export function describeWatchdogVerdict(verdict: WatchdogVerdict): string {
+  switch (verdict.kind) {
+    case "never-started":
+      return (
+        "no heartbeat file was ever written, so the suite hung before or during its first " +
+        "test (extension host failed to start, or run() never reached mocha.run)"
+      );
+    case "stalled": {
+      const seconds = Math.round(verdict.noProgressForMs / 1000);
+      const inFlight = verdict.lastHeartbeat.inFlight.length
+        ? verdict.lastHeartbeat.inFlight.map((t) => t.title).join(", ")
+        : "none";
+      return (
+        `no test completed for ${seconds}s (last progress: ${verdict.lastHeartbeat.completed} ` +
+        `completed, ${verdict.lastHeartbeat.failed} failed, in flight: ${inFlight})`
+      );
+    }
+    case "ceiling":
+      return (
+        `absolute ceiling reached while still completing tests (${verdict.lastHeartbeat.completed} ` +
+        `completed, ${verdict.lastHeartbeat.failed} failed so far)`
+      );
+  }
+}
+
+/**
+ * Print the full attributable breakdown behind a verdict — which test was in
+ * flight, for how long, whether the language server was still answering, and
+ * whether the extension host's own event loop was still turning. Without this
+ * the watchdog giving up printed a process list and a guess, which is what
+ * made issue #1274 need re-run archaeology rather than reading a log.
+ */
+export function reportWatchdogVerdict(verdict: WatchdogVerdict): void {
+  console.error("--- watchdog report ---");
+  console.error(`  ${describeWatchdogVerdict(verdict)}`);
+  if (verdict.kind === "never-started") {
+    console.error("--- end watchdog report ---");
+    return;
+  }
+  const beat = verdict.lastHeartbeat;
+  const age = Date.now() - beat.at;
+  console.error(
+    `  heartbeat written ${age}ms ago; ${beat.completed} test(s) completed, ${beat.failed} ` +
+      `failed; measured load factor ${beat.loadFactor.toFixed(1)}`,
+  );
+  if (beat.inFlight.length === 0) {
+    console.error(
+      "  no test was in flight — mocha had finished the last test but the run() " +
+        "callback never fired, or a root-level hook is stuck.",
+    );
+  } else {
+    for (const t of beat.inFlight) {
+      console.error(`  IN FLIGHT for ${t.forMs}ms: ${t.title}`);
+    }
+  }
+  if (beat.server === null) {
+    console.error(
+      "  server: not probed — no test had been in flight long enough to be suspicious " +
+        "when this heartbeat was written.",
+    );
+  } else if (beat.server.responsive) {
+    console.error(
+      `  server: RESPONSIVE (${beat.server.roundTripMs}ms round trip), so the stall is in ` +
+        "the test or the extension host, not a wedged server.",
+    );
+  } else {
+    console.error(
+      `  server: NOT RESPONDING after ${beat.server.afterMs}ms (${beat.server.reason}) — ` +
+        "the language server stopped answering, so suspect the server, not the test.",
+    );
+  }
+  if (age > 3 * HEARTBEAT_INTERVAL_MS) {
+    console.error(
+      `  the heartbeat itself is ${age}ms stale (it refreshes every ${HEARTBEAT_INTERVAL_MS}ms), ` +
+        "so the extension host's event loop stopped turning — a blocked main thread or a " +
+        "crashed host, not a test waiting on a promise.",
+    );
+  }
+  console.error("--- end watchdog report ---");
+}
+
+/** Everything [`createHeartbeatWriter`] needs from its host runner. Injected
+ *  rather than imported so this module never needs `import "vscode"` — the
+ *  probe itself talks to the language server via the extension host's
+ *  `vscode.commands.executeCommand`, which only the caller (`index.ts` /
+ *  `multiFolder/index.ts`) can provide. */
+export interface HeartbeatWriterOptions {
+  heartbeatMarker: string;
+  /** Ask the language server a question that touches neither the document
+   *  store nor the analyser, so what it times is the client→server→client
+   *  path itself. Only called once a test has been in flight for
+   *  [`SERVER_PROBE_AFTER_MS`]. */
+  probeServer: () => Promise<NonNullable<Heartbeat["server"]>>;
+}
+
+export interface HeartbeatWriter {
+  /** Wire this to mocha's `test` event. */
+  onTestStart: (fullTitle: string) => void;
+  /** Wire this to mocha's `test end` event. */
+  onTestEnd: (fullTitle: string) => void;
+  /** Wire this to mocha's `fail` event. */
+  onFail: () => void;
+  /** Stop the refresh interval. Call from mocha's completion callback. */
+  stop: () => void;
+}
+
+/**
+ * The heartbeat-writing driver shared by `index.ts` and `multiFolder/index.ts`
+ * — previously only the former had one, which left a hung multi-folder run
+ * with no progress evidence at all and (worse) a runner that treated its own
+ * timeout as success.
+ *
+ * Removes any stale heartbeat file up front and starts an unref'd refresh
+ * interval; the heartbeat must never be the reason the extension host stays
+ * alive after the suite finishes.
+ */
+export function createHeartbeatWriter(options: HeartbeatWriterOptions): HeartbeatWriter {
+  const { heartbeatMarker, probeServer } = options;
+
+  fs.mkdirSync(path.dirname(heartbeatMarker), { recursive: true });
+  try {
+    fs.unlinkSync(heartbeatMarker);
+  } catch {
+    // No stale heartbeat to remove.
+  }
+
+  const inFlight = new Map<string, number>();
+  let completed = 0;
+  let failed = 0;
+  let lastServerProbe: Heartbeat["server"] = null;
+  let probeInFlight = false;
+
+  const writeHeartbeat = () => {
+    const now = Date.now();
+    const entries = [...inFlight.entries()].map(([title, startedAt]) => ({
+      title,
+      forMs: now - startedAt,
+    }));
+    const stalled = entries.some((e) => e.forMs >= SERVER_PROBE_AFTER_MS);
+    if (stalled && !probeInFlight) {
+      probeInFlight = true;
+      void probeServer().then((result) => {
+        lastServerProbe = result;
+        probeInFlight = false;
+      });
+    } else if (!stalled) {
+      lastServerProbe = null;
+    }
+    const beat: Heartbeat = {
+      at: now,
+      inFlight: entries,
+      completed,
+      failed,
+      server: lastServerProbe,
+      loadFactor: loadFactor(),
+    };
+    try {
+      fs.writeFileSync(heartbeatMarker, JSON.stringify(beat) + "\n", "utf8");
+    } catch {
+      // The heartbeat is diagnostics only — never fail a run over it.
+    }
+  };
+
+  // Write one immediately rather than waiting out the first interval: the
+  // file's *existence* is what tells the watchdog the host started at all, so
+  // publishing it the moment `run()` is reached keeps everything after that
+  // point inside the progress-aware bound rather than the start-up grace.
+  writeHeartbeat();
+  const interval = setInterval(writeHeartbeat, HEARTBEAT_INTERVAL_MS);
+  interval.unref();
+
+  return {
+    onTestStart: (fullTitle: string) => {
+      inFlight.set(fullTitle, Date.now());
+      writeHeartbeat();
+    },
+    onTestEnd: (fullTitle: string) => {
+      inFlight.delete(fullTitle);
+      completed++;
+    },
+    onFail: () => {
+      failed++;
+    },
+    stop: () => {
+      clearInterval(interval);
+    },
+  };
+}
+
+/** What [`runWatchedSuite`] needs on top of the plain `runTests` call. */
+export interface RunWatchedSuiteOptions {
+  extensionDevelopmentPath: string;
+  extensionTestsPath: string;
+  launchArgs: string[];
+  /** Where the extension host writes its heartbeat (see [`createHeartbeatWriter`]). */
+  heartbeatMarker: string;
+  /** Where the extension host writes `{ failures: number }` once mocha's `run()`
+   *  callback fires, pass or fail. Its *absence* after the watchdog gives up
+   *  means mocha never finished at all — never safe to treat as success. */
+  resultMarker: string;
+  /** How often to re-check the heartbeat while racing the launch. Not itself
+   *  load-scaled — polling cost is negligible and this is not a hang backstop,
+   *  just the sampling rate for one. Defaults to [`HEARTBEAT_INTERVAL_MS`]. */
+  pollIntervalMs?: number;
+}
+
+/**
+ * Launch the suite via `@vscode/test-electron`, race it against the watchdog,
+ * and exit the process with an honest status — the "launch/race/exit" logic
+ * both runners previously duplicated (and `runMultiFolderTest.ts` got wrong:
+ * it treated its own timeout as `process.exit(0)`, which could silently pass
+ * a hung multi-folder run).
+ *
+ * Every path ends in `process.exit`, matching the shape both runners already
+ * had; the `Promise<void>` return is never actually awaited by a caller that
+ * does anything after it.
+ */
+export async function runWatchedSuite(opts: RunWatchedSuiteOptions): Promise<void> {
+  const {
+    extensionDevelopmentPath,
+    extensionTestsPath,
+    launchArgs,
+    heartbeatMarker,
+    resultMarker,
+  } = opts;
+  const pollIntervalMs = opts.pollIntervalMs ?? HEARTBEAT_INTERVAL_MS;
+
+  cleanupStaleTestHosts(extensionDevelopmentPath, extensionTestsPath);
+  for (const marker of [resultMarker, heartbeatMarker]) {
+    try {
+      fs.unlinkSync(marker);
+    } catch {
+      // No stale marker to remove.
+    }
+  }
+
+  const ceilingBaseMs = parseExitTimeoutMs();
+  const noProgressBaseMs = parseNoProgressTimeoutMs();
+  const watchdogDisabled = ceilingBaseMs <= 0;
+
+  // Fetch VS Code *before* the watchdog's clock starts. `runTests` downloads it
+  // on demand, so a cold `.vscode-test` would otherwise spend minutes inside
+  // the never-started grace period with no heartbeat to show for it — and be
+  // failed for not having started, which is the same "a correct run was killed
+  // by a deadline that isn't about it" mistake issue #1293 records. Nothing is
+  // fetched when the cached build is already present.
+  let vscodeExecutablePath: string | undefined;
+  let prefetched = false;
+  try {
+    vscodeExecutablePath = await downloadAndUnzipVSCode();
+    prefetched = true;
+  } catch (err) {
+    // Fall through to `runTests`, which will attempt (and report) the download
+    // itself rather than us swallowing a network failure as a hang. The
+    // never-started grace is stood down below: the download is now inside the
+    // watchdog's clock, and no grace derived from start-up cost can bound it.
+    console.warn("Could not pre-fetch VS Code; falling back to on-demand download:", err);
+  }
+
+  const runPromise = runTests({
+    extensionDevelopmentPath,
+    extensionTestsPath,
+    launchArgs,
+    vscodeExecutablePath,
+  });
+
+  const finishOk = (): void => {
+    cleanupStaleTestHosts(extensionDevelopmentPath, extensionTestsPath);
+    process.exit(0);
+  };
+
+  const finishFromMarkerOrFail = (verdict: WatchdogVerdict | null): void => {
+    emitProcessSnapshot(extensionDevelopmentPath, extensionTestsPath);
+    cleanupStaleTestHosts(extensionDevelopmentPath, extensionTestsPath);
+    if (fs.existsSync(resultMarker)) {
+      let failures: number | null = null;
+      try {
+        failures = JSON.parse(fs.readFileSync(resultMarker, "utf8")).failures;
+      } catch {
+        // Unparseable marker -- treat like a failure below.
+      }
+      if (failures === 0) {
+        console.warn(
+          "VS Code tests completed successfully but the runner did not exit; continuing after cleanup.",
+        );
+        process.exit(0);
+        return;
+      }
+      console.error(
+        `VS Code tests reported ${failures ?? "an unknown number of"} failure(s) before the watchdog gave up.`,
+      );
+      process.exit(1);
+      return;
+    }
+    // No marker at all means mocha's run() callback never fired -- the suite
+    // was still mid-run (hung, or just slower than the watchdog) when we gave
+    // up. That is never safe to report as success: it has silently skipped
+    // every test after the point it got stuck.
+    const reason = verdict ? describeWatchdogVerdict(verdict) : "the runner failed unexpectedly";
+    console.error(`${reason} -- mocha did not complete. Treating as failure.`);
+    process.exit(1);
+  };
+
+  if (watchdogDisabled) {
+    try {
+      await runPromise;
+      finishOk();
+    } catch (err) {
+      console.error("Failed to run tests:", err);
+      process.exit(1);
+    }
+    return;
+  }
+
+  const ceilingMs = scaledTimeout(ceilingBaseMs);
+  const config: WatchdogConfig = {
+    ceilingMs,
+    noProgressWindowMs: noProgressBaseMs > 0 ? scaledTimeout(noProgressBaseMs) : Infinity,
+    // With the pre-fetch done, "no heartbeat yet" means start-up, which the
+    // grace period bounds. Without it, `runTests` may be fetching ~334MB
+    // inside the watchdog's clock, and calling that "the host never started"
+    // would be the same mistake as the flat budget this module replaced. So
+    // the grace stands down to the ceiling, which still bounds the run.
+    neverStartedGraceMs: prefetched ? scaledTimeout(DEFAULT_NEVER_STARTED_GRACE_MS) : ceilingMs,
+  };
+  console.log(
+    `==> watchdog: absolute ceiling ${config.ceilingMs}ms (base ${ceilingBaseMs}ms), ` +
+      `no-progress window ${config.noProgressWindowMs}ms (base ${noProgressBaseMs}ms), ` +
+      `never-started grace ${config.neverStartedGraceMs}ms` +
+      `${prefetched ? "" : " (stood down to the ceiling — VS Code was not pre-fetched)"} — ` +
+      `all x measured load factor ${loadFactor().toFixed(1)}`,
+  );
+
+  const started = Date.now();
+  const history: WatchdogObservation[] = [];
+  let verdict: WatchdogVerdict | null = null;
+  let pollTimer: NodeJS.Timeout | undefined;
+
+  const watchdogPromise = new Promise<never>((_resolve, reject) => {
+    const tick = () => {
+      const atMs = Date.now() - started;
+      const heartbeat = readHeartbeat(heartbeatMarker);
+      history.push({ atMs, heartbeat });
+      const decided = evaluateWatchdog(history, atMs, config);
+      if (decided) {
+        verdict = decided;
+        reject(new Error("watchdog gave up"));
+        return;
+      }
+      pollTimer = setTimeout(tick, pollIntervalMs);
+      pollTimer.unref();
+    };
+    pollTimer = setTimeout(tick, pollIntervalMs);
+    pollTimer.unref();
+  });
+  // Keep a late rejection (the loop keeps scheduling until cleared below, so
+  // in practice this never fires again once the race is decided) from going
+  // unhandled.
+  watchdogPromise.catch(() => {});
+
+  try {
+    await Promise.race([runPromise, watchdogPromise]);
+    if (pollTimer) clearTimeout(pollTimer);
+    finishOk();
+  } catch (err) {
+    if (pollTimer) clearTimeout(pollTimer);
+    if (verdict) {
+      // Read the heartbeat-derived report *before* the cleanup below kills
+      // the host that writes it, so what is reported is the state at the
+      // moment of giving up.
+      reportWatchdogVerdict(verdict);
+      finishFromMarkerOrFail(verdict);
+      return;
+    }
+    // runPromise itself rejected (a real launch failure), not the watchdog.
+    emitProcessSnapshot(extensionDevelopmentPath, extensionTestsPath);
+    cleanupStaleTestHosts(extensionDevelopmentPath, extensionTestsPath);
+    console.error("Failed to run tests:", err);
+    process.exit(1);
+  }
+}

--- a/editors/vscode/src/test/runnerWatchdog.ts
+++ b/editors/vscode/src/test/runnerWatchdog.ts
@@ -99,22 +99,37 @@ export const SERVER_PROBE_TIMEOUT_MS = 5_000;
 export const MOCHA_TEST_TIMEOUT_BASE_MS = 60_000;
 
 /**
+ * The largest per-test backstop (base, before load scaling) any single test may
+ * claim with `this.timeout(...)`.
+ *
+ * A test whose bounded waits genuinely need longer than the suite default may
+ * raise its own bound — `progressiveDiagnostics` waits on `activate` and then a
+ * 50s deep-tier publish — but it may not raise it past this, because
+ * [`DEFAULT_NO_PROGRESS_TIMEOUT_MS`] is derived from it. A test that outran the
+ * no-progress window would be killed by the *watchdog* instead of by mocha,
+ * which loses the per-test attribution mocha's own timeout gives and fails the
+ * whole run rather than the one test. (Observed for real: raising one test to
+ * 150s against a 90s window turned a single slow test into "no test completed
+ * for 90s" and a failed suite.)
+ */
+export const MAX_TEST_TIMEOUT_BASE_MS = 150_000;
+
+/**
  * Base no-progress window (before load scaling): how long `completed + failed`
  * may sit unchanged, with the in-flight test title also unchanged, before the
  * watchdog calls it a stall.
  *
- * Must exceed [`MOCHA_TEST_TIMEOUT_BASE_MS`]: mocha kills a single stuck test
- * at that bound, and `completed + failed` advances the instant it does (the
- * `fail` event fires). A window at or below the mocha timeout would flag
- * *every* mocha-timeout-recovered test as a stall in the moment before mocha's
- * own backstop resolves it — mistaking the cure for the disease. 1.5x leaves a
- * full half of an extra mocha timeout as slack for the heartbeat's own
- * [`HEARTBEAT_INTERVAL_MS`] write cadence and the round trip of mocha's `fail`
- * handler, so one unlucky stuck test never trips this — while a *second*,
- * consecutive one (a genuine wedge, not a single flaky test) still does well
- * before the old flat 180s budget would have.
+ * Must exceed [`MAX_TEST_TIMEOUT_BASE_MS`] — the longest any one test may run
+ * before mocha kills it, not merely the suite default: mocha kills a stuck test
+ * at *its own* bound, and `completed + failed` advances the instant it does
+ * (the `fail` event fires). A window at or below that would flag every
+ * mocha-timeout-recovered test as a stall in the moment before mocha's backstop
+ * resolves it — mistaking the cure for the disease. 1.5x leaves half again as
+ * slack for the heartbeat's [`HEARTBEAT_INTERVAL_MS`] write cadence and the
+ * round trip of mocha's `fail` handler, so one unlucky stuck test never trips
+ * this — while a genuine wedge still does, far inside the ceiling.
  */
-export const DEFAULT_NO_PROGRESS_TIMEOUT_MS = MOCHA_TEST_TIMEOUT_BASE_MS * 1.5;
+export const DEFAULT_NO_PROGRESS_TIMEOUT_MS = MAX_TEST_TIMEOUT_BASE_MS * 1.5;
 
 /**
  * Base absolute ceiling (before load scaling): bounds a run that never stalls
@@ -127,8 +142,13 @@ export const DEFAULT_NO_PROGRESS_TIMEOUT_MS = MOCHA_TEST_TIMEOUT_BASE_MS * 1.5;
  * a pathological case that keeps nudging `completed` without ever reaching
  * the end, so it can afford to sit an order of magnitude above a normal green
  * run rather than hugging it the way the old constant did.
+ *
+ * It must also stay well clear of [`DEFAULT_NO_PROGRESS_TIMEOUT_MS`], so the
+ * bound that fires is the one that understands progress. A ceiling only a few
+ * stall-windows wide would start catching runs the stall check was still
+ * deciding about, which is how a backstop quietly becomes the primary bound.
  */
-export const DEFAULT_ABSOLUTE_CEILING_MS = 900_000;
+export const DEFAULT_ABSOLUTE_CEILING_MS = 1_800_000;
 
 /**
  * Base grace period (before load scaling) before "no heartbeat file was ever

--- a/editors/vscode/src/test/semanticTokens.test.ts
+++ b/editors/vscode/src/test/semanticTokens.test.ts
@@ -18,7 +18,7 @@
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getDocUri, activate, setTestContent, pollUntil } from "./helper";
+import { getDocUri, activate, setTestContent, pollUntil, scaledTimeout } from "./helper";
 
 interface DecodedToken {
   line: number;
@@ -666,7 +666,7 @@ suite("Semantic Tokens", () => {
   }
 
   test("issue #829: semantic tokens arrive promptly on a large (600-proc) document", async function () {
-    this.timeout(30_000);
+    this.timeout(scaledTimeout(30_000));
     const uri = getDocUri("largeSemanticTokens.tcl");
     const doc = await activate(uri);
     const editor = await vscode.window.showTextDocument(doc);
@@ -742,7 +742,7 @@ suite("Semantic Tokens", () => {
   // fully enriched stream -- proving highlighting converges rather than
   // staying permanently stuck on the coarse tier.
   test("issue #829: highlighting eventually converges to the enriched result without an edit", async function () {
-    this.timeout(30_000);
+    this.timeout(scaledTimeout(30_000));
     const uri = getDocUri("largeSemanticTokens.tcl");
     const doc = await activate(uri);
     const editor = await vscode.window.showTextDocument(doc);

--- a/editors/vscode/src/test/serverHealth.test.ts
+++ b/editors/vscode/src/test/serverHealth.test.ts
@@ -19,7 +19,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import { LanguageClient, State } from "vscode-languageclient/node";
-import { activate, getDocUri } from "./helper";
+import { activate, getDocUri, scaledTimeout } from "./helper";
 
 interface TclLspApi {
   getClient(): LanguageClient;
@@ -36,7 +36,7 @@ function getApi(): TclLspApi {
 // missing or crashes on startup then ext.activate() rejects because
 // client.start() fails, and the whole test run aborts with a clear message.
 suiteSetup(async function () {
-  this.timeout(60_000);
+  this.timeout(scaledTimeout(60_000));
   const ext = vscode.extensions.getExtension("bitwisecook.tcl-lsp")!;
   await ext.activate();
   assert.ok(ext.isActive, "Extension failed to activate – server may have crashed on startup");
@@ -44,7 +44,7 @@ suiteSetup(async function () {
 
 // Runs after ALL test suites.  Catches server crashes that happen mid-run.
 suiteTeardown(async function () {
-  this.timeout(30_000);
+  this.timeout(scaledTimeout(30_000));
   const client = getApi().getClient();
   assert.strictEqual(
     client.state,

--- a/editors/vscode/src/test/serverProbe.ts
+++ b/editors/vscode/src/test/serverProbe.ts
@@ -1,0 +1,62 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The heartbeat's server-liveness probe, shared by both mocha entry points.
+//!
+//! Split out of `index.ts` / `multiFolder/index.ts` (which each carried a copy)
+//! rather than folded into `runnerWatchdog.ts`, which must stay free of
+//! `import "vscode"` so its pure decision function is testable outside the
+//! extension host. This is the piece that genuinely needs the host, so it is
+//! injected into the watchdog's heartbeat writer rather than imported by it.
+
+import * as vscode from "vscode";
+import { scaledTimeout } from "./signal";
+import { Heartbeat, SERVER_PROBE_TIMEOUT_MS } from "./runnerWatchdog";
+
+/**
+ * Ask the language server a question that touches neither the document store
+ * nor the analyser, so what it times is the client → server → client path
+ * itself. Mirrors the native harness's `LatencyBudget` no-op probe.
+ *
+ * Bounded and non-throwing: the heartbeat must never become the thing that
+ * hangs, and a probe failure is an *answer* ("not responding"), not an error.
+ */
+export async function probeServer(): Promise<NonNullable<Heartbeat["server"]>> {
+  const started = Date.now();
+  try {
+    const answered = await Promise.race([
+      vscode.commands.executeCommand("tcl-lsp.getEffectiveConfig", "").then(() => true),
+      new Promise<false>((resolve) =>
+        setTimeout(() => resolve(false), scaledTimeout(SERVER_PROBE_TIMEOUT_MS)).unref(),
+      ),
+    ]);
+    return answered
+      ? { responsive: true, roundTripMs: Date.now() - started }
+      : {
+          responsive: false,
+          reason: "getEffectiveConfig did not answer",
+          afterMs: Date.now() - started,
+        };
+  } catch (err) {
+    return {
+      responsive: false,
+      reason: err instanceof Error ? err.message : String(err),
+      afterMs: Date.now() - started,
+    };
+  }
+}

--- a/editors/vscode/src/test/showReferences.test.ts
+++ b/editors/vscode/src/test/showReferences.test.ts
@@ -18,7 +18,7 @@
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { activate, getDocUri } from "./helper";
+import { activate, getDocUri, scaledTimeout } from "./helper";
 import { convertShowReferencesArgs } from "../showReferences";
 
 suite("tcl-lsp.showReferences adapter", () => {
@@ -92,7 +92,7 @@ suite("tcl-lsp.showReferences adapter", () => {
 
   suite("command registration", () => {
     suiteSetup(async function () {
-      this.timeout(60_000);
+      this.timeout(scaledTimeout(60_000));
       await activate(getDocUri("simple.tcl"));
     });
 

--- a/editors/vscode/src/test/signal.ts
+++ b/editors/vscode/src/test/signal.ts
@@ -281,6 +281,54 @@ export interface AwaitSignalOptions<T> {
    * unchanged, so a real provider fault still fails the test immediately.
    */
   retryProbeErrors?: (error: unknown) => boolean;
+  /** See [`TimeoutDiagnostic`]. */
+  diagnose?: TimeoutDiagnostic;
+}
+
+/**
+ * An extra investigation run **only** on the failing path, whose prose is
+ * appended to the timeout message.
+ *
+ * A timeout says the answer never came; it does not say what the server was
+ * doing instead, which is the gap issue #1294 records — four consecutive waits
+ * on one document's `didOpen` drain expired with a healthy machine, and the
+ * evidence could not tell "the server is wedged" apart from "this document's
+ * queue is wedged". A caller that knows a cheaper, independent question to ask
+ * supplies it here, and the answer lands in the same message as the failure.
+ *
+ * It must be self-bounding and must never throw: this runs when the test is
+ * already failing, and a diagnostic that hangs would replace an attributable
+ * failure with an unattributable one. [`diagnose`] enforces both.
+ */
+export type TimeoutDiagnostic = () => string | PromiseLike<string>;
+
+/** Ceiling on a [`TimeoutDiagnostic`], so the diagnostic can never become the
+ *  thing that hangs. Load-scaled like every other bound here: the probes a
+ *  diagnostic makes are themselves load-scaled, so a fixed cap would truncate
+ *  the answer on precisely the machines whose failures are hardest to read. */
+const DIAGNOSTIC_BUDGET_MS = 15_000;
+
+/**
+ * Run a [`TimeoutDiagnostic`] under a hard cap, converting any failure of the
+ * diagnostic itself into prose rather than letting it displace the timeout it
+ * was meant to explain.
+ */
+async function diagnose(probe: TimeoutDiagnostic | undefined): Promise<string> {
+  if (!probe) return "";
+  const cap = scaledTimeout(DIAGNOSTIC_BUDGET_MS);
+  try {
+    const note = await Promise.race([
+      Promise.resolve(probe()),
+      sleepDetached(cap).then(
+        () =>
+          `follow-up probe did not finish within ${cap}ms, which is itself evidence: the ` +
+          `server did not answer an independent question either`,
+      ),
+    ]);
+    return note ? `\n  ${note}` : "";
+  } catch (err) {
+    return `\n  follow-up probe itself failed: ${err instanceof Error ? err.message : String(err)}`;
+  }
 }
 
 function defaultDescribe(value: unknown): string {
@@ -364,7 +412,7 @@ export async function awaitSignal<T>(opts: AwaitSignalOptions<T>): Promise<T> {
             `${factor.toFixed(1)}; ${extensions} extension(s); ${probes} probe(s), ` +
             `${signals} signal(s))\n` +
             `  last seen: ${describe(last)}${retried}\n` +
-            `  ${note}`,
+            `  ${note}${await diagnose(opts.diagnose)}`,
         );
       }
 
@@ -402,7 +450,7 @@ export async function awaitSignal<T>(opts: AwaitSignalOptions<T>): Promise<T> {
 export function bounded<T>(
   work: PromiseLike<T>,
   label: string,
-  opts?: { timeout?: number },
+  opts?: { timeout?: number; diagnose?: TimeoutDiagnostic },
 ): Promise<T> {
   const base = opts?.timeout ?? DEFAULT_SIGNAL_TIMEOUT_MS;
   const started = Date.now();
@@ -438,7 +486,7 @@ export function bounded<T>(
               `${factor.toFixed(1)}; ${extensions} extension(s))\n` +
               `  this await has no completion signal to wait on — it *is* the signal — so a ` +
               `timeout here means the request never came back.\n` +
-              `  ${note}`,
+              `  ${note}${await diagnose(opts?.diagnose)}`,
           );
         }
       }

--- a/editors/vscode/src/test/signal.ts
+++ b/editors/vscode/src/test/signal.ts
@@ -56,6 +56,14 @@
 //! contention it grows with the contention. The constants stay honest and a
 //! quiet machine keeps the tight bound.
 //!
+//! That applies to **mocha's own per-test backstop** too. A test that overrides
+//! it with `this.timeout(N)` must (a) scale `N` with [`scaledTimeout`], and (b)
+//! choose it to outlast the *sum* of the bounded waits inside the test —
+//! `activate` alone can spend 60s on a cold LSP handshake before the test's own
+//! wait begins. An override that fires first reports "Timeout of Nms exceeded"
+//! and names neither the outstanding wait nor why, which is precisely the
+//! unattributable failure this module exists to remove.
+//!
 //! The cheap signal (run-queue oversubscription) is read up front; the
 //! expensive one (scheduling latency, which costs ~100ms to sample) is taken
 //! only **at the moment of giving up**, where its cost is irrelevant. If it

--- a/editors/vscode/src/test/variableContexts.test.ts
+++ b/editors/vscode/src/test/variableContexts.test.ts
@@ -25,6 +25,7 @@ import {
   waitForDeepDiagnostics,
   getServerLogSize,
   pollUntil,
+  scaledTimeout,
 } from "./helper";
 
 function labelOf(item: vscode.CompletionItem): string {
@@ -204,7 +205,7 @@ suite("Variable Completion: command contexts", () => {
   }
 
   suiteSetup(async function () {
-    this.timeout(30_000);
+    this.timeout(scaledTimeout(30_000));
     doc = await activate(docUri);
     for (let i = 0; i < PROBES.length; i++) {
       const p = PROBES[i];

--- a/editors/vscode/src/test/w120WorkspaceReschedule.test.ts
+++ b/editors/vscode/src/test/w120WorkspaceReschedule.test.ts
@@ -19,7 +19,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import * as path from "path";
-import { getDocUri, activate, waitForDiagnostics } from "./helper";
+import { getDocUri, activate, waitForDiagnostics, scaledTimeout } from "./helper";
 
 // Issue #829, third bug: `initialized()` kicks off `scan_workspace_folders()`
 // (which populates `workspace_index` / `package_resolver`, the inputs the
@@ -70,7 +70,7 @@ suite("W120 workspace-index reschedule (#829)", () => {
     "a false-positive W120 clears once an on-disk (unopened) ancestor sources " +
       "and requires it, without editing the caller",
     async function () {
-      this.timeout(60_000);
+      this.timeout(scaledTimeout(60_000));
       await activate(callerUri);
 
       // Precondition: with no ancestor on disk, the single-file W120 stands

--- a/editors/vscode/src/test/waitDiscipline.test.ts
+++ b/editors/vscode/src/test/waitDiscipline.test.ts
@@ -22,8 +22,10 @@ import {
   activate,
   awaitSignal,
   bounded,
+  classifyLiveness,
   getDocUri,
   loadFactor,
+  type ProbeOutcome,
   scaledTimeout,
   waitForDiagnostics,
 } from "./helper";
@@ -246,6 +248,128 @@ suite("Wait discipline (issue #1274)", () => {
       Date.now() - started < 1_000,
       "bounded must not delay a promise that already settled",
     );
+  });
+
+  // Attributability of a stalled document (issue #1294).
+  //
+  // A timeout says the answer never came; on its own it cannot tell a wedged
+  // server apart from one document's queue being stuck, which is what left
+  // #1294's four consecutive `didOpen`-drain timeouts unexplainable. These pin
+  // both halves: that the classification is right for every combination of
+  // outcomes, and that the plumbing carries the verdict into the message
+  // without ever being able to displace the failure it explains.
+
+  const outcome = (answered: boolean): ProbeOutcome => ({ answered, afterMs: 1 });
+
+  test("the liveness verdict names the most general fault the probes support", () => {
+    // Nothing answers: the server, not this document.
+    assert.match(
+      classifyLiveness({
+        transport: outcome(false),
+        otherDocument: outcome(false),
+        retry: outcome(false),
+      }),
+      /SERVER WEDGED/,
+    );
+    // The server answers a document-free request but no document at all.
+    assert.match(
+      classifyLiveness({
+        transport: outcome(true),
+        otherDocument: outcome(false),
+        retry: outcome(false),
+      }),
+      /DOCUMENT PIPELINE WEDGED/,
+    );
+    // Another document answers, this one still does not — #1294's hypothesis,
+    // and the distinction the report could not previously make.
+    assert.match(
+      classifyLiveness({
+        transport: outcome(true),
+        otherDocument: outcome(true),
+        retry: outcome(false),
+      }),
+      /THIS DOCUMENT'S QUEUE WEDGED/,
+    );
+    // Everything answers on retry: the request was lost, not the queue.
+    assert.match(
+      classifyLiveness({
+        transport: outcome(true),
+        otherDocument: outcome(true),
+        retry: outcome(true),
+      }),
+      /REQUEST DROPPED, NOT WEDGED/,
+    );
+    // A transport that never answered outranks a retry that did — a server
+    // that cannot answer a document-free request is the more general fault,
+    // whatever the later probes claim.
+    assert.match(
+      classifyLiveness({
+        transport: outcome(false),
+        otherDocument: outcome(true),
+        retry: outcome(true),
+      }),
+      /SERVER WEDGED/,
+    );
+  });
+
+  test("a timeout carries its follow-up probe's verdict", async () => {
+    let error: Error | undefined;
+    try {
+      await bounded(new Promise<void>(() => {}), "a stalled document request", {
+        timeout: 300,
+        diagnose: () => "LIVENESS: the follow-up probe ran",
+      });
+      assert.fail("bounded resolved for a promise that never settles");
+    } catch (err) {
+      error = err as Error;
+    }
+    assert.ok(error, "expected a rejection");
+    assert.ok(
+      error.message.includes("LIVENESS: the follow-up probe ran"),
+      `the verdict must reach the failure message: ${error.message}`,
+    );
+    assert.ok(
+      error.message.includes("a stalled document request"),
+      "the diagnostic must not displace what was awaited",
+    );
+  });
+
+  test("a follow-up probe that throws or hangs cannot displace the timeout", async () => {
+    for (const [label, diagnose] of [
+      [
+        "throws",
+        () => {
+          throw new Error("probe blew up");
+        },
+      ],
+      ["hangs", () => new Promise<string>(() => {})],
+    ] as const) {
+      const base = 300;
+      const started = Date.now();
+      let error: Error | undefined;
+      try {
+        await bounded(new Promise<void>(() => {}), `a stalled request (${label})`, {
+          timeout: base,
+          diagnose,
+        });
+        assert.fail(`bounded resolved for a promise that never settles (${label})`);
+      } catch (err) {
+        error = err as Error;
+      }
+      assert.ok(error, `expected a rejection (${label})`);
+      assert.ok(
+        error.message.includes("VSCODE-WAIT-TIMEOUT") &&
+          error.message.includes(`a stalled request (${label})`),
+        `the original timeout must survive a ${label} probe: ${error.message}`,
+      );
+      // The hanging probe is capped by signal.ts's own diagnostic budget, so
+      // the failure still arrives — it just arrives later than the bound.
+      const ceiling = boundCeiling(base) + (label === "hangs" ? 16_000 : 0);
+      assert.ok(
+        Date.now() - started < ceiling,
+        `a ${label} probe must not make the failure unbounded; took ${Date.now() - started}ms`,
+      );
+    }
   });
 
   test("a diagnostics wait returns on the publish event without waiting out a backstop", async () => {

--- a/editors/vscode/testFixture/issue1296Call.tcl
+++ b/editors/vscode/testFixture/issue1296Call.tcl
@@ -1,0 +1,2 @@
+set w [::MC::Widget new]
+puts [$w go]

--- a/editors/vscode/testFixture/issue1296MetaA.tcl
+++ b/editors/vscode/testFixture/issue1296MetaA.tcl
@@ -1,0 +1,2 @@
+namespace eval ::MC {}
+oo::class create ::MC::MetaA { superclass oo::class }

--- a/editors/vscode/testFixture/issue1296MetaB.tcl
+++ b/editors/vscode/testFixture/issue1296MetaB.tcl
@@ -1,0 +1,1 @@
+::MC::MetaA create ::MC::MetaB { superclass oo::class }

--- a/editors/vscode/testFixture/issue1296Unproved.tcl
+++ b/editors/vscode/testFixture/issue1296Unproved.tcl
@@ -1,0 +1,4 @@
+namespace eval ::U {}
+::U::Meta create ::U::Widget { method go {} { return went } }
+set u [::U::Widget new]
+puts [$u go]

--- a/editors/vscode/testFixture/issue1296Widget.tcl
+++ b/editors/vscode/testFixture/issue1296Widget.tcl
@@ -1,0 +1,1 @@
+::MC::MetaB create ::MC::Widget { method go {} { return went } }

--- a/editors/vscode/testFixture/livenessProbe.tcl
+++ b/editors/vscode/testFixture/livenessProbe.tcl
@@ -1,0 +1,5 @@
+# Asked about only by the liveness probe in src/test/helper.ts (issue #1294),
+# never driven by a test — so a hover on it can never be queued behind another
+# test's edits, and an answer here means the server's document pipeline is
+# draining for documents other than the stalled one.
+set probe 1

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -5678,6 +5678,123 @@ mod class_factories {
             r.all_procs.keys().collect::<Vec<_>>()
         );
     }
+
+    // -- the chained factory index (issue #1296) -------------------------
+    //
+    // The workspace index is published by the host as a *fixpoint*, because a
+    // metaclass manufactured by another file's metaclass is only provable once
+    // the manufacturing one is already in the index.  The salsa-layer loop is
+    // covered by `tcl-lsp-db`'s `class_factory_fixpoint` suite; what belongs
+    // here is the analyser half of the same fact — that a round handed the
+    // deeper index really does prove the next link, and that the surfaces the
+    // language allows around it behave.
+    //
+    // Ground truth, byte-identical on tclsh 8.6.16 and 9.0.4, for the chain
+    // below sourced as one script:
+    //
+    //   info object isa class ::MC::MetaB      -> 1
+    //   info class superclasses ::MC::MetaB    -> ::oo::class
+    //   info object isa class ::MC::Widget     -> 1
+    //   info class methods ::MC::Widget        -> go
+    //   [::MC::Widget new] go                  -> went
+
+    const CHAIN_META_A: &str =
+        "namespace eval ::MC {}\noo::class create ::MC::MetaA { superclass oo::class }\n";
+    const CHAIN_META_B: &str = "::MC::MetaA create ::MC::MetaB { superclass oo::class }\n";
+    const CHAIN_WIDGET: &str = "::MC::MetaB create ::MC::Widget { method go {} { return went } }\n";
+
+    #[test]
+    fn a_second_link_metaclass_publishes_a_factory_once_the_first_is_indexed() {
+        // TP, the analyser half of #1296. Round 1's index (`MetaA` alone,
+        // provable with no index at all) is exactly what lets the file holding
+        // `MetaA create MetaB` publish `MetaB` — so the host's next round has
+        // something new to merge. Without the index the same file publishes
+        // nothing, which is the FN the ticket is about.
+        let round1 = factories_of(CHAIN_META_A);
+        assert_eq!(round1.keys().collect::<Vec<_>>(), ["::MC::MetaA"]);
+
+        let bare = Analyser::new()
+            .analyse(CHAIN_META_B, "tcl9.0")
+            .class_factories();
+        assert!(
+            bare.is_empty(),
+            "with no oracle the middle link proves nothing: {:?}",
+            bare.keys().collect::<Vec<_>>()
+        );
+
+        let round2 = analysis_with_factories(CHAIN_META_B, &round1).class_factories();
+        assert_eq!(
+            round2.keys().collect::<Vec<_>>(),
+            ["::MC::MetaB"],
+            "handed the first link, the file proves the second"
+        );
+        assert_eq!(round2["::MC::MetaB"].root_metaclass, "oo::class");
+    }
+
+    #[test]
+    fn the_third_link_records_the_class_and_its_members() {
+        // TP. With both metaclasses in the index the consuming file records a
+        // real class with a real method — the fact go-to-definition on `$w go`
+        // needs, and the one that came back empty before the fixpoint.
+        let mut index = (*factories_of(CHAIN_META_A)).clone();
+        for (name, factory) in
+            analysis_with_factories(CHAIN_META_B, &factories_of(CHAIN_META_A)).class_factories()
+        {
+            index.insert(name, factory);
+        }
+        let index = std::sync::Arc::new(index);
+        let r = analysis_with_factories(CHAIN_WIDGET, &index);
+        let cd = r
+            .all_classes
+            .get("::MC::Widget")
+            .unwrap_or_else(|| panic!("::MC::Widget: {:?}", r.all_classes.keys()));
+        assert_eq!(cd.methods.keys().collect::<Vec<_>>(), ["go"], "{cd:?}");
+        assert!(!cd.inheritance_unknown, "{cd:?}");
+    }
+
+    #[test]
+    fn oo_define_after_the_fact_extends_a_chained_factory_made_class() {
+        // The `oo::define` surface: a class manufactured by a second-link
+        // metaclass takes later `oo::define` members like any other class.
+        //
+        // Oracle (tclsh 9.0.4 / 8.6.16): `info class methods ::MC::Widget`
+        // -> `go later` after the `oo::define`.
+        let index = chained_index();
+        let src = concat!(
+            "::MC::MetaB create ::MC::Widget { method go {} { return went } }\n",
+            "oo::define ::MC::Widget { method later {} { return l } }\n",
+        );
+        let r = analysis_with_factories(src, &index);
+        let cd = &r.all_classes["::MC::Widget"];
+        let mut methods: Vec<&str> = cd.methods.keys().map(String::as_str).collect();
+        methods.sort_unstable();
+        assert_eq!(methods, ["go", "later"], "{cd:?}");
+    }
+
+    #[test]
+    fn an_unproved_second_link_still_abstains() {
+        // TN. Handed an index that names only `MetaA`, a file writing
+        // `::MC::MetaB create …` has no proof `::MC::MetaB` manufactures
+        // anything — it could be `interp create` for all the walk knows — so it
+        // must record nothing rather than guessing the deeper link.
+        let r = analysis_with_factories(CHAIN_WIDGET, &factories_of(CHAIN_META_A));
+        assert!(
+            r.all_classes.is_empty(),
+            "no guess from a partially-published index: {:?}",
+            r.all_classes.keys().collect::<Vec<_>>()
+        );
+    }
+
+    /// The index a two-round publish produces for the ticket's chain:
+    /// `MetaA` proved with no oracle, `MetaB` proved with `MetaA` published.
+    fn chained_index() -> std::sync::Arc<tcl_compiler::analyser::ClassFactoryIndex> {
+        let first = factories_of(CHAIN_META_A);
+        let mut index = (*first).clone();
+        for (name, factory) in analysis_with_factories(CHAIN_META_B, &first).class_factories() {
+            index.insert(name, factory);
+        }
+        std::sync::Arc::new(index)
+    }
 }
 
 // ===========================================================================

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -395,12 +395,25 @@ pub fn project_proc_names(db: &dyn salsa::Database, project: Project) -> Arc<BTr
 /// edit that does not change a metaclass's `create` override leaves this
 /// equal, so it backdates and no cross-file query re-runs.
 ///
-/// [`item_tree`] itself reads [`SourceFile::workspace_class_factories`], so a
-/// metaclass that is *itself* manufactured by another file's metaclass is
-/// picked up on the host's next sync round rather than needing a fixpoint
-/// here: the sync is compare-then-set, so it stops as soon as the index stops
-/// moving. What never happens is a *guess* — a round adds an entry only when
-/// some file proved it.
+/// [`item_tree`] itself reads [`SourceFile::workspace_class_factories`], so
+/// this query is a function of the very input the host computes *from* it. A
+/// metaclass that is **itself** manufactured by another file's metaclass is
+/// therefore not provable until the manufacturing metaclass has already been
+/// published: the file holding `MetaA create MetaB` proves `MetaB` only on a
+/// round whose index already names `MetaA`. One publish is consequently one
+/// link of the chain deep, and no more — so the host must **iterate the
+/// publish to a fixpoint**, not publish once (issue #1296; before the fixpoint
+/// landed a cross-file `MetaA` → `MetaB` → `Widget` chain left `Widget`
+/// unknown, and a call site on one of its methods resolved to nothing).
+///
+/// The fixpoint is cheap and terminates: a round adds an entry only when some
+/// file *proved* it — never a guess — so the round function is normally
+/// monotone over a set bounded by the project's creation calls, and the host
+/// stops as soon as a round moves nothing. A workspace with no metaclass at
+/// all computes an empty index, which the host stores as `None`, so it settles
+/// in one round that writes nothing and invalidates nothing. The host caps the
+/// loop regardless rather than assuming convergence — see
+/// `sync_workspace_class_factories` in `tcl-lsp-server`.
 #[salsa::tracked]
 pub fn file_class_factories(
     db: &dyn salsa::Database,

--- a/rust/tcl-lsp-db/tests/class_factory_fixpoint.rs
+++ b/rust/tcl-lsp-db/tests/class_factory_fixpoint.rs
@@ -1,0 +1,475 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The workspace class-factory index is a **fixpoint**, not a single round
+//! (issue #1296).
+//!
+//! `project_class_factories` merges every file's `file_class_factories`, which
+//! reads `item_tree`, which reads the per-file `SourceFile::workspace_class_factories`
+//! input the host computes *from* that merge.  The query is therefore a
+//! function of its own published answer, and one publish only ever advances the
+//! metaclass chain by one link: `MetaA` is provable with no index at all, but
+//! the file holding `MetaA create MetaB` proves `MetaB` only on a round whose
+//! published index already names `MetaA`.  A host that publishes once leaves
+//! every class `MetaB` manufactures unknown — which is what made a cross-file
+//! three-level chain resolve to nothing from a call site.
+//!
+//! These tests drive the same loop `tcl-lsp-server`'s
+//! `sync_workspace_class_factories` drives, so a regression in the salsa layer
+//! (a query that stops seeing the published input, a merge that stops being
+//! monotone) fails here without needing a live server.
+//!
+//! C-Tcl ground truth for the shapes below (tclsh 8.6.16 and 9.0.4 agree):
+//!
+//! ```text
+//! namespace eval ::MC {}
+//! oo::class create ::MC::MetaA { superclass oo::class }
+//! ::MC::MetaA create ::MC::MetaB { superclass oo::class }
+//! ::MC::MetaB create ::MC::Widget { method go {} { return went } }
+//! puts [[::MC::Widget new] go]              -> went
+//! info object isa class ::MC::Widget        -> 1
+//! info class methods ::MC::Widget           -> go
+//! ```
+
+use salsa::Setter as _;
+use std::sync::Arc;
+use tcl_compiler::analyser::ClassFactoryIndex;
+use tcl_lsp_db::{
+    Project, SourceFile, TclDatabase, file_class_factories, file_decls, project_class_factories,
+};
+
+const DIALECT: &str = "tcl9.0";
+
+/// Same bound the host applies, and for the same reason: convergence is
+/// expected, not assumed.
+const ROUND_CAP: usize = 16;
+
+/// What one fixpoint run observed.
+struct Fixpoint {
+    /// Rounds run, including the final one that only confirmed the fixpoint.
+    /// A workspace with no metaclass settles in 1.
+    rounds: usize,
+    /// The converged project-wide index.
+    index: Arc<ClassFactoryIndex>,
+    /// Whether the loop hit [`ROUND_CAP`] without settling.
+    hit_cap: bool,
+}
+
+/// Drive the class-factory publish to a fixpoint exactly as the host does:
+/// merge the project, compare-then-set the merged index on every file, and stop
+/// as soon as a round moves nothing.
+fn publish_to_fixpoint(db: &mut TclDatabase, project: Project, files: &[SourceFile]) -> Fixpoint {
+    for round in 1..=ROUND_CAP {
+        let index = project_class_factories(db, project);
+        let want = (!index.is_empty()).then(|| Arc::clone(&index));
+        let mut moved = false;
+        for &file in files {
+            if file.workspace_class_factories(db).as_deref() != want.as_deref() {
+                file.set_workspace_class_factories(db).to(want.clone());
+                moved = true;
+            }
+        }
+        if !moved {
+            return Fixpoint {
+                rounds: round,
+                index,
+                hit_cap: false,
+            };
+        }
+    }
+    Fixpoint {
+        rounds: ROUND_CAP,
+        index: project_class_factories(db, project),
+        hit_cap: true,
+    }
+}
+
+/// Build a project out of `sources` and publish its factory index to a
+/// fixpoint, returning the files (in the order given) and what the loop saw.
+fn project_of(db: &mut TclDatabase, sources: &[&str]) -> (Vec<SourceFile>, Fixpoint) {
+    let files: Vec<SourceFile> = sources
+        .iter()
+        .enumerate()
+        .map(|(i, src)| {
+            SourceFile::new(
+                db,
+                (*src).to_owned(),
+                DIALECT.to_owned(),
+                Some(format!("/w/f{i}.tcl")),
+            )
+        })
+        .collect();
+    let project = Project::new(&*db, files.clone());
+    let settled = publish_to_fixpoint(db, project, &files);
+    (files, settled)
+}
+
+fn factory_names(index: &ClassFactoryIndex) -> Vec<&str> {
+    index.keys().map(String::as_str).collect()
+}
+
+fn classes_of(db: &TclDatabase, file: SourceFile) -> Vec<String> {
+    file_decls(db, file).classes.iter().cloned().collect()
+}
+
+// The three files of the ticket's reproduction, one metaclass link each.
+const META_A: &str = "namespace eval ::MC {}\noo::class create ::MC::MetaA { superclass oo::class }\n";
+const META_B: &str = "::MC::MetaA create ::MC::MetaB { superclass oo::class }\n";
+const WIDGET: &str = "::MC::MetaB create ::MC::Widget { method go {} { return went } }\n";
+
+#[test]
+fn a_cross_file_three_level_chain_converges_and_records_the_class() {
+    // TP, the ticket itself. Three files, three links: the class the innermost
+    // metaclass manufactures must come out of the third file's declarations.
+    let mut db = TclDatabase::default();
+    let (files, settled) = project_of(&mut db, &[META_A, META_B, WIDGET]);
+    assert!(!settled.hit_cap, "must settle within the cap");
+    assert_eq!(
+        factory_names(&settled.index),
+        ["::MC::MetaA", "::MC::MetaB"],
+        "both metaclasses are proved, each by the file that writes it"
+    );
+    assert_eq!(
+        classes_of(&db, files[2]),
+        ["::MC::Widget"],
+        "the manufactured class must be a declaration of the consuming file"
+    );
+    // Three links, so the loop needs one round per link plus a confirming one.
+    assert_eq!(settled.rounds, 3, "one round per link, plus the confirmation");
+}
+
+#[test]
+fn a_single_publish_is_one_link_deep() {
+    // The regression itself, stated as an assertion rather than a story: run
+    // exactly one round of the same loop and the deepest link is missing, so a
+    // host that publishes once cannot see `::MC::Widget`. This is what fails if
+    // someone replaces the fixpoint with a single publish again.
+    let mut db = TclDatabase::default();
+    let files: Vec<SourceFile> = [META_A, META_B, WIDGET]
+        .iter()
+        .enumerate()
+        .map(|(i, src)| {
+            SourceFile::new(
+                &db,
+                (*src).to_owned(),
+                DIALECT.to_owned(),
+                Some(format!("/w/f{i}.tcl")),
+            )
+        })
+        .collect();
+    let project = Project::new(&db, files.clone());
+    let index = project_class_factories(&db, project);
+    let want = (!index.is_empty()).then(|| Arc::clone(&index));
+    for &file in &files {
+        file.set_workspace_class_factories(&mut db).to(want.clone());
+    }
+    assert_eq!(
+        factory_names(&index),
+        ["::MC::MetaA"],
+        "one publish proves only the link that needed no index"
+    );
+    assert!(
+        classes_of(&db, files[2]).is_empty(),
+        "the class made by the second-link metaclass is still invisible: {:?}",
+        classes_of(&db, files[2])
+    );
+}
+
+#[test]
+fn a_chain_deeper_than_three_still_converges() {
+    // The bound is the chain depth, not a hardcoded three: five links across
+    // five files, one per file, must all come out.
+    let mut db = TclDatabase::default();
+    let sources = [
+        "namespace eval ::D {}\noo::class create ::D::M1 { superclass oo::class }\n",
+        "::D::M1 create ::D::M2 { superclass oo::class }\n",
+        "::D::M2 create ::D::M3 { superclass oo::class }\n",
+        "::D::M3 create ::D::M4 { superclass oo::class }\n",
+        "::D::M4 create ::D::Leaf { method go {} { return went } }\n",
+    ];
+    let (files, settled) = project_of(&mut db, &sources);
+    assert!(!settled.hit_cap, "must settle within the cap");
+    assert_eq!(
+        factory_names(&settled.index),
+        ["::D::M1", "::D::M2", "::D::M3", "::D::M4"],
+        "every metaclass in the chain is a factory; the leaf class is not"
+    );
+    assert_eq!(classes_of(&db, files[4]), ["::D::Leaf"]);
+}
+
+#[test]
+fn the_file_order_does_not_change_the_answer() {
+    // The merge is unordered by design (a metaclass either exists in the
+    // project or it does not), so presenting the chain leaf-first must produce
+    // the same converged index and the same recorded class.
+    let mut db = TclDatabase::default();
+    let (files, settled) = project_of(&mut db, &[WIDGET, META_B, META_A]);
+    assert!(!settled.hit_cap);
+    assert_eq!(
+        factory_names(&settled.index),
+        ["::MC::MetaA", "::MC::MetaB"]
+    );
+    assert_eq!(
+        classes_of(&db, files[0]),
+        ["::MC::Widget"],
+        "the consumer is the first file this time"
+    );
+}
+
+#[test]
+fn a_metaclass_reached_through_namespace_eval_converges() {
+    // The chain's links are written inside `namespace eval` bodies and named
+    // relatively, so the resolution the walk does is the real
+    // current-namespace-then-global one rather than a global-name match.
+    //
+    // Oracle (tclsh 9.0.4 / 8.6.16): `[::N::Widget new] go` -> went, and
+    // `info class superclasses ::N::MetaB` -> ::oo::class.
+    let mut db = TclDatabase::default();
+    let sources = [
+        "namespace eval ::N {\n    oo::class create MetaA { superclass oo::class }\n}\n",
+        "namespace eval ::N {\n    MetaA create MetaB { superclass oo::class }\n}\n",
+        "namespace eval ::N {\n    MetaB create Widget { method go {} { return went } }\n}\n",
+    ];
+    let (files, settled) = project_of(&mut db, &sources);
+    assert!(!settled.hit_cap);
+    assert_eq!(factory_names(&settled.index), ["::N::MetaA", "::N::MetaB"]);
+    assert_eq!(classes_of(&db, files[2]), ["::N::Widget"]);
+}
+
+#[test]
+fn a_cycle_terminates_and_proves_nothing() {
+    // TN + termination. `A` made by `B` made by `A` is not a program real Tcl
+    // can run (neither command exists when the other is defined), and neither
+    // link is ever proved, so the loop must settle immediately on an empty
+    // index rather than oscillating up to the cap.
+    let mut db = TclDatabase::default();
+    let sources = [
+        "namespace eval ::C {}\n::C::B create ::C::A { superclass oo::class }\n",
+        "::C::A create ::C::B { superclass oo::class }\n",
+    ];
+    let (files, settled) = project_of(&mut db, &sources);
+    assert!(!settled.hit_cap, "a cycle must not run to the cap");
+    assert_eq!(settled.rounds, 1, "nothing is proved, so nothing moves");
+    assert!(
+        settled.index.is_empty(),
+        "no guess: {:?}",
+        factory_names(&settled.index)
+    );
+    for &file in &files {
+        assert!(
+            classes_of(&db, file).is_empty(),
+            "a cyclic declaration manufactures nothing: {:?}",
+            classes_of(&db, file)
+        );
+    }
+}
+
+#[test]
+fn an_unproved_metaclass_still_abstains() {
+    // TN. `Meta create X …` where nothing in the project proves `::U::Meta` is
+    // a class factory is, on shape alone, indistinguishable from `interp
+    // create` — so no class may be recorded and no index entry invented.
+    let mut db = TclDatabase::default();
+    let sources = [
+        "namespace eval ::U {}\nputs hello\n",
+        "::U::Meta create ::U::Widget { method go {} { return went } }\n",
+    ];
+    let (files, settled) = project_of(&mut db, &sources);
+    assert_eq!(settled.rounds, 1);
+    assert!(
+        settled.index.is_empty(),
+        "nothing proved a factory: {:?}",
+        factory_names(&settled.index)
+    );
+    assert!(
+        classes_of(&db, files[1]).is_empty(),
+        "abstain rather than guess a class: {:?}",
+        classes_of(&db, files[1])
+    );
+}
+
+#[test]
+fn a_same_named_proc_is_not_mistaken_for_the_metaclass() {
+    // FP guard. A `proc ::MC::MetaB {args} {…}` in the project declares a
+    // command with the metaclass's name but is not a class factory, so it must
+    // not put `::MC::MetaB` in the index and must not turn
+    // `::MC::MetaB create …` into a class. The chain is deliberately cut one
+    // link short (no `MetaA create MetaB`) so the *only* candidate for the name
+    // is the proc.
+    let mut db = TclDatabase::default();
+    let sources = [
+        META_A,
+        "proc ::MC::MetaB {args} { return $args }\n",
+        WIDGET,
+    ];
+    let (files, settled) = project_of(&mut db, &sources);
+    assert_eq!(
+        factory_names(&settled.index),
+        ["::MC::MetaA"],
+        "a proc of that name proves nothing about class manufacture"
+    );
+    assert!(
+        classes_of(&db, files[2]).is_empty(),
+        "`::MC::MetaB create …` must stay unclassified: {:?}",
+        classes_of(&db, files[2])
+    );
+}
+
+#[test]
+fn a_local_class_of_the_same_name_shadows_the_workspace_one() {
+    // FP guard, the other direction: the consuming file writes its own
+    // `::MC::MetaB` that is an ordinary class (no metaclass superclass), so the
+    // workspace entry must not reach past it. Real Tcl resolves the command to
+    // whatever the interpreter last defined; the walk's rule is that the file's
+    // own declaration wins, exactly as it does for a proc.
+    let mut db = TclDatabase::default();
+    let sources = [
+        META_A,
+        META_B,
+        "oo::class create ::MC::MetaB { method plain {} { return p } }\n\
+         ::MC::MetaB create ::MC::Widget { method go {} { return went } }\n",
+    ];
+    let (files, _) = project_of(&mut db, &sources);
+    let classes = classes_of(&db, files[2]);
+    assert!(
+        classes.contains(&"::MC::MetaB".to_owned()),
+        "the file's own class is a declaration: {classes:?}"
+    );
+    assert!(
+        !classes.contains(&"::MC::Widget".to_owned()),
+        "the local, non-factory `::MC::MetaB` manufactures nothing: {classes:?}"
+    );
+}
+
+#[test]
+fn a_workspace_with_no_metaclass_costs_no_extra_round() {
+    // The overwhelmingly common case, and the one the whole mechanism promises
+    // to leave alone: an empty index is stored as `None`, the input never
+    // leaves its default, so the loop settles on its first round having written
+    // nothing at all.
+    let mut db = TclDatabase::default();
+    let sources = [
+        "proc greet {name} { puts \"hi $name\" }\n",
+        "oo::class create Dog {\n    method speak {} { return woof }\n}\ngreet world\n",
+    ];
+    let (files, settled) = project_of(&mut db, &sources);
+    assert_eq!(settled.rounds, 1, "no metaclass ⇒ exactly one round");
+    assert!(settled.index.is_empty());
+    for &file in &files {
+        assert!(
+            file.workspace_class_factories(&db).is_none(),
+            "the input must never leave its `None` default"
+        );
+        assert!(
+            file_class_factories(&db, file).is_empty(),
+            "and no file publishes a factory"
+        );
+    }
+    assert_eq!(classes_of(&db, files[1]), ["::Dog"]);
+}
+
+#[test]
+fn adding_the_middle_link_later_converges_from_the_settled_state() {
+    // The edit path, not just the cold-start path: a project that has already
+    // settled without the middle link must converge again — to the deeper
+    // answer — when that link is typed in, starting from the previously
+    // published index rather than from scratch.
+    let mut db = TclDatabase::default();
+    let files: Vec<SourceFile> = ["", META_A, WIDGET]
+        .iter()
+        .enumerate()
+        .map(|(i, src)| {
+            SourceFile::new(
+                &db,
+                (*src).to_owned(),
+                DIALECT.to_owned(),
+                Some(format!("/w/f{i}.tcl")),
+            )
+        })
+        .collect();
+    let project = Project::new(&db, files.clone());
+    let first = publish_to_fixpoint(&mut db, project, &files);
+    assert_eq!(factory_names(&first.index), ["::MC::MetaA"]);
+    assert!(
+        classes_of(&db, files[2]).is_empty(),
+        "without the middle link there is nothing to prove `::MC::MetaB`"
+    );
+
+    files[0].set_text(&mut db).to(META_B.to_owned());
+    let second = publish_to_fixpoint(&mut db, project, &files);
+    assert!(!second.hit_cap);
+    assert_eq!(
+        factory_names(&second.index),
+        ["::MC::MetaA", "::MC::MetaB"],
+        "the edit's link is picked up and published"
+    );
+    assert_eq!(classes_of(&db, files[2]), ["::MC::Widget"]);
+}
+
+#[test]
+fn removing_a_link_retracts_the_classes_it_manufactured() {
+    // The monotone story is per-round, not across edits: deleting the middle
+    // link must take `::MC::MetaB` — and the class it made — back out, rather
+    // than leaving a published entry nothing proves any more.
+    let mut db = TclDatabase::default();
+    let (files, settled) = project_of(&mut db, &[META_A, META_B, WIDGET]);
+    assert_eq!(factory_names(&settled.index), ["::MC::MetaA", "::MC::MetaB"]);
+
+    files[1].set_text(&mut db).to(String::new());
+    let project = Project::new(&db, files.clone());
+    let after = publish_to_fixpoint(&mut db, project, &files);
+    assert!(!after.hit_cap);
+    assert_eq!(factory_names(&after.index), ["::MC::MetaA"]);
+    assert!(
+        classes_of(&db, files[2]).is_empty(),
+        "the class its metaclass made goes with it: {:?}",
+        classes_of(&db, files[2])
+    );
+}
+
+#[test]
+fn an_overriding_manufacturer_survives_the_extra_link() {
+    // The Tk shape (issue #1276) with one more link in front of it: the
+    // metaclass that overrides `create {name superclasses body}` is *itself*
+    // manufactured cross-file, so the override's argument layout has to survive
+    // being read on a later round rather than the first.
+    //
+    // Oracle (tclsh 9.0.4 / 8.6.16):
+    //   info class superclasses ::IconList -> ::Root ::Focusable
+    //   info class methods ::IconList      -> (its own)
+    let mut db = TclDatabase::default();
+    let sources = [
+        "oo::class create ::Root { method trace {} { return traced } }\n\
+         oo::class create ::Base { superclass oo::class }\n",
+        "::Base create ::Mega {\n    superclass oo::class\n\
+         \x20   self method create {name superclasses body} {\n\
+         \x20       next $name [list superclass ::Root {*}$superclasses]\\;$body\n\
+         \x20   }\n}\n",
+        "::Mega create ::IconList ::Focusable {\n    method GetSpecs {} { return specs }\n}\n",
+    ];
+    let (files, settled) = project_of(&mut db, &sources);
+    assert!(!settled.hit_cap);
+    assert_eq!(factory_names(&settled.index), ["::Base", "::Mega"]);
+    assert_eq!(classes_of(&db, files[2]), ["::IconList"]);
+    let spec = &settled.index["::Mega"].overrides["create"];
+    assert_eq!(
+        (spec.name_arg, spec.body_arg),
+        (1, 3),
+        "the override's own layout is read, not guessed: {spec:?}"
+    );
+}

--- a/rust/tcl-lsp-db/tests/class_factory_fixpoint.rs
+++ b/rust/tcl-lsp-db/tests/class_factory_fixpoint.rs
@@ -128,7 +128,8 @@ fn classes_of(db: &TclDatabase, file: SourceFile) -> Vec<String> {
 }
 
 // The three files of the ticket's reproduction, one metaclass link each.
-const META_A: &str = "namespace eval ::MC {}\noo::class create ::MC::MetaA { superclass oo::class }\n";
+const META_A: &str =
+    "namespace eval ::MC {}\noo::class create ::MC::MetaA { superclass oo::class }\n";
 const META_B: &str = "::MC::MetaA create ::MC::MetaB { superclass oo::class }\n";
 const WIDGET: &str = "::MC::MetaB create ::MC::Widget { method go {} { return went } }\n";
 
@@ -150,7 +151,10 @@ fn a_cross_file_three_level_chain_converges_and_records_the_class() {
         "the manufactured class must be a declaration of the consuming file"
     );
     // Three links, so the loop needs one round per link plus a confirming one.
-    assert_eq!(settled.rounds, 3, "one round per link, plus the confirmation");
+    assert_eq!(
+        settled.rounds, 3,
+        "one round per link, plus the confirmation"
+    );
 }
 
 #[test]
@@ -312,11 +316,7 @@ fn a_same_named_proc_is_not_mistaken_for_the_metaclass() {
     // link short (no `MetaA create MetaB`) so the *only* candidate for the name
     // is the proc.
     let mut db = TclDatabase::default();
-    let sources = [
-        META_A,
-        "proc ::MC::MetaB {args} { return $args }\n",
-        WIDGET,
-    ];
+    let sources = [META_A, "proc ::MC::MetaB {args} { return $args }\n", WIDGET];
     let (files, settled) = project_of(&mut db, &sources);
     assert_eq!(
         factory_names(&settled.index),
@@ -428,7 +428,10 @@ fn removing_a_link_retracts_the_classes_it_manufactured() {
     // than leaving a published entry nothing proves any more.
     let mut db = TclDatabase::default();
     let (files, settled) = project_of(&mut db, &[META_A, META_B, WIDGET]);
-    assert_eq!(factory_names(&settled.index), ["::MC::MetaA", "::MC::MetaB"]);
+    assert_eq!(
+        factory_names(&settled.index),
+        ["::MC::MetaA", "::MC::MetaB"]
+    );
 
     files[1].set_text(&mut db).to(String::new());
     let project = Project::new(&db, files.clone());

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -1954,8 +1954,16 @@ async fn refresh_cross_file_evidence(
     slots: &Arc<Mutex<HashMap<Uri, DiagSlot>>>,
     uri: &Uri,
 ) {
-    let mut changed = sync_cross_file_evidence(handles).await;
-    for uri in sync_workspace_class_factories(handles).await {
+    // Class factories first, call-site evidence second, because the second
+    // reads the first: `file_call_site_evidence` resolves against
+    // `project_proc_names` / `file_decls`, both of which come off `item_tree`,
+    // which reads `SourceFile::workspace_class_factories`.  Run the other way
+    // round, every call-site table is computed under the pre-sync oracle and
+    // then immediately invalidated by the factory publish, so the pass costs a
+    // full project scan whose answer is thrown away and the corrected one
+    // waits on a reschedule (issue #1296).
+    let mut changed = sync_workspace_class_factories(handles).await;
+    for uri in sync_cross_file_evidence(handles).await {
         if !changed.contains(&uri) {
             changed.push(uri);
         }
@@ -2164,35 +2172,136 @@ async fn sync_cross_file_evidence(handles: &EvidenceHandles) -> Vec<Uri> {
     changed
 }
 
+/// How many publish rounds [`sync_workspace_class_factories`] will run before
+/// it gives up and logs.
+///
+/// The round function only ever *adds* an entry some file proved, so it
+/// converges after one round per link of the longest metaclass chain plus one
+/// to observe the fixpoint.  Real chains are two or three links
+/// (`oo::class` → `Megawidget` → a widget's own metaclass); this leaves an
+/// order of magnitude of headroom while still making the loop provably
+/// bounded, so a pathological or half-edited workspace — one where an added
+/// entry re-shapes a body such that a previously-proved entry disappears, and
+/// the index oscillates instead of settling — costs a bounded amount of work
+/// rather than spinning the diagnostics worker forever.
+const CLASS_FACTORY_SYNC_ROUNDS: usize = 16;
+
 /// Refresh every project file's [`tcl_lsp_db::SourceFile::workspace_class_factories`]
-/// — the workspace's user-defined `TclOO` metaclasses (issue #1276) — and
-/// report the URIs whose oracle actually moved.
+/// — the workspace's user-defined `TclOO` metaclasses (issue #1276) — to a
+/// **fixpoint**, and report the union of the URIs whose oracle moved across
+/// all rounds.
 ///
 /// One index serves every file: a metaclass is a project-wide declaration,
 /// not a per-file slice, and there is no per-file narrowing to make.  It is
 /// **empty for the overwhelming majority of workspaces**, and an empty index
 /// is stored as `None`, so the input never leaves its default and nothing is
 /// ever invalidated by it — a workspace with no metaclass behaves exactly as
-/// it did before the index existed.
+/// it did before the index existed, and settles in exactly one round that
+/// writes nothing.
 ///
-/// Same shape as [`sync_cross_file_evidence`] and for the same reasons: the
-/// project-wide read runs on a cloned salsa snapshot inside `spawn_blocking`
-/// so the `db` mutex is held only for the short write section, cancellation
-/// is caught and reported as "nothing changed", and the write is
-/// compare-then-set against the *live* database rather than the snapshot.
+/// **Why a fixpoint and not a single round** (issue #1296).  The index is
+/// computed from [`tcl_lsp_db::project_class_factories`], which reads each
+/// file's `item_tree`, which reads the very input this function writes.  A
+/// metaclass that is *itself* manufactured by another file's metaclass is
+/// therefore provable only once the manufacturing metaclass is already
+/// published: round 1 proves `MetaA` (written out as `oo::class create`, so
+/// provable with no index at all), and only in round 2 can the file holding
+/// `MetaA create MetaB` prove `MetaB`.  A single round left `MetaB` — and so
+/// every class `MetaB` makes — unknown, which is what made a cross-file
+/// three-level chain resolve to nothing from a call site.  Each round is run
+/// against a snapshot taken *after* the previous round's writes, so the next
+/// link of the chain is visible to it.
+///
+/// **Termination.**  A round writes only what some file proved — never a
+/// guess — so the normal case is monotone growth over a set bounded by the
+/// project's creation calls, and the loop ends as soon as a round moves
+/// nothing.  A cyclic declaration (`A` made by `B` made by `A`) proves
+/// neither, so it settles empty on the first round.  Convergence is not
+/// *assumed*, though: [`CLASS_FACTORY_SYNC_ROUNDS`] caps the loop, and hitting
+/// the cap logs to stderr and returns what has been published so far, which is
+/// a valid — if possibly incomplete — index, because every entry in it was
+/// proved by some file.
+///
+/// Each round has the same shape as [`sync_cross_file_evidence`] and for the
+/// same reasons: the project-wide read runs on a cloned salsa snapshot inside
+/// `spawn_blocking` so the `db` mutex is held only for the short write
+/// section, and the write is compare-then-set against the *live* database
+/// rather than the snapshot.  A round the concurrent write cancelled publishes
+/// nothing and is **not** the fixpoint — it is simply a round whose answer we
+/// never learned, so the loop takes another one against a fresh snapshot
+/// rather than mistaking "unknown" for "settled".  That retry is what the cap
+/// bounds in the pathological case; without it a `did_open` arriving mid-pass
+/// truncated the chain at whatever link had been published so far, and the
+/// deeper links waited on whatever unrelated edit happened to run the sync
+/// next.
 ///
 /// Called from two places, because the answer must be in place before either
 /// consumer needs it: at the end of the workspace scan (so a document opened
 /// afterwards is analysed with the oracle on its very first pass) and after
 /// each diagnostics publish (so a metaclass added by an *edit* propagates).
 async fn sync_workspace_class_factories(handles: &EvidenceHandles) -> Vec<Uri> {
+    let mut changed: Vec<Uri> = Vec::new();
+    let mut seen: HashSet<Uri> = HashSet::new();
+    for _ in 0..CLASS_FACTORY_SYNC_ROUNDS {
+        let __t0 = std::time::Instant::now();
+        let __r = sync_workspace_class_factories_round(handles).await;
+        {
+            use std::io::Write as _;
+            if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open("/tmp/dbg1296.log") {
+                let _ = writeln!(f, "ROUND {:?} {}", __t0.elapsed(), match &__r { ClassFactoryRound::Settled => "settled".to_string(), ClassFactoryRound::Cancelled => "cancelled".to_string(), ClassFactoryRound::Moved(v) => format!("moved {}", v.len()) });
+            }
+        }
+        match __r {
+            // The fixpoint: every file already carries the index the project
+            // proves, so another round would recompute a byte-identical one
+            // off unchanged inputs.
+            ClassFactoryRound::Settled => return changed,
+            ClassFactoryRound::Cancelled => {}
+            ClassFactoryRound::Moved(moved) => {
+                for uri in moved {
+                    if seen.insert(uri.clone()) {
+                        changed.push(uri);
+                    }
+                }
+            }
+        }
+    }
+    eprintln!(
+        "tcl-lsp: the workspace class-factory index did not settle in \
+         {CLASS_FACTORY_SYNC_ROUNDS} rounds; publishing what has been proved so far. \
+         Classes made by a metaclass deeper than that in the chain may not resolve \
+         until the next sync."
+    );
+    changed
+}
+
+/// What one [`sync_workspace_class_factories`] round learned.
+///
+/// `Settled` and `Cancelled` are deliberately distinct: both publish nothing,
+/// but only the first is evidence that the index has stopped moving.
+enum ClassFactoryRound {
+    /// The published index already equals the one the project proves.
+    Settled,
+    /// These files' published index moved.
+    Moved(Vec<Uri>),
+    /// A concurrent write cancelled the read before it finished; nothing was
+    /// published and nothing was learned.
+    Cancelled,
+}
+
+/// One round of [`sync_workspace_class_factories`]: recompute the project's
+/// class-factory index off a fresh snapshot and compare-then-set it on every
+/// file.
+async fn sync_workspace_class_factories_round(handles: &EvidenceHandles) -> ClassFactoryRound {
     use salsa::Setter as _;
     let (snapshot, files, project) = {
         let db = handles.db.lock().await;
         let db_files = handles.db_files.lock().await;
         let db_project = handles.db_project.lock().await;
         let Some(&project) = db_project.as_ref() else {
-            return Vec::new();
+            // No project input yet — nothing to merge, and nothing a further
+            // round could learn.
+            return ClassFactoryRound::Settled;
         };
         let files: Vec<(Uri, tcl_lsp_db::SourceFile)> =
             db_files.iter().map(|(u, &f)| (u.clone(), f)).collect();
@@ -2204,6 +2313,12 @@ async fn sync_workspace_class_factories(handles: &EvidenceHandles) -> Vec<Uri> {
     let computed = tokio::task::spawn_blocking(move || {
         salsa::Cancelled::catch(std::panic::AssertUnwindSafe(|| {
             let index = tcl_lsp_db::project_class_factories(&snapshot, project);
+            {
+                use std::io::Write as _;
+                if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open("/tmp/dbg1296.log") {
+                    let _ = writeln!(f, "  index={:?}", index.keys().collect::<Vec<_>>());
+                }
+            }
             let want = (!index.is_empty()).then_some(index);
             let pending: Vec<(Uri, tcl_lsp_db::SourceFile)> = files
                 .into_iter()
@@ -2217,7 +2332,7 @@ async fn sync_workspace_class_factories(handles: &EvidenceHandles) -> Vec<Uri> {
     })
     .await;
     let Ok(Some((want, pending))) = computed else {
-        return Vec::new();
+        return ClassFactoryRound::Cancelled;
     };
     let mut db = handles.db.lock().await;
     let mut changed = Vec::with_capacity(pending.len());
@@ -2229,7 +2344,11 @@ async fn sync_workspace_class_factories(handles: &EvidenceHandles) -> Vec<Uri> {
             .to(want.clone());
         changed.push(uri);
     }
-    changed
+    if changed.is_empty() {
+        ClassFactoryRound::Settled
+    } else {
+        ClassFactoryRound::Moved(changed)
+    }
 }
 
 /// The evidence `uri` should be carrying, or `None` when the host cannot claim
@@ -3640,6 +3759,19 @@ impl FeatureToggles {
     /// [`Self::apply`].
     fn set_flag(&mut self, feature: &str, value: bool) {
         self.set.insert(feature.to_owned(), value);
+    }
+
+    /// `self` with every key `overlay` sets explicitly taking precedence —
+    /// the folder-over-global resolution
+    /// [`Backend::resolved_feature_toggles`] performs.  A key the overlay does
+    /// not carry keeps this set's value, so a folder that mentions one feature
+    /// does not silently reset the rest to their defaults.
+    fn overlaid_with(&self, overlay: &Self) -> Self {
+        let mut merged = self.clone();
+        for (key, &flag) in &overlay.set {
+            merged.set.insert(key.clone(), flag);
+        }
+        merged
     }
 
     /// The full resolved `{feature: bool}` map for `getEffectiveConfig`.
@@ -9593,7 +9725,20 @@ impl Backend {
             Some(uri) => self.resolved_extra_commands(uri).await,
             None => self.extra_commands.lock().await.clone(),
         };
-        let features = self.feature_toggles.lock().await.resolved_map();
+        // Resolved through the same folder chain every provider gate uses, so a
+        // client polling this command observes the fact the provider will act
+        // on rather than the process-global one.  The two used to differ, which
+        // made a folder-scoped toggle invisible here and left the VS Code
+        // suite's toggle barrier waiting on the wrong fact (issue #1295).
+        // Resolved through the same folder chain every provider gate uses, so a
+        // client polling this command observes the fact the provider will act
+        // on rather than the process-global one.  The two used to differ, which
+        // made a folder-scoped toggle invisible here and left the VS Code
+        // suite's toggle barrier waiting on the wrong fact (issue #1295).
+        let features = self
+            .resolved_feature_toggles(parsed_uri.as_ref())
+            .await
+            .resolved_map();
         let optimiser_enabled = *self.optimiser_enabled.lock().await;
         // The optimiser *profile* and the editor `libraryPaths` are as much a
         // part of "what config is in effect" as the master switch, and a caller
@@ -10277,19 +10422,34 @@ impl Backend {
         *self.folder_configs.lock().await = parsed;
     }
 
+    /// The feature toggles in effect for `uri` — the process-global set with
+    /// the deepest containing folder's explicitly-set keys layered on top.
+    ///
+    /// Every per-URI toggle question resolves through this one place, so what
+    /// `getEffectiveConfig` *reports* for a document cannot drift from what the
+    /// providers *do* for it.  It used to: the command reported the global map
+    /// while every gate below consulted the folder chain first, which made
+    /// `waitForFeatureToggle` (the VS Code suite's barrier before asserting a
+    /// toggle took effect) observe a different fact from the one the provider
+    /// would use — issue #1295.
+    ///
+    /// `uri` is optional because the command also answers for no document at
+    /// all, which resolves to the global set alone.
+    async fn resolved_feature_toggles(&self, uri: Option<&Uri>) -> FeatureToggles {
+        let global = self.feature_toggles.lock().await.clone();
+        let Some(uri) = uri else { return global };
+        let configs = self.folder_configs.lock().await;
+        match longest_folder_match(&configs, uri) {
+            Some(fc) => global.overlaid_with(&fc.feature_toggles),
+            None => global,
+        }
+    }
+
     /// Whether the named `tclLsp.features.*` provider is enabled.
     async fn feature_enabled(&self, feature: &str, uri: &Uri) -> bool {
-        // A folder that explicitly sets the toggle wins for documents under it;
-        // otherwise fall back to the process-global toggle state.
-        {
-            let configs = self.folder_configs.lock().await;
-            if let Some(fc) = longest_folder_match(&configs, uri)
-                && let Some(flag) = fc.feature_toggles.set.get(feature).copied()
-            {
-                return flag;
-            }
-        }
-        self.feature_toggles.lock().await.is_enabled(feature)
+        self.resolved_feature_toggles(Some(uri))
+            .await
+            .is_enabled(feature)
     }
 
     /// Whether opt-in format-on-save (`tclLsp.features.willSaveWaitUntil`)
@@ -10299,16 +10459,7 @@ impl Backend {
     /// defaults **off**, so it cannot reuse
     /// `feature_enabled` (whose absent-key fallback is `true`).
     async fn will_save_format_enabled(&self, uri: &Uri) -> bool {
-        {
-            let configs = self.folder_configs.lock().await;
-            if let Some(fc) = longest_folder_match(&configs, uri)
-                && let Some(flag) = fc.feature_toggles.set.get("willSaveWaitUntil").copied()
-            {
-                return flag;
-            }
-        }
-        self.feature_toggles
-            .lock()
+        self.resolved_feature_toggles(Some(uri))
             .await
             .is_enabled_default_off("willSaveWaitUntil")
     }
@@ -10323,16 +10474,7 @@ impl Backend {
     /// per folder like [`Self::feature_enabled`] so a folder-scoped opt-in
     /// works in a multi-root workspace.
     async fn inlay_family_enabled(&self, uri: &Uri, family: &str) -> bool {
-        {
-            let configs = self.folder_configs.lock().await;
-            if let Some(fc) = longest_folder_match(&configs, uri)
-                && let Some(flag) = fc.feature_toggles.set.get(family).copied()
-            {
-                return flag;
-            }
-        }
-        self.feature_toggles
-            .lock()
+        self.resolved_feature_toggles(Some(uri))
             .await
             .is_enabled_default_off(family)
     }
@@ -19884,6 +20026,53 @@ mod tests {
         ] {
             assert!(map.contains_key(key), "missing reported feature {key}");
         }
+    }
+
+    /// Issue #1295: the folder-over-global overlay `getEffectiveConfig` and
+    /// every provider gate share.  A folder that mentions one feature must
+    /// override exactly that one and leave the rest of the global set alone —
+    /// the mistake in the other direction (a folder resetting unmentioned keys
+    /// to their defaults) would silently re-enable a globally-disabled feature
+    /// for every document under that folder.
+    #[test]
+    fn folder_toggles_overlay_only_the_keys_the_folder_sets() {
+        let mut global = FeatureToggles::default();
+        global.apply(
+            serde_json::json!({ "hover": false, "completion": false })
+                .as_object()
+                .unwrap(),
+        );
+        let mut folder = FeatureToggles::default();
+        folder.apply(
+            serde_json::json!({ "hover": true, "selectionRange": false })
+                .as_object()
+                .unwrap(),
+        );
+
+        let merged = global.overlaid_with(&folder);
+        assert!(merged.is_enabled("hover"), "folder must win over global");
+        assert!(
+            !merged.is_enabled("completion"),
+            "a key the folder does not mention keeps the global value"
+        );
+        assert!(
+            !merged.is_enabled("selectionRange"),
+            "a key only the folder sets must take effect"
+        );
+        assert!(
+            merged.is_enabled("definition"),
+            "a key neither sets keeps its default"
+        );
+        // Default-off keys stay off through the overlay unless something sets
+        // them, so an opt-in feature cannot be switched on by mere merging.
+        assert!(!merged.is_enabled("inlayTypeHints"));
+        assert!(!merged.is_enabled_default_off("willSaveWaitUntil"));
+
+        // An empty folder override is the identity, which is what makes the
+        // no-folder-config case indistinguishable from the pre-overlay
+        // behaviour.
+        let unchanged = global.overlaid_with(&FeatureToggles::default());
+        assert_eq!(unchanged.resolved_map(), global.resolved_map());
     }
 
     /// The shipped `tclLsp.xcDiagnostics.enabled` setting is a dedicated

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -1954,16 +1954,29 @@ async fn refresh_cross_file_evidence(
     slots: &Arc<Mutex<HashMap<Uri, DiagSlot>>>,
     uri: &Uri,
 ) {
-    // Class factories first, call-site evidence second, because the second
-    // reads the first: `file_call_site_evidence` resolves against
-    // `project_proc_names` / `file_decls`, both of which come off `item_tree`,
-    // which reads `SourceFile::workspace_class_factories`.  Run the other way
-    // round, every call-site table is computed under the pre-sync oracle and
-    // then immediately invalidated by the factory publish, so the pass costs a
-    // full project scan whose answer is thrown away and the corrected one
-    // waits on a reschedule (issue #1296).
-    let mut changed = sync_workspace_class_factories(handles).await;
-    for uri in sync_cross_file_evidence(handles).await {
+    // Call-site evidence first, class factories second — deliberately, and
+    // *not* in dependency order.  `file_call_site_evidence` does read the
+    // factory oracle transitively (`project_proc_names` / `file_decls` come off
+    // `item_tree`, which reads `SourceFile::workspace_class_factories`), so
+    // running the factory sync first looks like the tidier order.  Measured, it
+    // is much worse: the factory publish invalidates every file's `item_tree`,
+    // so the call-site pass that follows it is a *cold* one — the ~7s
+    // whole-project lower-and-CFG path this function is explicitly kept off the
+    // edit handler for — and that lands in front of `reschedule_peers`, which
+    // is what actually republishes the files the factory publish invalidated.
+    // On a large workspace that delayed convergence enough to lose a case that
+    // resolved before (issue #1296: a two-level cross-file chain rooted in
+    // tcllib's `clay.tcl` stopped resolving inside the probe's window).  Run in
+    // this order the call-site pass reads memoised state and the reschedule
+    // follows the factory publish immediately; the call-site tables computed
+    // under the pre-sync oracle are corrected by the peers' own next refresh,
+    // which the reschedule has already scheduled.
+    let mut changed = sync_cross_file_evidence(handles).await;
+    let wake = RoundReschedule {
+        slots,
+        self_uri: uri,
+    };
+    for uri in sync_workspace_class_factories(handles, Some(wake)).await {
         if !changed.contains(&uri) {
             changed.push(uri);
         }
@@ -2235,29 +2248,40 @@ const CLASS_FACTORY_SYNC_ROUNDS: usize = 16;
 /// deeper links waited on whatever unrelated edit happened to run the sync
 /// next.
 ///
+/// `wake`, when supplied, republishes each round's invalidated peers **as that
+/// round lands** rather than after the whole fixpoint.  A round only reads, but
+/// the round *after* a publish has to recompute every file's `item_tree`
+/// through the input the publish just moved, so on a large workspace the
+/// confirming round — the one that merely agrees the index has stopped moving —
+/// is the slowest part of the pass.  Left in front of the reschedule it delays
+/// the republish that the *previous* round already earned, and a two-level
+/// chain that resolved before the fixpoint existed stopped resolving until
+/// later (measured on tcllib's `clay.tcl`, issue #1296).  Waking per round
+/// keeps the fixpoint's extra rounds strictly additive: nothing that was
+/// already provable waits on them.
+///
 /// Called from two places, because the answer must be in place before either
 /// consumer needs it: at the end of the workspace scan (so a document opened
-/// afterwards is analysed with the oracle on its very first pass) and after
-/// each diagnostics publish (so a metaclass added by an *edit* propagates).
-async fn sync_workspace_class_factories(handles: &EvidenceHandles) -> Vec<Uri> {
+/// afterwards is analysed with the oracle on its very first pass; no peers to
+/// wake there, since nothing has published yet) and after each diagnostics
+/// publish (so a metaclass added by an *edit* propagates).
+async fn sync_workspace_class_factories(
+    handles: &EvidenceHandles,
+    wake: Option<RoundReschedule<'_>>,
+) -> Vec<Uri> {
     let mut changed: Vec<Uri> = Vec::new();
     let mut seen: HashSet<Uri> = HashSet::new();
     for _ in 0..CLASS_FACTORY_SYNC_ROUNDS {
-        let __t0 = std::time::Instant::now();
-        let __r = sync_workspace_class_factories_round(handles).await;
-        {
-            use std::io::Write as _;
-            if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open("/tmp/dbg1296.log") {
-                let _ = writeln!(f, "ROUND {:?} {}", __t0.elapsed(), match &__r { ClassFactoryRound::Settled => "settled".to_string(), ClassFactoryRound::Cancelled => "cancelled".to_string(), ClassFactoryRound::Moved(v) => format!("moved {}", v.len()) });
-            }
-        }
-        match __r {
+        match sync_workspace_class_factories_round(handles).await {
             // The fixpoint: every file already carries the index the project
             // proves, so another round would recompute a byte-identical one
             // off unchanged inputs.
             ClassFactoryRound::Settled => return changed,
             ClassFactoryRound::Cancelled => {}
             ClassFactoryRound::Moved(moved) => {
+                if let Some(wake) = wake.as_ref() {
+                    reschedule_peers(wake.slots, wake.self_uri, moved.clone()).await;
+                }
                 for uri in moved {
                     if seen.insert(uri.clone()) {
                         changed.push(uri);
@@ -2273,6 +2297,15 @@ async fn sync_workspace_class_factories(handles: &EvidenceHandles) -> Vec<Uri> {
          until the next sync."
     );
     changed
+}
+
+/// Where [`sync_workspace_class_factories`] sends each round's invalidated
+/// peers, so a later round never sits in front of an earlier round's republish.
+struct RoundReschedule<'a> {
+    slots: &'a Arc<Mutex<HashMap<Uri, DiagSlot>>>,
+    /// The document driving this pass; [`reschedule_peers`] skips it, because
+    /// its own worker decides separately whether to re-run it.
+    self_uri: &'a Uri,
 }
 
 /// What one [`sync_workspace_class_factories`] round learned.
@@ -2313,12 +2346,6 @@ async fn sync_workspace_class_factories_round(handles: &EvidenceHandles) -> Clas
     let computed = tokio::task::spawn_blocking(move || {
         salsa::Cancelled::catch(std::panic::AssertUnwindSafe(|| {
             let index = tcl_lsp_db::project_class_factories(&snapshot, project);
-            {
-                use std::io::Write as _;
-                if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open("/tmp/dbg1296.log") {
-                    let _ = writeln!(f, "  index={:?}", index.keys().collect::<Vec<_>>());
-                }
-            }
             let want = (!index.is_empty()).then_some(index);
             let pending: Vec<(Uri, tcl_lsp_db::SourceFile)> = files
                 .into_iter()
@@ -4148,9 +4175,17 @@ impl Backend {
             file.set_text(&mut *db).to(text);
             file.set_dialect(&mut *db).to(dialect);
         } else {
+            let oracle = Self::published_class_factories(&db, &files);
             let file = {
                 let mut tombstones = self.db_tombstones.lock().await;
-                Self::revive_or_create_db_source(&mut db, &mut tombstones, uri, text, dialect)
+                Self::revive_or_create_db_source(
+                    &mut db,
+                    &mut tombstones,
+                    uri,
+                    text,
+                    dialect,
+                    oracle,
+                )
             };
             files.insert(uri.clone(), file);
             // Membership changed — re-set the `Project` file set.
@@ -4211,16 +4246,49 @@ impl Backend {
         uri: &Uri,
         text: String,
         dialect: String,
+        oracle: Option<Arc<tcl_compiler::analyser::ClassFactoryIndex>>,
     ) -> tcl_lsp_db::SourceFile {
         use salsa::Setter as _;
-        if let Some(file) = tombstones.remove(uri) {
+        let file = if let Some(file) = tombstones.remove(uri) {
             file.set_text(db).to(text);
             file.set_dialect(db).to(dialect);
             file
         } else {
             let path = uri.to_file_path().map(|p| p.display().to_string());
             tcl_lsp_db::SourceFile::new(&*db, text, dialect, path)
+        };
+        // Hand the arriving file the workspace class-factory oracle the rest of
+        // the project already carries (issue #1276/#1296), rather than leaving
+        // it at `None` for `sync_workspace_class_factories` to correct a publish
+        // later. A default-`None` arrival is analysed — and *published* — as if
+        // the workspace declared no metaclass at all, so every class a
+        // cross-file metaclass manufactures in it is missing from that first
+        // result and from the workspace index built out of it; only a second,
+        // rescheduled pass repaired it. The value is a project-wide fact every
+        // other file is already entitled to, so seeding it asserts nothing the
+        // next sync would not assert anyway.
+        if oracle.is_some() {
+            file.set_workspace_class_factories(db).to(oracle);
         }
+        file
+    }
+
+    /// The workspace class-factory oracle currently published to the project,
+    /// or `None` when the workspace has no metaclass (the overwhelmingly
+    /// common case, and the state every file starts in).
+    ///
+    /// One index serves every file, so any file carrying one carries *the* one.
+    /// Mid-round the publish is applied file by file, so a few may still hold
+    /// the previous, smaller index; the widest published index is the right
+    /// seed, and the next compare-then-set round corrects it either way.
+    fn published_class_factories(
+        db: &tcl_lsp_db::TclDatabase,
+        files: &HashMap<Uri, tcl_lsp_db::SourceFile>,
+    ) -> Option<Arc<tcl_compiler::analyser::ClassFactoryIndex>> {
+        files
+            .values()
+            .filter_map(|file| file.workspace_class_factories(db).clone())
+            .max_by_key(|index| index.len())
     }
 
     /// Add/update many salsa `SourceFile` inputs at once (disk-backed workspace
@@ -4237,6 +4305,7 @@ impl Backend {
         let mut db = self.db.lock().await;
         let mut files = self.db_files.lock().await;
         let mut tombstones = self.db_tombstones.lock().await;
+        let oracle = Self::published_class_factories(&db, &files);
         let mut membership_changed = false;
         for (uri, text, dialect) in entries {
             // Same analysis-form invariant `db_set_source` enforces; the disk
@@ -4252,6 +4321,7 @@ impl Backend {
                     uri,
                     text.clone(),
                     dialect.clone(),
+                    oracle.clone(),
                 );
                 files.insert(uri.clone(), file);
                 membership_changed = true;
@@ -11761,12 +11831,15 @@ impl Backend {
         // navigation come back empty for every class a cross-file metaclass
         // manufactures — the exact symptom the issue reports — until some
         // later edit happens to re-run the diagnostics worker.
-        sync_workspace_class_factories(&EvidenceHandles {
-            db: Arc::clone(&self.db),
-            db_files: Arc::clone(&self.db_files),
-            db_project: Arc::clone(&self.db_project),
-            workspace_index: Arc::clone(&self.workspace_index),
-        })
+        sync_workspace_class_factories(
+            &EvidenceHandles {
+                db: Arc::clone(&self.db),
+                db_files: Arc::clone(&self.db_files),
+                db_project: Arc::clone(&self.db_project),
+                workspace_index: Arc::clone(&self.workspace_index),
+            },
+            None,
+        )
         .await;
         // In-process readiness signal, released before the log line so a
         // handler waiting on it is not held up by a client round-trip.

--- a/rust/tcl-lsp-server/tests/e2e.rs
+++ b/rust/tcl-lsp-server/tests/e2e.rs
@@ -69,6 +69,8 @@ mod issue1137_call_site_resolution;
 mod issue1214_uri_canonicalisation;
 #[path = "e2e/issue1281_ensemble_rename.rs"]
 mod issue1281_ensemble_rename;
+#[path = "e2e/issue1296_metaclass_chain.rs"]
+mod issue1296_metaclass_chain;
 #[path = "e2e/issue923_class_refs.rs"]
 mod issue923_class_refs;
 #[path = "e2e/issue923_crossdoc.rs"]

--- a/rust/tcl-lsp-server/tests/e2e/config.rs
+++ b/rust/tcl-lsp-server/tests/e2e/config.rs
@@ -75,6 +75,31 @@ fn feature_enabled(cfg: &Value, feature: &str) -> bool {
     cfg.get("features").and_then(|f| f.get(feature)) == Some(&Value::Bool(true))
 }
 
+/// Wait until `predicate` holds over the live server, bounded by a load-scaled
+/// deadline that **panics** naming `what`.
+///
+/// The per-folder `workspace/configuration` pull is a round trip the server
+/// makes on its own schedule, so a test that reads a folder-resolved value
+/// straight after `initialize` is reading it before the answer exists. There is
+/// no notification announcing the pull landed — `getEffectiveConfig` is the
+/// observation — so this is a bounded settle, not a fixed sleep, and it is the
+/// one place the shape is written.
+fn settle(lsp: &mut Lsp, what: &str, predicate: impl Fn(&mut Lsp) -> bool) {
+    use std::time::{Duration, Instant};
+    let budget = scaled_timeout(Duration::from_secs(20));
+    let deadline = Instant::now() + budget;
+    loop {
+        if predicate(lsp) {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "{what} never settled within {budget:?} (load-scaled)"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
 // -- TestEffectiveConfigShape --------------------------------------------
 
 #[test]
@@ -461,8 +486,6 @@ fn diagnostic_severity_override_is_per_code() {
 /// suite (`multiFolderConfig.test.ts`) without an editor.
 #[test]
 fn folder_scoped_dialect_reaches_documents_in_that_folder() {
-    use std::time::{Duration, Instant};
-
     let base = std::env::temp_dir().join(format!(
         "tcl-lsp-e2e-folder-dialect-{}-{}",
         std::process::id(),
@@ -497,21 +520,10 @@ fn folder_scoped_dialect_reaches_documents_in_that_folder() {
     // the VS Code suite polls to know the per-folder pull has settled.
     let uri_a = format!("file://{}", root_a.to_string_lossy());
     let uri_b = format!("file://{}", root_b.to_string_lossy());
-    let deadline = Instant::now() + Duration::from_secs(20);
-    loop {
-        let a = lsp.effective_config(&uri_a);
-        let b = lsp.effective_config(&uri_b);
-        if a.get("dialect") == Some(&json!("tcl8.4"))
-            && b.get("dialect") == Some(&json!("f5-irules"))
-        {
-            break;
-        }
-        assert!(
-            Instant::now() < deadline,
-            "per-folder dialects never settled: proj-a={a}, proj-b={b}"
-        );
-        std::thread::sleep(Duration::from_millis(50));
-    }
+    settle(&mut lsp, "per-folder dialects", |lsp| {
+        lsp.effective_config(&uri_a).get("dialect") == Some(&json!("tcl8.4"))
+            && lsp.effective_config(&uri_b).get("dialect") == Some(&json!("f5-irules"))
+    });
 
     // …and so do documents inside them, which is what actually changes analysis.
     let doc_a = format!("file://{}", file_a.to_string_lossy());
@@ -562,6 +574,79 @@ fn folder_scoped_dialect_reaches_documents_in_that_folder() {
     assert!(
         known.contains(&uri_a.as_str()) && known.contains(&uri_b.as_str()),
         "known_folder_uris must name both roots: {cfg}"
+    );
+
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// Issue #1295: `getEffectiveConfig`'s `features` map must resolve through the
+/// same folder chain the provider gates use.
+///
+/// It used to report the process-global toggles while every gate consulted the
+/// deepest containing folder first.  A client that polls this command before
+/// asserting a toggle took effect — which is exactly what the VS Code suite's
+/// `waitForFeatureToggle` barrier does — was therefore waiting on a different
+/// fact from the one the provider would act on, and in a multi-root workspace
+/// a folder-scoped toggle was invisible here entirely.
+///
+/// Both halves are asserted together, because the report is only worth anything
+/// if it agrees with the behaviour: the folder that disables `selectionRange`
+/// must both *say* so and *suppress* the provider, and the folder that does not
+/// must keep both.
+#[test]
+fn a_folder_scoped_feature_toggle_is_reported_and_applied_for_that_folder() {
+    let base = std::env::temp_dir().join(format!(
+        "tcl-lsp-e2e-folder-feature-{}-{}",
+        std::process::id(),
+        line!()
+    ));
+    let root_off = base.join("proj-off");
+    let root_on = base.join("proj-on");
+    std::fs::create_dir_all(&root_off).expect("mk proj-off");
+    std::fs::create_dir_all(&root_on).expect("mk proj-on");
+    let src = "proc greet {} {\n    set x 1\n    return $x\n}\n";
+    let file_off = root_off.join("foo.tcl");
+    let file_on = root_on.join("foo.tcl");
+    std::fs::write(&file_off, src).expect("write proj-off fixture");
+    std::fs::write(&file_on, src).expect("write proj-on fixture");
+
+    let mut lsp = Lsp::multi_root(
+        // The unscoped pull leaves the feature at its default (on), so the only
+        // thing that can turn it off for `proj-off` is that folder's override.
+        json!({}),
+        &[
+            (
+                root_off.as_path(),
+                json!({ "features": { "selectionRange": false } }),
+            ),
+            (root_on.as_path(), json!({})),
+        ],
+    );
+
+    let doc_off = format!("file://{}", file_off.to_string_lossy());
+    let doc_on = format!("file://{}", file_on.to_string_lossy());
+    lsp.open_ready(&doc_off, src);
+    lsp.open_ready(&doc_on, src);
+
+    let position = json!([{ "line": 2, "character": 11 }]);
+
+    // The report. `proj-off` must say the feature is off *for a document in it*
+    // — the global map says nothing about this folder and would report `true`.
+    settle(&mut lsp, "per-folder selectionRange toggles", |lsp| {
+        feature_disabled(&lsp.effective_config(&doc_off), "selectionRange")
+            && feature_enabled(&lsp.effective_config(&doc_on), "selectionRange")
+    });
+
+    // The behaviour, which is the fact the report is a proxy for.
+    let suppressed = lsp.selection_range(&doc_off, position.clone());
+    assert!(
+        is_empty(&suppressed),
+        "proj-off disables selectionRange, so its provider must return empty: {suppressed}"
+    );
+    let served = lsp.selection_range(&doc_on, position);
+    assert!(
+        !is_empty(&served),
+        "proj-on leaves selectionRange enabled, so its provider must answer: {served}"
     );
 
     std::fs::remove_dir_all(&base).ok();

--- a/rust/tcl-lsp-server/tests/e2e/issue1296_metaclass_chain.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue1296_metaclass_chain.rs
@@ -42,16 +42,32 @@
 //! so `::MC::Widget` genuinely has `go`, and a definition request on it has a
 //! real answer to find.
 //!
-//! **Not covered here, deliberately.** Every case below opens the chain's
-//! documents. A chain that lives entirely in *unopened* workspace files does
-//! not resolve, and that is a separate, pre-existing gap in issue #1276 rather
-//! than one of publish depth: the startup scan indexes each file's analysis
-//! into `workspace_index` *before* the class-factory oracle is published, and
-//! nothing re-indexes an unopened file afterwards, so the classes a cross-file
-//! metaclass manufactures never reach the index the navigation providers read.
-//! It reproduces identically with a **two**-level chain (one metaclass, one
-//! manufactured class), which is the shape #1276 shipped, so it is not a
-//! regression of this change and is not fixed by it.
+//! **Not covered here.** Every case below opens the chain's documents. A chain
+//! living entirely in *unopened* workspace files does not resolve — measured,
+//! and tracked as issue #1304.
+//!
+//! That is a pre-existing #1276 gap rather than one of publish depth, and this
+//! change neither causes nor fixes it. The evidence for that is the shape it
+//! takes, not an argument about the code: it reproduces identically with a
+//! **two**-level chain (one metaclass, one manufactured class), which is
+//! exactly what #1276 shipped, while a plain `oo::class` in the same position
+//! resolves unopened perfectly well. So unopened files are indexed; it is
+//! specifically classes that exist only because a metaclass made them that go
+//! missing.
+//!
+//! The *mechanism* — that the startup scan indexes each file before the
+//! class-factory oracle is published, and `reschedule_peers` only reaches
+//! documents with a diagnostics slot, i.e. open ones — is a reading of the
+//! code and is deliberately left as a hypothesis on #1304. This bug existed
+//! because a design note recorded "it converges on the next sync round" as
+//! settled fact when nothing had checked it; the mechanism here has had no
+//! more checking than that note did.
+//!
+//! Beware when probing it by hand: `.claude/skills/lsp-client/lsp_client.py`
+//! sets `rootUri` from `--server-dir`, so a probe that points that at the repo
+//! puts its fixtures outside the scanned workspace and *everything* cross-file
+//! fails, a plain `proc` included. Pass `--server-dir <fixture dir>` with
+//! `--server-bin <binary>` to separate the two.
 
 use crate::common::helpers::*;
 use crate::common::{Lsp, scaled_timeout, unique_uri};

--- a/rust/tcl-lsp-server/tests/e2e/issue1296_metaclass_chain.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue1296_metaclass_chain.rs
@@ -1,0 +1,236 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Issue #1296 — a class made by a cross-file metaclass that was itself made
+//! by *another* file's metaclass.
+//!
+//! The workspace class-factory index (issue #1276) is computed from a query
+//! that reads the index, so one publish only ever advances the metaclass chain
+//! by one link. Four files — `MetaA`, `MetaA create MetaB`,
+//! `MetaB create Widget`, and a call site on `Widget`'s method — need three
+//! links, and go-to-definition on the method came back with nothing. Collapsing
+//! the first two files into one (the same three-level chain, two documents)
+//! resolved fine, which is what pins the fault on publish depth rather than on
+//! the analyser.
+//!
+//! C-Tcl ground truth (tclsh 8.6.16 and 9.0.4, identical), sourcing the four
+//! files in order:
+//!
+//! ```text
+//! info object isa class ::MC::MetaB   -> 1
+//! info class superclasses ::MC::MetaB -> ::oo::class
+//! info object isa class ::MC::Widget  -> 1
+//! info class methods ::MC::Widget     -> go
+//! puts [$w go]                        -> went
+//! ```
+//!
+//! so `::MC::Widget` genuinely has `go`, and a definition request on it has a
+//! real answer to find.
+//!
+//! **Not covered here, deliberately.** Every case below opens the chain's
+//! documents. A chain that lives entirely in *unopened* workspace files does
+//! not resolve, and that is a separate, pre-existing gap in issue #1276 rather
+//! than one of publish depth: the startup scan indexes each file's analysis
+//! into `workspace_index` *before* the class-factory oracle is published, and
+//! nothing re-indexes an unopened file afterwards, so the classes a cross-file
+//! metaclass manufactures never reach the index the navigation providers read.
+//! It reproduces identically with a **two**-level chain (one metaclass, one
+//! manufactured class), which is the shape #1276 shipped, so it is not a
+//! regression of this change and is not fixed by it.
+
+use crate::common::helpers::*;
+use crate::common::{Lsp, scaled_timeout, unique_uri};
+use serde_json::Value;
+use std::time::{Duration, Instant};
+
+/// The chain, one link per document.
+const META_A: &str =
+    "namespace eval ::MC {}\noo::class create ::MC::MetaA { superclass oo::class }\n";
+const META_B: &str = "::MC::MetaA create ::MC::MetaB { superclass oo::class }\n";
+const WIDGET: &str = "::MC::MetaB create ::MC::Widget { method go {} { return went } }\n";
+const CALL: &str = "set w [::MC::Widget new]\nputs [$w go]\n";
+
+/// How long to let the workspace's class-factory index converge.
+///
+/// The index is published by the diagnostics worker after each publish, and
+/// each round of the publish invalidates every file's item tree — so the deeper
+/// links of a chain land a few debounced passes after the last document opens,
+/// not synchronously with it. This is the same "wait for the converged state
+/// rather than the first publish" discipline the cross-file call-site tests use
+/// (`caller_in_a_sourcing_file_with_a_differing_literal_clears_i230`), with the
+/// same load scaling.
+const CONVERGE: Duration = Duration::from_secs(25);
+
+/// Poll `definition` at `(line, ch)` until it reports at least one location,
+/// bounded. Returns the locations, or the last (empty) result at the deadline
+/// so the assertion — not the helper — reports the failure.
+fn definition_settled(lsp: &mut Lsp, uri: &str, line: u32, ch: u32) -> Vec<Loc> {
+    let deadline = Instant::now() + scaled_timeout(CONVERGE);
+    loop {
+        let found = locations(&lsp.definition(uri, line, ch));
+        if !found.is_empty() || Instant::now() >= deadline {
+            return found;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+/// TP — the ticket. Four documents, a three-link chain, and the call site's
+/// method resolves to its declaration in the document that writes the class.
+#[test]
+fn a_three_level_cross_file_metaclass_chain_resolves_from_a_call_site() {
+    let mut lsp = Lsp::tcl();
+    let meta_a = unique_uri("tcl");
+    let meta_b = unique_uri("tcl");
+    let widget = unique_uri("tcl");
+    let call = unique_uri("tcl");
+    lsp.open_ready(&meta_a, META_A);
+    lsp.open_ready(&meta_b, META_B);
+    lsp.open_ready(&widget, WIDGET);
+    lsp.open_ready(&call, CALL);
+
+    // `puts [$w go]` — `go` starts at character 10 of line 1.
+    let found = definition_settled(&mut lsp, &call, 1, 10);
+    assert_eq!(
+        found.len(),
+        1,
+        "`$w go` must resolve to `::MC::Widget`'s method: {found:?}"
+    );
+    assert_eq!(
+        found[0].uri, widget,
+        "the target is the document that writes the class: {found:?}"
+    );
+    assert_eq!(
+        found[0]
+            .range
+            .get("start")
+            .and_then(|s| s.get("line"))
+            .and_then(Value::as_i64),
+        Some(0),
+        "and the method's own line: {found:?}"
+    );
+}
+
+/// TP control — the two-document form of the same three-level chain (the
+/// ticket's "collapse `b_meta.tcl` into `a_meta.tcl`" row, which resolved
+/// before the fix). It must keep resolving, and it is what tells a regression
+/// in publish *depth* apart from one in the analyser.
+#[test]
+fn the_same_chain_in_two_documents_still_resolves() {
+    let mut lsp = Lsp::tcl();
+    let meta = unique_uri("tcl");
+    let widget = unique_uri("tcl");
+    let call = unique_uri("tcl");
+    lsp.open_ready(&meta, &format!("{META_A}{META_B}"));
+    lsp.open_ready(&widget, WIDGET);
+    lsp.open_ready(&call, CALL);
+
+    let found = definition_settled(&mut lsp, &call, 1, 10);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0].uri, widget, "{found:?}");
+}
+
+/// TP — a chain deeper than the ticket's, to show the publish follows the chain
+/// rather than a fixed number of links: five documents, four metaclasses.
+///
+/// Oracle (tclsh 9.0.4 / 8.6.16): `[::D::Leaf new] go` -> went.
+#[test]
+fn a_five_level_chain_resolves_too() {
+    let mut lsp = Lsp::tcl();
+    let uris: Vec<String> = (0..5).map(|_| unique_uri("tcl")).collect();
+    lsp.open_ready(
+        &uris[0],
+        "namespace eval ::D {}\noo::class create ::D::M1 { superclass oo::class }\n",
+    );
+    lsp.open_ready(
+        &uris[1],
+        "::D::M1 create ::D::M2 { superclass oo::class }\n",
+    );
+    lsp.open_ready(
+        &uris[2],
+        "::D::M2 create ::D::M3 { superclass oo::class }\n",
+    );
+    lsp.open_ready(
+        &uris[3],
+        "::D::M3 create ::D::Leaf { method go {} { return went } }\n",
+    );
+    lsp.open_ready(&uris[4], "set d [::D::Leaf new]\nputs [$d go]\n");
+
+    let found = definition_settled(&mut lsp, &uris[4], 1, 10);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0].uri, uris[3], "{found:?}");
+}
+
+/// TN — nothing in the project proves `::U::Meta` manufactures classes, so the
+/// call site has no answer and the server must report none rather than invent a
+/// class. Bounded the same way, so "abstains" is a settled answer and not a
+/// race that happened to be read early.
+#[test]
+fn an_unproved_metaclass_resolves_to_nothing() {
+    let mut lsp = Lsp::tcl();
+    let other = unique_uri("tcl");
+    let widget = unique_uri("tcl");
+    let call = unique_uri("tcl");
+    lsp.open_ready(&other, "namespace eval ::U {}\nputs hello\n");
+    lsp.open_ready(
+        &widget,
+        "::U::Meta create ::U::Widget { method go {} { return went } }\n",
+    );
+    lsp.open_ready(&call, "set w [::U::Widget new]\nputs [$w go]\n");
+
+    // Give the index the same chance to converge it gets in the TP cases, then
+    // require it to still have found nothing.
+    let deadline = Instant::now() + scaled_timeout(Duration::from_secs(3));
+    while Instant::now() < deadline {
+        assert!(
+            locations(&lsp.definition(&call, 1, 10)).is_empty(),
+            "no file proves `::U::Meta` is a class factory; guessing is worse \
+             than abstaining"
+        );
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+/// TP, the edit path — the middle link is typed in *after* the project has
+/// already settled without it. The publish has to converge again to the deeper
+/// answer rather than staying at the depth it had reached.
+#[test]
+fn typing_the_middle_link_makes_the_chain_resolve() {
+    let mut lsp = Lsp::tcl();
+    let meta_a = unique_uri("tcl");
+    let meta_b = unique_uri("tcl");
+    let widget = unique_uri("tcl");
+    let call = unique_uri("tcl");
+    lsp.open_ready(&meta_a, META_A);
+    lsp.open_ready(&meta_b, "# the middle link is not written yet\n");
+    lsp.open_ready(&widget, WIDGET);
+    lsp.open_ready(&call, CALL);
+    assert!(
+        locations(&lsp.definition(&call, 1, 10)).is_empty(),
+        "without the middle link there is nothing to resolve through"
+    );
+
+    lsp.settle_analysis(&meta_b, 2, META_B);
+    let found = definition_settled(&mut lsp, &call, 1, 10);
+    assert_eq!(
+        found.len(),
+        1,
+        "the typed-in link completes the chain: {found:?}"
+    );
+    assert_eq!(found[0].uri, widget, "{found:?}");
+}


### PR DESCRIPTION
## Summary

Fixes #1293, #1294, #1295, #1296. Three are VS Code test-harness faults; one is a product bug in cross-file `TclOO` metaclass resolution. Each was reproduced first, then fixed, then the reproduction re-run against the fix.

### #1296 — a class made by a cross-file metaclass chain resolved to nothing

`file_class_factories` reads `item_tree`, which reads the `workspace_class_factories` **input** the host computes *from that query*. A file can therefore prove `MetaB` only on a round whose published index already names `MetaA`, so one publish advances the chain by one link.

The publish now iterates to a fixpoint. Termination is argued, not assumed: a round writes only what some file *proved*, never a guess, so growth is monotone over a set bounded by the project's creation calls; a cycle (`A` made by `B` made by `A`) proves neither and settles empty on the first round; and the loop is capped regardless. A workspace with no metaclass — nearly all of them — settles in one round that writes nothing and invalidates nothing.

A second, independent fault: `sync_workspace_class_factories` could not tell "nothing moved" from "a concurrent `set_text` cancelled the read" — both returned an empty `Vec`, so a cancelled round was mistaken for the fixpoint and truncated the chain wherever it had reached. Cancelled rounds are now distinguished and retried.

Arriving files are also seeded with the oracle the project already carries, rather than being analysed *and published* as if the workspace had no metaclasses and repaired on a later pass.

**Measured with every file in the chain open** — that condition matters, see the scope note below:

| Case | Before | After |
|---|---|---|
| plain `oo::class`, cross-file | 1 | 1 |
| 2-level metaclass, cross-file | 1 | 1 |
| 3-level metaclass, single file | 1 | 1 |
| **3-level metaclass, cross-file** | **0** | **1** |

Oracle: C Tcl 8.6.14 and 9.0.4 both print `went`.

#### Scope: what this does *not* yet fix

Every test here — the e2e suite's `open_ready` and the extension test's `activate` — opens **all** the chain's documents. With the same files present but unopened, a metaclass-manufactured class still resolves to nothing (#1304), while a plain `oo::class` in the same position resolves fine.

That is the more common editing shape: you open the consumer, not the framework's own files. So the practical reach of this fix is narrower than the table alone suggests, and #1304 is what closes the gap. #1304 reproduces at the 2-level shape #1276 shipped, so it is pre-existing rather than introduced here, and the fixpoint neither causes nor cures it.

**Correction to my own commit message.** `43141a5` says the index "never recomputed" and that convergence "did not" happen. That is too strong. A fix-neutralised build (cap = 1 round, no seeding) *does* reach the fixpoint given ~3s settle intervals, via `reschedule_peers` → peer republish. The real defect is convergence depth per pass plus latency, compounded by the cancelled-round confusion above. The fix and its tests are right; that sentence overstated the diagnosis.

### #1293 — the runner killed a fully green suite

A flat 180s launch-to-exit budget sat below the suite's own runtime (~190s for 846 tests), so a green run raced its own successful exit and lost, reported as "mocha never completed (likely hung)" with `0 failed`.

The bound is now lack of *progress* — `completed + failed` advancing, or the in-flight title changing. Heartbeat freshness is deliberately not the signal: a test stuck on a promise still refreshes it, and that staleness means a dead event loop, which the report says separately.

Constants are derived. The no-progress window is 1.5x the longest any single test may run before mocha kills it, because progress resumes the instant mocha's own backstop fires. That relationship is asserted by a test, and it earned its keep immediately — widening the window put the absolute ceiling at exactly 4x it, which the same test caught.

Centralised into one `runnerWatchdog.ts` both runners use. `runMultiFolderTest.ts` wrote no heartbeat, no result marker, and treated its own timeout as `process.exit(0)` — it could silently pass a hung run.

### #1294 — a `didOpen` stall could not be attributed

`bounded`/`awaitSignal` gained a `diagnose` hook that runs only on the failing path, is capped, and cannot throw. The drain asks three independent questions concurrently — a document-free request, a hover on a fixture no test drives, and a retry — and reports which answered. The classification is a pure function, so all four verdicts are pinned by tests rather than only reachable through a real stall.

### #1295 — the toggle test, and the product bug behind it

The ticket said the evidence could not distinguish "bad wait" from "product bug". It was both.

Every provider gate resolves `tclLsp.features.*` folder-first, but `getEffectiveConfig` reported the process-global map — despite its own doc comment promising the folder chain. A folder-scoped toggle was invisible in the report while fully in effect in the behaviour, so a client polling to know a toggle had landed was waiting on a different fact from the one the provider would act on. Both paths now share one `resolved_feature_toggles`. The e2e test is a real guard: reverting the report fix alone fails it.

The test's single-sample `after` is now a bounded wait on the result.

## Found while verifying, fixed here

- **VS Code's 334MB download sat inside the new watchdog's clock** — caught on a real cold run. Pre-fetched before the clock starts; if the pre-fetch fails the never-started grace stands down rather than guessing.
- **14 tests set an unscaled `this.timeout(...)`**, several below the suite default, while the waits inside them are load-scaled and can extend. One failed exactly this way on a real run here.
- **`npm run test:multi-folder` was wired into nothing** — no Makefile target, no CI job, no doc. The tests guarding #230/#407 had no enforcement, which is also how `runMultiFolderTest.ts`'s timeout-as-success went unnoticed. Now part of `make test-ext`.

## Filed separately, not fixed here

Found against the #1181 corpus (tcllib, tk, SpiceGenTcl, pave, tomato, argparse). Each verified and isolated before filing; none is a regression of this work.

- **#1306** — a metaclass created under a computed name is never indexed. This is why tcllib's `oo::dialect`, clay, and practcl resolve nothing.
- **#1304** — cross-file metaclass resolution needs the defining file *open* (see the scope note above — this is what limits #1296's reach in practice).
- **#1303** — a handle bound via a metaclass `unknown` dispatch resolves no members (Tk's `::tk::IconList .il`).
- **#1305** — a `rename`d metaclass command manufactures nothing.

Also noted, not filed: `oo::objdefine` class-side members are missing from `documentSymbol` although go-to-definition on them resolves — narrower than it was first reported to me, so it did not warrant a ticket.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

All against this tree, after a clean rebuild (an earlier run was invalidated by a disk-full linker failure, and `rustup update` had silently dropped the `wasm32-*` targets — both fixed before these runs):

```
make test-rust          # 17135 passed, 0 failed
make check-all          # PASSED
make test-ext           # 860 passing (single-root) + 14 (multi-root)
make runtime-rust-test  # 331 passed, 0 failed
make test-emacs         # exit 0
cargo clippy --workspace --all-targets   # clean
cargo fmt --check                        # clean
```

Plus the ticket's own reproduction for #1296, re-run against the built server for all four isolation rows.

No new clippy allows. No `#[ignore]` or xfail markers added.

**Known coverage gap:** the cancelled-round retry described above has no test of its own. Forcing a round to be cancelled needs a concurrent `set_text` landing inside the round's snapshot read, which the salsa-layer suite cannot stage deterministically. The 17 fixpoint tests cover convergence, depth, ordering, cycles, retraction and shadowing; none of them would fail if the `Cancelled` arm regressed to returning early. Flagging it rather than leaving a reviewer to find an unguarded claim.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] **Did this change alter a compiler fact contract?** Yes — #1296 changes when the workspace class-factory index is complete, and #1295 changes what `getEffectiveConfig` reports for a URI.
- [x] **If yes, I updated at least one relevant KCS note.** `docs/kcs/kcs-issue-classes-made-by-a-class-factory-are-invisible.md` — its cross-file troubleshooting checklist listed four deliberate abstentions, and chain depth was a missing fifth cause, so anyone hitting #1296 would have worked through all four and had nowhere to land. Added the depth case, the fixpoint with its termination argument, and a pointer to #1303. Also `docs/design/contracts/config-precedence.md` for the #1295 contract, and two new KCS notes for the harness issues (`kcs-issue-vscode-test-runner-reports-false-hang.md`, `kcs-issue-vscode-test-timed-out-on-didopen.md`), both linked from `docs/kcs/README.md`.
- [x] **New compiler KCS note linked from both indexes?** No new note under `docs/kcs/compiler/` — that directory does not exist in this tree, so the relevant note lives at `docs/kcs/` and was updated in place and is already indexed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145wjbRkxm2DsMZtn4PfV17