### PR TITLE
corpus: pin the iRules corpus and make the fetcher the general one

### DIFF
--- a/scripts/perf/MANIFEST.toml
+++ b/scripts/perf/MANIFEST.toml
@@ -168,6 +168,132 @@ url = "https://github.com/OSVVM/OSVVM-Scripts"
 commit = "60a2751c1d2087e6e58671585d3649cd5eb0b93d"
 group = "other"
 
+# --- iRules corpus (issue #1181) ----------------------------------------------
+#
+# The iRules dialect had no pinned corpus at all: everything above is plain
+# Tcl/TclOO, so nothing here exercised `when` blocks, the `HTTP::`/`LB::`/`TCP::`
+# command namespaces, `class match`, or the RULE_INIT/event split. These groups
+# fill that gap from public sources.
+#
+# Deliberately *not* added to any existing `[scope.*]`. The benchmark's stored
+# results are only comparable within one `corpus.revision`, and adding files to
+# `small`/`medium`/`full` would invalidate every measurement taken so far for no
+# benefit. These groups are reachable through the new `irules` and `everything`
+# scopes below, and `corpus.revision` is therefore left alone — no existing pin
+# moved, so no existing result changed meaning.
+#
+# One caveat that bites anyone sweeping this tree: iRule sources are **not**
+# reliably `.tcl`. Across these repos the split is roughly 147 `.tcl`, 63
+# `.irule`, 7 `.tmsh` and 198 `.txt` — DevCentral publishes them as plain text.
+# Filtering on `*.tcl` silently drops most of the corpus.
+
+# KaiWilke — the deepest single-author iRule work that is public: full RADIUS
+# client/server stacks implemented in iRules, plus a natural-language expression
+# compiler. Long procedures, heavy binary scan/format, deep nesting.
+[[repo]]
+name = "F5-iRule-RADIUS-Server-Stack"
+url = "https://github.com/KaiWilke/F5-iRule-RADIUS-Server-Stack"
+commit = "d69925554c45d1010a8dbb58bf5a98d275d005ca"
+group = "irules-kaiwilke"
+
+[[repo]]
+name = "F5-iRule-RADIUS-Client-Stack"
+url = "https://github.com/KaiWilke/F5-iRule-RADIUS-Client-Stack"
+commit = "2689ed3c55ff5b84620851231d199d6cdfb69d2a"
+group = "irules-kaiwilke"
+
+[[repo]]
+name = "F5-Natural-Speech-Expression"
+url = "https://github.com/KaiWilke/F5-Natural-Speech-Expression"
+commit = "2f73abbb2692063d4f05b2b344129c4a8c9535eb"
+group = "irules-kaiwilke"
+
+[[repo]]
+name = "F5CrowdSRC"
+url = "https://github.com/KaiWilke/F5CrowdSRC"
+commit = "aad8a81d5338681ce9045cb45fddfbfc4e29918e"
+group = "irules-kaiwilke"
+
+# Not Tcl itself — a Prism.js grammar for iRules. Kept because it is an
+# independent, maintained answer to "which words are iRule keywords", which is
+# the same question our TextMate grammar and command registry answer.
+[[repo]]
+name = "F5-PrismJS-iRule-Language-Definition"
+url = "https://github.com/KaiWilke/F5-PrismJS-iRule-Language-Definition"
+commit = "c6fc0072983d05cbfafdc1963d92e4013cf199f3"
+group = "irules-kaiwilke"
+
+# f5devcentral — vendor-published teaching and reference material.
+[[repo]]
+name = "f5-agility-labs-irules"
+url = "https://github.com/f5devcentral/f5-agility-labs-irules"
+commit = "2c2119606c6e039c5285184c7fc1f90d4b8cc07c"
+group = "irules-f5devcentral"
+
+[[repo]]
+name = "irules-toolbox"
+url = "https://github.com/f5devcentral/irules-toolbox"
+commit = "b8b13de8550effbfa06428cc79fa789d20ebe3c8"
+group = "irules-f5devcentral"
+
+# Community. `TesTcl` is the odd one out and is here on purpose: it is an iRule
+# *unit-testing* library, so it contains both iRules and Tcl that mocks the
+# iRule command surface — the iRules themselves live under `TesTcl/irules/`.
+[[repo]]
+name = "TesTcl"
+url = "https://github.com/landro/TesTcl"
+commit = "e31743809b976ba39da39138aeebf36f8d264fd9"
+group = "irules-community"
+
+[[repo]]
+name = "f5"
+url = "https://github.com/e-XpertSolutions/f5"
+commit = "702f20826ea475201f825e469f287ee593b5da14"
+group = "irules-community"
+
+[[repo]]
+name = "iRules"
+url = "https://github.com/megamattzilla/iRules"
+commit = "078f45638bad19dedf8d2f52f0e374d01cab6eac"
+group = "irules-community"
+
+[[repo]]
+name = "f5-irules-json"
+url = "https://github.com/JuergenMang/f5-irules-json"
+commit = "a8d9e0ffa7f4227f8696523f1551e304025b467a"
+group = "irules-community"
+
+[[repo]]
+name = "simple-sideband"
+url = "https://github.com/pwhitef5/simple-sideband"
+commit = "95b13e0e323919330cabe1dcbba7bb966173b9cd"
+group = "irules-community"
+
+[[repo]]
+name = "HTTP_Debug_iRule"
+url = "https://github.com/0xHiteshPatel/HTTP_Debug_iRule"
+commit = "f86aff4adab021fba7b158914b8c1ae0f7f8b142"
+group = "irules-community"
+
+[[repo]]
+name = "f5-irules"
+url = "https://github.com/erkac/f5-irules"
+commit = "96ce76edde28e1295b5b50888cacaee149d48d29"
+group = "irules-community"
+
+# --- private corpus -----------------------------------------------------------
+#
+# Publicly *sourced* (≈620 iRules gathered from 60+ upstream repos) but held in
+# a private repo, so it is skipped unless `--include-private` is passed and the
+# caller has credentials. Listed here rather than left as tribal knowledge: a
+# corpus you cannot enumerate is one you cannot tell is missing.
+[[repo]]
+name = "tcl-lsp-testsrc"
+url = "https://github.com/bitwisecook/tcl-lsp-testsrc"
+commit = "7bbe00d8e2b7c9c7ffa38497a298a23ad2c1c80a"
+group = "private"
+visibility = "private"
+
 # --- benchmark scopes ---------------------------------------------------------
 #
 # The full corpus is ~2400 .tcl files, which is the right scale for the
