### PR TITLE
Keep the iRules compiler profile in live sessions

### DIFF
--- a/rust/tcl-irule-test/src/live.rs
+++ b/rust/tcl-irule-test/src/live.rs
@@ -85,8 +85,7 @@ impl std::error::Error for SessionError {}
 /// runtime `eval` / command substitution: the real Rust compiler pipeline,
 /// built from the iRules profile (issue #1462) so everything the harness
 /// compiles — the framework and the iRule under test alike — parses under
-/// the TMM's genuine Tcl 8.4.6 grammar: no `{*}` expansion (a hard `extra
-/// characters after close-brace`, exactly as on a real BIG-IP), the 8.x
+/// the TMM's genuine Tcl 8.4.6 grammar: no TIP-157 `{*}` expansion, the 8.x
 /// first-close `${…}` rule, and the iRules-only `}{` ghost word separator.
 struct Svc {
     registry: &'static CommandRegistry,
@@ -189,7 +188,10 @@ impl LiveSession {
         // compat84.tcl then polyfills; the TMM sandbox itself is emulated in
         // Tcl by tmm_shim.tcl.
         let profile = DialectProfile::irules();
-        vm.set_runtime_version(profile.vm_runtime_version);
+        vm.set_dialect_profile(profile);
+        vm.set_command_surface_profile(DialectProfile::by_name(
+            profile.vm_runtime_version.dialect_name(),
+        ));
         vm.set_compiler(Box::new(Svc::for_profile(profile)));
         let mut session = Self { vm, output };
         session.bootstrap(lib_dir)?;
@@ -731,8 +733,8 @@ mod tests {
     /// availability gate, so `compat84.tcl`'s Tcl-level polyfill *procs* are
     /// what the framework (and these probes) actually run — a user-defined
     /// proc must always win over a hidden builtin. And the compiler parses
-    /// under the TMM's 8.4.6 grammar, so `{*}` is a hard `extra characters
-    /// after close-brace` exactly as a real BIG-IP reports it.
+    /// under the TMM's 8.4.6 grammar while preserving the iRules-only
+    /// adjacent-brace word separator.
     #[test]
     fn harness_runs_the_tmm_84_surface() {
         let mut s = LiveSession::new(&lib_dir()).expect("session");
@@ -766,20 +768,16 @@ mod tests {
             other => panic!("sandbox_blocks_hidden_dict: dict must be invalid, got {other:?}"),
         }
 
-        // tmm_grammar_has_no_expansion: `{*}` is 8.5+ syntax the embedded
-        // 8.4.6 grammar does not have. The adjacent close/open braces are a
-        // hard parse error, matching Tcl 8.4 rather than TIP-157 expansion.
+        // tmm_grammar_has_no_expansion: `{*}` is not TIP-157 expansion under
+        // iRules. Its adjacent close/open braces are the dialect's ghost word
+        // separator, so this is two literal list arguments rather than one
+        // expanded argument.
         scenario(&mut s);
-        match s.eval("llength [list {*}{a b}]") {
-            Err(SessionError::Eval(message)) => assert_eq!(
-                message, "extra characters after close-brace",
-                "tmm_grammar_has_no_expansion: Tcl 8.4 must reject TIP-157 syntax"
-            ),
-            other => {
-                panic!("tmm_grammar_has_no_expansion: Tcl 8.4 syntax must fail, got {other:?}")
-            }
-        }
-
+        assert_eq!(
+            s.eval("llength [list {*}{a b}]").unwrap(),
+            "2",
+            "iRules must use its ghost separator rather than TIP-157 expansion"
+        );
         // surface_hides_86_builtins: an 8.6+-only builtin with no polyfill
         // (lmap) does not exist at 8.4 — the miss reports through the
         // sandbox's resolution chain (which has also hidden the `unknown`

--- a/rust/tcl-irule-test/src/live.rs
+++ b/rust/tcl-irule-test/src/live.rs
@@ -189,9 +189,9 @@ impl LiveSession {
         // Tcl by tmm_shim.tcl.
         let profile = DialectProfile::irules();
         vm.set_dialect_profile(profile);
-        vm.set_command_surface_profile(DialectProfile::by_name(
+        assert!(vm.set_command_surface_profile(DialectProfile::by_name(
             profile.vm_runtime_version.dialect_name(),
-        ));
+        )));
         vm.set_compiler(Box::new(Svc::for_profile(profile)));
         let mut session = Self { vm, output };
         session.bootstrap(lib_dir)?;

--- a/rust/tcl-vm/src/cmd_thread.rs
+++ b/rust/tcl-vm/src/cmd_thread.rs
@@ -295,7 +295,7 @@ fn run_worker(shared: &Arc<Shared>, id: u64, inbox: Receiver<Job>, script: &str)
     // the runtime must agree or numerals mean different things either side of
     // `thread::send`.
     vm.set_dialect_profile(shared.dialect_profile);
-    vm.set_command_surface_profile(shared.command_surface_profile);
+    debug_assert!(vm.set_command_surface_profile(shared.command_surface_profile));
     let _ = vm.write_array_raw("tcl_platform", "threaded", Value::string("1"));
     vm.thread = ThreadSystem {
         shared: Some(Arc::clone(shared)),
@@ -831,7 +831,7 @@ fn run_pool_worker(shared: &Arc<Shared>, queue: &Arc<PoolQueue>, initcmd: Option
     // the runtime must agree or numerals mean different things either side of
     // `thread::send`.
     vm.set_dialect_profile(shared.dialect_profile);
-    vm.set_command_surface_profile(shared.command_surface_profile);
+    debug_assert!(vm.set_command_surface_profile(shared.command_surface_profile));
     let _ = vm.write_array_raw("tcl_platform", "threaded", Value::string("1"));
     let id = shared.next_id.fetch_add(1, Ordering::SeqCst);
     vm.thread = ThreadSystem {

--- a/rust/tcl-vm/src/cmd_thread.rs
+++ b/rust/tcl-vm/src/cmd_thread.rs
@@ -295,7 +295,10 @@ fn run_worker(shared: &Arc<Shared>, id: u64, inbox: Receiver<Job>, script: &str)
     // the runtime must agree or numerals mean different things either side of
     // `thread::send`.
     vm.set_dialect_profile(shared.dialect_profile);
-    debug_assert!(vm.set_command_surface_profile(shared.command_surface_profile));
+    assert!(
+        vm.set_command_surface_profile(shared.command_surface_profile),
+        "worker command surface must remain compatible with its dialect"
+    );
     let _ = vm.write_array_raw("tcl_platform", "threaded", Value::string("1"));
     vm.thread = ThreadSystem {
         shared: Some(Arc::clone(shared)),
@@ -831,7 +834,10 @@ fn run_pool_worker(shared: &Arc<Shared>, queue: &Arc<PoolQueue>, initcmd: Option
     // the runtime must agree or numerals mean different things either side of
     // `thread::send`.
     vm.set_dialect_profile(shared.dialect_profile);
-    debug_assert!(vm.set_command_surface_profile(shared.command_surface_profile));
+    assert!(
+        vm.set_command_surface_profile(shared.command_surface_profile),
+        "pool worker command surface must remain compatible with its dialect"
+    );
     let _ = vm.write_array_raw("tcl_platform", "threaded", Value::string("1"));
     let id = shared.next_id.fetch_add(1, Ordering::SeqCst);
     vm.thread = ThreadSystem {

--- a/rust/tcl-vm/src/cmd_thread.rs
+++ b/rust/tcl-vm/src/cmd_thread.rs
@@ -104,6 +104,9 @@ struct Shared {
     /// Carrying the whole profile (not a bare release) keeps the worker's
     /// command-surface availability gate aligned too (issue #1463).
     dialect_profile: &'static tcl_dialect::DialectProfile,
+    /// The separately overridden host command surface, when the parent runs a
+    /// sandboxed dialect inside a broader Tcl interpreter.
+    command_surface_profile: &'static tcl_dialect::DialectProfile,
     output: ThreadedOutput,
     next_id: AtomicU64,
     /// Monotonic source of opaque handles (`mutex`/`cond`/`rwmutex`/`tpool`).
@@ -176,6 +179,7 @@ impl Vm {
         let shared = Arc::new(Shared {
             factory,
             dialect_profile: self.dialect_profile(),
+            command_surface_profile: self.command_surface_profile(),
             output,
             next_id: AtomicU64::new(MAIN_ID + 1),
             handle_seq: AtomicU64::new(0),
@@ -291,6 +295,7 @@ fn run_worker(shared: &Arc<Shared>, id: u64, inbox: Receiver<Job>, script: &str)
     // the runtime must agree or numerals mean different things either side of
     // `thread::send`.
     vm.set_dialect_profile(shared.dialect_profile);
+    vm.set_command_surface_profile(shared.command_surface_profile);
     let _ = vm.write_array_raw("tcl_platform", "threaded", Value::string("1"));
     vm.thread = ThreadSystem {
         shared: Some(Arc::clone(shared)),
@@ -826,6 +831,7 @@ fn run_pool_worker(shared: &Arc<Shared>, queue: &Arc<PoolQueue>, initcmd: Option
     // the runtime must agree or numerals mean different things either side of
     // `thread::send`.
     vm.set_dialect_profile(shared.dialect_profile);
+    vm.set_command_surface_profile(shared.command_surface_profile);
     let _ = vm.write_array_raw("tcl_platform", "threaded", Value::string("1"));
     let id = shared.next_id.fetch_add(1, Ordering::SeqCst);
     vm.thread = ThreadSystem {

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -505,7 +505,12 @@ pub struct InterpState {
     /// fallback profile, which hides nothing; `set_runtime_version` pins the
     /// matching plain-Tcl profile and `set_dialect_profile` pins a vendor one.
     dialect_profile: &'static tcl_dialect::DialectProfile,
-    /// The availability registry for [`Self::dialect_profile`], resolved once
+    /// The profile used solely for builtin command-surface availability.
+    /// Normally identical to [`Self::dialect_profile`], but an embedding host
+    /// may expose a broader Tcl host surface while retaining a vendor grammar
+    /// and bytecode identity (for example, the iRules simulation harness).
+    command_surface_profile: &'static tcl_dialect::DialectProfile,
+    /// The availability registry for [`Self::command_surface_profile`], resolved once
     /// at pin time (`registry_for_profile` guards its cache with a lock, and
     /// this is consulted on every command resolution). `None` for the
     /// permissive fallback profile, which gates nothing.
@@ -1026,6 +1031,7 @@ impl Vm {
             self.module_procs.clear();
         }
         self.dialect_profile = profile;
+        self.command_surface_profile = profile;
         self.profile_registry =
             (!profile.is_fallback()).then(|| tcl_registry::registry_for_profile(profile));
         self.runtime_version = profile.vm_runtime_version;
@@ -1038,6 +1044,22 @@ impl Vm {
         // mid-execution.
         tcl_syntax::number::set_runtime_syntax(self.runtime_version.number_syntax());
         self.write_release_globals();
+    }
+
+    /// Override only the builtin command-availability surface.
+    ///
+    /// Compilation, bytecode profile validation, lexer/expr semantics, and
+    /// [`Self::dialect_profile`] remain unchanged. This is for embedding hosts
+    /// that execute a sandboxed dialect inside a broader host interpreter.
+    pub fn set_command_surface_profile(&mut self, profile: &'static tcl_dialect::DialectProfile) {
+        self.bump_cmd_epoch();
+        self.profile_generation = self.profile_generation.wrapping_add(1);
+        self.eval_cache.clear();
+        self.eval_cache_traced.clear();
+        self.module_procs.clear();
+        self.command_surface_profile = profile;
+        self.profile_registry =
+            (!profile.is_fallback()).then(|| tcl_registry::registry_for_profile(profile));
     }
 
     /// The Tcl release this VM emulates (see
@@ -1144,7 +1166,7 @@ impl InterpState {
         };
         registry.get(name).is_none()
             || registry
-                .get_for_dialect(name, self.dialect_profile.availability_mask)
+                .get_for_dialect(name, self.command_surface_profile.availability_mask)
                 .is_some()
     }
 
@@ -1162,6 +1184,7 @@ impl InterpState {
         Self {
             runtime_version: tcl_dialect::TclVersion::V9_0,
             dialect_profile: tcl_dialect::DialectProfile::plain_tcl(),
+            command_surface_profile: tcl_dialect::DialectProfile::plain_tcl(),
             profile_registry: None,
             profile_generation: 0,
             frames: vec![CallFrame::new(0, ROOT_NS, None, Vec::new())],
@@ -2287,6 +2310,7 @@ impl Vm {
         child.host = Rc::clone(&self.host);
         child.runtime_version = self.runtime_version;
         child.dialect_profile = self.dialect_profile;
+        child.command_surface_profile = self.command_surface_profile;
         child.profile_registry = self.profile_registry;
         Box::new(child)
     }

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -1051,18 +1051,26 @@ impl Vm {
     /// Compilation, bytecode profile validation, lexer/expr semantics, and
     /// [`Self::dialect_profile`] remain unchanged. This is for embedding hosts
     /// that execute a sandboxed dialect inside a broader host interpreter.
-    /// The override is rejected when its Tcl runtime base is older than the
-    /// compilation dialect's base, or when it hides a bytecode-compiled
-    /// command available to that dialect. Otherwise a specialised opcode
-    /// could execute a command that ordinary lookup hides. Returns whether the
-    /// requested surface was installed.
+    /// A named override is rejected when its Tcl runtime base is older than
+    /// the compilation dialect's base, or when it hides a bytecode-compiled
+    /// command available to that dialect. The permissive fallback is the
+    /// deliberate universal-surface exception: it never hides a builtin, even
+    /// though its inert runtime base remains Tcl 9.0. Otherwise a specialised
+    /// opcode could execute a command that ordinary lookup hides. Returns
+    /// whether the requested surface was installed.
     #[must_use]
     pub fn set_command_surface_profile(
         &mut self,
         profile: &'static tcl_dialect::DialectProfile,
     ) -> bool {
-        if profile.vm_runtime_version < self.dialect_profile.vm_runtime_version
-            || !Self::command_surface_covers_compiled_commands(self.dialect_profile, profile)
+        // `plain_tcl` deliberately gates no commands, so it is compatible
+        // with every dialect independently of its fallback runtime base.
+        // Keep the runtime and visibility checks coupled for named profiles:
+        // a named surface must still be new enough *and* expose each compiled
+        // command from the execution dialect.
+        if !profile.is_fallback()
+            && (profile.vm_runtime_version < self.dialect_profile.vm_runtime_version
+                || !Self::command_surface_covers_compiled_commands(self.dialect_profile, profile))
         {
             return false;
         }

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -1062,6 +1062,12 @@ impl Vm {
             (!profile.is_fallback()).then(|| tcl_registry::registry_for_profile(profile));
     }
 
+    /// The profile currently governing builtin command availability.
+    #[must_use]
+    pub fn command_surface_profile(&self) -> &'static tcl_dialect::DialectProfile {
+        self.command_surface_profile
+    }
+
     /// The Tcl release this VM emulates (see
     /// [`Self::set_runtime_version`]).
     #[must_use]

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -1051,7 +1051,18 @@ impl Vm {
     /// Compilation, bytecode profile validation, lexer/expr semantics, and
     /// [`Self::dialect_profile`] remain unchanged. This is for embedding hosts
     /// that execute a sandboxed dialect inside a broader host interpreter.
-    pub fn set_command_surface_profile(&mut self, profile: &'static tcl_dialect::DialectProfile) {
+    /// The override is rejected when its Tcl runtime base is older than the
+    /// compilation dialect's base: otherwise release-specific bytecode could
+    /// execute a command that ordinary lookup hides. Returns whether the
+    /// requested surface was installed.
+    #[must_use]
+    pub fn set_command_surface_profile(
+        &mut self,
+        profile: &'static tcl_dialect::DialectProfile,
+    ) -> bool {
+        if profile.vm_runtime_version < self.dialect_profile.vm_runtime_version {
+            return false;
+        }
         self.bump_cmd_epoch();
         self.profile_generation = self.profile_generation.wrapping_add(1);
         self.eval_cache.clear();
@@ -1060,6 +1071,7 @@ impl Vm {
         self.command_surface_profile = profile;
         self.profile_registry =
             (!profile.is_fallback()).then(|| tcl_registry::registry_for_profile(profile));
+        true
     }
 
     /// The profile currently governing builtin command availability.

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -1052,15 +1052,18 @@ impl Vm {
     /// [`Self::dialect_profile`] remain unchanged. This is for embedding hosts
     /// that execute a sandboxed dialect inside a broader host interpreter.
     /// The override is rejected when its Tcl runtime base is older than the
-    /// compilation dialect's base: otherwise release-specific bytecode could
-    /// execute a command that ordinary lookup hides. Returns whether the
+    /// compilation dialect's base, or when it hides a bytecode-compiled
+    /// command available to that dialect. Otherwise a specialised opcode
+    /// could execute a command that ordinary lookup hides. Returns whether the
     /// requested surface was installed.
     #[must_use]
     pub fn set_command_surface_profile(
         &mut self,
         profile: &'static tcl_dialect::DialectProfile,
     ) -> bool {
-        if profile.vm_runtime_version < self.dialect_profile.vm_runtime_version {
+        if profile.vm_runtime_version < self.dialect_profile.vm_runtime_version
+            || !Self::command_surface_covers_compiled_commands(self.dialect_profile, profile)
+        {
             return false;
         }
         self.bump_cmd_epoch();
@@ -1072,6 +1075,37 @@ impl Vm {
         self.profile_registry =
             (!profile.is_fallback()).then(|| tcl_registry::registry_for_profile(profile));
         true
+    }
+
+    /// Whether `surface` exposes every registry command whose source-profile
+    /// bytecode may bypass normal command lookup.  Runtime-version ordering is
+    /// necessary but not sufficient: profiles on the same Tcl release can
+    /// carry disjoint availability masks (for example BPF versus BIG-IP).
+    ///
+    /// `Traits::BYTE_COMPILED` is the registry-owned declaration that a
+    /// literal command head may be lowered to bytecode.  Checking its actual
+    /// source and target profile visibility preserves compatible cross-profile
+    /// hosts such as iRules over a plain Tcl 8.4 host without allowing a
+    /// narrowed same-release surface to hide an intrinsic.
+    fn command_surface_covers_compiled_commands(
+        dialect: &'static tcl_dialect::DialectProfile,
+        surface: &'static tcl_dialect::DialectProfile,
+    ) -> bool {
+        if surface.is_fallback() {
+            return true;
+        }
+        let compiled_registry = tcl_registry::registry_for_profile(dialect);
+        let surface_registry = tcl_registry::registry_for_profile(surface);
+        compiled_registry.command_names().all(|name| {
+            let Some(spec) = compiled_registry.get_for_dialect(name, dialect.availability_mask)
+            else {
+                return true;
+            };
+            !spec.traits.contains(tcl_registry::Traits::BYTE_COMPILED)
+                || surface_registry
+                    .get_for_dialect(name, surface.availability_mask)
+                    .is_some()
+        })
     }
 
     /// The profile currently governing builtin command availability.

--- a/rust/tcl-vm/tests/cmd_thread_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_thread_e2e.rs
@@ -146,7 +146,7 @@ fn workers_inherit_a_separate_host_command_surface() {
     let mut vm = Vm::with_output(Box::new(std::io::sink()));
     vm.set_compiler(Box::new(ProfileCompilerSvc));
     vm.set_dialect_profile(dialect);
-    vm.set_command_surface_profile(host);
+    assert!(vm.set_command_surface_profile(host));
     vm.enable_threads(
         Arc::new(|| Box::new(ProfileCompilerSvc)),
         Arc::new(Mutex::new(Box::new(std::io::sink()))),

--- a/rust/tcl-vm/tests/cmd_thread_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_thread_e2e.rs
@@ -31,6 +31,8 @@ use std::sync::{Arc, Mutex};
 use tcl_compiler::cfg_builder::build_cfg_codegen;
 use tcl_compiler::codegen::codegen_module;
 use tcl_compiler::lowering::lower_to_ir;
+use tcl_compiler::lowering::lower_to_ir_for_bytecode_with_dialect;
+use tcl_dialect::DialectProfile;
 use tcl_registry::CommandRegistry;
 use tcl_vm::{CompileError, CompileService, Vm};
 
@@ -73,6 +75,32 @@ fn compiler() -> Box<dyn CompileService<Module = tcl_bytecode::ModuleAsm>> {
     })
 }
 
+struct ProfileCompilerSvc;
+
+impl CompileService for ProfileCompilerSvc {
+    type Module = tcl_bytecode::ModuleAsm;
+
+    fn compile(&self, src: &str) -> Result<Self::Module, CompileError> {
+        self.compile_for_profile(src, DialectProfile::plain_tcl())
+    }
+
+    fn compile_for_profile(
+        &self,
+        src: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<Self::Module, CompileError> {
+        let registry = tcl_registry::registry_for_profile(profile);
+        let config = tcl_lexer::LexerConfig::from_grammar(profile.grammar);
+        if let Some(msg) = tcl_compiler::lowering::first_fatal_parse_error_with_config(src, config)
+        {
+            return Err(CompileError(msg));
+        }
+        let ir = lower_to_ir_for_bytecode_with_dialect(src, registry, config, profile.name);
+        let cfg = build_cfg_codegen(&ir, false);
+        Ok(codegen_module(&cfg, &ir, registry))
+    }
+}
+
 /// Compile and run `src` on a thread-enabled VM; return `(ok, result, stdout)`.
 fn run(src: &str) -> (bool, String, String) {
     let registry = CommandRegistry::build_default();
@@ -102,6 +130,31 @@ fn result(src: &str) -> String {
     let (ok, res, _) = run(src);
     assert!(ok, "script errored: {res}");
     res
+}
+
+#[test]
+fn workers_inherit_a_separate_host_command_surface() {
+    let dialect = DialectProfile::by_name("f5-irules");
+    let host = DialectProfile::by_name("tcl8.4");
+    let registry = tcl_registry::registry_for_profile(dialect);
+    let config = tcl_lexer::LexerConfig::from_grammar(dialect.grammar);
+    let source = "set w [thread::create]; set threaded [thread::send $w {llength [info commands interp]}]; thread::release $w; set p [tpool::create -maxworkers 1]; set j [tpool::post $p {llength [info commands interp]}]; set pooled [tpool::get $p $j]; tpool::release $p; list $threaded $pooled";
+    let ir = lower_to_ir_for_bytecode_with_dialect(source, registry, config, dialect.name);
+    let cfg = build_cfg_codegen(&ir, false);
+    let asm = codegen_module(&cfg, &ir, registry);
+
+    let mut vm = Vm::with_output(Box::new(std::io::sink()));
+    vm.set_compiler(Box::new(ProfileCompilerSvc));
+    vm.set_dialect_profile(dialect);
+    vm.set_command_surface_profile(host);
+    vm.enable_threads(
+        Arc::new(|| Box::new(ProfileCompilerSvc)),
+        Arc::new(Mutex::new(Box::new(std::io::sink()))),
+    );
+
+    let completion = vm.run_module(&asm);
+    assert!(completion.code.is_ok(), "{}", completion.result.to_str());
+    assert_eq!(&*completion.result.to_str(), "1 1");
 }
 
 // ===========================================================================

--- a/rust/tcl-vm/tests/cmd_thread_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_thread_e2e.rs
@@ -132,8 +132,7 @@ fn result(src: &str) -> String {
     res
 }
 
-#[test]
-fn workers_inherit_a_separate_host_command_surface() {
+fn assert_workers_inherit_a_separate_host_command_surface() {
     let dialect = DialectProfile::by_name("f5-irules");
     let host = DialectProfile::by_name("tcl8.4");
     let registry = tcl_registry::registry_for_profile(dialect);
@@ -155,6 +154,19 @@ fn workers_inherit_a_separate_host_command_surface() {
     let completion = vm.run_module(&asm);
     assert!(completion.code.is_ok(), "{}", completion.result.to_str());
     assert_eq!(&*completion.result.to_str(), "1 1");
+}
+
+/// This must hold in release too: a `debug_assert!` around the setter would
+/// make the override disappear only in an optimised worker.
+#[test]
+fn workers_inherit_a_separate_host_command_surface() {
+    assert_workers_inherit_a_separate_host_command_surface();
+}
+
+#[cfg(not(debug_assertions))]
+#[test]
+fn workers_inherit_a_separate_host_command_surface_in_release() {
+    assert_workers_inherit_a_separate_host_command_surface();
 }
 
 // ===========================================================================

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -174,19 +174,37 @@ fn named_profiles_reject_fixed_or_mislabelled_compile_services() {
 }
 
 #[test]
-fn command_surface_override_cannot_hide_compiled_release_commands() {
+fn command_surface_override_accepts_the_universal_fallback_from_tcl91() {
+    let v91 = DialectProfile::by_name("tcl9.1");
+    let fallback = DialectProfile::plain_tcl();
+    let mut vm = Vm::new();
+    vm.set_dialect_profile(v91);
+
+    assert_eq!(fallback.vm_runtime_version, TclVersion::V9_0);
+    assert!(
+        vm.set_command_surface_profile(fallback),
+        "the permissive fallback must cover every Tcl 9.1 builtin despite its inert 9.0 base"
+    );
+    assert!(std::ptr::eq(vm.command_surface_profile(), fallback));
+}
+
+#[test]
+fn named_command_surface_override_cannot_hide_compiled_release_commands() {
+    let v91 = DialectProfile::by_name("tcl9.1");
     let v90 = DialectProfile::by_name("tcl9.0");
-    let v84 = DialectProfile::by_name("tcl8.4");
-    let registry = tcl_registry::registry_for_profile(v90);
-    let config = tcl_lexer::LexerConfig::from_grammar(v90.grammar);
-    let ir = lower_to_ir("lassign {a b} x; set x", registry, config, v90.name);
+    let registry = tcl_registry::registry_for_profile(v91);
+    let config = tcl_lexer::LexerConfig::from_grammar(v91.grammar);
+    let ir = lower_to_ir("lassign {a b} x; set x", registry, config, v91.name);
     let cfg = build_cfg_codegen(&ir, false);
     let module = codegen_module(&cfg, &ir, registry);
 
     let mut vm = Vm::new();
-    vm.set_dialect_profile(v90);
-    assert!(!vm.set_command_surface_profile(v84));
-    assert!(std::ptr::eq(vm.command_surface_profile(), v90));
+    vm.set_dialect_profile(v91);
+    assert!(
+        !vm.set_command_surface_profile(v90),
+        "a named Tcl 9.0 surface cannot host Tcl 9.1 bytecode"
+    );
+    assert!(std::ptr::eq(vm.command_surface_profile(), v91));
     let completion = vm.run_module(&module);
     assert!(completion.code.is_ok(), "{}", completion.result.to_str());
     assert_eq!(&*completion.result.to_str(), "a");

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -173,6 +173,25 @@ fn named_profiles_reject_fixed_or_mislabelled_compile_services() {
     );
 }
 
+#[test]
+fn command_surface_override_cannot_hide_compiled_release_commands() {
+    let v90 = DialectProfile::by_name("tcl9.0");
+    let v84 = DialectProfile::by_name("tcl8.4");
+    let registry = tcl_registry::registry_for_profile(v90);
+    let config = tcl_lexer::LexerConfig::from_grammar(v90.grammar);
+    let ir = lower_to_ir("lassign {a b} x; set x", registry, config, v90.name);
+    let cfg = build_cfg_codegen(&ir, false);
+    let module = codegen_module(&cfg, &ir, registry);
+
+    let mut vm = Vm::new();
+    vm.set_dialect_profile(v90);
+    assert!(!vm.set_command_surface_profile(v84));
+    assert!(std::ptr::eq(vm.command_surface_profile(), v90));
+    let completion = vm.run_module(&module);
+    assert!(completion.code.is_ok(), "{}", completion.result.to_str());
+    assert_eq!(&*completion.result.to_str(), "a");
+}
+
 /// Run `src` on a VM pinned to `profile`, compiling for that profile exactly
 /// as `tclvm --tcl-version` does. Returns the `puts` output; a compile
 /// rejection or an uncaught runtime error becomes the error's message, so a

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -192,6 +192,40 @@ fn command_surface_override_cannot_hide_compiled_release_commands() {
     assert_eq!(&*completion.result.to_str(), "a");
 }
 
+#[test]
+fn command_surface_override_rejects_a_same_release_narrower_profile() {
+    let bpf = DialectProfile::by_name("bpf");
+    let bigip = DialectProfile::by_name("f5-bigip");
+    let registry = tcl_registry::registry_for_profile(bpf);
+    let config = tcl_lexer::LexerConfig::from_grammar(bpf.grammar);
+    // `lassign` becomes list/variable opcodes, so it proves that module
+    // profile validation alone cannot enforce a later command-surface change.
+    let ir = lower_to_ir("lassign {a b} x; set x", registry, config, bpf.name);
+    let cfg = build_cfg_codegen(&ir, false);
+    let module = codegen_module(&cfg, &ir, registry);
+
+    let mut vm = Vm::new();
+    vm.set_dialect_profile(bpf);
+    assert!(
+        !vm.set_command_surface_profile(bigip),
+        "the config-only BIG-IP surface hides BPF's Tcl bytecode commands"
+    );
+    assert!(std::ptr::eq(vm.command_surface_profile(), bpf));
+    let completion = vm.run_module(&module);
+    assert!(completion.code.is_ok(), "{}", completion.result.to_str());
+    assert_eq!(&*completion.result.to_str(), "a");
+}
+
+#[test]
+fn compatible_irules_host_surface_override_remains_accepted() {
+    let irules = DialectProfile::by_name("f5-irules");
+    let host = DialectProfile::by_name("tcl8.4");
+    let mut vm = Vm::new();
+    vm.set_dialect_profile(irules);
+    assert!(vm.set_command_surface_profile(host));
+    assert!(std::ptr::eq(vm.command_surface_profile(), host));
+}
+
 /// Run `src` on a VM pinned to `profile`, compiling for that profile exactly
 /// as `tclvm --tcl-version` does. Returns the `puts` output; a compile
 /// rejection or an uncaught runtime error becomes the error's message, so a


### PR DESCRIPTION
Follow-up to #1510 and its final review thread.

Separates the VM compilation/bytecode dialect from an embedding host command-availability surface. The iRules live harness therefore retains the `f5-irules` lexer and registry while exposing the broader Tcl 8.4 host commands needed by its orchestrator.

The live regression, full tcl-vm+tcl-irule-test suites, strict clippy, and all four final gates pass under ionice idle / nice 19.