### PR TITLE
Fix Spec Studio asset provenance, formatting, and editor defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4513,6 +4513,7 @@ dependencies = [
  "tcl-core-types",
  "tcl-dialect",
  "tcl-lexer",
+ "tcl-lsp-core",
  "tcl-registry",
  "tcl-spectcl",
  "tcl-syntax",

--- a/rust/tcl-lsp-server-wasm/worker.js
+++ b/rust/tcl-lsp-server-wasm/worker.js
@@ -47,9 +47,15 @@ const backlog = [];
 
 async function init() {
   // Everything is local — the worker makes no network request at runtime.
-  const baseUrl = new URL(".", self.location.href).href;
-  importScripts(baseUrl + "tcl_lsp_server_wasm.js");
-  await wasm_bindgen(baseUrl + "tcl_lsp_server_wasm_bg.wasm");
+  const workerUrl = new URL(self.location.href);
+  const assetVersion = workerUrl.searchParams.get("v");
+  const sibling = (name) => {
+    const url = new URL(name, workerUrl);
+    if (assetVersion) url.searchParams.set("v", assetVersion);
+    return url.href;
+  };
+  importScripts(sibling("tcl_lsp_server_wasm.js"));
+  await wasm_bindgen(sibling("tcl_lsp_server_wasm_bg.wasm"));
 
   // Bind postMessage: the server calls it with `this` unbound.
   server = new wasm_bindgen.LspWorker((text) => self.postMessage(text));

--- a/rust/tcl-spec-studio-wasm/Cargo.lock
+++ b/rust/tcl-spec-studio-wasm/Cargo.lock
@@ -146,6 +146,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +291,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -361,6 +368,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tcl-bigip"
+version = "0.1.0"
+dependencies = [
+ "indexmap",
+ "ipnet",
+ "regex",
+ "serde_json",
+ "sha2",
+ "tcl-dialect",
+ "tcl-irules",
+ "tcl-lexer",
+ "tcl-registry",
+ "tcl-syntax",
+ "thiserror",
+]
+
+[[package]]
 name = "tcl-bytecode"
 version = "0.1.0"
 dependencies = [
@@ -433,12 +457,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "tcl-irules"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tcl-compiler",
+ "tcl-core-types",
+ "tcl-dialect",
+ "tcl-lexer",
+ "tcl-registry",
+ "tcl-syntax",
+]
+
+[[package]]
 name = "tcl-lexer"
 version = "0.1.0"
 dependencies = [
  "tcl-core-types",
  "tcl-dialect",
  "thiserror",
+]
+
+[[package]]
+name = "tcl-lsp-core"
+version = "0.1.0"
+dependencies = [
+ "regex",
+ "rustc-hash",
+ "serde_json",
+ "tcl-bigip",
+ "tcl-compiler",
+ "tcl-core-types",
+ "tcl-dialect",
+ "tcl-irules",
+ "tcl-lexer",
+ "tcl-registry",
+ "tcl-syntax",
 ]
 
 [[package]]
@@ -493,6 +548,7 @@ dependencies = [
  "tcl-compiler",
  "tcl-dialect",
  "tcl-lexer",
+ "tcl-lsp-core",
  "tcl-registry",
  "tcl-spectcl",
  "tcl-syntax",

--- a/rust/tcl-spec-studio-wasm/build-wasm.sh
+++ b/rust/tcl-spec-studio-wasm/build-wasm.sh
@@ -60,10 +60,13 @@ lspdist="$here/../tcl-lsp-server-wasm/dist"
 dist="$here/dist"
 out="$(mktemp -d)"
 trap 'rm -rf "$out"' EXIT
+version="$(git -C "$here" describe --tags --always --dirty)"
 # Rebuilt from scratch each time: a stale `assets/` or `lsp/` left behind by an
 # older layout would be deployed alongside the new one and served to somebody.
 rm -rf "$dist"
 mkdir -p "$dist/assets" "$dist/lsp"
+
+echo "==> Spec Studio $version"
 
 echo "==> cargo build --target wasm32-unknown-unknown --release"
 ( cd "$here" && cargo build --target wasm32-unknown-unknown --release )
@@ -147,14 +150,44 @@ echo "==> assembling dist/index.html"
 python3 - \
     "$web/studio.html" "$web/src/studio.css" "$web/dist/studio.js" \
     "$out/tcl_spec_studio_wasm.js" "$out/tcl_spec_studio_wasm_bg.wasm" \
-    "$dist/index.html" "$assets" <<'PY'
-import base64, os, sys
-tmpl_path, css_path, js_path, glue_path, wasm_path, out_path, assets_dir = sys.argv[1:8]
-tmpl = open(tmpl_path, encoding="utf-8").read()
-css = open(css_path, encoding="utf-8").read()
-js = open(js_path, encoding="utf-8").read()
-glue = open(glue_path, encoding="utf-8").read()
-b64 = base64.b64encode(open(wasm_path, "rb").read()).decode("ascii")
+    "$dist/index.html" "$assets" "$dist/assets/monaco-host.js" \
+    "$dist/assets/monaco-host.css" "$dist/lsp/worker.js" \
+    "$dist/lsp/tcl_lsp_server_wasm.js" "$dist/lsp/tcl_lsp_server_wasm_bg.wasm" \
+    "$version" <<'PY'
+import base64, hashlib, json, os, sys
+(
+    tmpl_path, css_path, js_path, glue_path, wasm_path, out_path, assets_dir,
+    editor_js_path, editor_css_path, lsp_worker_path, lsp_glue_path,
+    lsp_wasm_path, version,
+) = sys.argv[1:14]
+
+def read_bytes(path):
+    with open(path, "rb") as stream:
+        return stream.read()
+
+def asset(name, payload):
+    return {
+        "name": name,
+        "version": version,
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "bytes": len(payload),
+    }
+
+tmpl_bytes = read_bytes(tmpl_path)
+css_bytes = read_bytes(css_path)
+js_bytes = read_bytes(js_path)
+glue_bytes = read_bytes(glue_path)
+wasm_bytes = read_bytes(wasm_path)
+editor_js_bytes = read_bytes(editor_js_path)
+editor_css_bytes = read_bytes(editor_css_path)
+lsp_worker_bytes = read_bytes(lsp_worker_path)
+lsp_glue_bytes = read_bytes(lsp_glue_path)
+lsp_wasm_bytes = read_bytes(lsp_wasm_path)
+tmpl = tmpl_bytes.decode("utf-8")
+css = css_bytes.decode("utf-8")
+js = js_bytes.decode("utf-8")
+glue = glue_bytes.decode("utf-8")
+b64 = base64.b64encode(wasm_bytes).decode("ascii")
 payload = (
     '<script id="studio-wasm" type="application/octet-stream">' + b64 + "</script>\n"
     "<script>" + glue + "</script>"
@@ -165,6 +198,27 @@ LOGOS = {
     "__LOGO_TCL_LSP__": "logo-tcl-lsp.svg",
     "__LOGO_TCL_LSP_DARK__": "logo-tcl-lsp-dark.svg",
 }
+logo_bytes = {
+    token: read_bytes(os.path.join(assets_dir, name)) for token, name in LOGOS.items()
+}
+build_info = {
+    "version": version,
+    "assets": [
+        asset("html-shell", tmpl_bytes),
+        asset("studio-style", css_bytes),
+        asset("studio-controller", js_bytes),
+        asset("studio-wasm-glue", glue_bytes),
+        asset("studio-wasm", wasm_bytes),
+        asset("logo-light", logo_bytes["__LOGO_TCL_LSP__"]),
+        asset("logo-dark", logo_bytes["__LOGO_TCL_LSP_DARK__"]),
+        asset("editor-controller", editor_js_bytes),
+        asset("editor-style", editor_css_bytes),
+        asset("lsp-worker", lsp_worker_bytes),
+        asset("lsp-wasm-glue", lsp_glue_bytes),
+        asset("lsp-wasm", lsp_wasm_bytes),
+    ],
+}
+build_json = json.dumps(build_info, separators=(",", ":")).replace("<", "\\u003c")
 # The narrowest policy the page can actually run under, enumerated rather than
 # relaxed wholesale. Everything is `'self'` — the editor chunk, its stylesheet,
 # the worker, and the fetches that pull the server's wasm — with exactly two
@@ -201,12 +255,18 @@ CSP = (
 # payload are safe.
 tmpl = tmpl.replace("__CSP__", CSP)
 tmpl = tmpl.replace("__STYLES__", "<style>" + css + "</style>")
+tmpl = tmpl.replace(
+    "__BUILD_INFO__",
+    '<script id="studio-build" type="application/json">' + build_json + "</script>",
+)
 tmpl = tmpl.replace("__WASM_PAYLOAD__", payload)
 tmpl = tmpl.replace("__STUDIO_JS__", "<script>" + js + "</script>")
-for tok, name in LOGOS.items():
-    mark = open(os.path.join(assets_dir, name), encoding="utf-8").read()
-    tmpl = tmpl.replace(tok, mark)
-for tok in ("__CSP__", "__STYLES__", "__WASM_PAYLOAD__", "__STUDIO_JS__", *LOGOS):
+for tok in LOGOS:
+    tmpl = tmpl.replace(tok, logo_bytes[tok].decode("utf-8"))
+for tok in (
+    "__CSP__", "__STYLES__", "__BUILD_INFO__", "__WASM_PAYLOAD__",
+    "__STUDIO_JS__", *LOGOS,
+):
     if tok in tmpl:
         raise SystemExit(f"placeholder {tok} substitution failed")
 open(out_path, "w", encoding="utf-8").write(tmpl)

--- a/rust/tcl-spec-studio-wasm/src/lib.rs
+++ b/rust/tcl-spec-studio-wasm/src/lib.rs
@@ -119,6 +119,14 @@ pub fn new_subcommand() -> String {
     ))
 }
 
+/// Format a `.tclspec` document with the shared Tcl formatter under the Tcl 9
+/// + `SpecTcl` profile used by the studio's Tcl editors.
+#[wasm_bindgen]
+#[must_use]
+pub fn format_pack(source: &str) -> String {
+    to_string(&json!({ "source": tcl_spec_studio::format_pack(source) }))
+}
+
 /// Render `draft_json` as a registry `.rs` source file, copyright banner
 /// included.
 ///

--- a/rust/tcl-spec-studio/Cargo.toml
+++ b/rust/tcl-spec-studio/Cargo.toml
@@ -32,6 +32,7 @@ tcl-dialect = { path = "../tcl-dialect" }
 tcl-registry = { path = "../tcl-registry" }
 tcl-spectcl = { path = "../tcl-spectcl" }
 tcl-compiler = { path = "../tcl-compiler" }
+tcl-lsp-core = { path = "../tcl-lsp-core" }
 tcl-lexer = { path = "../tcl-lexer" }
 tcl-syntax = { path = "../tcl-syntax" }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/rust/tcl-spec-studio/src/lib.rs
+++ b/rust/tcl-spec-studio/src/lib.rs
@@ -41,6 +41,8 @@
 //! - [`render_rs`] — draft → registry `.rs` source, copyright banner included.
 //! - [`render_stub`] — draft → `# tcl-lsp: stub` block or `.tcl.stubs` file.
 //! - [`render_spectcl`] — draft → `.tclspec` spec pack, the loader's inverse.
+//! - [`format_pack`] — `.tclspec` source → the shared Tcl formatter under the
+//!   Tcl 9 + `SpecTcl` profile used by the studio's code editors.
 //! - [`infer`] — Tcl package sources → draft specs, via the real analyser.
 //! - [`versions`] — the same, over several *releases* of one package, so the
 //!   lifecycle fields carry a range the releases actually witness rather than
@@ -82,6 +84,7 @@ pub use tcl_spectcl::catalogue;
 pub use tcl_spectcl::loader as spectcl;
 
 use serde_json::{Value, json};
+use tcl_lsp_core::formatting::{FormatterConfig, format_tcl};
 use tcl_registry::cache::registry_for_dialect;
 
 /// Dialects the studio offers, as `(registry name, label)`.
@@ -90,6 +93,7 @@ use tcl_registry::cache::registry_for_dialect;
 /// primitive `DialectSet` bits — a profile is what decides which commands are
 /// actually visible.
 pub const BROWSABLE_DIALECTS: &[(&str, &str)] = &[
+    ("spectcl", "SpecTcl (Tcl 9.0)"),
     ("tcl9.1", "Tcl 9.1"),
     ("tcl9.0", "Tcl 9.0"),
     ("tcl8.6", "Tcl 8.6"),
@@ -100,6 +104,16 @@ pub const BROWSABLE_DIALECTS: &[(&str, &str)] = &[
     ("tk", "Tk"),
     ("expect", "Expect"),
 ];
+
+/// Format a `SpecTcl` pack with the same Tcl formatter used by the LSP and CLI.
+///
+/// A `.tclspec` file is Tcl 9 source extended by the `SpecTcl` command layer,
+/// so the formatter grammar and registry come from that resolved profile.
+#[must_use]
+pub fn format_pack(source: &str) -> String {
+    let config = FormatterConfig::for_dialect("spectcl");
+    format_tcl(source, &config, registry_for_dialect("spectcl"))
+}
 
 /// The command names available in `dialect`, sorted.
 #[must_use]
@@ -204,5 +218,14 @@ mod tests {
                 "{name} resolved to an empty registry"
             );
         }
+    }
+
+    #[test]
+    fn pack_formatting_uses_the_shared_spectcl_profile() {
+        let source = "speclib demo 1 {\ncommand foo {\nsynopsis {foo value}\narity 1\n}\n}";
+        assert_eq!(
+            format_pack(source),
+            "speclib demo 1 {\n    command foo {\n        synopsis {foo value}\n        arity 1\n    }\n}\n"
+        );
     }
 }

--- a/rust/tcl-spec-studio/tests/web_contract.rs
+++ b/rust/tcl-spec-studio/tests/web_contract.rs
@@ -1,0 +1,42 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Source-level guards for the browser shell's editor and provenance contracts.
+
+const HTML: &str = include_str!("../web/studio.html");
+const STUDIO_TS: &str = include_str!("../web/src/studio.ts");
+const MONACO_TS: &str = include_str!("../web/src/monacoHost.ts");
+const BUILD_INFO_TS: &str = include_str!("../web/src/buildInfo.ts");
+const BUILD_MJS: &str = include_str!("../web/build.mjs");
+
+#[test]
+fn every_code_pane_has_the_required_initial_language() {
+    for id in ["dslEditor", "testEditor", "stubEditor"] {
+        let marker = format!(
+            r#"id="{id}" data-language="tcl" data-dialect="spectcl" data-tcl-version="9.0""#
+        );
+        assert!(HTML.contains(&marker), "{id} has the wrong initial profile");
+    }
+    assert!(HTML.contains(r#"id="rsEditor" data-language="rust""#));
+    assert!(MONACO_TS.contains(r#"RUST_URI, "rust", null"#));
+    assert!(MONACO_TS.contains(r#"STUB_URI, TCL_LANGUAGE, "spectcl""#));
+    assert!(STUDIO_TS.contains(r#"dialect: "spectcl""#));
+}
+
+#[test]
+fn every_pack_source_update_passes_through_the_shared_formatter() {
+    assert!(STUDIO_TS.contains("wasm.format_pack(source)"));
+    assert!(STUDIO_TS.contains("state.pack.source = formatted"));
+    assert!(STUDIO_TS.contains("writeDsl(formatted)"));
+}
+
+#[test]
+fn build_version_mismatch_has_a_one_shot_cache_break() {
+    assert!(BUILD_MJS.contains(r#"["describe", "--tags", "--always", "--dirty"]"#));
+    assert!(HTML.contains("__BUILD_INFO__"));
+    assert!(BUILD_INFO_TS.contains("__SPEC_STUDIO_FRONTEND_VERSION__ !== info.version"));
+    assert!(BUILD_INFO_TS.contains("window.location.replace"));
+    assert!(BUILD_INFO_TS.contains("spec-studio-cache-bust"));
+    assert!(BUILD_INFO_TS.contains("console.table"));
+}

--- a/rust/tcl-spec-studio/tests/web_contract.rs
+++ b/rust/tcl-spec-studio/tests/web_contract.rs
@@ -28,7 +28,8 @@ fn every_code_pane_has_the_required_initial_language() {
 fn every_pack_source_update_passes_through_the_shared_formatter() {
     assert!(STUDIO_TS.contains("wasm.format_pack(source)"));
     assert!(STUDIO_TS.contains("state.pack.source = formatted"));
-    assert!(STUDIO_TS.contains("writeDsl(formatted)"));
+    assert!(STUDIO_TS.contains("writeDsl(formatted, opts.fromDsl)"));
+    assert!(STUDIO_TS.contains("mapSelectionThroughFormat(previous, source"));
 }
 
 #[test]

--- a/rust/tcl-spec-studio/web/build.mjs
+++ b/rust/tcl-spec-studio/web/build.mjs
@@ -21,6 +21,7 @@
 // Usage: `npm run build` (from rust/tcl-spec-studio/web).
 
 import * as esbuild from "esbuild";
+import { execFileSync } from "node:child_process";
 import { mkdirSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -29,6 +30,12 @@ const here = dirname(fileURLToPath(import.meta.url));
 const distDir = join(here, "dist");
 const assetsDir = join(distDir, "assets");
 const testsDir = join(distDir, "tests");
+const version =
+  process.env.TCL_LSP_GIT_DESCRIBE ??
+  execFileSync("git", ["describe", "--tags", "--always", "--dirty"], {
+    cwd: here,
+    encoding: "utf8",
+  }).trim();
 
 // `node build.mjs --tests` bundles the unit tests instead of the app: they
 // import the same TypeScript sources the browser bundle does, and node's test
@@ -44,6 +51,7 @@ if (process.argv.includes("--tests")) {
     format: "esm",
     platform: "node",
     target: "node22",
+    define: { __SPEC_STUDIO_FRONTEND_VERSION__: JSON.stringify(version) },
     // node's own modules stay external — bundling them would be nonsense.
     packages: "external",
     logLevel: "info",
@@ -85,6 +93,7 @@ await esbuild.build({
   minify: false,
   legalComments: "none",
   banner: { js: banner },
+  define: { __SPEC_STUDIO_FRONTEND_VERSION__: JSON.stringify(version) },
   logLevel: "info",
 });
 
@@ -101,10 +110,13 @@ await esbuild.build({
   minify: true,
   legalComments: "none",
   banner: { js: vendorBanner },
+  define: { __SPEC_STUDIO_FRONTEND_VERSION__: JSON.stringify(version) },
   // Monaco's CSS pulls in the codicon font; inlining it as a data URI is what
   // keeps the dist to files that can be copied anywhere without a loader.
   loader: { ".ttf": "dataurl", ".woff": "dataurl", ".woff2": "dataurl", ".svg": "dataurl" },
   logLevel: "info",
 });
 
-console.log("spec studio front-end: built dist/studio.js + dist/assets/monaco-host.{js,css}");
+console.log(
+  `spec studio front-end ${version}: built dist/studio.js + dist/assets/monaco-host.{js,css}`,
+);

--- a/rust/tcl-spec-studio/web/src/buildInfo.ts
+++ b/rust/tcl-spec-studio/web/src/buildInfo.ts
@@ -1,0 +1,105 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/** Injected into both front-end bundles from `git describe`. */
+declare const __SPEC_STUDIO_FRONTEND_VERSION__: string;
+
+export interface BuildAsset {
+  name: string;
+  version: string;
+  sha256: string;
+  bytes: number;
+}
+
+export interface BuildInfo {
+  version: string;
+  assets: BuildAsset[];
+}
+
+const CACHE_BUST_PARAM = "spec-studio-cache-bust";
+
+function reportFatal(message: string): void {
+  console.error(`Spec Studio: ${message}`);
+  const status = document.getElementById("status");
+  if (status) {
+    status.className = "status err";
+    status.textContent = message;
+  }
+}
+
+/** Reload an HTTP deployment once with a unique query after a version mismatch. */
+function cacheBreak(reason: string, expectedVersion: string): boolean {
+  const url = new URL(window.location.href);
+  if (!/^https?:$/.test(url.protocol)) {
+    reportFatal(`asset version mismatch in local file: ${reason}`);
+    return false;
+  }
+  if (url.searchParams.has(CACHE_BUST_PARAM)) {
+    reportFatal(`asset version mismatch after cache refresh: ${reason}`);
+    return false;
+  }
+
+  url.searchParams.set(CACHE_BUST_PARAM, `${expectedVersion}-${Date.now()}`);
+  console.warn(`Spec Studio: ${reason}; reloading with cache-busting URL ${url}`);
+  window.location.replace(url.toString());
+  return true;
+}
+
+/** Read and validate the embedded manifest before the WASM engine starts. */
+export function verifyBuildInfo(): BuildInfo | null {
+  const node = document.getElementById("studio-build");
+  if (!node?.textContent) {
+    reportFatal("embedded build manifest is missing");
+    return null;
+  }
+
+  let info: BuildInfo;
+  try {
+    info = JSON.parse(node.textContent) as BuildInfo;
+  } catch (error) {
+    reportFatal(`embedded build manifest is invalid: ${String(error)}`);
+    return null;
+  }
+
+  console.info(`Spec Studio ${info.version}`);
+  console.table(
+    info.assets.map((asset) => ({
+      asset: asset.name,
+      version: asset.version,
+      sha256: asset.sha256,
+      bytes: asset.bytes,
+    })),
+  );
+
+  const wrongVersion = info.assets.find((asset) => asset.version !== info.version);
+  if (wrongVersion) {
+    cacheBreak(
+      `${wrongVersion.name} is ${wrongVersion.version}, manifest is ${info.version}`,
+      info.version,
+    );
+    return null;
+  }
+  if (__SPEC_STUDIO_FRONTEND_VERSION__ !== info.version) {
+    cacheBreak(
+      `controller is ${__SPEC_STUDIO_FRONTEND_VERSION__}, assets are ${info.version}`,
+      info.version,
+    );
+    return null;
+  }
+  return info;
+}
+
+/** Compare a lazily-loaded bundle's own embedded version with the page. */
+export function verifyAssetVersion(info: BuildInfo, name: string, actual: string): boolean {
+  if (actual === info.version) return true;
+  cacheBreak(`${name} is ${actual}, page is ${info.version}`, info.version);
+  return false;
+}
+
+/** Give a deployed external asset a content-keyed URL so normal caches are safe. */
+export function assetUrl(info: BuildInfo, name: string, relative: string): string {
+  const asset = info.assets.find((candidate) => candidate.name === name);
+  const url = new URL(relative, document.baseURI);
+  url.searchParams.set("v", asset?.sha256 ?? info.version);
+  return url.href;
+}

--- a/rust/tcl-spec-studio/web/src/editorHost.ts
+++ b/rust/tcl-spec-studio/web/src/editorHost.ts
@@ -37,30 +37,44 @@ export interface SurfaceSpec {
   onChange: (text: string) => void;
 }
 
-/** Everything the host needs to stand both editors up. */
+/** One read-only rendered-code surface. */
+export interface OutputSurfaceSpec {
+  /** The element Monaco mounts into. */
+  container: HTMLElement;
+  /** The fallback `<pre>` whose current text seeds the model. */
+  fallback: HTMLElement;
+}
+
+/** Everything the host needs to stand all four editors up. */
 export interface EditorHostOptions {
-  /**
-   * Directory holding the language server worker's three files
-   * (`worker.js`, the wasm-bindgen glue, and the `.wasm`), relative to the
-   * page. Passed in rather than derived so a test can point at a stub.
-   */
-  workerDir: string;
+  /** Content-keyed URL for the language server worker. */
+  workerUrl: string;
+  /** Content-keyed URL for Monaco's emitted stylesheet. */
+  stylesheetUrl: string;
   /** The `.tclspec` pack document. Always opened as `spectcl`. */
   dsl: SurfaceSpec;
   /** The Tcl sample, opened under whichever dialect the studio has selected. */
   sample: SurfaceSpec;
+  /** Rendered Rust source, always a Rust model. */
+  rust: OutputSurfaceSpec;
+  /** Rendered Tcl stub, opened as Tcl 9 + SpecTcl. */
+  stub: OutputSurfaceSpec;
   /** The studio's current dialect, used as the sample's LSP language id. */
   dialect: string;
   /** Where boot progress and any degradation is announced. */
   report: Report;
 }
 
-/** A mounted pair of editors. */
+/** The four mounted code editors. */
 export interface EditorHost {
   /** Replace the pack document's text without re-entering `onChange`. */
   setDslText(text: string): void;
   /** Replace the sample's text without re-entering `onChange`. */
   setSampleText(text: string): void;
+  /** Replace the rendered Rust model. */
+  setRustText(text: string): void;
+  /** Replace the rendered Tcl-stub model. */
+  setStubText(text: string): void;
   /** Re-open the sample under a new dialect (its LSP language id). */
   setDialect(dialect: string): void;
   /** Re-measure after the containing tab became visible. */
@@ -71,5 +85,7 @@ export interface EditorHost {
 
 /** The lazily-imported chunk's shape — the one export `studio.ts` calls. */
 export interface MonacoHostModule {
+  /** `git describe` embedded in this lazy bundle. */
+  buildVersion: string;
   mountEditors(options: EditorHostOptions): Promise<EditorHost>;
 }

--- a/rust/tcl-spec-studio/web/src/lspClient.ts
+++ b/rust/tcl-spec-studio/web/src/lspClient.ts
@@ -302,16 +302,13 @@ export class LspClient {
 /**
  * Boot the language server worker and return a ready client.
  *
- * `workerDir` is the directory holding the worker's three build outputs. It is
- * a parameter rather than a constant because the studio's dist lays them out
- * under `lsp/` while a test serves a stub from wherever it likes.
+ * `workerUrl` is already resolved and content-keyed by the controller.
  */
-export async function startLspClient(workerDir: string): Promise<LspClient> {
-  const url = new URL(`${workerDir.replace(/\/$/, "")}/worker.js`, document.baseURI).href;
+export async function startLspClient(workerUrl: string): Promise<LspClient> {
   // A classic worker, deliberately: the server's glue is built with
   // wasm-bindgen's `--target no-modules`, so `new Worker(url)` needs no
   // `{ type: "module" }` and works in every browser the studio supports.
-  return LspClient.start(() => new Worker(url));
+  return LspClient.start(() => new Worker(workerUrl));
 }
 
 /**

--- a/rust/tcl-spec-studio/web/src/monacoHost.ts
+++ b/rust/tcl-spec-studio/web/src/monacoHost.ts
@@ -33,6 +33,7 @@
 // it in TypeScript.
 
 import * as monaco from "monaco-editor/editor/editor.api.js";
+import "monaco-editor/languages/definitions/rust/register.js";
 import type {
   CompletionItem as LspCompletionItem,
   CompletionList as LspCompletionList,
@@ -41,16 +42,27 @@ import type {
   TextEdit as LspTextEdit,
 } from "vscode-languageserver-protocol";
 
-import type { EditorHost, EditorHostOptions, SurfaceSpec } from "./editorHost.js";
+import type {
+  EditorHost,
+  EditorHostOptions,
+  OutputSurfaceSpec,
+  SurfaceSpec,
+} from "./editorHost.js";
 import { LspClient, startLspClient } from "./lspClient.js";
 
 /** The Monaco language id both surfaces' models are registered under. */
 const SPECTCL_LANGUAGE = "spectcl";
 const TCL_LANGUAGE = "tcl";
 
+/** Build provenance checked by the controller before this chunk is mounted. */
+declare const __SPEC_STUDIO_FRONTEND_VERSION__: string;
+export const buildVersion = __SPEC_STUDIO_FRONTEND_VERSION__;
+
 /** In-memory document URIs. Nothing resolves them — they are identities. */
 const DSL_URI = "inmemory://studio/pack.tclspec";
 const SAMPLE_URI = "inmemory://studio/sample.tcl";
+const RUST_URI = "inmemory://studio/command.rs";
+const STUB_URI = "inmemory://studio/stubs.tcl";
 
 /** How long keystrokes settle before the change is pushed on. */
 const SETTLE_MS = 120;
@@ -334,8 +346,7 @@ function currentTheme(): string {
  * pair together wherever the dist is deployed — a subdirectory on Pages, a
  * local `python3 -m http.server`, anywhere.
  */
-async function loadStylesheet(): Promise<void> {
-  const href = new URL("./monaco-host.css", import.meta.url).href;
+async function loadStylesheet(href: string): Promise<void> {
   if (document.querySelector(`link[href="${href}"]`)) return;
   await new Promise<void>((resolve) => {
     const link = document.createElement("link");
@@ -438,6 +449,59 @@ class Surface {
   }
 }
 
+/** A read-only Monaco surface used by both generated-code panes. */
+class OutputSurface {
+  readonly editor: monaco.editor.IStandaloneCodeEditor;
+
+  private readonly model: monaco.editor.ITextModel;
+
+  private readonly client: LspClient | null;
+
+  private readonly uri: string;
+
+  constructor(
+    spec: OutputSurfaceSpec,
+    uri: string,
+    language: string,
+    languageId: string | null,
+    client: LspClient | null,
+  ) {
+    this.client = languageId ? client : null;
+    this.uri = uri;
+    spec.container.classList.add("monaco-mounted");
+    this.model = monaco.editor.createModel(
+      spec.fallback.textContent ?? "",
+      language,
+      monaco.Uri.parse(uri),
+    );
+    this.editor = monaco.editor.create(spec.container, {
+      ...editorOptions(),
+      model: this.model,
+      readOnly: true,
+      domReadOnly: true,
+    });
+    if (languageId) this.client?.openDocument(uri, languageId, this.model.getValue());
+  }
+
+  setText(text: string): void {
+    if (this.model.getValue() === text) return;
+    this.model.setValue(text);
+    this.client?.changeDocument(this.uri, text);
+  }
+
+  layout(): void {
+    this.editor.layout();
+  }
+
+  setDiagnostics(items: LspDiagnostic[]): void {
+    monaco.editor.setModelMarkers(this.model, "tcl-lsp", toMarkers(items));
+  }
+
+  get documentUri(): string {
+    return this.uri;
+  }
+}
+
 /**
  * Stand both editors up, with the language server behind them when it boots.
  *
@@ -447,7 +511,7 @@ class Surface {
  * which means this module never loaded — takes the page back to the textarea.
  */
 export async function mountEditors(options: EditorHostOptions): Promise<EditorHost> {
-  await loadStylesheet();
+  await loadStylesheet(options.stylesheetUrl);
   registerLanguages();
   monaco.editor.setTheme(currentTheme());
   window
@@ -457,7 +521,7 @@ export async function mountEditors(options: EditorHostOptions): Promise<EditorHo
   let client: LspClient | null = null;
   try {
     options.report("starting the language server…");
-    client = await startLspClient(options.workerDir);
+    client = await startLspClient(options.workerUrl);
     registerProviders(client);
     options.report("the Tcl language server is running in this page", "ok");
   } catch (e) {
@@ -468,22 +532,29 @@ export async function mountEditors(options: EditorHostOptions): Promise<EditorHo
     );
   }
 
-  const dsl = new Surface(options.dsl, DSL_URI, SPECTCL_LANGUAGE, "tclspec", client);
+  const dsl = new Surface(options.dsl, DSL_URI, SPECTCL_LANGUAGE, "spectcl", client);
   const sample = new Surface(options.sample, SAMPLE_URI, TCL_LANGUAGE, options.dialect, client);
+  const rust = new OutputSurface(options.rust, RUST_URI, "rust", null, client);
+  const stub = new OutputSurface(options.stub, STUB_URI, TCL_LANGUAGE, "spectcl", client);
 
   client?.onDiagnostics((uri, items) => {
     if (uri === dsl.documentUri) dsl.setDiagnostics(items);
     else if (uri === sample.documentUri) sample.setDiagnostics(items);
+    else if (uri === stub.documentUri) stub.setDiagnostics(items);
   });
 
   const ready = client !== null;
   return {
     setDslText: (text) => dsl.setText(text),
     setSampleText: (text) => sample.setText(text),
+    setRustText: (text) => rust.setText(text),
+    setStubText: (text) => stub.setText(text),
     setDialect: (dialect) => sample.setLanguageId(dialect),
     layout: () => {
       dsl.layout();
       sample.layout();
+      rust.layout();
+      stub.layout();
     },
     get lspReady() {
       return ready;

--- a/rust/tcl-spec-studio/web/src/studio.css
+++ b/rust/tcl-spec-studio/web/src/studio.css
@@ -462,6 +462,7 @@ pre.testview { white-space: pre-wrap; overflow-wrap: anywhere; margin-bottom: 1r
   border-radius: 10px; overflow: hidden;
 }
 .editorhost.short { height: 14rem; }
+.editorhost.output { height: 32rem; }
 .editorhost.monaco-mounted { display: block; }
 /* Monaco paints its own background; keep the rounded corner from clipping the
    scrollbar overlay it renders on top. */

--- a/rust/tcl-spec-studio/web/src/studio.ts
+++ b/rust/tcl-spec-studio/web/src/studio.ts
@@ -35,6 +35,7 @@ import {
   setStatus,
   type Child,
 } from "./dom.js";
+import { assetUrl, verifyAssetVersion, verifyBuildInfo, type BuildInfo } from "./buildInfo.js";
 import { renderDslHighlight, renderDslMarkers, syncDslScroll } from "./dslEditor.js";
 import { asRecord, asString, makeEditors, STRUCTURAL_KINDS, type Editor } from "./editors.js";
 import type { EditorHost, MonacoHostModule } from "./editorHost.js";
@@ -45,6 +46,7 @@ import type {
   DialectEntry,
   Draft,
   FieldSchema,
+  Formatted,
   ImportResult,
   IndexEntry,
   InferredCommand,
@@ -179,6 +181,8 @@ let formDirty = false;
 let editorHost: EditorHost | null = null;
 /** Set while the chunk is loading, so two tab clicks do not mount twice. */
 let editorMounting: Promise<void> | null = null;
+/** Provenance for this assembled page and every external asset it names. */
+let activeBuildInfo: BuildInfo;
 
 /* Drafts ---------------------------------------------------------------- */
 
@@ -425,23 +429,23 @@ function unwrap<T extends { error?: string }>(json: string): T {
 /**
  * Adopt `source` as the pack document and re-render every projection of it.
  *
- * `fromDsl` says the edit came from the DSL textarea, which is the one case
- * where the textarea must *not* be written back to — doing so would move the
- * author's caret to the end of the file on every keystroke.
+ * `fromDsl` preserves the active editor's selection while the formatter's
+ * full-document replacement is written back.
  */
 function setPackSource(
   source: string,
   opts: { fromDsl?: boolean; refreshForm?: boolean } = {},
 ): void {
-  state.pack.source = source;
+  const formatted = unwrap<Formatted>(wasm.format_pack(source)).source;
+  state.pack.source = formatted;
   try {
-    state.pack.view = unwrap<PackStoreView>(wasm.pack_load(source, state.dialect));
+    state.pack.view = unwrap<PackStoreView>(wasm.pack_load(formatted, state.dialect));
     setStatus("dslStatus", "");
   } catch (e) {
     state.pack.view = null;
     setStatus("dslStatus", `could not read the pack: ${message(e)}`, "err");
   }
-  if (!opts.fromDsl) writeDsl(source);
+  writeDsl(formatted, opts.fromDsl);
 
   // A command the document no longer declares cannot stay open.
   const names = new Set((state.pack.view?.commands ?? []).map((c) => c.name));
@@ -459,7 +463,7 @@ function setPackSource(
   // Repainting it anyway would cost a full re-tokenise per keystroke for
   // something nobody can see.
   if (!usingMonaco()) {
-    renderDslHighlight(wasm, source);
+    renderDslHighlight(wasm, formatted);
     renderDslMarkers(state.pack.view?.notices ?? []);
   }
   if (opts.refreshForm && state.pack.open) refreshOpenCommand();
@@ -912,6 +916,7 @@ function renderOutputs(): void {
     if (rs.error) throw new Error(rs.error);
     rendered.rs = rs;
     byId("rsOut").firstElementChild!.textContent = rs.source;
+    editorHost?.setRustText(rs.source);
     byId("rsPath").textContent = rs.path;
 
     const mode = byId<HTMLSelectElement>("stubMode").value;
@@ -921,6 +926,7 @@ function renderOutputs(): void {
     if (stub.error) throw new Error(stub.error);
     rendered.stub = stub;
     byId("stubOut").firstElementChild!.textContent = stub.source;
+    editorHost?.setStubText(stub.source);
     byId("stubPath").textContent = stub.path;
   } catch (e) {
     setStatus("status", `render failed: ${e instanceof Error ? e.message : String(e)}`, "err");
@@ -1746,10 +1752,12 @@ async function mountEditorHost(): Promise<void> {
   };
   editorMounting = (async () => {
     report("loading the editor…");
-    const specifier = new URL(EDITOR_CHUNK, document.baseURI).href;
+    const specifier = assetUrl(activeBuildInfo, "editor-controller", EDITOR_CHUNK);
     const chunk = (await import(specifier)) as MonacoHostModule;
+    if (!verifyAssetVersion(activeBuildInfo, "editor controller", chunk.buildVersion)) return;
     editorHost = await chunk.mountEditors({
-      workerDir: LSP_WORKER_DIR,
+      workerUrl: assetUrl(activeBuildInfo, "lsp-worker", `${LSP_WORKER_DIR}/worker.js`),
+      stylesheetUrl: assetUrl(activeBuildInfo, "editor-style", "assets/monaco-host.css"),
       dialect: state.dialect,
       report,
       dsl: {
@@ -1762,10 +1770,20 @@ async function mountEditorHost(): Promise<void> {
         textarea: byId<HTMLTextAreaElement>("testText"),
         onChange: () => runTest(),
       },
+      rust: {
+        container: byId("rsEditor"),
+        fallback: byId("rsOut"),
+      },
+      stub: {
+        container: byId("stubEditor"),
+        fallback: byId("stubOut"),
+      },
     });
     // The overlay was the text surface; now it is a hidden fallback that must
     // not keep painting over the editor that replaced it.
     byId("dslFallback").hidden = true;
+    byId("rsOut").hidden = true;
+    byId("stubOut").hidden = true;
   })();
   try {
     await editorMounting;
@@ -1782,8 +1800,14 @@ async function mountEditorHost(): Promise<void> {
 }
 
 /** Push text into whichever surface is live, without echoing a change back. */
-function writeDsl(source: string): void {
-  byId<HTMLTextAreaElement>("dslText").value = source;
+function writeDsl(source: string, preserveSelection = false): void {
+  const textarea = byId<HTMLTextAreaElement>("dslText");
+  const start = textarea.selectionStart;
+  const end = textarea.selectionEnd;
+  textarea.value = source;
+  if (preserveSelection && !usingMonaco()) {
+    textarea.setSelectionRange(Math.min(start, source.length), Math.min(end, source.length));
+  }
   editorHost?.setDslText(source);
 }
 
@@ -1802,7 +1826,7 @@ function selectTab(name: Tab): void {
     byId(`tab-${tab}`).setAttribute("aria-selected", on ? "true" : "false");
     byId(`pane-${tab}`).hidden = !on;
   }
-  if (name === "dsl" || name === "test") {
+  if (name === "dsl" || name === "test" || name === "rs" || name === "stub") {
     void mountEditorHost().then(() => {
       // Monaco measures the container it was created in; a container inside a
       // `hidden` pane measures zero, so every reveal needs a re-layout.
@@ -2081,6 +2105,9 @@ async function restoreSession(): Promise<void> {
 }
 
 function boot(): void {
+  const buildInfo = verifyBuildInfo();
+  if (!buildInfo) return;
+  activeBuildInfo = buildInfo;
   const payload = byId("studio-wasm").textContent?.trim() ?? "";
   const binary = Uint8Array.from(atob(payload), (c) => c.charCodeAt(0));
 
@@ -2096,7 +2123,7 @@ function boot(): void {
         schema,
         defaultCommand: JSON.parse(wasm.new_command()) as Draft,
         defaultSubcommand: JSON.parse(wasm.new_subcommand()) as Draft,
-        dialect: "tcl9.0",
+        dialect: "spectcl",
         index: [],
         draft: null,
         files: [],
@@ -2137,7 +2164,7 @@ function boot(): void {
       );
 
       byId("ver").textContent =
-        `${schema.command.length} spec fields · ${state.index.length} commands`;
+        `${buildInfo.version} · ${schema.command.length} spec fields · ${state.index.length} commands`;
       setStatus("status", "");
       void restoreSession();
     },

--- a/rust/tcl-spec-studio/web/src/studio.ts
+++ b/rust/tcl-spec-studio/web/src/studio.ts
@@ -41,6 +41,7 @@ import { asRecord, asString, makeEditors, STRUCTURAL_KINDS, type Editor } from "
 import type { EditorHost, MonacoHostModule } from "./editorHost.js";
 import * as idb from "./idb.js";
 import { initReleasesPanel } from "./importReleases.js";
+import { mapSelectionThroughFormat } from "./textSelection.js";
 import type {
   CommandIndex,
   DialectEntry,
@@ -1802,11 +1803,14 @@ async function mountEditorHost(): Promise<void> {
 /** Push text into whichever surface is live, without echoing a change back. */
 function writeDsl(source: string, preserveSelection = false): void {
   const textarea = byId<HTMLTextAreaElement>("dslText");
+  const previous = textarea.value;
   const start = textarea.selectionStart;
   const end = textarea.selectionEnd;
+  const direction = textarea.selectionDirection ?? "none";
   textarea.value = source;
   if (preserveSelection && !usingMonaco()) {
-    textarea.setSelectionRange(Math.min(start, source.length), Math.min(end, source.length));
+    const mapped = mapSelectionThroughFormat(previous, source, { start, end });
+    textarea.setSelectionRange(mapped.start, mapped.end, direction);
   }
   editorHost?.setDslText(source);
 }

--- a/rust/tcl-spec-studio/web/src/textSelection.ts
+++ b/rust/tcl-spec-studio/web/src/textSelection.ts
@@ -1,0 +1,112 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/** A textarea selection expressed as UTF-16 offsets. */
+export interface TextSelection {
+  start: number;
+  end: number;
+}
+
+const isWhitespace = (character: string): boolean => /\s/u.test(character);
+
+/** The document with formatter-controlled whitespace removed. */
+function significantText(text: string): string {
+  return text.replace(/\s/gu, "");
+}
+
+/** Offset immediately after the first `count` non-whitespace code units. */
+function afterSignificant(text: string, count: number): number {
+  if (count === 0) return 0;
+  let seen = 0;
+  for (let at = 0; at < text.length; at += 1) {
+    if (!isWhitespace(text[at])) {
+      seen += 1;
+      if (seen === count) return at + 1;
+    }
+  }
+  return text.length;
+}
+
+/** Offset immediately before the non-whitespace code unit after `count`. */
+function beforeNextSignificant(text: string, count: number): number {
+  let seen = 0;
+  for (let at = 0; at < text.length; at += 1) {
+    if (isWhitespace(text[at])) continue;
+    if (seen === count) return at;
+    seen += 1;
+  }
+  return text.length;
+}
+
+/**
+ * Keep an offset attached to the same content while a formatter changes whitespace.
+ *
+ * Formatting a line can insert indentation before the caret. Numeric offsets do
+ * not describe that intent, so map through the surrounding pair of significant
+ * characters instead. Within a whitespace run, retain affinity to the nearer
+ * edge so both "after the token" and "before the next token" remain natural.
+ */
+function throughWhitespace(source: string, formatted: string, offset: number): number {
+  const bounded = Math.max(0, Math.min(offset, source.length));
+  let significantBefore = 0;
+  for (let at = 0; at < bounded; at += 1) {
+    if (!isWhitespace(source[at])) significantBefore += 1;
+  }
+
+  const sourceStart = afterSignificant(source, significantBefore);
+  const sourceEnd = beforeNextSignificant(source, significantBefore);
+  const targetStart = afterSignificant(formatted, significantBefore);
+  const targetEnd = beforeNextSignificant(formatted, significantBefore);
+
+  if (bounded <= sourceStart) return targetStart;
+  if (bounded >= sourceEnd) return targetEnd;
+
+  const fromStart = bounded - sourceStart;
+  const fromEnd = sourceEnd - bounded;
+  return fromStart <= fromEnd
+    ? Math.min(targetStart + fromStart, targetEnd)
+    : Math.max(targetEnd - fromEnd, targetStart);
+}
+
+/** Conservative mapping for an unexpected formatter change beyond whitespace. */
+function throughChangedText(source: string, formatted: string, offset: number): number {
+  const bounded = Math.max(0, Math.min(offset, source.length));
+  let prefix = 0;
+  while (
+    prefix < source.length &&
+    prefix < formatted.length &&
+    source[prefix] === formatted[prefix]
+  ) {
+    prefix += 1;
+  }
+
+  let suffix = 0;
+  while (
+    suffix < source.length - prefix &&
+    suffix < formatted.length - prefix &&
+    source[source.length - suffix - 1] === formatted[formatted.length - suffix - 1]
+  ) {
+    suffix += 1;
+  }
+
+  if (bounded <= prefix) return bounded;
+  if (bounded >= source.length - suffix) {
+    return formatted.length - (source.length - bounded);
+  }
+  return Math.min(prefix + (bounded - prefix), formatted.length - suffix);
+}
+
+/** Map both ends of a selection through a full-document formatter replacement. */
+export function mapSelectionThroughFormat(
+  source: string,
+  formatted: string,
+  selection: TextSelection,
+): TextSelection {
+  if (source === formatted) return selection;
+  const map =
+    significantText(source) === significantText(formatted)
+      ? (offset: number): number => throughWhitespace(source, formatted, offset)
+      : (offset: number): number => throughChangedText(source, formatted, offset);
+  return { start: map(selection.start), end: map(selection.end) };
+}

--- a/rust/tcl-spec-studio/web/src/types.ts
+++ b/rust/tcl-spec-studio/web/src/types.ts
@@ -105,6 +105,12 @@ export interface Rendered {
   error?: string;
 }
 
+/** Source returned by a pure formatter operation. */
+export interface Formatted {
+  source: string;
+  error?: string;
+}
+
 /** One inferred command from an imported package, with its evidence. */
 export interface InferredCommand {
   name: string;
@@ -362,6 +368,7 @@ export interface StudioWasm {
   load_command(name: string, dialect: string): string;
   new_command(): string;
   new_subcommand(): string;
+  format_pack(source: string): string;
   render_rs(draftJson: string, pack: string): string;
   render_stub(draftsJson: string, mode: string, dialect: string): string;
   import_package(filesJson: string, dialect: string): string;

--- a/rust/tcl-spec-studio/web/studio.html
+++ b/rust/tcl-spec-studio/web/studio.html
@@ -3,7 +3,7 @@
      registry, compiled to one self-contained HTML file.
 
      Substitution tokens, filled in by rust/tcl-spec-studio-wasm/build-wasm.sh:
-     __CSP__, __STYLES__, __WASM_PAYLOAD__, __STUDIO_JS__, and the project marks
+     __CSP__, __STYLES__, __BUILD_INFO__, __WASM_PAYLOAD__, __STUDIO_JS__, and the project marks
      __LOGO_TCL_LSP__ / __LOGO_TCL_LSP_DARK__, each replaced with the contents of
      the matching `assets/logo-*.svg` so the mark inlines as <svg> — the same
      pattern the BIG-IP report builder page uses. -->
@@ -123,7 +123,7 @@ __STYLES__
               <button type="button" class="ghost" id="dslCanonical" title="Re-render the whole document from its commands — this discards your comments and layout">Re-render canonically</button>
               <span class="path" id="dslPath"></span>
             </div>
-            <div class="editorhost" id="dslEditor"></div>
+            <div class="editorhost" id="dslEditor" data-language="tcl" data-dialect="spectcl" data-tcl-version="9.0"></div>
             <div class="dsl-wrap" id="dslFallback">
               <pre class="dsl-hl" id="dslHl" aria-hidden="true"></pre>
               <div class="dsl-markers" id="dslMarkers" aria-hidden="true"></div>
@@ -153,7 +153,7 @@ __STYLES__
                  model: the document is opened under whichever dialect the
                  selector at the top of the page names, so the server analyses
                  it exactly as an editor configured for that dialect would. -->
-            <div class="editorhost short" id="testEditor"></div>
+            <div class="editorhost short" id="testEditor" data-language="tcl" data-dialect="spectcl" data-tcl-version="9.0"></div>
             <textarea id="testText" class="dsl" rows="10" spellcheck="false" autocapitalize="off" autocorrect="off" aria-label="Tcl to test the pack with"></textarea>
             <div class="status" id="testStatus"></div>
             <div class="testsplit">
@@ -183,6 +183,7 @@ __STYLES__
               </label>
               <span class="path" id="rsPath"></span>
             </div>
+            <div class="editorhost output" id="rsEditor" data-language="rust"></div>
             <pre id="rsOut"><code>—</code></pre>
           </div>
         </section>
@@ -202,6 +203,7 @@ __STYLES__
               </label>
               <span class="path" id="stubPath"></span>
             </div>
+            <div class="editorhost output" id="stubEditor" data-language="tcl" data-dialect="spectcl" data-tcl-version="9.0"></div>
             <pre id="stubOut"><code>—</code></pre>
           </div>
         </section>
@@ -339,6 +341,7 @@ __STYLES__
   </footer>
 </div>
 
+__BUILD_INFO__
 __WASM_PAYLOAD__
 __STUDIO_JS__
 </body>

--- a/rust/tcl-spec-studio/web/test/units.test.ts
+++ b/rust/tcl-spec-studio/web/test/units.test.ts
@@ -49,6 +49,47 @@ import {
   versionFromFileName,
   type Release,
 } from "../src/releases.js";
+import { mapSelectionThroughFormat } from "../src/textSelection.js";
+
+describe("mapSelectionThroughFormat", () => {
+  it("keeps a caret after its text when formatting inserts indentation", () => {
+    const source = "command foo {\nsummary bar\n}";
+    const formatted = "command foo {\n    summary bar\n}";
+    const caret = source.indexOf("bar") + "bar".length;
+
+    assert.deepEqual(mapSelectionThroughFormat(source, formatted, { start: caret, end: caret }), {
+      start: formatted.indexOf("bar") + "bar".length,
+      end: formatted.indexOf("bar") + "bar".length,
+    });
+  });
+
+  it("keeps the caret at the end of indentation before the next token", () => {
+    const source = "command foo {\n summary bar\n}";
+    const formatted = "command foo {\n    summary bar\n}";
+    const caret = source.indexOf("summary");
+
+    assert.deepEqual(mapSelectionThroughFormat(source, formatted, { start: caret, end: caret }), {
+      start: formatted.indexOf("summary"),
+      end: formatted.indexOf("summary"),
+    });
+  });
+
+  it("maps both ends of a selection through whitespace-only edits", () => {
+    const source = "command foo {\nsummary bar\n}";
+    const formatted = "command foo {\n    summary bar\n}";
+
+    assert.deepEqual(
+      mapSelectionThroughFormat(source, formatted, {
+        start: source.indexOf("summary"),
+        end: source.indexOf("bar") + "bar".length,
+      }),
+      {
+        start: formatted.indexOf("summary"),
+        end: formatted.indexOf("bar") + "bar".length,
+      },
+    );
+  });
+});
 
 /** A scripted reply. */
 interface Scripted {


### PR DESCRIPTION
## What changed

- embed the build's `git describe` value in the Spec Studio controller, lazy Monaco bundle, and assembled page
- emit and log a 12-asset provenance manifest with versions, SHA-256 identifiers, and byte sizes
- detect controller/lazy-editor version mismatches and perform a one-shot cache-busting reload; content-key external editor and LSP-worker URLs
- route every Pack DSL update through the shared Tcl formatter using the Tcl 9 + SpecTcl profile
- give Pack DSL, Test Tcl, and Tcl stub editors explicit Tcl 9 + SpecTcl defaults, while keeping the Rust export in a read-only Rust Monaco model
- retain the existing Monaco + real browser LSP integration and extend it to the rendered output panes

## Why

The page previously had no deployable build provenance, stale front-end assets could be mixed by intermediary caches, Pack DSL text could persist arbitrary layout, and the generated-code panes were not embedded editor models with explicit language profiles.

## Impact

Authors get consistently formatted `.tclspec` source, correct language behaviour across all code panes, and actionable console provenance when diagnosing a deployment. A detected front-end mismatch refreshes once with a cache-breaking URL and then reports a fatal mismatch instead of looping.

## Root cause

The self-contained shell and lazy assets were assembled without a shared revision contract, Pack DSL writes bypassed `tcl-lsp-core` formatting, and the Monaco host only owned the editable DSL and sample surfaces.

## Validation

- `make rust-check`
- `make prep-pr`
- `make spec-studio-wasm`
- `cargo test -p tcl-spec-studio`
- `cargo test --manifest-path rust/tcl-spec-studio-wasm/Cargo.toml`
- Spec Studio front-end typecheck, 29 unit tests, lint, and production bundle build
- assembled manifest verified to contain 12 same-version assets with individual SHA-256 identifiers

Closes #1498
Closes #1499
Closes #1500
