### PR TITLE
fix: model Tcl startup globals for W210

### DIFF
--- a/docs/design/compiler/command-registry.md
+++ b/docs/design/compiler/command-registry.md
@@ -167,6 +167,7 @@ covers the compiler-facing ones.
 | `CONTROL_FLOW` | Command is a control-flow statement (break, continue, return) |
 | `NEEDS_START_CMD` | Bytecode control flow: needs a `startCmd` instruction |
 | `CREATES_SCOPE_ALIAS` | Creates a scope alias (upvar-like binding) |
+| `ALIASES_GLOBAL` | Refines `CREATES_SCOPE_ALIAS`: binds the interpreter global namespace |
 | `STRUCTURALLY_CHECKED_ARITY` | Registry `arity` is a descriptive floor only; a `clause_shape_check` hook owns real arity + shape validation, so the generic E002/E003 floor/ceiling check steps aside (`if`) |
 
 Traits compose across levels: a `SubCommand` carries its own `traits`, and

--- a/docs/design/special-variable-registry.md
+++ b/docs/design/special-variable-registry.md
@@ -19,8 +19,18 @@ Special variables differ from user variables in ways the analysis must respect:
 - A **write is observed by the runtime** even when the script never reads the
   value back. `set auto_path …` configures the package auto-loader; flagging it
   as a dead store (W220) or unused variable (W211) is a false positive.
-- A **read is always defined** — the interpreter seeds the variable before user
-  code runs — so a bare read is never read-before-set (W210).
+- **Startup readability is lifecycle-specific.** `SPECIAL_VARS` describes the
+  recognised runtime-sensitive vocabulary, while `initially_bound` and
+  `lazily_readable` record the narrower set a default host makes readable
+  before user code. W210 consumes those facts only for the initial global SSA
+  version; a same-named procedure local or a value removed with `unset` still
+  warns.
+- The default-host qualification matters: Tcl 8.4's successful stock
+  `Tcl_Init` runs `init.tcl`, which seeds `errorCode` and `errorInfo`; a bare
+  `Tcl_CreateInterp`, failed/overridden initialisation, and Tcl 8.5+ do not
+  provide that entry fact. `auto_index` is similarly not a startup binding:
+  interactive or auto-loader activity can materialise it later, but a normal
+  script's direct read remains undefined.
 - A **write can carry an interpreter side effect** beyond the variable slot
   (`set tcl_precision …` changes float formatting; `set env(X) …` mutates the
   process environment).
@@ -42,6 +52,9 @@ Each entry is a `SpecialVarSpec`:
 | `access` | `ReadOnly` vs `ReadWrite` — informational (hover). |
 | `origin` | Provenance for hover grouping (`Interpreter`, `AutoLoader`, `Platform`, `Environment`, `Dialect`). |
 | `dialects` | `DialectSet` in which the variable exists. |
+| `initially_bound` | Dialects in which the default host has bound the global before user code. |
+| `lazily_readable` | Dialects where a core read trace materialises an otherwise-unbound value. |
+| `startup_binding` | Why the entry is readable (`Interpreter`, `TclInit`, `TclMain`, `AppInit`, `ReadTrace`, or `None`). |
 | `keys` | Known array keys, each with its own `DialectSet` (per-key version gating). |
 | `externally_read` | A write is runtime-observed → not a dead store / unused variable. |
 | `cmp_unsafe` | iRules: plain access demotes the virtual server from CMP; use `static::`. |
@@ -50,8 +63,9 @@ Each entry is a `SpecialVarSpec`:
 | `summary` | One-line hover prose. |
 
 Array keys carry their own `DialectSet`, so `tcl_platform(pointerSize)` is Tcl
-8.6+, `tcl_platform(pathSeparator)` is 9.0+, and `tcl_platform(tmmVersion)` is
-iRules-only.
+8.5+, `tcl_platform(pathSeparator)` is Tcl 8.6+, and
+`tcl_platform(tmmVersion)` is iRules-only. Build-only keys such as `threaded`
+and `debug` are not advertised by a release-only profile.
 
 ## Dialect resolution
 
@@ -60,10 +74,10 @@ flag used by the query helpers:
 
 - An unrecognised name (empty, generic `"tcl"`, config-only `"f5-bigip"`)
   resolves to every standard Tcl version.
