### PR TITLE
Add semantic owner resolution gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,31 @@ docs/             Design docs, KCS notes, references, perf reports.
 The native LSP end-to-end suite lives at
 `rust/tcl-lsp-server/tests/*_e2e.rs` (30 suites, run by `cargo test`).
 
+## Shared semantic owner map
+
+The full, machine-checked owner map is
+[`docs/design/contracts/shared-utility-contracts-rust.md`](docs/design/contracts/shared-utility-contracts-rust.md).
+The current owners and their semantic axes are:
+
+| Surface | Owner | Axis |
+|---|---|---|
+| Names / namespaces | `tcl-syntax::naming` + `tcl-cmd-core::namespace` | invariant; #1493 absolute marker |
+| Lists | `tcl-syntax::list` | invariant |
+| Dicts | `tcl-syntax::value::ValueOps::dict_pairs` + list codec | invariant |
+| Numbers | `tcl-syntax::number` | `NumberSyntax` per release |
+| Backslash escapes | shared lexer/syntax decoder | `LexerGrammar::escapes` per release |
+| Quotes, braces, word spans | `tcl-lexer::ranges` | close rule per release; tmsh mode per dialect |
+| Indices | `tcl-cmd-core::index` | grammar-parameterised; number axis |
+| Option words / subcommands | `tcl-cmd-core::prefix` + registry tables | release/dialect surface |
+| Expr grammar / evaluation | `tcl-syntax::expr` + `RuntimeExprSurface` | per release |
+| Command / word segmentation | `tcl-compiler::segmenter` over the red-green CST | `LexerConfig` per document dialect |
+| Per-command knowledge | `tcl-registry::CommandSpec` and descriptors | per release/dialect |
+| Dialect / release facts | `tcl-dialect::DialectProfile` | resolved profile axis |
+
+Run `cargo xtask owner-resolution` (included in `make rust-check`) after
+moving an owner or changing one of these axes. Do not add a new owner-shaped
+implementation without updating the contract and its gate.
+
 ## The registry is the source of truth — no per-command logic elsewhere
 
 Per-command knowledge lives in **`tcl-registry`** (`CommandSpec` and its

--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 .PHONY: rust-check check-all prep-pr _prep-pr-checks _prep-pr-tests _prep-pr-smoke _prep-pr-smoke-tier
 # Tests
 .PHONY: test test-ext test-emacs test-rust rust-server rust-tcl rust-f5 rust-mcp rust-clis ensure-server-cross-deps server-cross-build server-cross-build-all mcp-cross-build-all cli-cross-build-all server-cross-test server-cross-test-build print-server-targets-all print-server-targets-jetbrains
-.PHONY: xtask-check xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-zed-queries xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-command-backing xtask-audit-option-dialects xtask-registry-oracle tcltest-sweep tcltest-sweep-check
+.PHONY: xtask-check xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-zed-queries xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-command-backing xtask-audit-option-dialects xtask-registry-oracle tcltest-sweep tcltest-sweep-check
 .PHONY: xtask-workflow-sync xtask-resolution-drift xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift
 # Lint / format / typecheck
 .PHONY: lint format lint-ts format-ts typecheck-ts check-rust rust-deny
@@ -600,7 +600,11 @@ coverage-ext: compile $(NPM_STAMP) ensure-vscode-test-deps ## Run VS Code extens
 # --- Native (cargo xtask) check gates.  These need the Rust toolchain, so CI
 # runs them in the rust-tests job (rust-gate.yml / ci.yml).  `xtask-check` is
 # the CI aggregate.
-xtask-check: xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-resolution-drift xtask-number-drift xtask-command-backing xtask-option-registry-drift ## Rust-side check gates (docs index coverage + generated-table/catalog drift)
+xtask-check: xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-number-drift xtask-command-backing xtask-option-registry-drift ## Rust-side check gates (docs index coverage + generated-table/catalog drift)
+
+xtask-owner-resolution: ## Verify the shared semantic-owner contract resolves to live source and gates
+	@echo "==> Checking shared semantic-owner contract (cargo xtask)"
+	cd $(ROOT) && cargo xtask owner-resolution
 
 xtask-workflow-sync: ## Verify .github/workflows/ copies match their canonical deploy sources (drift gate)
 	@echo "==> Checking installed workflows match their canonical sources (cargo xtask)"

--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -23,6 +23,36 @@ never re-derives it.
 
 ## Owners
 
+The machine-checked manifest below is the canonical source-to-owner map. An
+owner row names the source files that implement the owner, the public entry
+points consumers use, the semantic axis that must be threaded, and the drift
+gate (if one exists). `cargo xtask owner-resolution` fails when a listed file,
+entry point, or gate moves without this contract being updated.
+
+<!-- owner-resolution-manifest -->
+| Surface | Owner source paths | Public entry points | Dialect/release axis | Drift gate |
+| --- | --- | --- | --- | --- |
+| names / namespaces | `rust/tcl-syntax/src/naming.rs`; `rust/tcl-cmd-core/src/namespace.rs` | `qualifier_segments`; `command_resolution_candidates`; `qualifiers`; `tail` | invariant; absolute-marker contract from #1493 | `xtask-resolution-drift` |
+| lists | `rust/tcl-syntax/src/list.rs` | `split_list`; `list_element` | invariant | none |
+| dicts | `rust/tcl-syntax/src/list.rs`; `rust/tcl-syntax/src/value.rs` | `split_list`; `ValueOps::dict_pairs` | invariant | none |
+| glob matching | `rust/tcl-syntax/src/glob.rs` | `string_match`; `string_case_match` | invariant | none |
+| switch body grammar | `rust/tcl-syntax/src/switch_body.rs` | `tokenise_switch_body`; `parse_braced_pairs` | invariant | none |
+| numbers | `rust/tcl-syntax/src/number.rs`; `rust/tcl-dialect/src/grammar.rs` | `parse`; `parse_whole_with`; `NumberSyntax` | `NumberSyntax` per release | `xtask-number-drift` |
+| backslash escapes | `rust/tcl-lexer/src/substitution.rs`; `rust/tcl-syntax/src/backslash.rs`; `rust/tcl-dialect/src/grammar.rs` | `backslash_subst`; `backslash_subst_in`; `decode_bytes_in`; `EscapeSyntax` | `LexerGrammar::escapes` per release | none |
+| boolean words | `rust/tcl-syntax/src/boolean.rs` | `parse_boolean_word`; `truthiness_with` | fixed boolean vocabulary; number axis per release | none |
+| quotes / braces / word spans | `rust/tcl-lexer/src/ranges.rs` | `close_quote_offset`; `word_closer_offset`; `word_span_at` | `${...}` close rule per release; tmsh brace mode per dialect | none |
+| indices | `rust/tcl-cmd-core/src/index.rs` | `resolve_with`; `drill` | grammar-parameterised, inheriting the number axis | none |
+| option words / subcommands | `rust/tcl-cmd-core/src/prefix.rs`; `rust/tcl-registry/src/hover.rs`; `rust/tcl-registry/src/spec.rs` | `OptionTable`; `OptionSpec`; `SubCommand` | option surface per release/dialect | `xtask-option-registry-drift` |
+| sort numeric parsing | `rust/tcl-cmd-core/src/sort.rs` | `parse_wide`; `parse_real` | `NumberSyntax` per release | none |
+| command errors | `rust/tcl-cmd-core/src/error.rs` | `CmdError`; `wrong_args`; `bad_choice` | invariant | none |
+| expression grammar / evaluation | `rust/tcl-syntax/src/expr/parser.rs`; `rust/tcl-syntax/src/expr/eval.rs`; `rust/tcl-registry/src/expr_surface.rs` | `parse_expr`; `eval`; `RuntimeExprSurface` | `RuntimeExprSurface` per release | none |
+| command / word segmentation | `rust/tcl-compiler/src/segmenter.rs` | `SegmentedCommand`; `segment_commands` | `LexerConfig` per document dialect | none |
+| text similarity | `rust/tcl-compiler/src/text.rs` | `edit_distance`; `rank_suggestions`; `rank_containment_suggestions` | invariant | none |
+| per-command knowledge | `rust/tcl-registry/src/spec.rs`; `rust/tcl-registry/src/hooks.rs`; `rust/tcl-registry/src/registry.rs` | `CommandSpec`; `SubCommand`; `CommandRegistry` | per release/dialect | `xtask-command-backing` |
+| dialect / release facts | `rust/tcl-dialect/src/profile.rs`; `rust/tcl-dialect/src/grammar.rs` | `DialectProfile`; `LexerGrammar`; `by_name` | the resolved dialect/release axis | none |
+| shared plain types | `rust/tcl-core-types/src/diag_code.rs` | `DiagCode` | invariant | `xtask-diag-tables` |
+<!-- end-owner-resolution-manifest -->
+
 ### `tcl-syntax` — the parse grammars and value seam
 
 - `list` — the Tcl list codec (`split_list`, `list_element` /

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -44,6 +44,8 @@
 //!   catalog JSON from the registry (`--check` to verify instead of write).
 //! - `number-drift` — flag hand-rolled Tcl radix-prefix recognition outside
 //!   the one numeral parser (`tcl_syntax::number`).
+//! - `owner-resolution` — verify that the shared semantic-owner contract
+//!   resolves to live source files and drift gates.
 
 #![forbid(unsafe_code)]
 
@@ -66,6 +68,7 @@ mod gen_vscode_package;
 mod gen_zed_queries;
 mod kcs_index_links;
 mod number_drift;
+mod owner_resolution;
 mod registry_oracle;
 mod resolution_drift;
 mod tcltest_sweep;
@@ -203,6 +206,7 @@ enum Command {
 
     /// Flag hand-rolled Tcl radix-prefix recognition outside the one numeral
     /// parser (`tcl_syntax::number`) — the numeric-grammar drift class.
+    #[command(name = "number-drift")]
     NumberDrift {
         /// Accepted for symmetry with the other gates (the lint always
         /// verifies; it never rewrites).
@@ -212,12 +216,18 @@ enum Command {
 
     /// Flag namespace-blind `.name ==` scans over `all_procs`/`all_classes`
     /// outside the shared resolution contract (the M1 drift class).
+    #[command(name = "resolution-drift")]
     ResolutionDrift {
         /// Accepted for symmetry with the other gates (the lint always
         /// verifies; it never rewrites).
         #[arg(long)]
         check: bool,
     },
+
+    /// Verify that the shared semantic-owner contract resolves to live source
+    /// files, public entry points, and registered Makefile drift gates.
+    #[command(name = "owner-resolution")]
+    OwnerResolution,
 
     /// Compare the iRules registry with a local BIG-IP schema/man-page
     /// extract; exact source omissions fail, newer registry entries are
@@ -297,6 +307,7 @@ fn main() -> anyhow::Result<ExitCode> {
         Command::WorkflowSync { check } => workflow_sync::run(check),
         Command::NumberDrift { check } => Ok(number_drift::run(check)),
         Command::ResolutionDrift { check } => Ok(resolution_drift::run(check)),
+        Command::OwnerResolution => owner_resolution::run(),
         Command::RegistryOracle {
             irules_root,
             output,

--- a/rust/xtask/src/owner_resolution.rs
+++ b/rust/xtask/src/owner_resolution.rs
@@ -1,0 +1,555 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The source-of-truth check for the shared semantic-owner contract.
+//!
+//! The contract deliberately owns this manifest: a Rust table here would be
+//! easy to update while leaving the human-facing map stale. The check parses
+//! the small, marked Markdown table, then verifies every source path, entry
+//! point, and named Makefile gate. It also makes sure the existing owner
+//! headings are represented by a manifest row.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::process::ExitCode;
+
+use anyhow::{Context, Result};
+
+const CONTRACT_PATH: &str = "docs/design/contracts/shared-utility-contracts-rust.md";
+const MAKEFILE_PATH: &str = "Makefile";
+const XTASK_MAIN_PATH: &str = "rust/xtask/src/main.rs";
+const START_MARKER: &str = "<!-- owner-resolution-manifest -->";
+const END_MARKER: &str = "<!-- end-owner-resolution-manifest -->";
+
+#[derive(Debug, PartialEq, Eq)]
+struct OwnerRow {
+    surface: String,
+    source_paths: Vec<String>,
+    entry_points: Vec<String>,
+    axis: String,
+    drift_gate: Option<String>,
+}
+
+/// Verify the owner manifest and its registered drift gates.
+pub fn run() -> Result<ExitCode> {
+    let root = crate::util::repo_root();
+    let contract = read(&root, CONTRACT_PATH)?;
+    let makefile = read(&root, MAKEFILE_PATH)?;
+    let xtask_main = read(&root, XTASK_MAIN_PATH)?;
+
+    let mut problems = validate_manifest(&root, &contract, &makefile, &xtask_main);
+    if problems.is_empty() {
+        let owner_count = parse_manifest(&contract)
+            .map(|rows| rows.len())
+            .unwrap_or_default();
+        println!(
+            "owner-resolution: OK ({owner_count} owner row(s) resolve to live source and gates)"
+        );
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    problems.sort();
+    eprintln!("owner-resolution: contract drift detected:");
+    for problem in problems {
+        eprintln!("  - {problem}");
+    }
+    Ok(ExitCode::FAILURE)
+}
+
+fn read(root: &Path, relative: &str) -> Result<String> {
+    std::fs::read_to_string(root.join(relative))
+        .with_context(|| format!("read owner-resolution input `{relative}`"))
+}
+
+fn validate_manifest(root: &Path, contract: &str, makefile: &str, xtask_main: &str) -> Vec<String> {
+    let mut problems = Vec::new();
+    let rows = match parse_manifest(contract) {
+        Ok(rows) => rows,
+        Err(problem) => {
+            problems.push(problem);
+            return problems;
+        }
+    };
+
+    let owner_headings = owner_headings(contract);
+    let mut manifest_owners = BTreeSet::new();
+    for row in &rows {
+        for path in &row.source_paths {
+            if let Some(owner) = owner_crate(path) {
+                manifest_owners.insert(owner.to_owned());
+            }
+        }
+    }
+    for owner in owner_headings {
+        if !manifest_owners.contains(&owner) {
+            problems.push(format!(
+                "owner heading `{owner}` has no row in the owner-resolution manifest"
+            ));
+        }
+    }
+    for (owner, declared) in declared_owner_bullets(contract) {
+        let declared_name = declared.rsplit("::").next().unwrap_or(&declared);
+        let covered = rows.iter().any(|row| {
+            row.source_paths.iter().any(|path| {
+                path.ends_with(&format!("/{declared_name}.rs"))
+                    || path.contains(&format!("/{declared_name}/"))
+            }) || row
+                .entry_points
+                .iter()
+                .any(|entry| entry == &declared || entry == declared_name)
+        });
+        if !covered {
+            problems.push(format!(
+                "declared owner bullet `{owner}::{declared}` has no manifest row"
+            ));
+        }
+    }
+
+    for row in rows {
+        if row.surface.is_empty() {
+            problems.push("owner row has an empty surface name".to_owned());
+        }
+        if row.source_paths.is_empty() {
+            problems.push(format!("owner `{}` has no source path", row.surface));
+        }
+        if row.entry_points.is_empty() {
+            problems.push(format!("owner `{}` has no public entry point", row.surface));
+        }
+        if row.axis.is_empty() {
+            problems.push(format!(
+                "owner `{}` has no dialect/release axis",
+                row.surface
+            ));
+        }
+
+        let mut source_texts = Vec::new();
+        for source in &row.source_paths {
+            let path = root.join(source);
+            match std::fs::read_to_string(&path) {
+                Ok(text) => source_texts.push((source.as_str(), text)),
+                Err(error) => problems.push(format!(
+                    "owner `{}` source `{source}` is missing or unreadable: {error}",
+                    row.surface
+                )),
+            }
+        }
+        for entry in &row.entry_points {
+            let resolved_source = source_texts
+                .iter()
+                .find(|(_, source)| entry_is_declared(source, entry));
+            if resolved_source.is_none() {
+                problems.push(format!(
+                    "owner `{}` entry point `{entry}` has no public declaration in its source paths",
+                    row.surface,
+                ));
+            }
+        }
+
+        if let Some(gate) = row.drift_gate {
+            let Some(dispatch_name) = make_gate_command(makefile, &gate) else {
+                problems.push(format!(
+                    "owner `{}` names missing or non-xtask Makefile drift gate `{gate}`",
+                    row.surface
+                ));
+                continue;
+            };
+            if !xtask_dispatches(xtask_main, &dispatch_name) {
+                problems.push(format!(
+                    "owner `{}` gate `{gate}` invokes `{dispatch_name}` but xtask dispatch has no matching command",
+                    row.surface,
+                ));
+            }
+        }
+    }
+    problems
+}
+
+fn parse_manifest(markdown: &str) -> Result<Vec<OwnerRow>, String> {
+    let start = markdown
+        .find(START_MARKER)
+        .ok_or_else(|| format!("missing `{START_MARKER}` in {CONTRACT_PATH}"))?;
+    let body = &markdown[start + START_MARKER.len()..];
+    let end = body
+        .find(END_MARKER)
+        .ok_or_else(|| format!("missing `{END_MARKER}` in {CONTRACT_PATH}"))?;
+
+    let mut rows = Vec::new();
+    for line in body[..end].lines() {
+        let cells = split_row(line);
+        if cells.is_empty() || cells[0] == "Surface" || cells.iter().all(|cell| *cell == "---") {
+            continue;
+        }
+        if cells.len() != 5 {
+            return Err(format!(
+                "owner manifest row must have five columns: `{line}`"
+            ));
+        }
+        let source_paths = code_tokens(cells[1]);
+        let entry_points = code_tokens(cells[2]);
+        let drift_gate = if cells[4] == "none" {
+            None
+        } else {
+            let gates = code_tokens(cells[4]);
+            if gates.len() != 1 {
+                return Err(format!(
+                    "owner manifest drift gate must be `none` or one backticked Make target: `{line}`"
+                ));
+            }
+            gates.into_iter().next()
+        };
+        rows.push(OwnerRow {
+            surface: cells[0].to_owned(),
+            source_paths,
+            entry_points,
+            axis: cells[3].to_owned(),
+            drift_gate,
+        });
+    }
+    if rows.is_empty() {
+        return Err(format!("owner manifest in {CONTRACT_PATH} has no rows"));
+    }
+    Ok(rows)
+}
+
+fn split_row(line: &str) -> Vec<&str> {
+    let trimmed = line.trim();
+    if !trimmed.starts_with('|') || !trimmed.ends_with('|') {
+        return Vec::new();
+    }
+    trimmed[1..trimmed.len() - 1]
+        .split('|')
+        .map(str::trim)
+        .collect()
+}
+
+fn code_tokens(cell: &str) -> Vec<String> {
+    cell.split('`')
+        .enumerate()
+        .filter_map(|(index, part)| (index % 2 == 1).then_some(part.trim().to_owned()))
+        .filter(|part| !part.is_empty())
+        .collect()
+}
+
+fn owner_headings(markdown: &str) -> BTreeSet<String> {
+    let Some(start) = markdown.find("## Owners") else {
+        return BTreeSet::new();
+    };
+    let tail = &markdown[start..];
+    let end = tail.find("\n## Decision rules").unwrap_or(tail.len());
+    tail[..end]
+        .lines()
+        .filter_map(|line| line.strip_prefix("### `"))
+        .filter_map(|line| line.split('`').next())
+        .map(str::to_owned)
+        .collect()
+}
+
+fn declared_owner_bullets(markdown: &str) -> Vec<(String, String)> {
+    let Some(start) = markdown.find("## Owners") else {
+        return Vec::new();
+    };
+    let tail = &markdown[start..];
+    let end = tail.find("\n## Decision rules").unwrap_or(tail.len());
+    let mut owner = String::new();
+    let mut out = Vec::new();
+    for line in tail[..end].lines() {
+        if let Some(heading) = line.strip_prefix("### `") {
+            heading
+                .split('`')
+                .next()
+                .unwrap_or_default()
+                .clone_into(&mut owner);
+        } else if let Some(bullet) = line.trim_start().strip_prefix("- `")
+            && let Some(name) = bullet.split('`').next()
+        {
+            out.push((owner.clone(), name.to_owned()));
+        }
+    }
+    out
+}
+
+fn entry_is_declared(source: &str, entry: &str) -> bool {
+    let ident = entry.rsplit("::").next().unwrap_or(entry);
+    let public_declaration = source.lines().any(|line| {
+        let trimmed = line.trim_start();
+        [
+            "pub fn ",
+            "pub const ",
+            "pub static ",
+            "pub struct ",
+            "pub enum ",
+            "pub trait ",
+            "pub type ",
+            "pub use ",
+        ]
+        .iter()
+        .any(|prefix| {
+            trimmed.strip_prefix(prefix).is_some_and(|rest| {
+                rest.starts_with(ident)
+                    && rest
+                        .as_bytes()
+                        .get(ident.len())
+                        .is_none_or(|byte| !byte.is_ascii_alphanumeric() && *byte != b'_')
+            })
+        })
+    });
+    if public_declaration {
+        return true;
+    }
+    let Some(owner) = entry
+        .strip_suffix(ident)
+        .and_then(|prefix| prefix.strip_suffix("::"))
+    else {
+        return false;
+    };
+    let mut trait_depth = None;
+    let mut depth = 0usize;
+    for line in source.lines() {
+        let trimmed = line.trim_start();
+        if trait_depth.is_none()
+            && trimmed
+                .strip_prefix("pub trait ")
+                .is_some_and(|rest| starts_with_identifier(rest, owner))
+        {
+            trait_depth = Some(depth + line.bytes().filter(|&byte| byte == b'{').count());
+        } else if let Some(start_depth) = trait_depth {
+            if depth >= start_depth
+                && trimmed
+                    .strip_prefix("fn ")
+                    .is_some_and(|rest| starts_with_identifier(rest, ident))
+            {
+                return true;
+            }
+            let opens = line.bytes().filter(|&byte| byte == b'{').count();
+            let closes = line.bytes().filter(|&byte| byte == b'}').count();
+            depth = depth.saturating_add(opens).saturating_sub(closes);
+            if depth < start_depth {
+                trait_depth = None;
+            }
+            continue;
+        }
+        let opens = line.bytes().filter(|&byte| byte == b'{').count();
+        let closes = line.bytes().filter(|&byte| byte == b'}').count();
+        depth = depth.saturating_add(opens).saturating_sub(closes);
+    }
+    false
+}
+
+fn xtask_dispatches(main: &str, command: &str) -> bool {
+    let variant = match command {
+        "resolution-drift" => "ResolutionDrift",
+        "number-drift" => "NumberDrift",
+        "audit-option-dialects" => "AuditOptionDialects",
+        "command-backing" => "WasmBacking",
+        "diag-tables" => "DiagTables",
+        "owner-resolution" => "OwnerResolution",
+        _ => return false,
+    };
+    let prefix = format!("Command::{variant}");
+    main.lines().any(|line| {
+        let trimmed = line.trim_start();
+        trimmed.starts_with(&prefix) && trimmed.contains("=>")
+    })
+}
+
+fn starts_with_identifier(text: &str, identifier: &str) -> bool {
+    text.strip_prefix(identifier).is_some_and(|rest| {
+        rest.as_bytes()
+            .first()
+            .is_none_or(|byte| !byte.is_ascii_alphanumeric() && *byte != b'_')
+    })
+}
+
+fn owner_crate(path: &str) -> Option<&str> {
+    let path = path.strip_prefix("rust/")?;
+    path.split('/').next()
+}
+
+fn make_gate_command(makefile: &str, target: &str) -> Option<String> {
+    let target_prefix = format!("{target}:");
+    let mut in_recipe = false;
+    for line in makefile.lines() {
+        if !in_recipe {
+            if line.trim_start().starts_with(&target_prefix) {
+                in_recipe = true;
+            }
+            continue;
+        }
+        if !line.starts_with('\t') {
+            if !line.trim().is_empty() {
+                break;
+            }
+            continue;
+        }
+        let Some(command) = line.split_once("cargo xtask ").map(|(_, rest)| rest) else {
+            continue;
+        };
+        return command.split_whitespace().next().map(str::to_owned);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_marked_manifest_rows() {
+        let md = "<!-- owner-resolution-manifest -->\n| Surface | Owner source paths | Public entry points | Axis | Drift gate |\n| --- | --- | --- | --- | --- |\n| names | `rust/a/src/lib.rs`; `rust/b/src/lib.rs` | `one`; `two` | invariant | `xtask-example` |\n<!-- end-owner-resolution-manifest -->";
+        let rows = parse_manifest(md).expect("manifest parses");
+        assert_eq!(
+            rows,
+            vec![OwnerRow {
+                surface: "names".to_owned(),
+                source_paths: vec![
+                    "rust/a/src/lib.rs".to_owned(),
+                    "rust/b/src/lib.rs".to_owned()
+                ],
+                entry_points: vec!["one".to_owned(), "two".to_owned()],
+                axis: "invariant".to_owned(),
+                drift_gate: Some("xtask-example".to_owned()),
+            }]
+        );
+    }
+
+    #[test]
+    fn owner_headings_are_limited_to_owner_section() {
+        let md = "## Owners\n### `tcl-syntax` — owner\n## Decision rules\n### `not-an-owner`";
+        assert_eq!(
+            owner_headings(md),
+            BTreeSet::from(["tcl-syntax".to_owned()])
+        );
+    }
+
+    #[test]
+    fn missing_declared_owner_row_is_reported() {
+        let root = crate::util::repo_root();
+        let contract = std::fs::read_to_string(root.join(CONTRACT_PATH)).expect("contract");
+        let contract = contract
+            .lines()
+            .filter(|line| !line.starts_with("| glob matching |"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let makefile = std::fs::read_to_string(root.join(MAKEFILE_PATH)).expect("Makefile");
+        let main = std::fs::read_to_string(root.join(XTASK_MAIN_PATH)).expect("xtask main");
+        let problems = validate_manifest(&root, &contract, &makefile, &main);
+        assert!(
+            problems
+                .iter()
+                .any(|problem| problem.contains("tcl-syntax::glob"))
+        );
+    }
+
+    #[test]
+    fn missing_source_is_reported() {
+        let root = crate::util::repo_root();
+        let contract = synthetic_manifest("`rust/tcl-syntax/src/moved.rs`", "`Moved`", "none");
+        let makefile = std::fs::read_to_string(root.join(MAKEFILE_PATH)).expect("Makefile");
+        let main = std::fs::read_to_string(root.join(XTASK_MAIN_PATH)).expect("xtask main");
+        let problems = validate_manifest(&root, &contract, &makefile, &main);
+        assert!(
+            problems
+                .iter()
+                .any(|problem| problem.contains("missing or unreadable"))
+        );
+    }
+
+    #[test]
+    fn missing_entry_point_is_reported() {
+        let root = crate::util::repo_root();
+        let contract = synthetic_manifest(
+            "`rust/tcl-syntax/src/list.rs`",
+            "`DefinitelyMissing`",
+            "none",
+        );
+        let makefile = std::fs::read_to_string(root.join(MAKEFILE_PATH)).expect("Makefile");
+        let main = std::fs::read_to_string(root.join(XTASK_MAIN_PATH)).expect("xtask main");
+        let problems = validate_manifest(&root, &contract, &makefile, &main);
+        assert!(
+            problems
+                .iter()
+                .any(|problem| problem.contains("no public declaration"))
+        );
+    }
+
+    #[test]
+    fn private_functions_do_not_satisfy_public_entry_points() {
+        assert!(!entry_is_declared("fn hidden() {}", "hidden"));
+        assert!(!entry_is_declared(
+            "pub trait ValueOpsExtra {\n    fn dict_pairs_extra(&self);\n}",
+            "ValueOps::dict_pairs"
+        ));
+        assert!(!entry_is_declared(
+            "pub trait ValueOps {\n    fn dict_pairs_extra(&self);\n}",
+            "ValueOps::dict_pairs"
+        ));
+        assert!(entry_is_declared(
+            "pub trait Public {\n    fn member(&self);\n}",
+            "Public::member"
+        ));
+    }
+
+    #[test]
+    fn missing_make_gate_is_reported() {
+        let root = crate::util::repo_root();
+        let contract = synthetic_manifest(
+            "`rust/tcl-syntax/src/list.rs`",
+            "`split_list`",
+            "`xtask-does-not-exist`",
+        );
+        let makefile = std::fs::read_to_string(root.join(MAKEFILE_PATH)).expect("Makefile");
+        let main = std::fs::read_to_string(root.join(XTASK_MAIN_PATH)).expect("xtask main");
+        let problems = validate_manifest(&root, &contract, &makefile, &main);
+        assert!(
+            problems
+                .iter()
+                .any(|problem| problem.contains("missing or non-xtask Makefile drift gate"))
+        );
+    }
+
+    fn synthetic_manifest(paths: &str, entries: &str, gate: &str) -> String {
+        format!(
+            "## Owners\n### `tcl-syntax` — owner\n\n<!-- owner-resolution-manifest -->\n| Surface | Owner source paths | Public entry points | Dialect/release axis | Drift gate |\n| --- | --- | --- | --- | --- |\n| test | {paths} | {entries} | invariant | {gate} |\n<!-- end-owner-resolution-manifest -->\n\n## Decision rules"
+        )
+    }
+
+    #[test]
+    fn resolves_make_targets_to_their_actual_xtask_commands() {
+        let makefile = "xtask-resolution-drift:\n\tcd $(ROOT) && cargo xtask resolution-drift\n\nxtask-option-registry-drift:\n\tcd $(ROOT) && cargo xtask audit-option-dialects --check\n";
+        assert_eq!(
+            make_gate_command(makefile, "xtask-resolution-drift"),
+            Some("resolution-drift".to_owned())
+        );
+        assert_eq!(
+            make_gate_command(makefile, "xtask-option-registry-drift"),
+            Some("audit-option-dialects".to_owned())
+        );
+    }
+
+    #[test]
+    fn dispatch_check_ignores_comments_and_requires_match_arm() {
+        assert!(!xtask_dispatches(
+            "// Command::ResolutionDrift => resolution_drift::run(check),",
+            "resolution-drift"
+        ));
+        assert!(xtask_dispatches(
+            "Command::ResolutionDrift { check } => resolution_drift::run(check),",
+            "resolution-drift"
+        ));
+    }
+}


### PR DESCRIPTION
## Issues

Phase-0 prerequisite for the semantic-centralisation programme tracked in #1473.

## Root cause

The shared semantic-owner contract was prose-only. Owner files, public entry points, dialect/release axes, and associated drift gates could be moved or renamed while the documentation and agent guidance continued to look authoritative.

## Fix

- adds a canonical machine-readable owner manifest to the shared-utility contract;
- adds the concise owner map to `AGENTS.md`;
- adds `cargo xtask owner-resolution`;
- verifies every declared owner bullet has a manifest row;
- verifies owner paths and declaration-shaped public entry points;
- verifies each named Make gate invokes a live xtask dispatch;
- wires `xtask-owner-resolution` into `xtask-check`.

## Dialect/release behaviour

No runtime semantics change. The manifest records each current axis explicitly, including `NumberSyntax`, `EscapeSyntax`, `LexerGrammar`, `RuntimeExprSurface`, per-document `LexerConfig`, registry release/dialect surfaces, and resolved `DialectProfile`.

## Duplication audit

Compared the prompt owner map with the existing contract and live sources. Added missing rows for dicts, word ranges, command segmentation, per-command knowledge, dialect facts, glob, switch-body parsing, boolean words, sort parsing, command errors, and text similarity. No semantic implementation was duplicated or moved.

## Tests

- 9 focused xtask tests, including mutation-style failures for omitted owners, missing sources, moved/private entry points, trait-member lookalikes, missing Make targets, mismatched target→command mappings, and comment-only pseudo-dispatches;
- independent Terra adversarial review: PASS.

## Gates

- `make rust-check` — pass
- `make prep-pr` — pass
- `make test-rust` — pass
- local `make lsp-e2e` replacement: `cargo test -p tcl-lsp-server --all-features` — pass (the repository has no `lsp-e2e` Make target; `test-rust` also includes this suite)
- `make test-ext` — pass
- `cargo xtask owner-resolution` — pass, 19 owner rows resolved
- `git diff --check` — pass

Full local logs are retained under `/tmp/pr0-*.log`.

## Generated artefacts/docs

No generated output changed. The new check participates in the canonical `xtask-check` drift aggregate.

## Performance

No runtime path changes and no material performance risk identified.