### PR TITLE
Read ${…} names, ensemble subcommands, and export patterns like Tcl does

### DIFF
--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -2854,9 +2854,7 @@ impl Analyser {
     ) {
         if let Some(entry) = self
             .result
-            .ensemble_subcommand_targets
-            .get(resolved_cmd)
-            .and_then(|subs| subs.get(sub))
+            .resolve_ensemble_subcommand(resolved_cmd, sub)
             .cloned()
         {
             self.push_ensemble_dispatch_reference(sub.to_owned(), span, &entry, argc);
@@ -2892,9 +2890,7 @@ impl Analyser {
         for cand in pending {
             let Some(entry) = self
                 .result
-                .ensemble_subcommand_targets
-                .get(&cand.ensemble)
-                .and_then(|subs| subs.get(&cand.sub))
+                .resolve_ensemble_subcommand(&cand.ensemble, &cand.sub)
                 .cloned()
             else {
                 continue;

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -1169,11 +1169,7 @@ impl Analyser {
         cmd_tok: tcl_lexer::Token,
         arg_tokens: &[tcl_lexer::Token],
     ) {
-        if self.prefixless_ensembles.contains(cmd_name)
-            || self
-                .prefixless_ensembles
-                .contains(&format!("::{}", cmd_name.trim_start_matches(':')))
-        {
+        if self.result.ensemble_refuses_prefixes(cmd_name) {
             return;
         }
         let span = match arg_tokens.first() {
@@ -3629,7 +3625,7 @@ before this value so it is treated as data, not an option."
         // A `-prefixes 0` ensemble in this file turns prefix matching off for
         // its option table too, so abbreviations there are plain unknown
         // options rather than ambiguities.
-        let prefix_matching = if self.prefixless_ensembles.contains(cmd_name) {
+        let prefix_matching = if self.result.prefixless_ensembles.contains(cmd_name) {
             tcl_registry::abbrev::PrefixMatching::Strict
         } else {
             spec.prefix_matching

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -3740,7 +3740,7 @@ impl Analyser {
         if let (Some(value), Some(key)) = (value, ensemble_key)
             && matches!(tcl_registry::abbrev::resolve_boolean(value), Some(false))
         {
-            self.prefixless_ensembles.insert(key.to_owned());
+            self.result.prefixless_ensembles.insert(key.to_owned());
         }
     }
 
@@ -9204,7 +9204,13 @@ impl Analyser {
     /// to a glob text, so it is silently skipped — the wildcard-import
     /// resolver then correctly abstains for names it might have covered,
     /// rather than guessing. A dynamic word cannot hide a `-clear`, which is
-    /// a literal flag word or nothing.
+    /// a literal flag word or nothing. It is skipped rather than treated as
+    /// the abort below, for the same reason: whether it resolves to a
+    /// qualified pattern is unknowable here.
+    ///
+    /// A **qualified** pattern is a guaranteed runtime error (`Tcl_Export`
+    /// rejects it), and C `return`s from the pattern loop on that failure, so
+    /// recording stops there — see the loop for the oracle.
     ///
     /// Dispatched via
     /// [`tcl_registry::hooks::AnalyserHookId::NamespaceExport`] (stamped on
@@ -9251,6 +9257,18 @@ impl Analyser {
             if pattern.contains('$') || pattern.contains('[') {
                 idx += 1;
                 continue;
+            }
+            // `NamespaceExportCmd` calls `Tcl_Export` per pattern and
+            // `return`s on the first failure, so a qualified pattern aborts
+            // the loop: every *later* word is never exported at all. The
+            // earlier ones stay — C commits each pattern as it goes.
+            // Oracle (tclsh 8.6.16 / 9.0.4): `namespace export one ::bad
+            // three` leaves exactly `one` exported, and `namespace export
+            // ::bad ok` leaves nothing. Recording past the bad word let a
+            // wildcard-import bareword resolve where real Tcl would not
+            // (issue #1612).
+            if tcl_syntax::naming::is_qualified(pattern.as_bytes()) {
+                break;
             }
             self.result.namespace_exports.push(
                 crate::signature_scan::types::SignatureNamespaceExport {
@@ -10815,6 +10833,89 @@ mod tests {
             .map(|e| e.pattern.as_str())
             .collect();
         assert_eq!(patterns, vec!["bar", "b*"]);
+    }
+
+    /// `NamespaceExportCmd` calls `Tcl_Export` per pattern and returns on the
+    /// first failure, so a qualified pattern aborts the loop — the patterns
+    /// *before* it are committed, the ones after are never exported at all.
+    /// Oracle rows (identical on tclsh 8.6.16 and 9.0.4, `namespace export`
+    /// read back from the namespace afterwards):
+    ///
+    /// | script | exports |
+    /// |---|---|
+    /// | `namespace export ::bad ok` | nothing |
+    /// | `namespace export ok ::bad` | `ok` |
+    /// | `namespace export one ::bad three` | `one` |
+    #[test]
+    fn handle_namespace_export_stops_at_the_first_qualified_pattern() {
+        let recorded = |words: &[&str]| -> Vec<String> {
+            let mut a = Analyser::new();
+            let args: Vec<String> = std::iter::once("export".to_string())
+                .chain(words.iter().map(|w| (*w).to_string()))
+                .collect();
+            let tokens: Vec<Token> = (0..args.len())
+                .map(|i| {
+                    let start = u32::try_from(i).expect("small index") * 10;
+                    esc_tok(span(start, start + 5))
+                })
+                .collect();
+            a.handle_namespace_export_command(&args, &tokens, &[]);
+            a.result
+                .namespace_exports
+                .iter()
+                .map(|e| e.pattern.clone())
+                .collect()
+        };
+
+        // The bad pattern is first: nothing is exported.
+        assert!(recorded(&["::bad", "ok"]).is_empty());
+        // …and after a valid one: only the valid one survives.
+        assert_eq!(recorded(&["ok", "::bad"]), vec!["ok".to_string()]);
+        assert_eq!(
+            recorded(&["one", "::bad", "three"]),
+            vec!["one".to_string()]
+        );
+        // A *relative* qualifier is equally invalid (oracle: `namespace
+        // export sub::pat` errors), so it aborts too.
+        assert!(recorded(&["sub::pat", "ok"]).is_empty());
+        // A lone colon is not a separator, so `a:b` is a perfectly valid
+        // pattern and must not abort (oracle: exports `a:b`).
+        assert_eq!(
+            recorded(&["a:b", "ok"]),
+            vec!["a:b".to_string(), "ok".to_string()]
+        );
+        // The empty pattern is valid too (oracle: exports `{} ok`).
+        assert_eq!(recorded(&["", "ok"]), vec![String::new(), "ok".to_string()]);
+    }
+
+    #[test]
+    fn handle_namespace_export_clear_commits_before_an_invalid_pattern() {
+        // C spends a whole `Tcl_Export(…, "::", 1)` call on `-clear`, which
+        // resets the list before any pattern is looked at, so a later bad
+        // pattern cannot undo it. Oracle: a namespace exporting `keep`, then
+        // `namespace export -clear ::bad`, exports nothing afterwards.
+        let mut a = Analyser::new();
+        a.registry = Some(tcl_registry::registry_handle_for_dialect("tcl"));
+        a.handle_namespace_export_command(
+            &[
+                "export".to_string(),
+                "-clear".to_string(),
+                "::bad".to_string(),
+            ],
+            &[
+                esc_tok(span(0, 6)),
+                esc_tok(span(7, 13)),
+                esc_tok(span(14, 19)),
+            ],
+            &[],
+        );
+        let events: Vec<(&str, bool)> = a
+            .result
+            .namespace_exports
+            .iter()
+            .map(|e| (e.pattern.as_str(), e.clears))
+            .collect();
+        assert_eq!(events, vec![("", true)]);
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -2050,6 +2050,7 @@ impl Analyser {
                 // fold candidate (issue #1132).
                 command_trust: None,
                 ensemble_targets: Vec::new(),
+                prefixless_ensembles: Vec::new(),
                 oo_defining_class: None,
                 safe_interp_ctx,
             });
@@ -2218,6 +2219,7 @@ impl Analyser {
                     // with a fold candidate (issue #1132).
                     command_trust: None,
                     ensemble_targets: Vec::new(),
+                    prefixless_ensembles: Vec::new(),
                     oo_defining_class: None,
                     safe_interp_ctx,
                 });
@@ -2606,6 +2608,7 @@ impl Analyser {
                 // fold candidate (issue #1132).
                 command_trust: None,
                 ensemble_targets: Vec::new(),
+                prefixless_ensembles: Vec::new(),
                 oo_defining_class: None,
                 safe_interp_ctx,
             });

--- a/rust/tcl-compiler/src/analyser/oo.rs
+++ b/rust/tcl-compiler/src/analyser/oo.rs
@@ -1302,6 +1302,7 @@ impl Analyser {
                 // fold candidate (issue #1132).
                 command_trust: None,
                 ensemble_targets: Vec::new(),
+                prefixless_ensembles: Vec::new(),
                 oo_defining_class,
                 safe_interp_ctx,
             });

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -221,6 +221,21 @@ pub struct DeferredBody {
         String,
         Vec<(String, super::types::EnsembleSubcommandTarget)>,
     )>,
+    /// The `-prefixes 0` opt-out for the ensembles in
+    /// [`Self::ensemble_targets`] — the visible slice of
+    /// [`super::types::AnalysisResult::prefixless_ensembles`], under the same
+    /// precedes-the-body and occurs-in-the-body-text filters, sorted so it can
+    /// key `tcl-lsp-db`'s `ItemBodyKey`.
+    ///
+    /// **Travels with `ensemble_targets`, and must keep doing so.** The two
+    /// are read together by
+    /// [`super::types::AnalysisResult::resolve_ensemble_subcommand`]: the map
+    /// says which subcommands exist, this says whether an abbreviation of one
+    /// may match. Seeding only the map let an isolated body resolve `g fo`
+    /// against a `-prefixes 0` ensemble and record a dispatch invocation the
+    /// whole-file walk (and real Tcl) refuse — so the two are seeded and
+    /// merged at one site each, never separately.
+    pub prefixless_ensembles: Vec<String>,
     /// Mirrors [`super::types::Scope::oo_defining_class`] for the isolated
     /// rebuild: the fully-qualified defining class when this is an
     /// instance-side `TclOO` method body of a statically-named class,
@@ -522,6 +537,58 @@ impl Analyser {
     /// qualified `$::g` reads — replayed at graft) takes the fast incremental
     /// path.  Guarded by the corpus `per_item == analyse` gate + the
     /// `incremental == fresh` fuzzer.
+    /// Attach the ensemble facts each deferred body can see: the
+    /// `subcommand → target` maps whose `namespace ensemble` recording
+    /// **precedes** the body in source order (the whole-file DFS's own
+    /// visibility rule), filtered to ensembles whose tail name occurs in the
+    /// body text so an unrelated ensemble edit re-keys no body, canonically
+    /// sorted so the snapshot can key `tcl-lsp-db`'s `ItemBodyKey`.
+    ///
+    /// The **one** site that decides what an isolated body knows about
+    /// ensembles. `-prefixes 0` is attached here beside the map it modifies,
+    /// rather than at a second site, because
+    /// [`super::types::AnalysisResult::resolve_ensemble_subcommand`] reads the
+    /// two together: attaching only the map let an isolated body resolve
+    /// `<ensemble> fo` against an ensemble that refuses abbreviations and
+    /// record a dispatch real Tcl rejects.
+    fn attach_ensemble_facts(&self, deferred: &mut [DeferredBody]) {
+        if self.result.ensemble_subcommand_targets.is_empty() {
+            return;
+        }
+        let mut all: Vec<(
+            &String,
+            &std::collections::HashMap<String, super::types::EnsembleSubcommandTarget>,
+        )> = self.result.ensemble_subcommand_targets.iter().collect();
+        all.sort_by_key(|(k, _)| *k);
+        for db in deferred {
+            let body_start = db.body_tok.span.start();
+            let visible: Vec<(
+                String,
+                Vec<(String, super::types::EnsembleSubcommandTarget)>,
+            )> = all
+                .iter()
+                .filter(|(k, _)| {
+                    self.ensemble_record_offsets
+                        .get(*k)
+                        .is_some_and(|&off| off < body_start)
+                        && db.body_text.contains(crate::naming::key_tail(k))
+                })
+                .map(|(k, subs)| {
+                    let mut inner: Vec<(String, super::types::EnsembleSubcommandTarget)> =
+                        subs.iter().map(|(s, t)| (s.clone(), t.clone())).collect();
+                    inner.sort();
+                    ((*k).clone(), inner)
+                })
+                .collect();
+            db.prefixless_ensembles = visible
+                .iter()
+                .map(|(k, _)| k.clone())
+                .filter(|k| self.result.ensemble_refuses_prefixes(k))
+                .collect();
+            db.ensemble_targets = visible;
+        }
+    }
+
     fn fill_deferred_bodies(
         &mut self,
         source: &str,
@@ -598,41 +665,7 @@ impl Analyser {
                 }
             }
         }
-        // Attach the ensemble subcommand→target maps each body can see —
-        // the entries whose `namespace ensemble` recording precedes the
-        // body in source order (whole-file DFS visibility), filtered to
-        // ensembles whose tail name occurs in the body text so an
-        // unrelated ensemble edit re-keys no body. Canonically sorted so
-        // the snapshot can key `tcl-lsp-db`'s `ItemBodyKey`.
-        if !self.result.ensemble_subcommand_targets.is_empty() {
-            let mut all: Vec<(
-                &String,
-                &std::collections::HashMap<String, super::types::EnsembleSubcommandTarget>,
-            )> = self.result.ensemble_subcommand_targets.iter().collect();
-            all.sort_by_key(|(k, _)| *k);
-            for db in &mut deferred {
-                let body_start = db.body_tok.span.start();
-                let visible: Vec<(
-                    String,
-                    Vec<(String, super::types::EnsembleSubcommandTarget)>,
-                )> = all
-                    .iter()
-                    .filter(|(k, _)| {
-                        self.ensemble_record_offsets
-                            .get(*k)
-                            .is_some_and(|&off| off < body_start)
-                            && db.body_text.contains(crate::naming::key_tail(k))
-                    })
-                    .map(|(k, subs)| {
-                        let mut inner: Vec<(String, super::types::EnsembleSubcommandTarget)> =
-                            subs.iter().map(|(s, t)| (s.clone(), t.clone())).collect();
-                        inner.sort();
-                        ((*k).clone(), inner)
-                    })
-                    .collect();
-                db.ensemble_targets = visible;
-            }
-        }
+        self.attach_ensemble_facts(&mut deferred);
         let deferred = deferred;
         // **Proc duplicates take the fast path.**  A whole-file walk's
         // `all_variables` for a duplicated proc is the *union* of every
@@ -875,6 +908,13 @@ impl Analyser {
                 .or_default()
                 .extend(subs);
         }
+        // A body may *create* an ensemble as well as call one, so the
+        // `-prefixes 0` opt-out merges back on the same seam its subcommand
+        // map does — otherwise an ensemble configured inside a body would
+        // come back abbreviation-matching for every later reader.
+        self.result
+            .prefixless_ensembles
+            .extend(r.prefixless_ensembles);
         Self::merge_per_object_records(&mut self.result, r.object_methods, r.object_member_state);
         self.result.instance_classes.extend(r.instance_classes);
         // `object_handle_facts` is deliberately **not** merged here (issue #994
@@ -1248,6 +1288,30 @@ pub struct BodyFragment {
     minted_synthetics: std::collections::HashSet<String>,
 }
 
+/// Seed an isolated body's throwaway result with the ensemble facts the shell
+/// attached ([`Analyser::attach_ensemble_facts`]) — the `subcommand → target`
+/// maps, so an `<ensemble> <sub> …` call inside the body records the same
+/// existence-probed invocation the whole-file walk does (provenance included,
+/// so the body's dispatch words carry the same `-map`/`-subcommands` tag rename
+/// gates on, issue #1281), **and** the `-prefixes 0` opt-out that decides
+/// whether an abbreviation of one of those subcommands may match at all.
+///
+/// The counterpart of [`Analyser::graft_proc_body`]'s merge-back, and the one
+/// site that reads `DeferredBody`'s ensemble pair, so the two facts cannot
+/// drift apart again (issue #1636 review).
+fn seed_ensemble_facts(a: &mut super::state::Analyser, db: &DeferredBody) {
+    for (ensemble, subs) in &db.ensemble_targets {
+        a.result
+            .ensemble_subcommand_targets
+            .entry(ensemble.clone())
+            .or_default()
+            .extend(subs.iter().cloned());
+    }
+    a.result
+        .prefixless_ensembles
+        .extend(db.prefixless_ensembles.iter().cloned());
+}
+
 /// Analyse one `proc` **or method** body as an isolated unit at **offset 0** — a
 /// pure function of `(body_text, namespace, scope_name, params, is_method,
 /// class_variables)`, so a shifted-but-unedited body is a cache hit
@@ -1304,18 +1368,7 @@ pub fn analyse_proc_body_isolated<S: std::hash::BuildHasher>(
     // (`upvar ::ns::cell local`) must reach the shell's real global scope,
     // not the throwaway root this isolated walk builds (issue #923 idx 98).
     a.capture_global_defs = Some(Vec::new());
-    // Seed the ensemble subcommand→target maps visible to this body (the
-    // shell attached exactly the whole-file-DFS-visible, body-relevant
-    // slice — see `DeferredBody::ensemble_targets`), so an
-    // `<ensemble> <sub> …` call inside the body records the same
-    // existence-probed subcommand invocation the whole-file walk does.
-    for (ensemble, subs) in &db.ensemble_targets {
-        a.result
-            .ensemble_subcommand_targets
-            .entry(ensemble.clone())
-            .or_default()
-            .extend(subs.iter().cloned());
-    }
+    seed_ensemble_facts(&mut a, db);
     // Capture object-instance creations: the isolated body's `all_classes` is
     // empty, so the class can't be resolved here — the graft replays them.
     a.pending_instances = Some(Vec::new());
@@ -1835,6 +1888,8 @@ fn rebase_result_names(r: &mut AnalysisResult, fix: &impl Fn(&mut String)) {
     }
     fix_string_keys(&mut r.rename_offsets, fix);
     fix_string_keys(&mut r.ensemble_subcommand_targets, fix);
+    // Same key space as the map's outer keys, so it rebases with it.
+    fix_string_set(&mut r.prefixless_ensembles, fix);
     for subs in r.ensemble_subcommand_targets.values_mut() {
         for entry in subs.values_mut() {
             fix(&mut entry.target);
@@ -2747,6 +2802,31 @@ mod tests {
         // shape).
         eq(
             "namespace eval ::tm {\n    proc add {p} { return $p }\n}\nnamespace ensemble create -command ::tm::path -map {add ::tm::add}\nproc use {} { ::tm::path add x }\n",
+        );
+    }
+
+    #[test]
+    fn prefixless_ensemble_setting_reaches_and_returns_from_bodies() {
+        // The `-prefixes 0` opt-out has to travel **both** ways across the
+        // isolated-body seam, because `resolve_ensemble_subcommand` reads it
+        // together with the subcommand map (issue #1636 review).
+        //
+        // Seeding: the ensemble is configured at top level and abbreviated
+        // inside a body. Real Tcl (8.6.16 / 9.0.4) answers `unknown
+        // subcommand "fo"`, so neither walk may record a dispatch — the
+        // isolated pass used to, because only the map was seeded.
+        eq(
+            "namespace eval ::e {\n    proc Foo {} { return FOO }\n}\nnamespace ensemble create -command ::e::g -map {foo ::e::Foo} -prefixes 0\nproc use {} { ::e::g fo }\n",
+        );
+        // The positive control: without `-prefixes 0` the same abbreviation
+        // *does* dispatch (`FOO`), so the fix must not silence it.
+        eq(
+            "namespace eval ::e {\n    proc Foo {} { return FOO }\n}\nnamespace ensemble create -command ::e::h -map {foo ::e::Foo}\nproc use {} { ::e::h fo }\n",
+        );
+        // Merging back: a body may *create* the ensemble, and the opt-out has
+        // to reach the shell result the way its subcommand map already does.
+        eq(
+            "namespace eval ::e {\n    proc Foo {} { return FOO }\n}\nproc setup {} {\n    namespace ensemble create -command ::e::g -map {foo ::e::Foo} -prefixes 0\n}\nproc use {} { ::e::g fo }\n",
         );
     }
 

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -671,12 +671,6 @@ pub struct Analyser {
     /// their tail names become valid commands.
     pub ensemble_namespaces: HashSet<String>,
 
-    /// Resolved command names of ensembles this file configured with
-    /// `namespace ensemble … -prefixes 0`, which turns off `Tcl_GetIndexFromObj`
-    /// prefix matching for that ensemble.  Consulted by the abbreviation
-    /// machinery (W145 and the formatter's expansion) so an abbreviation on a
-    /// `-prefixes 0` ensemble is never reported ambiguous or rewritten.
-    pub prefixless_ensembles: HashSet<String>,
     /// Source offset of the **latest** `namespace ensemble` list token that
     /// (re)filed each [`super::types::AnalysisResult::ensemble_subcommand_targets`]
     /// key.  Analyser-side book-keeping for the per-item path only: the
@@ -1378,7 +1372,6 @@ impl Analyser {
             widget_dispatch_sites: Vec::new(),
             cmd_command_sites: Vec::new(),
             ensemble_namespaces: HashSet::new(),
-            prefixless_ensembles: HashSet::new(),
             ensemble_command_maps: HashMap::new(),
             ensemble_record_offsets: HashMap::new(),
             pending_ensemble_subcommands: Vec::new(),

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -1868,6 +1868,16 @@ pub struct AnalysisResult {
     /// the name — because a consumer that rewrites the subcommand word
     /// (rename) is only correct for one of the two.
     pub ensemble_subcommand_targets: HashMap<String, HashMap<String, EnsembleSubcommandTarget>>,
+    /// Resolved command names of ensembles this file configured with
+    /// `namespace ensemble … -prefixes 0`, which turns off the
+    /// `Tcl_GetIndexFromObj` prefix matching every other ensemble has.
+    ///
+    /// Consulted by the abbreviation machinery (W145 and the formatter's
+    /// expansion) so an abbreviation on such an ensemble is never reported
+    /// ambiguous or rewritten, and by
+    /// [`Self::resolve_ensemble_subcommand`] so navigation does not follow
+    /// an abbreviation the ensemble would refuse.
+    pub prefixless_ensembles: std::collections::HashSet<String>,
     /// Namespace import records.
     pub namespace_imports: Vec<SignatureNamespaceImport>,
     /// Namespace `forget` records — the removal half of the import edge's
@@ -2118,6 +2128,56 @@ pub struct AnalysisResult {
 }
 
 impl AnalysisResult {
+    /// Does this document configure the ensemble resolving to `ensemble`
+    /// with `namespace ensemble … -prefixes 0`?
+    ///
+    /// [`Self::prefixless_ensembles`] is keyed by the ensemble's resolved
+    /// command name, which callers hold in either spelling depending on how
+    /// they got it, so both are tried here rather than at each call site.
+    #[must_use]
+    pub fn ensemble_refuses_prefixes(&self, ensemble: &str) -> bool {
+        self.prefixless_ensembles.contains(ensemble)
+            || self
+                .prefixless_ensembles
+                .contains(&format!("::{}", ensemble.trim_start_matches(':')))
+    }
+
+    /// Resolve `sub` against the subcommands recorded for the ensemble
+    /// command `ensemble`, the way the ensemble itself would
+    /// (`NsEnsembleImplementationCmd`): an exact name first, then — unless
+    /// the ensemble was configured `-prefixes 0` — a **unique** prefix.
+    ///
+    /// The match rule is not re-derived here: it is
+    /// [`tcl_cmd_core::ensemble::resolve_subcommand`], the owner the engines
+    /// dispatch through, so navigation follows exactly the subcommand real
+    /// Tcl would run. An *ambiguous* prefix resolves to nothing and the
+    /// caller keeps abstaining — the ensemble would error there, so there is
+    /// no target to point at (issue #1611).
+    ///
+    /// `None` when the ensemble is unknown to this document, its `-map` was
+    /// dynamic (nothing is ever recorded for it), or `sub` matches nothing.
+    #[must_use]
+    pub fn resolve_ensemble_subcommand(
+        &self,
+        ensemble: &str,
+        sub: &str,
+    ) -> Option<&EnsembleSubcommandTarget> {
+        let subs = self.ensemble_subcommand_targets.get(ensemble)?;
+        if let Some(entry) = subs.get(sub) {
+            return Some(entry); // the exact-name probe C does first
+        }
+        // The recorded map is unordered; the scan needs a stable candidate
+        // order to call a prefix unique, and C's own table is sorted.
+        let mut names: Vec<&str> = subs.keys().map(String::as_str).collect();
+        names.sort_unstable();
+        let index = tcl_cmd_core::ensemble::resolve_subcommand(
+            &names,
+            sub.as_bytes(),
+            !self.ensemble_refuses_prefixes(ensemble),
+        )?;
+        subs.get(names[index])
+    }
+
     /// Every **class factory** this document declares, keyed by qualified
     /// name — the slice a host merges into the workspace factory index it
     /// feeds back through

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -1794,11 +1794,19 @@ pub fn indirection_pending_at(analysis: &AnalysisResult, qualified: &str, cursor
 /// Resolve `head sub` (as returned by [`instance_method_at_cursor`], with
 /// `is_dollar == false`) to the target command it dispatches to, when
 /// `head` names a known `namespace ensemble create -map`/`-subcommands`
-/// ensemble and `sub` exactly matches one of its literal, statically
-/// -recorded subcommands (issue #923 idx 106) — `namespace` is the call
-/// site's own command-resolution namespace, so a relative `head` (the
-/// overwhelmingly common case: an ensemble dispatches through its own short
-/// name) resolves the same way an ordinary bare command call would.
+/// ensemble and `sub` resolves against its literal, statically-recorded
+/// subcommands (issue #923 idx 106) — `namespace` is the call site's own
+/// command-resolution namespace, so a relative `head` (the overwhelmingly
+/// common case: an ensemble dispatches through its own short name) resolves
+/// the same way an ordinary bare command call would.
+///
+/// `sub` need not be written in full: a real ensemble abbreviates, so
+/// `e fo` dispatching to `-map {foo ::e::Foo}` is navigable here too
+/// (issue #1611). The rule is
+/// [`AnalysisResult::resolve_ensemble_subcommand`]'s — exact first, then a
+/// unique prefix unless the ensemble declared `-prefixes 0` — so navigation
+/// lands on whatever the ensemble itself would dispatch, and abstains
+/// wherever it would error.
 pub(crate) fn ensemble_subcommand_target<'a>(
     analysis: &'a AnalysisResult,
     namespace: &str,
@@ -1807,8 +1815,7 @@ pub(crate) fn ensemble_subcommand_target<'a>(
 ) -> Option<&'a str> {
     tcl_syntax::naming::bareword_resolution_candidates(namespace, head)
         .into_iter()
-        .find_map(|cand| analysis.ensemble_subcommand_targets.get(&cand))
-        .and_then(|subs| subs.get(sub))
+        .find_map(|cand| analysis.resolve_ensemble_subcommand(&cand, sub))
         .map(|entry| entry.target.as_str())
 }
 
@@ -6417,6 +6424,49 @@ mod tests {
         assert_eq!(locs[0].start_line, 6);
     }
 
+    /// A real ensemble abbreviates, so navigation on the abbreviated word
+    /// must land where the dispatch would. Oracle (identical on tclsh 8.6.16
+    /// and 9.0.4), for `namespace ensemble create -command ::e -map {foo
+    /// ::e::Foo}`: `e fo` returns `FOO`.
+    #[test]
+    fn ensemble_unique_prefix_subcommand_jumps_to_target_proc() {
+        let src = "namespace eval ::e {\n    namespace ensemble create -map {\n        foo ::e::Foo\n    }\n}\nproc ::e::Foo {args} { return \"foo: $args\" }\n\nputs [e fo bar]\n";
+        let analysis = analyse(src);
+        // Cursor on the abbreviated "fo" in `puts [e fo bar]`.
+        let locs = definition(src, 7, 8, &analysis);
+        assert_eq!(locs.len(), 1, "{locs:?}");
+        assert_eq!(locs[0].start_line, 5);
+    }
+
+    /// An *ambiguous* prefix is an error at runtime, so there is no target to
+    /// point at and navigation must keep abstaining. Oracle: with `-map {foo
+    /// … fob …}`, `f fo` errors `unknown or ambiguous subcommand "fo": must
+    /// be fob, or foo`.
+    #[test]
+    fn ensemble_ambiguous_prefix_subcommand_abstains() {
+        let src = "namespace eval ::f {\n    namespace ensemble create -map {\n        foo ::f::Foo\n        fob ::f::Fob\n    }\n}\nproc ::f::Foo {args} { return F }\nproc ::f::Fob {args} { return B }\n\nputs [f fo bar]\n";
+        let analysis = analyse(src);
+        let locs = definition(src, 9, 8, &analysis);
+        assert!(locs.is_empty(), "{locs:?}");
+    }
+
+    /// `-prefixes 0` turns prefix matching off, so the abbreviation is a
+    /// plain unknown subcommand and navigation must not follow it — while the
+    /// exact word still resolves. Oracle: `g fo` errors `unknown subcommand
+    /// "fo": must be foo`; `g foo` returns `FOO`.
+    #[test]
+    fn prefixless_ensemble_resolves_only_the_exact_subcommand() {
+        let src = "namespace eval ::g {\n    namespace ensemble create -map {\n        foo ::g::Foo\n    } -prefixes 0\n}\nproc ::g::Foo {args} { return G }\n\nputs [g fo bar]\nputs [g foo bar]\n";
+        let analysis = analyse(src);
+        // The abbreviation must NOT resolve…
+        let abbreviated = definition(src, 7, 8, &analysis);
+        assert!(abbreviated.is_empty(), "{abbreviated:?}");
+        // …while the exact spelling still does.
+        let exact = definition(src, 8, 8, &analysis);
+        assert_eq!(exact.len(), 1, "{exact:?}");
+        assert_eq!(exact[0].start_line, 5);
+    }
+
     #[test]
     fn ensemble_subcommands_form_jumps_to_target_proc() {
         // TP — the `-subcommands` sibling form (not `-map`), the folded-in
@@ -6460,19 +6510,28 @@ mod tests {
 
     #[test]
     fn ensemble_unmapped_subcommand_abstains_rather_than_guessing() {
-        // FN (accepted, documented) — a typo'd/genuinely-unmapped
-        // subcommand silently abstains rather than crashing or guessing.
-        // Also documents that this fix deliberately does not implement
-        // Tcl's unique-prefix ensemble-subcommand matching (a real tclsh
-        // would dispatch "mak" to "make" here since it's an unambiguous
-        // prefix and `-prefixes` defaults to true) — a reusable, named
-        // follow-up (`CommandSpec::resolve_subcommand_for_dialect`-style
-        // logic), not attempted here.
-        let src = "namespace eval ::widget {\n    namespace ensemble create -map {\n        make ::widget::Make\n    }\n}\nproc ::widget::Make {args} {}\nputs [widget mak hello]\n";
+        // A genuinely-unmapped subcommand silently abstains rather than
+        // crashing or guessing. `zzz` is not a prefix of anything the
+        // ensemble maps, so the ensemble itself would error here.
+        let src = "namespace eval ::widget {\n    namespace ensemble create -map {\n        make ::widget::Make\n    }\n}\nproc ::widget::Make {args} {}\nputs [widget zzz hello]\n";
         let analysis = analyse(src);
-        // Cursor on "mak" in `puts [widget mak hello]` (0-based line 6).
+        // Cursor on "zzz" in `puts [widget zzz hello]` (0-based line 6).
         let locs = definition(src, 6, 13, &analysis);
         assert!(locs.is_empty(), "{locs:?}");
+    }
+
+    #[test]
+    fn ensemble_abbreviated_subcommand_resolves_like_the_dispatch_does() {
+        // This case used to be an accepted FN: `mak` is an unambiguous
+        // prefix of `make` and `-prefixes` defaults to true, so tclsh
+        // dispatches it (oracle 8.6.16 / 9.0.4) while navigation abstained.
+        // Issue #1611 closed that gap by routing the lookup through
+        // `tcl_cmd_core::ensemble::resolve_subcommand`.
+        let src = "namespace eval ::widget {\n    namespace ensemble create -map {\n        make ::widget::Make\n    }\n}\nproc ::widget::Make {args} {}\nputs [widget mak hello]\n";
+        let analysis = analyse(src);
+        let locs = definition(src, 6, 13, &analysis);
+        assert_eq!(locs.len(), 1, "{locs:?}");
+        assert_eq!(locs[0].start_line, 5);
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/minify.rs
+++ b/rust/tcl-lsp-core/src/minify.rs
@@ -1568,7 +1568,7 @@ fn collect_live_names(
     let mut i = 0;
     while i < bytes.len() {
         if bytes[i] == b'$' {
-            let (end, name) = parse_var_ref(source, i);
+            let (end, name) = parse_var_ref(source, i, dialect.grammar.braced_var);
             if let Some(name) = name {
                 out.insert(name.to_owned());
                 i = end.max(i + 1);
@@ -2365,7 +2365,11 @@ fn fold_static_substrings(
     let mut scopes: Vec<&FunctionUnit> = vec![&cu.top_level];
     scopes.extend(cu.procedures.values());
     for fu in scopes {
-        collect_folds_for_scope(source, fu, &mut edits, &mut fold_map);
+        let cx = FoldContext {
+            fu,
+            style: dialect.grammar.braced_var,
+        };
+        collect_folds_for_scope(source, cx, &mut edits, &mut fold_map);
     }
     if edits.is_empty() {
         return (source.to_owned(), 0, fold_map);
@@ -2383,13 +2387,23 @@ fn fold_static_substrings(
     (result, fold_count, fold_map)
 }
 
+/// The read-only context a constant-fold decision needs: the scope's
+/// analysed unit and the document's `${…}` close rule (which decides where
+/// a `${…}` reference's name ends — issue #1605).
+#[derive(Clone, Copy)]
+struct FoldContext<'a> {
+    fu: &'a FunctionUnit,
+    style: tcl_dialect::BracedVarStyle,
+}
+
 /// Collect static-fold edits for one function scope.
 fn collect_folds_for_scope(
     source: &str,
-    fu: &FunctionUnit,
+    cx: FoldContext<'_>,
     edits: &mut Vec<Edit>,
     fold_map: &mut BTreeMap<String, String>,
 ) {
+    let (fu, style) = (cx.fu, cx.style);
     for (block_id, block) in &fu.cfg.blocks {
         let Some(ssa_block) = fu.ssa.blocks.get(block_id) else {
             continue;
@@ -2417,7 +2431,7 @@ fn collect_folds_for_scope(
                     value_needs_backsubst: true,
                     ..
                 } if value.contains('$') || value.contains('[') => {
-                    try_fold_region(source, *span, value, &uses, fu, edits, fold_map);
+                    try_fold_region(source, *span, value, &uses, cx, edits, fold_map);
                 }
                 Statement::Call {
                     tokens: Some(toks), ..
@@ -2432,9 +2446,10 @@ fn collect_folds_for_scope(
                             continue;
                         }
                         if let Some(folded) =
-                            fold_string_via_sccp(content, &uses, &fu.sccp.values, &fu.ssa)
+                            fold_string_via_sccp(content, &uses, &fu.sccp.values, &fu.ssa, style)
                         {
-                            if has_unsafe_tainted_inputs(content, &uses, &fu.taints, &fu.ssa) {
+                            if has_unsafe_tainted_inputs(content, &uses, &fu.taints, &fu.ssa, style)
+                            {
                                 continue;
                             }
                             if let Some(close) = close_quote_offset(source, arg_off) {
@@ -2464,14 +2479,15 @@ fn try_fold_region(
     span: Span,
     value: &str,
     uses: &HashMap<String, Version>,
-    fu: &FunctionUnit,
+    cx: FoldContext<'_>,
     edits: &mut Vec<Edit>,
     fold_map: &mut BTreeMap<String, String>,
 ) {
-    let Some(folded) = fold_string_via_sccp(value, uses, &fu.sccp.values, &fu.ssa) else {
+    let (fu, style) = (cx.fu, cx.style);
+    let Some(folded) = fold_string_via_sccp(value, uses, &fu.sccp.values, &fu.ssa, style) else {
         return;
     };
-    if has_unsafe_tainted_inputs(value, uses, &fu.taints, &fu.ssa) {
+    if has_unsafe_tainted_inputs(value, uses, &fu.taints, &fu.ssa, style) {
         return;
     }
     let (start, end) = (span.start() as usize, span.end() as usize);
@@ -2499,6 +2515,7 @@ fn fold_string_via_sccp(
     uses: &HashMap<String, Version>,
     values: &HashMap<(tcl_compiler::ssa::Symbol, Version), LatticeValue>,
     ssa: &tcl_compiler::ssa::SsaFunction,
+    style: tcl_dialect::BracedVarStyle,
 ) -> Option<String> {
     let bytes = content.as_bytes();
     let n = bytes.len();
@@ -2508,7 +2525,7 @@ fn fold_string_via_sccp(
     while pos < n {
         match bytes[pos] {
             b'$' => {
-                let (end, name) = parse_var_ref(content, pos);
+                let (end, name) = parse_var_ref(content, pos, style);
                 let name = name?;
                 let ver = uses.get(name).copied().unwrap_or(0);
                 if ver == 0 {
@@ -2559,13 +2576,14 @@ fn has_unsafe_tainted_inputs(
     uses: &HashMap<String, Version>,
     taints: &HashMap<(tcl_compiler::ssa::Symbol, Version), TaintLattice>,
     ssa: &tcl_compiler::ssa::SsaFunction,
+    style: tcl_dialect::BracedVarStyle,
 ) -> bool {
     let safe = safe_taint_colours();
     let mut pos = 0;
     let bytes = content.as_bytes();
     while pos < bytes.len() {
         if bytes[pos] == b'$' {
-            let (end, name) = parse_var_ref(content, pos);
+            let (end, name) = parse_var_ref(content, pos, style);
             if let Some(name) = name {
                 let ver = uses.get(name).copied().unwrap_or(0);
                 if ver > 0
@@ -2590,7 +2608,17 @@ fn has_unsafe_tainted_inputs(
 /// Parse a `$var` / `${var}` reference at `pos`, returning
 /// `(end, name)`.  Rejects array (`$a(i)`) and namespaced
 /// (`$a::b`) forms.
-fn parse_var_ref(text: &str, pos: usize) -> (usize, Option<&str>) {
+///
+/// The braced form is delimited by [`tcl_lexer::braced_var_name_end`] under
+/// the document's own `${…}` close rule: on a Tcl 9 document `${a{b}c}` is
+/// one variable named `a{b}c`, where the 8.x first-`}` rule reads `a{b` and
+/// leaves `c}` as word text. Minify rewrites these spans, so reading the
+/// wrong one changes what the output program means (issue #1605).
+fn parse_var_ref(
+    text: &str,
+    pos: usize,
+    style: tcl_dialect::BracedVarStyle,
+) -> (usize, Option<&str>) {
     let bytes = text.as_bytes();
     if pos >= bytes.len() || bytes[pos] != b'$' {
         return (pos + 1, None);
@@ -2600,12 +2628,9 @@ fn parse_var_ref(text: &str, pos: usize) -> (usize, Option<&str>) {
         return (start, None);
     }
     if bytes[start] == b'{' {
-        return match text[start + 1..].find('}') {
-            Some(rel) => {
-                let close = start + 1 + rel;
-                (close + 1, Some(&text[start + 1..close]))
-            }
-            None => (start, None),
+        return match tcl_lexer::braced_var_name_end(bytes, start + 1, style) {
+            tcl_lexer::BracedVarEnd::Closed(close) => (close + 1, Some(&text[start + 1..close])),
+            tcl_lexer::BracedVarEnd::Unterminated => (start, None),
         };
     }
     let mut end = start;
@@ -2934,6 +2959,15 @@ fn reconstruct_raw(
         TokenType::Str => format!("{{{}}}", sm.token_text(tok)),
         TokenType::Cmd => format!("[{}]", minify_body(sm.token_text(tok), env, depth + 1)),
         TokenType::Var => {
+            let name = sm.token_text(tok);
+            // A name that is not a bare `$name` word can only ever be written
+            // braced: `${a{b}c}` names the variable `a{b}c`, but `$a{b}c` is
+            // the variable `a` followed by the literal `{b}c`. The predicate
+            // is the shared one quick fixes use for exactly this `${x}` ↔
+            // `$x` equivalence (issue #1605).
+            if !tcl_syntax::naming::is_bare_var_name(name) {
+                return format!("${{{name}}}");
+            }
             // Keep `${var}` when the next token would otherwise extend the
             // variable name.  Beyond name characters, `(` (array index) and `:`
             // (namespace separator) also extend a `$` reference, so dropping
@@ -2943,9 +2977,9 @@ fn reconstruct_raw(
                 && let Some(c) = first_rendered_char(sm, next)
                 && (c.is_alphanumeric() || c == '_' || c == '(' || c == ':')
             {
-                return format!("${{{}}}", sm.token_text(tok));
+                return format!("${{{name}}}");
             }
-            format!("${}", sm.token_text(tok))
+            format!("${name}")
         }
         TokenType::Expand => "{*}".to_owned(),
         _ => sm.token_text(tok).to_owned(),
@@ -2956,7 +2990,7 @@ fn reconstruct_raw(
 const NEEDS_QUOTING: &[char] = &[' ', '\t', '\n', '\r', '\u{0b}', '\u{0c}', ';', '"', '\0'];
 
 /// Whether a quoted argument can safely drop its double quotes.
-fn can_strip_quotes(raw: &str) -> bool {
+fn can_strip_quotes(raw: &str, style: tcl_dialect::BracedVarStyle) -> bool {
     if raw.is_empty() {
         return false;
     }
@@ -2971,13 +3005,19 @@ fn can_strip_quotes(raw: &str) -> bool {
         return false;
     }
     // Any `{` / `}` outside `${var}` references blocks stripping.
-    let stripped = strip_braced_var_refs(raw);
+    let stripped = strip_braced_var_refs(raw, style);
     !(stripped.contains('{') || stripped.contains('}'))
 }
 
 /// Remove `${…}` references from `raw` so the residual brace check
 /// in [`can_strip_quotes`] only sees bare braces.
-fn strip_braced_var_refs(raw: &str) -> String {
+///
+/// Delimited by the document's own `${…}` close rule: under 8.x `${a{b}c}`
+/// ends at the first `}`, so `c}` is a *real* residual brace and the quotes
+/// must stay; under 9.x the whole thing is one reference and they may go.
+/// Scanning by the wrong rule strips quotes that were load-bearing, or
+/// keeps ones that were not (issue #1605).
+fn strip_braced_var_refs(raw: &str, style: tcl_dialect::BracedVarStyle) -> String {
     let bytes = raw.as_bytes();
     let n = bytes.len();
     let mut out = String::with_capacity(n);
@@ -2986,9 +3026,10 @@ fn strip_braced_var_refs(raw: &str) -> String {
         if bytes[i] == b'$'
             && i + 1 < n
             && bytes[i + 1] == b'{'
-            && let Some(close) = raw[i + 2..].find('}')
+            && let tcl_lexer::BracedVarEnd::Closed(close) =
+                tcl_lexer::braced_var_name_end(bytes, i + 2, style)
         {
-            i = i + 2 + close + 1;
+            i = close + 1;
             continue;
         }
         let ch_len = utf8_len(bytes[i]);
@@ -3022,7 +3063,7 @@ fn reconstruct_arg(sm: &SourceMap, arg: &Arg, env: MinifyEnv<'_>, depth: u32) ->
         let next = arg.tokens.get(idx + 1).copied();
         raw.push_str(&reconstruct_raw(sm, tok, next, env, arg.is_quoted, depth));
     }
-    if arg.is_quoted && !can_strip_quotes(&raw) {
+    if arg.is_quoted && !can_strip_quotes(&raw, env.dialect.grammar.braced_var) {
         format!("\"{raw}\"")
     } else {
         raw
@@ -3588,6 +3629,115 @@ mod tests {
             tcl_dialect::DialectProfile::by_name("tcl8.6"),
             &registry,
         )
+    }
+
+    /// A `${…}` whose name is not a bare `$name` word may never shed its
+    /// braces, whatever follows it: `${a{b}c}` reads the variable `a{b}c`,
+    /// while `$a{b}c` reads `a` and appends the literal `{b}c`.
+    ///
+    /// Found while pinning the plumb above — minify dropped the braces
+    /// because it only asked whether the *next* token would extend the
+    /// reference, never whether the name itself could be written bare
+    /// (issue #1605).
+    #[test]
+    fn a_non_bare_braced_name_keeps_its_braces() {
+        let registry = CommandRegistry::build_default();
+        for release in ["tcl9.0", "tcl8.6"] {
+            let out = minify_tcl(
+                "set {a b} 1\nputs ${a b}\n",
+                tcl_dialect::DialectProfile::by_name(release),
+                &registry,
+            );
+            assert!(
+                out.contains("${a b}"),
+                "a name with a space must stay braced on {release}: {out}"
+            );
+        }
+        // A plain name still sheds them.
+        let out = minify_tcl(
+            "set plain 1\nputs ${plain}\n",
+            tcl_dialect::DialectProfile::by_name("tcl9.0"),
+            &registry,
+        );
+        assert!(out.contains("$plain"), "{out}");
+        assert!(!out.contains("${plain}"), "{out}");
+    }
+
+    /// The **plumb**: minify must take the `${…}` rule from the document's
+    /// own dialect, not a constant. A quoted `"${a{b}c}"` may shed its
+    /// quotes on 9.x (the whole word is one variable reference) but not on
+    /// 8.x, where the reference stops at the first `}` and the residual `c}`
+    /// is a bare brace.
+    #[test]
+    fn quote_stripping_follows_the_documents_dialect() {
+        let registry = CommandRegistry::build_default();
+        let src = "puts \"${a{b}c}\"\n";
+        let nine = minify_tcl(
+            src,
+            tcl_dialect::DialectProfile::by_name("tcl9.0"),
+            &registry,
+        );
+        let eight = minify_tcl(
+            src,
+            tcl_dialect::DialectProfile::by_name("tcl8.6"),
+            &registry,
+        );
+        assert!(
+            !nine.contains('"'),
+            "9.x reads one reference, so the quotes may go: {nine}"
+        );
+        assert!(
+            eight.contains('"'),
+            "8.x leaves a bare `c}}`, so the quotes must stay: {eight}"
+        );
+    }
+
+    /// Issue #1605 — minify decides whether a quoted word may drop its
+    /// quotes by checking for braces left over after `${…}` references are
+    /// removed, so the removal must use the document's own `${…}` close
+    /// rule.
+    ///
+    /// Oracle: `puts ${a{b}c}` prints `NINE` on tclsh 9.0.4 (the whole thing
+    /// is one reference, so nothing brace-like remains) and `EIGHTc}` on
+    /// 8.6.16 (the reference ends at the first `}` and the residual `c}`
+    /// really is a bare brace).
+    #[test]
+    fn braced_var_stripping_follows_the_documents_release() {
+        use tcl_dialect::BracedVarStyle;
+        // 9.x: one reference, nothing left behind.
+        assert_eq!(
+            strip_braced_var_refs("${a{b}c}", BracedVarStyle::Tcl9Nesting),
+            ""
+        );
+        // 8.x: the reference is `${a{b}`, so `c}` survives as a bare brace.
+        assert_eq!(
+            strip_braced_var_refs("${a{b}c}", BracedVarStyle::FirstClose),
+            "c}"
+        );
+        // …which is exactly what decides whether the quotes may go.
+        assert!(can_strip_quotes("${a{b}c}", BracedVarStyle::Tcl9Nesting));
+        assert!(!can_strip_quotes("${a{b}c}", BracedVarStyle::FirstClose));
+    }
+
+    /// The `$var` reader behind constant folding and the live-name sweep
+    /// splits the same bytes at the same release-dependent point.
+    #[test]
+    fn parse_var_ref_reads_braced_names_by_the_documents_release() {
+        use tcl_dialect::BracedVarStyle;
+        let text = "${a{b}c}";
+        assert_eq!(
+            parse_var_ref(text, 0, BracedVarStyle::Tcl9Nesting),
+            (8, Some("a{b}c"))
+        );
+        assert_eq!(
+            parse_var_ref(text, 0, BracedVarStyle::FirstClose),
+            (6, Some("a{b"))
+        );
+        // An unterminated `${` yields no name under either rule.
+        assert_eq!(
+            parse_var_ref("${abc", 0, BracedVarStyle::Tcl9Nesting),
+            (1, None)
+        );
     }
 
     /// Regression coverage for issue #996: `minify_body`'s recursive

--- a/rust/tcl-lsp-core/src/refactor/extract_proc.rs
+++ b/rust/tcl-lsp-core/src/refactor/extract_proc.rs
@@ -77,6 +77,8 @@ use tcl_compiler::analyser::AnalysisResult;
 use tcl_compiler::segmenter::{SegmentedCommand, segment_commands_with_offset};
 use tcl_registry::{ArgRole, CommandRegistry, Traits};
 
+use tcl_dialect::BracedVarStyle;
+
 use super::{RefactorEdit, Refactoring, command_span_offsets};
 use crate::code_actions::{ActionCommand, ActionKind};
 
@@ -200,7 +202,11 @@ fn plan_extraction(
 ) -> Result<Plan, String> {
     reject_enclosing_definition_body(source, scope, registry)?;
     reject_frame_sensitive_selection(source, selected, registry)?;
-    let roles = classify_variables(source, selected, registry)?;
+    // The document's own `${…}` close rule — a brace-bearing name read by
+    // the wrong release's rule produces a proc built for a variable that
+    // does not exist (issue #1605).
+    let style = super::braced_var_style(analysis);
+    let roles = classify_variables(source, selected, registry, style)?;
 
     // The selection's own byte range, snapped to the commands it covers.
     let block_start = command_span_offsets(source, selected[0]).0;
@@ -218,7 +224,7 @@ fn plan_extraction(
         .into_iter()
         .filter(|command| !command.name().is_empty())
         .collect();
-    let mut used_after: BTreeSet<String> = variable_references(tail);
+    let mut used_after: BTreeSet<String> = variable_references(tail, style);
     for command in &tail_commands {
         used_after.extend(role_named_variables(command, registry));
     }
@@ -278,6 +284,7 @@ fn classify_variables(
     source: &str,
     selected: &[&SegmentedCommand],
     registry: &CommandRegistry,
+    style: BracedVarStyle,
 ) -> Result<VariableRoles, String> {
     let mut read = BTreeSet::new();
     let mut written = BTreeSet::new();
@@ -285,6 +292,7 @@ fn classify_variables(
         let (start, end) = command_span_offsets(source, command);
         read.extend(variable_references(
             source.get(start as usize..end as usize).unwrap_or(""),
+            style,
         ));
         let head = command.name();
         if head.contains('$') || head.contains('[') || head.contains('{') {
@@ -573,38 +581,16 @@ fn unique_proc_name(analysis: &AnalysisResult, registry: &CommandRegistry) -> St
 
 /// Distinct `$name` / `${name}` references in `text`, array elements
 /// reduced to the array's own name.
-fn variable_references(text: &str) -> BTreeSet<String> {
-    let bytes = text.as_bytes();
-    let mut out = BTreeSet::new();
-    let mut index = 0usize;
-    while index < bytes.len() {
-        if bytes[index] != b'$' {
-            index += 1;
-            continue;
-        }
-        if bytes.get(index + 1) == Some(&b'{') {
-            if let Some(offset) = text.get(index + 2..).and_then(|rest| rest.find('}')) {
-                out.insert(text[index + 2..index + 2 + offset].to_string());
-                index = index + 2 + offset + 1;
-                continue;
-            }
-            index += 1;
-            continue;
-        }
-        let mut end = index + 1;
-        while end < bytes.len()
-            && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_' || bytes[end] == b':')
-        {
-            end += 1;
-        }
-        if end > index + 1 {
-            out.insert(text[index + 1..end].to_string());
-            index = end;
-        } else {
-            index += 1;
-        }
-    }
-    out
+///
+/// `style` is the document's `${…}` close rule: the captured-variable set
+/// decides the generated proc's parameter list and its call-site arguments,
+/// so reading a brace-bearing name by the wrong release's rule emits a proc
+/// built for a variable that does not exist (issue #1605).
+fn variable_references(text: &str, style: BracedVarStyle) -> BTreeSet<String> {
+    super::variable_reference_spans(text, style)
+        .into_iter()
+        .map(|(name, _, _)| name)
+        .collect()
 }
 
 /// The variable names `command` names through a registry `VarRead` /
@@ -630,9 +616,15 @@ mod tests {
 
     /// Run the transform over the byte range of `needle` in `src`.
     fn at(src: &str, needle: &str) -> Option<Refactoring> {
+        at_dialect(src, needle, "tcl9.0")
+    }
+
+    /// [`at`] against a document analysed under a named release — the
+    /// `${…}` close rule is release-dependent (issue #1605).
+    fn at_dialect(src: &str, needle: &str, dialect: &str) -> Option<Refactoring> {
         let registry = super::super::test_registry();
         let mut analyser = Analyser::new();
-        let analysis = analyser.analyse(src, "tcl9.0").clone();
+        let analysis = analyser.analyse(src, dialect).clone();
         let start = u32::try_from(src.find(needle).expect("needle in source")).unwrap();
         let end = start + u32::try_from(needle.len()).unwrap();
         extract_proc(src, (start, end), &analysis, &registry)
@@ -658,6 +650,74 @@ mod tests {
             "{result}"
         );
         assert!(result.contains("extracted_proc $x"), "{result}");
+    }
+
+    /// Issue #1605 — the captured-variable set decides the generated proc's
+    /// parameters and its call-site arguments, so a brace-bearing `${…}`
+    /// name must be read by the **document's** release rule, not always the
+    /// 8.x first-`}` one.
+    ///
+    /// Oracle: with `a{b}c` set to `NINE` and `a{b` set to `EIGHT`,
+    /// `puts ${a{b}c}` prints `NINE` on tclsh 9.0.4 (one variable named
+    /// `a{b}c`) and `EIGHTc}` on 8.6.16 (the name ends at the first `}` and
+    /// `c}` is ordinary word text).
+    ///
+    /// Asserted on `variable_references` rather than through a whole
+    /// extraction because the **segmenter**'s own `${…}` word span still
+    /// truncates at the first `}` on a 9.x document (issue #1568, the
+    /// compiled-word path — explicitly out of #1605's scope), so the block
+    /// boundary an end-to-end extraction computes is wrong for a reason this
+    /// change does not touch.
+    #[test]
+    fn variable_references_read_braced_names_by_the_documents_release() {
+        let text = "puts ${a{b}c}";
+        // 9.x: brace depth, so the whole `a{b}c` is the name.
+        let nine = variable_references(text, BracedVarStyle::Tcl9Nesting);
+        assert_eq!(
+            nine.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec!["a{b}c"]
+        );
+        // 8.x: the name ends at the first `}`.
+        let eight = variable_references(text, BracedVarStyle::FirstClose);
+        assert_eq!(
+            eight.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec!["a{b"]
+        );
+    }
+
+    /// An unterminated `${` names nothing — inventing a name for it would
+    /// put that name into the generated proc's parameter list.
+    #[test]
+    fn variable_references_reject_an_unterminated_braced_name() {
+        assert!(variable_references("puts ${abc", BracedVarStyle::Tcl9Nesting).is_empty());
+        assert!(variable_references("puts ${abc", BracedVarStyle::FirstClose).is_empty());
+    }
+
+    /// The **plumb**: the style must come from the document's own dialect,
+    /// not a constant. The reference sits inside a braced body so the whole
+    /// command's span is balanced and the segmenter hands over the complete
+    /// `${a{b}c}` (issue #1568 only truncates a bare `${…}` word).
+    ///
+    /// Oracle: `puts ${a{b}c}` reads the variable `a{b}c` on tclsh 9.0.4 and
+    /// `a{b` on 8.6.16, so the two releases capture different names — and
+    /// the generated proc's parameter list differs accordingly.
+    #[test]
+    fn the_documents_dialect_decides_the_captured_braced_name() {
+        let src = "if {1} {puts ${a{b}c}}\nputs done\n";
+        let nine = at_dialect(src, "if {1} {puts ${a{b}c}}", "tcl9.0")
+            .expect("a selection")
+            .apply(src);
+        assert!(
+            nine.contains("proc extracted_proc {a{b}c} {"),
+            "9.x must capture the whole name: {nine}"
+        );
+        let eight = at_dialect(src, "if {1} {puts ${a{b}c}}", "tcl8.6")
+            .expect("a selection")
+            .apply(src);
+        assert!(
+            eight.contains("proc extracted_proc {a{b} {"),
+            "8.x must capture only `a{{b`: {eight}"
+        );
     }
 
     #[test]
@@ -795,7 +855,7 @@ mod tests {
 
     #[test]
     fn variable_references_collects_bare_and_braced_names() {
-        let found = variable_references("puts $a ${b} $c_1");
+        let found = variable_references("puts $a ${b} $c_1", BracedVarStyle::Tcl9Nesting);
         assert_eq!(
             found.into_iter().collect::<Vec<_>>(),
             vec!["a".to_string(), "b".to_string(), "c_1".to_string()]

--- a/rust/tcl-lsp-core/src/refactor/extract_proc.rs
+++ b/rust/tcl-lsp-core/src/refactor/extract_proc.rs
@@ -520,7 +520,16 @@ fn render_definition(
     params.extend(by_name.iter().map(|var| format!("{var}Name")));
     let mut body = String::new();
     for var in by_name {
-        let _ = writeln!(body, "    upvar 1 ${var}Name {var}");
+        // The `$<var>Name` read is a *reference* and needs the brace form for a
+        // non-bare name; the `upvar` target is a plain word, so it needs list
+        // quoting instead (a name may carry an unbalanced brace — on 8.x
+        // `${a{b}` names `a{b`).
+        let _ = writeln!(
+            body,
+            "    upvar 1 {} {}",
+            var_ref(&format!("{var}Name")),
+            word(var)
+        );
     }
     for line in block.lines() {
         let stripped = line.strip_prefix(block_indent).unwrap_or(line);
@@ -530,17 +539,41 @@ fn render_definition(
             let _ = writeln!(body, "    {}", stripped.trim_end());
         }
     }
-    format!("proc {name} {{{}}} {{\n{body}}}\n\n", params.join(" "))
+    // The parameter list is a Tcl *list*, so each name goes in as a properly
+    // quoted element rather than raw text.
+    let param_list = tcl_syntax::list::join_list(params.iter());
+    format!("proc {name} {{{param_list}}} {{\n{body}}}\n\n")
+}
+
+/// A `$` reference to `name`, braced unless the name can be written bare.
+///
+/// `${…}` is the spelling that survives every name this repository's scanners
+/// can produce, on both release rules: the 9.x scanner ends the name at the
+/// *matching* `}`, so `${a{b}c}` reads `a{b}c`, and the 8.x scanner ends it at
+/// the first `}`, so `${a{b}` reads `a{b}`'s 8.x form `a{b`. Emitting the bare
+/// `$a{b}c` instead would parse as `$a` followed by literal text on **both**
+/// releases — the same mistake the minifier made (issue #1605, fifth site).
+fn var_ref(name: &str) -> String {
+    if tcl_syntax::naming::is_bare_var_name(name) {
+        format!("${name}")
+    } else {
+        format!("${{{name}}}")
+    }
+}
+
+/// `name` as a single command word, list-quoted when it cannot stand raw.
+fn word(name: &str) -> String {
+    tcl_syntax::list::join_list(std::iter::once(name))
 }
 
 /// Render the call that replaces the selection.
 ///
 /// A by-value parameter is passed as `$var`; a by-name one is passed as the
-/// bare *name*, which is what `upvar` in the proc binds against.
+/// *name* itself, which is what `upvar` in the proc binds against.
 fn render_call(name: &str, by_value: &[String], by_name: &[String]) -> String {
     let mut words = vec![name.to_string()];
-    words.extend(by_value.iter().map(|var| format!("${var}")));
-    words.extend(by_name.iter().cloned());
+    words.extend(by_value.iter().map(|var| var_ref(var)));
+    words.extend(by_name.iter().map(|var| word(var)));
     words.join(" ")
 }
 
@@ -714,9 +747,63 @@ mod tests {
         let eight = at_dialect(src, "if {1} {puts ${a{b}c}}", "tcl8.6")
             .expect("a selection")
             .apply(src);
+        // `a{b` carries an unbalanced brace, so it reaches the parameter list
+        // as the quoted element tclsh itself writes (`list a{b` → `a\{b`).
+        // Emitting it raw made `proc extracted_proc {a{b} {…}` — an unbalanced
+        // brace that breaks the whole generated command.
         assert!(
-            eight.contains("proc extracted_proc {a{b} {"),
-            "8.x must capture only `a{{b`: {eight}"
+            eight.contains(r"proc extracted_proc {a\{b} {"),
+            "8.x must capture only `a{{b`, quoted: {eight}"
+        );
+    }
+
+    #[test]
+    fn render_call_braces_a_non_bare_captured_name() {
+        // A bare-writable name keeps the bare form…
+        assert_eq!(
+            render_call("p", &["plain".to_string()], &[]),
+            "p $plain",
+            "a bare name needs no braces"
+        );
+        // …and one that cannot be written bare gets the `${…}` spelling.
+        // `$a{b}c` would parse as `$a` followed by the literal `{b}c` on both
+        // 8.6.16 and 9.0.4, so the call passed the wrong value (issue #1636
+        // review).
+        assert_eq!(
+            render_call("p", &["a{b}c".to_string()], &[]),
+            "p ${a{b}c}",
+            "a brace-bearing name must be passed braced"
+        );
+        // A by-name argument is a word, not a reference, so it is list-quoted
+        // rather than braced.
+        assert_eq!(
+            render_call("p", &[], &["a{b".to_string()]),
+            r"p a\{b",
+            "an unbalanced-brace name must reach the call as one word"
+        );
+        assert_eq!(
+            render_call("p", &[], &["plain".to_string()]),
+            "p plain",
+            "a bare by-name argument stays raw"
+        );
+    }
+
+    #[test]
+    fn extracted_call_passes_a_brace_bearing_name_braced() {
+        // End-to-end, with the reference inside a braced body so the command
+        // span is balanced and the segmenter hands over the complete word
+        // (the #1568 cap the PR documents).
+        let src = "if {1} {puts ${a{b}c}}\nputs done\n";
+        let out = at_dialect(src, "if {1} {puts ${a{b}c}}", "tcl9.0")
+            .expect("a selection")
+            .apply(src);
+        assert!(
+            out.contains("extracted_proc ${a{b}c}"),
+            "the generated call must brace the name: {out}"
+        );
+        assert!(
+            !out.contains("extracted_proc $a{b}c"),
+            "the bare form parses as `$a` plus literal text: {out}"
         );
     }
 

--- a/rust/tcl-lsp-core/src/refactor/inline_proc.rs
+++ b/rust/tcl-lsp-core/src/refactor/inline_proc.rs
@@ -73,7 +73,7 @@
 
 use tcl_compiler::analyser::AnalysisResult;
 use tcl_compiler::segmenter::segment_commands_with_offset;
-use tcl_dialect::NumberSyntax;
+use tcl_dialect::{BracedVarStyle, NumberSyntax};
 use tcl_lexer::{Token, TokenType};
 use tcl_registry::{ArgRole, CommandRegistry};
 
@@ -149,8 +149,12 @@ pub fn inline_proc_in_program(
     let numbers = tcl_dialect::DialectProfile::by_name(&analysis.dialect)
         .grammar
         .numbers;
+    // …and its `${…}` close rule, for the same reason: which bytes are the
+    // variable's name is release-dependent, and this transform rewrites the
+    // reference's own span (issue #1605).
+    let style = super::braced_var_style(analysis);
 
-    match plan_inline(source, &call, proc_def, registry, numbers) {
+    match plan_inline(source, &call, proc_def, registry, numbers, style) {
         Ok(new_text) => Some(Refactoring {
             title,
             edits: vec![RefactorEdit {
@@ -179,6 +183,7 @@ fn plan_inline(
     proc_def: &tcl_compiler::analyser::ProcDef,
     registry: &CommandRegistry,
     numbers: NumberSyntax,
+    style: BracedVarStyle,
 ) -> Result<String, String> {
     if proc_def.params_computed {
         return Err(
@@ -190,8 +195,8 @@ fn plan_inline(
     let bindings = bind_arguments(source, call, proc_def)?;
     reject_frame_sensitive_body(&body, registry)?;
     reject_body_variable_writes(&body, registry)?;
-    reject_args_reference(&body, proc_def)?;
-    substitute_bindings(&body, &bindings, registry, numbers)
+    reject_args_reference(&body, proc_def, style)?;
+    substitute_bindings(&body, &bindings, registry, numbers, style)
 }
 
 /// One command's worth of proc body, re-segmented so its argument roles and
@@ -452,11 +457,12 @@ fn reject_body_variable_writes(
 fn reject_args_reference(
     body: &BodyCommand,
     proc_def: &tcl_compiler::analyser::ProcDef,
+    style: BracedVarStyle,
 ) -> Result<(), String> {
     if proc_def.params.last().is_none_or(|p| p.name != "args") {
         return Ok(());
     }
-    if variable_references(&body.text)
+    if variable_references(&body.text, style)
         .into_iter()
         .any(|(name, _, _)| name == "args")
     {
@@ -477,8 +483,9 @@ fn substitute_bindings(
     bindings: &[Binding],
     registry: &CommandRegistry,
     numbers: NumberSyntax,
+    style: BracedVarStyle,
 ) -> Result<String, String> {
-    let references = variable_references(&body.text);
+    let references = variable_references(&body.text, style);
     let expr_ranges = expr_argument_ranges(&body.command, registry);
     let mut replacements: Vec<(usize, usize, String)> = Vec::new();
     for binding in bindings {
@@ -562,39 +569,11 @@ fn expr_argument_ranges(
 /// Matching whole references rather than doing a `str::replace` is what keeps
 /// `$nn` intact when the parameter is `n`, and stops a `$name` embedded in a
 /// longer token being half-rewritten.
-fn variable_references(text: &str) -> Vec<(String, usize, usize)> {
-    let bytes = text.as_bytes();
-    let mut out = Vec::new();
-    let mut index = 0usize;
-    while index < bytes.len() {
-        if bytes[index] != b'$' {
-            index += 1;
-            continue;
-        }
-        if bytes.get(index + 1) == Some(&b'{') {
-            if let Some(offset) = text.get(index + 2..).and_then(|rest| rest.find('}')) {
-                let name = text[index + 2..index + 2 + offset].to_string();
-                out.push((name, index, index + 2 + offset + 1));
-                index = index + 2 + offset + 1;
-                continue;
-            }
-            index += 1;
-            continue;
-        }
-        let mut end = index + 1;
-        while end < bytes.len()
-            && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_' || bytes[end] == b':')
-        {
-            end += 1;
-        }
-        if end > index + 1 {
-            out.push((text[index + 1..end].to_string(), index, end));
-            index = end;
-        } else {
-            index += 1;
-        }
-    }
-    out
+/// Every `$name` / `${name}` reference in `text`, with the byte span of the
+/// whole reference — the span this transform rewrites, so it must be the
+/// span the document's own release would parse (issue #1605).
+fn variable_references(text: &str, style: BracedVarStyle) -> Vec<(String, usize, usize)> {
+    super::variable_reference_spans(text, style)
 }
 
 /// `true` when `value` can be written into any Tcl word position verbatim
@@ -941,8 +920,33 @@ mod tests {
 
     #[test]
     fn variable_references_finds_whole_names_only() {
-        let found = variable_references("puts $n$nn ${n}x");
+        let found = variable_references("puts $n$nn ${n}x", BracedVarStyle::Tcl9Nesting);
         let names: Vec<&str> = found.iter().map(|(name, _, _)| name.as_str()).collect();
         assert_eq!(names, vec!["n", "nn", "n"]);
+    }
+
+    /// Issue #1605 — inline-proc **rewrites** each reference's own byte
+    /// span, so the span must be the one the document's release parses. On a
+    /// 9.x document `${a{b}c}` is one reference spanning all 8 bytes; on 8.x
+    /// it ends at the first `}` and the trailing `c}` is word text that must
+    /// survive the substitution untouched.
+    ///
+    /// Oracle: `puts ${a{b}c}` prints `NINE` on tclsh 9.0.4 and `EIGHTc}` on
+    /// 8.6.16.
+    #[test]
+    fn variable_reference_spans_follow_the_documents_release() {
+        let text = "puts ${a{b}c}";
+        let nine = variable_references(text, BracedVarStyle::Tcl9Nesting);
+        assert_eq!(nine.len(), 1, "{nine:?}");
+        assert_eq!(nine[0].0, "a{b}c");
+        // `$` at 5 through the closing `}` at 12 inclusive.
+        assert_eq!((nine[0].1, nine[0].2), (5, 13));
+
+        let eight = variable_references(text, BracedVarStyle::FirstClose);
+        assert_eq!(eight.len(), 1, "{eight:?}");
+        assert_eq!(eight[0].0, "a{b");
+        // The reference stops before `c}`, which stays ordinary word text.
+        assert_eq!((eight[0].1, eight[0].2), (5, 11));
+        assert_eq!(&text[eight[0].2..], "c}");
     }
 }

--- a/rust/tcl-lsp-core/src/refactor/mod.rs
+++ b/rust/tcl-lsp-core/src/refactor/mod.rs
@@ -72,11 +72,80 @@ pub use inline_variable::inline_variable;
 pub use switch_to_dict::switch_to_dict;
 
 use tcl_compiler::segmenter::{SegmentedCommand, segment_commands_with_offset};
+use tcl_dialect::BracedVarStyle;
 use tcl_lexer::{LineIndex, Token, TokenType};
 use tcl_registry::{ArgRole, CommandRegistry};
 use tcl_syntax::switch_body::parse_braced_pairs;
 
 use crate::definition::LspRange;
+
+/// The `${…}` close rule the document's dialect uses.
+///
+/// A refactor rewrites *text*, so reading a variable name by one release's
+/// rule while the document is another's changes what the edit means: on a
+/// Tcl 9 document `${a{b}c}` is one variable named `a{b}c`, but the 8.x
+/// first-`}` rule reads `a{b` and leaves `c}` looking like ordinary word
+/// text (issue #1605).
+pub(crate) fn braced_var_style(
+    analysis: &tcl_compiler::analyser::AnalysisResult,
+) -> BracedVarStyle {
+    tcl_dialect::DialectProfile::by_name(&analysis.dialect)
+        .grammar
+        .braced_var
+}
+
+/// Every `$name` / `${name}` reference in `text`, as
+/// `(name, start, end)` byte offsets covering the whole reference
+/// (`$` through the closing `}`).
+///
+/// The braced form is delimited by [`tcl_lexer::braced_var_name_end`] — the
+/// one release-aware `Tcl_ParseVarName` port — rather than a `find('}')`,
+/// so a brace-bearing name is read the way the document's own release reads
+/// it. An unterminated `${` is not a reference: it is a parse error in the
+/// document, and inventing a name for it would put that name into a
+/// generated parameter list.
+///
+/// Array elements are **not** reduced here; a caller that wants the array's
+/// own name (extract-proc's captured set) trims at the `(`.
+pub(crate) fn variable_reference_spans(
+    text: &str,
+    style: BracedVarStyle,
+) -> Vec<(String, usize, usize)> {
+    let bytes = text.as_bytes();
+    let mut out = Vec::new();
+    let mut index = 0usize;
+    while index < bytes.len() {
+        if bytes[index] != b'$' {
+            index += 1;
+            continue;
+        }
+        if bytes.get(index + 1) == Some(&b'{') {
+            let name_start = index + 2;
+            if let tcl_lexer::BracedVarEnd::Closed(close) =
+                tcl_lexer::braced_var_name_end(bytes, name_start, style)
+            {
+                out.push((text[name_start..close].to_string(), index, close + 1));
+                index = close + 1;
+                continue;
+            }
+            index += 1;
+            continue;
+        }
+        let mut end = index + 1;
+        while end < bytes.len()
+            && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_' || bytes[end] == b':')
+        {
+            end += 1;
+        }
+        if end > index + 1 {
+            out.push((text[index + 1..end].to_string(), index, end));
+            index = end;
+        } else {
+            index += 1;
+        }
+    }
+    out
+}
 
 /// A single text replacement, in byte-offset space.
 ///

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -4579,6 +4579,55 @@ mod tests {
         );
     }
 
+    /// Issue #1611 — the analyser's own dispatch recording resolves the
+    /// subcommand the way the ensemble does, so an **abbreviated** call site
+    /// is a reference too. Oracle (tclsh 8.6.16 / 9.0.4): with `-map {foo
+    /// ::e::Foo}` and the default `-prefixes 1`, `e fo` returns `foo: bar`.
+    ///
+    /// The abbreviated site sits inside a proc body so the deferred replay
+    /// path (`flush_pending_ensemble_subcommand_invocations`) resolves it,
+    /// not only the direct one.
+    #[test]
+    fn ensemble_abbreviated_dispatch_is_a_reference_to_the_target() {
+        let src = "namespace eval ::e {\n    namespace ensemble create -map {\n        foo ::e::Foo\n    }\n}\nproc ::e::Foo {args} { return \"foo: $args\" }\nproc caller {} {\n    return [e fo bar]\n}\n";
+        let analysis = analyse(src);
+        // Cursor on the declaration of ::e::Foo (0-based line 5).
+        let refs = references(
+            src,
+            tcl_dialect::DialectProfile::by_name("tcl"),
+            5,
+            11,
+            &analysis,
+            true,
+        );
+        assert!(
+            refs.iter().any(|r| r.start_line == 7),
+            "expected the abbreviated call site inside the proc body: {refs:?}",
+        );
+    }
+
+    /// The `-prefixes 0` counterpart: prefix matching is off, so the
+    /// abbreviated word is a plain unknown subcommand and must NOT be
+    /// recorded as a dispatch reference. Oracle: `g fo` errors
+    /// `unknown subcommand "fo": must be foo`.
+    #[test]
+    fn prefixless_ensemble_abbreviation_is_not_a_reference() {
+        let src = "namespace eval ::g {\n    namespace ensemble create -map {\n        foo ::g::Foo\n    } -prefixes 0\n}\nproc ::g::Foo {args} { return G }\nproc caller {} {\n    return [g fo bar]\n}\n";
+        let analysis = analyse(src);
+        let refs = references(
+            src,
+            tcl_dialect::DialectProfile::by_name("tcl"),
+            5,
+            11,
+            &analysis,
+            true,
+        );
+        assert!(
+            !refs.iter().any(|r| r.start_line == 7),
+            "a -prefixes 0 ensemble must not resolve the abbreviation: {refs:?}",
+        );
+    }
+
     /// Issue #923 idx 85 — the ensemble is created by
     /// `namespace ensemble create -map` inside a proc declared with a
     /// fully-qualified name at top level, with no enclosing `namespace eval`,

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -1447,17 +1447,34 @@ pub struct ItemBodyKey<'db> {
         Arc<tcl_compiler::command_binding::CommandTrustSnapshot>,
         Option<String>,
     )>,
-    /// The body's enclosing-environment snapshot, two halves in one field
+    /// The body's enclosing-environment snapshot, several halves in one field
     /// (salsa interns the field tuple, whose `Hash` impl caps at 12
-    /// elements):
+    /// elements — and this struct is already at that cap, which is why these
+    /// travel packed rather than as fields of their own):
     ///
-    /// - `.0` — the ensemble `subcommand → target` maps visible to this
-    ///   body, mirroring
-    ///   [`tcl_compiler::analyser::per_item::DeferredBody::ensemble_targets`]
-    ///   (already canonically sorted and filtered to ensembles the body
-    ///   mentions, so an unrelated ensemble edit re-keys no body). Part of
-    ///   the key so an `<ensemble> <sub> …` call inside the body
-    ///   re-analyses when the mapping it resolves through changes.
+    /// - `.0` — the ensemble environment, itself a pair that must stay a
+    ///   pair:
+    ///   - `.0.0` — the ensemble `subcommand → target` maps visible to this
+    ///     body, mirroring
+    ///     [`tcl_compiler::analyser::per_item::DeferredBody::ensemble_targets`]
+    ///     (already canonically sorted and filtered to ensembles the body
+    ///     mentions, so an unrelated ensemble edit re-keys no body). Part of
+    ///     the key so an `<ensemble> <sub> …` call inside the body
+    ///     re-analyses when the mapping it resolves through changes.
+    ///   - `.0.1` — the `-prefixes 0` opt-out for those same ensembles,
+    ///     mirroring
+    ///     [`tcl_compiler::analyser::per_item::DeferredBody::prefixless_ensembles`].
+    ///     **Bound to `.0.0` by type on purpose.**
+    ///     `AnalysisResult::resolve_ensemble_subcommand` reads the two
+    ///     together — the map says which subcommands exist, this says
+    ///     whether an abbreviation of one may match — so seeding the map
+    ///     alone lets an isolated body resolve `g fo` against a
+    ///     `-prefixes 0` ensemble and record a dispatch the whole-file walk
+    ///     (and real Tcl) refuse. This query *resolves* the body rather than
+    ///     replaying a recorded answer, so the salsa altitude needs the
+    ///     opt-out exactly as much as the whole-file walk does; the nested
+    ///     pair is what stops a future edit from cloning one without the
+    ///     other.
     /// - `.1` — the enclosing safe-interpreter visibility context (issue
     ///   #1001 follow-up), mirroring
     ///   [`tcl_compiler::analyser::per_item::DeferredBody::safe_interp_ctx`]
@@ -1477,13 +1494,16 @@ pub struct ItemBodyKey<'db> {
     ///   bodies whose creation calls it decides.
     #[returns(ref)]
     pub body_env: (
-        Vec<(
-            String,
+        (
             Vec<(
                 String,
-                tcl_compiler::analyser::types::EnsembleSubcommandTarget,
+                Vec<(
+                    String,
+                    tcl_compiler::analyser::types::EnsembleSubcommandTarget,
+                )>,
             )>,
-        )>,
+            Vec<String>,
+        ),
         Option<(bool, Vec<String>, Vec<String>)>,
         Option<Arc<tcl_compiler::analyser::ClassFactoryIndex>>,
     ),
@@ -1520,7 +1540,10 @@ pub fn item_body_analysis<'db>(db: &'db dyn TclDb, key: ItemBodyKey<'db>) -> Arc
         class_variables: key.class_variables(db).clone(),
         command_trust,
         oo_defining_class,
-        ensemble_targets: key.body_env(db).0.clone(),
+        // The two ensemble halves are seeded together, never separately —
+        // see `ItemBodyKey::body_env`.
+        ensemble_targets: key.body_env(db).0.0.clone(),
+        prefixless_ensembles: key.body_env(db).0.1.clone(),
         safe_interp_ctx: key.body_env(db).1.clone(),
     };
     let disabled: HashSet<String> = key.disabled(db).iter().cloned().collect();
@@ -3105,7 +3128,10 @@ pub fn file_analysis_incremental(
                 .clone()
                 .map(|trust| (trust, body.oo_defining_class.clone())),
             (
-                body.ensemble_targets.clone(),
+                (
+                    body.ensemble_targets.clone(),
+                    body.prefixless_ensembles.clone(),
+                ),
                 body.safe_interp_ctx.clone(),
                 workspace_class_factories.clone(),
             ),
@@ -3676,7 +3702,7 @@ mod tests {
                 false,
                 Vec::new(),
                 None,
-                (Vec::new(), None, None),
+                ((Vec::new(), Vec::new()), None, None),
                 "tcl8.6".to_owned(),
                 Vec::new(),
                 NonAsciiMode::Default,
@@ -3699,7 +3725,7 @@ mod tests {
             false,
             Vec::new(),
             None,
-            (Vec::new(), None, None),
+            ((Vec::new(), Vec::new()), None, None),
             "tcl8.6".to_owned(),
             Vec::new(),
             NonAsciiMode::Default,


### PR DESCRIPTION
## Summary

Three user-facing frontend bugs. Each is fixed by routing the site through the owner that already knows the rule, rather than adding a second hand-rolled scan.

Fixes #1605
Fixes #1611
Fixes #1612

### #1605 — `${…}` names re-derived with a release-blind first-`}` scan

Four sites hard-coded the 8.x rule at every release: `refactor/extract_proc.rs` and `refactor/inline_proc.rs` (`variable_references`), and `minify.rs` (`parse_var_ref`, `strip_braced_var_refs`). They now delimit the braced form with `tcl_lexer::braced_var_name_end` under the document's own `BracedVarStyle`, resolved from `AnalysisResult::dialect` the way `inline_proc` already resolved its `NumberSyntax`. The two near-identical refactor scanners collapse into one shared `refactor::variable_reference_spans`.

Oracle for the divergence, with `a{b}c` set to `NINE` and `a{b` set to `EIGHT`:

| script | tclsh 8.6.16 | tclsh 9.0.4 |
|---|---|---|
| `puts ${a{b}c}` | `EIGHTc}` | `NINE` |

So on a Tcl 9 document `${a{b}c}` is one variable named `a{b}c`; on 8.x the name ends at the first `}` and `c}` is ordinary word text. Extract-proc computed its captured set — which becomes the generated proc's parameter list and its call-site arguments — from the truncated name.

**A fifth site, found while mutation-verifying the plumb.** Minify re-emits a `Var` token as `${name}` only when the *next* token would extend the reference; otherwise it dropped the braces unconditionally, without asking whether the name could be written bare at all. `${a{b}c}` became `$a{b}c` — the variable `a` followed by the literal `{b}c`, wrong on **both** releases. That decision now consults `tcl_syntax::naming::is_bare_var_name`, the predicate the quick fixes already use for exactly this `${x}` and `$x` equivalence.

### #1611 — user-ensemble subcommands resolved by exact match only

`definition.rs` and the analyser's two recording paths in `analyser/commands.rs` all did an exact map lookup, so navigation abstained on an abbreviated dispatch word that real Tcl dispatches. The lookup now has one owner, `AnalysisResult::resolve_ensemble_subcommand`, which delegates the match rule to `tcl_cmd_core::ensemble::resolve_subcommand` (the owner PR #1592 established) with the ensemble's recorded `-prefixes` flag. An ambiguous prefix resolves to nothing and the caller keeps abstaining — the ensemble would error there, so there is no target to point at.

`prefixless_ensembles` moves from analyser walker state onto `AnalysisResult`, because lsp-core reads the result and could not otherwise see the `-prefixes 0` opt-out. Its two W145 readers move with it, and the bare-versus-`::`-prefixed key dance they duplicated becomes `AnalysisResult::ensemble_refuses_prefixes`.

Oracle (identical on 8.6.16 and 9.0.4), for a `-map` binding `foo` to `::e::Foo`:

| call | result |
|---|---|
| `e fo` (unique prefix) | `FOO` |
| `f fo` where both `foo` and `fob` are mapped | error: unknown or ambiguous subcommand |
| `g fo` with `-prefixes 0` | error: unknown subcommand |
| `g foo` with `-prefixes 0` | `FOO` |

### #1612 — `namespace export` recorded patterns past an invalid one

`NamespaceExportCmd` calls `Tcl_Export` per pattern and returns on the first failure, so a qualified pattern aborts the loop. The analyser recorded the later ones anyway, letting a wildcard-import bareword resolve where real Tcl would not. Recording now stops at the first qualified pattern, keeping the ones already committed.

Oracle rows, identical on both releases:

| script | exports |
|---|---|
| `namespace export ::bad ok` | nothing |
| `namespace export ok ::bad` | `ok` |
| `namespace export one ::bad three` | `one` |
| `namespace export -clear ::bad` | nothing, and the clear stands |
| `namespace export a:b ok` | `a:b ok` — a lone colon is not a separator |
| `namespace export {} ok` | the empty pattern and `ok` — both valid |

A dynamic pattern (a `$` or `[` substitution) is still skipped rather than treated as the abort: whether it resolves to a qualified pattern is unknowable here.

### Deliberately not changed

`extract_proc`'s end-to-end output for a bare `${a{b}c}` word is still wrong, for a reason this change does not touch: the **segmenter**'s own `${…}` word span truncates at the first `}` on a 9.x document (issue #1568, the compiled-word path, explicitly outside #1605's scope). The `${…}` reading is asserted directly, plus one end-to-end case where the reference sits inside a braced body so the command span is balanced and the segmenter hands over the complete word.

No diagnostic was added for a qualified export pattern. #1612 lists it as optional; a new code needs its editor-catalogue codegen and a per-code KCS page, which would outweigh the rest of this bundle. Noted as a follow-up.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo fmt --all --check                              # clean
cargo clippy -p tcl-compiler -p tcl-lsp-core --all-targets   # clean
cargo test -p tcl-lsp-core --no-fail-fast            # 33 suites, 3249 passed, 0 failed
cargo test -p tcl-compiler --no-fail-fast            # 63 suites, 8850 passed, 0 failed
cargo test -p tcl-lsp-server --no-fail-fast          #  7 suites, 2014 passed, 0 failed
```

Every guard is mutation-verified by a named test:

| mutation | test that fails |
|---|---|
| drop the qualified-pattern abort | `handle_namespace_export_stops_at_the_first_qualified_pattern`, `handle_namespace_export_clear_commits_before_an_invalid_pattern` |
| pass `true` for the prefixes flag | `prefixless_ensemble_resolves_only_the_exact_subcommand` |
| pin `braced_var_style` to the 8.x rule | `the_documents_dialect_decides_the_captured_braced_name` |

One pre-existing test changed meaning rather than being deleted: `ensemble_unmapped_subcommand_abstains_rather_than_guessing` documented the missing prefix matching as an accepted false negative and named it as a follow-up. Its `mak` case is now the positive assertion `ensemble_abbreviated_subcommand_resolves_like_the_dispatch_does`, and the abstain case keeps a word that is a prefix of nothing.

Refactoring note: `try_fold_region` crossed clippy's argument limit once the style was threaded in, so the scope's analysed unit and the style group into a `FoldContext`.

## Compiler / diagnostics checklist

- **Did this change alter a compiler fact contract?** Additively. `AnalysisResult` gains the `prefixless_ensembles` field (moved from walker state, so the fact itself is not new) and the `resolve_ensemble_subcommand` / `ensemble_refuses_prefixes` accessors. Both are documented at their definitions.
- **Owning design doc:** unchanged. No new owner is introduced — the ensemble match rule is `tcl_cmd_core::ensemble`, already recorded in the shared-utility contract by #1592, and the `${…}` rule is `tcl_lexer::ranges::braced_var_name_end`, already recorded there too. This change adds consumers, not owners.
- **Diagnostic or optimisation code added or changed?** No.
- **Design doc added?** No.

## Follow-ups

- #1568 — the segmenter's compiled-word `${…}` span, which still truncates at the first `}` on 9.x documents and caps what extract-proc can produce for a bare braced word.
- A diagnostic for a qualified `namespace export` pattern, which is a guaranteed runtime error that `namespace_rename.rs` already knows how to recognise.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o)_