### PR TITLE
Index a namespace's wildcard imports by the names they admit (#1319)

### DIFF
--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -3946,9 +3946,7 @@ impl WorkspaceIndex {
         // unordered foreign ones, and among foreign ones the index's own
         // stable source order breaks the tie.
         imports
-            .iter()
-            .filter(|row| tcl_syntax::glob::string_match(&row.imp.tail_pattern, word))
-            .filter(|row| row.exported.covers(word))
+            .admitting(word)
             .filter(|row| {
                 let target = tcl_syntax::naming::qualify(ns, word);
                 row.imp.forced
@@ -4039,6 +4037,100 @@ struct GlobImportRow<'a> {
     registry: Option<&'static tcl_registry::CommandRegistry>,
 }
 
+/// Every wildcard import recorded for one importing namespace, indexed by the
+/// names its imports can actually admit.
+///
+/// [`WorkspaceIndex::import_hop`] used to scan every row in the namespace on
+/// every call, applying `string_match(tail_pattern, word)` and
+/// `ExportGate::covers(word)` to each. On the #1181 corpus that was 28 369
+/// calls scanning 3 987 739 rows — ~140 rows per call, and ~390 ms of the
+/// ~420 ms a `textDocument/references` cost after any edit (issue #1319).
+///
+/// Both of those filters depend only on the *word*, never on the call, so the
+/// admissible set per word is a build-time fact. A row whose gate exports
+/// nothing can admit no word at all and disappears from every lookup — which
+/// is most of them in practice, since a workspace typically imports several
+/// namespaces it has no `namespace export` records for (`::tcl::mathop`,
+/// `::tcltest`).
+#[derive(Debug, Default)]
+struct NamespaceImports<'a> {
+    /// The namespace's rows, in recorded order. [`Self::admitting`] yields
+    /// indices into this, ascending, so callers see exactly the subsequence a
+    /// full scan would have produced.
+    rows: Vec<GlobImportRow<'a>>,
+    /// Row indices keyed by a **literal** name that both the row's tail
+    /// pattern and its export gate admit.
+    by_name: rustc_hash::FxHashMap<&'a str, Vec<u32>>,
+    /// Rows whose export gate holds a glob pattern: any word may pass, so
+    /// these keep the per-word check.
+    glob_gated: Vec<u32>,
+    /// `-force` rows, for [`WildcardImportIndex::forced_shadow_at`] — which
+    /// can bypass the export gate entirely for an unobservable source
+    /// namespace, so it cannot use [`Self::by_name`].
+    forced: Vec<u32>,
+}
+
+impl<'a> NamespaceImports<'a> {
+    /// Index `rows` by the names they admit. Called once per namespace per
+    /// index build.
+    fn index(rows: Vec<GlobImportRow<'a>>) -> Self {
+        let mut by_name: rustc_hash::FxHashMap<&'a str, Vec<u32>> =
+            rustc_hash::FxHashMap::default();
+        let mut glob_gated = Vec::new();
+        let mut forced = Vec::new();
+        for (i, row) in rows.iter().enumerate() {
+            let idx = u32::try_from(i).unwrap_or(u32::MAX);
+            if row.imp.forced {
+                forced.push(idx);
+            }
+            if !row.exported.globs.is_empty() {
+                glob_gated.push(idx);
+            }
+            for name in &row.exported.literal {
+                // The tail pattern is the other half of the admission test,
+                // and it is decidable here because the name is known.
+                if tcl_syntax::glob::string_match(&row.imp.tail_pattern, name) {
+                    by_name.entry(name).or_default().push(idx);
+                }
+            }
+        }
+        Self {
+            rows,
+            by_name,
+            glob_gated,
+            forced,
+        }
+    }
+
+    /// The rows whose tail pattern **and** export gate both admit `word`, in
+    /// recorded order — the exact subsequence
+    /// `rows.iter().filter(tail matches).filter(gate covers)` would yield.
+    ///
+    /// Order matters: `import_hop` breaks ties on the position within this
+    /// sequence, so producing it out of order would change which import wins.
+    fn admitting(&self, word: &str) -> impl Iterator<Item = &GlobImportRow<'a>> {
+        let mut idx: Vec<u32> = self
+            .by_name
+            .get(word)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .to_vec();
+        idx.extend(self.glob_gated.iter().copied().filter(|&i| {
+            let row = &self.rows[i as usize];
+            tcl_syntax::glob::string_match(&row.imp.tail_pattern, word) && row.exported.covers(word)
+        }));
+        // A row carrying both literal and glob patterns can arrive twice.
+        idx.sort_unstable();
+        idx.dedup();
+        idx.into_iter().map(|i| &self.rows[i as usize])
+    }
+
+    /// The `-force` rows, in recorded order.
+    fn forced_rows(&self) -> impl Iterator<Item = &GlobImportRow<'a>> {
+        self.forced.iter().map(|&i| &self.rows[i as usize])
+    }
+}
+
 impl<'a> GlobImportRow<'a> {
     fn site(&self) -> ImportSite<'a> {
         self.imp.site()
@@ -4089,7 +4181,7 @@ impl<'a> ExactImportRow<'a> {
 /// than re-scanned per call site — see
 /// [`WorkspaceIndex::resolve_wildcard_import_indexed`]'s doc for why.
 struct WildcardImportIndex<'a> {
-    imports_by_ns: std::collections::HashMap<&'a str, Vec<GlobImportRow<'a>>>,
+    imports_by_ns: std::collections::HashMap<&'a str, NamespaceImports<'a>>,
     /// Every **exact** `namespace import` link, by importing namespace. The
     /// exact-pattern twin of [`Self::imports_by_ns`]: the two tables are one
     /// command table as far as the import-conflict rule is concerned, which is
@@ -4127,10 +4219,10 @@ impl<'a> WildcardImportIndex<'a> {
             exports_by_ns.entry(exp.ns.as_str()).or_default().push(exp);
         }
         let order = index.run_order();
-        let mut imports_by_ns: std::collections::HashMap<&str, Vec<GlobImportRow<'a>>> =
+        let mut rows_by_ns: std::collections::HashMap<&str, Vec<GlobImportRow<'a>>> =
             std::collections::HashMap::new();
         for imp in index.glob_imports() {
-            imports_by_ns
+            rows_by_ns
                 .entry(imp.ns.as_str())
                 .or_default()
                 .push(GlobImportRow {
@@ -4201,6 +4293,10 @@ impl<'a> WildcardImportIndex<'a> {
                 .or_default()
                 .push((uri, at));
         }
+        let imports_by_ns = rows_by_ns
+            .into_iter()
+            .map(|(ns, rows)| (ns, NamespaceImports::index(rows)))
+            .collect();
         Self {
             imports_by_ns,
             exact_by_ns,
@@ -4230,9 +4326,11 @@ impl<'a> WildcardImportIndex<'a> {
     /// worse than answering nothing.
     fn forced_shadow_at(&self, ns: &str, name: &str, call: CallSite<'_>) -> bool {
         self.imports_by_ns.get(ns).is_some_and(|imports| {
-            imports.iter().any(|row| {
-                row.imp.forced
-                    && tcl_syntax::glob::string_match(&row.imp.tail_pattern, name)
+            // Only the `-force` rows: this is the one path whose export gate
+            // can be bypassed (an unobservable source namespace), so it cannot
+            // read `NamespaceImports::by_name`.
+            imports.forced_rows().any(|row| {
+                tcl_syntax::glob::string_match(&row.imp.tail_pattern, name)
                     && (!self
                         .observable
                         .contains(row.imp.source_ns.trim_start_matches("::"))
@@ -4449,13 +4547,21 @@ impl<'a> WildcardImportIndex<'a> {
             at: site.at,
             enclosing_body: site.enclosing_body,
         };
+        // `admitting` applies exactly the two tests this arm needs — the tail
+        // pattern covers `name`, and the export gate admits it — as a probe
+        // rather than a scan of the namespace. Re-scanning here was what
+        // remained of issue #1319 once `import_hop` stopped scanning: this runs
+        // once per row `import_hop` admitted, so the two multiplied.
+        //
+        // `other_exported.covers(name)` stays in the conjunction below: it is
+        // redundant for the glob arm now, but the exact arm chained onto it is
+        // *not* filtered by the gate, so the test still has work to do there.
         let mut earlier = self
             .imports_by_ns
             .get(ns)
-            .map(Vec::as_slice)
+            .map(|imports| imports.admitting(name).collect::<Vec<_>>())
             .unwrap_or_default()
-            .iter()
-            .filter(|other| tcl_syntax::glob::string_match(&other.imp.tail_pattern, name))
+            .into_iter()
             .map(|other| (other.imp.source_ns.as_str(), other.site(), &other.exported))
             .chain(
                 self.exact_by_ns
@@ -9085,5 +9191,118 @@ mod tests {
             irules.linked_invocations_of("::Mine::uri", "").is_empty(),
             "f5-irules declares ::HTTP::uri, so the unforced import installs nothing",
         );
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #1319 — `import_hop` must not scan a namespace's whole import
+    // list per call.
+    //
+    // Both of its first two filters — the tail pattern covers the word, and
+    // the export gate admits it — depend only on the word, so the admissible
+    // set is a build-time fact (`NamespaceImports`). On the #1181 corpus the
+    // scan was 28 369 calls over 3 987 739 rows, ~390 ms of the ~420 ms a
+    // `textDocument/references` cost after any edit.
+    //
+    // The risk in indexing it is order: `import_hop` breaks ties on the
+    // position *within the filtered sequence*, so a reordering — or a
+    // duplicate from a row carrying both literal and glob export patterns —
+    // would silently change which import wins. These pin that.
+    // ---------------------------------------------------------------------
+
+    /// The admitted sequence must be exactly what a full scan would yield,
+    /// in the same order, over every shape the gate can take: literal-only,
+    /// glob-only, both at once (the duplicate hazard), and a tail pattern
+    /// that excludes a name the gate would otherwise admit.
+    #[test]
+    fn admitting_matches_a_full_scan_in_order() {
+        let lib = analyse(
+            "namespace eval ::Lib {\n    proc alpha {} {}\n    proc beta {} {}\n    proc gamma {} {}\n    namespace export alpha beta gamma\n}\n",
+        );
+        let globby = analyse(
+            "namespace eval ::Glob {\n    proc alpha {} {}\n    proc beta {} {}\n    namespace export a*\n}\n",
+        );
+        let app = analyse(
+            "namespace import ::Lib::*\nnamespace import ::Glob::*\nnamespace import ::Lib::b*\nalpha\nbeta\ngamma\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///lib.tcl", &lib),
+            ("file:///glob.tcl", &globby),
+            ("file:///app.tcl", &app),
+        ]);
+        let wci = WildcardImportIndex::build(&index);
+        let imports = wci
+            .imports_by_ns
+            .get("::")
+            .expect("the three imports are all at global level");
+        for word in ["alpha", "beta", "gamma", "delta", "", "a", "*"] {
+            let scanned: Vec<_> = imports
+                .rows
+                .iter()
+                .filter(|row| tcl_syntax::glob::string_match(&row.imp.tail_pattern, word))
+                .filter(|row| row.exported.covers(word))
+                .map(|row| (row.imp.uri.as_str(), row.imp.at))
+                .collect();
+            let admitted: Vec<_> = imports
+                .admitting(word)
+                .map(|row| (row.imp.uri.as_str(), row.imp.at))
+                .collect();
+            assert_eq!(
+                admitted, scanned,
+                "admitting({word:?}) must equal the full scan, in order",
+            );
+        }
+    }
+
+    /// A row whose gate holds **both** a literal and a glob pattern is
+    /// reachable through both halves of the index and must still appear once.
+    /// A duplicate would shift every later row's tie-break position.
+    #[test]
+    fn a_row_indexed_twice_is_admitted_once() {
+        let lib = analyse(
+            "namespace eval ::Both {\n    proc alpha {} {}\n    namespace export alpha a*\n}\n",
+        );
+        let app = analyse("namespace import ::Both::*\nalpha\n");
+        let index =
+            WorkspaceIndex::from_documents([("file:///lib.tcl", &lib), ("file:///app.tcl", &app)]);
+        let wci = WildcardImportIndex::build(&index);
+        let imports = wci.imports_by_ns.get("::").expect("one global import");
+        assert_eq!(
+            imports.admitting("alpha").count(),
+            1,
+            "`alpha` matches both the literal and the `a*` pattern of one gate",
+        );
+    }
+
+    /// TP through the public answer: the indexed path still resolves a call
+    /// that only a wildcard import can reach. The perf guards below would be
+    /// happy with an index that admitted nothing at all.
+    #[test]
+    fn the_admission_index_still_resolves_a_wildcard_imported_call() {
+        let lib = analyse(
+            "namespace eval ::Lib {\n    proc helper {} {}\n    namespace export helper\n}\n",
+        );
+        let app = analyse("namespace import ::Lib::*\nhelper\n");
+        let index =
+            WorkspaceIndex::from_documents([("file:///lib.tcl", &lib), ("file:///app.tcl", &app)]);
+        assert_eq!(index.linked_invocations_of("::Lib::helper", "").len(), 1);
+    }
+
+    /// A gate that exports nothing admits nothing, so such rows drop out of
+    /// every lookup — the case that makes the index worth having, since a
+    /// workspace routinely imports namespaces it holds no exports for
+    /// (`::tcl::mathop`, `::tcltest`).
+    #[test]
+    fn an_import_of_an_unexporting_namespace_admits_no_word() {
+        let app = analyse("namespace import ::tcl::mathop::*\nset x 1\n+ 1 2\n");
+        let index = WorkspaceIndex::from_documents([("file:///app.tcl", &app)]);
+        let wci = WildcardImportIndex::build(&index);
+        let imports = wci.imports_by_ns.get("::").expect("one global import");
+        for word in ["set", "+", "puts", "anything"] {
+            assert_eq!(
+                imports.admitting(word).count(),
+                0,
+                "no export rows for ::tcl::mathop, so nothing is admissible",
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `textDocument/references` answered in 2.3 ms warm but **~420 ms** if any edit had landed since the last navigation — the ordinary type-then-navigate loop. Any edit drops the settled-target view, and the rebuild re-settles every invocation in the workspace.
- #1319 proposed caching that view per document. **Measuring first said otherwise**: of the ~420 ms, building the resolution environment is 1–2 ms and inserting into the target map is 2 ms. `settle_invocation` is 390 ms of it, and inside that `import_hop` made **28 369 calls scanning 3 987 739 rows** — ~140 per call — walking every import recorded for the namespace and applying `string_match(tail_pattern, word)` and `ExportGate::covers(word)` to each.
- Both tests depend only on the **word**, never on the call, so the admissible set is a build-time fact. `NamespaceImports` indexes each namespace's rows by the literal names both tests admit; rows whose gate holds a glob pattern keep the per-word check in a small list; `-force` rows are kept separately for `forced_shadow_at`, the one path whose export gate can be bypassed (an unobservable source namespace) and so cannot read the name index. A row whose gate exports nothing admits no word and drops out of every lookup — most of them, since a workspace routinely imports namespaces it holds no export records for (`::tcl::mathop`, `::tcltest`).
- That took row scanning to ~1 ms and the total to 317 ms, because **`conflicting_alias_at` re-scanned the same namespace once per row `import_hop` had admitted**, so the two multiplied. Its filter is the same pair of tests, so it reads the same index.

No behaviour change — this is a data-structure change to a walk whose semantics the #1297 and #1302 matrices already pin.

### Measurements

Release build, #1181 corpus — 8 `georgtree` repos under one root, 113 `.tcl` files. Same file, same position.

| | before | after |
|---|--:|--:|
| `references` during an edit session (median, n=12) | 419.6 ms | **136.1 ms** |
| `references` rebuild after an edit (max of 5) | 379.9 ms | 127.5 ms |
| edit throughput | 33.9 ms/edit | 23.0 ms/edit |
| `references` warm | 2.3 ms | 2.1 ms |

Memory unchanged and still flat: per-200-edit RSS growth `+4.10, +0.01, +0.07, 0.00, +0.28, 0.00` MiB over a 1200-edit session, 0.5 KiB/edit in the late half, plateauing at ~161 MiB.

### The hazard was ordering, not admission

`import_hop` breaks ties on the position *within the filtered sequence*:

```rust
.enumerate()
.max_by_key(|(seq, row)| (row.imp.uri == call.uri, row.imp.at, *seq))
```

So a reorder — or a duplicate from a row carrying **both** a literal and a glob export pattern — would silently change which import wins. `admitting` yields ascending, deduplicated row indices, which is exactly the subsequence a full scan produced.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
make rust-check                              # fmt + clippy + all drift gates — green
cargo test --workspace --all-features        # CARGO EXIT=0, 326 suites green
```

A note on that second line: an earlier run of it reported "exit 0" that actually came from a trailing `echo` in the pipeline, and the run after that died with `ld terminated with signal 7 [Bus error]` because the build disk filled. `AGENTS.md` treats any result after an ENOSPC event as untrustworthy, so the figure above is from a clean rebuild with `target/debug` removed, capturing cargo's own status.

**Tests, and their non-vacuity.** Four new tests in `tcl-lsp-core`:

| test | guards |
|---|---|
| `admitting_matches_a_full_scan_in_order` | equality with a live full scan, element-for-element, over 7 words × 4 gate shapes — literal-only, glob-only, both at once, and a tail pattern that excludes a name the gate would admit |
| `a_row_indexed_twice_is_admitted_once` | the duplicate hazard; **removing the dedup makes it fail 2 against 1** |
| `the_admission_index_still_resolves_a_wildcard_imported_call` | the public answer — the perf guards would be happy with an index that admitted nothing |
| `an_import_of_an_unexporting_namespace_admits_no_word` | the case that makes the index worth having |

1900 `tcl-lsp-core` tests pass, including the #1297 and #1302 matrices covering this walk's semantics.

No new `#[allow(...)]`.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract?

No. `admitting` is asserted equal to the scan it replaces, element-for-element and in order, so every resolution answer is unchanged. The contract this walk implements is documented at `kcs-qa-when-does-a-cross-file-namespace-import-count.md` and is untouched.

- [ ] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`.

N/A — no contract change.

- [ ] If I added a new compiler KCS note, I linked it from both `docs/kcs/compiler/README.md` and `docs/kcs/README.md`

N/A — no new note.

## Remaining

136 ms is a 3.1× improvement, not a fix to O(changed documents). The rebuild still re-settles the whole workspace on any edit; what is gone is the per-call scan inside it. If that residual cost matters, the per-document memoisation #1319 originally proposed is still available — but it needs an environment fingerprint that stays correct when an edit shifts the byte offsets of declarations below it, which is why it is not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVMsyKAqCqxAtjug8MTXYu