### PR TITLE
Improve native installer harness support

### DIFF
--- a/INSTALL-cli.md
+++ b/INSTALL-cli.md
@@ -30,6 +30,23 @@ Bobbit is project-only because it discovers the project-root `.mcp.json`.
 Claude Code skills are offered separately. Run `sh install.sh --help` for the full env-var list
 (`TCL_LSP_ONLY`, `TCL_LSP_NO_MCP`, `TCL_LSP_NO_SKILLS`, `TCL_LSP_NO_PATH`, …).
 
+### Migrating from the main-branch Python installer
+
+Migration is automatic, even when you decline an equivalent native component.
+The installer removes positively identified Python zipapps (`tcl`, `f5`, the
+two retired compiler-explorer launchers, and `tcl-lsp-mcp-server.pyz`), including
+installs with a suffix or in a custom directory recorded in your shell startup
+file. It also removes Python `argcomplete` scripts and stale Claude Code or
+Codex MCP registrations. The old Claude prompt and skill bundle is moved out of
+active discovery and backed up under `~/.claude/.tcl-lsp-python-backup-*` before
+the native bundle is installed.
+
+Shared system packages such as Python, Tcl, `curl`, `unzip`, `sshpass`, or
+Wireshark are not removed, because the installer did not own them. Existing
+`.tcl-lsp-bak-*` recovery directories are also preserved. Set
+`TCL_LSP_NO_LEGACY_CLEANUP=1` only if you deliberately need to keep the retired
+installation active.
+
 ## Manual install
 
 Release assets are named `<tool>-<target-triple>`, with no version in the

--- a/INSTALL-cli.md
+++ b/INSTALL-cli.md
@@ -6,7 +6,8 @@ no runtime, no interpreter — download one file per tool and run it.
 ## Install
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/bitwisecook/tcl-lsp/main/scripts/install/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/bitwisecook/tcl-lsp/rust/scripts/install/install.sh \
+  | TCL_LSP_VERSION=v2.1.19 sh
 ```
 
 Works on macOS and Linux (x86_64, arm64, and riscv64 on Linux).
@@ -15,15 +16,18 @@ Re-run the same line to update.
 To inspect first, or run unattended:
 
 ```sh
-curl -fsSLo install.sh https://raw.githubusercontent.com/bitwisecook/tcl-lsp/main/scripts/install/install.sh
+curl -fsSLo install.sh https://raw.githubusercontent.com/bitwisecook/tcl-lsp/rust/scripts/install/install.sh
 less install.sh
-TCL_LSP_ASSUME_YES=1 sh install.sh
+TCL_LSP_VERSION=v2.1.19 TCL_LSP_ASSUME_YES=1 sh install.sh
 ```
 
 The installer picks the binary for your platform, verifies it against the
-release `SHA256SUMS`, installs shell completions, and offers to set up the
-`tcl-mcp` MCP server and the Claude Code skills if it finds `claude` or
-`codex`. Run `sh install.sh --help` for the full env-var list
+release `SHA256SUMS`, installs shell completions, and offers each detected AI
+harness its own `tcl-mcp` registration. Claude Code, Codex, Gemini CLI, GitHub
+Copilot CLI, OpenCode, Hermes, Goose, and Bobbit are recognised. Harnesses with
+project files offer project or user scope; otherwise registration is user-level.
+Bobbit is project-only because it discovers the project-root `.mcp.json`.
+Claude Code skills are offered separately. Run `sh install.sh --help` for the full env-var list
 (`TCL_LSP_ONLY`, `TCL_LSP_NO_MCP`, `TCL_LSP_NO_SKILLS`, `TCL_LSP_NO_PATH`, …).
 
 ## Manual install
@@ -56,7 +60,7 @@ The MCP server is published the same way, as `tcl-mcp-<triple>`.
 ## Verify downloads
 
 ```sh
