### PR TITLE
fix(ensure-test-deps): make wasi-sdk actually installable

### DIFF
--- a/scripts/dev/ensure-test-deps.sh
+++ b/scripts/dev/ensure-test-deps.sh
@@ -772,6 +772,36 @@ ensure_wasi_sdk() {
         *) echo "ERROR: unsupported architecture for wasi-sdk: $ARCH" >&2; return 1 ;;
     esac
 
+    # Integrity pins, per platform, matching what every other tool here carries.
+    #
+    # Why pinned rather than verified against an upstream sidecar: wasi-sdk
+    # publishes **no checksums at all**.  There is no `SHA256SUMS` asset on the
+    # `wasi-sdk-25` release (the URL 404s), no per-asset `.sha256`, no hashes in
+    # the release body, and the GitHub API reports `digest: null` for the
+    # assets.  The same is true of every wasi-sdk release, so the sidecar this
+    # function used to fetch could never have existed — the fail-closed branch
+    # fired on every run and wasi-sdk was simply never installable.
+    #
+    # These values were computed from the published tarballs and then
+    # corroborated against independent third parties that pin the same
+    # artefacts, so they are not merely trust-on-first-use from one download:
+    # `spack/spack-packages` records the identical sha256 for 25.0 x86_64-linux,
+    # and `wevm/ox`'s `wasm/toolchain.json` records all four.
+    #
+    # To move `WASI_SDK_VERSION`: download each tarball, hash it, and replace
+    # the four values below — mismatches are fatal by design.
+    local expected_sha
+    case "${sdk_arch}-${sdk_os}" in
+        x86_64-linux) expected_sha="52640dde13599bf127a95499e61d6d640256119456d1af8897ab6725bcf3d89c" ;;
+        arm64-linux)  expected_sha="47fccad8b2498f2239e05e1115c3ffc652bf37e7de2f88fb64b2d663c976ce2d" ;;
+        x86_64-macos) expected_sha="55e3ff3fee1a15678a16eeccba0129276c9f6be481bc9c283e7f9f65bf055c11" ;;
+        arm64-macos)  expected_sha="e1e529ea226b1db0b430327809deae9246b580fa3cae32d31c82dfe770233587" ;;
+        *)
+            echo "ERROR: no wasi-sdk sha256 pin for ${sdk_arch}-${sdk_os}" >&2
+            return 1
+            ;;
+    esac
+
     ensure_download_tools
     local major="${WASI_SDK_VERSION%%.*}"
     local tarball="wasi-sdk-${WASI_SDK_VERSION}-${sdk_arch}-${sdk_os}.tar.gz"
@@ -784,27 +814,15 @@ ensure_wasi_sdk() {
     info "Downloading wasi-sdk ${WASI_SDK_VERSION} (${sdk_arch}-${sdk_os})"
     fetch_with_retry "${base}/${tarball}" "$tmpdir/$tarball"
 
-    # Integrity: verify against the release's published SHA256SUMS.  (A hardcoded
-    # per-arch pin, like the other tools carry, is a follow-up once the canonical
-    # version is fixed for this branch.)  Fail closed: a missing sidecar or a
-    # sidecar with no entry for this tarball means the artifact is unverified,
-    # so refuse it rather than installing on trust.
-    if ! fetch_with_retry "${base}/SHA256SUMS" "$tmpdir/SHA256SUMS" 2>/dev/null; then
-        echo "ERROR: could not fetch wasi-sdk SHA256SUMS; refusing to install unverified" >&2
+    # Still fail closed: a tarball that does not match its pin is refused rather
+    # than installed on trust.
+    local actual_sha
+    actual_sha="$(sha256_file "$tmpdir/$tarball")"
+    if [ "$actual_sha" != "$expected_sha" ]; then
+        echo "ERROR: wasi-sdk sha256 mismatch (expected $expected_sha, got $actual_sha)" >&2
         return 1
     fi
-    local expected actual
-    expected="$(awk -v f="$tarball" '{ n=$2; sub(/^\*/,"",n); if (n==f) { print $1; exit } }' "$tmpdir/SHA256SUMS")"
-    actual="$(sha256_file "$tmpdir/$tarball")"
-    if [ -z "$expected" ]; then
-        echo "ERROR: wasi-sdk SHA256SUMS has no entry for ${tarball}; refusing to install unverified" >&2
-        return 1
-    fi
-    if [ "$expected" != "$actual" ]; then
-        echo "ERROR: wasi-sdk sha256 mismatch (expected $expected, got $actual)" >&2
-        return 1
-    fi
-    info "wasi-sdk checksum verified against SHA256SUMS"
+    info "wasi-sdk checksum verified against the pin for ${sdk_arch}-${sdk_os}"
 
     local prefix="/opt/wasi-sdk-${WASI_SDK_VERSION}"
     $SUDO rm -rf "$prefix"


### PR DESCRIPTION
`install_wasi_sdk` verified the tarball against `${base}/SHA256SUMS` and failed closed when it could not fetch it. **That sidecar does not exist.**

The `wasi-sdk-25` release has no `SHA256SUMS` asset (the URL 404s), no per-asset `.sha256`, no hashes in the release body, and the GitHub API reports `digest: null` for the assets. The same holds for *every* wasi-sdk release, so the fetch could never have succeeded — the fail-closed branch fired on every run and wasi-sdk was simply never installable:

```
==> Downloading wasi-sdk 25.0 (x86_64-linux)
ERROR: could not fetch wasi-sdk SHA256SUMS; refusing to install unverified
make: *** [Makefile:939: ensure-test-deps] Error 1
```

The fail-closed behaviour was right; the thing it was closing on was imaginary.

## Fix

Hardcoded per-platform sha256 pins — the follow-up the function's own comment described, and the same shape `ensure_wasmtime` already uses.

**These are not bare trust-on-first-use from one download.** Each was computed from the published tarball and then corroborated against independent third parties pinning the same artefacts:

| platform | corroborated by |
|---|---|
| x86_64-linux | `spack/spack-packages` (identical sha256 for 25.0), `wevm/ox` |
| arm64-linux | `wevm/ox` |
| x86_64-macos | `wevm/ox` |
| arm64-macos | `wevm/ox`, `uncerso/wasm-rust-cpp-js` |

Still fail-closed: a tarball that does not match its pin is refused, and an unpinned platform is an error rather than an unverified install.

## Verification (x86_64-linux)

- Installs and works — `/opt/wasi-sdk/bin/clang --version` reports `clang version 19.1.5-wasi-sdk`, target `wasm32-unknown-wasi`.
- `ensure-test-deps.sh --check` then reports all dependencies satisfied (it previously listed wasi-sdk as missing indefinitely).
- Corrupting the pin makes it refuse and install nothing:
  ```
  ERROR: wasi-sdk sha256 mismatch (expected dead0000..., got 52640dde...)
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)