### PR TITLE
fix: activate Spec Studio Monaco LSP features

### DIFF
--- a/rust/tcl-spec-studio-wasm/test/boot.mjs
+++ b/rust/tcl-spec-studio-wasm/test/boot.mjs
@@ -201,9 +201,11 @@ async function main() {
     );
     console.log(`    LSP: ${(await page.textContent("#lspStatus")).trim()}`);
 
-    // The success status is published only after the host has requested both
-    // semantic tokens and hover from this opened pack document.
-    console.log("    Pack DSL hover is served by the in-page LSP");
+    // The success status is published only after Monaco itself has invoked the
+    // semantic-token provider for this model, and hover has answered for it.
+    // A direct transport probe is insufficient: editor.api exposes provider
+    // registration even when the controller which consumes it was omitted.
+    console.log("    Pack DSL semantics and hover are served by the in-page LSP");
 
     // The fallback overlay already colours the pack before Monaco arrives;
     // prove the replacement editor gets several semantic colours from the

--- a/rust/tcl-spec-studio/web/build.mjs
+++ b/rust/tcl-spec-studio/web/build.mjs
@@ -130,7 +130,7 @@ copyFileSync(join(here, "node_modules", "vscode-oniguruma", "release", "onig.was
 // The editor chunk. Minified, unlike the controller: this is vendored
 // third-party code whose readable form is upstream's repository, not ours, and
 // 2.5 MB unminified would be 9 MB of dist for no reader's benefit.
-await esbuild.build({
+const monacoBuild = await esbuild.build({
   entryPoints: [join(here, "src", "monacoHost.ts")],
   outfile: join(assetsDir, "monaco-host.js"),
   bundle: true,
@@ -140,12 +140,24 @@ await esbuild.build({
   minify: true,
   legalComments: "none",
   banner: { js: vendorBanner },
+  metafile: true,
   define: { __SPEC_STUDIO_FRONTEND_VERSION__: JSON.stringify(version) },
   // Monaco's CSS pulls in the codicon font; inlining it as a data URI is what
   // keeps the dist to files that can be copied anywhere without a loader.
   loader: { ".ttf": "dataurl", ".woff": "dataurl", ".woff2": "dataurl", ".svg": "dataurl" },
   logLevel: "info",
 });
+
+// `editor.api` lets code register an LSP provider even when the controller
+// which asks that provider for data was tree-shaken out. That failure looks
+// healthy to direct transport probes and leaves the user with TextMate-only
+// colouring. Make the controllers part of the build contract.
+for (const feature of ["format", "hover", "parameterHints", "semanticTokens", "suggest"]) {
+  const registration = `/features/${feature}/register.js`;
+  if (!Object.keys(monacoBuild.metafile.inputs).some((input) => input.includes(registration))) {
+    throw new Error(`Monaco's ${feature} controller is missing from the editor bundle`);
+  }
+}
 
 console.log(
   `spec studio front-end ${version}: built dist/studio.js + native/Monaco editor hosts`,

--- a/rust/tcl-spec-studio/web/src/monaco-features.d.ts
+++ b/rust/tcl-spec-studio/web/src/monaco-features.d.ts
@@ -1,0 +1,7 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Monaco publishes its feature entry points as JavaScript-only side-effect
+// modules. Their package export is valid, but there is intentionally no API
+// surface for TypeScript to describe.
+declare module "monaco-editor/features/*/register.js";

--- a/rust/tcl-spec-studio/web/src/monacoHost.ts
+++ b/rust/tcl-spec-studio/web/src/monacoHost.ts
@@ -33,6 +33,15 @@
 // it in TypeScript.
 
 import * as monaco from "monaco-editor/editor/editor.api.js";
+// `editor.api` exposes provider registration but deliberately does not install
+// the editor controllers which consume those providers. Keep this list
+// explicit so the lazy bundle contains only the LSP-backed features Studio
+// offers, while still making registration do something in the actual editor.
+import "monaco-editor/features/format/register.js";
+import "monaco-editor/features/hover/register.js";
+import "monaco-editor/features/parameterHints/register.js";
+import "monaco-editor/features/semanticTokens/register.js";
+import "monaco-editor/features/suggest/register.js";
 import "monaco-editor/languages/definitions/rust/register.js";
 import type {
   CompletionItem as LspCompletionItem,
@@ -188,7 +197,10 @@ function positionOf(text: string, needle: string): { line: number; character: nu
  * one registration each and the model's own URI decides which document the
  * request names.
  */
-function registerProviders(client: LspClient): void {
+function registerProviders(
+  client: LspClient,
+  semanticTokensApplied: (uri: string, tokenCount: number) => void,
+): void {
   const legend: monaco.languages.SemanticTokensLegend = {
     // Semantic-token legends contain token *identifiers*, not TextMate
     // scopes. Monaco's built-in themes already colour the standard LSP names
@@ -205,6 +217,7 @@ function registerProviders(client: LspClient): void {
       provideDocumentSemanticTokens: async (model) => {
         const reply = await client.semanticTokens(model.uri.toString());
         if (!reply) return null;
+        semanticTokensApplied(model.uri.toString(), reply.data.length);
         return { data: Uint32Array.from(reply.data), resultId: reply.resultId };
       },
       releaseDocumentSemanticTokens: () => {
@@ -514,10 +527,16 @@ export async function mountEditors(options: EditorHostOptions): Promise<EditorHo
     .addEventListener?.("change", () => monaco.editor.setTheme(currentTheme()));
 
   let client: LspClient | null = null;
+  let resolveDslSemanticTokens: ((tokenCount: number) => void) | undefined;
+  const dslSemanticTokens = new Promise<number>((resolve) => {
+    resolveDslSemanticTokens = resolve;
+  });
   try {
     options.report("starting the language server…");
     client = await startLspClient(options.workerUrl);
-    registerProviders(client);
+    registerProviders(client, (uri, tokenCount) => {
+      if (uri === DSL_URI) resolveDslSemanticTokens?.(tokenCount);
+    });
   } catch (e) {
     options.report(
       `the language server could not start (${e instanceof Error ? e.message : String(e)}) — ` +
@@ -537,8 +556,16 @@ export async function mountEditors(options: EditorHostOptions): Promise<EditorHo
     // regression otherwise leaves a green status beside an editor with no
     // tokens, hover, or diagnostics.
     try {
-      const tokens = await client.semanticTokens(DSL_URI);
-      if (!tokens?.data.length) throw new Error("the pack document returned no semantic tokens");
+      const tokenCount = await Promise.race([
+        dslSemanticTokens,
+        new Promise<never>((_resolve, reject) =>
+          window.setTimeout(
+            () => reject(new Error("Monaco did not request semantic tokens for the pack")),
+            10_000,
+          ),
+        ),
+      ]);
+      if (!tokenCount) throw new Error("the pack document returned no semantic tokens");
       const hoverAt = positionOf(options.dsl.textarea.value, "speclib");
       if (hoverAt && !(await client.hover(DSL_URI, hoverAt.line, hoverAt.character))) {
         throw new Error("the pack document returned no hover information");
@@ -604,7 +631,7 @@ export async function mountTclEditor(options: TclEditorOptions): Promise<{
   let client: LspClient | null = null;
   try {
     client = await startLspClient(options.workerUrl);
-    registerProviders(client);
+    registerProviders(client, () => {});
   } catch (error) {
     options.report?.(
       `language server unavailable: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
Fixes the remaining Spec Studio editor regression reported after #1512.

## Root cause

The lazy editor bundle imported `monaco-editor/editor/editor.api.js`. That API accepts semantic-token, hover, completion, signature-help, and formatting providers, but it does not install the Monaco feature controllers which invoke them. The existing health probe called the LSP client directly, so it incorrectly reported a healthy LSP while the editor settled on TextMate-only highlighting.

## Fix

- bundle the explicit Monaco controllers used by both Spec Studio and Compiler Explorer
- retain the VS Code extension Tcl TextMate grammar as their shared lexical base
- require Monaco itself to request non-empty SpecTcl semantic tokens before showing the green status
- assert the controller entry points remain in the esbuild metafile
- strengthen the browser boot-test contract

## Verification

- `make rust-check`
- `make prep-pr`
- Spec Studio web typecheck, lint, unit tests, build, and assembled WASM build

All local compilation ran at nice 15 and idle-class I/O priority.