### PR TITLE
Centralise expression numeral lexeme scanning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -617,7 +617,7 @@ xtask-resolution-drift: ## Flag namespace-blind simple-name scans over all_procs
 	@echo "==> Checking for name-resolution drift (cargo xtask)"
 	cd $(ROOT) && cargo xtask resolution-drift
 
-xtask-number-drift: ## Flag hand-rolled Tcl radix-prefix recognition outside tcl_syntax::number (numeric-grammar drift gate)
+xtask-number-drift: ## Check Tcl numeral parser and expression-boundary scanner ownership (numeric-grammar drift gate)
 	@echo "==> Checking for numeric-grammar drift (cargo xtask)"
 	cd $(ROOT) && cargo xtask number-drift
 

--- a/docs/design/contracts/numeric-tower-and-expr-semantics.md
+++ b/docs/design/contracts/numeric-tower-and-expr-semantics.md
@@ -199,11 +199,42 @@ dialect takes the newest grammar, like every other `LexerGrammar` knob — the
 operator set only ever grows, and inventing a split for a release that has no
 such operator reports a boundary that exists nowhere.
 
+The lower owner of those boundaries is
+`tcl_dialect::scan_expr_number` (`rust/tcl-dialect/src/expr_number.rs`). It
+takes the paired `NumberSyntax` and expression-word grammar, returns an
+exclusive byte end for a numeric candidate, and deliberately does not decide
+whether that candidate has a value. `tcl-lexer` uses it to create a `NUMBER`
+token; `tcl_syntax::number::is_expr_number` uses it again before its
+`TclParseNumber` port validates the complete spelling. This preserves the
+dependency direction (`tcl-dialect` below lexer and syntax) while ensuring a
+bad `0o8`, `1_eq`, `12x`, fractional separator, radix run, or `Inf`/`NaN`
+spelling cannot acquire separate boundaries in the two consumers. The scanner
+is source-derived from `ParseLexeme` in Tcl 8.4, 8.5, 8.6, 9.0, and 9.1; its
+mutation-sensitive rows are oracle-checked with tclsh 8.6.17 and 9.0.3.
+
+An explicit radix prefix has a real numeric boundary only after an available
+prefix and at least one radix-valid digit. Then the shared word-operator probe
+applies: `0b1ne 1` is `0b1` / `ne` / `1` on 8.5+, and `0d9lt 10` is
+`0d9` / `lt` / `10` from 9.0. `0o8ne` and a pre-9.0 `0d9ne` instead remain
+whole invalid bareword candidates. The release table is
+`NumberSyntax::explicit_radix`, shared by the value parser and lower scanner.
+
+Tcl 8.4 is intentionally a separate branch in that owner. Its `GetLexeme`
+first accepts the prefix returned by `TclParseInteger` and never executes the
+8.5+ bareword rescan: `1_eq` is literal `1` then invalid `_`, `12x` is `12`
+then `x`, and `0x1p2` is `0x1` then `p2`. For 8.5+, the same lower owner also
+owns `NaN(...)`: `TclParseNumber` accepts ASCII whitespace among one through
+thirteen hex digits, but a fourteenth digit invalidates the parenthesised form
+instead of truncating it. `tcl_syntax::number` calls `scan_nan_payload` for the
+decoded value, so tokenization and semantic validation share that ceiling.
+
 ### One facility, dialect-parameterised
 
-`rust/tcl-syntax/src/number.rs` is the **only** numeral parser in the workspace.
-It takes a `NumberSyntax` (`Tcl84` / `Tcl85` / `Tcl90`) and implements the table
-above. Every consumer asks it; nothing re-derives a prefix.
+`rust/tcl-syntax/src/number.rs` is the **only** numeral value parser in the
+workspace. It takes a `NumberSyntax` (`Tcl84` / `Tcl85` / `Tcl90`) and
+implements the table above. The expression-specific byte boundary is its
+separate, lower `tcl_dialect::scan_expr_number` owner; every other consumer
+asks one of those two facilities, never re-derives a prefix or boundary.
 
 How the grammar reaches a consumer depends on what the consumer is:
 
@@ -259,12 +290,20 @@ Abstaining is cheap: an unfolded expression is evaluated later by something that
 *does* know its release. Guessing is not — it bakes one release's answer into a
 program built for another.
 
-`cargo xtask number-drift` enforces the single-parser rule: it fails on
-hand-rolled radix-prefix recognition outside the facility. Parsing a prefix out
+`cargo xtask number-drift` enforces both ownership rules: it fails on
+hand-rolled radix-prefix recognition outside the value parser, and it checks
+that the lexer and syntax classifier call the one lower expression-boundary
+scanner rather than declaring another `scan_expr_number`; it applies the same
+check to the shared NaN-payload scanner. It also requires the named
+mutation-sensitive owner/consumer regression rows (legacy 8.4, radix/operator,
+and NaN payload), but this is wiring evidence rather than a proof that arbitrary
+source text cannot duplicate semantics; code review and those executed tests
+remain the semantic backstop. Parsing a prefix out
 of something that is *not* Tcl script text — a packet field, a hex colour, a
 hex-encoded byte string — is legitimate and carries a `// number-drift-ok:`
-waiver. The gate exists because the rule was broken six independent times, each
-with the identical shape: strip two characters, call `from_str_radix`.
+waiver. The value-parser gate exists because the rule was broken six independent
+times, each with the identical shape: strip two characters, call
+`from_str_radix`.
 
 ## Numeric semantics that are tested verbatim
 

--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -37,7 +37,7 @@ entry point, or gate moves without this contract being updated.
 | dicts | `rust/tcl-syntax/src/list.rs`; `rust/tcl-syntax/src/value.rs` | `split_list`; `ValueOps::dict_pairs` | invariant | none |
 | glob matching | `rust/tcl-syntax/src/glob.rs` | `string_match`; `string_case_match` | invariant | none |
 | switch body grammar | `rust/tcl-syntax/src/switch_body.rs` | `tokenise_switch_body`; `parse_braced_pairs` | invariant | none |
-| numbers | `rust/tcl-syntax/src/number.rs`; `rust/tcl-dialect/src/grammar.rs` | `parse`; `parse_whole_with`; `NumberSyntax` | `NumberSyntax` per release | `xtask-number-drift` |
+| numbers | `rust/tcl-syntax/src/number.rs`; `rust/tcl-dialect/src/expr_number.rs`; `rust/tcl-dialect/src/grammar.rs` | `parse`; `parse_whole_with`; `is_expr_number`; `scan_expr_number`; `scan_nan_payload`; `NumberSyntax` | `NumberSyntax` and expression-word grammar per release | `xtask-number-drift` |
 | backslash escapes | `rust/tcl-lexer/src/substitution.rs`; `rust/tcl-syntax/src/backslash.rs`; `rust/tcl-dialect/src/grammar.rs` | `backslash_subst`; `backslash_subst_in`; `decode_bytes_in`; `EscapeSyntax` | `LexerGrammar::escapes` per release | none |
 | boolean words | `rust/tcl-syntax/src/boolean.rs` | `parse_boolean_word`; `truthiness_with` | fixed boolean vocabulary; number axis per release | none |
 | quotes / braces / word spans | `rust/tcl-lexer/src/ranges.rs` | `close_quote_offset`; `word_closer_offset`; `word_span_at` | `${...}` close rule per release; tmsh brace mode per dialect | none |
