### PR TITLE
Fix compiler fact propagation

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -380,8 +380,8 @@ Distilled from the trickiest scars in the WASM runtime history
 
 - [kcs-codes-drift-audit-2026-08-12.md](kcs-codes-drift-audit-2026-08-12.md)
   — source-verified audit of the per-code diagnostic pages: missing
-  pages, behaviour contradictions, and the `safe_on_uninit` wiring gap
-  it surfaced.
+  pages, behaviour contradictions, and the now-closed `safe_on_uninit`
+  wiring gap it surfaced.
 - [issue-923-differential-audit/README.md](issue-923-differential-audit/README.md)
   — the three-way differential method (mine a corpus, reduce to a minimal
   repro, compare a real `tclsh` oracle against the LSP), the oracle-environment

--- a/docs/design/compiler/command-registry.md
+++ b/docs/design/compiler/command-registry.md
@@ -220,7 +220,7 @@ execution trace is absent.
 |-------|------|---------|---------|
 | `assigns_variable_at` | `Option<u8>` | `None` | Arg index of the variable this command writes to (e.g. 0 for `set varName value`) |
 | `var_write_typing` | `VarWriteTyping` | `ReturnValue` | How the type-inference pass types the variable(s) this command *writes*, distinct from `return_type` (which types the value it *returns*).  See below |
-| `safe_on_uninit` | `Option<DialectSet>` | `None` | Whether the command safely creates an uninitialised variable.  `None` = not safe (W210 fires); `Some(_)` = safe.  **The dialect set is currently inert**: every consumer tests only `is_some()`, so a version-gated spelling such as `Some(DialectSet::TCL85_PLUS)` does not actually restrict anything (`incr` is safe in 8.5+ but errors in 8.4 and iRules — the set does not yet express that).  The field's doc comment defines `Some(empty)` as "safe in all dialects", while shipped specs spell the all-dialects case `Some(DialectSet::ALL_TCL)`; both reach the same consumers.  Wiring the set through is an open gap |
+| `safe_on_uninit` | `Option<DialectSet>` | `None` | Whether the command safely creates an uninitialised variable. `None` = not safe (W210 fires); `Some(set)` = safe only when the active dialect belongs to `set` (an empty set means every concrete dialect). The lowerer resolves the matched command/subcommand form, projects this fact into IR, and W210 consumes the resulting statement flag. A profile-less registry abstains (`false`) rather than treating its union of dialects as proof. |
 | `inferred_storage_type` | `Option<StorageType>` | `None` | Inferred type for the target variable: `Dict`, `List`, or `Array` |
 | `Traits::DEFINES_PROCEDURE` | trait bit | unset | Command defines a procedure (proc, method, etc.) |
 | `defines_command_at` | `Option<u8>` | `None` | Argument index (0-based, after the command name) whose *literal* value becomes a callable command name once the call runs — `coroutine NAME cmd ?arg …?` binds `NAME` (`TclNRCoroutineObjCmd`, `tclBasic.c`).  Lighter than `creates_instance_at` (no `object_class` method dispatch); consumed generically by the analyser so later calls to the name don't draw W123.  The subcommand-level twin lives on `SubCommand` (`interp create ?-safe? ?--? ?name?`, index relative to the word after the subcommand); an option flag (leading `-`) or dynamic word at the index is never recorded, and a missing name is auto-generated at run time |
@@ -1260,15 +1260,17 @@ The version-gated sets are `DialectSet` constants
 (`rust/tcl-dialect/src/dialect_set.rs`), so a derived dialect inherits the
 right answer from the bits it contains rather than from a name comparison.
 
-**Current state (verified 2026-08-12):** the field is declared and stamped
-on the specs (`append`, `lappend`, `incr`, `catch`, the `dict` writers),
-but no production consumer reads it — every lowering site constructs
-`safe_on_uninit: false` on the statement, and the analyser's
-`use_site_safe_initialises` can therefore only fire on `Statement::Incr`.
-What actually keeps W210 quiet for these commands today is their
-`ArgRole::VarWrite` declaration, which records the write as a def. Wiring
-the field through lowering (registry lookup → statement flag) is an open
-gap from the port; the spec-side data is already correct for it.
+**Current state (verified 2026-08-15):** the registry resolves the most
+specific declared value (matched subcommand, otherwise command) into
+`InvocationSemantics`. Lowering evaluates that `DialectSet` against the
+active profile and writes the result to `Statement::Call` (including
+structured `dict` writers) or the specialised `Statement::Incr`.
+`use_site_safe_initialises` consumes the resulting IR flag when deciding
+whether W210 applies to the command's own read-before-write. A profile-less
+registry is deliberately conservative: its availability mask is a union,
+not a runtime guarantee, so lowering writes `false`. `ArgRole::VarWrite`
+still records the eventual definition; it is distinct from this
+read-before-write safety fact.
 
 ### Dialect loading
 

--- a/docs/design/compiler/taint-analysis.md
+++ b/docs/design/compiler/taint-analysis.md
@@ -39,11 +39,14 @@ TaintLattice::tainted().with(TaintColour::URL_ENCODED)   // tainted, but URI-enc
 
 ### TaintColour flags
 
