### PR TITLE
Import-walk perf, per-URI retire paths, rehoming convergence, and the salsa interned-GC invariant (#1297, #1298, #1299, #1300, #1301, #1302)

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -294,6 +294,11 @@ chunk-by-chunk dispatch story lives in
   per-item walk with cascade invalidation: the incremental analysis design.
 - [rust/incremental-analysis-experiments.md](rust/incremental-analysis-experiments.md)
   — experiments, discoveries, and the reasoning behind the incremental plan.
+- [rust/salsa-interned-gc.md](rust/salsa-interned-gc.md) — the salsa
+  interned garbage collector that keeps the per-keystroke interned keys in
+  `tcl-lsp-db` bounded: how it works, the two ways to disable it by accident
+  (a `Durability` bump on an input, interning outside a tracked query), and
+  the guardrails that pin it.
 - [rust/lsp-performance.md](rust/lsp-performance.md) — native LSP
   performance: results, optimisations, and how to measure.
 - [rust/s110-byte-array-corruption-port.md](rust/s110-byte-array-corruption-port.md)

--- a/docs/design/rust/salsa-interned-gc.md
+++ b/docs/design/rust/salsa-interned-gc.md
@@ -1,0 +1,175 @@
+# The salsa interned garbage collector — the invariant the edit path rests on
+
+> Contract for `rust/tcl-lsp-db`. Companion to
+> [`incremental-analysis.md`](incremental-analysis.md) (the per-item cascade
+> this crate implements) and [`lsp-performance.md`](lsp-performance.md) (how
+> the edit path is measured). Issue #1299.
+
+## Summary
+
+Six interned structs in `tcl-lsp-db` key on content that changes on **every
+keystroke** inside a procedure body. Typing therefore mints a brand-new
+interned id for each of them per edit, and each id holds a body's worth of
+`Arc` payload in its memo table — the exact shape of an unbounded interning
+leak.
+
+It does not leak. The reason is **salsa's interned garbage collector**, an
+implementation detail of salsa 0.27 that nothing in this repository used to
+assert. Two plausible, review-friendly changes would silently disable it and
+restore a KB-per-keystroke leak of the [#1035](#related-issues) class. This
+document is the written form of that invariant; the code and tests that pin it
+are listed under [Where it is enforced](#where-it-is-enforced).
+
+## The six per-revision interned keys
+
+All are defined in `rust/tcl-lsp-db/src/lib.rs`.
+
+| Interned struct | Field that changes per revision | What the stale memo retains |
+|---|---|---|
+| `ItemBodyKey` | `body_text: Arc<str>` | the body's isolated `AnalysisResult` |
+| `FnLatticeKey` | `body: Script` (the whole procedure IR) | the offset-0 `FunctionUnit` (CFG, SSA, types, taints) |
+| `ProcBodyKey` | `body_text: String` | the lowered `Arc<Script>` |
+| `OptDepsKey` | `body_source`, `proc_body_source` | the procedure's optimisation set |
+| `TaintSummaryKey` | `reachable` (shifts as projections move) | the taint cascade result |
+| `SummaryDepsKey` | `interproc_reachable`, `callee_summaries` | the interprocedural summary |
+
+Two other interned structs are deliberately **outside** this contract:
+
+- `LexerCfgKey` (two booleans) and `CommandTail` (one command name) have a
+  bounded key space, so even immortal slots cost a handful of tiny entries.
+  This matters because `compilation_unit`'s own public signature takes a
+  `LexerCfgKey`, which callers must therefore mint from untracked host code.
+- `CfgContext` is content-keyed but *signature*-level: a body edit leaves it
+  equal, so it churns only when a signature moves. It is reclaimed by the same
+  mechanism when that happens.
+
+## How the collector works (salsa 0.27.2)
+
+From `salsa-0.27.2/src/interned.rs`:
+
+1. **Slot reuse on a cold intern.** Interning a value that is not already in
+   the table walks the shard's LRU list from the tail. Any slot whose
+   `last_interned_at` is older than `DEFAULT_REVISIONS` (3) revisions is
+   *reused*: its fields are overwritten with the new value, its id generation
+   is bumped, and `clear_memos` is called on its memo table. That `clear_memos`
+   is what actually drops the retained `Arc`s. Only if no stale slot is found
+   does salsa allocate a new one.
+2. **`Durability::LOW` only.** `ValueShared::is_reusable_with_durability`
+   returns `true` **only** for `Durability::LOW`. Collecting a more durable
+   slot would require invalidating that durability's revision
+   (`Database::synthetic_write`, which needs `&mut` on the database), so salsa
+   refuses rather than risk an unsound `maybe_changed_after` short-circuit.
+3. **Where a slot's durability comes from.** It is the *minimum* durability of
+   the inputs the creating query had read at the moment it interned. With **no
+   active query at all**, salsa stamps `Durability::MAX` and
+   `Revision::MAX` — an immortal slot that is never even added to the LRU list.
+
+The consequence worth stating plainly: **`lru = N` is not what keeps a typing
+session bounded.** The `lru` caps documented in the crate's "Deep-memo
+eviction" section bound *memo payloads* for a given key; they do nothing about
+the interned tables themselves. The garbage collector is what bounds those, and
+it is silent — there is no error, no warning, and no slow-down when it stops
+working, only monotonically climbing memory.
+
+## The two hazards
+
+### 1. A durability bump on an input
+
+Marking `SourceFile`, `AnalyserConfig`, or `Project` as `Durability::HIGH`
+("the config only changes when the user edits settings", "the file set changes
+rarely") is a normal salsa optimisation — it lets revalidation skip
+dependency-tracing for queries that read only durable inputs. Here it is a
+memory-leak regression: every interned key above is minted by a query that has
+read one of those inputs, so every slot would be stamped non-`LOW` and the
+collector would never touch it again.
+
+There is no diagnostic for this. The change looks beneficial, the tests keep
+passing on behaviour, and memory grows by kilobytes per keystroke.
+
+### 2. Interning outside a tracked query
+
+`memoised_compilation_unit` interns `FnLatticeKey`, `ProcBodyKey`,
+`TaintSummaryKey`, `SummaryDepsKey`, and `OptDepsKey` directly. Called from a
+tracked query it inherits that query's `LOW` durability; called from ordinary
+code it mints **immortal** slots, each pinning a full procedure IR plus its
+lattice memos.
+
+## The rules
+
+1. `SourceFile`, `AnalyserConfig`, and `Project` stay at salsa's default
+   `Durability::LOW`. No `Setter::with_durability`, no input-builder
+   `durability` / `<field>_durability` call.
+2. Anything that interns one of the six per-revision keys runs inside a tracked
+   query. `memoised_compilation_unit` is `pub(crate)` for this reason; the
+   sanctioned entry point is the tracked `compilation_unit` query.
+3. A new interned struct whose key contains per-revision content joins the
+   table above, the crate documentation, and `PER_REVISION_INTERNED` in
+   `rust/tcl-lsp-db/tests/interned_gc.rs`.
+
+## Where it is enforced
+
+All three tests live in `rust/tcl-lsp-db/tests/interned_gc.rs`.
+
+| Guardrail | Kind | What it catches |
+|---|---|---|
+| `memoised_compilation_unit` is `pub(crate)` | compile-time | any caller outside `tcl-lsp-db` interning body keys from untracked code |
+| `interned_slots_are_reclaimed_across_an_edit_session` | test-time | the collector no longer reclaiming any one of the six ingredients, from any cause — a durability bump inside the crate's own graph, an untracked intern on the edit path, or a salsa upgrade that changes the policy |
+| `raising_input_durability_disables_the_collector` | test-time | the first test going vacuous, and any change to salsa's "`LOW` only" collection policy that would make the durability rule stop mattering |
+| `no_input_durability_is_raised` | test-time | a `with_durability` / builder-`durability` call site in `tcl-lsp-db` or `tcl-lsp-server`, i.e. the hazard-1 shape written where the behavioural tests cannot see it |
+| `edit_session_memory_growth_plateaus` (`rust/tcl-lsp-db/tests/memory_growth.rs`) | test-time | the aggregate retained-bytes plateau (the #1035 regression class), of which this invariant is one contributor |
+| Doc comments at the six struct definitions and the three inputs | doc-only | a reviewer reaching the definition site with no context |
+
+### What the behavioural tests measure
+
+Both drive 24 revisions of a small generated corpus through
+`file_analysis_incremental` + `compiler_check_diagnostics` and count salsa's
+`EventKind::DidReuseInternedValue` per ingredient, surfaced by
+`TclDatabase::with_interned_reuse_logger`. That event fires **exactly** when the
+collector recycles a stale slot, so the count is a direct read of the mechanism
+rather than a proxy for it.
+
+Live slot counts are the more obvious measure and were rejected: their steady
+state depends on salsa's shard count,
+`(available_parallelism() * 4).next_power_of_two()`, so any absolute budget
+would be tuned to the machine that wrote it and would fail on a bigger one.
+Reuse counts have no such dependence — the collector either runs for an
+ingredient or it does not.
+
+Measured on a four-core box (24 edits, four worker procedures re-keyed per
+edit): 81 / 77 / 80 / 77 reuses for `ItemBodyKey` / `FnLatticeKey` /
+`ProcBodyKey` / `OptDepsKey`, and 22 / 34 for `TaintSummaryKey` /
+`SummaryDepsKey`. The raised-durability control records **zero** of any kind,
+and its slot counts climb to `WORKERS × EDITS` instead. That control's
+slot-count assertion is what keeps the corpus honest: if a future change stopped
+re-keying the ingredients once per edit, the control would stop accumulating and
+fail, rather than letting the first test pass on a session that interned
+nothing.
+
+Hazard 2 was checked the same way while the guardrail was being written, by
+temporarily re-exposing `memoised_compilation_unit` and calling it once per
+revision from ordinary, untracked test code. Reuse for the ingredients that call
+reaches collapses to exactly zero — `FnLatticeKey` 77 → 0, `ProcBodyKey` 80 → 0,
+`TaintSummaryKey` 22 → 0 — while the ingredients it does not reach are
+unaffected. One untracked call per revision is enough to poison the shared
+slots, because salsa takes the *maximum* durability across every query that
+interns a value and drops a slot from the LRU list as soon as that maximum
+leaves `LOW`.
+
+### Why the source-level test exists as well
+
+Durability is chosen at the *setter call site*, so a `Durability::HIGH` written
+in `tcl-lsp-server` would never appear in a database `tcl-lsp-db`'s own tests
+build. `tcl-lsp-server` is the only crate in the workspace that depends on
+`tcl-lsp-db`, so those two crates are the whole search space.
+
+## Related issues
+
+- **#1035** — the original KB-per-keystroke leak (leaked `&'static` command
+  specs), the class this invariant protects against re-entering.
+- **#1181** — the corpus the edit path is measured against; the review that
+  found the incremental layer healthy (~0 bytes/edit steady state, ~66.5 MB
+  across 60–500 edits) and this invariant undocumented.
+- **#1144 / #1179** — the deep-memo eviction (`lru = N`) work, which is the
+  *separate* mechanism the crate documentation describes under "Deep-memo
+  eviction".
+- **#1299** — pinning this invariant.

--- a/docs/design/rust/salsa-interned-gc.md
+++ b/docs/design/rust/salsa-interned-gc.md
@@ -113,8 +113,8 @@ All three tests live in `rust/tcl-lsp-db/tests/interned_gc.rs`.
 | Guardrail | Kind | What it catches |
 |---|---|---|
 | `memoised_compilation_unit` is `pub(crate)` | compile-time | any caller outside `tcl-lsp-db` interning body keys from untracked code |
-| `interned_slots_are_reclaimed_across_an_edit_session` | test-time | the collector no longer reclaiming any one of the six ingredients, from any cause — a durability bump inside the crate's own graph, an untracked intern on the edit path, or a salsa upgrade that changes the policy |
-| `raising_input_durability_disables_the_collector` | test-time | the first test going vacuous, and any change to salsa's "`LOW` only" collection policy that would make the durability rule stop mattering |
+| `interned_slots_stay_bounded_across_an_edit_session` | test-time | the live interned working set tracking the edit count instead of the program, from any cause — a durability bump inside the crate's own graph, an untracked intern on the edit path, or a salsa upgrade that changes the policy |
+| `raising_input_durability_disables_the_collector` | test-time | the first test going vacuous — it asserts the leaking session really does break that test's bound — and any change to salsa's "`LOW` only" collection policy that would make the durability rule stop mattering |
 | `no_input_durability_is_raised` | test-time | a `with_durability` / builder-`durability` call site in `tcl-lsp-db` or `tcl-lsp-server`, i.e. the hazard-1 shape written where the behavioural tests cannot see it |
 | `edit_session_memory_growth_plateaus` (`rust/tcl-lsp-db/tests/memory_growth.rs`) | test-time | the aggregate retained-bytes plateau (the #1035 regression class), of which this invariant is one contributor |
 | Doc comments at the six struct definitions and the three inputs | doc-only | a reviewer reaching the definition site with no context |

--- a/docs/kcs/kcs-qa-when-does-a-cross-file-namespace-import-count.md
+++ b/docs/kcs/kcs-qa-when-does-a-cross-file-namespace-import-count.md
@@ -66,6 +66,57 @@ No order at all — so the pre-existing lenient answer stands — when:
 - the `package require` is conditional (`if {[catch {package require
   Tk}]}`) or names a variable (`package require $pkg`).
 
+### An import that never installed anything at all
+
+Order is only half the question. Even a perfectly ordered import binds
+nothing if the target namespace **already holds a command of that name**:
+real Tcl raises `can't import command "p": already exists` and installs
+nothing, so a bare call still reaches whatever was already there.
+
+"Already holds" means the workspace's own procs and classes *and* the
+commands the **registry** says a fresh interpreter of that document's
+dialect starts with. The second half is easy to forget and the effect is
+a find-references false positive on every call of the shadowed name:
+
+```tcl
+# lib.tcl
+namespace eval ::Shadow { proc set {n v} {…}; namespace export set }
+# app.tcl
+namespace import ::Shadow::*   ;# -> can't import command "set": already exists
+set counter 1                  ;# reaches the BUILTIN, not ::Shadow::set
+```
+
+Oracle (tclsh 9.0.4 and 8.6.14, byte-identical): `namespace origin ::set`
+answers `::set`. Note that the import *errors* and still binds the other
+names it matched — `mything` exported alongside `set` is imported — so one
+import statement can produce both outcomes at once.
+
+Three things that are **not** conflicts, each a real case:
+
+- **`namespace import -force`** replaces the existing command outright,
+  and the call then does reach the import's source (`namespace origin
+  ::set` -> `::Shadow::set`).
+- **A sub-namespace target.** The builtins live in `::`, so
+  `namespace eval ::Bar { namespace import ::Shadow::* }` binds
+  `::Bar::set` with no conflict at all.
+- **The bare operator spellings.** `+`, `eq`, `in` and friends are *not*
+  commands in `::` — `info commands ::+` is empty and `+ 1 2` raises
+  `invalid command name "+"` — they only become callable after an
+  explicit `namespace import ::tcl::mathop::*`. So exporting `+` and
+  importing it into `::` genuinely binds. This is why the question the
+  registry answers is `CommandRegistry::declares_command_at` ("does a
+  fresh interpreter hold a command at exactly this name") and not the
+  broader `get` ("is this a spelling a call site may write").
+
+The dialect matters: `HTTP::uri` is a command for `f5-irules` and for
+nothing else, so the same source conflicts there and binds under plain
+Tcl. The gate reads each document's own analysed dialect.
+
+*Known imprecision:* a command a **package** provides (`::csv::split`) is
+treated as present whether or not the script `package require`s it — the
+registry carries no "needs a `package require`" marker yet. Reaching that
+case means importing into a package's own namespace.
+
 For the relation itself, its proofs, and its measured effect on real
 code, see the
 [import-order design note](../design/import-order-source-graph.md).

--- a/editors/vscode/src/test/helper.ts
+++ b/editors/vscode/src/test/helper.ts
@@ -27,7 +27,14 @@ import {
   type TimeoutDiagnostic,
 } from "./signal";
 
-export { awaitSignal, bounded, loadFactor, scaledTimeout, sleep } from "./signal";
+export {
+  awaitSignal,
+  bounded,
+  DIAGNOSTIC_BUDGET_MS,
+  loadFactor,
+  scaledTimeout,
+  sleep,
+} from "./signal";
 
 /**
  * Resolve a fixture file name to a URI.

--- a/editors/vscode/src/test/issue1302ImportShadow.test.ts
+++ b/editors/vscode/src/test/issue1302ImportShadow.test.ts
@@ -1,0 +1,107 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { getDocUri, activate } from "./helper";
+
+// Issue #1302, through the editor: a `namespace import` cannot bind a name a
+// fresh interpreter already holds, so a bare call to such a name is not a
+// reference to the exported proc.
+//
+// The unit matrix lives in `tcl_lsp_core::workspace_index` and the protocol
+// matrix in `tests/e2e/issue1302_import_builtin_shadow.rs`. This layer exists
+// because the defect's user-visible face is find-references and the reference
+// count code lens, and neither of the other two exercises the editor wiring —
+// provider registration, the positions VS Code sends, the shapes it expects
+// back.
+//
+// The fixture pair is pinned to real C Tcl. Sourcing the lib and running the
+// import under tclsh 9.0.4 and 8.6.14 prints, byte-identically:
+//
+//   import: can't import command "set": already exists
+//   origin ::set     = ::set
+//   ::mything exists = 1
+//
+// Note the third line: the import *errors* on `set` and still binds
+// `mything`. Both halves matter here — one call is not a reference, the other
+// is, from the same import statement.
+//
+// issue1302ImportShadowLib.tcl:
+//   13:     proc set {name value} {
+//   16:     proc mything {} {
+// issue1302ImportShadow.tcl:
+//   11: namespace import ::Shadow::*
+//   12: set counter 1
+//   13: mything
+
+const docUri = getDocUri("issue1302ImportShadow.tcl");
+const libUri = getDocUri("issue1302ImportShadowLib.tcl");
+
+/** Start lines of *locations* that land in `uri`, sorted and deduplicated. */
+function linesIn(locations: vscode.Location[], uri: vscode.Uri): number[] {
+  return [
+    ...new Set(
+      locations.filter((l) => l.uri.toString() === uri.toString()).map((l) => l.range.start.line),
+    ),
+  ].sort((a, b) => a - b);
+}
+
+async function referencesAt(uri: vscode.Uri, line: number, ch: number) {
+  return (await vscode.commands.executeCommand(
+    "vscode.executeReferenceProvider",
+    uri,
+    new vscode.Position(line, ch),
+  )) as vscode.Location[];
+}
+
+suite("Issue #1302: a wildcard import cannot shadow a registry builtin", () => {
+  test("the bare `set` call is not reported as a reference to ::Shadow::set", async () => {
+    await activate(libUri);
+    await activate(docUri);
+
+    // Line 13, column 10 — the `set` of `proc set` in the library.
+    const locations = await referencesAt(libUri, 13, 10);
+
+    assert.deepStrictEqual(
+      linesIn(locations, docUri),
+      [],
+      'real Tcl raises `can\'t import command "set": already exists` and installs ' +
+        "nothing, so `set counter 1` reaches the builtin and must not be filed as a " +
+        `reference: ${JSON.stringify(locations.map((l) => [l.uri.path, l.range.start.line]))}`,
+    );
+  });
+
+  test("the bare `mything` call, bound by the same import, is a reference", async () => {
+    await activate(libUri);
+    await activate(docUri);
+
+    // Line 16, column 10 — the `mything` of `proc mything` in the library.
+    const locations = await referencesAt(libUri, 16, 10);
+
+    assert.deepStrictEqual(
+      linesIn(locations, docUri),
+      [13],
+      "`mything` is not a command any fresh interpreter holds, so the same import " +
+        "really does bind it (`info commands ::mything` is non-empty in the oracle) " +
+        `and the call is a genuine reference: ${JSON.stringify(
+          locations.map((l) => [l.uri.path, l.range.start.line]),
+        )}`,
+    );
+  });
+});

--- a/editors/vscode/src/test/signal.ts
+++ b/editors/vscode/src/test/signal.ts
@@ -314,7 +314,7 @@ export type TimeoutDiagnostic = () => string | PromiseLike<string>;
  *  thing that hangs. Load-scaled like every other bound here: the probes a
  *  diagnostic makes are themselves load-scaled, so a fixed cap would truncate
  *  the answer on precisely the machines whose failures are hardest to read. */
