### PR TITLE
fix(1334): bound server-to-client requests so they cannot strand the reader

### DIFF
--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -350,6 +350,29 @@ const DIAGNOSTICS_FAST_TIER_BUDGET: std::time::Duration = std::time::Duration::f
 /// multi-thousand-line documents #844 targets.
 const DIAGNOSTICS_FAST_TIER_MIN_LINES: usize = 500;
 
+/// How long to wait for the editor to answer a *server-to-client* request
+/// before giving up on it.
+///
+/// This is a liveness guard, and it is load-bearing rather than cosmetic.
+/// A handler parked on `client.configuration(..).await` is waiting for a reply
+/// that arrives on **stdin**, and only the transport's single `read_input`
+/// future can deliver it. That future parks once the task queue behind it
+/// fills, which happens as soon as
+/// `buffer_unordered(DEFAULT_MAX_CONCURRENCY)`'s four slots are occupied by
+/// handlers that never finish. Four parked config pulls with a burst behind
+/// them therefore close a cycle: the handlers wait for replies the parked
+/// reader will never read, and the session wedges with a perfectly healthy
+/// stdout. That is #1334 / #1294 reached by a route
+/// [`stdio_pump`](crate::stdio_pump) cannot cover, and
+/// `tests/stdio_deadlock.rs` demonstrates the mechanism.
+///
+/// Bounding the wait converts that permanent deadlock into a bounded stall:
+/// the handler returns, its slot frees, the queue drains and the reader
+/// resumes. Sized generously — a conforming client answers
+/// `workspace/configuration` in milliseconds, so ten seconds only ever fires
+/// for a client that is not going to answer.
+const CLIENT_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// The iRules dialect key.  A BIG-IP config's `ltm rule { … }` bodies are iRules
 /// code, so they are tokenised against this registry rather than the config's
 /// own `f5-bigip` one.
@@ -10295,15 +10318,48 @@ impl Backend {
         self.reresolve_open_document_dialects().await;
     }
 
+    /// `workspace/configuration`, bounded by [`CLIENT_REQUEST_TIMEOUT`].
+    ///
+    /// The timeout is a **liveness** guard, not politeness, and it is
+    /// load-bearing — see the constant. A client that never answers would
+    /// otherwise park this handler forever, and enough parked handlers stop the
+    /// server reading stdin at all, which is the wedge in #1334 / #1294 reached
+    /// by a route the stdout pump cannot cover.
+    ///
+    /// A timeout is reported as `Err(())`, the same shape as a client that
+    /// declines, so every caller's existing early-return path handles it: the
+    /// server keeps the config it already had rather than acting on a partial
+    /// pull.
+    async fn request_configuration(
+        &self,
+        items: Vec<ConfigurationItem>,
+    ) -> Result<Vec<serde_json::Value>, ()> {
+        match tokio::time::timeout(CLIENT_REQUEST_TIMEOUT, self.client.configuration(items)).await {
+            Ok(Ok(values)) => Ok(values),
+            Ok(Err(_)) => Err(()),
+            Err(_elapsed) => {
+                let message = format!(
+                    "tcl-lsp: the editor did not answer workspace/configuration within {}s; \
+                     keeping the previous settings. Giving up is deliberate — waiting \
+                     indefinitely can stop the server reading its input entirely (#1334).",
+                    CLIENT_REQUEST_TIMEOUT.as_secs()
+                );
+                eprintln!("{message}");
+                self.client.log_message(MessageType::WARNING, message).await;
+                Err(())
+            }
+        }
+    }
+
     /// The pull-and-apply body of [`Self::pull_and_apply_config`], without the
     /// trailing dialect re-resolve. Returns early when the client declines the
