### PR TITLE
fix(1334): stop a slow client wedging the whole stdio session

### DIFF
--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -31,6 +31,7 @@
 #![forbid(unsafe_code)]
 
 pub mod config_ini;
+pub mod stdio_pump;
 pub mod uri_norm;
 
 use std::collections::{HashMap, HashSet, VecDeque};

--- a/rust/tcl-lsp-server/src/main.rs
+++ b/rust/tcl-lsp-server/src/main.rs
@@ -27,6 +27,7 @@
 #![forbid(unsafe_code)]
 
 use tcl_lsp_server::Backend;
+use tcl_lsp_server::stdio_pump;
 use tcl_lsp_server::uri_norm::normalise_uris_in_params;
 use tower::ServiceExt as _;
 use tower_lsp_server::jsonrpc::{Request, Response};
@@ -128,7 +129,17 @@ fn main() {
 
 async fn serve() {
     let stdin = tokio::io::stdin();
-    let stdout = tokio::io::stdout();
+    // INVARIANT (no wedged sessions): the transport's write half must never be
+    // the reason its read half stops. `tower-lsp-server` 0.23 joins
+    // `read_input`, `process_server_tasks` and `print_output` on one task,
+    // chained by bounded channels, so a client that stops draining stdout
+    // seizes the chain all the way back to the only thing reading stdin — and
+    // a server that has stopped reading stdin makes the client block in
+    // `write()`, which is why it never resumes draining stdout. That is the
+    // 8h45m hang in issue #1334, and the server-wide unresponsiveness in
+    // #1294. `stdio_pump::pump` decouples the two halves; its module docs
+    // carry the full derivation and the reason the queue has to be unbounded.
+    let (stdout, stdout_drained) = stdio_pump::pump(tokio::io::stdout());
     let (service, socket) = LspService::new(Backend::new);
     // Wrap the service so every incoming message passes through the URI
     // canonicalisation shim (a no-op for a conforming client) and every
@@ -137,27 +148,34 @@ async fn serve() {
     let service = service
         .map_request(normalise_request_uris)
         .map_response(|resp: Option<Response>| resp.map(inject_type_hierarchy_provider));
-    // INVARIANT (no lost diagnostics under a slow client): the diagnostics
-    // delivery path relies on this transport being *bounded and
-    // backpressured*. `tower-lsp-server` 0.23 gives the `Client` a bounded
+    // INVARIANT (no lost and no reordered diagnostics under a slow client):
+    // the delivery path needs outbound messages to be *ordered* and *never
+    // dropped*. `tower-lsp-server` 0.23 gives the `Client` a bounded
     // `futures::mpsc::channel(1)` drained by a single `.forward(FramedWrite(
-    // stdout))`, so a `client.publish_diagnostics(..).await` suspends when the
-    // channel is full and resolves only once the message is durably queued —
-    // it never `try_send`s (drop-on-full) and never buffers unboundedly. That
-    // awaited backpressure *is* the "wait for the buffer to drain" behaviour; a
-    // burst of publishes to a slow client is throttled, not lost.
+    // stdout))`, so a `client.publish_diagnostics(..).await` resolves only
+    // once the message is durably queued — it never `try_send`s
+    // (drop-on-full). Behind that, `stdio_pump` keeps a single FIFO queue
+    // drained by a single writer task, so ordering and no-drop both hold end
+    // to end; what it deliberately does not do is make a slow client stall the
+    // producer, because that coupling is what deadlocked the session (#1334).
     //
     // Two things must not silently break this — re-audit the whole delivery
     // path (`deliver_diagnostics`, `deliver_fast_tier_if_current`,
     // `publish_diagnostics_result`) if either changes:
-    //   1. Swapping `tower-lsp-server` for a build whose client channel is
-    //      unbounded or uses `try_send` — outbound would then grow without
-    //      bound or drop under load. The dep is version-pinned in `Cargo.toml`;
-    //      treat an upgrade that touches its transport as a delivery-review gate.
+    //   1. Swapping `tower-lsp-server` for a build whose client channel uses
+    //      `try_send`, or reordering the outbound path so more than one task
+    //      writes to the pump — outbound would then drop or interleave. The dep
+    //      is version-pinned in `Cargo.toml`; treat an upgrade that touches its
+    //      transport as a delivery-review gate.
     //   2. Making any diagnostics publish fire-and-forget (e.g. wrapping it in a
     //      detached `tokio::spawn` to avoid holding the `documents` lock across
-    //      the send). That discards backpressure: publishes would reorder and
-    //      accumulate unboundedly, and a state-gated/disconnected drop would go
-    //      unnoticed. Delivery MUST stay an inline `.await`.
+    //      the send). Concurrent publishes would reorder, and a
+    //      state-gated/disconnected drop would go unnoticed. Delivery MUST stay
+    //      an inline `.await`.
     Server::new(stdin, stdout, socket).serve(service).await;
+    // `serve` has returned, so the transport's `FramedWrite` — and with it the
+    // pump's sender — has been dropped, which is what lets the drain task
+    // finish. Awaiting it here is what stops a burst of diagnostics sitting in
+    // the queue from being lost to `main` returning out from under it.
+    let _ = stdout_drained.await;
 }

--- a/rust/tcl-lsp-server/src/stdio_pump.rs
+++ b/rust/tcl-lsp-server/src/stdio_pump.rs
@@ -1,0 +1,337 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! An outbound-stdout adapter that keeps the server reading stdin no matter
+//! how slowly the client reads stdout — the fix for issue #1334.
+//!
+//! # The deadlock this exists to break
+//!
+//! `tower_lsp_server::Server::serve` joins three futures on one task, chained
+//! by bounded channels:
+//!
+//! ```text
+//! read_input ──server_tasks_tx(100)──▶ process_server_tasks
+//!                                            │
+//!                                     responses_tx(0)
+//!                                            ▼
+//!                                       print_output ──▶ FramedWrite(stdout)
+//! ```
+//!
+//! Every link is bounded, so backpressure propagates all the way back to
+//! `read_input`, which awaits `server_tasks_tx.send(..)`. When the client
+//! stops draining stdout the chain seizes in order: the framed write goes
+//! `Pending`, `responses_rx` (capacity 0) stops being drained,
+//! `process_server_tasks` stalls, the 100-slot task queue fills, and
+//! `read_input` — the *only* thing reading stdin — parks on a full channel.
+//!
+//! The server has now stopped reading stdin while doing no work. The client
+//! fills the 64 KiB stdin pipe, blocks in `write()`, and therefore never
+//! returns to draining stdout. Both processes sleep forever at 0% CPU, which
+//! is exactly the trace in #1334 (and, from the client's side, #1294).
+//!
+//! There is a second, tighter path to the same place: a handler suspended in
+//! `client.publish_diagnostics(..).await` is parked on the client socket's
+//! own `channel(1)`, which is *also* drained only by `print_output`. Four such
+//! handlers fill `buffer_unordered(DEFAULT_MAX_CONCURRENCY)` and the pipeline
+//! seizes without the 100-slot queue ever filling.
+//!
+//! # Why unbounded is the right shape here
+//!
+//! Both paths reduce to one property: the server cannot make progress reading
+//! stdin unless stdout is draining. Any bound on the outbound path preserves
+//! that coupling and merely changes how long the client must stall before the
+//! session wedges. Deadlock-freedom requires that outbound messages be
+//! absorbed without ever blocking the reader, and LSP does not permit dropping
+//! them, so the queue must be unbounded. This is the same shape
+//! `rust-analyzer`'s `lsp-server` uses: a dedicated writer with an unbounded
+//! queue in front of it.
+//!
+//! What the original bounded transport was protecting — **no dropped and no
+//! reordered diagnostics under a slow client** — is preserved exactly: a
+//! single FIFO channel drained by a single writer task keeps delivery ordered,
+//! and an unbounded channel never drops. What is given up is the throttling of
+//! a *producer* that outruns the client, which was never load-bearing for
+//! correctness and was the direct cause of the hang. The cost is memory, and
+//! it is observable: see [`BACKLOG_WARN_BYTES`].
+
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tokio::task::JoinHandle;
+
+/// Backlog at which the writer complains, once, on stderr.
+///
+/// Trading a deadlock for unbounded memory is only defensible if the trade is
+/// visible when it actually bites, so a client that has stopped reading leaves
+/// a trace rather than just a growing RSS. Sized well above any legitimate
+/// burst: a full workspace's diagnostics for the largest corpus member is
+/// under a megabyte, so reaching this means the client is not reading at all.
+pub const BACKLOG_WARN_BYTES: usize = 64 * 1024 * 1024;
+
+/// The write half handed to `tower_lsp_server::Server::new`.
+///
+/// `poll_write` never returns `Pending`: it moves the bytes into the queue and
+/// reports them written. That is the whole point — the transport's writer must
+/// never be the reason the reader stops.
+#[derive(Debug)]
+pub struct PumpedWriter {
+    /// `None` after `poll_shutdown`, which closes the channel and lets the
+    /// drain task finish.
+    tx: Option<UnboundedSender<Vec<u8>>>,
+    queued: Arc<AtomicUsize>,
+    warned: bool,
+}
+
+impl PumpedWriter {
+    /// Bytes accepted but not yet written to the real sink.
+    #[must_use]
+    pub fn backlog(&self) -> usize {
+        self.queued.load(Ordering::Relaxed)
+    }
+}
+
+impl AsyncWrite for PumpedWriter {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let Some(tx) = self.tx.as_ref() else {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "stdout pump already shut down",
+            )));
+        };
+        // A send failure means the drain task is gone, which happens when the
+        // real stdout errored — the client went away. Report it as a write
+        // error so the transport tears the session down as it would have.
+        if tx.send(buf.to_vec()).is_err() {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "stdout pump drained task has stopped",
+            )));
+        }
+        let queued = self.queued.fetch_add(buf.len(), Ordering::Relaxed) + buf.len();
+        if queued >= BACKLOG_WARN_BYTES && !self.warned {
+            self.warned = true;
+            eprintln!(
+                "tcl-lsp-server: {queued} bytes of LSP output are queued — the client has stopped \
+                 reading stdout. Output is being buffered rather than blocking the server (#1334)."
+            );
+        }
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    /// Always ready.
+    ///
+    /// This does *not* mean the bytes have reached the client, and that is
+    /// deliberate: `FramedWrite` flushes after each message, so a flush that
+    /// waited for the client would reintroduce precisely the coupling this
+    /// type removes. Durability is the drain task's job, and it flushes
+    /// whenever the queue empties, so an idle server has always flushed.
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        // Dropping the sender is what tells the drain task to flush and exit.
+        self.tx = None;
+        Poll::Ready(Ok(()))
+    }
+}
+
+/// Wrap `sink` in a queue drained by a dedicated task.
+///
+/// Returns the writer to hand to the transport and the drain task's handle.
+/// The caller must await the handle *after* the transport has returned (which
+/// drops the writer, closing the queue), or buffered output can be lost when
+/// the process exits — an `exit` notification arriving right behind a burst of
+/// diagnostics is the realistic case.
+pub fn pump<W>(sink: W) -> (PumpedWriter, JoinHandle<()>)
+where
+    W: AsyncWrite + Unpin + Send + 'static,
+{
+    let (tx, rx) = mpsc::unbounded_channel();
+    let queued = Arc::new(AtomicUsize::new(0));
+    let handle = tokio::spawn(drain(rx, sink, Arc::clone(&queued)));
+    (
+        PumpedWriter {
+            tx: Some(tx),
+            queued,
+            warned: false,
+        },
+        handle,
+    )
+}
+
+/// Write queued chunks to the real sink, in order, until the queue closes.
+async fn drain<W>(mut rx: UnboundedReceiver<Vec<u8>>, mut sink: W, queued: Arc<AtomicUsize>)
+where
+    W: AsyncWrite + Unpin,
+{
+    while let Some(chunk) = rx.recv().await {
+        let len = chunk.len();
+        let wrote = sink.write_all(&chunk).await;
+        queued.fetch_sub(len, Ordering::Relaxed);
+        if wrote.is_err() {
+            // The client's end is gone. Nothing left to deliver to; dropping
+            // `rx` makes subsequent `poll_write`s report a broken pipe, which
+            // is how the transport learns the session is over.
+            return;
+        }
+        // Coalesce flushes under load, but never leave a message sitting in
+        // the buffer once there is nothing behind it — that would look to the
+        // client exactly like the hang this module exists to prevent.
+        if rx.is_empty() && sink.flush().await.is_err() {
+            return;
+        }
+    }
+    let _ = sink.flush().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    /// A sink that never accepts anything, modelling a client that has stopped
+    /// reading stdout.
+    #[derive(Debug, Default)]
+    struct StalledSink;
+
+    impl AsyncWrite for StalledSink {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            _: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Pending
+        }
+        fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Pending
+        }
+        fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Pending
+        }
+    }
+
+    /// A sink that records everything written to it.
+    #[derive(Debug, Clone, Default)]
+    struct RecordingSink(Arc<Mutex<Vec<u8>>>);
+
+    impl AsyncWrite for RecordingSink {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Poll::Ready(Ok(buf.len()))
+        }
+        fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+        fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    /// The core property: writes complete even when the sink never accepts a
+    /// byte. Without this, `FramedWrite` returns `Pending` and the whole
+    /// transport chain seizes back to the stdin reader.
+    #[tokio::test]
+    async fn writes_complete_while_the_sink_is_stalled() {
+        let (mut writer, _drain) = pump(StalledSink);
+        for i in 0..1_000u32 {
+            writer
+                .write_all(&i.to_le_bytes())
+                .await
+                .expect("write must not block on a stalled sink");
+        }
+        writer.flush().await.expect("flush must not block either");
+        assert_eq!(writer.backlog(), 4_000, "nothing should have been written");
+    }
+
+    /// Ordering and completeness — the properties the bounded transport was
+    /// there to guarantee, which must survive the change.
+    #[tokio::test]
+    async fn everything_arrives_in_order() {
+        let sink = RecordingSink::default();
+        let seen = Arc::clone(&sink.0);
+        let (mut writer, drained) = pump(sink);
+
+        let mut expected = Vec::new();
+        for i in 0..1_000u32 {
+            let chunk = format!("msg{i};");
+            expected.extend_from_slice(chunk.as_bytes());
+            writer.write_all(chunk.as_bytes()).await.unwrap();
+        }
+        writer.shutdown().await.unwrap();
+        drop(writer);
+        drained.await.unwrap();
+
+        assert_eq!(*seen.lock().unwrap(), expected);
+    }
+
+    /// A dead client must surface as a write error, not a silent stall — the
+    /// transport relies on that to tear the session down.
+    #[tokio::test]
+    async fn a_failed_sink_becomes_a_write_error() {
+        #[derive(Debug)]
+        struct FailingSink;
+        impl AsyncWrite for FailingSink {
+            fn poll_write(
+                self: Pin<&mut Self>,
+                _: &mut Context<'_>,
+                _: &[u8],
+            ) -> Poll<io::Result<usize>> {
+                Poll::Ready(Err(io::Error::from(io::ErrorKind::BrokenPipe)))
+            }
+            fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+                Poll::Ready(Ok(()))
+            }
+            fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+                Poll::Ready(Ok(()))
+            }
+        }
+
+        let (mut writer, _drain) = pump(FailingSink);
+        // The first write is absorbed by the queue; the drain task then fails
+        // and closes it, so a later write reports the broken pipe.
+        writer.write_all(b"first").await.unwrap();
+        let mut err = None;
+        for _ in 0..100 {
+            tokio::task::yield_now().await;
+            if let Err(e) = writer.write_all(b"next").await {
+                err = Some(e);
+                break;
+            }
+        }
+        assert_eq!(
+            err.expect("a dead sink must eventually surface as a write error")
+                .kind(),
+            io::ErrorKind::BrokenPipe
+        );
+    }
+}

