### PR TITLE
Fix Spec Studio highlighting and imported code generation

### DIFF
--- a/rust/tcl-spec-studio-wasm/build-wasm.sh
+++ b/rust/tcl-spec-studio-wasm/build-wasm.sh
@@ -143,23 +143,25 @@ fi
 cp "$lspdist/worker.js" "$lspdist/tcl_lsp_server_wasm.js" \
    "$lspdist/tcl_lsp_server_wasm_bg.wasm" "$dist/lsp/"
 
-echo "==> copying the editor chunk into dist/assets/"
-cp "$web/dist/assets/monaco-host.js" "$web/dist/assets/monaco-host.css" "$dist/assets/"
+echo "==> copying the editor chunk and shared Tcl grammar into dist/assets/"
+cp "$web/dist/assets/monaco-host.js" "$web/dist/assets/monaco-host.css" \
+   "$web/dist/assets/tcl.tmLanguage.json" "$web/dist/assets/onig.wasm" "$dist/assets/"
 
 echo "==> assembling dist/index.html"
 python3 - \
     "$web/studio.html" "$web/src/studio.css" "$web/dist/studio.js" \
     "$out/tcl_spec_studio_wasm.js" "$out/tcl_spec_studio_wasm_bg.wasm" \
     "$dist/index.html" "$assets" "$dist/assets/monaco-host.js" \
-    "$dist/assets/monaco-host.css" "$dist/lsp/worker.js" \
+    "$dist/assets/monaco-host.css" "$dist/assets/tcl.tmLanguage.json" \
+    "$dist/assets/onig.wasm" "$dist/lsp/worker.js" \
     "$dist/lsp/tcl_lsp_server_wasm.js" "$dist/lsp/tcl_lsp_server_wasm_bg.wasm" \
     "$version" <<'PY'
 import base64, hashlib, json, os, sys
 (
     tmpl_path, css_path, js_path, glue_path, wasm_path, out_path, assets_dir,
-    editor_js_path, editor_css_path, lsp_worker_path, lsp_glue_path,
-    lsp_wasm_path, version,
-) = sys.argv[1:14]
+    editor_js_path, editor_css_path, grammar_path, oniguruma_path,
+    lsp_worker_path, lsp_glue_path, lsp_wasm_path, version,
+) = sys.argv[1:16]
 
 def read_bytes(path):
     with open(path, "rb") as stream:
@@ -180,6 +182,8 @@ glue_bytes = read_bytes(glue_path)
 wasm_bytes = read_bytes(wasm_path)
 editor_js_bytes = read_bytes(editor_js_path)
 editor_css_bytes = read_bytes(editor_css_path)
+grammar_bytes = read_bytes(grammar_path)
+oniguruma_bytes = read_bytes(oniguruma_path)
 lsp_worker_bytes = read_bytes(lsp_worker_path)
 lsp_glue_bytes = read_bytes(lsp_glue_path)
 lsp_wasm_bytes = read_bytes(lsp_wasm_path)