-const DIAGNOSTIC_BUDGET_MS = 15_000;
+export const DIAGNOSTIC_BUDGET_MS = 15_000;
 
 /**
  * Run a [`TimeoutDiagnostic`] under a hard cap, converting any failure of the

--- a/editors/vscode/src/test/waitDiscipline.test.ts
+++ b/editors/vscode/src/test/waitDiscipline.test.ts
@@ -23,6 +23,7 @@ import {
   awaitSignal,
   bounded,
   classifyLiveness,
+  DIAGNOSTIC_BUDGET_MS,
   getDocUri,
   loadFactor,
   type ProbeOutcome,
@@ -364,7 +365,18 @@ suite("Wait discipline (issue #1274)", () => {
       );
       // The hanging probe is capped by signal.ts's own diagnostic budget, so
       // the failure still arrives — it just arrives later than the bound.
-      const ceiling = boundCeiling(base) + (label === "hangs" ? 16_000 : 0);
+      //
+      // That budget is *load-scaled* (`scaledTimeout(DIAGNOSTIC_BUDGET_MS)`),
+      // so this ceiling has to scale with it. A fixed addend asserts a
+      // constant against a moving cap: on a busy machine the budget stretches
+      // past it and the test fails for being slow rather than for being
+      // unbounded, which is the opposite of what it is checking. Observed on
+      // CI with two runs sharing a runner — 24 201 ms against a fixed
+      // 22 400 ms ceiling — while the same job passed in the other run.
+      // Reading the budget from its own definition also stops the two
+      // drifting apart again.
+      const ceiling =
+        boundCeiling(base) + (label === "hangs" ? scaledTimeout(DIAGNOSTIC_BUDGET_MS) + 2_000 : 0);
       assert.ok(
         Date.now() - started < ceiling,
         `a ${label} probe must not make the failure unbounded; took ${Date.now() - started}ms`,

--- a/editors/vscode/testFixture/issue1302ImportShadow.tcl
+++ b/editors/vscode/testFixture/issue1302ImportShadow.tcl
@@ -1,0 +1,14 @@
+# Fixture for issue #1302 (see issue1302ImportShadow.test.ts).
+#
+# The unforced glob import below is REFUSED by real Tcl, because `::` already
+# holds `set`. So the `set` call reaches the builtin and is NOT a reference to
+# ::Shadow::set, while the `mything` call — a name no fresh interpreter holds
+# — really is bound by the same import and IS a reference to ::Shadow::mything.
+#
+#   0-based lines, as the test addresses them:
+#   11: namespace import ::Shadow::*
+#   12: set counter 1
+#   13: mything
+namespace import ::Shadow::*
+set counter 1
+mything

--- a/editors/vscode/testFixture/issue1302ImportShadowLib.tcl
+++ b/editors/vscode/testFixture/issue1302ImportShadowLib.tcl
@@ -1,0 +1,21 @@
+# Fixture for issue #1302 (see issue1302ImportShadow.test.ts).
+#
+# `::Shadow` exports two names: one that a fresh Tcl interpreter already holds
+# as a builtin (`set`), and one it does not (`mything`).  Real Tcl refuses to
+# import the first and installs the second.
+#
+# Oracle, tclsh 9.0.4 and 8.6.14, byte-identical:
+#
+#   namespace import ::Shadow::*
+#     -> can't import command "set": already exists
+#   namespace origin ::set        -> ::set
+#
+namespace eval ::Shadow {
+    proc set {name value} {
+        return SHADOW
+    }
+    proc mything {} {
+        return MINE
+    }
+    namespace export set mything
+}

--- a/rust/tcl-lsp-core/src/namespace_import.rs
+++ b/rust/tcl-lsp-core/src/namespace_import.rs
@@ -287,11 +287,12 @@ fn in_effect_at(order: &RunOrder, event: RunPoint<'_>, query: Option<RunPoint<'_
 /// One pass to collect the visible events, then an `O(patterns × clears)`
 /// check over them — both sets are a namespace's own `namespace export`
 /// statements, so in practice one or two of each, and the `Vec`s stay
-/// unallocated when nothing is visible. This runs inside the cross-document
-/// find-references loop, once per candidate import per invocation, where the
-/// workspace tier already had to hoist an index out (see
-/// `WorkspaceIndex::resolve_wildcard_import_indexed`) to keep that path off
-/// the profiler.
+/// unallocated when nothing is visible.
+///
+/// Stated over [`exports_in_effect`], which is the whole rule *except* the
+/// name: `name` enters only at the final glob match. Callers that ask about
+/// many names at one import site should hoist that half themselves rather
+/// than call this in a loop — see [`exports_in_effect`] and issue #1297.
 #[must_use]
 pub fn exported_at_import_site(
     events: &mut dyn Iterator<Item = ExportEvent<'_>>,
@@ -299,21 +300,55 @@ pub fn exported_at_import_site(
     order: &RunOrder,
     import_site: RunPoint<'_>,
 ) -> bool {
-    let mut patterns: Vec<RunPoint<'_>> = Vec::new();
-    let mut clears: Vec<RunPoint<'_>> = Vec::new();
+    exports_in_effect(events, order, import_site)
+        .iter()
+        .any(|pattern| string_match(pattern, name))
+}
+
+/// The export **patterns** in force at `import_site` — [`exported_at_import_site`]
+/// with the name left out, so a caller asking about many names at one site
+/// pays for the timeline once instead of once per name.
+///
+/// Every visible non-`-clear` pattern that no visible tombstone is *known* to
+/// follow, in recorded order. That is exactly the set
+/// [`exported_at_import_site`] would glob-match `name` against: the name only
+/// ever filtered which patterns were collected, never which tombstones applied
+/// (a `-clear` clears the slot, not one name), so pulling it out of the walk
+/// cannot change an answer.
+///
+/// # Why this exists
+///
+/// The workspace tier ranks every export row against the import with
+/// [`RunOrder`], which is a `HashMap` walk over document URIs. Asking per
+/// *call site* made that walk run once per (invocation × in-scope import ×
+/// export row) — 26 s to answer one `textDocument/references` on the #1181
+/// corpus, where 88 load-level `namespace import`s meet 38 `namespace export`
+/// rows (issue #1297). An import's site does not move between edits, so the
+/// timeline half is decided once per recorded import at index-build time and
+/// only the glob match stays on the per-call path.
+#[must_use]
+pub fn exports_in_effect<'e>(
+    events: &mut dyn Iterator<Item = ExportEvent<'e>>,
+    order: &RunOrder,
+    import_site: RunPoint<'_>,
+) -> Vec<&'e str> {
+    let mut patterns: Vec<(&'e str, RunPoint<'e>)> = Vec::new();
+    let mut clears: Vec<RunPoint<'e>> = Vec::new();
     for ev in events {
         if !in_effect_at(order, ev.at, Some(import_site)) {
             continue;
         }
         if ev.clears {
             clears.push(ev.at);
-        } else if string_match(ev.pattern, name) {
-            patterns.push(ev.at);
+        } else {
+            patterns.push((ev.pattern, ev.at));
         }
     }
     patterns
-        .iter()
-        .any(|&p| !clears.iter().any(|&c| ran_after(order, c, p)))
+        .into_iter()
+        .filter(|&(_, p)| !clears.iter().any(|&c| ran_after(order, c, p)))
+        .map(|(pattern, _)| pattern)
+        .collect()
 }
 
 /// The **load-order** position of a statement in its own document: `false`
@@ -1147,5 +1182,80 @@ mod tests {
             &order,
             Some(at("file:///app.tcl", 15))
         ));
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #1297: `exported_at_import_site` is now stated over
+    // `exports_in_effect`, which is the whole rule minus the name.  The
+    // workspace tier decides that half once per recorded import instead of
+    // once per (invocation x import x export row).  These pin that the split
+    // is exact: whatever `exports_in_effect` keeps must glob-match to the
+    // same verdict the one-shot function gives, over every shape the
+    // timeline can produce.
+    // ---------------------------------------------------------------------
+
+    /// The two must agree for every (event set, name) pair, including the
+    /// cases where the *timeline* is what decides — a `-clear` that provably
+    /// follows, one that does not, and a foreign event that cannot be ranked
+    /// at all.  A disagreement here would change what a `namespace import`
+    /// covers, silently.
+    #[test]
+    fn exports_in_effect_is_exported_at_import_site_without_the_name() {
+        let order = unlinked();
+        let site = at(DOC, 100);
+        let cases: Vec<Vec<ExportEvent<'_>>> = vec![
+            vec![],
+            vec![ev("p", 10)],
+            vec![ev("*", 10)],
+            vec![ev("get*", 10)],
+            vec![ev("p[ab]", 10)],
+            // A tombstone that provably follows the pattern revokes it.
+            vec![ev("p", 10), clear(20)],
+            // …one written before it does not.
+            vec![clear(10), ev("p", 20)],
+            // An event after the import site is not visible at all.
+            vec![ev("p", 200)],
+            vec![ev("p", 10), ev("q", 20)],
+            // A foreign event cannot be ranked, so it revokes nothing.
+            vec![ev("p", 10), foreign("q")],
+            vec![foreign("p"), clear(20)],
+            vec![ev("p", 10), clear(20), ev("p", 30)],
+        ];
+        for events in cases {
+            for name in ["p", "q", "pa", "pc", "getX", "setX", ""] {
+                let mut for_one = events.clone().into_iter();
+                let one_shot = exported_at_import_site(&mut for_one, name, &order, site);
+                let mut for_split = events.clone().into_iter();
+                let split = exports_in_effect(&mut for_split, &order, site)
+                    .iter()
+                    .any(|pattern| string_match(pattern, name));
+                assert_eq!(
+                    one_shot, split,
+                    "split disagreed for name={name:?} over {events:?}",
+                );
+            }
+        }
+    }
+
+    /// TP/TN on the surviving set itself, so a regression shows up as the
+    /// wrong *patterns* rather than only as a wrong verdict for some name.
+    #[test]
+    fn exports_in_effect_keeps_exactly_the_untombstoned_visible_patterns() {
+        let order = unlinked();
+        // TP: visible, no tombstone after it.
+        let mut evs = [ev("a", 10), ev("b", 20)].into_iter();
+        assert_eq!(
+            exports_in_effect(&mut evs, &order, at(DOC, 100)),
+            vec!["a", "b"],
+        );
+        // TN: a `-clear` that provably follows takes both away.
+        let mut evs = [ev("a", 10), ev("b", 20), clear(30)].into_iter();
+        assert!(exports_in_effect(&mut evs, &order, at(DOC, 100)).is_empty());
+        // FN guard: a re-export after the tombstone survives it.
+        let mut evs = [ev("a", 10), clear(20), ev("b", 30)].into_iter();
+        assert_eq!(exports_in_effect(&mut evs, &order, at(DOC, 100)), vec!["b"],);
+        // FP guard: nothing written after the import site is visible.
+        let mut evs = [ev("a", 200)].into_iter();
+        assert!(exports_in_effect(&mut evs, &order, at(DOC, 100)).is_empty());
     }
 }

--- a/rust/tcl-lsp-core/src/source_graph.rs
+++ b/rust/tcl-lsp-core/src/source_graph.rs
@@ -36,6 +36,7 @@
 use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasher;
 use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
 
 /// Resolve a literal `source` path argument written in `parent_file` to the
 /// absolute path it refers to.
@@ -320,6 +321,19 @@ pub struct Placed {
     pub exact: bool,
 }
 
+/// A `String`-keyed map on the [`RunOrder`] hot path.
+///
+/// Every one of these is probed from inside the cross-document import walk,
+/// which runs per (invocation × in-scope import), so the default `SipHash`
+/// over an owned URI string was itself a measurable share of a 26 s
+/// `textDocument/references` (issue #1297 — 338 of 439 samples under
+/// [`RunOrder::alternatives`] were in `sip::Hasher::write`).  These keys are
+/// workspace-local document URIs, never attacker-chosen, so the `HashDoS`
+/// resistance `SipHash` buys is not worth its cost here.
+type UriMap<V> = rustc_hash::FxHashMap<String, V>;
+/// The [`UriMap`] of sets — same keys, same reasoning.
+type UriSet = rustc_hash::FxHashSet<String>;
+
 /// The **load order the workspace proves** — the single relation both
 /// wildcard-import tiers rank cross-document events with (issue #1104 item 3,
 /// #1116 item 6, #1279; design in
@@ -391,17 +405,25 @@ pub struct RunOrder {
     /// Root-ward path of every document the graph knows: root-first positions
     /// of the `source` statements that enter the next document down.  Empty
     /// for a root.
-    paths: HashMap<String, Vec<Placed>>,
+    paths: UriMap<Vec<Placed>>,
     /// Root document of every keyed document (itself, for a root).
-    root_of: HashMap<String, String>,
+    root_of: UriMap<String>,
     /// Documents with no unique position — re-sourced from two sites, or on a
     /// cycle.  Every cross-document comparison touching one abstains.
-    ambiguous: HashSet<String>,
-    /// For each document a `package require` *loads*, the require sites that
-    /// load it — see [`Self::alternatives`].  Keyed by the loaded document,
-    /// which is always a `source`-forest root: a document that is both
-    /// `source`d and `package require`d is ambiguous instead.
-    package_entries: HashMap<String, Vec<OwnedRunPoint>>,
+    ambiguous: UriSet,
+    /// [`Self::alternatives`]'s answer, per **document** rather than per root.
+    ///
+    /// The `package require` sites that load a document's tree are a fact about
+    /// its root, and whether the document may use them is a fact about its own
+    /// ambiguity — both fixed at build time.  Resolving that per call meant up
+    /// to three hash probes on owned URI strings inside the import walk, and
+    /// the `package_entries.is_empty()` fast path that was supposed to make it
+    /// free vanished the moment *any* document in the workspace contributed a
+    /// package edge (issue #1297).  Folding it into one probe of one map costs
+    /// nothing extra: the site vectors are shared with `Arc`, so a root's
+    /// entry is stored once however many documents it covers, and a workspace
+    /// with no package edge leaves the map empty and every probe a miss.
+    package_alternatives: UriMap<Arc<[OwnedRunPoint]>>,
 }
 
 /// A [`RunPoint`] the order has to keep past the borrow it was built from —
@@ -444,7 +466,7 @@ impl RunOrder {
     #[must_use]
     pub fn build(edges: &[RunEdge]) -> Self {
         let mut parent_of: HashMap<&str, (&str, Placed)> = HashMap::new();
-        let mut ambiguous: HashSet<String> = HashSet::new();
+        let mut ambiguous: UriSet = UriSet::default();
         let mut documents: HashSet<&str> = HashSet::new();
         let mut package_entries: HashMap<String, Vec<OwnedRunPoint>> = HashMap::new();
         for edge in edges {
@@ -489,8 +511,8 @@ impl RunOrder {
                 ambiguous.insert(child.clone());
             }
         }
-        let mut paths: HashMap<String, Vec<Placed>> = HashMap::new();
-        let mut root_of: HashMap<String, String> = HashMap::new();
+        let mut paths: UriMap<Vec<Placed>> = UriMap::default();
+        let mut root_of: UriMap<String> = UriMap::default();
         for &doc in &documents {
             let mut chain: Vec<Placed> = Vec::new();
             let mut seen: HashSet<&str> = HashSet::new();
@@ -534,12 +556,51 @@ impl RunOrder {
             .cloned()
             .collect();
         ambiguous.extend(inherited);
+        let package_alternatives =
+            Self::fold_package_alternatives(&documents, &root_of, &ambiguous, &package_entries);
         Self {
             paths,
             root_of,
             ambiguous,
-            package_entries,
+            package_alternatives,
         }
+    }
+
+    /// Resolve [`Self::alternatives`] for every document up front: the root
+    /// walk and the ambiguity test do not depend on the point being asked
+    /// about, so they belong here rather than on the per-call path
+    /// (issue #1297).
+    ///
+    /// A root's site vector is shared by every document under it, so a tree is
+    /// stored once however deep it is.  A document the graph knows only as a
+    /// `package require` target is its own root, so it is keyed too.  An
+    /// ambiguous document is left out entirely — that is the abstention the
+    /// old per-call `self.ambiguous.contains` performed, moved rather than
+    /// dropped.
+    fn fold_package_alternatives(
+        documents: &HashSet<&str>,
+        root_of: &UriMap<String>,
+        ambiguous: &UriSet,
+        package_entries: &HashMap<String, Vec<OwnedRunPoint>>,
+    ) -> UriMap<Arc<[OwnedRunPoint]>> {
+        let mut out: UriMap<Arc<[OwnedRunPoint]>> = UriMap::default();
+        if package_entries.is_empty() {
+            return out;
+        }
+        let shared: HashMap<&str, Arc<[OwnedRunPoint]>> = package_entries
+            .iter()
+            .map(|(root, sites)| (root.as_str(), Arc::from(sites.as_slice())))
+            .collect();
+        for &doc in documents {
+            if ambiguous.contains(doc) {
+                continue;
+            }
+            let root = root_of.get(doc).map_or(doc, String::as_str);
+            if let Some(sites) = shared.get(root) {
+                out.insert(doc.to_owned(), Arc::clone(sites));
+            }
+        }
+        out
     }
 
     /// Whether the statement at `event` had already run when the statement at
@@ -667,16 +728,14 @@ impl RunOrder {
     /// A point's tree is identified by its root: a file the provider `source`s
     /// runs when the provider does, so it is bounded by the same require
     /// sites.
+    /// One probe: which document a point sits in is the only thing left to
+    /// look up, because the root walk and the ambiguity test that used to
+    /// stand in front of it do not depend on the point's offset and were
+    /// folded into [`Self::package_alternatives`] at build time.
     fn alternatives(&self, p: RunPoint<'_>) -> &[OwnedRunPoint] {
-        // The overwhelmingly common shape: no package edge anywhere, so the
-        // fallback costs nothing at all beyond this test.
-        if self.package_entries.is_empty() || self.ambiguous.contains(p.uri) {
-            return &[];
-        }
-        let root = self.root_of.get(p.uri).map_or(p.uri, String::as_str);
-        self.package_entries
-            .get(root)
-            .map_or(&[], std::vec::Vec::as_slice)
+        self.package_alternatives
+            .get(p.uri)
+            .map_or(&[], |sites| &**sites)
     }
 
     /// Both points as positions in their deepest common document — the single
@@ -1378,6 +1437,92 @@ mod tests {
         // Above the require, neither direction is a fact.
         assert_eq!(order.cmp_run(point("lib", 30), point("app", 5)), None);
         assert_eq!(order.cmp_run(point("app", 5), point("lib", 30)), None);
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #1297: `alternatives` used to resolve, per call, "is there any
+    // package edge at all / is this document ambiguous / what is its root /
+    // does that root have require sites" — three hash probes on owned URI
+    // strings, on the hottest path in the cross-document import walk.  All
+    // four questions are fixed at build time, so they are now one probe of
+    // `package_alternatives`.  These pin that the folded answer is the same
+    // answer, case by case, because a silent change here would move which
+    // cross-document events the import tiers can rank.
+    // ---------------------------------------------------------------------
+
+    /// TP: a document a `package require` loads, and everything under it,
+    /// gets the require sites; the require's own document does not.
+    #[test]
+    fn package_alternatives_cover_the_required_tree_and_nothing_else() {
+        let order = RunOrder::build(&[require_edge("app", "lib", 10), edge("lib", "deep", 5)]);
+        assert_eq!(order.alternatives(point("lib", 0)).len(), 1);
+        assert_eq!(
+            order.alternatives(point("deep", 0)).len(),
+            1,
+            "a file the provider sources rides the provider's bound",
+        );
+        assert!(
+            order.alternatives(point("app", 0)).is_empty(),
+            "the requiring document is not itself bounded by its own require",
+        );
+    }
+
+    /// TN: no package edge anywhere leaves every document without
+    /// alternatives — the shape the old `package_entries.is_empty()` fast
+    /// path existed for, which must stay free of any behaviour change.
+    #[test]
+    fn a_workspace_with_no_package_edge_has_no_alternatives() {
+        let order = RunOrder::build(&[edge("a", "b", 10), edge("b", "c", 5)]);
+        for doc in ["a", "b", "c"] {
+            assert!(order.alternatives(point(doc, 0)).is_empty(), "{doc}");
+        }
+    }
+
+    /// FP guard: an **ambiguous** document must get no alternatives even
+    /// though its root has require sites.  This was the `self.ambiguous`
+    /// test that stood in front of the old lookup; folding it into the build
+    /// must not lose it.  A document both `source`d and `package require`d is
+    /// exactly that case.
+    #[test]
+    fn an_ambiguous_document_gets_no_alternatives() {
+        let order = RunOrder::build(&[require_edge("app", "lib", 10), edge("other", "lib", 3)]);
+        assert!(
+            order.alternatives(point("lib", 0)).is_empty(),
+            "both sourced and required: two incompatible stories, so neither",
+        );
+        // …and ambiguity is inherited, so a file below it is barred too.
+        let order = RunOrder::build(&[
+            require_edge("app", "lib", 10),
+            edge("other", "lib", 3),
+            edge("lib", "deep", 1),
+        ]);
+        assert!(order.alternatives(point("deep", 0)).is_empty());
+    }
+
+    /// TN: a document the graph has never heard of has no alternatives, and
+    /// asking does not panic — the `map_or(p.uri, …)` fallback the old code
+    /// took, restated as a plain miss.
+    #[test]
+    fn an_unknown_document_has_no_alternatives() {
+        let order = RunOrder::build(&[require_edge("app", "lib", 10)]);
+        assert!(order.alternatives(point("never-indexed", 0)).is_empty());
+        assert!(RunOrder::default().alternatives(point("a", 0)).is_empty());
+    }
+
+    /// TP: many requires of one provider all reach it — the per-document
+    /// fold shares one site vector rather than dropping the extras.
+    #[test]
+    fn every_require_site_survives_the_per_document_fold() {
+        let order = RunOrder::build(&[
+            require_edge("a", "lib", 10),
+            require_edge("b", "lib", 20),
+            require_edge("c", "lib", 30),
+        ]);
+        let sites = order.alternatives(point("lib", 0));
+        assert_eq!(sites.len(), 3);
+        let mut ats: Vec<u32> = sites.iter().map(|s| s.at).collect();
+        ats.sort_unstable();
+        assert_eq!(ats, vec![10, 20, 30]);
     }
 
     /// `trusted` is the whole rule in one place: an answer needs the side it

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -1031,6 +1031,16 @@ fn sorted_names(names: &std::collections::HashSet<String>) -> Vec<String> {
 /// order the previous flat vectors held them in.
 #[derive(Debug, Clone, Default)]
 struct DocumentRecords {
+    /// The dialect this document was analysed under — carried straight from
+    /// [`AnalysisResult::dialect`], so the registry consulted for a decision
+    /// about this document is the one it was actually analysed with.
+    ///
+    /// A workspace is not one dialect: an iRule and a plain Tcl script can sit
+    /// in one folder, and which commands a fresh interpreter holds differs
+    /// between them (`HTTP::uri` exists for `f5-irules` and nowhere else).
+    /// Empty for a default-constructed record, which
+    /// [`WorkspaceIndex::registry_for`] reads as "no dialect known".
+    dialect: String,
     procs: Vec<WorkspaceProc>,
     classes: Vec<WorkspaceClass>,
     variables: Vec<WorkspaceVariable>,
@@ -1063,6 +1073,7 @@ impl DocumentRecords {
     /// removals.
     fn clear(&mut self) {
         let Self {
+            dialect,
             procs,
             classes,
             variables,
@@ -1082,6 +1093,7 @@ impl DocumentRecords {
             command_deletions,
             defined_symbols,
         } = self;
+        dialect.clear();
         procs.clear();
         classes.clear();
         variables.clear();
@@ -1215,6 +1227,7 @@ impl DocumentRecords {
     /// The caller ([`WorkspaceIndex::add_document`]) has already cleared the
     /// slot, so this only ever appends.
     fn index_document(&mut self, uri: &str, analysis: &AnalysisResult) {
+        self.dialect.clone_from(&analysis.dialect);
         // `all_procs` / `all_classes` / a class's `methods` are `HashMap`s, so
         // iterating them directly would order this document's index entries by
         // the process's random hash seed — and consumers that answer with the
@@ -2075,7 +2088,10 @@ impl WorkspaceIndex {
                         // namespace already holds installs nothing at all
                         // (oracle on `WorkspaceGlobImport::forced`), so
                         // the link it would introduce is not live either.
-                        // "Already holds" is a real *definition* or an
+                        // "Already holds" is a real *definition*, a command
+                        // a fresh interpreter of this document's dialect
+                        // already has (issue #1302 — the exact-import twin
+                        // of `GlobImportRow::declares_builtin_at`), or an
                         // earlier live alias from a **different** source
                         // in the same document (issue #1116 finding 4);
                         // a same-source re-import is a silent no-op, and
@@ -2084,6 +2100,9 @@ impl WorkspaceIndex {
                         let importing_ns = importing_namespace_of(&l.linked_qname);
                         if !g.forced
                             && (self.defines_command(&l.linked_qname)
+                                || self
+                                    .registry_for(&l.uri)
+                                    .is_some_and(|r| r.declares_command_at(&l.linked_qname))
                                 || wci.conflicting_alias_at(
                                     importing_ns,
                                     &g.source_ns,
@@ -2112,16 +2131,32 @@ impl WorkspaceIndex {
     /// `qualified_name` — the "already exists" side of a non-`-force`
     /// `namespace import` conflict.
     ///
+    /// The registry a decision about `uri`'s content must be made against —
+    /// the one for the dialect that document was analysed under.
+    ///
+    /// `None` for a document the index does not hold, or one whose record
+    /// carries no dialect (a default-constructed [`AnalysisResult`], which
+    /// only unit tests produce).  Callers abstain rather than guessing a
+    /// dialect: answering an iRule's question out of the plain-Tcl command
+    /// table would be worse than not answering it.
+    fn registry_for(&self, uri: &str) -> Option<&'static tcl_registry::CommandRegistry> {
+        let slot = *self.slots.get(uri)?;
+        let dialect = self.docs[slot].dialect.as_str();
+        (!dialect.is_empty()).then(|| tcl_registry::registry_for_dialect(dialect))
+    }
+
     /// Deliberately *not* [`Self::workspace_command_exists`], which also
     /// admits linked names: a link is what this question is being asked
     /// about, so counting one would make an import conflict with itself.
+    ///
+    /// Answered from the link-free reading of [`Self::defined_command_names`]
+    /// — which is that same proc + class name set, already derived once per
+    /// generation — rather than by re-walking every indexed proc and class.
+    /// This sits inside `import_hop`'s per-call filter chain, so the scan cost
+    /// was O(procs) *per call site per in-scope import* (issue #1297).
     fn defines_command(&self, qualified_name: &str) -> bool {
-        let target = qualified_name.trim_start_matches("::");
-        self.procs()
-            .any(|p| p.qualified_name.trim_start_matches("::") == target)
-            || self
-                .classes()
-                .any(|c| c.qualified_name.trim_start_matches("::") == target)
+        self.defined_command_names(false)
+            .contains(qualified_name.trim_start_matches("::"))
     }
 
     /// The `::`-stripped namespaces the workspace can say anything about: one
@@ -3912,17 +3947,140 @@ impl WorkspaceIndex {
         // stable source order breaks the tie.
         imports
             .iter()
-            .filter(|imp| tcl_syntax::glob::string_match(&imp.tail_pattern, word))
-            .filter(|imp| wci.exports_name_at(&imp.source_ns, word, imp.site()))
-            .filter(|imp| {
-                imp.forced
-                    || !(self.defines_command(&tcl_syntax::naming::qualify(ns, word))
-                        || wci.conflicting_alias_at(ns, &imp.source_ns, word, imp.site()))
+            .filter(|row| tcl_syntax::glob::string_match(&row.imp.tail_pattern, word))
+            .filter(|row| row.exported.covers(word))
+            .filter(|row| {
+                let target = tcl_syntax::naming::qualify(ns, word);
+                row.imp.forced
+                    || !(self.defines_command(&target)
+                        || row.declares_builtin_at(&target)
+                        || wci.conflicting_alias_at(ns, &row.imp.source_ns, word, row.site()))
             })
-            .filter(|imp| wci.alias_live_at(ns, &imp.source_ns, word, imp.site(), call))
+            .filter(|row| wci.alias_live_at(ns, &row.imp.source_ns, word, row.site(), call))
             .enumerate()
-            .max_by_key(|(seq, imp)| (imp.uri == call.uri, imp.at, *seq))
-            .map(|(_, imp)| imp.source_ns.clone())
+            .max_by_key(|(seq, row)| (row.imp.uri == call.uri, row.imp.at, *seq))
+            .map(|(_, row)| row.imp.source_ns.clone())
+    }
+}
+
+/// The names a source namespace had exported by the time one recorded import
+/// ran — the word-independent half of
+/// [`crate::namespace_import::exported_at_import_site`], decided once per
+/// import at index-build time (issue #1297).
+///
+/// An import's position is fixed by the source text, so which export rows are
+/// visible from it, and which of those a `-clear` tombstone revokes, cannot
+/// depend on the call being resolved. Only the final glob match can. Asking
+/// the whole question per call made the [`crate::source_graph::RunOrder`] walk
+/// run once per (invocation × in-scope import × export row); with the timeline
+/// half hoisted here it runs once per import, and the per-call cost is a hash
+/// probe plus a glob match against however few non-literal patterns remain.
+///
+/// Splitting literal patterns out is the same reasoning one level down:
+/// `namespace export Resistor R Capacitor C …` is the common shape, and a
+/// pattern with no metacharacter matches exactly its own text
+/// ([`tcl_syntax::glob::is_literal`]), so it belongs in a set rather than in a
+/// linear glob scan.
+#[derive(Debug, Default)]
+struct ExportGate<'a> {
+    /// Surviving patterns with no glob metacharacter: an exact-name set.
+    literal: HashSet<&'a str>,
+    /// Surviving patterns that need `Tcl_StringMatch` semantics (`*`, `b*`,
+    /// `{p[ab]}`, …), in recorded order.
+    globs: Vec<&'a str>,
+}
+
+impl<'a> ExportGate<'a> {
+    /// The gate for `source_ns` as seen from the import at `site`, or an empty
+    /// gate when the namespace has no export rows at all.
+    fn decide(
+        exports_by_ns: &std::collections::HashMap<&'a str, Vec<&'a WorkspaceNamespaceExport>>,
+        order: &crate::source_graph::RunOrder,
+        source_ns: &str,
+        site: ImportSite<'_>,
+    ) -> Self {
+        let Some(exports) = exports_by_ns.get(source_ns) else {
+            return Self::default();
+        };
+        let mut events = export_events(exports.iter().copied());
+        let surviving =
+            crate::namespace_import::exports_in_effect(&mut events, order, site.point());
+        let (literal, globs) = surviving
+            .into_iter()
+            .partition::<Vec<_>, _>(|p| tcl_syntax::glob::is_literal(p));
+        Self {
+            literal: literal.into_iter().collect(),
+            globs,
+        }
+    }
+
+    /// Whether the gate lets `name` through — the answer
+    /// [`crate::namespace_import::exported_at_import_site`] would give for the
+    /// same name at the same site.
+    fn covers(&self, name: &str) -> bool {
+        self.literal.contains(name)
+            || self
+                .globs
+                .iter()
+                .any(|pattern| tcl_syntax::glob::string_match(pattern, name))
+    }
+}
+
+/// One recorded wildcard `namespace import NS::*`, with its export gate
+/// already decided — see [`ExportGate`].
+#[derive(Debug)]
+struct GlobImportRow<'a> {
+    imp: &'a WorkspaceGlobImport,
+    exported: ExportGate<'a>,
+    /// The command table a fresh interpreter running *this import's document*
+    /// holds — the other half of the import-conflict rule, and dialect-correct
+    /// because it is resolved from that document's own analysed dialect
+    /// (issue #1302).  `None` when the index cannot say.
+    registry: Option<&'static tcl_registry::CommandRegistry>,
+}
+
+impl<'a> GlobImportRow<'a> {
+    fn site(&self) -> ImportSite<'a> {
+        self.imp.site()
+    }
+
+    /// Whether a fresh interpreter of this import's dialect already holds a
+    /// command at `qualified_name` — the registry half of the non-`-force`
+    /// "already exists" conflict (issue #1302).
+    ///
+    /// The workspace half ([`WorkspaceIndex::defines_command`]) sees only
+    /// procs and classes the workspace itself declares, so without this an
+    /// unforced `namespace import` of a namespace exporting `set` was treated
+    /// as installed and every bare `set` in the workspace was filed as a
+    /// reference to it — where real Tcl raises `can't import command "set":
+    /// already exists` and installs nothing (oracle 9.0.4 / 8.6.14). The
+    /// single-document tier has always applied this gate
+    /// (`definition::resolve_called_proc`'s `has_builtin`); this is the
+    /// cross-document tier catching up, from the same source of truth.
+    ///
+    /// Abstains toward *not* conflicting when the dialect is unknown, which is
+    /// the pre-#1302 behaviour: inventing a conflict drops an alias the
+    /// program really has.
+    fn declares_builtin_at(&self, qualified_name: &str) -> bool {
+        self.registry
+            .is_some_and(|r| r.declares_command_at(qualified_name))
+    }
+}
+
+/// One recorded **exact** `namespace import ::src::p` link, with its export
+/// gate already decided — the exact-pattern twin of [`GlobImportRow`].
+#[derive(Debug)]
+struct ExactImportRow<'a> {
+    /// The document the link's import is written in — [`WorkspaceImportGate`]
+    /// does not duplicate it.
+    uri: &'a str,
+    gate: &'a WorkspaceImportGate,
+    exported: ExportGate<'a>,
+}
+
+impl<'a> ExactImportRow<'a> {
+    fn site(&self) -> ImportSite<'a> {
+        self.gate.site(self.uri)
     }
 }
 
@@ -3931,13 +4089,12 @@ impl WorkspaceIndex {
 /// than re-scanned per call site — see
 /// [`WorkspaceIndex::resolve_wildcard_import_indexed`]'s doc for why.
 struct WildcardImportIndex<'a> {
-    imports_by_ns: std::collections::HashMap<&'a str, Vec<&'a WorkspaceGlobImport>>,
-    /// Every **exact** `namespace import` link, by importing namespace, as
-    /// `(document, gate)`. The exact-pattern twin of [`Self::imports_by_ns`]:
-    /// the two tables are one command table as far as the import-conflict rule
-    /// is concerned, which is why [`Self::conflicting_alias_at`] reads both
-    /// (issue #1116 item 7).
-    exact_by_ns: std::collections::HashMap<&'a str, Vec<(&'a str, &'a WorkspaceImportGate)>>,
+    imports_by_ns: std::collections::HashMap<&'a str, Vec<GlobImportRow<'a>>>,
+    /// Every **exact** `namespace import` link, by importing namespace. The
+    /// exact-pattern twin of [`Self::imports_by_ns`]: the two tables are one
+    /// command table as far as the import-conflict rule is concerned, which is
+    /// why [`Self::conflicting_alias_at`] reads both (issue #1116 item 7).
+    exact_by_ns: std::collections::HashMap<&'a str, Vec<ExactImportRow<'a>>>,
     exports_by_ns: std::collections::HashMap<&'a str, Vec<&'a WorkspaceNamespaceExport>>,
     forgets_by_ns: std::collections::HashMap<&'a str, Vec<&'a WorkspaceNamespaceForget>>,
     deletions_by_name: std::collections::HashMap<&'a str, Vec<&'a WorkspaceCommandDeletion>>,
@@ -3962,25 +4119,50 @@ struct WildcardImportIndex<'a> {
 
 impl<'a> WildcardImportIndex<'a> {
     fn build(index: &'a WorkspaceIndex) -> Self {
-        let mut imports_by_ns: std::collections::HashMap<&str, Vec<&WorkspaceGlobImport>> =
-            std::collections::HashMap::new();
-        for imp in index.glob_imports() {
-            imports_by_ns.entry(imp.ns.as_str()).or_default().push(imp);
-        }
-        let mut exact_by_ns: std::collections::HashMap<&str, Vec<(&str, &WorkspaceImportGate)>> =
-            std::collections::HashMap::new();
-        for link in index.command_links() {
-            if let Some(gate) = link.import_gate.as_ref() {
-                exact_by_ns
-                    .entry(importing_namespace_of(&link.linked_qname))
-                    .or_default()
-                    .push((link.uri.as_str(), gate));
-            }
-        }
+        // Exports first: every import row's gate is decided against them here,
+        // once, instead of once per call site (issue #1297).
         let mut exports_by_ns: std::collections::HashMap<&str, Vec<&WorkspaceNamespaceExport>> =
             std::collections::HashMap::new();
         for exp in index.namespace_exports() {
             exports_by_ns.entry(exp.ns.as_str()).or_default().push(exp);
+        }
+        let order = index.run_order();
+        let mut imports_by_ns: std::collections::HashMap<&str, Vec<GlobImportRow<'a>>> =
+            std::collections::HashMap::new();
+        for imp in index.glob_imports() {
+            imports_by_ns
+                .entry(imp.ns.as_str())
+                .or_default()
+                .push(GlobImportRow {
+                    imp,
+                    exported: ExportGate::decide(
+                        &exports_by_ns,
+                        &order,
+                        &imp.source_ns,
+                        imp.site(),
+                    ),
+                    registry: index.registry_for(&imp.uri),
+                });
+        }
+        let mut exact_by_ns: std::collections::HashMap<&str, Vec<ExactImportRow<'a>>> =
+            std::collections::HashMap::new();
+        for link in index.command_links() {
+            if let Some(gate) = link.import_gate.as_ref() {
+                let uri = link.uri.as_str();
+                exact_by_ns
+                    .entry(importing_namespace_of(&link.linked_qname))
+                    .or_default()
+                    .push(ExactImportRow {
+                        uri,
+                        gate,
+                        exported: ExportGate::decide(
+                            &exports_by_ns,
+                            &order,
+                            &gate.source_ns,
+                            gate.site(uri),
+                        ),
+                    });
+            }
         }
         let mut forgets_by_ns: std::collections::HashMap<&str, Vec<&WorkspaceNamespaceForget>> =
             std::collections::HashMap::new();
@@ -4026,7 +4208,7 @@ impl<'a> WildcardImportIndex<'a> {
             forgets_by_ns,
             deletions_by_name,
             declarations_by_qname,
-            order: index.run_order(),
+            order,
             observable: index.observable_namespaces(),
         }
     }
@@ -4048,14 +4230,14 @@ impl<'a> WildcardImportIndex<'a> {
     /// worse than answering nothing.
     fn forced_shadow_at(&self, ns: &str, name: &str, call: CallSite<'_>) -> bool {
         self.imports_by_ns.get(ns).is_some_and(|imports| {
-            imports.iter().any(|imp| {
-                imp.forced
-                    && tcl_syntax::glob::string_match(&imp.tail_pattern, name)
+            imports.iter().any(|row| {
+                row.imp.forced
+                    && tcl_syntax::glob::string_match(&row.imp.tail_pattern, name)
                     && (!self
                         .observable
-                        .contains(imp.source_ns.trim_start_matches("::"))
-                        || self.exports_name_at(&imp.source_ns, name, imp.site()))
-                    && self.alias_live_at(ns, &imp.source_ns, name, imp.site(), call)
+                        .contains(row.imp.source_ns.trim_start_matches("::"))
+                        || row.exported.covers(name))
+                    && self.alias_live_at(ns, &row.imp.source_ns, name, row.site(), call)
             })
         })
     }
@@ -4273,21 +4455,21 @@ impl<'a> WildcardImportIndex<'a> {
             .map(Vec::as_slice)
             .unwrap_or_default()
             .iter()
-            .filter(|other| tcl_syntax::glob::string_match(&other.tail_pattern, name))
-            .map(|other| (other.source_ns.as_str(), other.site()))
+            .filter(|other| tcl_syntax::glob::string_match(&other.imp.tail_pattern, name))
+            .map(|other| (other.imp.source_ns.as_str(), other.site(), &other.exported))
             .chain(
                 self.exact_by_ns
                     .get(ns)
                     .map(Vec::as_slice)
                     .unwrap_or_default()
                     .iter()
-                    .filter(|(_, gate)| gate.name == name)
-                    .map(|(uri, gate)| (gate.source_ns.as_str(), gate.site(uri))),
+                    .filter(|other| other.gate.name == name)
+                    .map(|other| (other.gate.source_ns.as_str(), other.site(), &other.exported)),
             );
-        earlier.any(|(other_source, other_site)| {
+        earlier.any(|(other_source, other_site, other_exported)| {
             self.order.cmp_run(other_site.point(), site.point()) == Some(std::cmp::Ordering::Less)
                 && !ns_eq(other_source, source_ns)
-                && self.exports_name_at(other_source, name, other_site)
+                && other_exported.covers(name)
                 && self.alias_live_at(ns, other_source, name, other_site, call)
         })
     }
@@ -4371,9 +4553,29 @@ impl<'a> WildcardImportIndex<'a> {
     }
 }
 
+/// A namespace's indexed export rows as [`crate::namespace_import::ExportEvent`]s
+/// — the one place `WorkspaceNamespaceExport` is turned into one.
+///
+/// No enclosing-body span: the index stores none per export row, so every
+/// consumer ranks a `-clear` against a pattern by position alone. Symmetric,
+/// and the safe direction — a body-local export the tombstone cannot be proven
+/// to follow keeps the name exported.
+fn export_events<'e>(
+    exports: impl Iterator<Item = &'e WorkspaceNamespaceExport>,
+) -> impl Iterator<Item = crate::namespace_import::ExportEvent<'e>> {
+    exports.map(|e| crate::namespace_import::ExportEvent {
+        pattern: e.pattern.as_str(),
+        clears: e.clears,
+        at: RunPoint {
+            uri: e.uri.as_str(),
+            at: e.at,
+            enclosing_body: None,
+        },
+    })
+}
+
 /// [`crate::namespace_import::exported_at_import_site`] over a namespace's
-/// indexed export rows — the one place `WorkspaceNamespaceExport` is turned
-/// into an [`crate::namespace_import::ExportEvent`].
+/// indexed export rows.
 ///
 /// Shared by the per-call wildcard walk ([`WildcardImportIndex::exports_name_at`])
 /// and the standalone [`NamespaceExportSnapshot`] the single-document tier
@@ -4384,15 +4586,7 @@ fn exported_at_site<'e>(
     order: &crate::source_graph::RunOrder,
     site: RunPoint<'_>,
 ) -> bool {
-    let mut events = exports.map(|e| crate::namespace_import::ExportEvent {
-        pattern: e.pattern.as_str(),
-        clears: e.clears,
-        at: RunPoint {
-            uri: e.uri.as_str(),
-            at: e.at,
-            enclosing_body: None,
-        },
-    });
+    let mut events = export_events(exports);
     crate::namespace_import::exported_at_import_site(&mut events, name, order, site)
 }
 
@@ -8602,6 +8796,294 @@ mod tests {
         assert_eq!(
             snapshot.exported_at("::app", "mc", site),
             ExportVerdict::NotExported,
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #1297 — the settlement walk's cost must not scale with
+    // (invocations x in-scope imports x export rows).
+    //
+    // The reported symptom was a 26 s `textDocument/references` on a 113-file
+    // workspace.  The shape that produced it is entirely ordinary and is
+    // reproduced below: many load-level `namespace import NS::*`, a source
+    // namespace with many `namespace export` patterns, and a great many bare
+    // calls that resolve to no workspace command at all (every `set`, `if`,
+    // `expr` in the project), each of which falls through to the wildcard
+    // import tier.  Every one of those calls asked, per in-scope import, per
+    // export row, "had this export run when that import ran?" — a
+    // `RunOrder` walk over `HashMap`s keyed by owned URI strings.
+    //
+    // Nothing about an import's position depends on the call being resolved,
+    // so that whole question is now decided once per recorded import at
+    // index-build time (`ExportGate`), leaving a hash probe and a glob match
+    // on the per-call path.
+    // ---------------------------------------------------------------------
+
+    /// A workspace of the #1297 shape, sized so the pre-fix cost is seconds
+    /// and the post-fix cost is milliseconds.
+    fn wildcard_import_heavy_workspace(
+        importers: usize,
+        exports: usize,
+        calls_per_file: usize,
+    ) -> Vec<(String, AnalysisResult)> {
+        use std::fmt::Write as _;
+        let patterns: Vec<String> = (0..exports).map(|i| format!("Exported{i}")).collect();
+        let lib = format!(
+            "namespace eval ::Lib {{\n    namespace export {}\n    proc helper {{}} {{}}\n}}\n",
+            patterns.join(" "),
+        );
+        let mut docs = vec![("file:///lib.tcl".to_owned(), analyse(&lib))];
+        for f in 0..importers {
+            // A load-level glob import, then bare calls that settle to no
+            // workspace command — the ones that reach the wildcard tier.
+            let mut src = String::from("namespace import ::Lib::*\n");
+            for c in 0..calls_per_file {
+                writeln!(src, "noSuchCommand{c} a b").expect("writing to a String cannot fail");
+            }
+            docs.push((format!("file:///f{f}.tcl"), analyse(&src)));
+        }
+        docs
+    }
+
+    #[test]
+    fn settling_invocations_does_not_scale_with_imports_times_exports() {
+        let docs = wildcard_import_heavy_workspace(60, 40, 60);
+        let index = WorkspaceIndex::from_documents(docs.iter().map(|(uri, a)| (uri.as_str(), a)));
+        let started = std::time::Instant::now();
+        // The first call builds the settled-target view for the whole
+        // workspace, which is where the cost lived.
+        let hits = index.linked_invocations_of("::Lib::helper", "");
+        let elapsed = started.elapsed();
+        assert!(
+            hits.is_empty(),
+            "no call names ::Lib::helper, so this is the empty answer the walk had to work for",
+        );
+        // Measured on this shape, debug build: 81 ms with the gate hoisted,
+        // 7.59 s with `import_hop` restored to asking `exports_name_at` per
+        // call.  The bound sits between them with a 25x margin below and a
+        // 3.8x margin above, so it cannot flake on a loaded CI box and still
+        // fails outright if the per-call export walk comes back.
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "settling {} documents took {elapsed:?} — the per-call export walk is back (#1297)",
+            docs.len(),
+        );
+    }
+
+    /// The same workspace, asserting the *memo* rather than the wall clock:
+    /// a second reading of an unchanged index must serve the cached view, so
+    /// the cost above is paid once per generation and not once per request.
+    /// (`code_lenses` asks once per proc *and* once per class — issue #1152.)
+    #[test]
+    fn the_settled_target_view_is_served_from_cache_within_a_generation() {
+        let docs = wildcard_import_heavy_workspace(8, 6, 4);
+        let index = WorkspaceIndex::from_documents(docs.iter().map(|(uri, a)| (uri.as_str(), a)));
+        let first = index.invocations_by_settled_target(true);
+        assert!(
+            Arc::ptr_eq(&first, &index.invocations_by_settled_target(true)),
+            "an unchanged index must serve the settled-target cache, not rebuild it",
+        );
+    }
+
+    /// TP/TN on the hoisted export gate itself, through the public answer: an
+    /// exported name really does resolve through a wildcard import, and an
+    /// unexported sibling really does not.  This is the behaviour the
+    /// `ExportGate` precomputation must preserve exactly — the perf tests
+    /// above would happily pass on a gate that answered "no" to everything.
+    #[test]
+    fn the_precomputed_export_gate_still_admits_exactly_what_is_exported() {
+        let lib = analyse(
+            "namespace eval ::Lib {\n    proc shown {} {}\n    proc hidden {} {}\n    namespace export shown\n}\n",
+        );
+        let app = analyse("namespace import ::Lib::*\nshown\nhidden\n");
+        let index =
+            WorkspaceIndex::from_documents([("file:///lib.tcl", &lib), ("file:///app.tcl", &app)]);
+        // TP: `shown` is exported, so the bare call reaches it through the import.
+        assert_eq!(
+            index.linked_invocations_of("::Lib::shown", "").len(),
+            1,
+            "an exported name must still resolve through the wildcard import",
+        );
+        // TN: `hidden` is not exported, so the bare call reaches nothing —
+        // tclsh 9.0.4 answers `invalid command name` for it.
+        assert!(
+            index.linked_invocations_of("::Lib::hidden", "").is_empty(),
+            "an unexported sibling must not be reachable through the import",
+        );
+    }
+
+    /// FN guard for the literal/glob split inside [`ExportGate`]: a *glob*
+    /// export pattern must keep working, since only metacharacter-free
+    /// patterns may take the hash-set path.
+    #[test]
+    fn a_glob_export_pattern_still_covers_the_names_it_matches() {
+        let lib = analyse(
+            "namespace eval ::Lib {\n    proc getThing {} {}\n    proc setThing {} {}\n    namespace export get*\n}\n",
+        );
+        let app = analyse("namespace import ::Lib::*\ngetThing\nsetThing\n");
+        let index =
+            WorkspaceIndex::from_documents([("file:///lib.tcl", &lib), ("file:///app.tcl", &app)]);
+        assert_eq!(index.linked_invocations_of("::Lib::getThing", "").len(), 1);
+        assert!(
+            index
+                .linked_invocations_of("::Lib::setThing", "")
+                .is_empty(),
+            "`get*` does not cover `setThing`",
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #1302 — the import-conflict rule's "already exists" side must
+    // include the commands the *registry* declares, not only the procs and
+    // classes the workspace declares.
+    //
+    // Every expectation below is oracle-verified on tclsh 9.0.4 (built from
+    // core-9-0-4) and 8.6.14, byte-identical:
+    //
+    //   namespace eval ::Foo { proc set {a b} {…}; namespace export set }
+    //   namespace import ::Foo::*   -> can't import command "set": already exists
+    //                                  namespace origin ::set  == ::set
+    //   namespace import ::Foo::set -> same error (the exact-pattern twin)
+    //   namespace import -force ::Foo::*  -> namespace origin ::set == ::Foo::set
+    //   namespace eval ::Bar { namespace import ::Foo::* }
+    //                               -> namespace origin ::Bar::set == ::Foo::set
+    //   # …and `+` is NOT a global command, so it does not conflict:
+    //   info commands ::+           -> {}      (+ 1 2 -> invalid command name)
+    // ---------------------------------------------------------------------
+
+    /// TP: the defect itself.  `::Foo` exports `set`; real Tcl refuses the
+    /// import, so the bare `set x 1` reaches the builtin and is **not** a
+    /// reference to `::Foo::set`.
+    #[test]
+    fn a_wildcard_import_does_not_bind_a_name_the_registry_already_declares() {
+        let a = analyse_as(
+            "namespace eval ::Foo {\n    proc set {a b} { return SHADOW }\n    namespace export set\n}\n",
+            "tcl9.0",
+        );
+        let b = analyse_as("namespace import ::Foo::*\nset x 1\n", "tcl9.0");
+        let index = WorkspaceIndex::from_documents([("file:///a.tcl", &a), ("file:///b.tcl", &b)]);
+        assert!(
+            index.linked_invocations_of("::Foo::set", "").is_empty(),
+            "the import raised `already exists` and installed nothing, so the \
+             bare call reaches the builtin",
+        );
+    }
+
+    /// TN: `-force` is the one import that *does* replace a command the
+    /// target namespace already holds, so the call really is a reference.
+    #[test]
+    fn a_forced_wildcard_import_still_shadows_a_registry_builtin() {
+        let a = analyse_as(
+            "namespace eval ::Foo {\n    proc set {a b} { return SHADOW }\n    namespace export set\n}\n",
+            "tcl9.0",
+        );
+        let b = analyse_as("namespace import -force ::Foo::*\nset x 1\n", "tcl9.0");
+        let index = WorkspaceIndex::from_documents([("file:///a.tcl", &a), ("file:///b.tcl", &b)]);
+        assert_eq!(
+            index.linked_invocations_of("::Foo::set", "").len(),
+            1,
+            "`namespace origin ::set` is `::Foo::set` after a -force import",
+        );
+    }
+
+    /// FP guard: the rule is about the **target** namespace's command table,
+    /// and the builtins live in `::`.  Importing into `::Bar` binds
+    /// `::Bar::set` with no conflict at all, so a call from `::Bar` must
+    /// still resolve — the gate must not fire on the bare name alone.
+    #[test]
+    fn importing_a_builtin_name_into_a_sub_namespace_still_binds() {
+        let a = analyse_as(
+            "namespace eval ::Foo {\n    proc set {a b} { return SHADOW }\n    namespace export set\n}\n",
+            "tcl9.0",
+        );
+        let b = analyse_as(
+            "namespace eval ::Bar {\n    namespace import ::Foo::*\n    proc go {} { set x 1 }\n}\n",
+            "tcl9.0",
+        );
+        let index = WorkspaceIndex::from_documents([("file:///a.tcl", &a), ("file:///b.tcl", &b)]);
+        assert_eq!(
+            index.linked_invocations_of("::Foo::set", "").len(),
+            1,
+            "`::Bar::set` is not a builtin, so the import installs and the \
+             call from ::Bar reaches it",
+        );
+    }
+
+    /// TN: an ordinary, non-builtin exported name is unaffected — the gate
+    /// must not have made the whole wildcard tier answer "no".
+    #[test]
+    fn a_wildcard_import_of_a_non_builtin_name_is_unaffected() {
+        let a = analyse_as(
+            "namespace eval ::Foo {\n    proc mything {} {}\n    namespace export mything\n}\n",
+            "tcl9.0",
+        );
+        let b = analyse_as("namespace import ::Foo::*\nmything\n", "tcl9.0");
+        let index = WorkspaceIndex::from_documents([("file:///a.tcl", &a), ("file:///b.tcl", &b)]);
+        assert_eq!(index.linked_invocations_of("::Foo::mything", "").len(), 1);
+    }
+
+    /// FN guard for the operator spellings, which is where a naive
+    /// "`registry.get(name).is_some()`" gate would break a *working* import:
+    /// `+` is not a command in `::` at all (`info commands ::+` is empty in a
+    /// fresh tclsh 9.0.4), so exporting `+` and importing it into `::`
+    /// genuinely binds — `namespace origin ::+` answers `::Ops::+`.
+    #[test]
+    fn importing_an_operator_name_into_the_global_namespace_still_binds() {
+        let a = analyse_as(
+            "namespace eval ::Ops {\n    proc + {a b} { return OPS }\n    namespace export +\n}\n",
+            "tcl9.0",
+        );
+        let b = analyse_as("namespace import ::Ops::*\n+ 1 2\n", "tcl9.0");
+        let index = WorkspaceIndex::from_documents([("file:///a.tcl", &a), ("file:///b.tcl", &b)]);
+        assert_eq!(
+            index.linked_invocations_of("::Ops::+", "").len(),
+            1,
+            "a bare operator spelling is the post-`namespace import \
+             ::tcl::mathop::*` form, not a command a fresh interpreter holds",
+        );
+    }
+
+    /// The exact-pattern twin: `namespace import ::Foo::set` is refused for
+    /// the identical reason, so the link it would introduce is not live.
+    #[test]
+    fn an_exact_import_of_a_registry_builtin_installs_no_link() {
+        let a = analyse_as(
+            "namespace eval ::Foo {\n    proc set {a b} { return SHADOW }\n    namespace export set\n}\n",
+            "tcl9.0",
+        );
+        let b = analyse_as("namespace import ::Foo::set\nset x 1\n", "tcl9.0");
+        let index = WorkspaceIndex::from_documents([("file:///a.tcl", &a), ("file:///b.tcl", &b)]);
+        assert!(
+            index.linked_invocations_of("::Foo::set", "").is_empty(),
+            "an exact import of an already-existing name installs nothing either",
+        );
+    }
+
+    /// Dialect sensitivity: the gate must read the *document's own* dialect,
+    /// not a workspace-wide guess.  `HTTP::uri` is a command only the
+    /// `f5-irules` registry declares, so an import of it conflicts there and
+    /// binds under plain Tcl.
+    #[test]
+    fn the_builtin_gate_reads_each_documents_own_dialect() {
+        let lib = "namespace eval ::Mine {\n    proc uri {} {}\n    namespace export uri\n}\n";
+        let importer =
+            "namespace eval ::HTTP {\n    namespace import ::Mine::*\n    proc go {} { uri }\n}\n";
+        // Plain Tcl knows no `::HTTP::uri`, so the import installs.
+        let a = analyse_as(lib, "tcl9.0");
+        let b = analyse_as(importer, "tcl9.0");
+        let plain = WorkspaceIndex::from_documents([("file:///a.tcl", &a), ("file:///b.tcl", &b)]);
+        assert_eq!(
+            plain.linked_invocations_of("::Mine::uri", "").len(),
+            1,
+            "plain Tcl has no ::HTTP::uri to conflict with",
+        );
+        // The iRules registry does, so the same source conflicts.
+        let a = analyse_as(lib, "f5-irules");
+        let b = analyse_as(importer, "f5-irules");
+        let irules = WorkspaceIndex::from_documents([("file:///a.tcl", &a), ("file:///b.tcl", &b)]);
+        assert!(
+            irules.linked_invocations_of("::Mine::uri", "").is_empty(),
+            "f5-irules declares ::HTTP::uri, so the unforced import installs nothing",
         );
     }
 }

--- a/rust/tcl-lsp-db/examples/edit_memory.rs
+++ b/rust/tcl-lsp-db/examples/edit_memory.rs
@@ -80,6 +80,12 @@ fn main() {
     // parses, so nothing fails loudly — it just measures the wrong thing, and a
     // parameter edit additionally re-keys every procedure's lattice through the
     // module-wide `proc_params` context rather than isolating one body.
+    //
+    // `body_span.start()` is the offset *of* the opening `{`, hence the `+ 1`:
+    // inserting at `start()` itself lands between the parameter list and the
+    // brace, which leaves every body unedited (merely shifted). The body-keyed
+    // interned structs are offset-invariant, so that session re-keys nothing —
+    // it measures a buffer that changes with no incremental work behind it.
     let edit_pos = Analyser::new()
         .analyse(&src, dialect)
         .all_procs
@@ -87,7 +93,7 @@ fn main() {
         .map(|p| p.body_span)
         .filter(|s| s.end() > s.start())
         .max_by_key(|s| s.end() - s.start())
-        .map_or(src.len() / 2, |s| s.start() as usize);
+        .map_or(src.len() / 2, |s| s.start() as usize + 1);
 
     let mut db = TclDatabase::default();
     let file = SourceFile::new(&db, src.clone(), dialect.to_owned(), None);

--- a/rust/tcl-lsp-db/examples/tail_profile.rs
+++ b/rust/tcl-lsp-db/examples/tail_profile.rs
@@ -30,8 +30,8 @@ use tcl_compiler::gvn::{
 use tcl_compiler::shimmer::{find_shimmer_warnings_for_cu, find_thunking_warnings_for_cu};
 use tcl_compiler::taint_interproc::solve_interprocedural_taints;
 use tcl_lsp_db::{
-    AnalyserConfig, SourceFile, TclDatabase, TclDb, compiler_check_diagnostics,
-    file_analysis_incremental,
+    AnalyserConfig, LexerCfgKey, SourceFile, TclDatabase, TclDb, compilation_unit,
+    compiler_check_diagnostics, file_analysis_incremental,
 };
 
 fn ms(d: std::time::Duration) -> f64 {
@@ -177,7 +177,7 @@ fn main() {
         t_taint,
     );
 
-    // The warm cost of a SECOND `memoised_compilation_unit` build on the
+    // The warm cost of a SECOND whole-file unit build on the
     // same db — exactly what a checks-path `proc_taint_solve` query would re-run to
     // recover the offset-0 `FnLatticeKey`s locally (they cannot be threaded out of
     // the shared `compilation_unit`: a salsa tracked return must be `'static`). The
@@ -186,24 +186,32 @@ fn main() {
     // reassembly (lex + segment + IR skeleton + interproc summary) the second build
     // cannot avoid. This delta is the duplicate-build cost the checks-path memo
     // must pay against its ~120 ms summary-floor saving.
+    //
+    // Measured through the tracked `compilation_unit` query, one fresh
+    // `SourceFile` per iteration: the same text under a distinct query key, so
+    // each iteration really rebuilds instead of hitting the memo. It does not
+    // call the crate's unit builder directly — that is crate-private precisely
+    // because its per-body interning is only garbage-collectable inside a
+    // tracked query (see tcl-lsp-db's "The interned garbage collector is
+    // load-bearing").
     println!("\n== 2b gate: warm duplicate-build cost (function_lattice cache hot) ==");
     {
+        const DUP_ITERS: u32 = 5;
         let cfg_d = tcl_lexer::LexerConfig::for_dialect(dialect);
         // Warm the shared build (populates function_lattice / taint_cascade) on the
         // *edited* text, mirroring the per-edit state proc_taint_solve runs in.
         file.set_text(&mut db).to(edited.clone());
         let _ = compiler_check_diagnostics(&db, file, cfg);
-        let dup = time("memoised_compilation_unit (2nd build, warm)", 5, || {
-            tcl_lsp_db::memoised_compilation_unit(
+        let cfg_key = LexerCfgKey::new(&db, cfg_d.expand_syntax, cfg_d.irules_brace_separator);
+        let mut dup_files = (0..DUP_ITERS)
+            .map(|_| SourceFile::new(&db, edited.clone(), dialect.to_owned(), None))
+            .collect::<Vec<_>>()
+            .into_iter();
+        let dup = time("compilation_unit (2nd build, warm)", DUP_ITERS, || {
+            compilation_unit(
                 &db,
-                &edited,
-                tcl_compiler::compilation_unit::UnitBuildOptions {
-                    registry,
-                    defer_top_level: false,
-                    config: cfg_d,
-                    dialect,
-                    external_call_sites: None,
-                },
+                dup_files.next().expect("one source file per iteration"),
+                cfg_key,
             )
         });
         println!(

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -78,6 +78,77 @@
 //! memos at all (#1144: the closed-file republish takes the uncached
 //! pipeline).  While they did, every closed-file sweep would `record_use` on
 //! hundreds of closed files and evict the *open* documents' units instead.
+//!
+//! # The interned garbage collector is load-bearing
+//!
+//! `lru = N` above bounds *memo payloads*.  It does **not** bound the
+//! **interned tables**, and six of this crate's interned structs key on
+//! content that changes on every keystroke inside a procedure body:
+//!
+//! | Interned struct | The per-revision field |
+//! |---|---|
+//! | [`ItemBodyKey`] | `body_text` — the procedure/method body source |
+//! | [`FnLatticeKey`] | `body` — the whole post-inline procedure IR |
+//! | [`ProcBodyKey`] | `body_text` |
+//! | [`OptDepsKey`] | `body_source` + `proc_body_source` |
+//! | [`TaintSummaryKey`] | `reachable` — shifts as the projections move |
+//! | [`SummaryDepsKey`] | `interproc_reachable` + `callee_summaries` |
+//!
+//! Typing inside a body therefore mints a brand-new interned id for every one
+//! of them on every keystroke, each holding a body's worth of `Arc` payload in
+//! its memo table — the exact shape of an unbounded interning leak.  Measured
+//! against the #1181 corpus the edit path is nonetheless flat (~0 bytes/edit
+//! steady state, ~66.5 MB across 60–500 edits), and the reason is **salsa's
+//! interned garbage collector**, not anything this crate does:
+//!
+//! * A cold intern walks the shard's LRU tail and reuses any slot that has not
+//!   been interned for `DEFAULT_REVISIONS` (3) revisions: it overwrites the
+//!   slot's fields and calls `clear_memos` on it.  That `clear_memos` is what
+//!   drops the retained `Arc`s — so the collector, not `lru = N`, is what keeps
+//!   a typing session bounded.
+//! * A slot is eligible only when its recorded durability is exactly
+//!   `Durability::LOW`.  Collecting anything more durable would require
+//!   invalidating that durability's revision (`Database::synthetic_write`,
+//!   which needs `&mut` on the database), so salsa refuses outright.
+//! * A slot's durability is the *minimum* durability of the inputs the creating
+//!   query had read when it interned — and with **no active query at all**
+//!   salsa stamps `Durability::MAX` / `Revision::MAX`, i.e. an immortal slot.
+//!
+//! Two rules follow, and breaking either restores a KB-per-keystroke leak of
+//! the #1035 class while looking like an optimisation in review:
+//!
+//! 1. **[`SourceFile`], [`AnalyserConfig`], and [`Project`] stay at
+//!    `Durability::LOW`** — salsa's default, which this workspace never
+//!    overrides.  Marking the document text or the analyser config `HIGH`
+//!    "because it rarely changes" would stamp every key in the table above
+//!    non-`LOW`, and none would ever be collected again.
+//! 2. **The per-body keys are interned from inside a tracked query.**  That is
+//!    why `memoised_compilation_unit` is crate-private and documented as
+//!    tracked-query-only: reached from [`compilation_unit`] its interning
+//!    inherits that query's `LOW` durability, whereas a direct call from
+//!    untracked code mints immortal slots holding whole `CompilationUnit`
+//!    lattices.
+//!
+//! Interned structs with a *bounded* key space are outside this contract:
+//! [`LexerCfgKey`] is two booleans and [`CommandTail`] one command name, so
+//! minting them from untracked host code (as [`compilation_unit`]'s own
+//! signature requires) can retain only a handful of tiny slots.
+//! [`CfgContext`] is content-keyed but signature-level, so a body edit leaves
+//! it alone; it is collected by the same mechanism when a signature does move.
+//!
+//! Neither rule is expressible in the type system, so both are pinned
+//! behaviourally by `tests/interned_gc.rs`.  It drives a typing session through
+//! the production queries and counts salsa's `DidReuseInternedValue` events per
+//! ingredient (see [`TclDatabase::with_interned_reuse_logger`]) — the event the
+//! collector fires when it recycles a slot, and one that a non-`LOW` or
+//! untracked slot can never produce.  A control session repeats the run with
+//! both inputs at `Durability::HIGH` and asserts the collector goes silent,
+//! which is what keeps the first test from going vacuous.  A third test fails
+//! on any `with_durability` / input-builder `durability` call site in this
+//! crate or in `tcl-lsp-server` (its only dependant), because durability is
+//! chosen at the setter call site where the behavioural tests cannot see it.
+//! The full contract is written up in
+//! `docs/design/rust/salsa-interned-gc.md`.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
@@ -151,6 +222,29 @@ impl TclDatabase {
         })));
         Self { storage }
     }
+
+    /// Construct a database that forwards, for every interned-slot **reuse**
+    /// (salsa's `DidReuseInternedValue`), the reused slot's `database_key`
+    /// `Debug` string — `"<IngredientName>(Id(..))"` — to `logger`.
+    ///
+    /// That event is the only observable face of the interned garbage
+    /// collector described under "The interned garbage collector is
+    /// load-bearing": salsa fires it exactly when a cold intern recycles a
+    /// stale LRU slot and clears its memo table.  A slot that is not
+    /// collectable — durability above `Durability::LOW`, or interned with no
+    /// active query — is never in the LRU list, so it can never produce this
+    /// event.  Counting the events per ingredient is therefore a direct,
+    /// machine-independent read of whether the collector is still working;
+    /// `tests/interned_gc.rs` is built on it.
+    #[must_use]
+    pub fn with_interned_reuse_logger(logger: impl Fn(String) + Send + Sync + 'static) -> Self {
+        let storage = salsa::Storage::new(Some(Box::new(move |ev: salsa::Event| {
+            if let salsa::EventKind::DidReuseInternedValue { key, .. } = ev.kind {
+                logger(format!("{key:?}"));
+            }
+        })));
+        Self { storage }
+    }
 }
 
 #[salsa::db]
@@ -173,6 +267,17 @@ impl TclDb for TclDatabase {
 ///
 /// `set_text` (generated) is the single write on an edit — salsa cascades
 /// invalidation to every query that read it.
+///
+/// # Durability must stay `LOW`
+///
+/// Write this input with a plain `set_*(…).to(…)`, never with
+/// `Setter::with_durability` or the builder's `durability` / `*_durability`
+/// methods.  Every per-body interned key in this crate is minted by a query
+/// that has read this input, so the key inherits its durability — and salsa's
+/// interned garbage collector only ever reclaims `Durability::LOW` slots.
+/// Raising it looks like a revalidation win and is in fact a
+/// KB-per-keystroke leak.  See the crate docs' "The interned garbage collector
+/// is load-bearing"; enforced by `tests/interned_gc.rs`.
 #[salsa::input(constructor = with_call_site_evidence)]
 pub struct SourceFile {
     #[returns(ref)]
@@ -243,6 +348,15 @@ impl SourceFile {
 /// `disabled_diagnostics` / `non_ascii_mode` server state).  One input
 /// instance shared by every file's analysis; setting it recomputes all
 /// analyses.
+///
+/// # Durability must stay `LOW`
+///
+/// This is the input a "it only changes when the user edits settings"
+/// argument most tempts one to mark `Durability::HIGH`.  Do not: an analysis
+/// query that has read this config interns [`ItemBodyKey`] under the minimum
+/// durability of everything it read, so a `HIGH` config makes those body keys
+/// uncollectable.  Same contract as [`SourceFile`] — see the crate docs' "The
+/// interned garbage collector is load-bearing".
 #[salsa::input]
 pub struct AnalyserConfig {
     #[returns(ref)]
@@ -357,6 +471,15 @@ pub fn file_decls(db: &dyn salsa::Database, file: SourceFile) -> Arc<FileDecls> 
 /// for free: editing one file recomputes only the cross-file facts that actually
 /// read it.  Setting `files` (open/close) recomputes the project aggregates;
 /// editing a file's text does not touch this input.
+///
+/// # Durability must stay `LOW`
+///
+/// The file *set* really does change rarely, which is exactly why this input
+/// attracts a durability bump.  It carries the same prohibition as
+/// [`SourceFile`] and [`AnalyserConfig`]: a cross-file query that has read it
+/// interns under its durability, and only `Durability::LOW` slots are
+/// garbage-collected.  See the crate docs' "The interned garbage collector is
+/// load-bearing".
 #[salsa::input]
 pub struct Project {
     /// The project's files (workspace + open documents).
@@ -1069,6 +1192,14 @@ pub fn project_diagnostics(
 /// config), *not* the body's position — so a shifted-but-unedited proc has the
 /// same key and reuses the cached [`item_body_analysis`] (the aggregator rebases
 /// the offset-0 facts by the body's real span).
+///
+/// **Per-revision key — reclaimed by salsa's interned garbage collector.**
+/// `body_text` changes on every keystroke inside the body, so each edit mints a
+/// fresh id here.  What keeps that bounded is the collector reusing the LRU
+/// tail's stale slots (`clear_memos` releasing the retained analysis `Arc`s),
+/// which happens only for `Durability::LOW` slots interned inside a tracked
+/// query.  See the crate docs' "The interned garbage collector is
+/// load-bearing"; pinned by `tests/interned_gc.rs`.
 #[salsa::interned]
 pub struct ItemBodyKey<'db> {
     /// The proc / method body source, shared with the
@@ -1230,6 +1361,13 @@ pub struct CfgContext<'db> {
 /// literal at that position changes (which re-interns to a new key).  The seeds
 /// are position-independent (keyed by parameter name + SSA version), so they do
 /// not break the offset-invariance of the body key.
+///
+/// **Per-revision key — reclaimed by salsa's interned garbage collector.**
+/// `body` is the procedure's whole post-inline IR, so an edit inside the body
+/// mints a fresh id *and* a fresh `Script` behind it.  The collector's slot
+/// reuse is what frees both, and it only reclaims `Durability::LOW` slots
+/// interned inside a tracked query.  See the crate docs' "The interned garbage
+/// collector is load-bearing"; pinned by `tests/interned_gc.rs`.
 #[salsa::interned]
 pub struct FnLatticeKey<'db> {
     #[returns(ref)]
@@ -1333,6 +1471,13 @@ pub fn function_lattice<'db>(db: &'db dyn TclDb, key: FnLatticeKey<'db>) -> Arc<
 /// where the isolated lowering is byte-identical to the in-place `lower_body`;
 /// guarded by the corpus differential gates (`file_analysis_corpus` /
 /// `compiler_check_corpus`).
+///
+/// **Per-revision key — reclaimed by salsa's interned garbage collector.**
+/// `body_text` changes on every keystroke inside the body; the lowered
+/// `Arc<Script>` memo behind the stale id is released when the collector reuses
+/// its slot, which happens only for `Durability::LOW` slots interned inside a
+/// tracked query.  See the crate docs' "The interned garbage collector is
+/// load-bearing"; pinned by `tests/interned_gc.rs`.
 #[salsa::interned]
 pub struct ProcBodyKey<'db> {
     #[returns(ref)]
@@ -1387,8 +1532,23 @@ pub fn lower_proc_body<'db>(db: &'db dyn TclDb, key: ProcBodyKey<'db>) -> Arc<Sc
 /// change a `{*}`/`}{` body's IR), so the same procedure can intern to two
 /// different bodies; because the **post-lowering body is part of the key**, the
 /// two never cross-pollute — no explicit namespace is needed.
+///
+/// # Must be called from inside a tracked query
+///
+/// This is crate-private, and stays crate-private, because it interns the
+/// per-body keys ([`FnLatticeKey`], [`ProcBodyKey`], [`TaintSummaryKey`],
+/// [`SummaryDepsKey`], [`OptDepsKey`]) directly.  Salsa stamps an interned slot
+/// with the minimum durability of the inputs the *active* query has read; with
+/// no active query it stamps `Durability::MAX`, and only `Durability::LOW`
+/// slots are ever garbage-collected.  An untracked call therefore mints
+/// immortal slots, each pinning a full procedure IR plus its lattice memos —
+/// a KB-per-keystroke leak if it ever landed on the edit path.
+///
+/// The sanctioned entry point is the tracked [`compilation_unit`] query, which
+/// reads [`SourceFile`] (`LOW`) before building.  See the crate docs' "The
+/// interned garbage collector is load-bearing".
 #[must_use]
-pub fn memoised_compilation_unit(
+pub(crate) fn memoised_compilation_unit(
     db: &dyn TclDb,
     source: &str,
     options: UnitBuildOptions<'_>,
@@ -1396,7 +1556,7 @@ pub fn memoised_compilation_unit(
     build_unit_with_keys(db, source, options).0
 }
 
-/// [`memoised_compilation_unit`] that also returns the per-procedure
+/// `memoised_compilation_unit` that also returns the per-procedure
 /// [`FnLatticeKey`] map built during lowering (qname → offset-0 baseline key).
 ///
 /// [`proc_taint_solve`] needs those keys to memoise the interprocedural summary
@@ -1561,6 +1721,13 @@ pub struct ProcTaintSummary {
 /// transitive callees.  A body edit that leaves these unchanged is a cache hit;
 /// an edit that flips a reachable callee's `writes_global` / passthrough
 /// re-interns this key for exactly the callers that reach it.
+///
+/// **Per-revision key — reclaimed by salsa's interned garbage collector.**
+/// `reachable` moves as the edited procedure's projections move, so a typing
+/// session mints fresh ids steadily.  Only the collector's reuse of stale LRU
+/// slots keeps the table flat, and it reclaims `Durability::LOW` slots interned
+/// inside a tracked query only.  See the crate docs' "The interned garbage
+/// collector is load-bearing"; pinned by `tests/interned_gc.rs`.
 #[salsa::interned]
 pub struct TaintSummaryKey<'db> {
     /// All procedure names in the module (sorted) — the call-resolution domain.
@@ -1673,6 +1840,13 @@ pub fn taint_cascade<'db>(
 /// edit that leaves all of these unchanged re-interns to the same key, so `P`'s
 /// inference is a cache hit; an edit that flips a reachable callee's summary
 /// re-keys exactly the callers that reach it.
+///
+/// **Per-revision key — reclaimed by salsa's interned garbage collector.**
+/// `interproc_reachable` / `callee_summaries` move with the edited procedure's
+/// projections, exactly as [`TaintSummaryKey`]'s `reachable` does, so the same
+/// contract applies: collection needs `Durability::LOW` slots interned inside a
+/// tracked query.  See the crate docs' "The interned garbage collector is
+/// load-bearing"; pinned by `tests/interned_gc.rs`.
 #[salsa::interned]
 pub struct SummaryDepsKey<'db> {
     /// All procedure names in the module (sorted) — the call-resolution domain.
@@ -2182,6 +2356,13 @@ fn opt_callee_to_summary(o: &OptCalleeSummary) -> ProcSummary {
 /// callees (O103 fold / purity inputs), and the module `redefined_procedures` set
 /// (the O103 don't-fold-a-redefined-callee gate).  A body edit to an unrelated proc
 /// whose summary this proc doesn't read leaves this key unchanged → cache hit.
+///
+/// **Per-revision key — reclaimed by salsa's interned garbage collector.**
+/// `body_source` and `proc_body_source` change on every keystroke inside the
+/// procedure, and the memo behind a stale id holds that procedure's whole
+/// optimisation set.  Slot reuse releases it, for `Durability::LOW` slots
+/// interned inside a tracked query only.  See the crate docs' "The interned
+/// garbage collector is load-bearing"; pinned by `tests/interned_gc.rs`.
 #[salsa::interned]
 pub struct OptDepsKey<'db> {
     #[returns(ref)]
@@ -2587,7 +2768,7 @@ fn lexer_cfg_key(db: &dyn TclDb, config: tcl_lexer::LexerConfig) -> LexerCfgKey<
 }
 
 /// The shared, memoised [`CompilationUnit`] for a document under a given lexer
-/// config — built via [`memoised_compilation_unit`] (per-procedure lattices on
+/// config — built via `memoised_compilation_unit` (per-procedure lattices on
 /// the salsa-native [`function_lattice`] graph).  Tracked + keyed on
 /// `(file, cfg)` so the analyser tail ([`file_analysis_incremental`]) and the
 /// optimiser/compiler-checks pass ([`compiler_check_diagnostics`]) **share one
@@ -2623,7 +2804,7 @@ pub fn compilation_unit<'db>(
 /// recomputes one body + the cheap shell instead of the whole walk; the
 /// CFG/SSA diagnostic tail's per-procedure lattices are likewise memoised via
 /// the salsa-native [`function_lattice`] query (through
-/// [`memoised_compilation_unit`]), so an unchanged procedure's lattice is reused
+/// `memoised_compilation_unit`), so an unchanged procedure's lattice is reused
 /// (and rebased) instead of rebuilt.  Byte-identical to [`file_analysis`] (and
 /// `analyse`) — proven by the `per_item_corpus` gate over the shared
 /// `analyse_per_item_with` orchestration.
@@ -3098,21 +3279,24 @@ mod tests {
     /// the unit at offset 0 and every consumer is rebased to the procedure's
     /// real position — but `def_use` / `types` / `taints` / `rendered_props` are
     /// span-free, so a rebuild that hits the memo must share them.
+    ///
+    /// Two *distinct* `SourceFile`s carrying the same text give two distinct
+    /// `compilation_unit` keys, so both really build — while their per-procedure
+    /// lattice demands land on the same `function_lattice` memos.  Driving it
+    /// through the tracked query rather than calling `memoised_compilation_unit`
+    /// directly is deliberate: the per-body keys are only garbage-collectable
+    /// when interned inside a tracked query (see the crate docs' "The interned
+    /// garbage collector is load-bearing").
     #[test]
     fn memoised_lattices_are_shared_not_deep_copied_across_builds() {
         const SRC: &str = "proc alpha {a b} {\n    set s [expr {$a + $b}]\n    return $s\n}\n\
                            proc beta {x} {\n    return [alpha $x 1]\n}\n";
         let db = TclDatabase::default();
-        let registry = db.registry("tcl8.6");
-        let options = || UnitBuildOptions {
-            registry,
-            defer_top_level: false,
-            config: tcl_lexer::LexerConfig::default(),
-            dialect: "tcl8.6",
-            external_call_sites: None,
-        };
-        let first = memoised_compilation_unit(&db, SRC, options());
-        let second = memoised_compilation_unit(&db, SRC, options());
+        let cfg_key = lexer_cfg_key(&db, tcl_lexer::LexerConfig::default());
+        let file_a = SourceFile::new(&db, SRC.to_owned(), "tcl8.6".to_owned(), None);
+        let file_b = SourceFile::new(&db, SRC.to_owned(), "tcl8.6".to_owned(), None);
+        let first = compilation_unit(&db, file_a, cfg_key);
+        let second = compilation_unit(&db, file_b, cfg_key);
         for qname in ["::alpha", "::beta"] {
             let a = first
                 .procedures

--- a/rust/tcl-lsp-db/tests/interned_gc.rs
+++ b/rust/tcl-lsp-db/tests/interned_gc.rs
@@ -47,11 +47,11 @@
 //! would be tuned to the machine it was written on and would fail on a bigger
 //! one.
 //!
-//! Reuse counts remove the dependence from the *assertion*, but not from the
-//! number of revisions needed to observe one, and assuming a fixed edit count
-//! sufficed was a real flake: a slot is only reclaimable once its **own**
-//! shard's LRU tail holds a stale entry, so the sparser ingredients need more
-//! interns before any shard accumulates enough. Measured on one machine by
+//! Reuse counts looked like the fix, and were not. They remove the shard
+//! dependence from the *assertion* but not from whether an event ever fires:
+//! a slot is only reclaimable once its **own** shard's LRU tail holds a stale
+//! entry, so a small working set spread across a wide machine's shards can be
+//! perfectly healthy and still never produce a single reuse. Measured by
 //! varying the visible CPU count, all else equal:
 //!
 //! | cores | shards | `TaintSummaryKey` reuses | `SummaryDepsKey` reuses |
@@ -59,24 +59,32 @@
 //! |     1 |      4 |                       32 |                     119 |
 //! |     2 |      8 |                       28 |                      39 |
 //! |     4 |     16 |                       22 |                      34 |
-//! |    CI |    32+ |                    **0** |                   **1** |
+//! |    CI |    32+ |                        0 |                       1 |
 //!
-//! So the session drives revisions **until the collector is observed for every
-//! ingredient**, bounded by [`edit_cap`], instead of a fixed count: it stops as
-//! soon as the invariant is demonstrated (24 edits on a small machine) and
-//! keeps going where sharding makes that take longer. The bound is what turns
-//! "we did not look long enough" into a real failure.
+//! Asserting on those zeroes was a false alarm, not a leak: the two summary
+//! ingredients hold a *bounded* set of slots whether or not the collector
+//! runs (24 and 32 respectively, unchanged from 24 edits to 96, under both
+//! `LOW` and `HIGH` durability), so they can never demonstrate the leak the
+//! test exists to catch.
+//!
+//! What the leak actually looks like is **slots tracking the edit count**, so
+//! that is what is asserted: drive a short session and a session four times
+//! longer, and require the live slot count not to scale with it
+//! ([`SLOT_GROWTH_BOUND`]). That is machine-independent — it compares two runs
+//! on the same machine — and strictly closer to the invariant. Reuse counts
+//! stay in the failure report as a diagnostic.
 //!
 //! # The two behavioural tests
 //!
-//! [`interned_slots_are_reclaimed_across_an_edit_session`] drives a typing
-//! session through the production queries and asserts every one of the six
-//! ingredients is being reclaimed.
+//! [`interned_slots_stay_bounded_across_an_edit_session`] drives a short typing
+//! session and one four times longer through the production queries, and
+//! asserts the live slot count of every one of the six ingredients does not
+//! scale with the session.
 //!
-//! [`raising_input_durability_disables_the_collector`] drives the *same*
-//! session with `SourceFile` and `AnalyserConfig` marked `Durability::HIGH` and
-//! asserts the collector goes completely silent while slot counts grow with the
-//! edit count. It is the break-the-invariant experiment, kept in the suite
+//! [`raising_input_durability_disables_the_collector`] drives the *same* two
+//! sessions with `SourceFile` and `AnalyserConfig` marked `Durability::HIGH`
+//! and asserts the collector goes completely silent, and that the slot counts
+//! then *do* break the bound the first test applies. It is the break-the-invariant experiment, kept in the suite
 //! rather than performed once and discarded: it is what proves the first test
 //! is not vacuous, and it pins the durability sensitivity that makes the rule
 //! necessary. If it ever fails because reuse *did* happen at `HIGH`, salsa's
@@ -120,35 +128,33 @@ const BODY_KEYED_INTERNED: [&str; 4] = ["ItemBodyKey", "FnLatticeKey", "ProcBody
 /// one edit produces `WORKERS` cold interns of each body-keyed ingredient.
 const WORKERS: u32 = 4;
 
-/// Edits every session drives before it may stop. Well above salsa's
-/// `DEFAULT_REVISIONS` staleness window (3), and `WORKERS * EDITS` cold interns
-/// is enough for the collector to reach steady state on a small machine while
-/// keeping the run around three seconds in a debug build.
-///
-/// A floor, not a budget: [`drive_until_collected`] keeps going past it while
-/// any ingredient has yet to show a reuse. The control session, which must
-/// observe *no* reuse, always runs exactly this many.
-const EDITS: u32 = 24;
+/// The short session. Well above salsa's `DEFAULT_REVISIONS` staleness window
+/// (3), so the collector has had every chance to run by the end of it.
+const SHORT_SESSION: u32 = 24;
 
-/// Salsa's interned-table shard count — `(available_parallelism() * 4)`
-/// rounded up to a power of two (`salsa::table::memo` sharding).  Read here
-/// only to scale [`edit_cap`]; nothing asserts on it.
-fn interned_shards() -> u32 {
-    let cpus = std::thread::available_parallelism().map_or(1, std::num::NonZero::get);
-    u32::try_from(cpus.saturating_mul(4).next_power_of_two()).unwrap_or(u32::MAX)
-}
+/// The long session — four times the short one. The invariant is measured as
+/// the ratio between the two.
+const LONG_SESSION: u32 = SHORT_SESSION * 4;
 
-/// The most edits [`drive_until_collected`] will drive before giving up and
-/// letting the assertion fail.
+/// How much the live slot count may grow when the session grows fourfold.
 ///
-/// Scaled by the shard count because that is what sets how many interns are
-/// needed before a shard accumulates a reclaimable slot (see the module docs'
-/// table).  Generous — roughly 40 interns per shard for the sparsest
-/// ingredient — so reaching it means the collector genuinely is not running,
-/// not that the machine is merely wide.
-fn edit_cap() -> u32 {
-    (interned_shards() * 40).max(EDITS)
-}
+/// A healthy working set is bounded by the *program*, not by how long the user
+/// has been typing, so it barely moves; a leak grows with the edit count.
+/// Measured on this corpus, slots after 24 -> 96 edits:
+///
+/// | ingredient | healthy (`LOW`) | leaking (`HIGH`) |
+/// |---|---|---|
+/// | `ItemBodyKey`     | 54 -> 64 (1.19x) | 116 -> 404 (3.48x) |
+/// | `FnLatticeKey`    | 50 -> 63 (1.26x) | 116 -> 404 (3.48x) |
+/// | `TaintSummaryKey` | 23 -> 23 (1.00x) |  24 ->  24 (1.00x) |
+/// | `SummaryDepsKey`  | 31 -> 31 (1.00x) |  32 ->  32 (1.00x) |
+///
+/// `2` sits with a wide margin either side. The two summary ingredients are
+/// bounded under *both* conditions — their keys are the interprocedural
+/// projections, whose set the corpus fixes — so they carry the invariant
+/// trivially and the four body-keyed ones are what discriminates.
+/// `raising_input_durability_disables_the_collector` asserts exactly that.
+const SLOT_GROWTH_BOUND: usize = 2;
 
 /// The corpus at revision `edit` — a small Tcl module shaped so every one of the
 /// six ingredients is actually re-keyed as the session runs:
@@ -224,7 +230,7 @@ struct Session {
     slots: BTreeMap<String, usize>,
     reuses: BTreeMap<String, usize>,
     /// Revisions actually driven — variable, since
-    /// [`drive_until_collected`] stops as soon as the invariant is shown.
+    /// Recorded so a failure report says how long the session was.
     edits: u32,
 }
 
@@ -256,13 +262,7 @@ impl Session {
     /// [`Self::summary`] with the session length, which a failure needs in
     /// order to be actionable now that the length is not a constant.
     fn report(&self) -> String {
-        format!(
-            "{} (over {} edits, cap {}, {} interned shards)",
-            self.summary(),
-            self.edits,
-            edit_cap(),
-            interned_shards(),
-        )
+        format!("{} (over {} edits)", self.summary(), self.edits)
     }
 }
 
@@ -292,29 +292,10 @@ fn make_inputs(db: &TclDatabase, durability: InputDurability) -> (SourceFile, An
     }
 }
 
-/// Drive revisions of [`corpus`] until every tracked ingredient has shown the
-/// collector at work, or [`edit_cap`] revisions have run.
-///
-/// Always drives at least [`EDITS`], so a session that stops early has still
-/// cleared salsa's staleness window several times over.  Returns whatever it
-/// measured; the caller asserts, so the failure message carries the real
-/// numbers and the edit count that produced them.
-fn drive_until_collected() -> Session {
-    drive_edit_session(InputDurability::Default, edit_cap(), true)
-}
-
 /// Drive exactly `max_edits` revisions of [`corpus`] through the two production
 /// diagnostic queries, recording interned slot reuse as it goes.
 ///
-/// With `stop_when_collected`, returns as soon as every ingredient in
-/// [`PER_REVISION_INTERNED`] has been reused at least once **and** at least
-/// [`EDITS`] revisions have run.  The control session passes `false`: it
-/// expects no reuse at all, so stopping on one would be nonsense.
-fn drive_edit_session(
-    durability: InputDurability,
-    max_edits: u32,
-    stop_when_collected: bool,
-) -> Session {
+fn drive_edit_session(durability: InputDurability, max_edits: u32) -> Session {
     let reuse_log: Arc<Mutex<Vec<String>>> = Arc::default();
     let sink = Arc::clone(&reuse_log);
     let mut db = TclDatabase::with_interned_reuse_logger(move |key| {
@@ -340,9 +321,6 @@ fn drive_edit_session(
         let _ = file_analysis_incremental(&db, file, config);
         let _ = compiler_check_diagnostics(&db, file, config);
         edits_driven = edit;
-        if stop_when_collected && edit >= EDITS && all_collected(&reuse_log) {
-            break;
-        }
     }
 
     let slots = <dyn salsa::Database>::memory_usage(&db)
@@ -364,59 +342,67 @@ fn drive_edit_session(
     }
 }
 
-/// Whether every tracked ingredient has appeared in the reuse log at least
-/// once — the stopping condition for [`drive_until_collected`].
-fn all_collected(reuse_log: &Arc<Mutex<Vec<String>>>) -> bool {
-    let log = reuse_log.lock().expect("reuse log");
-    PER_REVISION_INTERNED.iter().all(|name| {
-        log.iter()
-            .any(|key| key.split('(').next().unwrap_or(key) == *name)
-    })
-}
-
 #[test]
-fn interned_slots_are_reclaimed_across_an_edit_session() {
-    let session = drive_until_collected();
+fn interned_slots_stay_bounded_across_an_edit_session() {
+    let short = drive_edit_session(InputDurability::Default, SHORT_SESSION);
+    let long = drive_edit_session(InputDurability::Default, LONG_SESSION);
 
     for name in PER_REVISION_INTERNED {
         assert!(
-            session.slots(name) > 0,
+            short.slots(name) > 0,
             "`{name}` was never interned during the session, so this test proves nothing about \
              it — either the ingredient was renamed, or the corpus no longer reaches its query \
-             path (see the `corpus` doc comment). Measured: {}",
-            session.report()
+             path (see the `corpus` doc comment). Measured: short {}",
+            short.report()
         );
+        let bound = short.slots(name) * SLOT_GROWTH_BOUND;
         assert!(
-            session.reuses(name) > 0,
-            "salsa's interned garbage collector never reclaimed a `{name}` slot, even after \
-             driving revisions up to the shard-scaled cap, so every keystroke's key is retained \
-             for the session — a KB-per-keystroke leak of the issue #1035 class. The two ways to \
-             cause this are documented in the crate docs' \"The interned garbage collector is \
-             load-bearing\" section: an input raised above `Durability::LOW` (see \
+            long.slots(name) <= bound,
+            "`{name}` retained {} slots after {LONG_SESSION} edits against {} after \
+             {SHORT_SESSION} — {}x the session holding more than {SLOT_GROWTH_BOUND}x the \
+             slots, so the working set is tracking how long the user has been typing rather \
+             than the program. That is the issue #1035 leak shape. The two causes are \
+             documented in the crate docs' \"The interned garbage collector is load-bearing\" \
+             section: an input raised above `Durability::LOW` (see \
              `raising_input_durability_disables_the_collector`, which reproduces exactly this \
-             reading), or a slot interned outside a tracked query. If the collector *is* running \
-             and this machine simply needs longer, `edit_cap` is the bound to revisit — but \
-             check the two causes first. Measured: {}",
-            session.report()
+             reading), or a slot interned outside a tracked query. Measured: short {} | long {}",
+            long.slots(name),
+            short.slots(name),
+            LONG_SESSION / SHORT_SESSION,
+            short.report(),
+            long.report(),
         );
     }
 }
 
 #[test]
 fn raising_input_durability_disables_the_collector() {
-    // Fixed length, and no early stop: this session must observe *no* reuse,
-    // so there is nothing to stop on.
-    let session = drive_edit_session(InputDurability::RaisedToHigh, EDITS, false);
+    let session = drive_edit_session(InputDurability::RaisedToHigh, SHORT_SESSION);
+    let long = drive_edit_session(InputDurability::RaisedToHigh, LONG_SESSION);
 
     for name in BODY_KEYED_INTERNED {
         let slots = session.slots(name);
         assert!(
-            slots >= EDITS as usize,
-            "the control session retained only {slots} `{name}` slots across {EDITS} edits, so \
-             the corpus is no longer re-keying it once per edit and \
-             `interned_slots_are_reclaimed_across_an_edit_session` is measuring nothing. Fix the \
+            slots >= SHORT_SESSION as usize,
+            "the control session retained only {slots} `{name}` slots across {SHORT_SESSION} \
+             edits, so the corpus is no longer re-keying it once per edit and \
+             `interned_slots_stay_bounded_across_an_edit_session` is measuring nothing. Fix the \
              corpus (see its doc comment), not this bound. Measured: {}",
             session.report()
+        );
+        // …and the leak really does trip the bound the primary test applies,
+        // so that assertion cannot pass vacuously.
+        assert!(
+            long.slots(name) > slots * SLOT_GROWTH_BOUND,
+            "with the collector disabled, `{name}` grew only {} -> {} across \
+             {SHORT_SESSION} -> {LONG_SESSION} edits, which does not exceed the \
+             {SLOT_GROWTH_BOUND}x bound `interned_slots_stay_bounded_across_an_edit_session` \
+             applies — so that test would pass even with the leak restored and is no longer a \
+             guard. Measured: short {} | long {}",
+            slots,
+            long.slots(name),
+            session.report(),
+            long.report(),
         );
     }
 

--- a/rust/tcl-lsp-db/tests/interned_gc.rs
+++ b/rust/tcl-lsp-db/tests/interned_gc.rs
@@ -1,0 +1,442 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Guardrail for the **interned garbage collector** invariant (issue #1299).
+//!
+//! Six interned structs in this crate key on content that changes as a
+//! procedure body is edited — `ItemBodyKey`, `FnLatticeKey`, `ProcBodyKey`,
+//! `OptDepsKey`, `TaintSummaryKey`, and `SummaryDepsKey`. A typing session
+//! therefore mints brand-new interned ids for them continuously, each holding
+//! a body's worth of `Arc` payload in its memo table — the exact shape of an
+//! unbounded interning leak.
+//!
+//! It is bounded only because salsa 0.27 **garbage-collects interned slots**: a
+//! cold intern walks the shard's LRU tail and reuses any slot untouched for
+//! `DEFAULT_REVISIONS` (3) revisions, replacing the fields and clearing the
+//! slot's memo table — which is what releases the retained payload. A slot is
+//! eligible only when its durability is exactly `Durability::LOW`, and a slot
+//! interned with no active tracked query is stamped `Durability::MAX` and is
+//! never eligible at all. See the "The interned garbage collector is
+//! load-bearing" section of the crate documentation and
+//! `docs/design/rust/salsa-interned-gc.md`.
+//!
+//! # What is measured, and why it is not a proxy
+//!
+//! Salsa fires `EventKind::DidReuseInternedValue` exactly when it recycles a
+//! stale slot, so counting those events per ingredient reads the collector
+//! directly. `TclDatabase::with_interned_reuse_logger` exposes them.
+//!
+//! Live slot *counts* would be the more obvious measure, but their steady
+//! state depends on salsa's shard count, which is
+//! `(available_parallelism() * 4).next_power_of_two()` — so any absolute budget
+//! would be tuned to the machine it was written on and would fail on a bigger
+//! one. Reuse counts have no such dependence: the collector either runs for an
+//! ingredient or it does not.
+//!
+//! # The two behavioural tests
+//!
+//! [`interned_slots_are_reclaimed_across_an_edit_session`] drives a typing
+//! session through the production queries and asserts every one of the six
+//! ingredients is being reclaimed.
+//!
+//! [`raising_input_durability_disables_the_collector`] drives the *same*
+//! session with `SourceFile` and `AnalyserConfig` marked `Durability::HIGH` and
+//! asserts the collector goes completely silent while slot counts grow with the
+//! edit count. It is the break-the-invariant experiment, kept in the suite
+//! rather than performed once and discarded: it is what proves the first test
+//! is not vacuous, and it pins the durability sensitivity that makes the rule
+//! necessary. If it ever fails because reuse *did* happen at `HIGH`, salsa's
+//! collection policy changed and the design doc needs revisiting — a deliberate
+//! alarm, not a flake.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::sync::{Arc, Mutex};
+
+use salsa::Setter as _;
+
+use tcl_compiler::analyser::NonAsciiMode;
+use tcl_lsp_db::{
+    AnalyserConfig, SourceFile, TclDatabase, compiler_check_diagnostics, file_analysis_incremental,
+};
+
+/// The interned structs whose key contains per-revision content — the ones the
+/// garbage collector has to reclaim for the edit path to stay bounded.
+///
+/// Names are salsa's `IngredientInfo::debug_name`, i.e. the struct name; a
+/// rename that is not mirrored here fails both tests rather than silently
+/// dropping coverage.
+const PER_REVISION_INTERNED: [&str; 6] = [
+    "ItemBodyKey",
+    "FnLatticeKey",
+    "ProcBodyKey",
+    "OptDepsKey",
+    "TaintSummaryKey",
+    "SummaryDepsKey",
+];
+
+/// The four of [`PER_REVISION_INTERNED`] keyed on body *text* or body IR, so
+/// the corpus below re-keys all of them on every single edit. The other two are
+/// keyed on the interprocedural *projections*, which move less often by design
+/// (that firewall is the point of them), so they accumulate more slowly and
+/// carry no per-edit lower bound.
+const BODY_KEYED_INTERNED: [&str; 4] = ["ItemBodyKey", "FnLatticeKey", "ProcBodyKey", "OptDepsKey"];
+
+/// Worker procedures in the corpus. Each edit rewrites every worker body, so
+/// one edit produces `WORKERS` cold interns of each body-keyed ingredient.
+const WORKERS: u32 = 4;
+
+/// Edits driven through the database. Well above salsa's `DEFAULT_REVISIONS`
+/// staleness window (3), and `WORKERS * EDITS` cold interns is enough for the
+/// collector to reach steady state while keeping the run around three seconds
+/// in a debug build.
+const EDITS: u32 = 24;
+
+/// The corpus at revision `edit` — a small Tcl module shaped so every one of the
+/// six ingredients is actually re-keyed as the session runs:
+///
+/// * each **worker** body embeds `edit`, so its text, IR, and optimiser
+///   dependencies are new every revision (`ItemBodyKey`, `ProcBodyKey`,
+///   `FnLatticeKey`, `OptDepsKey`);
+/// * each worker's `return` alternates between a parameter and a local, which
+///   flips its `return_passthrough_param`, and each **caller** calls a rotating
+///   worker, which moves its `calls` set — between them that shifts the
+///   interprocedural projections the summary keys are built from
+///   (`TaintSummaryKey`, `SummaryDepsKey`);
+/// * every procedure calls `puts`, so none is `pure`: a pure-but-not-constant-
+///   return procedure sends `solve_optimisations` down its whole-module
+///   fallback and `OptDepsKey` would never be interned at all;
+/// * no `TclOO` methods and a plain `tcl8.6` dialect, the remaining
+///   whole-module fallback conditions.
+///
+/// [`raising_input_durability_disables_the_collector`] keeps this shaping
+/// honest: it asserts the uncollected slot count really does track the edit
+/// count, which only holds while the corpus re-keys as described.
+fn corpus(edit: u32) -> String {
+    let mut src = String::from("namespace eval ::bench {\n    variable counter 0\n}\n\n");
+    for worker in 0..WORKERS {
+        let returned = if (worker + edit).is_multiple_of(2) {
+            "$a"
+        } else {
+            "$total"
+        };
+        write!(
+            src,
+            "proc ::bench::w{worker} {{a b}} {{\n\
+             \x20   set probe_v {edit:08}\n\
+             \x20   set total [expr {{$a * {worker} + $b}}]\n\
+             \x20   if {{$total > 10}} {{\n\
+             \x20       set total 10\n\
+             \x20   }}\n\
+             \x20   puts \"w{worker} $total $probe_v\"\n\
+             \x20   return {returned}\n\
+             }}\n\n"
+        )
+        .expect("write to String");
+    }
+    for caller in 0..WORKERS {
+        let callee = (caller + edit) % WORKERS;
+        write!(
+            src,
+            "proc ::bench::c{caller} {{a}} {{\n\
+             \x20   set r [::bench::w{callee} $a {caller}]\n\
+             \x20   puts \"c{caller} $r\"\n\
+             \x20   return $r\n\
+             }}\n\n"
+        )
+        .expect("write to String");
+    }
+    src
+}
+
+/// Whether the session marks its salsa inputs more durable than the default.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum InputDurability {
+    /// Salsa's default, `Durability::LOW` — what production does, and the only
+    /// setting under which interned slots are collectable.
+    Default,
+    /// `Durability::HIGH` on every field of both inputs — the hazard, driven
+    /// deliberately so the guardrail can be shown to detect it.
+    RaisedToHigh,
+}
+
+/// What one edit session produced: live interned slots per ingredient, and how
+/// many times the collector recycled a slot of each ingredient.
+struct Session {
+    slots: BTreeMap<String, usize>,
+    reuses: BTreeMap<String, usize>,
+}
+
+impl Session {
+    fn slots(&self, ingredient: &str) -> usize {
+        self.slots.get(ingredient).copied().unwrap_or(0)
+    }
+
+    fn reuses(&self, ingredient: &str) -> usize {
+        self.reuses.get(ingredient).copied().unwrap_or(0)
+    }
+
+    /// The measured numbers for the six tracked ingredients, for failure
+    /// messages.
+    fn summary(&self) -> String {
+        PER_REVISION_INTERNED
+            .iter()
+            .map(|name| {
+                format!(
+                    "{name}: {} slots, {} reuses",
+                    self.slots(name),
+                    self.reuses(name)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("; ")
+    }
+}
+
+/// Build the session's two salsa inputs at the requested durability.
+fn make_inputs(db: &TclDatabase, durability: InputDurability) -> (SourceFile, AnalyserConfig) {
+    let dialect = "tcl8.6".to_owned();
+    match durability {
+        InputDurability::Default => (
+            SourceFile::new(db, corpus(0), dialect, None),
+            AnalyserConfig::new(
+                db,
+                Vec::new(),
+                NonAsciiMode::Default,
+                Vec::new(),
+                None,
+                None,
+            ),
+        ),
+        InputDurability::RaisedToHigh => (
+            SourceFile::builder(corpus(0), dialect, None, None, None)
+                .durability(salsa::Durability::HIGH)
+                .new(db),
+            AnalyserConfig::builder(Vec::new(), NonAsciiMode::Default, Vec::new(), None, None)
+                .durability(salsa::Durability::HIGH)
+                .new(db),
+        ),
+    }
+}
+
+/// Drive [`EDITS`] revisions of [`corpus`] through the two production
+/// diagnostic queries, recording interned slot reuse as it goes.
+fn drive_edit_session(durability: InputDurability) -> Session {
+    let reuse_log: Arc<Mutex<Vec<String>>> = Arc::default();
+    let sink = Arc::clone(&reuse_log);
+    let mut db = TclDatabase::with_interned_reuse_logger(move |key| {
+        sink.lock().expect("reuse log").push(key);
+    });
+
+    let (file, config) = make_inputs(&db, durability);
+
+    // Cold build first: the collector cannot reclaim anything until slots have
+    // had time to go stale, so the measurement starts from a populated graph.
+    let _ = file_analysis_incremental(&db, file, config);
+    let _ = compiler_check_diagnostics(&db, file, config);
+
+    for edit in 1..=EDITS {
+        let setter = file.set_text(&mut db);
+        match durability {
+            InputDurability::Default => setter.to(corpus(edit)),
+            InputDurability::RaisedToHigh => setter
+                .with_durability(salsa::Durability::HIGH)
+                .to(corpus(edit)),
+        };
+        let _ = file_analysis_incremental(&db, file, config);
+        let _ = compiler_check_diagnostics(&db, file, config);
+    }
+
+    let slots = <dyn salsa::Database>::memory_usage(&db)
+        .structs
+        .iter()
+        .map(|info| (info.debug_name().to_owned(), info.count()))
+        .collect();
+    // The logged key is `"<IngredientName>(Id(..))"`; the name is all this
+    // needs.
+    let mut reuses: BTreeMap<String, usize> = BTreeMap::new();
+    for key in reuse_log.lock().expect("reuse log").iter() {
+        let name = key.split('(').next().unwrap_or(key);
+        *reuses.entry(name.to_owned()).or_default() += 1;
+    }
+    Session { slots, reuses }
+}
+
+#[test]
+fn interned_slots_are_reclaimed_across_an_edit_session() {
+    let session = drive_edit_session(InputDurability::Default);
+
+    for name in PER_REVISION_INTERNED {
+        assert!(
+            session.slots(name) > 0,
+            "`{name}` was never interned during the session, so this test proves nothing about \
+             it — either the ingredient was renamed, or the corpus no longer reaches its query \
+             path (see the `corpus` doc comment). Measured: {}",
+            session.summary()
+        );
+        assert!(
+            session.reuses(name) > 0,
+            "salsa's interned garbage collector never reclaimed a `{name}` slot across {EDITS} \
+             edits, so every keystroke's key is retained for the session — a KB-per-keystroke \
+             leak of the issue #1035 class. The two ways to cause this are documented in the \
+             crate docs' \"The interned garbage collector is load-bearing\" section: an input \
+             raised above `Durability::LOW` (see \
+             `raising_input_durability_disables_the_collector`, which reproduces exactly this \
+             reading), or a slot interned outside a tracked query. Measured: {}",
+            session.summary()
+        );
+    }
+}
+
+#[test]
+fn raising_input_durability_disables_the_collector() {
+    let session = drive_edit_session(InputDurability::RaisedToHigh);
+
+    for name in BODY_KEYED_INTERNED {
+        let slots = session.slots(name);
+        assert!(
+            slots >= EDITS as usize,
+            "the control session retained only {slots} `{name}` slots across {EDITS} edits, so \
+             the corpus is no longer re-keying it once per edit and \
+             `interned_slots_are_reclaimed_across_an_edit_session` is measuring nothing. Fix the \
+             corpus (see its doc comment), not this bound. Measured: {}",
+            session.summary()
+        );
+    }
+
+    for name in PER_REVISION_INTERNED {
+        assert_eq!(
+            session.reuses(name),
+            0,
+            "salsa reclaimed `{name}` slots even though both inputs were set to \
+             `Durability::HIGH`. Interned slot reuse is supposed to be restricted to \
+             `Durability::LOW`, so this means salsa's collection policy changed: the reasoning in \
+             docs/design/rust/salsa-interned-gc.md and the crate docs' \"The interned garbage \
+             collector is load-bearing\" section no longer describes the library, and the \
+             durability rule may no longer be load-bearing. Measured: {}",
+            session.summary()
+        );
+    }
+}
+
+/// Crate roots that can name this crate's salsa inputs, and so are the only
+/// places a durability bump on them could be written.
+///
+/// `tcl-lsp-server` is the sole dependant of `tcl-lsp-db` in the workspace
+/// (`grep -l tcl-lsp-db rust/*/Cargo.toml`); if that stops being true, the new
+/// dependant belongs in this list. Paths are relative to this crate's manifest
+/// directory.
+const DURABILITY_SCAN_ROOTS: [&str; 2] = [".", "../tcl-lsp-server"];
+
+/// The ways salsa lets a caller move an input off `Durability::LOW`:
+/// `Setter::with_durability`, the builder's whole-struct `durability`, and the
+/// builder's generated per-field `<field>_durability`.
+fn durability_call(code: &str) -> bool {
+    code.contains(".durability(") || code.contains("_durability(")
+}
+
+/// Every `.rs` file under `dir`, skipping build output.
+fn rust_sources(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+    let entries = std::fs::read_dir(dir).unwrap_or_else(|err| {
+        panic!(
+            "cannot read {} while scanning for durability call sites: {err}",
+            dir.display()
+        )
+    });
+    for entry in entries {
+        let path = entry.expect("directory entry").path();
+        if path.is_dir() {
+            if path.file_name().is_some_and(|name| name == "target") {
+                continue;
+            }
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// The half of the invariant the behavioural tests cannot reach: durability is
+/// chosen at the *setter call site*, so a `Durability::HIGH` written by the
+/// server would never appear in a database this crate's own tests build.
+///
+/// The workspace currently contains **zero** such call sites, so the gate is a
+/// "still zero?" over the two crates that can name `SourceFile`,
+/// `AnalyserConfig`, and `Project`. A future input that genuinely wants a
+/// durability bump — one no interned key is created under — has to update this
+/// test deliberately, with the reasoning written down, rather than slip through
+/// review as a free optimisation.
+#[test]
+fn no_input_durability_is_raised() {
+    let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    // This file sets durability on purpose, in the control session above.
+    let this_file = manifest.join("tests").join("interned_gc.rs");
+
+    let mut files = Vec::new();
+    for root in DURABILITY_SCAN_ROOTS {
+        let path = manifest.join(root);
+        assert!(
+            path.is_dir(),
+            "durability scan root {} no longer exists — the crate layout moved and this \
+             guardrail is scanning nothing",
+            path.display()
+        );
+        rust_sources(&path, &mut files);
+    }
+    assert!(
+        files.len() > 1,
+        "the durability scan found only {} Rust source(s), which cannot be right",
+        files.len()
+    );
+
+    let mut offenders: Vec<String> = Vec::new();
+    for file in files {
+        if file == this_file {
+            continue;
+        }
+        let text = std::fs::read_to_string(&file)
+            .unwrap_or_else(|err| panic!("read {}: {err}", file.display()));
+        for (number, line) in text.lines().enumerate() {
+            // Comments and doc comments discuss this rule at length; only real
+            // code counts.
+            let code = line.split("//").next().unwrap_or("");
+            if durability_call(code) {
+                offenders.push(format!(
+                    "{}:{}: {}",
+                    file.display(),
+                    number + 1,
+                    line.trim()
+                ));
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "salsa input durability is set at {} call site(s):\n  {}\n\nEvery per-body interned key \
+         in tcl-lsp-db is minted by a query that has read `SourceFile` / `AnalyserConfig` / \
+         `Project`, and inherits the minimum durability of those reads. Salsa's interned garbage \
+         collector only ever reclaims `Durability::LOW` slots, so raising any of these turns the \
+         edit path back into a KB-per-keystroke leak of the issue #1035 class — while reading in \
+         review like a revalidation win. See the \"The interned garbage collector is \
+         load-bearing\" section of tcl-lsp-db's crate documentation and \
+         docs/design/rust/salsa-interned-gc.md.",
+        offenders.len(),
+        offenders.join("\n  ")
+    );
+}

--- a/rust/tcl-lsp-db/tests/interned_gc.rs
+++ b/rust/tcl-lsp-db/tests/interned_gc.rs
@@ -45,8 +45,27 @@
 //! state depends on salsa's shard count, which is
 //! `(available_parallelism() * 4).next_power_of_two()` — so any absolute budget
 //! would be tuned to the machine it was written on and would fail on a bigger
-//! one. Reuse counts have no such dependence: the collector either runs for an
-//! ingredient or it does not.
+//! one.
+//!
+//! Reuse counts remove the dependence from the *assertion*, but not from the
+//! number of revisions needed to observe one, and assuming a fixed edit count
+//! sufficed was a real flake: a slot is only reclaimable once its **own**
+//! shard's LRU tail holds a stale entry, so the sparser ingredients need more
+//! interns before any shard accumulates enough. Measured on one machine by
+//! varying the visible CPU count, all else equal:
+//!
+//! | cores | shards | `TaintSummaryKey` reuses | `SummaryDepsKey` reuses |
+//! |------:|-------:|-------------------------:|------------------------:|
+//! |     1 |      4 |                       32 |                     119 |
+//! |     2 |      8 |                       28 |                      39 |
+//! |     4 |     16 |                       22 |                      34 |
+//! |    CI |    32+ |                    **0** |                   **1** |
+//!
+//! So the session drives revisions **until the collector is observed for every
+//! ingredient**, bounded by [`edit_cap`], instead of a fixed count: it stops as
+//! soon as the invariant is demonstrated (24 edits on a small machine) and
+//! keeps going where sharding makes that take longer. The bound is what turns
+//! "we did not look long enough" into a real failure.
 //!
 //! # The two behavioural tests
 //!
@@ -101,11 +120,35 @@ const BODY_KEYED_INTERNED: [&str; 4] = ["ItemBodyKey", "FnLatticeKey", "ProcBody
 /// one edit produces `WORKERS` cold interns of each body-keyed ingredient.
 const WORKERS: u32 = 4;
 
-/// Edits driven through the database. Well above salsa's `DEFAULT_REVISIONS`
-/// staleness window (3), and `WORKERS * EDITS` cold interns is enough for the
-/// collector to reach steady state while keeping the run around three seconds
-/// in a debug build.
+/// Edits every session drives before it may stop. Well above salsa's
+/// `DEFAULT_REVISIONS` staleness window (3), and `WORKERS * EDITS` cold interns
+/// is enough for the collector to reach steady state on a small machine while
+/// keeping the run around three seconds in a debug build.
+///
+/// A floor, not a budget: [`drive_until_collected`] keeps going past it while
+/// any ingredient has yet to show a reuse. The control session, which must
+/// observe *no* reuse, always runs exactly this many.
 const EDITS: u32 = 24;
+
+/// Salsa's interned-table shard count — `(available_parallelism() * 4)`
+/// rounded up to a power of two (`salsa::table::memo` sharding).  Read here
+/// only to scale [`edit_cap`]; nothing asserts on it.
+fn interned_shards() -> u32 {
+    let cpus = std::thread::available_parallelism().map_or(1, std::num::NonZero::get);
+    u32::try_from(cpus.saturating_mul(4).next_power_of_two()).unwrap_or(u32::MAX)
+}
+
+/// The most edits [`drive_until_collected`] will drive before giving up and
+/// letting the assertion fail.
+///
+/// Scaled by the shard count because that is what sets how many interns are
+/// needed before a shard accumulates a reclaimable slot (see the module docs'
+/// table).  Generous — roughly 40 interns per shard for the sparsest
+/// ingredient — so reaching it means the collector genuinely is not running,
+/// not that the machine is merely wide.
+fn edit_cap() -> u32 {
+    (interned_shards() * 40).max(EDITS)
+}
 
 /// The corpus at revision `edit` — a small Tcl module shaped so every one of the
 /// six ingredients is actually re-keyed as the session runs:
@@ -180,6 +223,9 @@ enum InputDurability {
 struct Session {
     slots: BTreeMap<String, usize>,
     reuses: BTreeMap<String, usize>,
+    /// Revisions actually driven — variable, since
+    /// [`drive_until_collected`] stops as soon as the invariant is shown.
+    edits: u32,
 }
 
 impl Session {
@@ -205,6 +251,18 @@ impl Session {
             })
             .collect::<Vec<_>>()
             .join("; ")
+    }
+
+    /// [`Self::summary`] with the session length, which a failure needs in
+    /// order to be actionable now that the length is not a constant.
+    fn report(&self) -> String {
+        format!(
+            "{} (over {} edits, cap {}, {} interned shards)",
+            self.summary(),
+            self.edits,
+            edit_cap(),
+            interned_shards(),
+        )
     }
 }
 
@@ -234,9 +292,29 @@ fn make_inputs(db: &TclDatabase, durability: InputDurability) -> (SourceFile, An
     }
 }
 
-/// Drive [`EDITS`] revisions of [`corpus`] through the two production
+/// Drive revisions of [`corpus`] until every tracked ingredient has shown the
+/// collector at work, or [`edit_cap`] revisions have run.
+///
+/// Always drives at least [`EDITS`], so a session that stops early has still
+/// cleared salsa's staleness window several times over.  Returns whatever it
+/// measured; the caller asserts, so the failure message carries the real
+/// numbers and the edit count that produced them.
+fn drive_until_collected() -> Session {
+    drive_edit_session(InputDurability::Default, edit_cap(), true)
+}
+
+/// Drive exactly `max_edits` revisions of [`corpus`] through the two production
 /// diagnostic queries, recording interned slot reuse as it goes.
-fn drive_edit_session(durability: InputDurability) -> Session {
+///
+/// With `stop_when_collected`, returns as soon as every ingredient in
+/// [`PER_REVISION_INTERNED`] has been reused at least once **and** at least
+/// [`EDITS`] revisions have run.  The control session passes `false`: it
+/// expects no reuse at all, so stopping on one would be nonsense.
+fn drive_edit_session(
+    durability: InputDurability,
+    max_edits: u32,
+    stop_when_collected: bool,
+) -> Session {
     let reuse_log: Arc<Mutex<Vec<String>>> = Arc::default();
     let sink = Arc::clone(&reuse_log);
     let mut db = TclDatabase::with_interned_reuse_logger(move |key| {
@@ -250,7 +328,8 @@ fn drive_edit_session(durability: InputDurability) -> Session {
     let _ = file_analysis_incremental(&db, file, config);
     let _ = compiler_check_diagnostics(&db, file, config);
 
-    for edit in 1..=EDITS {
+    let mut edits_driven = 0_u32;
+    for edit in 1..=max_edits {
         let setter = file.set_text(&mut db);
         match durability {
             InputDurability::Default => setter.to(corpus(edit)),
@@ -260,6 +339,10 @@ fn drive_edit_session(durability: InputDurability) -> Session {
         };
         let _ = file_analysis_incremental(&db, file, config);
         let _ = compiler_check_diagnostics(&db, file, config);
+        edits_driven = edit;
+        if stop_when_collected && edit >= EDITS && all_collected(&reuse_log) {
+            break;
+        }
     }
 
     let slots = <dyn salsa::Database>::memory_usage(&db)
@@ -274,12 +357,26 @@ fn drive_edit_session(durability: InputDurability) -> Session {
         let name = key.split('(').next().unwrap_or(key);
         *reuses.entry(name.to_owned()).or_default() += 1;
     }
-    Session { slots, reuses }
+    Session {
+        slots,
+        reuses,
+        edits: edits_driven,
+    }
+}
+
+/// Whether every tracked ingredient has appeared in the reuse log at least
+/// once — the stopping condition for [`drive_until_collected`].
+fn all_collected(reuse_log: &Arc<Mutex<Vec<String>>>) -> bool {
+    let log = reuse_log.lock().expect("reuse log");
+    PER_REVISION_INTERNED.iter().all(|name| {
+        log.iter()
+            .any(|key| key.split('(').next().unwrap_or(key) == *name)
+    })
 }
 
 #[test]
 fn interned_slots_are_reclaimed_across_an_edit_session() {
-    let session = drive_edit_session(InputDurability::Default);
+    let session = drive_until_collected();
 
     for name in PER_REVISION_INTERNED {
         assert!(
@@ -287,25 +384,29 @@ fn interned_slots_are_reclaimed_across_an_edit_session() {
             "`{name}` was never interned during the session, so this test proves nothing about \
              it — either the ingredient was renamed, or the corpus no longer reaches its query \
              path (see the `corpus` doc comment). Measured: {}",
-            session.summary()
+            session.report()
         );
         assert!(
             session.reuses(name) > 0,
-            "salsa's interned garbage collector never reclaimed a `{name}` slot across {EDITS} \
-             edits, so every keystroke's key is retained for the session — a KB-per-keystroke \
-             leak of the issue #1035 class. The two ways to cause this are documented in the \
-             crate docs' \"The interned garbage collector is load-bearing\" section: an input \
-             raised above `Durability::LOW` (see \
+            "salsa's interned garbage collector never reclaimed a `{name}` slot, even after \
+             driving revisions up to the shard-scaled cap, so every keystroke's key is retained \
+             for the session — a KB-per-keystroke leak of the issue #1035 class. The two ways to \
+             cause this are documented in the crate docs' \"The interned garbage collector is \
+             load-bearing\" section: an input raised above `Durability::LOW` (see \
              `raising_input_durability_disables_the_collector`, which reproduces exactly this \
-             reading), or a slot interned outside a tracked query. Measured: {}",
-            session.summary()
+             reading), or a slot interned outside a tracked query. If the collector *is* running \
+             and this machine simply needs longer, `edit_cap` is the bound to revisit — but \
+             check the two causes first. Measured: {}",
+            session.report()
         );
     }
 }
 
 #[test]
 fn raising_input_durability_disables_the_collector() {
-    let session = drive_edit_session(InputDurability::RaisedToHigh);
+    // Fixed length, and no early stop: this session must observe *no* reuse,
+    // so there is nothing to stop on.
+    let session = drive_edit_session(InputDurability::RaisedToHigh, EDITS, false);
 
     for name in BODY_KEYED_INTERNED {
         let slots = session.slots(name);
@@ -315,7 +416,7 @@ fn raising_input_durability_disables_the_collector() {
              the corpus is no longer re-keying it once per edit and \
              `interned_slots_are_reclaimed_across_an_edit_session` is measuring nothing. Fix the \
              corpus (see its doc comment), not this bound. Measured: {}",
-            session.summary()
+            session.report()
         );
     }
 
@@ -329,7 +430,7 @@ fn raising_input_durability_disables_the_collector() {
              docs/design/rust/salsa-interned-gc.md and the crate docs' \"The interned garbage \
              collector is load-bearing\" section no longer describes the library, and the \
              durability rule may no longer be load-bearing. Measured: {}",
-            session.summary()
+            session.report()
         );
     }
 }

--- a/rust/tcl-lsp-db/tests/memory_growth.rs
+++ b/rust/tcl-lsp-db/tests/memory_growth.rs
@@ -52,7 +52,7 @@
 //!
 //! ## Shape of the assertion
 //!
-//! Runs a small, CI-fast number of synthetic edits (`EDITS`, each a
+//! Runs a small, CI-fast number of synthetic edits (see `edits`, each a
 //! distinct, constant-length inserted statement — never a repeat, so
 //! nothing can hide behind salsa's identical-input early cutoff) split into
 //! four equal quartiles. The first quartile is warm-up (lazily-populated
@@ -149,17 +149,58 @@ fn build_config(db: &TclDatabase) -> AnalyserConfig {
     )
 }
 
-/// Total edits driven through the database. Kept small enough to stay
-/// CI-fast (well under a second in a debug build) while still giving four
-/// distinct quartiles wide enough to average out per-edit noise.
-const EDITS: u32 = 80;
-const QUARTILE: u32 = EDITS / 4;
+/// Baseline edits driven through the database, on the narrowest machine.
+/// Small enough to stay CI-fast while still giving four distinct quartiles
+/// wide enough to average out per-edit noise.
+const BASE_EDITS: u32 = 80;
 
-/// Resident-set budget for the late half of the session, in KiB.
-/// Deliberately loose (measured late-window growth over 10 runs was
-/// 0-32 KiB) because RSS is coarse and platform-dependent; it still
-/// catches any leak above roughly 200 KiB per edit.
-const LATE_RSS_BUDGET_KIB: u64 = 8 * 1024;
+/// Salsa's interned-table shard count — `(available_parallelism() * 4)`
+/// rounded up to a power of two.  The reference width this file's baseline
+/// was measured at is 16 shards (a 4-core machine).
+fn interned_shards() -> u32 {
+    let cpus = std::thread::available_parallelism().map_or(1, std::num::NonZero::get);
+    u32::try_from(cpus.saturating_mul(4).next_power_of_two()).unwrap_or(u32::MAX)
+}
+
+/// Total edits driven through the database, scaled by the interned-table
+/// shard count.
+///
+/// The plateau this test asserts is reached when salsa's interned collector
+/// starts recycling slots instead of allocating new ones, and a slot only
+/// becomes reclaimable once its **own** shard's LRU tail holds a stale entry.
+/// So a wider machine needs proportionally more revisions to reach the same
+/// steady state, and a fixed count is a machine-dependent test.  Measured, all
+/// else equal:
+///
+/// | shards | q1 | q2 | q3 | q4 | late window |
+/// |-------:|---:|---:|---:|---:|------------:|
+/// |     16 | 7680 | 3232 |  792 | 1016 |  1808 (plateaued) |
+/// |    32+ | 10632 | 8440 | 6024 | 4672 | 10696 (still falling) |
+///
+/// Both rows are the *same* healthy behaviour seen at different points on the
+/// curve; only the second had not yet arrived.  Scaling the session length
+/// keeps the assertion measuring the steady state rather than the warm-up.
+fn edits() -> u32 {
+    (interned_shards() * (BASE_EDITS / 16)).max(BASE_EDITS)
+}
+
+/// One quarter of [`edits`], the checkpoint interval.
+fn quartile() -> u32 {
+    edits() / 4
+}
+
+/// Resident-set budget for the late half of a *baseline-length* session, in
+/// KiB.  Deliberately loose (measured late-window growth over 10 runs was
+/// 0-32 KiB) because RSS is coarse and platform-dependent; it still catches
+/// any leak above roughly 200 KiB per edit.
+const BASE_LATE_RSS_BUDGET_KIB: u64 = 8 * 1024;
+
+/// [`BASE_LATE_RSS_BUDGET_KIB`] scaled by the session length, so a wider
+/// machine — which drives proportionally more edits, see [`edits`] — is held
+/// to the same *per-edit* bound rather than a stricter absolute one.
+fn late_rss_budget_kib() -> u64 {
+    BASE_LATE_RSS_BUDGET_KIB * u64::from(edits()) / u64::from(BASE_EDITS)
+}
 
 #[test]
 fn edit_session_memory_growth_plateaus() {
@@ -196,7 +237,9 @@ fn edit_session_memory_growth_plateaus() {
     let mut rss: Vec<Option<u64>> = vec![rss_kib()];
     let mut checkpoints: Vec<u64> = vec![total_salsa_retained_bytes(&db)];
 
-    for i in 1..=EDITS {
+    let edits = edits();
+    let quartile = quartile();
+    for i in 1..=edits {
         // A distinct, constant-length statement every edit — the buffer
         // never repeats (so nothing can hide behind salsa's early cutoff
         // on an unchanged value) but never grows in length either, so
@@ -208,7 +251,7 @@ fn edit_session_memory_growth_plateaus() {
         let _ = file_analysis_incremental(&db, file, config);
         let _ = compiler_check_diagnostics(&db, file, config);
 
-        if i % QUARTILE == 0 {
+        if i % quartile == 0 {
             checkpoints.push(total_salsa_retained_bytes(&db));
             rss.push(rss_kib());
         }
@@ -240,13 +283,13 @@ fn edit_session_memory_growth_plateaus() {
     // catching any leak above roughly 100 bytes per edit — three orders of
     // magnitude under #1035's own ~500 KiB per edit.
     let late_window = q3 + q4;
-    let late_edits = u64::from(QUARTILE) * 2;
+    let late_edits = u64::from(quartile) * 2;
     // A quarter of warm-up, with a small absolute floor so a healthy zero
     // steady state cannot make the assertion spuriously strict.
     let late_budget = (q1 / 4).max(4 * 1024);
     assert!(
         late_window <= late_budget,
-        "salsa-retained-bytes growth did not plateau across the {EDITS}-edit session \
+        "salsa-retained-bytes growth did not plateau across the {edits}-edit session \
          (issue #1035 regression class): quartile growth q1={q1} q2={q2} q3={q3} q4={q4} \
          bytes; the late window (q3+q4 = {late_window} bytes over {late_edits} edits, \
          {} bytes/edit) must be at most {late_budget} — a quarter of the q1 warm-up, \
@@ -262,10 +305,11 @@ fn edit_session_memory_growth_plateaus() {
     // 8 MiB still catches any leak above ~200 KiB per edit.
     if let (Some(mid), Some(end)) = (rss[3], rss[4]) {
         let late_rss = end.saturating_sub(mid);
+        let budget = late_rss_budget_kib();
         assert!(
-            late_rss <= LATE_RSS_BUDGET_KIB,
+            late_rss <= budget,
             "resident set kept growing through the late half of the session: \
-             {late_rss} KiB over {late_edits} edits, budget {LATE_RSS_BUDGET_KIB} KiB; \
+             {late_rss} KiB over {late_edits} edits, budget {budget} KiB; \
              per-quartile RSS (KiB) = {rss:?}"
         );
     }

--- a/rust/tcl-lsp-db/tests/memory_growth.rs
+++ b/rust/tcl-lsp-db/tests/memory_growth.rs
@@ -169,6 +169,12 @@ fn edit_session_memory_growth_plateaus() {
     // proc body via the analyser, not a brace scan" approach
     // `examples/edit_memory.rs` uses, so the edit lands inside a real body
     // and re-keys the same body-scoped interned structs an editor would.
+    //
+    // `body_span.start()` is the offset *of* the opening `{`, so the insert
+    // point is one past it. Inserting at `start()` itself lands between the
+    // parameter list and the brace, which leaves every proc body unedited
+    // (merely shifted) — and the body-keyed interned structs are
+    // offset-invariant, so such a session re-keys nothing and measures nothing.
     let edit_pos = Analyser::new()
         .analyse(SRC, dialect)
         .all_procs
@@ -176,7 +182,7 @@ fn edit_session_memory_growth_plateaus() {
         .map(|p| p.body_span)
         .filter(|s| s.end() > s.start())
         .max_by_key(|s| s.end() - s.start())
-        .map_or(SRC.len() / 2, |s| s.start() as usize);
+        .map_or(SRC.len() / 2, |s| s.start() as usize + 1);
 
     let mut db = TclDatabase::default();
     let file = SourceFile::new(&db, SRC.to_owned(), dialect.to_owned(), None);

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -3167,6 +3167,19 @@ pub struct Backend {
     /// map records what is applied so [`Backend::refresh_source_rehoming`]
     /// only re-analyses on change, and so declaration-side queries can map a
     /// standalone name to its re-homed twin.
+    ///
+    /// **Invariant: this map holds exactly the documents whose indexed analysis
+    /// is re-homed *away from* the standalone view.**  A document whose only
+    /// source site is the global namespace has a desired seed set of exactly
+    /// `["::"]`, which *is* the ordinary standalone analysis the index already
+    /// holds, so it is recorded as **absence** — never as an entry.  Every
+    /// producer and consumer has to agree on that single representation, via
+    /// [`Backend::is_standalone_view`]: while
+    /// [`Backend::refresh_source_rehoming_locked`]'s work queue and its store
+    /// disagreed about it, an ordinary top-level `source b.tcl` never converged
+    /// — `b.tcl` was re-analysed and re-indexed on every round of every call,
+    /// and each re-index bumps the workspace index's generation, dropping every
+    /// `Derived` memo built on it (issue #1297).
     rehomed_source_seeds: Arc<Mutex<HashMap<String, Vec<String>>>>,
     /// Serialises [`Backend::refresh_source_rehoming`] passes.
     ///
@@ -3375,6 +3388,82 @@ pub struct Backend {
     /// `did_change` / `did_close`) so their buffer mutations apply in the exact
     /// order the client sent them. See [`EditOrder`].
     edit_order: EditOrder,
+}
+
+/// Every per-document-URI cache [`Backend`] holds, borrowed as one group.
+///
+/// Built only by [`Backend::per_uri_caches`] — whose exhaustive destructuring of
+/// `Backend` classifies *every* field and so refuses to compile once a new one
+/// is added — and consumed only by [`PerUriCaches::forget`], which destructures
+/// this struct exhaustively in turn.  Between them, a per-URI cache cannot be
+/// wired into one retirement path and forgotten by another: that asymmetry is
+/// exactly how issue #1298 arose (`retire_renamed_uri` cleared seven per-URI
+/// maps but not `rehomed_source_seeds`, which every other retirement path did
+/// clear) and how issue #1300's three stale caches survived a folder removal.
+struct PerUriCaches<'a> {
+    /// [`Backend::autoloaded_library_uris`] — keyed by `uri.as_str()`.
+    autoloaded_library_uris: &'a Arc<Mutex<HashSet<String>>>,
+    /// [`Backend::rehomed_source_seeds`] — keyed by `uri.as_str()`.
+    rehomed_source_seeds: &'a Arc<Mutex<HashMap<String, Vec<String>>>>,
+    /// [`Backend::last_semantic_tokens`].
+    last_semantic_tokens: &'a SemanticTokensCache,
+    /// [`Backend::semantic_tokens_refresh_asked`].
+    semantic_tokens_refresh_asked: &'a EnrichedRefreshAsked,
+    /// [`Backend::workspace_class_analyses`].
+    workspace_class_analyses: &'a Arc<Mutex<HashMap<Uri, WorkspaceClassAnalysis>>>,
+}
+
+impl PerUriCaches<'_> {
+    /// Drop every entry these caches hold for `uris`.
+    ///
+    /// Exhaustively destructured for the same reason
+    /// `WorkspaceIndex`'s `DocumentRecords::clear` is: a cache added to the
+    /// group does not compile until it is cleared here too.
+    ///
+    /// Each map is locked on its own, never nested inside another, so this adds
+    /// no edge to the server's global lock order.
+    async fn forget(&self, uris: &[Uri]) {
+        if uris.is_empty() {
+            return;
+        }
+        let Self {
+            autoloaded_library_uris,
+            rehomed_source_seeds,
+            last_semantic_tokens,
+            semantic_tokens_refresh_asked,
+            workspace_class_analyses,
+        } = self;
+        {
+            let mut autoloaded = autoloaded_library_uris.lock().await;
+            for uri in uris {
+                autoloaded.remove(uri.as_str());
+            }
+        }
+        {
+            let mut seeds = rehomed_source_seeds.lock().await;
+            for uri in uris {
+                seeds.remove(uri.as_str());
+            }
+        }
+        {
+            let mut tokens = last_semantic_tokens.lock().await;
+            for uri in uris {
+                tokens.remove(uri);
+            }
+        }
+        {
+            let mut asked = semantic_tokens_refresh_asked.lock().await;
+            for uri in uris {
+                asked.remove(uri);
+            }
+        }
+        {
+            let mut analyses = workspace_class_analyses.lock().await;
+            for uri in uris {
+                analyses.remove(uri);
+            }
+        }
+    }
 }
 
 /// Applies document-sync notifications in arrival order.
@@ -5290,6 +5379,17 @@ impl Backend {
     /// one of `folders` and is not currently open in the editor.  Used when a
     /// workspace folder is removed (`did_change_workspace_folders`) so its
     /// files stop contributing definitions / references / symbols.
+    ///
+    /// Documents the editor still has open are deliberately excluded
+    /// throughout: their live buffer is the source of truth regardless of which
+    /// folders the workspace currently holds, so neither their index entry nor
+    /// any of their per-URI state is touched here.
+    ///
+    /// Every per-URI cache of the *closed* files goes through the shared
+    /// [`Self::forget_uri_states`] (#1300): this function used to clear the
+    /// rehoming seeds by hand and left `last_semantic_tokens`,
+    /// `semantic_tokens_refresh_asked` and `workspace_class_analyses` holding
+    /// entries for files that are no longer in any workspace folder.
     async fn drop_index_under_folders(&self, folders: &[Uri]) {
         if folders.is_empty() {
             return;
@@ -5328,12 +5428,10 @@ impl Backend {
             .collect();
         self.db_remove_sources_batch(&removed_urls).await;
         drop(docs);
-        {
-            let mut seeds = self.rehomed_source_seeds.lock().await;
-            for uri in &to_remove {
-                seeds.remove(uri);
-            }
-        }
+        // Batched so each cache is locked once for the whole folder, not once
+        // per file.  Still inside the rehoming gate, so a reconciliation pass
+        // cannot observe the index entries gone while their seed records stand.
+        self.forget_uri_states(&removed_urls).await;
         drop(rehoming_guard);
         // Clear the Problems / File-Explorer badge of any removed-folder file
         // that still carried one (#865) — it is no longer part of the workspace,
@@ -5651,6 +5749,137 @@ impl Backend {
             .retain(|queued| queued != uri);
     }
 
+    /// Borrow the per-URI caches as one group, classifying every other
+    /// `Backend` field on the way past.
+    ///
+    /// The `let Self { … } = self` below names **every** field, so adding one to
+    /// `Backend` is a compile error here until the author has decided whether it
+    /// is keyed by a document URI.  That is deliberately stronger than grouping
+    /// the caches into an owned nested struct (the `DocumentRecords::clear`
+    /// technique this borrows, in `tcl-lsp-core`'s `workspace_index`): a nested
+    /// struct only catches a field added *inside* the group, whereas a new
+    /// per-URI map is by definition added to `Backend` first — which is precisely
+    /// how issue #1298 happened.  Moving the five fields into an owned struct
+    /// would also have rewritten ~60 unrelated access sites for no extra safety.
+    ///
+    /// The classification, by field:
+    ///
+    /// - **Per-URI caches** (returned here, forgotten wholesale by
+    ///   [`Self::forget_uri_states`]): `autoloaded_library_uris`,
+    ///   `rehomed_source_seeds`, `last_semantic_tokens`,
+    ///   `semantic_tokens_refresh_asked`, `workspace_class_analyses`.
+    /// - **Per-URI, but owned by a dedicated path** — each needs more than a map
+    ///   removal, so retirement paths call that path explicitly: `documents`
+    ///   (the live buffer set; `did_open` / `did_close` own it, and a folder
+    ///   removal deliberately leaves open documents alone), `diag_slots`
+    ///   ([`Self::evict_diag_slot`] — a slot a worker is draining is that
+    ///   worker's liveness record and must survive), `db_files` /
+    ///   `db_tombstones` ([`Self::db_remove_source`] retires the salsa handle
+    ///   rather than dropping it, #1145), `pull_diag_cache` / `closed_diag_gen` /
+    ///   `closed_diag_order` ([`Self::clear_closed_diagnostics`], which must also
+    ///   publish the empty diagnostic set), `semantic_tokens_convergence` (a
+    ///   claim released by [`ConvergenceGuard`] on drop), and `workspace_index`
+    ///   (URI-keyed, but the cross-document index — removed under its own write
+    ///   lock, batched where the caller has several URIs).
+    /// - **Keyed by *folder* URI, not document URI** — untouched by a document
+    ///   retirement: `workspace_folders`, `folder_dialects`, `folder_configs`,
+    ///   `folder_db_configs`, `folder_db_config_tombstones`.
+    /// - **Not keyed by a URI at all** — session configuration, gates, salsa
+    ///   inputs, and workspace-wide caches: everything else.
+    fn per_uri_caches(&self) -> PerUriCaches<'_> {
+        let Self {
+            // The group.
+            autoloaded_library_uris,
+            rehomed_source_seeds,
+            last_semantic_tokens,
+            semantic_tokens_refresh_asked,
+            workspace_class_analyses,
+            // Per-URI, owned by a dedicated path (see the doc comment).
+            documents: _,
+            diag_slots: _,
+            workspace_index: _,
+            db_files: _,
+            db_tombstones: _,
+            pull_diag_cache: _,
+            closed_diag_gen: _,
+            closed_diag_order: _,
+            semantic_tokens_convergence: _,
+            // Keyed by folder URI.
+            workspace_folders: _,
+            folder_dialects: _,
+            folder_configs: _,
+            folder_db_configs: _,
+            folder_db_config_tombstones: _,
+            // Not keyed by a URI.
+            client: _,
+            default_dialect: _,
+            default_dialect_explicit: _,
+            session_dialect_override: _,
+            config_reload: _,
+            non_ascii_mode: _,
+            disabled_diagnostics: _,
+            severity_overrides: _,
+            package_resolver: _,
+            recovery_names: _,
+            workspace_scan_gate: _,
+            workspace_scan_ready: _,
+            rehoming_gate: _,
+            discovered_tcl: _,
+            editor_library_paths: _,
+            package_prefer_latest_default: _,
+            extra_commands: _,
+            bigip_version: _,
+            generic_variable_patterns: _,
+            formatting_settings: _,
+            feature_toggles: _,
+            optimiser_enabled: _,
+            shimmer_enabled: _,
+            optimiser_profile: _,
+            optimiser_code_overrides: _,
+            line_length: _,
+            style_line_length: _,
+            db: _,
+            db_project: _,
+            db_config: _,
+            client_supports_pull_diagnostics: _,
+            semantic_tokens_refresh_pending: _,
+            warm_task: _,
+            edit_order: _,
+        } = self;
+        PerUriCaches {
+            autoloaded_library_uris,
+            rehomed_source_seeds,
+            last_semantic_tokens,
+            semantic_tokens_refresh_asked,
+            workspace_class_analyses,
+        }
+    }
+
+    /// Forget every piece of per-URI state keyed on `uris` — the single entry
+    /// point every path that retires a URI goes through (#1298, #1300).
+    ///
+    /// Covers the [`PerUriCaches`] group plus `diag_slots`, whose eviction is
+    /// not a plain map removal.  Callers keep the rest of their retirement
+    /// explicit, because the two paths legitimately differ there: the
+    /// `workspace_index` entry and the salsa source (batched for a folder
+    /// removal, single for a rename) and the published-diagnostics state
+    /// (unconditional for a dead path, badge-carrying files only for a folder
+    /// removal).
+    async fn forget_uri_states(&self, uris: &[Uri]) {
+        if uris.is_empty() {
+            return;
+        }
+        self.per_uri_caches().forget(uris).await;
+        for uri in uris {
+            self.evict_diag_slot(uri).await;
+        }
+    }
+
+    /// Single-URI [`Self::forget_uri_states`].
+    async fn forget_uri_state(&self, uri: &Uri) {
+        self.forget_uri_states(std::slice::from_ref(uri)).await;
+    }
+
     /// Retire every trace of a path a `workspace/didRenameFiles` moved away
     /// from (#1146).
     ///
@@ -5662,18 +5891,40 @@ impl Backend {
     /// entry, semantic-token baseline and class analysis survived every rename
     /// for the process's life.  The empty publish is what removes the client's
     /// Problems entry for the dead path.
+    ///
+    /// The per-URI caches go through the shared [`Self::forget_uri_states`]
+    /// (#1298): this function used to clear them by hand and missed
+    /// `rehomed_source_seeds` and `autoloaded_library_uris`, which every *other*
+    /// retirement path did clear.  A retained seed record is far worse than the
+    /// bytes it holds — `refresh_source_rehoming_locked` can never reach its
+    /// early return again, because the stale URI is queued as work on every
+    /// round of every call (the desired set no longer names it) and the work
+    /// item then dies at the `read_document` guard before it can heal the
+    /// record.  One rename of a `source`d file therefore turned an O(1) early
+    /// return into a permanent four-round workspace scan on every navigation
+    /// request that enters through `rehomed_index_guard`.
     async fn retire_renamed_uri(&self, uri: &Uri) {
-        self.workspace_index
-            .write()
-            .await
-            .remove_document(uri.as_str());
-        self.db_remove_source(uri).await;
-        self.last_semantic_tokens.lock().await.remove(uri);
-        self.semantic_tokens_refresh_asked.lock().await.remove(uri);
-        self.workspace_class_analyses.lock().await.remove(uri);
-        self.evict_diag_slot(uri).await;
-        // Publishes the empty set and drops the pull-cache + closed-generation
-        // entries, matching the watched-file DELETED branch's badge clear.
+        {
+            // Serialise the index/salsa removal *and* the cache forget with
+            // source-site reconciliation, as every other retirement path does,
+            // so a `refresh_source_rehoming` pass cannot observe the index entry
+            // gone while the seed record still stands.
+            let _rehoming_guard = self.rehoming_gate.lock().await;
+            self.workspace_index
+                .write()
+                .await
+                .remove_document(uri.as_str());
+            self.db_remove_source(uri).await;
+            self.forget_uri_state(uri).await;
+        }
+        // Rename-specific extra: publishes the empty set and drops the
+        // pull-cache + closed-generation entries, matching the watched-file
+        // DELETED branch's badge clear.  Unconditional — unlike the folder-drop
+        // path, which clears only files that still carry a badge — because this
+        // path is dead and the client must lose its Problems entry either way.
+        // Deliberately outside the gate above: it awaits a client notification,
+        // and holding the rehoming gate across that would stall every
+        // navigation request behind it.
         self.clear_closed_diagnostics(uri).await;
     }
 
@@ -11318,6 +11569,31 @@ impl Backend {
         guard
     }
 
+    /// The seed standing for "evaluated in the global namespace".
+    ///
+    /// Must match the seed `WorkspaceIndex::source_seed_map` emits for a
+    /// `source` whose site namespace is empty — the two halves of the same
+    /// convention.
+    const STANDALONE_SEED: &'static str = "::";
+
+    /// Whether a seed set is exactly the standalone view — i.e. the document is
+    /// **not** re-homed and [`Self::rehomed_source_seeds`] must hold no entry
+    /// for it.
+    ///
+    /// Taken as an iterator so the *one* definition serves every caller
+    /// whatever collection it holds: the desired set arrives from
+    /// `WorkspaceIndex::source_seed_map` as a `BTreeSet`, the recorded and
+    /// applied ones as a `Vec`.  Spelling the test twice — once per collection
+    /// type — is how the queue and the store came to disagree in the first
+    /// place (#1297), so there is deliberately nowhere else to state it.
+    fn is_standalone_view<'s>(seeds: impl IntoIterator<Item = &'s String>) -> bool {
+        let mut seeds = seeds.into_iter();
+        seeds
+            .next()
+            .is_some_and(|only| only == Self::STANDALONE_SEED)
+            && seeds.next().is_none()
+    }
+
     /// [`Self::refresh_source_rehoming`] with the transaction gate already held.
     async fn refresh_source_rehoming_locked(&self) {
         for _round in 0..4 {
@@ -11326,7 +11602,21 @@ impl Backend {
                 if !index.has_source_edges() && self.rehomed_source_seeds.lock().await.is_empty() {
                     return;
                 }
-                index.source_seed_map(resolve_source_edge)
+                // Documents whose only source site is the global namespace are
+                // dropped here: their desired view *is* the standalone analysis
+                // the index already holds, and [`Self::rehomed_source_seeds`]
+                // records that as absence.  Leaving them in is what stopped an
+                // ordinary top-level `source b.tcl` from ever converging — the
+                // queue below compared `recorded.get(uri)` against `Some(["::"])`
+                // while the store *removes* such an entry, so the same document
+                // was re-analysed and re-indexed on every round of every call,
+                // for ever, invalidating every index-generation memo with it
+                // (issue #1297).
+                index
+                    .source_seed_map(resolve_source_edge)
+                    .into_iter()
+                    .filter(|(_, seeds)| !Self::is_standalone_view(seeds))
+                    .collect::<HashMap<String, std::collections::BTreeSet<String>>>()
             };
             let recorded = self.rehomed_source_seeds.lock().await.clone();
             let mut work: Vec<(String, Vec<String>)> = Vec::new();
@@ -11337,9 +11627,13 @@ impl Backend {
                 }
             }
             for (uri, seeds) in &recorded {
-                if !desired.contains_key(uri) && seeds != &["::".to_owned()] {
-                    // No longer sourced from anywhere: restore the standalone view.
-                    work.push((uri.clone(), vec!["::".to_owned()]));
+                if !desired.contains_key(uri) && !Self::is_standalone_view(seeds) {
+                    // No longer re-homed anywhere: restore the standalone view.
+                    // The invariant makes a recorded standalone view impossible,
+                    // so the second test never fires; it stays because queuing
+                    // one would be work the store immediately undoes — the
+                    // non-convergence this pass must never re-admit.
+                    work.push((uri.clone(), vec![Self::STANDALONE_SEED.to_owned()]));
                 }
             }
             if work.is_empty() {
@@ -11360,7 +11654,7 @@ impl Backend {
                         .iter()
                         .map(|seed| {
                             let mut analyser = Analyser::new();
-                            if seed == "::" {
+                            if seed == Self::STANDALONE_SEED {
                                 analyser.analyse(&text, &dialect)
                             } else {
                                 analyser.analyse_with_source_namespace(&text, &dialect, seed)
@@ -11379,7 +11673,7 @@ impl Backend {
                         index.add_document(&uri_s, analysis);
                     }
                 }
-                if seeds == ["::".to_owned()] {
+                if Self::is_standalone_view(&seeds) {
                     self.rehomed_source_seeds.lock().await.remove(&uri_s);
                 } else {
                     self.rehomed_source_seeds.lock().await.insert(uri_s, seeds);
@@ -24402,6 +24696,81 @@ mod tests {
         );
     }
 
+    /// Issue #1300: removing a workspace folder cleared the index, the salsa
+    /// sources, the rehoming seeds and the diagnostics badge of the closed files
+    /// it took with it — but left `last_semantic_tokens`,
+    /// `semantic_tokens_refresh_asked` and `workspace_class_analyses` holding an
+    /// entry per file, for the process's life, even though the file was no
+    /// longer in any workspace folder.  All three are cleared by
+    /// `retire_renamed_uri`, which is the asymmetry
+    /// [`Backend::forget_uri_states`] now makes impossible.
+    ///
+    /// The negatives matter as much as the positive: a file under a folder that
+    /// stayed keeps everything, and so does an **open** document under the
+    /// removed folder — its live buffer is the source of truth regardless of the
+    /// folder set, and that exclusion is deliberate.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn workspace_folder_removal_forgets_per_uri_caches_1300() {
+        let backend = test_backend();
+        let dropped = Uri::from_str("file:///drop-a/closed.tcl").unwrap();
+        let still_open = Uri::from_str("file:///drop-a/open.tcl").unwrap();
+        let kept = Uri::from_str("file:///drop-b/closed.tcl").unwrap();
+        let src = "proc p {} {}\n";
+        {
+            let mut analyser = Analyser::new();
+            let analysis = analyser.analyse(src, "tcl8.6").clone();
+            let mut index = backend.workspace_index.write().await;
+            for uri in [&dropped, &still_open, &kept] {
+                index.add_document(uri.as_str(), &analysis);
+            }
+        }
+        backend.documents.lock().await.insert(
+            still_open.clone(),
+            DocumentState::new(src.to_owned(), "tcl8.6".to_owned()),
+        );
+        for uri in [&dropped, &still_open, &kept] {
+            seed_per_uri_caches(&backend, uri).await;
+        }
+        *backend.workspace_folders.lock().await = vec![
+            Uri::from_str("file:///drop-a").unwrap(),
+            Uri::from_str("file:///drop-b").unwrap(),
+        ];
+
+        backend
+            .did_change_workspace_folders(DidChangeWorkspaceFoldersParams {
+                event: tower_lsp_server::ls_types::WorkspaceFoldersChangeEvent {
+                    added: Vec::new(),
+                    removed: vec![tower_lsp_server::ls_types::WorkspaceFolder {
+                        uri: Uri::from_str("file:///drop-a").unwrap(),
+                        name: "drop-a".to_owned(),
+                    }],
+                },
+            })
+            .await;
+
+        assert_eq!(
+            per_uri_cache_hits(&backend, &dropped).await,
+            [false; 5],
+            "a closed file under the removed folder must lose every per-URI cache",
+        );
+        assert_eq!(
+            per_uri_cache_hits(&backend, &kept).await,
+            [true; 5],
+            "a file under a folder that stayed keeps its entries",
+        );
+        assert_eq!(
+            per_uri_cache_hits(&backend, &still_open).await,
+            [true; 5],
+            "an open document under the removed folder keeps its state — that \
+             exclusion is deliberate",
+        );
+        let uris = backend.workspace_index.read().await.document_uris();
+        assert!(
+            uris.iter().any(|u| u == still_open.as_str()),
+            "…and keeps its index entry too",
+        );
+    }
+
     /// Removing a workspace folder shifts the salsa `Project` without an open
     /// document's own edit, so open documents with cross-file diagnostics enabled
     /// must be rescheduled (matching the watched-file path) — otherwise a
@@ -27437,6 +27806,162 @@ mod tests {
         );
     }
 
+    /// Issue #1297: an ordinary top-level `source b.tcl` — no namespace, the
+    /// normal way to write Tcl — must reconcile to a fixed point.
+    ///
+    /// A document sourced only from the global namespace wants exactly the
+    /// standalone analysis the index already holds, so
+    /// [`Backend::rehomed_source_seeds`] records it as *absence*.  The work
+    /// queue used to compare against `Some(["::"])` instead, a value the store
+    /// never writes, so the document was queued, re-analysed and re-indexed on
+    /// every round of every call, for ever.
+    ///
+    /// The generation assertion is the one with the user-visible teeth: every
+    /// index mutation bumps it, and every `Derived` memo on the index (settled
+    /// invocations, defined names, command links, run order) is dropped when it
+    /// moves — so a non-converging pass threw the whole memo tier away on every
+    /// navigation request, which is the residual cost behind #1297's report.
+    #[tokio::test]
+    async fn a_global_source_site_converges_without_touching_the_index_1297() {
+        let backend = test_backend();
+        let a = Uri::from_str("file:///global-source/a.tcl").unwrap();
+        let b = Uri::from_str("file:///global-source/b.tcl").unwrap();
+        register(&backend, &b, "proc helper {} {}\n").await;
+        register(&backend, &a, "source b.tcl\nhelper\n").await;
+        let before = backend.workspace_index.read().await.generation();
+
+        backend.refresh_source_rehoming().await;
+
+        assert!(
+            backend.rehomed_source_seeds.lock().await.is_empty(),
+            "a document sourced only from the global namespace is not re-homed, \
+             so the map holds no entry for it",
+        );
+        let after_first = backend.workspace_index.read().await.generation();
+        assert_eq!(
+            before, after_first,
+            "there is nothing to re-home, so the pass must not re-index anything",
+        );
+        backend.refresh_source_rehoming().await;
+        assert_eq!(
+            after_first,
+            backend.workspace_index.read().await.generation(),
+            "a second pass over converged state must be a no-op — while it was \
+             not, every index-generation memo was invalidated on every \
+             navigation request",
+        );
+    }
+
+    /// Issue #1297, mixed shape: one document genuinely re-homed under `::ns`
+    /// and another sourced from global scope, in the same workspace.  Both must
+    /// reach a fixed point, and the re-homed one must keep its seed.
+    #[tokio::test]
+    async fn mixed_global_and_namespaced_source_sites_reach_a_fixed_point_1297() {
+        let backend = test_backend();
+        let a = Uri::from_str("file:///mixed-source/a.tcl").unwrap();
+        let b = Uri::from_str("file:///mixed-source/b.tcl").unwrap();
+        let c = Uri::from_str("file:///mixed-source/c.tcl").unwrap();
+        let d = Uri::from_str("file:///mixed-source/d.tcl").unwrap();
+        register(&backend, &b, "proc helper {} {}\n").await;
+        register(&backend, &c, "proc plain {} {}\n").await;
+        register(&backend, &a, "namespace eval ::ns { source b.tcl }\n").await;
+        register(&backend, &d, "source c.tcl\n").await;
+
+        backend.refresh_source_rehoming().await;
+
+        assert_eq!(
+            backend
+                .rehomed_source_seeds
+                .lock()
+                .await
+                .iter()
+                .map(|(uri, seeds)| (uri.clone(), seeds.clone()))
+                .collect::<std::collections::BTreeMap<_, _>>(),
+            [(b.as_str().to_owned(), vec!["::ns".to_owned()])]
+                .into_iter()
+                .collect::<std::collections::BTreeMap<_, _>>(),
+            "only the namespaced source site is re-homed; the global one is not",
+        );
+        {
+            let index = backend.workspace_index.read().await;
+            assert!(
+                index.workspace_command_exists("::ns::helper"),
+                "the re-homed twin is indexed",
+            );
+            assert!(
+                index.workspace_command_exists("::plain"),
+                "the globally-sourced document keeps its standalone view",
+            );
+        }
+
+        let settled = backend.workspace_index.read().await.generation();
+        backend.refresh_source_rehoming().await;
+        backend.refresh_source_rehoming().await;
+        assert_eq!(
+            settled,
+            backend.workspace_index.read().await.generation(),
+            "both documents are converged, so further passes do no work",
+        );
+    }
+
+    /// Issue #1297, transition: a document re-homed under `::ns` whose source
+    /// site later moves to global scope must end up standalone, lose its record,
+    /// and converge from there.  This is the direction the `recorded` loop
+    /// serves, and the one that proves filtering the standalone view out of the
+    /// desired set has not stranded anything.
+    #[tokio::test]
+    async fn a_source_site_moving_to_global_scope_restores_the_standalone_view_1297() {
+        let backend = test_backend();
+        let a = Uri::from_str("file:///unwrapped-source/a.tcl").unwrap();
+        let b = Uri::from_str("file:///unwrapped-source/b.tcl").unwrap();
+        register(&backend, &b, "proc helper {} {}\n").await;
+        register(&backend, &a, "namespace eval ::ns { source b.tcl }\n").await;
+        backend.refresh_source_rehoming().await;
+        assert_eq!(
+            backend
+                .rehomed_source_seeds
+                .lock()
+                .await
+                .get(b.as_str())
+                .cloned(),
+            Some(vec!["::ns".to_owned()]),
+            "precondition: b.tcl is re-homed under ::ns",
+        );
+
+        // The user unwraps the `namespace eval`: the same `source` now runs in
+        // the global namespace.
+        backend
+            .workspace_index
+            .write()
+            .await
+            .remove_document(a.as_str());
+        register(&backend, &a, "source b.tcl\n").await;
+        backend.refresh_source_rehoming().await;
+
+        assert!(
+            backend.rehomed_source_seeds.lock().await.is_empty(),
+            "the document is standalone again, so its record goes with the seed",
+        );
+        {
+            let index = backend.workspace_index.read().await;
+            assert!(
+                index.workspace_command_exists("::helper"),
+                "the standalone view is back in the index",
+            );
+            assert!(
+                !index.workspace_command_exists("::ns::helper"),
+                "and the re-homed twin is gone",
+            );
+        }
+        let settled = backend.workspace_index.read().await.generation();
+        backend.refresh_source_rehoming().await;
+        assert_eq!(
+            settled,
+            backend.workspace_index.read().await.generation(),
+            "the restored state is itself a fixed point",
+        );
+    }
+
     /// Issue #945 fault 3: a file sourced into **several** namespaces is one
     /// physical declaration with one runtime identity per source site
     /// (tclsh 9.0.4: `namespace eval ::x {source b.tcl}` + `namespace eval
@@ -30223,6 +30748,324 @@ mod tests {
                 .lock()
                 .await
                 .contains_key(&old)
+        );
+    }
+
+    /// Put an entry for `uri` in every cache [`Backend::forget_uri_states`]
+    /// clears, so a retirement test can assert on the whole group rather than
+    /// on whichever member the bug of the day happened to be about.
+    async fn seed_per_uri_caches(backend: &Backend, uri: &Uri) {
+        backend
+            .autoloaded_library_uris
+            .lock()
+            .await
+            .insert(uri.as_str().to_owned());
+        backend
+            .rehomed_source_seeds
+            .lock()
+            .await
+            .insert(uri.as_str().to_owned(), vec!["::seeded".to_owned()]);
+        backend
+            .last_semantic_tokens
+            .lock()
+            .await
+            .insert(uri.clone(), ("st-1".to_owned(), Vec::new()));
+        backend
+            .semantic_tokens_refresh_asked
+            .lock()
+            .await
+            .insert(uri.clone(), 7);
+        backend.workspace_class_analyses.lock().await.insert(
+            uri.clone(),
+            WorkspaceClassAnalysis {
+                fingerprint: (0, 0),
+                analysis: Arc::default(),
+            },
+        );
+    }
+
+    /// Whether each cache [`seed_per_uri_caches`] fills still holds `uri`, in
+    /// the same order, so an assertion reads `[false; 5]` / `[true; 5]`.
+    async fn per_uri_cache_hits(backend: &Backend, uri: &Uri) -> [bool; 5] {
+        [
+            backend
+                .autoloaded_library_uris
+                .lock()
+                .await
+                .contains(uri.as_str()),
+            backend
+                .rehomed_source_seeds
+                .lock()
+                .await
+                .contains_key(uri.as_str()),
+            backend.last_semantic_tokens.lock().await.contains_key(uri),
+            backend
+                .semantic_tokens_refresh_asked
+                .lock()
+                .await
+                .contains_key(uri),
+            backend
+                .workspace_class_analyses
+                .lock()
+                .await
+                .contains_key(uri),
+        ]
+    }
+
+    /// One `workspace/didRenameFiles` notification for `pairs`.
+    fn rename_params(pairs: &[(&Uri, &Uri)]) -> RenameFilesParams {
+        RenameFilesParams {
+            files: pairs
+                .iter()
+                .map(|(old, new)| tower_lsp_server::ls_types::FileRename {
+                    old_uri: old.to_string(),
+                    new_uri: new.to_string(),
+                })
+                .collect(),
+        }
+    }
+
+    /// Issue #1298: `retire_renamed_uri` is the *sole* cleanup for a
+    /// renamed-away path, and it dropped seven per-URI maps but not the M9
+    /// `rehomed_source_seeds` record — which every other retirement path
+    /// (`did_close`, the watched-file DELETED branch, the folder drop, the
+    /// batch reindex, the workspace scan) does drop.
+    ///
+    /// The rename arrives on its own here, with **no** `didChangeWatchedFiles`
+    /// alongside it: that racing watch event is what masks the leak under VS
+    /// Code, so a test that sends both proves nothing about this path.
+    #[tokio::test]
+    async fn did_rename_forgets_the_source_rehoming_seed_1298() {
+        let backend = test_backend();
+        let a = Uri::from_str("file:///rehome-rename/a.tcl").unwrap();
+        let b = Uri::from_str("file:///rehome-rename/b.tcl").unwrap();
+        let c = Uri::from_str("file:///rehome-rename/c.tcl").unwrap();
+        let sourced = "proc helper {} {}\n";
+        register(&backend, &b, sourced).await;
+        register(&backend, &a, "namespace eval ::ns { source b.tcl }\n").await;
+        backend.refresh_source_rehoming().await;
+        assert_eq!(
+            backend
+                .rehomed_source_seeds
+                .lock()
+                .await
+                .get(b.as_str())
+                .cloned(),
+            Some(vec!["::ns".to_owned()]),
+            "precondition: the sourced file is indexed under the ::ns source site",
+        );
+
+        // The client renames b.tcl → c.tcl: the file leaves its old path, the
+        // buffer follows it to the new URI, and the workspace edit
+        // `will_rename_files` handed back rewrites the `source` literal.
+        backend.documents.lock().await.remove(&b);
+        register(&backend, &c, sourced).await;
+        backend
+            .workspace_index
+            .write()
+            .await
+            .remove_document(a.as_str());
+        register(&backend, &a, "namespace eval ::ns { source c.tcl }\n").await;
+        backend.did_rename_files(rename_params(&[(&b, &c)])).await;
+
+        assert!(
+            !backend
+                .rehomed_source_seeds
+                .lock()
+                .await
+                .contains_key(b.as_str()),
+            "the renamed-away path's seed record must go with it",
+        );
+
+        // The consequence, not just the symptom.  `work` in
+        // `refresh_source_rehoming_locked` is derived purely from the recorded
+        // seeds and the set the index asks for, so their equality proves the
+        // next pass queues nothing and returns in its first round — the O(1)
+        // behaviour the leaked record destroyed for the rest of the session.
+        backend.refresh_source_rehoming().await;
+        let desired: std::collections::BTreeMap<String, Vec<String>> = backend
+            .workspace_index
+            .read()
+            .await
+            .source_seed_map(resolve_source_edge)
+            .into_iter()
+            .map(|(uri, seeds)| (uri, seeds.into_iter().collect()))
+            .collect();
+        let recorded: std::collections::BTreeMap<String, Vec<String>> = backend
+            .rehomed_source_seeds
+            .lock()
+            .await
+            .clone()
+            .into_iter()
+            .collect();
+        assert_eq!(
+            recorded, desired,
+            "reconciliation must have converged: anything recorded that the \
+             index no longer asks for is re-queued as work on every round of \
+             every later call, and dies at the `read_document` guard before it \
+             can heal itself",
+        );
+        assert_eq!(
+            recorded.keys().map(String::as_str).collect::<Vec<_>>(),
+            vec![c.as_str()],
+            "only the new path carries a seed record",
+        );
+    }
+
+    /// Issue #1298, the consequence in its purest form: when the renamed pair
+    /// takes the workspace's last `source` edge with it,
+    /// `refresh_source_rehoming_locked`'s early return
+    /// (`!has_source_edges() && seeds.is_empty()`) must be reachable again.
+    ///
+    /// A retained record fails the second half of that guard for good, so every
+    /// `references` / `definition` / `hover` / `rename` / call-hierarchy request
+    /// that enters through `rehomed_index_guard` pays a full four-round
+    /// workspace scan instead of an O(1) return, serialised behind one shared
+    /// gate.
+    #[tokio::test]
+    async fn renaming_a_sourced_pair_restores_the_rehoming_early_return_1298() {
+        let backend = test_backend();
+        let a = Uri::from_str("file:///rehome-moved/a.tcl").unwrap();
+        let b = Uri::from_str("file:///rehome-moved/b.tcl").unwrap();
+        let a2 = Uri::from_str("file:///moved/a.tcl").unwrap();
+        let b2 = Uri::from_str("file:///moved/b.tcl").unwrap();
+        register(&backend, &b, "proc helper {} {}\n").await;
+        register(&backend, &a, "namespace eval ::ns { source b.tcl }\n").await;
+        backend.refresh_source_rehoming().await;
+        assert!(
+            !backend.rehomed_source_seeds.lock().await.is_empty(),
+            "precondition: a seed record exists to be leaked",
+        );
+
+        // A directory move: the client renames both files in one notification
+        // and neither old path survives.
+        backend.documents.lock().await.remove(&a);
+        backend.documents.lock().await.remove(&b);
+        backend
+            .did_rename_files(rename_params(&[(&a, &a2), (&b, &b2)]))
+            .await;
+
+        // Both halves of the early-return guard, asserted as the guard reads.
+        assert!(
+            !backend.workspace_index.read().await.has_source_edges(),
+            "the `source` edge left with the renamed files",
+        );
+        assert!(
+            backend.rehomed_source_seeds.lock().await.is_empty(),
+            "a renamed-away seed record blocks the early return for the whole \
+             session — the real cost of #1298, far beyond the bytes retained",
+        );
+        // …and a pass over that state is a no-op, as the early return promises.
+        backend.refresh_source_rehoming().await;
+        assert!(backend.rehomed_source_seeds.lock().await.is_empty());
+    }
+
+    /// Issue #1298, FP/TN guard: retiring a path that was never source-rehomed
+    /// must disturb nobody — an unrelated document's seed record is still
+    /// relevant and must survive the rename.
+    #[tokio::test]
+    async fn did_rename_of_an_unrelated_file_keeps_other_seeds_1298() {
+        let backend = test_backend();
+        let a = Uri::from_str("file:///rehome-fp/a.tcl").unwrap();
+        let b = Uri::from_str("file:///rehome-fp/b.tcl").unwrap();
+        let unrelated = Uri::from_str("file:///rehome-fp/tool.tcl").unwrap();
+        let renamed = Uri::from_str("file:///rehome-fp/tool2.tcl").unwrap();
+        register(&backend, &b, "proc helper {} {}\n").await;
+        register(&backend, &a, "namespace eval ::ns { source b.tcl }\n").await;
+        register(&backend, &unrelated, "proc standalone {} {}\n").await;
+        backend.refresh_source_rehoming().await;
+        let before = backend.rehomed_source_seeds.lock().await.clone();
+        assert_eq!(
+            before.get(b.as_str()).cloned(),
+            Some(vec!["::ns".to_owned()]),
+            "precondition: only the sourced file has a record",
+        );
+
+        backend.documents.lock().await.remove(&unrelated);
+        backend
+            .did_rename_files(rename_params(&[(&unrelated, &renamed)]))
+            .await;
+
+        assert_eq!(
+            *backend.rehomed_source_seeds.lock().await,
+            before,
+            "renaming a file that was never source-rehomed must leave every \
+             other document's seed record exactly as it was",
+        );
+    }
+
+    /// Issue #1298, second half: `retire_renamed_uri` also skipped
+    /// `autoloaded_library_uris`, whose entries are otherwise drained only by a
+    /// full package-database rebuild — so a renamed library file kept claiming
+    /// to be merged into the index long after its index entry was gone.
+    #[tokio::test]
+    async fn did_rename_forgets_the_autoloaded_library_record_1298() {
+        let backend = test_backend();
+        let lib_uri = seed_autoload_library(&backend, "autoload-rename").await;
+        let app = Uri::from_str("file:///autoload-rename-app.tcl").unwrap();
+        let app_src = "Rbc_ActiveLegend .g\n";
+        register(&backend, &app, app_src).await;
+        let analysis = {
+            let mut a = Analyser::new();
+            a.analyse(app_src, "tcl8.6").clone()
+        };
+        let refs = backend
+            .cross_document_references(&app, app_src, &analysis, Position::new(0, 3), true)
+            .await;
+        assert!(
+            refs.iter().any(|l| l.uri == lib_uri),
+            "precondition: the autoload tier merged the library: {refs:?}",
+        );
+        assert!(
+            backend
+                .autoloaded_library_uris
+                .lock()
+                .await
+                .contains(lib_uri.as_str()),
+            "precondition: the merge is recorded against the library URI",
+        );
+
+        let moved = Uri::from_str("file:///autoload-rename-moved.tcl").unwrap();
+        backend
+            .did_rename_files(rename_params(&[(&lib_uri, &moved)]))
+            .await;
+
+        assert!(
+            !backend
+                .autoloaded_library_uris
+                .lock()
+                .await
+                .contains(lib_uri.as_str()),
+            "the renamed-away library must not stay recorded as merged",
+        );
+    }
+
+    /// Issue #1298 / #1300 together: both retirement paths clear the *same*
+    /// group of per-URI caches, because both go through
+    /// [`Backend::forget_uri_states`].  Asserting the whole group on the rename
+    /// path is what stops the two drifting apart again.
+    #[tokio::test]
+    async fn did_rename_forgets_every_per_uri_cache_1298() {
+        let backend = test_backend();
+        let old = Uri::from_str("file:///forget-all/old.tcl").unwrap();
+        let new = Uri::from_str("file:///forget-all/new.tcl").unwrap();
+        let bystander = Uri::from_str("file:///forget-all/other.tcl").unwrap();
+        seed_per_uri_caches(&backend, &old).await;
+        seed_per_uri_caches(&backend, &bystander).await;
+
+        backend
+            .did_rename_files(rename_params(&[(&old, &new)]))
+            .await;
+
+        assert_eq!(
+            per_uri_cache_hits(&backend, &old).await,
+            [false; 5],
+            "every per-URI cache keyed on the dead path must be forgotten",
+        );
+        assert_eq!(
+            per_uri_cache_hits(&backend, &bystander).await,
+            [true; 5],
+            "no other document's state may be touched",
         );
     }
 

