### PR TITLE
docs: record the legacy-duplication audit notes backing #1400

### DIFF
--- a/docs/audits/legacy-duplication-2026-08/README.md
+++ b/docs/audits/legacy-duplication-2026-08/README.md
@@ -1,0 +1,73 @@
+# Legacy duplication audit — August 2026
+
+> **TEMPORARY — DELETE THIS DIRECTORY WHEN EVERY ISSUE LISTED BELOW IS CLOSED.**
+>
+> These are working notes, not documentation. They exist only to carry detail
+> that did not fit into the issues they back — verified-clean lists, rejected
+> candidates, and the full reasoning behind each finding. Once the issues are
+> closed the notes are stale by definition: they describe code that no longer
+> exists, and a future reader cannot tell which parts were fixed. Delete the
+> whole directory, including this README, rather than trying to prune it.
+>
+> Tracking issue: **#1400**. When #1400 closes, this directory goes with it.
+
+## What this is
+
+Six read-only audits run in parallel after PR #1371, which found the
+optimiser's redundancy family answering one semantic question — "can Tcl's
+mutable dispatch machinery observe this call site?" — in two places: a legacy
+command-string classifier and a modern typed per-site proof. GVN was migrated
+to the proof; PRE and LICM were left on the legacy classifier, which was
+unsound.
+
+Each audit hunted the same shape in a different subsystem: a shared authority
+exists, most consumers adopt it, one or two do not, and nothing detects the
+stragglers.
+
+Every finding cites `file.rs:line` on both the modern and the legacy side.
+Four of the six audits additionally reproduced their findings against a
+locally built `tcl` binary; those reports quote the command and its output
+inline.
+
+## Reports and the issues they back
+
+| Report | Scope | Issues |
+|---|---|---|
+| [`optimiser.md`](optimiser.md) | Optimiser passes and the analyses feeding them | #1374, #1377, #1385, #1392 |
+| [`analyser.md`](analyser.md) | Analyser, semantic model, registry compliance | #1378, #1379, #1381, #1388, #1389, #1390, #1391 |
+| [`lowering.md`](lowering.md) | Parsing, CST, segmenter, IR, CFG, SSA, codegen | #1375, #1376, #1380, #1393 |
+| [`lsp.md`](lsp.md) | LSP feature providers | #1386 |
+| [`runtime.md`](runtime.md) | `runtime/rust`, `tcl-vm`, `tcl-cmd-core`, parity gate | #1382, #1383, #1384 |
+| [`tooling.md`](tooling.md) | CLIs, MCP, xtask generators, editor integrations | #1387, #1394 |
+
+Finding IDs inside each report (`F1`, `F2`, …) are local to that report and
+are referenced from the issues.
+
+Issues **#1395**, **#1396**, and **#1397** are carried forward from PR #890
+rather than found by these audits, and **#1398** and **#1399** come from
+#1371's own "known limitations" — none of those five is backed by a report
+here.
+
+## What these notes contain that the issues do not
+
+- **Verified-clean lists.** Each report records the subsystems checked with
+  nothing to report, and why. That is the part most expensive to reproduce
+  and most useful to a future auditor deciding where to look.
+- **Rejected candidates.** Findings considered and dismissed, with the reason
+  — including AGENTS.md's documented carve-outs (the lowering
+  fallback-to-generic-call pattern; the irreducible analyser-local TclOO
+  semantics) and debt already tracked at its call site, such as
+  `alias.rs:201-223`.
+- **Confidence and scale estimates** per finding.
+
+## Caveats
+
+These are agent-produced audit notes reviewed for evidence quality, not
+maintained documentation. They were accurate against the tree at
+`0f97d98` and are not updated as the code moves. Where a report and the code
+disagree, the code is right.
+
+One finding is explicitly scoped as a hazard rather than a live defect:
+`first_positional_index`'s five hand-rolled copies (#1395) were verified to
+exist, but no input was found where they currently produce a wrong answer.
+The live version of that fault is #1378.

