### PR TITLE
refactor(analyser): add diagnostic builder

### DIFF
--- a/rust/tcl-compiler/src/analyser/bounds_checks.rs
+++ b/rust/tcl-compiler/src/analyser/bounds_checks.rs
@@ -90,25 +90,23 @@ pub(crate) fn loop_termination_diagnostics(
 
     match condition_constant(cond_text) {
         Some(false) => {
-            return vec![Diagnostic {
-                code: DiagCode::W240,
-                span: cond_tok.span,
-                message: format!("{cmd_name} condition is constant false; body never executes."),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            }];
+            return vec![crate::analyser::types::Diagnostic::new(
+                DiagCode::W240,
+                cond_tok.span,
+                format!("{cmd_name} condition is constant false; body never executes."),
+                Severity::Warning,
+            )];
         }
         Some(true) if !body_may_exit(body_text, registry, lexer_config) => {
-            return vec![Diagnostic {
-                code: DiagCode::W241,
-                span: cond_tok.span,
-                message: format!(
+            return vec![crate::analyser::types::Diagnostic::new(
+                DiagCode::W241,
+                cond_tok.span,
+                format!(
                     "{cmd_name} is provably infinite: condition is constant true and the body \
                      never leaves the loop (no break/return/error/exit/throw/tailcall)."
                 ),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            }];
+                Severity::Warning,
+            )];
         }
         Some(true) => return Vec::new(),
         None => {}
@@ -125,13 +123,12 @@ pub(crate) fn loop_termination_diagnostics(
             lexer_config,
         )
     {
-        return vec![Diagnostic {
-            code: DiagCode::W241,
-            span: cond_tok.span,
-            message: format!("for loop is provably infinite: {reason}"),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        }];
+        return vec![crate::analyser::types::Diagnostic::new(
+            DiagCode::W241,
+            cond_tok.span,
+            format!("for loop is provably infinite: {reason}"),
+            Severity::Warning,
+        )];
     }
 
     // W242 (default-off): a counter variable appears in the condition but
@@ -142,16 +139,15 @@ pub(crate) fn loop_termination_diagnostics(
     if let Some(var) = extract_counter_name(cond_text)
         && !loop_modifies_var(&var, step_text, body_text, registry, lexer_config)
     {
-        return vec![Diagnostic {
-            code: DiagCode::W242,
-            span: cond_tok.span,
-            message: format!(
+        return vec![crate::analyser::types::Diagnostic::new(
+            DiagCode::W242,
+            cond_tok.span,
+            format!(
                 "{cmd_name} termination cannot be proven: variable '{var}' in the \
                      condition is never modified by the step or body."
             ),
-            severity: Severity::Hint,
-            fixes: Vec::new(),
-        }];
+            Severity::Hint,
+        )];
     }
     Vec::new()
 }
@@ -602,17 +598,16 @@ pub(crate) fn list_index_diagnostics(
     } else {
         "lreplace touches no element (first > last after clamping)".to_string()
     };
-    vec![Diagnostic {
-        code: DiagCode::W230,
-        span: tcl_lexer::Span::new(lo_token.span.start(), hi_token.span.end()),
-        message: format!(
+    vec![crate::analyser::types::Diagnostic::new(
+        DiagCode::W230,
+        tcl_lexer::Span::new(lo_token.span.start(), hi_token.span.end()),
+        format!(
             "{verb}: first='{lo_text}' resolves to {lo_index}, last='{hi_text}' resolves \
              to {hi_index} (list has {length} element{}).",
             if length == 1 { "" } else { "s" }
         ),
-        severity: Severity::Warning,
-        fixes: Vec::new(),
-    }]
+        Severity::Warning,
+    )]
 }
 
 /// The per-index `lindex` arm of W230.
@@ -636,17 +631,16 @@ fn lindex_diagnostics(
         if (0..length).contains(&resolved) {
             continue;
         }
-        out.push(Diagnostic {
-            code: DiagCode::W230,
-            span: idx_tok.span,
-            message: format!(
+        out.push(crate::analyser::types::Diagnostic::new(
+            DiagCode::W230,
+            idx_tok.span,
+            format!(
                 "Index '{}' {}; lindex silently returns empty string.",
                 idx_text.trim(),
                 describe_index(resolved, length)
             ),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        });
+            Severity::Warning,
+        ));
     }
     out
 }
@@ -699,16 +693,15 @@ pub(crate) fn lset_index_diagnostics(
         if let Some(n) = absolute_index(stripped, numbers)
             && n < 0
         {
-            out.push(Diagnostic {
-                code: DiagCode::W231,
-                span: idx_tok.span,
-                message: format!(
+            out.push(crate::analyser::types::Diagnostic::new(
+                DiagCode::W231,
+                idx_tok.span,
+                format!(
                     "lset index '{stripped}' is negative; \
                          raises 'index out of range' at runtime."
                 ),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+                Severity::Warning,
+            ));
             continue;
         }
         // `lset` accepts the append slot (`index == length`); only
@@ -718,17 +711,16 @@ pub(crate) fn lset_index_diagnostics(
                 continue;
             };
             if resolved < 0 || resolved > length {
-                out.push(Diagnostic {
-                    code: DiagCode::W231,
-                    span: idx_tok.span,
-                    message: format!(
+                out.push(crate::analyser::types::Diagnostic::new(
+                    DiagCode::W231,
+                    idx_tok.span,
+                    format!(
                         "lset index '{stripped}' {}; \
                          raises 'index out of range' at runtime.",
                         describe_index(resolved, length)
                     ),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                    Severity::Warning,
+                ));
             }
         }
     }
@@ -933,15 +925,12 @@ fn string_single_index(
     if let Some(n) = absolute_index(stripped, numbers)
         && n < 0
     {
-        return vec![Diagnostic {
-            code: DiagCode::W232,
-            span: idx_tok.span,
-            message: format!(
-                "string {sub}: index '{stripped}' is negative; result is empty or a no-op."
-            ),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        }];
+        return vec![crate::analyser::types::Diagnostic::new(
+            DiagCode::W232,
+            idx_tok.span,
+            format!("string {sub}: index '{stripped}' is negative; result is empty or a no-op."),
+            Severity::Warning,
+        )];
     }
     // `string insert` clamps other overshoots; only `string index`
     // flags an in-bounds miss.
@@ -950,16 +939,15 @@ fn string_single_index(
         && let Some(resolved) = resolve_index(stripped, len, numbers)
         && !(0..len).contains(&resolved)
     {
-        return vec![Diagnostic {
-            code: DiagCode::W232,
-            span: idx_tok.span,
-            message: format!(
+        return vec![crate::analyser::types::Diagnostic::new(
+            DiagCode::W232,
+            idx_tok.span,
+            format!(
                 "string index: '{stripped}' {}; returns empty string.",
                 describe_index_string(resolved, len)
             ),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        }];
+            Severity::Warning,
+        )];
     }
     Vec::new()
 }
@@ -996,16 +984,15 @@ fn string_pair_index(
     ) && f < 0
         && l < 0
     {
-        return vec![Diagnostic {
-            code: DiagCode::W232,
+        return vec![crate::analyser::types::Diagnostic::new(
+            DiagCode::W232,
             span,
-            message: format!(
+            format!(
                 "string {sub}: both indices are negative ('{first_text}', '{last_text}'); \
                      {verb}."
             ),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        }];
+            Severity::Warning,
+        )];
     }
     let Some(len) = str_len else {
         return Vec::new();
@@ -1019,17 +1006,16 @@ fn string_pair_index(
     if !pair_slice_empty(first_val, last_val, len) {
         return Vec::new();
     }
-    vec![Diagnostic {
-        code: DiagCode::W232,
+    vec![crate::analyser::types::Diagnostic::new(
+        DiagCode::W232,
         span,
-        message: format!(
+        format!(
             "string {sub}: {verb}: first='{first_text}' resolves to {first_val}, \
              last='{last_text}' resolves to {last_val} (string has {len} character{}).",
             if len == 1 { "" } else { "s" }
         ),
-        severity: Severity::Warning,
-        fixes: Vec::new(),
-    }]
+        Severity::Warning,
+    )]
 }
 
 /// Human-readable description of a resolved out-of-range string index.

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -38,7 +38,7 @@ use crate::segmenter::SegmentedCommand;
 use crate::signature_scan::command_prefix::CommandPrefixWords;
 
 use super::state::Analyser;
-use super::types::{CodeFix, Diagnostic, Severity};
+use super::types::{CodeFix, Severity};
 
 /// A command head collected from a `[...]` substitution / expression scan,
 /// ready to push as a `command_invocations` entry:
@@ -206,18 +206,19 @@ impl Analyser {
             // never the right failure mode either way (issue #996).
             if !self.structure_only && !self.e207_emitted {
                 self.e207_emitted = true;
-                self.result.diagnostics.push(Diagnostic {
-                    code: DiagCode::E207,
-                    span: body_tok.span,
-                    message: format!(
-                        "nesting depth exceeds the analysis limit ({} levels) — \
+                self.result
+                    .diagnostics
+                    .push(crate::analyser::types::Diagnostic::new(
+                        DiagCode::E207,
+                        body_tok.span,
+                        format!(
+                            "nesting depth exceeds the analysis limit ({} levels) — \
                          diagnostics for this body and anything nested inside it are not \
                          collected",
-                        MAX_BODY_DEPTH.0
-                    ),
-                    severity: Severity::Error,
-                    fixes: Vec::new(),
-                });
+                            MAX_BODY_DEPTH.0
+                        ),
+                        Severity::Error,
+                    ));
             }
             self.body_depth -= 1;
             return;
@@ -425,17 +426,18 @@ impl Analyser {
             return false;
         }
         if !self.structure_only {
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: tcl_core_types::DiagCode::W129,
-                span: cmd_tok.span,
-                message: format!(
-                    "'{cmd_name}' is hidden in this safe interpreter — the call \
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    tcl_core_types::DiagCode::W129,
+                    cmd_tok.span,
+                    format!(
+                        "'{cmd_name}' is hidden in this safe interpreter — the call \
                      raises `invalid command name` unless it is exposed or \
                      invoked via `interp invokehidden`"
-                ),
-                severity: super::types::Severity::Warning,
-                fixes: Vec::new(),
-            });
+                    ),
+                    super::types::Severity::Warning,
+                ));
         }
         true
     }
@@ -1467,16 +1469,17 @@ impl Analyser {
                 .as_ref()
                 .is_none_or(|r| r.get(cmd_name).is_none())
         {
-            self.result.diagnostics.push(Diagnostic {
-                code: DiagCode::W125,
-                span: cmd_tok.span,
-                message: format!(
-                    "\"{cmd_name}\" used as standalone command — should be part of \
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    DiagCode::W125,
+                    cmd_tok.span,
+                    format!(
+                        "\"{cmd_name}\" used as standalone command — should be part of \
                      \"{parent}\" (check for misplaced newline)"
-                ),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+                    ),
+                    Severity::Warning,
+                ));
         }
 
         let irules_proc_dispatch_context = self.profile.is_irules()
@@ -1491,14 +1494,14 @@ impl Analyser {
             } else {
                 format!(" {}", args.join(" "))
             };
-            self.result.diagnostics.push(Diagnostic {
-                code: DiagCode::Irule5005,
-                span: cmd_tok.span,
-                message: format!(
-                    "iRules procs must be invoked with 'call': call {cmd_name}{suffix}"
-                ),
-                severity: Severity::Error,
-                fixes: vec![CodeFix {
+            self.result.diagnostics.push(
+                crate::analyser::types::Diagnostic::new(
+                    DiagCode::Irule5005,
+                    cmd_tok.span,
+                    format!("iRules procs must be invoked with 'call': call {cmd_name}{suffix}"),
+                    Severity::Error,
+                )
+                .with_fixes(vec![CodeFix {
                     span: cmd_tok.span,
                     new_text: format!("call {cmd_name}"),
                     description: format!("Use 'call {cmd_name}'"),
@@ -1506,8 +1509,8 @@ impl Analyser {
                     // iRules proc, but the analyser cannot prove the head resolves to a
                     // proc rather than to a renamed or aliased command.
                     safety: crate::irules_checks::FixSafety::RequiresReview,
-                }],
-            });
+                }]),
+            );
         }
     }
 
@@ -1763,16 +1766,17 @@ impl Analyser {
             {
                 continue;
             }
-            self.result.diagnostics.push(Diagnostic {
-                code: DiagCode::W148,
-                span: token.span,
-                message: format!(
-                    "Numeral '{}' is not accepted by the resolved Tcl numeral grammar.",
-                    arg.trim()
-                ),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    DiagCode::W148,
+                    token.span,
+                    format!(
+                        "Numeral '{}' is not accepted by the resolved Tcl numeral grammar.",
+                        arg.trim()
+                    ),
+                    Severity::Warning,
+                ));
         }
     }
 

--- a/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
@@ -135,16 +135,17 @@ impl Analyser {
                 if !rebound.contains(&nqn(command)) {
                     continue; // never bound here → an ordinary external command
                 }
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W128,
-                    span: *span,
-                    message: format!(
-                        "Command '{command}' was renamed or deleted earlier in this \
+                self.result
+                    .diagnostics
+                    .push(crate::analyser::types::Diagnostic::new(
+                        DiagCode::W128,
+                        *span,
+                        format!(
+                            "Command '{command}' was renamed or deleted earlier in this \
 file; this call falls through to the 'unknown' handler."
-                    ),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                        ),
+                        Severity::Warning,
+                    ));
             }
         }
     }
@@ -410,13 +411,14 @@ file; this call falls through to the 'unknown' handler."
             if let Some(similar) = find_case_mismatch(var, defined_vars) {
                 let _ = write!(message, "; did you mean '{similar}'?");
             }
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W220,
-                span,
-                message,
-                severity: Severity::Hint,
-                fixes: Vec::new(),
-            });
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    DiagCode::W220,
+                    span,
+                    message,
+                    Severity::Hint,
+                ));
         }
     }
 
@@ -688,13 +690,14 @@ file; this call falls through to the 'unknown' handler."
             if let Some(similar) = find_case_mismatch(&var, defined_vars) {
                 let _ = write!(message, "; did you mean '{similar}'?");
             }
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W211,
-                span,
-                message,
-                severity: Severity::Hint,
-                fixes: Vec::new(),
-            });
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    DiagCode::W211,
+                    span,
+                    message,
+                    Severity::Hint,
+                ));
         }
     }
 