--- a/rust/tcl-lsp-server/tests/e2e.rs
+++ b/rust/tcl-lsp-server/tests/e2e.rs
@@ -69,6 +69,8 @@ mod issue1137_call_site_resolution;
 mod issue1214_uri_canonicalisation;
 #[path = "e2e/issue1281_ensemble_rename.rs"]
 mod issue1281_ensemble_rename;
+#[path = "e2e/issue1302_import_builtin_shadow.rs"]
+mod issue1302_import_builtin_shadow;
 #[path = "e2e/issue923_class_refs.rs"]
 mod issue923_class_refs;
 #[path = "e2e/issue923_crossdoc.rs"]

--- a/rust/tcl-lsp-server/tests/e2e/issue1302_import_builtin_shadow.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue1302_import_builtin_shadow.rs
@@ -1,0 +1,218 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Issue #1302, end-to-end: a `namespace import` cannot bind a name the
+//! **registry** says a fresh interpreter already holds, so a bare call to
+//! such a name is not a reference to the exported proc.
+//!
+//! The unit-level matrix lives in `tcl_lsp_core::workspace_index`; this is the
+//! same question asked through the real server on the requests a user
+//! actually issues — `textDocument/references` and `textDocument/definition`
+//! — because the defect's blast radius is find-references and the reference
+//! count code lenses, not the index in the abstract.
+//!
+//! Every expectation is oracle-verified on tclsh 9.0.4 (built from
+//! `core-9-0-4`) and 8.6.14, byte-identical. Each test records the transcript
+//! it was written against.
+
+use crate::common::helpers::*;
+use crate::common::{Lsp, unique_uri};
+use serde_json::Value;
+
+/// The reference start lines that land in document `uri`.
+fn lines_in(result: &Value, uri: &str) -> Vec<i64> {
+    locations(result)
+        .iter()
+        .filter(|l| l.uri == uri)
+        .map(|l| {
+            l.range
+                .get("start")
+                .and_then(|s| s.get("line"))
+                .and_then(Value::as_i64)
+                .unwrap_or(-1)
+        })
+        .collect()
+}
+
+/// TP — the defect itself. `::Foo` exports `set`; the unforced import is
+/// refused, so `set x 1` reaches the builtin and is **not** a reference to
+/// `::Foo::set`.
+///
+/// Oracle:
+/// ```text
+/// namespace eval ::Foo { proc set {a b} {return SHADOW}; namespace export set }
+/// namespace import ::Foo::*   -> can't import command "set": already exists
+/// namespace origin ::set      -> ::set
+/// ```
+#[test]
+fn tp_a_bare_builtin_call_is_not_a_reference_to_an_exported_shadow() {
+    let mut lsp = Lsp::tcl();
+    let lib = unique_uri("tcl");
+    lsp.open_ready(
+        &lib,
+        "namespace eval ::Foo {\n    proc set {a b} { return SHADOW }\n    namespace export set\n}\n",
+    );
+    let user = unique_uri("tcl");
+    lsp.open_ready(&user, "namespace import ::Foo::*\nset x 1\n");
+
+    // Cursor on the `set` of `proc set` in the library document.
+    let refs = lsp.references(&lib, 1, 10, false);
+    assert!(
+        lines_in(&refs, &user).is_empty(),
+        "the import raised `already exists` and installed nothing, so the bare \
+         `set x 1` must not be filed as a reference: {:?}",
+        locations(&refs),
+    );
+}
+
+/// TN — `-force` is the one import that *does* replace a command the target
+/// namespace already holds, so there the call really is a reference.
+///
+/// Oracle: `namespace import -force ::Foo::*` then
+/// `namespace origin ::set` -> `::Foo::set`.
+#[test]
+fn tn_a_forced_import_does_shadow_the_builtin_and_the_call_is_a_reference() {
+    let mut lsp = Lsp::tcl();
+    let lib = unique_uri("tcl");
+    lsp.open_ready(
+        &lib,
+        "namespace eval ::Foo {\n    proc set {a b} { return SHADOW }\n    namespace export set\n}\n",
+    );
+    let user = unique_uri("tcl");
+    lsp.open_ready(&user, "namespace import -force ::Foo::*\nset x 1\n");
+
+    let refs = lsp.references(&lib, 1, 10, false);
+    assert_eq!(
+        lines_in(&refs, &user),
+        vec![1],
+        "`-force` replaces the builtin, so the bare call is a real reference: {:?}",
+        locations(&refs),
+    );
+}
+
+/// FP guard — the conflict is about the **target** namespace's command table,
+/// and the builtins live in `::`. Importing into `::Bar` binds `::Bar::set`
+/// with no conflict at all, so the call from `::Bar` must still resolve.
+///
+/// Oracle: `namespace eval ::Bar { namespace import ::Foo::* }` then
+/// `namespace origin ::Bar::set` -> `::Foo::set`.
+#[test]
+fn fp_guard_importing_a_builtin_name_into_a_sub_namespace_still_resolves() {
+    let mut lsp = Lsp::tcl();
+    let lib = unique_uri("tcl");
+    lsp.open_ready(
+        &lib,
+        "namespace eval ::Foo {\n    proc set {a b} { return SHADOW }\n    namespace export set\n}\n",
+    );
+    let user = unique_uri("tcl");
+    lsp.open_ready(
+        &user,
+        "namespace eval ::Bar {\n    namespace import ::Foo::*\n    proc go {} { set x 1 }\n}\n",
+    );
+
+    let refs = lsp.references(&lib, 1, 10, false);
+    assert_eq!(
+        lines_in(&refs, &user),
+        vec![2],
+        "`::Bar::set` is not a builtin, so the import installs and the call \
+         from ::Bar is a reference: {:?}",
+        locations(&refs),
+    );
+}
+
+/// FN guard for the operator spellings — the case a naive
+/// `registry.get(name).is_some()` gate would break. `+` is **not** a command
+/// in `::` at all, so exporting `+` and importing it into `::` genuinely
+/// binds.
+///
+/// Oracle:
+/// ```text
+/// info commands ::+   -> {}          (and `+ 1 2` -> invalid command name "+")
+/// namespace eval ::Ops { proc + {a b} {return OPS}; namespace export + }
+/// namespace import ::Ops::*
+/// namespace origin ::+  -> ::Ops::+
+/// ```
+#[test]
+fn fn_guard_an_operator_name_still_binds_into_the_global_namespace() {
+    let mut lsp = Lsp::tcl();
+    let lib = unique_uri("tcl");
+    lsp.open_ready(
+        &lib,
+        "namespace eval ::Ops {\n    proc + {a b} { return OPS }\n    namespace export +\n}\n",
+    );
+    let user = unique_uri("tcl");
+    lsp.open_ready(&user, "namespace import ::Ops::*\n+ 1 2\n");
+
+    // Column 9 is the `+` itself — the name is one character wide, unlike the
+    // `set` / `mything` cases above where column 10 still lands inside it.
+    let refs = lsp.references(&lib, 1, 9, false);
+    assert_eq!(
+        lines_in(&refs, &user),
+        vec![1],
+        "a bare operator spelling is the post-`namespace import ::tcl::mathop::*` \
+         form, not a command a fresh interpreter holds: {:?}",
+        locations(&refs),
+    );
+}
+
+/// TN — an ordinary, non-builtin exported name is unaffected. Guards against
+/// the gate having simply made the whole wildcard tier answer "no".
+#[test]
+fn tn_a_non_builtin_exported_name_still_resolves_through_the_import() {
+    let mut lsp = Lsp::tcl();
+    let lib = unique_uri("tcl");
+    lsp.open_ready(
+        &lib,
+        "namespace eval ::Foo {\n    proc mything {} {}\n    namespace export mything\n}\n",
+    );
+    let user = unique_uri("tcl");
+    lsp.open_ready(&user, "namespace import ::Foo::*\nmything\n");
+
+    let refs = lsp.references(&lib, 1, 10, false);
+    assert_eq!(
+        lines_in(&refs, &user),
+        vec![1],
+        "an ordinary exported name must still resolve: {:?}",
+        locations(&refs),
+    );
+}
+
+/// The exact-pattern twin: `namespace import ::Foo::set` is refused for the
+/// identical reason, so go-to-definition from the bare call must not land on
+/// the shadow either.
+///
+/// Oracle: `namespace import ::Foo::set` -> `can't import command "set":
+/// already exists`.
+#[test]
+fn tp_an_exact_import_of_a_builtin_name_installs_no_link() {
+    let mut lsp = Lsp::tcl();
+    let lib = unique_uri("tcl");
+    lsp.open_ready(
+        &lib,
+        "namespace eval ::Foo {\n    proc set {a b} { return SHADOW }\n    namespace export set\n}\n",
+    );
+    let user = unique_uri("tcl");
+    lsp.open_ready(&user, "namespace import ::Foo::set\nset x 1\n");
+
+    let refs = lsp.references(&lib, 1, 10, false);
+    assert!(
+        lines_in(&refs, &user).is_empty(),
+        "an exact import of an already-existing name installs nothing either: {:?}",
+        locations(&refs),
+    );
+}

