### PR TITLE
fix(bigip): follow up SslicTcl review findings

### DIFF
--- a/rust/tcl-bigip/src/tls.rs
+++ b/rust/tcl-bigip/src/tls.rs
@@ -215,8 +215,15 @@ pub fn import_bigip_tls<S: BuildHasher>(
             _ => None,
         })
         .collect();
-    let mut endpoints =
-        import_virtual_endpoints(&virtuals, &profiles, &mut effective, version, &mut notices);
+    let mut endpoints = import_virtual_endpoints(
+        &virtuals,
+        &profiles,
+        &mut effective,
+        &pem_by_object,
+        &key_by_object,
+        version,
+        &mut notices,
+    );
 
     let used: BTreeMap<String, BTreeSet<String>> =
         endpoints.iter().fold(BTreeMap::new(), |mut acc, endpoint| {
@@ -255,6 +262,8 @@ fn import_virtual_endpoints(
     virtuals: &[&BigipVirtualServer],
     profiles: &BTreeMap<String, &BigipProfile>,
     effective: &mut BTreeMap<String, EffectiveTlsProfile>,
+    pem_by_object: &BTreeMap<String, Vec<Certificate>>,
+    key_by_object: &BTreeMap<String, String>,
     version: Option<BigipVersion>,
     notices: &mut Vec<BigipTlsNotice>,
 ) -> Vec<VirtualTlsEndpoint> {
@@ -264,13 +273,15 @@ fn import_virtual_endpoints(
             let ListItemValue::Profile(attachment) = &item.value else {
                 continue;
             };
-            let Some(path) = resolve_reference(&attachment.path, profiles)
+            let Some(path) = resolve_attached_profile(&attachment.path, virtual_server, profiles)
                 .or_else(|| factory_profile_path(&attachment.path))
             else {
                 continue;
             };
             if !effective.contains_key(&path) {
-                let Some(profile) = factory_profile(&path, version, notices) else {
+                let Some(profile) =
+                    factory_profile(&path, pem_by_object, key_by_object, version, notices)
+                else {
                     continue;
                 };
                 effective.insert(path.clone(), profile);
@@ -286,6 +297,27 @@ fn import_virtual_endpoints(
         }
     }
     endpoints
+}
+
+fn resolve_attached_profile(
+    reference: &str,
+    virtual_server: &BigipVirtualServer,
+    profiles: &BTreeMap<String, &BigipProfile>,
+) -> Option<String> {
+    if profiles.contains_key(reference) {
+        return Some(reference.to_owned());
+    }
+    if !reference.starts_with('/')
+        && let Some(partition) = virtual_server
+            .full_path
+            .strip_prefix('/')
+            .and_then(|path| path.split('/').next())
+        && let candidate = format!("/{partition}/{reference}")
+        && profiles.contains_key(&candidate)
+    {
+        return Some(candidate);
+    }
+    resolve_reference(reference, profiles)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -378,18 +410,24 @@ fn resolve_profile(
 
 fn factory_profile(
     path: &str,
+    pem_by_object: &BTreeMap<String, Vec<Certificate>>,
+    key_by_object: &BTreeMap<String, String>,
     version: Option<BigipVersion>,
     notices: &mut Vec<BigipTlsNotice>,
 ) -> Option<EffectiveTlsProfile> {
     let side = factory_profile_side(path)?;
     add_unknown_version_notice(path, version, notices);
+    let fields = factory_default_fields(side, version);
+    let certificate_bindings =
+        resolve_bindings(path, &fields, None, pem_by_object, key_by_object, notices);
+    add_unexpanded_cipher_notice(path, &fields, notices);
     Some(EffectiveTlsProfile {
         full_path: path.to_owned(),
         side,
         defaults_from: String::new(),
         inheritance_chain: Vec::new(),
-        fields: factory_default_fields(side, version),
-        certificate_bindings: Vec::new(),
+        fields,
+        certificate_bindings,
         events: events_for_profile(type_name(side))
             .into_iter()
             .map(str::to_owned)
@@ -1095,6 +1133,51 @@ ltm virtual https {
             &HashMap::new(),
         );
         assert!(mutated_import.endpoints.is_empty());
+    }
+
+    #[test]
+    fn resolves_partition_local_profile_before_factory_fallback() {
+        let source = r"
+ltm profile client-ssl /Tenant/clientssl { ciphers TENANT }
+ltm profile client-ssl /Other/clientssl { ciphers OTHER }
+ltm virtual /Tenant/https {
+    destination /Tenant/192.0.2.1:443
+    profiles { clientssl { context clientside } }
+}
+";
+        let config = parse_bigip_conf(source, "Tenant");
+        let imported = import_bigip_tls(&config, BigipVersion::parse("17.1"), &HashMap::new());
+        assert_eq!(imported.endpoints.len(), 1);
+        assert_eq!(imported.endpoints[0].profile, "/Tenant/clientssl");
+        assert_eq!(
+            imported.endpoints[0].endpoint.extensions["bigip-cipher-expression"],
+            [TlsValue::Scalar("TENANT".to_owned())]
+        );
+    }
+
+    #[test]
+    fn factory_profile_materialises_available_default_certificate() {
+        let source = r"
+sys file ssl-cert /Common/default.crt { cache-path /config/ssl/ssl.crt/default.crt }
+ltm virtual /Common/https {
+    destination /Common/192.0.2.1:443
+    profiles { /Common/clientssl { context clientside } }
+}
+";
+        let config = parse_bigip_conf(source, "Common");
+        let material = HashMap::from([(
+            "/Common/default.crt".to_owned(),
+            include_str!("../../tcl-bigip-query/tests/fixtures/x509_example.pem").to_owned(),
+        )]);
+        let imported = import_bigip_tls(&config, BigipVersion::parse("17.1"), &material);
+        let endpoint = &imported.endpoints[0];
+        assert_eq!(endpoint.profile, "/Common/clientssl");
+        assert_eq!(endpoint.binding.as_deref(), Some("legacy"));
+        assert_eq!(endpoint.certificates.len(), 1);
+        assert_eq!(
+            endpoint.key_match.status,
+            tcl_sslictcl::KeyMatchStatus::Unknown
+        );
     }
 
     #[test]

--- a/rust/tcl-bigip/src/tls.rs
+++ b/rust/tcl-bigip/src/tls.rs
@@ -418,8 +418,29 @@ fn factory_profile(
     let side = factory_profile_side(path)?;
     add_unknown_version_notice(path, version, notices);
     let fields = factory_default_fields(side, version);
-    let certificate_bindings =
-        resolve_bindings(path, &fields, None, pem_by_object, key_by_object, notices);
+    let factory_references = [
+        field_value(&fields, "cert"),
+        field_value(&fields, "key"),
+        field_value(&fields, "chain"),
+    ];
+    let factory_certificates = pem_by_object
+        .iter()
+        .filter(|(reference, _)| factory_references.contains(reference))
+        .map(|(reference, certificates)| (reference.clone(), certificates.clone()))
+        .collect();
+    let factory_keys = key_by_object
+        .iter()
+        .filter(|(reference, _)| factory_references.contains(reference))
+        .map(|(reference, key)| (reference.clone(), key.clone()))
+        .collect();
+    let certificate_bindings = resolve_bindings(
+        path,
+        &fields,
+        None,
+        &factory_certificates,
+        &factory_keys,
+        notices,
+    );
     add_unexpanded_cipher_notice(path, &fields, notices);
     Some(EffectiveTlsProfile {
         full_path: path.to_owned(),

--- a/rust/tcl-bigip/src/tls.rs
+++ b/rust/tcl-bigip/src/tls.rs
@@ -215,29 +215,8 @@ pub fn import_bigip_tls<S: BuildHasher>(
             _ => None,
         })
         .collect();
-    let mut endpoints = Vec::new();
-    for virtual_server in virtuals {
-        for item in &virtual_server.profiles.items {
-            let ListItemValue::Profile(attachment) = &item.value else {
-                continue;
-            };
-            let Some(path) = resolve_reference(&attachment.path, &profiles) else {
-                continue;
-            };
-            let Some(profile) = effective.get(&path) else {
-                continue;
-            };
-            let allowed = match profile.side {
-                TlsProfileSide::Client => attachment.context != "serverside",
-                TlsProfileSide::Server => attachment.context != "clientside",
-            };
-            if !allowed {
-                continue;
-            }
-            let variants = endpoint_variants(virtual_server, profile);
-            endpoints.extend(variants);
-        }
-    }
+    let mut endpoints =
+        import_virtual_endpoints(&virtuals, &profiles, &mut effective, version, &mut notices);
 
     let used: BTreeMap<String, BTreeSet<String>> =
         endpoints.iter().fold(BTreeMap::new(), |mut acc, endpoint| {
@@ -272,6 +251,43 @@ pub fn import_bigip_tls<S: BuildHasher>(
     }
 }
 
+fn import_virtual_endpoints(
+    virtuals: &[&BigipVirtualServer],
+    profiles: &BTreeMap<String, &BigipProfile>,
+    effective: &mut BTreeMap<String, EffectiveTlsProfile>,
+    version: Option<BigipVersion>,
+    notices: &mut Vec<BigipTlsNotice>,
+) -> Vec<VirtualTlsEndpoint> {
+    let mut endpoints = Vec::new();
+    for virtual_server in virtuals {
+        for item in &virtual_server.profiles.items {
+            let ListItemValue::Profile(attachment) = &item.value else {
+                continue;
+            };
+            let Some(path) = resolve_reference(&attachment.path, profiles)
+                .or_else(|| factory_profile_path(&attachment.path))
+            else {
+                continue;
+            };
+            if !effective.contains_key(&path) {
+                let Some(profile) = factory_profile(&path, version, notices) else {
+                    continue;
+                };
+                effective.insert(path.clone(), profile);
+            }
+            let profile = &effective[&path];
+            let allowed = match profile.side {
+                TlsProfileSide::Client => attachment.context != "serverside",
+                TlsProfileSide::Server => attachment.context != "clientside",
+            };
+            if allowed {
+                endpoints.extend(endpoint_variants(virtual_server, profile));
+            }
+        }
+    }
+    endpoints
+}
+
 #[allow(clippy::too_many_arguments)]
 fn resolve_profile(
     path: &str,
@@ -285,31 +301,8 @@ fn resolve_profile(
 ) -> EffectiveTlsProfile {
     let side = profile_side(profile.profile_type);
     let type_name = type_name(side);
-    let mut fields: BTreeMap<String, EffectiveTlsField> = version
-        .map(|version| profile_field_defaults(type_name, Some(version)))
-        .unwrap_or_default()
-        .into_iter()
-        .filter(|(field, _)| TLS_FIELDS.contains(field))
-        .map(|(field, value)| {
-            (
-                field.to_owned(),
-                EffectiveTlsField {
-                    field: field.to_owned(),
-                    value: value.to_owned(),
-                    origin: EffectiveValueOrigin::FactoryDefault,
-                    source: format!("TMOS {type_name} factory default"),
-                },
-            )
-        })
-        .collect();
-    if version.is_none() {
-        notices.push(BigipTlsNotice {
-            kind: "unknown-tmos-version".to_owned(),
-            object: path.to_owned(),
-            message: "TMOS version is absent or malformed; factory TLS defaults were not guessed"
-                .to_owned(),
-        });
-    }
+    let mut fields = factory_default_fields(side, version);
+    add_unknown_version_notice(path, version, notices);
     let mut inheritance_chain = Vec::new();
     let mut ancestors = Vec::new();
     let mut current = profile.defaults_from.clone();
@@ -380,6 +373,67 @@ fn resolve_profile(
             .map(str::to_owned)
             .collect(),
         used_by_virtuals: Vec::new(),
+    }
+}
+
+fn factory_profile(
+    path: &str,
+    version: Option<BigipVersion>,
+    notices: &mut Vec<BigipTlsNotice>,
+) -> Option<EffectiveTlsProfile> {
+    let side = factory_profile_side(path)?;
+    add_unknown_version_notice(path, version, notices);
+    Some(EffectiveTlsProfile {
+        full_path: path.to_owned(),
+        side,
+        defaults_from: String::new(),
+        inheritance_chain: Vec::new(),
+        fields: factory_default_fields(side, version),
+        certificate_bindings: Vec::new(),
+        events: events_for_profile(type_name(side))
+            .into_iter()
+            .map(str::to_owned)
+            .collect(),
+        used_by_virtuals: Vec::new(),
+    })
+}
+
+fn factory_default_fields(
+    side: TlsProfileSide,
+    version: Option<BigipVersion>,
+) -> BTreeMap<String, EffectiveTlsField> {
+    let type_name = type_name(side);
+    version
+        .map(|version| profile_field_defaults(type_name, Some(version)))
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|(field, _)| TLS_FIELDS.contains(field))
+        .map(|(field, value)| {
+            (
+                field.to_owned(),
+                EffectiveTlsField {
+                    field: field.to_owned(),
+                    value: value.to_owned(),
+                    origin: EffectiveValueOrigin::FactoryDefault,
+                    source: format!("TMOS {type_name} factory default"),
+                },
+            )
+        })
+        .collect()
+}
+
+fn add_unknown_version_notice(
+    path: &str,
+    version: Option<BigipVersion>,
+    notices: &mut Vec<BigipTlsNotice>,
+) {
+    if version.is_none() {
+        notices.push(BigipTlsNotice {
+            kind: "unknown-tmos-version".to_owned(),
+            object: path.to_owned(),
+            message: "TMOS version is absent or malformed; factory TLS defaults were not guessed"
+                .to_owned(),
+        });
     }
 }
 
@@ -785,11 +839,22 @@ const fn type_name(side: TlsProfileSide) -> &'static str {
 }
 
 fn is_factory_profile(reference: &str, side: TlsProfileSide) -> bool {
-    let leaf = reference.rsplit('/').next().unwrap_or(reference);
-    matches!(
-        (side, leaf),
-        (TlsProfileSide::Client, "clientssl") | (TlsProfileSide::Server, "serverssl")
-    )
+    factory_profile_side(reference).is_some_and(|factory_side| factory_side == side)
+}
+
+fn factory_profile_path(reference: &str) -> Option<String> {
+    factory_profile_side(reference).map(|side| match side {
+        TlsProfileSide::Client => "/Common/clientssl".to_owned(),
+        TlsProfileSide::Server => "/Common/serverssl".to_owned(),
+    })
+}
+
+fn factory_profile_side(reference: &str) -> Option<TlsProfileSide> {
+    match reference {
+        "clientssl" | "/Common/clientssl" => Some(TlsProfileSide::Client),
+        "serverssl" | "/Common/serverssl" => Some(TlsProfileSide::Server),
+        _ => None,
+    }
 }
 
 fn field_value(fields: &BTreeMap<String, EffectiveTlsField>, name: &str) -> String {
@@ -992,6 +1057,44 @@ ltm virtual https {
         assert!(imported.notices.iter().any(|notice| {
             notice.kind == "unknown-tmos-version" && notice.object == "/Common/custom"
         }));
+    }
+
+    #[test]
+    fn projects_direct_factory_profile_attachments_with_unknown_key_evidence() {
+        let source = r"
+ltm virtual https {
+    destination /Common/192.0.2.1:443
+    profiles { /Common/clientssl { context clientside } }
+}
+";
+        let config = parse_bigip_conf(source, "Common");
+        let imported = import_bigip_tls(&config, BigipVersion::parse("17.1"), &HashMap::new());
+        let profile = imported
+            .profiles
+            .iter()
+            .find(|profile| profile.full_path == "/Common/clientssl")
+            .expect("factory profile is projected");
+        assert_eq!(profile.side, TlsProfileSide::Client);
+        assert_eq!(
+            profile.fields["options"].origin,
+            EffectiveValueOrigin::FactoryDefault
+        );
+        assert_eq!(profile.used_by_virtuals, ["/Common/https"]);
+        assert_eq!(imported.endpoints.len(), 1);
+        assert!(imported.endpoints[0].certificates.is_empty());
+        assert_eq!(
+            imported.endpoints[0].key_match.status,
+            tcl_sslictcl::KeyMatchStatus::Unknown
+        );
+
+        let mutated = source.replace("/Common/clientssl", "/Common/not-a-factory-profile");
+        let mutated_config = parse_bigip_conf(&mutated, "Common");
+        let mutated_import = import_bigip_tls(
+            &mutated_config,
+            BigipVersion::parse("17.1"),
+            &HashMap::new(),
+        );
+        assert!(mutated_import.endpoints.is_empty());
     }
 
     #[test]

--- a/rust/tcl-bigip/src/validator.rs
+++ b/rust/tcl-bigip/src/validator.rs
@@ -48,7 +48,7 @@ use regex::Regex;
 use tcl_core_types::DiagCode;
 use tcl_irules::extract_irules_event_handlers;
 use tcl_lexer::LineIndex;
-use tcl_registry::base_objects::is_base_object;
+use tcl_registry::base_objects::base_object_identities;
 use tcl_registry::profile_defaults::{BigipVersion, profile_field_defaults};
 
 use crate::canonical::Canon;
@@ -60,6 +60,12 @@ use crate::parser::helpers::{
 };
 use crate::range::Range;
 use crate::value::MonitorExpression;
+
+static FACTORY_OBJECT_IDENTITIES: LazyLock<HashSet<String>> = LazyLock::new(|| {
+    base_object_identities()
+        .map(|(module, object_type, name)| factory_object_identity(module, object_type, name))
+        .collect()
+});
 
 /// BIG-IP model diagnostics emitted by this validator.
 pub const BIGIP_DIAGNOSTIC_CODES: &[DiagCode] = &[
@@ -941,11 +947,20 @@ fn resolves_factory_reference(
         .flat_map(|spec| spec.header_types)
         .any(|&(module, object_type)| {
             candidates.iter().any(|candidate| {
-                candidate
-                    .strip_prefix("/Common/")
-                    .is_some_and(|name| is_base_object(module, object_type, name))
+                factory_object_exists(module, object_type, candidate)
+                    || candidate
+                        .strip_prefix("/Common/")
+                        .is_some_and(|name| factory_object_exists(module, object_type, name))
             })
         })
+}
+
+fn factory_object_exists(module: &str, object_type: &str, name: &str) -> bool {
+    FACTORY_OBJECT_IDENTITIES.contains(&factory_object_identity(module, object_type, name))
+}
+
+fn factory_object_identity(module: &str, object_type: &str, name: &str) -> String {
+    format!("{module}\0{object_type}\0{name}")
 }
 
 /// BIGIP6014: duplicate declarations are ambiguous even when the source

--- a/rust/tcl-bigip/src/validator.rs
+++ b/rust/tcl-bigip/src/validator.rs
@@ -48,6 +48,7 @@ use regex::Regex;
 use tcl_core_types::DiagCode;
 use tcl_irules::extract_irules_event_handlers;
 use tcl_lexer::LineIndex;
+use tcl_registry::base_objects::is_base_object;
 use tcl_registry::profile_defaults::{BigipVersion, profile_field_defaults};
 
 use crate::canonical::Canon;
@@ -904,12 +905,13 @@ fn check_registry_references(config: &BigipConfig, out: &mut Vec<ConfigDiagnosti
                 for value in property_reference_values(&property, &parsed.value) {
                     let candidates =
                         reference_candidates(&value, &object.identifier, &config.default_partition);
-                    let resolved = objects.iter().any(|(target, target_kind)| {
-                        edge.to_kinds.contains(target_kind)
-                            && candidates
-                                .iter()
-                                .any(|candidate| candidate == &target.identifier)
-                    });
+                    let resolved =
+                        objects.iter().any(|(target, target_kind)| {
+                            edge.to_kinds.contains(target_kind)
+                                && candidates
+                                    .iter()
+                                    .any(|candidate| candidate == &target.identifier)
+                        }) || resolves_factory_reference(&registry, edge.to_kinds, &candidates);
                     if !resolved {
                         out.push(ConfigDiagnostic {
                             code: DiagCode::Bigip6013.as_str().to_owned(),
@@ -926,6 +928,24 @@ fn check_registry_references(config: &BigipConfig, out: &mut Vec<ConfigDiagnosti
             }
         }
     }
+}
+
+fn resolves_factory_reference(
+    registry: &tcl_registry::bigip::BigipRegistry,
+    target_kinds: &[&str],
+    candidates: &[String],
+) -> bool {
+    target_kinds
+        .iter()
+        .filter_map(|kind| registry.get(kind))
+        .flat_map(|spec| spec.header_types)
+        .any(|&(module, object_type)| {
+            candidates.iter().any(|candidate| {
+                candidate
+                    .strip_prefix("/Common/")
+                    .is_some_and(|name| is_base_object(module, object_type, name))
+            })
+        })
 }
 
 /// BIGIP6014: duplicate declarations are ambiguous even when the source
@@ -1283,6 +1303,15 @@ mod tests {
         assert!(!has(source, "BIGIP6013"));
         let common = source.replace("local_persist", "common_persist");
         assert!(!has(&common, "BIGIP6013"));
+    }
+
+    #[test]
+    fn bigip6013_recognises_registry_owned_factory_profiles_only() {
+        let factory = "ltm virtual /Common/vs {\n  profiles {\n    /Common/http { }\n    /Common/tcp { }\n    /Common/clientssl { context clientside }\n  }\n}\n";
+        assert!(!has(factory, "BIGIP6013"));
+
+        let mutated = factory.replace("/Common/clientssl", "/Common/not-a-factory-profile");
+        assert!(has(&mutated, "BIGIP6013"));
     }
 
     #[test]

--- a/rust/tcl-sslictcl/scripts/generate-source-data.sh
+++ b/rust/tcl-sslictcl/scripts/generate-source-data.sh
@@ -18,6 +18,30 @@ elif [[ $# -ne 0 ]]; then
     exit 2
 fi
 
+sha256_digest() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$@" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$@" | awk '{print $1}'
+    else
+        echo "generate-source-data requires sha256sum or shasum" >&2
+        return 1
+    fi
+}
+
+base64_file() {
+    base64 "$1" | tr -d '\n'
+}
+
+date_to_epoch() {
+    local timestamp="$1"
+    if date -u -d "$timestamp" +%s >/dev/null 2>&1; then
+        date -u -d "$timestamp" +%s
+    else
+        date -u -j -f '%b %e %T %Y %Z' "$timestamp" +%s
+    fi
+}
+
 REVISION_FILE="$RAW/observatory-revision.txt"
 if [[ ! -s "$REVISION_FILE" ]]; then
     echo "missing pinned Observatory revision: $REVISION_FILE" >&2
@@ -65,14 +89,14 @@ for pem in "$RAW"/pem/*.pem; do
         grep -q -- '-----BEGIN CERTIFICATE-----' "$cert" || continue
         der="$TMP/der"
         openssl x509 -in "$cert" -outform DER -out "$der"
-        fingerprint="$(sha256sum "$der" | awk '{print $1}')"
-        der_base64="$(base64 -w 0 "$der")"
-        spki_sha256="$(openssl x509 -in "$cert" -pubkey -noout | openssl pkey -pubin -outform DER 2>/dev/null | sha256sum | awk '{print $1}')"
+        fingerprint="$(sha256_digest "$der")"
+        der_base64="$(base64_file "$der")"
+        spki_sha256="$(openssl x509 -in "$cert" -pubkey -noout | openssl pkey -pubin -outform DER 2>/dev/null | sha256_digest)"
         subject_key_id="$(openssl x509 -in "$cert" -noout -ext subjectKeyIdentifier 2>/dev/null | awk '/Subject Key Identifier/{getline; gsub(/[^0-9A-Fa-f]/, ""); print tolower($0)}')"
         not_before_text="$(openssl x509 -in "$cert" -noout -startdate | sed 's/^notBefore=//')"
         not_after_text="$(openssl x509 -in "$cert" -noout -enddate | sed 's/^notAfter=//')"
-        not_before="$(date -u -d "$not_before_text" +%s)"
-        not_after="$(date -u -d "$not_after_text" +%s)"
+        not_before="$(date_to_epoch "$not_before_text")"
+        not_after="$(date_to_epoch "$not_after_text")"
         subject="$(openssl x509 -in "$cert" -noout -subject -nameopt RFC2253 | sed 's/^subject=//')"
         printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$fingerprint" "$der_base64" "$spki_sha256" "$subject_key_id" "$not_before" "$not_after" "$subject" >> "$MATERIAL_TSV"
     done

--- a/rust/tcl-sslictcl/scripts/generate-source-data.sh
+++ b/rust/tcl-sslictcl/scripts/generate-source-data.sh
@@ -30,7 +30,7 @@ sha256_digest() {
 }
 
 base64_file() {
-    base64 "$1" | tr -d '\n'
+    base64 < "$1" | tr -d '\n'
 }
 
 date_to_epoch() {

--- a/rust/tcl-sslictcl/scripts/update-source-data.sh
+++ b/rust/tcl-sslictcl/scripts/update-source-data.sh
@@ -23,6 +23,26 @@ CHROMIUM_REVISION="${SSLICTCL_CHROMIUM_REVISION:-}"
 command -v curl >/dev/null || { echo "update-source-data requires curl" >&2; exit 1; }
 command -v git >/dev/null || { echo "update-source-data requires git" >&2; exit 1; }
 command -v tar >/dev/null || { echo "update-source-data requires tar" >&2; exit 1; }
+command -v base64 >/dev/null || { echo "update-source-data requires base64" >&2; exit 1; }
+
+sha256_digest() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$@" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$@" | awk '{print $1}'
+    else
+        echo "update-source-data requires sha256sum or shasum" >&2
+        return 1
+    fi
+}
+
+decode_base64() {
+    if base64 --decode </dev/null >/dev/null 2>&1; then
+        base64 --decode
+    else
+        base64 -D
+    fi
+}
 
 if [[ -z "$REVISION" ]]; then
     REVISION="$(git ls-remote "$OBSERVATORY" HEAD | awk 'NR == 1 {print $1}')"
@@ -67,16 +87,16 @@ CHROME_DIR="$STAGE/chrome_root_store"
 echo "fetching Chromium Chrome Root Store at $CHROMIUM_REVISION"
 curl --fail --location --retry 3 --silent --show-error \
     "$CHROMIUM_RAW/$CHROMIUM_REVISION/net/data/ssl/chrome_root_store/root_store.certs?format=TEXT" \
-    | base64 --decode > "$CHROME_DIR/root_store.certs"
+    | decode_base64 > "$CHROME_DIR/root_store.certs"
 curl --fail --location --retry 3 --silent --show-error \
     "$CHROMIUM_RAW/$CHROMIUM_REVISION/net/data/ssl/chrome_root_store/root_store.textproto?format=TEXT" \
-    | base64 --decode > "$CHROME_DIR/root_store.textproto"
+    | decode_base64 > "$CHROME_DIR/root_store.textproto"
 printf '%s\n' "$CHROMIUM_REVISION" > "$CHROME_DIR/revision.txt"
 cp "$CHROME_DIR/root_store.certs" "$STAGE/pem/chrome.pem"
 
 curl --fail --location --retry 3 --silent --show-error \
     "$CHROMIUM_RAW/$CHROMIUM_REVISION/LICENSE?format=TEXT" \
-    | base64 --decode > "$STAGE/licenses/chromium-LICENSE"
+    | decode_base64 > "$STAGE/licenses/chromium-LICENSE"
 
 # Validate every staged certificate before replacing the committed snapshot.
 for pem in "$STAGE"/pem/*.pem "$CHROME_DIR/root_store.certs"; do
@@ -107,7 +127,7 @@ trap 'rm -rf "$STAGE"; rm -f "$FILES_JSON"' EXIT
     find "$ROOT/rust/tcl-sslictcl/data/generated" -type f -print0
 } | while IFS= read -r -d '' file; do
     relative="${file#"$ROOT/"}"
-    digest="$(sha256sum "$file" | awk '{print $1}')"
+    digest="$(sha256_digest "$file")"
     if [[ "$relative" == rust/tcl-sslictcl/data/raw/* ]]; then
         kind=raw
     else

--- a/rust/tcl-sslictcl/src/certificate.rs
+++ b/rust/tcl-sslictcl/src/certificate.rs
@@ -6,7 +6,7 @@
 
 use std::error::Error;
 use std::fmt;
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -89,8 +89,12 @@ impl Certificate {
     /// clients require SAN, and silently accepting CN would overstate trust.
     #[must_use]
     pub fn covers_hostname(&self, hostname: &str) -> bool {
-        if hostname.parse::<std::net::IpAddr>().is_ok() {
-            return self.ip_addresses.iter().any(|name| name == hostname);
+        if let Ok(hostname) = hostname.parse::<IpAddr>() {
+            return self
+                .ip_addresses
+                .iter()
+                .filter_map(|name| name.parse::<IpAddr>().ok())
+                .any(|name| name == hostname);
         }
         self.dns_names
             .iter()
@@ -492,5 +496,40 @@ mod tests {
     #[test]
     fn bad_der_is_an_error() {
         assert!(parse_certificates(b"not a certificate").is_err());
+    }
+
+    #[test]
+    fn ip_sans_match_addresses_not_textual_spellings() {
+        let certificate = Certificate {
+            fingerprint_sha256: String::new(),
+            spki_sha256: String::new(),
+            subject: String::new(),
+            issuer: String::new(),
+            common_names: Vec::new(),
+            serial: String::new(),
+            not_before: 0,
+            not_after: 0,
+            public_key_algorithm: String::new(),
+            public_key_bits: None,
+            signature_algorithm: String::new(),
+            subject_key_id: None,
+            authority_key_id: None,
+            dns_names: Vec::new(),
+            ip_addresses: vec!["2001:db8::1".to_owned(), "not-an-ip".to_owned()],
+            key_usage: Vec::new(),
+            extended_key_usage: Vec::new(),
+            is_ca: false,
+            path_len_constraint: None,
+            policy_oids: Vec::new(),
+            permitted_name_subtrees: Vec::new(),
+            excluded_name_subtrees: Vec::new(),
+            ocsp_uris: Vec::new(),
+            ca_issuer_uris: Vec::new(),
+            crl_uris: Vec::new(),
+            unknown_critical_extensions: Vec::new(),
+            raw_der: Vec::new(),
+        };
+        assert!(certificate.covers_hostname("2001:0db8:0:0:0:0:0:1"));
+        assert!(!certificate.covers_hostname("2001:db8::2"));
     }
 }

--- a/rust/xtask/src/sslictcl_data.rs
+++ b/rust/xtask/src/sslictcl_data.rs
@@ -384,4 +384,21 @@ mod tests {
         assert!(validate_manifest(&root, &manifest, None).is_err());
         fs::remove_dir_all(&root).expect("remove test tree");
     }
+
+    #[test]
+    fn source_data_scripts_keep_macos_compatible_fallbacks() {
+        let root = repo_root();
+        let generator =
+            fs::read_to_string(root.join("rust/tcl-sslictcl/scripts/generate-source-data.sh"))
+                .expect("read generator script");
+        assert!(generator.contains("shasum -a 256"));
+        assert!(generator.contains("base64 \"$1\" | tr -d '\\n'"));
+        assert!(generator.contains("date -u -j -f"));
+
+        let updater =
+            fs::read_to_string(root.join("rust/tcl-sslictcl/scripts/update-source-data.sh"))
+                .expect("read updater script");
+        assert!(updater.contains("shasum -a 256"));
+        assert!(updater.contains("base64 -D"));
+    }
 }

--- a/rust/xtask/src/sslictcl_data.rs
+++ b/rust/xtask/src/sslictcl_data.rs
@@ -392,7 +392,7 @@ mod tests {
             fs::read_to_string(root.join("rust/tcl-sslictcl/scripts/generate-source-data.sh"))
                 .expect("read generator script");
         assert!(generator.contains("shasum -a 256"));
-        assert!(generator.contains("base64 \"$1\" | tr -d '\\n'"));
+        assert!(generator.contains("base64 < \"$1\" | tr -d '\\n'"));
         assert!(generator.contains("date -u -j -f"));
 
         let updater =


### PR DESCRIPTION
Follow-up to #1541, which merged before its fresh Codex review findings could be pushed.

Addresses the four actionable findings:
- projects directly attached /Common clientssl and serverssl factory profiles with versioned defaults and explicit unknown certificate/key evidence;
- recognises registry-owned factory objects in BIGIP6013 without exempting unknown paths;
- compares IP SANs as parsed addresses;
- uses GNU/BSD portable SHA-256, Base64, and date handling for SslicTcl source-data scripts.

Regression tests include mutation-sensitive negative cases.

Validated on this exact head with `cargo test -p tcl-bigip -p tcl-sslictcl -p xtask`, `make rust-check`, and `make prep-pr`.