@@ -773,13 +776,14 @@ file; this call falls through to the 'unknown' handler."
                      with static value '{pretty}'; \
                      did you mean to assign a different variable?"
                 );
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::H300,
-                    span,
-                    message,
-                    severity: Severity::Hint,
-                    fixes: Vec::new(),
-                });
+                self.result
+                    .diagnostics
+                    .push(crate::analyser::types::Diagnostic::new(
+                        DiagCode::H300,
+                        span,
+                        message,
+                        Severity::Hint,
+                    ));
             }
         }
     }
@@ -942,13 +946,14 @@ file; this call falls through to the 'unknown' handler."
                 "Parameter '{param}' of proc '{name}' is unused",
                 name = ir_proc.qualified_name,
             );
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W214,
-                span: param_spans.get(idx).copied().unwrap_or(ir_proc.span),
-                message,
-                severity: Severity::Hint,
-                fixes: Vec::new(),
-            });
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    DiagCode::W214,
+                    param_spans.get(idx).copied().unwrap_or(ir_proc.span),
+                    message,
+                    Severity::Hint,
+                ));
         }
     }
 
@@ -1165,13 +1170,14 @@ file; this call falls through to the 'unknown' handler."
             if let Some(similar) = undefined_var_suggestion(&var, defined_vars) {
                 let _ = write!(message, "; did you mean '{similar}'?");
             }
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W210,
-                span,
-                message,
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    DiagCode::W210,
+                    span,
+                    message,
+                    Severity::Warning,
+                ));
         }
     }
 
@@ -1277,13 +1283,15 @@ file; this call falls through to the 'unknown' handler."
                 // the same fix the LSP layer synthesises, now carried on the
                 // diagnostic itself so every editor surfaces it uniformly.
                 let (diag_span, fixes) = w213_span_and_fix(fu, tokens.as_ref(), var, span);
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W213,
-                    span: diag_span,
-                    message,
-                    severity: Severity::Warning,
-                    fixes,
-                });
+                self.result.diagnostics.push(
+                    crate::analyser::types::Diagnostic::new(
+                        DiagCode::W213,
+                        diag_span,
+                        message,
+                        Severity::Warning,
+                    )
+                    .with_fixes(fixes),
+                );
                 continue;
             }
             // A use site that itself safely initialises the variable
@@ -1410,13 +1418,14 @@ file; this call falls through to the 'unknown' handler."
                 if let Some(similar) = undefined_var_suggestion(&name, defined_vars) {
                     let _ = write!(message, "; did you mean '{similar}'?");
                 }
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W210,
-                    span,
-                    message,
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                self.result
+                    .diagnostics
+                    .push(crate::analyser::types::Diagnostic::new(
+                        DiagCode::W210,
+                        span,
+                        message,
+                        Severity::Warning,
+                    ));
             }
         }
     }
@@ -1602,13 +1611,14 @@ file; this call falls through to the 'unknown' handler."
                     if let Some(similar) = undefined_var_suggestion(name, defined_vars) {
                         let _ = write!(message, "; did you mean '{similar}'?");
                     }
-                    self.result.diagnostics.push(super::types::Diagnostic {
-                        code: DiagCode::W210,
-                        span,
-                        message,
-                        severity: Severity::Warning,
-                        fixes: Vec::new(),
-                    });
+                    self.result
+                        .diagnostics
+                        .push(crate::analyser::types::Diagnostic::new(
+                            DiagCode::W210,
+                            span,
+                            message,
+                            Severity::Warning,
+                        ));
                 }
             }
         }
@@ -1786,15 +1796,16 @@ file; this call falls through to the 'unknown' handler."
                 (DiagCode::I230, msg)
             };
 
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code,
-                span,
-                message,
-                // I230/I231 are observational (LSP `Information`);
-                // they previously collapsed to `Hint`.
-                severity: Severity::Info,
-                fixes: Vec::new(),
-            });
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    code,
+                    span,
+                    message,
+                    // I230/I231 are observational (LSP `Information`);
+                    // they previously collapsed to `Hint`.
+                    Severity::Info,
+                ));
         }
     }
 
@@ -1852,14 +1863,15 @@ file; this call falls through to the 'unknown' handler."
                     cb.condition,
                 )
             };
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::I230,
-                span,
-                message,
-                // I230 is observational (LSP `Information`).
-                severity: Severity::Info,
-                fixes: Vec::new(),
-            });
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    DiagCode::I230,
+                    span,
+                    message,
+                    // I230 is observational (LSP `Information`).
+                    Severity::Info,
+                ));
         }
     }
 
@@ -1950,13 +1962,14 @@ file; this call falls through to the 'unknown' handler."
                             "Variable '${name}' passed as channel to '{command}' \
                              has type {type_label}, not CHANNEL.",
                         );
-                        self.result.diagnostics.push(super::types::Diagnostic {
-                            code: DiagCode::W126,
-                            span: arg_span,
-                            message,
-                            severity: Severity::Warning,
-                            fixes: Vec::new(),
-                        });
+                        self.result
+                            .diagnostics
+                            .push(crate::analyser::types::Diagnostic::new(
+                                DiagCode::W126,
+                                arg_span,
+                                message,
+                                Severity::Warning,
+                            ));
                     } else {
                         // Literal — strip surrounding braces / quotes.
                         let literal = arg_text
@@ -1974,13 +1987,14 @@ file; this call falls through to the 'unknown' handler."
                             "String literal '{literal}' used as channel argument to \
                              '{command}' — expected a channel from open/socket/chan create.",
                         );
-                        self.result.diagnostics.push(super::types::Diagnostic {
-                            code: DiagCode::W126,
-                            span: arg_span,
-                            message,
-                            severity: Severity::Warning,
-                            fixes: Vec::new(),
-                        });
+                        self.result
+                            .diagnostics
+                            .push(crate::analyser::types::Diagnostic::new(
+                                DiagCode::W126,
+                                arg_span,
+                                message,
+                                Severity::Warning,
+                            ));
                     }
                 }
             }
@@ -2046,15 +2060,16 @@ file; this call falls through to the 'unknown' handler."
             } else {
                 "Modulo"
             };
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W233,
-                span,
-                message: format!(
-                    "{verb} by a provably-zero divisor — raises 'divide by zero' at runtime."
-                ),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    DiagCode::W233,
+                    span,
+                    format!(
+                        "{verb} by a provably-zero divisor — raises 'divide by zero' at runtime."
+                    ),
+                    Severity::Warning,
+                ));
         }
     }
 
@@ -2114,16 +2129,17 @@ file; this call falls through to the 'unknown' handler."
             } else {
                 "silently returns the empty string"
             };
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: f.code,
-                span: fu.abs_span(f.span),
-                message: format!(
-                    "{}: index ${} {rng}, {bound} \u{2014} {outcome}.",
-                    f.command, f.index_var
-                ),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    f.code,
+                    fu.abs_span(f.span),
+                    format!(
+                        "{}: index ${} {rng}, {bound} \u{2014} {outcome}.",
+                        f.command, f.index_var
+                    ),
+                    Severity::Warning,
+                ));
         }
     }
 
@@ -2277,13 +2293,14 @@ file; this call falls through to the 'unknown' handler."
                 None
             })
             .unwrap_or(stmt_span);
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W124,
-            span,
-            message: message.to_string(),
-            severity,
-            fixes: Vec::new(),
-        });
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                DiagCode::W124,
+                span,
+                message.to_string(),
+                severity,
+            ));
     }
 
     /// IRULE4005 — racy ``static::`` cross-event flow.
@@ -2327,13 +2344,14 @@ file; this call falls through to the 'unknown' handler."
                          the same virtual server; concurrent writes can produce unpredictable \
                          results."
                     );
-                    self.result.diagnostics.push(super::types::Diagnostic {
-                        code: DiagCode::Irule4005,
-                        span,
-                        message,
-                        severity: Severity::Warning,
-                        fixes: Vec::new(),
-                    });
+                    self.result
+                        .diagnostics
+                        .push(crate::analyser::types::Diagnostic::new(
+                            DiagCode::Irule4005,
+                            span,
+                            message,
+                            Severity::Warning,
+                        ));
                 }
             }
         }

--- a/rust/tcl-compiler/src/analyser/diagnostics/security.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/security.rs
@@ -172,15 +172,17 @@ impl Analyser {
         }
         let fixes = self.trailing_arg_fixes(cmd_name, args, arg_tokens, "Add catch");
         let span = cmd_tok.span;
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W302,
-            span,
-            message: "catch without a result variable silently swallows errors. \
+        self.result.diagnostics.push(
+            crate::analyser::types::Diagnostic::new(
+                DiagCode::W302,
+                span,
+                "catch without a result variable silently swallows errors. \
 Consider capturing the result: catch {\u{2026}} result"
-                .to_string(),
-            severity: Severity::Hint,
-            fixes,
-        });
+                    .to_string(),
+                Severity::Hint,
+            )
+            .with_fixes(fixes),
+        );
     }
 
     /// Build the "append the omitted optional result variable(s)" quick-fixes
@@ -368,16 +370,18 @@ Consider capturing the result: catch {\u{2026}} result"
         // Only offered when the substituted word is itself the quoted string
         // (`eval_list_fix` returns empty otherwise).
         let fixes = self.eval_list_fix(anchor);
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W101,
-            span: anchor.span,
-            message: format!(
-                "{cmd_name} with substituted arguments risks code injection. \
+        self.result.diagnostics.push(
+            crate::analyser::types::Diagnostic::new(
+                DiagCode::W101,
+                anchor.span,
+                format!(
+                    "{cmd_name} with substituted arguments risks code injection. \
 Prefer direct invocation or {{*}}$cmdList to preserve argument boundaries."
-            ),
-            severity: Severity::Warning,
-            fixes,
-        });
+                ),
+                Severity::Warning,
+            )
+            .with_fixes(fixes),
+        );
     }
 
     /// Build the `eval [list …]` rewrite fix for a W101 diagnostic whose
@@ -617,16 +621,17 @@ word as one argument; no re-parsing)"
         if self.resolve_var_token_literal(tok).is_some() {
             return;
         }
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W300,
-            span: tok.span,
-            message: format!(
-                "{cmd_name} with a dynamic path (variable or command substitution) \
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                DiagCode::W300,
+                tok.span,
+                format!(
+                    "{cmd_name} with a dynamic path (variable or command substitution) \
 executes arbitrary Tcl code. Ensure the path is not influenced by untrusted input."
-            ),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        });
+                ),
+                Severity::Warning,
+            ));
     }
 
     /// **W309.** Emit "eval/uplevel with `[subst]` — double
@@ -652,17 +657,18 @@ executes arbitrary Tcl code. Ensure the path is not influenced by untrusted inpu
                 continue;
             };
             if self.inner_head_performs_substitution(inner) {
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W309,
-                    span: tok.span,
-                    message: format!(
-                        "{cmd_name} with [subst] creates double substitution: \
+                self.result
+                    .diagnostics
+                    .push(crate::analyser::types::Diagnostic::new(
+                        DiagCode::W309,
+                        tok.span,
+                        format!(
+                            "{cmd_name} with [subst] creates double substitution: \
 subst expands $var and [cmd], then {cmd_name} re-parses the result as Tcl. \
 This is a code-injection risk. Use [format] or [string map] for safe templating."
-                    ),
-                    severity: Severity::Error,
-                    fixes: Vec::new(),
-                });
+                        ),
+                        Severity::Error,
+                    ));
                 break;
             }
         }
@@ -698,16 +704,17 @@ This is a code-injection risk. Use [format] or [string map] for safe templating.
         if remaining.len() > 1 {
             // Multiple args = concat behaviour = danger.
             if self.args_have_substitution(arg_tokens, arg_single) {
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W301,
-                    span: remaining_toks[0].span,
-                    message: format!(
-                        "{cmd_name} with multiple arguments concatenates them into \
+                self.result
+                    .diagnostics
+                    .push(crate::analyser::types::Diagnostic::new(
+                        DiagCode::W301,
+                        remaining_toks[0].span,
+                        format!(
+                            "{cmd_name} with multiple arguments concatenates them into \
 a script (like eval). Use a single braced body or {{*}}$cmdList to avoid injection."
-                    ),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                        ),
+                        Severity::Warning,
+                    ));
             }
         } else if let Some(tok) = remaining_toks.first() {
             // Single arg — unbraced + substituted (and not [list …]).
@@ -727,16 +734,17 @@ a script (like eval). Use a single braced body or {{*}}$cmdList to avoid injecti
                 return;
             }
             if self.args_have_substitution(arg_tokens, arg_single) {
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W301,
-                    span: tok.span,
-                    message: format!(
-                        "{cmd_name} with an unbraced script argument may cause \
+                self.result
+                    .diagnostics
+                    .push(crate::analyser::types::Diagnostic::new(
+                        DiagCode::W301,
+                        tok.span,
+                        format!(
+                            "{cmd_name} with an unbraced script argument may cause \
 double substitution. Use braces: {cmd_name} 1 {{...}}"
-                    ),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                        ),
+                        Severity::Warning,
+                    ));
             }
         }
     }
@@ -773,16 +781,17 @@ double substitution. Use braces: {cmd_name} 1 {{...}}"
         // concatenates them, like `eval`.
         if concatenates && script_args.len() > 1 {
             if self.args_have_substitution(arg_tokens, arg_single) {
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W312,
-                    span: script_toks[0].span,
-                    message: format!(
-                        "{cmd_name} {sub_name} with multiple arguments concatenates \
+                self.result
+                    .diagnostics
+                    .push(crate::analyser::types::Diagnostic::new(
+                        DiagCode::W312,
+                        script_toks[0].span,
+                        format!(
+                            "{cmd_name} {sub_name} with multiple arguments concatenates \
 them into a script (like eval). Use a single braced body to avoid injection."
-                    ),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                        ),
+                        Severity::Warning,
+                    ));
             }
             return;
         }
