### PR TITLE
fix(vscode-test): progress-driven suite budget + bounded feature-toggle waits (#1293, #1295)

### DIFF
--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -113,6 +113,9 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
 - [kcs-issue-vscode-test-runner-reports-false-hang.md](kcs-issue-vscode-test-runner-reports-false-hang.md)
   — `make test-ext` reports "mocha never completed (likely hung)" on a run
   that actually passed every test.
+- [kcs-issue-vscode-test-feature-toggle-sampled-once.md](kcs-issue-vscode-test-feature-toggle-sampled-once.md)
+  — a feature-toggle test samples the provider once right after disabling it
+  and is flaky (or fails deterministically) instead of waiting on the result.
 - [kcs-issue-runtime-string-subcommands-corrupt-binary-values.md](kcs-issue-runtime-string-subcommands-corrupt-binary-values.md)
   — `string index`/`range`/`replace`/`toupper` under the WASM runtime used to
   replace non-UTF-8 bytes from `binary format`/a binary channel read with

--- a/docs/kcs/kcs-issue-vscode-test-feature-toggle-sampled-once.md
+++ b/docs/kcs/kcs-issue-vscode-test-feature-toggle-sampled-once.md
@@ -1,0 +1,123 @@
+# KCS: a VS Code feature-toggle test samples the provider once and is flaky
+
+> **Audience:** Contributor
+> **Type:** Issue
+
+## Applies to
+
+VS Code
+
+## Question
+
+A VS Code extension test disables a `tclLsp.features.*` toggle, waits for the
+config change, then queries the provider exactly once and asserts on the
+result — and it occasionally (or, worse, deterministically) sees the
+*pre-toggle* answer. How do you fix the wait, and how do you tell that apart
+from the toggle genuinely not working?
+
+## Symptoms
+
+- A test shaped like: disable a feature, `await waitForFeatureToggle(...)`,
+  then a single `await vscode.commands.executeCommand("vscode.execute*Provider",
+  ...)` immediately asserted against.
+- The failure (when it happens) shows the *old* answer — the depth, item, or
+  symbol the provider returned before the toggle — not an error and not an
+  empty result.
+- It reproduces rarely in isolation but more often under load or inside the
+  full suite, because the race window it depends on is short.
+
+## Answer
+
+This is [issue #1295](https://github.com/bitwisecook/tcl-lsp/issues/1295):
+`waitForFeatureToggle` (and `waitForEffectiveConfig` underneath it) only
+proves the **server's effective config** changed — it says nothing about
+whether a provider request issued right *now* will be answered under the new
+config. There is no LSP event that announces "the next request reflects the
+new toggle", so a single sample taken immediately after the config barrier is
+racing an unobserved transition.
+
+The fix is a **bounded wait on the result itself**, not a longer sleep:
+
+```ts
+const after = await waitForProviderResult(
+  docUri,
+  () => selectionRangesAt(docUri, pos),
+  (r) => chainDepth(r) < depthBefore,
+  { timeout: 10_000, label: "selection range depth to drop after disabling the feature" },
+);
+```
+
+`waitForProviderResult` (`editors/vscode/src/test/helper.ts`) re-pulls the
+provider on every `onDidChangeDiagnostics` publish plus a tight backstop
+interval, and **rejects** rather than resolving with a stale value if the
+predicate never holds. That makes the fixed test fast in the common case (it
+resolves the instant the new answer lands) and loud in the broken case — a
+timeout that names the label and the last value seen, not a silent pass
+against the wrong result. `pollUntil` is the same shape for a query with no
+useful diagnostics-publish signal to key off (e.g. a raw config read).
+
+Two outcomes once converted:
+
+- **It passes reliably.** The toggle worked; the bug was the single sample.
+  This was true for every case fixed under #1295 in this codebase
+  (`selectionRange`, `documentSymbols` — see the note on that one below —
+  and a `folding` test tightened for consistency).
+- **It fails deterministically at the bound.** Before concluding the feature
+  toggle itself is broken, rule out the VS Code test-instrument problem
+  below — it produces exactly this symptom and is not a product bug.
+
+### A deterministic failure can still be a test bug, not a product bug
+
+Converting `disabling features.documentSymbols removes LSP document symbols`
+to a bounded wait initially failed *deterministically*, including in
+isolation under `MOCHA_GREP`, with the provider always answering the
+pre-toggle symbol set. That looked exactly like "the toggle is not applied to
+in-flight provider registrations" — but the server-side e2e contract test
+(`disabling_document_symbols_suppresses_provider`,
+`rust/tcl-lsp-server/tests/e2e/config.rs`) already passed, and a raw
+`textDocument/documentSymbol` request sent directly over the LSP connection
+(bypassing the VS Code command) returned the correct, empty answer
+immediately.
+
+The command `vscode.executeDocumentSymbolProvider` goes through VS Code's own
+outline/breadcrumbs model, which caches the last answer for a document and
+does not invalidate it on a bare configuration change with no document edit —
+the same class of problem already documented for
+`vscode.executeFoldingRangeProvider` (see `foldingRangeViaLsp` in
+`editors/vscode/src/test/configSettings.test.ts`). The fix was the same one:
+send the raw LSP request via `getClient().sendRequest(...)` instead of the VS
+Code command, which is what the registered provider actually receives.
+
+**Rule of thumb:** if a bounded provider-result wait fails deterministically,
+check whether an independent oracle agrees before concluding the toggle is
+broken —
+
+1. the Rust e2e contract test for that feature in
+   `rust/tcl-lsp-server/tests/e2e/config.rs` (`TOGGLEABLE_FEATURES`), and
+2. a raw `client.sendRequest("textDocument/...", ...)` call instead of the
+   `vscode.execute*Provider` command.
+
+If both agree with the raw LSP answer and only the VS Code command disagrees,
+the bug is in the test's oracle, not the product. If the raw LSP request
+*also* shows the stale answer, that is a real product bug and must be fixed
+in the server (or the extension's feature gating), not worked around in the
+test.
+
+### Auditing for the same shape elsewhere
+
+This is a shape, not a one-off: any test that establishes a baseline with a
+bounded wait but samples the "after" state exactly once has the same defect,
+whatever provider it queries. Search for a single `await
+vscode.commands.executeCommand("vscode.execute*Provider", ...)` (or
+`client.sendRequest`) sitting directly after a `waitForFeatureToggle` /
+`waitForEffectiveConfig` call with no wait wrapped around it — that pairing
+is the signature to grep for.
+
+## Related
+
+- [KCS index](README.md)
+- [Glossary](../GLOSSARY.md)
+- [kcs-issue-vscode-test-runner-reports-false-hang.md](kcs-issue-vscode-test-runner-reports-false-hang.md)
+  — the companion fix (issue #1293) for the suite's launch-to-exit budget.
+- [kcs-issue-vscode-test-timed-out-on-didopen.md](kcs-issue-vscode-test-timed-out-on-didopen.md)
+  — a different, per-test wait timeout with its own three-way verdict.

--- a/docs/kcs/kcs-issue-vscode-test-runner-reports-false-hang.md
+++ b/docs/kcs/kcs-issue-vscode-test-runner-reports-false-hang.md
@@ -73,3 +73,6 @@ backstop for a run that never stalls but also never finishes.
 - [Glossary](../GLOSSARY.md)
 - [a VS Code test timed out draining `didOpen`](kcs-issue-vscode-test-timed-out-on-didopen.md)
   — a different, per-test wait timeout with its own three-way verdict.
+- [a feature-toggle test samples the provider once and is flaky](kcs-issue-vscode-test-feature-toggle-sampled-once.md)
+  — the companion fix (issue #1295) for a single-sample "after" read racing
+  an unobserved config transition.

--- a/editors/vscode/src/test/configSettings.test.ts
+++ b/editors/vscode/src/test/configSettings.test.ts
@@ -258,7 +258,18 @@ suite("Configuration Settings", () => {
       // data" from "the folding UI is off for this editor". The raw request
       // is what the LSP client's registered FoldingRangeProvider (and, in
       // turn, sticky scroll) actually sees.
-      const after = await foldingRangeViaLsp(docUri);
+      //
+      // Bounded wait, not a single sample (issue #1295's shape): the toggle
+      // barrier above only proves the server's effective config round-tripped
+      // back to true, not that a request issued right now sees it. This test
+      // expects the *same* answer as the baseline, so in the common case the
+      // wait resolves on its first poll; it only matters if there is ever a
+      // transient dip immediately after the editor.folding change propagates.
+      const after = await pollUntil(
+        () => foldingRangeViaLsp(docUri),
+        (r) => Array.isArray(r) && r.length > 0,
+        { timeout: 10_000, label: "folding after editor.folding=false (issue #1122)" },
+      );
       assert.ok(
         Array.isArray(after) && after.length > 0,
         `LSP folding provider should stay enabled when editor.folding=false (issue #1122), got ${JSON.stringify(after)}`,
@@ -807,39 +818,65 @@ suite("Configuration Settings", () => {
     }
   });
 
-  test("disabling features.documentSymbols reduces symbol detail", async () => {
+  const documentSymbolsOf = async (
+    docUri: vscode.Uri,
+  ): Promise<vscode.DocumentSymbol[] | undefined> =>
+    (await vscode.commands.executeCommand("vscode.executeDocumentSymbolProvider", docUri)) as
+      vscode.DocumentSymbol[] | undefined;
+
+  test("disabling features.documentSymbols removes LSP document symbols", async () => {
     const docUri = getDocUri("procs.tcl");
     await activate(docUri);
 
-    // Baseline: our LSP provides rich proc symbols with children/detail
-    const before = (await pollUntil(
-      () => vscode.commands.executeCommand("vscode.executeDocumentSymbolProvider", docUri),
-      (r) => Array.isArray(r) && (r as vscode.DocumentSymbol[]).some((s) => s.name === "fib"),
+    // Baseline: our LSP provides a 'fib' symbol by default. `fib`'s body has
+    // no nested proc/class/tcltest construct, so its `children` array is
+    // legitimately empty even when our provider is fully active -- proc
+    // parameters live in `.detail`, not `.children` (see `proc_symbol` in
+    // `rust/tcl-lsp-core/src/document_symbols.rs`). A previous version of
+    // this test asserted on `.children` richness instead of presence, which
+    // was wrong about what the provider actually returns; wrapped in a
+    // guard that only ran the "after" assertion when that (near-always
+    // false) premise held, the bug was invisible because the test never
+    // actually asserted anything.
+    const before = await pollUntil(
+      () => documentSymbolsOf(docUri),
+      (r): r is vscode.DocumentSymbol[] => Array.isArray(r) && r.some((s) => s.name === "fib"),
       { timeout: 10_000, label: "document symbols before disable (feature)" },
-    )) as vscode.DocumentSymbol[];
-    const fibBefore = before.find((s) => s.name === "fib");
-    assert.ok(fibBefore, "LSP should provide 'fib' symbol by default");
-    // Our LSP symbols have children (proc parameters, body elements)
-    const richBefore = fibBefore.children && fibBefore.children.length > 0;
+    );
+    assert.ok(
+      before.some((s) => s.name === "fib"),
+      "LSP should provide a 'fib' symbol by default",
+    );
 
     const config = vscode.workspace.getConfiguration("tclLsp.features");
     try {
       await config.update("documentSymbols", false, undefined);
       await waitForFeatureToggle(docUri, "documentSymbols", false);
 
-      const after = (await vscode.commands.executeCommand(
-        "vscode.executeDocumentSymbolProvider",
+      // Wait on the *result*, not on a single sample of it (issue #1295):
+      // the toggle barrier above only proves the server's effective config
+      // moved, not that a request issued now is answered under the new
+      // config. The server's `document_symbol` handler returns `None` when
+      // the feature is off (`rust/tcl-lsp-server/src/lib.rs`) and there is
+      // no other outline provider registered for Tcl, so the answer should
+      // become empty entirely -- and because the wait rejects rather than
+      // resolving, a feature that genuinely never stops answering fails
+      // here loudly and deterministically instead of an assertion that
+      // silently never runs.
+      const after = await waitForProviderResult(
         docUri,
-      )) as vscode.DocumentSymbol[];
-      if (richBefore && after && after.length > 0) {
-        // When our provider is disabled, VS Code's built-in may still
-        // find symbols but without the rich children our LSP provides.
-        const fibAfter = after.find((s) => s.name === "fib");
-        if (fibAfter) {
-          const richAfter = fibAfter.children && fibAfter.children.length > 0;
-          assert.ok(!richAfter, "LSP 'fib' symbol should lose children when provider disabled");
-        }
-      }
+        () => documentSymbolsOf(docUri),
+        (r) => !r || r.length === 0,
+        {
+          timeout: 10_000,
+          label: "document symbols to disappear after disabling the feature",
+          describe: (r) => (r === undefined ? "<undefined>" : `${r.length} symbol(s)`),
+        },
+      );
+      assert.ok(
+        !after || after.length === 0,
+        `Document symbols should be suppressed when disabled, got ${after?.length ?? 0}`,
+      );
     } finally {
       await config.update("documentSymbols", undefined, undefined);
       await waitForFeatureToggle(docUri, "documentSymbols", true);

--- a/editors/vscode/src/test/configSettings.test.ts
+++ b/editors/vscode/src/test/configSettings.test.ts
@@ -818,11 +818,33 @@ suite("Configuration Settings", () => {
     }
   });
 
-  const documentSymbolsOf = async (
-    docUri: vscode.Uri,
-  ): Promise<vscode.DocumentSymbol[] | undefined> =>
-    (await vscode.commands.executeCommand("vscode.executeDocumentSymbolProvider", docUri)) as
-      vscode.DocumentSymbol[] | undefined;
+  /** Shape of a raw `textDocument/documentSymbol` response entry -- enough of
+   *  it for this test's purposes (name + nesting), not the full LSP type. */
+  interface RawDocumentSymbol {
+    name: string;
+    children?: RawDocumentSymbol[];
+  }
+
+  /**
+   * Raw `textDocument/documentSymbol` request, bypassing
+   * `vscode.executeDocumentSymbolProvider`. That command is unsuitable for
+   * the toggle test below for the same reason `foldingRangeViaLsp` bypasses
+   * `executeFoldingRangeProvider`: confirmed by a throwaway diagnostic run
+   * (comparing both paths side by side after disabling the feature), VS
+   * Code's own outline/breadcrumbs model caches the last
+   * `executeDocumentSymbolProvider` answer for a document and does not
+   * invalidate it on a bare config change with no document edit -- so the
+   * command kept returning the pre-toggle symbols indefinitely while the raw
+   * request correctly returned `null`, matching the passing server-side e2e
+   * contract test (`rust/tcl-lsp-server/tests/e2e/config.rs`,
+   * `disabling_document_symbols_suppresses_provider`). The raw request is
+   * what the LSP client's registered DocumentSymbolProvider actually
+   * receives from the server.
+   */
+  const documentSymbolsViaLsp = (docUri: vscode.Uri): Promise<RawDocumentSymbol[] | null> =>
+    getClient().sendRequest("textDocument/documentSymbol", {
+      textDocument: { uri: docUri.toString() },
+    }) as Promise<RawDocumentSymbol[] | null>;
 
   test("disabling features.documentSymbols removes LSP document symbols", async () => {
     const docUri = getDocUri("procs.tcl");
@@ -839,8 +861,8 @@ suite("Configuration Settings", () => {
     // false) premise held, the bug was invisible because the test never
     // actually asserted anything.
     const before = await pollUntil(
-      () => documentSymbolsOf(docUri),
-      (r): r is vscode.DocumentSymbol[] => Array.isArray(r) && r.some((s) => s.name === "fib"),
+      () => documentSymbolsViaLsp(docUri),
+      (r): r is RawDocumentSymbol[] => Array.isArray(r) && r.some((s) => s.name === "fib"),
       { timeout: 10_000, label: "document symbols before disable (feature)" },
     );
     assert.ok(
@@ -865,12 +887,12 @@ suite("Configuration Settings", () => {
       // silently never runs.
       const after = await waitForProviderResult(
         docUri,
-        () => documentSymbolsOf(docUri),
+        () => documentSymbolsViaLsp(docUri),
         (r) => !r || r.length === 0,
         {
           timeout: 10_000,
           label: "document symbols to disappear after disabling the feature",
-          describe: (r) => (r === undefined ? "<undefined>" : `${r.length} symbol(s)`),
+          describe: (r) => (r === null || r === undefined ? "<none>" : `${r.length} symbol(s)`),
         },
       );
       assert.ok(

--- a/editors/vscode/src/test/inlayHints.test.ts
+++ b/editors/vscode/src/test/inlayHints.test.ts
@@ -18,7 +18,19 @@
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getDocUri, activate } from "./helper";
+import { getDocUri, activate, pollUntil } from "./helper";
+
+/** Raw `vscode.executeInlayHintProvider` pull, shared by every test below so
+ *  the polling loops that wait on it (via `pollUntil`) do not each redeclare
+ *  the same `executeCommand` call. */
+function inlayHintsOf(
+  uri: vscode.Uri,
+  range: vscode.Range,
+): Thenable<vscode.InlayHint[] | undefined> {
+  return vscode.commands.executeCommand("vscode.executeInlayHintProvider", uri, range) as Thenable<
+    vscode.InlayHint[] | undefined
+  >;
+}
 
 suite("Inlay Hints", () => {
   const docUri = getDocUri("simple.tcl");
@@ -57,22 +69,17 @@ suite("Inlay Hints", () => {
       });
       await vscode.window.showTextDocument(doc);
 
-      // Poll for the server to process the change (up to 10s).
+      // Poll for the server to process the change (up to 10s). Accept either
+      // `undefined` (server hasn't produced yet) or a valid array -- this
+      // wait only needs the provider to have settled *some* answer, not a
+      // non-empty one, so it stops the instant that happens rather than
+      // sleeping out the interval like the hand-rolled loop this replaced.
       const fullRange = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(10, 0));
-      let hints: vscode.InlayHint[] | undefined;
-      const deadline = Date.now() + 10_000;
-      while (Date.now() < deadline) {
-        hints = (await vscode.commands.executeCommand(
-          "vscode.executeInlayHintProvider",
-          doc.uri,
-          fullRange,
-        )) as vscode.InlayHint[] | undefined;
-        // Accept either null (server hasn't produced yet) or a valid array.
-        if (hints !== undefined) {
-          break;
-        }
-        await new Promise((r) => setTimeout(r, 250));
-      }
+      const hints = await pollUntil(
+        () => inlayHintsOf(doc.uri, fullRange),
+        (r) => r !== undefined,
+        { timeout: 10_000, label: "inlay hints to settle with inlayTypeHints enabled" },
+      ).catch(() => undefined); // No signal ever settling is itself a valid (if unlikely) outcome here.
 
       // When enabled, the server may or may not produce inlay hints
       // depending on the analysis; just verify no error.
@@ -105,21 +112,11 @@ suite("Inlay Hints", () => {
       await vscode.window.showTextDocument(doc);
 
       const fullRange = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(10, 0));
-      let hints: vscode.InlayHint[] | undefined;
-      const deadline = Date.now() + 10_000;
-      while (Date.now() < deadline) {
-        hints = (await vscode.commands.executeCommand(
-          "vscode.executeInlayHintProvider",
-          doc.uri,
-          fullRange,
-        )) as vscode.InlayHint[] | undefined;
-        if (hints && hints.length > 0) {
-          break;
-        }
-        await new Promise((r) => setTimeout(r, 250));
-      }
-
-      assert.ok(hints && hints.length > 0, "expected inlay hints with the feature enabled");
+      const hints = await pollUntil(
+        () => inlayHintsOf(doc.uri, fullRange),
+        (r): r is vscode.InlayHint[] => !!r && r.length > 0,
+        { timeout: 10_000, label: "inlay hints with inlayParameterHints enabled" },
+      );
 
       const labelText = (hint: vscode.InlayHint): string =>
         typeof hint.label === "string" ? hint.label : hint.label.map((p) => p.value).join("");
@@ -179,34 +176,26 @@ suite("Inlay Hints", () => {
       });
       await vscode.window.showTextDocument(doc);
 
+      // Wait for the *steady state* after both config changes propagate to the
+      // server: the parameter hint present AND the type hint gone. Resolving
+      // the moment a parameter hint appears would race the
+      // `inlayTypeHints=false` change — a previous test may have left type
+      // hints on, and they linger until the config update lands.
       const fullRange = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(10, 0));
-      let hints: vscode.InlayHint[] | undefined;
-      const deadline = Date.now() + 10_000;
-      while (Date.now() < deadline) {
-        hints = (await vscode.commands.executeCommand(
-          "vscode.executeInlayHintProvider",
-          doc.uri,
-          fullRange,
-        )) as vscode.InlayHint[] | undefined;
-        // Wait for the *steady state* after both config changes propagate to
-        // the server: the parameter hint present AND the type hint gone.
-        // Breaking the moment a parameter hint appears would race the
-        // `inlayTypeHints=false` change — a previous test may have left type
-        // hints on, and they linger until the config update lands.
-        const hasParam = hints?.some((h) => h.kind === vscode.InlayHintKind.Parameter) ?? false;
-        const hasType = hints?.some((h) => h.kind === vscode.InlayHintKind.Type) ?? false;
-        if (hasParam && !hasType) {
-          break;
-        }
-        await new Promise((r) => setTimeout(r, 250));
-      }
+      const hints = await pollUntil(
+        () => inlayHintsOf(doc.uri, fullRange),
+        (r): r is vscode.InlayHint[] =>
+          (r?.some((h) => h.kind === vscode.InlayHintKind.Parameter) ?? false) &&
+          !(r?.some((h) => h.kind === vscode.InlayHintKind.Type) ?? false),
+        { timeout: 10_000, label: "inlay hints to settle with only inlayParameterHints enabled" },
+      );
 
       assert.ok(
-        hints && hints.some((h) => h.kind === vscode.InlayHintKind.Parameter),
+        hints.some((h) => h.kind === vscode.InlayHintKind.Parameter),
         "expected a parameter-kind hint with inlayParameterHints enabled",
       );
       assert.ok(
-        !hints!.some((h) => h.kind === vscode.InlayHintKind.Type),
+        !hints.some((h) => h.kind === vscode.InlayHintKind.Type),
         "type hints must stay off when only inlayParameterHints is enabled",
       );
     } finally {
@@ -233,33 +222,25 @@ suite("Inlay Hints", () => {
       });
       await vscode.window.showTextDocument(doc);
 
+      // Wait for the *steady state*: the type hint present AND parameter
+      // labels gone. Resolving the moment a type hint appears would race the
+      // `inlayParameterHints=false` change — a previous test may have left
+      // parameter labels on until the config update propagates.
       const fullRange = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(10, 0));
-      let hints: vscode.InlayHint[] | undefined;
-      const deadline = Date.now() + 10_000;
-      while (Date.now() < deadline) {
-        hints = (await vscode.commands.executeCommand(
-          "vscode.executeInlayHintProvider",
-          doc.uri,
-          fullRange,
-        )) as vscode.InlayHint[] | undefined;
-        // Wait for the *steady state*: the type hint present AND parameter
-        // labels gone.  Breaking the moment a type hint appears would race
-        // the `inlayParameterHints=false` change — a previous test may have
-        // left parameter labels on until the config update propagates.
-        const hasType = hints?.some((h) => h.kind === vscode.InlayHintKind.Type) ?? false;
-        const hasParam = hints?.some((h) => h.kind === vscode.InlayHintKind.Parameter) ?? false;
-        if (hasType && !hasParam) {
-          break;
-        }
-        await new Promise((r) => setTimeout(r, 250));
-      }
+      const hints = await pollUntil(
+        () => inlayHintsOf(doc.uri, fullRange),
+        (r): r is vscode.InlayHint[] =>
+          (r?.some((h) => h.kind === vscode.InlayHintKind.Type) ?? false) &&
+          !(r?.some((h) => h.kind === vscode.InlayHintKind.Parameter) ?? false),
+        { timeout: 10_000, label: "inlay hints to settle with only inlayTypeHints enabled" },
+      );
 
       assert.ok(
-        hints && hints.some((h) => h.kind === vscode.InlayHintKind.Type),
+        hints.some((h) => h.kind === vscode.InlayHintKind.Type),
         "expected a type-kind hint with inlayTypeHints enabled",
       );
       assert.ok(
-        !hints!.some((h) => h.kind === vscode.InlayHintKind.Parameter),
+        !hints.some((h) => h.kind === vscode.InlayHintKind.Parameter),
         "parameter labels must stay off when only inlayTypeHints is enabled",
       );
     } finally {

--- a/editors/vscode/src/test/waitDiscipline.test.ts
+++ b/editors/vscode/src/test/waitDiscipline.test.ts
@@ -33,6 +33,7 @@ import {
   scaledTimeout,
   serverTransportWedged,
   waitForDiagnostics,
+  waitForProviderResult,
 } from "./helper";
 
 // Properties of the wait discipline itself (issue #1274).
@@ -171,6 +172,51 @@ suite("Wait discipline (issue #1274)", () => {
     assert.ok(
       elapsed < boundCeiling(base),
       `stall must fail at its bound; took ${elapsed}ms for a ${base}ms base`,
+    );
+  });
+
+  test("waitForProviderResult rejects loudly when the provider's answer never changes (issue #1295 shape)", async () => {
+    // The shape #1295 exists to catch: a feature-toggle "after" sample whose
+    // provider keeps answering with its pre-toggle result. Prove the failure
+    // is loud (rejects, names what was awaited and what was last seen)
+    // rather than silent (resolving with the stale value and letting the
+    // caller's assertion pass or fail on its own, or worse, pass vacuously).
+    await activate(docUri);
+    const base = 500;
+    const started = Date.now();
+    let probes = 0;
+    let error: Error | undefined;
+    try {
+      const result = await waitForProviderResult<number>(
+        docUri,
+        () => {
+          probes++;
+          return 7; // a "depth" that never drops, as if a toggle never took effect
+        },
+        (depth) => depth < 7,
+        { timeout: base, backstopInterval: 20, label: "depth to drop below 7" },
+      );
+      assert.fail(`waitForProviderResult resolved with ${result} instead of rejecting`);
+    } catch (err) {
+      error = err as Error;
+    }
+    const elapsed = Date.now() - started;
+    assert.ok(error, "expected a rejection");
+    assert.ok(
+      error.message.includes("VSCODE-WAIT-TIMEOUT"),
+      `failure must carry the greppable marker: ${error.message}`,
+    );
+    assert.ok(
+      error.message.includes("depth to drop below 7"),
+      `failure must name what was awaited: ${error.message}`,
+    );
+    assert.ok(
+      elapsed < boundCeiling(base),
+      `stall must fail at its bound; took ${elapsed}ms for a ${base}ms base`,
+    );
+    assert.ok(
+      probes > 1,
+      `the provider must have been re-probed, not sampled once; got ${probes} probe(s)`,
     );
   });
 


### PR DESCRIPTION
## Summary

- **#1293** (progress-driven suite budget) was already fixed on `rust` before this branch started (commit `3279e85` / PR #1307, which this branch's base includes): `editors/vscode/src/test/runnerWatchdog.ts` centralises a pure `evaluateWatchdog` decision function — heartbeat-driven (`completed`/`failed`/in-flight-title progress), not wall-clock — shared by both `runTest.ts` and `runMultiFolderTest.ts`, with a generous absolute-ceiling backstop and honest wording ("absolute ceiling reached while still completing tests", never "likely hung"). `runnerWatchdog.test.ts` unit-tests all the required verdicts directly against the pure function (true-negative past the old 180s budget, true-positive stall, never-started, ceiling-while-progressing). I verified this against every requirement in the ask and left it alone rather than duplicate working code.
- **#1295** (asymmetric feature-toggle wait): the named `selectionRange` test was also already fixed in the same prior commit. I audited the rest of `configSettings.test.ts` and its siblings per the issue's explicit "fix every instance" instruction and found two more real cases of the same single-sample-after-toggle shape, plus a duplicated hand-rolled polling pattern:
  - `disabling features.documentSymbols …` took a single unbounded sample after the toggle, guarded by `if (richBefore && ...)` — which was permanently false (the test's premise about `.children` was simply wrong: proc params live in `.detail`, not `.children`; see `rust/tcl-lsp-core/src/document_symbols.rs`), so the assertion never actually ran. Converting to a bounded `waitForProviderResult` wait correctly exposed this and initially failed *deterministically*, including in isolation. Root-caused it before assuming a product bug: the server-side e2e contract test (`disabling_document_symbols_suppresses_provider`, `rust/tcl-lsp-server/tests/e2e/config.rs`) already passed, and a raw `textDocument/documentSymbol` request bypassing `vscode.executeDocumentSymbolProvider` returned the correct answer immediately. The VS Code command itself was the problem — its outline/breadcrumbs model caches the last answer and doesn't invalidate on a bare config change, the same class of issue this file already worked around for `executeFoldingRangeProvider` via `foldingRangeViaLsp`. Applied the identical fix (query the server directly over `textDocument/documentSymbol`). **No product bug** — see the evidence below.
  - `editor.folding=false does not suppress the LSP folding provider (issue #1122)` had the same single-sample shape on its `after` read; converted to a bounded `pollUntil` for consistency.
  - `inlayHints.test.ts` had four hand-rolled `while (Date.now() < deadline) { …; await sleep(250) }` polling loops duplicating `pollUntil`; centralised onto the shared helper (per the "factor out what is duplicated" constraint).
  - Added dedicated loud-failure coverage: `waitForProviderResult rejects loudly when the provider's answer never changes (issue #1295 shape)` in `waitDiscipline.test.ts`, pinned directly against the helper the #1295 conversions use (not just the generic `awaitSignal` coverage that already existed).
- **Docs**: new KCS note `docs/kcs/kcs-issue-vscode-test-feature-toggle-sampled-once.md` (Contributor/Issue) covering the #1295 shape, the fix, and — importantly — how to tell a genuine product bug apart from a VS Code test-instrument artifact like the one found here (cross-check the Rust e2e contract test + a raw LSP request before concluding the toggle itself is broken). Linked from `docs/kcs/README.md` and cross-linked with the existing #1293 note.
- No product/server code was changed — every fix here is in the VS Code test harness (`editors/vscode/src/test/**`) and docs.
- No new `#[allow(clippy::…)]` or `eslint-disable` comments were added anywhere in this change.
- Issue #1334 (the stdio deadlock wedge) was not touched — the stall-detection/server-probe machinery it depends on is unmodified.

## Validation

Commands run, with real output:

```
$ make lint-ts typecheck-ts
==> Linting TypeScript code (ESLint + Prettier check)   -> clean
==> Type-checking TypeScript code with tsc               -> clean

$ cd editors/vscode && npx tsc --noEmit -p .              -> clean, no output

$ cargo xtask kcs-index-links
KCS docs checks passed with 1 warnings (pre-existing, unrelated file):
- KCS note missing `> **Audience:**` header: docs/kcs/kcs-howto-array-element-ssa-typing.md
KCS docs checks passed.
```

`make test-ext` (single-root + multi-root, xvfb, native Rust server), full run against the final tree:

```
==> Running VS Code extension tests (native server: …/target/release/tcl-lsp-server)
 866 passing (4m)
Exit code:   0
==> Running multi-root VS Code extension tests
 14 passing (7s)
Exit code:   0
```

Zero failures across both suites. The single-root run alone (~4 minutes / ~240s wall clock) is well past the old fixed 180s budget this repo used to have before #1293 — a direct demonstration that the progress-driven watchdog does not kill a slow-but-honest green run. (866 = the 864-passing baseline this suite already had on `rust`, plus the 2 tests added here: the previously-hidden `documentSymbols` case now genuinely asserting and passing, and the new `waitForProviderResult` loud-failure test.)

Investigation history for the `documentSymbols` case (kept because it's the interesting part of this PR):
1. First full run after converting the wait: `864 passing, 1 failing` — but that failure was at the *baseline* assertion, from my own initial (wrong) premise about `.children` richness. Fixed the test's premise.
2. Second full run: `864 passing, 1 failing` again, this time at the *bound* — `waited 49904ms … last seen: 3 symbol(s)`, i.e. deterministically stuck on the pre-toggle answer. Reproduced in isolation via `MOCHA_GREP` (`waited 55104ms … 1028 probe(s) … last seen: 3 symbol(s)`) to rule out full-suite ordering effects.
3. Ran the equivalent server-side contract test directly: `cargo test -p tcl-lsp-server --test e2e disabling_document_symbols_suppresses_provider` → `test result: ok. 1 passed`, 0.67s. Server behaviour is correct.
4. Added a throwaway diagnostic test comparing a raw `textDocument/documentSymbol` request against `vscode.executeDocumentSymbolProvider` side by side after disabling: raw → `null` (correct), VS Code command → the same 3 pre-toggle symbols (stale). Confirmed the test-instrument hypothesis, applied the `foldingRangeViaLsp`-style fix, removed the diagnostic, and reran in isolation — passes reliably (`4003ms`).

Things I could not fully verify:
- The exact CI-mirrored `pr-gate` job (Rust fmt/clippy/xtask drift) was not re-run here since no Rust source changed in this PR (only test/docs) — `make rust-check` was not part of this change's surface, per AGENTS.md's own scoping (`make check-all` is the push gate for the languages actually touched; the heavier Rust suites `test-rust`/`runtime-rust-test`/`test-emacs` are unaffected by this change and were not re-run for that reason, not because they were skipped under time pressure).
- This box was under heavy contention throughout (other agents' concurrent worktree builds; load average reached ~14 on a 4-core machine mid-session), which is why several of the intermediate diagnostic runs show inflated wait times and measured load factors in the ~3.6–4.5x range — the harness's own load-scaling and starvation-probe wording is what made those readable rather than confusing, which is itself a small piece of evidence the mechanism this PR is about works as designed.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? — No, this PR touches only the VS Code test harness and KCS docs.
- [ ] N/A — no compiler KCS note needed.
- [ ] N/A — no new compiler KCS note added.

---
_Generated by [Claude Code](https://claude.ai/code/session_013q5EKuiUJfZyRT4AeppMto)_