### PR TITLE
ci: install wasm-bindgen for editor release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1020,6 +1020,12 @@ jobs:
           toolchain: stable
           cache-key: build-vsix
 
+      # The VSIX embeds the spec studio, whose real LSP worker is built from
+      # Rust to wasm32 and post-processed with the version matching its lockfile.
+      - name: Install wasm-bindgen CLI
+        uses: taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d # v2.85.12
+        with:
+          tool: wasm-bindgen-cli@0.2.127
 
       # No Python setup: the VSIX bundles native binaries and the build
       # (compile + filter-readme + vsce) is Node-only.
@@ -1191,6 +1197,19 @@ jobs:
           pattern: server-bins-*
           path: target
           merge-multiple: true
+
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          toolchain: stable
+          cache-key: build-jetbrains
+
+      # The JetBrains plugin embeds the same spec studio as the VSIX. Keep the
+      # CLI pinned to the wasm-bindgen crate version in the standalone lockfile.
+      - name: Install wasm-bindgen CLI
+        uses: taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d # v2.85.12
+        with:
+          tool: wasm-bindgen-cli@0.2.127
 
       - name: Set up Java 17
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0


### PR DESCRIPTION
## Summary
- install the pinned `wasm-bindgen-cli@0.2.127` before building the embedded spec studio
- set up stable Rust explicitly in the JetBrains release job

## Context
The v2.1.20 VSIX and JetBrains release jobs failed at `lsp-server-wasm` because the runner did not have `wasm-bindgen` installed. Both standalone WASM lockfiles resolve wasm-bindgen 0.2.127, matching the pinned CLI here.

## Validation
- workflow YAML parses successfully
- `git diff --check` passes
- `make rust-check` reaches the standalone WASM lint but is blocked locally by Apple Clang lacking wasm32 target support while compiling `ring`
- `make prep-pr` is blocked by unavailable local uv/PyPI access; no generated files changed