@@ -792,16 +801,17 @@ them into a script (like eval). Use a single braced body to avoid injection."
             return;
         }
         if self.args_have_substitution(arg_tokens, arg_single) {
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W312,
-                span: tok.span,
-                message: format!(
-                    "{cmd_name} {sub_name} with an unbraced script argument may \
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    DiagCode::W312,
+                    tok.span,
+                    format!(
+                        "{cmd_name} {sub_name} with an unbraced script argument may \
 cause code injection. Use braces: {cmd_name} {sub_name} $child {{...}}"
-                ),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+                    ),
+                    Severity::Warning,
+                ));
         }
     }
 
@@ -903,13 +913,14 @@ cause code injection. Use braces: {cmd_name} {sub_name} $child {{...}}"
 scope, or use [format] / [string map] for safe templating.",
             mitigations.join(" ")
         );
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W102,
-            span: tok.span,
-            message,
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        });
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                DiagCode::W102,
+                tok.span,
+                message,
+                Severity::Warning,
+            ));
     }
 
     /// **W103.** Emit "open with a pipeline" when `open`'s first
@@ -962,13 +973,14 @@ Ensure the command is not influenced by untrusted input."
                     ),
                 )
             };
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W103,
-                span: tok.span,
-                message,
-                severity,
-                fixes: Vec::new(),
-            });
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    DiagCode::W103,
+                    tok.span,
+                    message,
+                    severity,
+                ));
         } else if matches!(
             tok.kind,
             tcl_lexer::TokenType::Var | tcl_lexer::TokenType::Cmd
@@ -1004,32 +1016,34 @@ Ensure the command is not influenced by untrusted input."
         // argument stays a Warning (it may resolve to a `|`-pipeline).
         if let Some(literal) = self.resolve_var_token_literal(tok) {
             if literal.starts_with('|') {
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W103,
-                    span: tok.span,
-                    message: format!(
-                        "{cmd_name} with a pipeline (\"|\") executes an external command. \
+                self.result
+                    .diagnostics
+                    .push(crate::analyser::types::Diagnostic::new(
+                        DiagCode::W103,
+                        tok.span,
+                        format!(
+                            "{cmd_name} with a pipeline (\"|\") executes an external command. \
 Ensure the command is not influenced by untrusted input."
-                    ),
-                    severity: Severity::Hint,
-                    fixes: Vec::new(),
-                });
+                        ),
+                        Severity::Hint,
+                    ));
             }
             return;
         }
         // A `$var` or `[cmd]`-computed first argument is equally dynamic —
         // either may resolve to a `|`-prefixed pipeline.
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W103,
-            span: tok.span,
-            message: format!(
-                "{cmd_name} with a dynamic argument (variable or command substitution): \
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                DiagCode::W103,
+                tok.span,
+                format!(
+                    "{cmd_name} with a dynamic argument (variable or command substitution): \
 if the value starts with \"|\", it will execute a command pipeline. Validate input \
 or use explicit I/O commands."
-            ),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        });
+                ),
+                Severity::Warning,
+            ));
     }
 
     /// **W303.** Emit "regexp vulnerable to catastrophic backtracking
@@ -1065,16 +1079,17 @@ or use explicit I/O commands."
         // `(a|a)+`.
         for (pattern, tok) in patterns {
             if has_redos_shape(&pattern) {
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W303,
-                    span: tok.span,
-                    message: "Regular expression may be vulnerable to catastrophic \
+                self.result
+                    .diagnostics
+                    .push(crate::analyser::types::Diagnostic::new(
+                        DiagCode::W303,
+                        tok.span,
+                        "Regular expression may be vulnerable to catastrophic \
 backtracking (ReDoS). Nested quantifiers like (a+)+ can cause exponential \
 matching time on crafted input."
-                        .to_string(),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                            .to_string(),
+                        Severity::Warning,
+                    ));
             }
         }
     }
@@ -1149,15 +1164,14 @@ matching time on crafted input."
         } else {
             ". Use braces '{...}' to prevent substitution."
         };
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W306,
-            span: tok.span,
-            message: format!(
-                "Literal expected in {cmd_name} pattern \u{2014} found {found}{advice}"
-            ),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        });
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                DiagCode::W306,
+                tok.span,
+                format!("Literal expected in {cmd_name} pattern \u{2014} found {found}{advice}"),
+                Severity::Warning,
+            ));
     }
 
     /// **W127.** A literal at a closed-value argument index is not in the
@@ -1232,13 +1246,15 @@ matching time on crafted input."
             }
         }
         for hit in hits {
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W127,
-                span: hit.span,
-                message: hit.message,
-                severity: Severity::Warning,
-                fixes: hit.fixes,
-            });
+            self.result.diagnostics.push(
+                crate::analyser::types::Diagnostic::new(
+                    DiagCode::W127,
+                    hit.span,
+                    hit.message,
+                    Severity::Warning,
+                )
+                .with_fixes(hit.fixes),
+            );
         }
     }
 
@@ -1344,22 +1360,26 @@ matching time on crafted input."
             }
         }
         for hit in hits {
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W127,
-                span: hit.span,
-                message: hit.message,
-                severity: Severity::Warning,
-                fixes: hit.fixes,
-            });
+            self.result.diagnostics.push(
+                crate::analyser::types::Diagnostic::new(
+                    DiagCode::W127,
+                    hit.span,
+                    hit.message,
+                    Severity::Warning,
+                )
+                .with_fixes(hit.fixes),
+            );
         }
         for hit in hook_hits {
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W141,
-                span: hit.span,
-                message: hit.message,
-                severity: Severity::Warning,
-                fixes: hit.fixes,
-            });
+            self.result.diagnostics.push(
+                crate::analyser::types::Diagnostic::new(
+                    DiagCode::W141,
+                    hit.span,
+                    hit.message,
+                    Severity::Warning,
+                )
+                .with_fixes(hit.fixes),
+            );
         }
     }
 
@@ -1404,16 +1424,17 @@ matching time on crafted input."
                 continue;
             };
             if is_literal_credential_value(value, val_tok) {
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W310,
-                    span: val_tok.span,
-                    message: format!(
-                        "Hardcoded credential in {text} argument. Store secrets in \
+                self.result
+                    .diagnostics
+                    .push(crate::analyser::types::Diagnostic::new(
+                        DiagCode::W310,
+                        val_tok.span,
+                        format!(
+                            "Hardcoded credential in {text} argument. Store secrets in \
 environment variables or a vault, not in source code."
-                    ),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                        ),
+                        Severity::Warning,
+                    ));
                 return; // one diagnostic per command
             }
         }
@@ -1440,16 +1461,17 @@ environment variables or a vault, not in source code."
                         (args.get(cred_arg), arg_tokens.get(cred_arg))
                     && is_literal_credential_value(value, val_tok)
                 {
-                    self.result.diagnostics.push(super::types::Diagnostic {
-                        code: DiagCode::W310,
-                        span: val_tok.span,
-                        message: format!(
-                            "Hardcoded credential in {header_name} header value. \
+                    self.result
+                        .diagnostics
+                        .push(crate::analyser::types::Diagnostic::new(
+                            DiagCode::W310,
+                            val_tok.span,
+                            format!(
+                                "Hardcoded credential in {header_name} header value. \
 Store secrets in environment variables or a vault, not in source code."
-                        ),
-                        severity: Severity::Warning,
-                        fixes: Vec::new(),
-                    });
+                            ),
+                            Severity::Warning,
+                        ));
                 }
             }
         }

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -1391,13 +1391,7 @@ fn body_references_param_namespace_qualified() {
 }
 
 fn diag(code: DiagCode, span: Span, msg: &str) -> Diagnostic {
-    Diagnostic {
-        code,
-        span,
-        message: msg.to_string(),
-        severity: Severity::Warning,
-        fixes: Vec::new(),
-    }
+    crate::analyser::types::Diagnostic::new(code, span, msg.to_string(), Severity::Warning)
 }
 
 #[test]

--- a/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
@@ -892,13 +892,15 @@ impl Analyser {
                     safety: crate::irules_checks::FixSafety::RequiresReview,
                 });
             }
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W123,
-                span: inv.range,
-                message,
-                severity: Severity::Hint,
-                fixes,
-            });
+            self.result.diagnostics.push(
+                crate::analyser::types::Diagnostic::new(
+                    DiagCode::W123,
+                    inv.range,
+                    message,
+                    Severity::Hint,
+                )
+                .with_fixes(fixes),
+            );
         }
         self.result.command_invocations = invocations;
     }
@@ -1087,13 +1089,15 @@ impl Analyser {
                 // initialisation code and changing what commands exist.
                 safety: crate::irules_checks::FixSafety::BehaviourHardening,
             };
-            new_diags.push(super::types::Diagnostic {
-                code: DiagCode::W120,
-                span: inv.range,
-                message: format!("\"{}\" requires `package require {pkg}`", inv.name),
-                severity: Severity::Warning,
-                fixes: vec![fix],
-            });
+            new_diags.push(
+                crate::analyser::types::Diagnostic::new(
+                    DiagCode::W120,
+                    inv.range,
+                    format!("\"{}\" requires `package require {pkg}`", inv.name),
+                    Severity::Warning,
+                )
+                .with_fixes(vec![fix]),
+            );
         }
         self.result.diagnostics.extend(new_diags);
     }

--- a/rust/tcl-compiler/src/analyser/diagnostics/usage.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/usage.rs
@@ -121,12 +121,14 @@ Use braces: {{ \u{2026} }}"
             )
         };
         let new_text = format!("{{{body_text}}}");
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W105,
-            span: body_tok.span,
-            message,
-            severity,
-            fixes: vec![super::types::CodeFix {
+        self.result.diagnostics.push(
+            crate::analyser::types::Diagnostic::new(
+                DiagCode::W105,
+                body_tok.span,
+                message,
+                severity,
+            )
+            .with_fixes(vec![super::types::CodeFix {
                 span: body_tok.span,
                 new_text,
                 description: "Wrap code block in braces".to_string(),
@@ -134,8 +136,8 @@ Use braces: {{ \u{2026} }}"
                 // command byte-identically; bracing one that substitutes
                 // removes a round of substitution by design.
                 safety: super::helpers::brace_wrap_fix_safety(trimmed, has_substitution),
-            }],
-        });
+            }]),
+        );
     }
 
     /// W100: an expression argument (`expr` / `if` / `while`
@@ -279,23 +281,20 @@ Use braces: {{ \u{2026} }}"
         } else {
             text
         };
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W100,
-            span,
-            message,
-            severity,
-            fixes: vec![super::types::CodeFix {
-                span,
-                new_text: format!("{{{fix_inner}}}"),
-                description: "Wrap expression in braces".to_string(),
-                // Per-instance: `expr 1 + 2` → `expr {1 + 2}` reaches `expr`
-                // with the same string, but `expr $a + $b` → `expr {$a + $b}`
-                // stops `$a` being substituted before `expr` parses it, which
-                // is a real behaviour change when `$a` holds expression text
-                // (issue #1195).
-                safety: super::helpers::brace_wrap_fix_safety(text, has_sub),
-            }],
-        });
+        self.result.diagnostics.push(
+            crate::analyser::types::Diagnostic::new(DiagCode::W100, span, message, severity)
+                .with_fixes(vec![super::types::CodeFix {
+                    span,
+                    new_text: format!("{{{fix_inner}}}"),
+                    description: "Wrap expression in braces".to_string(),
+                    // Per-instance: `expr 1 + 2` → `expr {1 + 2}` reaches `expr`
+                    // with the same string, but `expr $a + $b` → `expr {$a + $b}`
+                    // stops `$a` being substituted before `expr` parses it, which
+                    // is a real behaviour change when `$a` holds expression text
+                    // (issue #1195).
+                    safety: super::helpers::brace_wrap_fix_safety(text, has_sub),
+                }]),
+        );
     }
 
     /// W311: a channel configured with `-encoding binary` *and*
@@ -335,17 +334,18 @@ Use braces: {{ \u{2026} }}"
                 .or(binary_tok)
                 .or_else(|| arg_tokens.first());
             if let Some(tok) = target {
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W311,
-                    span: tok.span,
-                    message: "Channel configured with -encoding binary and a non-binary \
+                self.result
+                    .diagnostics
+                    .push(crate::analyser::types::Diagnostic::new(
+                        DiagCode::W311,
+                        tok.span,
+                        "Channel configured with -encoding binary and a non-binary \
                               -translation. Binary encoding implies no translation; the \
                               conflicting -translation may silently corrupt data or enable \
                               encoding-differential attacks."
-                        .to_string(),
-                    severity: super::types::Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                            .to_string(),
+                        super::types::Severity::Warning,
+                    ));
             }
         }
     }
@@ -450,13 +450,14 @@ Use braces: {{ \u{2026} }}"
                     use std::fmt::Write as _;
                     let _ = write!(message, " Did you mean '{s}'?");
                 }
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W121,
-                    span: tok.span,
-                    message,
-                    severity: super::types::Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                self.result
+                    .diagnostics
+                    .push(crate::analyser::types::Diagnostic::new(
+                        DiagCode::W121,
+                        tok.span,
+                        message,
+                        super::types::Severity::Warning,
+                    ));
             }
         }
     }
@@ -581,17 +582,16 @@ Use braces: {{ \u{2026} }}"
                         }]
                     })
                     .unwrap_or_default();
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W108,
-                    span,
-                    message: format!(
+                self.result.diagnostics.push(crate::analyser::types::Diagnostic::new(
+    DiagCode::W108,
+    span,
+    format!(
                         "Non-ASCII character U+{:04X} '{ch}' \u{2014} outside the standard ASCII \
                          printable/whitespace set",
                         ch as u32
                     ),
-                    severity: super::types::Severity::Warning,
-                    fixes,
-                });
+    super::types::Severity::Warning,
+).with_fixes(fixes));
             }
             if flagged_here {
                 seen.insert(tok.span.start());
@@ -633,16 +633,18 @@ Use braces: {{ \u{2026} }}"
                     .w104_lappend_fix(args, arg_tokens, arg_expand, cmd_tok)
                     .into_iter()
                     .collect();
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W104,
-                    span: tok.span,
-                    message: "append with space-separated values looks like list \
+                self.result.diagnostics.push(
+                    crate::analyser::types::Diagnostic::new(
+                        DiagCode::W104,
+                        tok.span,
+                        "append with space-separated values looks like list \
                               construction. Use [lappend] instead to safely handle values \
                               containing spaces, braces, or backslashes."
-                        .to_string(),
-                    severity: super::types::Severity::Hint,
-                    fixes,
-                });
+                            .to_string(),
+                        super::types::Severity::Hint,
+                    )
+                    .with_fixes(fixes),
+                );
                 return;
             }
         }