-- The **restricted** F5 embedded dialects (iRules, iApps) resolve to *only*
-  their own bit — their interpreter provides none of the command-line /
-  auto-loader / environment globals, so `env` / `argv` / `auto_path` are not
-  recognised there.
+- The **restricted** F5 iRules runtime resolves to its own bit — it provides
+  none of the command-line / auto-loader / environment globals, so `env` /
+  `argv` / `auto_path` are not recognised there. iApps instead resolves with
+  its documented host-Tcl base, so standard Tcl facts apply where evidenced.
 - A specific Tcl version (`tcl8.6`) keeps its exact bit, so per-key version
   gating stays precise.
 - Every other parseable dialect is a Tcl **superset** (Tk, Expect, EDA shells,
@@ -74,8 +88,10 @@ flag used by the query helpers:
 
 The crate exposes name + dialect queries; consumers never hold their own list:
 
-- `is_special_var(name, dialect)` — read-before-set (W210) suppression, in
-  `tcl-compiler`'s dataflow pass.
+- `is_special_var(name, dialect)` — availability / metadata lookup; it does
+  not imply an initial value.
+- `is_readable_at_startup(name, dialect)` — the lifecycle-aware W210 entry
+  fact, applied only to the initial global SSA version by `tcl-compiler`.
 - `is_externally_read(name, dialect)` — dead-store (W220) and unused-variable
   (W211) suppression.
 - `special_var_write_effect(name, dialect)` — `classify_variable_assignment`
@@ -95,4 +111,7 @@ The crate exposes name + dialect queries; consumers never hold their own list:
 Adding a variable — or a dialect's variant of one — is an edit to
 `SPECIAL_VARS`, not a new branch in a consumer. A new dialect's globals are new
 rows with that dialect's `DialectSet` bit; a version-gated array key is a new
-`SpecialVarKey` with the version's `DialectSet`.
+`SpecialVarKey` with the version's `DialectSet`. A new startup binding must
+also state whether it comes from interpreter creation, `Tcl_Init`, `Tcl_Main`,
+application initialisation, or a lazy read trace; availability alone must not
+silence W210.

--- a/docs/references/command-spec/fields.md
+++ b/docs/references/command-spec/fields.md
@@ -1245,6 +1245,7 @@ The registry's behavioural vocabulary — one flag per fact a consumer might nee
 | `DESTROYS_VARIABLE` | destroys a variable |
 | `READS_BEFORE_WRITE` | reads its target before writing it |
 | `CREATES_SCOPE_ALIAS` | creates an upvar-like scope alias |
+| `ALIASES_GLOBAL` | creates an alias to the interpreter global namespace |
 | `CREATES_BARRIER` | creates an analysis barrier |
 | `EVALUATES_CODE` | evaluates its argument as code |
 | `PERFORMS_SUBSTITUTION` | performs Tcl substitution |

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -858,6 +858,10 @@ impl Analyser {
         );
         let scope_aliases =
             crate::optimiser::elimination::scan_scope_aliases(&function_unit.cfg, scan_registry);
+        let global_aliases = crate::optimiser::elimination::scan_global_scope_aliases(
+            &function_unit.cfg,
+            scan_registry,
+        );
         let mut textually_referenced =
             crate::optimiser::elimination::collect_textual_var_references(
                 &self.source,
@@ -906,14 +910,20 @@ impl Analyser {
             } else {
                 function_unit.sccp.executable_blocks.clone()
             };
-        let supp =
-            build_undef_suppression(function_unit, &considered, initial_global, self.dialect());
+        let supp = build_undef_suppression(
+            function_unit,
+            &considered,
+            initial_global,
+            &global_aliases,
+            self.dialect(),
+        );
         let exists_guards = collect_existence_guards(function_unit);
         let rbs_params: HashSet<&str> = ir_proc
             .map(|p| p.params.iter().map(String::as_str).collect())
             .unwrap_or_default();
         let read_before_set_ctx = dataflow::ReadBeforeSetCtx {
             initial_global,
+            global_aliases: &global_aliases,
             defined_vars: &defined,
             scope_aliases: &scope_aliases,
             extra_known_defined,
@@ -927,6 +937,7 @@ impl Analyser {
             function_unit,
             &dataflow::ReturnUndefCtx {
                 initial_global,
+                global_aliases: &global_aliases,
                 dialect: self.dialect(),
                 params: &rbs_params,
                 exists_guards: &exists_guards,

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -279,6 +279,14 @@ fn when_proc_cross_event_names(
 }
 
 impl<'a> BodyFrame<'a> {
+    /// Whether this is the document's initial global frame. Startup bindings
+    /// apply only here; procedure and method locals with the same name remain
+    /// ordinary fresh Tcl variables.
+    #[must_use]
+    fn is_initial_global(self) -> bool {
+        matches!(self, Self::TopLevel)
+    }
+
     /// The [`crate::ir::Procedure`] backing this frame, or `None` when the
     /// body is not a procedure-shaped one.  The parameter-specific emitters
     /// (W214 unused-parameter, and the W210 read-before-set parameter
@@ -878,6 +886,7 @@ impl Analyser {
         // qualified name, so the name alone cannot tell them apart (see
         // [`BodyFrame`]).
         let ir_proc = frame.procedure();
+        let initial_global = frame.is_initial_global();
         let existence_frame = frame.existence_frame();
         self.emit_dead_store_diagnostics(function_unit, &defined, &scope_aliases, cross_event_vars);
         self.emit_unused_variable_diagnostics(
@@ -897,25 +906,28 @@ impl Analyser {
             } else {
                 function_unit.sccp.executable_blocks.clone()
             };
-        let supp = build_undef_suppression(function_unit, &considered);
+        let supp =
+            build_undef_suppression(function_unit, &considered, initial_global, self.dialect());
         let exists_guards = collect_existence_guards(function_unit);
         let rbs_params: HashSet<&str> = ir_proc
             .map(|p| p.params.iter().map(String::as_str).collect())
             .unwrap_or_default();
-        self.emit_read_before_set_diagnostics(
-            function_unit,
-            ir_proc,
-            &defined,
-            &scope_aliases,
+        let read_before_set_ctx = dataflow::ReadBeforeSetCtx {
+            initial_global,
+            defined_vars: &defined,
+            scope_aliases: &scope_aliases,
             extra_known_defined,
-            &supp,
-        );
+            supp: &supp,
+        };
+        self.emit_read_before_set_diagnostics(function_unit, ir_proc, &read_before_set_ctx);
         // Phi-from-undef on `return $v` reads (the def-use builder records
         // statement + branch-condition uses but NOT `Terminator::Return`
         // values).
         self.emit_return_phi_undef_w210(
             function_unit,
             &dataflow::ReturnUndefCtx {
+                initial_global,
+                dialect: self.dialect(),
                 params: &rbs_params,
                 exists_guards: &exists_guards,
                 scope_aliases: &scope_aliases,

--- a/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
@@ -63,6 +63,7 @@ struct PhiUndefIndex<'a> {
 /// emitters from acquiring separate, subtly divergent entry-scope contracts.
 pub(super) struct ReadBeforeSetCtx<'a> {
     pub initial_global: bool,
+    pub global_aliases: &'a HashSet<String>,
     pub defined_vars: &'a HashSet<String>,
     pub scope_aliases: &'a HashSet<String>,
     pub extra_known_defined: &'a HashSet<String>,
@@ -71,6 +72,7 @@ pub(super) struct ReadBeforeSetCtx<'a> {
 
 pub(super) struct ReturnUndefCtx<'a> {
     pub initial_global: bool,
+    pub global_aliases: &'a HashSet<String>,
     pub dialect: &'a str,
     pub params: &'a HashSet<&'a str>,
     pub exists_guards: &'a [(String, crate::cfg::BlockId)],
@@ -79,6 +81,45 @@ pub(super) struct ReturnUndefCtx<'a> {
     pub defined_vars: &'a HashSet<String>,
     pub considered: &'a HashSet<crate::cfg::BlockId>,
     pub supp: &'a UndefSuppression,
+}
+
+/// Registry-owned startup lifecycle facts for one SSA variable version.
+#[derive(Clone, Copy)]
+struct StartupReadFacts {
+    readable: bool,
+    initially_bound: bool,
+    lazy_read: bool,
+}
+
+fn startup_read_facts(
+    name: &str,
+    version: crate::ssa::Version,
+    killed: bool,
+    initial_global: bool,
+    global_aliases: &HashSet<String>,
+    dialect: &str,
+) -> StartupReadFacts {
+    let global_binding =
+        super::helpers::has_global_startup_binding(name, initial_global, global_aliases);
+    let startup_name = super::helpers::startup_var_name(name);
+    StartupReadFacts {
+        readable: global_binding
+            && version == 0
+            && !killed
+            && tcl_registry::special_vars::is_readable_at_startup(startup_name, dialect),
+        initially_bound: global_binding
+            && version == 0
+            && tcl_registry::special_vars::is_initially_bound(startup_name, dialect),
+        lazy_read: global_binding
+            && tcl_registry::special_vars::is_lazily_readable(startup_name, dialect),
+    }
+}
+
+/// Facts used while recording the read sites of one undef def-use chain.
+struct W210ChainCtx<'a> {
+    exists_guards: &'a [(String, crate::cfg::BlockId)],
+    supp: &'a UndefSuppression,
+    startup: StartupReadFacts,
 }
 
 impl Analyser {
@@ -1106,13 +1147,15 @@ file; this call falls through to the 'unknown' handler."
             // Tcl 8.x's registry-declared `tcl_precision` read trace
             // recreates its value after `unset`; an eager startup binding
             // (for example argv) deliberately does not get this exemption.
-            if ctx.initial_global
-                && ctx.supp.killed.contains(&chain.key)
-                && tcl_registry::special_vars::is_lazily_readable(
-                    crate::naming::normalise_var_name(var),
-                    self.dialect(),
-                )
-            {
+            let startup = startup_read_facts(
+                var,
+                *version,
+                ctx.supp.killed.contains(&chain.key),
+                ctx.initial_global,
+                ctx.global_aliases,
+                self.dialect(),
+            );
+            if startup.lazy_read && ctx.supp.killed.contains(&chain.key) {
                 continue;
             }
             // `SPECIAL_VARS` distinguishes recognised runtime-sensitive names
@@ -1120,16 +1163,6 @@ file; this call falls through to the 'unknown' handler."
             // user code. That entry fact belongs only to this document's
             // initial global frame and version zero: local shadows and a
             // version killed by `unset` are still genuine W210 reads.
-            if ctx.initial_global
-                && *version == 0
-                && !ctx.supp.killed.contains(&chain.key)
-                && tcl_registry::special_vars::is_readable_at_startup(
-                    crate::naming::normalise_var_name(var),
-                    self.dialect(),
-                )
-            {
-                continue;
-            }
             // An element read (`$arr(a)`) of an array whose *base* is
             // defined, aliased, or a parameter anywhere in the function
             // stays silent: which elements a dynamic write / whole-array
@@ -1192,7 +1225,16 @@ file; this call falls through to the 'unknown' handler."
             if ctx.supp.suppresses(var) {
                 continue;
             }
-            self.record_chain_w210_uses(fu, chain, &exists_guards, ctx.supp, &mut w210_min);
+            self.record_chain_w210_uses(
+                fu,
+                chain,
+                &W210ChainCtx {
+                    exists_guards: &exists_guards,
+                    supp: ctx.supp,
+                    startup,
+                },
+                &mut w210_min,
+            );
         }
 
         let mut entries: Vec<(String, tcl_lexer::Span)> = w210_min.into_iter().collect();
@@ -1221,8 +1263,7 @@ file; this call falls through to the 'unknown' handler."
         &mut self,
         fu: &crate::compilation_unit::FunctionUnit,
         chain: &crate::def_use::DefUseChain,
-        exists_guards: &[(String, crate::cfg::BlockId)],
-        supp: &UndefSuppression,
+        ctx: &W210ChainCtx<'_>,
         w210_min: &mut std::collections::HashMap<String, tcl_lexer::Span>,
     ) {
         use crate::def_use::UseKind;
@@ -1247,7 +1288,7 @@ file; this call falls through to the 'unknown' handler."
             // `UndefSuppression::loop_entry_only_undef`): we assume a may-run
             // loop runs, matching C Tcl. A read *inside* the loop body still
             // fires.
-            if supp.after_loop_defined(&chain.key, &use_site.block) {
+            if ctx.supp.after_loop_defined(&chain.key, &use_site.block) {
                 continue;
             }
             let Some(block) = fu.cfg.block_by_name(&use_site.block) else {
@@ -1291,7 +1332,7 @@ file; this call falls through to the 'unknown' handler."
             }
             // Skip the existence-query word itself and
             // reads narrowed by an enclosing `[info exists X]` guard.
-            if existence_exempt(stmt_opt, var, exists_guards, &fu.ssa, &use_site.block) {
+            if existence_exempt(stmt_opt, var, ctx.exists_guards, &fu.ssa, &use_site.block) {
                 continue;
             }
             // ``unset`` without ``-nocomplain`` → W213.
@@ -1304,6 +1345,21 @@ file; this call falls through to the 'unknown' handler."
                 && command == "unset"
                 && !args.iter().any(|a| a == "-nocomplain")
             {
+                // Eager startup bindings (`argv`, `tcl_version`, …) already
+                // exist when their first `unset` runs. A lazy read trace is
+                // different: its first `unset` still errors until an earlier
+                // actual read has materialised its value in this block.
+                if ctx.startup.initially_bound
+                    || (ctx.startup.lazy_read
+                        && chain.uses.iter().any(|prior| {
+                            prior.block == use_site.block
+                                && prior.statement_index >= 0
+                                && prior.statement_index < use_site.statement_index
+                                && prior.class != crate::ssa::UseClass::Quoted
+                        }))
+                {
+                    continue;
+                }
                 let message = format!(
                     "Variable '{var}' may not exist; \
                          use 'unset -nocomplain' to suppress the error",
@@ -1327,6 +1383,13 @@ file; this call falls through to the 'unknown' handler."
             // (`safe_on_uninit` calls like `lappend`/`dict set`, or an
             // `incr` of its own target) is not read-before-set.
             if use_site_safe_initialises(stmt_opt, var) {
+                continue;
+            }
+            // This is an ordinary initial read, not the destructive `unset`
+            // target handled above.  Its startup fact is registry-owned and
+            // applies to the initial global frame, a qualified global, or a
+            // registry-declared global alias — never a same-named local.
+            if ctx.startup.readable {
                 continue;
             }
             // Anchor at the `$var` read token; fall back to the command
@@ -1488,6 +1551,7 @@ file; this call falls through to the 'unknown' handler."
             executable_edges: &fu.sccp.executable_edges,
             exists_guards: ctx.exists_guards,
             initial_global: ctx.initial_global,
+            global_aliases: ctx.global_aliases,
             dialect: ctx.dialect,
             ssa: &fu.ssa,
         };

--- a/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
@@ -58,7 +58,20 @@ struct PhiUndefIndex<'a> {
     killed: &'a FxHashSet<(String, crate::ssa::Version)>,
 }
 
+/// The read-only scope and suppression facts for the version-0 / statement
+/// W210 pass. Keeping this alongside [`ReturnUndefCtx`] prevents the two W210
+/// emitters from acquiring separate, subtly divergent entry-scope contracts.
+pub(super) struct ReadBeforeSetCtx<'a> {
+    pub initial_global: bool,
+    pub defined_vars: &'a HashSet<String>,
+    pub scope_aliases: &'a HashSet<String>,
+    pub extra_known_defined: &'a HashSet<String>,
+    pub supp: &'a UndefSuppression,
+}
+
 pub(super) struct ReturnUndefCtx<'a> {
+    pub initial_global: bool,
+    pub dialect: &'a str,
     pub params: &'a HashSet<&'a str>,
     pub exists_guards: &'a [(String, crate::cfg::BlockId)],
     pub scope_aliases: &'a HashSet<String>,
@@ -1035,10 +1048,7 @@ file; this call falls through to the 'unknown' handler."
         &mut self,
         fu: &crate::compilation_unit::FunctionUnit,
         ir_proc: Option<&crate::ir::Procedure>,
-        defined_vars: &HashSet<String>,
-        scope_aliases: &HashSet<String>,
-        extra_known_defined: &HashSet<String>,
-        supp: &UndefSuppression,
+        ctx: &ReadBeforeSetCtx<'_>,
     ) {
         use crate::def_use::DefKind;
         use std::fmt::Write as _;
@@ -1084,13 +1094,28 @@ file; this call falls through to the 'unknown' handler."
             // undef at their reads too — all flow through the same
             // suppression + emission logic below.
             if chain.definition.kind != DefKind::Parameter
-                && !supp.killed.contains(&chain.key)
-                && !supp.can_undef.contains(&chain.key)
+                && !ctx.supp.killed.contains(&chain.key)
+                && !ctx.supp.can_undef.contains(&chain.key)
             {
                 continue;
             }
-            let (var, _version) = &chain.key;
+            let (var, version) = &chain.key;
             if params.contains(var.as_str()) {
+                continue;
+            }
+            // `SPECIAL_VARS` distinguishes recognised runtime-sensitive names
+            // from the subset the default host actually makes readable before
+            // user code. That entry fact belongs only to this document's
+            // initial global frame and version zero: local shadows and a
+            // version killed by `unset` are still genuine W210 reads.
+            if ctx.initial_global
+                && *version == 0
+                && !ctx.supp.killed.contains(&chain.key)
+                && tcl_registry::special_vars::is_readable_at_startup(
+                    crate::naming::normalise_var_name(var),
+                    self.dialect(),
+                )
+            {
                 continue;
             }
             // An element read (`$arr(a)`) of an array whose *base* is
@@ -1111,9 +1136,9 @@ file; this call falls through to the 'unknown' handler."
                 });
                 if base_defined
                     || params.contains(base)
-                    || scope_aliases.contains(base)
-                    || extra_known_defined.contains(base)
-                    || supp.suppresses(base)
+                    || (ctx.scope_aliases.contains(base) && !ctx.supp.killed.contains(&chain.key))
+                    || ctx.extra_known_defined.contains(base)
+                    || ctx.supp.suppresses(base)
                 {
                     continue;
                 }
@@ -1122,10 +1147,10 @@ file; this call falls through to the 'unknown' handler."
             // targets the global / a named namespace scope, whose definition
             // may live in another proc, another namespace, or — for a
             // multi-file project — another file entirely.  Single-unit
-            // dataflow can't see those writers, so a qualified read must never
-            // be flagged read-before-set (matches the phi-undef emitter and
-            // the dead-store pass, which already exempt `::`-qualified names).
-            if var.contains("::") {
+            // dataflow cannot see those writers, so an otherwise-unresolved
+            // qualified read is conservatively exempt. A same-unit `unset`
+            // records a killed chain, however, so it must still be reported.
+            if var.contains("::") && !ctx.supp.killed.contains(&chain.key) {
                 continue;
             }
             // A scope-aliased local (`global` / `variable` / `upvar` /
@@ -1136,13 +1161,13 @@ file; this call falls through to the 'unknown' handler."
             // variable is missing — a runtime condition, not a static one — so
             // the dynamic target is suppressed exactly like the literal one
             // (matching C Tcl and the "assume the may-run path does run" stance
-            // the loop / cross-event passes already take). This is the standard
-            // Tcl pass-by-reference idiom; a genuinely unrelated local that is
-            // not an alias is absent from `scope_aliases` and still fires.
-            if scope_aliases.contains(var) {
+            // the loop / cross-event passes already take). A known `unset` of
+            // the alias wins over that conservative assumption; a genuinely
+            // unrelated local is absent from `scope_aliases` and still fires.
+            if ctx.scope_aliases.contains(var) && !ctx.supp.killed.contains(&chain.key) {
                 continue;
             }
-            if extra_known_defined.contains(var) {
+            if ctx.extra_known_defined.contains(var) {
                 continue;
             }
             // `dict with`/`dict update` unpacking + qualified-`variable`
@@ -1152,17 +1177,17 @@ file; this call falls through to the 'unknown' handler."
             // CONST("") (keys = ∅, not unknown), so the blanket variant fires
             // on a genuine missing-key read while still suppressing an
             // unknown-shape (mixed-caller / no-caller) dict.
-            if supp.suppresses(var) {
+            if ctx.supp.suppresses(var) {
                 continue;
             }
-            self.record_chain_w210_uses(fu, chain, &exists_guards, supp, &mut w210_min);
+            self.record_chain_w210_uses(fu, chain, &exists_guards, ctx.supp, &mut w210_min);
         }
 
         let mut entries: Vec<(String, tcl_lexer::Span)> = w210_min.into_iter().collect();
         entries.sort_by_key(|(_, s)| s.start());
         for (var, span) in entries {
             let mut message = format!("Variable '{var}' is read before it is set");
-            if let Some(similar) = undefined_var_suggestion(&var, defined_vars) {
+            if let Some(similar) = undefined_var_suggestion(&var, ctx.defined_vars) {
                 let _ = write!(message, "; did you mean '{similar}'?");
             }
             self.result.diagnostics.push(super::types::Diagnostic {
@@ -1401,8 +1426,7 @@ file; this call falls through to the 'unknown' handler."
                     .and_then(|s| ssa_block.exit_versions.get(&s))
                     .copied()
                     .unwrap_or(0);
-                if !Self::return_read_fires_w210(fu, &name, ver, bn, &phi_idx, ctx, self.dialect())
-                {
+                if !Self::return_read_fires_w210(fu, &name, ver, bn, &phi_idx, ctx) {
                     continue;
                 }
                 reported.insert(name.clone());
@@ -1424,7 +1448,7 @@ file; this call falls through to the 'unknown' handler."
     /// Decide whether a single `return`-value read of `(name, ver)` in block
     /// `bn` is a W210 phi-from-undef read: its reaching version must be able to
     /// reach an undef origin, and it must not be a parameter / scope alias /
-    /// known-defined / implicit / qualified / suppressed name or be proven
+    /// known-defined / qualified / suppressed name or be proven
     /// defined by a dominating existence guard.  Version-0 reads are handled by
     /// the def-use `DefKind::Parameter` emitter, so they never fire here.
     fn return_read_fires_w210(
@@ -1434,7 +1458,6 @@ file; this call falls through to the 'unknown' handler."
         bn: crate::cfg::BlockId,
         phi_idx: &PhiUndefIndex<'_>,
         ctx: &ReturnUndefCtx<'_>,
-        dialect: &str,
     ) -> bool {
         // Version-0 return reads are now recorded in def_use, so the version-0
         // (`DefKind::Parameter`) emitter handles them with the full suppression
@@ -1452,16 +1475,21 @@ file; this call falls through to the 'unknown' handler."
             considered: ctx.considered,
             executable_edges: &fu.sccp.executable_edges,
             exists_guards: ctx.exists_guards,
+            initial_global: ctx.initial_global,
+            dialect: ctx.dialect,
             ssa: &fu.ssa,
         };
         if !phi_can_undef(name, ver, &undef_ctx, &mut seen) {
             return false;
         }
+        // A killed SSA version is concrete same-unit evidence that overrides
+        // the conservative external-scope assumptions for `global`/`upvar`
+        // aliases and qualified names.
+        let known_killed = phi_idx.killed.contains(&(name.to_owned(), ver));
         if ctx.params.contains(name)
-            || ctx.scope_aliases.contains(name)
+            || (ctx.scope_aliases.contains(name) && !known_killed)
             || ctx.extra_known_defined.contains(name)
-            || is_implicit_var(name, dialect)
-            || name.contains("::")
+            || (name.contains("::") && !known_killed)
             || ctx.supp.suppresses(name)
         {
             return false;
@@ -2654,15 +2682,6 @@ fn w213_span_and_fix(
         }]
     });
     (diag_span, fixes)
-}
-
-/// Implicit / interpreter-provided variables that are always defined and
-/// must never raise a read-before-set.  Dialect-aware: the set is sourced from
-/// the [`tcl_registry::special_vars`] registry, which knows that iRules
-/// provides a different set (its `static::` namespace, no `argv`/`env`) than
-/// standard Tcl.
-fn is_implicit_var(name: &str, dialect: &str) -> bool {
-    tcl_registry::special_vars::is_special_var(crate::naming::normalise_var_name(name), dialect)
 }
 
 /// Tcl ARE metacharacters: a pattern free of these reduces to a literal

--- a/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
@@ -1103,6 +1103,18 @@ file; this call falls through to the 'unknown' handler."
             if params.contains(var.as_str()) {
                 continue;
             }
+            // Tcl 8.x's registry-declared `tcl_precision` read trace
+            // recreates its value after `unset`; an eager startup binding
+            // (for example argv) deliberately does not get this exemption.
+            if ctx.initial_global
+                && ctx.supp.killed.contains(&chain.key)
+                && tcl_registry::special_vars::is_lazily_readable(
+                    crate::naming::normalise_var_name(var),
+                    self.dialect(),
+                )
+            {
+                continue;
+            }
             // `SPECIAL_VARS` distinguishes recognised runtime-sensitive names
             // from the subset the default host actually makes readable before
             // user code. That entry fact belongs only to this document's

--- a/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
@@ -351,6 +351,18 @@ pub(super) fn phi_can_undef(
         dialect,
         ssa,
     } = ctx;
+    let normalised = crate::naming::normalise_var_name(name);
+    let startup_name = normalised.strip_prefix("::").unwrap_or(normalised);
+    let rematerialises_after_unset =
+        *initial_global && tcl_registry::special_vars::is_lazily_readable(startup_name, dialect);
+    let key = (name.to_string(), version);
+    if killed.contains(&key) {
+        // A Tcl read trace is not an eager startup fact: `unset` removes the
+        // current value, but a later read materialises it again.  Registry
+        // data confines this to `tcl_precision` on Tcl 8.x; eager bindings
+        // such as argv remain genuine W210 reads after `unset`.
+        return !rematerialises_after_unset;
+    }
     if version == 0 {
         // A version-zero incoming normally is the undef origin.  The default
         // Tcl host, however, binds a registry-declared subset before user
@@ -358,14 +370,8 @@ pub(super) fn phi_can_undef(
         // conditional write otherwise makes a merge with the startup version
         // look undefined.  `unset` still wins below for real killed versions,
         // and procedure-local frames never set `initial_global`.
-        let normalised = crate::naming::normalise_var_name(name);
-        let startup_name = normalised.strip_prefix("::").unwrap_or(normalised);
         return !(*initial_global
             && tcl_registry::special_vars::is_readable_at_startup(startup_name, dialect));
-    }
-    let key = (name.to_string(), version);
-    if killed.contains(&key) {
-        return true;
     }
     if seen.contains(&key) {
         // Cycle (loop-header phi): the DFS seed already accounted for the

--- a/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
@@ -319,8 +319,40 @@ pub(super) struct PhiUndefCtx<'a> {
     pub exists_guards: &'a [(String, BlockId)],
     /// Startup bindings exist only in the document's initial global frame.
     pub initial_global: bool,
+    /// Locals that registry metadata says alias the interpreter's global
+    /// namespace in this function (`global name`).
+    pub global_aliases: &'a HashSet<String>,
     pub dialect: &'a str,
     pub ssa: &'a crate::ssa::SsaFunction,
+}
+
+/// Return the registry spelling for a potential startup variable, removing
+/// only Tcl's global marker.  A named namespace (`::pkg::name`) deliberately
+/// remains qualified and cannot accidentally inherit a global startup fact.
+pub(super) fn startup_var_name(name: &str) -> &str {
+    let normalised = crate::naming::normalise_var_name(name);
+    normalised.strip_prefix("::").unwrap_or(normalised)
+}
+
+/// Whether `name` resolves to the interpreter's global binding in this
+/// analysis frame.  The `global`-alias set comes from a registry trait, so a
+/// new dialect spelling can opt in without a command-name branch here.
+pub(super) fn has_global_startup_binding(
+    name: &str,
+    initial_global: bool,
+    global_aliases: &HashSet<String>,
+) -> bool {
+    if initial_global || crate::naming::normalise_var_name(name).starts_with("::") {
+        return true;
+    }
+    let startup_name = startup_var_name(name);
+    global_aliases.iter().any(|alias| {
+        let alias_normalised = crate::naming::normalise_var_name(alias);
+        alias_normalised
+            .strip_prefix("::")
+            .unwrap_or(alias_normalised)
+            == startup_name
+    })
 }
 
 /// Phi-from-undef trace.  A use's SSA version > 0 normally proves a prior
@@ -348,13 +380,14 @@ pub(super) fn phi_can_undef(
         executable_edges,
         exists_guards,
         initial_global,
+        global_aliases,
         dialect,
         ssa,
     } = ctx;
-    let normalised = crate::naming::normalise_var_name(name);
-    let startup_name = normalised.strip_prefix("::").unwrap_or(normalised);
+    let startup_name = startup_var_name(name);
+    let global_binding = has_global_startup_binding(name, *initial_global, global_aliases);
     let rematerialises_after_unset =
-        *initial_global && tcl_registry::special_vars::is_lazily_readable(startup_name, dialect);
+        global_binding && tcl_registry::special_vars::is_lazily_readable(startup_name, dialect);
     let key = (name.to_string(), version);
     if killed.contains(&key) {
         // A Tcl read trace is not an eager startup fact: `unset` removes the
@@ -370,7 +403,7 @@ pub(super) fn phi_can_undef(
         // conditional write otherwise makes a merge with the startup version
         // look undefined.  `unset` still wins below for real killed versions,
         // and procedure-local frames never set `initial_global`.
-        return !(*initial_global
+        return !(global_binding
             && tcl_registry::special_vars::is_readable_at_startup(startup_name, dialect));
     }
     if seen.contains(&key) {
@@ -851,6 +884,7 @@ pub(super) fn build_undef_suppression(
     fu: &crate::compilation_unit::FunctionUnit,
     considered: &HashSet<BlockId>,
     initial_global: bool,
+    global_aliases: &HashSet<String>,
     dialect: &str,
 ) -> UndefSuppression {
     let (phi_def, phi_block, killed) = build_phi_undef_index(&fu.ssa, considered);
@@ -866,6 +900,7 @@ pub(super) fn build_undef_suppression(
         executable_edges: &fu.sccp.executable_edges,
         exists_guards: &exists_guards,
         initial_global,
+        global_aliases,
         dialect,
         ssa: &fu.ssa,
     };

--- a/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
@@ -308,7 +308,8 @@ fn whole_unset_names(args: &[String]) -> FxHashSet<String> {
 
 /// Read-only context threaded unchanged through [`phi_can_undef`]'s recursion:
 /// the phi indices, the `unset`-killed set, the executable block / edge sets,
-/// the dominating existence guards, and the SSA function itself.
+/// the dominating existence guards, the registry-owned startup binding, and
+/// the SSA function itself.
 pub(super) struct PhiUndefCtx<'a> {
     pub phi_def: &'a PhiDefMap,
     pub phi_block: &'a PhiBlockMap,
@@ -316,6 +317,9 @@ pub(super) struct PhiUndefCtx<'a> {
     pub considered: &'a HashSet<BlockId>,
     pub executable_edges: &'a HashSet<(BlockId, BlockId)>,
     pub exists_guards: &'a [(String, BlockId)],
+    /// Startup bindings exist only in the document's initial global frame.
+    pub initial_global: bool,
+    pub dialect: &'a str,
     pub ssa: &'a crate::ssa::SsaFunction,
 }
 
@@ -343,10 +347,21 @@ pub(super) fn phi_can_undef(
         considered,
         executable_edges,
         exists_guards,
+        initial_global,
+        dialect,
         ssa,
     } = ctx;
     if version == 0 {
-        return true;
+        // A version-zero incoming normally is the undef origin.  The default
+        // Tcl host, however, binds a registry-declared subset before user
+        // code.  This must be decided while tracing phi incomings too: a
+        // conditional write otherwise makes a merge with the startup version
+        // look undefined.  `unset` still wins below for real killed versions,
+        // and procedure-local frames never set `initial_global`.
+        let normalised = crate::naming::normalise_var_name(name);
+        let startup_name = normalised.strip_prefix("::").unwrap_or(normalised);
+        return !(*initial_global
+            && tcl_registry::special_vars::is_readable_at_startup(startup_name, dialect));
     }
     let key = (name.to_string(), version);
     if killed.contains(&key) {
@@ -829,37 +844,33 @@ fn harvest_dict_with_suppression(
 pub(super) fn build_undef_suppression(
     fu: &crate::compilation_unit::FunctionUnit,
     considered: &HashSet<BlockId>,
+    initial_global: bool,
+    dialect: &str,
 ) -> UndefSuppression {
     let (phi_def, phi_block, killed) = build_phi_undef_index(&fu.ssa, considered);
     // Phi versions that can reach an undef origin on some executable path —
     // a statement read of one is read-before-set. The per-use existence
     // guard + suppression set still apply in the emitter loop.
     let exists_guards = collect_existence_guards(fu);
+    let undef_ctx = PhiUndefCtx {
+        phi_def: &phi_def,
+        phi_block: &phi_block,
+        killed: &killed,
+        considered,
+        executable_edges: &fu.sccp.executable_edges,
+        exists_guards: &exists_guards,
+        initial_global,
+        dialect,
+        ssa: &fu.ssa,
+    };
     let mut can_undef: FxHashSet<(String, crate::ssa::Version)> = FxHashSet::default();
     for key in phi_def.keys() {
         let mut seen = FxHashSet::default();
-        let ctx = PhiUndefCtx {
-            phi_def: &phi_def,
-            phi_block: &phi_block,
-            killed: &killed,
-            considered,
-            executable_edges: &fu.sccp.executable_edges,
-            exists_guards: &exists_guards,
-            ssa: &fu.ssa,
-        };
-        if phi_can_undef(&key.0, key.1, &ctx, &mut seen) {
+        if phi_can_undef(&key.0, key.1, &undef_ctx, &mut seen) {
             can_undef.insert(key.clone());
         }
     }
-    let loop_entry_only_undef = build_loop_entry_only_undef(
-        fu,
-        considered,
-        &phi_def,
-        &phi_block,
-        &killed,
-        &exists_guards,
-        &can_undef,
-    );
+    let loop_entry_only_undef = build_loop_entry_only_undef(fu, &can_undef, &undef_ctx);
     let mut s = UndefSuppression {
         cmd_sub_writes: collect_expr_cmd_sub_writes(fu, considered),
         script_concat_writes: collect_script_concat_writes(fu, considered),
@@ -910,27 +921,14 @@ pub(super) fn build_undef_suppression(
 /// and the read must keep firing.
 fn build_loop_entry_only_undef(
     fu: &crate::compilation_unit::FunctionUnit,
-    considered: &HashSet<BlockId>,
-    phi_def: &PhiDefMap,
-    phi_block: &PhiBlockMap,
-    killed: &FxHashSet<(String, crate::ssa::Version)>,
-    exists_guards: &[(String, BlockId)],
     can_undef: &FxHashSet<(String, crate::ssa::Version)>,
+    ctx: &PhiUndefCtx<'_>,
 ) -> FxHashMap<(String, crate::ssa::Version), FxHashSet<String>> {
     let mut out: FxHashMap<(String, crate::ssa::Version), FxHashSet<String>> = FxHashMap::default();
     if can_undef.is_empty() {
         return out;
     }
-    let forest = crate::loops::build_loop_forest(&fu.cfg, &fu.ssa, considered);
-    let ctx = PhiUndefCtx {
-        phi_def,
-        phi_block,
-        killed,
-        considered,
-        executable_edges: &fu.sccp.executable_edges,
-        exists_guards,
-        ssa: &fu.ssa,
-    };
+    let forest = crate::loops::build_loop_forest(&fu.cfg, &fu.ssa, ctx.considered);
     // Fixpoint over the loop forest so *nested* accumulators converge: an inner
     // loop whose body defines the variable is itself loop-entry-only-undef, so
     // for the enclosing loop its exit operand counts as defined (we assume both
@@ -968,7 +966,7 @@ fn build_loop_entry_only_undef(
                     // Only in-loop (back-edge) predecessors gate the verdict;
                     // the pre-header entry edge carries the zero-trip undef we
                     // assume away. Non-executable predecessors never read.
-                    if !considered.contains(&pred) {
+                    if !ctx.considered.contains(&pred) {
                         return true;
                     }
                     if !body_blocks.contains(fu.cfg.block_name(pred)) {
@@ -978,7 +976,7 @@ fn build_loop_entry_only_undef(
                         return true;
                     }
                     let mut seen = FxHashSet::default();
-                    !phi_can_undef(&name, ver_in, &ctx, &mut seen)
+                    !phi_can_undef(&name, ver_in, ctx, &mut seen)
                 });
                 if entry_only {
                     out.insert(key, body_blocks.clone());

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -5746,6 +5746,100 @@ fn emit_cfg_ssa_diagnostics_w210_fires_at_top_level() {
 }
 
 #[test]
+fn w210_uses_registry_owned_startup_lifecycle_facts() {
+    // #1557: availability in SPECIAL_VARS is intentionally broader than
+    // startup readability.  Build this probe from the central table so a new
+    // default global gains W210 coverage automatically; the registry's own
+    // exact fixture guards the audited release-by-release inventory.
+    for dialect in ["tcl8.4", "tcl8.5", "tcl8.6", "tcl9.0", "tcl9.1"] {
+        let source: String = tcl_registry::special_vars::special_vars_for_dialect(dialect)
+            .filter(|spec| tcl_registry::special_vars::is_readable_at_startup(spec.name, dialect))
+            .filter_map(|spec| match spec.kind {
+                tcl_registry::special_vars::SpecialVarKind::Scalar => {
+                    Some(format!("puts ${}\n", spec.name))
+                }
+                // Array elements are normalised to their registry-owned base
+                // by the SSA model.  The synthetic key need not exist at
+                // runtime; the assertion is specifically about W210's entry
+                // binding knowledge, not an array-key value claim.
+                tcl_registry::special_vars::SpecialVarKind::Array => {
+                    Some(format!("puts ${}(__tcl_lsp_startup_probe__)\n", spec.name))
+                }
+                tcl_registry::special_vars::SpecialVarKind::Namespace => None,
+            })
+            .collect();
+        let result = Analyser::new().analyse(&source, dialect);
+        assert!(
+            !result.diagnostics.iter().any(|d| d.code == DiagCode::W210),
+            "startup-readable special vars must not emit W210 for {dialect}: {:?}",
+            result.diagnostics
+        );
+    }
+
+    // Controls make the test mutation-sensitive: these names remain special
+    // / documented but are not default-readable in the cited lifecycle.
+    for name in ["auto_index", "auto_execs", "auto_noexec", "auto_noload"] {
+        let result = Analyser::new().analyse(&format!("puts ${name}\n"), "tcl8.6");
+        assert!(
+            result.diagnostics.iter().any(|d| d.code == DiagCode::W210),
+            "lazy special variable {name} must still emit W210: {:?}",
+            result.diagnostics
+        );
+    }
+    let result = Analyser::new().analyse("puts $tcl_precision\n", "tcl9.0");
+    assert!(result.diagnostics.iter().any(|d| d.code == DiagCode::W210));
+    let result = Analyser::new().analyse("puts $argv\n", "f5-irules");
+    assert!(result.diagnostics.iter().any(|d| d.code == DiagCode::W210));
+
+    // Startup facts are global-only and version-zero-only.  They must not
+    // leak into a fresh procedure local, nor survive an explicit deletion.
+    for src in [
+        "proc local {} { puts $argv }\n",
+        "proc local_return {} { return $argv }\n",
+        "unset argv\nputs $argv\n",
+        "unset ::argv\nputs $::argv\n",
+    ] {
+        let result = Analyser::new().analyse(src, "tcl8.6");
+        assert!(
+            result.diagnostics.iter().any(|d| d.code == DiagCode::W210),
+            "{src:?} must retain W210 after scope/lifecycle handling: {:?}",
+            result.diagnostics
+        );
+    }
+    let result = Analyser::new().analyse("proc global {} { global argv; puts $argv }\n", "tcl8.6");
+    assert!(
+        !result.diagnostics.iter().any(|d| d.code == DiagCode::W210),
+        "an explicit global alias must retain the startup binding: {:?}",
+        result.diagnostics
+    );
+
+    // The startup version can also be one incoming of an SSA phi.  A
+    // conditional write must not turn its untouched global incoming into a
+    // synthetic undef; this covers both ordinary statement reads and return
+    // values, whose phi walk is a separate consumer of the shared fact.
+    for src in [
+        "if {[info exists tcl_interactive]} { set argv replacement }\nputs $argv\n",
+        "if {[info exists tcl_interactive]} { set argv replacement }\nreturn $argv\n",
+    ] {
+        let result = Analyser::new().analyse(src, "tcl8.6");
+        assert!(
+            !result.diagnostics.iter().any(|d| d.code == DiagCode::W210),
+            "a phi including startup-bound argv must remain defined for {src:?}: {:?}",
+            result.diagnostics
+        );
+    }
+    let result = Analyser::new().analyse(
+        "if {[info exists tcl_interactive]} { unset argv }\nputs $argv\n",
+        "tcl8.6",
+    );
+    assert!(
+        result.diagnostics.iter().any(|d| d.code == DiagCode::W210),
+        "an unset incoming must keep the phi possibly undefined: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
 fn emit_cfg_ssa_diagnostics_w210_suppressed_when_proc_writes_global() {
     // A helper proc ``init`` writes ``::counter`` via ``set``,
     // so the top-level read should not flag W210 — the proc

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -5837,6 +5837,27 @@ fn w210_uses_registry_owned_startup_lifecycle_facts() {
         "an unset incoming must keep the phi possibly undefined: {:?}",
         result.diagnostics
     );
+
+    // `tcl_precision` is the Tcl 8.x registry-owned read-trace exception:
+    // unlike an eager startup binding, reading it after `unset` materialises
+    // its value again. Exercise both W210 consumers and the Tcl 9 boundary.
+    for src in [
+        "unset tcl_precision\nputs $tcl_precision\n",
+        "unset tcl_precision\nreturn $tcl_precision\n",
+    ] {
+        let result = Analyser::new().analyse(src, "tcl8.6");
+        assert!(
+            !result.diagnostics.iter().any(|d| d.code == DiagCode::W210),
+            "Tcl 8 read trace must rematerialise after unset for {src:?}: {:?}",
+            result.diagnostics
+        );
+        let result = Analyser::new().analyse(src, "tcl9.0");
+        assert!(
+            result.diagnostics.iter().any(|d| d.code == DiagCode::W210),
+            "Tcl 9 must not inherit Tcl 8 read-trace behaviour for {src:?}: {:?}",
+            result.diagnostics
+        );
+    }
 }
 
 #[test]

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -5861,6 +5861,82 @@ fn w210_uses_registry_owned_startup_lifecycle_facts() {
 }
 
 #[test]
+fn w210_startup_read_trace_respects_global_alias_and_unset_lifecycle() {
+    // The trace belongs to the global storage cell even when that cell is
+    // reached through `global` or an explicit `::` spelling.  A same-named
+    // procedure local remains an ordinary local and must not inherit it.
+    for src in [
+        "proc global_lazy {} { global tcl_precision; set seen $tcl_precision; unset tcl_precision; puts $tcl_precision }\n",
+        "proc global_lazy_return {} { global tcl_precision; set seen $tcl_precision; unset tcl_precision; return $tcl_precision }\n",
+        "set seen $::tcl_precision\nunset ::tcl_precision\nputs $::tcl_precision\n",
+    ] {
+        let result = Analyser::new().analyse(src, "tcl8.6");
+        assert!(
+            !result.diagnostics.iter().any(|d| d.code == DiagCode::W210),
+            "Tcl 8 global read trace must rematerialise for {src:?}: {:?}",
+            result.diagnostics
+        );
+        assert!(
+            !result.diagnostics.iter().any(|d| d.code == DiagCode::W213),
+            "a prior Tcl 8 trace read makes its unset valid for {src:?}: {:?}",
+            result.diagnostics
+        );
+    }
+    let result = Analyser::new().analyse(
+        "proc local_lazy {} { unset tcl_precision; puts $tcl_precision }\n",
+        "tcl8.6",
+    );
+    assert!(
+        result.diagnostics.iter().any(|d| d.code == DiagCode::W210),
+        "a same-named procedure local must remain undefined: {:?}",
+        result.diagnostics
+    );
+
+    // Readability through a trace is not eager existence.  In a fresh Tcl 8
+    // interpreter `unset tcl_precision` itself errors; once an ordinary read
+    // has materialised it, the unset is valid.  Eager argv is valid to unset
+    // immediately, yet its later read remains W210.
+    let fresh_unset = Analyser::new().analyse("unset tcl_precision\n", "tcl8.6");
+    assert!(
+        fresh_unset
+            .diagnostics
+            .iter()
+            .any(|d| d.code == DiagCode::W213),
+        "a fresh lazy trace must not be mistaken for an eager binding: {:?}",
+        fresh_unset.diagnostics
+    );
+    let materialised_unset = Analyser::new().analyse(
+        "set observed $tcl_precision\nunset tcl_precision\n",
+        "tcl8.6",
+    );
+    assert!(
+        !materialised_unset
+            .diagnostics
+            .iter()
+            .any(|d| d.code == DiagCode::W213),
+        "a prior trace read must make its unset valid: {:?}",
+        materialised_unset.diagnostics
+    );
+    let eager_unset = Analyser::new().analyse("unset argv\nputs $argv\n", "tcl8.6");
+    assert!(
+        !eager_unset
+            .diagnostics
+            .iter()
+            .any(|d| d.code == DiagCode::W213),
+        "an eagerly-bound startup global is safe to unset: {:?}",
+        eager_unset.diagnostics
+    );
+    assert!(
+        eager_unset
+            .diagnostics
+            .iter()
+            .any(|d| d.code == DiagCode::W210),
+        "the later argv read must still see the deletion: {:?}",
+        eager_unset.diagnostics
+    );
+}
+
+#[test]
 fn emit_cfg_ssa_diagnostics_w210_suppressed_when_proc_writes_global() {
     // A helper proc ``init`` writes ``::counter`` via ``set``,
     // so the top-level read should not flag W210 — the proc

--- a/rust/tcl-compiler/src/optimiser/elimination.rs
+++ b/rust/tcl-compiler/src/optimiser/elimination.rs
@@ -1323,6 +1323,32 @@ pub(crate) fn scan_scope_aliases(
     aliases
 }
 
+/// Scan one CFG for registry-declared aliases that target the interpreter's
+/// global namespace.  This is intentionally narrower than
+/// [`scan_scope_aliases`]: a `variable` or `upvar` alias may name a same-named
+/// local or caller variable, whereas a global alias can inherit an
+/// interpreter startup binding.
+pub(crate) fn scan_global_scope_aliases(
+    cfg: &CfgFunction,
+    registry: &tcl_registry::CommandRegistry,
+) -> HashSet<String> {
+    let mut aliases = HashSet::new();
+    for block in cfg.blocks.values() {
+        for stmt in &block.statements {
+            if let Statement::Call { command, args, .. } = stmt {
+                for i in
+                    crate::var_scoping::global_scope_alias_local_indices(registry, command, args)
+                {
+                    if let Some(alias) = args.get(i) {
+                        aliases.insert(alias.clone());
+                    }
+                }
+            }
+        }
+    }
+    aliases
+}
+
 /// Module-wide set of namespace-qualified (`::`) globals that carry a variable
 /// **write trace** anywhere in the compilation unit.
 ///

--- a/rust/tcl-compiler/src/var_scoping.rs
+++ b/rust/tcl-compiler/src/var_scoping.rs
@@ -172,6 +172,36 @@ pub fn scope_alias_local_indices(
         .collect()
 }
 
+/// Indices (into `args`) of the local names bound to the interpreter's
+/// global namespace by this registry-described command, or empty when the
+/// alias targets a namespace or caller frame instead.
+///
+/// This refines [`scope_alias_local_indices`] with the registry-owned
+/// [`tcl_registry::Traits::ALIASES_GLOBAL`] fact.  It deliberately does not
+/// name Tcl's `global` command: a dialect extension can declare the same
+/// target scope without teaching analysis consumers another spelling.
+#[must_use]
+pub fn global_scope_alias_local_indices(
+    registry: &tcl_registry::CommandRegistry,
+    command: &str,
+    args: &[String],
+) -> Vec<usize> {
+    let canonical = command.trim_start_matches(':');
+    let Some(spec) = registry.get(canonical) else {
+        return Vec::new();
+    };
+    if !spec
+        .traits
+        .contains(tcl_registry::prelude::Traits::ALIASES_GLOBAL)
+    {
+        return Vec::new();
+    }
+    registry_role_indices(registry, canonical, args)
+        .into_iter()
+        .filter(|&i| args.get(i).is_some_and(|a| !a.starts_with('$')))
+        .collect()
+}
+
 /// Indices (into `args`) of the variable names a scope-alias command
 /// *declares* for **navigation** consumers (the LSP go-to-declaration
 /// provider), or empty for any other command. Layout and parity come from the
@@ -230,6 +260,18 @@ mod tests {
     #[test]
     fn global_decls_empty_input() {
         assert!(global_declaration_indices(&[]).is_empty());
+    }
+
+    #[test]
+    fn global_scope_aliases_are_registry_described() {
+        let registry = tcl_registry::CommandRegistry::build_default();
+        assert_eq!(
+            global_scope_alias_local_indices(&registry, "global", &v(&["x", "y"])),
+            vec![0, 1]
+        );
+        assert!(
+            global_scope_alias_local_indices(&registry, "upvar", &v(&["1", "x", "y"])).is_empty()
+        );
     }
 
     // -- variable --

--- a/rust/tcl-registry/src/command_snapshot.rs
+++ b/rust/tcl-registry/src/command_snapshot.rs
@@ -54,6 +54,7 @@ const TRAIT_FLAGS: &[(&str, Traits)] = &[
     ("byte_compiled", Traits::BYTE_COMPILED),
     ("configures_channel", Traits::CONFIGURES_CHANNEL),
     ("creates_dynamic_barrier", Traits::CREATES_DYNAMIC_BARRIER),
+    ("aliases_global", Traits::ALIASES_GLOBAL),
     ("creates_scope_alias", Traits::CREATES_SCOPE_ALIAS),
     ("cse_candidate", Traits::CSE_CANDIDATE),
     ("defines_procedure", Traits::DEFINES_PROCEDURE),

--- a/rust/tcl-registry/src/commands/tcl/global_.rs
+++ b/rust/tcl-registry/src/commands/tcl/global_.rs
@@ -111,6 +111,7 @@ pub fn spec() -> CommandSpec {
             | Traits::LANGUAGE_KEYWORD
             | Traits::CREATES_BARRIER
             | Traits::CREATES_SCOPE_ALIAS
+            | Traits::ALIASES_GLOBAL
             | Traits::CREATES_DYNAMIC_BARRIER
             | Traits::FRAME_HASH_BUILTIN,
         // `global ?varName ...?` in Tcl 8.6/9.0/9.1 (and Expect/Synopsys/

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -274,8 +274,8 @@ pub use spec::{
 };
 pub use special_vars::{
     SPECIAL_VARS, SpecialVarKey, SpecialVarKind, SpecialVarSpec, StartupBinding, VarAccess,
-    VarOrigin, is_externally_read, is_readable_at_startup, is_special_var, special_var,
-    special_var_in_dialect, special_var_read_taint, special_var_write_effect,
+    VarOrigin, is_externally_read, is_lazily_readable, is_readable_at_startup, is_special_var,
+    special_var, special_var_in_dialect, special_var_read_taint, special_var_write_effect,
     special_vars_for_dialect,
 };
 pub use state_transition::{

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -273,9 +273,10 @@ pub use spec::{
     SubCommand, SubSubCommand, VersionedArgValue,
 };
 pub use special_vars::{
-    SPECIAL_VARS, SpecialVarKey, SpecialVarKind, SpecialVarSpec, VarAccess, VarOrigin,
-    is_externally_read, is_special_var, special_var, special_var_in_dialect,
-    special_var_read_taint, special_var_write_effect, special_vars_for_dialect,
+    SPECIAL_VARS, SpecialVarKey, SpecialVarKind, SpecialVarSpec, StartupBinding, VarAccess,
+    VarOrigin, is_externally_read, is_readable_at_startup, is_special_var, special_var,
+    special_var_in_dialect, special_var_read_taint, special_var_write_effect,
+    special_vars_for_dialect,
 };
 pub use state_transition::{
     AbruptTransitionTransfer, CallerFrameSelection, ChildInterpreterSafety,

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -274,9 +274,9 @@ pub use spec::{
 };
 pub use special_vars::{
     SPECIAL_VARS, SpecialVarKey, SpecialVarKind, SpecialVarSpec, StartupBinding, VarAccess,
-    VarOrigin, is_externally_read, is_lazily_readable, is_readable_at_startup, is_special_var,
-    special_var, special_var_in_dialect, special_var_read_taint, special_var_write_effect,
-    special_vars_for_dialect,
+    VarOrigin, is_externally_read, is_initially_bound, is_lazily_readable, is_readable_at_startup,
+    is_special_var, special_var, special_var_in_dialect, special_var_read_taint,
+    special_var_write_effect, special_vars_for_dialect,
 };
 pub use state_transition::{
     AbruptTransitionTransfer, CallerFrameSelection, ChildInterpreterSafety,

--- a/rust/tcl-registry/src/special_vars.rs
+++ b/rust/tcl-registry/src/special_vars.rs
@@ -296,6 +296,18 @@ pub fn is_readable_at_startup(name: &str, dialect: &str) -> bool {
     special_var(name).is_some_and(|v| v.readable_at_startup_in(resolved))
 }
 
+/// Whether `name` is eagerly bound before user code in the default startup
+/// context for `dialect`.
+///
+/// Unlike [`is_readable_at_startup`], this excludes a read trace such as Tcl
+/// 8.x `tcl_precision`: an initial read is valid there, but a first `unset`
+/// still fails until that trace has materialised a value.
+#[must_use]
+pub fn is_initially_bound(name: &str, dialect: &str) -> bool {
+    let resolved = resolve_dialect(dialect);
+    special_var(name).is_some_and(|v| v.initially_bound.intersects(resolved))
+}
+
 /// Whether reading `name` in `dialect` invokes a registry-declared Tcl read
 /// trace which can materialise the value again after `unset`.  Unlike
 /// [`is_readable_at_startup`], this intentionally excludes eager startup
@@ -932,6 +944,8 @@ mod tests {
         );
         assert!(is_readable_at_startup("tcl_precision", "tcl8.6"));
         assert!(!is_readable_at_startup("tcl_precision", "tcl9.0"));
+        assert!(!is_initially_bound("tcl_precision", "tcl8.6"));
+        assert!(is_initially_bound("argv", "tcl8.6"));
         assert!(is_lazily_readable("tcl_precision", "tcl8.6"));
         assert!(!is_lazily_readable("tcl_precision", "tcl9.0"));
         assert!(!is_lazily_readable("argv", "tcl8.6"));

--- a/rust/tcl-registry/src/special_vars.rs
+++ b/rust/tcl-registry/src/special_vars.rs
@@ -27,8 +27,11 @@
 //! * A **write is observed by the runtime** even when the script never reads
 //!   the value back (`set auto_path …` configures the package auto-loader).
 //!   Such a write is *not* a dead store / unused variable (issue #831).
-//! * A **read is always defined** — the interpreter seeds the variable before
-//!   user code runs — so a bare read is never read-before-set.
+//! * Some entries are **readable at startup** — either because the default
+//!   host / interpreter / `init.tcl` has already bound them, or because a core
+//!   read trace materialises their value.  That lifecycle fact, rather than
+//!   special-variable availability alone, suppresses W210 for the initial
+//!   top-level read.
 //!
 //! Beyond existence, each spec records the *effects* a read or write carries so
 //! the side-effect and taint analyses can consult one table instead of
@@ -91,6 +94,27 @@ pub enum VarOrigin {
     Dialect,
 }
 
+/// The lifecycle event that makes a special variable readable before user
+/// code.  Availability is deliberately separate: a recognised special
+/// variable may instead be created lazily by a library command, on error, or
+/// by user configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StartupBinding {
+    /// No startup guarantee.  The variable may still be a meaningful runtime
+    /// control, but a direct read must satisfy ordinary Tcl scoping rules.
+    None,
+    /// Bound by the standard interpreter / platform initialisation.
+    Interpreter,
+    /// Bound by a successful standard-library `Tcl_Init` / `init.tcl` run.
+    TclInit,
+    /// Bound by the default `Tcl_Main` command-line host.
+    TclMain,
+    /// Bound by the standard `tclsh` application initialisation.
+    AppInit,
+    /// A core read trace materialises the value on the first direct read.
+    ReadTrace,
+}
+
 /// One known key of an array-shaped special variable, with the dialects that
 /// provide it. Arrays with open, data-dependent keys (`env`, `auto_index`)
 /// carry an empty key list.
@@ -99,7 +123,7 @@ pub struct SpecialVarKey {
     /// The array index (`os`, `wordSize`, `tmmVersion`).
     pub key: &'static str,
     /// Dialects in which this key is present. `tcl_platform(tmmVersion)` is
-    /// iRules-only; `tcl_platform(pointerSize)` is Tcl 8.6+.
+    /// iRules-only; `tcl_platform(pointerSize)` is Tcl 8.5+.
     pub dialects: DialectSet,
     /// One-line description for hover.
     pub summary: &'static str,
@@ -120,6 +144,25 @@ pub struct SpecialVarSpec {
     /// Dialects that provide this variable. A membership test against the
     /// active dialect decides whether the variable exists there.
     pub dialects: DialectSet,
+    /// Dialects in which the default host has bound this global before user
+    /// code runs.  This is deliberately independent of [`Self::dialects`]:
+    /// a runtime-sensitive variable such as `errorInfo` or `auto_execs` can
+    /// exist as a recognised special-variable surface without having an
+    /// initial value.
+    ///
+    /// These are startup-*global* facts only.  They do not make a same-named
+    /// procedure local defined, and a later `unset` removes the binding.
+    pub initially_bound: DialectSet,
+    /// Dialects where an otherwise-unbound direct read is defined by a core
+    /// read trace.  Tcl 8.x's `tcl_precision` is the current example: it is
+    /// not materialised in a fresh globals snapshot, but `$tcl_precision`
+    /// reads as `0`.  A read trace is semantically equivalent to an entry
+    /// binding for W210, but must remain distinct for lifecycle auditing.
+    pub lazily_readable: DialectSet,
+    /// Lifecycle event behind [`Self::initially_bound`] or
+    /// [`Self::lazily_readable`].  It documents why W210 can treat only the
+    /// initial global version as defined.
+    pub startup_binding: StartupBinding,
     /// Known array keys (empty for scalars, namespaces, and open-keyed
     /// arrays). Each key is itself dialect-gated.
     pub keys: &'static [SpecialVarKey],
@@ -160,6 +203,14 @@ impl SpecialVarSpec {
         self.dialects.intersects(dialect)
     }
 
+    /// Whether a read from the initial, default global scope is defined in
+    /// `dialect`.  This combines an eager startup binding with any documented
+    /// lazy read trace; callers must still account for scope and later writes.
+    #[must_use]
+    pub fn readable_at_startup_in(&self, dialect: DialectSet) -> bool {
+        self.initially_bound.intersects(dialect) || self.lazily_readable.intersects(dialect)
+    }
+
     /// The known keys of this array that are present in `dialect`.
     pub fn keys_in(&self, dialect: DialectSet) -> impl Iterator<Item = &SpecialVarKey> {
         self.keys
@@ -187,7 +238,7 @@ impl SpecialVarSpec {
 ///   *host* interpreter (not the TMM sandbox), so the standard interpreter
 ///   globals resolve there — the old bare-`IAPPS` view wrongly hid them.
 /// * A specific Tcl version (`tcl8.6`) keeps its exact bit, so per-key
-///   version gating (`tcl_platform(pointerSize)` is 8.6+) stays precise.
+///   version gating (`tcl_platform(pointerSize)` is 8.5+) stays precise.
 /// * A vendor shell (Expect, the EDA tools) composes its documented embedded
 ///   Tcl base with its own bit (`TCL86|EXPECT`, …) — the standard globals
 ///   resolve, but keys introduced *after* the embedded base version no
@@ -225,11 +276,24 @@ pub fn special_var_in_dialect(name: &str, dialect: &str) -> Option<&'static Spec
 
 /// Whether `name` is an interpreter-provided special variable in `dialect`.
 ///
-/// A read of such a name is always defined (the runtime seeds it before user
-/// code runs), so it is never read-before-set.
+/// This is an availability / metadata query.  It is intentionally *not* a
+/// W210 predicate: a number of special variables are created only after a
+/// runtime event or library call.
 #[must_use]
 pub fn is_special_var(name: &str, dialect: &str) -> bool {
     special_var_in_dialect(name, dialect).is_some()
+}
+
+/// Whether a bare global `name` is readable before user code has written it
+/// in the default startup context for `dialect`.
+///
+/// Consumers must apply this only to an initial global SSA version.  A
+/// procedure-local variable of the same name, or a version killed by `unset`,
+/// remains a genuine read-before-set.
+#[must_use]
+pub fn is_readable_at_startup(name: &str, dialect: &str) -> bool {
+    let resolved = resolve_dialect(dialect);
+    special_var(name).is_some_and(|v| v.readable_at_startup_in(resolved))
 }
 
 /// Whether a *write* to `name` in `dialect` is observed by the runtime — so
@@ -300,8 +364,8 @@ const TCL_PLATFORM_KEYS: &[SpecialVarKey] = &[
     },
     SpecialVarKey {
         key: "pointerSize",
-        dialects: DialectSet::TCL86_PLUS,
-        summary: "Size in bytes of a native pointer (Tcl 8.6+).",
+        dialects: DialectSet::TCL85_PLUS,
+        summary: "Size in bytes of a native pointer (Tcl 8.5+).",
     },
     SpecialVarKey {
         key: "user",
@@ -310,23 +374,23 @@ const TCL_PLATFORM_KEYS: &[SpecialVarKey] = &[
     },
     SpecialVarKey {
         key: "engine",
-        dialects: DialectSet::TCL86_PLUS,
-        summary: "Interpreter engine name — `Tcl` for the reference implementation (8.6+).",
+        dialects: DialectSet::TCL85_PLUS,
+        summary: "Interpreter engine name — `Tcl` for the reference implementation (8.5+).",
     },
     SpecialVarKey {
         key: "pathSeparator",
-        dialects: DialectSet::TCL90_PLUS,
-        summary: "Separator between paths in a search-path list (Tcl 9.0+).",
+        dialects: DialectSet::TCL86_PLUS,
+        summary: "Separator between paths in a search-path list (Tcl 8.6+).",
     },
     SpecialVarKey {
         key: "threaded",
-        dialects: DialectSet::ALL_TCL,
-        summary: "Present and true when the interpreter was built with threads.",
+        dialects: DialectSet::TCL8X,
+        summary: "Present on Tcl 8.x builds configured with thread support.",
     },
     SpecialVarKey {
         key: "debug",
-        dialects: DialectSet::ALL_TCL,
-        summary: "Present when built with symbolic debugging enabled.",
+        dialects: DialectSet::TCL8X,
+        summary: "Present on Tcl 8.x Windows debug builds.",
     },
     SpecialVarKey {
         key: "tmmVersion",
@@ -348,6 +412,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadOnly,
         origin: VarOrigin::Interpreter,
         dialects: DialectSet::ALL_TCL,
+        initially_bound: DialectSet::ALL_TCL,
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::TclMain,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -361,6 +428,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadWrite,
         origin: VarOrigin::Interpreter,
         dialects: DialectSet::ALL_TCL,
+        initially_bound: DialectSet::ALL_TCL,
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::TclMain,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -374,6 +444,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadOnly,
         origin: VarOrigin::Interpreter,
         dialects: DialectSet::ALL_TCL,
+        initially_bound: DialectSet::ALL_TCL,
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::TclMain,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -388,6 +461,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadWrite,
         origin: VarOrigin::AutoLoader,
         dialects: DialectSet::ALL_TCL,
+        initially_bound: DialectSet::ALL_TCL,
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::TclInit,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -402,6 +478,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadWrite,
         origin: VarOrigin::AutoLoader,
         dialects: DialectSet::ALL_TCL,
+        initially_bound: DialectSet::empty(),
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::None,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -415,6 +494,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadWrite,
         origin: VarOrigin::AutoLoader,
         dialects: DialectSet::ALL_TCL,
+        initially_bound: DialectSet::empty(),
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::None,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -428,6 +510,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadWrite,
         origin: VarOrigin::AutoLoader,
         dialects: DialectSet::ALL_TCL,
+        initially_bound: DialectSet::empty(),
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::None,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -441,6 +526,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadWrite,
         origin: VarOrigin::AutoLoader,
         dialects: DialectSet::ALL_TCL,
+        initially_bound: DialectSet::empty(),
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::None,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -455,6 +543,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadWrite,
         origin: VarOrigin::Environment,
         dialects: DialectSet::ALL_TCL,
+        initially_bound: DialectSet::ALL_TCL,
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::Interpreter,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -464,12 +555,18 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
                   keys are environment-variable names.",
     },
     // ── Error context ──────────────────────────────────────────────────────
+    // Tcl 8.4's default `init.tcl` unconditionally initialises these after a
+    // successful Tcl_Init. Later releases intentionally leave them absent
+    // until an error occurs, and plain Tcl_CreateInterp does not qualify.
     SpecialVarSpec {
         name: "errorInfo",
         kind: SpecialVarKind::Scalar,
         access: VarAccess::ReadWrite,
         origin: VarOrigin::Interpreter,
         dialects: DialectSet::ALL_TCL.union(DialectSet::IRULES),
+        initially_bound: DialectSet::TCL84,
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::TclInit,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -483,6 +580,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadWrite,
         origin: VarOrigin::Interpreter,
         dialects: DialectSet::ALL_TCL.union(DialectSet::IRULES),
+        initially_bound: DialectSet::TCL84,
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::TclInit,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -497,6 +597,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadOnly,
         origin: VarOrigin::Interpreter,
         dialects: DialectSet::ALL_TCL.union(DialectSet::IRULES),
+        initially_bound: DialectSet::ALL_TCL.union(DialectSet::IRULES),
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::Interpreter,
         keys: &[],
         externally_read: false,
         cmp_unsafe: true,
@@ -510,6 +613,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadOnly,
         origin: VarOrigin::Interpreter,
         dialects: DialectSet::ALL_TCL.union(DialectSet::IRULES),
+        initially_bound: DialectSet::ALL_TCL.union(DialectSet::IRULES),
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::Interpreter,
         keys: &[],
         externally_read: false,
         cmp_unsafe: true,
@@ -523,6 +629,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadWrite,
         origin: VarOrigin::Interpreter,
         dialects: DialectSet::ALL_TCL,
+        initially_bound: DialectSet::ALL_TCL,
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::TclInit,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -536,6 +645,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadWrite,
         origin: VarOrigin::Interpreter,
         dialects: DialectSet::ALL_TCL,
+        initially_bound: DialectSet::ALL_TCL,
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::Interpreter,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -549,6 +661,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadOnly,
         origin: VarOrigin::Platform,
         dialects: DialectSet::ALL_TCL.union(DialectSet::IRULES),
+        initially_bound: DialectSet::ALL_TCL.union(DialectSet::IRULES),
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::Interpreter,
         keys: TCL_PLATFORM_KEYS,
         externally_read: false,
         cmp_unsafe: true,
@@ -562,7 +677,10 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         kind: SpecialVarKind::Scalar,
         access: VarAccess::ReadWrite,
         origin: VarOrigin::Interpreter,
-        dialects: DialectSet::ALL_TCL,
+        dialects: DialectSet::TCL8X,
+        initially_bound: DialectSet::empty(),
+        lazily_readable: DialectSet::TCL8X,
+        startup_binding: StartupBinding::ReadTrace,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -576,6 +694,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadWrite,
         origin: VarOrigin::Interpreter,
         dialects: DialectSet::ALL_TCL,
+        initially_bound: DialectSet::ALL_TCL,
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::AppInit,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -589,6 +710,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadWrite,
         origin: VarOrigin::Interpreter,
         dialects: DialectSet::ALL_TCL,
+        initially_bound: DialectSet::ALL_TCL,
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::TclMain,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -602,6 +726,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadWrite,
         origin: VarOrigin::Interpreter,
         dialects: DialectSet::ALL_TCL,
+        initially_bound: DialectSet::empty(),
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::None,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -615,6 +742,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadWrite,
         origin: VarOrigin::Interpreter,
         dialects: DialectSet::ALL_TCL,
+        initially_bound: DialectSet::empty(),
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::None,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -628,6 +758,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadWrite,
         origin: VarOrigin::Interpreter,
         dialects: DialectSet::ALL_TCL,
+        initially_bound: DialectSet::empty(),
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::None,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -641,6 +774,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadWrite,
         origin: VarOrigin::Interpreter,
         dialects: DialectSet::ALL_TCL,
+        initially_bound: DialectSet::empty(),
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::None,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -654,6 +790,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadWrite,
         origin: VarOrigin::Interpreter,
         dialects: DialectSet::ALL_TCL,
+        initially_bound: DialectSet::empty(),
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::None,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -667,6 +806,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadWrite,
         origin: VarOrigin::Interpreter,
         dialects: DialectSet::ALL_TCL,
+        initially_bound: DialectSet::empty(),
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::None,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -681,6 +823,9 @@ pub const SPECIAL_VARS: &[SpecialVarSpec] = &[
         access: VarAccess::ReadWrite,
         origin: VarOrigin::Dialect,
         dialects: DialectSet::IRULES,
+        initially_bound: DialectSet::empty(),
+        lazily_readable: DialectSet::empty(),
+        startup_binding: StartupBinding::None,
         keys: &[],
         externally_read: true,
         cmp_unsafe: false,
@@ -709,6 +854,88 @@ mod tests {
         assert!(!is_special_var("myVar", "tcl8.6"));
         assert!(!is_externally_read("myVar", "tcl8.6"));
         assert!(special_var("myVar").is_none());
+    }
+
+    #[test]
+    fn startup_readability_is_lifecycle_not_special_var_availability() {
+        // This fixture is the audited default-host contract for an ordinary
+        // Tcl script: it catches both an omitted startup global and an
+        // accidental promotion of a lazy/configuration-only special var.
+        // In particular, 8.4's successful default Tcl_Init runs init.tcl's
+        // unconditional `set errorCode ""` / `set errorInfo ""`; 8.5+ does
+        // not seed either name until error handling creates it.
+        let common = [
+            "argc",
+            "argv",
+            "argv0",
+            "auto_path",
+            "env",
+            "tcl_interactive",
+            "tcl_library",
+            "tcl_patchLevel",
+            "tcl_pkgPath",
+            "tcl_platform",
+            "tcl_rcFileName",
+            "tcl_version",
+        ];
+        for dialect in ["tcl8.4", "tcl8.5", "tcl8.6", "tcl9.0", "tcl9.1"] {
+            let mut expected = common.to_vec();
+            if dialect == "tcl8.4" {
+                expected.extend(["errorCode", "errorInfo"]);
+            }
+            if matches!(dialect, "tcl8.4" | "tcl8.5" | "tcl8.6") {
+                expected.push("tcl_precision");
+            }
+            expected.sort_unstable();
+
+            let mut actual: Vec<_> = SPECIAL_VARS
+                .iter()
+                .filter(|spec| spec.readable_at_startup_in(resolve_dialect(dialect)))
+                .map(|spec| spec.name)
+                .collect();
+            actual.sort_unstable();
+            assert_eq!(actual, expected, "startup-readable vars for {dialect}");
+        }
+
+        // The embedded iRules runtime has a deliberately smaller proven
+        // startup surface.  In particular, namespace availability for
+        // `static::` does not promise a value for arbitrary static variables.
+        let mut irules: Vec<_> = SPECIAL_VARS
+            .iter()
+            .filter(|spec| spec.readable_at_startup_in(resolve_dialect("f5-irules")))
+            .map(|spec| spec.name)
+            .collect();
+        irules.sort_unstable();
+        assert_eq!(irules, ["tcl_patchLevel", "tcl_platform", "tcl_version"]);
+
+        assert_eq!(
+            special_var("argv").unwrap().startup_binding,
+            StartupBinding::TclMain
+        );
+        assert_eq!(
+            special_var("tcl_precision").unwrap().startup_binding,
+            StartupBinding::ReadTrace
+        );
+        assert!(is_readable_at_startup("tcl_precision", "tcl8.6"));
+        assert!(!is_readable_at_startup("tcl_precision", "tcl9.0"));
+        // iApps uses its host Tcl interpreter profile, whereas the embedded
+        // iRules runtime has only the explicitly evidenced metadata globals.
+        assert!(is_readable_at_startup("argv", "f5-iapps"));
+        assert!(!is_readable_at_startup("argv", "f5-irules"));
+        // `auto_index` can materialise after interactive activity or an
+        // auto-loader operation, but an ordinary default-host script begins
+        // with no array and a direct `$auto_index` / `$auto_index(key)` read
+        // still errors. The other names below are likewise special metadata,
+        // not default startup bindings.
+        for name in [
+            "auto_index",
+            "auto_execs",
+            "auto_noexec",
+            "auto_noload",
+            "static",
+        ] {
+            assert!(!is_readable_at_startup(name, "tcl8.6"), "{name}");
+        }
     }
 
     #[test]
@@ -745,7 +972,13 @@ mod tests {
         assert!(irules_keys.contains(&"os"));
         assert!(!irules_keys.contains(&"pointerSize")); // Tcl-only key
 
-        // `pointerSize` is Tcl 8.6+, absent in 8.4.
+        // `pointerSize` arrived in Tcl 8.5, while `pathSeparator` arrived in
+        // Tcl 8.6; build-only keys are deliberately not advertised by a
+        // release-only profile.
+        let keys_85: Vec<_> = spec
+            .keys_in(resolve_dialect("tcl8.5"))
+            .map(|k| k.key)
+            .collect();
         let keys_86: Vec<_> = spec
             .keys_in(resolve_dialect("tcl8.6"))
             .map(|k| k.key)
@@ -754,8 +987,13 @@ mod tests {
             .keys_in(resolve_dialect("tcl8.4"))
             .map(|k| k.key)
             .collect();
+        assert!(keys_85.contains(&"pointerSize"));
         assert!(keys_86.contains(&"pointerSize"));
         assert!(!keys_84.contains(&"pointerSize"));
+        assert!(!keys_85.contains(&"pathSeparator"));
+        assert!(keys_86.contains(&"pathSeparator"));
+        assert!(!keys_86.contains(&"threaded"));
+        assert!(!keys_86.contains(&"debug"));
         assert!(!keys_86.contains(&"tmmVersion")); // iRules-only key absent in Tcl
     }
 
@@ -853,7 +1091,7 @@ mod tests {
     #[test]
     fn version_dialects_keep_exact_bit_for_per_key_gating() {
         // A specific Tcl version must not be widened to ALL_TCL, or per-key
-        // version gating (pointerSize is 8.6+) would leak into 8.4.
+        // version gating (pointerSize is 8.5+) would leak into 8.4.
         assert_eq!(resolve_dialect("tcl8.4"), DialectSet::TCL84);
         let spec = special_var("tcl_platform").unwrap();
         let keys_84: Vec<_> = spec

--- a/rust/tcl-registry/src/special_vars.rs
+++ b/rust/tcl-registry/src/special_vars.rs
@@ -296,6 +296,17 @@ pub fn is_readable_at_startup(name: &str, dialect: &str) -> bool {
     special_var(name).is_some_and(|v| v.readable_at_startup_in(resolved))
 }
 
+/// Whether reading `name` in `dialect` invokes a registry-declared Tcl read
+/// trace which can materialise the value again after `unset`.  Unlike
+/// [`is_readable_at_startup`], this intentionally excludes eager startup
+/// bindings such as `argv`: deleting those leaves an ordinary undefined Tcl
+/// variable.
+#[must_use]
+pub fn is_lazily_readable(name: &str, dialect: &str) -> bool {
+    let resolved = resolve_dialect(dialect);
+    special_var(name).is_some_and(|v| v.lazily_readable.intersects(resolved))
+}
+
 /// Whether a *write* to `name` in `dialect` is observed by the runtime — so
 /// `set NAME …` must not be flagged as a dead store (W220) or unused variable
 /// (W211) even when the script never reads `$NAME`. This is the fix for the
@@ -384,13 +395,16 @@ const TCL_PLATFORM_KEYS: &[SpecialVarKey] = &[
     },
     SpecialVarKey {
         key: "threaded",
-        dialects: DialectSet::TCL8X,
-        summary: "Present on Tcl 8.x builds configured with thread support.",
+        // Build conditional (`TCL_THREADS`), so no release-only profile can
+        // promise this key to ordinary user code.
+        dialects: DialectSet::empty(),
+        summary: "Present only on Tcl 8.x builds configured with thread support.",
     },
     SpecialVarKey {
         key: "debug",
-        dialects: DialectSet::TCL8X,
-        summary: "Present on Tcl 8.x Windows debug builds.",
+        // Windows debug-build conditional, likewise not a release fact.
+        dialects: DialectSet::empty(),
+        summary: "Present only on Tcl 8.x Windows debug builds.",
     },
     SpecialVarKey {
         key: "tmmVersion",
@@ -918,6 +932,9 @@ mod tests {
         );
         assert!(is_readable_at_startup("tcl_precision", "tcl8.6"));
         assert!(!is_readable_at_startup("tcl_precision", "tcl9.0"));
+        assert!(is_lazily_readable("tcl_precision", "tcl8.6"));
+        assert!(!is_lazily_readable("tcl_precision", "tcl9.0"));
+        assert!(!is_lazily_readable("argv", "tcl8.6"));
         // iApps uses its host Tcl interpreter profile, whereas the embedded
         // iRules runtime has only the explicitly evidenced metadata globals.
         assert!(is_readable_at_startup("argv", "f5-iapps"));

--- a/rust/tcl-registry/src/traits.rs
+++ b/rust/tcl-registry/src/traits.rs
@@ -279,6 +279,12 @@ declare_traits! {
     ReadsBeforeWrite => READS_BEFORE_WRITE;
     /// Creates a scope alias — upvar-like binding (`upvar`, `global`, `variable`).
     CreatesScopeAlias => CREATES_SCOPE_ALIAS;
+    /// Creates an alias to the interpreter's global namespace (`global`).
+    ///
+    /// This refines [`Traits::CREATES_SCOPE_ALIAS`] for consumers that need
+    /// to distinguish a global binding from a namespace or caller-frame
+    /// alias.  Alias recognition and target layout remain registry-owned.
+    AliasesGlobal => ALIASES_GLOBAL;
     /// Creates a runtime control-flow barrier (`eval`, `uplevel`, `upvar`).
     CreatesBarrier => CREATES_BARRIER;
 

--- a/rust/tcl-spectcl/src/catalogue.rs
+++ b/rust/tcl-spectcl/src/catalogue.rs
@@ -409,6 +409,10 @@ pub const TRAITS: &[Variant] = &[
     v("DESTROYS_VARIABLE", "destroys a variable"),
     v("READS_BEFORE_WRITE", "reads its target before writing it"),
     v("CREATES_SCOPE_ALIAS", "creates an upvar-like scope alias"),
+    v(
+        "ALIASES_GLOBAL",
+        "creates an alias to the interpreter global namespace",
+    ),
     v("CREATES_BARRIER", "creates an analysis barrier"),
     v("EVALUATES_CODE", "evaluates its argument as code"),
     v("PERFORMS_SUBSTITUTION", "performs Tcl substitution"),


### PR DESCRIPTION
## Summary

- model default Tcl startup bindings centrally with lifecycle- and release-specific registry facts
- use those facts only in the initial global frame, including SSA phi and return propagation
- preserve W210 for proc locals and values made undefined by `unset`
- correct Tcl platform-variable masks and document the audited startup lifecycle

Closes #1557

## Validation

- `ionice -c3 nice -n15 cargo test -p tcl-compiler --lib w210_uses_registry_owned_startup_lifecycle_facts`
- `ionice -c3 nice -n15 make rust-check`
- `ionice -c3 nice -n15 make prep-pr`

All commands verified NI=15 and idle I/O priority. The lifecycle matrix covers Tcl 8.4–9.1, Tcl Main/AppInit variables, Tcl 8.4 `errorInfo`/`errorCode`, Tcl 8.4–8.6 `tcl_precision`, iRules controls, lazy-variable negatives, proc/global scope, `unset`, and phi mutations.