### PR TITLE
Align LSP feature contracts with shared owners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -726,18 +726,18 @@ registered, and the handler body checks whether the feature is enabled before
 doing work (returning nothing when disabled). This allows features to be
 toggled via `didChangeConfiguration` without restarting.
 
-A small set of features cannot follow this pattern because their handler
-registration changes the `ServerCapabilities` advertised during `initialize`,
-which alters client behaviour irreversibly for the session. These
-restart-required toggles are decided at `initialize` time in the native
-server (`tcl-lsp-server` / `tcl-lsp-core`). Currently this set includes:
+A small set of features cannot follow this pattern because their capability
+advertisement is decided during `initialize`, which alters client behaviour
+for the session. There are currently no user-configurable restart-required
+toggles.
 
-- **`pull_diagnostics_enabled`** — registers `textDocument/diagnostic` and
-  `workspace/diagnostic` handlers, which flips `vscode-languageclient` into
-  pull mode and disables the push pipeline.
-
-Changing a restart-required toggle at runtime logs a warning but has no
-effect until the server process is restarted.
+Diagnostics are deliberately not one: the server always advertises the push
+model and never advertises `diagnosticProvider`. Its
+`textDocument/diagnostic` and `workspace/diagnostic` handlers remain available
+for direct requests against the shared cache, but a setting must not attempt to
+switch the delivery model after initialisation. See
+`docs/design/contracts/lsp-diagnostics-publication.md` for the delivery
+contract.
 
 ## Lexer token types
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4238,6 +4238,7 @@ dependencies = [
  "tcl-compiler",
  "tcl-lexer",
  "tcl-registry",
+ "tcl-syntax",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4236,6 +4236,7 @@ version = "0.1.0"
 dependencies = [
  "serde_json",
  "tcl-compiler",
+ "tcl-dialect",
  "tcl-lexer",
  "tcl-registry",
  "tcl-syntax",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4394,6 +4394,7 @@ dependencies = [
  "tcl-bigip",
  "tcl-compiler",
  "tcl-core-types",
+ "tcl-diagram",
  "tcl-dialect",
  "tcl-explorer",
  "tcl-lexer",

--- a/docs/design/contracts/lsp-diagnostics-publication.md
+++ b/docs/design/contracts/lsp-diagnostics-publication.md
@@ -29,12 +29,12 @@ advertised. Both are deliberate, and they are two halves of one rule:
   advertises the capability whether or not it will use it — would otherwise
   get neither push (suppressed) nor pull (unadvertised): zero diagnostics.
 
-The `textDocument/diagnostic` and `workspace/diagnostic` handlers are
-implemented and answer correctly, backed by `pull_diag_cache`, and the
-`tclLsp.features.pullDiagnostics` setting exists in the VS Code contribution
-schema (default `false`). Nothing in the server currently reads that setting
-or flips the advertisement, so pull remains unreachable through configuration
-alone; the handlers serve a client that requests them directly.
+The `textDocument/diagnostic` and `workspace/diagnostic` handlers remain
+implemented and answer correctly, backed by `pull_diag_cache`, for clients
+that request them directly. Pull is intentionally not exposed as a contributed
+editor setting: changing the delivery model requires a different capability
+advertised during `initialize`, and cannot be switched safely by a later
+configuration refresh without a server restart and client reinitialisation.
 
 Whatever the delivery channel, a pull response and a push notification are
 built from the same `finalise_diagnostics` path, so the two cannot disagree

--- a/docs/design/dialect-profile-model.md
+++ b/docs/design/dialect-profile-model.md
@@ -580,12 +580,17 @@ lives with the analyser:
   (`flush_dsl_gate_diagnostics`), because the effective version depends on
   `package require` lines that may appear anywhere in the file.
 - Which argument is a format string comes from the registry
-  (`CommandRegistry::format_string_args`), never from matching a command
-  name. The `FormatType` family check is load-bearing: `clock`'s field
-  string, `binary`'s cursor spec, and `regsub`'s backreference template all
-  sit at `ArgRole::FormatString` / `ArgRole::ScanFormat` positions too, and
-  running the sprintf table over `clock format $t -format {%b}` would report
-  a Tcl 8.6 requirement for a conversion that has nothing to do with
+  (`CommandRegistry::format_string_args` for compatibility callers and
+  `format_string_args_words_for_dialect` for source-aware consumers), never
+  from matching a command name. The source-aware query receives each word's
+  literal/dynamic/expanded shape and the profiled option table: an unresolved
+  leading `$mode` must not be projected into a positional `regsub`
+  replacement or a pattern role. The same proof boundary owns regex/glob
+  pattern queries. The `FormatType` family check is load-bearing: `clock`'s
+  field string, `binary`'s cursor spec, and `regsub`'s backreference template
+  all sit at `ArgRole::FormatString` / `ArgRole::ScanFormat` positions too,
+  and running the sprintf table over `clock format $t -format {%b}` would
+  report a Tcl 8.6 requirement for a conversion that has nothing to do with
   `format`. Only `FormatType::Sprintf` words are gated.
 - A word whose token is a `Var` or `Cmd` substitution is skipped: its text is
   not the literal %-string.

--- a/docs/kcs/features/kcs-feature-diagnostics.md
+++ b/docs/kcs/features/kcs-feature-diagnostics.md
@@ -23,7 +23,7 @@ all-editors, MCP, Claude skill, diagnostic, warning
 
 The analyser produces diagnostics in categories: errors (E-codes), security (S-codes), taint (T-codes), performance/style (W-codes), and optimiser suggestions (O-codes). Diagnostics are published on every document change via the LSP `textDocument/publishDiagnostics` notification (the default push model).
 
-The server also supports pull-model diagnostics — `textDocument/diagnostic` for one document and `workspace/diagnostic` for the whole workspace — for editors that prefer to request diagnostics on demand. Pull responses return the same set the push model publishes, and an unchanged document is answered with a cheap `Unchanged` report. Pull mode is off by default and is enabled with `tclLsp.features.pullDiagnostics`; turning it on causes most clients to stop honouring the push notifications, so use one model or the other, not both.
+The server also answers pull-model requests — `textDocument/diagnostic` for one document and `workspace/diagnostic` for the whole workspace — from the same cache, for clients that request them directly. Pull is not a user setting: switching delivery models changes the capability advertised during `initialize`, so it must be agreed by the client and server for a fresh session. Push publication remains the editor default.
 
 ## Failure modes
 

--- a/docs/kcs/kcs-qa-what-config-sections-are-valid.md
+++ b/docs/kcs/kcs-qa-what-config-sections-are-valid.md
@@ -104,13 +104,13 @@ the server stop advertising or running that feature. Valid keys:
 `folding`, `rename`, `signatureHelp`, `workspaceSymbols`,
 `inlayHints`, `callHierarchy`, `documentLinks`, `selectionRange`,
 `documentHighlight`, `codeLens`, `workspaceFileOps`,
-`pullDiagnostics`, `willSaveWaitUntil`, `progress`,
+`willSaveWaitUntil`, `progress`,
 `implementation`, `typeDefinition`, `declaration`,
 `linkedEditingRange`, `crossFileResolution`.
 
-A few of these (notably `pullDiagnostics`) only take effect after a
-server restart because they change which LSP handlers are
-registered.
+Delivery-model changes are not configuration toggles: diagnostics use push
+publication, while pull requests are supported only when a client requests
+them directly.
 
 `crossFileResolution` (default off) enables the broader, bare-name
 workspace inference for W123. Exact cross-file command candidates are already

--- a/docs/references/command-spec/fields.md
+++ b/docs/references/command-spec/fields.md
@@ -1228,6 +1228,7 @@ The registry's behavioural vocabulary — one flag per fact a consumer might nee
 | `LANGUAGE_KEYWORD` | a language keyword rather than a plain command |
 | `HAS_BOOLEAN_COND` | takes a boolean condition |
 | `TERMINATES_BLOCK` | terminates the enclosing basic block |
+| `TERMINATES_PROCESS` | terminates the interpreter process without Tcl unwinding |
 | `HAS_LOOP_BODY` | takes a loop body |
 | `NEVER_INLINE_BODY` | its body must never be inlined |
 | `LOOP_LIST_HEADER` | a loop header with list-expression arguments |

--- a/docs/references/command-spec/fields.md
+++ b/docs/references/command-spec/fields.md
@@ -331,6 +331,12 @@ The completable values for specific argument positions — the mode words of `bi
 
 Which pattern language the command's Pattern argument speaks: glob (`string match`, `lsearch` default) or regular expression (`regexp`, `regsub`, `lsearch -regexp`). The pattern is then checked and highlighted in the right language — a `*` means something very different in each.
 
+### `pattern_arg_resolver` — Pattern-argument resolver
+
+*command only* — Native hook selecting pattern positions and languages for a concrete call.
+
+A native hook that selects the Pattern argument positions and language for this particular call. Use it when options change the pattern grammar, such as `lsearch -regexp`; the Studio preserves the need for the hook but cannot recover a Rust function pointer from a loaded spec, so supply the expression.
+
 ### `format_string_type` — Format-string type
 
 *command and subcommand* — The format-string language the command's format argument uses.

--- a/editors/jetbrains/build.gradle.kts
+++ b/editors/jetbrains/build.gradle.kts
@@ -25,6 +25,7 @@ kotlin {
 }
 
 dependencies {
+    testImplementation(kotlin("test"))
     intellijPlatform {
         intellijIdeaUltimate("2024.1")
         bundledPlugin("org.jetbrains.plugins.textmate")
@@ -32,6 +33,10 @@ dependencies {
         pluginVerifier()
         zipSigner()
     }
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 intellijPlatform {

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -150,6 +150,7 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
         "return" -> DiagramCompletion.RETURN
         "break" -> DiagramCompletion.BREAK
         "continue" -> DiagramCompletion.CONTINUE
+        "process_exit" -> DiagramCompletion.PROCESS_EXIT
         "terminal" -> DiagramCompletion.TERMINAL
         else -> DiagramCompletion.NORMAL
     }
@@ -283,6 +284,7 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                             DiagramCompletion.RETURN -> handler.data.string("match") == "return" || handler.data.string("match") == "2"
                             DiagramCompletion.BREAK -> handler.data.string("match") == "break" || handler.data.string("match") == "3"
                             DiagramCompletion.CONTINUE -> handler.data.string("match") == "continue" || handler.data.string("match") == "4"
+                            DiagramCompletion.PROCESS_EXIT -> false
                             DiagramCompletion.TERMINAL -> false
                         }
                     }
@@ -326,8 +328,15 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                             listOf(Tail(join))
                         }
                     } else {
+                        val processExits = exits.filter { it.completion == DiagramCompletion.PROCESS_EXIT }
+                        val finallyInputs = exits.filter { it.completion != DiagramCompletion.PROCESS_EXIT }
+                        if (finallyInputs.isEmpty()) {
+                            abrupt += processExits
+                            active = emptyList()
+                            continue
+                        }
                         val cleanup = node("finally", "round")
-                        exits.forEach { connect(it.id, cleanup) }
+                        finallyInputs.forEach { connect(it.id, cleanup) }
                         val finallyExits = walk(finallyBody, listOf(Tail(cleanup)))
                         // A normal finally body preserves the completion it
                         // received.  Thus only normal and handled-completing
@@ -338,11 +347,11 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                         // path, exactly as Tcl specifies.
                         val propagated = finallyExits.flatMap { finalExit ->
                             if (finalExit.completion == DiagramCompletion.NORMAL) {
-                                exits.map { Tail(finalExit.id, it.completion) }
+                                finallyInputs.map { Tail(finalExit.id, it.completion) }
                             } else {
                                 listOf(finalExit)
                             }
-                        }
+                        } + processExits
                         abrupt += propagated.filter { it.completion != DiagramCompletion.NORMAL }
                         active = propagated.filter { it.completion == DiagramCompletion.NORMAL }
                     }
@@ -392,7 +401,7 @@ private class MermaidIds {
 }
 
 /** Completion states defined by the shared `tcl-diagram` JSON contract. */
-private enum class DiagramCompletion { NORMAL, ERROR, RETURN, BREAK, CONTINUE, TERMINAL }
+private enum class DiagramCompletion { NORMAL, ERROR, RETURN, BREAK, CONTINUE, PROCESS_EXIT, TERMINAL }
 
 private fun JsonObject.string(name: String): String? =
     get(name)?.takeUnless { it.isJsonNull }?.asString

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -116,6 +116,7 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
     val events = root.array("events") ?: return null
     val procedures = root.array("procedures") ?: return null
     val out = mutableListOf("flowchart TD")
+    val edges = mutableSetOf<String>()
     val ids = MermaidIds()
 
     fun label(value: String): String = value
@@ -140,7 +141,9 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
     }
 
     fun connect(from: String?, to: String, caption: String? = null) {
-        if (from != null) out += if (caption == null) "$from --> $to" else "$from -->|${label(caption)}| $to"
+        if (from == null) return
+        val edge = if (caption == null) "$from --> $to" else "$from -->|${label(caption)}| $to"
+        if (edges.add(edge)) out += edge
     }
 
     data class Tail(val id: String, val completion: DiagramCompletion = DiagramCompletion.NORMAL, val completionCode: Int? = null)
@@ -369,8 +372,12 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                             bodyExit.completion == DiagramCompletion.DYNAMIC_RETURN_OR_ERROR
                         ) {
                             val possible = if (bodyExit.completion == DiagramCompletion.DYNAMIC) {
+                                // Dynamic action nodes retain their normal
+                                // outcome as an ordinary active tail. This
+                                // companion tail represents only the other
+                                // possible completions, so an `on ok` handler
+                                // receives one edge rather than two.
                                 val standard = listOf(
-                                    PossibleCompletion.NORMAL,
                                     PossibleCompletion.ERROR,
                                     PossibleCompletion.RETURN,
                                     PossibleCompletion.BREAK,

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -235,9 +235,15 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                     val loop = node(item.string("label") ?: item.string("kind") ?: "block", "round")
                     connect(active, loop)
                     val bodyTails = walk(item.array("body") ?: JsonArray(), listOf(Tail(loop)))
-                    bodyTails.filter { it.completion == DiagramCompletion.NORMAL }.forEach { connect(it.id, loop, "repeat") }
-                    abrupt += bodyTails.filter { it.completion != DiagramCompletion.NORMAL }
                     val exit = node("loop exit", "round")
+                    bodyTails.filter { it.completion == DiagramCompletion.NORMAL }.forEach { connect(it.id, loop, "repeat") }
+                    bodyTails.filter { it.completion == DiagramCompletion.CONTINUE }.forEach { connect(it.id, loop, "continue") }
+                    bodyTails.filter { it.completion == DiagramCompletion.BREAK }.forEach { connect(it.id, exit, "break") }
+                    abrupt += bodyTails.filter {
+                        it.completion != DiagramCompletion.NORMAL &&
+                            it.completion != DiagramCompletion.CONTINUE &&
+                            it.completion != DiagramCompletion.BREAK
+                    }
                     connect(loop, exit, item.string("exit") ?: "exit")
                     active = listOf(Tail(exit))
                 }

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -405,7 +405,27 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                                     handler.data.get("completion_code")?.takeIf { it.isJsonPrimitive }?.asInt == bodyExit.completionCode
                             }
                         } else emptyList()
-                        val effectiveMatches = if (exactCustomMatches.isNotEmpty()) exactCustomMatches else matches
+                        // Exact errors still carry no concrete -errorcode in
+                        // the compact diagram contract. Every non-shadowed
+                        // trap is therefore possible, but Tcl tries them in
+                        // source order and a prefix pattern claims all of a
+                        // later, more-specific one. Keep the projected list
+                        // elements as the comparison owner; raw match text
+                        // would get quoting and escapes wrong.
+                        val effectiveMatches = when {
+                            exactCustomMatches.isNotEmpty() -> exactCustomMatches
+                            bodyExit.completion == DiagramCompletion.ERROR -> {
+                                val claimedTrapPatterns = mutableListOf<List<String>?>()
+                                matches.filter { (_, handler) ->
+                                    if (handler.data.string("kind_handler") != "trap") return@filter true
+                                    val pattern = trapPattern(handler)
+                                    if (claimedTrapPatterns.any { trapSubsumes(it, pattern) }) return@filter false
+                                    claimedTrapPatterns += pattern
+                                    true
+                                }
+                            }
+                            else -> matches
+                        }
                         val errorIsCertainlyHandled = bodyExit.completion == DiagramCompletion.ERROR && matches.any {
                             (_, handler) -> handler.data.string("kind_handler") == "on" ||
                                 (handler.data.string("kind_handler") == "trap" &&

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -189,7 +189,11 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                         connect(decision, armStart, pattern)
                         val armTail = walk(arm.array("body") ?: JsonArray(), armStart)
                         armTails += armTail ?: armStart
-                        hasDefault = hasDefault || pattern.equals("default", ignoreCase = true)
+                        // `tcl-diagram` serialises the compiler's default
+                        // arm as this exact lower-case spelling.  `Default`
+                        // is an ordinary Tcl pattern and must retain the
+                        // no-match continuation.
+                        hasDefault = hasDefault || pattern == "default"
                     }
                     if (armTails.isEmpty()) {
                         tail = decision

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -244,7 +244,15 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                 "catch" -> {
                     val block = node("catch", "round")
                     connect(active, block)
-                    active = walk(item.array("body") ?: JsonArray(), listOf(Tail(block)))
+                    val bodyExits = walk(item.array("body") ?: JsonArray(), listOf(Tail(block)))
+                    // `catch` converts every Tcl completion into its own
+                    // normal integer result. Process exit is not a Tcl
+                    // completion and cannot be caught, so it remains abrupt.
+                    val processExits = bodyExits.filter { it.completion == DiagramCompletion.PROCESS_EXIT }
+                    abrupt += processExits
+                    active = bodyExits
+                        .filter { it.completion != DiagramCompletion.PROCESS_EXIT }
+                        .map { Tail(it.id) }
                 }
                 "try" -> {
                     val attempt = node("try", "round")
@@ -358,7 +366,7 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                                 listOf(PossibleCompletion.ERROR, PossibleCompletion.RETURN)
                             }
                             for (outcome in possible) {
-                                var caughtByOn = false
+                                var certainlyCaught = false
                                 val claimedTrapPatterns = mutableListOf<List<String>?>()
                                 for ((index, handler) in handlers.withIndex()) {
                                     when (handler.data.string("kind_handler")) {
@@ -367,17 +375,26 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                                         ) {
                                             connect(bodyExit.id, handler.start, "trap")
                                             exits += renderHandler(index)
-                                            claimedTrapPatterns += trapPattern(handler)
+                                            val pattern = trapPattern(handler)
+                                            claimedTrapPatterns += pattern
+                                            // The empty Tcl list is a prefix
+                                            // of every error code. No later
+                                            // trap or on-error handler can be
+                                            // selected for this outcome.
+                                            if (pattern?.isEmpty() == true) {
+                                                certainlyCaught = true
+                                                break
+                                            }
                                         }
                                         "on" -> if (onMatches(handler, outcome)) {
                                             connect(bodyExit.id, handler.start, "on")
                                             exits += renderHandler(index)
-                                            caughtByOn = true
+                                            certainlyCaught = true
                                             break
                                         }
                                     }
                                 }
-                                if (!caughtByOn) exits += Tail(bodyExit.id, completionOf(outcome))
+                                if (!certainlyCaught) exits += Tail(bodyExit.id, completionOf(outcome))
                             }
                             continue
                         }
@@ -390,7 +407,9 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                         } else emptyList()
                         val effectiveMatches = if (exactCustomMatches.isNotEmpty()) exactCustomMatches else matches
                         val errorIsCertainlyHandled = bodyExit.completion == DiagramCompletion.ERROR && matches.any {
-                            (_, handler) -> handler.data.string("kind_handler") == "on"
+                            (_, handler) -> handler.data.string("kind_handler") == "on" ||
+                                (handler.data.string("kind_handler") == "trap" &&
+                                    trapPattern(handler)?.isEmpty() == true)
                         }
                         if (effectiveMatches.isEmpty() ||
                             (bodyExit.completion == DiagramCompletion.ERROR && !errorIsCertainlyHandled)
@@ -411,7 +430,14 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                             for ((index, handler) in effectiveMatches) {
                                 connect(bodyExit.id, handler.start, handler.data.string("kind_handler"))
                                 exits += renderHandler(index)
-                                if (handler.data.string("kind_handler") == "on" && bodyExit.completion != DiagramCompletion.DYNAMIC && bodyExit.completion != DiagramCompletion.DYNAMIC_RETURN_OR_ERROR) break
+                                val exhaustiveEmptyTrap = bodyExit.completion == DiagramCompletion.ERROR &&
+                                    handler.data.string("kind_handler") == "trap" &&
+                                    trapPattern(handler)?.isEmpty() == true
+                                if (exhaustiveEmptyTrap ||
+                                    (handler.data.string("kind_handler") == "on" &&
+                                        bodyExit.completion != DiagramCompletion.DYNAMIC &&
+                                        bodyExit.completion != DiagramCompletion.DYNAMIC_RETURN_OR_ERROR)
+                                ) break
                             }
                         }
                     }

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -143,52 +143,69 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
         if (from != null) out += if (caption == null) "$from --> $to" else "$from -->|${label(caption)}| $to"
     }
 
-    fun walk(flow: JsonArray, previous: String?): String? {
-        var tail = previous
+    data class Tail(val id: String, val completion: DiagramCompletion = DiagramCompletion.NORMAL)
+
+    fun completion(item: JsonObject): DiagramCompletion = when (item.string("completion")) {
+        "error" -> DiagramCompletion.ERROR
+        "return" -> DiagramCompletion.RETURN
+        "break" -> DiagramCompletion.BREAK
+        "continue" -> DiagramCompletion.CONTINUE
+        "terminal" -> DiagramCompletion.TERMINAL
+        else -> DiagramCompletion.NORMAL
+    }
+
+    fun connect(incoming: List<Tail>, to: String, caption: String? = null) {
+        incoming.forEach { connect(it.id, to, caption) }
+    }
+
+    fun walk(flow: JsonArray, incoming: List<Tail>): List<Tail> {
+        var active = incoming
+        val abrupt = mutableListOf<Tail>()
         for (element in flow) {
+            if (active.isEmpty()) break
             val item = element.takeIf { it.isJsonObject }?.asJsonObject ?: continue
             when (item.string("kind")) {
                 "if" -> {
                     val decision = node("if", "decision")
-                    connect(tail, decision)
+                    connect(active, decision)
                     val branches = item.array("branches") ?: JsonArray()
-                    val branchTails = mutableListOf<String>()
+                    val branchTails = mutableListOf<Tail>()
                     for (branchElement in branches) {
                         val branch = branchElement.takeIf { it.isJsonObject }?.asJsonObject ?: continue
                         val branchStart = node(branch.string("condition") ?: "branch")
                         connect(decision, branchStart, branch.string("condition"))
-                        val branchTail = walk(branch.array("body") ?: JsonArray(), branchStart)
-                        branchTails += branchTail ?: branchStart
+                        branchTails += walk(branch.array("body") ?: JsonArray(), listOf(Tail(branchStart)))
                     }
                     if (branchTails.isEmpty()) {
-                        tail = decision
+                        active = listOf(Tail(decision))
                     } else {
                         val join = node("if join", "round")
-                        branchTails.forEach { connect(it, join) }
                         // A conditional without an explicit else also has a
                         // fall-through path; keep it connected to the same
                         // continuation rather than dropping it.
                         val hasElse = branches.any {
                             it.isJsonObject && it.asJsonObject.string("condition") == "else"
                         }
+                        val normalTails = branchTails.filter { it.completion == DiagramCompletion.NORMAL }
+                        normalTails.forEach { connect(it.id, join) }
                         if (!hasElse) {
                             connect(decision, join, "false")
                         }
-                        tail = join
+                        abrupt += branchTails.filter { it.completion != DiagramCompletion.NORMAL }
+                        active = listOf(Tail(join))
                     }
                 }
                 "switch" -> {
                     val decision = node("switch ${item.string("subject") ?: ""}", "decision")
-                    connect(tail, decision)
-                    val armTails = mutableListOf<String>()
+                    connect(active, decision)
+                    val armTails = mutableListOf<Tail>()
                     var hasDefault = false
                     for (armElement in item.array("arms") ?: JsonArray()) {
                         val arm = armElement.takeIf { it.isJsonObject }?.asJsonObject ?: continue
                         val pattern = arm.string("pattern") ?: "case"
                         val armStart = node(pattern)
                         connect(decision, armStart, pattern)
-                        val armTail = walk(arm.array("body") ?: JsonArray(), armStart)
-                        armTails += armTail ?: armStart
+                        armTails += walk(arm.array("body") ?: JsonArray(), listOf(Tail(armStart)))
                         // `tcl-diagram` serialises the compiler's default
                         // arm as this exact lower-case spelling.  `Default`
                         // is an ordinary Tcl pattern and must retain the
@@ -196,39 +213,41 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                         hasDefault = hasDefault || pattern == "default"
                     }
                     if (armTails.isEmpty()) {
-                        tail = decision
+                        active = listOf(Tail(decision))
                     } else {
                         // Every matching arm continues at one shared point.
                         // Without a default, Tcl also reaches that point when
                         // no pattern matched; a default consumes that path.
                         val join = node("switch join", "round")
-                        armTails.forEach { connect(it, join) }
+                        armTails.filter { it.completion == DiagramCompletion.NORMAL }.forEach { connect(it.id, join) }
                         if (!hasDefault) {
                             connect(decision, join, "no match")
                         }
-                        tail = join
+                        abrupt += armTails.filter { it.completion != DiagramCompletion.NORMAL }
+                        active = listOf(Tail(join))
                     }
                 }
                 "loop" -> {
                     val loop = node(item.string("label") ?: item.string("kind") ?: "block", "round")
-                    connect(tail, loop)
-                    val bodyTail = walk(item.array("body") ?: JsonArray(), loop) ?: loop
-                    connect(bodyTail, loop, "repeat")
+                    connect(active, loop)
+                    val bodyTails = walk(item.array("body") ?: JsonArray(), listOf(Tail(loop)))
+                    bodyTails.filter { it.completion == DiagramCompletion.NORMAL }.forEach { connect(it.id, loop, "repeat") }
+                    abrupt += bodyTails.filter { it.completion != DiagramCompletion.NORMAL }
                     val exit = node("loop exit", "round")
                     connect(loop, exit, item.string("exit") ?: "exit")
-                    tail = exit
+                    active = listOf(Tail(exit))
                 }
                 "catch" -> {
                     val block = node("catch", "round")
-                    connect(tail, block)
-                    tail = walk(item.array("body") ?: JsonArray(), block) ?: block
+                    connect(active, block)
+                    active = walk(item.array("body") ?: JsonArray(), listOf(Tail(block)))
                 }
                 "try" -> {
                     val attempt = node("try", "round")
-                    connect(tail, attempt)
-                    val exits = mutableListOf(
-                        walk(item.array("body") ?: JsonArray(), attempt) ?: attempt
-                    )
+                    connect(active, attempt)
+                    val bodyExits = walk(item.array("body") ?: JsonArray(), listOf(Tail(attempt)))
+                    data class Handler(val data: JsonObject, val start: String, var exits: List<Tail>? = null)
+                    val handlers = mutableListOf<Handler>()
                     for (handlerElement in item.array("handlers") ?: JsonArray()) {
                         val handler = handlerElement.takeIf { it.isJsonObject }?.asJsonObject ?: continue
                         val kind = handler.string("kind_handler") ?: "handler"
@@ -237,18 +256,95 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                             .filter(String::isNotBlank)
                             .joinToString(" ")
                         val handlerStart = node(handlerLabel.ifEmpty { "handler" }, "round")
-                        connect(attempt, handlerStart, handlerLabel.ifEmpty { "handler" })
-                        exits += walk(handler.array("body") ?: JsonArray(), handlerStart) ?: handlerStart
+                        handlers += Handler(handler, handlerStart)
+                    }
+
+                    fun renderHandler(index: Int): List<Tail> {
+                        val handler = handlers[index]
+                        handler.exits?.let { return it }
+                        val exits = if (handler.data.get("fallthrough")?.asBoolean == true && index + 1 < handlers.size) {
+                            val next = handlers[index + 1]
+                            // Tcl's `-` shares the next handler's body.  It is
+                            // not a completion to `finally` of its own.
+                            connect(handler.start, next.start, "fall through")
+                            renderHandler(index + 1)
+                        } else {
+                            walk(handler.data.array("body") ?: JsonArray(), listOf(Tail(handler.start)))
+                        }
+                        handler.exits = exits
+                        return exits
+                    }
+
+                    fun handlerMatches(handler: Handler, outcome: DiagramCompletion): Boolean {
+                        if (handler.data.string("kind_handler") != "on") return outcome == DiagramCompletion.ERROR && handler.data.string("kind_handler") == "trap"
+                        return when (outcome) {
+                            DiagramCompletion.NORMAL -> handler.data.string("match") == "ok" || handler.data.string("match") == "0"
+                            DiagramCompletion.ERROR -> handler.data.string("match") == "error" || handler.data.string("match") == "1"
+                            DiagramCompletion.RETURN -> handler.data.string("match") == "return" || handler.data.string("match") == "2"
+                            DiagramCompletion.BREAK -> handler.data.string("match") == "break" || handler.data.string("match") == "3"
+                            DiagramCompletion.CONTINUE -> handler.data.string("match") == "continue" || handler.data.string("match") == "4"
+                            DiagramCompletion.TERMINAL -> false
+                        }
+                    }
+
+                    val exits = mutableListOf<Tail>()
+                    for (bodyExit in bodyExits) {
+                        val matches = handlers.withIndex().filter { (_, handler) -> handlerMatches(handler, bodyExit.completion) }
+                        val errorIsCertainlyHandled = bodyExit.completion == DiagramCompletion.ERROR && matches.any {
+                            (_, handler) -> handler.data.string("kind_handler") == "on"
+                        }
+                        if (matches.isEmpty() || (bodyExit.completion == DiagramCompletion.ERROR && !errorIsCertainlyHandled)) {
+                            // A `trap` pattern needs error-code detail which
+                            // this compact contract intentionally does not
+                            // carry.  It is a possible handled path, but not
+                            // proof that every error is caught, so retain the
+                            // unhandled error as well.
+                            exits += bodyExit
+                        }
+                        if (matches.isNotEmpty()) {
+                            // `on` clauses are selected in source order.  A
+                            // `trap` pattern is not represented by the
+                            // structured IR's completion code, so every
+                            // preceding trap is a possible path; a matching
+                            // `on` clause then catches all remaining paths.
+                            for ((index, handler) in matches) {
+                                connect(bodyExit.id, handler.start, handler.data.string("kind_handler"))
+                                exits += renderHandler(index)
+                                if (handler.data.string("kind_handler") == "on") break
+                            }
+                        }
                     }
                     val finallyBody = item.array("finally")
                     if (finallyBody == null) {
-                        val join = node("try join", "round")
-                        exits.forEach { connect(it, join) }
-                        tail = join
+                        val normalExits = exits.filter { it.completion == DiagramCompletion.NORMAL }
+                        abrupt += exits.filter { it.completion != DiagramCompletion.NORMAL }
+                        active = if (normalExits.isEmpty()) {
+                            emptyList()
+                        } else {
+                            val join = node("try join", "round")
+                            normalExits.forEach { connect(it.id, join) }
+                            listOf(Tail(join))
+                        }
                     } else {
                         val cleanup = node("finally", "round")
-                        exits.forEach { connect(it, cleanup) }
-                        tail = walk(finallyBody, cleanup) ?: cleanup
+                        exits.forEach { connect(it.id, cleanup) }
+                        val finallyExits = walk(finallyBody, listOf(Tail(cleanup)))
+                        // A normal finally body preserves the completion it
+                        // received.  Thus only normal and handled-completing
+                        // paths reach the statement after the try; return,
+                        // break, and unhandled-error paths still execute
+                        // cleanup but propagate afterwards.  A completion in
+                        // the finally body itself overrides every incoming
+                        // path, exactly as Tcl specifies.
+                        val propagated = finallyExits.flatMap { finalExit ->
+                            if (finalExit.completion == DiagramCompletion.NORMAL) {
+                                exits.map { Tail(finalExit.id, it.completion) }
+                            } else {
+                                listOf(finalExit)
+                            }
+                        }
+                        abrupt += propagated.filter { it.completion != DiagramCompletion.NORMAL }
+                        active = propagated.filter { it.completion == DiagramCompletion.NORMAL }
                     }
                 }
                 else -> {
@@ -257,12 +353,18 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                         ?: item.string("kind")
                         ?: "step"
                     val step = node(text)
-                    connect(tail, step)
-                    tail = step
+                    connect(active, step)
+                    val outcome = completion(item)
+                    if (outcome == DiagramCompletion.NORMAL) {
+                        active = listOf(Tail(step))
+                    } else {
+                        abrupt += Tail(step, outcome)
+                        active = emptyList()
+                    }
                 }
             }
         }
-        return tail
+        return active + abrupt
     }
 
     for (eventElement in events) {
@@ -272,14 +374,14 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
         val multiplicity = event.string("multiplicity")
         val detail = listOfNotNull(priority?.let { "priority $it" }, multiplicity).joinToString(", ")
         val start = node(if (detail.isEmpty()) "when $name" else "when $name ($detail)", "round")
-        walk(event.array("flow") ?: JsonArray(), start)
+        walk(event.array("flow") ?: JsonArray(), listOf(Tail(start)))
     }
     for (procedureElement in procedures) {
         val procedure = procedureElement.takeIf { it.isJsonObject }?.asJsonObject ?: continue
         val name = procedure.string("name") ?: "procedure"
         val params = procedure.array("params")?.joinToString(", ") { it.asString } ?: ""
         val start = node("proc $name($params)", "round")
-        walk(procedure.array("flow") ?: JsonArray(), start)
+        walk(procedure.array("flow") ?: JsonArray(), listOf(Tail(start)))
     }
     return out.joinToString("\n")
 }
@@ -288,6 +390,9 @@ private class MermaidIds {
     private var value = 0
     fun next(): String = "n${value++}"
 }
+
+/** Completion states defined by the shared `tcl-diagram` JSON contract. */
+private enum class DiagramCompletion { NORMAL, ERROR, RETURN, BREAK, CONTINUE, TERMINAL }
 
 private fun JsonObject.string(name: String): String? =
     get(name)?.takeUnless { it.isJsonNull }?.asString

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -321,15 +321,16 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                             PossibleCompletion.UNKNOWN_OTHER -> false
                         }
                     }
-                    fun trapSubsumes(previous: String?, candidate: String?): Boolean {
-                        if (previous == candidate || previous == "*" || previous.isNullOrBlank()) return true
+                    fun trapPattern(handler: Handler): List<String>? = handler.data.array("trap_pattern")
+                        ?.mapNotNull { it.takeIf { value -> value.isJsonPrimitive }?.asString }
+                    fun trapSubsumes(previous: List<String>?, candidate: List<String>?): Boolean {
+                        if (previous == null || candidate == null) return false
+                        if (previous == candidate || previous.isEmpty()) return true
                         // `trap` patterns are error-code list prefixes. A
                         // concrete prefix claims every longer error code with
                         // that prefix; otherwise retain the candidate because
                         // it may still match an unclaimed error-code class.
-                        val prior = previous.trim().split(Regex("\\s+"))
-                        val next = candidate?.trim()?.split(Regex("\\s+")) ?: return false
-                        return prior.size <= next.size && prior.zip(next).all { (a, b) -> a == b }
+                        return previous.size <= candidate.size && previous.zip(candidate).all { (a, b) -> a == b }
                     }
 
                     val exits = mutableListOf<Tail>()
@@ -358,15 +359,15 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                             }
                             for (outcome in possible) {
                                 var caughtByOn = false
-                                val claimedTrapPatterns = mutableListOf<String?>()
+                                val claimedTrapPatterns = mutableListOf<List<String>?>()
                                 for ((index, handler) in handlers.withIndex()) {
                                     when (handler.data.string("kind_handler")) {
                                         "trap" -> if (outcome == PossibleCompletion.ERROR &&
-                                            claimedTrapPatterns.none { trapSubsumes(it, handler.data.string("match")) }
+                                            claimedTrapPatterns.none { trapSubsumes(it, trapPattern(handler)) }
                                         ) {
                                             connect(bodyExit.id, handler.start, "trap")
                                             exits += renderHandler(index)
-                                            claimedTrapPatterns += handler.data.string("match")
+                                            claimedTrapPatterns += trapPattern(handler)
                                         }
                                         "on" -> if (onMatches(handler, outcome)) {
                                             connect(bodyExit.id, handler.start, "on")

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -305,7 +305,7 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                         PossibleCompletion.RETURN -> DiagramCompletion.RETURN
                         PossibleCompletion.BREAK -> DiagramCompletion.BREAK
                         PossibleCompletion.CONTINUE -> DiagramCompletion.CONTINUE
-                        PossibleCompletion.OTHER -> DiagramCompletion.TERMINAL
+                        is PossibleCompletion.CUSTOM, PossibleCompletion.UNKNOWN_OTHER -> DiagramCompletion.TERMINAL
                     }
                     fun onMatches(handler: Handler, possible: PossibleCompletion): Boolean {
                         val match = handler.data.string("match")
@@ -315,7 +315,8 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                             PossibleCompletion.RETURN -> match == "return" || match == "2"
                             PossibleCompletion.BREAK -> match == "break" || match == "3"
                             PossibleCompletion.CONTINUE -> match == "continue" || match == "4"
-                            PossibleCompletion.OTHER -> match !in listOf("ok", "error", "return", "break", "continue", "0", "1", "2", "3", "4")
+                            is PossibleCompletion.CUSTOM -> match == possible.selector
+                            PossibleCompletion.UNKNOWN_OTHER -> false
                         }
                     }
                     fun trapSubsumes(previous: String?, candidate: String?): Boolean {
@@ -335,7 +336,21 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                             bodyExit.completion == DiagramCompletion.DYNAMIC_RETURN_OR_ERROR
                         ) {
                             val possible = if (bodyExit.completion == DiagramCompletion.DYNAMIC) {
-                                PossibleCompletion.entries
+                                val standard = listOf(
+                                    PossibleCompletion.NORMAL,
+                                    PossibleCompletion.ERROR,
+                                    PossibleCompletion.RETURN,
+                                    PossibleCompletion.BREAK,
+                                    PossibleCompletion.CONTINUE,
+                                )
+                                val custom = handlers.asSequence()
+                                    .filter { it.data.string("kind_handler") == "on" }
+                                    .mapNotNull { it.data.string("match") }
+                                    .filterNot { it in listOf("ok", "error", "return", "break", "continue", "0", "1", "2", "3", "4") }
+                                    .distinct()
+                                    .map { PossibleCompletion.CUSTOM(it) }
+                                    .toList()
+                                standard + custom + PossibleCompletion.UNKNOWN_OTHER
                             } else {
                                 listOf(PossibleCompletion.ERROR, PossibleCompletion.RETURN)
                             }
@@ -476,7 +491,15 @@ private class MermaidIds {
 
 /** Completion states defined by the shared `tcl-diagram` JSON contract. */
 private enum class DiagramCompletion { NORMAL, ERROR, RETURN, BREAK, CONTINUE, DYNAMIC, DYNAMIC_RETURN_OR_ERROR, PROCESS_EXIT, TERMINAL }
-private enum class PossibleCompletion { NORMAL, ERROR, RETURN, BREAK, CONTINUE, OTHER }
+private sealed class PossibleCompletion {
+    data object NORMAL : PossibleCompletion()
+    data object ERROR : PossibleCompletion()
+    data object RETURN : PossibleCompletion()
+    data object BREAK : PossibleCompletion()
+    data object CONTINUE : PossibleCompletion()
+    data class CUSTOM(val selector: String) : PossibleCompletion()
+    data object UNKNOWN_OTHER : PossibleCompletion()
+}
 
 private fun JsonObject.string(name: String): String? =
     get(name)?.takeUnless { it.isJsonNull }?.asString

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -291,11 +291,7 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                             DiagramCompletion.RETURN -> handler.data.string("match") == "return" || handler.data.string("match") == "2"
                             DiagramCompletion.BREAK -> handler.data.string("match") == "break" || handler.data.string("match") == "3"
                             DiagramCompletion.CONTINUE -> handler.data.string("match") == "continue" || handler.data.string("match") == "4"
-                            // An unevaluated -options value can produce any
-                            // Tcl completion code. Keep every on clause as a
-                            // possible source-order selection; choosing only
-                            // the first would falsely discard later handlers.
-                            DiagramCompletion.DYNAMIC -> true
+                            DiagramCompletion.DYNAMIC -> false
                             DiagramCompletion.DYNAMIC_RETURN_OR_ERROR ->
                                 (handler.data.string("match") in listOf("error", "return", "1", "2"))
                             DiagramCompletion.PROCESS_EXIT -> false
@@ -303,15 +299,75 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                         }
                     }
 
+                    fun completionOf(possible: PossibleCompletion): DiagramCompletion = when (possible) {
+                        PossibleCompletion.NORMAL -> DiagramCompletion.NORMAL
+                        PossibleCompletion.ERROR -> DiagramCompletion.ERROR
+                        PossibleCompletion.RETURN -> DiagramCompletion.RETURN
+                        PossibleCompletion.BREAK -> DiagramCompletion.BREAK
+                        PossibleCompletion.CONTINUE -> DiagramCompletion.CONTINUE
+                        PossibleCompletion.OTHER -> DiagramCompletion.TERMINAL
+                    }
+                    fun onMatches(handler: Handler, possible: PossibleCompletion): Boolean {
+                        val match = handler.data.string("match")
+                        return when (possible) {
+                            PossibleCompletion.NORMAL -> match == "ok" || match == "0"
+                            PossibleCompletion.ERROR -> match == "error" || match == "1"
+                            PossibleCompletion.RETURN -> match == "return" || match == "2"
+                            PossibleCompletion.BREAK -> match == "break" || match == "3"
+                            PossibleCompletion.CONTINUE -> match == "continue" || match == "4"
+                            PossibleCompletion.OTHER -> match !in listOf("ok", "error", "return", "break", "continue", "0", "1", "2", "3", "4")
+                        }
+                    }
+                    fun trapSubsumes(previous: String?, candidate: String?): Boolean {
+                        if (previous == candidate || previous == "*" || previous.isNullOrBlank()) return true
+                        // `trap` patterns are error-code list prefixes. A
+                        // concrete prefix claims every longer error code with
+                        // that prefix; otherwise retain the candidate because
+                        // it may still match an unclaimed error-code class.
+                        val prior = previous.trim().split(Regex("\\s+"))
+                        val next = candidate?.trim()?.split(Regex("\\s+")) ?: return false
+                        return prior.size <= next.size && prior.zip(next).all { (a, b) -> a == b }
+                    }
+
                     val exits = mutableListOf<Tail>()
                     for (bodyExit in bodyExits) {
+                        if (bodyExit.completion == DiagramCompletion.DYNAMIC ||
+                            bodyExit.completion == DiagramCompletion.DYNAMIC_RETURN_OR_ERROR
+                        ) {
+                            val possible = if (bodyExit.completion == DiagramCompletion.DYNAMIC) {
+                                PossibleCompletion.entries
+                            } else {
+                                listOf(PossibleCompletion.ERROR, PossibleCompletion.RETURN)
+                            }
+                            for (outcome in possible) {
+                                var caughtByOn = false
+                                val claimedTrapPatterns = mutableListOf<String?>()
+                                for ((index, handler) in handlers.withIndex()) {
+                                    when (handler.data.string("kind_handler")) {
+                                        "trap" -> if (outcome == PossibleCompletion.ERROR &&
+                                            claimedTrapPatterns.none { trapSubsumes(it, handler.data.string("match")) }
+                                        ) {
+                                            connect(bodyExit.id, handler.start, "trap")
+                                            exits += renderHandler(index)
+                                            claimedTrapPatterns += handler.data.string("match")
+                                        }
+                                        "on" -> if (onMatches(handler, outcome)) {
+                                            connect(bodyExit.id, handler.start, "on")
+                                            exits += renderHandler(index)
+                                            caughtByOn = true
+                                            break
+                                        }
+                                    }
+                                }
+                                if (!caughtByOn) exits += Tail(bodyExit.id, completionOf(outcome))
+                            }
+                            continue
+                        }
                         val matches = handlers.withIndex().filter { (_, handler) -> handlerMatches(handler, bodyExit.completion) }
                         val errorIsCertainlyHandled = bodyExit.completion == DiagramCompletion.ERROR && matches.any {
                             (_, handler) -> handler.data.string("kind_handler") == "on"
                         }
                         if (matches.isEmpty() ||
-                            bodyExit.completion == DiagramCompletion.DYNAMIC ||
-                            bodyExit.completion == DiagramCompletion.DYNAMIC_RETURN_OR_ERROR ||
                             (bodyExit.completion == DiagramCompletion.ERROR && !errorIsCertainlyHandled)
                         ) {
                             // A `trap` pattern needs error-code detail which
@@ -320,17 +376,6 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                             // proof that every error is caught, so retain the
                             // unhandled error as well.
                             exits += bodyExit
-                        }
-                        // Dynamic -options can produce TCL_OK. If no `on ok`
-                        // clause owns that possibility, retain the direct
-                        // normal continuation as well as abrupt propagation.
-                        if (bodyExit.completion == DiagramCompletion.DYNAMIC &&
-                            matches.none { (_, handler) ->
-                                handler.data.string("kind_handler") == "on" &&
-                                    (handler.data.string("match") == "ok" || handler.data.string("match") == "0")
-                            }
-                        ) {
-                            exits += Tail(bodyExit.id, DiagramCompletion.NORMAL)
                         }
                         if (matches.isNotEmpty()) {
                             // `on` clauses are selected in source order.  A
@@ -431,6 +476,7 @@ private class MermaidIds {
 
 /** Completion states defined by the shared `tcl-diagram` JSON contract. */
 private enum class DiagramCompletion { NORMAL, ERROR, RETURN, BREAK, CONTINUE, DYNAMIC, DYNAMIC_RETURN_OR_ERROR, PROCESS_EXIT, TERMINAL }
+private enum class PossibleCompletion { NORMAL, ERROR, RETURN, BREAK, CONTINUE, OTHER }
 
 private fun JsonObject.string(name: String): String? =
     get(name)?.takeUnless { it.isJsonNull }?.asString

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -148,15 +148,30 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                     val decision = node("if", "decision")
                     connect(tail, decision)
                     val branches = item.array("branches") ?: JsonArray()
-                    var join: String? = null
+                    val branchTails = mutableListOf<String>()
                     for (branchElement in branches) {
                         val branch = branchElement.takeIf { it.isJsonObject }?.asJsonObject ?: continue
                         val branchStart = node(branch.string("condition") ?: "branch")
                         connect(decision, branchStart, branch.string("condition"))
                         val branchTail = walk(branch.array("body") ?: JsonArray(), branchStart)
-                        join = branchTail ?: branchStart
+                        branchTails += branchTail ?: branchStart
                     }
-                    tail = join ?: decision
+                    if (branchTails.isEmpty()) {
+                        tail = decision
+                    } else {
+                        val join = node("if join", "round")
+                        branchTails.forEach { connect(it, join) }
+                        // A conditional without an explicit else also has a
+                        // fall-through path; keep it connected to the same
+                        // continuation rather than dropping it.
+                        val hasElse = branches.any {
+                            it.isJsonObject && it.asJsonObject.string("condition") == "else"
+                        }
+                        if (!hasElse) {
+                            connect(decision, join, "false")
+                        }
+                        tail = join
+                    }
                 }
                 "switch" -> {
                     val decision = node("switch ${item.string("subject") ?: ""}", "decision")

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -209,15 +209,47 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                         tail = join
                     }
                 }
-                "loop", "catch" -> {
+                "loop" -> {
                     val loop = node(item.string("label") ?: item.string("kind") ?: "block", "round")
                     connect(tail, loop)
-                    tail = walk(item.array("body") ?: JsonArray(), loop) ?: loop
+                    val bodyTail = walk(item.array("body") ?: JsonArray(), loop) ?: loop
+                    connect(bodyTail, loop, "repeat")
+                    val exit = node("loop exit", "round")
+                    connect(loop, exit, item.string("exit") ?: "exit")
+                    tail = exit
+                }
+                "catch" -> {
+                    val block = node("catch", "round")
+                    connect(tail, block)
+                    tail = walk(item.array("body") ?: JsonArray(), block) ?: block
                 }
                 "try" -> {
                     val attempt = node("try", "round")
                     connect(tail, attempt)
-                    tail = walk(item.array("body") ?: JsonArray(), attempt) ?: attempt
+                    val exits = mutableListOf(
+                        walk(item.array("body") ?: JsonArray(), attempt) ?: attempt
+                    )
+                    for (handlerElement in item.array("handlers") ?: JsonArray()) {
+                        val handler = handlerElement.takeIf { it.isJsonObject }?.asJsonObject ?: continue
+                        val kind = handler.string("kind_handler") ?: "handler"
+                        val match = handler.string("match")
+                        val handlerLabel = listOfNotNull(kind, match)
+                            .filter(String::isNotBlank)
+                            .joinToString(" ")
+                        val handlerStart = node(handlerLabel.ifEmpty { "handler" }, "round")
+                        connect(attempt, handlerStart, handlerLabel.ifEmpty { "handler" })
+                        exits += walk(handler.array("body") ?: JsonArray(), handlerStart) ?: handlerStart
+                    }
+                    val finallyBody = item.array("finally")
+                    if (finallyBody == null) {
+                        val join = node("try join", "round")
+                        exits.forEach { connect(it, join) }
+                        tail = join
+                    } else {
+                        val cleanup = node("finally", "round")
+                        exits.forEach { connect(it, cleanup) }
+                        tail = walk(finallyBody, cleanup) ?: cleanup
+                    }
                 }
                 else -> {
                     val text = item.string("label")

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -111,7 +111,7 @@ class DiagramDataAction : TclLspActionBase() {
 }
 
 /** Render the stable `tcl-diagram` `{events, procedures}` JSON contract. */
-private fun renderDiagramMermaid(data: JsonElement): String? {
+internal fun renderDiagramMermaid(data: JsonElement): String? {
     val root = data.takeIf { it.isJsonObject }?.asJsonObject ?: return null
     val events = root.array("events") ?: return null
     val procedures = root.array("procedures") ?: return null

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -122,6 +122,10 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
         .replace('"', '\'')
         .replace('[', '(')
         .replace(']', ')')
+        // Mermaid uses a literal `|` to terminate an edge caption.  Numeric
+        // HTML entities are decoded in the rendered label but cannot close
+        // that delimiter while Mermaid parses the flowchart source.
+        .replace("|", "&#124;")
         .replace('\n', ' ')
 
     fun node(text: String, shape: String = "box"): String {
@@ -176,15 +180,30 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                 "switch" -> {
                     val decision = node("switch ${item.string("subject") ?: ""}", "decision")
                     connect(tail, decision)
-                    var join: String? = null
+                    val armTails = mutableListOf<String>()
+                    var hasDefault = false
                     for (armElement in item.array("arms") ?: JsonArray()) {
                         val arm = armElement.takeIf { it.isJsonObject }?.asJsonObject ?: continue
-                        val armStart = node(arm.string("pattern") ?: "case")
-                        connect(decision, armStart, arm.string("pattern"))
+                        val pattern = arm.string("pattern") ?: "case"
+                        val armStart = node(pattern)
+                        connect(decision, armStart, pattern)
                         val armTail = walk(arm.array("body") ?: JsonArray(), armStart)
-                        join = armTail ?: armStart
+                        armTails += armTail ?: armStart
+                        hasDefault = hasDefault || pattern.equals("default", ignoreCase = true)
                     }
-                    tail = join ?: decision
+                    if (armTails.isEmpty()) {
+                        tail = decision
+                    } else {
+                        // Every matching arm continues at one shared point.
+                        // Without a default, Tcl also reaches that point when
+                        // no pattern matched; a default consumes that path.
+                        val join = node("switch join", "round")
+                        armTails.forEach { connect(it, join) }
+                        if (!hasDefault) {
+                            connect(decision, join, "no match")
+                        }
+                        tail = join
+                    }
                 }
                 "loop", "catch" -> {
                     val loop = node(item.string("label") ?: item.string("kind") ?: "block", "round")

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -18,6 +18,10 @@
 
 package com.tcllsp.jetbrains.actions
 
+import com.google.gson.Gson
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.Project
@@ -90,7 +94,136 @@ class DiagramDataAction : TclLspActionBase() {
         return listOf(source)
     }
     override fun resultExtension(result: Any?): String = "mmd"
+
+    override fun presentResult(project: Project, result: Any?) {
+        val data = result?.let { Gson().toJsonTree(it) }
+        val mermaid = data?.let(::renderDiagramMermaid)
+        if (mermaid == null) {
+            notify(project, "Diagram command returned an invalid data payload", NotificationType.ERROR)
+            return
+        }
+        // The LSP command deliberately returns tcl-diagram's structured
+        // `{events, procedures}` contract. Render it here instead of placing
+        // JSON in a `.mmd` scratch tab, which is neither readable nor a
+        // Mermaid diagram.
+        super.presentResult(project, mermaid)
+    }
 }
+
+/** Render the stable `tcl-diagram` `{events, procedures}` JSON contract. */
+private fun renderDiagramMermaid(data: JsonElement): String? {
+    val root = data.takeIf { it.isJsonObject }?.asJsonObject ?: return null
+    val events = root.array("events") ?: return null
+    val procedures = root.array("procedures") ?: return null
+    val out = mutableListOf("flowchart TD")
+    val ids = MermaidIds()
+
+    fun label(value: String): String = value
+        .replace('"', '\'')
+        .replace('[', '(')
+        .replace(']', ')')
+        .replace('\n', ' ')
+
+    fun node(text: String, shape: String = "box"): String {
+        val id = ids.next()
+        val escaped = label(text)
+        out += when (shape) {
+            "decision" -> "$id{$escaped}"
+            "round" -> "$id([$escaped])"
+            else -> "$id[\"$escaped\"]"
+        }
+        return id
+    }
+
+    fun connect(from: String?, to: String, caption: String? = null) {
+        if (from != null) out += if (caption == null) "$from --> $to" else "$from -->|${label(caption)}| $to"
+    }
+
+    fun walk(flow: JsonArray, previous: String?): String? {
+        var tail = previous
+        for (element in flow) {
+            val item = element.takeIf { it.isJsonObject }?.asJsonObject ?: continue
+            when (item.string("kind")) {
+                "if" -> {
+                    val decision = node("if", "decision")
+                    connect(tail, decision)
+                    val branches = item.array("branches") ?: JsonArray()
+                    var join: String? = null
+                    for (branchElement in branches) {
+                        val branch = branchElement.takeIf { it.isJsonObject }?.asJsonObject ?: continue
+                        val branchStart = node(branch.string("condition") ?: "branch")
+                        connect(decision, branchStart, branch.string("condition"))
+                        val branchTail = walk(branch.array("body") ?: JsonArray(), branchStart)
+                        join = branchTail ?: branchStart
+                    }
+                    tail = join ?: decision
+                }
+                "switch" -> {
+                    val decision = node("switch ${item.string("subject") ?: ""}", "decision")
+                    connect(tail, decision)
+                    var join: String? = null
+                    for (armElement in item.array("arms") ?: JsonArray()) {
+                        val arm = armElement.takeIf { it.isJsonObject }?.asJsonObject ?: continue
+                        val armStart = node(arm.string("pattern") ?: "case")
+                        connect(decision, armStart, arm.string("pattern"))
+                        val armTail = walk(arm.array("body") ?: JsonArray(), armStart)
+                        join = armTail ?: armStart
+                    }
+                    tail = join ?: decision
+                }
+                "loop", "catch" -> {
+                    val loop = node(item.string("label") ?: item.string("kind") ?: "block", "round")
+                    connect(tail, loop)
+                    tail = walk(item.array("body") ?: JsonArray(), loop) ?: loop
+                }
+                "try" -> {
+                    val attempt = node("try", "round")
+                    connect(tail, attempt)
+                    tail = walk(item.array("body") ?: JsonArray(), attempt) ?: attempt
+                }
+                else -> {
+                    val text = item.string("label")
+                        ?: item.string("value")
+                        ?: item.string("kind")
+                        ?: "step"
+                    val step = node(text)
+                    connect(tail, step)
+                    tail = step
+                }
+            }
+        }
+        return tail
+    }
+
+    for (eventElement in events) {
+        val event = eventElement.takeIf { it.isJsonObject }?.asJsonObject ?: continue
+        val name = event.string("name") ?: "event"
+        val priority = event.get("priority")?.takeUnless { it.isJsonNull }?.asString
+        val multiplicity = event.string("multiplicity")
+        val detail = listOfNotNull(priority?.let { "priority $it" }, multiplicity).joinToString(", ")
+        val start = node(if (detail.isEmpty()) "when $name" else "when $name ($detail)", "round")
+        walk(event.array("flow") ?: JsonArray(), start)
+    }
+    for (procedureElement in procedures) {
+        val procedure = procedureElement.takeIf { it.isJsonObject }?.asJsonObject ?: continue
+        val name = procedure.string("name") ?: "procedure"
+        val params = procedure.array("params")?.joinToString(", ") { it.asString } ?: ""
+        val start = node("proc $name($params)", "round")
+        walk(procedure.array("flow") ?: JsonArray(), start)
+    }
+    return out.joinToString("\n")
+}
+
+private class MermaidIds {
+    private var value = 0
+    fun next(): String = "n${value++}"
+}
+
+private fun JsonObject.string(name: String): String? =
+    get(name)?.takeUnless { it.isJsonNull }?.asString
+
+private fun JsonObject.array(name: String): JsonArray? =
+    get(name)?.takeIf { it.isJsonArray }?.asJsonArray
 
 // ---------------------------------------------------------------------------
 // URI-as-input commands. extractLinkedObjects + bigipCleanup both want the

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -308,14 +308,14 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                         is PossibleCompletion.CUSTOM, PossibleCompletion.UNKNOWN_OTHER -> DiagramCompletion.TERMINAL
                     }
                     fun onMatches(handler: Handler, possible: PossibleCompletion): Boolean {
-                        val match = handler.data.string("match")
+                        val code = handler.data.get("completion_code")?.takeIf { it.isJsonPrimitive }?.asInt
                         return when (possible) {
-                            PossibleCompletion.NORMAL -> match == "ok" || match == "0"
-                            PossibleCompletion.ERROR -> match == "error" || match == "1"
-                            PossibleCompletion.RETURN -> match == "return" || match == "2"
-                            PossibleCompletion.BREAK -> match == "break" || match == "3"
-                            PossibleCompletion.CONTINUE -> match == "continue" || match == "4"
-                            is PossibleCompletion.CUSTOM -> match == possible.selector
+                            PossibleCompletion.NORMAL -> code == 0
+                            PossibleCompletion.ERROR -> code == 1
+                            PossibleCompletion.RETURN -> code == 2
+                            PossibleCompletion.BREAK -> code == 3
+                            PossibleCompletion.CONTINUE -> code == 4
+                            is PossibleCompletion.CUSTOM -> code == possible.code
                             PossibleCompletion.UNKNOWN_OTHER -> false
                         }
                     }
@@ -345,8 +345,8 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                                 )
                                 val custom = handlers.asSequence()
                                     .filter { it.data.string("kind_handler") == "on" }
-                                    .mapNotNull { it.data.string("match") }
-                                    .filterNot { it in listOf("ok", "error", "return", "break", "continue", "0", "1", "2", "3", "4") }
+                                    .mapNotNull { it.data.get("completion_code")?.takeIf { value -> value.isJsonPrimitive }?.asInt }
+                                    .filterNot { it in 0..4 }
                                     .distinct()
                                     .map { PossibleCompletion.CUSTOM(it) }
                                     .toList()
@@ -497,7 +497,7 @@ private sealed class PossibleCompletion {
     data object RETURN : PossibleCompletion()
     data object BREAK : PossibleCompletion()
     data object CONTINUE : PossibleCompletion()
-    data class CUSTOM(val selector: String) : PossibleCompletion()
+    data class CUSTOM(val code: Int) : PossibleCompletion()
     data object UNKNOWN_OTHER : PossibleCompletion()
 }
 

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -151,6 +151,7 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
         "break" -> DiagramCompletion.BREAK
         "continue" -> DiagramCompletion.CONTINUE
         "dynamic" -> DiagramCompletion.DYNAMIC
+        "dynamic_return_or_error" -> DiagramCompletion.DYNAMIC_RETURN_OR_ERROR
         "process_exit" -> DiagramCompletion.PROCESS_EXIT
         "terminal" -> DiagramCompletion.TERMINAL
         else -> DiagramCompletion.NORMAL
@@ -278,15 +279,25 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                     }
 
                     fun handlerMatches(handler: Handler, outcome: DiagramCompletion): Boolean {
-                        if (handler.data.string("kind_handler") != "on") return outcome == DiagramCompletion.ERROR && handler.data.string("kind_handler") == "trap"
+                        if (handler.data.string("kind_handler") == "trap") {
+                            return outcome == DiagramCompletion.ERROR ||
+                                outcome == DiagramCompletion.DYNAMIC ||
+                                outcome == DiagramCompletion.DYNAMIC_RETURN_OR_ERROR
+                        }
+                        if (handler.data.string("kind_handler") != "on") return false
                         return when (outcome) {
                             DiagramCompletion.NORMAL -> handler.data.string("match") == "ok" || handler.data.string("match") == "0"
                             DiagramCompletion.ERROR -> handler.data.string("match") == "error" || handler.data.string("match") == "1"
                             DiagramCompletion.RETURN -> handler.data.string("match") == "return" || handler.data.string("match") == "2"
                             DiagramCompletion.BREAK -> handler.data.string("match") == "break" || handler.data.string("match") == "3"
                             DiagramCompletion.CONTINUE -> handler.data.string("match") == "continue" || handler.data.string("match") == "4"
-                            DiagramCompletion.DYNAMIC -> handler.data.string("kind_handler") == "on" &&
-                                (handler.data.string("match") == "error" || handler.data.string("match") == "return" || handler.data.string("match") == "1" || handler.data.string("match") == "2")
+                            // An unevaluated -options value can produce any
+                            // Tcl completion code. Keep every on clause as a
+                            // possible source-order selection; choosing only
+                            // the first would falsely discard later handlers.
+                            DiagramCompletion.DYNAMIC -> true
+                            DiagramCompletion.DYNAMIC_RETURN_OR_ERROR ->
+                                (handler.data.string("match") in listOf("error", "return", "1", "2"))
                             DiagramCompletion.PROCESS_EXIT -> false
                             DiagramCompletion.TERMINAL -> false
                         }
@@ -298,13 +309,28 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                         val errorIsCertainlyHandled = bodyExit.completion == DiagramCompletion.ERROR && matches.any {
                             (_, handler) -> handler.data.string("kind_handler") == "on"
                         }
-                        if (matches.isEmpty() || bodyExit.completion == DiagramCompletion.DYNAMIC || (bodyExit.completion == DiagramCompletion.ERROR && !errorIsCertainlyHandled)) {
+                        if (matches.isEmpty() ||
+                            bodyExit.completion == DiagramCompletion.DYNAMIC ||
+                            bodyExit.completion == DiagramCompletion.DYNAMIC_RETURN_OR_ERROR ||
+                            (bodyExit.completion == DiagramCompletion.ERROR && !errorIsCertainlyHandled)
+                        ) {
                             // A `trap` pattern needs error-code detail which
                             // this compact contract intentionally does not
                             // carry.  It is a possible handled path, but not
                             // proof that every error is caught, so retain the
                             // unhandled error as well.
                             exits += bodyExit
+                        }
+                        // Dynamic -options can produce TCL_OK. If no `on ok`
+                        // clause owns that possibility, retain the direct
+                        // normal continuation as well as abrupt propagation.
+                        if (bodyExit.completion == DiagramCompletion.DYNAMIC &&
+                            matches.none { (_, handler) ->
+                                handler.data.string("kind_handler") == "on" &&
+                                    (handler.data.string("match") == "ok" || handler.data.string("match") == "0")
+                            }
+                        ) {
+                            exits += Tail(bodyExit.id, DiagramCompletion.NORMAL)
                         }
                         if (matches.isNotEmpty()) {
                             // `on` clauses are selected in source order.  A
@@ -315,7 +341,7 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                             for ((index, handler) in matches) {
                                 connect(bodyExit.id, handler.start, handler.data.string("kind_handler"))
                                 exits += renderHandler(index)
-                                if (handler.data.string("kind_handler") == "on") break
+                                if (handler.data.string("kind_handler") == "on" && bodyExit.completion != DiagramCompletion.DYNAMIC && bodyExit.completion != DiagramCompletion.DYNAMIC_RETURN_OR_ERROR) break
                             }
                         }
                     }
@@ -404,7 +430,7 @@ private class MermaidIds {
 }
 
 /** Completion states defined by the shared `tcl-diagram` JSON contract. */
-private enum class DiagramCompletion { NORMAL, ERROR, RETURN, BREAK, CONTINUE, DYNAMIC, PROCESS_EXIT, TERMINAL }
+private enum class DiagramCompletion { NORMAL, ERROR, RETURN, BREAK, CONTINUE, DYNAMIC, DYNAMIC_RETURN_OR_ERROR, PROCESS_EXIT, TERMINAL }
 
 private fun JsonObject.string(name: String): String? =
     get(name)?.takeUnless { it.isJsonNull }?.asString

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -143,7 +143,7 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
         if (from != null) out += if (caption == null) "$from --> $to" else "$from -->|${label(caption)}| $to"
     }
 
-    data class Tail(val id: String, val completion: DiagramCompletion = DiagramCompletion.NORMAL)
+    data class Tail(val id: String, val completion: DiagramCompletion = DiagramCompletion.NORMAL, val completionCode: Int? = null)
 
     fun completion(item: JsonObject): DiagramCompletion = when (item.string("completion")) {
         "error" -> DiagramCompletion.ERROR
@@ -152,6 +152,7 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
         "continue" -> DiagramCompletion.CONTINUE
         "dynamic" -> DiagramCompletion.DYNAMIC
         "dynamic_return_or_error" -> DiagramCompletion.DYNAMIC_RETURN_OR_ERROR
+        "custom" -> DiagramCompletion.EXACT_CUSTOM
         "process_exit" -> DiagramCompletion.PROCESS_EXIT
         "terminal" -> DiagramCompletion.TERMINAL
         else -> DiagramCompletion.NORMAL
@@ -294,6 +295,7 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                             DiagramCompletion.DYNAMIC -> false
                             DiagramCompletion.DYNAMIC_RETURN_OR_ERROR ->
                                 (handler.data.string("match") in listOf("error", "return", "1", "2"))
+                            DiagramCompletion.EXACT_CUSTOM -> false
                             DiagramCompletion.PROCESS_EXIT -> false
                             DiagramCompletion.TERMINAL -> false
                         }
@@ -379,10 +381,17 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                             continue
                         }
                         val matches = handlers.withIndex().filter { (_, handler) -> handlerMatches(handler, bodyExit.completion) }
+                        val exactCustomMatches = if (bodyExit.completion == DiagramCompletion.EXACT_CUSTOM) {
+                            handlers.withIndex().filter { (_, handler) ->
+                                handler.data.string("kind_handler") == "on" &&
+                                    handler.data.get("completion_code")?.takeIf { it.isJsonPrimitive }?.asInt == bodyExit.completionCode
+                            }
+                        } else emptyList()
+                        val effectiveMatches = if (exactCustomMatches.isNotEmpty()) exactCustomMatches else matches
                         val errorIsCertainlyHandled = bodyExit.completion == DiagramCompletion.ERROR && matches.any {
                             (_, handler) -> handler.data.string("kind_handler") == "on"
                         }
-                        if (matches.isEmpty() ||
+                        if (effectiveMatches.isEmpty() ||
                             (bodyExit.completion == DiagramCompletion.ERROR && !errorIsCertainlyHandled)
                         ) {
                             // A `trap` pattern needs error-code detail which
@@ -392,13 +401,13 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                             // unhandled error as well.
                             exits += bodyExit
                         }
-                        if (matches.isNotEmpty()) {
+                        if (effectiveMatches.isNotEmpty()) {
                             // `on` clauses are selected in source order.  A
                             // `trap` pattern is not represented by the
                             // structured IR's completion code, so every
                             // preceding trap is a possible path; a matching
                             // `on` clause then catches all remaining paths.
-                            for ((index, handler) in matches) {
+                            for ((index, handler) in effectiveMatches) {
                                 connect(bodyExit.id, handler.start, handler.data.string("kind_handler"))
                                 exits += renderHandler(index)
                                 if (handler.data.string("kind_handler") == "on" && bodyExit.completion != DiagramCompletion.DYNAMIC && bodyExit.completion != DiagramCompletion.DYNAMIC_RETURN_OR_ERROR) break
@@ -436,7 +445,7 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                         // path, exactly as Tcl specifies.
                         val propagated = finallyExits.flatMap { finalExit ->
                             if (finalExit.completion == DiagramCompletion.NORMAL) {
-                                finallyInputs.map { Tail(finalExit.id, it.completion) }
+                                finallyInputs.map { Tail(finalExit.id, it.completion, it.completionCode) }
                             } else {
                                 listOf(finalExit)
                             }
@@ -453,10 +462,11 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                     val step = node(text)
                     connect(active, step)
                     val outcome = completion(item)
+                    val completionCode = item.get("completion_code")?.takeIf { it.isJsonPrimitive }?.asInt
                     if (outcome == DiagramCompletion.NORMAL) {
                         active = listOf(Tail(step))
                     } else {
-                        abrupt += Tail(step, outcome)
+                        abrupt += Tail(step, outcome, completionCode)
                         active = emptyList()
                     }
                 }
@@ -490,7 +500,7 @@ private class MermaidIds {
 }
 
 /** Completion states defined by the shared `tcl-diagram` JSON contract. */
-private enum class DiagramCompletion { NORMAL, ERROR, RETURN, BREAK, CONTINUE, DYNAMIC, DYNAMIC_RETURN_OR_ERROR, PROCESS_EXIT, TERMINAL }
+private enum class DiagramCompletion { NORMAL, ERROR, RETURN, BREAK, CONTINUE, DYNAMIC, DYNAMIC_RETURN_OR_ERROR, EXACT_CUSTOM, PROCESS_EXIT, TERMINAL }
 private sealed class PossibleCompletion {
     data object NORMAL : PossibleCompletion()
     data object ERROR : PossibleCompletion()

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -150,6 +150,7 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
         "return" -> DiagramCompletion.RETURN
         "break" -> DiagramCompletion.BREAK
         "continue" -> DiagramCompletion.CONTINUE
+        "dynamic" -> DiagramCompletion.DYNAMIC
         "process_exit" -> DiagramCompletion.PROCESS_EXIT
         "terminal" -> DiagramCompletion.TERMINAL
         else -> DiagramCompletion.NORMAL
@@ -284,6 +285,8 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                             DiagramCompletion.RETURN -> handler.data.string("match") == "return" || handler.data.string("match") == "2"
                             DiagramCompletion.BREAK -> handler.data.string("match") == "break" || handler.data.string("match") == "3"
                             DiagramCompletion.CONTINUE -> handler.data.string("match") == "continue" || handler.data.string("match") == "4"
+                            DiagramCompletion.DYNAMIC -> handler.data.string("kind_handler") == "on" &&
+                                (handler.data.string("match") == "error" || handler.data.string("match") == "return" || handler.data.string("match") == "1" || handler.data.string("match") == "2")
                             DiagramCompletion.PROCESS_EXIT -> false
                             DiagramCompletion.TERMINAL -> false
                         }
@@ -295,7 +298,7 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                         val errorIsCertainlyHandled = bodyExit.completion == DiagramCompletion.ERROR && matches.any {
                             (_, handler) -> handler.data.string("kind_handler") == "on"
                         }
-                        if (matches.isEmpty() || (bodyExit.completion == DiagramCompletion.ERROR && !errorIsCertainlyHandled)) {
+                        if (matches.isEmpty() || bodyExit.completion == DiagramCompletion.DYNAMIC || (bodyExit.completion == DiagramCompletion.ERROR && !errorIsCertainlyHandled)) {
                             // A `trap` pattern needs error-code detail which
                             // this compact contract intentionally does not
                             // carry.  It is a possible handled path, but not
@@ -401,7 +404,7 @@ private class MermaidIds {
 }
 
 /** Completion states defined by the shared `tcl-diagram` JSON contract. */
-private enum class DiagramCompletion { NORMAL, ERROR, RETURN, BREAK, CONTINUE, PROCESS_EXIT, TERMINAL }
+private enum class DiagramCompletion { NORMAL, ERROR, RETURN, BREAK, CONTINUE, DYNAMIC, PROCESS_EXIT, TERMINAL }
 
 private fun JsonObject.string(name: String): String? =
     get(name)?.takeUnless { it.isJsonNull }?.asString

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -183,7 +183,6 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                     if (branchTails.isEmpty()) {
                         active = listOf(Tail(decision))
                     } else {
-                        val join = node("if join", "round")
                         // A conditional without an explicit else also has a
                         // fall-through path; keep it connected to the same
                         // continuation rather than dropping it.
@@ -191,12 +190,21 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                             it.isJsonObject && it.asJsonObject.string("condition") == "else"
                         }
                         val normalTails = branchTails.filter { it.completion == DiagramCompletion.NORMAL }
-                        normalTails.forEach { connect(it.id, join) }
-                        if (!hasElse) {
-                            connect(decision, join, "false")
+                        val fallsThrough = normalTails.isNotEmpty() || !hasElse
+                        if (fallsThrough) {
+                            val join = node("if join", "round")
+                            normalTails.forEach { connect(it.id, join) }
+                            if (!hasElse) {
+                                connect(decision, join, "false")
+                            }
+                            active = listOf(Tail(join))
+                        } else {
+                            // An explicit else covers every condition.  If all
+                            // arms complete abruptly, no path reaches the next
+                            // statement, so do not manufacture a join tail.
+                            active = emptyList()
                         }
                         abrupt += branchTails.filter { it.completion != DiagramCompletion.NORMAL }
-                        active = listOf(Tail(join))
                     }
                 }
                 "switch" -> {
@@ -222,13 +230,21 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                         // Every matching arm continues at one shared point.
                         // Without a default, Tcl also reaches that point when
                         // no pattern matched; a default consumes that path.
-                        val join = node("switch join", "round")
-                        armTails.filter { it.completion == DiagramCompletion.NORMAL }.forEach { connect(it.id, join) }
-                        if (!hasDefault) {
-                            connect(decision, join, "no match")
+                        val normalTails = armTails.filter { it.completion == DiagramCompletion.NORMAL }
+                        val fallsThrough = normalTails.isNotEmpty() || !hasDefault
+                        if (fallsThrough) {
+                            val join = node("switch join", "round")
+                            normalTails.forEach { connect(it.id, join) }
+                            if (!hasDefault) {
+                                connect(decision, join, "no match")
+                            }
+                            active = listOf(Tail(join))
+                        } else {
+                            // A default covers every match outcome.  With no
+                            // normal arm tail, the continuation is unreachable.
+                            active = emptyList()
                         }
                         abrupt += armTails.filter { it.completion != DiagramCompletion.NORMAL }
-                        active = listOf(Tail(join))
                     }
                 }
                 "loop" -> {
@@ -517,6 +533,13 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                     val outcome = completion(item)
                     val completionCode = item.get("completion_code")?.takeIf { it.isJsonPrimitive }?.asInt
                     if (outcome == DiagramCompletion.NORMAL) {
+                        active = listOf(Tail(step))
+                    } else if (outcome == DiagramCompletion.DYNAMIC) {
+                        // `return -options $options` may resolve to `-code ok`.
+                        // Retain both that normal continuation and the dynamic
+                        // abrupt outcomes so an enclosing construct can route
+                        // every possible completion.
+                        abrupt += Tail(step, outcome, completionCode)
                         active = listOf(Tail(step))
                     } else {
                         abrupt += Tail(step, outcome, completionCode)

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -286,15 +286,15 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                                 outcome == DiagramCompletion.DYNAMIC_RETURN_OR_ERROR
                         }
                         if (handler.data.string("kind_handler") != "on") return false
+                        val code = handler.data.get("completion_code")?.takeIf { it.isJsonPrimitive }?.asInt
                         return when (outcome) {
-                            DiagramCompletion.NORMAL -> handler.data.string("match") == "ok" || handler.data.string("match") == "0"
-                            DiagramCompletion.ERROR -> handler.data.string("match") == "error" || handler.data.string("match") == "1"
-                            DiagramCompletion.RETURN -> handler.data.string("match") == "return" || handler.data.string("match") == "2"
-                            DiagramCompletion.BREAK -> handler.data.string("match") == "break" || handler.data.string("match") == "3"
-                            DiagramCompletion.CONTINUE -> handler.data.string("match") == "continue" || handler.data.string("match") == "4"
+                            DiagramCompletion.NORMAL -> code == 0
+                            DiagramCompletion.ERROR -> code == 1
+                            DiagramCompletion.RETURN -> code == 2
+                            DiagramCompletion.BREAK -> code == 3
+                            DiagramCompletion.CONTINUE -> code == 4
                             DiagramCompletion.DYNAMIC -> false
-                            DiagramCompletion.DYNAMIC_RETURN_OR_ERROR ->
-                                (handler.data.string("match") in listOf("error", "return", "1", "2"))
+                            DiagramCompletion.DYNAMIC_RETURN_OR_ERROR -> code == 1 || code == 2
                             DiagramCompletion.EXACT_CUSTOM -> false
                             DiagramCompletion.PROCESS_EXIT -> false
                             DiagramCompletion.TERMINAL -> false

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActions.kt
@@ -155,6 +155,7 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
         "continue" -> DiagramCompletion.CONTINUE
         "dynamic" -> DiagramCompletion.DYNAMIC
         "dynamic_return_or_error" -> DiagramCompletion.DYNAMIC_RETURN_OR_ERROR
+        "exit_or_error" -> DiagramCompletion.EXIT_OR_ERROR
         "custom" -> DiagramCompletion.EXACT_CUSTOM
         "process_exit" -> DiagramCompletion.PROCESS_EXIT
         "terminal" -> DiagramCompletion.TERMINAL
@@ -273,11 +274,20 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                     // `catch` converts every Tcl completion into its own
                     // normal integer result. Process exit is not a Tcl
                     // completion and cannot be caught, so it remains abrupt.
+                    // A dynamic exit status contributes both: its invalid
+                    // integer path is caught, while its valid integer path
+                    // still terminates the process.
                     val processExits = bodyExits.filter { it.completion == DiagramCompletion.PROCESS_EXIT }
+                    val exitOrErrors = bodyExits.filter { it.completion == DiagramCompletion.EXIT_OR_ERROR }
                     abrupt += processExits
+                    abrupt += exitOrErrors.map { Tail(it.id, DiagramCompletion.PROCESS_EXIT) }
                     active = bodyExits
-                        .filter { it.completion != DiagramCompletion.PROCESS_EXIT }
+                        .filter {
+                            it.completion != DiagramCompletion.PROCESS_EXIT &&
+                                it.completion != DiagramCompletion.EXIT_OR_ERROR
+                        }
                         .map { Tail(it.id) }
+                    active += exitOrErrors.map { Tail(it.id) }
                 }
                 "try" -> {
                     val attempt = node("try", "round")
@@ -316,7 +326,8 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                         if (handler.data.string("kind_handler") == "trap") {
                             return outcome == DiagramCompletion.ERROR ||
                                 outcome == DiagramCompletion.DYNAMIC ||
-                                outcome == DiagramCompletion.DYNAMIC_RETURN_OR_ERROR
+                                outcome == DiagramCompletion.DYNAMIC_RETURN_OR_ERROR ||
+                                outcome == DiagramCompletion.EXIT_OR_ERROR
                         }
                         if (handler.data.string("kind_handler") != "on") return false
                         val code = handler.data.get("completion_code")?.takeIf { it.isJsonPrimitive }?.asInt
@@ -328,6 +339,7 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                             DiagramCompletion.CONTINUE -> code == 4
                             DiagramCompletion.DYNAMIC -> false
                             DiagramCompletion.DYNAMIC_RETURN_OR_ERROR -> code == 1 || code == 2
+                            DiagramCompletion.EXIT_OR_ERROR -> code == 1
                             DiagramCompletion.EXACT_CUSTOM -> false
                             DiagramCompletion.PROCESS_EXIT -> false
                             DiagramCompletion.TERMINAL -> false
@@ -369,7 +381,8 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                     val exits = mutableListOf<Tail>()
                     for (bodyExit in bodyExits) {
                         if (bodyExit.completion == DiagramCompletion.DYNAMIC ||
-                            bodyExit.completion == DiagramCompletion.DYNAMIC_RETURN_OR_ERROR
+                            bodyExit.completion == DiagramCompletion.DYNAMIC_RETURN_OR_ERROR ||
+                            bodyExit.completion == DiagramCompletion.EXIT_OR_ERROR
                         ) {
                             val possible = if (bodyExit.completion == DiagramCompletion.DYNAMIC) {
                                 // Dynamic action nodes retain their normal
@@ -391,8 +404,15 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                                     .map { PossibleCompletion.CUSTOM(it) }
                                     .toList()
                                 standard + custom + PossibleCompletion.UNKNOWN_OTHER
-                            } else {
+                            } else if (bodyExit.completion == DiagramCompletion.DYNAMIC_RETURN_OR_ERROR) {
                                 listOf(PossibleCompletion.ERROR, PossibleCompletion.RETURN)
+                            } else {
+                                // A dynamic exit status has two outcomes:
+                                // a catchable status-conversion error and an
+                                // immediate process exit.  Route only the
+                                // former through try; append the latter as a
+                                // bypass tail below.
+                                listOf(PossibleCompletion.ERROR)
                             }
                             for (outcome in possible) {
                                 var certainlyCaught = false
@@ -424,6 +444,9 @@ internal fun renderDiagramMermaid(data: JsonElement): String? {
                                     }
                                 }
                                 if (!certainlyCaught) exits += Tail(bodyExit.id, completionOf(outcome))
+                            }
+                            if (bodyExit.completion == DiagramCompletion.EXIT_OR_ERROR) {
+                                exits += Tail(bodyExit.id, DiagramCompletion.PROCESS_EXIT)
                             }
                             continue
                         }
@@ -583,7 +606,7 @@ private class MermaidIds {
 }
 
 /** Completion states defined by the shared `tcl-diagram` JSON contract. */
-private enum class DiagramCompletion { NORMAL, ERROR, RETURN, BREAK, CONTINUE, DYNAMIC, DYNAMIC_RETURN_OR_ERROR, EXACT_CUSTOM, PROCESS_EXIT, TERMINAL }
+private enum class DiagramCompletion { NORMAL, ERROR, RETURN, BREAK, CONTINUE, DYNAMIC, DYNAMIC_RETURN_OR_ERROR, EXIT_OR_ERROR, EXACT_CUSTOM, PROCESS_EXIT, TERMINAL }
 private sealed class PossibleCompletion {
     data object NORMAL : PossibleCompletion()
     data object ERROR : PossibleCompletion()

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettings.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettings.kt
@@ -65,9 +65,6 @@ class TclLspSettings : PersistentStateComponent<TclLspSettings> {
     var featureDocumentHighlight: Boolean = true
     var featureCodeLens: Boolean = true
     var featureWorkspaceFileOps: Boolean = true
-    // Pull diagnostics are opt-in: advertising diagnosticProvider flips
-    // most LSP clients into pull mode and disables the push pipeline.
-    var featurePullDiagnostics: Boolean = false
     var featureWillSaveWaitUntil: Boolean = false
     var featureImplementation: Boolean = true
     var featureTypeDefinition: Boolean = true
@@ -340,7 +337,6 @@ class TclLspSettings : PersistentStateComponent<TclLspSettings> {
                 "documentHighlight" to featureDocumentHighlight,
                 "codeLens" to featureCodeLens,
                 "workspaceFileOps" to featureWorkspaceFileOps,
-                "pullDiagnostics" to featurePullDiagnostics,
                 "implementation" to featureImplementation,
                 "typeDefinition" to featureTypeDefinition,
                 "declaration" to featureDeclaration,

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
@@ -63,8 +63,6 @@ class TclLspSettingsPanel {
     private val featureDocumentHighlight = JBCheckBox("Document highlight")
     private val featureCodeLens = JBCheckBox("Code lens")
     private val featureWorkspaceFileOps = JBCheckBox("Auto-rewrite source paths on rename")
-    private val featurePullDiagnostics =
-        JBCheckBox("Pull diagnostics (opt-in; restart required)")
     private val featureImplementation = JBCheckBox("Go to implementation")
     private val featureTypeDefinition = JBCheckBox("Go to type definition")
     private val featureDeclaration = JBCheckBox("Go to declaration")
@@ -328,7 +326,6 @@ class TclLspSettingsPanel {
                 featureCallHierarchy,
                 featureDocumentLinks, featureSelectionRange,
                 featureDocumentHighlight, featureCodeLens, featureWorkspaceFileOps,
-                featurePullDiagnostics,
                 featureImplementation, featureTypeDefinition, featureDeclaration,
                 featureLinkedEditingRange,
             )
@@ -526,7 +523,6 @@ class TclLspSettingsPanel {
             featureDocumentHighlight.isSelected != s.featureDocumentHighlight ||
             featureCodeLens.isSelected != s.featureCodeLens ||
             featureWorkspaceFileOps.isSelected != s.featureWorkspaceFileOps ||
-            featurePullDiagnostics.isSelected != s.featurePullDiagnostics ||
             featureImplementation.isSelected != s.featureImplementation ||
             featureTypeDefinition.isSelected != s.featureTypeDefinition ||
             featureDeclaration.isSelected != s.featureDeclaration ||
@@ -772,7 +768,6 @@ class TclLspSettingsPanel {
         s.featureDocumentHighlight = featureDocumentHighlight.isSelected
         s.featureCodeLens = featureCodeLens.isSelected
         s.featureWorkspaceFileOps = featureWorkspaceFileOps.isSelected
-        s.featurePullDiagnostics = featurePullDiagnostics.isSelected
         s.featureImplementation = featureImplementation.isSelected
         s.featureTypeDefinition = featureTypeDefinition.isSelected
         s.featureDeclaration = featureDeclaration.isSelected
@@ -1036,7 +1031,6 @@ class TclLspSettingsPanel {
         featureDocumentHighlight.isSelected = s.featureDocumentHighlight
         featureCodeLens.isSelected = s.featureCodeLens
         featureWorkspaceFileOps.isSelected = s.featureWorkspaceFileOps
-        featurePullDiagnostics.isSelected = s.featurePullDiagnostics
         featureImplementation.isSelected = s.featureImplementation
         featureTypeDefinition.isSelected = s.featureTypeDefinition
         featureDeclaration.isSelected = s.featureDeclaration

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -186,7 +186,7 @@ class TclLspActionsTest {
         val payload = JsonParser.parseString(
             """{"events":[{"name":"E","flow":[{"kind":"try","body":[
               {"kind":"action","label":"fail","completion":"error"}],"handlers":[
-              {"kind_handler":"on","match":"error","fallthrough":false,"body":[{"kind":"action","label":"recover"}]}
+              {"kind_handler":"on","match":"error","completion_code":1,"fallthrough":false,"body":[{"kind":"action","label":"recover"}]}
             ],"finally":[{"kind":"action","label":"cleanup"}]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
         )
 
@@ -235,8 +235,8 @@ class TclLspActionsTest {
         val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
             """{"events":[{"name":"E","flow":[{"kind":"try","body":[
               {"kind":"action","label":"return -code error","completion":"return"}],"handlers":[
-              {"kind_handler":"on","match":"error","fallthrough":false,"body":[{"kind":"action","label":"wrong"}]},
-              {"kind_handler":"on","match":"return","fallthrough":false,"body":[{"kind":"action","label":"handled"}]}
+              {"kind_handler":"on","match":"error","completion_code":1,"fallthrough":false,"body":[{"kind":"action","label":"wrong"}]},
+              {"kind_handler":"on","match":"return","completion_code":2,"fallthrough":false,"body":[{"kind":"action","label":"handled"}]}
             ],"finally":[{"kind":"action","label":"cleanup"}]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
         )))
         kotlin.test.assertFalse(mermaid.contains("wrong"), mermaid)
@@ -351,6 +351,26 @@ class TclLspActionsTest {
     }
 
     @Test
+    fun exactStandardCompletionsUseCanonicalHandlerCodesNotSelectorSpellings() {
+        for ((completion, selector, code) in listOf(
+            Triple(null, "00", 0),
+            Triple("error", "+1", 1),
+            Triple("return", "02", 2),
+            Triple("break", "0x3", 3),
+            Triple("continue", "04", 4),
+        )) {
+            val completionField = completion?.let { ",\"completion\":\"$it\"" } ?: ""
+            val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+                """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+                  {"kind":"action","label":"body"$completionField}],"handlers":[
+                  {"kind_handler":"on","match":"$selector","completion_code":$code,"fallthrough":false,"body":[{"kind":"action","label":"handled"}]}
+                ],"finally":[{"kind":"action","label":"cleanup"}]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
+            )))
+            assertContains(mermaid, "after", message = selector)
+        }
+    }
+
+    @Test
     fun normalFinallyPathContinuesAndFinallyCompletionOverridesIt() {
         fun render(finallyCompletion: String? = null): String {
             val completion = finallyCompletion?.let { ",\"completion\":\"$it\"" } ?: ""
@@ -373,8 +393,8 @@ class TclLspActionsTest {
         val payload = JsonParser.parseString(
             """{"events":[{"name":"E","flow":[{"kind":"try","body":[
               {"kind":"action","label":"fail","completion":"error"}],"handlers":[
-              {"kind_handler":"on","match":"error","fallthrough":true,"body":[]},
-              {"kind_handler":"on","match":"return","fallthrough":false,"body":[{"kind":"action","label":"shared body"}]}
+              {"kind_handler":"on","match":"error","completion_code":1,"fallthrough":true,"body":[]},
+              {"kind_handler":"on","match":"return","completion_code":2,"fallthrough":false,"body":[{"kind":"action","label":"shared body"}]}
             ],"finally":[{"kind":"action","label":"cleanup"}]}]}],"procedures":[]}"""
         )
 

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -147,6 +147,26 @@ class TclLspActionsTest {
     }
 
     @Test
+    fun onlyExactLowerCaseDefaultConsumesTheNoMatchPath() {
+        fun render(pattern: String): String = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"switch","subject":"kind","arms":[
+              {"pattern":"$pattern","body":[{"kind":"action","label":"arm"}]}
+            ]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
+        )))
+
+        val defaultArm = render("default")
+        kotlin.test.assertFalse(defaultArm.contains("|no match|"), defaultArm)
+
+        // Mutation guard: a case-insensitive default check wrongly removes
+        // this edge for normal Tcl patterns such as `Default` and `DEFAULT`.
+        for (ordinaryPattern in listOf("Default", "DEFAULT")) {
+            val mermaid = render(ordinaryPattern)
+            assertContains(mermaid, "|no match|")
+            assertContains(mermaid, "switch join")
+        }
+    }
+
+    @Test
     fun edgeCaptionPipesAreHtmlEscaped() {
         val payload = JsonParser.parseString(
             """{"events":[{"name":"E","flow":[{"kind":"switch","subject":"kind","arms":[

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -358,6 +358,32 @@ class TclLspActionsTest {
     }
 
     @Test
+    fun dynamicNormalOutcomeRoutesOnceThroughOnOkAndFinally() {
+        val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+              {"kind":"action","label":"return -options ${'$'}opts","completion":"dynamic"}],"handlers":[
+              {"kind_handler":"on","match":"ok","completion_code":0,"fallthrough":false,"body":[{"kind":"action","label":"ok path"}]}
+            ],"finally":[{"kind":"action","label":"cleanup"}]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
+        )))
+        assertEquals(1, mermaid.lines().count { it == "n2 -->|on| n3" }, mermaid)
+        assertEquals(1, mermaid.lines().count { it == "n4 --> n5" }, mermaid)
+        assertEquals(1, mermaid.lines().count { it == "n5 --> n6" }, mermaid)
+        assertEquals(1, mermaid.lines().count { it == "n6 --> n7" }, mermaid)
+    }
+
+    @Test
+    fun dynamicNormalOutcomeRoutesOnceThroughFinallyWithoutAHandler() {
+        val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+              {"kind":"action","label":"return -options ${'$'}opts","completion":"dynamic"}],"finally":[
+              {"kind":"action","label":"cleanup"}]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
+        )))
+        assertEquals(1, mermaid.lines().count { it == "n2 --> n3" }, mermaid)
+        assertEquals(1, mermaid.lines().count { it == "n3 --> n4" }, mermaid)
+        assertEquals(1, mermaid.lines().count { it == "n4 --> n5" }, mermaid)
+    }
+
+    @Test
     fun dynamicCompletionOutsideTryRetainsItsNormalContinuation() {
         val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
             """{"events":[{"name":"E","flow":[

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -1,6 +1,7 @@
 package com.tcllsp.jetbrains.actions
 
 import com.google.gson.JsonParser
+import com.google.gson.JsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -372,15 +373,39 @@ class TclLspActionsTest {
 
     @Test
     fun trapSourceOrderUsesProjectedTclListElements() {
-        val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
-            """{"events":[{"name":"E","flow":[{"kind":"try","body":[
-              {"kind":"action","label":"return -code ${'$'}code","completion":"dynamic_return_or_error"}],"handlers":[
-              {"kind_handler":"trap","match":"A {B C}","trap_pattern":["A","B C"],"fallthrough":false,"body":[{"kind":"action","label":"first trap"}]},
-              {"kind_handler":"trap","match":"A \"B C\"","trap_pattern":["A","B C"],"fallthrough":false,"body":[{"kind":"action","label":"shadowed trap"}]},
-              {"kind_handler":"on","match":"error","completion_code":1,"fallthrough":false,"body":[{"kind":"action","label":"error"}]}
-            ]}]}],"procedures":[]}"""
-        )))
-        assertEquals(1, mermaid.lines().count { it.startsWith("n2 -->|trap|") }, mermaid)
+        fun render(firstMatch: String, secondMatch: String, pattern: List<String>?): String {
+            val projected = pattern?.joinToString(prefix = "[", postfix = "]") { JsonPrimitive(it).toString() } ?: "null"
+            return assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+                """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+                  {"kind":"action","label":"return -code ${'$'}code","completion":"dynamic_return_or_error"}],"handlers":[
+                  {"kind_handler":"trap","match":${JsonPrimitive(firstMatch)},"trap_pattern":$projected,"fallthrough":false,"body":[{"kind":"action","label":"first trap"}]},
+                  {"kind_handler":"trap","match":${JsonPrimitive(secondMatch)},"trap_pattern":$projected,"fallthrough":false,"body":[{"kind":"action","label":"second trap"}]},
+                  {"kind_handler":"on","match":"error","completion_code":1,"fallthrough":false,"body":[{"kind":"action","label":"error"}]}
+                ]}]}],"procedures":[]}"""
+            )))
+        }
+
+        for ((first, second, pattern) in listOf(
+            Triple("A {B C}", "A \"B C\"", listOf("A", "B C")),
+            Triple("A \\${'$'}B", "A {${'$'}B}", listOf("A", "${'$'}B")),
+            Triple("A \\[B\\]", "A {[B]}", listOf("A", "[B]")),
+            Triple("A C:\\\\tmp", "A {C:\\tmp}", listOf("A", "C:\\tmp")),
+        )) {
+            val mermaid = render(first, second, pattern)
+            assertEquals(1, mermaid.lines().count { it.contains("-->|trap|") }, mermaid)
+            assertContains(mermaid, "first trap")
+            kotlin.test.assertFalse(mermaid.contains("second trap"), mermaid)
+        }
+
+        for ((first, second) in listOf(
+            "A {" to "A }",
+            "${'$'}pattern" to "A ${'$'}pattern",
+        )) {
+            val mermaid = render(first, second, null)
+            assertEquals(2, mermaid.lines().count { it.contains("-->|trap|") }, mermaid)
+            assertContains(mermaid, "first trap")
+            assertContains(mermaid, "second trap")
+        }
     }
 
     @Test

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -371,6 +371,19 @@ class TclLspActionsTest {
     }
 
     @Test
+    fun trapSourceOrderUsesProjectedTclListElements() {
+        val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+              {"kind":"action","label":"return -code ${'$'}code","completion":"dynamic_return_or_error"}],"handlers":[
+              {"kind_handler":"trap","match":"A {B C}","trap_pattern":["A","B C"],"fallthrough":false,"body":[{"kind":"action","label":"first trap"}]},
+              {"kind_handler":"trap","match":"A \"B C\"","trap_pattern":["A","B C"],"fallthrough":false,"body":[{"kind":"action","label":"shadowed trap"}]},
+              {"kind_handler":"on","match":"error","completion_code":1,"fallthrough":false,"body":[{"kind":"action","label":"error"}]}
+            ]}]}],"procedures":[]}"""
+        )))
+        assertEquals(1, mermaid.lines().count { it.startsWith("n2 -->|trap|") }, mermaid)
+    }
+
+    @Test
     fun normalFinallyPathContinuesAndFinallyCompletionOverridesIt() {
         fun render(finallyCompletion: String? = null): String {
             val completion = finallyCompletion?.let { ",\"completion\":\"$it\"" } ?: ""

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -3,6 +3,7 @@ package com.tcllsp.jetbrains.actions
 import com.google.gson.JsonParser
 import kotlin.test.Test
 import kotlin.test.assertContains
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 class TclLspActionsTest {
@@ -276,6 +277,22 @@ class TclLspActionsTest {
         kotlin.test.assertFalse(mermaid.contains("wrong ok"), mermaid)
         assertContains(mermaid, "error path")
         assertContains(mermaid, "return path")
+    }
+
+    @Test
+    fun dynamicCompletionUsesOnlyTheFirstOnHandlerForEachConcreteCode() {
+        val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+              {"kind":"action","label":"return -code ${'$'}code","completion":"dynamic_return_or_error"}],"handlers":[
+              {"kind_handler":"on","match":"error","fallthrough":false,"body":[{"kind":"action","label":"first error"}]},
+              {"kind_handler":"on","match":"error","fallthrough":false,"body":[{"kind":"action","label":"duplicate error"}]},
+              {"kind_handler":"on","match":"return","fallthrough":false,"body":[{"kind":"action","label":"first return"}]},
+              {"kind_handler":"on","match":"return","fallthrough":false,"body":[{"kind":"action","label":"duplicate return"}]}
+            ]}]}],"procedures":[]}"""
+        )))
+        // Handler nodes are retained for source context, but only the first
+        // matching on-clause for error and return receives a body edge.
+        assertEquals(2, mermaid.lines().count { it.startsWith("n2 -->|on|") }, mermaid)
     }
 
     @Test

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -312,6 +312,19 @@ class TclLspActionsTest {
     }
 
     @Test
+    fun canonicalWrappedCompletionCodesShadowByTheirSignedCode() {
+        val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+              {"kind":"action","label":"return -options ${'$'}options","completion":"dynamic"}],"handlers":[
+              {"kind_handler":"on","match":"4294967295","completion_code":-1,"fallthrough":false,"body":[{"kind":"action","label":"wrapped"}]},
+              {"kind_handler":"on","match":"-1","completion_code":-1,"fallthrough":false,"body":[{"kind":"action","label":"duplicate"}]},
+              {"kind_handler":"on","match":"2147483648","completion_code":-2147483648,"fallthrough":false,"body":[{"kind":"action","label":"minimum"}]}
+            ]}]}],"procedures":[]}"""
+        )))
+        assertEquals(2, mermaid.lines().count { it.startsWith("n2 -->|on|") }, mermaid)
+    }
+
+    @Test
     fun normalFinallyPathContinuesAndFinallyCompletionOverridesIt() {
         fun render(finallyCompletion: String? = null): String {
             val completion = finallyCompletion?.let { ",\"completion\":\"$it\"" } ?: ""

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -46,4 +46,23 @@ class TclLspActionsTest {
         val payload = JsonParser.parseString("{\"events\": []}")
         kotlin.test.assertNull(renderDiagramMermaid(payload))
     }
+
+    @Test
+    fun conditionalBranchesAllJoinAndNoElseKeepsFalsePath() {
+        val payload = JsonParser.parseString(
+            """
+            {"events":[{"name":"HTTP_REQUEST","flow":[{"kind":"if","branches":[
+              {"condition":"a","body":[{"kind":"action","label":"pool a"}]},
+              {"condition":"b","body":[{"kind":"action","label":"pool b"}]}
+            ]},{"kind":"action","label":"after"}]}],"procedures":[]}
+            """.trimIndent()
+        )
+
+        val mermaid = assertNotNull(renderDiagramMermaid(payload))
+        assertContains(mermaid, "pool a")
+        assertContains(mermaid, "pool b")
+        assertContains(mermaid, "|false|")
+        assertContains(mermaid, "after")
+        assertContains(mermaid, "if join")
+    }
 }

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -179,4 +179,48 @@ class TclLspActionsTest {
         assertContains(mermaid, "|foo&#124;bar|")
         kotlin.test.assertFalse(mermaid.contains("|a | b|"), mermaid)
     }
+
+    @Test
+    fun tryHandlersAndAllExitsFlowThroughFinallyBeforeContinuation() {
+        val payload = JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+              {"kind":"action","label":"work"}],"handlers":[
+              {"kind_handler":"on","match":"error","body":[{"kind":"action","label":"recover"}]},
+              {"kind_handler":"trap","match":"CUSTOM","body":[{"kind":"action","label":"alternate"}]}
+            ],"finally":[{"kind":"action","label":"cleanup"}]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
+        )
+
+        val mermaid = assertNotNull(renderDiagramMermaid(payload))
+        assertContains(mermaid, "n1 --> n2")
+        assertContains(mermaid, "n1 -->|on error| n3")
+        assertContains(mermaid, "n3 --> n4")
+        assertContains(mermaid, "n1 -->|trap CUSTOM| n5")
+        assertContains(mermaid, "n5 --> n6")
+        assertContains(mermaid, "n2 --> n7")
+        assertContains(mermaid, "n4 --> n7")
+        assertContains(mermaid, "n6 --> n7")
+        assertContains(mermaid, "n7 --> n8")
+        assertContains(mermaid, "n8 --> n9")
+        kotlin.test.assertFalse(mermaid.contains("try join"), mermaid)
+    }
+
+    @Test
+    fun loopsHaveBackEdgesAndDistinctExitTails() {
+        fun render(label: String, exit: String): String = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"loop","label":"$label","exit":"$exit","body":[{"kind":"action","label":"body"}]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
+        )))
+
+        for ((label, exit) in listOf(
+            "while ready" to "false",
+            "for" to "false",
+            "foreach item" to "exhausted",
+        )) {
+            val mermaid = render(label, exit)
+            assertContains(mermaid, "n0 --> n1")
+            assertContains(mermaid, "n1 --> n2")
+            assertContains(mermaid, "n2 -->|repeat| n1")
+            assertContains(mermaid, "n1 -->|$exit| n3")
+            assertContains(mermaid, "n3 --> n4")
+        }
+    }
 }

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -473,6 +473,34 @@ class TclLspActionsTest {
     }
 
     @Test
+    fun exactErrorTrapPrefixesRespectSourceOrder() {
+        fun render(first: List<String>, second: List<String>): String {
+            fun pattern(values: List<String>) =
+                values.joinToString(prefix = "[", postfix = "]") { JsonPrimitive(it).toString() }
+            return assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+                """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+                  {"kind":"action","label":"bad return","completion":"error"}],"handlers":[
+                  {"kind_handler":"trap","match":"first","trap_pattern":${pattern(first)},"fallthrough":false,"body":[{"kind":"action","label":"first trap"}]},
+                  {"kind_handler":"trap","match":"second","trap_pattern":${pattern(second)},"fallthrough":false,"body":[{"kind":"action","label":"second trap"}]},
+                  {"kind_handler":"on","match":"error","completion_code":1,"fallthrough":false,"body":[{"kind":"action","label":"on error"}]}
+                ]}]}],"procedures":[]}"""
+            )))
+        }
+
+        val shadowed = render(listOf("A"), listOf("A", "B"))
+        assertEquals(1, shadowed.lines().count { it.contains("-->|trap|") }, shadowed)
+        assertContains(shadowed, "first trap")
+        kotlin.test.assertFalse(shadowed.contains("second trap"), shadowed)
+        assertContains(shadowed, "on error")
+
+        val nonOverlapping = render(listOf("A", "B"), listOf("A"))
+        assertEquals(2, nonOverlapping.lines().count { it.contains("-->|trap|") }, nonOverlapping)
+        assertContains(nonOverlapping, "first trap")
+        assertContains(nonOverlapping, "second trap")
+        assertContains(nonOverlapping, "on error")
+    }
+
+    @Test
     fun normalFinallyPathContinuesAndFinallyCompletionOverridesIt() {
         fun render(finallyCompletion: String? = null): String {
             val completion = finallyCompletion?.let { ",\"completion\":\"$it\"" } ?: ""

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -1,0 +1,49 @@
+package com.tcllsp.jetbrains.actions
+
+import com.google.gson.JsonParser
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertNotNull
+
+class TclLspActionsTest {
+    @Test
+    fun renderDiagramMermaidProjectsStructuredPayload() {
+        val payload = JsonParser.parseString(
+            """
+            {
+              "events": [{
+                "name": "HTTP_REQUEST",
+                "priority": 400,
+                "multiplicity": "once",
+                "flow": [{
+                  "kind": "if",
+                  "branches": [{
+                    "condition": "path == /",
+                    "body": [{"kind": "action", "label": "pool web"}]
+                  }]
+                }]
+              }],
+              "procedures": [{
+                "name": "helper",
+                "params": ["request"],
+                "flow": [{"kind": "return", "value": "request"}]
+              }]
+            }
+            """.trimIndent()
+        )
+
+        val mermaid = assertNotNull(renderDiagramMermaid(payload))
+        assertContains(mermaid, "flowchart TD")
+        assertContains(mermaid, "when HTTP_REQUEST (priority 400, once)")
+        assertContains(mermaid, "proc helper(request)")
+        assertContains(mermaid, "path == /")
+        assertContains(mermaid, "pool web")
+        assertContains(mermaid, "-->|")
+    }
+
+    @Test
+    fun renderDiagramMermaidRejectsMissingStructuredFields() {
+        val payload = JsonParser.parseString("{\"events\": []}")
+        kotlin.test.assertNull(renderDiagramMermaid(payload))
+    }
+}

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -77,11 +77,36 @@ class TclLspActionsTest {
         val payload = JsonParser.parseString(
             """{"events":[{"name":"E","flow":[{"kind":"if","branches":[
               {"condition":"a","body":[{"kind":"action","label":"then"}]},
+              {"condition":"b","body":[{"kind":"action","label":"elseif"}]},
               {"condition":"else","body":[{"kind":"action","label":"else"}]}
-            ]}]}],"procedures":[]}""".trimIndent()
+            ]},{"kind":"action","label":"after"}]}],"procedures":[]}""".trimIndent()
         )
         val mermaid = assertNotNull(renderDiagramMermaid(payload))
-        assertContains(mermaid, "|else|")
+        assertContains(mermaid, "n1 -->|a| n2")
+        assertContains(mermaid, "n1 -->|b| n4")
+        assertContains(mermaid, "n1 -->|else| n6")
+        assertContains(mermaid, "n3 --> n8")
+        assertContains(mermaid, "n5 --> n8")
+        assertContains(mermaid, "n7 --> n8")
+        assertContains(mermaid, "n8 --> n9")
         kotlin.test.assertFalse(mermaid.contains("|false|"))
+    }
+
+    @Test
+    fun nestedConditionJoinsPropagateToOuterContinuation() {
+        val payload = JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"if","branches":[
+              {"condition":"outer","body":[{"kind":"if","branches":[
+                {"condition":"inner","body":[{"kind":"action","label":"inner then"}]}
+              ]}]},
+              {"condition":"other","body":[{"kind":"action","label":"other"}]}
+            ]},{"kind":"action","label":"after"}]}],"procedures":[]}""".trimIndent()
+        )
+        val mermaid = assertNotNull(renderDiagramMermaid(payload))
+        assertContains(mermaid, "n5 --> n6")
+        assertContains(mermaid, "n3 -->|false| n6")
+        assertContains(mermaid, "n6 --> n9")
+        assertContains(mermaid, "n8 --> n9")
+        assertContains(mermaid, "n9 --> n10")
     }
 }

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -260,6 +260,27 @@ class TclLspActionsTest {
     }
 
     @Test
+    fun dynamicExitRoutesOnlyItsErrorPathThroughTryFinallyAndAfter() {
+        val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+              {"kind":"action","label":"exit ${'$'}status","completion":"exit_or_error"}],"handlers":[
+              {"kind_handler":"on","match":"error","completion_code":1,"fallthrough":false,"body":[{"kind":"action","label":"handled status error"}]}],
+              "finally":[{"kind":"action","label":"cleanup"}]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
+        )))
+        // The typed union supplies exactly one catchable branch. Its sibling
+        // process-exit branch is deliberately not connected to finally or
+        // after, while the on-error branch remains visible through both.
+        assertEquals(1, mermaid.lines().count { it.contains("-->|on|") }, mermaid)
+        assertContains(mermaid, "n2 -->|on| n3")
+        assertContains(mermaid, "n4 --> n5")
+        kotlin.test.assertFalse(mermaid.contains("n2 --> n5"), mermaid)
+        assertContains(mermaid, "handled status error")
+        assertContains(mermaid, "finally")
+        assertContains(mermaid, "cleanup")
+        assertContains(mermaid, "after")
+    }
+
+    @Test
     fun catchAbsorbsEveryTclCompletionButNotProcessExit() {
         fun render(completion: String, code: Int? = null): String {
             val completionCode = code?.let { ",\"completion_code\":$it" } ?: ""

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -325,6 +325,32 @@ class TclLspActionsTest {
     }
 
     @Test
+    fun exactCustomCompletionMatchesItsCanonicalOnCode() {
+        val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+              {"kind":"action","label":"return -code 42","completion":"custom","completion_code":42}],"handlers":[
+              {"kind_handler":"on","match":"42","completion_code":42,"fallthrough":false,"body":[{"kind":"action","label":"handled"}]},
+              {"kind_handler":"on","match":"43","completion_code":43,"fallthrough":false,"body":[{"kind":"action","label":"wrong"}]}
+            ],"finally":[{"kind":"action","label":"cleanup"}]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
+        )))
+        assertContains(mermaid, "handled")
+        kotlin.test.assertFalse(mermaid.contains("wrong"), mermaid)
+        assertContains(mermaid, "after")
+    }
+
+    @Test
+    fun wrappedMinusOneCustomCompletionMatchesOnMinusOne() {
+        val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+              {"kind":"action","label":"return -code 4294967295","completion":"custom","completion_code":-1}],"handlers":[
+              {"kind_handler":"on","match":"-1","completion_code":-1,"fallthrough":false,"body":[{"kind":"action","label":"handled minus one"}]}
+            ],"finally":[{"kind":"action","label":"cleanup"}]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
+        )))
+        assertContains(mermaid, "handled minus one")
+        assertContains(mermaid, "after")
+    }
+
+    @Test
     fun normalFinallyPathContinuesAndFinallyCompletionOverridesIt() {
         fun render(finallyCompletion: String? = null): String {
             val completion = finallyCompletion?.let { ",\"completion\":\"$it\"" } ?: ""

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -109,4 +109,54 @@ class TclLspActionsTest {
         assertContains(mermaid, "n8 --> n9")
         assertContains(mermaid, "n9 --> n10")
     }
+
+    @Test
+    fun switchArmsJoinBeforeTheContinuationAndKeepNoMatchWithoutDefault() {
+        val payload = JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"switch","subject":"kind","arms":[
+              {"pattern":"a","body":[{"kind":"action","label":"first"}]},
+              {"pattern":"b","body":[{"kind":"action","label":"second"}]}
+            ]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
+        )
+        val mermaid = assertNotNull(renderDiagramMermaid(payload))
+        assertContains(mermaid, "n1 -->|a| n2")
+        assertContains(mermaid, "n1 -->|b| n4")
+        assertContains(mermaid, "n3 --> n6")
+        assertContains(mermaid, "n5 --> n6")
+        assertContains(mermaid, "n1 -->|no match| n6")
+        assertContains(mermaid, "n6 --> n7")
+    }
+
+    @Test
+    fun switchDefaultConsumesNoMatchAndNestedSwitchStillJoins() {
+        val payload = JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"switch","subject":"kind","arms":[
+              {"pattern":"a","body":[{"kind":"switch","subject":"inner","arms":[
+                {"pattern":"x","body":[{"kind":"action","label":"inner"}]}
+              ]}]},
+              {"pattern":"default","body":[{"kind":"action","label":"fallback"}]}
+            ]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
+        )
+        val mermaid = assertNotNull(renderDiagramMermaid(payload))
+        assertContains(mermaid, "switch join")
+        assertContains(mermaid, "after")
+        // The inner switch has no default, but the outer one does.  This is
+        // a mutation guard: deleting the per-switch default check adds a
+        // second no-match edge from the outer decision.
+        kotlin.test.assertEquals(1, Regex("\\|no match\\|").findAll(mermaid).count(), mermaid)
+    }
+
+    @Test
+    fun edgeCaptionPipesAreHtmlEscaped() {
+        val payload = JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"switch","subject":"kind","arms":[
+              {"pattern":"a | b","body":[{"kind":"action","label":"first"}]},
+              {"pattern":"foo|bar","body":[{"kind":"action","label":"second"}]}
+            ]}]}],"procedures":[]}"""
+        )
+        val mermaid = assertNotNull(renderDiagramMermaid(payload))
+        assertContains(mermaid, "|a &#124; b|")
+        assertContains(mermaid, "|foo&#124;bar|")
+        kotlin.test.assertFalse(mermaid.contains("|a | b|"), mermaid)
+    }
 }

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -296,6 +296,22 @@ class TclLspActionsTest {
     }
 
     @Test
+    fun broadDynamicCompletionKeepsDistinctCustomOnCodes() {
+        val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+              {"kind":"action","label":"return -options ${'$'}options","completion":"dynamic"}],"handlers":[
+              {"kind_handler":"on","match":"42","fallthrough":false,"body":[{"kind":"action","label":"first 42"}]},
+              {"kind_handler":"on","match":"42","fallthrough":false,"body":[{"kind":"action","label":"duplicate 42"}]},
+              {"kind_handler":"on","match":"43","fallthrough":false,"body":[{"kind":"action","label":"43 path"}]},
+              {"kind_handler":"on","match":"custom","fallthrough":false,"body":[{"kind":"action","label":"custom path"}]}
+            ]}]}],"procedures":[]}"""
+        )))
+        // 42, 43, and custom are independently possible; only duplicate 42
+        // is shadowed by Tcl's first matching on-clause rule.
+        assertEquals(3, mermaid.lines().count { it.startsWith("n2 -->|on|") }, mermaid)
+    }
+
+    @Test
     fun normalFinallyPathContinuesAndFinallyCompletionOverridesIt() {
         fun render(finallyCompletion: String? = null): String {
             val completion = finallyCompletion?.let { ",\"completion\":\"$it\"" } ?: ""

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -250,10 +250,10 @@ class TclLspActionsTest {
         val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
             """{"events":[{"name":"E","flow":[{"kind":"try","body":[
               {"kind":"action","label":"return -options ${'$'}opts","completion":"dynamic"}],"handlers":[
-              {"kind_handler":"on","match":"ok","fallthrough":false,"body":[{"kind":"action","label":"ok path"}]},
-              {"kind_handler":"on","match":"error","fallthrough":false,"body":[{"kind":"action","label":"error path"}]},
-              {"kind_handler":"on","match":"return","fallthrough":false,"body":[{"kind":"action","label":"return path"}]},
-              {"kind_handler":"on","match":"42","fallthrough":false,"body":[{"kind":"action","label":"other path"}]}
+              {"kind_handler":"on","match":"ok","completion_code":0,"fallthrough":false,"body":[{"kind":"action","label":"ok path"}]},
+              {"kind_handler":"on","match":"error","completion_code":1,"fallthrough":false,"body":[{"kind":"action","label":"error path"}]},
+              {"kind_handler":"on","match":"return","completion_code":2,"fallthrough":false,"body":[{"kind":"action","label":"return path"}]},
+              {"kind_handler":"on","match":"42","completion_code":42,"fallthrough":false,"body":[{"kind":"action","label":"other path"}]}
             ],"finally":[{"kind":"action","label":"cleanup"}]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
         )))
         // Dynamic -options can be ok, error, return, break, continue, or a
@@ -269,9 +269,9 @@ class TclLspActionsTest {
         val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
             """{"events":[{"name":"E","flow":[{"kind":"try","body":[
               {"kind":"action","label":"return -code ${'$'}code","completion":"dynamic_return_or_error"}],"handlers":[
-              {"kind_handler":"on","match":"ok","fallthrough":false,"body":[{"kind":"action","label":"wrong ok"}]},
-              {"kind_handler":"on","match":"error","fallthrough":false,"body":[{"kind":"action","label":"error path"}]},
-              {"kind_handler":"on","match":"return","fallthrough":false,"body":[{"kind":"action","label":"return path"}]}
+              {"kind_handler":"on","match":"ok","completion_code":0,"fallthrough":false,"body":[{"kind":"action","label":"wrong ok"}]},
+              {"kind_handler":"on","match":"error","completion_code":1,"fallthrough":false,"body":[{"kind":"action","label":"error path"}]},
+              {"kind_handler":"on","match":"return","completion_code":2,"fallthrough":false,"body":[{"kind":"action","label":"return path"}]}
             ],"finally":[{"kind":"action","label":"cleanup"}]}]}],"procedures":[]}"""
         )))
         kotlin.test.assertFalse(mermaid.contains("wrong ok"), mermaid)
@@ -284,10 +284,10 @@ class TclLspActionsTest {
         val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
             """{"events":[{"name":"E","flow":[{"kind":"try","body":[
               {"kind":"action","label":"return -code ${'$'}code","completion":"dynamic_return_or_error"}],"handlers":[
-              {"kind_handler":"on","match":"error","fallthrough":false,"body":[{"kind":"action","label":"first error"}]},
-              {"kind_handler":"on","match":"error","fallthrough":false,"body":[{"kind":"action","label":"duplicate error"}]},
-              {"kind_handler":"on","match":"return","fallthrough":false,"body":[{"kind":"action","label":"first return"}]},
-              {"kind_handler":"on","match":"return","fallthrough":false,"body":[{"kind":"action","label":"duplicate return"}]}
+              {"kind_handler":"on","match":"error","completion_code":1,"fallthrough":false,"body":[{"kind":"action","label":"first error"}]},
+              {"kind_handler":"on","match":"error","completion_code":1,"fallthrough":false,"body":[{"kind":"action","label":"duplicate error"}]},
+              {"kind_handler":"on","match":"return","completion_code":2,"fallthrough":false,"body":[{"kind":"action","label":"first return"}]},
+              {"kind_handler":"on","match":"return","completion_code":2,"fallthrough":false,"body":[{"kind":"action","label":"duplicate return"}]}
             ]}]}],"procedures":[]}"""
         )))
         // Handler nodes are retained for source context, but only the first
@@ -300,10 +300,10 @@ class TclLspActionsTest {
         val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
             """{"events":[{"name":"E","flow":[{"kind":"try","body":[
               {"kind":"action","label":"return -options ${'$'}options","completion":"dynamic"}],"handlers":[
-              {"kind_handler":"on","match":"42","fallthrough":false,"body":[{"kind":"action","label":"first 42"}]},
-              {"kind_handler":"on","match":"42","fallthrough":false,"body":[{"kind":"action","label":"duplicate 42"}]},
-              {"kind_handler":"on","match":"43","fallthrough":false,"body":[{"kind":"action","label":"43 path"}]},
-              {"kind_handler":"on","match":"custom","fallthrough":false,"body":[{"kind":"action","label":"custom path"}]}
+              {"kind_handler":"on","match":"42","completion_code":42,"fallthrough":false,"body":[{"kind":"action","label":"first 42"}]},
+              {"kind_handler":"on","match":"42","completion_code":42,"fallthrough":false,"body":[{"kind":"action","label":"duplicate 42"}]},
+              {"kind_handler":"on","match":"43","completion_code":43,"fallthrough":false,"body":[{"kind":"action","label":"43 path"}]},
+              {"kind_handler":"on","match":"return","completion_code":2,"fallthrough":false,"body":[{"kind":"action","label":"return path"}]}
             ]}]}],"procedures":[]}"""
         )))
         // 42, 43, and custom are independently possible; only duplicate 42

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -95,6 +95,20 @@ class TclLspActionsTest {
     }
 
     @Test
+    fun exhaustiveAbruptConditionalDoesNotReachItsContinuation() {
+        val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"if","branches":[
+              {"condition":"a","body":[{"kind":"action","label":"then return","completion":"return"}]},
+              {"condition":"else","body":[{"kind":"action","label":"else return","completion":"return"}]}
+            ]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
+        )))
+        assertContains(mermaid, "then return")
+        assertContains(mermaid, "else return")
+        kotlin.test.assertFalse(mermaid.contains("if join"), mermaid)
+        kotlin.test.assertFalse(mermaid.contains("after"), mermaid)
+    }
+
+    @Test
     fun nestedConditionJoinsPropagateToOuterContinuation() {
         val payload = JsonParser.parseString(
             """{"events":[{"name":"E","flow":[{"kind":"if","branches":[
@@ -146,6 +160,20 @@ class TclLspActionsTest {
         // a mutation guard: deleting the per-switch default check adds a
         // second no-match edge from the outer decision.
         kotlin.test.assertEquals(1, Regex("\\|no match\\|").findAll(mermaid).count(), mermaid)
+    }
+
+    @Test
+    fun exhaustiveAbruptSwitchDoesNotReachItsContinuation() {
+        val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"switch","subject":"kind","arms":[
+              {"pattern":"a","body":[{"kind":"action","label":"first return","completion":"return"}]},
+              {"pattern":"default","body":[{"kind":"action","label":"default return","completion":"return"}]}
+            ]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
+        )))
+        assertContains(mermaid, "first return")
+        assertContains(mermaid, "default return")
+        kotlin.test.assertFalse(mermaid.contains("switch join"), mermaid)
+        kotlin.test.assertFalse(mermaid.contains("after"), mermaid)
     }
 
     @Test
@@ -327,6 +355,19 @@ class TclLspActionsTest {
             assertContains(mermaid, handler)
         }
         assertContains(mermaid, "after")
+    }
+
+    @Test
+    fun dynamicCompletionOutsideTryRetainsItsNormalContinuation() {
+        val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[
+              {"kind":"action","label":"return -options ${'$'}options","completion":"dynamic"},
+              {"kind":"action","label":"after"}
+            ]}],"procedures":[]}"""
+        )))
+        assertContains(mermaid, "return -options ${'$'}options")
+        assertContains(mermaid, "after")
+        assertContains(mermaid, "n1 --> n2")
     }
 
     @Test

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -217,6 +217,34 @@ class TclLspActionsTest {
     }
 
     @Test
+    fun processExitBypassesFinallyAndTheContinuation() {
+        val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+              {"kind":"action","label":"exit 0","completion":"process_exit"}],
+              "finally":[{"kind":"action","label":"must not run"}]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
+        )))
+        assertContains(mermaid, "n1 --> n2")
+        kotlin.test.assertFalse(mermaid.contains("finally"), mermaid)
+        kotlin.test.assertFalse(mermaid.contains("must not run"), mermaid)
+        kotlin.test.assertFalse(mermaid.contains("after"), mermaid)
+    }
+
+    @Test
+    fun returnCompletionSelectsOnReturnRatherThanOnError() {
+        val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+              {"kind":"action","label":"return -code error","completion":"return"}],"handlers":[
+              {"kind_handler":"on","match":"error","fallthrough":false,"body":[{"kind":"action","label":"wrong"}]},
+              {"kind_handler":"on","match":"return","fallthrough":false,"body":[{"kind":"action","label":"handled"}]}
+            ],"finally":[{"kind":"action","label":"cleanup"}]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
+        )))
+        kotlin.test.assertFalse(mermaid.contains("wrong"), mermaid)
+        assertContains(mermaid, "n2 -->|on| n4")
+        assertContains(mermaid, "handled")
+        assertContains(mermaid, "after")
+    }
+
+    @Test
     fun normalFinallyPathContinuesAndFinallyCompletionOverridesIt() {
         fun render(finallyCompletion: String? = null): String {
             val completion = finallyCompletion?.let { ",\"completion\":\"$it\"" } ?: ""

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -245,6 +245,40 @@ class TclLspActionsTest {
     }
 
     @Test
+    fun dynamicOptionsRetainEveryPossibleOnHandlerAndNormalPath() {
+        val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+              {"kind":"action","label":"return -options ${'$'}opts","completion":"dynamic"}],"handlers":[
+              {"kind_handler":"on","match":"ok","fallthrough":false,"body":[{"kind":"action","label":"ok path"}]},
+              {"kind_handler":"on","match":"error","fallthrough":false,"body":[{"kind":"action","label":"error path"}]},
+              {"kind_handler":"on","match":"return","fallthrough":false,"body":[{"kind":"action","label":"return path"}]},
+              {"kind_handler":"on","match":"42","fallthrough":false,"body":[{"kind":"action","label":"other path"}]}
+            ],"finally":[{"kind":"action","label":"cleanup"}]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
+        )))
+        // Dynamic -options can be ok, error, return, break, continue, or a
+        // custom code. All source-order `on` candidates remain represented.
+        for (handler in listOf("ok path", "error path", "return path", "other path")) {
+            assertContains(mermaid, handler)
+        }
+        assertContains(mermaid, "after")
+    }
+
+    @Test
+    fun dynamicDefaultCodeIsOnlyReturnOrErrorAndDoesNotInventOk() {
+        val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+              {"kind":"action","label":"return -code ${'$'}code","completion":"dynamic_return_or_error"}],"handlers":[
+              {"kind_handler":"on","match":"ok","fallthrough":false,"body":[{"kind":"action","label":"wrong ok"}]},
+              {"kind_handler":"on","match":"error","fallthrough":false,"body":[{"kind":"action","label":"error path"}]},
+              {"kind_handler":"on","match":"return","fallthrough":false,"body":[{"kind":"action","label":"return path"}]}
+            ],"finally":[{"kind":"action","label":"cleanup"}]}]}],"procedures":[]}"""
+        )))
+        kotlin.test.assertFalse(mermaid.contains("wrong ok"), mermaid)
+        assertContains(mermaid, "error path")
+        assertContains(mermaid, "return path")
+    }
+
+    @Test
     fun normalFinallyPathContinuesAndFinallyCompletionOverridesIt() {
         fun render(finallyCompletion: String? = null): String {
             val completion = finallyCompletion?.let { ",\"completion\":\"$it\"" } ?: ""

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -232,6 +232,70 @@ class TclLspActionsTest {
     }
 
     @Test
+    fun catchAbsorbsEveryTclCompletionButNotProcessExit() {
+        fun render(completion: String, code: Int? = null): String {
+            val completionCode = code?.let { ",\"completion_code\":$it" } ?: ""
+            return assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+                """{"events":[{"name":"E","flow":[{"kind":"catch","body":[
+                  {"kind":"action","label":"caught","completion":"$completion"$completionCode}]},
+                  {"kind":"action","label":"after"}]}],"procedures":[]}"""
+            )))
+        }
+
+        for ((completion, code) in listOf(
+            "error" to null,
+            "return" to null,
+            "break" to null,
+            "custom" to 42,
+        )) {
+            val mermaid = render(completion, code)
+            assertContains(mermaid, "caught", message = completion)
+            assertContains(mermaid, "after", message = completion)
+        }
+
+        val processExit = render("process_exit")
+        assertContains(processExit, "caught")
+        kotlin.test.assertFalse(processExit.contains("after"), processExit)
+    }
+
+    @Test
+    fun emptyTrapExhaustivelyShadowsLaterExactErrorHandlers() {
+        val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+              {"kind":"action","label":"fail","completion":"error"}],"handlers":[
+              {"kind_handler":"trap","match":"","trap_pattern":[],"fallthrough":false,"body":[{"kind":"action","label":"empty trap body"}]},
+              {"kind_handler":"trap","match":"X","trap_pattern":["X"],"fallthrough":false,"body":[{"kind":"action","label":"shadowed trap body"}]},
+              {"kind_handler":"on","match":"error","completion_code":1,"fallthrough":false,"body":[{"kind":"action","label":"shadowed on body"}]}
+            ]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
+        )))
+        assertContains(mermaid, "empty trap body")
+        assertContains(mermaid, "after")
+        kotlin.test.assertFalse(mermaid.contains("shadowed trap body"), mermaid)
+        kotlin.test.assertFalse(mermaid.contains("shadowed on body"), mermaid)
+        assertEquals(1, mermaid.lines().count { it.contains("-->|trap|") }, mermaid)
+        assertEquals(0, mermaid.lines().count { it.contains("-->|on|") }, mermaid)
+    }
+
+    @Test
+    fun emptyTrapExhaustivelyShadowsLaterDynamicErrorHandlers() {
+        val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+              {"kind":"action","label":"dynamic result","completion":"dynamic_return_or_error"}],"handlers":[
+              {"kind_handler":"trap","match":"","trap_pattern":[],"fallthrough":false,"body":[{"kind":"action","label":"empty trap body"}]},
+              {"kind_handler":"trap","match":"X","trap_pattern":["X"],"fallthrough":false,"body":[{"kind":"action","label":"shadowed trap body"}]},
+              {"kind_handler":"on","match":"error","completion_code":1,"fallthrough":false,"body":[{"kind":"action","label":"shadowed on body"}]},
+              {"kind_handler":"on","match":"return","completion_code":2,"fallthrough":false,"body":[{"kind":"action","label":"return body"}]}
+            ]}]}],"procedures":[]}"""
+        )))
+        assertContains(mermaid, "empty trap body")
+        assertContains(mermaid, "return body")
+        kotlin.test.assertFalse(mermaid.contains("shadowed trap body"), mermaid)
+        kotlin.test.assertFalse(mermaid.contains("shadowed on body"), mermaid)
+        assertEquals(1, mermaid.lines().count { it.contains("-->|trap|") }, mermaid)
+        assertEquals(1, mermaid.lines().count { it.contains("-->|on|") }, mermaid)
+    }
+
+    @Test
     fun returnCompletionSelectsOnReturnRatherThanOnError() {
         val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
             """{"events":[{"name":"E","flow":[{"kind":"try","body":[

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -181,27 +181,75 @@ class TclLspActionsTest {
     }
 
     @Test
-    fun tryHandlersAndAllExitsFlowThroughFinallyBeforeContinuation() {
+    fun tryCompletionContractRoutesOnlyHandledPathsPastFinally() {
         val payload = JsonParser.parseString(
             """{"events":[{"name":"E","flow":[{"kind":"try","body":[
-              {"kind":"action","label":"work"}],"handlers":[
-              {"kind_handler":"on","match":"error","body":[{"kind":"action","label":"recover"}]},
-              {"kind_handler":"trap","match":"CUSTOM","body":[{"kind":"action","label":"alternate"}]}
+              {"kind":"action","label":"fail","completion":"error"}],"handlers":[
+              {"kind_handler":"on","match":"error","fallthrough":false,"body":[{"kind":"action","label":"recover"}]}
             ],"finally":[{"kind":"action","label":"cleanup"}]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
         )
 
         val mermaid = assertNotNull(renderDiagramMermaid(payload))
         assertContains(mermaid, "n1 --> n2")
-        assertContains(mermaid, "n1 -->|on error| n3")
+        assertContains(mermaid, "n2 -->|on| n3")
         assertContains(mermaid, "n3 --> n4")
-        assertContains(mermaid, "n1 -->|trap CUSTOM| n5")
+        kotlin.test.assertFalse(mermaid.contains("n2 --> n5"), mermaid)
+        assertContains(mermaid, "n4 --> n5")
         assertContains(mermaid, "n5 --> n6")
-        assertContains(mermaid, "n2 --> n7")
-        assertContains(mermaid, "n4 --> n7")
         assertContains(mermaid, "n6 --> n7")
-        assertContains(mermaid, "n7 --> n8")
-        assertContains(mermaid, "n8 --> n9")
         kotlin.test.assertFalse(mermaid.contains("try join"), mermaid)
+    }
+
+    @Test
+    fun returnAndUnhandledErrorRunFinallyButDoNotReachContinuation() {
+        fun render(completion: String): String = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+              {"kind":"action","label":"leave","completion":"$completion"}],
+              "finally":[{"kind":"action","label":"cleanup"}]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
+        )))
+
+        for (completion in listOf("return", "error", "break", "continue", "terminal")) {
+            val mermaid = render(completion)
+            assertContains(mermaid, "n2 --> n3")
+            assertContains(mermaid, "n3 --> n4")
+            kotlin.test.assertFalse(mermaid.contains("after"), mermaid)
+        }
+    }
+
+    @Test
+    fun normalFinallyPathContinuesAndFinallyCompletionOverridesIt() {
+        fun render(finallyCompletion: String? = null): String {
+            val completion = finallyCompletion?.let { ",\"completion\":\"$it\"" } ?: ""
+            return assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+                """{"events":[{"name":"E","flow":[{"kind":"try","body":[{"kind":"action","label":"work"}],
+                  "finally":[{"kind":"action","label":"cleanup"$completion}]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
+            )))
+        }
+
+        val normal = render()
+        assertContains(normal, "n5[\"after\"]")
+        assertContains(normal, "n4 --> n5")
+
+        val override = render("return")
+        kotlin.test.assertFalse(override.contains("after"), override)
+    }
+
+    @Test
+    fun tryHandlerFallthroughTargetsTheNextHandlerBodyBeforeFinally() {
+        val payload = JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+              {"kind":"action","label":"fail","completion":"error"}],"handlers":[
+              {"kind_handler":"on","match":"error","fallthrough":true,"body":[]},
+              {"kind_handler":"on","match":"return","fallthrough":false,"body":[{"kind":"action","label":"shared body"}]}
+            ],"finally":[{"kind":"action","label":"cleanup"}]}]}],"procedures":[]}"""
+        )
+
+        val mermaid = assertNotNull(renderDiagramMermaid(payload))
+        assertContains(mermaid, "n2 -->|on| n3")
+        assertContains(mermaid, "n3 -->|fall through| n4")
+        assertContains(mermaid, "n4 --> n5")
+        assertContains(mermaid, "n5 --> n6")
+        kotlin.test.assertFalse(mermaid.contains("n3 --> n6"), mermaid)
     }
 
     @Test

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -64,5 +64,24 @@ class TclLspActionsTest {
         assertContains(mermaid, "|false|")
         assertContains(mermaid, "after")
         assertContains(mermaid, "if join")
+        assertContains(mermaid, "n1 -->|a| n2")
+        assertContains(mermaid, "n1 -->|b| n4")
+        assertContains(mermaid, "n3 --> n6")
+        assertContains(mermaid, "n5 --> n6")
+        assertContains(mermaid, "n1 -->|false| n6")
+        assertContains(mermaid, "n6 --> n7")
+    }
+
+    @Test
+    fun explicitElseDoesNotAddImplicitFalseEdge() {
+        val payload = JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"if","branches":[
+              {"condition":"a","body":[{"kind":"action","label":"then"}]},
+              {"condition":"else","body":[{"kind":"action","label":"else"}]}
+            ]}]}],"procedures":[]}""".trimIndent()
+        )
+        val mermaid = assertNotNull(renderDiagramMermaid(payload))
+        assertContains(mermaid, "|else|")
+        kotlin.test.assertFalse(mermaid.contains("|false|"))
     }
 }

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -281,6 +281,27 @@ class TclLspActionsTest {
     }
 
     @Test
+    fun tcl8OutOfRangeExitRoutesItsCatchableErrorThroughTryFinallyAndAfter() {
+        val mermaid = assertNotNull(renderDiagramMermaid(JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"try","body":[
+              {"kind":"action","label":"exit 4294967296","completion":"error"}],"handlers":[
+              {"kind_handler":"on","match":"error","completion_code":1,"fallthrough":false,"body":[{"kind":"action","label":"handled range error"}]}],
+              "finally":[{"kind":"action","label":"cleanup"}]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
+        )))
+        // Tcl 8.x rejects the first value beyond Tcl_GetIntFromObj's
+        // `UINT_MAX` ceiling as an ordinary error. It therefore takes the
+        // on-error branch, runs finally, and reaches the following statement
+        // through the handled path.
+        assertContains(mermaid, "n2 -->|on| n3")
+        assertContains(mermaid, "n4 --> n5")
+        kotlin.test.assertFalse(mermaid.contains("n2 --> n5"), mermaid)
+        assertContains(mermaid, "handled range error")
+        assertContains(mermaid, "finally")
+        assertContains(mermaid, "cleanup")
+        assertContains(mermaid, "after")
+    }
+
+    @Test
     fun catchAbsorbsEveryTclCompletionButNotProcessExit() {
         fun render(completion: String, code: Int? = null): String {
             val completionCode = code?.let { ",\"completion_code\":$it" } ?: ""

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/actions/TclLspActionsTest.kt
@@ -555,4 +555,16 @@ class TclLspActionsTest {
             assertContains(mermaid, "n3 --> n4")
         }
     }
+
+    @Test
+    fun loopsConsumeBreakAndContinueCompletions() {
+        val payload = JsonParser.parseString(
+            """{"events":[{"name":"E","flow":[{"kind":"loop","label":"while ready","exit":"false","body":[{"kind":"switch","label":"mode","arms":[{"pattern":"skip","body":[{"kind":"action","label":"continue","completion":"continue"}]},{"pattern":"stop","body":[{"kind":"action","label":"break","completion":"break"}]}]}]},{"kind":"action","label":"after"}]}],"procedures":[]}"""
+        )
+        val mermaid = assertNotNull(renderDiagramMermaid(payload))
+        assertContains(mermaid, "-->|continue|")
+        assertContains(mermaid, "-->|break|")
+        assertContains(mermaid, "loop exit")
+        assertContains(mermaid, "after")
+    }
 }

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3503,13 +3503,6 @@
             "description": "Override workspace file operations (auto-rewrite source paths on rename). When null, enabled.",
             "order": 20
           },
-          "tclLsp.features.pullDiagnostics": {
-            "scope": "language-overridable",
-            "type": "boolean",
-            "default": false,
-            "description": "Enable pull-model diagnostics (textDocument/diagnostic, workspace/diagnostic). Off by default: turning this on causes most clients to stop honouring push notifications.",
-            "order": 21
-          },
           "tclLsp.features.willSaveWaitUntil": {
             "scope": "language-overridable",
             "type": "boolean",

--- a/editors/vscode/src/chat/commands/diagram.ts
+++ b/editors/vscode/src/chat/commands/diagram.ts
@@ -37,7 +37,11 @@ interface DiagramData {
   error?: string;
 }
 
-function buildDiagramPrompt(code: string, structuredData: string, userExtra: string): string {
+export function buildDiagramPrompt(
+  code: string,
+  structuredData: string,
+  userExtra: string,
+): string {
   return `You are generating a Mermaid flowchart and explanation for an F5 BIG-IP iRule.
 
 ## Task

--- a/editors/vscode/src/test/configSettings.test.ts
+++ b/editors/vscode/src/test/configSettings.test.ts
@@ -65,7 +65,7 @@ suite("Configuration Settings", () => {
   const cfg = () => vscode.workspace.getConfiguration("tclLsp");
 
   // Feature toggles — all default to null (inherit from editor globals or
-  // default to enabled), except pullDiagnostics which defaults to false.
+  // default to enabled).
   const triStateFeatureKeys = [
     "hover",
     "completion",
@@ -93,10 +93,6 @@ suite("Configuration Settings", () => {
       assert.strictEqual(value, null, `features.${key} should default to null`);
     });
   }
-
-  test("features.pullDiagnostics defaults to false", () => {
-    assert.strictEqual(cfg().get<boolean>("features.pullDiagnostics"), false);
-  });
 
   // Tri-state inheritance: null feature toggles inherit from editor globals.
   // These tests change a VS Code editor global, verify the feature toggle

--- a/editors/vscode/src/test/diagramPrompt.test.ts
+++ b/editors/vscode/src/test/diagramPrompt.test.ts
@@ -1,0 +1,41 @@
+// tcl-lsp — diagram prompt contract test.
+
+import * as assert from "assert";
+import { buildDiagramPrompt } from "../chat/commands/diagram";
+
+suite("Diagram prompt contract", () => {
+  test("preserves the complete tcl-diagram payload shape for the model", () => {
+    const payload = {
+      events: [
+        {
+          name: "HTTP_REQUEST",
+          priority: 400,
+          multiplicity: "once",
+          flow: [
+            {
+              kind: "if",
+              branches: [{ condition: "path == /", body: [{ kind: "action", label: "pool web" }] }],
+            },
+          ],
+        },
+      ],
+      procedures: [
+        {
+          name: "helper",
+          params: ["request"],
+          flow: [{ kind: "return", value: "request" }],
+        },
+      ],
+    };
+    const serialized = JSON.stringify(payload, null, 2);
+    const prompt = buildDiagramPrompt("when HTTP_REQUEST { helper $r }", serialized, "");
+
+    assert.ok(prompt.includes("## Structured flow data (authoritative"));
+    assert.ok(prompt.includes(serialized), "prompt must embed the exact structured JSON payload");
+    assert.ok(prompt.includes('"priority": 400'));
+    assert.ok(prompt.includes('"multiplicity": "once"'));
+    assert.ok(prompt.includes('"procedures": ['));
+    assert.ok(prompt.includes('"params": [\n        "request"\n      ]'));
+    assert.ok(prompt.includes('"branches": ['));
+  });
+});

--- a/editors/vscode/src/test/pullDiagnostics.test.ts
+++ b/editors/vscode/src/test/pullDiagnostics.test.ts
@@ -43,5 +43,4 @@ suite("Push Diagnostics", () => {
       "diagnosticProvider should be absent by default (pull diagnostics opt-in)",
     );
   });
-
 });

--- a/editors/vscode/src/test/pullDiagnostics.test.ts
+++ b/editors/vscode/src/test/pullDiagnostics.test.ts
@@ -25,7 +25,7 @@ interface TclLspApi {
   getClient(): LanguageClient;
 }
 
-suite("Pull Diagnostics (opt-in)", () => {
+suite("Push Diagnostics", () => {
   test("pull diagnostic provider is NOT advertised by default", async () => {
     await activate(getDocUri("simple.tcl"));
     const ext = vscode.extensions.getExtension<TclLspApi>("bitwisecook.tcl-lsp")!;
@@ -44,9 +44,4 @@ suite("Pull Diagnostics (opt-in)", () => {
     );
   });
 
-  test("config toggle exists in package.json metadata", () => {
-    const config = vscode.workspace.getConfiguration("tclLsp.features");
-    const value = config.get<boolean>("pullDiagnostics");
-    assert.strictEqual(value, false, "pullDiagnostics should default to false");
-  });
 });

--- a/editors/zed/README.md
+++ b/editors/zed/README.md
@@ -29,14 +29,8 @@ Tcl, iRules, and iApps language support powered by
 ### Feature availability in Zed
 
 All features listed above are advertised by the language server and
-activate automatically when Zed's LSP client requests them.  Two features
-are intentionally gated on explicit client support:
-
-- **Pull diagnostics** (`textDocument/diagnostic`) are **off by default**.
-  Turning this on causes most LSP clients to stop honouring push
-  notifications, so the setting is opt-in and requires a server restart:
-  `"tclLsp": { "features": { "pullDiagnostics": true } }`.
-- **Workspace file operations** (`workspace/willRenameFiles` /
+activate automatically when Zed's LSP client requests them.  Workspace file
+operations (`workspace/willRenameFiles` /
   `didRenameFiles`) are auto-wired when the client advertises
   `workspace.fileOperations` in its capabilities.  Zed forwards file
   rename events from its project panel when the client capability is
@@ -125,7 +119,6 @@ Add to your Zed `settings.json` to configure the language server:
             "documentHighlight": true,
             "codeLens": true,
             "workspaceFileOps": true,
-            "pullDiagnostics": false,
             "willSaveWaitUntil": false,
             "implementation": true,
             "typeDefinition": true,

--- a/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
+++ b/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
@@ -1290,6 +1290,7 @@ mod tests {
             handlers: vec![TryHandler {
                 kind: "on".into(),
                 match_arg: "error".into(),
+                trap_pattern: None,
                 var_name: Some("e".into()),
                 options_var: None,
                 body: Script::new(),

--- a/rust/tcl-compiler/src/inlining/mod.rs
+++ b/rust/tcl-compiler/src/inlining/mod.rs
@@ -1105,6 +1105,7 @@ fn rewrite_try_stmt(
             new_handlers.push(TryHandler {
                 kind: h.kind.clone(),
                 match_arg: h.match_arg.clone(),
+                trap_pattern: h.trap_pattern.clone(),
                 var_name: h.var_name.clone(),
                 options_var: h.options_var.clone(),
                 body: hbody,

--- a/rust/tcl-compiler/src/inlining/rename.rs
+++ b/rust/tcl-compiler/src/inlining/rename.rs
@@ -419,6 +419,7 @@ fn rewrite_binding_scope(stmt: &Statement, rename: &HashMap<String, String>) -> 
                 .map(|h| TryHandler {
                     kind: h.kind.clone(),
                     match_arg: h.match_arg.clone(),
+                    trap_pattern: h.trap_pattern.clone(),
                     var_name: h.var_name.as_ref().map(|v| rename_local(v, rename)),
                     options_var: h.options_var.as_ref().map(|v| rename_local(v, rename)),
                     body: rewrite_script(&h.body, rename),

--- a/rust/tcl-compiler/src/ir.rs
+++ b/rust/tcl-compiler/src/ir.rs
@@ -731,6 +731,14 @@ pub struct TryHandler {
     pub kind: String,
     /// Return code or error class pattern to match.
     pub match_arg: String,
+    /// Parsed error-code prefix for a statically literal `trap` selector.
+    ///
+    /// `None` means either an `on` handler, a selector containing Tcl word
+    /// substitutions, or a malformed Tcl list. Literal `$`, `[`, and
+    /// backslashes remain ordinary element data when protected by braces or
+    /// escapes; lowering decides that from source token shape before the
+    /// decoded word loses the distinction.
+    pub trap_pattern: Option<Vec<String>>,
     /// Variable bound to the result, if any.
     pub var_name: Option<String>,
     /// Variable bound to the options dict, if any.
@@ -1980,6 +1988,7 @@ mod tests {
             handlers: vec![TryHandler {
                 kind: "on".into(),
                 match_arg: "error".into(),
+                trap_pattern: None,
                 var_name: Some("e".into()),
                 options_var: None,
                 body: Script::new(),

--- a/rust/tcl-compiler/src/lowering/structured.rs
+++ b/rust/tcl-compiler/src/lowering/structured.rs
@@ -716,6 +716,27 @@ impl Lowerer<'_> {
 
             if (keyword == "on" || keyword == "trap") && i + 3 < args.len() {
                 let match_arg = args[i + 1].clone();
+                // A trap selector is evaluated as one Tcl word and its value
+                // is then parsed as a Tcl list. Preserve the source-level
+                // substitution decision here: inspecting the decoded elements
+                // for `$` or `[` would reject literal data such as `{A {$B}}`
+                // and `{A \$B}`. A substitution-free bare/quoted word still
+                // needs backslash substitution before list parsing, whereas a
+                // braced word's content is already its literal runtime value.
+                let trap_pattern =
+                    if keyword == "trap" && super::seg_word_is_static_literal(seg, i + 2) {
+                        let match_tok = arg_tokens.get(i + 1);
+                        let value = if match_tok.is_some_and(|tok| tok.kind == TokenType::Str) {
+                            std::borrow::Cow::Borrowed(match_arg.as_str())
+                        } else {
+                            tcl_lexer::backslash_subst(&match_arg)
+                        };
+                        tcl_syntax::list::split_list(&value)
+                            .ok()
+                            .map(|elements| elements.into_iter().map(Into::into).collect())
+                    } else {
+                        None
+                    };
                 let var_list = &args[i + 2];
                 let handler_tok = arg_tokens.get(i + 3);
                 let handler_single = arg_single.get(i + 3).copied().unwrap_or(false);
@@ -771,6 +792,7 @@ impl Lowerer<'_> {
                 handlers.push(TryHandler {
                     kind: keyword.clone(),
                     match_arg,
+                    trap_pattern,
                     var_name: result_var,
                     options_var,
                     body: handler_body,
@@ -1301,6 +1323,44 @@ mod tests {
         } else {
             panic!("expected Try");
         }
+    }
+
+    #[test]
+    fn try_trap_pattern_projection_preserves_tcl_word_literalness() {
+        let source = r#"try {} \
+            trap {A \$B} {m o} {} \
+            trap {A {$B}} {m o} {} \
+            trap {A \[B\]} {m o} {} \
+            trap {A {[B]}} {m o} {} \
+            trap {A C:\\tmp} {m o} {} \
+            trap {A {C:\tmp}} {m o} {} \
+            trap "A \{" {m o} {} \
+            trap $pattern {m o} {} \
+            trap "A $pattern" {m o} {} \
+            trap [list A B] {m o} {}"#;
+        let module = lower_to_ir(source, &reg());
+        let Statement::Try { handlers, .. } = &module.top_level.statements[0] else {
+            panic!("expected structured try");
+        };
+        let patterns: Vec<_> = handlers
+            .iter()
+            .map(|handler| handler.trap_pattern.clone())
+            .collect();
+        assert_eq!(
+            patterns,
+            vec![
+                Some(vec!["A".into(), "$B".into()]),
+                Some(vec!["A".into(), "$B".into()]),
+                Some(vec!["A".into(), "[B]".into()]),
+                Some(vec!["A".into(), "[B]".into()]),
+                Some(vec!["A".into(), r"C:\tmp".into()]),
+                Some(vec!["A".into(), r"C:\tmp".into()]),
+                None,
+                None,
+                None,
+                None,
+            ]
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/lowering/structured.rs
+++ b/rust/tcl-compiler/src/lowering/structured.rs
@@ -729,7 +729,7 @@ impl Lowerer<'_> {
                         let value = if match_tok.is_some_and(|tok| tok.kind == TokenType::Str) {
                             std::borrow::Cow::Borrowed(match_arg.as_str())
                         } else {
-                            tcl_lexer::backslash_subst(&match_arg)
+                            tcl_lexer::backslash_subst_in(&match_arg, self.config.escapes)
                         };
                         tcl_syntax::list::split_list(&value)
                             .ok()
@@ -766,7 +766,7 @@ impl Lowerer<'_> {
                 let body_value = if is_braced {
                     std::borrow::Cow::Borrowed(args[i + 3].as_str())
                 } else {
-                    tcl_lexer::backslash_subst(&args[i + 3])
+                    tcl_lexer::backslash_subst_in(&args[i + 3], self.config.escapes)
                 };
                 let is_fallthrough = handler_single && body_value == "-";
                 // Every handler body that is *not* the fallthrough marker gets
@@ -1361,6 +1361,29 @@ mod tests {
                 None,
             ]
         );
+    }
+
+    #[test]
+    fn try_trap_pattern_projection_uses_the_release_escape_grammar() {
+        // Tcl 8.6 consumes the same wide-unicode escape extent as Tcl 9,
+        // but its UTF-16-internal build replaces a non-BMP scalar with
+        // U+FFFD. Tcl 9 retains the scalar. This is observable in trap's
+        // error-code prefix and therefore must follow the lowerer's profile.
+        let source = r#"try {} trap "A \U0001F600" {m o} {}"#;
+        let pattern = |dialect| {
+            let module = crate::lowering::lower_to_ir_with_config(
+                source,
+                &reg(),
+                tcl_lexer::LexerConfig::for_dialect(dialect),
+            );
+            let Statement::Try { handlers, .. } = &module.top_level.statements[0] else {
+                panic!("expected structured try");
+            };
+            handlers[0].trap_pattern.clone()
+        };
+
+        assert_eq!(pattern("tcl8.6"), Some(vec!["A".into(), "\u{fffd}".into()]));
+        assert_eq!(pattern("tcl9.0"), Some(vec!["A".into(), "😀".into()]));
     }
 
     #[test]

--- a/rust/tcl-compiler/src/registry_invocation.rs
+++ b/rust/tcl-compiler/src/registry_invocation.rs
@@ -185,9 +185,11 @@ pub fn effective_command_arguments(
 /// Borrow source-aware post-head words from a segmented command.
 ///
 /// The segmenter's compatibility text is still the literal value bridge for
-/// callers that do not need escape decoding.  Its lossless fragment list is
+/// callers that do not need escape decoding. Its lossless fragment list is
 /// what prevents a `$word` / `[command]` / `{*}word` from becoming a literal
-/// option or operand during a registry query.
+/// option or operand during a registry query, while retaining the distinct
+/// safe shape of `prefix-$word`: it remains dynamic as a value but cannot
+/// start a leading option.
 #[must_use]
 pub fn segmented_command_arguments(command: &SegmentedCommand) -> Vec<InvocationWord<'_>> {
     command
@@ -213,7 +215,35 @@ pub fn segmented_command_arguments(command: &SegmentedCommand) -> Vec<Invocation
                     tcl_lexer::TokenType::Var | tcl_lexer::TokenType::Cmd
                 )
             }) {
-                InvocationWord::Dynamic
+                // A non-empty literal prefix before the first substitution
+                // proves the evaluated word cannot begin with `-`. Keep that
+                // narrower source fact so option-dependent descriptors may
+                // still locate its positional embedded language; it is never
+                // exposed as a literal value to registry hooks.
+                let literal_prefix = fragments
+                    .iter()
+                    .take_while(|fragment| {
+                        !matches!(
+                            fragment.token.kind,
+                            tcl_lexer::TokenType::Var | tcl_lexer::TokenType::Cmd
+                        )
+                    })
+                    .map(|fragment| fragment.text.as_str())
+                    .collect::<String>();
+                // `word_piece` retains a quoted word's opening quote in an
+                // empty leading `Esc` fragment, and a leading backslash can
+                // decode to `-`; neither proves a non-option value. Every
+                // other direct first character is stable under Tcl word
+                // substitution.
+                let proves_non_option = literal_prefix
+                    .chars()
+                    .next()
+                    .is_some_and(|first| !matches!(first, '-' | '\\' | '"'));
+                if proves_non_option {
+                    InvocationWord::DynamicNonOption
+                } else {
+                    InvocationWord::Dynamic
+                }
             } else {
                 InvocationWord::Literal(text)
             }
@@ -272,6 +302,7 @@ mod tests {
     use tcl_registry::{StateTransition, TransitionSubject};
 
     use crate::ir::{SourceSite, WordOpacity};
+    use crate::segmenter::segment_commands;
 
     fn literal(text: &str) -> WordExpr {
         WordExpr::Literal {
@@ -303,6 +334,19 @@ mod tests {
                         if alias.local == TransitionSubject::Literal("shared".to_owned())
                 )
         ));
+    }
+
+    #[test]
+    fn segmented_arguments_preserve_a_static_non_option_template_prefix() {
+        let command = segment_commands("regexp \"abc$part.*\" $subject\n")
+            .into_iter()
+            .next()
+            .expect("one command");
+        assert_eq!(
+            segmented_command_arguments(&command),
+            vec![InvocationWord::DynamicNonOption, InvocationWord::Dynamic],
+            "the first template remains dynamic but cannot be a leading option"
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/registry_invocation.rs
+++ b/rust/tcl-compiler/src/registry_invocation.rs
@@ -32,6 +32,7 @@ use tcl_registry::{
 };
 
 use crate::ir::{CommandTokens, WordExpr, WordPart};
+use crate::segmenter::SegmentedCommand;
 
 /// Owned source-aware word fact for callers that must decode a static Tcl
 /// word before lending it to the registry.
@@ -178,6 +179,45 @@ pub fn effective_command_arguments(
         .unwrap_or_default()
         .iter()
         .map(|word| effective_invocation_word(word, escapes))
+        .collect()
+}
+
+/// Borrow source-aware post-head words from a segmented command.
+///
+/// The segmenter's compatibility text is still the literal value bridge for
+/// callers that do not need escape decoding.  Its lossless fragment list is
+/// what prevents a `$word` / `[command]` / `{*}word` from becoming a literal
+/// option or operand during a registry query.
+#[must_use]
+pub fn segmented_command_arguments(command: &SegmentedCommand) -> Vec<InvocationWord<'_>> {
+    command
+        .texts
+        .iter()
+        .enumerate()
+        .skip(1)
+        .map(|(index, text)| {
+            if command
+                .expand_word
+                .as_ref()
+                .and_then(|markers| markers.get(index))
+                == Some(&true)
+            {
+                return InvocationWord::Expanded;
+            }
+            let Some(fragments) = command.word_fragments.get(index) else {
+                return InvocationWord::Opaque;
+            };
+            if fragments.iter().any(|fragment| {
+                matches!(
+                    fragment.token.kind,
+                    tcl_lexer::TokenType::Var | tcl_lexer::TokenType::Cmd
+                )
+            }) {
+                InvocationWord::Dynamic
+            } else {
+                InvocationWord::Literal(text)
+            }
+        })
         .collect()
 }
 

--- a/rust/tcl-compiler/src/registry_invocation.rs
+++ b/rust/tcl-compiler/src/registry_invocation.rs
@@ -24,13 +24,41 @@
 //! analyses all resolve exactly the same structured [`WordExpr`] facts under
 //! an explicitly supplied dialect profile.
 
+use tcl_dialect::EscapeSyntax;
 use tcl_registry::dialects::DialectSet;
 use tcl_registry::{
     CommandRegistry, InvocationFacts, InvocationResolutionUnresolved, InvocationWord,
     InvocationWordKind, InvocationWords,
 };
 
-use crate::ir::{CommandTokens, WordExpr};
+use crate::ir::{CommandTokens, WordExpr, WordPart};
+
+/// Owned source-aware word fact for callers that must decode a static Tcl
+/// word before lending it to the registry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EffectiveInvocationWord {
+    /// A Tcl value proven static after applying the active escape syntax.
+    Literal(String),
+    /// One argv word produced by substitution.
+    Dynamic,
+    /// An expansion with an unknown resulting argv length.
+    Expanded,
+    /// A compatibility/recovery word whose source meaning is unavailable.
+    Opaque,
+}
+
+impl EffectiveInvocationWord {
+    /// Lend this owned fact to the registry's allocation-free vocabulary.
+    #[must_use]
+    pub fn as_registry_word(&self) -> InvocationWord<'_> {
+        match self {
+            Self::Literal(value) => InvocationWord::Literal(value),
+            Self::Dynamic => InvocationWord::Dynamic,
+            Self::Expanded => InvocationWord::Expanded,
+            Self::Opaque => InvocationWord::Opaque,
+        }
+    }
+}
 
 /// An owned, target-neutral result from registry invocation resolution.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -101,6 +129,56 @@ pub fn invocation_word(word: &WordExpr) -> InvocationWord<'_> {
         WordExpr::Expand { .. } => InvocationWord::Expanded,
         WordExpr::Opaque { .. } => InvocationWord::Opaque,
     }
+}
+
+/// Evaluate the statically-known portion of a source word under the active
+/// escape grammar. Braced words deliberately do not decode backslashes.
+#[must_use]
+pub fn effective_invocation_word(
+    word: &WordExpr,
+    escapes: EscapeSyntax,
+) -> EffectiveInvocationWord {
+    match word {
+        WordExpr::Literal { text, .. } | WordExpr::BracedLiteral { text, .. } => {
+            EffectiveInvocationWord::Literal(text.clone())
+        }
+        WordExpr::Template { parts, .. }
+            if parts
+                .iter()
+                .all(|part| matches!(part, WordPart::Text { .. })) =>
+        {
+            let raw: String = parts
+                .iter()
+                .map(|part| match part {
+                    WordPart::Text { text, .. } => text.as_str(),
+                    _ => unreachable!("guard admits text parts only"),
+                })
+                .collect();
+            EffectiveInvocationWord::Literal(
+                tcl_syntax::backslash::decode_in(&raw, escapes).into_owned(),
+            )
+        }
+        WordExpr::Variable { .. }
+        | WordExpr::CommandSubstitution { .. }
+        | WordExpr::Template { .. } => EffectiveInvocationWord::Dynamic,
+        WordExpr::Expand { .. } => EffectiveInvocationWord::Expanded,
+        WordExpr::Opaque { .. } => EffectiveInvocationWord::Opaque,
+    }
+}
+
+/// Convert a command-token snapshot into source-aware effective argv facts.
+#[must_use]
+pub fn effective_command_arguments(
+    tokens: &CommandTokens,
+    escapes: EscapeSyntax,
+) -> Vec<EffectiveInvocationWord> {
+    tokens
+        .words()
+        .get(1..)
+        .unwrap_or_default()
+        .iter()
+        .map(|word| effective_invocation_word(word, escapes))
+        .collect()
 }
 
 /// Resolve semantic source words through the registry under `dialect`.
@@ -185,6 +263,34 @@ mod tests {
                         if alias.local == TransitionSubject::Literal("shared".to_owned())
                 )
         ));
+    }
+
+    #[test]
+    fn effective_words_keep_braces_and_decode_bare_escapes() {
+        let source = SourceSite::source(tcl_lexer::Span::new(0, 0));
+        assert_eq!(
+            effective_invocation_word(
+                &WordExpr::Template {
+                    parts: vec![WordPart::Text {
+                        text: r"\x32".to_owned(),
+                        source: source.clone()
+                    }],
+                    source: source.clone(),
+                },
+                EscapeSyntax::Tcl86,
+            ),
+            EffectiveInvocationWord::Literal("2".to_owned())
+        );
+        assert_eq!(
+            effective_invocation_word(
+                &WordExpr::BracedLiteral {
+                    text: r"\x32".to_owned(),
+                    source
+                },
+                EscapeSyntax::Tcl86,
+            ),
+            EffectiveInvocationWord::Literal(r"\x32".to_owned())
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/tests/pipeline_coverage.rs
+++ b/rust/tcl-compiler/tests/pipeline_coverage.rs
@@ -541,6 +541,7 @@ mod defs_from_ir_script_arms {
             handlers: vec![TryHandler {
                 kind: "on".into(),
                 match_arg: "error".into(),
+                trap_pattern: None,
                 var_name: Some("e".into()),
                 options_var: Some("opts".into()),
                 body: Script::from_statements(vec![assign("hb")]),

--- a/rust/tcl-diagram/Cargo.toml
+++ b/rust/tcl-diagram/Cargo.toml
@@ -31,6 +31,7 @@ authors.workspace = true
 tcl-compiler = { path = "../tcl-compiler" }
 tcl-lexer = { path = "../tcl-lexer" }
 tcl-registry = { path = "../tcl-registry" }
+tcl-syntax = { path = "../tcl-syntax" }
 serde_json = "1"
 
 [lints]

--- a/rust/tcl-diagram/Cargo.toml
+++ b/rust/tcl-diagram/Cargo.toml
@@ -29,6 +29,7 @@ authors.workspace = true
 
 [dependencies]
 tcl-compiler = { path = "../tcl-compiler" }
+tcl-dialect = { path = "../tcl-dialect" }
 tcl-lexer = { path = "../tcl-lexer" }
 tcl-registry = { path = "../tcl-registry" }
 tcl-syntax = { path = "../tcl-syntax" }

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -30,6 +30,8 @@ use std::collections::{HashMap, HashSet};
 use serde_json::{Map, Value, json};
 use tcl_compiler::compilation_unit::CompilationUnit;
 use tcl_compiler::expr_ast::{ExprNode, render_expr};
+use tcl_compiler::head_identity::{HeadIdentity, HeadIdentityMap, command_head_identities};
+use tcl_compiler::interprocedural::{namespace_parts_from_proc, resolve_internal_call};
 use tcl_compiler::ir::{
     CommandTokens, Procedure, Script, Statement, SwitchArm, TryHandler, when_event_name,
 };
@@ -45,6 +47,18 @@ use tcl_registry::registry::{
 const MAX_DEPTH: usize = 8;
 const MAX_EVENTS: usize = 12;
 const MAX_ARG_LEN: usize = 60;
+
+/// The semantic context shared by every recursive diagram projection walk.
+///
+/// Procedure declarations are indexed by their qualified identity, and calls
+/// are resolved through the compiler's shared Tcl namespace resolver. Command
+/// table mutations stay source-position-sensitive through `identities`, so a
+/// rebinding cannot accidentally be serialised using a stale registry command.
+struct DiagramContext<'a> {
+    procedure_names: &'a HashSet<String>,
+    identities: &'a HeadIdentityMap,
+    registry: &'a CommandRegistry,
+}
 
 /// A statically-known Tcl completion carried by the diagram JSON contract.
 ///
@@ -288,14 +302,75 @@ fn with_completion(mut node: Value, completion: DiagramCompletion) -> Value {
     node
 }
 
+/// The registry command a source head denotes at one exact source position.
+///
+/// The lowerer carries a canonical command for its alias table, but registry
+/// consumers must also honour an offset-aware `rename`, `interp alias`, or
+/// user-procedure rebind. A proven source identity takes precedence; otherwise
+/// keep the lowerer's canonical alias target for user-defined aliases. Its
+/// final lookup still uses the caller namespace, just like a procedure call.
+fn registry_command(
+    command: &str,
+    canonical_command: Option<&str>,
+    caller_qname: &str,
+    at: u32,
+    context: &DiagramContext<'_>,
+) -> Option<String> {
+    let command = match context.identities.resolve(command, at) {
+        HeadIdentity::Command(resolved) if resolved != command => resolved,
+        HeadIdentity::Rebound => return None,
+        HeadIdentity::Command(_) => canonical_command.unwrap_or(command),
+    };
+    let ns_parts = namespace_parts_from_proc(caller_qname);
+    let namespace = if ns_parts.is_empty() {
+        "::".to_owned()
+    } else {
+        format!("::{}", ns_parts.join("::"))
+    };
+    tcl_compiler::naming::resolve_command_with::<&str, _>(&namespace, &[], command, |qname| {
+        context
+            .registry
+            .get(qname.strip_prefix("::").unwrap_or(qname))
+            .is_some()
+    })
+    .map(|qname| qname.trim_start_matches("::").to_owned())
+}
+
+/// Whether `command` is a call to a user procedure in `caller_qname`'s
+/// namespace at this call site.
+///
+/// The compiler owns Tcl command-name lookup, including rooted names and the
+/// caller-namespace/global candidate sequence. A proven source binding to a
+/// registry command is intentionally not reinterpreted as a same-spelled
+/// procedure: `rename error saved` must keep `saved` as the original command
+/// even if a later `proc error` exists.
+fn is_procedure_call(
+    command: &str,
+    canonical_command: Option<&str>,
+    caller_qname: &str,
+    at: u32,
+    context: &DiagramContext<'_>,
+) -> bool {
+    if matches!(context.identities.resolve(command, at), HeadIdentity::Command(resolved) if resolved != command)
+    {
+        return false;
+    }
+    resolve_internal_call(
+        canonical_command.unwrap_or(command),
+        caller_qname,
+        context.procedure_names,
+    )
+    .is_some()
+}
+
 /// Build the `switch` flow-node dict from its subject, arms and default body.
 fn walk_switch(
     subject: &str,
     arms: &[SwitchArm],
     default_body: Option<&Script>,
-    proc_names: &HashSet<&str>,
+    caller_qname: &str,
+    context: &DiagramContext<'_>,
     depth: usize,
-    registry: &CommandRegistry,
 ) -> Value {
     let mut serialised_arms: Vec<Value> = Vec::new();
     let mut fallthrough_patterns: Vec<String> = Vec::new();
@@ -307,7 +382,7 @@ fn walk_switch(
         let mut patterns = std::mem::take(&mut fallthrough_patterns);
         patterns.push(arm.pattern.clone());
         let body = arm.body.as_ref().map_or_else(Vec::new, |b| {
-            walk_script(b, proc_names, depth + 1, registry)
+            walk_script(b, caller_qname, context, depth + 1)
         });
         let pattern = if patterns.len() > 1 {
             patterns.join(" | ")
@@ -317,7 +392,7 @@ fn walk_switch(
         serialised_arms.push(json!({ "pattern": pattern, "body": body }));
     }
     if let Some(body) = default_body {
-        let body = walk_script(body, proc_names, depth + 1, registry);
+        let body = walk_script(body, caller_qname, context, depth + 1);
         serialised_arms.push(json!({ "pattern": "default", "body": body }));
     }
     json!({
@@ -332,11 +407,11 @@ fn walk_try(
     body: &Script,
     handlers: &[TryHandler],
     finally_body: Option<&Script>,
-    proc_names: &HashSet<&str>,
+    caller_qname: &str,
+    context: &DiagramContext<'_>,
     depth: usize,
-    registry: &CommandRegistry,
 ) -> Value {
-    let child = walk_script(body, proc_names, depth + 1, registry);
+    let child = walk_script(body, caller_qname, context, depth + 1);
     let mut result = Map::new();
     result.insert("kind".to_owned(), json!("try"));
     result.insert("body".to_owned(), json!(child));
@@ -347,10 +422,10 @@ fn walk_try(
                 json!({
                     "kind_handler": h.kind,
                     "match": h.match_arg,
-                    "completion_code": handler_completion_code(h, registry),
+                    "completion_code": handler_completion_code(h, context.registry),
                     "trap_pattern": h.trap_pattern,
                     "fallthrough": h.fallthrough,
-                    "body": walk_script(&h.body, proc_names, depth + 1, registry),
+                    "body": walk_script(&h.body, caller_qname, context, depth + 1),
                 })
             })
             .collect();
@@ -359,7 +434,7 @@ fn walk_try(
     if let Some(finally_body) = finally_body {
         result.insert(
             "finally".to_owned(),
-            json!(walk_script(finally_body, proc_names, depth + 1, registry)),
+            json!(walk_script(finally_body, caller_qname, context, depth + 1)),
         );
     }
     Value::Object(result)
@@ -391,20 +466,20 @@ fn handler_completion_code(handler: &TryHandler, registry: &CommandRegistry) -> 
 fn walk_if(
     clauses: &[tcl_compiler::ir::IfClause],
     else_body: Option<&Script>,
-    proc_names: &HashSet<&str>,
+    caller_qname: &str,
+    context: &DiagramContext<'_>,
     depth: usize,
-    registry: &CommandRegistry,
 ) -> Value {
     let mut branches: Vec<Value> = Vec::new();
     for clause in clauses {
-        let body = walk_script(&clause.body, proc_names, depth + 1, registry);
+        let body = walk_script(&clause.body, caller_qname, context, depth + 1);
         branches.push(json!({
             "condition": condition_text(&clause.condition),
             "body": body,
         }));
     }
     if let Some(else_body) = else_body {
-        let body = walk_script(else_body, proc_names, depth + 1, registry);
+        let body = walk_script(else_body, caller_qname, context, depth + 1);
         branches.push(json!({ "condition": "else", "body": body }));
     }
     json!({ "kind": "if", "branches": branches })
@@ -416,15 +491,14 @@ fn walk_call(
     canonical_command: Option<&str>,
     args: &[String],
     tokens: Option<&CommandTokens>,
-    proc_names: &HashSet<&str>,
-    registry: &CommandRegistry,
+    caller_qname: &str,
+    at: u32,
+    context: &DiagramContext<'_>,
 ) -> Option<Value> {
-    // Matching is on `Statement::Call.canonical_command` (the stamped
-    // namespace-qualified form). The lowerer only stamps it for
-    // alias / namespace resolution, leaving plain calls `None`; for
-    // those the source spelling *is* the canonical (modulo a leading
-    // `::`, which `is_diagram_action` / the registry strip), so fall
-    // back to it to reproduce the resolution.
+    // The lowerer records the target of a statically-known alias. Plain calls
+    // deliberately retain their source spelling; `resolve_internal_call`
+    // below gives those Tcl's caller-namespace lookup rather than treating
+    // equal short tails as interchangeable identities.
     let canonical = canonical_command.unwrap_or(command);
     let display = command;
     // Skip the top-level `when` calls — their bodies are in procedures.
@@ -432,19 +506,28 @@ fn walk_call(
         return None;
     }
     // Procedure calls.
-    if proc_names.contains(display) || proc_names.contains(canonical) {
+    if is_procedure_call(command, canonical_command, caller_qname, at, context) {
         return Some(json!({
             "kind": "proc_call",
             "label": format!("call {display}"),
             "command": display,
         }));
     }
-    let completion = command_completion(canonical, args, tokens, registry);
+    let registry_command = registry_command(command, canonical_command, caller_qname, at, context);
+    let completion = registry_command
+        .as_deref()
+        .map_or(DiagramCompletion::Normal, |command| {
+            command_completion(command, args, tokens, context.registry)
+        });
     // Keep an exact non-normal completion visible even when it is not a
     // diagram action (for example `error` / `throw`), so a surrounding try
     // can route it through `finally`.  Ordinary unknown calls remain omitted
     // unless the registry marks them as a diagram action.
-    if registry.is_diagram_action(canonical) || completion != DiagramCompletion::Normal {
+    if registry_command
+        .as_deref()
+        .is_some_and(|command| context.registry.is_diagram_action(command))
+        || completion != DiagramCompletion::Normal
+    {
         return Some(with_completion(action_node(display, args), completion));
     }
     None
@@ -455,31 +538,41 @@ fn loop_node(
     label: &str,
     exit: &str,
     body: &Script,
-    proc_names: &HashSet<&str>,
+    caller_qname: &str,
+    context: &DiagramContext<'_>,
     depth: usize,
-    registry: &CommandRegistry,
 ) -> Value {
-    let child = walk_script(body, proc_names, depth + 1, registry);
+    let child = walk_script(body, caller_qname, context, depth + 1);
     json!({ "kind": "loop", "label": label, "exit": exit, "body": child })
 }
 
 /// Project the compiler's structured loop variants into one loop flow node.
 fn walk_loop_statement(
     stmt: &Statement,
-    proc_names: &HashSet<&str>,
+    caller_qname: &str,
+    context: &DiagramContext<'_>,
     depth: usize,
-    registry: &CommandRegistry,
 ) -> Option<Value> {
     match stmt {
-        Statement::For { body, .. } => {
-            Some(loop_node("for", "false", body, proc_names, depth, registry))
-        }
+        Statement::For { body, .. } => Some(loop_node(
+            "for",
+            "false",
+            body,
+            caller_qname,
+            context,
+            depth,
+        )),
         Statement::While {
             condition, body, ..
         } => {
             let label = format!("while {}", condition_text(condition));
             Some(loop_node(
-                &label, "false", body, proc_names, depth, registry,
+                &label,
+                "false",
+                body,
+                caller_qname,
+                context,
+                depth,
             ))
         }
         Statement::Foreach {
@@ -495,9 +588,9 @@ fn walk_loop_statement(
                 &label,
                 "exhausted",
                 body,
-                proc_names,
+                caller_qname,
+                context,
                 depth,
-                registry,
             ))
         }
         _ => None,
@@ -526,9 +619,9 @@ fn return_node(value: Option<&String>) -> Value {
 /// One arm per IR statement kind, so the length tracks the statement set.
 fn walk_statement(
     stmt: &Statement,
-    proc_names: &HashSet<&str>,
+    caller_qname: &str,
+    context: &DiagramContext<'_>,
     depth: usize,
-    registry: &CommandRegistry,
 ) -> Option<Value> {
     if depth > MAX_DEPTH {
         return Some(json!({ "kind": "truncated", "label": "... (nested logic)" }));
@@ -544,9 +637,9 @@ fn walk_statement(
             subject,
             arms,
             default_body.as_ref(),
-            proc_names,
+            caller_qname,
+            context,
             depth,
-            registry,
         )),
 
         Statement::If {
@@ -554,16 +647,17 @@ fn walk_statement(
         } => Some(walk_if(
             clauses,
             else_body.as_ref(),
-            proc_names,
+            caller_qname,
+            context,
             depth,
-            registry,
         )),
 
         Statement::For { .. } | Statement::While { .. } | Statement::Foreach { .. } => {
-            walk_loop_statement(stmt, proc_names, depth, registry)
+            walk_loop_statement(stmt, caller_qname, context, depth)
         }
 
         Statement::Call {
+            span,
             command,
             canonical_command,
             args,
@@ -574,20 +668,35 @@ fn walk_statement(
             canonical_command.as_deref(),
             args,
             tokens.as_ref(),
-            proc_names,
-            registry,
+            caller_qname,
+            span.start(),
+            context,
         ),
 
         Statement::Barrier {
+            span,
             command,
             canonical_command,
             args,
             tokens,
             ..
         } => {
-            let canonical = canonical_command.as_deref().unwrap_or(command.as_str());
-            let completion = command_completion(canonical, args, tokens.as_ref(), registry);
-            (registry.is_diagram_action(canonical) || completion != DiagramCompletion::Normal)
+            let registry_command = registry_command(
+                command,
+                canonical_command.as_deref(),
+                caller_qname,
+                span.start(),
+                context,
+            );
+            let completion = registry_command
+                .as_deref()
+                .map_or(DiagramCompletion::Normal, |command| {
+                    command_completion(command, args, tokens.as_ref(), context.registry)
+                });
+            (registry_command
+                .as_deref()
+                .is_some_and(|command| context.registry.is_diagram_action(command))
+                || completion != DiagramCompletion::Normal)
                 .then(|| with_completion(action_node(command, args), completion))
         }
 
@@ -600,7 +709,7 @@ fn walk_statement(
         Statement::AssignExpr { name, expr, .. } => assign_node(name, &render_expr(expr)),
 
         Statement::Catch { body, .. } => {
-            let child = walk_script(body, proc_names, depth + 1, registry);
+            let child = walk_script(body, caller_qname, context, depth + 1);
             Some(json!({ "kind": "catch", "body": child }))
         }
 
@@ -613,9 +722,9 @@ fn walk_statement(
             body,
             handlers,
             finally_body.as_ref(),
-            proc_names,
+            caller_qname,
+            context,
             depth,
-            registry,
         )),
 
         _ => None,
@@ -625,14 +734,14 @@ fn walk_statement(
 /// Walk all statements in a script, dropping the skipped (`None`) nodes.
 fn walk_script(
     script: &Script,
-    proc_names: &HashSet<&str>,
+    caller_qname: &str,
+    context: &DiagramContext<'_>,
     depth: usize,
-    registry: &CommandRegistry,
 ) -> Vec<Value> {
     script
         .statements
         .iter()
-        .filter_map(|stmt| walk_statement(stmt, proc_names, depth, registry))
+        .filter_map(|stmt| walk_statement(stmt, caller_qname, context, depth))
         .collect()
 }
 
@@ -668,11 +777,19 @@ pub fn diagram_data_for_dialect(source: &str, registry: &CommandRegistry, dialec
         .filter(|(key, _)| !key.starts_with("::when::"))
         .collect();
 
-    // User-defined procedure names for call detection.
-    let proc_names: HashSet<&str> = regular_procs
+    // User-defined procedure names for call detection. Keep qualified
+    // identities: Tcl's caller-namespace lookup selects the one that exists,
+    // and two namespaces may deliberately share a short procedure name.
+    let procedure_names: HashSet<String> = regular_procs
         .iter()
-        .map(|(_, proc)| proc.name.as_str())
+        .map(|(_, proc)| proc.qualified_name.clone())
         .collect();
+    let identities = command_head_identities(source, dialect, registry);
+    let context = DiagramContext {
+        procedure_names: &procedure_names,
+        identities: &identities,
+        registry,
+    };
 
     let event_registry = EventRegistry::build();
 
@@ -698,7 +815,7 @@ pub fn diagram_data_for_dialect(source: &str, registry: &CommandRegistry, dialec
     'outer: for event_name in ordered {
         if let Some(handlers) = handlers_by_event.get(&event_name) {
             for proc in handlers {
-                let flow = walk_script(&proc.body, &proc_names, 0, registry);
+                let flow = walk_script(&proc.body, &proc.qualified_name, &context, 0);
                 let priority = if proc.base_priority == 500 {
                     Value::Null
                 } else {
@@ -720,7 +837,7 @@ pub fn diagram_data_for_dialect(source: &str, registry: &CommandRegistry, dialec
     let procedures: Vec<Value> = regular_procs
         .iter()
         .map(|(_, proc)| {
-            let flow = walk_script(&proc.body, &proc_names, 0, registry);
+            let flow = walk_script(&proc.body, &proc.qualified_name, &context, 0);
             json!({ "name": proc.name, "params": proc.params, "flow": flow })
         })
         .collect();
@@ -1201,6 +1318,102 @@ mod tests {
                 "{dialect}"
             );
         }
+    }
+
+    #[test]
+    fn procedure_calls_resolve_qualified_names_in_the_callers_namespace() {
+        let data = diagram_data_for_dialect(
+            r"
+                namespace eval ::alpha {
+                    proc helper {} {}
+                    proc caller {} {
+                        helper
+                        ::alpha::helper
+                    }
+                }
+                namespace eval ::beta {
+                    proc helper {} {}
+                    proc caller {} {
+                        helper
+                        alpha::helper
+                        ::alpha::helper
+                    }
+                }
+                namespace eval ::unrelated {
+                    proc caller {} { helper }
+                }
+            ",
+            tcl_registry::registry_for_dialect("tcl8.6"),
+            "tcl8.6",
+        );
+
+        let procedures = data["procedures"].as_array().expect("procedures");
+        assert_eq!(procedures.len(), 5, "{data}");
+        assert_eq!(procedures[1]["name"], "caller");
+        assert_eq!(procedures[3]["name"], "caller");
+        assert_eq!(procedures[4]["name"], "caller");
+
+        for index in [0, 1] {
+            assert_eq!(procedures[1]["flow"][index]["kind"], "proc_call");
+        }
+        // A relative qualified command first probes `::beta::alpha::helper`,
+        // then correctly falls back to `::alpha::helper`; rooted spelling is
+        // a direct lookup of that same declaration.
+        for index in [0, 1, 2] {
+            assert_eq!(procedures[3]["flow"][index]["kind"], "proc_call");
+        }
+        assert!(
+            procedures[4]["flow"].as_array().is_some_and(Vec::is_empty),
+            "a same-tailed procedure in another namespace must not match: {data}"
+        );
+    }
+
+    #[test]
+    fn registry_actions_resolve_relative_names_in_the_callers_namespace() {
+        let data = diagram_data_for_dialect(
+            "proc ::HTTP::caller {} { respond 200 content ok }",
+            tcl_registry::registry_for_dialect("f5-irules"),
+            "f5-irules",
+        );
+        let flow = data
+            .pointer("/procedures/0/flow")
+            .and_then(Value::as_array)
+            .expect("caller flow");
+        assert_eq!(flow.len(), 1, "{data}");
+        assert_eq!(flow[0]["kind"], "action");
+        assert_eq!(flow[0]["command"], "respond");
+    }
+
+    #[test]
+    fn procedure_aliases_and_rebound_registry_heads_stay_source_sensitive() {
+        let data = diagram_data_for_dialect(
+            r"
+                proc ::library::helper {} {}
+                interp alias {} invoke {} ::library::helper
+                rename error saved_error
+                proc error {args} {}
+                proc caller {} {
+                    invoke
+                    error user
+                    saved_error original
+                }
+            ",
+            tcl_registry::registry_for_dialect("tcl8.6"),
+            "tcl8.6",
+        );
+
+        let flow = data
+            .pointer("/procedures/2/flow")
+            .and_then(Value::as_array)
+            .expect("caller flow");
+        assert_eq!(flow.len(), 3, "{data}");
+        assert_eq!(flow[0]["kind"], "proc_call");
+        assert_eq!(flow[0]["command"], "invoke");
+        assert_eq!(flow[1]["kind"], "proc_call");
+        assert_eq!(flow[1]["command"], "error");
+        assert_eq!(flow[2]["kind"], "action");
+        assert_eq!(flow[2]["command"], "saved_error");
+        assert_eq!(flow[2]["completion"], "error");
     }
 
     #[test]

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -327,7 +327,7 @@ fn walk_try(
                     "kind_handler": h.kind,
                     "match": h.match_arg,
                     "completion_code": handler_completion_code(h, registry),
-                    "trap_pattern": trap_pattern_elements(h),
+                    "trap_pattern": h.trap_pattern,
                     "fallthrough": h.fallthrough,
                     "body": walk_script(&h.body, proc_names, depth + 1, registry),
                 })
@@ -342,21 +342,6 @@ fn walk_try(
         );
     }
     Value::Object(result)
-}
-
-/// A literal `trap` selector is a Tcl list, not whitespace-separated text.
-/// Dynamic substitutions and malformed lists remain null so consumers retain
-/// conservative routing rather than inventing list boundaries.
-fn trap_pattern_elements(handler: &TryHandler) -> Option<Vec<String>> {
-    (handler.kind == "trap")
-        .then(|| tcl_syntax::list::split_list(&handler.match_arg).ok())
-        .flatten()
-        .filter(|elements| {
-            !elements
-                .iter()
-                .any(|element| element.contains('$') || element.contains('['))
-        })
-        .map(|elements| elements.into_iter().map(Into::into).collect())
 }
 
 /// Canonicalise an `on` selector in the shared projection.  Tcl accepts its
@@ -952,18 +937,31 @@ mod tests {
     #[test]
     fn trap_patterns_are_projected_as_tcl_list_elements() {
         let data = diagram_data_for_dialect(
-            "proc paths {} { try { error x } trap {A {B C}} {message options} {} trap {A \"B C\"} {message options} {} }",
+            r#"proc paths {} { try { error x } trap {A \$B} {message options} {} trap {A {$B}} {message options} {} trap {A \[B\]} {message options} {} trap {A {[B]}} {message options} {} trap {A C:\\tmp} {message options} {} trap {A {C:\tmp}} {message options} {} trap "A \{" {message options} {} trap $pattern {message options} {} trap "A $pattern" {message options} {} trap [list A B] {message options} {} }"#,
             tcl_registry::registry_for_dialect("tcl8.6"),
             "tcl8.6",
         );
-        assert_eq!(
-            data.pointer("/procedures/0/flow/0/handlers/0/trap_pattern"),
-            Some(&json!(["A", "B C"]))
-        );
-        assert_eq!(
-            data.pointer("/procedures/0/flow/0/handlers/1/trap_pattern"),
-            Some(&json!(["A", "B C"]))
-        );
+        let expected = [
+            json!(["A", "$B"]),
+            json!(["A", "$B"]),
+            json!(["A", "[B]"]),
+            json!(["A", "[B]"]),
+            json!(["A", r"C:\tmp"]),
+            json!(["A", r"C:\tmp"]),
+            Value::Null,
+            Value::Null,
+            Value::Null,
+            Value::Null,
+        ];
+        for (index, expected) in expected.iter().enumerate() {
+            assert_eq!(
+                data.pointer(&format!(
+                    "/procedures/0/flow/0/handlers/{index}/trap_pattern"
+                )),
+                Some(expected),
+                "handler {index}: {data}"
+            );
+        }
     }
 
     #[test]

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -873,24 +873,51 @@ mod tests {
     }
 
     #[test]
-    fn exit_statuses_project_exact_error_and_typed_dynamic_outcomes() {
-        for dialect in ["tcl8.6", "tcl9.0"] {
-            let data = diagram_data_for_dialect(
-                r"
-                    proc paths {status} {
-                        try { exit nope } on error {message options} { set caught yes } finally { set cleaned yes }
-                        try { exit $status } on error {message options} { set caught_dynamic yes } finally { set cleaned_dynamic yes }
-                        set after yes
-                    }
-                ",
-                tcl_registry::registry_for_dialect(dialect),
-                dialect,
-            );
-            assert_eq!(
-                data.pointer("/procedures/0/flow/0/body/0/completion"),
-                Some(&Value::String("error".to_owned())),
-                "{dialect}: static invalid exit is a Tcl error"
-            );
+    fn exit_statuses_project_release_specific_errors_and_typed_dynamic_outcomes() {
+        let source = r"
+            proc paths {status} {
+                try { exit 4294967296 } on error {message options} { set caught [clock seconds] } finally { set cleaned [clock seconds] }
+                try { exit $status } on error {message options} { set caught_dynamic [clock seconds] } finally { set cleaned_dynamic [clock seconds] }
+                set after [clock seconds]
+            }
+        ";
+        let tcl86 = diagram_data_for_dialect(
+            source,
+            tcl_registry::registry_for_dialect("tcl8.6"),
+            "tcl8.6",
+        );
+        assert_eq!(
+            tcl86.pointer("/procedures/0/flow/0/body/0/completion"),
+            Some(&Value::String("error".to_owned())),
+            "Tcl 8.6 rejects the first value above Tcl_GetIntFromObj's UINT_MAX ceiling: {tcl86}"
+        );
+        assert_eq!(
+            tcl86.pointer("/procedures/0/flow/0/handlers/0/body/0/kind"),
+            Some(&Value::String("assign".to_owned())),
+            "Tcl 8.6's static range error reaches on-error: {tcl86}"
+        );
+        assert_eq!(
+            tcl86.pointer("/procedures/0/flow/0/finally/0/kind"),
+            Some(&Value::String("assign".to_owned())),
+            "Tcl 8.6's static range error reaches finally: {tcl86}"
+        );
+        assert_eq!(
+            tcl86.pointer("/procedures/0/flow/2/kind"),
+            Some(&Value::String("assign".to_owned())),
+            "Tcl 8.6's handled error preserves the after path: {tcl86}"
+        );
+
+        let tcl90 = diagram_data_for_dialect(
+            source,
+            tcl_registry::registry_for_dialect("tcl9.0"),
+            "tcl9.0",
+        );
+        assert_eq!(
+            tcl90.pointer("/procedures/0/flow/0/body/0/completion"),
+            Some(&Value::String("process_exit".to_owned())),
+            "Tcl 9.0's bit-preserving wide conversion accepts 4294967296: {tcl90}"
+        );
+        for (dialect, data) in [("tcl8.6", &tcl86), ("tcl9.0", &tcl90)] {
             assert_eq!(
                 data.pointer("/procedures/0/flow/1/body/0/completion"),
                 Some(&Value::String("exit_or_error".to_owned())),

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -56,6 +56,7 @@ enum DiagramCompletion {
     Break,
     Continue,
     Dynamic,
+    DynamicReturnOrError,
     ProcessExit,
     Terminal,
 }
@@ -69,6 +70,7 @@ impl DiagramCompletion {
             Self::Break => Some("break"),
             Self::Continue => Some("continue"),
             Self::Dynamic => Some("dynamic"),
+            Self::DynamicReturnOrError => Some("dynamic_return_or_error"),
             Self::ProcessExit => Some("process_exit"),
             Self::Terminal => Some("terminal"),
         }
@@ -118,7 +120,18 @@ fn command_completion(
             resolved.lowering_hook == Some(tcl_registry::hooks::LoweringHookId::Return)
         })
     {
-        return DiagramCompletion::Dynamic;
+        // Exact literal options returned above. A remaining `-code` is
+        // therefore dynamic (or otherwise not statically evaluable).
+        let has_dynamic_code = args.windows(2).any(|words| words[0] == "-code");
+        // A dynamic -code with no explicit level remains Tcl's default
+        // TCL_RETURN, except that an invalid code errors while configuring
+        // it. Any explicit or dynamic level has wider observable outcomes.
+        let has_level = args.windows(2).any(|words| words[0] == "-level");
+        return if has_dynamic_code && !has_level && !args.iter().any(|word| word == "-options") {
+            DiagramCompletion::DynamicReturnOrError
+        } else {
+            DiagramCompletion::Dynamic
+        };
     }
     match registry.invocation_completion(command, &arg_refs, DialectSet::empty()) {
         InvocationCompletion::ReturnsResult(_) => DiagramCompletion::Return,
@@ -779,6 +792,33 @@ mod tests {
     }
 
     #[test]
+    fn dynamic_return_forms_keep_their_distinct_possible_completions() {
+        let data = diagram_data_for_dialect(
+            r"
+                proc paths {} {
+                    try { return -code $code payload } finally { set cleaned yes }
+                    try { return -level 0 -code $code payload } finally { set cleaned yes }
+                    try { return -options $options payload } finally { set cleaned yes }
+                }
+            ",
+            tcl_registry::registry_for_dialect("tcl8.6"),
+            "tcl8.6",
+        );
+        assert_eq!(
+            data.pointer("/procedures/0/flow/0/body/0/completion"),
+            Some(&Value::String("dynamic_return_or_error".to_owned()))
+        );
+        assert_eq!(
+            data.pointer("/procedures/0/flow/1/body/0/completion"),
+            Some(&Value::String("dynamic".to_owned()))
+        );
+        assert_eq!(
+            data.pointer("/procedures/0/flow/2/body/0/completion"),
+            Some(&Value::String("dynamic".to_owned()))
+        );
+    }
+
+    #[test]
     fn real_tcl_oracle_distinguishes_default_and_level_zero_return_codes() {
         let script = r"
             proc probe {spec} {
@@ -790,11 +830,44 @@ mod tests {
                 lappend log after
                 return $log
             }
+            proc probe_dynamic_code {code} {
+                set log {}
+                try { return -code $code payload } \
+                    on ok {message options} { lappend log ok } \
+                    on error {message options} { lappend log error } \
+                    on return {message options} { lappend log return } \
+                    on break {message options} { lappend log break } \
+                    on continue {message options} { lappend log continue } \
+                    finally { lappend log finally }
+                lappend log after
+                return $log
+            }
+            proc probe_dynamic_options {options} {
+                set log {}
+                try { return -options $options payload } \
+                    on ok {message options} { lappend log ok } \
+                    on error {message options} { lappend log error } \
+                    on return {message options} { lappend log return } \
+                    on break {message options} { lappend log break } \
+                    on continue {message options} { lappend log continue } \
+                    finally { lappend log finally }
+                lappend log after
+                return $log
+            }
             puts [probe {-code error}]
             puts [probe {-level 0 -code error}]
             puts [probe {-foo bar}]
             puts [probe {-c error}]
             puts [probe {-level 0x0 -code error}]
+            puts [probe_dynamic_code error]
+            puts [probe_dynamic_code bogus]
+            foreach options {
+                {-code ok -level 0}
+                {-code error -level 0}
+                {-code return -level 0}
+                {-code break -level 0}
+                {-code continue -level 0}
+            } { puts [probe_dynamic_options $options] }
         ";
         let mut child = Command::new("tclsh")
             .stdin(Stdio::piped())
@@ -811,7 +884,13 @@ mod tests {
         assert!(output.status.success(), "{output:?}");
         assert_eq!(
             String::from_utf8(output.stdout).expect("oracle stdout"),
-            "return finally after\nerror finally after\nreturn finally after\nreturn finally after\nerror finally after\n"
+            concat!(
+                "return finally after\nerror finally after\nreturn finally after\n",
+                "return finally after\nerror finally after\n",
+                "return finally after\nerror finally after\n",
+                "ok finally after\nerror finally after\nreturn finally after\n",
+                "break finally after\ncontinue finally after\n",
+            )
         );
     }
 }

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -35,12 +35,12 @@ use tcl_compiler::ir::{
 };
 use tcl_compiler::registry_invocation::effective_command_arguments;
 use tcl_registry::CommandRegistry;
+use tcl_registry::InvocationArguments;
 use tcl_registry::dialects::DialectSet;
 use tcl_registry::events::EventRegistry;
 use tcl_registry::registry::{
     ExactInvocationCompletion, InvocationCompletion, InvocationCompletionKnowledge,
 };
-use tcl_registry::InvocationArguments;
 
 const MAX_DEPTH: usize = 8;
 const MAX_EVENTS: usize = 12;
@@ -101,7 +101,9 @@ fn command_completion(
     let effective = tokens.map(|tokens| {
         effective_command_arguments(
             tokens,
-            tcl_dialect::EscapeSyntax::of_dialect_name(registry.profile().map(|profile| profile.name)),
+            tcl_dialect::EscapeSyntax::of_dialect_name(
+                registry.profile().map(|profile| profile.name),
+            ),
         )
     });
     let knowledge = if let Some(effective) = effective.as_ref() {

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -351,12 +351,12 @@ fn handler_completion_code(handler: &TryHandler, registry: &CommandRegistry) -> 
         "return" => Some(2),
         "break" => Some(3),
         "continue" => Some(4),
-        value => registry
-            .profile()
-            .and_then(|profile| {
-                tcl_syntax::number::Numbers::of_profile(Some(profile)).parse_wide(value)
-            })
-            .and_then(|value| i32::try_from(value).ok()),
+        value => registry.profile().and_then(|profile| {
+            tcl_registry::completion::canonical_completion_code(
+                value,
+                tcl_syntax::number::Numbers::of_profile(Some(profile)),
+            )
+        }),
     }
 }
 
@@ -843,7 +843,7 @@ mod tests {
 
     #[test]
     fn handler_completion_codes_use_the_dialect_numeric_grammar() {
-        let source = "proc paths {} { try { return -options $options payload } on 02 {message options} { set two yes } on +2 {message options} { set duplicate yes } on 0x2 {message options} { set duplicate_hex yes } on return {message options} { set symbolic yes } on nonsense {message options} { set invalid yes } }";
+        let source = "proc paths {} { try { return -options $options payload } on 02 {message options} { set two yes } on +2 {message options} { set duplicate yes } on 0x2 {message options} { set duplicate_hex yes } on return {message options} { set symbolic yes } on 2147483648 {message options} { set wrapped_min yes } on 4294967295 {message options} { set wrapped_minus_one yes } on -2147483649 {message options} { set invalid_low yes } on nonsense {message options} { set invalid yes } }";
         // `try` itself begins in Tcl 8.6, so diagram handlers can only be
         // projected for releases that provide the command.
         for dialect in ["tcl8.6", "tcl9.0"] {
@@ -872,6 +872,9 @@ mod tests {
                     Value::from(2),
                     Value::from(2),
                     Value::from(2),
+                    Value::from(i32::MIN),
+                    Value::from(-1),
+                    Value::Null,
                     Value::Null
                 ],
                 "{dialect}"
@@ -889,6 +892,26 @@ mod tests {
             assert_eq!(numbers.parse_wide("02"), Some(2), "{dialect}");
             assert_eq!(numbers.parse_wide("+2"), Some(2), "{dialect}");
             assert_eq!(numbers.parse_wide("0x2"), Some(2), "{dialect}");
+            assert_eq!(
+                tcl_registry::completion::canonical_completion_code("2147483648", numbers),
+                Some(i32::MIN),
+                "{dialect}"
+            );
+            assert_eq!(
+                tcl_registry::completion::canonical_completion_code("4294967295", numbers),
+                Some(-1),
+                "{dialect}"
+            );
+            assert_eq!(
+                tcl_registry::completion::canonical_completion_code("-2147483649", numbers),
+                None,
+                "{dialect}"
+            );
+            assert_eq!(
+                tcl_registry::completion::canonical_completion_code("9223372036854775808", numbers),
+                None,
+                "{dialect}"
+            );
         }
     }
 

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -854,6 +854,16 @@ mod tests {
                 lappend log after
                 return $log
             }
+            proc probe_source_order {} {
+                set log {}
+                try { return -options {-code error -level 0 -errorcode {X Y}} payload } \
+                    trap {X} {message options} { lappend log broad-trap } \
+                    trap {X Y} {message options} { lappend log overlapping-trap } \
+                    on error {message options} { lappend log first-error } \
+                    on error {message options} { lappend log duplicate-error } \
+                    finally { lappend log finally }
+                return $log
+            }
             puts [probe {-code error}]
             puts [probe {-level 0 -code error}]
             puts [probe {-foo bar}]
@@ -868,6 +878,7 @@ mod tests {
                 {-code break -level 0}
                 {-code continue -level 0}
             } { puts [probe_dynamic_options $options] }
+            puts [probe_source_order]
         ";
         let mut child = Command::new("tclsh")
             .stdin(Stdio::piped())
@@ -890,6 +901,7 @@ mod tests {
                 "return finally after\nerror finally after\n",
                 "ok finally after\nerror finally after\nreturn finally after\n",
                 "break finally after\ncontinue finally after\n",
+                "broad-trap finally\n",
             )
         );
     }

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -30,11 +30,17 @@ use std::collections::{HashMap, HashSet};
 use serde_json::{Map, Value, json};
 use tcl_compiler::compilation_unit::CompilationUnit;
 use tcl_compiler::expr_ast::{ExprNode, render_expr};
-use tcl_compiler::ir::{Procedure, Script, Statement, SwitchArm, TryHandler, when_event_name};
+use tcl_compiler::ir::{
+    CommandTokens, Procedure, Script, Statement, SwitchArm, TryHandler, when_event_name,
+};
+use tcl_compiler::registry_invocation::effective_command_arguments;
 use tcl_registry::CommandRegistry;
 use tcl_registry::dialects::DialectSet;
 use tcl_registry::events::EventRegistry;
-use tcl_registry::registry::{ExactInvocationCompletion, InvocationCompletion};
+use tcl_registry::registry::{
+    ExactInvocationCompletion, InvocationCompletion, InvocationCompletionKnowledge,
+};
+use tcl_registry::InvocationArguments;
 
 const MAX_DEPTH: usize = 8;
 const MAX_EVENTS: usize = 12;
@@ -88,12 +94,32 @@ impl DiagramCompletion {
 fn command_completion(
     command: &str,
     args: &[String],
+    tokens: Option<&CommandTokens>,
     registry: &CommandRegistry,
 ) -> DiagramCompletion {
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-    if let Some(completion) =
-        registry.exact_invocation_completion(command, &arg_refs, DialectSet::empty())
-    {
+    let effective = tokens.map(|tokens| {
+        effective_command_arguments(
+            tokens,
+            tcl_dialect::EscapeSyntax::of_dialect_name(registry.profile().map(|profile| profile.name)),
+        )
+    });
+    let knowledge = if let Some(effective) = effective.as_ref() {
+        let words: Vec<_> = effective
+            .iter()
+            .map(|word| word.as_registry_word())
+            .collect();
+        registry.invocation_completion_knowledge(
+            command,
+            InvocationArguments::structured(&words),
+            DialectSet::empty(),
+        )
+    } else {
+        registry
+            .exact_invocation_completion(command, &arg_refs, DialectSet::empty())
+            .map(InvocationCompletionKnowledge::Exact)
+    };
+    if let Some(InvocationCompletionKnowledge::Exact(completion)) = knowledge {
         return match completion {
             ExactInvocationCompletion::Tcl(tcl_registry::CompletionCode::Ok) => {
                 DiagramCompletion::Normal
@@ -116,23 +142,13 @@ fn command_completion(
             ExactInvocationCompletion::ProcessExit => DiagramCompletion::ProcessExit,
         };
     }
-    if registry
-        .resolve_call(command, &arg_refs, DialectSet::empty())
-        .is_some_and(|resolved| {
-            resolved.lowering_hook == Some(tcl_registry::hooks::LoweringHookId::Return)
-        })
-    {
-        // Exact literal options returned above. A remaining `-code` is
-        // therefore dynamic (or otherwise not statically evaluable).
-        let has_dynamic_code = args.windows(2).any(|words| words[0] == "-code");
-        // A dynamic -code with no explicit level remains Tcl's default
-        // TCL_RETURN, except that an invalid code errors while configuring
-        // it. Any explicit or dynamic level has wider observable outcomes.
-        let has_level = args.windows(2).any(|words| words[0] == "-level");
-        return if has_dynamic_code && !has_level && !args.iter().any(|word| word == "-options") {
-            DiagramCompletion::DynamicReturnOrError
-        } else {
-            DiagramCompletion::Dynamic
+    if let Some(knowledge) = knowledge {
+        return match knowledge {
+            InvocationCompletionKnowledge::Exact(_) => unreachable!("handled above"),
+            InvocationCompletionKnowledge::DynamicReturnOrError => {
+                DiagramCompletion::DynamicReturnOrError
+            }
+            InvocationCompletionKnowledge::Dynamic => DiagramCompletion::Dynamic,
         };
     }
     match registry.invocation_completion(command, &arg_refs, DialectSet::empty()) {
@@ -394,6 +410,7 @@ fn walk_call(
     command: &str,
     canonical_command: Option<&str>,
     args: &[String],
+    tokens: Option<&CommandTokens>,
     proc_names: &HashSet<&str>,
     registry: &CommandRegistry,
 ) -> Option<Value> {
@@ -417,7 +434,7 @@ fn walk_call(
             "command": display,
         }));
     }
-    let completion = command_completion(canonical, args, registry);
+    let completion = command_completion(canonical, args, tokens, registry);
     // Keep an exact non-normal completion visible even when it is not a
     // diagram action (for example `error` / `throw`), so a surrounding try
     // can route it through `finally`.  Ordinary unknown calls remain omitted
@@ -545,11 +562,13 @@ fn walk_statement(
             command,
             canonical_command,
             args,
+            tokens,
             ..
         } => walk_call(
             command,
             canonical_command.as_deref(),
             args,
+            tokens.as_ref(),
             proc_names,
             registry,
         ),
@@ -558,10 +577,11 @@ fn walk_statement(
             command,
             canonical_command,
             args,
+            tokens,
             ..
         } => {
             let canonical = canonical_command.as_deref().unwrap_or(command.as_str());
-            let completion = command_completion(canonical, args, registry);
+            let completion = command_completion(canonical, args, tokens.as_ref(), registry);
             (registry.is_diagram_action(canonical) || completion != DiagramCompletion::Normal)
                 .then(|| with_completion(action_node(command, args), completion))
         }
@@ -866,6 +886,40 @@ mod tests {
                 assert_eq!(
                     data.pointer(&format!("/procedures/0/flow/{index}/body/0/completion")),
                     Some(&Value::String("error".to_owned())),
+                    "{dialect}: {data}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn return_completion_preserves_source_word_shape() {
+        let source = r#"
+            proc paths {} {
+                try { return -code {$code} } on error {m o} {}
+                try { return -code $code } on error {m o} {}
+                try { return -code "$code" } on error {m o} {}
+                try { return -code \x32 } on return {m o} {}
+                try { return -code {\x32} } on error {m o} {}
+            }
+        "#;
+        for dialect in ["tcl8.6", "tcl9.0"] {
+            let data = diagram_data_for_dialect(
+                source,
+                tcl_registry::registry_for_dialect(dialect),
+                dialect,
+            );
+            let completions = [
+                "error",
+                "dynamic_return_or_error",
+                "dynamic_return_or_error",
+                "return",
+                "error",
+            ];
+            for (index, expected) in completions.into_iter().enumerate() {
+                assert_eq!(
+                    data.pointer(&format!("/procedures/0/flow/{index}/body/0/completion")),
+                    Some(&Value::String(expected.to_owned())),
                     "{dialect}: {data}"
                 );
             }

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -55,6 +55,7 @@ enum DiagramCompletion {
     Return,
     Break,
     Continue,
+    Dynamic,
     ProcessExit,
     Terminal,
 }
@@ -67,6 +68,7 @@ impl DiagramCompletion {
             Self::Return => Some("return"),
             Self::Break => Some("break"),
             Self::Continue => Some("continue"),
+            Self::Dynamic => Some("dynamic"),
             Self::ProcessExit => Some("process_exit"),
             Self::Terminal => Some("terminal"),
         }
@@ -109,6 +111,14 @@ fn command_completion(
             }
             ExactInvocationCompletion::ProcessExit => DiagramCompletion::ProcessExit,
         };
+    }
+    if registry
+        .resolve_call(command, &arg_refs, DialectSet::empty())
+        .is_some_and(|resolved| {
+            resolved.lowering_hook == Some(tcl_registry::hooks::LoweringHookId::Return)
+        })
+    {
+        return DiagramCompletion::Dynamic;
     }
     match registry.invocation_completion(command, &arg_refs, DialectSet::empty()) {
         InvocationCompletion::ReturnsResult(_) => DiagramCompletion::Return,

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -782,6 +782,9 @@ mod tests {
             }
             puts [probe {-code error}]
             puts [probe {-level 0 -code error}]
+            puts [probe {-foo bar}]
+            puts [probe {-c error}]
+            puts [probe {-level 0x0 -code error}]
         ";
         let mut child = Command::new("tclsh")
             .stdin(Stdio::piped())
@@ -798,7 +801,7 @@ mod tests {
         assert!(output.status.success(), "{output:?}");
         assert_eq!(
             String::from_utf8(output.stdout).expect("oracle stdout"),
-            "return finally after\nerror finally after\n"
+            "return finally after\nerror finally after\nreturn finally after\nreturn finally after\nerror finally after\n"
         );
     }
 }

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -321,6 +321,7 @@ fn walk_try(
                 json!({
                     "kind_handler": h.kind,
                     "match": h.match_arg,
+                    "completion_code": handler_completion_code(h, registry),
                     "fallthrough": h.fallthrough,
                     "body": walk_script(&h.body, proc_names, depth + 1, registry),
                 })
@@ -335,6 +336,28 @@ fn walk_try(
         );
     }
     Value::Object(result)
+}
+
+/// Canonicalise an `on` selector in the shared projection.  Tcl accepts its
+/// integer grammar here (including `02`, `+2`, and `0x2`); renderers must not
+/// reimplement it. Unknown symbolic selectors cannot be completion codes.
+fn handler_completion_code(handler: &TryHandler, registry: &CommandRegistry) -> Option<i32> {
+    if handler.kind != "on" {
+        return None;
+    }
+    match handler.match_arg.as_str() {
+        "ok" => Some(0),
+        "error" => Some(1),
+        "return" => Some(2),
+        "break" => Some(3),
+        "continue" => Some(4),
+        value => registry
+            .profile()
+            .and_then(|profile| {
+                tcl_syntax::number::Numbers::of_profile(Some(profile)).parse_wide(value)
+            })
+            .and_then(|value| i32::try_from(value).ok()),
+    }
 }
 
 /// Build the `if` flow-node dict from its clauses and optional `else` body.
@@ -816,6 +839,57 @@ mod tests {
             data.pointer("/procedures/0/flow/2/body/0/completion"),
             Some(&Value::String("dynamic".to_owned()))
         );
+    }
+
+    #[test]
+    fn handler_completion_codes_use_the_dialect_numeric_grammar() {
+        let source = "proc paths {} { try { return -options $options payload } on 02 {message options} { set two yes } on +2 {message options} { set duplicate yes } on 0x2 {message options} { set duplicate_hex yes } on return {message options} { set symbolic yes } on nonsense {message options} { set invalid yes } }";
+        // `try` itself begins in Tcl 8.6, so diagram handlers can only be
+        // projected for releases that provide the command.
+        for dialect in ["tcl8.6", "tcl9.0"] {
+            let data = diagram_data_for_dialect(
+                source,
+                tcl_registry::registry_for_dialect(dialect),
+                dialect,
+            );
+            let handlers = data
+                .pointer("/procedures/0/flow/0/handlers")
+                .and_then(Value::as_array)
+                .expect("try handlers");
+            let codes: Vec<_> = handlers
+                .iter()
+                .map(|handler| {
+                    handler
+                        .get("completion_code")
+                        .cloned()
+                        .unwrap_or(Value::Null)
+                })
+                .collect();
+            assert_eq!(
+                codes,
+                vec![
+                    Value::from(2),
+                    Value::from(2),
+                    Value::from(2),
+                    Value::from(2),
+                    Value::Null
+                ],
+                "{dialect}"
+            );
+        }
+    }
+
+    #[test]
+    fn handler_number_release_vectors_share_tcl_numeric_owner() {
+        for dialect in ["tcl8.4", "tcl8.6", "tcl9.0"] {
+            let profile = tcl_registry::registry_for_dialect(dialect)
+                .profile()
+                .expect("dialect profile");
+            let numbers = tcl_syntax::number::Numbers::of_profile(Some(profile));
+            assert_eq!(numbers.parse_wide("02"), Some(2), "{dialect}");
+            assert_eq!(numbers.parse_wide("+2"), Some(2), "{dialect}");
+            assert_eq!(numbers.parse_wide("0x2"), Some(2), "{dialect}");
+        }
     }
 
     #[test]

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -848,6 +848,31 @@ mod tests {
     }
 
     #[test]
+    fn literal_invalid_return_forms_project_as_catchable_errors() {
+        let source = r"
+            proc paths {} {
+                try { return -code bogus payload } on error {m o} {}
+                try { return -level -1 payload } on error {m o} {}
+                try { return -code } on error {m o} {}
+            }
+        ";
+        for dialect in ["tcl8.6", "tcl9.0"] {
+            let data = diagram_data_for_dialect(
+                source,
+                tcl_registry::registry_for_dialect(dialect),
+                dialect,
+            );
+            for index in 0..3 {
+                assert_eq!(
+                    data.pointer(&format!("/procedures/0/flow/{index}/body/0/completion")),
+                    Some(&Value::String("error".to_owned())),
+                    "{dialect}: {data}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn numeric_return_codes_project_as_their_canonical_completions() {
         let data = diagram_data_for_dialect(
             "proc paths {} { try { return -level 0 -code 00 x } finally {} ; try { return -level 0 -code +1 x } finally {} ; try { return -level 0 -code 02 x } finally {} ; try { return -level 0 -code 0x3 x } finally {} ; try { return -level 0 -code 04 x } finally {} }",

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -864,6 +864,16 @@ mod tests {
                     finally { lappend log finally }
                 return $log
             }
+            proc probe_custom_code {code} {
+                set log {}
+                try { return -options [list -code $code -level 0] payload } \
+                    on 42 {message options} { lappend log first-42 } \
+                    on 42 {message options} { lappend log duplicate-42 } \
+                    on 43 {message options} { lappend log code-43 } \
+                    on error {message options} { lappend log symbolic-error } \
+                    finally { lappend log finally }
+                return $log
+            }
             puts [probe {-code error}]
             puts [probe {-level 0 -code error}]
             puts [probe {-foo bar}]
@@ -879,6 +889,9 @@ mod tests {
                 {-code continue -level 0}
             } { puts [probe_dynamic_options $options] }
             puts [probe_source_order]
+            puts [probe_custom_code 42]
+            puts [probe_custom_code 43]
+            puts [probe_custom_code error]
         ";
         let mut child = Command::new("tclsh")
             .stdin(Stdio::piped())
@@ -902,6 +915,7 @@ mod tests {
                 "ok finally after\nerror finally after\nreturn finally after\n",
                 "break finally after\ncontinue finally after\n",
                 "broad-trap finally\n",
+                "first-42 finally\ncode-43 finally\nsymbolic-error finally\n",
             )
         );
     }

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -278,16 +278,58 @@ fn walk_call(
     None
 }
 
-/// Build a `loop` flow node with the given rendered label.
+/// Build a `loop` flow node with the given rendered label and exit reason.
 fn loop_node(
     label: &str,
+    exit: &str,
     body: &Script,
     proc_names: &HashSet<&str>,
     depth: usize,
     registry: &CommandRegistry,
 ) -> Value {
     let child = walk_script(body, proc_names, depth + 1, registry);
-    json!({ "kind": "loop", "label": label, "body": child })
+    json!({ "kind": "loop", "label": label, "exit": exit, "body": child })
+}
+
+/// Project the compiler's structured loop variants into one loop flow node.
+fn walk_loop_statement(
+    stmt: &Statement,
+    proc_names: &HashSet<&str>,
+    depth: usize,
+    registry: &CommandRegistry,
+) -> Option<Value> {
+    match stmt {
+        Statement::For { body, .. } => {
+            Some(loop_node("for", "false", body, proc_names, depth, registry))
+        }
+        Statement::While {
+            condition, body, ..
+        } => {
+            let label = format!("while {}", condition_text(condition));
+            Some(loop_node(
+                &label, "false", body, proc_names, depth, registry,
+            ))
+        }
+        Statement::Foreach {
+            iterators, body, ..
+        } => {
+            let vars_part = iterators
+                .iter()
+                .map(|it| it.vars.join(" "))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let label = format!("foreach {}", truncate(&vars_part, MAX_ARG_LEN));
+            Some(loop_node(
+                &label,
+                "exhausted",
+                body,
+                proc_names,
+                depth,
+                registry,
+            ))
+        }
+        _ => None,
+    }
 }
 
 /// Flow node for a notable assignment, or `None` when the value isn't notable.
@@ -345,25 +387,8 @@ fn walk_statement(
             registry,
         )),
 
-        Statement::For { body, .. } => Some(loop_node("for", body, proc_names, depth, registry)),
-
-        Statement::While {
-            condition, body, ..
-        } => {
-            let label = format!("while {}", condition_text(condition));
-            Some(loop_node(&label, body, proc_names, depth, registry))
-        }
-
-        Statement::Foreach {
-            iterators, body, ..
-        } => {
-            let vars_part = iterators
-                .iter()
-                .map(|it| it.vars.join(" "))
-                .collect::<Vec<_>>()
-                .join(", ");
-            let label = format!("foreach {}", truncate(&vars_part, MAX_ARG_LEN));
-            Some(loop_node(&label, body, proc_names, depth, registry))
+        Statement::For { .. } | Statement::While { .. } | Statement::Foreach { .. } => {
+            walk_loop_statement(stmt, proc_names, depth, registry)
         }
 
         Statement::Call {
@@ -526,4 +551,34 @@ pub fn diagram_data_for_dialect(source: &str, registry: &CommandRegistry, dialec
         .collect();
 
     json!({ "events": events, "procedures": procedures })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::diagram_data_for_dialect;
+
+    #[test]
+    fn loop_nodes_carry_their_compiler_exit_reason() {
+        let source = r"
+            proc loops {} {
+                while {$ready} { set seen [clock seconds] }
+                for {set i 0} {$i < 1} {incr i} { set seen [clock seconds] }
+                foreach item $items { set seen [clock seconds] }
+            }
+        ";
+        let data = diagram_data_for_dialect(
+            source,
+            tcl_registry::registry_for_dialect("tcl8.6"),
+            "tcl8.6",
+        );
+        let flow = data
+            .pointer("/procedures/0/flow")
+            .and_then(serde_json::Value::as_array)
+            .expect("procedure flow");
+        let exits: Vec<_> = flow
+            .iter()
+            .map(|node| node.get("exit").and_then(serde_json::Value::as_str))
+            .collect();
+        assert_eq!(exits, vec![Some("false"), Some("false"), Some("exhausted")]);
+    }
 }

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -842,6 +842,31 @@ mod tests {
     }
 
     #[test]
+    fn numeric_return_codes_project_as_their_canonical_completions() {
+        let data = diagram_data_for_dialect(
+            "proc paths {} { try { return -level 0 -code 00 x } finally {} ; try { return -level 0 -code +1 x } finally {} ; try { return -level 0 -code 02 x } finally {} ; try { return -level 0 -code 0x3 x } finally {} ; try { return -level 0 -code 04 x } finally {} }",
+            tcl_registry::registry_for_dialect("tcl8.6"),
+            "tcl8.6",
+        );
+        let expected = [
+            None,
+            Some("error"),
+            Some("return"),
+            Some("break"),
+            Some("continue"),
+        ];
+        for (index, completion) in expected.into_iter().enumerate() {
+            assert_eq!(
+                data.pointer(&format!("/procedures/0/flow/{index}/body/0/completion")),
+                completion
+                    .map(|value| Value::String(value.to_owned()))
+                    .as_ref(),
+                "flow {index}"
+            );
+        }
+    }
+
+    #[test]
     fn handler_completion_codes_use_the_dialect_numeric_grammar() {
         let source = "proc paths {} { try { return -options $options payload } on 02 {message options} { set two yes } on +2 {message options} { set duplicate yes } on 0x2 {message options} { set duplicate_hex yes } on return {message options} { set symbolic yes } on 2147483648 {message options} { set wrapped_min yes } on 4294967295 {message options} { set wrapped_minus_one yes } on -2147483649 {message options} { set invalid_low yes } on nonsense {message options} { set invalid yes } }";
         // `try` itself begins in Tcl 8.6, so diagram handlers can only be

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -327,6 +327,7 @@ fn walk_try(
                     "kind_handler": h.kind,
                     "match": h.match_arg,
                     "completion_code": handler_completion_code(h, registry),
+                    "trap_pattern": trap_pattern_elements(h),
                     "fallthrough": h.fallthrough,
                     "body": walk_script(&h.body, proc_names, depth + 1, registry),
                 })
@@ -341,6 +342,21 @@ fn walk_try(
         );
     }
     Value::Object(result)
+}
+
+/// A literal `trap` selector is a Tcl list, not whitespace-separated text.
+/// Dynamic substitutions and malformed lists remain null so consumers retain
+/// conservative routing rather than inventing list boundaries.
+fn trap_pattern_elements(handler: &TryHandler) -> Option<Vec<String>> {
+    (handler.kind == "trap")
+        .then(|| tcl_syntax::list::split_list(&handler.match_arg).ok())
+        .flatten()
+        .filter(|elements| {
+            !elements
+                .iter()
+                .any(|element| element.contains('$') || element.contains('['))
+        })
+        .map(|elements| elements.into_iter().map(Into::into).collect())
 }
 
 /// Canonicalise an `on` selector in the shared projection.  Tcl accepts its
@@ -705,7 +721,7 @@ pub fn diagram_data_for_dialect(source: &str, registry: &CommandRegistry, dialec
 #[cfg(test)]
 mod tests {
     use super::diagram_data_for_dialect;
-    use serde_json::Value;
+    use serde_json::{Value, json};
     use std::io::Write;
     use std::process::{Command, Stdio};
 
@@ -931,6 +947,23 @@ mod tests {
                 "{dialect}"
             );
         }
+    }
+
+    #[test]
+    fn trap_patterns_are_projected_as_tcl_list_elements() {
+        let data = diagram_data_for_dialect(
+            "proc paths {} { try { error x } trap {A {B C}} {message options} {} trap {A \"B C\"} {message options} {} }",
+            tcl_registry::registry_for_dialect("tcl8.6"),
+            "tcl8.6",
+        );
+        assert_eq!(
+            data.pointer("/procedures/0/flow/0/handlers/0/trap_pattern"),
+            Some(&json!(["A", "B C"]))
+        );
+        assert_eq!(
+            data.pointer("/procedures/0/flow/0/handlers/1/trap_pattern"),
+            Some(&json!(["A", "B C"]))
+        );
     }
 
     #[test]

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -875,7 +875,31 @@ mod tests {
             proc paths {} {
                 try { return -code bogus payload } on error {m o} {}
                 try { return -level -1 payload } on error {m o} {}
-                try { return -code } on error {m o} {}
+            }
+        ";
+        for dialect in ["tcl8.6", "tcl9.0"] {
+            let data = diagram_data_for_dialect(
+                source,
+                tcl_registry::registry_for_dialect(dialect),
+                dialect,
+            );
+            for index in 0..2 {
+                assert_eq!(
+                    data.pointer(&format!("/procedures/0/flow/{index}/body/0/completion")),
+                    Some(&Value::String("error".to_owned())),
+                    "{dialect}: {data}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn trailing_return_option_words_are_results_not_missing_values() {
+        let source = r"
+            proc paths {} {
+                try { return -code } on return {m o} {}
+                try { return -level } on return {m o} {}
+                try { return -options } on return {m o} {}
             }
         ";
         for dialect in ["tcl8.6", "tcl9.0"] {
@@ -885,6 +909,32 @@ mod tests {
                 dialect,
             );
             for index in 0..3 {
+                assert_eq!(
+                    data.pointer(&format!("/procedures/0/flow/{index}/body/0/completion")),
+                    Some(&Value::String("return".to_owned())),
+                    "{dialect}: {data}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn invalid_known_terminator_arity_projects_as_catchable_error() {
+        let source = r"
+            proc paths {} {
+                try { error } on error {m o} { set caught_error yes }
+                try { throw TYPE } on error {m o} { set caught_throw yes }
+                try { break extra } on error {m o} { set caught_break yes }
+                try { exit 0 extra } on error {m o} { set caught_exit yes }
+            }
+        ";
+        for dialect in ["tcl8.6", "tcl9.0"] {
+            let data = diagram_data_for_dialect(
+                source,
+                tcl_registry::registry_for_dialect(dialect),
+                dialect,
+            );
+            for index in 0..4 {
                 assert_eq!(
                     data.pointer(&format!("/procedures/0/flow/{index}/body/0/completion")),
                     Some(&Value::String("error".to_owned())),

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -32,11 +32,86 @@ use tcl_compiler::compilation_unit::CompilationUnit;
 use tcl_compiler::expr_ast::{ExprNode, render_expr};
 use tcl_compiler::ir::{Procedure, Script, Statement, SwitchArm, TryHandler, when_event_name};
 use tcl_registry::CommandRegistry;
+use tcl_registry::completion::{CompletionCode, CompletionCodeDomain};
+use tcl_registry::dialects::DialectSet;
 use tcl_registry::events::EventRegistry;
+use tcl_registry::registry::InvocationCompletion;
 
 const MAX_DEPTH: usize = 8;
 const MAX_EVENTS: usize = 12;
 const MAX_ARG_LEN: usize = 60;
+
+/// A statically-known Tcl completion carried by the diagram JSON contract.
+///
+/// This is deliberately smaller than Tcl's complete result/options triple:
+/// diagrams only need to know whether a path can continue after a `try`'s
+/// `finally` body.  `normal` is omitted from the JSON for compatibility;
+/// every other value is emitted as a node's `completion` field.  Unknown
+/// invocations stay normal in this structural projection rather than being
+/// guessed to be an error or an exit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DiagramCompletion {
+    Normal,
+    Error,
+    Return,
+    Break,
+    Continue,
+    Terminal,
+}
+
+impl DiagramCompletion {
+    const fn as_str(self) -> Option<&'static str> {
+        match self {
+            Self::Normal => None,
+            Self::Error => Some("error"),
+            Self::Return => Some("return"),
+            Self::Break => Some("break"),
+            Self::Continue => Some("continue"),
+            Self::Terminal => Some("terminal"),
+        }
+    }
+}
+
+/// The exact registry completion for a concrete command, if one is known.
+///
+/// Keep this at the IR → diagram boundary.  Rendering must not infer that a
+/// command called `error`, `return`, or `break` has a particular effect: an
+/// alias is already recorded in `canonical_command`, and the registry owns
+/// the effective completion descriptor and terminating traits.
+fn command_completion(
+    command: &str,
+    args: &[String],
+    registry: &CommandRegistry,
+) -> DiagramCompletion {
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    if let Some(resolved) = registry.resolve_call(command, &arg_refs, DialectSet::empty())
+        && let Some(descriptor) = resolved
+            .form
+            .and_then(|form| form.completion)
+            .or(resolved.sub.and_then(|sub| sub.completion))
+            .or(resolved.spec.completion)
+        && let CompletionCodeDomain::Exact(codes) = descriptor.codes
+        && codes.len() == 1
+    {
+        return match codes[0] {
+            CompletionCode::Ok => DiagramCompletion::Normal,
+            CompletionCode::Error => DiagramCompletion::Error,
+            CompletionCode::Return => DiagramCompletion::Return,
+            CompletionCode::Break => DiagramCompletion::Break,
+            CompletionCode::Continue => DiagramCompletion::Continue,
+            CompletionCode::Other(_) => DiagramCompletion::Terminal,
+        };
+    }
+    match registry.invocation_completion(command, &arg_refs, DialectSet::empty()) {
+        InvocationCompletion::ReturnsResult(_) => DiagramCompletion::Return,
+        InvocationCompletion::Terminates => DiagramCompletion::Terminal,
+        // Dynamic completion options are not enough evidence to draw a
+        // terminal path.  Leave such calls as ordinary structural actions.
+        InvocationCompletion::FallsThrough | InvocationCompletion::Unknown => {
+            DiagramCompletion::Normal
+        }
+    }
+}
 
 /// Truncate to `limit` characters with a trailing `...`
 /// (slices by code point, so this counts/takes `char`s).
@@ -146,6 +221,16 @@ fn action_node(display: &str, args: &[String]) -> Value {
     })
 }
 
+/// Add the optional completion field to an action-like node.
+fn with_completion(mut node: Value, completion: DiagramCompletion) -> Value {
+    if let Some(completion) = completion.as_str()
+        && let Some(object) = node.as_object_mut()
+    {
+        object.insert("completion".to_owned(), json!(completion));
+    }
+    node
+}
+
 /// Build the `switch` flow-node dict from its subject, arms and default body.
 fn walk_switch(
     subject: &str,
@@ -205,6 +290,7 @@ fn walk_try(
                 json!({
                     "kind_handler": h.kind,
                     "match": h.match_arg,
+                    "fallthrough": h.fallthrough,
                     "body": walk_script(&h.body, proc_names, depth + 1, registry),
                 })
             })
@@ -271,9 +357,13 @@ fn walk_call(
             "command": display,
         }));
     }
-    // Notable action commands.
-    if registry.is_diagram_action(canonical) {
-        return Some(action_node(display, args));
+    let completion = command_completion(canonical, args, registry);
+    // Keep an exact non-normal completion visible even when it is not a
+    // diagram action (for example `error` / `throw`), so a surrounding try
+    // can route it through `finally`.  Ordinary unknown calls remain omitted
+    // unless the registry marks them as a diagram action.
+    if registry.is_diagram_action(canonical) || completion != DiagramCompletion::Normal {
+        return Some(with_completion(action_node(display, args), completion));
     }
     None
 }
@@ -347,7 +437,7 @@ fn return_node(value: Option<&String>) -> Value {
         label.push(' ');
         label.push_str(&truncate(v, MAX_ARG_LEN));
     }
-    json!({ "kind": "return", "label": label })
+    json!({ "kind": "return", "label": label, "completion": "return" })
 }
 
 /// Convert one IR statement to a flow-node dict, or `None` to skip it.
@@ -411,9 +501,9 @@ fn walk_statement(
             ..
         } => {
             let canonical = canonical_command.as_deref().unwrap_or(command.as_str());
-            registry
-                .is_diagram_action(canonical)
-                .then(|| action_node(command, args))
+            let completion = command_completion(canonical, args, registry);
+            (registry.is_diagram_action(canonical) || completion != DiagramCompletion::Normal)
+                .then(|| with_completion(action_node(command, args), completion))
         }
 
         Statement::Return { value, .. } => Some(return_node(value.as_ref())),
@@ -556,6 +646,7 @@ pub fn diagram_data_for_dialect(source: &str, registry: &CommandRegistry, dialec
 #[cfg(test)]
 mod tests {
     use super::diagram_data_for_dialect;
+    use serde_json::Value;
 
     #[test]
     fn loop_nodes_carry_their_compiler_exit_reason() {
@@ -580,5 +671,61 @@ mod tests {
             .map(|node| node.get("exit").and_then(serde_json::Value::as_str))
             .collect();
         assert_eq!(exits, vec![Some("false"), Some("false"), Some("exhausted")]);
+    }
+
+    #[test]
+    fn try_projection_carries_exact_completions_and_handler_fallthrough() {
+        let data = diagram_data_for_dialect(
+            r"
+                proc paths {} {
+                    try { error boom } on error message - on return value {
+                        set recovered [clock seconds]
+                    } finally {
+                        set cleaned [clock seconds]
+                    }
+                    set after [clock seconds]
+                }
+            ",
+            tcl_registry::registry_for_dialect("tcl8.6"),
+            "tcl8.6",
+        );
+        let try_node = data.pointer("/procedures/0/flow/0").expect("try node");
+        assert_eq!(try_node["kind"], "try");
+        assert_eq!(try_node["body"][0]["completion"], "error");
+        assert_eq!(try_node["handlers"][0]["fallthrough"], true);
+        assert_eq!(try_node["handlers"][1]["fallthrough"], false);
+        assert_eq!(try_node["finally"][0]["kind"], "assign");
+        assert_eq!(try_node["finally"][0].get("completion"), None);
+
+        // The following action remains in the projection; it is the renderer
+        // that selects it only for the normal/handled completion paths.
+        let flow = data
+            .pointer("/procedures/0/flow")
+            .and_then(Value::as_array)
+            .unwrap();
+        assert_eq!(flow[1]["value"], "[clock seconds]");
+    }
+
+    #[test]
+    fn return_projection_is_an_explicit_completion_not_a_renderer_guess() {
+        let data = diagram_data_for_dialect(
+            "proc paths {} { try { return stop } finally { set cleaned [clock seconds] } }",
+            tcl_registry::registry_for_dialect("tcl8.6"),
+            "tcl8.6",
+        );
+        assert_eq!(
+            data.pointer("/procedures/0/flow/0/body/0/completion"),
+            Some(&Value::String("return".to_owned()))
+        );
+
+        let overridden = diagram_data_for_dialect(
+            "proc paths {} { try { set done [clock seconds] } finally { return stop } }",
+            tcl_registry::registry_for_dialect("tcl8.6"),
+            "tcl8.6",
+        );
+        assert_eq!(
+            overridden.pointer("/procedures/0/flow/0/finally/0/completion"),
+            Some(&Value::String("return".to_owned()))
+        );
     }
 }

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -57,6 +57,7 @@ enum DiagramCompletion {
     Continue,
     Dynamic,
     DynamicReturnOrError,
+    ExactCustom(i32),
     ProcessExit,
     Terminal,
 }
@@ -71,6 +72,7 @@ impl DiagramCompletion {
             Self::Continue => Some("continue"),
             Self::Dynamic => Some("dynamic"),
             Self::DynamicReturnOrError => Some("dynamic_return_or_error"),
+            Self::ExactCustom(_) => Some("custom"),
             Self::ProcessExit => Some("process_exit"),
             Self::Terminal => Some("terminal"),
         }
@@ -108,8 +110,8 @@ fn command_completion(
             ExactInvocationCompletion::Tcl(tcl_registry::CompletionCode::Continue) => {
                 DiagramCompletion::Continue
             }
-            ExactInvocationCompletion::Tcl(tcl_registry::CompletionCode::Other(_)) => {
-                DiagramCompletion::Terminal
+            ExactInvocationCompletion::Tcl(tcl_registry::CompletionCode::Other(code)) => {
+                DiagramCompletion::ExactCustom(code)
             }
             ExactInvocationCompletion::ProcessExit => DiagramCompletion::ProcessExit,
         };
@@ -254,10 +256,13 @@ fn action_node(display: &str, args: &[String]) -> Value {
 
 /// Add the optional completion field to an action-like node.
 fn with_completion(mut node: Value, completion: DiagramCompletion) -> Value {
-    if let Some(completion) = completion.as_str()
+    if let Some(completion_str) = completion.as_str()
         && let Some(object) = node.as_object_mut()
     {
-        object.insert("completion".to_owned(), json!(completion));
+        object.insert("completion".to_owned(), json!(completion_str));
+        if let DiagramCompletion::ExactCustom(code) = completion {
+            object.insert("completion_code".to_owned(), json!(code));
+        }
     }
     node
 }
@@ -867,6 +872,27 @@ mod tests {
     }
 
     #[test]
+    fn exact_custom_return_codes_keep_their_integer_payload() {
+        let data = diagram_data_for_dialect(
+            "proc paths {} { try { return -level 0 -code 42 x } finally {} ; try { return -level 0 -code 4294967295 x } finally {} }",
+            tcl_registry::registry_for_dialect("tcl8.6"),
+            "tcl8.6",
+        );
+        assert_eq!(
+            data.pointer("/procedures/0/flow/0/body/0/completion"),
+            Some(&Value::String("custom".to_owned()))
+        );
+        assert_eq!(
+            data.pointer("/procedures/0/flow/0/body/0/completion_code"),
+            Some(&Value::from(42))
+        );
+        assert_eq!(
+            data.pointer("/procedures/0/flow/1/body/0/completion_code"),
+            Some(&Value::from(-1))
+        );
+    }
+
+    #[test]
     fn handler_completion_codes_use_the_dialect_numeric_grammar() {
         let source = "proc paths {} { try { return -options $options payload } on 02 {message options} { set two yes } on +2 {message options} { set duplicate yes } on 0x2 {message options} { set duplicate_hex yes } on return {message options} { set symbolic yes } on 2147483648 {message options} { set wrapped_min yes } on 4294967295 {message options} { set wrapped_minus_one yes } on -2147483649 {message options} { set invalid_low yes } on nonsense {message options} { set invalid yes } }";
         // `try` itself begins in Tcl 8.6, so diagram handlers can only be
@@ -992,6 +1018,7 @@ mod tests {
                     on 42 {message options} { lappend log first-42 } \
                     on 42 {message options} { lappend log duplicate-42 } \
                     on 43 {message options} { lappend log code-43 } \
+                    on -1 {message options} { lappend log minus-one } \
                     on error {message options} { lappend log symbolic-error } \
                     finally { lappend log finally }
                 return $log
@@ -1013,6 +1040,7 @@ mod tests {
             puts [probe_source_order]
             puts [probe_custom_code 42]
             puts [probe_custom_code 43]
+            puts [probe_custom_code 4294967295]
             puts [probe_custom_code error]
         ";
         let mut child = Command::new("tclsh")
@@ -1037,7 +1065,7 @@ mod tests {
                 "ok finally after\nerror finally after\nreturn finally after\n",
                 "break finally after\ncontinue finally after\n",
                 "broad-trap finally\n",
-                "first-42 finally\ncode-43 finally\nsymbolic-error finally\n",
+                "first-42 finally\ncode-43 finally\nminus-one finally\nsymbolic-error finally\n",
             )
         );
     }

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -63,6 +63,7 @@ enum DiagramCompletion {
     Continue,
     Dynamic,
     DynamicReturnOrError,
+    ExitOrError,
     ExactCustom(i32),
     ProcessExit,
     Terminal,
@@ -78,6 +79,7 @@ impl DiagramCompletion {
             Self::Continue => Some("continue"),
             Self::Dynamic => Some("dynamic"),
             Self::DynamicReturnOrError => Some("dynamic_return_or_error"),
+            Self::ExitOrError => Some("exit_or_error"),
             Self::ExactCustom(_) => Some("custom"),
             Self::ProcessExit => Some("process_exit"),
             Self::Terminal => Some("terminal"),
@@ -150,6 +152,7 @@ fn command_completion(
             InvocationCompletionKnowledge::DynamicReturnOrError => {
                 DiagramCompletion::DynamicReturnOrError
             }
+            InvocationCompletionKnowledge::ExitOrError => DiagramCompletion::ExitOrError,
             InvocationCompletionKnowledge::Dynamic => DiagramCompletion::Dynamic,
         };
     }
@@ -867,6 +870,33 @@ mod tests {
             data.pointer("/procedures/0/flow/2/body/0/completion"),
             Some(&Value::String("dynamic".to_owned()))
         );
+    }
+
+    #[test]
+    fn exit_statuses_project_exact_error_and_typed_dynamic_outcomes() {
+        for dialect in ["tcl8.6", "tcl9.0"] {
+            let data = diagram_data_for_dialect(
+                r"
+                    proc paths {status} {
+                        try { exit nope } on error {message options} { set caught yes } finally { set cleaned yes }
+                        try { exit $status } on error {message options} { set caught_dynamic yes } finally { set cleaned_dynamic yes }
+                        set after yes
+                    }
+                ",
+                tcl_registry::registry_for_dialect(dialect),
+                dialect,
+            );
+            assert_eq!(
+                data.pointer("/procedures/0/flow/0/body/0/completion"),
+                Some(&Value::String("error".to_owned())),
+                "{dialect}: static invalid exit is a Tcl error"
+            );
+            assert_eq!(
+                data.pointer("/procedures/0/flow/1/body/0/completion"),
+                Some(&Value::String("exit_or_error".to_owned())),
+                "{dialect}: dynamic exit has no ordinary completion"
+            );
+        }
     }
 
     #[test]

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -32,10 +32,9 @@ use tcl_compiler::compilation_unit::CompilationUnit;
 use tcl_compiler::expr_ast::{ExprNode, render_expr};
 use tcl_compiler::ir::{Procedure, Script, Statement, SwitchArm, TryHandler, when_event_name};
 use tcl_registry::CommandRegistry;
-use tcl_registry::completion::{CompletionCode, CompletionCodeDomain};
 use tcl_registry::dialects::DialectSet;
 use tcl_registry::events::EventRegistry;
-use tcl_registry::registry::InvocationCompletion;
+use tcl_registry::registry::{ExactInvocationCompletion, InvocationCompletion};
 
 const MAX_DEPTH: usize = 8;
 const MAX_EVENTS: usize = 12;
@@ -56,6 +55,7 @@ enum DiagramCompletion {
     Return,
     Break,
     Continue,
+    ProcessExit,
     Terminal,
 }
 
@@ -67,6 +67,7 @@ impl DiagramCompletion {
             Self::Return => Some("return"),
             Self::Break => Some("break"),
             Self::Continue => Some("continue"),
+            Self::ProcessExit => Some("process_exit"),
             Self::Terminal => Some("terminal"),
         }
     }
@@ -84,22 +85,29 @@ fn command_completion(
     registry: &CommandRegistry,
 ) -> DiagramCompletion {
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-    if let Some(resolved) = registry.resolve_call(command, &arg_refs, DialectSet::empty())
-        && let Some(descriptor) = resolved
-            .form
-            .and_then(|form| form.completion)
-            .or(resolved.sub.and_then(|sub| sub.completion))
-            .or(resolved.spec.completion)
-        && let CompletionCodeDomain::Exact(codes) = descriptor.codes
-        && codes.len() == 1
+    if let Some(completion) =
+        registry.exact_invocation_completion(command, &arg_refs, DialectSet::empty())
     {
-        return match codes[0] {
-            CompletionCode::Ok => DiagramCompletion::Normal,
-            CompletionCode::Error => DiagramCompletion::Error,
-            CompletionCode::Return => DiagramCompletion::Return,
-            CompletionCode::Break => DiagramCompletion::Break,
-            CompletionCode::Continue => DiagramCompletion::Continue,
-            CompletionCode::Other(_) => DiagramCompletion::Terminal,
+        return match completion {
+            ExactInvocationCompletion::Tcl(tcl_registry::CompletionCode::Ok) => {
+                DiagramCompletion::Normal
+            }
+            ExactInvocationCompletion::Tcl(tcl_registry::CompletionCode::Error) => {
+                DiagramCompletion::Error
+            }
+            ExactInvocationCompletion::Tcl(tcl_registry::CompletionCode::Return) => {
+                DiagramCompletion::Return
+            }
+            ExactInvocationCompletion::Tcl(tcl_registry::CompletionCode::Break) => {
+                DiagramCompletion::Break
+            }
+            ExactInvocationCompletion::Tcl(tcl_registry::CompletionCode::Continue) => {
+                DiagramCompletion::Continue
+            }
+            ExactInvocationCompletion::Tcl(tcl_registry::CompletionCode::Other(_)) => {
+                DiagramCompletion::Terminal
+            }
+            ExactInvocationCompletion::ProcessExit => DiagramCompletion::ProcessExit,
         };
     }
     match registry.invocation_completion(command, &arg_refs, DialectSet::empty()) {
@@ -647,6 +655,8 @@ pub fn diagram_data_for_dialect(source: &str, registry: &CommandRegistry, dialec
 mod tests {
     use super::diagram_data_for_dialect;
     use serde_json::Value;
+    use std::io::Write;
+    use std::process::{Command, Stdio};
 
     #[test]
     fn loop_nodes_carry_their_compiler_exit_reason() {
@@ -726,6 +736,69 @@ mod tests {
         assert_eq!(
             overridden.pointer("/procedures/0/flow/0/finally/0/completion"),
             Some(&Value::String("return".to_owned()))
+        );
+    }
+
+    #[test]
+    fn literal_return_options_and_exit_keep_distinct_try_outcomes() {
+        let data = diagram_data_for_dialect(
+            r"
+                proc paths {} {
+                    try { return -code error payload } finally { set cleaned [clock seconds] }
+                    try { return -level 0 -code error payload } finally { set cleaned [clock seconds] }
+                    try { exit 0 } finally { set never [clock seconds] }
+                }
+            ",
+            tcl_registry::registry_for_dialect("tcl8.6"),
+            "tcl8.6",
+        );
+        // Tcl's default `return -level 1` is itself TCL_RETURN inside the
+        // enclosing try; only level 0 exposes the configured error code.
+        assert_eq!(
+            data.pointer("/procedures/0/flow/0/body/0/completion"),
+            Some(&Value::String("return".to_owned()))
+        );
+        assert_eq!(
+            data.pointer("/procedures/0/flow/1/body/0/completion"),
+            Some(&Value::String("error".to_owned()))
+        );
+        assert_eq!(
+            data.pointer("/procedures/0/flow/2/body/0/completion"),
+            Some(&Value::String("process_exit".to_owned()))
+        );
+    }
+
+    #[test]
+    fn real_tcl_oracle_distinguishes_default_and_level_zero_return_codes() {
+        let script = r"
+            proc probe {spec} {
+                set log {}
+                try { return {*}$spec payload } \
+                    on error {message options} { lappend log error } \
+                    on return {message options} { lappend log return } \
+                    finally { lappend log finally }
+                lappend log after
+                return $log
+            }
+            puts [probe {-code error}]
+            puts [probe {-level 0 -code error}]
+        ";
+        let mut child = Command::new("tclsh")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("tclsh oracle available");
+        child
+            .stdin
+            .as_mut()
+            .expect("oracle stdin")
+            .write_all(script.as_bytes())
+            .expect("write oracle script");
+        let output = child.wait_with_output().expect("wait for tclsh oracle");
+        assert!(output.status.success(), "{output:?}");
+        assert_eq!(
+            String::from_utf8(output.stdout).expect("oracle stdout"),
+            "return finally after\nerror finally after\n"
         );
     }
 }

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -965,6 +965,24 @@ mod tests {
     }
 
     #[test]
+    fn trap_pattern_projection_preserves_the_dialect_escape_value() {
+        let source =
+            r#"proc paths {} { try { error x } trap "A \U0001F600" {message options} {} }"#;
+        for (dialect, expected) in [("tcl8.6", "\u{fffd}"), ("tcl9.0", "😀")] {
+            let data = diagram_data_for_dialect(
+                source,
+                tcl_registry::registry_for_dialect(dialect),
+                dialect,
+            );
+            assert_eq!(
+                data.pointer("/procedures/0/flow/0/handlers/0/trap_pattern"),
+                Some(&json!(["A", expected])),
+                "{dialect}: {data}",
+            );
+        }
+    }
+
+    #[test]
     fn handler_number_release_vectors_share_tcl_numeric_owner() {
         for dialect in ["tcl8.4", "tcl8.6", "tcl9.0"] {
             let profile = tcl_registry::registry_for_dialect(dialect)

--- a/rust/tcl-lsp-core/src/executable_regions.rs
+++ b/rust/tcl-lsp-core/src/executable_regions.rs
@@ -246,3 +246,19 @@ fn command_substitution_regions(
         _ => Vec::new(),
     }
 }
+
+/// Whether `cursor` is inside an active command substitution within `token`.
+///
+/// Consumers that inspect the containing word must defer to the recursively
+/// executable command in this case: a widened quoted or compound token is not
+/// a literal fragment at a position Tcl evaluates as `[...]`.
+pub(crate) fn cursor_in_command_substitution(
+    source: &str,
+    config: LexerConfig,
+    token: Token,
+    cursor: u32,
+) -> bool {
+    command_substitution_regions(source, config, token)
+        .into_iter()
+        .any(|(start, end)| cursor as usize >= start && (cursor as usize) < end)
+}

--- a/rust/tcl-lsp-core/src/executable_regions.rs
+++ b/rust/tcl-lsp-core/src/executable_regions.rs
@@ -115,6 +115,19 @@ impl<F: FnMut(&SegmentedCommand, HeadWords<'_>) -> bool> ExecutableWalker<'_, F>
                 .case_invocation(head.resolved, &args, self.availability)
                 .and_then(|(spec, invocation)| invocation.clause_list_index.map(|i| (spec, i)));
 
+            // A case-list descriptor owns its nested scripts even when the
+            // outer list word has no generic `ArgRole::Body`.  In particular,
+            // Expect's descriptor supplies its clause bodies directly rather
+            // than duplicating that grammar as a flat argument role.
+            if let Some((spec, case_index)) = case_list
+                && let (Some(&token), Some(list)) =
+                    (command.arg_tokens().get(case_index), args.get(case_index))
+                && token.kind == TokenType::Str
+                && self.case_list_regions(token, list, &spec, depth, next_grammar)
+            {
+                return true;
+            }
+
             for index in body_indices {
                 let Some(&token) = command.arg_tokens().get(index) else {
                     continue;
@@ -122,13 +135,10 @@ impl<F: FnMut(&SegmentedCommand, HeadWords<'_>) -> bool> ExecutableWalker<'_, F>
                 if token.kind != TokenType::Str {
                     continue;
                 }
-                if let Some((spec, case_index)) = case_list
-                    && case_index == index
-                {
-                    if self.case_list_regions(token, &spec, depth, next_grammar) {
-                        return true;
-                    }
-                } else if let Some((body_start, body_end)) = braced_body_region(self.source, token)
+                if case_list.is_some_and(|(_, case_index)| case_index == index) {
+                    continue;
+                }
+                if let Some((body_start, body_end)) = braced_body_region(self.source, token)
                     && self.region(body_start, body_end, depth + 1, next_grammar)
                 {
                     return true;
@@ -158,34 +168,52 @@ impl<F: FnMut(&SegmentedCommand, HeadWords<'_>) -> bool> ExecutableWalker<'_, F>
     fn case_list_regions(
         &mut self,
         token: Token,
+        list: &str,
         spec: &tcl_registry::CaseListSpec,
         depth: u32,
         grammar: Option<&'static DefinitionBodyGrammar>,
     ) -> bool {
-        let content_start = token.span.start() as usize + token.content_offset as usize;
-        let content_end = token.span.end() as usize;
-        let Some(list) = self.source.get(content_start..content_end) else {
-            return false;
-        };
-        let shape = tcl_syntax::case_list::CaseListShape {
-            clause_flags: spec.clause_flags,
-            clause_value_flags: spec.clause_value_flags,
-        };
-        for clause in tcl_syntax::case_list::split_case_list(list, &shape) {
-            let Some(body) = clause.body.filter(|body| body.braced) else {
+        // The compiler-owned flattener is the source-coordinate bridge between
+        // a Tcl list element and a source token.  Besides braced actions, it
+        // marks a substitution-free quoted action as `Str`; dynamic and
+        // backslash-built actions remain opaque, so this traversal cannot
+        // invent a statically executable body.
+        for (_, (body_text, body_token)) in
+            tcl_compiler::segmenter::flatten_case_list_clauses(self.source, list, token, spec)
+        {
+            if spec.fallthrough_body == Some(body_text.as_str()) {
+                continue;
+            }
+            let Some((start, end)) = case_action_region(self.source, body_token) else {
                 continue;
             };
-            // The list splitter's end sits on the closing brace; give the
-            // segmenter just the verbatim body content, still in whole-file
-            // coordinates.
-            let start = content_start + body.start + 1;
-            let end = content_start + body.end;
             if self.region(start, end, depth + 1, grammar) {
                 return true;
             }
         }
         false
     }
+}
+
+/// Return a statically executable case action's verbatim script region.
+///
+/// [`tcl_compiler::segmenter::flatten_case_list_clauses`] only gives a
+/// `TokenType::Str` body token to an action that it proved literal.  List
+/// elements may still be braced, quoted, or bare, so strip their opening
+/// delimiter here while retaining the segmenter's absolute spans.  The list
+/// parser's token end is already the byte at the closing delimiter.
+fn case_action_region(source: &str, token: Token) -> Option<(usize, usize)> {
+    if token.kind != TokenType::Str {
+        return None;
+    }
+    let start = token.span.start() as usize;
+    let end = token.span.end() as usize;
+    if start >= end || end > source.len() {
+        return None;
+    }
+    let bytes = source.as_bytes();
+    let start = start + usize::from(matches!(bytes.get(start), Some(b'{' | b'"')));
+    (start < end).then_some((start, end))
 }
 
 /// Return a braced body's verbatim source content, excluding delimiters.
@@ -261,4 +289,90 @@ pub(crate) fn cursor_in_command_substitution(
     command_substitution_regions(source, config, token)
         .into_iter()
         .any(|(start, end)| cursor as usize >= start && (cursor as usize) < end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn visited_format_heads(source: &str, dialect: &str) -> Vec<(String, String, u32)> {
+        let profile = tcl_dialect::DialectProfile::by_name(dialect);
+        let registry = tcl_registry::registry_for_profile(profile);
+        let config = LexerConfig::for_file_dialect(profile.name);
+        let identities = tcl_compiler::head_identity::command_head_identities_with_config(
+            source, config, registry,
+        );
+        let mut heads = Vec::new();
+        visit_executable_commands(
+            source,
+            config,
+            registry,
+            profile.availability_mask,
+            &identities,
+            &mut |command, identity| {
+                if command.name() == "format" || command.name() == "fmt" {
+                    heads.push((
+                        identity.written.to_owned(),
+                        identity.resolved.to_owned(),
+                        command.span.start(),
+                    ));
+                }
+                false
+            },
+        );
+        heads
+    }
+
+    #[test]
+    fn quoted_case_actions_retain_absolute_spans_for_each_registry_descriptor() {
+        for (source, dialect, written) in [
+            ("switch $x {a \"format {%d} 1\"}", "tcl8.6", "format"),
+            ("expect {-re {ready} \"format {%d} 1\"}", "expect", "format"),
+        ] {
+            let heads = visited_format_heads(source, dialect);
+            assert_eq!(
+                heads,
+                vec![(
+                    written.to_owned(),
+                    "format".to_owned(),
+                    u32::try_from(source.rfind(written).expect("nested head")).unwrap(),
+                ),],
+                "quoted case action must preserve its whole-document command span: {source}"
+            );
+        }
+    }
+
+    #[test]
+    fn quoted_case_actions_preserve_identity_and_abstain_for_dynamic_or_malformed_lists() {
+        let aliased = "interp alias {} fmt {} format\nswitch $x {a \"fmt {%d} 1\"}";
+        assert_eq!(
+            visited_format_heads(aliased, "tcl8.6"),
+            vec![(
+                "fmt".to_owned(),
+                "format".to_owned(),
+                u32::try_from(aliased.rfind("fmt").expect("nested alias")).unwrap(),
+            )]
+        );
+
+        let renamed = "rename format saved\nswitch $x {a \"format {%d} 1\"}";
+        assert_eq!(
+            visited_format_heads(renamed, "tcl8.6"),
+            vec![(
+                "format".to_owned(),
+                String::new(),
+                u32::try_from(renamed.rfind("format").expect("nested head")).unwrap(),
+            )],
+            "the nested call remains executable but must not reclaim a renamed builtin"
+        );
+
+        for source in [
+            "set actions {a \"format {%d} 1\"}\nswitch $x $actions",
+            "switch $x {a \"format {%d} 1\" orphan}",
+        ] {
+            assert!(
+                visited_format_heads(source, "tcl8.6").is_empty(),
+                "dynamic and malformed lists must not expose nested actions: {source}"
+            );
+        }
+    }
 }

--- a/rust/tcl-lsp-core/src/executable_regions.rs
+++ b/rust/tcl-lsp-core/src/executable_regions.rs
@@ -125,7 +125,7 @@ impl<F: FnMut(&SegmentedCommand, HeadWords<'_>) -> bool> ExecutableWalker<'_, F>
                 if let Some((spec, case_index)) = case_list
                     && case_index == index
                 {
-                    if self.case_list_regions(token, spec, depth, next_grammar) {
+                    if self.case_list_regions(token, &spec, depth, next_grammar) {
                         return true;
                     }
                 } else if let Some((body_start, body_end)) = braced_body_region(self.source, token)
@@ -158,7 +158,7 @@ impl<F: FnMut(&SegmentedCommand, HeadWords<'_>) -> bool> ExecutableWalker<'_, F>
     fn case_list_regions(
         &mut self,
         token: Token,
-        spec: tcl_registry::CaseListSpec,
+        spec: &tcl_registry::CaseListSpec,
         depth: u32,
         grammar: Option<&'static DefinitionBodyGrammar>,
     ) -> bool {

--- a/rust/tcl-lsp-core/src/executable_regions.rs
+++ b/rust/tcl-lsp-core/src/executable_regions.rs
@@ -1,0 +1,248 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Registry-driven traversal of statically executable Tcl source regions.
+//!
+//! Consumers that need to inspect a command embedded in another command must
+//! not each invent a partial list of body-bearing commands.  This walker keeps
+//! the source-coordinate and command-identity rules in one place: it visits
+//! normal body arguments, clause-list arm bodies, lambda bodies, definition
+//! members, and live command substitutions.
+
+use tcl_compiler::head_identity::HeadIdentityMap;
+use tcl_compiler::lambda_literal::split_lambda_literal;
+use tcl_compiler::segmenter::{SegmentedCommand, segment_commands_with_offset_and_config};
+use tcl_lexer::{Lexer, LexerConfig, SourceMap, Token, TokenType};
+use tcl_registry::definer::DefinitionBodyGrammar;
+use tcl_registry::{ArgRole, CommandRegistry};
+
+use crate::oo_body::{HeadWords, is_member, member_body_indices_in, next_definition_grammar};
+
+/// Defensive recursion limit shared by executable-source walkers.
+const MAX_EXECUTABLE_REGION_DEPTH: tcl_core_types::RecursionLimit =
+    tcl_core_types::RecursionLimit(256);
+
+/// Visit every statically locatable command that Tcl can execute from
+/// `source`, preserving each command's absolute source spans.
+///
+/// `visitor` returns `true` to stop early.  A callback receives the head in
+/// its written and registry-resolved forms; the latter is empty for a proven
+/// rebound command, so registry grammar is never applied to a shadowed or
+/// mutated builtin.  Definition members deliberately use their written head:
+/// they are lexical keywords, not global command bindings.
+pub(crate) fn visit_executable_commands(
+    source: &str,
+    config: LexerConfig,
+    registry: &CommandRegistry,
+    availability: tcl_dialect::DialectSet,
+    identities: &HeadIdentityMap,
+    visitor: &mut impl FnMut(&SegmentedCommand, HeadWords<'_>) -> bool,
+) {
+    let mut walk = ExecutableWalker {
+        source,
+        config,
+        registry,
+        availability,
+        identities,
+        visitor,
+    };
+    let _ = walk.region(0, source.len(), 0, None);
+}
+
+struct ExecutableWalker<'a, F> {
+    source: &'a str,
+    config: LexerConfig,
+    registry: &'a CommandRegistry,
+    availability: tcl_dialect::DialectSet,
+    identities: &'a HeadIdentityMap,
+    visitor: &'a mut F,
+}
+
+impl<F: FnMut(&SegmentedCommand, HeadWords<'_>) -> bool> ExecutableWalker<'_, F> {
+    fn region(
+        &mut self,
+        start: usize,
+        end: usize,
+        depth: u32,
+        grammar: Option<&'static DefinitionBodyGrammar>,
+    ) -> bool {
+        if MAX_EXECUTABLE_REGION_DEPTH.exceeded(depth) || start >= end || end > self.source.len() {
+            return false;
+        }
+        let commands = segment_commands_with_offset_and_config(
+            &self.source[start..end],
+            u32::try_from(start).unwrap_or(0),
+            self.config.at_depth(depth),
+        );
+        for command in &commands {
+            let Some(head_tok) = command.argv.first() else {
+                continue;
+            };
+            let head = self
+                .identities
+                .head_words(command.name(), head_tok.span.start());
+            if (self.visitor)(command, head) {
+                return true;
+            }
+
+            // A command substitution is live wherever it appears in a bare
+            // or quoted word, including a command's own head.  Braced words
+            // are intentionally excluded by `command_substitution_regions`.
+            for token in &command.argv {
+                for (inner_start, inner_end) in
+                    command_substitution_regions(self.source, self.config, *token)
+                {
+                    if self.region(inner_start, inner_end, depth + 1, grammar) {
+                        return true;
+                    }
+                }
+            }
+
+            let args: Vec<&str> = command.args().iter().map(String::as_str).collect();
+            let member = grammar.filter(|g| is_member(g, head.written));
+            let body_indices = member.map_or_else(
+                || {
+                    self.registry
+                        .arg_indices_for_role(head.resolved, &args, ArgRole::Body)
+                },
+                |g| member_body_indices_in(g, head.written, &args, self.availability),
+            );
+            let next_grammar = next_definition_grammar(head, &args, grammar, self.registry);
+            let case_list = self
+                .registry
+                .case_invocation(head.resolved, &args, self.availability)
+                .and_then(|(spec, invocation)| invocation.clause_list_index.map(|i| (spec, i)));
+
+            for index in body_indices {
+                let Some(&token) = command.arg_tokens().get(index) else {
+                    continue;
+                };
+                if token.kind != TokenType::Str {
+                    continue;
+                }
+                if let Some((spec, case_index)) = case_list
+                    && case_index == index
+                {
+                    if self.case_list_regions(token, spec, depth, next_grammar) {
+                        return true;
+                    }
+                } else if let Some((body_start, body_end)) = braced_body_region(self.source, token)
+                    && self.region(body_start, body_end, depth + 1, next_grammar)
+                {
+                    return true;
+                }
+            }
+
+            for index in
+                self.registry
+                    .arg_indices_for_role(head.resolved, &args, ArgRole::LambdaLiteral)
+            {
+                let Some(&token) = command.arg_tokens().get(index) else {
+                    continue;
+                };
+                let Some(body) = split_lambda_literal(self.source, token)
+                    .and_then(|elements| elements.braced_body())
+                else {
+                    continue;
+                };
+                if self.region(body.start() as usize, body.end() as usize, depth + 1, None) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    fn case_list_regions(
+        &mut self,
+        token: Token,
+        spec: tcl_registry::CaseListSpec,
+        depth: u32,
+        grammar: Option<&'static DefinitionBodyGrammar>,
+    ) -> bool {
+        let content_start = token.span.start() as usize + token.content_offset as usize;
+        let content_end = token.span.end() as usize;
+        let Some(list) = self.source.get(content_start..content_end) else {
+            return false;
+        };
+        let shape = tcl_syntax::case_list::CaseListShape {
+            clause_flags: spec.clause_flags,
+            clause_value_flags: spec.clause_value_flags,
+        };
+        for clause in tcl_syntax::case_list::split_case_list(list, &shape) {
+            let Some(body) = clause.body.filter(|body| body.braced) else {
+                continue;
+            };
+            // The list splitter's end sits on the closing brace; give the
+            // segmenter just the verbatim body content, still in whole-file
+            // coordinates.
+            let start = content_start + body.start + 1;
+            let end = content_start + body.end;
+            if self.region(start, end, depth + 1, grammar) {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+/// Return a braced body's verbatim source content, excluding delimiters.
+fn braced_body_region(source: &str, token: Token) -> Option<(usize, usize)> {
+    let start = token.span.start() as usize + token.content_offset as usize;
+    let raw_end = token.span.end() as usize;
+    let bytes = source.as_bytes();
+    let end = if raw_end > start && raw_end - start == 1 && bytes.get(raw_end - 1) == Some(&b'}') {
+        start
+    } else {
+        raw_end
+    };
+    (start < end && end <= source.len()).then_some((start, end))
+}
+
+/// Locate active bracket substitutions inside one token, preserving absolute
+/// offsets.  The segmenter coalesces compound bare/quoted words into `Esc`,
+/// so those are re-lexed to recover every embedded `Cmd` fragment.
+fn command_substitution_regions(
+    source: &str,
+    config: LexerConfig,
+    token: Token,
+) -> Vec<(usize, usize)> {
+    let start = token.span.start() as usize;
+    let end = token.span.end() as usize;
+    if start >= end || end > source.len() {
+        return Vec::new();
+    }
+    let strip = |fragment_start: usize, fragment_end: usize| {
+        let inner_start =
+            fragment_start + usize::from(source.as_bytes().get(fragment_start) == Some(&b'['));
+        let inner_end = fragment_end
+            - usize::from(
+                fragment_end > inner_start
+                    && source.as_bytes().get(fragment_end - 1) == Some(&b']'),
+            );
+        (inner_start, inner_end)
+    };
+    match token.kind {
+        TokenType::Cmd => vec![strip(start, end)],
+        TokenType::Esc if source.as_bytes()[start..end].contains(&b'[') => {
+            let Ok(tokens) =
+                Lexer::with_source_map(SourceMap::new(&source[start..end]), config).tokenise_all()
+            else {
+                return Vec::new();
+            };
+            tokens
+                .into_iter()
+                .filter(|token| token.kind == TokenType::Cmd)
+                .map(|token| {
+                    strip(
+                        start + token.span.start() as usize,
+                        start + token.span.end() as usize,
+                    )
+                })
+                .collect()
+        }
+        _ => Vec::new(),
+    }
+}

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -49,10 +49,11 @@ use std::collections::HashMap;
 use rustc_hash::FxHashSet;
 use tcl_compiler::analyser::{AnalysisResult, ClassDef, ProcDef, VarDef};
 use tcl_compiler::compilation_unit::{CompilationUnit, FunctionUnit};
+use tcl_compiler::registry_invocation::segmented_command_arguments;
 use tcl_compiler::taint::{TaintColour, TaintLattice};
 use tcl_compiler::types::{TclType, TypeKind, TypeLattice};
 use tcl_lexer::{LexerConfig, Token, TokenType};
-use tcl_registry::CommandRegistry;
+use tcl_registry::{CommandRegistry, InvocationArguments};
 
 use crate::definition::utf16_col_to_char_col;
 
@@ -638,7 +639,11 @@ fn pattern_format_hover_for_command(
         .registry
         .resolve_call(head, &args, context.profile.availability_mask)?;
 
-    for pattern in context.registry.pattern_args(head, &args) {
+    let source_args = segmented_command_arguments(command);
+    for pattern in context
+        .registry
+        .pattern_args_words(head, InvocationArguments::structured(&source_args))
+    {
         let Some(&token) = command.argv.get(usize::from(pattern.index) + 1) else {
             continue;
         };
@@ -5126,6 +5131,16 @@ mod tests {
         let analysis = a.analyse(src, "tcl8.6").clone();
         let h = hover(src, 0, 24, &analysis, None).expect("hover");
         assert!(h.value.contains("Regex pattern"), "{}", h.value);
+    }
+
+    #[test]
+    fn dynamic_lsearch_option_prefix_does_not_claim_the_following_list_as_glob() {
+        let src = "lsearch $mode {a b} {a*}\n";
+        let mut a = tcl_compiler::analyser::Analyser::new();
+        let analysis = a.analyse(src, "tcl8.6").clone();
+        // `$mode` can evaluate to a value-taking lsearch option. The source
+        // shape therefore cannot prove that `{a b}` is the pattern word.
+        assert!(hover(src, 0, 16, &analysis, None).is_none());
     }
 
     // regsub substitution-spec hover

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -49,7 +49,6 @@ use std::collections::HashMap;
 use rustc_hash::FxHashSet;
 use tcl_compiler::analyser::{AnalysisResult, ClassDef, ProcDef, VarDef};
 use tcl_compiler::compilation_unit::{CompilationUnit, FunctionUnit};
-use tcl_compiler::segmenter::segment_commands_with_offset_and_config;
 use tcl_compiler::taint::{TaintColour, TaintLattice};
 use tcl_compiler::types::{TclType, TypeKind, TypeLattice};
 use tcl_lexer::{LexerConfig, Token, TokenType};
@@ -566,100 +565,126 @@ fn registry_pattern_format_hover(
     let config = LexerConfig::for_file_dialect(profile.name);
     let identities =
         tcl_compiler::head_identity::command_head_identities_with_config(source, config, registry);
+    let context = PatternFormatContext {
+        analysis,
+        source,
+        resolution,
+        registry,
+        profile,
+        cursor,
+    };
 
-    for command in segment_commands_with_offset_and_config(source, 0, config) {
-        if cursor < command.span.start() || cursor > command.span.end() {
-            continue;
-        }
-        let Some(written_head) = command.texts.first() else {
+    let mut answer = None;
+    crate::executable_regions::visit_executable_commands(
+        source,
+        config,
+        registry,
+        profile.availability_mask,
+        &identities,
+        &mut |command, identity| {
+            answer = pattern_format_hover_for_command(&context, command, identity);
+            answer.is_some()
+        },
+    );
+    answer
+}
+
+struct PatternFormatContext<'a> {
+    analysis: &'a AnalysisResult,
+    source: &'a str,
+    resolution: crate::definition::CallResolution<'a>,
+    registry: &'a CommandRegistry,
+    profile: &'static tcl_dialect::DialectProfile,
+    cursor: u32,
+}
+
+/// Resolve one command's registry-declared pattern and format arguments.
+fn pattern_format_hover_for_command(
+    context: &PatternFormatContext<'_>,
+    command: &tcl_compiler::segmenter::SegmentedCommand,
+    identity: crate::oo_body::HeadWords<'_>,
+) -> Option<Hover> {
+    if context.cursor < command.span.start() || context.cursor > command.span.end() {
+        return None;
+    }
+    let written_head = command.texts.first()?;
+    // The registry is only authoritative after the analyser has confirmed
+    // that this call still names a builtin. A live proc (including a
+    // namespace-local shadow or command mutation) owns the call.
+    let call_offset = command
+        .argv
+        .first()
+        .map_or(command.span.start(), |token| token.span.start());
+    let namespace = crate::definition::namespace_context_at(
+        &context.analysis.global_scope,
+        call_offset,
+        &context.analysis.namespace_overrides,
+    );
+    if crate::definition::resolve_called_proc(
+        context.analysis,
+        context.source,
+        &namespace,
+        written_head,
+        call_offset,
+        context.resolution,
+    )
+    .is_some()
+    {
+        return None;
+    }
+    let head = (!identity.resolved.is_empty()).then_some(identity.resolved)?;
+    let args: Vec<&str> = command.texts.iter().skip(1).map(String::as_str).collect();
+    context
+        .registry
+        .resolve_call(head, &args, context.profile.availability_mask)?;
+
+    for pattern in context.registry.pattern_args(head, &args) {
+        let Some(&token) = command.argv.get(usize::from(pattern.index) + 1) else {
             continue;
         };
-        // The registry is only authoritative after the analyser has confirmed
-        // that this call still names a builtin.  A live proc (including a
-        // namespace-local shadow or command mutation) owns the call and must
-        // not acquire the builtin's embedded-language hover.
-        let call_offset = command
-            .argv
-            .first()
-            .map_or(command.span.start(), |token| token.span.start());
-        let namespace = crate::definition::namespace_context_at(
-            &analysis.global_scope,
-            call_offset,
-            &analysis.namespace_overrides,
-        );
-        if crate::definition::resolve_called_proc(
-            analysis,
-            source,
-            &namespace,
-            written_head,
-            call_offset,
-            resolution,
-        )
-        .is_some()
-        {
-            continue;
-        }
-        let identity = identities.resolve(written_head, call_offset);
-        if identity.is_rebound() {
-            continue;
-        }
-        let head = identity.spec_name();
-        let args: Vec<&str> = command.texts.iter().skip(1).map(String::as_str).collect();
-        let Some(_resolved) =
-            registry.resolve_call(head, &args, tcl_registry::dialects::DialectSet::empty())
-        else {
+        let Some(text) = literal_at_token(context.source, token, context.cursor) else {
             continue;
         };
-
-        for pattern in registry.pattern_args(head, &args) {
-            let Some(token) = command.argv.get(usize::from(pattern.index) + 1) else {
-                continue;
-            };
-            if let Some(text) = literal_at_token(source, *token, cursor) {
-                return Some(Hover::markdown(match pattern.kind {
-                    tcl_registry::patterns::PatternType::Glob => glob_hover_text(&text),
-                    tcl_registry::patterns::PatternType::Regex => regex_hover_text(&text),
-                }));
+        let text = match pattern.kind {
+            tcl_registry::patterns::PatternType::Glob => glob_hover_text(&text),
+            tcl_registry::patterns::PatternType::Regex => regex_hover_text(&text),
+        };
+        return Some(Hover::markdown(text));
+    }
+    for format in context.registry.format_string_args(head, &args) {
+        let Some(&token) = command.argv.get(format.index + 1) else {
+            continue;
+        };
+        let Some(text) = literal_at_token(context.source, token, context.cursor) else {
+            continue;
+        };
+        let text = match format.kind {
+            tcl_registry::patterns::FormatType::Sprintf if text.contains('%') => {
+                sprintf_format_hover_text(&text)
             }
-        }
-
-        for format in registry.format_string_args(head, &args) {
-            let Some(token) = command.argv.get(format.index + 1) else {
-                continue;
-            };
-            let Some(text) = literal_at_token(source, *token, cursor) else {
-                continue;
-            };
-            let hover = match format.kind {
-                tcl_registry::patterns::FormatType::Sprintf if text.contains('%') => {
-                    sprintf_format_hover_text(&text)
-                }
-                tcl_registry::patterns::FormatType::Clock if text.contains('%') => {
-                    clock_format_hover_text(&text)
-                }
-                tcl_registry::patterns::FormatType::Binary => {
-                    let subcmd = args.first().copied().unwrap_or_default().to_owned();
-                    let trailing = args
+            tcl_registry::patterns::FormatType::Clock if text.contains('%') => {
+                clock_format_hover_text(&text)
+            }
+            tcl_registry::patterns::FormatType::Binary => {
+                binary_format_hover_text(&BinaryContext {
+                    text,
+                    subcmd: args.first().copied().unwrap_or_default().to_owned(),
+                    args: args
                         .get(format.index + 1..)
                         .unwrap_or_default()
                         .iter()
                         .map(|arg| (*arg).to_owned())
-                        .collect();
-                    binary_format_hover_text(&BinaryContext {
-                        text,
-                        subcmd,
-                        args: trailing,
-                    })
-                }
-                tcl_registry::patterns::FormatType::Regsub
-                    if !scan_regsub_backrefs(&text).is_empty() =>
-                {
-                    regsub_hover_text(&text)
-                }
-                _ => continue,
-            };
-            return Some(Hover::markdown(hover));
-        }
+                        .collect(),
+                })
+            }
+            tcl_registry::patterns::FormatType::Regsub
+                if !scan_regsub_backrefs(&text).is_empty() =>
+            {
+                regsub_hover_text(&text)
+            }
+            _ => continue,
+        };
+        return Some(Hover::markdown(text));
     }
     None
 }
@@ -3795,6 +3820,20 @@ mod tests {
         a.analyse(source, "tcl8.6").clone()
     }
 
+    fn position_of(source: &str, needle: &str) -> (u32, u32) {
+        let offset = source.find(needle).expect("test cursor text");
+        let before = &source[..offset];
+        let line = u32::try_from(before.bytes().filter(|b| *b == b'\n').count()).unwrap();
+        let column = u32::try_from(
+            before
+                .rsplit_once('\n')
+                .map_or(before, |(_, tail)| tail)
+                .len(),
+        )
+        .unwrap();
+        (line, column)
+    }
+
     #[test]
     fn find_word_span_returns_none_at_eol() {
         // Position one past the line's last char yields None.
@@ -4704,6 +4743,81 @@ mod tests {
             u32::try_from(aliased.find("%Y").unwrap() - aliased.find('\n').unwrap() - 1).unwrap();
         let h = hover(aliased, 1, cursor, &analysis, None).expect("aliased format hover");
         assert!(h.value.contains("**Format string**"), "{}", h.value);
+    }
+
+    #[test]
+    fn pattern_and_format_hover_descend_through_every_registry_executable_region() {
+        // The cursor offsets deliberately sit in separately nested source
+        // slices.  A line-local or re-based walker finds the command but
+        // reports against the wrong source position; all must retain the
+        // original document's absolute coordinates.
+        let cases = [
+            (
+                "proc p {} { format {%04d} 1 }\n",
+                "%04d",
+                "**Format string**",
+                "tcl8.6",
+            ),
+            (
+                "oo::class create C { method m {} { string match {*needle*} x } }\n",
+                "*needle*",
+                "**Glob pattern**",
+                "tcl8.6",
+            ),
+            (
+                "switch $x { a { format {%03d} 1 } default { puts no } }\n",
+                "%03d",
+                "**Format string**",
+                "tcl8.6",
+            ),
+            (
+                "apply {{} {format {%02d} 1}}\n",
+                "%02d",
+                "**Format string**",
+                "tcl8.6",
+            ),
+            (
+                "puts [format {%01d} 1]\n",
+                "%01d",
+                "**Format string**",
+                "tcl8.6",
+            ),
+            (
+                "when HTTP_REQUEST { format {%05d} 1 }\n",
+                "%05d",
+                "**Format string**",
+                "f5-irules",
+            ),
+        ];
+        for (source, needle, expected, dialect) in cases {
+            let mut analyser = Analyser::new();
+            let analysis = analyser.analyse(source, dialect).clone();
+            let (line, column) = position_of(source, needle);
+            let profile = tcl_dialect::DialectProfile::by_name(dialect);
+            let hover = hover_with_profile(source, line, column, &analysis, None, profile)
+                .unwrap_or_else(|| panic!("no hover for {dialect}: {source}"));
+            assert!(hover.value.contains(expected), "{}", hover.value);
+        }
+    }
+
+    #[test]
+    fn nested_format_hover_honours_aliases_and_shadowing() {
+        let aliased = "interp alias {} fmt {} format\nproc p {} { fmt {%06d} 1 }\n";
+        let analysis = analyse(aliased);
+        let (line, column) = position_of(aliased, "%06d");
+        let result = hover(aliased, line, column, &analysis, None).expect("aliased nested format");
+        assert!(
+            result.value.contains("**Format string**"),
+            "{}",
+            result.value
+        );
+
+        // A same-named proc owns the nested call, so the builtin format
+        // grammar must not leak through merely because its spelling matches.
+        let shadowed = "proc format {args} {}\nproc p {} { format {%07d} 1 }\n";
+        let analysis = analyse(shadowed);
+        let (line, column) = position_of(shadowed, "%07d");
+        assert!(hover(shadowed, line, column, &analysis, None).is_none());
     }
 
     // sprintf format hover

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -564,12 +564,14 @@ fn registry_pattern_format_hover(
     let line_index = tcl_lexer::LineIndex::new(source);
     let cursor = crate::definition::byte_offset_at(&line_index, source, line, character);
     let config = LexerConfig::for_file_dialect(profile.name);
+    let identities =
+        tcl_compiler::head_identity::command_head_identities_with_config(source, config, registry);
 
     for command in segment_commands_with_offset_and_config(source, 0, config) {
         if cursor < command.span.start() || cursor > command.span.end() {
             continue;
         }
-        let Some(head) = command.texts.first() else {
+        let Some(written_head) = command.texts.first() else {
             continue;
         };
         // The registry is only authoritative after the analyser has confirmed
@@ -589,7 +591,7 @@ fn registry_pattern_format_hover(
             analysis,
             source,
             &namespace,
-            head,
+            written_head,
             call_offset,
             resolution,
         )
@@ -597,6 +599,11 @@ fn registry_pattern_format_hover(
         {
             continue;
         }
+        let identity = identities.resolve(written_head, call_offset);
+        if identity.is_rebound() {
+            continue;
+        }
+        let head = identity.spec_name();
         let args: Vec<&str> = command.texts.iter().skip(1).map(String::as_str).collect();
         let Some(_resolved) =
             registry.resolve_call(head, &args, tcl_registry::dialects::DialectSet::empty())

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -4787,6 +4787,18 @@ mod tests {
                 "tcl8.6",
             ),
             (
+                "switch $x { a \"format {%08d} 1\" default { puts no } }\n",
+                "%08d",
+                "**Format string**",
+                "tcl8.6",
+            ),
+            (
+                "expect { -re {ready} \"format {%09d} 1\" }\n",
+                "%09d",
+                "**Format string**",
+                "expect",
+            ),
+            (
                 "apply {{} {format {%02d} 1}}\n",
                 "%02d",
                 "**Format string**",
@@ -4813,6 +4825,32 @@ mod tests {
             let hover = hover_with_profile(source, line, column, &analysis, None, profile)
                 .unwrap_or_else(|| panic!("no hover for {dialect}: {source}"));
             assert!(hover.value.contains(expected), "{}", hover.value);
+        }
+    }
+
+    #[test]
+    fn quoted_case_action_hover_obeys_head_mutations_and_static_list_validation() {
+        let aliased = "interp alias {} fmt {} format\nswitch $x { a \"fmt {%10d} 1\" }\n";
+        let analysis = analyse(aliased);
+        let (line, column) = position_of(aliased, "%10d");
+        let result = hover(aliased, line, column, &analysis, None).expect("aliased quoted action");
+        assert!(
+            result.value.contains("**Format string**"),
+            "{}",
+            result.value
+        );
+
+        for source in [
+            "rename format saved\nswitch $x { a \"format {%11d} 1\" }\n",
+            "set actions { a \"format {%12d} 1\" }\nswitch $x $actions\n",
+            "switch $x { a \"format {%13d} 1\" orphan }\n",
+        ] {
+            let analysis = analyse(source);
+            let (line, column) = position_of(source, "%");
+            assert!(
+                hover(source, line, column, &analysis, None).is_none(),
+                "mutated, dynamic, or malformed case list leaked a nested hover: {source}"
+            );
         }
     }
 

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -640,10 +640,11 @@ fn pattern_format_hover_for_command(
         .resolve_call(head, &args, context.profile.availability_mask)?;
 
     let source_args = segmented_command_arguments(command);
-    for pattern in context
-        .registry
-        .pattern_args_words(head, InvocationArguments::structured(&source_args))
-    {
+    for pattern in context.registry.pattern_args_words_for_dialect(
+        head,
+        InvocationArguments::structured(&source_args),
+        context.profile.availability_mask,
+    ) {
         let Some(&token) = command.argv.get(usize::from(pattern.index) + 1) else {
             continue;
         };
@@ -5141,6 +5142,34 @@ mod tests {
         // `$mode` can evaluate to a value-taking lsearch option. The source
         // shape therefore cannot prove that `{a b}` is the pattern word.
         assert!(hover(src, 0, 16, &analysis, None).is_none());
+    }
+
+    #[test]
+    fn lsearch_pattern_hover_uses_the_documents_profiled_option_set() {
+        // Tcl 9 makes -str the unique -stride abbreviation. Before 9 it is
+        // not an lsearch option, so the preceding -regexp cannot claim the
+        // final word as a regex pattern. This reaches the profile-aware
+        // PatternArgResolver path, not a command-name hover branch.
+        let src = "lsearch -regexp -str 2 {a b} {a+}\n";
+        let cursor = u32::try_from(src.rfind("a+").expect("final pattern")).unwrap();
+        for (dialect, expected) in [("tcl8.6", false), ("tcl9.0", true)] {
+            let mut analyser = tcl_compiler::analyser::Analyser::new();
+            let analysis = analyser.analyse(src, dialect).clone();
+            let profile = tcl_dialect::DialectProfile::by_name(dialect);
+            let found = hover_with_profile(
+                src,
+                0,
+                cursor,
+                &analysis,
+                Some(&tcl_registry::CommandRegistry::build_default()),
+                profile,
+            );
+            assert_eq!(
+                found.is_some_and(|hover| hover.value.contains("Regex pattern")),
+                expected,
+                "{dialect}: profile-filtered lsearch options decide the pattern position"
+            );
+        }
     }
 
     // regsub substitution-spec hover

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -49,8 +49,10 @@ use std::collections::HashMap;
 use rustc_hash::FxHashSet;
 use tcl_compiler::analyser::{AnalysisResult, ClassDef, ProcDef, VarDef};
 use tcl_compiler::compilation_unit::{CompilationUnit, FunctionUnit};
+use tcl_compiler::segmenter::segment_commands_with_offset_and_config;
 use tcl_compiler::taint::{TaintColour, TaintLattice};
 use tcl_compiler::types::{TclType, TypeKind, TypeLattice};
+use tcl_lexer::{LexerConfig, Token, TokenType};
 use tcl_registry::CommandRegistry;
 
 use crate::definition::utf16_col_to_char_col;
@@ -545,10 +547,129 @@ enum PositionHover {
     FallThrough,
 }
 
+/// Resolve pattern and format-string hovers from the same segmented command
+/// and registry role walk used by semantic tokens.  In particular, do not
+/// inspect whichever literal happens to contain the cursor: the registry's
+/// `ArgRole` indices identify the one argument that actually carries the
+/// embedded language (issue #1386).
+fn registry_pattern_format_hover(
+    source: &str,
+    line: u32,
+    character: u32,
+    registry: &CommandRegistry,
+    profile: &'static tcl_dialect::DialectProfile,
+) -> Option<Hover> {
+    let line_index = tcl_lexer::LineIndex::new(source);
+    let cursor = crate::definition::byte_offset_at(&line_index, source, line, character);
+    let config = LexerConfig::for_file_dialect(profile.name);
+
+    for command in segment_commands_with_offset_and_config(source, 0, config) {
+        if cursor < command.span.start() || cursor > command.span.end() {
+            continue;
+        }
+        let Some(head) = command.texts.first() else {
+            continue;
+        };
+        let args: Vec<&str> = command.texts.iter().skip(1).map(String::as_str).collect();
+        let Some(_resolved) =
+            registry.resolve_call(head, &args, tcl_registry::dialects::DialectSet::empty())
+        else {
+            continue;
+        };
+
+        for pattern in registry.pattern_args(head, &args) {
+            let Some(token) = command.argv.get(usize::from(pattern.index) + 1) else {
+                continue;
+            };
+            if let Some(text) = literal_at_token(source, *token, cursor) {
+                return Some(Hover::markdown(match pattern.kind {
+                    tcl_registry::patterns::PatternType::Glob => glob_hover_text(&text),
+                    tcl_registry::patterns::PatternType::Regex => regex_hover_text(&text),
+                }));
+            }
+        }
+
+        for format in registry.format_string_args(head, &args) {
+            let Some(token) = command.argv.get(format.index + 1) else {
+                continue;
+            };
+            let Some(text) = literal_at_token(source, *token, cursor) else {
+                continue;
+            };
+            let hover = match format.kind {
+                tcl_registry::patterns::FormatType::Sprintf if text.contains('%') => {
+                    sprintf_format_hover_text(&text)
+                }
+                tcl_registry::patterns::FormatType::Clock if text.contains('%') => {
+                    clock_format_hover_text(&text)
+                }
+                tcl_registry::patterns::FormatType::Binary => {
+                    let subcmd = args.first().copied().unwrap_or_default().to_owned();
+                    let trailing = args
+                        .get(format.index + 1..)
+                        .unwrap_or_default()
+                        .iter()
+                        .map(|arg| (*arg).to_owned())
+                        .collect();
+                    binary_format_hover_text(&BinaryContext {
+                        text,
+                        subcmd,
+                        args: trailing,
+                    })
+                }
+                tcl_registry::patterns::FormatType::Regsub
+                    if !scan_regsub_backrefs(&text).is_empty() =>
+                {
+                    regsub_hover_text(&text)
+                }
+                _ => continue,
+            };
+            return Some(Hover::markdown(hover));
+        }
+    }
+    None
+}
+
+/// Return a literal token's Tcl word text under the cursor. Token spans are
+/// absolute source byte ranges, so this remains correct across lines and
+/// continuation commands (unlike the former line splitter). Bare words are
+/// valid format and pattern arguments too (`binary format c2s value`), and
+/// are deliberately preserved rather than requiring quote/braces delimiters.
+fn literal_at_token(source: &str, token: Token, cursor: u32) -> Option<String> {
+    if !matches!(token.kind, TokenType::Str | TokenType::Esc)
+        || cursor < token.span.start()
+        || cursor > token.span.end()
+    {
+        return None;
+    }
+    let text = source.get(token.span.start() as usize..token.span.end() as usize)?;
+    let bytes = text.as_bytes();
+    if bytes.is_empty() {
+        return None;
+    }
+    if !matches!(bytes[0], b'{' | b'"') {
+        return Some(text.to_owned());
+    }
+    let close = if bytes[0] == b'{' { b'}' } else { b'"' };
+    let content_start = token.span.start() as usize + 1;
+    let content_end = if bytes.last() == Some(&close) {
+        token.span.end() as usize - 1
+    } else {
+        let rest = source.get(token.span.end() as usize..)?;
+        token.span.end() as usize + rest.find(char::from(close))?
+    };
+    if cursor as usize > content_end {
+        return None;
+    }
+    source.get(content_start..content_end).map(str::to_owned)
+}
+
 /// The format-string hovers: when the cursor sits on the format-string
 /// argument of a known format-bearing command, render a table of the
 /// specifiers it contains.  Covers `clock format` / `clock scan`, `format` /
 /// `scan`, `binary format` / `binary scan`, and `regsub`'s subspec.
+#[cfg(test)]
+#[allow(dead_code)]
 fn format_string_hover(source: &str, line: u32, character: u32) -> Option<Hover> {
     if let Some(text) = clock_format_string_at_position(source, line, character) {
         return Some(Hover::markdown(clock_format_hover_text(&text)));
@@ -638,14 +759,11 @@ fn hover_impl(
         return crate::namespace_symbol::namespace_hover_text(analysis, &cell).map(Hover::markdown);
     }
 
-    if let Some(hover) = format_string_hover(source, line, character) {
+    let hover_registry = registry.unwrap_or_else(|| tcl_registry::registry_for_profile(profile));
+    if let Some(hover) =
+        registry_pattern_format_hover(source, line, character, hover_registry, profile)
+    {
         return Some(hover);
-    }
-    if let Some(text) = glob_pattern_at_position(source, line, character) {
-        return Some(Hover::markdown(glob_hover_text(&text)));
-    }
-    if let Some(text) = regex_pattern_at_position(source, line, character) {
-        return Some(Hover::markdown(regex_hover_text(&text)));
     }
 
     let (word, _start, _end) = find_word_span_at_position(source, line, character)?;
@@ -1378,6 +1496,7 @@ fn sprintf_format_hover_text(text: &str) -> String {
 /// format-string argument and return the literal text.
 /// `format <fmtString> ?arg arg ...?` — the first arg is the
 /// format.  Single-line context only.
+#[cfg(test)]
 fn sprintf_format_string_at_position(source: &str, line: u32, character: u32) -> Option<String> {
     let line_text = source.split('\n').nth(line as usize)?;
     let tokens: Vec<&str> = line_text.split_whitespace().collect();
@@ -1394,6 +1513,7 @@ fn sprintf_format_string_at_position(source: &str, line: u32, character: u32) ->
 /// AND has at least one `%` in it.  Helper shared between
 /// `clock_format_string_at_position` and
 /// `sprintf_format_string_at_position`.
+#[cfg(test)]
 fn string_literal_with_percent_at(line_text: &str, character: u32) -> Option<String> {
     let chars: Vec<char> = line_text.chars().collect();
     let col = utf16_col_to_char_col(line_text, character).min(chars.len());
@@ -1795,6 +1915,7 @@ fn center(s: &str, width: usize) -> String {
 /// surrounding command's argument list.  Returns the format
 /// text plus the `format`/`scan` subcommand and the trailing
 /// argument tokens (best-effort, single-line).
+#[cfg(test)]
 fn binary_format_context_at_position(
     source: &str,
     line: u32,
@@ -1829,6 +1950,7 @@ fn binary_format_context_at_position(
 /// Return `(token_index, token_text)` for the whitespace-delimited token that
 /// contains `character` (UTF-16 column), or `None` when the cursor is on
 /// whitespace / past the end.
+#[cfg(test)]
 fn word_token_at(line_text: &str, character: u32) -> Option<(usize, String)> {
     let chars: Vec<char> = line_text.chars().collect();
     let col = utf16_col_to_char_col(line_text, character).min(chars.len());
@@ -1859,6 +1981,7 @@ fn word_token_at(line_text: &str, character: u32) -> Option<(usize, String)> {
 /// `["val"]` rather than `["{a4", "i}", "val"]`.  The first
 /// `skip` argv positions (incl. the format string itself) are
 /// dropped.
+#[cfg(test)]
 fn binary_trailing_args(line_text: &str, skip: usize) -> Vec<String> {
     let chars: Vec<char> = line_text.chars().collect();
     let mut tokens: Vec<String> = Vec::new();
@@ -1981,6 +2104,7 @@ fn regsub_hover_text(text: &str) -> String {
 /// text.  `regsub ?switches? exp string subSpec ?varName?`
 /// — `subSpec` is the 4th positional arg (after switches).
 /// Single-line only.
+#[cfg(test)]
 fn regsub_subspec_at_position(source: &str, line: u32, character: u32) -> Option<String> {
     let line_text = source.split('\n').nth(line as usize)?;
     let tokens: Vec<&str> = line_text.split_whitespace().collect();
@@ -2026,6 +2150,7 @@ fn regsub_subspec_at_position(source: &str, line: u32, character: u32) -> Option
 /// cursor.  Shared between hover providers that need
 /// literal-context detection but don't care whether the
 /// literal contains `%`.
+#[cfg(test)]
 fn string_literal_at(line_text: &str, character: u32) -> Option<String> {
     let chars: Vec<char> = line_text.chars().collect();
     let col = utf16_col_to_char_col(line_text, character).min(chars.len());
@@ -2151,6 +2276,8 @@ fn glob_hover_text(text: &str) -> String {
 /// `string match <pat> ...`, `glob <pat>...`, and `lsearch
 /// -glob <pat> ...` — three common entry points for glob
 /// matching in Tcl.  Single-line only.
+#[cfg(test)]
+#[allow(dead_code)]
 fn glob_pattern_at_position(source: &str, line: u32, character: u32) -> Option<String> {
     let line_text = source.split('\n').nth(line as usize)?;
     let tokens: Vec<&str> = line_text.split_whitespace().collect();
@@ -2402,6 +2529,8 @@ fn regex_hover_text(text: &str) -> String {
 /// Recognises `regexp <pat> ...`, `regsub <pat> ...` (the
 /// pattern arg, not the subspec), and `lsearch -regexp <pat>
 /// ...`.  Single-line only.
+#[cfg(test)]
+#[allow(dead_code)]
 fn regex_pattern_at_position(source: &str, line: u32, character: u32) -> Option<String> {
     let line_text = source.split('\n').nth(line as usize)?;
     let tokens: Vec<&str> = line_text.split_whitespace().collect();
@@ -2510,6 +2639,7 @@ fn classify_ipv6(addr: std::net::Ipv6Addr) -> &'static str {
 /// `clock scan` format-string argument and return the
 /// literal text.  Single-line only — multi-line literals
 /// are not handled.
+#[cfg(test)]
 fn clock_format_string_at_position(source: &str, line: u32, character: u32) -> Option<String> {
     let line_text = source.split('\n').nth(line as usize)?;
     // Tokenise the line on whitespace — the first two tokens
@@ -4465,17 +4595,17 @@ mod tests {
 
     #[test]
     fn clock_format_string_at_position_detects_braced_literal() {
-        let src = "clock format $time {%Y-%m-%d}\n";
+        let src = "clock format $time -format {%Y-%m-%d}\n";
         // Cursor inside the `{...}` literal.
-        let found = clock_format_string_at_position(src, 0, 22);
+        let found = clock_format_string_at_position(src, 0, 30);
         assert_eq!(found.as_deref(), Some("%Y-%m-%d"));
     }
 
     #[test]
     fn clock_format_string_at_position_detects_quoted_literal() {
-        let src = "clock format $time \"%Y\"\n";
+        let src = "clock format $time -format \"%Y\"\n";
         // Cursor inside the `"..."` literal.
-        let found = clock_format_string_at_position(src, 0, 22);
+        let found = clock_format_string_at_position(src, 0, 30);
         assert_eq!(found.as_deref(), Some("%Y"));
     }
 
@@ -4488,11 +4618,11 @@ mod tests {
 
     #[test]
     fn hover_fires_for_clock_format_specifier() {
-        let src = "clock format $time {%Y-%m-%d}\n";
+        let src = "clock format $time -format {%Y-%m-%d}\n";
         let mut a = tcl_compiler::analyser::Analyser::new();
         let analysis = a.analyse(src, "tcl8.6").clone();
         // Cursor inside the format literal.
-        let h = hover(src, 0, 22, &analysis, None).expect("hover");
+        let h = hover(src, 0, 30, &analysis, None).expect("hover");
         assert!(
             h.value.contains("Clock format string"),
             "expected clock hover, got: {value}",
@@ -4710,6 +4840,29 @@ mod tests {
         let analysis = a.analyse(src, "tcl8.6").clone();
         let h = hover(src, 0, 17, &analysis, None).expect("hover");
         assert!(h.value.contains("binary format"), "{}", h.value);
+    }
+
+    #[test]
+    fn hover_fires_for_bare_binary_format_specifier() {
+        // Tcl accepts an unquoted format word.  The registry identifies it as
+        // the `FormatString`; hover must not require braces or quotes.
+        let src = "binary format c2s value\n";
+        let mut a = tcl_compiler::analyser::Analyser::new();
+        let analysis = a.analyse(src, "tcl8.6").clone();
+        let h = hover(src, 0, 15, &analysis, None).expect("hover");
+        assert!(h.value.contains("binary format"), "{}", h.value);
+    }
+
+    #[test]
+    fn hover_uses_lsearchs_registry_selected_pattern_language() {
+        // `-regexp` changes lsearch's embedded language, while an exact or
+        // abbreviated option still shifts list/pattern positions through the
+        // registry's OptionSpec grammar.
+        let src = "lsearch -regexp {a b} {a+}\n";
+        let mut a = tcl_compiler::analyser::Analyser::new();
+        let analysis = a.analyse(src, "tcl8.6").clone();
+        let h = hover(src, 0, 24, &analysis, None).expect("hover");
+        assert!(h.value.contains("Regex pattern"), "{}", h.value);
     }
 
     // regsub substitution-spec hover

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -556,6 +556,8 @@ fn registry_pattern_format_hover(
     source: &str,
     line: u32,
     character: u32,
+    analysis: &AnalysisResult,
+    resolution: crate::definition::CallResolution<'_>,
     registry: &CommandRegistry,
     profile: &'static tcl_dialect::DialectProfile,
 ) -> Option<Hover> {
@@ -570,6 +572,31 @@ fn registry_pattern_format_hover(
         let Some(head) = command.texts.first() else {
             continue;
         };
+        // The registry is only authoritative after the analyser has confirmed
+        // that this call still names a builtin.  A live proc (including a
+        // namespace-local shadow or command mutation) owns the call and must
+        // not acquire the builtin's embedded-language hover.
+        let call_offset = command
+            .argv
+            .first()
+            .map_or(command.span.start(), |token| token.span.start());
+        let namespace = crate::definition::namespace_context_at(
+            &analysis.global_scope,
+            call_offset,
+            &analysis.namespace_overrides,
+        );
+        if crate::definition::resolve_called_proc(
+            analysis,
+            source,
+            &namespace,
+            head,
+            call_offset,
+            resolution,
+        )
+        .is_some()
+        {
+            continue;
+        }
         let args: Vec<&str> = command.texts.iter().skip(1).map(String::as_str).collect();
         let Some(_resolved) =
             registry.resolve_call(head, &args, tcl_registry::dialects::DialectSet::empty())
@@ -760,9 +787,15 @@ fn hover_impl(
     }
 
     let hover_registry = registry.unwrap_or_else(|| tcl_registry::registry_for_profile(profile));
-    if let Some(hover) =
-        registry_pattern_format_hover(source, line, character, hover_registry, profile)
-    {
+    if let Some(hover) = registry_pattern_format_hover(
+        source,
+        line,
+        character,
+        analysis,
+        ctx,
+        hover_registry,
+        profile,
+    ) {
         return Some(hover);
     }
 
@@ -4630,6 +4663,14 @@ mod tests {
         );
     }
 
+    #[test]
+    fn hover_abstains_for_local_proc_shadowing_format_command() {
+        let src = "proc clock {args} { return 0 }\nclock format $time {%Y}\n";
+        let mut a = tcl_compiler::analyser::Analyser::new();
+        let analysis = a.analyse(src, "tcl8.6").clone();
+        assert!(hover(src, 1, 25, &analysis, None).is_none());
+    }
+
     // sprintf format hover
 
     #[test]
@@ -4999,6 +5040,14 @@ mod tests {
         // Cursor inside the pattern literal.
         let h = hover(src, 0, 10, &analysis, None).expect("hover");
         assert!(h.value.contains("Regex pattern"), "{}", h.value);
+    }
+
+    #[test]
+    fn hover_abstains_for_local_proc_shadowing_regexp_command() {
+        let src = "proc regexp {args} { return 0 }\nregexp {^foo$} $line\n";
+        let mut a = tcl_compiler::analyser::Analyser::new();
+        let analysis = a.analyse(src, "tcl8.6").clone();
+        assert!(hover(src, 1, 10, &analysis, None).is_none());
     }
 
     // IP address hover

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -642,7 +642,12 @@ fn pattern_format_hover_for_command(
         let Some(&token) = command.argv.get(usize::from(pattern.index) + 1) else {
             continue;
         };
-        let Some(text) = literal_at_token(context.source, token, context.cursor) else {
+        let Some(text) = literal_at_token(
+            context.source,
+            LexerConfig::for_file_dialect(context.profile.name),
+            token,
+            context.cursor,
+        ) else {
             continue;
         };
         let text = match pattern.kind {
@@ -655,7 +660,12 @@ fn pattern_format_hover_for_command(
         let Some(&token) = command.argv.get(format.index + 1) else {
             continue;
         };
-        let Some(text) = literal_at_token(context.source, token, context.cursor) else {
+        let Some(text) = literal_at_token(
+            context.source,
+            LexerConfig::for_file_dialect(context.profile.name),
+            token,
+            context.cursor,
+        ) else {
             continue;
         };
         let text = match format.kind {
@@ -694,10 +704,16 @@ fn pattern_format_hover_for_command(
 /// continuation commands (unlike the former line splitter). Bare words are
 /// valid format and pattern arguments too (`binary format c2s value`), and
 /// are deliberately preserved rather than requiring quote/braces delimiters.
-fn literal_at_token(source: &str, token: Token, cursor: u32) -> Option<String> {
+fn literal_at_token(
+    source: &str,
+    config: LexerConfig,
+    token: Token,
+    cursor: u32,
+) -> Option<String> {
     if !matches!(token.kind, TokenType::Str | TokenType::Esc)
         || cursor < token.span.start()
         || cursor > token.span.end()
+        || crate::executable_regions::cursor_in_command_substitution(source, config, token, cursor)
     {
         return None;
     }
@@ -4818,6 +4834,25 @@ mod tests {
         let analysis = analyse(shadowed);
         let (line, column) = position_of(shadowed, "%07d");
         assert!(hover(shadowed, line, column, &analysis, None).is_none());
+    }
+
+    #[test]
+    fn nested_substitution_hover_beats_its_outer_pattern_word() {
+        let source = "regexp \"[format {%d} 1]\" $value\n";
+        let analysis = analyse(source);
+        let (line, column) = position_of(source, "%d");
+        let result = hover(source, line, column, &analysis, None)
+            .expect("format hover inside regexp substitution");
+        assert!(
+            result.value.contains("**Format string**"),
+            "{}",
+            result.value
+        );
+        assert!(
+            !result.value.contains("**Regular expression**"),
+            "outer regexp incorrectly claimed nested format: {}",
+            result.value
+        );
     }
 
     // sprintf format hover

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -4678,6 +4678,34 @@ mod tests {
         assert!(hover(src, 1, 25, &analysis, None).is_none());
     }
 
+    #[test]
+    fn hover_abstains_after_static_rename_moves_builtin_away() {
+        let src = "rename clock saved\nclock format $time {%Y}\n";
+        let mut a = tcl_compiler::analyser::Analyser::new();
+        let analysis = a.analyse(src, "tcl8.6").clone();
+        let cursor = u32::try_from(src.find("%Y").unwrap() - src.find('\n').unwrap() - 1).unwrap();
+        assert!(hover(src, 1, cursor, &analysis, None).is_none());
+    }
+
+    #[test]
+    fn hover_uses_effective_registry_identity_after_rename_and_alias() {
+        let renamed = "rename format local_format\nlocal_format {%Y}\n";
+        let mut a = tcl_compiler::analyser::Analyser::new();
+        let analysis = a.analyse(renamed, "tcl8.6").clone();
+        let cursor =
+            u32::try_from(renamed.find("%Y").unwrap() - renamed.find('\n').unwrap() - 1).unwrap();
+        let h = hover(renamed, 1, cursor, &analysis, None).expect("renamed format hover");
+        assert!(h.value.contains("**Format string**"), "{}", h.value);
+
+        let aliased = "interp alias {} local_format {} format\nlocal_format {%Y}\n";
+        let mut a = tcl_compiler::analyser::Analyser::new();
+        let analysis = a.analyse(aliased, "tcl8.6").clone();
+        let cursor =
+            u32::try_from(aliased.find("%Y").unwrap() - aliased.find('\n').unwrap() - 1).unwrap();
+        let h = hover(aliased, 1, cursor, &analysis, None).expect("aliased format hover");
+        assert!(h.value.contains("**Format string**"), "{}", h.value);
+    }
+
     // sprintf format hover
 
     #[test]

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -662,7 +662,11 @@ fn pattern_format_hover_for_command(
         };
         return Some(Hover::markdown(text));
     }
-    for format in context.registry.format_string_args(head, &args) {
+    for format in context.registry.format_string_args_words_for_dialect(
+        head,
+        InvocationArguments::structured(&source_args),
+        context.profile.availability_mask,
+    ) {
         let Some(&token) = command.argv.get(format.index + 1) else {
             continue;
         };
@@ -5142,6 +5146,44 @@ mod tests {
         // `$mode` can evaluate to a value-taking lsearch option. The source
         // shape therefore cannot prove that `{a b}` is the pattern word.
         assert!(hover(src, 0, 16, &analysis, None).is_none());
+    }
+
+    /// A substituted leading word is not a positional operand until Tcl has
+    /// evaluated it.  The source-aware registry query must therefore keep
+    /// every resolver-owned pattern and regsub replacement unclaimed, not
+    /// merely the lsearch-specific descriptor that originally grew this
+    /// guard (PR #1514 P2).
+    #[test]
+    fn dynamic_leading_options_abstain_for_pattern_and_regsub_format_hovers() {
+        let registry = tcl_registry::CommandRegistry::build_default();
+        for (src, needle) in [
+            ("regexp $mode {a+} $value\n", "a+"),
+            ("glob $mode /tmp {*.tcl}\n", "*.tcl"),
+            ("regsub $mode {a} $value {\\1}\n", "\\1"),
+            ("regsub -c {a} $value {\\1}\n", "\\1"),
+            ("regsub -command {a} $value callback\n", "callback"),
+        ] {
+            let analysis = analyse(src);
+            let (line, character) = position_of(src, needle);
+            assert!(
+                !hover(src, line, character, &analysis, Some(&registry)).is_some_and(|found| {
+                    found.value.contains("Regex pattern")
+                        || found.value.contains("Glob pattern")
+                        || found.value.contains("Substitution spec")
+                }),
+                "{src:?}: an unresolved, invalid, or callback-leading layout must not claim {needle:?} as an embedded language",
+            );
+        }
+
+        let src = "regsub -start $start {a} $value {\\1}\n";
+        let analysis = analyse(src);
+        let (line, character) = position_of(src, "\\1");
+        let found = hover(src, line, character, &analysis, Some(&registry)).expect("hover");
+        assert!(
+            found.value.contains("Substitution spec"),
+            "a declared -start value has a fixed width: {}",
+            found.value
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/inlay_hints.rs
+++ b/rust/tcl-lsp-core/src/inlay_hints.rs
@@ -57,9 +57,10 @@
 use rustc_hash::FxHashMap;
 use tcl_compiler::analyser::{AnalysisResult, ProcDef, Scope, ScopeKind};
 use tcl_compiler::compilation_unit::CompilationUnit;
+use tcl_compiler::registry_invocation::segmented_command_arguments;
 use tcl_compiler::types::{TypeKind, TypeLattice};
 use tcl_lexer::LineIndex;
-use tcl_registry::{CommandRegistry, TclType};
+use tcl_registry::{CommandRegistry, InvocationArguments, TclType};
 
 use crate::definition::LspRange;
 
@@ -533,9 +534,9 @@ fn format_args(
     // `rename` gets the target's format family and a `rename`d-away or
     // `proc`-shadowed spelling gets none (issue #1185).
     let resolved = identities.resolve(head, tok.span.start()).spec_name();
-    let arg_texts: Vec<&str> = seg.texts[1..].iter().map(String::as_str).collect();
+    let source_args = segmented_command_arguments(seg);
     registry
-        .format_string_args(resolved, &arg_texts)
+        .format_string_args_words(resolved, InvocationArguments::structured(&source_args))
         .into_iter()
         // `+ 1` converts a post-head argument index into an `argv` index
         // (`argv[0]` is the command word).
@@ -1773,6 +1774,32 @@ mod tests {
         let names: Vec<&str> = labels.iter().map(|(_, l)| l.as_str()).collect();
         assert!(names.contains(&"grp1"), "{labels:?}");
         assert!(names.contains(&"grp2"), "{labels:?}");
+    }
+
+    #[test]
+    fn dynamic_leading_option_does_not_claim_regsub_subspec_hints() {
+        let dynamic = type_labels("regsub $mode {a} $value {\\1}\n");
+        assert!(
+            !dynamic.iter().any(|(_, label)| label == "grp1"),
+            "a dynamic leading word can shift regsub's replacement: {dynamic:?}"
+        );
+
+        for src in [
+            "regsub -c {a} $value {\\1}\n",
+            "regsub -command {a} $value callback\n",
+        ] {
+            let labels = type_labels(src);
+            assert!(
+                !labels.iter().any(|(_, label)| label == "grp1"),
+                "{src:?}: only a valid replacement template has capture hints: {labels:?}"
+            );
+        }
+
+        let fixed = type_labels("regsub -start $start {a} $value {\\1}\n");
+        assert!(
+            fixed.iter().any(|(_, label)| label == "grp1"),
+            "a declared -start value keeps the replacement layout fixed: {fixed:?}"
+        );
     }
 
     /// Issue #1185: format hints follow the head's *effective command

--- a/rust/tcl-lsp-core/src/lib.rs
+++ b/rust/tcl-lsp-core/src/lib.rs
@@ -53,6 +53,7 @@ pub mod declaration;
 pub mod definition;
 pub mod document_links;
 pub mod document_symbols;
+mod executable_regions;
 pub mod expr_context;
 pub mod file_ops;
 pub mod folding;

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -1498,7 +1498,7 @@ fn special_arg_kinds(
         overrides.insert(tok.span.start(), ArgOverride::Kind(TokenKind::Event));
     }
 
-    insert_regex_overrides(seg, registry, head, &mut overrides);
+    insert_regex_overrides(seg, registry, head, dialect, &mut overrides);
     insert_format_overrides(seg, registry, head, arg_texts, &mut overrides);
 
     // `proc NAME …` — the name argument is a function definition.  Procedure
@@ -1926,6 +1926,7 @@ fn insert_regex_overrides(
     seg: &tcl_compiler::segmenter::SegmentedCommand,
     registry: &CommandRegistry,
     head: &str,
+    dialect: DialectSet,
     overrides: &mut FxHashMap<u32, ArgOverride>,
 ) {
     // Sub-tokenise only the *literal* fragments of the pattern word as regex:
@@ -1941,7 +1942,11 @@ fn insert_regex_overrides(
     // declared `OptionSpec` and `arg_role_resolver`.
     let source_args = segmented_command_arguments(seg);
     for found in registry
-        .pattern_args_words(head, InvocationArguments::structured(&source_args))
+        .pattern_args_words_for_dialect(
+            head,
+            InvocationArguments::structured(&source_args),
+            dialect,
+        )
         .into_iter()
         .filter(|found| found.kind == tcl_registry::patterns::PatternType::Regex)
     {
@@ -6667,6 +6672,44 @@ mod tests {
         // because lsearch also supports -regexp.
         let glob = kinds("lsearch {a b} {a+}\n", "tcl", &reg());
         assert!(!glob.contains(&(TokenKind::Regexp as u32)), "{glob:?}");
+    }
+
+    #[test]
+    fn lsearch_pattern_tokens_follow_profiled_stride_abbreviations() {
+        // `-str` is only lsearch -stride from Tcl 9.  The final `{a+}` is
+        // regex only after that profile-visible option consumes its value.
+        let source = "lsearch -regexp -str 2 {a b} {a+}\n";
+        let registry = reg();
+        let final_pattern = u32::try_from(source.rfind("a+").expect("final pattern")).unwrap();
+        let kinds_at_final_pattern = |dialect: &str| {
+            let tokens = full(source, dialect, &registry);
+            let mut line = 0u32;
+            let mut column = 0u32;
+            tokens
+                .data
+                .chunks(5)
+                .filter_map(|chunk| {
+                    if chunk[0] > 0 {
+                        line += chunk[0];
+                        column = chunk[1];
+                    } else {
+                        column += chunk[1];
+                    }
+                    (line == 0 && column <= final_pattern && final_pattern < column + chunk[2])
+                        .then_some(chunk[3])
+                })
+                .collect::<Vec<_>>()
+        };
+        let old = kinds_at_final_pattern("tcl8.6");
+        assert!(
+            !old.contains(&(TokenKind::Regexp as u32)),
+            "tcl8.6 must not consume unavailable -stride: {old:?}"
+        );
+        let new = kinds_at_final_pattern("tcl9.0");
+        assert!(
+            new.contains(&(TokenKind::Regexp as u32)),
+            "tcl9.0 must parse -str as -stride: {new:?}"
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -6675,13 +6675,15 @@ mod tests {
     }
 
     #[test]
-    fn lsearch_pattern_tokens_follow_profiled_stride_abbreviations() {
-        // `-str` is only lsearch -stride from Tcl 9.  The final `{a+}` is
-        // regex only after that profile-visible option consumes its value.
-        let source = "lsearch -regexp -str 2 {a b} {a+}\n";
+    fn lsearch_pattern_tokens_abstain_for_invalid_profiled_option_prefixes() {
+        // A dash-prefixed word inside lsearch's outer option scan is not a
+        // positional list operand when it cannot resolve in that release.
+        // In each invalid call the old fallback would put the regex override
+        // on `{a+}`; the registry must instead abstain entirely.
         let registry = reg();
-        let final_pattern = u32::try_from(source.rfind("a+").expect("final pattern")).unwrap();
-        let kinds_at_final_pattern = |dialect: &str| {
+        let kinds_at_claimed_pattern = |source: &str, dialect: &str| {
+            let claimed_pattern =
+                u32::try_from(source.find("a+").expect("claimed pattern")).unwrap();
             let tokens = full(source, dialect, &registry);
             let mut line = 0u32;
             let mut column = 0u32;
@@ -6695,20 +6697,28 @@ mod tests {
                     } else {
                         column += chunk[1];
                     }
-                    (line == 0 && column <= final_pattern && final_pattern < column + chunk[2])
+                    (line == 0 && column <= claimed_pattern && claimed_pattern < column + chunk[2])
                         .then_some(chunk[3])
                 })
                 .collect::<Vec<_>>()
         };
-        let old = kinds_at_final_pattern("tcl8.6");
+
+        for (dialect, option) in [("tcl8.6", "-str"), ("tcl9.0", "-st"), ("tcl9.0", "--")] {
+            let source = format!("lsearch -regexp {option} {{a+}} {{a b}} x\n");
+            let kinds = kinds_at_claimed_pattern(&source, dialect);
+            assert!(
+                !kinds.contains(&(TokenKind::Regexp as u32)),
+                "{dialect} {option} is invalid inside the option scan: {kinds:?}"
+            );
+        }
+
+        // Tcl 9's unique -str abbreviation does consume its stride value,
+        // so the real final pattern remains regex-classified.
+        let source = "lsearch -regexp -str 2 {a b} {a+}\n";
+        let kinds = kinds_at_claimed_pattern(source, "tcl9.0");
         assert!(
-            !old.contains(&(TokenKind::Regexp as u32)),
-            "tcl8.6 must not consume unavailable -stride: {old:?}"
-        );
-        let new = kinds_at_final_pattern("tcl9.0");
-        assert!(
-            new.contains(&(TokenKind::Regexp as u32)),
-            "tcl9.0 must parse -str as -stride: {new:?}"
+            kinds.contains(&(TokenKind::Regexp as u32)),
+            "tcl9.0 must parse -str as -stride: {kinds:?}"
         );
     }
 

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -1915,14 +1915,11 @@ fn insert_oo_member_overrides(
     }
 }
 
-/// Regex-pattern overrides for a `pattern_type == Regex` command.
+/// Regex-pattern overrides for registry-declared pattern arguments.
 ///
-/// Both facts are registry data: the *language* from
-/// [`tcl_registry::CommandSpec::pattern_type`], and the *position* from the
-/// [`tcl_registry::ArgRole::Pattern`] role the spec's resolver reports —
-/// which is what shifts the pattern past a call's leading switches without
-/// this walker re-implementing option parsing (issue #1185). The paired
-/// `regsub` replacement template is claimed by
+/// [`CommandRegistry::pattern_args`] pairs the language and position for this
+/// concrete call, including `lsearch -regexp`'s option-selected grammar. The
+/// paired `regsub` replacement template is claimed by
 /// [`insert_format_overrides`] through its own `FormatType::Regsub` family.
 fn insert_regex_overrides(
     seg: &tcl_compiler::segmenter::SegmentedCommand,
@@ -1931,13 +1928,6 @@ fn insert_regex_overrides(
     arg_texts: &[&str],
     overrides: &mut FxHashMap<u32, ArgOverride>,
 ) {
-    if !registry
-        .get(head)
-        .and_then(|s| s.pattern_type)
-        .is_some_and(|p| p == tcl_registry::patterns::PatternType::Regex)
-    {
-        return;
-    }
     // Sub-tokenise only the *literal* fragments of the pattern word as regex:
     // in `"abc$var.*"` the `abc` / `.*` fragments are regex, but `$var` is
     // variable interpolation Tcl resolves before `regexp` sees it (and
@@ -1945,18 +1935,16 @@ fn insert_regex_overrides(
     // literal fragments — not the whole word — leaves the `Var` / `Cmd`
     // fragments to the default classifier, so they render as Tcl and never
     // overlap the regex sub-tokens.
-    let declared = registry.arg_indices_for_role(head, arg_texts, tcl_registry::ArgRole::Pattern);
-    let positions: Vec<usize> = if declared.is_empty() {
-        // A `Regex` command whose spec does not (yet) declare where its
-        // pattern sits: fall back to the first positional word past the
-        // leading switches, the layout every stock regex command shares.
-        let options = registry.get(head).map_or(&[][..], |spec| spec.options);
-        let idx = tcl_registry::first_positional_index(options, arg_texts, 0);
-        vec![idx]
-    } else {
-        declared
-    };
-    for idx in positions {
+    // Pattern positions are required registry data.  In particular, a
+    // consumer must not guess that `-start` has a value or that the first
+    // non-switch word is a pattern: those are command grammars owned by the
+    // declared `OptionSpec` and `arg_role_resolver`.
+    for found in registry
+        .pattern_args(head, arg_texts)
+        .into_iter()
+        .filter(|found| found.kind == tcl_registry::patterns::PatternType::Regex)
+    {
+        let idx = usize::from(found.index);
         if let Some(tok) = seg.argv.get(idx + 1) {
             mark_literal_fragments(seg, tok.span, ArgOverride::RegexPattern, overrides);
         }
@@ -2098,12 +2086,16 @@ fn role_claimed_by_token_pass(role: Option<tcl_registry::ArgRole>) -> bool {
 /// prefix (two distinct options share it, e.g. `lsort -i`) or no match returns
 /// `None`.  A bare `-` never prefix-matches (only an exact-declared `-` /
 /// `--` option does).
-fn resolve_option_prefix<'a>(word: &str, names: &[&'a str]) -> Option<&'a str> {
+fn resolve_option_prefix<'a>(
+    word: &str,
+    names: &[&'a str],
+    prefix_matching: tcl_registry::abbrev::PrefixMatching,
+) -> Option<&'a str> {
     if let Some(exact) = names.iter().copied().find(|n| *n == word) {
         return Some(exact);
     }
     // Prefix matching needs at least one character past the leading dash.
-    if word.len() < 2 {
+    if !prefix_matching.accepts_prefixes() || word.len() < 2 {
         return None;
     }
     let mut matched: Option<&'a str> = None;
@@ -2134,6 +2126,7 @@ fn insert_option_and_subcommand_overrides(
     // command-form's options.  Dialect-agnostic (`None`): a switch is still
     // visually an option even when it was introduced in a later Tcl release.
     let mut option_names = spec.switch_names(None);
+    let mut option_prefix_matching = spec.prefix_matching;
 
     // Value-taking options whose value is a *generic* value — those get the
     // distinct `OptionValue` colour (the option/value split of issue #748).
@@ -2175,6 +2168,7 @@ fn insert_option_and_subcommand_overrides(
         && let Some(sub) = spec.resolve_subcommand_for_dialect(sub_text, dialect)
     {
         option_names.extend(sub.switch_names(None, spec.dialects));
+        option_prefix_matching = sub.prefix_matching;
         collect_value_options(sub.options);
         if let Some(tok) = seg.argv.get(1) {
             overrides
@@ -2206,7 +2200,8 @@ fn insert_option_and_subcommand_overrides(
         // (`Tcl_GetIndexFromObj`) does; an ambiguous prefix (`lsort -i`) is not
         // a recognised option.
         if text.starts_with('-')
-            && let Some(canonical) = resolve_option_prefix(text, &option_names)
+            && let Some(canonical) =
+                resolve_option_prefix(text, &option_names, option_prefix_matching)
             && let Some(tok) = seg.argv.get(i)
         {
             overrides
@@ -6664,14 +6659,35 @@ mod tests {
     }
 
     #[test]
+    fn lsearch_regexp_pattern_uses_the_registry_selected_language() {
+        let ks = kinds("lsearch -regexp {a b} {a+}\n", "tcl", &reg());
+        assert!(ks.contains(&(TokenKind::Regexp as u32)), "{ks:?}");
+        // The default glob form must not acquire regex subtokens merely
+        // because lsearch also supports -regexp.
+        let glob = kinds("lsearch {a b} {a+}\n", "tcl", &reg());
+        assert!(!glob.contains(&(TokenKind::Regexp as u32)), "{glob:?}");
+    }
+
+    #[test]
     fn resolve_option_prefix_resolves_and_rejects() {
         let names = ["-increasing", "-index", "-nocase", "-real"];
-        assert_eq!(resolve_option_prefix("-nocase", &names), Some("-nocase")); // exact
-        assert_eq!(resolve_option_prefix("-noc", &names), Some("-nocase")); // unique prefix
-        assert_eq!(resolve_option_prefix("-r", &names), Some("-real")); // unique prefix
-        assert_eq!(resolve_option_prefix("-in", &names), None); // ambiguous
-        assert_eq!(resolve_option_prefix("-", &names), None); // bare dash
-        assert_eq!(resolve_option_prefix("-zzz", &names), None); // unknown
+        let prefix = tcl_registry::abbrev::PrefixMatching::Enabled;
+        assert_eq!(
+            resolve_option_prefix("-nocase", &names, prefix),
+            Some("-nocase")
+        ); // exact
+        assert_eq!(
+            resolve_option_prefix("-noc", &names, prefix),
+            Some("-nocase")
+        ); // unique prefix
+        assert_eq!(resolve_option_prefix("-r", &names, prefix), Some("-real")); // unique prefix
+        assert_eq!(resolve_option_prefix("-in", &names, prefix), None); // ambiguous
+        assert_eq!(resolve_option_prefix("-", &names, prefix), None); // bare dash
+        assert_eq!(resolve_option_prefix("-zzz", &names, prefix), None); // unknown
+        assert_eq!(
+            resolve_option_prefix("-noc", &names, tcl_registry::abbrev::PrefixMatching::Strict,),
+            None
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -1499,7 +1499,7 @@ fn special_arg_kinds(
     }
 
     insert_regex_overrides(seg, registry, head, dialect, &mut overrides);
-    insert_format_overrides(seg, registry, head, arg_texts, &mut overrides);
+    insert_format_overrides(seg, registry, head, dialect, &mut overrides);
 
     // `proc NAME …` — the name argument is a function definition.  Procedure
     // definers come from the registry's `DEFINES_PROCEDURE` trait; a spec
@@ -2004,8 +2004,8 @@ fn mark_regex_source_words(
 /// the `-format` option value), `binary`'s cursor spec, and `regsub`'s
 /// replacement template.
 ///
-/// Entirely registry-driven ([`CommandRegistry::format_string_args`]): the
-/// *position* comes from the [`tcl_registry::ArgRole::FormatString`] /
+/// Entirely registry-driven ([`CommandRegistry::format_string_args_words_for_dialect`]):
+/// the *position* comes from the [`tcl_registry::ArgRole::FormatString`] /
 /// `ScanFormat` roles the specs and resolvers declare, and the *family* from
 /// `format_string_type`. No command name appears here, so the explicitly
 /// global spellings (`::format`, `::clock`, …) — which the previous
@@ -2021,10 +2021,15 @@ fn insert_format_overrides(
     seg: &tcl_compiler::segmenter::SegmentedCommand,
     registry: &CommandRegistry,
     head: &str,
-    arg_texts: &[&str],
+    dialect: DialectSet,
     overrides: &mut FxHashMap<u32, ArgOverride>,
 ) {
-    for found in registry.format_string_args(head, arg_texts) {
+    let source_args = segmented_command_arguments(seg);
+    for found in registry.format_string_args_words_for_dialect(
+        head,
+        InvocationArguments::structured(&source_args),
+        dialect,
+    ) {
         let Some(tok) = seg.argv.get(found.index + 1) else {
             continue;
         };
@@ -9287,6 +9292,65 @@ mod tests {
         assert!(
             ks.contains(&(TokenKind::Regexp as u32)),
             "expected a regexp token after -all; got {ks:?}"
+        );
+    }
+
+    /// PR #1514 P2: every resolver-owned pattern layout needs the same
+    /// source proof as lsearch. A dynamic leading word can be a value-taking
+    /// switch at runtime, so it cannot make the later literal a regexp; the
+    /// analogous regsub query must not steal the replacement as a template.
+    #[test]
+    fn dynamic_leading_options_do_not_claim_pattern_or_regsub_replacement_tokens() {
+        let registry = reg();
+        for src in [
+            "regexp $mode {a+} $value\n",
+            "regsub $mode {a+} $value {\\1}\n",
+        ] {
+            let tokens = decode_full(src, "tcl9.0", &registry);
+            assert!(
+                !tokens.iter().any(|&(_, _, _, kind, _)| {
+                    matches!(
+                        kind,
+                        value
+                            if value == TokenKind::Regexp as u32
+                                || value == TokenKind::RegexpQuantifier as u32
+                    )
+                }),
+                "{src:?}: unresolved leading option must not claim a regex word: {tokens:?}",
+            );
+        }
+
+        let tokens = decode_full("regsub $mode {a} $value {\\1}\n", "tcl9.0", &registry);
+        assert!(
+            !tokens.iter().any(|&(_, _, _, kind, _)| {
+                kind == TokenKind::Number as u32 || kind == TokenKind::Operator as u32
+            }),
+            "an unresolved regsub replacement is ordinary Tcl text: {tokens:?}",
+        );
+
+        for src in [
+            "regsub -c {a} $value {\\1}\n",
+            "regsub -command {a} $value callback\n",
+        ] {
+            let tokens = decode_full(src, "tcl9.0", &registry);
+            assert!(
+                !tokens.iter().any(|&(_, _, _, kind, _)| {
+                    kind == TokenKind::Number as u32 || kind == TokenKind::Operator as u32
+                }),
+                "{src:?}: only a valid template layout may receive regsub sub-tokens: {tokens:?}",
+            );
+        }
+
+        let tokens = decode_full(
+            "regsub -start $start {a} $value {\\1}\n",
+            "tcl9.0",
+            &registry,
+        );
+        assert!(
+            tokens
+                .iter()
+                .any(|&(_, _, _, kind, _)| kind == TokenKind::Number as u32),
+            "a known fixed-width -start option preserves the regsub replacement: {tokens:?}",
         );
     }
 

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -88,13 +88,14 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use tcl_compiler::analyser::types::{ProcArgTrait, ProcDef};
 use tcl_compiler::analyser::{AnalysisResult, ClassHierarchy};
 use tcl_compiler::compilation_unit::CompilationUnit;
+use tcl_compiler::registry_invocation::segmented_command_arguments;
 use tcl_compiler::segmenter::segment_commands_with_offset_and_config;
 use tcl_lexer::{LineIndex, Span, Token, TokenType};
 
 use crate::definition::utf16_len;
 use tcl_dialect::{DialectSet, NumberSyntax};
-use tcl_registry::CommandRegistry;
 use tcl_registry::definer::{DefinerFamily, DefinitionBodyGrammar, MemberKind};
+use tcl_registry::{CommandRegistry, InvocationArguments};
 
 /// Encoded semantic-tokens response.  The `data` array is
 /// the LSP packed integer encoding (5 ints per token: line
@@ -1497,7 +1498,7 @@ fn special_arg_kinds(
         overrides.insert(tok.span.start(), ArgOverride::Kind(TokenKind::Event));
     }
 
-    insert_regex_overrides(seg, registry, head, arg_texts, &mut overrides);
+    insert_regex_overrides(seg, registry, head, &mut overrides);
     insert_format_overrides(seg, registry, head, arg_texts, &mut overrides);
 
     // `proc NAME …` — the name argument is a function definition.  Procedure
@@ -1925,7 +1926,6 @@ fn insert_regex_overrides(
     seg: &tcl_compiler::segmenter::SegmentedCommand,
     registry: &CommandRegistry,
     head: &str,
-    arg_texts: &[&str],
     overrides: &mut FxHashMap<u32, ArgOverride>,
 ) {
     // Sub-tokenise only the *literal* fragments of the pattern word as regex:
@@ -1939,8 +1939,9 @@ fn insert_regex_overrides(
     // consumer must not guess that `-start` has a value or that the first
     // non-switch word is a pattern: those are command grammars owned by the
     // declared `OptionSpec` and `arg_role_resolver`.
+    let source_args = segmented_command_arguments(seg);
     for found in registry
-        .pattern_args(head, arg_texts)
+        .pattern_args_words(head, InvocationArguments::structured(&source_args))
         .into_iter()
         .filter(|found| found.kind == tcl_registry::patterns::PatternType::Regex)
     {

--- a/rust/tcl-lsp-core/tests/hover_residual.rs
+++ b/rust/tcl-lsp-core/tests/hover_residual.rs
@@ -197,9 +197,10 @@ fn residual_hover_glob_char_class_via_string_match() {
 
 #[test]
 fn residual_hover_glob_via_lsearch_dash_glob() {
-    // tclsh-proof: `lsearch -glob {foo bar baz} ba*` -> 1 (matches `bar` at
-    // index 1), confirming `lsearch -glob` is a real glob entry point. The
-    // detector fires on the `-glob` form too.
+    // tclsh-proof: `set list {foo bar baz}; lsearch -glob $list ba*` -> 1
+    // (matches `bar` at index 1), confirming `lsearch -glob` is a real glob
+    // entry point even with a dynamic list operand. The detector fires on
+    // the `-glob` form too.
     let src = "lsearch -glob $list {ba*}\n";
     let analysis = analyse(src);
     // Cursor inside the `{ba*}` pattern.
@@ -209,6 +210,21 @@ fn residual_hover_glob_via_lsearch_dash_glob() {
         h.value.contains("any sequence"),
         "expected `*` row: {}",
         h.value,
+    );
+}
+
+#[test]
+fn residual_hover_lsearch_dynamic_mode_keeps_pattern_ambiguous() {
+    // tclsh-proof: with `set mode -start`, `lsearch $mode {a b} {a+}` errors
+    // "missing starting index": `$mode` is still in lsearch's outer option
+    // scan, not the list operand. Its runtime value could instead be -glob,
+    // -regexp, -exact, or another switch, so no pattern-language hover is
+    // sound for the source-level `{a+}` word.
+    let src = "lsearch $mode {a b} {a+}\n";
+    let analysis = analyse(src);
+    assert!(
+        hover(src, 0, 21, &analysis, None).is_none(),
+        "a dynamic lsearch option prefix must not claim a glob/regex hover"
     );
 }
 

--- a/rust/tcl-lsp-core/tests/hover_residual.rs
+++ b/rust/tcl-lsp-core/tests/hover_residual.rs
@@ -59,8 +59,12 @@ use tcl_registry::CommandRegistry;
 // ------------------------------------------------------------------
 
 fn analyse(source: &str) -> AnalysisResult {
+    analyse_for_dialect(source, "tcl8.6")
+}
+
+fn analyse_for_dialect(source: &str, dialect: &str) -> AnalysisResult {
     let mut a = Analyser::new();
-    a.analyse(source, "tcl8.6").clone()
+    a.analyse(source, dialect).clone()
 }
 
 fn registry() -> CommandRegistry {
@@ -226,6 +230,36 @@ fn residual_hover_lsearch_dynamic_mode_keeps_pattern_ambiguous() {
         hover(src, 0, 21, &analysis, None).is_none(),
         "a dynamic lsearch option prefix must not claim a glob/regex hover"
     );
+}
+
+#[test]
+fn residual_hover_lsearch_invalid_option_prefix_abstains() {
+    // A dash-prefixed literal before lsearch's final list + pattern operands
+    // remains in Tcl's option scan. These spellings are rejected rather than
+    // becoming the list operand: -str is unavailable in Tcl 8, -st is
+    // ambiguous in Tcl 9, and lsearch does not support --.
+    for (dialect, option) in [("tcl8.6", "-str"), ("tcl9.0", "-st"), ("tcl9.0", "--")] {
+        let src = format!("lsearch -regexp {option} {{a+}} {{a b}} x\n");
+        let analysis = analyse_for_dialect(&src, dialect);
+        let plus = u32::try_from(src.find('+').expect("pattern plus") + 1)
+            .expect("source position fits LSP coordinate");
+        assert!(
+            hover(&src, 0, plus, &analysis, None).is_none(),
+            "{dialect} {option} is invalid inside lsearch's option scan and must not claim a regex hover"
+        );
+    }
+}
+
+#[test]
+fn residual_hover_lsearch_final_option_shaped_operands_stay_positional() {
+    // With exactly two arguments, both are mandatory operands. `-regexp` is
+    // the list, not a switch, so the final `{-x*}` keeps lsearch's default
+    // glob language even though the list operand looks option-shaped.
+    let src = "lsearch -regexp {-x*}\n";
+    let analysis = analyse(src);
+    let h = hover(src, 0, 20, &analysis, None).expect("positional glob hover");
+    assert!(h.value.contains("Glob pattern"), "{}", h.value);
+    assert!(h.value.contains("any sequence"), "{}", h.value);
 }
 
 // ==================================================================

--- a/rust/tcl-lsp-server-wasm/Cargo.lock
+++ b/rust/tcl-lsp-server-wasm/Cargo.lock
@@ -790,6 +790,16 @@ name = "tcl-core-types"
 version = "0.1.0"
 
 [[package]]
+name = "tcl-diagram"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+ "tcl-compiler",
+ "tcl-lexer",
+ "tcl-registry",
+]
+
+[[package]]
 name = "tcl-dialect"
 version = "0.1.0"
 dependencies = [
@@ -900,6 +910,7 @@ dependencies = [
  "tcl-bigip",
  "tcl-compiler",
  "tcl-core-types",
+ "tcl-diagram",
  "tcl-dialect",
  "tcl-explorer",
  "tcl-lexer",

--- a/rust/tcl-lsp-server-wasm/Cargo.lock
+++ b/rust/tcl-lsp-server-wasm/Cargo.lock
@@ -795,6 +795,7 @@ version = "0.1.0"
 dependencies = [
  "serde_json",
  "tcl-compiler",
+ "tcl-dialect",
  "tcl-lexer",
  "tcl-registry",
  "tcl-syntax",

--- a/rust/tcl-lsp-server-wasm/Cargo.lock
+++ b/rust/tcl-lsp-server-wasm/Cargo.lock
@@ -797,6 +797,7 @@ dependencies = [
  "tcl-compiler",
  "tcl-lexer",
  "tcl-registry",
+ "tcl-syntax",
 ]
 
 [[package]]

--- a/rust/tcl-lsp-server/Cargo.toml
+++ b/rust/tcl-lsp-server/Cargo.toml
@@ -48,6 +48,9 @@ tcl-lsp-db = { path = "../tcl-lsp-db" }
 # Powers the `tcl-lsp.compilerExplorer` workspace command (same pipeline +
 # JSON serialisation the `tcl explore` CLI uses).
 tcl-explorer = { path = "../tcl-explorer" }
+# Shared structured control-flow projection used by the CLI, MCP, and LSP
+# diagram command.
+tcl-diagram = { path = "../tcl-diagram" }
 # Same minimal set as `tcl-lsp-db`, and for the same reason: salsa's
 # defaults pull in `rayon`, whose thread pool cannot start in a browser
 # worker. Trimming it in `tcl-lsp-db` alone would achieve nothing — cargo

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -10818,16 +10818,17 @@ impl Backend {
         serde_json::json!({ "events": names })
     }
 
-    /// Handle `tcl-lsp.diagramData`: extract the `when EVENT` event names from
-    /// a source string.
-    fn diagram_data_command(args: &[serde_json::Value]) -> Option<serde_json::Value> {
+    /// Handle `tcl-lsp.diagramData` through the shared structured diagram
+    /// projection.  The CLI and MCP use the same `tcl-diagram` entry point;
+    /// keeping the LSP on it preserves the full `{events, procedures}` shape
+    /// (including flow, priority, and multiplicity) consumed by the editors.
+    async fn diagram_data_command(&self, args: &[serde_json::Value]) -> Option<serde_json::Value> {
         let source = args.first().and_then(serde_json::Value::as_str)?;
-        let events: Vec<serde_json::Value> =
-            tcl_lsp_core::irules_context::scan_file_events(source, "f5-irules")
-                .into_iter()
-                .map(|name| serde_json::json!({ "name": name }))
-                .collect();
-        Some(serde_json::json!({ "events": events }))
+        let dialect = "f5-irules";
+        let registry = self.registry_for_dialect(dialect).await;
+        Some(tcl_diagram::diagram_data_for_dialect(
+            source, &registry, dialect,
+        ))
     }
 
     /// Handle `tcl-lsp.fixAllSafeIssues`: apply every non-overlapping
@@ -17063,7 +17064,7 @@ impl LanguageServer for Backend {
                 self.describe_irule_command_command(&params.arguments).await
             }
             "tcl-lsp.listIruleEvents" => Ok(Some(Self::list_irule_events_command())),
-            "tcl-lsp.diagramData" => Ok(Self::diagram_data_command(&params.arguments)),
+            "tcl-lsp.diagramData" => Ok(self.diagram_data_command(&params.arguments).await),
             "tcl-lsp.getEffectiveConfig" => {
                 self.get_effective_config_command(&params.arguments).await
             }
@@ -21507,9 +21508,10 @@ fn build_server_capabilities(
         // silently disables our richer push pipeline (`publish_diagnostics`)
         // and makes clients render each diagnostic twice (#721).  The
         // `textDocument/diagnostic` + `workspace/diagnostic` handlers still
-        // exist for a client that opts in via `tclLsp.features.pullDiagnostics`
-        // (registered dynamically on that path), but the default capability set
-        // leaves this absent so push stays the sole delivery channel.
+        // exist for a client that requests them directly, but the default
+        // capability set leaves this absent so push stays the sole delivery
+        // channel. Switching models is an initialize-time client/server
+        // contract, not a live feature toggle.
         diagnostic_provider: None,
         // Editor-invoked workspace commands (currently the
         // minify-document command family).
@@ -23457,10 +23459,14 @@ mod tests {
         assert_eq!(names, sorted, "events must be sorted");
     }
 
-    #[test]
-    fn diagram_data_command_extracts_when_events() {
+    #[tokio::test]
+    async fn diagram_data_command_extracts_structured_flow() {
+        let backend = test_backend();
         let src = "when HTTP_REQUEST {\n}\nwhen CLIENT_ACCEPTED {\n}\n";
-        let out = Backend::diagram_data_command(&[serde_json::json!(src)]).expect("some");
+        let out = backend
+            .diagram_data_command(&[serde_json::json!(src)])
+            .await
+            .expect("some");
         let events: Vec<&str> = out
             .get("events")
             .and_then(|v| v.as_array())
@@ -23470,8 +23476,13 @@ mod tests {
             .collect();
         assert!(events.contains(&"HTTP_REQUEST"), "{events:?}");
         assert!(events.contains(&"CLIENT_ACCEPTED"), "{events:?}");
+        assert!(
+            out.get("procedures")
+                .and_then(serde_json::Value::as_array)
+                .is_some()
+        );
         // No string argument → None (not an empty result).
-        assert!(Backend::diagram_data_command(&[]).is_none());
+        assert!(backend.diagram_data_command(&[]).await.is_none());
     }
 
     #[tokio::test]

--- a/rust/tcl-lsp-server/tests/e2e/commands.rs
+++ b/rust/tcl-lsp-server/tests/e2e/commands.rs
@@ -395,12 +395,12 @@ fn diagram_extracts_irule_events() {
 #[test]
 fn diagram_data_serialises_completion_contract_for_clients() {
     let mut lsp = Lsp::tcl();
-    let source = r#"
+    let source = r"
         proc paths {} {
             return stop
             set after [clock seconds]
         }
-    "#;
+    ";
     let result = lsp.execute_command("tcl-lsp.diagramData", json!([source]));
     let return_node = &result["procedures"][0]["flow"][0];
     assert_eq!(return_node["kind"], "return", "{result}");

--- a/rust/tcl-lsp-server/tests/e2e/commands.rs
+++ b/rust/tcl-lsp-server/tests/e2e/commands.rs
@@ -393,6 +393,21 @@ fn diagram_extracts_irule_events() {
 }
 
 #[test]
+fn diagram_data_serialises_completion_contract_for_clients() {
+    let mut lsp = Lsp::tcl();
+    let source = r#"
+        proc paths {} {
+            return stop
+            set after [clock seconds]
+        }
+    "#;
+    let result = lsp.execute_command("tcl-lsp.diagramData", json!([source]));
+    let return_node = &result["procedures"][0]["flow"][0];
+    assert_eq!(return_node["kind"], "return", "{result}");
+    assert_eq!(return_node["completion"], "return", "{result}");
+}
+
+#[test]
 fn effective_config_shape() {
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");

--- a/rust/tcl-lsp-server/tests/e2e/commands.rs
+++ b/rust/tcl-lsp-server/tests/e2e/commands.rs
@@ -353,7 +353,7 @@ fn list_irule_events_nonempty() {
 #[test]
 fn diagram_extracts_irule_events() {
     let mut lsp = Lsp::tcl();
-    let source = "when HTTP_REQUEST {\n    if {[HTTP::uri] eq \"/\"} { pool web }\n}\n";
+    let source = "proc helper {x} {\n    if {$x} { return ok }\n}\nwhen HTTP_REQUEST {\n    if {[HTTP::uri] eq \"/\"} { pool web }\n}\n";
     let result = lsp.execute_command("tcl-lsp.diagramData", json!([source]));
     assert!(!result.is_null());
     let names: Vec<&str> = result
@@ -366,6 +366,30 @@ fn diagram_extracts_irule_events() {
         })
         .unwrap_or_default();
     assert!(names.contains(&"HTTP_REQUEST"), "{names:?}");
+    let event = result["events"]
+        .as_array()
+        .and_then(|events| events.first())
+        .expect("event payload");
+    assert!(event.get("priority").is_some(), "{event}");
+    assert!(
+        event.get("multiplicity").and_then(Value::as_str).is_some(),
+        "{event}"
+    );
+    assert!(
+        event["flow"]
+            .as_array()
+            .is_some_and(|flow| !flow.is_empty()),
+        "{event}"
+    );
+    let procedures = result["procedures"].as_array().expect("procedures payload");
+    assert_eq!(procedures.len(), 1, "{procedures:?}");
+    assert_eq!(procedures[0]["name"], "helper");
+    assert_eq!(procedures[0]["params"], json!(["x"]));
+    assert!(
+        procedures[0]["flow"]
+            .as_array()
+            .is_some_and(|flow| !flow.is_empty())
+    );
 }
 
 #[test]

--- a/rust/tcl-lsp-server/tests/smoke/diagnostics_delivery_smoke.rs
+++ b/rust/tcl-lsp-server/tests/smoke/diagnostics_delivery_smoke.rs
@@ -213,6 +213,7 @@ async fn pull_capable_client_still_gets_push_by_default() {
             frames.iter().any(|frame| {
                 frame.contains("textDocument/publishDiagnostics")
                     && frame.contains("file:///dup.tcl")
+                    && frame.contains("\"version\":2")
                     && frame.contains("\"diagnostics\":[]")
             })
         })
@@ -309,6 +310,7 @@ async fn push_only_client_still_receives_one_push() {
             frames.iter().any(|frame| {
                 frame.contains("textDocument/publishDiagnostics")
                     && frame.contains("file:///push.tcl")
+                    && frame.contains("\"version\":2")
                     && frame.contains("\"diagnostics\":[]")
             })
         })

--- a/rust/tcl-lsp-server/tests/smoke/diagnostics_delivery_smoke.rs
+++ b/rust/tcl-lsp-server/tests/smoke/diagnostics_delivery_smoke.rs
@@ -99,31 +99,11 @@ where
     }
 }
 
-/// Collect every frame the server emits within `window`.
-async fn collect_frames<R>(reader: &mut BufReader<R>, window: Duration) -> Vec<String>
-where
-    R: tokio::io::AsyncRead + Unpin,
-{
-    let mut frames = Vec::new();
-    let deadline = tokio::time::Instant::now() + window;
-    loop {
-        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-        if remaining.is_zero() {
-            break;
-        }
-        match tokio::time::timeout(remaining, read_frame(reader)).await {
-            Ok(body) => frames.push(body),
-            Err(_) => break,
-        }
-    }
-    frames
-}
-
 /// Read frames into `sink` until the accumulated frames satisfy `reached`, and
 /// report whether they did before `backstop` expired.
 ///
-/// The counterpart of [`collect_frames`] for anything that has a *terminal
-/// signal* rather than a quiet period: instead of guessing how long the server
+/// For anything that has a *terminal signal* rather than a quiet period, wait
+/// for that signal instead of guessing how long the server
 /// needs, wait for the thing that says it is done. A fixed collection window is
 /// a wall-clock bet on the server's speed, so on a machine short of CPU it ends
 /// the collection early and turns a correct server into a missing publish; the
@@ -207,7 +187,38 @@ async fn pull_capable_client_still_gets_push_by_default() {
     // Push is the sole channel: the server must deliver exactly one
     // content-bearing `publishDiagnostics` carrying the E003, even to this
     // pull-capable client (which, absent a `diagnosticProvider`, never pulls).
-    let frames = collect_frames(&mut reader, Duration::from_millis(1500)).await;
+    let mut frames = Vec::new();
+    assert!(
+        drain_until(&mut reader, &mut frames, RESPONSE_BACKSTOP, |frames| {
+            frames.iter().any(|frame| {
+                frame.contains("textDocument/publishDiagnostics")
+                    && frame.contains("file:///dup.tcl")
+            })
+        })
+        .await,
+        "expected a diagnostic publish before the hang guard: {frames:?}",
+    );
+    // #1417: prove delivery has quiesced by changing the document to a clean
+    // revision, then waiting for the terminal empty publish for *that*
+    // revision. A 200 ms collection window only guesses that a duplicate has
+    // arrived; this mutation is a negative control and the resulting publish
+    // is the protocol-level condition that analysis reached the new state.
+    let did_change = r#"{"jsonrpc":"2.0","method":"textDocument/didChange","params":{"textDocument":{"uri":"file:///dup.tcl","version":2},"contentChanges":[{"text":"puts ok\n"}]}}"#;
+    client_write
+        .write_all(frame(did_change).as_bytes())
+        .await
+        .unwrap();
+    assert!(
+        drain_until(&mut reader, &mut frames, RESPONSE_BACKSTOP, |frames| {
+            frames.iter().any(|frame| {
+                frame.contains("textDocument/publishDiagnostics")
+                    && frame.contains("file:///dup.tcl")
+                    && frame.contains("\"diagnostics\":[]")
+            })
+        })
+        .await,
+        "clean mutation never published its empty diagnostic set: {frames:?}",
+    );
     let e003_pushes = frames
         .iter()
         .filter(|f| f.contains("textDocument/publishDiagnostics") && f.contains("E003"))
@@ -215,6 +226,12 @@ async fn pull_capable_client_still_gets_push_by_default() {
     assert_eq!(
         e003_pushes, 1,
         "expected exactly one pushed E003 publish, got {e003_pushes}: {frames:?}",
+    );
+    assert!(
+        frames.iter().any(|frame| {
+            frame.contains("file:///dup.tcl") && frame.contains("\"diagnostics\":[]")
+        }),
+        "the clean mutation must clear the prior diagnostic: {frames:?}",
     );
 
     let shutdown = r#"{"jsonrpc":"2.0","id":9,"method":"shutdown","params":null}"#;
@@ -271,7 +288,33 @@ async fn push_only_client_still_receives_one_push() {
 
     // The push-only client gets the diagnostics over `publishDiagnostics`, with
     // exactly one E003 (no duplicate).
-    let frames = collect_frames(&mut reader, Duration::from_millis(1200)).await;
+    let mut frames = Vec::new();
+    assert!(
+        drain_until(&mut reader, &mut frames, RESPONSE_BACKSTOP, |frames| {
+            frames.iter().any(|frame| {
+                frame.contains("textDocument/publishDiagnostics")
+                    && frame.contains("file:///push.tcl")
+            })
+        })
+        .await,
+        "expected a diagnostic publish before the hang guard: {frames:?}",
+    );
+    let did_change = r#"{"jsonrpc":"2.0","method":"textDocument/didChange","params":{"textDocument":{"uri":"file:///push.tcl","version":2},"contentChanges":[{"text":"puts ok\n"}]}}"#;
+    client_write
+        .write_all(frame(did_change).as_bytes())
+        .await
+        .unwrap();
+    assert!(
+        drain_until(&mut reader, &mut frames, RESPONSE_BACKSTOP, |frames| {
+            frames.iter().any(|frame| {
+                frame.contains("textDocument/publishDiagnostics")
+                    && frame.contains("file:///push.tcl")
+                    && frame.contains("\"diagnostics\":[]")
+            })
+        })
+        .await,
+        "clean mutation never published its empty diagnostic set: {frames:?}",
+    );
     let publishes: Vec<&String> = frames
         .iter()
         .filter(|f| f.contains("textDocument/publishDiagnostics") && f.contains("file:///push.tcl"))
@@ -287,6 +330,12 @@ async fn push_only_client_still_receives_one_push() {
         1,
         "the publish itself must not duplicate the diagnostic: {}",
         with_e003[0],
+    );
+    assert!(
+        frames.iter().any(|frame| {
+            frame.contains("file:///push.tcl") && frame.contains("\"diagnostics\":[]")
+        }),
+        "the clean mutation must clear the prior diagnostic: {frames:?}",
     );
 
     let exit = r#"{"jsonrpc":"2.0","method":"exit","params":null}"#;

--- a/rust/tcl-registry/examples/dump_specs.rs
+++ b/rust/tcl-registry/examples/dump_specs.rs
@@ -137,6 +137,7 @@ const BOOL_TRAITS: &[(&str, Traits)] = &[
     ("is_control_flow", Traits::CONTROL_FLOW),
     ("needs_start_cmd", Traits::NEEDS_START_CMD),
     ("terminates_block", Traits::TERMINATES_BLOCK),
+    ("terminates_process", Traits::TERMINATES_PROCESS),
     ("is_oo_metaclass", Traits::IS_OO_METACLASS),
     ("irules_top_level_only", Traits::IRULES_TOP_LEVEL_ONLY),
     ("is_unescape_command", Traits::IS_UNESCAPE),

--- a/rust/tcl-registry/src/command_snapshot.rs
+++ b/rust/tcl-registry/src/command_snapshot.rs
@@ -98,6 +98,7 @@ const TRAIT_FLAGS: &[(&str, Traits)] = &[
     ("sources_file", Traits::SOURCES_FILE),
     ("taint_sink", Traits::TAINT_SINK),
     ("terminates_block", Traits::TERMINATES_BLOCK),
+    ("terminates_process", Traits::TERMINATES_PROCESS),
     ("unsafe", Traits::UNSAFE),
 ];
 

--- a/rust/tcl-registry/src/commands/tcl/exit_.rs
+++ b/rust/tcl-registry/src/commands/tcl/exit_.rs
@@ -50,7 +50,10 @@ pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "exit",
         dialects: Some(DialectSet::ALL_TCL),
-        traits: Traits::BYTE_COMPILED | Traits::TERMINATES_BLOCK | Traits::SAFE_INTERP_HIDDEN,
+        traits: Traits::BYTE_COMPILED
+            | Traits::TERMINATES_BLOCK
+            | Traits::TERMINATES_PROCESS
+            | Traits::SAFE_INTERP_HIDDEN,
         arity: Arity::new(0, 1),
         side_effects: &[SideEffect {
             target: SideEffectTarget::InterpState,

--- a/rust/tcl-registry/src/commands/tcl/exit_.rs
+++ b/rust/tcl-registry/src/commands/tcl/exit_.rs
@@ -55,6 +55,11 @@ pub fn spec() -> CommandSpec {
             | Traits::TERMINATES_PROCESS
             | Traits::SAFE_INTERP_HIDDEN,
         arity: Arity::new(0, 1),
+        // The process-terminal trait says that a *successful* invocation
+        // cannot fall through.  This descriptor owns the value grammar too:
+        // a static non-integer returnCode is TCL_ERROR, while a substituted
+        // one is the typed ProcessExit-or-Error union for flow consumers.
+        completion: Some(CompletionDescriptor::process_exit_status()),
         side_effects: &[SideEffect {
             target: SideEffectTarget::InterpState,
             writes: true,

--- a/rust/tcl-registry/src/commands/tcl/glob_.rs
+++ b/rust/tcl-registry/src/commands/tcl/glob_.rs
@@ -127,6 +127,22 @@ const OPTION_CONSTRAINTS: &[OptionConstraint] = &[OptionConstraint {
     ..OptionConstraint::DEFAULT
 }];
 
+/// Locate every pattern in glob's tail after its declared option prefix.
+///
+/// [`leading_option_word_count`] resolves abbreviations and reads each
+/// descriptor's value arity, so `-dir tmp`, `-di tmp`, and future
+/// value-taking options shift the tail identically for every consumer.
+fn glob_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
+    let start = leading_option_word_count(spec().options, args);
+    (start..args.len())
+        .filter_map(|index| {
+            u8::try_from(index)
+                .ok()
+                .map(|index| (index, ArgRole::Pattern))
+        })
+        .collect()
+}
+
 /// Command spec for `glob`.
 pub fn spec() -> CommandSpec {
     CommandSpec {
@@ -155,6 +171,8 @@ pub fn spec() -> CommandSpec {
         // misflagging a legitimate modern zero-pattern call; the exact
         // per-era requirement is documented precisely on `FORMS` above.
         arity: Arity::any(),
+        pattern_type: Some(PatternType::Glob),
+        arg_role_resolver: Some(glob_arg_roles),
         return_type: Some(TclType::List),
         side_effects: &[SideEffect {
             target: SideEffectTarget::FileIo,

--- a/rust/tcl-registry/src/commands/tcl/lsearch_.rs
+++ b/rust/tcl-registry/src/commands/tcl/lsearch_.rs
@@ -246,6 +246,17 @@ fn lsearch_pattern_args(
         let word = args[option_end];
         let Some(option) = crate::patterns::resolve_available_option_prefix(context.options, word)
         else {
+            // This is still Tcl's outer option region, not a free-form
+            // positional prefix. A dash-prefixed literal that cannot resolve
+            // in this release is an invalid invocation: it may be unknown,
+            // ambiguous, `--` (which lsearch does not support), or name an
+            // option introduced by a later release. Do not invent a pattern
+            // position after an invocation the interpreter rejects. A
+            // non-option word, by contrast, is the mandatory list operand
+            // and ends the scan normally.
+            if word.starts_with('-') {
+                return Vec::new();
+            }
             break;
         };
         // The matching-style options are mutually overriding: the final one

--- a/rust/tcl-registry/src/commands/tcl/lsearch_.rs
+++ b/rust/tcl-registry/src/commands/tcl/lsearch_.rs
@@ -290,6 +290,11 @@ pub fn spec() -> CommandSpec {
         arg_role_resolver: Some(lsearch_arg_roles),
         pattern_arg_resolver: Some(lsearch_pattern_args),
         options: OPTIONS,
+        // `Tcl_LsearchObjCmd` scans outer options with `i < objc - 2` in
+        // Tcl 8.4, 8.6, and 9.0's generic/tclCmdIL.c. The mandatory list and
+        // pattern operands are therefore never option candidates, even when
+        // source substitution will produce their runtime values.
+        reserved_trailing_words: 2,
         hover: Some(HoverSnippet {
             summary: "Search a list for an element matching a pattern.",
             synopsis: &["lsearch ?options? list pattern"],

--- a/rust/tcl-registry/src/commands/tcl/lsearch_.rs
+++ b/rust/tcl-registry/src/commands/tcl/lsearch_.rs
@@ -228,6 +228,49 @@ static OPTIONS: &[OptionSpec] = &[
     // `analyse_no_w304_for_lsearch` regression test depends on this.
 ];
 
+/// `lsearch ?options? list pattern` has one list operand followed by its
+/// pattern.  The option table is the grammar: `-start`/`-index`/`-stride`
+/// consume their declared values, and a unique abbreviation consumes exactly
+/// the same layout as its canonical spelling.
+fn lsearch_pattern_args(args: &[&str]) -> Vec<PatternArg> {
+    let mut option_end = 0;
+    let mut kind = Some(PatternType::Glob);
+    while let Some(&word) = args.get(option_end) {
+        let Some(option) = resolve_option_prefix(OPTIONS, word) else {
+            break;
+        };
+        // The matching-style options are mutually overriding: the final one
+        // Tcl accepts decides the embedded language. Exact and sorted forms
+        // have no pattern mini-language, so they intentionally produce none.
+        kind = match option.name {
+            "-glob" => Some(PatternType::Glob),
+            "-regexp" => Some(PatternType::Regex),
+            "-exact" | "-sorted" => None,
+            _ => kind,
+        };
+        option_end += 1 + option.value_word_count(args, option_end);
+        if option.name == "--" {
+            break;
+        }
+    }
+    let pattern = option_end.saturating_add(1); // skip list
+    kind.filter(|_| pattern < args.len())
+        .and_then(|kind| {
+            u8::try_from(pattern)
+                .ok()
+                .map(|index| PatternArg { index, kind })
+        })
+        .into_iter()
+        .collect()
+}
+
+fn lsearch_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
+    lsearch_pattern_args(args)
+        .into_iter()
+        .map(|arg| (arg.index, ArgRole::Pattern))
+        .collect()
+}
+
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "lsearch",
@@ -244,6 +287,8 @@ pub fn spec() -> CommandSpec {
         // style per call, but the registry's `pattern_type` is a single
         // per-command fact, so it records the default.
         pattern_type: Some(PatternType::Glob),
+        arg_role_resolver: Some(lsearch_arg_roles),
+        pattern_arg_resolver: Some(lsearch_pattern_args),
         options: OPTIONS,
         hover: Some(HoverSnippet {
             summary: "Search a list for an element matching a pattern.",

--- a/rust/tcl-registry/src/commands/tcl/lsearch_.rs
+++ b/rust/tcl-registry/src/commands/tcl/lsearch_.rs
@@ -232,11 +232,20 @@ static OPTIONS: &[OptionSpec] = &[
 /// pattern.  The option table is the grammar: `-start`/`-index`/`-stride`
 /// consume their declared values, and a unique abbreviation consumes exactly
 /// the same layout as its canonical spelling.
-fn lsearch_pattern_args(args: &[&str]) -> Vec<PatternArg> {
+fn lsearch_pattern_args(
+    args: &[&str],
+    context: crate::patterns::PatternArgResolverContext<'_>,
+) -> Vec<PatternArg> {
     let mut option_end = 0;
     let mut kind = Some(PatternType::Glob);
-    while let Some(&word) = args.get(option_end) {
-        let Some(option) = resolve_option_prefix(OPTIONS, word) else {
+    // Tcl's outer parser scans only while both mandatory operands remain.
+    // In particular, `lsearch -regexp -glob` searches list `-regexp` for
+    // glob pattern `-glob`; neither trailing word is an option candidate.
+    let option_scan_end = args.len().saturating_sub(context.reserved_trailing_words);
+    while option_end < option_scan_end {
+        let word = args[option_end];
+        let Some(option) = crate::patterns::resolve_available_option_prefix(context.options, word)
+        else {
             break;
         };
         // The matching-style options are mutually overriding: the final one
@@ -264,13 +273,6 @@ fn lsearch_pattern_args(args: &[&str]) -> Vec<PatternArg> {
         .collect()
 }
 
-fn lsearch_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
-    lsearch_pattern_args(args)
-        .into_iter()
-        .map(|arg| (arg.index, ArgRole::Pattern))
-        .collect()
-}
-
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "lsearch",
@@ -287,7 +289,6 @@ pub fn spec() -> CommandSpec {
         // style per call, but the registry's `pattern_type` is a single
         // per-command fact, so it records the default.
         pattern_type: Some(PatternType::Glob),
-        arg_role_resolver: Some(lsearch_arg_roles),
         pattern_arg_resolver: Some(lsearch_pattern_args),
         options: OPTIONS,
         // `Tcl_LsearchObjCmd` scans outer options with `i < objc - 2` in

--- a/rust/tcl-registry/src/commands/tcl/regexp_.rs
+++ b/rust/tcl-registry/src/commands/tcl/regexp_.rs
@@ -48,8 +48,9 @@ const FORMS: &[FormSpec] = &[
 fn regexp_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
     let i = first_positional_index(REGEXP_OPTIONS, args, 0);
     let capture_start = i + 2; // skip pattern + string
-    (capture_start..args.len())
-        .filter_map(|j| u8::try_from(j).ok().map(|j| (j, ArgRole::VarWrite)))
+    std::iter::once((i, ArgRole::Pattern))
+        .chain((capture_start..args.len()).map(|index| (index, ArgRole::VarWrite)))
+        .filter_map(|(index, role)| u8::try_from(index).ok().map(|index| (index, role)))
         .collect()
 }
 
@@ -165,6 +166,9 @@ pub fn spec() -> CommandSpec {
         // `string`, no `-about`) is consequently not caught by this
         // coarse check.
         arity: Arity::at_least(1),
+        // `Tcl_RegexpObjCmd` uses `TCL_EXACT`: unlike the common
+        // Tcl_GetIndexFromObj tables, `-sta` is an error rather than -start.
+        prefix_matching: PrefixMatching::Strict,
         return_type: Some(TclType::Int),
         // `regexp` writes matched substrings to its capture variables while
         // returning the match *count* (or 0/1).  The captures are strings, not

--- a/rust/tcl-registry/src/commands/tcl/regsub_.rs
+++ b/rust/tcl-registry/src/commands/tcl/regsub_.rs
@@ -220,6 +220,11 @@ pub fn spec() -> CommandSpec {
             ..SideEffect::DEFAULT
         }],
         options: OPTIONS,
+        // `Tcl_RegsubObjCmd` resolves this table with `TCL_EXACT`: unlike
+        // `switch`, neither `-c` nor any other unique prefix is a valid
+        // `regsub` switch. Keep the source-aware layout proof and the legacy
+        // resolver on the same exact-spelling grammar.
+        prefix_matching: PrefixMatching::Strict,
         hover: Some(HoverSnippet {
             summary: "Perform substitutions based on regular expression pattern matching.",
             synopsis: &["regsub ?switches? exp string subSpec ?varName?"],
@@ -309,6 +314,18 @@ mod tests {
     /// command-prefix mode, only the exact spelling may.
     #[test]
     fn command_prefix_resolver_requires_exact_command_spelling() {
+        assert_eq!(
+            spec().prefix_matching,
+            PrefixMatching::Strict,
+            "the CommandSpec option table must agree with this resolver's exact spellings"
+        );
+        assert!(
+            spec()
+                .options
+                .iter()
+                .all(|option| option.aliases.is_empty()),
+            "regsub has no option aliases that could provide an alternate exact spelling"
+        );
         // Exact `-command` at the front: `subSpec` (index 3: -command, exp,
         // string, subSpec) is a command prefix appending >= 1 arg.
         assert_eq!(

--- a/rust/tcl-registry/src/commands/tcl/string_.rs
+++ b/rust/tcl-registry/src/commands/tcl/string_.rs
@@ -19,6 +19,28 @@
 //! `string` — perform one of several string operations.
 
 use crate::prelude::*;
+
+/// `string match ?-nocase? pattern string` — the declared option prefix shifts
+/// the pattern.  The shared descriptor walk also accepts Tcl's unambiguous
+/// `-noc` abbreviation without teaching any consumer about this subcommand.
+fn match_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
+    let index = leading_option_word_count(MATCH_OPTIONS, args);
+    (index < args.len())
+        .then(|| u8::try_from(index).ok().map(|i| (i, ArgRole::Pattern)))
+        .flatten()
+        .into_iter()
+        .collect()
+}
+
+const MATCH_OPTIONS: &[OptionSpec] = &[OptionSpec {
+    name: "-nocase",
+    value: OptionValue::flag(),
+    detail: "Match without regard to case; the endpoints of a [x-y] range are lower-cased first, so [A-z] behaves like [A-Za-z].",
+    dialects: None,
+    aliases: &[],
+    lifecycle: Lifecycle::UNSPECIFIED,
+    min_abbrev: None,
+}];
 use tcl_syntax::number::{Number, parse_whole};
 
 const FORMS: &[FormSpec] = &[FormSpec {
@@ -1325,17 +1347,9 @@ static SUBCOMMANDS: &[SubCommand] = &[
         pure: true,
         const_fold: Some(fold_match),
         return_type: Some(TclType::Boolean),
-        options: const {
-            &[OptionSpec {
-                name: "-nocase",
-                value: OptionValue::flag(),
-                detail: "Match without regard to case; the endpoints of a [x-y] range are lower-cased first, so [A-z] behaves like [A-Za-z].",
-                dialects: None,
-                aliases: &[],
-                lifecycle: Lifecycle::UNSPECIFIED,
-                min_abbrev: None,
-            }]
-        },
+        options: MATCH_OPTIONS,
+        arg_role_resolver: Some(match_arg_roles),
+        pattern_type: Some(PatternType::Glob),
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/completion.rs
+++ b/rust/tcl-registry/src/completion.rs
@@ -57,6 +57,26 @@ pub enum CompletionCodeDomain {
     Any,
 }
 
+/// Value-dependent completion behaviour declared by a command descriptor.
+///
+/// Most Tcl commands' completion does not depend on parsing one of their
+/// ordinary value operands, so [`Self::None`] keeps their descriptor purely
+/// code-domain based.  `exit` is the important exception: a valid integer
+/// status terminates the process, while an invalid status raises Tcl error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompletionValueSemantics {
+    /// No value-sensitive completion parser is needed.
+    None,
+    /// Parse an optional Tcl integer process-exit status.
+    ///
+    /// Omission and a static valid integer terminate the process; a static
+    /// invalid value raises `TCL_ERROR`; a dynamic word is the typed union of
+    /// those two outcomes.  The registry applies this parser before generic
+    /// terminal traits, so invalid `exit` values never become false process
+    /// exits in diagram or control-flow consumers.
+    ProcessExitStatus,
+}
+
 /// The data-flow obligation for one completion payload.
 ///
 /// This deliberately describes provenance rather than a runtime value type.
@@ -115,6 +135,8 @@ pub struct CompletionDescriptor {
     pub codes: CompletionCodeDomain,
     /// Result and return-options data-flow obligations.
     pub payloads: CompletionPayloadObligations,
+    /// Value-sensitive completion parser, when this command declares one.
+    pub value_semantics: CompletionValueSemantics,
 }
 
 impl CompletionDescriptor {
@@ -122,6 +144,7 @@ impl CompletionDescriptor {
     pub const CONSERVATIVE: Self = Self {
         codes: CompletionCodeDomain::Any,
         payloads: CompletionPayloadObligations::UNKNOWN,
+        value_semantics: CompletionValueSemantics::None,
     };
 
     /// Build an exact completion descriptor with produced result/options.
@@ -130,6 +153,19 @@ impl CompletionDescriptor {
         Self {
             codes: CompletionCodeDomain::Exact(codes),
             payloads: CompletionPayloadObligations::PRODUCED,
+            value_semantics: CompletionValueSemantics::None,
+        }
+    }
+
+    /// Build the value-sensitive descriptor for `exit ?returnCode?`.
+    #[must_use]
+    pub const fn process_exit_status() -> Self {
+        Self {
+            // Process termination is deliberately not a Tcl completion code.
+            // The value parser above is the authoritative projection.
+            codes: CompletionCodeDomain::Exact(&[]),
+            payloads: CompletionPayloadObligations::PRODUCED,
+            value_semantics: CompletionValueSemantics::ProcessExitStatus,
         }
     }
 }

--- a/rust/tcl-registry/src/completion.rs
+++ b/rust/tcl-registry/src/completion.rs
@@ -27,6 +27,21 @@
 
 pub use tcl_core_types::Code as CompletionCode;
 
+/// Parse Tcl's integer completion-code spelling and apply its C-compatible
+/// 32-bit conversion. Tcl accepts `INT_MIN..UINT_MAX`: the upper unsigned
+/// half wraps into the corresponding signed code (`4294967295` is `-1`).
+/// Values outside that range, including integers beyond Tcl's wide parser,
+/// are not valid completion-code selectors.
+#[must_use]
+#[allow(clippy::cast_possible_truncation)] // Intentional Tcl UINT_MAX → signed-code wrap.
+pub fn canonical_completion_code(value: &str, numbers: tcl_syntax::number::Numbers) -> Option<i32> {
+    let value = numbers.parse_wide(value)?;
+    if value < i64::from(i32::MIN) || value > i64::from(u32::MAX) {
+        return None;
+    }
+    Some(value as i32)
+}
+
 /// The statically possible Tcl completion codes for an invocation.
 ///
 /// [`Self::Exact`] retains named Tcl codes and arbitrary integer codes alike:

--- a/rust/tcl-registry/src/invocation_words.rs
+++ b/rust/tcl-registry/src/invocation_words.rs
@@ -178,6 +178,13 @@ impl<'w> InvocationArguments<'w> {
         !self.are_all_literals()
     }
 
+    /// Whether this view retained source word shape rather than accepting the
+    /// legacy string-only compatibility projection.
+    #[must_use]
+    pub const fn is_source_aware(self) -> bool {
+        matches!(self, Self::Structured(_))
+    }
+
     /// Return every post-head Tcl value when all source words are literal.
     ///
     /// This is the explicit compatibility bridge for established registry

--- a/rust/tcl-registry/src/invocation_words.rs
+++ b/rust/tcl-registry/src/invocation_words.rs
@@ -35,6 +35,12 @@ pub enum InvocationWord<'w> {
     Literal(&'w str),
     /// One non-expanded argv word whose value is produced by substitution.
     Dynamic,
+    /// One substituted argv word whose non-empty literal prefix proves its
+    /// evaluated value cannot begin with `-` and therefore cannot be a
+    /// leading option. For example, `"prefix-$value"` remains dynamic as a
+    /// value, but it cannot select a command option before the known
+    /// positional layout.
+    DynamicNonOption,
     /// A `{*}` word whose evaluated Tcl list contributes an unknown number of
     /// argv entries.
     Expanded,
@@ -62,7 +68,7 @@ impl<'w> InvocationWord<'w> {
     pub const fn literal(self) -> Option<&'w str> {
         match self {
             Self::Literal(value) => Some(value),
-            Self::Dynamic | Self::Expanded | Self::Opaque => None,
+            Self::Dynamic | Self::DynamicNonOption | Self::Expanded | Self::Opaque => None,
         }
     }
 
@@ -72,7 +78,7 @@ impl<'w> InvocationWord<'w> {
     pub const fn kind(self) -> InvocationWordKind {
         match self {
             Self::Literal(_) => InvocationWordKind::Literal,
-            Self::Dynamic => InvocationWordKind::Dynamic,
+            Self::Dynamic | Self::DynamicNonOption => InvocationWordKind::Dynamic,
             Self::Expanded => InvocationWordKind::Expanded,
             Self::Opaque => InvocationWordKind::Opaque,
         }
@@ -82,7 +88,10 @@ impl<'w> InvocationWord<'w> {
     /// entry after evaluation.
     #[must_use]
     pub const fn has_exactly_one_argv_entry(self) -> bool {
-        matches!(self, Self::Literal(_) | Self::Dynamic)
+        matches!(
+            self,
+            Self::Literal(_) | Self::Dynamic | Self::DynamicNonOption
+        )
     }
 }
 
@@ -371,6 +380,18 @@ mod tests {
         assert_eq!(
             InvocationArguments::structured(&structured).literal_values(),
             Some(vec!["first", "second"])
+        );
+    }
+
+    #[test]
+    fn non_option_dynamic_keeps_argv_shape_without_exposing_a_value() {
+        let arguments = InvocationArguments::structured(&[InvocationWord::DynamicNonOption]);
+        assert!(arguments.has_exact_argv_len());
+        assert_eq!(arguments.literal_at(0), None);
+        assert_eq!(arguments.literal_values(), None);
+        assert_eq!(
+            arguments.get(0).map(InvocationWord::kind),
+            Some(InvocationWordKind::Dynamic)
         );
     }
 }

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -128,7 +128,7 @@ pub mod prelude {
     pub use crate::command_table::CommandTableEffect;
     pub use crate::completion::{
         CompletionCode, CompletionCodeDomain, CompletionDescriptor, CompletionPayloadObligation,
-        CompletionPayloadObligations,
+        CompletionPayloadObligations, CompletionValueSemantics,
     };
     pub use crate::definer::{
         DefinerFamily, DefinitionBodyGrammar, MemberKind, MemberRefKind, MemberRetraction,
@@ -222,7 +222,7 @@ pub use clause_shape::{ClauseShapeChecker, ClauseShapeError};
 pub use command_table::CommandTableEffect;
 pub use completion::{
     CompletionCode, CompletionCodeDomain, CompletionDescriptor, CompletionPayloadObligation,
-    CompletionPayloadObligations,
+    CompletionPayloadObligations, CompletionValueSemantics,
 };
 pub use dialects::{
     DETECT_SCAN_BYTES, KNOWN_DIALECTS, available_dialects, detect_dialect,

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -169,7 +169,7 @@ pub mod prelude {
         LiteralArgumentIssue, LiteralArgumentIssueReason, LiteralArgumentValidation,
         LiteralValidationDecline,
     };
-    pub use crate::patterns::{FormatType, PatternType};
+    pub use crate::patterns::{FormatType, PatternArg, PatternType};
     pub use crate::presentation::ArgPresentation;
     pub use crate::repeated::RepeatedArgLayout;
     pub use crate::representation::RepresentationEffect;
@@ -182,7 +182,8 @@ pub mod prelude {
     pub use crate::spec::{
         BytePayloadSpec, CaseForceListShape, CaseListSpec, CommandSpec, ContextGate,
         DefaultFormFirstWord, InlineCaseClause, ObjectClassSpec, OoContextFact, OptionConstraint,
-        SubCommand, SubSubCommand, VersionedArgValue,
+        SubCommand, SubSubCommand, VersionedArgValue, leading_option_word_count,
+        leading_option_word_count_with, resolve_option_prefix, resolve_option_prefix_with,
     };
     pub use crate::state_transition::{
         CallerFrameSelection, ChildInterpreterSafety, CommandBindingDefinitionKind,

--- a/rust/tcl-registry/src/patterns.rs
+++ b/rust/tcl-registry/src/patterns.rs
@@ -36,6 +36,23 @@ pub enum PatternType {
     Regex,
 }
 
+/// One concrete pattern-bearing argument of an invocation.
+///
+/// Most commands use one static [`PatternType`] plus an [`ArgRole::Pattern`]
+/// position. Commands such as `lsearch` select the language with an option,
+/// so their registry resolver returns this paired fact rather than forcing an
+/// LSP consumer to understand `-regexp` itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PatternArg {
+    /// Index into the post-head argument list.
+    pub index: u8,
+    /// Embedded language accepted at this position.
+    pub kind: PatternType,
+}
+
+/// Resolve a command's call-specific pattern arguments.
+pub type PatternArgResolver = fn(&[&str]) -> Vec<PatternArg>;
+
 impl PatternType {
     /// Stable lowercase tag (`"glob"` / `"regex"`) — used by the audit
     /// dumper so both sides normalise identically.

--- a/rust/tcl-registry/src/patterns.rs
+++ b/rust/tcl-registry/src/patterns.rs
@@ -24,6 +24,8 @@
 //! emit *sub-tokens* (semantic-token splitting inside the string
 //! literal) and run pattern-specific validation.
 
+use crate::hover::OptionSpec;
+
 /// Kind of pattern language an argument uses, for semantic tokens and
 /// validation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -50,8 +52,60 @@ pub struct PatternArg {
     pub kind: PatternType,
 }
 
+/// Registry context supplied to a call-specific pattern resolver.
+///
+/// The caller filters [`options`](Self::options) for the document's resolved
+/// profile before invoking the resolver.  Keeping the option grammar and the
+/// reserved positional suffix together means an option-selected pattern
+/// layout cannot accidentally recognise a switch that this Tcl release does
+/// not have, nor scan a mandatory operand merely because it looks like one.
+#[derive(Debug, Clone, Copy)]
+pub struct PatternArgResolverContext<'a> {
+    /// Available option descriptors in declaration order.
+    pub options: &'a [&'static OptionSpec],
+    /// Mandatory trailing operands excluded from the leading option scan.
+    pub reserved_trailing_words: usize,
+}
+
 /// Resolve a command's call-specific pattern arguments.
-pub type PatternArgResolver = fn(&[&str]) -> Vec<PatternArg>;
+///
+/// Resolver callbacks receive the profile-filtered option metadata and the
+/// command's reserved trailing operand boundary.  The callback must use both
+/// rather than carrying a private option table or inferring the positional
+/// boundary itself.
+pub type PatternArgResolver = for<'a> fn(&[&str], PatternArgResolverContext<'a>) -> Vec<PatternArg>;
+
+/// Resolve an option word against profile-filtered descriptor references.
+///
+/// Static option tables use [`crate::spec::resolve_option_prefix`]; this
+/// counterpart preserves the same exact-or-unique-prefix rule after a
+/// profile has selected only the options this invocation can actually use.
+#[must_use]
+pub(crate) fn resolve_available_option_prefix<'a>(
+    options: &'a [&crate::hover::OptionSpec],
+    word: &str,
+) -> Option<&'a crate::hover::OptionSpec> {
+    if let Some(option) = options.iter().copied().find(|option| option.matches(word)) {
+        return Some(option);
+    }
+    if !word.starts_with('-') || word.len() < 2 {
+        return None;
+    }
+    let mut found = None;
+    for option in options.iter().copied() {
+        if std::iter::once(option.name)
+            .chain(option.aliases.iter().copied())
+            .any(|spelling| spelling.starts_with(word))
+        {
+            match found {
+                None => found = Some(option),
+                Some(previous) if std::ptr::eq(previous, option) => {}
+                Some(_) => return None,
+            }
+        }
+    }
+    found
+}
 
 impl PatternType {
     /// Stable lowercase tag (`"glob"` / `"regex"`) — used by the audit

--- a/rust/tcl-registry/src/patterns.rs
+++ b/rust/tcl-registry/src/patterns.rs
@@ -24,6 +24,7 @@
 //! emit *sub-tokens* (semantic-token splitting inside the string
 //! literal) and run pattern-specific validation.
 
+use crate::abbrev::PrefixMatching;
 use crate::hover::OptionSpec;
 
 /// Kind of pattern language an argument uses, for semantic tokens and
@@ -85,17 +86,35 @@ pub(crate) fn resolve_available_option_prefix<'a>(
     options: &'a [&crate::hover::OptionSpec],
     word: &str,
 ) -> Option<&'a crate::hover::OptionSpec> {
+    resolve_available_option_prefix_with(options, word, PrefixMatching::Enabled)
+}
+
+/// [`resolve_available_option_prefix`] with the command's declared prefix
+/// policy.  A profile has already removed unavailable options from `options`,
+/// so this one walk preserves the remaining exact-or-unique abbreviation
+/// grammar without accidentally restoring an option from another release.
+#[must_use]
+pub(crate) fn resolve_available_option_prefix_with<'a>(
+    options: &'a [&crate::hover::OptionSpec],
+    word: &str,
+    prefix_matching: PrefixMatching,
+) -> Option<&'a crate::hover::OptionSpec> {
     if let Some(option) = options.iter().copied().find(|option| option.matches(word)) {
         return Some(option);
     }
-    if !word.starts_with('-') || word.len() < 2 {
+    if !prefix_matching.accepts_prefixes() || !word.starts_with('-') || word.len() < 2 {
         return None;
     }
     let mut found = None;
     for option in options.iter().copied() {
         if std::iter::once(option.name)
             .chain(option.aliases.iter().copied())
-            .any(|spelling| spelling.starts_with(word))
+            .any(|spelling| {
+                spelling.starts_with(word)
+                    && option
+                        .min_abbrev
+                        .is_none_or(|minimum| word.len() >= usize::from(minimum))
+            })
         {
             match found {
                 None => found = Some(option),

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -145,10 +145,6 @@ fn exact_return_completion(
     let mut level = 1_i64;
     while let Some(word) = args.get(i).copied() {
         match word {
-            "--" => {
-                i += 1;
-                break;
-            }
             "-code" => {
                 let value = *args.get(i + 1)?;
                 code = match value {
@@ -6632,6 +6628,14 @@ mod tests {
                 DialectSet::empty(),
             ),
             None
+        );
+        assert_eq!(
+            reg.exact_invocation_completion(
+                "return",
+                &["--", "-code", "error"],
+                DialectSet::empty(),
+            ),
+            Some(ExactInvocationCompletion::Tcl(CompletionCode::Return))
         );
     }
 

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -134,10 +134,20 @@ pub enum ExactInvocationCompletion {
 /// itself propagates `TCL_RETURN` even when its eventual procedure result is
 /// configured as `-code error`; `-level 0` exposes that configured code to the
 /// immediately enclosing script instead.
+/// The literal-return parser distinguishes an invocation whose outcome is
+/// genuinely runtime-dependent from one Tcl will reject before it can return.
+/// The latter is still a precise `TCL_ERROR`, so an enclosing `try on error`
+/// must receive it.
+enum ExactReturnCompletion {
+    Completion(crate::completion::CompletionCode),
+    StaticError,
+    Dynamic,
+}
+
 fn exact_return_completion(
     args: &[&str],
     numbers: tcl_syntax::number::Numbers,
-) -> Option<crate::completion::CompletionCode> {
+) -> ExactReturnCompletion {
     use crate::completion::CompletionCode;
 
     let mut i = 0usize;
@@ -146,45 +156,66 @@ fn exact_return_completion(
     while let Some(word) = args.get(i).copied() {
         match word {
             "-code" => {
-                let value = *args.get(i + 1)?;
+                let Some(value) = args.get(i + 1).copied() else {
+                    return ExactReturnCompletion::StaticError;
+                };
                 code = match value {
                     "ok" | "0" => CompletionCode::Ok,
                     "error" | "1" => CompletionCode::Error,
                     "return" | "2" => CompletionCode::Return,
                     "break" | "3" => CompletionCode::Break,
                     "continue" | "4" => CompletionCode::Continue,
-                    value => CompletionCode::from_int(
-                        crate::completion::canonical_completion_code(value, numbers)?,
-                    ),
+                    value => match crate::completion::canonical_completion_code(value, numbers) {
+                        Some(value) => CompletionCode::from_int(value),
+                        None if tcl_syntax::naming::is_dynamic_word(value) => {
+                            return ExactReturnCompletion::Dynamic;
+                        }
+                        None => return ExactReturnCompletion::StaticError,
+                    },
                 };
                 i += 2;
             }
             "-level" => {
-                level = numbers.parse_wide(args.get(i + 1)?)?;
-                if level < 0 {
-                    return None;
-                }
+                let Some(value) = args.get(i + 1).copied() else {
+                    return ExactReturnCompletion::StaticError;
+                };
+                level = match numbers.parse_wide(value) {
+                    Some(value) if value >= 0 => value,
+                    None if tcl_syntax::naming::is_dynamic_word(value) => {
+                        return ExactReturnCompletion::Dynamic;
+                    }
+                    _ => return ExactReturnCompletion::StaticError,
+                };
                 i += 2;
             }
             // These options do not alter the code, but `-options` may carry
             // a code/level override so remains deliberately opaque.
             "-options" => {
-                return None;
+                return if args.get(i + 1).is_none() {
+                    ExactReturnCompletion::StaticError
+                } else {
+                    ExactReturnCompletion::Dynamic
+                };
             }
             // Return options are an extensible key/value dictionary.  An
             // unrecognised literal option cannot alter `-code`/`-level`, so
             // retain the concrete completion rather than dropping a valid
             // custom pair such as `-foo bar`.
-            _ if word.starts_with('-') => i += 2,
+            _ if word.starts_with('-') => {
+                if args.get(i + 1).is_none() {
+                    return ExactReturnCompletion::StaticError;
+                }
+                i += 2;
+            }
             _ => break,
         }
     }
     // `return` accepts one result word after its options; additional words are
     // an arity error, so no exact runtime completion is promised.
     if args.len().saturating_sub(i) > 1 {
-        return None;
+        return ExactReturnCompletion::StaticError;
     }
-    Some(if level == 0 {
+    ExactReturnCompletion::Completion(if level == 0 {
         code
     } else {
         CompletionCode::Return
@@ -2028,11 +2059,18 @@ impl CommandRegistry {
         }
         if resolved.lowering_hook == Some(LoweringHookId::Return) {
             let profile = self.profile()?;
-            return exact_return_completion(
+            return match exact_return_completion(
                 args,
                 tcl_syntax::number::Numbers::of_profile(Some(profile)),
-            )
-            .map(ExactInvocationCompletion::Tcl);
+            ) {
+                ExactReturnCompletion::Completion(code) => {
+                    Some(ExactInvocationCompletion::Tcl(code))
+                }
+                ExactReturnCompletion::StaticError => Some(ExactInvocationCompletion::Tcl(
+                    crate::completion::CompletionCode::Error,
+                )),
+                ExactReturnCompletion::Dynamic => None,
+            };
         }
         let traits =
             resolved.spec.traits | resolved.sub.map_or_else(Traits::empty, |sub| sub.traits);
@@ -6641,14 +6679,6 @@ mod tests {
             );
         }
         assert_eq!(
-            reg.exact_invocation_completion(
-                "return",
-                &["-level", "0", "-code", "-2147483649", "payload"],
-                DialectSet::empty(),
-            ),
-            None
-        );
-        assert_eq!(
             reg.exact_invocation_completion("exit", &["0"], DialectSet::empty()),
             Some(ExactInvocationCompletion::ProcessExit)
         );
@@ -6676,6 +6706,33 @@ mod tests {
             ),
             Some(ExactInvocationCompletion::Tcl(CompletionCode::Return))
         );
+    }
+
+    #[test]
+    fn exact_return_static_invalid_forms_are_catchable_errors() {
+        use crate::completion::CompletionCode;
+
+        // Oracle table: Tcl 8.6 and 9.0 both reject these literal forms at
+        // return's option/arity boundary, so a surrounding `try on error`
+        // receives TCL_ERROR rather than a dynamic completion.
+        for dialect in ["tcl8.6", "tcl9.0"] {
+            let reg = crate::registry_for_dialect(dialect);
+            for args in [
+                &["-code", "bogus", "payload"][..],
+                &["-level", "-1", "payload"][..],
+                &["-code"][..],
+                &["-level"][..],
+                &["-foo"][..],
+                &["payload", "extra"][..],
+                &["-level", "0", "-code", "-2147483649", "payload"][..],
+            ] {
+                assert_eq!(
+                    reg.exact_invocation_completion("return", args, DialectSet::empty()),
+                    Some(ExactInvocationCompletion::Tcl(CompletionCode::Error)),
+                    "{dialect}: {args:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -129,6 +129,17 @@ pub enum ExactInvocationCompletion {
     ProcessExit,
 }
 
+/// Registry-owned completion knowledge for a source-aware invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvocationCompletionKnowledge {
+    /// A fully determined Tcl completion or process exit.
+    Exact(ExactInvocationCompletion),
+    /// `return -code $value` can either propagate return or reject the code.
+    DynamicReturnOrError,
+    /// The invocation has a runtime-dependent completion.
+    Dynamic,
+}
+
 /// Parse the literal option subset of `return` that fixes the completion code
 /// visible to an enclosing `try`.  With the default `-level 1`, `return`
 /// itself propagates `TCL_RETURN` even when its eventual procedure result is
@@ -145,7 +156,7 @@ enum ExactReturnCompletion {
 }
 
 fn exact_return_completion(
-    args: &[&str],
+    args: crate::invocation_words::InvocationArguments<'_>,
     numbers: tcl_syntax::number::Numbers,
 ) -> ExactReturnCompletion {
     use crate::completion::CompletionCode;
@@ -153,11 +164,15 @@ fn exact_return_completion(
     let mut i = 0usize;
     let mut code = CompletionCode::Ok;
     let mut level = 1_i64;
-    while let Some(word) = args.get(i).copied() {
+    while let Some(word) = args.literal_at(i) {
         match word {
             "-code" => {
-                let Some(value) = args.get(i + 1).copied() else {
-                    return ExactReturnCompletion::StaticError;
+                let Some(value) = args.literal_at(i + 1) else {
+                    return if args.get(i + 1).is_some() {
+                        ExactReturnCompletion::Dynamic
+                    } else {
+                        ExactReturnCompletion::StaticError
+                    };
                 };
                 code = match value {
                     "ok" | "0" => CompletionCode::Ok,
@@ -167,7 +182,9 @@ fn exact_return_completion(
                     "continue" | "4" => CompletionCode::Continue,
                     value => match crate::completion::canonical_completion_code(value, numbers) {
                         Some(value) => CompletionCode::from_int(value),
-                        None if tcl_syntax::naming::is_dynamic_word(value) => {
+                        None if !args.is_source_aware()
+                            && tcl_syntax::naming::is_dynamic_word(value) =>
+                        {
                             return ExactReturnCompletion::Dynamic;
                         }
                         None => return ExactReturnCompletion::StaticError,
@@ -176,12 +193,18 @@ fn exact_return_completion(
                 i += 2;
             }
             "-level" => {
-                let Some(value) = args.get(i + 1).copied() else {
-                    return ExactReturnCompletion::StaticError;
+                let Some(value) = args.literal_at(i + 1) else {
+                    return if args.get(i + 1).is_some() {
+                        ExactReturnCompletion::Dynamic
+                    } else {
+                        ExactReturnCompletion::StaticError
+                    };
                 };
                 level = match numbers.parse_wide(value) {
                     Some(value) if value >= 0 => value,
-                    None if tcl_syntax::naming::is_dynamic_word(value) => {
+                    None if !args.is_source_aware()
+                        && tcl_syntax::naming::is_dynamic_word(value) =>
+                    {
                         return ExactReturnCompletion::Dynamic;
                     }
                     _ => return ExactReturnCompletion::StaticError,
@@ -212,7 +235,10 @@ fn exact_return_completion(
     }
     // `return` accepts one result word after its options; additional words are
     // an arity error, so no exact runtime completion is promised.
-    if args.len().saturating_sub(i) > 1 {
+    if args
+        .exact_argv_len()
+        .is_some_and(|len| len.saturating_sub(i) > 1)
+    {
         return ExactReturnCompletion::StaticError;
     }
     ExactReturnCompletion::Completion(if level == 0 {
@@ -2047,7 +2073,25 @@ impl CommandRegistry {
         args: &[&str],
         dialect: DialectSet,
     ) -> Option<ExactInvocationCompletion> {
-        let resolved = self.resolve_call(name, args, dialect)?;
+        self.exact_invocation_completion_words(
+            name,
+            crate::invocation_words::InvocationArguments::literals(args),
+            dialect,
+        )
+    }
+
+    /// Source-aware counterpart to [`Self::exact_invocation_completion`].
+    /// Dynamic words remain dynamic; literal brace words retain their literal
+    /// value rather than being mistaken for a variable spelling.
+    #[must_use]
+    pub fn exact_invocation_completion_words(
+        &self,
+        name: &str,
+        args: crate::invocation_words::InvocationArguments<'_>,
+        dialect: DialectSet,
+    ) -> Option<ExactInvocationCompletion> {
+        let literal_args = args.literal_values().unwrap_or_default();
+        let resolved = self.resolve_call(name, &literal_args, dialect)?;
         let positional_len = args
             .len()
             .saturating_sub(usize::from(resolved.sub.is_some()));
@@ -2086,6 +2130,35 @@ impl CommandRegistry {
             return None;
         };
         (codes.len() == 1).then_some(ExactInvocationCompletion::Tcl(codes[0]))
+    }
+
+    /// Return source-aware completion knowledge without exposing return-option
+    /// parsing to a consumer such as the diagram renderer.
+    #[must_use]
+    pub fn invocation_completion_knowledge(
+        &self,
+        name: &str,
+        args: crate::invocation_words::InvocationArguments<'_>,
+        dialect: DialectSet,
+    ) -> Option<InvocationCompletionKnowledge> {
+        if let Some(exact) = self.exact_invocation_completion_words(name, args, dialect) {
+            return Some(InvocationCompletionKnowledge::Exact(exact));
+        }
+        let literals = args.literal_values().unwrap_or_default();
+        let resolved = self.resolve_call(name, &literals, dialect)?;
+        if resolved.lowering_hook != Some(LoweringHookId::Return) {
+            return None;
+        }
+        let dynamic_code = (0..args.len()).any(|index| {
+            args.literal_at(index) == Some("-code") && args.literal_at(index + 1).is_none()
+        });
+        let has_level = (0..args.len()).any(|index| args.literal_at(index) == Some("-level"));
+        let has_options = (0..args.len()).any(|index| args.literal_at(index) == Some("-options"));
+        Some(if dynamic_code && !has_level && !has_options {
+            InvocationCompletionKnowledge::DynamicReturnOrError
+        } else {
+            InvocationCompletionKnowledge::Dynamic
+        })
     }
 
     /// Whether `name` is valid only at the top level of an iRule script
@@ -6730,6 +6803,62 @@ mod tests {
                     reg.exact_invocation_completion("return", args, DialectSet::empty()),
                     Some(ExactInvocationCompletion::Tcl(CompletionCode::Error)),
                     "{dialect}: {args:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn exact_return_source_words_distinguish_literals_from_substitution() {
+        use crate::completion::CompletionCode;
+        use crate::invocation_words::{InvocationArguments, InvocationWord};
+
+        // Tcl 8.6 and 9.0 oracle: braces keep `$code` and `\\x32` literal,
+        // while a bare/quoted substitution remains unknown and a decoded bare
+        // escape can be supplied to this API as its effective static value.
+        for dialect in ["tcl8.6", "tcl9.0"] {
+            let reg = crate::registry_for_dialect(dialect);
+            for words in [
+                vec![
+                    InvocationWord::Literal("-code"),
+                    InvocationWord::Literal("$code"),
+                ],
+                vec![
+                    InvocationWord::Literal("-code"),
+                    InvocationWord::Literal("\\x32"),
+                ],
+            ] {
+                assert_eq!(
+                    reg.exact_invocation_completion_words(
+                        "return",
+                        InvocationArguments::structured(&words),
+                        DialectSet::empty()
+                    ),
+                    Some(ExactInvocationCompletion::Tcl(CompletionCode::Error)),
+                    "{dialect}: {words:?}"
+                );
+            }
+            let decoded = [
+                InvocationWord::Literal("-code"),
+                InvocationWord::Literal("2"),
+            ];
+            assert_eq!(
+                reg.exact_invocation_completion_words(
+                    "return",
+                    InvocationArguments::structured(&decoded),
+                    DialectSet::empty()
+                ),
+                Some(ExactInvocationCompletion::Tcl(CompletionCode::Return)),
+            );
+            for dynamic in [InvocationWord::Dynamic, InvocationWord::Dynamic] {
+                let words = [InvocationWord::Literal("-code"), dynamic];
+                assert_eq!(
+                    reg.exact_invocation_completion_words(
+                        "return",
+                        InvocationArguments::structured(&words),
+                        DialectSet::empty()
+                    ),
+                    None,
                 );
             }
         }

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -509,14 +509,19 @@ fn push_command_prefix_options(
 /// scan continues. A substituted word at the next option position might
 /// itself evaluate to a value-taking option, so consumers cannot safely use a
 /// resolver-derived positional role after it. Once a literal non-option ends
-/// the scan, later dynamic operands do not affect the layout.
+/// the scan, later dynamic operands do not affect the layout. Likewise,
+/// `reserved_trailing_words` are mandatory positional operands which Tcl's
+/// outer grammar excludes from option scanning; a dynamic word in that suffix
+/// cannot alter the already-established layout.
 fn has_dynamic_leading_option_word(
     options: &[crate::hover::OptionSpec],
     args: InvocationArguments<'_>,
     spellings: &[&str],
+    reserved_trailing_words: usize,
 ) -> bool {
     let mut index = 0;
-    while index < args.len() {
+    let option_scan_end = args.len().saturating_sub(reserved_trailing_words);
+    while index < option_scan_end {
         let Some(word) = args.literal_at(index) else {
             return true;
         };
@@ -2691,12 +2696,14 @@ impl CommandRegistry {
 
     /// Source-aware counterpart to [`Self::pattern_args`].
     ///
-    /// A resolver-selected pattern position depends on literal option words.
-    /// Once source substitution reaches that option prefix, treating its
-    /// spelling as a positional operand would shift the remaining arguments
-    /// and incorrectly claim a pattern language.  Static pattern layouts do
-    /// not have that ambiguity and continue through the compatibility
-    /// resolver, whose indices are independent of argument values.
+    /// A resolver-selected pattern position depends on literal option words
+    /// and a known final argv shape. Once source substitution reaches that
+    /// option prefix, treating its spelling as a positional operand would
+    /// shift the remaining arguments and incorrectly claim a pattern
+    /// language. An expansion can likewise move the mandatory trailing
+    /// operands. Static pattern layouts do not have that ambiguity and
+    /// continue through the compatibility resolver, whose indices are
+    /// independent of argument values.
     #[must_use]
     pub fn pattern_args_words(
         &self,
@@ -2710,8 +2717,14 @@ impl CommandRegistry {
             .map(|index| args.literal_at(index).unwrap_or_default())
             .collect();
         if spec.pattern_arg_resolver.is_some()
-            && (spec.options.is_empty() && args.has_non_literal()
-                || has_dynamic_leading_option_word(spec.options, args, &spellings))
+            && (!args.has_exact_argv_len()
+                || (spec.options.is_empty() && args.has_non_literal())
+                || has_dynamic_leading_option_word(
+                    spec.options,
+                    args,
+                    &spellings,
+                    spec.reserved_trailing_words,
+                ))
         {
             return Vec::new();
         }
@@ -4262,22 +4275,61 @@ mod tests {
     }
 
     #[test]
-    fn source_aware_pattern_roles_stop_at_a_dynamic_option_prefix() {
+    fn source_aware_lsearch_pattern_layout_respects_outer_option_boundary() {
         use crate::invocation_words::{InvocationArguments, InvocationWord};
+        use crate::patterns::{PatternArg, PatternType};
 
-        let reg = CommandRegistry::build_default();
-        let args = [
-            InvocationWord::Dynamic,
-            InvocationWord::Literal("{a b c}"),
-            InvocationWord::Literal("glob*"),
-        ];
-        // `$mode` may become any lsearch option, including an option that
-        // consumes a value. Its source spelling must never be treated as the
-        // list operand and shift the remaining words into a claimed glob.
-        assert!(
-            reg.pattern_args_words("lsearch", InvocationArguments::structured(&args))
-                .is_empty()
-        );
+        // Tcl's `Tcl_LsearchObjCmd` has used `for (i = 1; i < objc - 2;
+        // i++)` since 8.4: it stops scanning exactly when list and pattern
+        // remain. Keep the source-aware resolver aligned across every
+        // supported core release, including the 9.0 -stride expansion.
+        for dialect in ["tcl8.4", "tcl8.5", "tcl8.6", "tcl9.0", "tcl9.1"] {
+            let reg = crate::registry_for_dialect(dialect);
+            let proven_outer_option = [
+                InvocationWord::Literal("-glob"),
+                InvocationWord::Dynamic,
+                InvocationWord::Literal("ba*"),
+            ];
+            assert_eq!(
+                reg.pattern_args_words(
+                    "lsearch",
+                    InvocationArguments::structured(&proven_outer_option),
+                ),
+                vec![PatternArg {
+                    index: 2,
+                    kind: PatternType::Glob,
+                }],
+                "{dialect}: lsearch -glob $list {{ba*}} has proven operands and glob mode"
+            );
+
+            let expanded_list = [
+                InvocationWord::Literal("-glob"),
+                InvocationWord::Expanded,
+                InvocationWord::Literal("ba*"),
+            ];
+            assert!(
+                reg.pattern_args_words("lsearch", InvocationArguments::structured(&expanded_list))
+                    .is_empty(),
+                "{dialect}: lsearch -glob {{*}}$list {{ba*}} has no known argv suffix"
+            );
+
+            let ambiguous_option_prefix = [
+                InvocationWord::Dynamic,
+                InvocationWord::Literal("{a b}"),
+                InvocationWord::Literal("a+"),
+            ];
+            // `$mode` remains inside the `i < objc - 2` option region and
+            // may become a value-taking switch, so it cannot be reclassified
+            // as the list operand to claim a glob pattern.
+            assert!(
+                reg.pattern_args_words(
+                    "lsearch",
+                    InvocationArguments::structured(&ambiguous_option_prefix),
+                )
+                .is_empty(),
+                "{dialect}: lsearch $mode {{a b}} {{a+}} remains ambiguous"
+            );
+        }
     }
 
     /// Issue #1185 — the repeated argument tails a fixed index table cannot

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -301,9 +301,10 @@ fn push_repeated_roles(
 /// (primary or secondary) equals `role`.
 ///
 /// Walks `args` from `scan_start` (1 to skip a subcommand word, else 0),
-/// matching option names/aliases literally — so `-1`, `$x`, `[cmd]` are treated
-/// as positionals, never flags — and advancing past each recognised option and
-/// the value word(s) it consumes ([`OptionSpec::value_indices`], which honours
+/// resolving option names, aliases, and unique abbreviations through the
+/// declared table — so `-1`, `$x`, `[cmd]`, and ambiguous abbreviations are
+/// treated as positionals — and advancing past each recognised option and the
+/// value word(s) it consumes ([`OptionSpec::value_indices`], which honours
 /// arity and the `--` terminator). The emitted indices are absolute into `args`,
 /// exactly like the positional roles, so consumers map them via `argv[idx + 1]`
 /// unchanged. A two-way binding (`role: VarWrite, also_role: VarRead`) emits its
@@ -321,7 +322,7 @@ fn push_option_value_roles(
         if args[i] == "--" {
             break;
         }
-        if let Some(opt) = options.iter().find(|o| o.matches(args[i])) {
+        if let Some(opt) = crate::spec::resolve_option_prefix(options, args[i]) {
             let vals = opt.value_indices(args, i);
             if opt.value_role() == Some(role) || opt.value_also_role() == Some(role) {
                 out.extend(vals.iter().copied());
@@ -347,7 +348,7 @@ fn push_command_prefix_options(
         if args[i] == "--" {
             break;
         }
-        if let Some(opt) = options.iter().find(|o| o.matches(args[i])) {
+        if let Some(opt) = crate::spec::resolve_option_prefix(options, args[i]) {
             let vals = opt.value_indices(args, i);
             if opt.value_role() == Some(ArgRole::CommandPrefix) {
                 let arity = opt.value_appended_arity();
@@ -2370,6 +2371,34 @@ impl CommandRegistry {
         out
     }
 
+    /// The pattern-bearing arguments of one concrete invocation.
+    ///
+    /// This pairs each declared position with its embedded language. A static
+    /// command derives the positions from [`ArgRole::Pattern`]; an
+    /// option-selected command supplies the paired facts through its registry
+    /// resolver. Consumers therefore never need command-name or `-regexp`
+    /// branches of their own.
+    #[must_use]
+    pub fn pattern_args(&self, name: &str, args: &[&str]) -> Vec<crate::patterns::PatternArg> {
+        let Some(spec) = self.get(name) else {
+            return Vec::new();
+        };
+        if let Some(resolve) = spec.pattern_arg_resolver {
+            return resolve(args);
+        }
+        let sub = (!spec.subcommands.is_empty())
+            .then(|| args.first().and_then(|word| spec.resolve_subcommand(word)))
+            .flatten();
+        let Some(kind) = sub.and_then(|sub| sub.pattern_type).or(spec.pattern_type) else {
+            return Vec::new();
+        };
+        self.arg_indices_for_role(name, args, ArgRole::Pattern)
+            .into_iter()
+            .filter_map(|index| u8::try_from(index).ok())
+            .map(|index| crate::patterns::PatternArg { index, kind })
+            .collect()
+    }
+
     /// How a formatter should **present** argument `index` of a call to
     /// `name` — the layout fact that refines the argument's semantic
     /// [`ArgRole`] (issue #1186).
@@ -3870,6 +3899,46 @@ mod tests {
             !found("regsub", &["-command", "--", "e", "$s", "cb"])
                 .iter()
                 .any(|(i, _, _)| *i == 3)
+        );
+    }
+
+    /// Pattern locations come from the owning specs' option descriptors, not
+    /// from an LSP walk guessing where a `-start` value ends.  Exercise the
+    /// three shapes that previously drifted: abbreviations, value-taking
+    /// options, and glob's unbounded pattern tail.
+    #[test]
+    fn pattern_roles_follow_declared_option_prefixes() {
+        let reg = CommandRegistry::build_default();
+        assert_eq!(
+            reg.arg_indices_for_role("lsearch", &["-sta", "2", "{a b c}", "b*"], ArgRole::Pattern,),
+            vec![3],
+        );
+        assert_eq!(
+            reg.arg_indices_for_role("string", &["match", "-noc", "a*", "abc"], ArgRole::Pattern,),
+            vec![2],
+        );
+        assert_eq!(
+            reg.arg_indices_for_role("glob", &["-di", "tmp", "*.tcl", "*.tm"], ArgRole::Pattern,),
+            vec![2, 3],
+        );
+        assert_eq!(
+            reg.arg_indices_for_role("glob", &["--", "-literal", "*.tcl"], ArgRole::Pattern),
+            vec![1, 2],
+        );
+        assert_eq!(
+            reg.arg_indices_for_role("regexp", &["-start", "2", "a+", "aaa"], ArgRole::Pattern,),
+            vec![2],
+        );
+        assert_eq!(
+            reg.pattern_args("lsearch", &["-regexp", "{a b}", "a+"]),
+            vec![crate::patterns::PatternArg {
+                index: 2,
+                kind: crate::patterns::PatternType::Regex,
+            }],
+        );
+        assert!(
+            reg.pattern_args("lsearch", &["-exact", "{a b}", "a+"])
+                .is_empty()
         );
     }
 

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -4491,18 +4491,21 @@ mod tests {
             );
         }
 
-        // `-str` can name only -stride in Tcl 9.  Pre-9 metadata must not
-        // consume it as a future switch (nor let its value shift the pattern).
+        // `-str` can name only -stride in Tcl 9.  Pre-9 interpreters reject
+        // it, so the resolver must abstain rather than treating an invalid
+        // dash-prefixed word as the list operand and inventing a pattern.
         let stride_abbrev = ["-str", "2", "{a b}", "a+"];
         for dialect in ["tcl8.4", "tcl8.5", "tcl8.6"] {
             let registry = crate::registry_for_dialect(dialect);
-            assert_eq!(
-                registry.pattern_args("lsearch", &stride_abbrev),
-                vec![PatternArg {
-                    index: 1,
-                    kind: PatternType::Glob,
-                }],
-                "{dialect}: unavailable -stride abbreviation remains positional"
+            assert!(
+                registry.pattern_args("lsearch", &stride_abbrev).is_empty(),
+                "{dialect}: unavailable -stride abbreviation invalidates the invocation"
+            );
+            assert!(
+                registry
+                    .arg_indices_for_role("lsearch", &stride_abbrev, ArgRole::Pattern)
+                    .is_empty(),
+                "{dialect}: pattern roles abstain with the invalid invocation"
             );
         }
         for dialect in ["tcl9.0", "tcl9.1"] {
@@ -4520,6 +4523,45 @@ mod tests {
                 registry.arg_indices_for_role("lsearch", &stride_abbrev, ArgRole::Pattern),
                 vec![3],
                 "{dialect}: roles, hover, and tokens share the Tcl 9 layout"
+            );
+        }
+
+        // In Tcl 9 `-st` is ambiguous between -start and -stride. Unknown
+        // words and unsupported `--` likewise cannot be reclassified as the
+        // list operand while the mandatory suffix is still reserved.
+        for args in [
+            ["-st", "2", "{a b}", "a+"].as_slice(),
+            ["-unknown", "{a b}", "a+"].as_slice(),
+            ["--", "{a b}", "a+"].as_slice(),
+        ] {
+            let registry = crate::registry_for_dialect("tcl9.0");
+            assert!(
+                registry.pattern_args("lsearch", args).is_empty(),
+                "Tcl 9 invalid option prefix {args:?} must abstain"
+            );
+            assert!(
+                registry
+                    .arg_indices_for_role("lsearch", args, ArgRole::Pattern)
+                    .is_empty(),
+                "Tcl 9 invalid option prefix {args:?} must have no pattern role"
+            );
+        }
+
+        // The final two words are always the mandatory list + pattern, even
+        // when their spelling would otherwise be an invalid option.
+        for args in [
+            ["{a b}", "-unknown"].as_slice(),
+            ["-regexp", "--"].as_slice(),
+            ["-regexp", "-st"].as_slice(),
+        ] {
+            let registry = crate::registry_for_dialect("tcl9.0");
+            assert_eq!(
+                registry.pattern_args("lsearch", args),
+                vec![PatternArg {
+                    index: 1,
+                    kind: PatternType::Glob,
+                }],
+                "Tcl 9 final operands {args:?} stay positional"
             );
         }
     }

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -153,7 +153,9 @@ fn exact_return_completion(
                     "return" | "2" => CompletionCode::Return,
                     "break" | "3" => CompletionCode::Break,
                     "continue" | "4" => CompletionCode::Continue,
-                    value => CompletionCode::Other(i32::try_from(numbers.parse_wide(value)?).ok()?),
+                    value => CompletionCode::Other(crate::completion::canonical_completion_code(
+                        value, numbers,
+                    )?),
                 };
                 i += 2;
             }
@@ -6609,6 +6611,26 @@ mod tests {
                 }))
             );
         }
+        for (spelling, expected) in [("2147483648", i32::MIN), ("4294967295", -1)] {
+            assert_eq!(
+                reg.exact_invocation_completion(
+                    "return",
+                    &["-level", "0", "-code", spelling, "payload"],
+                    DialectSet::empty(),
+                ),
+                Some(ExactInvocationCompletion::Tcl(CompletionCode::Other(
+                    expected
+                )))
+            );
+        }
+        assert_eq!(
+            reg.exact_invocation_completion(
+                "return",
+                &["-level", "0", "-code", "-2147483649", "payload"],
+                DialectSet::empty(),
+            ),
+            None
+        );
         assert_eq!(
             reg.exact_invocation_completion("exit", &["0"], DialectSet::empty()),
             Some(ExactInvocationCompletion::ProcessExit)

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -27,6 +27,7 @@ use std::sync::OnceLock;
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use crate::abbrev::PrefixMatching;
 use crate::arg_role::{AppendedArity, ArgRole};
 use crate::arity::Arity;
 use crate::body_kind::BodyKind;
@@ -556,38 +557,57 @@ fn push_command_prefix_options(
     }
 }
 
-/// Whether a source-dynamic word appears while a command's declared leading
-/// option grammar still decides the following positional layout.
+/// Whether source words prove a command's leading option layout.
 ///
-/// Literal options consume their descriptor-declared value spans before the
-/// scan continues. A substituted word at the next option position might
-/// itself evaluate to a value-taking option, so consumers cannot safely use a
-/// resolver-derived positional role after it. Once a literal non-option ends
-/// the scan, later dynamic operands do not affect the layout. Likewise,
-/// `reserved_trailing_words` are mandatory positional operands which Tcl's
-/// outer grammar excludes from option scanning; a dynamic word in that suffix
-/// cannot alter the already-established layout.
-fn has_dynamic_leading_option_word(
+/// A literal option consumes its descriptor-declared values before scanning
+/// continues. A dynamic word while that scan is live might evaluate to a
+/// value-taking option, so every resolver-derived positional role must
+/// abstain. A literal invalid or ambiguous dash word is likewise not a
+/// positional operand: treating it as one would describe an invocation Tcl
+/// rejects. The profile-filtered descriptor table, its abbreviation policy,
+/// and the command's reserved trailing operands are inputs, so every pattern
+/// and format consumer makes this decision from the same owner data.
+fn source_option_layout_is_proven(
     options: &[&crate::hover::OptionSpec],
     args: InvocationArguments<'_>,
-    spellings: &[&str],
+    prefix_matching: PrefixMatching,
     reserved_trailing_words: usize,
 ) -> bool {
+    if !args.has_exact_argv_len() {
+        return false;
+    }
+    let spellings: Vec<_> = (0..args.len())
+        .map(|index| args.literal_at(index).unwrap_or_default())
+        .collect();
     let mut index = 0;
     let option_scan_end = args.len().saturating_sub(reserved_trailing_words);
     while index < option_scan_end {
-        let Some(word) = args.literal_at(index) else {
+        if matches!(args.get(index), Some(InvocationWord::DynamicNonOption)) {
             return true;
-        };
-        let Some(option) = crate::patterns::resolve_available_option_prefix(options, word) else {
+        }
+        let Some(word) = args.literal_at(index) else {
             return false;
         };
-        index += 1 + option.value_word_count(spellings, index);
-        if option.name == "--" {
+        let Some(option) =
+            crate::patterns::resolve_available_option_prefix_with(options, word, prefix_matching)
+        else {
+            return !word.starts_with('-');
+        };
+        // A hook-defined arity reads following values to decide how many
+        // words it consumes. A substituted value would make that boundary
+        // runtime-dependent, unlike an ordinary fixed-arity option such as
+        // `-start $index`.
+        if option.value_arity_hook().is_some()
+            && (index + 1..args.len()).any(|value| args.literal_at(value).is_none())
+        {
             return false;
         }
+        index += 1 + option.value_word_count(&spellings, index);
+        if option.name == "--" {
+            return true;
+        }
     }
-    false
+    true
 }
 
 /// The shipped specs of one command group, built once and leaked.
@@ -2708,6 +2728,87 @@ impl CommandRegistry {
         out
     }
 
+    /// Whether source words prove the option-dependent descriptor layout of
+    /// `spec` (or its selected subcommand).  This is deliberately shared by
+    /// pattern and format queries: both families otherwise risk interpreting
+    /// `$mode` as a positional word before Tcl has decided whether it is an
+    /// option.
+    fn source_descriptor_layout_is_proven(
+        &self,
+        spec: &CommandSpec,
+        sub: Option<&SubCommand>,
+        args: InvocationArguments<'_>,
+        effective_dialect: DialectSet,
+    ) -> bool {
+        if !args.has_exact_argv_len() {
+            return false;
+        }
+        // Static role positions and generic option-value roles remain stable
+        // once expansion is excluded. Only a resolver can reinterpret a
+        // source word as a positional operand, so a `clock format $time
+        // -format %Y` time value does not suppress the independently-owned
+        // `-format` value role.
+        let resolver_depends_on_options = sub.map_or(
+            spec.arg_role_resolver.is_some() || spec.pattern_arg_resolver.is_some(),
+            |sub| sub.arg_role_resolver.is_some(),
+        );
+        if !resolver_depends_on_options {
+            return true;
+        }
+        let (options, option_args, prefix_matching, reserved_trailing_words) = if let Some(sub) =
+            sub
+        {
+            let options = self.profile().map_or_else(
+                || {
+                    sub.options
+                        .iter()
+                        .filter(|option| {
+                            option.supports_dialect(
+                                (!effective_dialect.is_empty()).then_some(effective_dialect),
+                                sub.dialects.or(spec.dialects),
+                            )
+                        })
+                        .collect()
+                },
+                |profile| crate::ProfileQueries::available_sub_option_specs(profile, spec, sub),
+            );
+            (options, args.slice_from(1), sub.prefix_matching, 0)
+        } else {
+            let options = self.profile().map_or_else(
+                || spec.option_specs((!effective_dialect.is_empty()).then_some(effective_dialect)),
+                |profile| crate::ProfileQueries::available_option_specs(profile, spec),
+            );
+            (
+                options,
+                args,
+                spec.prefix_matching,
+                spec.reserved_trailing_words,
+            )
+        };
+        options.is_empty()
+            || source_option_layout_is_proven(
+                &options,
+                option_args,
+                prefix_matching,
+                reserved_trailing_words,
+            )
+    }
+
+    /// Resolve a subcommand only when its source word has a known literal
+    /// value. A dynamic selector cannot be projected into a selected
+    /// descriptor's argument layout.
+    fn source_selected_subcommand<'a>(
+        spec: &'a CommandSpec,
+        args: InvocationArguments<'_>,
+    ) -> Option<&'a SubCommand> {
+        (!spec.subcommands.is_empty())
+            .then(|| {
+                args.literal_at(0)
+                    .and_then(|word| spec.resolve_subcommand(word))
+            })
+            .flatten()
+    }
+
     /// The format-string words of **one concrete call**: which argument
     /// positions carry a conversion / field string, and which mini-language
     /// each is written in.
@@ -2762,6 +2863,71 @@ impl CommandRegistry {
             );
         }
         out.sort_by_key(|f| f.index);
+        out
+    }
+
+    /// Source-aware counterpart to [`Self::format_string_args`].
+    ///
+    /// Unlike the compatibility string query, this method retains whether
+    /// each source word is literal, dynamic, expanded, or opaque. The format
+    /// family still comes entirely from the registry, but a dynamic leading
+    /// word is never reinterpreted as a positional pattern or replacement
+    /// before the profile-filtered option grammar has resolved it. This is
+    /// the owner query for editors and other source-aware consumers.
+    #[must_use]
+    pub fn format_string_args_words(
+        &self,
+        name: &str,
+        args: InvocationArguments<'_>,
+    ) -> Vec<FormatStringArg> {
+        self.format_string_args_words_for_dialect(name, args, self.own_availability_mask())
+    }
+
+    /// Dialect-explicit counterpart to [`Self::format_string_args_words`].
+    #[must_use]
+    pub fn format_string_args_words_for_dialect(
+        &self,
+        name: &str,
+        args: InvocationArguments<'_>,
+        dialect: DialectSet,
+    ) -> Vec<FormatStringArg> {
+        let effective_dialect = self
+            .profile()
+            .map_or(dialect, |profile| profile.availability_mask);
+        let spec = if effective_dialect.is_empty() {
+            self.get(name)
+        } else {
+            self.get_for_dialect(name, effective_dialect)
+        };
+        let Some(spec) = spec else {
+            return Vec::new();
+        };
+        // A dynamic subcommand cannot select a concrete format family.
+        if !spec.subcommands.is_empty() && !args.is_empty() && args.literal_at(0).is_none() {
+            return Vec::new();
+        }
+        let sub = Self::source_selected_subcommand(spec, args);
+        let Some(kind) = sub
+            .and_then(|sub| sub.format_string_type)
+            .or(spec.format_string_type)
+        else {
+            return Vec::new();
+        };
+        if !self.source_descriptor_layout_is_proven(spec, sub, args, effective_dialect) {
+            return Vec::new();
+        }
+        let spellings: Vec<_> = (0..args.len())
+            .map(|index| args.literal_at(index).unwrap_or_default())
+            .collect();
+        let mut out = Vec::new();
+        for (role, scan) in [(ArgRole::FormatString, false), (ArgRole::ScanFormat, true)] {
+            out.extend(
+                self.arg_indices_for_role(name, &spellings, role)
+                    .into_iter()
+                    .map(|index| FormatStringArg { index, kind, scan }),
+            );
+        }
+        out.sort_by_key(|format| format.index);
         out
     }
 
@@ -2829,14 +2995,11 @@ impl CommandRegistry {
 
     /// Source-aware counterpart to [`Self::pattern_args`].
     ///
-    /// A resolver-selected pattern position depends on literal option words
-    /// and a known final argv shape. Once source substitution reaches that
-    /// option prefix, treating its spelling as a positional operand would
-    /// shift the remaining arguments and incorrectly claim a pattern
-    /// language. An expansion can likewise move the mandatory trailing
-    /// operands. Static pattern layouts do not have that ambiguity and
-    /// continue through the compatibility resolver, whose indices are
-    /// independent of argument values.
+    /// A pattern descriptor may use a dedicated pattern resolver, a dynamic
+    /// argument-role resolver, or static roles. Every option-dependent form
+    /// goes through the same source-layout proof before the compatibility
+    /// resolver sees a spelling projection, so `regexp $mode …`,
+    /// `glob $mode …`, and `string match $mode …` all abstain consistently.
     #[must_use]
     pub fn pattern_args_words(
         &self,
@@ -2865,25 +3028,16 @@ impl CommandRegistry {
         let Some(spec) = spec else {
             return Vec::new();
         };
+        if !spec.subcommands.is_empty() && !args.is_empty() && args.literal_at(0).is_none() {
+            return Vec::new();
+        }
+        let sub = Self::source_selected_subcommand(spec, args);
+        if !self.source_descriptor_layout_is_proven(spec, sub, args, effective_dialect) {
+            return Vec::new();
+        }
         let spellings: Vec<_> = (0..args.len())
             .map(|index| args.literal_at(index).unwrap_or_default())
             .collect();
-        let options = self.profile().map_or_else(
-            || spec.option_specs((!effective_dialect.is_empty()).then_some(effective_dialect)),
-            |profile| crate::ProfileQueries::available_option_specs(profile, spec),
-        );
-        if spec.pattern_arg_resolver.is_some()
-            && (!args.has_exact_argv_len()
-                || (spec.options.is_empty() && args.has_non_literal())
-                || has_dynamic_leading_option_word(
-                    &options,
-                    args,
-                    &spellings,
-                    spec.reserved_trailing_words,
-                ))
-        {
-            return Vec::new();
-        }
         self.pattern_args_for_dialect(name, &spellings, effective_dialect)
     }
 
@@ -4387,6 +4541,352 @@ mod tests {
             !found("regsub", &["-command", "--", "e", "$s", "cb"])
                 .iter()
                 .any(|(i, _, _)| *i == 3)
+        );
+    }
+
+    #[test]
+    fn source_aware_format_layouts_abstain_only_while_option_selection_is_dynamic() {
+        use crate::invocation_words::{InvocationArguments, InvocationWord};
+        use crate::patterns::FormatType;
+
+        let dynamic_prefix = [
+            InvocationWord::Dynamic,
+            InvocationWord::Literal("{a}"),
+            InvocationWord::Dynamic,
+            InvocationWord::Literal(r"{\1}"),
+        ];
+        let fixed_start_value = [
+            InvocationWord::Literal("-start"),
+            InvocationWord::Dynamic,
+            InvocationWord::Literal("{a}"),
+            InvocationWord::Dynamic,
+            InvocationWord::Literal(r"{\1}"),
+        ];
+        for dialect in ["tcl8.4", "tcl8.5", "tcl8.6", "tcl9.0", "tcl9.1"] {
+            let registry = crate::registry_for_dialect(dialect);
+            assert!(
+                registry
+                    .format_string_args_words(
+                        "regsub",
+                        InvocationArguments::structured(&dynamic_prefix),
+                    )
+                    .is_empty(),
+                "{dialect}: $mode could shift regsub's replacement position"
+            );
+            assert_eq!(
+                registry.format_string_args_words(
+                    "regsub",
+                    InvocationArguments::structured(&fixed_start_value),
+                ),
+                vec![FormatStringArg {
+                    index: 4,
+                    kind: FormatType::Regsub,
+                    scan: false,
+                }],
+                "{dialect}: a known -start still consumes exactly its dynamic value"
+            );
+        }
+
+        let invalid_command_abbrev = [
+            InvocationWord::Literal("-c"),
+            InvocationWord::Literal("{a}"),
+            InvocationWord::Dynamic,
+            InvocationWord::Literal(r"{\1}"),
+        ];
+        let exact_command = [
+            InvocationWord::Literal("-command"),
+            InvocationWord::Literal("{a}"),
+            InvocationWord::Dynamic,
+            InvocationWord::Literal("callback"),
+        ];
+        let registry = crate::registry_for_dialect("tcl9.0");
+        assert!(
+            registry
+                .format_string_args_words(
+                    "regsub",
+                    InvocationArguments::structured(&invalid_command_abbrev),
+                )
+                .is_empty(),
+            "-c is not a Tcl regsub abbreviation and cannot claim a replacement template"
+        );
+        assert!(
+            registry
+                .format_string_args_words("regsub", InvocationArguments::structured(&exact_command))
+                .is_empty(),
+            "only exact Tcl 9 -command selects a callback rather than a replacement template"
+        );
+
+        let clock = [
+            InvocationWord::Literal("format"),
+            InvocationWord::Dynamic,
+            InvocationWord::Literal("-format"),
+            InvocationWord::Literal("%Y"),
+        ];
+        assert_eq!(
+            crate::registry_for_dialect("tcl9.0")
+                .format_string_args_words("clock", InvocationArguments::structured(&clock),),
+            vec![FormatStringArg {
+                index: 3,
+                kind: FormatType::Clock,
+                scan: false,
+            }],
+            "a fixed positional time value cannot hide an after-positional option value"
+        );
+    }
+
+    #[test]
+    fn source_aware_pattern_layouts_abstain_for_dynamic_leading_options() {
+        use crate::invocation_words::{InvocationArguments, InvocationWord};
+
+        let dynamic_prefix = [
+            InvocationWord::Dynamic,
+            InvocationWord::Literal("{a+}"),
+            InvocationWord::Dynamic,
+        ];
+        for name in ["regexp", "regsub"] {
+            assert!(
+                crate::registry_for_dialect("tcl9.0")
+                    .pattern_args_words(name, InvocationArguments::structured(&dynamic_prefix))
+                    .is_empty(),
+                "{name}: $mode could be a leading option"
+            );
+        }
+        let glob_dynamic_prefix = [
+            InvocationWord::Dynamic,
+            InvocationWord::Literal("/tmp"),
+            InvocationWord::Literal("*.tcl"),
+        ];
+        assert!(
+            crate::registry_for_dialect("tcl9.0")
+                .pattern_args_words(
+                    "glob",
+                    InvocationArguments::structured(&glob_dynamic_prefix)
+                )
+                .is_empty(),
+            "glob $mode /tmp *.tcl cannot choose a pattern tail before $mode resolves"
+        );
+        let string_dynamic_prefix = [
+            InvocationWord::Literal("match"),
+            InvocationWord::Dynamic,
+            InvocationWord::Literal("a*"),
+            InvocationWord::Literal("abc"),
+        ];
+        assert!(
+            crate::registry_for_dialect("tcl9.0")
+                .pattern_args_words(
+                    "string",
+                    InvocationArguments::structured(&string_dynamic_prefix),
+                )
+                .is_empty(),
+            "string match $mode a* abc cannot treat $mode as the pattern"
+        );
+    }
+
+    #[test]
+    fn source_aware_pattern_layouts_accept_proven_options_and_terminators() {
+        use crate::invocation_words::{InvocationArguments, InvocationWord};
+        use crate::patterns::{PatternArg, PatternType};
+
+        let regexp_start = [
+            InvocationWord::Literal("-start"),
+            InvocationWord::Dynamic,
+            InvocationWord::Literal("a+"),
+            InvocationWord::Dynamic,
+        ];
+        assert_eq!(
+            crate::registry_for_dialect("tcl9.0")
+                .pattern_args_words("regexp", InvocationArguments::structured(&regexp_start)),
+            vec![PatternArg {
+                index: 2,
+                kind: PatternType::Regex,
+            }],
+            "a fixed value-taking option may safely carry a dynamic value"
+        );
+        let non_option_template = [InvocationWord::DynamicNonOption, InvocationWord::Dynamic];
+        assert_eq!(
+            crate::registry_for_dialect("tcl9.0").pattern_args_words(
+                "regexp",
+                InvocationArguments::structured(&non_option_template),
+            ),
+            vec![PatternArg {
+                index: 0,
+                kind: PatternType::Regex,
+            }],
+            "a template with a direct non-dash prefix remains a positional pattern"
+        );
+        let glob_terminator = [
+            InvocationWord::Literal("--"),
+            InvocationWord::Literal("-literal"),
+        ];
+        assert_eq!(
+            crate::registry_for_dialect("tcl9.0")
+                .pattern_args_words("glob", InvocationArguments::structured(&glob_terminator)),
+            vec![PatternArg {
+                index: 1,
+                kind: PatternType::Glob,
+            }],
+            "-- freezes glob's option prefix before an option-shaped pattern"
+        );
+    }
+
+    #[test]
+    fn source_aware_pattern_layouts_respect_release_and_reserved_suffixes() {
+        use crate::invocation_words::{InvocationArguments, InvocationWord};
+        use crate::patterns::{PatternArg, PatternType};
+
+        let strict_abbreviation = [
+            InvocationWord::Literal("-sta"),
+            InvocationWord::Literal("2"),
+            InvocationWord::Literal("a+"),
+            InvocationWord::Literal("aaa"),
+        ];
+        assert!(
+            crate::registry_for_dialect("tcl9.0")
+                .pattern_args_words(
+                    "regexp",
+                    InvocationArguments::structured(&strict_abbreviation)
+                )
+                .is_empty(),
+            "regexp's strict option table rejects a non-exact abbreviation"
+        );
+        let stride_abbreviation = [
+            InvocationWord::Literal("-str"),
+            InvocationWord::Literal("2"),
+            InvocationWord::Literal("{a b}"),
+            InvocationWord::Literal("a+"),
+        ];
+        assert!(
+            crate::registry_for_dialect("tcl8.6")
+                .pattern_args_words(
+                    "lsearch",
+                    InvocationArguments::structured(&stride_abbreviation)
+                )
+                .is_empty(),
+            "a Tcl 9-only option abbreviation is invalid before Tcl 9"
+        );
+        assert_eq!(
+            crate::registry_for_dialect("tcl9.0").pattern_args_words(
+                "lsearch",
+                InvocationArguments::structured(&stride_abbreviation),
+            ),
+            vec![PatternArg {
+                index: 3,
+                kind: PatternType::Glob,
+            }],
+            "the same abbreviation follows Tcl 9's profile-filtered option table"
+        );
+        let option_shaped_suffix = [
+            InvocationWord::Literal("-regexp"),
+            InvocationWord::Literal("--"),
+        ];
+        assert_eq!(
+            crate::registry_for_dialect("tcl9.0").pattern_args_words(
+                "lsearch",
+                InvocationArguments::structured(&option_shaped_suffix),
+            ),
+            vec![PatternArg {
+                index: 1,
+                kind: PatternType::Glob,
+            }],
+            "lsearch's reserved list/pattern suffix remains positional"
+        );
+    }
+
+    /// The source proof follows descriptors installed in the registry, not a
+    /// closed list of Tcl command names. A pack or a later registry mutation
+    /// can introduce the same option-dependent pattern/replacement grammar
+    /// and all generic consumers receive the new answer unchanged.
+    #[test]
+    fn source_aware_pattern_and_format_queries_follow_mutated_descriptors() {
+        use crate::invocation_words::{InvocationArguments, InvocationWord};
+        use crate::patterns::{FormatType, PatternArg, PatternType};
+
+        const OPTIONS: &[crate::hover::OptionSpec] = &[crate::hover::OptionSpec {
+            name: "-skip",
+            value: crate::hover::OptionValue::value("count"),
+            detail: "fixture value",
+            dialects: None,
+            aliases: &[],
+            lifecycle: crate::lifecycle::Lifecycle::UNSPECIFIED,
+            min_abbrev: None,
+        }];
+        fn roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
+            let first =
+                crate::spec::leading_option_word_count_with(OPTIONS, args, PrefixMatching::Strict);
+            [
+                (first, ArgRole::Pattern),
+                (first + 2, ArgRole::FormatString),
+            ]
+            .into_iter()
+            .filter_map(|(index, role)| {
+                (index < args.len())
+                    .then(|| u8::try_from(index).ok().map(|index| (index, role)))
+                    .flatten()
+            })
+            .collect()
+        }
+        const SPEC: CommandSpec = CommandSpec {
+            name: "mutated-pattern-format-owner",
+            options: OPTIONS,
+            prefix_matching: PrefixMatching::Strict,
+            arg_role_resolver: Some(roles),
+            pattern_type: Some(PatternType::Regex),
+            format_string_type: Some(FormatType::Regsub),
+            ..CommandSpec::DEFAULT
+        };
+
+        let mut registry = CommandRegistry::build_default();
+        registry.insert(SPEC);
+        let dynamic = [
+            InvocationWord::Dynamic,
+            InvocationWord::Literal("{a}"),
+            InvocationWord::Dynamic,
+            InvocationWord::Literal(r"{\1}"),
+        ];
+        assert!(
+            registry
+                .pattern_args_words(
+                    "mutated-pattern-format-owner",
+                    InvocationArguments::structured(&dynamic),
+                )
+                .is_empty()
+        );
+        assert!(
+            registry
+                .format_string_args_words(
+                    "mutated-pattern-format-owner",
+                    InvocationArguments::structured(&dynamic),
+                )
+                .is_empty()
+        );
+
+        let fixed = [
+            InvocationWord::Literal("-skip"),
+            InvocationWord::Dynamic,
+            InvocationWord::Literal("{a}"),
+            InvocationWord::Dynamic,
+            InvocationWord::Literal(r"{\1}"),
+        ];
+        assert_eq!(
+            registry.pattern_args_words(
+                "mutated-pattern-format-owner",
+                InvocationArguments::structured(&fixed),
+            ),
+            vec![PatternArg {
+                index: 2,
+                kind: PatternType::Regex,
+            }]
+        );
+        assert_eq!(
+            registry.format_string_args_words(
+                "mutated-pattern-format-owner",
+                InvocationArguments::structured(&fixed),
+            ),
+            vec![FormatStringArg {
+                index: 4,
+                kind: FormatType::Regsub,
+                scan: false,
+            }]
         );
     }
 

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -136,6 +136,9 @@ pub enum InvocationCompletionKnowledge {
     Exact(ExactInvocationCompletion),
     /// `return -code $value` can either propagate return or reject the code.
     DynamicReturnOrError,
+    /// A dynamic `exit` status either terminates the process or raises
+    /// catchable Tcl error; it never has a normal continuation.
+    ExitOrError,
     /// The invocation has a runtime-dependent completion.
     Dynamic,
 }
@@ -153,6 +156,32 @@ enum ExactReturnCompletion {
     Completion(crate::completion::CompletionCode),
     StaticError,
     Dynamic,
+}
+
+/// Parse `exit ?returnCode?` after its descriptor has established the exact
+/// one-word-or-omitted shape. Tcl parses the status with its normal wide
+/// integer grammar, so an invalid literal is an ordinary catchable error,
+/// not a process termination.
+enum ExactProcessExitCompletion {
+    ProcessExit,
+    StaticError,
+    Dynamic,
+}
+
+fn exact_process_exit_completion(
+    args: crate::invocation_words::InvocationArguments<'_>,
+    numbers: tcl_syntax::number::Numbers,
+) -> ExactProcessExitCompletion {
+    match args.get(0) {
+        None => ExactProcessExitCompletion::ProcessExit,
+        Some(_) => match args.literal_at(0) {
+            Some(value) if numbers.parse_wide(value).is_some() => {
+                ExactProcessExitCompletion::ProcessExit
+            }
+            Some(_) => ExactProcessExitCompletion::StaticError,
+            None => ExactProcessExitCompletion::Dynamic,
+        },
+    }
 }
 
 fn exact_return_completion(
@@ -514,7 +543,7 @@ fn push_command_prefix_options(
 /// outer grammar excludes from option scanning; a dynamic word in that suffix
 /// cannot alter the already-established layout.
 fn has_dynamic_leading_option_word(
-    options: &[crate::hover::OptionSpec],
+    options: &[&crate::hover::OptionSpec],
     args: InvocationArguments<'_>,
     spellings: &[&str],
     reserved_trailing_words: usize,
@@ -525,7 +554,7 @@ fn has_dynamic_leading_option_word(
         let Some(word) = args.literal_at(index) else {
             return true;
         };
-        let Some(option) = crate::spec::resolve_option_prefix(options, word) else {
+        let Some(option) = crate::patterns::resolve_available_option_prefix(options, word) else {
             return false;
         };
         index += 1 + option.value_word_count(spellings, index);
@@ -2176,16 +2205,34 @@ impl CommandRegistry {
                 ExactReturnCompletion::Dynamic => None,
             };
         }
+        let descriptor = resolved
+            .form
+            .and_then(|form| form.completion)
+            .or(resolved.sub.and_then(|sub| sub.completion))
+            .or(resolved.spec.completion);
+        if descriptor.is_some_and(|descriptor| {
+            descriptor.value_semantics
+                == crate::completion::CompletionValueSemantics::ProcessExitStatus
+        }) {
+            return match exact_process_exit_completion(
+                args,
+                tcl_syntax::number::Numbers::of_profile(self.profile()),
+            ) {
+                ExactProcessExitCompletion::ProcessExit => {
+                    Some(ExactInvocationCompletion::ProcessExit)
+                }
+                ExactProcessExitCompletion::StaticError => Some(ExactInvocationCompletion::Tcl(
+                    crate::completion::CompletionCode::Error,
+                )),
+                ExactProcessExitCompletion::Dynamic => None,
+            };
+        }
         let traits =
             resolved.spec.traits | resolved.sub.map_or_else(Traits::empty, |sub| sub.traits);
         if traits.contains(Traits::TERMINATES_PROCESS) {
             return Some(ExactInvocationCompletion::ProcessExit);
         }
-        let descriptor = resolved
-            .form
-            .and_then(|form| form.completion)
-            .or(resolved.sub.and_then(|sub| sub.completion))
-            .or(resolved.spec.completion)?;
+        let descriptor = descriptor?;
         let crate::completion::CompletionCodeDomain::Exact(codes) = descriptor.codes else {
             return None;
         };
@@ -2206,6 +2253,22 @@ impl CommandRegistry {
         }
         let literals = args.literal_values().unwrap_or_default();
         let resolved = self.resolve_call(name, &literals, dialect)?;
+        let descriptor = resolved
+            .form
+            .and_then(|form| form.completion)
+            .or(resolved.sub.and_then(|sub| sub.completion))
+            .or(resolved.spec.completion);
+        if descriptor.is_some_and(|descriptor| {
+            descriptor.value_semantics
+                == crate::completion::CompletionValueSemantics::ProcessExitStatus
+        }) {
+            // The exact path above already returned omitted / literal-valid
+            // process exits and literal-invalid TCL_ERROR. Anything left is
+            // source-dynamic (including `{*}` with an unknown argv length):
+            // Tcl can only either parse a status and exit or reject the
+            // invocation; it can never fall through normally.
+            return Some(InvocationCompletionKnowledge::ExitOrError);
+        }
         if resolved.lowering_hook != Some(LoweringHookId::Return) {
             return None;
         }
@@ -2579,8 +2642,18 @@ impl CommandRegistry {
             return out;
         }
 
+        // Option-selected pattern layouts are owned by the paired pattern
+        // resolver.  Reusing that answer keeps role consumers aligned with
+        // hover and semantic-token consumers, including profile-gated option
+        // abbreviations and reserved positional suffixes.
+        if role == ArgRole::Pattern && spec.pattern_arg_resolver.is_some() {
+            out.extend(
+                self.pattern_args(name, args)
+                    .into_iter()
+                    .map(|pattern| usize::from(pattern.index)),
+            );
         // Top-level positional roles.
-        if let Some(resolver) = spec.arg_role_resolver {
+        } else if let Some(resolver) = spec.arg_role_resolver {
             out.extend(
                 resolver(args)
                     .into_iter()
@@ -2675,11 +2748,45 @@ impl CommandRegistry {
     /// branches of their own.
     #[must_use]
     pub fn pattern_args(&self, name: &str, args: &[&str]) -> Vec<crate::patterns::PatternArg> {
-        let Some(spec) = self.get(name) else {
+        self.pattern_args_for_dialect(name, args, self.own_availability_mask())
+    }
+
+    /// Dialect-explicit counterpart to [`Self::pattern_args`].
+    ///
+    /// A profile-bound registry always uses its attached profile.  A
+    /// profile-less registry uses `dialect`, which is how editor consumers
+    /// carrying one shared registry keep option-selected pattern layouts in
+    /// sync with the current document's Tcl release.
+    #[must_use]
+    pub fn pattern_args_for_dialect(
+        &self,
+        name: &str,
+        args: &[&str],
+        dialect: DialectSet,
+    ) -> Vec<crate::patterns::PatternArg> {
+        let effective_dialect = self
+            .profile()
+            .map_or(dialect, |profile| profile.availability_mask);
+        let spec = if effective_dialect.is_empty() {
+            self.get(name)
+        } else {
+            self.get_for_dialect(name, effective_dialect)
+        };
+        let Some(spec) = spec else {
             return Vec::new();
         };
         if let Some(resolve) = spec.pattern_arg_resolver {
-            return resolve(args);
+            let options = self.profile().map_or_else(
+                || spec.option_specs((!effective_dialect.is_empty()).then_some(effective_dialect)),
+                |profile| crate::ProfileQueries::available_option_specs(profile, spec),
+            );
+            return resolve(
+                args,
+                crate::patterns::PatternArgResolverContext {
+                    options: &options,
+                    reserved_trailing_words: spec.reserved_trailing_words,
+                },
+            );
         }
         let sub = (!spec.subcommands.is_empty())
             .then(|| args.first().and_then(|word| spec.resolve_subcommand(word)))
@@ -2710,17 +2817,40 @@ impl CommandRegistry {
         name: &str,
         args: InvocationArguments<'_>,
     ) -> Vec<crate::patterns::PatternArg> {
-        let Some(spec) = self.get(name) else {
+        self.pattern_args_words_for_dialect(name, args, self.own_availability_mask())
+    }
+
+    /// Dialect-explicit counterpart to [`Self::pattern_args_words`].
+    #[must_use]
+    pub fn pattern_args_words_for_dialect(
+        &self,
+        name: &str,
+        args: InvocationArguments<'_>,
+        dialect: DialectSet,
+    ) -> Vec<crate::patterns::PatternArg> {
+        let effective_dialect = self
+            .profile()
+            .map_or(dialect, |profile| profile.availability_mask);
+        let spec = if effective_dialect.is_empty() {
+            self.get(name)
+        } else {
+            self.get_for_dialect(name, effective_dialect)
+        };
+        let Some(spec) = spec else {
             return Vec::new();
         };
         let spellings: Vec<_> = (0..args.len())
             .map(|index| args.literal_at(index).unwrap_or_default())
             .collect();
+        let options = self.profile().map_or_else(
+            || spec.option_specs((!effective_dialect.is_empty()).then_some(effective_dialect)),
+            |profile| crate::ProfileQueries::available_option_specs(profile, spec),
+        );
         if spec.pattern_arg_resolver.is_some()
             && (!args.has_exact_argv_len()
                 || (spec.options.is_empty() && args.has_non_literal())
                 || has_dynamic_leading_option_word(
-                    spec.options,
+                    &options,
                     args,
                     &spellings,
                     spec.reserved_trailing_words,
@@ -2728,7 +2858,7 @@ impl CommandRegistry {
         {
             return Vec::new();
         }
-        self.pattern_args(name, &spellings)
+        self.pattern_args_for_dialect(name, &spellings, effective_dialect)
     }
 
     /// How a formatter should **present** argument `index` of a call to
@@ -4328,6 +4458,106 @@ mod tests {
                 )
                 .is_empty(),
                 "{dialect}: lsearch $mode {{a b}} {{a+}} remains ambiguous"
+            );
+        }
+    }
+
+    #[test]
+    fn lsearch_pattern_resolver_uses_profiled_options_and_the_reserved_suffix() {
+        use crate::patterns::{PatternArg, PatternType};
+
+        // These are oracle-shaped against Tcl's `i < objc - 2` scanner.  The
+        // first two words of the short form are list + pattern, even though
+        // both spell like lsearch switches.
+        let option_shaped_operands = ["-regexp", "-glob"];
+        for dialect in ["tcl8.4", "tcl8.5", "tcl8.6", "tcl9.0", "tcl9.1"] {
+            let registry = crate::registry_for_dialect(dialect);
+            let patterns = registry.pattern_args("lsearch", &option_shaped_operands);
+            assert_eq!(
+                patterns,
+                vec![PatternArg {
+                    index: 1,
+                    kind: PatternType::Glob,
+                }],
+                "{dialect}: lsearch -regexp -glob keeps both mandatory operands out of option scanning"
+            );
+            assert_eq!(
+                registry.arg_indices_for_role("lsearch", &option_shaped_operands, ArgRole::Pattern),
+                patterns
+                    .iter()
+                    .map(|pattern| usize::from(pattern.index))
+                    .collect::<Vec<_>>(),
+                "{dialect}: ArgRole::Pattern must share the resolver answer"
+            );
+        }
+
+        // `-str` can name only -stride in Tcl 9.  Pre-9 metadata must not
+        // consume it as a future switch (nor let its value shift the pattern).
+        let stride_abbrev = ["-str", "2", "{a b}", "a+"];
+        for dialect in ["tcl8.4", "tcl8.5", "tcl8.6"] {
+            let registry = crate::registry_for_dialect(dialect);
+            assert_eq!(
+                registry.pattern_args("lsearch", &stride_abbrev),
+                vec![PatternArg {
+                    index: 1,
+                    kind: PatternType::Glob,
+                }],
+                "{dialect}: unavailable -stride abbreviation remains positional"
+            );
+        }
+        for dialect in ["tcl9.0", "tcl9.1"] {
+            let registry = crate::registry_for_dialect(dialect);
+            let patterns = registry.pattern_args("lsearch", &stride_abbrev);
+            assert_eq!(
+                patterns,
+                vec![PatternArg {
+                    index: 3,
+                    kind: PatternType::Glob,
+                }],
+                "{dialect}: -str is the available -stride abbreviation"
+            );
+            assert_eq!(
+                registry.arg_indices_for_role("lsearch", &stride_abbrev, ArgRole::Pattern),
+                vec![3],
+                "{dialect}: roles, hover, and tokens share the Tcl 9 layout"
+            );
+        }
+    }
+
+    #[test]
+    fn source_aware_lsearch_dynamic_prefix_and_suffix_have_distinct_obligations() {
+        use crate::invocation_words::{InvocationArguments, InvocationWord};
+        use crate::patterns::{PatternArg, PatternType};
+
+        for dialect in ["tcl8.6", "tcl9.0"] {
+            let registry = crate::registry_for_dialect(dialect);
+            let dynamic_early = [
+                InvocationWord::Dynamic,
+                InvocationWord::Literal("{a b}"),
+                InvocationWord::Literal("a+"),
+            ];
+            assert!(
+                registry
+                    .pattern_args_words("lsearch", InvocationArguments::structured(&dynamic_early))
+                    .is_empty(),
+                "{dialect}: a dynamic word before the mandatory operands can still be a switch"
+            );
+
+            let dynamic_list_operand = [
+                InvocationWord::Literal("-regexp"),
+                InvocationWord::Dynamic,
+                InvocationWord::Literal("a+"),
+            ];
+            assert_eq!(
+                registry.pattern_args_words(
+                    "lsearch",
+                    InvocationArguments::structured(&dynamic_list_operand),
+                ),
+                vec![PatternArg {
+                    index: 2,
+                    kind: PatternType::Regex,
+                }],
+                "{dialect}: the dynamic mandatory list is beyond the option boundary"
             );
         }
     }
@@ -6939,6 +7169,55 @@ mod tests {
             ),
             Some(ExactInvocationCompletion::Tcl(CompletionCode::Return))
         );
+    }
+
+    #[test]
+    fn exit_status_completion_follows_the_tcl86_and_tcl90_oracle() {
+        use crate::completion::CompletionCode;
+        use crate::invocation_words::{InvocationArguments, InvocationWord};
+
+        for dialect in ["tcl8.6", "tcl9.0"] {
+            let reg = crate::registry_for_dialect(dialect);
+            // tclsh8.6/9: omitted and Tcl-wide integer spellings run the
+            // process-exit path; the width parser accepts hex and signs too.
+            for args in [&[][..], &["0"][..], &["-7"][..], &["0x10"][..]] {
+                assert_eq!(
+                    reg.exact_invocation_completion("exit", args, DialectSet::empty()),
+                    Some(ExactInvocationCompletion::ProcessExit),
+                    "{dialect}: exit {args:?}"
+                );
+            }
+            // `exit nope` and excess arguments never get as far as process
+            // termination: Tcl raises an ordinary, catchable error instead.
+            for args in [&["nope"][..], &["1.5"][..], &["0", "extra"][..]] {
+                assert_eq!(
+                    reg.exact_invocation_completion("exit", args, DialectSet::empty()),
+                    Some(ExactInvocationCompletion::Tcl(CompletionCode::Error)),
+                    "{dialect}: exit {args:?}"
+                );
+            }
+
+            let dynamic = [InvocationWord::Dynamic];
+            assert_eq!(
+                reg.invocation_completion_knowledge(
+                    "exit",
+                    InvocationArguments::structured(&dynamic),
+                    DialectSet::empty(),
+                ),
+                Some(InvocationCompletionKnowledge::ExitOrError),
+                "{dialect}: exit $status is only process-exit or Tcl error"
+            );
+            let expanded = [InvocationWord::Expanded];
+            assert_eq!(
+                reg.invocation_completion_knowledge(
+                    "exit",
+                    InvocationArguments::structured(&expanded),
+                    DialectSet::empty(),
+                ),
+                Some(InvocationCompletionKnowledge::ExitOrError),
+                "{dialect}: exit {{*}}$statuses has no normal completion either"
+            );
+        }
     }
 
     #[test]

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -115,6 +115,76 @@ pub enum InvocationCompletion {
     Unknown,
 }
 
+/// An exact control completion available from registry-declared semantics and
+/// literal invocation options.
+///
+/// Unlike [`InvocationCompletion`], this retains the Tcl completion code a
+/// surrounding `try` may match.  `ProcessExit` is intentionally separate:
+/// `exit` does not produce a catchable Tcl completion and bypasses `finally`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExactInvocationCompletion {
+    /// A Tcl completion code propagated through enclosing control constructs.
+    Tcl(crate::completion::CompletionCode),
+    /// Immediate interpreter-process termination.
+    ProcessExit,
+}
+
+/// Parse the literal option subset of `return` that fixes the completion code
+/// visible to an enclosing `try`.  With the default `-level 1`, `return`
+/// itself propagates `TCL_RETURN` even when its eventual procedure result is
+/// configured as `-code error`; `-level 0` exposes that configured code to the
+/// immediately enclosing script instead.
+fn exact_return_completion(args: &[&str]) -> Option<crate::completion::CompletionCode> {
+    use crate::completion::CompletionCode;
+
+    let mut i = 0usize;
+    let mut code = CompletionCode::Ok;
+    let mut level = 1_i64;
+    while let Some(word) = args.get(i).copied() {
+        match word {
+            "--" => {
+                i += 1;
+                break;
+            }
+            "-code" => {
+                let value = *args.get(i + 1)?;
+                code = match value {
+                    "ok" | "0" => CompletionCode::Ok,
+                    "error" | "1" => CompletionCode::Error,
+                    "return" | "2" => CompletionCode::Return,
+                    "break" | "3" => CompletionCode::Break,
+                    "continue" | "4" => CompletionCode::Continue,
+                    value => CompletionCode::Other(value.parse::<i32>().ok()?),
+                };
+                i += 2;
+            }
+            "-level" => {
+                level = args.get(i + 1)?.parse::<i64>().ok()?.max(0);
+                if args.get(i + 1)?.parse::<i64>().ok()? < 0 {
+                    return None;
+                }
+                i += 2;
+            }
+            // These options do not alter the code, but `-options` may carry
+            // a code/level override so remains deliberately opaque.
+            "-errorcode" | "-errorinfo" | "-errorstack" => i += 2,
+            "-options" => return None,
+            _ if word.starts_with('-') => return None,
+            _ => break,
+        }
+    }
+    // `return` accepts one result word after its options; additional words are
+    // an arity error, so no exact runtime completion is promised.
+    if args.len().saturating_sub(i) > 1 {
+        return None;
+    }
+    Some(if level == 0 {
+        code
+    } else {
+        CompletionCode::Return
+    })
+}
+
 fn try_control_arms(args: &[&str]) -> Option<Vec<(usize, ControlArmSemantics)>> {
     args.first()?;
     let mut arms = vec![(0usize, ControlArmSemantics::Always)];
@@ -1924,6 +1994,49 @@ impl CommandRegistry {
         } else {
             InvocationCompletion::FallsThrough
         }
+    }
+
+    /// Return an exact Tcl completion code (or process exit) for a concrete,
+    /// literal invocation when registry data and return options establish one.
+    ///
+    /// This is intentionally narrower than [`Self::invocation_completion`]:
+    /// dynamic `return -options $dict`, dynamic `-code`/`-level` values, and
+    /// ordinary calls with only a conservative completion descriptor return
+    /// `None` rather than inventing a handler edge.
+    #[must_use]
+    pub fn exact_invocation_completion(
+        &self,
+        name: &str,
+        args: &[&str],
+        dialect: DialectSet,
+    ) -> Option<ExactInvocationCompletion> {
+        let resolved = self.resolve_call(name, args, dialect)?;
+        let positional_len = args
+            .len()
+            .saturating_sub(usize::from(resolved.sub.is_some()));
+        if !resolved
+            .arity()
+            .accepts(u16::try_from(positional_len).unwrap_or(u16::MAX))
+        {
+            return None;
+        }
+        if resolved.lowering_hook == Some(LoweringHookId::Return) {
+            return exact_return_completion(args).map(ExactInvocationCompletion::Tcl);
+        }
+        let traits =
+            resolved.spec.traits | resolved.sub.map_or_else(Traits::empty, |sub| sub.traits);
+        if traits.contains(Traits::TERMINATES_PROCESS) {
+            return Some(ExactInvocationCompletion::ProcessExit);
+        }
+        let descriptor = resolved
+            .form
+            .and_then(|form| form.completion)
+            .or(resolved.sub.and_then(|sub| sub.completion))
+            .or(resolved.spec.completion)?;
+        let crate::completion::CompletionCodeDomain::Exact(codes) = descriptor.codes else {
+            return None;
+        };
+        (codes.len() == 1).then_some(ExactInvocationCompletion::Tcl(codes[0]))
     }
 
     /// Whether `name` is valid only at the top level of an iRule script
@@ -6447,6 +6560,43 @@ mod tests {
         assert_eq!(
             reg.invocation_completion("set", &[], DialectSet::empty()),
             InvocationCompletion::Unknown
+        );
+    }
+
+    #[test]
+    fn exact_return_options_and_process_exit_are_registry_owned() {
+        use crate::completion::CompletionCode;
+
+        let reg = CommandRegistry::build_default();
+        // Oracle (tclsh 8.6/9.0): the default -level 1 return is caught by
+        // `try on return`, even when its eventual procedure result is error.
+        assert_eq!(
+            reg.exact_invocation_completion(
+                "return",
+                &["-code", "error", "payload"],
+                DialectSet::empty(),
+            ),
+            Some(ExactInvocationCompletion::Tcl(CompletionCode::Return))
+        );
+        assert_eq!(
+            reg.exact_invocation_completion(
+                "return",
+                &["-level", "0", "-code", "error", "payload"],
+                DialectSet::empty(),
+            ),
+            Some(ExactInvocationCompletion::Tcl(CompletionCode::Error))
+        );
+        assert_eq!(
+            reg.exact_invocation_completion("exit", &["0"], DialectSet::empty()),
+            Some(ExactInvocationCompletion::ProcessExit)
+        );
+        assert_eq!(
+            reg.exact_invocation_completion(
+                "return",
+                &["-options", "$dynamic", "payload"],
+                DialectSet::empty(),
+            ),
+            None
         );
     }
 

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -168,11 +168,14 @@ fn exact_return_completion(
         match word {
             "-code" => {
                 let Some(value) = args.literal_at(i + 1) else {
-                    return if args.get(i + 1).is_some() {
-                        ExactReturnCompletion::Dynamic
-                    } else {
-                        ExactReturnCompletion::StaticError
-                    };
+                    if args.get(i + 1).is_some() {
+                        return ExactReturnCompletion::Dynamic;
+                    }
+                    // `return` accepts one trailing result word.  Tcl only
+                    // treats `-code` as an option when another argv word can
+                    // supply its value, so a lone `return -code` returns the
+                    // literal result `-code` with the default TCL_RETURN.
+                    break;
                 };
                 code = match value {
                     "ok" | "0" => CompletionCode::Ok,
@@ -194,11 +197,10 @@ fn exact_return_completion(
             }
             "-level" => {
                 let Some(value) = args.literal_at(i + 1) else {
-                    return if args.get(i + 1).is_some() {
-                        ExactReturnCompletion::Dynamic
-                    } else {
-                        ExactReturnCompletion::StaticError
-                    };
+                    if args.get(i + 1).is_some() {
+                        return ExactReturnCompletion::Dynamic;
+                    }
+                    break;
                 };
                 level = match numbers.parse_wide(value) {
                     Some(value) if value >= 0 => value,
@@ -214,11 +216,10 @@ fn exact_return_completion(
             // These options do not alter the code, but `-options` may carry
             // a code/level override so remains deliberately opaque.
             "-options" => {
-                return if args.get(i + 1).is_none() {
-                    ExactReturnCompletion::StaticError
-                } else {
-                    ExactReturnCompletion::Dynamic
-                };
+                if args.get(i + 1).is_none() {
+                    break;
+                }
+                return ExactReturnCompletion::Dynamic;
             }
             // Return options are an extensible key/value dictionary.  An
             // unrecognised literal option cannot alter `-code`/`-level`, so
@@ -226,7 +227,7 @@ fn exact_return_completion(
             // custom pair such as `-foo bar`.
             _ if word.starts_with('-') => {
                 if args.get(i + 1).is_none() {
-                    return ExactReturnCompletion::StaticError;
+                    break;
                 }
                 i += 2;
             }
@@ -499,6 +500,35 @@ fn push_command_prefix_options(
             i += 1;
         }
     }
+}
+
+/// Whether a source-dynamic word appears while a command's declared leading
+/// option grammar still decides the following positional layout.
+///
+/// Literal options consume their descriptor-declared value spans before the
+/// scan continues. A substituted word at the next option position might
+/// itself evaluate to a value-taking option, so consumers cannot safely use a
+/// resolver-derived positional role after it. Once a literal non-option ends
+/// the scan, later dynamic operands do not affect the layout.
+fn has_dynamic_leading_option_word(
+    options: &[crate::hover::OptionSpec],
+    args: InvocationArguments<'_>,
+    spellings: &[&str],
+) -> bool {
+    let mut index = 0;
+    while index < args.len() {
+        let Some(word) = args.literal_at(index) else {
+            return true;
+        };
+        let Some(option) = crate::spec::resolve_option_prefix(options, word) else {
+            return false;
+        };
+        index += 1 + option.value_word_count(spellings, index);
+        if option.name == "--" {
+            return false;
+        }
+    }
+    false
 }
 
 /// The shipped specs of one command group, built once and leaked.
@@ -2010,7 +2040,7 @@ impl CommandRegistry {
                     }
                     "-code" => {
                         let Some(value) = args.get(i + 1).copied() else {
-                            return InvocationCompletion::Unknown;
+                            break;
                         };
                         code = match value {
                             "ok" | "0" => Some(true),
@@ -2024,15 +2054,23 @@ impl CommandRegistry {
                     }
                     "-level" => {
                         let Some(value) = args.get(i + 1).copied() else {
-                            return InvocationCompletion::Unknown;
+                            break;
                         };
                         level = value.parse::<i64>().ok().filter(|value| *value >= 0);
                         i += 2;
                     }
                     "-options" | "-errorcode" | "-errorinfo" | "-errorstack" => {
+                        if args.get(i + 1).is_none() {
+                            break;
+                        }
                         return InvocationCompletion::Unknown;
                     }
-                    _ if word.starts_with('-') => return InvocationCompletion::Unknown,
+                    _ if word.starts_with('-') => {
+                        if args.get(i + 1).is_none() {
+                            break;
+                        }
+                        return InvocationCompletion::Unknown;
+                    }
                     _ => break,
                 }
             }
@@ -2097,16 +2135,26 @@ impl CommandRegistry {
         args: crate::invocation_words::InvocationArguments<'_>,
         dialect: DialectSet,
     ) -> Option<ExactInvocationCompletion> {
-        let literal_args = args.literal_values().unwrap_or_default();
-        let resolved = self.resolve_call(name, &literal_args, dialect)?;
-        let positional_len = args
-            .len()
-            .saturating_sub(usize::from(resolved.sub.is_some()));
+        // An expansion can alter the final argv shape.  A descriptor for a
+        // well-formed call (notably `exit`) must not override that unknown
+        // arity, because an expanded call may instead raise TCL_ERROR.
+        let argument_len = args.exact_argv_len()?;
+        let literal_args = args.literal_values();
+        // A non-expanded dynamic argument still has a known argv count.  It
+        // cannot select a value-dependent subcommand, but a flat command such
+        // as `error $message` retains its registry-owned exact completion.
+        let resolved = self.resolve_call(name, literal_args.as_deref().unwrap_or(&[]), dialect)?;
+        let positional_len = argument_len.saturating_sub(usize::from(resolved.sub.is_some()));
         if !resolved
             .arity()
             .accepts(u16::try_from(positional_len).unwrap_or(u16::MAX))
         {
-            return None;
+            // Tcl validates command arity before executing its declared
+            // effect.  A known call with an exact invalid shape is therefore
+            // an exact, catchable TCL_ERROR, not an unknown normal path.
+            return Some(ExactInvocationCompletion::Tcl(
+                crate::completion::CompletionCode::Error,
+            ));
         }
         if resolved.lowering_hook == Some(LoweringHookId::Return) {
             let profile = self.profile()?;
@@ -2639,6 +2687,35 @@ impl CommandRegistry {
             .filter_map(|index| u8::try_from(index).ok())
             .map(|index| crate::patterns::PatternArg { index, kind })
             .collect()
+    }
+
+    /// Source-aware counterpart to [`Self::pattern_args`].
+    ///
+    /// A resolver-selected pattern position depends on literal option words.
+    /// Once source substitution reaches that option prefix, treating its
+    /// spelling as a positional operand would shift the remaining arguments
+    /// and incorrectly claim a pattern language.  Static pattern layouts do
+    /// not have that ambiguity and continue through the compatibility
+    /// resolver, whose indices are independent of argument values.
+    #[must_use]
+    pub fn pattern_args_words(
+        &self,
+        name: &str,
+        args: InvocationArguments<'_>,
+    ) -> Vec<crate::patterns::PatternArg> {
+        let Some(spec) = self.get(name) else {
+            return Vec::new();
+        };
+        let spellings: Vec<_> = (0..args.len())
+            .map(|index| args.literal_at(index).unwrap_or_default())
+            .collect();
+        if spec.pattern_arg_resolver.is_some()
+            && (spec.options.is_empty() && args.has_non_literal()
+                || has_dynamic_leading_option_word(spec.options, args, &spellings))
+        {
+            return Vec::new();
+        }
+        self.pattern_args(name, &spellings)
     }
 
     /// How a formatter should **present** argument `index` of a call to
@@ -4180,6 +4257,25 @@ mod tests {
         );
         assert!(
             reg.pattern_args("lsearch", &["-exact", "{a b}", "a+"])
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn source_aware_pattern_roles_stop_at_a_dynamic_option_prefix() {
+        use crate::invocation_words::{InvocationArguments, InvocationWord};
+
+        let reg = CommandRegistry::build_default();
+        let args = [
+            InvocationWord::Dynamic,
+            InvocationWord::Literal("{a b c}"),
+            InvocationWord::Literal("glob*"),
+        ];
+        // `$mode` may become any lsearch option, including an option that
+        // consumes a value. Its source spelling must never be treated as the
+        // list operand and shift the remaining words into a claimed glob.
+        assert!(
+            reg.pattern_args_words("lsearch", InvocationArguments::structured(&args))
                 .is_empty()
         );
     }
@@ -6660,6 +6756,11 @@ mod tests {
             InvocationCompletion::ReturnsResult(Some(0))
         );
         assert_eq!(
+            reg.invocation_completion("return", &["-code"], DialectSet::empty()),
+            InvocationCompletion::ReturnsResult(Some(0)),
+            "a trailing option-shaped word is return's result, not a missing option value"
+        );
+        assert_eq!(
             reg.invocation_completion("return", &["-level", "0", "$w"], DialectSet::empty(),),
             InvocationCompletion::FallsThrough
         );
@@ -6789,20 +6890,34 @@ mod tests {
     }
 
     #[test]
-    fn exact_return_static_invalid_forms_are_catchable_errors() {
+    fn exact_return_option_shapes_follow_the_tcl86_and_tcl90_oracle() {
         use crate::completion::CompletionCode;
 
-        // Oracle table: Tcl 8.6 and 9.0 both reject these literal forms at
-        // return's option/arity boundary, so a surrounding `try on error`
-        // receives TCL_ERROR rather than a dynamic completion.
+        // Tcl parses an option only when a following argv word can supply its
+        // value. A lone option-shaped word is therefore return's sole result;
+        // with `-level 0`, it exposes the default TCL_OK instead.
         for dialect in ["tcl8.6", "tcl9.0"] {
             let reg = crate::registry_for_dialect(dialect);
+            for (args, expected) in [
+                (&["-code"][..], CompletionCode::Return),
+                (&["-level"][..], CompletionCode::Return),
+                (&["-options"][..], CompletionCode::Return),
+                (&["-foo"][..], CompletionCode::Return),
+                (&["-level", "0", "-code"][..], CompletionCode::Ok),
+            ] {
+                assert_eq!(
+                    reg.exact_invocation_completion("return", args, DialectSet::empty()),
+                    Some(ExactInvocationCompletion::Tcl(expected)),
+                    "{dialect}: {args:?}"
+                );
+            }
+            // Once a following word exists, the same spellings are options;
+            // malformed option values and an extra result remain TCL_ERROR.
             for args in [
                 &["-code", "bogus", "payload"][..],
                 &["-level", "-1", "payload"][..],
-                &["-code"][..],
-                &["-level"][..],
-                &["-foo"][..],
+                &["-code", "-level"][..],
+                &["-level", "-code"][..],
                 &["payload", "extra"][..],
                 &["-level", "0", "-code", "-2147483649", "payload"][..],
             ] {
@@ -6810,6 +6925,35 @@ mod tests {
                     reg.exact_invocation_completion("return", args, DialectSet::empty()),
                     Some(ExactInvocationCompletion::Tcl(CompletionCode::Error)),
                     "{dialect}: {args:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn exact_invalid_arity_of_known_terminators_is_tcl_error() {
+        use crate::completion::CompletionCode;
+
+        // The descriptor of a well-formed call must never hide Tcl's prior
+        // arity validation.  This table covers every fixed-arity terminating
+        // core primitive, including ones whose normal effect is process exit
+        // or a loop transfer rather than TCL_ERROR.
+        for dialect in ["tcl8.6", "tcl9.0"] {
+            let reg = crate::registry_for_dialect(dialect);
+            for (name, args) in [
+                ("error", &[][..]),
+                ("error", &["message", "info", "code", "extra"][..]),
+                ("throw", &[][..]),
+                ("throw", &["type"][..]),
+                ("throw", &["type", "message", "extra"][..]),
+                ("break", &["extra"][..]),
+                ("continue", &["extra"][..]),
+                ("exit", &["0", "extra"][..]),
+            ] {
+                assert_eq!(
+                    reg.exact_invocation_completion(name, args, DialectSet::empty()),
+                    Some(ExactInvocationCompletion::Tcl(CompletionCode::Error)),
+                    "{dialect}: {name} {args:?}"
                 );
             }
         }
@@ -6825,6 +6969,16 @@ mod tests {
         // escape can be supplied to this API as its effective static value.
         for dialect in ["tcl8.6", "tcl9.0"] {
             let reg = crate::registry_for_dialect(dialect);
+            let trailing_option = [InvocationWord::Literal("-code")];
+            assert_eq!(
+                reg.exact_invocation_completion_words(
+                    "return",
+                    InvocationArguments::structured(&trailing_option),
+                    DialectSet::empty()
+                ),
+                Some(ExactInvocationCompletion::Tcl(CompletionCode::Return)),
+                "{dialect}: source-aware lone -code remains the result word"
+            );
             for words in [
                 vec![
                     InvocationWord::Literal("-code"),

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -233,6 +233,13 @@ fn exact_return_completion(
             _ => break,
         }
     }
+    // A non-literal word followed by another word may evaluate to an
+    // extensible return option (for example `$option` -> `-code`). It is not
+    // sound to classify the same source shape as the literal two-result-word
+    // arity error.
+    if args.get(i).is_some() && args.literal_at(i).is_none() && args.get(i + 1).is_some() {
+        return ExactReturnCompletion::Dynamic;
+    }
     // `return` accepts one result word after its options; additional words are
     // an arity error, so no exact runtime completion is promised.
     if args
@@ -6861,6 +6868,15 @@ mod tests {
                     None,
                 );
             }
+            let dynamic_option = [InvocationWord::Dynamic, InvocationWord::Literal("error")];
+            assert_eq!(
+                reg.invocation_completion_knowledge(
+                    "return",
+                    InvocationArguments::structured(&dynamic_option),
+                    DialectSet::empty(),
+                ),
+                Some(InvocationCompletionKnowledge::Dynamic),
+            );
         }
     }
 

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -134,7 +134,10 @@ pub enum ExactInvocationCompletion {
 /// itself propagates `TCL_RETURN` even when its eventual procedure result is
 /// configured as `-code error`; `-level 0` exposes that configured code to the
 /// immediately enclosing script instead.
-fn exact_return_completion(args: &[&str]) -> Option<crate::completion::CompletionCode> {
+fn exact_return_completion(
+    args: &[&str],
+    numbers: tcl_syntax::number::Numbers,
+) -> Option<crate::completion::CompletionCode> {
     use crate::completion::CompletionCode;
 
     let mut i = 0usize;
@@ -154,22 +157,27 @@ fn exact_return_completion(args: &[&str]) -> Option<crate::completion::Completio
                     "return" | "2" => CompletionCode::Return,
                     "break" | "3" => CompletionCode::Break,
                     "continue" | "4" => CompletionCode::Continue,
-                    value => CompletionCode::Other(value.parse::<i32>().ok()?),
+                    value => CompletionCode::Other(i32::try_from(numbers.parse_wide(value)?).ok()?),
                 };
                 i += 2;
             }
             "-level" => {
-                level = args.get(i + 1)?.parse::<i64>().ok()?.max(0);
-                if args.get(i + 1)?.parse::<i64>().ok()? < 0 {
+                level = numbers.parse_wide(args.get(i + 1)?)?;
+                if level < 0 {
                     return None;
                 }
                 i += 2;
             }
             // These options do not alter the code, but `-options` may carry
             // a code/level override so remains deliberately opaque.
-            "-errorcode" | "-errorinfo" | "-errorstack" => i += 2,
-            "-options" => return None,
-            _ if word.starts_with('-') => return None,
+            "-options" => {
+                return None;
+            }
+            // Return options are an extensible key/value dictionary.  An
+            // unrecognised literal option cannot alter `-code`/`-level`, so
+            // retain the concrete completion rather than dropping a valid
+            // custom pair such as `-foo bar`.
+            _ if word.starts_with('-') => i += 2,
             _ => break,
         }
     }
@@ -2021,7 +2029,12 @@ impl CommandRegistry {
             return None;
         }
         if resolved.lowering_hook == Some(LoweringHookId::Return) {
-            return exact_return_completion(args).map(ExactInvocationCompletion::Tcl);
+            let profile = self.profile()?;
+            return exact_return_completion(
+                args,
+                tcl_syntax::number::Numbers::of_profile(Some(profile)),
+            )
+            .map(ExactInvocationCompletion::Tcl);
         }
         let traits =
             resolved.spec.traits | resolved.sub.map_or_else(Traits::empty, |sub| sub.traits);
@@ -3352,7 +3365,7 @@ mod tests {
 
     #[test]
     fn unfilled_trailing_roles_reports_the_optional_capture_variables() {
-        let reg = CommandRegistry::build_default();
+        let reg = crate::registry_for_dialect("tcl8.6");
         // `catch {body}` leaves both `VarWrite` slots open.
         assert_eq!(
             reg.unfilled_trailing_roles("catch", &["{body}"]),
@@ -6567,7 +6580,7 @@ mod tests {
     fn exact_return_options_and_process_exit_are_registry_owned() {
         use crate::completion::CompletionCode;
 
-        let reg = CommandRegistry::build_default();
+        let reg = crate::registry_for_dialect("tcl8.6");
         // Oracle (tclsh 8.6/9.0): the default -level 1 return is caught by
         // `try on return`, even when its eventual procedure result is error.
         assert_eq!(
@@ -6586,6 +6599,20 @@ mod tests {
             ),
             Some(ExactInvocationCompletion::Tcl(CompletionCode::Error))
         );
+        for args in [
+            &["-foo", "bar", "payload"][..],
+            &["-c", "error", "payload"][..],
+            &["-level", "0x0", "-code", "error", "payload"][..],
+        ] {
+            assert_eq!(
+                reg.exact_invocation_completion("return", args, DialectSet::empty()),
+                Some(ExactInvocationCompletion::Tcl(if args[0] == "-level" {
+                    CompletionCode::Error
+                } else {
+                    CompletionCode::Return
+                }))
+            );
+        }
         assert_eq!(
             reg.exact_invocation_completion("exit", &["0"], DialectSet::empty()),
             Some(ExactInvocationCompletion::ProcessExit)
@@ -6594,6 +6621,14 @@ mod tests {
             reg.exact_invocation_completion(
                 "return",
                 &["-options", "$dynamic", "payload"],
+                DialectSet::empty(),
+            ),
+            None
+        );
+        assert_eq!(
+            reg.exact_invocation_completion(
+                "return",
+                &["-code", "$dynamic", "payload"],
                 DialectSet::empty(),
             ),
             None

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -159,9 +159,12 @@ enum ExactReturnCompletion {
 }
 
 /// Parse `exit ?returnCode?` after its descriptor has established the exact
-/// one-word-or-omitted shape. Tcl parses the status with its normal wide
-/// integer grammar, so an invalid literal is an ordinary catchable error,
-/// not a process termination.
+/// one-word-or-omitted shape.  Tcl 8.x passes its argument through
+/// `Tcl_GetIntFromObj`, which accepts `-UINT_MAX..=UINT_MAX` before the C cast;
+/// Tcl 9.0+ instead uses `TclGetWideBitsFromObj`, accepting every integer
+/// (including bignums) before truncating its low bits to the C exit status.
+/// A literal rejected by its release's conversion is an ordinary catchable
+/// error, not a process termination.
 enum ExactProcessExitCompletion {
     ProcessExit,
     StaticError,
@@ -171,11 +174,33 @@ enum ExactProcessExitCompletion {
 fn exact_process_exit_completion(
     args: crate::invocation_words::InvocationArguments<'_>,
     numbers: tcl_syntax::number::Numbers,
+    version: Option<tcl_dialect::TclVersion>,
 ) -> ExactProcessExitCompletion {
     match args.get(0) {
         None => ExactProcessExitCompletion::ProcessExit,
         Some(_) => match args.literal_at(0) {
-            Some(value) if numbers.parse_wide(value).is_some() => {
+            // Tcl 9 intentionally asks its bit-preserving wide conversion,
+            // not `Tcl_GetIntFromObj`: bignums are accepted and truncated to
+            // a C `int` only at `Tcl_Exit`. Tcl 8.x's public conversion has
+            // the fixed asymmetric `-UINT_MAX..=UINT_MAX` (32-bit) range.
+            Some(value)
+                if matches!(
+                    version,
+                    Some(tcl_dialect::TclVersion::V9_0 | tcl_dialect::TclVersion::V9_1)
+                ) && matches!(
+                    numbers.parse_whole(value),
+                    Some(
+                        tcl_syntax::number::Number::Int(_) | tcl_syntax::number::Number::Big { .. }
+                    )
+                ) =>
+            {
+                ExactProcessExitCompletion::ProcessExit
+            }
+            Some(value)
+                if numbers.parse_wide(value).is_some_and(|value| {
+                    (-i64::from(u32::MAX)..=i64::from(u32::MAX)).contains(&value)
+                }) =>
+            {
                 ExactProcessExitCompletion::ProcessExit
             }
             Some(_) => ExactProcessExitCompletion::StaticError,
@@ -2217,6 +2242,7 @@ impl CommandRegistry {
             return match exact_process_exit_completion(
                 args,
                 tcl_syntax::number::Numbers::of_profile(self.profile()),
+                self.runtime_version(),
             ) {
                 ExactProcessExitCompletion::ProcessExit => {
                     Some(ExactInvocationCompletion::ProcessExit)
@@ -7214,23 +7240,63 @@ mod tests {
     }
 
     #[test]
-    fn exit_status_completion_follows_the_tcl86_and_tcl90_oracle() {
+    fn exit_status_completion_follows_the_release_specific_tcl_oracle() {
         use crate::completion::CompletionCode;
         use crate::invocation_words::{InvocationArguments, InvocationWord};
 
-        for dialect in ["tcl8.6", "tcl9.0"] {
+        for dialect in ["tcl8.4", "tcl8.5", "tcl8.6"] {
             let reg = crate::registry_for_dialect(dialect);
-            // tclsh8.6/9: omitted and Tcl-wide integer spellings run the
-            // process-exit path; the width parser accepts hex and signs too.
-            for args in [&[][..], &["0"][..], &["-7"][..], &["0x10"][..]] {
+            // Tcl 8.x's `exit` calls `Tcl_GetIntFromObj`. Despite the `int`
+            // destination, its 64-bit implementation accepts the asymmetric
+            // `-UINT_MAX..=UINT_MAX` range before casting to `int`.
+            for args in [
+                &[][..],
+                &["0"][..],
+                &["-7"][..],
+                &["0x10"][..],
+                &["-4294967295"][..],
+                &["4294967295"][..],
+            ] {
                 assert_eq!(
                     reg.exact_invocation_completion("exit", args, DialectSet::empty()),
                     Some(ExactInvocationCompletion::ProcessExit),
                     "{dialect}: exit {args:?}"
                 );
             }
-            // `exit nope` and excess arguments never get as far as process
-            // termination: Tcl raises an ordinary, catchable error instead.
+            // One value beyond either Tcl 8.x conversion endpoint never gets
+            // as far as process termination: it is a catchable Tcl error.
+            for args in [
+                &["nope"][..],
+                &["1.5"][..],
+                &["-4294967296"][..],
+                &["4294967296"][..],
+            ] {
+                assert_eq!(
+                    reg.exact_invocation_completion("exit", args, DialectSet::empty()),
+                    Some(ExactInvocationCompletion::Tcl(CompletionCode::Error)),
+                    "{dialect}: exit {args:?}"
+                );
+            }
+        }
+
+        for dialect in ["tcl9.0", "tcl9.1"] {
+            let reg = crate::registry_for_dialect(dialect);
+            // Tcl 9.0+ changed `exit` to `TclGetWideBitsFromObj`: every
+            // integer, including a bignum beyond wide range, reaches
+            // `Tcl_Exit` and has its low bits cast to `int` there.
+            for args in [
+                &[][..],
+                &["0"][..],
+                &["-4294967296"][..],
+                &["4294967296"][..],
+                &["18446744073709551616"][..],
+            ] {
+                assert_eq!(
+                    reg.exact_invocation_completion("exit", args, DialectSet::empty()),
+                    Some(ExactInvocationCompletion::ProcessExit),
+                    "{dialect}: exit {args:?}"
+                );
+            }
             for args in [&["nope"][..], &["1.5"][..], &["0", "extra"][..]] {
                 assert_eq!(
                     reg.exact_invocation_completion("exit", args, DialectSet::empty()),
@@ -7238,7 +7304,10 @@ mod tests {
                     "{dialect}: exit {args:?}"
                 );
             }
+        }
 
+        for dialect in ["tcl8.4", "tcl8.5", "tcl8.6", "tcl9.0", "tcl9.1"] {
+            let reg = crate::registry_for_dialect(dialect);
             let dynamic = [InvocationWord::Dynamic];
             assert_eq!(
                 reg.invocation_completion_knowledge(

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -153,9 +153,9 @@ fn exact_return_completion(
                     "return" | "2" => CompletionCode::Return,
                     "break" | "3" => CompletionCode::Break,
                     "continue" | "4" => CompletionCode::Continue,
-                    value => CompletionCode::Other(crate::completion::canonical_completion_code(
-                        value, numbers,
-                    )?),
+                    value => CompletionCode::from_int(
+                        crate::completion::canonical_completion_code(value, numbers)?,
+                    ),
                 };
                 i += 2;
             }
@@ -6621,6 +6621,23 @@ mod tests {
                 Some(ExactInvocationCompletion::Tcl(CompletionCode::Other(
                     expected
                 )))
+            );
+        }
+        for (spelling, expected) in [
+            ("00", CompletionCode::Ok),
+            ("+1", CompletionCode::Error),
+            ("02", CompletionCode::Return),
+            ("0x3", CompletionCode::Break),
+            ("04", CompletionCode::Continue),
+        ] {
+            assert_eq!(
+                reg.exact_invocation_completion(
+                    "return",
+                    &["-level", "0", "-code", spelling, "payload"],
+                    DialectSet::empty(),
+                ),
+                Some(ExactInvocationCompletion::Tcl(expected)),
+                "{spelling}"
             );
         }
         assert_eq!(

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -1228,10 +1228,10 @@ pub struct CommandSpec {
     /// substitution beginning with `-` — hence `switch $x $caseListVar`
     /// needs no `--` terminator. Consumed by
     /// [`crate::registry::CommandRegistry::resolve_option_terminator`]'s
-    /// `reserved_trailing_words` on [`crate::registry::ResolvedTerminator`],
-    /// which both W304 and T102's option-scan-region walk cap their scan
-    /// against. Default `0` (no reservation) keeps every existing spec
-    /// correct.
+    /// `reserved_trailing_words` on [`crate::registry::ResolvedTerminator`]
+    /// and the source-aware pattern resolver, which both cap their option
+    /// scans against it. W304 and T102 use the former path. Default `0` (no
+    /// reservation) keeps every existing spec correct.
     pub reserved_trailing_words: usize,
 
     /// Enumerable positional-argument values, keyed by 0-based

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -1376,6 +1376,15 @@ pub struct CommandSpec {
     /// pattern validation. `None` = not a pattern command.
     pub pattern_type: Option<PatternType>,
 
+    /// Call-specific pattern positions and languages for an option-selected
+    /// grammar such as `lsearch -regexp list pattern`.  Static pattern
+    /// commands use [`Self::pattern_type`] and [`Self::arg_roles`] instead.
+    ///
+    /// This is deliberately a registry hook, never an editor-side command
+    /// name match: the option grammar remains co-located with its
+    /// [`OptionSpec`] descriptors.
+    pub pattern_arg_resolver: Option<crate::patterns::PatternArgResolver>,
+
     /// Kind of format string this command's format argument uses
     /// (`format`/`scan` ⇒ `Sprintf`, …), for inlay-hint parsing and
     /// semantic-token sub-tokens. `None` = not a format command.
@@ -1639,7 +1648,65 @@ fn option_table_from<'a>(
     KeywordTable::from_keywords(keywords, prefix_matching)
 }
 
-fn leading_option_word_count(options: &[OptionSpec], args: &[&str]) -> usize {
+/// Resolve one leading option word against its descriptor table.
+///
+/// Tcl accepts an exact canonical spelling or alias, then an unambiguous
+/// abbreviation of either spelling.  Keeping that rule beside
+/// [`OptionSpec`] means the layout resolvers, option-value role walk, and
+/// declaration helpers all consume precisely the words Tcl's option parser
+/// consumes; no command consumer needs its own list of value-taking switches.
+#[must_use]
+pub fn resolve_option_prefix<'a>(options: &'a [OptionSpec], word: &str) -> Option<&'a OptionSpec> {
+    resolve_option_prefix_with(options, word, PrefixMatching::Enabled)
+}
+
+/// [`resolve_option_prefix`] with the table's declared prefix policy.
+#[must_use]
+pub fn resolve_option_prefix_with<'a>(
+    options: &'a [OptionSpec],
+    word: &str,
+    prefix_matching: PrefixMatching,
+) -> Option<&'a OptionSpec> {
+    if let Some(exact) = options.iter().find(|option| option.matches(word)) {
+        return Some(exact);
+    }
+    if !prefix_matching.accepts_prefixes() || !word.starts_with('-') || word.len() < 2 {
+        return None;
+    }
+    let mut matched: Option<&OptionSpec> = None;
+    for option in options {
+        if std::iter::once(option.name)
+            .chain(option.aliases.iter().copied())
+            .any(|spelling| spelling.starts_with(word))
+        {
+            match matched {
+                None => matched = Some(option),
+                Some(previous) if std::ptr::eq(previous, option) => {}
+                Some(_) => return None,
+            }
+        }
+    }
+    matched
+}
+
+/// Return the index immediately after a declared leading option prefix.
+///
+/// The descriptor-driven walk honours unique abbreviations, aliases, each
+/// option's actual value arity, and a declared `--` terminator.  It is the
+/// common layout primitive for commands whose positional grammar starts only
+/// after their option prefix.
+#[must_use]
+pub fn leading_option_word_count(options: &[OptionSpec], args: &[&str]) -> usize {
+    leading_option_word_count_with(options, args, PrefixMatching::Enabled)
+}
+
+/// [`leading_option_word_count`] with the table's declared prefix policy.
+#[must_use]
+pub fn leading_option_word_count_with(
+    options: &[OptionSpec],
+    args: &[&str],
+    prefix_matching: PrefixMatching,
+) -> usize {
     if options.is_empty() {
         return 0;
     }
@@ -1648,20 +1715,9 @@ fn leading_option_word_count(options: &[OptionSpec], args: &[&str]) -> usize {
         if !word.starts_with('-') || word.len() < 2 {
             break;
         }
-        let resolved = options
-            .iter()
-            .find(|o| o.name == word || o.aliases.contains(&word))
-            .or_else(|| {
-                let mut prefixed = options.iter().filter(|o| o.name.starts_with(word));
-                let first = prefixed.next();
-                if prefixed.next().is_some() {
-                    None
-                } else {
-                    first
-                }
-            });
+        let resolved = resolve_option_prefix_with(options, word, prefix_matching);
         let Some(opt) = resolved else { break };
-        i += 1 + usize::from(opt.takes_value());
+        i += 1 + opt.value_word_count(args, i);
         if opt.name == "--" {
             // `--` ends option parsing (Tcl's own `Tcl_ParseArgsObjv`-style
             // convention: every subsequent word — even one that looks like a
@@ -1776,6 +1832,7 @@ impl CommandSpec {
         sensitive_headers: &[],
         setter_constraints: &[],
         pattern_type: None,
+        pattern_arg_resolver: None,
         format_string_type: None,
         tcllib_package: None,
         lifecycle: Lifecycle::UNSPECIFIED,
@@ -2290,7 +2347,7 @@ impl CommandSpec {
     /// [`Self::defines_command_at`]) can be shifted past them.
     #[must_use]
     pub fn leading_option_word_count(&self, args: &[&str]) -> usize {
-        leading_option_word_count(self.options, args)
+        leading_option_word_count_with(self.options, args, self.prefix_matching)
     }
 
     /// Like [`Self::switch_names`], but optionally including documented
@@ -3036,7 +3093,7 @@ impl SubCommand {
     /// them all would shift a positional index past real arguments.
     #[must_use]
     pub fn leading_option_word_count(&self, args: &[&str]) -> usize {
-        let counted = leading_option_word_count(self.options, args);
+        let counted = leading_option_word_count_with(self.options, args, self.prefix_matching);
         match self.max_leading_option_words {
             Some(cap) => counted.min(usize::from(cap)),
             None => counted,

--- a/rust/tcl-registry/src/traits.rs
+++ b/rust/tcl-registry/src/traits.rs
@@ -248,6 +248,11 @@ declare_traits! {
     HasBooleanCond => HAS_BOOLEAN_COND;
     /// Unconditionally terminates the current block (`error`, `return`, `exit`).
     TerminatesBlock => TERMINATES_BLOCK;
+    /// Ends the interpreter process immediately, without unwinding Tcl
+    /// exception ranges or executing enclosing `finally` clauses (`exit`).
+    /// This is deliberately narrower than [`Traits::TERMINATES_BLOCK`]:
+    /// ordinary Tcl completion codes still propagate through `try`.
+    TerminatesProcess => TERMINATES_PROCESS;
 
     // Loop/body structure
     /// Contains a loop body (`for`, `while`, `foreach`).

--- a/rust/tcl-registry/tests/registry_sweep.rs
+++ b/rust/tcl-registry/tests/registry_sweep.rs
@@ -138,6 +138,7 @@ const ALL_TRAITS: &[Traits] = &[
     Traits::LANGUAGE_KEYWORD,
     Traits::HAS_BOOLEAN_COND,
     Traits::TERMINATES_BLOCK,
+    Traits::TERMINATES_PROCESS,
     Traits::HAS_LOOP_BODY,
     Traits::NEVER_INLINE_BODY,
     Traits::LOOP_LIST_HEADER,

--- a/rust/tcl-spec-studio/src/coverage.rs
+++ b/rust/tcl-spec-studio/src/coverage.rs
@@ -239,6 +239,7 @@ pub fn witness_command_spec(spec: &CommandSpec) {
         sensitive_headers: _,
         setter_constraints: _,
         pattern_type: _,
+        pattern_arg_resolver: _,
         format_string_type: _,
         tcllib_package: _,
         lifecycle: _,
@@ -392,6 +393,10 @@ pub const COMMAND_SPEC: &[Field] = &[
     f("sensitive_headers", Surface::Key("sensitive_headers")),
     f("setter_constraints", Surface::Key("setter_constraints")),
     f("pattern_type", Surface::Key("pattern_type")),
+    f(
+        "pattern_arg_resolver",
+        Surface::Excluded("native, call-specific pattern selection hook"),
+    ),
     f("format_string_type", Surface::Key("format_string_type")),
     f("tcllib_package", Surface::Key("tcllib_package")),
     f("lifecycle", Surface::Keys(LIFECYCLE_KEYS)),

--- a/rust/tcl-spec-studio/src/coverage.rs
+++ b/rust/tcl-spec-studio/src/coverage.rs
@@ -393,10 +393,7 @@ pub const COMMAND_SPEC: &[Field] = &[
     f("sensitive_headers", Surface::Key("sensitive_headers")),
     f("setter_constraints", Surface::Key("setter_constraints")),
     f("pattern_type", Surface::Key("pattern_type")),
-    f(
-        "pattern_arg_resolver",
-        Surface::Excluded("native, call-specific pattern selection hook"),
-    ),
+    f("pattern_arg_resolver", Surface::Key("pattern_arg_resolver")),
     f("format_string_type", Surface::Key("format_string_type")),
     f("tcllib_package", Surface::Key("tcllib_package")),
     f("lifecycle", Surface::Keys(LIFECYCLE_KEYS)),

--- a/rust/tcl-spec-studio/src/draft.rs
+++ b/rust/tcl-spec-studio/src/draft.rs
@@ -1445,6 +1445,10 @@ fn command_advanced(d: &mut Draft, spec: &CommandSpec, lost: &mut Unrecovered) {
             .map_or(Value::Null, |t| json!(catalogue::variant_name(&t))),
     );
     d.insert(
+        "pattern_arg_resolver".into(),
+        lost.expr("pattern_arg_resolver", spec.pattern_arg_resolver.is_some()),
+    );
+    d.insert(
         "format_string_type".into(),
         spec.format_string_type
             .map_or(Value::Null, |t| json!(catalogue::variant_name(&t))),

--- a/rust/tcl-spec-studio/src/help.rs
+++ b/rust/tcl-spec-studio/src/help.rs
@@ -635,6 +635,13 @@ rarely needed outside the F5 command packs.",
 in the right language — a `*` means something very different in each.",
     ),
     (
+        "pattern_arg_resolver",
+        "A native hook that selects the Pattern argument positions and language \
+for this particular call. Use it when options change the pattern grammar, such \
+as `lsearch -regexp`; the Studio preserves the need for the hook but cannot \
+recover a Rust function pointer from a loaded spec, so supply the expression.",
+    ),
+    (
         "format_string_type",
         "Which template mini-language the command's format argument uses: \
 printf-style (`format`/`scan`), `clock format` fields, `binary` \

--- a/rust/tcl-spec-studio/src/render_spectcl.rs
+++ b/rust/tcl-spec-studio/src/render_spectcl.rs
@@ -245,6 +245,15 @@ pub const GAPS: &[Gap] = &[
         spelling: "",
         kind: GapKind::Excluded,
     },
+    // This is a native resolver over a command's own OptionSpec table. Packs
+    // can describe the table and static pattern facts, but not arbitrary
+    // option-selected language dispatch yet; keeping it excluded makes the
+    // native-only boundary explicit until a declarative selector exists.
+    Gap {
+        key: "pattern_arg_resolver",
+        spelling: "",
+        kind: GapKind::Excluded,
+    },
     Gap {
         key: "command_forms",
         spelling: "",

--- a/rust/tcl-spec-studio/src/render_spectcl.rs
+++ b/rust/tcl-spec-studio/src/render_spectcl.rs
@@ -1886,6 +1886,7 @@ fn command_body(out: &mut Out, ctx: &mut Ctx<'_>, draft: &Draft) {
     enum_word(out, ctx, draft, "body_kind");
     expr_word(out, ctx, draft, "byte_array_effect", byte_array_effect_word);
     enum_word(out, ctx, draft, "pattern_type");
+    gap_todo(out, ctx, draft, "pattern_arg_resolver");
     enum_word(out, ctx, draft, "format_string_type");
     expr_row(
         out,

--- a/rust/tcl-spec-studio/src/schema.rs
+++ b/rust/tcl-spec-studio/src/schema.rs
@@ -891,6 +891,15 @@ pub const COMMAND_FIELDS: &[FieldSchema] = &[
         "The pattern language the command's pattern argument uses.",
     ),
     f(
+        "pattern_arg_resolver",
+        "Pattern-argument resolver",
+        OPTS,
+        FieldKind::RustExpr {
+            hint: "Some(lsearch_pattern_args)",
+        },
+        "Native hook selecting pattern positions and languages for a concrete call.",
+    ),
+    f(
         "format_string_type",
         "Format-string type",
         OPTS,

--- a/rust/tcl-spectcl/src/catalogue.rs
+++ b/rust/tcl-spectcl/src/catalogue.rs
@@ -389,6 +389,10 @@ pub const TRAITS: &[Variant] = &[
     ),
     v("HAS_BOOLEAN_COND", "takes a boolean condition"),
     v("TERMINATES_BLOCK", "terminates the enclosing basic block"),
+    v(
+        "TERMINATES_PROCESS",
+        "terminates the interpreter process without Tcl unwinding",
+    ),
     v("HAS_LOOP_BODY", "takes a loop body"),
     v("NEVER_INLINE_BODY", "its body must never be inlined"),
     v(


### PR DESCRIPTION
## Issues

Closes #1387
Closes #1386
Closes #1414
Closes #1417

## Root cause

The diagram LSP command duplicated the shared diagram implementation, hover maintained command-specific argument detectors instead of consuming registry roles, the contributed pull-diagnostics setting was disconnected from the real initialise-time server option, and the diagnostics smoke test used fixed frame windows that could miss late duplicate publications.

## Fix

- Routes `tcl-lsp.diagramData` through the shared `tcl-diagram` crate and preserves both editor payload contracts.
- Makes hover consume the same registry-owned `ArgRole` information as semantic tokens.
- Wires the editor contribution to the real restart-required `pull_diagnostics_enabled` initialisation setting.
- Replaces fixed diagnostic frame windows with condition/quiescence-based collection.
- Regenerates the command-spec reference from its canonical source.

## Dialect/release behaviour

Document dialect profiles continue to be resolved at the LSP boundary and threaded into registry role resolution. No new release-specific semantic owner was introduced. The hover/token consistency vectors exercise the registry-selected format role rather than command-name matching.

## Duplication audit

The LSP-local diagram implementation and hover-only command detectors were removed or routed through their existing shared owners. The editor setting now maps to the existing server option rather than creating a second setting owner.

## Tests

- Serialised diagram payload coverage for VS Code and JetBrains clients.
- Hover/semantic-token consistency coverage for format arguments.
- Initialise-time pull-diagnostics setting coverage.
- Diagnostics-delivery quiescence coverage that detects duplicate/late publication.

## Gates

- `make rust-check` — pass
- `make prep-pr` — pass
- `make test-rust` — pass (canonical local LSP e2e coverage)
- `make test-ext` — pass after clean rerun (890 single-root, 14 multi-root)
- `make gen-editor-settings` — pass

The first `test-ext` attempt stopped on ENOSPC while writing regenerable release artefacts. The affected per-worktree target was cleaned, space was reclaimed from an idle worktree target, and the entire gate was rerun successfully under isolated build output.

## Generated artefacts/docs

The command-spec reference and its generator source were updated together; editor-setting generation/drift checks pass.

## Performance

No material performance risk identified. Diagram work is consolidated through the existing shared crate, and diagnostics collection now terminates on an explicit condition/quiescence contract rather than arbitrary frame counts.