@@ -808,13 +810,14 @@ Use braces: {{ \u{2026} }}"
         } else {
             super::types::Severity::Warning
         };
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W106,
-            span,
-            message,
-            severity,
-            fixes: Vec::new(),
-        });
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                DiagCode::W106,
+                span,
+                message,
+                severity,
+            ));
     }
 
     /// Argument indices (0-based, command-name excluded) that `cmd` reads as a
@@ -925,16 +928,17 @@ Use braces: {{ \u{2026} }}"
                 .copied()
                 .unwrap_or(bare)
             };
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W212,
-                span: tok.span,
-                message: format!(
-                    "'{display_cmd}' expects a variable name, got substitution (${bare}). \
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    DiagCode::W212,
+                    tok.span,
+                    format!(
+                        "'{display_cmd}' expects a variable name, got substitution (${bare}). \
                      Did you mean '{suggestion}'?"
-                ),
-                severity: super::types::Severity::Warning,
-                fixes: Vec::new(),
-            });
+                    ),
+                    super::types::Severity::Warning,
+                ));
         }
     }
 
@@ -1008,19 +1012,21 @@ Use braces: {{ \u{2026} }}"
 (the brace form is documented to apply no further substitution to its \
 content); use `{corrected}` to access the array element with index substitution"
                         );
-                        self.result.diagnostics.push(super::types::Diagnostic {
-                            code: DiagCode::W216,
-                            span,
-                            message,
-                            severity: Severity::Warning,
-                            fixes: vec![super::types::CodeFix {
+                        self.result.diagnostics.push(
+                            crate::analyser::types::Diagnostic::new(
+                                DiagCode::W216,
+                                span,
+                                message,
+                                Severity::Warning,
+                            )
+                            .with_fixes(vec![super::types::CodeFix {
                                 span,
                                 new_text: corrected.clone(),
                                 description: format!("Replace with `{corrected}`"),
                                 // W216: a `did you mean` reading of an ambiguous reference.
                                 safety: crate::irules_checks::FixSafety::RequiresReview,
-                            }],
-                        });
+                            }]),
+                        );
                     }
                 }
                 continue;
@@ -1054,19 +1060,21 @@ content); use `{corrected}` to access the array element with index substitution"
                 "`${{{text}}}({inner})` is parsed as scalar `${{{text}}}` followed by \
 literal text `({inner})`; did you mean `{corrected}` for array element access?"
             );
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W216,
-                span,
-                message,
-                severity: Severity::Warning,
-                fixes: vec![super::types::CodeFix {
+            self.result.diagnostics.push(
+                crate::analyser::types::Diagnostic::new(
+                    DiagCode::W216,
+                    span,
+                    message,
+                    Severity::Warning,
+                )
+                .with_fixes(vec![super::types::CodeFix {
                     span,
                     new_text: corrected.clone(),
                     description: format!("Replace with `{corrected}`"),
                     // W216: as above.
                     safety: crate::irules_checks::FixSafety::RequiresReview,
-                }],
-            });
+                }]),
+            );
         }
     }
 
@@ -1103,13 +1111,15 @@ literal text `({inner})`; did you mean `{corrected}` for array element access?"
         let fixes = w114_unwrap_fix(slice, open, close, nested_span)
             .into_iter()
             .collect();
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W114,
-            span: nested_span,
-            message: "Redundant nested [expr] \u{2014} already in expression context".to_string(),
-            severity: super::types::Severity::Warning,
-            fixes,
-        });
+        self.result.diagnostics.push(
+            crate::analyser::types::Diagnostic::new(
+                DiagCode::W114,
+                nested_span,
+                "Redundant nested [expr] \u{2014} already in expression context".to_string(),
+                super::types::Severity::Warning,
+            )
+            .with_fixes(fixes),
+        );
     }
 
     /// **W110.** Emit "use `eq`/`ne` instead of `==`/`!=` for
@@ -1190,13 +1200,10 @@ literal text `({inner})`; did you mean `{corrected}` for array element access?"
 comparison in expressions to avoid ambiguous \
 numeric/string coercion."
         );
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W110,
-            span,
-            message,
-            severity: Severity::Hint,
-            fixes,
-        });
+        self.result.diagnostics.push(
+            crate::analyser::types::Diagnostic::new(DiagCode::W110, span, message, Severity::Hint)
+                .with_fixes(fixes),
+        );
     }
 
     /// Map a W110 operator offset (within the emitter's `expr_text`) to

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -188,13 +188,15 @@ pub(in crate::analyser) fn emit_invalid_formal_parameter_list_diagnostics(
                 )]
             })
             .unwrap_or_default();
-        analyser.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::E006,
-            span,
-            message: format!("Invalid formal parameter list: {error}"),
-            severity: Severity::Error,
-            fixes,
-        });
+        analyser.result.diagnostics.push(
+            crate::analyser::types::Diagnostic::new(
+                DiagCode::E006,
+                span,
+                format!("Invalid formal parameter list: {error}"),
+                Severity::Error,
+            )
+            .with_fixes(fixes),
+        );
     }
 }
 
@@ -237,13 +239,15 @@ pub(in crate::analyser) fn emit_invalid_lambda_parameter_list_diagnostics(
                 )]
             })
             .unwrap_or_default();
-        analyser.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::E006,
-            span,
-            message: format!("Invalid formal parameter list: {error}"),
-            severity: Severity::Error,
-            fixes,
-        });
+        analyser.result.diagnostics.push(
+            crate::analyser::types::Diagnostic::new(
+                DiagCode::E006,
+                span,
+                format!("Invalid formal parameter list: {error}"),
+                Severity::Error,
+            )
+            .with_fixes(fixes),
+        );
     }
 }
 
@@ -372,16 +376,15 @@ pub(super) fn arity_verdict(
         return None;
     }
     if !positional_any_expand && nargs_min < min {
-        Some(crate::analyser::types::Diagnostic {
-            code: DiagCode::E002,
+        Some(crate::analyser::types::Diagnostic::new(
+            DiagCode::E002,
             span,
-            message: format!(
+            format!(
                 "Too few arguments for '{display_name}': expected at least {min}, \
 got {nargs_min}{usage_suffix}"
             ),
-            severity: Severity::Error,
-            fixes: Vec::new(),
-        })
+            Severity::Error,
+        ))
     } else if !arity.is_unlimited() && nargs_min > max {
         // Highlight only the surplus arguments when the caller could
         // isolate them (the whole command otherwise), and offer to delete
@@ -402,31 +405,32 @@ got {nargs_min}{usage_suffix}"
             ),
             None => (span, Vec::new()),
         };
-        Some(crate::analyser::types::Diagnostic {
-            code: DiagCode::E003,
-            span: e003_span,
-            message: format!(
-                "Too many arguments for '{display_name}': expected at most {max}, \
+        Some(
+            crate::analyser::types::Diagnostic::new(
+                DiagCode::E003,
+                e003_span,
+                format!(
+                    "Too many arguments for '{display_name}': expected at most {max}, \
 got {nargs_min}{usage_suffix}"
-            ),
-            severity: Severity::Error,
-            fixes,
-        })
+                ),
+                Severity::Error,
+            )
+            .with_fixes(fixes),
+        )
     } else if !positional_any_expand
         && arity.step != 0
         && !(nargs_min - min).is_multiple_of(usize::from(arity.step))
     {
-        Some(crate::analyser::types::Diagnostic {
-            code: DiagCode::E005,
+        Some(crate::analyser::types::Diagnostic::new(
+            DiagCode::E005,
             span,
-            message: format!(
+            format!(
                 "Wrong argument-count shape for '{display_name}': expected {}, \
 got {nargs_min}{usage_suffix}",
                 describe_step_shape(arity)
             ),
-            severity: Severity::Error,
-            fixes: Vec::new(),
-        })
+            Severity::Error,
+        ))
     } else {
         None
     }
@@ -799,13 +803,13 @@ impl Analyser {
                     format!("Remove invalid member(s) {invalid_description}"),
                 )]
             });
-        let diagnostic = crate::analyser::types::Diagnostic {
-            code: DiagCode::W146,
+        let diagnostic = crate::analyser::types::Diagnostic::new(
+            DiagCode::W146,
             span,
             message,
-            severity: Severity::Warning,
-            fixes,
-        };
+            Severity::Warning,
+        )
+        .with_fixes(fixes);
         let namespace = self.command_resolution_namespace(scope_path);
         let enforce_order = !self.scope_path_in_proc_body(scope_path);
         self.pending_arity
@@ -881,13 +885,12 @@ impl Analyser {
         let suffix = registry.get(bare).map_or(String::new(), |spec| {
             dialect_availability_suffix(spec.dialects)
         });
-        let diag = super::types::Diagnostic {
-            code: DiagCode::W002,
-            span: cmd_tok.span,
-            message: format!("'{cmd_name}' is disabled in the active dialect profile{suffix}"),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        };
+        let diag = crate::analyser::types::Diagnostic::new(
+            DiagCode::W002,
+            cmd_tok.span,
+            format!("'{cmd_name}' is disabled in the active dialect profile{suffix}"),
+            Severity::Warning,
+        );
         let ns = self.command_resolution_namespace(scope_path);
         let enforce_order = !self.scope_path_in_proc_body(scope_path);
         self.pending_disabled_commands
@@ -1124,13 +1127,13 @@ impl Analyser {
             cmd_name.to_string(),
             ns,
             enforce_order,
-            super::types::Diagnostic {
-                code: DiagCode::W001,
+            crate::analyser::types::Diagnostic::new(
+                DiagCode::W001,
                 span,
                 message,
-                severity: Severity::Warning,
-                fixes,
-            },
+                Severity::Warning,
+            )
+            .with_fixes(fixes),
         ));
     }
 
@@ -1182,13 +1185,15 @@ impl Analyser {
                 safety: crate::irules_checks::FixSafety::RequiresReview,
             })
             .collect();
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W145,
-            span,
-            message: format!("Ambiguous abbreviation '{word}' for '{cmd_name}': matches {listed}."),
-            severity: Severity::Warning,
-            fixes,
-        });
+        self.result.diagnostics.push(
+            crate::analyser::types::Diagnostic::new(
+                DiagCode::W145,
+                span,
+                format!("Ambiguous abbreviation '{word}' for '{cmd_name}': matches {listed}."),
+                Severity::Warning,
+            )
+            .with_fixes(fixes),
+        );
     }
 
     /// Whether `cmd_name subcommand_name …` is a call into an ensemble
@@ -1320,15 +1325,12 @@ impl Analyser {
                     dialect_availability_suffix(sub.dialects.or(spec.dialects))
                 })
         });
-        let diag = super::types::Diagnostic {
-            code: DiagCode::W002,
+        let diag = crate::analyser::types::Diagnostic::new(
+            DiagCode::W002,
             span,
-            message: format!(
-                "'{cmd_name} {first_arg}' is disabled in the active dialect profile{suffix}"
-            ),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        };
+            format!("'{cmd_name} {first_arg}' is disabled in the active dialect profile{suffix}"),
+            Severity::Warning,
+        );
         let ns = self.command_resolution_namespace(scope_path);
         let enforce_order = !self.scope_path_in_proc_body(scope_path);
         self.pending_disabled_commands
@@ -1461,13 +1463,12 @@ impl Analyser {
                         cmd_name.to_string(),
                         ns,
                         enforce_order,
-                        super::types::Diagnostic {
-                            code: DiagCode::E001,
-                            span: cmd_tok.span,
-                            message: format!("'{cmd_name}' requires a subcommand"),
-                            severity: Severity::Error,
-                            fixes: Vec::new(),
-                        },
+                        crate::analyser::types::Diagnostic::new(
+                            DiagCode::E001,
+                            cmd_tok.span,
+                            format!("'{cmd_name}' requires a subcommand"),
+                            Severity::Error,
+                        ),
                     ));
                     return;
                 };
@@ -1696,13 +1697,12 @@ impl Analyser {
             .join(", ");
         let ns = self.command_resolution_namespace(scope_path);
         let enforce_order = !self.scope_path_in_proc_body(scope_path);
-        let diagnostic = super::types::Diagnostic {
-            code: DiagCode::W147,
-            span: tcl_lexer::Span::new(first.start(), second.end()),
-            message: format!("Options {names} cannot be used together for '{display_name}'"),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        };
+        let diagnostic = crate::analyser::types::Diagnostic::new(
+            DiagCode::W147,
+            tcl_lexer::Span::new(first.start(), second.end()),
+            format!("Options {names} cannot be used together for '{display_name}'"),
+            Severity::Warning,
+        );
         if constraint.lifecycle.is_unspecified() {
             self.pending_arity
                 .push((resolution_name.to_string(), ns, enforce_order, diagnostic));
@@ -2743,13 +2743,10 @@ impl Analyser {
 
         let fixes = self.e004_fixes(args, arg_tokens, error);
 
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::E004,
-            span,
-            message,
-            severity: Severity::Error,
-            fixes,
-        });
+        self.result.diagnostics.push(
+            crate::analyser::types::Diagnostic::new(DiagCode::E004, span, message, Severity::Error)
+                .with_fixes(fixes),
+        );
     }
 
     /// **W142.** Runs a resolved command's [`tcl_registry::CommandSpec::context_gate`]
@@ -2773,13 +2770,14 @@ impl Analyser {
         let Some(message) = gate(&arg_strs, self.current_event.is_some()) else {
             return;
         };
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W142,
-            span: cmd_tok.span,
-            message: message.to_string(),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        });
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                DiagCode::W142,
+                cmd_tok.span,
+                message.to_string(),
+                Severity::Warning,
+            ));
     }
 
     /// Code fixes for [`Self::emit_e004_clause_shape_diagnostic`]. See
