### PR TITLE
feat: add native-editor Spec Studio hosts and shared Pages editor

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -80,6 +80,8 @@ on:
       - "rust/tcl-lsp-server-wasm/**"
       - "rust/tcl-lsp-server/**"
       - "rust/tcl-cli/gui/**"
+      - "rust/web-shared/**"
+      - "scripts/stamp-pages-tool.mjs"
       - "rust/tcl-lexer/**"
       - "rust/tcl-syntax/**"
       - "rust/tcl-registry/**"
@@ -252,6 +254,8 @@ jobs:
           mkdir -p site/compiler-explorer
           cp -r rust/tcl-cli/gui/. site/compiler-explorer/
           rm -f site/compiler-explorer/.gitignore
+          cp rust/web-shared/site-update.js site/compiler-explorer/site-update.js
+          node scripts/stamp-pages-tool.mjs site/compiler-explorer "$TCL_LSP_VERSION"
 
           # Command-registry spec studio → /spec-studio/. The dist IS a
           # directory now — index.html, the lazily-loaded editor chunk under
@@ -269,6 +273,12 @@ jobs:
               || { echo "spec-studio: dist is missing $required"; exit 1; }
           done
           du -sh site/spec-studio
+
+          # The explorer imports the sibling Spec Studio editor bundle on
+          # Pages. Exercise that deployed directory layout in the same browser
+          # installed for the Studio boot check.
+          NODE_PATH="$PWD/rust/tcl-spec-studio/web/node_modules" \
+            node rust/tcl-cli/gui/test/pages-boot.mjs site
 
           # Root landing page linking both apps (the shared Pages root).
           cat > site/index.html <<'HTML'

--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ publish-vsix: package-vsix ## Publish the .vsix to the VS Code Marketplace (lapt
 		exit 1; \
 	fi
 
-$(VSIX_FILE): $(OUT_DIR)/extension.js $(EXT_DIR)/package.json $(EXT_DIR)/.vscodeignore $(LICENSE_SRC) $(README_SRC) $(SCREENSHOTS) $(ROOT)scripts/install/filter-readme.mjs
+$(VSIX_FILE): spec-studio-wasm $(OUT_DIR)/extension.js $(EXT_DIR)/package.json $(EXT_DIR)/.vscodeignore $(LICENSE_SRC) $(README_SRC) $(SCREENSHOTS) $(ROOT)scripts/install/filter-readme.mjs
 	@echo "==> Preparing VSIX staging directory"
 	rm -rf $(STAGE_DIR)
 	mkdir -p $(STAGE_DIR)
@@ -264,6 +264,8 @@ $(VSIX_FILE): $(OUT_DIR)/extension.js $(EXT_DIR)/package.json $(EXT_DIR)/.vscode
 		--exclude='.mypy_cache/' \
 		--exclude='.vscode-test/' \
 		$(EXT_DIR)/ $(STAGE_DIR)/
+	mkdir -p $(STAGE_DIR)/spec-studio
+	cp -R $(ROOT)rust/tcl-spec-studio-wasm/dist/. $(STAGE_DIR)/spec-studio/
 	@# Inject version from git describe into staged package.json
 	node -e "const f='$(STAGE_DIR)/package.json';const p=JSON.parse(require('fs').readFileSync(f));p.version='$(SEMVER_VERSION)';require('fs').writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
 	@echo "==> Bundling native tcl-lsp-server binaries: $(BUNDLED_TARGETS)"
@@ -1379,7 +1381,8 @@ explorer-wasm: ## Build the Rust → WASM compiler-explorer core into the tcl GU
 		|| echo "    note: node not found — skipping wasm growability check"
 	@ls -lh $(EXPLORER_STATIC)/tcl_explorer_wasm_bg.wasm
 
-explorer-build: explorer-wasm $(MERMAID_JS) ## Build the compiler-explorer GUI bundle (Rust → WASM, offline)
+explorer-build: explorer-wasm $(MERMAID_JS) $(ROOT)rust/web-shared/site-update.js ## Build the compiler-explorer GUI bundle (Rust → WASM, offline)
+	cp $(ROOT)rust/web-shared/site-update.js $(EXPLORER_STATIC)/site-update.js
 	@echo "==> Compiler explorer bundle ready in $(EXPLORER_STATIC) — rebuild the tcl binary to embed it"
 
 TCL_VM_WASM_DIR := $(ROOT)rust/tcl-vm-wasm
@@ -1490,7 +1493,7 @@ build-editor-jetbrains: $(JB_PLUGIN) verify-jetbrains-server ## Build JetBrains 
 .PHONY: jb-plugin-force
 jb-plugin-force:
 
-$(JB_PLUGIN): jb-plugin-force
+$(JB_PLUGIN): jb-plugin-force spec-studio-wasm
 	@echo "==> Building JetBrains plugin"
 	@# build.gradle.kts reads RELEASE_VERSION from the environment first, so
 	@# the gradle.properties source file is never mutated by the build.
@@ -1531,6 +1534,9 @@ $(JB_PLUGIN): jb-plugin-force
 		const {getWebviewHtml} = require('./out/compilerExplorerHtml'); \
 		require('fs').writeFileSync('$(JB_DIR)/src/main/resources/compilerExplorer.html', getWebviewHtml()); \
 	" 2>/dev/null || echo "(compiler explorer HTML extraction skipped — compile TS first)"
