### PR TITLE
fix(lsp): a freshly opened definition no longer strands its callers on W123 (#1619)

### DIFF
--- a/editors/vscode/src/test/crossFileDiagnostics.test.ts
+++ b/editors/vscode/src/test/crossFileDiagnostics.test.ts
@@ -35,7 +35,7 @@
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getDocUri, activate, pollUntil } from "./helper";
+import { getDocUri, activate, pollUntil, waitForDeepDiagnostics } from "./helper";
 
 /** The diagnostic codes present on `uri`, as plain strings. */
 function codesFor(uri: vscode.Uri): string[] {
@@ -89,6 +89,28 @@ suite("Cross-file diagnostics in a multi-file workspace (#1331, #1332)", () => {
   const noTk = getDocUri("crossFileNoTk.tcl");
   const mutableDef = getDocUri("crossFileMutableDef.tcl");
   const mutableCaller = getDocUri("crossFileMutableCaller.tcl");
+
+  // Open the definition once, and wait for the server to have *published* it,
+  // before any test opens a caller (issue #1619).
+  //
+  // `did_open` momentarily drops a document's workspace-index entry, and the
+  // debounced diagnostics publish is what puts it back. A caller opened inside
+  // that window is analysed against an index with no `libtest` in it, settles
+  // `W123`, and — because re-activating an already-open, unedited document
+  // starts no new analysis — never gets another verdict, so `openUntil`'s
+  // barrier can never hold. The deep-diagnostics marker is emitted *after* the
+  // index write that restores the entry, so waiting on it here closes the
+  // window for the whole suite.
+  //
+  // It belongs in `suiteSetup` rather than in `openUntil`: the marker is
+  // emitted per analysis, and these tests re-open the same documents, so only
+  // the first open produces one.
+  suiteSetup(async () => {
+    await activate(defLib);
+    await waitForDeepDiagnostics(defLib);
+    await activate(mutableDef);
+    await waitForDeepDiagnostics(mutableDef);
+  });
 
   test("a call to a proc defined in another file is not flagged unknown", async () => {
     await activate(defLib);

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -3716,6 +3716,47 @@ struct IndexedDiagnosticChange {
     source_or_package_changed: bool,
 }
 
+impl IndexedDiagnosticChange {
+    /// Whether this publish moved any workspace fact another document's
+    /// diagnostics can be a function of.
+    fn moved_workspace_facts(&self) -> bool {
+        !self.command_names.is_empty() || self.source_or_package_changed
+    }
+}
+
+/// The **open** documents the index does not currently hold — the ones a
+/// workspace-fact write has to wake by hand (issue #1619).
+///
+/// Every other consumer set is read *from* the index, so a document that is
+/// open but has no entry cannot be found in one — and that is exactly the
+/// document whose analysis ran against a snapshot older than the write that
+/// just happened: `did_open` drops the entry and the debounced publish is what
+/// puts it back, so its own call-site records do not exist yet. Before this,
+/// such a document kept whatever verdict it reached against the older index,
+/// because re-opening an unedited buffer starts no new analysis and nothing
+/// else ever named it a consumer.
+///
+/// Call only when the publish moved something
+/// ([`IndexedDiagnosticChange::moved_workspace_facts`]): with no change there
+/// is nothing a peer could conclude differently, and waking one anyway would
+/// republish a byte-identical set for an unchanged version, which the
+/// one-publish-per-version contract (`diagnostics_delivery_smoke`) forbids.
+///
+/// Terminating: each woken peer's own publish puts it into the index, so the
+/// set this can draw from strictly shrinks, and a peer that moves no workspace
+/// fact of its own — the common case, a caller that defines nothing — wakes
+/// nobody.
+fn unindexed_open_documents(
+    index: &core_workspace_index::WorkspaceIndex,
+    docs: &HashMap<Uri, DocumentState>,
+) -> Vec<String> {
+    docs.keys()
+        .map(|uri| uri.as_str())
+        .filter(|uri| !index.contains_document(uri))
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
 /// Documents whose own call-site records consume one of the changed command
 /// signatures. Both exact qualified candidates and the opt-in W123 tail tier
 /// are dependencies; unrelated open documents are deliberately absent.
@@ -3926,6 +3967,11 @@ async fn publish_diagnostics_result(
             if change.source_or_package_changed {
                 consumers.extend(before.stale_source_consumers(&index, delivery.uri.as_str()));
                 consumers.extend(source_diagnostic_consumers(&index, delivery.uri.as_str()));
+            }
+            // …plus the open documents this write could have raced — see
+            // [`unindexed_open_documents`] (issue #1619).
+            if change.moved_workspace_facts() {
+                consumers.extend(unindexed_open_documents(&index, &docs));
             }
             (change, consumers)
         };
@@ -5288,6 +5334,30 @@ impl Backend {
             edit_order: EditOrder::default(),
             store,
         }
+    }
+
+    /// Whether the salsa db *already* holds exactly this `(text, dialect)` for
+    /// `uri` — i.e. nothing about the analysis inputs changes by setting them.
+    ///
+    /// Used by `did_open` (issue #1619) to tell an opened buffer that merely
+    /// mirrors what the workspace scan read from disk apart from one that
+    /// differs, so only the latter has to drop its workspace-index entry. The
+    /// db is the right thing to ask because the scan sets this input from the
+    /// same text it indexed, in the same pass — so agreement here *is*
+    /// agreement with the index entry, with no second disk read.
+    ///
+    /// Compared in the analysis form [`Self::db_set_source`] stores, so a lone
+    /// `\r` cannot make an identical document look changed.
+    ///
+    /// Lock order is the global one: `db` → `db_files`, both taken and
+    /// released here, and always under `documents` at the call site.
+    async fn db_source_matches(&self, uri: &Uri, text: &str, dialect: &str) -> bool {
+        let normalised = tcl_lexer::normalise_lone_cr(text);
+        let db = self.db.lock().await;
+        let files = self.db_files.lock().await;
+        files.get(uri).is_some_and(|file| {
+            file.text(&*db).as_str() == normalised.as_ref() && file.dialect(&*db) == dialect
+        })
     }
 
     /// Create or update the salsa `SourceFile` input for `uri`.  Called by
@@ -14875,12 +14945,40 @@ impl LanguageServer for Backend {
                 DocumentState::with_version(params.text_document.text, dialect, version)
                     .with_language_id(params.text_document.language_id.clone()),
             );
+            // Dropping the index entry is what makes a freshly opened
+            // definition invisible to every *other* open document until this
+            // one's debounced publish puts it back — the window issue #1619
+            // wedges in: a sibling analysed inside it settles `W123` on a call
+            // this workspace does define, and the publish that restores the
+            // entry wakes only documents the index already records as invoking
+            // the name, which the sibling — also just opened, also just
+            // removed — is not yet one of.
+            //
+            // The entry is stale only if the buffer differs from what it was
+            // built from. Asked of the salsa db rather than of the disk,
+            // because the db already holds the very text the scan (or a
+            // watched-file reindex) read: this is an in-memory comparison, not
+            // a second read, and it cannot disagree with the index entry that
+            // was built alongside it. The dialect is part of the question —
+            // the same bytes analysed under a different dialect are a
+            // different analysis.
+            //
+            // Residual, deliberately accepted: the scan analyses with a bare
+            // `Analyser::new()`, so a kept entry can lack the class-factory
+            // oracle until this document's own publish replaces it a debounce
+            // later. That is strictly better than the entry being *absent* for
+            // that same window, which is what it was before.
+            let matches_indexed_source = self
+                .db_source_matches(&uri, &text, &dialect_for_diags)
+                .await;
             self.db_set_source(&uri, &text, dialect_for_diags.clone())
                 .await;
-            self.workspace_index
-                .write()
-                .await
-                .remove_document(uri.as_str());
+            if !matches_indexed_source {
+                self.workspace_index
+                    .write()
+                    .await
+                    .remove_document(uri.as_str());
+            }
             drop(docs);
         }
         // Do not keep the global document-sync turn across disk I/O. If a


### PR DESCRIPTION
## Summary

Fixes #1619.

A document opened in the editor loses its cross-file index entry for one
debounce interval, and nothing wakes the siblings that were analysed inside
that window. A caller opened right after its definition therefore settles
`W123 "Unknown command"` on a proc the workspace plainly defines — and keeps
it, because re-activating an already-open, unedited buffer starts no new
analysis.

This is what wedged `test-ext` on #1592: four failures, all four the same root
event — `crossFileCaller.tcl` stuck at `["W123"]`, `E002` never arriving, each
test then burning its own 30s on a barrier that could no longer hold.

### Mechanism

| # | What happens | Where |
|---|---|---|
| 1 | `activate(defLib)` -> `did_open` calls `workspace_index.remove_document`; `libtest` leaves the index | `lib.rs` `did_open` |
| 2 | `activate(caller)` -> `did_open` removes the caller's entry too; 50ms later (`DIAGNOSTICS_DEBOUNCE`) its worker reads the index, finds no `libtest`, and settles `W123` with no `E002` | `lib.rs` `run_diagnostics_core` |
| 3 | `defLib`'s publish re-adds `libtest`. Its wake set is `command_diagnostic_consumers`, read **from the index** — and the caller, also just opened and also just removed, is not in it | `lib.rs` `publish_diagnostics_result` |
| 4 | The caller publishes `W123`. Nothing ever re-analyses it: `openUntil`'s predicate can never hold | — |

Step 3 is the trap. The recovery path exists, but it can only find consumers
the index already knows about, and the document that most needs waking is
precisely the one the index has just been told to forget.

### The fixes

**(a) `did_open` keeps the index entry when the buffer matches what that entry
was built from.** The entry is stale only if the text or dialect differ, and
that question is answered in memory: the salsa db already holds the very text
the workspace scan read, set in the same pass that built the index entry, so
agreement with the db *is* agreement with the index — no second disk read.
This closes the window rather than papering over it, and the probe numbers
below attribute the whole effect to it.

**(b) A publish that moves a workspace fact also wakes open-but-unindexed
documents.** The residual: a buffer that genuinely differs from disk (an
unsaved edit, a file the scan never reached) still drops its entry, and a
sibling can still be analysed inside that window. Every existing consumer set
is read from the index, so such a document is structurally unfindable there;
it is added by hand instead.

I picked this over "reschedule every open document at the end of
`scan_workspace_folders`" because the scan boundary is not where the race
lives — the two `didOpen`s race each other, with or without a scan in flight,
so waking at the scan's end would leave the actual defect untouched. It is
gated on `moved_workspace_facts()`, so steady state is unchanged and the
one-publish-per-version contract (`diagnostics_delivery_smoke`) still holds;
it terminates because each woken peer's own publish puts it into the index,
shrinking the set it can draw from.

**(c) A `suiteSetup` stabiliser in `crossFileDiagnostics.test.ts`.** Opens the
definitions once and waits for the server's own deep-diagnostics marker —
emitted *after* the index write that restores the entry — before any test opens
a caller. It belongs in `suiteSetup` rather than in `openUntil` because the
marker is emitted per analysis and these tests re-open the same documents, so
only the first open produces one. That is the reason the suite's existing
comment rules a log-marker barrier out for `openUntil` itself.

### Probe evidence

A JSON-RPC probe drives the real server: initialize on
`editors/vscode/testFixture`, wait for the `[timing] workspace_folders_scan`
completion line, then `didOpen` `crossFileDefLib.tcl` and `crossFileCaller.tcl`
back to back and record every `publishDiagnostics` for the caller over 4s.
Waiting for the scan matters — without it the probe races the scan instead of
the window under test. 30 iterations each, release build, 4-core box:

| build | wedged (no `E002` ever) | recovered (`W123` -> `E002`) | clean (`E002` first) |
|---|---|---|---|
| fix (a) disabled, (b)+(c) in | 0/30 | **11/30** | 19/30 |
| all three fixes | 0/30 | **0/30** | **30/30** |

The mutation is one line (`did_open` always removes the entry, as before);
everything else is held constant. Fix (a) is what closes the window: the
caller never observes a `libtest`-less index at all, so there is no transient
`W123` left to recover from. Fix (b) is why the disabled-(a) column still
shows 0 wedged — it converts every remaining race into a recovery rather than
a wedge, which is the property that matters when a buffer really does differ
from disk.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

All on the rebased tree (`origin/rust` = `fcc7966c2`, which already contains
#1592), each prefixed with
`CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=2`:

| command | result |
|---|---|
| `cargo fmt --all --check` | clean |
| `cargo clippy -p tcl-lsp-server --all-targets -- -D warnings` | clean |
| `cargo test -p tcl-lsp-server --no-fail-fast` | 2013 passed, 0 failed, 6 ignored |
| `npx tsc -p ./` and `npm run lint` (in `editors/vscode`) | clean |
| `make rust-server` | ok |
| `TCL_LSP_SERVER_BIN=.../target/release/tcl-lsp-server make test-ext` | exit 0 — 900 passing, 0 failing; cross-file suite 7/7 |

For reference, the same `test-ext` on the wedged #1592 head was 896 passing /
4 failing.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? **No.** This is LSP-server
      scheduling and index bookkeeping only; no analyser input, fact, or
      resolution rule changes.
- [x] If yes, I updated the owning design doc — n/a, no contract changed.
- [x] If I added or changed a diagnostic or optimisation code, I updated its KCS
      page — n/a. No code was added or changed; `W123` and `E002` keep their
      existing meanings. What changes is *when* the server has the cross-file
      facts needed to decide between them.
- [x] If I added a design doc, I linked it from `docs/design/README.md` — n/a, no
      design doc added.

---
Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o)_