@@ -3005,13 +3003,10 @@ impl Analyser {
 
         let (severity, message, origin) =
             self.classify_w304(tok, is_dynamic, looks_like_option, &command_label);
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W304,
-            span: diag_span,
-            message,
-            severity,
-            fixes,
-        });
+        self.result.diagnostics.push(
+            crate::analyser::types::Diagnostic::new(DiagCode::W304, diag_span, message, severity)
+                .with_fixes(fixes),
+        );
         if let Some(origin_diag) = origin {
             self.result.diagnostics.push(origin_diag);
         }
@@ -3083,16 +3078,18 @@ impl Analyser {
             }]
         })
         .unwrap_or_default();
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W217,
-            span: diag_span,
-            message: "`unset` unsets no variable here — `-nocomplain` / `--` are consumed as \
+        self.result.diagnostics.push(
+            crate::analyser::types::Diagnostic::new(
+                DiagCode::W217,
+                diag_span,
+                "`unset` unsets no variable here — `-nocomplain` / `--` are consumed as \
 options. To unset a variable whose name begins with `-`, put `--` before it \
 (e.g. `unset -- -nocomplain`)."
-                .to_string(),
-            severity: Severity::Warning,
-            fixes,
-        });
+                    .to_string(),
+                Severity::Warning,
+            )
+            .with_fixes(fixes),
+        );
     }
 
     /// Emit the per-item path's pending W304 diagnostics, classifying each
@@ -3106,13 +3103,15 @@ options. To unset a variable whose name begins with `-`, put `--` before it \
         let pending = std::mem::take(&mut self.pending_w304);
         for (tok, command_label, fixes, diag_span) in pending {
             let (severity, message, origin) = self.classify_w304(tok, true, false, &command_label);
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W304,
-                span: diag_span,
-                message,
-                severity,
-                fixes,
-            });
+            self.result.diagnostics.push(
+                crate::analyser::types::Diagnostic::new(
+                    DiagCode::W304,
+                    diag_span,
+                    message,
+                    severity,
+                )
+                .with_fixes(fixes),
+            );
             if let Some(origin_diag) = origin {
                 self.result.diagnostics.push(origin_diag);
             }
@@ -3144,7 +3143,7 @@ options. To unset a variable whose name begins with `-`, put `--` before it \
     /// registered command; W117 when a stub expr function/operator name
     /// collides with a built-in `expr` function or operator.
     pub(in crate::analyser) fn emit_w116_w117_stub_shadows(&mut self) {
-        use super::types::{Diagnostic, Severity};
+        use super::types::Severity;
 
         if self.result.stub_commands.is_empty() && self.result.stub_expr_defs.is_empty() {
             return;
@@ -3166,13 +3165,14 @@ options. To unset a variable whose name begins with `-`, put `--` before it \
                 .map(|s| (s.name.clone(), s.range))
                 .collect();
             for (name, span) in hits {
-                self.result.diagnostics.push(Diagnostic {
-                    code: DiagCode::W116,
-                    span,
-                    message: format!("Stub command '{name}' shadows built-in command."),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                self.result
+                    .diagnostics
+                    .push(crate::analyser::types::Diagnostic::new(
+                        DiagCode::W116,
+                        span,
+                        format!("Stub command '{name}' shadows built-in command."),
+                        Severity::Warning,
+                    ));
             }
         }
 
@@ -3197,15 +3197,16 @@ options. To unset a variable whose name begins with `-`, put `--` before it \
                 } else {
                     "operator"
                 };
-                self.result.diagnostics.push(Diagnostic {
-                    code: DiagCode::W117,
-                    span,
-                    message: format!(
-                        "Stub expression {kind_label} '{name}' shadows built-in {kind_label}."
-                    ),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                self.result
+                    .diagnostics
+                    .push(crate::analyser::types::Diagnostic::new(
+                        DiagCode::W117,
+                        span,
+                        format!(
+                            "Stub expression {kind_label} '{name}' shadows built-in {kind_label}."
+                        ),
+                        Severity::Warning,
+                    ));
             }
         }
     }
@@ -3250,13 +3251,15 @@ options. To unset a variable whose name begins with `-`, put `--` before it \
         } else {
             Vec::new()
         };
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::Irule2002,
-            span: cmd_tok.span,
-            message: format!("'{cmd_name}' is deprecated in iRules. Use '{replacement}' instead."),
-            severity: Severity::Warning,
-            fixes,
-        });
+        self.result.diagnostics.push(
+            crate::analyser::types::Diagnostic::new(
+                DiagCode::Irule2002,
+                cmd_tok.span,
+                format!("'{cmd_name}' is deprecated in iRules. Use '{replacement}' instead."),
+                Severity::Warning,
+            )
+            .with_fixes(fixes),
+        );
     }
 
     /// **W143.** Warn on a direct call into a private, undocumented
@@ -3327,13 +3330,13 @@ options. To unset a variable whose name begins with `-`, put `--` before it \
             }
             _ => Vec::new(),
         };
-        let diag = super::types::Diagnostic {
-            code: DiagCode::W143,
-            span: cmd_tok.span,
+        let diag = crate::analyser::types::Diagnostic::new(
+            DiagCode::W143,
+            cmd_tok.span,
             message,
-            severity: Severity::Warning,
-            fixes,
-        };
+            Severity::Warning,
+        )
+        .with_fixes(fixes);
         let ns = self.command_resolution_namespace(scope_path);
         let enforce_order = !self.scope_path_in_proc_body(scope_path);
         self.pending_w143
@@ -3472,15 +3475,17 @@ options. To unset a variable whose name begins with `-`, put `--` before it \
                 }]
             })
             .unwrap_or_default();
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::Irule2001,
-            span: cmd_tok.span,
-            message: "'matchclass' is deprecated since BIG-IP v10. \
+        self.result.diagnostics.push(
+            crate::analyser::types::Diagnostic::new(
+                DiagCode::Irule2001,
+                cmd_tok.span,
+                "'matchclass' is deprecated since BIG-IP v10. \
 Use 'class match <item> <operator> <class>' instead."
-                .to_string(),
-            severity: Severity::Warning,
-            fixes,
-        });
+                    .to_string(),
+                Severity::Warning,
+            )
+            .with_fixes(fixes),
+        );
     }
 
     /// Classify the positional value for W304: tristate severity,
@@ -3521,16 +3526,15 @@ This value is reported at INFO because '{var_text}' currently resolves to \
 static literal '{resolved_text}'. Keep '--' to guard against future \
 option-injection regressions if the variable changes."
                     );
-                    let origin = super::types::Diagnostic {
-                        code: DiagCode::W304,
-                        span: resolved_span,
-                        message: format!(
+                    let origin = crate::analyser::types::Diagnostic::new(
+                        DiagCode::W304,
+                        resolved_span,
+                        format!(
                             "'{var_text}' is currently assigned static \
 literal '{resolved_text}' here; this is why the diagnostic is INFO."
                         ),
-                        severity: Severity::Suggestion,
-                        fixes: Vec::new(),
-                    };
+                        Severity::Suggestion,
+                    );
                     return (Severity::Suggestion, message, Some(origin));
                 }
             }
@@ -3753,17 +3757,17 @@ before this value so it is treated as data, not an option."
                     let sub_suffix = sub_name.map_or(String::new(), |n| format!(" {n}"));
                     let consumed = 1 + opt.value_word_count(args, i);
                     let fixes = self.w004_remove_option_fix(arg, arg_tokens, i, consumed);
-                    let diag = super::types::Diagnostic {
-                        code: DiagCode::W004,
+                    let diag = crate::analyser::types::Diagnostic::new(
+                        DiagCode::W004,
                         span,
-                        message: format!(
+                        format!(
                             "Option '{arg}' on '{cmd_name}'{sub_suffix} is not available \
 in the active dialect ({}).",
                             self.dialect()
                         ),
-                        severity: Severity::Warning,
-                        fixes,
-                    };
+                        Severity::Warning,
+                    )
+                    .with_fixes(fixes);
                     let ns = self.command_resolution_namespace(scope_path);
                     let enforce_order = !self.scope_path_in_proc_body(scope_path);
                     self.pending_arity
@@ -3829,15 +3833,14 @@ in the active dialect ({}).",
                 safety: crate::irules_checks::FixSafety::RequiresReview,
             })
             .collect();
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W145,
-            span,
-            message: format!(
+        self.result.diagnostics.push(crate::analyser::types::Diagnostic::new(
+    DiagCode::W145,
+    span,
+    format!(
                 "Ambiguous abbreviation '{word}' for '{cmd_name}{sub_suffix}': matches {listed}."
             ),
-            severity: Severity::Warning,
-            fixes,
-        });
+    Severity::Warning,
+).with_fixes(fixes));
     }
 
     /// Build the "remove option" fix for a W004 candidate: deletes the flag
@@ -4013,17 +4016,16 @@ in the active dialect ({}).",
                     safety: crate::irules_checks::FixSafety::RequiresReview,
                 });
             }
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W003,
-                span: op_span,
-                message: format!(
+            self.result.diagnostics.push(crate::analyser::types::Diagnostic::new(
+    DiagCode::W003,
+    op_span,
+    format!(
                     "Expression operator '{op_name}' is not available in dialect '{}'; requires {}.",
                     self.dialect(),
                     w003_tip_citation(op_name)
                 ),
-                severity: Severity::Warning,
-                fixes,
-            });
+    Severity::Warning,
+).with_fixes(fixes));
         }
     }
 
@@ -4045,16 +4047,15 @@ in the active dialect ({}).",
                 continue;
             };
             if since > ceiling {
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W002,
-                    span,
-                    message: format!(
+                self.result.diagnostics.push(crate::analyser::types::Diagnostic::new(
+    DiagCode::W002,
+    span,
+    format!(
                         "'::tcl::mathfunc::{name}' is disabled in the active dialect profile ('{}')",
                         self.dialect()
                     ),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+    Severity::Warning,
+));
             }
         }
     }
@@ -4095,21 +4096,20 @@ in the active dialect ({}).",
             let Some(op_name) = gated_operator_name(word, base, is_irules) else {
                 continue;
             };
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W003,
-                span: tok.span,
-                message: format!(
+            self.result.diagnostics.push(crate::analyser::types::Diagnostic::new(
+    DiagCode::W003,
+    tok.span,
+    format!(
                     "Expression operator '{op_name}' is not available in dialect '{}'; requires {}.",
                     self.dialect(),
                     w003_tip_citation(op_name)
                 ),
-                severity: Severity::Warning,
-                // The unbraced multi-word form has no single local
+    Severity::Warning,
+).with_fixes(// The unbraced multi-word form has no single local
                 // span to rewrite in place without also re-bracing
                 // the whole expression (W100's concern, not this
                 // one) — left unfixed.
-                fixes: Vec::new(),
-            });
+Vec::new()));
         }
     }
 

--- a/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
@@ -558,13 +558,8 @@ impl Analyser {
                 });
             }
         }
-        super::types::Diagnostic {
-            code: DiagCode::W308,
-            span,
-            message,
-            severity: Severity::Warning,
-            fixes,
-        }
+        crate::analyser::types::Diagnostic::new(DiagCode::W308, span, message, Severity::Warning)
+            .with_fixes(fixes)
     }
 
     /// **E001** (`TclOO` form) — `$obj` invoked with no method word at all.
@@ -611,13 +606,12 @@ impl Analyser {
         if !all_tcloo {
             return None;
         }
-        Some(super::types::Diagnostic {
-            code: DiagCode::E001,
-            span: site.cmd_span,
-            message: format!("'{}' requires a method", site.var_name),
-            severity: Severity::Error,
-            fixes: Vec::new(),
-        })
+        Some(crate::analyser::types::Diagnostic::new(
+            DiagCode::E001,
+            site.cmd_span,
+            format!("'{}' requires a method", site.var_name),
+            Severity::Error,
+        ))
     }
 
     /// **E001** (`TclOO` form) for a command-substitution head: a bare
@@ -655,13 +649,12 @@ impl Analyser {
             .strip_prefix('[')
             .and_then(|w| w.strip_suffix(']'))
             .map_or(inner, str::trim);
-        Some(super::types::Diagnostic {
-            code: DiagCode::E001,
-            span: site.cmd_span,
-            message: format!("'{inner}' requires a method"),
-            severity: Severity::Error,
-            fixes: Vec::new(),
-        })
+        Some(crate::analyser::types::Diagnostic::new(
+            DiagCode::E001,
+            site.cmd_span,
+            format!("'{inner}' requires a method"),
+            Severity::Error,
+        ))
     }
 
     /// Check a resolved `$obj method …` dispatch's argument count
@@ -1463,12 +1456,13 @@ impl Analyser {
             return self.w308_for_object_var(site, &live_classes, hierarchy, objdefined_vars);
         }
 
-        (!self.w307_site_suppressed(site, w307_ctx)).then(|| super::types::Diagnostic {
-            code: DiagCode::W307,
-            span: site.cmd_span,
-            message: "Non-literal command name — cannot statically analyze".to_string(),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
+        (!self.w307_site_suppressed(site, w307_ctx)).then(|| {
+            crate::analyser::types::Diagnostic::new(
+                DiagCode::W307,
+                site.cmd_span,
+                "Non-literal command name — cannot statically analyze".to_string(),
+                Severity::Warning,
+            )
         })
     }
 
@@ -1508,6 +1502,10 @@ impl Analyser {
     /// call isn't an OO self-dispatch (`my` / `self`).  When the return type is
     /// a known class, the method is validated against the hierarchy and W308 is
     /// emitted instead.  Restores `cmd_command_sites` on exit.
+    #[allow(
+        clippy::too_many_lines,
+        reason = "the diagnostic's closely coupled dispatch and type-validation cases share one restored-site lifecycle"
+    )]
     fn emit_cmd_command_diagnostics(
         &mut self,
         registry: &tcl_registry::CommandRegistry,
@@ -1569,13 +1567,14 @@ impl Analyser {
                     self.oo_self_method_returns_literal(site.cmd_span.start(), method)
                 });
                 if returns_literal {
-                    self.result.diagnostics.push(super::types::Diagnostic {
-                        code: DiagCode::W307,
-                        span: site.cmd_span,
-                        message: "Non-literal command name — cannot statically analyze".to_string(),
-                        severity: Severity::Warning,
-                        fixes: Vec::new(),
-                    });
+                    self.result
+                        .diagnostics
+                        .push(crate::analyser::types::Diagnostic::new(
+                            DiagCode::W307,
+                            site.cmd_span,
+                            "Non-literal command name — cannot statically analyze".to_string(),
+                            Severity::Warning,
+                        ));
                     continue;
                 }
                 // `[self]` / `[self object]` is not just *some* self-dispatch