@@ -198,6 +324,31 @@ groups = ["georgtree", "nico-robert", "aplsimple"]
 
 [scope.full]
 groups = ["georgtree", "nico-robert", "aplsimple", "tcltk", "other"]
+
+# iRules only. Not a benchmark scope — the check suite's anchors and seeded
+# document selection are tuned for the Tcl corpus — but the right scope for
+# dialect work: diagnostics, the command registry, `when` handling.
+[scope.irules]
+groups = ["irules-kaiwilke", "irules-f5devcentral", "irules-community"]
+
+# Everything public, both dialects. For sweeps that want maximum surface
+# (fuzzing, parser crash hunts, false-positive audits) rather than comparable
+# timings.
+[scope.everything]
+groups = [
+  "georgtree", "nico-robert", "aplsimple", "tcltk", "other",
+  "irules-kaiwilke", "irules-f5devcentral", "irules-community",
+]
+
+# Adds the private aggregate on top of `everything`. Needs `--include-private`
+# *and* credentials; without them `fetch_corpus.py` skips the entry and says so
+# rather than failing the run.
+[scope.everything-private]
+groups = [
+  "georgtree", "nico-robert", "aplsimple", "tcltk", "other",
+  "irules-kaiwilke", "irules-f5devcentral", "irules-community",
+  "private",
+]
 
 # --- versions under test ------------------------------------------------------
 #

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -122,11 +122,49 @@ Two design points worth knowing:
 
 ## Corpus scopes
 
+`python3 fetch_corpus.py --list` prints the groups and scopes; the manifest is
+the source of truth.
+
 `small` (georgtree, ~113 files) is the default and the right one for routine
 release tracking: seconds to run, and it still contains `SpiceGenTcl`, the
 smallest corpus member that builds a `source` forest and package edges at
 once — the shape behind #1297. `medium` and `full` (~2400 files) exist for
 scan-cost and steady-state memory work.