@@ -61,8 +61,8 @@ entry point, or gate moves without this contract being updated.
 - `number` — the `TclParseNumber` port (9.0-first: `0d` radix prefix,
   `_` digit separators, bare leading `0` is decimal), with
   `parse`/`parse_whole`/`parse_whole_with` (`ParseFlags` mirrors
-  `TCL_PARSE_INTEGER_ONLY` etc.) and `format_double`
-  (`Tcl_PrintDouble`).
+  `TCL_PARSE_INTEGER_ONLY` etc.), `is_expr_number` (which delegates its
+  boundary question below), and `format_double` (`Tcl_PrintDouble`).
 - `glob` — `string match` globbing (`string_match`,
   `string_case_match`).
 - `switch_body` — the one `switch` pattern/body-pair tokeniser (brace
@@ -83,6 +83,17 @@ entry point, or gate moves without this contract being updated.
   (`ExprOps`, `mathfunc`).
 - `backslash` — the byte-slice convenience over the lexer's decoder
   (see next); deliberately no second decode implementation.
+
+### `tcl-dialect` — foundational expression grammar
+
+- `tcl_dialect::scan_expr_number` — the lower `ParseLexeme` numeric-boundary
+  owner. The lexer consumes its `ExprNumberLexeme`; `tcl-syntax` uses the same
+  boundary before it classifies a token's value. It lives below both crates so
+  neither can reintroduce a second `1_eq` / fractional-`_` scanner.
+- `tcl_dialect::scan_nan_payload` — the 8.5+ `TclParseNumber` NaN payload
+  state machine: ASCII whitespace is allowed around/between one through thirteen
+  hexadecimal digits; a fourteenth digit invalidates the parenthesised form.
+  The scanner and value parser share it.
 
 ### `tcl-lexer` — source-text decoding
 

--- a/rust/tcl-dialect/src/expr_number.rs
+++ b/rust/tcl-dialect/src/expr_number.rs
@@ -1,0 +1,673 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Expression-numeral lexeme boundaries.
+//!
+//! This is the lower half of C Tcl's `ParseLexeme`: it determines where a
+//! numeric-looking expression lexeme ends, but deliberately does **not** turn
+//! that spelling into a value. The latter is `tcl_syntax::number`'s
+//! `TclParseNumber` port. Keeping this below both `tcl-lexer` and `tcl-syntax`
+//! prevents either layer from growing a second boundary scanner.
+//!
+//! Tcl draws an unusual boundary after a partially parsed number. A trailing
+//! bareword run normally makes the entire thing one bareword (`12x`, `1_eq`),
+//! except when the numeric run contains `.` / an exponent sign, or the suffix
+//! starts a release-available word operator (`1eq 2`). The source is
+//! `ParseLexeme` in `tcl8.5.19/generic/tclCompExpr.c:1923-1980`,
+//! `tcl8.6.16/generic/tclCompExpr.c:2016-2073`, and
+//! `tcl9.0.4/generic/tclCompExpr.c:2078-2125`; Tcl 8.4 has the predecessor in
+//! `tcl8.4.20/generic/tclParseExpr.c`. The scanner intentionally mirrors that
+//! *boundary* only. Invalid radix digits and unavailable prefixes remain one
+//! candidate lexeme for the parser to diagnose as barewords.
+
+use crate::{NumberSyntax, TclVersion, is_expr_word_operator};
+
+/// One numeric-looking expression lexeme's exclusive ending byte offset.
+///
+/// This is a byte offset into the source passed to [`scan_expr_number`]. Tcl's
+/// expression grammar is byte-oriented here (`TclIsBareword` is ASCII), so an
+/// offset is the correct boundary even beside non-ASCII source text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExprNumberLexeme {
+    end: usize,
+}
+
+/// The complete, decoded payload of a `NaN(...)` spelling.
+///
+/// Tcl's `TclParseNumber` accepts ASCII whitespace between its one through
+/// thirteen hexadecimal digits. It deliberately stops accepting after the
+/// thirteenth digit: a fourteenth digit makes the parenthesised form invalid,
+/// rather than truncating the payload. This owner is shared with
+/// `tcl_syntax::number` so lexing and value parsing cannot disagree about that
+/// boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NanPayloadLexeme {
+    end: usize,
+    value: u64,
+}
+
+impl NanPayloadLexeme {
+    /// The exclusive end offset, immediately after the closing `)`.
+    #[must_use]
+    pub const fn end(self) -> usize {
+        self.end
+    }
+
+    /// The hexadecimal payload value, with whitespace omitted.
+    #[must_use]
+    pub const fn value(self) -> u64 {
+        self.value
+    }
+}
+
+impl ExprNumberLexeme {
+    /// The exclusive end offset of this lexeme in its source byte slice.
+    #[must_use]
+    pub const fn end(self) -> usize {
+        self.end
+    }
+}
+
+/// Scan a numeric-looking expression lexeme beginning at `start`.
+///
+/// `None` means the source begins a regular bareword, not a numeric lexeme.
+/// A successful result is deliberately not a validity verdict: `0o8`, `0x`,
+/// and `0d99` under Tcl 8.6 still produce one candidate lexeme, and
+/// `tcl_syntax::number` decides that they are invalid. `numbers` controls the
+/// fractional/exponent `_` boundary; `expr_grammar_base` controls the sole
+/// word-operator exception to bareword joining. Pass a profile's
+/// `grammar.numbers` and `expr_grammar_base` together.
+///
+/// The special floating spellings are case-insensitive, as Tcl's
+/// `TclParseNumber` is: `Inf`, `Infinity`, `NaN`, and 8.5+'s
+/// `NaN(hex-payload)` (one through thirteen digits, with whitespace allowed).
+#[must_use]
+pub fn scan_expr_number(
+    source: &[u8],
+    start: usize,
+    numbers: NumberSyntax,
+    expr_grammar_base: Option<TclVersion>,
+) -> Option<ExprNumberLexeme> {
+    let first = *source.get(start)?;
+    let end = if numbers == NumberSyntax::Tcl84 {
+        scan_tcl84_number(source, start, first)?
+    } else if first.is_ascii_digit()
+        || (first == b'.' && source.get(start + 1).is_some_and(u8::is_ascii_digit))
+    {
+        scan_digit_number(source, start, numbers, expr_grammar_base)
+    } else {
+        scan_special_float(source, start, expr_grammar_base, true, true)?
+    };
+    Some(ExprNumberLexeme { end })
+}
+
+/// Parse C Tcl's `NaN(hexdigits)` payload beginning at its opening `(`.
+///
+/// This mirrors the `sNANPAREN`/`sNANHEX` states in
+/// `tcl8.5.19/generic/tclStrToD.c:1032-1060`,
+/// `tcl8.6.17/generic/tclStrToD.c:1117-1145`, and
+/// `tcl9.0.4/generic/tclStrToD.c:1178-1206`. It is intentionally unavailable
+/// to the 8.4 `GetLexeme` path, which delegates special floats to the platform
+/// `strtod` and has no parenthesised payload grammar.
+#[must_use]
+pub fn scan_nan_payload(source: &[u8], open_paren: usize) -> Option<NanPayloadLexeme> {
+    if source.get(open_paren) != Some(&b'(') {
+        return None;
+    }
+    let mut cursor = open_paren + 1;
+    let mut digits = 0usize;
+    let mut value = 0u64;
+    while let Some(&byte) = source.get(cursor) {
+        if byte.is_ascii_whitespace() {
+            cursor += 1;
+            continue;
+        }
+        if byte == b')' {
+            return (digits != 0).then_some(NanPayloadLexeme {
+                end: cursor + 1,
+                value,
+            });
+        }
+        let digit = byte.to_ascii_lowercase();
+        let value_digit = match digit {
+            b'0'..=b'9' => u64::from(digit - b'0'),
+            b'a'..=b'f' => u64::from(digit - b'a' + 10),
+            _ => return None,
+        };
+        if digits == 13 {
+            return None;
+        }
+        value = (value << 4) | value_digit;
+        digits += 1;
+        cursor += 1;
+    }
+    None
+}
+
+/// C's `TclIsBareword` for the ASCII bytes that matter at a numeric junction.
+#[must_use]
+pub const fn is_expr_bareword_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
+/// Whether `op` has C Tcl's word-operator lexical boundary at `at`.
+///
+/// `ParseLexeme` protects the right side with `!isalpha`, rather than with
+/// `!TclIsBareword`: `eq2` is consequently `eq` plus `2`, while `eqx` is one
+/// bareword. The preceding guard falls out of C's preceding bareword scan and
+/// is explicit here so callers can ask about an arbitrary offset.
+#[must_use]
+pub fn expr_word_operator_boundary_ok(source: &[u8], op: &str, at: usize) -> bool {
+    if !expr_word_operator_right_boundary_ok(source, op, at) {
+        return false;
+    }
+    if source
+        .get(at.wrapping_sub(1))
+        .is_some_and(|byte| byte.is_ascii_alphabetic() || *byte == b'_')
+    {
+        return false;
+    }
+    true
+}
+
+/// Whether `op` has C Tcl's trailing word-operator boundary at `at`.
+///
+/// `ParseLexeme(end, …)` recursively probes the suffix after a number. In
+/// that call `end` is the *start* of a new lexeme, so the byte before it must
+/// not participate: `Infinityeq` is `Infinity eq`, even though `y` precedes
+/// `eq` in the enclosing source. Call [`expr_word_operator_boundary_ok`] when
+/// asking about a word operator in the outer source stream instead.
+#[must_use]
+pub fn expr_word_operator_right_boundary_ok(source: &[u8], op: &str, at: usize) -> bool {
+    if at > source.len()
+        || !source
+            .get(at..)
+            .is_some_and(|tail| tail.starts_with(op.as_bytes()))
+    {
+        return false;
+    }
+    !source
+        .get(at + op.len())
+        .is_some_and(u8::is_ascii_alphabetic)
+}
+
+/// The release-available binary word operator beginning at `at`, if any.
+///
+/// This is the `ParseLexeme(end, …)` probe the numeral scanner needs before it
+/// decides whether `1eq` is `1` followed by `eq`, or one bareword. Only the
+/// word-shaped binary operators participate; punctuation operators cannot be
+/// swallowed by a bareword run in the first place.
+#[must_use]
+pub fn expr_binary_word_operator_at(
+    source: &[u8],
+    at: usize,
+    expr_grammar_base: Option<TclVersion>,
+) -> Option<&'static str> {
+    crate::EXPR_WORD_OPERATORS.iter().find_map(|&(op, _)| {
+        (is_expr_word_operator(op, expr_grammar_base)
+            && expr_word_operator_right_boundary_ok(source, op, at))
+        .then_some(op)
+    })
+}
+
+fn scan_digit_number(
+    source: &[u8],
+    start: usize,
+    numbers: NumberSyntax,
+    expr_grammar_base: Option<TclVersion>,
+) -> usize {
+    let mut end = start;
+
+    // C first lets TclParseNumber inspect a radix spelling. A valid prefix plus
+    // at least one valid digit has a real numeric end, which must be offered to
+    // the recursive word-operator probe (`0b1ne`, `0d9lt`). An unavailable
+    // prefix or invalid first digit has no numeric end, so it stays one greedy
+    // bareword candidate (`0o8`, `0d99` before 9.0, `0xg`). Prefix availability
+    // is the NumberSyntax grammar owner, never a lexer-local table.
+    if source.get(start) == Some(&b'0')
+        && source.get(start + 1).is_some_and(|byte| {
+            matches!(byte, b'x' | b'X' | b'o' | b'O' | b'b' | b'B' | b'd' | b'D')
+        })
+    {
+        if let Some(end) = scan_explicit_radix_number(source, start, numbers) {
+            return join_trailing_bareword(source, start, end, expr_grammar_base, true);
+        }
+        end = start + 2;
+        while source
+            .get(end)
+            .is_some_and(|byte| is_expr_bareword_byte(*byte))
+        {
+            end += 1;
+        }
+        return end;
+    }
+
+    while source
+        .get(end)
+        .is_some_and(|byte| byte.is_ascii_digit() || *byte == b'_')
+    {
+        end += 1;
+    }
+    if source.get(end) == Some(&b'.') {
+        end += 1;
+        while source.get(end).is_some_and(|byte| {
+            byte.is_ascii_digit() || (numbers.allows_digit_separators() && *byte == b'_')
+        }) {
+            end += 1;
+        }
+    }
+    if source
+        .get(end)
+        .is_some_and(|byte| matches!(byte, b'e' | b'E'))
+    {
+        let exponent = end;
+        end += 1;
+        if source
+            .get(end)
+            .is_some_and(|byte| matches!(byte, b'+' | b'-'))
+        {
+            end += 1;
+        }
+        if source.get(end).is_some_and(u8::is_ascii_digit) {
+            while source.get(end).is_some_and(|byte| {
+                byte.is_ascii_digit() || (numbers.allows_digit_separators() && *byte == b'_')
+            }) {
+                end += 1;
+            }
+        } else {
+            end = exponent;
+        }
+    }
+    join_trailing_bareword(source, start, end, expr_grammar_base, false)
+}
+
+/// Scan an available explicit-radix numeral through its last valid digit.
+///
+/// `None` deliberately means the candidate has no valid numeral at all, not
+/// merely that it has trailing junk. This preserves C Tcl's whole-bareword
+/// diagnostic for `0o8`/`0xg`; a successful prefix can instead let
+/// `join_trailing_bareword` distinguish `0b1ne` from `0b1x`.
+fn scan_explicit_radix_number(source: &[u8], start: usize, numbers: NumberSyntax) -> Option<usize> {
+    let radix = numbers.explicit_radix(*source.get(start + 1)?)?;
+    let mut end = start + 2;
+    let mut digits = 0usize;
+    while let Some(&byte) = source.get(end) {
+        if let Some(value) = ascii_digit_value(byte) {
+            if value >= radix {
+                break;
+            }
+            digits += 1;
+            end += 1;
+            continue;
+        }
+        if numbers.allows_digit_separators()
+            && byte == b'_'
+            && digits != 0
+            && source
+                .get(end + 1)
+                .and_then(|next| ascii_digit_value(*next))
+                .is_some_and(|value| value < radix)
+        {
+            end += 1;
+            continue;
+        }
+        break;
+    }
+    (digits != 0).then_some(end)
+}
+
+fn ascii_digit_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Tcl 8.4's pre-`TclParseNumber` expression scanner.
+///
+/// `GetLexeme` first uses `TclParseInteger`, then falls back to `strtod`; it
+/// never performs the 8.5+ `ParseLexeme` bareword rescan. Consequently `1_eq`
+/// is a literal `1` followed by invalid `_`, `12x` is literal `12` then `x`,
+/// and a `0x` prefix stops after its valid hex digits (`0x1p2` is `0x1`, then
+/// `p2`). See `tcl8.4.20/generic/tclParseExpr.c:1592-1645` and
+/// `:1898-1928`.
+fn scan_tcl84_number(source: &[u8], start: usize, first: u8) -> Option<usize> {
+    if first.is_ascii_digit() {
+        if source
+            .get(start + 1)
+            .is_some_and(|byte| matches!(byte, b'x' | b'X'))
+        {
+            let mut end = start + 2;
+            while source.get(end).is_some_and(u8::is_ascii_hexdigit) {
+                end += 1;
+            }
+            return Some(if end == start + 2 { start + 1 } else { end });
+        }
+        return Some(scan_tcl84_decimal(source, start));
+    }
+    if first == b'.' && source.get(start + 1).is_some_and(u8::is_ascii_digit) {
+        return Some(scan_tcl84_decimal(source, start));
+    }
+    scan_special_float(source, start, None, false, false)
+}
+
+fn scan_tcl84_decimal(source: &[u8], start: usize) -> usize {
+    let mut end = start;
+    while source.get(end).is_some_and(u8::is_ascii_digit) {
+        end += 1;
+    }
+    let needs_double = source
+        .get(end)
+        .is_some_and(|byte| matches!(byte, b'.' | b'e' | b'E'))
+        || (source.get(start) == Some(&b'.') && end > start);
+    if !needs_double {
+        return end;
+    }
+    if source.get(end) == Some(&b'.') {
+        end += 1;
+        while source.get(end).is_some_and(u8::is_ascii_digit) {
+            end += 1;
+        }
+    }
+    if source
+        .get(end)
+        .is_some_and(|byte| matches!(byte, b'e' | b'E'))
+    {
+        let exponent = end;
+        end += 1;
+        if source
+            .get(end)
+            .is_some_and(|byte| matches!(byte, b'+' | b'-'))
+        {
+            end += 1;
+        }
+        let digits = end;
+        while source.get(end).is_some_and(u8::is_ascii_digit) {
+            end += 1;
+        }
+        if end == digits {
+            return exponent;
+        }
+    }
+    end
+}
+
+fn scan_special_float(
+    source: &[u8],
+    start: usize,
+    expr_grammar_base: Option<TclVersion>,
+    nan_payload: bool,
+    modern_bareword_junction: bool,
+) -> Option<usize> {
+    let (end, completed_nan_payload) = if starts_with_ignore_ascii_case(source, start, b"inf") {
+        let after_inf = start + 3;
+        if starts_with_ignore_ascii_case(source, after_inf, b"inity") {
+            (after_inf + 5, false)
+        } else {
+            (after_inf, false)
+        }
+    } else if starts_with_ignore_ascii_case(source, start, b"nan") {
+        if nan_payload {
+            if let Some(payload) = scan_nan_payload(source, start + 3) {
+                (payload.end(), true)
+            } else {
+                (start + 3, false)
+            }
+        } else {
+            (start + 3, false)
+        }
+    } else {
+        return None;
+    };
+
+    if modern_bareword_junction
+        && !completed_nan_payload
+        && source
+            .get(end)
+            .is_some_and(|byte| is_expr_bareword_byte(*byte))
+    {
+        // A special float is a double, but it has no `.` / exponent sign to
+        // force C down the number path. It therefore follows exactly the same
+        // bareword-vs-following-operator rule as an integer.
+        expr_binary_word_operator_at(source, end, expr_grammar_base)?;
+    }
+    Some(end)
+}
+
+fn join_trailing_bareword(
+    source: &[u8],
+    start: usize,
+    end: usize,
+    expr_grammar_base: Option<TclVersion>,
+    restarted_at_suffix: bool,
+) -> usize {
+    if !source
+        .get(end)
+        .is_some_and(|byte| is_expr_bareword_byte(*byte))
+        || !source[start..end]
+            .iter()
+            .copied()
+            .all(is_expr_bareword_byte)
+        || expr_binary_word_operator_at(source, end, expr_grammar_base).is_some_and(|op| {
+            // C restarts ParseLexeme after a successful explicit-radix parse.
+            // That probe sees only the suffix's right boundary: a preceding
+            // hexadecimal `f` belongs to the finished number, so `0xfne` is
+            // `0xf ne`. Other numeric scans still inspect the enclosing
+            // bareword boundary (`1_eq` remains one candidate).
+            restarted_at_suffix || expr_word_operator_boundary_ok(source, op, end)
+        })
+    {
+        return end;
+    }
+    let mut end = end;
+    while source
+        .get(end)
+        .is_some_and(|byte| is_expr_bareword_byte(*byte))
+    {
+        end += 1;
+    }
+    end
+}
+
+fn starts_with_ignore_ascii_case(source: &[u8], at: usize, word: &[u8]) -> bool {
+    source
+        .get(at..at.saturating_add(word.len()))
+        .is_some_and(|candidate| candidate.eq_ignore_ascii_case(word))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scan(source: &str, numbers: NumberSyntax, base: Option<TclVersion>) -> Option<&str> {
+        scan_expr_number(source.as_bytes(), 0, numbers, base).map(|lexeme| &source[..lexeme.end()])
+    }
+
+    /// Boundary rows are source-derived from Tcl's `ParseLexeme`: 8.4 uses
+    /// `tclParseExpr.c`; 8.5/8.6 use `tclCompExpr.c`; 9.0/9.1 use the same
+    /// routine with `TclParseNumber`. Oracle runs on tclsh 8.6.17 and 9.0.3:
+    /// `expr {1_eq}` reports one bareword, `expr {1eq 2}` returns 0,
+    /// `expr {1.0_2}` is BADCHAR on 8.6 and returns 1.02 on 9.0.
+    #[test]
+    fn number_bareword_junctions_match_tcl_parselexeme() {
+        for (numbers, base) in [
+            (NumberSyntax::Tcl85, Some(TclVersion::V8_5)),
+            (NumberSyntax::Tcl90, Some(TclVersion::V9_0)),
+        ] {
+            for source in ["1_eq", "12x", "1e_0", "1_2_eq"] {
+                assert_eq!(scan(source, numbers, base), Some(source), "{source}");
+            }
+            for (source, start) in [("0 + 1_eq", 4), ("0 + 12x", 4)] {
+                assert_eq!(
+                    scan_expr_number(source.as_bytes(), start, numbers, base)
+                        .map(|lexeme| &source[start..lexeme.end()]),
+                    Some(&source[start..]),
+                    "{source}"
+                );
+            }
+            assert_eq!(scan("1.5abc", numbers, base), Some("1.5"));
+            assert_eq!(scan("1eq 2", numbers, base), Some("1"));
+        }
+    }
+
+    /// Tcl 8.4's `GetLexeme` predates the 8.5 `ParseLexeme` bareword rescan.
+    /// `tcl8.4.20/generic/tclParseExpr.c:1592-1645` first accepts the prefix
+    /// returned by `TclParseInteger` (`:1898-1928`), so each of these is two
+    /// lexemes rather than one modern bareword. Mutating the 8.4 branch to use
+    /// `join_trailing_bareword` reverses every row.
+    #[test]
+    fn tcl84_getlexeme_keeps_integer_prefixes_separate() {
+        let syntax = NumberSyntax::Tcl84;
+        let base = Some(TclVersion::V8_4);
+        assert_eq!(scan("1_eq", syntax, base), Some("1"));
+        assert_eq!(scan("12x", syntax, base), Some("12"));
+        assert_eq!(scan("0x1p2", syntax, base), Some("0x1"));
+        assert_eq!(scan("0xg", syntax, base), Some("0"));
+        assert_eq!(scan("1.5abc", syntax, base), Some("1.5"));
+    }
+
+    /// `_` after a decimal point or in an exponent is a release-sensitive
+    /// boundary, whereas the all-bareword integer run is deliberately whole
+    /// on every release. Mutating either branch makes a 8.x/9.x row fail.
+    #[test]
+    fn digit_separator_boundaries_follow_the_number_syntax() {
+        let old = (NumberSyntax::Tcl85, Some(TclVersion::V8_6));
+        let new = (NumberSyntax::Tcl90, Some(TclVersion::V9_0));
+        assert_eq!(scan("1.0_2", old.0, old.1), Some("1.0"));
+        assert_eq!(scan("1.0_2", new.0, new.1), Some("1.0_2"));
+        assert_eq!(scan("1e1_0", old.0, old.1), Some("1e1_0"));
+        assert_eq!(scan("1e1_0", new.0, new.1), Some("1e1_0"));
+        assert_eq!(scan("0xff_ff", old.0, old.1), Some("0xff_ff"));
+        assert_eq!(scan("0xff_ff", new.0, new.1), Some("0xff_ff"));
+    }
+
+    /// A word operator only splits a preceding numeral in the release that
+    /// owns that operator. The `lt_` row is the mutation-sensitive boundary
+    /// oracle: changing either release gate or right-boundary test reverses it.
+    #[test]
+    fn word_operator_availability_controls_numeric_joining() {
+        assert_eq!(
+            scan("1lt 2", NumberSyntax::Tcl85, Some(TclVersion::V8_6)),
+            Some("1lt")
+        );
+        assert_eq!(
+            scan("1lt 2", NumberSyntax::Tcl90, Some(TclVersion::V9_0)),
+            Some("1")
+        );
+        assert_eq!(
+            scan("1eq_ 2", NumberSyntax::Tcl85, Some(TclVersion::V8_6)),
+            Some("1")
+        );
+        assert_eq!(
+            scan("1 lt_ 2", NumberSyntax::Tcl85, Some(TclVersion::V8_6)),
+            Some("1")
+        );
+    }
+
+    /// A successful `TclParseNumber` radix prefix has a distinct numeric end,
+    /// so the usual recursive operator probe applies there too. A missing,
+    /// invalid, or release-unavailable prefix has no such end and remains one
+    /// bareword candidate. These are tclsh 8.6.17 / 9.0.3 oracle rows.
+    #[test]
+    fn explicit_radix_numerals_split_only_before_available_word_operators() {
+        let old = (NumberSyntax::Tcl85, Some(TclVersion::V8_6));
+        for source in [
+            "0x1ne 1",
+            "0xfne 1",
+            "0xffin {255}",
+            "0b1ne 1",
+            "0o7in {7}",
+            "0b1ni {1}",
+        ] {
+            let expected = match source {
+                "0x1ne 1" => "0x1",
+                "0xfne 1" => "0xf",
+                "0xffin {255}" => "0xff",
+                "0b1ne 1" | "0b1ni {1}" => "0b1",
+                "0o7in {7}" => "0o7",
+                _ => unreachable!(),
+            };
+            assert_eq!(scan(source, old.0, old.1), Some(expected), "{source}");
+        }
+        let new = (NumberSyntax::Tcl90, Some(TclVersion::V9_0));
+        for source in ["0d9lt 10", "0d9le 9", "0d9gt 8", "0d9ge 9"] {
+            assert_eq!(scan(source, new.0, new.1), Some("0d9"), "{source}");
+        }
+        assert_eq!(scan("0xfge 15", new.0, new.1), Some("0xf"));
+        assert_eq!(scan("0o8ne 1", old.0, old.1), Some("0o8ne"));
+        assert_eq!(scan("0d9ne 1", old.0, old.1), Some("0d9ne"));
+        assert_eq!(scan("0b2ne 1", new.0, new.1), Some("0b2ne"));
+    }
+
+    /// Tcl's special floats are parsed case-insensitively. `Infinityeq` is
+    /// `Infinity eq` (tclsh 8.6.17 / 9.0.3 return 0), while `Infinityx` is a
+    /// bareword/function name rather than a numeric prefix. `TclParseNumber`'s
+    /// NaN state permits thirteen hexadecimal digits and whitespace only; its
+    /// fourteenth digit leaves the scanner at bare `NaN`.
+    #[test]
+    fn special_floats_follow_numeric_junction_rules() {
+        for syntax in NumberSyntax::ALL {
+            let base = match syntax {
+                NumberSyntax::Tcl84 => Some(TclVersion::V8_4),
+                NumberSyntax::Tcl85 => Some(TclVersion::V8_5),
+                NumberSyntax::Tcl90 => Some(TclVersion::V9_0),
+            };
+            assert_eq!(scan("iNf", *syntax, base), Some("iNf"));
+            let nan = if *syntax == NumberSyntax::Tcl84 {
+                Some("NaN")
+            } else {
+                Some("NaN(1)")
+            };
+            assert_eq!(scan("NaN(1)", *syntax, base), nan);
+            assert_eq!(scan("Infinityeq 1", *syntax, base), Some("Infinity"));
+            let infinity_x = if *syntax == NumberSyntax::Tcl84 {
+                Some("Infinity")
+            } else {
+                None
+            };
+            assert_eq!(scan("Infinityx", *syntax, base), infinity_x);
+        }
+        let modern = (NumberSyntax::Tcl85, Some(TclVersion::V8_6));
+        assert_eq!(
+            scan("NaN(123456789abcd)", modern.0, modern.1),
+            Some("NaN(123456789abcd)")
+        );
+        assert_eq!(
+            scan("NaN( 1 2 3 )", modern.0, modern.1),
+            Some("NaN( 1 2 3 )")
+        );
+        assert_eq!(scan("NaN(123456789abcde)", modern.0, modern.1), Some("NaN"));
+        assert_eq!(scan("NaN(1)x", modern.0, modern.1), Some("NaN(1)"));
+        assert_eq!(scan("NaNx", modern.0, modern.1), None);
+    }
+
+    #[test]
+    fn nan_payload_owner_matches_tcl_parse_number_limits() {
+        assert_eq!(
+            scan_nan_payload(b"NaN( 1 2 3 )", 3),
+            Some(NanPayloadLexeme {
+                end: 12,
+                value: 0x123
+            })
+        );
+        assert_eq!(scan_nan_payload(b"NaN(  )", 3), None);
+        assert_eq!(scan_nan_payload(b"NaN(123456789abcde)", 3), None);
+    }
+}

