### PR TITLE
Emit analysed Tcl object operations in WASM

### DIFF
--- a/docs/design/compiler/wasm-codegen.md
+++ b/docs/design/compiler/wasm-codegen.md
@@ -1,220 +1,107 @@
 # WASM codegen pipeline
 
-Walkthrough of how a Tcl script becomes a `tcl_runtime.wasm`-linkable
-module, end to end.  Links into the actual files so a contributor can
-follow the flow.
+The Rust WASM backend emits Tcl-object operations from the compiler's lowered
+program. Unsupported statements retain an exact source-span fallback to the
+runtime interpreter.
 
-## Entry point
+## Entry points
 
-`compiler/codegen/wasm/__init__.py::wasm_codegen_module(ir_module)`
-produces a `WasmModule` (defined in `_ir.py`) from an `IRModule`.
-That's the top of the call graph — every other file below executes
-under this call.
+`codegen::wasm::wasm_codegen_compilation_unit` is the analysis-aware entry
+point used by `tcl compwasm --backend tree-walker`. It consumes the existing
+`CompilationUnit`, including its lowered IR, CFG, SSA, SCCP results, type
+lattices, and original CST-derived source spans.
 
-## The six phases
+`wasm_codegen_module` remains available for callers that only have an IR
+module. It emits the structured control-flow and source-evaluation fallback,
+but does not attempt direct calls because it has no binding proof.
 
-### Phase 0 — Var-escape analysis (per proc)
+## Direct-emission proof
 
-`compiler/var_escape/` runs before codegen starts.  For each
-`IRProcedure` it identifies which local variables escape the frame
-(via `upvar`, `variable`, dynamic `$name` reads, etc.) and tags them
-`FRAME`.  The WASM emitter later routes those reads/writes through
-`tcl_local_set` / `tcl_local_get` instead of a plain WASM local slot.
+The backend specialises a statement only when all required compiler facts
+agree:
 
-### Phase 1 — Pre-scan IR for runtime imports
+1. Lowering produced a typed IR statement or expression AST the emitter
+   supports.
+2. The flow-sensitive command-binding lattice proves that a builtin or user
+   procedure name still denotes the expected command at that statement.
+3. The whole-module command-mutation summary proves no procedure body can
+   rename or alias that binding later.
+4. A direct arithmetic procedure has a numeric return in the type lattice and
+   a supported expression tree.
+5. The command's `CommandSpec.wasm_codegen_hook` selects the runtime operation.
 
-`_scan.py::_scan_needed_imports()` walks the full IR tree once —
-every `IRCall`, embedded `[cmd]` substitution, `expr` operator, and
-statement-level side effect — and accumulates the set of runtime
-imports the emitter will need (`tcl_puts`, `tcl_list_index`, `tcl_arith_add`,
-…).  This is a read-only pass; no code emitted yet.
+If any proof is absent, the structured walk passes the statement's original
+source span to `tcl_eval_code`. This keeps dynamic Tcl semantics as the
+conservative boundary.
 
-The scan also descends into `ir_module.methods` (TclOO method bodies).
-Method *functions* are not emitted to WASM — they are dispatched by the
-bundled runtime's interpreter at call time — but their bodies still need
-the runtime imports for the commands they invoke, so an OO program whose
-methods use a command not used elsewhere correctly declares that import.
-(`build_cfg` deliberately excludes methods from `cfg_module.procedures`,
-so Phase 5 never emits a method as a standalone callable.)
+## Tcl-object stack and variables
 
-The scan reads import keys from two sources:
-1. `runtime_import_for(command)` — walks `CommandSpec.wasm_runtime_import`
-   on every matching spec.
-2. `subcommand_runtime_import_for(command, subcommand)` — same for
-   `SubCommand.wasm_runtime_import`.
+Generated values are `i32` pointers to owned `TclObj` values in shared linear
+memory. Procedure parameters are WebAssembly parameters of that same type.
 
-The legacy `_RUNTIME_IMPORTS` dict in `_imports.py` is still used for
-infrastructure imports (obj lifecycle, arith ops, frame ops) that
-don't have a command owner.
+Compiled procedure locals have two ports onto one runtime variable cell:
 
-### Phase 2 — Register imports as WASM function indices
+- an indexed slot used by generated `local_get` and `local_set` operations;
+- the ordinary Tcl name used by traces, `upvar`, and interpreted fallback.
 
-Back in `wasm_codegen_module()`, the set collected by Phase 1 is
-allocated `funcref` indices in the `WasmModule.imports` section.  The
-order matters — WASM function references are opaque indices into the
-full `(imports ++ defined_funcs)` table, so every `call $idx`
-instruction elsewhere in the module assumes this order.  The scan
-phase produces a deterministic set; Phase 2 sorts it and assigns
-indices `0..N-1`.
+The procedure prologue binds each slot index to its Tcl-visible name in the
+normal call frame. This deliberately preserves Tcl semantics before later
+escape and representation passes prove that a variable can become a plain
+WebAssembly local.
 
-### Phase 3 — Build proc index + namespace-import tables
+## Current direct tier
 
-For each `IRProcedure` in the module, the emitter pre-allocates a
-function index and collects `namespace import` / `namespace export` /
-`namespace forget` declarations so the prologue of each proc can emit
-the alias-setup calls.
+The initial direct tier covers:
 
-### Phase 4 — Compile `::top` (the module's top-level script)
+- literal top-level `set` assignments;
+- lowered procedure registration without evaluating the `proc` command;
+- fixed-arity procedures whose body is a supported numeric return expression;
+- variable reads through indexed procedure slots or named top-level cells;
+- Tcl numeric-tower addition;
+- binding-proven direct user-procedure calls in command substitution;
+- the one-argument stdout form of registry-stamped `puts`.
 
-The script body is emitted into function 0 (exported as `::top`).
-`_statements.py::_WasmEmitterStmtMixin._emit_stmt()` is the entry
-point; it pattern-matches on `IRStatement` variants:
+For example, the procedure in:
 
