### PR TITLE
fix(lsp): gate iRules declaration tokens by context

### DIFF
--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -1460,6 +1460,11 @@ fn push_regsub_subtokens(
 /// excluded) borrowed as `&[&str]`.  The caller builds it once and shares it
 /// with the registry-role and OO-body override passes, so the hot path makes
 /// only a single bridging allocation per command.
+///
+/// `at_top_level` is traversal context rather than command knowledge. The
+/// registry remains the owner of whether a command has a valid iRules
+/// declaration *shape*; this walk owns the separate fact that the command is
+/// actually on the iRules file-level declaration boundary.
 #[allow(clippy::too_many_arguments)] // one override builder threading the whole per-command context
 fn special_arg_kinds(
     source: &str,
@@ -1476,6 +1481,7 @@ fn special_arg_kinds(
     extra_var_write: &FxHashMap<String, Vec<u32>>,
     extra_var_read: &FxHashMap<String, Vec<u32>>,
     extra_command: &FxHashMap<String, Vec<u32>>,
+    at_top_level: bool,
     deferred_role: bool,
 ) -> FxHashMap<u32, ArgOverride> {
     let mut overrides = FxHashMap::default();
@@ -1492,11 +1498,17 @@ fn special_arg_kinds(
             closed,
         )
     });
-    let irules_declaration = declaration_arguments.and_then(|arguments| {
-        registry
-            .irules_top_level_declaration_shape(head, arguments)
-            .or_else(|| irules_registry().irules_top_level_declaration_shape(head, arguments))
-    });
+    let irules_declaration = at_top_level
+        .then(|| {
+            declaration_arguments.and_then(|arguments| {
+                registry
+                    .irules_top_level_declaration_shape(head, arguments)
+                    .or_else(|| {
+                        irules_registry().irules_top_level_declaration_shape(head, arguments)
+                    })
+            })
+        })
+        .flatten();
 
     // `when EVENT` — the literal event-name argument.  Event handlers come
     // from the registry's `IS_EVENT_HANDLER` trait; the event name is the
@@ -4894,6 +4906,7 @@ fn collect_script(
             ctx.extra_var_write,
             ctx.extra_var_read,
             ctx.extra_command,
+            depth == 0,
             deferred_role,
         );
         // A `[list HEAD …]` sitting in a deferred (script) slot *is* the
@@ -5044,6 +5057,10 @@ fn merge_list_quoted_command_overrides(
         ctx.extra_var_write,
         ctx.extra_var_read,
         ctx.extra_command,
+        // A command merely built by `[list ...]` is not a source-level iRules
+        // declaration, even when the surrounding `list` command is at the
+        // file boundary.
+        false,
         // The built command is the invocation itself; nothing further defers
         // it, so its own arguments are decided fresh at the next `[…]` hop.
         false,

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -1212,6 +1212,74 @@ fn irules_registry() -> &'static CommandRegistry {
     IRULES.get_or_init(|| tcl_registry::registry_for_dialect("f5-irules"))
 }
 
+/// Return the source offsets whose commands are admitted by the shared
+/// iRules top-level declaration boundary.
+///
+/// Event handlers come from the registry/syntax owner directly.  Procedures
+/// use the same top-level segmented command stream and registry-owned
+/// declaration shape, because the syntax owner intentionally only exposes the
+/// `when`-specific boundary record.  Recursive walks must consult these facts
+/// rather than infer declaration placement from their own recursion depth:
+/// command identity mutations and the iRules lexer grammar are document facts,
+/// not properties of this token walk.
+fn irules_top_level_declaration_heads(
+    source: &str,
+    identities: &tcl_compiler::head_identity::HeadIdentityMap,
+) -> FxHashSet<u32> {
+    let registry = irules_registry();
+    let mut heads: FxHashSet<u32> =
+        tcl_registry::events::top_level_when_handler_candidates_with_registry_and_head_resolver(
+            source, registry, identities,
+        )
+        .into_iter()
+        .map(|handler| handler.span.start())
+        .collect();
+
+    // The shared syntax boundary parser intentionally models `when`'s
+    // handler-specific grammar.  Procedure declarations use the same
+    // top-level lexer stream and the registry's declaration-shape owner.
+    for seg in segment_commands_with_offset_and_config(
+        source,
+        0,
+        tcl_lexer::LexerConfig::for_file_dialect("f5-irules"),
+    ) {
+        let Some(head_token) = seg.argv.first() else {
+            continue;
+        };
+        let Some(head) = seg.texts.first() else {
+            continue;
+        };
+        let resolved = tcl_registry::events::CommandHeadResolver::resolve(
+            identities,
+            head,
+            head_token.span.start(),
+        );
+        let Some(closed) = tcl_registry::events::closed_braced_argument_words(
+            source,
+            seg.arg_tokens(),
+            seg.arg_single_token(),
+        ) else {
+            continue;
+        };
+        let args: Vec<&str> = seg.args().iter().map(String::as_str).collect();
+        let Some(arguments) = tcl_registry::events::IrulesDeclarationArguments::new(
+            &args,
+            seg.arg_tokens(),
+            seg.arg_single_token(),
+            &closed,
+        ) else {
+            continue;
+        };
+        if matches!(
+            registry.irules_top_level_declaration_shape(resolved.as_ref(), arguments),
+            Some(tcl_registry::events::IrulesTopLevelDeclaration::Procedure { .. })
+        ) {
+            heads.insert(head_token.span.start());
+        }
+    }
+    heads
+}
+
 /// True when `s` looks like an iRules event name (`^[A-Z][A-Z0-9_]+$`).
 fn is_event_name(s: &str) -> bool {
     let bytes = s.as_bytes();
@@ -4267,6 +4335,9 @@ struct ScriptCtx<'a> {
     /// command name passed to a dispatcher highlights as a command.  Empty on
     /// the pure-segmentation path.
     extra_command: &'a FxHashMap<String, Vec<u32>>,
+    /// Source offsets admitted by the shared iRules declaration-boundary
+    /// owner. Empty outside the iRules overlay.
+    irules_top_level_declaration_heads: &'a FxHashSet<u32>,
 }
 
 /// Emit one clause-list *pattern* element.
@@ -4906,7 +4977,8 @@ fn collect_script(
             ctx.extra_var_write,
             ctx.extra_var_read,
             ctx.extra_command,
-            depth == 0,
+            ctx.irules_top_level_declaration_heads
+                .contains(&seg.argv[0].span.start()),
             deferred_role,
         );
         // A `[list HEAD …]` sitting in a deferred (script) slot *is* the
@@ -5911,6 +5983,12 @@ fn collect_entries(
     let head_identities =
         tcl_compiler::head_identity::command_head_identities(source, dialect, registry);
 
+    // The iRules declaration overlay uses the shared top-level boundary facts
+    // (including offset-resolved command identity) rather than this walk's
+    // recursive depth as its placement predicate.
+    let irules_top_level_declaration_heads =
+        irules_top_level_declaration_heads(source, &head_identities);
+
     // Object-handle → class provenance (`set chart [ticklecharts::chart new]`
     // → `chart`), so a `$chart Xaxis -name …` dispatch resolves the method's
     // options through the registry (issue #748).  Empty without a
@@ -5982,6 +6060,7 @@ fn collect_entries(
         extra_var_write: &extra_var_write,
         extra_var_read: &extra_var_read,
         extra_command: &extra_command,
+        irules_top_level_declaration_heads: &irules_top_level_declaration_heads,
     };
     collect_script(ctx, source, 0, &mut entries, 0, false);
 

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -1224,9 +1224,9 @@ fn irules_registry() -> &'static CommandRegistry {
 /// not properties of this token walk.
 fn irules_top_level_declaration_heads(
     source: &str,
+    registry: &CommandRegistry,
     identities: &tcl_compiler::head_identity::HeadIdentityMap,
 ) -> FxHashSet<u32> {
-    let registry = irules_registry();
     let mut heads: FxHashSet<u32> =
         tcl_registry::events::top_level_when_handler_candidates_with_registry_and_head_resolver(
             source, registry, identities,
@@ -5987,7 +5987,7 @@ fn collect_entries(
     // (including offset-resolved command identity) rather than this walk's
     // recursive depth as its placement predicate.
     let irules_top_level_declaration_heads =
-        irules_top_level_declaration_heads(source, &head_identities);
+        irules_top_level_declaration_heads(source, registry, &head_identities);
 
     // Object-handle → class provenance (`set chart [ticklecharts::chart new]`
     // → `chart`), so a `$chart Xaxis -name …` dispatch resolves the method's

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -1235,6 +1235,21 @@ fn irules_top_level_declaration_heads(
         .map(|handler| handler.span.start())
         .collect();
 
+    // Keep the dialect-independent generic-Tcl fallback for built-in iRules
+    // event handlers.  The active registry carries workspace extensions, but
+    // a generic registry does not include `when`; dropping the process-wide
+    // iRules candidates here regresses the existing `when EVENT` colouring in
+    // plain Tcl buffers.
+    heads.extend(
+        tcl_registry::events::top_level_when_handler_candidates_with_registry_and_head_resolver(
+            source,
+            irules_registry(),
+            identities,
+        )
+        .into_iter()
+        .map(|handler| handler.span.start()),
+    );
+
     // The shared syntax boundary parser intentionally models `when`'s
     // handler-specific grammar.  Procedure declarations use the same
     // top-level lexer stream and the registry's declaration-shape owner.

--- a/rust/tcl-lsp-core/tests/semantic_tokens_residual.rs
+++ b/rust/tcl-lsp-core/tests/semantic_tokens_residual.rs
@@ -959,6 +959,53 @@ fn st_irules_declaration_body_shape_gates_event_and_proc_definition_tokens() {
 }
 
 #[test]
+fn st_irules_declaration_tokens_require_source_top_level() {
+    // The registry owns valid declaration shape, but only commands at the
+    // iRules file boundary are declarations. A `when` or `proc` nested in a
+    // body / command substitution may look shape-valid to the registry while
+    // being placement-invalid in an iRule.
+    let r = irules_registry();
+    let src = concat!(
+        "when HTTP_REQUEST {}\n",
+        "proc top_level {} {}\n",
+        "when HTTP_REQUEST { when CLIENT_DATA {} }\n",
+        "proc outer {} { when CLIENT_DATA {} }\n",
+        "set ignored [when HTTP_RESPONSE {}]\n",
+        "if {1} { proc inner {} {} }\n",
+    );
+    let toks = decode_with(src, "f5-irules", &r);
+
+    assert!(
+        toks.iter()
+            .any(|t| t.line == 0 && t.character == 5 && t.ttype == "event"),
+        "a valid top-level handler must remain an event: {toks:?}",
+    );
+    assert!(
+        toks.iter()
+            .any(|t| t.line == 1 && t.character == 5 && t.ttype == "function"),
+        "a valid top-level proc name must remain a definition: {toks:?}",
+    );
+
+    for (line, character) in [(2, 25), (3, 21), (4, 18)] {
+        let kind = toks
+            .iter()
+            .find(|t| t.line == line && t.character == character)
+            .map(|t| t.ttype.as_str());
+        assert_eq!(
+            kind,
+            Some("string"),
+            "nested `when` at {line}:{character} must not receive an event override: {toks:?}",
+        );
+    }
+    assert!(
+        !toks
+            .iter()
+            .any(|t| t.line == 5 && t.character == 14 && t.ttype == "function"),
+        "a nested iRules `proc` name must not receive a definition override: {toks:?}",
+    );
+}
+
+#[test]
 fn st_irules_object_ref_in_multiline_body_is_object_token() {
     // `pool /Common/web_pool` inside a multi-line `when` body — the body is
     // tokenised by recursion; the object overlay marks the partitioned pool

--- a/rust/tcl-lsp-core/tests/semantic_tokens_residual.rs
+++ b/rust/tcl-lsp-core/tests/semantic_tokens_residual.rs
@@ -1032,6 +1032,23 @@ fn st_irules_custom_registry_proc_is_a_declaration() {
 }
 
 #[test]
+fn st_irules_event_fallback_survives_generic_tcl_registry() {
+    // `when EVENT` has intentionally been event-coloured in generic Tcl
+    // buffers for years.  The active generic registry has no iRules `when`
+    // spec, so the declaration-boundary candidate set must retain the
+    // built-in iRules fallback as well as workspace extensions.
+    let src = "when HTTP_REQUEST {}\n";
+    let toks = decode(src, "tcl8.6");
+    assert_eq!(
+        toks.iter()
+            .find(|t| t.line == 0 && t.character == 5)
+            .map(|t| t.ttype.as_str()),
+        Some("event"),
+        "generic Tcl must retain dialect-independent event colouring: {toks:?}",
+    );
+}
+
+#[test]
 fn st_irules_declaration_boundary_tracks_resolved_head_identity() {
     // The shared top-level boundary owner resolves command identity at the
     // source offset: redefining `when` means the later spelling is no longer

--- a/rust/tcl-lsp-core/tests/semantic_tokens_residual.rs
+++ b/rust/tcl-lsp-core/tests/semantic_tokens_residual.rs
@@ -53,7 +53,7 @@ use std::collections::HashSet;
 
 use tcl_lsp_core::definition::LspRange;
 use tcl_lsp_core::semantic_tokens::{full, legend_token_types, range};
-use tcl_registry::{CommandRegistry, registry_for_dialect};
+use tcl_registry::{ArgRole, Arity, CommandRegistry, CommandSpec, Traits, registry_for_dialect};
 
 fn reg() -> &'static CommandRegistry {
     registry_for_dialect("tcl8.6")
@@ -1002,6 +1002,32 @@ fn st_irules_declaration_tokens_require_source_top_level() {
             .iter()
             .any(|t| t.line == 5 && t.character == 14 && t.ttype == "function"),
         "a nested iRules `proc` name must not receive a definition override: {toks:?}",
+    );
+}
+
+#[test]
+fn st_irules_custom_registry_proc_is_a_declaration() {
+    // A workspace `.tclspec` pack can add an iRules procedure definer.  The
+    // declaration-boundary scan must use that active registry, rather than
+    // the process-wide built-in iRules registry, to admit the name override.
+    let mut r = irules_registry();
+    r.insert(CommandSpec {
+        name: "custom_proc",
+        traits: Traits::DEFINES_PROCEDURE | Traits::IRULES_TOP_LEVEL_ONLY,
+        arity: Arity::exact(3),
+        arg_roles: &[
+            (0, ArgRole::Name),
+            (1, ArgRole::ParamList),
+            (2, ArgRole::Body),
+        ],
+        ..CommandSpec::DEFAULT
+    });
+    let src = "custom_proc declared {} { return }\n";
+    let toks = decode_with(src, "f5-irules", &r);
+    assert!(
+        toks.iter()
+            .any(|t| t.line == 0 && t.character == 12 && t.ttype == "function"),
+        "the custom registry definer's name must be a function definition: {toks:?}",
     );
 }
 

--- a/rust/tcl-lsp-core/tests/semantic_tokens_residual.rs
+++ b/rust/tcl-lsp-core/tests/semantic_tokens_residual.rs
@@ -1006,6 +1006,28 @@ fn st_irules_declaration_tokens_require_source_top_level() {
 }
 
 #[test]
+fn st_irules_declaration_boundary_tracks_resolved_head_identity() {
+    // The shared top-level boundary owner resolves command identity at the
+    // source offset: redefining `when` means the later spelling is no longer
+    // an iRules event handler, even though its words retain declaration shape.
+    let r = irules_registry();
+    let src = "proc when {args} {}\nwhen HTTP_REQUEST {}\n";
+    let toks = decode_with(src, "f5-irules", &r);
+    assert!(
+        toks.iter()
+            .any(|t| t.line == 0 && t.character == 5 && t.ttype == "function"),
+        "the redefining proc name remains a definition: {toks:?}",
+    );
+    assert_eq!(
+        toks.iter()
+            .find(|t| t.line == 1 && t.character == 5)
+            .map(|t| t.ttype.as_str()),
+        Some("string"),
+        "a rebound `when` must not receive an event override: {toks:?}",
+    );
+}
+
+#[test]
 fn st_irules_object_ref_in_multiline_body_is_object_token() {
     // `pool /Common/web_pool` inside a multi-line `when` body — the body is
     // tokenised by recursion; the object overlay marks the partitioned pool


### PR DESCRIPTION
## Summary
- gate iRules event/procedure declaration semantic-token overrides on actual source top-level context
- keep registry-owned declaration shape logic unchanged
- cover nested bodies, command substitutions, and top-level declarations with regression tests

## Validation
- `make rust-check`
- `make prep-pr`

Closes #1544.