### PR TITLE
Fix LSP handler admission liveness

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -398,6 +398,8 @@ are its rules, and what are the failure modes". One contract per file.
   invariant, and the release flow.
 - [lsp-feature-providers.md](contracts/lsp-feature-providers.md) —
   non-diagnostics LSP provider contracts and failure modes.
+- [lsp-transport-liveness.md](contracts/lsp-transport-liveness.md) — stdin,
+  handler-admission, and stdout liveness boundaries for the LSP transport.
 - [workspace-indexing.md](contracts/workspace-indexing.md) — workspace
   cache, index, and scanner contracts.
 - [package-loading.md](contracts/package-loading.md) — stdlib, tcllib,

--- a/docs/design/contracts/lsp-transport-liveness.md
+++ b/docs/design/contracts/lsp-transport-liveness.md
@@ -33,17 +33,19 @@ the transport absorbs every request future already read from the local editor,
 rather than stopping after four pending futures.
 
 `DeferredConcurrency` calls the inner LSP service immediately, preserving its
-request registration, cancellation, and exit side effects, but polls only four
-ordinary returned handler futures at a time. It also forwards the inner
-service's `poll_ready` state before each call. This matters during `initialize`:
-later messages must not be admitted until initialisation has completed.
+request registration, cancellation, and notification side effects. It polls
+only four ordinary request futures at a time; every JSON-RPC notification (a
+message with no `id`) bypasses that limit. It also forwards the inner service's
+`poll_ready` state before each call. This matters during `initialize`: later
+messages must not be admitted until initialisation has completed.
 
 The resulting responsibilities are:
 
 | Layer | Bound | Purpose |
 |---|---:|---|
 | stdin admission after initialisation | no finite bound | Client responses can always be routed. |
-| active application handlers | 4 | Shared server state retains the upstream concurrency limit. |
+| active request handlers | 4 | Shared server state retains the upstream concurrency limit. |
+| notification handlers | no transport limit | Protocol progress cannot be overtaken by later requests. |
 | stdout pump | no finite message bound | A slow reader cannot stop stdin. |
 | configuration request | 10 seconds | A client which never replies releases its handler permit. |
 
@@ -56,10 +58,15 @@ would turn a non-responsive editor into unbounded retained state. A general
 request timeout therefore needs cancellation-safe pending-request tracking in
 the transport dependency first.
 
-`exit` and `$/cancelRequest` bypass the four-handler application limit. They
-exist to stop queued or running work, so putting either behind that work would
-make shutdown and cancellation least effective precisely when the server is
-busy.
+Every JSON-RPC notification bypasses the four-request application limit.
+`exit` and `$/cancelRequest` exist to stop queued or running work, so putting
+either behind that work would make shutdown and cancellation least effective
+precisely when the server is busy. Document-sync notifications have the same
+ordering requirement: `didOpen`, `didChange`, and `didClose` draw their
+`EditOrder` ticket when their handler is first polled. A following read waits
+only for tickets already drawn; delaying the preceding notification behind
+saturated requests lets that read snapshot the barrier first and answer from
+text older than an edit the server has already received.
 
 ## Example
 
@@ -77,6 +84,11 @@ handlers finish, and the queued hover requests then run four at a time.
 - The pending-future set can grow with a request burst. This is deliberate: a
   finite input-admission bound recreates the deadlock at a different threshold.
   The peer is the local editor process, not an internet-facing client.
+- Notification futures can grow with a notification burst for the same reason.
+  This is a deliberate protocol-ordering trade-off, not a new work queue:
+  document mutations serialise through `EditOrder`, and notification paths that
+  trigger expensive follow-on work must coalesce or bound it locally rather
+  than relying on request admission for backpressure.
 - This does not make a slow or faulty handler fast. Timeouts remain appropriate
   where the awaited operation has cancellation-safe cleanup. The configuration
   timeout predates this transport change and can retain one dependency waiter
@@ -101,6 +113,8 @@ cannot come from a fixture which never reaches the fault:
 | Production topology, client reply after 400 queued requests | reply is routed and all handlers finish | False-negative guard for the cycle break |
 | Deferred wrapper with twelve handlers and a limit of two | peak inner polling is exactly two | False-positive guard against unbounded application concurrency |
 | Inner service is initially not ready | `call` runs only after readiness changes | Protocol-ordering guard |
+| Generic no-id notification with a saturated request pool | its inner future is polled immediately | Protocol-progress admission guard |
+| `didChange` followed by a read with a saturated request pool | the read observes the notification's state | Document ordering guard |
 | `exit` and `$/cancelRequest` with a saturated application pool | both reach the inner service immediately | Shutdown/cancellation ordering guard |
 | Request cancelled while queued for a handler permit | cancellation response is returned and the handler is never polled | Queued-request cancellation guard |
 

--- a/docs/design/contracts/lsp-transport-liveness.md
+++ b/docs/design/contracts/lsp-transport-liveness.md
@@ -1,0 +1,117 @@
+# LSP transport liveness
+
+This contract keeps the language server able to read editor input even when
+application handlers or stdout are slow.
+
+## The two independent cycles
+
+`tower-lsp-server` 0.23 joins one stdin reader, a bounded handler queue, a
+four-handler pool, and one stdout writer. Two different forms of backpressure
+can stop the only stdin reader:
+
+```text
+stdin reader -> task queue (100) -> active handlers (4) -> stdout
+      ^                                      |
+      |                                      |
+      +---------- client replies ------------+
+```
+
+1. A client which stops reading stdout blocks outbound messages. Backpressure
+   then fills the task queue and stops stdin.
+2. Four handlers can wait for server-to-client replies. A request burst fills
+   the task queue before stdin reaches those replies, so the handlers wait for
+   input which the server no longer reads.
+
+The cycles need separate fixes. `stdio_pump` owns the stdout side.
+`transport_liveness` owns handler admission.
+
+## Production topology
+
+The production binary configures the transport's `buffer_unordered` limit as
+`usize::MAX`. `FuturesUnordered` does not reserve that many entries. It means
+the transport absorbs every request future already read from the local editor,
+rather than stopping after four pending futures.
+
+`DeferredConcurrency` calls the inner LSP service immediately, preserving its
+request registration, cancellation, and exit side effects, but polls only four
+ordinary returned handler futures at a time. It also forwards the inner
+service's `poll_ready` state before each call. This matters during `initialize`:
+later messages must not be admitted until initialisation has completed.
+
+The resulting responsibilities are:
+
+| Layer | Bound | Purpose |
+|---|---:|---|
+| stdin admission after initialisation | no finite bound | Client responses can always be routed. |
+| active application handlers | 4 | Shared server state retains the upstream concurrency limit. |
+| stdout pump | no finite message bound | A slow reader cannot stop stdin. |
+| configuration request | 10 seconds | A client which never replies releases its handler permit. |
+
+The existing configuration timeout is defence in depth for application
+capacity; stdin routing does not depend on it firing. It is intentionally not
+generalised to every server-to-client request. In `tower-lsp-server` 0.23,
+dropping a timed-out response future leaves its pending-map sender registered
+until a late reply arrives. Applying that pattern to periodic refresh requests
+would turn a non-responsive editor into unbounded retained state. A general
+request timeout therefore needs cancellation-safe pending-request tracking in
+the transport dependency first.
+
+`exit` and `$/cancelRequest` bypass the four-handler application limit. They
+exist to stop queued or running work, so putting either behind that work would
+make shutdown and cancellation least effective precisely when the server is
+busy.
+
+## Example
+
+Suppose four workspace-folder notifications all pull configuration. The editor
+delays those replies, then sends 400 hover requests. Under the old topology,
+the first four handlers waited, the 100-item queue filled, and the reader never
+reached the configuration replies behind the hover burst.
+
+Under the production topology, the hover futures wait outside the four-handler
+application limit. The reader continues to the replies, the four configuration
+handlers finish, and the queued hover requests then run four at a time.
+
+## Limits
+
+- The pending-future set can grow with a request burst. This is deliberate: a
+  finite input-admission bound recreates the deadlock at a different threshold.
+  The peer is the local editor process, not an internet-facing client.
+- This does not make a slow or faulty handler fast. Timeouts remain appropriate
+  where the awaited operation has cancellation-safe cleanup. The configuration
+  timeout predates this transport change and can retain one dependency waiter
+  until a late reply arrives; it must not be copied to periodic requests.
+- The stdout pump remains required. Unbounded input admission does not prevent
+  a blocked stdout writer from propagating pressure through the response path.
+- The wrapper is for the LSP service, whose returned futures are `'static`.
+  Services which borrow from `call` need a different admission boundary.
+- During `initialize`, the wrapped LSP service deliberately retains its own
+  readiness barrier. The current initialise handler does not make a
+  server-to-client request, so it cannot form the reply cycle described here.
+
+## Regression coverage
+
+The tests use both controls and the production topology so a passing result
+cannot come from a fixture which never reaches the fault:
+
+| Case | Expected result | Guard |
+|---|---|---|
+| Raw upstream topology, client reply after 400 queued requests | four handlers start, no handler completes | Positive fault control using the identical reply fixture |
+| Raw upstream topology, handlers finish after a short delay | all 400 requests drain | Negative control |
+| Production topology, client reply after 400 queued requests | reply is routed and all handlers finish | False-negative guard for the cycle break |
+| Deferred wrapper with twelve handlers and a limit of two | peak inner polling is exactly two | False-positive guard against unbounded application concurrency |
+| Inner service is initially not ready | `call` runs only after readiness changes | Protocol-ordering guard |
+| `exit` and `$/cancelRequest` with a saturated application pool | both reach the inner service immediately | Shutdown/cancellation ordering guard |
+| Request cancelled while queued for a handler permit | cancellation response is returned and the handler is never polled | Queued-request cancellation guard |
+
+The paired upstream control is also a dependency-upgrade sentinel. If a later
+`tower-lsp-server` routes the response itself, that control will fail and the
+local admission workaround should be re-evaluated rather than kept by habit.
+
+The consolidated LSP end-to-end suite repeats the real client shape with four
+workspace configuration pulls and a 400-request burst. The VS Code suite is a
+separate negative control: it sends a larger-than-queue provider burst through
+the packaged extension and confirms that ordinary concurrent work remains
+responsive under the new admission layer. VS Code's language-client test API
+does not provide a safe hook for delaying its built-in configuration replies,
+so the Rust end-to-end and paired transport fixtures carry the fault injection.