-    /// `workspace/configuration` request.
+    /// `workspace/configuration` request, or does not answer it in time.
     async fn pull_and_apply_config_values(&self) {
         let items = vec![ConfigurationItem {
             scope_uri: None,
             section: Some("tclLsp".to_owned()),
         }];
-        let Ok(values) = self.client.configuration(items).await else {
+        let Ok(values) = self.request_configuration(items).await else {
             return;
         };
         let Some(cfg) = values.into_iter().next() else {
@@ -10361,7 +10417,7 @@ impl Backend {
                     section: Some("tclLsp".to_owned()),
                 })
                 .collect();
-            if let Ok(values) = self.client.configuration(items).await {
+            if let Ok(values) = self.request_configuration(items).await {
                 let parsed: Vec<(Uri, FolderConfig)> = folders
                     .into_iter()
                     .zip(values)

--- a/rust/tcl-lsp-server/tests/stdio_deadlock.rs
+++ b/rust/tcl-lsp-server/tests/stdio_deadlock.rs
@@ -25,7 +25,7 @@
 //! which is what makes the assertion meaningful rather than vacuous.
 
 use std::convert::Infallible;
-use std::future::{Ready, ready};
+use std::future::{Future, Ready, ready};
 use std::io;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -114,6 +114,59 @@ impl Service<Request> for CountingService {
     }
 }
 
+/// A service whose handlers never finish, modelling a handler parked on a
+/// server-to-client request (`client.configuration(..).await`) whose reply can
+/// only be delivered by `read_input`.
+#[derive(Debug, Clone)]
+struct StuckService {
+    calls: Arc<AtomicUsize>,
+}
+
+/// A service whose handlers block, but only for `delay` — the shape
+/// `CLIENT_REQUEST_TIMEOUT` imposes on a config pull the editor never answers.
+#[derive(Debug, Clone)]
+struct SlowService {
+    calls: Arc<AtomicUsize>,
+    delay: std::time::Duration,
+}
+
+impl Service<Request> for SlowService {
+    type Response = Option<Response>;
+    type Error = Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let (_method, id, _params) = req.into_parts();
+        let delay = self.delay;
+        Box::pin(async move {
+            tokio::time::sleep(delay).await;
+            Ok(id.map(|id| Response::from_parts(id, Ok(serde_json::Value::Null))))
+        })
+    }
+}
+
+impl Service<Request> for StuckService {
+    type Response = Option<Response>;
+    type Error = Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: Request) -> Self::Future {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        // Never resolves — exactly what awaiting a client reply that can no
+        // longer be read amounts to.
+        Box::pin(std::future::pending())
+    }
+}
+
 /// No server-to-client traffic of its own; the outbound pressure in this test
 /// comes from responses.
 struct NoLoopback;
@@ -190,5 +243,73 @@ async fn pumped_stdout_keeps_the_stdin_reader_running() {
     assert_eq!(
         drained, REQUESTS,
         "the server must keep reading stdin while the client is not reading stdout"
+    );
+}
+
+/// A **second** way to wedge the stdin reader, which the stdout pump does not
+/// address — recorded because it is a live hazard, not a hypothetical.
+///
+/// `buffer_unordered(DEFAULT_MAX_CONCURRENCY)` stops pulling from the task
+/// queue while its four slots are occupied. Handlers that never complete
+/// therefore let the 100-slot queue fill, after which `read_input` parks on
+/// `server_tasks_tx.send(..)` and stops reading stdin — with a perfectly
+/// healthy stdout.
+///
+/// That matters because several handlers here (`initialized`,
+/// `did_change_workspace_folders`, `did_change_watched_files`) `await`
+/// `client.configuration(..)`, a *server-to-client request*. Its reply arrives
+/// as a `Message::Response` on stdin, and only `read_input` can deliver it.
+/// Four concurrent config pulls with a burst behind them therefore close a
+/// cycle the stdout fix cannot open: the handlers wait for replies that the
+/// parked reader will never read.
+///
+/// This asserts the mechanism (stuck handlers stop the reader), not the
+/// LSP-level scenario. It is why `client.configuration` needs a timeout.
+#[tokio::test]
+async fn stuck_handlers_wedge_the_stdin_reader_even_with_a_healthy_stdout() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let service = StuckService {
+        calls: Arc::clone(&calls),
+    };
+    // A sink that accepts everything: stdout is explicitly not the problem.
+    let (stdout, _drain) = stdio_pump::pump(tokio::io::sink());
+    let served = Server::new(BurstThenIdle(burst()), stdout, NoLoopback).serve(service);
+    let _ = tokio::time::timeout(DRAIN_BUDGET, served).await;
+
+    let drained = calls.load(Ordering::SeqCst);
+    println!("with stuck handlers, the reader drained {drained}/{REQUESTS}");
+    assert!(
+        drained < REQUESTS,
+        "expected stuck handlers to stall the reader, but it drained all {REQUESTS}"
+    );
+}
+
+/// The property `CLIENT_REQUEST_TIMEOUT` buys: handlers that are *bounded*
+/// cannot wedge the reader, only slow it down.
+///
+/// This is the counterpart to
+/// `stuck_handlers_wedge_the_stdin_reader_even_with_a_healthy_stdout`. The only
+/// difference is that these handlers finish. Every request still gets through,
+/// which is why bounding `client.configuration(..)` turns a permanent deadlock
+/// into a bounded stall: the handler returns, its `buffer_unordered` slot
+/// frees, the queue drains, and `read_input` resumes.
+///
+/// The delay here is short so the test is quick; in the server the bound is
+/// `CLIENT_REQUEST_TIMEOUT`. What is under test is the shape, not the number.
+#[tokio::test]
+async fn bounded_handlers_only_slow_the_stdin_reader_down() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let service = SlowService {
+        calls: Arc::clone(&calls),
+        delay: std::time::Duration::from_millis(20),
+    };
+    let (stdout, _drain) = stdio_pump::pump(tokio::io::sink());
+    let served = Server::new(BurstThenIdle(burst()), stdout, NoLoopback).serve(service);
+    let _ = tokio::time::timeout(DRAIN_BUDGET, served).await;
+
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        REQUESTS,
+        "handlers that finish must not be able to strand the reader"
     );
 }