@@ -213,6 +217,8 @@ build_info = {
         asset("logo-dark", logo_bytes["__LOGO_TCL_LSP_DARK__"]),
         asset("editor-controller", editor_js_bytes),
         asset("editor-style", editor_css_bytes),
+        asset("tcl-grammar", grammar_bytes),
+        asset("oniguruma", oniguruma_bytes),
         asset("lsp-worker", lsp_worker_bytes),
         asset("lsp-wasm-glue", lsp_glue_bytes),
         asset("lsp-wasm", lsp_wasm_bytes),

--- a/rust/tcl-spec-studio-wasm/test/boot.mjs
+++ b/rust/tcl-spec-studio-wasm/test/boot.mjs
@@ -201,6 +201,28 @@ async function main() {
     );
     console.log(`    LSP: ${(await page.textContent("#lspStatus")).trim()}`);
 
+    // The success status is published only after the host has requested both
+    // semantic tokens and hover from this opened pack document.
+    console.log("    Pack DSL hover is served by the in-page LSP");
+
+    // The fallback overlay already colours the pack before Monaco arrives;
+    // prove the replacement editor gets several semantic colours from the
+    // LSP too. This catches a provider whose legend contains theme scopes
+    // instead of semantic-token identifiers: the worker is healthy, but every
+    // token settles back to Monaco's one generic text colour.
+    await page.waitForFunction(
+      () => {
+        const colours = new Set(
+          Array.from(document.querySelectorAll("#dslEditor .view-lines span[class*='mtk']"))
+            .map((node) => getComputedStyle(node).color),
+        );
+        return colours.size > 1;
+      },
+      null,
+      { timeout: 60_000 },
+    );
+    console.log("    Pack DSL semantic colours are visible in Monaco");
+
     // 4. The server actually analyses: type a broken pack line and expect the
     //    editor to show a marker. This is the difference between "the worker
     //    booted" and "the worker is doing the job".
@@ -223,16 +245,52 @@ async function main() {
     // 5. The Test tab's second editor mounts on its own model.
     await page.click("#tab-test");
     await page.waitForSelector("#testEditor .monaco-editor", { timeout: 30_000 });
+    await page.click("#testEditor .monaco-editor .view-lines");
+    await page.keyboard.press("Control+End");
+    await page.keyboard.type("set colour red\nputs $colour");
+    await page.waitForFunction(
+      () => {
+        const colours = new Set(
+          Array.from(document.querySelectorAll("#testEditor .view-lines span[class*='mtk']"))
+            .map((node) => getComputedStyle(node).color),
+        );
+        return colours.size > 1;
+      },
+      null,
+      { timeout: 60_000 },
+    );
     console.log("    Monaco mounted on the Test tab");
 
-    // 6. The Releases import mode and its GitHub panel are present and inert
+    // 6. A one-snapshot import writes the pack *and* becomes the active draft,
+    // so the generated Rust pane follows it instead of retaining `mycommand`,
+    // the placeholder draft installed at boot.
+    await page.click("#tab-import");
+    await page.setInputFiles("#picker", {
+      name: "widget.tcl",
+      mimeType: "text/plain",
+      buffer: Buffer.from("proc widget::paint {colour} { return $colour }\n", "utf8"),
+    });
+    await page.waitForSelector("#importOut .found", { timeout: 30_000 });
+    await page.click("#importAll");
+    await page.click("#tab-rs");
+    await page.waitForFunction(
+      () => {
+        const text = document.querySelector("#rsEditor .view-lines")?.textContent ?? "";
+        return text.includes("widget::paint") && !text.includes('name: "mycommand"');
+      },
+      null,
+      { timeout: 30_000 },
+    );
+    console.log("    imported Tcl activates generated Rust for the imported command");
+
+    // 7. The Releases import mode and its GitHub panel are present and inert
     //    until asked — no request is made by opening them.
     await page.click("#tab-import");
     await page.click("#imode-releases");
     await page.waitForSelector("#ghPanel:not([hidden])", { timeout: 10_000 });
     console.log("    the Releases mode and the GitHub panel are reachable");
 
-    // 7. The whole multi-release pipeline, through the real UI: two archives
+    // 8. The whole multi-release pipeline, through the real UI: two archives
     //    in, one version range out. `greet` exists in both releases and
     //    `farewell` only in the newer one, so the importer must derive
     //    `introduced 1.1` for the second and nothing for the first — the
@@ -292,7 +350,8 @@ async function main() {
         `${derived.map((c) => `${c.name} [${c.ranges.join(" ")}]`).join(", ")}`,
     );
   } catch (e) {
-    fail(e instanceof Error ? e.message : String(e));
+    const status = await page.textContent("#lspStatus").catch(() => "");
+    fail(`${e instanceof Error ? e.message : String(e)}; LSP status: ${status?.trim() ?? ""}`);
   } finally {
     await browser.close();
     server.close();

--- a/rust/tcl-spec-studio/tests/web_contract.rs
+++ b/rust/tcl-spec-studio/tests/web_contract.rs
@@ -7,6 +7,7 @@
 const HTML: &str = include_str!("../web/studio.html");
 const STUDIO_TS: &str = include_str!("../web/src/studio.ts");
 const MONACO_TS: &str = include_str!("../web/src/monacoHost.ts");
+const TEXTMATE_TS: &str = include_str!("../web/src/textmateHost.ts");
 const BUILD_INFO_TS: &str = include_str!("../web/src/buildInfo.ts");
 const BUILD_MJS: &str = include_str!("../web/build.mjs");
 
@@ -22,6 +23,25 @@ fn every_code_pane_has_the_required_initial_language() {
     assert!(MONACO_TS.contains(r#"RUST_URI, "rust", null"#));
     assert!(MONACO_TS.contains(r#"STUB_URI, TCL_LANGUAGE, "spectcl""#));
     assert!(STUDIO_TS.contains(r#"dialect: "spectcl""#));
+}
+
+#[test]
+fn monaco_preserves_the_servers_semantic_token_identifiers() {
+    assert!(MONACO_TS.contains("tokenTypes: [...client.legend.tokenTypes]"));
+    assert!(!MONACO_TS.contains("SCOPE_BY_TOKEN_TYPE"));
+    assert!(MONACO_TS.contains(r"file:///__tcl_spec_studio__/pack.tclspec"));
+    assert!(!MONACO_TS.contains("inmemory://studio"));
+    assert!(MONACO_TS.contains("registerTclGrammar"));
+    assert!(TEXTMATE_TS.contains("source.tcl"));
+    assert!(TEXTMATE_TS.contains("vscode-textmate"));
+}
+
+#[test]
+fn importing_a_pack_activates_a_renderable_command() {
+    assert!(STUDIO_TS.contains("firstWritten ??= found.name"));
+    assert!(
+        STUDIO_TS.contains("if (view.pack) loadDraft(view.pack, packOrigin(view), firstWritten)")
+    );
 }
 
 #[test]

--- a/rust/tcl-spec-studio/web/THIRD-PARTY-NOTICES.md
+++ b/rust/tcl-spec-studio/web/THIRD-PARTY-NOTICES.md
@@ -16,6 +16,8 @@ bump this file when you bump those.
 | `vscode-jsonrpc` | 9.0.1 | MIT | <https://github.com/microsoft/vscode-languageserver-node> |
 | `vscode-languageserver-protocol` | 3.18.2 | MIT | <https://github.com/microsoft/vscode-languageserver-node> |
 | `vscode-languageserver-types` | 3.18.0 | MIT | <https://github.com/microsoft/vscode-languageserver-node> |
+| `vscode-oniguruma` | 2.0.1 | MIT | <https://github.com/microsoft/vscode-oniguruma> |
+| `vscode-textmate` | 9.3.2 | MIT | <https://github.com/microsoft/vscode-textmate> |
 
 `vscode-languageserver-types` is a transitive dependency of
 `vscode-languageserver-protocol` and is bundled with it.
@@ -80,6 +82,12 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
+
+## vscode-oniguruma and vscode-textmate
+
+Both Microsoft packages carry the same MIT notice printed above for the
+language-server packages. `vscode-oniguruma` also incorporates Oniguruma, whose
+BSD-2-Clause notice is retained inside the package and the shipped `onig.wasm`.
 
 ## What is *not* third-party
 

--- a/rust/tcl-spec-studio/web/build.mjs
+++ b/rust/tcl-spec-studio/web/build.mjs
@@ -22,7 +22,7 @@
 
 import * as esbuild from "esbuild";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, rmSync } from "node:fs";
+import { copyFileSync, mkdirSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -73,6 +73,8 @@ const vendorBanner = `${banner}
 //   vscode-jsonrpc                 (c) Microsoft Corporation      — MIT
 //   vscode-languageserver-protocol (c) Microsoft Corporation      — MIT
 //   vscode-languageserver-types    (c) Microsoft Corporation      — MIT
+//   vscode-oniguruma                (c) Microsoft Corporation      — MIT/BSD-2-Clause
+//   vscode-textmate                 (c) Microsoft Corporation      — MIT
 // Full licence texts: rust/tcl-spec-studio/web/THIRD-PARTY-NOTICES.md`;
 
 rmSync(distDir, { recursive: true, force: true });
@@ -96,6 +98,15 @@ await esbuild.build({
   define: { __SPEC_STUDIO_FRONTEND_VERSION__: JSON.stringify(version) },
   logLevel: "info",
 });
+
+// Monaco has no bundled Tcl syntax. Ship the exact TextMate grammar used by
+// the VS Code extension, plus the same Oniguruma engine that executes it, so
+// the Studio's pre-semantic paint cannot drift into a second Tcl grammar.
+copyFileSync(
+  join(here, "..", "..", "..", "editors", "vscode", "syntaxes", "tcl.tmLanguage.json"),
+  join(assetsDir, "tcl.tmLanguage.json"),
+);
+copyFileSync(join(here, "node_modules", "vscode-oniguruma", "release", "onig.wasm"), join(assetsDir, "onig.wasm"));
 
 // The editor chunk. Minified, unlike the controller: this is vendored
 // third-party code whose readable form is upstream's repository, not ours, and

--- a/rust/tcl-spec-studio/web/package-lock.json
+++ b/rust/tcl-spec-studio/web/package-lock.json
@@ -19,7 +19,9 @@
         "prettier": "^3.9.6",
         "typescript": "^6.0.3",
         "vscode-jsonrpc": "^9.0.1",
-        "vscode-languageserver-protocol": "^3.18.2"
+        "vscode-languageserver-protocol": "^3.18.2",
+        "vscode-oniguruma": "^2.0.1",
+        "vscode-textmate": "^9.3.2"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1793,6 +1795,20 @@
       "version": "3.18.0",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
       "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-2.0.1.tgz",
+      "integrity": "sha512-poJU8iHIWnC3vgphJnrLZyI3YdqRlR27xzqDmpPXYzA93R4Gk8z7T6oqDzDoHjoikA2aS82crdXFkjELCdJsjQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-textmate": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-9.3.2.tgz",
+      "integrity": "sha512-n2uGbUcrjhUEBH16uGA0TvUfhWwliFZ1e3+pTjrkim1Mt7ydB41lV08aUvsi70OlzDWp6X7Bx3w/x3fAXIsN0Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/rust/tcl-spec-studio/web/package.json
+++ b/rust/tcl-spec-studio/web/package.json
@@ -23,6 +23,8 @@
     "prettier": "^3.9.6",
     "typescript": "^6.0.3",
     "vscode-jsonrpc": "^9.0.1",
-    "vscode-languageserver-protocol": "^3.18.2"
+    "vscode-languageserver-protocol": "^3.18.2",
+    "vscode-oniguruma": "^2.0.1",
+    "vscode-textmate": "^9.3.2"
   }
 }

--- a/rust/tcl-spec-studio/web/src/editorHost.ts
+++ b/rust/tcl-spec-studio/web/src/editorHost.ts
@@ -51,6 +51,10 @@ export interface EditorHostOptions {
   workerUrl: string;
   /** Content-keyed URL for Monaco's emitted stylesheet. */
   stylesheetUrl: string;
+  /** The VS Code extension's authoritative Tcl TextMate grammar. */
+  grammarUrl: string;
+  /** Oniguruma WASM used to execute that grammar in the browser. */
+  onigurumaUrl: string;
   /** The `.tclspec` pack document. Always opened as `spectcl`. */
   dsl: SurfaceSpec;
   /** The Tcl sample, opened under whichever dialect the studio has selected. */

--- a/rust/tcl-spec-studio/web/src/monacoHost.ts
+++ b/rust/tcl-spec-studio/web/src/monacoHost.ts
@@ -49,6 +49,7 @@ import type {
   SurfaceSpec,
 } from "./editorHost.js";
 import { LspClient, startLspClient } from "./lspClient.js";
+import { registerTclGrammar } from "./textmateHost.js";
 
 /** The Monaco language id both surfaces' models are registered under. */
 const SPECTCL_LANGUAGE = "spectcl";
@@ -58,49 +59,22 @@ const TCL_LANGUAGE = "tcl";
 declare const __SPEC_STUDIO_FRONTEND_VERSION__: string;
 export const buildVersion = __SPEC_STUDIO_FRONTEND_VERSION__;
 
-/** In-memory document URIs. Nothing resolves them — they are identities. */
-const DSL_URI = "inmemory://studio/pack.tclspec";
-const SAMPLE_URI = "inmemory://studio/sample.tcl";
-const RUST_URI = "inmemory://studio/command.rs";
-const STUB_URI = "inmemory://studio/stubs.tcl";
+/**
+ * Virtual document URIs.
+ *
+ * They are never read from disk, but they deliberately use the `file:` scheme:
+ * the native server's document pipeline derives paths, extensions, and dialect
+ * hints from file URIs. Monaco's usual `inmemory:` scheme lets `initialize`
+ * succeed while later semantic-token and hover requests fall off that path,
+ * leaving a healthy worker apparently doing nothing.
+ */
+const DSL_URI = "file:///__tcl_spec_studio__/pack.tclspec";
+const SAMPLE_URI = "file:///__tcl_spec_studio__/sample.tcl";
+const RUST_URI = "file:///__tcl_spec_studio__/command.rs";
+const STUB_URI = "file:///__tcl_spec_studio__/stubs.tcl";
 
 /** How long keystrokes settle before the change is pushed on. */
 const SETTLE_MS = 120;
-
-/**
- * Map an LSP semantic token type onto a Monaco theme scope.
- *
- * Monaco has no semantic-token theming of its own the way VS Code does, so the
- * legend the server sends is projected onto the TextMate-ish scopes Monaco's
- * themes already colour. An unrecognised type falls through to `source`, which
- * paints as plain text — a new token type on the server therefore shows up
- * uncoloured rather than breaking the whole pass.
- */
-const SCOPE_BY_TOKEN_TYPE: Record<string, string> = {
-  namespace: "entity.name.namespace",
-  type: "entity.name.type",
-  class: "entity.name.class",
-  enum: "entity.name.type.enum",
-  interface: "entity.name.type.interface",
-  struct: "entity.name.type.struct",
-  typeParameter: "entity.name.type.parameter",
-  parameter: "variable.parameter",
-  variable: "variable.other",
-  property: "variable.other.property",
-  enumMember: "variable.other.enummember",
-  event: "entity.name.function",
-  function: "entity.name.function",
-  method: "entity.name.function.member",
-  macro: "entity.name.function.macro",
-  keyword: "keyword",
-  modifier: "storage.modifier",
-  comment: "comment",
-  string: "string",
-  number: "constant.numeric",
-  regexp: "string.regexp",
-  operator: "keyword.operator",
-  decorator: "entity.name.decorator",
-};
 
 /** Whether a Monaco instance has already had the languages registered. */
 let languagesRegistered = false;
@@ -196,6 +170,15 @@ function completionItems(
   return Array.isArray(reply) ? reply : reply.items;
 }
 
+/** Zero-based LSP position of `needle` in `text`, when present. */
+function positionOf(text: string, needle: string): { line: number; character: number } | null {
+  const offset = text.indexOf(needle);
+  if (offset < 0) return null;
+  const before = text.slice(0, offset);
+  const lines = before.split("\n");
+  return { line: lines.length - 1, character: lines[lines.length - 1]?.length ?? 0 };
+}
+
 /**
  * Register every provider that forwards to the server.
  *
@@ -206,7 +189,12 @@ function completionItems(
  */
 function registerProviders(client: LspClient): void {
   const legend: monaco.languages.SemanticTokensLegend = {
-    tokenTypes: client.legend.tokenTypes.map((type) => SCOPE_BY_TOKEN_TYPE[type] ?? "source"),
+    // Semantic-token legends contain token *identifiers*, not TextMate
+    // scopes. Monaco's built-in themes already colour the standard LSP names
+    // (`keyword`, `variable`, `function`, ...). Replacing them with scopes such
+    // as `entity.name.function` leaves Monaco unable to match any rule and
+    // turns the whole Tcl document back into generic text.
+    tokenTypes: [...client.legend.tokenTypes],
     tokenModifiers: [...client.legend.tokenModifiers],
   };
 
@@ -513,6 +501,12 @@ class OutputSurface {
 export async function mountEditors(options: EditorHostOptions): Promise<EditorHost> {
   await loadStylesheet(options.stylesheetUrl);
   registerLanguages();
+  await registerTclGrammar(
+    monaco,
+    [SPECTCL_LANGUAGE, TCL_LANGUAGE],
+    options.grammarUrl,
+    options.onigurumaUrl,
+  );
   monaco.editor.setTheme(currentTheme());
   window
     .matchMedia?.("(prefers-color-scheme: dark)")
@@ -523,7 +517,6 @@ export async function mountEditors(options: EditorHostOptions): Promise<EditorHo
     options.report("starting the language server…");
     client = await startLspClient(options.workerUrl);
     registerProviders(client);
-    options.report("the Tcl language server is running in this page", "ok");
   } catch (e) {
     options.report(
       `the language server could not start (${e instanceof Error ? e.message : String(e)}) — ` +
@@ -536,6 +529,28 @@ export async function mountEditors(options: EditorHostOptions): Promise<EditorHo
   const sample = new Surface(options.sample, SAMPLE_URI, TCL_LANGUAGE, options.dialect, client);
   const rust = new OutputSurface(options.rust, RUST_URI, "rust", null, client);
   const stub = new OutputSurface(options.stub, STUB_URI, TCL_LANGUAGE, "spectcl", client);
+
+  if (client) {
+    // `initialize` proves only that the worker booted. Exercise an opened
+    // document before claiming the LSP is usable: a URI scheme or transport
+    // regression otherwise leaves a green status beside an editor with no
+    // tokens, hover, or diagnostics.
+    try {
+      const tokens = await client.semanticTokens(DSL_URI);
+      if (!tokens?.data.length) throw new Error("the pack document returned no semantic tokens");
+      const hoverAt = positionOf(options.dsl.textarea.value, "speclib");
+      if (hoverAt && !(await client.hover(DSL_URI, hoverAt.line, hoverAt.character))) {
+        throw new Error("the pack document returned no hover information");
+      }
+      options.report("the Tcl language server is running in this page", "ok");
+    } catch (e) {
+      options.report(
+        `the language server started but could not analyse the pack (${e instanceof Error ? e.message : String(e)}) — ` +
+          "the editor is running without analysis; reload to try again",
+        "err",
+      );
+    }
+  }
 
   client?.onDiagnostics((uri, items) => {
     if (uri === dsl.documentUri) dsl.setDiagnostics(items);

--- a/rust/tcl-spec-studio/web/src/studio.ts
+++ b/rust/tcl-spec-studio/web/src/studio.ts
@@ -1112,10 +1112,12 @@ function readFiles(fileList: FileList | null, opts: { directory?: boolean } = {}
 function writeDraftsToPack(commands: { name: string; draft: Draft }[]): {
   written: number;
   failed: string[];
+  firstWritten: string | null;
 } {
   let source = state.pack.source;
   let written = 0;
   const failed: string[] = [];
+  let firstWritten: string | null = null;
   for (const found of commands) {
     try {
       const out = unwrap<PackWrite>(
@@ -1123,18 +1125,30 @@ function writeDraftsToPack(commands: { name: string; draft: Draft }[]): {
       );
       source = out.source;
       written += 1;
+      firstWritten ??= found.name;
     } catch {
       failed.push(found.name);
     }
   }
   state.pack.open = null;
   setPackSource(source);
-  return { written, failed };
+  return { written, failed, firstWritten };
 }
 
 function addImportedToPack(): void {
   if (!state.imported.length) return;
-  const { written, failed } = writeDraftsToPack(state.imported);
+  const { written, failed, firstWritten } = writeDraftsToPack(state.imported);
+  // The generated-code panes render the active draft, not the pack as a
+  // whole. Import used to write a perfectly good `.tclspec` and leave the
+  // boot-time `mycommand` placeholder active, so Rust and stub output looked
+  // as though generation had failed. Make the first successfully imported
+  // command the active pack draft while leaving the author on the Import tab.
+  if (firstWritten) {
+    const view = unwrap<PackCommandView>(
+      wasm.pack_command(state.pack.source, firstWritten, state.dialect),
+    );
+    if (view.pack) loadDraft(view.pack, packOrigin(view), firstWritten);
+  }
   setStatus(
     "importStatus",
     `${written} command(s) written into pack ${state.pack.view?.pack ?? ""}` +
@@ -1759,6 +1773,8 @@ async function mountEditorHost(): Promise<void> {
     editorHost = await chunk.mountEditors({
       workerUrl: assetUrl(activeBuildInfo, "lsp-worker", `${LSP_WORKER_DIR}/worker.js`),
       stylesheetUrl: assetUrl(activeBuildInfo, "editor-style", "assets/monaco-host.css"),
+      grammarUrl: assetUrl(activeBuildInfo, "tcl-grammar", "assets/tcl.tmLanguage.json"),
+      onigurumaUrl: assetUrl(activeBuildInfo, "oniguruma", "assets/onig.wasm"),
       dialect: state.dialect,
       report,
       dsl: {

--- a/rust/tcl-spec-studio/web/src/textmateHost.ts
+++ b/rust/tcl-spec-studio/web/src/textmateHost.ts
@@ -1,0 +1,76 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Adapt the VS Code extension's authoritative Tcl TextMate grammar to Monaco.
+// Semantic tokens still supply the precise registry-backed paint; this is the
+// shared lexical base visible before those tokens arrive and while a hidden
+// editor is being revealed.
+
+import type * as monaco from "monaco-editor/editor/editor.api.js";
+import * as oniguruma from "vscode-oniguruma";
+import * as textmate from "vscode-textmate";
+
+class GrammarState implements monaco.languages.IState {
+  constructor(readonly stack: textmate.StateStack) {}
+
+  clone(): GrammarState {
+    return new GrammarState(this.stack);
+  }
+
+  equals(other: monaco.languages.IState): boolean {
+    return other instanceof GrammarState && this.stack.equals(other.stack);
+  }
+}
+
+/** Register `languageIds` against the one shared Tcl grammar. */
+export async function registerTclGrammar(
+  monacoApi: typeof monaco,
+  languageIds: string[],
+  grammarUrl: string,
+  onigurumaUrl: string,
+): Promise<void> {
+  const onigBytes = await fetch(onigurumaUrl).then((response) => {
+    if (!response.ok) throw new Error(`could not load Oniguruma (${response.status})`);
+    return response.arrayBuffer();
+  });
+  await oniguruma.loadWASM(onigBytes);
+
+  const registry = new textmate.Registry({
+    onigLib: Promise.resolve({
+      createOnigScanner: (patterns) => new oniguruma.OnigScanner(patterns),
+      createOnigString: (text) => new oniguruma.OnigString(text),
+    }),
+    loadGrammar: async (scopeName) => {
+      if (scopeName !== "source.tcl") return null;
+      const response = await fetch(grammarUrl);
+      if (!response.ok) throw new Error(`could not load the Tcl grammar (${response.status})`);
+      // `grammarUrl` is content-keyed with a query string; passing it as the
+      // filename makes vscode-textmate miss the `.json` suffix and attempt to
+      // parse the JSON as a plist.
+      return textmate.parseRawGrammar(await response.text(), "tcl.tmLanguage.json");
+    },
+  });
+  const grammar = await registry.loadGrammar("source.tcl");
+  if (!grammar) throw new Error("the Tcl grammar did not declare source.tcl");
+
+  for (const languageId of languageIds) {
+    monacoApi.languages.setTokensProvider(languageId, {
+      getInitialState: () => new GrammarState(textmate.INITIAL),
+      tokenize: (line, state) => {
+        const current = state instanceof GrammarState ? state.stack : textmate.INITIAL;
+        const result = grammar.tokenizeLine(line, current);
+        return {
+          endState: new GrammarState(result.ruleStack),
+          tokens: result.tokens.map((token) => ({
+            startIndex: token.startIndex,
+            // Monaco's themes match dotted token prefixes in the same manner
+            // as TextMate scope selectors, so preserve the most-specific
+            // scope emitted by the extension grammar.
+            scopes: token.scopes[token.scopes.length - 1] ?? "source.tcl",
+          })),
+        };
+      },
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- keep Monaco documents on stable file URIs and verify semantic tokens plus hover before reporting the embedded LSP healthy
- use the VS Code extension's canonical Tcl TextMate grammar for both Pack DSL and Test fallback highlighting
- preserve the LSP semantic-token legend instead of converting token identifiers into TextMate scopes
- activate the first successfully imported Tcl command so Rust and stub projections regenerate instead of retaining the placeholder draft
- package the grammar and Oniguruma runtime into the assembled Studio and strengthen browser/contract coverage

## Root causes

The initial TextMate highlighting was replaced when Monaco installed a malformed semantic-token provider: the LSP legend identifiers had been translated into TextMate scope names, so Monaco could not classify them correctly. The in-memory document URIs also bypassed the file-oriented server path, while the UI declared the LSP healthy immediately after initialization without proving document features worked.

Bulk import populated the pack, but deliberately cleared the active command while the original boot draft remained selected. Generated Rust therefore continued to render the placeholder rather than an imported command.

## Validation

- `make rust-check`
- `make prep-pr` (after rebasing onto current `rust`)
- Spec Studio web unit suite (32 tests)
- Rust web-contract suite (5 tests)
- assembled Chromium boot test, including DSL/Test colour diversity, hover, semantic tokens, diagnostics, and imported-command Rust generation

Fixes #1503

Follow-up native host integrations are tracked in #1505 (VS Code) and #1506 (JetBrains).
