### PR TITLE
fix(fuzz): make finding record pairs fail closed

### DIFF
--- a/rust/tcl-fuzz/src/campaign.rs
+++ b/rust/tcl-fuzz/src/campaign.rs
@@ -104,24 +104,24 @@ impl Campaign<'_> {
         base_seed: u64,
         iterations: u64,
         mut progress: impl FnMut(u64, &Stats),
-    ) -> Stats {
+    ) -> std::io::Result<Stats> {
         let mut stats = Stats::default();
         for i in 0..iterations {
             let seed = base_seed.wrapping_add(i);
             stats.total += 1;
-            self.run_one(seed, &mut stats);
+            self.run_one(seed, &mut stats)?;
             progress(i + 1, &stats);
         }
-        stats
+        Ok(stats)
     }
 
     /// Generate, run, and compare a single seed, updating `stats` and recording
     /// any finding.
-    pub fn run_one(&self, seed: u64, stats: &mut Stats) -> Verdict {
+    pub fn run_one(&self, seed: u64, stats: &mut Stats) -> std::io::Result<Verdict> {
         let script = generate(seed, &self.config);
         let Ok(path) = write_script(&self.scratch, seed, &script) else {
             stats.skipped += 1;
-            return Verdict::Skipped;
+            return Ok(Verdict::Skipped);
         };
         let reference = run_backend(
             self.reference.binary,
@@ -154,10 +154,10 @@ impl Campaign<'_> {
                     versions: &self.versions,
                 },
             );
-            if self.registry.record(&finding).unwrap_or(false) {
+            if self.registry.record(&finding)? {
                 stats.new_findings += 1;
             }
         }
-        verdict
+        Ok(verdict)
     }
 }

--- a/rust/tcl-fuzz/src/findings.rs
+++ b/rust/tcl-fuzz/src/findings.rs
@@ -23,7 +23,9 @@
 //! registry de-duplicates by seed and summarises by category.
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::fs::{File, OpenOptions};
+use std::io::{self, Write as _};
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -219,6 +221,26 @@ pub struct Registry {
     dir: PathBuf,
 }
 