+	rm -rf $(JB_DIR)/src/main/resources/spec-studio
+	mkdir -p $(JB_DIR)/src/main/resources/spec-studio
+	cp -R $(ROOT)rust/tcl-spec-studio-wasm/dist/. $(JB_DIR)/src/main/resources/spec-studio/
 	@# Build plugin — pass version via env so build.gradle.kts picks it up
 	cd $(JB_DIR) && RELEASE_VERSION="$(SEMVER_VERSION)" ./gradlew buildPlugin
 	mkdir -p $(BUILD_DIR)

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/SpecStudioHtml.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/SpecStudioHtml.kt
@@ -1,0 +1,31 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains
+
+import com.google.gson.Gson
+
+internal fun getSpecStudioHtml(): String {
+    val loader = SpecStudioToolWindowFactory::class.java.classLoader
+    val html = loader.getResourceAsStream("spec-studio/index.html")
+        ?.bufferedReader()?.use { it.readText() }
+        ?: return "<html><body>Spec Studio assets are missing from this plugin build.</body></html>"
+    val nativeModule = loader.getResourceAsStream("spec-studio/assets/native-editor-host.js")
+        ?.bufferedReader()?.use { it.readText() }
+        ?: return "<html><body>Spec Studio native editor bridge is missing.</body></html>"
+    val source = Gson().toJson(nativeModule).replace("<", "\\u003c")
+    val bridge = """
+        <script>
+        window.__tclSpecStudioQueue=[];
+        window.__tclSpecStudioHost={postMessage:function(message){
+          var json=JSON.stringify(message);
+          if(window.__tclSpecStudioBridge){window.__tclSpecStudioBridge(json);}
+          else{window.__tclSpecStudioQueue.push(json);}
+        }};
+        window.__tclSpecStudioNativeModuleUrl=URL.createObjectURL(new Blob([$source],{type:'text/javascript'}));
+        </script>
+    """.trimIndent()
+    return html
+        .replace("script-src 'self'", "script-src 'self' blob:")
+        .replace("<head>", "<head>$bridge")
+}

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/SpecStudioStartupActivity.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/SpecStudioStartupActivity.kt
@@ -1,0 +1,37 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.StartupActivity
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Comparator
+
+/** Cleans crash-abandoned Studio packs before the project LSP is used. */
+class SpecStudioStartupActivity : StartupActivity.DumbAware {
+    override fun runActivity(project: Project) {
+        val base = project.basePath ?: return
+        val root = Path.of(base, ".tcl-lsp", ".spec-studio")
+        val abandoned = root.resolve("jetbrains")
+        try {
+            if (Files.exists(abandoned)) {
+                Files.walk(abandoned).use { paths ->
+                    paths.sorted(Comparator.reverseOrder()).forEach(Files::deleteIfExists)
+                }
+            }
+            Files.createDirectories(root)
+            // The ignore file intentionally ignores itself as well. Git still
+            // reads it, but neither it nor any live projection enters status.
+            Files.writeString(root.resolve(".gitignore"), "*\n")
+        } catch (error: Exception) {
+            LOG.warn("Could not clean abandoned Spec Studio session", error)
+        }
+    }
+
+    private companion object {
+        val LOG = Logger.getInstance(SpecStudioStartupActivity::class.java)
+    }
+}

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/SpecStudioToolWindowFactory.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/SpecStudioToolWindowFactory.kt
@@ -1,0 +1,183 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains
+
+import com.google.gson.Gson
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.editor.event.DocumentEvent
+import com.intellij.openapi.editor.event.DocumentListener
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.platform.lsp.api.LspServerManager
+import com.intellij.platform.lsp.api.LspServerState
+import com.intellij.ui.content.ContentFactory
+import com.intellij.ui.jcef.JBCefBrowser
+import com.intellij.ui.jcef.JBCefBrowserBase
+import com.intellij.ui.jcef.JBCefJSQuery
+import org.cef.browser.CefBrowser
+import org.cef.handler.CefLoadHandlerAdapter
+import org.eclipse.lsp4j.DidChangeWatchedFilesParams
+import org.eclipse.lsp4j.FileChangeType
+import org.eclipse.lsp4j.FileEvent
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Comparator
+
+private val SPEC_LOG = Logger.getInstance("com.tcllsp.jetbrains.SpecStudio")
+
+class SpecStudioToolWindowFactory : ToolWindowFactory, DumbAware {
+    override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        val panel = SpecStudioPanel(project)
+        val content = ContentFactory.getInstance().createContent(panel.browser.component, "", false)
+        content.setDisposer(panel)
+        toolWindow.contentManager.addContent(content)
+    }
+
+    override fun shouldBeAvailable(project: Project): Boolean = project.basePath != null
+}
+
+internal class SpecStudioPanel(private val project: Project) : Disposable {
+    val browser = JBCefBrowser()
+    private val query = JBCefJSQuery.create(browser as JBCefBrowserBase)
+    private val gson = Gson()
+    private val sessionDir = Path.of(project.basePath!!, ".tcl-lsp", ".spec-studio", "jetbrains")
+    private val paths = mapOf(
+        "dsl" to sessionDir.resolve("active.tclspec"),
+        "sample" to sessionDir.resolve("test.tcl"),
+        "rust" to sessionDir.resolve("generated.rs"),
+        "stub" to sessionDir.resolve("generated-stub.tcl"),
+    )
+    private var disposed = false
+
+    init {
+        Disposer.register(this, browser)
+        Disposer.register(this, query)
+        query.addHandler { message ->
+            handleMessage(message)
+            null
+        }
+        browser.jbCefClient.addLoadHandler(object : CefLoadHandlerAdapter() {
+            override fun onLoadEnd(cefBrowser: CefBrowser?, frame: org.cef.browser.CefFrame?, httpStatusCode: Int) {
+                if (frame?.isMain != true) return
+                val script = """
+                    window.__tclSpecStudioBridge=function(json){${query.inject("json")}};
+                    (window.__tclSpecStudioQueue||[]).splice(0).forEach(window.__tclSpecStudioBridge);
+                """.trimIndent()
+                cefBrowser?.executeJavaScript(script, "", 0)
+            }
+        }, browser.cefBrowser)
+        EditorFactory.getInstance().eventMulticaster.addDocumentListener(object : DocumentListener {
+            override fun documentChanged(event: DocumentEvent) {
+                if (disposed) return
+                val file = FileDocumentManager.getInstance().getFile(event.document) ?: return
+                val surface = paths.entries.firstOrNull { it.value == file.toNioPath() }?.key ?: return
+                if (surface != "dsl" && surface != "sample") return
+                sendUpdate(surface, event.document.text)
+                ApplicationManager.getApplication().invokeLater {
+                    if (!disposed) {
+                        FileDocumentManager.getInstance().saveDocument(event.document)
+                        if (surface == "dsl") notifyPack(paths.getValue("dsl"), FileChangeType.Changed)
+                    }
+                }
+            }
+        }, this)
+        browser.loadHTML(getSpecStudioHtml())
+    }
+
+    private fun handleMessage(json: String) {
+        try {
+            val message = gson.fromJson(json, Map::class.java)
+            val type = message["type"] as? String ?: return
+            val surface = message["surface"] as? String
+            when (type) {
+                "surfaceUpdate" -> if (surface in paths && message["text"] is String) {
+                    materialise(surface!!, message["text"] as String)
+                }
+                "openSurface" -> if (surface in paths) openSurface(surface!!)
+            }
+        } catch (error: Exception) {
+            SPEC_LOG.warn("Could not handle Spec Studio message", error)
+        }
+    }
+
+    private fun materialise(surface: String, text: String) {
+        val path = paths.getValue(surface)
+        ApplicationManager.getApplication().executeOnPooledThread {
+            try {
+                Files.createDirectories(sessionDir)
+                val existed = Files.exists(path)
+                Files.writeString(path, text)
+                LocalFileSystem.getInstance().refreshAndFindFileByNioFile(path)?.refresh(false, false)
+                if (surface == "dsl") notifyPack(path, if (existed) FileChangeType.Changed else FileChangeType.Created)
+            } catch (error: Exception) {
+                SPEC_LOG.warn("Could not materialise Spec Studio $surface", error)
+            }
+        }
+    }
+
+    private fun openSurface(surface: String) {
+        val path = paths.getValue(surface)
+        ApplicationManager.getApplication().executeOnPooledThread {
+            if (!Files.exists(path)) {
+                Files.createDirectories(sessionDir)
+                Files.writeString(path, "")
+            }
+            val file = LocalFileSystem.getInstance().refreshAndFindFileByNioFile(path) ?: return@executeOnPooledThread
+            ApplicationManager.getApplication().invokeLater {
+                FileEditorManager.getInstance(project).openFile(file, true)
+            }
+        }
+    }
+
+    private fun sendUpdate(surface: String, text: String) {
+        val escapedSurface = gson.toJson(surface)
+        val escapedText = gson.toJson(text)
+        browser.cefBrowser.executeJavaScript(
+            "window.dispatchEvent(new MessageEvent('message',{data:{type:'tclSpecStudioHostUpdate',surface:$escapedSurface,text:$escapedText}}));",
+            "", 0,
+        )
+    }
+
+    @Suppress("UnstableApiUsage")
+    private fun notifyPack(path: Path, type: FileChangeType) {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val server = LspServerManager.getInstance(project)
+                .getServersForProvider(TclLspServerSupportProvider::class.java)
+                .firstOrNull { it.state == LspServerState.Running } ?: return@executeOnPooledThread
+            server.sendNotification { lsp4j ->
+                lsp4j.workspaceService.didChangeWatchedFiles(
+                    DidChangeWatchedFilesParams(listOf(FileEvent(path.toUri().toString(), type)))
+                )
+            }
+        }
+    }
+
+    override fun dispose() {
+        if (disposed) return
+        disposed = true
+        val pack = paths.getValue("dsl")
+        val existed = Files.exists(pack)
+        ApplicationManager.getApplication().executeOnPooledThread {
+            try {
+                if (Files.exists(sessionDir)) {
+                    Files.walk(sessionDir).use { paths ->
+                        paths.sorted(Comparator.reverseOrder()).forEach(Files::deleteIfExists)
+                    }
+                }
+                if (existed) notifyPack(pack, FileChangeType.Deleted)
+            } catch (error: Exception) {
+                SPEC_LOG.warn("Could not remove the Spec Studio override", error)
+            }
+        }
+    }
+}

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/OpenSpecStudioAction.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/OpenSpecStudioAction.kt
@@ -1,0 +1,20 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.wm.ToolWindowManager
+
+class OpenSpecStudioAction : AnAction(), DumbAware {
+    override fun actionPerformed(event: AnActionEvent) {
+        val project = event.project ?: return
+        ToolWindowManager.getInstance(project).getToolWindow("Tcl Spec Studio")?.show()
+    }
+
+    override fun update(event: AnActionEvent) {
+        event.presentation.isEnabledAndVisible = event.project?.basePath != null
+    }
+}

--- a/editors/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/editors/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -73,6 +73,8 @@
             factoryClass="com.tcllsp.jetbrains.SpecStudioToolWindowFactory"
             icon="/icons/tcl.svg"
             secondary="true"/>
+        <postStartupActivity
+            implementation="com.tcllsp.jetbrains.SpecStudioStartupActivity"/>
 
         <!-- Notification group for error messages -->
         <notificationGroup id="Tcl LSP" displayType="BALLOON"/>

--- a/editors/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/editors/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -66,6 +66,14 @@
         <projectService
             serviceImplementation="com.tcllsp.jetbrains.CompilerExplorerService"/>
 
+        <!-- Spec Studio uses JCEF for the form/import/reference UI and opens
+             its four code projections in ordinary IntelliJ editors. -->
+        <toolWindow id="Tcl Spec Studio"
+            anchor="right"
+            factoryClass="com.tcllsp.jetbrains.SpecStudioToolWindowFactory"
+            icon="/icons/tcl.svg"
+            secondary="true"/>
+
         <!-- Notification group for error messages -->
         <notificationGroup id="Tcl LSP" displayType="BALLOON"/>
     </extensions>
@@ -94,6 +102,13 @@
                     class="com.tcllsp.jetbrains.actions.FixAllSafeIssuesAction"
                     text="Apply Safe Quick Fixes"
                     description="Apply every quick fix marked safe in the current document"/>
