### PR TITLE
Fix nextest --no-run/--no-fail-fast conflict; optimise the analysis crates in dev-profile test builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,7 +445,13 @@ jobs:
     # healthy — a 2026-08 regression to 16 min turned out to be two oversized
     # `tcl-compiler` per_item tests, since fixed; if this job blows past ~5
     # min again, suspect a runaway test before suspecting the box or the
-    # cache).  It is the ONLY job routed to the self-hosted runner, and that
+    # cache).  No longer the longest pole: `lsp-e2e` now is (~390s vs ~150s
+    # here).  Note that neither is the workflow's critical path — the
+    # `build-tcl-lsp-server` -> `test-ext` chain is, finishing 40-80s after
+    # `lsp-e2e` does, so shortening the test jobs cuts cost and the local
+    # `make test-rust` loop rather than PR turnaround.
+    #
+    # It is the ONLY job routed to the self-hosted runner, and that
     # is deliberate: the box has one runner instance, so anything sent there
     # executes serially and queues behind this job.
     #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,18 +480,22 @@ jobs:
       # Skipped entirely for docs-only changes and already-green tags;
       # downgraded to a cache-warming build (--no-run) on an already-green
       # merge push, because PR runs restore this job's cache from the base
-      # branch — see the channel job header for the full contract.
+      # branch — see the channel job header for the full contract.  --no-run
+      # drops --no-fail-fast rather than adding to it: nextest 0.9.143 rejects
+      # `--no-run --no-fail-fast` outright ("the argument '--no-run' cannot be
+      # used with '--no-fail-fast'"), and the flag is meaningless anyway when
+      # no tests are executed.
       - name: cargo nextest run (workspace minus VM-sim heavies and lsp-e2e)
         if: needs.channel.outputs.docs_only != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')
         env:
           ALREADY_GREEN: ${{ needs.channel.outputs.already_green }}
         run: |
-          extra=""
+          extra="--no-fail-fast"
           if [ "$ALREADY_GREEN" = "true" ]; then
             echo "tree already green on its PR run — building test binaries (cache warmth) without re-running them"
             extra="--no-run"
           fi
-          cargo nextest run $extra --workspace --exclude tcl-irule-test --exclude f5-cli --exclude tcl-lsp-server --exclude tcl-fuzz --all-features --no-fail-fast
+          cargo nextest run $extra --workspace --exclude tcl-irule-test --exclude f5-cli --exclude tcl-lsp-server --exclude tcl-fuzz --all-features
 
       # nextest does not run doctests; run them for the WHOLE workspace (incl.
       # the crates excluded above — doctests are cheap) so the other jobs need
@@ -537,12 +541,12 @@ jobs:
         env:
           ALREADY_GREEN: ${{ needs.channel.outputs.already_green }}
         run: |
-          extra=""
+          extra="--no-fail-fast"
           if [ "$ALREADY_GREEN" = "true" ]; then
             echo "tree already green on its PR run — building test binaries (cache warmth) without re-running them"
             extra="--no-run"
           fi
-          cargo nextest run $extra -p tcl-irule-test -p f5-cli -p tcl-fuzz --all-features --no-fail-fast
+          cargo nextest run $extra -p tcl-irule-test -p f5-cli -p tcl-fuzz --all-features
 
   # Native-server lsp_e2e suite.  Its own job (hence its own status check)
   # because it is a distinct, heavier surface: it builds the `tcl-lsp-server`
@@ -579,12 +583,12 @@ jobs:
         env:
           ALREADY_GREEN: ${{ needs.channel.outputs.already_green }}
         run: |
-          extra=""
+          extra="--no-fail-fast"
           if [ "$ALREADY_GREEN" = "true" ]; then
             echo "tree already green on its PR run — building test binaries (cache warmth) without re-running them"
             extra="--no-run"
           fi
-          cargo nextest run $extra -p tcl-lsp-server --no-fail-fast
+          cargo nextest run $extra -p tcl-lsp-server
 
   # Supply-chain audit (advisories / licenses / bans / sources) via the
   # committed deny.toml.  Its own job so a denial is attributable independently

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,6 +230,17 @@ debug = "line-tables-only"
 # miniz_oxide / sha2 / aes overrides below already make, for the same reason.
 # These crates change far less often than the server, so their (one-time,
 # cached) build cost is paid rarely.
