### PR TITLE
Apply project SpecTcl packs across CLI and VS Code

### DIFF
--- a/docs/design/spec-dsl-examples/external/README.md
+++ b/docs/design/spec-dsl-examples/external/README.md
@@ -7,6 +7,13 @@ private-library author would need to say, and where the provisional DSL
 sketch (and the ported core-command examples already sitting in the parent
 directory) falls short.
 
+A later end-to-end validation uses the relationship between
+`georgtree/tclinterp` and `georgtree/SpiceGenTcl`. Its focused generated pack
+and reproducible CLI/VS Code results are recorded in
+[tclinterp-validation-report.md](tclinterp-validation-report.md). That real
+code is documentation evidence only; automated regression tests use the
+synthetic fixture under `tests/fixtures/spec-packs/`.
+
 Every claim below is grounded in a `file:line` from an actual clone; nothing
 here is invented from the library's documentation alone. Syntax that is
 *invented* for the drafted specs is marked `DSL GAP` inline in the

--- a/docs/design/spec-dsl-examples/external/tclinterp-validation-report.md
+++ b/docs/design/spec-dsl-examples/external/tclinterp-validation-report.md
@@ -1,0 +1,212 @@
+# SpecTcl end-to-end validation: `tclinterp` consumed by `SpiceGenTcl`
+
+> Validation date: 14 August 2026
+>
+> Product branch: `rust`-line implementation under test
+>
+> Automated-test boundary: the GeorgeTree repositories are evidence only and are not test dependencies
+
+## Result
+
+A project `.tclspec` changes the Rust CLI and VS Code language features for a
+real library command. Without the pack, the command has no registry metadata;
+with it, the CLI reports the command and diagnoses an incomplete call, while
+VS Code gains hover and signature help and reclassifies the three option names
+from `string` to `decorator` semantic tokens.
+
+The permanent regression tests do not clone or execute external code. They use
+the small library/consumer pair in
+[`tests/fixtures/spec-packs/tiny-project`](../../../../tests/fixtures/spec-packs/tiny-project/).
+The pinned GeorgeTree example in this report is a reproducible documentation
+case for the same path through the product.
+
+## Pinned library and consumer
+
+The library is
+[`georgtree/tclinterp` at `ccd894bbcf759607cec37cb308e12fca639b17b0`](https://github.com/georgtree/tclinterp/tree/ccd894bbcf759607cec37cb308e12fca639b17b0).
+Its `lin1d` implementation and inline documentation are pinned at
+[`tclinterp.tcl:139`](https://github.com/georgtree/tclinterp/blob/ccd894bbcf759607cec37cb308e12fca639b17b0/tclinterp.tcl#L139).
+The consumer is
+[`georgtree/SpiceGenTcl` at `e8aa45cee7053ebbd92af029f27ee2d6d31ed6ec`](https://github.com/georgtree/SpiceGenTcl/tree/e8aa45cee7053ebbd92af029f27ee2d6d31ed6ec).
+
+The consumer requires the dependency and imports its interpolation namespace
+([`diode_extract.tcl:5-8`](https://github.com/georgtree/SpiceGenTcl/blob/e8aa45cee7053ebbd92af029f27ee2d6d31ed6ec/examples/ngspice/advanced/diode_extract.tcl#L5-L8)):
+
+```tcl
+package require tclinterp
+namespace import ::tclinterp::interpolation::*
+```
+
+It then calls `lin1d` with measured voltage/current lists
+([`diode_extract.tcl:55`](https://github.com/georgtree/SpiceGenTcl/blob/e8aa45cee7053ebbd92af029f27ee2d6d31ed6ec/examples/ngspice/advanced/diode_extract.tcl#L55)):
+
+```tcl
+set iInterp [lin1d -x $vRaw -y $iRaw -xi $vInterp]
+```
+
+The library declares a variadic Tcl procedure and describes the actual option
+shape in its `argparse` block:
+
+```tcl
+proc ::tclinterp::interpolation::lin1d {args} {
+    argparse -help {Does linear one-dimensional interpolation.} {
+        {-x!=  -help {Strictly increasing independent values}}
+        {-y!=  -help {Dependent values}}
+        {-xi!= -help {Interpolation points}}
+    }
+}
+```
+
+## Pack generation and validation
+
+The SpecTcl authoring workflow produced structured procedure documentation
+from the source, including the `-x`, `-y`, and `-xi` parameter descriptions and
+the list return. A registry lookup returned `found: false`, confirming that the
+fully-qualified command did not collide with a shipped command. Validation of
+the generated pack reported:
+
+```text
+commands: 1
+notices: 0
+collisions: 0
+fields: arity, dialects, forms, hover, options, required_package, return_type
+```
+
+The generated pack is committed as
+[`tclinterp.tclspec`](tclinterp.tclspec). Its executable contents are:
+
+```tcl
+speclib tclinterp 0.15 {
+
+command ::tclinterp::interpolation::lin1d {
+    dialects {tcl9.0 tcl9.1}
+    arity 6
+    required_package tclinterp
+    return_type List
+
+    option -x -takes xValues \
+        -detail {List of independent values; values must be strictly increasing.}
+    option -y -takes yValues \
+        -detail {List of dependent values corresponding one-for-one with -x.}
+    option -xi -takes interpolationPoints \
+        -detail {List of independent values at which to interpolate.}
+
+    form Default {::tclinterp::interpolation::lin1d -x xValues -y yValues -xi interpolationPoints}
+
+    hover {
+        summary {Perform one-dimensional linear interpolation.}
+        synopsis {::tclinterp::interpolation::lin1d -x xValues -y yValues -xi interpolationPoints}
+        description {Interpolate dependent values at each point in -xi from paired -x and -y samples. The -x list must be strictly increasing, and the -x and -y lists must have equal lengths.}
+        source {georgtree/tclinterp tclinterp.tcl:139-171 at ccd894bbcf759607cec37cb308e12fca639b17b0}
+        returns {A list of interpolated dependent values, one for each value in -xi.}
+    }
+}
+
+}
+```
+
+The current DSL has no option-level `required exactly once` declaration.
+`arity 6` captures this command's three option/value pairs, but it cannot prove
+that each distinct option occurs exactly once. That limitation is kept explicit
+instead of inventing unsupported syntax.
+
+## CLI proof
+
+The same `tcl` binary was run in two working directories against Tcl 9.0. The
+“without” directory had no `.tcl-lsp`; the “with” project root contained the
+validated pack at `.tcl-lsp/tclinterp.tclspec`.
+
+| Query | Without `.tclspec` | With `.tclspec` |
+|---|---|---|
+| `command-info ::tclinterp::interpolation::lin1d --json` | exit 1, `found: false` | exit 0, `found: true` |
+| Summary | absent | `Perform one-dimensional linear interpolation.` |
+| Synopsis | absent | qualified `lin1d -x … -y … -xi …` form |
+| Switches | absent | `-x`, `-xi`, `-y` |
+| Incomplete call, `lin1d -x $x` | exit 0, no diagnostics | exit 1, `E002` and `W120` |
+| Complete call after `package require tclinterp` | opaque but clean | recognised and clean |
+
+The two diagnostics are meaningful analysis that is impossible while the
+command is unknown:
+
+- `E002`: the call does not satisfy the declared command shape and reports the
+  pack-authored usage form.
+- `W120`: the call is missing `package require tclinterp`.
+
+## VS Code proof
+
+The extension integration harness opened this qualified probe using VS Code
+1.133.0 on arm64 macOS:
+
+```tcl
+::tclinterp::interpolation::lin1d -x $vRaw -y $iRaw -xi $vInterp
+```
+
+It first set `tclLsp.specPacks` to an empty list, captured providers, then set
+it to the generated pack. The extension waited for `getEffectiveConfig` to
+confirm that `tclinterp` and its one command were loaded before capturing the
+second result.
+
+| Language feature | Without `.tclspec` | With `.tclspec` |
+|---|---|---|
+| Hover | empty | summary plus the qualified synopsis |
+| Signature help | empty | `::tclinterp::interpolation::lin1d -x xValues -y yValues -xi interpolationPoints` |
+| `-x` token | `string` | `decorator` |
+| `-y` token | `string` | `decorator` |
+| `-xi` token | `string` | `decorator` |
+
+The complete token sequence on the call line was:
+
+| Text | Without type | With type |
+|---|---|---|
+| `::tclinterp::interpolation::` | `namespace` | `namespace` |
+| `lin1d` | `function` | `function` |
+| `-x` | `string` | `decorator` |
+| `$vRaw` | `variable` | `variable` |
+| `-y` | `string` | `decorator` |
+| `$iRaw` | `variable` | `variable` |
+| `-xi` | `string` | `decorator` |
+| `$vInterp` | `variable` | `variable` |
+
+The harness passed in 2.2 seconds. This also exposed and verified a product
+fix: semantic-token database queries had used the base dialect registry even
+after hover and signature help had loaded the workspace overlay. They now use
+the registry keyed by the active spec-pack generation, so all providers see
+the same command metadata.
+
+## Permanent regression coverage
+
+The repository-owned fixture defines `::tcl_lsp_fixture::collect`, whose first
+argument is `VarWrite` and whose second is a Tcl `Body`. Its consumer is:
+
+```tcl
+package require tcl_lsp_fixture
+
+set input 3
+::tcl_lsp_fixture::collect output {
+    set doubled [expr {$input * 2}]
+    lappend output $doubled
+}
+puts $output
+```
+
+The CLI tests prove current-project `.tcl-lsp` discovery and compare diagnostics
+with and without the pack. The VS Code test proves the hover/signature change,
+that `output` becomes a `variable` token through `VarWrite`, and that `set` and
+`lappend` inside the custom command become `function` tokens only when the
+second argument is recognised as a `Body`.
+
+Relevant tests and fixture:
+
+- [`rust/tcl-cli/tests/cli.rs`](../../../../rust/tcl-cli/tests/cli.rs)
+- [`editors/vscode/src/test/specPacks.test.ts`](../../../../editors/vscode/src/test/specPacks.test.ts)
+- [`tests/fixtures/spec-packs/tiny-project`](../../../../tests/fixtures/spec-packs/tiny-project/)
+
+## macOS launch-crash note
+
+Two sandboxed launches of VS Code 1.132.0 and 1.133.0 aborted in
+`HIServices::_RegisterApplication` while AppKit was creating
+`NSApplication`. Both stacks end in Electron startup before an extension host
+or tcl-lsp process starts. Launching the same 1.133.0 test build outside that
+GUI sandbox started the extension host, ran this test, and exited normally.
+Those reports therefore describe the test-launch environment, not a crash in
+the Tcl extension or language server.

--- a/docs/design/spec-dsl-examples/external/tclinterp.tclspec
+++ b/docs/design/spec-dsl-examples/external/tclinterp.tclspec
@@ -1,0 +1,33 @@
+# Focused SpecTcl pack for georgtree/tclinterp 0.15.
+#
+# This is documentation evidence, not a test dependency. The committed
+# regression fixture under tests/fixtures/spec-packs/ is deliberately
+# synthetic. Source evidence is pinned in tclinterp-validation-report.md.
+
+speclib tclinterp 0.15 {
+
+command ::tclinterp::interpolation::lin1d {
+    dialects {tcl9.0 tcl9.1}
+    arity 6
+    required_package tclinterp
+    return_type List
+
+    option -x -takes xValues \
+        -detail {List of independent values; values must be strictly increasing.}
+    option -y -takes yValues \
+        -detail {List of dependent values corresponding one-for-one with -x.}
+    option -xi -takes interpolationPoints \
+        -detail {List of independent values at which to interpolate.}
+
+    form Default {::tclinterp::interpolation::lin1d -x xValues -y yValues -xi interpolationPoints}
+
+    hover {
+        summary {Perform one-dimensional linear interpolation.}
+        synopsis {::tclinterp::interpolation::lin1d -x xValues -y yValues -xi interpolationPoints}
+        description {Interpolate dependent values at each point in -xi from paired -x and -y samples. The -x list must be strictly increasing, and the -x and -y lists must have equal lengths.}
+        source {georgtree/tclinterp tclinterp.tcl:139-171 at ccd894bbcf759607cec37cb308e12fca639b17b0}
+        returns {A list of interpolated dependent values, one for each value in -xi.}
+    }
+}
+
+}

--- a/editors/vscode/src/test/helper.ts
+++ b/editors/vscode/src/test/helper.ts
@@ -304,6 +304,13 @@ export interface EffectiveConfig {
   extra_commands: string[];
   non_ascii_mode: string | null;
   library_paths: string[];
+  spec_packs: string[];
+  spec_packs_loaded: Array<{
+    name: string;
+    tier: string;
+    commands: number;
+    files: string[];
+  }>;
   line_length: number;
   dialect_explicitly_set: boolean;
   features: Record<string, boolean>;

--- a/editors/vscode/src/test/specPacks.test.ts
+++ b/editors/vscode/src/test/specPacks.test.ts
@@ -1,0 +1,181 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as assert from "assert";
+import * as path from "path";
+import * as vscode from "vscode";
+
+import { activate, pollUntil, waitForEffectiveConfig } from "./helper";
+
+interface DecodedToken {
+  line: number;
+  char: number;
+  length: number;
+  type: string;
+}
+
+function decodeTokens(
+  tokens: vscode.SemanticTokens,
+  legend: vscode.SemanticTokensLegend,
+): DecodedToken[] {
+  const decoded: DecodedToken[] = [];
+  let line = 0;
+  let char = 0;
+  for (let i = 0; i < tokens.data.length; i += 5) {
+    const [deltaLine, deltaChar, length, typeIndex] = tokens.data.slice(i, i + 5);
+    if (deltaLine) {
+      line += deltaLine;
+      char = deltaChar;
+    } else {
+      char += deltaChar;
+    }
+    decoded.push({ line, char, length, type: legend.tokenTypes[typeIndex] });
+  }
+  return decoded;
+}
+
+function hoverText(hovers: vscode.Hover[] | undefined): string {
+  return (hovers ?? [])
+    .flatMap((hover) => hover.contents)
+    .map((content) => (typeof content === "string" ? content : content.value))
+    .join("\n");
+}
+
+suite("SpecTcl project packs", () => {
+  test("a .tclspec changes hover, signature help, and semantic analysis", async () => {
+    const project = path.resolve(__dirname, "../../../../tests/fixtures/spec-packs/tiny-project");
+    const pack = path.join(project, ".tcl-lsp", "tcl_lsp_fixture.tclspec");
+    const docUri = vscode.Uri.file(path.join(project, "consumer.tcl"));
+    const config = vscode.workspace.getConfiguration("tclLsp", docUri);
+    const original = config.inspect<string[]>("specPacks")?.workspaceValue;
+
+    try {
+      await config.update("specPacks", [], vscode.ConfigurationTarget.Workspace);
+      const doc = await activate(docUri);
+      await waitForEffectiveConfig(
+        docUri,
+        (effective) =>
+          effective.spec_packs.length === 0 &&
+          !effective.spec_packs_loaded.some((loaded) => loaded.name === "tcl_lsp_fixture"),
+        { timeout: 20_000, label: "synthetic pack absent" },
+      );
+
+      const commandPosition = new vscode.Position(3, 2);
+      const argumentPosition = new vscode.Position(3, 28);
+      const legend = (await vscode.commands.executeCommand(
+        "vscode.provideDocumentSemanticTokensLegend",
+        docUri,
+      )) as vscode.SemanticTokensLegend;
+
+      const beforeHover = (await vscode.commands.executeCommand(
+        "vscode.executeHoverProvider",
+        docUri,
+        commandPosition,
+      )) as vscode.Hover[] | undefined;
+      const beforeSignature = (await vscode.commands.executeCommand(
+        "vscode.executeSignatureHelpProvider",
+        docUri,
+        argumentPosition,
+      )) as vscode.SignatureHelp | undefined;
+      const beforeTokens = decodeTokens(
+        (await vscode.commands.executeCommand(
+          "vscode.provideDocumentSemanticTokens",
+          docUri,
+        )) as vscode.SemanticTokens,
+        legend,
+      );
+
+      assert.ok(
+        !hoverText(beforeHover).includes("collecting a result"),
+        "the pack-authored hover must be absent before the pack loads",
+      );
+      assert.ok(
+        !beforeSignature || beforeSignature.signatures.length === 0,
+        "unknown command must have no pack signature",
+      );
+
+      await config.update("specPacks", [pack], vscode.ConfigurationTarget.Workspace);
+      await waitForEffectiveConfig(
+        docUri,
+        (effective) =>
+          effective.spec_packs.includes(pack) &&
+          effective.spec_packs_loaded.some(
+            (loaded) => loaded.name === "tcl_lsp_fixture" && loaded.commands === 1,
+          ),
+        { timeout: 20_000, label: "synthetic pack loaded" },
+      );
+
+      const afterHover = (await pollUntil(
+        () =>
+          vscode.commands.executeCommand(
+            "vscode.executeHoverProvider",
+            docUri,
+            commandPosition,
+          ) as Thenable<vscode.Hover[] | undefined>,
+        (hovers) => hoverText(hovers).includes("collecting a result"),
+        { timeout: 20_000, label: "SpecTcl hover" },
+      )) as vscode.Hover[];
+      const afterSignature = (await pollUntil(
+        () =>
+          vscode.commands.executeCommand(
+            "vscode.executeSignatureHelpProvider",
+            docUri,
+            argumentPosition,
+          ) as Thenable<vscode.SignatureHelp | undefined>,
+        (signature) =>
+          Boolean(
+            signature?.signatures.some((item) => item.label.includes("::tcl_lsp_fixture::collect")),
+          ),
+        { timeout: 20_000, label: "SpecTcl signature help" },
+      )) as vscode.SignatureHelp;
+      const afterTokens = await pollUntil(
+        async () =>
+          decodeTokens(
+            (await vscode.commands.executeCommand(
+              "vscode.provideDocumentSemanticTokens",
+              docUri,
+            )) as vscode.SemanticTokens,
+            legend,
+          ),
+        (tokens) =>
+          tokens.some(
+            (token) =>
+              token.line === 4 &&
+              token.type === "function" &&
+              doc.lineAt(token.line).text.slice(token.char, token.char + token.length) === "set",
+          ),
+        { timeout: 20_000, label: "SpecTcl body semantic tokens" },
+      );
+
+      assert.ok(hoverText(afterHover).includes("collecting a result"));
+      assert.ok(
+        afterSignature.signatures.some((item) => item.label.includes("::tcl_lsp_fixture::collect")),
+      );
+
+      const tokenText = (token: DecodedToken): string =>
+        doc.lineAt(token.line).text.slice(token.char, token.char + token.length);
+      assert.ok(
+        !beforeTokens.some(
+          (token) => token.line === 4 && token.type === "function" && tokenText(token) === "set",
+        ),
+        "without the pack, the custom command's braced body stays opaque",
+      );
+      for (const word of ["set", "lappend"]) {
+        assert.ok(
+          afterTokens.some((token) => token.type === "function" && tokenText(token) === word),
+          `with the pack, '${word}' inside the Body argument must be a function token`,
+        );
+      }
+      assert.ok(
+        afterTokens.some(
+          (token) => token.line === 3 && token.type === "variable" && tokenText(token) === "output",
+        ),
+        "the VarWrite argument must be a variable token",
+      );
+    } finally {
+      await config.update("specPacks", original, vscode.ConfigurationTarget.Workspace);
+    }
+  });
+});

--- a/editors/vscode/src/test/specPacks.test.ts
+++ b/editors/vscode/src/test/specPacks.test.ts
@@ -102,7 +102,7 @@ suite("SpecTcl project packs", () => {
         (effective) =>
           effective.spec_packs.includes(pack) &&
           effective.spec_packs_loaded.some(
-            (loaded) => loaded.name === "tcl_lsp_fixture" && loaded.commands === 1,
+            (loaded) => loaded.name === "tcl_lsp_fixture" && loaded.commands > 0,
           ),
         { timeout: 20_000, label: "synthetic pack loaded" },
       );

--- a/rust/tcl-cli-support/src/highlight.rs
+++ b/rust/tcl-cli-support/src/highlight.rs
@@ -25,9 +25,9 @@
 
 use std::collections::HashSet;
 
+use crate::registry_for_dialect;
 use tcl_compiler::segmenter::segment_commands;
 use tcl_lexer::{Lexer, TokenType};
-use tcl_registry::registry_for_dialect;
 
 const ANSI_RESET: &str = "\x1b[0m";
 

--- a/rust/tcl-cli-support/src/lib.rs
+++ b/rust/tcl-cli-support/src/lib.rs
@@ -74,12 +74,15 @@ pub fn registry_for_dialect(
 /// command reads as unknown, because the vendor libraries are `.tclspec` packs
 /// now and nothing compiled-in answers for them.
 ///
-/// Call [`registry_for_dialect`] for the same dialect first (every CLI verb
-/// already does): that is what *builds* the entry this key names, and the
-/// analyser can only look it up.
+/// This builds the dialect overlay before returning its key. The analyser's
+/// overlay lookup is intentionally read-only, so returning a key without
+/// installing the corresponding `(profile, key)` entry would silently fall
+/// back to the plain profile.
 #[must_use]
-pub fn spec_pack_key() -> u64 {
-    cli_packs().key
+pub fn spec_pack_key(dialect: &str) -> u64 {
+    let packs = cli_packs();
+    let _registry = tcl_spectcl::install::registry_for_dialect_with_packs(dialect, packs);
+    packs.key
 }
 
 /// Discover the CLI process's workspace once, rooted at its current directory.
@@ -91,7 +94,14 @@ fn cli_packs() -> &'static tcl_spectcl::PackSet {
             workspace_roots,
             ..tcl_spectcl::DiscoveryOptions::default()
         });
-        tcl_spectcl::bundled::load_discovered(&files)
+        let packs = tcl_spectcl::bundled::load_discovered(&files);
+        // Pack commands and their typed behaviour are one publication. Hook
+        // dispatch consults the process-wide plan, while explorer consumers
+        // consult the active pack set; publish both before exposing `packs`.
+        tcl_spectcl::hooks::publish(&packs);
+        tcl_spectcl::hooks::ensure_thread_host();
+        tcl_spectcl::bundled::set_active(Some(std::sync::Arc::new(packs.clone())));
+        packs
     })
 }
 

--- a/rust/tcl-cli-support/src/lib.rs
+++ b/rust/tcl-cli-support/src/lib.rs
@@ -45,17 +45,14 @@ pub use output::{
     OutputTarget, ensure_ascii, expand_tabs, resolve_use_colour, write_binary_output,
     write_highlighted_output, write_text_output,
 };
-/// The command registry for `dialect`, **with the shipped `.tclspec`
-/// loadables installed**.
+/// The command registry for `dialect`, with project, user, and shipped
+/// `.tclspec` loadables installed.
 ///
-/// The per-dialect registry cache lives in `tcl-registry` so every downstream
-/// tool shares one cache; this is the same cache, entered through the one door
-/// that also carries the bundled packs. It has to be: the EDA vendor libraries
-/// are loadables now (`docs/design/spec-packs.md`), so a `tcl lookup --dialect
-/// xilinx-eda-tcl synth_design` reaches its spec only if the CLI parses
-/// `specs/synth_design`'s pack the way the language server does. With no
-/// bundled directory present this is byte-for-byte
-/// [`tcl_registry::registry_for_dialect`], down to the same cached instance.
+/// A CLI invocation treats its current directory as its workspace root. That
+/// gives a project the same automatic `.tcl-lsp/` and `tclpkg.tcl`-adjacent
+/// discovery the language server performs, while retaining the user and
+/// bundled tiers. The set is loaded once because a CLI process has one stable
+/// working directory and exits after its verb completes.
 ///
 /// An owning handle, because the pack-carrying entry it names is refcounted
 /// and retirable. A CLI verb resolves its packs once and runs to exit, so in
@@ -65,10 +62,10 @@ pub use output::{
 pub fn registry_for_dialect(
     dialect: &str,
 ) -> std::sync::Arc<tcl_registry::registry::CommandRegistry> {
-    tcl_spectcl::bundled::registry_for_dialect(dialect)
+    tcl_spectcl::install::registry_for_dialect_with_packs(dialect, cli_packs())
 }
 
-/// The shipped loadables' content identity, for
+/// The discovered loadables' content identity, for
 /// [`Analyser::with_pack_overlay`](tcl_compiler::analyser::Analyser::with_pack_overlay).
 ///
 /// The analyser resolves its own registry from its `DialectProfile`, so it
@@ -82,7 +79,20 @@ pub fn registry_for_dialect(
 /// analyser can only look it up.
 #[must_use]
 pub fn spec_pack_key() -> u64 {
-    tcl_spectcl::bundled::packs().key
+    cli_packs().key
+}
+
+/// Discover the CLI process's workspace once, rooted at its current directory.
+fn cli_packs() -> &'static tcl_spectcl::PackSet {
+    static PACKS: std::sync::OnceLock<tcl_spectcl::PackSet> = std::sync::OnceLock::new();
+    PACKS.get_or_init(|| {
+        let workspace_roots = std::env::current_dir().into_iter().collect();
+        let files = tcl_spectcl::discover(&tcl_spectcl::DiscoveryOptions {
+            workspace_roots,
+            ..tcl_spectcl::DiscoveryOptions::default()
+        });
+        tcl_spectcl::bundled::load_discovered(&files)
+    })
 }
 
 /// Result alias for fallible CLI-support operations.

--- a/rust/tcl-cli/src/commands/diag.rs
+++ b/rust/tcl-cli/src/commands/diag.rs
@@ -253,7 +253,7 @@ fn collect_rows(
     let file_path = document.path.as_deref().map(|p| p.display().to_string());
     let mut analyser = Analyser::new()
         .with_file_path(file_path)
-        .with_pack_overlay(tcl_cli_support::spec_pack_key());
+        .with_pack_overlay(tcl_cli_support::spec_pack_key(dialect));
     analyser.set_cu_override(std::sync::Arc::clone(&analysis_cu));
     let result = analyser.analyse(source, dialect);
     for d in &result.diagnostics {

--- a/rust/tcl-cli/src/commands/explore.rs
+++ b/rust/tcl-cli/src/commands/explore.rs
@@ -45,6 +45,11 @@ pub fn run_explore(
     let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
     let source = combine_sources(&documents);
 
+    // `tcl-explorer` deliberately resolves the process's active registry so
+    // its pipeline matches the LSP. Initialising the CLI registry publishes
+    // the discovered project pack set (and its hook plan) on that interface.
+    let _registry = tcl_cli_support::registry_for_dialect(&dialect);
+
     if tui {
         return run_tui(&source, &dialect);
     }

--- a/rust/tcl-cli/src/commands/graphs.rs
+++ b/rust/tcl-cli/src/commands/graphs.rs
@@ -192,7 +192,7 @@ pub fn run_symbols(input: &InputArgs, json: bool) -> anyhow::Result<u8> {
     let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
     let source = combine_sources(&documents);
     let result = Analyser::new()
-        .with_pack_overlay(tcl_cli_support::spec_pack_key())
+        .with_pack_overlay(tcl_cli_support::spec_pack_key(&dialect))
         .analyse(&source, &dialect);
     let line_index = LineIndex::new(&source);
 

--- a/rust/tcl-cli/src/commands/minimize.rs
+++ b/rust/tcl-cli/src/commands/minimize.rs
@@ -98,7 +98,7 @@ pub enum MinimizeError {
 /// Whether `code` fires anywhere in `source` under `dialect`.
 fn fires(source: &str, code: &str, dialect: &str) -> bool {
     Analyser::new()
-        .with_pack_overlay(tcl_cli_support::spec_pack_key())
+        .with_pack_overlay(tcl_cli_support::spec_pack_key(dialect))
         .analyse(source, dialect)
         .diagnostics
         .iter()

--- a/rust/tcl-cli/src/commands/misc.rs
+++ b/rust/tcl-cli/src/commands/misc.rs
@@ -88,7 +88,7 @@ pub fn run_find_legacy(input: &InputArgs, json: bool) -> anyhow::Result<u8> {
     let source = combine_sources(&documents);
 
     let result = Analyser::new()
-        .with_pack_overlay(tcl_cli_support::spec_pack_key())
+        .with_pack_overlay(tcl_cli_support::spec_pack_key(&dialect))
         .analyse(&source, &dialect);
     let line_index = LineIndex::new(&source);
 

--- a/rust/tcl-cli/tests/cli.rs
+++ b/rust/tcl-cli/tests/cli.rs
@@ -30,6 +30,10 @@ fn fixtures_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
 }
 
+fn spec_pack_project() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures/spec-packs/tiny-project")
+}
+
 /// Run the built `tcl` binary with `args`, returning captured stdout bytes.
 fn run_tcl(args: &[&str]) -> Vec<u8> {
     let output = Command::new(env!("CARGO_BIN_EXE_tcl"))
@@ -43,6 +47,75 @@ fn run_tcl(args: &[&str]) -> Vec<u8> {
         String::from_utf8_lossy(&output.stderr)
     );
     output.stdout
+}
+
+#[test]
+fn command_info_discovers_the_current_projects_spec_pack() {
+    let project = spec_pack_project();
+    let with_pack = Command::new(env!("CARGO_BIN_EXE_tcl"))
+        .current_dir(&project)
+        .args(["command-info", "::tcl_lsp_fixture::collect", "--json"])
+        .output()
+        .expect("failed to spawn tcl binary");
+    assert!(
+        with_pack.status.success(),
+        "project pack was not discovered: {}",
+        String::from_utf8_lossy(&with_pack.stderr)
+    );
+    let found: serde_json::Value =
+        serde_json::from_slice(&with_pack.stdout).expect("command-info JSON");
+    assert_eq!(found["found"], true);
+    assert_eq!(
+        found["summary"],
+        "Evaluate a script while collecting a result in a caller variable."
+    );
+
+    let without_pack = Command::new(env!("CARGO_BIN_EXE_tcl"))
+        .current_dir(project.join("lib"))
+        .args(["command-info", "::tcl_lsp_fixture::collect", "--json"])
+        .output()
+        .expect("failed to spawn tcl binary");
+    assert_eq!(without_pack.status.code(), Some(1));
+    let missing: serde_json::Value =
+        serde_json::from_slice(&without_pack.stdout).expect("command-info JSON");
+    assert_eq!(missing["found"], false);
+}
+
+#[test]
+fn diag_analysis_changes_when_the_current_projects_spec_pack_is_present() {
+    let project = spec_pack_project();
+    let args = [
+        "diag",
+        "--source",
+        "::tcl_lsp_fixture::collect output",
+        "--json",
+    ];
+
+    let with_pack = Command::new(env!("CARGO_BIN_EXE_tcl"))
+        .current_dir(&project)
+        .args(args)
+        .output()
+        .expect("failed to spawn tcl binary");
+    assert_eq!(with_pack.status.code(), Some(1));
+    let analysed: serde_json::Value =
+        serde_json::from_slice(&with_pack.stdout).expect("diag JSON with pack");
+    let codes: Vec<&str> = analysed[0]["diagnostics"]
+        .as_array()
+        .expect("diagnostics array")
+        .iter()
+        .filter_map(|diagnostic| diagnostic["code"].as_str())
+        .collect();
+    assert_eq!(codes, ["E002", "W120"]);
+
+    let without_pack = Command::new(env!("CARGO_BIN_EXE_tcl"))
+        .current_dir(project.join("lib"))
+        .args(args)
+        .output()
+        .expect("failed to spawn tcl binary");
+    assert!(without_pack.status.success());
+    let opaque: serde_json::Value =
+        serde_json::from_slice(&without_pack.stdout).expect("diag JSON without pack");
+    assert_eq!(opaque[0]["diagnostics"], serde_json::json!([]));
 }
 
 #[test]

--- a/rust/tcl-cli/tests/cli.rs
+++ b/rust/tcl-cli/tests/cli.rs
@@ -24,7 +24,7 @@
 //! committed golden/snapshot fixtures.
 
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Output};
 
 fn fixtures_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
@@ -47,6 +47,14 @@ fn run_tcl(args: &[&str]) -> Vec<u8> {
         String::from_utf8_lossy(&output.stderr)
     );
     output.stdout
+}
+
+fn run_tcl_in(current_dir: &std::path::Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_tcl"))
+        .current_dir(current_dir)
+        .args(args)
+        .output()
+        .expect("failed to spawn tcl binary")
 }
 
 #[test]
@@ -116,6 +124,131 @@ fn diag_analysis_changes_when_the_current_projects_spec_pack_is_present() {
     let opaque: serde_json::Value =
         serde_json::from_slice(&without_pack.stdout).expect("diag JSON without pack");
     assert_eq!(opaque[0]["diagnostics"], serde_json::json!([]));
+}
+
+#[test]
+fn analyser_only_verbs_install_the_current_projects_spec_pack_overlay() {
+    let project = spec_pack_project();
+    let source = "::tcl_lsp_fixture::collect output { proc nested {} { expr $input + 1 } }";
+
+    let symbols = run_tcl_in(&project, &["symbols", "--source", source, "--json"]);
+    assert!(symbols.status.success());
+    let symbols: serde_json::Value =
+        serde_json::from_slice(&symbols.stdout).expect("symbols JSON with pack");
+    assert!(
+        symbols["symbols"]
+            .as_array()
+            .expect("symbols array")
+            .iter()
+            .any(|symbol| symbol["name"] == "nested"),
+        "the Body role must expose the nested procedure"
+    );
+
+    let legacy = run_tcl_in(&project, &["find-legacy", "--source", source, "--json"]);
+    assert!(legacy.status.success());
+    let legacy: serde_json::Value =
+        serde_json::from_slice(&legacy.stdout).expect("find-legacy JSON with pack");
+    assert_eq!(legacy["issues"][0]["code"], "W100");
+
+    let minimized = run_tcl_in(
+        &project,
+        &["minimize", "--source", source, "W100", "--json"],
+    );
+    assert!(minimized.status.success());
+    let minimized: serde_json::Value =
+        serde_json::from_slice(&minimized.stdout).expect("minimize JSON with pack");
+    assert_eq!(minimized[0]["reproduces"], true);
+
+    let without_pack = run_tcl_in(
+        &project.join("lib"),
+        &["symbols", "--source", source, "--json"],
+    );
+    assert!(without_pack.status.success());
+    let without_pack: serde_json::Value =
+        serde_json::from_slice(&without_pack.stdout).expect("symbols JSON without pack");
+    assert_eq!(without_pack["count"], 0);
+}
+
+#[test]
+fn explore_uses_the_current_projects_active_spec_pack_registry() {
+    let project = spec_pack_project();
+    let source = "::tcl_lsp_fixture::collect output { set value 1 }";
+    let args = ["explore", "--source", source, "--json"];
+
+    let with_pack = run_tcl_in(&project, &args);
+    assert!(with_pack.status.success());
+    let with_pack: serde_json::Value =
+        serde_json::from_slice(&with_pack.stdout).expect("explore JSON with pack");
+    assert_eq!(
+        with_pack["semantic"][0]["invocations"][0]["resolution"],
+        "resolved"
+    );
+    assert_eq!(
+        with_pack["worldSsa"][0]["invocations"][0]["command"],
+        "::tcl_lsp_fixture::collect"
+    );
+
+    let without_pack = run_tcl_in(&project.join("lib"), &args);
+    assert!(without_pack.status.success());
+    let without_pack: serde_json::Value =
+        serde_json::from_slice(&without_pack.stdout).expect("explore JSON without pack");
+    assert_eq!(
+        without_pack["semantic"][0]["invocations"][0]["resolution"],
+        "unresolved-unknown-literal-head"
+    );
+}
+
+#[test]
+fn cli_publishes_project_pack_hooks() {
+    let project = spec_pack_project();
+    let args = [
+        "opt",
+        "--source",
+        "set length [::tcl_lsp_fixture::strlen abcde]",
+    ];
+
+    let with_pack = run_tcl_in(&project, &args);
+    assert!(with_pack.status.success());
+    let with_pack = String::from_utf8(with_pack.stdout).expect("UTF-8 opt output");
+    assert!(
+        with_pack.contains("set length 5"),
+        "hook did not fold: {with_pack}"
+    );
+    assert!(
+        with_pack.contains("O129"),
+        "hook rewrite was not reported: {with_pack}"
+    );
+
+    let without_pack = run_tcl_in(&project.join("lib"), &args);
+    assert!(without_pack.status.success());
+    let without_pack = String::from_utf8(without_pack.stdout).expect("UTF-8 opt output");
+    assert!(without_pack.contains("::tcl_lsp_fixture::strlen abcde"));
+    assert!(!without_pack.contains("O129"));
+}
+
+#[test]
+fn highlight_uses_the_current_projects_spec_pack_registry() {
+    let project = spec_pack_project();
+    let args = [
+        "highlight",
+        "--source",
+        "::tcl_lsp_fixture::catalog names",
+        "--format",
+        "html",
+    ];
+
+    let with_pack = run_tcl_in(&project, &args);
+    assert!(with_pack.status.success());
+    let with_pack = String::from_utf8(with_pack.stdout).expect("UTF-8 highlight output");
+    assert!(
+        with_pack.contains("color:#2c5282;\">names</span>"),
+        "pack subcommand was not highlighted: {with_pack}"
+    );
+
+    let without_pack = run_tcl_in(&project.join("lib"), &args);
+    assert!(without_pack.status.success());
+    let without_pack = String::from_utf8(without_pack.stdout).expect("UTF-8 highlight output");
+    assert!(!without_pack.contains("color:#2c5282;\">names</span>"));
 }
 
 #[test]

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -233,6 +233,11 @@ pub trait TclDb: salsa::Database {
     /// The dialect-loaded command registry (built once per canonical dialect
     /// key, then shared).  Immutable for the process lifetime.
     fn registry(&self, dialect: &str) -> &'static CommandRegistry;
+
+    /// An owning registry handle for a workspace pack generation already
+    /// installed by the server. Falls back to the plain profile on a cache
+    /// miss; only `tcl-spectcl` can construct the overlay's contents.
+    fn registry_with_overlay(&self, dialect: &str, overlay: u64) -> Arc<CommandRegistry>;
 }
 
 /// The Tcl LSP query database.
@@ -303,6 +308,12 @@ impl TclDb for TclDatabase {
         // iRules documents as plain Tcl and declined every word-operator fold
         // (issue #1048).
         tcl_registry::registry_for_dialect(dialect)
+    }
+
+    fn registry_with_overlay(&self, dialect: &str, overlay: u64) -> Arc<CommandRegistry> {
+        let profile = tcl_dialect::DialectProfile::by_name(dialect);
+        tcl_registry::cache::registry_for_profile_if_built(profile, overlay)
+            .unwrap_or_else(|| tcl_registry::cache::registry_handle_for_profile(profile))
     }
 }
 
@@ -3268,13 +3279,13 @@ pub fn document_compilation_unit(db: &dyn TclDb, file: SourceFile) -> Arc<Compil
 // anyway, so a borrow would buy nothing even if it were safe.
 #[salsa::tracked(returns(clone))]
 pub fn semantic_tokens(db: &dyn TclDb, file: SourceFile, config: AnalyserConfig) -> SemanticTokens {
-    let registry = db.registry(file.dialect(db));
+    let registry = db.registry_with_overlay(file.dialect(db), config.spec_pack_key(db));
     let cu = document_compilation_unit(db, file);
     let analysis = file_analysis_incremental(db, file, config);
     tcl_lsp_core::semantic_tokens::full_with_cu_and_analysis(
         file.text(db),
         file.dialect(db),
-        registry,
+        &registry,
         Some(&cu),
         Some(&analysis),
     )
@@ -3465,8 +3476,9 @@ pub fn semantic_tokens_project(
     db: &dyn TclDb,
     file: SourceFile,
     project: Project,
+    config: AnalyserConfig,
 ) -> SemanticTokens {
-    let registry = db.registry(file.dialect(db));
+    let registry = db.registry_with_overlay(file.dialect(db), config.spec_pack_key(db));
     let cu = document_compilation_unit(db, file);
     let classes = project_class_index(db, project);
     let proc_roles = project_proc_var_index(db, project);
@@ -3474,7 +3486,7 @@ pub fn semantic_tokens_project(
     tcl_lsp_core::semantic_tokens::full_with_cu_and_facts(
         file.text(db),
         file.dialect(db),
-        registry,
+        &registry,
         Some(&cu),
         tcl_lsp_core::semantic_tokens::WorkspaceTokenFacts {
             classes: Some(&classes),
@@ -4329,7 +4341,7 @@ mod tests {
             None,
         );
         let project = Project::new(&db, vec![lib, user]);
-        let cross = semantic_tokens_project(&db, user, project);
+        let cross = semantic_tokens_project(&db, user, project, cfg(&db));
         let local = semantic_tokens(&db, user, cfg(&db));
         assert_ne!(
             cross.data, local.data,

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -5684,7 +5684,9 @@ impl Backend {
         let snapshot = self.db.lock().await.clone();
         Some(tokio::task::spawn_blocking(move || {
             salsa::Cancelled::catch(|| match project {
-                Some(project) => tcl_lsp_db::semantic_tokens_project(&snapshot, file, project),
+                Some(project) => {
+                    tcl_lsp_db::semantic_tokens_project(&snapshot, file, project, config)
+                }
                 None => tcl_lsp_db::semantic_tokens(&snapshot, file, config),
             })
             .ok()
@@ -6391,6 +6393,11 @@ impl Backend {
             return Ok(data);
         }
 
+        // Install (and retain) this workspace pack generation before the salsa
+        // query resolves its opaque `spec_pack_key`. The query database sits
+        // below `tcl-spectcl`, so it can look up an installed overlay but must
+        // never manufacture one without the pack contents.
+        let _registry_generation = self.registry_for_dialect(&doc.dialect).await;
         let Some(mut enriched) = self.db_semantic_tokens(uri).await else {
             let registry = self.registry_for_dialect(&doc.dialect).await;
             let (text, dialect) = (doc.text.clone(), doc.dialect.clone());

--- a/rust/tcl-lsp-server/tests/e2e/spec_packs.rs
+++ b/rust/tcl-lsp-server/tests/e2e/spec_packs.rs
@@ -26,7 +26,7 @@
 //! absence of an unknown-command diagnostic, and load notices squiggled on the
 //! pack file itself.
 
-use crate::common::helpers::hover_text;
+use crate::common::helpers::{decode_semantic_tokens, hover_text};
 use crate::common::{Lsp, scaled_timeout};
 use serde_json::{Value, json};
 use std::path::{Path, PathBuf};
@@ -37,8 +37,8 @@ const MYLIB_PACK: &str = r"
 speclib mylib 1 {
     command mylib::with_var {
         arity 2..3
-        arg 0 -role varwrite
-        arg 1 -role body
+        arg 0 -role VarWrite
+        arg 1 -role Body
         hover {
             summary  {Run a script with a caller variable bound.}
             synopsis {mylib::with_var varName script ?mode?}
@@ -174,6 +174,52 @@ fn a_workspace_pack_makes_an_unknown_command_resolve_with_hover() {
         .find(|pack| pack.get("name").and_then(Value::as_str) == Some("mylib"))
         .unwrap_or_else(|| panic!("the workspace pack: {packs:#?}"));
     assert_eq!(mine.get("tier").and_then(Value::as_str), Some("workspace"));
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Pack argument roles must reach the memoised semantic-token query too, not
+/// only hover and diagnostics. `Body` recurses into the script and `VarWrite`
+/// paints the caller variable as a variable rather than a string.
+#[test]
+fn a_workspace_packs_argument_roles_drive_semantic_tokens() {
+    let root = workspace("semantic-tokens");
+    write(&root.join(".tcl-lsp/mylib.tclspec"), MYLIB_PACK);
+    let source = "mylib::with_var counter {\n    set counter 1\n}\n";
+    let doc = root.join("app.tcl");
+    write(&doc, source);
+
+    let mut lsp =
+        Lsp::with_config_at_root(json!({ "features": { "linkedEditingRange": true } }), &root);
+    let uri = file_uri(&doc);
+    await_pack_named(&mut lsp, "mylib");
+    lsp.open_ready(&uri, source);
+
+    let legend: Vec<String> =
+        lsp.initialize_result()["capabilities"]["semanticTokensProvider"]["legend"]["tokenTypes"]
+            .as_array()
+            .expect("semantic-token legend")
+            .iter()
+            .filter_map(Value::as_str)
+            .map(ToOwned::to_owned)
+            .collect();
+    let tokens = decode_semantic_tokens(&lsp.semantic_tokens_settled(&uri));
+    assert!(
+        tokens.iter().any(|token| {
+            token.line == 1
+                && token.char == 4
+                && legend[usize::try_from(token.ttype).expect("token type index")] == "function"
+        }),
+        "the inner `set` must be tokenised through the pack's Body role: {tokens:?}"
+    );
+    assert!(
+        tokens.iter().any(|token| {
+            token.line == 0
+                && token.char == 16
+                && legend[usize::try_from(token.ttype).expect("token type index")] == "variable"
+        }),
+        "the `counter` argument must use the pack's VarWrite role: {tokens:?}"
+    );
 
     let _ = std::fs::remove_dir_all(&root);
 }

--- a/rust/tcl-spectcl/src/install.rs
+++ b/rust/tcl-spectcl/src/install.rs
@@ -172,8 +172,8 @@ mod tests {
             "speclib mylib 1 {\n  \
              command mylib::with_var {\n    \
                arity 2..3\n    \
-               arg 0 -role varwrite\n    \
-               arg 1 -role body\n    \
+               arg 0 -role VarWrite\n    \
+               arg 1 -role Body\n    \
                hover -summary {Run a script with a caller variable bound.}\n  \
              }\n}\n",
         );
@@ -184,6 +184,22 @@ mod tests {
             .expect("the pack command resolves like any other");
         assert_eq!(spec.arity.min, 2);
         assert_eq!(spec.arity.max, 3);
+        assert_eq!(
+            registry.arg_indices_for_role(
+                "mylib::with_var",
+                &["counter", "set counter 1"],
+                tcl_registry::ArgRole::VarWrite,
+            ),
+            vec![0],
+        );
+        assert_eq!(
+            registry.arg_indices_for_role(
+                "mylib::with_var",
+                &["counter", "set counter 1"],
+                tcl_registry::ArgRole::Body,
+            ),
+            vec![1],
+        );
         assert!(
             registry.command_names().any(|n| n == "mylib::with_var"),
             "and is enumerable, so completion sees it"

--- a/rust/tcl-spectcl/tests/spec_corpus.rs
+++ b/rust/tcl-spectcl/tests/spec_corpus.rs
@@ -53,7 +53,7 @@
 //! The shipped collision policy is *shipped wins unless the pack says
 //! `-override`*, and no example port declares `-override` — they are ports of
 //! shipped specs, so installing them naturally is a no-op and step 2 would be
-//! vacuous for eleven of the twenty-one packs. The harness therefore reports
+//! vacuous for eleven of the twenty-two packs. The harness therefore reports
 //! the natural outcome ([`tcl_spectcl::pack::collision_notices`], the
 //! `collide` column) **and** installs with the override flag forced on, so the
 //! analyser reads the *pack's* specs and the *pack's* hook bodies run. Both
@@ -205,7 +205,7 @@ fn tclspec_files_in(dir: &Path) -> Vec<PathBuf> {
 }
 
 /// Every `.tclspec` the repository ships: the bundled EDA loadables under
-/// `specs/`, the eleven ports, and the four external drafts.
+/// `specs/`, the eleven ports, and the five external drafts.
 ///
 /// Discovered by scanning, never listed, so a pack added tomorrow is covered
 /// by this harness the day it lands — and, if it loads with a notice, fails
@@ -1111,8 +1111,8 @@ fn every_shipped_tclspec_loads_installs_and_analyses_against_corpus() {
             let (corpus_files, tmp) = corpus(&root);
             let packs = inventory(&root);
             assert!(
-                packs.len() >= 21,
-                "the repository ships 21 .tclspec files (6 bundled + 11 ports + 4 external); \
+                packs.len() >= 22,
+                "the repository ships 22 .tclspec files (6 bundled + 11 ports + 5 external); \
              found {}",
                 packs.len()
             );

--- a/tests/fixtures/spec-packs/tiny-project/.tcl-lsp/tcl_lsp_fixture.tclspec
+++ b/tests/fixtures/spec-packs/tiny-project/.tcl-lsp/tcl_lsp_fixture.tclspec
@@ -20,4 +20,29 @@ command ::tcl_lsp_fixture::collect {
     }
 }
 
+command ::tcl_lsp_fixture::catalog {
+    dialects tcl8.6+
+    arity 1
+    required_package tcl_lsp_fixture
+
+    subcommand names {
+        arity 0
+        detail {Return the available fixture entry names.}
+        synopsis {::tcl_lsp_fixture::catalog names}
+    }
+}
+
+command ::tcl_lsp_fixture::strlen {
+    dialects tcl8.6+
+    arity 1
+    required_package tcl_lsp_fixture
+
+    arg 0 -role Value
+    const_fold -inputs {words} {words ctx} {
+        set subject [lindex $words 0]
+        if {![string is ascii $subject]} { return }
+        fold [string length $subject]
+    }
+}
+
 }

--- a/tests/fixtures/spec-packs/tiny-project/.tcl-lsp/tcl_lsp_fixture.tclspec
+++ b/tests/fixtures/spec-packs/tiny-project/.tcl-lsp/tcl_lsp_fixture.tclspec
@@ -1,0 +1,23 @@
+# Test-only specification for the package in ../lib/tcl_lsp_fixture.tcl.
+speclib tcl_lsp_fixture 1.0 {
+
+command ::tcl_lsp_fixture::collect {
+    dialects tcl8.6+
+    arity 2
+    required_package tcl_lsp_fixture
+
+    arg 0 -role VarWrite
+    arg 1 -role Body
+
+    form Default {::tcl_lsp_fixture::collect resultVar script}
+
+    hover {
+        summary {Evaluate a script while collecting a result in a caller variable.}
+        synopsis {::tcl_lsp_fixture::collect resultVar script}
+        description {Clears resultVar in the caller, evaluates script in that caller, and returns the final value of resultVar.}
+        source {tests/fixtures/spec-packs/tiny-project/lib/tcl_lsp_fixture.tcl}
+        returns {The final value of resultVar.}
+    }
+}
+
+}

--- a/tests/fixtures/spec-packs/tiny-project/consumer.tcl
+++ b/tests/fixtures/spec-packs/tiny-project/consumer.tcl
@@ -1,0 +1,8 @@
+package require tcl_lsp_fixture
+
+set input 3
+::tcl_lsp_fixture::collect output {
+    set doubled [expr {$input * 2}]
+    lappend output $doubled
+}
+puts $output

--- a/tests/fixtures/spec-packs/tiny-project/lib/pkgIndex.tcl
+++ b/tests/fixtures/spec-packs/tiny-project/lib/pkgIndex.tcl
@@ -1,0 +1,2 @@
+package ifneeded tcl_lsp_fixture 1.0 \
+    [list source [file join $dir tcl_lsp_fixture.tcl]]

--- a/tests/fixtures/spec-packs/tiny-project/lib/tcl_lsp_fixture.tcl
+++ b/tests/fixtures/spec-packs/tiny-project/lib/tcl_lsp_fixture.tcl
@@ -15,3 +15,14 @@ proc ::tcl_lsp_fixture::collect {resultVar script} {
     uplevel 1 $script
     return $result
 }
+
+proc ::tcl_lsp_fixture::catalog {subcommand} {
+    if {$subcommand eq "names"} {
+        return {collect catalog strlen}
+    }
+    return -code error "unknown subcommand $subcommand"
+}
+
+proc ::tcl_lsp_fixture::strlen {value} {
+    string length $value
+}

--- a/tests/fixtures/spec-packs/tiny-project/lib/tcl_lsp_fixture.tcl
+++ b/tests/fixtures/spec-packs/tiny-project/lib/tcl_lsp_fixture.tcl
@@ -1,0 +1,17 @@
+# A deliberately small package used by the SpecTcl integration tests.
+package provide tcl_lsp_fixture 1.0
+
+namespace eval ::tcl_lsp_fixture {
+    namespace export collect
+}
+
+# Evaluate script in the caller while exposing resultVar as a list accumulator.
+#
+# resultVar is the name of a variable in the caller. The command clears that
+# variable before evaluating script, then returns its final value.
+proc ::tcl_lsp_fixture::collect {resultVar script} {
+    upvar 1 $resultVar result
+    set result {}
+    uplevel 1 $script
+    return $result
+}


### PR DESCRIPTION
## Summary

- discover current-project SpecTcl packs in CLI commands
- make semantic-token queries use the active pack overlay
- add an internal library/consumer regression fixture with CLI and VS Code coverage
- document the real tclinterp/SpiceGenTcl example, including token and analysis differences and the generated `.tclspec`

## Root cause

The CLI only loaded bundled packs, and memoised semantic-token queries used the base dialect registry after the server loaded a workspace overlay. Hover, signature help, semantic tokens, and CLI analysis could therefore disagree about commands supplied by a project pack.

## Fix

Load project packs consistently for CLI commands, propagate the active registry overlay into semantic-token analysis, and cover the behaviour through an internally maintained library/consumer fixture. The report retains the GeorgeTree example as real-world evidence without making the test suite depend on external source code.

## Validation

- `make prep-pr`
- `make rust-check`
- `cargo test -p tcl-cli --test cli`
- `cargo test -p tcl-spectcl --test spec_corpus`
- native semantic-token workspace-pack end-to-end test
- VS Code internal SpecTcl project-pack integration test
- VS Code GeorgeTree documentation proof
