### PR TITLE
[DO NOT MERGE] Measure the .vscode-test cache hit/miss delta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1642,3 +1642,6 @@ jobs:
             done < <(jq -r '.artifacts[] | [.id | tostring, .workflow_run.id | tostring] | @tsv' <<< "$payload")
             (( page++ ))
           done
+
+# (measurement scaffold — this branch exists only to measure the .vscode-test
+# cache hit/miss delta; not for merge)


### PR DESCRIPTION
## Result — measurement complete, scaffold closed unmerged

Same commit, same scaffold, attempts 1 and 2 of run 31822607316. Cache hit confirmed mechanically: the restore step took 5s where the miss took 0s, and the post-save step took 0s because the key already existed (the miss spent 6s saving).

| | attempt 1 (miss) | attempt 2 (hit) | Δ |
|---|---|---|---|
| `Cache VS Code test download` | 0s (miss) | 5s (restore) | |
| `Run extension tests` | **167s** | **152s** | **−15s** |
| `Post Cache VS Code test download` | 6s (save) | 0s | −6s |
| `test-ext` job | 224s | 198s | −26s |

**#1488 is a real but modest win: ~15s on the extension-test step.** Restoring VS Code costs 5s against a download of roughly 20s — GitHub runners fetch 120 MB quickly. It stays; 15s off the critical path at no risk is worth keeping.

**The hypothesis behind it was wrong, though.** I expected the download to be the bulk of a 275s step. It isn't. That step measured 275s / 199s / 167s across three separate cache-*miss* runs — roughly ±50% runner variance, which is what the earlier apparent "improvement" actually was. Only the same-commit hit/miss pair isolates the cache, and it says 15s.

**What's still unexplained:** ~150s of that step, against suites that report `14 passing (3s)`. Remaining suspects are the two Electron/xvfb hosts starting sequentially and the xtask drift gates inside `make test-ext`.

Already excluded by experiment: `ci`-profile opt-level on `tcl-lsp-server` (44s → 33s ceiling, and a slower shipped server), and `zed-query-check` (10s cold, 0s warm).

Closing unmerged and deleting the branch — this existed only to produce the table above.