### PR TITLE
fix(bpf): stamp the Tcl 9 profile on BPF registries

### DIFF
--- a/rust/bpf-tcl-ir/src/frontend.rs
+++ b/rust/bpf-tcl-ir/src/frontend.rs
@@ -27,7 +27,6 @@
 
 use tcl_compiler::cfg_builder::build_cfg_function;
 use tcl_compiler::ir::CommandTokens;
-use tcl_compiler::lowering::lower_to_ir;
 use tcl_compiler::{Script, Statement};
 use tcl_lexer::Span;
 use tcl_registry::bpf_op::{BpfDeclKind, BpfOpKind};
@@ -38,8 +37,9 @@ use crate::deploy::resolve_attach;
 use crate::diag::{BpfDiag, BpfError};
 use crate::event::{event_to_prog_type, known_event_names};
 use crate::ir::{BpfModule, BpfProgramDecl, ProgType};
-use crate::lower::lower_function;
+use crate::lower::{lower_function, parse_int};
 use crate::profile::{BpfProfileSpec, collect_profile, expand_fields};
+use crate::source::lower_bpf_source;
 use crate::template::{TemplateDef, collect_templates, expand_uses};
 use crate::unroll::unroll_loops;
 
@@ -54,7 +54,7 @@ pub fn compile_module(source: &str) -> Result<BpfModule, BpfError> {
     // `when` spec carries no lowering hook, so `when` stays a generic call we
     // re-lower ourselves — a separate event space from F5's `::when::`.
     let registry = bpf_registry();
-    let module = lower_to_ir(source, registry);
+    let module = lower_bpf_source(source, registry);
 
     // The (optional) active profile — the top-layer config selected for the file.
     let profile = collect_profile(&module.top_level, registry)?;
@@ -127,7 +127,7 @@ pub fn compile_module(source: &str) -> Result<BpfModule, BpfError> {
     if !saw_when {
         let body = strip_decls(&module.top_level, registry);
         if !body.statements.is_empty() {
-            let used = expand_uses(&body, &templates)?;
+            let used = expand_uses(&body, &templates, registry.numbers())?;
             let unrolled = unroll_loops(&used, registry)?;
             let expanded = match profile.as_ref() {
                 Some(p) => expand_fields(&unrolled, p)?,
@@ -233,17 +233,19 @@ fn lower_when_decl(
                     "the `when` priority must be a literal (no substitutions)",
                 ));
             }
-            args[2].parse::<u32>().map_err(|_| {
-                BpfError::new(
-                    BpfDiag::BadArity,
-                    word_span(2),
-                    format!(
-                        "invalid `when` priority `{}` — must be a non-negative \
+            parse_int(&args[2], registry.numbers())
+                .and_then(|value| u32::try_from(value).ok())
+                .ok_or_else(|| {
+                    BpfError::new(
+                        BpfDiag::BadArity,
+                        word_span(2),
+                        format!(
+                            "invalid `when` priority `{}` — must be a non-negative \
                          integer literal",
-                        args[2]
-                    ),
-                )
-            })?
+                            args[2]
+                        ),
+                    )
+                })?
         }
         _ => {
             return Err(BpfError::new(
@@ -272,8 +274,9 @@ fn lower_when_decl(
         .and_then(|t| t.argv.get(body_idx).copied())
         .map_or(0, |sp| sp.start() + 1);
 
-    let body_module = lower_to_ir(body_text, registry);
-    let used = expand_uses(&body_module.top_level, templates).map_err(|e| e.offset(source_base))?;
+    let body_module = lower_bpf_source(body_text, registry);
+    let used = expand_uses(&body_module.top_level, templates, registry.numbers())
+        .map_err(|e| e.offset(source_base))?;
     let unrolled = unroll_loops(&used, registry).map_err(|e| e.offset(source_base))?;
     let expanded = match profile {
         Some(p) => expand_fields(&unrolled, p).map_err(|e| e.offset(source_base))?,
@@ -406,6 +409,7 @@ mod tests {
     use super::*;
     use crate::ir::Term;
     use tcl_dialect::{DialectSet, NumberSyntax, TclVersion};
+    use tcl_syntax::number::{runtime_syntax, set_runtime_syntax};
 
     /// Regression and mutation proof for #1466: loading the BPF command pack
     /// alone is intentionally profile-less. The front end must instead obtain
@@ -430,6 +434,86 @@ mod tests {
         let mut unstamped = CommandRegistry::build_default();
         unstamped.load_bpf();
         assert!(unstamped.profile().is_none());
+    }
+
+    /// Every BPF source numeral must read through the BPF profile, never the
+    /// ambient grammar a Tcl 8.x interpreter installed on this worker thread.
+    #[test]
+    fn bpf_source_numbers_ignore_an_ambient_tcl85_runtime() {
+        let original_syntax = runtime_syntax();
+        set_runtime_syntax(NumberSyntax::Tcl85);
+
+        let cases = [
+            ("when priority", "when XDP priority 0d10 { pass }\n"),
+            (
+                "loop count",
+                "when XDP {\n  loop 0o2 index { setint value {$index + 1} }\n  pass\n}\n",
+            ),
+            (
+                "template binding",
+                "template init {value} { setint result {$value} }\n\
+                 when XDP {\n  use init value=1_000\n  pass\n}\n",
+            ),
+            (
+                "profile field offset and width",
+                "profile custom { field first 0d0 0d8 }\nwhen XDP { pass }\n",
+            ),
+            (
+                "expression literal",
+                "when XDP {\n  setint value {0d10 + 1_000}\n  pass\n}\n",
+            ),
+        ];
+        let failures: Vec<&str> = cases
+            .into_iter()
+            .filter_map(|(surface, source)| compile_module(source).err().map(|_| surface))
+            .collect();
+
+        set_runtime_syntax(original_syntax);
+        assert!(
+            failures.is_empty(),
+            "BPF Tcl 9.0 numeral grammar was not used by: {}",
+            failures.join(", ")
+        );
+    }
+
+    /// The profile must reach structured conditions in every nested BPF source
+    /// body; otherwise `lower_to_ir` reads an ambient Tcl 8.x grammar before
+    /// the typed BPF lowerer can apply its target grammar.
+    #[test]
+    fn bpf_structured_bodies_ignore_an_ambient_tcl85_runtime() {
+        let original_syntax = runtime_syntax();
+        set_runtime_syntax(NumberSyntax::Tcl85);
+
+        let cases = [
+            (
+                "top-level structured body",
+                "if {0d10} { accept } else { drop }\n",
+            ),
+            (
+                "when body",
+                "when XDP {\n  if {0d10} { pass } else { drop }\n}\n",
+            ),
+            (
+                "template body",
+                "template branch {} { if {0d10} { pass } else { drop } }\n\
+                 when XDP {\n  use branch\n}\n",
+            ),
+            (
+                "loop body",
+                "when XDP {\n  loop 0d1 index { if {0d10} { pass } else { drop } }\n}\n",
+            ),
+        ];
+        let failures: Vec<&str> = cases
+            .into_iter()
+            .filter_map(|(surface, source)| compile_module(source).err().map(|_| surface))
+            .collect();
+
+        set_runtime_syntax(original_syntax);
+        assert!(
+            failures.is_empty(),
+            "BPF Tcl 9.0 structured lowering inherited Tcl 8.5 for: {}",
+            failures.join(", ")
+        );
     }
 
     #[test]

--- a/rust/bpf-tcl-ir/src/frontend.rs
+++ b/rust/bpf-tcl-ir/src/frontend.rs
@@ -20,7 +20,7 @@
 //! [`BpfModule`] of typed programs.
 //!
 //! F5-inspired `when <EVENT> priority N { body }` blocks define programs, but in
-//! a *separate* event space: we load a vanilla `build_default()` registry (no
+//! a *separate* event space: we load the profile-stamped `bpf` registry (not
 //! iRules), so `when` flows through as a generic [`Statement::Call`] rather than
 //! the F5 `::when::` lowering. We recognise that call, map the event via our own
 //! table, and re-lower each handler body independently.
@@ -31,7 +31,7 @@ use tcl_compiler::lowering::lower_to_ir;
 use tcl_compiler::{Script, Statement};
 use tcl_lexer::Span;
 use tcl_registry::bpf_op::{BpfDeclKind, BpfOpKind};
-use tcl_registry::registry::CommandRegistry;
+use tcl_registry::{CommandRegistry, registry_for_dialect};
 
 use crate::capability::{CapabilityPolicy, check_policy, collect_policy};
 use crate::deploy::resolve_attach;
@@ -49,20 +49,19 @@ use crate::unroll::unroll_loops;
 /// Returns the first [`BpfError`] encountered (bad event, out-of-subset
 /// construct, type error, …).
 pub fn compile_module(source: &str) -> Result<BpfModule, BpfError> {
-    // Load the BPF dialect (the typed verbs + `when`). This is deliberately NOT
-    // the iRules dialect, and the BPF `when` spec carries no lowering hook, so
-    // `when` stays a generic call we re-lower ourselves — a separate event space
-    // from F5's `::when::`.
-    let mut registry = CommandRegistry::build_default();
-    registry.load_bpf();
-    let module = lower_to_ir(source, &registry);
+    // The BPF profile provides the typed verbs + `when` *and* its exact Tcl 9.0
+    // embedding facts. This is deliberately NOT the iRules dialect, and the BPF
+    // `when` spec carries no lowering hook, so `when` stays a generic call we
+    // re-lower ourselves — a separate event space from F5's `::when::`.
+    let registry = bpf_registry();
+    let module = lower_to_ir(source, registry);
 
     // The (optional) active profile — the top-layer config selected for the file.
-    let profile = collect_profile(&module.top_level, &registry)?;
+    let profile = collect_profile(&module.top_level, registry)?;
     // Reusable parameterised handlers a `use` site can splice in.
-    let templates = collect_templates(&module.top_level, &registry)?;
+    let templates = collect_templates(&module.top_level, registry)?;
     // The capability policy that sandboxes each handler's operations.
-    let policy = collect_policy(&module.top_level, &registry)?;
+    let policy = collect_policy(&module.top_level, registry)?;
 
     let mut programs = Vec::new();
     let mut saw_when = false;
@@ -78,7 +77,7 @@ pub fn compile_module(source: &str) -> Result<BpfModule, BpfError> {
         } = stmt
             && decl_kind(
                 canonical_command.as_deref().unwrap_or(command.as_str()),
-                &registry,
+                registry,
             ) == Some(BpfDeclKind::When)
         {
             saw_when = true;
@@ -86,7 +85,7 @@ pub fn compile_module(source: &str) -> Result<BpfModule, BpfError> {
                 args,
                 tokens.as_ref(),
                 *span,
-                &registry,
+                registry,
                 profile.as_ref(),
                 &templates,
                 &policy,
@@ -106,10 +105,10 @@ pub fn compile_module(source: &str) -> Result<BpfModule, BpfError> {
                 Statement::Call { command, canonical_command, .. }
                     if decl_kind(
                         canonical_command.as_deref().unwrap_or(command.as_str()),
-                        &registry,
+                        registry,
                     ) == Some(BpfDeclKind::When)
             );
-            if !is_when && !is_decl(stmt, &registry) {
+            if !is_when && !is_decl(stmt, registry) {
                 let (name, span) = stray_stmt_info(stmt);
                 return Err(BpfError::new(
                     BpfDiag::StrayTopLevel,
@@ -126,17 +125,17 @@ pub fn compile_module(source: &str) -> Result<BpfModule, BpfError> {
     // No framework envelope: treat the top level (minus profile/field decls) as a
     // single anonymous SOCKET_FILTER program (the raw-DSL path, handy for tests).
     if !saw_when {
-        let body = strip_decls(&module.top_level, &registry);
+        let body = strip_decls(&module.top_level, registry);
         if !body.statements.is_empty() {
             let used = expand_uses(&body, &templates)?;
-            let unrolled = unroll_loops(&used, &registry)?;
+            let unrolled = unroll_loops(&used, registry)?;
             let expanded = match profile.as_ref() {
                 Some(p) => expand_fields(&unrolled, p)?,
                 None => unrolled,
             };
-            check_policy(&expanded, &policy, &registry)?;
+            check_policy(&expanded, &policy, registry)?;
             let cfg = build_cfg_function("main", &expanded, false);
-            let program = lower_function(&cfg, ProgType::SocketFilter, &registry)?;
+            let program = lower_function(&cfg, ProgType::SocketFilter, registry)?;
             programs.push(BpfProgramDecl {
                 event: "SOCKET_FILTER".to_owned(),
                 priority: 500,
@@ -180,6 +179,12 @@ pub fn compile_module(source: &str) -> Result<BpfModule, BpfError> {
     }
 
     Ok(module)
+}
+
+/// The canonical BPF registry, with the BPF profile and its Tcl 9.0 embedding
+/// stamped by the registry owner.
+fn bpf_registry() -> &'static CommandRegistry {
+    registry_for_dialect("bpf")
 }
 
 /// The default handler priority when the `when` header names none
@@ -400,6 +405,32 @@ fn is_decl(stmt: &Statement, registry: &CommandRegistry) -> bool {
 mod tests {
     use super::*;
     use crate::ir::Term;
+    use tcl_dialect::{DialectSet, NumberSyntax, TclVersion};
+
+    /// Regression and mutation proof for #1466: loading the BPF command pack
+    /// alone is intentionally profile-less. The front end must instead obtain
+    /// the cached, profile-stamped registry so every downstream registry fact
+    /// describes BPF's exact Tcl 9.0 embedding.
+    #[test]
+    fn bpf_frontend_uses_the_profile_stamped_tcl90_registry() {
+        let registry = bpf_registry();
+        let profile = registry.profile().expect("BPF registry has a profile");
+        assert_eq!(profile.name, "bpf");
+        assert_eq!(
+            profile.availability_mask,
+            DialectSet::TCL90 | DialectSet::BPF
+        );
+        assert_eq!(registry.runtime_version(), Some(TclVersion::V9_0));
+        assert_eq!(registry.numbers(), NumberSyntax::Tcl90);
+        assert_eq!(registry.octal_fold_policy(), Some(false));
+        assert!(registry.bpf_op("when").is_some(), "BPF pack is loaded");
+
+        // Mutant: the pre-#1466 construction has the same command pack but no
+        // profile, so it cannot carry BPF's release facts through the registry.
+        let mut unstamped = CommandRegistry::build_default();
+        unstamped.load_bpf();
+        assert!(unstamped.profile().is_none());
+    }
 
     #[test]
     fn accept_all_compiles_to_one_program() {
@@ -532,8 +563,7 @@ mod tests {
     #[test]
     fn every_registered_bpf_command_has_a_descriptor() {
         use tcl_registry::bpf_op::BpfOpKind;
-        let mut registry = CommandRegistry::build_default();
-        registry.load_bpf();
+        let registry = bpf_registry();
         let bpf_names: Vec<&str> = registry
             .command_names()
             .filter(|n| registry.bpf_op(n).is_some())

--- a/rust/bpf-tcl-ir/src/lib.rs
+++ b/rust/bpf-tcl-ir/src/lib.rs
@@ -39,6 +39,7 @@ pub mod lower;
 pub mod profile;
 pub mod ringbuf;
 pub mod semantic_bridge;
+mod source;
 pub mod template;
 pub mod ty;
 pub mod unroll;

--- a/rust/bpf-tcl-ir/src/lower.rs
+++ b/rust/bpf-tcl-ir/src/lower.rs
@@ -86,6 +86,7 @@ pub fn lower_function(
         // uses. With no profile loaded, fall back to the grammar the process
         // was built for.
         numbers: registry.numbers(),
+        expr_dialect: registry.profile().map(|profile| profile.name),
         prog_type,
         env: HashMap::new(),
         slot_types: Vec::new(),
@@ -135,6 +136,10 @@ struct Lowerer<'f> {
     /// The numeric-literal grammar of the dialect being compiled for — every
     /// integer literal in the DSL is read through it.
     numbers: NumberSyntax,
+    /// Named target profile for expression parsing. Unlike an unpinned parser,
+    /// this cannot inherit the ambient grammar of an interpreter that happened
+    /// to run earlier on the current thread.
+    expr_dialect: Option<&'static str>,
     /// Program type — selects verdict semantics (`accept`/`drop` vs `pass`/`tx`).
     prog_type: ProgType,
     /// Typed symbol table: variable name → (stable slot, type). Function-global
@@ -325,7 +330,7 @@ impl Lowerer<'_> {
             return Err(arity(span, "map_get", "DST NAME {KEY}"));
         }
         let map = self.resolve_map(&args[1], span)?;
-        let key = self.lower_expr(&parse_expr(&args[2], None), insts, span)?;
+        let key = self.lower_expr(&self.parse_expr(&args[2]), insts, span)?;
         let dst = self.var_slot(&args[0], Ty::Int, span)?;
         insts.push(Inst::MapGet {
             dst,
@@ -347,7 +352,7 @@ impl Lowerer<'_> {
             return Err(arity(span, "map_has", "DST NAME {KEY}"));
         }
         let map = self.resolve_map(&args[1], span)?;
-        let key = self.lower_expr(&parse_expr(&args[2], None), insts, span)?;
+        let key = self.lower_expr(&self.parse_expr(&args[2]), insts, span)?;
         let dst = self.var_slot(&args[0], Ty::Int, span)?;
         insts.push(Inst::MapHas {
             dst,
@@ -369,8 +374,8 @@ impl Lowerer<'_> {
             return Err(arity(span, "map_set", "NAME {KEY} {VAL}"));
         }
         let map = self.resolve_map(&args[0], span)?;
-        let key = self.lower_expr(&parse_expr(&args[1], None), insts, span)?;
-        let val = self.lower_expr(&parse_expr(&args[2], None), insts, span)?;
+        let key = self.lower_expr(&self.parse_expr(&args[1]), insts, span)?;
+        let val = self.lower_expr(&self.parse_expr(&args[2]), insts, span)?;
         insts.push(Inst::MapSet {
             map,
             key,
@@ -470,7 +475,7 @@ impl Lowerer<'_> {
                     insts.push(Inst::CtxLen { dst, span });
                     dst
                 } else if args.len() == 1 {
-                    self.lower_expr(&parse_expr(&args[0], None), insts, span)?
+                    self.lower_expr(&self.parse_expr(&args[0]), insts, span)?
                 } else {
                     return Err(arity(span, cmd, "?N?"));
                 }
@@ -731,7 +736,7 @@ impl Lowerer<'_> {
                 if args.len() != 2 {
                     return Err(arity(span, cmd, "NAME {EXPR}"));
                 }
-                let expr = parse_expr(&args[1], None);
+                let expr = self.parse_expr(&args[1]);
                 let tmp = self.lower_expr(&expr, insts, span)?;
                 let dst = self.var_slot(&args[0], Ty::Int, span)?;
                 self.emit_width_set(width, tmp, dst, insts, span)?;
@@ -801,6 +806,11 @@ impl Lowerer<'_> {
                 framework_in_handler_message(cmd, decl),
             )),
         }
+    }
+
+    /// Parse a BPF expression under the profile stamped on this registry.
+    fn parse_expr(&self, source: &str) -> ExprNode {
+        parse_expr(source, self.expr_dialect)
     }
 
     fn lower_expr(
@@ -1092,7 +1102,7 @@ fn map_un(op: UnaryOp) -> Option<UnOp> {
 /// it), the same octal-by-leading-zero rule, and the same `_` separators.
 /// `integer_only` makes a fractional part trailing junk, and a magnitude past
 /// `i64` is rejected here because every BPF operand is a wide or narrower.
-fn parse_int(text: &str, numbers: NumberSyntax) -> Option<i64> {
+pub(crate) fn parse_int(text: &str, numbers: NumberSyntax) -> Option<i64> {
     let flags = ParseFlags {
         integer_only: true,
         ..ParseFlags::for_syntax(numbers)

--- a/rust/bpf-tcl-ir/src/lower.rs
+++ b/rust/bpf-tcl-ir/src/lower.rs
@@ -54,10 +54,11 @@ const MAX_RAW_SLOTS: usize = 4096;
 
 /// Lower a single CFG function to a typed [`BpfProgram`] of the given type.
 ///
-/// `registry` must have the BPF dialect loaded (its `BpfOpSpec` descriptors
-/// drive all command dispatch). Slot allocation (liveness-based reuse + the
-/// 512-byte stack cap) runs as part of lowering, so the returned program is
-/// ready for any codegen target.
+/// `registry` must be the profile-stamped BPF registry: its `BpfOpSpec`
+/// descriptors drive command dispatch and its Tcl 9.0 embedding supplies the
+/// numeric grammar. Slot allocation (liveness-based reuse + the 512-byte stack
+/// cap) runs as part of lowering, so the returned program is ready for any
+/// codegen target.
 ///
 /// # Errors
 /// Returns a [`BpfError`] for any construct outside the typed DSL subset, a
@@ -128,8 +129,8 @@ pub fn lower_function(
 
 struct Lowerer<'f> {
     func: &'f Function,
-    /// The command registry (with the BPF dialect loaded) whose `BpfOpSpec`
-    /// descriptors drive all command dispatch.
+    /// The profile-stamped BPF command registry whose `BpfOpSpec` descriptors
+    /// drive all command dispatch.
     registry: &'f CommandRegistry,
     /// The numeric-literal grammar of the dialect being compiled for — every
     /// integer literal in the DSL is read through it.
@@ -1272,7 +1273,7 @@ mod tests {
     /// and `1_000` were all rejected as bad integers.
     #[test]
     fn integer_literals_follow_the_target_dialects_number_grammar() {
-        let numbers = tcl_dialect::DialectProfile::by_name("bpf").grammar.numbers;
+        let numbers = tcl_registry::registry_for_dialect("bpf").numbers();
         for (text, want) in [
             ("42", Some(42)),
             ("-42", Some(-42)),

--- a/rust/bpf-tcl-ir/src/profile.rs
+++ b/rust/bpf-tcl-ir/src/profile.rs
@@ -41,12 +41,13 @@
 //! else is rejected rather than silently dropped.
 
 use tcl_compiler::ir::IfClause;
-use tcl_compiler::lowering::lower_to_ir;
 use tcl_compiler::{Script, Statement};
 use tcl_lexer::Span;
 use tcl_registry::registry::CommandRegistry;
 
 use crate::diag::{BpfDiag, BpfError};
+use crate::lower::parse_int;
+use crate::source::lower_bpf_source;
 use crate::ty::ByteOrder;
 
 /// A named header field at a fixed packet offset.
@@ -196,7 +197,7 @@ fn parse_user_profile(
     body: &str,
     registry: &CommandRegistry,
 ) -> Result<BpfProfileSpec, BpfError> {
-    let module = lower_to_ir(body, registry);
+    let module = lower_bpf_source(body, registry);
     let mut fields = Vec::new();
     for stmt in &module.top_level.statements {
         let Statement::Call {
@@ -234,10 +235,12 @@ fn parse_user_profile(
                 "`field` expects: field NAME OFFSET WIDTHBITS ?be|le|native?",
             ));
         }
-        let offset = args[1].parse::<i32>().map_err(|_| {
-            BpfError::new(BpfDiag::BadInt, *span, "field offset must be an integer")
-        })?;
-        let width_bits = parse_width(&args[2]).ok_or_else(|| {
+        let offset = parse_int(&args[1], registry.numbers())
+            .and_then(|value| i32::try_from(value).ok())
+            .ok_or_else(|| {
+                BpfError::new(BpfDiag::BadInt, *span, "field offset must be an integer")
+            })?;
+        let width_bits = parse_width(&args[2], registry.numbers()).ok_or_else(|| {
             BpfError::new(
                 BpfDiag::BadProfile,
                 *span,
@@ -265,13 +268,9 @@ fn parse_user_profile(
     })
 }
 
-fn parse_width(s: &str) -> Option<u8> {
-    match s.trim() {
-        "8" => Some(8),
-        "16" => Some(16),
-        "32" => Some(32),
-        _ => None,
-    }
+fn parse_width(s: &str, numbers: tcl_syntax::number::NumberSyntax) -> Option<u8> {
+    let width = u8::try_from(parse_int(s, numbers)?).ok()?;
+    matches!(width, 8 | 16 | 32).then_some(width)
 }
 
 /// Rewrite a handler body's field-access commands into `load*` calls, recursing

--- a/rust/bpf-tcl-ir/src/semantic_bridge.rs
+++ b/rust/bpf-tcl-ir/src/semantic_bridge.rs
@@ -502,28 +502,27 @@ mod tests {
     use super::*;
     use tcl_compiler::lowering::lower_to_ir;
     use tcl_registry::dialects::DialectSet;
+    use tcl_registry::registry_for_dialect;
 
-    fn bpf_registry() -> CommandRegistry {
-        let mut registry = CommandRegistry::build_default();
-        registry.load_bpf();
-        registry
+    fn bpf_registry() -> &'static CommandRegistry {
+        registry_for_dialect("bpf")
     }
 
     #[test]
     fn bpf_descriptor_alone_never_seals_a_generic_tcl_invocation() {
         let registry = bpf_registry();
-        let module = lower_to_ir("setint result {1}", &registry);
+        let module = lower_to_ir("setint result {1}", registry);
         let bundle = SemanticAnalysisBundle::build(
-            &registry,
+            registry,
             DialectSet::BPF,
             &module.top_level,
             tcl_compiler::dispatch_proof::DispatchEntryAssumption::PristineRegistryWorld,
         );
 
         let EbpfRegionEligibility::Declined(EbpfRegionDecline::Invocations(declines)) =
-            EbpfSemanticBridge::new().assess(&registry, &bundle)
+            EbpfSemanticBridge::new().assess(registry, &bundle)
         else {
-            panic!("unstamped BPF command must not be certified as direct eBPF");
+            panic!("a BPF descriptor alone must not certify direct eBPF");
         };
         assert_eq!(declines.len(), 1);
         assert_eq!(declines[0].canonical_command.as_deref(), Some("setint"));
@@ -536,16 +535,16 @@ mod tests {
     #[test]
     fn non_bpf_lowered_statement_retains_a_typed_shape_decline() {
         let registry = bpf_registry();
-        let module = lower_to_ir("set result 1", &registry);
+        let module = lower_to_ir("set result 1", registry);
         let bundle = SemanticAnalysisBundle::build(
-            &registry,
+            registry,
             DialectSet::BPF,
             &module.top_level,
             tcl_compiler::dispatch_proof::DispatchEntryAssumption::PristineRegistryWorld,
         );
 
         let EbpfRegionEligibility::Declined(EbpfRegionDecline::ExecutableShape(declines)) =
-            EbpfSemanticBridge::new().assess(&registry, &bundle)
+            EbpfSemanticBridge::new().assess(registry, &bundle)
         else {
             panic!("ordinary lowered Tcl must retain its typed executable-shape decline");
         };
@@ -609,9 +608,9 @@ mod tests {
     #[test]
     fn any_common_tcl_world_access_prevents_sealing() {
         let registry = bpf_registry();
-        let module = lower_to_ir("setint result {1}", &registry);
+        let module = lower_to_ir("setint result {1}", registry);
         let bundle = SemanticAnalysisBundle::build(
-            &registry,
+            registry,
             DialectSet::BPF,
             &module.top_level,
             tcl_compiler::dispatch_proof::DispatchEntryAssumption::PristineRegistryWorld,

--- a/rust/bpf-tcl-ir/src/source.rs
+++ b/rust/bpf-tcl-ir/src/source.rs
@@ -1,0 +1,30 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! BPF-profile-pinned Tcl source lowering.
+
+use tcl_compiler::Module;
+use tcl_compiler::lowering::lower_to_ir_with_dialect;
+use tcl_lexer::LexerConfig;
+use tcl_registry::registry::CommandRegistry;
+
+/// Lower BPF Tcl source under the BPF profile for every top-level and nested
+/// body re-segmentation.
+pub(crate) fn lower_bpf_source(source: &str, registry: &CommandRegistry) -> Module {
+    lower_to_ir_with_dialect(source, registry, LexerConfig::for_dialect("bpf"), "bpf")
+}

--- a/rust/bpf-tcl-ir/src/template.rs
+++ b/rust/bpf-tcl-ir/src/template.rs
@@ -30,12 +30,14 @@
 //! overwritten by the expansion.
 
 use tcl_compiler::ir::IfClause;
-use tcl_compiler::lowering::lower_to_ir;
 use tcl_compiler::{Script, Statement};
 use tcl_lexer::Span;
 use tcl_registry::registry::CommandRegistry;
+use tcl_syntax::number::NumberSyntax;
 
 use crate::diag::{BpfDiag, BpfError};
+use crate::lower::parse_int;
+use crate::source::lower_bpf_source;
 
 /// The deepest a `use` may nest (one template using another), a guard against
 /// mutually-recursive templates expanding forever.
@@ -100,7 +102,7 @@ fn parse_template(
         ));
     }
     let params = args[1].split_whitespace().map(str::to_owned).collect();
-    let body = lower_to_ir(&args[2], registry).top_level;
+    let body = lower_bpf_source(&args[2], registry).top_level;
     Ok(TemplateDef {
         name: args[0].clone(),
         params,
@@ -114,13 +116,18 @@ fn parse_template(
 /// # Errors
 /// Unknown template, missing/extra binding, a non-integer binding value, or
 /// recursion past [`MAX_DEPTH`].
-pub fn expand_uses(script: &Script, templates: &[TemplateDef]) -> Result<Script, BpfError> {
-    expand_script(script, templates, 0)
+pub fn expand_uses(
+    script: &Script,
+    templates: &[TemplateDef],
+    numbers: NumberSyntax,
+) -> Result<Script, BpfError> {
+    expand_script(script, templates, numbers, 0)
 }
 
 fn expand_script(
     script: &Script,
     templates: &[TemplateDef],
+    numbers: NumberSyntax,
     depth: usize,
 ) -> Result<Script, BpfError> {
     let mut out = Vec::with_capacity(script.statements.len());
@@ -133,7 +140,7 @@ fn expand_script(
                 span,
                 ..
             } if canonical_command.as_deref().unwrap_or(command.as_str()) == "use" => {
-                expand_use(args, *span, templates, depth, &mut out)?;
+                expand_use(args, *span, templates, numbers, depth, &mut out)?;
             }
             Statement::If {
                 span,
@@ -147,6 +154,7 @@ fn expand_script(
                     else_body.as_ref(),
                     *else_span,
                     templates,
+                    numbers,
                     depth,
                 )?);
             }
@@ -162,6 +170,7 @@ fn expand_if(
     else_body: Option<&Script>,
     else_span: Option<Span>,
     templates: &[TemplateDef],
+    numbers: NumberSyntax,
     depth: usize,
 ) -> Result<Statement, BpfError> {
     let clauses = clauses
@@ -171,13 +180,13 @@ fn expand_if(
                 condition: c.condition.clone(),
                 condition_span: c.condition_span,
                 condition_base: c.condition_base,
-                body: expand_script(&c.body, templates, depth)?,
+                body: expand_script(&c.body, templates, numbers, depth)?,
                 body_span: c.body_span,
             })
         })
         .collect::<Result<Vec<_>, BpfError>>()?;
     let else_body = else_body
-        .map(|b| expand_script(b, templates, depth))
+        .map(|b| expand_script(b, templates, numbers, depth))
         .transpose()?;
     Ok(Statement::If {
         span,
@@ -191,6 +200,7 @@ fn expand_use(
     args: &[String],
     span: Span,
     templates: &[TemplateDef],
+    numbers: NumberSyntax,
     depth: usize,
     out: &mut Vec<Statement>,
 ) -> Result<(), BpfError> {
@@ -216,7 +226,7 @@ fn expand_use(
         )
     })?;
 
-    let pairs = parse_bindings(bindings, span)?;
+    let pairs = parse_bindings(bindings, span, numbers)?;
     // Every declared parameter must be bound; bind it via a synthetic `setint`.
     for p in &tmpl.params {
         let (_, val) = pairs.iter().find(|(k, _)| k == p).ok_or_else(|| {
@@ -238,14 +248,18 @@ fn expand_use(
     }
 
     // Splice the body, expanding any nested `use` one level deeper.
-    let expanded = expand_script(&tmpl.body, templates, depth + 1)?;
+    let expanded = expand_script(&tmpl.body, templates, numbers, depth + 1)?;
     out.extend(expanded.statements);
     Ok(())
 }
 
 /// Parse `key=value` words into `(key, value)` pairs; the value must be an
 /// integer literal (the DSL's only binding type in v1).
-fn parse_bindings(words: &[String], span: Span) -> Result<Vec<(String, i64)>, BpfError> {
+fn parse_bindings(
+    words: &[String],
+    span: Span,
+    numbers: NumberSyntax,
+) -> Result<Vec<(String, i64)>, BpfError> {
     let mut pairs = Vec::with_capacity(words.len());
     for w in words {
         let (k, v) = w.split_once('=').ok_or_else(|| {
@@ -255,7 +269,7 @@ fn parse_bindings(words: &[String], span: Span) -> Result<Vec<(String, i64)>, Bp
                 format!("`use` binding `{w}` must be key=value"),
             )
         })?;
-        let n = v.trim().parse::<i64>().map_err(|_| {
+        let n = parse_int(v, numbers).ok_or_else(|| {
             BpfError::new(
                 BpfDiag::BadTemplate,
                 span,

--- a/rust/bpf-tcl-ir/src/unroll.rs
+++ b/rust/bpf-tcl-ir/src/unroll.rs
@@ -26,12 +26,14 @@
 //! is left in place and rejected later by the typed lowering (a v1 limitation —
 //! loops must appear at the statement level).
 
-use tcl_compiler::lowering::lower_to_ir;
 use tcl_compiler::{Script, Statement};
 use tcl_lexer::Span;
 use tcl_registry::registry::CommandRegistry;
+use tcl_syntax::number::NumberSyntax;
 
 use crate::diag::{BpfDiag, BpfError};
+use crate::lower::parse_int;
+use crate::source::lower_bpf_source;
 
 /// Maximum iterations a single `loop` may unroll to in v1.
 const MAX_UNROLL: i64 = 64;
@@ -75,7 +77,7 @@ fn expand_loop(
             "`loop` expects: loop N VAR { body }",
         ));
     }
-    let count = parse_count(&args[0]).ok_or_else(|| {
+    let count = parse_count(&args[0], registry.numbers()).ok_or_else(|| {
         BpfError::new(
             BpfDiag::BadInt,
             span,
@@ -93,7 +95,7 @@ fn expand_loop(
     let body_text = &args[2];
 
     // Lower the loop body, then recursively unroll any loops inside it.
-    let body_module = lower_to_ir(body_text, registry);
+    let body_module = lower_bpf_source(body_text, registry);
     let body = unroll_loops(&body_module.top_level, registry)?;
 
     for k in 0..count {
@@ -119,7 +121,7 @@ fn synth_setint(var: &str, k: i64, span: Span) -> Statement {
     }
 }
 
-fn parse_count(s: &str) -> Option<i64> {
-    let v: i64 = s.trim().parse().ok()?;
+fn parse_count(s: &str, numbers: NumberSyntax) -> Option<i64> {
+    let v = parse_int(s, numbers)?;
     (v >= 0).then_some(v)
 }

--- a/rust/tcl-registry/tests/dialect_profile.rs
+++ b/rust/tcl-registry/tests/dialect_profile.rs
@@ -30,7 +30,7 @@
 //! `operators_as_commands`). These tests pin that banned surface stays banned
 //! and the retired `NON_IRULES_OPERATORS` union never creeps back as a gate.
 
-use tcl_dialect::{DialectProfile, DialectSet};
+use tcl_dialect::{DialectProfile, DialectSet, NumberSyntax, TclVersion};
 use tcl_registry::traits::Traits;
 use tcl_registry::{ProfileQueries, registry_for_dialect};
 
@@ -338,6 +338,26 @@ fn additive_profiles_resolve_their_embedded_tcl_core() {
             );
         }
     }
+}
+
+/// BPF is a genuine Tcl 9.0 embedding, not merely a BPF command pack. The
+/// cache must install the pack and stamp that one profile so registry-owning
+/// consumers receive the full release/dialect fact set (issue #1466).
+#[test]
+fn bpf_registry_is_stamped_with_its_tcl90_embedding() {
+    let registry = registry_for_dialect("bpf");
+    let profile = DialectProfile::by_name("bpf");
+
+    assert_eq!(registry.profile(), Some(profile));
+    assert_eq!(
+        profile.availability_mask,
+        DialectSet::TCL90 | DialectSet::BPF
+    );
+    assert_eq!(registry.runtime_version(), Some(TclVersion::V9_0));
+    assert_eq!(registry.numbers(), NumberSyntax::Tcl90);
+    assert_eq!(registry.octal_fold_policy(), Some(false));
+    assert!(profile.resolve_command(registry, "zipfs").is_some());
+    assert!(profile.resolve_command(registry, "setint").is_some());
 }
 
 /// Alias canonicalisation is load-bearing (§2.4): the legacy `irules`


### PR DESCRIPTION
## Summary

- use the canonical profile-stamped BPF registry throughout the BPF IR frontend and semantic bridge
- keep numeric grammar and registry facts aligned with the Tcl 9.0 BPF embedding
- add regression coverage proving the profile is present and the old unstamped construction is rejected

## Validation

- `make rust-check`
- `cargo test -p bpf-tcl-ir -p bpf-tcl-codegen -p bpf-tcl --tests -p tcl-registry --test dialect_profile`

Closes #1466