--- a/editors/vscode/src/test/serverHealth.test.ts
+++ b/editors/vscode/src/test/serverHealth.test.ts
@@ -19,7 +19,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import { LanguageClient, State } from "vscode-languageclient/node";
-import { activate, getDocUri, scaledTimeout } from "./helper";
+import { activate, bounded, getDocUri, scaledTimeout } from "./helper";
 
 interface TclLspApi {
   getClient(): LanguageClient;
@@ -79,5 +79,28 @@ suite("Server Health", () => {
     await activate(docUri);
     // activate() sends a hover request serialised behind didOpen.
     // Reaching here means the server processed both successfully.
+  });
+
+  test("server remains responsive past the transport queue size", async function () {
+    this.timeout(scaledTimeout(30_000));
+    const docUri = getDocUri("simple.tcl");
+    await activate(docUri);
+    const client = getApi().getClient();
+    // Negative control for the new admission wrapper: ordinary provider work
+    // still drains when the burst is larger than the transport's old queue.
+    // The Rust transport/E2E fixtures inject the delayed client reply which
+    // VS Code's built-in configuration handler does not expose here.
+    const requests = Array.from({ length: 240 }, () =>
+      client.sendRequest("textDocument/hover", {
+        textDocument: { uri: docUri.toString() },
+        position: { line: 0, character: 0 },
+      }),
+    );
+
+    const results = await bounded(Promise.all(requests), "240 concurrent hover responses", {
+      timeout: 10_000,
+    });
+    assert.strictEqual(results.length, 240);
+    assert.strictEqual(client.state, State.Running);
   });
 });

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -749,14 +749,21 @@ impl SemanticTokensRefreshCtx {
     /// a client without `workspace/semanticTokens/refresh` support rejects the
     /// request, which is harmless.
     ///
-    /// Returns whether a refresh was asked for, so the caller can record that
-    /// decision in its settled marker.
-    async fn deliver_if_changed(&self, uri: &Uri, data: &[u32]) -> bool {
+    /// Returns the comparison's distinct outcomes so a caller can tell an
+    /// enriched response that was already served from a coarse response whose
+    /// detached comparison either matched or had its repeat refresh suppressed.
+    async fn deliver_if_changed(&self, uri: &Uri, data: &[u32]) -> EnrichedDelivery {
         let changed = {
             let cache = self.last_semantic_tokens.lock().await;
             cache.get(uri).is_none_or(|(_, cached)| cached != data)
         };
-        changed && self.request_refresh_for_enriched(uri, data).await
+        if !changed {
+            EnrichedDelivery::ComparedEqual
+        } else if self.request_refresh_for_enriched(uri, data).await {
+            EnrichedDelivery::RefreshRequested
+        } else {
+            EnrichedDelivery::RefreshSuppressed
+        }
     }
 
     /// Ask the client to re-pull tokens because `uri`'s enriched stream
@@ -822,8 +829,21 @@ impl SemanticTokensRefreshCtx {
     }
 }
 
-/// Emit the settled marker for a `semanticTokens/full` request that was served
-/// the coarse tier.
+/// What comparing a detached enriched stream against the last served stream
+/// decided.  This stays separate from [`FullSettleOutcome`]: the latter also
+/// represents paths that never detached a comparison at all.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum EnrichedDelivery {
+    /// The enriched bytes equal the response already served for this URI.
+    ComparedEqual,
+    /// The enriched bytes differ and scheduled a client re-request.
+    RefreshRequested,
+    /// The enriched bytes differ, but that exact stream was already asked for.
+    RefreshSuppressed,
+}
+
+/// Emit the settled marker for a `semanticTokens/full` request's convergence
+/// decision.
 ///
 /// The twin of the `semantic_tokens.range_convergence.settled` line
 /// [`Backend::spawn_range_convergence`] logs, and it exists for the same