--- a/rust/tcl-lsp-server/tests/e2e/rename.rs
+++ b/rust/tcl-lsp-server/tests/e2e/rename.rs
@@ -32,7 +32,7 @@
 use crate::common::helpers::*;
 use crate::common::{Lsp, unique_uri};
 
-use serde_json::Value;
+use serde_json::{Value, json};
 
 /// The set of `newText` values for edits applied to `uri`.
 fn texts(
@@ -807,5 +807,88 @@ fn rename_rewrites_bare_calls_to_a_proc_installed_into_oo_helpers() {
     assert!(
         replacements.contains(&"renamedClassvar"),
         "expected the short replacement at the bare call site; got {replacements:?}"
+    );
+}
+
+/// Issue #1298, end to end: `workspace/didRenameFiles` is the *sole* cleanup a
+/// renamed-away path gets — an editor that renames a file from its explorer
+/// sends it on its own, with no `didChangeWatchedFiles` alongside — and it is
+/// the one path that used to skip the M9 source-rehoming record.
+///
+/// The behaviour that record exists to serve is asserted here rather than the
+/// record itself (the map is server-internal; `lib.rs`'s unit tests assert it
+/// directly): a file `source`d from inside `namespace eval ::ns` resolves as
+/// `::ns::rehomed_marker`, and after the file is renamed the very same
+/// navigation request must resolve to the new path — never to the dead one —
+/// which is only true if the retirement forgot the old path *and* the
+/// reconciliation still converges on the new one.
+#[test]
+fn did_rename_files_retires_the_old_path_and_keeps_source_rehoming() {
+    use std::time::{Duration, Instant};
+
+    let root = std::env::temp_dir().join(format!(
+        "tcl-lsp-e2e-rename-sourced-{}-{}",
+        std::process::id(),
+        line!()
+    ));
+    std::fs::create_dir_all(&root).expect("mk workspace root");
+    let old_path = root.join("sourced_old.tcl");
+    let new_path = root.join("sourced_new.tcl");
+    let main_path = root.join("rename_main.tcl");
+    std::fs::write(&old_path, "proc rehomed_marker {} { return 1 }\n").expect("write sourced file");
+    let before = "namespace eval ::ns {\n    source sourced_old.tcl\n}\n::ns::rehomed_marker\n";
+    std::fs::write(&main_path, before).expect("write main");
+
+    let uri_of = |p: &std::path::Path| format!("file://{}", p.to_string_lossy());
+    let (old_uri, new_uri, main_uri) = (uri_of(&old_path), uri_of(&new_path), uri_of(&main_path));
+
+    let mut lsp = Lsp::at_workspace_root(&root);
+    lsp.open_ready(&main_uri, before);
+
+    // The call on line 3 is a `references`/`definition` entry point — one of the
+    // ~ten request paths that reconcile source-site views on the way in.
+    let definition_uris = |lsp: &mut Lsp| -> Vec<String> {
+        locations(&lsp.definition(&main_uri, 3, 6))
+            .into_iter()
+            .map(|loc| loc.uri)
+            .collect()
+    };
+    let settle = |lsp: &mut Lsp, want: &str, what: &str| {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            let got = definition_uris(lsp);
+            if got == vec![want.to_owned()] {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "{what}: expected the qualified call to resolve to {want}, got {got:?}"
+            );
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    };
+    settle(
+        &mut lsp,
+        &old_uri,
+        "precondition: the sourced file is re-homed under ::ns",
+    );
+
+    // Rename on disk and apply the `willRenameFiles` edit to the open buffer,
+    // exactly as an editor does…
+    std::fs::rename(&old_path, &new_path).expect("rename on disk");
+    let after = "namespace eval ::ns {\n    source sourced_new.tcl\n}\n::ns::rehomed_marker\n";
+    std::fs::write(&main_path, after).expect("rewrite main");
+    lsp.settle_analysis(&main_uri, 2, after);
+    // …then the rename notification, and *only* that: the racing watched-file
+    // event is what masks a missing retirement, so this test must not send one.
+    lsp.notify(
+        "workspace/didRenameFiles",
+        json!({ "files": [ { "oldUri": old_uri, "newUri": new_uri } ] }),
+    );
+
+    settle(
+        &mut lsp,
+        &new_uri,
+        "after the rename the re-homed definition must follow the file",
     );
 }

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -467,6 +467,63 @@ impl CommandRegistry {
             .and_then(|v| v.last())
     }
 
+    /// Whether a **fresh interpreter** of this registry's dialect already holds
+    /// a command at exactly `qualified_name` — the question `namespace
+    /// import`'s "already exists" conflict asks, and the one `info commands
+    /// ::x` answers.
+    ///
+    /// Deliberately *not* [`Self::get`], which resolves every **spelling** a
+    /// call site may legally write, including spellings that only become
+    /// callable after an explicit `namespace import`.  The bare operator forms
+    /// are exactly that case, and conflating the two inverts a real answer:
+    ///
+    /// ```text
+    /// # oracle, tclsh 9.0.4 and 8.6.14, byte-identical
+    /// info commands ::+            ;# -> {}          (empty!)
+    /// + 1 2                        ;# -> invalid command name "+"
+    /// info commands ::set          ;# -> ::set
+    ///
+    /// namespace eval ::Ops { proc + {a b} {…}; namespace export + }
+    /// namespace import ::Ops::*    ;# -> OK, namespace origin ::+ is ::Ops::+
+    ///
+    /// namespace eval ::Foo { proc set {a b} {…}; namespace export set }
+    /// namespace import ::Foo::*    ;# -> can't import command "set": already exists
+    /// ```
+    ///
+    /// So `set` blocks an unforced import and `+` does not, even though
+    /// [`Self::get`] answers `Some` for both.  A bare
+    /// [`Traits::OPERATOR_COMMAND`] spelling is the post-`namespace import
+    /// ::tcl::mathop::*` form and is excluded here; the namespaced
+    /// `::tcl::mathop::+` spelling is a genuine member of a fresh
+    /// interpreter's command table and is kept.
+    ///
+    /// The name must also *be* the spec's own canonical name, so `get`'s
+    /// leading-`::` fallback cannot make a namespaced command answer for a
+    /// global one.
+    ///
+    /// # Known imprecision
+    ///
+    /// A command a *package* provides (`::csv::split`, `::math::statistics::mean`)
+    /// is declared here whether or not the script `package require`s it, so
+    /// asking about a package's own namespace can over-claim.  The registry
+    /// carries no "needs a `package require`" marker to gate on yet.  Reaching
+    /// that case means importing *into* a package's own namespace, which is
+    /// why it is documented rather than worked around.
+    #[must_use]
+    pub fn declares_command_at(&self, qualified_name: &str) -> bool {
+        let bare = qualified_name.trim_start_matches("::");
+        self.get(bare).is_some_and(|spec| {
+            // `get` resolves spellings; this asks about one exact name, so the
+            // spec has to be the one that *is* that command.
+            if spec.name.trim_start_matches("::") != bare {
+                return false;
+            }
+            // The namespaced `::tcl::mathop::+` is in a fresh interpreter's
+            // command table; the bare `+` it can be imported to is not.
+            bare.contains("::") || !spec.traits.contains(Traits::OPERATOR_COMMAND)
+        })
+    }
+
     /// The typed BPF-Tcl lowering descriptor for `name`, when `name` is a
     /// BPF-dialect command (see [`crate::bpf_op`]).  The BPF-Tcl front-end
     /// dispatches on this — never on the command name.
@@ -4831,5 +4888,62 @@ mod tests {
         let brk = reg.get("break").expect("break is registered");
         assert!(brk.traits.contains(Traits::TRANSFERS_CONTROL));
         assert!(!brk.traits.contains(Traits::SAFE_INTERP_HIDDEN));
+    }
+
+    /// Issue #1302: `declares_command_at` answers "is this in a fresh
+    /// interpreter's command table", which is strictly narrower than `get`'s
+    /// "is this a spelling a call site may write".
+    ///
+    /// Every row is oracle-verified on tclsh 9.0.4 and 8.6.14 via
+    /// `info commands <name>` in a fresh `interp create`.
+    #[test]
+    fn declares_command_at_is_the_fresh_interpreter_command_table() {
+        let reg = crate::registry_for_dialect("tcl9.0");
+        // `info commands ::set` -> ::set
+        for name in ["set", "::set", "puts", "::puts", "if", "foreach"] {
+            assert!(reg.declares_command_at(name), "{name} is a global builtin");
+        }
+        // `info commands ::tcl::mathop::+` -> ::tcl::mathop::+
+        for name in [
+            "tcl::mathop::+",
+            "::tcl::mathop::+",
+            "oo::define",
+            "::oo::define",
+        ] {
+            assert!(
+                reg.declares_command_at(name),
+                "{name} is a namespaced builtin"
+            );
+        }
+        // `info commands ::+` -> {} and `+ 1 2` -> invalid command name "+".
+        // `get` still answers `Some` for these — that is the whole point.
+        for name in ["+", "::+", "eq", "::eq", "in", "::in"] {
+            assert!(
+                reg.get(name).is_some(),
+                "{name} must stay a resolvable *spelling*",
+            );
+            assert!(
+                !reg.declares_command_at(name),
+                "{name} is only callable after `namespace import ::tcl::mathop::*`",
+            );
+        }
+        // A name nothing declares.
+        for name in ["notACommand", "::notACommand", "define"] {
+            assert!(!reg.declares_command_at(name), "{name}");
+        }
+    }
+
+    /// The answer is per dialect, because the command table is: `HTTP::uri`
+    /// exists for iRules and nowhere else.
+    #[test]
+    fn declares_command_at_is_dialect_specific() {
+        assert!(
+            crate::registry_for_dialect("f5-irules").declares_command_at("HTTP::uri"),
+            "iRules declares HTTP::uri",
+        );
+        assert!(
+            !crate::registry_for_dialect("tcl9.0").declares_command_at("HTTP::uri"),
+            "plain Tcl does not",
+        );
     }
 }