-`TaintColour` is a `bitflags` set over `u32`. The canonical definition is
-`rust/tcl-registry/src/taint.rs`, so spec data (`taint_transform`,
+`TaintColour` is a `bitflags` set over `u32`, with its atomic declarations in
+the registry-owned `TaintColourAtom` enum at `rust/tcl-registry/src/taint.rs`.
+Spec data (`taint_transform`,
 `taint_double_encode_colour`, `taint_sink_safe_colour`) can name colours.
-`rust/tcl-compiler/src/taint.rs` declares its own bitflags with the same bit
-layout, and `reg_colour` bridges the two with `TaintColour::from_bits_truncate`.
+`rust/tcl-compiler/src/taint.rs` declares a same-width mirror. Its bridge
+exhaustively matches the registry-owned `TaintColourAtom` enum in both
+directions, then asserts the mapped mask is bit-identical; adding a registry
+colour therefore breaks the compiler match until it is handled deliberately.
 
 | Flag | Meaning |
 |------|---------|
@@ -58,14 +61,8 @@ layout, and `reg_colour` bridges the two with `TaintColour::from_bits_truncate`.
 | `NON_DASH_PREFIXED` | Cannot be read as an option flag |
 | `HEADER_TOKEN_SAFE` | Safe as an HTTP header token |
 | `IP_ADDRESS` / `PORT` / `FQDN` | Validated network-address shapes |
-| `PATH_JOINED` | Assembled by `[file join]` — **registry-side only** |
-| `CHANNEL` | A channel handle — **registry-side only** |
-
-The compiler's mirror stops at bit 14 (`FQDN`). `PATH_JOINED` (bit 15) and
-`CHANNEL` (bit 16) exist only in the registry's set, and `reg_colour`'s
-`from_bits_truncate` drops them, so a spec declaring
-`taint_transform: Some(TaintColour::PATH_JOINED)` — `file join` does — yields
-no colour on the compiler side.
+| `PATH_JOINED` | Assembled by `[file join]` (portable, not canonicalised) |
+| `CHANNEL` | A channel handle |
 
 Colours compose with `|` (bitwise OR); mitigations join by `&`
 (intersection).
@@ -128,8 +125,7 @@ subcommand's transform over the bare command's:
 - `URI::encode` on tainted data: adds `URL_ENCODED | CRLF_FREE`.
 - `HTML::encode` / `HTML::escape` / `htmlencode` on tainted data: adds
   `HTML_ESCAPED | CRLF_FREE`.
-- `file normalize` adds `PATH_NORMALISED`; `file join` declares
-  `PATH_JOINED`, which the compiler's mirror truncates away (see above).
+- `file normalize` adds `PATH_NORMALISED`; `file join` adds `PATH_JOINED`.
 
 A command with *no* registry classification at all — not a source, sanitiser,
 transform, or passthrough — is not a no-op: `TaintLattice::shape_unproven`
@@ -152,7 +148,7 @@ procedure boundaries using `ProcTaintSummary` values:
 A summary is a **transfer function**, not a single value: a clean base return
 taint, plus — for each parameter — one return taint per colour basis, so a
 caller can ask "what comes back if I pass a value tainted *this* way?".  There
-are 15 bases, so inferring a summary the direct way is `1 + 15P` complete
+are 17 bases, so inferring a summary the direct way is `1 + 17P` complete
 dataflow solves over the procedure's control-flow graph, for `P` parameters.
 That is the dominant cost of the whole pass: about 80% of `run_all_checks` on
 tcllib's `practcl.tcl`.
@@ -167,18 +163,24 @@ differential keep validating the inference unchanged:
   all three require the return word to contain a `$` or a `[`.  A procedure whose
   executable returns are all value-less or all substitution-free therefore
   returns `clean` whatever the map holds, so the whole summary is the clean one:
-  **0** solves instead of `1 + 15P`.  This is the common case in real Tcl — a
+  **0** solves instead of `1 + 17P`.  This is the common case in real Tcl — a
   procedure that returns nothing, a literal, or a braced constant.
 - **Unread parameter** — `seed_entry_taints` skips a name that is not interned in
   the SSA, so seeding a parameter the body never reads leaves the initial taint
   map bit-identical to the clean base run's.  The scenario *is* `return_base`:
-  **0** solves instead of 15, per such parameter.
+  **0** solves instead of 17, per such parameter.
 
-What remains is `1 + 15 × (parameters actually read, in a procedure whose return
-value is substitution-bearing)`.  Collapsing that last `15×` needs a different
+What remains is `1 + 17 × (parameters actually read, in a procedure whose return
+value is substitution-bearing)`.  Collapsing that last `17×` needs a different
 representation — one multi-colour symbolic traversal carrying a
 per-`(parameter, basis)` dependency bitset — which changes what the solver
 computes rather than skipping work it can prove redundant, and is not attempted.
+
+**Cost note.** Adding `PATH_JOINED` and `CHANNEL` widens the unpruned transfer
+matrix from `1 + 15P` to `1 + 17P`: at most two additional solves per read
+parameter (about 13% on that inner matrix). The constant-return and unread-
+parameter prunes above still apply unchanged; the historical measurements below
+predate this domain widening and are not presented as a new benchmark.
 
 Measured with `cargo run --release -p tcl-lsp-db --example tail_profile` on
 tcllib's `practcl.tcl` (8,463 lines, 116 functions), same machine, same binary:

--- a/docs/design/kcs-codes-drift-audit-2026-08-12.md
+++ b/docs/design/kcs-codes-drift-audit-2026-08-12.md
@@ -52,11 +52,11 @@ explicitly replaced.
 
 ## Source-level finding surfaced by the audit
 
-`CommandSpec::safe_on_uninit` / `SubCommand::safe_on_uninit` have **no
-production consumer**: every lowering site constructs
-`safe_on_uninit: false`, so `use_site_safe_initialises` can only fire on
-`Statement::Incr`. W210 is actually kept quiet by `ArgRole::VarWrite`
-defs. The spec-side data is stamped and correct; the wiring through
-lowering is the open gap. Recorded in
-[command-registry.md](compiler/command-registry.md) and the CommandSpec
+At the time of this 2026-08-12 audit, `CommandSpec::safe_on_uninit` /
+`SubCommand::safe_on_uninit` had no production consumer: lowering wrote
+`safe_on_uninit: false`, so W210 relied only on `ArgRole::VarWrite` defs.
+That wiring gap was closed on 2026-08-15: resolved registry semantics now
+flow through the active dialect profile into the IR statement flag consumed
+by W210, and profile-less lowering abstains conservatively. See the current
+[command-registry.md](compiler/command-registry.md) and CommandSpec
 reference.

--- a/docs/references/command-spec/diagnostics.md
+++ b/docs/references/command-spec/diagnostics.md
@@ -45,7 +45,7 @@
 
 | Code | Reports | Registry drivers |
 |---|---|---|
-| W210 | Read before set | `ArgRole::VarWrite` on your writing argument suppresses (the write becomes a def); `Traits::CREATES_SCOPE_ALIAS` suppresses; `DESTROYS_VARIABLE` diverts to W213. `safe_on_uninit` records the version fact but is not consulted today — see the design doc |
+| W210 | Read before set | `ArgRole::VarWrite` records the eventual def; `safe_on_uninit` suppresses the command's own read-before-write only when its resolved `DialectSet` contains the active profile (and lowers conservatively to false without a profile); `Traits::CREATES_SCOPE_ALIAS` suppresses; `DESTROYS_VARIABLE` diverts to W213 |
 | W211 / W220 | Unused variable / dead store | `ArgRole::VarRead` records the read; `Traits::READS_BEFORE_WRITE` keeps the feeding store alive |
 | W212 | `$` where a name is expected | Any `VarWrite` / `VarRead` role position receiving `$var` causes |
 | W126 | Non-channel in a channel slot | `ArgRole::Channel` causes (and filters that position out of taint output sinks) |

--- a/docs/references/command-spec/fields.md
+++ b/docs/references/command-spec/fields.md
@@ -35,7 +35,7 @@ This is what makes the same file lint differently as Tcl 8.4 versus 9.0: a comma
 
 Whether the command may be handed a variable name that does not exist yet. `lappend v x` happily creates `v`; so does `append`. `incr` creates it in Tcl 8.5+ but errors in 8.4 — which is why this is a *set of dialects* rather than yes/no.
 
-Note: today the "variable read before set" warning is actually kept quiet by declaring the argument a written variable (a VarWrite role); this field records the version fact but is not yet consulted by that check.
+The compiler resolves this set for the active profile, stores the result in lowered IR, and W210 uses it for the command's own read-before-write. A VarWrite role still records the eventual definition. Without a concrete profile, lowering abstains and treats the operation as not safe.
 
 ### `required_package` — Required package
 

--- a/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
@@ -1252,24 +1252,6 @@ file; this call falls through to the 'unknown' handler."
             if barrier_body_locally_sets(stmt_opt, var, self.registry.as_deref()) {
                 continue;
             }
-            // A read-modify-write command (`lappend` / `append`) that
-            // auto-creates its target is not a read-before-set: it both
-            // reads and defines the variable, creating it from an empty
-            // default when absent. `unset` also carries
-            // `reads_own_defs` but is destructive, not auto-creating — its
-            // missing-variable case is exactly the W213 handled just below,
-            // so it must not be skipped here.
-            if let Some(Statement::Call {
-                reads_own_defs: true,
-                command,
-                defs,
-                ..
-            }) = stmt_opt
-                && command != "unset"
-                && defs.iter().any(|d| d == var)
-            {
-                continue;
-            }
             // Skip the existence-query word itself and
             // reads narrowed by an enclosing `[info exists X]` guard.
             if existence_exempt(stmt_opt, var, exists_guards, &fu.ssa, &use_site.block) {
@@ -2614,7 +2596,11 @@ fn use_site_safe_initialises(stmt: Option<&crate::ir::Statement>, var: &str) -> 
             defs,
             ..
         }) => *safe_on_uninit && defs.iter().any(|d| d == var),
-        Some(Statement::Incr { name, .. }) => crate::naming::normalise_var_name(name) == var,
+        Some(Statement::Incr {
+            name,
+            safe_on_uninit,
+            ..
+        }) => *safe_on_uninit && crate::naming::normalise_var_name(name) == var,
         _ => false,
     }
 }

--- a/rust/tcl-compiler/src/dynamic_names.rs
+++ b/rust/tcl-compiler/src/dynamic_names.rs
@@ -572,10 +572,12 @@ fn scan_text(
     config: LexerConfig,
 ) {
     // Native-stack safety net (issue #996): `[a [b [c …]]]` nests inside one
-    // word. Past the cap, stop descending — an unset flag is the "no barrier
-    // proved" fallback, which matches every other bounded walk's contract of
-    // returning what it gathered rather than crashing.
+    // word. This is a soundness fact, not a best-effort diagnostic: past the
+    // cap the unread suffix may contain any dynamic read, write, or destroy.
+    // Fail closed for every consumer rather than treating a bounded walk as a
+    // proof that no barrier exists (issue #1497).
     if MAX_BRACKET_TEXT_DEPTH.exceeded(depth) {
+        *barrier = barrier.union(DynamicNameBarrier::OPAQUE_SCRIPT);
         return;
     }
     for inner in crate::var_refs::command_subst_texts(text) {
@@ -593,6 +595,7 @@ fn scan_script_text(
     config: LexerConfig,
 ) {
     if MAX_BRACKET_TEXT_DEPTH.exceeded(depth) {
+        *barrier = barrier.union(DynamicNameBarrier::OPAQUE_SCRIPT);
         return;
     }
     for words in crate::ir_helpers::tokenise_command_words(text, config) {
@@ -1299,5 +1302,31 @@ computed; got {b:?}"
                 assert!(b.is_clear(), "{dialect}: `{body}` got {b:?}");
             }
         }
+    }
+
+    /// Issue #1497 — the bracket-depth cap protects the native stack, but it
+    /// cannot certify that the unread suffix has no dynamic variable access.
+    /// The source mutation is deliberately under the cap boundary: replacing
+    /// the dynamic `set $name` with a literal `set x` must not make a bounded
+    /// scan claim either source is fully known.
+    #[test]
+    fn bracket_depth_exhaustion_fails_closed_for_dynamic_name_facts() {
+        let nest = |leaf: &str| {
+            let mut text = leaf.to_owned();
+            for _ in 0..=MAX_BRACKET_TEXT_DEPTH.0 {
+                text = format!("[list {text}]");
+            }
+            text
+        };
+        let dynamic = barrier_for(&format!(
+            "proc f {{name}} {{ set sink {}; return ok }}\n",
+            nest("[set $name 2]")
+        ));
+        let literal = barrier_for(&format!(
+            "proc f {{}} {{ set sink {}; return ok }}\n",
+            nest("[set x 2]")
+        ));
+        assert_eq!(dynamic, DynamicNameBarrier::OPAQUE_SCRIPT, "{dynamic:?}");
+        assert_eq!(literal, DynamicNameBarrier::OPAQUE_SCRIPT, "{literal:?}");
     }
 }

