### PR TITLE
refactor(dialect): resolve profile ingress consumers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4176,6 +4176,7 @@ dependencies = [
  "serde_json",
  "tabled",
  "tcl-compiler",
+ "tcl-dialect",
  "tcl-lexer",
  "tcl-lsp-core",
  "tcl-pkg",

--- a/rust/tcl-cli-support/Cargo.toml
+++ b/rust/tcl-cli-support/Cargo.toml
@@ -29,6 +29,7 @@ authors.workspace = true
 
 [dependencies]
 tcl-lexer = { path = "../tcl-lexer" }
+tcl-dialect = { path = "../tcl-dialect" }
 tcl-registry = { path = "../tcl-registry" }
 tcl-compiler = { path = "../tcl-compiler" }
 tcl-lsp-core = { path = "../tcl-lsp-core" }

--- a/rust/tcl-cli-support/src/input.rs
+++ b/rust/tcl-cli-support/src/input.rs
@@ -22,7 +22,7 @@
 use std::io::{IsTerminal, Read};
 use std::path::{Path, PathBuf};
 
-use tcl_dialect::DialectProfile;
+use tcl_dialect::{DialectProfile, DialectSet};
 use tcl_lsp_core::source_decode::{DecodeReport, decode_source, encoding_integrity_diagnostics};
 use tcl_lsp_core::source_style::StyleDiagnostic;
 
@@ -180,15 +180,24 @@ pub fn combined_effective_dialect(
 /// This is the CLI ingest boundary: an unrecognised spelling is an input
 /// error, never an accidental fallback to plain Tcl. Registered aliases are
 /// accepted through [`DialectProfile::find`] and become the catalog's one
-/// canonical profile before any command-specific behaviour runs.
+/// canonical profile before any command-specific behaviour runs. A recognised
+/// set-only ingress name (currently `tk`) has no catalog profile by design, so
+/// it is accepted through [`DialectSet::parse`] and resolved to the typed
+/// additive profile that carries its identity through downstream consumers.
 pub fn resolve_dialect(value: Option<&str>) -> Result<Option<&'static DialectProfile>, CliError> {
     value
         .map(|name| {
-            DialectProfile::find(name).ok_or_else(|| {
-                CliError::input(format!(
-                    "unknown dialect `{name}`; use a registered dialect name or alias"
-                ))
-            })
+            DialectProfile::find(name)
+                .or_else(|| {
+                    DialectSet::parse(name)
+                        .filter(|&set| set == DialectSet::TK)
+                        .map(|_| DialectProfile::tk())
+                })
+                .ok_or_else(|| {
+                    CliError::input(format!(
+                        "unknown dialect `{name}`; use a registered dialect name or alias"
+                    ))
+                })
         })
         .transpose()
 }
@@ -412,6 +421,7 @@ fn expand_user(path: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::resolve_dialect;
+    use tcl_dialect::{DialectProfile, DialectSet};
 
     #[test]
     fn explicit_irules_alias_resolves_to_the_canonical_profile() {
@@ -420,6 +430,17 @@ mod tests {
             .expect("an explicit dialect resolves");
         assert_eq!(profile.name, "f5-irules");
         assert!(profile.is_irules());
+    }
+
+    #[test]
+    fn explicit_set_only_dialect_resolves_at_cli_ingress() {
+        let profile = resolve_dialect(Some("tk"))
+            .expect("recognized set-only dialect")
+            .expect("an explicit dialect resolves");
+        assert_eq!(profile.name, "tk");
+        assert!(!profile.is_fallback());
+        assert!(profile.hosts_tk());
+        assert!(DialectProfile::availability_for_name("tk").contains(DialectSet::TK));
     }
 
     #[test]

--- a/rust/tcl-cli-support/src/input.rs
+++ b/rust/tcl-cli-support/src/input.rs
@@ -22,7 +22,7 @@
 use std::io::{IsTerminal, Read};
 use std::path::{Path, PathBuf};
 
-use tcl_dialect::{DialectProfile, DialectSet};
+use tcl_dialect::DialectProfile;
 use tcl_lsp_core::source_decode::{DecodeReport, decode_source, encoding_integrity_diagnostics};
 use tcl_lsp_core::source_style::StyleDiagnostic;
 
@@ -187,17 +187,11 @@ pub fn combined_effective_dialect(
 pub fn resolve_dialect(value: Option<&str>) -> Result<Option<&'static DialectProfile>, CliError> {
     value
         .map(|name| {
-            DialectProfile::find(name)
-                .or_else(|| {
-                    DialectSet::parse(name)
-                        .filter(|&set| set == DialectSet::TK)
-                        .map(|_| DialectProfile::tk())
-                })
-                .ok_or_else(|| {
-                    CliError::input(format!(
-                        "unknown dialect `{name}`; use a registered dialect name or alias"
-                    ))
-                })
+            DialectProfile::resolve_known(name).ok_or_else(|| {
+                CliError::input(format!(
+                    "unknown dialect `{name}`; use a registered dialect name or alias"
+                ))
+            })
         })
         .transpose()
 }

--- a/rust/tcl-cli-support/src/input.rs
+++ b/rust/tcl-cli-support/src/input.rs
@@ -22,6 +22,7 @@
 use std::io::{IsTerminal, Read};
 use std::path::{Path, PathBuf};
 
+use tcl_dialect::DialectProfile;
 use tcl_lsp_core::source_decode::{DecodeReport, decode_source, encoding_integrity_diagnostics};
 use tcl_lsp_core::source_style::StyleDiagnostic;
 
@@ -95,11 +96,18 @@ impl InputDocument {
     /// `tcl8.6` — the same priority order the LSP server applies, so `tcl
     /// diag` and the editor report the same set for the same file.
     #[must_use]
-    pub fn effective_dialect(&self, explicit: Option<&str>) -> String {
-        if let Some(d) = explicit {
-            return d.to_string();
+    pub fn effective_dialect(
+        &self,
+        explicit: Option<&'static DialectProfile>,
+    ) -> &'static DialectProfile {
+        if let Some(profile) = explicit {
+            return profile;
         }
-        tcl_registry::dialects::detect_dialect(&self.source, self.filename(), "tcl8.6").to_string()
+        DialectProfile::by_name(tcl_registry::dialects::detect_dialect(
+            &self.source,
+            self.filename(),
+            "tcl8.6",
+        ))
     }
 
     /// The dialect this document's own content or name gives away, or `None`
@@ -108,9 +116,9 @@ impl InputDocument {
     /// documents can tell "this file says nothing" from "this file says plain
     /// Tcl".
     #[must_use]
-    fn detected_dialect(&self) -> Option<&'static str> {
+    fn detected_dialect(&self) -> Option<&'static DialectProfile> {
         let detected = tcl_registry::dialects::detect_dialect(&self.source, self.filename(), "");
-        (!detected.is_empty()).then_some(detected)
+        (!detected.is_empty()).then(|| DialectProfile::by_name(detected))
     }
 
     /// The originating file name, for the detector's extension tier.
@@ -154,15 +162,35 @@ impl InputDocument {
 /// gives the per-document diagnostics verbs, so `tcl opt` and `tcl diag` agree
 /// about what a file is.
 #[must_use]
-pub fn combined_effective_dialect(documents: &[InputDocument], explicit: Option<&str>) -> String {
-    if let Some(d) = explicit {
-        return d.to_string();
+pub fn combined_effective_dialect(
+    documents: &[InputDocument],
+    explicit: Option<&'static DialectProfile>,
+) -> &'static DialectProfile {
+    if let Some(profile) = explicit {
+        return profile;
     }
     documents
         .iter()
         .find_map(InputDocument::detected_dialect)
-        .unwrap_or("tcl8.6")
-        .to_owned()
+        .unwrap_or_else(|| DialectProfile::by_name("tcl8.6"))
+}
+
+/// Resolve an optional CLI dialect argument to its canonical profile.
+///
+/// This is the CLI ingest boundary: an unrecognised spelling is an input
+/// error, never an accidental fallback to plain Tcl. Registered aliases are
+/// accepted through [`DialectProfile::find`] and become the catalog's one
+/// canonical profile before any command-specific behaviour runs.
+pub fn resolve_dialect(value: Option<&str>) -> Result<Option<&'static DialectProfile>, CliError> {
+    value
+        .map(|name| {
+            DialectProfile::find(name).ok_or_else(|| {
+                CliError::input(format!(
+                    "unknown dialect `{name}`; use a registered dialect name or alias"
+                ))
+            })
+        })
+        .transpose()
 }
 
 /// `pkgIndex.tcl` is always accepted; otherwise the extension must be known.
@@ -379,4 +407,28 @@ fn expand_user(path: &Path) -> PathBuf {
         return PathBuf::from(home);
     }
     path.to_path_buf()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_dialect;
+
+    #[test]
+    fn explicit_irules_alias_resolves_to_the_canonical_profile() {
+        let profile = resolve_dialect(Some("irules"))
+            .expect("registered alias")
+            .expect("an explicit dialect resolves");
+        assert_eq!(profile.name, "f5-irules");
+        assert!(profile.is_irules());
+    }
+
+    #[test]
+    fn unknown_explicit_dialect_is_an_input_error() {
+        let error = resolve_dialect(Some("not-a-real-dialect"))
+            .expect_err("an unknown spelling must not fall back");
+        assert_eq!(
+            error.to_string(),
+            "unknown dialect `not-a-real-dialect`; use a registered dialect name or alias"
+        );
+    }
 }

--- a/rust/tcl-cli-support/src/lib.rs
+++ b/rust/tcl-cli-support/src/lib.rs
@@ -41,6 +41,7 @@ pub mod spec_import;
 pub use highlight::{highlight_ansi, highlight_html};
 pub use input::{
     CliError, InputDocument, combine_sources, combined_effective_dialect, read_input_documents,
+    resolve_dialect,
 };
 pub use output::{
     OutputTarget, ensure_ascii, expand_tabs, resolve_use_colour, write_binary_output,

--- a/rust/tcl-cli/src/cli.rs
+++ b/rust/tcl-cli/src/cli.rs
@@ -83,6 +83,18 @@ pub struct InputArgs {
     pub output: Option<PathBuf>,
 }
 
+impl InputArgs {
+    /// Resolve the optional CLI spelling once at the ingest boundary.
+    ///
+    /// Every verb receives the canonical profile, so aliases such as
+    /// `irules` cannot leak into string-keyed downstream checks.
+    pub fn dialect_profile(
+        &self,
+    ) -> Result<Option<&'static tcl_dialect::DialectProfile>, tcl_cli_support::CliError> {
+        tcl_cli_support::resolve_dialect(self.dialect.as_deref())
+    }
+}
+
 /// Paired `--colour` / `--no-colour` toggle (resolved against config + TTY).
 #[derive(Debug, Args)]
 pub struct ColourArgs {

--- a/rust/tcl-cli/src/commands/compile.rs
+++ b/rust/tcl-cli/src/commands/compile.rs
@@ -70,20 +70,20 @@ fn maybe_optimise(
 /// `tcl dis` — compile source and emit human-readable bytecode disassembly.
 pub fn run_dis(input: &InputArgs, optimise_on: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
-    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
-    let registry = registry_for_dialect(&dialect);
+    let dialect = combined_effective_dialect(&documents, input.dialect_profile()?);
+    let registry = registry_for_dialect(dialect.name);
     let source = maybe_optimise(
         &combine_sources(&documents),
         &registry,
-        &dialect,
+        dialect.name,
         optimise_on,
     );
 
     let ir = lower_to_ir_for_bytecode_with_dialect(
         &source,
         &registry,
-        tcl_lexer::LexerConfig::for_dialect(&dialect),
-        &dialect,
+        tcl_lexer::LexerConfig::for_dialect(dialect.name),
+        dialect.name,
     );
     let cfg = build_cfg_codegen(&ir, false);
     let module = codegen_module(&cfg, &ir, &registry);
@@ -99,11 +99,11 @@ pub fn run_dis(input: &InputArgs, optimise_on: bool) -> anyhow::Result<u8> {
 /// fallback inside the generated module.
 pub fn run_compwasm(input: &InputArgs, wat_output: Option<&std::path::Path>) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
-    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
-    let registry = registry_for_dialect(&dialect);
+    let dialect = combined_effective_dialect(&documents, input.dialect_profile()?);
+    let registry = registry_for_dialect(dialect.name);
     let source = combine_sources(&documents);
 
-    let unit = CompilationUnit::build_for_dialect(&source, &registry, false, &dialect);
+    let unit = CompilationUnit::build_for_dialect(&source, &registry, false, dialect.name);
     let mut wasm = compile_wasm(&unit, &registry, WasmCompileOptions::hosted());
     let bytes = wasm.to_bytes();
 

--- a/rust/tcl-cli/src/commands/compile.rs
+++ b/rust/tcl-cli/src/commands/compile.rs
@@ -58,9 +58,10 @@ fn maybe_optimise(
     optimise_on: bool,
 ) -> String {
     if optimise_on {
+        let profile = tcl_dialect::DialectProfile::by_name(dialect);
         apply_optimisations(
             source,
-            &optimise_with_dialect(source, registry, Some(dialect)),
+            &optimise_with_dialect(source, registry, Some(profile)),
         )
     } else {
         source.to_owned()

--- a/rust/tcl-cli/src/commands/diag.rs
+++ b/rust/tcl-cli/src/commands/diag.rs
@@ -146,7 +146,7 @@ struct Row {
 /// very claim issue #977 is about.
 fn cross_file_call_site_evidence(
     documents: &[InputDocument],
-    dialect_override: Option<&str>,
+    dialect_override: Option<&'static tcl_dialect::DialectProfile>,
 ) -> Option<CallSiteEvidence> {
     if documents.len() < 2 {
         return None;
@@ -154,7 +154,7 @@ fn cross_file_call_site_evidence(
     let mut known: HashSet<String> = HashSet::new();
     for document in documents {
         let dialect = document.effective_dialect(dialect_override);
-        known.extend(document_proc_names(document, &dialect));
+        known.extend(document_proc_names(document, dialect));
     }
     // Naming several files on one command line asserts they are one program,
     // so an unenumerable dispatch in any of them may reach any of their
@@ -167,8 +167,8 @@ fn cross_file_call_site_evidence(
         let dialect = document.effective_dialect(dialect_override);
         merged.merge_from(&tcl_compiler::unit_scope::scan_source_call_sites(
             &document.source,
-            &registry_for_dialect(&dialect),
-            &dialect,
+            &registry_for_dialect(dialect.name),
+            dialect.name,
             &known,
             &reach,
         ));
@@ -178,10 +178,13 @@ fn cross_file_call_site_evidence(
 
 /// The qualified names of every procedure `document` declares, from the same
 /// [`tcl_compiler::signature_scan`] the analyser and the LSP index use.
-fn document_proc_names(document: &InputDocument, dialect: &str) -> Vec<String> {
+fn document_proc_names(
+    document: &InputDocument,
+    dialect: &tcl_dialect::DialectProfile,
+) -> Vec<String> {
     tcl_compiler::signature_scan::extract_signatures(
         &document.source,
-        &registry_for_dialect(dialect),
+        &registry_for_dialect(dialect.name),
     )
     .procs
     .into_keys()
@@ -198,7 +201,7 @@ fn document_proc_names(document: &InputDocument, dialect: &str) -> Vec<String> {
 /// `(line, column, code)` order; `disabled` removes `--disable`d codes.
 fn collect_rows(
     document: &InputDocument,
-    dialect: &str,
+    dialect: &tcl_dialect::DialectProfile,
     disabled: &HashSet<String>,
     external_call_sites: Option<&CallSiteEvidence>,
 ) -> Vec<Row> {
@@ -238,14 +241,14 @@ fn collect_rows(
     // compiler-checks pass below.  `LexerConfig::default()` matches what
     // `emit_cfg_ssa_diagnostics` builds for itself, mirroring the server's
     // `set_cu_override` seam in `tcl_lsp_db::file_analysis_incremental`.
-    let registry = registry_for_dialect(dialect);
+    let registry = registry_for_dialect(dialect.name);
     let analysis_cu = std::sync::Arc::new(CompilationUnit::build_with_options(
         source,
         UnitBuildOptions {
             registry: &registry,
             defer_top_level: false,
             config: tcl_lexer::LexerConfig::default(),
-            dialect,
+            dialect: dialect.name,
             external_call_sites,
         },
     ));
@@ -253,9 +256,9 @@ fn collect_rows(
     let file_path = document.path.as_deref().map(|p| p.display().to_string());
     let mut analyser = Analyser::new()
         .with_file_path(file_path)
-        .with_pack_overlay(tcl_cli_support::spec_pack_key(dialect));
+        .with_pack_overlay(tcl_cli_support::spec_pack_key(dialect.name));
     analyser.set_cu_override(std::sync::Arc::clone(&analysis_cu));
-    let result = analyser.analyse(source, dialect);
+    let result = analyser.analyse(source, dialect.name);
     for d in &result.diagnostics {
         if disabled.contains(d.code.as_str()) {
             continue;
@@ -277,7 +280,7 @@ fn collect_rows(
     // iRules braces), which coincides with the analyser tail's default for
     // every dialect but `tcl8.4` / `f5-irules` — reuse the unit above when it
     // does, exactly as the server's shared `compilation_unit` query does.
-    let checks_config = tcl_lexer::LexerConfig::for_dialect(dialect);
+    let checks_config = tcl_lexer::LexerConfig::for_dialect(dialect.name);
     let checks_cu = if checks_config == tcl_lexer::LexerConfig::default() {
         std::sync::Arc::clone(&analysis_cu)
     } else {
@@ -287,13 +290,13 @@ fn collect_rows(
                 registry: &registry,
                 defer_top_level: false,
                 config: checks_config,
-                dialect,
+                dialect: dialect.name,
                 external_call_sites,
             },
         ))
     };
     let cu = checks_cu.as_ref();
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
+    let dialect_opt = Some(dialect.name);
     for d in run_all_checks(cu, &registry, dialect_opt) {
         if d.code.is_optimisation() || disabled.contains(d.code.as_str()) {
             continue;
@@ -323,14 +326,15 @@ pub fn run_diag(input: &InputArgs, diag: &DiagArgs) -> anyhow::Result<u8> {
     let mut problem_count = 0usize;
     let mut diagnostic_count = 0usize;
 
-    let evidence = cross_file_call_site_evidence(&documents, input.dialect.as_deref());
+    let explicit_dialect = input.dialect_profile()?;
+    let evidence = cross_file_call_site_evidence(&documents, explicit_dialect);
     for document in &documents {
-        let dialect = document.effective_dialect(input.dialect.as_deref());
-        let declared = document_proc_names(document, &dialect);
+        let dialect = document.effective_dialect(explicit_dialect);
+        let declared = document_proc_names(document, dialect);
         let slice = evidence
             .as_ref()
             .map(|all| all.slice_for(declared.iter().map(String::as_str)));
-        let rows = collect_rows(document, &dialect, &disabled, slice.as_ref());
+        let rows = collect_rows(document, dialect, &disabled, slice.as_ref());
         let mut items = Vec::with_capacity(rows.len());
         for r in rows {
             diagnostic_count += 1;
@@ -385,14 +389,15 @@ pub fn run_validate(input: &InputArgs, diag: &DiagArgs) -> anyhow::Result<u8> {
     let disabled = resolve_disabled(&diag.disable, &diag.enable);
 
     let mut errors: Vec<ValidateError> = Vec::new();
-    let evidence = cross_file_call_site_evidence(&documents, input.dialect.as_deref());
+    let explicit_dialect = input.dialect_profile()?;
+    let evidence = cross_file_call_site_evidence(&documents, explicit_dialect);
     for document in &documents {
-        let dialect = document.effective_dialect(input.dialect.as_deref());
-        let declared = document_proc_names(document, &dialect);
+        let dialect = document.effective_dialect(explicit_dialect);
+        let declared = document_proc_names(document, dialect);
         let slice = evidence
             .as_ref()
             .map(|all| all.slice_for(declared.iter().map(String::as_str)));
-        for r in collect_rows(document, &dialect, &disabled, slice.as_ref()) {
+        for r in collect_rows(document, dialect, &disabled, slice.as_ref()) {
             if r.severity == Severity::Error {
                 errors.push(ValidateError {
                     file: document.label.clone(),

--- a/rust/tcl-cli/src/commands/diag.rs
+++ b/rust/tcl-cli/src/commands/diag.rs
@@ -296,7 +296,7 @@ fn collect_rows(
         ))
     };
     let cu = checks_cu.as_ref();
-    let dialect_opt = Some(dialect.name);
+    let dialect_opt = Some(dialect);
     for d in run_all_checks(cu, &registry, dialect_opt) {
         if d.code.is_optimisation() || disabled.contains(d.code.as_str()) {
             continue;

--- a/rust/tcl-cli/src/commands/diagram.rs
+++ b/rust/tcl-cli/src/commands/diagram.rs
@@ -36,10 +36,10 @@ use crate::cli::InputArgs;
 /// `tcl diagram` — extract control-flow diagram data from the IR.
 pub fn run_diagram(input: &InputArgs, json_out: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
-    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
+    let dialect = combined_effective_dialect(&documents, input.dialect_profile()?);
     let source = combine_sources(&documents);
-    let registry = registry_for_dialect(&dialect);
-    let data = diagram::diagram_data_for_dialect(&source, &registry, &dialect);
+    let registry = registry_for_dialect(dialect.name);
+    let data = diagram::diagram_data_for_dialect(&source, &registry, dialect.name);
 
     let target = OutputTarget::from_arg(input.output.as_deref());
 

--- a/rust/tcl-cli/src/commands/diff.rs
+++ b/rust/tcl-cli/src/commands/diff.rs
@@ -285,7 +285,7 @@ pub fn run_diff(
     right: Option<&Path>,
     left_source: Option<&str>,
     right_source: Option<&str>,
-    dialect: Option<&str>,
+    dialect: Option<&'static tcl_dialect::DialectProfile>,
     show: &[String],
     json_out: bool,
     output: Option<&Path>,
@@ -324,15 +324,14 @@ pub fn run_diff(
     // pipelines rather than two sources. Detected from the left-hand (baseline)
     // input unless `--dialect` names one.
     let dialect = combined_effective_dialect(&left_docs, dialect);
-    let dialect = dialect.as_str();
-    let registry = registry_for_dialect(dialect);
+    let registry = registry_for_dialect(dialect.name);
     let left_index = LineIndex::new(&left_src);
     let right_index = LineIndex::new(&right_src);
 
     let mut results: Vec<(String, bool, Vec<String>)> = Vec::new();
     for layer in &layers {
-        let lp = layer_payload(layer, &left_src, dialect, &registry, &left_index)?;
-        let rp = layer_payload(layer, &right_src, dialect, &registry, &right_index)?;
+        let lp = layer_payload(layer, &left_src, dialect.name, &registry, &left_index)?;
+        let rp = layer_payload(layer, &right_src, dialect.name, &registry, &right_index)?;
         let (equal, lines) = compute_layer_diff(layer, &lp, &rp, &left_name, &right_name);
         results.push(((*layer).to_owned(), equal, lines));
     }
@@ -341,7 +340,7 @@ pub fn run_diff(
     write_diff_result(
         &target,
         json_out,
-        dialect,
+        dialect.name,
         &left_name,
         &right_name,
         &left_docs,
@@ -436,7 +435,7 @@ mod tests {
             None,
             Some("set x 1"),
             Some("set x 2"),
-            Some("tcl8.6"),
+            Some(tcl_dialect::DialectProfile::by_name("tcl8.6")),
             &show,
             true,
             None,
@@ -449,7 +448,7 @@ mod tests {
             None,
             None,
             Some("set x 2"),
-            Some("tcl8.6"),
+            Some(tcl_dialect::DialectProfile::by_name("tcl8.6")),
             &show,
             true,
             None,

--- a/rust/tcl-cli/src/commands/explore.rs
+++ b/rust/tcl-cli/src/commands/explore.rs
@@ -42,19 +42,19 @@ pub fn run_explore(
     colour: &ColourArgs,
 ) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
-    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
+    let dialect = combined_effective_dialect(&documents, input.dialect_profile()?);
     let source = combine_sources(&documents);
 
     // `tcl-explorer` deliberately resolves the process's active registry so
     // its pipeline matches the LSP. Initialising the CLI registry publishes
     // the discovered project pack set (and its hook plan) on that interface.
-    let _registry = tcl_cli_support::registry_for_dialect(&dialect);
+    let _registry = tcl_cli_support::registry_for_dialect(dialect.name);
 
     if tui {
-        return run_tui(&source, &dialect);
+        return run_tui(&source, dialect.name);
     }
 
-    let result = tcl_explorer::run_pipeline(&source, &dialect);
+    let result = tcl_explorer::run_pipeline(&source, dialect.name);
     let value = tcl_explorer::serialise_result(&result);
 
     let target = OutputTarget::from_arg(input.output.as_deref());

--- a/rust/tcl-cli/src/commands/graphs.rs
+++ b/rust/tcl-cli/src/commands/graphs.rs
@@ -76,10 +76,14 @@ fn line_of(line_index: &LineIndex, offset: u32) -> u32 {
 ///
 /// Runs unconditionally (every dialect),
 /// each entry at depth 0 with its 1-based line.
-fn detect_event_entries(source: &str, line_index: &LineIndex, dialect: &str) -> Vec<SymbolEntry> {
-    let registry = registry_for_dialect(dialect);
+fn detect_event_entries(
+    source: &str,
+    line_index: &LineIndex,
+    dialect: &tcl_dialect::DialectProfile,
+) -> Vec<SymbolEntry> {
+    let registry = registry_for_dialect(dialect.name);
     let identities =
-        tcl_compiler::head_identity::command_head_identities(source, dialect, &registry);
+        tcl_compiler::head_identity::command_head_identities(source, dialect.name, &registry);
     let mut entries = Vec::new();
     let mut seen = std::collections::HashSet::new();
     for handler in tcl_registry::events::top_level_when_handlers_with_registry_and_head_resolver(
@@ -164,14 +168,14 @@ fn collect_scope_entries(
 /// iRules `when` events) across the combined input.
 pub fn run_symbols(input: &InputArgs, json: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
-    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
+    let dialect = combined_effective_dialect(&documents, input.dialect_profile()?);
     let source = combine_sources(&documents);
     let result = Analyser::new()
-        .with_pack_overlay(tcl_cli_support::spec_pack_key(&dialect))
-        .analyse(&source, &dialect);
+        .with_pack_overlay(tcl_cli_support::spec_pack_key(dialect.name))
+        .analyse(&source, dialect.name);
     let line_index = LineIndex::new(&source);
 
-    let mut entries = detect_event_entries(&source, &line_index, &dialect);
+    let mut entries = detect_event_entries(&source, &line_index, dialect);
     collect_scope_entries(&result.global_scope, 0, &line_index, &mut entries);
 
     let target = OutputTarget::from_arg(input.output.as_deref());
@@ -179,7 +183,7 @@ pub fn run_symbols(input: &InputArgs, json: bool) -> anyhow::Result<u8> {
     if json {
         let payload = SymbolsPayload {
             count: entries.len(),
-            dialect: dialect.clone(),
+            dialect: dialect.name.to_owned(),
             inputs: documents.iter().map(|d| d.label.clone()).collect(),
             symbols: entries,
         };
@@ -279,9 +283,9 @@ fn append_symbolgraph_scope(lines: &mut Vec<String>, scope: &Value, depth: usize
 /// `tcl symbolgraph` — scope hierarchy with proc/variable references.
 pub fn run_symbolgraph(input: &InputArgs, json_out: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
-    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
+    let dialect = combined_effective_dialect(&documents, input.dialect_profile()?);
     let source = combine_sources(&documents);
-    let data = graphs::symbol_graph(&source, &dialect);
+    let data = graphs::symbol_graph(&source, dialect.name);
 
     let summary = data.get("summary").cloned().unwrap_or_else(|| json!({}));
     let count = |key: &str| summary.get(key).and_then(Value::as_i64).unwrap_or(0);
@@ -316,10 +320,10 @@ pub fn run_symbolgraph(input: &InputArgs, json_out: bool) -> anyhow::Result<u8> 
 #[allow(clippy::similar_names)] // caller / callee mirror the domain
 pub fn run_callgraph(input: &InputArgs, json_out: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
-    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
+    let dialect = combined_effective_dialect(&documents, input.dialect_profile()?);
     let source = combine_sources(&documents);
-    let registry = registry_for_dialect(&dialect);
-    let data = graphs::call_graph(&source, &registry, &dialect);
+    let registry = registry_for_dialect(dialect.name);
+    let data = graphs::call_graph(&source, &registry, dialect.name);
 
     let target = OutputTarget::from_arg(input.output.as_deref());
 
@@ -405,10 +409,10 @@ pub fn run_callgraph(input: &InputArgs, json_out: bool) -> anyhow::Result<u8> {
 /// side-effect classification.
 pub fn run_dataflow(input: &InputArgs, json_out: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
-    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
+    let dialect = combined_effective_dialect(&documents, input.dialect_profile()?);
     let source = combine_sources(&documents);
-    let registry = registry_for_dialect(&dialect);
-    let data = graphs::dataflow_graph(&source, &registry, &dialect);
+    let registry = registry_for_dialect(dialect.name);
+    let data = graphs::dataflow_graph(&source, &registry, dialect.name);
 
     let target = OutputTarget::from_arg(input.output.as_deref());
 
@@ -456,7 +460,11 @@ mod tests {
     #[test]
     fn event_symbols_use_top_level_rooted_normalised_owner() {
         let source = "::when http_request {\n  if {1} { :::when client_data {} }\n}";
-        let entries = detect_event_entries(source, &LineIndex::new(source), "f5-irules");
+        let entries = detect_event_entries(
+            source,
+            &LineIndex::new(source),
+            tcl_dialect::DialectProfile::irules(),
+        );
         assert_eq!(
             entries
                 .iter()
@@ -469,7 +477,11 @@ mod tests {
     #[test]
     fn event_symbols_ignore_inert_braced_and_quoted_when_text() {
         let source = "set payload {when CLIENT_DATA {}}\nset q \"when SERVER_DATA {}\"\nwhen HTTP_REQUEST {}";
-        let entries = detect_event_entries(source, &LineIndex::new(source), "f5-irules");
+        let entries = detect_event_entries(
+            source,
+            &LineIndex::new(source),
+            tcl_dialect::DialectProfile::irules(),
+        );
         assert_eq!(
             entries
                 .iter()

--- a/rust/tcl-cli/src/commands/help.rs
+++ b/rust/tcl-cli/src/commands/help.rs
@@ -38,6 +38,7 @@ use std::path::PathBuf;
 use rusqlite::{Connection, OpenFlags};
 use serde_json::{Map, Value, json};
 use tcl_cli_support::{OutputTarget, ensure_ascii, write_text_output};
+use tcl_dialect::DialectProfile;
 
 /// The KCS help database, built at compile time by `build.rs` (from
 /// `docs/kcs/features/*.md`) into `$OUT_DIR` and embedded here.
@@ -87,6 +88,16 @@ impl Feature {
         }
         let hay = self.dialect_haystack();
         terms.iter().any(|t| hay.contains(t))
+    }
+
+    fn matches_profile(&self, dialect: Option<&DialectProfile>) -> bool {
+        dialect.is_none_or(|profile| {
+            profile.help_terms.is_empty()
+                || profile
+                    .help_terms
+                    .iter()
+                    .any(|term| self.dialect_haystack().contains(term))
+        })
     }
 
     /// JSON view for embedders (the MCP `help` tool). `rank` is included only
@@ -428,7 +439,7 @@ fn render_search_results(results: &[Feature], query: &str) -> String {
 /// `tcl help` (`docs`) — search the bundled KCS help database.
 pub fn run_help(
     query: &[String],
-    dialect: &str,
+    dialect: Option<&DialectProfile>,
     limit: usize,
     json: bool,
     output: Option<&std::path::Path>,
@@ -447,7 +458,7 @@ pub fn run_help(
 fn run_help_inner(
     conn: &Connection,
     query: &[String],
-    dialect: &str,
+    dialect: Option<&DialectProfile>,
     limit: usize,
     json: bool,
     output: Option<&std::path::Path>,
@@ -458,9 +469,9 @@ fn run_help_inner(
 
     if query_str.is_empty() {
         let mut catalogue = list_features(conn)?;
-        if dialect != "all" {
+        if dialect.is_some() {
             for (_, features) in &mut catalogue {
-                features.retain(|f| f.matches_dialect(dialect));
+                features.retain(|f| f.matches_profile(dialect));
             }
             catalogue.retain(|(_, features)| !features.is_empty());
         }
@@ -472,13 +483,13 @@ fn run_help_inner(
         return Ok(u8::from(catalogue.is_empty()));
     }
 
-    let search_limit = if dialect == "all" {
+    let search_limit = if dialect.is_none() {
         limit
     } else {
         (limit * 5).max(limit)
     };
     let mut results = search_help(conn, query_str, search_limit)?;
-    results.retain(|f| f.matches_dialect(dialect));
+    results.retain(|f| f.matches_profile(dialect));
     results.truncate(limit);
 
     if json {

--- a/rust/tcl-cli/src/commands/highlight.rs
+++ b/rust/tcl-cli/src/commands/highlight.rs
@@ -36,14 +36,14 @@ const DEFAULT_TAB_WIDTH: usize = 4;
 /// `tcl highlight` — emit syntax-highlighted source (ANSI or HTML).
 pub fn run_highlight(input: &InputArgs, format: &str, colour: &ColourArgs) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
-    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
+    let dialect = combined_effective_dialect(&documents, input.dialect_profile()?);
     let source = combine_sources(&documents);
     let target = OutputTarget::from_arg(input.output.as_deref());
 
     let mut out = if format == "html" {
-        highlight_html(&source, &dialect)
+        highlight_html(&source, dialect.name)
     } else if resolve_use_colour(colour.colour, colour.no_colour, &target) {
-        highlight_ansi(&source, &dialect)
+        highlight_ansi(&source, dialect.name)
     } else {
         source
     };

--- a/rust/tcl-cli/src/commands/lookup.rs
+++ b/rust/tcl-cli/src/commands/lookup.rs
@@ -51,7 +51,7 @@ struct NotFoundPayload {
 /// `tcl command-info` — look up registry metadata for one command.
 pub fn run_command_info(
     command: &str,
-    dialect: &str,
+    dialect: &DialectProfile,
     json: bool,
     output: Option<&Path>,
 ) -> anyhow::Result<u8> {
@@ -59,8 +59,7 @@ pub fn run_command_info(
     if query.is_empty() {
         anyhow::bail!("command name is required");
     }
-    let registry = registry_for_dialect(dialect);
-    let profile = DialectProfile::by_name(dialect);
+    let registry = registry_for_dialect(dialect.name);
     let target = OutputTarget::from_arg(output);
 
     // Exact match, then a case-insensitive fallback (mirrors
@@ -68,14 +67,14 @@ pub fn run_command_info(
     // that exists in the data but is unavailable under `dialect` — banned
     // in iRules, version-gated above the profile's base — reports
     // not-found for that dialect.
-    let resolved_name: Option<String> = if profile.resolve_command(&registry, query).is_some() {
+    let resolved_name: Option<String> = if dialect.resolve_command(&registry, query).is_some() {
         Some(query.to_owned())
     } else {
         let lowered = query.to_lowercase();
         registry
             .command_names()
             .find(|c| {
-                c.to_lowercase() == lowered && profile.resolve_command(&registry, c).is_some()
+                c.to_lowercase() == lowered && dialect.resolve_command(&registry, c).is_some()
             })
             .map(str::to_owned)
     };
@@ -85,7 +84,7 @@ pub fn run_command_info(
             let payload = NotFoundPayload {
                 found: false,
                 command: query.to_owned(),
-                dialect: dialect.to_owned(),
+                dialect: dialect.name.to_owned(),
             };
             write_text_output(
                 &target,
@@ -94,13 +93,13 @@ pub fn run_command_info(
         } else {
             write_text_output(
                 &target,
-                &format!("command not found: {query} (dialect={dialect})"),
+                &format!("command not found: {query} (dialect={})", dialect.name),
             )?;
         }
         return Ok(1);
     };
 
-    let spec = profile
+    let spec = dialect
         .resolve_command(&registry, &resolved_name)
         .expect("resolved command spec");
     let summary = spec
@@ -114,7 +113,7 @@ pub fn run_command_info(
         .unwrap_or_default();
     // §5.2 option gating (intersects + version ceiling) — the same rule
     // hover/completion/the snapshot use.
-    let mut switches: Vec<String> = profile
+    let mut switches: Vec<String> = dialect
         .available_option_names(spec)
         .into_iter()
         .map(str::to_owned)
@@ -128,7 +127,7 @@ pub fn run_command_info(
         let payload = FoundPayload {
             found: true,
             command: resolved_name.clone(),
-            dialect: dialect.to_owned(),
+            dialect: dialect.name.to_owned(),
             summary,
             synopsis,
             switches,
@@ -143,7 +142,7 @@ pub fn run_command_info(
 
     let mut lines = vec![
         format!("command: {resolved_name}"),
-        format!("dialect: {dialect}"),
+        format!("dialect: {}", dialect.name),
     ];
     if !summary.is_empty() {
         lines.push(format!("summary: {summary}"));

--- a/rust/tcl-cli/src/commands/minimize.rs
+++ b/rust/tcl-cli/src/commands/minimize.rs
@@ -96,10 +96,10 @@ pub enum MinimizeError {
 }
 
 /// Whether `code` fires anywhere in `source` under `dialect`.
-fn fires(source: &str, code: &str, dialect: &str) -> bool {
+fn fires(source: &str, code: &str, dialect: &tcl_dialect::DialectProfile) -> bool {
     Analyser::new()
-        .with_pack_overlay(tcl_cli_support::spec_pack_key(dialect))
-        .analyse(source, dialect)
+        .with_pack_overlay(tcl_cli_support::spec_pack_key(dialect.name))
+        .analyse(source, dialect.name)
         .diagnostics
         .iter()
         .any(|d| d.code.as_str() == code)
@@ -298,7 +298,7 @@ pub fn minimize_diagnostic(
     source: &str,
     code: &str,
     rename: bool,
-    dialect: &str,
+    dialect: &tcl_dialect::DialectProfile,
 ) -> Result<MinimizeResult, MinimizeError> {
     let original_lines = source.matches('\n').count() + 1;
     if !fires(source, code, dialect) {
@@ -372,11 +372,12 @@ pub fn run_minimize(input: &InputArgs, no_rename: bool, json: bool) -> anyhow::R
     let rename = !no_rename;
 
     let mut results: Vec<MinimizeItem> = Vec::new();
+    let explicit_dialect = input.dialect_profile()?;
     for document in &documents {
         // Per document, like `diag`: the reproducer is reduced under the same
         // dialect the diagnostic was reported under.
-        let dialect = document.effective_dialect(input.dialect.as_deref());
-        match minimize_diagnostic(&document.source, code, rename, &dialect) {
+        let dialect = document.effective_dialect(explicit_dialect);
+        match minimize_diagnostic(&document.source, code, rename, dialect) {
             Ok(r) => results.push(MinimizeItem {
                 file: document.label.clone(),
                 code: r.code,

--- a/rust/tcl-cli/src/commands/misc.rs
+++ b/rust/tcl-cli/src/commands/misc.rs
@@ -84,12 +84,12 @@ struct LegacyPayload {
 /// `tcl find-legacy` — report legacy patterns eligible for modernisation.
 pub fn run_find_legacy(input: &InputArgs, json: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
-    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
+    let dialect = combined_effective_dialect(&documents, input.dialect_profile()?);
     let source = combine_sources(&documents);
 
     let result = Analyser::new()
-        .with_pack_overlay(tcl_cli_support::spec_pack_key(&dialect))
-        .analyse(&source, &dialect);
+        .with_pack_overlay(tcl_cli_support::spec_pack_key(dialect.name))
+        .analyse(&source, dialect.name);
     let line_index = LineIndex::new(&source);
 
     let issues: Vec<LegacyIssue> = result
@@ -113,7 +113,7 @@ pub fn run_find_legacy(input: &InputArgs, json: bool) -> anyhow::Result<u8> {
     if json {
         let payload = LegacyPayload {
             count: issues.len(),
-            dialect: dialect.clone(),
+            dialect: dialect.name.to_owned(),
             issues,
         };
         let rendered = ensure_ascii(&serde_json::to_string_pretty(&payload)?);

--- a/rust/tcl-cli/src/commands/registry.rs
+++ b/rust/tcl-cli/src/commands/registry.rs
@@ -24,6 +24,7 @@
 use std::path::Path;
 
 use tcl_cli_support::{OutputTarget, registry_for_dialect, write_text_output};
+use tcl_dialect::DialectProfile;
 use tcl_registry::command_snapshot::{command_registry_snapshot, command_registry_snapshots};
 
 /// The Tcl dialects `--all-dialects` snapshots, in stable order.
@@ -32,7 +33,7 @@ const TCL_DIALECTS: [&str; 4] = ["tcl8.4", "tcl8.5", "tcl8.6", "tcl9.0"];
 /// `tcl registry-dump` — dump the command registry for one dialect (or
 /// every Tcl dialect with `--all-dialects`) as canonical JSON.
 pub fn run_registry_dump(
-    dialect: &str,
+    dialect: &DialectProfile,
     all_dialects: bool,
     output: Option<&Path>,
 ) -> anyhow::Result<u8> {
@@ -40,11 +41,11 @@ pub fn run_registry_dump(
     // `build_default` already carries every Tcl dialect's commands, so the
     // `tcl8.6` registry serves all four Tcl dialects (and `--all-dialects`).
     let json = if all_dialects {
-        let registry = registry_for_dialect("tcl8.6");
+        let registry = registry_for_dialect(DialectProfile::by_name("tcl8.6").name);
         command_registry_snapshots(&registry, &TCL_DIALECTS)
     } else {
-        let registry = registry_for_dialect(dialect);
-        command_registry_snapshot(&registry, dialect)
+        let registry = registry_for_dialect(dialect.name);
+        command_registry_snapshot(&registry, dialect.name)
     };
     write_text_output(&target, &json.dumps_indent2())?;
     Ok(0)

--- a/rust/tcl-cli/src/commands/transform.rs
+++ b/rust/tcl-cli/src/commands/transform.rs
@@ -154,7 +154,7 @@ pub fn run_opt(
     let (optimised, optimisations, _iterations) = optimise_source_multipass_filtered(
         &source,
         &registry,
-        Some(dialect.name),
+        Some(dialect),
         profile.max_iterations(),
         &disabled,
     );

--- a/rust/tcl-cli/src/commands/transform.rs
+++ b/rust/tcl-cli/src/commands/transform.rs
@@ -84,11 +84,11 @@ pub fn run_format(
     colour: &ColourArgs,
 ) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
-    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
+    let dialect = combined_effective_dialect(&documents, input.dialect_profile()?);
     let source = combine_sources(&documents);
-    let registry = registry_for_dialect(&dialect);
+    let registry = registry_for_dialect(dialect.name);
 
-    let config = format_config(&dialect, indent_size, indent_style, max_line_length);
+    let config = format_config(dialect.name, indent_size, indent_style, max_line_length);
 
     // `formatting_with` returns a single whole-document edit, or an empty Vec
     // when the source is already canonical.
@@ -100,7 +100,13 @@ pub fn run_format(
 
     let target = OutputTarget::from_arg(input.output.as_deref());
     let use_colour = tcl_cli_support::resolve_use_colour(colour.colour, colour.no_colour, &target);
-    write_highlighted_output(&target, &formatted, use_colour, DEFAULT_TAB_WIDTH, &dialect)?;
+    write_highlighted_output(
+        &target,
+        &formatted,
+        use_colour,
+        DEFAULT_TAB_WIDTH,
+        dialect.name,
+    )?;
     Ok(0)
 }
 
@@ -116,9 +122,9 @@ pub fn run_opt(
     colour: &ColourArgs,
 ) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
-    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
+    let dialect = combined_effective_dialect(&documents, input.dialect_profile()?);
     let source = combine_sources(&documents);
-    let registry = registry_for_dialect(&dialect);
+    let registry = registry_for_dialect(dialect.name);
 
     let profile = OptimisationProfile::parse(profile);
     let mut disabled: HashSet<String> = profile_to_disabled(profile)
@@ -148,7 +154,7 @@ pub fn run_opt(
     let (optimised, optimisations, _iterations) = optimise_source_multipass_filtered(
         &source,
         &registry,
-        Some(dialect.as_str()),
+        Some(dialect.name),
         profile.max_iterations(),
         &disabled,
     );
@@ -172,7 +178,13 @@ pub fn run_opt(
     }
 
     let use_colour = tcl_cli_support::resolve_use_colour(colour.colour, colour.no_colour, &target);
-    write_highlighted_output(&target, &rendered, use_colour, DEFAULT_TAB_WIDTH, &dialect)?;
+    write_highlighted_output(
+        &target,
+        &rendered,
+        use_colour,
+        DEFAULT_TAB_WIDTH,
+        dialect.name,
+    )?;
 
     if !target.is_stdout() {
         eprintln!(
@@ -239,27 +251,38 @@ pub fn run_minify(
         isolated,
     } = options;
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
-    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
+    let dialect = combined_effective_dialect(&documents, input.dialect_profile()?);
     let source = combine_sources(&documents);
-    let registry = registry_for_dialect(&dialect);
+    let registry = registry_for_dialect(dialect.name);
 
     let target = OutputTarget::from_arg(input.output.as_deref());
     let use_colour = tcl_cli_support::resolve_use_colour(colour.colour, colour.no_colour, &target);
 
     let (rendered, map) = match tier {
         MinifyTier::Aggressive => {
-            let result =
-                minify_tcl_aggressive_with(&source, &dialect, isolated, &registry, abbreviations);
+            let result = minify_tcl_aggressive_with(
+                &source,
+                dialect.name,
+                isolated,
+                &registry,
+                abbreviations,
+            );
             (result.source, Some(result.symbol_map))
         }
         MinifyTier::Compact => {
-            let (minified, sm) = minify_tcl_compact(&source, &dialect, isolated, &registry);
+            let (minified, sm) = minify_tcl_compact(&source, dialect.name, isolated, &registry);
             (minified, Some(sm))
         }
-        MinifyTier::Default => (minify_tcl(&source, &dialect, &registry), None),
+        MinifyTier::Default => (minify_tcl(&source, dialect.name, &registry), None),
     };
 
-    write_highlighted_output(&target, &rendered, use_colour, DEFAULT_TAB_WIDTH, &dialect)?;
+    write_highlighted_output(
+        &target,
+        &rendered,
+        use_colour,
+        DEFAULT_TAB_WIDTH,
+        dialect.name,
+    )?;
 
     if let Some(path) = symbol_map {
         // Always honour `--symbol-map FILE`, even for plain minify (which does

--- a/rust/tcl-cli/src/lib.rs
+++ b/rust/tcl-cli/src/lib.rs
@@ -127,7 +127,7 @@ fn dispatch(command: &Command) -> anyhow::Result<u8> {
             right.as_deref(),
             left_source.as_deref(),
             right_source.as_deref(),
-            dialect.as_deref(),
+            tcl_cli_support::resolve_dialect(dialect.as_deref())?,
             show,
             *json,
             output.as_deref(),
@@ -137,7 +137,13 @@ fn dispatch(command: &Command) -> anyhow::Result<u8> {
             dialect,
             json,
             output,
-        } => commands::lookup::run_command_info(command, dialect, *json, output.as_deref()),
+        } => commands::lookup::run_command_info(
+            command,
+            tcl_cli_support::resolve_dialect(Some(dialect))?
+                .expect("a supplied command-info dialect resolves"),
+            *json,
+            output.as_deref(),
+        ),
         Command::Highlight {
             input,
             format,
@@ -192,7 +198,12 @@ fn dispatch(command: &Command) -> anyhow::Result<u8> {
             all_dialects,
             json: _,
             output,
-        } => commands::registry::run_registry_dump(dialect, *all_dialects, output.as_deref()),
+        } => commands::registry::run_registry_dump(
+            tcl_cli_support::resolve_dialect(Some(dialect))?
+                .expect("a supplied registry-dump dialect resolves"),
+            *all_dialects,
+            output.as_deref(),
+        ),
         Command::UnminifyError {
             symbol_map,
             error,
@@ -232,7 +243,17 @@ fn dispatch(command: &Command) -> anyhow::Result<u8> {
             limit,
             json,
             output,
-        } => commands::help::run_help(query, dialect, *limit, *json, output.as_deref()),
+        } => commands::help::run_help(
+            query,
+            if dialect == "all" {
+                None
+            } else {
+                tcl_cli_support::resolve_dialect(Some(dialect))?
+            },
+            *limit,
+            *json,
+            output.as_deref(),
+        ),
         Command::FindLegacy { input, json } => commands::misc::run_find_legacy(input, *json),
         Command::Minimize {
             input,

--- a/rust/tcl-cli/tests/cli.rs
+++ b/rust/tcl-cli/tests/cli.rs
@@ -440,7 +440,7 @@ fn opt_detects_the_irules_dialect_without_the_flag() {
     ]))
     .expect("utf-8 output");
     assert!(
-        detected.contains("if {1}") && detected.contains("O101"),
+        detected.contains("O112") && detected.contains("HTTP::respond 200"),
         "the detected dialect must fold the word-operator condition: {detected}"
     );
     assert_eq!(

--- a/rust/tcl-compiler/examples/incr_experiments.rs
+++ b/rust/tcl-compiler/examples/incr_experiments.rs
@@ -33,6 +33,7 @@ use std::time::Instant;
 use tcl_compiler::analyser::Analyser;
 use tcl_compiler::analyser::types::{AnalysisResult, Diagnostic};
 use tcl_compiler::segmenter::segment_commands_with_offset_and_config;
+use tcl_dialect::DialectProfile;
 use tcl_lexer::LexerConfig;
 
 fn gather_tcl(dir: &Path, out: &mut Vec<PathBuf>, cap: usize) {
@@ -301,20 +302,21 @@ fn e6_e7_lattice_costs(root: &Path, dialect: &str) {
         s.elapsed().as_secs_f64() * 1000.0 / f64::from(n)
     };
     let cfg = LexerConfig::for_dialect(dialect);
+    let profile = DialectProfile::by_name(dialect);
     let t_cu = time(&|| {
         let _ = CompilationUnit::build_for_with_config(&src, &reg, false, cfg);
     });
     let t_cu_ip = time(&|| {
         let _ = CompilationUnit::build_for_with_config(&src, &reg, false, cfg)
-            .with_interprocedural(&reg, Some(dialect));
+            .with_interprocedural(&reg, Some(profile));
     });
     let t_checks = time(&|| {
         let cu = CompilationUnit::build_for_with_config(&src, &reg, false, cfg)
-            .with_interprocedural(&reg, Some(dialect));
-        let _ = run_all_checks(&cu, &reg, Some(dialect));
+            .with_interprocedural(&reg, Some(profile));
+        let _ = run_all_checks(&cu, &reg, Some(profile));
     });
     let t_opt = time(&|| {
-        let _ = optimise_with_dialect(&src, &reg, Some(dialect));
+        let _ = optimise_with_dialect(&src, &reg, Some(profile));
     });
     let nprocs = CompilationUnit::build_for_with_config(&src, &reg, false, cfg)
         .procedures

--- a/rust/tcl-compiler/examples/mro_delta.rs
+++ b/rust/tcl-compiler/examples/mro_delta.rs
@@ -52,6 +52,7 @@ use tcl_compiler::analyser::state::Analyser;
 use tcl_compiler::analyser::types::{ClassDef, Diagnostic};
 use tcl_compiler::compilation_unit::CompilationUnit;
 use tcl_core_types::DiagCode;
+use tcl_dialect::DialectProfile;
 use tcl_registry::CommandRegistry;
 
 fn collect_tcl_files(root: &Path, out: &mut Vec<PathBuf>) {
@@ -93,8 +94,8 @@ fn analyse_file(path: &Path, reg: &CommandRegistry) -> Option<FileData> {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let mut a = Analyser::new();
         let result = a.analyse(&src, "tcl8.6");
-        let cu =
-            CompilationUnit::build_for(&src, reg, false).with_interprocedural(reg, Some("tcl8.6"));
+        let cu = CompilationUnit::build_for(&src, reg, false)
+            .with_interprocedural(reg, Some(DialectProfile::by_name("tcl8.6")));
         let ns = NsContext::from_result(&result);
         FileData {
             path: path.to_path_buf(),

--- a/rust/tcl-compiler/examples/mro_eval.rs
+++ b/rust/tcl-compiler/examples/mro_eval.rs
@@ -53,6 +53,7 @@ use tcl_compiler::analyser::class_lattice::{
 use tcl_compiler::analyser::state::Analyser;
 use tcl_compiler::analyser::types::ClassDef;
 use tcl_compiler::compilation_unit::CompilationUnit;
+use tcl_dialect::DialectProfile;
 use tcl_registry::CommandRegistry;
 
 /// Lossless-for-realistic-counts `usize`→`f64` conversion used for the
@@ -159,8 +160,8 @@ fn analyse_file(path: &Path, reg: &CommandRegistry) -> Option<Analysed> {
         // class index lives on the returned value, not on `a.result`.  The
         // deferred `var_command_sites` stay on the analyser field.
         let result = a.analyse(&src, "tcl8.6");
-        let cu =
-            CompilationUnit::build_for(&src, reg, false).with_interprocedural(reg, Some("tcl8.6"));
+        let cu = CompilationUnit::build_for(&src, reg, false)
+            .with_interprocedural(reg, Some(DialectProfile::by_name("tcl8.6")));
         let ns = NsContext::from_result(&result);
         Analysed {
             cu,

--- a/rust/tcl-compiler/examples/mro_interproc.rs
+++ b/rust/tcl-compiler/examples/mro_interproc.rs
@@ -50,6 +50,7 @@ use tcl_compiler::analyser::state::Analyser;
 use tcl_compiler::analyser::types::{AnalysisResult, ClassDef};
 use tcl_compiler::compilation_unit::CompilationUnit;
 use tcl_compiler::ir::Statement;
+use tcl_dialect::DialectProfile;
 use tcl_registry::CommandRegistry;
 
 /// Lossless-enough `usize`→`f64` for percentage reporting (counts fit u32).
@@ -187,8 +188,8 @@ fn analyse_file(
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let mut a = Analyser::new();
         let result = a.analyse(&src, "tcl8.6");
-        let cu =
-            CompilationUnit::build_for(&src, reg, false).with_interprocedural(reg, Some("tcl8.6"));
+        let cu = CompilationUnit::build_for(&src, reg, false)
+            .with_interprocedural(reg, Some(DialectProfile::by_name("tcl8.6")));
         let ns = NsContext::from_result(&result);
         // Resolve against the merged (cross-file) index — matches the FULL
         // config that produced the 81 % ⊤-rate.

--- a/rust/tcl-compiler/examples/object_lattice_cost.rs
+++ b/rust/tcl-compiler/examples/object_lattice_cost.rs
@@ -55,6 +55,7 @@ use tcl_compiler::compilation_unit::CompilationUnit;
 use tcl_compiler::object_types::{
     LatticeStats, object_handle_classes, object_handle_classes_full_walk, object_handle_facts,
 };
+use tcl_dialect::DialectProfile;
 use tcl_registry::CommandRegistry;
 
 /// Lossless-for-realistic-counts `usize`→`f64`, as `mro_eval` does it.
@@ -130,11 +131,11 @@ fn measure(path: &Path, reg: &CommandRegistry, repeats: usize) -> Option<Row> {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let cu_ms = best_ms(repeats, || {
             let cu = CompilationUnit::build_for(&src, reg, false)
-                .with_interprocedural(reg, Some("tcl8.6"));
+                .with_interprocedural(reg, Some(DialectProfile::by_name("tcl8.6")));
             std::hint::black_box(&cu);
         });
-        let cu =
-            CompilationUnit::build_for(&src, reg, false).with_interprocedural(reg, Some("tcl8.6"));
+        let cu = CompilationUnit::build_for(&src, reg, false)
+            .with_interprocedural(reg, Some(DialectProfile::by_name("tcl8.6")));
         let lattice_ms = best_ms(repeats, || {
             std::hint::black_box(object_handle_classes(&cu, reg));
         });

--- a/rust/tcl-compiler/examples/optimise_memo_experiments.rs
+++ b/rust/tcl-compiler/examples/optimise_memo_experiments.rs
@@ -39,6 +39,7 @@ use std::time::Instant;
 
 use tcl_compiler::compilation_unit::CompilationUnit;
 use tcl_compiler::optimiser::optimise_unit;
+use tcl_dialect::DialectProfile;
 use tcl_registry::CommandRegistry;
 
 fn gather(dir: &Path, out: &mut Vec<PathBuf>, cap: usize) {
@@ -90,6 +91,7 @@ fn encode_interproc(cu: &CompilationUnit) -> usize {
 fn main() {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tmp");
     let dialect = "tcl8.6";
+    let profile = DialectProfile::by_name(dialect);
     let reg = registry(dialect);
     let cfg = tcl_lexer::LexerConfig::for_dialect(dialect);
 
@@ -113,12 +115,12 @@ fn main() {
             continue;
         };
         let cu = CompilationUnit::build_for_with_config(&src, &reg, false, cfg)
-            .with_interprocedural(&reg, Some(dialect));
+            .with_interprocedural(&reg, Some(profile));
         let n_procs = cu.procedures.len();
         let iters = 20u32;
         let t0 = Instant::now();
         for _ in 0..iters {
-            std::hint::black_box(optimise_unit(&cu, &reg, Some(dialect)));
+            std::hint::black_box(optimise_unit(&cu, &reg, Some(profile)));
         }
         let opt_ms = t0.elapsed().as_secs_f64() * 1000.0 / f64::from(iters);
         let t1 = Instant::now();
@@ -154,7 +156,7 @@ fn main() {
             continue;
         }
         let cu = CompilationUnit::build_for_with_config(&src, &reg, false, cfg)
-            .with_interprocedural(&reg, Some(dialect));
+            .with_interprocedural(&reg, Some(profile));
         let Some(base_ia) = &cu.interproc else {
             continue;
         };
@@ -181,7 +183,7 @@ fn main() {
             let mut edited = src.clone();
             edited.insert(pos, ' ');
             let cu2 = CompilationUnit::build_for_with_config(&edited, &reg, false, cfg)
-                .with_interprocedural(&reg, Some(dialect));
+                .with_interprocedural(&reg, Some(profile));
             let Some(ia2) = &cu2.interproc else { continue };
             total_edits += 1;
             if base_ia == ia2 {

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -352,7 +352,9 @@ impl Analyser {
         // overflow is separately bounded by the lowering depth guards;
         // `catch_unwind` cannot contain a SIGABRT.)
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let dialect_opt = dialect_owned.as_deref();
+            let dialect_opt = dialect_owned
+                .as_deref()
+                .and_then(tcl_dialect::DialectProfile::find);
             // Build under the analyser's own dialect, not a blind default: the
             // lowering needs it to parse a dialect-only operator (an iRules
             // `contains` condition) as an operator, and the lattice pipeline
@@ -371,7 +373,7 @@ impl Analyser {
                     registry,
                     defer_top_level: false,
                     config: tcl_lexer::LexerConfig::default(),
-                    dialect: dialect_opt.unwrap_or_default(),
+                    dialect: dialect_opt.map_or("", |profile| profile.name),
                     external_call_sites: None,
                 },
             )
@@ -472,7 +474,7 @@ impl Analyser {
             let ia = crate::interprocedural::build_interprocedural_analysis(
                 &cu.ir_module,
                 registry,
-                Some(self.dialect()),
+                Some(tcl_dialect::DialectProfile::by_name(self.dialect())),
                 crate::interprocedural::ObjectTypeMap::none(),
                 &self.head_identities,
             );

--- a/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
@@ -2035,7 +2035,9 @@ file; this call falls through to the 'unknown' handler."
             // The document's own numeral grammar: a divisor literal means what
             // this dialect says it means (`0755` is 493 up to 8.6, 755 from
             // 9.0), and this process analyses documents of several dialects.
-            crate::intervals::numbers_for_dialect(Some(self.dialect())),
+            crate::intervals::numbers_for_dialect(Some(tcl_dialect::DialectProfile::by_name(
+                self.dialect(),
+            ))),
         ) {
             let span = fu.abs_span(finding.span);
             if span.is_empty() {
@@ -2083,7 +2085,9 @@ file; this call falls through to the 'unknown' handler."
             tcl_dialect::DialectProfile::by_name(self.dialect()).character_model(),
             // The document's own numeral grammar, alongside the character model
             // — both dialect-derived facts, both threaded rather than ambient.
-            crate::intervals::numbers_for_dialect(Some(self.dialect())),
+            crate::intervals::numbers_for_dialect(Some(tcl_dialect::DialectProfile::by_name(
+                self.dialect(),
+            ))),
         );
         for f in findings {
             if f.span.is_empty() {

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/bnd.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/bnd.rs
@@ -31,7 +31,7 @@ use tcl_registry::registry_for_dialect;
 fn diags(src: &str, dialect: &str) -> Vec<(String, String)> {
     let registry = registry_for_dialect(dialect);
     let cu = CompilationUnit::build_for(src, registry, false);
-    let d = (!dialect.is_empty()).then_some(dialect);
+    let d = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     let mut v: Vec<(String, String)> = Analyser::new()
         .analyse(src, dialect)
         .diagnostics

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/mod.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/mod.rs
@@ -54,7 +54,7 @@ pub(super) fn codes(src: &str, dialect: &str) -> Vec<String> {
         .collect();
     let registry = registry_for_dialect(dialect);
     let cu = CompilationUnit::build_for(src, registry, false);
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
+    let dialect_opt = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     for d in run_all_checks(&cu, registry, dialect_opt) {
         if d.code.is_optimisation() {
             continue;

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/nab.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/nab.rs
@@ -39,7 +39,7 @@ const D: &str = "tcl8.6";
 fn diags(src: &str, dialect: &str) -> Vec<(String, String)> {
     let registry = registry_for_dialect(dialect);
     let cu = CompilationUnit::build_for(src, registry, false);
-    let d = (!dialect.is_empty()).then_some(dialect);
+    let d = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     let mut v: Vec<(String, String)> = Analyser::new()
         .analyse(src, dialect)
         .diagnostics

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/opt.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/opt.rs
@@ -35,7 +35,7 @@ use super::D;
 /// True if any optimisation with `code` fires on `src` under `dialect`.
 fn opt_fires(src: &str, dialect: &str, code: &str) -> bool {
     let registry = registry_for_dialect(dialect);
-    let d = (!dialect.is_empty()).then_some(dialect);
+    let d = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     optimise_with_dialect(src, registry, d)
         .iter()
         .any(|o| o.code.as_str() == code)
@@ -44,14 +44,14 @@ fn opt_fires(src: &str, dialect: &str, code: &str) -> bool {
 /// Apply all optimisations and return the rewritten source.
 fn optimised(src: &str, dialect: &str) -> String {
     let registry = registry_for_dialect(dialect);
-    let d = (!dialect.is_empty()).then_some(dialect);
+    let d = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     apply_optimisations(src, &optimise_with_dialect(src, registry, d))
 }
 
 /// Collect `(code, replacement)` pairs from the optimiser for `src`.
 fn opt_rewrites(src: &str, dialect: &str) -> Vec<(String, String)> {
     let registry = registry_for_dialect(dialect);
-    let d = (!dialect.is_empty()).then_some(dialect);
+    let d = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     optimise_with_dialect(src, registry, d)
         .into_iter()
         .map(|o| (o.code.as_str().to_owned(), o.replacement.clone()))
@@ -64,7 +64,7 @@ fn opt_rewrites(src: &str, dialect: &str) -> Vec<(String, String)> {
 /// the right probe for those codes.
 fn check_codes(src: &str, dialect: &str) -> Vec<String> {
     let registry = registry_for_dialect(dialect);
-    let d = (!dialect.is_empty()).then_some(dialect);
+    let d = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     let cu = CompilationUnit::build_for(src, registry, false);
     run_all_checks(&cu, registry, d)
         .iter()
@@ -147,7 +147,7 @@ const FP_OPT_02_REPRO: &str = "set x [list]\nlappend x a\nputs $x\n";
 fn fp_opt_02_empty_list_quick_fix_uses_braces() {
     // FP-OPT-02: O116 on `[list]` must propose replacement "{}" (canonical empty-list literal).
     let registry = registry_for_dialect(D);
-    let d = Some(D);
+    let d = Some(tcl_dialect::DialectProfile::by_name(D));
     let opts = optimise_with_dialect(FP_OPT_02_REPRO, registry, d);
     let o116: Vec<_> = opts.iter().filter(|o| o.code.as_str() == "O116").collect();
     assert!(
@@ -242,7 +242,7 @@ fn fp_opt_04_call_by_name_suppresses_dead_store() {
     // FP-OPT-04: call-by-name upvar idiom must suppress O109/O126 on tag/type in decode.
     // Check optimiser codes (O109, O126) — the analyser W211/W220 are not in opt surface.
     let registry = registry_for_dialect(D);
-    let d = Some(D);
+    let d = Some(tcl_dialect::DialectProfile::by_name(D));
     let opts = optimise_with_dialect(FP_OPT_04_REPRO, registry, d);
     let relevant: Vec<_> = opts
         .iter()
@@ -269,7 +269,7 @@ proc f {} {
 }
 ";
     let registry = registry_for_dialect(D);
-    let d = Some(D);
+    let d = Some(tcl_dialect::DialectProfile::by_name(D));
     let opts = optimise_with_dialect(src, registry, d);
     let fires = opts
         .iter()
@@ -404,7 +404,7 @@ fn fp_opt_09_unknown_type_param_blocks_identity_rewrite() {
     // FP-OPT-09: $x + 0 on unknown-type param must NOT be rewritten to $x (hides coercion error).
     // Both the code check and the replacement check.
     let registry = registry_for_dialect(D);
-    let d = Some(D);
+    let d = Some(tcl_dialect::DialectProfile::by_name(D));
     let opts = optimise_with_dialect(FP_OPT_09_TP_REPRO, registry, d);
     // No O110 at all is fine; but if O110 fires it must not drop "+ 0".
     let unsound_o110: Vec<_> = opts

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/rch.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/rch.rs
@@ -34,7 +34,7 @@ use tcl_registry::registry_for_dialect;
 fn all_codes(src: &str, dialect: &str) -> Vec<String> {
     let registry = registry_for_dialect(dialect);
     let cu = CompilationUnit::build_for(src, registry, false);
-    let d = (!dialect.is_empty()).then_some(dialect);
+    let d = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     let mut v: Vec<String> = Analyser::new()
         .analyse(src, dialect)
         .diagnostics
@@ -56,7 +56,7 @@ fn all_codes(src: &str, dialect: &str) -> Vec<String> {
 
 fn o107_fires(src: &str, dialect: &str) -> bool {
     let registry = registry_for_dialect(dialect);
-    let d = (!dialect.is_empty()).then_some(dialect);
+    let d = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     optimise_with_dialect(src, registry, d)
         .iter()
         .any(|o| o.code == DiagCode::O107)

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -4346,7 +4346,7 @@ fn memoized_compilation_unit_diagnostics_match_whole_file() {
                     fu
                 },
             )
-            .with_interprocedural(&registry, Some("tcl"))
+            .with_interprocedural(&registry, Some(tcl_dialect::DialectProfile::by_name("tcl")))
         };
 
         let cold = build_cu(&mut cache);
@@ -4441,7 +4441,7 @@ fn memoized_compilation_unit_shift_correctness() {
                 fu
             },
         )
-        .with_interprocedural(&registry, Some("tcl"));
+        .with_interprocedural(&registry, Some(tcl_dialect::DialectProfile::by_name("tcl")));
         let mut a = Analyser::new();
         a.set_cu_override(Arc::new(cu));
         a.analyse(s, "tcl")

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -1028,7 +1028,9 @@ impl Analyser {
             return None;
         }
         let version = (!self.result.dialect.is_empty())
-            .then(|| tcl_dialect::DialectProfile::by_name(&self.result.dialect).runtime_version())
+            .then(|| {
+                tcl_dialect::DialectProfile::by_name(&self.result.dialect).const_fold_version()
+            })
             .flatten();
         let trusts = |name: &str| trust.trusts(name);
         let lookup = |name: &str| {
@@ -7421,7 +7423,7 @@ impl Analyser {
                 .collect::<Option<_>>()?;
             let version = (!self.result.dialect.is_empty())
                 .then(|| {
-                    tcl_dialect::DialectProfile::by_name(&self.result.dialect).runtime_version()
+                    tcl_dialect::DialectProfile::by_name(&self.result.dialect).const_fold_version()
                 })
                 .flatten();
             if spec.subcommands.is_empty() {

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -1027,8 +1027,9 @@ impl Analyser {
         {
             return None;
         }
-        let dialect = &self.result.dialect;
-        let dialect = (!dialect.is_empty()).then_some(dialect.as_str());
+        let version = (!self.result.dialect.is_empty())
+            .then(|| tcl_dialect::DialectProfile::by_name(&self.result.dialect).runtime_version())
+            .flatten();
         let trusts = |name: &str| trust.trusts(name);
         let lookup = |name: &str| {
             self.lookup_dominating_const_string(name, scope_path)
@@ -1036,7 +1037,7 @@ impl Analyser {
         };
         crate::const_subst::ConstSubstCtx {
             registry: &registry,
-            dialect,
+            version,
             defining_class: defining_class.as_deref(),
             trusts: &trusts,
             lookup_var: &lookup,
@@ -7418,12 +7419,16 @@ impl Analyser {
                 .iter()
                 .map(|value| value.as_deref())
                 .collect::<Option<_>>()?;
-            let dialect = (!self.result.dialect.is_empty()).then_some(self.result.dialect.as_str());
+            let version = (!self.result.dialect.is_empty())
+                .then(|| {
+                    tcl_dialect::DialectProfile::by_name(&self.result.dialect).runtime_version()
+                })
+                .flatten();
             if spec.subcommands.is_empty() {
-                return spec.run_const_fold(&values, dialect);
+                return spec.run_const_fold(&values, version);
             }
             let (sub, rest) = values.split_first()?;
-            return spec.resolve_subcommand(sub)?.run_const_fold(rest, dialect);
+            return spec.resolve_subcommand(sub)?.run_const_fold(rest, version);
         }
 
         let qname = self.resolve_static_proc_name(proc_qname, head)?;

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -297,12 +297,14 @@ impl Analyser {
         // Evaluated one gate at a time (rather than as one `||` chain) so the
         // telemetry can name which fired — these are checked in cheapest-first
         // order, so the split costs nothing.
+        let profile = tcl_dialect::DialectProfile::by_name(dialect);
+        let availability = tcl_dialect::DialectProfile::availability_for_name(dialect);
         let entry_gate = if tcl_lexer::script_is_complete(source) {
             if source.contains("tcl-lsp: stub") {
                 Some(PerItemFallback::StubDirective)
-            } else if super::utils::has_sidecar_stubs(self.file_path.as_deref(), dialect) {
+            } else if super::utils::has_sidecar_stubs(self.file_path.as_deref(), profile) {
                 Some(PerItemFallback::SidecarStub)
-            } else if dialect == "tk" {
+            } else if availability.contains(tcl_dialect::DialectSet::TK) {
                 Some(PerItemFallback::TkActive)
             } else {
                 None
@@ -442,7 +444,8 @@ impl Analyser {
         self.profile = tcl_dialect::DialectProfile::by_name(dialect);
         self.result.dialect = dialect.to_string();
         self.result.library_versions = self.library_versions.clone();
-        self.tk_dialect = dialect == "tk";
+        self.tk_dialect = tcl_dialect::DialectProfile::availability_for_name(dialect)
+            .contains(tcl_dialect::DialectSet::TK);
         // The per-item path deliberately accumulates **no** Tk state, unlike
         // `analyse` / `analyse_chunked` / `analyse_commands`.  Everything the
         // accumulation feeds is discarded unless Tk turns out to be active, and

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -1643,8 +1643,10 @@ impl Analyser {
         let _dialect_scope = tcl_registry::pack_hooks::DialectScope::enter(Some(self.profile.name));
         self.result.dialect = dialect.to_string();
         self.result.library_versions = self.library_versions.clone();
-        self.tk_accumulation_enabled = super::tk_checks::tk_checks_could_apply(source, dialect);
-        self.tk_dialect = dialect == "tk";
+        let availability = tcl_dialect::DialectProfile::availability_for_name(dialect);
+        self.tk_accumulation_enabled =
+            super::tk_checks::tk_checks_could_apply(source, availability);
+        self.tk_dialect = availability.contains(tcl_dialect::DialectSet::TK);
         // Clear the per-run iRules file-profile memo so a reused analyser
         // instance recomputes it for the new source / dialect.
         self.irules_file_profiles = None;
@@ -2045,8 +2047,10 @@ impl Analyser {
         self.profile = tcl_dialect::DialectProfile::by_name(dialect);
         self.result.dialect = dialect.to_string();
         self.result.library_versions = self.library_versions.clone();
-        self.tk_accumulation_enabled = super::tk_checks::tk_checks_could_apply(source, dialect);
-        self.tk_dialect = dialect == "tk";
+        let availability = tcl_dialect::DialectProfile::availability_for_name(dialect);
+        self.tk_accumulation_enabled =
+            super::tk_checks::tk_checks_could_apply(source, availability);
+        self.tk_dialect = availability.contains(tcl_dialect::DialectSet::TK);
         self.unresolved_commands_emitted = false;
 
         let file_codes = super::utils::parse_file_suppression(source);
@@ -2137,8 +2141,10 @@ impl Analyser {
         self.profile = tcl_dialect::DialectProfile::by_name(dialect);
         self.result.dialect = dialect.to_string();
         self.result.library_versions = self.library_versions.clone();
-        self.tk_accumulation_enabled = super::tk_checks::tk_checks_could_apply(source, dialect);
-        self.tk_dialect = dialect == "tk";
+        let availability = tcl_dialect::DialectProfile::availability_for_name(dialect);
+        self.tk_accumulation_enabled =
+            super::tk_checks::tk_checks_could_apply(source, availability);
+        self.tk_dialect = availability.contains(tcl_dialect::DialectSet::TK);
         self.unresolved_commands_emitted = false;
 
         let file_codes = super::utils::parse_file_suppression(source);

--- a/rust/tcl-compiler/src/analyser/tk_checks.rs
+++ b/rust/tcl-compiler/src/analyser/tk_checks.rs
@@ -159,8 +159,8 @@ pub(super) const TK_PACKAGE: &str = "Tk";
 /// [`Analyser::flush_tk_geometry_diagnostics`] discards everything the walk
 /// buffered unless the exact activation fact holds.
 #[must_use]
-pub(super) fn tk_checks_could_apply(source: &str, dialect: &str) -> bool {
-    dialect == "tk" || source.contains(TK_PACKAGE)
+pub(super) fn tk_checks_could_apply(source: &str, availability: tcl_dialect::DialectSet) -> bool {
+    availability.contains(tcl_dialect::DialectSet::TK) || source.contains(TK_PACKAGE)
 }
 
 /// Return `true` if `path` matches Tcl/Tk widget-path syntax — a leading

--- a/rust/tcl-compiler/src/analyser/utils.rs
+++ b/rust/tcl-compiler/src/analyser/utils.rs
@@ -904,13 +904,16 @@ pub fn scan_sidecar_stubs(
 /// isolated proc bodies, so their presence selects the full analyser until
 /// those signatures are part of every per-body memo key.
 #[must_use]
-pub fn has_sidecar_stubs(file_path: Option<&str>, dialect: &str) -> bool {
+pub fn has_sidecar_stubs(file_path: Option<&str>, profile: &tcl_dialect::DialectProfile) -> bool {
     let Some(file_path) = file_path else {
         return false;
     };
     let mut dir = std::path::Path::new(file_path).parent();
     while let Some(current) = dir {
-        if current.join(format!("{dialect}.tcl.stubs")).is_file() {
+        if current
+            .join(format!("{}.tcl.stubs", profile.name))
+            .is_file()
+        {
             return true;
         }
         dir = current.parent();

--- a/rust/tcl-compiler/src/common_aot_plan.rs
+++ b/rust/tcl-compiler/src/common_aot_plan.rs
@@ -1464,7 +1464,12 @@ fn collect_materialisable_slots(
             &function.cfg,
             &function.ssa,
             &function.sccp.values,
-            numbers_for_dialect(unit.ir_module.dialect.as_deref()),
+            numbers_for_dialect(
+                unit.ir_module
+                    .dialect
+                    .as_deref()
+                    .map(tcl_dialect::DialectProfile::by_name),
+            ),
         );
         for key in ssa_value_keys(function, unit.ir_module.procedures.get(qname)) {
             let identity = SsaValueIdentity {

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -1305,11 +1305,28 @@ impl CompilationUnit {
         defer_top_level: bool,
         dialect: &str,
     ) -> Self {
-        Self::build_for_profile(
+        let profile = tcl_dialect::DialectProfile::by_name(dialect);
+        // Most names canonicalise through the profile catalogue.  Additive
+        // set-only names (currently `tk`) intentionally resolve to the plain
+        // fallback profile, though, so retain the recognized ingress spelling
+        // long enough for `build_with` to parse its semantic dialect bit.
+        let effective_dialect =
+            if profile.is_fallback() && tcl_dialect::DialectSet::parse(dialect).is_some() {
+                dialect
+            } else {
+                profile.name
+            };
+        Self::build_with(
             source,
-            registry,
-            defer_top_level,
-            tcl_dialect::DialectProfile::by_name(dialect),
+            UnitBuildOptions {
+                registry,
+                defer_top_level,
+                config: tcl_lexer::LexerConfig::for_dialect(effective_dialect),
+                dialect: effective_dialect,
+                external_call_sites: None,
+            },
+            None,
+            None,
         )
     }
 

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -851,7 +851,7 @@ impl FunctionUnit {
         &self,
         registry: &CommandRegistry,
         ia: &InterproceduralAnalysis,
-        dialect: Option<&str>,
+        dialect: Option<&tcl_dialect::DialectProfile>,
     ) -> HashMap<ValueKey, TaintLattice> {
         propagate_taints(
             &TaintGraph::new(&self.cfg, &self.ssa, &self.sccp),
@@ -1285,8 +1285,9 @@ impl CompilationUnit {
         )
     }
 
-    /// Build for a document whose dialect is known — the entry point every
-    /// production consumer holding a dialect string should use.
+    /// Compatibility entry point for a host which has not yet resolved its
+    /// dialect name. New compiler-facing callers should resolve at their
+    /// boundary and use [`Self::build_for_profile`].
     ///
     /// Derives the lexer config from `dialect`
     /// ([`tcl_lexer::LexerConfig::for_dialect`]) *and* records the dialect in
@@ -1304,13 +1305,34 @@ impl CompilationUnit {
         defer_top_level: bool,
         dialect: &str,
     ) -> Self {
+        Self::build_for_profile(
+            source,
+            registry,
+            defer_top_level,
+            tcl_dialect::DialectProfile::by_name(dialect),
+        )
+    }
+
+    /// Build for an already-resolved dialect profile.
+    ///
+    /// Keeping the profile through this boundary prevents an alias spelling
+    /// from selecting a lexer configuration different from the lowering and
+    /// analysis facts. The string compatibility wrapper above resolves once
+    /// and delegates here.
+    #[must_use]
+    pub fn build_for_profile(
+        source: &str,
+        registry: &CommandRegistry,
+        defer_top_level: bool,
+        profile: &tcl_dialect::DialectProfile,
+    ) -> Self {
         Self::build_with(
             source,
             UnitBuildOptions {
                 registry,
                 defer_top_level,
-                config: tcl_lexer::LexerConfig::for_dialect(dialect),
-                dialect,
+                config: tcl_lexer::LexerConfig::for_dialect(profile.name),
+                dialect: profile.name,
                 external_call_sites: None,
             },
             None,
@@ -1691,7 +1713,7 @@ impl CompilationUnit {
     pub fn with_interprocedural(
         mut self,
         registry: &CommandRegistry,
-        dialect: Option<&str>,
+        dialect: Option<&tcl_dialect::DialectProfile>,
     ) -> Self {
         // Object-handle → class map (SSA/VTA-derived) so a `$g walk … -command
         // cb` instance-method callback becomes a call-graph / reachability edge.
@@ -1700,7 +1722,7 @@ impl CompilationUnit {
         // classifies a rebound head as the command it is (issue #1275).
         let identities = crate::head_identity::command_head_identities_with_config(
             &self.source,
-            tcl_lexer::LexerConfig::for_dialect(dialect.unwrap_or_default()),
+            tcl_lexer::LexerConfig::for_dialect(dialect.map_or("", |profile| profile.name)),
             registry,
         );
         let interproc = crate::interprocedural::build_interprocedural_analysis(
@@ -1761,7 +1783,7 @@ impl CompilationUnit {
     pub fn with_interprocedural_memoized(
         mut self,
         registry: &CommandRegistry,
-        dialect: Option<&str>,
+        dialect: Option<&tcl_dialect::DialectProfile>,
         taint_cb: &mut TaintCascadeCallback<'_>,
     ) -> Self {
         let object_types = crate::object_types::object_handle_classes(&self, registry);
@@ -1769,7 +1791,7 @@ impl CompilationUnit {
         // classifies a rebound head as the command it is (issue #1275).
         let identities = crate::head_identity::command_head_identities_with_config(
             &self.source,
-            tcl_lexer::LexerConfig::for_dialect(dialect.unwrap_or_default()),
+            tcl_lexer::LexerConfig::for_dialect(dialect.map_or("", |profile| profile.name)),
             registry,
         );
         let interproc = crate::interprocedural::build_interprocedural_analysis(

--- a/rust/tcl-compiler/src/compiler_checks.rs
+++ b/rust/tcl-compiler/src/compiler_checks.rs
@@ -256,7 +256,7 @@ fn shift(fu: &FunctionUnit, mut d: Diagnostic) -> Diagnostic {
 pub fn run_all_checks(
     cu: &CompilationUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Vec<Diagnostic> {
     run_all_checks_with_generic_patterns(cu, registry, dialect, None)
 }
@@ -269,7 +269,7 @@ pub fn run_all_checks(
 pub fn run_all_checks_with_generic_patterns(
     cu: &CompilationUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     generic_patterns: Option<&[String]>,
 ) -> Vec<Diagnostic> {
     let solved = crate::taint_interproc::solve_interprocedural_taints(cu, registry, dialect);
@@ -283,7 +283,7 @@ pub fn run_all_checks_with_generic_patterns(
 pub fn run_all_checks_with_solved(
     cu: &CompilationUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     solved: &crate::taint_interproc::InterprocTaintResult,
 ) -> Vec<Diagnostic> {
     run_all_checks_with_solved_and_patterns(cu, registry, dialect, solved, None)
@@ -295,7 +295,7 @@ pub fn run_all_checks_with_solved(
 pub fn run_all_checks_with_solved_and_patterns(
     cu: &CompilationUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     solved: &crate::taint_interproc::InterprocTaintResult,
     generic_patterns: Option<&[String]>,
 ) -> Vec<Diagnostic> {
@@ -348,7 +348,7 @@ pub fn run_all_checks_with_solved_and_patterns(
 pub fn function_nontaint_checks<S: std::hash::BuildHasher>(
     fu: &FunctionUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     instance_vars: Option<&std::collections::HashSet<String, S>>,
 ) -> Vec<Diagnostic> {
     let mut out: Vec<Diagnostic> = Vec::new();
@@ -384,7 +384,7 @@ pub fn function_nontaint_checks<S: std::hash::BuildHasher>(
 pub fn shimmer_family_checks<S: std::hash::BuildHasher>(
     fu: &FunctionUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     instance_vars: Option<&std::collections::HashSet<String, S>>,
 ) -> Vec<Diagnostic> {
     let mut out: Vec<Diagnostic> = Vec::new();
@@ -443,7 +443,7 @@ pub fn shimmer_family_checks<S: std::hash::BuildHasher>(
 pub fn push_taint_and_module_checks(
     cu: &CompilationUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     solved: &crate::taint_interproc::InterprocTaintResult,
     generic_patterns: Option<&[String]>,
     out: &mut Vec<Diagnostic>,
@@ -558,10 +558,15 @@ pub fn push_taint_and_module_checks(
 fn push_irules_flow_checks(
     cu: &CompilationUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     generic_patterns: Option<&[String]>,
     out: &mut Vec<Diagnostic>,
 ) {
+    // Every iRules security/flow check receives the resolved availability
+    // fact, so a legacy alias cannot be treated differently by a later pass.
+    let dialect = dialect.map_or(tcl_dialect::DialectSet::empty(), |profile| {
+        profile.availability_mask
+    });
     for w in find_unguarded_drop_warnings(cu, dialect) {
         out.push(Diagnostic::from_irules_check(&w));
     }
@@ -642,7 +647,11 @@ mod tests {
             false,
             "tcl9.0",
         );
-        let diags = run_all_checks(&cu, &registry(), Some("tcl9.0"));
+        let diags = run_all_checks(
+            &cu,
+            &registry(),
+            Some(tcl_dialect::DialectProfile::by_name("tcl9.0")),
+        );
         let o105: Vec<_> = diags
             .iter()
             .filter(|diagnostic| diagnostic.code.as_str() == "O105")
@@ -783,8 +792,15 @@ mod tests {
             &registry(),
             false,
         )
-        .with_interprocedural(&registry(), Some("f5-irules"));
-        let diagnostics = run_all_checks(&cu, &registry(), Some("f5-irules"));
+        .with_interprocedural(
+            &registry(),
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+        );
+        let diagnostics = run_all_checks(
+            &cu,
+            &registry(),
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+        );
         assert!(
             diagnostics
                 .iter()
@@ -796,8 +812,15 @@ mod tests {
     #[test]
     fn run_all_checks_reports_irule3101_end_to_end() {
         let cu = CompilationUnit::build_for("HTTP::uri foo", &registry(), false)
-            .with_interprocedural(&registry(), Some("f5-irules"));
-        let diagnostics = run_all_checks(&cu, &registry(), Some("f5-irules"));
+            .with_interprocedural(
+                &registry(),
+                Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+            );
+        let diagnostics = run_all_checks(
+            &cu,
+            &registry(),
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+        );
         assert!(
             diagnostics
                 .iter()
@@ -814,8 +837,15 @@ mod tests {
             &registry(),
             false,
         )
-        .with_interprocedural(&registry(), Some("f5-irules"));
-        let diagnostics = run_all_checks(&cu, &registry(), Some("f5-irules"));
+        .with_interprocedural(
+            &registry(),
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+        );
+        let diagnostics = run_all_checks(
+            &cu,
+            &registry(),
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+        );
         let hit = diagnostics
             .iter()
             .find(|d| d.code == DiagCode::S110)
@@ -847,8 +877,15 @@ mod tests {
         // wider span. `run_all_checks` must therefore stay silent — the
         // analyser end-to-end assertion lives alongside.
         let cu = CompilationUnit::build_for("set u [HTTP::uri]", &registry(), false)
-            .with_interprocedural(&registry(), Some("f5-irules"));
-        let diagnostics = run_all_checks(&cu, &registry(), Some("f5-irules"));
+            .with_interprocedural(
+                &registry(),
+                Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+            );
+        let diagnostics = run_all_checks(
+            &cu,
+            &registry(),
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+        );
         assert!(
             diagnostics.iter().all(|d| d.code != DiagCode::Irule3102),
             "run_all_checks must not double-report IRULE3102: {diagnostics:?}"
@@ -881,9 +918,15 @@ mod tests {
         // must not trigger a high-severity error).
         let src = "HTTP::uri foo";
 
-        let irules_cu = CompilationUnit::build_for(src, &registry(), false)
-            .with_interprocedural(&registry(), Some("f5-irules"));
-        let irules_diags = run_all_checks(&irules_cu, &registry(), Some("f5-irules"));
+        let irules_cu = CompilationUnit::build_for(src, &registry(), false).with_interprocedural(
+            &registry(),
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+        );
+        let irules_diags = run_all_checks(
+            &irules_cu,
+            &registry(),
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+        );
         assert!(
             irules_diags.iter().any(|d| d.code == DiagCode::Irule3101),
             "expected IRULE3101 under f5-irules dialect, got {irules_diags:?}",

--- a/rust/tcl-compiler/src/const_subst.rs
+++ b/rust/tcl-compiler/src/const_subst.rs
@@ -51,6 +51,7 @@
 //! frame) declines the fold; a wrong constant is a miscompile, a missed one
 //! only a lost optimisation.
 
+use tcl_dialect::TclVersion;
 use tcl_registry::{CommandRegistry, CommandSpec};
 
 use crate::naming::normalise_var_name;
@@ -67,9 +68,9 @@ const MAX_CONST_SUBST_DEPTH: u32 = 16;
 pub struct ConstSubstCtx<'a> {
     /// Command / subcommand specs — the fold callbacks live here.
     pub registry: &'a CommandRegistry,
-    /// Dialect name forwarded to versioned folds (`const_fold_versioned`);
-    /// `None` when the consumer has no dialect context.
-    pub dialect: Option<&'a str>,
+    /// Resolved Tcl release forwarded to versioned folds
+    /// (`const_fold_versioned`); `None` when the consumer has no release fact.
+    pub version: Option<TclVersion>,
     /// The fully-qualified class defining the enclosing `TclOO` method
     /// implementation, when the consumer *proved* the frame (instance-side
     /// method of a statically-named, never-renamed class). Enables the
@@ -122,7 +123,7 @@ impl ConstSubstCtx<'_> {
         }
         if spec.subcommands.is_empty() {
             let arg_refs: Vec<&str> = rest.iter().map(String::as_str).collect();
-            spec.run_const_fold(&arg_refs, self.dialect)
+            spec.run_const_fold(&arg_refs, self.version)
         } else {
             // Subcommand-dispatched builtin (`string`, `namespace`, …): the
             // fold lives on the matching subcommand and sees the args after
@@ -130,7 +131,7 @@ impl ConstSubstCtx<'_> {
             let (sub, sub_rest) = rest.split_first()?;
             let arg_refs: Vec<&str> = sub_rest.iter().map(String::as_str).collect();
             spec.resolve_subcommand(sub)?
-                .run_const_fold(&arg_refs, self.dialect)
+                .run_const_fold(&arg_refs, self.version)
         }
     }
 
@@ -306,7 +307,7 @@ mod tests {
     ) -> ConstSubstCtx<'a> {
         ConstSubstCtx {
             registry,
-            dialect: None,
+            version: None,
             defining_class: None,
             trusts,
             lookup_var: lookup,

--- a/rust/tcl-compiler/src/gvn.rs
+++ b/rust/tcl-compiler/src/gvn.rs
@@ -435,7 +435,7 @@ impl PureProcs {
 pub fn find_pure_procs(
     registry: &CommandRegistry,
     cfg_module: &CfgModule,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> PureProcs {
     let mut pure: FxHashSet<String> = cfg_module.procedures.keys().cloned().collect();
 
@@ -463,7 +463,7 @@ fn function_body_is_pure(
     registry: &CommandRegistry,
     cfg: &CfgFunction,
     pure: &FxHashSet<String>,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> bool {
     for block in cfg.blocks.values() {
         for stmt in &block.statements {
@@ -481,7 +481,7 @@ fn statement_is_pure(
     registry: &CommandRegistry,
     stmt: &Statement,
     pure: &FxHashSet<String>,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> bool {
     match stmt {
         Statement::Call {
@@ -533,7 +533,7 @@ fn is_pure_with_procs_core(
     pure: &FxHashSet<String>,
     cmd: &str,
     args: &[String],
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> bool {
     let outer_pure = pure.contains(cmd)
         // Try the common `::` prefix form too — some lowerings yield
@@ -559,7 +559,7 @@ pub fn is_pure_with_procs(
     pure_procs: &PureProcs,
     cmd: &str,
     args: &[String],
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> bool {
     is_pure_with_procs_core(registry, &pure_procs.names, cmd, args, dialect)
 }
@@ -595,14 +595,14 @@ pub fn is_worth_reporting_with_procs(
 /// purposes — i.e. has no observable side effects.
 ///
 /// Bridges to [`classify_side_effects`]. An optional
-/// dialect (`Some("irules")` / `Some("tcl")`) threads through to
+/// dialect (`Some(tcl_dialect::DialectProfile::by_name("irules"))` / `Some(tcl_dialect::DialectProfile::by_name("tcl"))`) threads through to
 /// the classifier.
 #[must_use]
 pub fn is_pure_command(
     registry: &CommandRegistry,
     command: &str,
     args: &[String],
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> bool {
     if !classify_side_effects(registry, command, args, dialect, None).pure {
         return false;
@@ -646,7 +646,7 @@ pub fn is_pure_command_with_traces(
     registry: &CommandRegistry,
     command: &str,
     args: &[String],
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     traced_commands: &std::collections::BTreeSet<String>,
     has_dynamic_trace: bool,
 ) -> bool {
@@ -936,7 +936,7 @@ fn gvn_site_eligibility(
 pub fn statement_writes_state(
     registry: &CommandRegistry,
     stmt: &Statement,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> bool {
     match stmt {
         Statement::Barrier { .. } => true,
@@ -958,7 +958,7 @@ pub fn statement_writes_state(
 fn statement_writes_state_for_gvn(
     registry: &CommandRegistry,
     stmt: &Statement,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     legality: GvnLegalitySource<'_>,
 ) -> bool {
     match legality {
@@ -995,7 +995,7 @@ pub fn statement_occurrences(
     stmt_ssa: &SsaStatement,
     block_name: &str,
     statement_index: usize,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     ssa: &SsaFunction,
 ) -> Vec<ExprOccurrence> {
     statement_occurrences_for_gvn(
@@ -1016,7 +1016,7 @@ fn statement_occurrences_for_gvn(
     stmt_ssa: &SsaStatement,
     block_name: &str,
     statement_index: usize,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     ssa: &SsaFunction,
     legality: GvnLegalitySource<'_>,
 ) -> Vec<ExprOccurrence> {
@@ -1324,7 +1324,7 @@ pub fn find_redundancies(
     registry: &CommandRegistry,
     cfg: &CfgFunction,
     ssa: &SsaFunction,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Vec<RedundantComputation> {
     find_redundancies_with_semantic_facts(registry, cfg, ssa, dialect, GvnLegalitySource::Legacy)
 }
@@ -1335,7 +1335,7 @@ fn find_redundancies_with_semantic_facts(
     registry: &CommandRegistry,
     cfg: &CfgFunction,
     ssa: &SsaFunction,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     legality: GvnLegalitySource<'_>,
 ) -> Vec<RedundantComputation> {
     let mut table = ScopedValueTable::new();
@@ -1422,7 +1422,7 @@ fn find_redundancies_with_semantic_facts(
 pub fn find_redundancies_for_function(
     registry: &CommandRegistry,
     function: &crate::compilation_unit::FunctionUnit,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Vec<RedundantComputation> {
     let semantic = GvnSemanticFacts::from_function(function);
     find_redundancies_with_semantic_facts(
@@ -1540,7 +1540,7 @@ pub fn find_loop_invariants<S: std::hash::BuildHasher>(
     cfg: &CfgFunction,
     ssa: &SsaFunction,
     executable: &std::collections::HashSet<BlockId, S>,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Vec<RedundantComputation> {
     find_loop_invariants_with_legality(
         registry,
@@ -1567,7 +1567,7 @@ pub fn find_loop_invariants<S: std::hash::BuildHasher>(
 pub fn find_loop_invariants_for_function(
     registry: &CommandRegistry,
     function: &crate::compilation_unit::FunctionUnit,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Vec<RedundantComputation> {
     let semantic = GvnSemanticFacts::from_function(function);
     find_loop_invariants_with_legality(
@@ -1585,7 +1585,7 @@ fn find_loop_invariants_with_legality(
     cfg: &CfgFunction,
     ssa: &SsaFunction,
     executable: &FxHashSet<BlockId>,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     legality: GvnLegalitySource<'_>,
 ) -> Vec<RedundantComputation> {
     let mut results: Vec<RedundantComputation> = Vec::new();
@@ -1717,7 +1717,7 @@ pub fn collect_function_occurrence_events<S: std::hash::BuildHasher>(
     cfg: &CfgFunction,
     ssa: &SsaFunction,
     executable: &std::collections::HashSet<BlockId, S>,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> (
     FxHashMap<BlockId, Vec<OccurrenceEvent>>,
     Vec<ExprOccurrence>,
@@ -1738,7 +1738,7 @@ fn collect_function_occurrence_events_with_legality(
     cfg: &CfgFunction,
     ssa: &SsaFunction,
     executable: &FxHashSet<BlockId>,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     legality: GvnLegalitySource<'_>,
 ) -> (
     FxHashMap<BlockId, Vec<OccurrenceEvent>>,
@@ -1918,7 +1918,7 @@ pub fn find_partial_redundancies<S: std::hash::BuildHasher>(
     cfg: &CfgFunction,
     ssa: &SsaFunction,
     executable: &std::collections::HashSet<BlockId, S>,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Vec<RedundantComputation> {
     find_partial_redundancies_with_legality(
         registry,
@@ -1944,7 +1944,7 @@ pub fn find_partial_redundancies<S: std::hash::BuildHasher>(
 pub fn find_partial_redundancies_for_function(
     registry: &CommandRegistry,
     function: &crate::compilation_unit::FunctionUnit,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Vec<RedundantComputation> {
     let semantic = GvnSemanticFacts::from_function(function);
     find_partial_redundancies_with_legality(
@@ -1962,7 +1962,7 @@ fn find_partial_redundancies_with_legality(
     cfg: &CfgFunction,
     ssa: &SsaFunction,
     executable: &FxHashSet<BlockId>,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     legality: GvnLegalitySource<'_>,
 ) -> Vec<RedundantComputation> {
     if !executable.contains(&ssa.entry) {
@@ -2054,7 +2054,7 @@ fn find_partial_redundancies_with_legality(
 pub fn find_redundancies_for_cu(
     cu: &crate::compilation_unit::CompilationUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Vec<RedundantComputation> {
     let mut out = Vec::new();
     for fu in cu.analysable_functions() {
@@ -2070,7 +2070,7 @@ pub fn find_redundancies_for_cu(
 pub fn find_partial_redundancies_for_cu(
     cu: &crate::compilation_unit::CompilationUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Vec<RedundantComputation> {
     let mut out = Vec::new();
     for fu in cu.analysable_functions() {
@@ -2088,7 +2088,7 @@ pub fn find_partial_redundancies_for_cu(
 pub fn find_loop_invariants_for_cu(
     cu: &crate::compilation_unit::CompilationUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Vec<RedundantComputation> {
     let mut out = Vec::new();
     for fu in cu.analysable_functions() {
@@ -2114,10 +2114,20 @@ mod tests {
         let function = &cu.top_level;
 
         assert!(
-            !find_redundancies(&registry, &function.cfg, &function.ssa, Some("tcl8.6")).is_empty(),
+            !find_redundancies(
+                &registry,
+                &function.cfg,
+                &function.ssa,
+                Some(tcl_dialect::DialectProfile::by_name("tcl8.6"))
+            )
+            .is_empty(),
             "the legacy classifier recognises the registry pure trait"
         );
-        let semantic = find_redundancies_for_function(&registry, function, Some("tcl8.6"));
+        let semantic = find_redundancies_for_function(
+            &registry,
+            function,
+            Some(tcl_dialect::DialectProfile::by_name("tcl8.6")),
+        );
         assert_eq!(
             semantic.len(),
             1,
@@ -2155,11 +2165,22 @@ mod tests {
         );
         let function = &cu.top_level;
         assert!(
-            !find_redundancies(&registry, &function.cfg, &function.ssa, Some("tcl8.6")).is_empty(),
+            !find_redundancies(
+                &registry,
+                &function.cfg,
+                &function.ssa,
+                Some(tcl_dialect::DialectProfile::by_name("tcl8.6"))
+            )
+            .is_empty(),
             "the explicit legacy API still sees the nested string-classified calls"
         );
         assert!(
-            find_redundancies_for_function(&registry, function, Some("tcl8.6")).is_empty(),
+            find_redundancies_for_function(
+                &registry,
+                function,
+                Some(tcl_dialect::DialectProfile::by_name("tcl8.6"))
+            )
+            .is_empty(),
             "opaque structured source sites have no exact invocation mapping and must abstain"
         );
     }
@@ -2183,7 +2204,12 @@ mod tests {
             ExecutableAnalysisAvailability::Available(_)
         ));
         assert_eq!(
-            find_redundancies_for_function(&registry, &cu.top_level, Some("tcl8.6")).len(),
+            find_redundancies_for_function(
+                &registry,
+                &cu.top_level,
+                Some(tcl_dialect::DialectProfile::by_name("tcl8.6"))
+            )
+            .len(),
             1,
             "a closed registry contract plus a complete site proof reports the replay"
         );
@@ -2201,7 +2227,12 @@ mod tests {
                 source, &registry, false, "tcl9.0",
             );
             assert_eq!(
-                find_redundancies_for_function(&registry, &cu.top_level, Some("tcl9.0")).len(),
+                find_redundancies_for_function(
+                    &registry,
+                    &cu.top_level,
+                    Some(tcl_dialect::DialectProfile::by_name("tcl9.0"))
+                )
+                .len(),
                 1,
                 "closed stable registry category with a live dispatch proof reuses: {source}"
             );
@@ -2284,7 +2315,12 @@ mod tests {
             ExecutableAnalysisAvailability::Available(_)
         ));
         assert!(
-            find_redundancies_for_function(&registry, &cu.top_level, Some("tcl9.0")).is_empty(),
+            find_redundancies_for_function(
+                &registry,
+                &cu.top_level,
+                Some(tcl_dialect::DialectProfile::by_name("tcl9.0"))
+            )
+            .is_empty(),
             "an execution-traced command is observably invoked twice"
         );
 
@@ -2296,7 +2332,12 @@ mod tests {
             "tcl9.0",
         );
         assert_eq!(
-            find_redundancies_for_function(&registry, &untraced.top_level, Some("tcl9.0")).len(),
+            find_redundancies_for_function(
+                &registry,
+                &untraced.top_level,
+                Some(tcl_dialect::DialectProfile::by_name("tcl9.0"))
+            )
+            .len(),
             1,
             "the trace registration must be the only reason the report is withheld"
         );
@@ -2321,7 +2362,12 @@ mod tests {
         );
 
         assert!(
-            find_redundancies_for_function(&registry, &cu.top_level, Some("tcl9.0")).is_empty(),
+            find_redundancies_for_function(
+                &registry,
+                &cu.top_level,
+                Some(tcl_dialect::DialectProfile::by_name("tcl9.0"))
+            )
+            .is_empty(),
             "read-only volatile results must not become common subexpressions"
         );
     }
@@ -2337,7 +2383,12 @@ mod tests {
                 source, &registry, false, "tcl9.0",
             );
             assert!(
-                find_redundancies_for_function(&registry, &cu.top_level, Some("tcl9.0")).is_empty(),
+                find_redundancies_for_function(
+                    &registry,
+                    &cu.top_level,
+                    Some(tcl_dialect::DialectProfile::by_name("tcl9.0"))
+                )
+                .is_empty(),
                 "clock result dependencies must make production GVN abstain: {source}"
             );
         }
@@ -3843,7 +3894,11 @@ mod tests {
             ),
             "executable semantic facts must be available for: {source}"
         );
-        find_redundancies_for_function(registry, &cu.top_level, Some("tcl9.0"))
+        find_redundancies_for_function(
+            registry,
+            &cu.top_level,
+            Some(tcl_dialect::DialectProfile::by_name("tcl9.0")),
+        )
     }
 
     /// How many stable-call reuse findings one top-level script produces.
@@ -4274,12 +4329,22 @@ mod tests {
         );
         let procedure = cu.procedures.get("::p").expect("the proc unit is built");
         assert!(
-            !find_redundancies(&registry, &procedure.cfg, &procedure.ssa, Some("tcl9.0"))
-                .is_empty(),
+            !find_redundancies(
+                &registry,
+                &procedure.cfg,
+                &procedure.ssa,
+                Some(tcl_dialect::DialectProfile::by_name("tcl9.0"))
+            )
+            .is_empty(),
             "the legacy classifier still recognises the repeated pure call"
         );
         assert!(
-            find_redundancies_for_function(&registry, procedure, Some("tcl9.0")).is_empty(),
+            find_redundancies_for_function(
+                &registry,
+                procedure,
+                Some(tcl_dialect::DialectProfile::by_name("tcl9.0"))
+            )
+            .is_empty(),
             "a proc body runs after arbitrary interposed history, so every site proof fails closed"
         );
     }
@@ -4298,13 +4363,18 @@ mod tests {
                 &registry,
                 &cu.top_level.cfg,
                 &cu.top_level.ssa,
-                Some("tcl9.0")
+                Some(tcl_dialect::DialectProfile::by_name("tcl9.0"))
             )
             .is_empty(),
             "the explicit legacy API still sees the nested string-classified calls"
         );
         assert!(
-            find_redundancies_for_function(&registry, &cu.top_level, Some("tcl9.0")).is_empty(),
+            find_redundancies_for_function(
+                &registry,
+                &cu.top_level,
+                Some(tcl_dialect::DialectProfile::by_name("tcl9.0"))
+            )
+            .is_empty(),
             "structured loop bodies are unmapped executable source and must abstain"
         );
     }

--- a/rust/tcl-compiler/src/interprocedural.rs
+++ b/rust/tcl-compiler/src/interprocedural.rs
@@ -582,7 +582,7 @@ static EMPTY_OBJECT_TYPES: std::sync::LazyLock<HashMap<String, HashSet<String>>>
 pub fn build_interprocedural_analysis(
     ir_module: &crate::ir::Module,
     registry: &tcl_registry::CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     object_types: ObjectTypeMap<'_>,
     identities: &crate::head_identity::HeadIdentityMap,
 ) -> InterproceduralAnalysis {
@@ -659,7 +659,7 @@ fn build_method_summaries(
     ir_module: &crate::ir::Module,
     known: &HashSet<String>,
     registry: &tcl_registry::CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     identities: &crate::head_identity::HeadIdentityMap,
     procs: ProcFixpoints<'_>,
 ) -> HashMap<String, MethodSummary> {
@@ -800,7 +800,7 @@ struct MethodScan<'a> {
     mqname: &'a str,
     method_known: &'a HashSet<String>,
     registry: &'a tcl_registry::CommandRegistry,
-    dialect: Option<&'a str>,
+    dialect: Option<&'a tcl_dialect::DialectProfile>,
     identities: &'a crate::head_identity::HeadIdentityMap,
 }
 
@@ -990,7 +990,7 @@ fn scan_all_procs(
     ir_module: &crate::ir::Module,
     known: &HashSet<String>,
     registry: &tcl_registry::CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     object_types: &HashMap<String, HashSet<String>>,
     identities: &crate::head_identity::HeadIdentityMap,
 ) -> HashMap<String, LocalFacts> {
@@ -1020,7 +1020,7 @@ struct ProcScan<'a> {
     proc: &'a crate::ir::Procedure,
     known: &'a HashSet<String>,
     registry: &'a tcl_registry::CommandRegistry,
-    dialect: Option<&'a str>,
+    dialect: Option<&'a tcl_dialect::DialectProfile>,
     object_types: &'a HashMap<String, HashSet<String>>,
     identities: &'a crate::head_identity::HeadIdentityMap,
 }
@@ -1293,7 +1293,7 @@ struct ScanCtx<'a> {
     caller: &'a str,
     known: &'a HashSet<String>,
     registry: &'a tcl_registry::CommandRegistry,
-    dialect: Option<&'a str>,
+    dialect: Option<&'a tcl_dialect::DialectProfile>,
     params: &'a HashSet<String>,
     /// Object-handle → candidate class names for this module
     /// ([`crate::object_types::object_handle_classes`]), so a `$g walk …
@@ -1939,7 +1939,7 @@ fn scan_value_substitutions(text: &str, ctx: ScanCtx<'_>, facts: &mut LocalFacts
     }
     let lexer = tcl_lexer::Lexer::with_source_map(
         tcl_lexer::SourceMap::new(text),
-        tcl_lexer::LexerConfig::for_dialect(dialect.unwrap_or_default()),
+        tcl_lexer::LexerConfig::for_dialect(dialect.map_or("", |profile| profile.name)),
     );
     let Ok(tokens) = lexer.tokenise_all() else {
         return;
@@ -1984,7 +1984,7 @@ fn scan_source_for_calls(source: &str, ctx: ScanCtx<'_>, facts: &mut LocalFacts,
     let commands = crate::segmenter::segment_commands_with_offset_and_config(
         source,
         0,
-        tcl_lexer::LexerConfig::for_dialect(dialect.unwrap_or_default()),
+        tcl_lexer::LexerConfig::for_dialect(dialect.map_or("", |profile| profile.name)),
     );
     for cmd in commands {
         // Skip empty / non-literal command names — they're not
@@ -2515,7 +2515,7 @@ mod tests {
         let ia = build_interprocedural_analysis(
             &ir,
             registry,
-            Some(dialect),
+            Some(tcl_dialect::DialectProfile::by_name(dialect)),
             ObjectTypeMap::none(),
             crate::head_identity::HeadIdentityMap::none(),
         );
@@ -2930,7 +2930,7 @@ mod tests {
             &registry,
             false,
         )
-        .with_interprocedural(&registry, Some("tcl9.0"));
+        .with_interprocedural(&registry, Some(tcl_dialect::DialectProfile::by_name("tcl9.0")));
         let summary = &cu.interproc.as_ref().expect("interproc").procedures["::build"];
         assert!(
             summary.direct_calls.iter().any(|c| c == "::onNode"),
@@ -3614,7 +3614,7 @@ mod effect_propagation_tests {
             let ia = build_interprocedural_analysis(
                 &module,
                 &reg,
-                Some("f5-irules"),
+                Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
                 ObjectTypeMap::none(),
                 crate::head_identity::HeadIdentityMap::none(),
             );
@@ -3631,7 +3631,7 @@ mod effect_propagation_tests {
         let ia = build_interprocedural_analysis(
             &module,
             &reg,
-            Some("f5-irules"),
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
             ObjectTypeMap::none(),
             crate::head_identity::HeadIdentityMap::none(),
         );

--- a/rust/tcl-compiler/src/intervals.rs
+++ b/rust/tcl-compiler/src/intervals.rs
@@ -693,10 +693,10 @@ fn loop_headers(cfg: &CfgFunction, ssa: &SsaFunction) -> HashSet<BlockId> {
 /// profile, whose grammar is `Tcl90`: the same default
 /// [`crate::codegen::CodegenCtx::numbers`] takes for its hand-built contexts.
 #[must_use]
-pub fn numbers_for_dialect(dialect: Option<&str>) -> NumberSyntax {
-    tcl_dialect::DialectProfile::by_opt_name(dialect)
-        .grammar
-        .numbers
+pub fn numbers_for_dialect(dialect: Option<&tcl_dialect::DialectProfile>) -> NumberSyntax {
+    dialect.map_or(tcl_dialect::NumberSyntax::Tcl90, |profile| {
+        profile.grammar.numbers
+    })
 }
 
 /// [`compute_intervals_with`] under the Tcl 9.0 numeral grammar.
@@ -1325,7 +1325,7 @@ mod tests {
             &fu.cfg,
             &fu.ssa,
             &fu.sccp.values,
-            numbers_for_dialect(Some("tcl8.6")),
+            numbers_for_dialect(Some(tcl_dialect::DialectProfile::by_name("tcl8.6"))),
         );
         // The analysis runs and produces a (possibly empty but well-formed) map;
         // every computed interval is a valid lattice element (not the lo>hi

--- a/rust/tcl-compiler/src/irules_checks.rs
+++ b/rust/tcl-compiler/src/irules_checks.rs
@@ -36,6 +36,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::OnceLock;
 use tcl_core_types::DiagCode;
+use tcl_dialect::DialectSet;
 
 use tcl_lexer::Span;
 use tcl_registry::events::{
@@ -49,7 +50,6 @@ use crate::compilation_unit::CompilationUnit;
 use crate::ir::{Script, Statement};
 use crate::lowering::lower_to_ir_with_config;
 use crate::sccp::cfg_order;
-use crate::taint::is_irules_dialect;
 use crate::value_shapes::parse_command_substitution;
 
 /// Process-wide iRules command registry, used to derive the HTTP-flow command
@@ -333,10 +333,10 @@ pub(crate) fn is_unnormalised_getter(
 pub fn find_unnormalised_getter_warnings(
     cu: &CompilationUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: DialectSet,
 ) -> Vec<IrulesCheckWarning> {
     let mut out: Vec<IrulesCheckWarning> = Vec::new();
-    if !is_irules_dialect(dialect) {
+    if !dialect.contains(DialectSet::IRULES) {
         return out;
     }
 
@@ -517,10 +517,10 @@ fn drop_flow_leaf(st: &DropFlowState, stmt: &Statement) -> DropFlowState {
 #[must_use]
 pub fn find_unguarded_drop_warnings(
     cu: &CompilationUnit,
-    dialect: Option<&str>,
+    dialect: DialectSet,
 ) -> Vec<IrulesCheckWarning> {
     let mut out: Vec<IrulesCheckWarning> = Vec::new();
-    if !is_irules_dialect(dialect) {
+    if !dialect.contains(DialectSet::IRULES) {
         return out;
     }
     let leaf = |st: &DropFlowState, stmt: &Statement, _out: &mut Vec<IrulesCheckWarning>| {
@@ -853,9 +853,9 @@ fn scan_side_switch_body(
 pub fn find_collect_flow_warnings(
     cu: &CompilationUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: DialectSet,
 ) -> Vec<IrulesCheckWarning> {
-    if !is_irules_dialect(dialect) {
+    if !dialect.contains(DialectSet::IRULES) {
         return Vec::new();
     }
     let (state, events_seen) = collect_flow_state(cu, registry);
@@ -1100,10 +1100,10 @@ struct HttpFlowState {
 #[must_use]
 pub fn find_http_flow_warnings(
     cu: &CompilationUnit,
-    dialect: Option<&str>,
+    dialect: DialectSet,
 ) -> Vec<IrulesCheckWarning> {
     let mut out = Vec::new();
-    if !is_irules_dialect(dialect) {
+    if !dialect.contains(DialectSet::IRULES) {
         return out;
     }
     let events = EventRegistry::build();
@@ -1471,10 +1471,10 @@ where
 #[must_use]
 pub fn find_hoistable_set_warnings(
     cu: &CompilationUnit,
-    dialect: Option<&str>,
+    dialect: DialectSet,
 ) -> Vec<IrulesCheckWarning> {
     let mut out = Vec::new();
-    if !is_irules_dialect(dialect) {
+    if !dialect.contains(DialectSet::IRULES) {
         return out;
     }
     let events = EventRegistry::build();
@@ -1623,11 +1623,11 @@ fn is_generic_static_name(var_name: &str, compiled: &[regex::Regex]) -> bool {
 #[must_use]
 pub fn find_generic_static_name_warnings(
     cu: &CompilationUnit,
-    dialect: Option<&str>,
+    dialect: DialectSet,
     generic_patterns: Option<&[String]>,
 ) -> Vec<IrulesCheckWarning> {
     let mut out = Vec::new();
-    if !is_irules_dialect(dialect) {
+    if !dialect.contains(DialectSet::IRULES) {
         return out;
     }
     let compiled = compile_generic_patterns(generic_patterns);
@@ -1709,7 +1709,7 @@ mod tests {
 
     fn warnings_for_irules(source: &str) -> Vec<IrulesCheckWarning> {
         let cu = CompilationUnit::build_for(source, &registry(), false);
-        find_unnormalised_getter_warnings(&cu, &registry(), Some("f5-irules"))
+        find_unnormalised_getter_warnings(&cu, &registry(), DialectSet::IRULES)
     }
 
     #[test]
@@ -1767,8 +1767,12 @@ mod tests {
     #[test]
     fn irule3102_non_irules_dialect_returns_empty() {
         let cu = CompilationUnit::build_for("set u [HTTP::uri]", &registry(), false);
-        assert!(find_unnormalised_getter_warnings(&cu, &registry(), None).is_empty());
-        assert!(find_unnormalised_getter_warnings(&cu, &registry(), Some("tcl")).is_empty());
+        assert!(
+            find_unnormalised_getter_warnings(&cu, &registry(), DialectSet::empty()).is_empty()
+        );
+        assert!(
+            find_unnormalised_getter_warnings(&cu, &registry(), DialectSet::ALL_TCL).is_empty()
+        );
     }
 
     #[test]
@@ -1839,7 +1843,7 @@ mod tests {
 
     fn drop_warnings(source: &str) -> Vec<IrulesCheckWarning> {
         let cu = CompilationUnit::build_for(source, &registry(), false);
-        find_unguarded_drop_warnings(&cu, Some("f5-irules"))
+        find_unguarded_drop_warnings(&cu, DialectSet::IRULES)
     }
 
     #[test]
@@ -1881,9 +1885,9 @@ mod tests {
     #[test]
     fn irule5002_only_in_irules_dialect() {
         let cu = CompilationUnit::build_for("when CLIENT_ACCEPTED { drop }", &registry(), false);
-        let none_dialect = find_unguarded_drop_warnings(&cu, None);
+        let none_dialect = find_unguarded_drop_warnings(&cu, DialectSet::empty());
         assert!(none_dialect.is_empty(), "got {none_dialect:?}");
-        let tcl_dialect = find_unguarded_drop_warnings(&cu, Some("tcl"));
+        let tcl_dialect = find_unguarded_drop_warnings(&cu, DialectSet::ALL_TCL);
         assert!(tcl_dialect.is_empty(), "got {tcl_dialect:?}");
     }
 
@@ -2058,7 +2062,7 @@ mod tests {
     fn flow_warnings(source: &str) -> Vec<IrulesCheckWarning> {
         let reg = registry();
         let cu = CompilationUnit::build_for(source, &reg, false);
-        find_collect_flow_warnings(&cu, &reg, Some("f5-irules"))
+        find_collect_flow_warnings(&cu, &reg, DialectSet::IRULES)
     }
 
     #[test]
@@ -2384,7 +2388,7 @@ mod tests {
     fn collect_flow_only_in_irules_dialect() {
         let reg = registry();
         let cu = CompilationUnit::build_for("when CLIENT_ACCEPTED { TCP::collect }", &reg, false);
-        let none = find_collect_flow_warnings(&cu, &reg, None);
+        let none = find_collect_flow_warnings(&cu, &reg, DialectSet::empty());
         assert!(none.is_empty(), "got {none:?}");
     }
 
@@ -2392,7 +2396,7 @@ mod tests {
 
     fn http_warnings(source: &str) -> Vec<IrulesCheckWarning> {
         let cu = CompilationUnit::build_for(source, &registry(), false);
-        find_http_flow_warnings(&cu, Some("f5-irules"))
+        find_http_flow_warnings(&cu, DialectSet::IRULES)
     }
 
     #[test]
@@ -2636,7 +2640,7 @@ mod tests {
 
     fn hoist_warnings(source: &str) -> Vec<IrulesCheckWarning> {
         let cu = CompilationUnit::build_for(source, &registry(), false);
-        find_hoistable_set_warnings(&cu, Some("f5-irules"))
+        find_hoistable_set_warnings(&cu, DialectSet::IRULES)
     }
 
     #[test]
@@ -2729,7 +2733,7 @@ mod tests {
             "the control event must be guarded"
         );
 
-        let ws = find_hoistable_set_warnings(&cu, Some("f5-irules"));
+        let ws = find_hoistable_set_warnings(&cu, DialectSet::IRULES);
         assert!(
             !ws.iter().any(|w| w.code == DiagCode::Irule4004),
             "a guarded event's second write must suppress the hoist warning, got {ws:?}",
@@ -2776,7 +2780,7 @@ mod tests {
             &registry(),
             false,
         );
-        let none = find_hoistable_set_warnings(&cu, None);
+        let none = find_hoistable_set_warnings(&cu, DialectSet::empty());
         assert!(none.is_empty(), "got {none:?}");
     }
 
@@ -2784,12 +2788,12 @@ mod tests {
 
     fn generic_warnings(source: &str) -> Vec<IrulesCheckWarning> {
         let cu = CompilationUnit::build_for(source, &registry(), false);
-        find_generic_static_name_warnings(&cu, Some("f5-irules"), None)
+        find_generic_static_name_warnings(&cu, DialectSet::IRULES, None)
     }
 
     fn generic_warnings_with(source: &str, patterns: &[String]) -> Vec<IrulesCheckWarning> {
         let cu = CompilationUnit::build_for(source, &registry(), false);
-        find_generic_static_name_warnings(&cu, Some("f5-irules"), Some(patterns))
+        find_generic_static_name_warnings(&cu, DialectSet::IRULES, Some(patterns))
     }
 
     #[test]
@@ -2830,7 +2834,7 @@ mod tests {
             &registry(),
             false,
         );
-        assert!(find_generic_static_name_warnings(&cu, None, None).is_empty());
+        assert!(find_generic_static_name_warnings(&cu, DialectSet::empty(), None).is_empty());
     }
 
     #[test]

--- a/rust/tcl-compiler/src/native_integer_proof.rs
+++ b/rust/tcl-compiler/src/native_integer_proof.rs
@@ -270,7 +270,12 @@ pub fn prove_native_integer_adds(
     // operand's value depends on it (`0755` is 493 up to 8.6, 755 from 9.0), and
     // this proof turns a range into a native-width decision, so it must be the
     // target's grammar rather than whatever is ambient.
-    let numbers = numbers_for_dialect(unit.ir_module.dialect.as_deref());
+    let numbers = numbers_for_dialect(
+        unit.ir_module
+            .dialect
+            .as_deref()
+            .map(tcl_dialect::DialectProfile::by_name),
+    );
     let intervals = compute_intervals_with(
         &function_unit.cfg,
         &function_unit.ssa,
@@ -438,6 +443,10 @@ struct CallerRangeEvidence {
     dispatch_dependencies: DispatchDependencies,
 }
 
+#[allow(
+    clippy::too_many_lines,
+    reason = "the caller-evidence walk shares one conservative decline path across every supported call shape"
+)]
 fn collect_caller_ranges(
     unit: &CompilationUnit,
     function: &str,
@@ -487,7 +496,12 @@ fn collect_caller_ranges(
             &caller.cfg,
             &caller.ssa,
             &caller.sccp.values,
-            numbers_for_dialect(unit.ir_module.dialect.as_deref()),
+            numbers_for_dialect(
+                unit.ir_module
+                    .dialect
+                    .as_deref()
+                    .map(tcl_dialect::DialectProfile::by_name),
+            ),
         );
         let caller_observability = analyse_var_observability(&caller.cfg, registry);
         for (param, argument) in params.iter().zip(args.iter()) {

--- a/rust/tcl-compiler/src/optimiser/helpers/expr_simplify.rs
+++ b/rust/tcl-compiler/src/optimiser/helpers/expr_simplify.rs
@@ -321,12 +321,12 @@ fn is_integer_string(text: &str) -> bool {
 /// substitution, or any domain error (match `eval_tcl_expr`'s
 /// conservative "give up, use runtime form" contract).
 #[must_use]
-pub fn try_fold_expr(expr: &str, dialect: Option<&str>) -> Option<String> {
+pub fn try_fold_expr(expr: &str, dialect: Option<&tcl_dialect::DialectProfile>) -> Option<String> {
     let trimmed = expr.trim();
     if trimmed.is_empty() {
         return None;
     }
-    let node = parse_expr(trimmed, dialect);
+    let node = parse_expr(trimmed, dialect.map(|profile| profile.name));
     if matches!(node, ExprNode::Raw { .. }) {
         return None;
     }
@@ -365,14 +365,14 @@ pub fn try_fold_expr_with_constants<S: std::hash::BuildHasher>(
     expr: &str,
     constants: &std::collections::HashMap<String, String, S>,
     braced: bool,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Option<String> {
     use crate::tcl_expr_eval::EnvValue;
     let trimmed = expr.trim();
     if trimmed.is_empty() {
         return None;
     }
-    let node = parse_expr(trimmed, dialect);
+    let node = parse_expr(trimmed, dialect.map(|profile| profile.name));
     if matches!(node, ExprNode::Raw { .. }) {
         return None;
     }
@@ -384,7 +384,7 @@ pub fn try_fold_expr_with_constants<S: std::hash::BuildHasher>(
             || is_numeric_string_under(
                 value,
                 Some(tcl_dialect::NumberSyntax::of_profile(Some(
-                    tcl_dialect::DialectProfile::by_opt_name(dialect),
+                    dialect.unwrap_or(tcl_dialect::DialectProfile::plain_tcl()),
                 ))),
             )
         {
@@ -469,9 +469,9 @@ pub struct SubstitutionResult {
 pub fn substitute_expr_constants<S: std::hash::BuildHasher>(
     expr: &str,
     constants: &std::collections::HashMap<String, String, S>,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> SubstitutionResult {
-    let tokens = tokenise_expr(expr, dialect);
+    let tokens = tokenise_expr(expr, dialect.map(|profile| profile.name));
     let mut pieces: Vec<String> = Vec::new();
     let mut cursor: usize = 0;
     let mut changed = false;

--- a/rust/tcl-compiler/src/optimiser/manager.rs
+++ b/rust/tcl-compiler/src/optimiser/manager.rs
@@ -60,15 +60,14 @@ pub fn optimise(source: &str, registry: &CommandRegistry) -> Vec<Optimisation> {
 pub fn optimise_with_dialect(
     source: &str,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Vec<Optimisation> {
-    let cu = CompilationUnit::build_for_with_config(
-        source,
-        registry,
-        false,
-        tcl_lexer::LexerConfig::for_dialect(dialect.unwrap_or_default()),
-    )
-    .with_interprocedural(registry, dialect);
+    let profile = match dialect {
+        Some(profile) => profile,
+        None => tcl_dialect::DialectProfile::plain_tcl(),
+    };
+    let cu = CompilationUnit::build_for_profile(source, registry, false, profile)
+        .with_interprocedural(registry, dialect);
     optimise_unit(&cu, registry, dialect)
 }
 
@@ -83,7 +82,7 @@ pub fn optimise_with_dialect(
 pub fn optimise_unit(
     cu: &CompilationUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Vec<Optimisation> {
     let raw = optimise_unit_raw(cu, registry, dialect);
     finalise_optimisations(&raw, cu, registry, dialect)
@@ -132,7 +131,7 @@ fn sort_optimisations(opts: &mut [Optimisation]) {
 fn build_pass_context<'a>(
     cu: &'a CompilationUnit,
     registry: &'a CommandRegistry,
-    dialect: Option<&'a str>,
+    dialect: Option<&'a tcl_dialect::DialectProfile>,
 ) -> PassContext<'a> {
     let ia = cu.interproc.clone().unwrap_or_default();
     let mut ctx = PassContext::with_dialect(&cu.source, ia, dialect);
@@ -175,7 +174,7 @@ fn build_pass_context<'a>(
 pub fn optimise_unit_raw(
     cu: &CompilationUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Vec<Optimisation> {
     let mut ctx = build_pass_context(cu, registry, dialect);
     run_passes(&mut ctx, cu, &PassId::all());
@@ -201,7 +200,7 @@ pub fn finalise_optimisations(
     raw: &[Optimisation],
     cu: &CompilationUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Vec<Optimisation> {
     let mut selected = select_non_overlapping(raw);
     // Couple constant propagation with dead-store removal: a `set x <const>`
@@ -413,7 +412,7 @@ fn in_string_or_braces(bytes: &[u8], pos: usize) -> bool {
 fn couple_propagated_const_dead_stores(
     cu: &CompilationUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     selected: &mut Vec<Optimisation>,
 ) {
     if crate::taint::is_irules_dialect(dialect) {
@@ -791,7 +790,7 @@ fn renumber_groups(opts: &mut [Optimisation]) {
 pub fn find_dead_stores(
     cu: &CompilationUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Vec<DeadStore> {
     let mut ctx = build_pass_context(cu, registry, dialect);
     run_passes(&mut ctx, cu, &PassId::all());
@@ -809,7 +808,7 @@ pub fn find_dead_stores(
 pub fn optimise_by_pass(
     cu: &CompilationUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Vec<(PassId, Vec<Optimisation>)> {
     let mut ctx = build_pass_context(cu, registry, dialect);
     let mut by_pass = Vec::new();
@@ -821,15 +820,30 @@ pub fn optimise_by_pass(
     by_pass
 }
 
-/// Build, run every pass, and return the full *unfiltered*
-/// optimisation list (no overlap resolution). Exposed mainly for
-/// tests that want to inspect raw per-pass output before the
-/// manager's arbitration.
+/// Compatibility entry point for test and external dialect-name callers.
+///
+/// Typed callers should use [`optimise_raw_for_profile`].
 #[must_use]
 pub fn optimise_raw(
     source: &str,
     registry: &CommandRegistry,
     dialect: Option<&str>,
+) -> Vec<Optimisation> {
+    optimise_raw_for_profile(
+        source,
+        registry,
+        dialect.map(tcl_dialect::DialectProfile::by_name),
+    )
+}
+
+/// Build, run every pass, and return the full *unfiltered* optimisation list
+/// (no overlap resolution) under an already-resolved profile. Exposed mainly
+/// for tests that inspect raw per-pass output before manager arbitration.
+#[must_use]
+pub fn optimise_raw_for_profile(
+    source: &str,
+    registry: &CommandRegistry,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Vec<Optimisation> {
     // Split the raw CU build to avoid `with_interprocedural`'s taint
     // re-run (irrelevant for `optimise_raw`'s test callers) — but `cu.interproc`
@@ -842,12 +856,12 @@ pub fn optimise_raw(
         source,
         registry,
         false,
-        tcl_lexer::LexerConfig::for_dialect(dialect.unwrap_or_default()),
+        tcl_lexer::LexerConfig::for_dialect(dialect.map_or("", |profile| profile.name)),
     );
     let object_types = crate::object_types::object_handle_classes(&cu, registry);
     let identities = crate::head_identity::command_head_identities_with_config(
         &cu.source,
-        tcl_lexer::LexerConfig::for_dialect(dialect.unwrap_or_default()),
+        tcl_lexer::LexerConfig::for_dialect(dialect.map_or("", |profile| profile.name)),
         registry,
     );
     let ia = build_interprocedural_analysis(
@@ -913,7 +927,7 @@ pub fn apply_optimisations(source: &str, optimisations: &[Optimisation]) -> Stri
 pub fn optimise_source_multipass_filtered<S: std::hash::BuildHasher>(
     source: &str,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     max_iterations: usize,
     disabled: &std::collections::HashSet<String, S>,
 ) -> (String, Vec<Optimisation>, usize) {
@@ -948,7 +962,7 @@ pub fn optimise_source_multipass_filtered<S: std::hash::BuildHasher>(
 pub fn optimise_source_multipass(
     source: &str,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     max_iterations: usize,
 ) -> (String, Vec<Optimisation>) {
     let mut current = source.to_owned();
@@ -993,7 +1007,11 @@ mod tests {
     #[test]
     fn cross_event_vars_reach_code_sinking_before_elimination() {
         let source = "when HTTP_REQUEST {\n    if {$cond} { set n 1 } else { set n 2 }\n    set flag $n\n    if {$n > 1} { log local0. $flag }\n}\nwhen HTTP_RESPONSE { log local0. $flag }\n";
-        let opts = optimise_with_dialect(source, &registry(), Some("f5-irules"));
+        let opts = optimise_with_dialect(
+            source,
+            &registry(),
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+        );
         assert!(
             opts.iter().all(|opt| {
                 opt.code != DiagCode::O125
@@ -1352,13 +1370,21 @@ mod tests {
     fn dialect_gated_passes_observe_active_dialect() {
         // irules-only O124 should fire when dialect = f5-irules.
         let src = "proc ::dead {} { return 1 }\nwhen HTTP_REQUEST { set x 0 }\n";
-        let opts = optimise_with_dialect(src, &registry(), Some("f5-irules"));
+        let opts = optimise_with_dialect(
+            src,
+            &registry(),
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+        );
         assert!(
             opts.iter().any(|o| o.code == DiagCode::O124),
             "expected O124 in irules dialect, got {opts:?}",
         );
         // And should NOT fire for plain tcl.
-        let tcl_opts = optimise_with_dialect(src, &registry(), Some("tcl"));
+        let tcl_opts = optimise_with_dialect(
+            src,
+            &registry(),
+            Some(tcl_dialect::DialectProfile::by_name("tcl")),
+        );
         assert!(
             tcl_opts.iter().all(|o| o.code != DiagCode::O124),
             "O124 should be gated on irules dialect, got {tcl_opts:?}",

--- a/rust/tcl-compiler/src/optimiser/mod.rs
+++ b/rust/tcl-compiler/src/optimiser/mod.rs
@@ -66,8 +66,8 @@ pub mod unused_procs;
 pub use elimination::DeadStore;
 pub use manager::{
     apply_optimisations, finalise_optimisations, find_dead_stores, optimise, optimise_by_pass,
-    optimise_raw, optimise_source_multipass, optimise_source_multipass_filtered, optimise_unit,
-    optimise_unit_raw, optimise_with_dialect,
+    optimise_raw, optimise_raw_for_profile, optimise_source_multipass,
+    optimise_source_multipass_filtered, optimise_unit, optimise_unit_raw, optimise_with_dialect,
 };
 
 use std::collections::{HashMap, HashSet};
@@ -228,7 +228,7 @@ pub struct PassContext<'a> {
     /// context is built so gated passes (e.g. O124) can check
     /// for `"f5-irules"` without threading it through every
     /// entry point.
-    pub dialect: Option<&'a str>,
+    pub dialect: Option<&'a tcl_dialect::DialectProfile>,
     /// Accumulator for produced optimisations.
     pub optimisations: Vec<Optimisation>,
     /// Accumulator for the **O109 dead stores** the elimination pass
@@ -296,7 +296,7 @@ impl<'a> PassContext<'a> {
     pub fn with_dialect(
         source: &'a str,
         interproc: InterproceduralAnalysis,
-        dialect: Option<&'a str>,
+        dialect: Option<&'a tcl_dialect::DialectProfile>,
     ) -> Self {
         Self {
             source,

--- a/rust/tcl-compiler/src/optimiser/pattern_recognition.rs
+++ b/rust/tcl-compiler/src/optimiser/pattern_recognition.rs
@@ -135,10 +135,12 @@ const SET_PACK_MIN_GROUP: usize = 3;
 fn detect_multi_set_packing(ctx: &mut PassContext<'_>, script: &Script) {
     // Tcl 9.0 prefers individual `set`s; 8.5 / 8.6 get `lassign`; older
     // (and dialect-unset) fall back to the universally-valid `foreach`.
-    if ctx.dialect == Some("tcl9.0") {
+    if ctx.dialect.is_some_and(|profile| profile.name == "tcl9.0") {
         return;
     }
-    let use_lassign = matches!(ctx.dialect, Some("tcl8.5" | "tcl8.6"));
+    let use_lassign = ctx
+        .dialect
+        .is_some_and(|profile| matches!(profile.name, "tcl8.5" | "tcl8.6"));
     let stmts = &script.statements;
 
     let mut i = 0;
@@ -589,7 +591,7 @@ mod tests {
         let mut ctx = super::super::PassContext::with_dialect(
             &cu.source,
             InterproceduralAnalysis::default(),
-            Some("tcl8.6"),
+            Some(tcl_dialect::DialectProfile::by_name("tcl8.6")),
         );
         run(&mut ctx, &cu);
         assert!(
@@ -607,7 +609,7 @@ mod tests {
         let mut ctx = super::super::PassContext::with_dialect(
             &cu.source,
             InterproceduralAnalysis::default(),
-            Some("tcl9.0"),
+            Some(tcl_dialect::DialectProfile::by_name("tcl9.0")),
         );
         run(&mut ctx, &cu);
         assert!(

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -2530,7 +2530,7 @@ fn fold_builtin_cmd_subst_raw(
     let lookup = |name: &str| constants.get(name).cloned();
     crate::const_subst::ConstSubstCtx {
         registry,
-        version: dialect.and_then(tcl_dialect::DialectProfile::runtime_version),
+        version: dialect.and_then(tcl_dialect::DialectProfile::const_fold_version),
         defining_class: oo.map(|f| f.defining_class.as_str()),
         trusts: &trusts,
         lookup_var: &lookup,
@@ -2555,7 +2555,7 @@ fn literal_words(
     let lookup = |name: &str| constants.get(name).cloned();
     crate::const_subst::ConstSubstCtx {
         registry,
-        version: dialect.and_then(tcl_dialect::DialectProfile::runtime_version),
+        version: dialect.and_then(tcl_dialect::DialectProfile::const_fold_version),
         defining_class: oo.map(|f| f.defining_class.as_str()),
         trusts: &trusts,
         lookup_var: &lookup,

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -160,7 +160,7 @@ pub fn run(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
 fn statement_may_have_untracked_effects(
     stmt: &Statement,
     registry: &tcl_registry::CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     traced: &std::collections::BTreeSet<String>,
     has_dynamic_trace: bool,
 ) -> bool {
@@ -478,7 +478,6 @@ fn report_load_forward(
 fn run_store_to_load_forwarding(ctx: &mut PassContext<'_>, fu: &FunctionUnit) {
     use crate::memory_ssa::compute_aliases;
     use std::collections::BTreeSet;
-    use tcl_dialect::DialectProfile;
 
     // Like O102, O127 moves a value across statements. A dynamic or opaque
     // variable name can change either the stored name or a name read by the
@@ -494,10 +493,7 @@ fn run_store_to_load_forwarding(ctx: &mut PassContext<'_>, fu: &FunctionUnit) {
     // Aliasing facts depend on the selected registry profile. Without an
     // explicit profile this optimisation cannot prove its alias safety gate,
     // so it abstains rather than interpreting every dialect at once.
-    let Some(dialect) = ctx
-        .dialect
-        .map(|name| DialectProfile::by_name(name).availability_mask)
-    else {
+    let Some(dialect) = ctx.dialect.map(|profile| profile.availability_mask) else {
         return;
     };
 
@@ -2079,7 +2075,8 @@ fn try_fold_return_terminator(
                 .strip_prefix('{')
                 .and_then(|b| b.strip_suffix('}'))
                 .unwrap_or(body);
-            let body_node = crate::expr_parser::parse_expr(body, ctx.dialect);
+            let body_node =
+                crate::expr_parser::parse_expr(body, ctx.dialect.map(|profile| profile.name));
             if !super::helpers::expr_simplify::expr_uses_shadowed_mathfunc(&body_node, procedures)
                 && let Some(folded) =
                     super::helpers::expr_simplify::try_fold_expr(body, ctx.dialect)
@@ -2185,7 +2182,7 @@ fn try_substitute_assign_expr(
     // the substituted expression is fully constant we can emit
     // the unwrapped ``set name VALUE`` form directly. Otherwise
     // keep the expression wrapper around the substituted text.
-    let parsed = parse_expr(&result.text, ctx.dialect);
+    let parsed = parse_expr(&result.text, ctx.dialect.map(|profile| profile.name));
     let env = Env::new();
     let octal = ctx.dialect.and_then(leading_zero_is_octal);
     if let Some(val) = eval_tcl_expr_with_octal_and_dialect(&parsed, &env, octal, ctx.dialect) {
@@ -2279,7 +2276,7 @@ fn try_o101_expr_arg_fold(
     // `::tcl::mathfunc::<name>` proc anywhere in the module means folding
     // it would use builtin semantics that no longer apply.
     if super::helpers::expr_simplify::expr_uses_shadowed_mathfunc(
-        &crate::expr_parser::parse_expr(body, ctx.dialect),
+        &crate::expr_parser::parse_expr(body, ctx.dialect.map(|profile| profile.name)),
         procedures,
     ) {
         return None;
@@ -2446,7 +2443,7 @@ fn try_o103_proc_fold(
             callee,
             &summary.params,
             &args,
-            crate::tcl_expr_eval::FoldPolicy::for_dialect(
+            crate::tcl_expr_eval::FoldPolicy::for_profile(
                 ctx.dialect
                     .and_then(crate::tcl_expr_eval::leading_zero_is_octal),
                 ctx.dialect,
@@ -2499,7 +2496,7 @@ fn try_o129_fold(
     mutations: &crate::command_binding::ModuleCommandMutations,
     constants: &std::collections::HashMap<String, String>,
     inner: &str,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     oo: Option<&OoFrame>,
 ) -> Option<String> {
     let folded = fold_builtin_cmd_subst_raw(registry, mutations, constants, inner, dialect, oo)?;
@@ -2526,14 +2523,14 @@ fn fold_builtin_cmd_subst_raw(
     mutations: &crate::command_binding::ModuleCommandMutations,
     constants: &std::collections::HashMap<String, String>,
     inner: &str,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     oo: Option<&OoFrame>,
 ) -> Option<String> {
     let trusts = |name: &str| mutations.trusts(name);
     let lookup = |name: &str| constants.get(name).cloned();
     crate::const_subst::ConstSubstCtx {
         registry,
-        dialect,
+        version: dialect.and_then(tcl_dialect::DialectProfile::runtime_version),
         defining_class: oo.map(|f| f.defining_class.as_str()),
         trusts: &trusts,
         lookup_var: &lookup,
@@ -2551,14 +2548,14 @@ fn literal_words(
     constants: &std::collections::HashMap<String, String>,
     registry: &tcl_registry::CommandRegistry,
     mutations: &crate::command_binding::ModuleCommandMutations,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     oo: Option<&OoFrame>,
 ) -> Option<Vec<String>> {
     let trusts = |name: &str| mutations.trusts(name);
     let lookup = |name: &str| constants.get(name).cloned();
     crate::const_subst::ConstSubstCtx {
         registry,
-        dialect,
+        version: dialect.and_then(tcl_dialect::DialectProfile::runtime_version),
         defining_class: oo.map(|f| f.defining_class.as_str()),
         trusts: &trusts,
         lookup_var: &lookup,
@@ -3169,10 +3166,14 @@ mod tests {
     /// threaded — needed for the O127 store-to-load-forwarding pass,
     /// which bails without a registry.
     fn o127(source: &str) -> Vec<Optimisation> {
-        crate::optimiser::optimise_raw(source, &registry(), Some("tcl8.6"))
-            .into_iter()
-            .filter(|o| o.code == DiagCode::O127)
-            .collect()
+        crate::optimiser::optimise_raw_for_profile(
+            source,
+            &registry(),
+            Some(tcl_dialect::DialectProfile::by_name("tcl8.6")),
+        )
+        .into_iter()
+        .filter(|o| o.code == DiagCode::O127)
+        .collect()
     }
 
     #[test]

--- a/rust/tcl-compiler/src/optimiser/tail_call.rs
+++ b/rust/tcl-compiler/src/optimiser/tail_call.rs
@@ -84,14 +84,14 @@ const LASSIGN_DIALECTS: &[&str] = &[
 /// Whether `tailcall` is available in `dialect`.  `None` (no dialect
 /// info on the context — only set by the public-API entry points
 /// that don't carry one) defaults to **enabled**.
-fn tailcall_supported(dialect: Option<&str>) -> bool {
-    dialect.is_none_or(|d| TAILCALL_DIALECTS.contains(&d))
+fn tailcall_supported(dialect: Option<&tcl_dialect::DialectProfile>) -> bool {
+    dialect.is_none_or(|profile| TAILCALL_DIALECTS.contains(&profile.name))
 }
 
 /// Whether `lassign` is available in `dialect`.  Same `None`-means-
 /// enabled fallback as [`tailcall_supported`].
-fn lassign_supported(dialect: Option<&str>) -> bool {
-    dialect.is_none_or(|d| LASSIGN_DIALECTS.contains(&d))
+fn lassign_supported(dialect: Option<&tcl_dialect::DialectProfile>) -> bool {
+    dialect.is_none_or(|profile| LASSIGN_DIALECTS.contains(&profile.name))
 }
 
 /// Run the tail-call detection pass. Emits `O121` for every
@@ -716,7 +716,7 @@ mod tests {
         let mut ctx = PassContext::with_dialect(
             &cu.source,
             InterproceduralAnalysis::default(),
-            Some(dialect),
+            Some(tcl_dialect::DialectProfile::by_name(dialect)),
         );
         ctx.registry = Some(&reg);
         run(&mut ctx, &cu);

--- a/rust/tcl-compiler/src/optimiser/unused_procs.rs
+++ b/rust/tcl-compiler/src/optimiser/unused_procs.rs
@@ -27,7 +27,7 @@
 //!
 //! The pass reports `O124` with a replacement that prefixes every
 //! non-empty body line with `# ` and prepends an explanatory
-//! banner. The code is gated on `ctx.dialect == Some("f5-irules")`.
+//! banner. The code is gated on `ctx.dialect == Some(tcl_dialect::DialectProfile::by_name("f5-irules"))`.
 //! If any reachable proc has a `has_barrier` flag (dynamic
 //! dispatch — `eval`, `uplevel`, etc.), the pass bails out to
 //! avoid false positives.
@@ -44,8 +44,8 @@ use super::{Optimisation, PassContext};
 
 /// Run the unused-procs pass.
 ///
-/// No-op unless [`PassContext::dialect`] is `Some("f5-irules")`
-/// or `Some("irules")` (the two names `active_dialect()`
+/// No-op unless [`PassContext::dialect`] is `Some(tcl_dialect::DialectProfile::by_name("f5-irules"))`
+/// or `Some(tcl_dialect::DialectProfile::by_name("irules"))` (the two names `active_dialect()`
 /// accepts interchangeably for iRules).
 pub fn run(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
     if !is_irules_dialect(ctx.dialect) {
@@ -256,9 +256,15 @@ mod tests {
 
     #[test]
     fn dialect_gate_rejects_non_irules() {
-        assert!(is_irules_dialect(Some("f5-irules")));
-        assert!(is_irules_dialect(Some("irules")));
-        assert!(!is_irules_dialect(Some("tcl")));
+        assert!(is_irules_dialect(Some(
+            tcl_dialect::DialectProfile::by_name("f5-irules")
+        )));
+        assert!(is_irules_dialect(Some(
+            tcl_dialect::DialectProfile::by_name("irules")
+        )));
+        assert!(!is_irules_dialect(Some(
+            tcl_dialect::DialectProfile::by_name("tcl")
+        )));
         assert!(!is_irules_dialect(None));
     }
 
@@ -266,7 +272,7 @@ mod tests {
 
     fn run_pass(
         source: &str,
-        dialect: Option<&str>,
+        dialect: Option<&tcl_dialect::DialectProfile>,
         ip: InterproceduralAnalysis,
     ) -> Vec<Optimisation> {
         // `when` (and any other dialect-gated structured command)
@@ -277,7 +283,9 @@ mod tests {
         // spellings load the iRules pack exactly as the optimiser passes
         // recognise both via `is_irules_dialect`.
         let registry = tcl_registry::cache::registry_for_profile(
-            tcl_dialect::DialectProfile::by_opt_name(dialect),
+            dialect.map_or(tcl_dialect::DialectProfile::plain_tcl(), |profile| {
+                tcl_dialect::DialectProfile::by_name(profile.name)
+            }),
         );
         let cu = CompilationUnit::build_for(source, registry, false);
         let mut ctx = PassContext::with_dialect(&cu.source, ip, dialect);
@@ -291,7 +299,14 @@ mod tests {
         // yields no O124 — gated.
         let source = "proc ::foo {} { set x 1 }\n";
         let ip = ip_with(&[("::foo", &[], false)]);
-        assert!(run_pass(source, Some("tcl"), ip.clone()).is_empty());
+        assert!(
+            run_pass(
+                source,
+                Some(tcl_dialect::DialectProfile::by_name("tcl")),
+                ip.clone()
+            )
+            .is_empty()
+        );
         assert!(run_pass(source, None, ip).is_empty());
     }
 
@@ -300,7 +315,11 @@ mod tests {
         // Only procs + RULE_INIT → library → skip.
         let source = "proc ::helper {} { set x 1 }\nwhen RULE_INIT { set static::y 0 }\n";
         let ip = ip_with(&[("::helper", &[], false), ("::when::RULE_INIT", &[], false)]);
-        let opts = run_pass(source, Some("f5-irules"), ip);
+        let opts = run_pass(
+            source,
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+            ip,
+        );
         assert!(
             opts.is_empty(),
             "library iRule should not emit O124: {opts:?}"
@@ -314,7 +333,11 @@ mod tests {
             ("::helper", &[], false),
             ("::when::HTTP_REQUEST", &["::helper"], false),
         ]);
-        let opts = run_pass(source, Some("f5-irules"), ip);
+        let opts = run_pass(
+            source,
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+            ip,
+        );
         assert!(
             opts.is_empty(),
             "reachable proc should not be flagged: {opts:?}"
@@ -331,7 +354,11 @@ mod tests {
             ("::b", &[], false),
             ("::when::HTTP_REQUEST", &["::a"], false),
         ]);
-        let opts = run_pass(source, Some("f5-irules"), ip);
+        let opts = run_pass(
+            source,
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+            ip,
+        );
         assert!(
             opts.is_empty(),
             "barrier in reachable proc should suppress all O124: {opts:?}",
@@ -348,7 +375,11 @@ mod tests {
             ("::dead", &[], false),
             ("::when::HTTP_REQUEST", &["::used"], false),
         ]);
-        let opts = run_pass(source, Some("f5-irules"), ip);
+        let opts = run_pass(
+            source,
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+            ip,
+        );
         assert_eq!(opts.len(), 1);
         let opt = &opts[0];
         assert_eq!(opt.code, DiagCode::O124);
@@ -367,7 +398,11 @@ mod tests {
             ("::dead", &[], false),
             ("::when::HTTP_REQUEST", &["::used"], false),
         ]);
-        let opts = run_pass(source, Some("irules"), ip);
+        let opts = run_pass(
+            source,
+            Some(tcl_dialect::DialectProfile::by_name("irules")),
+            ip,
+        );
         assert_eq!(opts.len(), 1);
     }
 
@@ -383,7 +418,11 @@ mod tests {
             ("::gamma", &[], false),
             ("::when::HTTP_REQUEST", &[], false),
         ]);
-        let opts = run_pass(source, Some("f5-irules"), ip);
+        let opts = run_pass(
+            source,
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+            ip,
+        );
         assert_eq!(opts.len(), 3);
         // Results are sorted by qualified name.
         let names: Vec<&str> = opts.iter().map(|o| o.message.as_str()).collect();
@@ -414,7 +453,11 @@ mod tests {
             "::when::HTTP_REQUEST".into(),
             summary_with_calls("::when::HTTP_REQUEST", &[], false),
         );
-        let opts = run_pass(source, Some("f5-irules"), ip);
+        let opts = run_pass(
+            source,
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+            ip,
+        );
         assert_eq!(opts.len(), 1);
     }
 }

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -286,8 +286,8 @@ pub struct BuiltinFoldInputs<'a> {
     pub registry: &'a CommandRegistry,
     /// Whole-module `rename` / `interp alias` / shadowing-`proc` trust scan.
     pub mutations: &'a crate::command_binding::ModuleCommandMutations,
-    /// Dialect name for versioned folds; `None` for plain Tcl.
-    pub dialect: Option<&'a str>,
+    /// Resolved dialect profile for versioned folds; `None` when unavailable.
+    pub dialect: Option<&'a tcl_dialect::DialectProfile>,
     /// Proven defining class of the enclosing `TclOO` instance-method frame
     /// (enables `[self class]`-style frame-fact folds); `None` elsewhere.
     pub defining_class: Option<&'a str>,
@@ -1686,7 +1686,9 @@ fn fold_assign_value<S1: std::hash::BuildHasher, S2: std::hash::BuildHasher>(
             let lookup = |name: &str| lattice_const_text(name, uses, values, ssa);
             if let Some(folded) = (crate::const_subst::ConstSubstCtx {
                 registry: f.registry,
-                dialect: f.dialect,
+                version: f
+                    .dialect
+                    .and_then(tcl_dialect::DialectProfile::runtime_version),
                 defining_class: f.defining_class,
                 trusts: &trusts,
                 lookup_var: &lookup,
@@ -2613,7 +2615,8 @@ mod tests {
             LatticeValue::Const(ConstValue::String("abcde".into())),
         );
 
-        let irules = FoldPolicy::for_dialect(Some(true), Some("f5-irules"));
+        let irules =
+            FoldPolicy::for_profile(Some(true), Some(tcl_dialect::DialectProfile::irules()));
         assert_eq!(
             evaluate_def(&stmt_ssa, &values, &ssa, irules),
             LatticeValue::Const(ConstValue::Int(1)),
@@ -3079,20 +3082,20 @@ mod tests {
         // decline when no release is selected, leaving the width ambiguous.
         let mut ssa = bare_ssa();
         let stmt = assign_value_stmt(&mut ssa, "n", "[string length \"\u{1D11E}\"]", 1);
-        let fold = |dialect| {
+        let fold = |dialect: Option<&tcl_dialect::DialectProfile>| {
             evaluate_def(
                 &stmt,
                 &HashMap::new(),
                 &ssa,
-                FoldPolicy::for_dialect(Some(false), dialect),
+                FoldPolicy::for_profile(Some(false), dialect),
             )
         };
         assert_eq!(
-            fold(Some("tcl9.0")),
+            fold(Some(tcl_dialect::DialectProfile::by_name("tcl9.0"))),
             LatticeValue::Const(ConstValue::Int(1))
         );
         assert_eq!(
-            fold(Some("tcl8.6")),
+            fold(Some(tcl_dialect::DialectProfile::by_name("tcl8.6"))),
             LatticeValue::Const(ConstValue::Int(2))
         );
         assert_eq!(
@@ -3110,7 +3113,7 @@ mod tests {
                 &ascii,
                 &HashMap::new(),
                 &ssa,
-                FoldPolicy::for_dialect(Some(false), None)
+                FoldPolicy::for_profile(Some(false), None)
             ),
             LatticeValue::Const(ConstValue::Int(5))
         );

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -1688,7 +1688,7 @@ fn fold_assign_value<S1: std::hash::BuildHasher, S2: std::hash::BuildHasher>(
                 registry: f.registry,
                 version: f
                     .dialect
-                    .and_then(tcl_dialect::DialectProfile::runtime_version),
+                    .and_then(tcl_dialect::DialectProfile::const_fold_version),
                 defining_class: f.defining_class,
                 trusts: &trusts,
                 lookup_var: &lookup,

--- a/rust/tcl-compiler/src/side_effects.rs
+++ b/rust/tcl-compiler/src/side_effects.rs
@@ -638,7 +638,7 @@ pub fn classify_side_effects(
     registry: &CommandRegistry,
     command: &str,
     args: &[String],
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     callee_summary: Option<&CalleeSummary>,
 ) -> CommandSideEffects {
     if let Some(summary) = callee_summary {
@@ -657,7 +657,7 @@ pub fn classify_side_effects(
         return CommandSideEffects {
             effects: vec![SideEffect::new(SideEffectTarget::Unknown, true, true)],
             dynamic_barrier: true,
-            dialect: dialect.map(str::to_owned),
+            dialect: dialect.map(|profile| profile.name.to_owned()),
             ..CommandSideEffects::default()
         };
     }
@@ -669,7 +669,7 @@ pub fn classify_side_effects(
         return CommandSideEffects {
             pure: true,
             deterministic: true,
-            dialect: dialect.map(str::to_owned),
+            dialect: dialect.map(|profile| profile.name.to_owned()),
             ..CommandSideEffects::default()
         };
     }
@@ -707,7 +707,7 @@ pub fn classify_side_effects(
                 effects,
                 pure: true,
                 deterministic: true,
-                dialect: dialect.map(str::to_owned),
+                dialect: dialect.map(|profile| profile.name.to_owned()),
                 ..CommandSideEffects::default()
             };
         }
@@ -729,7 +729,7 @@ pub fn classify_side_effects(
         return CommandSideEffects {
             pure: true,
             deterministic: true,
-            dialect: dialect.map(str::to_owned),
+            dialect: dialect.map(|profile| profile.name.to_owned()),
             ..CommandSideEffects::default()
         };
     }
@@ -749,7 +749,7 @@ pub fn classify_side_effects(
         }
         return CommandSideEffects {
             effects: vec![SideEffect::new(SideEffectTarget::Variable, true, true)],
-            dialect: dialect.map(str::to_owned),
+            dialect: dialect.map(|profile| profile.name.to_owned()),
             ..CommandSideEffects::default()
         };
     }
@@ -758,10 +758,10 @@ pub fn classify_side_effects(
     if spec.traits.contains(Traits::DEFINES_PROCEDURE) {
         let mut e = SideEffect::new(SideEffectTarget::ProcDefinition, false, true);
         e.scope = StorageScope::Namespace;
-        e.dialect = dialect.map(str::to_owned);
+        e.dialect = dialect.map(|profile| profile.name.to_owned());
         return CommandSideEffects {
             effects: vec![e],
-            dialect: dialect.map(str::to_owned),
+            dialect: dialect.map(|profile| profile.name.to_owned()),
             ..CommandSideEffects::default()
         };
     }
@@ -784,7 +784,7 @@ pub fn classify_side_effects(
                 e.namespace = ns;
                 e.key = Some(name.to_owned());
             }
-            e.dialect = dialect.map(str::to_owned);
+            e.dialect = dialect.map(|profile| profile.name.to_owned());
             e
         };
         // No named target (`unset`, `unset -nocomplain`, `unset --`) is a
@@ -800,7 +800,7 @@ pub fn classify_side_effects(
         };
         return CommandSideEffects {
             effects,
-            dialect: dialect.map(str::to_owned),
+            dialect: dialect.map(|profile| profile.name.to_owned()),
             ..CommandSideEffects::default()
         };
     }
@@ -814,7 +814,7 @@ pub fn classify_side_effects(
     if let Some(effects) = dialect_side_effect_hints(registry, command, effective_sub, dialect) {
         return CommandSideEffects {
             effects,
-            dialect: dialect.map(str::to_owned),
+            dialect: dialect.map(|profile| profile.name.to_owned()),
             ..CommandSideEffects::default()
         };
     }
@@ -827,7 +827,7 @@ pub fn classify_side_effects(
 /// [`CommandSideEffects`].
 fn classify_from_callee_summary(
     summary: &CalleeSummary,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> CommandSideEffects {
     let reads = summary.effect_reads;
     let writes = summary.effect_writes;
@@ -865,7 +865,7 @@ fn classify_from_callee_summary(
         pure: summary.pure,
         deterministic: summary.pure,
         dynamic_barrier: false,
-        dialect: dialect.map(str::to_owned),
+        dialect: dialect.map(|profile| profile.name.to_owned()),
     }
 }
 
@@ -883,7 +883,7 @@ fn classify_variable_assignment(
     args: &[String],
     idx: usize,
     traits: Traits,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> CommandSideEffects {
     let varname = &args[idx];
     let (scope, ns) = scope_from_varname(varname);
@@ -912,7 +912,7 @@ fn classify_variable_assignment(
     effect.scope = scope;
     effect.connection_side = side;
     effect.namespace = ns;
-    effect.dialect = dialect.map(str::to_owned);
+    effect.dialect = dialect.map(|profile| profile.name.to_owned());
     effect.key = Some(varname.clone());
 
     let mut effects = vec![effect];
@@ -926,18 +926,19 @@ fn classify_variable_assignment(
     // actually exists.
     if is_write {
         let base = crate::naming::normalise_var_name(varname);
-        if let Some(target) =
-            tcl_registry::special_vars::special_var_write_effect(base, dialect.unwrap_or(""))
-        {
+        if let Some(target) = tcl_registry::special_vars::special_var_write_effect(
+            base,
+            dialect.map_or("", |profile| profile.name),
+        ) {
             let mut extra = SideEffect::new(lift_registry_target(target), false, true);
-            extra.dialect = dialect.map(str::to_owned);
+            extra.dialect = dialect.map(|profile| profile.name.to_owned());
             effects.push(extra);
         }
     }
 
     CommandSideEffects {
         effects,
-        dialect: dialect.map(str::to_owned),
+        dialect: dialect.map(|profile| profile.name.to_owned()),
         ..CommandSideEffects::default()
     }
 }
@@ -1019,10 +1020,13 @@ fn lift_registry_side(s: RegistryConnectionSide) -> ConnectionSide {
 /// is supplied. The registry hint carries only
 /// `target`/`reads`/`writes`/`connection_side`; the remaining fields
 /// stay at their defaults.
-fn lift_registry_effect(e: RegistrySideEffect, dialect: Option<&str>) -> SideEffect {
+fn lift_registry_effect(
+    e: RegistrySideEffect,
+    dialect: Option<&tcl_dialect::DialectProfile>,
+) -> SideEffect {
     let mut effect = SideEffect::new(lift_registry_target(e.target), e.reads, e.writes);
     effect.connection_side = lift_registry_side(e.connection_side);
-    effect.dialect = dialect.map(str::to_owned);
+    effect.dialect = dialect.map(|profile| profile.name.to_owned());
     effect
 }
 
@@ -1032,20 +1036,17 @@ fn lift_registry_effect(e: RegistrySideEffect, dialect: Option<&str>) -> SideEff
 /// dialect string fails to parse to a known [`DialectSet`] (e.g. the
 /// bare `"tcl"` family alias) only universal (`dialects = None`) specs
 /// qualify — an unknown name intersects no explicit dialect set.
-fn spec_in_dialect(spec: &CommandSpec, filter: Option<&str>) -> bool {
+fn spec_in_dialect(spec: &CommandSpec, filter: Option<&tcl_dialect::DialectProfile>) -> bool {
     match filter {
         None => true,
         // Profile availability: composed mask + the iRules disable list
         // (§9 — a banned command's hints never fire under f5-irules). A
         // name with no catalog profile (`tk`) keeps the conservative
         // universal-spec-only rule.
-        Some(name) => match tcl_dialect::DialectProfile::find(name) {
-            Some(profile) => {
-                use tcl_registry::ProfileQueries;
-                profile.is_available(spec)
-            }
-            None => spec.dialects.is_none(),
-        },
+        Some(profile) => {
+            use tcl_registry::ProfileQueries;
+            profile.is_available(spec)
+        }
     }
 }
 
@@ -1061,16 +1062,10 @@ fn dialect_side_effect_hints(
     registry: &CommandRegistry,
     command: &str,
     subcommand: Option<&str>,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Option<Vec<SideEffect>> {
-    // lookup_dialect is "f5-irules" when dialect == "irules", else dialect.
-    let filter = match dialect {
-        Some("irules") => Some("f5-irules"),
-        other => other,
-    };
-
     for spec in registry.specs(command).iter().rev() {
-        if !spec_in_dialect(spec, filter) {
+        if !spec_in_dialect(spec, dialect) {
             continue;
         }
         if let Some(sub_name) = subcommand
@@ -1096,10 +1091,10 @@ fn dialect_side_effect_hints(
     None
 }
 
-fn fallback_unknown_write(dialect: Option<&str>) -> CommandSideEffects {
+fn fallback_unknown_write(dialect: Option<&tcl_dialect::DialectProfile>) -> CommandSideEffects {
     CommandSideEffects {
         effects: vec![SideEffect::new(SideEffectTarget::Unknown, true, true)],
-        dialect: dialect.map(str::to_owned),
+        dialect: dialect.map(|profile| profile.name.to_owned()),
         ..CommandSideEffects::default()
     }
 }
@@ -1472,7 +1467,7 @@ mod tests {
             &registry,
             "set",
             &["static::counter".into(), "0".into()],
-            Some("irules"),
+            Some(tcl_dialect::DialectProfile::by_name("irules")),
             None,
         );
         let eff = &cse.effects[0];
@@ -1487,7 +1482,7 @@ mod tests {
             &registry,
             "set",
             &["local".into(), "0".into()],
-            Some("irules"),
+            Some(tcl_dialect::DialectProfile::by_name("irules")),
             None,
         );
         let eff = &cse.effects[0];
@@ -1562,7 +1557,7 @@ mod tests {
             &registry,
             "HTTP::header",
             &["value".into(), "Host".into()],
-            Some("f5-irules"),
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
             None,
         );
         assert!(getter.pure, "HTTP::header getter should stay pure");
@@ -1576,7 +1571,7 @@ mod tests {
             &registry,
             "HTTP::header",
             &["insert".into(), "X-Foo".into(), "y".into()],
-            Some("f5-irules"),
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
             None,
         );
         assert!(
@@ -1608,7 +1603,13 @@ mod tests {
             (EffectRegion::NONE, EffectRegion::NONE)
         );
         // Under a Tcl dialect the irules spec is gated out → UNKNOWN write.
-        let tcl = classify_side_effects(&registry, "log", &["hi".into()], Some("tcl8.6"), None);
+        let tcl = classify_side_effects(
+            &registry,
+            "log",
+            &["hi".into()],
+            Some(tcl_dialect::DialectProfile::by_name("tcl8.6")),
+            None,
+        );
         assert!(!tcl.pure);
         assert_eq!(tcl.effects[0].target, SideEffectTarget::Unknown);
         assert_eq!(

--- a/rust/tcl-compiler/src/taint.rs
+++ b/rust/tcl-compiler/src/taint.rs
@@ -372,7 +372,7 @@ fn source_colour(
     registry: &CommandRegistry,
     command: &str,
     args: &[&str],
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Option<TaintLattice> {
     let dialect_set = dialect_to_set(dialect);
     tcl_registry::taint::taint_source_colour(registry, command, args, dialect_set).map(|c| {
@@ -481,20 +481,18 @@ fn double_encode_label(colour: TaintColour) -> &'static str {
 /// Exposed so adjacent check modules (`compiler_checks`, `irules_checks`)
 /// can gate their iRules-only diagnostics on the same predicate.
 #[must_use]
-pub fn is_irules_dialect(dialect: Option<&str>) -> bool {
-    tcl_dialect::DialectProfile::by_opt_name(dialect).is_irules()
+pub fn is_irules_dialect(dialect: Option<&tcl_dialect::DialectProfile>) -> bool {
+    dialect.is_some_and(tcl_dialect::DialectProfile::is_irules)
 }
 
-fn dialect_to_set(dialect: Option<&str>) -> DialectSet {
+fn dialect_to_set(dialect: Option<&tcl_dialect::DialectProfile>) -> DialectSet {
     // The profile's availability mask: bare IRULES for iRules (aliases
     // canonicalise), the composed (version|vendor) mask for the additive
     // vendor shells — so version-gated taint/side-effect hints reach a
     // vendor dialect's embedded Tcl core. An unknown / unset dialect stays
     // EMPTY (not the permissive fallback): taint hints gated to a specific
     // dialect must not fire when the dialect is unknown.
-    dialect
-        .and_then(tcl_dialect::DialectProfile::find)
-        .map_or(DialectSet::empty(), |p| p.availability_mask)
+    dialect.map_or(DialectSet::empty(), |profile| profile.availability_mask)
 }
 
 fn is_sanitiser(registry: &CommandRegistry, command: &str, args: &[&str]) -> bool {
@@ -522,7 +520,7 @@ pub(crate) struct TaintCtx<'a> {
     pub(crate) interproc: Option<&'a InterproceduralAnalysis>,
     pub(crate) known_procs: Option<&'a HashSet<String>>,
     pub(crate) caller_qname: Option<&'a str>,
-    pub(crate) dialect: Option<&'a str>,
+    pub(crate) dialect: Option<&'a tcl_dialect::DialectProfile>,
     /// Colour-aware return summaries from the interprocedural taint
     /// solve (`taint_interproc::solve_interprocedural_taints`). When
     /// present, calls to a known proc apply the full
@@ -1230,7 +1228,7 @@ pub(crate) fn propagate_taints(
     registry: &CommandRegistry,
     rendered_props: Option<&HashMap<ValueKey, RenderedValueProps>>,
     interproc: Option<&InterproceduralAnalysis>,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     param_taints: Option<&HashMap<String, TaintLattice>>,
     taint_summaries: Option<&HashMap<String, crate::taint_interproc::ProcTaintSummary>>,
 ) -> HashMap<ValueKey, TaintLattice> {
@@ -1290,7 +1288,7 @@ fn seed_entry_taints(
     cfg: &CfgFunction,
     interproc: Option<&InterproceduralAnalysis>,
     param_taints: Option<&HashMap<String, TaintLattice>>,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) {
     // Seed entry taints for tainted parameters (interprocedural solve).
     // Only tainted params seed a slot; clean params leave the version-0
@@ -1336,7 +1334,9 @@ fn seed_entry_taints(
     // local `set env …` writes a higher SSA version, so a read that resolves
     // to the local (version > 0) is unaffected; shadowing falls out of the SSA
     // versioning, not a check here.
-    for spec in tcl_registry::special_vars::special_vars_for_dialect(dialect.unwrap_or("")) {
+    for spec in tcl_registry::special_vars::special_vars_for_dialect(
+        dialect.map_or("", |profile| profile.name),
+    ) {
         let Some(colour) = spec.read_taint else {
             continue;
         };
@@ -1499,7 +1499,7 @@ fn classify_sink(
     registry: &CommandRegistry,
     command: &str,
     args: &[String],
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Option<(DiagCode, String)> {
     // A call whose own option flags disable this command's hazard for
     // *this* invocation (e.g. `subst -nocommands $tainted`) is not a sink
@@ -2195,7 +2195,7 @@ pub fn apply_module_variable_traces(
 pub fn find_taint_warnings_for_cu(
     cu: &crate::compilation_unit::CompilationUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Vec<TaintWarning> {
     let mut out = Vec::new();
     let solved = crate::taint_interproc::solve_interprocedural_taints(cu, registry, dialect);
@@ -2325,7 +2325,7 @@ pub fn find_taint_warnings<
     taints: &HashMap<ValueKey, TaintLattice, S>,
     executable_blocks: &HashSet<BlockId, E>,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     shadowed_builtins: &HashSet<String, H>,
 ) -> Vec<TaintWarning> {
     let mut warnings: Vec<TaintWarning> = Vec::new();
@@ -2373,7 +2373,7 @@ fn emit_statement_warnings<S: std::hash::BuildHasher, H: std::hash::BuildHasher>
     ssa_stmt: &SsaStatement,
     taints: &HashMap<ValueKey, TaintLattice, S>,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     shadowed_builtins: &HashSet<String, H>,
     warnings: &mut Vec<TaintWarning>,
     ssa: &SsaFunction,
@@ -2775,7 +2775,7 @@ struct BranchTaintCtx<'a, S> {
     ssa: &'a SsaFunction,
     taints: &'a HashMap<ValueKey, TaintLattice, S>,
     registry: &'a CommandRegistry,
-    dialect: Option<&'a str>,
+    dialect: Option<&'a tcl_dialect::DialectProfile>,
 }
 
 /// Emit taint warnings for a block's `if`/`while`/`for` branch condition:
@@ -3419,7 +3419,7 @@ fn emit_option_injection<S: std::hash::BuildHasher>(
     sink_call: &SinkCall<'_>,
     env: &TaintScan<'_, S>,
     span: Span,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     warnings: &mut Vec<TaintWarning>,
     stmt: &Statement,
 ) {
@@ -3556,7 +3556,7 @@ pub fn find_setter_constraint_warnings<S: std::hash::BuildHasher, E: std::hash::
     ssa: &SsaFunction,
     taints: &HashMap<ValueKey, TaintLattice, S>,
     executable_blocks: &HashSet<BlockId, E>,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Vec<TaintWarning> {
     let mut out: Vec<TaintWarning> = Vec::new();
     if !is_irules_dialect(dialect) {
@@ -4219,7 +4219,7 @@ mod tests {
             &taints,
             &sccp.executable_blocks,
             &registry,
-            Some("f5-irules"),
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
             &HashSet::new(),
         );
         let t106 = warnings
@@ -4705,7 +4705,10 @@ mod tests {
         // analyser taints `u` here; only the separate W002
         // "disabled command" check is dialect-gated.) The getter form
         // carries the path-prefixed, option-injection-safe colours.
-        for dialect in [None, Some("f5-irules")] {
+        for dialect in [
+            None,
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+        ] {
             let cu = CompilationUnit::build_for("set u [HTTP::uri]", &registry, false)
                 .with_interprocedural(&registry, dialect);
             let fu = cu.function("::top").unwrap();
@@ -4811,8 +4814,10 @@ mod tests {
         // prefix-aware sink classification.
         let mut registry = CommandRegistry::build_default();
         registry.load_dialect(DialectSet::IRULES);
-        let cu = CompilationUnit::build_for(source, &registry, false)
-            .with_interprocedural(&registry, Some("f5-irules"));
+        let cu = CompilationUnit::build_for(source, &registry, false).with_interprocedural(
+            &registry,
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+        );
         let mut out: Vec<TaintWarning> = Vec::new();
         for fu in cu.analysable_functions() {
             out.extend(find_taint_warnings(
@@ -4821,7 +4826,7 @@ mod tests {
                 &fu.taints,
                 &fu.sccp.executable_blocks,
                 &registry,
-                Some("f5-irules"),
+                Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
                 &HashSet::new(),
             ));
         }
@@ -4913,7 +4918,12 @@ mod tests {
     #[test]
     fn classify_irules_sink_http_respond() {
         let reg = tcl_registry::registry_for_dialect("f5-irules");
-        let hit = classify_sink(reg, "HTTP::respond", &[], Some("f5-irules"));
+        let hit = classify_sink(
+            reg,
+            "HTTP::respond",
+            &[],
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+        );
         assert_eq!(hit.as_ref().map(|(c, _)| *c), Some(DiagCode::Irule3001));
     }
 
@@ -4924,7 +4934,7 @@ mod tests {
             reg,
             "HTTP::header",
             &["insert".to_owned(), "X-Foo".to_owned(), "bar".to_owned()],
-            Some("f5-irules"),
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
         );
         assert_eq!(hit.as_ref().map(|(c, _)| *c), Some(DiagCode::Irule3002));
         assert_eq!(hit.as_ref().unwrap().1, "HTTP::header insert");
@@ -4937,7 +4947,7 @@ mod tests {
             reg,
             "HTTP::cookie",
             &["replace".to_owned(), "sid".to_owned(), "val".to_owned()],
-            Some("f5-irules"),
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
         );
         assert_eq!(hit.as_ref().map(|(c, _)| *c), Some(DiagCode::Irule3002));
         assert_eq!(hit.as_ref().unwrap().1, "HTTP::cookie replace");
@@ -4952,7 +4962,7 @@ mod tests {
             reg,
             "HTTP::cookie",
             &["ins".to_owned(), "sid".to_owned(), "val".to_owned()],
-            Some("f5-irules"),
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
         );
         assert_eq!(hit.as_ref().map(|(c, _)| *c), Some(DiagCode::Irule3002));
         // The label reports the canonical subcommand name.
@@ -4966,7 +4976,7 @@ mod tests {
             reg,
             "HTTP::header",
             &["remove".to_owned(), "X-Foo".to_owned()],
-            Some("f5-irules"),
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
         );
         assert!(hit.is_none(), "remove subcommand must not emit IRULE3002");
     }
@@ -4979,7 +4989,7 @@ mod tests {
                 reg,
                 "log",
                 &["local0.info".to_owned(), "x".to_owned()],
-                Some("f5-irules")
+                Some(tcl_dialect::DialectProfile::by_name("f5-irules"))
             )
             .as_ref()
             .map(|(c, _)| *c),
@@ -4990,7 +5000,7 @@ mod tests {
                 reg,
                 "HTTP::redirect",
                 &["https://evil".to_owned()],
-                Some("f5-irules")
+                Some(tcl_dialect::DialectProfile::by_name("f5-irules"))
             )
             .as_ref()
             .map(|(c, _)| *c),
@@ -5035,7 +5045,12 @@ mod tests {
         // the dialect where flagging it matters most.
         let mut registry = CommandRegistry::build_default();
         registry.load_irules();
-        let hit = classify_sink(&registry, "exec", &["$cmd".to_owned()], Some("f5-irules"));
+        let hit = classify_sink(
+            &registry,
+            "exec",
+            &["$cmd".to_owned()],
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+        );
         assert_eq!(hit.as_ref().map(|(c, _)| *c), Some(DiagCode::T100));
     }
 
@@ -5144,7 +5159,7 @@ mod tests {
             &fu.taints,
             &fu.sccp.executable_blocks,
             &registry,
-            Some("tcl8.6"),
+            Some(tcl_dialect::DialectProfile::by_name("tcl8.6")),
             &HashSet::new(),
         );
         let t102 = warnings.iter().find(|w| w.code == DiagCode::T102);
@@ -5187,7 +5202,7 @@ mod tests {
             &fu.taints,
             &fu.sccp.executable_blocks,
             &registry,
-            Some("tcl8.6"),
+            Some(tcl_dialect::DialectProfile::by_name("tcl8.6")),
             &HashSet::new(),
         );
         assert!(
@@ -5217,7 +5232,7 @@ mod tests {
             &fu.taints,
             &fu.sccp.executable_blocks,
             &registry,
-            Some("tcl8.6"),
+            Some(tcl_dialect::DialectProfile::by_name("tcl8.6")),
             &HashSet::new(),
         );
         assert!(
@@ -5245,7 +5260,7 @@ mod tests {
             &fu.taints,
             &fu.sccp.executable_blocks,
             &registry,
-            Some("tcl8.6"),
+            Some(tcl_dialect::DialectProfile::by_name("tcl8.6")),
             &HashSet::new(),
         );
         let t102 = warnings
@@ -5277,7 +5292,7 @@ mod tests {
             &fu.taints,
             &fu.sccp.executable_blocks,
             &registry,
-            Some("tcl8.6"),
+            Some(tcl_dialect::DialectProfile::by_name("tcl8.6")),
             &HashSet::new(),
         );
         let t102 = warnings
@@ -5307,7 +5322,7 @@ mod tests {
             &fu.taints,
             &fu.sccp.executable_blocks,
             &registry,
-            Some("tcl8.6"),
+            Some(tcl_dialect::DialectProfile::by_name("tcl8.6")),
             &HashSet::new(),
         );
         let t102 = warnings
@@ -5353,7 +5368,7 @@ mod tests {
             &fu.taints,
             &fu.sccp.executable_blocks,
             &registry,
-            Some("tcl8.6"),
+            Some(tcl_dialect::DialectProfile::by_name("tcl8.6")),
             &HashSet::new(),
         );
         let t102 = warnings
@@ -5398,7 +5413,7 @@ mod tests {
             &fu.taints,
             &fu.sccp.executable_blocks,
             &registry,
-            Some("tcl8.6"),
+            Some(tcl_dialect::DialectProfile::by_name("tcl8.6")),
             &HashSet::new(),
         );
         assert!(
@@ -5413,7 +5428,7 @@ mod tests {
     fn irule_sinks_do_not_fire_without_dialect() {
         use crate::compilation_unit::CompilationUnit;
         let registry = CommandRegistry::build_default();
-        // Without `with_interprocedural(Some("f5-irules"))`, no dialect
+        // Without `with_interprocedural(Some(tcl_dialect::DialectProfile::by_name("f5-irules")))`, no dialect
         // is active, and HTTP commands aren't sinks.
         let cu = CompilationUnit::build_for(
             "set u [HTTP::uri]\nHTTP::respond 200 content $u",
@@ -5511,10 +5526,16 @@ mod tests {
     /// Default helper: run the setter check under the `f5-irules` dialect
     /// (which is the only dialect that can surface IRULE3101 post-internal-gate).
     fn setter_warnings_for(source: &str) -> Vec<TaintWarning> {
-        setter_warnings_for_dialect(source, Some("f5-irules"))
+        setter_warnings_for_dialect(
+            source,
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+        )
     }
 
-    fn setter_warnings_for_dialect(source: &str, dialect: Option<&str>) -> Vec<TaintWarning> {
+    fn setter_warnings_for_dialect(
+        source: &str,
+        dialect: Option<&tcl_dialect::DialectProfile>,
+    ) -> Vec<TaintWarning> {
         use crate::compilation_unit::CompilationUnit;
         let mut registry = CommandRegistry::build_default();
         // The IRULE3101 setter constraints live on the iRules specs, so the
@@ -5606,7 +5627,10 @@ mod tests {
         // `run_all_checks`), IRULE3101 must not fire under a non-iRules
         // dialect against user-defined commands named `HTTP::uri` /
         // `HTTP::path`.
-        let under_irules = setter_warnings_for_dialect("HTTP::uri foo", Some("f5-irules"));
+        let under_irules = setter_warnings_for_dialect(
+            "HTTP::uri foo",
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+        );
         assert_eq!(under_irules.len(), 1);
         assert_eq!(under_irules[0].code, DiagCode::Irule3101);
 
@@ -5616,7 +5640,10 @@ mod tests {
             "no IRULE3101 under None dialect, got {under_none:?}"
         );
 
-        let under_tcl = setter_warnings_for_dialect("HTTP::uri foo", Some("tcl"));
+        let under_tcl = setter_warnings_for_dialect(
+            "HTTP::uri foo",
+            Some(tcl_dialect::DialectProfile::by_name("tcl")),
+        );
         assert!(
             under_tcl.is_empty(),
             "no IRULE3101 under tcl dialect, got {under_tcl:?}"
@@ -5703,7 +5730,10 @@ mod tests {
     fn arch3_setter_constraint_is_dialect_driven() {
         // `HTTP::uri foo` (no leading slash) under iRules produces
         // an IRULE3101 setter-constraint violation.
-        let irules = setter_warnings_for_dialect("HTTP::uri foo", Some("f5-irules"));
+        let irules = setter_warnings_for_dialect(
+            "HTTP::uri foo",
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+        );
         assert!(
             irules.iter().any(|w| w.code == DiagCode::Irule3101),
             "expected IRULE3101 under iRules dialect, got {irules:?}",

--- a/rust/tcl-compiler/src/taint_interproc.rs
+++ b/rust/tcl-compiler/src/taint_interproc.rs
@@ -334,7 +334,7 @@ fn run_propagation(
     fu: &FunctionUnit,
     registry: &CommandRegistry,
     interproc: Option<&crate::interprocedural::InterproceduralAnalysis>,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     param_taints: Option<&HashMap<String, TaintLattice>>,
     summaries: &HashMap<String, ProcTaintSummary>,
 ) -> HashMap<ValueKey, TaintLattice> {
@@ -354,7 +354,7 @@ fn return_ctx<'a>(
     fu: &'a FunctionUnit,
     registry: &'a CommandRegistry,
     interproc: Option<&'a crate::interprocedural::InterproceduralAnalysis>,
-    dialect: Option<&'a str>,
+    dialect: Option<&'a tcl_dialect::DialectProfile>,
     known: &'a HashSet<String>,
     summaries: &'a HashMap<String, ProcTaintSummary>,
 ) -> TaintCtx<'a> {
@@ -436,7 +436,7 @@ pub fn infer_proc_summary(
     fu: &FunctionUnit,
     registry: &CommandRegistry,
     interproc: Option<&crate::interprocedural::InterproceduralAnalysis>,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     known: &HashSet<String>,
     summaries: &HashMap<String, ProcTaintSummary>,
 ) -> ProcTaintSummary {
@@ -503,7 +503,7 @@ fn resolve_call_flows(
     taints: &HashMap<ValueKey, TaintLattice>,
     registry: &CommandRegistry,
     interproc: Option<&crate::interprocedural::InterproceduralAnalysis>,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     known: &HashSet<String>,
     summaries: &HashMap<String, ProcTaintSummary>,
 ) -> Vec<(String, Vec<TaintLattice>)> {
@@ -789,7 +789,7 @@ pub fn converge_summaries_with(
     cu: &CompilationUnit,
     registry: &CommandRegistry,
     interproc: Option<&crate::interprocedural::InterproceduralAnalysis>,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     infer_fn: &mut InferProcSummaryFn<'_>,
 ) -> HashMap<String, ProcTaintSummary> {
     let mut proc_names: Vec<&String> = cu.ir_module.procedures.keys().collect();
@@ -938,7 +938,7 @@ pub fn converge_summaries_with(
 pub fn solve_interprocedural_taints(
     cu: &CompilationUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> InterprocTaintResult {
     let interproc = cu.interproc.as_ref();
     solve_interprocedural_taints_with(
@@ -964,7 +964,7 @@ pub fn solve_interprocedural_taints(
 pub fn solve_interprocedural_taints_with(
     cu: &CompilationUnit,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     infer_fn: &mut InferProcSummaryFn<'_>,
 ) -> InterprocTaintResult {
     let interproc = cu.interproc.as_ref();

--- a/rust/tcl-compiler/src/tcl_expr_eval.rs
+++ b/rust/tcl-compiler/src/tcl_expr_eval.rs
@@ -160,7 +160,7 @@ pub fn eval_tcl_expr_in_dialect(node: &ExprNode, env: &Env, dialect: &str) -> Op
     eval_with_config(
         node,
         env,
-        leading_zero_is_octal(dialect),
+        leading_zero_is_octal(tcl_dialect::DialectProfile::by_name(dialect)),
         math_func_ceiling_for_dialect(dialect),
         tcl_dialect::DialectProfile::by_name(dialect).is_irules(),
     )
@@ -188,10 +188,9 @@ pub fn eval_tcl_expr_with_octal(
 }
 
 /// Like [`eval_tcl_expr_with_octal`] but for the (more common) optimiser call
-/// sites that already have both an `octal` policy *and* the dialect string
-/// itself locally in scope (`PassContext::dialect` / a `dialect: Option<&str>`
-/// parameter) — so, unlike `eval_tcl_expr_with_octal`'s plain `None`-dialect
-/// callers, these can resolve [`FoldOps::is_irules`] precisely instead of
+/// sites that already have both an `octal` policy and a resolved dialect
+/// profile in scope — so, unlike `eval_tcl_expr_with_octal`'s plain
+/// `None`-profile callers, these can resolve [`FoldOps::is_irules`] precisely instead of
 /// defaulting it to declined (issue #983/#985 residual: several of these
 /// sites were passing the string on to `leading_zero_is_octal` for the octal
 /// policy while never using it to gate the iRules word-operator fold).
@@ -200,9 +199,9 @@ pub fn eval_tcl_expr_with_octal_and_dialect(
     node: &ExprNode,
     env: &Env,
     octal: Option<bool>,
-    dialect: Option<&str>,
+    profile: Option<&tcl_dialect::DialectProfile>,
 ) -> Option<TclValue> {
-    eval_tcl_expr_with_policy(node, env, FoldPolicy::for_dialect(octal, dialect))
+    eval_tcl_expr_with_policy(node, env, FoldPolicy::for_profile(octal, profile))
 }
 
 /// The dialect-derived facts a constant fold needs: the leading-zero octal
@@ -254,16 +253,16 @@ impl FoldPolicy {
         }
     }
 
-    /// The policy for an octal rule plus the dialect string a pass already
-    /// holds (`PassContext::dialect`, a `dialect: Option<&str>` parameter).
+    /// The policy for an octal rule plus a resolved profile. Name parsing and
+    /// alias handling happen before this point, so every fact comes from one
+    /// canonical profile.
     #[must_use]
-    pub fn for_dialect(octal: Option<bool>, dialect: Option<&str>) -> Self {
+    pub fn for_profile(octal: Option<bool>, profile: Option<&tcl_dialect::DialectProfile>) -> Self {
         Self {
             octal,
-            is_irules: dialect.is_some_and(|d| tcl_dialect::DialectProfile::by_name(d).is_irules()),
-            characters: dialect
-                .and_then(|d| tcl_dialect::DialectProfile::by_name(d).character_model()),
-            numbers: dialect.map(|d| NumberSyntax::of_dialect_name(Some(d))),
+            is_irules: profile.is_some_and(tcl_dialect::DialectProfile::is_irules),
+            characters: profile.and_then(tcl_dialect::DialectProfile::character_model),
+            numbers: profile.map(|p| NumberSyntax::of_profile(Some(p))),
         }
     }
 
@@ -326,10 +325,8 @@ pub fn parse_integer_operand_with_policy(text: &str, policy: FoldPolicy) -> Opti
 /// (`f5-bigip`) or an unknown dialect string (the permissive fallback,
 /// design doc §11.1).
 #[must_use]
-pub fn leading_zero_is_octal(dialect: &str) -> Option<bool> {
-    tcl_dialect::DialectProfile::by_name(dialect)
-        .leading_zero_is_octal
-        .as_bool()
+pub fn leading_zero_is_octal(profile: &tcl_dialect::DialectProfile) -> Option<bool> {
+    profile.leading_zero_is_octal.as_bool()
 }
 
 /// The newest `expr` math-function release available in `dialect`, or `None`
@@ -1644,16 +1641,30 @@ mod tests {
             "f5-tmsh",
             "expect",
         ] {
-            assert_eq!(leading_zero_is_octal(d), Some(true), "{d}");
+            assert_eq!(
+                leading_zero_is_octal(tcl_dialect::DialectProfile::by_name(d)),
+                Some(true),
+                "{d}"
+            );
         }
         // 9.x runtimes dropped the rule (TIP 114/472) — bpf embeds Tcl 9.0
         // (D7), so `010` is not octal there either.
         for d in ["tcl9.0", "tcl9.1", "bpf"] {
-            assert_eq!(leading_zero_is_octal(d), Some(false), "{d}");
+            assert_eq!(
+                leading_zero_is_octal(tcl_dialect::DialectProfile::by_name(d)),
+                Some(false),
+                "{d}"
+            );
         }
         // No Tcl runtime / unknown dialect: abstain, never guess (§11.1).
-        assert_eq!(leading_zero_is_octal("f5-bigip"), None);
-        assert_eq!(leading_zero_is_octal("no-such-dialect"), None);
+        assert_eq!(
+            leading_zero_is_octal(tcl_dialect::DialectProfile::by_name("f5-bigip")),
+            None
+        );
+        assert_eq!(
+            leading_zero_is_octal(tcl_dialect::DialectProfile::by_name("no-such-dialect")),
+            None
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/type_infer.rs
+++ b/rust/tcl-compiler/src/type_infer.rs
@@ -2321,8 +2321,8 @@ mod tests {
     /// As [`infer_str`] but parses under `dialect` (the iRules string
     /// predicates only tokenise as operators in the iRules dialect) and reads
     /// numerals under that dialect's grammar.
-    fn infer_str_dialect(src: &str, dialect: Option<&str>) -> TypeLattice {
-        let node = crate::parse_expr(src, dialect);
+    fn infer_str_dialect(src: &str, dialect: Option<&tcl_dialect::DialectProfile>) -> TypeLattice {
+        let node = crate::parse_expr(src, dialect.map(|profile| profile.name));
         infer_expr_type(
             &node,
             &HashMap::new(),
@@ -2434,7 +2434,7 @@ mod tests {
             "$s matches_glob \"x*\"",
             "$s matches_regex \"x.\"",
         ] {
-            let t = infer_str_dialect(src, Some("f5-irules"));
+            let t = infer_str_dialect(src, Some(tcl_dialect::DialectProfile::by_name("f5-irules")));
             assert_eq!(
                 t.tcl_type(),
                 Some(TclType::Boolean),

--- a/rust/tcl-compiler/src/uri_split.rs
+++ b/rust/tcl-compiler/src/uri_split.rs
@@ -1002,7 +1002,7 @@ pub fn find_uri_split_suggestions<S, B>(
     sccp_values: Option<&HashMap<ValueKey, LatticeValue, S>>,
     executable_blocks: &HashSet<BlockId, B>,
     registry: &CommandRegistry,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Vec<TaintWarning>
 where
     S: std::hash::BuildHasher,
@@ -1078,7 +1078,10 @@ mod tests {
 
     /// Run the IRULE3103 pass over `source` under the iRules dialect.
     fn warnings_for(source: &str) -> Vec<TaintWarning> {
-        warnings_for_dialect(source, Some("f5-irules"))
+        warnings_for_dialect(
+            source,
+            Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+        )
     }
 
     /// Regression coverage for issue #996: `walk_expr` recurses once per
@@ -1120,7 +1123,10 @@ mod tests {
         walk_expr(&node, &uses, ctx, &mut hits, 0);
     }
 
-    fn warnings_for_dialect(source: &str, dialect: Option<&str>) -> Vec<TaintWarning> {
+    fn warnings_for_dialect(
+        source: &str,
+        dialect: Option<&tcl_dialect::DialectProfile>,
+    ) -> Vec<TaintWarning> {
         let r = registry();
         let cu = CompilationUnit::build_for(source, &r, false);
         let mut out: Vec<TaintWarning> = Vec::new();
@@ -1296,7 +1302,7 @@ set parts [split [HTTP::uri /path] "?"]"#,
         let ws = warnings_for_dialect(
             r#"set x "foo"
 set parts [split $x "?"]"#,
-            Some("tcl"),
+            Some(tcl_dialect::DialectProfile::by_name("tcl")),
         );
         assert!(ws.is_empty());
     }

--- a/rust/tcl-compiler/tests/alias_scoping.rs
+++ b/rust/tcl-compiler/tests/alias_scoping.rs
@@ -139,7 +139,7 @@ fn codes(src: &str) -> Vec<String> {
         .collect();
     let registry = registry();
     let cu = CompilationUnit::build_for(src, registry, false);
-    for d in run_all_checks(&cu, registry, Some(D)) {
+    for d in run_all_checks(&cu, registry, Some(tcl_dialect::DialectProfile::by_name(D))) {
         if d.code.is_optimisation() {
             continue;
         }

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -7254,6 +7254,28 @@ mod const_cmd_subst_set_rhs {
     }
 
     #[test]
+    fn a_vendor_profile_abstains_from_version_sensitive_const_substitution() {
+        // FP guard: iRules has a real Tcl runtime version, but its profile's
+        // const-fold projection is deliberately unknown until versioned
+        // folds are verified for that shell.  The version-sensitive
+        // `format %d 010` therefore must stay unresolved rather than being
+        // folded as Tcl 8.4/9.0 semantics.
+        let src = concat!(
+            "namespace eval tc { proc setdef {a b} { return 1 } }\n",
+            "proc user {} {\n",
+            "    set value [format %d 010]\n",
+            "    ${value}::setdef x y\n",
+            "}\n",
+        );
+        let r = analysis(src, "f5-irules");
+        assert_eq!(
+            resolutions_of(&r, "${value}"),
+            ["::${value}::setdef"],
+            "a version-sensitive vendor fold must abstain"
+        );
+    }
+
+    #[test]
     fn a_self_class_chain_folds_inside_an_instance_method() {
         // TP — the ticklecharts idiom one level removed: `set ns
         // [namespace qualifiers [self class]]` inside an instance method

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -89,7 +89,7 @@ fn codes(src: &str, dialect: &str) -> Vec<String> {
         .collect();
     let registry = registry_for_dialect(dialect);
     let cu = CompilationUnit::build_for(src, registry, false);
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
+    let dialect_opt = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     for d in run_all_checks(&cu, registry, dialect_opt) {
         if d.code.is_optimisation() {
             continue;

--- a/rust/tcl-compiler/tests/checks.rs
+++ b/rust/tcl-compiler/tests/checks.rs
@@ -110,7 +110,7 @@ fn codes(src: &str, dialect: &str) -> Vec<String> {
         .collect();
     let registry = registry_for_dialect(dialect);
     let cu = CompilationUnit::build_for(src, registry, false);
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
+    let dialect_opt = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     for d in run_all_checks(&cu, registry, dialect_opt) {
         if d.code.is_optimisation() {
             continue;
@@ -169,7 +169,7 @@ fn of_code(src: &str, dialect: &str, code: &str) -> Vec<(String, Severity, Vec<S
 fn taint_of_code(src: &str, dialect: &str, code: &str) -> Vec<(String, Severity)> {
     let registry = registry_for_dialect(dialect);
     let cu = CompilationUnit::build_for(src, registry, false);
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
+    let dialect_opt = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     run_all_checks(&cu, registry, dialect_opt)
         .into_iter()
         .filter(|d| !d.code.is_optimisation() && d.code.to_string() == code)

--- a/rust/tcl-compiler/tests/compiler_analysis_residual.rs
+++ b/rust/tcl-compiler/tests/compiler_analysis_residual.rs
@@ -103,7 +103,7 @@ fn codes(src: &str, dialect: &str) -> Vec<String> {
         .collect();
     let registry = registry_for_dialect(dialect);
     let cu = CompilationUnit::build_for(src, registry, false);
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
+    let dialect_opt = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     for d in run_all_checks(&cu, registry, dialect_opt) {
         if d.code.is_optimisation() {
             continue;
@@ -124,7 +124,7 @@ fn o107_fires(src: &str, dialect: &str) -> bool {
     use tcl_compiler::optimiser::manager::optimise_with_dialect;
     use tcl_core_types::DiagCode;
     let registry = registry_for_dialect(dialect);
-    let d = (!dialect.is_empty()).then_some(dialect);
+    let d = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     optimise_with_dialect(src, registry, d)
         .iter()
         .any(|o| o.code == DiagCode::O107)

--- a/rust/tcl-compiler/tests/core_analyses.rs
+++ b/rust/tcl-compiler/tests/core_analyses.rs
@@ -808,7 +808,7 @@ fn codes(src: &str, dialect: &str) -> Vec<String> {
         .collect();
     let registry = registry_for_dialect(dialect);
     let cu = CompilationUnit::build_for(src, registry, false);
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
+    let dialect_opt = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     for d in tcl_compiler::compiler_checks::run_all_checks(&cu, registry, dialect_opt) {
         if d.code.is_optimisation() {
             continue;

--- a/rust/tcl-compiler/tests/dialect_threading.rs
+++ b/rust/tcl-compiler/tests/dialect_threading.rs
@@ -163,6 +163,22 @@ fn build_for_dialect_folds_a_word_operator_branch() {
     );
 }
 
+/// The resolved-profile entry point must carry the same iRules fold policy as
+/// the string compatibility entry point.  This is the path used by CLI/LSP
+/// callers after dialect detection and guards against a profile being reduced
+/// to the plain fallback between registry construction and SCCP.
+#[test]
+fn build_for_profile_folds_a_word_operator_branch() {
+    let registry = registry_for_dialect(IRULES);
+    let profile = tcl_dialect::DialectProfile::by_name(IRULES);
+    let unit = CompilationUnit::build_for_profile(CONSTANT_WORD_OP, registry, false, profile);
+    assert!(
+        unit.functions()
+            .any(|function| !function.sccp.constant_branches.is_empty()),
+        "a resolved f5-irules profile must retain the word-operator fold policy"
+    );
+}
+
 /// `tk` is an additive command-surface bit rather than a catalogue profile.
 /// The compatibility entry point must retain it in the unit instead of
 /// canonicalising the input to the plain fallback profile's `tcl` name.

--- a/rust/tcl-compiler/tests/dialect_threading.rs
+++ b/rust/tcl-compiler/tests/dialect_threading.rs
@@ -38,6 +38,7 @@ use tcl_compiler::compilation_unit::CompilationUnit;
 use tcl_compiler::expr_ast::{BinOp, ExprNode};
 use tcl_compiler::ir::Statement;
 use tcl_compiler::lowering::{lower_to_ir_with_config, lower_to_ir_with_dialect};
+use tcl_registry::dialects::DialectSet;
 use tcl_registry::registry_for_dialect;
 
 const IRULES: &str = "f5-irules";
@@ -160,6 +161,18 @@ fn build_for_dialect_folds_a_word_operator_branch() {
         blind_folded, 0,
         "a dialect-blind build has no word operator to fold"
     );
+}
+
+/// `tk` is an additive command-surface bit rather than a catalogue profile.
+/// The compatibility entry point must retain it in the unit instead of
+/// canonicalising the input to the plain fallback profile's `tcl` name.
+#[test]
+fn build_for_dialect_retains_the_tk_set_only_bit() {
+    let registry = registry_for_dialect("tk");
+    let unit = CompilationUnit::build_for_dialect("button .b\n", registry, false, "tk");
+
+    assert_eq!(unit.ir_module.dialect.as_deref(), Some("tk"));
+    assert_eq!(unit.top_level.semantic_facts.dialect(), DialectSet::TK);
 }
 
 // I230 — TP / TN / FP / FN

--- a/rust/tcl-compiler/tests/fp_depth.rs
+++ b/rust/tcl-compiler/tests/fp_depth.rs
@@ -89,7 +89,7 @@ fn codes(src: &str, dialect: &str) -> Vec<String> {
         .collect();
     let registry = registry_for_dialect(dialect);
     let cu = CompilationUnit::build_for(src, registry, false);
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
+    let dialect_opt = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     for d in run_all_checks(&cu, registry, dialect_opt) {
         if d.code.is_optimisation() {
             continue;
@@ -110,7 +110,7 @@ fn fires(src: &str, dialect: &str, code: &str) -> bool {
 fn all_codes(src: &str, dialect: &str) -> Vec<String> {
     let registry = registry_for_dialect(dialect);
     let cu = CompilationUnit::build_for(src, registry, false);
-    let d = (!dialect.is_empty()).then_some(dialect);
+    let d = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     let mut v: Vec<String> = Analyser::new()
         .analyse(src, dialect)
         .diagnostics
@@ -134,7 +134,7 @@ fn all_codes(src: &str, dialect: &str) -> Vec<String> {
 /// Copied from `src/analyser/diagnostics/fp/rch.rs::o107_fires`.
 fn o107_fires(src: &str, dialect: &str) -> bool {
     let registry = registry_for_dialect(dialect);
-    let d = (!dialect.is_empty()).then_some(dialect);
+    let d = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     optimise_with_dialect(src, registry, d)
         .iter()
         .any(|o| o.code == DiagCode::O107)
@@ -143,7 +143,7 @@ fn o107_fires(src: &str, dialect: &str) -> bool {
 /// True if any optimisation with `code` fires on `src`.
 fn opt_fires(src: &str, dialect: &str, code: &str) -> bool {
     let registry = registry_for_dialect(dialect);
-    let d = (!dialect.is_empty()).then_some(dialect);
+    let d = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     optimise_with_dialect(src, registry, d)
         .iter()
         .any(|o| o.code.as_str() == code)

--- a/rust/tcl-compiler/tests/intervals.rs
+++ b/rust/tcl-compiler/tests/intervals.rs
@@ -109,7 +109,7 @@ const D: &str = "tcl8.6";
 /// The numeral grammar of [`D`], threaded into every lattice-surface call the
 /// way the analyser threads the document's dialect.
 fn numbers() -> tcl_dialect::NumberSyntax {
-    numbers_for_dialect(Some(D))
+    numbers_for_dialect(Some(tcl_dialect::DialectProfile::by_name(D)))
 }
 
 // ===========================================================================
@@ -1052,7 +1052,7 @@ mod dialect_numerals {
         );
         let cu = CompilationUnit::build_for(&src, registry_for_dialect(dialect), false);
         let fu = cu.procedures.get("::f").expect("::f lowered");
-        let numbers = numbers_for_dialect(Some(dialect));
+        let numbers = numbers_for_dialect(Some(tcl_dialect::DialectProfile::by_name(dialect)));
         let iv = compute_intervals_with(&fu.cfg, &fu.ssa, &fu.sccp.values, numbers);
         let gi = build_guard_index(&fu.cfg, &fu.ssa);
         let pc = pred_counts(fu);
@@ -1170,7 +1170,7 @@ mod dialect_numerals {
                 &fu.cfg,
                 &fu.ssa,
                 &fu.sccp.values,
-                numbers_for_dialect(Some(dialect)),
+                numbers_for_dialect(Some(tcl_dialect::DialectProfile::by_name(dialect))),
             );
             let sym = fu.ssa.var_symbol("x")?;
             iv.get(&(sym, 1)).copied()
@@ -1191,10 +1191,22 @@ mod dialect_numerals {
     /// a nameless build falls back to 9.0 (the crate-wide convention).
     #[test]
     fn numbers_for_dialect_reads_the_profile_grammar() {
-        assert_eq!(numbers_for_dialect(Some("tcl8.4")), NumberSyntax::Tcl84);
-        assert_eq!(numbers_for_dialect(Some("tcl8.5")), NumberSyntax::Tcl85);
-        assert_eq!(numbers_for_dialect(Some("tcl8.6")), NumberSyntax::Tcl85);
-        assert_eq!(numbers_for_dialect(Some("tcl9.0")), NumberSyntax::Tcl90);
+        assert_eq!(
+            numbers_for_dialect(Some(tcl_dialect::DialectProfile::by_name("tcl8.4"))),
+            NumberSyntax::Tcl84
+        );
+        assert_eq!(
+            numbers_for_dialect(Some(tcl_dialect::DialectProfile::by_name("tcl8.5"))),
+            NumberSyntax::Tcl85
+        );
+        assert_eq!(
+            numbers_for_dialect(Some(tcl_dialect::DialectProfile::by_name("tcl8.6"))),
+            NumberSyntax::Tcl85
+        );
+        assert_eq!(
+            numbers_for_dialect(Some(tcl_dialect::DialectProfile::by_name("tcl9.0"))),
+            NumberSyntax::Tcl90
+        );
         assert_eq!(numbers_for_dialect(None), NumberSyntax::Tcl90);
     }
 }

--- a/rust/tcl-compiler/tests/mro_lattice_adversarial.rs
+++ b/rust/tcl-compiler/tests/mro_lattice_adversarial.rs
@@ -27,8 +27,8 @@ fn resolve(src: &str) -> Vec<SiteReport> {
     let reg = CommandRegistry::build_default();
     let mut a = Analyser::new();
     let result = a.analyse(src, "tcl8.6");
-    let cu =
-        CompilationUnit::build_for(src, &reg, false).with_interprocedural(&reg, Some("tcl8.6"));
+    let cu = CompilationUnit::build_for(src, &reg, false)
+        .with_interprocedural(&reg, Some(tcl_dialect::DialectProfile::by_name("tcl8.6")));
     let ns = NsContext::from_result(&result);
     let (reports, _stats) = analyse_dispatch(
         &cu,

--- a/rust/tcl-compiler/tests/optimiser.rs
+++ b/rust/tcl-compiler/tests/optimiser.rs
@@ -488,10 +488,12 @@ fn irules_word_operators_fold_through_sccp() {
     // A known-constant subject: the lattice resolves `$x` to `abcde` and the
     // word operator folds, collapsing the condition to a literal.
     let contains = "when HTTP_REQUEST {\n    set x \"abcde\"\n    if {$x contains \"cd\"} {\n        pool p1\n    }\n}";
+    let contains_out = optimised(contains, IR);
     assert!(
-        optimised(contains, IR).contains("if {1}"),
-        "`contains` on a known constant must fold under f5-irules; got {:?}",
-        optimised(contains, IR)
+        opt_fires(contains, IR, "O112")
+            && contains_out.contains("pool p1")
+            && !contains_out.contains("contains"),
+        "`contains` on a known constant must fold under f5-irules; got {contains_out:?}"
     );
     // Control: `eq`, an operator plain Tcl shares, folds on the identical
     // shape — the two dialect halves now agree.
@@ -500,10 +502,12 @@ fn irules_word_operators_fold_through_sccp() {
 
     // A provably-false subject folds the other way.
     let miss = "when HTTP_REQUEST {\n    set x \"abcde\"\n    if {$x contains \"zz\"} {\n        pool p1\n    }\n}";
+    let miss_out = optimised(miss, IR);
     assert!(
-        optimised(miss, IR).contains("if {0}"),
-        "a provably-false `contains` must fold to 0; got {:?}",
-        optimised(miss, IR)
+        opt_fires(miss, IR, "O112")
+            && !miss_out.contains("pool p1")
+            && !miss_out.contains("contains"),
+        "a provably-false `contains` must fold to 0; got {miss_out:?}"
     );
 
     // TN: plain Tcl has no word operators, so the same text must not fold —

--- a/rust/tcl-compiler/tests/optimiser.rs
+++ b/rust/tcl-compiler/tests/optimiser.rs
@@ -62,7 +62,7 @@ const TCL: &str = "tcl8.6";
 /// Every `Oxxx` code emitted by a single optimiser pass over `src`.
 fn opt_codes(src: &str, dialect: &str) -> Vec<String> {
     let registry = registry_for_dialect(dialect);
-    let d = (!dialect.is_empty()).then_some(dialect);
+    let d = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     optimise_with_dialect(src, registry, d)
         .iter()
         .map(|o| o.code.as_str().to_owned())
@@ -77,14 +77,14 @@ fn opt_fires(src: &str, dialect: &str, code: &str) -> bool {
 /// Apply all (non-hint) optimisations and return the rewritten source.
 fn optimised(src: &str, dialect: &str) -> String {
     let registry = registry_for_dialect(dialect);
-    let d = (!dialect.is_empty()).then_some(dialect);
+    let d = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     apply_optimisations(src, &optimise_with_dialect(src, registry, d))
 }
 
 /// `(code, replacement)` pairs from the optimiser for `src`.
 fn opt_rewrites(src: &str, dialect: &str) -> Vec<(String, String)> {
     let registry = registry_for_dialect(dialect);
-    let d = (!dialect.is_empty()).then_some(dialect);
+    let d = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     optimise_with_dialect(src, registry, d)
         .into_iter()
         .map(|o| (o.code.as_str().to_owned(), o.replacement.clone()))
@@ -137,7 +137,7 @@ fn propagation_and_constant_folding_core() {
     let (reassign_out, _) = optimise_source_multipass(
         "set a 1\nset a 5\nset b [expr {$a + 2}]",
         registry,
-        Some(TCL),
+        Some(tcl_dialect::DialectProfile::by_name(TCL)),
         10,
     );
     assert_eq!(reassign_out.trim_start_matches('\n'), "set b 7");
@@ -639,7 +639,12 @@ fn structure_elimination_nesting_via_multipass() {
     assert!(pass1.contains("set alive 2"));
     assert!(opt_count(nested, TCL, "O112") >= 1);
     let registry = registry_for_dialect(TCL);
-    let (fixed, _) = optimise_source_multipass(nested, registry, Some(TCL), 10);
+    let (fixed, _) = optimise_source_multipass(
+        nested,
+        registry,
+        Some(tcl_dialect::DialectProfile::by_name(TCL)),
+        10,
+    );
     assert!(!fixed.contains("set dead 1"));
     assert!(fixed.contains("set alive 2"));
 }
@@ -1346,10 +1351,14 @@ fn accumulator_hint_o123() {
 
     // The O123 finding is hint-only (informational, not an applied rewrite).
     let registry = registry_for_dialect(TCL);
-    let o123: Vec<_> = optimise_with_dialect(fac, registry, Some(TCL))
-        .into_iter()
-        .filter(|o| o.code.as_str() == "O123")
-        .collect();
+    let o123: Vec<_> = optimise_with_dialect(
+        fac,
+        registry,
+        Some(tcl_dialect::DialectProfile::by_name(TCL)),
+    )
+    .into_iter()
+    .filter(|o| o.code.as_str() == "O123")
+    .collect();
     assert_eq!(o123.len(), 1);
     assert!(o123[0].hint_only);
 
@@ -1409,10 +1418,14 @@ fn unused_irule_procs_o124() {
     // Multiple unused procs ⇒ two O124, naming each.
     let multi = "proc used {} {\n    return 1\n}\n\nproc unused_a {} {\n    return 2\n}\n\nproc unused_b {} {\n    return 3\n}\n\nwhen HTTP_REQUEST {\n    set val [call used]\n}";
     let registry = registry_for_dialect(IR);
-    let o124s: Vec<_> = optimise_with_dialect(multi, registry, Some(IR))
-        .into_iter()
-        .filter(|o| o.code.as_str() == "O124")
-        .collect();
+    let o124s: Vec<_> = optimise_with_dialect(
+        multi,
+        registry,
+        Some(tcl_dialect::DialectProfile::by_name(IR)),
+    )
+    .into_iter()
+    .filter(|o| o.code.as_str() == "O124")
+    .collect();
     assert_eq!(o124s.len(), 2);
     assert!(o124s.iter().any(|o| o.message.contains("unused_a")));
     assert!(o124s.iter().any(|o| o.message.contains("unused_b")));
@@ -1575,7 +1588,12 @@ fn multipass_string_build_collapses_to_literal() {
     // tclsh: the proc returns "Hello World" either way.
     let registry = registry_for_dialect(TCL);
     let src = "proc build_banner {} {\n    set msg {Hello}\n    append msg { }\n    append msg World\n    return $msg\n}\n";
-    let (out, _) = optimise_source_multipass(src, registry, Some(TCL), 10);
+    let (out, _) = optimise_source_multipass(
+        src,
+        registry,
+        Some(tcl_dialect::DialectProfile::by_name(TCL)),
+        10,
+    );
     assert!(out.contains("return {Hello World}"));
     assert!(!out.contains("append"));
     assert!(!out.contains("set msg"));
@@ -1592,7 +1610,14 @@ mod cross_event_dse {
 
     fn optimised(src: &str) -> String {
         let reg = registry_for_dialect("f5-irules");
-        apply_optimisations(src, &optimise_with_dialect(src, reg, Some("f5-irules")))
+        apply_optimisations(
+            src,
+            &optimise_with_dialect(
+                src,
+                reg,
+                Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+            ),
+        )
     }
 
     #[test]
@@ -1763,14 +1788,20 @@ fn gvn_offers_under_sccp(src: &str) -> (usize, usize) {
     let fu = &cu.top_level;
     let executable = &fu.sccp.executable_blocks;
     (
-        tcl_compiler::gvn::find_loop_invariants(registry, &fu.cfg, &fu.ssa, executable, Some(TCL))
-            .len(),
+        tcl_compiler::gvn::find_loop_invariants(
+            registry,
+            &fu.cfg,
+            &fu.ssa,
+            executable,
+            Some(tcl_dialect::DialectProfile::by_name(TCL)),
+        )
+        .len(),
         tcl_compiler::gvn::find_partial_redundancies(
             registry,
             &fu.cfg,
             &fu.ssa,
             executable,
-            Some(TCL),
+            Some(tcl_dialect::DialectProfile::by_name(TCL)),
         )
         .len(),
     )
@@ -1837,12 +1868,21 @@ fn production_gvn_entries_read_the_sccp_executable_fact_issue_1385() {
         "the reproducer must actually contain SCCP-dead blocks"
     );
     assert!(
-        tcl_compiler::gvn::find_loop_invariants_for_function(registry, fu, Some(TCL)).is_empty(),
+        tcl_compiler::gvn::find_loop_invariants_for_function(
+            registry,
+            fu,
+            Some(tcl_dialect::DialectProfile::by_name(TCL))
+        )
+        .is_empty(),
         "O106 must not fire inside SCCP-dead code"
     );
     assert!(
-        tcl_compiler::gvn::find_partial_redundancies_for_function(registry, fu, Some(TCL))
-            .is_empty(),
+        tcl_compiler::gvn::find_partial_redundancies_for_function(
+            registry,
+            fu,
+            Some(tcl_dialect::DialectProfile::by_name(TCL))
+        )
+        .is_empty(),
         "O105-PRE must not fire inside SCCP-dead code"
     );
 }

--- a/rust/tcl-compiler/tests/optimiser_coverage.rs
+++ b/rust/tcl-compiler/tests/optimiser_coverage.rs
@@ -74,7 +74,7 @@ const IR: &str = "f5-irules";
 /// Sorted, de-duplicated `Oxxx` codes emitted by a single optimiser pass.
 fn opt_codes(src: &str, dialect: &str) -> Vec<String> {
     let registry = registry_for_dialect(dialect);
-    let d = (!dialect.is_empty()).then_some(dialect);
+    let d = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     let mut v: Vec<String> = optimise_with_dialect(src, registry, d)
         .iter()
         .map(|o| o.code.as_str().to_owned())
@@ -87,7 +87,7 @@ fn opt_codes(src: &str, dialect: &str) -> Vec<String> {
 /// True if any optimisation with `code` fires on `src` under `dialect`.
 fn opt_fires(src: &str, dialect: &str, code: &str) -> bool {
     let registry = registry_for_dialect(dialect);
-    let d = (!dialect.is_empty()).then_some(dialect);
+    let d = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     optimise_with_dialect(src, registry, d)
         .iter()
         .any(|o| o.code.as_str() == code)
@@ -101,14 +101,14 @@ fn opt_absent(src: &str, dialect: &str, code: &str) -> bool {
 /// Apply all optimisations and return the rewritten source.
 fn optimised(src: &str, dialect: &str) -> String {
     let registry = registry_for_dialect(dialect);
-    let d = (!dialect.is_empty()).then_some(dialect);
+    let d = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     apply_optimisations(src, &optimise_with_dialect(src, registry, d))
 }
 
 /// True if any emitted code is in `wanted`.
 fn opt_any_of(src: &str, dialect: &str, wanted: &[&str]) -> bool {
     let registry = registry_for_dialect(dialect);
-    let d = (!dialect.is_empty()).then_some(dialect);
+    let d = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     optimise_with_dialect(src, registry, d)
         .iter()
         .any(|o| wanted.contains(&o.code.as_str()))
@@ -125,7 +125,12 @@ fn legacy_gvn_codes(src: &str) -> Vec<String> {
     let cu = CompilationUnit::build_for(src, registry, false);
     let mut v: Vec<String> = Vec::new();
     for function in cu.analysable_functions() {
-        for redundancy in find_redundancies(registry, &function.cfg, &function.ssa, Some(TCL)) {
+        for redundancy in find_redundancies(
+            registry,
+            &function.cfg,
+            &function.ssa,
+            Some(tcl_dialect::DialectProfile::by_name(TCL)),
+        ) {
             v.push(redundancy.code.as_str().to_owned());
         }
     }
@@ -194,7 +199,7 @@ fn o100_constant_propagation() {
     let (reassign, _) = optimise_source_multipass(
         "set a 1\nset a 2\nset b [expr {$a + 1}]",
         registry,
-        Some(TCL),
+        Some(tcl_dialect::DialectProfile::by_name(TCL)),
         10,
     );
     assert!(reassign.contains("set b 3"));
@@ -1474,7 +1479,12 @@ fn o112_nested_via_multipass() {
     let nested = "if {1} {\n    if {0} {\n        set dead 1\n    }\n    set alive 2\n}";
     assert!(optimised(nested, TCL).contains("set alive 2"));
     let registry = registry_for_dialect(TCL);
-    let (fixed, _) = optimise_source_multipass(nested, registry, Some(TCL), 10);
+    let (fixed, _) = optimise_source_multipass(
+        nested,
+        registry,
+        Some(tcl_dialect::DialectProfile::by_name(TCL)),
+        10,
+    );
     assert!(!fixed.contains("set dead 1"));
     assert!(fixed.contains("set alive 2"));
 }
@@ -1848,7 +1858,11 @@ fn apply_optimisations_edge_cases() {
     // expr span) are permitted before application; `apply_optimisations` resolves
     // them, which the value assertions above already exercise.
     let src = "set a 1\nset b [expr {$a + 2}]\nset c [expr {$a + 3}]";
-    let opts = optimise_with_dialect(src, registry, Some(TCL));
+    let opts = optimise_with_dialect(
+        src,
+        registry,
+        Some(tcl_dialect::DialectProfile::by_name(TCL)),
+    );
     let starts: Vec<u32> = opts.iter().map(|o| o.span.start()).collect();
     let mut sorted = starts.clone();
     sorted.sort_unstable();
@@ -2325,7 +2339,12 @@ fn profile_directive_and_multipass() {
     // returns "Hello World" either way.
     let registry = registry_for_dialect(TCL);
     let build = "proc build_banner {} {\n    set msg {Hello}\n    append msg { }\n    append msg World\n    return $msg\n}\n";
-    let (mp, _) = optimise_source_multipass(build, registry, Some(TCL), 10);
+    let (mp, _) = optimise_source_multipass(
+        build,
+        registry,
+        Some(tcl_dialect::DialectProfile::by_name(TCL)),
+        10,
+    );
     assert!(mp.contains("return {Hello World}"));
     assert!(!mp.contains("append"));
     assert!(!mp.contains("set msg"));

--- a/rust/tcl-compiler/tests/optimiser_depth.rs
+++ b/rust/tcl-compiler/tests/optimiser_depth.rs
@@ -82,7 +82,7 @@ const IR: &str = "f5-irules";
 /// Every `Oxxx` code emitted by a single optimiser pass over `src`.
 fn opt_codes(src: &str, dialect: &str) -> Vec<String> {
     let registry = registry_for_dialect(dialect);
-    let d = (!dialect.is_empty()).then_some(dialect);
+    let d = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     optimise_with_dialect(src, registry, d)
         .iter()
         .map(|o| o.code.as_str().to_owned())
@@ -105,7 +105,7 @@ fn opt_count(src: &str, dialect: &str, code: &str) -> usize {
 /// Apply all (non-hint) optimisations and return the rewritten source.
 fn optimised(src: &str, dialect: &str) -> String {
     let registry = registry_for_dialect(dialect);
-    let d = (!dialect.is_empty()).then_some(dialect);
+    let d = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     apply_optimisations(src, &optimise_with_dialect(src, registry, d))
 }
 
@@ -760,7 +760,12 @@ fn structure_elimination_nested_switch_via_multipass() {
     // One pass already removes the dead switch arm / unwraps the if (structural).
     assert!(opt_count(nested, TCL, "O112") >= 1);
     let registry = registry_for_dialect(TCL);
-    let (fixed, _) = optimise_source_multipass(nested, registry, Some(TCL), 10);
+    let (fixed, _) = optimise_source_multipass(
+        nested,
+        registry,
+        Some(tcl_dialect::DialectProfile::by_name(TCL)),
+        10,
+    );
     assert!(
         !fixed.contains("set dead 1"),
         "dead switch arm must be eliminated: {fixed}"

--- a/rust/tcl-compiler/tests/pipeline_coverage.rs
+++ b/rust/tcl-compiler/tests/pipeline_coverage.rs
@@ -741,7 +741,10 @@ mod compilation_unit_build {
         // The interprocedural pass attaches a summary and re-runs taint on every
         // unit; the unit must still be well-formed afterwards.
         let cu = build("proc src {} { return [exec cat /etc/passwd] }\nproc f {} { set x [src] }")
-            .with_interprocedural(registry_for_dialect(D), Some(D));
+            .with_interprocedural(
+                registry_for_dialect(D),
+                Some(tcl_dialect::DialectProfile::by_name(D)),
+            );
         assert!(
             cu.interproc.is_some(),
             "interproc summary must be populated"

--- a/rust/tcl-compiler/tests/side_effects_binding.rs
+++ b/rust/tcl-compiler/tests/side_effects_binding.rs
@@ -90,7 +90,7 @@ fn classify(
     reg: &CommandRegistry,
     command: &str,
     args: &[&str],
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> CommandSideEffects {
     let owned: Vec<String> = args.iter().map(|s| (*s).to_owned()).collect();
     classify_side_effects(reg, command, &owned, dialect, None)
@@ -354,7 +354,12 @@ fn classify_set_static_var_irules() {
     // f5-dialect: `static::` is an iRules scope marker; the var is system-wide
     // (ConnectionSide::Global).
     let reg = irules_registry();
-    let r = classify(&reg, "set", &["static::counter", "0"], Some("irules"));
+    let r = classify(
+        &reg,
+        "set",
+        &["static::counter", "0"],
+        Some(tcl_dialect::DialectProfile::by_name("irules")),
+    );
     let e = only_effect(&r);
     assert_eq!(e.scope, StorageScope::Static);
     assert_eq!(e.connection_side, ConnectionSide::Global);
@@ -365,7 +370,12 @@ fn classify_set_static_var_irules() {
 fn classify_set_static_var_f5_irules() {
     // Same, under the `f5-irules` dialect alias. // f5-dialect.
     let reg = irules_registry();
-    let r = classify(&reg, "set", &["static::counter", "0"], Some("f5-irules"));
+    let r = classify(
+        &reg,
+        "set",
+        &["static::counter", "0"],
+        Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+    );
     let e = only_effect(&r);
     assert_eq!(e.scope, StorageScope::Static);
     assert_eq!(e.connection_side, ConnectionSide::Global);
@@ -425,7 +435,12 @@ fn classify_table_set() {
     // at Unknown. The load-bearing facts hold: it writes the SESSION_TABLE
     // target on BOTH sides.
     let reg = irules_registry();
-    let r = classify(&reg, "table", &["set", "mykey", "myval"], Some("irules"));
+    let r = classify(
+        &reg,
+        "table",
+        &["set", "mykey", "myval"],
+        Some(tcl_dialect::DialectProfile::by_name("irules")),
+    );
     assert!(r.writes_any());
     let e = only_effect(&r);
     assert_eq!(e.target, SideEffectTarget::SessionTable);
@@ -438,7 +453,12 @@ fn classify_table_set() {
 fn classify_table_lookup() {
     // f5-dialect. `table lookup` is a pure read of the SESSION_TABLE target.
     let reg = irules_registry();
-    let r = classify(&reg, "table", &["lookup", "mykey"], Some("irules"));
+    let r = classify(
+        &reg,
+        "table",
+        &["lookup", "mykey"],
+        Some(tcl_dialect::DialectProfile::by_name("irules")),
+    );
     let e = only_effect(&r);
     assert!(e.reads);
     assert!(!e.writes);
@@ -453,7 +473,12 @@ fn classify_table_lookup() {
 fn classify_pool_selection() {
     // f5-dialect.
     let reg = irules_registry();
-    let r = classify(&reg, "pool", &["mypool"], Some("irules"));
+    let r = classify(
+        &reg,
+        "pool",
+        &["mypool"],
+        Some(tcl_dialect::DialectProfile::by_name("irules")),
+    );
     assert!(r.writes_target(SideEffectTarget::PoolSelection));
     let e = only_effect(&r);
     assert_eq!(e.connection_side, ConnectionSide::Server);
@@ -463,7 +488,12 @@ fn classify_pool_selection() {
 fn classify_node_selection() {
     // f5-dialect.
     let reg = irules_registry();
-    let r = classify(&reg, "node", &["10.0.0.1"], Some("irules"));
+    let r = classify(
+        &reg,
+        "node",
+        &["10.0.0.1"],
+        Some(tcl_dialect::DialectProfile::by_name("irules")),
+    );
     assert!(r.writes_target(SideEffectTarget::NodeSelection));
 }
 
@@ -471,7 +501,12 @@ fn classify_node_selection() {
 fn classify_snat_selection() {
     // f5-dialect.
     let reg = irules_registry();
-    let r = classify(&reg, "snat", &["automap"], Some("irules"));
+    let r = classify(
+        &reg,
+        "snat",
+        &["automap"],
+        Some(tcl_dialect::DialectProfile::by_name("irules")),
+    );
     assert!(r.writes_target(SideEffectTarget::SnatSelection));
 }
 
@@ -488,7 +523,12 @@ fn classify_class_lookup() {
     // The DataGroup read is reachable via the command-level hint only when no
     // pure subcommand matches; assert the registry actually carries it so the
     // hint is not dead metadata.
-    let unknown_sub = classify(&reg, "class", &["__nosuchsub", "x"], Some("irules"));
+    let unknown_sub = classify(
+        &reg,
+        "class",
+        &["__nosuchsub", "x"],
+        Some(tcl_dialect::DialectProfile::by_name("irules")),
+    );
     assert!(unknown_sub.reads_target(SideEffectTarget::DataGroup));
 }
 
@@ -497,7 +537,12 @@ fn classify_persist_command() {
     // f5-dialect. Hint-derived effect ⇒ scope left at default. Target +
     // client-side context hold.
     let reg = irules_registry();
-    let r = classify(&reg, "persist", &["source_addr"], Some("irules"));
+    let r = classify(
+        &reg,
+        "persist",
+        &["source_addr"],
+        Some(tcl_dialect::DialectProfile::by_name("irules")),
+    );
     let e = only_effect(&r);
     assert_eq!(e.target, SideEffectTarget::PersistenceTable);
     assert_eq!(e.connection_side, ConnectionSide::Client);
@@ -508,7 +553,12 @@ fn classify_persist_command() {
 fn classify_session_add() {
     // f5-dialect.
     let reg = irules_registry();
-    let r = classify(&reg, "session", &["add", "key", "val"], Some("irules"));
+    let r = classify(
+        &reg,
+        "session",
+        &["add", "key", "val"],
+        Some(tcl_dialect::DialectProfile::by_name("irules")),
+    );
     let e = only_effect(&r);
     assert_eq!(e.target, SideEffectTarget::PersistenceTable);
     assert!(e.writes);
@@ -523,7 +573,12 @@ fn classify_session_lookup() {
     // the persistence table is still exercised by `session add` (a mutator
     // subcommand) below.
     let reg = irules_registry();
-    let r = classify(&reg, "session", &["lookup", "key"], Some("irules"));
+    let r = classify(
+        &reg,
+        "session",
+        &["lookup", "key"],
+        Some(tcl_dialect::DialectProfile::by_name("irules")),
+    );
     assert!(
         r.pure,
         "session lookup resolves via the pure-subcommand path"
@@ -538,7 +593,12 @@ fn classify_http_header_read() {
     // f5-dialect. Hint-derived effects don't set `namespace`; assert the read +
     // HttpHeader target instead.
     let reg = irules_registry();
-    let r = classify(&reg, "HTTP::header", &["value", "Host"], Some("irules"));
+    let r = classify(
+        &reg,
+        "HTTP::header",
+        &["value", "Host"],
+        Some(tcl_dialect::DialectProfile::by_name("irules")),
+    );
     let e = only_effect(&r);
     assert!(e.reads);
     assert_eq!(e.target, SideEffectTarget::HttpHeader);
@@ -556,7 +616,12 @@ fn classify_http_uri_normalized_getter_is_read_only() {
     // target *is* exercised via the `URI::path` conformance row, which does
     // carry the hint.)
     let reg = irules_registry();
-    let r = classify(&reg, "HTTP::uri", &["-normalized"], Some("f5-irules"));
+    let r = classify(
+        &reg,
+        "HTTP::uri",
+        &["-normalized"],
+        Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+    );
     assert!(r.pure, "HTTP::uri -normalized is a pure getter");
     assert!(!r.writes_any(), "a getter must not write");
 }
@@ -565,10 +630,15 @@ fn classify_http_uri_normalized_getter_is_read_only() {
 fn classify_dialect_propagation() {
     // The active dialect is stamped onto both the result and each effect.
     let reg = irules_registry();
-    let r = classify(&reg, "set", &["x", "1"], Some("irules"));
-    assert_eq!(r.dialect.as_deref(), Some("irules"));
+    let r = classify(
+        &reg,
+        "set",
+        &["x", "1"],
+        Some(tcl_dialect::DialectProfile::by_name("irules")),
+    );
+    assert_eq!(r.dialect.as_deref(), Some("f5-irules"));
     let e = only_effect(&r);
-    assert_eq!(e.dialect.as_deref(), Some("irules"));
+    assert_eq!(e.dialect.as_deref(), Some("f5-irules"));
 }
 
 #[test]
@@ -587,11 +657,16 @@ fn classify_command_level_hint_is_applied() {
     // f5-dialect. `HTTP2::disable` carries a command-level Http2State write hint
     // on BOTH sides.
     let reg = irules_registry();
-    let r = classify(&reg, "HTTP2::disable", &[], Some("irules"));
+    let r = classify(
+        &reg,
+        "HTTP2::disable",
+        &[],
+        Some(tcl_dialect::DialectProfile::by_name("irules")),
+    );
     assert!(r.writes_target(SideEffectTarget::Http2State));
     let e = only_effect(&r);
     assert_eq!(e.connection_side, ConnectionSide::Both);
-    assert_eq!(e.dialect.as_deref(), Some("irules"));
+    assert_eq!(e.dialect.as_deref(), Some("f5-irules"));
 }
 
 #[test]
@@ -603,7 +678,7 @@ fn classify_subcommand_hint_overrides_command_level() {
         &reg,
         "HTTP::header",
         &["replace", "Host", "example.com"],
-        Some("irules"),
+        Some(tcl_dialect::DialectProfile::by_name("irules")),
     );
     let e = only_effect(&r);
     assert_eq!(e.target, SideEffectTarget::HttpHeader);
@@ -614,7 +689,12 @@ fn classify_subcommand_hint_overrides_command_level() {
 fn classify_hint_precedence_beats_fallback() {
     // f5-dialect. `call my_proc` reads the PROC_DEFINITION and does not write.
     let reg = irules_registry();
-    let r = classify(&reg, "call", &["my_proc"], Some("irules"));
+    let r = classify(
+        &reg,
+        "call",
+        &["my_proc"],
+        Some(tcl_dialect::DialectProfile::by_name("irules")),
+    );
     assert!(r.reads_target(SideEffectTarget::ProcDefinition));
     assert!(!r.writes_any());
 }
@@ -640,7 +720,12 @@ fn classify_hint_with_unspecified_dialect_preserves_shape() {
 fn classify_close_in_tcl_is_file_io() {
     // tclsh: `close $fd` closes a channel (file I/O), no F5 connection context.
     let reg = irules_registry();
-    let r = classify(&reg, "close", &["$fd"], Some("tcl8.6"));
+    let r = classify(
+        &reg,
+        "close",
+        &["$fd"],
+        Some(tcl_dialect::DialectProfile::by_name("tcl8.6")),
+    );
     let e = only_effect(&r);
     assert_eq!(e.target, SideEffectTarget::FileIo);
     assert_eq!(e.connection_side, ConnectionSide::None);
@@ -651,7 +736,12 @@ fn classify_close_in_irules_is_connection_control() {
     // f5-dialect. Under iRules, bare `close` tears down the proxied connection
     // on BOTH sides (ConnectionControl), not a file channel.
     let reg = irules_registry();
-    let r = classify(&reg, "close", &[], Some("f5-irules"));
+    let r = classify(
+        &reg,
+        "close",
+        &[],
+        Some(tcl_dialect::DialectProfile::by_name("f5-irules")),
+    );
     let e = only_effect(&r);
     assert_eq!(e.target, SideEffectTarget::ConnectionControl);
     assert_eq!(e.connection_side, ConnectionSide::Both);
@@ -663,7 +753,12 @@ fn classify_file_io_does_not_kill_unknown_region() {
     // so it must NOT register as an UNKNOWN_STATE write that would kill GVN
     // facts.
     let reg = irules_registry();
-    let r = classify(&reg, "puts", &["hello"], Some("tcl8.6"));
+    let r = classify(
+        &reg,
+        "puts",
+        &["hello"],
+        Some(tcl_dialect::DialectProfile::by_name("tcl8.6")),
+    );
     let (_reads, writes) = r.to_effect_regions();
     assert_eq!(writes, EffectRegion::NONE);
 }
@@ -676,7 +771,7 @@ fn classify_file_io_does_not_kill_unknown_region() {
 fn assert_conformance_target(
     reg: &CommandRegistry,
     command: &str,
-    dialect: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     expected: SideEffectTarget,
 ) {
     let r = classify(reg, command, &[], dialect);
@@ -718,7 +813,12 @@ fn conformance_irules_protocol_namespace_targets() {
         ("URI::path", SideEffectTarget::HttpUri),
     ];
     for (cmd, target) in rows {
-        assert_conformance_target(&reg, cmd, Some("irules"), *target);
+        assert_conformance_target(
+            &reg,
+            cmd,
+            Some(tcl_dialect::DialectProfile::by_name("irules")),
+            *target,
+        );
     }
 }
 
@@ -760,7 +860,12 @@ fn hinted_irules_commands_return_non_unknown_effects() {
         "redirect",
     ];
     for cmd in cmds {
-        let r = classify(&reg, cmd, &[], Some("irules"));
+        let r = classify(
+            &reg,
+            cmd,
+            &[],
+            Some(tcl_dialect::DialectProfile::by_name("irules")),
+        );
         assert!(!r.effects.is_empty(), "{cmd}: expected non-empty effects");
     }
 }

--- a/rust/tcl-compiler/tests/taint.rs
+++ b/rust/tcl-compiler/tests/taint.rs
@@ -96,7 +96,7 @@ const IR: &str = "f5-irules";
 fn warns(src: &str, dialect: &str) -> Vec<TaintWarning> {
     let registry = registry_for_dialect(dialect);
     let cu = CompilationUnit::build_for(src, registry, false);
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
+    let dialect_opt = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     find_taint_warnings_for_cu(&cu, registry, dialect_opt)
 }
 

--- a/rust/tcl-compiler/tests/taint_depth.rs
+++ b/rust/tcl-compiler/tests/taint_depth.rs
@@ -85,7 +85,7 @@ const IR: &str = "f5-irules";
 fn warns(src: &str, dialect: &str) -> Vec<TaintWarning> {
     let registry = registry_for_dialect(dialect);
     let cu = CompilationUnit::build_for(src, registry, false);
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
+    let dialect_opt = (!dialect.is_empty()).then(|| tcl_dialect::DialectProfile::by_name(dialect));
     find_taint_warnings_for_cu(&cu, registry, dialect_opt)
 }
 

--- a/rust/tcl-compiler/tests/unused_var_tricky_features.rs
+++ b/rust/tcl-compiler/tests/unused_var_tricky_features.rs
@@ -69,7 +69,11 @@ fn codes(src: &str, dialect: &str) -> Vec<String> {
         .collect();
     let registry = registry_for_dialect(dialect);
     let cu = CompilationUnit::build_for(src, registry, false);
-    for d in run_all_checks(&cu, registry, Some(dialect)) {
+    for d in run_all_checks(
+        &cu,
+        registry,
+        Some(tcl_dialect::DialectProfile::by_name(dialect)),
+    ) {
         if d.code.is_optimisation() {
             continue;
         }

--- a/rust/tcl-diagram/src/attach.rs
+++ b/rust/tcl-diagram/src/attach.rs
@@ -44,6 +44,7 @@ use std::collections::HashMap;
 use serde_json::{Value, json};
 use tcl_compiler::compilation_unit::CompilationUnit;
 use tcl_compiler::ir::{Script, Statement};
+use tcl_dialect::DialectProfile;
 use tcl_lexer::{Lexer, LexerConfig, SourceMap, TokenType};
 
 /// Cap on patterns collected per object type per rule body — a runaway-input
@@ -453,7 +454,12 @@ pub fn attach_reach(source: &str) -> AttachReach {
         return reach;
     }
     let registry = tcl_registry::registry_for_dialect("f5-irules");
-    let cu = CompilationUnit::build_for_dialect(source, registry, false, "f5-irules");
+    let cu = CompilationUnit::build_for_profile(
+        source,
+        registry,
+        false,
+        DialectProfile::by_name("f5-irules"),
+    );
 
     // Each `when` handler (and any user proc) is its own frame; walk each with a
     // fresh env in source order for stable output.
@@ -486,7 +492,12 @@ pub fn proc_call_refs(source: &str) -> Vec<String> {
         return out;
     }
     let registry = tcl_registry::registry_for_dialect("f5-irules");
-    let cu = CompilationUnit::build_for_dialect(source, registry, false, "f5-irules");
+    let cu = CompilationUnit::build_for_profile(
+        source,
+        registry,
+        false,
+        DialectProfile::by_name("f5-irules"),
+    );
     let mut procs: Vec<_> = cu.ir_module.procedures.values().collect();
     procs.sort_by_key(|p| p.span.start());
     for proc in procs {

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -36,6 +36,7 @@ use tcl_compiler::ir::{
     CommandTokens, Procedure, Script, Statement, SwitchArm, TryHandler, when_event_name,
 };
 use tcl_compiler::registry_invocation::effective_command_arguments;
+use tcl_dialect::DialectProfile;
 use tcl_registry::CommandRegistry;
 use tcl_registry::InvocationArguments;
 use tcl_registry::dialects::DialectSet;
@@ -758,7 +759,8 @@ pub fn diagram_data(source: &str, registry: &CommandRegistry) -> Value {
 /// dialect's registry.
 #[must_use]
 pub fn diagram_data_for_dialect(source: &str, registry: &CommandRegistry, dialect: &str) -> Value {
-    let cu = CompilationUnit::build_for_dialect(source, registry, false, dialect);
+    let profile = DialectProfile::by_name(dialect);
+    let cu = CompilationUnit::build_for_profile(source, registry, false, profile);
     let module = &cu.ir_module;
 
     // Recover the source-order dict iteration (the procedures map is a

--- a/rust/tcl-dialect/src/dialect_set.rs
+++ b/rust/tcl-dialect/src/dialect_set.rs
@@ -233,7 +233,11 @@ impl DialectSet {
             "tcl8.6" => Self::TCL86,
             "tcl9.0" => Self::TCL90,
             "tcl9.1" => Self::TCL91,
-            "f5-irules" => Self::IRULES,
+            // Keep historic iRules spellings at this ingress boundary. The
+            // typed set is passed through compiler and registry APIs, so an
+            // alias cannot survive far enough for a security gate to disagree
+            // with the profile catalogue.
+            "f5-irules" | "irules" | "tcl-irule" => Self::IRULES,
             "f5-iapps" => Self::IAPPS,
             "tk" => Self::TK,
             "expect" => Self::EXPECT,
@@ -564,6 +568,15 @@ mod tests {
         assert!(!DialectSet::is_irules_dialect(Some("f5-iapps")));
         assert!(!DialectSet::is_irules_dialect(Some("f5-bigip")));
         assert!(!DialectSet::is_irules_dialect(None));
+    }
+
+    #[test]
+    fn parse_canonicalises_irules_aliases() {
+        for spelling in ["f5-irules", "irules", "tcl-irule"] {
+            let dialect = DialectSet::parse(spelling).expect("registered iRules spelling");
+            assert_eq!(dialect, DialectSet::IRULES);
+            assert_eq!(dialect.canonical_name(), Some("f5-irules"));
+        }
     }
 
     #[test]

--- a/rust/tcl-dialect/src/profile.rs
+++ b/rust/tcl-dialect/src/profile.rs
@@ -936,6 +936,27 @@ impl DialectProfile {
         Self::find(name).unwrap_or(&PLAIN_TCL)
     }
 
+    /// Resolve the command-availability fact for an ingest dialect name.
+    ///
+    /// Profiles own the base Tcl and vendor availability semantics, while a
+    /// few typed [`DialectSet`] inputs describe an additive library surface
+    /// rather than a selectable profile.  In particular, `tk` intentionally
+    /// resolves to the plain Tcl profile (it must not appear in the editor's
+    /// profile catalog), but a `wish` document still has the `TK` command
+    /// surface.  Compose the parsed input bit here, at the one string ingress
+    /// boundary, so consumers carry a typed fact rather than recover that
+    /// distinction with spelling checks.
+    ///
+    /// Catalogued names and aliases are unchanged: their parsed bit is already
+    /// represented by the resolved profile's mask, including iRules' bare
+    /// security-gated `IRULES` mask.
+    #[must_use]
+    pub fn availability_for_name(name: &str) -> DialectSet {
+        Self::by_name(name)
+            .availability_mask
+            .union(DialectSet::parse(name).unwrap_or_else(DialectSet::empty))
+    }
+
     /// Resolve an *optional* dialect-name string: `None` and unknown names
     /// both land on [`Self::plain_tcl`]. The ingest-boundary form of
     /// [`Self::by_name`] for callers holding `Option<&str>`.
@@ -1269,6 +1290,31 @@ mod tests {
             DialectProfile::plain_tcl()
         ));
         assert_eq!(DialectProfile::by_opt_name(Some("expect")).name, "expect");
+    }
+
+    #[test]
+    fn ingress_availability_preserves_the_tk_library_bit() {
+        // Tk deliberately remains a library pin rather than an editor-visible
+        // catalog profile, but an explicit `tk` / wish document must retain
+        // the typed command-surface fact through profile resolution.
+        assert_eq!(DialectProfile::by_name("tk").name, "tcl");
+        assert_eq!(
+            DialectProfile::availability_for_name("tk"),
+            DialectProfile::plain_tcl()
+                .availability_mask
+                .union(DialectSet::TK)
+        );
+        // A canonical profile and a legacy alias keep their profile-owned
+        // security mask; composing ingress facts must not re-admit Tcl bits
+        // for the iRules sandbox.
+        assert_eq!(
+            DialectProfile::availability_for_name("f5-irules"),
+            DialectSet::IRULES
+        );
+        assert_eq!(
+            DialectProfile::availability_for_name("irules"),
+            DialectSet::IRULES
+        );
     }
 
     #[test]

--- a/rust/tcl-dialect/src/profile.rs
+++ b/rust/tcl-dialect/src/profile.rs
@@ -997,7 +997,7 @@ impl DialectProfile {
     /// is the *fold* policy.
     #[must_use]
     pub fn const_fold_version(&self) -> Option<TclVersion> {
-        TclVersion::from_dialect(Some(self.name))
+        TclVersion::from_profile(self)
     }
 
     /// The [`LibraryPin`] this profile declares for `package`, if any

--- a/rust/tcl-dialect/src/profile.rs
+++ b/rust/tcl-dialect/src/profile.rs
@@ -999,6 +999,21 @@ impl DialectProfile {
             .find(|p| p.name == name || p.aliases.contains(&name))
     }
 
+    /// Resolve a known ingress name, including additive set-only dialects.
+    ///
+    /// Most names resolve to an interned catalog profile through [`Self::find`].
+    /// Some valid ingress names instead describe an additive command surface;
+    /// they need a typed profile so version- and availability-aware consumers
+    /// do not silently fall back to their unknown-dialect defaults.
+    #[must_use]
+    pub fn resolve_known(name: &str) -> Option<&'static DialectProfile> {
+        Self::find(name).or_else(|| {
+            DialectSet::parse(name)
+                .filter(|&set| set == DialectSet::TK)
+                .map(|_| Self::tk())
+        })
+    }
+
     /// The `f5-irules` profile — an explicit handle for the hardcoded
     /// iRules lookups (event checks, taint, the iRules test framework).
     #[must_use]
@@ -1317,6 +1332,21 @@ mod tests {
             );
         }
         assert!(DialectProfile::find("nonsense").is_none());
+        assert!(DialectProfile::resolve_known("nonsense").is_none());
+    }
+
+    #[test]
+    fn resolve_known_preserves_set_only_tk_identity() {
+        assert!(std::ptr::eq(
+            DialectProfile::resolve_known("tk").expect("Tk is a recognised ingress"),
+            DialectProfile::tk()
+        ));
+        assert_eq!(
+            DialectProfile::resolve_known("f5-irules")
+                .expect("catalogued dialect")
+                .name,
+            "f5-irules"
+        );
     }
 
     #[test]

--- a/rust/tcl-dialect/src/profile.rs
+++ b/rust/tcl-dialect/src/profile.rs
@@ -894,6 +894,30 @@ static PLAIN_TCL: DialectProfile = DialectProfile {
     help_terms: &[],
 };
 
+/// Set-only `tk` ingress: modern Tcl behaviour plus the Tk availability bit.
+/// This is deliberately not part of [`DialectProfile::all`] or
+/// [`DialectProfile::find`].
+static TK_PROFILE: DialectProfile = DialectProfile {
+    name: "tk",
+    aliases: &[],
+    vendor_bit: None,
+    availability_mask: DialectSet::TK_AND_TCL,
+    base_layers: &[],
+    grammar_union: DialectSet::TK_AND_TCL,
+    version_ceiling: None,
+    signature_base: None,
+    runtime_base: None,
+    leading_zero_is_octal: Ternary::Inert,
+    expr_grammar_base: None,
+    grammar: GRAMMAR_TCL9X,
+    operators_as_commands: true,
+    tcloo: true,
+    has_fixed_ensembles: false,
+    vm_runtime_version: TclVersion::V9_0,
+    libraries: LIBS_TCL86_PLUS,
+    help_terms: &["tk"],
+};
+
 impl DialectProfile {
     /// The release this profile's *runtime* behaviour follows, if it names one.
     ///
@@ -987,6 +1011,18 @@ impl DialectProfile {
     #[must_use]
     pub fn plain_tcl() -> &'static DialectProfile {
         &PLAIN_TCL
+    }
+
+    /// The additive Tk-only ingress profile.
+    ///
+    /// Tk is intentionally absent from the selectable profile catalogue: it
+    /// is a library surface layered onto Tcl rather than a runtime with its
+    /// own release semantics. CLI/LSP compatibility inputs still need a
+    /// resolved identity, though, so this profile carries the typed `TK` bit
+    /// while retaining the permissive Tcl behaviour of that ingress.
+    #[must_use]
+    pub fn tk() -> &'static DialectProfile {
+        &TK_PROFILE
     }
 
     /// Whether this profile is the permissive unknown-dialect fallback

--- a/rust/tcl-dialect/src/version.rs
+++ b/rust/tcl-dialect/src/version.rs
@@ -20,6 +20,8 @@
 //! three-valued policy type for behaviours a non-Tcl profile has no
 //! opinion on.
 
+use crate::DialectProfile;
+
 /// How Tcl converts a Unicode string representation to binary bytes.
 ///
 /// Tcl 8.x keeps the historic one-byte conversion: each character contributes
@@ -107,20 +109,27 @@ impl TclVersion {
     /// than rebuilding the vocabulary beside their own parser.
     pub const ALL: [Self; 5] = [Self::V8_4, Self::V8_5, Self::V8_6, Self::V9_0, Self::V9_1];
 
-    /// Map an optimiser dialect string (`"tcl8.4"` … `"tcl9.1"`) to a version,
-    /// or `None` for an unversioned (`"tcl"`), non-Tcl (`"f5-irules"`), or
-    /// unknown dialect — in which case a versioned fold must return only the
-    /// dialect-invariant subset every release shares.
+    /// Compatibility parser for a dialect name at an external boundary.
+    ///
+    /// Typed compiler and registry paths use [`Self::from_profile`]. An
+    /// unversioned (`"tcl"`), non-Tcl (`"f5-irules"`), or unknown name has no
+    /// fold version, so versioned folds return only their invariant subset.
     #[must_use]
     pub fn from_dialect(dialect: Option<&str>) -> Option<Self> {
-        match dialect {
-            Some("tcl8.4") => Some(Self::V8_4),
-            Some("tcl8.5") => Some(Self::V8_5),
-            Some("tcl8.6") => Some(Self::V8_6),
-            Some("tcl9.0") => Some(Self::V9_0),
+        dialect.and_then(|name| Self::from_profile(DialectProfile::by_name(name)))
+    }
+
+    /// Return the release fact represented by an already-resolved profile.
+    #[must_use]
+    pub fn from_profile(profile: &DialectProfile) -> Option<Self> {
+        match profile.name {
+            "tcl8.4" => Some(Self::V8_4),
+            "tcl8.5" => Some(Self::V8_5),
+            "tcl8.6" => Some(Self::V8_6),
+            "tcl9.0" => Some(Self::V9_0),
             // 9.1 must not fall through to `None` (which degrades a versioned
             // fold to the dialect-invariant subset) — it behaves as 9.0+.
-            Some("tcl9.1") => Some(Self::V9_1),
+            "tcl9.1" => Some(Self::V9_1),
             _ => None,
         }
     }

--- a/rust/tcl-explorer/src/lib.rs
+++ b/rust/tcl-explorer/src/lib.rs
@@ -209,15 +209,16 @@ pub fn run_pipeline(source: &str, dialect: &str) -> ExplorerResult {
     // Memory-SSA is built so the `dataflow` view can surface alias sets
     // (upvar / global / variable / namespace upvar). Without it the
     // `aliases` list degrades to empty.
-    let profile = DialectProfile::by_name(dialect);
+    let profile =
+        DialectProfile::resolve_known(dialect).unwrap_or_else(|| DialectProfile::by_name(dialect));
     let unit = CompilationUnit::build_for_profile(source, registry, false, profile)
-        .with_interprocedural(registry, DialectProfile::find(dialect))
-        .with_memory_ssa(registry, DialectProfile::by_name(dialect).availability_mask)
+        .with_interprocedural(registry, Some(profile))
+        .with_memory_ssa(registry, profile.availability_mask)
         // The ordinary compiler path builds world SSA only when interactive
         // GVN can consume it. Explorer is an explicit inspection surface, so
         // it asks for the complete source-faithful sidecar and displays typed
         // declines rather than silently presenting an empty graph.
-        .with_deep_semantic_analysis(registry, DialectProfile::by_name(dialect).availability_mask);
+        .with_deep_semantic_analysis(registry, profile.availability_mask);
 
     ExplorerResult {
         source: source.to_owned(),

--- a/rust/tcl-explorer/src/lib.rs
+++ b/rust/tcl-explorer/src/lib.rs
@@ -209,8 +209,9 @@ pub fn run_pipeline(source: &str, dialect: &str) -> ExplorerResult {
     // Memory-SSA is built so the `dataflow` view can surface alias sets
     // (upvar / global / variable / namespace upvar). Without it the
     // `aliases` list degrades to empty.
-    let unit = CompilationUnit::build_for_dialect(source, registry, false, dialect)
-        .with_interprocedural(registry, Some(dialect))
+    let profile = DialectProfile::by_name(dialect);
+    let unit = CompilationUnit::build_for_profile(source, registry, false, profile)
+        .with_interprocedural(registry, DialectProfile::find(dialect))
         .with_memory_ssa(registry, DialectProfile::by_name(dialect).availability_mask)
         // The ordinary compiler path builds world SSA only when interactive
         // GVN can consume it. Explorer is an explicit inspection surface, so

--- a/rust/tcl-explorer/src/serialise.rs
+++ b/rust/tcl-explorer/src/serialise.rs
@@ -1094,7 +1094,7 @@ fn serialise_world_ssa(result: &ExplorerResult) -> Value {
 pub fn serialise_gvn(result: &ExplorerResult, li: &LineIndex, source: &str) -> Value {
     let registry_held = registry_for_dialect(&result.dialect);
     let registry = &*registry_held;
-    let dialect = DialectProfile::find(&result.dialect);
+    let dialect = DialectProfile::resolve_known(&result.dialect);
     let mut all = find_redundancies_for_cu(&result.unit, registry, dialect);
     all.extend(find_partial_redundancies_for_cu(
         &result.unit,
@@ -1145,7 +1145,7 @@ fn taint_severity(code: &str) -> &'static str {
 pub fn serialise_taint(result: &ExplorerResult, li: &LineIndex, source: &str) -> Value {
     let registry_held = registry_for_dialect(&result.dialect);
     let registry = &*registry_held;
-    let dialect = DialectProfile::find(&result.dialect);
+    let dialect = DialectProfile::resolve_known(&result.dialect);
     let out: Vec<Value> = find_taint_warnings_for_cu(&result.unit, registry, dialect)
         .iter()
         .map(|w| {
@@ -1197,7 +1197,7 @@ pub fn serialise_optimiser_passes(result: &ExplorerResult, li: &LineIndex, sourc
     let passes: Vec<Value> = optimise_by_pass(
         &result.unit,
         registry,
-        DialectProfile::find(&result.dialect),
+        DialectProfile::resolve_known(&result.dialect),
     )
     .iter()
     .map(|(pass, opts)| {
@@ -2077,7 +2077,7 @@ fn serialise_memory_ssa(memory: &MemorySsaFunction) -> Value {
 pub fn serialise_irules_flow(result: &ExplorerResult, li: &LineIndex, source: &str) -> Value {
     let registry_held = registry_for_dialect(&result.dialect);
     let registry = &*registry_held;
-    let dialect = DialectProfile::find(&result.dialect);
+    let dialect = DialectProfile::resolve_known(&result.dialect);
     let cu = &result.unit;
     let mut warnings = find_unnormalised_getter_warnings(
         cu,
@@ -2660,7 +2660,7 @@ fn serialise_source_map_units(result: &ExplorerResult) -> Value {
 fn serialise_stats(result: &ExplorerResult) -> Value {
     let registry_held = registry_for_dialect(&result.dialect);
     let registry = &*registry_held;
-    let dialect = DialectProfile::find(&result.dialect);
+    let dialect = DialectProfile::resolve_known(&result.dialect);
 
     let unreachable: usize = result
         .all_snapshots()
@@ -2773,7 +2773,7 @@ fn walk_barriers(script: &Script, scope: &str, out: &mut Vec<Ann>) {
 fn serialise_annotations(result: &ExplorerResult, li: &LineIndex, source: &str) -> (Value, Value) {
     let registry_held = registry_for_dialect(&result.dialect);
     let registry = &*registry_held;
-    let dialect = DialectProfile::find(&result.dialect);
+    let dialect = DialectProfile::resolve_known(&result.dialect);
     let mut anns: Vec<Ann> = Vec::new();
 
     // Barriers (IR walk).
@@ -3168,6 +3168,22 @@ mod tests {
                 .iter()
                 .any(|v| v["id"] == "greentree"),
             "greentree tab must be dropped"
+        );
+    }
+
+    #[test]
+    fn optimiser_passes_preserve_set_only_tk_profile() {
+        let result = run_pipeline("proc recurse {} { recurse }\n", "tk");
+        let serialised = serialise_result(&result);
+        let passes = serialised["optimiserPasses"]
+            .as_array()
+            .expect("optimiser passes");
+        assert!(
+            !passes
+                .iter()
+                .flat_map(|pass| { pass["optimisations"].as_array().into_iter().flatten() })
+                .any(|optimisation| optimisation["code"] == "O121"),
+            "Tk must not offer tailcall: {passes:?}"
         );
     }
 

--- a/rust/tcl-explorer/src/serialise.rs
+++ b/rust/tcl-explorer/src/serialise.rs
@@ -66,6 +66,7 @@ use tcl_compiler::state_ssa::adapters::{
 use tcl_compiler::state_ssa::{CfgStatePosition, StateOp, StateSite};
 use tcl_compiler::taint::find_taint_warnings_for_cu;
 use tcl_compiler::world_state_ssa::{WorldStateSsaDecline, project_transition_facts};
+use tcl_dialect::DialectProfile;
 use tcl_lexer::{LexerConfig, LineIndex, Span, TokenType};
 use tcl_registry::available_dialects;
 // See the note in `lib.rs`: the explorer resolves against the active pack set.
@@ -1093,7 +1094,7 @@ fn serialise_world_ssa(result: &ExplorerResult) -> Value {
 pub fn serialise_gvn(result: &ExplorerResult, li: &LineIndex, source: &str) -> Value {
     let registry_held = registry_for_dialect(&result.dialect);
     let registry = &*registry_held;
-    let dialect = Some(result.dialect.as_str());
+    let dialect = DialectProfile::find(&result.dialect);
     let mut all = find_redundancies_for_cu(&result.unit, registry, dialect);
     all.extend(find_partial_redundancies_for_cu(
         &result.unit,
@@ -1144,7 +1145,7 @@ fn taint_severity(code: &str) -> &'static str {
 pub fn serialise_taint(result: &ExplorerResult, li: &LineIndex, source: &str) -> Value {
     let registry_held = registry_for_dialect(&result.dialect);
     let registry = &*registry_held;
-    let dialect = Some(result.dialect.as_str());
+    let dialect = DialectProfile::find(&result.dialect);
     let out: Vec<Value> = find_taint_warnings_for_cu(&result.unit, registry, dialect)
         .iter()
         .map(|w| {
@@ -1193,28 +1194,32 @@ pub fn serialise_optimisations(result: &ExplorerResult, li: &LineIndex, source: 
 pub fn serialise_optimiser_passes(result: &ExplorerResult, li: &LineIndex, source: &str) -> Value {
     let registry_held = registry_for_dialect(&result.dialect);
     let registry = &*registry_held;
-    let passes: Vec<Value> = optimise_by_pass(&result.unit, registry, Some(&result.dialect))
-        .iter()
-        .map(|(pass, opts)| {
-            let optimisations: Vec<Value> = opts
-                .iter()
-                .map(|o| {
-                    json!({
-                        "code": o.code.as_str(),
-                        "message": o.message,
-                        "range": range_dict(o.span, li, source),
-                        "replacement": o.replacement,
-                    })
+    let passes: Vec<Value> = optimise_by_pass(
+        &result.unit,
+        registry,
+        DialectProfile::find(&result.dialect),
+    )
+    .iter()
+    .map(|(pass, opts)| {
+        let optimisations: Vec<Value> = opts
+            .iter()
+            .map(|o| {
+                json!({
+                    "code": o.code.as_str(),
+                    "message": o.message,
+                    "range": range_dict(o.span, li, source),
+                    "replacement": o.replacement,
                 })
-                .collect();
-            json!({
-                "id": pass.as_str(),
-                "label": pass.label(),
-                "count": optimisations.len(),
-                "optimisations": optimisations,
             })
+            .collect();
+        json!({
+            "id": pass.as_str(),
+            "label": pass.label(),
+            "count": optimisations.len(),
+            "optimisations": optimisations,
         })
-        .collect();
+    })
+    .collect();
     Value::Array(passes)
 }
 
@@ -2072,13 +2077,40 @@ fn serialise_memory_ssa(memory: &MemorySsaFunction) -> Value {
 pub fn serialise_irules_flow(result: &ExplorerResult, li: &LineIndex, source: &str) -> Value {
     let registry_held = registry_for_dialect(&result.dialect);
     let registry = &*registry_held;
-    let dialect = Some(result.dialect.as_str());
+    let dialect = DialectProfile::find(&result.dialect);
     let cu = &result.unit;
-    let mut warnings = find_unnormalised_getter_warnings(cu, registry, dialect);
-    warnings.extend(find_unguarded_drop_warnings(cu, dialect));
-    warnings.extend(find_collect_flow_warnings(cu, registry, dialect));
-    warnings.extend(find_http_flow_warnings(cu, dialect));
-    warnings.extend(find_hoistable_set_warnings(cu, dialect));
+    let mut warnings = find_unnormalised_getter_warnings(
+        cu,
+        registry,
+        dialect.map_or(tcl_dialect::DialectSet::empty(), |profile| {
+            profile.availability_mask
+        }),
+    );
+    warnings.extend(find_unguarded_drop_warnings(
+        cu,
+        dialect.map_or(tcl_dialect::DialectSet::empty(), |profile| {
+            profile.availability_mask
+        }),
+    ));
+    warnings.extend(find_collect_flow_warnings(
+        cu,
+        registry,
+        dialect.map_or(tcl_dialect::DialectSet::empty(), |profile| {
+            profile.availability_mask
+        }),
+    ));
+    warnings.extend(find_http_flow_warnings(
+        cu,
+        dialect.map_or(tcl_dialect::DialectSet::empty(), |profile| {
+            profile.availability_mask
+        }),
+    ));
+    warnings.extend(find_hoistable_set_warnings(
+        cu,
+        dialect.map_or(tcl_dialect::DialectSet::empty(), |profile| {
+            profile.availability_mask
+        }),
+    ));
 
     let out: Vec<Value> = warnings
         .iter()
@@ -2628,7 +2660,7 @@ fn serialise_source_map_units(result: &ExplorerResult) -> Value {
 fn serialise_stats(result: &ExplorerResult) -> Value {
     let registry_held = registry_for_dialect(&result.dialect);
     let registry = &*registry_held;
-    let dialect = Some(result.dialect.as_str());
+    let dialect = DialectProfile::find(&result.dialect);
 
     let unreachable: usize = result
         .all_snapshots()
@@ -2741,7 +2773,7 @@ fn walk_barriers(script: &Script, scope: &str, out: &mut Vec<Ann>) {
 fn serialise_annotations(result: &ExplorerResult, li: &LineIndex, source: &str) -> (Value, Value) {
     let registry_held = registry_for_dialect(&result.dialect);
     let registry = &*registry_held;
-    let dialect = Some(result.dialect.as_str());
+    let dialect = DialectProfile::find(&result.dialect);
     let mut anns: Vec<Ann> = Vec::new();
 
     // Barriers (IR walk).

--- a/rust/tcl-lexer/src/expr_lexer.rs
+++ b/rust/tcl-lexer/src/expr_lexer.rs
@@ -247,17 +247,40 @@ fn irules_ops() -> HashSet<&'static str> {
     .collect()
 }
 
-/// Tokenise a Tcl expression string.
+/// Tokenise a Tcl expression string from a compatibility name boundary.
+///
+/// Internal typed callers should use [`tokenise_expr_for_profile`].
 #[must_use]
 pub fn tokenise_expr(source: &str, dialect: Option<&str>) -> Vec<ExprToken> {
-    let mut lex = Inner::new(source, dialect);
+    let mut lex = Inner::new(source, tcl_dialect::DialectProfile::by_opt_name(dialect));
     lex.run()
 }
 
-/// Tokenise and report whether unknown characters were skipped.
+/// Tokenise under an already-resolved dialect profile.
+#[must_use]
+pub fn tokenise_expr_for_profile(
+    source: &str,
+    profile: &tcl_dialect::DialectProfile,
+) -> Vec<ExprToken> {
+    let mut lex = Inner::new(source, profile);
+    lex.run()
+}
+
+/// Tokenise from a compatibility name boundary and report skipped characters.
+///
+/// Internal typed callers should use [`tokenise_expr_checked_for_profile`].
 #[must_use]
 pub fn tokenise_expr_checked(source: &str, dialect: Option<&str>) -> (Vec<ExprToken>, bool) {
-    let mut lex = Inner::new(source, dialect);
+    tokenise_expr_checked_for_profile(source, tcl_dialect::DialectProfile::by_opt_name(dialect))
+}
+
+/// Tokenise under an already-resolved profile and report skipped characters.
+#[must_use]
+pub fn tokenise_expr_checked_for_profile(
+    source: &str,
+    profile: &tcl_dialect::DialectProfile,
+) -> (Vec<ExprToken>, bool) {
+    let mut lex = Inner::new(source, profile);
     let tokens = lex.run();
     (tokens, lex.unknown)
 }
@@ -296,8 +319,7 @@ struct Inner<'s> {
 }
 
 impl<'s> Inner<'s> {
-    fn new(s: &'s str, dialect: Option<&'s str>) -> Self {
-        let profile = tcl_dialect::DialectProfile::by_opt_name(dialect);
+    fn new(s: &'s str, profile: &tcl_dialect::DialectProfile) -> Self {
         Self {
             b: s.as_bytes(),
             s,

--- a/rust/tcl-lexer/src/lib.rs
+++ b/rust/tcl-lexer/src/lib.rs
@@ -67,7 +67,7 @@ mod tokens;
 
 pub use expr_lexer::{
     ExprToken, ExprTokenType, math_functions as expr_math_functions, tokenise_expr,
-    tokenise_expr_checked,
+    tokenise_expr_checked, tokenise_expr_checked_for_profile, tokenise_expr_for_profile,
 };
 #[cfg(feature = "html")]
 pub use highlight::{

--- a/rust/tcl-lsp-core/src/code_actions.rs
+++ b/rust/tcl-lsp-core/src/code_actions.rs
@@ -2930,14 +2930,15 @@ mod tests {
         let mut registry = tcl_registry::CommandRegistry::build_default();
         registry.load_irules();
         let src = "when CLIENT_ACCEPTED { drop }\n";
+        let profile = tcl_dialect::DialectProfile::by_name("f5-irules");
         let cu = CompilationUnit::build_for_with_config(
             src,
             &registry,
             false,
             LexerConfig::for_dialect("f5-irules"),
         )
-        .with_interprocedural(&registry, Some("f5-irules"));
-        let checks = run_all_checks(&cu, &registry, Some("f5-irules"));
+        .with_interprocedural(&registry, Some(profile));
+        let checks = run_all_checks(&cu, &registry, Some(profile));
         assert!(
             checks
                 .iter()
@@ -2987,14 +2988,15 @@ mod tests {
         let mut registry = tcl_registry::CommandRegistry::build_default();
         registry.load_irules();
         let src = "when CLIENT_ACCEPTED { drop }\n";
+        let profile = tcl_dialect::DialectProfile::by_name("f5-irules");
         let cu = CompilationUnit::build_for_with_config(
             src,
             &registry,
             false,
             LexerConfig::for_dialect("f5-irules"),
         )
-        .with_interprocedural(&registry, Some("f5-irules"));
-        let checks = run_all_checks(&cu, &registry, Some("f5-irules"));
+        .with_interprocedural(&registry, Some(profile));
+        let checks = run_all_checks(&cu, &registry, Some(profile));
 
         let mut disabled = std::collections::HashSet::new();
         disabled.insert("IRULE5002".to_string());

--- a/rust/tcl-lsp-core/src/completion.rs
+++ b/rust/tcl-lsp-core/src/completion.rs
@@ -703,8 +703,9 @@ pub fn completions(
         // only *present* once the Tk package is loaded — the `tk` dialect (a
         // `wish` document) or a `package require Tk` in this file.  Without
         // that, a plain `.tcl` script must not be offered `button`/`pack`/… .
-        let tk_loaded =
-            dialect == "tk" || analysis.package_requires.iter().any(|req| req.name == "Tk");
+        let tk_loaded = tcl_dialect::DialectSet::parse(dialect)
+            .is_some_and(|set| set.contains(tcl_dialect::DialectSet::TK))
+            || analysis.package_requires.iter().any(|req| req.name == "Tk");
         let oo_frame = oo_frame_at(analysis, source, line, character, &line_index);
         items.extend(builtin_completions(
             registry, dialect, &partial, &usage, tk_loaded, analysis, oo_frame,
@@ -2309,8 +2310,9 @@ fn fuzzy_command_fallback(
     }
     universe.extend(proc_completions(analysis, "", &usage));
     if let Some(registry) = registry {
-        let tk_loaded =
-            dialect == "tk" || analysis.package_requires.iter().any(|req| req.name == "Tk");
+        let tk_loaded = tcl_dialect::DialectSet::parse(dialect)
+            .is_some_and(|set| set.contains(tcl_dialect::DialectSet::TK))
+            || analysis.package_requires.iter().any(|req| req.name == "Tk");
         let oo_frame = oo_frame_at(analysis, source, line, character, line_index);
         universe.extend(builtin_completions(
             registry, dialect, "", &usage, tk_loaded, analysis, oo_frame,

--- a/rust/tcl-lsp-core/src/graphs.rs
+++ b/rust/tcl-lsp-core/src/graphs.rs
@@ -449,8 +449,9 @@ pub fn call_graph(source: &str, registry: &CommandRegistry, dialect: &str) -> Va
     // Build the full compilation unit (via `ensure_compilation_unit`) so the
     // interprocedural pass sees the same lowered IR — raw `lower_to_ir` alone
     // does not surface nested `[cmd …]` call sites to the call scanner.
-    let cu = CompilationUnit::build_for_dialect(source, registry, false, dialect)
-        .with_interprocedural(registry, Some(dialect));
+    let profile = DialectProfile::by_name(dialect);
+    let cu = CompilationUnit::build_for_profile(source, registry, false, profile)
+        .with_interprocedural(registry, Some(profile));
     let ir_module = &cu.ir_module;
     let interproc = cu
         .interproc
@@ -575,6 +576,7 @@ struct TaintWarnCtx<'a> {
 /// yields a `variable` + `sink_command` (the path-concat warning is a
 /// `TaintWarning` with `sink_command="set"`; the Rust `PathConcatWarning`
 /// carries no command field, so we supply the same constant).
+#[allow(clippy::too_many_lines)] // fixed diagnostic-family ordering mirrors compiler_checks.
 fn collect_taint_warnings(
     fu: &FunctionUnit,
     taints: &std::collections::HashMap<
@@ -591,6 +593,7 @@ fn collect_taint_warnings(
         module_traces,
         line_index,
     } = ctx;
+    let profile = DialectProfile::by_name(dialect);
     let mut push = |code: &str, span: Span, message: &str, variable: &str, sink: &str| {
         out.push(json!({
             "code": code,
@@ -624,7 +627,7 @@ fn collect_taint_warnings(
         taints,
         &fu.sccp.executable_blocks,
         registry,
-        Some(dialect),
+        Some(profile),
         &shadowed,
     ) {
         push(
@@ -639,14 +642,14 @@ fn collect_taint_warnings(
     // 2 + 3. Setter-constraint + uri-split are iRules-only. The helpers
     // gate internally too; skipping the walk under a non-iRules dialect
     // matches `compiler_checks` and avoids needless work.
-    if is_irules_dialect(Some(dialect)) {
+    if is_irules_dialect(Some(profile)) {
         for w in find_setter_constraint_warnings(
             registry,
             &fu.cfg,
             &fu.ssa,
             taints,
             &fu.sccp.executable_blocks,
-            Some(dialect),
+            Some(profile),
         ) {
             push(
                 w.code.as_str(),
@@ -662,7 +665,7 @@ fn collect_taint_warnings(
             Some(&fu.sccp.values),
             &fu.sccp.executable_blocks,
             registry,
-            Some(dialect),
+            Some(profile),
         ) {
             push(
                 w.code.as_str(),
@@ -761,8 +764,9 @@ fn tainted_var_names(fu: &FunctionUnit) -> Vec<&str> {
 /// Build the dataflow / taint graph payload.
 #[must_use]
 pub fn dataflow_graph(source: &str, registry: &CommandRegistry, dialect: &str) -> Value {
-    let cu = CompilationUnit::build_for_dialect(source, registry, false, dialect)
-        .with_interprocedural(registry, Some(dialect));
+    let profile = DialectProfile::by_name(dialect);
+    let cu = CompilationUnit::build_for_profile(source, registry, false, profile)
+        .with_interprocedural(registry, Some(profile));
     let line_index = LineIndex::new(source);
 
     let mut proc_names: Vec<&String> = cu.procedures.keys().collect();
@@ -774,7 +778,7 @@ pub fn dataflow_graph(source: &str, registry: &CommandRegistry, dialect: &str) -
     // `find_taint_warnings`. The `tainted_variables` listing below keeps the
     // per-unit `fu.taints` lattice.
     let solved =
-        tcl_compiler::taint_interproc::solve_interprocedural_taints(&cu, registry, Some(dialect));
+        tcl_compiler::taint_interproc::solve_interprocedural_taints(&cu, registry, Some(profile));
 
     // Taint warnings: top level first, then each procedure.
     let shadow_proc_qnames: std::collections::HashSet<&str> =
@@ -936,8 +940,9 @@ pub fn def_use_graph(source: &str, registry: &CommandRegistry, dialect: &str) ->
         }
     }
 
-    let cu = CompilationUnit::build_for_dialect(source, registry, false, dialect)
-        .with_interprocedural(registry, Some(dialect));
+    let profile = DialectProfile::by_name(dialect);
+    let cu = CompilationUnit::build_for_profile(source, registry, false, profile)
+        .with_interprocedural(registry, Some(profile));
 
     let mut proc_names: Vec<&String> = cu.procedures.keys().collect();
     proc_names.sort();
@@ -1005,9 +1010,10 @@ fn memory_function_json(
 /// `variable`) with the reason and locations, plus memory-op counts.
 #[must_use]
 pub fn memory_alias_graph(source: &str, registry: &CommandRegistry, dialect: &str) -> Value {
-    let cu = CompilationUnit::build_for_dialect(source, registry, false, dialect)
-        .with_interprocedural(registry, Some(dialect))
-        .with_memory_ssa(registry, DialectProfile::by_name(dialect).availability_mask);
+    let profile = DialectProfile::by_name(dialect);
+    let cu = CompilationUnit::build_for_profile(source, registry, false, profile)
+        .with_interprocedural(registry, Some(profile))
+        .with_memory_ssa(registry, profile.availability_mask);
 
     let mut functions: Vec<Value> = vec![memory_function_json(
         "::top",

--- a/rust/tcl-lsp-core/src/minify.rs
+++ b/rust/tcl-lsp-core/src/minify.rs
@@ -570,8 +570,9 @@ pub fn minify_tcl_aggressive_with(
     let original_length = source.len();
 
     // Phase 1: apply the optimiser's semantic-preserving rewrites.
+    let profile = tcl_dialect::DialectProfile::by_name(dialect);
     let optimisations =
-        tcl_compiler::optimiser::optimise_with_dialect(source, registry, Some(dialect));
+        tcl_compiler::optimiser::optimise_with_dialect(source, registry, Some(profile));
     let opt_count = optimisations.iter().filter(|o| !o.hint_only).count();
     let opt_edits: Vec<Edit> = optimisations
         .iter()

--- a/rust/tcl-lsp-core/tests/code_actions_depth.rs
+++ b/rust/tcl-lsp-core/tests/code_actions_depth.rs
@@ -98,14 +98,15 @@ fn irules_checks(
     source: &str,
     registry: &tcl_registry::CommandRegistry,
 ) -> Vec<tcl_compiler::compiler_checks::Diagnostic> {
+    let profile = tcl_dialect::DialectProfile::by_name("f5-irules");
     let cu = CompilationUnit::build_for_with_config(
         source,
         registry,
         false,
         LexerConfig::for_dialect("f5-irules"),
     )
-    .with_interprocedural(registry, Some("f5-irules"));
-    run_all_checks(&cu, registry, Some("f5-irules"))
+    .with_interprocedural(registry, Some(profile));
+    run_all_checks(&cu, registry, Some(profile))
 }
 
 /// A single-position (empty) `LspRange` at `(line, character)`.

--- a/rust/tcl-lsp-db/examples/tail_profile.rs
+++ b/rust/tcl-lsp-db/examples/tail_profile.rs
@@ -142,17 +142,18 @@ fn main() {
     println!("\n== compiler-check tail breakdown (whole-file, no memo) ==");
     let registry = db.registry(dialect);
     let cfg_lexer = tcl_lexer::LexerConfig::for_dialect(dialect);
+    let profile = tcl_dialect::DialectProfile::by_name(dialect);
     let build = || {
         CompilationUnit::build_for_with_config(&src, registry, false, cfg_lexer)
-            .with_interprocedural(registry, Some(dialect))
+            .with_interprocedural(registry, Some(profile))
     };
     time("CompilationUnit::build_for + interproc", 3, build);
     let cu = build();
     time("run_all_checks", 3, || {
-        tcl_compiler::compiler_checks::run_all_checks(&cu, registry, Some(dialect))
+        tcl_compiler::compiler_checks::run_all_checks(&cu, registry, Some(profile))
     });
     time("optimise_unit", 3, || {
-        tcl_compiler::optimiser::optimise_unit(&cu, registry, Some(dialect))
+        tcl_compiler::optimiser::optimise_unit(&cu, registry, Some(profile))
     });
     println!("  (functions in unit: {})", cu.functions().count());
 
@@ -161,16 +162,16 @@ fn main() {
     // memo; the whole-unit interproc taint solve does not.
     println!("\n== run_all_checks phase decomposition (whole-file, no memo) ==");
     let t_gvn = time("GVN redundancy/partial/loop (per-fn)", 3, || {
-        find_redundancies_for_cu(&cu, registry, Some(dialect)).len()
-            + find_partial_redundancies_for_cu(&cu, registry, Some(dialect)).len()
-            + find_loop_invariants_for_cu(&cu, registry, Some(dialect)).len()
+        find_redundancies_for_cu(&cu, registry, Some(profile)).len()
+            + find_partial_redundancies_for_cu(&cu, registry, Some(profile)).len()
+            + find_loop_invariants_for_cu(&cu, registry, Some(profile)).len()
     });
     let t_shimmer = time("shimmer + thunking (per-fn)", 3, || {
         find_shimmer_warnings_for_cu(&cu, registry).len()
             + find_thunking_warnings_for_cu(&cu, registry).len()
     });
     let t_taint = time("solve_interprocedural_taints (whole-unit)", 3, || {
-        solve_interprocedural_taints(&cu, registry, Some(dialect))
+        solve_interprocedural_taints(&cu, registry, Some(profile))
     });
     println!(
         "  per-function (GVN+shimmer) ~ {:.0} ms  |  whole-unit taint solve ~ {:.0} ms",

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -1796,7 +1796,7 @@ fn build_unit_with_keys<'db>(
         registry, config, ..
     } = options;
     let dialect = options.dialect;
-    let dialect_opt = tcl_dialect::DialectProfile::find(dialect);
+    let dialect_opt = tcl_dialect::DialectProfile::resolve_known(dialect);
     // The module CFG context is the same for every procedure in this build;
     // intern it once on the first request and reuse the id (O(procs), not
     // O(procs²)).
@@ -2020,7 +2020,7 @@ pub fn taint_cascade<'db>(
 ) -> Arc<HashMap<ValueKey, TaintLattice>> {
     let baseline = function_lattice(db, lattice_key);
     let dialect = summary_key.dialect(db);
-    let dialect_opt = tcl_dialect::DialectProfile::find(dialect);
+    let dialect_opt = tcl_dialect::DialectProfile::resolve_known(dialect);
     let registry = db.registry(dialect);
 
     // Reconstruct the minimal summary: a stub per known name (resolution
@@ -2197,7 +2197,7 @@ pub fn proc_summary_cascade<'db>(
     let qname = lattice_key.qname(db);
     let params = lattice_key.params(db);
     let dialect = deps_key.dialect(db);
-    let dialect_opt = tcl_dialect::DialectProfile::find(dialect);
+    let dialect_opt = tcl_dialect::DialectProfile::resolve_known(dialect);
     let registry = db.registry(dialect);
 
     // Reconstruct the minimal interproc summary (stub per known name + real
@@ -2257,7 +2257,7 @@ pub fn proc_summary_cascade<'db>(
 pub fn function_checks<'db>(db: &'db dyn TclDb, key: FnLatticeKey<'db>) -> Arc<Vec<CompilerCheck>> {
     let fu = function_lattice(db, key);
     let dialect = key.dialect(db);
-    let dialect_opt = tcl_dialect::DialectProfile::find(dialect);
+    let dialect_opt = tcl_dialect::DialectProfile::resolve_known(dialect);
     let registry = db.registry(dialect);
     // Per-procedure memo — procs have no implicit instance variables.
     Arc::new(tcl_compiler::compiler_checks::function_nontaint_checks(
@@ -2340,7 +2340,7 @@ pub fn proc_taint_solve<'db>(
     cfg: LexerCfgKey<'db>,
 ) -> Arc<CheckSolve> {
     let dialect = file.dialect(db).clone();
-    let dialect_opt = tcl_dialect::DialectProfile::find(&dialect);
+    let dialect_opt = tcl_dialect::DialectProfile::resolve_known(&dialect);
     let registry = db.registry(&dialect);
     let external = file.external_call_sites(db).clone();
     let (cu, lattice_keys) = build_unit_with_keys(
@@ -2472,7 +2472,7 @@ pub fn proc_taint_solve<'db>(
         &cu,
         &lattice_keys,
         registry,
-        tcl_dialect::DialectProfile::find(&dialect),
+        tcl_dialect::DialectProfile::resolve_known(&dialect),
     );
     Arc::new(CheckSolve {
         taints,
@@ -2683,7 +2683,7 @@ pub fn function_optimisations<'db>(
     let params = key.params(db).clone();
     let body = key.body(db).clone();
     let dialect = key.dialect(db).clone();
-    let dialect_opt = tcl_dialect::DialectProfile::find(&dialect);
+    let dialect_opt = tcl_dialect::DialectProfile::resolve_known(&dialect);
     let registry = db.registry(&dialect);
     let body_source = deps.body_source(db).clone();
 
@@ -3166,7 +3166,7 @@ pub fn compiler_check_diagnostics(
     config: AnalyserConfig,
 ) -> Arc<CompilerDiagnostics> {
     let dialect = file.dialect(db).clone();
-    let dialect_opt = tcl_dialect::DialectProfile::find(&dialect);
+    let dialect_opt = tcl_dialect::DialectProfile::resolve_known(&dialect);
     let registry = db.registry(&dialect);
     // Share the analyser tail's build via the [`compilation_unit`] query when the
     // dialect's lexer config matches the default (every dialect but `tcl8.4` /
@@ -3212,7 +3212,7 @@ pub fn compiler_check_diagnostics_uncached(
     generic_patterns: Option<&[String]>,
     external_call_sites: Option<&CallSiteEvidence>,
 ) -> CompilerDiagnostics {
-    let dialect_opt = tcl_dialect::DialectProfile::find(dialect);
+    let dialect_opt = tcl_dialect::DialectProfile::resolve_known(dialect);
     let cu = CompilationUnit::build_with_options(
         text,
         UnitBuildOptions {
@@ -3227,7 +3227,7 @@ pub fn compiler_check_diagnostics_uncached(
     compiler_diagnostics_from_unit(
         &cu,
         registry,
-        tcl_dialect::DialectProfile::find(dialect),
+        tcl_dialect::DialectProfile::resolve_known(dialect),
         generic_patterns,
     )
 }

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -2467,7 +2467,13 @@ pub fn proc_taint_solve<'db>(
         }
     }
 
-    let optimisations = solve_optimisations(db, &cu, &lattice_keys, registry, dialect_opt);
+    let optimisations = solve_optimisations(
+        db,
+        &cu,
+        &lattice_keys,
+        registry,
+        tcl_dialect::DialectProfile::find(&dialect),
+    );
     Arc::new(CheckSolve {
         taints,
         fn_checks,
@@ -2816,7 +2822,7 @@ fn solve_optimisations<'db>(
     cu: &CompilationUnit,
     lattice_keys: &HashMap<String, FnLatticeKey<'db>>,
     registry: &CommandRegistry,
-    dialect_opt: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
 ) -> Vec<Optimisation> {
     let mutations =
         tcl_compiler::command_binding::scan_module_command_mutations(&cu.ir_module, registry);
@@ -2824,7 +2830,8 @@ fn solve_optimisations<'db>(
         .procedures
         .keys()
         .all(|qname| lattice_keys.contains_key(qname));
-    let is_irules = tcl_compiler::taint::is_irules_dialect(dialect_opt);
+    let is_irules = dialect.is_some_and(tcl_dialect::DialectProfile::is_irules);
+    let dialect_opt = dialect.map(|profile| profile.name);
     // The **argument-sensitive** O103 fold re-runs a *pure* callee's body with the
     // call's constant arguments (`evaluate_proc_with_constants`), so it reads the
     // callee's whole `FunctionUnit` (`cu.procedures.get(callee)`), not just its
@@ -3129,9 +3136,10 @@ pub struct CompilerDiagnostics {
 fn compiler_diagnostics_from_unit(
     cu: &CompilationUnit,
     registry: &CommandRegistry,
-    dialect_opt: Option<&str>,
+    dialect: Option<&tcl_dialect::DialectProfile>,
     generic_patterns: Option<&[String]>,
 ) -> CompilerDiagnostics {
+    let dialect_opt = dialect.map(|profile| profile.name);
     CompilerDiagnostics {
         checks: tcl_compiler::compiler_checks::run_all_checks_with_generic_patterns(
             cu,
@@ -3216,7 +3224,12 @@ pub fn compiler_check_diagnostics_uncached(
         },
     )
     .with_interprocedural(registry, dialect_opt);
-    compiler_diagnostics_from_unit(&cu, registry, dialect_opt, generic_patterns)
+    compiler_diagnostics_from_unit(
+        &cu,
+        registry,
+        tcl_dialect::DialectProfile::find(dialect),
+        generic_patterns,
+    )
 }
 
 /// Document outline — wraps `document_symbols_from_analysis`, reusing the

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -1796,7 +1796,7 @@ fn build_unit_with_keys<'db>(
         registry, config, ..
     } = options;
     let dialect = options.dialect;
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
+    let dialect_opt = tcl_dialect::DialectProfile::find(dialect);
     // The module CFG context is the same for every procedure in this build;
     // intern it once on the first request and reuse the id (O(procs), not
     // O(procs²)).
@@ -2020,7 +2020,7 @@ pub fn taint_cascade<'db>(
 ) -> Arc<HashMap<ValueKey, TaintLattice>> {
     let baseline = function_lattice(db, lattice_key);
     let dialect = summary_key.dialect(db);
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect.as_str());
+    let dialect_opt = tcl_dialect::DialectProfile::find(dialect);
     let registry = db.registry(dialect);
 
     // Reconstruct the minimal summary: a stub per known name (resolution
@@ -2197,7 +2197,7 @@ pub fn proc_summary_cascade<'db>(
     let qname = lattice_key.qname(db);
     let params = lattice_key.params(db);
     let dialect = deps_key.dialect(db);
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect.as_str());
+    let dialect_opt = tcl_dialect::DialectProfile::find(dialect);
     let registry = db.registry(dialect);
 
     // Reconstruct the minimal interproc summary (stub per known name + real
@@ -2257,7 +2257,7 @@ pub fn proc_summary_cascade<'db>(
 pub fn function_checks<'db>(db: &'db dyn TclDb, key: FnLatticeKey<'db>) -> Arc<Vec<CompilerCheck>> {
     let fu = function_lattice(db, key);
     let dialect = key.dialect(db);
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect.as_str());
+    let dialect_opt = tcl_dialect::DialectProfile::find(dialect);
     let registry = db.registry(dialect);
     // Per-procedure memo — procs have no implicit instance variables.
     Arc::new(tcl_compiler::compiler_checks::function_nontaint_checks(
@@ -2340,7 +2340,7 @@ pub fn proc_taint_solve<'db>(
     cfg: LexerCfgKey<'db>,
 ) -> Arc<CheckSolve> {
     let dialect = file.dialect(db).clone();
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect.as_str());
+    let dialect_opt = tcl_dialect::DialectProfile::find(&dialect);
     let registry = db.registry(&dialect);
     let external = file.external_call_sites(db).clone();
     let (cu, lattice_keys) = build_unit_with_keys(
@@ -2683,7 +2683,7 @@ pub fn function_optimisations<'db>(
     let params = key.params(db).clone();
     let body = key.body(db).clone();
     let dialect = key.dialect(db).clone();
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect.as_str());
+    let dialect_opt = tcl_dialect::DialectProfile::find(&dialect);
     let registry = db.registry(&dialect);
     let body_source = deps.body_source(db).clone();
 
@@ -2732,7 +2732,7 @@ pub fn function_optimisations<'db>(
         // release is a trap for the next consumer: `numbers_for_dialect(None)`
         // silently means Tcl 9.0, so a future reader would mis-fold rather than
         // fail. Cheap to keep honest, expensive to debug later.
-        dialect: dialect_opt.map(str::to_owned),
+        dialect: dialect_opt.map(|profile| profile.name.to_owned()),
         top_level: tcl_compiler::ir::Script::new(),
         procedures: ir_procs,
         methods: HashMap::new(),
@@ -2831,7 +2831,7 @@ fn solve_optimisations<'db>(
         .keys()
         .all(|qname| lattice_keys.contains_key(qname));
     let is_irules = dialect.is_some_and(tcl_dialect::DialectProfile::is_irules);
-    let dialect_opt = dialect.map(|profile| profile.name);
+    let dialect_opt = dialect;
     // The **argument-sensitive** O103 fold re-runs a *pure* callee's body with the
     // call's constant arguments (`evaluate_proc_with_constants`), so it reads the
     // callee's whole `FunctionUnit` (`cu.procedures.get(callee)`), not just its
@@ -3139,7 +3139,7 @@ fn compiler_diagnostics_from_unit(
     dialect: Option<&tcl_dialect::DialectProfile>,
     generic_patterns: Option<&[String]>,
 ) -> CompilerDiagnostics {
-    let dialect_opt = dialect.map(|profile| profile.name);
+    let dialect_opt = dialect;
     CompilerDiagnostics {
         checks: tcl_compiler::compiler_checks::run_all_checks_with_generic_patterns(
             cu,
@@ -3166,7 +3166,7 @@ pub fn compiler_check_diagnostics(
     config: AnalyserConfig,
 ) -> Arc<CompilerDiagnostics> {
     let dialect = file.dialect(db).clone();
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect.as_str());
+    let dialect_opt = tcl_dialect::DialectProfile::find(&dialect);
     let registry = db.registry(&dialect);
     // Share the analyser tail's build via the [`compilation_unit`] query when the
     // dialect's lexer config matches the default (every dialect but `tcl8.4` /
@@ -3212,7 +3212,7 @@ pub fn compiler_check_diagnostics_uncached(
     generic_patterns: Option<&[String]>,
     external_call_sites: Option<&CallSiteEvidence>,
 ) -> CompilerDiagnostics {
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
+    let dialect_opt = tcl_dialect::DialectProfile::find(dialect);
     let cu = CompilationUnit::build_with_options(
         text,
         UnitBuildOptions {

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -10684,7 +10684,7 @@ impl Backend {
         let dialect = doc.dialect.clone();
         let value = crate::rt::spawn_blocking(move || {
             tcl_spectcl::hooks::ensure_thread_host();
-            let dialect_opt = Some(dialect.as_str());
+            let dialect_opt = tcl_dialect::DialectProfile::find(&dialect);
             let (source, opts) = if profile == "full" {
                 tcl_compiler::optimiser::optimise_source_multipass(&text, &registry, dialect_opt, 5)
             } else {

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -4395,6 +4395,36 @@ pub struct Backend {
     store: Arc<dyn vfs::SourceStore>,
 }
 
+/// A known editor language ID after its ingress spelling has been resolved.
+///
+/// Most IDs map to a full catalog profile; `tk` is a library-shell dialect
+/// represented directly by its singleton [`DialectSet`] bit until the catalog
+/// grows a dedicated profile. Keeping both cases typed prevents the language
+/// ID table from leaking a raw dialect string into server routing.
+#[derive(Clone, Copy)]
+enum LanguageDialect {
+    Profile(&'static tcl_dialect::DialectProfile),
+    Set(DialectSet),
+}
+
+impl LanguageDialect {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Profile(profile) => profile.name,
+            Self::Set(set) => set
+                .canonical_name()
+                .expect("language-id dialect sets are singleton bits"),
+        }
+    }
+
+    fn is_explicit_non_tcl(self) -> bool {
+        match self {
+            Self::Profile(profile) => !profile.name.starts_with("tcl"),
+            Self::Set(_) => true,
+        }
+    }
+}
+
 /// Every per-document-URI cache [`Backend`] holds, borrowed as one group.
 ///
 /// Built only by [`Backend::per_uri_caches`] — whose exhaustive destructuring of
@@ -5964,7 +5994,7 @@ impl Backend {
         // harness open ``bigip.conf`` with ``languageId: "tcl"`` and still
         // get the BIG-IP path (parse / outline + general-Tcl-diagnostic
         // suppression).
-        let explicit_non_tcl = matches!(lang_dialect, Some(d) if !d.starts_with("tcl"));
+        let explicit_non_tcl = lang_dialect.is_some_and(LanguageDialect::is_explicit_non_tcl);
         if !explicit_non_tcl && core_bigip::is_bigip_conf_name(uri.as_str()) {
             return "f5-bigip".to_owned();
         }
@@ -6014,7 +6044,7 @@ impl Backend {
         if language_id != "tcl"
             && let Some(d) = lang_dialect
         {
-            return d.to_owned();
+            return d.name().to_owned();
         }
         if let Some(d) = folder_dialect_for(uri, folder_dialects) {
             return d;
@@ -6026,7 +6056,8 @@ impl Backend {
     /// signal every BIG-IP-specific branch (analysis suppression,
     /// config outline) keys on.
     fn is_bigip_dialect(dialect: &str) -> bool {
-        dialect == "f5-bigip"
+        tcl_dialect::DialectProfile::find(dialect)
+            .is_some_and(|profile| profile.availability_mask.contains(DialectSet::BIGIP))
     }
 
     /// Look up the per-folder dialect override for `uri`,
@@ -6037,7 +6068,7 @@ impl Backend {
     }
 
     /// Map an LSP ``languageId`` string to a dialect name accepted
-    /// by ``DialectSet::parse`` / the providers' ``dialect`` arg.
+    /// by the dialect catalog / the providers' ``dialect`` arg.
     ///
     /// Recognises the editor-extension language ids
     /// (``tcl-irule`` → ``f5-irules``, etc.) plus the canonical
@@ -6045,7 +6076,7 @@ impl Backend {
     /// (``f5-irules``, ``tcl9.0``, …).  Returns ``None`` when the
     /// language id does not name a known dialect — the caller falls
     /// back to the session default.
-    fn dialect_from_language_id(language_id: &str) -> Option<&'static str> {
+    fn dialect_from_language_id(language_id: &str) -> Option<LanguageDialect> {
         // Group editor language ids alongside the canonical dialect
         // name they map to so callers in either world land on the
         // string the registry / provider trait expects.
@@ -6086,15 +6117,12 @@ impl Backend {
             "tk" => "tk",
             _ => return None,
         };
-        // Sanity-check the mapped string is something the registry accepts;
-        // guards against typos in the table. A catalog profile (the EDA shells
-        // included — they are packaged dialects with no DialectSet bit) or a
-        // parseable library shell (`tk`).
-        debug_assert!(
-            tcl_dialect::DialectProfile::find(mapped).is_some()
-                || DialectSet::parse(mapped).is_some()
-        );
-        Some(mapped)
+        // The table is an editor-ID ingress boundary. It resolves straight to
+        // the interned profile so aliases and command consumers cannot retain
+        // a free-text dialect spelling after this point.
+        tcl_dialect::DialectProfile::find(mapped)
+            .map(LanguageDialect::Profile)
+            .or_else(|| DialectSet::parse(mapped).map(LanguageDialect::Set))
     }
 
     /// Barrier: block until every document-sync notification the client sent
@@ -25969,30 +25997,36 @@ mod tests {
     #[test]
     fn dialect_from_language_id_recognises_editor_ids() {
         assert_eq!(
-            Backend::dialect_from_language_id("tcl-irule"),
+            Backend::dialect_from_language_id("tcl-irule").map(LanguageDialect::name),
             Some("f5-irules"),
         );
         assert_eq!(
-            Backend::dialect_from_language_id("tcl-iapp"),
+            Backend::dialect_from_language_id("tcl-iapp").map(LanguageDialect::name),
             Some("f5-iapps"),
         );
         // APL presentation files are an iApp sublanguage → f5-iapps.
         assert_eq!(
-            Backend::dialect_from_language_id("tcl-apl"),
+            Backend::dialect_from_language_id("tcl-apl").map(LanguageDialect::name),
             Some("f5-iapps"),
         );
-        assert_eq!(Backend::dialect_from_language_id("tcl"), Some("tcl8.6"));
+        assert_eq!(
+            Backend::dialect_from_language_id("tcl").map(LanguageDialect::name),
+            Some("tcl8.6")
+        );
     }
 
     #[test]
     fn dialect_from_language_id_passes_through_canonical_names() {
         assert_eq!(
-            Backend::dialect_from_language_id("f5-irules"),
+            Backend::dialect_from_language_id("f5-irules").map(LanguageDialect::name),
             Some("f5-irules"),
         );
-        assert_eq!(Backend::dialect_from_language_id("tcl9.0"), Some("tcl9.0"),);
         assert_eq!(
-            Backend::dialect_from_language_id("synopsys-eda-tcl"),
+            Backend::dialect_from_language_id("tcl9.0").map(LanguageDialect::name),
+            Some("tcl9.0"),
+        );
+        assert_eq!(
+            Backend::dialect_from_language_id("synopsys-eda-tcl").map(LanguageDialect::name),
             Some("synopsys-eda-tcl"),
         );
     }
@@ -26012,12 +26046,12 @@ mod tests {
             ("tcl91", "tcl9.1"),
         ] {
             assert_eq!(
-                Backend::dialect_from_language_id(undotted),
+                Backend::dialect_from_language_id(undotted).map(LanguageDialect::name),
                 Some(dotted),
                 "undotted VS Code language id `{undotted}` should map to dialect `{dotted}`",
             );
             assert_eq!(
-                Backend::dialect_from_language_id(dotted),
+                Backend::dialect_from_language_id(dotted).map(LanguageDialect::name),
                 Some(dotted),
                 "dotted language id `{dotted}` must keep working for non-VS Code editors",
             );
@@ -35233,5 +35267,12 @@ mod tests {
         assert_eq!(cross[0].to.name, "::helper");
         assert_eq!(cross[0].to.uri, lib);
         assert_eq!(cross[0].from_ranges.len(), 1, "{cross:?}");
+    }
+
+    #[test]
+    fn bigip_routing_uses_the_profile_availability_fact() {
+        assert!(Backend::is_bigip_dialect("f5-bigip"));
+        assert!(!Backend::is_bigip_dialect("f5-irules"));
+        assert!(!Backend::is_bigip_dialect("not-a-real-dialect"));
     }
 }

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -10684,7 +10684,7 @@ impl Backend {
         let dialect = doc.dialect.clone();
         let value = crate::rt::spawn_blocking(move || {
             tcl_spectcl::hooks::ensure_thread_host();
-            let dialect_opt = tcl_dialect::DialectProfile::find(&dialect);
+            let dialect_opt = tcl_dialect::DialectProfile::resolve_known(&dialect);
             let (source, opts) = if profile == "full" {
                 tcl_compiler::optimiser::optimise_source_multipass(&text, &registry, dialect_opt, 5)
             } else {

--- a/rust/tcl-lsp-server/tests/e2e/commands.rs
+++ b/rust/tcl-lsp-server/tests/e2e/commands.rs
@@ -171,6 +171,31 @@ fn optimise_returns_optimisation_offers() {
 }
 
 #[test]
+fn optimise_document_preserves_set_only_tk_profile() {
+    // Tk is a valid additive dialect surface, but it is intentionally absent
+    // from the catalog. The optimiser must receive its typed profile rather
+    // than `None`, whose unknown-dialect fallback would offer Tcl 8.6's
+    // `tailcall` rewrite for this recursive Tk script.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tk");
+    lsp.open_ready_lang(&uri, "proc recurse {} { recurse }\n", "tk");
+    let result = lsp.execute_command("tcl-lsp.optimiseDocument", json!([uri, "full"]));
+    let codes = result
+        .get("optimisations")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|item| item.get("code").and_then(Value::as_str))
+        .collect::<std::collections::BTreeSet<_>>();
+    assert!(
+        !codes.contains("O121"),
+        "Tk must not offer tailcall: {result:?}"
+    );
+    assert!(source(&result).contains("recurse"), "{result:?}");
+    assert!(!source(&result).contains("tailcall"), "{result:?}");
+}
+
+#[test]
 fn optimise_document_does_not_forward_across_a_variable_trace() {
     // Regression for a confirmed silent miscompile: `tcl-lsp.optimiseDocument`
     // (`profile: "full"`) previously rewrote this to `puts 5`, dropping the

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -90,6 +90,17 @@ fn unbraced_expr_is_w100() {
 }
 
 #[test]
+fn tk_diagnostics_do_not_offer_tailcall() {
+    // The memoised diagnostics path receives Tk as a set-only dialect. It must
+    // retain the typed profile rather than use the unknown-dialect optimiser
+    // default, which would incorrectly offer Tcl 8.6's O121 tailcall rewrite.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tk");
+    let diagnostics = lsp.open_ready_lang(&uri, "proc recurse {} { recurse }\n", "tk");
+    assert!(!has_code(&diagnostics, "O121"), "{diagnostics:?}");
+}
+
+#[test]
 fn catch_without_result_is_w302() {
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");

--- a/rust/tcl-mcp/src/tools.rs
+++ b/rust/tcl-mcp/src/tools.rs
@@ -26,7 +26,7 @@ use std::collections::HashSet;
 
 use serde_json::{Map, Value, json};
 use tcl_compiler::analyser::{Analyser, AnalysisResult, Diagnostic};
-use tcl_dialect::KNOWN_DIALECTS;
+use tcl_dialect::{DialectProfile, KNOWN_DIALECTS};
 use tcl_lexer::{LineIndex, SourceMap, Span, Utf16Col};
 use tcl_lsp_core::definition::LspRange;
 use tcl_registry::CommandRegistry;
@@ -428,8 +428,9 @@ fn compile_wasm(args: &Value) -> Value {
     let source = arg_str(args, "source");
     let dialect = resolve_dialect(args, source);
     let registry = registry(&dialect);
-    let unit = tcl_compiler::compilation_unit::CompilationUnit::build_for_dialect(
-        source, &registry, false, &dialect,
+    let profile = DialectProfile::by_name(&dialect);
+    let unit = tcl_compiler::compilation_unit::CompilationUnit::build_for_profile(
+        source, &registry, false, profile,
     );
     let mut wasm = tcl_compiler::codegen::wasm::compile_wasm(
         &unit,

--- a/rust/tcl-mcp/src/tools.rs
+++ b/rust/tcl-mcp/src/tools.rs
@@ -383,7 +383,7 @@ fn optimize(args: &Value) -> Value {
     let (optimised, opts, iterations) = optimise_source_multipass_filtered(
         source,
         &registry(&dialect),
-        Some(dialect.as_str()),
+        Some(tcl_dialect::DialectProfile::by_name(&dialect)),
         profile.max_iterations(),
         &disabled,
     );

--- a/rust/tcl-registry/src/commands/tcl/namespace_.rs
+++ b/rust/tcl-registry/src/commands/tcl/namespace_.rs
@@ -1281,11 +1281,13 @@ mod tests {
             .find(|s| s.name == "tail")
             .expect("tail subcommand");
         assert_eq!(
-            q.run_const_fold(&["::a::b::c"], Some("tcl9.0")).as_deref(),
+            q.run_const_fold(&["::a::b::c"], Some(tcl_dialect::TclVersion::V9_0))
+                .as_deref(),
             Some("::a::b")
         );
         assert_eq!(
-            t.run_const_fold(&["::a::b::c"], Some("tcl8.6")).as_deref(),
+            t.run_const_fold(&["::a::b::c"], Some(tcl_dialect::TclVersion::V8_6))
+                .as_deref(),
             Some("c")
         );
     }

--- a/rust/tcl-registry/src/commands/tcl/regsub_.rs
+++ b/rust/tcl-registry/src/commands/tcl/regsub_.rs
@@ -257,16 +257,25 @@ mod tests {
         let registry = crate::CommandRegistry::build_default();
         let spec = registry.get("regsub").unwrap();
         assert_eq!(
-            spec.run_const_fold(&["-all", "::+", "::::clay", "::"], Some("tcl9.0")),
+            spec.run_const_fold(
+                &["-all", "::+", "::::clay", "::"],
+                Some(tcl_dialect::TclVersion::V9_0)
+            ),
             Some("::clay".to_owned())
         );
         assert_eq!(
-            spec.run_const_fold(&["::+", "::clay", "::", "out"], Some("tcl9.0")),
+            spec.run_const_fold(
+                &["::+", "::clay", "::", "out"],
+                Some(tcl_dialect::TclVersion::V9_0)
+            ),
             None,
             "the variable-writing form is not a pure value fold"
         );
         assert_eq!(
-            spec.run_const_fold(&["-command", ".", "x", "callback"], Some("tcl9.0")),
+            spec.run_const_fold(
+                &["-command", ".", "x", "callback"],
+                Some(tcl_dialect::TclVersion::V9_0)
+            ),
             None,
             "analysis must never run a regsub callback"
         );

--- a/rust/tcl-registry/src/commands/tcl/string_.rs
+++ b/rust/tcl-registry/src/commands/tcl/string_.rs
@@ -2046,7 +2046,7 @@ mod tests {
             .expect("string is subcommand");
         assert!(sub.const_fold_versioned.is_some());
         assert_eq!(
-            sub.run_const_fold(&["alpha", "abc"], Some("tcl9.0"))
+            sub.run_const_fold(&["alpha", "abc"], Some(tcl_dialect::TclVersion::V9_0))
                 .as_deref(),
             Some("1")
         );
@@ -2124,7 +2124,7 @@ mod tests {
         let fold = |args: &[&str]| {
             spec.subcommand("match")
                 .unwrap()
-                .run_const_fold(args, Some("tcl9.0"))
+                .run_const_fold(args, Some(tcl_dialect::TclVersion::V9_0))
         };
         assert_eq!(fold(&["::*", "::clay"]), Some("1".to_owned()));
         assert_eq!(fold(&["::*", "clay"]), Some("0".to_owned()));

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -1926,16 +1926,15 @@ impl CommandSpec {
     };
 
     /// Run this command's constant folder for `args` under the optimiser's
-    /// `dialect` (`"tcl8.4"` … `"tcl9.0"`, or `None`/unversioned).  All the
-    /// dialect interpretation lives here in the registry layer: the
-    /// version-aware [`Self::const_fold_versioned`] is tried first (the dialect
-    /// is mapped to a [`TclVersion`] for it), falling back to the
-    /// version-invariant [`Self::const_fold`].  Downstream consumers just pass
-    /// the dialect they already have.
+    /// resolved Tcl `version`, or `None` when the caller has no version fact.
+    /// The version-aware [`Self::const_fold_versioned`] is tried first,
+    /// falling back to the version-invariant [`Self::const_fold`]. Dialect
+    /// names are resolved at the ingestion boundary; the registry never
+    /// reinterprets a free-form spelling.
     #[must_use]
-    pub fn run_const_fold(&self, args: &[&str], dialect: Option<&str>) -> Option<String> {
+    pub fn run_const_fold(&self, args: &[&str], version: Option<TclVersion>) -> Option<String> {
         if let Some(vf) = self.const_fold_versioned {
-            vf(args, TclVersion::from_dialect(dialect))
+            vf(args, version)
         } else {
             self.const_fold?(args)
         }
@@ -3140,14 +3139,13 @@ impl SubCommand {
         }
     }
 
-    /// Run this subcommand's constant folder for `args` under `dialect` —
-    /// version-aware [`Self::const_fold_versioned`] first (mapping the dialect
-    /// to a [`TclVersion`]), else the invariant [`Self::const_fold`].  See
-    /// [`CommandSpec::run_const_fold`].
+    /// Run this subcommand's constant folder for `args` under a resolved Tcl
+    /// `version`, trying [`Self::const_fold_versioned`] first and then the
+    /// invariant [`Self::const_fold`]. See [`CommandSpec::run_const_fold`].
     #[must_use]
-    pub fn run_const_fold(&self, args: &[&str], dialect: Option<&str>) -> Option<String> {
+    pub fn run_const_fold(&self, args: &[&str], version: Option<TclVersion>) -> Option<String> {
         if let Some(vf) = self.const_fold_versioned {
-            vf(args, TclVersion::from_dialect(dialect))
+            vf(args, version)
         } else {
             self.const_fold?(args)
         }

--- a/rust/tcl-registry/tests/differential_fold.rs
+++ b/rust/tcl-registry/tests/differential_fold.rs
@@ -128,8 +128,10 @@ fn registry_fold(
 ) -> Option<String> {
     let spec = reg.get(head)?;
     match sub {
-        None => spec.run_const_fold(args, Some("tcl9.0")),
-        Some(s) => spec.subcommand(s)?.run_const_fold(args, Some("tcl9.0")),
+        None => spec.run_const_fold(args, Some(tcl_dialect::TclVersion::V9_0)),
+        Some(s) => spec
+            .subcommand(s)?
+            .run_const_fold(args, Some(tcl_dialect::TclVersion::V9_0)),
     }
 }
 

--- a/rust/tcl-syntax/src/expr/parser.rs
+++ b/rust/tcl-syntax/src/expr/parser.rs
@@ -44,7 +44,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use tcl_dialect::{DialectProfile, NumberSyntax, TclVersion};
-use tcl_lexer::{ExprToken, ExprTokenType, tokenise_expr_checked};
+use tcl_lexer::{ExprToken, ExprTokenType};
 
 use crate::expr::ast::{BinOp, ExprNode, UnaryOp};
 use crate::naming::normalise_var_name;
@@ -439,21 +439,35 @@ impl<'a> PrattParser<'a> {
 /// profile, so without this a runtime built for 8.6 would *parse* `0o17` as a
 /// number and then fail to *read* it as one, leaving the literal to evaluate to
 /// its own text — the silent-wrong-answer shape this whole change removes.
-pub(super) fn numbers_for(dialect: Option<&str>, profile: &DialectProfile) -> NumberSyntax {
-    if dialect.is_some() {
-        NumberSyntax::of_profile(Some(profile))
+pub(super) fn numbers_for(
+    profile: Option<&DialectProfile>,
+    resolved: &DialectProfile,
+) -> NumberSyntax {
+    if profile.is_some() {
+        NumberSyntax::of_profile(Some(resolved))
     } else {
         crate::number::runtime_syntax()
     }
 }
 
 #[must_use]
+/// Parse from a compatibility dialect-name boundary.
+///
+/// Typed callers should use [`parse_expr_for_profile`].
 pub fn parse_expr(source: &str, dialect: Option<&str>) -> ExprNode {
+    parse_expr_for_profile(source, dialect.map(DialectProfile::by_name))
+}
+
+/// Parse under an already-resolved dialect profile.
+#[must_use]
+pub fn parse_expr_for_profile(source: &str, profile: Option<&DialectProfile>) -> ExprNode {
     // Resolve the dialect string to its interned profile once and thread the
     // canonical name down — so the grammar branch in the expr lexer and the
     // cache key below can never disagree about what a given spelling means.
-    let profile = DialectProfile::by_opt_name(dialect);
-    let (raw_tokens, has_unknown) = tokenise_expr_checked(source, Some(profile.name));
+    let resolved = profile.map_or_else(DialectProfile::plain_tcl, |profile| {
+        DialectProfile::by_name(profile.name)
+    });
+    let (raw_tokens, has_unknown) = tcl_lexer::tokenise_expr_checked_for_profile(source, resolved);
 
     if has_unknown {
         return ExprNode::Raw {
@@ -474,8 +488,8 @@ pub fn parse_expr(source: &str, dialect: Option<&str>) -> ExprNode {
 
     let mut parser = PrattParser::new(
         &tokens,
-        numbers_for(dialect, profile),
-        profile.expr_grammar_base,
+        numbers_for(profile, resolved),
+        resolved.expr_grammar_base,
     );
     match parser.expression(0) {
         Ok(result) if parser.pos >= tokens.len() => result,
@@ -579,16 +593,30 @@ fn expr_cache() -> &'static Mutex<ExprCache> {
 /// on every iteration); use the un-cached [`parse_expr`] from
 /// once-per-invocation analyser sites.
 #[must_use]
+/// Cached parse from a compatibility dialect-name boundary.
+///
+/// Typed callers should use [`parse_expr_cached_for_profile`].
 pub fn parse_expr_cached(source: &str, dialect: Option<&str>) -> Arc<ExprNode> {
-    let profile = DialectProfile::by_opt_name(dialect);
-    let key: ExprCacheKey = (source.to_owned(), profile.name);
+    parse_expr_cached_for_profile(source, dialect.map(DialectProfile::by_name))
+}
+
+/// Cached expression parse under an already-resolved profile.
+#[must_use]
+pub fn parse_expr_cached_for_profile(
+    source: &str,
+    profile: Option<&DialectProfile>,
+) -> Arc<ExprNode> {
+    let resolved = profile.map_or_else(DialectProfile::plain_tcl, |profile| {
+        DialectProfile::by_name(profile.name)
+    });
+    let key: ExprCacheKey = (source.to_owned(), resolved.name);
     {
         let mut cache = expr_cache().lock().expect("expr cache mutex poisoned");
         if let Some(hit) = cache.get(&key) {
             return hit;
         }
     }
-    let parsed = Arc::new(parse_expr(source, dialect));
+    let parsed = Arc::new(parse_expr_for_profile(source, profile));
     {
         let mut cache = expr_cache().lock().expect("expr cache mutex poisoned");
         // A concurrent caller may have populated the same key

--- a/rust/tcl-syntax/src/expr/syntax_error.rs
+++ b/rust/tcl-syntax/src/expr/syntax_error.rs
@@ -37,7 +37,7 @@
 //! cases `parseExpr-21.1` … `parseExpr-21.31`.
 
 use tcl_dialect::{DialectProfile, TclVersion};
-use tcl_lexer::{ExprToken, ExprTokenType, tokenise_expr_checked};
+use tcl_lexer::{ExprToken, ExprTokenType};
 
 /// C's `limit` (`tclCompExpr.c:615`): the longest substring of the expression
 /// any part of the message quotes before eliding with `...`.
@@ -191,15 +191,24 @@ pub struct ExprSyntaxError {
 }
 
 impl ExprSyntaxError {
-    /// Diagnose why `source` does not parse as an expression under `dialect`.
+    /// Diagnose from a compatibility dialect-name boundary.
     ///
     /// Always returns an error: call it only for a source
     /// [`parse_expr`](super::parser::parse_expr) rejected, and pass the same
     /// dialect it was given so the two agree on which words are operators.
+    /// Typed callers use [`Self::diagnose_for_profile`].
     #[must_use]
     pub fn diagnose(source: &str, dialect: Option<&str>) -> Self {
-        let profile = DialectProfile::by_opt_name(dialect);
-        let (raw, has_unknown) = tokenise_expr_checked(source, Some(profile.name));
+        Self::diagnose_for_profile(source, dialect.map(DialectProfile::by_name))
+    }
+
+    /// Diagnose under an already-resolved dialect profile.
+    #[must_use]
+    pub fn diagnose_for_profile(source: &str, profile: Option<&DialectProfile>) -> Self {
+        let resolved = profile.map_or_else(DialectProfile::plain_tcl, |profile| {
+            DialectProfile::by_name(profile.name)
+        });
+        let (raw, has_unknown) = tcl_lexer::tokenise_expr_checked_for_profile(source, resolved);
         if has_unknown && let Some(error) = Self::first_invalid_character(source, &raw) {
             return error;
         }
@@ -207,8 +216,8 @@ impl ExprSyntaxError {
         Scan::new(
             source,
             &tokens,
-            super::parser::numbers_for(dialect, profile),
-            profile.expr_grammar_base,
+            super::parser::numbers_for(profile, resolved),
+            resolved.expr_grammar_base,
         )
         .run()
     }

--- a/rust/xtask/src/fp_sweep.rs
+++ b/rust/xtask/src/fp_sweep.rs
@@ -482,7 +482,7 @@ fn sweep_document(doc: &SweepDocument, wanted: &[DiagCode], out: &mut Vec<Firing
     let dialect = profile.name;
     let registry = registry_for_dialect(dialect);
     let line_index = LineIndex::new(&doc.input.source);
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
+    let dialect_opt = Some(profile);
 
     let mut push = |code: DiagCode, span: tcl_lexer::Span, message: String| {
         if !wanted.contains(&code) {

--- a/rust/xtask/src/fp_sweep.rs
+++ b/rust/xtask/src/fp_sweep.rs
@@ -475,12 +475,14 @@ fn shape_key(message: &str) -> String {
 /// 3. [`style_diagnostics`] — the pure-text W111/W112/W115/W118 checks,
 ///    which read raw source and are not part of either compiler pass.
 fn sweep_document(doc: &SweepDocument, wanted: &[DiagCode], out: &mut Vec<Firing>) {
-    let dialect = doc
+    let profile = doc
         .dialect_override
-        .map_or_else(|| doc.input.effective_dialect(None), str::to_owned);
-    let registry = registry_for_dialect(&dialect);
+        .and_then(tcl_dialect::DialectProfile::find)
+        .unwrap_or_else(|| doc.input.effective_dialect(None));
+    let dialect = profile.name;
+    let registry = registry_for_dialect(dialect);
     let line_index = LineIndex::new(&doc.input.source);
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect.as_str());
+    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
 
     let mut push = |code: DiagCode, span: tcl_lexer::Span, message: String| {
         if !wanted.contains(&code) {
@@ -490,7 +492,7 @@ fn sweep_document(doc: &SweepDocument, wanted: &[DiagCode], out: &mut Vec<Firing
         out.push(Firing {
             code,
             file: doc.input.label.clone(),
-            dialect: dialect.clone(),
+            dialect: dialect.to_owned(),
             line: pos.line + 1 + doc.line_offset,
             column: pos.character.get() + 1,
             message,
@@ -504,14 +506,14 @@ fn sweep_document(doc: &SweepDocument, wanted: &[DiagCode], out: &mut Vec<Firing
             registry,
             defer_top_level: false,
             config: tcl_lexer::LexerConfig::default(),
-            dialect: &dialect,
+            dialect,
             external_call_sites: None,
         },
     ));
     let mut analyser =
         Analyser::new().with_file_path(doc.input.path.as_ref().map(|p| p.display().to_string()));
     analyser.set_cu_override(Arc::clone(&analysis_cu));
-    let result = analyser.analyse(&doc.input.source, &dialect);
+    let result = analyser.analyse(&doc.input.source, dialect);
     for d in &result.diagnostics {
         push(d.code, d.span, d.message.clone());
     }
@@ -523,8 +525,8 @@ fn sweep_document(doc: &SweepDocument, wanted: &[DiagCode], out: &mut Vec<Firing
         UnitBuildOptions {
             registry,
             defer_top_level: false,
-            config: tcl_lexer::LexerConfig::for_dialect(&dialect),
-            dialect: &dialect,
+            config: tcl_lexer::LexerConfig::for_dialect(dialect),
+            dialect,
             external_call_sites: None,
         },
     )
@@ -554,7 +556,7 @@ fn sweep_document(doc: &SweepDocument, wanted: &[DiagCode], out: &mut Vec<Firing
         &no_disabled,
         &no_suppressed,
         Some(&doc.input.decode),
-        &dialect,
+        dialect,
     ) {
         let Ok(code) = DiagCode::from_str(d.code) else {
             continue;
@@ -565,7 +567,7 @@ fn sweep_document(doc: &SweepDocument, wanted: &[DiagCode], out: &mut Vec<Firing
         out.push(Firing {
             code,
             file: doc.input.label.clone(),
-            dialect: dialect.clone(),
+            dialect: dialect.to_owned(),
             line: d.range.start_line + 1 + doc.line_offset,
             column: d.range.start_character + 1,
             message: d.message,


### PR DESCRIPTION
Closes #1405

Resolve dialect strings at CLI/LSP ingress and thread the resolved dialect profiles through compiler consumers, eliminating inconsistent legacy iRules spelling checks and silent string mismatches.

Validation: existing exact-tree `make rust-check` and `make prep-pr` are green for head `5d50c19037953a0a659bf580bf40c69baf1d4c7b`; not rerun because the tree was preserved unchanged.

@codex please review.