--- a/rust/tcl-syntax/src/glob.rs
+++ b/rust/tcl-syntax/src/glob.rs
@@ -37,9 +37,57 @@ pub fn string_match(pattern: &str, text: &str) -> bool {
     string_case_match(pattern, text, false)
 }
 
+/// Whether `pattern` contains no glob metacharacter, so
+/// [`string_match(pattern, text)`](string_match) is exactly `pattern == text`.
+///
+/// The metacharacters are the four [`match_one`] and the star loop act on —
+/// `*`, `?`, `[` and `\` — named here rather than at each caller so a change
+/// to the matcher's dialect cannot leave a "this is a plain name" test behind.
+/// (An unterminated `[` is still special: it makes the match depend on where
+/// both sides end, which is not string equality.)
+///
+/// Lets a caller that matches one pattern set against many names put the
+/// literal patterns in a hash set and glob-match only the rest — the shape
+/// [`crate::glob`]'s `namespace export` consumers need (issue #1297).
+#[must_use]
+pub fn is_literal(pattern: &str) -> bool {
+    !pattern.contains(['*', '?', '[', '\\'])
+}
+
 /// Tcl `string match ?-nocase? pattern text`.
+///
+/// Two allocation-free fast paths stand in front of [`do_match`], which needs
+/// random access with backtracking and so has to collect both sides into
+/// `Vec<char>` first. Both are answers `do_match` would reach anyway, proven
+/// equivalent over a pattern × text matrix by
+/// `fast_paths_agree_with_the_general_matcher`:
+///
+/// - `*` matches every string, including the empty one.
+/// - a pattern with no metacharacter ([`is_literal`]) is consumed one
+///   folded char per folded char and must end where the text does, which is
+///   exactly (folded) string equality.
+///
+/// They are here rather than at one caller because they are properties of the
+/// glob dialect, and because those two shapes dominate every consumer: `*` and
+/// a plain name are what `namespace export` / `namespace import` patterns
+/// almost always are. The workspace import walk alone called this ~5 M times
+/// to answer one `textDocument/references`, and the two `Vec<char>`
+/// allocations per call were ~1 s of it (issue #1297).
 #[must_use]
 pub fn string_case_match(pattern: &str, text: &str, nocase: bool) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    if is_literal(pattern) {
+        return if nocase {
+            pattern
+                .chars()
+                .map(|c| fold(c, true))
+                .eq(text.chars().map(|c| fold(c, true)))
+        } else {
+            pattern == text
+        };
+    }
     let p: Vec<char> = pattern.chars().collect();
     let s: Vec<char> = text.chars().collect();
     do_match(&p, 0, &s, 0, nocase)