@@ -1647,13 +1646,14 @@ impl Analyser {
 
             // Type is unknown — emit W307 (only the emit-half
             // for the residual unknown-type case).
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W307,
-                span: site.cmd_span,
-                message: "Non-literal command name — cannot statically analyze".to_string(),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    DiagCode::W307,
+                    site.cmd_span,
+                    "Non-literal command name — cannot statically analyze".to_string(),
+                    Severity::Warning,
+                ));
         }
         self.cmd_command_sites = cmd_sites;
     }
@@ -1985,15 +1985,12 @@ impl Analyser {
         };
         let mut diags: Vec<super::types::Diagnostic> = Vec::new();
         let mut flag = |span: tcl_lexer::Span, class: &str| {
-            diags.push(super::types::Diagnostic {
-                code: DiagCode::W250,
+            diags.push(crate::analyser::types::Diagnostic::new(
+                DiagCode::W250,
                 span,
-                message: format!(
-                    "Instantiating abstract class '{class}' — use a concrete subclass"
-                ),
-                severity: super::types::Severity::Warning,
-                fixes: Vec::new(),
-            });
+                format!("Instantiating abstract class '{class}' — use a concrete subclass"),
+                super::types::Severity::Warning,
+            ));
         };
         let units = std::iter::once(&cu.top_level)
             .chain(cu.procedures.values())

--- a/rust/tcl-compiler/src/analyser/diagnostics/version_gate.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/version_gate.rs
@@ -747,13 +747,15 @@ impl Analyser {
                 .flatten()
                 .into_iter()
                 .collect();
-            new_diags.push(Diagnostic {
-                code,
-                span: site.span,
-                message,
-                severity: Severity::Warning,
-                fixes,
-            });
+            new_diags.push(
+                crate::analyser::types::Diagnostic::new(
+                    code,
+                    site.span,
+                    message,
+                    Severity::Warning,
+                )
+                .with_fixes(fixes),
+            );
         }
         self.result.diagnostics.extend(new_diags);
     }
@@ -1157,19 +1159,18 @@ impl Analyser {
             if site.min <= effective {
                 continue;
             }
-            new_diags.push(Diagnostic {
-                code: site.code,
-                span: site.span,
-                message: format!(
+            new_diags.push(crate::analyser::types::Diagnostic::new(
+                site.code,
+                site.span,
+                format!(
                     "{} requires Tcl {} but {} provides {}.",
                     site.what,
                     site.min.as_package_version(),
                     self.profile.name,
                     effective.as_package_version()
                 ),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+                Severity::Warning,
+            ));
         }
         self.result.diagnostics.extend(new_diags);
     }

--- a/rust/tcl-compiler/src/analyser/diagnostics/widget_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/widget_command.rs
@@ -54,7 +54,7 @@ use tcl_lexer::{Span, Token};
 use tcl_registry::{CommandRegistry, SubCommand};
 
 use super::super::state::Analyser;
-use super::super::types::{Diagnostic, Severity};
+use super::super::types::Severity;
 use super::validity::arity_verdict;
 
 /// `configure`/`cget` are universal on every Tk widget instance (baked into
@@ -189,16 +189,17 @@ impl Analyser {
                 .iter()
                 .find(|s: &&SubCommand| s.name == site.subcommand)
             else {
-                self.result.diagnostics.push(Diagnostic {
-                    code: DiagCode::W001,
-                    span: site.subcommand_span,
-                    message: format!(
-                        "Unknown subcommand '{}' for widget '{class}'",
-                        site.subcommand
-                    ),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                self.result
+                    .diagnostics
+                    .push(crate::analyser::types::Diagnostic::new(
+                        DiagCode::W001,
+                        site.subcommand_span,
+                        format!(
+                            "Unknown subcommand '{}' for widget '{class}'",
+                            site.subcommand
+                        ),
+                        Severity::Warning,
+                    ));
                 continue;
             };
             if site.has_expand {

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -1522,13 +1522,14 @@ impl Analyser {
                 format!(" ({})", self.dialect())
             };
             let message = format!("Procedure '{raw_name}' shadows built-in command{dialect_label}");
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W113,
-                span: name_span,
-                message,
-                severity: super::types::Severity::Warning,
-                fixes: Vec::new(),
-            });
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    DiagCode::W113,
+                    name_span,
+                    message,
+                    super::types::Severity::Warning,
+                ));
         }
     }
 
@@ -1574,18 +1575,19 @@ impl Analyser {
         if !unaddressable {
             return;
         }
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W314,
-            span: name_span,
-            message: format!(
-                "'{raw_name}' has no absolute (fully-qualified) name — a written colon run \
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                DiagCode::W314,
+                name_span,
+                format!(
+                    "'{raw_name}' has no absolute (fully-qualified) name — a written colon run \
                  is a namespace separator, so this definition is reachable only by \
                  unqualified/relative lookup ([namespace which] output will not resolve, \
                  and ensembles cannot dispatch it)"
-            ),
-            severity: super::types::Severity::Warning,
-            fixes: Vec::new(),
-        });
+                ),
+                super::types::Severity::Warning,
+            ));
     }
 
     /// **W315.** Drain `class`'s recorded
@@ -1647,13 +1649,14 @@ impl Analyser {
             });
         }
         for abort in aborts {
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W315,
-                span: abort.span,
-                message: abort.message(),
-                severity: super::types::Severity::Warning,
-                fixes: Vec::new(),
-            });
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    DiagCode::W315,
+                    abort.span,
+                    abort.message(),
+                    super::types::Severity::Warning,
+                ));
         }
     }
 
@@ -1669,17 +1672,18 @@ impl Analyser {
         if !has_all_colon_segment {
             return;
         }
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W314,
-            span,
-            message: format!(
-                "namespace '{written_ns}' has no absolute (fully-qualified) path — a \
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                DiagCode::W314,
+                span,
+                format!(
+                    "namespace '{written_ns}' has no absolute (fully-qualified) path — a \
                  written colon run is a namespace separator, so everything defined \
                  inside is reachable only by relative lookup"
-            ),
-            severity: super::types::Severity::Warning,
-            fixes: Vec::new(),
-        });
+                ),
+                super::types::Severity::Warning,
+            ));
     }
 
     /// **W218.** `args` declared anywhere but the final parameter position
@@ -1703,14 +1707,13 @@ impl Analyser {
                 continue;
             }
             let span = param_spans.get(i).copied().unwrap_or(fallback_tok.span);
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W218,
-                span,
-                message: "`args` here is an ordinary parameter — it only has its special                           collect-the-rest meaning as the final parameter. Move it last, or                           rename it if a plain parameter is intended."
+            self.result.diagnostics.push(crate::analyser::types::Diagnostic::new(
+    DiagCode::W218,
+    span,
+    "`args` here is an ordinary parameter — it only has its special                           collect-the-rest meaning as the final parameter. Move it last, or                           rename it if a plain parameter is intended."
                     .to_string(),
-                severity: super::types::Severity::Warning,
-                fixes: Vec::new(),
-            });
+    super::types::Severity::Warning,
+));
         }
     }
 
@@ -2911,17 +2914,18 @@ impl Analyser {
                 && !self.dynamic_interp_ops
                 && let Some(tok) = arg_tokens.get(1)
             {
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: tcl_core_types::DiagCode::W140,
-                    span: tok.span,
-                    message: format!(
-                        "interpreter '{}' is never created in this file — \
+                self.result
+                    .diagnostics
+                    .push(crate::analyser::types::Diagnostic::new(
+                        tcl_core_types::DiagCode::W140,
+                        tok.span,
+                        format!(
+                            "interpreter '{}' is never created in this file — \
                          `interp eval` will raise `could not find interpreter`",
-                        args[1]
-                    ),
-                    severity: super::types::Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                            args[1]
+                        ),
+                        super::types::Severity::Warning,
+                    ));
             }
         }
         // Multiple script words concatenate at run time (`Tcl_ConcatObj`),
@@ -5723,13 +5727,12 @@ impl Analyser {
                 }
             };
             if emit {
-                diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W315,
-                    span: cand.abort.span,
-                    message: cand.abort.object_message(),
-                    severity: super::types::Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                diagnostics.push(crate::analyser::types::Diagnostic::new(
+                    DiagCode::W315,
+                    cand.abort.span,
+                    cand.abort.object_message(),
+                    super::types::Severity::Warning,
+                ));
             }
         }
         self.result.diagnostics.extend(diagnostics);

--- a/rust/tcl-compiler/src/analyser/irules_event_checks.rs
+++ b/rust/tcl-compiler/src/analyser/irules_event_checks.rs
@@ -51,7 +51,7 @@ use tcl_registry::profiles::ProfileRegistry;
 use tcl_registry::{ArgRole, CommandRegistry, Traits};
 
 use super::state::Analyser;
-use super::types::{CodeFix, Diagnostic, Severity};
+use super::types::{CodeFix, Severity};
 
 /// Process-wide cached iRules event registry.  The data is static, so
 /// building it once and sharing it avoids rebuilding the table on every
@@ -262,6 +262,10 @@ impl Analyser {
     ///
     /// Only fires inside a `when EVENT` block; `emit_irules_event_checks`
     /// supplies the enclosing `event`.
+    #[allow(
+        clippy::too_many_lines,
+        reason = "event legality, protocol requirements, and profile hints intentionally produce one cohesive diagnostic"
+    )]
     fn emit_irule1001_command_event_validity(
         &mut self,
         cmd_name: &str,
@@ -310,13 +314,14 @@ impl Analyser {
                     })
                 });
             if let Some(info) = hint {
-                self.result.diagnostics.push(Diagnostic {
-                    code: DiagCode::Irule1001,
-                    span: cmd_tok.span,
-                    message: format!("'{cmd_name}' {info}."),
-                    severity: Severity::Hint,
-                    fixes: Vec::new(),
-                });
+                self.result
+                    .diagnostics
+                    .push(crate::analyser::types::Diagnostic::new(
+                        DiagCode::Irule1001,
+                        cmd_tok.span,
+                        format!("'{cmd_name}' {info}."),
+                        Severity::Hint,
+                    ));
             }
             return;
         }
@@ -327,16 +332,17 @@ impl Analyser {
         // This is entirely form-data-driven: the analyser does not name the
         // command or its selector words.
         if !requirements.only_in.is_empty() && !requirements.only_in.contains(&event) {
-            self.result.diagnostics.push(Diagnostic {
-                code: DiagCode::Irule1001,
-                span: cmd_tok.span,
-                message: format!(
-                    "'{cmd_name}' cannot be used in {event}. Available in: {}.",
-                    requirements.only_in.join(", ")
-                ),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    DiagCode::Irule1001,
+                    cmd_tok.span,
+                    format!(
+                        "'{cmd_name}' cannot be used in {event}. Available in: {}.",
+                        requirements.only_in.join(", ")
+                    ),
+                    Severity::Warning,
+                ));
             return;
         }
 
@@ -353,13 +359,14 @@ impl Analyser {
                 }
                 hint.push('.');
             }
-            self.result.diagnostics.push(Diagnostic {
-                code: DiagCode::Irule1001,
-                span: cmd_tok.span,
-                message: format!("'{cmd_name}' cannot be used in {event}.{hint}"),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    DiagCode::Irule1001,
+                    cmd_tok.span,
+                    format!("'{cmd_name}' cannot be used in {event}.{hint}"),
+                    Severity::Warning,
+                ));
             return;
         }
 
@@ -373,13 +380,14 @@ impl Analyser {
                     format!("'{cmd_name}' may not work in {event}: {desc}.")
                 }
             };
-            self.result.diagnostics.push(Diagnostic {
-                code: DiagCode::Irule1001,
-                span: cmd_tok.span,
-                message,
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    DiagCode::Irule1001,
+                    cmd_tok.span,
+                    message,
+                    Severity::Warning,
+                ));
         }
     }
 
@@ -402,16 +410,17 @@ impl Analyser {
         if !body_decrements(&args[1], &var_name) {
             return;
         }
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule5003,
-            span: tok.span,
-            message: format!(
-                "Loop condition '${var_name} != 0' can miss zero if decremented past it. \
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                DiagCode::Irule5003,
+                tok.span,
+                format!(
+                    "Loop condition '${var_name} != 0' can miss zero if decremented past it. \
                  Consider '${var_name} > 0'."
-            ),
-            severity: Severity::Hint,
-            fixes: Vec::new(),
-        });
+                ),
+                Severity::Hint,
+            ));
     }
 
     /// **IRULE5006.** A top-level-only command (`when` / `proc` /
@@ -429,13 +438,14 @@ impl Analyser {
         if !misplaced {
             return;
         }
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule5006,
-            span: cmd_tok.span,
-            message: format!("'{cmd_name}' is only valid at the top level of an iRule."),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        });
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                DiagCode::Irule5006,
+                cmd_tok.span,
+                format!("'{cmd_name}' is only valid at the top level of an iRule."),
+                Severity::Warning,
+            ));
     }
 
     /// **IRULE5007.** An executable command used on iRules' declaration-only
@@ -455,15 +465,14 @@ impl Analyser {
         {
             return;
         }
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule5007,
-            span: cmd_tok.span,
-            message: format!(
+        self.result.diagnostics.push(crate::analyser::types::Diagnostic::new(
+    DiagCode::Irule5007,
+    cmd_tok.span,
+    format!(
                 "'{cmd_name}' is executable and cannot appear at iRules top level — use it inside a `when` block or a top-level `proc`."
             ),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        });
+    Severity::Warning,
+));
     }
 
     pub(super) fn irules_execution_context(
@@ -580,26 +589,28 @@ impl Analyser {
                     }
                     (None, None) => "an unknown BIG-IP range".to_owned(),
                 };