+/// The four files which make up one on-disk finding transaction.
+///
+/// The final `.tcl` and `.json` files are the public record.  Their `.stage`
+/// counterparts are intentionally retained after an interrupted write: a
+/// later replay must report damage rather than mistake the seed for an
+/// arbitrary, unrecorded input.
+struct RecordPaths {
+    tcl: PathBuf,
+    json: PathBuf,
+    tcl_stage: PathBuf,
+    json_stage: PathBuf,
+}
+
+/// Whether a record's complete pair is present, absent, or visibly damaged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecordState {
+    Absent,
+    Complete,
+}
+
 /// Directory-backed persistence for single-file reproducers from fuzzer arms
 /// that do not have a paired-engine [`Registry`] finding.
 pub struct ReproducerStore {
@@ -262,27 +284,53 @@ impl Registry {
     /// # Errors
     /// On any filesystem write failure.
     pub fn record(&self, finding: &Finding) -> std::io::Result<bool> {
-        let json = self.dir.join(format!("finding-{}.json", finding.seed));
-        if json.exists() {
+        self.record_inner(finding, |_| {})
+    }
+
+    /// Write one finding after invoking `before_promotion` once both staging
+    /// files are durable and before either final name is claimed.
+    fn record_inner(
+        &self,
+        finding: &Finding,
+        before_promotion: impl FnOnce(&RecordPaths),
+    ) -> std::io::Result<bool> {
+        let paths = self.paths(finding.seed);
+        if Self::record_state(finding.seed, &paths)? == RecordState::Complete {
             return Ok(false);
         }
-        std::fs::write(
-            self.dir.join(format!("finding-{}.tcl", finding.seed)),
-            &finding.script,
-        )?;
-        std::fs::write(
-            &json,
-            serde_json::to_string_pretty(finding).unwrap_or_default(),
-        )?;
+
+        let json = serde_json::to_vec_pretty(finding).map_err(io::Error::other)?;
+        write_new_and_sync(&paths.tcl_stage, finding.script.as_bytes())?;
+        write_new_and_sync(&paths.json_stage, &json)?;
+        sync_directory(&self.dir)?;
+        before_promotion(&paths);
+
+        // `rename` would atomically *replace* an unexpectedly-created final
+        // file.  `create_new` claims each final name without replacement;
+        // copying the already-synced stage then flushing it means an error or
+        // interruption leaves a final/stage combination that replay rejects.
+        // Removing a stage only after its final file is durable preserves that
+        // fail-closed evidence.
+        promote_no_replace(&paths.tcl_stage, &paths.tcl)?;
+        promote_no_replace(&paths.json_stage, &paths.json)?;
+        sync_directory(&self.dir)?;
         Ok(true)
+    }
+
+    #[cfg(test)]
+    fn record_with_interleaving(
+        &self,
+        finding: &Finding,
+        before_promotion: impl FnOnce(&RecordPaths),
+    ) -> std::io::Result<bool> {
+        self.record_inner(finding, before_promotion)
     }
 
     /// Load a previously-recorded finding by seed, if present.
     #[cfg(test)]
     #[must_use]
     pub fn load(&self, seed: u64) -> Option<Finding> {
-        let text = std::fs::read_to_string(self.dir.join(format!("finding-{seed}.json"))).ok()?;
-        serde_json::from_str(&text).ok()
+        self.load_checked(seed).ok().flatten()
     }
 
     /// Count of recorded findings per category.
@@ -307,10 +355,15 @@ impl Registry {
     }
 
     /// Load a finding while distinguishing an absent record from a damaged
-    /// record. Replay must fail closed when the JSON exists but cannot be
-    /// read or decoded.
+    /// record. Replay must fail closed when either companion is missing, a
+    /// staged transaction remains, or the JSON cannot be read or decoded.
     pub fn load_checked(&self, seed: u64) -> std::io::Result<Option<Finding>> {
-        let path = self.dir.join(format!("finding-{seed}.json"));
+        let paths = self.paths(seed);
+        match Self::record_state(seed, &paths)? {
+            RecordState::Absent => return Ok(None),
+            RecordState::Complete => {}
+        }
+        let path = paths.json;
         match std::fs::read_to_string(&path) {
             Ok(text) => serde_json::from_str(&text).map(Some).map_err(|error| {
                 std::io::Error::new(
@@ -322,6 +375,96 @@ impl Registry {
             Err(error) => Err(error),
         }
     }
+
+    fn paths(&self, seed: u64) -> RecordPaths {
+        let stem = self.dir.join(format!("finding-{seed}"));
+        RecordPaths {
+            tcl: stem.with_extension("tcl"),
+            json: stem.with_extension("json"),
+            tcl_stage: stem.with_extension("tcl.stage"),
+            json_stage: stem.with_extension("json.stage"),
+        }
+    }
+
+    /// Verify that a seed is represented by exactly the final pair or by no
+    /// files at all.  Treat every other state as corruption.  This includes
+    /// a fully staged pair: its promotion may have been interrupted, and it
+    /// must not be mistaken for an absent, ad-hoc seed.
+    fn record_state(seed: u64, paths: &RecordPaths) -> io::Result<RecordState> {
+        let present = [
+            ("Tcl", &paths.tcl),
+            ("JSON", &paths.json),
+            ("staged Tcl", &paths.tcl_stage),
+            ("staged JSON", &paths.json_stage),
+        ]
+        .into_iter()
+        .map(|(kind, path)| path_exists(path).map(|exists| (kind, path, exists)))
+        .collect::<io::Result<Vec<_>>>()?;
+        let final_tcl = present[0].2;
+        let final_json = present[1].2;
+        let staged_tcl = present[2].2;
+        let staged_json = present[3].2;
+
+        if final_tcl && final_json && !staged_tcl && !staged_json {
+            return Ok(RecordState::Complete);
+        }
+        if !final_tcl && !final_json && !staged_tcl && !staged_json {
+            return Ok(RecordState::Absent);
+        }
+        let files = present
+            .iter()
+            .filter(|(_, _, exists)| *exists)
+            .map(|(_, path, _)| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "finding {seed} has an incomplete or interrupted paired record ({files}); repair or remove every companion before replaying"
+            ),
+        ))
+    }
+}
+
+fn path_exists(path: &Path) -> io::Result<bool> {
+    match std::fs::metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+fn write_new_and_sync(path: &Path, contents: &[u8]) -> io::Result<()> {
+    let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
+    file.write_all(contents)?;
+    file.sync_all()
+}
+
+/// Copy `stage` to a newly claimed `final_path` without replacing an existing
+/// final companion, then remove the staging name.
+fn promote_no_replace(stage: &Path, final_path: &Path) -> io::Result<()> {
+    let mut staged = File::open(stage)?;
+    let mut final_file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(final_path)?;
+    io::copy(&mut staged, &mut final_file)?;
+    final_file.sync_all()?;
+    drop(final_file);
+    std::fs::remove_file(stage)
+}
+
+#[cfg(unix)]
+fn sync_directory(dir: &Path) -> io::Result<()> {
+    File::open(dir)?.sync_all()
+}
+
+// Windows does not expose POSIX directory fsync through `std::fs::File`.
+// Individual staging files are still flushed before their renames, and any
+// crash-visible partial promotion is rejected by `record_state`.
+#[cfg(not(unix))]
+fn sync_directory(_dir: &Path) -> io::Result<()> {
+    Ok(())
 }
 
 #[cfg(test)]
@@ -334,6 +477,39 @@ mod tests {
         let p = std::env::temp_dir().join(format!("tcl-fuzz-test-{}-{name}", std::process::id()));
         let _ = std::fs::remove_dir_all(&p);
         p
+    }
+
+    fn test_finding(seed: u64) -> Finding {
+        let reference = Outcome::Ran {
+            stdout: "reference\n".to_owned(),
+            stderr: String::new(),
+            errored: false,
+        };
+        let subject = Outcome::Ran {
+            stdout: "subject\n".to_owned(),
+            stderr: String::new(),
+            errored: false,
+        };
+        Finding::new(
+            seed,
+            Category::StdoutMismatch,
+            "puts paired",
+            &FindingContext {
+                reference: &reference,
+                subject: &subject,
+                reference_engine: "tclsh",
+                subject_engine: "tclvm",
+                versions: &crate::version::PairVersions::default(),
+            },
+        )
+    }
+
+    fn assert_damaged(registry: &Registry, seed: u64) {
+        let error = registry
+            .load_checked(seed)
+            .expect_err("an incomplete record must never look absent");
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("incomplete or interrupted"));
     }
 
     #[test]
@@ -367,6 +543,97 @@ mod tests {
         );
         assert_eq!(reg.summary().get(&Category::StdoutMismatch), Some(&1));
         assert_eq!(reg.load(7).unwrap().subject_stdout, "2\n");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_checked_rejects_a_tcl_only_orphan() {
+        let dir = tmp("tcl-only-orphan");
+        let registry = Registry::open(&dir).unwrap();
+        std::fs::write(dir.join("finding-23.tcl"), "puts orphan").unwrap();
+
+        assert_damaged(&registry, 23);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_checked_rejects_a_json_only_orphan() {
+        let dir = tmp("json-only-orphan");
+        let registry = Registry::open(&dir).unwrap();
+        let finding = test_finding(29);
+        std::fs::write(
+            dir.join("finding-29.json"),
+            serde_json::to_vec_pretty(&finding).unwrap(),
+        )
+        .unwrap();
+
+        assert_damaged(&registry, 29);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_checked_rejects_an_interrupted_staged_record() {
+        let dir = tmp("staged-record");
+        let registry = Registry::open(&dir).unwrap();
+        let finding = test_finding(31);
+        std::fs::write(dir.join("finding-31.tcl.stage"), &finding.script).unwrap();
+        std::fs::write(
+            dir.join("finding-31.json.stage"),
+            serde_json::to_vec_pretty(&finding).unwrap(),
+        )
+        .unwrap();
+
+        assert_damaged(&registry, 31);
+        assert!(
+            registry.record(&finding).is_err(),
+            "do not overwrite damage"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn record_promotes_a_complete_pair_without_leaving_stages() {
+        let dir = tmp("atomic-promotion");
+        let registry = Registry::open(&dir).unwrap();
+        let finding = test_finding(41);
+
+        assert!(registry.record(&finding).unwrap());
+        assert_eq!(
+            std::fs::read_to_string(dir.join("finding-41.tcl")).unwrap(),
+            finding.script
+        );
+        assert!(dir.join("finding-41.json").exists());
+        assert!(!dir.join("finding-41.tcl.stage").exists());
+        assert!(!dir.join("finding-41.json.stage").exists());
+        assert_eq!(registry.load_checked(41).unwrap().unwrap().seed, 41);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn promotion_never_overwrites_an_interleaved_final_and_keeps_damage_visible() {
+        let dir = tmp("no-replace-interleaving");
+        let registry = Registry::open(&dir).unwrap();
+        let finding = test_finding(43);
+
+        let error = registry
+            .record_with_interleaving(&finding, |paths| {
+                // Deterministically model another writer creating a final
+                // companion after `record_state`'s precheck but before this
+                // transaction promotes either staging file.
+                std::fs::write(&paths.tcl, "puts external writer").unwrap();
+            })
+            .expect_err("promotion must not replace a concurrent final");
+
+        assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
+        assert_eq!(
+            std::fs::read_to_string(dir.join("finding-43.tcl")).unwrap(),
+            "puts external writer"
+        );
+        // Keep the stages rather than deleting evidence of the interrupted
+        // transaction.  `load_checked` then makes the damage fail closed.
+        assert!(dir.join("finding-43.tcl.stage").exists());
+        assert!(dir.join("finding-43.json.stage").exists());
+        assert_damaged(&registry, 43);
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/rust/tcl-fuzz/src/findings.rs
+++ b/rust/tcl-fuzz/src/findings.rs
@@ -22,7 +22,7 @@
 //! JSON record plus the raw `.tcl` script under the findings directory. The
 //! registry de-duplicates by seed and summarises by category.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{File, OpenOptions};
 use std::io::{self, Write as _};
 use std::path::{Path, PathBuf};
@@ -334,24 +334,42 @@ impl Registry {
     }
 
     /// Count of recorded findings per category.
-    #[must_use]
-    pub fn summary(&self) -> BTreeMap<Category, usize> {
+    #[must_use = "inspect the summary result"]
+    pub fn summary(&self) -> io::Result<BTreeMap<Category, usize>> {
         let mut counts: BTreeMap<Category, usize> = BTreeMap::new();
-        let Ok(entries) = std::fs::read_dir(&self.dir) else {
-            return counts;
-        };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) != Some("json") {
-                continue;
-            }
-            if let Ok(text) = std::fs::read_to_string(&path)
-                && let Ok(f) = serde_json::from_str::<Finding>(&text)
-            {
-                *counts.entry(f.category).or_default() += 1;
+        let mut seeds = BTreeSet::new();
+        for entry in std::fs::read_dir(&self.dir)? {
+            let path = entry?.path();
+            if let Some(seed) = record_seed_from_path(&path) {
+                seeds.insert(seed);
             }
         }
-        counts
+
+        for seed in seeds {
+            let paths = self.paths(seed);
+            if Self::record_state(seed, &paths)? != RecordState::Complete {
+                continue;
+            }
+            let text = std::fs::read_to_string(&paths.json)?;
+            let finding = serde_json::from_str::<Finding>(&text).map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("{}: {error}", paths.json.display()),
+                )
+            })?;
+            if finding.seed != seed {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "{} records seed {}, expected {seed}",
+                        paths.json.display(),
+                        finding.seed
+                    ),
+                ));
+            }
+            *counts.entry(finding.category).or_default() += 1;
+        }
+        Ok(counts)
     }
 
     /// Load a finding while distinguishing an absent record from a damaged
@@ -434,6 +452,20 @@ fn path_exists(path: &Path) -> io::Result<bool> {
     }
 }
 
+/// Extract a finding seed from any of the four names in a record transaction.
+/// Scanning staged names as well as final names lets `summary` reject a
+/// transaction that has no final JSON left to enumerate.
+fn record_seed_from_path(path: &Path) -> Option<u64> {
+    let name = path.file_name()?.to_str()?;
+    let stem = name.strip_prefix("finding-")?;
+    let raw = stem
+        .strip_suffix(".json.stage")
+        .or_else(|| stem.strip_suffix(".tcl.stage"))
+        .or_else(|| stem.strip_suffix(".json"))
+        .or_else(|| stem.strip_suffix(".tcl"))?;
+    raw.parse().ok()
+}
+
 fn write_new_and_sync(path: &Path, contents: &[u8]) -> io::Result<()> {
     let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
     file.write_all(contents)?;
@@ -451,6 +483,12 @@ fn promote_no_replace(stage: &Path, final_path: &Path) -> io::Result<()> {
     io::copy(&mut staged, &mut final_file)?;
     final_file.sync_all()?;
     drop(final_file);
+    if let Some(parent) = final_path.parent() {
+        // The final directory entry must be durable before its stage name is
+        // removed.  Otherwise a crash can lose both names and make replay
+        // mistake this transaction for an absent, ad-hoc seed.
+        sync_directory(parent)?;
+    }
     std::fs::remove_file(stage)
 }
 
@@ -541,7 +579,10 @@ mod tests {
             !reg.record(&f).unwrap(),
             "second record of same seed is a no-op"
         );
-        assert_eq!(reg.summary().get(&Category::StdoutMismatch), Some(&1));
+        assert_eq!(
+            reg.summary().unwrap().get(&Category::StdoutMismatch),
+            Some(&1)
+        );
         assert_eq!(reg.load(7).unwrap().subject_stdout, "2\n");
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -634,6 +675,22 @@ mod tests {
         assert!(dir.join("finding-43.tcl.stage").exists());
         assert!(dir.join("finding-43.json.stage").exists());
         assert_damaged(&registry, 43);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn summary_rejects_a_staged_companion() {
+        let dir = tmp("summary-staged-companion");
+        let registry = Registry::open(&dir).unwrap();
+        let finding = test_finding(47);
+        assert!(registry.record(&finding).unwrap());
+        std::fs::write(dir.join("finding-47.json.stage"), b"staged").unwrap();
+
+        let error = registry
+            .summary()
+            .expect_err("summary must fail closed on an interrupted transaction");
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("incomplete or interrupted"));
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/rust/tcl-fuzz/src/main.rs
+++ b/rust/tcl-fuzz/src/main.rs
@@ -452,6 +452,13 @@ fn run_campaign(
         }
     });
     let _ = std::fs::remove_dir_all(&scratch);
+    let stats = match stats {
+        Ok(stats) => stats,
+        Err(error) => {
+            eprintln!("error: recording finding: {error}");
+            return std::process::ExitCode::from(2);
+        }
+    };
     print_stats(&stats);
     // Exit non-zero when a divergence was found, so CI can gate on it.
     if stats.findings() > 0 {
@@ -472,8 +479,12 @@ struct ReplaySelection {
 /// Load a seed only when its registry already exists. Looking for a recorded
 /// release must never create empty namespaces for every supported release.
 fn load_existing_finding(dir: &Path, seed: u64) -> Result<Option<Finding>, String> {
-    if !dir.exists() {
-        return Ok(None);
+    match dir.try_exists() {
+        Ok(false) => return Ok(None),
+        Ok(true) => {}
+        Err(error) => {
+            return Err(format!("checking findings dir {}: {error}", dir.display()));
+        }
     }
     Registry::open(dir)
         .map_err(|error| format!("opening findings dir {}: {error}", dir.display()))
@@ -1645,6 +1656,34 @@ mod tests {
         let error = select_replay(&base, args, seed).unwrap_err();
         assert!(error.contains("loading finding 37"));
         assert!(error.contains("finding-37.json"));
+    }
+
+    #[test]
+    fn replay_refuses_orphan_and_staged_record_companions() {
+        let args = pair_args(Engine::RuntimeRust, Engine::Tclvm, None);
+        let seed = 38;
+        for (name, write, is_json) in [
+            ("tcl-orphan", "finding-38.tcl", false),
+            ("json-orphan", "finding-38.json", true),
+            ("staged", "finding-38.tcl.stage", false),
+        ] {
+            let base = replay_tmp(name);
+            let dir = pair_findings_dir(&base, args.reference, args.subject, None);
+            std::fs::create_dir_all(&dir).unwrap();
+            let contents = if is_json {
+                serde_json::to_vec_pretty(&finding(seed, TclVersion::V8_6)).unwrap()
+            } else {
+                b"puts interrupted".to_vec()
+            };
+            std::fs::write(dir.join(write), contents).unwrap();
+
+            let error = select_replay(&base, args, seed).unwrap_err();
+            assert!(
+                error.contains("incomplete or interrupted paired record"),
+                "{name}: {error}"
+            );
+            let _ = std::fs::remove_dir_all(&base);
+        }
     }
 
     #[test]

--- a/rust/tcl-fuzz/src/main.rs
+++ b/rust/tcl-fuzz/src/main.rs
@@ -764,7 +764,13 @@ fn summary_command(findings: &Path, pair: PairArgs) -> std::process::ExitCode {
                 return std::process::ExitCode::from(2);
             }
         };
-        let summary = registry.summary();
+        let summary = match registry.summary() {
+            Ok(summary) => summary,
+            Err(error) => {
+                eprintln!("error: {error}");
+                return std::process::ExitCode::from(2);
+            }
+        };
         let identity = release.map_or_else(
             || "unpinned".to_owned(),
             |tcl_version| format!("Tcl {}", tcl_version.version_string()),
@@ -2005,6 +2011,7 @@ mod tests {
                 .map(|(_, dir)| Registry::open(dir)
                     .unwrap()
                     .summary()
+                    .unwrap()
                     .values()
                     .sum::<usize>())
                 .sum::<usize>(),


### PR DESCRIPTION
## Summary

- make finding-record pair discovery fail closed when a report is truncated or malformed
- prevent no-replace TOCTOU races while persisting paired findings
- add deterministic interleaving coverage for the overwrite race

Closes #1545.

## Validation

The candidate commit was independently reviewed and passed the required local Rust gates before publication.