### PR TITLE
Preserve VM command surface through indirection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4258,6 +4258,7 @@ dependencies = [
  "tcl-compiler",
  "tcl-dialect",
  "tcl-engine-api",
+ "tcl-lexer",
  "tcl-registry",
  "tcl-vm",
 ]
@@ -4486,6 +4487,7 @@ name = "tcl-runtime-api"
 version = "0.1.0"
 dependencies = [
  "tcl-core-types",
+ "tcl-dialect",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4127,6 +4127,7 @@ dependencies = [
 name = "tcl-bytecode"
 version = "0.1.0"
 dependencies = [
+ "tcl-dialect",
  "tcl-lexer",
  "tcl-syntax",
 ]

--- a/runtime/rust/Cargo.lock
+++ b/runtime/rust/Cargo.lock
@@ -252,6 +252,7 @@ name = "tcl-runtime-api"
 version = "0.1.0"
 dependencies = [
  "tcl-core-types",
+ "tcl-dialect",
 ]
 
 [[package]]

--- a/rust/tcl-bytecode/Cargo.toml
+++ b/rust/tcl-bytecode/Cargo.toml
@@ -44,6 +44,7 @@ authors.workspace = true
 description = "Tcl 9 bytecode artifact types (opcodes, instructions, FunctionAsm/ModuleAsm, layout, disassembly)"
 
 [dependencies]
+tcl-dialect = { path = "../tcl-dialect" }
 tcl-lexer = { path = "../tcl-lexer" }
 tcl-syntax = { path = "../tcl-syntax" }
 

--- a/rust/tcl-bytecode/src/lib.rs
+++ b/rust/tcl-bytecode/src/lib.rs
@@ -1374,6 +1374,10 @@ pub struct ErrorRegion {
 /// Assembly for an entire module.
 #[derive(Debug, Clone)]
 pub struct ModuleAsm {
+    /// Exact interned dialect profile selected during lowering/codegen.  A VM
+    /// must reject an AOT module compiled for another profile rather than
+    /// treating its specialised opcodes as belonging to its current surface.
+    pub profile: &'static tcl_dialect::DialectProfile,
     /// Top-level script assembly.
     pub top_level: FunctionAsm,
     /// Procedure assemblies keyed by qualified name.

--- a/rust/tcl-compiler/src/codegen/emitter/mod.rs
+++ b/rust/tcl-compiler/src/codegen/emitter/mod.rs
@@ -175,14 +175,7 @@ pub fn codegen_module(
         );
     }
     ModuleAsm {
-        // The historic generic lowering spelling `tcl` is an explicit
-        // profile-independent artifact contract, not the named release
-        // profile `tcl9.0`.
-        profile: if dialect == Some("tcl") {
-            tcl_dialect::DialectProfile::plain_tcl()
-        } else {
-            tcl_dialect::DialectProfile::by_opt_name(dialect)
-        },
+        profile: tcl_dialect::DialectProfile::by_opt_name(dialect),
         top_level: top,
         procedures: procs,
     }

--- a/rust/tcl-compiler/src/codegen/emitter/mod.rs
+++ b/rust/tcl-compiler/src/codegen/emitter/mod.rs
@@ -175,6 +175,14 @@ pub fn codegen_module(
         );
     }
     ModuleAsm {
+        // The historic generic lowering spelling `tcl` is an explicit
+        // profile-independent artifact contract, not the named release
+        // profile `tcl9.0`.
+        profile: if dialect == Some("tcl") {
+            tcl_dialect::DialectProfile::plain_tcl()
+        } else {
+            tcl_dialect::DialectProfile::by_opt_name(dialect)
+        },
         top_level: top,
         procedures: procs,
     }

--- a/rust/tcl-compiler/src/lowering/mod.rs
+++ b/rust/tcl-compiler/src/lowering/mod.rs
@@ -3609,8 +3609,23 @@ pub fn lower_to_ir_traced_with_config(
     registry: &CommandRegistry,
     config: tcl_lexer::LexerConfig,
 ) -> Module {
+    lower_to_ir_traced_with_dialect(source, registry, config, "")
+}
+
+/// Like [`lower_to_ir_traced_with_config`] but also records the exact dialect
+/// selected by the host.  Runtime compile services for a named profile must
+/// use this entry point so the resulting bytecode artifact retains the
+/// profile identity that its lexer, registry, and expression grammar used.
+#[must_use]
+pub fn lower_to_ir_traced_with_dialect(
+    source: &str,
+    registry: &CommandRegistry,
+    config: tcl_lexer::LexerConfig,
+    dialect: &str,
+) -> Module {
     lower_with(
         Lowerer::with_config(registry, config)
+            .with_dialect(dialect)
             .for_bytecode_backend()
             .trace_visible(),
         source,

--- a/rust/tcl-debugger/src/backend.rs
+++ b/rust/tcl-debugger/src/backend.rs
@@ -36,7 +36,7 @@ use std::rc::Rc;
 use tcl_compiler::cfg_builder::build_cfg_codegen as build_cfg;
 use tcl_compiler::codegen::codegen_module;
 use tcl_compiler::lowering::lower_to_ir_for_bytecode_with_dialect as lower_to_ir;
-use tcl_compiler::lowering::lower_to_ir_traced_with_config;
+use tcl_compiler::lowering::lower_to_ir_traced_with_dialect;
 use tcl_dialect::DialectProfile;
 use tcl_registry::CommandRegistry;
 use tcl_vm::{CompileError, CompileService, DebugAction, DebugSnapshot, Vm};
@@ -174,7 +174,7 @@ impl CompileService for Svc {
         Self::for_profile(profile).compile(src)
     }
     fn compile_traced(&self, src: &str) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
-        let ir = lower_to_ir_traced_with_config(src, self.registry, self.config);
+        let ir = lower_to_ir_traced_with_dialect(src, self.registry, self.config, self.dialect);
         let cfg = build_cfg(&ir, false);
         Ok(codegen_module(&cfg, &ir, self.registry))
     }

--- a/rust/tcl-debugger/src/backend.rs
+++ b/rust/tcl-debugger/src/backend.rs
@@ -166,10 +166,24 @@ impl CompileService for Svc {
         let cfg = build_cfg(&ir, false);
         Ok(codegen_module(&cfg, &ir, self.registry))
     }
+    fn compile_for_profile(
+        &self,
+        src: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        Self::for_profile(profile).compile(src)
+    }
     fn compile_traced(&self, src: &str) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
         let ir = lower_to_ir_traced_with_config(src, self.registry, self.config);
         let cfg = build_cfg(&ir, false);
         Ok(codegen_module(&cfg, &ir, self.registry))
+    }
+    fn compile_traced_for_profile(
+        &self,
+        src: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        Self::for_profile(profile).compile_traced(src)
     }
 }
 

--- a/rust/tcl-engine-tclvm/Cargo.toml
+++ b/rust/tcl-engine-tclvm/Cargo.toml
@@ -42,6 +42,7 @@ tcl-bytecode = { path = "../tcl-bytecode" }
 tcl-compiler = { path = "../tcl-compiler" }
 tcl-registry = { path = "../tcl-registry" }
 tcl-dialect = { path = "../tcl-dialect" }
+tcl-lexer = { path = "../tcl-lexer" }
 
 [lints]
 workspace = true

--- a/rust/tcl-engine-tclvm/src/lib.rs
+++ b/rust/tcl-engine-tclvm/src/lib.rs
@@ -50,7 +50,11 @@ use std::rc::Rc;
 
 use tcl_compiler::cfg_builder::build_cfg_codegen;
 use tcl_compiler::codegen::codegen_module;
-use tcl_compiler::lowering::lower_to_ir_for_bytecode;
+use tcl_compiler::lowering::{
+    first_fatal_parse_error_with_config, lower_to_ir_for_bytecode,
+    lower_to_ir_for_bytecode_with_dialect, lower_to_ir_traced_with_config,
+};
+use tcl_dialect::DialectProfile;
 use tcl_engine_api::{Budget, BudgetKind, CompileUnit, Engine, EngineError, HostCommand, Value};
 use tcl_registry::CommandRegistry;
 use tcl_vm::{Code, CompileError, CompileService, Completion, NativeCommand, Vm};
@@ -72,6 +76,36 @@ impl CompileService for VmCompiler {
         let ir = lower_to_ir_for_bytecode(source, &self.registry);
         let cfg = build_cfg_codegen(&ir, false);
         Ok(codegen_module(&cfg, &ir, &self.registry))
+    }
+
+    fn compile_for_profile(
+        &self,
+        source: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        let registry = tcl_registry::registry_for_profile(profile);
+        let config = tcl_lexer::LexerConfig::from_grammar(profile.grammar);
+        if let Some(message) = first_fatal_parse_error_with_config(source, config) {
+            return Err(CompileError(message));
+        }
+        let ir = lower_to_ir_for_bytecode_with_dialect(source, registry, config, profile.name);
+        let cfg = build_cfg_codegen(&ir, false);
+        Ok(codegen_module(&cfg, &ir, registry))
+    }
+
+    fn compile_traced_for_profile(
+        &self,
+        source: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        let registry = tcl_registry::registry_for_profile(profile);
+        let config = tcl_lexer::LexerConfig::from_grammar(profile.grammar);
+        if let Some(message) = first_fatal_parse_error_with_config(source, config) {
+            return Err(CompileError(message));
+        }
+        let ir = lower_to_ir_traced_with_config(source, registry, config);
+        let cfg = build_cfg_codegen(&ir, false);
+        Ok(codegen_module(&cfg, &ir, registry))
     }
 }
 

--- a/rust/tcl-engine-tclvm/src/lib.rs
+++ b/rust/tcl-engine-tclvm/src/lib.rs
@@ -52,7 +52,7 @@ use tcl_compiler::cfg_builder::build_cfg_codegen;
 use tcl_compiler::codegen::codegen_module;
 use tcl_compiler::lowering::{
     first_fatal_parse_error_with_config, lower_to_ir_for_bytecode,
-    lower_to_ir_for_bytecode_with_dialect, lower_to_ir_traced_with_config,
+    lower_to_ir_for_bytecode_with_dialect, lower_to_ir_traced_with_dialect,
 };
 use tcl_dialect::DialectProfile;
 use tcl_engine_api::{Budget, BudgetKind, CompileUnit, Engine, EngineError, HostCommand, Value};
@@ -103,7 +103,7 @@ impl CompileService for VmCompiler {
         if let Some(message) = first_fatal_parse_error_with_config(source, config) {
             return Err(CompileError(message));
         }
-        let ir = lower_to_ir_traced_with_config(source, registry, config);
+        let ir = lower_to_ir_traced_with_dialect(source, registry, config, profile.name);
         let cfg = build_cfg_codegen(&ir, false);
         Ok(codegen_module(&cfg, &ir, registry))
     }

--- a/rust/tcl-explorer-wasm/Cargo.lock
+++ b/rust/tcl-explorer-wasm/Cargo.lock
@@ -295,6 +295,7 @@ dependencies = [
 name = "tcl-bytecode"
 version = "0.1.0"
 dependencies = [
+ "tcl-dialect",
  "tcl-lexer",
  "tcl-syntax",
 ]
@@ -354,6 +355,7 @@ dependencies = [
  "tcl-compiler",
  "tcl-dialect",
  "tcl-engine-api",
+ "tcl-lexer",
  "tcl-registry",
  "tcl-vm",
 ]
@@ -430,6 +432,7 @@ name = "tcl-runtime-api"
 version = "0.1.0"
 dependencies = [
  "tcl-core-types",
+ "tcl-dialect",
 ]
 
 [[package]]

--- a/rust/tcl-irule-test/src/live.rs
+++ b/rust/tcl-irule-test/src/live.rs
@@ -117,6 +117,13 @@ impl CompileService for Svc {
         let cfg = build_cfg(&ir, false);
         Ok(codegen_module(&cfg, &ir, self.registry))
     }
+    fn compile_for_profile(
+        &self,
+        src: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        Self::for_profile(profile).compile(src)
+    }
     fn compile_traced(&self, src: &str) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
         if let Some(msg) =
             tcl_compiler::lowering::first_fatal_parse_error_with_config(src, self.config)
@@ -126,6 +133,13 @@ impl CompileService for Svc {
         let ir = lower_to_ir_traced_with_config(src, self.registry, self.config);
         let cfg = build_cfg(&ir, false);
         Ok(codegen_module(&cfg, &ir, self.registry))
+    }
+    fn compile_traced_for_profile(
+        &self,
+        src: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        Self::for_profile(profile).compile_traced(src)
     }
 }
 

--- a/rust/tcl-irule-test/src/live.rs
+++ b/rust/tcl-irule-test/src/live.rs
@@ -767,22 +767,18 @@ mod tests {
         }
 
         // tmm_grammar_has_no_expansion: `{*}` is 8.5+ syntax the embedded
-        // 8.4.6 does not have. Under the iRules grammar `{*}{a b}` is not an
-        // expansion (and, unlike plain tclsh8.4, not an error either): the
-        // TMM's `}{` ghost word separator splits it into the two literal
-        // words `*` and `a b`. TIP-157 expansion would instead yield the
-        // elements `a` and `b` — pin the first element to tell them apart.
+        // 8.4.6 grammar does not have. The adjacent close/open braces are a
+        // hard parse error, matching Tcl 8.4 rather than TIP-157 expansion.
         scenario(&mut s);
-        assert_eq!(
-            s.eval("llength [list {*}{a b}]").unwrap(),
-            "2",
-            "tmm_grammar_has_no_expansion: `}}{{` splits into two words"
-        );
-        assert_eq!(
-            s.eval("lindex [list {*}{a b}] 0").unwrap(),
-            "*",
-            "tmm_grammar_has_no_expansion: the first word is the literal `*`, not an expanded `a`"
-        );
+        match s.eval("llength [list {*}{a b}]") {
+            Err(SessionError::Eval(message)) => assert_eq!(
+                message, "extra characters after close-brace",
+                "tmm_grammar_has_no_expansion: Tcl 8.4 must reject TIP-157 syntax"
+            ),
+            other => {
+                panic!("tmm_grammar_has_no_expansion: Tcl 8.4 syntax must fail, got {other:?}")
+            }
+        }
 
         // surface_hides_86_builtins: an 8.6+-only builtin with no polyfill
         // (lmap) does not exist at 8.4 — the miss reports through the

--- a/rust/tcl-irule-test/src/live.rs
+++ b/rust/tcl-irule-test/src/live.rs
@@ -38,7 +38,7 @@ use std::rc::Rc;
 use tcl_compiler::cfg_builder::build_cfg_codegen as build_cfg;
 use tcl_compiler::codegen::codegen_module;
 use tcl_compiler::lowering::lower_to_ir_for_bytecode_with_dialect as lower_to_ir;
-use tcl_compiler::lowering::lower_to_ir_traced_with_config;
+use tcl_compiler::lowering::lower_to_ir_traced_with_dialect;
 use tcl_dialect::DialectProfile;
 use tcl_registry::CommandRegistry;
 use tcl_vm::{Code, CompileError, CompileService, Vm};
@@ -130,7 +130,7 @@ impl CompileService for Svc {
         {
             return Err(CompileError(msg));
         }
-        let ir = lower_to_ir_traced_with_config(src, self.registry, self.config);
+        let ir = lower_to_ir_traced_with_dialect(src, self.registry, self.config, self.dialect);
         let cfg = build_cfg(&ir, false);
         Ok(codegen_module(&cfg, &ir, self.registry))
     }

--- a/rust/tcl-lsp-server-wasm/Cargo.lock
+++ b/rust/tcl-lsp-server-wasm/Cargo.lock
@@ -748,6 +748,7 @@ dependencies = [
 name = "tcl-bytecode"
 version = "0.1.0"
 dependencies = [
+ "tcl-dialect",
  "tcl-lexer",
  "tcl-syntax",
 ]
@@ -807,6 +808,7 @@ dependencies = [
  "tcl-compiler",
  "tcl-dialect",
  "tcl-engine-api",
+ "tcl-lexer",
  "tcl-registry",
  "tcl-vm",
 ]
@@ -960,6 +962,7 @@ name = "tcl-runtime-api"
 version = "0.1.0"
 dependencies = [
  "tcl-core-types",
+ "tcl-dialect",
 ]
 
 [[package]]

--- a/rust/tcl-runtime-api/Cargo.toml
+++ b/rust/tcl-runtime-api/Cargo.toml
@@ -36,6 +36,7 @@ description = "Family-B runtime-state contract (Code/Completion, handles, role t
 
 [dependencies]
 tcl-core-types = { path = "../tcl-core-types" }
+tcl-dialect = { path = "../tcl-dialect" }
 
 [lints]
 workspace = true

--- a/rust/tcl-runtime-api/src/lib.rs
+++ b/rust/tcl-runtime-api/src/lib.rs
@@ -73,6 +73,23 @@ pub trait CompileService {
     /// Compile `src` to a [`Module`](Self::Module), or report why it could not.
     fn compile(&self, src: &str) -> Result<Self::Module, CompileError>;
 
+    /// Compile `src` for the dialect profile currently selected by the
+    /// interpreter. A VM may change profile after it has cached dynamic
+    /// bodies, so reusing a compiler constructed for an older registry/grammar
+    /// is not sound: an unavailable command could already have been lowered to
+    /// bytecode and bypass normal command dispatch.
+    ///
+    /// Profile-aware services should override this and select the profile's
+    /// registry, lexer grammar, and expression dialect for this invocation.
+    /// The default preserves compatibility for profile-invariant embedders.
+    fn compile_for_profile(
+        &self,
+        src: &str,
+        _profile: &'static tcl_dialect::DialectProfile,
+    ) -> Result<Self::Module, CompileError> {
+        self.compile(src)
+    }
+
     /// Compile `src` with every registry-driven inline/structured lowering
     /// hook suppressed: every command compiles to a plain dispatch, so
     /// execution traces — including `enterstep`/`leavestep` step traces —
@@ -88,6 +105,18 @@ pub trait CompileService {
     /// existing behaviour; the divergence stays but nothing breaks).
     fn compile_traced(&self, src: &str) -> Result<Self::Module, CompileError> {
         self.compile(src)
+    }
+
+    /// Profile-aware counterpart of [`Self::compile_traced`]. See
+    /// [`Self::compile_for_profile`] for why dynamic recompilation must select
+    /// the VM's current profile rather than a compiler's construction-time
+    /// profile.
+    fn compile_traced_for_profile(
+        &self,
+        src: &str,
+        _profile: &'static tcl_dialect::DialectProfile,
+    ) -> Result<Self::Module, CompileError> {
+        self.compile_traced(src)
     }
 }
 

--- a/rust/tcl-runtime-api/src/lib.rs
+++ b/rust/tcl-runtime-api/src/lib.rs
@@ -79,15 +79,24 @@ pub trait CompileService {
     /// is not sound: an unavailable command could already have been lowered to
     /// bytecode and bypass normal command dispatch.
     ///
-    /// Profile-aware services should override this and select the profile's
+    /// Profile-aware services must override this and select the profile's
     /// registry, lexer grammar, and expression dialect for this invocation.
-    /// The default preserves compatibility for profile-invariant embedders.
+    /// A fixed-profile compiler is permitted only for the permissive fallback;
+    /// named-profile dynamic compilation is rejected rather than silently
+    /// stamping older bytecode as current.
     fn compile_for_profile(
         &self,
         src: &str,
-        _profile: &'static tcl_dialect::DialectProfile,
+        profile: &'static tcl_dialect::DialectProfile,
     ) -> Result<Self::Module, CompileError> {
-        self.compile(src)
+        if profile.is_fallback() {
+            self.compile(src)
+        } else {
+            Err(CompileError(format!(
+                "CompileService does not support dialect profile {}",
+                profile.name
+            )))
+        }
     }
 
     /// Compile `src` with every registry-driven inline/structured lowering
@@ -110,13 +119,20 @@ pub trait CompileService {
     /// Profile-aware counterpart of [`Self::compile_traced`]. See
     /// [`Self::compile_for_profile`] for why dynamic recompilation must select
     /// the VM's current profile rather than a compiler's construction-time
-    /// profile.
+    /// profile. The default follows the same fixed-profile rejection rule.
     fn compile_traced_for_profile(
         &self,
         src: &str,
-        _profile: &'static tcl_dialect::DialectProfile,
+        profile: &'static tcl_dialect::DialectProfile,
     ) -> Result<Self::Module, CompileError> {
-        self.compile_traced(src)
+        if profile.is_fallback() {
+            self.compile_traced(src)
+        } else {
+            Err(CompileError(format!(
+                "CompileService does not support dialect profile {}",
+                profile.name
+            )))
+        }
     }
 }
 

--- a/rust/tcl-spec-studio-wasm/Cargo.lock
+++ b/rust/tcl-spec-studio-wasm/Cargo.lock
@@ -388,6 +388,7 @@ dependencies = [
 name = "tcl-bytecode"
 version = "0.1.0"
 dependencies = [
+ "tcl-dialect",
  "tcl-lexer",
  "tcl-syntax",
 ]
@@ -447,6 +448,7 @@ dependencies = [
  "tcl-compiler",
  "tcl-dialect",
  "tcl-engine-api",
+ "tcl-lexer",
  "tcl-registry",
  "tcl-vm",
 ]
@@ -531,6 +533,7 @@ name = "tcl-runtime-api"
 version = "0.1.0"
 dependencies = [
  "tcl-core-types",
+ "tcl-dialect",
 ]
 
 [[package]]

--- a/rust/tcl-vm-cli/src/main.rs
+++ b/rust/tcl-vm-cli/src/main.rs
@@ -42,7 +42,7 @@ use std::sync::{Arc, Mutex};
 use tcl_compiler::cfg_builder::build_cfg_codegen as build_cfg;
 use tcl_compiler::codegen::codegen_module;
 use tcl_compiler::lowering::lower_to_ir_for_bytecode_with_dialect as lower_to_ir;
-use tcl_compiler::lowering::lower_to_ir_traced_with_config;
+use tcl_compiler::lowering::lower_to_ir_traced_with_dialect;
 use tcl_dialect::{DialectProfile, TclVersion};
 use tcl_lexer::script_is_complete;
 use tcl_registry::CommandRegistry;
@@ -98,7 +98,7 @@ impl CompileService for Svc {
         {
             return Err(CompileError(msg));
         }
-        let ir = lower_to_ir_traced_with_config(src, self.registry, self.config);
+        let ir = lower_to_ir_traced_with_dialect(src, self.registry, self.config, self.dialect);
         let cfg = build_cfg(&ir, false);
         Ok(codegen_module(&cfg, &ir, self.registry))
     }

--- a/rust/tcl-vm-cli/src/main.rs
+++ b/rust/tcl-vm-cli/src/main.rs
@@ -85,6 +85,13 @@ impl CompileService for Svc {
         let cfg = build_cfg(&ir, false);
         Ok(codegen_module(&cfg, &ir, self.registry))
     }
+    fn compile_for_profile(
+        &self,
+        src: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        Self::for_profile(profile).compile(src)
+    }
     fn compile_traced(&self, src: &str) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
         if let Some(msg) =
             tcl_compiler::lowering::first_fatal_parse_error_with_config(src, self.config)
@@ -94,6 +101,13 @@ impl CompileService for Svc {
         let ir = lower_to_ir_traced_with_config(src, self.registry, self.config);
         let cfg = build_cfg(&ir, false);
         Ok(codegen_module(&cfg, &ir, self.registry))
+    }
+    fn compile_traced_for_profile(
+        &self,
+        src: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        Self::for_profile(profile).compile_traced(src)
     }
 }
 

--- a/rust/tcl-vm-wasm/Cargo.lock
+++ b/rust/tcl-vm-wasm/Cargo.lock
@@ -302,6 +302,7 @@ name = "tcl-runtime-api"
 version = "0.1.0"
 dependencies = [
  "tcl-core-types",
+ "tcl-dialect",
 ]
 
 [[package]]
@@ -342,6 +343,8 @@ version = "0.1.0"
 dependencies = [
  "tcl-bytecode",
  "tcl-compiler",
+ "tcl-dialect",
+ "tcl-lexer",
  "tcl-registry",
  "tcl-vm",
 ]

--- a/rust/tcl-vm-wasm/Cargo.lock
+++ b/rust/tcl-vm-wasm/Cargo.lock
@@ -207,6 +207,7 @@ dependencies = [
 name = "tcl-bytecode"
 version = "0.1.0"
 dependencies = [
+ "tcl-dialect",
  "tcl-lexer",
  "tcl-syntax",
 ]

--- a/rust/tcl-vm-wasm/Cargo.toml
+++ b/rust/tcl-vm-wasm/Cargo.toml
@@ -45,6 +45,8 @@ tcl-vm = { path = "../tcl-vm" }
 tcl-compiler = { path = "../tcl-compiler" }
 tcl-registry = { path = "../tcl-registry" }
 tcl-bytecode = { path = "../tcl-bytecode" }
+tcl-dialect = { path = "../tcl-dialect" }
+tcl-lexer = { path = "../tcl-lexer" }
 
 # A self-contained wasm module: abort on panic (no unwinding across the C-ABI
 # boundary) and optimise for size.

--- a/rust/tcl-vm-wasm/src/lib.rs
+++ b/rust/tcl-vm-wasm/src/lib.rs
@@ -43,8 +43,10 @@ use std::rc::Rc;
 use tcl_compiler::cfg_builder::build_cfg_codegen;
 use tcl_compiler::codegen::codegen_module;
 use tcl_compiler::lowering::{
-    first_fatal_parse_error, lower_to_ir_for_bytecode, lower_to_ir_traced,
+    first_fatal_parse_error, first_fatal_parse_error_with_config, lower_to_ir_for_bytecode,
+    lower_to_ir_for_bytecode_with_dialect, lower_to_ir_traced, lower_to_ir_traced_with_config,
 };
+use tcl_dialect::DialectProfile;
 use tcl_registry::CommandRegistry;
 use tcl_vm::{CompileError, CompileService, Vm};
 
@@ -74,6 +76,36 @@ impl CompileService for Svc {
         let ir = lower_to_ir_traced(src, &self.0);
         let cfg = build_cfg_codegen(&ir, false);
         Ok(codegen_module(&cfg, &ir, &self.0))
+    }
+
+    fn compile_for_profile(
+        &self,
+        src: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        let registry = tcl_registry::registry_for_profile(profile);
+        let config = tcl_lexer::LexerConfig::from_grammar(profile.grammar);
+        if let Some(msg) = first_fatal_parse_error_with_config(src, config) {
+            return Err(CompileError(msg));
+        }
+        let ir = lower_to_ir_for_bytecode_with_dialect(src, registry, config, profile.name);
+        let cfg = build_cfg_codegen(&ir, false);
+        Ok(codegen_module(&cfg, &ir, registry))
+    }
+
+    fn compile_traced_for_profile(
+        &self,
+        src: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        let registry = tcl_registry::registry_for_profile(profile);
+        let config = tcl_lexer::LexerConfig::from_grammar(profile.grammar);
+        if let Some(msg) = first_fatal_parse_error_with_config(src, config) {
+            return Err(CompileError(msg));
+        }
+        let ir = lower_to_ir_traced_with_config(src, registry, config);
+        let cfg = build_cfg_codegen(&ir, false);
+        Ok(codegen_module(&cfg, &ir, registry))
     }
 }
 

--- a/rust/tcl-vm-wasm/src/lib.rs
+++ b/rust/tcl-vm-wasm/src/lib.rs
@@ -44,7 +44,7 @@ use tcl_compiler::cfg_builder::build_cfg_codegen;
 use tcl_compiler::codegen::codegen_module;
 use tcl_compiler::lowering::{
     first_fatal_parse_error, first_fatal_parse_error_with_config, lower_to_ir_for_bytecode,
-    lower_to_ir_for_bytecode_with_dialect, lower_to_ir_traced, lower_to_ir_traced_with_config,
+    lower_to_ir_for_bytecode_with_dialect, lower_to_ir_traced, lower_to_ir_traced_with_dialect,
 };
 use tcl_dialect::DialectProfile;
 use tcl_registry::CommandRegistry;
@@ -103,7 +103,7 @@ impl CompileService for Svc {
         if let Some(msg) = first_fatal_parse_error_with_config(src, config) {
             return Err(CompileError(msg));
         }
-        let ir = lower_to_ir_traced_with_config(src, registry, config);
+        let ir = lower_to_ir_traced_with_dialect(src, registry, config, profile.name);
         let cfg = build_cfg_codegen(&ir, false);
         Ok(codegen_module(&cfg, &ir, registry))
     }

--- a/rust/tcl-vm/src/cmd_coro.rs
+++ b/rust/tcl-vm/src/cmd_coro.rs
@@ -152,7 +152,7 @@ pub(crate) fn on_command_deleted(vm: &mut Vm, fqn: &str) {
         vm.fire_parked_unset_traces(&mut state.parked);
     }
     if let Some(p) = state.temp_proc {
-        vm.take_command(&p);
+        vm.take_command_unchecked(&p);
     }
 }
 
@@ -222,7 +222,7 @@ fn cmd_coroutine(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let body_src = Value::list(words).to_str();
     let Some(body) = vm.compile_dynamic_body(&body_src) else {
         if let Some(p) = &temp_proc {
-            vm.take_command(p);
+            vm.take_command_unchecked(p);
         }
         return err(format!("coroutine \"{name}\": could not compile body"));
     };
@@ -408,12 +408,12 @@ fn run_injections(
 /// unwinding caller tears everything down instead.
 fn teardown_coro(vm: &mut Vm, fqn: &str) {
     if !vm.exit_pending() {
-        vm.take_command(fqn);
+        vm.take_command_unchecked(fqn);
     }
     if let Some(state) = vm.coro.live.remove(fqn)
         && let Some(p) = state.temp_proc
     {
-        vm.take_command(&p);
+        vm.take_command_unchecked(&p);
     }
 }
 

--- a/rust/tcl-vm/src/cmd_coro.rs
+++ b/rust/tcl-vm/src/cmd_coro.rs
@@ -124,9 +124,12 @@ pub(crate) fn current_coroutine(vm: &Vm) -> Value {
         // A coroutine that deleted its own command (`rename [info coroutine] {}`)
         // is no longer live even though its driver is still on the stack; C Tcl
         // then reports `[info coroutine]` as empty (coroutine-3.5).
-        Some(h) if vm.coro.live.contains_key(&h.key.key()) => {
-            Value::string(format!("::{}", h.key.key().name()))
-        }
+        Some(h) => match h.key.key() {
+            Some(key) if vm.coro.live.contains_key(&key) => {
+                Value::string(format!("::{}", key.name()))
+            }
+            _ => Value::empty(),
+        },
         _ => Value::empty(),
     }
 }
@@ -196,6 +199,7 @@ fn cmd_coroutine(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     // first so it does not leak; the command entry itself is overwritten by
     // `register_command` below.
     if is_coroutine(vm, &fqn) {
+        vm.detach_active_sidecars(&CommandSidecarKey::visible(&fqn));
         on_command_deleted(vm, &fqn);
     }
     // `coroutine NAME apply {lambda} arg…` — bind the lambda to an internal proc
@@ -352,7 +356,9 @@ fn resume(
                 // is restored, and the error propagates.
                 vm.coro.stack.pop();
                 vm.swap_flow(&mut parked);
-                teardown_coro(vm, &active_key.key());
+                if let Some(key) = active_key.key() {
+                    teardown_coro(vm, &key);
+                }
                 return r;
             }
         }
@@ -372,7 +378,9 @@ fn resume(
                 YieldReq::YieldTo(_) => SuspendKind::YieldTo,
             };
             // Park the coroutine (its frozen stack + flow) for the next resume.
-            if let Some(state) = vm.coro.live.get_mut(&key) {
+            if let Some(key) = key
+                && let Some(state) = vm.coro.live.get_mut(&key)
+            {
                 state.acts = acts;
                 state.parked = parked;
                 state.status = CoroStatus::Suspended;
@@ -391,7 +399,9 @@ fn resume(
         RunExit::Done(c) => {
             // The body finished: remove the command + state (unless `exit` is
             // propagating, in which case leave teardown to the unwinding caller).
-            teardown_coro(vm, &key);
+            if let Some(key) = key {
+                teardown_coro(vm, &key);
+            }
             c
         }
     }
@@ -530,7 +540,9 @@ fn cmd_coroprobe(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let result = vm.invoke_command(&cmd.to_str(), rest);
     vm.coro.stack.pop();
     vm.swap_flow(&mut parked);
-    if let Some(state) = vm.coro.live.get_mut(&active_key.key()) {
+    if let Some(key) = active_key.key()
+        && let Some(state) = vm.coro.live.get_mut(&key)
+    {
         state.parked = parked;
         state.status = CoroStatus::Suspended;
     }

--- a/rust/tcl-vm/src/cmd_coro.rs
+++ b/rust/tcl-vm/src/cmd_coro.rs
@@ -45,14 +45,14 @@ use tcl_runtime_api::Completion;
 
 use crate::command::Command;
 use crate::exec::{Frame, RunExit, YieldReq};
-use crate::interp::{ParkedFlow, Vm, err, ok};
+use crate::interp::{CommandSidecarKey, ParkedFlow, Vm, err, ok};
 use crate::value::Value;
 
 /// The coroutine subsystem held by the [`Vm`].
 #[derive(Default)]
 pub(crate) struct CoroSystem {
     /// Live coroutines, keyed by fully-qualified name.
-    live: HashMap<String, CoroState>,
+    live: HashMap<CommandSidecarKey, CoroState>,
     /// Active drivers (innermost last) — one entry per in-flight `resume`. Drives
     /// `[info coroutine]` and the yield-boundary check.
     stack: Vec<CoroHandle>,
@@ -104,7 +104,7 @@ enum SuspendKind {
 /// A driver frame for an in-flight `resume`: which coroutine, and the
 /// `activation_depth` its `drive` started at (for the yield-boundary check).
 struct CoroHandle {
-    name: String,
+    key: CommandSidecarKey,
     base_depth: usize,
 }
 
@@ -124,7 +124,9 @@ pub(crate) fn current_coroutine(vm: &Vm) -> Value {
         // A coroutine that deleted its own command (`rename [info coroutine] {}`)
         // is no longer live even though its driver is still on the stack; C Tcl
         // then reports `[info coroutine]` as empty (coroutine-3.5).
-        Some(h) if is_coroutine(vm, &h.name) => Value::string(format!("::{}", h.name)),
+        Some(h) if vm.coro.live.contains_key(&h.key) => {
+            Value::string(format!("::{}", h.key.name()))
+        }
         _ => Value::empty(),
     }
 }
@@ -132,7 +134,7 @@ pub(crate) fn current_coroutine(vm: &Vm) -> Value {
 /// Whether `fqn` (canonical) names a live coroutine — used by `rename`/deletion
 /// to tear one down.
 pub(crate) fn is_coroutine(vm: &Vm, fqn: &str) -> bool {
-    vm.coro.live.contains_key(fqn)
+    vm.coro.live.contains_key(&CommandSidecarKey::visible(fqn))
 }
 
 /// Drop a coroutine's state on command deletion (`rename $coro {}`). The
@@ -141,7 +143,7 @@ pub(crate) fn is_coroutine(vm: &Vm, fqn: &str) -> bool {
 /// `apply` coroutine's bound lambda proc is removed here (its lifetime is the
 /// coroutine's).
 pub(crate) fn on_command_deleted(vm: &mut Vm, fqn: &str) {
-    let Some(mut state) = vm.coro.live.remove(fqn) else {
+    let Some(mut state) = vm.coro.live.remove(&CommandSidecarKey::visible(fqn)) else {
         return;
     };
     // A suspended coroutine's locals are about to disappear with its frozen
@@ -158,8 +160,24 @@ pub(crate) fn on_command_deleted(vm: &mut Vm, fqn: &str) {
 
 /// Move a coroutine's state to a new key on `rename $coro $new`.
 pub(crate) fn on_command_renamed(vm: &mut Vm, old_fqn: &str, new_fqn: &str) {
-    if let Some(state) = vm.coro.live.remove(old_fqn) {
-        vm.coro.live.insert(new_fqn.to_string(), state);
+    if let Some(state) = vm.coro.live.remove(&CommandSidecarKey::visible(old_fqn)) {
+        vm.coro
+            .live
+            .insert(CommandSidecarKey::visible(new_fqn), state);
+    }
+}
+
+pub(crate) fn on_command_hidden(vm: &mut Vm, old_fqn: &str, token: &str) {
+    if let Some(state) = vm.coro.live.remove(&CommandSidecarKey::visible(old_fqn)) {
+        vm.coro.live.insert(CommandSidecarKey::hidden(token), state);
+    }
+}
+
+pub(crate) fn on_command_exposed(vm: &mut Vm, token: &str, new_fqn: &str) {
+    if let Some(state) = vm.coro.live.remove(&CommandSidecarKey::hidden(token)) {
+        vm.coro
+            .live
+            .insert(CommandSidecarKey::visible(new_fqn), state);
     }
 }
 
@@ -227,7 +245,7 @@ fn cmd_coroutine(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         return err(format!("coroutine \"{name}\": could not compile body"));
     };
     vm.coro.live.insert(
-        fqn.clone(),
+        CommandSidecarKey::visible(&fqn),
         CoroState {
             acts: vec![Frame::new(body, false)],
             parked: ParkedFlow::default(),
@@ -238,7 +256,7 @@ fn cmd_coroutine(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         },
     );
     vm.register_command(&fqn, Command::Builtin(coro_resume));
-    resume(vm, &fqn, &[], &name)
+    resume(vm, &CommandSidecarKey::visible(&fqn), &[], &name)
 }
 
 /// The builtin the coroutine command name resolves to: `$coro ?value ...?`
@@ -250,8 +268,10 @@ fn coro_resume(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let Some(invoked) = vm.invoked_name().map(str::to_owned) else {
         return err("invalid command name");
     };
-    let fqn = vm.qualify_name(&invoked);
-    resume(vm, &fqn, args, &invoked)
+    let key = vm
+        .take_invoked_sidecar()
+        .unwrap_or_else(|| CommandSidecarKey::visible(vm.qualify_name(&invoked)));
+    resume(vm, &key, args, &invoked)
 }
 
 /// Resume the coroutine `fqn`, delivering `args` as the result of the parked
@@ -260,13 +280,18 @@ fn coro_resume(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
 /// empty on the first run; `display_name` names the resume command for the
 /// arity error. Returns the yielded value, or — on completion — the body's
 /// result with its code.
-fn resume(vm: &mut Vm, fqn: &str, args: &[Value], display_name: &str) -> Completion<Value> {
+fn resume(
+    vm: &mut Vm,
+    key: &CommandSidecarKey,
+    args: &[Value],
+    display_name: &str,
+) -> Completion<Value> {
     // Validate the resume arity against how the coroutine last suspended, before
     // the borrow choreography, so an error leaves the coroutine untouched.
-    match vm.coro.live.get(fqn) {
-        None => return err(format!("invalid command name \"{fqn}\"")),
+    match vm.coro.live.get(key) {
+        None => return err(format!("invalid command name \"{}\"", key.name())),
         Some(s) if s.status == CoroStatus::Running => {
-            return err(format!("coroutine \"{fqn}\" is already running"));
+            return err(format!("coroutine \"{}\" is already running", key.name()));
         }
         Some(s)
             if s.status == CoroStatus::Suspended
@@ -281,7 +306,7 @@ fn resume(vm: &mut Vm, fqn: &str, args: &[Value], display_name: &str) -> Complet
     // out (a `Running` sentinel stays in the map) so no `coro.live` borrow is
     // held across the `&mut self` drive.
     let (mut acts, mut parked, was_fresh, injections, kind) = {
-        let state = vm.coro.live.get_mut(fqn).expect("presence checked above");
+        let state = vm.coro.live.get_mut(key).expect("presence checked above");
         let was_fresh = state.status == CoroStatus::Fresh;
         state.status = CoroStatus::Running;
         (
@@ -300,7 +325,7 @@ fn resume(vm: &mut Vm, fqn: &str, args: &[Value], display_name: &str) -> Complet
     // before the push to avoid overlapping the whole-`Vm` deref borrow.
     let base_depth = vm.activation_depth + 1;
     vm.coro.stack.push(CoroHandle {
-        name: fqn.to_string(),
+        key: key.clone(),
         base_depth,
     });
     // Deliver the resume value where the parked `yield`'s result belongs. A Fresh
@@ -326,7 +351,7 @@ fn resume(vm: &mut Vm, fqn: &str, args: &[Value], display_name: &str) -> Complet
                 // is restored, and the error propagates.
                 vm.coro.stack.pop();
                 vm.swap_flow(&mut parked);
-                teardown_coro(vm, fqn);
+                teardown_coro(vm, key);
                 return r;
             }
         }
@@ -345,7 +370,7 @@ fn resume(vm: &mut Vm, fqn: &str, args: &[Value], display_name: &str) -> Complet
                 YieldReq::YieldTo(_) => SuspendKind::YieldTo,
             };
             // Park the coroutine (its frozen stack + flow) for the next resume.
-            if let Some(state) = vm.coro.live.get_mut(fqn) {
+            if let Some(state) = vm.coro.live.get_mut(key) {
                 state.acts = acts;
                 state.parked = parked;
                 state.status = CoroStatus::Suspended;
@@ -364,7 +389,7 @@ fn resume(vm: &mut Vm, fqn: &str, args: &[Value], display_name: &str) -> Complet
         RunExit::Done(c) => {
             // The body finished: remove the command + state (unless `exit` is
             // propagating, in which case leave teardown to the unwinding caller).
-            teardown_coro(vm, fqn);
+            teardown_coro(vm, key);
             c
         }
     }
@@ -406,11 +431,11 @@ fn run_injections(
 /// Drop a finished or unwound coroutine: remove its command and, for an `apply`
 /// coroutine, its bound lambda proc — unless `exit` is propagating, when the
 /// unwinding caller tears everything down instead.
-fn teardown_coro(vm: &mut Vm, fqn: &str) {
+fn teardown_coro(vm: &mut Vm, key: &CommandSidecarKey) {
     if !vm.exit_pending() {
-        vm.retire_command_lifecycle(fqn);
+        vm.retire_command_lifecycle_key(key);
     }
-    if let Some(state) = vm.coro.live.remove(fqn)
+    if let Some(state) = vm.coro.live.remove(key)
         && let Some(p) = state.temp_proc
     {
         vm.take_command_unchecked(&p);
@@ -482,7 +507,7 @@ fn cmd_coroprobe(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let fqn = vm.qualify_name(&name.to_str());
     // Take the coroutine's parked flow out; it must be suspended.
     let mut parked = {
-        let Some(state) = vm.coro.live.get_mut(&fqn) else {
+        let Some(state) = vm.coro.live.get_mut(&CommandSidecarKey::visible(&fqn)) else {
             return err("can only inject a probe command into a coroutine");
         };
         if state.status != CoroStatus::Suspended {
@@ -496,13 +521,13 @@ fn cmd_coroprobe(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     vm.swap_flow(&mut parked);
     let base_depth = vm.activation_depth + 1;
     vm.coro.stack.push(CoroHandle {
-        name: fqn.clone(),
+        key: CommandSidecarKey::visible(&fqn),
         base_depth,
     });
     let result = vm.invoke_command(&cmd.to_str(), rest);
     vm.coro.stack.pop();
     vm.swap_flow(&mut parked);
-    if let Some(state) = vm.coro.live.get_mut(&fqn) {
+    if let Some(state) = vm.coro.live.get_mut(&CommandSidecarKey::visible(&fqn)) {
         state.parked = parked;
         state.status = CoroStatus::Suspended;
     }
@@ -519,7 +544,7 @@ fn cmd_coroinject(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         return err("wrong # args: should be \"coroinject coroName cmd ?arg1 arg2 ...?\"");
     };
     let fqn = vm.qualify_name(&name.to_str());
-    match vm.coro.live.get_mut(&fqn) {
+    match vm.coro.live.get_mut(&CommandSidecarKey::visible(&fqn)) {
         Some(state) if state.status == CoroStatus::Suspended => {
             state.injections.push(args[1..].to_vec());
             ok(Value::empty())
@@ -536,7 +561,7 @@ fn cmd_corotype(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         return err("wrong # args: should be \"::tcl::unsupported::corotype coroName\"");
     };
     let fqn = vm.qualify_name(&name.to_str());
-    match vm.coro.live.get(&fqn) {
+    match vm.coro.live.get(&CommandSidecarKey::visible(&fqn)) {
         None => err("can only get coroutine type of a coroutine"),
         Some(s) if s.status == CoroStatus::Running => ok(Value::string("active")),
         Some(s) => ok(Value::string(match s.last_suspend {

--- a/rust/tcl-vm/src/cmd_coro.rs
+++ b/rust/tcl-vm/src/cmd_coro.rs
@@ -408,7 +408,7 @@ fn run_injections(
 /// unwinding caller tears everything down instead.
 fn teardown_coro(vm: &mut Vm, fqn: &str) {
     if !vm.exit_pending() {
-        vm.take_command_unchecked(fqn);
+        vm.retire_command_lifecycle(fqn);
     }
     if let Some(state) = vm.coro.live.remove(fqn)
         && let Some(p) = state.temp_proc

--- a/rust/tcl-vm/src/cmd_coro.rs
+++ b/rust/tcl-vm/src/cmd_coro.rs
@@ -248,10 +248,11 @@ fn cmd_coroutine(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         }
         return err(format!("coroutine \"{name}\": could not compile body"));
     };
+    let profile_generation = vm.profile_generation();
     vm.coro.live.insert(
         CommandSidecarKey::visible(&fqn),
         CoroState {
-            acts: vec![Frame::new(body, false)],
+            acts: vec![Frame::new(body, false, profile_generation)],
             parked: ParkedFlow::default(),
             status: CoroStatus::Fresh,
             last_suspend: SuspendKind::Yield,

--- a/rust/tcl-vm/src/cmd_coro.rs
+++ b/rust/tcl-vm/src/cmd_coro.rs
@@ -45,7 +45,7 @@ use tcl_runtime_api::Completion;
 
 use crate::command::Command;
 use crate::exec::{Frame, RunExit, YieldReq};
-use crate::interp::{CommandSidecarKey, ParkedFlow, Vm, err, ok};
+use crate::interp::{CommandSidecarHandle, CommandSidecarKey, ParkedFlow, Vm, err, ok};
 use crate::value::Value;
 
 /// The coroutine subsystem held by the [`Vm`].
@@ -104,7 +104,7 @@ enum SuspendKind {
 /// A driver frame for an in-flight `resume`: which coroutine, and the
 /// `activation_depth` its `drive` started at (for the yield-boundary check).
 struct CoroHandle {
-    key: CommandSidecarKey,
+    key: CommandSidecarHandle,
     base_depth: usize,
 }
 
@@ -124,8 +124,8 @@ pub(crate) fn current_coroutine(vm: &Vm) -> Value {
         // A coroutine that deleted its own command (`rename [info coroutine] {}`)
         // is no longer live even though its driver is still on the stack; C Tcl
         // then reports `[info coroutine]` as empty (coroutine-3.5).
-        Some(h) if vm.coro.live.contains_key(&h.key) => {
-            Value::string(format!("::{}", h.key.name()))
+        Some(h) if vm.coro.live.contains_key(&h.key.key()) => {
+            Value::string(format!("::{}", h.key.key().name()))
         }
         _ => Value::empty(),
     }
@@ -324,8 +324,9 @@ fn resume(
     // interp state (reached through `Deref`), so read the depth into a local
     // before the push to avoid overlapping the whole-`Vm` deref borrow.
     let base_depth = vm.activation_depth + 1;
+    let active_key = vm.active_sidecar(key.clone());
     vm.coro.stack.push(CoroHandle {
-        key: key.clone(),
+        key: active_key.clone(),
         base_depth,
     });
     // Deliver the resume value where the parked `yield`'s result belongs. A Fresh
@@ -351,7 +352,7 @@ fn resume(
                 // is restored, and the error propagates.
                 vm.coro.stack.pop();
                 vm.swap_flow(&mut parked);
-                teardown_coro(vm, key);
+                teardown_coro(vm, &active_key.key());
                 return r;
             }
         }
@@ -362,6 +363,7 @@ fn resume(
     vm.coro.stack.pop();
     // Swap the resumer's flow back in; `parked` again holds the coroutine's flow.
     vm.swap_flow(&mut parked);
+    let key = active_key.key();
 
     match exit {
         RunExit::Yielded(req) => {
@@ -370,7 +372,7 @@ fn resume(
                 YieldReq::YieldTo(_) => SuspendKind::YieldTo,
             };
             // Park the coroutine (its frozen stack + flow) for the next resume.
-            if let Some(state) = vm.coro.live.get_mut(key) {
+            if let Some(state) = vm.coro.live.get_mut(&key) {
                 state.acts = acts;
                 state.parked = parked;
                 state.status = CoroStatus::Suspended;
@@ -389,7 +391,7 @@ fn resume(
         RunExit::Done(c) => {
             // The body finished: remove the command + state (unless `exit` is
             // propagating, in which case leave teardown to the unwinding caller).
-            teardown_coro(vm, key);
+            teardown_coro(vm, &key);
             c
         }
     }
@@ -520,14 +522,15 @@ fn cmd_coroprobe(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     // and its locals resolve), then restore the caller's flow.
     vm.swap_flow(&mut parked);
     let base_depth = vm.activation_depth + 1;
+    let active_key = vm.active_sidecar(CommandSidecarKey::visible(&fqn));
     vm.coro.stack.push(CoroHandle {
-        key: CommandSidecarKey::visible(&fqn),
+        key: active_key.clone(),
         base_depth,
     });
     let result = vm.invoke_command(&cmd.to_str(), rest);
     vm.coro.stack.pop();
     vm.swap_flow(&mut parked);
-    if let Some(state) = vm.coro.live.get_mut(&CommandSidecarKey::visible(&fqn)) {
+    if let Some(state) = vm.coro.live.get_mut(&active_key.key()) {
         state.parked = parked;
         state.status = CoroStatus::Suspended;
     }

--- a/rust/tcl-vm/src/cmd_namespace.rs
+++ b/rust/tcl-vm/src/cmd_namespace.rs
@@ -181,13 +181,15 @@ fn cmd_namespace(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         }
         "origin" => {
             // `namespace origin command` → the original command's fully-qualified
-            // name (following imports). We do not track import provenance, so the
-            // resolved qualified name is returned; an unknown command errors.
+            // name (following imports).  Visibility is checked before exposing
+            // the provenance: an import of a builtin absent from this emulated
+            // release is no more observable than a missing command.
             let name = first(rest);
-            if vm.lookup_command(&name).is_some() {
-                ok(Value::string(display_ns(&vm.qualify_name(&name))))
-            } else {
-                err(format!("invalid command name \"{name}\""))
+            match vm.resolve_command_fqn(vm.current_ns(), &name) {
+                Some(key) if vm.lookup_command(&name).is_some() => {
+                    ok(Value::string(display_ns(&vm.command_origin_key(&key))))
+                }
+                _ => err(format!("invalid command name \"{name}\"")),
             }
         }
         "export" => {

--- a/rust/tcl-vm/src/cmd_oo.rs
+++ b/rust/tcl-vm/src/cmd_oo.rs
@@ -1731,7 +1731,7 @@ fn oo_destroy(vm: &mut Vm, obj_key: &str) -> Completion<Value> {
 
 /// Remove an object's command and records (no destructor run).
 fn teardown(vm: &mut Vm, obj_key: &str) {
-    vm.take_command(obj_key);
+    vm.take_command_unchecked(obj_key);
     vm.oo.objects.remove(obj_key);
     vm.oo.classes.remove(obj_key);
 }

--- a/rust/tcl-vm/src/cmd_oo.rs
+++ b/rust/tcl-vm/src/cmd_oo.rs
@@ -62,6 +62,10 @@ struct Method {
     has_args: bool,
     body: Rc<FunctionAsm>,
     body_src: Value,
+    /// Dialect-profile generation under which `body` was compiled. The
+    /// transient `ProcDef` built for an invocation carries this through the
+    /// shared profile/trace freshness owner.
+    compiled_profile_generation: u64,
     /// `None` for an ordinary method; `Some(prefix)` for a `forward` (invoking
     /// the method evaluates `prefix args…`).
     forward: Option<Vec<Value>>,
@@ -1444,12 +1448,11 @@ fn run_step_inner(
         body_src: m.body_src.clone(),
         usage_name: Some(usage_prefix.clone()),
         compiled_epoch: 0,
+        compiled_profile_generation: m.compiled_profile_generation,
     };
     // A method body is rebuilt fresh from `m.body_src` every call (never
-    // cached back onto the class), so it always picks up the interp's
-    // current trace-deopt mode — no separate epoch bookkeeping needed for
-    // methods; `ensure_proc_traced` only recompiles when it's actually
-    // needed (step_trace_active).
+    // cached back onto the class), so the shared owner can refresh either a
+    // trace-deopt or dialect-profile mismatch without mutating the class.
     let proc = vm.ensure_proc_traced(Rc::new(proc));
     let frame = OoFrame {
         object: obj_key.to_string(),
@@ -1896,6 +1899,7 @@ fn build_method(
         has_args,
         body: compiled,
         body_src: body.clone(),
+        compiled_profile_generation: vm.profile_generation(),
         forward: None,
         exported,
     })
@@ -2065,6 +2069,7 @@ fn def_forward(vm: &mut Vm, is_class: bool, target: &str, args: &[Value]) -> Com
         has_args: true,
         body: empty_body(vm),
         body_src: Value::empty(),
+        compiled_profile_generation: vm.profile_generation(),
         forward: Some(prefix.to_vec()),
         exported,
     };

--- a/rust/tcl-vm/src/cmd_oo.rs
+++ b/rust/tcl-vm/src/cmd_oo.rs
@@ -1350,7 +1350,7 @@ fn run_step(
     result
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)] // A method activation genuinely carries this context and persistence seam.
 fn run_step_inner(
     vm: &mut Vm,
     obj_key: &str,
@@ -1450,10 +1450,32 @@ fn run_step_inner(
         compiled_epoch: 0,
         compiled_profile_generation: m.compiled_profile_generation,
     };
-    // A method body is rebuilt fresh from `m.body_src` every call (never
-    // cached back onto the class), so the shared owner can refresh either a
-    // trace-deopt or dialect-profile mismatch without mutating the class.
+    // Refresh through the shared proc owner, then persist the replacement on
+    // its defining facet.  Recompiling on every method call after a profile
+    // switch is both wasteful and makes the class cache lie about its body.
     let proc = vm.ensure_proc_traced(Rc::new(proc));
+    if !Rc::ptr_eq(&proc.body, &m.body)
+        || proc.compiled_profile_generation != m.compiled_profile_generation
+    {
+        let mut refreshed = m.clone();
+        refreshed.body = Rc::clone(&proc.body);
+        refreshed.compiled_profile_generation = proc.compiled_profile_generation;
+        if method.is_empty() {
+            if let Some(class) = vm.oo.classes.get_mut(&step.provider) {
+                class.constructor = Some(refreshed);
+            }
+        } else if method == "<destructor>" {
+            if let Some(class) = vm.oo.classes.get_mut(&step.provider) {
+                class.destructor = Some(refreshed);
+            }
+        } else if step.is_object {
+            if let Some(object) = vm.oo.objects.get_mut(&step.provider) {
+                object.methods.insert(method.clone(), refreshed);
+            }
+        } else if let Some(class) = vm.oo.classes.get_mut(&step.provider) {
+            class.methods.insert(method.clone(), refreshed);
+        }
+    }
     let frame = OoFrame {
         object: obj_key.to_string(),
         chain: chain.to_vec(),

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -91,6 +91,10 @@ pub struct ProcDef {
     /// fast, matching whether a step trace is currently active — when they
     /// differ (issue #946 fault 3). See [`crate::interp::Vm::ensure_proc_traced`].
     pub compiled_epoch: u64,
+    /// The VM dialect-profile generation under which `body` was compiled.
+    /// Profile mutation recompiles stored bodies from [`Self::body_src`] before
+    /// specialised bytecode can run under the new command surface.
+    pub compiled_profile_generation: u64,
 }
 
 /// A registered command.
@@ -412,6 +416,7 @@ pub(crate) fn build_lambda_proc(vm: &mut Vm, lambda: &Value) -> Result<String, C
         body_src: body,
         usage_name: Some("apply lambdaExpr".to_string()),
         compiled_epoch: 0,
+        compiled_profile_generation: vm.profile_generation(),
     });
     Ok(name)
 }
@@ -1227,6 +1232,7 @@ fn cmd_proc(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         body_src: body_text.clone(),
         usage_name: None,
         compiled_epoch: 0,
+        compiled_profile_generation: vm.profile_generation(),
     });
     ok(Value::empty())
 }

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -483,12 +483,14 @@ fn cmd_rename(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     // A coroutine's state travels with its command: a delete (`rename $coro {}`)
     // drops it (no `finally` runs — the frozen continuation is inert data,
     // matching C Tcl); a rename re-keys it so it keeps working under the new name.
-    let old_fqn = vm.qualify_name(&old_name);
-    let is_coro = crate::cmd_coro::is_coroutine(vm, &old_fqn);
+    // The prepared transaction holds the exact key resolved by Tcl's full
+    // command lookup rule (including `namespace path`), rather than the
+    // spelling rooted at the caller's current namespace.
+    let is_coro = crate::cmd_coro::is_coroutine(vm, &old_key);
     if new_name.is_empty() {
         vm.delete_prepared_renamed_command(&rename);
         if is_coro {
-            crate::cmd_coro::on_command_deleted(vm, &old_fqn);
+            crate::cmd_coro::on_command_deleted(vm, &old_key);
         }
         // `rename x {}` is a delete: fire the command's `delete` traces
         // (`callback ::old {} delete`, tclsh-pinned) and drop its traces.
@@ -504,7 +506,7 @@ fn cmd_rename(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             vm.qualify_name(&new_name)
         };
         if is_coro {
-            crate::cmd_coro::on_command_renamed(vm, &old_fqn, &key);
+            crate::cmd_coro::on_command_renamed(vm, &old_key, &key);
         }
         // A proc executes in the namespace it currently lives in, so renaming
         // it across namespaces re-homes its body (C `TclRenameCommand` updates

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -486,6 +486,7 @@ fn cmd_rename(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let old_fqn = vm.qualify_name(&old_name);
     let is_coro = crate::cmd_coro::is_coroutine(vm, &old_fqn);
     if new_name.is_empty() {
+        vm.delete_prepared_renamed_command(&rename);
         if is_coro {
             crate::cmd_coro::on_command_deleted(vm, &old_fqn);
         }

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -468,7 +468,7 @@ fn cmd_rename(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             "can't rename to \"{new_name}\": command already exists"
         ));
     }
-    let Some((cmd, mut rename)) = vm.take_command_for_rename(&old_name) else {
+    let Some((cmd, mut rename)) = vm.prepare_command_rename(&old_name) else {
         // Renaming to the empty name is a delete; C words the miss accordingly.
         let verb = if new_name.is_empty() {
             "delete"
@@ -528,18 +528,20 @@ fn cmd_rename(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             other => other,
         };
         let is_alias = matches!(&cmd, Command::Alias(_) | Command::CrossAlias { .. });
-        vm.install_renamed_command(&mut rename, &key, cmd);
         // C's `TclPreventAliasLoop` guards *rename* too: moving an alias onto
         // a name its own target chain resolves back to is refused, with the
-        // command restored under its old name (tclsh-pinned: `interp alias {}
-        // a {} b; rename a b` errors, `a` survives, `b` stays free).
-        if is_alias && vm.alias_chain_loops_here(&key) {
-            vm.rollback_renamed_command(rename);
+        // command left untouched (tclsh-pinned: `interp alias {} a {} b;
+        // rename a b` errors, `a` survives, `b` stays free).  This logical
+        // check must precede registration: a hidden destination can carry
+        // delete callbacks and trace/deoptimisation state that cannot be
+        // rolled back after `register_command` observes an overwrite.
+        if is_alias && vm.alias_chain_loops_for_rename(&key, &cmd) {
             let tail = crate::interp::key_holder_and_tail_unrooted(&key).1;
             return err(format!(
                 "cannot define or rename alias \"{tail}\": would create a loop"
             ));
         }
+        vm.install_renamed_command(&mut rename, &key, cmd);
         vm.commit_renamed_command(&rename);
         // The rename happened: fire the command's `rename` traces
         // (`callback ::old ::new rename`, both fully qualified — tclsh-

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -468,14 +468,7 @@ fn cmd_rename(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             "can't rename to \"{new_name}\": command already exists"
         ));
     }
-    // The exact key `take_command` resolves to — captured up front so a
-    // refused alias-loop rename can restore the command where it came from.
-    let old_key = vm
-        .resolve_command_fqn(vm.current_ns(), &old_name)
-        .unwrap_or_default();
-    let import_origin = vm.import_origin(&old_key);
-    let builtin_identity = vm.builtin_identity(&old_key);
-    let Some(cmd) = vm.take_command(&old_name) else {
+    let Some((cmd, mut rename)) = vm.take_command_for_rename(&old_name) else {
         // Renaming to the empty name is a delete; C words the miss accordingly.
         let verb = if new_name.is_empty() {
             "delete"
@@ -486,6 +479,7 @@ fn cmd_rename(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             "can't {verb} \"{old_name}\": command doesn't exist"
         ));
     };
+    let old_key = rename.old_key().to_owned();
     // A coroutine's state travels with its command: a delete (`rename $coro {}`)
     // drops it (no `finally` runs — the frozen continuation is inert data,
     // matching C Tcl); a rename re-keys it so it keeps working under the new name.
@@ -534,55 +528,19 @@ fn cmd_rename(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             other => other,
         };
         let is_alias = matches!(&cmd, Command::Alias(_) | Command::CrossAlias { .. });
-        let cross_target = match &cmd {
-            Command::CrossAlias { target, .. } => Some(*target),
-            _ => None,
-        };
-        vm.register_command(&key, cmd);
-        if let Some(origin) = &import_origin {
-            vm.restore_import_origin(&key, origin.clone());
-        }
-        if let Some(identity) = &builtin_identity {
-            vm.restore_builtin_identity(&key, identity.clone());
-        }
-        // Imported commands retain the source command's Tcl identity.  A
-        // rename moves that identity (C's import holds the source token), so
-        // every import must follow before later visibility/origin lookups.
-        vm.retarget_imports(&old_key, &key);
+        vm.install_renamed_command(&mut rename, &key, cmd);
         // C's `TclPreventAliasLoop` guards *rename* too: moving an alias onto
         // a name its own target chain resolves back to is refused, with the
         // command restored under its old name (tclsh-pinned: `interp alias {}
         // a {} b; rename a b` errors, `a` survives, `b` stays free).
         if is_alias && vm.alias_chain_loops_here(&key) {
-            let restored = vm
-                .remove_command_exact(&key)
-                .expect("the alias was just registered under this key");
-            vm.register_command(&old_key, restored);
-            if let Some(origin) = &import_origin {
-                vm.restore_import_origin(&old_key, origin.clone());
-            }
-            if let Some(identity) = &builtin_identity {
-                vm.restore_builtin_identity(&old_key, identity.clone());
-            }
-            // `register_command` just dropped the backref sitting at `old_key`
-            // (stale since `take_command` doesn't touch the backref table) —
-            // put it back now the alias is confirmed to still live there.
-            if let Some(target) = cross_target {
-                vm.note_alias_backref(&old_key, target);
-            }
+            vm.rollback_renamed_command(rename);
             let tail = crate::interp::key_holder_and_tail_unrooted(&key).1;
             return err(format!(
                 "cannot define or rename alias \"{tail}\": would create a loop"
             ));
         }
-        // A renamed cross-interp alias keeps its target-death backref current
-        // (the source-side sweep keys on the command's table key). Retargeted
-        // only now — any earlier and `register_command`'s own overwrite
-        // cleanup (which unconditionally drops a backref at the key it just
-        // wrote) would immediately undo it.
-        if let Some(target) = cross_target {
-            vm.retarget_alias_backref(&old_key, &key, target);
-        }
+        vm.commit_renamed_command(&rename);
         // The rename happened: fire the command's `rename` traces
         // (`callback ::old ::new rename`, both fully qualified — tclsh-
         // pinned) and move every trace to the new key so it keeps firing

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -814,16 +814,21 @@ fn interp_hidectl_cmd(vm: &mut Vm, hide: bool, rest: &[Value]) -> Completion<Val
         }
     }
     if path.is_empty() {
-        if hide {
-            vm.hide_command(&cmd, &token);
+        let result = if hide {
+            vm.hide_command(&cmd, &token)
         } else {
-            vm.expose_own_command(&cmd, &token);
+            vm.expose_own_command(&cmd, &token)
+        };
+        match result {
+            Ok(()) => ok(Value::empty()),
+            Err(message) => err(message),
         }
-        ok(Value::empty())
-    } else if vm.child_hide(&path, &cmd, &token, hide) {
-        ok(Value::empty())
     } else {
-        err(format!("could not find interpreter \"{path}\""))
+        match vm.child_hide(&path, &cmd, &token, hide) {
+            Ok(true) => ok(Value::empty()),
+            Ok(false) => err(format!("could not find interpreter \"{path}\"")),
+            Err(message) => err(message),
+        }
     }
 }
 

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -447,7 +447,7 @@ fn cmd_apply(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             ok(Value::empty())
         }
         Err(e) => {
-            vm.take_command(&name);
+            vm.take_command_unchecked(&name);
             err(e.message)
         }
     }
@@ -473,6 +473,8 @@ fn cmd_rename(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let old_key = vm
         .resolve_command_fqn(vm.current_ns(), &old_name)
         .unwrap_or_default();
+    let import_origin = vm.import_origin(&old_key);
+    let builtin_identity = vm.builtin_identity(&old_key);
     let Some(cmd) = vm.take_command(&old_name) else {
         // Renaming to the empty name is a delete; C words the miss accordingly.
         let verb = if new_name.is_empty() {
@@ -537,6 +539,16 @@ fn cmd_rename(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             _ => None,
         };
         vm.register_command(&key, cmd);
+        if let Some(origin) = &import_origin {
+            vm.restore_import_origin(&key, origin.clone());
+        }
+        if let Some(identity) = &builtin_identity {
+            vm.restore_builtin_identity(&key, identity.clone());
+        }
+        // Imported commands retain the source command's Tcl identity.  A
+        // rename moves that identity (C's import holds the source token), so
+        // every import must follow before later visibility/origin lookups.
+        vm.retarget_imports(&old_key, &key);
         // C's `TclPreventAliasLoop` guards *rename* too: moving an alias onto
         // a name its own target chain resolves back to is refused, with the
         // command restored under its old name (tclsh-pinned: `interp alias {}
@@ -546,6 +558,12 @@ fn cmd_rename(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
                 .remove_command_exact(&key)
                 .expect("the alias was just registered under this key");
             vm.register_command(&old_key, restored);
+            if let Some(origin) = &import_origin {
+                vm.restore_import_origin(&old_key, origin.clone());
+            }
+            if let Some(identity) = &builtin_identity {
+                vm.restore_builtin_identity(&old_key, identity.clone());
+            }
             // `register_command` just dropped the backref sitting at `old_key`
             // (stale since `take_command` doesn't touch the backref table) —
             // put it back now the alias is confirmed to still live there.
@@ -834,9 +852,7 @@ fn interp_hidectl_cmd(vm: &mut Vm, hide: bool, rest: &[Value]) -> Completion<Val
     }
     if path.is_empty() {
         if hide {
-            if let Some(command) = vm.take_command(&cmd) {
-                vm.hide_own_command(&token, command);
-            }
+            vm.hide_command(&cmd, &token);
         } else {
             vm.expose_own_command(&cmd, &token);
         }

--- a/rust/tcl-vm/src/embed.rs
+++ b/rust/tcl-vm/src/embed.rs
@@ -62,6 +62,8 @@ pub struct FunctionHandle {
 
 struct FunctionHandleState {
     asm: Rc<FunctionAsm>,
+    owner_nonce: u64,
+    profile: &'static tcl_dialect::DialectProfile,
     profile_generation: u64,
 }
 
@@ -69,6 +71,8 @@ impl std::fmt::Debug for FunctionHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FunctionHandle")
             .field("source", &self.source)
+            .field("owner_nonce", &self.state.borrow().owner_nonce)
+            .field("profile", &self.state.borrow().profile.name)
             .field("instructions", &self.state.borrow().asm.instructions.len())
             .field(
                 "profile_generation",
@@ -88,6 +92,8 @@ impl Vm {
             source: src.to_owned(),
             state: Rc::new(RefCell::new(FunctionHandleState {
                 asm: self.compile_source_cached(src)?,
+                owner_nonce: self.owner_nonce,
+                profile: self.dialect_profile(),
                 profile_generation: self.profile_generation(),
             })),
         })
@@ -160,13 +166,18 @@ impl Vm {
     /// call.
     #[must_use]
     pub fn invoke_function(&mut self, handle: &FunctionHandle) -> Completion<Value> {
-        if handle.state.borrow().profile_generation != self.profile_generation() {
+        if handle.state.borrow().owner_nonce != self.owner_nonce {
+            return crate::interp::err("FunctionHandle belongs to a different Vm");
+        }
+        if !std::ptr::eq(handle.state.borrow().profile, self.dialect_profile()) {
             let asm = match self.compile_source_cached(&handle.source) {
                 Ok(asm) => asm,
                 Err(error) => return crate::command::completion_from_tcl_error(error),
             };
             *handle.state.borrow_mut() = FunctionHandleState {
                 asm,
+                owner_nonce: self.owner_nonce,
+                profile: self.dialect_profile(),
                 profile_generation: self.profile_generation(),
             };
         }

--- a/rust/tcl-vm/src/embed.rs
+++ b/rust/tcl-vm/src/embed.rs
@@ -165,7 +165,10 @@ impl Vm {
 
     /// Delete `name` from the command table, reporting whether it was there.
     pub fn remove_command(&mut self, name: &str) -> bool {
-        self.take_command(name).is_some()
+        // This is an embedder-owned teardown API, not Tcl's `rename`/`interp
+        // hide` surface.  Keep it able to remove a command even when the
+        // command is hidden by the emulated release.
+        self.take_command_unchecked(name).is_some()
     }
 
     /// Reduce the command table to the commands `keep` accepts, returning how

--- a/rust/tcl-vm/src/embed.rs
+++ b/rust/tcl-vm/src/embed.rs
@@ -36,6 +36,7 @@
 //! - **Bound the work.** [`Vm::set_command_limit`] arms the `commands` limit
 //!   the VM now enforces, and [`Vm::commands_run`] reports the fuel spent.
 
+use std::cell::RefCell;
 use std::rc::Rc;
 
 use tcl_bytecode::FunctionAsm;
@@ -51,16 +52,28 @@ use crate::value::Value;
 /// Holds the compiled activation behind an `Rc`, so invoking it is a pointer
 /// clone rather than a deep copy of the bytecode — the difference between a
 /// hook body that costs its own execution and one that pays for its
-/// compilation shape on every call site.
+/// compilation shape on every call site. It also retains its source solely to
+/// refresh the activation when the owning VM changes dialect profile.
 #[derive(Clone)]
 pub struct FunctionHandle {
+    source: String,
+    state: Rc<RefCell<FunctionHandleState>>,
+}
+
+struct FunctionHandleState {
     asm: Rc<FunctionAsm>,
+    profile_generation: u64,
 }
 
 impl std::fmt::Debug for FunctionHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FunctionHandle")
-            .field("instructions", &self.asm.instructions.len())
+            .field("source", &self.source)
+            .field("instructions", &self.state.borrow().asm.instructions.len())
+            .field(
+                "profile_generation",
+                &self.state.borrow().profile_generation,
+            )
             .finish()
     }
 }
@@ -72,7 +85,11 @@ impl Vm {
     /// runtime-compilation path.
     pub fn compile_function(&mut self, src: &str) -> Result<FunctionHandle, TclError> {
         Ok(FunctionHandle {
-            asm: self.compile_source_cached(src)?,
+            source: src.to_owned(),
+            state: Rc::new(RefCell::new(FunctionHandleState {
+                asm: self.compile_source_cached(src)?,
+                profile_generation: self.profile_generation(),
+            })),
         })
     }
 
@@ -114,6 +131,7 @@ impl Vm {
             body_src: Value::string(body),
             usage_name: None,
             compiled_epoch: 0,
+            compiled_profile_generation: self.profile_generation(),
         });
         Ok(())
     }
@@ -142,7 +160,17 @@ impl Vm {
     /// call.
     #[must_use]
     pub fn invoke_function(&mut self, handle: &FunctionHandle) -> Completion<Value> {
-        self.run_function_rc(Rc::clone(&handle.asm))
+        if handle.state.borrow().profile_generation != self.profile_generation() {
+            let asm = match self.compile_source_cached(&handle.source) {
+                Ok(asm) => asm,
+                Err(error) => return crate::command::completion_from_tcl_error(error),
+            };
+            *handle.state.borrow_mut() = FunctionHandleState {
+                asm,
+                profile_generation: self.profile_generation(),
+            };
+        }
+        self.run_function_rc(Rc::clone(&handle.state.borrow().asm))
     }
 
     /// Register an embedder command carrying its own state.

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -983,12 +983,8 @@ fn proc_usage(proc: &ProcDef) -> String {
 impl Vm {
     /// Run a module: register its compiled procs, then run the top-level script.
     pub fn run_module(&mut self, module: &ModuleAsm) -> Completion<Value> {
-        if !module.profile.is_fallback() && !std::ptr::eq(module.profile, self.dialect_profile()) {
-            return err(format!(
-                "bytecode compiled for dialect profile {} cannot run under {}",
-                module.profile.name,
-                self.dialect_profile().name
-            ));
+        if let Err(error) = self.validate_module_profile(module) {
+            return crate::command::completion_from_tcl_error(error);
         }
         self.claim_number_grammar();
         self.merge_procs(&module.procedures);

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -4071,7 +4071,7 @@ impl Vm {
         if self.trace_in_progress.get()
             || (self.exec_traces.is_empty() && self.exec_step_scopes.is_empty())
         {
-            return self.dispatch_words_inner(f, words);
+            return self.dispatch_words_inner(f, words, None);
         }
         self.dispatch_words_traced(f, words)
     }
@@ -4147,10 +4147,10 @@ impl Vm {
         }
         let ctx = ExecLeaveCtx {
             cmd_string,
-            key: sidecar,
+            key: sidecar.clone(),
             step_scopes: pushed,
         };
-        match self.dispatch_words_inner(f, words) {
+        match self.dispatch_words_inner(f, words, Some(&sidecar)) {
             Ok(Some(tick)) => {
                 match &tick {
                     // The body runs on a pushed frame: the context rides
@@ -4344,11 +4344,20 @@ impl Vm {
         &mut self,
         f: &mut Frame,
         words: &[Value],
+        sidecar_handle: Option<&CommandSidecarHandle>,
     ) -> Result<Option<Tick>, Completion<Value>> {
         let name = words[0].to_str();
         match self.lookup_command(&name) {
             Some(Command::Proc(p)) => {
-                let p = self.ensure_proc_ready(p);
+                let sidecar = self
+                    .resolve_command_fqn(self.current_ns(), &name)
+                    .map(CommandSidecarKey::visible);
+                // A traced dispatch re-resolves after its callbacks. Keep the
+                // handle only when it still identifies that resolved binding;
+                // a callback may have renamed or replaced the original key.
+                let sidecar_handle =
+                    sidecar_handle.filter(|handle| handle.key().as_ref() == sidecar.as_ref());
+                let p = self.ensure_proc_ready_in(p, sidecar.as_ref(), sidecar_handle);
                 Ok(Some(Tick::Call {
                     proc: p,
                     argv: words[1..].to_vec(),
@@ -4456,7 +4465,7 @@ impl Vm {
         if self.trace_in_progress.get()
             || (self.exec_traces.is_empty() && self.exec_step_scopes.is_empty())
         {
-            return self.invoke_command_inner(name, argv);
+            return self.invoke_command_inner(name, argv, None);
         }
         let key = self
             .resolve_command_fqn(self.current_ns(), name)
@@ -4518,10 +4527,10 @@ impl Vm {
         }
         let ctx = ExecLeaveCtx {
             cmd_string,
-            key: sidecar,
+            key: sidecar.clone(),
             step_scopes: pushed,
         };
-        let c = self.invoke_command_inner(name, argv);
+        let c = self.invoke_command_inner(name, argv, Some(&sidecar));
         match self.finish_exec_leave(&ctx, &c) {
             Some(replacement) => replacement,
             None => c,
@@ -4685,9 +4694,21 @@ impl Vm {
     }
 
     /// The untraced invoke body — see [`Self::invoke_command`].
-    fn invoke_command_inner(&mut self, name: &str, argv: &[Value]) -> Completion<Value> {
+    fn invoke_command_inner(
+        &mut self,
+        name: &str,
+        argv: &[Value],
+        sidecar_handle: Option<&CommandSidecarHandle>,
+    ) -> Completion<Value> {
         match self.lookup_command(name) {
-            Some(command) => self.invoke_resolved_command_inner(name, command, argv, None, None),
+            Some(command) => {
+                let sidecar = self
+                    .resolve_command_fqn(self.current_ns(), name)
+                    .map(CommandSidecarKey::visible);
+                let sidecar_handle =
+                    sidecar_handle.filter(|handle| handle.key().as_ref() == sidecar.as_ref());
+                self.invoke_resolved_command_inner(name, command, argv, sidecar, sidecar_handle)
+            }
             None if name != "unknown" => {
                 if let Some(handler) = self.ns_unknown_handler() {
                     let mut handler_words = handler;

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -4019,8 +4019,12 @@ impl Vm {
             }
         }
         let key = CommandSidecarKey::visible(key);
+        let sidecar = self.active_sidecar(key.clone());
         let own = self.exec_traces.get(&key).cloned().unwrap_or_default();
         for entry in &own {
+            if !sidecar.is_attached() {
+                break;
+            }
             if entry.has_op("enter") {
                 let r = self.run_cmd_trace_callback(
                     entry,
@@ -4033,6 +4037,9 @@ impl Vm {
         }
         let mut pushed = 0usize;
         for entry in &own {
+            if !sidecar.is_attached() {
+                break;
+            }
             if entry.has_op("enterstep") || entry.has_op("leavestep") {
                 self.exec_step_scopes.push(Rc::clone(entry));
                 pushed += 1;
@@ -4040,7 +4047,7 @@ impl Vm {
         }
         let ctx = ExecLeaveCtx {
             cmd_string,
-            key: self.active_sidecar(key),
+            key: sidecar,
             step_scopes: pushed,
         };
         match self.dispatch_words_inner(f, words) {
@@ -4113,6 +4120,9 @@ impl Vm {
             && let Some(entries) = self.exec_traces.get(&key).cloned()
         {
             for e in entries {
+                if !ctx.key.is_attached() {
+                    break;
+                }
                 if e.has_op("leave") {
                     let r = self.run_cmd_trace_callback(&e, &args("leave"));
                     if !r.code.is_ok() {
@@ -4337,8 +4347,12 @@ impl Vm {
             }
         }
         let key = CommandSidecarKey::visible(key);
+        let sidecar = self.active_sidecar(key.clone());
         let own = self.exec_traces.get(&key).cloned().unwrap_or_default();
         for entry in &own {
+            if !sidecar.is_attached() {
+                break;
+            }
             if entry.has_op("enter") {
                 let r = self.run_cmd_trace_callback(
                     entry,
@@ -4351,6 +4365,9 @@ impl Vm {
         }
         let mut pushed = 0usize;
         for entry in &own {
+            if !sidecar.is_attached() {
+                break;
+            }
             if entry.has_op("enterstep") || entry.has_op("leavestep") {
                 self.exec_step_scopes.push(Rc::clone(entry));
                 pushed += 1;
@@ -4358,7 +4375,7 @@ impl Vm {
         }
         let ctx = ExecLeaveCtx {
             cmd_string,
-            key: self.active_sidecar(key),
+            key: sidecar,
             step_scopes: pushed,
         };
         let c = self.invoke_command_inner(name, argv);
@@ -4409,12 +4426,16 @@ impl Vm {
                 }
             }
         }
+        let sidecar = self.active_sidecar(trace_key.clone());
         let own = self
             .exec_traces
             .get(&trace_key)
             .cloned()
             .unwrap_or_default();
         for entry in &own {
+            if !sidecar.is_attached() {
+                break;
+            }
             if entry.has_op("enter") {
                 let r = self.run_cmd_trace_callback(
                     entry,
@@ -4427,18 +4448,20 @@ impl Vm {
         }
         let mut pushed = 0usize;
         for entry in &own {
+            if !sidecar.is_attached() {
+                break;
+            }
             if entry.has_op("enterstep") || entry.has_op("leavestep") {
                 self.exec_step_scopes.push(Rc::clone(entry));
                 pushed += 1;
             }
         }
-        let sidecar = trace_key.clone();
         let ctx = ExecLeaveCtx {
             cmd_string,
-            key: self.active_sidecar(trace_key),
+            key: sidecar,
             step_scopes: pushed,
         };
-        let c = self.invoke_resolved_command_inner(display_name, command, argv, Some(sidecar));
+        let c = self.invoke_resolved_command_inner(display_name, command, argv, Some(trace_key));
         match self.finish_exec_leave(&ctx, &c) {
             Some(replacement) => replacement,
             None => c,

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -120,6 +120,13 @@ struct CaughtState {
 /// pushes its resume value via [`Frame::push_operand`]).
 pub(crate) struct Frame {
     asm: Rc<FunctionAsm>,
+    /// Dialect-profile generation under which this activation's bytecode was
+    /// compiled.
+    /// Stored frames cannot be rewound/recompiled after a profile switch (in
+    /// particular a suspended coroutine has a live PC and operand stack), so
+    /// the trampoline rejects stale execution before another specialised
+    /// opcode can run.
+    profile_generation: u64,
     off2idx: Rc<HashMap<i32, usize>>,
     /// `FOREACH_START` index → paired `FOREACH_STEP` index (the implicit jump).
     foreach_pairs: Rc<HashMap<usize, usize>>,
@@ -306,11 +313,12 @@ enum SubstFold {
 }
 
 impl Frame {
-    pub(crate) fn new(asm: Rc<FunctionAsm>, is_proc: bool) -> Self {
+    pub(crate) fn new(asm: Rc<FunctionAsm>, is_proc: bool, profile_generation: u64) -> Self {
         let off2idx = Rc::new(build_off2idx(&asm));
         let foreach_pairs = Rc::new(pair_foreach(&asm));
         Self {
             asm,
+            profile_generation,
             off2idx,
             foreach_pairs,
             pc: 0,
@@ -336,8 +344,12 @@ impl Frame {
     /// yieldably on the explicit stack (`EVAL_STK`, and the `eval`/`uplevel`
     /// builtins routed through it). `label` is the `errorInfo` body-frame label
     /// (`Some("eval")`/`Some("uplevel")`), or `None` for a command substitution.
-    pub(crate) fn new_script(asm: Rc<FunctionAsm>, label: Option<&'static str>) -> Self {
-        let mut f = Self::new(asm, false);
+    pub(crate) fn new_script(
+        asm: Rc<FunctionAsm>,
+        label: Option<&'static str>,
+        profile_generation: u64,
+    ) -> Self {
+        let mut f = Self::new(asm, false, profile_generation);
         f.is_script = true;
         f.body_label = label;
         f
@@ -346,8 +358,8 @@ impl Frame {
     /// A **catch** activation: the body runs on the explicit stack (yieldable),
     /// but its completion is absorbed by the catch epilogue rather than delivered
     /// to the parent (see [`Frame::catch`]).
-    pub(crate) fn new_catch(req: CatchReq) -> Self {
-        let mut f = Self::new(req.asm, false);
+    pub(crate) fn new_catch(req: CatchReq, profile_generation: u64) -> Self {
+        let mut f = Self::new(req.asm, false, profile_generation);
         f.catch = Some(Box::new(CatchCtx {
             resvar: req.resvar,
             optvar: req.optvar,
@@ -358,8 +370,8 @@ impl Frame {
     /// A **subst** activation: a scanner-driven frame (empty placeholder asm — it
     /// never executes bytecode) carrying the resumable scan state. `tick` runs the
     /// scanner instead of the bytecode dispatch when `subst` is set.
-    pub(crate) fn new_subst(req: SubstReq) -> Self {
-        let mut f = Self::new(Rc::new(FunctionAsm::default()), false);
+    pub(crate) fn new_subst(req: SubstReq, profile_generation: u64) -> Self {
+        let mut f = Self::new(Rc::new(FunctionAsm::default()), false, profile_generation);
         f.subst = Some(Box::new(crate::subst::SubstState::new(
             req.template,
             req.backslashes,
@@ -373,8 +385,8 @@ impl Frame {
     /// asm, like `subst`) carrying the resumable `foreach`/`lmap` iteration
     /// state. `tick` runs the loop driver instead of the bytecode dispatch when
     /// `each_loop` is set.
-    pub(crate) fn new_each_loop(req: EachLoopReq) -> Self {
-        let mut f = Self::new(Rc::new(FunctionAsm::default()), false);
+    pub(crate) fn new_each_loop(req: EachLoopReq, profile_generation: u64) -> Self {
+        let mut f = Self::new(Rc::new(FunctionAsm::default()), false, profile_generation);
         f.each_loop = Some(Box::new(EachLoopState {
             name: req.name,
             collect: req.collect,
@@ -390,8 +402,8 @@ impl Frame {
     /// A **try-phase** activation ([`Frame::try_ctx`]): runs `req.asm` (the
     /// current phase's compiled script) as ordinary bytecode, tagged with the
     /// state `Vm::unwind` hands to `cmd_try::advance_try` on completion.
-    pub(crate) fn new_try(req: crate::cmd_try::TryReq) -> Self {
-        let mut f = Self::new(req.asm, false);
+    pub(crate) fn new_try(req: crate::cmd_try::TryReq, profile_generation: u64) -> Self {
+        let mut f = Self::new(req.asm, false, profile_generation);
         f.try_ctx = Some(Box::new(req.state));
         f
     }
@@ -990,7 +1002,7 @@ impl Vm {
     /// Run an already-`Rc`-wrapped function to completion — the clone-free
     /// path behind [`Vm::invoke_function`].
     pub(crate) fn run_function_rc(&mut self, asm: Rc<FunctionAsm>) -> Completion<Value> {
-        self.run_activation(Frame::new(asm, false))
+        self.run_activation(Frame::new(asm, false, self.profile_generation()))
     }
 
     /// Run one activation stack to completion (the ordinary, non-coroutine path).
@@ -1033,6 +1045,23 @@ impl Vm {
         self.drive(acts, DriveMode::CoroDriver)
     }
 
+    /// Enter an already-validated procedure body.  The frame deliberately
+    /// carries the generation at which the body was compiled, rather than the
+    /// VM's current generation: if a source-less stored body could not be
+    /// refreshed after a profile change, `drive_loop` must reject it before an
+    /// inline opcode can run.
+    fn push_proc_frame(&mut self, acts: &mut Vec<Frame>, proc: &Rc<ProcDef>) {
+        let mut frame = Frame::new(
+            Rc::clone(&proc.body),
+            true,
+            proc.compiled_profile_generation,
+        );
+        if let Some(ctx) = self.pending_exec_leave.take() {
+            frame.exec_leave.push(ctx);
+        }
+        acts.push(frame);
+    }
+
     fn drive_loop(&mut self, acts: &mut Vec<Frame>, mode: DriveMode) -> RunExit {
         loop {
             // Enforce `interp limit $i time` for unbounded bytecode loops: the
@@ -1044,6 +1073,11 @@ impl Vm {
                 }
                 continue;
             }
+            match self.unwind_stale_profile_frame(acts) {
+                Ok(false) => {}
+                Ok(true) => continue,
+                Err(exit) => return exit,
+            }
             let tick = {
                 let top = acts.last_mut().expect("activation stack is non-empty");
                 self.tick(top)
@@ -1051,13 +1085,7 @@ impl Vm {
             match tick {
                 Tick::Continue => {}
                 Tick::Call { proc, argv } => match self.enter_proc(&proc, &argv) {
-                    Ok(()) => {
-                        let mut fr = Frame::new(Rc::clone(&proc.body), true);
-                        if let Some(ctx) = self.pending_exec_leave.take() {
-                            fr.exec_leave.push(ctx);
-                        }
-                        acts.push(fr);
-                    }
+                    Ok(()) => self.push_proc_frame(acts, &proc),
                     Err(c) => {
                         // A traced dispatch that failed at proc entry (arity)
                         // still settles its leave with the error.
@@ -1075,7 +1103,7 @@ impl Vm {
                     label,
                     cleanup_proc,
                 } => {
-                    let mut fr = Frame::new_script(asm, label);
+                    let mut fr = Frame::new_script(asm, label, self.profile_generation());
                     fr.cleanup_proc = cleanup_proc;
                     if let Some(ctx) = self.pending_exec_leave.take() {
                         fr.exec_leave.push(ctx);
@@ -1083,28 +1111,28 @@ impl Vm {
                     acts.push(fr);
                 }
                 Tick::PushCatch(req) => {
-                    let mut fr = Frame::new_catch(req);
+                    let mut fr = Frame::new_catch(req, self.profile_generation());
                     if let Some(ctx) = self.pending_exec_leave.take() {
                         fr.exec_leave.push(ctx);
                     }
                     acts.push(fr);
                 }
                 Tick::PushSubst(req) => {
-                    let mut fr = Frame::new_subst(req);
+                    let mut fr = Frame::new_subst(req, self.profile_generation());
                     if let Some(ctx) = self.pending_exec_leave.take() {
                         fr.exec_leave.push(ctx);
                     }
                     acts.push(fr);
                 }
                 Tick::PushEachLoop(req) => {
-                    let mut fr = Frame::new_each_loop(req);
+                    let mut fr = Frame::new_each_loop(req, self.profile_generation());
                     if let Some(ctx) = self.pending_exec_leave.take() {
                         fr.exec_leave.push(ctx);
                     }
                     acts.push(fr);
                 }
                 Tick::PushTry(req) => {
-                    let mut fr = Frame::new_try(req);
+                    let mut fr = Frame::new_try(req, self.profile_generation());
                     if let Some(ctx) = self.pending_exec_leave.take() {
                         fr.exec_leave.push(ctx);
                     }
@@ -1139,6 +1167,27 @@ impl Vm {
                 },
             }
         }
+    }
+
+    /// Reject a frame whose profile changed while it was live. Stored
+    /// activations can have a PC and operand stack in the middle of a lowered
+    /// command, so they cannot be safely recompiled like an unentered proc.
+    /// `Ok(true)` means unwinding consumed the stale frame and the caller must
+    /// continue its drive loop; an empty stack is returned as a completed run.
+    fn unwind_stale_profile_frame(&mut self, acts: &mut Vec<Frame>) -> Result<bool, RunExit> {
+        if acts
+            .last()
+            .is_some_and(|frame| frame.profile_generation != self.profile_generation())
+        {
+            return match self.unwind(
+                acts,
+                err("cannot continue bytecode after dialect profile changed"),
+            ) {
+                Some(done) => Err(RunExit::Done(done)),
+                None => Ok(true),
+            };
+        }
+        Ok(false)
     }
 
     /// Settle a frame's exceptional completion (`Tick::Return`): a live catch
@@ -1389,7 +1438,7 @@ impl Vm {
             if let Some(ctx) = act.try_ctx.take() {
                 match crate::cmd_try::advance_try(self, *ctx, c) {
                     crate::cmd_try::TryOutcome::Push(req) => {
-                        acts.push(Frame::new_try(req));
+                        acts.push(Frame::new_try(req, self.profile_generation()));
                         return None;
                     }
                     crate::cmd_try::TryOutcome::Deliver(fc) => c = fc,
@@ -4559,7 +4608,8 @@ impl Vm {
         // a `yield` inside cannot cross it, exactly like every other
         // `invoke_command` re-entry.
         if let Some((asm, label, cleanup_proc)) = self.pending_eval.take() {
-            let comp = self.run_activation(Frame::new_script(asm, label));
+            let comp =
+                self.run_activation(Frame::new_script(asm, label, self.profile_generation()));
             if let Some(name) = cleanup_proc {
                 self.take_command_unchecked(&name);
             }
@@ -4569,20 +4619,21 @@ impl Vm {
         // inside cannot cross this native re-entry), then absorb its
         // completion with the catch epilogue.
         if let Some(req) = self.pending_catch.take() {
-            let comp = self.run_activation(Frame::new_script(req.asm, None));
+            let comp =
+                self.run_activation(Frame::new_script(req.asm, None, self.profile_generation()));
             return self.finish_catch(comp, req.resvar.as_ref(), req.optvar.as_ref());
         }
         // A `subst` deferred: run the scanner-driven subst frame via a
         // nested drive (its `[…]` bodies can't yield across this native
         // re-entry), returning its accumulated result.
         if let Some(req) = self.pending_subst.take() {
-            return self.run_activation(Frame::new_subst(req));
+            return self.run_activation(Frame::new_subst(req, self.profile_generation()));
         }
         // A `foreach`/`lmap` runtime-fallback loop deferred: run the
         // scanner-driven each-loop frame via a nested drive (a `yield` in
         // its body can't cross this native re-entry either).
         if let Some(req) = self.pending_each_loop.take() {
-            return self.run_activation(Frame::new_each_loop(req));
+            return self.run_activation(Frame::new_each_loop(req, self.profile_generation()));
         }
         // A `try` deferred its body: run it (and, via `Vm::unwind`'s own
         // `try_ctx` handling, every subsequent phase `advance_try`
@@ -4592,7 +4643,7 @@ impl Vm {
         // `run_activation` call carries the whole construct through to
         // its final completion.
         if let Some(req) = self.pending_try.take() {
-            return self.run_activation(Frame::new_try(req));
+            return self.run_activation(Frame::new_try(req, self.profile_generation()));
         }
         res
     }
@@ -4644,7 +4695,11 @@ impl Vm {
             Command::Proc(p) => {
                 let p = self.ensure_proc_ready(p);
                 match self.enter_proc(&p, argv) {
-                    Ok(()) => self.run_activation(Frame::new(Rc::clone(&p.body), true)),
+                    Ok(()) => self.run_activation(Frame::new(
+                        Rc::clone(&p.body),
+                        true,
+                        p.compiled_profile_generation,
+                    )),
                     Err(c) => c,
                 }
             }
@@ -4703,7 +4758,11 @@ impl Vm {
             self.add_link(local, 0, storage);
         }
         self.oo.call_stack.push(frame);
-        let result = self.run_activation(Frame::new(Rc::clone(&proc.body), true));
+        let result = self.run_activation(Frame::new(
+            Rc::clone(&proc.body),
+            true,
+            proc.compiled_profile_generation,
+        ));
         self.oo.call_stack.pop();
         result
     }
@@ -4772,7 +4831,11 @@ impl Vm {
             Some(parent) => match self.dispatch_words(parent, words) {
                 Ok(Some(Tick::Call { proc, argv })) => match self.enter_proc(&proc, &argv) {
                     Ok(()) => {
-                        let mut fr = Frame::new(Rc::clone(&proc.body), true);
+                        let mut fr = Frame::new(
+                            Rc::clone(&proc.body),
+                            true,
+                            proc.compiled_profile_generation,
+                        );
                         if let Some(ctx) = self.pending_exec_leave.take() {
                             fr.exec_leave.push(ctx);
                         }

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -988,17 +988,36 @@ impl Vm {
         }
         self.claim_number_grammar();
         self.merge_procs(&module.procedures);
-        self.run_function(&module.top_level)
+        self.run_function_unchecked(&module.top_level)
     }
 
-    /// Run one bytecode function to completion via the NRE trampoline.
+    /// Run one profile-less bytecode function to completion via the NRE
+    /// trampoline.
     ///
-    /// Deep-copies `asm` into the `Rc` the activation needs. An embedder
+    /// A bare [`FunctionAsm`] carries no dialect-profile identity, so this
+    /// low-level assembler API is deliberately available only while the VM is
+    /// using the permissive fallback profile. Named profiles must enter via
+    /// [`run_module`](Self::run_module), whose [`ModuleAsm`] is validated, or
+    /// via a VM-owned [`FunctionHandle`](crate::embed::FunctionHandle).
+    ///
+    /// Deep-copies `asm` into the `Rc` the activation needs. A fallback embedder
     /// invoking the same body repeatedly should hold a
     /// [`FunctionHandle`](crate::embed::FunctionHandle) and call
     /// [`Vm::invoke_function`] instead, which pays that copy once (issue
     /// #1373 finding 3).
     pub fn run_function(&mut self, asm: &FunctionAsm) -> Completion<Value> {
+        if !self.dialect_profile().is_fallback() {
+            return err(format!(
+                "profile-less bytecode cannot run under dialect profile {}",
+                self.dialect_profile().name
+            ));
+        }
+        self.run_function_unchecked(asm)
+    }
+
+    /// Execute a function whose containing module has already passed the
+    /// exact-profile check, or whose ownership is otherwise VM-internal.
+    fn run_function_unchecked(&mut self, asm: &FunctionAsm) -> Completion<Value> {
         self.run_function_rc(Rc::new(asm.clone()))
     }
 
@@ -1011,7 +1030,7 @@ impl Vm {
     /// Run one activation stack to completion (the ordinary, non-coroutine path).
     /// The initial frame's `is_proc` decides whether the outermost body is a proc
     /// call (so `unwind` pops a call-frame + namespace and absorbs `return`):
-    /// `false` for a module top-level ([`run_function`](Self::run_function)),
+    /// `false` for a module top-level,
     /// `true` for [`invoke_command`](Self::invoke_command) running a proc body.
     fn run_activation(&mut self, initial: Frame) -> Completion<Value> {
         let mut acts: Vec<Frame> = vec![initial];

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -1342,7 +1342,7 @@ impl Vm {
             // nested-drive `cmd_apply`'s unconditional `vm.take_command` after
             // `eval_source` returned (issue #1311).
             if let Some(name) = act.cleanup_proc.take() {
-                self.take_command(&name);
+                self.take_command_unchecked(&name);
             }
             // A `catch` activation absorbs the body's completion of *any* code:
             // its epilogue binds the result / options variables and yields the
@@ -3805,19 +3805,22 @@ impl Vm {
             // chain and errors when the name resolves to nothing.
             Op::RESOLVE_CMD => {
                 let name = pop(f).to_str();
-                let fqn = self
-                    .resolve_command_fqn(self.current_ns(), &name)
-                    .map_or_else(Value::empty, |key| Value::string(format!("::{key}")));
+                let fqn = if self.lookup_command(&name).is_some() {
+                    self.resolve_command_fqn(self.current_ns(), &name)
+                        .map_or_else(Value::empty, |key| Value::string(format!("::{key}")))
+                } else {
+                    Value::empty()
+                };
                 f.stack.push(fqn);
             }
             Op::ORIGIN_CMD => {
                 let name = pop(f).to_str();
                 match self.resolve_command_fqn(self.current_ns(), &name) {
-                    Some(key) => {
+                    Some(key) if self.lookup_command(&name).is_some() => {
                         let origin = self.command_origin_key(&key);
                         f.stack.push(Value::string(format!("::{origin}")));
                     }
-                    None => {
+                    _ => {
                         return Tick::Return(err(format!("invalid command name \"{name}\"")));
                     }
                 }
@@ -4376,7 +4379,7 @@ impl Vm {
         if let Some((asm, label, cleanup_proc)) = self.pending_eval.take() {
             let comp = self.run_activation(Frame::new_script(asm, label));
             if let Some(name) = cleanup_proc {
-                self.take_command(&name);
+                self.take_command_unchecked(&name);
             }
             return comp;
         }

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -4109,7 +4109,9 @@ impl Vm {
             ]
         };
         let mut replacement = None;
-        if let Some(entries) = self.exec_traces.get(&ctx.key.key()).cloned() {
+        if let Some(key) = ctx.key.key()
+            && let Some(entries) = self.exec_traces.get(&key).cloned()
+        {
             for e in entries {
                 if e.has_op("leave") {
                     let r = self.run_cmd_trace_callback(&e, &args("leave"));

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -4019,14 +4019,9 @@ impl Vm {
         // The complete current command, list-merged (tclsh-pinned shape:
         // `p one {t w o}`).
         let cmd_string = Value::list(words.to_vec()).to_str().to_string();
-        for scope in self
-            .exec_step_scopes
-            .iter()
-            .rev()
-            .cloned()
-            .collect::<Vec<_>>()
-        {
-            if scope.active_for("enterstep") {
+        for scope in self.exec_step_scopes.clone() {
+            if scope.active_for("enterstep") && self.exec_trace_entry_live(&scope.key, &scope.entry)
+            {
                 let r = self.run_cmd_trace_callback(
                     &scope.entry,
                     &[
@@ -4043,7 +4038,7 @@ impl Vm {
         let sidecar = self.active_sidecar(key.clone());
         let own = self.exec_traces.get(&key).cloned().unwrap_or_default();
         for entry in own.iter().rev() {
-            if !sidecar.is_attached() {
+            if !self.exec_trace_entry_live(&sidecar, entry) {
                 break;
             }
             if entry.has_op("enter") {
@@ -4058,7 +4053,7 @@ impl Vm {
         }
         let mut pushed = 0usize;
         for entry in own.iter().rev() {
-            if !sidecar.is_attached() {
+            if !self.exec_trace_entry_live(&sidecar, entry) {
                 break;
             }
             if entry.has_op("enterstep") || entry.has_op("leavestep") {
@@ -4147,7 +4142,7 @@ impl Vm {
             && let Some(entries) = self.exec_traces.get(&key).cloned()
         {
             for e in entries {
-                if !ctx.key.is_attached() {
+                if !self.exec_trace_entry_live(&ctx.key, &e) {
                     break;
                 }
                 if e.has_op("leave") {
@@ -4167,7 +4162,8 @@ impl Vm {
             .cloned()
             .collect::<Vec<_>>()
         {
-            if scope.active_for("leavestep") {
+            if scope.active_for("leavestep") && self.exec_trace_entry_live(&scope.key, &scope.entry)
+            {
                 let r = self
                     .run_cmd_trace_callback(&scope.entry, &args(trace_result.clone(), "leavestep"));
                 if !r.code.is_ok() {
@@ -4178,6 +4174,21 @@ impl Vm {
             }
         }
         replacement
+    }
+
+    /// A cloned trace snapshot may outlive an earlier callback removing its
+    /// registration.  Rc pointer identity distinguishes duplicate callbacks;
+    /// a later addition is absent from the snapshot and therefore excluded.
+    fn exec_trace_entry_live(
+        &self,
+        handle: &CommandSidecarHandle,
+        entry: &Rc<CmdTraceEntry>,
+    ) -> bool {
+        handle.key().is_some_and(|key| {
+            self.exec_traces
+                .get(&key)
+                .is_some_and(|entries| entries.iter().any(|live| Rc::ptr_eq(live, entry)))
+        })
     }
 
     /// Deliver a synchronously-completed dispatch into `f`: an ok result is
@@ -4370,14 +4381,9 @@ impl Vm {
         words.push(Value::string(name));
         words.extend_from_slice(argv);
         let cmd_string = Value::list(words).to_str().to_string();
-        for scope in self
-            .exec_step_scopes
-            .iter()
-            .rev()
-            .cloned()
-            .collect::<Vec<_>>()
-        {
-            if scope.active_for("enterstep") {
+        for scope in self.exec_step_scopes.clone() {
+            if scope.active_for("enterstep") && self.exec_trace_entry_live(&scope.key, &scope.entry)
+            {
                 let r = self.run_cmd_trace_callback(
                     &scope.entry,
                     &[
@@ -4394,7 +4400,7 @@ impl Vm {
         let sidecar = self.active_sidecar(key.clone());
         let own = self.exec_traces.get(&key).cloned().unwrap_or_default();
         for entry in own.iter().rev() {
-            if !sidecar.is_attached() {
+            if !self.exec_trace_entry_live(&sidecar, entry) {
                 break;
             }
             if entry.has_op("enter") {
@@ -4409,7 +4415,7 @@ impl Vm {
         }
         let mut pushed = 0usize;
         for entry in own.iter().rev() {
-            if !sidecar.is_attached() {
+            if !self.exec_trace_entry_live(&sidecar, entry) {
                 break;
             }
             if entry.has_op("enterstep") || entry.has_op("leavestep") {
@@ -4459,14 +4465,9 @@ impl Vm {
         words.push(Value::string(display_name));
         words.extend_from_slice(argv);
         let cmd_string = Value::list(words).to_str().to_string();
-        for scope in self
-            .exec_step_scopes
-            .iter()
-            .rev()
-            .cloned()
-            .collect::<Vec<_>>()
-        {
-            if scope.active_for("enterstep") {
+        for scope in self.exec_step_scopes.clone() {
+            if scope.active_for("enterstep") && self.exec_trace_entry_live(&scope.key, &scope.entry)
+            {
                 let r = self.run_cmd_trace_callback(
                     &scope.entry,
                     &[
@@ -4486,7 +4487,7 @@ impl Vm {
             .cloned()
             .unwrap_or_default();
         for entry in own.iter().rev() {
-            if !sidecar.is_attached() {
+            if !self.exec_trace_entry_live(&sidecar, entry) {
                 break;
             }
             if entry.has_op("enter") {
@@ -4501,7 +4502,7 @@ impl Vm {
         }
         let mut pushed = 0usize;
         for entry in own.iter().rev() {
-            if !sidecar.is_attached() {
+            if !self.exec_trace_entry_live(&sidecar, entry) {
                 break;
             }
             if entry.has_op("enterstep") || entry.has_op("leavestep") {

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -36,7 +36,7 @@ use tcl_syntax::value::string_char_len;
 
 use crate::command::{Command, ProcDef};
 use crate::expr;
-use crate::interp::{Vm, err, ok};
+use crate::interp::{CommandSidecarKey, Vm, err, ok};
 use crate::value::Value;
 
 /// Active `foreach` iteration state (C Tcl `ForeachInfo` + the loop counters).
@@ -205,7 +205,7 @@ pub(crate) struct Frame {
 /// pushed (popped before firing).
 pub(crate) struct ExecLeaveCtx {
     cmd_string: String,
-    key: String,
+    key: CommandSidecarKey,
     step_scopes: usize,
 }
 
@@ -4018,6 +4018,7 @@ impl Vm {
                 }
             }
         }
+        let key = CommandSidecarKey::visible(key);
         let own = self.exec_traces.get(&key).cloned().unwrap_or_default();
         for entry in &own {
             if entry.has_op("enter") {
@@ -4333,6 +4334,7 @@ impl Vm {
                 }
             }
         }
+        let key = CommandSidecarKey::visible(key);
         let own = self.exec_traces.get(&key).cloned().unwrap_or_default();
         for entry in &own {
             if entry.has_op("enter") {
@@ -4370,7 +4372,7 @@ impl Vm {
     pub(crate) fn invoke_resolved_command(
         &mut self,
         display_name: &str,
-        trace_key: &str,
+        trace_key: CommandSidecarKey,
         command: Command,
         argv: &[Value],
     ) -> Completion<Value> {
@@ -4380,7 +4382,12 @@ impl Vm {
         if self.trace_in_progress.get()
             || (self.exec_traces.is_empty() && self.exec_step_scopes.is_empty())
         {
-            return self.invoke_resolved_command_inner(display_name, command, argv);
+            return self.invoke_resolved_command_inner(
+                display_name,
+                command,
+                argv,
+                Some(trace_key),
+            );
         }
         let mut words = Vec::with_capacity(argv.len() + 1);
         words.push(Value::string(display_name));
@@ -4400,7 +4407,11 @@ impl Vm {
                 }
             }
         }
-        let own = self.exec_traces.get(trace_key).cloned().unwrap_or_default();
+        let own = self
+            .exec_traces
+            .get(&trace_key)
+            .cloned()
+            .unwrap_or_default();
         for entry in &own {
             if entry.has_op("enter") {
                 let r = self.run_cmd_trace_callback(
@@ -4419,12 +4430,13 @@ impl Vm {
                 pushed += 1;
             }
         }
+        let sidecar = trace_key.clone();
         let ctx = ExecLeaveCtx {
             cmd_string,
-            key: trace_key.to_owned(),
+            key: trace_key,
             step_scopes: pushed,
         };
-        let c = self.invoke_resolved_command_inner(display_name, command, argv);
+        let c = self.invoke_resolved_command_inner(display_name, command, argv, Some(sidecar));
         match self.finish_exec_leave(&ctx, &c) {
             Some(replacement) => replacement,
             None => c,
@@ -4485,7 +4497,7 @@ impl Vm {
     /// The untraced invoke body — see [`Self::invoke_command`].
     fn invoke_command_inner(&mut self, name: &str, argv: &[Value]) -> Completion<Value> {
         match self.lookup_command(name) {
-            Some(command) => self.invoke_resolved_command_inner(name, command, argv),
+            Some(command) => self.invoke_resolved_command_inner(name, command, argv, None),
             None if name != "unknown" => {
                 if let Some(handler) = self.ns_unknown_handler() {
                     let mut handler_words = handler;
@@ -4511,11 +4523,14 @@ impl Vm {
         name: &str,
         command: Command,
         argv: &[Value],
+        sidecar: Option<CommandSidecarKey>,
     ) -> Completion<Value> {
         match command {
             Command::Builtin(bf) => {
                 self.set_invoked_name(name);
+                let saved = std::mem::replace(&mut self.invoked_sidecar, sidecar);
                 let res = bf(self, argv);
+                self.invoked_sidecar = saved;
                 self.settle_native_invoke(res)
             }
             Command::Native(cmd) => {

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -4364,6 +4364,73 @@ impl Vm {
         }
     }
 
+    /// Invoke an already-resolved command without consulting the visible
+    /// command table.  Hidden-command dispatch uses this to keep a hidden
+    /// binding private while preserving its display spelling and trace key.
+    pub(crate) fn invoke_resolved_command(
+        &mut self,
+        display_name: &str,
+        trace_key: &str,
+        command: Command,
+        argv: &[Value],
+    ) -> Completion<Value> {
+        if let Some(exceeded) = self.charge_command() {
+            return exceeded;
+        }
+        if self.trace_in_progress.get()
+            || (self.exec_traces.is_empty() && self.exec_step_scopes.is_empty())
+        {
+            return self.invoke_resolved_command_inner(display_name, command, argv);
+        }
+        let mut words = Vec::with_capacity(argv.len() + 1);
+        words.push(Value::string(display_name));
+        words.extend_from_slice(argv);
+        let cmd_string = Value::list(words).to_str().to_string();
+        for scope in self.exec_step_scopes.clone() {
+            if scope.has_op("enterstep") && !scope.firing() {
+                let r = self.run_cmd_trace_callback(
+                    &scope,
+                    &[
+                        Value::string(cmd_string.clone()),
+                        Value::string("enterstep"),
+                    ],
+                );
+                if !r.code.is_ok() {
+                    return r;
+                }
+            }
+        }
+        let own = self.exec_traces.get(trace_key).cloned().unwrap_or_default();
+        for entry in &own {
+            if entry.has_op("enter") {
+                let r = self.run_cmd_trace_callback(
+                    entry,
+                    &[Value::string(cmd_string.clone()), Value::string("enter")],
+                );
+                if !r.code.is_ok() {
+                    return r;
+                }
+            }
+        }
+        let mut pushed = 0usize;
+        for entry in &own {
+            if entry.has_op("enterstep") || entry.has_op("leavestep") {
+                self.exec_step_scopes.push(Rc::clone(entry));
+                pushed += 1;
+            }
+        }
+        let ctx = ExecLeaveCtx {
+            cmd_string,
+            key: trace_key.to_owned(),
+            step_scopes: pushed,
+        };
+        let c = self.invoke_resolved_command_inner(display_name, command, argv);
+        match self.finish_exec_leave(&ctx, &c) {
+            Some(replacement) => replacement,
+            None => c,
+        }
+    }
+
     /// Settle a synchronously-run native command on the native re-entry path
     /// ([`Self::invoke_command`]): a deferred body runs via a nested drive,
     /// else the completion is the command's own. The
@@ -4418,50 +4485,7 @@ impl Vm {
     /// The untraced invoke body — see [`Self::invoke_command`].
     fn invoke_command_inner(&mut self, name: &str, argv: &[Value]) -> Completion<Value> {
         match self.lookup_command(name) {
-            Some(Command::Builtin(bf)) => {
-                self.set_invoked_name(name);
-                let res = bf(self, argv);
-                self.settle_native_invoke(res)
-            }
-            Some(Command::Native(cmd)) => {
-                self.set_invoked_name(name);
-                let res = cmd.invoke(self, argv);
-                self.settle_native_invoke(res)
-            }
-            Some(Command::Proc(p)) => {
-                let p = self.ensure_proc_ready(p);
-                match self.enter_proc(&p, argv) {
-                    Ok(()) => self.run_activation(Frame::new(Rc::clone(&p.body), true)),
-                    Err(c) => c,
-                }
-            }
-            Some(Command::Alias(target)) => {
-                // Target resolves in the GLOBAL namespace, caller's frame kept
-                // — see the `dispatch_words` Alias arm for the tclsh pins.
-                let mut full: Vec<Value> = (*target).clone();
-                full.extend_from_slice(argv);
-                let here = self.cur_interp();
-                self.invoke_alias_words(here, &full)
-            }
-            // Cross-interp alias: switch to the target interp and run the words
-            // there.  Identical to the bytecode path — a cross-interp alias
-            // works from a native re-entry (coroutine resume, `lsort
-            // -command`, `invoke_command`), which used to error
-            // `cannot invoke parent-interp alias: C stack busy` (issue #946
-            // fault 1).
-            Some(Command::CrossAlias {
-                target: target_interp,
-                words: target,
-            }) => {
-                let mut full: Vec<Value> = (*target).clone();
-                full.extend_from_slice(argv);
-                self.invoke_alias_words(target_interp, &full)
-            }
-            Some(Command::ChildInterp(child)) => self.dispatch_child(name, child, argv),
-            Some(Command::Ensemble(e)) => self.dispatch_ensemble(name, &e, argv),
-            Some(Command::Object(key)) => crate::cmd_oo::oo_dispatch(self, &key, name, argv),
-            // Miss fallback chain (see `dispatch_words`): `namespace unknown`
-            // handler first, then the plain `unknown` proc, then a hard error.
+            Some(command) => self.invoke_resolved_command_inner(name, command, argv),
             None if name != "unknown" => {
                 if let Some(handler) = self.ns_unknown_handler() {
                     let mut handler_words = handler;
@@ -4479,6 +4503,60 @@ impl Vm {
                 }
             }
             None => err(format!("invalid command name \"{name}\"")),
+        }
+    }
+
+    fn invoke_resolved_command_inner(
+        &mut self,
+        name: &str,
+        command: Command,
+        argv: &[Value],
+    ) -> Completion<Value> {
+        match command {
+            Command::Builtin(bf) => {
+                self.set_invoked_name(name);
+                let res = bf(self, argv);
+                self.settle_native_invoke(res)
+            }
+            Command::Native(cmd) => {
+                self.set_invoked_name(name);
+                let res = cmd.invoke(self, argv);
+                self.settle_native_invoke(res)
+            }
+            Command::Proc(p) => {
+                let p = self.ensure_proc_ready(p);
+                match self.enter_proc(&p, argv) {
+                    Ok(()) => self.run_activation(Frame::new(Rc::clone(&p.body), true)),
+                    Err(c) => c,
+                }
+            }
+            Command::Alias(target) => {
+                // Target resolves in the GLOBAL namespace, caller's frame kept
+                // — see the `dispatch_words` Alias arm for the tclsh pins.
+                let mut full: Vec<Value> = (*target).clone();
+                full.extend_from_slice(argv);
+                let here = self.cur_interp();
+                self.invoke_alias_words(here, &full)
+            }
+            // Cross-interp alias: switch to the target interp and run the words
+            // there.  Identical to the bytecode path — a cross-interp alias
+            // works from a native re-entry (coroutine resume, `lsort
+            // -command`, `invoke_command`), which used to error
+            // `cannot invoke parent-interp alias: C stack busy` (issue #946
+            // fault 1).
+            Command::CrossAlias {
+                target: target_interp,
+                words: target,
+            } => {
+                let mut full: Vec<Value> = (*target).clone();
+                full.extend_from_slice(argv);
+                self.invoke_alias_words(target_interp, &full)
+            }
+            Command::ChildInterp(child) => self.dispatch_child(name, child, argv),
+            Command::Ensemble(e) => self.dispatch_ensemble(name, &e, argv),
+            Command::Object(key) => crate::cmd_oo::oo_dispatch(self, &key, name, argv),
+            // Miss fallback chain (see `dispatch_words`): `namespace unknown`
+            // handler first, then the plain `unknown` proc, then a hard error.
         }
     }
 

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -36,7 +36,7 @@ use tcl_syntax::value::string_char_len;
 
 use crate::command::{Command, ProcDef};
 use crate::expr;
-use crate::interp::{CommandSidecarKey, Vm, err, ok};
+use crate::interp::{CommandSidecarHandle, CommandSidecarKey, Vm, err, ok};
 use crate::value::Value;
 
 /// Active `foreach` iteration state (C Tcl `ForeachInfo` + the loop counters).
@@ -205,7 +205,7 @@ pub(crate) struct Frame {
 /// pushed (popped before firing).
 pub(crate) struct ExecLeaveCtx {
     cmd_string: String,
-    key: CommandSidecarKey,
+    key: CommandSidecarHandle,
     step_scopes: usize,
 }
 
@@ -4040,7 +4040,7 @@ impl Vm {
         }
         let ctx = ExecLeaveCtx {
             cmd_string,
-            key,
+            key: self.active_sidecar(key),
             step_scopes: pushed,
         };
         match self.dispatch_words_inner(f, words) {
@@ -4109,7 +4109,7 @@ impl Vm {
             ]
         };
         let mut replacement = None;
-        if let Some(entries) = self.exec_traces.get(&ctx.key).cloned() {
+        if let Some(entries) = self.exec_traces.get(&ctx.key.key()).cloned() {
             for e in entries {
                 if e.has_op("leave") {
                     let r = self.run_cmd_trace_callback(&e, &args("leave"));
@@ -4356,7 +4356,7 @@ impl Vm {
         }
         let ctx = ExecLeaveCtx {
             cmd_string,
-            key,
+            key: self.active_sidecar(key),
             step_scopes: pushed,
         };
         let c = self.invoke_command_inner(name, argv);
@@ -4433,7 +4433,7 @@ impl Vm {
         let sidecar = trace_key.clone();
         let ctx = ExecLeaveCtx {
             cmd_string,
-            key: trace_key,
+            key: self.active_sidecar(trace_key),
             step_scopes: pushed,
         };
         let c = self.invoke_resolved_command_inner(display_name, command, argv, Some(sidecar));

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -36,7 +36,7 @@ use tcl_syntax::value::string_char_len;
 
 use crate::command::{Command, ProcDef};
 use crate::expr;
-use crate::interp::{CommandSidecarHandle, CommandSidecarKey, Vm, err, ok};
+use crate::interp::{CmdTraceEntry, CommandSidecarHandle, CommandSidecarKey, Vm, err, ok};
 use crate::value::Value;
 
 /// Active `foreach` iteration state (C Tcl `ForeachInfo` + the loop counters).
@@ -207,6 +207,21 @@ pub(crate) struct ExecLeaveCtx {
     cmd_string: String,
     key: CommandSidecarHandle,
     step_scopes: usize,
+}
+
+/// A step trace remains attached to the command invocation that installed it.
+/// A copied trace entry alone is not enough: its command may be deleted and
+/// replaced while an inner command is running.
+#[derive(Clone)]
+pub(crate) struct ExecStepScope {
+    pub(crate) entry: Rc<CmdTraceEntry>,
+    pub(crate) key: CommandSidecarHandle,
+}
+
+impl ExecStepScope {
+    fn active_for(&self, op: &str) -> bool {
+        self.key.is_attached() && self.entry.has_op(op) && !self.entry.firing()
+    }
 }
 
 /// A `catch`'s bind targets, carried on its activation until it completes.
@@ -4004,10 +4019,16 @@ impl Vm {
         // The complete current command, list-merged (tclsh-pinned shape:
         // `p one {t w o}`).
         let cmd_string = Value::list(words.to_vec()).to_str().to_string();
-        for scope in self.exec_step_scopes.clone() {
-            if scope.has_op("enterstep") && !scope.firing() {
+        for scope in self
+            .exec_step_scopes
+            .iter()
+            .rev()
+            .cloned()
+            .collect::<Vec<_>>()
+        {
+            if scope.active_for("enterstep") {
                 let r = self.run_cmd_trace_callback(
-                    &scope,
+                    &scope.entry,
                     &[
                         Value::string(cmd_string.clone()),
                         Value::string("enterstep"),
@@ -4021,7 +4042,7 @@ impl Vm {
         let key = CommandSidecarKey::visible(key);
         let sidecar = self.active_sidecar(key.clone());
         let own = self.exec_traces.get(&key).cloned().unwrap_or_default();
-        for entry in &own {
+        for entry in own.iter().rev() {
             if !sidecar.is_attached() {
                 break;
             }
@@ -4036,12 +4057,15 @@ impl Vm {
             }
         }
         let mut pushed = 0usize;
-        for entry in &own {
+        for entry in own.iter().rev() {
             if !sidecar.is_attached() {
                 break;
             }
             if entry.has_op("enterstep") || entry.has_op("leavestep") {
-                self.exec_step_scopes.push(Rc::clone(entry));
+                self.exec_step_scopes.push(ExecStepScope {
+                    entry: Rc::clone(entry),
+                    key: sidecar.clone(),
+                });
                 pushed += 1;
             }
         }
@@ -4107,15 +4131,18 @@ impl Vm {
         if self.exec_traces.is_empty() && self.exec_step_scopes.is_empty() {
             return None;
         }
-        let args = |op: &str| {
+        let args = |result: Value, op: &str| {
             [
                 Value::string(ctx.cmd_string.clone()),
                 Value::string(c.code.as_int().to_string()),
-                c.result.clone(),
+                result,
                 Value::string(op),
             ]
         };
         let mut replacement = None;
+        // Tcl threads a successful leave callback's result to the next
+        // callback, while the traced command's own completion remains `c`.
+        let mut trace_result = c.result.clone();
         if let Some(key) = ctx.key.key()
             && let Some(entries) = self.exec_traces.get(&key).cloned()
         {
@@ -4124,19 +4151,30 @@ impl Vm {
                     break;
                 }
                 if e.has_op("leave") {
-                    let r = self.run_cmd_trace_callback(&e, &args("leave"));
+                    let r = self.run_cmd_trace_callback(&e, &args(trace_result.clone(), "leave"));
                     if !r.code.is_ok() {
                         replacement = Some(r);
+                        break;
                     }
+                    trace_result = r.result;
                 }
             }
         }
-        for scope in self.exec_step_scopes.clone() {
-            if scope.has_op("leavestep") && !scope.firing() {
-                let r = self.run_cmd_trace_callback(&scope, &args("leavestep"));
+        for scope in self
+            .exec_step_scopes
+            .iter()
+            .rev()
+            .cloned()
+            .collect::<Vec<_>>()
+        {
+            if scope.active_for("leavestep") {
+                let r = self
+                    .run_cmd_trace_callback(&scope.entry, &args(trace_result.clone(), "leavestep"));
                 if !r.code.is_ok() {
                     replacement = Some(r);
+                    break;
                 }
+                trace_result = r.result;
             }
         }
         replacement
@@ -4332,10 +4370,16 @@ impl Vm {
         words.push(Value::string(name));
         words.extend_from_slice(argv);
         let cmd_string = Value::list(words).to_str().to_string();
-        for scope in self.exec_step_scopes.clone() {
-            if scope.has_op("enterstep") && !scope.firing() {
+        for scope in self
+            .exec_step_scopes
+            .iter()
+            .rev()
+            .cloned()
+            .collect::<Vec<_>>()
+        {
+            if scope.active_for("enterstep") {
                 let r = self.run_cmd_trace_callback(
-                    &scope,
+                    &scope.entry,
                     &[
                         Value::string(cmd_string.clone()),
                         Value::string("enterstep"),
@@ -4349,7 +4393,7 @@ impl Vm {
         let key = CommandSidecarKey::visible(key);
         let sidecar = self.active_sidecar(key.clone());
         let own = self.exec_traces.get(&key).cloned().unwrap_or_default();
-        for entry in &own {
+        for entry in own.iter().rev() {
             if !sidecar.is_attached() {
                 break;
             }
@@ -4364,12 +4408,15 @@ impl Vm {
             }
         }
         let mut pushed = 0usize;
-        for entry in &own {
+        for entry in own.iter().rev() {
             if !sidecar.is_attached() {
                 break;
             }
             if entry.has_op("enterstep") || entry.has_op("leavestep") {
-                self.exec_step_scopes.push(Rc::clone(entry));
+                self.exec_step_scopes.push(ExecStepScope {
+                    entry: Rc::clone(entry),
+                    key: sidecar.clone(),
+                });
                 pushed += 1;
             }
         }
@@ -4412,10 +4459,16 @@ impl Vm {
         words.push(Value::string(display_name));
         words.extend_from_slice(argv);
         let cmd_string = Value::list(words).to_str().to_string();
-        for scope in self.exec_step_scopes.clone() {
-            if scope.has_op("enterstep") && !scope.firing() {
+        for scope in self
+            .exec_step_scopes
+            .iter()
+            .rev()
+            .cloned()
+            .collect::<Vec<_>>()
+        {
+            if scope.active_for("enterstep") {
                 let r = self.run_cmd_trace_callback(
-                    &scope,
+                    &scope.entry,
                     &[
                         Value::string(cmd_string.clone()),
                         Value::string("enterstep"),
@@ -4432,7 +4485,7 @@ impl Vm {
             .get(&trace_key)
             .cloned()
             .unwrap_or_default();
-        for entry in &own {
+        for entry in own.iter().rev() {
             if !sidecar.is_attached() {
                 break;
             }
@@ -4447,12 +4500,15 @@ impl Vm {
             }
         }
         let mut pushed = 0usize;
-        for entry in &own {
+        for entry in own.iter().rev() {
             if !sidecar.is_attached() {
                 break;
             }
             if entry.has_op("enterstep") || entry.has_op("leavestep") {
-                self.exec_step_scopes.push(Rc::clone(entry));
+                self.exec_step_scopes.push(ExecStepScope {
+                    entry: Rc::clone(entry),
+                    key: sidecar.clone(),
+                });
                 pushed += 1;
             }
         }

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -4038,8 +4038,11 @@ impl Vm {
         let sidecar = self.active_sidecar(key.clone());
         let own = self.exec_traces.get(&key).cloned().unwrap_or_default();
         for entry in own.iter().rev() {
-            if !self.exec_trace_entry_live(&sidecar, entry) {
+            if !sidecar.is_attached() {
                 break;
+            }
+            if !self.exec_trace_entry_live(&sidecar, entry) {
+                continue;
             }
             if entry.has_op("enter") {
                 let r = self.run_cmd_trace_callback(
@@ -4053,8 +4056,11 @@ impl Vm {
         }
         let mut pushed = 0usize;
         for entry in own.iter().rev() {
-            if !self.exec_trace_entry_live(&sidecar, entry) {
+            if !sidecar.is_attached() {
                 break;
+            }
+            if !self.exec_trace_entry_live(&sidecar, entry) {
+                continue;
             }
             if entry.has_op("enterstep") || entry.has_op("leavestep") {
                 self.exec_step_scopes.push(ExecStepScope {
@@ -4142,8 +4148,11 @@ impl Vm {
             && let Some(entries) = self.exec_traces.get(&key).cloned()
         {
             for e in entries {
-                if !self.exec_trace_entry_live(&ctx.key, &e) {
+                if !ctx.key.is_attached() {
                     break;
+                }
+                if !self.exec_trace_entry_live(&ctx.key, &e) {
+                    continue;
                 }
                 if e.has_op("leave") {
                     let r = self.run_cmd_trace_callback(&e, &args(trace_result.clone(), "leave"));
@@ -4400,8 +4409,11 @@ impl Vm {
         let sidecar = self.active_sidecar(key.clone());
         let own = self.exec_traces.get(&key).cloned().unwrap_or_default();
         for entry in own.iter().rev() {
-            if !self.exec_trace_entry_live(&sidecar, entry) {
+            if !sidecar.is_attached() {
                 break;
+            }
+            if !self.exec_trace_entry_live(&sidecar, entry) {
+                continue;
             }
             if entry.has_op("enter") {
                 let r = self.run_cmd_trace_callback(
@@ -4415,8 +4427,11 @@ impl Vm {
         }
         let mut pushed = 0usize;
         for entry in own.iter().rev() {
-            if !self.exec_trace_entry_live(&sidecar, entry) {
+            if !sidecar.is_attached() {
                 break;
+            }
+            if !self.exec_trace_entry_live(&sidecar, entry) {
+                continue;
             }
             if entry.has_op("enterstep") || entry.has_op("leavestep") {
                 self.exec_step_scopes.push(ExecStepScope {
@@ -4487,8 +4502,11 @@ impl Vm {
             .cloned()
             .unwrap_or_default();
         for entry in own.iter().rev() {
-            if !self.exec_trace_entry_live(&sidecar, entry) {
+            if !sidecar.is_attached() {
                 break;
+            }
+            if !self.exec_trace_entry_live(&sidecar, entry) {
+                continue;
             }
             if entry.has_op("enter") {
                 let r = self.run_cmd_trace_callback(
@@ -4502,8 +4520,11 @@ impl Vm {
         }
         let mut pushed = 0usize;
         for entry in own.iter().rev() {
-            if !self.exec_trace_entry_live(&sidecar, entry) {
+            if !sidecar.is_attached() {
                 break;
+            }
+            if !self.exec_trace_entry_live(&sidecar, entry) {
+                continue;
             }
             if entry.has_op("enterstep") || entry.has_op("leavestep") {
                 self.exec_step_scopes.push(ExecStepScope {

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -4549,6 +4549,7 @@ impl Vm {
                 command,
                 argv,
                 Some(trace_key),
+                None,
             );
         }
         let mut words = Vec::with_capacity(argv.len() + 1);
@@ -4611,10 +4612,19 @@ impl Vm {
         }
         let ctx = ExecLeaveCtx {
             cmd_string,
-            key: sidecar,
+            key: sidecar.clone(),
             step_scopes: pushed,
         };
-        let c = self.invoke_resolved_command_inner(display_name, command, argv, Some(trace_key));
+        let Some(live_key) = sidecar.key() else {
+            return err("attempt to invoke a deleted command");
+        };
+        let c = self.invoke_resolved_command_inner(
+            display_name,
+            command,
+            argv,
+            Some(live_key),
+            Some(&sidecar),
+        );
         match self.finish_exec_leave(&ctx, &c) {
             Some(replacement) => replacement,
             None => c,
@@ -4677,7 +4687,7 @@ impl Vm {
     /// The untraced invoke body — see [`Self::invoke_command`].
     fn invoke_command_inner(&mut self, name: &str, argv: &[Value]) -> Completion<Value> {
         match self.lookup_command(name) {
-            Some(command) => self.invoke_resolved_command_inner(name, command, argv, None),
+            Some(command) => self.invoke_resolved_command_inner(name, command, argv, None, None),
             None if name != "unknown" => {
                 if let Some(handler) = self.ns_unknown_handler() {
                     let mut handler_words = handler;
@@ -4704,6 +4714,7 @@ impl Vm {
         command: Command,
         argv: &[Value],
         sidecar: Option<CommandSidecarKey>,
+        sidecar_handle: Option<&CommandSidecarHandle>,
     ) -> Completion<Value> {
         match command {
             Command::Builtin(bf) => {
@@ -4719,7 +4730,7 @@ impl Vm {
                 self.settle_native_invoke(res)
             }
             Command::Proc(p) => {
-                let p = self.ensure_proc_ready_in(p, sidecar.as_ref());
+                let p = self.ensure_proc_ready_in(p, sidecar.as_ref(), sidecar_handle);
                 match self.enter_proc(&p, argv) {
                     Ok(()) => self.run_activation(Frame::new(
                         Rc::clone(&p.body),

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -983,6 +983,13 @@ fn proc_usage(proc: &ProcDef) -> String {
 impl Vm {
     /// Run a module: register its compiled procs, then run the top-level script.
     pub fn run_module(&mut self, module: &ModuleAsm) -> Completion<Value> {
+        if !module.profile.is_fallback() && !std::ptr::eq(module.profile, self.dialect_profile()) {
+            return err(format!(
+                "bytecode compiled for dialect profile {} cannot run under {}",
+                module.profile.name,
+                self.dialect_profile().name
+            ));
+        }
         self.claim_number_grammar();
         self.merge_procs(&module.procedures);
         self.run_function(&module.top_level)
@@ -1179,7 +1186,11 @@ impl Vm {
             .last()
             .is_some_and(|frame| frame.profile_generation != self.profile_generation())
         {
-            return match self.unwind(
+            // This is a command-like failure at the current instruction
+            // boundary. Route it through the ordinary settlement seam so an
+            // enclosing inline `catch` observes it before the activation is
+            // unwound.
+            return match self.settle_completion(
                 acts,
                 err("cannot continue bytecode after dialect profile changed"),
             ) {

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -4719,7 +4719,7 @@ impl Vm {
                 self.settle_native_invoke(res)
             }
             Command::Proc(p) => {
-                let p = self.ensure_proc_ready(p);
+                let p = self.ensure_proc_ready_in(p, sidecar.as_ref());
                 match self.enter_proc(&p, argv) {
                     Ok(()) => self.run_activation(Frame::new(
                         Rc::clone(&p.body),

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -2552,7 +2552,11 @@ impl Vm {
     /// registered builtin derives it from its key; a moved builtin carries it
     /// in [`Self::builtin_identities`].
     fn builtin_identity_for_key(&self, key: &str) -> Option<String> {
-        matches!(self.commands.get(key), Some(Command::Builtin(_))).then(|| {
+        matches!(
+            self.commands.get(key),
+            Some(Command::Builtin(_) | Command::Native(_))
+        )
+        .then(|| {
             self.builtin_identities
                 .get(key)
                 .cloned()
@@ -2580,6 +2584,7 @@ impl Vm {
             _ => None,
         };
         self.hidden_commands.insert(token.to_owned(), command);
+        self.move_command_traces(&source, token);
         if let Some(origin) = import_origin {
             self.hidden_imported_commands
                 .insert(token.to_owned(), origin);
@@ -2609,6 +2614,7 @@ impl Vm {
                 _ => None,
             };
             self.register_command(token, c);
+            self.move_command_traces(cmd, token);
             if let Some(origin) = self.hidden_imported_commands.remove(cmd) {
                 self.imported_commands.insert(token.to_owned(), origin);
             }
@@ -3566,12 +3572,13 @@ impl Vm {
                 // at 8.4 and keeps import chains' provenance meaningful.
                 && self.builtin_command_visible_for_surface(cmd_name, cmd)
             {
-                let builtin_identity = matches!(cmd, Command::Builtin(_)).then(|| {
-                    self.builtin_identities
-                        .get(cmd_name)
-                        .cloned()
-                        .unwrap_or_else(|| cmd_name.clone())
-                });
+                let builtin_identity = matches!(cmd, Command::Builtin(_) | Command::Native(_))
+                    .then(|| {
+                        self.builtin_identities
+                            .get(cmd_name)
+                            .cloned()
+                            .unwrap_or_else(|| cmd_name.clone())
+                    });
                 to_import.push((tail.to_string(), cmd.clone(), builtin_identity));
             }
         }
@@ -4073,6 +4080,23 @@ impl Vm {
             moved_trace = true;
         }
         if moved_trace {
+            self.invalidate_guard_domain(GuardDomain::CommandTrace);
+        }
+    }
+
+    /// Move trace registrations with a command through the hidden table.  A
+    /// hide/expose is not a Tcl rename, so no callback is fired.
+    fn move_command_traces(&mut self, old_key: &str, new_key: &str) {
+        let mut moved = false;
+        if let Some(entries) = self.cmd_traces.remove(old_key) {
+            self.cmd_traces.insert(new_key.to_owned(), entries);
+            moved = true;
+        }
+        if let Some(entries) = self.exec_traces.remove(old_key) {
+            self.exec_traces.insert(new_key.to_owned(), entries);
+            moved = true;
+        }
+        if moved {
             self.invalidate_guard_domain(GuardDomain::CommandTrace);
         }
     }

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -2046,6 +2046,19 @@ impl Vm {
     ///   user procs, aliases, embedder `Native` replacements, and names the
     ///   registry does not know remain callable.
     fn builtin_command_visible_for_surface(&self, name: &str, command: &Command) -> bool {
+        self.builtin_command_visible_for_identity(name, command, None)
+    }
+
+    /// The command-surface gate with identity supplied by an owning table.
+    /// Hidden commands retain their identity outside the visible table, so
+    /// `interp invokehidden` must use this form without transiently publishing
+    /// that metadata under the hidden token.
+    pub(crate) fn builtin_command_visible_for_identity(
+        &self,
+        name: &str,
+        command: &Command,
+        identity: Option<&str>,
+    ) -> bool {
         if !matches!(command, Command::Builtin(_) | Command::Native(_)) {
             return true;
         }
@@ -2054,10 +2067,9 @@ impl Vm {
         // gate on that stable identity rather than the local spelling or
         // mutable `namespace origin` name. This mirrors runtime/rust's
         // `Command::Imported` redirect through `resolve_dispatchable`.
-        let origin = self
-            .builtin_identities
-            .get(name)
-            .cloned()
+        let origin = identity
+            .map(str::to_owned)
+            .or_else(|| self.builtin_identities.get(name).cloned())
             .unwrap_or_else(|| self.command_origin_key(name));
         if !tcl_registry::expr_surface::RuntimeExprSurface::for_tcl_version(self.runtime_version)
             .permits_builtin_math_function_command(&origin)
@@ -2564,56 +2576,11 @@ impl Vm {
         let Some(hidden) = self.hidden_commands.get(cmd).cloned() else {
             return err(format!("invalid hidden command name \"{cmd}\""));
         };
-        let key = cmd.to_string();
-        let saved_command = self.commands.insert(key.clone(), hidden);
-        let saved_origin = self.imported_commands.get(cmd).cloned();
-        let saved_identity = self.builtin_identities.get(cmd).cloned();
-        match self.hidden_imported_commands.get(cmd).cloned() {
-            Some(origin) => {
-                self.imported_commands.insert(key.clone(), origin);
-            }
-            None => {
-                self.imported_commands.remove(cmd);
-            }
+        let identity = self.hidden_builtin_identities.get(cmd).map(String::as_str);
+        if !self.builtin_command_visible_for_identity(cmd, &hidden, identity) {
+            return err(format!("invalid command name \"{cmd}\""));
         }
-        match self.hidden_builtin_identities.get(cmd).cloned() {
-            Some(identity) => {
-                self.builtin_identities.insert(key.clone(), identity);
-            }
-            None => {
-                self.builtin_identities.remove(cmd);
-            }
-        }
-
-        self.bump_cmd_epoch();
-        let result = self.invoke_command(cmd, args);
-        self.bump_cmd_epoch();
-
-        match saved_origin {
-            Some(origin) => {
-                self.imported_commands.insert(key.clone(), origin);
-            }
-            None => {
-                self.imported_commands.remove(cmd);
-            }
-        }
-        match saved_identity {
-            Some(identity) => {
-                self.builtin_identities.insert(key.clone(), identity);
-            }
-            None => {
-                self.builtin_identities.remove(cmd);
-            }
-        }
-        match saved_command {
-            Some(command) => {
-                self.commands.insert(key, command);
-            }
-            None => {
-                self.commands.remove(cmd);
-            }
-        }
-        result
+        self.invoke_resolved_command(cmd, cmd, hidden, args)
     }
 
     /// `interp marktrusted path` — clear a child's safe flag (exposing every
@@ -2665,6 +2632,7 @@ impl Vm {
             _ => None,
         };
         self.hidden_commands.insert(token.to_owned(), command);
+        crate::cmd_coro::on_command_renamed(self, &source, token);
         self.move_command_traces(&source, token);
         if let Some(origin) = import_origin {
             self.hidden_imported_commands
@@ -2695,6 +2663,7 @@ impl Vm {
                 _ => None,
             };
             self.register_command(token, c);
+            crate::cmd_coro::on_command_renamed(self, cmd, token);
             self.move_command_traces(cmd, token);
             if let Some(origin) = self.hidden_imported_commands.remove(cmd) {
                 self.imported_commands.insert(token.to_owned(), origin);
@@ -6114,7 +6083,9 @@ mod family_b_tests {
                 .code
                 .is_ok()
         );
-        assert_eq!(observed.borrow().as_deref(), Some("src::probe"));
+        // Direct hidden dispatch must not publish hidden provenance under the
+        // token: normal command lookup from the body sees only visible state.
+        assert_eq!(observed.borrow().as_deref(), Some("held"));
         assert_eq!(
             vm.hidden_imported_commands.get("held").map(String::as_str),
             Some("src::probe")

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -1227,10 +1227,12 @@ impl Vm {
             .enumerate()
             .filter_map(|(index, slot)| slot.parked.as_ref().map(|st| (InterpId(index), st)))
             .flat_map(|(source, st)| {
-                st.hidden_commands.iter().filter_map(move |(key, command)| {
-                    matches!(command, Command::CrossAlias { target, .. } if *target == id)
-                        .then(|| (source, key.clone()))
-                })
+                st.hidden_commands
+                    .iter()
+                    .filter(move |(_, command)| {
+                        matches!(command, Command::CrossAlias { target, .. } if *target == id)
+                    })
+                    .map(move |(key, _)| (source, key.clone()))
             })
             .collect();
         for (source, key) in hidden_targeting {
@@ -2546,45 +2548,72 @@ impl Vm {
         cmd: &str,
         args: &[Value],
     ) -> Option<Completion<Value>> {
+        if name.is_empty() {
+            return Some(self.invoke_own_hidden(cmd, args));
+        }
         let id = self.child_id(name).filter(|&id| self.interp_alive(id))?;
-        Some(self.in_interp(id, |vm| {
-            let Some(hidden) = vm.hidden_commands.get(cmd).cloned() else {
-                return err(format!("invalid hidden command name \"{cmd}\""));
-            };
-            vm.bump_cmd_epoch();
-            let saved = vm.commands.insert(cmd.to_string(), hidden);
-            let saved_origin = vm
-                .hidden_imported_commands
-                .get(cmd)
-                .cloned()
-                .map(|origin| vm.imported_commands.insert(cmd.to_string(), origin));
-            let saved_identity = vm
-                .hidden_builtin_identities
-                .get(cmd)
-                .cloned()
-                .map(|identity| vm.builtin_identities.insert(cmd.to_string(), identity));
-            let r = vm.invoke_command(cmd, args);
-            vm.bump_cmd_epoch();
-            if let Some(Some(saved)) = saved_origin {
-                vm.imported_commands.insert(cmd.to_string(), saved);
-            } else {
-                vm.imported_commands.remove(cmd);
+        Some(self.in_interp(id, |vm| vm.invoke_own_hidden(cmd, args)))
+    }
+
+    /// Invoke one of this interpreter's hidden commands without making its
+    /// temporary visibility observable after dispatch.  The command's stable
+    /// identity and import provenance must accompany the transient visible
+    /// entry: command-surface checks and `namespace origin` consult those
+    /// tables while a command is running.
+    fn invoke_own_hidden(&mut self, cmd: &str, args: &[Value]) -> Completion<Value> {
+        let Some(hidden) = self.hidden_commands.get(cmd).cloned() else {
+            return err(format!("invalid hidden command name \"{cmd}\""));
+        };
+        let key = cmd.to_string();
+        let saved_command = self.commands.insert(key.clone(), hidden);
+        let saved_origin = self.imported_commands.get(cmd).cloned();
+        let saved_identity = self.builtin_identities.get(cmd).cloned();
+        match self.hidden_imported_commands.get(cmd).cloned() {
+            Some(origin) => {
+                self.imported_commands.insert(key.clone(), origin);
             }
-            if let Some(Some(saved)) = saved_identity {
-                vm.builtin_identities.insert(cmd.to_string(), saved);
-            } else {
-                vm.builtin_identities.remove(cmd);
+            None => {
+                self.imported_commands.remove(cmd);
             }
-            match saved {
-                Some(prev) => {
-                    vm.commands.insert(cmd.to_string(), prev);
-                }
-                None => {
-                    vm.commands.remove(cmd);
-                }
+        }
+        match self.hidden_builtin_identities.get(cmd).cloned() {
+            Some(identity) => {
+                self.builtin_identities.insert(key.clone(), identity);
             }
-            r
-        }))
+            None => {
+                self.builtin_identities.remove(cmd);
+            }
+        }
+
+        self.bump_cmd_epoch();
+        let result = self.invoke_command(cmd, args);
+        self.bump_cmd_epoch();
+
+        match saved_origin {
+            Some(origin) => {
+                self.imported_commands.insert(key.clone(), origin);
+            }
+            None => {
+                self.imported_commands.remove(cmd);
+            }
+        }
+        match saved_identity {
+            Some(identity) => {
+                self.builtin_identities.insert(key.clone(), identity);
+            }
+            None => {
+                self.builtin_identities.remove(cmd);
+            }
+        }
+        match saved_command {
+            Some(command) => {
+                self.commands.insert(key, command);
+            }
+            None => {
+                self.commands.remove(cmd);
+            }
+        }
+        result
     }
 
     /// `interp marktrusted path` — clear a child's safe flag (exposing every
@@ -3176,44 +3205,7 @@ impl Vm {
         if !self.interp_alive(id) {
             return None;
         }
-        Some(self.in_interp(id, |vm| {
-            let Some(hidden) = vm.hidden_commands.get(cmd).cloned() else {
-                return err(format!("invalid hidden command name \"{cmd}\""));
-            };
-            vm.bump_cmd_epoch();
-            let saved = vm.commands.insert(cmd.to_string(), hidden);
-            let saved_origin = vm
-                .hidden_imported_commands
-                .get(cmd)
-                .cloned()
-                .map(|origin| vm.imported_commands.insert(cmd.to_string(), origin));
-            let saved_identity = vm
-                .hidden_builtin_identities
-                .get(cmd)
-                .cloned()
-                .map(|identity| vm.builtin_identities.insert(cmd.to_string(), identity));
-            let r = vm.invoke_command(cmd, args);
-            vm.bump_cmd_epoch();
-            if let Some(Some(saved)) = saved_origin {
-                vm.imported_commands.insert(cmd.to_string(), saved);
-            } else {
-                vm.imported_commands.remove(cmd);
-            }
-            if let Some(Some(saved)) = saved_identity {
-                vm.builtin_identities.insert(cmd.to_string(), saved);
-            } else {
-                vm.builtin_identities.remove(cmd);
-            }
-            match saved {
-                Some(prev) => {
-                    vm.commands.insert(cmd.to_string(), prev);
-                }
-                None => {
-                    vm.commands.remove(cmd);
-                }
-            }
-            r
-        }))
+        Some(self.in_interp(id, |vm| vm.invoke_own_hidden(cmd, args)))
     }
 
     pub(crate) fn lookup_command(&self, name: &str) -> Option<Command> {
@@ -6016,9 +6008,120 @@ fn direct_member_tail<'a>(key: &'a str, canonical: &str) -> Option<&'a str> {
 #[cfg(test)]
 mod family_b_tests {
     use super::*;
+    use crate::command::NativeCommand;
+    use tcl_dialect::DialectProfile;
     use tcl_runtime_api::GLOBAL_FRAME;
 
     const GUARDED_IDENTITY: GuardIdentity = GuardIdentity::new(1, 41);
+
+    #[test]
+    fn invokehidden_rechecks_a_hidden_builtin_against_the_child_profile() {
+        let mut vm = Vm::new();
+        let child_name = vm.create_child(Some("child".to_string()), false);
+        let child = vm.child_id(&child_name).unwrap();
+        vm.in_interp(child, |child_vm| {
+            child_vm.set_dialect_profile(DialectProfile::by_name("tcl8.5"));
+            child_vm.hide_command("lassign", "held").unwrap();
+            child_vm.set_dialect_profile(DialectProfile::by_name("tcl8.4"));
+        });
+        let named = vm.invoke_hidden_in_child("child", "held", &[]).unwrap();
+        assert_eq!(named.code, Code::Error);
+        let by_id = vm.invoke_hidden_by_id(child, "held", &[]).unwrap();
+        assert_eq!(by_id.code, Code::Error);
+        assert!(
+            vm.st_of(child)
+                .unwrap()
+                .hidden_commands
+                .contains_key("held")
+        );
+        assert!(!vm.st_of(child).unwrap().commands.contains_key("held"));
+    }
+
+    #[test]
+    fn root_invokehidden_rechecks_identity_and_restores_hidden_state_after_error() {
+        let mut vm = Vm::new();
+        vm.set_dialect_profile(DialectProfile::by_name("tcl8.5"));
+        vm.hide_command("lassign", "held").unwrap();
+        vm.set_dialect_profile(DialectProfile::by_name("tcl8.4"));
+
+        let result = vm.invoke_hidden_in_child("", "held", &[]).unwrap();
+        assert_eq!(result.code, Code::Error);
+        assert!(vm.hidden_commands.contains_key("held"));
+        assert!(!vm.commands.contains_key("held"));
+        assert!(!vm.builtin_identities.contains_key("held"));
+        assert!(!vm.imported_commands.contains_key("held"));
+    }
+
+    struct TestNative;
+
+    impl NativeCommand for TestNative {
+        fn invoke(&self, _vm: &mut Vm, _args: &[Value]) -> Completion<Value> {
+            ok(Value::empty())
+        }
+    }
+
+    struct OriginNative(Rc<RefCell<Option<String>>>);
+
+    impl NativeCommand for OriginNative {
+        fn invoke(&self, vm: &mut Vm, _args: &[Value]) -> Completion<Value> {
+            *self.0.borrow_mut() = Some(vm.command_origin_key("held"));
+            ok(Value::empty())
+        }
+    }
+
+    #[test]
+    fn invokehidden_rechecks_a_hidden_native_identity_for_both_child_paths() {
+        let mut vm = Vm::new();
+        let child_name = vm.create_child(Some("child".to_string()), false);
+        let child = vm.child_id(&child_name).unwrap();
+        vm.in_interp(child, |child_vm| {
+            child_vm.set_dialect_profile(DialectProfile::by_name("tcl9.0"));
+            child_vm.register_native_command("tcl::mathfunc::isfinite", Rc::new(TestNative));
+            child_vm
+                .hide_command("tcl::mathfunc::isfinite", "held")
+                .unwrap();
+            child_vm.set_dialect_profile(DialectProfile::by_name("tcl8.6"));
+        });
+
+        assert_eq!(
+            vm.invoke_hidden_in_child("child", "held", &[])
+                .unwrap()
+                .code,
+            Code::Error
+        );
+        assert_eq!(
+            vm.invoke_hidden_by_id(child, "held", &[]).unwrap().code,
+            Code::Error
+        );
+        let state = vm.st_of(child).unwrap();
+        assert!(state.hidden_commands.contains_key("held"));
+        assert!(!state.commands.contains_key("held"));
+        assert!(!state.builtin_identities.contains_key("held"));
+    }
+
+    #[test]
+    fn invokehidden_temporarily_restores_imported_command_provenance() {
+        let observed = Rc::new(RefCell::new(None));
+        let mut vm = Vm::new();
+        vm.register_native_command("src::probe", Rc::new(OriginNative(Rc::clone(&observed))));
+        vm.declare_namespace_exports("src", &["*"]);
+        assert_eq!(vm.import_commands("::src::*"), vec!["probe"]);
+        vm.hide_command("probe", "held").unwrap();
+
+        assert!(
+            vm.invoke_hidden_in_child("", "held", &[])
+                .unwrap()
+                .code
+                .is_ok()
+        );
+        assert_eq!(observed.borrow().as_deref(), Some("src::probe"));
+        assert_eq!(
+            vm.hidden_imported_commands.get("held").map(String::as_str),
+            Some("src::probe")
+        );
+        assert!(!vm.imported_commands.contains_key("held"));
+        assert!(!vm.commands.contains_key("held"));
+    }
 
     fn guarded_builtin(_vm: &mut Vm, _args: &[Value]) -> Completion<Value> {
         ok(Value::empty())

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -468,6 +468,12 @@ pub struct InterpState {
     /// leaving a real command of the same name intact. Cleared whenever the key
     /// is re-registered (a redefine) or taken (a `rename`).
     imported_commands: HashMap<String, String>,
+    /// Stable registry identity for a builtin that has moved away from its
+    /// registered spelling (via import, rename, or hide/expose).  This is
+    /// deliberately distinct from the mutable `namespace origin` provenance:
+    /// `rename lassign escaped` remains the `lassign` builtin for release
+    /// availability purposes.
+    builtin_identities: HashMap<String, String>,
     /// Namespace-name ⇆ opaque `NsId` arena for the Family-B `Frames`/`Namespaces`
     /// contract. The VM resolves namespaces by their canonical `String` name; this
     /// side-table mints stable `NsId` handles for them (`ns_arena[id]` is the name,
@@ -685,6 +691,11 @@ pub struct InterpState {
     /// Commands hidden by `interp create -safe` / `interp hide`, keyed by name —
     /// invocable via `interp invokehidden`, restorable with `interp expose`.
     hidden_commands: HashMap<String, Command>,
+    /// Import provenance and stable builtin identities carried while a command
+    /// lives in the hidden table.  Hiding is a temporary relocation, not a
+    /// metadata-dropping deletion: expose must restore both under its new key.
+    hidden_imported_commands: HashMap<String, String>,
+    hidden_builtin_identities: HashMap<String, String>,
     /// Monotonic counter minting auto-generated child names (`interp0`, …).
     interp_counter: u64,
     /// `interp debug -frame` — a one-way switch (once on, stays on).
@@ -997,6 +1008,7 @@ impl InterpState {
             namespaces: std::collections::HashSet::new(),
             ns_exports: HashMap::new(),
             imported_commands: HashMap::new(),
+            builtin_identities: HashMap::new(),
             ns_arena: vec![String::new()],
             ns_intern: HashMap::from([(String::new(), ROOT_NS)]),
             ns_paths: HashMap::new(),
@@ -1039,6 +1051,8 @@ impl InterpState {
             is_safe: false,
             recursion_limit: RECURSION_LIMIT,
             hidden_commands: HashMap::new(),
+            hidden_imported_commands: HashMap::new(),
+            hidden_builtin_identities: HashMap::new(),
             interp_counter: 0,
             debug_frame: false,
             bgerror_handler: Value::string("::tcl::Bgerror"),
@@ -1696,6 +1710,7 @@ impl Vm {
         }
         self.bump_cmd_epoch();
         self.imported_commands.remove(name);
+        self.builtin_identities.remove(name);
         self.commands.insert(name.to_owned(), cmd);
     }
 
@@ -1711,6 +1726,7 @@ impl Vm {
         if self.commands.remove(name).is_some() {
             self.bump_cmd_epoch();
             self.imported_commands.remove(name);
+            self.builtin_identities.remove(name);
         }
     }
 
@@ -1722,9 +1738,37 @@ impl Vm {
     /// command).
     pub(crate) fn take_command(&mut self, name: &str) -> Option<Command> {
         let key = self.resolve_command_fqn(self.current_ns(), name)?;
+        // A command that is present in the engine table may still be absent
+        // from the emulated release's surface.  Treat it exactly like a
+        // missing command here: otherwise `rename` (and `interp hide`, which
+        // uses the same removal seam) can move a hidden builtin to a registry-
+        // unknown name and make it callable again (#1463).
+        if self
+            .commands
+            .get(&key)
+            .is_some_and(|command| !self.builtin_command_visible_for_surface(&key, command))
+        {
+            return None;
+        }
+        self.take_command_unchecked_key(&key)
+    }
+
+    /// Resolve and remove a command without consulting the emulated command
+    /// surface.  This is for VM-owned teardown only (temporary `apply`
+    /// procedures, coroutine state, and `TclOO` objects); those paths are
+    /// deleting an implementation that is already unreachable, not exposing
+    /// a command to Tcl code.  User-facing removal must use [`Self::take_command`].
+    pub(crate) fn take_command_unchecked(&mut self, name: &str) -> Option<Command> {
+        let key = self.resolve_command_fqn(self.current_ns(), name)?;
+        self.take_command_unchecked_key(&key)
+    }
+
+    /// Remove a command by its already-resolved table key.
+    fn take_command_unchecked_key(&mut self, key: &str) -> Option<Command> {
         self.bump_cmd_epoch();
-        self.imported_commands.remove(&key);
-        self.commands.remove(&key)
+        self.imported_commands.remove(key);
+        self.builtin_identities.remove(key);
+        self.commands.remove(key)
     }
 
     /// Remove a command by its exact table key (no name resolution) — the
@@ -1732,6 +1776,7 @@ impl Vm {
     pub(crate) fn remove_command_exact(&mut self, key: &str) -> Option<Command> {
         self.bump_cmd_epoch();
         self.imported_commands.remove(key);
+        self.builtin_identities.remove(key);
         self.commands.remove(key)
     }
 
@@ -1853,12 +1898,22 @@ impl Vm {
         if !matches!(command, Command::Builtin(_) | Command::Native(_)) {
             return true;
         }
+        // `namespace import` stores a command-table clone for dispatch. Its
+        // source name can change, but the clone remains the original builtin;
+        // gate on that stable identity rather than the local spelling or
+        // mutable `namespace origin` name. This mirrors runtime/rust's
+        // `Command::Imported` redirect through `resolve_dispatchable`.
+        let origin = self
+            .builtin_identities
+            .get(name)
+            .cloned()
+            .unwrap_or_else(|| self.command_origin_key(name));
         if !tcl_registry::expr_surface::RuntimeExprSurface::for_tcl_version(self.runtime_version)
-            .permits_builtin_math_function_command(name)
+            .permits_builtin_math_function_command(&origin)
         {
             return false;
         }
-        matches!(command, Command::Native(_)) || self.profile_admits_registry_builtin(name)
+        matches!(command, Command::Native(_)) || self.profile_admits_registry_builtin(&origin)
     }
 
     /// The availability half of [`Self::builtin_command_visible_for_surface`]:
@@ -2371,17 +2426,48 @@ impl Vm {
         };
         if let Some(child) = self.st_of_mut(id) {
             child.bump_cmd_epoch();
-            for (cmd_name, cmd) in std::mem::take(&mut child.hidden_commands) {
-                child.commands.insert(cmd_name, cmd);
-            }
+            child.expose_all_hidden_commands();
             child.is_safe = false;
         }
     }
 
-    /// `interp hide {} cmd` — move one of *this* interp's commands into its
-    /// hidden table.
-    pub(crate) fn hide_own_command(&mut self, cmd: &str, command: Command) {
-        self.hidden_commands.insert(cmd.to_string(), command);
+    /// Stable registry identity for a visible builtin, if any.  A direct
+    /// registered builtin derives it from its key; a moved builtin carries it
+    /// in [`Self::builtin_identities`].
+    fn builtin_identity_for_key(&self, key: &str) -> Option<String> {
+        matches!(self.commands.get(key), Some(Command::Builtin(_))).then(|| {
+            self.builtin_identities
+                .get(key)
+                .cloned()
+                .unwrap_or_else(|| self.command_origin_key(key))
+        })
+    }
+
+    /// `interp hide {} cmd` — move one visible command plus all of its
+    /// metadata into the hidden table.  This is the only public hide seam;
+    /// every caller therefore observes the same release-visibility check.
+    pub(crate) fn hide_command(&mut self, cmd: &str, token: &str) -> bool {
+        let Some(source) = self.resolve_command_fqn(self.current_ns(), cmd) else {
+            return false;
+        };
+        let import_origin = self.imported_commands.get(&source).cloned();
+        let builtin_identity = self.builtin_identity_for_key(&source);
+        let Some(command) = self.take_command(cmd) else {
+            return false;
+        };
+        self.hidden_commands.insert(token.to_owned(), command);
+        if let Some(origin) = import_origin {
+            self.hidden_imported_commands
+                .insert(token.to_owned(), origin);
+        }
+        if let Some(identity) = builtin_identity {
+            self.hidden_builtin_identities
+                .insert(token.to_owned(), identity);
+        }
+        // A hidden token is the command's temporary name.  Imports that
+        // pointed at this source follow it until expose gives it a new key.
+        self.retarget_imports(&source, token);
+        true
     }
 
     /// `interp expose {} hidden ?token?` — restore one of *this* interp's
@@ -2390,6 +2476,16 @@ impl Vm {
         if let Some(c) = self.hidden_commands.remove(cmd) {
             self.bump_cmd_epoch();
             self.commands.insert(token.to_string(), c);
+            if let Some(origin) = self.hidden_imported_commands.remove(cmd) {
+                self.imported_commands.insert(token.to_owned(), origin);
+            }
+            if let Some(identity) = self.hidden_builtin_identities.remove(cmd) {
+                self.builtin_identities.insert(token.to_owned(), identity);
+            }
+            // `interp hide` + `interp expose ... newName` is a rename through
+            // the hidden table. Imported commands retain the source token in
+            // C Tcl, so their provenance follows the newly exposed name too.
+            self.retarget_imports(cmd, token);
         }
     }
 
@@ -2407,17 +2503,15 @@ impl Vm {
         let Some(id) = self.child_id(name) else {
             return false;
         };
-        let Some(child) = self.st_of_mut(id) else {
-            return false;
-        };
-        child.bump_cmd_epoch();
-        if hide {
-            if let Some(c) = child.commands.remove(cmd) {
-                child.hidden_commands.insert(token.to_string(), c);
+        // Enter the child so public hide uses the same visibility-aware
+        // removal seam as `rename` and same-interpreter `interp hide`.
+        self.in_interp(id, |vm| {
+            if hide {
+                vm.hide_command(cmd, token);
+            } else {
+                vm.expose_own_command(cmd, token);
             }
-        } else if let Some(c) = child.hidden_commands.remove(cmd) {
-            child.commands.insert(token.to_string(), c);
-        }
+        });
         true
     }
 
@@ -2464,8 +2558,19 @@ impl Vm {
         ];
         self.bump_cmd_epoch();
         for &c in UNSAFE {
+            let import_origin = self.imported_commands.get(c).cloned();
+            let builtin_identity = self.builtin_identity_for_key(c);
             if let Some(cmd) = self.commands.remove(c) {
+                self.imported_commands.remove(c);
+                self.builtin_identities.remove(c);
                 self.hidden_commands.insert(c.to_string(), cmd);
+                if let Some(origin) = import_origin {
+                    self.hidden_imported_commands.insert(c.to_string(), origin);
+                }
+                if let Some(identity) = builtin_identity {
+                    self.hidden_builtin_identities
+                        .insert(c.to_string(), identity);
+                }
             }
         }
         for &k in UNSAFE_PLATFORM {
@@ -2513,8 +2618,20 @@ impl Vm {
         argv: &[Value],
     ) -> Completion<Value> {
         if target_interp == self.cur {
-            let script = crate::exec::alias_invoke_script(argv);
             self.push_ns(String::new());
+            // Alias words are recompiled as a script so aliases to control
+            // commands retain Tcl's syntax.  Validate the fixed head through
+            // normal resolution first, though: otherwise a compiler-special
+            // form (for example `lassign`) can run after its target was
+            // renamed away or gated out by the selected release.
+            if let Some((head, tail)) = argv.split_first()
+                && self.lookup_command(&head.to_str()).is_none()
+            {
+                let completion = self.invoke_command(&head.to_str(), tail);
+                self.pop_ns();
+                return completion;
+            }
+            let script = crate::exec::alias_invoke_script(argv);
             let evaled = self.eval_source(&script);
             self.pop_ns();
             return match evaled {
@@ -2528,6 +2645,13 @@ impl Vm {
         let script = crate::exec::alias_invoke_script(argv);
         self.in_interp(target_interp, |vm| {
             vm.push_ns(String::new());
+            if let Some((head, tail)) = argv.split_first()
+                && vm.lookup_command(&head.to_str()).is_none()
+            {
+                let completion = vm.invoke_command(&head.to_str(), tail);
+                vm.pop_ns();
+                return completion;
+            }
             let evaled = vm.eval_source(&script);
             vm.pop_ns();
             match evaled {
@@ -2722,9 +2846,7 @@ impl Vm {
                 }
                 if let Some(child) = self.st_of_mut(id) {
                     child.bump_cmd_epoch();
-                    for (cmd_name, cmd) in std::mem::take(&mut child.hidden_commands) {
-                        child.commands.insert(cmd_name, cmd);
-                    }
+                    child.expose_all_hidden_commands();
                     child.is_safe = false;
                 }
                 ok(Value::empty())
@@ -2822,17 +2944,17 @@ impl Vm {
     /// [`Self::child_hide`] addressing the child by id (the `$child hide/expose`
     /// form, whose id is already resolved).
     fn child_hide_by_id(&mut self, id: InterpId, cmd: &str, token: &str, hide: bool) -> bool {
-        let Some(child) = self.st_of_mut(id) else {
+        if !self.interp_alive(id) {
             return false;
-        };
-        child.bump_cmd_epoch();
-        if hide {
-            if let Some(c) = child.commands.remove(cmd) {
-                child.hidden_commands.insert(token.to_string(), c);
-            }
-        } else if let Some(c) = child.hidden_commands.remove(cmd) {
-            child.commands.insert(token.to_string(), c);
         }
+        // This is the `$child hide` spelling of the same public operation.
+        self.in_interp(id, |vm| {
+            if hide {
+                vm.hide_command(cmd, token);
+            } else {
+                vm.expose_own_command(cmd, token);
+            }
+        });
         true
     }
 
@@ -3011,6 +3133,22 @@ fn is_step_capable(ops: &[String]) -> bool {
 /// coercion keeps every `impl Vm` caller (`self.resolve_command_fqn(…)`)
 /// working against the current interp unchanged.
 impl InterpState {
+    /// Move every hidden command back into the visible table, retaining the
+    /// import provenance and stable builtin identity that travelled with it.
+    fn expose_all_hidden_commands(&mut self) {
+        let origins = std::mem::take(&mut self.hidden_imported_commands);
+        let identities = std::mem::take(&mut self.hidden_builtin_identities);
+        for (name, command) in std::mem::take(&mut self.hidden_commands) {
+            self.commands.insert(name.clone(), command);
+            if let Some(origin) = origins.get(&name) {
+                self.imported_commands.insert(name.clone(), origin.clone());
+            }
+            if let Some(identity) = identities.get(&name) {
+                self.builtin_identities.insert(name, identity.clone());
+            }
+        }
+    }
+
     /// Invalidate the command-resolution memo (M16.4): every command-table /
     /// `namespace path` / runtime-version mutation routes through here so a
     /// cached `(namespace, name) → key` can never outlive the state it was
@@ -3261,7 +3399,7 @@ impl Vm {
         };
         // Candidate commands: those in the source namespace whose tail matches
         // the import glob and an export pattern.
-        let mut to_import: Vec<(String, Command)> = Vec::new();
+        let mut to_import: Vec<(String, Command, Option<String>)> = Vec::new();
         for (cmd_name, cmd) in &self.commands {
             let Some(tail) = cmd_name.strip_prefix(&prefix) else {
                 continue;
@@ -3273,18 +3411,31 @@ impl Vm {
                 && exports
                     .iter()
                     .any(|p| tcl_syntax::glob::string_match(p, tail))
+                // C imports only a command visible in the current release.
+                // Skipping a hidden source avoids manufacturing a local clone
+                // at 8.4 and keeps import chains' provenance meaningful.
+                && self.builtin_command_visible_for_surface(cmd_name, cmd)
             {
-                to_import.push((tail.to_string(), cmd.clone()));
+                let builtin_identity = matches!(cmd, Command::Builtin(_)).then(|| {
+                    self.builtin_identities
+                        .get(cmd_name)
+                        .cloned()
+                        .unwrap_or_else(|| cmd_name.clone())
+                });
+                to_import.push((tail.to_string(), cmd.clone(), builtin_identity));
             }
         }
         let mut imported = Vec::new();
-        for (tail, cmd) in to_import {
+        for (tail, cmd, builtin_identity) in to_import {
             let alias = self.qualify_name(&tail);
             let origin = format!("{prefix}{tail}");
             self.register_command(&alias, cmd);
             // `register_command` cleared any stale provenance; now stamp this key
             // as an import so `namespace forget` can target it.
-            self.imported_commands.insert(alias, origin);
+            self.imported_commands.insert(alias.clone(), origin);
+            if let Some(identity) = builtin_identity {
+                self.builtin_identities.insert(alias, identity);
+            }
             imported.push(tail);
         }
         imported
@@ -3306,6 +3457,41 @@ impl Vm {
             }
         }
         cur
+    }
+
+    /// Retarget imports when their source command is renamed.  The command
+    /// table stores an import as a cloned dispatcher, whereas C stores the
+    /// source command token; rewrite the provenance explicitly so dispatch,
+    /// visibility, and `namespace origin` continue to identify the final
+    /// builtin under its new name.  A deletion deliberately does not take this
+    /// path: C leaves the imported command dangling in that case.
+    pub(crate) fn retarget_imports(&mut self, old_key: &str, new_key: &str) {
+        let new_key = new_key.to_owned();
+        for source in self.imported_commands.values_mut() {
+            if source == old_key {
+                source.clone_from(&new_key);
+            }
+        }
+    }
+
+    /// Import provenance carried by `key`, if it is an imported command.
+    pub(crate) fn import_origin(&self, key: &str) -> Option<String> {
+        self.imported_commands.get(key).cloned()
+    }
+
+    /// Stable registry identity for a visible builtin at `key`.
+    pub(crate) fn builtin_identity(&self, key: &str) -> Option<String> {
+        self.builtin_identity_for_key(key)
+    }
+
+    /// Restore a renamed imported command's own origin record.
+    pub(crate) fn restore_import_origin(&mut self, key: &str, origin: String) {
+        self.imported_commands.insert(key.to_owned(), origin);
+    }
+
+    /// Restore a renamed builtin's stable registry identity.
+    pub(crate) fn restore_builtin_identity(&mut self, key: &str, identity: String) {
+        self.builtin_identities.insert(key.to_owned(), identity);
     }
 
     /// `namespace forget pattern` — remove previously imported commands matching
@@ -3367,6 +3553,7 @@ impl Vm {
         self.bump_cmd_epoch();
         for key in victims {
             self.imported_commands.remove(&key);
+            self.builtin_identities.remove(&key);
             self.commands.remove(&key);
         }
         Ok(())
@@ -3392,6 +3579,8 @@ impl Vm {
         self.bump_cmd_epoch();
         self.commands.retain(|k, _| !k.starts_with(&prefix));
         self.imported_commands
+            .retain(|k, _| !k.starts_with(&prefix));
+        self.builtin_identities
             .retain(|k, _| !k.starts_with(&prefix));
         if let Some(g) = self.frames.first_mut() {
             g.locals.retain(|k, _| !k.starts_with(&prefix));

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -2980,8 +2980,10 @@ impl Vm {
                     ));
                 }
                 let c = rest[0].to_str();
-                self.child_hide_by_id(id, &c, &c, hide);
-                ok(Value::empty())
+                match self.child_hide_by_id(id, &c, &c, hide) {
+                    Ok(()) => ok(Value::empty()),
+                    Err(message) => err(message),
+                }
             }
             "marktrusted" => {
                 if self.is_safe() {
@@ -3086,19 +3088,24 @@ impl Vm {
 
     /// [`Self::child_hide`] addressing the child by id (the `$child hide/expose`
     /// form, whose id is already resolved).
-    fn child_hide_by_id(&mut self, id: InterpId, cmd: &str, token: &str, hide: bool) -> bool {
+    fn child_hide_by_id(
+        &mut self,
+        id: InterpId,
+        cmd: &str,
+        token: &str,
+        hide: bool,
+    ) -> Result<(), String> {
         if !self.interp_alive(id) {
-            return false;
+            return Err("interpreter no longer exists".to_string());
         }
         // This is the `$child hide` spelling of the same public operation.
         self.in_interp(id, |vm| {
             if hide {
-                let _ = vm.hide_command(cmd, token);
+                vm.hide_command(cmd, token)
             } else {
-                let _ = vm.expose_own_command(cmd, token);
+                vm.expose_own_command(cmd, token)
             }
-        });
-        true
+        })
     }
 
     /// [`Self::invoke_hidden_in_child`] addressing the child by id.

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -1825,6 +1825,16 @@ impl Vm {
         self.retarget_imports(&transaction.old_key, new_key);
     }
 
+    /// Remove the source for an already validated `rename old {}`.  Deletion
+    /// deliberately does not retarget imports; C leaves them dangling.
+    pub(crate) fn delete_prepared_renamed_command(
+        &mut self,
+        transaction: &CommandRenameTransaction,
+    ) {
+        self.take_command_unchecked_key(&transaction.old_key)
+            .expect("the prepared delete source remains registered");
+    }
+
     /// Commit a rename after all semantic validation has succeeded.
     pub(crate) fn commit_renamed_command(&mut self, transaction: &CommandRenameTransaction) {
         if let Some(target) = transaction.cross_alias_target {

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -421,6 +421,14 @@ impl CommandSidecarHandle {
     pub(crate) fn key(&self) -> Option<CommandSidecarKey> {
         self.0.borrow().clone()
     }
+
+    /// Whether this in-flight operation still belongs to a command binding.
+    /// Deletion clears the cell before Tcl callbacks run; trace iteration must
+    /// re-check this after every re-entrant callback rather than continuing a
+    /// cloned pre-mutation trace list.
+    pub(crate) fn is_attached(&self) -> bool {
+        self.0.borrow().is_some()
+    }
 }
 
 impl CommandSidecarKey {

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -1981,7 +1981,7 @@ impl Vm {
     /// deleting an implementation that is already unreachable, not exposing
     /// a command to Tcl code.  User-facing removal must use [`Self::take_command`].
     pub(crate) fn take_command_unchecked(&mut self, name: &str) -> Option<Command> {
-        let key = self.resolve_command_fqn(self.current_ns(), name)?;
+        let key = self.resolve_command_fqn_raw(self.current_ns(), name)?;
         self.take_command_unchecked_key(&key)
     }
 
@@ -3452,7 +3452,7 @@ impl InterpState {
                 return hit.clone();
             }
         }
-        let res = self.resolve_command_fqn_uncached(cxt, name);
+        let res = self.resolve_command_fqn_uncached(cxt, name, true);
         let mut cache = self.cmd_resolve_cache.borrow_mut();
         if cache.0 != epoch {
             cache.0 = epoch;
@@ -3467,8 +3467,23 @@ impl InterpState {
         res
     }
 
+    /// Resolve a registered command for VM/embedder teardown without applying
+    /// the emulated release's public command-surface filter.
+    ///
+    /// This deliberately bypasses only availability filtering. Namespace,
+    /// namespace-path, and global candidate ordering remain the active Tcl
+    /// release's resolution rules. Never use this for Tcl-visible dispatch.
+    fn resolve_command_fqn_raw(&self, cxt: &str, name: &str) -> Option<String> {
+        self.resolve_command_fqn_uncached(cxt, name, false)
+    }
+
     /// The uncached resolution rule — see [`Self::resolve_command_fqn`].
-    fn resolve_command_fqn_uncached(&self, cxt: &str, name: &str) -> Option<String> {
+    fn resolve_command_fqn_uncached(
+        &self,
+        cxt: &str,
+        name: &str,
+        filter_public_surface: bool,
+    ) -> Option<String> {
         // Collapse separator runs up front — C treats any colon run as one
         // separator, so `foo:::bar` dispatches `foo::bar` and `quux:::` the
         // `{}` command `quux::` (tclsh8.6-verified). The key form keeps the
@@ -3508,9 +3523,9 @@ impl InterpState {
         };
         tcl_syntax::naming::resolve_command_with(cxt, &rooted, &name, |candidate| {
             let key = unroot(candidate);
-            self.commands
-                .get(&key)
-                .is_some_and(|command| self.builtin_command_visible_for_surface(&key, command))
+            self.commands.get(&key).is_some_and(|command| {
+                !filter_public_surface || self.builtin_command_visible_for_surface(&key, command)
+            })
         })
         .map(|winner| unroot(&winner))
     }

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -1200,14 +1200,21 @@ impl Vm {
             .map(|b| (b.source, b.key.clone()))
             .collect();
         for (src, key) in targeting {
-            let still_aliased = self.st_of(src).is_some_and(|st| {
-                matches!(st.commands.get(&key),
-                    Some(Command::CrossAlias { target, .. }) if *target == id)
-            });
-            if still_aliased {
+            let visible = self.st_of(src).is_some_and(|st| matches!(st.commands.get(&key), Some(Command::CrossAlias { target, .. }) if *target == id));
+            let hidden = self.st_of(src).is_some_and(|st| matches!(st.hidden_commands.get(&key), Some(Command::CrossAlias { target, .. }) if *target == id));
+            if visible {
                 self.in_interp(src, |vm| {
                     vm.remove_command_exact(&key);
                     vm.on_command_removed(&key);
+                });
+            }
+            if hidden {
+                self.in_interp(src, |vm| {
+                    vm.hidden_commands.remove(&key);
+                    vm.hidden_imported_commands.remove(&key);
+                    vm.hidden_builtin_identities.remove(&key);
+                    vm.cmd_traces.remove(&key);
+                    vm.exec_traces.remove(&key);
                 });
             }
         }
@@ -2521,8 +2528,28 @@ impl Vm {
             };
             vm.bump_cmd_epoch();
             let saved = vm.commands.insert(cmd.to_string(), hidden);
+            let saved_origin = vm
+                .hidden_imported_commands
+                .get(cmd)
+                .cloned()
+                .map(|origin| vm.imported_commands.insert(cmd.to_string(), origin));
+            let saved_identity = vm
+                .hidden_builtin_identities
+                .get(cmd)
+                .cloned()
+                .map(|identity| vm.builtin_identities.insert(cmd.to_string(), identity));
             let r = vm.invoke_command(cmd, args);
             vm.bump_cmd_epoch();
+            if let Some(Some(saved)) = saved_origin {
+                vm.imported_commands.insert(cmd.to_string(), saved);
+            } else {
+                vm.imported_commands.remove(cmd);
+            }
+            if let Some(Some(saved)) = saved_identity {
+                vm.builtin_identities.insert(cmd.to_string(), saved);
+            } else {
+                vm.builtin_identities.remove(cmd);
+            }
             match saved {
                 Some(prev) => {
                     vm.commands.insert(cmd.to_string(), prev);
@@ -3130,8 +3157,28 @@ impl Vm {
             };
             vm.bump_cmd_epoch();
             let saved = vm.commands.insert(cmd.to_string(), hidden);
+            let saved_origin = vm
+                .hidden_imported_commands
+                .get(cmd)
+                .cloned()
+                .map(|origin| vm.imported_commands.insert(cmd.to_string(), origin));
+            let saved_identity = vm
+                .hidden_builtin_identities
+                .get(cmd)
+                .cloned()
+                .map(|identity| vm.builtin_identities.insert(cmd.to_string(), identity));
             let r = vm.invoke_command(cmd, args);
             vm.bump_cmd_epoch();
+            if let Some(Some(saved)) = saved_origin {
+                vm.imported_commands.insert(cmd.to_string(), saved);
+            } else {
+                vm.imported_commands.remove(cmd);
+            }
+            if let Some(Some(saved)) = saved_identity {
+                vm.builtin_identities.insert(cmd.to_string(), saved);
+            } else {
+                vm.builtin_identities.remove(cmd);
+            }
             match saved {
                 Some(prev) => {
                     vm.commands.insert(cmd.to_string(), prev);

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -4626,14 +4626,38 @@ impl Vm {
     /// under its own key, so later calls while the same trace-deopt epoch
     /// holds reuse the compiled body instead of recompiling on every call.
     pub(crate) fn ensure_proc_ready(&mut self, proc: Rc<ProcDef>) -> Rc<ProcDef> {
+        self.ensure_proc_ready_in(proc, None)
+    }
+
+    /// Refresh a stored procedure and memoise it in the command domain from
+    /// which this invocation was resolved. Hidden and visible commands may
+    /// share the same spelling, so publishing by `ProcDef::name` would leak a
+    /// hidden proc back into the visible table (and overwrite a replacement).
+    pub(crate) fn ensure_proc_ready_in(
+        &mut self,
+        proc: Rc<ProcDef>,
+        sidecar: Option<&CommandSidecarKey>,
+    ) -> Rc<ProcDef> {
         if proc.compiled_epoch == self.trace_deopt_epoch()
             && proc.compiled_profile_generation == self.profile_generation
         {
             return proc;
         }
-        let key = proc.name.clone();
         let fresh = self.ensure_proc_traced(proc);
-        self.commands.insert(key, Command::Proc(Rc::clone(&fresh)));
+        match sidecar {
+            Some(CommandSidecarKey::Hidden(token)) => {
+                self.hidden_commands
+                    .insert(token.clone(), Command::Proc(Rc::clone(&fresh)));
+            }
+            Some(CommandSidecarKey::Visible(name)) => {
+                self.commands
+                    .insert(name.clone(), Command::Proc(Rc::clone(&fresh)));
+            }
+            None => {
+                self.commands
+                    .insert(fresh.name.clone(), Command::Proc(Rc::clone(&fresh)));
+            }
+        }
         fresh
     }
 
@@ -6304,10 +6328,35 @@ fn direct_member_tail<'a>(key: &'a str, canonical: &str) -> Option<&'a str> {
 mod family_b_tests {
     use super::*;
     use crate::command::NativeCommand;
+    use tcl_compiler::cfg_builder::build_cfg_codegen;
+    use tcl_compiler::codegen::codegen_module;
+    use tcl_compiler::lowering::lower_to_ir_for_bytecode_with_dialect as lower_to_ir;
     use tcl_dialect::DialectProfile;
-    use tcl_runtime_api::GLOBAL_FRAME;
+    use tcl_runtime_api::{CompileError, GLOBAL_FRAME};
 
     const GUARDED_IDENTITY: GuardIdentity = GuardIdentity::new(1, 41);
+
+    struct TestCompiler;
+
+    impl CompileService for TestCompiler {
+        type Module = ModuleAsm;
+
+        fn compile(&self, src: &str) -> Result<Self::Module, CompileError> {
+            self.compile_for_profile(src, DialectProfile::plain_tcl())
+        }
+
+        fn compile_for_profile(
+            &self,
+            src: &str,
+            profile: &'static DialectProfile,
+        ) -> Result<Self::Module, CompileError> {
+            let registry = tcl_registry::registry_for_profile(profile);
+            let config = tcl_lexer::LexerConfig::from_grammar(profile.grammar);
+            let ir = lower_to_ir(src, registry, config, profile.name);
+            let cfg = build_cfg_codegen(&ir, false);
+            Ok(codegen_module(&cfg, &ir, registry))
+        }
+    }
 
     #[test]
     fn invokehidden_rechecks_a_hidden_builtin_against_the_child_profile() {
@@ -6345,6 +6394,65 @@ mod family_b_tests {
         assert!(!vm.commands.contains_key("held"));
         assert!(!vm.builtin_identities.contains_key("held"));
         assert!(!vm.imported_commands.contains_key("held"));
+    }
+
+    fn eval_value(vm: &mut Vm, script: &str) -> String {
+        let completion = vm.eval_source(script).expect("script compiles");
+        assert_eq!(completion.code, Code::Ok, "{script}: {completion:?}");
+        completion.result.to_str().to_string()
+    }
+
+    fn prepare_stale_hidden_proc(vm: &mut Vm) {
+        vm.set_compiler(Box::new(TestCompiler));
+        vm.set_dialect_profile(DialectProfile::by_name("tcl8.5"));
+        assert_eq!(eval_value(vm, "proc p {} { return hidden }"), "");
+        vm.hide_command("p", "held").unwrap();
+        assert_eq!(eval_value(vm, "proc p {} { return replacement }"), "");
+        vm.set_dialect_profile(DialectProfile::by_name("tcl8.6"));
+    }
+
+    #[test]
+    fn refreshed_hidden_proc_stays_hidden_and_preserves_visible_replacement() {
+        let mut vm = Vm::new();
+        prepare_stale_hidden_proc(&mut vm);
+        let hidden = vm.invoke_hidden_in_child("", "held", &[]).unwrap();
+        assert_eq!(hidden.code, Code::Ok);
+        assert_eq!(hidden.result.to_str().as_ref(), "hidden");
+        assert_eq!(eval_value(&mut vm, "p"), "replacement");
+        assert!(matches!(
+            vm.hidden_commands.get("held"),
+            Some(Command::Proc(proc))
+                if proc.compiled_profile_generation == vm.profile_generation
+        ));
+
+        let child_name = vm.create_child(Some("child".to_owned()), false);
+        let child = vm.child_id(&child_name).unwrap();
+        vm.in_interp(child, prepare_stale_hidden_proc);
+
+        let named = vm.invoke_hidden_in_child("child", "held", &[]).unwrap();
+        assert_eq!(named.code, Code::Ok);
+        assert_eq!(named.result.to_str().as_ref(), "hidden");
+        assert_eq!(
+            vm.in_interp(child, |child| eval_value(child, "p")),
+            "replacement"
+        );
+
+        vm.in_interp(child, |child| {
+            child.set_dialect_profile(DialectProfile::by_name("tcl8.5"));
+        });
+        let by_id = vm.invoke_hidden_by_id(child, "held", &[]).unwrap();
+        assert_eq!(by_id.code, Code::Ok);
+        assert_eq!(by_id.result.to_str().as_ref(), "hidden");
+        assert_eq!(
+            vm.in_interp(child, |child| eval_value(child, "p")),
+            "replacement"
+        );
+        let state = vm.st_of(child).unwrap();
+        assert!(matches!(
+            state.hidden_commands.get("held"),
+            Some(Command::Proc(proc))
+                if proc.compiled_profile_generation == state.profile_generation
+        ));
     }
 
     struct TestNative;

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -30,6 +30,7 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::io::{self, Write};
 use std::rc::{Rc, Weak};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use tcl_bytecode::{FunctionAsm, ModuleAsm};
 use tcl_core_types::RecursionLimit;
@@ -374,6 +375,10 @@ fn elem_ref(name: &str) -> Option<(&str, &str)> {
 /// already executing deeper on the stack is legal: its persistent state stays
 /// addressable in the arena throughout (the fix for issue #946 faults 1–2).
 pub struct Vm {
+    /// Process-unique identity for embedder artefacts. A reusable compiled
+    /// handle belongs to the VM that compiled it; generations alone are not a
+    /// cross-VM identity domain.
+    pub(crate) owner_nonce: u64,
     /// The currently-executing interpreter's state ([`Deref`] target).
     state: Box<InterpState>,
     /// Which interp `state` belongs to.
@@ -1065,7 +1070,9 @@ impl Vm {
 
     /// A VM writing to an already-shared output sink.
     fn with_shared_output(out: Rc<RefCell<Box<dyn Write>>>) -> Self {
+        static NEXT_VM_OWNER: AtomicU64 = AtomicU64::new(1);
         let mut vm = Self {
+            owner_nonce: NEXT_VM_OWNER.fetch_add(1, Ordering::Relaxed),
             state: Box::new(InterpState::fresh(out)),
             cur: ROOT_INTERP,
             interps: vec![InterpSlot {

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -297,7 +297,7 @@ impl InterpSlot {
 /// b`, an `a`-side alias into `b` is gone from `info commands`).
 struct AliasBackref {
     source: InterpId,
-    key: String,
+    key: CommandSidecarKey,
     target: InterpId,
 }
 
@@ -396,6 +396,31 @@ pub struct Vm {
     alias_backrefs: Vec<AliasBackref>,
 }
 
+/// Identity domain for metadata that follows a command binding.  Tcl permits
+/// a hidden token and a visible command to have the same spelling at the same
+/// time; consequently a bare `String` is not a command identity.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum CommandSidecarKey {
+    Visible(String),
+    Hidden(String),
+}
+
+impl CommandSidecarKey {
+    pub(crate) fn visible(name: impl Into<String>) -> Self {
+        Self::Visible(name.into())
+    }
+
+    pub(crate) fn hidden(name: impl Into<String>) -> Self {
+        Self::Hidden(name.into())
+    }
+
+    pub(crate) fn name(&self) -> &str {
+        match self {
+            Self::Visible(name) | Self::Hidden(name) => name,
+        }
+    }
+}
+
 /// Metadata and any release-hidden destination displaced while a command is
 /// temporarily installed under a new name.  A rename can still be refused
 /// after installation when it would make an alias loop, so this keeps the
@@ -403,7 +428,7 @@ pub struct Vm {
 pub(crate) struct CommandRenameTransaction {
     old_key: String,
     new_key: String,
-    source_import_origin: Option<String>,
+    source_import_origin: Option<CommandSidecarKey>,
     source_builtin_identity: Option<String>,
     cross_alias_target: Option<InterpId>,
 }
@@ -485,7 +510,7 @@ pub struct InterpState {
     /// `Tcl_ForgetImport`, which matches on `deleteProc == DeleteImportedCmd`),
     /// leaving a real command of the same name intact. Cleared whenever the key
     /// is re-registered (a redefine) or taken (a `rename`).
-    imported_commands: HashMap<String, String>,
+    imported_commands: HashMap<String, CommandSidecarKey>,
     /// Stable registry identity for a builtin that has moved away from its
     /// registered spelling (via import, rename, or hide/expose).  This is
     /// deliberately distinct from the mutable `namespace origin` provenance:
@@ -530,10 +555,10 @@ pub struct InterpState {
     /// `trace add command` registrations (`rename`/`delete` ops), keyed by the
     /// command's table key.  Entries follow the command through `rename` and
     /// are dropped when it is deleted or overwritten (M16.3).
-    pub(crate) cmd_traces: HashMap<String, Vec<Rc<CmdTraceEntry>>>,
+    pub(crate) cmd_traces: HashMap<CommandSidecarKey, Vec<Rc<CmdTraceEntry>>>,
     /// `trace add execution` registrations (`enter`/`leave`/`enterstep`/
     /// `leavestep` ops), keyed like [`Self::cmd_traces`] and moved on rename.
-    pub(crate) exec_traces: HashMap<String, Vec<Rc<CmdTraceEntry>>>,
+    pub(crate) exec_traces: HashMap<CommandSidecarKey, Vec<Rc<CmdTraceEntry>>>,
     /// Step-trace scopes currently active: one entry per `enterstep`/
     /// `leavestep`-bearing trace of each traced proc whose body is running.
     /// Every command dispatched while non-empty fires these (C's step
@@ -647,6 +672,10 @@ pub struct InterpState {
     /// error messages — e.g. `::tcl::mathop::!` reached via `namespace path` says
     /// `wrong # args: should be "! boolean"`, not the resolved full name.
     invoked_name: Option<String>,
+    /// Hidden-domain command currently entering a native handler. Consumed by
+    /// lifecycle-aware handlers (currently coroutine resume) so an equal
+    /// visible spelling cannot select the wrong sidecar state.
+    pub(crate) invoked_sidecar: Option<CommandSidecarKey>,
     /// Open I/O channels (file handles), keyed by channel id (`file3`, …). The
     /// predefined `stdin`/`stdout`/`stderr` are not stored here; commands
     /// special-case those names.
@@ -712,7 +741,7 @@ pub struct InterpState {
     /// Import provenance and stable builtin identities carried while a command
     /// lives in the hidden table.  Hiding is a temporary relocation, not a
     /// metadata-dropping deletion: expose must restore both under its new key.
-    hidden_imported_commands: HashMap<String, String>,
+    hidden_imported_commands: HashMap<String, CommandSidecarKey>,
     hidden_builtin_identities: HashMap<String, String>,
     /// Monotonic counter minting auto-generated child names (`interp0`, …).
     interp_counter: u64,
@@ -1003,6 +1032,63 @@ impl Vm {
 }
 
 impl InterpState {
+    /// Release/dialect visibility belongs to the interpreter state because
+    /// command candidate traversal happens here, including for parked child
+    /// interpreters.  Filtering after resolution is too late: an unavailable
+    /// namespace-local builtin must not shadow a later path/global candidate.
+    /// The registry owns the versioned filters; procedures and aliases are
+    /// invariant, while registered builtin/native handlers retain a stable
+    /// identity through import, rename, hide, and expose.
+    fn builtin_command_visible_for_surface(&self, name: &str, command: &Command) -> bool {
+        self.builtin_command_visible_for_identity(name, command, None)
+    }
+
+    fn builtin_command_visible_for_identity(
+        &self,
+        name: &str,
+        command: &Command,
+        identity: Option<&str>,
+    ) -> bool {
+        if !matches!(command, Command::Builtin(_) | Command::Native(_)) {
+            return true;
+        }
+        let origin = identity
+            .map(str::to_owned)
+            .or_else(|| self.builtin_identities.get(name).cloned())
+            .unwrap_or_else(|| {
+                let mut current = CommandSidecarKey::visible(name);
+                for _ in 0..=self.imported_commands.len() + self.hidden_imported_commands.len() {
+                    let next = match &current {
+                        CommandSidecarKey::Visible(visible) => self.imported_commands.get(visible),
+                        CommandSidecarKey::Hidden(hidden) => {
+                            self.hidden_imported_commands.get(hidden)
+                        }
+                    };
+                    let Some(next) = next else {
+                        break;
+                    };
+                    current = next.clone();
+                }
+                current.name().to_owned()
+            });
+        if !tcl_registry::expr_surface::RuntimeExprSurface::for_tcl_version(self.runtime_version)
+            .permits_builtin_math_function_command(&origin)
+        {
+            return false;
+        }
+        matches!(command, Command::Native(_)) || self.profile_admits_registry_builtin(&origin)
+    }
+
+    fn profile_admits_registry_builtin(&self, name: &str) -> bool {
+        let Some(registry) = self.profile_registry else {
+            return true;
+        };
+        registry.get(name).is_none()
+            || registry
+                .get_for_dialect(name, self.dialect_profile.availability_mask)
+                .is_some()
+    }
+
     /// A fresh interpreter state writing `puts` output to `out` — no commands
     /// registered yet ([`Vm::with_shared_output`] / [`Vm::fork_child`] follow
     /// up with `register_builtins`).
@@ -1058,6 +1144,7 @@ impl InterpState {
             error_logged: false,
             error_line: 1,
             invoked_name: None,
+            invoked_sidecar: None,
             channels: HashMap::new(),
             chan_counter: 2,
             script_stack: Vec::new(),
@@ -1107,15 +1194,6 @@ impl Vm {
             Some(&self.state)
         } else {
             self.interps.get(id.0)?.parked.as_deref()
-        }
-    }
-
-    /// Mutable access to another interpreter's state (or the current one's).
-    pub(crate) fn st_of_mut(&mut self, id: InterpId) -> Option<&mut InterpState> {
-        if id == self.cur {
-            Some(&mut self.state)
-        } else {
-            self.interps.get_mut(id.0)?.parked.as_deref_mut()
         }
     }
 
@@ -1193,28 +1271,28 @@ impl Vm {
         for c in child_ids {
             self.retire_interp(c);
         }
-        let targeting: Vec<(InterpId, String)> = self
+        let targeting: Vec<(InterpId, CommandSidecarKey)> = self
             .alias_backrefs
             .iter()
             .filter(|b| b.target == id && b.source != id)
             .map(|b| (b.source, b.key.clone()))
             .collect();
         for (src, key) in targeting {
-            let visible = self.st_of(src).is_some_and(|st| matches!(st.commands.get(&key), Some(Command::CrossAlias { target, .. }) if *target == id));
-            let hidden = self.st_of(src).is_some_and(|st| matches!(st.hidden_commands.get(&key), Some(Command::CrossAlias { target, .. }) if *target == id));
+            let visible = matches!(&key, CommandSidecarKey::Visible(name) if self.st_of(src).is_some_and(|st| matches!(st.commands.get(name), Some(Command::CrossAlias { target, .. }) if *target == id)));
+            let hidden = matches!(&key, CommandSidecarKey::Hidden(name) if self.st_of(src).is_some_and(|st| matches!(st.hidden_commands.get(name), Some(Command::CrossAlias { target, .. }) if *target == id)));
             if visible {
                 self.in_interp(src, |vm| {
-                    vm.remove_command_exact(&key);
-                    vm.on_command_removed(&key);
+                    vm.remove_command_exact(key.name());
+                    vm.on_command_removed_for(&key);
                 });
             }
             if hidden {
                 self.in_interp(src, |vm| {
-                    vm.hidden_commands.remove(&key);
-                    vm.hidden_imported_commands.remove(&key);
-                    vm.hidden_builtin_identities.remove(&key);
-                    vm.cmd_traces.remove(&key);
-                    vm.exec_traces.remove(&key);
+                    vm.hidden_commands.remove(key.name());
+                    vm.hidden_imported_commands.remove(key.name());
+                    vm.hidden_builtin_identities.remove(key.name());
+                    vm.on_command_removed_for(&key);
+                    vm.drop_alias_backref_key(&key);
                 });
             }
         }
@@ -1240,9 +1318,9 @@ impl Vm {
                 vm.hidden_commands.remove(&key);
                 vm.hidden_imported_commands.remove(&key);
                 vm.hidden_builtin_identities.remove(&key);
-                vm.cmd_traces.remove(&key);
-                vm.exec_traces.remove(&key);
-                vm.drop_alias_backref(&key);
+                let sidecar = CommandSidecarKey::hidden(&key);
+                vm.on_command_removed_for(&sidecar);
+                vm.drop_alias_backref_key(&sidecar);
             });
         }
         self.alias_backrefs.retain(|b| b.target != id);
@@ -1298,12 +1376,16 @@ impl Vm {
 
     /// Record a just-registered cross-interp alias for the target-death sweep.
     pub(crate) fn note_alias_backref(&mut self, key: &str, target: InterpId) {
+        self.note_alias_backref_key(CommandSidecarKey::visible(key), target);
+    }
+
+    fn note_alias_backref_key(&mut self, key: CommandSidecarKey, target: InterpId) {
         let source = self.cur;
         self.alias_backrefs
-            .retain(|b| !(b.source == source && b.key == key));
+            .retain(|b| !(b.source == source && b.key.eq(&key)));
         self.alias_backrefs.push(AliasBackref {
             source,
-            key: key.to_string(),
+            key,
             target,
         });
     }
@@ -1316,12 +1398,25 @@ impl Vm {
         new_key: &str,
         target: InterpId,
     ) {
+        self.retarget_alias_backref_key(
+            &CommandSidecarKey::visible(old_key),
+            CommandSidecarKey::visible(new_key),
+            target,
+        );
+    }
+
+    fn retarget_alias_backref_key(
+        &mut self,
+        old_key: &CommandSidecarKey,
+        new_key: CommandSidecarKey,
+        target: InterpId,
+    ) {
         let source = self.cur;
         self.alias_backrefs
-            .retain(|b| !(b.source == source && (b.key == old_key || b.key == new_key)));
+            .retain(|b| !(b.source == source && (b.key.eq(old_key) || b.key == new_key)));
         self.alias_backrefs.push(AliasBackref {
             source,
-            key: new_key.to_string(),
+            key: new_key,
             target,
         });
     }
@@ -1329,9 +1424,13 @@ impl Vm {
     /// Drop any cross-interp alias backref for `key` in the current interp (the
     /// alias was deleted or overwritten with a non-alias).
     pub(crate) fn drop_alias_backref(&mut self, key: &str) {
+        self.drop_alias_backref_key(&CommandSidecarKey::visible(key));
+    }
+
+    fn drop_alias_backref_key(&mut self, key: &CommandSidecarKey) {
         let source = self.cur;
         self.alias_backrefs
-            .retain(|b| !(b.source == source && b.key == key));
+            .retain(|b| !(b.source == source && b.key.eq(key)));
     }
 
     /// Reseed the `rand()` generator (`srand(n)`): mask to 31 bits, and nudge a
@@ -1889,17 +1988,22 @@ impl Vm {
     /// Retire a VM-owned command whether its lifecycle key is currently
     /// visible or hidden. Completion is a real command deletion, so delete
     /// traces fire exactly once before all trace/deopt sidecars are dropped.
-    pub(crate) fn retire_command_lifecycle(&mut self, key: &str) -> Option<Command> {
-        if let Some(command) = self.take_command_unchecked(key) {
-            self.on_command_removed(key);
-            return Some(command);
-        }
-        let command = self.hidden_commands.remove(key)?;
-        self.bump_cmd_epoch();
-        self.hidden_imported_commands.remove(key);
-        self.hidden_builtin_identities.remove(key);
-        self.drop_alias_backref(key);
-        self.on_command_removed(key);
+    pub(crate) fn retire_command_lifecycle_key(
+        &mut self,
+        key: &CommandSidecarKey,
+    ) -> Option<Command> {
+        let command = match key {
+            CommandSidecarKey::Visible(name) => self.take_command_unchecked_key(name)?,
+            CommandSidecarKey::Hidden(name) => {
+                let command = self.hidden_commands.remove(name)?;
+                self.bump_cmd_epoch();
+                self.hidden_imported_commands.remove(name);
+                self.hidden_builtin_identities.remove(name);
+                command
+            }
+        };
+        self.drop_alias_backref_key(key);
+        self.on_command_removed_for(key);
         Some(command)
     }
 
@@ -2046,68 +2150,6 @@ impl Vm {
     /// it were renamed to `key`.
     pub(crate) fn alias_chain_loops_for_rename(&self, key: &str, alias: &Command) -> bool {
         self.alias_chain_loops_from(self.cur, key, alias)
-    }
-
-    /// Whether this registered builtin is visible on the selected command
-    /// surface. The registry owns the only versioned command filters; ordinary
-    /// procedures, aliases, and extensions are never hidden here.
-    ///
-    /// Two registry-backed cases, both scoped to engine-registered handlers:
-    ///
-    /// - the math-function surface (`::tcl::mathfunc::*` vs the 8.4 fixed
-    ///   table), for `Builtin` and embedder `Native` handlers alike;
-    /// - release availability (issue #1463): a `Builtin` whose registry spec
-    ///   the [`Self::dialect_profile`] availability mask does not admit
-    ///   (`lassign` at 8.4, `lpop` before 9.0) resolves like C Tcl — to
-    ///   `invalid command name`. Only registry-known builtins are gated:
-    ///   user procs, aliases, embedder `Native` replacements, and names the
-    ///   registry does not know remain callable.
-    fn builtin_command_visible_for_surface(&self, name: &str, command: &Command) -> bool {
-        self.builtin_command_visible_for_identity(name, command, None)
-    }
-
-    /// The command-surface gate with identity supplied by an owning table.
-    /// Hidden commands retain their identity outside the visible table, so
-    /// `interp invokehidden` must use this form without transiently publishing
-    /// that metadata under the hidden token.
-    pub(crate) fn builtin_command_visible_for_identity(
-        &self,
-        name: &str,
-        command: &Command,
-        identity: Option<&str>,
-    ) -> bool {
-        if !matches!(command, Command::Builtin(_) | Command::Native(_)) {
-            return true;
-        }
-        // `namespace import` stores a command-table clone for dispatch. Its
-        // source name can change, but the clone remains the original builtin;
-        // gate on that stable identity rather than the local spelling or
-        // mutable `namespace origin` name. This mirrors runtime/rust's
-        // `Command::Imported` redirect through `resolve_dispatchable`.
-        let origin = identity
-            .map(str::to_owned)
-            .or_else(|| self.builtin_identities.get(name).cloned())
-            .unwrap_or_else(|| self.command_origin_key(name));
-        if !tcl_registry::expr_surface::RuntimeExprSurface::for_tcl_version(self.runtime_version)
-            .permits_builtin_math_function_command(&origin)
-        {
-            return false;
-        }
-        matches!(command, Command::Native(_)) || self.profile_admits_registry_builtin(&origin)
-    }
-
-    /// The availability half of [`Self::builtin_command_visible_for_surface`]:
-    /// whether the pinned [`Self::dialect_profile`] admits registry builtin
-    /// `name`. Names the registry does not know are always admitted — they
-    /// may be engine extensions the registry has no spec for.
-    fn profile_admits_registry_builtin(&self, name: &str) -> bool {
-        let Some(registry) = self.profile_registry else {
-            return true; // the permissive fallback profile gates nothing
-        };
-        registry.get(name).is_none()
-            || registry
-                .get_for_dialect(name, self.dialect_profile.availability_mask)
-                .is_some()
     }
 
     /// The names `info functions` exposes on the selected Tcl release.
@@ -2597,7 +2639,11 @@ impl Vm {
         if !self.builtin_command_visible_for_identity(cmd, &hidden, identity) {
             return err(format!("invalid command name \"{cmd}\""));
         }
-        self.invoke_resolved_command(cmd, cmd, hidden, args)
+        self.invoke_resolved_command(cmd, CommandSidecarKey::hidden(cmd), hidden, args)
+    }
+
+    pub(crate) fn take_invoked_sidecar(&mut self) -> Option<CommandSidecarKey> {
+        self.invoked_sidecar.take()
     }
 
     /// `interp marktrusted path` — clear a child's safe flag (exposing every
@@ -2606,11 +2652,24 @@ impl Vm {
         let Some(id) = self.child_id(name) else {
             return;
         };
-        if let Some(child) = self.st_of_mut(id) {
-            child.bump_cmd_epoch();
-            child.expose_all_hidden_commands();
-            child.is_safe = false;
-        }
+        self.mark_interp_trusted(id);
+    }
+
+    fn mark_interp_trusted(&mut self, id: InterpId) {
+        let names: Vec<String> = self
+            .st_of(id)
+            .map(|state| state.hidden_commands.keys().cloned().collect())
+            .unwrap_or_default();
+        self.in_interp(id, |vm| {
+            vm.bump_cmd_epoch();
+            for name in names {
+                if !vm.commands.contains_key(&name) {
+                    vm.expose_own_command(&name, &name)
+                        .expect("a non-colliding hidden command exposes");
+                }
+            }
+            vm.is_safe = false;
+        });
     }
 
     /// Stable registry identity for a visible builtin, if any.  A direct
@@ -2649,8 +2708,11 @@ impl Vm {
             _ => None,
         };
         self.hidden_commands.insert(token.to_owned(), command);
-        crate::cmd_coro::on_command_renamed(self, &source, token);
-        self.move_command_traces(&source, token);
+        crate::cmd_coro::on_command_hidden(self, &source, token);
+        self.move_command_traces(
+            &CommandSidecarKey::visible(&source),
+            CommandSidecarKey::hidden(token),
+        );
         if let Some(origin) = import_origin {
             self.hidden_imported_commands
                 .insert(token.to_owned(), origin);
@@ -2659,11 +2721,19 @@ impl Vm {
             self.hidden_builtin_identities
                 .insert(token.to_owned(), identity);
         }
-        // A hidden token is the command's temporary name.  Imports that
-        // pointed at this source follow it until expose gives it a new key.
-        self.retarget_imports(&source, token);
+        // Hiding does not change the Tcl-visible origin. Retarget the internal
+        // reference into the hidden domain so the lineage remains traversable
+        // without colliding with an equal visible token.
+        self.retarget_imports_key(
+            &CommandSidecarKey::visible(&source),
+            &CommandSidecarKey::hidden(token),
+        );
         if let Some(target) = cross_target {
-            self.retarget_alias_backref(&source, token, target);
+            self.retarget_alias_backref_key(
+                &CommandSidecarKey::visible(&source),
+                CommandSidecarKey::hidden(token),
+                target,
+            );
         }
         Ok(())
     }
@@ -2680,20 +2750,29 @@ impl Vm {
                 _ => None,
             };
             self.register_command(token, c);
-            crate::cmd_coro::on_command_renamed(self, cmd, token);
-            self.move_command_traces(cmd, token);
+            crate::cmd_coro::on_command_exposed(self, cmd, token);
+            self.move_command_traces(
+                &CommandSidecarKey::hidden(cmd),
+                CommandSidecarKey::visible(token),
+            );
             if let Some(origin) = self.hidden_imported_commands.remove(cmd) {
                 self.imported_commands.insert(token.to_owned(), origin);
             }
             if let Some(identity) = self.hidden_builtin_identities.remove(cmd) {
                 self.builtin_identities.insert(token.to_owned(), identity);
             }
-            // `interp hide` + `interp expose ... newName` is a rename through
-            // the hidden table. Imported commands retain the source token in
-            // C Tcl, so their provenance follows the newly exposed name too.
-            self.retarget_imports(cmd, token);
+            // Reconnect internal references to the visible domain; their
+            // Tcl-visible ultimate source lineage remains unchanged.
+            self.retarget_imports_key(
+                &CommandSidecarKey::hidden(cmd),
+                &CommandSidecarKey::visible(token),
+            );
             if let Some(target) = cross_target {
-                self.retarget_alias_backref(cmd, token, target);
+                self.retarget_alias_backref_key(
+                    &CommandSidecarKey::hidden(cmd),
+                    CommandSidecarKey::visible(token),
+                    target,
+                );
             }
         }
         Ok(())
@@ -3062,11 +3141,7 @@ impl Vm {
                 if self.is_safe() {
                     return err("permission denied: safe interpreter cannot mark trusted");
                 }
-                if let Some(child) = self.st_of_mut(id) {
-                    child.bump_cmd_epoch();
-                    child.expose_all_hidden_commands();
-                    child.is_safe = false;
-                }
+                self.mark_interp_trusted(id);
                 ok(Value::empty())
             }
             "invokehidden" if !rest.is_empty() => self.dispatch_child_invokehidden(name, id, rest),
@@ -3339,22 +3414,6 @@ fn is_step_capable(ops: &[String]) -> bool {
 /// coercion keeps every `impl Vm` caller (`self.resolve_command_fqn(…)`)
 /// working against the current interp unchanged.
 impl InterpState {
-    /// Move every hidden command back into the visible table, retaining the
-    /// import provenance and stable builtin identity that travelled with it.
-    fn expose_all_hidden_commands(&mut self) {
-        let origins = std::mem::take(&mut self.hidden_imported_commands);
-        let identities = std::mem::take(&mut self.hidden_builtin_identities);
-        for (name, command) in std::mem::take(&mut self.hidden_commands) {
-            self.commands.insert(name.clone(), command);
-            if let Some(origin) = origins.get(&name) {
-                self.imported_commands.insert(name.clone(), origin.clone());
-            }
-            if let Some(identity) = identities.get(&name) {
-                self.builtin_identities.insert(name, identity.clone());
-            }
-        }
-    }
-
     /// Invalidate the command-resolution memo (M16.4): every command-table /
     /// `namespace path` / runtime-version mutation routes through here so a
     /// cached `(namespace, name) → key` can never outlive the state it was
@@ -3448,7 +3507,10 @@ impl InterpState {
                 .map_or_else(|| c.to_string(), String::from)
         };
         tcl_syntax::naming::resolve_command_with(cxt, &rooted, &name, |candidate| {
-            self.commands.contains_key(&unroot(candidate))
+            let key = unroot(candidate);
+            self.commands
+                .get(&key)
+                .is_some_and(|command| self.builtin_command_visible_for_surface(&key, command))
         })
         .map(|winner| unroot(&winner))
     }
@@ -3639,7 +3701,8 @@ impl Vm {
             self.register_command(&alias, cmd);
             // `register_command` cleared any stale provenance; now stamp this key
             // as an import so `namespace forget` can target it.
-            self.imported_commands.insert(alias.clone(), origin);
+            self.imported_commands
+                .insert(alias.clone(), CommandSidecarKey::visible(origin));
             if let Some(identity) = builtin_identity {
                 self.builtin_identities.insert(alias, identity);
             }
@@ -3654,16 +3717,20 @@ impl Vm {
     /// when it names no import. Keys are canonical (unrooted), as
     /// `imported_commands` stores them.
     pub(crate) fn command_origin_key(&self, key: &str) -> String {
-        let mut cur = key.to_owned();
+        let mut cur = CommandSidecarKey::visible(key);
         // Bounded walk: a chain cannot be longer than the import table, so a
         // (malformed) cycle terminates instead of spinning.
-        for _ in 0..self.imported_commands.len() {
-            match self.imported_commands.get(&cur) {
+        for _ in 0..self.imported_commands.len() + self.hidden_imported_commands.len() {
+            let next = match &cur {
+                CommandSidecarKey::Visible(visible) => self.imported_commands.get(visible),
+                CommandSidecarKey::Hidden(hidden) => self.hidden_imported_commands.get(hidden),
+            };
+            match next {
                 Some(next) => cur = next.clone(),
                 None => break,
             }
         }
-        cur
+        cur.name().to_owned()
     }
 
     /// Retarget imports when their source command is renamed.  The command
@@ -3673,16 +3740,22 @@ impl Vm {
     /// builtin under its new name.  A deletion deliberately does not take this
     /// path: C leaves the imported command dangling in that case.
     pub(crate) fn retarget_imports(&mut self, old_key: &str, new_key: &str) {
-        let new_key = new_key.to_owned();
+        self.retarget_imports_key(
+            &CommandSidecarKey::visible(old_key),
+            &CommandSidecarKey::visible(new_key),
+        );
+    }
+
+    fn retarget_imports_key(&mut self, old_key: &CommandSidecarKey, new_key: &CommandSidecarKey) {
         for source in self.imported_commands.values_mut() {
             if source == old_key {
-                source.clone_from(&new_key);
+                source.clone_from(new_key);
             }
         }
     }
 
     /// Restore a renamed imported command's own origin record.
-    pub(crate) fn restore_import_origin(&mut self, key: &str, origin: String) {
+    pub(crate) fn restore_import_origin(&mut self, key: &str, origin: CommandSidecarKey) {
         self.imported_commands.insert(key.to_owned(), origin);
     }
 
@@ -3729,7 +3802,7 @@ impl Vm {
                 .iter()
                 .filter(|(key, origin)| {
                     split_key(key).0 == cur && {
-                        let (o_ns, o_tail) = split_key(origin);
+                        let (o_ns, o_tail) = split_key(origin.name());
                         o_ns == src_ns && tcl_syntax::glob::string_match(simple, o_tail)
                     }
                 })
@@ -3940,7 +4013,7 @@ impl Vm {
             &mut self.cmd_traces
         };
         table
-            .entry(key)
+            .entry(CommandSidecarKey::visible(key))
             .or_default()
             .push(Rc::new(CmdTraceEntry::new(ops, callback)));
         self.invalidate_guard_domain(GuardDomain::CommandTrace);
@@ -3972,6 +4045,7 @@ impl Vm {
         } else {
             &mut self.cmd_traces
         };
+        let key = CommandSidecarKey::visible(key);
         let mut removed = false;
         if let Some(list) = table.get_mut(&key) {
             if let Some(index) = list
@@ -4007,7 +4081,7 @@ impl Vm {
         };
         let Some(list) = self
             .resolve_command_fqn(self.current_ns(), name)
-            .and_then(|key| table.get(&key))
+            .and_then(|key| table.get(&CommandSidecarKey::visible(key)))
         else {
             return Value::empty();
         };
@@ -4063,7 +4137,7 @@ impl Vm {
     /// `::victim ::victim2 rename`; a delete passes `{}` for the new name).
     /// Callback errors are ignored (C: "Any errors in these traces are
     /// ignored").
-    pub(crate) fn fire_command_traces(&mut self, key: &str, new_display: &str, op: &str) {
+    fn fire_command_traces_for(&mut self, key: &CommandSidecarKey, new_display: &str, op: &str) {
         // C's `INTERP_TRACE_IN_PROGRESS`: a rename/delete triggered by a
         // trace callback's own body does not itself fire further traces.
         if self.cmd_traces.is_empty() || self.trace_in_progress.get() {
@@ -4072,7 +4146,7 @@ impl Vm {
         let Some(entries) = self.cmd_traces.get(key).cloned() else {
             return;
         };
-        let old_display = format!("::{key}");
+        let old_display = format!("::{}", key.name());
         for entry in entries {
             if entry.ops.iter().any(|o| o == op) {
                 let _ = self.run_cmd_trace_callback(
@@ -4091,9 +4165,13 @@ impl Vm {
     /// `delete` traces (tclsh-pinned: redefining a traced proc fires them
     /// too) and drop every trace registered on it.
     pub(crate) fn on_command_removed(&mut self, key: &str) {
+        self.on_command_removed_for(&CommandSidecarKey::visible(key));
+    }
+
+    fn on_command_removed_for(&mut self, key: &CommandSidecarKey) {
         let mut removed_trace = false;
         if !self.cmd_traces.is_empty() {
-            self.fire_command_traces(key, "", "delete");
+            self.fire_command_traces_for(key, "", "delete");
             removed_trace |= self.cmd_traces.remove(key).is_some();
         }
         if !self.exec_traces.is_empty()
@@ -4115,18 +4193,20 @@ impl Vm {
     /// traces with both fully-qualified names, then move every trace with it
     /// (tclsh-pinned: an execution trace keeps firing under the new name).
     pub(crate) fn on_command_renamed_traces(&mut self, old_key: &str, new_key: &str) {
+        let old_key = CommandSidecarKey::visible(old_key);
+        let new_key = CommandSidecarKey::visible(new_key);
         let mut moved_trace = false;
         if !self.cmd_traces.is_empty() {
-            self.fire_command_traces(old_key, &format!("::{new_key}"), "rename");
-            if let Some(entries) = self.cmd_traces.remove(old_key) {
-                self.cmd_traces.insert(new_key.to_owned(), entries);
+            self.fire_command_traces_for(&old_key, &format!("::{}", new_key.name()), "rename");
+            if let Some(entries) = self.cmd_traces.remove(&old_key) {
+                self.cmd_traces.insert(new_key.clone(), entries);
                 moved_trace = true;
             }
         }
         if !self.exec_traces.is_empty()
-            && let Some(entries) = self.exec_traces.remove(old_key)
+            && let Some(entries) = self.exec_traces.remove(&old_key)
         {
-            self.exec_traces.insert(new_key.to_owned(), entries);
+            self.exec_traces.insert(new_key, entries);
             moved_trace = true;
         }
         if moved_trace {
@@ -4136,14 +4216,14 @@ impl Vm {
 
     /// Move trace registrations with a command through the hidden table.  A
     /// hide/expose is not a Tcl rename, so no callback is fired.
-    fn move_command_traces(&mut self, old_key: &str, new_key: &str) {
+    fn move_command_traces(&mut self, old_key: &CommandSidecarKey, new_key: CommandSidecarKey) {
         let mut moved = false;
         if let Some(entries) = self.cmd_traces.remove(old_key) {
-            self.cmd_traces.insert(new_key.to_owned(), entries);
+            self.cmd_traces.insert(new_key.clone(), entries);
             moved = true;
         }
         if let Some(entries) = self.exec_traces.remove(old_key) {
-            self.exec_traces.insert(new_key.to_owned(), entries);
+            self.exec_traces.insert(new_key, entries);
             moved = true;
         }
         if moved {
@@ -6104,7 +6184,9 @@ mod family_b_tests {
         // token: normal command lookup from the body sees only visible state.
         assert_eq!(observed.borrow().as_deref(), Some("held"));
         assert_eq!(
-            vm.hidden_imported_commands.get("held").map(String::as_str),
+            vm.hidden_imported_commands
+                .get("held")
+                .map(CommandSidecarKey::name),
             Some("src::probe")
         );
         assert!(!vm.imported_commands.contains_key("held"));

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -4549,8 +4549,25 @@ impl Vm {
             .as_ref()?
             .compile_for_profile(src, self.dialect_profile)
             .ok()?;
+        self.validate_module_profile(&module).ok()?;
         self.merge_procs(&module.procedures);
         Some(Rc::new(module.top_level))
+    }
+
+    /// Enforce the bytecode artifact's exact profile at every consumption
+    /// boundary.  The permissive fallback profile is still a real compile
+    /// target: bytecode lowered with its all-Tcl registry can contain an
+    /// intrinsic unavailable in a named release, so it is only executable by
+    /// a fallback-profile VM.
+    pub(crate) fn validate_module_profile(&self, module: &ModuleAsm) -> Result<(), TclError> {
+        if std::ptr::eq(module.profile, self.dialect_profile) {
+            Ok(())
+        } else {
+            Err(TclError::new(format!(
+                "bytecode compiled for dialect profile {} cannot run under {}",
+                module.profile.name, self.dialect_profile.name
+            )))
+        }
     }
 
     /// Merge a module's pre-compiled proc bodies into the registry.
@@ -4592,6 +4609,9 @@ impl Vm {
         let Ok(module) = recompiled else {
             return proc;
         };
+        if self.validate_module_profile(&module).is_err() {
+            return proc;
+        }
         self.merge_procs(&module.procedures);
         let mut fresh = (*proc).clone();
         fresh.body = Rc::new(module.top_level);
@@ -5919,6 +5939,7 @@ impl Vm {
             c.compile_for_profile(src, self.dialect_profile)
         };
         let m = Rc::new(compiled.map_err(|e| TclError::new(e.0))?);
+        self.validate_module_profile(&m)?;
         let cache = if traced {
             &mut self.eval_cache_traced
         } else {
@@ -5951,6 +5972,7 @@ impl Vm {
     /// counterpart of the nested drive `eval_source` performs.
     pub(crate) fn compile_source_cached(&mut self, src: &str) -> Result<Rc<FunctionAsm>, TclError> {
         let module = self.compile_cached(src)?;
+        self.validate_module_profile(&module)?;
         self.merge_procs(&module.procedures);
         Ok(Rc::new(module.top_level.clone()))
     }

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -1886,6 +1886,24 @@ impl Vm {
         self.take_command_unchecked_key(&key)
     }
 
+    /// Retire a VM-owned command whether its lifecycle key is currently
+    /// visible or hidden.  Coroutine completion is not a user `rename`/delete
+    /// operation, so hidden retirement deliberately does not fire a command
+    /// delete callback, but it must clear every hidden-table sidecar.
+    pub(crate) fn retire_command_lifecycle(&mut self, key: &str) -> Option<Command> {
+        if let Some(command) = self.take_command_unchecked(key) {
+            return Some(command);
+        }
+        let command = self.hidden_commands.remove(key)?;
+        self.bump_cmd_epoch();
+        self.hidden_imported_commands.remove(key);
+        self.hidden_builtin_identities.remove(key);
+        self.cmd_traces.remove(key);
+        self.exec_traces.remove(key);
+        self.drop_alias_backref(key);
+        Some(command)
+    }
+
     /// Remove a command by its already-resolved table key.
     fn take_command_unchecked_key(&mut self, key: &str) -> Option<Command> {
         self.bump_cmd_epoch();

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -3752,6 +3752,11 @@ impl Vm {
                 source.clone_from(new_key);
             }
         }
+        for source in self.hidden_imported_commands.values_mut() {
+            if source == old_key {
+                source.clone_from(new_key);
+            }
+        }
     }
 
     /// Restore a renamed imported command's own origin record.
@@ -3800,9 +3805,13 @@ impl Vm {
             }
             self.imported_commands
                 .iter()
-                .filter(|(key, origin)| {
+                .filter(|(key, _)| {
                     split_key(key).0 == cur && {
-                        let (o_ns, o_tail) = split_key(origin.name());
+                        // C's TclGetOriginalCommand follows an import chain;
+                        // qualified forget matches that ultimate source, not
+                        // merely the immediately imported alias.
+                        let origin = self.command_origin_key(key);
+                        let (o_ns, o_tail) = split_key(&origin);
                         o_ns == src_ns && tcl_syntax::glob::string_match(simple, o_tail)
                     }
                 })

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -592,7 +592,7 @@ pub struct InterpState {
     /// `leavestep`-bearing trace of each traced proc whose body is running.
     /// Every command dispatched while non-empty fires these (C's step
     /// semantics); the traced proc's frame pops its own pushes on completion.
-    pub(crate) exec_step_scopes: Vec<Rc<CmdTraceEntry>>,
+    pub(crate) exec_step_scopes: Vec<crate::exec::ExecStepScope>,
     /// Bumped on every `trace add|remove execution … enterstep|leavestep …`
     /// (and command rename, which moves such a trace's registration) — the
     /// analogue of C's `compileEpoch` bump on `DONT_COMPILE_CMDS_INLINE`

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -4626,7 +4626,7 @@ impl Vm {
     /// under its own key, so later calls while the same trace-deopt epoch
     /// holds reuse the compiled body instead of recompiling on every call.
     pub(crate) fn ensure_proc_ready(&mut self, proc: Rc<ProcDef>) -> Rc<ProcDef> {
-        self.ensure_proc_ready_in(proc, None)
+        self.ensure_proc_ready_in(proc, None, None)
     }
 
     /// Refresh a stored procedure and memoise it in the command domain from
@@ -4637,6 +4637,7 @@ impl Vm {
         &mut self,
         proc: Rc<ProcDef>,
         sidecar: Option<&CommandSidecarKey>,
+        sidecar_handle: Option<&CommandSidecarHandle>,
     ) -> Rc<ProcDef> {
         if proc.compiled_epoch == self.trace_deopt_epoch()
             && proc.compiled_profile_generation == self.profile_generation
@@ -4644,7 +4645,15 @@ impl Vm {
             return proc;
         }
         let fresh = self.ensure_proc_traced(proc);
-        match sidecar {
+        // A traced invocation's handle follows the command through hide/expose
+        // and becomes detached when a callback deletes it.  Never fall back to
+        // the pre-callback key in that case: doing so would resurrect the stale
+        // proc or overwrite a replacement installed by the callback.
+        let memo_sidecar = match sidecar_handle {
+            Some(handle) => handle.key(),
+            None => sidecar.cloned(),
+        };
+        match memo_sidecar.as_ref() {
             Some(CommandSidecarKey::Hidden(token)) => {
                 self.hidden_commands
                     .insert(token.clone(), Command::Proc(Rc::clone(&fresh)));
@@ -6411,6 +6420,23 @@ mod family_b_tests {
         vm.set_dialect_profile(DialectProfile::by_name("tcl8.6"));
     }
 
+    fn prepare_trace_deleted_hidden_proc(vm: &mut Vm) {
+        vm.set_compiler(Box::new(TestCompiler));
+        vm.set_dialect_profile(DialectProfile::by_name("tcl8.5"));
+        assert_eq!(eval_value(vm, "proc p {} { return hidden }"), "");
+        assert_eq!(
+            eval_value(
+                vm,
+                "proc replace args { rename p {}; interp expose {} held p; rename p {}; proc p {} { return replacement } }"
+            ),
+            ""
+        );
+        assert_eq!(eval_value(vm, "trace add execution p enter replace"), "");
+        vm.hide_command("p", "held").unwrap();
+        assert_eq!(eval_value(vm, "proc p {} { return initial }"), "");
+        vm.set_dialect_profile(DialectProfile::by_name("tcl8.6"));
+    }
+
     #[test]
     fn refreshed_hidden_proc_stays_hidden_and_preserves_visible_replacement() {
         let mut vm = Vm::new();
@@ -6453,6 +6479,74 @@ mod family_b_tests {
             Some(Command::Proc(proc))
                 if proc.compiled_profile_generation == state.profile_generation
         ));
+    }
+
+    #[test]
+    fn trace_deleted_hidden_refresh_never_resurrects_or_overwrites_replacement() {
+        let mut vm = Vm::new();
+        prepare_trace_deleted_hidden_proc(&mut vm);
+        let root = vm.invoke_hidden_in_child("", "held", &[]).unwrap();
+        assert_eq!(root.code, Code::Error);
+        assert_eq!(
+            root.result.to_str().as_ref(),
+            "attempt to invoke a deleted command"
+        );
+        assert_eq!(eval_value(&mut vm, "p"), "replacement");
+        assert!(!vm.hidden_commands.contains_key("held"));
+
+        for by_id in [false, true] {
+            let child_name = vm.create_child(None, false);
+            let child = vm.child_id(&child_name).unwrap();
+            vm.in_interp(child, prepare_trace_deleted_hidden_proc);
+            let result = if by_id {
+                vm.invoke_hidden_by_id(child, "held", &[]).unwrap()
+            } else {
+                vm.invoke_hidden_in_child(&child_name, "held", &[]).unwrap()
+            };
+            assert_eq!(result.code, Code::Error);
+            assert_eq!(
+                result.result.to_str().as_ref(),
+                "attempt to invoke a deleted command"
+            );
+            assert_eq!(
+                vm.in_interp(child, |child| eval_value(child, "p")),
+                "replacement"
+            );
+            assert!(
+                !vm.st_of(child)
+                    .unwrap()
+                    .hidden_commands
+                    .contains_key("held")
+            );
+        }
+    }
+
+    #[test]
+    fn relocated_hidden_refresh_persists_at_the_live_visible_key() {
+        let mut vm = Vm::new();
+        vm.set_compiler(Box::new(TestCompiler));
+        vm.set_dialect_profile(DialectProfile::by_name("tcl8.5"));
+        assert_eq!(eval_value(&mut vm, "proc p {} { return hidden }"), "");
+        assert_eq!(
+            eval_value(
+                &mut vm,
+                "proc expose args { rename p {}; interp expose {} held p; trace remove execution p enter expose }"
+            ),
+            ""
+        );
+        assert_eq!(
+            eval_value(&mut vm, "trace add execution p enter expose"),
+            ""
+        );
+        vm.hide_command("p", "held").unwrap();
+        assert_eq!(eval_value(&mut vm, "proc p {} { return replacement }"), "");
+        vm.set_dialect_profile(DialectProfile::by_name("tcl8.6"));
+
+        let result = vm.invoke_hidden_in_child("", "held", &[]).unwrap();
+        assert_eq!(result.code, Code::Ok);
+        assert_eq!(result.result.to_str().as_ref(), "hidden");
+        assert!(!vm.hidden_commands.contains_key("held"));
+        assert_eq!(eval_value(&mut vm, "p"), "hidden");
     }
 
     struct TestNative;

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -396,6 +396,28 @@ pub struct Vm {
     alias_backrefs: Vec<AliasBackref>,
 }
 
+/// Metadata and any release-hidden destination displaced while a command is
+/// temporarily installed under a new name.  A rename can still be refused
+/// after installation when it would make an alias loop, so this keeps the
+/// command-table mutation reversible as one semantic operation.
+pub(crate) struct CommandRenameTransaction {
+    old_key: String,
+    new_key: String,
+    source_import_origin: Option<String>,
+    source_builtin_identity: Option<String>,
+    displaced_command: Option<Command>,
+    displaced_import_origin: Option<String>,
+    displaced_builtin_identity: Option<String>,
+    retargeted_imports: Vec<(String, String)>,
+    cross_alias_target: Option<InterpId>,
+}
+
+impl CommandRenameTransaction {
+    pub(crate) fn old_key(&self) -> &str {
+        &self.old_key
+    }
+}
+
 impl std::ops::Deref for Vm {
     type Target = InterpState;
 
@@ -1751,6 +1773,102 @@ impl Vm {
             return None;
         }
         self.take_command_unchecked_key(&key)
+    }
+
+    /// Remove a command as the first half of a potentially-reversible rename.
+    /// The transaction owns every metadata map a later alias-loop rejection
+    /// must restore, rather than making callers repair selected maps by hand.
+    pub(crate) fn take_command_for_rename(
+        &mut self,
+        name: &str,
+    ) -> Option<(Command, CommandRenameTransaction)> {
+        let old_key = self.resolve_command_fqn(self.current_ns(), name)?;
+        if self
+            .commands
+            .get(&old_key)
+            .is_some_and(|command| !self.builtin_command_visible_for_surface(&old_key, command))
+        {
+            return None;
+        }
+        let source_import_origin = self.imported_commands.get(&old_key).cloned();
+        let source_builtin_identity = self.builtin_identity_for_key(&old_key);
+        let command = self.take_command_unchecked_key(&old_key)?;
+        Some((
+            command,
+            CommandRenameTransaction {
+                old_key,
+                new_key: String::new(),
+                source_import_origin,
+                source_builtin_identity,
+                displaced_command: None,
+                displaced_import_origin: None,
+                displaced_builtin_identity: None,
+                retargeted_imports: Vec::new(),
+                cross_alias_target: None,
+            },
+        ))
+    }
+
+    /// Install the new half of a rename and record every changed semantic map.
+    pub(crate) fn install_renamed_command(
+        &mut self,
+        transaction: &mut CommandRenameTransaction,
+        new_key: &str,
+        command: Command,
+    ) {
+        new_key.clone_into(&mut transaction.new_key);
+        transaction.displaced_command = self.commands.get(new_key).cloned();
+        transaction.displaced_import_origin = self.imported_commands.get(new_key).cloned();
+        transaction.displaced_builtin_identity = self.builtin_identity_for_key(new_key);
+        transaction.cross_alias_target = match &command {
+            Command::CrossAlias { target, .. } => Some(*target),
+            _ => None,
+        };
+        self.register_command(new_key, command);
+        if let Some(origin) = &transaction.source_import_origin {
+            self.restore_import_origin(new_key, origin.clone());
+        }
+        if let Some(identity) = &transaction.source_builtin_identity {
+            self.restore_builtin_identity(new_key, identity.clone());
+        }
+        transaction.retargeted_imports = self.retarget_imports(&transaction.old_key, new_key);
+    }
+
+    /// Commit a rename after all semantic validation has succeeded.
+    pub(crate) fn commit_renamed_command(&mut self, transaction: &CommandRenameTransaction) {
+        if let Some(target) = transaction.cross_alias_target {
+            self.retarget_alias_backref(&transaction.old_key, &transaction.new_key, target);
+        }
+    }
+
+    /// Undo a rejected rename, including import provenance and version-surface
+    /// identity for both the source and an otherwise-hidden destination.
+    pub(crate) fn rollback_renamed_command(&mut self, transaction: CommandRenameTransaction) {
+        let restored = self
+            .remove_command_exact(&transaction.new_key)
+            .expect("the renamed command was just registered");
+        self.register_command(&transaction.old_key, restored);
+        if let Some(origin) = transaction.source_import_origin {
+            self.restore_import_origin(&transaction.old_key, origin);
+        }
+        if let Some(identity) = transaction.source_builtin_identity {
+            self.restore_builtin_identity(&transaction.old_key, identity);
+        }
+        self.restore_retargeted_imports(transaction.retargeted_imports);
+        if let Some(command) = transaction.displaced_command {
+            self.register_command(&transaction.new_key, command);
+            if let Some(origin) = transaction.displaced_import_origin {
+                self.restore_import_origin(&transaction.new_key, origin);
+            }
+            if let Some(identity) = transaction.displaced_builtin_identity {
+                self.restore_builtin_identity(&transaction.new_key, identity);
+            }
+        }
+        if let Some(target) = transaction.cross_alias_target {
+            // `register_command` clears the stale old-key record as it restores
+            // the alias, so re-establish the target-death back-reference here.
+            self.note_alias_backref(&transaction.old_key, target);
+        }
     }
 
     /// Resolve and remove a command without consulting the emulated command
@@ -3465,23 +3583,30 @@ impl Vm {
     /// visibility, and `namespace origin` continue to identify the final
     /// builtin under its new name.  A deletion deliberately does not take this
     /// path: C leaves the imported command dangling in that case.
-    pub(crate) fn retarget_imports(&mut self, old_key: &str, new_key: &str) {
+    pub(crate) fn retarget_imports(
+        &mut self,
+        old_key: &str,
+        new_key: &str,
+    ) -> Vec<(String, String)> {
         let new_key = new_key.to_owned();
-        for source in self.imported_commands.values_mut() {
+        let mut retargeted = Vec::new();
+        for (import, source) in &mut self.imported_commands {
             if source == old_key {
+                retargeted.push((import.clone(), source.clone()));
                 source.clone_from(&new_key);
             }
         }
+        retargeted
     }
 
-    /// Import provenance carried by `key`, if it is an imported command.
-    pub(crate) fn import_origin(&self, key: &str) -> Option<String> {
-        self.imported_commands.get(key).cloned()
-    }
-
-    /// Stable registry identity for a visible builtin at `key`.
-    pub(crate) fn builtin_identity(&self, key: &str) -> Option<String> {
-        self.builtin_identity_for_key(key)
+    /// Restore exactly the provenance entries a failed rename retargeted.
+    /// Entries removed by the rollback itself are deliberately skipped.
+    fn restore_retargeted_imports(&mut self, retargeted: Vec<(String, String)>) {
+        for (import, source) in retargeted {
+            if let Some(current) = self.imported_commands.get_mut(&import) {
+                current.clone_from(&source);
+            }
+        }
     }
 
     /// Restore a renamed imported command's own origin record.

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -1887,20 +1887,19 @@ impl Vm {
     }
 
     /// Retire a VM-owned command whether its lifecycle key is currently
-    /// visible or hidden.  Coroutine completion is not a user `rename`/delete
-    /// operation, so hidden retirement deliberately does not fire a command
-    /// delete callback, but it must clear every hidden-table sidecar.
+    /// visible or hidden. Completion is a real command deletion, so delete
+    /// traces fire exactly once before all trace/deopt sidecars are dropped.
     pub(crate) fn retire_command_lifecycle(&mut self, key: &str) -> Option<Command> {
         if let Some(command) = self.take_command_unchecked(key) {
+            self.on_command_removed(key);
             return Some(command);
         }
         let command = self.hidden_commands.remove(key)?;
         self.bump_cmd_epoch();
         self.hidden_imported_commands.remove(key);
         self.hidden_builtin_identities.remove(key);
-        self.cmd_traces.remove(key);
-        self.exec_traces.remove(key);
         self.drop_alias_backref(key);
+        self.on_command_removed(key);
         Some(command)
     }
 

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -2563,14 +2563,21 @@ impl Vm {
     /// `interp hide {} cmd` — move one visible command plus all of its
     /// metadata into the hidden table.  This is the only public hide seam;
     /// every caller therefore observes the same release-visibility check.
-    pub(crate) fn hide_command(&mut self, cmd: &str, token: &str) -> bool {
+    pub(crate) fn hide_command(&mut self, cmd: &str, token: &str) -> Result<(), String> {
+        if self.hidden_commands.contains_key(token) {
+            return Err(format!("hidden command named \"{token}\" already exists"));
+        }
         let Some(source) = self.resolve_command_fqn(self.current_ns(), cmd) else {
-            return false;
+            return Ok(());
         };
         let import_origin = self.imported_commands.get(&source).cloned();
         let builtin_identity = self.builtin_identity_for_key(&source);
         let Some(command) = self.take_command(cmd) else {
-            return false;
+            return Ok(());
+        };
+        let cross_target = match &command {
+            Command::CrossAlias { target, .. } => Some(*target),
+            _ => None,
         };
         self.hidden_commands.insert(token.to_owned(), command);
         if let Some(origin) = import_origin {
@@ -2584,15 +2591,24 @@ impl Vm {
         // A hidden token is the command's temporary name.  Imports that
         // pointed at this source follow it until expose gives it a new key.
         self.retarget_imports(&source, token);
-        true
+        if let Some(target) = cross_target {
+            self.retarget_alias_backref(&source, token, target);
+        }
+        Ok(())
     }
 
     /// `interp expose {} hidden ?token?` — restore one of *this* interp's
     /// hidden commands, optionally under a new name (`token`).
-    pub(crate) fn expose_own_command(&mut self, cmd: &str, token: &str) {
+    pub(crate) fn expose_own_command(&mut self, cmd: &str, token: &str) -> Result<(), String> {
+        if self.lookup_command(token).is_some() {
+            return Err(format!("exposed command \"{token}\" already exists"));
+        }
         if let Some(c) = self.hidden_commands.remove(cmd) {
-            self.bump_cmd_epoch();
-            self.commands.insert(token.to_string(), c);
+            let cross_target = match &c {
+                Command::CrossAlias { target, .. } => Some(*target),
+                _ => None,
+            };
+            self.register_command(token, c);
             if let Some(origin) = self.hidden_imported_commands.remove(cmd) {
                 self.imported_commands.insert(token.to_owned(), origin);
             }
@@ -2603,7 +2619,11 @@ impl Vm {
             // the hidden table. Imported commands retain the source token in
             // C Tcl, so their provenance follows the newly exposed name too.
             self.retarget_imports(cmd, token);
+            if let Some(target) = cross_target {
+                self.retarget_alias_backref(cmd, token, target);
+            }
         }
+        Ok(())
     }
 
     /// Sorted hidden-command names of *this* interp (`interp hidden {}`).
@@ -2616,20 +2636,26 @@ impl Vm {
     /// `interp hide|expose path cmd ?token?` on a child. When hiding, the
     /// command `cmd` is filed under `token`; when exposing, the hidden `cmd` is
     /// restored as the command `token`.
-    pub(crate) fn child_hide(&mut self, name: &str, cmd: &str, token: &str, hide: bool) -> bool {
+    pub(crate) fn child_hide(
+        &mut self,
+        name: &str,
+        cmd: &str,
+        token: &str,
+        hide: bool,
+    ) -> Result<bool, String> {
         let Some(id) = self.child_id(name) else {
-            return false;
+            return Ok(false);
         };
         // Enter the child so public hide uses the same visibility-aware
         // removal seam as `rename` and same-interpreter `interp hide`.
         self.in_interp(id, |vm| {
             if hide {
-                vm.hide_command(cmd, token);
+                vm.hide_command(cmd, token)
             } else {
-                vm.expose_own_command(cmd, token);
+                vm.expose_own_command(cmd, token)
             }
-        });
-        true
+        })?;
+        Ok(true)
     }
 
     /// Make this interp safe (`interp create -safe`): hide the commands that
@@ -3067,9 +3093,9 @@ impl Vm {
         // This is the `$child hide` spelling of the same public operation.
         self.in_interp(id, |vm| {
             if hide {
-                vm.hide_command(cmd, token);
+                let _ = vm.hide_command(cmd, token);
             } else {
-                vm.expose_own_command(cmd, token);
+                let _ = vm.expose_own_command(cmd, token);
             }
         });
         true

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -412,10 +412,13 @@ pub(crate) enum CommandSidecarKey {
 /// updates coroutine parking/retirement and execution-trace leave delivery as
 /// one operation.
 #[derive(Clone, Debug)]
-pub(crate) struct CommandSidecarHandle(Rc<RefCell<CommandSidecarKey>>);
+pub(crate) struct CommandSidecarHandle(Rc<RefCell<Option<CommandSidecarKey>>>);
 
 impl CommandSidecarHandle {
-    pub(crate) fn key(&self) -> CommandSidecarKey {
+    /// The binding this operation still belongs to.  A deletion detaches an
+    /// in-flight handle before Tcl can create another binding at the same
+    /// spelling, so it can never be retargeted to that later lifecycle.
+    pub(crate) fn key(&self) -> Option<CommandSidecarKey> {
         self.0.borrow().clone()
     }
 }
@@ -576,7 +579,7 @@ pub struct InterpState {
     pub(crate) exec_traces: HashMap<CommandSidecarKey, Vec<Rc<CmdTraceEntry>>>,
     /// Weak registry of in-flight sidecar identities. Relocation updates live
     /// handles without retaining completed invocations.
-    active_sidecar_handles: Vec<Weak<RefCell<CommandSidecarKey>>>,
+    active_sidecar_handles: Vec<Weak<RefCell<Option<CommandSidecarKey>>>>,
     /// Step-trace scopes currently active: one entry per `enterstep`/
     /// `leavestep`-bearing trace of each traced proc whose body is running.
     /// Every command dispatched while non-empty fires these (C's step
@@ -1864,11 +1867,14 @@ impl Vm {
         // Overwriting an existing command deletes it (C `Tcl_CreateObjCommand`
         // does the same), so its `delete` command traces fire and every trace
         // on it is dropped — tclsh-pinned: redefining a traced proc fires the
-        // delete trace.  (Gated on the trace table so the startup builtin
-        // sweep pays nothing.)
-        if !(self.cmd_traces.is_empty() && self.exec_traces.is_empty())
-            && self.commands.contains_key(name)
-        {
+        // delete trace.  This also detaches any in-flight sidecar handle, so
+        // overwriting a binding cannot let it follow the replacement.
+        if self.commands.contains_key(name) {
+            let was_coroutine = crate::cmd_coro::is_coroutine(self, name);
+            self.detach_active_sidecars(&CommandSidecarKey::visible(name));
+            if was_coroutine {
+                crate::cmd_coro::on_command_deleted(self, name);
+            }
             self.on_command_removed(name);
         }
         // Overwriting a cross-interp alias drops its target-death backref (the
@@ -1894,6 +1900,11 @@ impl Vm {
     /// [`Self::registered_command_names`] needs.
     pub(crate) fn remove_registered_command(&mut self, name: &str) {
         if self.commands.remove(name).is_some() {
+            let was_coroutine = crate::cmd_coro::is_coroutine(self, name);
+            self.detach_active_sidecars(&CommandSidecarKey::visible(name));
+            if was_coroutine {
+                crate::cmd_coro::on_command_deleted(self, name);
+            }
             self.bump_cmd_epoch();
             self.imported_commands.remove(name);
             self.builtin_identities.remove(name);
@@ -1985,6 +1996,7 @@ impl Vm {
     ) {
         self.take_command_unchecked_key(&transaction.old_key)
             .expect("the prepared delete source remains registered");
+        self.detach_active_sidecars(&CommandSidecarKey::visible(&transaction.old_key));
     }
 
     /// Commit a rename after all semantic validation has succeeded.
@@ -2001,7 +2013,13 @@ impl Vm {
     /// a command to Tcl code.  User-facing removal must use [`Self::take_command`].
     pub(crate) fn take_command_unchecked(&mut self, name: &str) -> Option<Command> {
         let key = self.resolve_command_fqn_raw(self.current_ns(), name)?;
-        self.take_command_unchecked_key(&key)
+        let command = self.take_command_unchecked_key(&key)?;
+        let was_coroutine = crate::cmd_coro::is_coroutine(self, &key);
+        self.detach_active_sidecars(&CommandSidecarKey::visible(&key));
+        if was_coroutine {
+            crate::cmd_coro::on_command_deleted(self, &key);
+        }
+        Some(command)
     }
 
     /// Retire a VM-owned command whether its lifecycle key is currently
@@ -2037,10 +2055,13 @@ impl Vm {
     /// Remove a command by its exact table key (no name resolution) — the
     /// rollback path for a refused alias creation.
     pub(crate) fn remove_command_exact(&mut self, key: &str) -> Option<Command> {
-        self.bump_cmd_epoch();
-        self.imported_commands.remove(key);
-        self.builtin_identities.remove(key);
-        self.commands.remove(key)
+        let command = self.take_command_unchecked_key(key)?;
+        let was_coroutine = crate::cmd_coro::is_coroutine(self, key);
+        self.detach_active_sidecars(&CommandSidecarKey::visible(key));
+        if was_coroutine {
+            crate::cmd_coro::on_command_deleted(self, key);
+        }
+        Some(command)
     }
 
     /// `interp alias srcPath srcCmd targetPath target…` — route the alias by
@@ -2760,7 +2781,12 @@ impl Vm {
     /// `interp expose {} hidden ?token?` — restore one of *this* interp's
     /// hidden commands, optionally under a new name (`token`).
     pub(crate) fn expose_own_command(&mut self, cmd: &str, token: &str) -> Result<(), String> {
-        if self.lookup_command(token).is_some() {
+        // `interp expose` always installs the destination in the global
+        // namespace.  A contextual lookup here would incorrectly see (and
+        // reject because of) a same-spelled local command in the caller's
+        // namespace, instead of checking the exact global table owner.
+        let destination = canonical_cmd_key(token);
+        if self.visible_command_exists_exact(&destination) {
             return Err(format!("exposed command \"{token}\" already exists"));
         }
         if let Some(c) = self.hidden_commands.remove(cmd) {
@@ -2768,28 +2794,30 @@ impl Vm {
                 Command::CrossAlias { target, .. } => Some(*target),
                 _ => None,
             };
-            self.register_command(token, c);
-            crate::cmd_coro::on_command_exposed(self, cmd, token);
+            self.register_command(&destination, c);
+            crate::cmd_coro::on_command_exposed(self, cmd, destination.as_ref());
             self.move_command_traces(
                 &CommandSidecarKey::hidden(cmd),
-                CommandSidecarKey::visible(token),
+                CommandSidecarKey::visible(destination.as_ref()),
             );
             if let Some(origin) = self.hidden_imported_commands.remove(cmd) {
-                self.imported_commands.insert(token.to_owned(), origin);
+                self.imported_commands
+                    .insert(destination.to_string(), origin);
             }
             if let Some(identity) = self.hidden_builtin_identities.remove(cmd) {
-                self.builtin_identities.insert(token.to_owned(), identity);
+                self.builtin_identities
+                    .insert(destination.to_string(), identity);
             }
             // Reconnect internal references to the visible domain; their
             // Tcl-visible ultimate source lineage remains unchanged.
             self.retarget_imports_key(
                 &CommandSidecarKey::hidden(cmd),
-                &CommandSidecarKey::visible(token),
+                &CommandSidecarKey::visible(destination.as_ref()),
             );
             if let Some(target) = cross_target {
                 self.retarget_alias_backref_key(
                     &CommandSidecarKey::hidden(cmd),
-                    CommandSidecarKey::visible(token),
+                    CommandSidecarKey::visible(destination.as_ref()),
                     target,
                 );
             }
@@ -3295,6 +3323,15 @@ impl Vm {
             return None;
         }
         Some(command)
+    }
+
+    /// Whether the exact visible command-table owner exists on the active
+    /// release surface.  Unlike [`Self::lookup_command`], this never applies
+    /// current-namespace or namespace-path resolution.
+    fn visible_command_exists_exact(&self, key: &str) -> bool {
+        self.commands
+            .get(key)
+            .is_some_and(|command| self.builtin_command_visible_for_surface(key, command))
     }
 
     /// Get the current namespace's command resolution path (`namespace path`)
@@ -3867,7 +3904,9 @@ impl Vm {
         for key in victims {
             self.imported_commands.remove(&key);
             self.builtin_identities.remove(&key);
-            self.commands.remove(&key);
+            if self.commands.remove(&key).is_some() {
+                self.detach_active_sidecars(&CommandSidecarKey::visible(key));
+            }
         }
         Ok(())
     }
@@ -3889,8 +3928,21 @@ impl Vm {
         // Commands and namespace variables are keyed by their fully-qualified
         // (unrooted) name, so a member of the namespace or a descendant begins
         // with `canonical::`.
+        let removed_commands: Vec<String> = self
+            .commands
+            .keys()
+            .filter(|key| key.starts_with(&prefix))
+            .cloned()
+            .collect();
         self.bump_cmd_epoch();
         self.commands.retain(|k, _| !k.starts_with(&prefix));
+        for key in removed_commands {
+            let was_coroutine = crate::cmd_coro::is_coroutine(self, &key);
+            self.detach_active_sidecars(&CommandSidecarKey::visible(&key));
+            if was_coroutine {
+                crate::cmd_coro::on_command_deleted(self, &key);
+            }
+        }
         self.imported_commands
             .retain(|k, _| !k.starts_with(&prefix));
         self.builtin_identities
@@ -4212,6 +4264,11 @@ impl Vm {
     }
 
     fn on_command_removed_for(&mut self, key: &CommandSidecarKey) {
+        // A key is a location, not an eternal command identity.  Do this
+        // before delete callbacks: they may create, hide, expose, or rename a
+        // replacement binding with the same key while this operation is still
+        // in flight.  That replacement must not inherit the old handle.
+        self.detach_active_sidecars(key);
         let mut removed_trace = false;
         if !self.cmd_traces.is_empty() {
             self.fire_command_traces_for(key, "", "delete");
@@ -4281,7 +4338,7 @@ impl Vm {
     pub(crate) fn active_sidecar(&mut self, key: CommandSidecarKey) -> CommandSidecarHandle {
         self.active_sidecar_handles
             .retain(|handle| handle.strong_count() != 0);
-        let cell = Rc::new(RefCell::new(key));
+        let cell = Rc::new(RefCell::new(Some(key)));
         self.active_sidecar_handles.push(Rc::downgrade(&cell));
         CommandSidecarHandle(cell)
     }
@@ -4295,8 +4352,23 @@ impl Vm {
             let Some(handle) = weak.upgrade() else {
                 return false;
             };
-            if *handle.borrow() == *old_key {
-                *handle.borrow_mut() = new_key.clone();
+            if handle.borrow().as_ref() == Some(old_key) {
+                *handle.borrow_mut() = Some(new_key.clone());
+            }
+            true
+        });
+    }
+
+    /// Disconnect all active users of a deleted command binding.  Retaining
+    /// the weak cells is harmless; they are pruned when the in-flight calls
+    /// complete, while their `None` identity prevents later relocation.
+    pub(crate) fn detach_active_sidecars(&mut self, key: &CommandSidecarKey) {
+        self.active_sidecar_handles.retain(|weak| {
+            let Some(handle) = weak.upgrade() else {
+                return false;
+            };
+            if handle.borrow().as_ref() == Some(key) {
+                *handle.borrow_mut() = None;
             }
             true
         });

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -1218,6 +1218,31 @@ impl Vm {
                 });
             }
         }
+        // Hidden aliases are not dispatchable, so a stale/missing backref must
+        // not keep one alive after its target dies.  Sweep the hidden tables as
+        // a defensive counterpart to C's target-side alias list.
+        let hidden_targeting: Vec<(InterpId, String)> = self
+            .interps
+            .iter()
+            .enumerate()
+            .filter_map(|(index, slot)| slot.parked.as_ref().map(|st| (InterpId(index), st)))
+            .flat_map(|(source, st)| {
+                st.hidden_commands.iter().filter_map(move |(key, command)| {
+                    matches!(command, Command::CrossAlias { target, .. } if *target == id)
+                        .then(|| (source, key.clone()))
+                })
+            })
+            .collect();
+        for (source, key) in hidden_targeting {
+            self.in_interp(source, |vm| {
+                vm.hidden_commands.remove(&key);
+                vm.hidden_imported_commands.remove(&key);
+                vm.hidden_builtin_identities.remove(&key);
+                vm.cmd_traces.remove(&key);
+                vm.exec_traces.remove(&key);
+                vm.drop_alias_backref(&key);
+            });
+        }
         self.alias_backrefs.retain(|b| b.target != id);
         let slot = &mut self.interps[id.0];
         slot.dying = true;

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -4620,15 +4620,6 @@ impl Vm {
         Rc::new(fresh)
     }
 
-    /// [`Self::ensure_proc_traced`], memoised: a proc looked up from the
-    /// `commands` table (an ordinary named call, as opposed to an ephemeral
-    /// `apply`/TclOO-method `ProcDef`) has its recompiled body reinstalled
-    /// under its own key, so later calls while the same trace-deopt epoch
-    /// holds reuse the compiled body instead of recompiling on every call.
-    pub(crate) fn ensure_proc_ready(&mut self, proc: Rc<ProcDef>) -> Rc<ProcDef> {
-        self.ensure_proc_ready_in(proc, None, None)
-    }
-
     /// Refresh a stored procedure and memoise it in the command domain from
     /// which this invocation was resolved. Hidden and visible commands may
     /// share the same spelling, so publishing by `ProcDef::name` would leak a
@@ -6547,6 +6538,32 @@ mod family_b_tests {
         assert_eq!(result.result.to_str().as_ref(), "hidden");
         assert!(!vm.hidden_commands.contains_key("held"));
         assert_eq!(eval_value(&mut vm, "p"), "hidden");
+    }
+
+    #[test]
+    fn imported_proc_profile_refresh_updates_the_resolved_import_not_its_source_name() {
+        let mut vm = Vm::new();
+        vm.set_compiler(Box::new(TestCompiler));
+        vm.set_dialect_profile(DialectProfile::by_name("tcl8.5"));
+        assert_eq!(
+            eval_value(
+                &mut vm,
+                "namespace eval src {proc p {} {return original}; namespace export p}; \\
+                 namespace eval dst {namespace import ::src::p}; \\
+                 rename ::src::p ::src::q; proc ::src::p {} {return replacement}",
+            ),
+            ""
+        );
+
+        vm.set_dialect_profile(DialectProfile::by_name("tcl8.6"));
+        assert_eq!(eval_value(&mut vm, "::dst::p"), "original");
+        assert_eq!(eval_value(&mut vm, "::src::p"), "replacement");
+        assert_eq!(eval_value(&mut vm, "::src::q"), "original");
+        assert!(matches!(
+            vm.commands.get("dst::p"),
+            Some(Command::Proc(proc))
+                if proc.compiled_profile_generation == vm.profile_generation
+        ));
     }
 
     struct TestNative;

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -505,6 +505,11 @@ pub struct InterpState {
     /// this is consulted on every command resolution). `None` for the
     /// permissive fallback profile, which gates nothing.
     profile_registry: Option<&'static tcl_registry::CommandRegistry>,
+    /// Monotonic invalidation generation for bytecode that depends on the
+    /// selected profile's grammar or command surface. It is deliberately
+    /// independent of `cmd_epoch`: command resolution can be recomputed from
+    /// names, whereas specialised bytecode must be recompiled from source.
+    profile_generation: u64,
     /// Call-frame stack; `frames[0]` is the global scope.
     frames: Vec<CallFrame>,
     /// Command table (builtins + user procs), keyed by canonical name — a
@@ -664,7 +669,7 @@ pub struct InterpState {
     pending_exit: Option<i32>,
     /// Cache of compiled scripts for the runtime-`eval` / command-substitution
     /// path (`eval_source`), keyed by source text. Compilation is a pure
-    /// function of the source and the (fixed) command registry, so a script
+    /// function of the source and the currently selected profile, so a script
     /// re-evaluated every loop iteration — a `switch`/`if`/`while` body, a
     /// `[subst]`ed command, a tcltest `-body` — compiles once instead of each
     /// time. This is the dominant cost in the tcltest workload.
@@ -679,7 +684,8 @@ pub struct InterpState {
     /// each call site — makes every one of them trace-visible with one change
     /// (issue #946 fault 3). Kept as a wholly separate map (not a mode-keyed
     /// entry in `eval_cache`) so the two compiled forms of the same source
-    /// never collide or get served to the wrong mode.
+    /// never collide or get served to the wrong mode. Both maps are cleared
+    /// when the profile changes.
     eval_cache_traced: HashMap<String, Rc<ModuleAsm>>,
     /// The accumulating `errorInfo` source trace (C's `iPtr->errorInfo`): the
     /// error message followed by `while executing` / `invoked from within`
@@ -1003,6 +1009,17 @@ impl Vm {
         // gate change resolution outcomes, so the command-resolution memo
         // (M16.4) must not survive a version flip.
         self.bump_cmd_epoch();
+        if !std::ptr::eq(self.dialect_profile, profile) {
+            self.profile_generation = self.profile_generation.wrapping_add(1);
+            // Dynamic modules and their precompiled-proc sidecars may contain
+            // profile-sensitive lowerings. ProcDef retains source and is
+            // rebuilt lazily; these cache-only forms do not, so discard them.
+            // Active frames carry this generation and fail closed at the
+            // trampoline seam if a native callback changes profile mid-run.
+            self.eval_cache.clear();
+            self.eval_cache_traced.clear();
+            self.module_procs.clear();
+        }
         self.dialect_profile = profile;
         self.profile_registry =
             (!profile.is_fallback()).then(|| tcl_registry::registry_for_profile(profile));
@@ -1030,6 +1047,12 @@ impl Vm {
     #[must_use]
     pub fn dialect_profile(&self) -> &'static tcl_dialect::DialectProfile {
         self.dialect_profile
+    }
+
+    /// Generation of the dialect profile used to compile dynamic bytecode.
+    #[must_use]
+    pub(crate) fn profile_generation(&self) -> u64 {
+        self.profile_generation
     }
 
     /// The backslash-escape grammar this VM decodes under — the pinned
@@ -1133,6 +1156,7 @@ impl InterpState {
             runtime_version: tcl_dialect::TclVersion::V9_0,
             dialect_profile: tcl_dialect::DialectProfile::plain_tcl(),
             profile_registry: None,
+            profile_generation: 0,
             frames: vec![CallFrame::new(0, ROOT_NS, None, Vec::new())],
             commands: HashMap::new(),
             fixed_math_builtins: HashMap::new(),
@@ -2294,6 +2318,23 @@ impl Vm {
     /// The [`InterpId`] of a direct child by name, or `None`.
     pub(crate) fn child_id(&self, name: &str) -> Option<InterpId> {
         self.children.get(name).copied()
+    }
+
+    /// Select the dialect profile of a direct child interpreter. This is the
+    /// host-side counterpart to configuring a standalone [`Vm`]: child state
+    /// is parked in the interpreter arena, so route through `in_interp` rather
+    /// than mutating a copied state and thereby skipping its bytecode-cache
+    /// invalidation owner.
+    pub fn set_child_dialect_profile(
+        &mut self,
+        name: &str,
+        profile: &'static tcl_dialect::DialectProfile,
+    ) -> bool {
+        let Some(id) = self.child_id(name) else {
+            return false;
+        };
+        self.in_interp(id, |child| child.set_dialect_profile(profile));
+        true
     }
 
     /// Whether a child interpreter `name` exists (and is not being torn down).
@@ -4496,7 +4537,11 @@ impl Vm {
     /// top-level compilation runs correctly as a proc body. Any procs the body
     /// itself defines are merged into the registry.
     pub(crate) fn compile_dynamic_body(&mut self, src: &str) -> Option<Rc<FunctionAsm>> {
-        let module = self.compiler.as_ref()?.compile(src).ok()?;
+        let module = self
+            .compiler
+            .as_ref()?
+            .compile_for_profile(src, self.dialect_profile)
+            .ok()?;
         self.merge_procs(&module.procedures);
         Some(Rc::new(module.top_level))
     }
@@ -4510,8 +4555,8 @@ impl Vm {
         }
     }
 
-    /// Ensure `proc`'s compiled body matches the interp's current
-    /// trace-deopt epoch, recompiling `body_src` — trace-visible
+    /// Ensure `proc`'s compiled body matches the interp's current trace-deopt
+    /// and dialect-profile generations, recompiling `body_src` — trace-visible
     /// ([`CompileService::compile_traced`]) or fast
     /// ([`CompileService::compile`]), per [`Self::step_trace_active`] —
     /// when it doesn't. This is the general recompile-on-demand mechanism
@@ -4524,7 +4569,8 @@ impl Vm {
     /// running rather than failing the call over a trace-visibility nicety).
     pub(crate) fn ensure_proc_traced(&mut self, proc: Rc<ProcDef>) -> Rc<ProcDef> {
         let want_epoch = self.trace_deopt_epoch();
-        if proc.compiled_epoch == want_epoch {
+        let want_profile = self.profile_generation;
+        if proc.compiled_epoch == want_epoch && proc.compiled_profile_generation == want_profile {
             return proc;
         }
         let Some(svc) = self.compiler.clone() else {
@@ -4532,9 +4578,9 @@ impl Vm {
         };
         let src = proc.body_src.to_str();
         let recompiled = if self.step_trace_active() {
-            svc.compile_traced(&src)
+            svc.compile_traced_for_profile(&src, self.dialect_profile)
         } else {
-            svc.compile(&src)
+            svc.compile_for_profile(&src, self.dialect_profile)
         };
         let Ok(module) = recompiled else {
             return proc;
@@ -4543,6 +4589,7 @@ impl Vm {
         let mut fresh = (*proc).clone();
         fresh.body = Rc::new(module.top_level);
         fresh.compiled_epoch = want_epoch;
+        fresh.compiled_profile_generation = want_profile;
         Rc::new(fresh)
     }
 
@@ -4552,7 +4599,9 @@ impl Vm {
     /// under its own key, so later calls while the same trace-deopt epoch
     /// holds reuse the compiled body instead of recompiling on every call.
     pub(crate) fn ensure_proc_ready(&mut self, proc: Rc<ProcDef>) -> Rc<ProcDef> {
-        if proc.compiled_epoch == self.trace_deopt_epoch() {
+        if proc.compiled_epoch == self.trace_deopt_epoch()
+            && proc.compiled_profile_generation == self.profile_generation
+        {
             return proc;
         }
         let key = proc.name.clone();
@@ -5858,9 +5907,9 @@ impl Vm {
             ));
         };
         let compiled = if traced {
-            c.compile_traced(src)
+            c.compile_traced_for_profile(src, self.dialect_profile)
         } else {
-            c.compile(src)
+            c.compile_for_profile(src, self.dialect_profile)
         };
         let m = Rc::new(compiled.map_err(|e| TclError::new(e.0))?);
         let cache = if traced {

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -405,10 +405,6 @@ pub(crate) struct CommandRenameTransaction {
     new_key: String,
     source_import_origin: Option<String>,
     source_builtin_identity: Option<String>,
-    displaced_command: Option<Command>,
-    displaced_import_origin: Option<String>,
-    displaced_builtin_identity: Option<String>,
-    retargeted_imports: Vec<(String, String)>,
     cross_alias_target: Option<InterpId>,
 }
 
@@ -1775,36 +1771,32 @@ impl Vm {
         self.take_command_unchecked_key(&key)
     }
 
-    /// Remove a command as the first half of a potentially-reversible rename.
-    /// The transaction owns every metadata map a later alias-loop rejection
-    /// must restore, rather than making callers repair selected maps by hand.
-    pub(crate) fn take_command_for_rename(
-        &mut self,
+    /// Prepare a rename without touching the command table.  Alias-loop
+    /// validation runs against the returned logical command, so a rejected
+    /// rename cannot fire callbacks or disturb traces, guards, or caches.
+    pub(crate) fn prepare_command_rename(
+        &self,
         name: &str,
     ) -> Option<(Command, CommandRenameTransaction)> {
         let old_key = self.resolve_command_fqn(self.current_ns(), name)?;
-        if self
-            .commands
-            .get(&old_key)
-            .is_some_and(|command| !self.builtin_command_visible_for_surface(&old_key, command))
-        {
+        let command = self.commands.get(&old_key)?;
+        if !self.builtin_command_visible_for_surface(&old_key, command) {
             return None;
         }
         let source_import_origin = self.imported_commands.get(&old_key).cloned();
         let source_builtin_identity = self.builtin_identity_for_key(&old_key);
-        let command = self.take_command_unchecked_key(&old_key)?;
+        let cross_alias_target = match command {
+            Command::CrossAlias { target, .. } => Some(*target),
+            _ => None,
+        };
         Some((
-            command,
+            (*command).clone(),
             CommandRenameTransaction {
                 old_key,
                 new_key: String::new(),
                 source_import_origin,
                 source_builtin_identity,
-                displaced_command: None,
-                displaced_import_origin: None,
-                displaced_builtin_identity: None,
-                retargeted_imports: Vec::new(),
-                cross_alias_target: None,
+                cross_alias_target,
             },
         ))
     }
@@ -1817,13 +1809,12 @@ impl Vm {
         command: Command,
     ) {
         new_key.clone_into(&mut transaction.new_key);
-        transaction.displaced_command = self.commands.get(new_key).cloned();
-        transaction.displaced_import_origin = self.imported_commands.get(new_key).cloned();
-        transaction.displaced_builtin_identity = self.builtin_identity_for_key(new_key);
-        transaction.cross_alias_target = match &command {
-            Command::CrossAlias { target, .. } => Some(*target),
-            _ => None,
-        };
+        // Keep the successful rename's established source-removal then
+        // destination-registration order.  The caller has already completed
+        // every rejection path, so this is now allowed to fire destination
+        // delete traces and invalidate command/trace guard state.
+        self.take_command_unchecked_key(&transaction.old_key)
+            .expect("the prepared rename source remains registered");
         self.register_command(new_key, command);
         if let Some(origin) = &transaction.source_import_origin {
             self.restore_import_origin(new_key, origin.clone());
@@ -1831,43 +1822,13 @@ impl Vm {
         if let Some(identity) = &transaction.source_builtin_identity {
             self.restore_builtin_identity(new_key, identity.clone());
         }
-        transaction.retargeted_imports = self.retarget_imports(&transaction.old_key, new_key);
+        self.retarget_imports(&transaction.old_key, new_key);
     }
 
     /// Commit a rename after all semantic validation has succeeded.
     pub(crate) fn commit_renamed_command(&mut self, transaction: &CommandRenameTransaction) {
         if let Some(target) = transaction.cross_alias_target {
             self.retarget_alias_backref(&transaction.old_key, &transaction.new_key, target);
-        }
-    }
-
-    /// Undo a rejected rename, including import provenance and version-surface
-    /// identity for both the source and an otherwise-hidden destination.
-    pub(crate) fn rollback_renamed_command(&mut self, transaction: CommandRenameTransaction) {
-        let restored = self
-            .remove_command_exact(&transaction.new_key)
-            .expect("the renamed command was just registered");
-        self.register_command(&transaction.old_key, restored);
-        if let Some(origin) = transaction.source_import_origin {
-            self.restore_import_origin(&transaction.old_key, origin);
-        }
-        if let Some(identity) = transaction.source_builtin_identity {
-            self.restore_builtin_identity(&transaction.old_key, identity);
-        }
-        self.restore_retargeted_imports(transaction.retargeted_imports);
-        if let Some(command) = transaction.displaced_command {
-            self.register_command(&transaction.new_key, command);
-            if let Some(origin) = transaction.displaced_import_origin {
-                self.restore_import_origin(&transaction.new_key, origin);
-            }
-            if let Some(identity) = transaction.displaced_builtin_identity {
-                self.restore_builtin_identity(&transaction.new_key, identity);
-            }
-        }
-        if let Some(target) = transaction.cross_alias_target {
-            // `register_command` clears the stale old-key record as it restores
-            // the alias, so re-establish the target-death back-reference here.
-            self.note_alias_backref(&transaction.old_key, target);
         }
     }
 
@@ -1890,7 +1851,7 @@ impl Vm {
     }
 
     /// Remove a command by its exact table key (no name resolution) — the
-    /// rollback path for a refused alias creation / rename.
+    /// rollback path for a refused alias creation.
     pub(crate) fn remove_command_exact(&mut self, key: &str) -> Option<Command> {
         self.bump_cmd_epoch();
         self.imported_commands.remove(key);
@@ -1963,16 +1924,18 @@ impl Vm {
     /// address the target by its stable [`InterpId`], so the walk follows the
     /// alias graph across the whole tree.  Terminates because every *existing*
     /// alias already passed this check (no pre-existing loops to spin in).
-    fn alias_chain_loops(&self, defining_interp: InterpId, defining_key: &str) -> bool {
+    fn alias_chain_loops_from(
+        &self,
+        defining_interp: InterpId,
+        defining_key: &str,
+        first: &Command,
+    ) -> bool {
+        let mut command = first;
         let mut interp = defining_interp;
-        let mut key = defining_key.to_string();
         loop {
-            let Some(st) = self.st_of(interp) else {
-                return false;
-            };
-            let (target_interp, target_words) = match st.commands.get(&key) {
-                Some(Command::Alias(w)) => (interp, Rc::clone(w)),
-                Some(Command::CrossAlias { target, words }) => (*target, Rc::clone(words)),
+            let (target_interp, target_words) = match command {
+                Command::Alias(words) => (interp, Rc::clone(words)),
+                Command::CrossAlias { target, words } => (*target, Rc::clone(words)),
                 _ => return false,
             };
             let Some(target_name) = target_words.first().map(|v| v.to_str().to_string()) else {
@@ -1981,21 +1944,47 @@ impl Vm {
             let Some(target_st) = self.st_of(target_interp) else {
                 return false;
             };
-            let Some(next) = target_st.resolve_command_fqn("", &target_name) else {
+            // The just-renamed alias is not installed yet.  Let its candidate
+            // key shadow an existing hidden builtin (or an absent name) for
+            // this logical validation only; mutating the command table first
+            // would fire irreversible delete traces on that builtin.
+            let next = if target_interp == defining_interp
+                && canonical_cmd_key(&target_name) == defining_key
+            {
+                defining_key.to_owned()
+            } else if let Some(next) = target_st.resolve_command_fqn("", &target_name) {
+                next
+            } else {
                 return false;
             };
             if target_interp == defining_interp && next == defining_key {
                 return true;
             }
+            let Some(next_st) = self.st_of(target_interp) else {
+                return false;
+            };
+            let Some(next_command) = next_st.commands.get(&next) else {
+                return false;
+            };
             interp = target_interp;
-            key = next;
+            command = next_command;
         }
     }
 
-    /// [`Self::alias_chain_loops`] for a same-interp key — the `rename` gate's
-    /// entry (a `rename` never crosses interps, so it starts in the current one).
-    pub(crate) fn alias_chain_loops_here(&self, key: &str) -> bool {
-        self.alias_chain_loops(self.cur, key)
+    fn alias_chain_loops(&self, defining_interp: InterpId, defining_key: &str) -> bool {
+        let Some(st) = self.st_of(defining_interp) else {
+            return false;
+        };
+        let Some(first) = st.commands.get(defining_key) else {
+            return false;
+        };
+        self.alias_chain_loops_from(defining_interp, defining_key, first)
+    }
+
+    /// Check whether a not-yet-installed same-interpreter alias would loop if
+    /// it were renamed to `key`.
+    pub(crate) fn alias_chain_loops_for_rename(&self, key: &str, alias: &Command) -> bool {
+        self.alias_chain_loops_from(self.cur, key, alias)
     }
 
     /// Whether this registered builtin is visible on the selected command
@@ -3583,28 +3572,11 @@ impl Vm {
     /// visibility, and `namespace origin` continue to identify the final
     /// builtin under its new name.  A deletion deliberately does not take this
     /// path: C leaves the imported command dangling in that case.
-    pub(crate) fn retarget_imports(
-        &mut self,
-        old_key: &str,
-        new_key: &str,
-    ) -> Vec<(String, String)> {
+    pub(crate) fn retarget_imports(&mut self, old_key: &str, new_key: &str) {
         let new_key = new_key.to_owned();
-        let mut retargeted = Vec::new();
-        for (import, source) in &mut self.imported_commands {
+        for source in self.imported_commands.values_mut() {
             if source == old_key {
-                retargeted.push((import.clone(), source.clone()));
                 source.clone_from(&new_key);
-            }
-        }
-        retargeted
-    }
-
-    /// Restore exactly the provenance entries a failed rename retargeted.
-    /// Entries removed by the rollback itself are deliberately skipped.
-    fn restore_retargeted_imports(&mut self, retargeted: Vec<(String, String)>) {
-        for (import, source) in retargeted {
-            if let Some(current) = self.imported_commands.get_mut(&import) {
-                current.clone_from(&source);
             }
         }
     }

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -29,7 +29,7 @@
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::io::{self, Write};
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 
 use tcl_bytecode::{FunctionAsm, ModuleAsm};
 use tcl_core_types::RecursionLimit;
@@ -405,6 +405,21 @@ pub(crate) enum CommandSidecarKey {
     Hidden(String),
 }
 
+/// Relocation-aware identity held by an in-flight command operation.
+///
+/// Hide, expose, and rename move a command's sidecar domain while its body may
+/// still be running. Every active consumer shares this cell, so a relocation
+/// updates coroutine parking/retirement and execution-trace leave delivery as
+/// one operation.
+#[derive(Clone, Debug)]
+pub(crate) struct CommandSidecarHandle(Rc<RefCell<CommandSidecarKey>>);
+
+impl CommandSidecarHandle {
+    pub(crate) fn key(&self) -> CommandSidecarKey {
+        self.0.borrow().clone()
+    }
+}
+
 impl CommandSidecarKey {
     pub(crate) fn visible(name: impl Into<String>) -> Self {
         Self::Visible(name.into())
@@ -559,6 +574,9 @@ pub struct InterpState {
     /// `trace add execution` registrations (`enter`/`leave`/`enterstep`/
     /// `leavestep` ops), keyed like [`Self::cmd_traces`] and moved on rename.
     pub(crate) exec_traces: HashMap<CommandSidecarKey, Vec<Rc<CmdTraceEntry>>>,
+    /// Weak registry of in-flight sidecar identities. Relocation updates live
+    /// handles without retaining completed invocations.
+    active_sidecar_handles: Vec<Weak<RefCell<CommandSidecarKey>>>,
     /// Step-trace scopes currently active: one entry per `enterstep`/
     /// `leavestep`-bearing trace of each traced proc whose body is running.
     /// Every command dispatched while non-empty fires these (C's step
@@ -1123,6 +1141,7 @@ impl InterpState {
             var_traces: HashMap::new(),
             cmd_traces: HashMap::new(),
             exec_traces: HashMap::new(),
+            active_sidecar_handles: Vec::new(),
             exec_step_scopes: Vec::new(),
             trace_deopt_epoch: std::cell::Cell::new(0),
             trace_in_progress: std::cell::Cell::new(false),
@@ -4219,6 +4238,7 @@ impl Vm {
     pub(crate) fn on_command_renamed_traces(&mut self, old_key: &str, new_key: &str) {
         let old_key = CommandSidecarKey::visible(old_key);
         let new_key = CommandSidecarKey::visible(new_key);
+        self.relocate_active_sidecars(&old_key, &new_key);
         let mut moved_trace = false;
         if !self.cmd_traces.is_empty() {
             self.fire_command_traces_for(&old_key, &format!("::{}", new_key.name()), "rename");
@@ -4241,6 +4261,7 @@ impl Vm {
     /// Move trace registrations with a command through the hidden table.  A
     /// hide/expose is not a Tcl rename, so no callback is fired.
     fn move_command_traces(&mut self, old_key: &CommandSidecarKey, new_key: CommandSidecarKey) {
+        self.relocate_active_sidecars(old_key, &new_key);
         let mut moved = false;
         if let Some(entries) = self.cmd_traces.remove(old_key) {
             self.cmd_traces.insert(new_key.clone(), entries);
@@ -4253,6 +4274,32 @@ impl Vm {
         if moved {
             self.invalidate_guard_domain(GuardDomain::CommandTrace);
         }
+    }
+
+    /// Create an active identity that follows this command through every
+    /// visible/hidden/renamed sidecar relocation.
+    pub(crate) fn active_sidecar(&mut self, key: CommandSidecarKey) -> CommandSidecarHandle {
+        self.active_sidecar_handles
+            .retain(|handle| handle.strong_count() != 0);
+        let cell = Rc::new(RefCell::new(key));
+        self.active_sidecar_handles.push(Rc::downgrade(&cell));
+        CommandSidecarHandle(cell)
+    }
+
+    fn relocate_active_sidecars(
+        &mut self,
+        old_key: &CommandSidecarKey,
+        new_key: &CommandSidecarKey,
+    ) {
+        self.active_sidecar_handles.retain(|weak| {
+            let Some(handle) = weak.upgrade() else {
+                return false;
+            };
+            if *handle.borrow() == *old_key {
+                *handle.borrow_mut() = new_key.clone();
+            }
+            true
+        });
     }
 
     /// The traces on `name` as `(ops, command)` pairs (newest first), for

--- a/rust/tcl-vm/tests/cmd_coro_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_coro_e2e.rs
@@ -598,6 +598,20 @@ fn completed_coroutine_command_is_removed() {
 }
 
 #[test]
+fn completed_hidden_coroutine_is_retired_from_hidden_state() {
+    // Tcl 9.0.4: completing through invokehidden consumes the hidden token;
+    // neither a second resume nor a later expose can resurrect it.
+    assert_eq!(
+        result(
+            "proc g {} {yield a; return done}; coroutine c g; interp hide {} c held; \
+             list [interp invokehidden {} held] [interp hidden {}] \
+             [catch {interp invokehidden {} held}] [catch {interp expose {} held again}]"
+        ),
+        "done {} 1 0"
+    );
+}
+
+#[test]
 fn deleting_a_suspended_coroutine() {
     // tclsh 9.0.4: `rename $coro {}` drops a suspended coroutine.
     assert_eq!(

--- a/rust/tcl-vm/tests/cmd_coro_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_coro_e2e.rs
@@ -624,6 +624,69 @@ fn completed_hidden_coroutine_fires_its_delete_trace_once() {
 }
 
 #[test]
+fn equal_visible_and_hidden_tokens_keep_distinct_traces_and_coroutines() {
+    // Tcl 9.0.4 oracle: `visible visible-enter visible-leave hidden-enter
+    // hidden-delete b`. The visible `b` survives retirement of the hidden
+    // coroutine whose token is also `b`.
+    assert_eq!(
+        result(
+            "set ev {}; proc g {} {yield first; return hiddenDone}; coroutine a g; \
+             proc b {} {return visible}; \
+             trace add command a delete {apply {{args} {lappend ::ev hidden-delete}}}; \
+             trace add execution a {enter leave} {apply {{args} {lappend ::ev hidden-[lindex $args end]}}}; \
+             trace add command b delete {apply {{args} {lappend ::ev visible-delete}}}; \
+             trace add execution b {enter leave} {apply {{args} {lappend ::ev visible-[lindex $args end]}}}; \
+             interp hide {} a b; set visible [b]; set hidden [interp invokehidden {} b]; \
+             list $visible $hidden $::ev [info commands b] [interp hidden {}]"
+        ),
+        "visible hiddenDone {visible-enter visible-leave hidden-enter hidden-delete} b {}"
+    );
+}
+
+#[test]
+fn equal_hidden_tokens_hold_independent_coroutines_in_distinct_interpreters() {
+    assert_eq!(
+        result(
+            "proc g {tag} {yield $tag; return $tag-done}; \
+             coroutine a g root; proc b {} {return root-visible}; interp hide {} a b; \
+             interp create child; child eval {proc g {tag} {yield $tag; return $tag-done}; \
+                 coroutine a g child; proc b {} {return child-visible}}; \
+             interp hide child a b; \
+             list [b] [child eval b] [interp invokehidden {} b] \
+                  [interp invokehidden child b] [b] [child eval b]"
+        ),
+        "root-visible child-visible root-done child-done root-visible child-visible"
+    );
+}
+
+#[test]
+fn errored_hidden_coroutine_retires_without_touching_equal_visible_command() {
+    assert_eq!(
+        result(
+            "set ev {}; proc g {} {yield first; error boom}; coroutine a g; \
+             proc b {} {return visible}; \
+             trace add command a delete {apply {{args} {lappend ::ev hidden-delete}}}; \
+             trace add command b delete {apply {{args} {lappend ::ev visible-delete}}}; \
+             interp hide {} a b; catch {interp invokehidden {} b} message; \
+             list $message [b] $::ev [interp hidden {}]"
+        ),
+        "boom visible hidden-delete {}"
+    );
+}
+
+#[test]
+fn hidden_alias_to_equal_visible_coroutine_uses_target_domain() {
+    assert_eq!(
+        result(
+            "proc g {} {yield first; return done}; coroutine b g; \
+             interp alias {} a {} b; interp hide {} a b; \
+             list [interp invokehidden {} b] [info commands b] [interp hidden {}]"
+        ),
+        "done {} b"
+    );
+}
+
+#[test]
 fn deleting_a_suspended_coroutine() {
     // tclsh 9.0.4: `rename $coro {}` drops a suspended coroutine.
     assert_eq!(

--- a/rust/tcl-vm/tests/cmd_coro_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_coro_e2e.rs
@@ -612,6 +612,18 @@ fn completed_hidden_coroutine_is_retired_from_hidden_state() {
 }
 
 #[test]
+fn completed_hidden_coroutine_fires_its_delete_trace_once() {
+    assert_eq!(
+        result(
+            "proc g {} {yield a; return done}; proc cb args {lappend ::events [lindex $args end]}; \
+             coroutine c g; trace add command c delete cb; interp hide {} c held; \
+             list [interp invokehidden {} held] $::events [interp hidden {}]"
+        ),
+        "done delete {}"
+    );
+}
+
+#[test]
 fn deleting_a_suspended_coroutine() {
     // tclsh 9.0.4: `rename $coro {}` drops a suspended coroutine.
     assert_eq!(

--- a/rust/tcl-vm/tests/cmd_string_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_string_e2e.rs
@@ -35,6 +35,7 @@ use std::rc::Rc;
 use tcl_compiler::cfg_builder::build_cfg_codegen;
 use tcl_compiler::codegen::codegen_module;
 use tcl_compiler::lowering::lower_to_ir;
+use tcl_dialect::DialectProfile;
 use tcl_registry::CommandRegistry;
 use tcl_vm::{CompileError, CompileService, Vm};
 
@@ -56,6 +57,27 @@ impl CompileService for CompilerSvc {
         let cfg = build_cfg_codegen(&ir, false);
         Ok(codegen_module(&cfg, &ir, &self.registry))
     }
+
+    fn compile_for_profile(
+        &self,
+        src: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        let registry = tcl_registry::registry_for_profile(profile);
+        let config = tcl_lexer::LexerConfig::from_grammar(profile.grammar);
+        if let Some(msg) = tcl_compiler::lowering::first_fatal_parse_error_with_config(src, config)
+        {
+            return Err(CompileError(msg));
+        }
+        let ir = tcl_compiler::lowering::lower_to_ir_for_bytecode_with_dialect(
+            src,
+            registry,
+            config,
+            profile.name,
+        );
+        let cfg = build_cfg_codegen(&ir, false);
+        Ok(codegen_module(&cfg, &ir, registry))
+    }
 }
 
 /// A `Write` sink backed by a shared buffer the test can read afterwards.
@@ -74,17 +96,18 @@ impl Write for Capture {
 
 /// Compile and run `src`; return `(ok, result-string, captured-stdout)`.
 fn run_for_version(src: &str, version: tcl_dialect::TclVersion) -> (bool, String, String) {
-    let registry = CommandRegistry::build_default();
-    let ir = lower_to_ir(src, &registry);
-    let cfg = build_cfg_codegen(&ir, false);
-    let asm = codegen_module(&cfg, &ir, &registry);
+    let profile = DialectProfile::by_name(version.dialect_name());
+    let service = CompilerSvc {
+        registry: CommandRegistry::build_default(),
+    };
+    let asm = service
+        .compile_for_profile(src, profile)
+        .expect("test script compiles for its selected profile");
 
     let buf = Rc::new(RefCell::new(Vec::new()));
     let mut vm = Vm::with_output(Box::new(Capture(Rc::clone(&buf))));
     vm.set_runtime_version(version);
-    vm.set_compiler(Box::new(CompilerSvc {
-        registry: CommandRegistry::build_default(),
-    }));
+    vm.set_compiler(Box::new(service));
     let completion = vm.run_module(&asm);
 
     let out = String::from_utf8(buf.borrow().clone()).expect("utf-8 output");

--- a/rust/tcl-vm/tests/cross_interp_reentry_e2e.rs
+++ b/rust/tcl-vm/tests/cross_interp_reentry_e2e.rs
@@ -134,6 +134,15 @@ struct Vector {
 }
 
 const VECTORS: &[Vector] = &[
+    Vector {
+        name: "TP: deleting a target removes a hidden cross-interpreter alias",
+        script: "interp create target\n\
+                 interp alias {} bridge target set\n\
+                 interp hide {} bridge held\n\
+                 interp delete target\n\
+                 puts [interp hidden {}]\n",
+        want: "",
+    },
     // -- fault 1: parent alias reached across a native re-entry ----------
     Vector {
         name: "TP: a parent alias fires from inside a resumed coroutine",

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -994,6 +994,21 @@ set code [catch {p} result]
 puts [list $code $result $log [interp hidden {}]]
 ";
 
+// A leave callback can delete the running binding and install a replacement.
+// Tcl stops the cloned old trace list at that lifecycle boundary: later old
+// callbacks must not run against the replacement generation.
+const LEAVE_TRACE_DELETE_RECREATE_STOPS_OLD_LIST: &str = r"
+set log {}
+proc a {} {return old}
+proc first args {lappend ::log A; rename a {}; proc a {} {return new}}
+proc second args {lappend ::log B}
+trace add execution a leave first
+trace add execution a leave second
+set old [a]
+set new [a]
+puts [list $old $log $new]
+";
+
 #[test]
 fn active_coroutine_and_execution_trace_follow_self_hide() {
     for profile in [
@@ -1023,6 +1038,10 @@ fn active_coroutine_and_execution_trace_follow_self_hide() {
         assert_eq!(
             profile_output(SELF_HIDING_TRACED_ERROR, profile),
             "1 boom {{p enter} {p 1 boom leave}} held"
+        );
+        assert_eq!(
+            profile_output(LEAVE_TRACE_DELETE_RECREATE_STOPS_OLD_LIST, profile),
+            "old A new"
         );
     }
 }
@@ -1055,6 +1074,7 @@ fn self_hide_vectors_match_real_tcl_when_available() {
                 SELF_HIDING_TRACED_ERROR,
                 "1 boom {{p enter} {p 1 boom leave}} held",
             ),
+            (LEAVE_TRACE_DELETE_RECREATE_STOPS_OLD_LIST, "old A new"),
         ] {
             if let Some(actual) = tclsh_output(env, names, script) {
                 assert_eq!(actual, expected, "{env}");

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -490,17 +490,26 @@ fn refused_alias_rename_restores_import_provenance() {
 #[test]
 fn refused_alias_rename_preserves_a_hidden_destination_for_later_releases() {
     let mut vm = Vm::new();
+    vm.set_dialect_profile(DialectProfile::by_name("tcl8.5"));
+    vm.set_compiler(Box::new(CompilerSvc::for_profile(DialectProfile::by_name(
+        "tcl8.5",
+    ))));
+    let trace_setup = vm
+        .eval_source(
+            "proc on_delete args {lappend ::events delete}\n\
+             proc on_enter args {lappend ::events enter}\n\
+             trace add command lassign delete on_delete\n\
+             trace add execution lassign enter on_enter\n",
+        )
+        .expect("8.5 trace setup compiles");
+    assert!(trace_setup.code.is_ok());
     vm.set_dialect_profile(DialectProfile::by_name("tcl8.4"));
     vm.set_compiler(Box::new(CompilerSvc::for_profile(DialectProfile::by_name(
         "tcl8.4",
     ))));
     let setup = vm
         .eval_source(
-            "proc on_delete args {lappend ::events delete}\n\
-             proc on_enter args {lappend ::events enter}\n\
-             trace add command lassign delete on_delete\n\
-             trace add execution lassign enter on_enter\n\
-             namespace eval src {interp alias {} ::src::a {} lassign; namespace export a}\n\
+            "namespace eval src {interp alias {} ::src::a {} lassign; namespace export a}\n\
              namespace eval imported {namespace import ::src::a}\n\
              catch {rename ::src::a lassign} message\n\
              list $message [namespace origin ::imported::a] \\
@@ -511,7 +520,7 @@ fn refused_alias_rename_preserves_a_hidden_destination_for_later_releases() {
     assert!(setup.code.is_ok());
     assert_eq!(
         setup.result.to_str().as_ref(),
-        "{cannot define or rename alias \"lassign\": would create a loop} ::src::a 1 1 0"
+        "{cannot define or rename alias \"lassign\": would create a loop} ::src::a 0 0 0"
     );
 
     vm.set_dialect_profile(DialectProfile::by_name("tcl8.5"));
@@ -523,6 +532,66 @@ fn refused_alias_rename_preserves_a_hidden_destination_for_later_releases() {
         .expect("8.5 probe compiles");
     assert!(probe.code.is_ok());
     assert_eq!(probe.result.to_str().as_ref(), "::src::a b enter");
+}
+
+/// Candidate selection, rather than only final dispatch, owns release
+/// visibility. An unavailable namespace-local builtin must not shadow a later
+/// global command with the same tail.
+#[test]
+fn unavailable_local_candidate_falls_through_to_global_command() {
+    let mut vm = Vm::new();
+    vm.set_dialect_profile(DialectProfile::by_name("tcl8.5"));
+    vm.set_compiler(Box::new(CompilerSvc::for_profile(DialectProfile::by_name(
+        "tcl8.5",
+    ))));
+    let setup = vm
+        .eval_source("namespace eval n {}; rename lassign ::n::x; proc ::x {} {return global}\n")
+        .expect("8.5 setup compiles");
+    assert!(setup.code.is_ok());
+
+    vm.set_dialect_profile(DialectProfile::by_name("tcl8.4"));
+    vm.set_compiler(Box::new(CompilerSvc::for_profile(DialectProfile::by_name(
+        "tcl8.4",
+    ))));
+    let probe = vm
+        .eval_source("namespace eval n {x}\n")
+        .expect("8.4 probe compiles");
+    assert!(probe.code.is_ok());
+    assert_eq!(probe.result.to_str().as_ref(), "global");
+}
+
+#[test]
+fn equal_hidden_token_does_not_capture_visible_import_provenance() {
+    // Tcl 9.0.4 keeps the imported clone's original lineage when its source is
+    // hidden; it must not chase the unrelated visible `b` import merely
+    // because the hidden token is also `b`.
+    assert_eq!(
+        profile_output(
+            "namespace eval src {proc a {} {return hidden}; namespace export a}\n\
+             namespace eval other {proc b {} {return visible}; namespace export b}\n\
+             namespace import ::src::a; namespace import ::other::b; namespace export a b\n\
+             namespace eval consumer {namespace import ::a}\n\
+             interp hide {} a b\n\
+             list [namespace origin ::consumer::a] [namespace origin ::b] \
+                  [consumer::a] [b] [interp hidden {}]\n",
+            DialectProfile::by_name("tcl9.0"),
+        ),
+        "::src::a ::other::b hidden visible b"
+    );
+}
+
+#[test]
+fn retiring_hidden_cross_alias_does_not_delete_equal_visible_command() {
+    assert_eq!(
+        profile_output(
+            "interp create target; target eval {proc p {} {return target}}\n\
+             interp alias {} a target p; proc b {} {return visible}\n\
+             interp hide {} a b; interp delete target\n\
+             list [b] [interp hidden {}] [info commands b]\n",
+            DialectProfile::by_name("tcl9.0"),
+        ),
+        "visible {} b"
+    );
 }
 
 /// `rename command {}` is deletion, not the failed-rename transaction path:

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -42,7 +42,7 @@ use tcl_compiler::cfg_builder::build_cfg_codegen;
 use tcl_compiler::codegen::codegen_module;
 use tcl_compiler::lowering::lower_to_ir_for_bytecode_with_dialect as lower_to_ir;
 use tcl_dialect::{DialectProfile, TclVersion};
-use tcl_vm::{CompileError, CompileService, Vm};
+use tcl_vm::{Code, CompileError, CompileService, Vm};
 
 #[derive(Clone, Default)]
 struct Capture(Rc<RefCell<Vec<u8>>>);
@@ -87,6 +87,14 @@ impl CompileService for CompilerSvc {
         let ir = lower_to_ir(src, self.registry, self.config, self.dialect);
         let cfg = build_cfg_codegen(&ir, false);
         Ok(codegen_module(&cfg, &ir, self.registry))
+    }
+
+    fn compile_for_profile(
+        &self,
+        src: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        Self::for_profile(profile).compile(src)
     }
 }
 
@@ -397,6 +405,155 @@ fn version_mutation_rechecks_an_existing_imports_source_identity() {
         probe.result.to_str().as_ref(),
         "{invalid command name \"imported_lassign\"} {invalid command name \"escaped\"}"
     );
+}
+
+/// Changing a VM's profile is not merely a lookup-cache invalidation: bodies
+/// compiled while a newer surface was active can contain direct bytecode for a
+/// command that the older profile would reject.  Keep the compiler installed
+/// at its original 8.5 construction profile to prove the VM selects the new
+/// profile for every recompile itself.
+#[test]
+#[allow(clippy::too_many_lines)] // One stateful profile lifecycle must stay in one causal vector.
+fn profile_mutation_recompiles_cached_bodies_and_rejects_live_continuations() {
+    let v85 = DialectProfile::by_name("tcl8.5");
+    let v84 = DialectProfile::by_name("tcl8.4");
+    let v86 = DialectProfile::by_name("tcl8.6");
+    let mut vm = Vm::new();
+    vm.set_dialect_profile(v85);
+    vm.set_compiler(Box::new(CompilerSvc::for_profile(v85)));
+
+    // Prime every cache/body owner that retains executable bytecode: an
+    // ordinary proc, TclOO method, child proc reached through an alias,
+    // reusable host FunctionHandle, eval cache, lexer/parser cache, and a
+    // parked coroutine continuation.
+    let setup = vm
+        .eval_source(
+            "proc p {} {lassign {a b} x; return $x}\n\
+             oo::class create C {method m {} {lassign {a b} x; return $x}}\n\
+             C create o\n\
+             expr {0b10 + 1}",
+        )
+        .expect("8.5 setup compiles");
+    assert!(setup.code.is_ok(), "{}", setup.result.to_str());
+    let handle = vm
+        .compile_function("lassign {a b} handle_x; set handle_x")
+        .expect("8.5 handle compiles");
+
+    // The reported escape, exactly: a body compiled under 8.5 must not retain
+    // its inline lassign lowering after a direct 8.4 flip, and the reverse
+    // flip must compile it back onto the newer surface.
+    vm.set_dialect_profile(v84);
+    let exact_84 = vm
+        .eval_source("catch {p} message; set message")
+        .expect("8.4 exact repro compiles");
+    assert_eq!(
+        exact_84.result.to_str().as_ref(),
+        "invalid command name \"lassign\""
+    );
+    assert_eq!(
+        vm.eval_source("expr {0b10 + 1}")
+            .expect("8.4 expression repro compiles")
+            .code,
+        Code::Error
+    );
+    assert!(
+        vm.eval_source("{*}[list set ::profile_mutation_lexer 1]")
+            .is_err()
+    );
+    vm.set_dialect_profile(v85);
+    assert_eq!(
+        vm.eval_source("list [p] [expr {0b10 + 1}]")
+            .expect("8.5 reverse repro compiles")
+            .result
+            .to_str()
+            .as_ref(),
+        "a 3"
+    );
+
+    // `coroutine` begins in 8.6. Retain the 8.5-built proc/handle above, then
+    // add a live continuation and child-owned profile while the newer surface
+    // is selected.
+    vm.set_dialect_profile(v86);
+    let newer_setup = vm
+        .eval_source(
+            "coroutine c apply {{} {yield ready; lassign {a b} x; return $x}}\n\
+             interp create child\n\
+             child eval {proc p {} {lassign {a b} x; return $x}}\n\
+             interp alias {} child_p child p",
+        )
+        .expect("8.6 coroutine setup compiles");
+    assert!(newer_setup.code.is_ok(), "{}", newer_setup.result.to_str());
+    // This source is lexically accepted on 8.5+ (its eventual runtime
+    // command error is immaterial); retaining its compiled module exercises
+    // the lexer-sensitive eval cache that 8.4 must discard and re-lex.
+    let lexer_86 = vm
+        .eval_source("{*}[list set ::profile_mutation_lexer 1]")
+        .expect("8.5 lexer source compiles");
+    assert_eq!(lexer_86.code, Code::Error);
+
+    assert!(vm.set_child_dialect_profile("child", v84));
+    vm.set_dialect_profile(v84);
+
+    let stale = vm
+        .eval_source(
+            "catch {p} proc_msg; catch {o m} method_msg; catch {child_p} alias_msg; \\
+             list $proc_msg $method_msg $alias_msg",
+        )
+        .expect("8.4 probes compile");
+    assert_eq!(
+        stale.result.to_str().as_ref(),
+        "{invalid command name \"lassign\"} {invalid command name \"lassign\"} {invalid command name \"lassign\"}"
+    );
+    let handle_result = vm.invoke_function(&handle);
+    assert_eq!(handle_result.code, Code::Error);
+    assert_eq!(
+        handle_result.result.to_str().as_ref(),
+        "invalid command name \"lassign\""
+    );
+
+    // The exact same source must not be served from its newer-profile eval cache:
+    // expression grammar and lexer grammar changed with the profile too.
+    assert_eq!(
+        vm.eval_source("expr {0b10 + 1}")
+            .expect("8.4 expr compile")
+            .code,
+        Code::Error
+    );
+    assert!(
+        vm.eval_source("{*}[list set ::profile_mutation_lexer 2]")
+            .is_err()
+    );
+
+    // A coroutine cannot be recompiled in place after it yielded: it owns a
+    // live PC/operand stack. The frame generation guard therefore rejects the
+    // stale continuation before it reaches its old inline lassign opcode.
+    let continuation = vm
+        .eval_source("catch {c} continuation_msg; set continuation_msg")
+        .expect("8.4 continuation probe compiles");
+    assert_eq!(
+        continuation.result.to_str().as_ref(),
+        "cannot continue bytecode after dialect profile changed"
+    );
+
+    // The reverse mutation gets fresh 8.5 bodies (including the child and
+    // alias) rather than retaining the failed 8.4 recompilation.
+    assert!(vm.set_child_dialect_profile("child", v85));
+    vm.set_dialect_profile(v85);
+    let restored = vm
+        .eval_source(
+            "proc q {} {lassign {a b} x; return $x}; \\
+             list [p] [o m] [child_p] [q] [expr {0b10 + 1}]",
+        )
+        .expect("8.5 restoration compiles");
+    assert_eq!(restored.result.to_str().as_ref(), "a a a a 3");
+
+    // And the live-coroutine surface returns normally once a newly-created
+    // continuation is compiled under a release that supports it.
+    vm.set_dialect_profile(v86);
+    let resumed = vm
+        .eval_source("coroutine c2 apply {{} {yield ready; lassign {a b} x; return $x}}; c2")
+        .expect("8.6 coroutine restoration compiles");
+    assert_eq!(resumed.result.to_str().as_ref(), "a");
 }
 
 /// Renaming an import moves its local key, not its source provenance.  A

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -668,6 +668,28 @@ fn child_command_hide_and_expose_collisions_propagate_without_mutation() {
     }
 }
 
+#[test]
+fn hide_expose_moves_traces_without_callbacks() {
+    let src = concat!(
+        "proc a {} {return A}; proc cb args {lappend ::events [lindex $args end]}\n",
+        "trace add command a {rename delete} cb; trace add execution a enter cb\n",
+        "interp hide {} a token\n",
+        "interp expose {} token moved\n",
+        "puts \"state=[moved] [llength [trace info command moved]] [llength [trace info execution moved]] $::events\"\n",
+    );
+    let want = "state=A 1 1 enter";
+    for version in [TclVersion::V8_6, TclVersion::V9_0, TclVersion::V9_1] {
+        assert_eq!(
+            vm_output(src, version),
+            want,
+            "[{version:?}] hide trace move"
+        );
+    }
+    if let Some(out) = tclsh_output("TCLSH90", &["tclsh9.0"], src) {
+        assert_eq!(out, want, "[TCLSH90] real Tcl oracle");
+    }
+}
+
 /// A `catch` body is compiled at run time through the VM's compile service,
 /// so an 8.5+-only spelling inside it is a *catchable* error under an 8.4
 /// pin — matching C Tcl, which defers a compile-time parse error to a

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -1491,3 +1491,34 @@ fn vectors_match_real_tclsh_when_available() {
         eprintln!("no system tclsh found — pinned expectations still verified");
     }
 }
+
+/// An enter trace may delete the command currently being invoked while also
+/// installing a replacement under its former visible name.  Tcl treats the
+/// in-flight command token as deleted; it neither invokes nor resurrects it,
+/// and the callback-created replacement remains authoritative.
+#[test]
+fn deleted_hidden_enter_trace_matches_real_tclsh() {
+    let src = concat!(
+        "proc p {} {return hidden}\n",
+        "proc replace args {\n",
+        "  rename p {}\n",
+        "  interp expose {} held p\n",
+        "  rename p {}\n",
+        "  proc p {} {return replacement}\n",
+        "}\n",
+        "trace add execution p enter replace\n",
+        "interp hide {} p held\n",
+        "proc p {} {return initial}\n",
+        "set rc [catch {interp invokehidden {} held} msg]\n",
+        "puts [list $rc $msg [p] [interp hidden {}]]\n",
+    );
+    let want = "1 {attempt to invoke a deleted command} replacement {}";
+    for (env, names) in [
+        ("TCLSH86", &["tclsh8.6"][..]),
+        ("TCLSH90", &["tclsh9.0"][..]),
+    ] {
+        if let Some(out) = tclsh_output(env, names, src) {
+            assert_eq!(out, want, "[{env}] hidden enter-trace lifecycle");
+        }
+    }
+}

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -1522,3 +1522,29 @@ fn deleted_hidden_enter_trace_matches_real_tclsh() {
         }
     }
 }
+
+/// An imported proc owns its local binding even after its source has been
+/// renamed. Refreshing trace-stale bytecode must update that exact resolved
+/// import, never the `ProcDef` source name, which may now name a replacement.
+#[test]
+fn imported_proc_refresh_preserves_renamed_source_replacement() {
+    let src = concat!(
+        "namespace eval src {proc p {} {return original}; namespace export p}\n",
+        "namespace eval dst {namespace import ::src::p}\n",
+        "rename ::src::p ::src::q\n",
+        "proc ::src::p {} {return replacement}\n",
+        "proc noop args {}\n",
+        "trace add execution ::dst::p enterstep noop\n",
+        "puts [list [::dst::p] [::src::p] [::src::q] [namespace origin ::dst::p]]\n",
+    );
+    let want = "original replacement original ::src::q";
+    assert_eq!(profile_output(src, DialectProfile::by_name("tcl8.6")), want);
+    for (env, names) in [
+        ("TCLSH86", &["tclsh8.6"][..]),
+        ("TCLSH90", &["tclsh9.0"][..]),
+    ] {
+        if let Some(out) = tclsh_output(env, names, src) {
+            assert_eq!(out, want, "[{env}] imported proc refresh");
+        }
+    }
+}

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -640,6 +640,34 @@ fn hide_and_expose_collisions_preserve_bindings_and_traces() {
     }
 }
 
+#[test]
+fn child_command_hide_and_expose_collisions_propagate_without_mutation() {
+    let src = concat!(
+        "interp create kid\n",
+        "kid eval {proc a {} {return A}; proc cb args {lappend ::events [lindex $args end]}}\n",
+        "kid hide a\n",
+        "kid eval {proc a {} {return B}; trace add command a delete cb; trace add execution a enter cb}\n",
+        "puts \"hide=[catch {kid hide a} m];$m\"\n",
+        "puts \"expose=[catch {kid expose a} m];$m\"\n",
+        "puts \"state=[kid eval {list [a] [llength [trace info command a]] [llength [trace info execution a]]}]\"\n",
+    );
+    let want = concat!(
+        "hide=1;hidden command named \"a\" already exists\n",
+        "expose=1;exposed command \"a\" already exists\n",
+        "state=B 1 1",
+    );
+    for version in [TclVersion::V8_6, TclVersion::V9_0, TclVersion::V9_1] {
+        assert_eq!(
+            vm_output(src, version),
+            want,
+            "[{version:?}] child hide collision"
+        );
+    }
+    if let Some(out) = tclsh_output("TCLSH90", &["tclsh9.0"], src) {
+        assert_eq!(out, want, "[TCLSH90] real Tcl oracle");
+    }
+}
+
 /// A `catch` body is compiled at run time through the VM's compile service,
 /// so an 8.5+-only spelling inside it is a *catchable* error under an 8.4
 /// pin — matching C Tcl, which defers a compile-time parse error to a

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -437,6 +437,64 @@ fn renamed_imports_preserve_origin_through_nested_imports() {
     }
 }
 
+/// Hiding an imported command moves its provenance into the hidden-token
+/// sidecar.  Renaming the source while that import is hidden must retarget the
+/// hidden provenance too, so exposing it restores the same live source-token
+/// relationship that C Tcl preserves.  Imports from a named child namespace
+/// and through two nested consumers follow the restored root import, and
+/// qualified `namespace forget` recognises the source's new name through every
+/// import layer.  The equal visible `held` command pins the typed
+/// visible/hidden key domains: it must neither capture nor be captured by the
+/// hidden token.
+#[test]
+fn source_rename_retargets_hidden_import_provenance() {
+    let src = concat!(
+        "namespace eval outer::src {proc a {} {return imported}; namespace export a}\n",
+        "proc held {} {return visible}\n",
+        "namespace import ::outer::src::a; namespace export a\n",
+        "namespace eval one {namespace import ::a; namespace export a}\n",
+        "namespace eval two {namespace import ::one::a}\n",
+        "interp hide {} a held\n",
+        "rename ::outer::src::a ::outer::src::b\n",
+        "interp expose {} held a\n",
+        "puts \"root=[namespace origin a];[a]\"\n",
+        "puts \"one=[namespace origin ::one::a];[::one::a]\"\n",
+        "puts \"two=[namespace origin ::two::a];[::two::a]\"\n",
+        "puts \"collision=[held]\"\n",
+        "namespace eval two {namespace forget ::outer::src::b}\n",
+        "namespace eval one {namespace forget ::outer::src::b}\n",
+        "namespace forget ::outer::src::b\n",
+        "puts \"forgot=[info commands a],[info commands ::one::a],[info commands ::two::a]\"\n",
+    );
+    let want = concat!(
+        "root=::outer::src::b;imported\n",
+        "one=::outer::src::b;imported\n",
+        "two=::outer::src::b;imported\n",
+        "collision=visible\n",
+        "forgot=,,",
+    );
+    for version in [
+        TclVersion::V8_5,
+        TclVersion::V8_6,
+        TclVersion::V9_0,
+        TclVersion::V9_1,
+    ] {
+        assert_eq!(
+            vm_output(src, version),
+            want,
+            "[{version:?}] hidden imported provenance retarget"
+        );
+    }
+    for (env, names) in [
+        ("TCLSH86", &["tclsh8.6"][..]),
+        ("TCLSH90", &["tclsh9.0"][..]),
+    ] {
+        if let Some(out) = tclsh_output(env, names, src) {
+            assert_eq!(out, want, "[{env}] real Tcl oracle");
+        }
+    }
+}
+
 /// A refused alias rename must undo the retargeting of every import that had
 /// followed the provisional new name.  This covers direct and nested
 /// `namespace origin` lookups, and proves qualified `namespace forget` still

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -795,6 +795,39 @@ fn child_command_hide_and_expose_collisions_propagate_without_mutation() {
     }
 }
 
+/// `interp expose`'s destination is always the exact global command-table
+/// key.  A caller may have a same-spelled local command, which Tcl leaves
+/// untouched while exposing the hidden binding globally.  Exercise the root,
+/// named-child, and child-command (by-id) entry points so each routes through
+/// the same collision owner rather than contextual command lookup.
+#[test]
+fn expose_uses_exact_global_destination_in_every_entry_point() {
+    let src = concat!(
+        "proc a {} {return root-global}; interp hide {} a held\n",
+        "namespace eval n {proc b {} {return root-local}; interp expose {} held b; puts \"root=[b],[::b]\"}\n",
+        "interp create named; named eval {proc a {} {return named-global}; interp hide {} a held; namespace eval n {proc b {} {return named-local}; interp expose {} held b; puts \"named=[b],[::b]\"}}\n",
+        "interp create byid; byid eval {proc a {} {return byid-global}; interp hide {} a; namespace eval n {proc a {} {return byid-local}}}\n",
+        "byid expose a; puts \"byid=[byid eval {namespace eval n {join [list [a] [::a]] ,}}]\"\n",
+    );
+    let want =
+        "root=root-local,root-global\nnamed=named-local,named-global\nbyid=byid-local,byid-global";
+    for version in [TclVersion::V8_6, TclVersion::V9_0, TclVersion::V9_1] {
+        assert_eq!(
+            vm_output(src, version),
+            want,
+            "[{version:?}] exact expose destination"
+        );
+    }
+    for (env, names) in [
+        ("TCLSH86", &["tclsh8.6"][..]),
+        ("TCLSH90", &["tclsh9.0"][..]),
+    ] {
+        if let Some(out) = tclsh_output(env, names, src) {
+            assert_eq!(out, want, "[{env}] real Tcl oracle");
+        }
+    }
+}
+
 #[test]
 fn hide_expose_moves_traces_without_callbacks() {
     let src = concat!(
@@ -908,6 +941,22 @@ set first [coroutine c apply {{} {
 puts [list $first [interp invokehidden {} held] [d] [interp hidden {}]]
 ";
 
+// A deleted coroutine binding and a later command at the same spelling are
+// distinct lifecycles.  The original driver is still unwinding after it
+// deletes `c`; the replacement is then created at `c` and renamed to `d`.
+// Its completion must not retire `d` through the stale active sidecar handle.
+const SELF_DELETING_COROUTINE_REUSES_AND_RENAMES_BINDING: &str = r"
+proc fresh {} {yield fresh-one; yield fresh-two; return fresh-done}
+proc stale {} {
+    rename [info coroutine] {}
+    coroutine c fresh
+    rename c d
+    return stale-done
+}
+set start [coroutine c stale]
+puts [list $start [d] [d] [catch {d} message] $message]
+";
+
 const SELF_HIDING_TRACED_COMMAND: &str = r"
 set log {}
 proc tr args {lappend ::log $args}
@@ -956,6 +1005,10 @@ fn active_coroutine_and_execution_trace_follow_self_hide() {
             "first second done {}"
         );
         assert_eq!(
+            profile_output(SELF_DELETING_COROUTINE_REUSES_AND_RENAMES_BINDING, profile),
+            "stale-done fresh-two fresh-done 1 {invalid command name \"d\"}"
+        );
+        assert_eq!(
             profile_output(SELF_HIDING_TRACED_COMMAND, profile),
             "ok {{p enter} {p 0 ok leave}} held"
         );
@@ -982,6 +1035,10 @@ fn self_hide_vectors_match_real_tcl_when_available() {
     ] {
         for (script, expected) in [
             (SELF_HIDING_COROUTINE, "first second done {}"),
+            (
+                SELF_DELETING_COROUTINE_REUSES_AND_RENAMES_BINDING,
+                "stale-done fresh-two fresh-done 1 {invalid command name \"d\"}",
+            ),
             (
                 SELF_HIDING_TRACED_COMMAND,
                 "ok {{p enter} {p 0 ok leave}} held",

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -573,6 +573,39 @@ fn empty_rename_destination_deletes_commands_across_indirections() {
     }
 }
 
+/// Coroutine state follows the command key chosen by Tcl's full lookup rule,
+/// rather than the caller namespace spelling.  A `namespace path` source is
+/// therefore renamed into the caller namespace, while an empty destination
+/// tears down the continuation at the resolved source key.
+#[test]
+fn namespace_path_resolved_coroutine_rename_and_delete_keep_state_in_sync() {
+    let src = concat!(
+        "namespace eval ::pr {proc g {} {yield 1; yield 2}; coroutine c g}\n",
+        "namespace eval ::pc {namespace path ::pr}\n",
+        "namespace eval ::pc {rename c d}\n",
+        "puts \"renamed=[::pc::d]\"\n",
+        "namespace eval ::pr {coroutine c g}\n",
+        "namespace eval ::pc {rename c {}}\n",
+        "puts \"deleted=[catch {::pr::c} message];$message\"\n",
+    );
+    let want = "renamed=2\ndeleted=1;invalid command name \"::pr::c\"";
+    for version in [TclVersion::V8_6, TclVersion::V9_0, TclVersion::V9_1] {
+        assert_eq!(
+            vm_output(src, version),
+            want,
+            "[{version:?}] path-resolved coroutine"
+        );
+    }
+    for (env, names) in [
+        ("TCLSH86", &["tclsh8.6"][..]),
+        ("TCLSH90", &["tclsh9.0"][..]),
+    ] {
+        if let Some(out) = tclsh_output(env, names, src) {
+            assert_eq!(out, want, "[{env}] real Tcl oracle");
+        }
+    }
+}
+
 /// A `catch` body is compiled at run time through the VM's compile service,
 /// so an 8.5+-only spelling inside it is a *catchable* error under an 8.4
 /// pin — matching C Tcl, which defers a compile-time parse error to a

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -482,10 +482,11 @@ fn refused_alias_rename_restores_import_provenance() {
     }
 }
 
-/// The provisional alias can replace an engine-registered command that is
-/// hidden by the current release.  Restoring that destination is essential:
-/// a later release change must reveal the original builtin, not a command
-/// table hole left by the rejected rename.
+/// An alias-loop check must not provisionally overwrite an engine-registered
+/// command hidden by the current release.  That overwrite would invoke its
+/// delete callback and discard command/execution traces before rollback could
+/// restore the command; a later release change must reveal the original
+/// builtin with both trace registrations intact.
 #[test]
 fn refused_alias_rename_preserves_a_hidden_destination_for_later_releases() {
     let mut vm = Vm::new();
@@ -495,16 +496,22 @@ fn refused_alias_rename_preserves_a_hidden_destination_for_later_releases() {
     ))));
     let setup = vm
         .eval_source(
-            "namespace eval src {interp alias {} ::src::a {} lassign; namespace export a}\n\
+            "proc on_delete args {lappend ::events delete}\n\
+             proc on_enter args {lappend ::events enter}\n\
+             trace add command lassign delete on_delete\n\
+             trace add execution lassign enter on_enter\n\
+             namespace eval src {interp alias {} ::src::a {} lassign; namespace export a}\n\
              namespace eval imported {namespace import ::src::a}\n\
              catch {rename ::src::a lassign} message\n\
-             list $message [namespace origin ::imported::a]\n",
+             list $message [namespace origin ::imported::a] \\
+                  [llength [trace info command lassign]] \\
+                  [llength [trace info execution lassign]] [info exists ::events]\n",
         )
         .expect("8.4 setup compiles");
     assert!(setup.code.is_ok());
     assert_eq!(
         setup.result.to_str().as_ref(),
-        "{cannot define or rename alias \"lassign\": would create a loop} ::src::a"
+        "{cannot define or rename alias \"lassign\": would create a loop} ::src::a 1 1 0"
     );
 
     vm.set_dialect_profile(DialectProfile::by_name("tcl8.5"));
@@ -512,10 +519,10 @@ fn refused_alias_rename_preserves_a_hidden_destination_for_later_releases() {
         "tcl8.5",
     ))));
     let probe = vm
-        .eval_source("list [namespace origin ::imported::a] [lassign {a b} value]\n")
+        .eval_source("list [namespace origin ::imported::a] [lassign {a b} value] $::events\n")
         .expect("8.5 probe compiles");
     assert!(probe.code.is_ok());
-    assert_eq!(probe.result.to_str().as_ref(), "::src::a b");
+    assert_eq!(probe.result.to_str().as_ref(), "::src::a b enter");
 }
 
 /// A `catch` body is compiled at run time through the VM's compile service,

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -35,7 +35,7 @@
 //! byte-compared against a real interpreter whenever one is on `PATH`
 //! (`TCLSH84` / `TCLSH86` / `TCLSH90` override the binary names).
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use tcl_compiler::cfg_builder::build_cfg_codegen;
@@ -96,6 +96,81 @@ impl CompileService for CompilerSvc {
     ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
         Self::for_profile(profile).compile(src)
     }
+}
+
+struct CountingCompilerSvc {
+    calls: Rc<Cell<usize>>,
+}
+
+impl CompileService for CountingCompilerSvc {
+    type Module = tcl_bytecode::ModuleAsm;
+
+    fn compile(&self, src: &str) -> Result<Self::Module, CompileError> {
+        self.compile_for_profile(src, DialectProfile::plain_tcl())
+    }
+
+    fn compile_for_profile(
+        &self,
+        src: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<Self::Module, CompileError> {
+        self.calls.set(self.calls.get() + 1);
+        CompilerSvc::for_profile(profile).compile(src)
+    }
+}
+
+struct FixedFallbackCompilerSvc;
+
+impl CompileService for FixedFallbackCompilerSvc {
+    type Module = tcl_bytecode::ModuleAsm;
+
+    fn compile(&self, src: &str) -> Result<Self::Module, CompileError> {
+        let registry = tcl_registry::CommandRegistry::build_default();
+        let ir = tcl_compiler::lowering::lower_to_ir_for_bytecode(src, &registry);
+        let cfg = build_cfg_codegen(&ir, false);
+        Ok(codegen_module(&cfg, &ir, &registry))
+    }
+}
+
+struct WrongProfileCompilerSvc;
+
+impl CompileService for WrongProfileCompilerSvc {
+    type Module = tcl_bytecode::ModuleAsm;
+
+    fn compile(&self, src: &str) -> Result<Self::Module, CompileError> {
+        CompilerSvc::for_profile(DialectProfile::by_name("tcl8.5")).compile(src)
+    }
+
+    fn compile_for_profile(
+        &self,
+        src: &str,
+        _profile: &'static DialectProfile,
+    ) -> Result<Self::Module, CompileError> {
+        self.compile(src)
+    }
+}
+
+#[test]
+fn named_profiles_reject_fixed_or_mislabelled_compile_services() {
+    let v84 = DialectProfile::by_name("tcl8.4");
+    let mut fixed = Vm::new();
+    fixed.set_dialect_profile(v84);
+    fixed.set_compiler(Box::new(FixedFallbackCompilerSvc));
+    assert_eq!(
+        fixed.eval_source("set x 1").unwrap_err().message,
+        "CompileService does not support dialect profile tcl8.4"
+    );
+
+    let mut mislabelled = Vm::new();
+    mislabelled.set_dialect_profile(v84);
+    mislabelled.set_compiler(Box::new(WrongProfileCompilerSvc));
+    assert_eq!(
+        mislabelled
+            .compile_function("lassign {a b} x")
+            .unwrap_err()
+            .message,
+        "bytecode compiled for dialect profile tcl8.5 cannot run under tcl8.4"
+    );
 }
 
 /// Run `src` on a VM pinned to `profile`, compiling for that profile exactly
@@ -457,6 +532,30 @@ fn profile_mutation_recompiles_cached_bodies_and_rejects_live_continuations() {
         foreign_vm.run_module(&aot).result.to_str().as_ref(),
         "bytecode compiled for dialect profile tcl8.5 cannot run under tcl8.4"
     );
+    let generic_registry = tcl_registry::CommandRegistry::build_default();
+    let generic_ir =
+        tcl_compiler::lowering::lower_to_ir_for_bytecode("lassign {a b} x", &generic_registry);
+    let generic_cfg = build_cfg_codegen(&generic_ir, false);
+    let generic_aot = codegen_module(&generic_cfg, &generic_ir, &generic_registry);
+    assert_eq!(
+        foreign_vm.run_module(&generic_aot).result.to_str().as_ref(),
+        "bytecode compiled for dialect profile tcl cannot run under tcl8.4"
+    );
+    let traced_registry = tcl_registry::registry_for_profile(v85);
+    let traced_config = tcl_lexer::LexerConfig::from_grammar(v85.grammar);
+    let traced_ir = tcl_compiler::lowering::lower_to_ir_traced_with_dialect(
+        "lassign {a b} x",
+        traced_registry,
+        traced_config,
+        v85.name,
+    );
+    let traced_cfg = build_cfg_codegen(&traced_ir, false);
+    let traced_aot = codegen_module(&traced_cfg, &traced_ir, traced_registry);
+    assert!(std::ptr::eq(traced_aot.profile, v85));
+    assert_eq!(
+        foreign_vm.run_module(&traced_aot).result.to_str().as_ref(),
+        "bytecode compiled for dialect profile tcl8.5 cannot run under tcl8.4"
+    );
 
     // The reported escape, exactly: a body compiled under 8.5 must not retain
     // its inline lassign lowering after a direct 8.4 flip, and the reverse
@@ -550,6 +649,11 @@ fn profile_mutation_recompiles_cached_bodies_and_rejects_live_continuations() {
         .eval_source("catch {c} continuation_msg; set continuation_msg")
         .expect("8.4 continuation probe compiles");
     assert_eq!(
+        continuation.code,
+        Code::Ok,
+        "catch must absorb the stale frame"
+    );
+    assert_eq!(
         continuation.result.to_str().as_ref(),
         "cannot continue bytecode after dialect profile changed"
     );
@@ -573,6 +677,38 @@ fn profile_mutation_recompiles_cached_bodies_and_rejects_live_continuations() {
         .eval_source("coroutine c2 apply {{} {yield ready; lassign {a b} x; return $x}}; c2")
         .expect("8.6 coroutine restoration compiles");
     assert_eq!(resumed.result.to_str().as_ref(), "a");
+}
+
+#[test]
+fn tcloo_method_profile_refresh_is_persisted_after_the_first_call() {
+    let calls = Rc::new(Cell::new(0));
+    let mut vm = Vm::new();
+    vm.set_dialect_profile(DialectProfile::by_name("tcl8.5"));
+    vm.set_compiler(Box::new(CountingCompilerSvc {
+        calls: Rc::clone(&calls),
+    }));
+    let setup = vm
+        .eval_source("oo::class create C {method m {} {lassign {a b} x; return $x}}; C create o")
+        .expect("class setup compiles");
+    assert!(setup.code.is_ok(), "{}", setup.result.to_str());
+
+    vm.set_dialect_profile(DialectProfile::by_name("tcl8.4"));
+    let before = calls.get();
+    let first = vm.invoke_command("o", &[tcl_vm::Value::string("m")]);
+    let after_first = calls.get();
+    let second = vm.invoke_command("o", &[tcl_vm::Value::string("m")]);
+    assert_eq!(first.code, Code::Error);
+    assert_eq!(second.code, Code::Error);
+    assert_eq!(
+        after_first,
+        before + 1,
+        "first call recompiles the method once"
+    );
+    assert_eq!(
+        calls.get(),
+        after_first,
+        "second call reuses the refreshed method"
+    );
 }
 
 /// Renaming an import moves its local key, not its source provenance.  A

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -525,6 +525,54 @@ fn refused_alias_rename_preserves_a_hidden_destination_for_later_releases() {
     assert_eq!(probe.result.to_str().as_ref(), "::src::a b enter");
 }
 
+/// `rename command {}` is deletion, not the failed-rename transaction path:
+/// it drops the command's provenance and traces, leaves alias targets and
+/// import sources alone, and deletes a visible builtin on every release that
+/// exposes it.
+#[test]
+fn empty_rename_destination_deletes_commands_across_indirections() {
+    let src = concat!(
+        "proc tracer args {puts \"trace:[join $args |]\"}\n",
+        "proc owned {} {}\n",
+        "trace add command owned delete tracer\n",
+        "interp alias {} alias {} set\n",
+        "namespace eval source {proc imported {} {}; namespace export imported}\n",
+        "namespace eval imported {namespace import ::source::imported}\n",
+        "rename owned {}\n",
+        "rename alias {}\n",
+        "rename ::imported::imported {}\n",
+        "puts \"owned=[info commands owned] alias=[info commands alias] target=[info commands set] imported=[info commands ::imported::imported] source=[info commands ::source::imported]\"\n",
+        "rename lassign {}\n",
+        "set builtin [string cat las sign]\n",
+        "puts \"builtin=[catch {$builtin {a b} x} message];$message\"\n",
+    );
+    let want = concat!(
+        "trace:::owned||delete\n",
+        "owned= alias= target=set imported= source=::source::imported\n",
+        "builtin=1;invalid command name \"lassign\"",
+    );
+    for version in [
+        TclVersion::V8_5,
+        TclVersion::V8_6,
+        TclVersion::V9_0,
+        TclVersion::V9_1,
+    ] {
+        assert_eq!(
+            vm_output(src, version),
+            want,
+            "[{version:?}] empty rename destination"
+        );
+    }
+    for (env, names) in [
+        ("TCLSH86", &["tclsh8.6"][..]),
+        ("TCLSH90", &["tclsh9.0"][..]),
+    ] {
+        if let Some(out) = tclsh_output(env, names, src) {
+            assert_eq!(out, want, "[{env}] real Tcl oracle");
+        }
+    }
+}
+
 /// A `catch` body is compiled at run time through the VM's compile service,
 /// so an 8.5+-only spelling inside it is a *catchable* error under an 8.4
 /// pin — matching C Tcl, which defers a compile-time parse error to a

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -438,6 +438,25 @@ fn profile_mutation_recompiles_cached_bodies_and_rejects_live_continuations() {
     let handle = vm
         .compile_function("lassign {a b} handle_x; set handle_x")
         .expect("8.5 handle compiles");
+    // A reusable handle is VM-affine: another VM can have the same profile
+    // generation but must never adopt its bytecode.
+    let mut foreign_vm = Vm::new();
+    foreign_vm.set_dialect_profile(v85);
+    foreign_vm.set_compiler(Box::new(CompilerSvc::for_profile(v85)));
+    assert_eq!(
+        foreign_vm.invoke_function(&handle).result.to_str().as_ref(),
+        "FunctionHandle belongs to a different Vm"
+    );
+    // AOT modules carry the profile they were lowered for and are rejected at
+    // the entry boundary instead of being stamped with the VM's generation.
+    let aot = CompilerSvc::for_profile(v85)
+        .compile("set profile_aot 1")
+        .expect("AOT module compiles");
+    foreign_vm.set_dialect_profile(v84);
+    assert_eq!(
+        foreign_vm.run_module(&aot).result.to_str().as_ref(),
+        "bytecode compiled for dialect profile tcl8.5 cannot run under tcl8.4"
+    );
 
     // The reported escape, exactly: a body compiled under 8.5 must not retain
     // its inline lassign lowering after a direct 8.4 flip, and the reverse

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -1023,6 +1023,21 @@ set result [p]
 puts [list $result $log]
 ";
 
+// Removing one pending registration skips only that entry; later entries in
+// the captured Tcl trace list still fire.
+const EXECUTION_TRACE_REMOVAL_CONTINUES_SNAPSHOT: &str = r"
+set log {}
+proc p {} {return ok}
+proc a args {lappend ::log A}
+proc b args {lappend ::log B}
+proc c args {lappend ::log C; trace remove execution p enter b}
+trace add execution p enter a
+trace add execution p enter b
+trace add execution p enter c
+p
+puts $log
+";
+
 #[test]
 fn active_coroutine_and_execution_trace_follow_self_hide() {
     for profile in [
@@ -1061,6 +1076,10 @@ fn active_coroutine_and_execution_trace_follow_self_hide() {
             profile_output(EXECUTION_TRACE_ORDER_AND_LEAVE_RESULT_CHAIN, profile),
             "ORIG {{B p enter} {A p enter} {A p 0 ORIG leave} {B p 0 R1 leave}}"
         );
+        assert_eq!(
+            profile_output(EXECUTION_TRACE_REMOVAL_CONTINUES_SNAPSHOT, profile),
+            "C A"
+        );
     }
 }
 
@@ -1097,6 +1116,7 @@ fn self_hide_vectors_match_real_tcl_when_available() {
                 EXECUTION_TRACE_ORDER_AND_LEAVE_RESULT_CHAIN,
                 "ORIG {{B p enter} {A p enter} {A p 0 ORIG leave} {B p 0 R1 leave}}",
             ),
+            (EXECUTION_TRACE_REMOVAL_CONTINUES_SNAPSHOT, "C A"),
         ] {
             if let Some(actual) = tclsh_output(env, names, script) {
                 assert_eq!(actual, expected, "{env}");

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -691,6 +691,27 @@ fn hide_expose_moves_traces_without_callbacks() {
 }
 
 #[test]
+fn root_invokehidden_dispatches_without_exposing_the_command() {
+    let src = concat!(
+        "proc a {} {return A}\n",
+        "interp hide {} a held\n",
+        "puts \"hidden=[interp invokehidden {} held]\"\n",
+        "puts \"visible=[llength [info commands held]] listed=[interp hidden {}]\"\n",
+    );
+    let want = "hidden=A\nvisible=0 listed=held";
+    for version in [TclVersion::V8_6, TclVersion::V9_0, TclVersion::V9_1] {
+        assert_eq!(
+            vm_output(src, version),
+            want,
+            "[{version:?}] root invokehidden"
+        );
+    }
+    if let Some(out) = tclsh_output("TCLSH90", &["tclsh9.0"], src) {
+        assert_eq!(out, want, "[TCLSH90] real Tcl oracle");
+    }
+}
+
+#[test]
 fn child_hide_expose_moves_traces_for_named_and_by_id_forms() {
     let src = concat!(
         "interp create named; interp create byid\n",

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -690,6 +690,30 @@ fn hide_expose_moves_traces_without_callbacks() {
     }
 }
 
+#[test]
+fn child_hide_expose_moves_traces_for_named_and_by_id_forms() {
+    let src = concat!(
+        "interp create named; interp create byid\n",
+        "named eval {proc a {} {return N}; proc cb args {lappend ::events [lindex $args end]}; trace add execution a enter cb}\n",
+        "interp hide named a held; puts \"named-hidden=[interp invokehidden named held]\"; interp expose named held moved\n",
+        "puts \"named=[named eval {list [moved] [llength [trace info execution moved]] $::events}]\"\n",
+        "byid eval {proc a {} {return I}; proc cb args {lappend ::events [lindex $args end]}; trace add execution a enter cb}\n",
+        "byid hide a; puts \"byid-hidden=[byid invokehidden a]\"; byid expose a\n",
+        "puts \"byid=[byid eval {list [a] [llength [trace info execution a]] $::events}]\"\n",
+    );
+    let want = "named-hidden=N\nnamed=N 1 {enter enter}\nbyid-hidden=I\nbyid=I 1 {enter enter}";
+    for version in [TclVersion::V8_6, TclVersion::V9_0, TclVersion::V9_1] {
+        assert_eq!(
+            vm_output(src, version),
+            want,
+            "[{version:?}] child trace move"
+        );
+    }
+    if let Some(out) = tclsh_output("TCLSH90", &["tclsh9.0"], src) {
+        assert_eq!(out, want, "[TCLSH90] real Tcl oracle");
+    }
+}
+
 /// A `catch` body is compiled at run time through the VM's compile service,
 /// so an 8.5+-only spelling inside it is a *catchable* error under an 8.4
 /// pin — matching C Tcl, which defers a compile-time parse error to a

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -437,6 +437,87 @@ fn renamed_imports_preserve_origin_through_nested_imports() {
     }
 }
 
+/// A refused alias rename must undo the retargeting of every import that had
+/// followed the provisional new name.  This covers direct and nested
+/// `namespace origin` lookups, and proves qualified `namespace forget` still
+/// recognises the original source.
+#[test]
+fn refused_alias_rename_restores_import_provenance() {
+    let src = concat!(
+        "namespace eval src {interp alias {} ::src::a {} b; namespace export a}\n",
+        "namespace eval one {namespace import ::src::a; namespace export a}\n",
+        "namespace eval two {namespace import ::one::a}\n",
+        "puts \"rename=[catch {rename ::src::a b} m];$m\"\n",
+        "puts \"one=[namespace origin ::one::a]\"\n",
+        "puts \"two=[namespace origin ::two::a]\"\n",
+        "namespace eval one {namespace forget ::src::a}\n",
+        "puts \"forgot=[info commands ::one::a]\"\n",
+    );
+    let want = concat!(
+        "rename=1;cannot define or rename alias \"b\": would create a loop\n",
+        "one=::src::a\n",
+        "two=::src::a\n",
+        "forgot=",
+    );
+    for version in [
+        TclVersion::V8_4,
+        TclVersion::V8_5,
+        TclVersion::V8_6,
+        TclVersion::V9_0,
+        TclVersion::V9_1,
+    ] {
+        assert_eq!(
+            vm_output(src, version),
+            want,
+            "[{version:?}] refused alias rename"
+        );
+    }
+    for (env, names) in [
+        ("TCLSH86", &["tclsh8.6"][..]),
+        ("TCLSH90", &["tclsh9.0"][..]),
+    ] {
+        if let Some(out) = tclsh_output(env, names, src) {
+            assert_eq!(out, want, "[{env}] real Tcl oracle");
+        }
+    }
+}
+
+/// The provisional alias can replace an engine-registered command that is
+/// hidden by the current release.  Restoring that destination is essential:
+/// a later release change must reveal the original builtin, not a command
+/// table hole left by the rejected rename.
+#[test]
+fn refused_alias_rename_preserves_a_hidden_destination_for_later_releases() {
+    let mut vm = Vm::new();
+    vm.set_dialect_profile(DialectProfile::by_name("tcl8.4"));
+    vm.set_compiler(Box::new(CompilerSvc::for_profile(DialectProfile::by_name(
+        "tcl8.4",
+    ))));
+    let setup = vm
+        .eval_source(
+            "namespace eval src {interp alias {} ::src::a {} lassign; namespace export a}\n\
+             namespace eval imported {namespace import ::src::a}\n\
+             catch {rename ::src::a lassign} message\n\
+             list $message [namespace origin ::imported::a]\n",
+        )
+        .expect("8.4 setup compiles");
+    assert!(setup.code.is_ok());
+    assert_eq!(
+        setup.result.to_str().as_ref(),
+        "{cannot define or rename alias \"lassign\": would create a loop} ::src::a"
+    );
+
+    vm.set_dialect_profile(DialectProfile::by_name("tcl8.5"));
+    vm.set_compiler(Box::new(CompilerSvc::for_profile(DialectProfile::by_name(
+        "tcl8.5",
+    ))));
+    let probe = vm
+        .eval_source("list [namespace origin ::imported::a] [lassign {a b} value]\n")
+        .expect("8.5 probe compiles");
+    assert!(probe.code.is_ok());
+    assert_eq!(probe.result.to_str().as_ref(), "::src::a b");
+}
+
 /// A `catch` body is compiled at run time through the VM's compile service,
 /// so an 8.5+-only spelling inside it is a *catchable* error under an 8.4
 /// pin — matching C Tcl, which defers a compile-time parse error to a

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -897,6 +897,115 @@ fn vendor_profile_masks_differ_from_the_plain_release() {
     );
 }
 
+const SELF_HIDING_COROUTINE: &str = r"
+set first [coroutine c apply {{} {
+    interp hide {} [info coroutine] held
+    yield first
+    interp expose {} held d
+    yield second
+    return done
+}}]
+puts [list $first [interp invokehidden {} held] [d] [interp hidden {}]]
+";
+
+const SELF_HIDING_TRACED_COMMAND: &str = r"
+set log {}
+proc tr args {lappend ::log $args}
+proc p {} {interp hide {} p held; return ok}
+trace add execution p {enter leave} tr
+set result [p]
+puts [list $result $log [interp hidden {}]]
+";
+
+const SELF_EXPOSING_TRACED_COMMAND: &str = r"
+set log {}
+proc tr args {lappend ::log $args}
+proc p {} {interp expose {} held q; return ok}
+trace add execution p {enter leave} tr
+interp hide {} p held
+set result [interp invokehidden {} held]
+puts [list $result $log [info commands q] [interp hidden {}]]
+";
+
+const SELF_RENAMING_TRACED_COMMAND: &str = r"
+set log {}
+proc tr args {lappend ::log $args}
+proc p {} {rename p q; return ok}
+trace add execution p {enter leave} tr
+set result [p]
+puts [list $result $log [info commands q]]
+";
+
+const SELF_HIDING_TRACED_ERROR: &str = r"
+set log {}
+proc tr args {lappend ::log $args}
+proc p {} {interp hide {} p held; error boom}
+trace add execution p {enter leave} tr
+set code [catch {p} result]
+puts [list $code $result $log [interp hidden {}]]
+";
+
+#[test]
+fn active_coroutine_and_execution_trace_follow_self_hide() {
+    for profile in [
+        DialectProfile::by_name("tcl8.6"),
+        DialectProfile::by_name("tcl9.0"),
+    ] {
+        assert_eq!(
+            profile_output(SELF_HIDING_COROUTINE, profile),
+            "first second done {}"
+        );
+        assert_eq!(
+            profile_output(SELF_HIDING_TRACED_COMMAND, profile),
+            "ok {{p enter} {p 0 ok leave}} held"
+        );
+        assert_eq!(
+            profile_output(SELF_EXPOSING_TRACED_COMMAND, profile),
+            "ok {{held enter} {held 0 ok leave}} q {}"
+        );
+        assert_eq!(
+            profile_output(SELF_RENAMING_TRACED_COMMAND, profile),
+            "ok {{p enter} {p 0 ok leave}} q"
+        );
+        assert_eq!(
+            profile_output(SELF_HIDING_TRACED_ERROR, profile),
+            "1 boom {{p enter} {p 1 boom leave}} held"
+        );
+    }
+}
+
+#[test]
+fn self_hide_vectors_match_real_tcl_when_available() {
+    for (env, names) in [
+        ("TCLSH86", &["tclsh8.6", "tclsh"][..]),
+        ("TCLSH90", &["tclsh9.0"][..]),
+    ] {
+        for (script, expected) in [
+            (SELF_HIDING_COROUTINE, "first second done {}"),
+            (
+                SELF_HIDING_TRACED_COMMAND,
+                "ok {{p enter} {p 0 ok leave}} held",
+            ),
+            (
+                SELF_EXPOSING_TRACED_COMMAND,
+                "ok {{held enter} {held 0 ok leave}} q {}",
+            ),
+            (
+                SELF_RENAMING_TRACED_COMMAND,
+                "ok {{p enter} {p 0 ok leave}} q",
+            ),
+            (
+                SELF_HIDING_TRACED_ERROR,
+                "1 boom {{p enter} {p 1 boom leave}} held",
+            ),
+        ] {
+            if let Some(actual) = tclsh_output(env, names, script) {
+                assert_eq!(actual, expected, "{env}");
+            }
+        }
+    }
+}
+
 /// Run `src` under a real tclsh, or `None` when that binary isn't available.
 fn tclsh_output(bin_env: &str, names: &[&str], src: &str) -> Option<String> {
     use std::io::Write as _;

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -1009,6 +1009,20 @@ set new [a]
 puts [list $old $log $new]
 ";
 
+// Tcl runs enter callbacks newest-first, then leave callbacks oldest-first.
+// Each successful leave result feeds the next callback, but never replaces
+// the traced command's completion.
+const EXECUTION_TRACE_ORDER_AND_LEAVE_RESULT_CHAIN: &str = r"
+set log {}
+proc p {} {return ORIG}
+proc a args {lappend ::log [list A {*}$args]; return R1}
+proc b args {lappend ::log [list B {*}$args]; return R2}
+trace add execution p {enter leave} a
+trace add execution p {enter leave} b
+set result [p]
+puts [list $result $log]
+";
+
 #[test]
 fn active_coroutine_and_execution_trace_follow_self_hide() {
     for profile in [
@@ -1043,6 +1057,10 @@ fn active_coroutine_and_execution_trace_follow_self_hide() {
             profile_output(LEAVE_TRACE_DELETE_RECREATE_STOPS_OLD_LIST, profile),
             "old A new"
         );
+        assert_eq!(
+            profile_output(EXECUTION_TRACE_ORDER_AND_LEAVE_RESULT_CHAIN, profile),
+            "ORIG {{B p enter} {A p enter} {A p 0 ORIG leave} {B p 0 R1 leave}}"
+        );
     }
 }
 
@@ -1075,6 +1093,10 @@ fn self_hide_vectors_match_real_tcl_when_available() {
                 "1 boom {{p enter} {p 1 boom leave}} held",
             ),
             (LEAVE_TRACE_DELETE_RECREATE_STOPS_OLD_LIST, "old A new"),
+            (
+                EXECUTION_TRACE_ORDER_AND_LEAVE_RESULT_CHAIN,
+                "ORIG {{B p enter} {A p enter} {A p 0 ORIG leave} {B p 0 R1 leave}}",
+            ),
         ] {
             if let Some(actual) = tclsh_output(env, names, script) {
                 assert_eq!(actual, expected, "{env}");

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -237,6 +237,206 @@ fn command_surface_follows_the_emulated_release() {
     }
 }
 
+/// A release-hidden builtin must stay hidden when Tcl code tries to move it
+/// out of the registry's namespace.  `rename` and `interp hide` both remove a
+/// command table entry before restoring it under another spelling; that
+/// removal must consult the same surface gate as ordinary dispatch.
+#[test]
+fn hidden_builtin_cannot_escape_through_rename_or_hide() {
+    let src = concat!(
+        "puts \"direct=[catch {lassign {a b} x y} msg];$msg\"\n",
+        "puts \"rename=[catch {rename lassign la} msg];$msg\"\n",
+        "puts \"alias=[catch {la {a b} x y} msg];$msg\"\n",
+        "puts \"hide=[catch {interp hide {} lassign} msg];$msg\"\n",
+        "puts \"expose=[catch {interp expose {} lassign la} msg];$msg\"\n",
+        "puts \"after-hide=[catch {la {a b} x y} msg];$msg\"\n",
+        "puts \"vars=[info exists x],[info exists y]\"\n",
+    );
+    assert_eq!(
+        vm_output(src, TclVersion::V8_4),
+        concat!(
+            "direct=1;invalid command name \"lassign\"\n",
+            "rename=1;can't rename \"lassign\": command doesn't exist\n",
+            "alias=1;invalid command name \"la\"\n",
+            "hide=0;\n",
+            "expose=0;\n",
+            "after-hide=1;invalid command name \"la\"\n",
+            "vars=0,0",
+        )
+    );
+    assert_eq!(
+        vm_output(src, TclVersion::V9_0),
+        concat!(
+            "direct=0;\n",
+            "rename=0;\n",
+            "alias=0;\n",
+            "hide=0;\n",
+            "expose=0;\n",
+            "after-hide=0;\n",
+            "vars=1,1",
+        )
+    );
+}
+
+/// Every public command-table mutation and indirection preserves the release
+/// surface.  In particular, child-interpreter hide used to mutate the parked
+/// table directly, and import used a cloned builtin without its final source
+/// identity, so both could expose `lassign` to an emulated 8.4 VM.
+#[test]
+fn hidden_builtin_stays_hidden_through_children_imports_and_aliases() {
+    let src = concat!(
+        "interp create child\n",
+        "namespace export lassign\n",
+        "namespace eval imported {namespace import ::lassign}\n",
+        "puts \"same-hide=[catch {interp hide {} lassign la} m];$m\"\n",
+        "puts \"same-hidden=[info commands la]\"\n",
+        "puts \"same-expose=[catch {interp expose {} la lassign2} m];$m\"\n",
+        "puts \"same-call=[catch {lassign2 {a b} x} m];$m\"\n",
+        "puts \"child-hide=[catch {interp hide child lassign la} m];$m\"\n",
+        "puts \"child-hidden=[child hidden]\"\n",
+        "puts \"child-expose=[catch {interp expose child la lassign2} m];$m\"\n",
+        "puts \"child-call=[catch {child eval {lassign2 {a b} x}} m];$m\"\n",
+        "interp create child_command\n",
+        "puts \"child-command-hide=[catch {child_command hide lassign} m];$m\"\n",
+        "puts \"child-command-hidden=[child_command hidden]\"\n",
+        "puts \"child-command-expose=[catch {child_command expose lassign} m];$m\"\n",
+        "puts \"child-command-call=[catch {child_command eval {lassign {a b} x}} m];$m\"\n",
+        "puts \"import-visible=[namespace eval imported {info commands lassign}]\"\n",
+        "puts \"import-origin=[catch {namespace eval imported {namespace origin lassign}} m];$m\"\n",
+        "puts \"import-call=[catch {namespace eval imported {lassign {a b} x}} m];$m\"\n",
+        "interp alias {} alias {} lassign\n",
+        "puts \"alias-call=[catch {alias {a b} x} m];$m\"\n",
+    );
+    assert_eq!(
+        vm_output(src, TclVersion::V8_4),
+        concat!(
+            "same-hide=0;\n",
+            "same-hidden=\n",
+            "same-expose=0;\n",
+            "same-call=1;invalid command name \"lassign2\"\n",
+            "child-hide=0;\n",
+            "child-hidden=\n",
+            "child-expose=0;\n",
+            "child-call=1;invalid command name \"lassign2\"\n",
+            "child-command-hide=0;\n",
+            "child-command-hidden=\n",
+            "child-command-expose=0;\n",
+            "child-command-call=1;invalid command name \"lassign\"\n",
+            "import-visible=\n",
+            "import-origin=1;invalid command name \"lassign\"\n",
+            "import-call=1;invalid command name \"lassign\"\n",
+            "alias-call=1;invalid command name \"lassign\"",
+        )
+    );
+    let want_newer = concat!(
+        "same-hide=0;\n",
+        "same-hidden=\n",
+        "same-expose=0;\n",
+        "same-call=0;b\n",
+        "child-hide=0;\n",
+        "child-hidden=la\n",
+        "child-expose=0;\n",
+        "child-call=0;b\n",
+        "child-command-hide=0;\n",
+        "child-command-hidden=lassign\n",
+        "child-command-expose=0;\n",
+        "child-command-call=0;b\n",
+        "import-visible=lassign\n",
+        "import-origin=0;::lassign2\n",
+        "import-call=0;b\n",
+        "alias-call=1;invalid command name \"lassign\"",
+    );
+    for version in [
+        TclVersion::V8_5,
+        TclVersion::V8_6,
+        TclVersion::V9_0,
+        TclVersion::V9_1,
+    ] {
+        assert_eq!(vm_output(src, version), want_newer, "[{version:?}] surface");
+    }
+    for (env, names) in [
+        ("TCLSH86", &["tclsh8.6"][..]),
+        ("TCLSH90", &["tclsh9.0"][..]),
+    ] {
+        if let Some(out) = tclsh_output(env, names, src) {
+            assert_eq!(out, want_newer, "[{env}] real Tcl oracle");
+        }
+    }
+}
+
+/// Reproduce the stateful form of the import escape: importing while the 8.5
+/// surface is active, then pinning that same interpreter to 8.4.  The local
+/// clone and provenance remain in its table, but resolution must now reject
+/// the final builtin identity.
+#[test]
+fn version_mutation_rechecks_an_existing_imports_source_identity() {
+    let mut vm = Vm::new();
+    vm.set_dialect_profile(DialectProfile::by_name("tcl8.5"));
+    vm.set_compiler(Box::new(CompilerSvc::for_profile(DialectProfile::by_name(
+        "tcl8.5",
+    ))));
+    let setup = vm
+        .eval_source(
+            "namespace export lassign\n\
+             namespace eval imported {namespace import ::lassign}\n\
+             interp hide {} lassign hidden_lassign\n\
+             interp expose {} hidden_lassign escaped\n\
+             namespace eval imported {rename lassign imported_lassign}\n",
+        )
+        .expect("8.5 import setup compiles");
+    assert!(setup.code.is_ok());
+    vm.set_dialect_profile(DialectProfile::by_name("tcl8.4"));
+    let probe = vm
+        .eval_source(
+            "catch {namespace eval imported {set cmd [string cat imported_ lass ign]; $cmd {a b} x}} imported; \\
+             catch {set cmd [string cat es caped]; $cmd {a b} x} escaped; \\
+             list $imported $escaped\n",
+        )
+        .expect("8.4 probe compiles");
+    assert_eq!(
+        probe.result.to_str().as_ref(),
+        "{invalid command name \"imported_lassign\"} {invalid command name \"escaped\"}"
+    );
+}
+
+/// Renaming an import moves its local key, not its source provenance.  A
+/// nested import must follow that renamed local key while both `namespace
+/// origin` calls still reach the original builtin, exactly as C Tcl's command
+/// token links do.
+#[test]
+fn renamed_imports_preserve_origin_through_nested_imports() {
+    let src = concat!(
+        "namespace export lassign\n",
+        "namespace eval one {namespace import ::lassign; namespace export lassign}\n",
+        "namespace eval two {namespace import ::one::lassign}\n",
+        "namespace eval one {rename lassign moved}\n",
+        "puts \"one=[namespace eval one {namespace origin moved}]\"\n",
+        "puts \"two=[namespace eval two {namespace origin lassign}]\"\n",
+        "puts \"call=[namespace eval two {lassign {a b} x}]\"\n",
+    );
+    let want = "one=::lassign\ntwo=::lassign\ncall=b";
+    for version in [
+        TclVersion::V8_5,
+        TclVersion::V8_6,
+        TclVersion::V9_0,
+        TclVersion::V9_1,
+    ] {
+        assert_eq!(
+            vm_output(src, version),
+            want,
+            "[{version:?}] renamed import"
+        );
+    }
+    for (env, names) in [
+        ("TCLSH86", &["tclsh8.6"][..]),
+        ("TCLSH90", &["tclsh9.0"][..]),
+    ] {
+        if let Some(out) = tclsh_output(env, names, src) {
+            assert_eq!(out, want, "[{env}] real Tcl oracle");
+        }
+    }
+}
+
 /// A `catch` body is compiled at run time through the VM's compile service,
 /// so an 8.5+-only spelling inside it is a *catchable* error under an 8.4
 /// pin — matching C Tcl, which defers a compile-time parse error to a

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -271,7 +271,7 @@ fn hidden_builtin_cannot_escape_through_rename_or_hide() {
             "rename=0;\n",
             "alias=0;\n",
             "hide=0;\n",
-            "expose=0;\n",
+            "expose=1;exposed command \"la\" already exists\n",
             "after-hide=0;\n",
             "vars=1,1",
         )
@@ -600,6 +600,40 @@ fn namespace_path_resolved_coroutine_rename_and_delete_keep_state_in_sync() {
         ("TCLSH86", &["tclsh8.6"][..]),
         ("TCLSH90", &["tclsh9.0"][..]),
     ] {
+        if let Some(out) = tclsh_output(env, names, src) {
+            assert_eq!(out, want, "[{env}] real Tcl oracle");
+        }
+    }
+}
+
+/// Hide/expose collisions reject before moving either binding.  The visible
+/// destination keeps both command and execution traces, and the hidden token
+/// remains invocable, matching Tcl's non-destructive failure contract.
+#[test]
+fn hide_and_expose_collisions_preserve_bindings_and_traces() {
+    let src = concat!(
+        "proc a {} {return A}; proc b {} {return B}\n",
+        "proc cb args {lappend ::events [lindex $args end]}\n",
+        "trace add command b delete cb; trace add execution b enter cb\n",
+        "interp hide {} a token\n",
+        "puts \"hide=[catch {interp hide {} b token} m];$m\"\n",
+        "puts \"expose=[catch {interp expose {} token b} m];$m\"\n",
+        "interp expose {} token restored\n",
+        "puts \"visible=[b] hidden=[restored] traces=[llength [trace info command b]],[llength [trace info execution b]] events=$::events\"\n",
+    );
+    let want = concat!(
+        "hide=1;hidden command named \"token\" already exists\n",
+        "expose=1;exposed command \"b\" already exists\n",
+        "visible=B hidden=A traces=1,1 events=enter",
+    );
+    for version in [TclVersion::V8_6, TclVersion::V9_0, TclVersion::V9_1] {
+        assert_eq!(
+            vm_output(src, version),
+            want,
+            "[{version:?}] hide collision"
+        );
+    }
+    for (env, names) in [("TCLSH90", &["tclsh9.0"][..])] {
         if let Some(out) = tclsh_output(env, names, src) {
             assert_eq!(out, want, "[{env}] real Tcl oracle");
         }

--- a/rust/tcl-vm/tests/cross_version_escapes_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_escapes_e2e.rs
@@ -48,7 +48,7 @@ use std::rc::Rc;
 use tcl_compiler::cfg_builder::build_cfg_codegen;
 use tcl_compiler::codegen::codegen_module;
 use tcl_compiler::lowering::lower_to_ir_for_bytecode_with_dialect as lower_to_ir;
-use tcl_dialect::TclVersion;
+use tcl_dialect::{DialectProfile, TclVersion};
 use tcl_registry::CommandRegistry;
 use tcl_vm::{CompileError, CompileService, Vm};
 
@@ -88,6 +88,27 @@ impl CompileService for CompilerSvc {
         let cfg = build_cfg_codegen(&ir, false);
         Ok(codegen_module(&cfg, &ir, &self.registry))
     }
+
+    fn compile_for_profile(
+        &self,
+        src: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        let registry = tcl_registry::registry_for_profile(profile);
+        let config = tcl_lexer::LexerConfig::from_grammar(profile.grammar);
+        if let Some(msg) = tcl_compiler::lowering::first_fatal_parse_error_with_config(src, config)
+        {
+            return Err(CompileError(msg));
+        }
+        let ir = tcl_compiler::lowering::lower_to_ir_for_bytecode_with_dialect(
+            src,
+            registry,
+            config,
+            profile.name,
+        );
+        let cfg = build_cfg_codegen(&ir, false);
+        Ok(codegen_module(&cfg, &ir, registry))
+    }
 }
 
 /// Run `src` in the VM at `version`, returning its `puts` output.
@@ -98,15 +119,16 @@ impl CompileService for CompilerSvc {
 /// the 9.0 default.
 fn vm_output(src: &str, version: TclVersion) -> String {
     let dialect = version.dialect_name();
-    let registry = CommandRegistry::build_default();
+    let profile = DialectProfile::by_name(dialect);
+    let registry = tcl_registry::registry_for_profile(profile);
     let ir = lower_to_ir(
         src,
-        &registry,
-        tcl_lexer::LexerConfig::for_dialect(dialect),
+        registry,
+        tcl_lexer::LexerConfig::from_grammar(profile.grammar),
         dialect,
     );
     let cfg = build_cfg_codegen(&ir, false);
-    let asm = codegen_module(&cfg, &ir, &registry);
+    let asm = codegen_module(&cfg, &ir, registry);
 
     let cap = Capture::default();
     let mut vm = Vm::with_output(Box::new(cap.clone()));

--- a/rust/tcl-vm/tests/cross_version_expr_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_expr_surface_e2e.rs
@@ -56,7 +56,7 @@ use std::rc::Rc;
 use tcl_compiler::cfg_builder::build_cfg_codegen;
 use tcl_compiler::codegen::codegen_module;
 use tcl_compiler::lowering::lower_to_ir_for_bytecode_with_dialect as lower_to_ir;
-use tcl_dialect::TclVersion;
+use tcl_dialect::{DialectProfile, TclVersion};
 use tcl_registry::CommandRegistry;
 use tcl_vm::{CompileError, CompileService, Vm};
 
@@ -96,6 +96,27 @@ impl CompileService for CompilerSvc {
         let cfg = build_cfg_codegen(&ir, false);
         Ok(codegen_module(&cfg, &ir, &self.registry))
     }
+
+    fn compile_for_profile(
+        &self,
+        src: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        let registry = tcl_registry::registry_for_profile(profile);
+        let config = tcl_lexer::LexerConfig::from_grammar(profile.grammar);
+        if let Some(msg) = tcl_compiler::lowering::first_fatal_parse_error_with_config(src, config)
+        {
+            return Err(CompileError(msg));
+        }
+        let ir = tcl_compiler::lowering::lower_to_ir_for_bytecode_with_dialect(
+            src,
+            registry,
+            config,
+            profile.name,
+        );
+        let cfg = build_cfg_codegen(&ir, false);
+        Ok(codegen_module(&cfg, &ir, registry))
+    }
 }
 
 /// Run `src` in the VM at `version`, returning its `puts` output.
@@ -105,10 +126,16 @@ impl CompileService for CompilerSvc {
 /// the newest grammar's answer and `set_runtime_version` cannot undo it.
 fn vm_output(src: &str, version: TclVersion) -> String {
     let dialect = version.dialect_name();
-    let registry = CommandRegistry::build_default();
-    let ir = lower_to_ir(src, &registry, tcl_lexer::LexerConfig::default(), dialect);
+    let profile = DialectProfile::by_name(dialect);
+    let registry = tcl_registry::registry_for_profile(profile);
+    let ir = lower_to_ir(
+        src,
+        registry,
+        tcl_lexer::LexerConfig::from_grammar(profile.grammar),
+        dialect,
+    );
     let cfg = build_cfg_codegen(&ir, false);
-    let asm = codegen_module(&cfg, &ir, &registry);
+    let asm = codegen_module(&cfg, &ir, registry);
 
     let cap = Capture::default();
     let mut vm = Vm::with_output(Box::new(cap.clone()));

--- a/rust/tcl-vm/tests/cross_version_info_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_info_surface_e2e.rs
@@ -30,7 +30,7 @@ use std::rc::Rc;
 use tcl_compiler::cfg_builder::build_cfg_codegen;
 use tcl_compiler::codegen::codegen_module;
 use tcl_compiler::lowering::lower_to_ir_for_bytecode as lower_to_ir;
-use tcl_dialect::TclVersion;
+use tcl_dialect::{DialectProfile, TclVersion};
 use tcl_registry::CommandRegistry;
 use tcl_vm::{CompileError, CompileService, Vm};
 
@@ -45,6 +45,23 @@ impl CompileService for CompilerSvc {
         let ir = lower_to_ir(src, &self.registry);
         let cfg = build_cfg_codegen(&ir, false);
         Ok(codegen_module(&cfg, &ir, &self.registry))
+    }
+
+    fn compile_for_profile(
+        &self,
+        src: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        let registry = tcl_registry::registry_for_profile(profile);
+        let config = tcl_lexer::LexerConfig::from_grammar(profile.grammar);
+        let ir = tcl_compiler::lowering::lower_to_ir_for_bytecode_with_dialect(
+            src,
+            registry,
+            config,
+            profile.name,
+        );
+        let cfg = build_cfg_codegen(&ir, false);
+        Ok(codegen_module(&cfg, &ir, registry))
     }
 }
 
@@ -63,15 +80,16 @@ impl std::io::Write for Capture {
 }
 
 fn vm_output(src: &str, version: TclVersion) -> String {
-    let registry = CommandRegistry::build_default();
-    let ir = lower_to_ir(src, &registry);
-    let cfg = build_cfg_codegen(&ir, false);
-    let asm = codegen_module(&cfg, &ir, &registry);
+    let profile = DialectProfile::by_name(version.dialect_name());
+    let service = CompilerSvc {
+        registry: CommandRegistry::build_default(),
+    };
+    let asm = service
+        .compile_for_profile(src, profile)
+        .expect("test script compiles for its selected profile");
     let capture = Capture::default();
     let mut vm = Vm::with_output(Box::new(capture.clone()));
-    vm.set_compiler(Box::new(CompilerSvc {
-        registry: CommandRegistry::build_default(),
-    }));
+    vm.set_compiler(Box::new(service));
     vm.set_runtime_version(version);
     let _ = vm.run_module(&asm);
     String::from_utf8_lossy(&capture.0.borrow())

--- a/rust/tcl-vm/tests/cross_version_numerals_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_numerals_e2e.rs
@@ -44,7 +44,7 @@ use std::rc::Rc;
 use tcl_compiler::cfg_builder::build_cfg_codegen;
 use tcl_compiler::codegen::codegen_module;
 use tcl_compiler::lowering::lower_to_ir_for_bytecode_with_dialect as lower_to_ir;
-use tcl_dialect::TclVersion;
+use tcl_dialect::{DialectProfile, TclVersion};
 use tcl_registry::CommandRegistry;
 use tcl_vm::{CompileError, CompileService, Vm};
 
@@ -84,6 +84,27 @@ impl CompileService for CompilerSvc {
         let cfg = build_cfg_codegen(&ir, false);
         Ok(codegen_module(&cfg, &ir, &self.registry))
     }
+
+    fn compile_for_profile(
+        &self,
+        src: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        let registry = tcl_registry::registry_for_profile(profile);
+        let config = tcl_lexer::LexerConfig::from_grammar(profile.grammar);
+        if let Some(msg) = tcl_compiler::lowering::first_fatal_parse_error_with_config(src, config)
+        {
+            return Err(CompileError(msg));
+        }
+        let ir = tcl_compiler::lowering::lower_to_ir_for_bytecode_with_dialect(
+            src,
+            registry,
+            config,
+            profile.name,
+        );
+        let cfg = build_cfg_codegen(&ir, false);
+        Ok(codegen_module(&cfg, &ir, registry))
+    }
 }
 
 /// Run `src` in the VM at `version`, returning its `puts` output.
@@ -96,10 +117,16 @@ impl CompileService for CompilerSvc {
 /// interpreter. The dialect is a compile target, not a runtime switch.
 fn vm_output(src: &str, version: TclVersion) -> String {
     let dialect = version.dialect_name();
-    let registry = CommandRegistry::build_default();
-    let ir = lower_to_ir(src, &registry, tcl_lexer::LexerConfig::default(), dialect);
+    let profile = DialectProfile::by_name(dialect);
+    let registry = tcl_registry::registry_for_profile(profile);
+    let ir = lower_to_ir(
+        src,
+        registry,
+        tcl_lexer::LexerConfig::from_grammar(profile.grammar),
+        dialect,
+    );
     let cfg = build_cfg_codegen(&ir, false);
-    let asm = codegen_module(&cfg, &ir, &registry);
+    let asm = codegen_module(&cfg, &ir, registry);
 
     let cap = Capture::default();
     let mut vm = Vm::with_output(Box::new(cap.clone()));
@@ -373,10 +400,16 @@ fn build_vm(version: TclVersion) -> (Vm, Capture, &'static str) {
 /// Run `src` on an already-configured VM, compiling for its dialect.
 fn run_on(vm: &mut Vm, cap: &Capture, dialect: &str, src: &str) -> String {
     cap.0.borrow_mut().clear();
-    let registry = CommandRegistry::build_default();
-    let ir = lower_to_ir(src, &registry, tcl_lexer::LexerConfig::default(), dialect);
+    let profile = DialectProfile::by_name(dialect);
+    let registry = tcl_registry::registry_for_profile(profile);
+    let ir = lower_to_ir(
+        src,
+        registry,
+        tcl_lexer::LexerConfig::from_grammar(profile.grammar),
+        dialect,
+    );
     let cfg = build_cfg_codegen(&ir, false);
-    let asm = codegen_module(&cfg, &ir, &registry);
+    let asm = codegen_module(&cfg, &ir, registry);
     let _ = vm.run_module(&asm);
     String::from_utf8_lossy(&cap.0.borrow()).trim().to_string()
 }

--- a/rust/tcl-vm/tests/cross_version_vars_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_vars_e2e.rs
@@ -41,7 +41,7 @@ use std::rc::Rc;
 use tcl_compiler::cfg_builder::build_cfg_codegen;
 use tcl_compiler::codegen::codegen_module;
 use tcl_compiler::lowering::lower_to_ir_for_bytecode as lower_to_ir;
-use tcl_dialect::TclVersion;
+use tcl_dialect::{DialectProfile, TclVersion};
 use tcl_registry::CommandRegistry;
 use tcl_vm::{CompileError, CompileService, Vm};
 
@@ -60,6 +60,33 @@ impl CompileService for CompilerSvc {
         let cfg = build_cfg_codegen(&ir, false);
         Ok(codegen_module(&cfg, &ir, &self.registry))
     }
+
+    fn compile_for_profile(
+        &self,
+        src: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        compile_exact_profile(src, profile)
+    }
+}
+
+fn compile_exact_profile(
+    src: &str,
+    profile: &'static DialectProfile,
+) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+    let registry = tcl_registry::registry_for_profile(profile);
+    let config = tcl_lexer::LexerConfig::from_grammar(profile.grammar);
+    if let Some(msg) = tcl_compiler::lowering::first_fatal_parse_error_with_config(src, config) {
+        return Err(CompileError(msg));
+    }
+    let ir = tcl_compiler::lowering::lower_to_ir_for_bytecode_with_dialect(
+        src,
+        registry,
+        config,
+        profile.name,
+    );
+    let cfg = build_cfg_codegen(&ir, false);
+    Ok(codegen_module(&cfg, &ir, registry))
 }
 
 #[derive(Clone, Default)]
@@ -79,16 +106,17 @@ impl std::io::Write for Capture {
 /// (the vectors communicate through stdout so the tclsh leg is directly
 /// comparable).
 fn vm_output(src: &str, version: TclVersion) -> String {
-    let registry = CommandRegistry::build_default();
-    let ir = lower_to_ir(src, &registry);
-    let cfg = build_cfg_codegen(&ir, false);
-    let asm = codegen_module(&cfg, &ir, &registry);
+    let profile = DialectProfile::by_name(version.dialect_name());
+    let service = CompilerSvc {
+        registry: CommandRegistry::build_default(),
+    };
+    let asm = service
+        .compile_for_profile(src, profile)
+        .expect("test script compiles for its selected profile");
 
     let cap = Capture::default();
     let mut vm = Vm::with_output(Box::new(cap.clone()));
-    vm.set_compiler(Box::new(CompilerSvc {
-        registry: CommandRegistry::build_default(),
-    }));
+    vm.set_compiler(Box::new(service));
     vm.set_runtime_version(version);
     let _ = vm.run_module(&asm);
     String::from_utf8_lossy(&cap.0.borrow()).trim().to_string()

--- a/rust/tcl-vm/tests/embed_api_e2e.rs
+++ b/rust/tcl-vm/tests/embed_api_e2e.rs
@@ -31,6 +31,7 @@ use std::rc::Rc;
 use tcl_compiler::cfg_builder::build_cfg_codegen;
 use tcl_compiler::codegen::codegen_module;
 use tcl_compiler::lowering::lower_to_ir_for_bytecode as lower_to_ir;
+use tcl_dialect::DialectProfile;
 use tcl_registry::CommandRegistry;
 use tcl_vm::{Code, CompileError, CompileService, Completion, NativeCommand, Value, Vm};
 
@@ -117,6 +118,32 @@ fn an_embedder_command_carries_its_own_state() {
             vec!["role".to_string(), "1".to_string(), "body".to_string()],
         ],
     );
+}
+
+#[test]
+fn native_mathfunc_identity_survives_rename_and_hide_expose_across_profiles() {
+    let mut vm = vm();
+    let recorder = Rc::new(Recorder {
+        calls: RefCell::new(Vec::new()),
+    });
+    vm.register_native_command("tcl::mathfunc::isfinite", recorder);
+    vm.set_dialect_profile(DialectProfile::by_name("tcl9.0"));
+    assert!(
+        vm.eval_source("rename ::tcl::mathfunc::isfinite finite")
+            .unwrap()
+            .code
+            .is_ok()
+    );
+    assert!(vm.invoke_command("finite", &[]).code.is_ok());
+    assert!(
+        vm.eval_source("interp hide {} finite held; interp expose {} held finite2")
+            .unwrap()
+            .code
+            .is_ok()
+    );
+    assert!(vm.invoke_command("finite2", &[]).code.is_ok());
+    vm.set_dialect_profile(DialectProfile::by_name("tcl8.6"));
+    assert!(!vm.invoke_command("finite2", &[]).code.is_ok());
 }
 
 /// A loop whose body really dispatches — `[$cmd length abc]` resolves a

--- a/rust/tcl-vm/tests/embed_api_e2e.rs
+++ b/rust/tcl-vm/tests/embed_api_e2e.rs
@@ -52,6 +52,27 @@ impl CompileService for CompilerSvc {
         let cfg = build_cfg_codegen(&ir, false);
         Ok(codegen_module(&cfg, &ir, &self.registry))
     }
+
+    fn compile_for_profile(
+        &self,
+        src: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        let registry = tcl_registry::registry_for_profile(profile);
+        let config = tcl_lexer::LexerConfig::from_grammar(profile.grammar);
+        if let Some(msg) = tcl_compiler::lowering::first_fatal_parse_error_with_config(src, config)
+        {
+            return Err(CompileError(msg));
+        }
+        let ir = tcl_compiler::lowering::lower_to_ir_for_bytecode_with_dialect(
+            src,
+            registry,
+            config,
+            profile.name,
+        );
+        let cfg = build_cfg_codegen(&ir, false);
+        Ok(codegen_module(&cfg, &ir, registry))
+    }
 }
 
 fn vm() -> Vm {

--- a/rust/tcl-vm/tests/embed_api_e2e.rs
+++ b/rust/tcl-vm/tests/embed_api_e2e.rs
@@ -121,6 +121,44 @@ fn a_compiled_handle_runs_repeatedly_without_recompiling() {
 }
 
 #[test]
+fn raw_function_execution_is_fallback_only_and_cannot_bypass_module_profile() {
+    let service = CompilerSvc {
+        registry: CommandRegistry::build_default(),
+    };
+    let v85 = DialectProfile::by_name("tcl8.5");
+    let named = service
+        .compile_for_profile("lassign {a b} x; set x", v85)
+        .expect("named-profile module compiles");
+
+    let mut v84_vm = vm();
+    v84_vm.set_dialect_profile(DialectProfile::by_name("tcl8.4"));
+    let rejected = v84_vm.run_function(&named.top_level);
+    assert_eq!(rejected.code, Code::Error);
+    assert_eq!(
+        rejected.result.to_str().as_ref(),
+        "profile-less bytecode cannot run under dialect profile tcl8.4"
+    );
+
+    // The low-level opcode/embedder contract remains available deliberately
+    // on the permissive fallback VM, where no named-profile claim is made.
+    let fallback = service
+        .compile("set fallback_ok yes; set fallback_ok")
+        .expect("fallback module compiles");
+    let mut fallback_vm = vm();
+    let completion = fallback_vm.run_function(&fallback.top_level);
+    assert!(completion.code.is_ok(), "{}", completion.result.to_str());
+    assert_eq!(completion.result.to_str().as_ref(), "yes");
+
+    // The supported named-profile AOT entry remains the profile-bearing
+    // module API, including same-profile execution.
+    let mut v85_vm = vm();
+    v85_vm.set_dialect_profile(v85);
+    let completion = v85_vm.run_module(&named);
+    assert!(completion.code.is_ok(), "{}", completion.result.to_str());
+    assert_eq!(completion.result.to_str().as_ref(), "a");
+}
+
+#[test]
 fn an_embedder_command_carries_its_own_state() {
     let mut vm = vm();
     let recorder = Rc::new(Recorder {

--- a/rust/tcl-vm/tests/embed_api_e2e.rs
+++ b/rust/tcl-vm/tests/embed_api_e2e.rs
@@ -146,6 +146,28 @@ fn native_mathfunc_identity_survives_rename_and_hide_expose_across_profiles() {
     assert!(!vm.invoke_command("finite2", &[]).code.is_ok());
 }
 
+#[test]
+fn embedder_can_remove_a_builtin_hidden_by_the_current_release() {
+    let mut vm = vm();
+    vm.set_dialect_profile(DialectProfile::by_name("tcl8.4"));
+    assert!(
+        !vm.invoke_command("lassign", &[]).code.is_ok(),
+        "lassign is outside Tcl 8.4's public surface"
+    );
+
+    assert!(
+        vm.remove_command("lassign"),
+        "embedder teardown must see the raw registered command"
+    );
+    assert!(!vm.command_names().iter().any(|name| name == "lassign"));
+
+    vm.set_dialect_profile(DialectProfile::by_name("tcl8.5"));
+    assert!(
+        !vm.invoke_command("lassign", &[]).code.is_ok(),
+        "changing release must not revive a command removed by the embedder"
+    );
+}
+
 /// A loop whose body really dispatches — `[$cmd length abc]` resolves a
 /// computed command name, so each iteration is a command the limit charges.
 const DISPATCHING_LOOP: &str =

--- a/rust/tcl-vm/tests/opcode_c_parity.rs
+++ b/rust/tcl-vm/tests/opcode_c_parity.rs
@@ -1120,6 +1120,7 @@ fn vm_with_seeded_proc(body: Asm) -> Vm {
     let mut procedures = HashMap::new();
     procedures.insert("p".to_string(), body.build());
     let module = ModuleAsm {
+        profile: tcl_dialect::DialectProfile::plain_tcl(),
         top_level: Asm::new().build(),
         procedures,
     };

--- a/rust/tcl-vm/tests/run_script.rs
+++ b/rust/tcl-vm/tests/run_script.rs
@@ -1216,6 +1216,7 @@ fn run_asm(literals: &[&str], instrs: Vec<tcl_bytecode::Instruction>) -> String 
         error_regions: Vec::new(),
     };
     let module = ModuleAsm {
+        profile: tcl_dialect::DialectProfile::plain_tcl(),
         top_level: top,
         procedures: std::collections::HashMap::new(),
     };

--- a/rust/tcl-vm/tests/safe_interp_e2e.rs
+++ b/rust/tcl-vm/tests/safe_interp_e2e.rs
@@ -104,6 +104,16 @@ fn hidden_command_direct_call_raises_invalid_command_name() {
     );
 }
 
+#[test]
+fn marktrusted_preserves_a_visible_command_colliding_with_hidden_token() {
+    let (ok, out) = run("interp create -safe s\n\
+         s eval {proc open args {return mine}}\n\
+         interp marktrusted s\n\
+         puts [list [s eval {open}] [expr {[lsearch -exact [interp hidden s] open] >= 0}]]\n");
+    assert!(ok, "marktrusted collision vector must complete: {out}");
+    assert_eq!(out, "mine 1");
+}
+
 /// TP: the same hidden command reached via `{*}[list source ...]` — the
 /// runtime must reject this exactly like the direct call, independent of
 /// whether the static W129 lint catches the shape.


### PR DESCRIPTION
## Issues

Closes #1463.

This addresses only the reopened native-VM residual. Direct dispatch and `runtime/rust` were already fixed.

## Root cause

`Vm::take_command` and several indirect command-move paths did not preserve or consult a builtin's final registry identity. Tcl 8.4 could therefore rename, hide/expose, import, or alias an 8.5+ builtin such as `lassign` under an unknown spelling and call it.

## Fix

- Gate public command removal through the active release surface.
- Keep an explicit unchecked removal path only for VM-owned teardown/rollback.
- Route same-interpreter and named-child hide paths through the gate.
- Preserve stable builtin identity and import origin through import, rename, hide/expose, and `marktrusted` moves.
- Preflight aliases through normal target resolution and keep `namespace origin`/bytecode command information visibility-aware.

## Dialect/release behaviour

- Tcl 8.4 rejects hidden/renamed/imported/aliased `lassign` escape paths.
- Tcl 8.5, 8.6, 9.0, and 9.1 positive vectors remain callable.
- Profile mutation from 8.5 to 8.4 fails closed even after hide/expose or import/rename moves.
- Profileless behavior remains the existing explicitly documented permissive union.

## Duplication audit

- Audited every `take_command` and direct `commands.remove` caller.
- Public rename/hide/expose paths are gated; apply/coroutine/TclOO cleanup remains deliberately unchecked.
- Compared the native design and vectors with `runtime/rust` final-identity dispatch.

## Tests

- Same-interpreter and both named-child hide APIs.
- Rename, alias, import, nested import, hide/expose, and namespace-origin provenance.
- 8.4 negative and 8.5+ positive vectors.
- Stateful 8.5→8.4 mutation regressions for direct and imported commands.
- Tcl 8.6/9.0 oracle comparisons.
- Independent Terra adversarial review with all bypass findings fixed.

## Gates

- `make rust-check`
- `make prep-pr`
- `make test-rust` (includes native LSP E2E)
- `make test-ext`

All passed on `6238ed306`.

## Generated artefacts/docs

No generated artefact or diagnostic catalogue changes.

## Performance

Adds bounded hash-map metadata lookups only at command resolution/move boundaries. No hot-loop concern was identified; final #1181 measurement remains scheduled.