--- a/rust/tcl-lsp-server/src/stdio_pump.rs
+++ b/rust/tcl-lsp-server/src/stdio_pump.rs
@@ -122,16 +122,26 @@ impl AsyncWrite for PumpedWriter {
                 "stdout pump already shut down",
             )));
         };
+        // Count the bytes *before* handing them over. The drain task subtracts
+        // as soon as it has written a chunk, and it runs on another thread, so
+        // adding afterwards leaves a window where the subtraction lands first
+        // and wraps the counter — after which this arithmetic overflows and
+        // panics the transport future, taking the whole server down. Ordering
+        // the accounting this way makes the counter monotone by construction.
+        let queued = self
+            .queued
+            .fetch_add(buf.len(), Ordering::Relaxed)
+            .saturating_add(buf.len());
         // A send failure means the drain task is gone, which happens when the
         // real stdout errored — the client went away. Report it as a write
         // error so the transport tears the session down as it would have.
         if tx.send(buf.to_vec()).is_err() {
+            self.queued.fetch_sub(buf.len(), Ordering::Relaxed);
             return Poll::Ready(Err(io::Error::new(
                 io::ErrorKind::BrokenPipe,
                 "stdout pump drained task has stopped",
             )));
         }
-        let queued = self.queued.fetch_add(buf.len(), Ordering::Relaxed) + buf.len();
         if queued >= BACKLOG_WARN_BYTES && !self.warned {
             self.warned = true;
             eprintln!(
@@ -255,6 +265,46 @@ mod tests {
         fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
             Poll::Ready(Ok(()))
         }
+    }
+
+    /// The backlog accounting stays sane while the drain task runs
+    /// concurrently: writer and drain touch the same counter from different
+    /// threads, and it must not wrap.
+    ///
+    /// What this test is *not*: a regression test for the count-then-send
+    /// ordering in `poll_write`. That bug — accounting after handing the chunk
+    /// over, letting the drain's subtraction land first, wrapping the counter
+    /// and overflow-panicking the transport future — was measured against this
+    /// test and it does **not** catch it: the window is a few instructions
+    /// wide and was not reachable in 3×20,000 iterations, with or without the
+    /// yields. The e2e suite is what caught it, and the guarantee comes from
+    /// the ordering itself being monotone by construction. Do not treat a pass
+    /// here as cover for changing that ordering.
+    ///
+    /// `multi_thread` is still required for the concurrency this *does* check:
+    /// on the default current-thread runtime the drain cannot run at all while
+    /// the writer is running.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn the_backlog_counter_never_wraps_against_a_fast_drain() {
+        let sink = RecordingSink::default();
+        let (mut writer, drained) = pump(sink);
+        for _ in 0..20_000 {
+            writer.write_all(b"some outbound bytes").await.unwrap();
+            // Hand the scheduler an opening for the drain task between every
+            // write, so writer and drain stay interleaved rather than the
+            // writer running away with the queue.
+            tokio::task::yield_now().await;
+            // A wrapped counter shows up as an absurd backlog long before it
+            // reaches the arithmetic that panics.
+            assert!(
+                writer.backlog() < BACKLOG_WARN_BYTES,
+                "backlog wrapped: {}",
+                writer.backlog()
+            );
+        }
+        writer.shutdown().await.unwrap();
+        drop(writer);
+        drained.await.unwrap();
     }
 
     /// The core property: writes complete even when the sink never accepts a

