### PR TITLE
Complete false-positive audit

### DIFF
--- a/docs/design/compiler/fp-audit-todo.md
+++ b/docs/design/compiler/fp-audit-todo.md
@@ -1088,9 +1088,12 @@ fixed; the probe scripts are named where they exist.
      (computed via LoopForest natural-loop bodies, keyed by header)
      prevents cross-loop pollution.  Sample tcllib impact: 93 → 30
      (-68%) on 6 high-S102 files; me_cpucore.tcl 48 → 3.
-- [~] **W123** unresolved command (1761) — mostly real missing stubs (argparse,
-  dget/dexist, custom widget cmds). Not analyser FPs, but a per-package stub
-  pass would cut noise. Triage which are stdlib-ish vs project-local.
+- [x] **W123** unresolved command (1761) — TRUE POSITIVES for commands whose
+  defining packages or factories are outside the analysed source. The Rust
+  analyser now loads the nearest workspace `<dialect>.tcl.stubs` sidecar through
+  the same overlay as inline stubs, so projects can supply authoritative
+  argparse, dict-extension, and custom-widget signatures without globally
+  guessing third-party APIs.
 
 ---
 
@@ -1339,9 +1342,20 @@ can simplify this" suggestion. None swept yet.
 
 ## NOT YET INSPECTED — errors (Exxx) + hints
 
-- [~] **E001** missing subcommand / **E002** too few args / **E003** too many
-  args — arity. Sweep for custom-arity commands (ensembles, varargs) that may
-  miscount. (E002/E003 fire in corpus.)  **One lexer-root-cause FP class fixed
+- [x] **E001** missing subcommand / **E002** too few args / **E003** too many
+  args — RESOLVED. The native sweep was rerun over all 416 recognised Tcl and
+  iRules files in the local #1181 corpus (`tcl-lsp-testsrc`). Its two E001 and
+  five E002 results are deliberate malformed/unsupported fixtures; three
+  `set name = value` E003 results are genuine Tcl errors. The remaining twelve
+  E003 results exposed three iRules registry arity gaps, now corrected with
+  paired TP/FP regressions: `pool POOL member ADDR PORT` (three corpus sites),
+  remote `log IP facility.level message` (two), and `class nextelement
+  ?options? CLASS SEARCH_ID` (four). `class anymore` and `class donesearch`
+  share the same two-positional iteration contract and were corrected with the
+  same registry pass. Oracle: `/Users/jimd/src/bigip-extract/man-21.0.0.1-0.0.13/`
+  `ltm_rule_command_pool.3`, `ltm_rule_command_log.3`, and
+  `ltm_rule_command_class.3` (the latter also restored `nextelement`'s
+  `-index`/`-element`/`-list` options). **One lexer-root-cause FP class fixed
   (FP-STY-15):** every corpus E002/E205 firing (tcltest.tcl, csv.tcl) was a
   quoted word ending in the regex end-anchor `$"` (`regsub "\n$" …`,
   `string match "abc$" …`) — the lexer misread the closing quote as a new
@@ -1488,11 +1502,18 @@ dedicated iRules corpus + the Tk stdlib for a real sweep.
   The corpus is not vendored: it remains third-party code under its own
   licences in `tmp/`.
 
-  Two corpus legs are additionally invisible to `fp-sweep`, which only walks
-  recognised Tcl/iRules extensions: `f5devcentral/f5-agility-labs-irules`
-  (~31 iRules embedded in `.rst` lab documents) and `f5devcentral/irules-toolbox`
-  (~186 `.txt` snippets). Extracting those into sweepable files would widen the
-  corpus further and is not yet done.
+  2026-08 completion: `fp-sweep` now also admits direct `.txt` iRules carrying
+  a `when EVENT` signature and extracts iRules-bearing reStructuredText `code`
+  / `code-block` directives while preserving their original document line
+  numbers. A combined run over `tcl-lsp-testsrc/irules` and the pinned
+  `f5-agility-labs-irules` checkout scanned 647 source files as 652 analysis
+  documents: 416 native sources, 200 `.txt` iRules, and 36 blocks from the 31
+  `.rst` lab documents. The seven `.tmsh` files enumerated by #1181 were also
+  inspected: they are BIG-IP configuration/data-group or iCall artefacts and
+  none contains a `when EVENT` handler, so they correctly remain outside this
+  iRules diagnostic sweep. The event signature accepts the optional
+  `priority` / `timing` tail and the next-line opening-brace form present in
+  the extracted BIG-IP man-page schema under `bigip-extract`.
 - [x] **TK1001/1002/1003** geometry/parent/option (0 corpus) — the Tk geometry
   W001 fix added coverage; sweep a real Tk app for TK100x FPs. 2026-08:
   TK1001 verified synthetically — mixing `pack`/`grid` on the same parent
@@ -1515,20 +1536,20 @@ dedicated iRules corpus + the Tk stdlib for a real sweep.
   synthetic `pkgIndex.tcl` (`package ifneeded foo 1.0 [list source [file
   join $dir foo.tcl]]`): no W210 on `$dir`. This checklist just never got
   updated when the fix landed.