-                self.result.diagnostics.push(Diagnostic {
-                    code: DiagCode::Irule1002,
-                    span: tok.span,
-                    message: format!(
-                        "iRules event '{event_name}' exists in {range}, but the target \
+                self.result
+                    .diagnostics
+                    .push(crate::analyser::types::Diagnostic::new(
+                        DiagCode::Irule1002,
+                        tok.span,
+                        format!(
+                            "iRules event '{event_name}' exists in {range}, but the target \
                          release is {target}."
-                    ),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                        ),
+                        Severity::Warning,
+                    ));
             }
             return;
         }
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule1002,
-            span: tok.span,
-            message: format!("Unknown iRules event '{event_name}'. Check the event name spelling."),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        });
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                DiagCode::Irule1002,
+                tok.span,
+                format!("Unknown iRules event '{event_name}'. Check the event name spelling."),
+                Severity::Warning,
+            ));
     }
 
     /// **IRULE2003.** Unsafe iRules command (context escalation).
@@ -611,13 +622,14 @@ impl Analyser {
         if !is_unsafe {
             return;
         }
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule2003,
-            span: cmd_tok.span,
-            message: format!("'{cmd_name}' is unsafe in iRules and may allow context escalation"),
-            severity: Severity::Error,
-            fixes: Vec::new(),
-        });
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                DiagCode::Irule2003,
+                cmd_tok.span,
+                format!("'{cmd_name}' is unsafe in iRules and may allow context escalation"),
+                Severity::Error,
+            ));
     }
 
     /// **IRULE3102.** `HTTP::path` / `HTTP::uri` / `HTTP::query` getter
@@ -639,13 +651,14 @@ impl Analyser {
         if !fires {
             return;
         }
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule3102,
-            span: cmd_tok.span,
-            message: crate::irules_checks::format_message(cmd_name),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        });
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                DiagCode::Irule3102,
+                cmd_tok.span,
+                crate::irules_checks::format_message(cmd_name),
+                Severity::Warning,
+            ));
     }
 
     /// **IRULE1003.** Deprecated iRules event referenced by `when`.
@@ -677,13 +690,14 @@ impl Analyser {
             .event_lifecycle(event_name)
             .and_then(|life| life.deprecated)
             .map_or_else(String::new, |release| format!(" as of BIG-IP {release}"));
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule1003,
-            span: tok.span,
-            message: format!("'{event_name}' event is deprecated{since}."),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        });
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                DiagCode::Irule1003,
+                tok.span,
+                format!("'{event_name}' event is deprecated{since}."),
+                Severity::Warning,
+            ));
     }
 
     /// **IRULE1004.** An event-handler command whose registry policy requires
@@ -712,16 +726,17 @@ impl Analyser {
         if !policy.warn_when_implicit || args.iter().skip(1).any(|arg| arg == policy.keyword) {
             return;
         }
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule1004,
-            span: cmd_tok.span,
-            message: format!(
-                "'{cmd_name}' missing an explicit {}. Add '{} <N>' to control execution order.",
-                policy.keyword, policy.keyword,
-            ),
-            severity: Severity::Hint,
-            fixes: Vec::new(),
-        });
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                DiagCode::Irule1004,
+                cmd_tok.span,
+                format!(
+                    "'{cmd_name}' missing an explicit {}. Add '{} <N>' to control execution order.",
+                    policy.keyword, policy.keyword,
+                ),
+                Severity::Hint,
+            ));
     }
 
     /// **IRULE2101.** Heavy `regexp` in a high-frequency event.
@@ -733,16 +748,17 @@ impl Analyser {
         if !is_hot_event(event) {
             return;
         }
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule2101,
-            span: cmd_tok.span,
-            message: format!(
-                "'regexp' in {event} may be expensive at high traffic volumes. \
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                DiagCode::Irule2101,
+                cmd_tok.span,
+                format!(
+                    "'regexp' in {event} may be expensive at high traffic volumes. \
                  Consider 'string match', 'switch -glob', or a data-group lookup."
-            ),
-            severity: Severity::Hint,
-            fixes: Vec::new(),
-        });
+                ),
+                Severity::Hint,
+            ));
     }
 
     /// **IRULE5001.** Ungated `log` in a high-frequency event.
@@ -754,17 +770,18 @@ impl Analyser {
         if !is_hot_event(event) {
             return;
         }
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule5001,
-            span: cmd_tok.span,
-            message: format!(
-                "'log' in {event} fires on every request. \
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                DiagCode::Irule5001,
+                cmd_tok.span,
+                format!(
+                    "'log' in {event} fires on every request. \
                  Set a debug flag in CLIENT_ACCEPTED (e.g. set debug 0) and gate with \
                  if {{$debug}} {{...}}."
-            ),
-            severity: Severity::Hint,
-            fixes: Vec::new(),
-        });
+                ),
+                Severity::Hint,
+            ));
     }
 
     /// **IRULE4001.** Write to a `static::` variable outside `RULE_INIT`.
@@ -781,17 +798,18 @@ impl Analyser {
         let Some(var_name) = static_var_from_set(cmd_name, args) else {
             return;
         };
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule4001,
-            span: cmd_tok.span,
-            message: format!(
-                "Writing to '{var_name}' outside RULE_INIT is dangerous. \
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                DiagCode::Irule4001,
+                cmd_tok.span,
+                format!(
+                    "Writing to '{var_name}' outside RULE_INIT is dangerous. \
                  static:: variables are shared across all connections; \
                  concurrent writes can cause race conditions."
-            ),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        });
+                ),
+                Severity::Warning,
+            ));
     }
 
     /// **IRULE4003.** Variable scoping concern across `when` events.
@@ -842,13 +860,14 @@ impl Analyser {
         if concerns.len() > 1 {
             msg = format!("{msg}; {}", concerns[1..].join("; "));
         }
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule4003,
-            span: cmd_tok.span,
-            message: msg,
-            severity: Severity::Hint,
-            fixes: Vec::new(),
-        });
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                DiagCode::Irule4003,
+                cmd_tok.span,
+                msg,
+                Severity::Hint,
+            ));
     }
 
     /// **IRULE6001.** Global namespace variable usage (CMP pinning).
@@ -865,17 +884,18 @@ impl Analyser {
             && let Some(var_name) = args.first()
         {
             let static_name = format!("static::{var_name}");
-            self.result.diagnostics.push(Diagnostic {
-                code: DiagCode::Irule6001,
-                span: cmd_tok.span,
-                message: format!(
-                    "'global {var_name}' imports from the global namespace, \
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    DiagCode::Irule6001,
+                    cmd_tok.span,
+                    format!(
+                        "'global {var_name}' imports from the global namespace, \
                      forcing CMP compatibility mode and pinning the virtual server \
                      to a single TMM. Use '{static_name}' instead."
-                ),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+                    ),
+                    Severity::Warning,
+                ));
             return;
         }
 
@@ -893,16 +913,18 @@ impl Analyser {
             if let Some(bare) = word.strip_prefix("::") {
                 let var_name = word.as_str();
                 let static_name = format!("static::{bare}");
-                self.result.diagnostics.push(Diagnostic {
-                    code: DiagCode::Irule6001,
-                    span: fix_span,
-                    message: format!(
-                        "Global namespace variable '{var_name}' forces CMP compatibility \
+                self.result.diagnostics.push(
+                    crate::analyser::types::Diagnostic::new(
+                        DiagCode::Irule6001,
+                        fix_span,
+                        format!(
+                            "Global namespace variable '{var_name}' forces CMP compatibility \
                          mode, pinning the virtual server to a single TMM. \
                          Use '{static_name}' instead."
-                    ),
-                    severity: Severity::Warning,
-                    fixes: vec![CodeFix {
+                        ),
+                        Severity::Warning,
+                    )
+                    .with_fixes(vec![CodeFix {
                         span: fix_span,
                         new_text: static_name.clone(),
                         description: format!("Replace '{var_name}' with '{static_name}'"),
@@ -910,8 +932,8 @@ impl Analyser {
                         // different lifetime from a global — the CMP fix, and a change of
                         // where the value lives.
                         safety: crate::irules_checks::FixSafety::RequiresReview,
-                    }],
-                });
+                    }]),
+                );
                 continue;
             }
             // Implicit globals in RULE_INIT: `set var value` (no `::`) is
@@ -923,24 +945,26 @@ impl Analyser {
             }
             let bare = word.as_str();
             let static_name = format!("static::{bare}");
-            self.result.diagnostics.push(Diagnostic {
-                code: DiagCode::Irule6001,
-                span: fix_span,
-                message: format!(
-                    "'{bare}' in RULE_INIT is implicitly global — RULE_INIT \
+            self.result.diagnostics.push(
+                crate::analyser::types::Diagnostic::new(
+                    DiagCode::Irule6001,
+                    fix_span,
+                    format!(
+                        "'{bare}' in RULE_INIT is implicitly global — RULE_INIT \
                      runs at the global namespace scope. This forces CMP \
                      compatibility mode, pinning the virtual server to a \
                      single TMM. Use '{static_name}' instead."
-                ),
-                severity: Severity::Warning,
-                fixes: vec![CodeFix {
+                    ),
+                    Severity::Warning,
+                )
+                .with_fixes(vec![CodeFix {
                     span: fix_span,
                     new_text: static_name.clone(),
                     description: format!("Replace '{bare}' with '{static_name}'"),
                     // IRULE6001: as above.
                     safety: crate::irules_checks::FixSafety::RequiresReview,
-                }],
-            });
+                }]),
+            );
         }
     }
 }

--- a/rust/tcl-compiler/src/analyser/oo.rs
+++ b/rust/tcl-compiler/src/analyser/oo.rs
@@ -466,16 +466,17 @@ impl Analyser {
         if definer_disabled || self.oo_member_available(grammar, subcmd) {
             return;
         }
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: tcl_core_types::DiagCode::W002,
-            span: tok.span,
-            message: format!(
-                "'{subcmd}' is disabled in the active dialect profile ('{}')",
-                self.dialect()
-            ),
-            severity: super::types::Severity::Warning,
-            fixes: Vec::new(),
-        });
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                tcl_core_types::DiagCode::W002,
+                tok.span,
+                format!(
+                    "'{subcmd}' is disabled in the active dialect profile ('{}')",
+                    self.dialect()
+                ),
+                super::types::Severity::Warning,
+            ));
     }
 
     /// Emit W002 for a recognised optional member argument that exists in the
@@ -505,17 +506,18 @@ impl Analyser {
         let Some(tok) = arg_tokens.get(usize::from(position)) else {
             return false;
         };
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: tcl_core_types::DiagCode::W002,
-            span: tok.span,
-            message: format!(
-                "'{}' is disabled in the active dialect profile ('{}')",
-                option.value,
-                self.dialect()
-            ),
-            severity: super::types::Severity::Warning,
-            fixes: Vec::new(),
-        });
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                tcl_core_types::DiagCode::W002,
+                tok.span,
+                format!(
+                    "'{}' is disabled in the active dialect profile ('{}')",
+                    option.value,
+                    self.dialect()
+                ),
+                super::types::Severity::Warning,
+            ));
         true
     }
 

--- a/rust/tcl-compiler/src/analyser/recovery.rs
+++ b/rust/tcl-compiler/src/analyser/recovery.rs
@@ -351,20 +351,22 @@ impl Analyser {
             // would shift the insertion one byte past the
             // intended location.
             let insert_span = tcl_lexer::Span::new(diag_span.end(), diag_span.end());
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::E101,
-                span: diag_span,
-                message: "Missing '{' after switch — body cases follow without braces".to_string(),
-                severity: super::types::Severity::Error,
-                fixes: vec![super::types::CodeFix {
+            self.result.diagnostics.push(
+                crate::analyser::types::Diagnostic::new(
+                    DiagCode::E101,
+                    diag_span,
+                    "Missing '{' after switch — body cases follow without braces".to_string(),
+                    super::types::Severity::Error,
+                )
+                .with_fixes(vec![super::types::CodeFix {
                     span: insert_span,
                     new_text: " {".to_string(),
                     description: "Insert missing '{'".to_string(),
                     // E101: the source does not parse; where the missing brace belongs
                     // is a recovery heuristic, not a proof.
                     safety: crate::irules_checks::FixSafety::RequiresReview,
-                }],
-            });
+                }]),
+            );
         }
 
         case_count
@@ -491,19 +493,21 @@ impl Analyser {
         let insert_span = tcl_lexer::Span::new(abs_insert, abs_insert);
 
         if !self.disabled_diagnostics.contains("E103") {
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::E103,
-                span: stolen_span,
-                message: "Missing '}' — a nested body consumed this closing brace".to_string(),
-                severity: super::types::Severity::Error,
-                fixes: vec![super::types::CodeFix {
+            self.result.diagnostics.push(
+                crate::analyser::types::Diagnostic::new(
+                    DiagCode::E103,
+                    stolen_span,
+                    "Missing '}' — a nested body consumed this closing brace".to_string(),
+                    super::types::Severity::Error,
+                )
+                .with_fixes(vec![super::types::CodeFix {
                     span: insert_span,
                     new_text: format!("{indent}}}\n"),
                     description: "Insert missing '}'".to_string(),
                     // E103: as E101 — a brace-recovery heuristic.
                     safety: crate::irules_checks::FixSafety::RequiresReview,
-                }],
-            });
+                }]),
+            );
         }
         true
     }
@@ -545,13 +549,14 @@ impl Analyser {
         // matching the E201/E202/E203 convention, so the squiggle sits on
         // the actual problem instead of underlining unrelated source.
         let anchor = last_delim_tok.map_or(cmd.span.start(), |t| t.span.start());
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::E200,
-            span: Span::new(anchor, anchor),
-            message: suffix.to_string(),
-            severity: super::types::Severity::Error,
-            fixes: Vec::new(),
-        });
+        self.result
+            .diagnostics
+            .push(crate::analyser::types::Diagnostic::new(
+                DiagCode::E200,
+                Span::new(anchor, anchor),
+                suffix.to_string(),
+                super::types::Severity::Error,
+            ));
     }
 
     /// Constant-folded view of [`Self::builtin_command_names`].