+
+`irules` (14 repos, 217 source files) is the iRules corpus. It is **not** a
+benchmark scope — the check suite's anchors and seeded document selection are
+tuned for the Tcl corpus — but it is the right one for dialect work:
+diagnostics, the command registry, `when` blocks. `everything` is both
+dialects, for sweeps that want maximum surface (fuzzing, parser crash hunts,
+false-positive audits) rather than comparable timings.
+
+Two things to know before sweeping the iRules tree:
+
+- **iRule sources are often not `.tcl`.** Across these repos it is roughly 147
+  `.tcl`, 63 `.irule`, 7 `.tmsh` and 198 `.txt` — DevCentral publishes iRules
+  as plain text. Globbing `*.tcl` silently drops most of the corpus, so
+  `fetch_corpus.py` counts `.tcl`/`.irule`/`.tmsh` and reports which suffixes
+  it counted.
+- **The iRules groups are outside every existing benchmark scope, on
+  purpose.** Stored results only compare within one `corpus.revision`, so
+  adding files to `small`/`medium`/`full` would invalidate every measurement
+  taken so far. No existing pin moved when they were added, so
+  `corpus.revision` did not change either.
+
+`everything-private` additionally pulls `bitwisecook/tcl-lsp-testsrc` (~620
+publicly-sourced iRules gathered from 60+ upstream repos). That repo is
+private, so the entry needs `--include-private` and credentials; without them
+the fetcher prints a `skipped` line rather than failing, because a private
+entry quietly dropped from a corpus is indistinguishable from one that was
+never there.
+
+## Growing the corpus
+
+Add a `[[repo]]` block with an exact `commit` and put its `group` in a scope.
+Pin to a SHA, never a branch — the whole point is that a run a year from now
+measures the same bytes. Advancing an *existing* pin is a different act: it
+invalidates every stored benchmark result, so bump `corpus.revision`, re-run
+the sweep, and say so in the release notes.
 
 ## Version coverage
 

--- a/scripts/perf/fetch_corpus.py
+++ b/scripts/perf/fetch_corpus.py
@@ -16,7 +16,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""Deterministically reconstitute the benchmark corpus from `MANIFEST.toml`.
+"""Deterministically reconstitute the corpus from `MANIFEST.toml`.
 
 Idempotent: an already-correct checkout is left alone. The important
 property is not speed but *pinning* — a cross-version graph is only
@@ -24,8 +24,16 @@ meaningful if every version measured the same bytes, so a checkout that
 does not match its pinned commit is a hard error, never a silent
 "benchmark whatever is on disk".
 
+The same pinning makes this the general corpus fetcher, not just the
+benchmark's: `--scope irules` reconstitutes the iRules corpus, and
+`--scope everything` both dialects. To grow the set, add a `[[repo]]`
+block with an exact `commit` and put its `group` in a scope. Advancing an
+existing pin invalidates stored benchmark results — see the header of
+`MANIFEST.toml`.
+
 Usage:
-    fetch_corpus.py [--scope small|medium|full] [--dest DIR] [--verify-only]
+    fetch_corpus.py [--scope NAME] [--dest DIR] [--verify-only]
+    fetch_corpus.py --list
 """
 
 from __future__ import annotations
@@ -125,6 +133,27 @@ def scope_groups(manifest: dict, scope: str) -> list[str]:
     return list(scopes[scope]["groups"])
 
 
+# iRule sources are published as often in `.txt` (DevCentral) or `.irule` as
+# in `.tcl`, so counting only `*.tcl` under-reports the iRules corpus by
+# roughly three quarters and makes a half-fetched tree look complete.
+SOURCE_SUFFIXES = ("*.tcl", "*.irule", "*.tmsh")
+
+
+def describe(manifest: dict) -> None:
+    """Print the groups and scopes on offer, so `--scope` is discoverable."""
+    counts: dict[str, int] = {}
+    for entry in manifest["repo"]:
+        counts[entry["group"]] = counts.get(entry["group"], 0) + 1
+    print("groups:")
+    for group in sorted(counts):
+        print(f"  {group:<24} {counts[group]:>3} repo(s)")
+    print("\nscopes:")
+    for scope in sorted(manifest.get("scope", {})):
+        groups = manifest["scope"][scope]["groups"]
+        repos = sum(counts.get(g, 0) for g in groups)
+        print(f"  {scope:<24} {repos:>3} repo(s)  ({', '.join(groups)})")
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--manifest", type=Path, default=HERE / "MANIFEST.toml")
@@ -135,26 +164,54 @@ def main() -> int:
         action="store_true",
         help="check pins without network access; exit non-zero on drift",
     )
+    ap.add_argument(
+        "--include-private",
+        action="store_true",
+        help='also fetch entries marked `visibility = "private"`, which need credentials',
+    )
+    ap.add_argument(
+        "--list",
+        action="store_true",
+        help="print the available groups and scopes, then exit",
+    )
     args = ap.parse_args()
 
     manifest = load_manifest(args.manifest)