--- a/rust/tcl-dialect/src/grammar.rs
+++ b/rust/tcl-dialect/src/grammar.rs
@@ -430,6 +430,22 @@ impl NumberSyntax {
         matches!(self, Self::Tcl90)
     }
 
+    /// The radix selected by an explicit numeral-prefix marker in this release.
+    ///
+    /// This is the grammar owner for the release availability of `0x`, `0b`,
+    /// `0o`, and `0d`. Both the value parser and expression-boundary scanner
+    /// must ask it instead of maintaining independent prefix tables.
+    #[must_use]
+    pub fn explicit_radix(self, marker: u8) -> Option<u8> {
+        match marker {
+            b'x' | b'X' => Some(16),
+            b'b' | b'B' if self.has_binary_octal_prefix() => Some(2),
+            b'o' | b'O' if self.has_binary_octal_prefix() => Some(8),
+            b'd' | b'D' if self.has_decimal_prefix() => Some(10),
+            _ => None,
+        }
+    }
+
     /// Whether `_` may separate digits (`1__000`, `0xff__ff`) — 9.0 onward.
     #[must_use]
     pub fn allows_digit_separators(self) -> bool {
@@ -455,7 +471,7 @@ impl Default for LexerGrammar {
 
 #[cfg(test)]
 mod tests {
-    use super::{BracedVarStyle, EscapeSyntax, ExprCommentStyle, LexerGrammar};
+    use super::{BracedVarStyle, EscapeSyntax, ExprCommentStyle, LexerGrammar, NumberSyntax};
 
     #[test]
     fn nesting_rule_is_tcl9_only() {
@@ -480,6 +496,16 @@ mod tests {
         assert!(g.script_skips_leading_bom);
         assert_eq!(g.expr_comments, ExprCommentStyle::Hash);
         assert_eq!(g.escapes, EscapeSyntax::Tcl90);
+    }
+
+    #[test]
+    fn explicit_radix_prefixes_follow_the_number_syntax() {
+        assert_eq!(NumberSyntax::Tcl84.explicit_radix(b'x'), Some(16));
+        assert_eq!(NumberSyntax::Tcl84.explicit_radix(b'b'), None);
+        assert_eq!(NumberSyntax::Tcl85.explicit_radix(b'b'), Some(2));
+        assert_eq!(NumberSyntax::Tcl85.explicit_radix(b'o'), Some(8));
+        assert_eq!(NumberSyntax::Tcl85.explicit_radix(b'd'), None);
+        assert_eq!(NumberSyntax::Tcl90.explicit_radix(b'd'), Some(10));
     }
 
     #[test]

--- a/rust/tcl-dialect/src/lib.rs
+++ b/rust/tcl-dialect/src/lib.rs
@@ -43,12 +43,18 @@
 #![deny(missing_docs)]
 
 mod dialect_set;
+mod expr_number;
 mod grammar;
 mod library;
 mod profile;
 mod version;
 
 pub use dialect_set::{DialectSet, KNOWN_DIALECTS, available_dialects};
+pub use expr_number::{
+    ExprNumberLexeme, NanPayloadLexeme, expr_binary_word_operator_at,
+    expr_word_operator_boundary_ok, expr_word_operator_right_boundary_ok, is_expr_bareword_byte,
+    scan_expr_number, scan_nan_payload,
+};
 pub use grammar::{
     BracedVarStyle, EXPR_WORD_OPERATORS, EscapeSyntax, ExprCommentStyle, LexerGrammar,
     NumberSyntax, expr_word_operator_since, is_expr_word_operator,

--- a/rust/tcl-lexer/src/expr_lexer.rs
+++ b/rust/tcl-lexer/src/expr_lexer.rs
@@ -224,14 +224,6 @@ const MULTI_OPS: &[&str] = &[
     "ge",
 ];
 
-/// C's `TclIsBareword` — ASCII letters, digits and `_`. Note it does *not*
-/// include `.`, which is what splits a numeric run holding a decimal point
-/// from one that doesn't at the number/bareword junction (see
-/// [`Inner::number`]).
-fn is_bareword_byte(ch: u8) -> bool {
-    ch.is_ascii_alphanumeric() || ch == b'_'
-}
-
 fn is_single_op(ch: u8) -> bool {
     matches!(
         ch,
@@ -285,23 +277,9 @@ struct Inner<'s> {
     /// `tcl_dialect::LexerGrammar::expr_comments`). When false, `#` stays an
     /// unknown character, which is what C 8.4-8.6 does with it.
     expr_comments: bool,
-    /// Whether `_` may sit inside a *fractional or exponent* digit run — 9.0+
-    /// only, and unlike the integer run this genuinely changes the lexeme
-    /// boundary, so it cannot be left to `tcl-syntax` to sort out.
-    ///
-    /// C's bareword scan takes `[A-Za-z0-9_]` but stops at `.`, which splits
-    /// the two cases (tclsh 8.6.16):
-    ///
-    /// | input | 8.6 | 9.0 |
-    /// |---|---|---|
-    /// | `1_0`, `1e1_0`, `0x1_f` | `invalid bareword` | valid |
-    /// | `1.0_2` | **`invalid character "_"`** | valid |
-    ///
-    /// With no `.`, the whole run is one bareword candidate on every release,
-    /// so the integer run absorbs `_` unconditionally. After a `.` the number
-    /// lexeme *ends* before 9.0 and the `_` is its own invalid lexeme — so
-    /// absorbing it there would report a bareword where C reports a character.
-    digit_separators: bool,
+    /// The release's number grammar, forwarded intact to the shared
+    /// expression-numeral boundary scanner.
+    numbers: tcl_dialect::NumberSyntax,
     /// The release whose `expr` lexeme table this dialect uses, for the
     /// word-shaped operators (`eq`, `in`, `lt`, …) — the profile's
     /// `expr_grammar_base`, resolved through
@@ -310,6 +288,10 @@ struct Inner<'s> {
     /// be settled above the lexer. `None` (plain `tcl`, iRules) takes the
     /// newest grammar, like every other knob on `LexerGrammar`.
     expr_grammar_base: Option<tcl_dialect::TclVersion>,
+    /// The previous emitted lexeme was a number with no intervening byte.
+    /// C's successful explicit-radix path recursively starts a fresh lexeme at
+    /// this point, so a word operator then has only a right-side boundary.
+    numeric_suffix_probe: bool,
     unknown: bool,
 }
 
@@ -322,8 +304,9 @@ impl<'s> Inner<'s> {
             i: 0,
             irules_operators: profile.is_irules(),
             expr_comments: profile.grammar.expr_comments.comments(),
-            digit_separators: profile.grammar.numbers.allows_digit_separators(),
+            numbers: profile.grammar.numbers,
             expr_grammar_base: profile.expr_grammar_base,
+            numeric_suffix_probe: false,
             unknown: false,
         }
     }
@@ -368,6 +351,8 @@ impl<'s> Inner<'s> {
         let irops = irules_ops();
         let mut out = Vec::new();
         while self.i < self.b.len() {
+            let follows_numeric_lexeme = self.numeric_suffix_probe;
+            self.numeric_suffix_probe = false;
             let ch = self.b[self.i];
             if matches!(ch, b' ' | b'\t' | b'\n' | b'\r') || self.is_backslash_nl(self.i) {
                 let start = self.i;
@@ -383,10 +368,13 @@ impl<'s> Inner<'s> {
                 out.push(self.tok(ExprTokenType::Whitespace, start));
             } else if ch == b'#' && self.expr_comments {
                 out.push(self.comment());
-            } else if ch.is_ascii_digit()
-                || (ch == b'.' && self.i + 1 < self.b.len() && self.b[self.i + 1].is_ascii_digit())
+            } else if let Some(number) =
+                tcl_dialect::scan_expr_number(self.b, self.i, self.numbers, self.expr_grammar_base)
             {
-                out.push(self.number());
+                let start = self.i;
+                self.i = number.end();
+                out.push(self.tok(ExprTokenType::Number, start));
+                self.numeric_suffix_probe = true;
             } else if ch == b'$' {
                 out.push(self.variable());
             } else if ch == b'[' {
@@ -403,7 +391,7 @@ impl<'s> Inner<'s> {
                 out.push(self.single(ExprTokenType::TernaryQ, "?"));
             } else if ch == b':' {
                 out.push(self.single(ExprTokenType::TernaryC, ":"));
-            } else if let Some(t) = self.multi_op() {
+            } else if let Some(t) = self.multi_op(follows_numeric_lexeme) {
                 out.push(t);
             } else if is_single_op(ch) {
                 out.push(ExprToken {
@@ -457,113 +445,6 @@ impl<'s> Inner<'s> {
                 start + k + usize::from(self.b[start + k] == 0)
             });
         self.tok(ExprTokenType::Comment, start)
-    }
-
-    /// Scan a numeric-looking run. Deliberately *dialect-blind* and greedy over
-    /// a radix prefix's alphanumerics: this only delimits the lexeme, exactly as
-    /// C's `ParseLexeme` scans before deciding. Whether the run is a valid
-    /// number in this release is settled above the lexer (`tcl-syntax` owns the
-    /// number parser and sits above this crate), which reclassifies an invalid
-    /// one as a bareword — so `0o8`, and `0d99` before 9.0, stay a single token
-    /// and are reported whole.
-    fn number(&mut self) -> ExprToken {
-        let start = self.i;
-        if self.b[self.i] == b'0'
-            && self.i + 1 < self.b.len()
-            && matches!(
-                self.b[self.i + 1],
-                b'x' | b'X' | b'o' | b'O' | b'b' | b'B' | b'd' | b'D'
-            )
-        {
-            self.i += 2;
-            while self.i < self.b.len()
-                && (self.b[self.i].is_ascii_alphanumeric() || self.b[self.i] == b'_')
-            {
-                self.i += 1;
-            }
-            return self.tok(ExprTokenType::Number, start);
-        }
-        // `_` rides along inside a digit run: 9.0 allows it as a separator, and
-        // before 9.0 the whole run must still be ONE lexeme so it is reported as
-        // a single bareword rather than a number followed by junk.
-        while self.i < self.b.len() && (self.b[self.i].is_ascii_digit() || self.b[self.i] == b'_') {
-            self.i += 1;
-        }
-        // The fraction and exponent digit runs take `_` for the same reason the
-        // integer run above does: 9.0 allows a separator anywhere between two
-        // digits, so `1.0_2` and `1e1_0` are single numerals (tclsh 9.0: 1.02
-        // and 10000000000.0). Keeping them digit-only split the lexeme and
-        // degraded valid input to a parse error.
-        if self.i < self.b.len() && self.b[self.i] == b'.' {
-            self.i += 1;
-            while self.i < self.b.len()
-                && (self.b[self.i].is_ascii_digit()
-                    || (self.digit_separators && self.b[self.i] == b'_'))
-            {
-                self.i += 1;
-            }
-        }
-        if self.i < self.b.len() && matches!(self.b[self.i], b'e' | b'E') {
-            let save = self.i;
-            self.i += 1;
-            if self.i < self.b.len() && matches!(self.b[self.i], b'+' | b'-') {
-                self.i += 1;
-            }
-            // The exponent commits only on a *digit*: `_` must sit between two
-            // digits, so `1e_0` is not an exponent at all (tclsh 9.0 errors).
-            // Once committed, the run takes separators like any other.
-            if self.i < self.b.len() && self.b[self.i].is_ascii_digit() {
-                while self.i < self.b.len()
-                    && (self.b[self.i].is_ascii_digit()
-                        || (self.digit_separators && self.b[self.i] == b'_'))
-                {
-                    self.i += 1;
-                }
-            } else {
-                self.i = save;
-            }
-        }
-        self.join_trailing_bareword(start);
-        self.tok(ExprTokenType::Number, start)
-    }
-
-    /// Extend a numeric run that butts straight against bareword characters
-    /// into the single bareword C would scan there.
-    ///
-    /// `tclCompExpr.c:2080-2126` (9.0.4): when `TclParseNumber` stops on a
-    /// `TclIsBareword` byte, C does *not* emit a number — it usually falls
-    /// through and rescans `[A-Za-z0-9_]*` from the start as one BAREWORD.
-    /// Two exceptions put it back on the number path (`goto number`):
-    ///
-    /// * **The run holds a non-bareword character.** C's
-    ///   `TclHasInternalRep(&tclDoubleType)` walk: a double whose spelling
-    ///   contains something a bareword cannot hold (`.`, an exponent sign)
-    ///   stays a number, so the junk after it is its own lexeme. This is why
-    ///   `1.5abc` names only `abc`, and why 8.6's `1.0_2` is
-    ///   `invalid character "_"` rather than naming the whole run.
-    /// * **A binary word operator follows.** `1eq 2` is `1 eq 2` (tclsh: 0).
-    ///   Release-sensitive, hence [`Self::word_operator_follows`]: under 8.6
-    ///   `lt` is not an operator, so `1lt 2` is `invalid bareword "1lt"`.
-    ///
-    /// Everything else is one bareword — `1_eq`, `1abc`, `12x`, `1e_0`,
-    /// `9_ne`, `1_2_eq` — all tclsh-verified on 8.5, 8.6, 9.0 and 9.1. The
-    /// token stays [`ExprTokenType::Number`]; `tcl-syntax` reclassifies an
-    /// invalid one to a bareword, and it can only name the whole run if the
-    /// lexeme was not split here first.
-    fn join_trailing_bareword(&mut self, start: usize) {
-        let end = self.i;
-        if !self.b.get(end).copied().is_some_and(is_bareword_byte) {
-            return;
-        }
-        if !self.b[start..end].iter().copied().all(is_bareword_byte) {
-            return;
-        }
-        if self.word_operator_follows(end) {
-            return;
-        }
-        while self.i < self.b.len() && is_bareword_byte(self.b[self.i]) {
-            self.i += 1;
-        }
     }
 
     fn variable(&mut self) -> ExprToken {
@@ -724,14 +605,6 @@ impl<'s> Inner<'s> {
             ExprTokenType::Bool
         } else if self.irules_operators && irops.contains(text) {
             ExprTokenType::Operator
-        } else if matches!(
-            text,
-            "Inf" | "inf" | "Infinity" | "infinity" | "NaN" | "nan"
-        ) {
-            // IEEE 754 special float literals — Tcl 9.0 recognises
-            // these as numeric literals in expressions, not function
-            // calls.
-            ExprTokenType::Number
         } else {
             ExprTokenType::Function
         };
@@ -776,47 +649,9 @@ impl<'s> Inner<'s> {
         self.tok(ExprTokenType::String, start)
     }
 
-    /// The release-independent half of C's word-operator case: the two
-    /// boundary guards that decide whether `op` at `at` is a standalone
-    /// lexeme rather than part of a neighbouring bareword.
-    ///
-    /// * **Nothing bareword-ish precedes it.** C never checks this explicitly;
-    ///   it falls out of the bareword scan having already consumed `a_eq` /
-    ///   `9_ne` whole. Checking `prev` here reproduces that boundary.
-    /// * **No *letter* follows it.** C's guard is `!isalpha(UCHAR(start[2]))`
-    ///   (`tclCompExpr.c:2014` in 9.0.4) — deliberately not `TclIsBareword`,
-    ///   so a digit or `_` after the operator leaves it an operator and the
-    ///   rest becomes its own lexeme: `1 eq2` is `1 eq 2` (tclsh: 0), and
-    ///   `1 eq_ 2` is `invalid character "_"` on every release 8.4–9.1.
-    fn word_operator_boundary_ok(&self, op: &str, at: usize) -> bool {
-        if at > 0 {
-            let prev = self.b[at - 1];
-            if prev.is_ascii_alphabetic() || prev == b'_' {
-                return false;
-            }
-        }
-        !self
-            .b
-            .get(at + op.len())
-            .is_some_and(u8::is_ascii_alphabetic)
-    }
-
-    /// Whether `op` at `at` is genuinely a binary operator lexeme in this
-    /// release — the faithful `ParseLexeme` answer, boundary guards plus the
-    /// release's own operator table.
-    ///
-    /// Used by [`Self::word_operator_follows`], where the truthful answer is
-    /// what C's `(NODE_TYPE & lexeme) == BINARY` probe needs: `1lt 2` is
-    /// `invalid bareword "1lt"` under 8.6 (no `lt` lexeme to stop the join)
-    /// but `1` `lt` `2` under 9.0.
-    fn word_operator_at(&self, op: &str, at: usize) -> bool {
-        tcl_dialect::is_expr_word_operator(op, self.expr_grammar_base)
-            && self.word_operator_boundary_ok(op, at)
-    }
-
     /// Whether the main scan should emit `op` at `at` as an operator token.
     ///
-    /// Deliberately *weaker* than [`Self::word_operator_at`]: the release gate
+    /// Deliberately *weaker* than [`tcl_dialect::expr_word_operator_boundary_ok`]: the release gate
     /// is applied only where it actually moves a boundary — when a bareword
     /// byte (a digit or `_`) follows, so the run would otherwise fuse into one
     /// bareword. tclsh 8.6 vs 9.0:
@@ -835,29 +670,20 @@ impl<'s> Inner<'s> {
     /// Tcl 9.0+ (TIP 461)", and it can only say so about an operator it can
     /// still see. Suppressing the token here made W003 silent on the very
     /// dialects it targets.
-    fn word_operator_lexeme_at(&self, op: &str, at: usize) -> bool {
-        self.word_operator_boundary_ok(op, at)
-            && (!self
-                .b
-                .get(at + op.len())
-                .copied()
-                .is_some_and(is_bareword_byte)
-                || tcl_dialect::is_expr_word_operator(op, self.expr_grammar_base))
+    fn word_operator_lexeme_at(&self, op: &str, at: usize, after_numeric_lexeme: bool) -> bool {
+        (if after_numeric_lexeme {
+            tcl_dialect::expr_word_operator_right_boundary_ok(self.b, op, at)
+        } else {
+            tcl_dialect::expr_word_operator_boundary_ok(self.b, op, at)
+        }) && (!self
+            .b
+            .get(at + op.len())
+            .copied()
+            .is_some_and(tcl_dialect::is_expr_bareword_byte)
+            || tcl_dialect::is_expr_word_operator(op, self.expr_grammar_base))
     }
 
-    /// Whether any word operator this release has begins at byte `at` — C's
-    /// `ParseLexeme(end, …)` probe at the number/bareword junction, whose
-    /// `(NODE_TYPE & lexeme) == BINARY` test keeps `1eq 2` a number followed
-    /// by an operator instead of one bareword.
-    fn word_operator_follows(&self, at: usize) -> bool {
-        MULTI_OPS.iter().any(|&op| {
-            tcl_dialect::expr_word_operator_since(op).is_some()
-                && self.b[at..].starts_with(op.as_bytes())
-                && self.word_operator_at(op, at)
-        })
-    }
-
-    fn multi_op(&mut self) -> Option<ExprToken> {
+    fn multi_op(&mut self, after_numeric_lexeme: bool) -> Option<ExprToken> {
         for &op in MULTI_OPS {
             // Compare on bytes, not `self.s[self.i..]`: `self.i` is a byte index
             // that the byte-wise scanner can leave *inside* a multi-byte UTF-8
@@ -866,7 +692,7 @@ impl<'s> Inner<'s> {
             // ASCII, so a byte-prefix check is exactly equivalent and total.
             if self.b[self.i..].starts_with(op.as_bytes()) {
                 if tcl_dialect::expr_word_operator_since(op).is_some()
-                    && !self.word_operator_lexeme_at(op, self.i)
+                    && !self.word_operator_lexeme_at(op, self.i, after_numeric_lexeme)
                 {
                     continue;
                 }
@@ -1091,15 +917,25 @@ mod tests {
 
     #[test]
     fn ieee_754_special_literals() {
-        // Tcl 9.0 treats Inf/NaN as numeric literals, not function
-        // names.
-        for word in ["Inf", "inf", "Infinity", "infinity", "NaN", "nan"] {
+        // Tcl's `TclParseNumber` treats these case-insensitively. The shared
+        // scanner also owns the NaN payload and number/bareword junction:
+        // tclsh 8.6.17 and 9.0.3 both accept `iNf`, `NaN(1)`, and
+        // `Infinityeq 1`, but keep `Infinityx` a bareword/function name.
+        for word in [
+            "Inf", "inf", "iNf", "Infinity", "infinity", "NaN", "nan", "NaN(1)",
+        ] {
             assert_eq!(
                 types(word),
                 vec![ExprTokenType::Number],
                 "word `{word}` should tokenise as NUMBER",
             );
         }
+        assert_eq!(
+            texts("Infinityeq 1"),
+            vec!["Infinity", "eq", "1"],
+            "a word operator after a special float starts a new lexeme",
+        );
+        assert_eq!(types("Infinityx"), vec![ExprTokenType::Function]);
     }
 
     #[test]
@@ -1432,6 +1268,97 @@ mod tests {
 #[cfg(test)]
 mod separator_boundary_tests {
     use super::*;
+
+    /// Tcl 8.4's `GetLexeme` takes an integer prefix before it reaches the
+    /// generic function-name/unknown scanner; it does not have the 8.5+
+    /// number-to-bareword rescan. The shared lower scanner must therefore keep
+    /// these token boundaries distinct for the last 8.4 profile.
+    #[test]
+    fn tcl84_keeps_legacy_integer_prefix_boundaries() {
+        let (tokens, unknown) = tokenise_expr_checked("1_eq", Some("tcl8.4"));
+        assert!(
+            unknown,
+            "`_` must be Tcl 8.4's invalid next lexeme: {tokens:?}"
+        );
+        assert_eq!(tokens[0].kind, ExprTokenType::Number);
+        assert_eq!(tokens[0].text, "1");
+
+        for (source, first, second) in [("12x", "12", "x"), ("0x1p2", "0x1", "p2")] {
+            let tokens = tokenise_expr(source, Some("tcl8.4"));
+            assert_eq!(
+                tokens[0].kind,
+                ExprTokenType::Number,
+                "{source}: {tokens:?}"
+            );
+            assert_eq!(tokens[0].text, first, "{source}: {tokens:?}");
+            assert_eq!(tokens[1].text, second, "{source}: {tokens:?}");
+        }
+    }
+
+    /// Explicit-radix spelling validity comes from the shared `NumberSyntax`
+    /// owner. Once a prefix has valid digits, a following release-available
+    /// word operator is a separate lexeme; an invalid radix stays whole.
+    #[test]
+    fn explicit_radix_numbers_stop_before_word_operators() {
+        for (dialect, source, number, operator) in [
+            ("tcl8.6", "0x1ne 1", "0x1", "ne"),
+            ("tcl8.6", "0xfne 1", "0xf", "ne"),
+            ("tcl8.6", "0xffin {255}", "0xff", "in"),
+            ("tcl9.0", "0xfge 15", "0xf", "ge"),
+            ("tcl8.6", "0b1ne 1", "0b1", "ne"),
+            ("tcl8.6", "0o7in {7}", "0o7", "in"),
+            ("tcl8.6", "0b1ni {1}", "0b1", "ni"),
+            ("tcl9.0", "0d9lt 10", "0d9", "lt"),
+            ("tcl9.0", "0d9le 9", "0d9", "le"),
+            ("tcl9.0", "0d9gt 8", "0d9", "gt"),
+            ("tcl9.0", "0d9ge 9", "0d9", "ge"),
+        ] {
+            let tokens = tokenise_expr(source, Some(dialect));
+            assert_eq!(
+                tokens[0].kind,
+                ExprTokenType::Number,
+                "{dialect}: {source}: {tokens:?}"
+            );
+            assert_eq!(tokens[0].text, number, "{dialect}: {source}: {tokens:?}");
+            assert_eq!(tokens[1].text, operator, "{dialect}: {source}: {tokens:?}");
+        }
+        for (dialect, source) in [
+            ("tcl8.6", "0o8ne 1"),
+            ("tcl8.6", "0d9ne 1"),
+            ("tcl9.0", "0b2ne 1"),
+        ] {
+            let tokens = tokenise_expr(source, Some(dialect));
+            assert_eq!(
+                tokens[0].text,
+                source.split_whitespace().next().unwrap(),
+                "{dialect}: {tokens:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ordinary_number_barewords_stay_whole_after_a_nonzero_offset() {
+        for source in ["0 + 1_eq", "0 + 12x"] {
+            let expected = source.split(" + ").nth(1).unwrap();
+            let tokens = tokenise_expr(source, Some("tcl9.0"));
+            assert!(
+                tokens.iter().any(|token| token.text == expected),
+                "{source}: {tokens:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn completed_nan_payload_is_a_number_before_following_bareword() {
+        let tokens = tokenise_expr("NaN(1)x", Some("tcl9.0"));
+        assert_eq!(tokens[0].kind, ExprTokenType::Number, "{tokens:?}");
+        assert_eq!(tokens[0].text, "NaN(1)");
+        assert_eq!(tokens[1].text, "x");
+        assert_eq!(
+            tokenise_expr("NaNx", Some("tcl9.0"))[0].kind,
+            ExprTokenType::Function
+        );
+    }
 
     /// `_` inside a *fraction* changes the lexeme boundary, so unlike the
     /// integer run it has to follow the release. C's bareword scan takes

--- a/rust/tcl-syntax/src/expr/parser.rs
+++ b/rust/tcl-syntax/src/expr/parser.rs
@@ -43,7 +43,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex, OnceLock};
 
-use tcl_dialect::{DialectProfile, NumberSyntax};
+use tcl_dialect::{DialectProfile, NumberSyntax, TclVersion};
 use tcl_lexer::{ExprToken, ExprTokenType, tokenise_expr_checked};
 
 use crate::expr::ast::{BinOp, ExprNode, UnaryOp};
@@ -172,17 +172,25 @@ struct PrattParser<'a> {
     /// Current recursion depth, bounded by [`MAX_EXPR_DEPTH`].
     depth: usize,
     /// The release's numeric-literal grammar, used to reject a `Number` token
-    /// the lexer only *delimited* (see [`Self::number_literal`]).
+    /// the lexer only delimited.
     numbers: NumberSyntax,
+    /// The profile's word-operator grammar, paired with [`Self::numbers`] for
+    /// the shared expression-number boundary validation.
+    expr_grammar_base: Option<TclVersion>,
 }
 
 impl<'a> PrattParser<'a> {
-    fn new(tokens: &'a [ExprToken], numbers: NumberSyntax) -> Self {
+    fn new(
+        tokens: &'a [ExprToken],
+        numbers: NumberSyntax,
+        expr_grammar_base: Option<TclVersion>,
+    ) -> Self {
         Self {
             tokens,
             pos: 0,
             depth: 0,
             numbers,
+            expr_grammar_base,
         }
     }
 
@@ -300,7 +308,7 @@ impl<'a> PrattParser<'a> {
         // what produces `invalid bareword "0o8"` instead of silently evaluating
         // the literal to its own text.
         if tok.kind == ExprTokenType::Number {
-            if !crate::number::is_whole_number(&tok.text, self.numbers) {
+            if !crate::number::is_expr_number(&tok.text, self.numbers, self.expr_grammar_base) {
                 return Err(ParseError);
             }
             let tok = self.advance();
@@ -464,7 +472,11 @@ pub fn parse_expr(source: &str, dialect: Option<&str>) -> ExprNode {
         };
     }
 
-    let mut parser = PrattParser::new(&tokens, numbers_for(dialect, profile));
+    let mut parser = PrattParser::new(
+        &tokens,
+        numbers_for(dialect, profile),
+        profile.expr_grammar_base,
+    );
     match parser.expression(0) {
         Ok(result) if parser.pos >= tokens.len() => result,
         _ => ExprNode::Raw {

--- a/rust/tcl-syntax/src/expr/syntax_error.rs
+++ b/rust/tcl-syntax/src/expr/syntax_error.rs
@@ -36,7 +36,7 @@
 //! The expected strings are pinned by C's own suite: `tests/parseExpr.test`
 //! cases `parseExpr-21.1` … `parseExpr-21.31`.
 
-use tcl_dialect::DialectProfile;
+use tcl_dialect::{DialectProfile, TclVersion};
 use tcl_lexer::{ExprToken, ExprTokenType, tokenise_expr_checked};
 
 /// C's `limit` (`tclCompExpr.c:615`): the longest substring of the expression
@@ -208,6 +208,7 @@ impl ExprSyntaxError {
             source,
             &tokens,
             super::parser::numbers_for(dialect, profile),
+            profile.expr_grammar_base,
         )
         .run()
     }
@@ -427,14 +428,23 @@ struct Scan<'a> {
     /// The release's numeric grammar, so a `Number` token the lexer only
     /// delimited can be re-tested here the way C's `ParseLexeme` does.
     numbers: crate::number::NumberSyntax,
+    /// The paired expression word-operator grammar for the shared numeral
+    /// boundary check.
+    expr_grammar_base: Option<TclVersion>,
 }
 
 impl<'a> Scan<'a> {
-    fn new(source: &'a str, tokens: &'a [ExprToken], numbers: crate::number::NumberSyntax) -> Self {
+    fn new(
+        source: &'a str,
+        tokens: &'a [ExprToken],
+        numbers: crate::number::NumberSyntax,
+        expr_grammar_base: Option<TclVersion>,
+    ) -> Self {
         Self {
             source,
             tokens,
             numbers,
+            expr_grammar_base,
             pos: 0,
             // C seeds the tree with a `START` node, which `IsOperator` accepts.
             expecting: Expecting::Operand,
@@ -497,7 +507,13 @@ impl<'a> Scan<'a> {
             // prefix this release lacks (`0d99` before 9.0) arrives as a
             // `Number`. C classifies exactly those as barewords, with a radix
             // hint where it can guess (`tclCompExpr.c:716-809`).
-            ExprTokenType::Number if !crate::number::is_whole_number(&token.text, self.numbers) => {
+            ExprTokenType::Number
+                if !crate::number::is_expr_number(
+                    &token.text,
+                    self.numbers,
+                    self.expr_grammar_base,
+                ) =>
+            {
                 Some(ExprSyntaxError::bad_numeral(at, &token.text, self.numbers))
             }
             ExprTokenType::Number

--- a/rust/tcl-syntax/src/number.rs
+++ b/rust/tcl-syntax/src/number.rs
@@ -533,6 +533,25 @@ pub fn is_whole_number(text: &str, syntax: NumberSyntax) -> bool {
     parse_whole_with(text, ParseFlags::for_syntax(syntax)).is_some()
 }
 
+/// Whether `text` is one complete expression-number lexeme under this release.
+///
+/// This is the expression-specific companion to [`is_whole_number`]. It first
+/// asks the lower shared boundary owner (`tcl_dialect::scan_expr_number`) to
+/// prove that the token ends where C `ParseLexeme` ends, then uses this module's
+/// value parser to classify it. The split is intentional: the dialect crate
+/// owns byte boundaries below both the lexer and syntax parser, while this
+/// module remains the sole `TclParseNumber` value implementation.
+#[must_use]
+pub fn is_expr_number(
+    text: &str,
+    syntax: NumberSyntax,
+    expr_grammar_base: Option<tcl_dialect::TclVersion>,
+) -> bool {
+    tcl_dialect::scan_expr_number(text.as_bytes(), 0, syntax, expr_grammar_base)
+        .is_some_and(|lexeme| lexeme.end() == text.len())
+        && is_whole_number(text, syntax)
+}
+
 /// Parse a number at the start of `s` (after optional leading whitespace),
 /// returning the classified value and where it ended. Returns `None` if no valid
 /// number begins there. This is the partial form (the lexer/`scan` entry); use
@@ -558,29 +577,33 @@ pub fn parse(s: &str, flags: ParseFlags) -> Option<Parsed> {
 
     // Inf / NaN (alphabetic forms).
     if i < len && matches!(b[i], b'i' | b'I' | b'n' | b'N') {
-        return parse_inf_nan(b, i, negative);
+        return parse_inf_nan(b, i, negative, flags.syntax);
     }
 
-    // Radix prefix, each requiring a following digit, and each gated on the
-    // release that introduced it: `0x` is universal, `0b`/`0o` arrived in 8.5,
-    // `0d` in 9.0. An unavailable prefix simply is not a prefix — `0o17` under
-    // 8.4 parses as the single digit `0` with `o17` left over, which is what
-    // makes it a bareword in an expression.
+    // Radix prefix, each requiring a following digit. `NumberSyntax` owns the
+    // release table (`0x` universally, `0b`/`0o` from 8.5, `0d` from 9.0), so
+    // this value parser and the lower expression-boundary scanner cannot drift.
+    // An unavailable prefix simply is not a prefix — `0o17` under 8.4 parses
+    // as the single digit `0` with `o17` left over, which makes it a bareword
+    // in an expression.
     let mut radix = Radix::Dec;
     let mut int_only_prefix = flags.integer_only;
     if i + 1 < len && b[i] == b'0' {
-        let (r, only) = match b[i + 1] {
-            b'x' | b'X' => (Some(Radix::Hex), true),
-            b'o' | b'O' if flags.syntax.has_binary_octal_prefix() => (Some(Radix::Oct), true),
-            b'b' | b'B' if flags.syntax.has_binary_octal_prefix() => (Some(Radix::Bin), true),
-            b'd' | b'D' if flags.syntax.has_decimal_prefix() => (Some(Radix::Dec), true),
-            _ => (None, false),
-        };
+        let r = flags
+            .syntax
+            .explicit_radix(b[i + 1])
+            .map(|base| match base {
+                2 => Radix::Bin,
+                8 => Radix::Oct,
+                10 => Radix::Dec,
+                16 => Radix::Hex,
+                _ => unreachable!("NumberSyntax only exposes Tcl's four explicit radices"),
+            });
         if let Some(r) = r {
             // Commit to the prefix only if a valid digit follows it.
             if i + 2 < len && digit_val(b[i + 2], r as u32).is_some() {
                 radix = r;
-                int_only_prefix = only; // `0x`/`0o`/`0b`/`0d` are integer forms
+                int_only_prefix = true; // `0x`/`0o`/`0b`/`0d` are integer forms
                 i += 2;
             }
         }
@@ -832,7 +855,7 @@ fn parse_decimal_float(
 }
 
 /// Parse the alphabetic `Inf`/`Infinity`/`NaN`/`NaN(hex)` forms (case-insensitive).
-fn parse_inf_nan(b: &[u8], start: usize, negative: bool) -> Option<Parsed> {
+fn parse_inf_nan(b: &[u8], start: usize, negative: bool, syntax: NumberSyntax) -> Option<Parsed> {
     let len = b.len();
     // Case-insensitive prefix match; returns the end offset if matched.
     let matches_ci = |word: &[u8], at: usize| -> bool {
@@ -858,25 +881,16 @@ fn parse_inf_nan(b: &[u8], start: usize, negative: bool) -> Option<Parsed> {
     if matches_ci(b"nan", start) {
         let mut end = start + 3;
         let mut payload = None;
-        // Optional `(hexdigits)` payload.
-        if end < len && b[end] == b'(' {
-            let p0 = end + 1;
-            let mut p = p0;
-            let mut acc: u64 = 0;
-            while p < len && p - p0 < 16 {
-                match digit_val(b[p], 16) {
-                    Some(d) => {
-                        acc = (acc << 4) | u64::from(d);
-                        p += 1;
-                    }
-                    None => break,
-                }
-            }
-            if p > p0 && p < len && b[p] == b')' {
-                payload = Some(acc);
-                end = p + 1;
-            }
-            // A malformed payload leaves `end` at the bare "NaN".
+        // 8.5+ shares the lower C `TclParseNumber` payload state machine with
+        // the expression lexer: one through thirteen hex digits, ASCII
+        // whitespace ignored, and a fourteenth digit invalidates the whole
+        // parenthesised form. Tcl 8.4 delegates special floats to `strtod`,
+        // whose `GetLexeme` path has no parenthesised payload grammar.
+        if syntax != NumberSyntax::Tcl84
+            && let Some(lexeme) = tcl_dialect::scan_nan_payload(b, end)
+        {
+            payload = Some(lexeme.value());
+            end = lexeme.end();
         }
         return Some(Parsed {
             number: Number::Nan { negative, payload },
@@ -1000,6 +1014,14 @@ mod tests {
                 payload: Some(0x1ff)
             })
         );
+        assert_eq!(
+            n("NaN( 1 2 3 )"),
+            Some(Number::Nan {
+                negative: false,
+                payload: Some(0x123)
+            })
+        );
+        assert_eq!(n("NaN(123456789abcde)"), None);
     }
 
     #[test]
@@ -1163,9 +1185,10 @@ mod tests {
 #[cfg(test)]
 mod dialect_tests {
     use super::{
-        Number, NumberSyntax, Numbers, ParseFlags, parse, parse_whole_with, runtime_syntax,
-        set_runtime_syntax,
+        Number, NumberSyntax, Numbers, ParseFlags, is_expr_number, parse, parse_whole_with,
+        runtime_syntax, set_runtime_syntax,
     };
+    use tcl_dialect::TclVersion;
 
     fn whole(s: &str, syntax: NumberSyntax) -> Option<Number> {
         parse_whole_with(s, ParseFlags::for_syntax(syntax))
@@ -1304,6 +1327,84 @@ mod dialect_tests {
             ..ParseFlags::default()
         };
         assert_eq!(parse_whole_with("1__000", no_sep), None);
+    }
+
+    /// Expression classification consumes the lower shared boundary scanner
+    /// before it asks this module's value parser. These paired rows fail if the
+    /// lexer and syntax parser ever start using different junction rules.
+    #[test]
+    fn expression_number_validation_shares_the_boundary_owner() {
+        assert!(is_expr_number(
+            "1.0_2",
+            NumberSyntax::Tcl90,
+            Some(TclVersion::V9_0)
+        ));
+        assert!(!is_expr_number(
+            "1.0_2",
+            NumberSyntax::Tcl85,
+            Some(TclVersion::V8_6)
+        ));
+        assert!(!is_expr_number(
+            "1_eq",
+            NumberSyntax::Tcl90,
+            Some(TclVersion::V9_0)
+        ));
+        // The value parser consumes the hexadecimal prefix, while the shared
+        // lower boundary scanner restarts at `ne`/`in`/`ge` rather than using
+        // the preceding alpha hex digit as a suffix boundary.
+        for (source, syntax, base, end) in [
+            ("0xfne 1", NumberSyntax::Tcl85, Some(TclVersion::V8_6), 3),
+            (
+                "0xffin {255}",
+                NumberSyntax::Tcl85,
+                Some(TclVersion::V8_6),
+                4,
+            ),
+            ("0xfge 15", NumberSyntax::Tcl90, Some(TclVersion::V9_0), 3),
+        ] {
+            assert_eq!(
+                tcl_dialect::scan_expr_number(source.as_bytes(), 0, syntax, base,)
+                    .unwrap()
+                    .end(),
+                end,
+                "{source}"
+            );
+            assert_eq!(
+                parse(source, ParseFlags::for_syntax(syntax)).unwrap().end,
+                end,
+                "{source}"
+            );
+        }
+        assert!(is_expr_number(
+            "NaN(1)",
+            NumberSyntax::Tcl85,
+            Some(TclVersion::V8_6)
+        ));
+        assert!(is_expr_number(
+            "NaN( 1 2 3 )",
+            NumberSyntax::Tcl90,
+            Some(TclVersion::V9_0)
+        ));
+        assert!(!is_expr_number(
+            "NaN(123456789abcde)",
+            NumberSyntax::Tcl90,
+            Some(TclVersion::V9_0)
+        ));
+        assert!(!is_expr_number(
+            "NaN(1)x",
+            NumberSyntax::Tcl90,
+            Some(TclVersion::V9_0)
+        ));
+        assert!(!is_expr_number(
+            "NaN(1)",
+            NumberSyntax::Tcl84,
+            Some(TclVersion::V8_4)
+        ));
+        assert!(!is_expr_number(
+            "Infinityeq",
+            NumberSyntax::Tcl90,
+            Some(TclVersion::V9_0)
+        ));
     }
 
     /// The three ways a consumer can stand in relation to the release, and what

--- a/rust/tcl-vm/src/expr.rs
+++ b/rust/tcl-vm/src/expr.rs
@@ -951,6 +951,40 @@ mod tests {
         assert_eq!(vm.eval_expr("sqrt(4)").unwrap().to_str().as_ref(), "99");
     }
 
+    /// These boundaries are established below the VM by the shared expression
+    /// numeral scanner. The parse success and error shape are direct tclsh
+    /// 8.6.17 / 9.0.3 oracle rows; if a radix run or completed NaN payload
+    /// fuses with its suffix, `eval_expr` reaches a different AST or misses
+    /// C's bareword. The VM's comparison coercion is intentionally not the
+    /// lexeme-boundary assertion here.
+    #[test]
+    fn shared_expr_numeral_boundaries_reach_the_vm() {
+        let mut vm = Vm::new();
+        vm.set_runtime_version(tcl_dialect::TclVersion::V8_6);
+        assert!(vm.eval_expr("0b1ne 1").is_ok());
+        assert!(vm.eval_expr("0xfne 1").is_ok());
+        assert!(vm.eval_expr("0xffin {255}").is_ok());
+
+        vm.set_runtime_version(tcl_dialect::TclVersion::V9_0);
+        assert!(vm.eval_expr("0xfge 15").is_ok());
+        assert!(vm.eval_expr("0d9lt 10").is_ok());
+        for source in ["0 + 1_eq", "0 + 12x"] {
+            assert!(
+                vm.eval_expr(source)
+                    .unwrap_err()
+                    .message
+                    .contains("invalid bareword"),
+                "{source}"
+            );
+        }
+        assert!(
+            vm.eval_expr("NaN(1)x")
+                .unwrap_err()
+                .message
+                .starts_with("invalid bareword \"x\"")
+        );
+    }
+
     #[test]
     fn int_div_mod_floored() {
         // Tcl: -7 / 2 == -4, -7 % 2 == 1

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -43,7 +43,8 @@
 //! - `gen-editor-catalogs` — generate the Zed/VS Code command & iRules-event
 //!   catalog JSON from the registry (`--check` to verify instead of write).
 //! - `number-drift` — flag hand-rolled Tcl radix-prefix recognition outside
-//!   the one numeral parser (`tcl_syntax::number`).
+//!   `tcl_syntax::number`, and verify expression boundaries use
+//!   `tcl_dialect::scan_expr_number`.
 //! - `owner-resolution` — verify that the shared semantic-owner contract
 //!   resolves to live source files and drift gates.
 
@@ -205,8 +206,8 @@ enum Command {
         check: bool,
     },
 
-    /// Flag hand-rolled Tcl radix-prefix recognition outside the one numeral
-    /// parser (`tcl_syntax::number`) — the numeric-grammar drift class.
+    /// Flag hand-rolled Tcl radix-prefix recognition outside the value parser,
+    /// and verify the single expression-number boundary scanner.
     #[command(name = "number-drift")]
     NumberDrift {
         /// Accepted for symmetry with the other gates (the lint always

--- a/rust/xtask/src/number_drift.rs
+++ b/rust/xtask/src/number_drift.rs
@@ -246,6 +246,14 @@ fn expr_boundary_owner_problems(root: &Path) -> Vec<String> {
              tcl_dialect::scan_nan_payload"
         ));
     }
+    if !read_rust_source(root, NAN_PAYLOAD_CONSUMER).is_some_and(|text| {
+        production_function_contains_call(&text, "is_expr_number", "tcl_dialect::scan_expr_number(")
+    }) {
+        problems.push(format!(
+            "{NAN_PAYLOAD_CONSUMER}: expression-number value classifier does not \
+             call tcl_dialect::scan_expr_number in its production body"
+        ));
+    }
     for &(path, test_name) in EXPR_BOUNDARY_CORPUS {
         if !read_rust_source(root, path)
             .is_some_and(|text| text.contains(&format!("fn {test_name}(")))
@@ -292,6 +300,39 @@ fn declares_nan_payload_scanner(text: &str) -> bool {
         let line = line.trim_start();
         line.starts_with("fn scan_nan_payload(") || line.starts_with("pub fn scan_nan_payload(")
     })
+}
+
+/// Return whether a named production function's body contains `call`.
+///
+/// The owner-wiring gate must inspect the production call site, not merely a
+/// test fixture elsewhere in the same source file. This intentionally small
+/// brace matcher is sufficient for Rust function bodies and avoids treating a
+/// test-only mention as evidence that the production classifier still routes
+/// through the shared boundary owner.
+fn production_function_contains_call(text: &str, function: &str, call: &str) -> bool {
+    let needle = format!("fn {function}(");
+    let Some(signature) = text.find(&needle) else {
+        return false;
+    };
+    let Some(open_rel) = text[signature..].find('{') else {
+        return false;
+    };
+    let open = signature + open_rel;
+    let bytes = text.as_bytes();
+    let mut depth = 0usize;
+    for (offset, byte) in bytes[open..].iter().enumerate() {
+        match byte {
+            b'{' => depth += 1,
+            b'}' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return text[open..open + offset].contains(call);
+                }
+            }
+            _ => {}
+        }
+    }
+    false
 }
 
 fn read_rust_source(root: &Path, relative: &str) -> Option<String> {
@@ -527,6 +568,30 @@ mod tests {
         ));
         assert!(declares_nan_payload_scanner(
             "pub fn scan_nan_payload(source: &[u8]) {}"
+        ));
+    }
+
+    #[test]
+    fn production_call_check_ignores_test_only_mentions() {
+        let test_only = "fn is_expr_number(text: &str) -> bool {\n\
+                         is_whole_number(text)\n\
+                     }\n\
+                     #[test]\n\
+                     fn wiring() { tcl_dialect::scan_expr_number(b\"1\", 0, s, None); }\n";
+        assert!(!production_function_contains_call(
+            test_only,
+            "is_expr_number",
+            "tcl_dialect::scan_expr_number("
+        ));
+
+        let production = "fn is_expr_number(text: &str) -> bool {\n\
+                          tcl_dialect::scan_expr_number(text.as_bytes(), 0, s, None)\
+                              .is_some()\n\
+                      }\n";
+        assert!(production_function_contains_call(
+            production,
+            "is_expr_number",
+            "tcl_dialect::scan_expr_number("
         ));
     }
 }

--- a/rust/xtask/src/number_drift.rs
+++ b/rust/xtask/src/number_drift.rs
@@ -25,11 +25,13 @@
 //! release, and — worse — wrong *silently*, because most numerals read the same
 //! either way.
 //!
-//! The workspace therefore has exactly one numeral parser,
-//! [`tcl_syntax::number`], parameterised by `NumberSyntax`. Everything else
-//! asks it. This lint exists because that rule was broken six separate times
-//! before it was enforced, each independently and each with the same shape —
-//! strip a two-character radix prefix by hand, then call `from_str_radix`:
+//! The workspace therefore has exactly one numeral **value parser**,
+//! [`tcl_syntax::number`], parameterised by `NumberSyntax`, and one expression
+//! **lexeme-boundary scanner**, [`tcl_dialect::scan_expr_number`]. Everything
+//! else asks one of those owners. This lint exists because the value-parser
+//! rule was broken six separate times, each independently and each with the
+//! same shape — strip a two-character radix prefix by hand, then call
+//! `from_str_radix`:
 //!
 //! - `bpf-tcl-ir`'s eBPF lowering — rejected valid 9.x numerals
 //! - `tcl-compiler`'s interval analysis — read `0755` as 755 for an 8.6 target
@@ -49,6 +51,16 @@
 //! recognition — nor a `from_str_radix` whose radix comes from somewhere real
 //! (a `scan` conversion character, a `format` spec), nor prefix literals
 //! appearing as test data. That keeps the signal about the one drift class.
+//!
+//! It also verifies the expression lexer and expression-number classifier both
+//! route through the lower `tcl-dialect` boundary owner, rejects another source
+//! declaring the owner's entry-point names, and requires the owner/consumer
+//! regression corpus for `1_eq`, radix-operator junctions, and NaN payloads.
+//! This is structural wiring evidence, not a proof that arbitrary Rust text
+//! cannot reproduce the semantics; review and the mutation-sensitive tests
+//! remain the semantic backstop. The same check pins `scan_nan_payload`, because
+//! its whitespace and thirteen-digit ceiling must agree between lexing and
+//! `tcl_syntax::number`.
 //!
 //! # Known blind spot
 //!
@@ -74,11 +86,58 @@ use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-/// Files allowed to recognise a Tcl radix prefix: the one numeral parser, and
-/// this lint's own docs and fixtures, which spell the pattern out.
+/// Files allowed to recognise a Tcl radix prefix: the value parser, the lower
+/// expression-boundary scanner, and this lint's own docs and fixtures.
 const SANCTIONED_FILES: &[&str] = &[
+    "rust/tcl-dialect/src/expr_number.rs",
     "rust/tcl-syntax/src/number.rs",
     "rust/xtask/src/number_drift.rs",
+];
+
+/// The lower owner of `ParseLexeme`'s expression-number boundary half.
+const EXPR_BOUNDARY_OWNER: &str = "rust/tcl-dialect/src/expr_number.rs";
+
+/// Higher layers that must call the boundary owner rather than scan again.
+const EXPR_BOUNDARY_CONSUMERS: &[&str] = &[
+    "rust/tcl-lexer/src/expr_lexer.rs",
+    "rust/tcl-syntax/src/number.rs",
+];
+
+/// The NaN payload sub-owner is shared by the lower scanner and value parser.
+const NAN_PAYLOAD_CONSUMER: &str = "rust/tcl-syntax/src/number.rs";
+
+/// Named regression rows that make the lower-owner wiring evidence semantic.
+/// The gate deliberately checks their presence rather than pretending a text
+/// scan proves semantic uniqueness; the Rust tests execute the actual rows.
+const EXPR_BOUNDARY_CORPUS: &[(&str, &str)] = &[
+    (
+        EXPR_BOUNDARY_OWNER,
+        "number_bareword_junctions_match_tcl_parselexeme",
+    ),
+    (
+        EXPR_BOUNDARY_OWNER,
+        "tcl84_getlexeme_keeps_integer_prefixes_separate",
+    ),
+    (
+        EXPR_BOUNDARY_OWNER,
+        "explicit_radix_numerals_split_only_before_available_word_operators",
+    ),
+    (
+        EXPR_BOUNDARY_OWNER,
+        "special_floats_follow_numeric_junction_rules",
+    ),
+    (
+        "rust/tcl-lexer/src/expr_lexer.rs",
+        "explicit_radix_numbers_stop_before_word_operators",
+    ),
+    (
+        "rust/tcl-lexer/src/expr_lexer.rs",
+        "completed_nan_payload_is_a_number_before_following_bareword",
+    ),
+    (
+        NAN_PAYLOAD_CONSUMER,
+        "expression_number_validation_shares_the_boundary_owner",
+    ),
 ];
 
 /// The radix-prefix spellings a Tcl numeral can carry, in both cases.
@@ -123,10 +182,16 @@ pub fn run(_check: bool) -> ExitCode {
         }
     }
 
+    for problem in expr_boundary_owner_problems(&root) {
+        hits += 1;
+        let _ = writeln!(report, "  {problem}");
+    }
+
     if hits == 0 {
         println!(
             "number-drift: OK (no hand-rolled Tcl radix-prefix recognition \
-             outside tcl_syntax::number)"
+             outside tcl_syntax::number; expr lexeme boundaries use \
+             tcl_dialect::scan_expr_number)"
         );
         return ExitCode::SUCCESS;
     }
@@ -134,12 +199,103 @@ pub fn run(_check: bool) -> ExitCode {
         "number-drift: {hits} site(s) recognising a Tcl radix prefix by hand. \
          Tcl's numeral grammar is release-dependent (`0b`/`0o` are 8.5+, `0d` \
          and `_` are 9.0+, leading-zero octal ends at 9.0), so a hand-rolled \
-         parser is silently wrong for some release. Route it through \
-         `tcl_syntax::number` with the target's `NumberSyntax` — or, if the \
+         parser is silently wrong for some release. Route value parsing through \
+         `tcl_syntax::number` with the target's `NumberSyntax`, and expression \
+         lexeme boundaries through `tcl_dialect::scan_expr_number` — or, if the \
          text is not Tcl script (a hex colour, a packet field, a hex-encoded \
          byte string), mark it `// number-drift-ok: <reason>`:\n{report}"
     );
     ExitCode::FAILURE
+}
+
+/// Check the dependency-safe split between value parsing and expression lexing.
+fn expr_boundary_owner_problems(root: &Path) -> Vec<String> {
+    let mut problems = Vec::new();
+    let owner_text = read_rust_source(root, EXPR_BOUNDARY_OWNER);
+    if !owner_text.as_ref().is_some_and(|text| {
+        text.lines()
+            .any(|line| line.trim_start().starts_with("pub fn scan_expr_number("))
+    }) {
+        problems.push(format!(
+            "{EXPR_BOUNDARY_OWNER}: missing public expression-number boundary owner"
+        ));
+    }
+    for consumer in EXPR_BOUNDARY_CONSUMERS {
+        if !read_rust_source(root, consumer)
+            .is_some_and(|text| text.contains("tcl_dialect::scan_expr_number("))
+        {
+            problems.push(format!(
+                "{consumer}: expression-number consumer does not call \
+                 tcl_dialect::scan_expr_number"
+            ));
+        }
+    }
+    if !owner_text.as_ref().is_some_and(|text| {
+        text.lines()
+            .any(|line| line.trim_start().starts_with("pub fn scan_nan_payload("))
+    }) {
+        problems.push(format!(
+            "{EXPR_BOUNDARY_OWNER}: missing public NaN payload boundary owner"
+        ));
+    }
+    if !read_rust_source(root, NAN_PAYLOAD_CONSUMER)
+        .is_some_and(|text| text.contains("tcl_dialect::scan_nan_payload("))
+    {
+        problems.push(format!(
+            "{NAN_PAYLOAD_CONSUMER}: NaN value parser does not call \
+             tcl_dialect::scan_nan_payload"
+        ));
+    }
+    for &(path, test_name) in EXPR_BOUNDARY_CORPUS {
+        if !read_rust_source(root, path)
+            .is_some_and(|text| text.contains(&format!("fn {test_name}(")))
+        {
+            problems.push(format!(
+                "{path}: missing expression-number regression row `{test_name}`"
+            ));
+        }
+    }
+
+    let mut files = Vec::new();
+    collect_rs_files(&root.join("rust"), &mut files);
+    collect_rs_files(&root.join("runtime/rust/src"), &mut files);
+    for path in files {
+        let rel = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        if rel == EXPR_BOUNDARY_OWNER || rel.contains("/tests/") || rel.ends_with("/tests.rs") {
+            continue;
+        }
+        if read_rust_source(root, &rel).is_some_and(|text| {
+            declares_expr_boundary_scanner(&text) || declares_nan_payload_scanner(&text)
+        }) {
+            problems.push(format!(
+                "{rel}: duplicate expression-number or NaN-payload boundary scanner; \
+                 use tcl_dialect's shared owner"
+            ));
+        }
+    }
+    problems
+}
+
+fn declares_expr_boundary_scanner(text: &str) -> bool {
+    text.lines().any(|line| {
+        let line = line.trim_start();
+        line.starts_with("fn scan_expr_number(") || line.starts_with("pub fn scan_expr_number(")
+    })
+}
+
+fn declares_nan_payload_scanner(text: &str) -> bool {
+    text.lines().any(|line| {
+        let line = line.trim_start();
+        line.starts_with("fn scan_nan_payload(") || line.starts_with("pub fn scan_nan_payload(")
+    })
+}
+
+fn read_rust_source(root: &Path, relative: &str) -> Option<String> {
+    std::fs::read_to_string(root.join(relative)).ok()
 }
 
 /// Recursively collect `.rs` files under `dir` (skipping `target/`).
@@ -347,5 +503,30 @@ mod tests {
     fn closure_params_after_a_prefix_literal_do_not_match() {
         let src = "let n = pick(\"0x\") | mask(y);\n";
         assert!(scan(src).is_empty());
+    }
+
+    #[test]
+    fn expression_boundary_owner_is_unique_and_consumed() {
+        assert!(expr_boundary_owner_problems(&crate::util::repo_root()).is_empty());
+    }
+
+    #[test]
+    fn scanner_declaration_check_ignores_a_string_mention() {
+        assert!(!declares_expr_boundary_scanner(
+            "let name = \"fn scan_expr_number(\";"
+        ));
+        assert!(declares_expr_boundary_scanner(
+            "pub fn scan_expr_number(source: &[u8]) {}"
+        ));
+    }
+
+    #[test]
+    fn nan_payload_declaration_check_ignores_a_string_mention() {
+        assert!(!declares_nan_payload_scanner(
+            "let name = \"fn scan_nan_payload(\";"
+        ));
+        assert!(declares_nan_payload_scanner(
+            "pub fn scan_nan_payload(source: &[u8]) {}"
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- close the remaining #1461 cleanup item by moving expression numeral lexeme-boundary scanning into the foundational `tcl-dialect` crate
- make `tcl-lexer` and `tcl-syntax::number` consume the same `scan_expr_number` owner, including the shared NaN-payload boundary scanner
- document the dependency-safe owner split and strengthen `cargo xtask number-drift` to reject duplicate scanners

The value parser remains owned by `tcl-syntax::number`; the lower boundary scanner lives in `tcl-dialect` so the dependency direction stays acyclic.

## Oracle / contract evidence

- scanner rows are source-derived from Tcl 8.4/8.5/8.6/9.0/9.1 `ParseLexeme` / `TclParseNumber` behaviour
- regression coverage includes Tcl 8.4 legacy prefix boundaries, radix/operator junctions, digit-separator release gates, and NaN payload length/whitespace rules
- `cargo xtask owner-resolution` passes
- `cargo xtask number-drift` passes and reports that expr lexeme boundaries use `tcl_dialect::scan_expr_number`

## Validation

- `make rust-check`
- `make prep-pr`
- `cargo test -p tcl-dialect expr_number` (7 passed)
- `cargo test -p tcl-lexer expr_lexer` (44 passed)
- `cargo test -p tcl-syntax --features num-bigint number` (30 passed)
- `cargo test -p tcl-vm expr` (11 unit + 51 expression tests and related expression cases passed)
- `cargo test -p xtask number_drift` (11 passed)

Closes #1461