-tag="v2.1.16"
+tag="v2.1.19"
 curl -fLO "https://github.com/bitwisecook/tcl-lsp/releases/download/$tag/SHA256SUMS"
 sha256sum --ignore-missing -c SHA256SUMS \
     || shasum -a 256 --ignore-missing -c SHA256SUMS

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ the VS Code extension from the
 [Marketplace](https://marketplace.visualstudio.com/items?itemName=bitwisecook.tcl-lsp).
 Nothing needs Python — the server is a self-contained native binary.
 
+While the Rust rewrite is on the pre-release channel, install it from the
+`rust` branch and pin the current pre-release:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/bitwisecook/tcl-lsp/rust/scripts/install/install.sh \
+  | TCL_LSP_VERSION=v2.1.19 sh
+```
+
 ### All editors
 
 | Editor | Type | Setup | Unique extras |
@@ -1411,7 +1419,11 @@ generation, …). Build it with `make rust-mcp`.
 
 **Install / register.** The installer fetches the prebuilt native binary for
 your platform from the GitHub release (`tcl-mcp-<triple>`), verifies its
-checksum, and registers it with Claude Code (`claude mcp add`) and Codex:
+checksum, detects supported AI harnesses, and asks separately whether to
+register each one. If the current project contains that harness's files, the
+installer offers project or user scope; otherwise it uses user scope. Claude
+Code, Codex, Gemini CLI, GitHub Copilot CLI, OpenCode, Hermes, Goose, and
+Bobbit are recognised (Bobbit supports project scope only):
 
 ```bash
 ./scripts/install/install.sh            # fetches + registers the native binary
@@ -1420,7 +1432,7 @@ checksum, and registers it with Claude Code (`claude mcp add`) and Codex:
 - `TCL_LSP_MCP_BIN=/path/to/tcl-mcp ./scripts/install/install.sh` — register a
   local build instead of downloading.
 
-Working **inside this repo**, Claude Code / Codex auto-discover the server via
+Working **inside this repo**, compatible harnesses auto-discover the server via
 the committed [`.mcp.json`](.mcp.json), which launches
 [`scripts/tcl-mcp`](scripts/tcl-mcp): it prefers a local build
 (`make rust-mcp`), else a cached binary, else fetches the release asset for the

--- a/rust/tcl-mcp/src/main.rs
+++ b/rust/tcl-mcp/src/main.rs
@@ -28,8 +28,8 @@ use std::sync::Arc;
 use rmcp::ServiceExt;
 use rmcp::handler::server::ServerHandler;
 use rmcp::model::{
-    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ErrorData,
-    ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
+    CacheScope, CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ErrorData,
+    ListToolsResult, PaginatedRequestParams, ProtocolVersion, ServerCapabilities, ServerInfo, Tool,
 };
 use rmcp::service::{RequestContext, RoleServer};
 use rmcp::transport::stdio;
@@ -66,7 +66,7 @@ impl ServerHandler for TclMcp {
     async fn list_tools(
         &self,
         _request: Option<PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, ErrorData> {
         let tools = tools::tool_schemas()
             .into_iter()
@@ -78,10 +78,12 @@ impl ServerHandler for TclMcp {
                 Tool::new(name, description, Arc::new(object))
             })
             .collect();
-        Ok(ListToolsResult {
+        Ok(tool_list_result(
             tools,
-            ..Default::default()
-        })
+            context
+                .protocol_version()
+                .is_some_and(|version| version >= ProtocolVersion::V_2026_07_28),
+        ))
     }
 
     async fn call_tool(
@@ -107,6 +109,19 @@ impl ServerHandler for TclMcp {
     }
 }
 
+fn tool_list_result(tools: Vec<Tool>, supports_cache_hints: bool) -> ListToolsResult {
+    let mut result = ListToolsResult::with_all_items(tools);
+    if supports_cache_hints {
+        // MCP 2026-07-28 requires both cache fields on list results.  The tool
+        // catalogue is static and contains no user-specific data, but keep a
+        // zero TTL so clients continue to refresh it exactly as they did for
+        // older protocol revisions.
+        result.ttl_ms = Some(0);
+        result.cache_scope = Some(CacheScope::Public);
+    }
+    result
+}
+
 /// Every Tokio worker thread's stack budget — see the matching constant
 /// and doc comment in `tcl-lsp-server/src/main.rs` for why this must be
 /// generous: the analyser's and CFG builder's depth-capped recursions
@@ -127,4 +142,21 @@ async fn serve() -> Result<(), Box<dyn std::error::Error>> {
     let service = TclMcp.serve(stdio()).await?;
     service.waiting().await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod protocol_tests {
+    use super::*;
+
+    #[test]
+    fn tool_list_cache_hints_follow_the_negotiated_protocol() {
+        let modern = serde_json::to_value(tool_list_result(Vec::new(), true)).unwrap();
+        assert_eq!(modern["resultType"], "complete");
+        assert_eq!(modern["ttlMs"], 0);
+        assert_eq!(modern["cacheScope"], "public");
+
+        let legacy = serde_json::to_value(tool_list_result(Vec::new(), false)).unwrap();
+        assert!(legacy.get("ttlMs").is_none());
+        assert!(legacy.get("cacheScope").is_none());
+    }
 }

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -1924,13 +1924,34 @@ legacy_claude_skill() {
         "$skill_dir/SKILL.md"
 }
 
+has_legacy_claude_bundle_marker() {
+    claude_root="$HOME/.claude"
+    if [ -f "$claude_root/tcl-ai.pyz" ] \
+       && looks_like_legacy_zipapp "$claude_root/tcl-ai.pyz"; then
+        return 0
+    fi
+    for skill_dir in "$claude_root"/skills/*; do
+        [ -d "$skill_dir" ] || continue
+        legacy_claude_skill "$skill_dir" && return 0
+    done
+    return 1
+}
+
 cleanup_legacy_claude_bundle() {
     # The Python bundle merged files into ~/.claude, so preserve every retired
     # item in one recovery directory before removing it from active discovery.
+    # Prompt filenames alone are not ownership markers: names such as
+    # manifest.json can belong to an unrelated Claude setup.
+    marker_override="${1:-0}"
+    keep_current_f5_query="${2:-0}"
     claude_root="$HOME/.claude"
     [ -d "$claude_root" ] || return 0
     backup="$claude_root/.tcl-lsp-python-backup-$(date +%Y%m%d%H%M%S)"
     staged=0
+    bundle_owned=0
+    if [ "$marker_override" = 1 ] || has_legacy_claude_bundle_marker; then
+        bundle_owned=1
+    fi
 
     if [ -f "$claude_root/tcl-ai.pyz" ] \
        && looks_like_legacy_zipapp "$claude_root/tcl-ai.pyz"; then
@@ -1940,22 +1961,25 @@ cleanup_legacy_claude_bundle() {
         staged=1
     fi
 
-    for prompt in brainstorm-security-checks.md explain_flow_system.md \
-                  irules_system.md irules_system.md.j2 manifest.json \
-                  tcl_system.md tcl_system.md.j2 tk_system.md; do
-        [ -f "$claude_root/prompts/$prompt" ] || continue
-        mkdir -p "$backup/prompts"
-        cp "$claude_root/prompts/$prompt" "$backup/prompts/"
-        rm -f "$claude_root/prompts/$prompt"
-        staged=1
-    done
+    if [ "$bundle_owned" = 1 ]; then
+        for prompt in brainstorm-security-checks.md explain_flow_system.md \
+                      irules_system.md irules_system.md.j2 manifest.json \
+                      tcl_system.md tcl_system.md.j2 tk_system.md; do
+            [ -f "$claude_root/prompts/$prompt" ] || continue
+            mkdir -p "$backup/prompts"
+            cp "$claude_root/prompts/$prompt" "$backup/prompts/"
+            rm -f "$claude_root/prompts/$prompt"
+            staged=1
+        done
+    fi
     rmdir "$claude_root/prompts" 2>/dev/null || true
 
     for skill_dir in "$claude_root"/skills/*; do
         [ -d "$skill_dir" ] || continue
         if legacy_claude_skill "$skill_dir"; then
             :
-        elif [ "$staged" = 1 ] \
+        elif [ "$bundle_owned" = 1 ] \
+             && [ "$keep_current_f5_query" != 1 ] \
              && [ "$(basename "$skill_dir")" = f5-query ] \
              && grep -aqE '^name:[[:space:]]*f5-query[[:space:]]*$' \
                     "$skill_dir/SKILL.md"; then
@@ -2016,7 +2040,6 @@ cleanup_legacy_python_installs() {
 
     cleanup_legacy_mcp_registrations "$claude_record" "$codex_mcp_path"
     cleanup_legacy_completions
-    cleanup_legacy_claude_bundle
 }
 
 propose_update_clis() {
@@ -2652,7 +2675,7 @@ register_mcp_claude() {
     if ! have_claude_cli; then
         warn "Claude Code was detected, but its CLI is not on PATH."
         warn "Register manually: claude mcp add -s $scope tcl-lsp -- $MCP_PATH"
-        return 1
+        return 0
     fi
     # Old installers relied on Claude's default local scope.  Remove that
     # stale entry as well as the chosen target, then add back explicitly.
@@ -2987,6 +3010,8 @@ install_claude_skills() {
         warn "could not locate extracted skill payload in $extract_dir"
         return 1
     fi
+    legacy_bundle_before=0
+    has_legacy_claude_bundle_marker && legacy_bundle_before=1
     mkdir -p "$HOME/.claude"
 
     # Snapshot existing ~/.claude/{skills,prompts,tcl-ai.pyz} before overwrite.
@@ -3011,26 +3036,64 @@ install_claude_skills() {
     [ -d "$inner/skills" ] && cp -R "$inner/skills" "$HOME/.claude/"
     n="$(find "$HOME/.claude/skills" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')"
     log "installed Claude Code skills -> $HOME/.claude/skills/ ($n skills)"
+    # Retire the Python-era bundle only after the replacement archive has been
+    # downloaded, verified, extracted, and installed. The current f5-query
+    # skill is content-compatible with the old bundle and has just been
+    # refreshed, so keep it while removing other positively identified items.
+    cleanup_legacy_claude_bundle "$legacy_bundle_before" 1
 }
 
 install_ai_integrations() {
     # No further questions asked here — choose_ai_components already
     # set WANT_MCP / WANT_SKILLS, and choose_mcp_prefix set the path.
     if [ "$WANT_MCP" = "1" ]; then
-        install_mcp
-        [ "$INSTALL_MCP_CLAUDE" = 1 ] && register_mcp_claude
-        [ "$INSTALL_MCP_CODEX" = 1 ] && register_mcp_codex
-        [ "$INSTALL_MCP_GEMINI" = 1 ] && register_mcp_gemini
-        [ "$INSTALL_MCP_COPILOT" = 1 ] && register_mcp_copilot
-        [ "$INSTALL_MCP_OPENCODE" = 1 ] && register_mcp_opencode
-        [ "$INSTALL_MCP_HERMES" = 1 ] && register_mcp_hermes
-        [ "$INSTALL_MCP_GOOSE" = 1 ] && register_mcp_goose
-        [ "$INSTALL_MCP_BOBBIT" = 1 ] && register_mcp_bobbit
+        install_mcp || return 1
+        if [ "$INSTALL_MCP_CLAUDE" = 1 ]; then register_mcp_claude || return 1; fi
+        if [ "$INSTALL_MCP_CODEX" = 1 ]; then register_mcp_codex || return 1; fi
+        if [ "$INSTALL_MCP_GEMINI" = 1 ]; then register_mcp_gemini || return 1; fi
+        if [ "$INSTALL_MCP_COPILOT" = 1 ]; then register_mcp_copilot || return 1; fi
+        if [ "$INSTALL_MCP_OPENCODE" = 1 ]; then register_mcp_opencode || return 1; fi
+        if [ "$INSTALL_MCP_HERMES" = 1 ]; then register_mcp_hermes || return 1; fi
+        if [ "$INSTALL_MCP_GOOSE" = 1 ]; then register_mcp_goose || return 1; fi
+        if [ "$INSTALL_MCP_BOBBIT" = 1 ]; then register_mcp_bobbit || return 1; fi
         cleanup_stale_mcp
     fi
     if [ "$WANT_SKILLS" = "1" ]; then
-        install_claude_skills
+        install_claude_skills || return 1
     fi
+}
+
+execute_install_plan() {
+    # Destructive migration is deliberately last. A failed download,
+    # verification, extraction, installation, or registration must leave the
+    # working Python-era installation available for recovery.
+    install_downloader || return 1
+
+    if needs_prefix; then
+        case "$ONLY" in
+            tcl)  install_cli tcl || return 1 ;;
+            f5)   install_cli f5 || return 1 ;;
+            both) install_cli tcl || return 1
+                  install_cli f5 || return 1 ;;
+            none) : ;;
+            *) die "invalid ONLY=$ONLY" ;;
+        esac
+        install_cli_runtime_dependencies || return 1
+        apply_path_update || return 1
+    fi
+
+    case "$ONLY" in
+        tcl)  install_completion tcl || return 1 ;;
+        f5)   install_completion f5 || return 1 ;;
+        both) install_completion tcl || return 1
+              install_completion f5 || return 1 ;;
+    esac
+
+    install_ai_integrations || return 1
+    cleanup_legacy_python_installs
+    # A declined skills component still needs its retired bundle cleaned up.
+    [ "$WANT_SKILLS" = "1" ] || cleanup_legacy_claude_bundle
+    cleanup_legacy_path_entries
 }
 
 
@@ -3091,32 +3154,7 @@ main() {
     require_root_or_die
 
     # === PHASE 3: execute the plan (no more questions) ===
-    # Retire main-branch Python artefacts before writing their native
-    # replacements. This also prevents old shell completions, Claude skills,
-    # or MCP registrations from surviving when that component was declined.
-    cleanup_legacy_python_installs
-    install_downloader
-
-    if needs_prefix; then
-        case "$ONLY" in
-            tcl)  install_cli tcl ;;
-            f5)   install_cli f5 ;;
-            both) install_cli tcl; install_cli f5 ;;
-            none) : ;;
-            *) die "invalid ONLY=$ONLY" ;;
-        esac
-        install_cli_runtime_dependencies
-        apply_path_update
-    fi
-
-    case "$ONLY" in
-        tcl)  install_completion tcl ;;
-        f5)   install_completion f5 ;;
-        both) install_completion tcl; install_completion f5 ;;
-    esac
-
-    install_ai_integrations
-    cleanup_legacy_path_entries
+    execute_install_plan
 
     printf '\n%sInstall complete.%s\n' "$BOLD" "$RESET"
     if needs_prefix && ! path_contains "$PREFIX"; then

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -33,9 +33,10 @@
 # All prompts run up front, before any download or install action — so
 # you can answer the questions and then walk away.
 #
-# If the `claude` or `codex` CLI is detected (or ~/.claude / ~/.codex
-# exists), offers to install the MCP server and — for Claude Code —
-# the skills zip from the same GitHub release.
+# Detects supported AI harnesses from their CLI or configuration directory.
+# For each one, offers to register the MCP server.  When the current project
+# contains that harness's files, the installer also offers project or user
+# scope; otherwise it uses user scope.  Claude Code skills remain optional.
 #
 # Downloaded release artefacts are verified against the release's
 # SHA256SUMS file (and, if `cosign` is installed and the release
@@ -51,6 +52,7 @@
 #   TCL_LSP_VERSION         - release tag (default: installer's stamped tag, or latest in a checkout)
 #   TCL_LSP_PREFIX          - install dir (default: prompt; non-interactive: ~/.local/bin)
 #   TCL_LSP_REPO            - GitHub owner/repo (default: bitwisecook/tcl-lsp)
+#   TCL_LSP_INSTALLER_BRANCH - source branch shown in re-run instructions (default: rust)
 #   TCL_LSP_ONLY            - "tcl", "f5", or "both" (default: both)
 #   TCL_LSP_OS              - bypass /etc/os-release: debian|rhel|fedora|arch|alpine|macos
 #   TCL_LSP_NO_DEPS         - 1 to skip OS-package install (curl, unzip)
@@ -61,6 +63,12 @@
 #   TCL_LSP_NO_SKILLS       - 1 to skip Claude Code skills install
 #   TCL_LSP_NO_CLAUDE       - 1 to ignore Claude Code even if detected
 #   TCL_LSP_NO_CODEX        - 1 to ignore Codex even if detected
+#   TCL_LSP_NO_GEMINI       - 1 to ignore Gemini CLI even if detected
+#   TCL_LSP_NO_COPILOT      - 1 to ignore GitHub Copilot CLI even if detected
+#   TCL_LSP_NO_OPENCODE     - 1 to ignore OpenCode even if detected
+#   TCL_LSP_NO_HERMES       - 1 to ignore Hermes even if detected
+#   TCL_LSP_NO_GOOSE        - 1 to ignore Goose even if detected
+#   TCL_LSP_NO_BOBBIT       - 1 to ignore Bobbit even if detected
 #   TCL_LSP_NO_VERIFY            - 1 to install without SHA256SUMS verification
 #   TCL_LSP_REQUIRE_COSIGN       - 1 to fail when cosign signature is missing/invalid
 #   TCL_LSP_ALLOW_INSECURE_WGET  - 1 to allow wget without --https-only (DANGEROUS)
@@ -101,6 +109,7 @@ INSTALLER_VERSION="${INSTALLER_VERSION_TAG} ${INSTALLER_VERSION_SHA}"
 
 DEFAULT_REPO="bitwisecook/tcl-lsp"
 REPO="${TCL_LSP_REPO:-$DEFAULT_REPO}"
+INSTALLER_SOURCE_BRANCH="${TCL_LSP_INSTALLER_BRANCH:-rust}"
 select_release_version() {
     requested="$1"
     stamped="$2"
@@ -136,6 +145,18 @@ WANT_TCL=""
 WANT_F5=""
 WANT_MCP=""
 WANT_SKILLS=""
+
+# Per-harness MCP registration plan.  Detection and all prompts happen before
+# any download.  Scope is "project" or "user"; user-only harnesses never offer
+# a project choice.
+INSTALL_MCP_CLAUDE=0; MCP_SCOPE_CLAUDE=user
+INSTALL_MCP_CODEX=0; MCP_SCOPE_CODEX=user
+INSTALL_MCP_GEMINI=0; MCP_SCOPE_GEMINI=user
+INSTALL_MCP_COPILOT=0; MCP_SCOPE_COPILOT=user
+INSTALL_MCP_OPENCODE=0; MCP_SCOPE_OPENCODE=user
+INSTALL_MCP_HERMES=0; MCP_SCOPE_HERMES=user
+INSTALL_MCP_GOOSE=0; MCP_SCOPE_GOOSE=user
+INSTALL_MCP_BOBBIT=0; MCP_SCOPE_BOBBIT=project
 
 GREEN=''; YELLOW=''; RED=''; BOLD=''; RESET=''
 if [ -t 1 ] && command -v tput >/dev/null 2>&1; then
@@ -443,8 +464,8 @@ require_root_or_die() {
 Re-run as root with the two-step pattern (safer than \`curl | sudo sh\` —
 you can inspect the script first):
   curl -fsSLo /tmp/tcl-lsp-install.sh \\
-       https://raw.githubusercontent.com/${REPO}/main/scripts/install/install.sh
-  sudo sh /tmp/tcl-lsp-install.sh"
+       https://raw.githubusercontent.com/${REPO}/${INSTALLER_SOURCE_BRANCH}/scripts/install/install.sh
+  sudo TCL_LSP_VERSION=${VERSION} sh /tmp/tcl-lsp-install.sh"
     die "$msg"
 }
 
@@ -1407,82 +1428,137 @@ needs_prefix() {
     [ "$WANT_TCL" = "1" ] || [ "$WANT_F5" = "1" ]
 }
 
+ai_client_detected() {
+    [ "${HAS_CLAUDE:-0}" = 1 ] || [ "${HAS_CODEX:-0}" = 1 ] \
+        || [ "${HAS_GEMINI:-0}" = 1 ] || [ "${HAS_COPILOT:-0}" = 1 ] \
+        || [ "${HAS_OPENCODE:-0}" = 1 ] || [ "${HAS_HERMES:-0}" = 1 ] \
+        || [ "${HAS_GOOSE:-0}" = 1 ] || [ "${HAS_BOBBIT:-0}" = 1 ]
+}
+
+harness_has_project_files() {
+    # Only files/directories that the harness itself owns count.  A generic
+    # repository checkout is not enough to make project scope appear.
+    root="$PROJECT_ROOT"
+    case "$1" in
+        claude)  [ -e "$root/.claude" ] || [ -e "$root/CLAUDE.md" ] || [ -e "$root/.mcp.json" ] ;;
+        codex)   [ -e "$root/.codex" ] || [ -e "$root/AGENTS.md" ] ;;
+        gemini)  [ -e "$root/.gemini" ] || [ -e "$root/GEMINI.md" ] ;;
+        copilot) [ -e "$root/.github/copilot-instructions.md" ] \
+                 || [ -e "$root/.github/instructions" ] \
+                 || [ -e "$root/.github/agents" ] \
+                 || [ -e "$root/.github/mcp.json" ] || [ -e "$root/.mcp.json" ] ;;
+        opencode) [ -e "$root/.opencode" ] || [ -e "$root/opencode.json" ] \
+                  || [ -e "$root/opencode.jsonc" ] ;;
+        bobbit)  [ -e "$root/.bobbit" ] ;;
+        *)       return 1 ;;
+    esac
+}
+
+set_harness_plan() {
+    client="$1"; enabled="$2"; scope="$3"
+    case "$client" in
+        claude)  INSTALL_MCP_CLAUDE="$enabled";  MCP_SCOPE_CLAUDE="$scope" ;;
+        codex)   INSTALL_MCP_CODEX="$enabled";   MCP_SCOPE_CODEX="$scope" ;;
+        gemini)  INSTALL_MCP_GEMINI="$enabled";  MCP_SCOPE_GEMINI="$scope" ;;
+        copilot) INSTALL_MCP_COPILOT="$enabled"; MCP_SCOPE_COPILOT="$scope" ;;
+        opencode) INSTALL_MCP_OPENCODE="$enabled"; MCP_SCOPE_OPENCODE="$scope" ;;
+        hermes)  INSTALL_MCP_HERMES="$enabled";  MCP_SCOPE_HERMES="$scope" ;;
+        goose)   INSTALL_MCP_GOOSE="$enabled";   MCP_SCOPE_GOOSE="$scope" ;;
+        bobbit)  INSTALL_MCP_BOBBIT="$enabled";  MCP_SCOPE_BOBBIT="$scope" ;;
+        *) die "internal: unknown AI harness: $client" ;;
+    esac
+}
+
+harness_env_disabled() {
+    case "$1" in
+        claude)  [ "${TCL_LSP_NO_CLAUDE:-0}" = 1 ] ;;
+        codex)   [ "${TCL_LSP_NO_CODEX:-0}" = 1 ] ;;
+        gemini)  [ "${TCL_LSP_NO_GEMINI:-0}" = 1 ] ;;
+        copilot) [ "${TCL_LSP_NO_COPILOT:-0}" = 1 ] ;;
+        opencode) [ "${TCL_LSP_NO_OPENCODE:-0}" = 1 ] ;;
+        hermes)  [ "${TCL_LSP_NO_HERMES:-0}" = 1 ] ;;
+        goose)   [ "${TCL_LSP_NO_GOOSE:-0}" = 1 ] ;;
+        bobbit)  [ "${TCL_LSP_NO_BOBBIT:-0}" = 1 ] ;;
+    esac
+}
+
+choose_harness_scope() {
+    client="$1"; label="$2"; supports_project="$3"
+    scope=user
+    # Bobbit intentionally discovers only a project-root .mcp.json.  It has no
+    # documented user MCP store, so do not manufacture an unsupported scope.
+    if [ "$supports_project" = 2 ]; then
+        prompt_record mcp-scope "$label registration scope" "project (only supported scope)"
+        printf '%s\n' project
+        return
+    fi
+    if [ "$supports_project" = 1 ] && harness_has_project_files "$client"; then
+        scope=project
+        if tty_available \
+           && [ "${TCL_LSP_ASSUME_YES:-0}" != 1 ] \
+           && [ "${TCL_LSP_ASSUME_NO:-0}" != 1 ]; then
+            if [ "$UI_BACKEND" != plain ]; then
+                scope="$(ui_menu "Register $label MCP server where?" project \
+                    project "project — $PROJECT_ROOT" \
+                    user "user — all projects")" || scope=project
+            else
+                print_line "  $label project files found in $PROJECT_ROOT"
+                print_line "    1) project (recommended)"
+                print_line "    2) user (all projects)"
+                print_prompt "  scope [1]:"
+                read_user_line || reply=""
+                case "${reply:-1}" in
+                    1) scope=project ;;
+                    2) scope=user ;;
+                    *) die "invalid scope selection: $reply (expected 1 or 2)" ;;
+                esac
+            fi
+        fi
+        prompt_record mcp-scope "$label registration scope" "$scope"
+    fi
+    printf '%s\n' "$scope"
+}
+
+choose_one_harness() {
+    client="$1"; label="$2"; detected="$3"; supports_project="$4"
+    [ "$detected" = 1 ] || return 0
+    harness_env_disabled "$client" && return 0
+    if ask_optout "Register tcl-mcp with $label? [Y/n]"; then
+        scope="$(choose_harness_scope "$client" "$label" "$supports_project")"
+        set_harness_plan "$client" 1 "$scope"
+        WANT_MCP=1
+        log "$label MCP registration selected ($scope scope)"
+    fi
+}
+
 choose_ai_components() {
-    # Phase 2: which AI components to install. Sets WANT_MCP / WANT_SKILLS.
-    # Short-circuits when no AI client was detected.
+    # Phase 2: ask separately for every detected harness.  All registration
+    # and scope decisions are complete before the MCP binary is downloaded.
     WANT_MCP=0; WANT_SKILLS=0
-    if [ "$HAS_CLAUDE" != "1" ] && [ "$HAS_CODEX" != "1" ]; then
+    INSTALL_MCP_CLAUDE=0; INSTALL_MCP_CODEX=0
+    INSTALL_MCP_GEMINI=0; INSTALL_MCP_COPILOT=0
+    INSTALL_MCP_OPENCODE=0; INSTALL_MCP_HERMES=0
+    INSTALL_MCP_GOOSE=0; INSTALL_MCP_BOBBIT=0
+    if ! ai_client_detected; then
         log "no AI client detected — skipping AI component selection"
         return
     fi
-    # Env opt-outs.
-    if [ "${TCL_LSP_NO_MCP:-0}" = "1" ] && [ "${TCL_LSP_NO_SKILLS:-0}" = "1" ]; then
-        log "AI components disabled via TCL_LSP_NO_MCP=1 TCL_LSP_NO_SKILLS=1"
-        return
-    fi
-    has_skills=0
-    [ "$HAS_CLAUDE" = "1" ] && has_skills=1
 
-    # Defaults — install everything the env didn't disable.
-    d_mcp=0; d_skills=0
-    [ "${TCL_LSP_NO_MCP:-0}"    != "1" ] && d_mcp=1
-    [ "${TCL_LSP_NO_SKILLS:-0}" != "1" ] && [ "$has_skills" = 1 ] && d_skills=1
-
-    if ! tty_available \
-       || [ "${TCL_LSP_ASSUME_YES:-0}" = "1" ] || [ "${TCL_LSP_ASSUME_NO:-0}" = "1" ]; then
-        WANT_MCP="$d_mcp"; WANT_SKILLS="$d_skills"
-        log "AI (non-interactive): mcp=$WANT_MCP skills=$WANT_SKILLS"
-        return
+    if [ "${TCL_LSP_NO_MCP:-0}" != 1 ]; then
+        choose_one_harness claude  "Claude Code"        "$HAS_CLAUDE"  1
+        choose_one_harness codex   "Codex"              "$HAS_CODEX"   1
+        choose_one_harness gemini  "Gemini CLI"         "$HAS_GEMINI"  1
+        choose_one_harness copilot "GitHub Copilot CLI" "$HAS_COPILOT" 1
+        choose_one_harness opencode "OpenCode"           "$HAS_OPENCODE" 1
+        choose_one_harness hermes  "Hermes"             "$HAS_HERMES"  0
+        choose_one_harness goose   "Goose"              "$HAS_GOOSE"   0
+        choose_one_harness bobbit  "Bobbit"             "$HAS_BOBBIT"  2
     fi
-
-    if [ "$has_skills" = 1 ]; then
-        menu_default=3
-        if [ "$UI_BACKEND" != plain ]; then
-            ans="$(ui_menu "Choose AI integrations" "$menu_default" \
-                1 "MCP server" \
-                2 "Claude Code skills" \
-                3 "both — MCP server and skills" \
-                4 "none")" || ans="$menu_default"
-        else
-            print_line ""
-            print_line "Choose which AI components to install:"
-            print_line "  1) mcp"
-            print_line "  2) skills"
-            print_line "  3) both (mcp + skills)"
-            print_line "  4) none"
-            print_prompt "$(printf '  selection [%s]: ' "$menu_default")"
-            read_user_line || reply=""
-            ans="${reply:-$menu_default}"
-        fi
-        case "$ans" in
-            1) WANT_MCP=1; WANT_SKILLS=0 ;;
-            2) WANT_MCP=0; WANT_SKILLS=1 ;;
-            3) WANT_MCP=1; WANT_SKILLS=1 ;;
-            4) WANT_MCP=0; WANT_SKILLS=0 ;;
-            *) die "invalid selection: $ans (expected 1..4)" ;;
-        esac
-    else
-        menu_default=1
-        if [ "$UI_BACKEND" != plain ]; then
-            ans="$(ui_menu "Choose Codex integration" "$menu_default" \
-                1 "MCP server" \
-                2 "none")" || ans="$menu_default"
-        else
-            print_line ""
-            print_line "Choose AI components (Codex only — no skills):"
-            print_line "  1) mcp"
-            print_line "  2) none"
-            print_prompt "$(printf '  selection [%s]: ' "$menu_default")"
-            read_user_line || reply=""
-            ans="${reply:-$menu_default}"
-        fi
-        case "$ans" in
-            1) WANT_MCP=1 ;;
-            2) WANT_MCP=0 ;;
-            *) die "invalid selection: $ans (expected 1..2)" ;;
-        esac
+    if [ "$HAS_CLAUDE" = 1 ] && [ "${TCL_LSP_NO_SKILLS:-0}" != 1 ] \
+       && [ "${TCL_LSP_NO_CLAUDE:-0}" != 1 ] \
+       && ask_optout "Install the tcl-lsp skills for Claude Code? [Y/n]"; then
+        WANT_SKILLS=1
     fi
-    prompt_record ai-plan "menu pick" "$ans"
     log "AI: mcp=$WANT_MCP skills=$WANT_SKILLS"
 }
 
@@ -1490,9 +1566,6 @@ guard_install_plan() {
     if [ "$WANT_TCL" != "1" ] && [ "$WANT_F5" != "1" ] \
        && [ "$WANT_MCP" != "1" ] && [ "$WANT_SKILLS" != "1" ]; then
         die "nothing selected — at least one component must be picked"
-    fi
-    if [ "$WANT_MCP" = "1" ] && [ "$HAS_CLAUDE" != "1" ] && [ "$HAS_CODEX" != "1" ]; then
-        warn "MCP requested but no AI client detected — installing anyway"
     fi
     if [ "$WANT_SKILLS" = "1" ] && [ "$HAS_CLAUDE" != "1" ]; then
         warn "skills requested but Claude Code not detected — installing anyway"
@@ -2142,8 +2215,30 @@ comp_install() {
 
 have_claude_cli() { have claude; }
 have_codex_cli()  { have codex; }
+have_gemini_cli() { have gemini; }
+have_copilot_cli() { have copilot; }
+have_opencode_cli() { have opencode || have opencode2; }
+have_hermes_cli() { have hermes; }
+have_goose_cli() { have goose; }
+have_bobbit_cli() { have bobbit; }
 has_claude_dir()  { [ -d "$HOME/.claude" ]; }
 has_codex_dir()   { [ -d "$HOME/.codex" ]; }
+has_gemini_dir()  { [ -d "$HOME/.gemini" ]; }
+has_copilot_dir() { [ -d "$HOME/.copilot" ]; }
+has_opencode_dir() { [ -d "${XDG_CONFIG_HOME:-$HOME/.config}/opencode" ]; }
+has_hermes_dir()  { [ -d "$HOME/.hermes" ]; }
+has_goose_dir()   { [ -d "${XDG_CONFIG_HOME:-$HOME/.config}/goose" ]; }
+has_bobbit_dir()  { [ -d "${PROJECT_ROOT:-$PWD}/.bobbit" ]; }
+
+PROJECT_ROOT=""
+detect_project_context() {
+    # Scope choices apply to the project containing the directory from which
+    # the installer was launched.  Outside a repository, inspect $PWD itself.
+    if have git; then
+        PROJECT_ROOT="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
+    fi
+    [ -n "$PROJECT_ROOT" ] || PROJECT_ROOT="$PWD"
+}
 
 AI_DETECTED=0
 detect_ai_clients() {
@@ -2152,16 +2247,46 @@ detect_ai_clients() {
     [ "$AI_DETECTED" = "1" ] && return 0
     HAS_CLAUDE=0
     HAS_CODEX=0
+    HAS_GEMINI=0
+    HAS_COPILOT=0
+    HAS_OPENCODE=0
+    HAS_HERMES=0
+    HAS_GOOSE=0
+    HAS_BOBBIT=0
     if [ "${TCL_LSP_NO_CLAUDE:-0}" != "1" ]; then
         if have_claude_cli || has_claude_dir; then HAS_CLAUDE=1; fi
     fi
     if [ "${TCL_LSP_NO_CODEX:-0}" != "1" ]; then
         if have_codex_cli || has_codex_dir; then HAS_CODEX=1; fi
     fi
-    if [ "$HAS_CLAUDE" = "1" ] || [ "$HAS_CODEX" = "1" ]; then
+    if [ "${TCL_LSP_NO_GEMINI:-0}" != "1" ]; then
+        if have_gemini_cli || has_gemini_dir; then HAS_GEMINI=1; fi
+    fi
+    if [ "${TCL_LSP_NO_COPILOT:-0}" != "1" ]; then
+        if have_copilot_cli || has_copilot_dir; then HAS_COPILOT=1; fi
+    fi
+    if [ "${TCL_LSP_NO_OPENCODE:-0}" != "1" ]; then
+        if have_opencode_cli || has_opencode_dir; then HAS_OPENCODE=1; fi
+    fi
+    if [ "${TCL_LSP_NO_HERMES:-0}" != "1" ]; then
+        if have_hermes_cli || has_hermes_dir; then HAS_HERMES=1; fi
+    fi
+    if [ "${TCL_LSP_NO_GOOSE:-0}" != "1" ]; then
+        if have_goose_cli || has_goose_dir; then HAS_GOOSE=1; fi
+    fi
+    if [ "${TCL_LSP_NO_BOBBIT:-0}" != "1" ]; then
+        if have_bobbit_cli || has_bobbit_dir; then HAS_BOBBIT=1; fi
+    fi
+    if ai_client_detected; then
         msg=""
         [ "$HAS_CLAUDE" = "1" ] && msg="${msg}Claude Code "
         [ "$HAS_CODEX"  = "1" ] && msg="${msg}Codex "
+        [ "$HAS_GEMINI" = "1" ] && msg="${msg}Gemini CLI "
+        [ "$HAS_COPILOT" = "1" ] && msg="${msg}GitHub Copilot CLI "
+        [ "$HAS_OPENCODE" = "1" ] && msg="${msg}OpenCode "
+        [ "$HAS_HERMES" = "1" ] && msg="${msg}Hermes "
+        [ "$HAS_GOOSE" = "1" ] && msg="${msg}Goose "
+        [ "$HAS_BOBBIT" = "1" ] && msg="${msg}Bobbit "
         log "detected AI client(s): ${msg}"
     fi
     AI_DETECTED=1
@@ -2288,56 +2413,36 @@ $(uname -sm 2>/dev/null) — this platform has no published MCP build."
 }
 
 register_mcp_claude() {
-    set -- "$MCP_PATH"
-    # Capture prior entry so a failed add can be restored.
+    scope="$MCP_SCOPE_CLAUDE"
     if ! have_claude_cli; then
-        warn "claude CLI not on PATH — add the MCP server manually:"
-        warn "  claude mcp add tcl-lsp -- $*"
-        return 0
+        warn "Claude Code was detected, but its CLI is not on PATH."
+        warn "Register manually: claude mcp add -s $scope tcl-lsp -- $MCP_PATH"
+        return 1
     fi
-    prior=""
-    if claude mcp list 2>/dev/null | awk '{print $1}' | grep -qx 'tcl-lsp'; then
-        # The exact `mcp list` format isn't a stable contract; capture
-        # the full record so we can echo it back as restore guidance.
-        prior="$(claude mcp list 2>/dev/null | awk '$1=="tcl-lsp" {sub(/^tcl-lsp[[:space:]]+/,""); print; exit}')"
-        claude mcp remove tcl-lsp >/dev/null 2>&1 || true
-    fi
-    if claude mcp add tcl-lsp -- "$@" >/dev/null 2>&1; then
-        log "registered MCP server with Claude Code (tcl-lsp)"
+    # Old installers relied on Claude's default local scope.  Remove that
+    # stale entry as well as the chosen target, then add back explicitly.
+    (cd "$PROJECT_ROOT" && claude mcp remove -s local tcl-lsp >/dev/null 2>&1) || true
+    (cd "$PROJECT_ROOT" && claude mcp remove -s "$scope" tcl-lsp >/dev/null 2>&1) || true
+    if (cd "$PROJECT_ROOT" && claude mcp add -s "$scope" tcl-lsp -- "$MCP_PATH" >/dev/null 2>&1); then
+        log "registered MCP server with Claude Code (tcl-lsp, $scope scope)"
         return
     fi
     warn "claude mcp add failed"
-    if [ -n "$prior" ]; then
-        warn "prior registration was: $prior"
-        warn "restore it manually if needed"
-    fi
-    warn "or register fresh with: claude mcp add tcl-lsp -- $*"
+    warn "register manually: claude mcp add -s $scope tcl-lsp -- $MCP_PATH"
     return 1
 }
 
-register_mcp_codex() {
-    cfg="$HOME/.codex/config.toml"
-    mkdir -p "$HOME/.codex"
+toml_basic_escape() {
+    # Escape \ and " for a TOML basic string.
+    printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+write_codex_mcp_config() {
+    cfg="$1"
+    mkdir -p "$(dirname "$cfg")"
     touch "$cfg"
     backup="${cfg}.bak.$(date +%Y%m%d%H%M%S)"
     cp "$cfg" "$backup"
-
-    # Prefer Codex's supported config command. The existing entry is removed
-    # first so a Python-era command/args pair cannot survive the migration.
-    if have_codex_cli; then
-        codex mcp remove tcl_lsp >/dev/null 2>&1 || true
-        if codex mcp add tcl_lsp -- "$MCP_PATH" >/dev/null 2>&1; then
-            log "registered native MCP server with Codex (tcl_lsp)"
-            return 0
-        fi
-        cp "$backup" "$cfg"
-        warn "codex mcp add failed; restored $cfg from $backup"
-        return 1
-    fi
-
-    # Codex directory detection also works when its CLI is not on PATH. In that
-    # case replace exactly our table (and any nested table) while preserving
-    # every unrelated setting. Write a complete temporary file, then rename.
     tmp_cfg="$WORKDIR/codex-config.toml"
     awk '
         /^[[:space:]]*\[mcp_servers\.tcl_lsp([.][^]]+)?\][[:space:]]*$/ { drop=1; next }
@@ -2355,9 +2460,271 @@ register_mcp_codex() {
     log "registered native MCP server with Codex in $cfg"
 }
 
-toml_basic_escape() {
-    # Escape \ and " for a TOML basic string.
+register_mcp_codex() {
+    scope="$MCP_SCOPE_CODEX"
+    if [ "$scope" = project ]; then
+        write_codex_mcp_config "$PROJECT_ROOT/.codex/config.toml"
+        return
+    fi
+    cfg="$HOME/.codex/config.toml"
+    # Prefer Codex's supported user-level command.  Project-level registration
+    # uses the documented .codex/config.toml because the CLI has no scope flag.
+    if have_codex_cli; then
+        mkdir -p "$HOME/.codex"
+        [ -f "$cfg" ] || : > "$cfg"
+        backup="${cfg}.bak.$(date +%Y%m%d%H%M%S)"
+        cp "$cfg" "$backup"
+        codex mcp remove tcl_lsp >/dev/null 2>&1 || true
+        if codex mcp add tcl_lsp -- "$MCP_PATH" >/dev/null 2>&1; then
+            log "registered native MCP server with Codex (tcl_lsp, user scope)"
+            return 0
+        fi
+        cp "$backup" "$cfg"
+        warn "codex mcp add failed; restored $cfg from $backup"
+        return 1
+    fi
+    write_codex_mcp_config "$cfg"
+}
+
+json_basic_escape() {
     printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+write_new_json_mcp_config() {
+    cfg="$1"; shape="$2"
+    command="$(json_basic_escape "$MCP_PATH")"
+    case "$shape" in
+        standard)
+            printf '{\n  "mcpServers": {\n    "tcl-lsp": {\n      "type": "stdio",\n      "command": "%s",\n      "args": []\n    }\n  }\n}\n' "$command" > "$cfg" ;;
+        copilot)
+            printf '{\n  "mcpServers": {\n    "tcl-lsp": {\n      "type": "local",\n      "command": "%s",\n      "args": [],\n      "tools": ["*"]\n    }\n  }\n}\n' "$command" > "$cfg" ;;
+        opencode-v1)
+            printf '{\n  "mcp": {\n    "tcl-lsp": {\n      "type": "local",\n      "command": ["%s"],\n      "enabled": true\n    }\n  }\n}\n' "$command" > "$cfg" ;;
+        *) die "internal: unknown JSON MCP shape: $shape" ;;
+    esac
+}
+
+write_json_mcp_config() {
+    cfg="$1"; shape="$2"
+    mkdir -p "$(dirname "$cfg")"
+    if [ ! -s "$cfg" ]; then
+        write_new_json_mcp_config "$cfg" "$shape"
+        log "registered native MCP server in $cfg"
+        return 0
+    fi
+    backup="${cfg}.bak.$(date +%Y%m%d%H%M%S)"
+    cp "$cfg" "$backup"
+    tmp_cfg="$WORKDIR/harness-config.json"
+    if have jq; then
+        case "$shape" in
+            standard)
+                filter='.mcpServers = (.mcpServers // {}) | .mcpServers["tcl-lsp"] = {type:"stdio", command:$command, args:[]}' ;;
+            copilot)
+                filter='.mcpServers = (.mcpServers // {}) | .mcpServers["tcl-lsp"] = {type:"local", command:$command, args:[], tools:["*"]}' ;;
+            opencode-v1)
+                filter='.mcp = (.mcp // {}) | .mcp["tcl-lsp"] = {type:"local", command:[$command], enabled:true}' ;;
+        esac
+        if jq --arg command "$MCP_PATH" "$filter" "$cfg" > "$tmp_cfg" 2>/dev/null; then
+            mv "$tmp_cfg" "$cfg"
+            log "registered native MCP server in $cfg"
+            return 0
+        fi
+    else
+        node_bin=""
+        if have node; then node_bin=node
+        elif have nodejs; then node_bin=nodejs
+        fi
+        if [ -n "$node_bin" ] && "$node_bin" -e '
+const fs = require("fs");
+const [shape, file, command] = process.argv.slice(1);
+const config = JSON.parse(fs.readFileSync(file, "utf8"));
+if (shape === "opencode-v1") {
+  config.mcp ||= {};
+  config.mcp["tcl-lsp"] = {type: "local", command: [command], enabled: true};
+} else {
+  config.mcpServers ||= {};
+  config.mcpServers["tcl-lsp"] = shape === "copilot"
+    ? {type: "local", command, args: [], tools: ["*"]}
+    : {type: "stdio", command, args: []};
+}
+process.stdout.write(JSON.stringify(config, null, 2) + "\\n");
+' "$shape" "$cfg" "$MCP_PATH" > "$tmp_cfg" 2>/dev/null; then
+            mv "$tmp_cfg" "$cfg"
+            log "registered native MCP server in $cfg"
+            return 0
+        fi
+    fi
+    cp "$backup" "$cfg"
+    warn "could not safely update $cfg (JSONC/comments need a client-supported editor)"
+    warn "left the original intact; backup: $backup"
+    return 1
+}
+
+write_yaml_mcp_config() {
+    cfg="$1"; shape="$2"
+    mkdir -p "$(dirname "$cfg")"
+    if [ ! -s "$cfg" ]; then
+        command="$(printf '%s' "$MCP_PATH" | sed 's/"/\\"/g')"
+        case "$shape" in
+            hermes)
+                printf 'mcp_servers:\n  tcl-lsp:\n    command: "%s"\n    args: []\n' "$command" > "$cfg" ;;
+            goose)
+                printf 'extensions:\n  tcl-lsp:\n    type: stdio\n    name: tcl-lsp\n    enabled: true\n    cmd: "%s"\n    args: []\n    env_keys: []\n    envs: {}\n    timeout: 300\n' "$command" > "$cfg" ;;
+        esac
+        log "registered native MCP server in $cfg"
+        return 0
+    fi
+    backup="${cfg}.bak.$(date +%Y%m%d%H%M%S)"
+    cp "$cfg" "$backup"
+    tmp_cfg="$WORKDIR/harness-config.yaml"
+    if have yq && yq --version 2>&1 | grep -qi 'mikefarah'; then
+        if [ "$shape" = hermes ]; then
+            expression='.mcp_servers."tcl-lsp" = {"command": strenv(TCL_LSP_MCP_COMMAND), "args": []}'
+        else
+            expression='.extensions."tcl-lsp" = {"type": "stdio", "name": "tcl-lsp", "enabled": true, "cmd": strenv(TCL_LSP_MCP_COMMAND), "args": [], "env_keys": [], "envs": {}, "timeout": 300}'
+        fi
+        if TCL_LSP_MCP_COMMAND="$MCP_PATH" yq "$expression" "$cfg" > "$tmp_cfg" 2>/dev/null; then
+            mv "$tmp_cfg" "$cfg"
+            log "registered native MCP server in $cfg"
+            return 0
+        fi
+    fi
+
+    # No YAML runtime is required for the ordinary block-map shape used by
+    # both clients. Replace exactly our two-space-indented child and preserve
+    # every unrelated line. Reject flow-style roots rather than guessing.
+    if [ "$shape" = hermes ]; then root_key=mcp_servers
+    else root_key=extensions
+    fi
+    if grep -q "^${root_key}:" "$cfg" \
+       && ! grep -qE "^${root_key}:[[:space:]]*(#.*)?$" "$cfg"; then
+        cp "$backup" "$cfg"
+        warn "cannot safely update flow-style YAML key '$root_key' in $cfg"
+        return 1
+    fi
+    block="$WORKDIR/harness-yaml-block"
+    command="$(printf '%s' "$MCP_PATH" | sed 's/"/\\"/g')"
+    if [ "$shape" = hermes ]; then
+        printf '  tcl-lsp:\n    command: "%s"\n    args: []\n' "$command" > "$block"
+    else
+        printf '  tcl-lsp:\n    type: stdio\n    name: tcl-lsp\n    enabled: true\n    cmd: "%s"\n    args: []\n    env_keys: []\n    envs: {}\n    timeout: 300\n' "$command" > "$block"
+    fi
+    if awk -v root="$root_key" -v block="$block" '
+        function emit( line) {
+            while ((getline line < block) > 0) print line
+            close(block)
+        }
+        BEGIN { in_root=0; found_root=0; inserted=0; skip_child=0 }
+        {
+            if (in_root && $0 ~ /^[^[:space:]#]/ && $0 !~ ("^" root ":[[:space:]]")) {
+                if (!inserted) { emit(); inserted=1 }
+                in_root=0; skip_child=0
+            }
+            if ($0 ~ ("^" root ":[[:space:]]*(#.*)?$")) {
+                found_root=1; in_root=1; print; next
+            }
+            if (in_root && $0 ~ /^  tcl-lsp:[[:space:]]*(#.*)?$/) {
+                skip_child=1; next
+            }
+            if (skip_child) {
+                if ($0 ~ /^  [^[:space:]#][^:]*:/) {
+                    skip_child=0
+                    if (!inserted) { emit(); inserted=1 }
+                } else if ($0 ~ /^[^[:space:]#]/) {
+                    skip_child=0
+                } else {
+                    next
+                }
+            }
+            print
+        }
+        END {
+            if (in_root && !inserted) emit()
+            if (!found_root) { print ""; print root ":"; emit() }
+        }
+    ' "$cfg" > "$tmp_cfg"; then
+        mv "$tmp_cfg" "$cfg"
+        log "registered native MCP server in $cfg"
+        return 0
+    fi
+    cp "$backup" "$cfg"
+    warn "could not update $cfg; restored the original from $backup"
+    return 1
+}
+
+register_mcp_gemini() {
+    scope="$MCP_SCOPE_GEMINI"
+    if have_gemini_cli; then
+        (cd "$PROJECT_ROOT" && gemini mcp remove -s "$scope" tcl-lsp >/dev/null 2>&1) || true
+        if (cd "$PROJECT_ROOT" && gemini mcp add -s "$scope" tcl-lsp "$MCP_PATH" >/dev/null 2>&1); then
+            log "registered MCP server with Gemini CLI (tcl-lsp, $scope scope)"
+            return 0
+        fi
+        warn "gemini mcp add failed"
+        return 1
+    fi
+    if [ "$scope" = project ]; then cfg="$PROJECT_ROOT/.gemini/settings.json"
+    else cfg="$HOME/.gemini/settings.json"
+    fi
+    write_json_mcp_config "$cfg" standard
+}
+
+register_mcp_copilot() {
+    scope="$MCP_SCOPE_COPILOT"
+    if [ "$scope" = user ] && have_copilot_cli; then
+        copilot mcp remove tcl-lsp >/dev/null 2>&1 || true
+        if copilot mcp add tcl-lsp -- "$MCP_PATH" >/dev/null 2>&1; then
+            log "registered MCP server with GitHub Copilot CLI (tcl-lsp, user scope)"
+            return 0
+        fi
+        warn "copilot mcp add failed"
+        return 1
+    fi
+    if [ "$scope" = project ]; then
+        if [ -e "$PROJECT_ROOT/.github/mcp.json" ] && [ ! -e "$PROJECT_ROOT/.mcp.json" ]; then
+            cfg="$PROJECT_ROOT/.github/mcp.json"
+        else
+            cfg="$PROJECT_ROOT/.mcp.json"
+        fi
+    else
+        cfg="$HOME/.copilot/mcp-config.json"
+    fi
+    write_json_mcp_config "$cfg" standard
+}
+
+register_mcp_opencode() {
+    scope="$MCP_SCOPE_OPENCODE"
+    if have opencode2; then
+        if [ "$scope" = user ]; then
+            opencode2 mcp add tcl-lsp --global -- "$MCP_PATH"
+        else
+            (cd "$PROJECT_ROOT" && opencode2 mcp add tcl-lsp -- "$MCP_PATH")
+        fi
+        log "registered MCP server with OpenCode ($scope scope)"
+        return 0
+    fi
+    if [ "$scope" = project ]; then
+        if [ -e "$PROJECT_ROOT/opencode.jsonc" ] && [ ! -e "$PROJECT_ROOT/opencode.json" ]; then
+            cfg="$PROJECT_ROOT/opencode.jsonc"
+        else
+            cfg="$PROJECT_ROOT/opencode.json"
+        fi
+    else
+        cfg="${XDG_CONFIG_HOME:-$HOME/.config}/opencode/opencode.json"
+    fi
+    write_json_mcp_config "$cfg" opencode-v1
+}
+
+register_mcp_hermes() {
+    write_yaml_mcp_config "$HOME/.hermes/config.yaml" hermes
+}
+
+register_mcp_goose() {
+    write_yaml_mcp_config "${XDG_CONFIG_HOME:-$HOME/.config}/goose/config.yaml" goose
+}
+
+register_mcp_bobbit() {
+    write_json_mcp_config "$PROJECT_ROOT/.mcp.json" standard
 }
 
 install_claude_skills() {
@@ -2416,12 +2783,14 @@ install_ai_integrations() {
     # set WANT_MCP / WANT_SKILLS, and choose_mcp_prefix set the path.
     if [ "$WANT_MCP" = "1" ]; then
         install_mcp
-        if [ "$HAS_CLAUDE" = "1" ]; then
-            register_mcp_claude || return 1
-        fi
-        if [ "$HAS_CODEX" = "1" ]; then
-            register_mcp_codex || return 1
-        fi
+        [ "$INSTALL_MCP_CLAUDE" = 1 ] && register_mcp_claude
+        [ "$INSTALL_MCP_CODEX" = 1 ] && register_mcp_codex
+        [ "$INSTALL_MCP_GEMINI" = 1 ] && register_mcp_gemini
+        [ "$INSTALL_MCP_COPILOT" = 1 ] && register_mcp_copilot
+        [ "$INSTALL_MCP_OPENCODE" = 1 ] && register_mcp_opencode
+        [ "$INSTALL_MCP_HERMES" = 1 ] && register_mcp_hermes
+        [ "$INSTALL_MCP_GOOSE" = 1 ] && register_mcp_goose
+        [ "$INSTALL_MCP_BOBBIT" = 1 ] && register_mcp_bobbit
         cleanup_stale_mcp
     fi
     if [ "$WANT_SKILLS" = "1" ]; then
@@ -2439,6 +2808,7 @@ main() {
     detect_shell
     detect_proxy
     plan_downloader              # record curl-install need if missing
+    detect_project_context
     detect_ai_clients
     detect_ui_backend
     [ "$UI_BACKEND" = plain ] || log "interactive UI: $UI_BACKEND"

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -58,7 +58,8 @@
 #   TCL_LSP_NO_DEPS         - 1 to skip OS-package install (curl, unzip)
 #   TCL_LSP_NO_PATH         - 1 to skip PATH/rc modification
 #   TCL_LSP_NO_COMP         - 1 to skip shell completion
-#   TCL_LSP_NO_LEGACY_CLEANUP - 1 to keep recognised Python-era tcl-lsp files
+#   TCL_LSP_NO_LEGACY_CLEANUP - 1 to keep the main installer's Python zipapps,
+#                               completions, Claude bundle, and MCP registrations
 #   TCL_LSP_NO_MCP          - 1 to skip MCP-server install for AI clients
 #   TCL_LSP_NO_SKILLS       - 1 to skip Claude Code skills install
 #   TCL_LSP_NO_CLAUDE       - 1 to ignore Claude Code even if detected
@@ -1596,11 +1597,9 @@ looks_like_legacy_zipapp() {
     f="$1"
     [ -r "$f" ] || return 1
 
-    first="$(head -n 1 "$f" 2>/dev/null)"
-    case "$first" in
-        '#!'*python*) : ;;
-        *) return 1 ;;
-    esac
+    # Avoid command substitution here: scanning a native executable whose
+    # basename starts with tcl/f5 can otherwise feed NUL bytes into the shell.
+    head -c 256 "$f" 2>/dev/null | grep -aq '^#!.*python' || return 1
     head -c 2048 "$f" 2>/dev/null | grep -aq 'PK' || return 1
     LC_ALL=C grep -aqE \
         'shared/_build_info\.py|lsp/_build_info\.py|static/index\.html|ai/mcp/tcl_mcp_server\.py|tooling/(tcl|f5|wasm)/|explorer/(tcl|f5|wasm)_cli\.py' \
@@ -1745,43 +1744,279 @@ remove_legacy_python_artefact() {
     fi
 }
 
+legacy_installer_dirs() {
+    # Main's installer could use any PATH directory, the common user/system
+    # prefixes offered by its picker, or a custom prefix written into a shell
+    # rc file. Emit all discoverable locations; duplicates are harmless.
+    printf '%s\n' "${PATH:-}" | tr ':' '\n'
+    printf '%s\n' "$HOME/.local/bin" "$HOME/bin" \
+        /usr/local/bin /opt/homebrew/bin /opt/local/bin
+    [ -n "${PREFIX:-}" ] && printf '%s\n' "$PREFIX"
+    [ -n "${TCL_PREFIX_OVERRIDE:-}" ] && printf '%s\n' "$TCL_PREFIX_OVERRIDE"
+    [ -n "${F5_PREFIX_OVERRIDE:-}" ] && printf '%s\n' "$F5_PREFIX_OVERRIDE"
+    [ -n "${MCP_PREFIX_OVERRIDE:-}" ] && printf '%s\n' "$MCP_PREFIX_OVERRIDE"
+
+    for rc in "${RC:-$HOME/.profile}" "$HOME/.profile" "$HOME/.bashrc" \
+              "$HOME/.bash_profile" "${ZDOTDIR:-$HOME}/.zshrc" \
+              "${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish"; do
+        [ -f "$rc" ] || continue
+        sed -n '
+            /^# Added by tcl-lsp installer$/ {
+                n
+                s#^export PATH="\([^":]*\):\$PATH"$#\1#p
+                s#^fish_add_path \([^[:space:]]*\)$#\1#p
+            }
+        ' "$rc"
+    done
+}
+
+legacy_claude_mcp_record() {
+    have claude || return 1
+    claude mcp list 2>/dev/null \
+        | awk '$1 == "tcl-lsp" || $1 == "tcl-lsp:" { print; exit }'
+}
+
+legacy_codex_mcp_path() {
+    cfg="$HOME/.codex/config.toml"
+    [ -f "$cfg" ] || return 1
+    awk '
+        /^[[:space:]]*\[mcp_servers\.tcl_lsp\][[:space:]]*$/ { inside=1; next }
+        inside && /^[[:space:]]*\[/ { inside=0 }
+        inside && /\.pyz/ {
+            if (match($0, /"[^"]+\.pyz"/)) {
+                print substr($0, RSTART+1, RLENGTH-2); exit
+            }
+        }
+    ' "$cfg"
+}
+
+cleanup_legacy_mcp_registrations() {
+    # The main-branch installer registered only Claude (implicit local scope)
+    # and Codex (user config). Remove an entry only when it still names the
+    # retired Python zipapp; native or unrelated entries are left untouched.
+    claude_record="$1"
+    case "$claude_record" in
+        *tcl-lsp-mcp-server.pyz*|*tcl-ai.pyz*)
+            if (cd "${PROJECT_ROOT:-$PWD}" \
+                && claude mcp remove -s local tcl-lsp >/dev/null 2>&1); then
+                log "removed retired Python MCP registration from Claude Code (local scope)"
+            elif (cd "${PROJECT_ROOT:-$PWD}" \
+                  && claude mcp remove tcl-lsp >/dev/null 2>&1); then
+                log "removed retired Python MCP registration from Claude Code"
+            else
+                warn "could not remove retired Python MCP registration from Claude Code"
+            fi
+            ;;
+    esac
+
+    cfg="$HOME/.codex/config.toml"
+    legacy_codex_path="$2"
+    if [ -n "$legacy_codex_path" ]; then
+        backup="${cfg}.bak.$(date +%Y%m%d%H%M%S).python-migration"
+        cp "$cfg" "$backup"
+        tmp_cfg="$WORKDIR/codex-legacy-cleanup.toml"
+        awk '
+            /^[[:space:]]*\[mcp_servers\.tcl_lsp([.][^]]+)?\][[:space:]]*$/ { drop=1; next }
+            drop && /^[[:space:]]*\[/ { drop=0 }
+            !drop { print }
+        ' "$cfg" > "$tmp_cfg"
+        mv "$tmp_cfg" "$cfg"
+        log "removed retired Python MCP registration from Codex (backup: $backup)"
+    fi
+}
+
+looks_like_legacy_completion() {
+    f="$1"
+    [ -f "$f" ] || return 1
+    LC_ALL=C grep -aqE '_ARGCOMPLETE|python_argcomplete|register-python-argcomplete' "$f"
+}
+
+cleanup_legacy_completions() {
+    # Main installed completion into these exact per-user paths. The generated
+    # scripts identify themselves through argcomplete protocol markers, which
+    # are absent from the native clap completions.
+    for completion in \
+        "$HOME/.local/share/bash-completion/completions/tcl" \
+        "$HOME/.local/share/bash-completion/completions/f5" \
+        "${ZDOTDIR:-$HOME}/.zsh/completions/_tcl" \
+        "${ZDOTDIR:-$HOME}/.zsh/completions/_f5" \
+        "${XDG_CONFIG_HOME:-$HOME/.config}/fish/completions/tcl.fish" \
+        "${XDG_CONFIG_HOME:-$HOME/.config}/fish/completions/f5.fish"; do
+        if looks_like_legacy_completion "$completion"; then
+            rm -f "$completion"
+            log "removed retired Python shell completion $completion"
+        fi
+    done
+}
+
+looks_like_any_native_cli() {
+    f="$1"
+    [ -f "$f" ] && [ -x "$f" ] || return 1
+    case "$(basename "$f")" in
+        tcl* ) LC_ALL=C grep -aq 'Unified Tcl toolchain CLI' "$f" ;;
+        f5* )  LC_ALL=C grep -aq 'BIG-IP.*query' "$f" ;;
+        * )    return 1 ;;
+    esac
+}
+
+dir_has_native_tcl_lsp() {
+    dir="$1"
+    [ -d "$dir" ] || return 1
+    for candidate in "$dir"/tcl* "$dir"/f5*; do
+        [ -f "$candidate" ] || continue
+        if looks_like_our_native_mcp "$candidate" \
+           || looks_like_any_native_cli "$candidate"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+installer_path_from_line() {
+    printf '%s\n' "$1" | sed -n '
+        s#^export PATH="\([^":]*\):\$PATH"$#\1#p
+        s#^fish_add_path \([^[:space:]]*\)$#\1#p
+    '
+}
+
+cleanup_legacy_path_entries() {
+    # Keep a marker block when its directory now contains a native replacement;
+    # otherwise remove the exact two lines owned by the main installer.
+    [ "${TCL_LSP_NO_LEGACY_CLEANUP:-0}" = "1" ] && return 0
+    for rc in "${RC:-$HOME/.profile}" "$HOME/.profile" "$HOME/.bashrc" \
+              "$HOME/.bash_profile" "${ZDOTDIR:-$HOME}/.zshrc" \
+              "${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish"; do
+        [ -f "$rc" ] || continue
+        tmp_rc="$(mktemp "$WORKDIR/rc-clean.XXXXXX")"
+        changed=0
+        while IFS= read -r line || [ -n "$line" ]; do
+            if [ "$line" = "$PATH_MARKER" ]; then
+                path_line=""
+                if IFS= read -r path_line || [ -n "$path_line" ]; then
+                    installer_dir="$(installer_path_from_line "$path_line")"
+                    if [ -n "$installer_dir" ] \
+                       && ! dir_has_native_tcl_lsp "$installer_dir"; then
+                        changed=1
+                        continue
+                    fi
+                    printf '%s\n%s\n' "$line" "$path_line" >> "$tmp_rc"
+                    continue
+                fi
+            fi
+            printf '%s\n' "$line" >> "$tmp_rc"
+        done < "$rc"
+        if [ "$changed" = 1 ]; then
+            backup="${rc}.bak.$(date +%Y%m%d%H%M%S).python-migration"
+            cp "$rc" "$backup"
+            mv "$tmp_rc" "$rc"
+            log "removed stale installer PATH entry from $rc (backup: $backup)"
+        else
+            rm -f "$tmp_rc"
+        fi
+    done
+}
+
+legacy_claude_skill() {
+    skill_dir="$1"
+    [ -f "$skill_dir/SKILL.md" ] || return 1
+    LC_ALL=C grep -aqE \
+        'python3[[:space:]]+\.claude/tcl-ai\.pyz|\.claude/prompts/' \
+        "$skill_dir/SKILL.md"
+}
+
+cleanup_legacy_claude_bundle() {
+    # The Python bundle merged files into ~/.claude, so preserve every retired
+    # item in one recovery directory before removing it from active discovery.
+    claude_root="$HOME/.claude"
+    [ -d "$claude_root" ] || return 0
+    backup="$claude_root/.tcl-lsp-python-backup-$(date +%Y%m%d%H%M%S)"
+    staged=0
+
+    if [ -f "$claude_root/tcl-ai.pyz" ] \
+       && looks_like_legacy_zipapp "$claude_root/tcl-ai.pyz"; then
+        mkdir -p "$backup"
+        cp "$claude_root/tcl-ai.pyz" "$backup/"
+        rm -f "$claude_root/tcl-ai.pyz"
+        staged=1
+    fi
+
+    for prompt in brainstorm-security-checks.md explain_flow_system.md \
+                  irules_system.md irules_system.md.j2 manifest.json \
+                  tcl_system.md tcl_system.md.j2 tk_system.md; do
+        [ -f "$claude_root/prompts/$prompt" ] || continue
+        mkdir -p "$backup/prompts"
+        cp "$claude_root/prompts/$prompt" "$backup/prompts/"
+        rm -f "$claude_root/prompts/$prompt"
+        staged=1
+    done
+    rmdir "$claude_root/prompts" 2>/dev/null || true
+
+    for skill_dir in "$claude_root"/skills/*; do
+        [ -d "$skill_dir" ] || continue
+        if legacy_claude_skill "$skill_dir"; then
+            :
+        elif [ "$staged" = 1 ] \
+             && [ "$(basename "$skill_dir")" = f5-query ] \
+             && grep -aqE '^name:[[:space:]]*f5-query[[:space:]]*$' \
+                    "$skill_dir/SKILL.md"; then
+            # f5-query was the one main-bundle skill with no Python/prompt
+            # reference. Remove it only after another legacy bundle marker
+            # proves this is a Python-era installation.
+            :
+        else
+            continue
+        fi
+        mkdir -p "$backup/skills"
+        cp -R "$skill_dir" "$backup/skills/"
+        rm -rf -- "$skill_dir"
+        staged=1
+    done
+    rmdir "$claude_root/skills" 2>/dev/null || true
+
+    if [ "$staged" = 1 ]; then
+        log "retired the Python Claude bundle (backup: $backup)"
+    else
+        rmdir "$backup" 2>/dev/null || true
+    fi
+}
+
 cleanup_legacy_python_installs() {
     [ "${TCL_LSP_NO_LEGACY_CLEANUP:-0}" = "1" ] && {
         log "keeping recognised Python-era artefacts (TCL_LSP_NO_LEGACY_CLEANUP=1)"
         return 0
     }
 
-    # Old installers wrote standalone zipapps into a PATH directory. Search
-    # only exact historical names, and delete only files whose shebang, ZIP
-    # structure, and embedded project paths positively identify them as ours.
-    # Python itself, virtual environments, and pip packages are never touched.
-    legacy_dirs="${PATH:-}"
-    legacy_dirs="${legacy_dirs}:$HOME/.local/bin:$HOME/bin"
-    [ -n "${PREFIX:-}" ] && legacy_dirs="${legacy_dirs}:$PREFIX"
-    [ -n "${MCP_PREFIX_OVERRIDE:-}" ] && legacy_dirs="${legacy_dirs}:$MCP_PREFIX_OVERRIDE"
+    # Capture registrations before removing their commands. Some clients hide
+    # an entry after its executable disappears.
+    claude_record="$(legacy_claude_mcp_record || true)"
+    codex_mcp_path="$(legacy_codex_mcp_path || true)"
 
-    OLD_IFS="$IFS"; IFS=:
+    # Delete every installer-owned Python zipapp in every discoverable legacy
+    # prefix, including binaries installed with TCL_LSP_SUFFIX. Ownership is
+    # established from the archive's embedded tcl-lsp paths, not its filename.
+    legacy_dirs="$(legacy_installer_dirs)"
+    OLD_IFS="$IFS"; IFS='
+'
     for legacy_dir in $legacy_dirs; do
-        [ -n "$legacy_dir" ] || legacy_dir=.
+        [ -n "$legacy_dir" ] || continue
         [ -d "$legacy_dir" ] || continue
-        if [ "$WANT_TCL" = "1" ]; then
-            remove_legacy_python_artefact "$legacy_dir/tcl"
-        fi
-        if [ "$WANT_F5" = "1" ]; then
-            remove_legacy_python_artefact "$legacy_dir/f5"
-        fi
-        # These products have no native successor on the Rust branch.
-        remove_legacy_python_artefact "$legacy_dir/tcl-explorer"
-        remove_legacy_python_artefact "$legacy_dir/tcl-explorer-gui"
-        if [ "$WANT_MCP" = "1" ]; then
-            remove_legacy_python_artefact "$legacy_dir/tcl-lsp-mcp-server.pyz"
-        fi
+        for legacy in "$legacy_dir"/tcl* "$legacy_dir"/f5*; do
+            [ -f "$legacy" ] || continue
+            remove_legacy_python_artefact "$legacy"
+        done
     done
     IFS="$OLD_IFS"
 
-    if [ "$WANT_SKILLS" = "1" ]; then
-        remove_legacy_python_artefact "$HOME/.claude/tcl-ai.pyz"
-    fi
+    # A registered MCP path may live outside PATH and outside every standard
+    # prefix, so collect it directly before removing the registration.
+    claude_mcp_path="$(printf '%s\n' "$claude_record" \
+        | grep -oE '/[A-Za-z0-9._/+~:-]+\.pyz' | head -n 1 || true)"
+    [ -n "$claude_mcp_path" ] && remove_legacy_python_artefact "$claude_mcp_path"
+    [ -n "$codex_mcp_path" ] && remove_legacy_python_artefact "$codex_mcp_path"
+
+    cleanup_legacy_mcp_registrations "$claude_record" "$codex_mcp_path"
+    cleanup_legacy_completions
+    cleanup_legacy_claude_bundle
 }
 
 propose_update_clis() {
@@ -2856,6 +3091,10 @@ main() {
     require_root_or_die
 
     # === PHASE 3: execute the plan (no more questions) ===
+    # Retire main-branch Python artefacts before writing their native
+    # replacements. This also prevents old shell completions, Claude skills,
+    # or MCP registrations from surviving when that component was declined.
+    cleanup_legacy_python_installs
     install_downloader
 
     if needs_prefix; then
@@ -2877,7 +3116,7 @@ main() {
     esac
 
     install_ai_integrations
-    cleanup_legacy_python_installs
+    cleanup_legacy_path_entries
 
     printf '\n%sInstall complete.%s\n' "$BOLD" "$RESET"
     if needs_prefix && ! path_contains "$PREFIX"; then

--- a/scripts/install/test_installer.sh
+++ b/scripts/install/test_installer.sh
@@ -84,6 +84,40 @@ looks_like_legacy_zipapp "$test_root/path-old/tcl" || fail "legacy zipapp was no
 if looks_like_legacy_zipapp "$test_root/path-old/unrelated"; then fail "unrelated Python file was claimed"; fi
 pass "legacy ownership recognition"
 
+# Migration is the final successful-plan step. If a selected native component
+# fails, the working Python-era artefact must remain; a successful plan still
+# removes it even when that component was declined.
+defer_root="$test_root/deferred-cleanup"
+mkdir -p "$defer_root/home" "$defer_root/bin" "$defer_root/work"
+make_legacy_zipapp "$defer_root/bin/tcl"
+if ! (
+    export HOME="$defer_root/home"
+    export PATH="$defer_root/bin:/usr/bin:/bin"
+    WORKDIR="$defer_root/work"
+    ONLY=none; WANT_MCP=1; WANT_SKILLS=0
+    needs_prefix() { return 1; }
+    install_downloader() { return 0; }
+    install_ai_integrations() { return 1; }
+    if execute_install_plan; then exit 20; fi
+    [ -e "$defer_root/bin/tcl" ]
+); then
+    fail "failed native plan removed the working legacy CLI"
+fi
+if ! (
+    export HOME="$defer_root/home"
+    export PATH="$defer_root/bin:/usr/bin:/bin"
+    WORKDIR="$defer_root/work"
+    ONLY=none; WANT_MCP=0; WANT_SKILLS=0
+    needs_prefix() { return 1; }
+    install_downloader() { return 0; }
+    install_ai_integrations() { return 0; }
+    execute_install_plan
+    [ ! -e "$defer_root/bin/tcl" ]
+); then
+    fail "successful native plan did not clean the legacy CLI"
+fi
+pass "legacy deletion waits for successful native installation"
+
 # Migration removes the main installer's complete discoverable footprint. It
 # must leave unrelated files and the newly installed native binary alone.
 make_legacy_zipapp "$test_root/path-old/f5"
@@ -141,6 +175,7 @@ mkdir -p "$PROJECT_ROOT"
 WANT_TCL=0; WANT_F5=0; WANT_MCP=0; WANT_SKILLS=0
 MCP_PREFIX_OVERRIDE="$test_root/path-new"
 cleanup_legacy_python_installs
+cleanup_legacy_claude_bundle
 cleanup_legacy_path_entries
 for old in tcl f5 tcl-explorer tcl-explorer-gui tcl-lsp-mcp-server.pyz; do
     assert_absent "$test_root/path-old/$old" "legacy $old cleanup"
@@ -178,6 +213,16 @@ grep -qF '# Added by tcl-lsp installer' "$HOME/.zshrc" \
 assert_file "$test_root/path-new/tcl" "native tcl preservation"
 assert_file "$test_root/path-old/unrelated" "unrelated Python file preservation"
 pass "complete safe main-installer migration cleanup"
+
+# A colliding prompt filename is not sufficient evidence that the main-branch
+# installer owns it. Preserve it when no legacy zipapp or skill marker exists.
+mkdir -p "$HOME/.claude/prompts"
+printf 'independent prompt manifest\n' > "$HOME/.claude/prompts/manifest.json"
+cleanup_legacy_claude_bundle
+assert_file "$HOME/.claude/prompts/manifest.json" \
+    "unowned Claude prompt preservation"
+rm -f "$HOME/.claude/prompts/manifest.json"
+pass "Claude prompt cleanup requires a legacy bundle marker"
 
 # When Codex is detected by its config directory but its CLI is unavailable,
 # replace exactly the old MCP table and preserve unrelated TOML settings.
@@ -261,6 +306,19 @@ grep -qF 'mcp remove -s user tcl-lsp' "$CLAUDE_LOG" \
 grep -qF "mcp add -s user tcl-lsp -- $MCP_PATH" "$CLAUDE_LOG" \
     || fail "Claude native user registration was not added explicitly"
 pass "Claude delete/add migration uses an explicit scope"
+
+# Detection through ~/.claude is enough to offer integration, but the CLI can
+# still be absent. Keep the manual-registration warning nonfatal so remaining
+# harnesses and cleanup continue.
+mv "$test_root/path-new/claude" "$test_root/path-new/claude.disabled"
+claude_config_only_output="$(register_mcp_claude 2>&1)" \
+    || fail "config-only Claude registration was fatal"
+case "$claude_config_only_output" in
+    *"CLI is not on PATH"*"Register manually"*) : ;;
+    *) fail "config-only Claude warning omitted manual registration guidance" ;;
+esac
+mv "$test_root/path-new/claude.disabled" "$test_root/path-new/claude"
+pass "config-only Claude registration is nonfatal"
 
 # Gemini has native scope-aware commands too; use those instead of editing its
 # settings format when the CLI is present.

--- a/scripts/install/test_installer.sh
+++ b/scripts/install/test_installer.sh
@@ -139,6 +139,101 @@ grep -qF 'mcp remove tcl_lsp' "$CODEX_LOG" || fail "Codex old registration was n
 grep -qF "mcp add tcl_lsp -- $MCP_PATH" "$CODEX_LOG" || fail "Codex native registration was not added"
 pass "Codex MCP migration through CLI"
 
+# Detection recognises CLI/config footprints for every supported harness.
+PROJECT_ROOT="$test_root/project"
+mkdir -p "$PROJECT_ROOT/.bobbit" "$HOME/.gemini" "$HOME/.copilot" \
+    "$HOME/.config/opencode" "$HOME/.hermes" "$HOME/.config/goose"
+AI_DETECTED=0
+detect_ai_clients
+assert_eq "$HAS_CLAUDE:$HAS_CODEX:$HAS_GEMINI:$HAS_COPILOT" "1:1:1:1" \
+    "primary harness detection"
+assert_eq "$HAS_OPENCODE:$HAS_HERMES:$HAS_GOOSE:$HAS_BOBBIT" "1:1:1:1" \
+    "config-driven harness detection"
+pass "supported harness detection"
+
+# Harness selection is independent. A harness with project-owned files defaults
+# to project scope; a detected harness without them gets user scope. Bobbit is
+# project-only because it deliberately discovers a project-root .mcp.json.
+mkdir -p "$PROJECT_ROOT/.claude" "$PROJECT_ROOT/.bobbit"
+HAS_CLAUDE=1; HAS_CODEX=1; HAS_GEMINI=0; HAS_COPILOT=0
+HAS_OPENCODE=0; HAS_HERMES=0; HAS_GOOSE=0; HAS_BOBBIT=1
+TCL_LSP_ASSUME_YES=1
+choose_ai_components
+assert_eq "$INSTALL_MCP_CLAUDE:$MCP_SCOPE_CLAUDE" "1:project" "Claude project scope selection"
+assert_eq "$INSTALL_MCP_CODEX:$MCP_SCOPE_CODEX" "1:user" "Codex user scope selection"
+assert_eq "$INSTALL_MCP_BOBBIT:$MCP_SCOPE_BOBBIT" "1:project" "Bobbit project scope selection"
+assert_eq "$WANT_MCP:$WANT_SKILLS" "1:1" "per-harness MCP and Claude skills plan"
+unset TCL_LSP_ASSUME_YES
+pass "per-harness registration and project-aware scope planning"
+
+# Claude migration must remove the historical implicit local registration and
+# replace the selected scope explicitly. `mcp list` prints names with a colon,
+# so migration must not depend on parsing that display format.
+CLAUDE_LOG="$test_root/claude.log"; export CLAUDE_LOG
+cat > "$test_root/path-new/claude" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$CLAUDE_LOG"
+if [ "$1 $2" = "mcp list" ]; then
+    printf 'tcl-lsp: python3 /old/tcl-lsp-mcp-server.pyz\n'
+fi
+EOF
+chmod +x "$test_root/path-new/claude"
+MCP_SCOPE_CLAUDE=user
+register_mcp_claude
+grep -qF 'mcp remove -s local tcl-lsp' "$CLAUDE_LOG" \
+    || fail "Claude stale local registration was not removed"
+grep -qF 'mcp remove -s user tcl-lsp' "$CLAUDE_LOG" \
+    || fail "Claude selected user registration was not replaced"
+grep -qF "mcp add -s user tcl-lsp -- $MCP_PATH" "$CLAUDE_LOG" \
+    || fail "Claude native user registration was not added explicitly"
+pass "Claude delete/add migration uses an explicit scope"
+
+# Gemini has native scope-aware commands too; use those instead of editing its
+# settings format when the CLI is present.
+GEMINI_LOG="$test_root/gemini.log"; export GEMINI_LOG
+printf '#!/bin/sh\nprintf "%%s\\n" "$*" >> "$GEMINI_LOG"\n' > "$test_root/path-new/gemini"
+chmod +x "$test_root/path-new/gemini"
+MCP_SCOPE_GEMINI=project
+register_mcp_gemini
+grep -qF 'mcp remove -s project tcl-lsp' "$GEMINI_LOG" \
+    || fail "Gemini project registration was not removed before replacement"
+grep -qF "mcp add -s project tcl-lsp $MCP_PATH" "$GEMINI_LOG" \
+    || fail "Gemini native project registration was not added"
+pass "Gemini delete/add migration uses an explicit scope"
+
+# Config-only harnesses can be bootstrapped without Python, Node.js, jq, or yq
+# when their config file does not exist yet.
+json_cfg="$test_root/config/new/.mcp.json"
+yaml_cfg="$test_root/config/hermes/config.yaml"
+write_json_mcp_config "$json_cfg" standard
+write_yaml_mcp_config "$yaml_cfg" hermes
+grep -qF '"tcl-lsp"' "$json_cfg" || fail "new standard MCP JSON omitted tcl-lsp"
+grep -qF "\"command\": \"$MCP_PATH\"" "$json_cfg" || fail "new standard MCP JSON omitted native command"
+grep -qF '  tcl-lsp:' "$yaml_cfg" || fail "new Hermes YAML omitted tcl-lsp"
+grep -qF "    command: \"$MCP_PATH\"" "$yaml_cfg" || fail "new Hermes YAML omitted native command"
+pass "native-only JSON and YAML MCP config bootstrap"
+
+# The no-dependency YAML updater replaces only our child map and preserves
+# unrelated harness configuration.
+cat > "$yaml_cfg" <<'EOF'
+model: example
+mcp_servers:
+  tcl-lsp:
+    command: python3
+    args: [/old/tcl-lsp-mcp-server.pyz]
+  other:
+    command: /keep/me
+theme: dark
+EOF
+write_yaml_mcp_config "$yaml_cfg" hermes
+grep -qF "    command: \"$MCP_PATH\"" "$yaml_cfg" \
+    || fail "Hermes native MCP command was not replaced"
+grep -qF '    command: /keep/me' "$yaml_cfg" \
+    || fail "unrelated Hermes MCP entry was not preserved"
+grep -qF 'theme: dark' "$yaml_cfg" || fail "unrelated Hermes root setting was not preserved"
+if grep -qF '.pyz' "$yaml_cfg"; then fail "old Hermes zipapp command survived"; fi
+pass "Hermes YAML migration preserves unrelated configuration"
+
 if grep -qE 'plan_python_if_needed|install_python|install_mcp_zipapp|MCP_NATIVE' \
     "$repo_root/scripts/install/install.sh"; then
     fail "retired Python installer path remains"

--- a/scripts/install/test_installer.sh
+++ b/scripts/install/test_installer.sh
@@ -84,26 +84,100 @@ looks_like_legacy_zipapp "$test_root/path-old/tcl" || fail "legacy zipapp was no
 if looks_like_legacy_zipapp "$test_root/path-old/unrelated"; then fail "unrelated Python file was claimed"; fi
 pass "legacy ownership recognition"
 
-# Migration removes only positively identified historical names. It must leave
-# unrelated files and the newly installed native binary alone.
+# Migration removes the main installer's complete discoverable footprint. It
+# must leave unrelated files and the newly installed native binary alone.
 make_legacy_zipapp "$test_root/path-old/f5"
 make_legacy_zipapp "$test_root/path-old/tcl-explorer"
 make_legacy_zipapp "$test_root/path-old/tcl-explorer-gui"
 make_legacy_zipapp "$test_root/path-old/tcl-lsp-mcp-server.pyz"
+mkdir -p "$test_root/custom-prefix" "$test_root/mcp-custom"
+make_legacy_zipapp "$test_root/custom-prefix/tcl-lsp"
+make_legacy_zipapp "$test_root/custom-prefix/f5-custom"
+make_legacy_zipapp "$test_root/mcp-custom/tcl-lsp-mcp-server.pyz"
+cat > "$HOME/.bashrc" <<EOF
+# Added by tcl-lsp installer
+export PATH="$test_root/custom-prefix:\$PATH"
+EOF
+cat > "$HOME/.zshrc" <<EOF
+# Added by tcl-lsp installer
+export PATH="$test_root/path-new:\$PATH"
+EOF
 mkdir -p "$HOME/.claude"
 make_legacy_zipapp "$HOME/.claude/tcl-ai.pyz"
+mkdir -p "$HOME/.claude/prompts" "$HOME/.claude/skills/tcl-fix" \
+    "$HOME/.claude/skills/f5-query" \
+    "$HOME/.claude/skills/unrelated" \
+    "$HOME/.local/share/bash-completion/completions"
+printf 'Tcl system prompt\n' > "$HOME/.claude/prompts/tcl_system.md"
+printf 'python3 .claude/tcl-ai.pyz fix\n' > "$HOME/.claude/skills/tcl-fix/SKILL.md"
+printf '%s\n' '---' 'name: f5-query' '---' > "$HOME/.claude/skills/f5-query/SKILL.md"
+printf 'keep me\n' > "$HOME/.claude/skills/unrelated/SKILL.md"
+printf '_ARGCOMPLETE=1 tcl.pyz\n' > "$HOME/.local/share/bash-completion/completions/tcl"
+printf 'native completion\n' > "$HOME/.local/share/bash-completion/completions/f5"
+mkdir -p "$HOME/.codex"
+cat > "$HOME/.codex/config.toml" <<EOF
+model = "example"
+
+[mcp_servers.tcl_lsp]
+command = "python3"
+args = ["$test_root/mcp-custom/tcl-lsp-mcp-server.pyz"]
+
+[mcp_servers.other]
+command = "/keep/me"
+EOF
+CLAUDE_LOG="$test_root/legacy-claude.log"; export CLAUDE_LOG
+cat > "$test_root/path-new/claude" <<EOF
+#!/bin/sh
+printf '%s\n' "\$*" >> "$CLAUDE_LOG"
+if [ "\$1 \$2" = "mcp list" ]; then
+    printf 'tcl-lsp: python3 $test_root/mcp-custom/tcl-lsp-mcp-server.pyz\n'
+fi
+EOF
+chmod +x "$test_root/path-new/claude"
 printf '#!/bin/sh\n# Unified Tcl toolchain CLI\n' > "$test_root/path-new/tcl"
 chmod +x "$test_root/path-new/tcl"
-WANT_TCL=1; WANT_F5=1; WANT_MCP=1; WANT_SKILLS=1
+PROJECT_ROOT="$test_root/project"
+mkdir -p "$PROJECT_ROOT"
+WANT_TCL=0; WANT_F5=0; WANT_MCP=0; WANT_SKILLS=0
 MCP_PREFIX_OVERRIDE="$test_root/path-new"
 cleanup_legacy_python_installs
+cleanup_legacy_path_entries
 for old in tcl f5 tcl-explorer tcl-explorer-gui tcl-lsp-mcp-server.pyz; do
     assert_absent "$test_root/path-old/$old" "legacy $old cleanup"
 done
+assert_absent "$test_root/custom-prefix/tcl-lsp" "suffixed legacy tcl cleanup"
+assert_absent "$test_root/custom-prefix/f5-custom" "suffixed legacy f5 cleanup"
+assert_absent "$test_root/mcp-custom/tcl-lsp-mcp-server.pyz" "registered MCP path cleanup"
 assert_absent "$HOME/.claude/tcl-ai.pyz" "legacy Claude AI zipapp cleanup"
+assert_absent "$HOME/.claude/prompts/tcl_system.md" "legacy Claude prompt cleanup"
+assert_absent "$HOME/.claude/skills/tcl-fix" "legacy Claude skill cleanup"
+assert_absent "$HOME/.claude/skills/f5-query" "standalone legacy Claude skill cleanup"
+assert_file "$HOME/.claude/skills/unrelated/SKILL.md" "unrelated Claude skill preservation"
+if ! compgen -G "$HOME/.claude/.tcl-lsp-python-backup-*/tcl-ai.pyz" >/dev/null; then
+    fail "legacy Claude bundle backup was not created"
+fi
+assert_absent "$HOME/.local/share/bash-completion/completions/tcl" \
+    "legacy argcomplete cleanup"
+assert_file "$HOME/.local/share/bash-completion/completions/f5" \
+    "native completion preservation"
+grep -qF 'mcp remove -s local tcl-lsp' "$CLAUDE_LOG" \
+    || fail "legacy Claude MCP registration was not removed"
+if grep -qF '[mcp_servers.tcl_lsp]' "$HOME/.codex/config.toml"; then
+    fail "legacy Codex MCP registration survived"
+fi
+grep -qF 'command = "/keep/me"' "$HOME/.codex/config.toml" \
+    || fail "unrelated Codex MCP registration was not preserved"
+if grep -qF '# Added by tcl-lsp installer' "$HOME/.bashrc"; then
+    fail "stale installer PATH entry survived"
+fi
+if ! compgen -G "$HOME/.bashrc.bak.*" >/dev/null; then
+    fail "shell startup backup was not created"
+fi
+grep -qF '# Added by tcl-lsp installer' "$HOME/.zshrc" \
+    || fail "active native installer PATH entry was removed"
 assert_file "$test_root/path-new/tcl" "native tcl preservation"
 assert_file "$test_root/path-old/unrelated" "unrelated Python file preservation"
-pass "safe Python-era migration cleanup"
+pass "complete safe main-installer migration cleanup"
 
 # When Codex is detected by its config directory but its CLI is unavailable,
 # replace exactly the old MCP table and preserve unrelated TOML settings.


### PR DESCRIPTION
## Summary

- detect Claude, Codex, Gemini CLI, GitHub Copilot CLI, OpenCode, Hermes, Goose, and Bobbit before offering MCP registration
- prompt independently for each detected harness and choose project or user scope from project-specific configuration
- treat Bobbit as project-only and preserve unrelated JSON, JSONC, TOML, and YAML configuration
- replace stale Tcl MCP registrations with the native `tcl-mcp` binary and remove the Python fallback
- completely retire discoverable artefacts installed by the main-branch Python installer
- point pre-release installation documentation at the `rust` branch
- support terminal selection through `fzf` or dialog-style tools when available

## Root cause and fix

The installer assumed a small fixed set of clients and did not model their different configuration formats or scope rules. Existing registrations could therefore retain Python entry points or be written at the wrong scope. The installer now detects each supported harness, plans scope from project artefacts, and updates only the `tcl-lsp` registration while preserving unrelated configuration.

The previous migration cleanup covered only unsuffixed binaries in a few locations and ran only for selected replacement components. It could leave compiler-explorer zipapps, custom or suffixed installs, Python shell completions, the Python Claude bundle, stale MCP registrations, and installer-owned shell `PATH` entries. Cleanup now runs independently of component selection, discovers main-installer prefixes from `PATH`, standard locations, explicit overrides, MCP registrations, and shell startup markers, and removes only positively identified tcl-lsp artefacts.

Claude also negotiates MCP protocol `2026-07-28`, whose complete tool-list response requires cache metadata. The native MCP server now emits the required `resultType`, `ttlMs`, and `cacheScope` fields for modern clients while keeping the legacy response compatible.

## Migration safety

- Python zipapps are identified from their shebang, ZIP structure, and embedded tcl-lsp paths before deletion.
- Native or unrelated binaries, completions, skills, and MCP entries are preserved.
- Codex configuration and modified shell startup files are backed up before changes.
- The retired Claude prompt/skill bundle is moved out of active discovery into `~/.claude/.tcl-lsp-python-backup-*`.
- Shared system packages and existing recovery directories are not removed.
- `TCL_LSP_NO_LEGACY_CLEANUP=1` retains the retired installation when explicitly requested.

## Impact

Users get an explicit installation choice for every detected harness, safe project/user placement, native-only upgrades, working Claude tool discovery, and a complete migration away from the main branch's Python installer. Unsupported release platforms still fail early with source-build guidance.

## Validation

- `make prep-pr` after a clean Cargo rebuild
- `make rust-check`
- `make test-installer` — 15 tests, including complete migration cleanup and preservation
- shell syntax checks with `sh -n` and `bash -n`
- focused `tcl-mcp` protocol tests and a raw MCP `2026-07-28` probe
- live native Claude and Codex registration checks
- `git diff --check`