+    if args.list:
+        describe(manifest)
+        return 0
+
     groups = set(scope_groups(manifest, args.scope))
     # Sorted so the log is stable run to run, like everything else here.
     entries = sorted(
         (e for e in manifest["repo"] if e["group"] in groups),
         key=lambda e: (e["group"], e["name"]),
     )
+    # Skipping is reported, never silent: a private entry quietly dropped from
+    # a corpus is indistinguishable from one that was never there.
+    skipped = [e for e in entries if e.get("visibility") == "private"]
+    if not args.include_private:
+        entries = [e for e in entries if e.get("visibility") != "private"]
+    else:
+        skipped = []
 
     failures = 0
     for entry in entries:
         ok, msg = ensure_repo(entry, args.dest, verify_only=args.verify_only)
         print(msg)
         failures += not ok
+    for entry in skipped:
+        print(
+            f"skipped  {entry['group']}/{entry['name']} (private; --include-private to fetch)"
+        )
 
-    tcl_files = sum(1 for _ in args.dest.rglob("*.tcl")) if args.dest.exists() else 0
+    files = 0
+    if args.dest.exists():
+        files = sum(len(list(args.dest.rglob(pat))) for pat in SOURCE_SUFFIXES)
     print(
         f"\nscope={args.scope} repos={len(entries)} "
-        f"corpus_revision={manifest['corpus']['revision']} .tcl files={tcl_files}"
+        f"corpus_revision={manifest['corpus']['revision']} "
+        f"source files={files} ({', '.join(SOURCE_SUFFIXES)})"
     )
     if failures:
         print(f"{failures} repo(s) not at their pin", file=sys.stderr)


### PR DESCRIPTION
The pinned corpus covered plain Tcl and TclOO only, so nothing in it exercised the iRules dialect: no `when` blocks, no `HTTP::`/`LB::`/`TCP::` namespaces, no `class match`, no RULE_INIT/event split.

## What is added

14 public iRule repos from #1181, each pinned to an exact commit, in three groups:

| group | repos |
|---|---|
| `irules-kaiwilke` | 5 — the RADIUS client/server stacks, natural-speech expression compiler, CrowdSRC, Prism grammar |
| `irules-f5devcentral` | 2 — agility labs, irules-toolbox |
| `irules-community` | 7 — TesTcl, e-XpertSolutions/f5, megamattzilla, f5-irules-json, simple-sideband, HTTP_Debug_iRule, erkac/f5-irules |

Two judgement calls worth flagging:

- **KaiWilke was a user profile, not a repo**, so all five public repos are enumerated.
- **`landro/TesTcl` is taken whole.** It is an iRule unit-test library, so it carries both iRules (under `irules/`) and Tcl that mocks the iRule command surface — both are useful, and the issue pointed only at the subdirectory.

## Deliberately outside every existing benchmark scope

Stored results only compare within one `corpus.revision`, so adding these to `small`/`medium`/`full` would invalidate every measurement taken so far for no benefit. New `irules` and `everything` scopes reach them instead, and since **no existing pin moved, `corpus.revision` is unchanged** — every existing result keeps its meaning.

## The private aggregate is listed, not hidden

`bitwisecook/tcl-lsp-testsrc` (~620 publicly-sourced iRules from 60+ upstream repos) is in the manifest marked `visibility = "private"`, pinned like everything else. It is skipped with a printed `skipped` line unless `--include-private` is passed. Enumerated rather than left as tribal knowledge: a corpus you cannot enumerate is one you cannot tell is missing.

## Fetcher changes

- `--list` prints groups and scopes, so `--scope` is discoverable.
- `--include-private` opts into the private entry.
- Counts `.tcl`, `.irule` **and** `.tmsh`, and says which suffixes it counted. This one matters: iRules are published as often in `.txt` or `.irule` as in `.tcl` — across these repos it is 147 `.tcl`, 63 `.irule`, 7 `.tmsh` and 198 `.txt`. The old `*.tcl`-only count under-reported the iRules corpus by roughly three quarters and would make a half-fetched tree look complete.

## Verification

- `--scope irules` fetches all 14 at their pins (217 source files).
- `--verify-only` re-checks them clean.
- `--scope everything-private --verify-only` prints the expected `skipped` line.
- Existing scopes are byte-identical in what they select.

🤖 Generated with [Claude Code](https://claude.com/claude-code)