--- a/rust/tcl-lsp-server/tests/stdio_deadlock.rs
+++ b/rust/tcl-lsp-server/tests/stdio_deadlock.rs
@@ -1,0 +1,194 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Regression test for the stdio deadlock in issue #1334 (client side: #1294).
+//!
+//! Drives the real `tower_lsp_server::Server` transport against a stdout that
+//! never accepts a byte — a client that has stopped reading — and asserts the
+//! server keeps draining stdin anyway. The control case runs the same traffic
+//! straight at the stalled sink and shows the transport wedging on its own,
+//! which is what makes the assertion meaningful rather than vacuous.
+
+use std::convert::Infallible;
+use std::future::{Ready, ready};
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::{Context, Poll};
+
+use futures_util::{sink, stream};
+use tokio::io::AsyncRead;
+use tower::Service;
+use tower_lsp_server::jsonrpc::{Request, Response};
+use tower_lsp_server::{Loopback, Server};
+
+use tcl_lsp_server::stdio_pump;
+
+/// Requests fed to the server. Comfortably past both bounds in the transport
+/// that can seize: `DEFAULT_MAX_CONCURRENCY` (4) and `MESSAGE_QUEUE_SIZE`
+/// (100).
+const REQUESTS: usize = 400;
+
+/// How long a healthy server gets to drain `REQUESTS` messages.
+const DRAIN_BUDGET: std::time::Duration = std::time::Duration::from_secs(10);
+
+// ---------------------------------------------------------------- test doubles
+
+/// A stdout that never accepts anything: the client has stopped reading.
+#[derive(Debug, Default)]
+struct StalledSink;
+
+impl tokio::io::AsyncWrite for StalledSink {
+    fn poll_write(self: Pin<&mut Self>, _: &mut Context<'_>, _: &[u8]) -> Poll<io::Result<usize>> {
+        Poll::Pending
+    }
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Pending
+    }
+    fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Pending
+    }
+}
+
+/// A stdin that yields `payload` once and then stays pending, modelling a
+/// client that has sent a burst and is still connected. If this returned EOF
+/// the server would shut down cleanly and the deadlock could not be observed.
+#[derive(Debug)]
+struct BurstThenIdle(Vec<u8>);
+
+impl AsyncRead for BurstThenIdle {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if self.0.is_empty() {
+            return Poll::Pending;
+        }
+        let n = buf.remaining().min(self.0.len());
+        let rest = self.0.split_off(n);
+        buf.put_slice(&self.0);
+        self.0 = rest;
+        Poll::Ready(Ok(()))
+    }
+}
+
+/// Counts how many requests actually reached the service — i.e. how much of
+/// stdin the server managed to read.
+#[derive(Debug, Clone)]
+struct CountingService(Arc<AtomicUsize>);
+
+impl Service<Request> for CountingService {
+    type Response = Option<Response>;
+    type Error = Infallible;
+    type Future = Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        let (_method, id, _params) = req.into_parts();
+        // Answering every request is what puts the outbound path under load;
+        // a service that returned `None` would never exercise the stall.
+        ready(Ok(id.map(|id| {
+            Response::from_parts(id, Ok(serde_json::Value::Null))
+        })))
+    }
+}
+
+/// No server-to-client traffic of its own; the outbound pressure in this test
+/// comes from responses.
+struct NoLoopback;
+
+impl Loopback for NoLoopback {
+    type RequestStream = stream::Pending<Request>;
+    type ResponseSink = sink::Drain<Response>;
+
+    fn split(self) -> (Self::RequestStream, Self::ResponseSink) {
+        (stream::pending(), sink::drain())
+    }
+}
+
+// ---------------------------------------------------------------- helpers
+
+/// `REQUESTS` framed JSON-RPC requests, back to back.
+fn burst() -> Vec<u8> {
+    let mut out = Vec::new();
+    for id in 0..REQUESTS {
+        let body =
+            format!(r#"{{"jsonrpc":"2.0","method":"textDocument/hover","params":{{}},"id":{id}}}"#);
+        out.extend_from_slice(format!("Content-Length: {}\r\n\r\n{body}", body.len()).as_bytes());
+    }
+    out
+}
+
+/// Run the transport until it drains `REQUESTS` or `DRAIN_BUDGET` expires,
+/// and report how many requests got through.
+async fn drained_within_budget<W>(stdout: W) -> usize
+where
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    let calls = Arc::new(AtomicUsize::new(0));
+    let service = CountingService(Arc::clone(&calls));
+    let served = Server::new(BurstThenIdle(burst()), stdout, NoLoopback).serve(service);
+    // `serve` never returns here — stdin stays open by construction — so the
+    // timeout is the exit path for both the healthy and the wedged case.
+    let _ = tokio::time::timeout(DRAIN_BUDGET, served).await;
+    calls.load(Ordering::SeqCst)
+}
+
+// ---------------------------------------------------------------- the tests
+
+/// The control. Writing straight at a stalled stdout, the transport's own
+/// bounded chain seizes back to the stdin reader and the server stops reading
+/// long before the burst is consumed. This is the bug in #1334; if this test
+/// ever starts draining all `REQUESTS`, the upstream transport has changed and
+/// the pump's justification needs re-checking.
+#[tokio::test]
+async fn unpumped_stdout_wedges_the_stdin_reader() {
+    let drained = drained_within_budget(StalledSink).await;
+    println!("raw transport drained {drained}/{REQUESTS} before wedging");
+    // A lower bound as well as an upper one: draining *nothing* would mean the
+    // test wedged for some unrelated reason and would pass for the wrong
+    // reason. Where exactly it stops is not worth pinning — it is the 100-slot
+    // task queue plus the four `buffer_unordered` slots plus whatever the
+    // framed reader had already buffered, which lands around 240 here — the
+    // property under test is only that it stops short and never recovers.
+    assert!(
+        (1..REQUESTS).contains(&drained),
+        "expected the raw transport to wedge part-way against a stalled client, \
+         got {drained}/{REQUESTS} — re-check the deadlock analysis in \
+         stdio_pump's module docs against the current tower-lsp-server"
+    );
+}
+
+/// The fix. With the pump in front of the same stalled stdout, stdin keeps
+/// draining: the server stays responsive to a client that has stopped reading,
+/// so the client never blocks in `write()` and the session cannot deadlock.
+#[tokio::test]
+async fn pumped_stdout_keeps_the_stdin_reader_running() {
+    let (stdout, _drain) = stdio_pump::pump(StalledSink);
+    let drained = drained_within_budget(stdout).await;
+    assert_eq!(
+        drained, REQUESTS,
+        "the server must keep reading stdin while the client is not reading stdout"
+    );
+}