@@ -269,6 +317,67 @@ mod tests {
         // member match (the old recursion's run-to-`]` skip of the `-`).
         assert!(string_match("[ab-", "a"));
         assert!(!string_match("[ab-", "aa"));
+    }
+
+    /// Issue #1297: [`string_case_match`]'s two allocation-free fast paths
+    /// (`*`, and a metacharacter-free pattern) must answer exactly what the
+    /// general matcher would. Checked over a full pattern × text matrix, in
+    /// both case modes, against [`do_match`] called directly — so a future
+    /// change to either side that makes them disagree fails here rather than
+    /// silently changing what `namespace export` covers.
+    ///
+    /// The matrix deliberately mixes the shapes the fast paths claim (`*`, a
+    /// plain name, the empty pattern, non-ASCII, case pairs) with ones they
+    /// must decline to (`*x`, `?`, `[ab]`, an escaped literal, an
+    /// unterminated class), so the test also pins that [`is_literal`] is not
+    /// over-claiming.
+    #[test]
+    fn fast_paths_agree_with_the_general_matcher() {
+        let patterns = [
+            "*", "", "Resistor", "resistor", "R", "*x", "x*", "a*b", "?", "a?", "[ab]", "[abc",
+            "\\*", "\\a", "p[ab]", "Ω", "ΩΩ", "a\\", "**", "*R*",
+        ];
+        let texts = [
+            "", "*", "R", "Resistor", "resistor", "RESISTOR", "x", "ax", "ab", "a", "p a", "pa",
+            "Ω", "ω", "a\\", "\\", "aXb",
+        ];
+        for pattern in patterns {
+            for text in texts {
+                for nocase in [false, true] {
+                    let p: Vec<char> = pattern.chars().collect();
+                    let s: Vec<char> = text.chars().collect();
+                    let general = do_match(&p, 0, &s, 0, nocase);
+                    assert_eq!(
+                        string_case_match(pattern, text, nocase),
+                        general,
+                        "fast path disagreed: pattern={pattern:?} text={text:?} nocase={nocase}",
+                    );
+                }
+            }
+        }
+    }
+
+    /// [`is_literal`] must claim a pattern only when `string_match` against it
+    /// really is string equality — the property the fast path above rests on.
+    #[test]
+    fn is_literal_claims_exactly_the_patterns_that_are_string_equality() {
+        for pattern in ["", "R", "Resistor", "a b", "Ω", "-", "]", "{p}"] {
+            assert!(is_literal(pattern), "should be literal: {pattern:?}");
+            assert!(string_match(pattern, pattern), "{pattern:?}");
+        }
+        // Every metacharacter the matcher acts on disqualifies a pattern, and
+        // each of these really does match something other than itself.
+        for (pattern, other) in [
+            ("*", "anything"),
+            ("?", "z"),
+            ("[ab]", "a"),
+            ("\\*", "*"),
+            ("a*", "abc"),
+        ] {
+            assert!(!is_literal(pattern), "should not be literal: {pattern:?}");
+            assert!(string_match(pattern, other), "{pattern:?} vs {other:?}");
+            assert_ne!(pattern, other);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **#1297** — `textDocument/references` and `codeLens/resolve` took **29 s** on the #1181 corpus. The cross-document wildcard-import walk asked "had this `namespace export` run when that import ran?" per (invocation × in-scope import × export row). None of that depends on the call being resolved, so the timeline half is now decided once per recorded import at index-build time (`ExportGate`), leaving a hash probe and a glob match on the per-call path. `defines_command` stopped re-walking every indexed proc, `RunOrder::alternatives` folded its three probes into one (the documented `package_entries.is_empty()` fast path never applied to a real project — every corpus repo has `package require`), and `glob::string_match` stopped heap-allocating two `Vec<char>` on each of ~5 M calls per settle. **29.00 s → 0.43 s**, and 0.00 s for subsequent requests.
- **#1301** *(found while measuring #1297; filed with repro, fixed here)* — `refresh_source_rehoming_locked` **never converged** on any workspace with a top-level `source b.tcl`, the ordinary way to write Tcl. Its work queue tested `recorded.get(uri) != Some(["::"])` while its store *removes* such an entry, so those documents were re-analysed and re-indexed on every round of every navigation request. Each re-index bumps the index generation, dropping **every** `Derived` memo — so the settled-target view rebuilt from scratch, ~1.0 s a time, on all 13 requests of a measured run. This is what made #1297's residual cost recur per-request rather than once.
- **#1298 / #1300** — the two bulk-retire paths cleared different sets of per-URI state. Both now go through one helper whose exhaustive destructuring of `Backend` makes forgetting a field a compile error.
- **#1302** *(found while measuring #1297; filed with repro, fixed here)* — the import-conflict gate consulted only workspace-declared procs, so an unforced `namespace import` of a namespace exporting `set` was treated as installed and every bare `set` in the workspace was filed as a reference to it. Real Tcl raises `can't import command "set": already exists`.
- **#1299** — no leak today, but the reason is an undocumented salsa detail. Pinned with one compile-time and three test-time guardrails plus a design note.

### Registry, not name lists

The #1302 predicate is registry data: `CommandRegistry::declares_command_at` answers *"does a fresh interpreter of this dialect hold a command at exactly this name"*, which is strictly narrower than `get`'s *"is this a spelling a call site may write"*. That distinction is load-bearing — `info commands ::+` is empty in a fresh interpreter and `+ 1 2` raises `invalid command name`, so exporting `+` and importing it into `::` genuinely binds, and a naive `get(…).is_some()` would have **broken a working import**. The consumer holds no knowledge of operators or `::tcl::mathop`; it asks the registry. The index records each document's analysed dialect so a mixed workspace (iRules beside plain Tcl) reads the right command table.

### Measurements

Release build, #1181 corpus — 8 `georgtree` repos under one workspace root, 113 `.tcl` files, `SpiceGenTcl` @ `b6ee79b5`, `tcl_tools` @ `6be5470f`. Same file, same position.

| request | before | after |
|---|--:|--:|
| `textDocument/references` (1st) | 29.00 s | **0.43 s** |
| `textDocument/references` (2nd+) | 29.00 s | **0.00 s** |
| `codeLens/resolve` | 29.30 s | **0.43 s** |

The second row is #1301: before, the memo was invalidated between every request; the corpus shows 13 rebuilds for 13 requests, now 2.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
make rust-check                              # fmt + clippy + all xtask drift gates — green
cargo test --workspace --all-features        # exit 0, all green
cargo clippy --workspace --all-targets --all-features   # clean
```

**No new `#[allow(...)]` anywhere.** Two clippy findings in this diff (`too_many_lines` on `RunOrder::build`, `format_push_string` in a test helper) were fixed by extracting a named function and using `writeln!`, not silenced.

**Oracle.** Built tclsh 9.0.4 from `core-9-0-4` and used 8.6.14 alongside it. Every behavioural claim is oracle-verified per row: the unforced/`-force` import conflict, the sub-namespace target, the operator spellings, `info commands` for the fresh-interpreter command table, and the `::tcl::mathop` ensemble. The glob matcher was diffed against tclsh 9.0.4 over **960 pattern × text cases with zero mismatches**.

**Tests are not vacuous — each was confirmed to fail with its fix reverted:**

| guard | reverted | fixed |
|---|---|---|
| #1302 matrix (7 tests) | exactly 3 fail; the 4 FP/TN guards correctly pass both ways | all pass |
| #1297 perf guard | 7.59 s (bound 2 s) | 81 ms |
| #1298/#1300 (6 tests) | 5 fail; the FP guard passes both ways | all pass |
| #1301 (3 tests) | all 3 fail | all pass |
| #1299 interned-GC | zero reuse events, growth exactly linear | bounded |

The #1299 break-the-invariant experiment is kept as a *permanent* control test, so the primary assertion cannot go vacuous. It also turned up that `memory_growth.rs` and `edit_memory.rs` computed their synthetic edit position as `body_span.start()` — the offset *of* the opening brace — so every "keystroke" landed outside the body and re-keyed nothing; those harnesses would have read flat whether or not a leak existed.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract?

Yes, one: #1302 changes what an unforced `namespace import` binds when the target namespace already holds a registry-declared command. The workspace tier now matches the single-document tier (`definition::resolve_called_proc`'s `has_builtin` gate) and C Tcl. Everything else is behaviour-preserving refactoring, held by the 1 878 pre-existing `tcl-lsp-core` tests.

- [ ] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`.

Not done — flagging rather than guessing at placement. The contract change is the import-conflict rule's "already exists" side, documented in full at `CommandRegistry::declares_command_at` with its oracle transcript and at both consumer sites. Happy to add the KCS note wherever you'd like it filed.

- [ ] If I added a new compiler KCS note, I linked it from both `docs/kcs/compiler/README.md` and `docs/kcs/README.md`

N/A — no new KCS note. `docs/design/rust/salsa-interned-gc.md` was added for #1299 and is linked from `docs/design/README.md`, which the `kcs-index-links` gate checks (green).

## Known limitations

- `declares_command_at` treats a package-provided command (`::csv::split`) as declared whether or not the script `package require`s it — the registry carries no "needs a `package require`" marker to gate on. Reaching that case means importing *into* a package's own namespace, so it is documented at the predicate rather than worked around.
- #1302's fix covers the glob and exact import paths. `workspace_command_exists_for_call` still takes a `has_builtin` flag computed by its caller in `tcl-lsp-server`, so the same fact is plumbed two ways; worth unifying separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVMsyKAqCqxAtjug8MTXYu

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVMsyKAqCqxAtjug8MTXYu)_