+
+            <separator/>
+
+            <action id="TclLsp.OpenSpecStudio"
+                    class="com.tcllsp.jetbrains.actions.OpenSpecStudioAction"
+                    text="Open Tcl Spec Studio"
+                    description="Open Spec Studio with native IntelliJ editors"/>
 
             <separator/>
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -419,6 +419,11 @@
         "category": "Tcl"
       },
       {
+        "command": "tclLsp.openSpecStudio",
+        "title": "Open Tcl Spec Studio",
+        "category": "Tcl"
+      },
+      {
         "command": "tclLsp.openTkPreview",
         "title": "Open Tk Preview",
         "category": "Tcl"
@@ -716,6 +721,9 @@
           "when": "editorLangId =~ /^tcl/"
         },
         {
+          "command": "tclLsp.openSpecStudio"
+        },
+        {
           "command": "tclLsp.openTkPreview",
           "when": "editorLangId =~ /^tcl/"
         },
@@ -820,6 +828,10 @@
         {
           "command": "tclLsp.openCompilerExplorer",
           "when": "editorLangId =~ /^tcl/",
+          "group": "4_tools"
+        },
+        {
+          "command": "tclLsp.openSpecStudio",
           "group": "4_tools"
         },
         {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -72,7 +72,7 @@ import {
   openCompilerExplorer,
 } from "./compilerExplorer";
 import { openTkPreview, tkPreviewDocChanged, tkPreviewEditorChanged } from "./tkPreviewPanel";
-import { openSpecStudio } from "./specStudio";
+import { openSpecStudio, prepareSpecStudioStorage } from "./specStudio";
 import { registerHighlightingHealthChecks } from "./highlightingHealth";
 import { ensureStickyScrollDefaultModel } from "./stickyScrollHealth";
 import { DiffDiagnosticsSuppressor } from "./diffAnalysis";
@@ -350,6 +350,7 @@ function resolveAllFeatureToggles(): Record<string, boolean> {
 
 export async function activate(context: ExtensionContext) {
   setDiagramPanelExtensionUri(context.extensionUri);
+  await prepareSpecStudioStorage();
   const activateStart = Date.now();
   const ch = getOutputChannel();
   const config = workspace.getConfiguration("tclLsp");

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -72,6 +72,7 @@ import {
   openCompilerExplorer,
 } from "./compilerExplorer";
 import { openTkPreview, tkPreviewDocChanged, tkPreviewEditorChanged } from "./tkPreviewPanel";
+import { openSpecStudio } from "./specStudio";
 import { registerHighlightingHealthChecks } from "./highlightingHealth";
 import { ensureStickyScrollDefaultModel } from "./stickyScrollHealth";
 import { DiffDiagnosticsSuppressor } from "./diffAnalysis";
@@ -596,6 +597,7 @@ export async function activate(context: ExtensionContext) {
     ),
     commands.registerCommand("tclLsp.runRuntimeValidation", runRuntimeValidation),
     commands.registerCommand("tclLsp.openCompilerExplorer", openCompilerExplorer),
+    commands.registerCommand("tclLsp.openSpecStudio", () => openSpecStudio(context, client)),
     commands.registerCommand("tclLsp.openTkPreview", openTkPreview),
     commands.registerCommand("tclLsp.formatDocument", formatDocument),
     commands.registerCommand("tclLsp.minifyDocument", minifyDocument),

--- a/editors/vscode/src/specStudio.ts
+++ b/editors/vscode/src/specStudio.ts
@@ -23,6 +23,31 @@ const filenames: Record<Surface, string> = {
 
 let current: SpecStudioSession | undefined;
 
+const studioIgnore = "*\n";
+
+/**
+ * Remove sessions which could only have survived an editor crash, and make
+ * every subsequently materialised projection invisible to Git. This runs
+ * before the language client starts, so an abandoned highest-precedence pack
+ * can never enter the server's initial discovery snapshot.
+ */
+export async function prepareSpecStudioStorage(): Promise<void> {
+  for (const folder of vscode.workspace.workspaceFolders ?? []) {
+    const root = vscode.Uri.joinPath(folder.uri, ".tcl-lsp", ".spec-studio");
+    const abandoned = vscode.Uri.joinPath(root, "vscode");
+    try {
+      await vscode.workspace.fs.delete(abandoned, { recursive: true, useTrash: false });
+    } catch (error) {
+      if (!(error instanceof vscode.FileSystemError && error.code === "FileNotFound")) throw error;
+    }
+    await vscode.workspace.fs.createDirectory(root);
+    await vscode.workspace.fs.writeFile(
+      vscode.Uri.joinPath(root, ".gitignore"),
+      Buffer.from(studioIgnore, "utf8"),
+    );
+  }
+}
+
 function injectNativeBridge(html: string, nativeModule: string): string {
   const source = JSON.stringify(nativeModule).replace(/</g, "\\u003c");
   const bridge = `<script>const vscode=acquireVsCodeApi();window.__tclSpecStudioHost={postMessage:(message)=>vscode.postMessage(message)};window.__tclSpecStudioNativeModuleUrl=URL.createObjectURL(new Blob([${source}],{type:'text/javascript'}));</script>`;

--- a/editors/vscode/src/specStudio.ts
+++ b/editors/vscode/src/specStudio.ts
@@ -1,0 +1,208 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as fs from "fs";
+import * as vscode from "vscode";
+import type { LanguageClient } from "vscode-languageclient/node";
+
+type Surface = "dsl" | "sample" | "rust" | "stub";
+
+interface StudioMessage {
+  type: string;
+  surface?: Surface;
+  text?: string;
+  dialect?: string;
+}
+
+const filenames: Record<Surface, string> = {
+  dsl: "active.tclspec",
+  sample: "test.tcl",
+  rust: "generated.rs",
+  stub: "generated-stub.tcl",
+};
+
+let current: SpecStudioSession | undefined;
+
+function injectNativeBridge(html: string, nativeModule: string): string {
+  const source = JSON.stringify(nativeModule).replace(/</g, "\\u003c");
+  const bridge = `<script>const vscode=acquireVsCodeApi();window.__tclSpecStudioHost={postMessage:(message)=>vscode.postMessage(message)};window.__tclSpecStudioNativeModuleUrl=URL.createObjectURL(new Blob([${source}],{type:'text/javascript'}));</script>`;
+  return html
+    .replace("script-src 'self'", "script-src 'self' blob:")
+    .replace("<head>", `<head>${bridge}`);
+}
+
+class SpecStudioSession implements vscode.Disposable {
+  private readonly panel: vscode.WebviewPanel;
+  private readonly root: vscode.Uri;
+  private readonly sessionDir: vscode.Uri;
+  private readonly documents = new Map<Surface, vscode.Uri>();
+  private readonly subscriptions: vscode.Disposable[] = [];
+  private readonly saveTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private disposed = false;
+
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    private readonly client: LanguageClient,
+    workspaceRoot: vscode.Uri,
+  ) {
+    this.root = vscode.Uri.joinPath(context.extensionUri, "spec-studio");
+    this.sessionDir = vscode.Uri.joinPath(workspaceRoot, ".tcl-lsp", ".spec-studio", "vscode");
+    this.panel = vscode.window.createWebviewPanel(
+      "tclSpecStudio",
+      "Tcl Spec Studio",
+      { viewColumn: vscode.ViewColumn.Beside, preserveFocus: true },
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [this.root],
+      },
+    );
+
+    for (const surface of Object.keys(filenames) as Surface[]) {
+      this.documents.set(surface, vscode.Uri.joinPath(this.sessionDir, filenames[surface]));
+    }
+    this.subscriptions.push(
+      this.panel.webview.onDidReceiveMessage((message: StudioMessage) => this.receive(message)),
+      vscode.workspace.onDidChangeTextDocument((event) => this.documentChanged(event.document)),
+      this.panel.onDidDispose(() => this.dispose()),
+    );
+  }
+
+  async start(): Promise<void> {
+    const index = vscode.Uri.joinPath(this.root, "index.html");
+    let html: string;
+    try {
+      html = (await vscode.workspace.fs.readFile(index)).toString();
+      const nativeModule = (
+        await vscode.workspace.fs.readFile(
+          vscode.Uri.joinPath(this.root, "assets", "native-editor-host.js"),
+        )
+      ).toString();
+      html = injectNativeBridge(html, nativeModule);
+    } catch {
+      void vscode.window.showErrorMessage(
+        "Tcl Spec Studio assets are missing from this extension build. Rebuild with `make spec-studio-wasm`.",
+      );
+      this.dispose();
+      return;
+    }
+    await vscode.workspace.fs.createDirectory(this.sessionDir);
+    this.panel.webview.html = html;
+  }
+
+  reveal(): void {
+    this.panel.reveal(vscode.ViewColumn.Beside, true);
+  }
+
+  private async receive(message: StudioMessage): Promise<void> {
+    if (message.type === "openSurface" && message.surface) {
+      await this.openSurface(message.surface);
+      return;
+    }
+    if (message.type === "surfaceUpdate" && message.surface && typeof message.text === "string") {
+      await this.writeSurface(message.surface, message.text);
+    }
+  }
+
+  private async writeSurface(surface: Surface, text: string): Promise<void> {
+    const uri = this.documents.get(surface)!;
+    const existed = fs.existsSync(uri.fsPath);
+    await vscode.workspace.fs.createDirectory(this.sessionDir);
+    const open = vscode.workspace.textDocuments.find(
+      (document) => document.uri.toString() === uri.toString(),
+    );
+    if (open && open.getText() !== text) {
+      const edit = new vscode.WorkspaceEdit();
+      edit.replace(
+        uri,
+        new vscode.Range(open.positionAt(0), open.positionAt(open.getText().length)),
+        text,
+      );
+      await vscode.workspace.applyEdit(edit);
+      await open.save();
+    } else if (!open) {
+      await vscode.workspace.fs.writeFile(uri, Buffer.from(text, "utf8"));
+    }
+    if (surface === "dsl") await this.notifyPack(uri, existed ? 2 : 1);
+  }
+
+  private async openSurface(surface: Surface): Promise<void> {
+    const uri = this.documents.get(surface)!;
+    if (!fs.existsSync(uri.fsPath)) await this.writeSurface(surface, "");
+    const document = await vscode.workspace.openTextDocument(uri);
+    await vscode.window.showTextDocument(document, {
+      viewColumn: vscode.ViewColumn.One,
+      preserveFocus: false,
+    });
+  }
+
+  private documentChanged(document: vscode.TextDocument): void {
+    const entry = [...this.documents.entries()].find(
+      ([, uri]) => uri.toString() === document.uri.toString(),
+    );
+    if (!entry || this.disposed) return;
+    const [surface] = entry;
+    if (surface === "rust" || surface === "stub") return;
+    void this.panel.webview.postMessage({
+      type: "tclSpecStudioHostUpdate",
+      surface,
+      text: document.getText(),
+    });
+    const key = document.uri.toString();
+    const previous = this.saveTimers.get(key);
+    if (previous) clearTimeout(previous);
+    this.saveTimers.set(
+      key,
+      setTimeout(() => {
+        this.saveTimers.delete(key);
+        void document.save().then(async () => {
+          if (surface === "dsl") await this.notifyPack(document.uri, 2);
+        });
+      }, 120),
+    );
+  }
+
+  private async notifyPack(uri: vscode.Uri, type: 1 | 2 | 3): Promise<void> {
+    await this.client.sendNotification("workspace/didChangeWatchedFiles", {
+      changes: [{ uri: uri.toString(), type }],
+    });
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    for (const timer of this.saveTimers.values()) clearTimeout(timer);
+    for (const subscription of this.subscriptions.splice(0)) subscription.dispose();
+    const pack = this.documents.get("dsl")!;
+    const packExisted = fs.existsSync(pack.fsPath);
+    void vscode.workspace.fs.delete(this.sessionDir, { recursive: true, useTrash: false }).then(
+      async () => {
+        if (packExisted) await this.notifyPack(pack, 3);
+      },
+      (error) => console.error("[spec-studio] could not remove temporary override", error),
+    );
+    if (current === this) current = undefined;
+  }
+}
+
+export async function openSpecStudio(
+  context: vscode.ExtensionContext,
+  client: LanguageClient,
+): Promise<void> {
+  if (current) {
+    current.reveal();
+    return;
+  }
+  const folder = vscode.workspace.workspaceFolders?.[0];
+  if (!folder) {
+    void vscode.window.showErrorMessage(
+      "Tcl Spec Studio needs an open workspace for its temporary pack override.",
+    );
+    return;
+  }
+  current = new SpecStudioSession(context, client, folder.uri);
+  context.subscriptions.push(current);
+  await current.start();
+}
+
+export const specStudioTest = { injectNativeBridge };

--- a/editors/vscode/src/test/commands.test.ts
+++ b/editors/vscode/src/test/commands.test.ts
@@ -46,6 +46,7 @@ suite("Command Registration", () => {
     "tclLsp.insertTemplateSnippet",
     "tclLsp.runRuntimeValidation",
     "tclLsp.openCompilerExplorer",
+    "tclLsp.openSpecStudio",
     "tclLsp.openTkPreview",
     "tclLsp.insertIrule",
     "tclLsp.applyFix",

--- a/rust/bigip-report-gen/python/deploy/github-pages.yml
+++ b/rust/bigip-report-gen/python/deploy/github-pages.yml
@@ -80,6 +80,8 @@ on:
       - "rust/tcl-lsp-server-wasm/**"
       - "rust/tcl-lsp-server/**"
       - "rust/tcl-cli/gui/**"
+      - "rust/web-shared/**"
+      - "scripts/stamp-pages-tool.mjs"
       - "rust/tcl-lexer/**"
       - "rust/tcl-syntax/**"
       - "rust/tcl-registry/**"
@@ -252,6 +254,8 @@ jobs:
           mkdir -p site/compiler-explorer
           cp -r rust/tcl-cli/gui/. site/compiler-explorer/
           rm -f site/compiler-explorer/.gitignore
+          cp rust/web-shared/site-update.js site/compiler-explorer/site-update.js
+          node scripts/stamp-pages-tool.mjs site/compiler-explorer "$TCL_LSP_VERSION"
 
           # Command-registry spec studio → /spec-studio/. The dist IS a
           # directory now — index.html, the lazily-loaded editor chunk under
@@ -269,6 +273,12 @@ jobs:
               || { echo "spec-studio: dist is missing $required"; exit 1; }
           done
           du -sh site/spec-studio
+
+          # The explorer imports the sibling Spec Studio editor bundle on
+          # Pages. Exercise that deployed directory layout in the same browser
+          # installed for the Studio boot check.
+          NODE_PATH="$PWD/rust/tcl-spec-studio/web/node_modules" \
+            node rust/tcl-cli/gui/test/pages-boot.mjs site
 
           # Root landing page linking both apps (the shared Pages root).
           cat > site/index.html <<'HTML'

--- a/rust/tcl-cli/gui/.gitignore
+++ b/rust/tcl-cli/gui/.gitignore
@@ -4,3 +4,5 @@ tcl_explorer_wasm.js
 tcl_explorer_wasm_bg.wasm
 # Mermaid renderer, vendored by `make explorer-wasm`.
 mermaid.min.js
+# Shared Pages update monitor, copied by `make explorer-build`.
+site-update.js

--- a/rust/tcl-cli/gui/index.html
+++ b/rust/tcl-cli/gui/index.html
@@ -138,6 +138,8 @@ body {
   position: relative;
   overflow: hidden;
 }
+#monacoSource { position: absolute; inset: 0; display: none; }
+#monacoSource.monaco-mounted { display: block; }
 .editor-container {
   display: flex;
   height: 100%;
@@ -909,6 +911,7 @@ textarea#source::selection { background: rgba(137, 180, 250, 0.3); }
 .disasm-diff-unchanged-note { padding: 4px 8px; color: var(--text-dim); font-size: 11px; font-style: italic; }
 </style>
 <script src="mermaid.min.js"></script>
+<script src="site-update.js"></script>
 <script>
   mermaid.initialize({
     startOnLoad: false,
@@ -956,6 +959,7 @@ textarea#source::selection { background: rgba(137, 180, 250, 0.3); }
         <span id="shortcutHint" style="color:var(--text-dim); font-size:11px">Ctrl+Enter to compile</span>
       </div>
       <div class="editor-wrap">
+        <div id="monacoSource"></div>
         <div class="editor-container" id="editorContainer">
           <div class="line-numbers" id="lineNumbers"></div>
           <div id="sourceHighlights"></div>
@@ -1054,6 +1058,45 @@ $('#shortcutHint').textContent = shortcutKey + '+Enter to compile';
 
 // Web Worker
 const worker = new Worker('worker.js');
+
+// Pages uses the exact Monaco/TextMate/LSP bundle shipped by Spec Studio.
+// Editor integrations render a different, host-adapted document and therefore
+// never reach this path: their ordinary VS Code/IntelliJ editor stays the one
+// authoritative Tcl surface.
+if ((location.protocol === 'https:' && /(?:^|\.)github\.io$/i.test(location.hostname))
+    || new URLSearchParams(location.search).has('pages-test')) {
+  (async function mountSharedMonaco() {
+    try {
+      const manifestUrl = new URL('../spec-studio/build-info.json', document.baseURI);
+      manifestUrl.searchParams.set('editor-check', String(Date.now()));
+      const info = await fetch(manifestUrl, { cache: 'no-store' }).then(r => r.json());
+      const asset = name => info.assets.find(a => a.name === name);
+      const url = (name, relative) => {
+        const value = new URL('../spec-studio/' + relative, document.baseURI);
+        value.searchParams.set('v', (asset(name) || {}).sha256 || info.version);
+        return value.href;
+      };
+      const editor = await import(url('editor-controller', 'assets/monaco-host.js'));
+      const host = await editor.mountTclEditor({
+        container: $('#monacoSource'),
+        textarea: $('#source'),
+        dialect: $('#dialect').value,
+        workerUrl: url('lsp-worker', 'lsp/worker.js'),
+        stylesheetUrl: url('editor-style', 'assets/monaco-host.css'),
+        grammarUrl: url('tcl-grammar', 'assets/tcl.tmLanguage.json'),
+        onigurumaUrl: url('oniguruma', 'assets/onig.wasm'),
+        onChange: function() { $('#source').dispatchEvent(new Event('input')); },
+        report: function(message) { $('#statusMsg').textContent = message; },
+      });
+      $('#lineNumbers').style.display = 'none';
+      $('#sourceHighlights').style.display = 'none';
+      $('#dialect').addEventListener('change', function() { host.setDialect($('#dialect').value); });
+      window.addEventListener('resize', function() { host.layout(); });
+    } catch (error) {
+      console.warn('Shared Monaco editor unavailable; keeping textarea', error);
+    }
+  })();
+}
 
 worker.onmessage = function(e) {
   const msg = e.data;
@@ -1736,12 +1779,21 @@ document.addEventListener('keydown', e => {
 // Clear selection when source changes (items become stale)
 textarea.addEventListener('input', () => { if (selectedItems.size > 0) clearSelection(); });
 
-// Version bar
-fetch('build_info.json').then(r => r.ok ? r.json() : null).then(info => {
-  if (!info) return;
-  const bar = document.getElementById('versionBar');
-  bar.textContent = `${info.full_version} (${info.build_timestamp})`;
-}).catch(() => {});
+// The Pages staging step replaces this marker and content-keys every external
+// asset. Local/embedded builds leave the readable marker in place.
+const explorerBuildVersion = '__TCL_LSP_BUILD_VERSION__';
+if (explorerBuildVersion.startsWith('__')) {
+  fetch('build_info.json').then(r => r.ok ? r.json() : null).then(info => {
+    if (info) document.getElementById('versionBar').textContent =
+      `${info.full_version} (${info.build_timestamp})`;
+  }).catch(() => {});
+} else {
+  document.getElementById('versionBar').textContent = explorerBuildVersion;
+  window.TclLspSiteUpdate && window.TclLspSiteUpdate.start({
+    currentVersion: explorerBuildVersion,
+    manifestUrl: 'build-info.json',
+  });
+}
 
 // Init
 updateLineNumbers();

--- a/rust/tcl-cli/gui/test/pages-boot.mjs
+++ b/rust/tcl-cli/gui/test/pages-boot.mjs
@@ -1,0 +1,102 @@
+// tcl-lsp — browser contract for the GitHub Pages Compiler Explorer
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { dirname, extname, join, normalize, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const site = resolve(
+  process.argv[2] ?? join(here, "..", "..", "..", "..", "site"),
+);
+const types = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json",
+  ".wasm": "application/wasm",
+};
+
+function serve() {
+  const server = createServer((request, response) => {
+    const url = new URL(request.url ?? "/", "http://localhost");
+    const relative = normalize(decodeURIComponent(url.pathname)).replace(
+      /^(\.\.[/\\])+/,
+      "",
+    );
+    const path = join(
+      site,
+      relative === "/" ? "index.html" : relative.replace(/\/$/, "/index.html"),
+    );
+    if (!path.startsWith(site)) return response.writeHead(403).end("no");
+    readFile(path).then(
+      (body) => {
+        response.writeHead(200, {
+          "content-type": types[extname(path)] ?? "application/octet-stream",
+        });
+        response.end(body);
+      },
+      () => response.writeHead(404).end("not found"),
+    );
+  });
+  return new Promise((resolveServer) =>
+    server.listen(0, "127.0.0.1", () => resolveServer(server)),
+  );
+}
+
+let chromium;
+try {
+  ({ chromium } = createRequire(import.meta.url)("playwright"));
+} catch {
+  console.log(
+    "playwright not installed — skipping Compiler Explorer Pages boot check",
+  );
+  process.exit(0);
+}
+
+const server = await serve();
+const { port } = server.address();
+const browser = await chromium.launch();
+const page = await browser.newPage();
+const problems = [];
+page.on("pageerror", (error) => problems.push(`page error: ${error.message}`));
+page.on("console", (message) => {
+  if (message.type() === "error")
+    problems.push(`console error: ${message.text()}`);
+});
+page.on("requestfailed", (request) =>
+  problems.push(
+    `request failed: ${request.url()} (${request.failure()?.errorText ?? "?"})`,
+  ),
+);
+
+try {
+  await page.goto(`http://127.0.0.1:${port}/compiler-explorer/?pages-test=1`, {
+    waitUntil: "load",
+  });
+  await page.waitForSelector("#monacoSource.monaco-mounted .monaco-editor", {
+    timeout: 120_000,
+  });
+  const textareaHidden = await page.$eval(
+    "#source",
+    (element) => element.hidden,
+  );
+  if (!textareaHidden)
+    throw new Error("the fallback textarea stayed visible beneath Monaco");
+  const version = (await page.textContent("#versionBar"))?.trim();
+  if (!version || version.includes("__TCL_LSP"))
+    throw new Error("the Pages version was not stamped");
+  if (problems.length > 0) throw new Error(problems.join("\n"));
+  console.log(
+    `Compiler Explorer mounted the shared Spec Studio Monaco editor (${version})`,
+  );
+} catch (error) {
+  if (problems.length > 0) console.error(problems.join("\n"));
+  throw error;
+} finally {
+  await page.close();
+  await browser.close();
+  await new Promise((done) => server.close(done));
+}

--- a/rust/tcl-cli/gui/worker.js
+++ b/rust/tcl-cli/gui/worker.js
@@ -52,8 +52,9 @@ async function init() {
 
   // `--target no-modules` defines a global `wasm_bindgen` init function
   // with `compile` attached to it.
-  importScripts(baseUrl + "tcl_explorer_wasm.js");
-  await wasm_bindgen(baseUrl + "tcl_explorer_wasm_bg.wasm");
+  const cacheKey = new URL(self.location.href).search;
+  importScripts(baseUrl + "tcl_explorer_wasm.js" + cacheKey);
+  await wasm_bindgen(baseUrl + "tcl_explorer_wasm_bg.wasm" + cacheKey);
 
   ready = true;
   postMessage({ type: "ready", meta: readMeta() });

--- a/rust/tcl-spec-studio-wasm/build-wasm.sh
+++ b/rust/tcl-spec-studio-wasm/build-wasm.sh
@@ -60,7 +60,7 @@ lspdist="$here/../tcl-lsp-server-wasm/dist"
 dist="$here/dist"
 out="$(mktemp -d)"
 trap 'rm -rf "$out"' EXIT
-version="$(git -C "$here" describe --tags --always --dirty)"
+version="${TCL_LSP_VERSION:-$(git -C "$here" describe --tags --always --dirty)}"
 # Rebuilt from scratch each time: a stale `assets/` or `lsp/` left behind by an
 # older layout would be deployed alongside the new one and served to somebody.
 rm -rf "$dist"
@@ -69,7 +69,7 @@ mkdir -p "$dist/assets" "$dist/lsp"
 echo "==> Spec Studio $version"
 
 echo "==> cargo build --target wasm32-unknown-unknown --release"
-( cd "$here" && cargo build --target wasm32-unknown-unknown --release )
+( cd "$here" && CARGO_TARGET_DIR="$here/target" cargo build --target wasm32-unknown-unknown --release )
 wasm="$here/target/wasm32-unknown-unknown/release/tcl_spec_studio_wasm.wasm"
 
 echo "==> wasm-bindgen (no-modules)"
@@ -122,7 +122,7 @@ else
     echo "    note: node not found — skipping wasm growability check"
 fi
 
-for required in dist/studio.js dist/assets/monaco-host.js dist/assets/monaco-host.css; do
+for required in dist/studio.js dist/assets/monaco-host.js dist/assets/monaco-host.css dist/assets/native-editor-host.js; do
     if [ ! -f "$web/$required" ]; then
         echo "error: $web/$required is missing — build the front-end first:" >&2
         echo "       cd $web && npm ci && npm run build" >&2
@@ -145,23 +145,25 @@ cp "$lspdist/worker.js" "$lspdist/tcl_lsp_server_wasm.js" \
 
 echo "==> copying the editor chunk and shared Tcl grammar into dist/assets/"
 cp "$web/dist/assets/monaco-host.js" "$web/dist/assets/monaco-host.css" \
-   "$web/dist/assets/tcl.tmLanguage.json" "$web/dist/assets/onig.wasm" "$dist/assets/"
+   "$web/dist/assets/native-editor-host.js" "$web/dist/assets/tcl.tmLanguage.json" \
+   "$web/dist/assets/onig.wasm" "$dist/assets/"
 
 echo "==> assembling dist/index.html"
 python3 - \
     "$web/studio.html" "$web/src/studio.css" "$web/dist/studio.js" \
     "$out/tcl_spec_studio_wasm.js" "$out/tcl_spec_studio_wasm_bg.wasm" \
     "$dist/index.html" "$assets" "$dist/assets/monaco-host.js" \
-    "$dist/assets/monaco-host.css" "$dist/assets/tcl.tmLanguage.json" \
+    "$dist/assets/monaco-host.css" "$dist/assets/native-editor-host.js" \
+    "$dist/assets/tcl.tmLanguage.json" \
     "$dist/assets/onig.wasm" "$dist/lsp/worker.js" \
     "$dist/lsp/tcl_lsp_server_wasm.js" "$dist/lsp/tcl_lsp_server_wasm_bg.wasm" \
-    "$version" <<'PY'
+    "$here/../web-shared/site-update.js" "$version" <<'PY'
 import base64, hashlib, json, os, sys
 (
     tmpl_path, css_path, js_path, glue_path, wasm_path, out_path, assets_dir,
-    editor_js_path, editor_css_path, grammar_path, oniguruma_path,
-    lsp_worker_path, lsp_glue_path, lsp_wasm_path, version,
-) = sys.argv[1:16]
+    editor_js_path, editor_css_path, native_editor_js_path, grammar_path, oniguruma_path,
+    lsp_worker_path, lsp_glue_path, lsp_wasm_path, site_update_path, version,
+) = sys.argv[1:18]
 
 def read_bytes(path):
     with open(path, "rb") as stream:
@@ -182,11 +184,13 @@ glue_bytes = read_bytes(glue_path)
 wasm_bytes = read_bytes(wasm_path)
 editor_js_bytes = read_bytes(editor_js_path)
 editor_css_bytes = read_bytes(editor_css_path)
+native_editor_js_bytes = read_bytes(native_editor_js_path)
 grammar_bytes = read_bytes(grammar_path)
 oniguruma_bytes = read_bytes(oniguruma_path)
 lsp_worker_bytes = read_bytes(lsp_worker_path)
 lsp_glue_bytes = read_bytes(lsp_glue_path)
 lsp_wasm_bytes = read_bytes(lsp_wasm_path)
+site_update_bytes = read_bytes(site_update_path)
 tmpl = tmpl_bytes.decode("utf-8")
 css = css_bytes.decode("utf-8")
 js = js_bytes.decode("utf-8")
@@ -211,12 +215,14 @@ build_info = {
         asset("html-shell", tmpl_bytes),
         asset("studio-style", css_bytes),
         asset("studio-controller", js_bytes),
+        asset("site-update-monitor", site_update_bytes),
         asset("studio-wasm-glue", glue_bytes),
         asset("studio-wasm", wasm_bytes),
         asset("logo-light", logo_bytes["__LOGO_TCL_LSP__"]),
         asset("logo-dark", logo_bytes["__LOGO_TCL_LSP_DARK__"]),
         asset("editor-controller", editor_js_bytes),
         asset("editor-style", editor_css_bytes),
+        asset("native-editor-controller", native_editor_js_bytes),
         asset("tcl-grammar", grammar_bytes),
         asset("oniguruma", oniguruma_bytes),
         asset("lsp-worker", lsp_worker_bytes),
@@ -261,6 +267,7 @@ CSP = (
 # payload are safe.
 tmpl = tmpl.replace("__CSP__", CSP)
 tmpl = tmpl.replace("__STYLES__", "<style>" + css + "</style>")
+tmpl = tmpl.replace("<head>", "<head><script>" + site_update_bytes.decode("utf-8") + "</script>", 1)
 tmpl = tmpl.replace(
     "__BUILD_INFO__",
     '<script id="studio-build" type="application/json">' + build_json + "</script>",
@@ -276,6 +283,7 @@ for tok in (
     if tok in tmpl:
         raise SystemExit(f"placeholder {tok} substitution failed")
 open(out_path, "w", encoding="utf-8").write(tmpl)
+open(os.path.join(os.path.dirname(out_path), "build-info.json"), "w", encoding="utf-8").write(build_json + "\n")
 print(f"    wrote {out_path} ({len(tmpl)/1024/1024:.2f} MiB, wasm {len(b64)/1024/1024:.2f} MiB b64)")
 PY
 

--- a/rust/tcl-spec-studio/web/build.mjs
+++ b/rust/tcl-spec-studio/web/build.mjs
@@ -31,6 +31,7 @@ const distDir = join(here, "dist");
 const assetsDir = join(distDir, "assets");
 const testsDir = join(distDir, "tests");
 const version =
+  process.env.TCL_LSP_VERSION ??
   process.env.TCL_LSP_GIT_DESCRIBE ??
   execFileSync("git", ["describe", "--tags", "--always", "--dirty"], {
     cwd: here,
@@ -99,6 +100,24 @@ await esbuild.build({
   logLevel: "info",
 });
 
+// Editor integrations inject a tiny host bridge and use their ordinary native
+// editors for Pack DSL, Test Tcl, generated Rust, and the generated stub.
+// Keep this separate from Monaco so embedding Studio does not embed an editor
+// inside an editor.
+await esbuild.build({
+  entryPoints: [join(here, "src", "nativeEditorHost.ts")],
+  outfile: join(assetsDir, "native-editor-host.js"),
+  bundle: true,
+  format: "esm",
+  target: "es2020",
+  platform: "browser",
+  minify: true,
+  legalComments: "none",
+  banner: { js: banner },
+  define: { __SPEC_STUDIO_FRONTEND_VERSION__: JSON.stringify(version) },
+  logLevel: "info",
+});
+
 // Monaco has no bundled Tcl syntax. Ship the exact TextMate grammar used by
 // the VS Code extension, plus the same Oniguruma engine that executes it, so
 // the Studio's pre-semantic paint cannot drift into a second Tcl grammar.
@@ -129,5 +148,5 @@ await esbuild.build({
 });
 
 console.log(
-  `spec studio front-end ${version}: built dist/studio.js + dist/assets/monaco-host.{js,css}`,
+  `spec studio front-end ${version}: built dist/studio.js + native/Monaco editor hosts`,
 );

--- a/rust/tcl-spec-studio/web/src/editorHost.ts
+++ b/rust/tcl-spec-studio/web/src/editorHost.ts
@@ -93,3 +93,18 @@ export interface MonacoHostModule {
   buildVersion: string;
   mountEditors(options: EditorHostOptions): Promise<EditorHost>;
 }
+
+/** Native-editor host injected by an editor integration before Studio boots. */
+export interface NativeEditorBridge {
+  postMessage(message: unknown): void;
+}
+
+declare global {
+  interface Window {
+    __tclSpecStudioHost?: NativeEditorBridge;
+    __tclSpecStudioNativeModuleUrl?: string;
+    TclLspSiteUpdate?: {
+      start(options: { currentVersion: string; manifestUrl?: string; intervalMs?: number }): void;
+    };
+  }
+}

--- a/rust/tcl-spec-studio/web/src/monacoHost.ts
+++ b/rust/tcl-spec-studio/web/src/monacoHost.ts
@@ -72,6 +72,7 @@ const DSL_URI = "file:///__tcl_spec_studio__/pack.tclspec";
 const SAMPLE_URI = "file:///__tcl_spec_studio__/sample.tcl";
 const RUST_URI = "file:///__tcl_spec_studio__/command.rs";
 const STUB_URI = "file:///__tcl_spec_studio__/stubs.tcl";
+const EXPLORER_URI = "file:///__tcl_compiler_explorer__/source.tcl";
 
 /** How long keystrokes settle before the change is pushed on. */
 const SETTLE_MS = 120;
@@ -571,6 +572,60 @@ export async function mountEditors(options: EditorHostOptions): Promise<EditorHo
       rust.layout();
       stub.layout();
     },
+    get lspReady() {
+      return ready;
+    },
+  };
+}
+
+/** Options for the Compiler Explorer's single editable Tcl surface. */
+export interface TclEditorOptions {
+  container: HTMLElement;
+  textarea: HTMLTextAreaElement;
+  onChange(text: string): void;
+  dialect: string;
+  workerUrl: string;
+  stylesheetUrl: string;
+  grammarUrl: string;
+  onigurumaUrl: string;
+  report?(message: string, kind?: "ok" | "err"): void;
+}
+
+/** Mount the same Monaco/TextMate/LSP stack for Compiler Explorer on Pages. */
+export async function mountTclEditor(options: TclEditorOptions): Promise<{
+  setDialect(dialect: string): void;
+  layout(): void;
+  readonly lspReady: boolean;
+}> {
+  await loadStylesheet(options.stylesheetUrl);
+  registerLanguages();
+  await registerTclGrammar(monaco, [TCL_LANGUAGE], options.grammarUrl, options.onigurumaUrl);
+  monaco.editor.setTheme(currentTheme());
+  let client: LspClient | null = null;
+  try {
+    client = await startLspClient(options.workerUrl);
+    registerProviders(client);
+  } catch (error) {
+    options.report?.(
+      `language server unavailable: ${error instanceof Error ? error.message : String(error)}`,
+      "err",
+    );
+  }
+  const surface = new Surface(
+    { container: options.container, textarea: options.textarea, onChange: options.onChange },
+    EXPLORER_URI,
+    TCL_LANGUAGE,
+    options.dialect,
+    client,
+  );
+  client?.onDiagnostics((uri, items) => {
+    if (uri === surface.documentUri) surface.setDiagnostics(items);
+  });
+  options.report?.("using the shared Tcl Monaco editor", "ok");
+  const ready = client !== null;
+  return {
+    setDialect: (dialect) => surface.setLanguageId(dialect),
+    layout: () => surface.layout(),
     get lspReady() {
       return ready;
     },

--- a/rust/tcl-spec-studio/web/src/nativeEditorHost.ts
+++ b/rust/tcl-spec-studio/web/src/nativeEditorHost.ts
@@ -1,0 +1,94 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type {
+  EditorHost,
+  EditorHostOptions,
+  MonacoHostModule,
+  OutputSurfaceSpec,
+  SurfaceSpec,
+} from "./editorHost.js";
+
+declare const __SPEC_STUDIO_FRONTEND_VERSION__: string;
+export const buildVersion = __SPEC_STUDIO_FRONTEND_VERSION__;
+
+type Surface = "dsl" | "sample" | "rust" | "stub";
+
+interface HostUpdate {
+  type: "tclSpecStudioHostUpdate";
+  surface: Surface;
+  text: string;
+}
+
+function openButton(container: HTMLElement, surface: Surface, label: string): void {
+  container.replaceChildren();
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "primary native-editor-button";
+  button.textContent = `Open ${label} in editor`;
+  button.addEventListener("click", () => {
+    window.__tclSpecStudioHost?.postMessage({ type: "openSurface", surface });
+  });
+  container.append(button);
+}
+
+function outputText(spec: OutputSurfaceSpec): string {
+  return spec.fallback.textContent ?? "";
+}
+
+export async function mountEditors(options: EditorHostOptions): Promise<EditorHost> {
+  const bridge = window.__tclSpecStudioHost;
+  if (!bridge) throw new Error("the native editor bridge was not installed");
+
+  openButton(options.dsl.container, "dsl", "Pack DSL");
+  openButton(options.sample.container, "sample", "Test Tcl");
+  openButton(options.rust.container, "rust", "generated Rust");
+  openButton(options.stub.container, "stub", "generated stub");
+
+  const texts: Record<Surface, string> = {
+    dsl: options.dsl.textarea.value,
+    sample: options.sample.textarea.value,
+    rust: outputText(options.rust),
+    stub: outputText(options.stub),
+  };
+
+  const publish = (surface: Surface, text: string): void => {
+    if (texts[surface] === text) return;
+    texts[surface] = text;
+    bridge.postMessage({ type: "surfaceUpdate", surface, text });
+  };
+
+  const acceptEdit = (spec: SurfaceSpec, surface: "dsl" | "sample", text: string): void => {
+    if (texts[surface] === text) return;
+    texts[surface] = text;
+    spec.textarea.value = text;
+    spec.onChange(text);
+  };
+
+  window.addEventListener("message", (event: MessageEvent<unknown>) => {
+    const update = event.data as Partial<HostUpdate> | undefined;
+    if (update?.type !== "tclSpecStudioHostUpdate" || typeof update.text !== "string") return;
+    if (update.surface === "dsl") acceptEdit(options.dsl, "dsl", update.text);
+    if (update.surface === "sample") acceptEdit(options.sample, "sample", update.text);
+  });
+
+  bridge.postMessage({ type: "surfaceUpdate", surface: "dsl", text: texts.dsl });
+  bridge.postMessage({ type: "surfaceUpdate", surface: "sample", text: texts.sample });
+  bridge.postMessage({ type: "surfaceUpdate", surface: "rust", text: texts.rust });
+  bridge.postMessage({ type: "surfaceUpdate", surface: "stub", text: texts.stub });
+  bridge.postMessage({ type: "studioReady" });
+  options.report("using the editor host's native Tcl language support", "ok");
+
+  return {
+    setDslText: (text) => publish("dsl", text),
+    setSampleText: (text) => publish("sample", text),
+    setRustText: (text) => publish("rust", text),
+    setStubText: (text) => publish("stub", text),
+    setDialect: (dialect) => bridge.postMessage({ type: "dialectUpdate", dialect }),
+    layout: () => undefined,
+    lspReady: true,
+  };
+}
+
+const moduleShape: MonacoHostModule = { buildVersion, mountEditors };
+void moduleShape;

--- a/rust/tcl-spec-studio/web/src/studio.ts
+++ b/rust/tcl-spec-studio/web/src/studio.ts
@@ -97,6 +97,7 @@ const SAMPLE_HINT = "# Call your pack's commands here.\n";
  * page back on the textarea it has always had.
  */
 const EDITOR_CHUNK = "assets/monaco-host.js";
+const NATIVE_EDITOR_CHUNK = "assets/native-editor-host.js";
 
 /** Where the language server worker's three files sit in the dist. */
 const LSP_WORKER_DIR = "lsp";
@@ -1767,7 +1768,11 @@ async function mountEditorHost(): Promise<void> {
   };
   editorMounting = (async () => {
     report("loading the editor…");
-    const specifier = assetUrl(activeBuildInfo, "editor-controller", EDITOR_CHUNK);
+    const native = window.__tclSpecStudioHost !== undefined;
+    const specifier = native
+      ? (window.__tclSpecStudioNativeModuleUrl ??
+        assetUrl(activeBuildInfo, "native-editor-controller", NATIVE_EDITOR_CHUNK))
+      : assetUrl(activeBuildInfo, "editor-controller", EDITOR_CHUNK);
     const chunk = (await import(specifier)) as MonacoHostModule;
     if (!verifyAssetVersion(activeBuildInfo, "editor controller", chunk.buildVersion)) return;
     editorHost = await chunk.mountEditors({
@@ -2128,6 +2133,7 @@ function boot(): void {
   const buildInfo = verifyBuildInfo();
   if (!buildInfo) return;
   activeBuildInfo = buildInfo;
+  window.TclLspSiteUpdate?.start({ currentVersion: buildInfo.version });
   const payload = byId("studio-wasm").textContent?.trim() ?? "";
   const binary = Uint8Array.from(atob(payload), (c) => c.charCodeAt(0));
 

--- a/rust/tcl-spectcl/src/discovery.rs
+++ b/rust/tcl-spectcl/src/discovery.rs
@@ -50,10 +50,12 @@ use std::path::{Path, PathBuf};
 use crate::PACK_EXTENSION;
 
 /// Which discovery tier a file came from. `Ord` is the precedence order —
-/// [`Tier::Workspace`] is the nearest and lowest, so a plain sort puts the
+/// [`Tier::StudioOverride`] is the nearest and lowest, so a plain sort puts the
 /// winner first.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Tier {
+    /// A live editor-hosted Spec Studio session under `.tcl-lsp/.spec-studio/`.
+    StudioOverride,
     /// The `tclLsp.specPacks` setting, `.tcl-lsp/`, or beside a `tclpkg.tcl`.
     Workspace,
     /// The per-user platform config directory, loaded for every workspace.
@@ -67,6 +69,7 @@ impl Tier {
     #[must_use]
     pub fn label(self) -> &'static str {
         match self {
+            Tier::StudioOverride => "Spec Studio override",
             Tier::Workspace => "workspace",
             Tier::User => "user",
             Tier::Bundled => "bundled",
@@ -78,6 +81,8 @@ impl Tier {
 /// pack in, which is the first question when an unexpected pack loads.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Origin {
+    /// Materialised by an editor-hosted Spec Studio session.
+    StudioOverride,
     /// Named by, or found under a directory named by, `tclLsp.specPacks`.
     Setting,
     /// Found under a `.tcl-lsp/` directory in a workspace folder.
@@ -95,6 +100,7 @@ impl Origin {
     #[must_use]
     pub fn label(self) -> &'static str {
         match self {
+            Origin::StudioOverride => ".tcl-lsp/.spec-studio/",
             Origin::Setting => "tclLsp.specPacks",
             Origin::DotDir => ".tcl-lsp/",
             Origin::BesideManifest => "beside tclpkg.tcl",
@@ -118,6 +124,9 @@ pub struct PackFile {
 
 /// The directory a workspace folder keeps its own packs in.
 pub const WORKSPACE_PACK_DIR: &str = ".tcl-lsp";
+
+/// Hidden session directory used by native editor-hosted Spec Studio panels.
+pub const STUDIO_OVERRIDE_DIR: &str = ".spec-studio";
 
 /// The package manifest whose directory is scanned for sibling packs.
 pub const PACKAGE_MANIFEST: &str = "tclpkg.tcl";
@@ -248,6 +257,12 @@ pub fn discover(options: &DiscoveryOptions) -> Vec<PackFile> {
 
     // --- workspace tier -----------------------------------------------------
     for root in &options.workspace_roots {
+        collect_dir(
+            &root.join(WORKSPACE_PACK_DIR).join(STUDIO_OVERRIDE_DIR),
+            Tier::StudioOverride,
+            Origin::StudioOverride,
+            &mut found,
+        );
         for configured in &options.configured {
             let path = if configured.is_absolute() {
                 configured.clone()
@@ -567,8 +582,12 @@ mod tests {
     }
 
     #[test]
-    fn tiers_sort_workspace_then_user_then_bundled() {
+    fn tiers_sort_studio_workspace_user_then_bundled() {
         let root = tmpdir("tiers");
+        write(
+            &root.join("ws/.tcl-lsp/.spec-studio/session/live.tclspec"),
+            "speclib live 1 {}\n",
+        );
         write(&root.join("ws/.tcl-lsp/w.tclspec"), "speclib w 1 {}\n");
         write(&root.join("user/u.tclspec"), "speclib u 1 {}\n");
         write(&root.join("bundled/b.tclspec"), "speclib b 1 {}\n");
@@ -580,7 +599,15 @@ mod tests {
             ..DiscoveryOptions::default()
         });
         let tiers: Vec<Tier> = found.iter().map(|f| f.tier).collect();
-        assert_eq!(tiers, vec![Tier::Workspace, Tier::User, Tier::Bundled]);
+        assert_eq!(
+            tiers,
+            vec![
+                Tier::StudioOverride,
+                Tier::Workspace,
+                Tier::User,
+                Tier::Bundled
+            ]
+        );
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/rust/tcl-spectcl/src/pack.rs
+++ b/rust/tcl-spectcl/src/pack.rs
@@ -27,7 +27,8 @@
 //!   directory-iteration order, which no filesystem promises.
 //! - **A command defined twice within one pack is a load-time diagnostic with
 //!   the first definition winning**, never a silent overwrite.
-//! - **Nearest tier wins**: a pack name declared at more than one tier loads
+//! - **Nearest tier wins**: a live Spec Studio override, then a workspace,
+//!   user, or bundled pack. A pack name declared at more than one tier loads
 //!   only from its nearest one, and the shadowed files are reported. This is
 //!   whole-pack, not per-command — a user-tier pack is not a base a workspace
 //!   pack patches, it is a different copy of the same pack, and merging them
@@ -541,13 +542,23 @@ mod tests {
             "ws/mylib.tclspec",
             "speclib mylib 1 {\n  command mylib::ws { arity 1 }\n}\n",
         );
+        let studio = write(
+            &dir,
+            "studio/mylib.tclspec",
+            "speclib mylib 1 {\n  command mylib::live { arity 2 }\n}\n",
+        );
         let user = write(
             &dir,
             "user/mylib.tclspec",
             "speclib mylib 1 {\n  command mylib::user { arity 1 }\n}\n",
         );
         let set = load(&[
-            workspace_file(ws),
+            PackFile {
+                tier: Tier::StudioOverride,
+                path: studio,
+                origin: Origin::StudioOverride,
+            },
+            workspace_file(ws.clone()),
             PackFile {
                 tier: Tier::User,
                 path: user.clone(),
@@ -556,11 +567,15 @@ mod tests {
         ]);
         assert_eq!(set.packs.len(), 1);
         let names: Vec<&str> = set.packs[0].commands.iter().map(|c| c.spec.name).collect();
-        assert_eq!(names, vec!["mylib::ws"]);
+        assert_eq!(names, vec!["mylib::live"]);
         assert!(
             set.notices
                 .iter()
-                .any(|n| n.path == user && n.message.contains("is not loaded")),
+                .any(|n| n.path == user && n.message.contains("is not loaded"))
+                && set
+                    .notices
+                    .iter()
+                    .any(|n| n.path == ws && n.message.contains("Spec Studio override")),
             "{:#?}",
             set.notices
         );

--- a/rust/web-shared/site-update.js
+++ b/rust/web-shared/site-update.js
@@ -1,0 +1,74 @@
+// tcl-lsp — shared GitHub Pages update monitor
+// SPDX-License-Identifier: AGPL-3.0-or-later
+(function (global) {
+  "use strict";
+  var timer = null;
+  function onPages() {
+    return (
+      (location.protocol === "https:" &&
+        /(?:^|\.)github\.io$/i.test(location.hostname)) ||
+      new URLSearchParams(location.search).has("pages-test")
+    );
+  }
+  function show(current, latest) {
+    if (document.getElementById("tcl-lsp-site-update")) return;
+    var banner = document.createElement("aside");
+    banner.id = "tcl-lsp-site-update";
+    banner.setAttribute("role", "status");
+    banner.style.cssText =
+      "position:fixed;z-index:2147483647;left:12px;right:12px;bottom:12px;padding:10px 14px;border:1px solid #f9e2af;border-radius:6px;background:#181825;color:#f9e2af;font:13px system-ui,sans-serif;box-shadow:0 4px 18px #0008";
+    var text = document.createElement("span");
+    text.textContent =
+      "A newer tcl-lsp web build is available (" +
+      latest +
+      "; this tab is " +
+      current +
+      "). ";
+    var reload = document.createElement("button");
+    reload.type = "button";
+    reload.textContent = "Reload now";
+    reload.style.cssText = "margin-left:8px;padding:3px 8px;cursor:pointer";
+    reload.addEventListener("click", function () {
+      location.reload();
+    });
+    banner.append(text, reload);
+    document.body.appendChild(banner);
+  }
+  async function check(options) {
+    try {
+      var url = new URL(
+        options.manifestUrl || "build-info.json",
+        document.baseURI,
+      );
+      url.searchParams.set("update-check", String(Date.now()));
+      var response = await fetch(url.href, {
+        cache: "no-store",
+        credentials: "omit",
+      });
+      if (!response.ok) return;
+      var latest = await response.json();
+      if (
+        latest &&
+        latest.version &&
+        latest.version !== options.currentVersion
+      ) {
+        show(options.currentVersion, latest.version);
+      }
+    } catch (_) {
+      // Update checks are advisory. Offline use must remain completely quiet.
+    }
+  }
+  global.TclLspSiteUpdate = {
+    start: function (options) {
+      if (!onPages() || !options || !options.currentVersion) return;
+      check(options);
+      if (timer !== null) clearInterval(timer);
+      timer = setInterval(function () {
+        check(options);
+      }, options.intervalMs || 300000);
+      document.addEventListener("visibilitychange", function () {
+        if (document.visibilityState === "visible") check(options);
+      });
+    },
+  };
+})(window);

--- a/scripts/stamp-pages-tool.mjs
+++ b/scripts/stamp-pages-tool.mjs
@@ -1,0 +1,59 @@
+// tcl-lsp — stamp one GitHub Pages tool with versioned asset URLs
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { createHash } from "node:crypto";
+import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const [directory, version] = process.argv.slice(2);
+if (!directory || !version)
+  throw new Error("usage: stamp-pages-tool.mjs DIRECTORY VERSION");
+
+const files = [];
+function walk(dir) {
+  for (const name of readdirSync(dir).sort()) {
+    if (name === "build-info.json") continue;
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) walk(path);
+    else files.push(path);
+  }
+}
+walk(directory);
+
+function describe(path) {
+  const bytes = readFileSync(path);
+  return {
+    name: relative(directory, path).replaceAll("\\", "/"),
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    bytes: bytes.length,
+  };
+}
+let assets = files.map(describe);
+const hash = (name) =>
+  assets.find((asset) => asset.name === name)?.sha256 ?? version;
+const indexPath = join(directory, "index.html");
+let html = readFileSync(indexPath, "utf8").replaceAll(
+  "__TCL_LSP_BUILD_VERSION__",
+  version,
+);
+for (const name of [
+  "mermaid.min.js",
+  "site-update.js",
+  "explorer-core.js",
+  "worker.js",
+  "tcl-lsp-logo.svg",
+  "favicon.png",
+]) {
+  // The worker's query propagates to the glue and WASM it imports, so key the
+  // whole worker graph by the build rather than only by worker.js's bytes.
+  const versioned = `${name}?v=${name === "worker.js" ? version : hash(name)}`;
+  html = html.replaceAll(`"${name}"`, `"${versioned}"`);
+  html = html.replaceAll(`'${name}'`, `'${versioned}'`);
+}
+writeFileSync(indexPath, html);
+// Stamping changes index.html, so describe the deployed bytes rather than the
+// input copy. This also makes the manifest useful as a provenance record.
+assets = files.map(describe);
+writeFileSync(
+  join(directory, "build-info.json"),
+  JSON.stringify({ version, assets }, null, 2) + "\n",
+);


### PR DESCRIPTION
## Summary

- add VS Code and JetBrains Spec Studio panels whose DSL, test Tcl, generated Rust, and stub open in the host's ordinary editor
- materialise the active pack under `.tcl-lsp/.spec-studio/` as a highest-precedence temporary override, notify the running LSP on every save, and unload it when the Studio closes
- make Compiler Explorer and Spec Studio share the exact Monaco/TextMate/LSP editor bundle on GitHub Pages while editor integrations keep their native VS Code/IntelliJ editors
- give Compiler Explorer the same build-version provenance and content-keyed cache breaking as Spec Studio
- add a shared periodic Pages update monitor that warns stale tabs and offers a reload
- package the Studio assets in both editor distributions and browser-test the sibling Pages layout

Depends on #1511.

Closes #1505.
Closes #1506.

## Validation

- `make rust-check`
- `make prep-pr` (`PREP_PR_EXIT=0`)
- VS Code integration suite: 893 passing
- JetBrains `compileKotlin` and `test`
- `cargo test -p tcl-spectcl`
- Spec Studio web unit suite: 32 passing
- assembled Spec Studio Playwright boot
- Compiler Explorer sibling-site shared-Monaco Playwright boot