### PR TITLE
Model `classvariable` as the class-level scope alias it is

### DIFF
--- a/rust/tcl-compiler/src/analyser/oo.rs
+++ b/rust/tcl-compiler/src/analyser/oo.rs
@@ -6093,6 +6093,179 @@ mod tests {
         );
     }
 
+    /// Issue #1593 — the reporter's snippet. A class-shared variable set up
+    /// by the class-level `initialize` script and reached from a method
+    /// through `classvariable` must not draw a read-before-set.
+    ///
+    /// Oracled on tclsh 9.0.4: this exact class answers `5e-6`. The
+    /// `initialize` body runs in the class's own object namespace, so the
+    /// write and the read live in different frames — which is precisely why
+    /// `classvariable` has to be modelled as a declaration rather than as a
+    /// plain local.
+    #[test]
+    fn classvariable_reaches_a_variable_initialise_declared() {
+        let src = "oo::class create Foo {\n\
+                   initialize {\n\
+                   variable Pitch\n\
+                   const Pitch 5e-6\n\
+                   }\n\
+                   method m {} { classvariable Pitch; return $Pitch }\n\
+                   }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl9.0");
+        assert!(
+            !r.diagnostics.iter().any(|d| d.code.as_str() == "W210"),
+            "classvariable reaches the initialise-declared cell: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// The near variants of the reporter's shape, each **run** on tclsh
+    /// 9.0.4 first: a plain `set` instead of `const`, a value-bearing
+    /// `variable`, the British `initialise` spelling, the `oo::define`
+    /// form, two names in one `classvariable` call (the second name used to
+    /// be left unbound because only index 0 carried a `VarWrite` role), and
+    /// a write/read split across two methods.
+    ///
+    /// The reporter's `variable Pitch` before the `const` is load-bearing,
+    /// not noise: an `initialize` script runs in a call frame, so a bare
+    /// `const Pitch 5e-6` there makes a *frame-local* constant that no
+    /// method can reach (tclsh 9.0.4: `can't read "Pitch": no such
+    /// variable`). Only the `variable` declaration aims the write at the
+    /// class-shared cell — which is why that shape is absent from this
+    /// clean-list.
+    #[test]
+    fn classvariable_variants_stay_clean() {
+        for (label, src) in [
+            (
+                "set instead of const",
+                "oo::class create Foo {\n\
+                 initialize { variable Pitch; set Pitch 5e-6 }\n\
+                 method m {} { classvariable Pitch; return $Pitch }\n\
+                 }",
+            ),
+            (
+                "value-bearing variable",
+                "oo::class create Foo {\n\
+                 initialize { variable Pitch 5e-6 }\n\
+                 method m {} { classvariable Pitch; return $Pitch }\n\
+                 }",
+            ),
+            (
+                "initialise spelling",
+                "oo::class create Foo {\n\
+                 initialise { variable Pitch; const Pitch 5e-6 }\n\
+                 method m {} { classvariable Pitch; return $Pitch }\n\
+                 }",
+            ),
+            (
+                "oo::define form",
+                "oo::class create Foo {}\n\
+                 oo::define Foo {\n\
+                 initialize { variable Pitch; const Pitch 5e-6 }\n\
+                 method m {} { classvariable Pitch; return $Pitch }\n\
+                 }",
+            ),
+            (
+                "two names in one call",
+                "oo::class create Foo {\n\
+                 initialize { variable a 1; variable b 2 }\n\
+                 method m {} { classvariable a b; return [list $a $b] }\n\
+                 }",
+            ),
+            (
+                "written in one method, read in another",
+                "oo::class create Foo {\n\
+                 method w {} { classvariable Count; set Count 1 }\n\
+                 method r {} { classvariable Count; return $Count }\n\
+                 }",
+            ),
+            (
+                // The `classvariable(n)` manual page's own example.
+                "manual-page Counted example",
+                "oo::class create Counted {\n\
+                 initialise { variable count 0 }\n\
+                 variable number\n\
+                 constructor {} { classvariable count; set number [incr count] }\n\
+                 method report {} { classvariable count; puts \"$number of $count\" }\n\
+                 }",
+            ),
+        ] {
+            let mut a = Analyser::new();
+            let r = a.analyse(src, "tcl9.0");
+            assert!(
+                !r.diagnostics
+                    .iter()
+                    .any(|d| matches!(d.code.as_str(), "W210" | "W211")),
+                "{label}: {:?}",
+                r.diagnostics
+            );
+        }
+    }
+
+    /// The other half of issue #1593: the fix must not silence a genuine
+    /// unbound read. Without `classvariable`, a method's `$Pitch` is an
+    /// *instance* variable that the class-level `initialize` never wrote —
+    /// tclsh 9.0.4 raises `can't read "Pitch": no such variable` — so W210
+    /// is correct and has to stay.
+    #[test]
+    fn a_method_read_without_classvariable_still_warns() {
+        let src = "oo::class create Foo {\n\
+                   initialize { variable Pitch; const Pitch 5e-6 }\n\
+                   method m {} { return $Pitch }\n\
+                   }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl9.0");
+        assert!(
+            r.diagnostics.iter().any(|d| d.code.as_str() == "W210"),
+            "an instance-side read of a class-scoped cell is a real bug: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// The same snippet under 8.6 reports what 8.6 actually lacks —
+    /// `initialize` and `const` are both 9.0 members — and never W210.
+    /// `classvariable` itself is reachable there only through Tcllib's
+    /// `ooutil`, which the document requires.
+    #[test]
+    fn the_reporter_snippet_under_86_reports_the_missing_commands() {
+        let src = "package require ooutil\n\
+                   oo::class create Foo {\n\
+                   initialize { variable Pitch; const Pitch 5e-6 }\n\
+                   method m {} { classvariable Pitch; return $Pitch }\n\
+                   }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl8.6");
+        let codes: Vec<&str> = r.diagnostics.iter().map(|d| d.code.as_str()).collect();
+        assert!(
+            !codes.contains(&"W210"),
+            "8.6 must not add a read-before-set: {:?}",
+            r.diagnostics
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code.as_str() == "W002" && d.message.contains("'const'")),
+            "8.6 has no `const` (TIP 677 is 9.0): {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// `classvariable` binds only literal, unqualified names: a
+    /// substitution names no cell the analyser can see, so it stays the
+    /// W212 it already was rather than silently declaring `$dyn`.
+    #[test]
+    fn a_dynamic_classvariable_name_is_not_a_declaration() {
+        let src = "oo::class create Foo { method m {} { classvariable $dyn; return $Pitch } }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl9.0");
+        assert!(
+            r.diagnostics.iter().any(|d| d.code.as_str() == "W212"),
+            "a substituted name is still reported: {:?}",
+            r.diagnostics
+        );
+    }
+
     #[test]
     fn oo_property_accessor_bodies_are_walked() {
         // `-get`/`-set` accessor bodies are walked with the instance variable

--- a/rust/tcl-registry/src/commands/tcl/oo_classvariable.rs
+++ b/rust/tcl-registry/src/commands/tcl/oo_classvariable.rs
@@ -46,15 +46,33 @@ const HOVER: HoverSnippet = HoverSnippet {
 };
 
 /// Traits shared by both the core and `ooutil` entries.
+///
+/// `CREATES_SCOPE_ALIAS` carries the fact issue #1593 turned on: like
+/// `variable`, `global`, and `namespace upvar`, `classvariable` binds a
+/// local name to a cell that lives in **another frame** — here the defining
+/// class's namespace, shared by every instance. Consumers key off that one
+/// trait (`var_scoping::scope_alias_local_indices`, which feeds the W211
+/// unused-variable exemption, the optimiser's dead-store elimination, SCCP,
+/// and shimmer thunking), so the fact belongs on the spec rather than in
+/// any one of them.
 const TRAITS: Traits = Traits::LANGUAGE_KEYWORD
     .union(Traits::TCLOO_METHOD_CONTEXT)
-    .union(Traits::TCLOO_REQUIRES_METHOD_FRAME);
+    .union(Traits::TCLOO_REQUIRES_METHOD_FRAME)
+    .union(Traits::CREATES_SCOPE_ALIAS);
 
 const SIDE_EFFECTS: &[SideEffect] = &[SideEffect {
     target: SideEffectTarget::Variable,
     writes: true,
     ..SideEffect::DEFAULT
 }];
+
+/// `classvariable name ?name ...?` — **every** word is a name, with no
+/// interleaved values (`variable`'s layout strides by two; this one by one).
+///
+/// Without this, only the first word carried a `VarWrite` role, so
+/// `classvariable a b` bound `a` and left `b` looking unbound — a false
+/// W210 on the second and later names (issue #1593).
+static REPEATED: &[RepeatedArgLayout] = &[RepeatedArgLayout::strided(ArgRole::VarWrite, 0, 1)];
 
 /// The core Tcl 9.0+ `oo::Helpers::classvariable` — no package needed.
 ///
@@ -74,6 +92,7 @@ pub fn spec() -> CommandSpec {
         arity: Arity::at_least(1),
         return_type: Some(TclType::String),
         side_effects: SIDE_EFFECTS,
+        repeated_args: REPEATED,
         hover: Some(HOVER),
         forms: FORMS,
         ..CommandSpec::DEFAULT
@@ -92,6 +111,7 @@ pub fn spec_ooutil_86() -> CommandSpec {
         arity: Arity::at_least(1),
         return_type: Some(TclType::String),
         side_effects: SIDE_EFFECTS,
+        repeated_args: REPEATED,
         hover: Some(HOVER),
         forms: FORMS,
         tcllib_package: Some("ooutil"),
@@ -124,6 +144,38 @@ mod tests {
         assert_eq!(ooutil.dialects, Some(DialectSet::TCL86));
         assert_eq!(ooutil.required_package, Some("ooutil"));
         assert_eq!(ooutil.tcllib_package, Some("ooutil"));
+    }
+
+    /// Issue #1593. `classvariable` declares a cell in another frame, so
+    /// both entries must carry the scope-alias fact every dataflow consumer
+    /// keys off — without it a `classvariable Count; set Count 1` in one
+    /// method drew W211 "set but never used" even though another method
+    /// reads it (tclsh 9.0.4 runs that shape and answers 1).
+    #[test]
+    fn both_entries_create_a_scope_alias() {
+        for s in [spec(), spec_ooutil_86()] {
+            assert!(
+                s.traits.contains(Traits::CREATES_SCOPE_ALIAS),
+                "{} must declare its names as scope aliases",
+                s.name
+            );
+        }
+    }
+
+    /// Issue #1593. Unlike `variable name ?value?`, **every** word is a
+    /// name, so the repeated layout strides by one — otherwise
+    /// `classvariable a b` bound only `a` and `$b` drew a false W210.
+    #[test]
+    fn every_word_is_a_variable_name() {
+        for s in [spec(), spec_ooutil_86()] {
+            let layout = s
+                .repeated_args
+                .first()
+                .unwrap_or_else(|| panic!("{} needs a repeated-name layout", s.name));
+            assert_eq!(layout.role, ArgRole::VarWrite, "{}", s.name);
+            assert_eq!(layout.start, 0, "{}", s.name);
+            assert_eq!(layout.stride, 1, "{}", s.name);
+        }
     }
 
     /// Scope, not dispatch: both entries resolve only where `::oo::Helpers`


### PR DESCRIPTION
Fixes #1593

## The report

```tcl
    initialize {
        variable Pitch
        const Pitch 5e-6
   }
```

draws a W210 read-before-set. The title — "W210 for **classvariable** variable" — is the load-bearing half: the snippet on its own is clean, and the diagnostic lands on the method that reaches `Pitch` through `classvariable`.

## Root cause

`classvariable` links a method-local name to a variable in the **defining class's** namespace. `classvariable(n)` puts it plainly: *"This is the class-level counterpart to the variable command."* Its spec declared neither half of that, so the analyser treated each name as an ordinary method local. Two false positives followed:

| shape | was | tclsh 9.0.4 |
|---|---|---|
| `initialize {variable Pitch; const Pitch 5e-6}` + `method m {} {classvariable Pitch; return $Pitch}` | **W210** | `5e-6` |
| `method w {} {classvariable Count; set Count 1}` + `method r {} {classvariable Count; return $Count}` | **W211** | `1` |

The second shape is the `classvariable(n)` manual page's own `Counted` example — which this repository already ships verbatim in the spec's `examples` field, and which the analyser was flagging.

## The fix — registry data only

Two fields, on both the core 9.0 entry and the Tcllib `ooutil` 8.6 entry:

- **`Traits::CREATES_SCOPE_ALIAS`** — the trait every dataflow consumer keys off (`var_scoping::scope_alias_local_indices`, which feeds the W211 unused-variable exemption, dead-store elimination, SCCP, and shimmer thunking). This is what `variable`, `global`, and `namespace upvar` already carry.
- **a stride-1 repeated `VarWrite` layout** — every word is a name, unlike `variable name ?value?` which strides by two. Without it `classvariable a b` bound only `a` and `$b` drew a false W210.

No walker learned a command name; no analyser hook was added. An earlier draft added an `AnalyserHookId::ClassVariable` plus a handler — it was reverted once the two registry facts turned out to cover every vector, which is the outcome the owner map wants.

**Mutation-verified**: dropping either field puts its own false positive back, and a test fails for each.

## Deliberately unchanged

A method that reads the cell **without** `classvariable` still draws W210, and should. An `initialize` script runs in the class's own object namespace, so a method's bare `$Pitch` is a different (instance) variable — tclsh 9.0.4 answers `can't read "Pitch": no such variable`.

## Oracle notes

Every expectation was run against tclsh 9.0.4 before being asserted. One correction came out of that: the reporter's `variable Pitch` before the `const` is **not** redundant. An `initialize` script runs in a call frame, so a bare `const Pitch 5e-6` there makes a frame-local constant no method can reach (`can't read "Pitch": no such variable`); only the `variable` declaration aims the write at the class-shared cell. That shape is therefore absent from the clean-list rather than asserted clean.

## Tests

- `rust/tcl-registry/.../oo_classvariable.rs` — the two load-bearing spec facts, on both entries.
- `rust/tcl-compiler/src/analyser/oo.rs` — the reporter's exact snippet; the near variants (`set` instead of `const`, value-bearing `variable`, `initialise` spelling, `oo::define` form, two names in one call, write/read split across methods, the manual-page `Counted` example); the genuine-bug case that must keep warning; the 8.6 dialect, where `initialize` and `const` are correctly reported as 9.0-only rather than as a read-before-set; and a dynamic name, which stays W212 rather than silently declaring `$dyn`.

## Gates

- `make rust-check` — green (fmt, clippy, and all drift gates including `owner-resolution` and `audit-option-dialects`).
- `cargo test -p tcl-registry -p tcl-compiler --no-fail-fast` — green except two `wasm_real_link` tests (`emitted_modules_run_against_the_real_runtime`, `sealed_native_i64_add_runs_and_trace_registration_falls_back`) that **fail identically on clean `origin/rust`** in this container, which builds the runtime without the `libtommath` bignum backend. Verified by stashing this change and re-running.
- `cargo test -p tcl-lsp-core --no-fail-fast` — green (33 suites).

## Follow-ups (out of scope here)

- Our analyser accepts `initialize { const Pitch 5e-6 }` with no prior `variable`, where tclsh fails at runtime — modelling `const`'s frame-local semantics is a separate change. Adjacent to #1584 (declared-unset variables).
- `ClassDef::variables` still does not record names an `initialize` body declares; the class-level init walk accumulates them into a local vector only. Nothing user-visible depends on it today now that `classvariable` binds, but the two representations are worth unifying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o)_