--- a/rust/tcl-compiler/src/lowering/hooks/incr.rs
+++ b/rust/tcl-compiler/src/lowering/hooks/incr.rs
@@ -39,7 +39,7 @@ use crate::lowering_hooks::{ArgTokenKind, LoweringCommand, has_expansion, make_c
 /// [`Statement::Call`] when the call shape is not the
 /// specialise-able `incr name ?amount?` form.
 #[must_use]
-pub fn try_lower_incr(cmd: &LoweringCommand<'_>) -> Statement {
+pub fn try_lower_incr(cmd: &LoweringCommand<'_>, safe_on_uninit: bool) -> Statement {
     if has_expansion(cmd) || cmd.args.is_empty() || cmd.args.len() > 2 {
         return make_call(cmd);
     }
@@ -73,9 +73,7 @@ pub fn try_lower_incr(cmd: &LoweringCommand<'_>) -> Statement {
         name: cmd.args[0].clone(),
         name_braced,
         amount: cmd.args.get(1).cloned(),
-        // Conservatively `false`: downstream passes treat ``incr``
-        // as if it reads the variable first.
-        safe_on_uninit: false,
+        safe_on_uninit,
     }
 }
 
@@ -268,7 +266,7 @@ mod tests {
         let single = vec![true, true];
         let kinds = vec![ArgTokenKind::Esc];
         let cmd = make_cmd(&args, &single, &kinds, None);
-        match try_lower_incr(&cmd) {
+        match try_lower_incr(&cmd, false) {
             Statement::Incr {
                 name,
                 amount,
@@ -289,7 +287,7 @@ mod tests {
         let single = vec![true, true, true];
         let kinds = vec![ArgTokenKind::Esc, ArgTokenKind::Esc];
         let cmd = make_cmd(&args, &single, &kinds, None);
-        match try_lower_incr(&cmd) {
+        match try_lower_incr(&cmd, false) {
             Statement::Incr { amount, .. } => assert_eq!(amount.as_deref(), Some("5")),
             other => panic!("expected Incr, got {other:?}"),
         }
@@ -301,7 +299,10 @@ mod tests {
         let single = vec![true];
         let kinds: Vec<ArgTokenKind> = vec![];
         let cmd = make_cmd(&args, &single, &kinds, None);
-        assert!(matches!(try_lower_incr(&cmd), Statement::Call { .. }));
+        assert!(matches!(
+            try_lower_incr(&cmd, false),
+            Statement::Call { .. }
+        ));
     }
 
     #[test]
@@ -311,7 +312,7 @@ mod tests {
         let kinds = vec![ArgTokenKind::Var];
         let expand = vec![false, true];
         let cmd = make_cmd(&args, &single, &kinds, Some(&expand));
-        match try_lower_incr(&cmd) {
+        match try_lower_incr(&cmd, false) {
             Statement::Call {
                 command, args: a, ..
             } => {

--- a/rust/tcl-compiler/src/lowering/mod.rs
+++ b/rust/tcl-compiler/src/lowering/mod.rs
@@ -116,6 +116,27 @@ struct DefinerCall {
 }
 
 impl Lowerer<'_> {
+    /// Whether this concrete invocation is declared to initialise an unset
+    /// target under the lowerer's active dialect profile.
+    ///
+    /// This is registry-driven: command form and Tcl release decide the
+    /// result, not a consumer-side command-name or read-modify-write rule.
+    fn safe_on_uninit(&self, command: &str, args: &[String]) -> bool {
+        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+        let dialect = self.registry.own_availability_mask();
+        // A profile-less registry is an intentionally dialect-blind union.
+        // `safe_on_uninit` is a release/runtime guarantee, so the union cannot
+        // prove it: in particular, `incr` differs between Tcl 8.4 and 8.5.
+        // Abstain until a concrete profile selects the applicable fact.
+        if dialect.is_empty() {
+            return false;
+        }
+        self.registry
+            .resolve_invocation(command, &arg_refs, dialect)
+            .and_then(|resolved| resolved.semantics.safe_on_uninit)
+            .is_some_and(|allowed| allowed.is_empty() || allowed.intersects(dialect))
+    }
+
     /// Classify one command as a statically-extractable definer call, from
     /// its registry spec (see [`DefinerCall`]).  `None` when the command is
     /// not a definer, uses a non-`create` metaclass form, or does not carry
@@ -1547,7 +1568,12 @@ impl<'r> Lowerer<'r> {
             arg_kinds: &Self::arg_kinds(seg),
             dialect: self.dialect,
         };
-        if let Some(stmt) = try_lower_hook(&hook_cmd, &self.aliases, self.registry) {
+        if let Some(stmt) = try_lower_hook(
+            &hook_cmd,
+            &self.aliases,
+            self.registry,
+            self.safe_on_uninit(cmd_name, args),
+        ) {
             return Some(stmt);
         }
 
@@ -2538,7 +2564,7 @@ impl<'r> Lowerer<'r> {
                 defs: var_defs,
                 reads: var_reads,
                 reads_own_defs: reads_before_write,
-                safe_on_uninit: false,
+                safe_on_uninit: self.safe_on_uninit(&role_cmd, &role_args),
                 tokens: Some(Self::cmd_tokens(seg)),
                 foreach_groups: None,
             };

--- a/rust/tcl-compiler/src/lowering/structured.rs
+++ b/rust/tcl-compiler/src/lowering/structured.rs
@@ -1097,7 +1097,7 @@ impl Lowerer<'_> {
                     defs: vec![var_name],
                     reads: vec![],
                     reads_own_defs: true,
-                    safe_on_uninit: false,
+                    safe_on_uninit: self.safe_on_uninit(seg.name(), args),
                     tokens: Some(Self::cmd_tokens(seg)),
                     foreach_groups: None,
                 }

--- a/rust/tcl-compiler/src/lowering_hooks.rs
+++ b/rust/tcl-compiler/src/lowering_hooks.rs
@@ -133,11 +133,12 @@ pub fn try_lower_hook(
     cmd: &LoweringCommand<'_>,
     aliases: &CommandAliasMap,
     registry: &CommandRegistry,
+    safe_on_uninit: bool,
 ) -> Option<Statement> {
     let arg_refs: Vec<&str> = cmd.args.iter().map(String::as_str).collect();
     let resolved = registry.resolve_invocation(cmd.name, &arg_refs, DialectSet::empty())?;
     let hook = resolved.semantics.lowering_hook?;
-    dispatch_lowering_hook(hook, cmd, aliases)
+    dispatch_lowering_hook(hook, cmd, aliases, safe_on_uninit)
 }
 
 /// Dispatch a typed [`LoweringHookId`] to its implementation.
@@ -153,6 +154,7 @@ pub fn dispatch_lowering_hook(
     hook: LoweringHookId,
     cmd: &LoweringCommand<'_>,
     aliases: &CommandAliasMap,
+    safe_on_uninit: bool,
 ) -> Option<Statement> {
     match hook {
         LoweringHookId::Expr => crate::lowering::hooks::control::try_lower_expr(cmd),
@@ -160,8 +162,11 @@ pub fn dispatch_lowering_hook(
             cmd, aliases,
         )),
         LoweringHookId::Set => Some(lower_set(cmd, aliases)),
-        LoweringHookId::Incr => Some(crate::lowering::hooks::incr::try_lower_incr(cmd)),
-        LoweringHookId::AppendOrLappend => lower_append_lappend(cmd),
+        LoweringHookId::Incr => Some(crate::lowering::hooks::incr::try_lower_incr(
+            cmd,
+            safe_on_uninit,
+        )),
+        LoweringHookId::AppendOrLappend => lower_append_lappend(cmd, safe_on_uninit),
         LoweringHookId::Unset => Some(lower_unset(cmd)),
         LoweringHookId::Global => lower_global(cmd),
         LoweringHookId::Variable => Some(lower_variable(cmd)),
@@ -409,7 +414,7 @@ fn lower_set(cmd: &LoweringCommand<'_>, aliases: &CommandAliasMap) -> Statement 
 
 // append / lappend
 
-fn lower_append_lappend(cmd: &LoweringCommand<'_>) -> Option<Statement> {
+fn lower_append_lappend(cmd: &LoweringCommand<'_>, safe_on_uninit: bool) -> Option<Statement> {
     if cmd.args.is_empty() {
         return None;
     }
@@ -444,7 +449,7 @@ fn lower_append_lappend(cmd: &LoweringCommand<'_>) -> Option<Statement> {
         defs,
         reads: vec![],
         reads_own_defs: true,
-        safe_on_uninit: false,
+        safe_on_uninit,
         tokens: cmd.tokens.clone(),
         foreach_groups: None,
     })
@@ -1095,7 +1100,7 @@ mod tests {
             arg_kinds: &kinds,
             dialect: None,
         };
-        let result = try_lower_hook(&cmd, &aliases, &registry);
+        let result = try_lower_hook(&cmd, &aliases, &registry, false);
         assert!(
             matches!(result, Some(Statement::AssignConst { .. })),
             "expected AssignConst from registry-driven dispatch; got {result:?}",
@@ -1122,6 +1127,6 @@ mod tests {
             arg_kinds: &kinds,
             dialect: None,
         };
-        assert!(try_lower_hook(&cmd, &aliases, &registry).is_none());
+        assert!(try_lower_hook(&cmd, &aliases, &registry, false).is_none());
     }
 }

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -480,6 +480,14 @@ fn run_store_to_load_forwarding(ctx: &mut PassContext<'_>, fu: &FunctionUnit) {
     use std::collections::BTreeSet;
     use tcl_dialect::DialectProfile;
 
+    // Like O102, O127 moves a value across statements. A dynamic or opaque
+    // variable name can change either the stored name or a name read by the
+    // expression under an unseen spelling, so this whole-function rewrite
+    // must honour the same fail-closed barrier (issue #1497).
+    if fu.dynamic_barrier_blocks_value_motion() {
+        return;
+    }
+
     let Some(registry) = ctx.registry else {
         return;
     };
@@ -1292,6 +1300,16 @@ fn run_function(
     namespace: &str,
     extra_escaping: &std::collections::HashSet<String>,
 ) {
+    // A computed or opaque variable name can rewrite any local binding under
+    // a spelling absent from SCCP's per-name lattice.  Do not let its raw
+    // constants reach the text-level folds below: unlike
+    // `run_load_forwarding`, this path used to bypass the shared dynamic-name
+    // guard and could emit (for example) `return 1` after a depth-capped
+    // nested substitution may have run `set $name 2` (issue #1497).
+    if fu.dynamic_barrier_blocks_value_motion() {
+        return;
+    }
+
     // Project the per-function SCCP lattice into a name → literal
     // map that survives only when every tracked version of the
     // variable collapses to the same single constant value. No
@@ -3640,6 +3658,40 @@ mod tests {
             opts.iter()
                 .all(|o| !matches!(o.code, DiagCode::O100 | DiagCode::O102)),
             "must not forward the pre-dynamic-write literal 1, got {opts:?}",
+        );
+    }
+
+    /// Issue #1497 — the native-stack depth cap is not evidence that no
+    /// dynamic write exists below it. Keep the actual O100/O102 consumer in
+    /// this regression: the source mutation is hidden past the cap, yet it
+    /// must still prevent forwarding the stale `x = 1` into the return.
+    #[test]
+    fn depth_exhaustion_blocks_dynamic_name_load_forwarding() {
+        let mut nested = "[set $name 2]".to_owned();
+        for _ in 0..=crate::depth_guard::MAX_BRACKET_TEXT_DEPTH.0 {
+            nested = format!("[list {nested}]");
+        }
+        let source = format!("proc ::f {{name}} {{ set x 1; set sink {nested}; return $x }}");
+        let reg = registry();
+        let cu = CompilationUnit::build_for(&source, &reg, false);
+        assert_eq!(
+            cu.function("::f")
+                .expect("procedure analysed")
+                .dynamic_names,
+            crate::dynamic_names::DynamicNameBarrier::OPAQUE_SCRIPT,
+            "the depth cap must fail closed before the optimiser runs"
+        );
+        let mut ctx = PassContext::new(&cu.source, InterproceduralAnalysis::default());
+        ctx.registry = Some(&reg);
+        ctx.ir_module = Some(&cu.ir_module);
+        run(&mut ctx, &cu);
+        let opts = ctx.optimisations;
+        assert!(
+            opts.iter().all(|opt| {
+                !matches!(opt.code, DiagCode::O100 | DiagCode::O102)
+                    || opt.replacement != "return 1"
+            }),
+            "a hidden dynamic write must block the stale return fold: {opts:?}"
         );
     }
 

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -1065,7 +1065,7 @@ pub fn existence_constant_branches(
     if cfg.blocks.values().any(|b| {
         b.statements
             .iter()
-            .any(|s| matches!(s, Statement::Barrier { .. }))
+            .any(|s| matches!(s, Statement::Barrier { .. } | Statement::UpFrame { .. }))
     }) {
         return out;
     }
@@ -2116,6 +2116,118 @@ mod tests {
         let e_pos = order.iter().position(|b| *b == e).unwrap();
         assert!(join_pos > t_pos);
         assert!(join_pos > e_pos);
+    }
+
+    /// Issue #1409 — a static-body `uplevel 0` is an `UpFrame`, not a generic
+    /// barrier, but its body can create a local in the frame whose existence
+    /// query follows. The whole-function existence fold must abstain just as
+    /// it does for `Barrier`.
+    #[test]
+    fn existence_fold_abstains_for_a_live_upframe() {
+        let registry = CommandRegistry::build_default();
+        let cu = crate::compilation_unit::CompilationUnit::build_for(
+            "proc f {} { uplevel 0 { set created 1 }; if {[info exists created]} { return yes } else { return no } }",
+            &registry,
+            false,
+        );
+        let f = cu.function("::f").expect("procedure analysed");
+        assert!(
+            f.cfg
+                .blocks
+                .values()
+                .flat_map(|block| block.statements.iter())
+                .any(|statement| matches!(statement, Statement::UpFrame { .. })),
+            "the regression requires the static uplevel lowering path"
+        );
+        assert!(
+            f.sccp.constant_branches.is_empty(),
+            "UpFrame may define `created`, so info exists must not fold: {:?}",
+            f.sccp.constant_branches
+        );
+    }
+
+    #[test]
+    fn existence_fold_abstains_for_nested_upframe_alias_unset_mutation() {
+        // `uplevel 0` evaluates in this procedure's frame. The nested body
+        // aliases that frame's parameter and unsets it, so Tcl observes the else
+        // branch. The no-uplevel twin proves the branch is otherwise foldable;
+        // this is a mutation test of the exact fact #1409 must block.
+        let registry = CommandRegistry::build_default();
+        let stable = crate::compilation_unit::CompilationUnit::build_for(
+            "proc f {local} { if {[info exists local]} { return yes } else { return no } }",
+            &registry,
+            false,
+        );
+        assert!(
+            !stable
+                .function("::f")
+                .expect("control procedure analysed")
+                .sccp
+                .constant_branches
+                .is_empty(),
+            "the unmutated control must be foldable"
+        );
+
+        let mutated = crate::compilation_unit::CompilationUnit::build_for(
+            "proc f {local} { uplevel 0 { uplevel 0 { upvar 0 local alias; unset alias } }; if {[info exists local]} { return yes } else { return no } }",
+            &registry,
+            false,
+        );
+        let f = mutated.function("::f").expect("mutated procedure analysed");
+        let outer = f
+            .cfg
+            .blocks
+            .values()
+            .flat_map(|block| block.statements.iter())
+            .find_map(|statement| match statement {
+                Statement::UpFrame { body, .. } => Some(body),
+                _ => None,
+            })
+            .expect("outer literal uplevel must lower to UpFrame");
+        assert!(
+            outer
+                .statements
+                .iter()
+                .any(|statement| matches!(statement, Statement::UpFrame { .. })),
+            "the nested literal uplevel must remain an UpFrame in its parent body"
+        );
+        assert!(
+            f.sccp.constant_branches.is_empty(),
+            "nested upframe/upvar/unset may remove local: {:?}",
+            f.sccp.constant_branches
+        );
+    }
+
+    #[test]
+    fn upframe_body_models_upvar_alias_unset_in_the_caller_frame() {
+        // tclsh: `proc caller {} {set caller_value 1; f; info exists
+        // caller_value}; proc f {} {uplevel 1 {upvar 0 caller_value alias;
+        // unset alias}}; caller` returns 0. The literal UpFrame body therefore
+        // carries a real caller-frame mutation, not merely a control-flow
+        // wrapper, and is a separate vector from the nested local-frame test.
+        let registry = CommandRegistry::build_default();
+        let cu = crate::compilation_unit::CompilationUnit::build_for(
+            "proc f {} { uplevel 1 { upvar 0 caller_value alias; unset alias } }",
+            &registry,
+            false,
+        );
+        let f = cu.function("::f").expect("procedure analysed");
+        let body = f
+            .cfg
+            .blocks
+            .values()
+            .flat_map(|block| block.statements.iter())
+            .find_map(|statement| match statement {
+                Statement::UpFrame { body, .. } => Some(body),
+                _ => None,
+            })
+            .expect("literal caller-frame body must lower to UpFrame");
+        assert!(body.statements.iter().any(|statement| {
+            matches!(statement, Statement::Call { command, .. } if command == "upvar")
+        }));
+        assert!(body.statements.iter().any(|statement| {
+            matches!(statement, Statement::Call { command, .. } if command == "unset")
+        }));
     }
 
     // -- driver --

--- a/rust/tcl-compiler/src/taint.rs
+++ b/rust/tcl-compiler/src/taint.rs
@@ -107,7 +107,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use tcl_dialect::DialectSet;
 use tcl_lexer::{Lexer, SourceMap, Span, TokenType, backslash_subst};
-use tcl_registry::{ArgRole, CommandRegistry, Traits};
+use tcl_registry::{ArgRole, CommandRegistry, TaintColourAtom, Traits};
 
 use crate::cfg::{BlockId, Function as CfgFunction, Terminator};
 use crate::depth_guard::{MAX_BRACKET_TEXT_DEPTH, MAX_EXPR_NODE_DEPTH};
@@ -165,6 +165,10 @@ bitflags! {
         const PORT               = 1 << 13;
         /// Value is a fully-qualified domain name.
         const FQDN               = 1 << 14;
+        /// Value was assembled via `[file join]`.
+        const PATH_JOINED        = 1 << 15;
+        /// Value is an I/O channel handle.
+        const CHANNEL            = 1 << 16;
     }
 }
 
@@ -187,7 +191,9 @@ impl TaintColour {
             | Self::URL_ENCODED.bits()
             | Self::IP_ADDRESS.bits()
             | Self::PORT.bits()
-            | Self::FQDN.bits(),
+            | Self::FQDN.bits()
+            | Self::PATH_JOINED.bits()
+            | Self::CHANNEL.bits(),
     );
 
     /// Colours that prove a value cannot start with `-` and so
@@ -376,11 +382,65 @@ fn source_colour(
     })
 }
 
-/// Bridge a `tcl_registry::TaintColour` to the compiler's mirror enum.
-/// The bit layouts are identical (registry is the canonical source), so
-/// a `from_bits_truncate` of the raw bits is exact.
+/// Bridge a registry colour to the compiler's mirror enum.
+///
+/// This must remain a total conversion: a registry bit must never disappear
+/// while crossing into the compiler's lattice. `from_bits` makes a future
+/// mismatch fail closed during development instead of silently truncating a
+/// sanitiser declaration (issue #1410).
+const fn compiler_colour_atom(atom: TaintColourAtom) -> TaintColour {
+    match atom {
+        TaintColourAtom::Tainted => TaintColour::TAINTED,
+        TaintColourAtom::PathPrefixed => TaintColour::PATH_PREFIXED,
+        TaintColourAtom::NonDashPrefixed => TaintColour::NON_DASH_PREFIXED,
+        TaintColourAtom::CrlfFree => TaintColour::CRLF_FREE,
+        TaintColourAtom::ShellAtom => TaintColour::SHELL_ATOM,
+        TaintColourAtom::ListCanonical => TaintColour::LIST_CANONICAL,
+        TaintColourAtom::RegexLiteral => TaintColour::REGEX_LITERAL,
+        TaintColourAtom::PathNormalised => TaintColour::PATH_NORMALISED,
+        TaintColourAtom::PathBounded => TaintColour::PATH_BOUNDED,
+        TaintColourAtom::HeaderTokenSafe => TaintColour::HEADER_TOKEN_SAFE,
+        TaintColourAtom::HtmlEscaped => TaintColour::HTML_ESCAPED,
+        TaintColourAtom::UrlEncoded => TaintColour::URL_ENCODED,
+        TaintColourAtom::IpAddress => TaintColour::IP_ADDRESS,
+        TaintColourAtom::Port => TaintColour::PORT,
+        TaintColourAtom::Fqdn => TaintColour::FQDN,
+        TaintColourAtom::PathJoined => TaintColour::PATH_JOINED,
+        TaintColourAtom::Channel => TaintColour::CHANNEL,
+    }
+}
+
 fn reg_colour(c: tcl_registry::TaintColour) -> TaintColour {
-    TaintColour::from_bits_truncate(c.bits())
+    let mut out = TaintColour::empty();
+    for atom in TaintColourAtom::ALL {
+        if c.contains(atom.colour()) {
+            out |= compiler_colour_atom(atom);
+        }
+    }
+    assert_eq!(
+        out.bits(),
+        c.bits(),
+        "registry and compiler TaintColour definitions must stay aligned"
+    );
+    out
+}
+
+/// The inverse bridge, kept beside [`reg_colour`] so conversions stay audited
+/// in both directions whenever the registry adds a colour.
+#[cfg(test)]
+fn compiler_colour(c: TaintColour) -> tcl_registry::TaintColour {
+    let mut out = tcl_registry::TaintColour::empty();
+    for atom in TaintColourAtom::ALL {
+        if c.contains(compiler_colour_atom(atom)) {
+            out |= atom.colour();
+        }
+    }
+    assert_eq!(
+        out.bits(),
+        c.bits(),
+        "compiler and registry TaintColour definitions must stay aligned"
+    );
+    out
 }
 
 /// The colour a command stamps on a tainted value it returns — its
@@ -4775,6 +4835,79 @@ mod tests {
         // Must not spill into unrelated colours.
         assert!(!TaintColour::REDIRECT_SAFE.contains(TaintColour::TAINTED));
         assert!(!TaintColour::REDIRECT_SAFE.contains(TaintColour::CRLF_FREE));
+    }
+
+    /// Issue #1410 — the compiler and registry colour domains are a bijection.
+    /// Keep both directions pinned so a future colour cannot be silently
+    /// dropped by a permissive bitflags conversion.
+    #[test]
+    fn registry_taint_colour_bridge_preserves_every_bit_in_both_directions() {
+        let registry_all = tcl_registry::TaintColour::all();
+        let compiler_all = TaintColour::all();
+        assert_eq!(reg_colour(registry_all), compiler_all);
+        assert_eq!(compiler_colour(compiler_all), registry_all);
+        for colour in [
+            tcl_registry::TaintColour::TAINTED,
+            tcl_registry::TaintColour::PATH_PREFIXED,
+            tcl_registry::TaintColour::NON_DASH_PREFIXED,
+            tcl_registry::TaintColour::CRLF_FREE,
+            tcl_registry::TaintColour::SHELL_ATOM,
+            tcl_registry::TaintColour::LIST_CANONICAL,
+            tcl_registry::TaintColour::REGEX_LITERAL,
+            tcl_registry::TaintColour::PATH_NORMALISED,
+            tcl_registry::TaintColour::PATH_BOUNDED,
+            tcl_registry::TaintColour::HEADER_TOKEN_SAFE,
+            tcl_registry::TaintColour::HTML_ESCAPED,
+            tcl_registry::TaintColour::URL_ENCODED,
+            tcl_registry::TaintColour::IP_ADDRESS,
+            tcl_registry::TaintColour::PORT,
+            tcl_registry::TaintColour::FQDN,
+            tcl_registry::TaintColour::PATH_JOINED,
+            tcl_registry::TaintColour::CHANNEL,
+        ] {
+            let compiler = reg_colour(colour);
+            assert_eq!(compiler_colour(compiler), colour, "round-trip {colour:?}");
+        }
+    }
+
+    #[test]
+    fn file_join_transform_reaches_the_live_cfg_taint_lattice() {
+        use crate::compilation_unit::CompilationUnit;
+
+        let registry = CommandRegistry::build_default();
+        let colour_for = |source: &str, name: &str| {
+            let cu = CompilationUnit::build_for(source, &registry, false);
+            let fu = cu.function("::top").expect("top-level CFG built");
+            fu.taints
+                .iter()
+                .find(|((symbol, _), _)| fu.ssa.var_name(*symbol) == name)
+                .map(|(_, taint)| *taint)
+                .expect("assignment has a live SSA taint value")
+        };
+
+        let joined = colour_for(
+            "set raw [gets stdin]\nset joined [file join /base $raw]",
+            "joined",
+        );
+        assert!(joined.is_tainted(), "the source taint must reach file join");
+        assert!(
+            joined.colours.contains(TaintColour::PATH_JOINED),
+            "file join's registry transform must reach the CFG taint lattice: {joined:?}"
+        );
+
+        // Mutation control: replacing the transform-bearing `file join` with
+        // a same-shape non-transform command removes the only PATH_JOINED
+        // producer. If `word_taint_at` stopped applying registry transforms,
+        // this and the live vector above would become indistinguishable.
+        let without_transform = colour_for(
+            "set raw [gets stdin]\nset joined [file tail $raw]",
+            "joined",
+        );
+        assert!(without_transform.is_tainted());
+        assert!(
+            !without_transform.colours.contains(TaintColour::PATH_JOINED),
+            "the mutation control must not inherit file join's transform: {without_transform:?}"
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/taint_interproc.rs
+++ b/rust/tcl-compiler/src/taint_interproc.rs
@@ -56,7 +56,7 @@ use crate::value_shapes::parse_command_substitution;
 /// Ordered taint-colour bases. The
 /// per-parameter return scenarios are computed by seeding the parameter with
 /// each basis lattice in turn.
-const BASIS_ORDER: [&str; 15] = [
+const BASIS_ORDER: [&str; 17] = [
     "generic",
     "path",
     "non_dash",
@@ -72,12 +72,15 @@ const BASIS_ORDER: [&str; 15] = [
     "ip",
     "port",
     "fqdn",
+    "path_joined",
+    "channel",
 ];
 
 /// The taint lattice each basis name seeds a parameter with.
 fn basis_lattice(basis: &str) -> TaintLattice {
     let t = TaintColour::TAINTED;
     let colour = match basis {
+        "generic" => t,
         "path" => t | TaintColour::PATH_PREFIXED,
         "non_dash" => t | TaintColour::NON_DASH_PREFIXED,
         "crlf_free" => t | TaintColour::CRLF_FREE,
@@ -94,7 +97,9 @@ fn basis_lattice(basis: &str) -> TaintLattice {
         "ip" => t | TaintColour::IP_ADDRESS,
         "port" => t | TaintColour::PORT,
         "fqdn" => t | TaintColour::FQDN,
-        _ => t,
+        "path_joined" => t | TaintColour::PATH_JOINED,
+        "channel" => t | TaintColour::CHANNEL,
+        unknown => panic!("BASIS_ORDER contains unknown taint basis {unknown:?}"),
     };
     TaintLattice { colours: colour }
 }
@@ -277,7 +282,7 @@ fn word_uses_from_versions(
 ///
 /// This is the cheap end of the pruning ladder and by far the most common case
 /// in real Tcl: a procedure that returns nothing, a literal, or a braced
-/// constant does no work here at all instead of `1 + 15P` whole-CFG solves.
+/// constant does no work here at all instead of `1 + 17P` whole-CFG solves.
 fn return_taint_is_constant(fu: &FunctionUnit) -> bool {
     fu.sccp.executable_blocks.iter().all(|bn| {
         let Some(block) = fu.cfg.blocks.get(bn) else {
@@ -390,7 +395,7 @@ pub type InferProcSummaryFn<'a> = dyn FnMut(
 ///
 /// The summary is a transfer function: a clean base plus, for each parameter, a
 /// return taint per [`BASIS_ORDER`] entry.  Computed naively that is
-/// `1 + BASIS_ORDER.len() * params.len()` — `1 + 15P` — complete dataflow
+/// `1 + BASIS_ORDER.len() * params.len()` — `1 + 17P` — complete dataflow
 /// solves over the procedure's CFG, and this is the dominant cost of the whole
 /// interprocedural taint pass (about 80% of `run_all_checks` on tcllib's
 /// `practcl.tcl`).
@@ -403,13 +408,13 @@ pub type InferProcSummaryFn<'a> = dyn FnMut(
 ///
 /// 1. [`return_taint_is_constant`] — the return taint cannot depend on the
 ///    taint map, so the whole summary is the clean one: **0** solves instead of
-///    `1 + 15P`.
+///    `1 + 17P`.
 /// 2. An un-interned parameter — seeding a name the body never reads leaves the
 ///    initial taint map bit-identical to the base run's, so the scenario *is*
-///    `return_base`: **0** solves instead of 15, per such parameter.
+///    `return_base`: **0** solves instead of 17, per such parameter.
 ///
-/// What remains is `1 + 15 × (parameters that are actually read, in a procedure
-/// whose return value is substitution-bearing)`.  Collapsing that last `15×`
+/// What remains is `1 + 17 × (parameters that are actually read, in a procedure
+/// whose return value is substitution-bearing)`.  Collapsing that last `17×`
 /// needs a genuinely different representation — one multi-colour symbolic
 /// traversal carrying a per-`(parameter, basis)` dependency bitset — which
 /// changes what the solver computes rather than skipping work it can prove
@@ -436,7 +441,7 @@ pub fn infer_proc_summary(
     summaries: &HashMap<String, ProcTaintSummary>,
 ) -> ProcTaintSummary {
     // Prune 1 — the return taint does not depend on the taint map at all, so
-    // neither the clean base nor any of the `15P` seeded scenarios needs a
+    // neither the clean base nor any of the `17P` seeded scenarios needs a
     // solve.  Every scenario is `clean`, which is exactly what
     // `ProcTaintSummary::untainted` builds.  Checked before the index build
     // below, so a constant-return procedure costs nothing at all.
@@ -1241,7 +1246,7 @@ mod tests {
     #[test]
     fn unread_parameter_scenarios_equal_the_base_return() {
         // `b` is never read, so seeding it cannot change the return: every one
-        // of its 15 basis scenarios is exactly `return_base`.
+        // of its 17 basis scenarios is exactly `return_base`.
         let summaries = summaries_for("proc half {a b} { return [string cat $a x] }\n");
         let s = summaries.get("::half").expect("::half summarised");
         let (name, values) = s

--- a/rust/tcl-compiler/tests/checks.rs
+++ b/rust/tcl-compiler/tests/checks.rs
@@ -567,6 +567,20 @@ mod path_concatenation {
     }
 
     #[test]
+    fn file_join_transform_does_not_masquerade_as_normalisation() {
+        // End-to-end registry transform coverage for #1410: `file join`
+        // stamps PATH_JOINED on a tainted result, but it does not collapse
+        // traversal or otherwise prove the preceding manual concatenation
+        // safe. W201 must therefore still report the original assignment.
+        let source = "set raw [read $fd]\nset p \"/base/$raw\"\nset p [file join /base $raw]\n";
+        assert_eq!(
+            taint_of_code(source, D, "W201").len(),
+            1,
+            "PATH_JOINED must not suppress the W201 portability hint"
+        );
+    }
+
+    #[test]
     fn url_scheme_not_path_concat() {
         // A URL is not a filesystem path → no W201.
         assert!(!fires("set u http://example.com/$page", D, "W201"));

--- a/rust/tcl-compiler/tests/taint_depth.rs
+++ b/rust/tcl-compiler/tests/taint_depth.rs
@@ -174,6 +174,8 @@ mod colour_masks {
             TaintColour::IP_ADDRESS,
             TaintColour::PORT,
             TaintColour::FQDN,
+            TaintColour::PATH_JOINED,
+            TaintColour::CHANNEL,
         ] {
             assert!(TaintColour::ALL.contains(c), "ALL missing {c:?}");
         }

--- a/rust/tcl-compiler/tests/unused_var_tricky_features.rs
+++ b/rust/tcl-compiler/tests/unused_var_tricky_features.rs
@@ -50,7 +50,8 @@
 use tcl_compiler::analyser::Analyser;
 use tcl_compiler::compilation_unit::CompilationUnit;
 use tcl_compiler::compiler_checks::run_all_checks;
-use tcl_registry::registry_for_dialect;
+use tcl_compiler::ir::Statement;
+use tcl_registry::{CommandRegistry, registry_for_dialect};
 
 /// Default dialect: the C Tcl 9 truth oracle (issue #941). The scoping
 /// constructs exercised here behave identically on 8.4–9.0.
@@ -360,5 +361,74 @@ mod read_before_set_tps {
             "namespace eval ::n {}\nproc ::n::f {} { return $missing }\n",
             "W210"
         ));
+    }
+
+    /// Issue #1403 — safe read-modify-write is a registry and dialect fact,
+    /// rather than a blanket `reads_own_defs` exemption. Tcl 8.6's declared
+    /// self-initialisers are silent, while `incr` under Tcl 8.4 keeps W210.
+    #[test]
+    fn safe_on_uninit_is_lowered_from_the_active_dialect_profile() {
+        for source in [
+            "proc f {} { append value x }\n",
+            "proc f {} { lappend value x }\n",
+            "proc f {} { dict set value key x }\n",
+            "proc f {} { incr value }\n",
+        ] {
+            assert!(
+                !codes(source, "tcl8.6").iter().any(|code| code == "W210"),
+                "safe Tcl 8.6 self-initialiser fired W210: {source:?}"
+            );
+        }
+        assert!(
+            codes("proc f {} { incr value }\n", "tcl8.4")
+                .iter()
+                .any(|code| code == "W210"),
+            "Tcl 8.4 must not inherit Tcl 8.5+'s incr self-initialisation"
+        );
+        for source in [
+            "proc f {} { append value x }\n",
+            "proc f {} { lappend value x }\n",
+        ] {
+            assert!(
+                !codes(source, "tcl8.4").iter().any(|code| code == "W210"),
+                "safe Tcl 8.4 self-initialiser fired W210: {source:?}"
+            );
+            assert!(
+                !codes(source, "f5-irules").iter().any(|code| code == "W210"),
+                "safe iRules self-initialiser fired W210: {source:?}"
+            );
+        }
+        assert!(
+            codes("proc f {} { incr value }\n", "f5-irules")
+                .iter()
+                .any(|code| code == "W210"),
+            "iRules' Tcl 8.4 base must not inherit Tcl 8.5+'s incr self-initialisation"
+        );
+    }
+
+    #[test]
+    fn profileless_registry_abstains_in_the_lowered_ir() {
+        // A profile-less registry is the union command table, not evidence of
+        // one release's runtime behaviour. The typed IR must therefore retain
+        // the conservative false fact before W210 consumes it.
+        let registry = CommandRegistry::build_default();
+        let cu = CompilationUnit::build_for("proc f {} { incr value }\n", &registry, false);
+        let f = cu.function("::f").expect("procedure analysed");
+        assert!(
+            f.cfg
+                .blocks
+                .values()
+                .flat_map(|block| &block.statements)
+                .any(|stmt| {
+                    matches!(
+                        stmt,
+                        Statement::Incr {
+                            safe_on_uninit: false,
+                            ..
+                        }
+                    )
+                }),
+            "profile-less lowering must not claim Tcl 8.5+ incr semantics"
+        );
     }
 }

--- a/rust/tcl-registry/src/commands/tcl/append_.rs
+++ b/rust/tcl-registry/src/commands/tcl/append_.rs
@@ -51,7 +51,10 @@ pub fn spec() -> CommandSpec {
         byte_array_effect: ByteArrayEffect::Coerces,
         arg_roles: &[(0, ArgRole::VarWrite)],
         assigns_variable_at: Some(0),
-        safe_on_uninit: Some(DialectSet::ALL_TCL),
+        // iRules embeds Tcl 8.4.6 and retains append's documented
+        // auto-creation behaviour. Its bare availability mask therefore
+        // needs an explicit membership bit alongside the ordinary Tcl cores.
+        safe_on_uninit: Some(DialectSet::ALL_TCL.union(DialectSet::IRULES)),
         return_type: Some(TclType::String),
         arg_types: &[(
             0,

--- a/rust/tcl-registry/src/commands/tcl/lappend_.rs
+++ b/rust/tcl-registry/src/commands/tcl/lappend_.rs
@@ -39,7 +39,10 @@ pub fn spec() -> CommandSpec {
         arity: Arity::at_least(1),
         arg_roles: &[(0, ArgRole::VarWrite)],
         assigns_variable_at: Some(0),
-        safe_on_uninit: Some(DialectSet::ALL_TCL),
+        // iRules embeds Tcl 8.4.6 and retains lappend's documented
+        // auto-creation behaviour; its bare profile mask needs explicit
+        // membership alongside the ordinary Tcl cores.
+        safe_on_uninit: Some(DialectSet::ALL_TCL.union(DialectSet::IRULES)),
         return_type: Some(TclType::List),
         var_elements_effect: Some(VarElementsEffect::AppendsListElements { values_from: 1 }),
         representation_effect: Some(RepresentationEffect::copy_on_write_container(0, 2)),

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -194,7 +194,7 @@ pub mod prelude {
         VariableCellAliasTransition,
     };
     pub use crate::symbol_def::{DefinedSymbolKind, SymbolDef};
-    pub use crate::taint::{SetterConstraint, TaintColour};
+    pub use crate::taint::{SetterConstraint, TaintColour, TaintColourAtom};
     pub use crate::traits::Traits;
     pub use crate::types::{ReturnElements, TclType, VarElementsEffect, VarWriteTyping};
     pub use crate::world_effect::{
@@ -286,7 +286,7 @@ pub use state_transition::{
     TransitionSubject, VariableAliasTarget, VariableCellAliasTransition,
 };
 pub use symbol_def::{DefinedSymbolKind, SymbolDef};
-pub use taint::{SetterConstraint, TaintColour};
+pub use taint::{SetterConstraint, TaintColour, TaintColourAtom};
 pub use traits::{FRAME_REACH_TRAITS, Traits, UNIT_LINKAGE_TRAITS};
 pub use types::{ReturnElements, TclType, VarElementsEffect, VarWriteTyping};
 pub use world_effect::{

--- a/rust/tcl-registry/src/resolved_invocation.rs
+++ b/rust/tcl-registry/src/resolved_invocation.rs
@@ -150,6 +150,9 @@ fn resolve_invocation_semantics<'r>(
             form: form.map_or(&[], |form| form.options),
         },
         return_type: sub.map_or(spec.return_type, |sub| sub.return_type),
+        safe_on_uninit: sub
+            .and_then(|sub| sub.safe_on_uninit)
+            .or(spec.safe_on_uninit),
         var_write_typing: sub.map_or(spec.var_write_typing, |sub| sub.var_write_typing),
         return_elements: sub.map_or(spec.return_elements, |sub| sub.return_elements),
         var_elements_effect: sub.map_or(spec.var_elements_effect, |sub| sub.var_elements_effect),
@@ -488,6 +491,8 @@ pub struct InvocationSemantics<'r> {
     pub options: InvocationOptions<'r>,
     /// Result Tcl internal-representation type, when declared.
     pub return_type: Option<TclType>,
+    /// Dialects in which this invocation safely initialises an unset target.
+    pub safe_on_uninit: Option<crate::dialects::DialectSet>,
     /// How the invocation types variables it writes.
     pub var_write_typing: VarWriteTyping,
     /// Result-to-container-element relationship, when declared.
@@ -914,6 +919,20 @@ mod tests {
             name: "plain",
             arity: Arity::exact(0),
             completion: Some(CompletionDescriptor::exact(SUBCOMMAND_CODES)),
+            ..SubCommand::DEFAULT
+        },
+    ];
+
+    const SAFE_ON_UNINIT_SUBCOMMANDS: &[SubCommand] = &[
+        SubCommand {
+            name: "narrow",
+            arity: Arity::exact(0),
+            safe_on_uninit: Some(DialectSet::TCL85_PLUS),
+            ..SubCommand::DEFAULT
+        },
+        SubCommand {
+            name: "inherit",
+            arity: Arity::exact(0),
             ..SubCommand::DEFAULT
         },
     ];
@@ -1699,6 +1718,34 @@ mod tests {
                 .dispatch_dependencies
                 .contains(DispatchDependencyDomain::UnknownHandling),
             "static registry resolution is not itself a live-dispatch proof"
+        );
+    }
+
+    #[test]
+    fn safe_on_uninit_resolves_from_the_matched_subcommand() {
+        let mut registry = CommandRegistry::build_default();
+        registry.insert(CommandSpec {
+            name: "safe-on-uninit-fixture",
+            arity: Arity::any(),
+            safe_on_uninit: Some(DialectSet::ALL_TCL),
+            subcommands: SAFE_ON_UNINIT_SUBCOMMANDS,
+            ..CommandSpec::DEFAULT
+        });
+
+        let narrow = registry
+            .resolve_invocation("safe-on-uninit-fixture", &["narrow"], DialectSet::empty())
+            .expect("fixture subcommand resolves");
+        assert_eq!(
+            narrow.semantics.safe_on_uninit,
+            Some(DialectSet::TCL85_PLUS)
+        );
+
+        let inherited = registry
+            .resolve_invocation("safe-on-uninit-fixture", &["inherit"], DialectSet::empty())
+            .expect("fixture subcommand resolves");
+        assert_eq!(
+            inherited.semantics.safe_on_uninit,
+            Some(DialectSet::ALL_TCL)
         );
     }
 

--- a/rust/tcl-registry/src/taint.rs
+++ b/rust/tcl-registry/src/taint.rs
@@ -52,39 +52,131 @@ bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct TaintColour: u32 {
         /// Value is attacker-controlled.
-        const TAINTED            = 1 << 0;
+        const TAINTED            = TaintColourAtom::Tainted as u32;
         /// Always starts with `/` (`HTTP::uri`, `HTTP::path`).
-        const PATH_PREFIXED      = 1 << 1;
+        const PATH_PREFIXED      = TaintColourAtom::PathPrefixed as u32;
         /// Provably starts with a non-`-` literal.
-        const NON_DASH_PREFIXED  = 1 << 2;
+        const NON_DASH_PREFIXED  = TaintColourAtom::NonDashPrefixed as u32;
         /// Proven to contain no CR/LF characters.
-        const CRLF_FREE          = 1 << 3;
+        const CRLF_FREE          = TaintColourAtom::CrlfFree as u32;
         /// Token-safe atom (no shell metachar splitting).
-        const SHELL_ATOM         = 1 << 4;
+        const SHELL_ATOM         = TaintColourAtom::ShellAtom as u32;
         /// Canonical Tcl list representation.
-        const LIST_CANONICAL     = 1 << 5;
+        const LIST_CANONICAL     = TaintColourAtom::ListCanonical as u32;
         /// Regex-escaped literal payload.
-        const REGEX_LITERAL      = 1 << 6;
+        const REGEX_LITERAL      = TaintColourAtom::RegexLiteral as u32;
         /// Path has been normalised (no raw traversal form).
-        const PATH_NORMALISED    = 1 << 7;
+        const PATH_NORMALISED    = TaintColourAtom::PathNormalised as u32;
         /// Normalised path verified within an intended directory.
-        const PATH_BOUNDED       = 1 << 8;
+        const PATH_BOUNDED       = TaintColourAtom::PathBounded as u32;
         /// Valid HTTP header-token charset.
-        const HEADER_TOKEN_SAFE  = 1 << 9;
+        const HEADER_TOKEN_SAFE  = TaintColourAtom::HeaderTokenSafe as u32;
         /// HTML-escaped text context.
-        const HTML_ESCAPED       = 1 << 10;
+        const HTML_ESCAPED       = TaintColourAtom::HtmlEscaped as u32;
         /// URL-encoded text context.
-        const URL_ENCODED        = 1 << 11;
+        const URL_ENCODED        = TaintColourAtom::UrlEncoded as u32;
         /// IPv4 or IPv6 address (digits, dots, colons).
-        const IP_ADDRESS         = 1 << 12;
+        const IP_ADDRESS         = TaintColourAtom::IpAddress as u32;
         /// Integer 0-65535.
-        const PORT               = 1 << 13;
+        const PORT               = TaintColourAtom::Port as u32;
         /// Fully qualified domain name.
-        const FQDN               = 1 << 14;
+        const FQDN               = TaintColourAtom::Fqdn as u32;
         /// Assembled via `[file join]` (portable, not canonicalised).
-        const PATH_JOINED        = 1 << 15;
+        const PATH_JOINED        = TaintColourAtom::PathJoined as u32;
         /// I/O channel handle (`open`, `socket`, `chan create`, `HSL::open`).
-        const CHANNEL            = 1 << 16;
+        const CHANNEL            = TaintColourAtom::Channel as u32;
+    }
+}
+
+/// One atomic [`TaintColour`] declaration.
+///
+/// This owner-defined enum is the compile-time exhaustiveness boundary for
+/// consumers that mirror the colour lattice. Adding a registry colour requires
+/// adding an atom here, which makes every downstream exhaustive match fail to
+/// compile until it maps the new declaration deliberately.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TaintColourAtom {
+    /// [`TaintColour::TAINTED`].
+    Tainted = 1 << 0,
+    /// [`TaintColour::PATH_PREFIXED`].
+    PathPrefixed = 1 << 1,
+    /// [`TaintColour::NON_DASH_PREFIXED`].
+    NonDashPrefixed = 1 << 2,
+    /// [`TaintColour::CRLF_FREE`].
+    CrlfFree = 1 << 3,
+    /// [`TaintColour::SHELL_ATOM`].
+    ShellAtom = 1 << 4,
+    /// [`TaintColour::LIST_CANONICAL`].
+    ListCanonical = 1 << 5,
+    /// [`TaintColour::REGEX_LITERAL`].
+    RegexLiteral = 1 << 6,
+    /// [`TaintColour::PATH_NORMALISED`].
+    PathNormalised = 1 << 7,
+    /// [`TaintColour::PATH_BOUNDED`].
+    PathBounded = 1 << 8,
+    /// [`TaintColour::HEADER_TOKEN_SAFE`].
+    HeaderTokenSafe = 1 << 9,
+    /// [`TaintColour::HTML_ESCAPED`].
+    HtmlEscaped = 1 << 10,
+    /// [`TaintColour::URL_ENCODED`].
+    UrlEncoded = 1 << 11,
+    /// [`TaintColour::IP_ADDRESS`].
+    IpAddress = 1 << 12,
+    /// [`TaintColour::PORT`].
+    Port = 1 << 13,
+    /// [`TaintColour::FQDN`].
+    Fqdn = 1 << 14,
+    /// [`TaintColour::PATH_JOINED`].
+    PathJoined = 1 << 15,
+    /// [`TaintColour::CHANNEL`].
+    Channel = 1 << 16,
+}
+
+impl TaintColourAtom {
+    /// Every registry-defined colour atom, in stable bit order.
+    pub const ALL: [Self; 17] = [
+        Self::Tainted,
+        Self::PathPrefixed,
+        Self::NonDashPrefixed,
+        Self::CrlfFree,
+        Self::ShellAtom,
+        Self::ListCanonical,
+        Self::RegexLiteral,
+        Self::PathNormalised,
+        Self::PathBounded,
+        Self::HeaderTokenSafe,
+        Self::HtmlEscaped,
+        Self::UrlEncoded,
+        Self::IpAddress,
+        Self::Port,
+        Self::Fqdn,
+        Self::PathJoined,
+        Self::Channel,
+    ];
+
+    /// The registry bit represented by this atom.
+    #[must_use]
+    pub const fn colour(self) -> TaintColour {
+        match self {
+            Self::Tainted => TaintColour::TAINTED,
+            Self::PathPrefixed => TaintColour::PATH_PREFIXED,
+            Self::NonDashPrefixed => TaintColour::NON_DASH_PREFIXED,
+            Self::CrlfFree => TaintColour::CRLF_FREE,
+            Self::ShellAtom => TaintColour::SHELL_ATOM,
+            Self::ListCanonical => TaintColour::LIST_CANONICAL,
+            Self::RegexLiteral => TaintColour::REGEX_LITERAL,
+            Self::PathNormalised => TaintColour::PATH_NORMALISED,
+            Self::PathBounded => TaintColour::PATH_BOUNDED,
+            Self::HeaderTokenSafe => TaintColour::HEADER_TOKEN_SAFE,
+            Self::HtmlEscaped => TaintColour::HTML_ESCAPED,
+            Self::UrlEncoded => TaintColour::URL_ENCODED,
+            Self::IpAddress => TaintColour::IP_ADDRESS,
+            Self::Port => TaintColour::PORT,
+            Self::Fqdn => TaintColour::FQDN,
+            Self::PathJoined => TaintColour::PATH_JOINED,
+            Self::Channel => TaintColour::CHANNEL,
+        }
     }
 }
 
@@ -409,6 +501,14 @@ pub fn setter_constraints(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn colour_atoms_cover_the_canonical_bitflags_domain() {
+        let atoms = TaintColourAtom::ALL
+            .into_iter()
+            .fold(TaintColour::empty(), |bits, atom| bits | atom.colour());
+        assert_eq!(atoms, TaintColour::all());
+    }
 
     #[test]
     fn gets_is_a_taint_source() {

--- a/rust/tcl-spec-studio/src/help.rs
+++ b/rust/tcl-spec-studio/src/help.rs
@@ -307,10 +307,11 @@ quiet, and rename reaches the name.",
         "Whether the command may be handed a variable name that does not \
 exist yet. `lappend v x` happily creates `v`; so does `append`. `incr` \
 creates it in Tcl 8.5+ but errors in 8.4 — which is why this is a *set of \
-dialects* rather than yes/no.\n\nNote: today the \"variable read before \
-set\" warning is actually kept quiet by declaring the argument a written \
-variable (a VarWrite role); this field records the version fact but is not \
-yet consulted by that check.",
+dialects* rather than yes/no.\n\nThe compiler resolves this set for the \
+active profile, stores the result in lowered IR, and W210 uses it for the \
+command's own read-before-write. A VarWrite role still records the eventual \
+definition. Without a concrete profile, lowering abstains and treats the \
+operation as not safe.",
     ),
     (
         "const_fold",


### PR DESCRIPTION
## Issues

Closes #1497.
Closes #1409.
Closes #1410.
Closes #1403.

## Root cause

- Dynamic-name scanning exhausted its depth budget without recording an opaque-script barrier, allowing value motion across a hidden computed write.
- SCCP existence folding treated `Barrier` conservatively but not the equivalent caller-frame `UpFrame` effect.
- The compiler taint mirror truncated registry colours above bit 14, dropping `PATH_JOINED` and `CHANNEL`.
- Registry `safe_on_uninit` facts never reached IR, while a broad analyser exemption masked the dead plumbing.

## Fix

- Fail closed at dynamic-name depth exhaustion and route O100/O102/O127 value motion through the shared barrier.
- Treat `Barrier | UpFrame` consistently for existence folding.
- Introduce a registry-owned exhaustive taint-colour atom boundary and map it into the compiler without wildcard matches.
- Resolve `safe_on_uninit` through the active registry/profile at lowering, including subcommands and typed `incr`, and make profileless lowering abstain.

## Dialect/release behaviour

- Tcl 8.4 and Tcl 8.6 vectors cover release-sensitive `incr` behaviour.
- iRules vectors preserve Tcl-core `append`/`lappend` self-initialisation while retaining the Tcl 8.5 floor for `incr`.
- A profileless registry deliberately emits `safe_on_uninit: false` rather than guessing.

## Duplication audit

- Audited every `DynamicNameBarrier` consumer and added missing propagation guards.
- Audited both registry/compiler taint conversion directions and interprocedural bases.
- Audited generic, structured, hook, and `incr` lowering paths for `safe_on_uninit`.

## Tests

- Depth-cap mutation regression over a hidden computed write.
- Nested/caller-frame `upvar` + `unset` UpFrame vectors.
- Bidirectional exhaustive taint-colour bridge and live CFG `PATH_JOINED` propagation.
- W201 path-transform integration regression.
- Tcl 8.4/8.6, iRules, subcommand, and profileless `safe_on_uninit` vectors.
- Two independent adversarial reviews: semantics/architecture and tests/callers/performance.

## Gates

- `make rust-check`
- `make prep-pr`
- `make test-rust` (canonical local target includes native LSP E2E; there is no standalone `make lsp-e2e` target)
- `make test-ext`

All passed on `fa2492b79`.

## Generated artefacts/docs

- Updated the taint-analysis design documentation.
- No diagnostic catalogue or generated editor settings changed.

## Performance

The interprocedural taint basis grows from 15 to 17 colours, increasing the documented worst-case inner solve matrix from `1 + 15P` to `1 + 17P`; existing constant/unread-parameter pruning remains. Focused review found no observed regression. This PR will also be measured in the final #1181 corpus sweep.