+#
+# `tcl-registry` is deliberately NOT in this list.  Its widget tables are
+# declared as `const SUBCOMMANDS: &[SubCommand]` (e.g. commands/tk/entry.rs),
+# and a `const` reference has no stable address — each use site may materialise
+# its own copy.  `registry_commands::tk_widgets_with_subcommands_self_reference
+# _their_object_class` asserts `ptr::eq(class.instance_methods,
+# spec.subcommands)`, which holds at opt-level 0 only by accident of codegen and
+# fails at 2.  The assertion's intent (the two must never drift apart) is worth
+# keeping; making it actually guaranteed means turning those tables into
+# `static`s, which is its own change.  Until then this crate stays unoptimised —
+# it is lookup tables, not hot compute, so the loss is small.
 [profile.dev.package.tcl-lsp-db]
 opt-level = 2
 
@@ -243,9 +254,6 @@ opt-level = 2
 opt-level = 2
 
 [profile.dev.package.tcl-syntax]
-opt-level = 2
-
-[profile.dev.package.tcl-registry]
 opt-level = 2
 
 [profile.dev.package.tcl-spectcl]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,6 +212,63 @@ debug = "line-tables-only"
 # tests (tcl-bigip-io, bigip-report-gen) gunzip + KDF real fixtures on every
 # run — measured ~157 s of dev-profile test time spent inside these three
 # crates' hot loops.  Optimising just them barely moves compile time.
+# The analysis path — parser, CST/IR, salsa queries, spec/registry lookup — is
+# what the lsp_e2e suite actually spends its time in, and at opt-level 0 it is
+# roughly 5x slower than at 2.  Measured on a 4-core box over the whole
+# `-p tcl-lsp-server` surface (1945 tests): test wall clock 211 s -> 120 s, and
+# the four heaviest tests (which analyse ~5400-line generated documents and
+# together burn a quarter of all test CPU) drop from 68.7/48.3/46.8/36.9 s to
+# 16.2/13.9/9.6/8.0 s, taking the straggler tail down with them.
+#
+# Deliberately the DEPENDENCY crates only — `tcl-lsp-server` itself stays at
+# opt-level 0.  That crate is ~30k lines and optimising it is what costs: a
+# blanket `[profile.dev] opt-level = 2` takes an incremental rebuild after
+# touching `tcl-lsp-server/src/lib.rs` from 24 s to 284 s, which loses more
+# than the 91 s of test time it wins.  Optimising just the crates below leaves
+# that edit-rebuild loop at 27 s (+3 s) while keeping essentially all of the
+# runtime win (120 s vs 114 s for the blanket build) — the same trade the
+# miniz_oxide / sha2 / aes overrides below already make, for the same reason.
+# These crates change far less often than the server, so their (one-time,
+# cached) build cost is paid rarely.
+[profile.dev.package.tcl-lsp-db]
+opt-level = 2
+
+[profile.dev.package.tcl-compiler]
+opt-level = 2
+
+[profile.dev.package.tcl-lsp-core]
+opt-level = 2
+
+[profile.dev.package.tcl-lexer]
+opt-level = 2
+
+[profile.dev.package.tcl-syntax]
+opt-level = 2
+
+[profile.dev.package.tcl-registry]
+opt-level = 2
+
+[profile.dev.package.tcl-spectcl]
+opt-level = 2
+
+[profile.dev.package.tcl-core-types]
+opt-level = 2
+
+[profile.dev.package.tcl-dialect]
+opt-level = 2
+
+[profile.dev.package.tcl-regex]
+opt-level = 2
+
+[profile.dev.package.tcl-bigip]
+opt-level = 2
+
+[profile.dev.package.tcl-irules]
+opt-level = 2
+
+[profile.dev.package.salsa]
+opt-level = 2
+
 [profile.dev.package.miniz_oxide]
 opt-level = 3
 [profile.dev.package.sha2]