--- a/rust/tcl-compiler/src/analyser/scope.rs
+++ b/rust/tcl-compiler/src/analyser/scope.rs
@@ -1991,7 +1991,7 @@ impl Analyser {
         site_span: Span,
         scope_path: &[usize],
     ) {
-        use super::types::{Diagnostic, Severity};
+        use super::types::Severity;
         use crate::naming::is_brace_substitutable;
         use std::borrow::Cow;
 
@@ -2067,13 +2067,14 @@ impl Analyser {
                 use std::fmt::Write as _;
                 let _ = write!(message, "; did you mean '{best}'?");
             }
-            self.result.diagnostics.push(Diagnostic {
-                code: DiagCode::W215,
-                span: site_span,
-                message,
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    DiagCode::W215,
+                    site_span,
+                    message,
+                    Severity::Warning,
+                ));
         }
 
         if let Some(elem) = element {
@@ -2083,17 +2084,18 @@ impl Analyser {
                 Cow::Borrowed(elem)
             };
             if runtime_element.contains(')') {
-                self.result.diagnostics.push(Diagnostic {
-                    code: DiagCode::W215,
-                    span: site_span,
-                    message: "array element index contains ')'; the element can be created \
+                self.result
+                    .diagnostics
+                    .push(crate::analyser::types::Diagnostic::new(
+                        DiagCode::W215,
+                        site_span,
+                        "array element index contains ')'; the element can be created \
                               and read via ``set arr(idx) ...`` / ``[set \"arr(idx)\"]``, but \
                               is not reachable via $-substitution (``$arr(idx)`` reads up \
                               to the first ``)`` and stops there)"
-                        .to_string(),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                            .to_string(),
+                        Severity::Warning,
+                    ));
             }
         }
     }

--- a/rust/tcl-compiler/src/analyser/source_integrity.rs
+++ b/rust/tcl-compiler/src/analyser/source_integrity.rs
@@ -32,10 +32,10 @@ pub fn bidi_control_diagnostics(source: &str) -> Vec<Diagnostic> {
             let name = bidi_control_name(ch)?;
             let start = u32::try_from(offset).unwrap_or(u32::MAX);
             let len = u32::try_from(ch.len_utf8()).unwrap_or(0);
-            Some(Diagnostic {
-                code: DiagCode::W305,
-                span: Span::new(start, start.saturating_add(len)),
-                message: format!(
+            Some(crate::analyser::types::Diagnostic::new(
+    DiagCode::W305,
+    Span::new(start, start.saturating_add(len)),
+    format!(
                     "Bidirectional formatting control U+{:04X} {name} — this makes the surrounding \
                      source render in a different order from the one it is parsed and executed in, \
                      so a reviewer can approve code that does something other than what their editor \
@@ -43,9 +43,8 @@ pub fn bidi_control_diagnostics(source: &str) -> Vec<Diagnostic> {
                      an escape (`\\u{:04X}`) if the character is genuinely part of the data.",
                     ch as u32, ch as u32,
                 ),
-                severity: Severity::Error,
-                fixes: Vec::new(),
-            })
+    Severity::Error,
+))
         })
         .collect()
 }

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -2006,13 +2006,14 @@ impl Analyser {
                 // Any unexpected lexer warning → catch-all E200.
                 _ => DiagCode::E200,
             };
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code,
-                span: Span::new(w.offset, w.offset),
-                message: w.message,
-                severity: super::types::Severity::Error,
-                fixes: Vec::new(),
-            });
+            self.result
+                .diagnostics
+                .push(crate::analyser::types::Diagnostic::new(
+                    code,
+                    Span::new(w.offset, w.offset),
+                    w.message,
+                    super::types::Severity::Error,
+                ));
         }
     }
 

--- a/rust/tcl-compiler/src/analyser/syntax_checks.rs
+++ b/rust/tcl-compiler/src/analyser/syntax_checks.rs
@@ -143,13 +143,12 @@ fn detect_e201(
         return d;
     }
     // Fallback: highlight just the opening `[`, no fix.
-    Diagnostic {
-        code: DiagCode::E201,
-        span: Span::new(bracket_off, bracket_off),
-        message: "missing close-bracket".to_string(),
-        severity: Severity::Error,
-        fixes: Vec::new(),
-    }
+    crate::analyser::types::Diagnostic::new(
+        DiagCode::E201,
+        Span::new(bracket_off, bracket_off),
+        "missing close-bracket".to_string(),
+        Severity::Error,
+    )
 }
 
 /// Build an E201 anchored from the `[` to `insert_idx`-in-content, with
@@ -163,19 +162,19 @@ fn e201_with_insert(
     let insert_off = content_start + u32::try_from(insert_idx).unwrap_or(0);
     // Diagnostic end: the last content byte before the insertion.
     let diag_end = content_start + u32::try_from(insert_idx.saturating_sub(1)).unwrap_or(0);
-    Diagnostic {
-        code: DiagCode::E201,
-        span: Span::new(bracket_off, diag_end.max(bracket_off)),
-        message: "missing close-bracket".to_string(),
-        severity: Severity::Error,
-        fixes: vec![CodeFix {
-            span: Span::new(insert_off, insert_off),
-            new_text: "]".to_string(),
-            description: fix_desc.to_string(),
-            // E201: a close-bracket recovery heuristic.
-            safety: crate::irules_checks::FixSafety::RequiresReview,
-        }],
-    }
+    crate::analyser::types::Diagnostic::new(
+        DiagCode::E201,
+        Span::new(bracket_off, diag_end.max(bracket_off)),
+        "missing close-bracket".to_string(),
+        Severity::Error,
+    )
+    .with_fixes(vec![CodeFix {
+        span: Span::new(insert_off, insert_off),
+        new_text: "]".to_string(),
+        description: fix_desc.to_string(),
+        // E201: a close-bracket recovery heuristic.
+        safety: crate::irules_checks::FixSafety::RequiresReview,
+    }])
 }
 
 /// E201 heuristic: a `#` comment line follows — insert `]` at the end of
@@ -443,31 +442,30 @@ fn detect_e202(
             if known.contains(extract_first_word(stripped)) {
                 // Virtual `"` right after the opening `"`.
                 let insert_off = quote_off + 1;
-                return Diagnostic {
-                    code: DiagCode::E202,
-                    span: diag_span,
-                    message: "missing \"".to_string(),
-                    severity: Severity::Error,
-                    fixes: vec![CodeFix {
-                        span: Span::new(insert_off, insert_off),
-                        new_text: "\"".to_string(),
-                        description: "Insert missing '\"' to close string".to_string(),
-                        // E202: a close-quote recovery heuristic.
-                        safety: crate::irules_checks::FixSafety::RequiresReview,
-                    }],
-                };
+                return crate::analyser::types::Diagnostic::new(
+                    DiagCode::E202,
+                    diag_span,
+                    "missing \"".to_string(),
+                    Severity::Error,
+                )
+                .with_fixes(vec![CodeFix {
+                    span: Span::new(insert_off, insert_off),
+                    new_text: "\"".to_string(),
+                    description: "Insert missing '\"' to close string".to_string(),
+                    // E202: a close-quote recovery heuristic.
+                    safety: crate::irules_checks::FixSafety::RequiresReview,
+                }]);
             }
             // First non-blank line isn't a known command — stop.
             break;
         }
     }
-    Diagnostic {
-        code: DiagCode::E202,
-        span: diag_span,
-        message: "missing \"".to_string(),
-        severity: Severity::Error,
-        fixes: Vec::new(),
-    }
+    crate::analyser::types::Diagnostic::new(
+        DiagCode::E202,
+        diag_span,
+        "missing \"".to_string(),
+        Severity::Error,
+    )
 }
 
 /// Build the E203 diagnostic for an unterminated `{`: the de-indented
@@ -495,21 +493,20 @@ fn detect_e203(
     // known-command-name universe.
     let expr_role = registry.is_some_and(|reg| unterminated_arg_is_expr(tok, cmd, reg));
     if let Some(fix) = e203_brace_fix(tok, source, content_start, known, expr_role) {
-        return Diagnostic {
-            code: DiagCode::E203,
-            span: diag_span,
-            message: "missing close-brace".to_string(),
-            severity: Severity::Error,
-            fixes: vec![fix],
-        };
+        return crate::analyser::types::Diagnostic::new(
+            DiagCode::E203,
+            diag_span,
+            "missing close-brace".to_string(),
+            Severity::Error,
+        )
+        .with_fixes(vec![fix]);
     }
-    Diagnostic {
-        code: DiagCode::E203,
-        span: diag_span,
-        message: "missing close-brace".to_string(),
-        severity: Severity::Error,
-        fixes: Vec::new(),
-    }
+    crate::analyser::types::Diagnostic::new(
+        DiagCode::E203,
+        diag_span,
+        "missing close-brace".to_string(),
+        Severity::Error,
+    )
 }
 
 /// `true` when the unterminated brace-word token `tok` sits in an
@@ -815,13 +812,13 @@ fn make_e100(
         bracket_off
     };
 
-    Diagnostic {
-        code: DiagCode::E100,
-        span: Span::new(diag_start.min(bracket_off), bracket_end),
-        message: "Unmatched ']' \u{2014} missing opening '['?".to_string(),
-        severity: Severity::Error,
-        fixes,
-    }
+    crate::analyser::types::Diagnostic::new(
+        DiagCode::E100,
+        Span::new(diag_start.min(bracket_off), bracket_end),
+        "Unmatched ']' \u{2014} missing opening '['?".to_string(),
+        Severity::Error,
+    )
+    .with_fixes(fixes)
 }
 
 /// Find where the missing `[` should go.  Heuristics, in order: a
@@ -895,13 +892,13 @@ fn make_e102(tok: &Token, rel: usize, source: &str) -> Diagnostic {
     let fixes = stray_brace_fix(tok, brace_off, source)
         .into_iter()
         .collect();
-    Diagnostic {
-        code: DiagCode::E102,
-        span: Span::new(brace_off, brace_off + 1),
-        message: "Unmatched '}' \u{2014} missing opening '{'?".to_string(),
-        severity: Severity::Error,
-        fixes,
-    }
+    crate::analyser::types::Diagnostic::new(
+        DiagCode::E102,
+        Span::new(brace_off, brace_off + 1),
+        "Unmatched '}' \u{2014} missing opening '{'?".to_string(),
+        Severity::Error,
+    )
+    .with_fixes(fixes)
 }
 
 /// Build a fix that deletes a stray `}` and its line, when the line

--- a/rust/tcl-compiler/src/analyser/tk_checks.rs
+++ b/rust/tcl-compiler/src/analyser/tk_checks.rs
@@ -95,7 +95,7 @@ use tcl_core_types::DiagCode;
 use tcl_lexer::Token;
 
 use super::state::Analyser;
-use super::types::{Diagnostic, Severity};
+use super::types::Severity;
 
 /// Per-parent geometry-manager usage accumulated during the walk so
 /// TK1001 can be decided post-walk.
@@ -261,15 +261,13 @@ impl Analyser {
                 && parent != "."
                 && !self.tk_parent_widget_exists(&domain, resolved, parent)
             {
-                self.tk_pending_diags.push(Diagnostic {
-                    code: DiagCode::Tk1002,
-                    span: cmd_tok.span,
-                    message: format!(
-                        "Widget path '{path}' references non-existent parent '{parent}'."
-                    ),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                self.tk_pending_diags
+                    .push(crate::analyser::types::Diagnostic::new(
+                        DiagCode::Tk1002,
+                        cmd_tok.span,
+                        format!("Widget path '{path}' references non-existent parent '{parent}'."),
+                        Severity::Warning,
+                    ));
             }
 
             self.tk_domain_state(&domain, resolved)
@@ -410,13 +408,15 @@ impl Analyser {
                     safety: crate::irules_checks::FixSafety::RequiresReview,
                 });
             }
-            self.tk_pending_diags.push(Diagnostic {
-                code: DiagCode::Tk1003,
-                span,
-                message,
-                severity: Severity::Hint,
-                fixes,
-            });
+            self.tk_pending_diags.push(
+                crate::analyser::types::Diagnostic::new(
+                    DiagCode::Tk1003,
+                    span,
+                    message,
+                    Severity::Hint,
+                )
+                .with_fixes(fixes),
+            );
         }
     }
 
@@ -499,16 +499,17 @@ impl Analyser {
                     continue;
                 };
                 for (_manager, span) in &usage.sites {
-                    self.result.diagnostics.push(Diagnostic {
-                        code: DiagCode::Tk1001,
-                        span: *span,
-                        message: format!(
-                            "Geometry manager conflict: cannot mix '{first}' and '{second}' \
+                    self.result
+                        .diagnostics
+                        .push(crate::analyser::types::Diagnostic::new(
+                            DiagCode::Tk1001,
+                            *span,
+                            format!(
+                                "Geometry manager conflict: cannot mix '{first}' and '{second}' \
                              in the same parent '{parent}'."
-                        ),
-                        severity: Severity::Warning,
-                        fixes: Vec::new(),
-                    });
+                            ),
+                            Severity::Warning,
+                        ));
                 }
             }
         }

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -106,6 +106,39 @@ pub struct Diagnostic {
     pub fixes: Vec<CodeFix>,
 }
 
+impl Diagnostic {
+    /// Construct a diagnostic without a suggested fix.
+    ///
+    /// Emitters that can offer a source edit add it with
+    /// [`Self::with_fix`] or [`Self::with_fixes`]. Keeping the empty list
+    /// here makes the common, fix-less case explicit without repeating the
+    /// representation detail at every emission site.
+    #[must_use]
+    pub fn new(code: DiagCode, span: Span, message: impl Into<String>, severity: Severity) -> Self {
+        Self {
+            code,
+            span,
+            message: message.into(),
+            severity,
+            fixes: Vec::new(),
+        }
+    }
+
+    /// Attach one suggested edit.
+    #[must_use]
+    pub fn with_fix(mut self, fix: CodeFix) -> Self {
+        self.fixes.push(fix);
+        self
+    }
+
+    /// Attach the complete set of suggested edits computed by an emitter.
+    #[must_use]
+    pub fn with_fixes(mut self, fixes: Vec<CodeFix>) -> Self {
+        self.fixes = fixes;
+        self
+    }
+}
+
 /// One statically recorded `namespace ensemble` subcommand: the command it
 /// dispatches to, plus **how** the ensemble bound the two together
 /// (issue #1281).


### PR DESCRIPTION
## Summary

- Add the reviewed diagnostic builder refactor across analyser diagnostics and state helpers.
- Centralize diagnostic construction while preserving existing diagnostic behaviour.

## Validation

- `cargo clippy -p tcl-compiler --lib --tests -- -D warnings`
- `make rust-check`
- `make prep-pr`

Closes #1397