-- `IRCall(command, args, defs)` — the main dispatch path (see below).
-- `IRAssignConst` / `IRAssignValue` / `IRAssignExpr` — value-to-var
-  store.
-- `IRIf` / `IRWhile` / `IRFor` / `IRForeach` / `IRSwitch` / `IRTry`
-  — control flow, handled by `_control_flow.py`.
-- `IRReturn` — inlined proc return.
-- `IRBarrier` — an IR node that forces the emitter to fall back to
-  `tcl_eval()` for a specific command.
+```tcl
+proc add {b c} {
+    return [expr {$b + $c}]
+}
 
-### Phase 5 — Compile each proc / method
-
-Same path as Phase 4 but the prologue sets up per-proc state: frame
-push, namespace push, argv materialisation (for `info level 0`), and
-default-argument fill-in.
-
-## Per-statement command dispatch
-
-`_statements.py::_emit_call_stmt()` — called for every `IRCall` —
-resolves in this order:
-
-1. Synthetic markers: `<upvar-invalidate>`, `<cond>` (no emit).
-2. `command_emits_nothing(command)` — scope-declaration commands
-   (`global`, `upvar`, `variable`, `foreach`, `namespace eval` in
-   some contexts).  Their side-effects are captured by the IR; the
-   call itself emits nothing.
-3. User-defined proc call — `_proc_index` lookup.
-4. Registry hook — `REGISTRY.get_wasm_hook(command)` finds a
-   `codegens["wasm"]` entry on the `CommandSpec` (or `SubCommand`
-   via Phase B.8's `wasm_runtime_import` on SubCommand).  Hooks are
-   registered by modules under `_emitter/cmds/` at import time (see
-   `_emitter/__init__.py`'s `from . import cmds as _cmds`).
-5. Specialised branches for `catch`, `break`, `continue`, bare
-   `return`.
-6. Generic runtime dispatch — `_emit_cmd_runtime(command, args, defs,
-   context)` uses the `WasmRuntimeImport` on the spec (via
-   `runtime_import_for(command)`) to find the target import, builds
-   the arg stack, calls, and drops/stores/keeps the result via
-   `_runtime_call_end(spec, defs, context)`.
-7. Eval fallback — `tcl_eval(<script>)` for anything still
-   unhandled.
-
-## Per-command files
-
-After Phases E.2 / E.3 each Tcl command's Python WASM codegen lives
-in one file under `_emitter/cmds/`:
-
-```
-_emitter/cmds/
-├── set_.py          # set, incr
-├── return_.py       # return
-├── list_.py         # list, lset, lassign, + helpers
-├── string_.py       # string + subcommand dispatch
-├── dict_.py         # dict + subcommand dispatch
-├── info_.py         # info + its big inline impl
-├── array_.py        # array subcmd helpers + array set literal
-├── clock_.py        # clock subcommand dispatch
-├── uplevel_.py      # uplevel, array, unset hooks + helpers
-├── scope_.py        # global, upvar, variable
-├── catch_.py        # catch
-├── runtime_.py      # auto-registration loop over specs with
-│                    #   CommandSpec.wasm_runtime_import
-└── __init__.py      # imports all of the above for side-effect
-                     #   registration
+set e 2
+set f 4
+puts [add $e $f]
 ```
 
-Each file:
-1. Imports `REGISTRY` / `EmitContext` from the registry package.
-2. Defines hook functions: `def _emit_cmd(emitter, args, defs, context)
-   -> bool`.
-3. Calls `REGISTRY.register_wasm_emitter("cmd", _emit_cmd)` at import
-   time.
-4. May also declare a small mixin class (`_CmdFooMixin`) exposing
-   helper functions as methods — this is how per-command helpers
-   like `_emit_info_value` reach the emitter without being defined
-   on a central `_cmd_helpers.py` mixin.
+is emitted as an `(i32, i32) -> i32` WebAssembly function. The top-level
+function registers its source metadata, stores `e` and `f`, loads both values,
+calls the generated `::add` function, and passes its result to the runtime
+`puts` primitive. None of those statements calls `tcl_eval_code`.
 
-## Runtime interop contract
+## Runtime ownership contract
 
-Each spec that maps to a runtime import declares a
-`WasmRuntimeImport(import_key, argc, nontrapping, module, export_name,
-params, results)` on its `CommandSpec.wasm_runtime_import` field (or
-on the parent's `SubCommand.wasm_runtime_import` for sub-command
-dispatchers).  The fields:
+The codegen ABI in `runtime/rust/src/codegen_abi.rs` uses one owned reference
+for every generated operand-stack value:
 
-| field | meaning |
+| Operation | Ownership |
 |---|---|
-| `import_key` | Internal name used by the compiler to refer to the import (e.g. `"tcl_puts"`) |
-| `argc` | Fixed argument count, or `None` for variadic |
-| `nontrapping` | When `True`, skip the `tcl_diag_set` preamble (runtime side is total) |
-| `module` | WASM import module (typically `"tcl"`) |
-| `export_name` | Runtime-exported symbol (defaults to `tcl_cmd_<key[4:]>`) |
-| `params` | WASM value types — `("i32",)`, `("i64", "i32")`, etc. |
-| `results` | WASM result types (`()` for void) |
+| `tcl_value_new_string` | returns `+1` |
+| variable load | returns a new `+1` beside the cell's reference |
+| variable store/bind | consumes the operand `+1`; the cell retains its own |
+| arithmetic add | consumes both operands and returns `+1` |
+| direct procedure call | transfers argument references to the callee |
+| procedure return | transfers one result reference to the caller |
+| `tcl_codegen_puts` | consumes its value |
 
-The CI parity gate (`make check-wasm-parity`) cross-verifies every
-CommandSpec's arity + subcommand arity against the runtime's
-command-table arity fields.  Drift is impossible to merge.
+Procedure frame push/pop uses the runtime's ordinary `FrameStack`; popping a
+frame releases its stored variable references.
 
-## Reference map
+## Module layout
 
-| File | Role |
-|---|---|
-| `_emitter/__init__.py` | `_WasmEmitter` class composition — multi-mixin inheritance |
-| `_emitter/_core.py` | Base class with state: locals, aliases, strings, imports |
-| `_emitter/_statements.py` | Statement dispatch, `_emit_call_stmt` |
-| `_emitter/_expressions.py` | `expr` language codegen |
-| `_emitter/_values.py` | Value-context codegen (`[cmd]` in expressions) |
-| `_emitter/_control_flow.py` | `if` / `while` / `for` / `foreach` / `switch` / `try` / `catch` |
-| `_emitter/_variables.py` | `set` / `incr` / alias handling / frame escape routing |
-| `_emitter/_commands.py` | Generic `_emit_cmd_runtime` + `_runtime_prep` / `_runtime_call_end` helpers + `_emit_cmd_proc_call` |
-| `_emitter/_optimisation.py` | Constant folding, barrier short-circuiting |
-| `_emitter/_ops.py` | Expr operator → WASM op translation |
-| `_emitter/cmds/*.py` | Per-command hook registration + helpers |
-| `_scan.py` | Pre-codegen IR scan for runtime imports |
-| `_imports.py` | Infrastructure FFI signatures; `import_signature()` helper |
-| `_ir.py` | WASM binary format, `ValType`, `WasmOp`, `WasmModule` |
-| `_encoding.py` | LEB128, string interning, list quoting |
-| `_parsing.py` | `_parse_array_ref` and other cheap string lookups |
+Runtime functions are imported first. `::top` is the first defined function,
+followed by user procedures in qualified-name order, so direct call indices are
+deterministic. A relocated module places its constant pool at
+`RESERVED_DATA_BASE`, inside the memory window reserved by the Rust runtime.
 
-### `_core.py` cohesion — why it stays as one file
-
-After the Phase E per-command split, `_core.py` holds ~200 lines of
-`__init__` state, the `generate()` prologue/body/epilogue pipeline
-(~320 lines), and a handful of low-level emit helpers.  Decomposing
-it further was considered during Phase E.4 and declined: the state
-it owns — locals, strings, shared imports, proc metadata,
-namespace context, diag map, escape summary — is needed by every
-mixin, and `generate()` reads linearly through the proc prologue
-(frame push, namespace set, argv build, default substitution,
-param mirror) without natural seams.  Splitting would multiply
-mixin interfaces without reducing real complexity.  The Phase E
-per-command migration already achieved the main goal: individual
-command behaviour lives in `cmds/<name>_.py`, not in a central
-helpers mixin.
-
-### Per-command hook file layout
-
-Each file under `_emitter/cmds/` registers one or more
-`(name, hook)` pairs via `REGISTRY.register_wasm_emitter`.  Hooks
-receive `(emitter, args, defs, context)` and return `True` when
-they handled the call — returning `False` falls through to the
-next dispatch layer (generic runtime, eval fallback, trap).
-
-Import order inside `cmds/__init__.py` matters: the generic
-`runtime_.py` auto-registration loop runs last, skipping commands
-that already have a specialised hook (first-writer-wins).  New
-specialised hooks therefore only need to be imported in
-`cmds/__init__.py` before `runtime_` to take effect.
+The WAT renderer and binary encoder both consume the same `WasmModule` IR in
+`rust/tcl-compiler/src/codegen/wasm/ir.rs`.

--- a/runtime/rust/src/c_alloc.rs
+++ b/runtime/rust/src/c_alloc.rs
@@ -1,0 +1,135 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! C allocation symbols for the libtommath archive in a freestanding WASM
+//! runtime. The allocation size is stored ahead of the aligned user pointer
+//! because C's `free` and `realloc` do not carry Rust's required layout.
+
+#![cfg(all(target_arch = "wasm32", target_os = "unknown", have_tommath))]
+
+use core::ptr;
+use std::alloc::{alloc, alloc_zeroed, dealloc, realloc as rust_realloc, Layout};
+
+const ALIGN: usize = 16;
+const HEADER: usize = ALIGN;
+
+fn allocation_layout(size: usize) -> Option<Layout> {
+    Layout::from_size_align(HEADER.checked_add(size.max(1))?, ALIGN).ok()
+}
+
+unsafe fn store_size(base: *mut u8, size: usize) {
+    // SAFETY: every allocation reserves HEADER bytes before the user pointer.
+    unsafe { base.cast::<usize>().write(size.max(1)) };
+}
+
+unsafe fn allocation_base(value: *mut u8) -> *mut u8 {
+    // SAFETY: callers pass a pointer returned by this module.
+    unsafe { value.sub(HEADER) }
+}
+
+#[no_mangle]
+/// Allocate a maximally aligned C block.
+///
+/// # Safety
+/// The returned pointer must be released only by this module's `free` or `realloc`.
+pub unsafe extern "C" fn malloc(size: usize) -> *mut u8 {
+    let Some(layout) = allocation_layout(size) else {
+        return ptr::null_mut();
+    };
+    // SAFETY: layout is non-zero and has a power-of-two alignment.
+    let base = unsafe { alloc(layout) };
+    if base.is_null() {
+        return base;
+    }
+    // SAFETY: base owns layout's HEADER prefix.
+    unsafe { store_size(base, size) };
+    // SAFETY: HEADER lies within the allocation.
+    unsafe { base.add(HEADER) }
+}
+
+#[no_mangle]
+/// Allocate and zero a maximally aligned C block.
+///
+/// # Safety
+/// The returned pointer must be released only by this module's `free` or `realloc`.
+pub unsafe extern "C" fn calloc(count: usize, size: usize) -> *mut u8 {
+    let Some(bytes) = count.checked_mul(size) else {
+        return ptr::null_mut();
+    };
+    let Some(layout) = allocation_layout(bytes) else {
+        return ptr::null_mut();
+    };
+    // SAFETY: layout is non-zero and has a power-of-two alignment.
+    let base = unsafe { alloc_zeroed(layout) };
+    if base.is_null() {
+        return base;
+    }
+    // SAFETY: base owns layout's HEADER prefix.
+    unsafe { store_size(base, bytes) };
+    // SAFETY: HEADER lies within the allocation.
+    unsafe { base.add(HEADER) }
+}
+
+#[no_mangle]
+/// Release a block returned by this module.
+///
+/// # Safety
+/// `value` must be null or a live pointer returned by `malloc`, `calloc`, or `realloc`.
+pub unsafe extern "C" fn free(value: *mut u8) {
+    if value.is_null() {
+        return;
+    }
+    // SAFETY: value was returned by this module.
+    let base = unsafe { allocation_base(value) };
+    // SAFETY: the first header word stores the original allocation size.
+    let size = unsafe { base.cast::<usize>().read() };
+    if let Some(layout) = allocation_layout(size) {
+        // SAFETY: base was allocated with this exact layout.
+        unsafe { dealloc(base, layout) };
+    }
+}
+
+#[no_mangle]
+/// Resize a block returned by this module.
+///
+/// # Safety
+/// `value` must be null or a live pointer returned by this module.
+pub unsafe extern "C" fn realloc(value: *mut u8, size: usize) -> *mut u8 {
+    if value.is_null() {
+        // SAFETY: equivalent to C realloc(NULL, size).
+        return unsafe { malloc(size) };
+    }
+    // SAFETY: value was returned by this module.
+    let base = unsafe { allocation_base(value) };
+    // SAFETY: the first header word stores the original allocation size.
+    let old_size = unsafe { base.cast::<usize>().read() };
+    let (Some(old_layout), Some(new_layout)) =
+        (allocation_layout(old_size), allocation_layout(size))
+    else {
+        return ptr::null_mut();
+    };
+    // SAFETY: base owns old_layout and new_layout supplies the new byte count.
+    let new_base = unsafe { rust_realloc(base, old_layout, new_layout.size()) };
+    if new_base.is_null() {
+        return new_base;
+    }
+    // SAFETY: new_base owns the resized allocation's HEADER prefix.
+    unsafe { store_size(new_base, size) };
+    // SAFETY: HEADER lies within the allocation.
+    unsafe { new_base.add(HEADER) }
+}

--- a/runtime/rust/src/cmd_chan.rs
+++ b/runtime/rust/src/cmd_chan.rs
@@ -411,7 +411,7 @@ fn gets_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 }
 
 /// `puts ?-nonewline? ?channelId? string` — to stdout/stderr or a file channel.
-fn puts_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+pub(crate) fn puts_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let usage = b"puts ?-nonewline? ?channelId? string";
     let mut rest = &argv[1..];
     let mut newline = true;

--- a/runtime/rust/src/codegen_abi.rs
+++ b/runtime/rust/src/codegen_abi.rs
@@ -74,6 +74,14 @@ use core::ptr;
 use crate::interp::{drop_fresh, obj_bytes, Interp};
 use crate::obj::{self, new_string_bytes, TclObj};
 
+unsafe fn input_bytes<'a>(ptr: *const u8, len: i32) -> &'a [u8] {
+    if ptr.is_null() || len <= 0 {
+        return b"";
+    }
+    // SAFETY: codegen passes a data-segment address and its exact byte length.
+    unsafe { core::slice::from_raw_parts(ptr, len as usize) }
+}
+
 // The interp emitted modules evaluate against (see the module docs). Null until
 // the host calls [`tcl_runtime_set_current_interp`].
 //
@@ -151,6 +159,291 @@ pub unsafe extern "C" fn tcl_obj_new_string(ptr: *const u8, len: i32) -> *mut Tc
     // SAFETY: forwarded per this fn's contract.
     let slice = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
     new_string_bytes(slice)
+}
+
+/// Construct an owned Tcl value for the generated operand stack.
+///
+/// # Safety
+/// `ptr..ptr+len` must be readable shared linear memory when `len` is positive.
+#[no_mangle]
+pub unsafe extern "C" fn tcl_value_new_string(ptr: *const u8, len: i32) -> *mut TclObj {
+    let value = new_string_bytes(unsafe { input_bytes(ptr, len) });
+    // SAFETY: a generated operand-stack value owns one reference.
+    unsafe { obj::incr_ref_count(value) };
+    value
+}
+
+/// Release one generated operand-stack value.
+///
+/// # Safety
+/// `value` must carry one live reference owned by generated code.
+#[no_mangle]
+pub unsafe extern "C" fn tcl_value_release(value: *mut TclObj) {
+    // SAFETY: generated code transfers its owned stack reference here.
+    unsafe { obj::decr_ref_count(value) };
+}
+
+/// Push a name-addressable Tcl frame for a generated procedure.
+#[no_mangle]
+pub extern "C" fn tcl_codegen_frame_push() {
+    let interp = current_interp();
+    if !interp.is_null() {
+        // SAFETY: the bootstrap installed a live current interpreter.
+        unsafe { (*interp).codegen_frame_push() };
+    }
+}
+
+/// Pop the current generated procedure frame.
+#[no_mangle]
+pub extern "C" fn tcl_codegen_frame_pop() {
+    let interp = current_interp();
+    if !interp.is_null() {
+        // SAFETY: the bootstrap installed a live current interpreter.
+        unsafe { (*interp).codegen_frame_pop() };
+    }
+}
+
+/// Bind a compiled slot index to the Tcl-visible variable cell and store value.
+///
+/// # Safety
+/// The name range must be readable, and `value` must be a live owned reference.
+#[no_mangle]
+pub unsafe extern "C" fn tcl_codegen_local_bind(
+    slot: i32,
+    name_ptr: *const u8,
+    name_len: i32,
+    value: *mut TclObj,
+) -> i32 {
+    let interp = current_interp();
+    if interp.is_null() || slot < 0 || value.is_null() {
+        return 1;
+    }
+    let name = unsafe { input_bytes(name_ptr, name_len) };
+    // SAFETY: the bootstrap installed a live current interpreter.
+    let interp = unsafe { &mut *interp };
+    interp.codegen_bind_slot(usize::try_from(slot).unwrap_or(0), name);
+    let code = match interp.var_set(name, value) {
+        Ok(()) => 0,
+        Err(e) => i32::try_from(crate::builtins::var_error(interp, name, e).as_int()).unwrap_or(1),
+    };
+    // SAFETY: generated assignment transfers its operand-stack reference.
+    unsafe { obj::decr_ref_count(value) };
+    code
+}
+
+/// Store through an indexed compiled-local port.
+///
+/// # Safety
+/// `value` must be a live owned reference transferred by generated code.
+#[no_mangle]
+pub unsafe extern "C" fn tcl_codegen_local_set(slot: i32, value: *mut TclObj) -> i32 {
+    let interp = current_interp();
+    if interp.is_null() || slot < 0 || value.is_null() {
+        return 1;
+    }
+    // SAFETY: the bootstrap installed a live current interpreter.
+    let interp = unsafe { &mut *interp };
+    let Some(name) = interp.codegen_slot_name(usize::try_from(slot).unwrap_or(0)) else {
+        // SAFETY: generated assignment transfers its operand-stack reference.
+        unsafe { obj::decr_ref_count(value) };
+        return 1;
+    };
+    let code = match interp.var_set(&name, value) {
+        Ok(()) => 0,
+        Err(e) => i32::try_from(crate::builtins::var_error(interp, &name, e).as_int()).unwrap_or(1),
+    };
+    // SAFETY: generated assignment transfers its operand-stack reference.
+    unsafe { obj::decr_ref_count(value) };
+    code
+}
+
+/// Load through an indexed port, returning an owned operand-stack value.
+///
+/// # Safety
+/// The current interpreter and generated frame must remain live for the call.
+#[no_mangle]
+pub unsafe extern "C" fn tcl_codegen_local_get(slot: i32) -> *mut TclObj {
+    let interp = current_interp();
+    if interp.is_null() || slot < 0 {
+        return ptr::null_mut();
+    }
+    // SAFETY: the bootstrap installed a live current interpreter.
+    let interp = unsafe { &mut *interp };
+    let Some(name) = interp.codegen_slot_name(usize::try_from(slot).unwrap_or(0)) else {
+        return ptr::null_mut();
+    };
+    if interp.fire_read_trace(&name, None).is_some() {
+        return ptr::null_mut();
+    }
+    let Some(value) = interp.var_get(&name) else {
+        let msg = interp.read_miss_msg(&name, None);
+        interp.set_error(&msg);
+        return ptr::null_mut();
+    };
+    // SAFETY: the frame owns the existing reference; the stack claims another.
+    unsafe { obj::incr_ref_count(value) };
+    value
+}
+
+/// Store a top-level or namespace variable by name.
+///
+/// # Safety
+/// The name range must be readable, and `value` must be a live owned reference.
+#[no_mangle]
+pub unsafe extern "C" fn tcl_codegen_var_set(
+    name_ptr: *const u8,
+    name_len: i32,
+    value: *mut TclObj,
+) -> i32 {
+    let interp = current_interp();
+    if interp.is_null() || value.is_null() {
+        return 1;
+    }
+    let name = unsafe { input_bytes(name_ptr, name_len) };
+    // SAFETY: the bootstrap installed a live current interpreter.
+    let interp = unsafe { &mut *interp };
+    let code = match interp.var_set(name, value) {
+        Ok(()) => 0,
+        Err(e) => i32::try_from(crate::builtins::var_error(interp, name, e).as_int()).unwrap_or(1),
+    };
+    // SAFETY: generated assignment transfers its operand-stack reference.
+    unsafe { obj::decr_ref_count(value) };
+    code
+}
+
+/// Load a top-level or namespace variable by name as an owned stack value.
+///
+/// # Safety
+/// The name range must be readable shared linear memory.
+#[no_mangle]
+pub unsafe extern "C" fn tcl_codegen_var_get(name_ptr: *const u8, name_len: i32) -> *mut TclObj {
+    let interp = current_interp();
+    if interp.is_null() {
+        return ptr::null_mut();
+    }
+    let name = unsafe { input_bytes(name_ptr, name_len) };
+    // SAFETY: the bootstrap installed a live current interpreter.
+    let interp = unsafe { &mut *interp };
+    if interp.fire_read_trace(name, None).is_some() {
+        return ptr::null_mut();
+    }
+    let Some(value) = interp.var_get(name) else {
+        let msg = interp.read_miss_msg(name, None);
+        interp.set_error(&msg);
+        return ptr::null_mut();
+    };
+    // SAFETY: variable storage owns the existing reference; the stack claims one.
+    unsafe { obj::incr_ref_count(value) };
+    value
+}
+
+/// Add two owned stack values through Tcl's numeric tower.
+///
+/// # Safety
+/// Both operands must be live references owned by generated code.
+#[no_mangle]
+#[cfg(have_tommath)]
+pub unsafe extern "C" fn tcl_codegen_expr_add(
+    left: *mut TclObj,
+    right: *mut TclObj,
+) -> *mut TclObj {
+    let interp = current_interp();
+    let result = crate::bignum::add(left, right);
+    // SAFETY: the operation consumes both generated operand-stack references.
+    unsafe {
+        obj::decr_ref_count(left);
+        obj::decr_ref_count(right);
+    }
+    match result {
+        Ok(value) => {
+            // SAFETY: transfer a single owned result to generated code.
+            unsafe { obj::incr_ref_count(value) };
+            value
+        }
+        Err(e) => {
+            if !interp.is_null() {
+                let err = crate::expr::arith_err(e);
+                // SAFETY: the bootstrap installed a live current interpreter.
+                unsafe { (*interp).set_error(&err.msg) };
+            }
+            ptr::null_mut()
+        }
+    }
+}
+
+/// Report that arithmetic is unavailable in a deliberately reduced runtime.
+///
+/// # Safety
+/// Both operands must be live references owned by generated code.
+#[no_mangle]
+#[cfg(not(have_tommath))]
+pub unsafe extern "C" fn tcl_codegen_expr_add(
+    left: *mut TclObj,
+    right: *mut TclObj,
+) -> *mut TclObj {
+    // SAFETY: the operation consumes both generated operand-stack references.
+    unsafe {
+        obj::decr_ref_count(left);
+        obj::decr_ref_count(right);
+    }
+    let interp = current_interp();
+    if !interp.is_null() {
+        // SAFETY: the bootstrap installed a live current interpreter.
+        unsafe { (*interp).set_error(b"arithmetic support is not available") };
+    }
+    ptr::null_mut()
+}
+
+/// Write one owned value to stdout using the runtime's `puts` implementation.
+///
+/// # Safety
+/// `value` must be a live reference owned by generated code.
+#[no_mangle]
+pub unsafe extern "C" fn tcl_codegen_puts(value: *mut TclObj) -> i32 {
+    let interp = current_interp();
+    if interp.is_null() || value.is_null() {
+        return 1;
+    }
+    let command = new_string_bytes(b"puts");
+    // SAFETY: the bootstrap installed a live current interpreter.
+    let code = unsafe { crate::cmd_chan::puts_cmd(&mut *interp, &[command, value]) };
+    drop_fresh(command);
+    // SAFETY: the command consumes the generated stack reference after dispatch.
+    unsafe { obj::decr_ref_count(value) };
+    i32::try_from(code.as_int()).unwrap_or(1)
+}
+
+/// Register source metadata for a generated procedure without evaluating `proc`.
+///
+/// # Safety
+/// All three pointer/length ranges must be readable shared linear memory.
+#[no_mangle]
+pub unsafe extern "C" fn tcl_codegen_proc_register(
+    name_ptr: *const u8,
+    name_len: i32,
+    params_ptr: *const u8,
+    params_len: i32,
+    body_ptr: *const u8,
+    body_len: i32,
+) -> i32 {
+    let interp = current_interp();
+    if interp.is_null() {
+        return 1;
+    }
+    let name = unsafe { input_bytes(name_ptr, name_len) };
+    let params = unsafe { input_bytes(params_ptr, params_len) };
+    let body = unsafe { input_bytes(body_ptr, body_len) };
+    // SAFETY: the bootstrap installed a live current interpreter.
+    let interp = unsafe { &mut *interp };
+    let params = match crate::cmd_proc::parse_params(params) {
+        Ok(params) => params,
+        Err(message) => return i32::try_from(interp.set_error(&message).as_int()).unwrap_or(1),
+    };
+    let body_obj = new_string_bytes(body);
+    interp.define_proc(name, params, body_obj);
+    drop_fresh(body_obj);
+    interp.set_result_bytes(b"");
+    0
 }
 
 /// `tcl_eval(script) -> result` — evaluate `script` against the current interp.
@@ -304,6 +597,38 @@ mod tests {
     unsafe fn box_str(s: &[u8]) -> *mut TclObj {
         // SAFETY: `s` is a valid readable slice.
         unsafe { tcl_obj_new_string(s.as_ptr(), s.len() as i32) }
+    }
+
+    unsafe fn owned_str(s: &[u8]) -> *mut TclObj {
+        // SAFETY: `s` is a valid readable slice.
+        unsafe { tcl_value_new_string(s.as_ptr(), s.len() as i32) }
+    }
+
+    #[test]
+    fn compiled_slots_and_named_access_share_one_cell() {
+        leak_free(|| unsafe {
+            let interp = tcl_runtime_create_interp();
+            tcl_runtime_set_current_interp(interp);
+            tcl_codegen_frame_push();
+
+            assert_eq!(
+                tcl_codegen_local_bind(0, b"b".as_ptr(), 1, owned_str(b"2")),
+                0
+            );
+            assert_eq!(
+                tcl_codegen_local_bind(1, b"c".as_ptr(), 1, owned_str(b"4")),
+                0
+            );
+            assert_eq!(tcl_eval_code(box_str(b"set b 5")), 0);
+
+            let sum = tcl_codegen_expr_add(tcl_codegen_local_get(0), tcl_codegen_local_get(1));
+            assert_eq!(obj_bytes(sum), b"9");
+            tcl_value_release(sum);
+
+            tcl_codegen_frame_pop();
+            tcl_runtime_set_current_interp(ptr::null_mut());
+            tcl_runtime_delete_interp(interp);
+        });
     }
 
     /// The eval-fallback round-trip: box → eval → release, against the current

--- a/runtime/rust/src/codegen_abi.rs
+++ b/runtime/rust/src/codegen_abi.rs
@@ -347,6 +347,13 @@ pub unsafe extern "C" fn tcl_codegen_expr_add(
     left: *mut TclObj,
     right: *mut TclObj,
 ) -> *mut TclObj {
+    if left.is_null() || right.is_null() {
+        unsafe {
+            obj::decr_ref_count(left);
+            obj::decr_ref_count(right);
+        }
+        return ptr::null_mut();
+    }
     let interp = current_interp();
     let result = crate::bignum::add(left, right);
     // SAFETY: the operation consumes both generated operand-stack references.
@@ -381,6 +388,13 @@ pub unsafe extern "C" fn tcl_codegen_expr_add(
     left: *mut TclObj,
     right: *mut TclObj,
 ) -> *mut TclObj {
+    if left.is_null() || right.is_null() {
+        unsafe {
+            obj::decr_ref_count(left);
+            obj::decr_ref_count(right);
+        }
+        return ptr::null_mut();
+    }
     // SAFETY: the operation consumes both generated operand-stack references.
     unsafe {
         obj::decr_ref_count(left);
@@ -626,6 +640,26 @@ mod tests {
             tcl_value_release(sum);
 
             tcl_codegen_frame_pop();
+            tcl_runtime_set_current_interp(ptr::null_mut());
+            tcl_runtime_delete_interp(interp);
+        });
+    }
+
+    #[test]
+    fn nested_add_propagates_the_inner_arithmetic_error() {
+        leak_free(|| unsafe {
+            let interp = tcl_runtime_create_interp();
+            tcl_runtime_set_current_interp(interp);
+
+            let inner = tcl_codegen_expr_add(owned_str(b"not-a-number"), owned_str(b"1"));
+            assert!(inner.is_null());
+            let error = (*interp).result_bytes();
+            assert!(!error.is_empty());
+
+            let outer = tcl_codegen_expr_add(inner, owned_str(b"2"));
+            assert!(outer.is_null());
+            assert_eq!((*interp).result_bytes(), error);
+
             tcl_runtime_set_current_interp(ptr::null_mut());
             tcl_runtime_delete_interp(interp);
         });

--- a/runtime/rust/src/frame.rs
+++ b/runtime/rust/src/frame.rs
@@ -410,6 +410,10 @@ impl Drop for VarTable {
 /// the `CallFrame.nsPtr` analogue).
 struct Frame {
     table: VarTable,
+    /// Compile-time slot index to Tcl variable name. Indexed and named access
+    /// both route through `table`, so dynamic Tcl code observes the same cell
+    /// as generated `frame_local_*_at` calls.
+    compiled_slots: Vec<Vec<u8>>,
     /// The logical call level (`info level`, `upvar`/`uplevel` arithmetic) — the
     /// invoking var-frame's level + 1, **not** the stack index. They diverge
     /// when a proc is invoked while `uplevel` has redirected the active frame:
@@ -434,6 +438,7 @@ impl Frame {
     fn new(level: usize, ns: NsId) -> Self {
         Frame {
             table: VarTable::default(),
+            compiled_slots: Vec::new(),
             level,
             ns,
             words: Vec::new(),
@@ -621,6 +626,28 @@ impl FrameStack {
     pub fn frame_ns(&self, level: usize) -> NsId {
         self.index_of_level(level)
             .map_or(crate::namespace::GLOBAL, |i| self.frames[i].ns)
+    }
+
+    /// Associate a generated-code slot with its Tcl-visible variable name.
+    pub(crate) fn bind_compiled_slot(&mut self, slot: usize, name: &[u8]) {
+        let Some(i) = self.index_of_level(self.active_level) else {
+            return;
+        };
+        let slots = &mut self.frames[i].compiled_slots;
+        if slots.len() <= slot {
+            slots.resize_with(slot + 1, Vec::new);
+        }
+        slots[slot] = name.to_vec();
+    }
+
+    /// Tcl-visible name associated with a generated-code slot.
+    pub(crate) fn compiled_slot_name(&self, slot: usize) -> Option<&[u8]> {
+        let i = self.index_of_level(self.active_level)?;
+        self.frames[i]
+            .compiled_slots
+            .get(slot)
+            .filter(|name| !name.is_empty())
+            .map(Vec::as_slice)
     }
 
     /// Local variable names of the active frame, sorted (`info locals`).

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -1371,6 +1371,31 @@ impl Interp {
         self.current_ns.get()
     }
 
+    /// Enter a generated procedure body using the ordinary Tcl variable frame.
+    pub(crate) fn codegen_frame_push(&mut self) {
+        self.frames.borrow_mut().push(self.current_ns.get());
+    }
+
+    /// Leave a generated procedure body and restore its caller's namespace.
+    pub(crate) fn codegen_frame_pop(&mut self) {
+        let mut frames = self.frames.borrow_mut();
+        frames.pop();
+        self.current_ns.set(frames.frame_ns(frames.current_level()));
+    }
+
+    /// Associate an indexed generated local with its name-addressable Tcl cell.
+    pub(crate) fn codegen_bind_slot(&self, slot: usize, name: &[u8]) {
+        self.frames.borrow_mut().bind_compiled_slot(slot, name);
+    }
+
+    /// Resolve a generated local index to its Tcl-visible name.
+    pub(crate) fn codegen_slot_name(&self, slot: usize) -> Option<Vec<u8>> {
+        self.frames
+            .borrow()
+            .compiled_slot_name(slot)
+            .map(<[u8]>::to_vec)
+    }
+
     /// Begin an ensemble-rewrite (a forward / ensemble / constructor replacing
     /// the original command words). Returns `true` if this is the *root* rewrite
     /// (no rewrite was active) — the caller must `clear_ensemble_rewrite` when

--- a/runtime/rust/src/lib.rs
+++ b/runtime/rust/src/lib.rs
@@ -64,6 +64,8 @@ pub mod bignum;
 // The `expr` evaluator (value-ops impl of the shared `tcl_syntax::expr` walk);
 // needs the bignum tower, so it tracks the same `have_tommath` cfg.
 pub mod builtins;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown", have_tommath))]
+mod c_alloc;
 pub mod capi;
 pub mod cmd_alias;
 pub mod cmd_array;

--- a/rust/bigip-report-gen/python/Cargo.lock
+++ b/rust/bigip-report-gen/python/Cargo.lock
@@ -10,13 +10,13 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
- "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpubits",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -112,6 +112,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,7 +144,7 @@ dependencies = [
 name = "bigip-report-gen-rust"
 version = "0.1.0"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "chrono",
  "ipnet",
  "md-5",
@@ -162,15 +168,6 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "block-buffer"
@@ -224,11 +221,11 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common",
  "inout",
 ]
 
@@ -248,6 +245,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,13 +267,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "cpubits"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -288,16 +288,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
 ]
 
 [[package]]
@@ -333,7 +323,7 @@ dependencies = [
  "asn1-rs",
  "displaydoc",
  "nom",
- "num-bigint",
+ "num-bigint 0.4.7",
  "num-traits",
  "rusticata-macros",
 ]
@@ -346,22 +336,13 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
- "crypto-common 0.2.2",
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
 ]
 
 [[package]]
@@ -463,16 +444,6 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -582,11 +553,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -663,12 +634,12 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -725,6 +696,16 @@ name = "num-bigint"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -822,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.12.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags",
  "memchr",
@@ -961,11 +942,11 @@ dependencies = [
 
 [[package]]
 name = "ripemd"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+checksum = "4dd4211456b4172d7e44261920c25acf07367c4f04bb5f5d54fc21b090d9b159"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1137,29 +1118,18 @@ dependencies = [
  "ctutils",
  "mcf",
  "password-hash",
- "sha2 0.11.0",
+ "sha2",
 ]
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1169,8 +1139,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1254,7 +1224,7 @@ dependencies = [
  "ipnet",
  "regex",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "tcl-dialect",
  "tcl-irules",
  "tcl-lexer",
@@ -1268,12 +1238,12 @@ name = "tcl-bigip-io"
 version = "0.1.0"
 dependencies = [
  "aes",
- "digest 0.10.7",
+ "digest",
  "flate2",
  "md-5",
  "ripemd",
  "sha1",
- "sha2 0.10.9",
+ "sha2",
  "tar",
  "tcl-bigip",
  "tcl-core-types",
@@ -1284,7 +1254,7 @@ dependencies = [
 name = "tcl-bigip-query"
 version = "0.1.0"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "chrono",
  "dns-lookup",
  "indexmap",
@@ -1294,7 +1264,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "tcl-bigip",
  "tcl-core-types",
  "tcl-lexer",
@@ -1326,7 +1296,7 @@ name = "tcl-compiler"
 version = "0.1.0"
 dependencies = [
  "bitflags",
- "num-bigint",
+ "num-bigint 0.5.1",
  "num-integer",
  "num-traits",
  "regex",
@@ -1367,7 +1337,7 @@ name = "tcl-f5mku"
 version = "0.1.0"
 dependencies = [
  "aes",
- "base64",
+ "base64 0.23.1",
  "getrandom 0.4.3",
 ]
 
@@ -1404,7 +1374,7 @@ version = "0.1.0"
 dependencies = [
  "bitflags",
  "rustc-hash",
- "sha2 0.10.9",
+ "sha2",
  "tcl-cmd-core",
  "tcl-core-types",
  "tcl-dialect",
@@ -1425,7 +1395,7 @@ version = "0.1.0"
 dependencies = [
  "bitflags",
  "libm",
- "num-bigint",
+ "num-bigint 0.5.1",
  "num-integer",
  "num-traits",
  "tcl-dialect",
@@ -1522,7 +1492,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "log",
  "percent-encoding",
@@ -1539,7 +1509,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http",
  "httparse",
  "log",
@@ -1550,12 +1520,6 @@ name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/rust/tcl-cli/src/commands/compile.rs
+++ b/rust/tcl-cli/src/commands/compile.rs
@@ -25,9 +25,8 @@
 //! - `dis` lowers to the bytecode IR, builds the codegen CFG (the
 //!   `faithful_exceptions`-off shape — see `tcl-explorer`'s `asm` view for why),
 //!   emits the `ModuleAsm`, and renders it with `format_module_asm`.
-//! - `compwasm` lowers to the analysis IR and runs the greenfield WASM
-//!   eval-fallback emitter, writing the binary module (and, optionally, its WAT
-//!   text form).
+//! - `compwasm` builds the complete analysis unit and runs the WASM emitter,
+//!   writing the binary module and, optionally, its WAT text form.
 //!
 //! `--optimise` runs the source-to-source optimiser first, exactly as the
 //! `compile_script(optimise=...)` path does (`apply_optimisations` over
@@ -40,8 +39,9 @@ use tcl_cli_support::{
 use tcl_compiler::cfg_builder::build_cfg_codegen;
 use tcl_compiler::codegen::codegen_module;
 use tcl_compiler::codegen::format::format_module_asm;
-use tcl_compiler::codegen::wasm::wasm_codegen_module;
-use tcl_compiler::lowering::{lower_to_ir_for_bytecode_with_dialect, lower_to_ir_with_dialect};
+use tcl_compiler::codegen::wasm::wasm_codegen_compilation_unit;
+use tcl_compiler::compilation_unit::CompilationUnit;
+use tcl_compiler::lowering::lower_to_ir_for_bytecode_with_dialect;
 use tcl_compiler::optimiser::{apply_optimisations, optimise_with_dialect};
 use tcl_registry::CommandRegistry;
 
@@ -96,7 +96,7 @@ pub fn run_dis(input: &InputArgs, optimise_on: bool) -> anyhow::Result<u8> {
 
 /// `tcl compwasm` — compile source to a WebAssembly binary. The default `vm`
 /// backend emits the self-contained bytecode-VM runner; `tree-walker` emits the
-/// legacy eval-fallback module (`RUST_ISSUE_008`).
+/// analysis-aware Tcl-object module with runtime fallback.
 pub fn run_compwasm(
     input: &InputArgs,
     backend: crate::cli::WasmBackend,
@@ -173,8 +173,8 @@ fn locate_vm_wasm() -> Option<std::path::PathBuf> {
     candidates.into_iter().find(|p| p.is_file())
 }
 
-/// The legacy `tree-walker` backend: the eval-fallback WASM emitter — a bare
-/// module importing the runtime C-ABI (`tcl_*`), with an optional WAT dump.
+/// The `tree-walker` backend: a bare module importing the runtime C ABI, with
+/// direct analysed operations, source fallback, and an optional WAT dump.
 fn run_compwasm_tree_walker(
     input: &InputArgs,
     wat_output: Option<&std::path::Path>,
@@ -184,13 +184,8 @@ fn run_compwasm_tree_walker(
     let registry = registry_for_dialect(&dialect);
     let source = combine_sources(&documents);
 
-    let ir = lower_to_ir_with_dialect(
-        &source,
-        registry,
-        tcl_lexer::LexerConfig::for_dialect(&dialect),
-        &dialect,
-    );
-    let mut wasm = wasm_codegen_module(&ir, &source);
+    let unit = CompilationUnit::build_for_dialect(&source, registry, false, &dialect);
+    let mut wasm = wasm_codegen_compilation_unit(&unit, registry);
     let bytes = wasm.to_bytes();
 
     // Unlike the other verbs, `compwasm` defaults to a file, not stdout: a bare

--- a/rust/tcl-compiler/src/codegen/emit.rs
+++ b/rust/tcl-compiler/src/codegen/emit.rs
@@ -27,10 +27,9 @@
 //! deliberately **not** retrofitted onto it (per the red-team: that is a rewrite,
 //! not a refactor — it stays on its own driver behind the byte-identity gate).
 //!
-//! The statement tier is **eval-fallback**: every leaf command is handed to the
-//! backend as its original source text, to be evaluated by the runtime at run
-//! time (`tcl_eval`). The inline AOT tiers (variable slots, arithmetic, …) and
-//! the per-command codegen hooks are a later stage, behind the same seam.
+//! A backend first receives the lowered statement through
+//! [`Emit::emit_typed_statement`]. Declining it preserves the original-source
+//! runtime fallback through [`Emit::emit_command`].
 //!
 //! Control flow is **structured** — `if`/`else` and the loop scaffolding — so a
 //! target with no arbitrary branches (WASM) can realise it directly. The
@@ -38,6 +37,8 @@
 //! primitives; because Tcl has no labelled break they always target the
 //! innermost enclosing loop, so the backend owns the (per-target) jump
 //! bookkeeping and the driver need only say *what* happened, not *where to jump*.
+
+use crate::ir::Statement;
 
 /// The semantic operations the [structured walk](crate::codegen::structured)
 /// emits. A backend maps each to its artifact (the WASM backend: an instruction
@@ -61,6 +62,12 @@
 /// A body that falls off its end re-tests via the back-edge naturally — no
 /// explicit `continue` is needed for the common iteration.
 pub trait Emit {
+    /// Try to emit a lowered statement directly. Returning `true` means the
+    /// backend consumed it; `false` keeps the original-source fallback.
+    fn emit_typed_statement(&mut self, _statement: &Statement, _source: &str) -> bool {
+        false
+    }
+
     /// A leaf command, given its original source text (eval-fallback tier).
     fn emit_command(&mut self, source_text: &str);
 

--- a/rust/tcl-compiler/src/codegen/structured.rs
+++ b/rust/tcl-compiler/src/codegen/structured.rs
@@ -108,6 +108,13 @@ fn walk_stmt<E: Emit>(
         emit.emit_command(slice(source, stmt.span()));
         return Flow::Normal;
     }
+    if emit.emit_typed_statement(stmt, source) {
+        return if matches!(stmt, Statement::Return { .. }) {
+            Flow::Diverged
+        } else {
+            Flow::Normal
+        };
+    }
     match stmt {
         Statement::If {
             clauses, else_body, ..

--- a/rust/tcl-compiler/src/codegen/wasm/backend.rs
+++ b/rust/tcl-compiler/src/codegen/wasm/backend.rs
@@ -19,9 +19,10 @@
 //! The greenfield WASM codegen backend — the first consumer of the [`Emit`] seam
 //! and the structured [`structured`](crate::codegen::structured) driver.
 //!
-//! The current tier is **eval-fallback**: every leaf command is boxed as a Tcl
-//! string in the module's data section and evaluated by the runtime at run time
-//! (`tcl_eval_code`, which reports the command's completion code); control flow
+//! The analysis-aware tier emits binding-proven assignments, procedure calls,
+//! arithmetic, and registry-selected commands over owned `TclObj` pointers.
+//! Anything outside that tier is boxed from its CST-derived source span and
+//! evaluated by the runtime (`tcl_eval_code`); control flow
 //! is **structured** WASM (`if`/`else`; `block`/`loop` with `br`/`br_if` for
 //! loops + `break`/`continue`/`return`), and the code a leaf command returns is
 //! honoured — an `error`/`return` unwinds, a `break`/`continue` re-enters the
@@ -30,15 +31,28 @@
 //! runtime provides (values are i32 `*mut TclObj` pointers into shared linear
 //! memory). The runtime side of that ABI is the leak-tested eval surface in
 //! `runtime/rust/src/codegen_abi.rs` (`tcl_eval_code`, `tcl_expr_bool`, the
-//! obj new/release helpers); an emitted module runs against it through the
+//! object and direct-operation helpers); an emitted module runs against it through the
 //! shared-memory dynamic link (`__memory_base` relocation), which the standalone
 //! `wasm_execute` test exercises with a stub provider.
 
 use super::encoding::{leb128_signed, leb128_unsigned};
 use super::ir::{ValType, WasmData, WasmFunction, WasmInstruction, WasmModule, WasmOp};
+use std::collections::{HashMap, HashSet};
+
+use tcl_dialect::DialectSet;
+use tcl_lexer::Span;
+use tcl_registry::hooks::WasmCodegenHookId;
+use tcl_registry::{CommandRegistry, TclType};
+use tcl_syntax::expr::{BinOp, ExprNode};
+
+use crate::codegen::cmd_subst::{is_pure_cmd_subst, parse_cmd_parts};
 use crate::codegen::emit::Emit;
 use crate::codegen::structured;
-use crate::ir::{Module, Procedure};
+use crate::command_binding::{
+    Binding, BindingKind, analyse_command_binding, scan_module_command_mutations,
+};
+use crate::compilation_unit::{CompilationUnit, FunctionUnit};
+use crate::ir::{Module, Procedure, Statement};
 
 /// Block type byte for a structured op (`block`/`loop`/`if`) yielding no value.
 const BLOCK_VOID: u8 = 0x40;
@@ -46,8 +60,6 @@ const BLOCK_VOID: u8 = 0x40;
 /// The completion-code scratch local (index 0). Every emitted function declares
 /// exactly one `i32` local so [`WasmEmitter::emit_completion_dispatch`] can stash
 /// the code a leaf command returns and test it more than once.
-const CODE_LOCAL: u64 = 0;
-
 /// Tcl completion codes the dispatch tests (`TCL_BREAK` / `TCL_CONTINUE`); the
 /// others (`TCL_ERROR` = 1, `TCL_RETURN` = 2, or a `return -code N`) are handled
 /// as "any non-`OK` code" (see [`WasmEmitter::emit_completion_dispatch`]).
@@ -79,6 +91,35 @@ struct Imports {
     eval_code: u32,
     /// `(expr_obj) -> i32` — evaluate a condition to a boolean.
     expr_bool: u32,
+    aot: Option<AotImports>,
+}
+
+#[derive(Clone, Copy)]
+struct AotImports {
+    value_new_string: u32,
+    frame_push: u32,
+    frame_pop: u32,
+    local_bind: u32,
+    local_set: u32,
+    local_get: u32,
+    var_set: u32,
+    var_get: u32,
+    expr_add: u32,
+    puts: u32,
+    proc_register: u32,
+}
+
+#[derive(Default)]
+struct FunctionFacts {
+    hooks: HashMap<(u32, u32), WasmCodegenHookId>,
+    direct_calls: HashMap<(u32, u32, String), String>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum FunctionMode {
+    Top,
+    FallbackProc,
+    DirectProc,
 }
 
 /// One open structured loop, recording the control-frame indices a
@@ -105,6 +146,14 @@ struct WasmEmitter {
     /// Stack of open loops; the last is the innermost (the `break`/`continue`
     /// target, since Tcl has no labelled break).
     loops: Vec<LoopFrame>,
+    code_local: u64,
+    mode: FunctionMode,
+    local_slots: HashMap<String, u32>,
+    proc_indices: HashMap<String, u32>,
+    procedure_arity: HashMap<String, usize>,
+    direct_procs: HashSet<String>,
+    procedures_by_span: HashMap<(u32, u32), Procedure>,
+    facts: FunctionFacts,
 }
 
 impl WasmEmitter {
@@ -184,6 +233,192 @@ impl WasmEmitter {
         self.call(self.imports.obj_new_string);
     }
 
+    fn push_text_pair(&mut self, text: &str) {
+        let (offset, len) = self.intern(text);
+        self.push_i32(offset);
+        self.push_i32(len);
+    }
+
+    fn box_value(&mut self, text: &str) -> bool {
+        let Some(aot) = self.imports.aot else {
+            return false;
+        };
+        self.push_text_pair(text);
+        self.call(aot.value_new_string);
+        true
+    }
+
+    fn emit_var_get(&mut self, name: &str) -> bool {
+        let Some(aot) = self.imports.aot else {
+            return false;
+        };
+        if self.mode == FunctionMode::DirectProc {
+            let Some(slot) = self.local_slots.get(name).copied() else {
+                return false;
+            };
+            self.push_i32(i64::from(slot));
+            self.call(aot.local_get);
+        } else {
+            self.push_text_pair(name);
+            self.call(aot.var_get);
+        }
+        true
+    }
+
+    fn emit_expr_value(&mut self, expr: &ExprNode) -> bool {
+        match expr {
+            ExprNode::Var { name, .. } => self.emit_var_get(name),
+            ExprNode::Literal { text, .. } => self.box_value(text),
+            ExprNode::Binary {
+                op: BinOp::Add,
+                left,
+                right,
+            } => {
+                if !self.emit_expr_value(left) || !self.emit_expr_value(right) {
+                    return false;
+                }
+                let Some(aot) = self.imports.aot else {
+                    return false;
+                };
+                self.call(aot.expr_add);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn emit_word_value(&mut self, word: &str, statement: &Statement) -> bool {
+        if let Some(name) = simple_var_name(word) {
+            return self.emit_var_get(name);
+        }
+        if !is_pure_cmd_subst(word) {
+            return !word.bytes().any(|b| matches!(b, b'$' | b'[' | b'\\')) && self.box_value(word);
+        }
+        let parts = parse_cmd_parts(word);
+        let Some((head, false)) = parts.first() else {
+            return false;
+        };
+        let key = span_command_key(statement.span(), head);
+        let Some(target) = self.facts.direct_calls.get(&key).cloned() else {
+            return false;
+        };
+        if !self.direct_procs.contains(&target) {
+            return false;
+        }
+        if self.procedure_arity.get(&target).copied() != Some(parts.len() - 1) {
+            return false;
+        }
+        for (arg, braced) in &parts[1..] {
+            if *braced {
+                if !self.box_value(arg) {
+                    return false;
+                }
+            } else if !self.emit_word_value(arg, statement) {
+                return false;
+            }
+        }
+        let Some(index) = self.proc_indices.get(&target).copied() else {
+            return false;
+        };
+        self.call(index);
+        true
+    }
+
+    fn emit_proc_prelude(&mut self, proc: &Procedure) {
+        let Some(aot) = self.imports.aot else {
+            return;
+        };
+        self.call(aot.frame_push);
+        for (param_idx, name) in proc.params.iter().enumerate() {
+            self.push_i32(i64::try_from(param_idx).unwrap_or(i64::MAX));
+            self.push_text_pair(name);
+            self.local_get(u64::try_from(param_idx).unwrap_or(u64::MAX));
+            self.call(aot.local_bind);
+            self.push(WasmOp::Drop);
+        }
+    }
+
+    fn try_emit_typed_statement(&mut self, statement: &Statement) -> bool {
+        let Some(aot) = self.imports.aot else {
+            return false;
+        };
+        match statement {
+            Statement::AssignConst { name, value, .. } => {
+                if self.mode == FunctionMode::DirectProc {
+                    let Some(slot) = self.local_slots.get(name).copied() else {
+                        return false;
+                    };
+                    self.push_i32(i64::from(slot));
+                    if !self.box_value(value) {
+                        return false;
+                    }
+                    self.call(aot.local_set);
+                } else if self.mode == FunctionMode::Top {
+                    self.push_text_pair(name);
+                    if !self.box_value(value) {
+                        return false;
+                    }
+                    self.call(aot.var_set);
+                } else {
+                    return false;
+                }
+                self.emit_completion_dispatch();
+                true
+            }
+            Statement::Return {
+                expr: Some(expr), ..
+            } if self.mode == FunctionMode::DirectProc => {
+                if !self.emit_expr_value(expr) {
+                    return false;
+                }
+                self.call(aot.frame_pop);
+                self.push(WasmOp::Return);
+                true
+            }
+            Statement::Call {
+                span, args, tokens, ..
+            } => {
+                let Some(hook) = self.facts.hooks.get(&span_key(*span)).copied() else {
+                    return false;
+                };
+                match hook {
+                    WasmCodegenHookId::Proc => {
+                        let Some(proc) = self.procedures_by_span.get(&span_key(*span)).cloned()
+                        else {
+                            return false;
+                        };
+                        let Some(body) = proc.body_source.as_deref() else {
+                            return false;
+                        };
+                        self.push_text_pair(&proc.qualified_name);
+                        self.push_text_pair(&proc.params_raw);
+                        self.push_text_pair(body);
+                        self.call(aot.proc_register);
+                        self.emit_completion_dispatch();
+                        true
+                    }
+                    WasmCodegenHookId::Puts
+                        if args.len() == 1
+                            && !tokens
+                                .as_ref()
+                                .is_some_and(|tokens| tokens.arg_is_braced_literal(0))
+                            && (simple_var_name(&args[0]).is_some()
+                                || is_pure_cmd_subst(&args[0])) =>
+                    {
+                        if !self.emit_word_value(&args[0], statement) {
+                            return false;
+                        }
+                        self.call(aot.puts);
+                        self.emit_completion_dispatch();
+                        true
+                    }
+                    WasmCodegenHookId::Puts => false,
+                }
+            }
+            _ => false,
+        }
+    }
+
     fn local_get(&mut self, idx: u64) {
         self.body.push(WasmInstruction::with_operands(
             WasmOp::LocalGet,
@@ -211,7 +446,7 @@ impl WasmEmitter {
     /// through to the next statement.
     fn emit_completion_dispatch(&mut self) {
         // Stash the code; the dispatch reads it up to three times.
-        self.local_set(CODE_LOCAL);
+        self.local_set(self.code_local);
 
         // In a loop, codes 3/4 are a structural break/continue of *this* loop.
         if let Some(frame) = self.loops.last() {
@@ -223,7 +458,7 @@ impl WasmEmitter {
 
         // Any remaining non-`OK` code (error/return/other, or break/continue with
         // no enclosing loop) unwinds the function.
-        self.local_get(CODE_LOCAL);
+        self.local_get(self.code_local);
         self.open_frame(WasmOp::If); // if (code != 0)
         self.push(WasmOp::Return);
         self.close_frame();
@@ -234,7 +469,7 @@ impl WasmEmitter {
     /// so the `br` depth is computed with it in place (crossing it, plus any
     /// enclosing `if`s, back to the loop scope).
     fn emit_code_eq_branch(&mut self, want: i64, target: u32) {
-        self.local_get(CODE_LOCAL);
+        self.local_get(self.code_local);
         self.push_i32(want);
         self.push(WasmOp::I32Eq);
         self.open_frame(WasmOp::If);
@@ -251,27 +486,68 @@ impl WasmEmitter {
     /// The terminal `end` is emitted unconditionally — a body ending in a loop's
     /// own `end` would otherwise leave `encode_body` to mistake that for the
     /// function `end` and leave a frame open.
-    fn finish_function(&mut self, name: &str, kind: &str) -> WasmFunction {
+    fn finish_function(
+        &mut self,
+        name: &str,
+        kind: &str,
+        proc: Option<&Procedure>,
+    ) -> WasmFunction {
+        let direct = self.mode == FunctionMode::DirectProc;
+        if direct {
+            self.box_value("");
+            if let Some(aot) = self.imports.aot {
+                self.call(aot.frame_pop);
+            }
+        }
         self.push(WasmOp::End);
         self.ctrl_depth = 0;
         self.loops.clear();
+        let params = if direct {
+            vec![ValType::I32; proc.map_or(0, |p| p.params.len())]
+        } else {
+            Vec::new()
+        };
+        let mut local_names = if direct {
+            proc.map_or_else(Vec::new, |p| {
+                p.params.iter().map(|name| format!("${name}")).collect()
+            })
+        } else {
+            Vec::new()
+        };
+        local_names.push("$code".to_string());
         WasmFunction {
             name: name.to_string(),
-            params: Vec::new(),
-            results: Vec::new(),
-            // One i32 scratch local (index [`CODE_LOCAL`]) for the completion-code
-            // dispatch; declared uniformly (harmless when a body has no commands).
+            params,
+            results: if direct {
+                vec![ValType::I32]
+            } else {
+                Vec::new()
+            },
             locals: vec![ValType::I32],
             body: std::mem::take(&mut self.body),
-            local_names: vec!["$code".to_string()],
+            local_names,
             exported: true,
-            source_range: None,
+            source_range: proc.map(|p| p.span),
             kind: kind.to_string(),
         }
     }
 }
 
 impl Emit for WasmEmitter {
+    fn emit_typed_statement(&mut self, statement: &Statement, _source: &str) -> bool {
+        let body_len = self.body.len();
+        let data_len = self.data.len();
+        let data_offset = self.data_offset;
+        if self.try_emit_typed_statement(statement) {
+            true
+        } else {
+            self.body.truncate(body_len);
+            self.data.truncate(data_len);
+            self.data_offset = data_offset;
+            false
+        }
+    }
+
     fn emit_command(&mut self, source_text: &str) {
         // code = tcl_eval_code(box(text)); then honour an abrupt completion code
         // (error/return unwinds, break/continue re-enters the loop) instead of
@@ -364,17 +640,299 @@ impl Emit for WasmEmitter {
     }
 }
 
+fn span_key(span: Span) -> (u32, u32) {
+    (span.start(), span.end())
+}
+
+fn span_command_key(span: Span, command: &str) -> (u32, u32, String) {
+    (span.start(), span.end(), command.to_string())
+}
+
+fn simple_var_name(word: &str) -> Option<&str> {
+    if let Some(name) = word.strip_prefix("${").and_then(|s| s.strip_suffix('}')) {
+        return (!name.is_empty()).then_some(name);
+    }
+    let name = word.strip_prefix('$')?;
+    (!name.is_empty()
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b':')))
+    .then_some(name)
+}
+
+fn direct_expr_supported(expr: &ExprNode, params: &HashSet<&str>) -> bool {
+    match expr {
+        ExprNode::Var { name, .. } => params.contains(name.as_str()),
+        ExprNode::Literal { .. } => true,
+        ExprNode::Binary {
+            op: BinOp::Add,
+            left,
+            right,
+        } => direct_expr_supported(left, params) && direct_expr_supported(right, params),
+        _ => false,
+    }
+}
+
+fn direct_proc_eligible(module: &Module, proc: &Procedure, unit: &FunctionUnit) -> bool {
+    if proc.namespace_scoped
+        || proc
+            .qualified_name
+            .strip_prefix("::")
+            .is_some_and(|name| name.contains("::"))
+        || module.redefined_procedures.contains(&proc.qualified_name)
+        || unit.complexity_guarded
+        || !matches!(
+            unit.return_type.tcl_type(),
+            Some(TclType::Int | TclType::Double | TclType::Numeric)
+        )
+    {
+        return false;
+    }
+    let raw_params: Vec<&str> = proc.params_raw.split_whitespace().collect();
+    if raw_params.len() != proc.params.len()
+        || !raw_params
+            .iter()
+            .zip(&proc.params)
+            .all(|(raw, name)| *raw == name)
+    {
+        return false;
+    }
+    let [
+        Statement::Return {
+            expr: Some(expr), ..
+        },
+    ] = proc.body.statements.as_slice()
+    else {
+        return false;
+    };
+    let params: HashSet<&str> = proc.params.iter().map(String::as_str).collect();
+    direct_expr_supported(expr, &params)
+}
+
+fn function_facts(
+    unit: &FunctionUnit,
+    module: &Module,
+    registry: &CommandRegistry,
+    is_top: bool,
+) -> FunctionFacts {
+    let mutations = scan_module_command_mutations(module, registry);
+    let initial: Vec<(String, Binding)> = if is_top {
+        Vec::new()
+    } else {
+        module
+            .procedures
+            .keys()
+            .map(|name| {
+                (
+                    name.clone(),
+                    Binding {
+                        kind: BindingKind::Proc,
+                        target: Some(name.clone()),
+                    },
+                )
+            })
+            .collect()
+    };
+    let bindings = analyse_command_binding(&unit.cfg, registry, &initial);
+    let mut facts = FunctionFacts::default();
+    for block in unit.cfg.reverse_postorder() {
+        let Some(cfg_block) = unit.cfg.blocks.get(&block) else {
+            continue;
+        };
+        for (stmt_idx, statement) in cfg_block.statements.iter().enumerate() {
+            let (Statement::Call { command, args, .. } | Statement::Barrier { command, args, .. }) =
+                statement
+            else {
+                continue;
+            };
+            let bare = statement
+                .canonical_command_or_source()
+                .strip_prefix("::")
+                .unwrap_or_else(|| statement.canonical_command_or_source());
+            let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+            if bindings.is_original_builtin_at(block, stmt_idx, command)
+                && mutations.trusts(bare)
+                && let Some(hook) = registry
+                    .resolve_call(bare, &arg_refs, DialectSet::empty())
+                    .and_then(|resolved| resolved.wasm_codegen_hook)
+            {
+                facts.hooks.insert(span_key(statement.span()), hook);
+            }
+            if !is_top {
+                continue;
+            }
+            for proc in module.procedures.values() {
+                if is_top && proc.span.start() >= statement.span().start() {
+                    continue;
+                }
+                for written in [proc.name.as_str(), proc.qualified_name.as_str()] {
+                    let binding = bindings.binding_at(block, stmt_idx, written);
+                    if binding.kind == BindingKind::Proc
+                        && binding.target.as_deref() == Some(proc.qualified_name.as_str())
+                        && mutations.trusts_proc_binding(&proc.qualified_name)
+                    {
+                        facts.direct_calls.insert(
+                            span_command_key(statement.span(), written),
+                            proc.qualified_name.clone(),
+                        );
+                    }
+                }
+            }
+        }
+    }
+    facts
+}
+
 fn add_tcl_import(m: &mut WasmModule, name: &str, params: &[ValType], results: &[ValType]) -> u32 {
     u32::try_from(m.add_import("tcl", name, params, results)).expect("import index fits in u32")
 }
 
-/// Lower a module's top-level script to a WASM module (eval-fallback tier +
+fn add_aot_imports(wasm: &mut WasmModule) -> AotImports {
+    AotImports {
+        value_new_string: add_tcl_import(
+            wasm,
+            "tcl_value_new_string",
+            &[ValType::I32, ValType::I32],
+            &[ValType::I32],
+        ),
+        frame_push: add_tcl_import(wasm, "tcl_codegen_frame_push", &[], &[]),
+        frame_pop: add_tcl_import(wasm, "tcl_codegen_frame_pop", &[], &[]),
+        local_bind: add_tcl_import(
+            wasm,
+            "tcl_codegen_local_bind",
+            &[ValType::I32, ValType::I32, ValType::I32, ValType::I32],
+            &[ValType::I32],
+        ),
+        local_set: add_tcl_import(
+            wasm,
+            "tcl_codegen_local_set",
+            &[ValType::I32, ValType::I32],
+            &[ValType::I32],
+        ),
+        local_get: add_tcl_import(
+            wasm,
+            "tcl_codegen_local_get",
+            &[ValType::I32],
+            &[ValType::I32],
+        ),
+        var_set: add_tcl_import(
+            wasm,
+            "tcl_codegen_var_set",
+            &[ValType::I32, ValType::I32, ValType::I32],
+            &[ValType::I32],
+        ),
+        var_get: add_tcl_import(
+            wasm,
+            "tcl_codegen_var_get",
+            &[ValType::I32, ValType::I32],
+            &[ValType::I32],
+        ),
+        expr_add: add_tcl_import(
+            wasm,
+            "tcl_codegen_expr_add",
+            &[ValType::I32, ValType::I32],
+            &[ValType::I32],
+        ),
+        puts: add_tcl_import(wasm, "tcl_codegen_puts", &[ValType::I32], &[ValType::I32]),
+        proc_register: add_tcl_import(
+            wasm,
+            "tcl_codegen_proc_register",
+            &[
+                ValType::I32,
+                ValType::I32,
+                ValType::I32,
+                ValType::I32,
+                ValType::I32,
+                ValType::I32,
+            ],
+            &[ValType::I32],
+        ),
+    }
+}
+
+struct ProcedurePlan<'a> {
+    procs: Vec<&'a Procedure>,
+    indices: HashMap<String, u32>,
+    arity: HashMap<String, usize>,
+    by_span: HashMap<(u32, u32), Procedure>,
+    direct: HashSet<String>,
+}
+
+fn procedure_plan<'a>(
+    module: &'a Module,
+    analysis: Option<(&CompilationUnit, &CommandRegistry)>,
+    top_idx: u32,
+) -> ProcedurePlan<'a> {
+    let mut procs: Vec<&Procedure> = module
+        .procedures
+        .values()
+        .filter(|p| !p.namespace_scoped)
+        .collect();
+    procs.sort_by(|a, b| a.qualified_name.cmp(&b.qualified_name));
+    let indices = procs
+        .iter()
+        .enumerate()
+        .map(|(position, proc)| {
+            (
+                proc.qualified_name.clone(),
+                top_idx
+                    .saturating_add(1)
+                    .saturating_add(u32::try_from(position).unwrap_or(u32::MAX)),
+            )
+        })
+        .collect();
+    let arity = procs
+        .iter()
+        .map(|proc| (proc.qualified_name.clone(), proc.params.len()))
+        .collect();
+    let by_span = procs
+        .iter()
+        .map(|proc| (span_key(proc.span), (*proc).clone()))
+        .collect();
+    let direct = analysis.map_or_else(HashSet::new, |(unit, _)| {
+        procs
+            .iter()
+            .filter(|proc| {
+                unit.procedures
+                    .get(&proc.qualified_name)
+                    .is_some_and(|fu| direct_proc_eligible(module, proc, fu))
+            })
+            .map(|proc| proc.qualified_name.clone())
+            .collect()
+    });
+    ProcedurePlan {
+        procs,
+        indices,
+        arity,
+        by_span,
+        direct,
+    }
+}
+
+/// Lower a module's top-level script to a WASM module (source fallback +
 /// structured control flow). `source` is the original Tcl text, sliced for
 /// command / expression text. The constant pool is placed at offset 0 — valid
 /// for a standalone module (own memory) or one whose host keeps low memory free.
 #[must_use]
 pub fn wasm_codegen_module(module: &Module, source: &str) -> WasmModule {
-    codegen(module, source, 0, false, false)
+    codegen(module, source, 0, false, false, None)
+}
+
+/// Emit from a complete compiler unit, enabling registry- and lattice-proven
+/// direct statements while retaining source-span fallback for the rest.
+#[must_use]
+pub fn wasm_codegen_compilation_unit(
+    unit: &CompilationUnit,
+    registry: &CommandRegistry,
+) -> WasmModule {
+    codegen(
+        &unit.ir_module,
+        &unit.source,
+        0,
+        false,
+        false,
+        Some((unit, registry)),
+    )
 }
 
 /// As [`wasm_codegen_module`], but relocate the constant pool to `data_base` so
@@ -384,7 +942,24 @@ pub fn wasm_codegen_module(module: &Module, source: &str) -> WasmModule {
 /// `tcl_obj_new_string` are based at `data_base`.
 #[must_use]
 pub fn wasm_codegen_module_based(module: &Module, source: &str, data_base: i64) -> WasmModule {
-    codegen(module, source, data_base, false, false)
+    codegen(module, source, data_base, false, false, None)
+}
+
+/// Relocated form of [`wasm_codegen_compilation_unit`].
+#[must_use]
+pub fn wasm_codegen_compilation_unit_based(
+    unit: &CompilationUnit,
+    registry: &CommandRegistry,
+    data_base: i64,
+) -> WasmModule {
+    codegen(
+        &unit.ir_module,
+        &unit.source,
+        data_base,
+        false,
+        false,
+        Some((unit, registry)),
+    )
 }
 
 /// As [`wasm_codegen_module_based`], but also emit a WASI-command entry point
@@ -398,7 +973,7 @@ pub fn wasm_codegen_module_based(module: &Module, source: &str, data_base: i64) 
 /// separate `_initialize` call is needed.
 #[must_use]
 pub fn wasm_codegen_module_standalone(module: &Module, source: &str, data_base: i64) -> WasmModule {
-    codegen(module, source, data_base, true, false)
+    codegen(module, source, data_base, true, false, None)
 }
 
 /// As [`wasm_codegen_module_standalone`], but the emitted `_start` also calls
@@ -414,7 +989,7 @@ pub fn wasm_codegen_module_standalone_init(
     source: &str,
     data_base: i64,
 ) -> WasmModule {
-    codegen(module, source, data_base, true, true)
+    codegen(module, source, data_base, true, true, None)
 }
 
 /// Shared codegen for the linkable ([`wasm_codegen_module_based`]) and
@@ -426,6 +1001,7 @@ fn codegen(
     data_base: i64,
     standalone: bool,
     init: bool,
+    analysis: Option<(&CompilationUnit, &CommandRegistry)>,
 ) -> WasmModule {
     let mut wasm = WasmModule::new();
     let imports = Imports {
@@ -437,7 +1013,12 @@ fn codegen(
         ),
         eval_code: add_tcl_import(&mut wasm, "tcl_eval_code", &[ValType::I32], &[ValType::I32]),
         expr_bool: add_tcl_import(&mut wasm, "tcl_expr_bool", &[ValType::I32], &[ValType::I32]),
+        aot: None,
     };
+    let mut imports = imports;
+    if analysis.is_some() {
+        imports.aot = Some(add_aot_imports(&mut wasm));
+    }
 
     // Standalone: the interp-bootstrap imports `_start` drives. Added after the
     // ABI imports so the ABI indices in `Imports` are unchanged.
@@ -458,6 +1039,17 @@ fn codegen(
     // count (imports occupy the low indices). Capture it before emitting bodies.
     let top_idx = u32::try_from(wasm.imports.len()).expect("import count fits in u32");
 
+    let ProcedurePlan {
+        procs,
+        indices: proc_indices,
+        arity: procedure_arity,
+        by_span: procedures_by_span,
+        direct: direct_procs,
+    } = procedure_plan(module, analysis, top_idx);
+    let top_facts = analysis.map_or_else(FunctionFacts::default, |(unit, registry)| {
+        function_facts(&unit.top_level, module, registry, true)
+    });
+
     let mut emitter = WasmEmitter {
         imports,
         body: Vec::new(),
@@ -465,10 +1057,18 @@ fn codegen(
         data_offset: data_base,
         ctrl_depth: 0,
         loops: Vec::new(),
+        code_local: 0,
+        mode: FunctionMode::Top,
+        local_slots: HashMap::new(),
+        proc_indices,
+        procedure_arity,
+        direct_procs,
+        procedures_by_span,
+        facts: top_facts,
     };
     // The top-level script.
     structured::walk(&mut emitter, &module.top_level, source);
-    let top = emitter.finish_function("::top", "top");
+    let top = emitter.finish_function("::top", "top", None);
     wasm.functions.push(top);
 
     // Each user-defined proc body becomes its own WASM function, driven through
@@ -477,15 +1077,39 @@ fn codegen(
     // `namespace eval`, not at load, so they are skipped — mirroring the bytecode
     // backend (`codegen/emitter/mod.rs`). Emitted in qualified-name order so the
     // module bytes are deterministic (`procedures` is a hash map).
-    let mut procs: Vec<&Procedure> = module
-        .procedures
-        .values()
-        .filter(|p| !p.namespace_scoped)
-        .collect();
-    procs.sort_by(|a, b| a.qualified_name.cmp(&b.qualified_name));
     for proc in procs {
+        let direct = emitter.direct_procs.contains(&proc.qualified_name);
+        emitter.mode = if direct {
+            FunctionMode::DirectProc
+        } else {
+            FunctionMode::FallbackProc
+        };
+        emitter.local_slots = if direct {
+            proc.params
+                .iter()
+                .enumerate()
+                .map(|(slot, name)| (name.clone(), u32::try_from(slot).unwrap_or(u32::MAX)))
+                .collect()
+        } else {
+            HashMap::new()
+        };
+        emitter.code_local = if direct {
+            u64::try_from(proc.params.len()).unwrap_or(u64::MAX)
+        } else {
+            0
+        };
+        emitter.facts = analysis
+            .and_then(|(unit, registry)| {
+                unit.procedures
+                    .get(&proc.qualified_name)
+                    .map(|fu| function_facts(fu, module, registry, false))
+            })
+            .unwrap_or_default();
+        if direct {
+            emitter.emit_proc_prelude(proc);
+        }
         structured::walk(&mut emitter, &proc.body, source);
-        let func = emitter.finish_function(&proc.qualified_name, "proc");
+        let func = emitter.finish_function(&proc.qualified_name, "proc", Some(proc));
         wasm.functions.push(func);
     }
 

--- a/rust/tcl-compiler/src/codegen/wasm/backend.rs
+++ b/rust/tcl-compiler/src/codegen/wasm/backend.rs
@@ -49,7 +49,8 @@ use crate::codegen::cmd_subst::{is_pure_cmd_subst, parse_cmd_parts};
 use crate::codegen::emit::Emit;
 use crate::codegen::structured;
 use crate::command_binding::{
-    Binding, BindingKind, analyse_command_binding, scan_module_command_mutations,
+    Binding, BindingKind, ModuleCommandMutations, analyse_command_binding,
+    scan_module_command_mutations,
 };
 use crate::compilation_unit::{CompilationUnit, FunctionUnit};
 use crate::ir::{Module, Procedure, Statement};
@@ -112,6 +113,7 @@ struct AotImports {
 #[derive(Default)]
 struct FunctionFacts {
     hooks: HashMap<(u32, u32), WasmCodegenHookId>,
+    direct_assignments: HashSet<(u32, u32)>,
     direct_calls: HashMap<(u32, u32, String), String>,
 }
 
@@ -343,7 +345,12 @@ impl WasmEmitter {
             return false;
         };
         match statement {
-            Statement::AssignConst { name, value, .. } => {
+            Statement::AssignConst {
+                span, name, value, ..
+            } => {
+                if !self.facts.direct_assignments.contains(&span_key(*span)) {
+                    return false;
+                }
                 if self.mode == FunctionMode::DirectProc {
                     let Some(slot) = self.local_slots.get(name).copied() else {
                         return false;
@@ -412,7 +419,10 @@ impl WasmEmitter {
                         self.emit_completion_dispatch();
                         true
                     }
-                    WasmCodegenHookId::Puts => false,
+                    WasmCodegenHookId::Set
+                    | WasmCodegenHookId::Expr
+                    | WasmCodegenHookId::Return
+                    | WasmCodegenHookId::Puts => false,
                 }
             }
             _ => false,
@@ -673,7 +683,24 @@ fn direct_expr_supported(expr: &ExprNode, params: &HashSet<&str>) -> bool {
     }
 }
 
-fn direct_proc_eligible(module: &Module, proc: &Procedure, unit: &FunctionUnit) -> bool {
+fn wasm_hook_is_trusted(
+    registry: &CommandRegistry,
+    mutations: &ModuleCommandMutations,
+    hook: WasmCodegenHookId,
+) -> bool {
+    let mut commands = registry
+        .command_names_for_wasm_codegen_hook(hook)
+        .peekable();
+    commands.peek().is_some() && commands.all(|command| mutations.trusts(command))
+}
+
+fn direct_proc_eligible(
+    module: &Module,
+    proc: &Procedure,
+    unit: &FunctionUnit,
+    registry: &CommandRegistry,
+    mutations: &ModuleCommandMutations,
+) -> bool {
     if proc.namespace_scoped
         || proc
             .qualified_name
@@ -681,6 +708,8 @@ fn direct_proc_eligible(module: &Module, proc: &Procedure, unit: &FunctionUnit) 
             .is_some_and(|name| name.contains("::"))
         || module.redefined_procedures.contains(&proc.qualified_name)
         || unit.complexity_guarded
+        || !wasm_hook_is_trusted(registry, mutations, WasmCodegenHookId::Expr)
+        || !wasm_hook_is_trusted(registry, mutations, WasmCodegenHookId::Return)
         || !matches!(
             unit.return_type.tcl_type(),
             Some(TclType::Int | TclType::Double | TclType::Numeric)
@@ -740,6 +769,28 @@ fn function_facts(
             continue;
         };
         for (stmt_idx, statement) in cfg_block.statements.iter().enumerate() {
+            if let Statement::AssignConst {
+                span,
+                name,
+                name_braced,
+                value,
+                ..
+            } = statement
+                && (*name_braced || !crate::naming::is_dynamic_word(name))
+                && registry
+                    .command_names_for_wasm_codegen_hook(WasmCodegenHookId::Set)
+                    .any(|command| {
+                        bindings.is_original_builtin_at(block, stmt_idx, command)
+                            && mutations.trusts(command)
+                            && registry
+                                .resolve_call(command, &[name, value], DialectSet::empty())
+                                .is_some_and(|resolved| {
+                                    resolved.wasm_codegen_hook == Some(WasmCodegenHookId::Set)
+                                })
+                    })
+            {
+                facts.direct_assignments.insert(span_key(*span));
+            }
             let (Statement::Call { command, args, .. } | Statement::Barrier { command, args, .. }) =
                 statement
             else {
@@ -770,6 +821,12 @@ fn function_facts(
                     if binding.kind == BindingKind::Proc
                         && binding.target.as_deref() == Some(proc.qualified_name.as_str())
                         && mutations.trusts_proc_binding(&proc.qualified_name)
+                        && !module.has_dynamic_trace
+                        && !module.traced_commands.contains(
+                            proc.qualified_name
+                                .strip_prefix("::")
+                                .unwrap_or(&proc.qualified_name),
+                        )
                     {
                         facts.direct_calls.insert(
                             span_command_key(statement.span(), written),
@@ -889,13 +946,14 @@ fn procedure_plan<'a>(
         .iter()
         .map(|proc| (span_key(proc.span), (*proc).clone()))
         .collect();
-    let direct = analysis.map_or_else(HashSet::new, |(unit, _)| {
+    let direct = analysis.map_or_else(HashSet::new, |(unit, registry)| {
+        let mutations = scan_module_command_mutations(module, registry);
         procs
             .iter()
             .filter(|proc| {
                 unit.procedures
                     .get(&proc.qualified_name)
-                    .is_some_and(|fu| direct_proc_eligible(module, proc, fu))
+                    .is_some_and(|fu| direct_proc_eligible(module, proc, fu, registry, &mutations))
             })
             .map(|proc| proc.qualified_name.clone())
             .collect()

--- a/rust/tcl-compiler/src/codegen/wasm/mod.rs
+++ b/rust/tcl-compiler/src/codegen/wasm/mod.rs
@@ -36,8 +36,9 @@ mod encoding;
 mod ir;
 
 pub use backend::{
-    RESERVED_DATA_BASE, wasm_codegen_module, wasm_codegen_module_based,
-    wasm_codegen_module_standalone, wasm_codegen_module_standalone_init,
+    RESERVED_DATA_BASE, wasm_codegen_compilation_unit, wasm_codegen_compilation_unit_based,
+    wasm_codegen_module, wasm_codegen_module_based, wasm_codegen_module_standalone,
+    wasm_codegen_module_standalone_init,
 };
 pub use ir::{
     SectionId, ValType, WasmData, WasmFunction, WasmImport, WasmInstruction, WasmModule, WasmOp,

--- a/rust/tcl-compiler/tests/wasm_codegen.rs
+++ b/rust/tcl-compiler/tests/wasm_codegen.rs
@@ -24,8 +24,10 @@
 //! present) validates the bytes for full structural validity.
 
 use tcl_compiler::codegen::wasm::{
-    RESERVED_DATA_BASE, WasmModule, wasm_codegen_module, wasm_codegen_module_based,
+    RESERVED_DATA_BASE, WasmModule, wasm_codegen_compilation_unit, wasm_codegen_module,
+    wasm_codegen_module_based,
 };
+use tcl_compiler::compilation_unit::CompilationUnit;
 use tcl_compiler::lowering::lower_to_ir;
 use tcl_registry::CommandRegistry;
 
@@ -41,6 +43,65 @@ fn compile_wasm_based(source: &str, data_base: i64) -> WasmModule {
     let registry = CommandRegistry::build_default();
     let module = lower_to_ir(source, &registry);
     wasm_codegen_module_based(&module, source, data_base)
+}
+
+fn compile_wasm_analysed(source: &str) -> WasmModule {
+    let registry = CommandRegistry::build_default();
+    let unit = CompilationUnit::build_for(source, &registry, false);
+    wasm_codegen_compilation_unit(&unit, &registry)
+}
+
+#[test]
+fn analysed_add_program_uses_direct_tcl_object_operations() {
+    let source = r"proc add {b c} {
+    return [expr {$b + $c}]
+}
+
+set e 2
+set f 4
+puts [add $e $f]
+";
+    let mut module = compile_wasm_analysed(source);
+    let wat = module.to_wat();
+
+    assert!(
+        wat.contains(r#"(func $::add (export "::add") (param $b i32) (param $c i32) (result i32)"#),
+        "{wat}"
+    );
+    assert!(wat.contains(r#""tcl_codegen_local_bind""#), "{wat}");
+    assert!(wat.contains(r#""tcl_codegen_expr_add""#), "{wat}");
+    assert!(wat.contains(r#""tcl_codegen_puts""#), "{wat}");
+    assert!(wat.contains(r#""tcl_codegen_proc_register""#), "{wat}");
+    assert!(!wat.lines().any(|line| line.trim() == "call 1"), "{wat}");
+    assert_eq!(&module.to_bytes()[0..4], b"\0asm");
+}
+
+#[test]
+fn analysed_direct_call_declines_when_binding_lattice_is_opaque() {
+    let source = r"proc add {b c} {return [expr {$b + $c}]}
+rename add old_add
+puts [add 2 4]
+";
+    let mut module = compile_wasm_analysed(source);
+    let wat = module.to_wat();
+
+    assert!(
+        wat.lines().any(|line| line.trim() == "call 1"),
+        "the rebound call must retain source evaluation:\n{wat}"
+    );
+    assert_eq!(&module.to_bytes()[0..4], b"\0asm");
+}
+
+#[test]
+fn analysed_puts_preserves_braced_command_text_as_literal() {
+    let mut module = compile_wasm_analysed("puts {[add 2 4]}\n");
+    let wat = module.to_wat();
+
+    assert!(
+        wat.lines().any(|line| line.trim() == "call 1"),
+        "a braced command-shaped word must remain literal:\n{wat}"
+    );
+    assert_eq!(&module.to_bytes()[0..4], b"\0asm");
 }
 
 /// With a non-zero data base, both the data segments and the `i32.const` offsets

--- a/rust/tcl-compiler/tests/wasm_codegen.rs
+++ b/rust/tcl-compiler/tests/wasm_codegen.rs
@@ -93,6 +93,97 @@ puts [add 2 4]
 }
 
 #[test]
+fn analysed_assignment_preserves_dynamic_array_index_substitution() {
+    let mut module = compile_wasm_analysed("set x foo\nset a($x) 1\n");
+    let wat = module.to_wat();
+
+    assert!(
+        wat.contains(r#""set a($x) 1""#),
+        "the substituted target must retain source evaluation:\n{wat}"
+    );
+    assert_eq!(&module.to_bytes()[0..4], b"\0asm");
+}
+
+#[test]
+fn analysed_assignment_preserves_a_rebound_set_command() {
+    let source = r"proc replacement args {return replacement}
+proc rebind {} {
+    rename set original_set
+    rename replacement set
+}
+rebind
+set x 1
+";
+    let mut module = compile_wasm_analysed(source);
+    let wat = module.to_wat();
+
+    assert!(
+        wat.contains(r#""set x 1""#),
+        "a potentially rebound set must retain source evaluation:\n{wat}"
+    );
+    assert_eq!(&module.to_bytes()[0..4], b"\0asm");
+}
+
+#[test]
+fn analysed_direct_proc_requires_original_expr_and_return_bindings() {
+    for (name, rebind) in [
+        ("expr", "rename expr original_expr\nrename replacement expr"),
+        (
+            "return",
+            "rename return original_return\nrename replacement return",
+        ),
+    ] {
+        let source = format!(
+            "proc replacement args {{list replacement}}\n\
+             proc rebind {{}} {{{rebind}}}\n\
+             proc add {{a b}} {{return [expr {{$a + $b}}]}}\n\
+             rebind\n\
+             puts [add 2 4]\n"
+        );
+        let mut module = compile_wasm_analysed(&source);
+        let wat = module.to_wat();
+
+        assert!(
+            !wat.contains(
+                r#"(func $::add (export "::add") (param $a i32) (param $b i32) (result i32)"#
+            ),
+            "a potentially rebound {name} must disable the direct procedure:\n{wat}"
+        );
+        assert!(
+            wat.contains(r#""puts [add 2 4]""#),
+            "the call must retain source evaluation when {name} can change:\n{wat}"
+        );
+        assert_eq!(&module.to_bytes()[0..4], b"\0asm");
+    }
+}
+
+#[test]
+fn analysed_direct_call_preserves_static_and_dynamic_execution_traces() {
+    for (name, trace_setup) in [
+        ("static", "trace add execution add enter callback"),
+        (
+            "dynamic",
+            "set traced_command add\ntrace add execution $traced_command enter callback",
+        ),
+    ] {
+        let source = format!(
+            "proc callback args {{}}\n\
+             proc add {{a b}} {{return [expr {{$a + $b}}]}}\n\
+             {trace_setup}\n\
+             puts [add 1 2]\n"
+        );
+        let mut module = compile_wasm_analysed(&source);
+        let wat = module.to_wat();
+
+        assert!(
+            wat.contains(r#""puts [add 1 2]""#),
+            "a {name} execution trace must retain runtime dispatch:\n{wat}"
+        );
+        assert_eq!(&module.to_bytes()[0..4], b"\0asm");
+    }
+}
+
+#[test]
 fn analysed_puts_preserves_braced_command_text_as_literal() {
     let mut module = compile_wasm_analysed("puts {[add 2 4]}\n");
     let wat = module.to_wat();

--- a/rust/tcl-compiler/tests/wasm_real_link.rs
+++ b/rust/tcl-compiler/tests/wasm_real_link.rs
@@ -21,10 +21,10 @@
 //!
 //! `wasm_execute.rs` runs emitted modules against a hand-built host stub. This
 //! goes all the way: it links the emitted module against the real Rust runtime
-//! compiled to `wasm32-unknown-unknown`, sharing one linear memory, and proves a
+//! compiled to `wasm32-wasip1`, sharing one linear memory, and proves a
 //! genuine side effect of the emitted program survives in the real interpreter.
 //!
-//! Three modules, composed by the wasmtime CLI (`--preload`), sharing the
+//! Three modules, composed by the wasmtime CLI (`--preload`), share the
 //! runtime's exported memory:
 //!
 //! 1. **`tcl` = the real runtime** — exports `memory` + the codegen ABI
@@ -33,35 +33,30 @@
 //!    (`Tcl_GetStringFromObj`). Built with `--global-base=0x200000` so its
 //!    data/heap sit above a reserved gap `[0x100000, 0x200000)` (its 1 MiB shadow
 //!    stack stays at `[0, 0x100000)`).
-//! 2. **`user` = the emitted module** — its `::top` boxes `set x 42` and
-//!    `tcl_eval_code`s it (honouring the command's completion code). Its constant
-//!    pool is relocated to [`RESERVED_DATA_BASE`] (`0x100000`) so it lands in the
-//!    gap, not under the runtime's stack.
+//! 2. **`user` = the emitted module** — its analysed statements use the direct
+//!    Tcl-object ABI where binding and type lattices prove that path. Its
+//!    constant pool is relocated to [`RESERVED_DATA_BASE`] (`0x100000`) so it
+//!    lands in the gap, not under the runtime's stack.
 //! 3. **bootstrap** (the WASI command) — creates an interp, makes it current,
 //!    calls `user::top`, then `tcl_eval`s a `query` against the *same* interp,
 //!    reads the result string with `Tcl_GetStringFromObj`, and writes it to
 //!    stdout. The printed result proves the emitted program's side effect
 //!    persisted in the real runtime.
 //!
-//! Two programs are linked and run: a bare `set x 42` (read back as `42`) and a
-//! **proc** defined and called — `proc greet {name} {return "hi $name"}` then
-//! `set r [greet world]`, read back as `hi world`. The proc exercises a real
-//! frame push, parameter binding, `return`, string interpolation, and command
-//! substitution in the live runtime. (Dispatch still flows through the interp's
-//! eval-fallback, so the separately-emitted `::greet` function is not yet the one
-//! that runs — wiring `greet …` calls to `call ::greet` is the next increment.)
+//! The cases cover a direct variable store, an interpreted fallback procedure,
+//! and the direct numeric `add` procedure. The final case proves the linked
+//! generated function binds Tcl-visible parameters, adds through the numeric
+//! tower, and writes `6` through the real WASI stdout path.
 //!
 //! Heavy + gated: it builds `runtime/rust` to wasm (cached after the first run)
 //! and shells out to the `wasmtime` CLI. It skips cleanly when either is
-//! unavailable, mirroring the other wasm tests. Neither program needs `expr` (the
-//! numeric tower is off in the wasm build) nor any host capability, so both run
-//! faithfully on the placeholder `BrowserHost`.
+//! unavailable, mirroring the other wasm tests.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use tcl_compiler::codegen::wasm::{RESERVED_DATA_BASE, wasm_codegen_module_based};
-use tcl_compiler::lowering::lower_to_ir;
+use tcl_compiler::codegen::wasm::{RESERVED_DATA_BASE, wasm_codegen_compilation_unit_based};
+use tcl_compiler::compilation_unit::CompilationUnit;
 use tcl_registry::CommandRegistry;
 
 /// The bootstrap WASI command (see the module docs): create + select an interp,
@@ -117,17 +112,33 @@ fn workspace_root() -> PathBuf {
         .expect("workspace root")
 }
 
-/// Build `runtime/rust` to `wasm32-unknown-unknown` with the reserved-region
+/// Build `runtime/rust` to `wasm32-wasip1` with the reserved-region
 /// linker flag, into an isolated target dir. Returns the artifact path, or `None`
 /// if the build can't run (e.g. the wasm32 target is missing) so the test skips.
 fn build_reserved_runtime() -> Option<PathBuf> {
     let root = workspace_root();
     let target_dir = std::env::temp_dir().join("tcl_reserved_runtime");
-    let ok = Command::new("cargo")
+    let mut command = Command::new("cargo");
+    let wasi_sdk = std::env::var_os("WASI_SDK_PATH")
+        .map(PathBuf::from)
+        .or(Some(PathBuf::from("/opt/wasi-sdk")))
+        .filter(|path| path.join("bin/clang").is_file())?;
+    command.env("WASI_SDK_PATH", wasi_sdk);
+    if let Some(tommath) = [
+        root.join("tmp/tcl9.0.4/libtommath"),
+        root.join("tmp/tcl9.0.3-src/libtommath"),
+        root.join("tmp/tcl8.6.16/libtommath"),
+    ]
+    .into_iter()
+    .find(|path| path.join("tommath.h").is_file())
+    {
+        command.env("TCL_TOMMATH_DIR", tommath);
+    }
+    let ok = command
         .arg("build")
         .arg("--manifest-path")
         .arg(root.join("runtime/rust/Cargo.toml"))
-        .args(["--target", "wasm32-unknown-unknown"])
+        .args(["--target", "wasm32-wasip1"])
         .arg("--target-dir")
         .arg(&target_dir)
         // Reserve [0x100000, 0x200000): the 1 MiB shadow stack stays at
@@ -136,16 +147,17 @@ fn build_reserved_runtime() -> Option<PathBuf> {
         .env("RUSTFLAGS", "-C link-arg=--global-base=2097152")
         .status()
         .is_ok_and(|s| s.success());
-    ok.then(|| target_dir.join("wasm32-unknown-unknown/debug/tcl_runtime.wasm"))
+    ok.then(|| target_dir.join("wasm32-wasip1/debug/tcl_runtime.wasm"))
 }
 
 /// Emit `program`, link it against the real `runtime`, run its `::top`, then
 /// evaluate `query` against the same interp and return the printed result.
 fn run_real_link(runtime: &Path, program: &str, query: &str) -> String {
     let registry = CommandRegistry::build_default();
-    let module = lower_to_ir(program, &registry);
+    let unit = CompilationUnit::build_for(program, &registry, false);
     // Constant pool in the reserved gap so it does not hit the runtime's stack.
-    let user_bytes = wasm_codegen_module_based(&module, program, RESERVED_DATA_BASE).to_bytes();
+    let user_bytes =
+        wasm_codegen_compilation_unit_based(&unit, &registry, RESERVED_DATA_BASE).to_bytes();
 
     let tmp = std::env::temp_dir();
     let user = tmp.join("tcl_real_link_user.wasm");
@@ -198,6 +210,11 @@ fn emitted_modules_run_against_the_real_runtime() {
             "proc greet {name} {return \"hi $name\"}\nset r [greet world]\n",
             "set r",
             "hi world",
+        ),
+        (
+            "proc add {b c} {\n    return [expr {$b + $c}]\n}\n\nset e 2\nset f 4\nputs [add $e $f]\n",
+            "set e",
+            "6\n2",
         ),
     ];
     for (program, query, expected) in cases {

--- a/rust/tcl-explorer-wasm/Cargo.lock
+++ b/rust/tcl-explorer-wasm/Cargo.lock
@@ -25,11 +25,11 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -55,42 +55,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
+name = "hybrid-array"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -119,9 +124,9 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "num-bigint"
-version = "0.4.8"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -255,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -429,12 +434,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasm-bindgen"

--- a/rust/tcl-explorer/src/serialise.rs
+++ b/rust/tcl-explorer/src/serialise.rs
@@ -198,23 +198,24 @@ fn serialise_children(stmt: &Statement, li: &LineIndex, source: &str) -> Option<
     }
 }
 
-/// Serialise the `wasm` view: drive the eval-fallback WASM emitter (the same
-/// `wasm_codegen_module` `tcl compwasm` uses) and emit the rich per-instruction
+/// Serialise the `wasm` view: drive the analysis-aware WASM emitter used by
+/// `tcl compwasm` and emit the rich per-instruction
 /// explorer shape (`wasm_explorer::wasm_to_explorer_json` — resolved `call`
 /// targets, paired `br`/`br_if` targets, block-pairing indices, per-instruction
 /// ranges). The synthetic `(module)` entry additionally carries the full WAT
 /// `text`, so both the text renderer and the web GUI read one shape; the
 /// module-wide counts (`functionCount` / `totalInstrCount`) and the type
 /// section come from `wasm_to_explorer_json` itself.
-fn serialise_wasm(module: &Module, source: &str) -> Value {
-    use tcl_compiler::codegen::wasm::wasm_codegen_module;
+fn serialise_wasm(result: &ExplorerResult) -> Value {
+    use tcl_compiler::codegen::wasm::wasm_codegen_compilation_unit;
 
-    let mut wasm = wasm_codegen_module(module, source);
+    let registry = registry_for_dialect(&result.dialect);
+    let mut wasm = wasm_codegen_compilation_unit(&result.unit, registry);
     let wat = wasm.to_wat();
 
     // Rich per-instruction entries (module header first, then functions).
-    let li = LineIndex::new(source);
-    let mut entries = crate::wasm_explorer::wasm_to_explorer_json(&wasm, &li, source);
+    let li = LineIndex::new(&result.source);
+    let mut entries = crate::wasm_explorer::wasm_to_explorer_json(&wasm, &li, &result.source);
 
     // Augment the synthetic `(module)` header with the WAT text the TUI
     // renderer reads (it reads `text` on the module entry and
@@ -1939,18 +1940,14 @@ pub fn serialise_result(result: &ExplorerResult) -> Value {
         }),
     );
 
-    // WASM views: drive the eval-fallback WASM emitter (the same one `tcl
-    // compwasm` uses) and surface its WAT plus the rich per-instruction
+    // WASM views: drive the analysis-aware WASM emitter used by `tcl compwasm`
+    // and surface its WAT plus the rich per-instruction
     // explorer shape (resolved `call`/branch targets, per-instruction ranges)
     // alongside per-function headers, which the text/`wasm` view renders.
-    out.insert(
-        "wasm".to_owned(),
-        serialise_wasm(&result.unit.ir_module, &result.source),
-    );
+    out.insert("wasm".to_owned(), serialise_wasm(result));
     out.insert(
         "wasmOptimised".to_owned(),
-        opt.as_ref()
-            .map_or(Value::Null, |(r, s)| serialise_wasm(&r.unit.ir_module, s)),
+        opt.as_ref().map_or(Value::Null, |(r, _)| serialise_wasm(r)),
     );
 
     let (annotations, by_line) = serialise_annotations(result, &li, &result.source);

--- a/rust/tcl-explorer/src/wasm_explorer.rs
+++ b/rust/tcl-explorer/src/wasm_explorer.rs
@@ -547,10 +547,9 @@ mod tests {
 
     fn wasm_entries(src: &str) -> Vec<Value> {
         let result = run_pipeline(src, "tcl8.6");
-        let module = tcl_compiler::codegen::wasm::wasm_codegen_module(
-            &result.unit.ir_module,
-            &result.source,
-        );
+        let registry = tcl_registry::registry_for_dialect(&result.dialect);
+        let module =
+            tcl_compiler::codegen::wasm::wasm_codegen_compilation_unit(&result.unit, registry);
         let li = LineIndex::new(&result.source);
         wasm_to_explorer_json(&module, &li, &result.source)
     }

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -3034,7 +3034,7 @@ fn a_load_only_package_does_not_suppress_unrelated_w120s_923_idx72() {
     while std::time::Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(100));
         let next = lsp.pull_diagnostics(&uri);
-        if codes(&next) == codes(&diags) {
+        if has_code(&next, "W120") {
             diags = next;
             break;
         }

--- a/rust/tcl-lsp-server/tests/e2e/issue923_idx80_mathfunc.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue923_idx80_mathfunc.rs
@@ -223,7 +223,9 @@ fn workspace_scan_clears_w123_for_a_cross_file_mathfunc() {
     let vector = format!("file://{}", vector_path.to_string_lossy());
     lsp.open_ready(&vector, VECTOR);
     let diags = lsp.await_diagnostics_settled(&vector, Duration::from_secs(30), |d| {
-        w123_names(d).iter().any(|n| n == "NeverDefinedAnywhere")
+        let names = w123_names(d);
+        names.iter().any(|n| n == "NeverDefinedAnywhere")
+            && !names.iter().any(|n| n == "Pi" || n == "Inv")
     });
     let names = w123_names(&diags);
     assert!(

--- a/rust/tcl-registry/src/commands/tcl/expr_.rs
+++ b/rust/tcl-registry/src/commands/tcl/expr_.rs
@@ -67,6 +67,7 @@ pub fn spec() -> CommandSpec {
             return_value: "The value of the evaluated expression — typically numeric, but a bare operand (e.g. `expr {$x}`) or a ternary branch can pass through an arbitrary string or list value unchanged.",
         }),
         lowering_hook: Some(LoweringHookId::Expr),
+        wasm_codegen_hook: Some(WasmCodegenHookId::Expr),
         inline_codegen_hook: Some(InlineCodegenHookId::Expr),
         forms: FORMS,
         side_effects: SIDE_EFFECTS,

--- a/rust/tcl-registry/src/commands/tcl/proc_.rs
+++ b/rust/tcl-registry/src/commands/tcl/proc_.rs
@@ -18,7 +18,7 @@
 
 //! `proc` — define a procedure.
 
-use crate::hooks::LoweringHookId;
+use crate::hooks::{LoweringHookId, WasmCodegenHookId};
 use crate::prelude::*;
 
 const SIDE_EFFECTS: &[SideEffect] = &[SideEffect {
@@ -84,6 +84,7 @@ pub fn spec() -> CommandSpec {
         ],
         return_type: Some(TclType::String),
         lowering_hook: Some(LoweringHookId::Proc),
+        wasm_codegen_hook: Some(WasmCodegenHookId::Proc),
         // A `proc` body runs in the proc's own frame on each
         // call — never the caller's frame.  Stamping `Structural`
         // here lets generic `body_indices_to_skip` consumers (SSA,

--- a/rust/tcl-registry/src/commands/tcl/puts_.rs
+++ b/rust/tcl-registry/src/commands/tcl/puts_.rs
@@ -99,6 +99,7 @@ pub fn spec() -> CommandSpec {
         arity: Arity::new(1, 2),
         arg_role_resolver: Some(puts_arg_roles),
         return_type: Some(TclType::String),
+        wasm_codegen_hook: Some(WasmCodegenHookId::Puts),
         side_effects: &[SideEffect {
             target: SideEffectTarget::FileIo,
             reads: false,

--- a/rust/tcl-registry/src/commands/tcl/return_.rs
+++ b/rust/tcl-registry/src/commands/tcl/return_.rs
@@ -223,6 +223,7 @@ pub fn spec() -> CommandSpec {
             return_value: "The result string that becomes the enclosing procedure's result (or, inside a script evaluated by source, that script's result). With -code other than the default ok, result instead becomes the payload of the resulting exceptional completion — e.g. the message text of a -code error, or the value a catch reports when it traps this return.",
         }),
         lowering_hook: Some(LoweringHookId::Return),
+        wasm_codegen_hook: Some(WasmCodegenHookId::Return),
         inline_codegen_hook: Some(InlineCodegenHookId::Return),
         forms: FORMS,
         context_gate: Some(return_context_gate),

--- a/rust/tcl-registry/src/commands/tcl/set_.rs
+++ b/rust/tcl-registry/src/commands/tcl/set_.rs
@@ -41,7 +41,7 @@
 // version of this same fact, and the hover snippet below for the
 // developer-facing wording.
 
-use crate::hooks::LoweringHookId;
+use crate::hooks::{LoweringHookId, WasmCodegenHookId};
 use crate::prelude::*;
 
 const SIDE_EFFECTS: &[SideEffect] = &[SideEffect {
@@ -127,6 +127,7 @@ pub fn spec() -> CommandSpec {
             return_value: "varName's new value when value is given, otherwise its current value.",
         }),
         lowering_hook: Some(LoweringHookId::Set),
+        wasm_codegen_hook: Some(WasmCodegenHookId::Set),
         forms: FORMS,
         side_effects: SIDE_EFFECTS,
         analyser_hook: Some(crate::hooks::AnalyserHookId::Set),

--- a/rust/tcl-registry/src/hooks.rs
+++ b/rust/tcl-registry/src/hooks.rs
@@ -430,9 +430,11 @@ pub enum AnalyserHookId {
 
 /// Typed identifier for a WASM-runtime codegen specialisation.
 ///
-/// Reserved for the WASM-target codegen path
-/// (`vm/`, the WASM runtime). Currently empty — no command
-/// has a WASM-specific emitter yet — but the field exists on
+/// Used by the WASM-target codegen path. The registry stamp selects the
+/// semantic emitter; applicability still depends on the compiler's binding
+/// lattice proving that the call reaches the stamped command.
+///
+/// The field exists on
 /// [`crate::CommandSpec`] / [`crate::SubCommand`] /
 /// [`crate::forms::CommandForm`] so the per-command coverage
 /// audit can track WASM hook stamping alongside the `TclVM` hook.
@@ -441,7 +443,12 @@ pub enum AnalyserHookId {
 /// keep it in sync with whatever dispatcher the WASM emitter
 /// uses on the compiler side.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum WasmCodegenHookId {}
+pub enum WasmCodegenHookId {
+    /// Register a lowered procedure definition without evaluating its source.
+    Proc,
+    /// Write the single-argument stdout form through the runtime channel API.
+    Puts,
+}
 
 /// Compile-time constant folder.
 ///

--- a/rust/tcl-registry/src/hooks.rs
+++ b/rust/tcl-registry/src/hooks.rs
@@ -444,6 +444,12 @@ pub enum AnalyserHookId {
 /// uses on the compiler side.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum WasmCodegenHookId {
+    /// Store a literal value through Tcl's variable machinery.
+    Set,
+    /// Evaluate a supported expression through the direct object ABI.
+    Expr,
+    /// Return a direct expression result from a generated procedure.
+    Return,
     /// Register a lowered procedure definition without evaluating its source.
     Proc,
     /// Write the single-argument stdout form through the runtime channel API.

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -33,7 +33,9 @@ use crate::body_kind::BodyKind;
 use crate::command_table::CommandTableEffect;
 use crate::dialects::DialectSet;
 use crate::forms::CommandForm;
-use crate::hooks::{AnalyserHookId, CodegenHookId, InlineCodegenHookId, LoweringHookId};
+use crate::hooks::{
+    AnalyserHookId, CodegenHookId, InlineCodegenHookId, LoweringHookId, WasmCodegenHookId,
+};
 use crate::lifecycle::{Lifecycle, LifecycleState};
 use crate::spec::{BytePayloadSpec, CommandSpec, SubCommand};
 use crate::traits::Traits;
@@ -1860,6 +1862,7 @@ impl CommandRegistry {
             lowering_hook: spec.lowering_hook,
             codegen_hook: spec.codegen_hook,
             inline_codegen_hook: spec.inline_codegen_hook,
+            wasm_codegen_hook: spec.wasm_codegen_hook,
             analyser_hook: spec.analyser_hook,
         };
 
@@ -1881,6 +1884,10 @@ impl CommandRegistry {
                 .and_then(|f| f.codegen_hook)
                 .or(sub.codegen_hook)
                 .or(spec.codegen_hook);
+            resolved.wasm_codegen_hook = form
+                .and_then(|f| f.wasm_codegen_hook)
+                .or(sub.wasm_codegen_hook)
+                .or(spec.wasm_codegen_hook);
             // Forms carry no inline hook — the inline emitters guard
             // their own applicability (arity / shape) at the dispatch
             // site, so subcommand-level wins over command-level.
@@ -1897,6 +1904,7 @@ impl CommandRegistry {
         if let Some(f) = form {
             resolved.lowering_hook = f.lowering_hook.or(spec.lowering_hook);
             resolved.codegen_hook = f.codegen_hook.or(spec.codegen_hook);
+            resolved.wasm_codegen_hook = f.wasm_codegen_hook.or(spec.wasm_codegen_hook);
             resolved.form = Some(f);
         }
         Some(resolved)
@@ -2167,6 +2175,8 @@ pub struct ResolvedCall<'r> {
     /// Effective inline (value-position / catch-body) codegen hook
     /// identifier (subcommand-level wins over command-level).
     pub inline_codegen_hook: Option<InlineCodegenHookId>,
+    /// Effective WASM-target codegen hook identifier.
+    pub wasm_codegen_hook: Option<WasmCodegenHookId>,
     /// Effective analyser handler-family hook identifier
     /// (subcommand-level wins over command-level).
     pub analyser_hook: Option<AnalyserHookId>,

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -769,6 +769,19 @@ impl CommandRegistry {
         self.by_name.keys().map(String::as_str)
     }
 
+    /// Return command names whose command-level spec selects `hook` for WASM.
+    pub fn command_names_for_wasm_codegen_hook(
+        &self,
+        hook: WasmCodegenHookId,
+    ) -> impl Iterator<Item = &str> {
+        self.by_name.iter().filter_map(move |(name, specs)| {
+            specs
+                .iter()
+                .any(|spec| spec.wasm_codegen_hook == Some(hook))
+                .then_some(name.as_str())
+        })
+    }
+
     /// The [`ObjectClassSpec`] for a `TclOO` / megawidget class named
     /// `class_name`, or `None` when it is not a registry-modelled class.
     ///

--- a/rust/tcl-spec-studio-wasm/Cargo.lock
+++ b/rust/tcl-spec-studio-wasm/Cargo.lock
@@ -25,11 +25,11 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -55,31 +55,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -90,20 +96,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "indexmap"
@@ -141,9 +146,9 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "num-bigint"
-version = "0.4.8"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -277,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -461,12 +466,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasm-bindgen"

--- a/rust/tcl-spec-studio/src/catalogue.rs
+++ b/rust/tcl-spec-studio/src/catalogue.rs
@@ -330,10 +330,10 @@ pub const INLINE_CODEGEN_HOOKS: &[Variant] = &[
 ];
 
 /// [`WasmCodegenHookId`] — the WASM-target emitter family.
-///
-/// Empty: the WASM emitter has no per-command specialisations yet. The field
-/// exists so the per-command coverage audit can track hook stamping.
-pub const WASM_CODEGEN_HOOKS: &[Variant] = &[];
+pub const WASM_CODEGEN_HOOKS: &[Variant] = &[
+    v("Proc", "procedure definition"),
+    v("Puts", "single-argument stdout write"),
+];
 
 /// [`AnalyserHookId`] — the per-command analyser handler family.
 pub const ANALYSER_HOOKS: &[Variant] = &[
@@ -981,10 +981,11 @@ mod tests {
         }
     }
 
-    /// [`WasmCodegenHookId`] is an empty enum — the WASM emitter has no
-    /// per-command specialisations yet, so this match has no arms.
+    /// Every [`WasmCodegenHookId`] variant is catalogued in `WASM_CODEGEN_HOOKS`.
     fn covered_wasm(h: WasmCodegenHookId) -> bool {
-        match h {}
+        match h {
+            WasmCodegenHookId::Proc | WasmCodegenHookId::Puts => true,
+        }
     }
 
     /// Every [`AnalyserHookId`] variant is catalogued in `ANALYSER_HOOKS`.
@@ -1042,14 +1043,7 @@ mod tests {
         assert!(covered_tcl_type(TclType::String));
         assert!(covered_side_effect_target(SideEffectTarget::Unknown));
         assert!(covered_small_enums());
-        // `WasmCodegenHookId` has no variants, so its witness can never be
-        // *called* — naming it is what keeps the exhaustive match compiled,
-        // and that match is the gate for the day the enum gains an arm.
-        let wasm_witness: fn(WasmCodegenHookId) -> bool = covered_wasm;
-        assert!(std::ptr::fn_addr_eq(
-            wasm_witness,
-            covered_wasm as fn(_) -> _
-        ));
+        assert!(covered_wasm(WasmCodegenHookId::Proc));
         assert!(covered_lowering(LoweringHookId::Expr));
         assert!(covered_codegen(CodegenHookId::Dict));
         assert!(covered_inline(InlineCodegenHookId::Expr));

--- a/rust/tcl-spec-studio/src/catalogue.rs
+++ b/rust/tcl-spec-studio/src/catalogue.rs
@@ -331,6 +331,9 @@ pub const INLINE_CODEGEN_HOOKS: &[Variant] = &[
 
 /// [`WasmCodegenHookId`] — the WASM-target emitter family.
 pub const WASM_CODEGEN_HOOKS: &[Variant] = &[
+    v("Set", "literal variable assignment"),
+    v("Expr", "direct expression evaluation"),
+    v("Return", "direct procedure return"),
     v("Proc", "procedure definition"),
     v("Puts", "single-argument stdout write"),
 ];
@@ -984,7 +987,11 @@ mod tests {
     /// Every [`WasmCodegenHookId`] variant is catalogued in `WASM_CODEGEN_HOOKS`.
     fn covered_wasm(h: WasmCodegenHookId) -> bool {
         match h {
-            WasmCodegenHookId::Proc | WasmCodegenHookId::Puts => true,
+            WasmCodegenHookId::Set
+            | WasmCodegenHookId::Expr
+            | WasmCodegenHookId::Return
+            | WasmCodegenHookId::Proc
+            | WasmCodegenHookId::Puts => true,
         }
     }
 


### PR DESCRIPTION
## Summary

- add a registry- and lattice-gated typed WASM path for literal variables, fixed-arity numeric procedures, direct procedure calls, and `puts`
- add dual-ported runtime frame slots and an explicit Tcl object ownership ABI
- preserve the tree-walker fallback whenever analysis cannot prove direct lowering is safe
- link and run the exact `add` sample against the real Rust runtime, verifying `6` on stdout

## Verification

- `make prep-pr`
- `make check-rust`
- `RUST_TEST_THREADS=1 make test`
- `make test-emacs`
- `make check-all`