### PR DESCRIPTION
Closes #1334. Very likely also closes #1294, which is the same fault seen from the client end.

## Root cause

`tower_lsp_server::Server::serve` joins `read_input`, `process_server_tasks` and `print_output` on one task, chained by bounded channels:

```
read_input ──server_tasks_tx(100)──▶ process_server_tasks
                                           │
                                    responses_tx(0)
                                           ▼
                                      print_output ──▶ FramedWrite(stdout)
```

Every link is bounded, so backpressure propagates from the stdout writer all the way back to the only future that reads stdin. When the client stops draining stdout the chain seizes in order: the framed write goes `Pending`, `responses_rx` (capacity 0) stops draining, `process_server_tasks` stalls, the 100-slot task queue fills, and `read_input` parks on `server_tasks_tx.send(..)`.

A server that has stopped reading stdin fills the client's 64 KiB stdin pipe, so the client blocks in `write()` — and therefore never returns to draining stdout. Both sides sleep at 0% CPU with no timeout on either. That is the 8h45m hang in #1334 and the server-wide unresponsiveness in #1294, and it explains the two details that looked odd: 10 MB RSS (it wedged before indexing) and a document-free request going unanswered (nothing document-specific is involved).

This answers the open question on #1334 — *does a suspended handler also stop the stdin pump?* Yes, and it does not even need `publish_diagnostics` to do it. There is a second, tighter path that does: handlers suspended in `publish_diagnostics(..).await` park on the client socket's own `channel(1)`, also drained only by `print_output`, and four of them exhaust `buffer_unordered(DEFAULT_MAX_CONCURRENCY)`.