### PR DESCRIPTION
## Summary

Two related CI changes — a correctness fix, then a performance one found while measuring the fallout.

**1. `ci.yml`: drop `--no-fail-fast` from the cache-warming `--no-run` branch** (`99eb40e1`)

The merge-push optimisation sets `--no-run` on an already-green tree, but all three call sites still appended `--no-fail-fast`. cargo-nextest 0.9.143 rejects that pair outright (`error: the argument '--no-run' cannot be used with '--no-fail-fast'`), so every cache-warming build failed at argument parsing with exit code 2 — no test ever ran. `extra` now defaults to `--no-fail-fast` and is *replaced* by `--no-run`, rather than the flag being appended unconditionally.

Reproduced against nextest 0.9.143: the old form exits 2, the fixed form exits 0.

**2. `Cargo.toml`: raise the analysis crates to `opt-level = 2` in dev-profile builds** (`27d53c4f`, `aac43a98`)

The lsp_e2e suite is CPU-bound in the Tcl analysis path (parser, CST/IR, salsa queries, spec lookup), which was compiled at `opt-level = 0`.

Dependency crates only — `tcl-lsp-server` itself stays unoptimised. That crate is ~30k lines and optimising it is what costs: a blanket `[profile.dev] opt-level = 2` takes an incremental rebuild after touching `lib.rs` from 24s to 284s, losing more than it wins. Restricting it to the dependencies keeps that edit-rebuild loop at 27s. This is the same trade the existing `miniz_oxide` / `sha2` / `aes` overrides already make.

`tcl-registry` is deliberately excluded — see Notes.

## Validation

- Full `-p tcl-lsp-server` suite: **1945 tests pass**
- `tcl-registry` + `tcl-dialect` + `tcl-spectcl`: **942 tests pass**
- CI green on `aac43a98`

Measured locally (4-core), whole `-p tcl-lsp-server` surface:

| | before | after |
|---|---|---|
| test wall clock | 211s | 134s |
| slowest test | 68.7s | 16.2s |
| incremental rebuild after touching `lib.rs` | 24s | 27s |

In CI, lsp-e2e's nextest run time went **284.4s → 125.3s** (2.27×) for the same 1945 tests. That is the one cache-independent figure; see Notes on the rest.

## Notes

**Why `tcl-registry` is excluded.** Its widget tables are declared `const SUBCOMMANDS: &[SubCommand]` (`commands/tk/entry.rs` and friends), and `registry_commands::tk_widgets_with_subcommands_self_reference_their_object_class` asserts `ptr::eq(class.instance_methods, spec.subcommands)`. A `const` reference has no stable address — each use site may materialise its own copy — so that assertion held at `opt-level = 0` only by accident of codegen and failed at 2. Weakening it to a content compare would discard its intent (the two tables must never drift apart); making it actually guaranteed means turning those tables into `static`s, which has its own const-eval constraints and deserves a separate change. Leaving the crate unoptimised costs ~12s (122s → 134s locally) and it is lookup tables, not hot compute.

`tcl-dialect` has a similar `ptr::eq` in *production* code (`profile.rs:952`) but is unaffected and stays optimised — `PLAIN_TCL` is a real `static`, so its address is stable by guarantee rather than by luck.

**On the other CI job timings.** Editing `Cargo.toml` invalidates Swatinem's cache for every job, so the first run after this change pays a cold rebuild everywhere — including jobs whose compilation settings did not change (`build-tcl-lsp-server` builds with `--profile ci`, which these overrides do not touch). Those numbers are not steady-state and should not be read as regressions. `test-ext` *is* affected indirectly, via the dev-profile `cargo xtask` work behind `make copy-canonical` and the Zed-query drift gates. The post-merge push run on `rust` is the first warm-cache measurement.

**Stale comment refreshed.** The `rust-tests` job header claimed to be the longest pole; `lsp-e2e` now is (~390s vs ~150s). Neither is the workflow's critical path — the `build-tcl-lsp-server` → `test-ext` chain is, finishing 40–80s later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEnwiPhct3GZqQAeDpG4bF