### PR DESCRIPTION
Follow-up to #1338. That PR removed **one** route to the wedge — a client that stops draining stdout. There is a second, and it survives that fix with a perfectly healthy stdout.

## The second cycle

`buffer_unordered(DEFAULT_MAX_CONCURRENCY)` stops pulling from the task queue while its four slots are occupied. Handlers that never complete therefore let the 100-slot queue fill, after which `read_input` parks on `server_tasks_tx.send(..)` and stops reading stdin.

That is reachable here, not hypothetical. `initialized`, `did_change_workspace_folders` and `did_change_watched_files` all `await self.client.configuration(..)` — a **server-to-client request**. Its reply arrives as a `Message::Response` on stdin, and only `read_input` can deliver it. Four concurrent config pulls with a burst behind them close a cycle #1338 cannot open: the handlers wait for replies that the parked reader will never read. Watched-file events arrive in bursts, which is how four get in flight at once.

Demonstrated rather than argued — new test, with a sink that accepts everything so stdout is explicitly not the problem:

```
with stuck handlers, the reader drained 105/400
```

105 is exactly the 100-slot queue plus the four occupied slots plus one.

## Fix

Bound the wait. `request_configuration` wraps the call in `CLIENT_REQUEST_TIMEOUT` (10s) and reports a timeout as `Err` — the same shape as a client that *declines* — so every caller's existing early-return path already handles it. The server keeps the config it had rather than acting on a partial pull, and says so on stderr and in the client log.

This converts a permanent deadlock into a bounded stall: the handler returns, its slot frees, the queue drains, the reader resumes.

## What this does **not** do

Worth being straight about, because it changes how much confidence to place in it:

- It does not *prevent* the stall, only bounds it at 10s.
- It is not a substitute for the queue being unbounded. `MESSAGE_QUEUE_SIZE` (100) and `DEFAULT_MAX_CONCURRENCY` (4) are `tower-lsp-server` constants we cannot set from here; only `concurrency_level` is settable, and raising it moves the bar without removing it.
- Any *other* handler that can block forever reopens the same cycle. `client.configuration` is the one that is currently reachable; `register_capability` is awaited too but only once, during `initialized`.

A structural fix means either an unbounded queue in front of the handler pool (upstream change) or not awaiting client replies inside handlers at all.

## Evidence that #1338 was real

Unrelated but worth recording: #1340's first CI run predated #1338 and reproduced the original wedge on the runner — `LIVENESS: SERVER WEDGED`, 4 failing, 771 passing. Rebased onto `rust` with #1338 in, the same job passes.

## Tests

Four now, all against the real transport:

| test | asserts |
|---|---|
| `unpumped_stdout_wedges_the_stdin_reader` | control: raw transport wedges at 241/400 |
| `pumped_stdout_keeps_the_stdin_reader_running` | #1338's fix: all 400 drain |
| `stuck_handlers_wedge_the_stdin_reader_even_with_a_healthy_stdout` | **this cycle**: 105/400 with stdout healthy |
| `bounded_handlers_only_slow_the_stdin_reader_down` | what the timeout buys: handlers that finish never strand the reader |

`cargo test -p tcl-lsp-server` green (1413 e2e + 370 lib + the rest); clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)