@@ -840,12 +860,12 @@ impl SemanticTokensRefreshCtx {
 /// all — otherwise the signal would be missing exactly when a waiter most needs
 /// to learn that nothing further is coming.
 ///
-/// `enriched=` says what became of the enriched stream, which `refresh=false`
-/// alone cannot express: `landed` (it materialised, and either matched what was
-/// served or has been refreshed), `cancelled` (a concurrent salsa write killed
-/// the read, so nothing was compared and a re-request will re-race), or
-/// `no-analysis` (the document has no salsa input, so the response was computed
-/// enriched from a fresh unit and there is nothing to converge to).
+/// `outcome=` says exactly how the response settled. In particular,
+/// `served-enriched` is distinct from `compared-equal`: the latter describes a
+/// coarse response whose detached enriched comparison matched it. A repeated
+/// differing stream is likewise recorded as `refresh-suppressed`, so a test
+/// client can re-request without causing the server to repeat its bounded
+/// workspace refresh.
 async fn log_full_convergence_settled(
     client: &Client,
     uri: &Uri,
@@ -857,7 +877,7 @@ async fn log_full_convergence_settled(
             MessageType::LOG,
             format!(
                 "[timing] semantic_tokens.full_convergence.settled \
-                 (uri={}, refresh={refreshed}, enriched={})",
+                 (uri={}, refresh={refreshed}, outcome={})",
                 uri.as_str(),
                 enriched.as_str(),
             ),
@@ -869,9 +889,14 @@ async fn log_full_convergence_settled(
 /// (see [`log_full_convergence_settled`]).
 #[derive(Clone, Copy)]
 enum FullSettleOutcome {
-    /// The enriched stream materialised — served directly, or delivered by the
-    /// detached continuation.
-    Landed,
+    /// The enriched stream won the fast-path race and was served directly.
+    ServedEnriched,
+    /// A coarse response's detached enriched stream matched the bytes served.
+    ComparedEqual,
+    /// A coarse response's differing enriched stream scheduled a re-request.
+    RefreshRequested,
+    /// A coarse response's differing enriched stream had already asked once.
+    RefreshSuppressed,
     /// The enriched read was cancelled by a concurrent salsa write, so nothing
     /// was compared; a re-request re-races it.
     Cancelled,
@@ -887,7 +912,10 @@ enum FullSettleOutcome {
 impl FullSettleOutcome {
     fn as_str(self) -> &'static str {
         match self {
-            Self::Landed => "landed",
+            Self::ServedEnriched => "served-enriched",
+            Self::ComparedEqual => "compared-equal",
+            Self::RefreshRequested => "refresh-requested",
+            Self::RefreshSuppressed => "refresh-suppressed",
             Self::Cancelled => "cancelled",
             Self::NoAnalysis => "no-analysis",
             Self::Coalesced => "coalesced",
@@ -5500,7 +5528,7 @@ impl Backend {
                         &self.client,
                         uri,
                         false,
-                        FullSettleOutcome::Landed,
+                        FullSettleOutcome::ServedEnriched,
                     )
                     .await;
                     return Ok(tokens.data);
@@ -5579,12 +5607,15 @@ impl Backend {
             // Settle either way — including on a cancelled read — so a waiter can
             // key on the marker instead of racing the debounced refresh that only
             // *sometimes* follows.
-            let (refreshed, outcome) = match enriched.await {
-                Ok(Some(tokens)) => (
-                    refresh_ctx.deliver_if_changed(&uri, &tokens.data).await,
-                    FullSettleOutcome::Landed,
-                ),
-                _ => (false, FullSettleOutcome::Cancelled),
+            let outcome = match enriched.await {
+                Ok(Some(tokens)) => {
+                    match refresh_ctx.deliver_if_changed(&uri, &tokens.data).await {
+                        EnrichedDelivery::ComparedEqual => FullSettleOutcome::ComparedEqual,
+                        EnrichedDelivery::RefreshRequested => FullSettleOutcome::RefreshRequested,
+                        EnrichedDelivery::RefreshSuppressed => FullSettleOutcome::RefreshSuppressed,
+                    }
+                }
+                _ => FullSettleOutcome::Cancelled,
             };
             // Release the per-URI claim only now the decision is made, so every
             // request that arrived while this ran rode along with it — and honour
@@ -5592,7 +5623,13 @@ impl Backend {
             // its own, so if this one decided against refreshing (its own read
             // matched the cache, or was cancelled) the coalesced ones would be
             // stranded.  The refresh is workspace-scoped, so one covers them all.
+            let refreshed = matches!(outcome, FullSettleOutcome::RefreshRequested);
             let refreshed = refresh_if_coalesced(&refresh_ctx, &mut guard, refreshed);
+            let outcome = if refreshed && !matches!(outcome, FullSettleOutcome::RefreshRequested) {
+                FullSettleOutcome::Coalesced
+            } else {
+                outcome
+            };
             refresh_ctx
                 .log_full_convergence_settled(&uri, refreshed, outcome)
                 .await;
@@ -30292,7 +30329,11 @@ mod tests {
 
         // No cache entry yet: "changed" (there is nothing to match), but still
         // must not write the cache itself.
-        ctx.deliver_if_changed(&uri, &[1, 2, 3]).await;
+        assert_eq!(
+            ctx.deliver_if_changed(&uri, &[1, 2, 3]).await,
+            EnrichedDelivery::RefreshRequested,
+            "a missing served entry must request a refresh",
+        );
         assert!(
             backend
                 .last_semantic_tokens
@@ -30310,7 +30351,11 @@ mod tests {
             .lock()
             .await
             .insert(uri.clone(), ("coarse-result-id".to_owned(), vec![1, 2, 3]));
-        ctx.deliver_if_changed(&uri, &[1, 2, 3]).await;
+        assert_eq!(
+            ctx.deliver_if_changed(&uri, &[1, 2, 3]).await,
+            EnrichedDelivery::ComparedEqual,
+            "a matching detached stream must be reported distinctly",
+        );
         assert_eq!(
             backend.last_semantic_tokens.lock().await.get(&uri).cloned(),
             Some(("coarse-result-id".to_owned(), vec![1, 2, 3])),
@@ -30320,7 +30365,11 @@ mod tests {
 
         // A landed result that differs from what was served: still must not
         // overwrite the cache — only the next served response does that.
-        ctx.deliver_if_changed(&uri, &[9, 9, 9]).await;
+        assert_eq!(
+            ctx.deliver_if_changed(&uri, &[9, 9, 9]).await,
+            EnrichedDelivery::RefreshRequested,
+            "a changed stream must report its refresh request",
+        );
         assert_eq!(
             backend.last_semantic_tokens.lock().await.get(&uri).cloned(),
             Some(("coarse-result-id".to_owned(), vec![1, 2, 3])),
@@ -30363,8 +30412,9 @@ mod tests {
             .lock()
             .await
             .insert(uri.clone(), coarse.clone());
-        assert!(
+        assert_eq!(
             ctx.deliver_if_changed(&uri, &enriched).await,
+            EnrichedDelivery::RefreshRequested,
             "the first enriched stream that differs must ask for a refresh",
         );
         // Round 2: the re-request overran the budget again, so the same coarse
@@ -30375,14 +30425,16 @@ mod tests {
             .lock()
             .await
             .insert(uri.clone(), coarse.clone());
-        assert!(
-            !ctx.deliver_if_changed(&uri, &enriched).await,
+        assert_eq!(
+            ctx.deliver_if_changed(&uri, &enriched).await,
+            EnrichedDelivery::RefreshSuppressed,
             "a repeat ask for the identical enriched stream must be dropped",
         );
         // A genuinely different enriched stream (an edit landed, a cross-file
         // class resolved) re-arms the ask.
-        assert!(
+        assert_eq!(
             ctx.deliver_if_changed(&uri, &[0, 0, 3, 9, 0]).await,
+            EnrichedDelivery::RefreshRequested,
             "a changed enriched stream must ask again",
         );
         // The bound is per URI, not global.
@@ -30391,10 +30443,36 @@ mod tests {
             .lock()
             .await
             .insert(other.clone(), coarse);
-        assert!(
+        assert_eq!(
             ctx.deliver_if_changed(&other, &enriched).await,
+            EnrichedDelivery::RefreshRequested,
             "another document's identical stream must ask on its own account",
         );
+    }
+
+    /// The full-token settled marker is a test-client contract: only these
+    /// three outcomes permit a caller to accept the response it already has.
+    /// In particular, a repeat-suppressed stream still differs from that
+    /// response even though the server correctly declines to issue another
+    /// workspace-wide refresh.
+    #[test]
+    fn full_settle_outcomes_keep_final_and_retryable_states_distinct() {
+        assert_eq!(
+            FullSettleOutcome::ServedEnriched.as_str(),
+            "served-enriched"
+        );
+        assert_eq!(FullSettleOutcome::ComparedEqual.as_str(), "compared-equal");
+        assert_eq!(FullSettleOutcome::NoAnalysis.as_str(), "no-analysis");
+        assert_eq!(
+            FullSettleOutcome::RefreshRequested.as_str(),
+            "refresh-requested"
+        );
+        assert_eq!(
+            FullSettleOutcome::RefreshSuppressed.as_str(),
+            "refresh-suppressed"
+        );
+        assert_eq!(FullSettleOutcome::Cancelled.as_str(), "cancelled");
+        assert_eq!(FullSettleOutcome::Coalesced.as_str(), "coalesced");
     }
 
     /// A fire already scheduled must absorb a second request rather than

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -32,6 +32,7 @@
 
 pub mod config_ini;
 pub mod stdio_pump;
+pub mod transport_liveness;
 pub mod uri_norm;
 
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -353,24 +354,12 @@ const DIAGNOSTICS_FAST_TIER_MIN_LINES: usize = 500;
 /// How long to wait for the editor to answer a *server-to-client* request
 /// before giving up on it.
 ///
-/// This is a liveness guard, and it is load-bearing rather than cosmetic.
-/// A handler parked on `client.configuration(..).await` is waiting for a reply
-/// that arrives on **stdin**, and only the transport's single `read_input`
-/// future can deliver it. That future parks once the task queue behind it
-/// fills, which happens as soon as
-/// `buffer_unordered(DEFAULT_MAX_CONCURRENCY)`'s four slots are occupied by
-/// handlers that never finish. Four parked config pulls with a burst behind
-/// them therefore close a cycle: the handlers wait for replies the parked
-/// reader will never read, and the session wedges with a perfectly healthy
-/// stdout. That is #1334 / #1294 reached by a route
-/// [`stdio_pump`](crate::stdio_pump) cannot cover, and
-/// `tests/stdio_deadlock.rs` demonstrates the mechanism.
-///
-/// Bounding the wait converts that permanent deadlock into a bounded stall:
-/// the handler returns, its slot frees, the queue drains and the reader
-/// resumes. Sized generously — a conforming client answers
-/// `workspace/configuration` in milliseconds, so ten seconds only ever fires
-/// for a client that is not going to answer.
+/// The transport keeps stdin routing independent of handler progress (see
+/// [`transport_liveness`](crate::transport_liveness)), so this timeout is
+/// defence in depth rather than the session's deadlock breaker. It bounds the
+/// existing configuration pull only; other server-to-client requests retain
+/// their own lifecycle until the dependency provides cancellation-safe pending
+/// request tracking.
 const CLIENT_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// The iRules dialect key.  A BIG-IP config's `ltm rule { … }` bodies are iRules
@@ -10320,11 +10309,10 @@ impl Backend {
 
     /// `workspace/configuration`, bounded by [`CLIENT_REQUEST_TIMEOUT`].
     ///
-    /// The timeout is a **liveness** guard, not politeness, and it is
-    /// load-bearing — see the constant. A client that never answers would
-    /// otherwise park this handler forever, and enough parked handlers stop the
-    /// server reading stdin at all, which is the wedge in #1334 / #1294 reached
-    /// by a route the stdout pump cannot cover.
+    /// The timeout bounds this request's lifetime and lets later pulls retry.
+    /// The transport independently guarantees that a parked handler cannot
+    /// stop stdin from routing its eventual reply; see
+    /// [`crate::transport_liveness`].
     ///
     /// A timeout is reported as `Err(())`, the same shape as a client that
     /// declines, so every caller's existing early-return path handles it: the
@@ -10340,8 +10328,7 @@ impl Backend {
             Err(_elapsed) => {
                 let message = format!(
                     "tcl-lsp: the editor did not answer workspace/configuration within {}s; \
-                     keeping the previous settings. Giving up is deliberate — waiting \
-                     indefinitely can stop the server reading its input entirely (#1334).",
+                     keeping the previous settings so a later pull can retry.",
                     CLIENT_REQUEST_TIMEOUT.as_secs()
                 );
                 eprintln!("{message}");

--- a/rust/tcl-lsp-server/src/main.rs
+++ b/rust/tcl-lsp-server/src/main.rs
@@ -28,6 +28,9 @@
 
 use tcl_lsp_server::Backend;
 use tcl_lsp_server::stdio_pump;
+use tcl_lsp_server::transport_liveness::{
+    DEFAULT_HANDLER_CONCURRENCY, DeferredConcurrency, UNBOUNDED_TRANSPORT_CONCURRENCY,
+};
 use tcl_lsp_server::uri_norm::normalise_uris_in_params;
 use tower::ServiceExt as _;
 use tower_lsp_server::jsonrpc::{Request, Response};
@@ -172,7 +175,15 @@ async fn serve() {
     //      the send). Concurrent publishes would reorder, and a
     //      state-gated/disconnected drop would go unnoticed. Delivery MUST stay
     //      an inline `.await`.
-    Server::new(stdin, stdout, socket).serve(service).await;
+    // Keep stdin routing independent of handler progress. The transport's
+    // queue is always drained into pending futures, while the wrapper retains
+    // the original four-handler application concurrency for ordinary work.
+    // Exit and cancellation remain immediate transport controls.
+    let service = DeferredConcurrency::new(service, DEFAULT_HANDLER_CONCURRENCY);
+    Server::new(stdin, stdout, socket)
+        .concurrency_level(UNBOUNDED_TRANSPORT_CONCURRENCY)
+        .serve(service)
+        .await;
     // `serve` has returned, so the transport's `FramedWrite` — and with it the
     // pump's sender — has been dropped, which is what lets the drain task
     // finish. Awaiting it here is what stops a burst of diagnostics sitting in

--- a/rust/tcl-lsp-server/src/stdio_pump.rs
+++ b/rust/tcl-lsp-server/src/stdio_pump.rs
@@ -50,6 +50,12 @@
 //! handlers fill `buffer_unordered(DEFAULT_MAX_CONCURRENCY)` and the pipeline
 //! seizes without the 100-slot queue ever filling.
 //!
+//! A distinct input-side cycle exists when handlers await server-to-client
+//! replies: their responses arrive on stdin, but the bounded handler queue can
+//! stop the sole stdin reader before it reaches them. The stdout pump cannot
+//! affect that path. [`crate::transport_liveness`] removes it by separating
+//! unbounded input admission from bounded application-handler polling.
+//!
 //! # Why unbounded is the right shape here
 //!
 //! Both paths reduce to one property: the server cannot make progress reading

--- a/rust/tcl-lsp-server/src/transport_liveness.rs
+++ b/rust/tcl-lsp-server/src/transport_liveness.rs
@@ -1,0 +1,405 @@
+// tcl-lsp -- a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Keeps the LSP stdin reader independent of handler progress.
+//!
+//! `tower-lsp-server` 0.23 places a 100-item channel in front of
+//! `buffer_unordered(max_concurrency)`. Its sole stdin reader awaits a send to
+//! that channel. When every handler slot is pending, the channel fills and the
+//! reader stops routing input, including responses needed by those handlers.
+//!
+//! Production uses [`UNBOUNDED_TRANSPORT_CONCURRENCY`] for the transport's
+//! `buffer_unordered` limit, so it always absorbs the bounded channel into its
+//! own pending-future set. [`DeferredConcurrency`] separately admits only four
+//! ordinary inner handler futures at a time, while transport-control
+//! notifications bypass that limit. Input routing is effectively unbounded,
+//! while shared application state sees the same ordinary concurrency as the
+//! upstream default.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use tokio::sync::Semaphore;
+use tower::Service;
+use tower_lsp_server::jsonrpc::Request;
+
+/// Makes `buffer_unordered` absorb every queued future rather than waiting for
+/// a handler to complete before it reads another item from the input queue.
+///
+/// `FuturesUnordered` does not allocate this capacity up front. In practice
+/// the only bound is the number of messages received from the local editor,
+/// which is deliberately not finite: any finite threshold recreates the same
+/// liveness cycle at a different queue length.
+pub const UNBOUNDED_TRANSPORT_CONCURRENCY: usize = usize::MAX;
+
+/// The ordinary application-handler concurrency retained from
+/// `tower-lsp-server`'s default transport configuration. Transport-control
+/// notifications do not consume these permits.
+pub const DEFAULT_HANDLER_CONCURRENCY: usize = 4;
+
+/// A service wrapper which keeps ordinary LSP handlers at `limit` concurrent
+/// while admitting transport-control notifications immediately.
+///
+/// The inner service's `poll_ready` and `call` run at the same points as they do
+/// in the upstream transport. That eager `call` is important: `LspService`
+/// registers cancellable request IDs and applies `exit` synchronously. Only
+/// polling the returned ordinary-handler future waits for a permit. `exit` and
+/// `$/cancelRequest` also bypass the polling limit because both exist to stop
+/// work already in progress.
+#[derive(Debug)]
+pub struct DeferredConcurrency<S> {
+    inner: S,
+    permits: Arc<Semaphore>,
+}
+
+impl<S> DeferredConcurrency<S> {
+    /// Wrap `inner`, polling at most `limit` returned futures concurrently.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `limit` is zero, because no ordinary handler could ever
+    /// make progress.
+    #[must_use]
+    pub fn new(inner: S, limit: usize) -> Self {
+        assert!(limit > 0, "handler concurrency must be non-zero");
+        Self {
+            inner,
+            permits: Arc::new(Semaphore::new(limit)),
+        }
+    }
+}
+
+impl<S> Service<Request> for DeferredConcurrency<S>
+where
+    S: Service<Request>,
+    S::Future: Send + 'static,
+    S::Response: 'static,
+    S::Error: 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let permits = Arc::clone(&self.permits);
+        let is_transport_control = matches!(request.method(), "exit" | "$/cancelRequest");
+        // Construct eagerly, before admission. Besides matching Tower's
+        // readiness contract, this lets LspService register a request with its
+        // cancellation map before a later `$/cancelRequest` is read.
+        let future = self.inner.call(request);
+        Box::pin(async move {
+            let permit = if is_transport_control {
+                None
+            } else {
+                Some(
+                    permits
+                        .acquire_owned()
+                        .await
+                        .expect("handler semaphore is owned by the queued futures"),
+                )
+            };
+            let result = future.await;
+            drop(permit);
+            result
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::convert::Infallible;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+    use tower_lsp_server::ls_types::{Hover, HoverParams, InitializeParams, InitializeResult};
+    use tower_lsp_server::{LanguageServer, LspService};
+
+    #[derive(Clone)]
+    struct PeakService {
+        active: Arc<AtomicUsize>,
+        peak: Arc<AtomicUsize>,
+    }
+
+    struct InitiallyPendingService {
+        readiness_polls: Arc<AtomicUsize>,
+        calls: Arc<AtomicUsize>,
+    }
+
+    struct ControlAwareService {
+        ordinary_started: Arc<AtomicUsize>,
+        controls_called: Arc<AtomicUsize>,
+    }
+
+    struct PendingHoverServer {
+        hover_polls: Arc<AtomicUsize>,
+    }
+
+    impl LanguageServer for PendingHoverServer {
+        async fn initialize(
+            &self,
+            _params: InitializeParams,
+        ) -> tower_lsp_server::jsonrpc::Result<InitializeResult> {
+            Ok(InitializeResult::default())
+        }
+
+        async fn shutdown(&self) -> tower_lsp_server::jsonrpc::Result<()> {
+            Ok(())
+        }
+
+        async fn hover(
+            &self,
+            _params: HoverParams,
+        ) -> tower_lsp_server::jsonrpc::Result<Option<Hover>> {
+            self.hover_polls.fetch_add(1, Ordering::SeqCst);
+            std::future::pending().await
+        }
+    }
+
+    fn request(method: &'static str) -> Request {
+        Request::build(method).finish()
+    }
+
+    impl Service<Request> for InitiallyPendingService {
+        type Response = ();
+        type Error = Infallible;
+        type Future = std::future::Ready<Result<(), Infallible>>;
+
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            let poll = self.readiness_polls.fetch_add(1, Ordering::SeqCst);
+            if poll == 0 {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            } else {
+                Poll::Ready(Ok(()))
+            }
+        }
+
+        fn call(&mut self, _request: Request) -> Self::Future {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            std::future::ready(Ok(()))
+        }
+    }
+
+    impl Service<Request> for PeakService {
+        type Response = ();
+        type Error = Infallible;
+        type Future = Pin<Box<dyn Future<Output = Result<(), Infallible>> + Send>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _request: Request) -> Self::Future {
+            let active = Arc::clone(&self.active);
+            let peak = Arc::clone(&self.peak);
+            Box::pin(async move {
+                let now = active.fetch_add(1, Ordering::SeqCst) + 1;
+                peak.fetch_max(now, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                active.fetch_sub(1, Ordering::SeqCst);
+                Ok(())
+            })
+        }
+    }
+
+    impl Service<Request> for ControlAwareService {
+        type Response = ();
+        type Error = Infallible;
+        type Future = Pin<Box<dyn Future<Output = Result<(), Infallible>> + Send>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, request: Request) -> Self::Future {
+            if matches!(request.method(), "exit" | "$/cancelRequest") {
+                self.controls_called.fetch_add(1, Ordering::SeqCst);
+                Box::pin(std::future::ready(Ok(())))
+            } else {
+                let ordinary_started = Arc::clone(&self.ordinary_started);
+                Box::pin(async move {
+                    ordinary_started.fetch_add(1, Ordering::SeqCst);
+                    std::future::pending().await
+                })
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn limits_polling_without_limiting_admission() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let mut service = DeferredConcurrency::new(
+            PeakService {
+                active: Arc::clone(&active),
+                peak: Arc::clone(&peak),
+            },
+            2,
+        );
+        let mut futures = Vec::new();
+        for _ in 0..12 {
+            std::future::poll_fn(|cx| service.poll_ready(cx))
+                .await
+                .unwrap();
+            futures.push(service.call(request("test")));
+        }
+        futures_util::future::join_all(futures).await;
+        assert_eq!(peak.load(Ordering::SeqCst), 2);
+        assert_eq!(active.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn forwards_inner_readiness_before_call() {
+        let readiness_polls = Arc::new(AtomicUsize::new(0));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut service = DeferredConcurrency::new(
+            InitiallyPendingService {
+                readiness_polls: Arc::clone(&readiness_polls),
+                calls: Arc::clone(&calls),
+            },
+            1,
+        );
+
+        std::future::poll_fn(|cx| service.poll_ready(cx))
+            .await
+            .unwrap();
+        service.call(request("test")).await.unwrap();
+        assert_eq!(readiness_polls.load(Ordering::SeqCst), 2);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn transport_controls_bypass_saturated_handlers() {
+        let ordinary_started = Arc::new(AtomicUsize::new(0));
+        let controls_called = Arc::new(AtomicUsize::new(0));
+        let mut service = DeferredConcurrency::new(
+            ControlAwareService {
+                ordinary_started: Arc::clone(&ordinary_started),
+                controls_called: Arc::clone(&controls_called),
+            },
+            2,
+        );
+
+        std::future::poll_fn(|cx| service.poll_ready(cx))
+            .await
+            .unwrap();
+        let first = tokio::spawn(service.call(request("ordinary/one")));
+        std::future::poll_fn(|cx| service.poll_ready(cx))
+            .await
+            .unwrap();
+        let second = tokio::spawn(service.call(request("ordinary/two")));
+        while ordinary_started.load(Ordering::SeqCst) != 2 {
+            tokio::task::yield_now().await;
+        }
+
+        for method in ["$/cancelRequest", "exit"] {
+            std::future::poll_fn(|cx| service.poll_ready(cx))
+                .await
+                .unwrap();
+            tokio::time::timeout(Duration::from_millis(100), service.call(request(method)))
+                .await
+                .expect("transport control was queued behind saturated handlers")
+                .unwrap();
+        }
+        assert_eq!(controls_called.load(Ordering::SeqCst), 2);
+
+        first.abort();
+        second.abort();
+    }
+
+    #[tokio::test]
+    async fn cancellation_reaches_a_request_queued_for_a_permit() {
+        let hover_polls = Arc::new(AtomicUsize::new(0));
+        let (inner, _socket) = LspService::new(|_client| PendingHoverServer {
+            hover_polls: Arc::clone(&hover_polls),
+        });
+        let mut service = DeferredConcurrency::new(inner, 1);
+
+        std::future::poll_fn(|cx| service.poll_ready(cx))
+            .await
+            .unwrap();
+        let initialize = Request::build("initialize")
+            .id(0)
+            .params(serde_json::json!({ "capabilities": {} }))
+            .finish();
+        service.call(initialize).await.unwrap();
+
+        let hover_params = serde_json::json!({
+            "textDocument": { "uri": "file:///queued-cancel.tcl" },
+            "position": { "line": 0, "character": 0 }
+        });
+        std::future::poll_fn(|cx| service.poll_ready(cx))
+            .await
+            .unwrap();
+        let first = tokio::spawn(
+            service.call(
+                Request::build("textDocument/hover")
+                    .id(1)
+                    .params(hover_params.clone())
+                    .finish(),
+            ),
+        );
+        while hover_polls.load(Ordering::SeqCst) != 1 {
+            tokio::task::yield_now().await;
+        }
+
+        std::future::poll_fn(|cx| service.poll_ready(cx))
+            .await
+            .unwrap();
+        let queued = tokio::spawn(
+            service.call(
+                Request::build("textDocument/hover")
+                    .id(2)
+                    .params(hover_params)
+                    .finish(),
+            ),
+        );
+        tokio::task::yield_now().await;
+        assert_eq!(
+            hover_polls.load(Ordering::SeqCst),
+            1,
+            "the queued request must not be polled before a permit is free"
+        );
+
+        std::future::poll_fn(|cx| service.poll_ready(cx))
+            .await
+            .unwrap();
+        service
+            .call(
+                Request::build("$/cancelRequest")
+                    .params(serde_json::json!({ "id": 2 }))
+                    .finish(),
+            )
+            .await
+            .unwrap();
+        first.abort();
+
+        let response = tokio::time::timeout(Duration::from_secs(1), queued)
+            .await
+            .expect("queued cancellation did not resolve")
+            .expect("queued handler task panicked")
+            .expect("LSP service exited while cancelling queued request")
+            .expect("cancelled request must return an error response");
+        let response = serde_json::to_value(response).unwrap();
+        assert_eq!(response["error"]["code"], -32800);
+        assert_eq!(
+            hover_polls.load(Ordering::SeqCst),
+            1,
+            "a request cancelled while queued must never poll its handler"
+        );
+    }
+}

--- a/rust/tcl-lsp-server/src/transport_liveness.rs
+++ b/rust/tcl-lsp-server/src/transport_liveness.rs
@@ -18,10 +18,13 @@
 //! Production uses [`UNBOUNDED_TRANSPORT_CONCURRENCY`] for the transport's
 //! `buffer_unordered` limit, so it always absorbs the bounded channel into its
 //! own pending-future set. [`DeferredConcurrency`] separately admits only four
-//! ordinary inner handler futures at a time, while transport-control
-//! notifications bypass that limit. Input routing is effectively unbounded,
-//! while shared application state sees the same ordinary concurrency as the
-//! upstream default.
+//! ordinary request-handler futures at a time, while every JSON-RPC
+//! notification bypasses that limit. A notification is protocol progress or
+//! state, not work a later request may overtake: in particular, a queued
+//! `didChange` must be polled soon enough to draw its [`crate::EditOrder`]
+//! ticket before a following read snapshots that barrier. Input routing is
+//! effectively unbounded, while ordinary request work retains the upstream
+//! default concurrency.
 
 use std::future::Future;
 use std::pin::Pin;
@@ -41,20 +44,29 @@ use tower_lsp_server::jsonrpc::Request;
 /// liveness cycle at a different queue length.
 pub const UNBOUNDED_TRANSPORT_CONCURRENCY: usize = usize::MAX;
 
-/// The ordinary application-handler concurrency retained from
-/// `tower-lsp-server`'s default transport configuration. Transport-control
+/// The ordinary request-handler concurrency retained from
+/// `tower-lsp-server`'s default transport configuration. JSON-RPC
 /// notifications do not consume these permits.
 pub const DEFAULT_HANDLER_CONCURRENCY: usize = 4;
 
-/// A service wrapper which keeps ordinary LSP handlers at `limit` concurrent
-/// while admitting transport-control notifications immediately.
+/// A service wrapper which keeps ordinary LSP requests at `limit` concurrent
+/// while admitting every notification immediately.
 ///
 /// The inner service's `poll_ready` and `call` run at the same points as they do
 /// in the upstream transport. That eager `call` is important: `LspService`
-/// registers cancellable request IDs and applies `exit` synchronously. Only
-/// polling the returned ordinary-handler future waits for a permit. `exit` and
-/// `$/cancelRequest` also bypass the polling limit because both exist to stop
-/// work already in progress.
+/// registers cancellable request IDs and applies notification setup
+/// synchronously. Only polling the returned request future waits for a permit.
+/// Every message with no JSON-RPC id bypasses that wait: document-sync
+/// notifications need to draw their ordering ticket before a later request
+/// observes the edit barrier, and `exit` / `$/cancelRequest` still need to
+/// stop work already in progress.
+///
+/// This intentionally permits an unbounded burst of notification futures, just
+/// as the surrounding transport intentionally keeps an unbounded pending set
+/// so stdin cannot wedge. The local editor is the only producer. Document-sync
+/// mutations serialise through [`crate::EditOrder`]; other notification paths
+/// must coalesce or bound their own expensive follow-on work rather than relying
+/// on this transport admission limit.
 #[derive(Debug)]
 pub struct DeferredConcurrency<S> {
     inner: S,
@@ -96,13 +108,18 @@ where
 
     fn call(&mut self, request: Request) -> Self::Future {
         let permits = Arc::clone(&self.permits);
-        let is_transport_control = matches!(request.method(), "exit" | "$/cancelRequest");
+        // JSON-RPC identifies notifications by the absence of an id. Do not
+        // name individual document methods here: every notification is protocol
+        // progress/state and must be able to begin before a later request takes
+        // its edit-order barrier snapshot. `exit` and `$/cancelRequest` are
+        // covered by the same protocol rule.
+        let is_notification = request.id().is_none();
         // Construct eagerly, before admission. Besides matching Tower's
         // readiness contract, this lets LspService register a request with its
         // cancellation map before a later `$/cancelRequest` is read.
         let future = self.inner.call(request);
         Box::pin(async move {
-            let permit = if is_transport_control {
+            let permit = if is_notification {
                 None
             } else {
                 Some(
@@ -123,9 +140,11 @@ where
 mod tests {
     use super::*;
     use std::convert::Infallible;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::time::Duration;
-    use tower_lsp_server::ls_types::{Hover, HoverParams, InitializeParams, InitializeResult};
+    use tower_lsp_server::ls_types::{
+        DidChangeTextDocumentParams, Hover, HoverParams, InitializeParams, InitializeResult,
+    };
     use tower_lsp_server::{LanguageServer, LspService};
 
     #[derive(Clone)]
@@ -146,6 +165,8 @@ mod tests {
 
     struct PendingHoverServer {
         hover_polls: Arc<AtomicUsize>,
+        changes: Arc<AtomicUsize>,
+        reads_observed_change: Arc<AtomicBool>,
     }
 
     impl LanguageServer for PendingHoverServer {
@@ -165,11 +186,23 @@ mod tests {
             _params: HoverParams,
         ) -> tower_lsp_server::jsonrpc::Result<Option<Hover>> {
             self.hover_polls.fetch_add(1, Ordering::SeqCst);
+            if self.changes.load(Ordering::SeqCst) != 0 {
+                self.reads_observed_change.store(true, Ordering::SeqCst);
+                return Ok(None);
+            }
             std::future::pending().await
+        }
+
+        async fn did_change(&self, _params: DidChangeTextDocumentParams) {
+            self.changes.fetch_add(1, Ordering::SeqCst);
         }
     }
 
     fn request(method: &'static str) -> Request {
+        Request::build(method).id(0).finish()
+    }
+
+    fn notification(method: &'static str) -> Request {
         Request::build(method).finish()
     }
 
@@ -310,10 +343,13 @@ mod tests {
             std::future::poll_fn(|cx| service.poll_ready(cx))
                 .await
                 .unwrap();
-            tokio::time::timeout(Duration::from_millis(100), service.call(request(method)))
-                .await
-                .expect("transport control was queued behind saturated handlers")
-                .unwrap();
+            tokio::time::timeout(
+                Duration::from_millis(100),
+                service.call(notification(method)),
+            )
+            .await
+            .expect("transport control was queued behind saturated handlers")
+            .unwrap();
         }
         assert_eq!(controls_called.load(Ordering::SeqCst), 2);
 
@@ -322,10 +358,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn notifications_bypass_saturated_requests() {
+        let ordinary_started = Arc::new(AtomicUsize::new(0));
+        let controls_called = Arc::new(AtomicUsize::new(0));
+        let mut service = DeferredConcurrency::new(
+            ControlAwareService {
+                ordinary_started: Arc::clone(&ordinary_started),
+                controls_called,
+            },
+            2,
+        );
+
+        std::future::poll_fn(|cx| service.poll_ready(cx))
+            .await
+            .unwrap();
+        let first = tokio::spawn(service.call(request("ordinary/one")));
+        std::future::poll_fn(|cx| service.poll_ready(cx))
+            .await
+            .unwrap();
+        let second = tokio::spawn(service.call(request("ordinary/two")));
+        while ordinary_started.load(Ordering::SeqCst) != 2 {
+            tokio::task::yield_now().await;
+        }
+
+        // Generic JSON-RPC notification, deliberately not one of the former
+        // `exit` / `$/cancelRequest` method-name exceptions. It must poll its
+        // inner future despite every request permit being occupied.
+        std::future::poll_fn(|cx| service.poll_ready(cx))
+            .await
+            .unwrap();
+        let state_update = tokio::spawn(service.call(notification("textDocument/didChange")));
+        while ordinary_started.load(Ordering::SeqCst) != 3 {
+            tokio::task::yield_now().await;
+        }
+
+        first.abort();
+        second.abort();
+        state_update.abort();
+    }
+
+    #[tokio::test]
     async fn cancellation_reaches_a_request_queued_for_a_permit() {
         let hover_polls = Arc::new(AtomicUsize::new(0));
+        let changes = Arc::new(AtomicUsize::new(0));
+        let reads_observed_change = Arc::new(AtomicBool::new(false));
         let (inner, _socket) = LspService::new(|_client| PendingHoverServer {
             hover_polls: Arc::clone(&hover_polls),
+            changes: Arc::clone(&changes),
+            reads_observed_change: Arc::clone(&reads_observed_change),
         });
         let mut service = DeferredConcurrency::new(inner, 1);
 
@@ -400,6 +480,99 @@ mod tests {
             hover_polls.load(Ordering::SeqCst),
             1,
             "a request cancelled while queued must never poll its handler"
+        );
+    }
+
+    #[tokio::test]
+    async fn did_change_notification_precedes_a_read_after_request_saturation() {
+        let hover_polls = Arc::new(AtomicUsize::new(0));
+        let changes = Arc::new(AtomicUsize::new(0));
+        let reads_observed_change = Arc::new(AtomicBool::new(false));
+        let (inner, _socket) = LspService::new(|_client| PendingHoverServer {
+            hover_polls: Arc::clone(&hover_polls),
+            changes: Arc::clone(&changes),
+            reads_observed_change: Arc::clone(&reads_observed_change),
+        });
+        let mut service = DeferredConcurrency::new(inner, 1);
+
+        std::future::poll_fn(|cx| service.poll_ready(cx))
+            .await
+            .unwrap();
+        service
+            .call(
+                Request::build("initialize")
+                    .id(0)
+                    .params(serde_json::json!({ "capabilities": {} }))
+                    .finish(),
+            )
+            .await
+            .unwrap();
+
+        let hover_params = serde_json::json!({
+            "textDocument": { "uri": "file:///notification-order.tcl" },
+            "position": { "line": 0, "character": 0 }
+        });
+        std::future::poll_fn(|cx| service.poll_ready(cx))
+            .await
+            .unwrap();
+        let blocked_read = tokio::spawn(
+            service.call(
+                Request::build("textDocument/hover")
+                    .id(1)
+                    .params(hover_params.clone())
+                    .finish(),
+            ),
+        );
+        while hover_polls.load(Ordering::SeqCst) != 1 {
+            tokio::task::yield_now().await;
+        }
+
+        // This is the protocol shape from the edit-stress regression: a
+        // document-sync notification arrives while request permits are full,
+        // then a reader follows it. The notification has no id, and must update
+        // state before the next read is admitted.
+        std::future::poll_fn(|cx| service.poll_ready(cx))
+            .await
+            .unwrap();
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            service.call(
+                Request::build("textDocument/didChange")
+                    .params(serde_json::json!({
+                        "textDocument": {
+                            "uri": "file:///notification-order.tcl",
+                            "version": 2
+                        },
+                        "contentChanges": [{ "text": "set current 1\n" }]
+                    }))
+                    .finish(),
+            ),
+        )
+        .await
+        .expect("didChange was queued behind a saturated request")
+        .unwrap();
+        assert_eq!(changes.load(Ordering::SeqCst), 1);
+
+        blocked_read.abort();
+        std::future::poll_fn(|cx| service.poll_ready(cx))
+            .await
+            .unwrap();
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            service.call(
+                Request::build("textDocument/hover")
+                    .id(2)
+                    .params(hover_params)
+                    .finish(),
+            ),
+        )
+        .await
+        .expect("read stayed queued after the saturated request was cancelled")
+        .expect("LSP service returned an exit error")
+        .expect("read request did not receive a response");
+        assert!(
+            reads_observed_change.load(Ordering::SeqCst),
+            "the post-change read did not observe the notification's state"
         );
     }
 }

--- a/rust/tcl-lsp-server/tests/e2e.rs
+++ b/rust/tcl-lsp-server/tests/e2e.rs
@@ -77,6 +77,8 @@ mod issue1302_import_builtin_shadow;
 mod issue1305_renamed_metaclass;
 #[path = "e2e/issue1312_named_object_dispatch.rs"]
 mod issue1312_named_object_dispatch;
+#[path = "e2e/issue1345_transport_liveness.rs"]
+mod issue1345_transport_liveness;
 #[path = "e2e/issue923_class_refs.rs"]
 mod issue923_class_refs;
 #[path = "e2e/issue923_crossdoc.rs"]

--- a/rust/tcl-lsp-server/tests/e2e/common/mod.rs
+++ b/rust/tcl-lsp-server/tests/e2e/common/mod.rs
@@ -1376,9 +1376,10 @@ impl Lsp {
     ///
     /// So this converges the way the client contract says to, driven by the
     /// server's own settled marker rather than by sleeps: request, wait for the
-    /// convergence decision to be logged, and re-request when it says a refresh
-    /// was warranted (or when it says the enriched read was cancelled outright,
-    /// in which case nothing was compared and the next request re-races).
+    /// convergence decision to be logged, and re-request when it says a
+    /// refresh was warranted. A cancelled read or a repeat-suppressed refresh
+    /// also re-races: neither has served the enriched stream. Only a response
+    /// marked `served-enriched`, `compared-equal`, or `no-analysis` is final.
     /// Returns the last response, so a genuine content divergence is still
     /// reported by the caller's assertion rather than hanging here.
     pub fn semantic_tokens_settled(&mut self, uri: &str) -> Value {
@@ -1401,9 +1402,10 @@ impl Lsp {
             ) else {
                 return response;
             };
-            if settled.contains("refresh=true") {
-                // The refresh is already scheduled; wait for it so the
-                // re-request below sees the landed enriched stream.
+            if settled.contains("refresh=true") || settled.contains("outcome=coalesced") {
+                // A coalesced request's holder schedules the refresh when it
+                // releases its claim, so wait for that just as we do a refresh
+                // already recorded by this request's own continuation.
                 let remaining = deadline.saturating_duration_since(Instant::now());
                 if self
                     .try_await_server_request(
@@ -1415,13 +1417,19 @@ impl Lsp {
                 {
                     return response;
                 }
-            } else if !settled.contains("enriched=cancelled") {
-                // Settled with the enriched stream in hand (`landed`) or with
-                // no analysis to converge to (`no-analysis`): this response is
-                // final.
+            } else if settled.contains("outcome=served-enriched")
+                || settled.contains("outcome=compared-equal")
+                || settled.contains("outcome=no-analysis")
+            {
+                // These are the only outcomes whose response is known to be
+                // final. In particular, `refresh-suppressed` has a differing
+                // enriched stream, but the server deliberately will not emit a
+                // second workspace-wide refresh for those same bytes.
                 return response;
             }
-            // Otherwise the enriched read was cancelled — loop and re-race.
+            // A cancelled read, a repeat-suppressed refresh, or an unexpected
+            // marker has not established that this response is enriched. Loop
+            // and re-race under the existing overall deadline.
         }
     }
 

--- a/rust/tcl-lsp-server/tests/e2e/common/mod.rs
+++ b/rust/tcl-lsp-server/tests/e2e/common/mod.rs
@@ -462,6 +462,10 @@ struct Shared {
     /// no entry falls back to `tcllsp_config`, so single-root tests are
     /// unaffected.
     folder_configs: Mutex<HashMap<String, Value>>,
+    /// Test-controlled delay before replying to `workspace/configuration`.
+    /// Zero in every ordinary test; the transport-liveness regression uses a
+    /// short delay to put four handlers in the reply-waiting state at once.
+    configuration_reply_delay: Mutex<Duration>,
     /// Captured stderr text.
     stderr: Mutex<String>,
 }
@@ -599,6 +603,7 @@ impl Lsp {
             requests_cv: Condvar::new(),
             tcllsp_config: Mutex::new(config),
             folder_configs: Mutex::new(HashMap::new()),
+            configuration_reply_delay: Mutex::new(Duration::ZERO),
             stderr: Mutex::new(String::new()),
         });
 
@@ -756,12 +761,26 @@ impl Lsp {
     /// refusal *as* an error (a `null` result would read as "nothing to
     /// rename here"), so its tests need the error itself.
     pub fn request_response(&mut self, method: &str, params: Value, timeout: Duration) -> Value {
+        let id = self.send_request_no_wait(method, params);
+        self.await_response(id, method, timeout)
+    }
+
+    /// Send a request without waiting for its response, returning its id.
+    ///
+    /// This models an editor's concurrent request burst. Most tests should use
+    /// [`Self::request`]; transport tests deliberately need more than the
+    /// server's internal queue in flight before they wait.
+    pub fn send_request_no_wait(&mut self, method: &str, params: Value) -> i64 {
         let id = self.next_id;
         self.next_id += 1;
         let mut msg = json!({ "jsonrpc": "2.0", "id": id, "method": method });
         msg["params"] = params;
         self.send(&msg);
+        id
+    }
 
+    /// Wait for a previously-sent request id.
+    pub fn await_response(&self, id: i64, method: &str, timeout: Duration) -> Value {
         let deadline = Instant::now() + scaled_timeout(timeout);
         loop {
             {
@@ -1554,6 +1573,11 @@ impl Lsp {
         *self.shared.tcllsp_config.lock().unwrap() = config;
     }
 
+    /// Delay configuration replies for a transport-liveness scenario.
+    pub fn set_configuration_reply_delay(&self, delay: Duration) {
+        *self.shared.configuration_reply_delay.lock().unwrap() = delay;
+    }
+
     pub fn apply_configuration(&mut self, config: Value) -> Value {
         *self.shared.tcllsp_config.lock().unwrap() = config;
         self.notify(
@@ -1738,6 +1762,10 @@ fn route(msg: &Value, shared: &Arc<Shared>) {
 fn auto_reply(msg: &Value, shared: &Arc<Shared>) {
     let method = msg.get("method").and_then(Value::as_str).unwrap_or("");
     let result = if method == "workspace/configuration" {
+        let delay = *shared.configuration_reply_delay.lock().unwrap();
+        if !delay.is_zero() {
+            std::thread::sleep(delay);
+        }
         let items = msg
             .get("params")
             .and_then(|p| p.get("items"))

--- a/rust/tcl-lsp-server/tests/e2e/edit_tracking_stress.rs
+++ b/rust/tcl-lsp-server/tests/e2e/edit_tracking_stress.rs
@@ -42,11 +42,11 @@
 //! insert/delete/replace/newline/astral edits is.
 
 use crate::common::helpers::*;
-use crate::common::{Lsp, Rng, scaled_timeout, unique_uri};
+use crate::common::{Lsp, Rng, unique_uri};
 
 use serde_json::{Value, json};
 use std::fmt::Write as _;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 // --------------------------------------------------------------------------- #
 // Client-side text mirror (native port of tests/lsp_e2e/_textmirror.py).
@@ -350,8 +350,8 @@ fn assert_buffer_equiv(
         (edited_first, fresh_first)
     } else {
         (
-            settled_tokens(lsp, edited_uri),
-            settled_tokens(lsp, fresh_uri),
+            decode_semantic_tokens(&lsp.semantic_tokens_settled(edited_uri)),
+            decode_semantic_tokens(&lsp.semantic_tokens_settled(fresh_uri)),
         )
     };
     assert_eq!(
@@ -367,54 +367,6 @@ fn assert_buffer_equiv(
         edited_syms == fresh_syms,
         "document-symbol tree diverged (content or position drift)"
     );
-}
-
-/// Fetch `uri`'s semantic tokens, converging onto the settled *enriched* stream.
-///
-/// `semanticTokens/full` may serve the cheap coarse tier when the enriched
-/// (SSA/SCCP-informed) computation overruns its 40 ms fast-path budget, then
-/// fire `workspace/semanticTokens/refresh` once the enriched stream lands — and
-/// it fires that refresh *iff* the enriched stream differs from the one just
-/// served (`deliver_if_changed`). So a request that draws no follow-up refresh
-/// was already the enriched stream; one that does is re-pulled. Looping until a
-/// request draws no refresh converges on the enriched tier the way a conformant
-/// client (and the `semantic_tokens_reference_client` suite) does, whichever
-/// tier won the first race — the deterministic input an oracle comparison needs.
-///
-/// If the enriched stream is starved past the deadline the last response is
-/// returned unchanged, so a genuine divergence is reported by the caller's
-/// assertion rather than the test hanging.
-///
-/// The deadline is load-scaled for the same reason as
-/// `semantic_tokens_reference_client::converge_via_refresh` (review of #1089):
-/// the per-round `try_await_server_request` below multiplies its argument by
-/// `load_factor` internally, so an unscaled outer deadline would be
-/// inconsistent with the rounds it bounds — one legitimate round could exhaust
-/// it, and this loop's expiry is silent (it returns the coarse stream), turning
-/// a busy machine into a *content* assertion failure at the caller.
-fn settled_tokens(lsp: &mut Lsp, uri: &str) -> Vec<SemToken> {
-    let deadline = Instant::now() + scaled_timeout(Duration::from_secs(20));
-    loop {
-        let since = lsp.server_request_cursor();
-        let current = decode_semantic_tokens(&lsp.semantic_tokens(uri));
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        if remaining.is_zero() {
-            return current;
-        }
-        // A follow-up refresh means the stream just served was the coarse tier
-        // and a better (enriched) one has landed — re-pull. No refresh within the
-        // grace means the served stream is already the enriched tier.
-        if lsp
-            .try_await_server_request(
-                "workspace/semanticTokens/refresh",
-                remaining.min(Duration::from_secs(2)),
-                since,
-            )
-            .is_none()
-        {
-            return current;
-        }
-    }
 }
 
 /// A comparable tuple form of a decoded semantic token.

--- a/rust/tcl-lsp-server/tests/e2e/issue1345_transport_liveness.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue1345_transport_liveness.rs
@@ -1,0 +1,55 @@
+// tcl-lsp -- a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! End-to-end coverage for the handler/input liveness cycle in issue #1345.
+
+use std::time::Duration;
+
+use serde_json::json;
+
+use super::common::Lsp;
+
+/// Four workspace notifications each enter a server-to-client configuration
+/// round trip. While their replies are delayed, enough ordinary requests are
+/// sent to exceed `tower-lsp-server`'s 100-item task channel. The final request
+/// can complete only if stdin continues past the burst and routes the delayed
+/// client replies which release those four handlers.
+#[test]
+fn delayed_client_replies_are_not_stranded_behind_the_handler_queue() {
+    let mut lsp = Lsp::tcl();
+    lsp.set_configuration_reply_delay(Duration::from_millis(100));
+
+    for _ in 0..4 {
+        lsp.notify(
+            "workspace/didChangeWorkspaceFolders",
+            json!({ "event": { "added": [], "removed": [] } }),
+        );
+    }
+    for _ in 0..400 {
+        lsp.send_request_no_wait("textDocument/hover", json!({}));
+    }
+    let final_id = lsp.send_request_no_wait(
+        "workspace/executeCommand",
+        json!({
+            "command": "tcl-lsp.getEffectiveConfig",
+            "arguments": [""]
+        }),
+    );
+
+    let response = lsp.await_response(
+        final_id,
+        "tcl-lsp.getEffectiveConfig",
+        Duration::from_secs(5),
+    );
+    assert!(
+        response.get("result").is_some(),
+        "server did not recover after delayed client replies: {response}"
+    );
+}

--- a/rust/tcl-lsp-server/tests/e2e/issue923_idx80_mathfunc.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue923_idx80_mathfunc.rs
@@ -222,6 +222,10 @@ fn workspace_scan_clears_w123_for_a_cross_file_mathfunc() {
     let mut lsp = Lsp::at_workspace_root(&root);
     let vector = format!("file://{}", vector_path.to_string_lossy());
     lsp.open_ready(&vector, VECTOR);
+    // The genuine unknown is present both before and after the startup scan,
+    // so it is not a scan-completion barrier by itself. Wait for that control
+    // and for the scan-informed pass to retract the two false positives. This
+    // keeps the test exercising the real startup race and its reschedule.
     let diags = lsp.await_diagnostics_settled(&vector, Duration::from_secs(30), |d| {
         let names = w123_names(d);
         names.iter().any(|n| n == "NeverDefinedAnywhere")

--- a/rust/tcl-lsp-server/tests/e2e/semantic_tokens_reference_client.rs
+++ b/rust/tcl-lsp-server/tests/e2e/semantic_tokens_reference_client.rs
@@ -75,12 +75,12 @@
 //! A convergence *round* is therefore: request tokens, await the settled
 //! marker, and — when it reports `refresh=true` — await the refresh and
 //! re-request, exactly as an editor would. A marker reporting `refresh=false`
-//! after a coarse response means the enriched read was cancelled (the
-//! diagnostics worker's cross-file evidence sync writes salsa inputs, which
-//! cancels in-flight reads); the loop simply re-races. That is a genuine
-//! source of non-determinism the old fixed `await_server_request` deadline
-//! could only absorb by being generous, and it is why these tests hung
-//! precisely when the machine was slow enough for the two to overlap.
+//! after a coarse response can mean a cancelled enriched read, or a differing
+//! enriched stream whose repeat refresh was deliberately suppressed; the loop
+//! re-races both. That is a genuine source of non-determinism the old fixed
+//! `await_server_request` deadline could only absorb by being generous, and it
+//! is why these tests hung precisely when the machine was slow enough for the
+//! two to overlap.
 
 use crate::common::helpers::{SemToken, decode_semantic_tokens};
 use crate::common::{LatencyBudget, Lsp, scaled_timeout, unique_uri};
@@ -404,10 +404,12 @@ impl Tier {
 /// marker**. That marker is the explicit progress signal this loop is built on
 /// (#1072): it is logged the instant the coarse-vs-enriched decision for that
 /// request is made, whatever the decision was, so the loop never has to guess
-/// whether a refresh is still coming. When the marker says `refresh=true` the
-/// refresh request must then actually arrive (asserted — that is the mechanism
-/// under test); when it says `refresh=false` the enriched read was cancelled by
-/// a concurrent salsa write, or matched what was served, and the loop re-races.
+/// whether a refresh is still coming. When the marker says `refresh=true` — or
+/// records a coalesced request whose holder will schedule one — the refresh
+/// request must then actually arrive (asserted — that is the mechanism under
+/// test). Full-token markers distinguish a response served enriched from a
+/// detached comparison; a cancelled read or repeat-suppressed refresh re-races,
+/// while a compared-equal response is final.
 ///
 /// `budget` bounds the whole loop. It is a hang guard: every round makes real
 /// progress against an explicit signal, so reaching it means the server never
@@ -483,30 +485,51 @@ fn converge_via_refresh(
             out.no_refresh_decisions += 1;
             continue;
         };
-        if settled.contains("refresh=true") {
+        if settled.contains("refresh=true") || settled.contains("outcome=coalesced") {
             out.refresh_decisions += 1;
-            // The decision is made, so the debounced refresh is already
-            // scheduled: this can only expire if the refresh path itself is
-            // broken, which is exactly the regression worth failing on. Its own
-            // budget (load-scaled inside the helper), never the outer
-            // leftover — see this function's docs.
+            // A coalesced request's holder schedules the refresh when it
+            // releases its claim; otherwise the decision has already scheduled
+            // it. This can only expire if that refresh path is broken, which is
+            // exactly the regression worth failing on. Its own budget
+            // (load-scaled inside the helper), never the outer leftover — see
+            // this function's docs.
             lsp.await_server_request(
                 "workspace/semanticTokens/refresh",
                 REFRESH_ARRIVAL,
                 req_since,
             );
             out.refreshes += 1;
-        } else if settled.contains("enriched=cancelled") || settled.contains("outcome=cancelled") {
-            // Nothing was compared — a concurrent salsa write killed the read.
-            // The next request re-races it, so go round again.
+        } else if matches!(tier, Tier::Full)
+            && (settled.contains("outcome=cancelled")
+                || settled.contains("outcome=refresh-suppressed"))
+        {
+            // Nothing was compared, or the server deliberately suppressed a
+            // second refresh for identical differing bytes. The next request
+            // may serve the enriched stream directly, so re-race it without
+            // weakening the server's repeat-ask bound.
             out.no_refresh_decisions += 1;
-        } else {
+        } else if matches!(tier, Tier::Full)
+            && (settled.contains("outcome=served-enriched")
+                || settled.contains("outcome=compared-equal")
+                || settled.contains("outcome=no-analysis"))
+        {
             // The server has settled and is asking for nothing further: this
             // stream is final. If it still differs from the truth that is a
             // genuine content divergence, which the caller reports — spinning
             // here would only turn it into an unhelpful timeout.
             out.no_refresh_decisions += 1;
             return out;
+        } else if matches!(tier, Tier::Range { .. }) {
+            if settled.contains("outcome=cancelled") {
+                // Nothing was compared — a concurrent salsa write killed the
+                // read. The next request re-races it.
+                out.no_refresh_decisions += 1;
+                continue;
+            }
+            out.no_refresh_decisions += 1;
+            return out;
+        } else {
+            panic!("unexpected full semantic-token convergence marker: {settled}");
         }
     }
 }

--- a/rust/tcl-lsp-server/tests/stdio_deadlock.rs
+++ b/rust/tcl-lsp-server/tests/stdio_deadlock.rs
@@ -16,13 +16,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! Regression test for the stdio deadlock in issue #1334 (client side: #1294).
+//! Regression tests for the stdio deadlocks in issues #1334 and #1345
+//! (client side: #1294).
 //!
 //! Drives the real `tower_lsp_server::Server` transport against a stdout that
 //! never accepts a byte — a client that has stopped reading — and asserts the
-//! server keeps draining stdin anyway. The control case runs the same traffic
-//! straight at the stalled sink and shows the transport wedging on its own,
-//! which is what makes the assertion meaningful rather than vacuous.
+//! server keeps draining stdin anyway. Separate controls cover blocked stdout
+//! and handlers awaiting client replies, so each production assertion first
+//! proves its fixture reaches the corresponding vulnerable topology.
 
 use std::convert::Infallible;
 use std::future::{Future, Ready, ready};
@@ -32,13 +33,17 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::task::{Context, Poll};
 
-use futures_util::{sink, stream};
+use futures_util::{Sink, sink, stream};
 use tokio::io::AsyncRead;
+use tokio::sync::Semaphore;
 use tower::Service;
 use tower_lsp_server::jsonrpc::{Request, Response};
 use tower_lsp_server::{Loopback, Server};
 
 use tcl_lsp_server::stdio_pump;
+use tcl_lsp_server::transport_liveness::{
+    DEFAULT_HANDLER_CONCURRENCY, DeferredConcurrency, UNBOUNDED_TRANSPORT_CONCURRENCY,
+};
 
 /// Requests fed to the server. Comfortably past both bounds in the transport
 /// that can seize: `DEFAULT_MAX_CONCURRENCY` (4) and `MESSAGE_QUEUE_SIZE`
@@ -47,6 +52,9 @@ const REQUESTS: usize = 400;
 
 /// How long a healthy server gets to drain `REQUESTS` messages.
 const DRAIN_BUDGET: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Observation window for a fixture which is expected to remain wedged.
+const STALL_OBSERVATION: std::time::Duration = std::time::Duration::from_secs(1);
 
 // ---------------------------------------------------------------- test doubles
 
@@ -130,6 +138,40 @@ struct SlowService {
     delay: std::time::Duration,
 }
 
+/// Handlers wait for a client response routed through `ReleaseSink`.
+#[derive(Debug, Clone)]
+struct ReplyWaitingService {
+    releases: Arc<Semaphore>,
+    started: Arc<AtomicUsize>,
+    completed: Arc<AtomicUsize>,
+}
+
+impl Service<Request> for ReplyWaitingService {
+    type Response = Option<Response>;
+    type Error = Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: Request) -> Self::Future {
+        let releases = Arc::clone(&self.releases);
+        let started = Arc::clone(&self.started);
+        let completed = Arc::clone(&self.completed);
+        Box::pin(async move {
+            started.fetch_add(1, Ordering::SeqCst);
+            let permit = releases
+                .acquire_owned()
+                .await
+                .expect("the response sink owns the release semaphore");
+            permit.forget();
+            completed.fetch_add(1, Ordering::SeqCst);
+            Ok(None)
+        })
+    }
+}
+
 impl Service<Request> for SlowService {
     type Response = Option<Response>;
     type Error = Infallible;
@@ -180,6 +222,41 @@ impl Loopback for NoLoopback {
     }
 }
 
+/// Routes one client response into enough permits to release every handler.
+struct ReleaseLoopback(Arc<Semaphore>);
+
+impl Loopback for ReleaseLoopback {
+    type RequestStream = stream::Pending<Request>;
+    type ResponseSink = ReleaseSink;
+
+    fn split(self) -> (Self::RequestStream, Self::ResponseSink) {
+        (stream::pending(), ReleaseSink(self.0))
+    }
+}
+
+struct ReleaseSink(Arc<Semaphore>);
+
+impl Sink<Response> for ReleaseSink {
+    type Error = Infallible;
+
+    fn poll_ready(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn start_send(self: Pin<&mut Self>, _response: Response) -> Result<(), Self::Error> {
+        self.0.add_permits(REQUESTS);
+        Ok(())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
 // ---------------------------------------------------------------- helpers
 
 /// `REQUESTS` framed JSON-RPC requests, back to back.
@@ -193,8 +270,17 @@ fn burst() -> Vec<u8> {
     out
 }
 
-/// Run the transport until it drains `REQUESTS` or `DRAIN_BUDGET` expires,
-/// and report how many requests got through.
+/// A saturated request burst followed by the client response every handler is
+/// waiting for. A bounded input queue never reaches the final frame.
+fn burst_then_client_response() -> Vec<u8> {
+    let mut out = burst();
+    let body = r#"{"jsonrpc":"2.0","result":null,"id":"release"}"#;
+    out.extend_from_slice(format!("Content-Length: {}\r\n\r\n{body}", body.len()).as_bytes());
+    out
+}
+
+/// Observe the raw transport for [`STALL_OBSERVATION`] and report how many
+/// requests got through.
 async fn drained_within_budget<W>(stdout: W) -> usize
 where
     W: tokio::io::AsyncWrite + Unpin,
@@ -204,7 +290,7 @@ where
     let served = Server::new(BurstThenIdle(burst()), stdout, NoLoopback).serve(service);
     // `serve` never returns here — stdin stays open by construction — so the
     // timeout is the exit path for both the healthy and the wedged case.
-    let _ = tokio::time::timeout(DRAIN_BUDGET, served).await;
+    let _ = tokio::time::timeout(STALL_OBSERVATION, served).await;
     calls.load(Ordering::SeqCst)
 }
 
@@ -263,8 +349,8 @@ async fn pumped_stdout_keeps_the_stdin_reader_running() {
 /// cycle the stdout fix cannot open: the handlers wait for replies that the
 /// parked reader will never read.
 ///
-/// This asserts the mechanism (stuck handlers stop the reader), not the
-/// LSP-level scenario. It is why `client.configuration` needs a timeout.
+/// This is the vulnerable-topology control. The production-topology test below
+/// must reach the client response beyond the same saturated queue.
 #[tokio::test]
 async fn stuck_handlers_wedge_the_stdin_reader_even_with_a_healthy_stdout() {
     let calls = Arc::new(AtomicUsize::new(0));
@@ -274,7 +360,7 @@ async fn stuck_handlers_wedge_the_stdin_reader_even_with_a_healthy_stdout() {
     // A sink that accepts everything: stdout is explicitly not the problem.
     let (stdout, _drain) = stdio_pump::pump(tokio::io::sink());
     let served = Server::new(BurstThenIdle(burst()), stdout, NoLoopback).serve(service);
-    let _ = tokio::time::timeout(DRAIN_BUDGET, served).await;
+    let _ = tokio::time::timeout(STALL_OBSERVATION, served).await;
 
     let drained = calls.load(Ordering::SeqCst);
     println!("with stuck handlers, the reader drained {drained}/{REQUESTS}");
@@ -284,15 +370,100 @@ async fn stuck_handlers_wedge_the_stdin_reader_even_with_a_healthy_stdout() {
     );
 }
 
-/// The property `CLIENT_REQUEST_TIMEOUT` buys: handlers that are *bounded*
-/// cannot wedge the reader, only slow it down.
+/// The exact response-behind-burst fixture wedges under the upstream default
+/// topology: four handlers start, the queue fills, and the reader never reaches
+/// the response which would release them.
+#[tokio::test]
+async fn upstream_topology_strands_client_reply_behind_saturated_handlers() {
+    let releases = Arc::new(Semaphore::new(0));
+    let started = Arc::new(AtomicUsize::new(0));
+    let completed = Arc::new(AtomicUsize::new(0));
+    let service = ReplyWaitingService {
+        releases: Arc::clone(&releases),
+        started: Arc::clone(&started),
+        completed: Arc::clone(&completed),
+    };
+    let loopback = ReleaseLoopback(releases);
+    let (stdout, _drain) = stdio_pump::pump(tokio::io::sink());
+    let served = Server::new(
+        BurstThenIdle(burst_then_client_response()),
+        stdout,
+        loopback,
+    )
+    .serve(service);
+    let _ = tokio::time::timeout(STALL_OBSERVATION, served).await;
+
+    assert_eq!(
+        started.load(Ordering::SeqCst),
+        DEFAULT_HANDLER_CONCURRENCY,
+        "the control must saturate every upstream handler slot"
+    );
+    assert_eq!(
+        completed.load(Ordering::SeqCst),
+        0,
+        "the reply beyond the bounded queue must remain stranded in the control"
+    );
+}
+
+/// The full cycle-break property: a response located beyond more queued
+/// requests than the upstream bounded transport can hold is still routed, and
+/// releases the handlers that were saturating the application pool.
+#[tokio::test]
+async fn production_topology_routes_client_reply_past_saturated_handlers() {
+    let releases = Arc::new(Semaphore::new(0));
+    let started = Arc::new(AtomicUsize::new(0));
+    let completed = Arc::new(AtomicUsize::new(0));
+    let service = DeferredConcurrency::new(
+        ReplyWaitingService {
+            releases: Arc::clone(&releases),
+            started: Arc::clone(&started),
+            completed: Arc::clone(&completed),
+        },
+        DEFAULT_HANDLER_CONCURRENCY,
+    );
+    let loopback = ReleaseLoopback(releases);
+    let (stdout, _drain) = stdio_pump::pump(tokio::io::sink());
+    let served = Server::new(
+        BurstThenIdle(burst_then_client_response()),
+        stdout,
+        loopback,
+    )
+    .concurrency_level(UNBOUNDED_TRANSPORT_CONCURRENCY)
+    .serve(service);
+    let observe_completion = async {
+        while completed.load(Ordering::SeqCst) != REQUESTS {
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+    };
+    tokio::pin!(served);
+    tokio::time::timeout(DRAIN_BUDGET, async {
+        tokio::select! {
+            () = observe_completion => {}
+            () = &mut served => panic!("transport stopped before routing the client response"),
+        }
+    })
+    .await
+    .expect("client response was stranded behind the handler queue");
+
+    assert_eq!(
+        started.load(Ordering::SeqCst),
+        REQUESTS,
+        "every queued handler must eventually start after the reply is routed"
+    );
+    assert_eq!(
+        completed.load(Ordering::SeqCst),
+        REQUESTS,
+        "the response beyond the saturated queue must release every handler"
+    );
+}
+
+/// A finite handler wait is still useful for request-local responsiveness, even
+/// though the production topology no longer needs it to keep stdin moving.
 ///
 /// This is the counterpart to
 /// `stuck_handlers_wedge_the_stdin_reader_even_with_a_healthy_stdout`. The only
-/// difference is that these handlers finish. Every request still gets through,
-/// which is why bounding `client.configuration(..)` turns a permanent deadlock
-/// into a bounded stall: the handler returns, its `buffer_unordered` slot
-/// frees, the queue drains, and `read_input` resumes.
+/// difference is that these handlers finish. Every request gets through on the
+/// upstream control topology once a slot eventually frees.
 ///
 /// The delay here is short so the test is quick; in the server the bound is
 /// `CLIENT_REQUEST_TIMEOUT`. What is under test is the shape, not the number.
@@ -305,7 +476,20 @@ async fn bounded_handlers_only_slow_the_stdin_reader_down() {
     };
     let (stdout, _drain) = stdio_pump::pump(tokio::io::sink());
     let served = Server::new(BurstThenIdle(burst()), stdout, NoLoopback).serve(service);
-    let _ = tokio::time::timeout(DRAIN_BUDGET, served).await;
+    let observe_completion = async {
+        while calls.load(Ordering::SeqCst) != REQUESTS {
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+    };
+    tokio::pin!(served);
+    tokio::time::timeout(DRAIN_BUDGET, async {
+        tokio::select! {
+            () = observe_completion => {}
+            () = &mut served => panic!("transport stopped before finite handlers completed"),
+        }
+    })
+    .await
+    .expect("finite handlers did not drain within the healthy-server budget");
 
     assert_eq!(
         calls.load(Ordering::SeqCst),


### PR DESCRIPTION
## Summary

- keep the standard-input transport reader live while ordinary language-server handlers wait for the configured execution limit
- preserve immediate request registration, cancellation, and exit handling through a generic deferred-concurrency service
- admit every JSON-RPC notification before later requests, so document changes take their edit-order ticket even when request permits are saturated
- add exact transport saturation tests, LSP end-to-end coverage, and a VS Code negative control
- document the admission topology, memory trade-offs, timeout boundary, and upgrade sentinel
- distinguish served, compared, cancelled, coalesced, and repeat-suppressed semantic-token convergence outcomes so reference clients never accept a coarse response as final

## Root cause

`tower-lsp-server` feeds a bounded 100-message task channel into a four-future handler queue. When four handlers wait for server-to-client replies, that channel can fill and the sole standard-input reader waits for its next send. It then cannot read and route the replies needed to release those handlers, creating a circular wait. Deferring `LspService::call` would also be wrong because request registration, cancellation, and exit side effects occur there synchronously; only polling ordinary returned futures may wait for admission.

The first CI run exposed the corresponding ordering boundary. An id-less `didChange` notification could be admitted by `LspService::call` but remain unpolled behind four saturated request permits. A later ID-bearing read could then snapshot the edit barrier before the change had taken its ticket and observe stale semantic tokens. Classifying notifications by the JSON-RPC protocol shape, rather than by method name, fixes the general ordering rule for document sync and future notification methods.

## Impact

The reader now continues admitting protocol traffic under handler saturation. Client responses and every notification remain live, while ordinary ID-bearing request polling stays bounded. Document-sync notifications begin before later requests can snapshot their edit barrier. This removes the configuration-request deadlock and stale-read window without adding Tcl command knowledge, a method-name allow-list, or an unsafe generic timeout. The deliberate trade-off is documented: notification futures are not transport-bounded, while document edits serialise through the existing edit order and expensive follow-on work must coalesce at its owning subsystem.

The semantic-token convergence marker also now states whether the response itself was enriched, a detached comparison matched, a refresh was requested, or an identical refresh was deliberately suppressed. Test clients re-race only the non-final outcomes under their existing bounded deadline. This preserves the one-refresh-per-identical-stream safeguard without mistaking a coarse response for settled output under heavy parallel load.

## Validation completed

- `make prep-pr`
- `make check-rust`
- `make test` (including 1,414 native LSP end-to-end tests, VS Code single-root and multi-root tests, the standalone runtime, and Zed query checks)
- `make test-emacs` (documented upstream painter XFAIL only)
- `make check-all`
- focused real-service cancellation and exit tests
- exact upstream and production standard-input saturation fixtures
- LSP end-to-end configuration saturation test
- VS Code server-health negative control
- semantic-token convergence outcome unit, edit-tracking stress, and reference-client tests
- generic saturated-notification admission and real `didChange`-before-read ordering tests
- all edit-tracking stress seeds, including the CI seed 256 failure
- `git diff --check`

Closes #1345