--- a/docs/audits/legacy-duplication-2026-08/analyser.md
+++ b/docs/audits/legacy-duplication-2026-08/analyser.md
@@ -1,0 +1,587 @@
+# Analyser / semantic-model layer — legacy duplication audit
+
+Branch `claude/legacy-code-duplication-audit-edm0bo`. Scope: `rust/tcl-compiler/src/analyser/**`
+plus the listed semantic-model modules, audited against `rust/tcl-registry/src/`.
+
+Findings are ranked strongest-first. Line numbers are as of the audited tree.
+
+---
+
+## F1: `switch` clause-list layout is hand-rolled in three analyser sites that all mis-parse value-taking options, while `CaseListSpec::invocation` already answers it
+
+**Confidence:** high
+**Category:** half-ported
+
+**Where the knowledge lives now:**
+- `rust/tcl-compiler/src/analyser/commands.rs:4655` — `let switch_list_idx = if name == "switch" { switch_list_body_index(&args) }`, gated on the literal command name.
+- `rust/tcl-compiler/src/analyser/commands.rs:4856-4870` — `switch_list_body_index`: an option skip that advances **one** word per `-flag`, then assumes the next word is the subject.
+- `rust/tcl-compiler/src/analyser/commands.rs:4904-4911` — `switch_arm_bodies`: the identical broken skip, consumed by `tcl_lsp_core::references::scan_my_method_region`.
+- `rust/tcl-compiler/src/analyser/diagnostics/usage.rs:718-733` — `emit_w106_unbraced_switch_body`: a third copy of the same skip, plus its own `-regexp` sniff.
+
+**Where it should live / what already exists:**
+- `rust/tcl-registry/src/spec.rs:390-490` — `CaseListSpec::invocation()` returns `CaseInvocation { subject_index, clause_list_index, inline_clause_start, mode, nocase }`. It consumes value-taking options via `OptionSpec::value_word_count`, implements the Tcl 8.5+ two-argument exception, validates pair parity and the `fallthrough_body` marker.
+- `rust/tcl-registry/src/registry.rs:1721-1734` — `CommandRegistry::case_invocation(name, args, dialect)`, the dialect-aware entry point.
+- `rust/tcl-registry/src/commands/tcl/switch_.rs:258` — `case_list: Some(&CaseListSpec::SWITCH)`.
+- The migrated twin: `rust/tcl-compiler/src/analyser/handlers.rs:4258-4262` — `handle_switch_command` already calls `registry.case_invocation(...)` and drives both forms off `invocation.clause_list_index` / `inline_clause_start`, naming no command.
+
+**Drift evidence:**
+1. `switch -matchvar m -- $s {a {puts A} b {puts B}}` (args = `["-matchvar","m","--","$s","{…}"]`).
+   `switch_list_body_index` breaks its option loop on `m` (which does not start with `-`), then treats `m`
+   as the subject, computes `i == 2`, finds `2 != len-1 == 4`, and returns `None`. The registry's
+   `CaseListSpec::invocation` consumes `-matchvar m` as an option+value and answers `clause_list_index = 4`.
+   With `None` returned, `commands.rs:4666` descends the clause list as a **plain script**, so `a` and `b`
+   are read as command heads. `switch_arm_bodies` and `emit_w106_unbraced_switch_body` fail the same way.
+   The registry's own `switch_arg_roles` (`rust/tcl-registry/src/commands/tcl/switch_.rs:57-99`) *does*
+   handle the value options (via its private `SWITCH_VALUE_OPTIONS` at line 50), so it still reports the
+   clause list as `ArgRole::Body` — the generic body descent walks it while the switch-aware path declines.
+2. `switch_arm_bodies`' doc comment (`commands.rs:4884-4889`) claims it "matches
+   `Analyser::handle_switch_command`'s own form-1/form-2 branching exactly … so the two can never
+   disagree about where an arm's body starts and ends." That is no longer true: `handle_switch_command`
+   was migrated to `case_invocation`, these were not.
+3. Six other specs carry `case_list` — `rust/tcl-registry/src/commands/expect/{expect_cmd,expect_after,expect_before,expect_user,expect_tty,expect_background}.rs`
+   (`CaseListSpec::EXPECT`). `tcl-lsp-core` handles them generically (folding.rs:441, semantic_tokens.rs:3376,
+   references.rs:3053, minify.rs:37), but every analyser site above is `switch`-only, so Expect clause
+   lists get no clause-aware analysis at all.
+
+**Why it matters:** with a `-matchvar`/`-indexvar` switch (the standard `-regexp` capture idiom), the
+W123 unresolved-command pass reads every arm *pattern* as a command head and emits a spurious
+"unknown command" for each one; arm bodies are simultaneously walked in the wrong structural context.
+`switch_arm_bodies`' breakage silently drops `my <method>` call sites inside such a switch from
+`textDocument/references`. W106 (unbraced switch body) stops firing on the same calls.
+
+**What cleanup looks like:** delete `switch_list_body_index` and rewrite `switch_arm_bodies` and
+`emit_w106_unbraced_switch_body` on `registry.case_invocation(cmd_name, &args, mask)`, keying the
+clause-list branch on `invocation.clause_list_index` and the inline branch on `inline_clause_start`,
+and taking `-regexp`-ness from `invocation.mode == CaseMatchMode::Regexp` rather than a literal flag
+scan. Drop the `name == "switch"` gate at `commands.rs:4655` in favour of
+`registry.get(name).and_then(|s| s.case_list).is_some()`. Then stamp
+`AnalyserHookId::Switch` onto the six `expect*` specs — `handle_switch_command`'s body is already
+command-agnostic, so nothing else changes.
+
+**Scale:** ~150 lines removed across three call sites, one hook stamp per Expect spec, plus tests
+pinning `switch -matchvar m -- $s {…}` and one Expect clause list.
+
+---
+
+## F2: `upvar`'s level word is detected by sniffing the word's text in two analyser sites, contradicting the registry's `FrameLevelWord::ArityParity` rule
+
+**Confidence:** high
+**Category:** stale-consumer
+
+**Where the knowledge lives now:**
+- `rust/tcl-compiler/src/var_scoping.rs:310-319` — `looks_like_level(head)`: true for a decimal integer,
+  an optionally `-`-prefixed integer, or `#<digits>`. Consumed at `var_scoping.rs:133` and `:180`.
+- `rust/tcl-compiler/src/analyser/diagnostics/usage.rs:1554-1568` — `upvar_local_name_positions`: a
+  *second, differently-spelled* text sniff (`head.starts_with('#') || all-digits after stripping every
+  leading '-')`, reached from `Analyser::variable_name_positions` (`usage.rs:836`).
+
+**Where it should live / what already exists:**
+- `rust/tcl-registry/src/frame_effect.rs:234-253` — `FrameLevelWord::ArityParity`, with the pinned
+  tclsh 9.0.4 / 8.6.14 table and the explicit warning: *"A text-sniffing consumer gets the third and
+  fourth rows backwards: it drops a real binding for `upvar $lvl a b` (the commonest by-reference idiom
+  of all) and invents a level for `upvar 1 b`."*
+- `rust/tcl-registry/src/frame_effect.rs:344-385` — `FrameEffectSpec::level_word_len` / `resolve`.
+- `rust/tcl-registry/src/commands/tcl/upvar_.rs:187` — `frame_effect: Some(UPVAR_FRAME_EFFECT)`.
+- The migrated twin: `rust/tcl-compiler/src/analyser/param_traits.rs:938-961` — `upvar_level_and_pairs`
+  queries `registry.frame_effect("upvar")`, and its doc says the rule "lives in the registry … queried
+  here through the spec rather than re-derived, **so this stays the one description of `upvar`'s
+  shape** (issue #1069)". Other migrated consumers: `cfg_builder/upvar_info.rs:501`,
+  `dynamic_names.rs:658`, `tcl-lsp-core/src/semantic_tokens.rs:1669`.
+
+**Drift evidence:** for `upvar $lvl a b` (3 words ⇒ parity says `$lvl` is the level, pair is `(a, b)`,
+local is `b` at index 2):
+- `upvar_local_declaration_indices("upvar", ["$lvl","a","b"])` — `looks_like_level("$lvl")` is false,
+  offset 0, pair `("$lvl","a")` is skipped for its `$` source, loop ends. Returns `[]` — the `b`
+  binding is lost entirely.
+- `upvar_local_alias_indices` on the same input returns `[1]` — it declares **`a`** the local alias,
+  which is the wrong word.
+- `upvar_local_name_positions(["$lvl","a","b"])` returns `[1]` — also `a`.
+For `upvar 1 b` (2 words ⇒ parity says no level, `1` is the *otherVar*, `b` is the local at index 1),
+`looks_like_level("1")` is true, offset 1, no complete pair remains, so the result is `[]`.
+Both rows are verbatim the two the registry doc names as the ones text sniffing gets backwards.
+`frame_effect.rs:36-38` records that three copies of the level rule had already drifted before the
+descriptor existed, "two of them wrong" — two are still here.
+
+**Why it matters:** `var_scoping`'s helpers are the shared home for scope-alias declarations. Wrong
+answers propagate to `textDocument/declaration` (`tcl-lsp-core/src/declaration.rs:39`, which
+go-to-declarations `a` instead of `b`), the memory-SSA alias detector
+(`var_escape/handlers.rs:186`, `var_escape/cfg_propagation/handlers.rs:184`), `place_bridge.rs:156`,
+`cfg_builder/global_write_info.rs:388`, and dead-store elimination
+(`optimiser/elimination.rs:1290`). A missed `upvar $lvl a b` alias means the optimiser does not know
+`b` is observable in another frame — the same soundness shape as PR #1371. W212's name-position check
+flags the wrong argument.
+
+**What cleanup looks like:** delete `looks_like_level` and `upvar_local_name_positions`; have
+`upvar_local_declaration_indices` / `upvar_local_alias_indices` take the registry (they already take
+it indirectly through `scope_alias_*`) and derive the offset from
+`registry.frame_effect("upvar").level_word_len(&refs)`, exactly as `param_traits::upvar_level_and_pairs`
+does. `var_escape/handlers.rs:168` and `cfg_propagation/handlers.rs:172` then drop their
+`looks_like_level` imports.
+
+**Scale:** ~60 lines deleted, three call sites rewritten, plus fixing the `var_scoping.rs:548-559`
+and `tests/alias_scoping.rs:444+` tests that currently pin the wrong behaviour.
+
+---
+
+## F3: `RepeatedArgLayout::optional_leading_word` was built for `upvar` and is set by no spec; `var_scoping` still hand-rolls all four alias layouts the registry already declares
+
+**Confidence:** high
+**Category:** half-ported
+
+**Where the knowledge lives now:**
+`rust/tcl-compiler/src/var_scoping.rs:248-262` and `:285-301` — after a registry-driven recognition
+step (`is_scope_alias_call`, `var_scoping.rs:210-227`, which correctly reads `Traits::CREATES_SCOPE_ALIAS`
+and `SubCommand::creates_scope_alias`), the *layout* is dispatched by a literal name match:
+
+```rust
+match canonical {
+    "global"   => global_declaration_indices(args),
+    "variable" => variable_declaration_indices(args),
+    "upvar" | "namespace" | "namespace upvar" => upvar_local_alias_indices(canonical, args),
+    _ => { /* registry ArgRole::VarWrite query */ }
+}
+```
+
+The three hand-rolled parsers are `var_scoping.rs:41-47`, `:59-69`, `:119-154` / `:167-197`.
+
+**Where it should live / what already exists:**
+- `rust/tcl-registry/src/repeated.rs` — the whole module exists for exactly this family. Its header
+  (lines 19-38) names `global a b c`, `variable n v n v`, `namespace upvar NS o l o l` and records
+  that "every LSP consumer that needed one of these layouts therefore re-derived it by hand from the
+  command's *name*" (issue #1185).
+- Already declared: `global_.rs:102` + `:133` (`RepeatedArgLayout::every(VarWrite, 0)`),
+  `variable_.rs:164` (`strided(VarWrite, 0, 2)`), `namespace_.rs:1056`
+  (`strided(VarWrite, 2, 2)` for `namespace upvar`).
+- `RepeatedArgLayout` feeds `CommandRegistry::arg_indices_for_role`, which the `_` arm above
+  already uses for `my variable`.
+
+**Drift evidence:** `rust/tcl-registry/src/repeated.rs:62-71` documents `optional_leading_word`
+with `upvar`'s `?level?` as its sole motivating case, and `repeated.rs:193-206`
+(`optional_leading_word_shifts_by_the_argument_count`) unit-tests it against
+`upvar ?level? other local` with the parity-correct answers. **No `CommandSpec` in
+`rust/tcl-registry/src/commands/` sets the flag** — `grep -rn 'optional_leading_word' commands/`
+returns nothing, and `upvar_.rs` declares neither `arg_roles` nor `repeated_args`. The registry
+feature was built, documented, and tested for `upvar`, then never wired to `upvar`'s spec, so
+`var_scoping` had nothing to migrate to and kept its parser. `diagnostics/usage.rs:832-836` even
+documents the gap as intentional ("the registry deliberately omits its roles"), which is how the
+`ArityParity` bug in F2 survives.
+
+**Why it matters:** four distinct grammars (`global`, `variable`, `upvar`, `namespace upvar`) with
+five consumers each are maintained in analyser code that the registry can already describe as data.
+Adding a fifth alias-creating command — a dialect's `::ns::localise`, say — requires editing
+`var_scoping.rs` twice, defeating the `CREATES_SCOPE_ALIAS` recognition work that was already done.
+Fixing F2 without doing this leaves the parity rule in two places (`frame_effect` and `repeated_args`).
+
+**What cleanup looks like:** add `repeated_args: &[RepeatedArgLayout { optional_leading_word: true,
+..RepeatedArgLayout::strided(ArgRole::VarWrite, 1, 2) }]` to `upvar_.rs`, then collapse both
+`scope_alias_*_indices` match arms to a single `registry.arg_indices_for_role(command, &args,
+ArgRole::VarWrite)` call, keeping only the two `$`-filters (the observability flavour keeps a local
+whose *source* substitutes; the navigation flavour does not) as post-filters over the returned indices.
+`global_declaration_indices` / `variable_declaration_indices` / `upvar_local_*_indices` and their
+duplicate callers in `place_bridge.rs`, `var_escape/handlers.rs`, `cfg_propagation/handlers.rs`,
+`cfg_builder/global_write_info.rs` all become one registry query.
+
+**Scale:** one registry field addition plus ~200 lines of parser and its mirrored tests deleted
+across six modules. Do it together with F2.
+
+---
+
+## F4: `irules_event_checks::var_write_index` is the hardcoded variable-write name table that `param_traits` already deleted as "a redundant duplicate of the registry query"
+
+**Confidence:** high
+**Category:** duplicated-table
+
+**Where the knowledge lives now:**
+`rust/tcl-compiler/src/analyser/irules_event_checks.rs:143-152`:
+
+```rust
+fn var_write_index(cmd_name: &str) -> Option<usize> {
+    match cmd_name {
+        "append" | "const" | "global" | "incr" | "lappend" | "ledit" | "lpop" | "lset" | "set"
+        | "unset" | "variable" => Some(0),
+        "array" | "gets" => Some(1),
+        _ => None,
+    }
+}
+```
+Consumed at `:170`, `:182`, `:812`, `:843`.
+
+**Where it should live / what already exists:**
+`CommandRegistry::arg_indices_for_role(cmd, &args, ArgRole::VarWrite)` — the same query the sibling
+module already uses. `rust/tcl-compiler/src/analyser/param_traits.rs:645-656` documents the removal
+of *its* copy verbatim: *"The old hardcoded `var_write_index` name list was a redundant duplicate of
+that registry query and has been removed."* Same query in `auto_path_eval.rs:676`,
+`var_scoping.rs:256`, `diagnostics/usage.rs:845`.
+
+**Drift evidence:** the hardcoded set names 13 commands. 33 spec files under
+`rust/tcl-registry/src/commands/` declare `ArgRole::VarWrite`. Commands the set misses that are live
+in the iRules dialect: `catch` (`catch_.rs`), `lassign` (`lassign.rs`), `scan` (`scan_.rs`),
+`binary scan` (`binary_.rs`), `regexp` (`regexp_.rs`), `regsub` (`regsub_.rs`), `dict` (`dict.rs`),
+`string` (`string_.rs`), `chan`, `info`, `vwait`, `trace`, `upvar`, `namespace upvar`
+(`namespace_.rs:1056`), and `foreach`/`lmap` loop variables. Conversely the two-index arm (`"array" |
+"gets" => Some(1)`) is unconditional, so `array names ::x` is read as a write to `::x`.
+
+**Why it matters:** IRULE6001 (global-variable CMP pinning) and its RULE_INIT implicit-global variant
+are silent for `catch {…} ::err`, `lassign $l ::a ::b`, `regexp $re $s ::m`, `scan $s $f ::v`, and
+`binary scan $d $f ::v` — all of which really do pin the virtual server to one TMM. The false
+positive on `array names ::x` produces a code fix that rewrites a *read* into `static::x`.
+
+**What cleanup looks like:** replace `var_write_index` with a helper returning **all**
+`ArgRole::VarWrite` indices from the registry (`Vec<usize>`, not `Option<usize>`), and let
+`global_var_from_command` / `implicit_global_var_from_command` / the two fix-span lookups iterate
+them. The special-cases at `:184-193` (`set` with one arg is a read; `unset` destroys; `array`
+without `set`) all disappear, because `set`'s and `array`'s `arg_role_resolver`s and `unset`'s
+`DESTROYS_VARIABLE` already encode them.
+
+**Scale:** ~40 lines, one module, plus IRULE6001 test cases for `catch`/`lassign`/`regexp`.
+
+---
+
+## F5: `when` is matched by literal name in three places in `irules_event_checks`, including a raw-source brace scanner that is the third copy of the `when EVENT` grammar
+
+**Confidence:** high
+**Category:** stale-consumer
+
+**Where the knowledge lives now:**
+- `rust/tcl-compiler/src/analyser/irules_event_checks.rs:486` (`if cmd_name != "when"`, IRULE1002
+  unknown-event check) and `:597` (the second `when` gate).
+- `rust/tcl-compiler/src/analyser/irules_event_checks.rs:870-948` — `scan_when_blocks`, a byte-level
+  `\bwhen\s+[A-Z_][A-Z0-9_]*` scan with its own `priority N` / `timing …` skip and its own
+  balanced-brace body extractor, run over `self.source` from inside IRULE4003
+  (`:749`) — i.e. re-scanning the whole document from a handler the segmenter already walked.
+
+**Where it should live / what already exists:**
+- `rust/tcl-registry/src/commands/irules/when.rs:72` — `Traits::IS_EVENT_HANDLER`, the registry's
+  answer to "which command opens an event body".
+- Migrated consumers, all of which explicitly say so: `rust/tcl-compiler/src/analyser/commands.rs:1900-1909`
+  ("Registry facts, not command names (gap-review C3). The event handler is whatever carries
+  `IS_EVENT_HANDLER` — `when` today, but a dialect that adds another gets the same treatment without
+  an edit here"), `tcl-lsp-core/src/completion.rs:474`, `tcl-lsp-core/src/semantic_tokens.rs:1497`.
+- The body text is already in hand structurally: `commands.rs:1909-1930` sets `self.current_event`
+  and descends the registry-resolved `ArgRole::Body`, so the analyser walks each `when` body once
+  already.
+
+**Drift evidence:** `scan_when_blocks` is a *third* implementation of the same regex-free scan —
+`rust/tcl-registry/src/events.rs:975-1015` (`scan_when_events`) and
+`rust/tcl-registry/src/profiles.rs:339-368` (`scan_file_events`) are the other two. They already
+disagree in scope: only the analyser copy handles `priority`/`timing` words, only the analyser copy
+extracts bodies, and only the registry copies deduplicate. None of the three respects comments,
+quoting, or `\{` inside a body, so a `when` in a `#` comment or a string literal produces a phantom
+event block. `irules_event_checks.rs:445-448` in the same file *does* use the registry
+(`is_irules_top_level_only`), so the file is half-migrated.
+
+**Why it matters:** IRULE4003 (cross-event variable scoping) is computed off a text scan rather than
+the event bodies the analyser already visited, so a `when` inside a comment or a braced string
+invents a phantom event and a spurious hint, while a `when` written through an alias or with an
+unusual `timing`/`priority` spelling is dropped. IRULE1002 (unknown event name) never fires for a
+future dialect's second event-handler command even though its spec would carry `IS_EVENT_HANDLER`.
+
+**What cleanup looks like:** replace both `cmd_name != "when"` gates with
+`spec.traits.contains(Traits::IS_EVENT_HANDLER)`, exactly as `commands.rs:1909` does. Replace
+`scan_when_blocks` by accumulating `(event, body_text)` during the existing structural walk — the
+analyser already knows `self.current_event` and the body span — so IRULE4003 consults a map built
+from the CST instead of re-scanning source. Then delete `scan_when_blocks` and its tests.
+
+**Scale:** ~90 lines deleted, one accumulator field added to the iRules check state.
+
+---
+
+## F6: `inline_uplevel`'s frame-reach guard is a two-name `matches!` where `CommandSpec::frame_effect` is the typed descriptor, and it reads the surface spelling instead of the canonical command
+
+**Confidence:** medium
+**Category:** stale-consumer
+
+**Where the knowledge lives now:**
+- `rust/tcl-compiler/src/inline_uplevel.rs:192-198` — `statement_has_frame_reach`:
+  `Statement::Barrier { command, .. } | Statement::Call { command, .. } if matches!(command.as_str(), "uplevel" | "upvar")`.
+- `rust/tcl-compiler/src/inline_uplevel.rs:155` — `if cmd != "uplevel" { return None; }` and
+  `:164` — `2 if args[0] == "1"`, a literal level-word test.
+
+**Where it should live / what already exists:**
+- `CommandSpec::frame_effect` (`rust/tcl-registry/src/spec.rs:620`) and the four frame traits
+  (`ALIASES_CALLER_FRAME`, `CURRENT_FRAME_INTROSPECTION`, `EVALUATES_IN_SHIFTED_FRAME`,
+  `REPLACES_FRAME`, `rust/tcl-registry/src/traits.rs`). Carriers today:
+  `commands/tcl/uplevel_.rs:166`, `commands/tcl/upvar_.rs:187`, `commands/tcl/eval_.rs:82`,
+  **`commands/argparse/command.rs:266`** (`FrameArgLayout::OpaqueCallerVars` — "injects variables into
+  the frame of **its own caller** under names it derives from an argument mini-language this analysis
+  does not interpret … a consumer must widen rather than enumerate"), plus
+  `commands/tcl/tailcall_.rs` (`REPLACES_FRAME`) and `commands/tcl/info_.rs`
+  (`CURRENT_FRAME_INTROSPECTION`).
+- `FrameLevel::parse` / `FrameEffectSpec::resolve_for_version` (`frame_effect.rs:127`, `:395`) for the
+  level word, already used by `var_escape/walker.rs:269` and `var_observability.rs:131`.
+- `Statement::canonical_command_or_source()` (`rust/tcl-compiler/src/ir.rs:1225`), whose doc says
+  "Use from downstream dispatch sites … so a single canonical key drives every consumer".
+
+**Drift evidence:** `argparse` carries a `frame_effect` whose whole point is that its caller-frame
+writes are unknowable, and the guard does not see it. Neither does `tailcall` nor `info level` /
+`info frame`. The surface-vs-canonical split is visible within the same crate: three diagnostics
+modules check both spellings — `diagnostics/helpers.rs:444`
+(`canonical_command.as_deref() == Some("::unset") || command == "unset"`),
+`diagnostics/var_command.rs:2675`, `diagnostics/dataflow.rs:1536-1537` — while `inline_uplevel.rs`
+checks only `command`. `uri_split.rs:66-71` documents the rule the guard breaks: "the SSA / IR layer
+preserves the surface text — so detection helpers must accept both". A body containing
+`::uplevel 1 {…}` therefore passes the guard. `connection_scope.rs:245`
+(`command == "unset"`) has the same surface-only defect.
+
+**Why it matters:** O-code "inline an `uplevel` passthrough proc" is a *rewriting* transform, so
+missing a frame reach in the body is a miscompile, not a missed optimisation — the PR #1371 shape.
+`proc P {b} {uplevel 1 $b}` invoked with a body that calls `argparse`, `tailcall`, or `::uplevel`
+is inlined today.
+
+**What cleanup looks like:** thread the registry into `body_has_frame_reach` (its callers already
+have one) and replace the `matches!` with
+`registry.get(stmt.canonical_command_or_source()).is_some_and(|s| s.frame_effect.is_some() || s.traits.intersects(FRAME_REACH_TRAITS))`,
+where `FRAME_REACH_TRAITS` is a registry-side composite constant. Replace the
+`cmd != "uplevel"` / `args[0] == "1"` pair with
+`registry.frame_effect(canonical).resolve(&refs)` and a `FrameLevel::Relative(1)` test. Fix
+`connection_scope.rs:245` to read `canonical_command_or_source()` at the same time.
+
+**Scale:** ~30 lines plus a registry composite-trait constant; one new inline-refusal test per
+missed carrier.
+
+---
+
+## F7: W231 recovers a list length by byte-scanning the source for `set var {literal}` with a hardcoded scope-marker name list, next to the segmenter it could have used
+
+**Confidence:** medium
+**Category:** stale-consumer
+
+**Where the knowledge lives now:**
+`rust/tcl-compiler/src/analyser/bounds_checks.rs`:
+- `:706-747` — `infer_list_length_from_recent_set`, a line-anchored raw-byte scan for
+  `(?:^|\n)\s*set\s+(\w+)\s+(\{[^{}]*\})\s*(?=\n|$|;)` over the whole source before the `lset`.
+- `:757-824` — `match_set_literal`, which hardcodes the byte string `"set"` and the argument layout.
+- `:829-855` / `:857-895` — `scope_is_flat` / `has_scope_marker`, a second raw scan for the literal
+  words `proc`, `apply`, `try`, and `namespace` followed by `eval`.
+
+**Where it should live / what already exists:**
+- The segmenter is already imported and used **in the same file**:
+  `bounds_checks.rs:506-522` (`any_command_recursive`) walks `segment_commands(script)` and recurses
+  into braced words structurally.
+- The registry answers every fact the byte scan re-derives: `set`'s write position via
+  `arg_indices_for_role(.., ArgRole::VarWrite)` (`set_.rs`), whether a command opens a definition
+  scope via `Traits::DEFINES_PROCEDURE` / `CommandSpec::definition_body` — the exact pair
+  `commands.rs:4843-4850` (`definition_handler_owns_body`) already uses — and body arguments via
+  `ArgRole::Body`.
+- Constant list values are already modelled: `crate::analyses::ConstValue` / the SCCP lattice, and
+  `auto_path_eval.rs` runs a full segmenter-based constant-assignment collector
+  (`collect_writes`, `auto_path_eval.rs:491`).
+
+**Drift evidence:** `has_scope_marker`'s four names are a strict subset of what the registry marks.
+It misses `oo::define` / `oo::class create` bodies, snit/itcl definer bodies (all of which carry
+`definition_body`), `coroutine`, `interp eval`, and any `eval`/`uplevel` body — so a `set x {a b c}`
+inside an `oo::define ... method` body followed by an `lset` outside it is treated as sharing one
+flat scope. It also matches the words inside comments and string literals, since it never
+segments.
+
+**Why it matters:** W231 (`lset` index out of range) can fire on an index that is in range for the
+list actually reaching the `lset`, and stays silent when the two really do share a scope but the
+`set` was not written at a line start or used a non-`{}` literal. The whole mechanism is a
+worse-than-SSA answer to a question SCCP already computes.
+
+**What cleanup looks like:** drop the four byte scanners and take the list length from the SSA/SCCP
+constant lattice for the `lset` target's reaching definition, the way `path_concat.rs` and
+`uri_split.rs` already consume `crate::analyses::LatticeValue`. If a lattice value is not
+threaded into `bounds_checks` today, the intermediate step is to reuse `segment_commands` plus
+`arg_indices_for_role(ArgRole::VarWrite)` and `definition_handler_owns_body` instead of the byte
+scans — which removes the hardcoded name list even before the SSA move.
+
+**Scale:** ~190 lines removed; the SSA-backed version is a larger refactor than the
+segmenter-backed intermediate.
+
+---
+
+## F8: `oo.rs`'s unknown-handler analysis keys on a literal `CHAIN_TARGETS` list plus `"exec"` / `"auto_load"`, while two sibling modules read the same fact from registry traits
+
+**Confidence:** medium
+**Category:** duplicated-table
+
+**Where the knowledge lives now:**
+- `rust/tcl-compiler/src/analyser/oo.rs:76-82` — `const CHAIN_TARGETS: &[&str] = &["_original_unknown",
+  "_orig_unknown", "::tcl::unknown", "tcl::unknown", "original_unknown"]`.
+- `rust/tcl-compiler/src/analyser/oo.rs:1996-2003` — `walk_unknown_stmt`:
+  `if CHAIN_TARGETS.contains(&command.as_str()) { … } else if command == "exec" { … } else if command == "auto_load" { … }`,
+  reading the bare `command` field of `Statement::Call`/`Barrier`.
+
+**Where it should live / what already exists:**
+- `Traits::UNRESOLVED_COMMAND_HANDLER` — `rust/tcl-registry/src/commands/tcl/unknown.rs:173`.
+- `Traits::LOADS_EXTERNAL_UNIT` — `rust/tcl-registry/src/commands/tcl/auto_load.rs:56`.
+- `exec`: `Traits::UNSAFE` + a `SideEffectTarget::Process` side effect
+  (`rust/tcl-registry/src/commands/tcl/exec_.rs:48-56`).
+- `Statement::canonical_command_or_source()` — `rust/tcl-compiler/src/ir.rs:1225`.
+- The migrated twins, both with doc comments saying so:
+  `rust/tcl-compiler/src/unit_scope.rs:884-905` ("Which command is the handler comes from
+  `Traits::UNRESOLVED_COMMAND_HANDLER`, **never a literal name here**") and
+  `rust/tcl-compiler/src/analyser/handlers.rs:2514-2546` (same sentence, and it admits both the
+  `::unknown` and `::tcl::unknown` spellings from the one trait carrier).
+
+**Drift evidence:** `handlers.rs:2540-2546` derives *both* accepted spellings from the single
+`unknown` spec by qualifying it against `::` and `::tcl`. `CHAIN_TARGETS` lists the `::tcl` pair by
+hand and omits `::unknown` / `unknown` entirely, so the two modules disagree about what "the original
+handler" is named. `command == "exec"` also misses the `::exec` spelling that
+`diagnostics/helpers.rs:444` and `uri_split.rs:66-71` establish as required.
+
+**Why it matters:** `UnknownProcInfo::chains_original` / `has_exec` / `has_auto_load` gate W123
+suppression for the whole file. A handler that chains via `::unknown`, or shells out via `::exec`,
+reads as a self-contained dispatcher, and every unresolved command in the document gets a spurious
+W123.
+
+**What cleanup looks like:** thread the registry into `walk_unknown_stmt` (the caller at `oo.rs:1888`
+already builds one) and resolve on `canonical_command_or_source()`:
+`registry.commands_with_trait(UNRESOLVED_COMMAND_HANDLER)` for the chain test (matching the
+`::`/`::tcl` qualification `handlers.rs:2542` uses), `LOADS_EXTERNAL_UNIT` for `auto_load`, and the
+`Process` side effect for `exec`. The genuinely irreducible residue — the *user-chosen* saved names
+`_original_unknown` / `_orig_unknown` / `original_unknown`, which no registry can know — shrinks to
+a three-name convention list with a comment saying why it cannot move.
+
+**Scale:** ~25 lines; the list shrinks rather than disappears.
+
+---
+
+## F9: `path_concat` detects `[file normalize]` by matching the source spelling, and its module doc calls the registry-declared taint path dead when it is not
+
+**Confidence:** medium
+**Category:** stale-consumer
+
+**Where the knowledge lives now:**
+`rust/tcl-compiler/src/path_concat.rs:70-86` — `is_file_normalize_of(value, var_name)`: parses the
+command substitution and requires `cmd == "file" && args[0] == "normalize"` and a textual
+`$var` / `${var}` match on the same variable. Driven from the same-block forward scan at `:283-295`.
+`:199-202` sets `suppress_colours = TaintColour::PATH_NORMALISED` and comments "It is not currently
+assigned by the taint engine".
+
+**Where it should live / what already exists:**
+- `rust/tcl-registry/src/commands/tcl/file_.rs:386` — `taint_transform: Some(TaintColour::PATH_NORMALISED)`
+  on the `normalize` subcommand, with `returns_path: true`.
+- `rust/tcl-compiler/src/taint.rs:390-402` — `transform_colour` resolves the *subcommand's*
+  `taint_transform` ahead of the bare command's, so `[file normalize …]` really does stamp
+  `PATH_NORMALISED`; `rust/tcl-registry/src/taint.rs:660-663` pins that with a test
+  (`taint_transform(&registry, "file", Some("normalize")) == Some(PATH_NORMALISED)`).
+
+**Drift evidence:** the module doc at `path_concat.rs:30-33` states "the taint engine does not yet set
+`PATH_NORMALISED` on `[file normalize]` results", and `:199-202` repeats it. Both are stale — the
+registry declares the transform and `taint.rs:390` applies it. The hardcoded text match is the only
+live suppression path *because* the doc's premise stopped being true without the code following.
+
+**Why it matters:** W201 (path built by string concatenation) fires despite a normalising sanitiser
+whenever the spelling is not literally `[file normalize $sameVar]` — `set p [file normalize [file
+join $a $b]]`, `set q [file normalize $p]; set p $q`, an `interp alias`'d `file`, or a
+`file nor` abbreviation (`file`'s ensemble accepts unique prefixes, which
+`is_file_normalize_of`'s `args[0] != "normalize"` rejects). Conversely the text match cannot see a
+normalisation that reaches the value through a phi.
+
+**What cleanup looks like:** delete `is_file_normalize_of` and the same-block forward scan; keep the
+existing `suppress_colours` arm and let the taint lattice answer, since the fact is already in it.
+Refresh the module doc. If the lattice's `PATH_NORMALISED` genuinely only rides on values that were
+tainted to begin with, the correct fix is to widen the taint engine to stamp `returns_path` +
+`taint_transform` colours on clean values too — a registry-driven change, not a new name match.
+
+**Scale:** ~60 lines deleted plus a doc rewrite; possibly one taint-engine widening.
+
+---
+
+## F10: `auto_path_eval::collect_writes` re-implements `set` / `variable` / `namespace eval` layouts and hand-folds `file dirname|normalize|join`
+
+**Confidence:** medium
+**Category:** hardcoded-command-knowledge
+
+**Where the knowledge lives now:**
+`rust/tcl-compiler/src/auto_path_eval.rs:503-545` — `match words[0].as_str() { "set" if len == 3 => …,
+"variable" if len >= 2 => …, "namespace" if len == 4 && words[1] == "eval" => … }`, with the
+`variable` arm open-coding the name/value stride at `:510-537`.
+`rust/tcl-compiler/src/auto_path_eval.rs:1091-1113` — a mini constant evaluator hardcoding
+`info script`, `file dirname`, `file normalize`, and `file join`.
+
+**Where it should live / what already exists:**
+- `variable`'s stride is registry data: `rust/tcl-registry/src/commands/tcl/variable_.rs:164`
+  (`RepeatedArgLayout::strided(ArgRole::VarWrite, 0, 2)`); `set`'s write index comes from its
+  `arg_role_resolver`; `namespace eval`'s body is `ArgRole::Body` +
+  `ArgRole::NamespaceName` (`namespace_.rs:785`) with `Traits::DECLARES_NAMESPACE`.
+- The same file already does it the right way 130 lines later:
+  `auto_path_eval.rs:660-690` (`poison_mutated_variables`) reads
+  `arg_indices_for_role(head, &args, ArgRole::VarWrite)` and `Traits::CREATES_SCOPE_ALIAS`, and its
+  doc comment cites AGENTS.md for doing so.
+- `CommandSpec::const_fold` / `const_fold_versioned` (`rust/tcl-registry/src/spec.rs:735`, `:740`) is
+  the field for the folder half. 40 specs already carry one
+  (`dict create`, `lindex`, `join`, `split`, `string cat/compare/index/length`, `scan`, `subst`, …).
+  `file` carries none.
+
+**Drift evidence:** the two halves of the same module disagree about how to find a variable write —
+`collect_writes` by name, `poison_mutated_variables` by role — so a write recorded by one is
+invisible to the other for any command outside the three-name list (`array set`, `dict set`,
+`lappend`, `append`, a stub-declared setter).
+
+**Why it matters:** `auto_path` constant resolution decides which `source`d / `package require`d
+units the workspace model can follow, so a missed `lappend dir …` or `append dir …` assignment loses
+a whole file from the index (definitions, references, and completion inside it). The absent
+`file` const-fold means every other consumer that wants `[file join $a $b]` folded — SCCP,
+`const_subst`, the lowering fast paths — has to write its own.
+
+**What cleanup looks like:** replace the three `match` arms with role queries: `ArgRole::VarWrite`
+indices for the write targets (covering `set`, `variable`, and everything else in one arm), and
+`ArgRole::Body` + `ArgRole::NamespaceName` for the namespace recursion, checking
+`Traits::DECLARES_NAMESPACE` rather than `words[1] == "eval"`. Move `file dirname` / `file normalize`
+/ `file join` into `const_fold` fns on the `file` subcommand specs, next to the existing
+`fold_join` / `fold_split`, and have the evaluator dispatch on `spec.const_fold` like the rest of the
+optimiser.
+
+**Scale:** ~80 lines in the analyser plus three small registry `const_fold` fns.
+
+---
+
+## F11: `tk_checks::GEOMETRY_COMMANDS` is a hardcoded three-name set in a module that otherwise gates on registry data
+
+**Confidence:** medium
+**Category:** hardcoded-command-knowledge
+
+**Where the knowledge lives now:**
+`rust/tcl-compiler/src/analyser/tk_checks.rs:140` — `const GEOMETRY_COMMANDS: &[&str] = &["pack",
+"grid", "place"]`, consumed by `is_geometry_command` at `:167`.
+
+**Where it should live / what already exists:** no registry field carries this today — it needs one.
+The specs exist (`rust/tcl-registry/src/commands/tk/{pack,grid,place}.rs`) and the surrounding module
+already resolves everything else from the registry: `TK_PACKAGE` (`tk_checks.rs:148`) is documented
+as "the single source of truth for both halves of the gate", and `Analyser::is_widget_command` reads
+`CommandSpec::required_package`. The natural home is a new `Traits::TK_GEOMETRY_MANAGER` flag
+alongside the existing widget/Tk traits, or — since TK1001 is really "two managers claim one
+parent" — a small descriptor recording the manager's identity so the diagnostic can name it.
+
+**Why it matters:** TK1001 (conflicting geometry managers on one parent) is silent for any manager
+outside the three core names — notably `ttk::` megawidget managers and vendor Tk forks that ship
+their own — and adding one means editing the analyser rather than the spec pack, which is exactly
+what the "Command registry" section of AGENTS.md forbids.
+
+**What cleanup looks like:** add the trait to `traits.rs`'s `declare_traits!` block, set it on the
+three Tk specs, and replace `is_geometry_command` with a `spec.traits.contains(...)` check taken
+from the already-resolved spec. `GEOMETRY_COMMANDS` and its helper both disappear.
+
+**Scale:** one trait, three spec edits, ~8 lines in the analyser.
+
+---
+
+## Not reported (verified clean or explicitly carved out)
+
+- `analyser/oo.rs`'s member routing (`:1605-1607`, `:3053-3140`, `:1755-1814`) — the
+  `ClassDef` field / `MethodDef` kind routing and the `destructor` vs `initialise` scope question,
+  carved out by AGENTS.md and documented at the call sites. Recognition and arg layout genuinely do
+  come from `definition_body` / `MemberSpec::indices_for` (`oo.rs:131-134`, `:340`, `:532-535`).
+- `analyser/dispatch.rs` — copies only static `arg_roles`, but every consumer of `CommandSig.arg_roles`
+  is an arity/option check; the role-*resolution* path is `param_traits::resolve_arg_roles`
+  (`param_traits.rs:566-595`), which honours the documented `arg_role_resolver` > `arg_roles` >
+  sub-roles order via `arg_indices_for_role`. No `assigns_variable_at` read exists anywhere in the
+  audited scope.
+- `analyser/commands.rs` body descent, `analyser/handlers.rs` (`defines_global_unresolved_handler`,
+  `handle_switch_command`, `defines_command_at` / `SymbolDef` handling), `unit_scope.rs`,
+  `head_identity.rs`, `command_binding.rs`, `registry_invocation.rs`, `rendered_properties.rs`,
+  `object_types.rs`, `dynamic_names.rs`, `var_refs.rs`, `var_resolve.rs`, `scan_predicate.rs`,
+  `lambda_literal.rs`, `subst_nocommands.rs` — registry-driven throughout; several carry explicit
+  "registry facts, not command names" comments.
+- `alias.rs:201-223` (`expr_alias_names` matching the literal target `"expr"`) — real debt, but
+  already documented as tracked debt at the call site with the intended replacement named
+  (`Traits::EXPR_CONCATENATES_ARGS`) and the blocker stated (the registry-less
+  `dispatch_lowering_hook` signature). Recorded here rather than as a finding.
+- `analyser/commands.rs:154-160` (`orphaned_keyword_parent` mapping `else`/`elseif`/`then` → `if`
+  and `on`/`trap`/`finally` → `try`) — the forward facts are registry data (`if`'s
+  `arg_role_resolver` marks them `ArgRole::Keyword`; `try`'s `FIRST_CLAUSE_KEYWORD_VALUES`,
+  `try_.rs:122-137`, lists the three), but no reverse keyword→parent index exists and the table has
+  not drifted. Worth folding into any future `ArgRole::Keyword` index; not a defect today.

--- a/docs/audits/legacy-duplication-2026-08/lowering.md
+++ b/docs/audits/legacy-duplication-2026-08/lowering.md
@@ -1,0 +1,294 @@
+# Lowering / codegen / front-end duplication audit
+
+Scope: `rust/tcl-compiler/src/{parsing,segmenter.rs,cfg_builder,cfg*.rs,ssa.rs,ir*.rs,
+executable_ir.rs,place*.rs,compilation_unit.rs,lowering*,shimmer,codegen,
+representation_plan.rs,slot_allocation.rs,target_contract.rs,backend_registry.rs,
+signature_scan,tcl_expr_eval.rs,text.rs}` plus `rust/tcl-syntax`, `rust/tcl-lexer`.
+
+(Note: the red-green CST is `tcl-compiler/src/parsing/syntax/{green,red,build,segment,
+descend}.rs`, not the `rust/tcl-syntax` crate — that crate holds the Tcl value grammars:
+list, number, glob, naming, backslash.)
+
+Every finding below was verified by reading both sides **and** by running the built
+`tcl` CLI (`target/debug/tcl`, toolchain 1.97.0) against a reproducer. Commands and
+observed output are quoted inline.
+
+Clean subsystems (checked, nothing to report): the segmenter is fully migrated onto the
+red-green CST — `segment_commands_local` (`segmenter.rs:807`) is a thin wrapper over
+`parsing::syntax::build::build_document` + `segment::segments_from_document`, with the
+old token loop retired to a differential-test oracle; `slot_allocation.rs` is documented
+as deliberately unwired and is; `shimmer/span.rs` reads spans straight off the IR;
+`executable_ir.rs` has real consumers (`world_state_ssa`, `semantic_analysis`, `gvn`,
+`codegen/wasm/semantic_plan`).
+
+---
+
+## F1: `while` / `for` / `try` / `foreach` / `dict` lower a substituted body word as a static script, so the IR span runs past end-of-source and `tcl compwasm` panics
+
+**Confidence:** high
+**Category:** duplicated-path
+
+**The modern path:** the family's shared "is this word a literal script?" predicates live
+in `lowering/mod.rs:200` (`seg_word_is_static_braced`) and `lowering/mod.rs:210`
+(`seg_word_is_static_literal`) — both gate on the *token kind* (`Str` / `Esc`), not just
+on single-token-ness. `lower_if` uses it (`lowering/structured.rs:266`), and
+`lower_catch` (`lowering/structured.rs:610-619`) and `lower_foreach_line`
+(`lowering/structured.rs:563-565`) hand-inline the equivalent `TokenType::Str` check,
+with `lower_catch`'s comment spelling out exactly why: *"Without the kind check,
+`catch $cmd res` would be compiled as 'call the proc named by `$cmd`' — wrong."*
+
+**The legacy/duplicate path:** five sibling lowerers in the same file never got the
+check and gate on `arg_single` alone:
+
+- `lower_while` — `lowering/structured.rs:383` (`if !(arg_single[0] && arg_single[1])`)
+- `lower_for` — `lowering/structured.rs:332`
+- `lower_foreach` / `lower_lmap` — `lowering/structured.rs:432`
+- `lower_try` — `lowering/structured.rs:656`
+- `lower_dict` — `lowering/structured.rs:986`
+
+All five then call `lower_body_from_tok` (`lowering/structured.rs:1075-1086`), which
+rebases the *segmenter-reconstructed* word text at `tok.span.start() + content_offset`.
+For `$body` the reconstructed text is `${body}` (7 bytes) over a 5-byte source word, so
+every span in the resulting `Script` lands 2 bytes too far right — past the end of the
+buffer for a trailing body.
+
+**Why it matters:** a hard crash on a production path.
+
+```
+$ printf 'while {1} $body\n' > t.tcl
+$ target/debug/tcl compwasm t.tcl -o out.wasm
+thread '<unnamed>' panicked at rust/tcl-compiler/src/codegen/structured.rs:284:12:
+end byte index 17 is out of bounds for string of length 15
+  ... tcl_compiler::codegen::structured::slice
+  ... tcl_compiler::codegen::wasm::backend::WasmEmitter
+```
+
+`for {} {1} {} $body` panics identically. `catch $body` and `if {1} $body` correctly
+barrier (`barrier catch with dynamic body`, `barrier if with non-literal body`) — the
+divergence is visible side-by-side in one `tcl explore --show ir` run. Where it does not
+crash it silently mis-compiles: `try $body` produces an `IRTry` whose body Script is the
+*text* `${body}` parsed as a script (a call to a command literally named `${body}`), and
+`foreach x $l $body` produces an `IRForeach` with the same fabrication.
+
+**What cleanup looks like:** replace the five ad-hoc `arg_single` gates with the existing
+shared predicate (`seg_word_is_static_braced` for the brace-only bodies, matching
+`lower_catch`; `seg_word_is_static_literal` where a bareword body is also legal, matching
+`lower_if`), and delete `lower_catch`/`lower_foreach_line`'s hand-inlined copies so there
+is one gate. Independently, `codegen/structured.rs:283`'s `slice` should clamp/`get`
+rather than index, so a bad IR span degrades instead of aborting the process.
+
+**Scale:** ~5 one-line guard changes plus one bounds-safe `slice`; the barrier reasons
+already exist, so no new IR shapes.
+
+---
+
+## F2: the structured WASM walk re-derives clause text by slicing source and hand-stripping the closer, truncating any condition or step clause whose content ends in `}` or `"`
+
+**Confidence:** high
+**Category:** range-rederivation
+
+**The modern path:** the IR already carries the parsed and the anchored forms of every
+clause. `Statement::While` (`ir.rs:1067-1086`) and `Statement::For` (`ir.rs:1033-1060`)
+each hold `condition: ExprNode`, `condition_span: Span`, **and** `condition_base:
+Option<u32>` — "absolute source offset of the condition text" — computed in lowering by
+`word_content_base` (`lowering/structured.rs:404`, `lowering/structured.rs:358`), the
+helper documented at `lowering_hooks.rs:201` as the one place the opening-delimiter width
+is recovered without guessing. `raw_args` carries the de-braced word text directly.
+
+**The legacy/duplicate path:** `codegen/structured.rs:294-303` ignores all of it:
+
+```rust
+fn condition_text(source: &str, span: Span) -> &str {
+    let s = slice(source, span).trim();
+    if let Some(inner) = s.strip_prefix('{') {
+        return inner.strip_suffix('}').unwrap_or(inner).trim();
+    }
+    ...
+```
+
+Called from the `While` arm (`codegen/structured.rs:139`), both `For` arms
+(`codegen/structured.rs:153-154`) and `emit_if` (`codegen/structured.rs:218`). Its own
+doc-comment states that the token span *excludes* the closing brace — so the
+`strip_suffix('}')` can only ever remove a byte of real content. This is precisely the
+`end.offset + 1`-class re-derivation AGENTS.md's "Word-token closing delimiters" section
+forbids, in the opposite direction.
+
+**Why it matters:** the emitted WASM evaluates a truncated expression / script.
+
+```
+$ printf 'while {${x}} {puts hi}\n' > g.tcl && target/debug/tcl compwasm g.tcl -o g.wasm
+$ od -c g.wasm | tail -3
+... 003   $   {   x  \0 ...      <- data segment holds "${x", not "${x}"
+```
+
+Same for `if {${x}} {puts a}`, and for a `for` step clause: `for {set i 0} {$i<2}
+{set x ${i}} {puts a}` embeds `set x ${i` (9 bytes) in the module. At runtime that is a
+parse error ("missing close-brace") on code the user wrote correctly. Any braced clause
+whose last inner character is `}` — `${name}`, `[expr {$a}]`-free arithmetic on a braced
+var, a nested dict literal — is affected.
+
+**What cleanup looks like:** drive the emitter from `condition_base` +
+`raw_args`/`ExprNode` instead of re-slicing: the lowerer already produced the exact text
+it parsed, and `condition_base` maps it back to absolute source when a verbatim mapping
+exists. Failing that, use `tcl_lexer::word_span` / the token's `content_offset` (the one
+authoritative "whole written word" helper, `tcl-lexer/src/ranges.rs:215`) rather than
+character stripping. Delete `condition_text` once the callers take the IR fact.
+
+Note the module doc at `codegen/structured.rs:50-51` still claims *"Not currently
+reachable from any wired-up production path (`structured::walk` has no caller yet)"* —
+the panic backtrace in F1 shows `codegen::wasm::backend::codegen` calling it. That stale
+claim is why neither `slice` nor `condition_text` was ever hardened.
+
+**Scale:** one function deleted, four call sites re-pointed at existing IR fields; plus
+one doc correction.
+
+---
+
+## F3: the `{*}`-expansion barrier for structured commands is keyed on a hardcoded command-name list that has drifted from the registry hook set that actually dispatches structured lowering
+
+**Confidence:** high
+**Category:** stale-consumer
+
+**The modern path:** structured lowering is dispatched purely from the registry's typed
+`LoweringHookId` — `try_dispatch_structured_hook` (`lowering/mod.rs:1166-1326`) resolves
+via `registry.resolve_invocation(...).semantics.lowering_hook` and covers `Proc`, `When`,
+`NamespaceEval`, `If`, `Switch`, `For`, `While`, `Foreach`, `Lmap`, `ForeachLine`,
+`Catch`, `Try`, `Dict`, `Eval`, `Uplevel`, `Apply`, `ArrayFor`. Its own doc-comment sells
+the migration: *"Dispatching through the hook ID picks up two benefits over a bare name
+match."* The non-structured hooks each ask `has_expansion(cmd)` (`lowering_hooks.rs:185`)
+themselves.
+
+**The legacy/duplicate path:** the expansion guard for the structured family is still a
+command-string classifier — `structured_expand_barrier` (`lowering/mod.rs:1105-1140`):
+
+```rust
+let structured = matches!(cmd_name,
+    "proc" | "when" | "namespace" | "if" | "switch" | "for" | "while"
+    | "foreach" | "foreach_in_collection");
+```
+
+called at `lowering/mod.rs:1400`, immediately before the hook dispatch. Nine names
+against seventeen hook IDs. This is also a direct violation of AGENTS.md's "the registry
+is the source of truth — no per-command logic elsewhere".
+
+**Why it matters:** every structured form missing from the list commits to the
+*un-expanded* argv shape, which is exactly what the barrier exists to prevent. Verified
+with `tcl explore --show ir`:
+
+| source | IR |
+|---|---|
+| `foreach i {*}$spec {puts $i}` | `barrier foreach with argument expansion` (correct) |
+| `lmap i {*}$spec {puts $i}` | `IRForeach` — one iterator over the literal word `${spec}` |
+| `dict for {k v} {*}$rest {puts $k}` | `IRForeach` |
+| `array for {k v} {*}$rest {puts $k}` | `IRForeach` |
+| `foreachLine ln {*}$rest {puts $ln}` | `IRForeach` |
+| `catch {body} {*}$rest` | `IRCatch` (result var taken from the un-expanded word) |
+
+Two commands with identical shape and the same lowering function (`lower_foreach`) get
+opposite treatment. User-visible: `set spec {{1 2} j {3 4}}` + `lmap i {*}$spec {puts
+"$i $j"}` reports `W210 Variable 'j' is read before it is set`, although the expansion
+makes `j` a loop variable. Downstream, SCCP/loop passes reason about an iterator count
+and a loop-variable set that the program does not have.
+
+**What cleanup looks like:** delete the name list and fold the expansion gate into
+`try_dispatch_structured_hook`: after resolving `hook`, if `seg.expand_word` has any flag
+set and the hook is one whose lowering commits to a positional argv shape, return the
+barrier. That makes the set registry-derived and impossible to drift when a new
+structured hook ID is added. `"foreach_in_collection"` in the current list is dead weight
+— it resolves to `LoweringHookId::Foreach` through its spec anyway.
+
+**Scale:** delete ~20 lines, add one guard inside the hook dispatcher; a handful of new
+barrier expectations in tests.
+
+---
+
+## F4: the issue-#1325 body-rebase guard was adopted by the analyser only; the lowerer — the producer of the IR spans codegen slices with — never got it
+
+**Confidence:** medium
+**Category:** half-ported
+
+**The modern path:** `segmenter::contiguous_prefix` (`segmenter.rs:376-394`) and
+`segmenter::body_text_in_region` (`segmenter.rs:411-421`) exist specifically because
+rebasing a body word's spans by `tok.span.start() + content_offset` is only truthful
+while the word's *value* is a verbatim slice of the source. Their doc-comment names the
+real incident: a compound `{body}x` word slid every token one byte left, and 40
+zero-width spaces in a real iRule produced an offset inside a UTF-8 sequence that
+panicked the first consumer to slice the source (issue #1325). The analyser's
+`analyse_body` uses it before segmenting a body (`analyser/commands.rs:220-239`).
+
+**The legacy/duplicate path:** `Lowerer::lower_body_from_tok`
+(`lowering/structured.rs:1075-1086`) performs the same rebase with no guard —
+
+```rust
+let offset = tok.span.start() + u32::from(tok.content_offset);
+self.lower_body(text, offset, namespace)
+```
+
+— and `lower_body_inner` (`lowering/mod.rs:945-952`) feeds that straight to
+`segment_commands_with_offset_and_config`. `body_text_in_region` / `contiguous_prefix`
+have exactly one production caller in the workspace, the analyser one above (everything
+else is `tests/span_char_boundaries.rs`).
+
+**Why it matters:** it is the second missing line of defence behind F1 — with the guard
+in place, `while {1} $body`'s 7-byte `${body}` against a 5-byte source region would be
+clamped instead of producing spans past end-of-source, and the WASM emitter would not
+abort. More generally, IR spans are the contract every downstream consumer trusts
+(AGENTS.md: "Trust it rather than re-deriving"), and the analyser side of the pipeline
+currently produces trustworthy ones while the lowering side does not.
+
+**What cleanup looks like:** give `Lowerer` the document source (it already receives it
+in `lower`/`lower_into_script` but does not retain it) and route `lower_body_from_tok`
+through `body_text_in_region(source, base, tok.span.end(), text)` the way
+`analyser::commands` does. Add a `debug_assert` in `Script::from_statements` (or in
+`lower_segmented`) that no emitted span exceeds the document length, so a future producer
+cannot regress this silently.
+
+**Scale:** one field on `Lowerer`, one call-site change, one assertion; the helper is
+already written and tested.
+
+---
+
+## F5: `ir_helpers::tokenise_command_words` is a second, dialect-blind command/word tokenisation loop feeding the SCCP dynamic-name barrier
+
+**Confidence:** medium
+**Category:** duplicated-path
+
+**The modern path:** `segment_commands_with_offset_and_config`
+(`segmenter.rs:328-341`) is the single command/word splitter, CST-backed since the
+migration (`segmenter.rs:807-823`) and *dialect-aware*: it threads
+`LexerConfig::for_dialect`, which controls `{*}` expansion (off for Tcl 8.4 and iRules)
+and the iRules `}{` ghost separator. Every body re-segmentation in the lowerer threads
+`self.config` for exactly this reason (`lowering/mod.rs:918`, `lowering/mod.rs:946`; the
+field at `lowering/mod.rs:760` and its doc spell out the contract). `SegmentedCommand` already
+exposes `texts`, `argv` kinds, `single_token_word` and `expand_word`.
+
+**The legacy/duplicate path:** `ir_helpers::tokenise_command_words`
+(`ir_helpers.rs:587-630`) re-implements the loop by hand — `Lexer::new(source)` with
+`LexerConfig::default()`, its own `prev_is_sep` accumulator, its own word-concatenation
+rule, and its own `CommandWord { text, raw, substituted, braced_literal }` record whose
+doc (`ir_helpers.rs:571-577`) concedes that `raw` reads back as `{s` for a braced word.
+Its one caller is `dynamic_names::scan_script_text` (`dynamic_names.rs:542`), which feeds
+`scan_command` and therefore `DynamicNameBarrier` — consumed by SCCP
+(`sccp.rs:1061`) and stored on the CFG (`cfg.rs:240`) and compilation unit
+(`compilation_unit.rs:630`).
+
+**Why it matters:** the barrier is an *optimisation-soundness* fact ("does anything in
+here write through a computed variable name?"). Deriving it from a differently-configured
+tokenisation than the one that built the IR means the two disagree on word boundaries for
+any non-default dialect: under `f5-irules` the segmenter splits `cmd {a}{b}` into three
+words and this loop into two; under `tcl8.4` the segmenter treats `{*}` as a literal
+word and this loop as an expansion marker. A word-boundary disagreement changes which
+argument index `scan_command` inspects, so a dynamic write can fail to raise the barrier
+and SCCP can then propagate a constant across it.
+
+**What cleanup looks like:** replace the body of `tokenise_command_words` with a call to
+`segment_commands_with_offset_and_config(text, 0, config)` and map each
+`SegmentedCommand` to the four facts `dynamic_names` wants — `text` from
+`SegmentedCommand::texts`, `braced_literal` from `argv[i].kind == Str && single_token_word[i]`,
+`substituted` from the word's `WordExpr` (`ir.rs:437`, which already distinguishes
+`Variable` / `CommandSubstitution` / `Template`), and the raw spelling from the word
+span. Thread the document's `LexerConfig` into `dynamic_name_barrier` so the barrier is
+computed under the same dialect as the IR.
+
+**Scale:** ~40 lines deleted, one config parameter threaded from `compilation_unit`
+through `dynamic_names`.

--- a/docs/audits/legacy-duplication-2026-08/lsp.md
+++ b/docs/audits/legacy-duplication-2026-08/lsp.md
@@ -1,0 +1,110 @@
+# LSP feature-layer duplication/hardcoding audit
+
+## F1: Hover's pattern/format-string detectors hardcode command names and mislocate arguments, disagreeing with semantic tokens' registry-driven marking
+
+**Confidence:** high
+**Category:** duplicated-logic
+
+**Where it is now:** `rust/tcl-lsp-core/src/hover.rs`. A family of private
+"detect the special-syntax argument under the cursor" helpers, all called
+unconditionally near the top of the main `hover_impl` dispatch chain
+(`hover.rs:641-649`, ahead of the generic word resolver at `hover.rs:651`):
+
+- `glob_pattern_at_position` (`hover.rs:2164-2183`) — hardcodes
+  `matches!(tokens[0], "glob") || (tokens[0]=="string" && tokens[1]=="match") || (tokens[0]=="lsearch" && tokens.contains(&"-glob"))`.
+- `regex_pattern_at_position` (`hover.rs:2415-2432`) — hardcodes
+  `matches!(tokens[0], "regexp" | "regsub") || (tokens[0]=="lsearch" && tokens.contains(&"-regexp"))`.
+- `sprintf_format_string_at_position` (`hover.rs:1395-1405`) — hardcodes
+  `tokens[0] != "format" && tokens[0] != "scan"`.
+- `clock_format_string_at_position` (`hover.rs:2523-2538`) — hardcodes
+  `tokens[0] != "clock" || (tokens[1] != "format" && tokens[1] != "scan")`.
+- `binary_format_context_at_position` (`hover.rs:1808-1837`) — hardcodes
+  `tokens[0] != "binary" || (tokens[1] != "format" && tokens[1] != "scan")`.
+- `regsub_subspec_at_position` (`hover.rs:1994-2033`).
+
+All six split the *current source line* on whitespace
+(`line_text.split_whitespace()`) to find the command name, then locate the
+literal under the cursor with `string_literal_at` / `string_literal_with_percent_at`
+(`hover.rs:2039-2064`, `1411-1440`) — a raw brace/quote scan over `line_text.chars()`
+that finds *whichever* `"…"`/`{…}` literal the cursor's column falls inside,
+with **no check of that literal's argument index**. (`binary_format_context_at_position`
+additionally falls back to an index-checked `word_token_at`, but only for the
+unbraced-bareword case — its primary, more common path is the unchecked
+`string_literal_at`.) The doc comments call this out as deliberate
+("Single-line only", `hover.rs:2163`, `2414`; "This is the same single-line
+context detection used by `signature_help` / `completion`", `hover.rs:2526-2529`)
+but the position-blindness is not: nothing stops a hover request on a
+*non-pattern* literal argument of the same command from being claimed.
+
+**What already exists that it should use:** `rust/tcl-lsp-core/src/semantic_tokens.rs`
+already solves the identical question — "which argument of this call is a
+pattern/format string, and what sub-language is it" — entirely from registry
+data, with no command-name matching:
+
+- `insert_regex_overrides` (`semantic_tokens.rs:1932-1978`) gates on
+  `registry.get(head).and_then(|s| s.pattern_type) == Some(PatternType::Regex)`
+  and locates the argument via
+  `registry.arg_indices_for_role(head, arg_texts, ArgRole::Pattern)`
+  (`semantic_tokens.rs:1939-1953`), falling back to switch-skipping only when
+  the spec hasn't declared a position yet.
+- `insert_format_overrides` (`semantic_tokens.rs:2040-2065`) does the same for
+  `FormatType::{Sprintf,Clock,Binary,Regsub}` via
+  `ArgRole::FormatString`/`ArgRole::ScanFormat`.
+
+Both operate on the segmenter's `SegmentedCommand`/`arg_texts` — the CST-derived
+argument list — rather than re-tokenising line text, so they are correct for
+multi-line commands and never pick up an unrelated literal.
+
+**Disagreement evidence:** `regsub {a.*b} $str {x.y}` — registry data for
+`regsub` (`rust/tcl-registry/src/commands/tcl/regsub_.rs:87,95`) assigns
+`ArgRole::Pattern` only to the *first* positional argument (`exp`) and
+`ArgRole::FormatString` to the third (`subSpec`, the replacement — it uses `&`/`\N`
+backreference syntax, not regex). Hovering over the replacement literal `x.y`:
+semantic tokens (via `insert_regex_overrides` + `arg_indices_for_role`) never
+marks it as a regex fragment — it renders as ordinary text. Hover, via
+`regex_pattern_at_position`, only checks that the line's first token is
+`regsub` and that the cursor sits inside *some* brace/quote literal on that
+line; it returns `"x.y"` and renders `regex_hover_text("x.y")`, i.e. a
+**"Regex pattern"** markdown panel describing `.` as "Match any single
+character" — wrong: in a `regsub` replacement, `.` is a literal character, and
+the only specials are `&` and `\N`. The same shape of bug applies to
+`binary_format_context_at_position` (no argument-index check on its primary
+`string_literal_at` path, so a `binary format`/`binary scan` call with a
+literal *value* argument gets it misparsed as the format specifier string) and
+to `glob_pattern_at_position`, which additionally hardcodes exactly `"glob"`
+and `"string" "match"` — the two commands whose registry specs
+(`rust/tcl-registry/src/commands/tcl/glob_.rs`, the `match` `SubCommand` in
+`string_.rs:1332-1349`) currently declare **no** `pattern_type`/`ArgRole::Pattern`
+at all, unlike `chan names`/`parray`/`lsearch`, which already do
+(`chan_.rs:616-617`, `parray.rs:92-93`). So the two commands hover.rs special-cases
+by hand are precisely the two not yet wired into the generic mechanism —
+this is the "migration debt" AGENTS.md describes: knowledge that should live
+in the registry is duplicated, ad hoc, and only partially, in a consumer.
+
+**Why it matters:** Hover text is directly editor-visible and is the
+disagreeing half of the pair — a user hovering the replacement/value argument
+of `regsub`/`binary format`/`binary scan` gets a plausible-looking but
+incorrect "Regex pattern" / binary-specifier breakdown, while the semantic
+token colouring on the same word correctly shows it as ordinary text. Because
+these checks run unconditionally near the top of `hover_impl`, ahead of the
+generic word resolver, a wrong match here also **pre-empts** whatever more
+specific/correct hover (e.g. a variable or command hover) would otherwise have
+fired for that literal.
+
+**What cleanup looks like:** Extend `glob_.rs`'s and `string_.rs`'s `match`
+`SubCommand` with `pattern_type: Some(PatternType::Glob)` + `arg_roles`/`arg_role_resolver`
+entries for the pattern position (mirroring `chan names`/`parray`), so `glob`
+and `string match` join the already-registry-driven set. Then replace
+`glob_pattern_at_position` / `regex_pattern_at_position` /
+`sprintf_format_string_at_position` / `clock_format_string_at_position` /
+`binary_format_context_at_position` / `regsub_subspec_at_position` with a
+single hover path that reuses the segmenter's `SegmentedCommand` (already
+built for the enclosing call) plus `registry.arg_indices_for_role(...)` /
+`CommandSpec::pattern_type` / `FormatType`, the same query
+`insert_regex_overrides`/`insert_format_overrides` already perform — so hover
+and semantic tokens are provably asking the registry the same question
+instead of maintaining two independently-hand-coded answers.
+
+**Scale:** Medium — six functions plus their two shared line-scanning helpers
+(`string_literal_at`, `string_literal_with_percent_at`) in one file; the
+registry extension is two small `CommandSpec` edits.

--- a/docs/audits/legacy-duplication-2026-08/optimiser.md
+++ b/docs/audits/legacy-duplication-2026-08/optimiser.md
@@ -1,0 +1,361 @@
+# Optimiser duplication / half-migration audit — `rust/tcl-compiler/src`
+
+Branch `claude/legacy-code-duplication-audit-edm0bo` (based on `rust`, tip `0f97d98`).
+
+**Note on the exemplar.** The PR #1371 shape is *still live on this branch*:
+`compiler_checks.rs:355` calls `find_redundancies_for_function` (the modern
+`GvnLegalitySource::Common` semantic-sidecar path, `gvn.rs:1419-1432`), while
+`compiler_checks.rs:358` and `:361` call `find_partial_redundancies` /
+`find_loop_invariants`, which both run on `GvnLegalitySource::Legacy` through
+`statement_occurrences` / `statement_writes_state` (`gvn.rs:994-1011`, `:937-951`)
+and therefore on the `is_pure_command` command-string classifier. I verified it
+but do **not** re-report it — it is the given exemplar. F3 below is a *different*
+defect inside those same two functions.
+
+Every finding below was verified by reading both sides **and** by running the
+built `tcl` CLI (`tcl opt` / `tcl diag` / `tcl explore --json`) on a reproducer.
+
+---
+
+## F1: Four optimiser rewrites ignore the dynamic-name barrier that dead-store elimination and SCCP both consult, and miscompile any function containing `set $name …`
+
+**Confidence:** high
+**Category:** soundness-asymmetry
+
+**The modern path:** `crate::dynamic_names::DynamicNameBarrier`
+(`dynamic_names.rs:143-155` — typed `{writes, destroys, reads}` flags) is built
+per function by `dynamic_name_barrier` (`dynamic_names.rs:404`) and stored on
+every `FunctionUnit` (`compilation_unit.rs:303`, populated at
+`compilation_unit.rs:630`). Its documented contract is "after a dynamic write,
+**any** name may be defined; after a dynamic read, **any** store may have been
+observed". Consumers that respect it: the O109/O126/O108 elimination pass, which
+abstains outright — `elimination.rs:446` `if fu.dynamic_names.reads { return
+HashSet::new(); }`; SCCP's existence-branch folding (`sccp.rs:1152`, `:1176`,
+`:1198`); and the analyser's dataflow diagnostics
+(`analyser/diagnostics/dataflow.rs:282`, `:561`, `:1038`).
+
+**The legacy/duplicate path:** four sibling passes decide the same "can an
+unnamed variable access reach this variable?" question by hand, from IR text,
+and never look at `fu.dynamic_names`:
+
+- **O104/O130 chain fold** — `chain_fold.rs:73` (`run`), `:96-104`
+  (`protected_vars`, which only unions `analyse_var_observability` +
+  `cross_event_vars`). Worse, `classify_write` (`chain_fold.rs:241-252`)
+  normalises the *dynamic* target word `$name` to the plain name `name`, so
+  `chain_fold.rs:345` (`Some(other) if write_var(&other) != var => { j += 1 }`)
+  walks the accumulation chain straight past `set $name …`.
+- **O125 code sinking** — `code_sinking.rs:57-62` (`run`) plus
+  `statement_uses_var` (`code_sinking.rs:579-584`), whose only "does anything
+  else read this?" evidence is a textual `$var` scan; it even returns `false`
+  for `Statement::Barrier` (`code_sinking.rs:584`).
+- **O102 load forwarding** — `propagation.rs:223-241`; its doc comment
+  (`propagation.rs:199-222`) enumerates its guards as
+  `is_externally_mutable` + `has_intervening_barrier` and explicitly argues that
+  "a plain proc-local variable … cannot be touched by an intervening call to any
+  other proc". A dynamic `set $name …` in the *same* frame is exactly the case
+  that argument misses.
+- **O119 multi-set packing** — `pattern_recognition.rs:122-153`.
+
+**Why it matters:** three demonstrated miscompiles on the current build.
+
+1. `proc f {name} { set acc {}; lappend acc a; set $name zzz; lappend acc b;
+   return $acc }` → `tcl opt` emits O130 and rewrites the body to
+   `set $name zzz; set acc {a b}; return $acc`. `f acc` returns `zzz b` before
+   and `a b` after.
+2. `proc f {name} { set x 1; set $name 2; puts $x }` → O102 + O109 rewrite it to
+   `set $name 2; puts 1`. `f x` prints `2` before and `1` after.
+3. `proc f {name c} { set flag hello; if {$c} { set $name zzz; puts $flag } }` →
+   O125 inserts `set flag hello;` immediately before `puts $flag`, *after* the
+   dynamic write. `f flag 1` prints `zzz` before and `hello` after. (The paired
+   O125 delete is separately suppressed by
+   `manager.rs:238 drop_def_elims_resurrected_by_replacements`, so the emitted
+   rewrite is insert-only — which is what makes this one visible.)
+
+All three are quick-fix-applicable rewrites surfaced in the editor, not hints.
+
+**What cleanup looks like:** give the four passes the same abstention
+`elimination.rs:446` already has. The narrow version is a shared helper on
+`FunctionUnit` (`fn dynamic_barrier_blocks_value_motion(&self) -> bool`) that
+`chain_fold::protected_vars`, `code_sinking::run`,
+`propagation::run_load_forwarding`, and `pattern_recognition` consult before
+emitting; the precise version is to make `chain_fold::classify_write` and
+`code_sinking::sinkable_assignment` return `None` for a non-literal variable
+word and to fold `dynamic_names.writes` into the `escaping` set
+`propagation.rs:238-241` builds (matching what `sccp_with_builtin_folds` does
+with `trace.traced_variables`). This **will** change user-visible output: O102 /
+O104 / O119 / O125 / O130 will stop firing in any proc that contains a computed
+variable name.
+**Scale:** four call sites plus one shared helper; no cross-crate change.
+
+---
+
+## F2: Variable-trace observability is answered by a canonical whole-module fact in SCCP/O102/taint and by two spelling-sensitive per-function scans in O109/O126, O104/O130 and W211/W220
+
+**Confidence:** high
+**Category:** half-ported
+
+**The modern path:** `Module::traced_variables` + `Module::has_dynamic_variable_trace`
+(`ir.rs:1502`, `ir.rs:1507`). Populated at lowering time by
+`populate_trace_facts` / `populate_variable_trace_facts`
+(`lowering/mod.rs:3427-3450`, `:3607-3633`) — registry-driven
+(`Traits::ESTABLISHES_VARIABLE_TRACE` + `ArgRole::VarWrite`, no hardcoded
+`trace` grammar), covering the top level, every proc, every `body_unit`, and
+every TclOO method, and **`::`-canonicalised on purpose** so that a top-level
+`set x 5` matches a `trace add variable ::x …` target — the comment at
+`lowering/mod.rs:3618-3622` says exactly that. The field doc at `ir.rs:1488-1501`
+states the intended consumers: "the propagation optimiser (`O102`
+load-forwarding) **and dead-store elimination** must never treat a use of one of
+these names as equivalent to its last literal assignment." It is threaded as
+`sccp::TraceInputs` (`sccp.rs:295-314`) and consumed by SCCP
+(`sccp.rs:395-398`, `:448`), by O102 (`propagation.rs:123-132`, `:238-248`), and
+by the taint engine (`taint.rs:2134-2135`).
+
+**The legacy/duplicate path:** dead-store elimination never received it.
+
+- `elimination.rs:456` builds `scope_aliases` from `scan_scope_aliases`
+  (`elimination.rs:1282-1310`), a per-CFG walk that inserts the trace target's
+  **raw argument text** (`aliases.insert(t.clone())` at `elimination.rs:1303`).
+  The O109/O126 gate at `elimination.rs:537` then compares that against the
+  chain's normalised name. `manager.rs:482` builds the same set for the O109
+  propagation-coupling removal and tests it at `manager.rs:523`.
+- `chain_fold.rs:96-104` (`protected_vars`) uses
+  `var_observability::analyse_var_observability(&fu.cfg, …).escaping_var_names()`,
+  which is single-function and likewise keys on the spelled name.
+- A *third* implementation exists — `scan_module_traced_globals`
+  (`elimination.rs:1322-1357`), a whole-module scan restricted to `::`-qualified
+  literal targets. It lives in the optimiser but its only caller is the
+  **analyser** (`analyser/diagnostics.rs:454-455`, feeding W211/W220
+  suppression). No optimiser pass calls it.
+
+**Why it matters:** the spelling of the trace target decides whether the
+rewrite is sound.
+
+```tcl
+proc onw {a b c} { puts trace }
+trace add variable ::g write ::onw
+set g 1
+set g 2
+puts $g
+```
+
+`tcl opt` emits **O109 "Eliminate dead store"** and deletes `set g 1`, so the
+write trace fires once instead of twice. `tcl diag` on the same file emits
+**W220 "Assignment to 'g' is never read"**. Change the stores to `set ::g 1` /
+`set ::g 2` and both correctly go silent (O109 via the unrelated
+`var.starts_with("::")` check at `elimination.rs:543`, W220 via
+`scan_module_traced_globals`). Meanwhile O102 on the *same* unqualified spelling
+correctly abstains — `set g 1; puts $g` under that trace is left alone, and
+without the trace it forwards. Same variable, same file, one pass sound and one
+not.
+
+The list fold has the same hole: `trace add variable ::acc write ::onw; set acc
+{}; lappend acc a; lappend acc b` folds to `set acc {a b}` under O130, dropping
+two write-trace callbacks — and it does so even when the `trace` call is in the
+*same* scope, because `analyse_var_observability` recorded `::acc` and
+`chain_fold` asks about `acc`.
+
+**What cleanup looks like:** route both the O109/O126 gate and
+`chain_fold::protected_vars` through the same canonicalised fact SCCP and O102
+use, i.e. widen their protected set with `cu.ir_module.traced_variables` and bail
+on `has_dynamic_variable_trace`, normalising the chain key the way
+`populate_variable_trace_facts` normalises the target. Because
+`Module::traced_variables` is name-keyed and scope-blind, doing this verbatim
+would also protect a *proc-local* `x` when some other proc traces its own local
+`x`; the precision-preserving version is to promote
+`scan_module_traced_globals`' scope filter into a single module-level fact
+(globals-traced-anywhere ∪ this-function's-own-traces) and have all four
+consumers — SCCP, O102, O109/O126, O104/O130 — read that one. This changes
+user-visible output: O109/O126/O104/O130 and W211/W220 all lose firings around
+traced globals.
+**Scale:** one new shared fact plus four consumer call sites; contained in
+`tcl-compiler`.
+
+---
+
+## F3: GVN's PRE and LICM define "executable block" as raw CFG reachability, so O105/O106 fire inside code that O107/O112 simultaneously propose to delete
+
+**Confidence:** high
+**Category:** duplicated-decision
+
+**The modern path:** `SccpResult::executable_blocks` is the compiler's
+reachability answer, and every sibling consumer uses it — `elimination.rs:395`
+(`unreachable_blocks`, the O107 source), `propagation.rs:602` (O127 candidate
+gate), `propagation.rs:1641`/`:1695`, and the analyser's
+`crate::loops::build_loop_forest`, which takes the executable set as a parameter
+(`loops.rs:127-131`) and is called with `fu.sccp.executable_blocks`
+(`analyser/diagnostics/helpers.rs:924`). `loops.rs:19-25` states its purpose
+outright: the natural-loop forest "lives in `tcl-compiler` next to the CFG/SSA so
+the compiler explorer (and any future loop-aware tooling) reuse it rather than
+re-deriving loops."
+
+**The legacy/duplicate path:** `gvn.rs:1533` (`find_loop_invariants`) and
+`gvn.rs:1825` (`find_partial_redundancies`) both do
+`let executable = reachable_from(cfg, ssa.entry);` — `reachable_from`
+(`gvn.rs:1437-1462`) is a plain terminator-successor walk with no SCCP input.
+`find_loop_invariants` then re-derives the whole loop forest inline
+(`gvn.rs:1545-1574`: back-edge detection, `natural_loop_blocks` at
+`gvn.rs:1468-1493`, `loop_defined_variables` at `gvn.rs:1497-1515`) — a
+line-for-line duplicate of `loops.rs:98-181`, differing only in that it never
+learns which blocks SCCP proved dead. The doc comment at `gvn.rs:1274-1276`
+records the choice ("Treats every CFG block as executable (no SCCP
+unreachability filter). Callers that want SCCP pruning can pre-filter the CFG"),
+and the production caller `compiler_checks.rs:358-363` passes `&fu.cfg, &fu.ssa`
+unfiltered.
+
+**Why it matters:** contradictory user-visible diagnostics on one file.
+
+```tcl
+proc f {lst} {
+    set t 0
+    if {0} {
+        for {set i 0} {$i < 3} {incr i} {
+            set n [llength $lst]
+            set t [expr {$t + $n}]
+        }
+    }
+    return $t
+}
+```
+
+`tcl explore --json` reports `unreachableBlocks: 6` and, from the same run, one
+`gvn` finding: **O106** "`llength $lst` is loop-invariant and re-computed on each
+iteration. Consider hoisting it before the loop." `tcl opt` on the same file
+emits **O112** "Eliminate dead if (all conditions are always false)" and deletes
+the entire block the O106 points into. The editor therefore offers a hoist
+refactor inside a region it is simultaneously offering to delete. The same
+divergence lets the latch-dominance gate at `gvn.rs:1593` compute a loop body
+that includes blocks reachable only through a constant-false edge, which can
+also *suppress* a legitimate O106.
+
+**What cleanup looks like:** change `find_loop_invariants` and
+`find_partial_redundancies` to take the executable set (or the `FunctionUnit`)
+and seed it from `fu.sccp.executable_blocks`, then delete `reachable_from`,
+`natural_loop_blocks`, and the inline back-edge loop in `gvn.rs` in favour of
+`crate::loops::build_loop_forest`. The `_for_cu` wrappers
+(`gvn.rs:1929`, `:1947`) already hold a `FunctionUnit`, so the signature change
+is local. Naturally paired with the exemplar's own PRE/LICM migration, since
+both touch the same two entry points. User-visible: O105-PRE and O106 stop
+firing inside SCCP-dead code.
+**Scale:** two function signatures plus deletion of ~90 duplicated lines.
+
+---
+
+## F4: The interprocedural purity summary reaches dead-store elimination but never GVN, while `gvn.rs` carries a complete unwired second implementation of it
+
+**Confidence:** high
+**Category:** half-ported
+
+**The modern path:** `InterproceduralAnalysis::procedures[q].pure`
+(`interprocedural.rs:168`), computed by the `fixpoint_pure` least fixpoint over
+local purity ∧ callee purity (`interprocedural.rs:1040-1064`, driven from
+`:578-626`). It is a real, load-bearing optimiser fact: `elimination.rs:234-249`
+(`pure_call_targets`) projects it into the `PurityCtx` that gates O109/O126/O108
+RHS deletion (`elimination.rs:126-139`).
+
+**The legacy/duplicate path:** `gvn.rs` ships a parallel intra-module purity
+fixpoint — `PureProcs` (`gvn.rs:384`), `find_pure_procs` (`gvn.rs:437-460`),
+`function_body_is_pure` / `statement_is_pure` (`gvn.rs:464-531`),
+`is_pure_with_procs` (`gvn.rs:559`), and `is_worth_reporting_with_procs`
+(`gvn.rs:573-592`), the last documented as "user procs proved pure by
+intra-module analysis count as CSE candidates even if they don't carry the
+`CSE_CANDIDATE` registry trait". A workspace-wide grep finds **zero production
+callers** of any of the five — only `gvn.rs`'s own `#[cfg(test)]` block
+(`gvn.rs:3306-3473`). Production GVN instead calls the registry-only
+`is_worth_reporting` (`gvn.rs:668-673`, used at `gvn.rs:1043` and `:1079`), and
+the modern semantic path requires `Traits::PURE | Traits::CSE_CANDIDATE` from the
+registry (`gvn.rs:896-900`), which a user-defined proc can never carry.
+
+**Why it matters:** a missed optimisation on the most valuable CSE shape in real
+Tcl. For
+
+```tcl
+proc double {a} { return [expr {$a * 2}] }
+proc f {x} { set p [double $x]; set q [double $x]; return [list $p $q] }
+```
+
+`tcl explore --json` reports `interprocedural[0] = {"name": "::double", "pure":
+true, …}` and `gvn: []`. The compiler has *proved* the call reusable and no
+redundancy pass can see it, while `elimination` in the same run happily uses that
+same `pure` bit. Secondary cost: ~130 lines of untested-in-production purity
+logic in `gvn.rs` that a reader will reasonably assume is live, and whose
+judgement differs from `interprocedural`'s (e.g. `statement_is_pure`
+`gvn.rs:501-505` treats any unqualified `def` as proc-local-and-therefore-pure,
+a rule the interprocedural summary does not have).
+
+**What cleanup looks like:** decide which purity oracle wins and delete the
+other. The straightforward version is to delete `PureProcs`/`find_pure_procs`/
+`is_pure_with_procs`/`is_worth_reporting_with_procs` and instead give
+`GvnSemanticFacts::from_function` (`gvn.rs:763`) access to the interprocedural
+summary, so an `InvocationResolution::Unresolved` head whose qualified name is in
+`interproc.procedures` with `pure: true` and no world barrier becomes
+`GvnSiteEligibility::Eligible` with the proc's qualified name as the canonical
+key. That is the larger half: the current sidecar deliberately fails closed on
+unresolved names, so the summary needs projecting into `InvocationFacts`-shaped
+evidence rather than being consulted as a name set. User-visible: new O105/O106
+findings on repeated pure user-proc calls.
+**Scale:** a pass-level change in `gvn.rs` plus a plumbing change to carry
+`InterproceduralAnalysis` into the GVN entry points; alternatively a pure
+deletion if the capability is not wanted.
+
+---
+
+## F5: `PassContext::cross_event_vars` is written only inside `elimination::run`, so the four passes that read it always see an empty set
+
+**Confidence:** medium
+**Category:** stale-consumer
+
+**The modern path:** the iRules cross-event / TclOO instance-state escape set is
+derived from real analyses inside `elimination::run` —
+`cu.connection_scope.cross_event_defs ∪ cross_event_imports` for `::when::*`
+procs (`elimination.rs:296-313`) and `ir_module.methods[q].instance_vars` for
+method bodies (`elimination.rs:333-340`). It is stashed into
+`ctx.cross_event_vars` and consumed at `elimination.rs:551`, then restored
+(`elimination.rs:307`, `:324`, `:333`, `:357`).
+
+**The legacy/duplicate path:** `PassContext::cross_event_vars`
+(`optimiser/mod.rs:254`) is documented as shared state — "names whose values must
+be preserved across `when <event>` boundaries" — and is read as a safety gate by
+four other passes: `code_sinking.rs:79` (O125), `pattern_recognition.rs:142`
+(O119), `chain_fold.rs:74` (O104/O130), and `propagation.rs:680` (O127). But the
+one production context builder, `manager::build_pass_context`
+(`manager.rs:132-144`), never populates it, and `elimination` `mem::take`s and
+restores it, so it is `HashSet::new()` for every reader. The `#[cfg(test)]`
+comment at `optimiser/mod.rs:526` ("cross_event_vars and next_group are
+intentionally preserved across functions") reads as if some caller fills it; none
+does.
+
+**Why it matters:** four passes document and test a protection that does not
+exist in the shipped pipeline. The largest exposure is O125: with the
+`::when::HTTP_REQUEST` handler
+
+```tcl
+when HTTP_REQUEST {
+    if { [HTTP::header exists X] } { set n 1 } else { set n 2 }
+    set flag $n
+    if { $n > 1 } { log local0. "req $flag" }
+}
+when HTTP_RESPONSE { log local0. "resp $flag" }
+```
+
+`tcl opt --dialect f5-irules` emits O125 to sink `set flag $n` into the
+conditional branch even though `flag` is a cross-event variable read in
+`HTTP_RESPONSE`. Today the paired delete is dropped by
+`manager.rs:238 drop_def_elims_resurrected_by_replacements` (the insert text
+always re-mentions `$var`), so applying the surviving edit only duplicates the
+assignment rather than losing it — the guard is currently latent rather than
+actively wrong. That accident is exactly why it is worth fixing now: any
+refinement to the FP-OPT-08 guard turns this into "variable unset on the
+not-taken path" in an iRule. Confidence is medium only on the severity, not on
+the fact: the field is verifiably never written outside `elimination`.
+
+**What cleanup looks like:** populate `cross_event_vars` once in
+`manager::build_pass_context` from `cu.connection_scope` (and per-function from
+`ir_module.methods[..].instance_vars` where the pass walks methods), and drop
+`elimination`'s local save/restore in favour of the shared value — or, if the
+per-function scoping `elimination` needs cannot be hoisted, replace the shared
+`PassContext` field with an explicit `fn cross_event_vars(cu, qname)` helper each
+pass calls, so a reader cannot mistake an empty default for "nothing is
+cross-event". No user-visible change today (the guard only ever suppresses);
+after the FP-OPT-08 interaction is fixed it would suppress some O125 in iRules.
+**Scale:** one context-builder change plus the removal of a misleading shared
+field; a few call sites.

--- a/docs/audits/legacy-duplication-2026-08/runtime.md
+++ b/docs/audits/legacy-duplication-2026-08/runtime.md
@@ -1,0 +1,72 @@
+# Runtime/VM execution-layer duplication audit
+
+Scope: `runtime/rust/`, `rust/tcl-vm*`, `rust/tcl-bytecode`, `rust/tcl-cmd-core`,
+`rust/tcl-runtime-api`, `rust/tcl-host-native`, `rust/tcl-sandbox`, the
+`command-backing` gate and its report.
+
+## F1: `int`/`wide`/`entier` disagree between the VM and the WASM runtime on out-of-range float operands — the runtime raises a domain error where TIP 237 requires a bignum result
+
+**Confidence:** high
+**Category:** duplicated-implementation
+
+**Implementation A:** `rust/tcl-vm/src/cmd_math.rs:121-134` (`exact_trunc`/`wide_window`, used by `int_window` at `cmd_math.rs:307-318`) and `rust/tcl-vm/src/cmd_math.rs:464-476` (`m_entier`)
+**Implementation B / what it should be:** `runtime/rust/src/cmd_mathfunc.rs:130-166` (float-operand path falls into `dispatch`), backed by `rust/tcl-syntax/src/expr/mathfunc.rs:454-462` (`finite_trunc_to_i64`) and `:708-711` (the `"int" | "entier" | "wide"` arm)
+
+**Divergence evidence:** `expr {entier(1e300)}` (or `int`/`wide` with the same operand):
+- `tcl-vm`: `m_entier` (`cmd_math.rs:464`) takes the finite-`f64` path, calls `exact_trunc` (`cmd_math.rs:121-123`, explicitly commented "`int(1e300)`-style conversions see the full 10^300-scale value C does") and returns the full-precision bignum — the VM's own doc comment at `cmd_math.rs:459-463` cites this as TIP 237's mandated unbounded behaviour, and `int`/`wide` wrap it to a 64-bit window (`wide_window`, `cmd_math.rs:129-134`) rather than erroring.
+- `runtime/rust`: the float operand (`1e300` is a `Num::Float`, not an integer object) skips the tower fast-path at `cmd_mathfunc.rs:135` (`is_integer(argv[1])` is false) and falls through to the **shared** `dispatch(&lname, &nums)` call at `cmd_mathfunc.rs:151`. `tcl_syntax::expr::mathfunc::dispatch`'s `"int" | "entier" | "wide"` arm (`mathfunc.rs:708-711`) calls `finite_trunc_to_i64`, which returns `None` for any magnitude outside `i64` (`mathfunc.rs:454-462`, and pinned by its own unit test `mathfunc.rs:794-797`: `dispatch("entier", &[Num::Float(1.0e20)]) == None`). `None` becomes `cmd_mathfunc.rs:163-166`'s `"domain error: argument not in valid range"` (`-errorcode ARITH DOMAIN`) — i.e. `expr {entier(1e300)}` **errors** in the WASM runtime instead of returning a 300-digit integer.
+- The two engines also disagree on `int(1e20)`/`wide(1e20)`: VM silently returns a specific wrapped 64-bit value (mod 2^64, matching real tclsh's truncate-then-wrap); the runtime raises `ARITH DOMAIN`.
+
+**Why it matters:** `entier`/`int`/`wide` are core `expr` functions and TIP 237 explicitly makes `entier()` unbounded; the shared `tcl_syntax::expr::mathfunc::dispatch` helper (used only by the WASM runtime's `format`-sibling `cmd_mathfunc.rs`, not by the VM) has no bignum branch for the `Num::Float` case, so any script doing arithmetic on a float literal or computed double outside `i64` range and then converting it to an integer produces a spurious runtime error under the WASM/compiler target while working correctly under the VM. This is a silent, input-dependent correctness divergence between the two engines the compiler's WASM codegen targets and the CLI/tests run against — exactly the shape PR #1371 flagged, except here the "shared" module is the one that is wrong, and the non-shared VM code is the one that is right.
+
+**What cleanup looks like:** Give `tcl_syntax::expr::mathfunc::Num` (or `dispatch`'s `int`/`wide`/`entier`/`round` arms) a bignum-producing path — mirroring what `tcl-vm`'s `exact_trunc`/`wide_window`/`m_entier` already do — so both engines widen through the shared tower instead of the runtime silently domain-erroring. At minimum, `runtime/rust/src/cmd_mathfunc.rs` needs its own bignum fallback for the `Num::Float` case (parallel to the existing integer-operand fast path at `cmd_mathfunc.rs:135-143`) before this reaches the f64-limited shared `dispatch`.
+
+**Scale:** small, surgical fix (one function family: `int`/`wide`/`entier`/`round` for float operands) but high-severity, since it changes *pass vs. fail* for valid `expr` scripts depending on which engine executes them.
+
+---
+
+## F2: `file` is a partial port in `runtime/rust` — 17 of the registry's 31 subcommands are unimplemented, invisible to the presence-based parity gate, and diverge from the VM
+
+**Confidence:** high
+**Category:** half-ported
+
+**Implementation A:** `rust/tcl-registry/src/commands/tcl/file_.rs` — 31 `SubCommand` entries (`atime`, `attributes`, `channels`, `copy`, `delete`, `dirname`, `executable`, `exists`, `extension`, `home`, `isdirectory`, `isfile`, `join`, `link`, `lstat`, `mkdir`, `mtime`, `nativename`, `normalize`, `owned`, `pathtype`, `readable`, `readlink`, `rename`, `rootname`, `separator`, `size`, `split`, `stat`, `system`, `tail`, `tempdir`, `tempfile`, `tildeexpand`, `type`, `volumes`, `writable`; all `dialects: None` or `TCL86_PLUS`/`TCL90_PLUS`, i.e. all valid at Tcl 9.0)
+**Implementation B / what it should be:** `runtime/rust/src/cmd_fs.rs:90-109` (`FILE_SUBCOMMANDS`, 20 entries) + the `match sub.as_slice()` at `cmd_fs.rs:130-249`, which implements only: `dirname`, `tail`, `rootname`, `extension`, `join`, `split`, `normalize`, `separator`, `nativename`, `exists`, `isdirectory`, `isfile`, `readable`, `writable`, `executable`, `pathtype`, `delete`, `mkdir`, `size`, `type`. Missing entirely: `atime`, `attributes`, `channels`, `copy`, `home`, `link`, `lstat`, `mtime`, `owned`, `readlink`, `rename`, `stat`, `system`, `tempdir`, `tempfile`, `tildeexpand`, `volumes` — all fall through to the `other =>` arm at `cmd_fs.rs:247-251` (`"unknown or ambiguous subcommand …"`).
+
+**Divergence evidence:** `file mtime somepath` — `rust/tcl-vm/src/cmd_file.rs:245-248` implements `"mtime"` (dispatching to `file_mtime`); `runtime/rust/src/cmd_fs.rs` has no `mtime` arm and it is absent from `FILE_SUBCOMMANDS`, so the identical script raises `unknown or ambiguous subcommand "mtime": must be delete, dirname, executable, exists, extension, isdirectory, isfile, join, mkdir, nativename, normalize, pathtype, readable, rootname, separator, size, split, tail, type, or writable` (the literal error text at `cmd_fs.rs:249-250`) in the WASM runtime while succeeding in the VM. `copy`/`rename`/`stat`/`attributes` are unimplemented in *both* engines (`tcl-vm/src/cmd_file.rs`'s own `canonical_file_sub` table at lines 93-121 lists them for prefix-resolution parity with C but has no match arm for them either) — so those are a shared, if half-ported, gap; `mtime` is the one place the two engines visibly disagree today.
+
+**Why it matters:** `cargo xtask command-backing` classifies `file` as a fully-backed `Handler` (`docs/generated/wasm-command-backing.md:194`: `` | `file` | handler | `` ``) because the gate only checks that `register_builtin(b"file", …)` exists (`rust/xtask/src/command_backing.rs` §`scan_handlers`) — it has no visibility into which of the ensemble's subcommands are actually implemented. A compiler-emitted WASM module calling any of `file copy`/`file rename`/`file stat`/`file attributes`/`file mtime`/`file atime`/`file link`/`file readlink`/`file owned`/`file volumes`/`file channels`/`file system`/`file tempdir`/`file tempfile`/`file home`/`file tildeexpand` will fail at runtime with "unknown or ambiguous subcommand" despite `file` reporting green in the parity report — this is precisely the presence-vs-completeness gap AGENTS.md's WASM-parity section describes the gate as unable to catch.
+
+**What cleanup looks like:** Either extend the parity gate to check subcommand coverage against the registry's `SubCommand` lists (not just top-level command presence) so a partial ensemble port shows up as a real gap, or track `file`'s missing subcommands explicitly (e.g. a documented "known-gap" note analogous to `KNOWN_UNBACKED`, but subcommand-scoped) until they are implemented. Implementing the missing subcommands themselves (`copy`, `rename`, `stat`/`lstat`, `attributes`, `atime`/`mtime`) is the larger piece of work; at minimum `mtime` should be ported to `runtime/rust` since the VM already has a working reference implementation to port from.
+
+**Scale:** medium — one file (`runtime/rust/src/cmd_fs.rs`), ~17 subcommands, several of which (`copy`, `rename`, `stat`) need real host-filesystem plumbing through `tcl_platform::Filesystem` and are not simple copy-paste ports.
+
+---
+
+## F3: `format` is reimplemented from scratch in `runtime/rust` instead of using the shared `tcl_cmd_core::format` the VM already migrated to, and is missing the Tcl 9 `%#d`/`%#i` alternate-form prefix as a result
+
+**Confidence:** high
+**Category:** duplicated-implementation
+
+**Implementation A:** `rust/tcl-cmd-core/src/format.rs` (the shared, `ValueOps`-generic implementation, driven by `tcl_syntax::format::parse_spec`), consumed by `rust/tcl-vm/src/cmd_format.rs:94-97` (`tcl_cmd_core::format::format_cmd(vm, args)`) — the module doc at `cmd_format.rs:19-23` states "Both rendering directions now live in the shared `tcl_cmd_core`".
+**Implementation B / what it should be:** `runtime/rust/src/cmd_format.rs` — an entirely independent, hand-rolled `format_cmd` (lines 70-285) with its own flag/width/precision parsing loop, not calling `tcl_cmd_core::format` or `tcl_syntax::format::parse_spec` at all (confirmed: `runtime/rust/src/cmd_format.rs` has no `tcl_cmd_core` reference anywhere in the file, unlike its sibling `cmd_scan.rs`, which *does* use the shared `tcl_cmd_core::scan` engine — `scan` was migrated, `format` was not).
+
+**Divergence evidence:** `format %#d 42`:
+- `tcl-cmd-core::format::render_spec` (`rust/tcl-cmd-core/src/format.rs:161-171`) explicitly adds the Tcl 9 `0d` alternate-form prefix for `%#d`/`%#i` (`digits.insert_str(0, "0d")` when `FmtFlags::HASH` is set and the verb is `d`/`i`) — this is regression-tested against real tclsh 9.0 at `rust/tcl-vm/tests/cmd_string_e2e.rs:895-906` (`bug_format_hash_decimal_prefix_tcl9`, asserting `format %#d 42` → `"0d42"`, with the test doc explicitly noting the *old*, wrong VM behaviour was `"42"` — i.e. this was already found and fixed once, on the VM/shared side).
+- `runtime/rust/src/cmd_format.rs`'s `int_field` (lines 348-435) only adds an alternate-form prefix for `o`/`x`/`X`/`b` (`cmd_format.rs:401-412`: `match conv { b"o" => "0o", b"x"|b"X" => "0x", b"b" => "0b", _ => "" }` — the `_` arm silently drops the prefix for `d`/`i`). So `format %#d 42` under `runtime/rust` returns `"42"`, while the exact same script under `tcl-vm` (and, per the pinned test, real tclsh 9.0) returns `"0d42"`.
+
+**Why it matters:** this is the PR #1371 shape precisely: one semantic question (`format`'s conversion rendering) answered in two independently-maintained places, and a bug that was found and fixed in the shared implementation (with a regression test) never propagated to the copy that didn't get migrated. A script compiled to WASM and a script run through the VM/CLI will silently render different output for `%#d`/`%#i` — a correctness divergence between the compiler's target runtime and the tool used to validate `format` behaviour day to day.
+
+**What cleanup looks like:** Port `runtime/rust/src/cmd_format.rs` onto `tcl_cmd_core::format::format_cmd` the same way `cmd_scan.rs` already sits on `tcl_cmd_core::scan`, and onto `runtime/rust`'s existing `ValueOps` adapter for `*mut TclObj` (`runtime/rust/src/value_ops.rs`, already used by the other migrated `cmd_*.rs` files). This deletes ~450 lines of duplicated spec-parsing/rendering logic and closes the `%#d`/`%#i` gap (and forecloses any other float/width/precision edge case the two copies may have quietly diverged on) for free.
+
+**Scale:** medium — one file, but a well-trodden migration path (identical to the `format`/`scan` split already completed for `tcl-vm` and for `runtime/rust`'s own `cmd_scan.rs`), so mechanical rather than exploratory.
+
+---
+
+## Areas checked with no reportable finding
+
+- `string`, `list`, `dict`, `array`, `namespace`, `binary`, `clock`, `regex`, `switch`, `trace`, `lseq`, `mathop` command families: both `tcl-vm` and `runtime/rust` route through `tcl_cmd_core` (confirmed via `grep -l tcl_cmd_core` over both `src/` trees), and the `append`/`lappend`/`incr` variable-mutation cores are explicitly shared via `tcl_cmd_core::var` even in files that don't otherwise import the crate.
+- `::tcl::mathfunc::*`/`::tcl::mathop::*` registration: both are driven off `tcl_syntax::expr::mathfunc`/`operators` tables rather than hand-typed name lists (the `command_backing.rs` header documents a prior staleness bug here, already fixed — issue #983/#987's unification).
+- `string bytelength`'s absence from `runtime/rust/src/cmd_string.rs`'s `STRING_SUBCOMMANDS` looked like a gap on first read, but the registry marks it `dialects: Some(DialectSet::TCL8X)` (`rust/tcl-registry/src/commands/tcl/string_.rs:920-931`) — removed in Tcl 9.0, so its absence from a Tcl-9-targeting runtime is correct, not a gap.
+- The `command-backing` gate itself (`rust/xtask/src/command_backing.rs`) is well-built for what it claims: it explicitly documents its own presence-only limitation, has drift tests for report staleness and stale classifications, and its `KNOWN_UNBACKED` list reads as genuinely tracked (each entry has a specific technical reason, several tied to numbered issues) rather than a dumping ground.
+- No overstated claims found regarding the embedded Tcltest files vs. the C `test*` command surface, or regarding package-driven extension bundling, in the files reviewed under `runtime/rust/src/`.

--- a/docs/audits/legacy-duplication-2026-08/tooling.md
+++ b/docs/audits/legacy-duplication-2026-08/tooling.md
@@ -1,0 +1,223 @@
+# tcl-lsp tooling/editor duplication audit
+
+Branch: `claude/legacy-code-duplication-audit-edm0bo`. Scope: `rust/tcl-cli*`,
+`rust/f5-cli`, `rust/tcl-mcp`, `rust/tcl-explorer*`, `rust/tcl-debugger`,
+`rust/tcl-pkg`, `rust/tcl-diagram`, `rust/tcl-spec-studio`, `rust/xtask`,
+`editors/`, `docs/generated/`, `scripts/`.
+
+---
+
+## F1: The native LSP's `diagramData` command is a private, shallower reimplementation of the shared `tcl-diagram` crate
+
+**Confidence:** high
+**Category:** duplicated-tooling
+
+**Authoritative source:** `rust/tcl-diagram/src/data.rs:444-524` (`diagram_data` /
+`diagram_data_for_dialect`) — projects a parsed script's IR into
+`{events: [{name, priority, multiplicity, flow}], procedures: [{name, params,
+flow}]}` (decision/action/assign/return/switch/loop nodes). Its module doc
+(`rust/tcl-diagram/src/lib.rs:18-32`) states it exists precisely so "any
+tool" shares one implementation, and names "the CLI, and the MCP" as
+consumers.
+
+- `rust/tcl-cli/src/commands/diagram.rs:32,42` — `tcl diagram` calls
+  `tcl_diagram::diagram_data_for_dialect` directly.
+- `rust/tcl-mcp/src/tools.rs:305-309` — the MCP `diagram` tool calls the same
+  function: `tcl_diagram::diagram_data_for_dialect(source, registry(&dialect), &dialect)`.
+
+**The duplicate / stale copy:** `rust/tcl-lsp-server/src/lib.rs:10600-10610`
+— the `tcl-lsp.diagramData` custom-command handler:
+
+```rust
+fn diagram_data_command(args: &[serde_json::Value]) -> Option<serde_json::Value> {
+    let source = args.first().and_then(serde_json::Value::as_str)?;
+    let events: Vec<serde_json::Value> =
+        tcl_lsp_core::irules_context::scan_file_events(source, "f5-irules")
+            .into_iter()
+            .map(|name| serde_json::json!({ "name": name }))
+            .collect();
+    Some(serde_json::json!({ "events": events }))
+}
+```
+
+This calls `scan_file_events` (`rust/tcl-lsp-core/src/irules_context.rs:67-73`),
+a helper that only regex/brace-scans `when EVENT { … }` headers for event
+*names*. It returns `{"events": [{"name": "..."}]}` — no `procedures` key at
+all, and each event carries only a bare name: no `priority`, no
+`multiplicity`, no `flow`. `tcl-lsp-server`/`tcl-lsp-core`'s `Cargo.toml`
+files have no dependency on `tcl-diagram` at all (`grep` for
+`tcl-diagram`/`tcl_diagram` in both returns nothing).
+
+**Is it gated?** No gate — this is hand-written Rust logic, not a generated
+artefact, so no xtask drift check applies. The only test is
+`rust/tcl-lsp-server/tests/e2e/commands.rs:354-368`
+(`diagram_extracts_irule_events`), which asserts only that `events[].name`
+contains the expected event name — it never asserts `procedures` or `flow`
+exist, so it cannot catch the shape mismatch.
+
+**Drift evidence:** Both consumer-side clients that call this command expect
+the full `tcl-diagram` shape, not what the server actually returns:
+
+- `editors/vscode/src/chat/commands/diagram.ts:25-35` declares
+  `interface DiagramData { events: Array<{name, priority, multiplicity,
+  flow}>; procedures: Array<{name, params, flow}>; error?}` and at line
+  118-119 invokes `command: "tcl-lsp.diagramData"` expecting that shape; line
+  134 checks `diagramData.events.length === 0 && diagramData.procedures.length
+  === 0` — `procedures` is always `undefined` in the real response, so that
+  branch can never distinguish "no procedures" from "field doesn't exist,"
+  and the LLM prompt built from `structuredDataStr` (the raw JSON) is missing
+  all flow/procedure data it is instructed to diagram.
+- `editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt:86-93`
+  (`DiagramDataAction`) sets `resultExtension(result) = "mmd"` — i.e. it
+  saves the command's raw JSON reply as a `.mmd` (Mermaid) scratch file
+  (via `TclLspActionBase.stringifyResult`/`presentResult`,
+  `editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActionBase.kt:152-181`,
+  which just does `Gson().toJson(result)`). The server's actual reply
+  (`{"events":[{"name":"HTTP_REQUEST"}]}`) is not Mermaid syntax, so the
+  resulting `diagram-data.mmd` scratch file cannot render as a diagram —
+  this action does not produce a usable diagram today.
+- By contrast, `editors/zed/README.md:206` advertises a `diagram` tool
+  through the `tcl-lsp-mcp` context server — that one, being the real MCP
+  `diagram` tool (`rust/tcl-mcp/src/tools.rs:305-309`), returns the correct
+  full structure. **Same underlying question ("what is this iRule's
+  structure?"), three different answers depending on which client path you
+  go through** — exactly the two-source-of-truth shape this audit is hunting
+  for.
+
+**Why it matters:** VS Code's `/diagram` chat command and JetBrains' "Diagram
+Data" action are both user-facing, advertised features
+(`rust/tcl-lsp-server/tests/e2e/commands.rs:388` lists `tcl-lsp.diagramData`
+as a `CORE_COMMANDS` every backend must expose) that silently produce
+degraded or broken output: VS Code's LLM diagram prompt only ever sees event
+names (no branches, no procedure bodies), and JetBrains' action produces a
+non-Mermaid `.mmd` file. A user going through the MCP tool (Zed, or `tcl-mcp`
+directly) gets the real, richly-structured diagram; a user going through the
+native LSP command in VS Code/JetBrains does not — with no error, so the gap
+is invisible until someone inspects the output.
+
+**What cleanup looks like:** Replace `diagram_data_command`'s body with a
+call into `tcl_diagram::diagram_data_for_dialect` (parse the source, resolve
+its dialect/registry the same way the compiler-explorer/diagnostics command
+does elsewhere in `tcl-lsp-server`, add the `tcl-diagram` crate dependency to
+`tcl-lsp-server`/`tcl-lsp-core`), then extend the e2e test to assert
+`procedures`, `flow`, `priority`, and `multiplicity` are present and
+non-trivial for a small fixture with both an event and a procedure — so this
+class of shape regression fails a test instead of shipping silently.
+
+**Scale:** ~10-line function replaced by a call to an existing crate; one
+`Cargo.toml` dependency line; one e2e test extended. Small, contained fix
+with an outsized correctness payoff (two editors' diagram feature currently
+under-delivers or is broken).
+
+---
+
+## F2: The canonical dialect list is hand-copied into 8+ editor files with no drift gate, and has already gone stale in the Sublime README
+
+**Confidence:** medium-high
+**Category:** ungated-duplication
+
+**Authoritative source:** `rust/tcl-dialect/src/profile.rs:259-816` —
+`static CATALOG: [DialectProfile; 16]`, one entry per dialect (`name: "..."`
+at lines 266 `bpf`, 286 `cadence-eda-tcl`, 346 `expect`, 376 `f5-bigip`, 403
+`f5-iapps`, 437 `f5-irules`, 467 `f5-tmsh`, 491 `intel-quartus-eda-tcl`, 552
+`mentor-eda-tcl`, 596 `synopsys-eda-tcl`, 654 `tcl8.4`, 682 `tcl8.5`, 706
+`tcl8.6`, 730 `tcl9.0`, 756 `tcl9.1`, 780 `xilinx-eda-tcl`). Of these, 15 are
+the LSP-selectable set (`bpf` is explicitly a `tcl-lsp CLI`-only dialect per
+its KCS page `docs/kcs/features/kcs-feature-bpf-tcl.md`'s `## Applies to`
+line, not something `tclLsp.dialect` is meant to expose — README.md's own
+tables at lines 867-881 list the 15 LSP dialects and `bpf` separately). None
+of the xtask generators (`gen-editor-settings`, `gen-vscode-package`,
+`gen-jetbrains-catalog`, `gen-editor-catalogs`, `gen-tmlanguage-keywords`)
+touch a dialect enum — they are all scoped to `DiagCode`/`OptCategory`
+tables, event/command catalogues, and TextMate keyword lists (confirmed by
+grepping `dialect` across `rust/xtask/src/gen_*.rs`: the only hits are
+`TCL_SOURCE_EXTENSIONS`/glob helpers, not the dialect *name* list).
+
+**The duplicate / stale copy:** the 15-entry dialect list is hand-typed,
+independently, in at least these places:
+
+- `editors/vscode/package.json:3193-3207` (`tclLsp.dialect` setting `enum`)
+  **and again** at `editors/vscode/package.json:7935-7949` (a chat-tool
+  argument schema's `dialects` enum) — two separate hand-typed copies in the
+  same file.
+- `editors/jetbrains/.../settings/TclLspSettings.kt:573-590`
+  (`DIALECT_OPTIONS`) — outside any `@generated:*` marker block (the file's
+  generated regions are `@generated:diagnostic-vars`,
+  `@generated:optimiser-vars`, `@generated:diagnostic-map`,
+  `@generated:optimiser-map` only, per `gen_jetbrains.rs:215-218,397-399`).
+- `editors/sublime-text/plugin.py:52-69` (`DIALECTS`, functional — feeds the
+  "Select Dialect" quick panel).
+- `editors/sublime-text/README.md:150-163` ("Supported dialects" table).
+- `editors/neovim/tcl_lsp.lua:19-21` and `editors/neovim/README.md:122`.
+- `editors/helix/README.md:83-86`.
+- `editors/emacs/README.md:73`.
+- `editors/zed/README.md:151-153`.
+- `README.md:865-881,992-1005` (two more copies at the repo root, outside
+  the audited `editors/` tree but the same knowledge again).
+
+**Is it gated?** No gate — none of the `xtask-check` generators, and no CI
+step, verifies any of these lists against `tcl-dialect`'s `CATALOG`. A new
+dialect profile can be added to `profile.rs` and every one of the ~10 copies
+above will silently continue advertising the old set.
+
+**Drift evidence:** `editors/sublime-text/README.md:150-163`'s "Supported
+dialects" table has already drifted from the canonical 15: it lists 11
+entries (`tcl8.4`, `tcl8.5`, `tcl8.6`, `tcl9.0`, `f5-irules`, `f5-iapps`,
+`synopsys-eda-tcl`, `cadence-eda-tcl`, `xilinx-eda-tcl`,
+`intel-quartus-eda-tcl`, `mentor-eda-tcl`) and is missing **`tcl9.1`,
+`f5-tmsh`, `f5-bigip`, and `expect`** — four dialects the extension actually
+supports (confirmed functional in `plugin.py:52-69`'s `DIALECTS`, which *is*
+complete). The doc undersells the extension to a Sublime user reading it.
+
+**Why it matters:** a Sublime user reading the README has no way to learn
+that `tcl9.1`, `f5-tmsh`, `f5-bigip`, or `expect` dialect selection exists —
+a documentation gap that actively misleads, not a typo. More broadly, every
+other copy is a maintenance trap: the next new dialect (there is prior art —
+`bpf` was added as dialect #16 without any editor file needing to change,
+because it's deliberately CLI-only) will need the same manual edit in up to
+10 files with nothing to catch a miss, unlike every diagnostic/optimisation/
+keyword catalogue in the same files, which the `xtask-check` gate protects.
+
+**What cleanup looks like:** Add a `dialect names` (or fold into
+`gen-editor-catalogs`) xtask generator that emits the canonical LSP-facing
+dialect list (all `CATALOG` entries except ones marked CLI-only, if such a
+flag is added) and patches the `enum` arrays in `package.json` (both
+occurrences), the JetBrains `DIALECT_OPTIONS` list (inside a new
+`@generated:dialect-options` marker pair), and the Sublime `DIALECTS`
+list/README table; wire its `--check` into `xtask-check`. The plain-Markdown
+READMEs (Neovim/Helix/Emacs/Zed/root `README.md`) that are prose, not
+settings schemas, are lower priority but could at minimum gain a `<!--
+dialects:begin/end -->` marker patched the same way, or a
+`kcs-index-links`-style check that greps them for the same set.
+
+**Scale:** one new small xtask generator (~50-100 lines, similar shape to
+`gen_tmlanguage_keywords.rs`'s multi-file patching) plus a Makefile/CI wire-
+up; fixing the immediate Sublime README drift is a 4-line documentation
+edit.
+
+---
+
+## Summary
+
+Two findings, both verified on both sides of the duplication:
+
+- **F1 (high confidence, duplicated-tooling):** `tcl-lsp-server`'s
+  `tcl-lsp.diagramData` command (`rust/tcl-lsp-server/src/lib.rs:10600`) is a
+  private, much shallower reimplementation of `tcl_diagram::diagram_data_for_dialect`
+  (`rust/tcl-diagram/src/data.rs:444`), which `tcl-cli` and `tcl-mcp` both
+  correctly share. It returns bare event names with no `procedures`/`flow`/
+  `priority`/`multiplicity`, breaking VS Code's `/diagram` chat prompt (which
+  expects that shape, `editors/vscode/src/chat/commands/diagram.ts:25`) and
+  producing a non-Mermaid `.mmd` file from JetBrains' `DiagramDataAction`
+  (`editors/jetbrains/.../TclLspActions.kt:86`) — while Zed's MCP-routed
+  `diagram` tool gets the correct answer for the identical input. Fix is a
+  ~10-line change plus a dependency add.
+- **F2 (medium-high confidence, ungated-duplication):** the 15-entry
+  LSP-facing dialect list, canonically `rust/tcl-dialect/src/profile.rs`'s
+  `CATALOG`, is hand-copied into 10+ files across VS Code, JetBrains, Sublime,
+  Neovim, Helix, Emacs, Zed, and the root README, with zero drift-gate
+  coverage (unlike every diagnostic/optimisation/keyword catalogue nearby,
+  which the `xtask-check` gate protects). It has already drifted: the
+  Sublime README's "Supported dialects" table is missing `tcl9.1`,
+  `f5-tmsh`, `f5-bigip`, and `expect`, even though the extension's own
+  `plugin.py` `DIALECTS` list supports all 15.

--- a/docs/audits/legacy-duplication-2026-08/tooling.md
+++ b/docs/audits/legacy-duplication-2026-08/tooling.md
@@ -121,11 +121,28 @@ under-delivers or is broken).
 at lines 266 `bpf`, 286 `cadence-eda-tcl`, 346 `expect`, 376 `f5-bigip`, 403
 `f5-iapps`, 437 `f5-irules`, 467 `f5-tmsh`, 491 `intel-quartus-eda-tcl`, 552
 `mentor-eda-tcl`, 596 `synopsys-eda-tcl`, 654 `tcl8.4`, 682 `tcl8.5`, 706
-`tcl8.6`, 730 `tcl9.0`, 756 `tcl9.1`, 780 `xilinx-eda-tcl`). Of these, 15 are
-the LSP-selectable set (`bpf` is explicitly a `tcl-lsp CLI`-only dialect per
-its KCS page `docs/kcs/features/kcs-feature-bpf-tcl.md`'s `## Applies to`
-line, not something `tclLsp.dialect` is meant to expose — README.md's own
-tables at lines 867-881 list the 15 LSP dialects and `bpf` separately). None
+`tcl8.6`, 730 `tcl9.0`, 756 `tcl9.1`, 780 `xilinx-eda-tcl`).
+
+> **Correction (review of PR #1401).** This report originally claimed only 15
+> of the 16 were LSP-selectable, treating `bpf` as CLI-only on the strength of
+> its KCS page's `## Applies to: tcl-lsp CLI` line. That was wrong, and the
+> server says so directly: `is_known_dialect_name`
+> (`rust/tcl-lsp-server/src/lib.rs:20059-20061`) accepts **any** catalogue
+> profile for `initializationOptions.folderDialects` and the per-folder
+> `tclLsp.dialect`, and its doc comment names the case explicitly — *"including
+> the config-only f5-tmsh / f5-bigip / **bpf**, which a bare `DialectSet::parse`
+> check wrongly rejects"*. `dialect_from_language_id`
+> (`lib.rs:5879`) maps `"tcl-bpf" | "bpf" => "bpf"`. The `## Applies to` line
+> scopes the *KCS note*, not `tclLsp.dialect`.
+>
+> All **16** catalogue entries are therefore LSP-selectable, and the finding is
+> larger than first written: `bpf` appears nowhere in
+> `editors/vscode/package.json` at all, so it is a supported dialect missing
+> from every editor enum — a second live drift alongside the Sublime README
+> one below. A generator that excludes "CLI-only" entries would preserve that
+> omission rather than detect it; it should emit all 16.
+
+None
 of the xtask generators (`gen-editor-settings`, `gen-vscode-package`,
 `gen-jetbrains-catalog`, `gen-editor-catalogs`, `gen-tmlanguage-keywords`)
 touch a dialect enum — they are all scoped to `DiagCode`/`OptCategory`
@@ -133,7 +150,8 @@ tables, event/command catalogues, and TextMate keyword lists (confirmed by
 grepping `dialect` across `rust/xtask/src/gen_*.rs`: the only hits are
 `TCL_SOURCE_EXTENSIONS`/glob helpers, not the dialect *name* list).
 
-**The duplicate / stale copy:** the 15-entry dialect list is hand-typed,
+**The duplicate / stale copy:** the dialect list is hand-typed (as 15
+entries, omitting `bpf` — see the correction above),
 independently, in at least these places:
 
 - `editors/vscode/package.json:3193-3207` (`tclLsp.dialect` setting `enum`)
@@ -161,7 +179,7 @@ dialect profile can be added to `profile.rs` and every one of the ~10 copies
 above will silently continue advertising the old set.
 
 **Drift evidence:** `editors/sublime-text/README.md:150-163`'s "Supported
-dialects" table has already drifted from the canonical 15: it lists 11
+dialects" table has already drifted from the canonical set: it lists 11
 entries (`tcl8.4`, `tcl8.5`, `tcl8.6`, `tcl9.0`, `f5-irules`, `f5-iapps`,
 `synopsys-eda-tcl`, `cadence-eda-tcl`, `xilinx-eda-tcl`,
 `intel-quartus-eda-tcl`, `mentor-eda-tcl`) and is missing **`tcl9.1`,
@@ -212,7 +230,7 @@ Two findings, both verified on both sides of the duplication:
   (`editors/jetbrains/.../TclLspActions.kt:86`) — while Zed's MCP-routed
   `diagram` tool gets the correct answer for the identical input. Fix is a
   ~10-line change plus a dependency add.
-- **F2 (medium-high confidence, ungated-duplication):** the 15-entry
+- **F2 (medium-high confidence, ungated-duplication):** the 16-entry
   LSP-facing dialect list, canonically `rust/tcl-dialect/src/profile.rs`'s
   `CATALOG`, is hand-copied into 10+ files across VS Code, JetBrains, Sublime,
   Neovim, Helix, Emacs, Zed, and the root README, with zero drift-gate
@@ -220,4 +238,6 @@ Two findings, both verified on both sides of the duplication:
   which the `xtask-check` gate protects). It has already drifted: the
   Sublime README's "Supported dialects" table is missing `tcl9.1`,
   `f5-tmsh`, `f5-bigip`, and `expect`, even though the extension's own
-  `plugin.py` `DIALECTS` list supports all 15.
+  `plugin.py` `DIALECTS` list supports all 15 of the ones it lists. Per the
+  correction at the top of F2, the canonical set is 16 — `bpf` is
+  LSP-selectable and missing from every editor enum.


### PR DESCRIPTION
## Summary

- Adds `docs/audits/legacy-duplication-2026-08/` — the working notes from six read-only audits run after #1371, backing the 27 issues tracked by #1400.
- **Docs only.** 7 markdown files, 1,720 insertions, zero source changes.
- **Explicitly temporary.** The README's first line is a delete instruction: when every issue tracked by #1400 is closed, delete the whole directory including the README. Rationale is stated in the file — once the issues are shut the notes describe code that no longer exists, and a reader cannot tell a fixed finding from a live one.

### Why keep them at all

The notes carry what did not fit into the issues:

- **Verified-clean lists** — the subsystems each audit checked with nothing to report, and why. The most expensive part to reproduce, and the most useful to whoever audits next.
- **Rejected candidates** — findings considered and dismissed with reasons, including AGENTS.md's documented carve-outs (the lowering fallback-to-generic-call pattern; the irreducible analyser-local TclOO semantics) and debt already tracked at its call site, such as `alias.rs:201-223`.
- **Per-finding confidence and scale estimates.**

### File → issue map

| Report | Scope | Issues |
|---|---|---|
| `optimiser.md` | Optimiser passes and their feeding analyses | #1374, #1377, #1385, #1392 |
| `analyser.md` | Analyser, semantic model, registry compliance | #1378, #1379, #1381, #1388, #1389, #1390, #1391 |
| `lowering.md` | Parsing, CST, segmenter, IR, CFG, SSA, codegen | #1375, #1376, #1380, #1393 |
| `lsp.md` | LSP feature providers | #1386 |
| `runtime.md` | `runtime/rust`, `tcl-vm`, `tcl-cmd-core`, parity gate | #1382, #1383, #1384 |
| `tooling.md` | CLIs, MCP, xtask generators, editor integrations | #1387, #1394 |

#1395–#1397 (carried forward from #890) and #1398–#1399 (from #1371's own known limitations) are not backed by a report here.

### Editing done to the raw notes

Stripped the scratchpad paths two agents wrote into their trailers, and recorded the tree state the reports were accurate against (`0f97d98`). Otherwise verbatim.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

| Command | Result |
|---|---|
| `cargo xtask kcs-index-links` | **pass** — "KCS docs checks passed." The gate that can actually fail on a docs change: it validates every local markdown link under `docs/`, plus design/KCS index coverage. The reports contain no markdown links; the README's links are relative to sibling files in the same directory and resolve. |
| `make check-all` | **pass** — "check-all: PASSED". Full multi-language lint + typecheck (TS ESLint/Prettier/tsc, Rust fmt + pedantic clippy across the workspace and both wasm targets, Python ruff/ty/pyright). |

The heavier suites (`make test`, `test-ext`, `runtime-rust-test`, `test-emacs`) were **not** run — waived by the maintainer for a docs-only commit that touches no source. Noting it explicitly rather than leaving the checklist ambiguous.

New files land under `docs/audits/`, which is outside the `docs/design/` and `docs/kcs/` trees the index-coverage checks police, so no index entry is required.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? **No** — no source files are touched. The notes *describe* contracts that other issues propose changing; this PR changes none of them.
- [ ] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`. — n/a
- [ ] If I added a new compiler KCS note, I linked it from both READMEs. — n/a (not a KCS note; these are transient working notes, deliberately not filed under `docs/kcs/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141dJWmHcLYEynMpDy9rXft

---
_Generated by [Claude Code](https://claude.ai/code/session_0141dJWmHcLYEynMpDy9rXft)_