-- [ ] **W110 / O120 near-duplicate** — 1020+ ranges are byte-identical between
-  the two. Policy call: which subsystem owns the user-facing squiggle. Still
-  open — a genuine product decision (which subsystem's diagnostic a user
-  sees, or whether both should keep firing), not a correctness bug; 2026-08
-  sweep reconfirmed both still fire on the same real sites (7 W120 corpus
-  firings this session were all clean `eq`/`ne`-worthy `==`-on-strings; no
-  W110/O120 pair was inspected side-by-side for exact range overlap this
-  session — the policy call itself needs a maintainer decision, not more
-  sweeping).
-- [ ] **W123 per-package stubs** — argparse / dict-extension (dget/dexist) /
-  custom widget commands. A stub bundle would cut ~half the W123 noise.
-  Still open — a content/registry-authoring task (writing stub bundles for
-  common third-party packages), not an analyser defect; out of scope for
-  this sweep.
+- [x] **W110 / O120 near-duplicate** — W110 owns the user-facing squiggle at
+  the LSP publication boundary because it is the analyser's semantics-aware
+  warning and the safe-fix path's source diagnostic. Exact same-range O120
+  suggestions are suppressed; O120 remains available when W110 is absent and
+  on distinct ranges. This prevents duplicate editor noise without changing
+  optimiser output or CLI/library callers.
+- [x] **W123 per-package stubs** — workspace-wide `<dialect>.tcl.stubs`
+  sidecars are now loaded by the Rust analyser (nearest source-directory
+  ancestor wins) through the same parser and overlay as inline stubs, so
+  projects can provide authoritative argparse/dict-extension/custom-widget
+  signatures without changing the global registry. No bundled third-party
+  API declarations were added: the available test corpus contains no
+  authoritative `dget`/`dexist` or custom-widget package sources, and
+  inventing signatures would be less safe than requiring a sidecar.
 
 ## Process
 

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -190,6 +190,11 @@ impl Analyser {
         for stub in &self.result.stub_commands {
             add(&stub.name);
         }
+        if let Some(overlay) = &self.stub_overlay {
+            for (name, _) in overlay.iter() {
+                add(name);
+            }
+        }
         for name in &self.result.created_instance_commands {
             add(name);
         }

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -2456,6 +2456,39 @@ fn arity_codes(src: &str, dialect: &str) -> Vec<String> {
 }
 
 #[test]
+fn irules_arity_accepts_documented_pool_log_and_class_iteration_forms() {
+    // Oracle: /Users/jimd/src/bigip-extract/man-21.0.0.1-0.0.13/
+    // ltm_rule_command_{pool,log,class}.3. These forms were found in the
+    // #1181 corpus by `cargo xtask fp-sweep` (issue #1316).
+    for src in [
+        "pool /Common/web member 192.0.2.10 443\n",
+        "log -noname 192.0.2.20:514 local0.info message\n",
+        "class nextelement -index -name -value -element -list -- /Common/users search_id\n",
+        "class anymore /Common/users search_id\n",
+        "class donesearch /Common/users search_id\n",
+    ] {
+        assert_eq!(
+            arity_codes(src, "f5-irules"),
+            Vec::<String>::new(),
+            "{src:?}"
+        );
+    }
+
+    // Keep the upper bounds useful after widening the three valid forms.
+    for src in [
+        "pool /Common/web member 192.0.2.10 443 extra\n",
+        "log 192.0.2.20 local0.info message extra\n",
+        "class nextelement /Common/users search_id extra\n",
+    ] {
+        assert_eq!(
+            arity_codes(src, "f5-irules"),
+            vec!["E003".to_owned()],
+            "{src:?}"
+        );
+    }
+}
+
+#[test]
 fn e003_fires_for_same_file_proc_call_too_many_args() {
     // The reported bug: a same-file call to a 7-parameter proc with 8
     // arguments produced no diagnostic at all. `arg8` inside the body

--- a/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
@@ -320,6 +320,17 @@ impl Analyser {
             .collect()
     }
 
+    /// Names declared by inline or sidecar stubs.  The analysis setup
+    /// assembles this shared, provenance-aware declaration surface, so this
+    /// must not rescan just the source document and omit sidecar bundles.
+    fn stub_command_names(&self) -> HashSet<String> {
+        self.result
+            .stub_commands
+            .iter()
+            .map(|stub| stub.name.clone())
+            .collect()
+    }
+
     /// Build the [`W123KnownNames`] sets consulted by the unresolved-command
     /// pass: registry names enabled in the active dialect, user proc / class /
     /// alias / ensemble simple-name tails, inline-stub names, and the
@@ -350,16 +361,7 @@ impl Analyser {
             .filter(|name| profile.resolve_command(registry, name).is_some())
             .map(str::to_string)
             .collect();
-        // Inline and sidecar stub declarations contribute to the candidate
-        // set and suppression set. `result.stub_commands` is the one
-        // provenance-aware declaration surface built at analysis setup; scanning
-        // the source here would silently omit `<dialect>.tcl.stubs` bundles.
-        let stub_names: HashSet<String> = self
-            .result
-            .stub_commands
-            .iter()
-            .map(|stub| stub.name.clone())
-            .collect();
+        let stub_names = self.stub_command_names();
         // These two tail sets feed only the "did you mean…?" candidate
         // list below — resolution itself uses `proc_defs_by_tail` /
         // `class_defs_by_tail` (built further down), which check each

--- a/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
@@ -350,11 +350,16 @@ impl Analyser {
             .filter(|name| profile.resolve_command(registry, name).is_some())
             .map(str::to_string)
             .collect();
-        // Inline ``# tcl-lsp: stub NAME ...``
-        // declarations contribute to the candidate set and the
-        // suppression set so users who declared a stub for a
-        // command don't get spurious W123s.
-        let stub_names: HashSet<String> = super::utils::scan_stub_command_names(&self.source);
+        // Inline and sidecar stub declarations contribute to the candidate
+        // set and suppression set. `result.stub_commands` is the one
+        // provenance-aware declaration surface built at analysis setup; scanning
+        // the source here would silently omit `<dialect>.tcl.stubs` bundles.
+        let stub_names: HashSet<String> = self
+            .result
+            .stub_commands
+            .iter()
+            .map(|stub| stub.name.clone())
+            .collect();
         // These two tail sets feed only the "did you mean…?" candidate
         // list below — resolution itself uses `proc_defs_by_tail` /
         // `class_defs_by_tail` (built further down), which check each

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -2876,7 +2876,7 @@ options. To unset a variable whose name begins with `-`, put `--` before it \
                 .result
                 .stub_commands
                 .iter()
-                .filter(|s| commands.contains(s.name.trim_start_matches(':')))
+                .filter(|s| !s.from_sidecar && commands.contains(s.name.trim_start_matches(':')))
                 .map(|s| (s.name.clone(), s.range))
                 .collect();
             for (name, span) in hits {
@@ -2898,9 +2898,10 @@ options. To unset a variable whose name begins with `-`, put `--` before it \
                 .stub_expr_defs
                 .iter()
                 .filter(|s| {
-                    is_builtin_math_function(&s.name)
-                        || is_builtin_expr_op(&s.name)
-                        || (irules && is_irules_only_expr_op(&s.name))
+                    !s.from_sidecar
+                        && (is_builtin_math_function(&s.name)
+                            || is_builtin_expr_op(&s.name)
+                            || (irules && is_irules_only_expr_op(&s.name)))
                 })
                 .map(|s| (s.name.clone(), s.kind.clone(), s.range))
                 .collect();

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -84,6 +84,10 @@ pub enum PerItemFallback {
     /// An inline `tcl-lsp: stub` directive; stub overlays are modelled only on
     /// the full path.
     StubDirective,
+    /// A nearest `<dialect>.tcl.stubs` sidecar is present. Its signatures must
+    /// reach every isolated proc body, so use the full analyser until the
+    /// per-body memo key carries the complete overlay.
+    SidecarStub,
     /// Tk checks are live, and their whole-file state (created widgets,
     /// per-parent geometry) is not visible to an isolated body.
     ///
@@ -128,6 +132,7 @@ impl PerItemFallback {
         match self {
             Self::IncompleteScript => "incomplete-script",
             Self::StubDirective => "stub-directive",
+            Self::SidecarStub => "sidecar-stub",
             Self::TkActive => "tk-active",
             Self::GhostRecovery => "ghost-recovery",
             Self::PartialCommand => "partial-command",
@@ -295,6 +300,8 @@ impl Analyser {
         let entry_gate = if tcl_lexer::script_is_complete(source) {
             if source.contains("tcl-lsp: stub") {
                 Some(PerItemFallback::StubDirective)
+            } else if super::utils::has_sidecar_stubs(self.file_path.as_deref(), dialect) {
+                Some(PerItemFallback::SidecarStub)
             } else if dialect == "tk" {
                 Some(PerItemFallback::TkActive)
             } else {

--- a/rust/tcl-compiler/src/analyser/scope.rs
+++ b/rust/tcl-compiler/src/analyser/scope.rs
@@ -2754,6 +2754,34 @@ mod tests {
     }
 
     #[test]
+    fn sidecar_stub_shadows_never_point_into_the_source_document() {
+        let root = std::env::temp_dir().join(format!(
+            "tcl-lsp-sidecar-shadow-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(
+            root.join("tcl.tcl.stubs"),
+            "stub set {value}\nstub expr-func sin 1\n",
+        )
+        .unwrap();
+        let source = root.join("main.tcl");
+        let result = Analyser::new()
+            .with_file_path(Some(source.display().to_string()))
+            .analyse("set value 1\n", "tcl");
+        assert!(
+            !result
+                .diagnostics
+                .iter()
+                .any(|d| matches!(d.code, DiagCode::W116 | DiagCode::W117)),
+            "sidecar shadow diagnostics must not be published on source spans: {:?}",
+            result.diagnostics
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn w127_fires_for_value_outside_closed_set() {
         let src = "when HTTP_REQUEST { HTTP::version \"2.0\" }";
         assert!(diag_codes(src, "f5-irules").contains(&"W127".to_string()));

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -1574,7 +1574,11 @@ impl Analyser {
         // overlay so analyser / compiler queries see the
         // user-declared stubs as first-class commands (without
         // mutating the global registry).
-        let (stub_cmds, stub_exprs) = super::utils::scan_source_for_stubs(source);
+        let (mut stub_cmds, mut stub_exprs) = super::utils::scan_source_for_stubs(source);
+        let (sidecar_cmds, sidecar_exprs) =
+            super::utils::scan_sidecar_stubs(self.file_path.as_deref(), dialect);
+        stub_cmds.extend(sidecar_cmds);
+        stub_exprs.extend(sidecar_exprs);
         self.stub_overlay = Some(super::types::build_stub_overlay(&stub_cmds));
         self.result.stub_commands = stub_cmds;
         self.result.stub_expr_defs = stub_exprs;

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -1574,14 +1574,18 @@ impl Analyser {
         // overlay so analyser / compiler queries see the
         // user-declared stubs as first-class commands (without
         // mutating the global registry).
-        let (mut stub_cmds, mut stub_exprs) = super::utils::scan_source_for_stubs(source);
+        let (stub_cmds, stub_exprs) = super::utils::scan_source_for_stubs(source);
         let (sidecar_cmds, sidecar_exprs) =
             super::utils::scan_sidecar_stubs(self.file_path.as_deref(), dialect);
-        stub_cmds.extend(sidecar_cmds);
-        stub_exprs.extend(sidecar_exprs);
-        self.stub_overlay = Some(super::types::build_stub_overlay(&stub_cmds));
-        self.result.stub_commands = stub_cmds;
-        self.result.stub_expr_defs = stub_exprs;
+        let mut overlay_cmds = sidecar_cmds;
+        // The document-local declaration is nearest in scope and wins over a
+        // workspace sidecar with the same name.
+        overlay_cmds.extend(stub_cmds.iter().cloned());
+        self.stub_overlay = Some(super::types::build_stub_overlay(&overlay_cmds));
+        self.result.stub_commands = overlay_cmds;
+        let mut all_exprs = sidecar_exprs;
+        all_exprs.extend(stub_exprs);
+        self.result.stub_expr_defs = all_exprs;
 
         // Segment with re-segmentation recovery so an unclosed delimiter
         // mid-file doesn't drop later top-level declarations.
@@ -2058,9 +2062,15 @@ impl Analyser {
         // resolution (W123 / W307 / param-trait inference) sees the same stub
         // surface and ``analyse_commands`` stays byte-identical to ``analyse``.
         let (stub_cmds, stub_exprs) = super::utils::scan_source_for_stubs(source);
-        self.stub_overlay = Some(super::types::build_stub_overlay(&stub_cmds));
-        self.result.stub_commands = stub_cmds;
-        self.result.stub_expr_defs = stub_exprs;
+        let (sidecar_cmds, sidecar_exprs) =
+            super::utils::scan_sidecar_stubs(self.file_path.as_deref(), dialect);
+        let mut overlay_cmds = sidecar_cmds;
+        overlay_cmds.extend(stub_cmds.iter().cloned());
+        self.stub_overlay = Some(super::types::build_stub_overlay(&overlay_cmds));
+        self.result.stub_commands = overlay_cmds;
+        let mut all_exprs = sidecar_exprs;
+        all_exprs.extend(stub_exprs);
+        self.result.stub_expr_defs = all_exprs;
 
         let file_env_pushed = self.seed_file_scope_env(source);
         self.analyse_commands_inner(commands);

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -2481,6 +2481,10 @@ pub struct StubCommandDef {
     /// Trailing flag set (``-barrier`` / ``-loop`` / ``-pure``
     /// / ``-mutator`` / ``-unsafe`` / ``-scope_alias``).
     pub flags: StubFlags,
+    /// `true` when this declaration came from a workspace sidecar rather than
+    /// the analysed document. Such declarations participate in resolution but
+    /// cannot produce source-positioned shadow diagnostics.
+    pub from_sidecar: bool,
 }
 
 impl StubCommandDef {
@@ -2544,6 +2548,8 @@ pub struct StubExprDef {
     pub arity: u32,
     /// Span of the comment line carrying the directive.
     pub range: Span,
+    /// See [`StubCommandDef::from_sidecar`].
+    pub from_sidecar: bool,
 }
 
 /// `regexp` / `regsub` / `switch -regexp` literal-pattern record.

--- a/rust/tcl-compiler/src/analyser/utils.rs
+++ b/rust/tcl-compiler/src/analyser/utils.rs
@@ -470,6 +470,7 @@ pub fn scan_source_for_stubs(
                 kind: kind.to_string(),
                 arity,
                 range: span,
+                from_sidecar: false,
             });
             continue;
         }
@@ -517,11 +518,37 @@ pub fn scan_sidecar_stubs(
                 adapted.push('\n');
             }
             adapted.push_str("# tcl-lsp: stubs-end\n");
-            return scan_source_for_stubs(&adapted);
+            let (mut cmds, mut exprs) = scan_source_for_stubs(&adapted);
+            for stub in &mut cmds {
+                stub.from_sidecar = true;
+            }
+            for stub in &mut exprs {
+                stub.from_sidecar = true;
+            }
+            return (cmds, exprs);
         }
         dir = current.parent();
     }
     (Vec::new(), Vec::new())
+}
+
+/// Whether the source's nearest ancestor sidecar is readable. The incremental
+/// analyser uses this as a correctness gate: sidecar signatures affect
+/// isolated proc bodies, so their presence selects the full analyser until
+/// those signatures are part of every per-body memo key.
+#[must_use]
+pub fn has_sidecar_stubs(file_path: Option<&str>, dialect: &str) -> bool {
+    let Some(file_path) = file_path else {
+        return false;
+    };
+    let mut dir = std::path::Path::new(file_path).parent();
+    while let Some(current) = dir {
+        if current.join(format!("{dialect}.tcl.stubs")).is_file() {
+            return true;
+        }
+        dir = current.parent();
+    }
+    false
 }
 
 /// Strip a leading ``tcl-lsp:`` keyword (case-insensitive) from
@@ -596,6 +623,7 @@ fn parse_command_stub(line: &str, range: tcl_lexer::Span) -> Option<super::types
         args,
         range,
         flags,
+        from_sidecar: false,
     })
 }
 

--- a/rust/tcl-compiler/src/analyser/utils.rs
+++ b/rust/tcl-compiler/src/analyser/utils.rs
@@ -480,6 +480,50 @@ pub fn scan_source_for_stubs(
     (cmds, exprs)
 }
 
+/// Load the nearest workspace sidecar named `<dialect>.tcl.stubs` and parse
+/// its declarations using the same grammar as inline stubs.  Sidecars are
+/// deliberately searched from the source directory upwards: a package or
+/// workspace can provide a broad bundle at its root while a nested project
+/// can override it with a nearer file.  The source itself is never modified,
+/// so all source spans remain stable; sidecar declaration spans are synthetic
+/// and are only retained for the normal stub metadata surface.
+#[must_use]
+pub fn scan_sidecar_stubs(
+    file_path: Option<&str>,
+    dialect: &str,
+) -> (
+    Vec<super::types::StubCommandDef>,
+    Vec<super::types::StubExprDef>,
+) {
+    let Some(file_path) = file_path else {
+        return (Vec::new(), Vec::new());
+    };
+    let mut dir = std::path::Path::new(file_path).parent();
+    while let Some(current) = dir {
+        let sidecar = current.join(format!("{dialect}.tcl.stubs"));
+        if let Ok(content) = std::fs::read_to_string(&sidecar) {
+            // Sidecar syntax is one declaration per line, without the inline
+            // comment prefix or begin/end markers.  Adapt it into the
+            // canonical scanner rather than maintaining a second parser.
+            let mut adapted = String::from("# tcl-lsp: stubs-begin\n");
+            for line in content.lines() {
+                let trimmed = line.trim_start();
+                if trimmed.starts_with('#') {
+                    adapted.push_str(trimmed);
+                } else {
+                    adapted.push_str("# tcl-lsp: ");
+                    adapted.push_str(line);
+                }
+                adapted.push('\n');
+            }
+            adapted.push_str("# tcl-lsp: stubs-end\n");
+            return scan_source_for_stubs(&adapted);
+        }
+        dir = current.parent();
+    }
+    (Vec::new(), Vec::new())
+}
+
 /// Strip a leading ``tcl-lsp:`` keyword (case-insensitive) from
 /// the comment body, if present.  Whitespace flexible.
 fn strip_tcl_lsp_prefix(body: &str) -> &str {
@@ -1129,6 +1173,33 @@ mod concat_script_window_tests {
 mod tests {
     use super::*;
     use tcl_lexer::Span;
+
+    #[test]
+    fn sidecar_stubs_load_nearest_dialect_bundle() {
+        let root = std::env::temp_dir().join(format!(
+            "tcl-lsp-sidecar-stubs-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        let nested = root.join("src");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(
+            root.join("tcl8.6.tcl.stubs"),
+            "# package API\nstub db_eval {sql script:body} -barrier\n",
+        )
+        .unwrap();
+        let file = nested.join("main.tcl");
+        let (commands, exprs) = scan_sidecar_stubs(Some(file.to_str().unwrap()), "tcl8.6");
+        assert_eq!(exprs.len(), 0);
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].name, "db_eval");
+        assert!(
+            commands[0]
+                .flags
+                .contains(super::super::types::StubFlags::BARRIER)
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
 
     #[test]
     fn parse_file_suppression_finds_codes() {

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -327,6 +327,10 @@ pub struct SourceFile {
     /// almost no document declares a metaclass.
     #[returns(ref)]
     pub workspace_class_factories: Option<Arc<tcl_compiler::analyser::ClassFactoryIndex>>,
+    /// Monotonic revision of workspace sidecar stubs. The server advances this
+    /// input for every `<dialect>.tcl.stubs` create/change/delete, so Salsa
+    /// invalidates analyses that read an external declaration bundle.
+    pub sidecar_stubs_epoch: u64,
 }
 
 impl SourceFile {
@@ -340,7 +344,7 @@ impl SourceFile {
         dialect: String,
         path: Option<String>,
     ) -> Self {
-        Self::with_call_site_evidence(db, text, dialect, path, None, None)
+        Self::with_call_site_evidence(db, text, dialect, path, None, None, 0)
     }
 }
 
@@ -402,6 +406,7 @@ pub fn file_analysis(
     file: SourceFile,
     config: AnalyserConfig,
 ) -> Arc<AnalysisResult> {
+    let _sidecar_stubs_epoch = file.sidecar_stubs_epoch(db);
     let disabled: HashSet<String> = config.disabled_diagnostics(db).iter().cloned().collect();
     let extra: HashSet<String> = config.extra_commands(db).iter().cloned().collect();
     let mut analyser = Analyser::with_disabled_diagnostics(disabled)
@@ -2884,6 +2889,7 @@ pub fn file_analysis_incremental(
     file: SourceFile,
     config: AnalyserConfig,
 ) -> Arc<AnalysisResult> {
+    let _sidecar_stubs_epoch = file.sidecar_stubs_epoch(db);
     let disabled_vec = config.disabled_diagnostics(db).clone();
     let non_ascii = config.non_ascii_mode(db);
     let extra_commands: HashSet<String> = config.extra_commands(db).iter().cloned().collect();
@@ -4328,6 +4334,47 @@ mod tests {
             let full = file_analysis(&db, file, cfg);
             assert_eq!(*inc, *full, "incremental != full for:\n{src}");
         }
+    }
+
+    #[test]
+    fn sidecar_stubs_reach_incremental_proc_bodies_and_invalidate() {
+        use salsa::Setter as _;
+
+        let root = std::env::temp_dir().join(format!(
+            "tcl-lsp-sidecar-incremental-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        let src_dir = root.join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        let sidecar = root.join("tcl8.6.tcl.stubs");
+        std::fs::write(&sidecar, "stub sidecar_cmd {value}\n").unwrap();
+        let path = src_dir.join("main.tcl");
+        let mut db = TclDatabase::default();
+        let config = cfg(&db);
+        let file = SourceFile::new(
+            &db,
+            "proc f {} { sidecar_cmd 1 }\n".to_owned(),
+            "tcl8.6".to_owned(),
+            Some(path.display().to_string()),
+        );
+
+        let initial = file_analysis_incremental(&db, file, config);
+        assert!(
+            !initial.diagnostics.iter().any(|d| d.code == DiagCode::W123),
+            "sidecar command must resolve inside a proc body: {:?}",
+            initial.diagnostics
+        );
+        assert_eq!(*initial, *file_analysis(&db, file, config));
+
+        std::fs::write(&sidecar, "stub replacement_cmd {value}\n").unwrap();
+        file.set_sidecar_stubs_epoch(&mut db).to(1);
+        let changed = file_analysis_incremental(&db, file, config);
+        assert!(
+            changed.diagnostics.iter().any(|d| d.code == DiagCode::W123),
+            "the unchanged source must be reanalysed after its sidecar changes"
+        );
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/rust/tcl-lsp-db/tests/interned_gc.rs
+++ b/rust/tcl-lsp-db/tests/interned_gc.rs
@@ -282,7 +282,7 @@ fn make_inputs(db: &TclDatabase, durability: InputDurability) -> (SourceFile, An
             ),
         ),
         InputDurability::RaisedToHigh => (
-            SourceFile::builder(corpus(0), dialect, None, None, None)
+            SourceFile::builder(corpus(0), dialect, None, None, None, 0)
                 .durability(salsa::Durability::HIGH)
                 .new(db),
             AnalyserConfig::builder(Vec::new(), NonAsciiMode::Default, Vec::new(), None, None)

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -4879,6 +4879,35 @@ impl Backend {
         }
     }
 
+    /// Invalidate every tracked analysis after a sidecar-stub change. A source
+    /// may inherit its nearest `<dialect>.tcl.stubs` from any ancestor, so the
+    /// rare event deliberately advances every loaded source instead of trying
+    /// to maintain a second, fallible ancestor dependency graph.
+    async fn invalidate_sidecar_stubs(&self) {
+        use salsa::Setter as _;
+        let tracked: Vec<Uri> = {
+            let mut db = self.db.lock().await;
+            let files = self.db_files.lock().await;
+            let mut uris = Vec::with_capacity(files.len());
+            for (uri, file) in files.iter() {
+                let next = file.sidecar_stubs_epoch(&*db).wrapping_add(1);
+                file.set_sidecar_stubs_epoch(&mut *db).to(next);
+                uris.push(uri.clone());
+            }
+            uris
+        };
+        let open: Vec<(Uri, String)> = {
+            let docs = self.documents.lock().await;
+            tracked
+                .into_iter()
+                .filter_map(|uri| docs.get(&uri).map(|doc| (uri, doc.dialect.clone())))
+                .collect()
+        };
+        for (uri, dialect) in open {
+            self.reschedule_diagnostics(uri, dialect).await;
+        }
+    }
+
     /// Retire the salsa `SourceFile` input for `uri` (on `did_close`).  Lock
     /// order is `db` → `db_files` → `db_tombstones` → `db_project`, matching
     /// [`Self::db_set_source`].
@@ -12431,6 +12460,13 @@ impl Backend {
                         kind: all_kinds,
                     },
                     FileSystemWatcher {
+                        // Sidecars are external analysis inputs, not Tcl
+                        // source documents. Their events advance the tracked
+                        // sidecar epoch and republish affected open documents.
+                        glob_pattern: GlobPattern::String("**/*.tcl.stubs".to_owned()),
+                        kind: all_kinds,
+                    },
+                    FileSystemWatcher {
                         // The project config the layered settings live-reload
                         // from ([`is_config_file`]). Registered here rather than
                         // left to each client's own `synchronize.fileEvents`, so
@@ -14006,6 +14042,7 @@ impl LanguageServer for Backend {
         // definition / references / rename / call-hierarchy keep seeing the
         // project's true on-disk state between restarts.
         let mut config_changed = false;
+        let mut sidecar_changed = false;
         // Reduce to the *last* event per URI before partitioning: a batch can
         // legitimately name the same path twice (a delete-and-recreate a
         // branch switch or a rapid rename can coalesce into one
@@ -14019,6 +14056,10 @@ impl LanguageServer for Backend {
             // layered config — a live-reload for these files.
             if is_config_file(&change.uri) {
                 config_changed = true;
+                continue;
+            }
+            if is_sidecar_stubs_file(&change.uri) {
+                sidecar_changed = true;
                 continue;
             }
             // Only Tcl sources drive the index.  The server's own registration
@@ -14037,6 +14078,9 @@ impl LanguageServer for Backend {
                 continue;
             }
             last_kind.insert(change.uri, change.typ);
+        }
+        if sidecar_changed {
+            self.invalidate_sidecar_stubs().await;
         }
         // Partition the (deduplicated) event set so the disk-backed work below
         // runs once per kind — a parallel read+analyse and one batched
@@ -17362,6 +17406,21 @@ fn is_config_file(uri: &Uri) -> bool {
         || s.ends_with("\\.tcl-lsp.ini")
         || s.ends_with("/tcl-lsp/config.ini")
         || s.ends_with("\\tcl-lsp\\config.ini")
+}
+
+/// Whether `uri` is a workspace sidecar declaration bundle. It is purposely
+/// kept outside [`is_tcl_source`]: a `.tcl.stubs` file controls analysis but is
+/// never itself indexed or diagnosed as Tcl source.
+fn is_sidecar_stubs_file(uri: &Uri) -> bool {
+    uri.to_file_path()
+        .and_then(|path| {
+            path.file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+        })
+        .is_some_and(|name| {
+            let name = name.to_ascii_lowercase();
+            name.ends_with(".tcl.stubs") && name.len() > ".tcl.stubs".len()
+        })
 }
 
 /// Read an INI config file at `path` (if present/readable) into the

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -3325,6 +3325,7 @@ async fn refine_and_lift_diagnostics(
             &disabled,
             &analysis_lifts.suppressed_lines,
         ));
+        suppress_duplicate_o120(&mut diagnostics);
         diagnostics.extend(lift_source_style_diagnostics(
             &lift_text,
             decode_report.as_ref(),
@@ -12145,6 +12146,7 @@ impl Backend {
                 &disabled,
                 &analysis.suppressed_lines,
             ));
+            suppress_duplicate_o120(&mut diagnostics);
             diagnostics.extend(lift_source_style_diagnostics(
                 &text,
                 decode_report.as_ref(),
@@ -19751,6 +19753,34 @@ fn lift_compiler_diagnostics(
     out
 }
 
+/// Keep one user-facing squiggle when the analyser's W110 and optimiser's
+/// O120 identify the same string-comparison operator.  W110 owns this case at
+/// the LSP boundary: it is the semantics-aware analyser warning and is the
+/// diagnostic used by the safe-fix path.  O120 is still published when W110
+/// is absent (for optimiser-only callers and when the analyser has been
+/// disabled), and distinct ranges are never coalesced.
+fn suppress_duplicate_o120(diagnostics: &mut Vec<tower_lsp_server::ls_types::Diagnostic>) {
+    let w110_ranges: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| {
+            matches!(
+                d.code.as_ref(),
+                Some(tower_lsp_server::ls_types::NumberOrString::String(code)) if code == "W110"
+            )
+        })
+        .map(|d| d.range)
+        .collect();
+    if w110_ranges.is_empty() {
+        return;
+    }
+    diagnostics.retain(|d| {
+        !(matches!(
+            d.code.as_ref(),
+            Some(tower_lsp_server::ls_types::NumberOrString::String(code)) if code == "O120"
+        ) && w110_ranges.contains(&d.range))
+    });
+}
+
 /// Build an empty `DocumentDiagnosticReportResult` for callers
 /// that hit a no-document or no-analysis path.
 fn empty_diagnostic_report() -> DocumentDiagnosticReportResult {
@@ -20534,8 +20564,47 @@ fn lift_folding_range(r: tcl_lsp_core::folding::FoldingRange) -> FoldingRange {
 mod tests {
     use super::*;
     use tower_lsp_server::ls_types::{
-        PartialResultParams, ReferenceContext, TextDocumentIdentifier, WorkDoneProgressParams,
+        Diagnostic, DiagnosticSeverity, NumberOrString, PartialResultParams, Range,
+        ReferenceContext, TextDocumentIdentifier, WorkDoneProgressParams,
     };
+
+    fn lifted_diag(code: &str, range: Range) -> Diagnostic {
+        Diagnostic {
+            range,
+            severity: Some(DiagnosticSeverity::WARNING),
+            code: Some(NumberOrString::String(code.to_owned())),
+            code_description: None,
+            source: Some("test".to_owned()),
+            message: code.to_owned(),
+            related_information: None,
+            tags: None,
+            data: None,
+        }
+    }
+
+    #[test]
+    fn duplicate_o120_is_removed_only_for_matching_w110_range() {
+        let same = Range::new(Position::new(1, 2), Position::new(1, 4));
+        let other = Range::new(Position::new(3, 0), Position::new(3, 2));
+        let mut diagnostics = vec![
+            lifted_diag("W110", same),
+            lifted_diag("O120", same),
+            lifted_diag("O120", other),
+        ];
+        suppress_duplicate_o120(&mut diagnostics);
+        let codes: Vec<_> = diagnostics
+            .iter()
+            .filter_map(|d| match d.code.as_ref() {
+                Some(NumberOrString::String(code)) => Some(code.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(codes, ["W110", "O120"]);
+
+        let mut optimiser_only = vec![lifted_diag("O120", same)];
+        suppress_duplicate_o120(&mut optimiser_only);
+        assert_eq!(optimiser_only.len(), 1, "O120 survives without W110");
+    }
 
     // ---- #723 W120 workspace-refinement helpers ----------------------------
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -104,24 +104,25 @@ use tower_lsp_server::ls_types::{
     DocumentHighlightKind, DocumentHighlightParams, DocumentLink, DocumentLinkOptions,
     DocumentLinkParams, DocumentRangeFormattingParams, DocumentSymbol, DocumentSymbolParams,
     DocumentSymbolResponse, Documentation, ExecuteCommandOptions, ExecuteCommandParams,
-    FileChangeType, FileOperationFilter, FileOperationPattern, FileOperationPatternOptions,
-    FileOperationRegistrationOptions, FileSystemWatcher, FoldingRange, FoldingRangeKind,
-    FoldingRangeParams, FoldingRangeProviderCapability, FullDocumentDiagnosticReport, GlobPattern,
-    GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverContents, HoverParams,
-    HoverProviderCapability, ImplementationProviderCapability, InitializeParams, InitializeResult,
-    InitializedParams, InlayHint, InlayHintKind, InlayHintLabel, InlayHintParams,
-    LinkedEditingRangeParams, LinkedEditingRanges, Location, MarkupContent, MarkupKind,
-    MessageType, OneOf, OptionalVersionedTextDocumentIdentifier, ParameterInformation,
-    ParameterLabel, Position, PositionEncodingKind, PrepareRenameResponse, Range, ReferenceParams,
-    Registration, RelatedFullDocumentDiagnosticReport, RelatedUnchangedDocumentDiagnosticReport,
-    RenameFilesParams, RenameOptions, RenameParams, SelectionRange, SelectionRangeParams,
-    SelectionRangeProviderCapability, SemanticTokens as LspSemanticTokens, SemanticTokensDelta,
-    SemanticTokensDeltaParams, SemanticTokensEdit, SemanticTokensFullDeltaResult,
-    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions, SemanticTokensParams,
-    SemanticTokensRangeParams, SemanticTokensRangeResult, SemanticTokensResult,
-    SemanticTokensServerCapabilities, ServerCapabilities, ServerInfo, SignatureHelp,
-    SignatureHelpOptions, SignatureHelpParams, SignatureInformation, SymbolInformation, SymbolKind,
-    TextDocumentEdit, TextDocumentPositionParams, TextDocumentSyncCapability, TextDocumentSyncKind,
+    FileChangeType, FileEvent, FileOperationFilter, FileOperationPattern,
+    FileOperationPatternOptions, FileOperationRegistrationOptions, FileSystemWatcher, FoldingRange,
+    FoldingRangeKind, FoldingRangeParams, FoldingRangeProviderCapability,
+    FullDocumentDiagnosticReport, GlobPattern, GotoDefinitionParams, GotoDefinitionResponse, Hover,
+    HoverContents, HoverParams, HoverProviderCapability, ImplementationProviderCapability,
+    InitializeParams, InitializeResult, InitializedParams, InlayHint, InlayHintKind,
+    InlayHintLabel, InlayHintParams, LinkedEditingRangeParams, LinkedEditingRanges, Location,
+    MarkupContent, MarkupKind, MessageType, OneOf, OptionalVersionedTextDocumentIdentifier,
+    ParameterInformation, ParameterLabel, Position, PositionEncodingKind, PrepareRenameResponse,
+    Range, ReferenceParams, Registration, RelatedFullDocumentDiagnosticReport,
+    RelatedUnchangedDocumentDiagnosticReport, RenameFilesParams, RenameOptions, RenameParams,
+    SelectionRange, SelectionRangeParams, SelectionRangeProviderCapability,
+    SemanticTokens as LspSemanticTokens, SemanticTokensDelta, SemanticTokensDeltaParams,
+    SemanticTokensEdit, SemanticTokensFullDeltaResult, SemanticTokensFullOptions,
+    SemanticTokensLegend, SemanticTokensOptions, SemanticTokensParams, SemanticTokensRangeParams,
+    SemanticTokensRangeResult, SemanticTokensResult, SemanticTokensServerCapabilities,
+    ServerCapabilities, ServerInfo, SignatureHelp, SignatureHelpOptions, SignatureHelpParams,
+    SignatureInformation, SymbolInformation, SymbolKind, TextDocumentEdit,
+    TextDocumentPositionParams, TextDocumentSyncCapability, TextDocumentSyncKind,
     TextDocumentSyncOptions, TextEdit, TypeDefinitionProviderCapability, TypeHierarchyItem,
     TypeHierarchyPrepareParams, TypeHierarchySubtypesParams, TypeHierarchySupertypesParams,
     UnchangedDocumentDiagnosticReport, Uri, WatchKind, WillSaveTextDocumentParams,
@@ -14041,44 +14042,8 @@ impl LanguageServer for Backend {
         // file, a deletion — must refresh the cross-document index so
         // definition / references / rename / call-hierarchy keep seeing the
         // project's true on-disk state between restarts.
-        let mut config_changed = false;
-        let mut sidecar_changed = false;
-        // Reduce to the *last* event per URI before partitioning: a batch can
-        // legitimately name the same path twice (a delete-and-recreate a
-        // branch switch or a rapid rename can coalesce into one
-        // `didChangeWatchedFiles` notification), and the serial per-file path
-        // this replaces applied each event as it arrived, so only the last
-        // one for a given URI survived. A HashMap insert naturally keeps that
-        // "last write wins" semantics without needing to preserve array order.
-        let mut last_kind: HashMap<Uri, FileChangeType> = HashMap::new();
-        for change in params.changes {
-            // A project `.tcl-lsp.ini` (or user `config.ini`) edit re-applies the
-            // layered config — a live-reload for these files.
-            if is_config_file(&change.uri) {
-                config_changed = true;
-                continue;
-            }
-            if is_sidecar_stubs_file(&change.uri) {
-                sidecar_changed = true;
-                continue;
-            }
-            // Only Tcl sources drive the index.  The server's own registration
-            // is exactly [`tcl_source_watch_glob`], but a client may watch more
-            // broadly through its own `synchronize.fileEvents` (or a `**/*`
-            // config), and a non-Tcl path must not enter the resolution domain
-            // or have diagnostics published against it.  Case-folded by
-            // [`is_tcl_source`], the same predicate the workspace scan uses, so
-            // an `UPPER.TCL` event is kept (issue #1215).  A non-`file` URI has
-            // no path to test and is left to the handlers below.
-            if change
-                .uri
-                .to_file_path()
-                .is_some_and(|path| !is_tcl_source(&path))
-            {
-                continue;
-            }
-            last_kind.insert(change.uri, change.typ);
-        }
+        let (config_changed, sidecar_changed, last_kind) =
+            partition_watched_file_changes(params.changes);
         if sidecar_changed {
             self.invalidate_sidecar_stubs().await;
         }
@@ -17421,6 +17386,31 @@ fn is_sidecar_stubs_file(uri: &Uri) -> bool {
             let name = name.to_ascii_lowercase();
             name.ends_with(".tcl.stubs") && name.len() > ".tcl.stubs".len()
         })
+}
+
+/// Split watched events into config / sidecar flags and the final event for
+/// each Tcl source.  A batch may contain a path more than once, so the last
+/// event wins, matching the old serial handling.
+fn partition_watched_file_changes(
+    changes: Vec<FileEvent>,
+) -> (bool, bool, HashMap<Uri, FileChangeType>) {
+    let mut config_changed = false;
+    let mut sidecar_changed = false;
+    let mut last_kind = HashMap::new();
+    for change in changes {
+        if is_config_file(&change.uri) {
+            config_changed = true;
+        } else if is_sidecar_stubs_file(&change.uri) {
+            sidecar_changed = true;
+        } else if change
+            .uri
+            .to_file_path()
+            .is_none_or(|path| is_tcl_source(&path))
+        {
+            last_kind.insert(change.uri, change.typ);
+        }
+    }
+    (config_changed, sidecar_changed, last_kind)
 }
 
 /// Read an INI config file at `path` (if present/readable) into the

--- a/rust/tcl-registry/src/commands/irules/class.rs
+++ b/rust/tcl-registry/src/commands/irules/class.rs
@@ -329,15 +329,42 @@ const SUBCOMMANDS: &[SubCommand] = &[
     },
     SubCommand {
         name: "nextelement",
-        arity: Arity::exact(1),
+        arity: Arity::exact(2),
         detail: "Get next element during iteration.",
-        synopsis: "class nextelement ?options? ?--? <search_id>",
+        synopsis: "class nextelement ?options? ?--? <class> <search_id>",
         options: const {
             &[
+                OptionSpec {
+                    name: "-index",
+                    value: OptionValue::flag(),
+                    detail: "Return index instead of element.",
+                    dialects: None,
+                    aliases: &[],
+                    lifecycle: Lifecycle::UNSPECIFIED,
+                    min_abbrev: None,
+                },
                 OptionSpec {
                     name: "-value",
                     value: OptionValue::flag(),
                     detail: "Return value instead of name.",
+                    dialects: None,
+                    aliases: &[],
+                    lifecycle: Lifecycle::UNSPECIFIED,
+                    min_abbrev: None,
+                },
+                OptionSpec {
+                    name: "-element",
+                    value: OptionValue::flag(),
+                    detail: "Return name and value as one element.",
+                    dialects: None,
+                    aliases: &[],
+                    lifecycle: Lifecycle::UNSPECIFIED,
+                    min_abbrev: None,
+                },
+                OptionSpec {
+                    name: "-list",
+                    value: OptionValue::flag(),
+                    detail: "Always return a list.",
                     dialects: None,
                     aliases: &[],
                     lifecycle: Lifecycle::UNSPECIFIED,
@@ -367,17 +394,17 @@ const SUBCOMMANDS: &[SubCommand] = &[
     },
     SubCommand {
         name: "anymore",
-        arity: Arity::exact(1),
+        arity: Arity::exact(2),
         detail: "Check if more elements remain.",
-        synopsis: "class anymore <search_id>",
+        synopsis: "class anymore <class> <search_id>",
         pure: true,
         ..SubCommand::DEFAULT
     },
     SubCommand {
         name: "donesearch",
-        arity: Arity::exact(1),
+        arity: Arity::exact(2),
         detail: "End a data group iteration.",
-        synopsis: "class donesearch <search_id>",
+        synopsis: "class donesearch <class> <search_id>",
         ..SubCommand::DEFAULT
     },
 ];

--- a/rust/tcl-registry/src/commands/irules/log.rs
+++ b/rust/tcl-registry/src/commands/irules/log.rs
@@ -23,10 +23,16 @@ pub const fn spec() -> CommandSpec {
         name: "log",
         traits: Traits::DIAGRAM_ACTION,
         dialects: Some(DialectSet::IRULES),
-        arity: Arity::new(1, 2),
+        // Remote logging has remote address, facility, and message as its
+        // three positional arguments. `-noname` is an OptionSpec and is
+        // consumed before this positional arity is checked.
+        arity: Arity::new(1, 3),
         hover: Some(HoverSnippet {
             summary: "Write a message to BIG-IP logging facilities.",
-            synopsis: &["log ?facility.level? message"],
+            synopsis: &[
+                "log ?-noname? ?facility.level? message",
+                "log ?-noname? remote_ip?:port? facility.level message",
+            ],
             snippet: "Common form: `log local0. \"message\"`.",
             source: "https://clouddocs.f5.com/api/irules/log.html",
             examples: "",

--- a/rust/tcl-registry/src/commands/irules/pool.rs
+++ b/rust/tcl-registry/src/commands/irules/pool.rs
@@ -23,10 +23,13 @@ pub const fn spec() -> CommandSpec {
         name: "pool",
         traits: Traits::DIAGRAM_ACTION,
         dialects: Some(DialectSet::IRULES),
-        arity: Arity::new(1, 3),
+        // The optional member form includes the literal `member` selector:
+        // `pool POOL member ADDRESS PORT`.  It is therefore four words after
+        // the command name, not three.
+        arity: Arity::new(1, 4),
         hover: Some(HoverSnippet {
             summary: "Select a load-balancing pool for the current flow.",
-            synopsis: &["pool pool_name ?member_addr member_port?"],
+            synopsis: &["pool <pool_name> [member <addr> [<port>]]"],
             snippet: "Can direct traffic to a pool, optionally pinning to a specific member.",
             source: "https://clouddocs.f5.com/api/irules/pool.html",
             examples: "",
@@ -44,7 +47,7 @@ pub const fn spec() -> CommandSpec {
         }),
         forms: &[FormSpec {
             kind: FormKind::Default,
-            synopsis: "pool pool_name ?member_addr member_port?",
+            synopsis: "pool <pool_name> [member <addr> [<port>]]",
             dialects: None,
         }],
         side_effects: &[SideEffect {

--- a/rust/xtask/src/fp_sweep.rs
+++ b/rust/xtask/src/fp_sweep.rs
@@ -43,12 +43,24 @@
 //!   into one row with a count, highest-volume shape first — the workflow
 //!   the checklist's resolved entries describe ("corpus 3641 → ~700-900").
 //!
-//! Corpus discovery reuses [`tcl_cli_support::read_input_documents`] (the
-//! same recursive walk + extension filter `tcl diag`/`tcl opt` use), so a
-//! `--corpus` argument can name a directory or a file, same as the CLI.
+//! Corpus discovery accepts the normal Tcl-family extensions plus two
+//! corpus-only publication formats common in the #1181 iRules sources:
+//!
+//! - a `.txt` file containing a top-level `when EVENT ... {` handler is swept
+//!   as one iRules document;
+//! - a reStructuredText `.rst` `code` / `code-block` directive is extracted
+//!   when its indented body contains that same signature. Its findings retain
+//!   the source document's original line numbers.
+//!
+//! The strong event-handler signal keeps arbitrary prose and console blocks
+//! out of the analyser. Normal source files are still decoded by
+//! [`tcl_cli_support::read_input_documents`], the same reader as `tcl diag` /
+//! `tcl opt`. The seven `.tmsh` files in the pinned public #1181 corpus are
+//! BIG-IP configuration/data-group or iCall artefacts, not iRules (none has a
+//! `when EVENT` handler), so they remain outside this iRules diagnostic sweep.
 
-use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -61,8 +73,350 @@ use tcl_compiler::compiler_checks::run_all_checks;
 use tcl_compiler::optimiser::optimise_unit;
 use tcl_core_types::DiagCode;
 use tcl_lexer::LineIndex;
+use tcl_lsp_core::source_decode::{DecodeReport, decode_source};
 use tcl_lsp_core::source_style::{DEFAULT_LINE_ENDING, DEFAULT_LINE_LENGTH, style_diagnostics};
+use tcl_registry::dialects::TCL_SOURCE_EXTENSIONS;
 use tcl_registry::registry_for_dialect;
+
+/// Directory names skipped by the corpus walk. Keep this aligned with the
+/// normal CLI input walk: generated/build trees and VCS metadata are neither
+/// user source nor useful third-party audit material.
+const SKIP_DIRECTORY_NAMES: &[&str] = &[
+    ".git",
+    ".hg",
+    ".svn",
+    ".venv",
+    "__pycache__",
+    "node_modules",
+    "build",
+    "dist",
+];
+
+/// A document entering the sweep, plus provenance needed only by corpus
+/// extraction. Native documents use no override and a zero offset.
+struct SweepDocument {
+    input: InputDocument,
+    line_offset: u32,
+    dialect_override: Option<&'static str>,
+}
+
+#[derive(Default)]
+struct CorpusDocuments {
+    documents: Vec<SweepDocument>,
+    text_files: usize,
+    rst_files: usize,
+    rst_blocks: usize,
+}
+
+impl CorpusDocuments {
+    fn source_files(&self) -> usize {
+        self.documents.len() - self.rst_blocks + self.rst_files
+    }
+}
+
+/// One extracted reStructuredText literal block. `line_offset` is zero-based,
+/// so a diagnostic at extracted line 1 maps to original line
+/// `line_offset + 1`.
+#[derive(Debug, PartialEq, Eq)]
+struct RstBlock {
+    source: String,
+    line_offset: u32,
+}
+
+fn canonical(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn extension_is(path: &Path, wanted: &str) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case(wanted))
+}
+
+fn is_native_source(path: &Path) -> bool {
+    if path.file_name().is_some_and(|name| name == "pkgIndex.tcl") {
+        return true;
+    }
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| {
+            TCL_SOURCE_EXTENSIONS
+                .iter()
+                .any(|known| ext.eq_ignore_ascii_case(known))
+        })
+}
+
+fn is_irules_when_clause_tail(tail: &str) -> bool {
+    let mut words = tail.split_whitespace();
+    while let Some(word) = words.next() {
+        match word {
+            "priority" => {
+                if !words
+                    .next()
+                    .is_some_and(|value| value.chars().all(|c| c.is_ascii_digit()))
+                {
+                    return false;
+                }
+            }
+            "timing" => {
+                if !words
+                    .next()
+                    .is_some_and(|value| value.chars().all(|c| c.is_ascii_alphabetic()))
+                {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+    }
+    true
+}
+
+/// The deliberately strong signature used to opt non-source extensions into
+/// the iRules sweep: a line-leading `when`, an all-caps event identifier, and
+/// an opening brace later on the same line. This accepts real optional clauses
+/// (`priority 500`, `timing on`) without teaching the harness their grammar.
+fn has_irules_event(source: &str) -> bool {
+    let lines: Vec<&str> = source.lines().collect();
+    lines.iter().enumerate().any(|(index, line)| {
+        let line = line.trim_start();
+        let Some(rest) = line.strip_prefix("when") else {
+            return false;
+        };
+        if !rest.starts_with(char::is_whitespace) {
+            return false;
+        }
+        let rest = rest.trim_start();
+        let event_len = rest
+            .chars()
+            .take_while(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || *c == '_')
+            .map(char::len_utf8)
+            .sum::<usize>();
+        event_len >= 3
+            && rest[..event_len]
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_ascii_uppercase())
+            && (rest[event_len..].contains('{')
+                // The BIG-IP man-page schema also carries canonical examples
+                // with the opening brace on the following line (for example,
+                // `when ASM_REQUEST_VIOLATION\n{`). Accept that Tcl layout,
+                // but only when the next non-empty line begins with the brace.
+                || (is_irules_when_clause_tail(rest[event_len..].trim())
+                    && lines[index + 1..]
+                        .iter()
+                        .map(|next| next.trim_start())
+                        .find(|next| !next.is_empty())
+                        .is_some_and(|next| next.starts_with('{'))))
+    })
+}
+
+fn indentation(line: &str) -> usize {
+    line.chars().take_while(|c| matches!(c, ' ' | '\t')).count()
+}
+
+fn is_rst_code_directive(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    let Some(rest) = trimmed.strip_prefix("..") else {
+        return false;
+    };
+    let rest = rest.trim_start();
+    let language = if let Some(rest) = rest.strip_prefix("code-block::") {
+        rest.trim()
+    } else if let Some(rest) = rest.strip_prefix("code::") {
+        rest.trim()
+    } else {
+        return false;
+    };
+
+    // An unlabelled literal block is common in class1 of the agility-labs
+    // corpus. Explicit Tcl/iRules labels are accepted; console, JavaScript,
+    // JSON, and other teaching snippets are not.
+    language.is_empty()
+        || language.eq_ignore_ascii_case("tcl")
+        || language.eq_ignore_ascii_case("irule")
+        || language.eq_ignore_ascii_case("irules")
+}
+
+/// Extract iRules-bearing `code` / `code-block` directives from an `.rst`
+/// document. Indentation is retained so reported columns also refer to the
+/// original document; Tcl accepts the leading whitespace at top level.
+fn extract_rst_irules(source: &str) -> Vec<RstBlock> {
+    let lines: Vec<&str> = source.split_inclusive('\n').collect();
+    let mut blocks = Vec::new();
+    let mut index = 0;
+
+    while index < lines.len() {
+        if !is_rst_code_directive(lines[index].trim_end_matches(['\r', '\n'])) {
+            index += 1;
+            continue;
+        }
+
+        let directive_indent = indentation(lines[index]);
+        let mut start = index + 1;
+
+        // Directive options (`:linenos:`, `:emphasize-lines:`) and blank
+        // separators precede the literal body. They are RST metadata, not Tcl.
+        while start < lines.len() {
+            let line = lines[start].trim_end_matches(['\r', '\n']);
+            if line.trim().is_empty()
+                || (indentation(line) > directive_indent && line.trim_start().starts_with(':'))
+            {
+                start += 1;
+            } else {
+                break;
+            }
+        }
+
+        if start >= lines.len() || indentation(lines[start]) <= directive_indent {
+            index += 1;
+            continue;
+        }
+
+        let mut end = start;
+        while end < lines.len() {
+            let line = lines[end].trim_end_matches(['\r', '\n']);
+            if !line.trim().is_empty() && indentation(line) <= directive_indent {
+                break;
+            }
+            end += 1;
+        }
+
+        let block_source = lines[start..end].concat();
+        if has_irules_event(&block_source) {
+            blocks.push(RstBlock {
+                source: block_source,
+                line_offset: u32::try_from(start).unwrap_or(u32::MAX),
+            });
+        }
+        index = end.max(index + 1);
+    }
+
+    blocks
+}
+
+fn walk_corpus(
+    directory: &Path,
+    native: &mut BTreeSet<PathBuf>,
+    embedded: &mut BTreeSet<PathBuf>,
+) -> Result<()> {
+    let entries = std::fs::read_dir(directory)
+        .with_context(|| format!("reading corpus directory {}", directory.display()))?;
+    for entry in entries {
+        let path = entry
+            .with_context(|| format!("reading corpus directory {}", directory.display()))?
+            .path();
+        if path.is_dir() {
+            let keep = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| {
+                    !name.starts_with('.') && !SKIP_DIRECTORY_NAMES.contains(&name)
+                });
+            if keep {
+                walk_corpus(&path, native, embedded)?;
+            }
+        } else if path.is_file() {
+            if is_native_source(&path) {
+                native.insert(canonical(&path));
+            } else if extension_is(&path, "txt") || extension_is(&path, "rst") {
+                embedded.insert(canonical(&path));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn discover_corpus(inputs: &[PathBuf]) -> Result<(BTreeSet<PathBuf>, BTreeSet<PathBuf>)> {
+    let mut native = BTreeSet::new();
+    let mut embedded = BTreeSet::new();
+    for input in inputs {
+        if !input.exists() {
+            bail!("corpus path does not exist: {}", input.display());
+        }
+        if input.is_dir() {
+            walk_corpus(&canonical(input), &mut native, &mut embedded)?;
+        } else if input.is_file() && is_native_source(input) {
+            native.insert(canonical(input));
+        } else if input.is_file() && (extension_is(input, "txt") || extension_is(input, "rst")) {
+            embedded.insert(canonical(input));
+        } else {
+            bail!(
+                "unsupported corpus file: {} (expected Tcl/iRules source, .txt, or .rst)",
+                input.display()
+            );
+        }
+    }
+    Ok((native, embedded))
+}
+
+fn read_corpus_documents(inputs: &[PathBuf]) -> Result<CorpusDocuments> {
+    let (native_paths, embedded_paths) = discover_corpus(inputs)?;
+    let mut corpus = CorpusDocuments::default();
+
+    if !native_paths.is_empty() {
+        let native_inputs: Vec<PathBuf> = native_paths.into_iter().collect();
+        let documents = read_input_documents(&native_inputs, &[], false)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+            .with_context(|| format!("reading native corpus from {inputs:?}"))?;
+        corpus
+            .documents
+            .extend(documents.into_iter().map(|input| SweepDocument {
+                input,
+                line_offset: 0,
+                dialect_override: None,
+            }));
+    }
+
+    for path in embedded_paths {
+        let bytes = std::fs::read(&path)
+            .with_context(|| format!("reading embedded corpus file {}", path.display()))?;
+        let (source, decode) = decode_source(&bytes);
+        if extension_is(&path, "txt") {
+            if has_irules_event(&source) {
+                corpus.text_files += 1;
+                corpus.documents.push(SweepDocument {
+                    input: InputDocument {
+                        label: path.display().to_string(),
+                        source,
+                        path: Some(path),
+                        decode,
+                    },
+                    line_offset: 0,
+                    dialect_override: Some("f5-irules"),
+                });
+            }
+            continue;
+        }
+
+        let blocks = extract_rst_irules(&source);
+        if blocks.is_empty() {
+            continue;
+        }
+        corpus.rst_files += 1;
+        corpus.rst_blocks += blocks.len();
+        for (block_index, block) in blocks.into_iter().enumerate() {
+            corpus.documents.push(SweepDocument {
+                input: InputDocument {
+                    label: format!("{}#irule-{}", path.display(), block_index + 1),
+                    source: block.source,
+                    path: Some(path.clone()),
+                    // The containing file was decoded above. Extracted text no
+                    // longer has a byte-for-byte range against the whole-file
+                    // decode report, so byte-integrity diagnostics abstain.
+                    decode: DecodeReport::default(),
+                },
+                line_offset: block.line_offset,
+                dialect_override: Some("f5-irules"),
+            });
+        }
+    }
+
+    if corpus.documents.is_empty() {
+        bail!("corpus contains no Tcl or iRules documents: {inputs:?}");
+    }
+    Ok(corpus)
+}
 
 /// One firing of a swept code.
 struct Firing {
@@ -123,22 +477,24 @@ fn shape_key(message: &str) -> String {
 ///    rather than diag.rs's simplified (non-interprocedural) one.
 /// 3. [`style_diagnostics`] — the pure-text W111/W112/W115/W118 checks,
 ///    which read raw source and are not part of either compiler pass.
-fn sweep_document(doc: &InputDocument, wanted: &[DiagCode], out: &mut Vec<Firing>) {
-    let dialect = doc.effective_dialect(None);
+fn sweep_document(doc: &SweepDocument, wanted: &[DiagCode], out: &mut Vec<Firing>) {
+    let dialect = doc
+        .dialect_override
+        .map_or_else(|| doc.input.effective_dialect(None), str::to_owned);
     let registry = registry_for_dialect(&dialect);
-    let line_index = LineIndex::new(&doc.source);
+    let line_index = LineIndex::new(&doc.input.source);
     let dialect_opt = (!dialect.is_empty()).then_some(dialect.as_str());
 
     let mut push = |code: DiagCode, span: tcl_lexer::Span, message: String| {
         if !wanted.contains(&code) {
             return;
         }
-        let pos = line_index.position_at_utf16(span.start(), &doc.source);
+        let pos = line_index.position_at_utf16(span.start(), &doc.input.source);
         out.push(Firing {
             code,
-            file: doc.label.clone(),
+            file: doc.input.label.clone(),
             dialect: dialect.clone(),
-            line: pos.line + 1,
+            line: pos.line + 1 + doc.line_offset,
             column: pos.character.get() + 1,
             message,
         });
@@ -146,7 +502,7 @@ fn sweep_document(doc: &InputDocument, wanted: &[DiagCode], out: &mut Vec<Firing
 
     // (1) Analyser tail.
     let analysis_cu = Arc::new(CompilationUnit::build_with_options(
-        &doc.source,
+        &doc.input.source,
         UnitBuildOptions {
             registry,
             defer_top_level: false,
@@ -156,9 +512,9 @@ fn sweep_document(doc: &InputDocument, wanted: &[DiagCode], out: &mut Vec<Firing
         },
     ));
     let mut analyser =
-        Analyser::new().with_file_path(doc.path.as_ref().map(|p| p.display().to_string()));
+        Analyser::new().with_file_path(doc.input.path.as_ref().map(|p| p.display().to_string()));
     analyser.set_cu_override(Arc::clone(&analysis_cu));
-    let result = analyser.analyse(&doc.source, &dialect);
+    let result = analyser.analyse(&doc.input.source, &dialect);
     for d in &result.diagnostics {
         push(d.code, d.span, d.message.clone());
     }
@@ -166,7 +522,7 @@ fn sweep_document(doc: &InputDocument, wanted: &[DiagCode], out: &mut Vec<Firing
     // (2) Compiler-checks + optimiser, over one interprocedural-summarised,
     // dialect-configured unit.
     let checks_cu = CompilationUnit::build_with_options(
-        &doc.source,
+        &doc.input.source,
         UnitBuildOptions {
             registry,
             defer_top_level: false,
@@ -187,19 +543,20 @@ fn sweep_document(doc: &InputDocument, wanted: &[DiagCode], out: &mut Vec<Firing
     // encoding-integrity set. W305 was already collected from the canonical
     // analyser producer in (1). No suppression / user-disabled set, since the
     // sweep wants every firing regardless of what a hypothetical editor config
-    // would silence.  The corpus is read through `read_input_documents`, so the
-    // document carries the byte-level decode report and the encoding findings
-    // come out at full precision (issue #1326).
+    // would silence. Native documents carry the byte-level decode report and
+    // therefore produce encoding findings at full precision (issue #1326).
+    // Extracted RST blocks use a faithful empty report because their offsets no
+    // longer refer to the containing file's byte stream.
     let no_disabled: std::collections::HashSet<String> = std::collections::HashSet::new();
     let no_suppressed: std::collections::HashMap<i32, std::collections::HashSet<String>> =
         std::collections::HashMap::new();
     for d in style_diagnostics(
-        &doc.source,
+        &doc.input.source,
         DEFAULT_LINE_LENGTH,
         DEFAULT_LINE_ENDING,
         &no_disabled,
         &no_suppressed,
-        Some(&doc.decode),
+        Some(&doc.input.decode),
     ) {
         let Ok(code) = DiagCode::from_str(d.code) else {
             continue;
@@ -209,9 +566,9 @@ fn sweep_document(doc: &InputDocument, wanted: &[DiagCode], out: &mut Vec<Firing
         }
         out.push(Firing {
             code,
-            file: doc.label.clone(),
+            file: doc.input.label.clone(),
             dialect: dialect.clone(),
-            line: d.range.start_line + 1,
+            line: d.range.start_line + 1 + doc.line_offset,
             column: d.range.start_character + 1,
             message: d.message,
         });
@@ -280,24 +637,122 @@ pub fn run(codes: &[String], corpus: &[PathBuf], examples: usize) -> Result<Exit
         .map(|c| DiagCode::from_str(c).map_err(|_| anyhow::anyhow!("unknown diagnostic code: {c}")))
         .collect::<Result<_>>()?;
 
-    let documents = read_input_documents(corpus, &[], true)
-        .map_err(|e| anyhow::anyhow!("{e}"))
-        .with_context(|| format!("reading corpus from {corpus:?}"))?;
+    let documents = read_corpus_documents(corpus)?;
 
     let mut firings: Vec<Firing> = Vec::new();
-    for doc in &documents {
+    for doc in &documents.documents {
         sweep_document(doc, &wanted, &mut firings);
     }
 
     println!(
-        "fp-sweep: {} file(s) scanned, {} code(s) requested, {} firing(s) found\n",
-        documents.len(),
+        "fp-sweep: {} file(s) scanned, {} code(s) requested, {} firing(s) found",
+        documents.source_files(),
         wanted.len(),
         firings.len()
     );
+    if documents.text_files != 0 || documents.rst_blocks != 0 {
+        println!(
+            "          embedded iRules: {} .txt file(s), {} block(s) from {} .rst file(s); {} analysis document(s)",
+            documents.text_files,
+            documents.rst_blocks,
+            documents.rst_files,
+            documents.documents.len()
+        );
+    }
+    println!();
 
     for code in &wanted {
         report_code(*code, &firings, examples);
     }
     Ok(ExitCode::SUCCESS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn irules_event_signal_accepts_clauses_but_rejects_prose_and_lowercase() {
+        assert!(has_irules_event("when HTTP_REQUEST {\n  pool web\n}\n"));
+        assert!(has_irules_event(
+            "  when CLIENT_ACCEPTED priority 500 timing on {\n}\n"
+        ));
+        assert!(has_irules_event("when ASM_REQUEST_VIOLATION\n{\n}\n"));
+        assert!(has_irules_event("when HTTP_REQUEST priority 500\n{\n}\n"));
+        assert!(!has_irules_event("Use `when HTTP_REQUEST {` here.\n"));
+        assert!(!has_irules_event("when http_request {\n}\n"));
+        assert!(!has_irules_event("whenever HTTP_REQUEST {\n}\n"));
+    }
+
+    #[test]
+    fn rst_extraction_handles_options_generic_blocks_and_original_lines() {
+        let rst = r"Heading
+-------
+
+.. code-block:: tcl
+   :linenos:
+   :emphasize-lines: 2
+
+   when HTTP_REQUEST priority 500 {
+       HTTP::redirect /
+   }
+
+Prose.
+
+.. code::
+
+  when CLIENT_ACCEPTED {
+      reject
+  }
+";
+
+        assert!(is_rst_code_directive(".. code-block:: tcl"));
+        assert!(has_irules_event(rst));
+        let blocks = extract_rst_irules(rst);
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0].line_offset, 7);
+        assert!(blocks[0].source.starts_with("   when HTTP_REQUEST"));
+        assert_eq!(blocks[1].line_offset, 15);
+        assert!(blocks[1].source.starts_with("  when CLIENT_ACCEPTED"));
+    }
+
+    #[test]
+    fn rst_extraction_skips_non_tcl_and_non_irules_code() {
+        let rst = r".. code-block:: console
+
+   when HTTP_REQUEST {
+   }
+
+.. code-block:: tcl
+
+   set ordinary_tcl 1
+
+.. code-block:: javascript
+
+   when HTTP_RESPONSE {
+   }
+";
+        assert!(extract_rst_irules(rst).is_empty());
+    }
+
+    #[test]
+    fn nested_rst_directive_keeps_its_body() {
+        let rst = r"#. Step
+
+   .. code-block:: irules
+
+      when RULE_INIT {
+          set static::enabled 1
+      }
+
+   Continue the step.
+";
+        assert!(is_rst_code_directive("   .. code-block:: irules"));
+        assert!(has_irules_event(rst));
+        let blocks = extract_rst_irules(rst);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].line_offset, 4);
+        assert!(blocks[0].source.contains("when RULE_INIT"));
+        assert!(!blocks[0].source.contains("Continue"));
+    }
 }

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -226,7 +226,8 @@ enum Command {
         #[arg(long = "code", required = true)]
         codes: Vec<String>,
         /// Corpus directory or file to sweep (repeatable). A directory is
-        /// walked recursively for Tcl/iRules source files.
+        /// walked recursively for Tcl/iRules source files, direct `.txt`
+        /// iRules, and iRules code blocks embedded in `.rst` documents.
         #[arg(long = "corpus", required = true)]
         corpus: Vec<PathBuf>,
         /// Sample locations printed per message shape.

--- a/scripts/dev/fetch-irules-corpus.sh
+++ b/scripts/dev/fetch-irules-corpus.sh
@@ -52,24 +52,18 @@ done
 echo
 echo "==> corpus at $DEST"
 
-# Only these extensions reach `xtask fp-sweep`; it walks a directory for
-# recognised Tcl/iRules source files and errors on a directory with none.
-# Two repos hold real iRules the sweep therefore cannot see as-is:
-#   f5devcentral/f5-agility-labs-irules -- ~31 iRules embedded in .rst lab docs
-#   f5devcentral/irules-toolbox         -- ~186 iRules as .txt snippets
-# Extracting those into sweepable files is not done here; see the corpus note
-# in docs/design/compiler/fp-audit-todo.md.
+# `xtask fp-sweep` also recognises direct `.txt` iRules and iRules-bearing
+# reStructuredText `code` / `code-block` directives. The extension count below
+# remains useful as the native-source subset; the event-signature count covers
+# every publication format.
 sweepable=$(find "$DEST" -type f \( -name '*.tcl' -o -name '*.irule' -o -name '*.irul' \) \
   -not -path '*/.git/*' 2>/dev/null | wc -l | tr -d ' ')
 witheventsig=$(grep -rlE '^[[:space:]]*when[[:space:]]+[A-Z][A-Z0-9_]*' "$DEST" \
   --exclude-dir=.git 2>/dev/null | wc -l | tr -d ' ')
-echo "    $sweepable file(s) with a sweepable extension (.tcl/.irule/.irul)"
+echo "    $sweepable native source file(s) (.tcl/.irule/.irul)"
 echo "    $witheventsig file(s) carrying a 'when EVENT' signature (any extension)"
 echo
 echo "Sweep the iRules diagnostic family with, e.g.:"
 echo "  cargo xtask fp-sweep --code IRULE1002 --code IRULE1003 \\"
 echo "    --code IRULE1004 --code IRULE1005 \\"
 echo "    \$(for d in $DEST/*/; do echo --corpus \"\$d\"; done)"
-echo
-echo "NOTE: pass only directories that contain a sweepable extension — fp-sweep"
-echo "errors out on a directory with no recognised Tcl source files."


### PR DESCRIPTION
Closes #1316.

## Summary
- complete the native corpus sweep, including direct text and RST-embedded iRules
- correct registry-driven iRules arity metadata for `pool`, `log`, and `class` iteration forms
- load nearest sidecar stubs and suppress only exact overlapping W110/O120 diagnostics

## Validation
- `make prep-pr`
- `make check-rust`
- `make test` (clean rerun; VS Code suite 890 passing)
- focused iRules corpus sweep: 416 recognised native files; only 10 intentional/genuine residual diagnostics
- `make test-emacs`: known upstream Eglot cases remain XFAIL; initial run was blocked by the host's 256-FD watcher limit