### PR TITLE
docs: reunite doc comments spliced by a stranded attribute

### DIFF
--- a/rust/tcl-compiler/src/codegen/emitter/mod.rs
+++ b/rust/tcl-compiler/src/codegen/emitter/mod.rs
@@ -81,11 +81,6 @@ pub fn codegen_function_with_procs(
     generate::generate(&mut ctx, cfg, proc_defs)
 }
 
-/// Like [`codegen_function_with_procs`] but threading the module source text so
-/// each instruction carries its command's surface text for `errorInfo`, plus
-/// the proc body's `base_line` (its `proc` definition line) so the
-/// `(procedure … line N)` frame reports a proc-relative line.
-#[must_use]
 /// The per-module facts every function emission shares: the registry, the
 /// module source (for `errorInfo` surface text) and the release being compiled
 /// for (its dialect name, and the numeral and backslash-escape grammars that
@@ -102,6 +97,11 @@ struct ModuleEmit<'a> {
     braced_var: tcl_dialect::BracedVarStyle,
 }
 
+/// Like [`codegen_function_with_procs`] but threading the module source text so
+/// each instruction carries its command's surface text for `errorInfo`, plus
+/// the proc body's `base_line` (its `proc` definition line) so the
+/// `(procedure … line N)` frame reports a proc-relative line.
+#[must_use]
 fn codegen_function_src(
     cfg: &CfgFunction,
     params: &[&str],

--- a/rust/tcl-compiler/src/taint.rs
+++ b/rust/tcl-compiler/src/taint.rs
@@ -2298,13 +2298,11 @@ pub fn shadowed_builtin_names<'a>(
     out
 }
 
-/// Run sink detection over a single function.
+/// Emit taint sink warnings (`T100` family) for one function.
 ///
 /// For each SSA use of a tainted variable in a sink statement, emits
 /// one `TaintWarning`. Iterates blocks in `cfg_order` for deterministic
 /// diagnostic ordering (matching the other shimmer/taint passes).
-#[must_use]
-/// Emit taint sink warnings (`T100` family) for one function.
 ///
 /// This is the per-function sink scan; the whole-unit `dataflow` / `diag`
 /// aggregation calls it over the top level and every procedure unit. The
@@ -2315,6 +2313,7 @@ pub fn shadowed_builtin_names<'a>(
 /// command names that resolve to a user proc rather than the registry
 /// builtin from this function's namespace — those are skipped by the
 /// registry-driven sink/source/pattern checks below.
+#[must_use]
 pub fn find_taint_warnings<
     S: std::hash::BuildHasher,
     E: std::hash::BuildHasher,

--- a/rust/tcl-syntax/src/expr/parser.rs
+++ b/rust/tcl-syntax/src/expr/parser.rs
@@ -581,6 +581,14 @@ fn expr_cache() -> &'static Mutex<ExprCache> {
     CACHE.get_or_init(|| Mutex::new(ExprCache::new()))
 }
 
+/// Cached parse from a compatibility dialect-name boundary.
+///
+/// Typed callers should use [`parse_expr_cached_for_profile`].
+#[must_use]
+pub fn parse_expr_cached(source: &str, dialect: Option<&str>) -> Arc<ExprNode> {
+    parse_expr_cached_for_profile(source, dialect.map(DialectProfile::by_name))
+}
+
 /// LRU-cached `parse_expr`.
 ///
 /// Identical semantics to [`parse_expr`] — same `(source, dialect)`
@@ -592,15 +600,6 @@ fn expr_cache() -> &'static Mutex<ExprCache> {
 /// Use this from VM-loop hot paths (re-evaluating `expr {$i < N}`
 /// on every iteration); use the un-cached [`parse_expr`] from
 /// once-per-invocation analyser sites.
-#[must_use]
-/// Cached parse from a compatibility dialect-name boundary.
-///
-/// Typed callers should use [`parse_expr_cached_for_profile`].
-pub fn parse_expr_cached(source: &str, dialect: Option<&str>) -> Arc<ExprNode> {
-    parse_expr_cached_for_profile(source, dialect.map(DialectProfile::by_name))
-}
-
-/// Cached expression parse under an already-resolved profile.
 #[must_use]
 pub fn parse_expr_cached_for_profile(
     source: &str,


### PR DESCRIPTION
## Summary

- Three doc comments were spliced mid-block by an attribute wedged between two `///` blocks, so the wrong half ended up attached to the wrong (or no) item:
  - rust/tcl-compiler/src/codegen/emitter/mod.rs — the doc for `codegen_function_src` was stranded above `ModuleEmit`'s own doc, with `#[must_use]` sandwiched between them and attaching to the struct instead of the function. `codegen_function_src` ended up with no doc at all.
  - rust/tcl-syntax/src/expr/parser.rs — `parse_expr_cached`'s short "compatibility dialect-name boundary" doc and `parse_expr_cached_for_profile`'s detailed LRU-cache doc were both combined onto `parse_expr_cached`, split by `#[must_use]` reading as a non-sequitur mid-paragraph. Each function now carries the doc that actually describes it.
  - rust/tcl-compiler/src/taint.rs — `find_taint_warnings` had two competing summary doc blocks (an older short one and a newer, more detailed one) glued together with `#[must_use]` in between. Merged into one coherent block, keeping the more detailed summary plus the unique SSA/cfg_order paragraph from the older one; `#[must_use]` now correctly trails right before the fn.
- Swept the rest of the repo for the same defect class (a doc line, then an attribute or item, then another doc continuation reading as a fragment) with a script over every .rs file. These three were the only matches — the sweep confirms zero remain after this fix.

Pure doc surgery — zero behaviour, signature, or attribute-semantics change.

Fixes #1620

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `cargo doc -p tcl-compiler -p tcl-syntax --no-deps`, teed to a log and grepped for warnings, compared before/after the fix: identical warning count (194) and byte-identical set of warning lines — no new warnings, and none near the touched regions.
  - `cargo fmt --all --check` — clean.
  - `cargo check -p tcl-compiler -p tcl-syntax` — clean.
  - Repo-wide sweep script (walks every `.rs` file, matches a `///` block immediately followed by `#[...]` attribute(s) immediately followed by another `///` block) found exactly the three sites above before the fix, and zero after.
  - All cargo invocations were run with CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=2 per repo convention.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

Not applicable — this PR only reorganises doc comments in tcl-compiler and tcl-syntax; no compiler fact contracts, diagnostics, or optimisation codes are involved, and no code logic changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o)_