## Fix

Both paths reduce to one property: the server cannot read stdin unless stdout is draining. `stdio_pump` decouples them — a FIFO queue and a dedicated writer task in front of stdout, whose `poll_write` never returns `Pending`.

Unbounded is forced, not chosen: any bound restores the coupling and only changes how long the client must stall first. LSP does not permit dropping messages, so absorbing them is the only deadlock-free option. Same shape `rust-analyzer`'s `lsp-server` uses.

The invariant in `main.rs` was **half right and is corrected rather than discarded**. What it was protecting — no dropped, no reordered diagnostics under a slow client — is preserved exactly by the single queue and single writer. What is given up is throttling a producer that outruns the client, which was never load-bearing for correctness and was the direct cause of the hang. A one-shot stderr warning at 64 MiB of backlog keeps the memory trade visible.

## Tests

`tests/stdio_deadlock.rs` drives the real transport against a stdout that never accepts a byte:

- **control** — the raw transport wedges 241/400 requests into a burst and never recovers.
- **fixed** — with the pump, all 400 drain.

The control is what makes the assertion non-vacuous; if it ever starts draining all 400, upstream changed and the analysis needs rechecking.

## Second commit

The first version of this had a real bug, caught by the e2e suite: the backlog counter was incremented *after* the chunk was handed to the drain task, so the drain's subtraction could land first, wrap the `AtomicUsize`, and overflow-panic the transport future. It presented as an intermittent broken pipe on a different e2e test each run. Counting before handing over makes the counter monotone by construction.

The accompanying unit test is documented for what it is: it does **not** detect that ordering bug (measured over 3×20,000 iterations, with and without yields — the window is a few instructions wide). Recorded so a future pass there is not mistaken for cover.

## Verification

- `cargo test -p tcl-lsp-server --test e2e` — 1413 passed, matching `rust`.
- `cargo clippy -p tcl-lsp-server --all-targets -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)