### PR TITLE
runtime/rust: fix cargo fmt drift and gate it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,15 @@ jobs:
           cargo clippy --workspace --all-targets -- -D warnings
           make xtask-check
 
+      # runtime/rust is a standalone crate excluded from the root workspace
+      # (it is `unsafe`; root forbids `unsafe`), so the root `cargo fmt --all
+      # --check` above never sees it. Gate it separately here so a drift like
+      # #1623 (four files unformatted, unnoticed until a manual `cargo fmt
+      # --all` run) can't recur silently.
+      - name: Run runtime/rust fmt gate
+        if: needs.channel.outputs.prerelease != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')
+        run: cd runtime/rust && cargo fmt --all --check
+
   # Build the native tcl-lsp-server release binary ONCE and share it via
   # artifact with every job that just needs to *run* it rather than build it
   # (currently test-ext).  The `--release` profile (opt-level 3, thin LTO, one

--- a/Makefile
+++ b/Makefile
@@ -1018,6 +1018,11 @@ check-rust: ensure-rust-deps ## Rust fmt-check + clippy on the workspace and the
 	cd $(ROOT); \
 	cargo fmt --all --check; \
 	cargo clippy --workspace --all-targets -- -D warnings; \
+	if [ -f "$(RUNTIME_RUST_DIR)/Cargo.toml" ]; then \
+		echo "==> Checking runtime/rust (fmt)"; \
+		cd $(RUNTIME_RUST_DIR); \
+		cargo fmt --all --check; \
+	fi; \
 	if [ -f "$(ZED_DIR)/Cargo.toml" ]; then \
 		echo "==> Checking Zed extension (fmt + clippy --target wasm32-wasip2 + host tests)"; \
 		cd $(ZED_DIR); \

--- a/runtime/rust/src/builtins.rs
+++ b/runtime/rust/src/builtins.rs
@@ -1080,9 +1080,9 @@ mod tests {
         const MSG: &[u8] = b"missing close-brace for variable name";
         leak_free(|i| {
             for hex in [
-                &b"247B616263"[..],       // `${abc`  — no closer at all
-                &b"7A247B617B62"[..],     // `z${a{b` — unbalanced `{`
-                &b"247B615C"[..],         // `${a\`   — trailing lone backslash
+                &b"247B616263"[..],   // `${abc`  — no closer at all
+                &b"7A247B617B62"[..], // `z${a{b` — unbalanced `{`
+                &b"247B615C"[..],     // `${a\`   — trailing lone backslash
             ] {
                 let script = [b"subst [binary format H* ".as_ref(), hex, b"]"].concat();
                 assert_eq!(i.eval_str(&script), Code::Error, "{hex:?}");

--- a/runtime/rust/src/cmd_dict.rs
+++ b/runtime/rust/src/cmd_dict.rs
@@ -1397,7 +1397,10 @@ mod tests {
         // The *list* noun is untouched — the two must stay distinguishable.
         let (c, b) = run(&[BAD, b"llength $d"].concat());
         assert_eq!(c, Code::Error);
-        assert_eq!(b, b"list element in braces followed by \"c\" instead of space");
+        assert_eq!(
+            b,
+            b"list element in braces followed by \"c\" instead of space"
+        );
     }
 
     /// Issue #1328 finding (2) — `dict lappend` onto a non-dict "silently

--- a/runtime/rust/src/cmd_string.rs
+++ b/runtime/rust/src/cmd_string.rs
@@ -365,7 +365,6 @@ fn tcl_prefix(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
 }
 
-
 /// Split `s` as a Tcl list, or set the full list-parse error and return the
 /// failing `Code` (used by the `tcl::prefix` subcommands).
 ///

--- a/runtime/rust/src/parse.rs
+++ b/runtime/rust/src/parse.rs
@@ -283,9 +283,7 @@ fn scan_parts_at_depth(
                     // unterminated where 8.x closes them.
                     tcl_lexer::BracedVarEnd::Unterminated => {
                         i = len;
-                        parts.push(WordPart::ParseError(
-                            tcl_lexer::MISSING_CLOSE_BRACE_FOR_VAR,
-                        ));
+                        parts.push(WordPart::ParseError(tcl_lexer::MISSING_CLOSE_BRACE_FOR_VAR));
                     }
                 }
             } else {


### PR DESCRIPTION
## Summary

- Fmt-only fix: `cargo fmt --all` in runtime/rust reformats four files that had drifted out of rustfmt style — src/builtins.rs, src/cmd_dict.rs, src/cmd_string.rs, src/parse.rs. Pure whitespace/wrapping changes, no logic touched.
- Adds a new pr-gate step in .github/workflows/ci.yml that runs cargo fmt --all --check from runtime/rust, so this drift can't recur silently. runtime/rust is a standalone crate excluded from the root Cargo workspace (it uses unsafe; the root workspace forbids unsafe), so the existing root cargo fmt --all --check in pr-gate never covered it.

Fixes #1623

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - In runtime/rust, ran `cargo fmt --all --check`; confirmed FAILING before the fix (on exactly the four files above) and PASSING after.
  - Root `cargo fmt --all --check` — clean.
  - In runtime/rust, ran `cargo test` with `TCL_TOMMATH_DIR` pointed at the vendored `tcl9.0.4/libtommath` tree — 522 passed, 0 failed.
  - `.github/workflows/ci.yml` parsed with PyYAML to confirm the new step is valid YAML.
  - All cargo/make invocations were run with the CARGO_INCREMENTAL=0, CARGO_PROFILE_DEV_DEBUG=0, CARGO_BUILD_JOBS=2 env vars per repo convention.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

Not applicable — this PR touches only rustfmt formatting in runtime/rust and a CI workflow step; no compiler fact contracts, diagnostics, or optimisation codes are involved.