### PR TITLE
test(spectcl): pre-release torture suite for `.tclspec` loading, live reload, and scale — loader altitude plus the extension host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ editors/vscode/testFixture/.vscode/
 # the source tree.
 /editors/zed/extension.wasm
 /editors/zed/grammars/
+editors/vscode/testFixture/specPackTortureScratch/

--- a/editors/vscode/src/test/specPackTorture.test.ts
+++ b/editors/vscode/src/test/specPackTorture.test.ts
@@ -73,8 +73,17 @@ const docUri = getDocUri("specPackTorture.tcl");
  *  merely that the consumer's queue happens to be alive. */
 const probeUri = getDocUri("livenessProbe.tcl");
 
-/** A well-formed pack: the state every hostile write is measured against. */
-const GOOD_PACK = `speclib ${PACK_NAME} 1.1 {
+/**
+ * A well-formed pack, stamped with `generation` in its hover summary.
+ *
+ * The stamp is what makes "which write is in effect" observable. Without it
+ * every well-formed generation is byte-identical in the fields a test can
+ * read, so a convergence assertion would be satisfied by *any* of them — a
+ * stale publish two generations old would pass. `gen=<generation>` reaches the
+ * hover, so a test can name the exact write it expects to win.
+ */
+function goodPack(generation: string): string {
+  return `speclib ${PACK_NAME} 1.1 {
 
 command ::torturepack::apply {
     dialects tcl8.6+
@@ -87,13 +96,28 @@ command ::torturepack::apply {
     form Default {::torturepack::apply resultVar script}
 
     hover {
-        summary {${HOVER_MARKER} — evaluate a script collecting into a caller variable.}
+        summary {${HOVER_MARKER} gen=${generation} — evaluate a script collecting into a caller variable.}
         synopsis {::torturepack::apply resultVar script}
     }
 }
 
 }
 `;
+}
+
+/** The baseline well-formed pack every hostile write is measured against. */
+const GOOD_PACK = goodPack("base");
+
+/** Opt-in for the manual-tier edit storm below.
+ *
+ *  Matches the Rust corpus sweep's `SPECTCL_CORPUS_TMP` convention: any
+ *  non-empty value other than `0` counts, so `SPECTCL_EXT_EDIT_STORM=1` reads
+ *  the way it is documented without `=0` silently meaning the opposite. */
+const EDIT_STORM_ENV = "SPECTCL_EXT_EDIT_STORM";
+function editStormOptedIn(): boolean {
+  const value = process.env[EDIT_STORM_ENV];
+  return value !== undefined && value !== "" && value !== "0";
+}
 
 /**
  * The hostile battery, each entry a complete file body.
@@ -281,6 +305,32 @@ async function awaitHoverMarker(label: string): Promise<void> {
   );
 }
 
+/**
+ * Wait until the hover shows exactly `generation`, then assert no other
+ * generation's stamp is present.
+ *
+ * The equality is the point. `awaitHoverMarker` only proves *some* well-formed
+ * generation is in effect, which any of a burst's writes would satisfy — this
+ * names the one that must have won.
+ */
+async function awaitHoverGeneration(generation: string, label: string): Promise<void> {
+  const stamp = `gen=${generation}`;
+  const text = await pollUntil(
+    () => hoverTextAt(COMMAND_POSITION),
+    (t) => t.includes(stamp),
+    {
+      timeout: 40_000,
+      label,
+    },
+  );
+  const others = [...text.matchAll(/gen=([A-Za-z0-9-]+)/g)].map((m) => m[1]);
+  assert.deepStrictEqual(
+    [...new Set(others)],
+    [generation],
+    `the hover must show only generation ${generation}, got ${JSON.stringify(others)}`,
+  );
+}
+
 suite("SpecTcl pack torture through the extension host", () => {
   let originalSetting: string[] | undefined;
 
@@ -369,42 +419,85 @@ suite("SpecTcl pack torture through the extension host", () => {
     await awaitHoverMarker("the repaired pack's hover to come back");
   });
 
-  test("rapid successive edits settle on the last write, not an earlier one", async function () {
-    // The pack-reload analogue of the #1619 / #1622 index-removal window: a
-    // reload takes its sequence number before it reads the disk, so a slower
-    // earlier reload must never publish over a faster later one. Ten writes
-    // back to back, with no wait between them, is what makes the interleaving
-    // likely rather than theoretical.
-    this.timeout(240_000);
+  test("a second write immediately after a first wins", async function () {
+    // The minimal stale-publish shape, and the one that belongs in CI: two
+    // writes with no wait between them, so the first reload is still reading
+    // the disk when the second lands. A reload takes its sequence number
+    // *before* it reads (`PublishedPackSet::seq`), so the earlier snapshot must
+    // never publish over the later one however long it then spends parsing.
+    //
+    // The generation stamps are what make this a real assertion: both writes
+    // are well-formed, so without them "some good pack is loaded" would be
+    // true of the loser too. `awaitHoverGeneration` demands `gen=second` and
+    // no other stamp — a stale publish leaves `gen=first` and fails.
+    this.timeout(180_000);
 
     const since = getServerLogSize();
-    for (let i = 0; i < 10; i++) {
-      // Alternate broken and well-formed so consecutive writes cannot
-      // coalesce into one content key, and so the *final* state is one whose
-      // effect is observable.
-      fs.writeFileSync(
-        PACK,
-        i % 2 === 0
-          ? `speclib ${PACK_NAME} 1.1 {\n  command ::torturepack::apply { arity ${i}\n`
-          : `${GOOD_PACK}\n# generation ${i}\n`,
-        "utf8",
-      );
-    }
-    // Last write is i === 9, an odd index, so the good pack is the final state.
-    fs.writeFileSync(PACK, `${GOOD_PACK}\n# final generation\n`, "utf8");
+    fs.writeFileSync(PACK, goodPack("first"), "utf8");
+    fs.writeFileSync(PACK, goodPack("second"), "utf8");
 
     await waitForServerLog((line) => line.includes("SpecTcl:"), {
       since,
       timeout: 40_000,
-      label: "at least one reload from the rapid-edit burst",
+      label: "a reload from the two back-to-back writes",
     });
-    await assertServerAlive("a burst of ten rapid pack edits");
+    await assertServerAlive("two back-to-back pack writes");
 
-    // The registry must converge on what is *on disk now*, not on whichever
-    // reload finished last. A stale publish would leave the truncated
-    // generation in effect and this would never hold.
-    await awaitPackLoaded("the pack set to converge on the final write");
-    await awaitHoverMarker("the hover to converge on the final write");
+    await awaitPackLoaded("the pack set to converge on the second write");
+    await awaitHoverGeneration("second", "the hover to converge on the second write");
+
+    // Leave the suite's baseline in place for whatever runs next.
+    await writePack(GOOD_PACK, "the baseline pack, restored");
+    await awaitHoverGeneration("base", "the baseline hover to return");
+  });
+
+  // Manual tier. The body is a generated edit storm, which `AGENTS.md`
+  // ("Fuzzing is always manual") keeps out of the automatic tiers "regardless
+  // of how fast it happens to be today" — the deterministic two-write test
+  // above is the CI cover for the same window. Opt in the way the Rust corpus
+  // sweep does (`SPECTCL_CORPUS_TMP`), with an env var:
+  //
+  //     SPECTCL_EXT_EDIT_STORM=1 make test-ext
+  test("a twenty-write edit storm still converges on the last write", async function () {
+    if (!editStormOptedIn()) {
+      this.skip();
+    }
+    this.timeout(300_000);
+
+    const since = getServerLogSize();
+    let last = "";
+    for (let i = 0; i < 20; i++) {
+      // Alternate broken and well-formed so consecutive writes cannot coalesce
+      // into one content key, and stamp every well-formed one so the winner is
+      // identifiable rather than merely well-formed.
+      if (i % 2 === 0) {
+        fs.writeFileSync(
+          PACK,
+          `speclib ${PACK_NAME} 1.1 {\n  command ::torturepack::apply { arity ${i}\n`,
+          "utf8",
+        );
+      } else {
+        last = `storm-${i}`;
+        fs.writeFileSync(PACK, goodPack(last), "utf8");
+      }
+    }
+    // End on a well-formed generation whose stamp nothing else in the burst
+    // used, so convergence is checkable.
+    last = "storm-final";
+    fs.writeFileSync(PACK, goodPack(last), "utf8");
+
+    await waitForServerLog((line) => line.includes("SpecTcl:"), {
+      since,
+      timeout: 40_000,
+      label: "at least one reload from the edit storm",
+    });
+    await assertServerAlive("a twenty-write edit storm");
+
+    await awaitPackLoaded("the pack set to converge after the storm");
+    await awaitHoverGeneration(last, "the hover to converge on the storm's final write");
+
+    await writePack(GOOD_PACK, "the baseline pack, restored after the storm");
+    await awaitHoverGeneration("base", "the baseline hover to return after the storm");
   });
 
   test("deleting the pack retires its command, and re-creating it brings it back", async function () {

--- a/editors/vscode/src/test/specPackTorture.test.ts
+++ b/editors/vscode/src/test/specPackTorture.test.ts
@@ -1,0 +1,540 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// SpecTcl pack torture, through the extension host.
+//
+// `rust/tcl-spectcl/tests/pack_torture.rs` is the loader-altitude half of this:
+// it proves no `.tclspec`, however malformed, can panic or hang the parser. It
+// cannot prove the thing a user actually cares about, which is that none of it
+// takes *the editor* with it — the loader runs on a worker inside a live
+// server, its result is published into a per-profile registry every open
+// document is analysed against, and a `.tclspec` is itself a watched file that
+// reloads the whole set on every save.
+//
+// So this suite drives the pack through the surface it really lives on: a
+// scratch `.tclspec` inside the workspace, named by `tclLsp.specPacks`, edited
+// / broken / fixed / deleted / renamed while a document using its commands is
+// open. After every hostile write it asks the server three questions it must
+// still be able to answer, so a wedge is attributed to the write that caused it
+// rather than to whichever later test happened to time out first.
+//
+// The pack lives under `specPackTortureScratch/` — a plain directory, not
+// `.tcl-lsp/`, so nothing here is discovered by convention and the suite has
+// exclusive control over when the pack exists. That also keeps every other
+// suite's registry untouched: no test outside this file ever sees
+// `torturepack`.
+
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+
+import {
+  activate,
+  bounded,
+  getDocUri,
+  getServerLogSize,
+  pollUntil,
+  serverTransportWedged,
+  waitForEffectiveConfig,
+  waitForServerLog,
+} from "./helper";
+
+/** The scratch directory the suite owns; created in `suiteSetup`, removed in
+ *  `suiteTeardown`, and git-ignored so a crashed run leaves no tracked drift. */
+const SCRATCH = path.resolve(__dirname, "../../testFixture/specPackTortureScratch");
+/** The one pack file the churn tests rewrite. */
+const PACK = path.join(SCRATCH, "torture.tclspec");
+/** The pack name every assertion keys on — the bundled tier is in
+ *  `spec_packs_loaded` too, so "any pack at all" is true from the first
+ *  reload and useless as a barrier. */
+const PACK_NAME = "torturepack";
+/** A phrase that appears in the pack's hover and nowhere else in the repo. */
+const HOVER_MARKER = "TORTURE-PACK-HOVER-MARKER";
+
+const docUri = getDocUri("specPackTorture.tcl");
+/** A document no test drives — the liveness probe's own fixture. Answering a
+ *  hover here means the server's document pipeline is draining generally, not
+ *  merely that the consumer's queue happens to be alive. */
+const probeUri = getDocUri("livenessProbe.tcl");
+
+/** A well-formed pack: the state every hostile write is measured against. */
+const GOOD_PACK = `speclib ${PACK_NAME} 1.1 {
+
+command ::torturepack::apply {
+    dialects tcl8.6+
+    arity 2
+    required_package torturelib
+
+    arg 0 -role VarWrite
+    arg 1 -role Body
+
+    form Default {::torturepack::apply resultVar script}
+
+    hover {
+        summary {${HOVER_MARKER} — evaluate a script collecting into a caller variable.}
+        synopsis {::torturepack::apply resultVar script}
+    }
+}
+
+}
+`;
+
+/**
+ * The hostile battery, each entry a complete file body.
+ *
+ * Every one of these is something a real editor can put on disk: a save
+ * mid-keystroke, a Windows editor's BOM, a CRLF checkout, a bad paste, a
+ * find-and-replace that ate a brace. The contract is not that any of them
+ * loads — most cannot — but that the server survives each one and is still
+ * answering afterwards.
+ */
+const HOSTILE: ReadonlyArray<{ label: string; body: string }> = [
+  { label: "empty file", body: "" },
+  { label: "a single open brace", body: "{" },
+  { label: "a single close brace", body: "}" },
+  { label: "no speclib wrapper", body: "command ::torturepack::apply { arity 2 }\n" },
+  {
+    label: "truncated mid-statement",
+    body: `speclib ${PACK_NAME} 1.1 {\n  command ::torturepack::apply {\n    arity 2\n    arg 0 -role`,
+  },
+  {
+    label: "unbalanced speclib body",
+    body: `speclib ${PACK_NAME} 1.1 {\n  command ::torturepack::apply { arity 2 }\n`,
+  },
+  {
+    label: "unbalanced command body",
+    body: `speclib ${PACK_NAME} 1.1 {\n  command ::torturepack::apply { arity 2\n}\n`,
+  },
+  {
+    label: "a UTF-8 BOM before speclib",
+    body: `﻿speclib ${PACK_NAME} 1.1 {\n  command ::torturepack::apply { arity 2 }\n}\n`,
+  },
+  {
+    label: "CRLF line endings",
+    body: `speclib ${PACK_NAME} 1.1 {\r\n  command ::torturepack::apply { arity 2 }\r\n}\r\n`,
+  },
+  {
+    label: "NUL bytes inside the body",
+    body: `speclib ${PACK_NAME} 1.1 {\0  command ::torturepack::apply\0{ arity 2 }\n}\n`,
+  },
+  {
+    label: "an unknown vocabulary version",
+    body: `speclib ${PACK_NAME} 99.99 {\n  command ::torturepack::apply { arity 2 }\n}\n`,
+  },
+  {
+    label: "unknown words at every level",
+    body:
+      `speclib ${PACK_NAME} 1.1 {\n  no_such_pack_word {x}\n` +
+      `  command ::torturepack::apply {\n    arity 2\n    no_such_command_word 3\n` +
+      `    arg 0 -role NoSuchRole\n    hover { summary {${HOVER_MARKER}} no_such_hover_word {x} }\n  }\n}\n`,
+  },
+  {
+    label: "an invalid lifecycle ordering",
+    body:
+      `speclib ${PACK_NAME} 1.1 {\n  command ::torturepack::apply {\n    arity 2\n` +
+      `    required_package torturelib\n    introduced_version 9.0\n    retired_version 1.0\n  }\n}\n`,
+  },
+  {
+    label: "a command name a megabyte long",
+    body: `speclib ${PACK_NAME} 1.1 {\n  command ${"x".repeat(1_000_000)} { arity 1 }\n}\n`,
+  },
+  {
+    label: "braces nested five thousand deep",
+    body:
+      `speclib ${PACK_NAME} 1.1 {\n  command ::torturepack::apply {\n    arity 2\n` +
+      `    hover { summary {${"{".repeat(5_000)}x${"}".repeat(5_000)}} }\n  }\n}\n`,
+  },
+  {
+    label: "Tcl injection shapes inside a hover summary",
+    body:
+      `speclib ${PACK_NAME} 1.1 {\n  command ::torturepack::apply {\n    arity 2\n` +
+      `    hover { summary {[exec /bin/sh -c {touch ${path.join(SCRATCH, "pwned")}}] ` +
+      `\${env(HOME)} $::argv %s %n} }\n  }\n}\n`,
+  },
+];
+
+/** Write `body` to the pack file and wait for the server to finish the reload
+ *  it triggers.
+ *
+ *  The barrier is the server's own `SpecTcl: N pack(s), …` line, which
+ *  `reload_spec_packs` logs after publishing — a **positive** marker, so it
+ *  cannot be satisfied vacuously the way "poll until the command is gone"
+ *  could be by a reload that has not started yet. It is logged only when the
+ *  pack set's content key actually moved, which is why every entry in the
+ *  battery is a distinct byte sequence. */
+async function writePack(body: string, label: string): Promise<void> {
+  const since = getServerLogSize();
+  fs.writeFileSync(PACK, body, "utf8");
+  await waitForServerLog((line) => line.includes("SpecTcl:"), {
+    since,
+    timeout: 40_000,
+    label: `the pack reload triggered by writing ${label}`,
+  });
+}
+
+/** Remove the pack file and wait for the reload that follows. */
+async function removePack(label: string): Promise<void> {
+  const since = getServerLogSize();
+  fs.rmSync(PACK, { force: true });
+  await waitForServerLog((line) => line.includes("SpecTcl:"), {
+    since,
+    timeout: 40_000,
+    label: `the pack reload triggered by ${label}`,
+  });
+}
+
+/**
+ * The three questions a live server must still answer, asked after each
+ * hostile write.
+ *
+ * Deliberately the same three the harness's own liveness probe asks (helper.ts,
+ * issue #1294): a document-free config pull proves the transport is alive, a
+ * hover on an undriven document proves the document pipeline is draining, and a
+ * hover on the consumer proves *this* document's queue is not wedged. Asking
+ * them here, immediately, is what makes a wedge attributable to the pack that
+ * caused it — without this the first symptom would be some later test's
+ * timeout, which is exactly the unattributable shape #1600 recorded.
+ */
+async function assertServerAlive(label: string): Promise<void> {
+  assert.ok(
+    !serverTransportWedged(),
+    `the server transport was already confirmed wedged before checking ${label}`,
+  );
+  const cfg = await bounded(
+    vscode.commands.executeCommand("tcl-lsp.getEffectiveConfig", docUri.toString()),
+    `a document-free getEffectiveConfig after ${label}`,
+    { timeout: 20_000 },
+  );
+  assert.ok(cfg, `getEffectiveConfig returned nothing after ${label}`);
+  await bounded(
+    vscode.commands.executeCommand(
+      "vscode.executeHoverProvider",
+      probeUri,
+      new vscode.Position(0, 0),
+    ),
+    `a hover on an undriven document after ${label}`,
+    { timeout: 20_000 },
+  );
+  await bounded(
+    vscode.commands.executeCommand(
+      "vscode.executeHoverProvider",
+      docUri,
+      new vscode.Position(0, 0),
+    ),
+    `a hover on the pack's consumer after ${label}`,
+    { timeout: 20_000 },
+  );
+}
+
+/** The text of every hover at `position` in the consumer document. */
+async function hoverTextAt(position: vscode.Position): Promise<string> {
+  const hovers = (await vscode.commands.executeCommand(
+    "vscode.executeHoverProvider",
+    docUri,
+    position,
+  )) as vscode.Hover[] | undefined;
+  return (hovers ?? [])
+    .flatMap((hover) => hover.contents)
+    .map((content) => (typeof content === "string" ? content : content.value))
+    .join("\n");
+}
+
+/** Position of the `::torturepack::apply` command word in the fixture. */
+const COMMAND_POSITION = new vscode.Position(12, 2);
+
+/** Wait until the server reports `torturepack` loaded with at least one
+ *  command — the positive barrier for "the good pack is in effect". */
+async function awaitPackLoaded(label: string): Promise<void> {
+  await waitForEffectiveConfig(
+    docUri,
+    (cfg) => cfg.spec_packs_loaded.some((pack) => pack.name === PACK_NAME && pack.commands > 0),
+    { timeout: 40_000, label },
+  );
+}
+
+/** Wait until the pack's hover marker is visible — the barrier that proves the
+ *  reload reached the *analysis*, not merely the pack set. */
+async function awaitHoverMarker(label: string): Promise<void> {
+  await pollUntil(
+    () => hoverTextAt(COMMAND_POSITION),
+    (text) => text.includes(HOVER_MARKER),
+    {
+      timeout: 40_000,
+      label,
+    },
+  );
+}
+
+suite("SpecTcl pack torture through the extension host", () => {
+  let originalSetting: string[] | undefined;
+
+  // One barrier for the whole suite, in `suiteSetup` rather than per test.
+  //
+  // The pattern is #1622's: a per-test wait cannot serve here because the
+  // marker each wait keys on is emitted per *reload*, and the suite reuses one
+  // consumer document throughout — re-activating an already-open, unedited
+  // document starts no new analysis and so produces no new marker. Getting the
+  // extension activated, the document open and drained, and the good pack in
+  // effect once, up front, is what lets every test below start from a known
+  // state.
+  suiteSetup(async function () {
+    this.timeout(180_000);
+    fs.mkdirSync(SCRATCH, { recursive: true });
+    fs.writeFileSync(PACK, GOOD_PACK, "utf8");
+
+    const config = vscode.workspace.getConfiguration("tclLsp", docUri);
+    originalSetting = config.inspect<string[]>("specPacks")?.workspaceValue;
+    // A directory, not a file: discovery's `collect_path` scans it, so the
+    // add / delete / rename tests can move files around underneath a setting
+    // that never changes.
+    await config.update("specPacks", [SCRATCH], vscode.ConfigurationTarget.Workspace);
+
+    await activate(docUri);
+    await awaitPackLoaded("the torture pack to load at suite start");
+    await awaitHoverMarker("the torture pack's hover to reach the consumer");
+  });
+
+  suiteTeardown(async function () {
+    this.timeout(60_000);
+    const config = vscode.workspace.getConfiguration("tclLsp", docUri);
+    try {
+      await config.update("specPacks", originalSetting, vscode.ConfigurationTarget.Workspace);
+    } catch {
+      // Best effort — the fixture-settings snapshot in index.ts restores the
+      // committed bytes regardless.
+    }
+    fs.rmSync(SCRATCH, { recursive: true, force: true });
+  });
+
+  test("the whole hostile battery leaves the server answering", async function () {
+    // Each entry costs a full workspace pack reload plus three liveness
+    // questions, so the backstop is sized for the battery rather than for one
+    // write. Every wait inside is individually bounded and names itself.
+    this.timeout(HOSTILE.length * 60_000 + 120_000);
+
+    for (const { label, body } of HOSTILE) {
+      await writePack(body, label);
+      await assertServerAlive(label);
+    }
+
+    // Surviving is half the contract. The other half is that the server is
+    // still *useful*: put the good pack back and the command must resolve
+    // again, which a server that had quietly stopped reloading could not do.
+    await writePack(GOOD_PACK, "the good pack, restored after the battery");
+    await awaitPackLoaded("the pack to reload after the hostile battery");
+    await awaitHoverMarker("the pack's hover to return after the hostile battery");
+
+    assert.ok(
+      !fs.existsSync(path.join(SCRATCH, "pwned")),
+      "loading a pack executed the Tcl inside its `hover` summary",
+    );
+  });
+
+  test("a pack broken and then fixed loses and regains its command", async function () {
+    this.timeout(180_000);
+
+    await writePack(
+      `speclib ${PACK_NAME} 1.1 {\n  command ::torturepack::apply { arity 2\n`,
+      "a pack truncated mid-body",
+    );
+    // Absence, read off a converged state: `awaitPackLoaded` cannot be the
+    // barrier here (the pack is gone from the report), so the barrier is the
+    // reload marker `writePack` already waited on, and the assertion is that
+    // the *hover* — which is what the user sees — has lost the marker.
+    await pollUntil(
+      () => hoverTextAt(COMMAND_POSITION),
+      (text) => !text.includes(HOVER_MARKER),
+      { timeout: 40_000, label: "the pack's hover to disappear once the pack is broken" },
+    );
+    await assertServerAlive("a pack truncated mid-body");
+
+    await writePack(GOOD_PACK, "the repaired pack");
+    await awaitPackLoaded("the repaired pack to load");
+    await awaitHoverMarker("the repaired pack's hover to come back");
+  });
+
+  test("rapid successive edits settle on the last write, not an earlier one", async function () {
+    // The pack-reload analogue of the #1619 / #1622 index-removal window: a
+    // reload takes its sequence number before it reads the disk, so a slower
+    // earlier reload must never publish over a faster later one. Ten writes
+    // back to back, with no wait between them, is what makes the interleaving
+    // likely rather than theoretical.
+    this.timeout(240_000);
+
+    const since = getServerLogSize();
+    for (let i = 0; i < 10; i++) {
+      // Alternate broken and well-formed so consecutive writes cannot
+      // coalesce into one content key, and so the *final* state is one whose
+      // effect is observable.
+      fs.writeFileSync(
+        PACK,
+        i % 2 === 0
+          ? `speclib ${PACK_NAME} 1.1 {\n  command ::torturepack::apply { arity ${i}\n`
+          : `${GOOD_PACK}\n# generation ${i}\n`,
+        "utf8",
+      );
+    }
+    // Last write is i === 9, an odd index, so the good pack is the final state.
+    fs.writeFileSync(PACK, `${GOOD_PACK}\n# final generation\n`, "utf8");
+
+    await waitForServerLog((line) => line.includes("SpecTcl:"), {
+      since,
+      timeout: 40_000,
+      label: "at least one reload from the rapid-edit burst",
+    });
+    await assertServerAlive("a burst of ten rapid pack edits");
+
+    // The registry must converge on what is *on disk now*, not on whichever
+    // reload finished last. A stale publish would leave the truncated
+    // generation in effect and this would never hold.
+    await awaitPackLoaded("the pack set to converge on the final write");
+    await awaitHoverMarker("the hover to converge on the final write");
+  });
+
+  test("deleting the pack retires its command, and re-creating it brings it back", async function () {
+    this.timeout(180_000);
+
+    await removePack("deleting the pack file");
+    await pollUntil(
+      () => hoverTextAt(COMMAND_POSITION),
+      (text) => !text.includes(HOVER_MARKER),
+      { timeout: 40_000, label: "the pack's hover to retire once the file is deleted" },
+    );
+    await assertServerAlive("deleting the pack file");
+
+    await writePack(GOOD_PACK, "re-creating the pack file");
+    await awaitPackLoaded("the re-created pack to load");
+    await awaitHoverMarker("the re-created pack's hover");
+  });
+
+  test("renaming the pack file keeps the pack loaded under its new path", async function () {
+    this.timeout(180_000);
+
+    const renamed = path.join(SCRATCH, "renamed.tclspec");
+    const since = getServerLogSize();
+    fs.renameSync(PACK, renamed);
+    await waitForServerLog((line) => line.includes("SpecTcl:"), {
+      since,
+      timeout: 40_000,
+      label: "the reload triggered by renaming the pack file",
+    });
+    await assertServerAlive("renaming the pack file");
+
+    // The pack is a logical unit, not a file: its name comes from `speclib`,
+    // so a rename must be invisible to everything downstream.
+    await awaitPackLoaded("the renamed pack to still be loaded");
+    await awaitHoverMarker("the renamed pack's hover to survive the rename");
+    const cfg = await waitForEffectiveConfig(
+      docUri,
+      (c) => c.spec_packs_loaded.some((p) => p.name === PACK_NAME),
+      { timeout: 40_000, label: "the renamed pack in the effective config" },
+    );
+    const loaded = cfg.spec_packs_loaded.find((p) => p.name === PACK_NAME);
+    assert.ok(
+      loaded?.files.some((f) => f.endsWith("renamed.tclspec")),
+      `the pack must be reported at its new path, got ${JSON.stringify(loaded?.files)}`,
+    );
+
+    // Restore the suite's invariant for whatever runs next.
+    const back = getServerLogSize();
+    fs.renameSync(renamed, PACK);
+    await waitForServerLog((line) => line.includes("SpecTcl:"), {
+      since: back,
+      timeout: 40_000,
+      label: "the reload restoring the original pack path",
+    });
+    await awaitPackLoaded("the pack at its original path");
+  });
+
+  test("a pack with thousands of commands loads and the editor stays responsive", async function () {
+    this.timeout(300_000);
+
+    const commands = 2_000;
+    let body = `speclib ${PACK_NAME} 1.1 {\n`;
+    // The consumer's own command has to stay in the pack, or the restore at the
+    // end of this test is the only thing proving the reload happened.
+    body += GOOD_PACK.split("\n").slice(1, -2).join("\n");
+    for (let i = 0; i < commands; i++) {
+      body +=
+        `\ncommand ::torturepack::bulk${i} {\n` +
+        `    arity 2\n` +
+        `    arg 0 -role Value\n` +
+        `    option -opt${i} -detail {Option ${i}.}\n` +
+        `    subcommand sub${i} { arity 0 }\n` +
+        `    hover { summary {Bulk command ${i}.} }\n` +
+        `}\n`;
+    }
+    body += "\n}\n";
+
+    const started = Date.now();
+    await writePack(body, `a pack declaring ${commands} commands`);
+    const elapsed = Date.now() - started;
+
+    await assertServerAlive(`a pack declaring ${commands} commands`);
+    await waitForEffectiveConfig(
+      docUri,
+      (cfg) => cfg.spec_packs_loaded.some((p) => p.name === PACK_NAME && p.commands > commands),
+      { timeout: 60_000, label: `all ${commands} bulk commands to be reported loaded` },
+    );
+    // The pack's original command must still work — a bulk load that dropped
+    // it would still satisfy the count above.
+    await awaitHoverMarker("the hover to survive a bulk pack load");
+
+    console.log(`[specPackTorture] ${commands} commands loaded in ${elapsed}ms`);
+
+    await writePack(GOOD_PACK, "the small pack, restored after the bulk load");
+    await awaitPackLoaded("the small pack to load after the bulk one");
+  });
+
+  test("load notices from a broken pack reach the Problems panel and clear when fixed", async function () {
+    this.timeout(180_000);
+
+    // An unknown property is the cleanest notice to assert on: the design
+    // promises it is dropped *with a notice*, and unlike a truncation it leaves
+    // the rest of the pack loading, so the pack is still reported and the
+    // notice is unambiguously about the one bad row.
+    await writePack(
+      GOOD_PACK.replace("    arity 2\n", "    arity 2\n    definitely_not_a_spectcl_word 42\n"),
+      "a pack with one unknown property",
+    );
+
+    const packUri = vscode.Uri.file(PACK);
+    const diagnostics = await pollUntil(
+      () => vscode.languages.getDiagnostics(packUri),
+      (diags) => diags.length > 0,
+      { timeout: 40_000, label: "a load notice on the pack file" },
+    );
+    assert.ok(
+      diagnostics.some((d) => d.message.includes("definitely_not_a_spectcl_word")),
+      `the notice must name the offending word, got: ${JSON.stringify(
+        diagnostics.map((d) => d.message),
+      )}`,
+    );
+    // The rest of the pack still loaded — degradation is per-declaration.
+    await awaitPackLoaded("the pack to load despite the unknown property");
+    await awaitHoverMarker("the hover to survive an unknown property beside it");
+
+    await writePack(GOOD_PACK, "the pack with the unknown property removed");
+    await pollUntil(
+      () => vscode.languages.getDiagnostics(packUri),
+      (diags) => !diags.some((d) => d.message.includes("definitely_not_a_spectcl_word")),
+      { timeout: 40_000, label: "the load notice to clear once the pack is fixed" },
+    );
+  });
+});

--- a/editors/vscode/testFixture/specPackTorture.tcl
+++ b/editors/vscode/testFixture/specPackTorture.tcl
@@ -1,0 +1,17 @@
+# Consumer for the SpecTcl pack-torture suite
+# (src/test/specPackTorture.test.ts).
+#
+# `::torturepack::apply` is declared only by the scratch pack the suite writes
+# into `specPackTortureScratch/`, so what the server knows about this document
+# is entirely a function of whether that pack loaded. The name is namespaced on
+# purpose: the analyser skips the unknown-command check for any name containing
+# `::`, so W123 is not the signal here — hover, signature help and the argument
+# roles are.
+package require torturelib 1.0
+
+set input 3
+::torturepack::apply output {
+    set doubled [expr {$input * 2}]
+    lappend output $doubled
+}
+puts $output

--- a/rust/tcl-spectcl/tests/pack_torture.rs
+++ b/rust/tcl-spectcl/tests/pack_torture.rs
@@ -234,28 +234,84 @@ fn degenerate_byte_sequences_never_panic() {
     }
 }
 
-/// A truncated pack — cut at every byte offset of a valid one — never panics
-/// and never hangs.
+/// The well-formed pack the truncation tests below cut down.
+const TRUNCATION_SUBJECT: &str = "speclib demo 1.1 {\n\
+     \x20 display_name {Demo}\n\
+     \x20 file_extension dem -name {Demo files} -dialect tcl9.0\n\
+     \x20 values level { value fast -detail {Quick.} }\n\
+     \x20 command demo::run {\n\
+     \x20   dialects tcl8.6+\n\
+     \x20   arity 2\n\
+     \x20   introduced_version 1.2\n\
+     \x20   arg 0 -role VarWrite\n\
+     \x20   arg 1 -role Body\n\
+     \x20   option -verbose -detail {Chatter.}\n\
+     \x20   subcommand now { arity 0 }\n\
+     \x20   hover { summary {Runs the demo.} }\n\
+     \x20 }\n\
+     }\n";
+
+/// A pack truncated at each of the loader's distinct parse states loads
+/// without panicking or hanging.
 ///
 /// Truncation is the shape a real editor produces constantly: a file saved
-/// mid-keystroke, a partial write, a `git checkout` racing the watcher. Every
-/// prefix of a well-formed pack is therefore an input the loader will see.
+/// mid-keystroke, a partial write, a `git checkout` racing the watcher.
+///
+/// These six cuts are fixed and hand-picked, one per state the loader can be
+/// interrupted in — the exhaustive every-byte sweep is
+/// [`every_prefix_of_a_valid_pack_loads`], which is `#[ignore]`d into the
+/// manual tier because a permuted-input loop is fuzz-shaped
+/// (`AGENTS.md`, "Fuzzing is always manual"). Keeping the representative set
+/// here is what that policy asks for: "deterministic fixed-input tests
+/// covering the same code stay in CI".
+#[test]
+fn truncation_at_each_parse_state_loads() {
+    let cases = [
+        ("mid-keyword", "speclib demo 1.1 {\n  comm"),
+        ("just past the speclib header", "speclib demo 1.1 {\n"),
+        (
+            "inside an open command body",
+            "speclib demo 1.1 {\n  command demo::run {\n",
+        ),
+        (
+            "mid-lifecycle, a flag with no value",
+            "speclib demo 1.1 {\n  command demo::run {\n    arity 2\n    introduced_version",
+        ),
+        (
+            "mid-string, inside a braced summary",
+            "speclib demo 1.1 {\n  command demo::run {\n    hover { summary {Runs the",
+        ),
+        (
+            "the last byte, one newline short of complete",
+            &TRUNCATION_SUBJECT[..TRUNCATION_SUBJECT.len() - 1],
+        ),
+    ];
+
+    for (label, source) in cases {
+        let owned = source.to_owned();
+        let pack = within(label, Duration::from_secs(20), move || load_pack(&owned));
+        assert!(
+            pack.commands.iter().all(|c| !c.spec.name.is_empty()),
+            "`{label}` produced a nameless command"
+        );
+    }
+}
+
+/// The exhaustive companion to [`truncation_at_each_parse_state_loads`]: every
+/// byte offset of the same pack, not just the six representative ones.
+///
+/// Deliberately in the manual tier. The body is a permuted-input loop over
+/// generated inputs, which `AGENTS.md` ("Fuzzing is always manual") puts
+/// behind `#[ignore]` "regardless of how fast it happens to be today" — the
+/// six-case test above is the CI cover for the same code.
+#[ignore = "permuted-input sweep over every truncation offset; fuzz-shaped, so \
+            manual tier only — run explicitly with `cargo test -p tcl-spectcl \
+            --test pack_torture -- --ignored`, or via `make test-exhaustive`. \
+            The representative fixed cases run in CI as \
+            truncation_at_each_parse_state_loads"]
 #[test]
 fn every_prefix_of_a_valid_pack_loads() {
-    let full = "speclib demo 1.1 {\n\
-                \x20 display_name {Demo}\n\
-                \x20 file_extension dem -name {Demo files} -dialect tcl9.0\n\
-                \x20 values level { value fast -detail {Quick.} }\n\
-                \x20 command demo::run {\n\
-                \x20   dialects tcl8.6+\n\
-                \x20   arity 2\n\
-                \x20   arg 0 -role VarWrite\n\
-                \x20   arg 1 -role Body\n\
-                \x20   option -verbose -detail {Chatter.}\n\
-                \x20   subcommand now { arity 0 }\n\
-                \x20   hover { summary {Runs the demo.} }\n\
-                \x20 }\n\
-                }\n";
+    let full = TRUNCATION_SUBJECT;
 
     for cut in 0..=full.len() {
         if !full.is_char_boundary(cut) {
@@ -978,8 +1034,21 @@ fn one_broken_pack_does_not_cost_the_others() {
 /// pack would be a remote-code-execution vector on open.
 #[test]
 fn injection_shapes_in_spec_strings_stay_literal() {
-    let hostile_summary =
-        r"[exec /bin/sh -c {touch /tmp/tcl-lsp-pwned}] ${env(HOME)} $::argv \x41 %s %n";
+    // The sentinel lives in this test's own scratch directory, never at a
+    // fixed path: a shared `/tmp` name collides between concurrent runs and
+    // between checkouts, and — worse — a single genuine failure would leave
+    // the file behind and make every later run fail for a reason that has
+    // nothing to do with the code under test. Removed before the load so the
+    // assertion cannot inherit a stale file, and again afterwards so a failure
+    // here does not poison the next run.
+    let root = scratch("injection");
+    let sentinel = root.join("pwned");
+    let _ = std::fs::remove_file(&sentinel);
+
+    let hostile_summary = format!(
+        r"[exec /bin/sh -c {{touch {}}}] ${{env(HOME)}} $::argv \x41 %s %n",
+        sentinel.display()
+    );
     let source = format!(
         "speclib evil 1.1 {{\n\
         \x20 command evil::cmd {{\n\
@@ -995,10 +1064,10 @@ fn injection_shapes_in_spec_strings_stay_literal() {
         summary.contains("[exec") && summary.contains("${env(HOME)}"),
         "the injection shapes must survive verbatim as data, got: {summary:?}"
     );
-    assert!(
-        !Path::new("/tmp/tcl-lsp-pwned").exists(),
-        "loading a pack executed its `hover` body"
-    );
+    let executed = sentinel.exists();
+    let _ = std::fs::remove_file(&sentinel);
+    let _ = std::fs::remove_dir_all(&root);
+    assert!(!executed, "loading a pack executed its `hover` body");
 }
 
 /// Path traversal in a path-like field is carried as text and never resolved

--- a/rust/tcl-spectcl/tests/pack_torture.rs
+++ b/rust/tcl-spectcl/tests/pack_torture.rs
@@ -1,0 +1,1249 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Torture tests for `.tclspec` loading — the stability half of the pack
+//! pipeline, at the altitude where a defect is a panic rather than a squiggle.
+//!
+//! `docs/design/spec-packs.md` makes two promises this file is the negative
+//! proof of:
+//!
+//! * **"a spec must never be able to take the LSP down"** — no input, however
+//!   malformed, may panic, hang, or overflow the stack inside the loader.
+//!   `Backend::reload_spec_packs` catches a loader panic and keeps the
+//!   previous pack set, but a caught panic is still a workspace whose packs
+//!   silently stop updating, so the loader is held to never panicking at all.
+//! * **"unknown property words … are dropped with a logged notice; the rest of
+//!   the spec loads"** — degradation is per-declaration, so one bad row must
+//!   not cost the file, and one bad file must not cost the pack set.
+//!
+//! The battery below walks the grammar from the byte level (empty file, BOM,
+//! CRLF, NUL, non-UTF-8) up through statement structure (truncation, brace
+//! imbalance, absurd sizes) to semantics (lifecycle ordering, vocabulary
+//! versions, dialect names, duplicate declarations, extension ownership), and
+//! finishes on scale and on adversarial spec *content*.
+//!
+//! Everything here runs against the real loader with no stubs. The editor-side
+//! half — that none of this wedges the extension host — is
+//! `editors/vscode/src/test/specPackTorture.test.ts`.
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use tcl_compiler::analyser::Analyser;
+use tcl_spectcl::discovery::{DiscoveryOptions, Origin, PackFile, Tier};
+use tcl_spectcl::loader::load_pack;
+use tcl_spectcl::pack::{self, PackSet};
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+/// A private on-disk workspace for one test.
+fn scratch(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "tcl-spectcl-torture-{name}-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    dir
+}
+
+/// A `PackFile` naming `path` in the workspace tier, as discovery would.
+fn workspace_file(path: &Path) -> PackFile {
+    PackFile {
+        path: path.to_path_buf(),
+        tier: Tier::Workspace,
+        origin: Origin::DotDir,
+    }
+}
+
+/// Load the given files as one pack set, with both non-workspace tiers pinned
+/// away so a developer's own `~/.config/tcl-lsp/specs` cannot change an answer.
+fn load_files(paths: &[PathBuf]) -> PackSet {
+    let files: Vec<PackFile> = paths.iter().map(|p| workspace_file(p)).collect();
+    pack::load(&files)
+}
+
+/// Discover and load `root` as a workspace, with the user and bundled tiers
+/// pinned at directories that do not exist.
+fn load_workspace(root: &Path) -> PackSet {
+    let files = tcl_spectcl::discover(&DiscoveryOptions {
+        workspace_roots: vec![root.to_path_buf()],
+        user_dir: Some(root.join("no-user-tier")),
+        bundled_dir: Some(root.join("no-bundled-tier")),
+        ..DiscoveryOptions::default()
+    });
+    pack::load(&files)
+}
+
+/// Write `body` to `<root>/.tcl-lsp/<name>` and return the path.
+fn write_pack(root: &Path, name: &str, body: &str) -> PathBuf {
+    let dir = root.join(".tcl-lsp");
+    std::fs::create_dir_all(&dir).expect("pack dir");
+    let path = dir.join(name);
+    std::fs::write(&path, body).expect("write pack");
+    path
+}
+
+/// Every notice message in the set, joined — for `contains` assertions that do
+/// not care which notice carried the phrase.
+fn notice_text(set: &PackSet) -> String {
+    set.notices
+        .iter()
+        .map(|n| {
+            format!(
+                "{}:{} [{}] {}",
+                n.path.display(),
+                n.line,
+                n.context,
+                n.message
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Run `body` on a thread with a small-ish stack, asserting it finishes within
+/// `budget`.
+///
+/// Two hazards in one harness: a loader that recurses per brace level
+/// overflows a stack, and a loader that backtracks per byte hangs. A plain
+/// `#[test]` catches neither — an overflow aborts the whole process (so the
+/// failure is unattributable) and a hang stalls CI until the job timeout.
+/// Running on a spawned thread bounds the damage of the first and lets the
+/// second be reported as a test failure naming the input.
+fn within<T: Send + 'static>(
+    label: &str,
+    budget: Duration,
+    body: impl FnOnce() -> T + Send + 'static,
+) -> T {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let handle = std::thread::Builder::new()
+        // Deliberately modest: the default 8 MiB main stack hides a
+        // per-brace-level recursion that a worker thread — which is where
+        // `reload_spec_packs` actually parses — would hit first.
+        .stack_size(2 * 1024 * 1024)
+        .name(format!("torture-{label}"))
+        .spawn(move || {
+            let value = body();
+            // Send before the value is dropped, so a slow drop is timed too.
+            tx.send(()).ok();
+            value
+        })
+        .expect("spawn torture thread");
+    match rx.recv_timeout(budget) {
+        Ok(()) => handle.join().expect("torture body must not panic"),
+        Err(why) => {
+            panic!(
+                "`{label}` did not finish within {budget:?} ({why}) — the loader hung or crashed"
+            )
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Axis 1a — the byte level
+// ---------------------------------------------------------------------------
+
+/// Every degenerate byte sequence a file can hold loads to *something* and
+/// never panics.
+///
+/// The assertion is deliberately weak on content and absolute on liveness: for
+/// most of these there is no useful pack to recover, and pinning the exact
+/// notice text would make the test a change-detector. What must hold is that
+/// `load_pack` returns.
+#[test]
+fn degenerate_byte_sequences_never_panic() {
+    let cases: Vec<(&str, String)> = vec![
+        ("empty", String::new()),
+        ("only-whitespace", "   \n\t\n  ".to_owned()),
+        ("single-open-brace", "{".to_owned()),
+        ("single-close-brace", "}".to_owned()),
+        ("only-braces", "{}{}{}".to_owned()),
+        (
+            "bom-then-speclib",
+            "\u{feff}speclib demo 1.1 {\n}\n".to_owned(),
+        ),
+        (
+            "crlf",
+            "speclib demo 1.1 {\r\n  command a { arity 1 }\r\n}\r\n".to_owned(),
+        ),
+        (
+            "lone-cr",
+            "speclib demo 1.1 {\r  command a { arity 1 }\r}\r".to_owned(),
+        ),
+        (
+            "nul-bytes",
+            "speclib demo 1.1 {\0command a\0{ arity 1 }\n}".to_owned(),
+        ),
+        ("comment-only", "# nothing but a comment\n".to_owned()),
+        (
+            "unterminated-quote",
+            "speclib demo 1.1 {\n  command \"a { arity 1 }\n}".to_owned(),
+        ),
+        (
+            "unterminated-bracket",
+            "speclib demo 1.1 {\n  command [a { arity 1 }\n}".to_owned(),
+        ),
+        (
+            "backslash-eof",
+            "speclib demo 1.1 {\n  command a { arity 1 }\n}\\".to_owned(),
+        ),
+        (
+            "dollar-eof",
+            "speclib demo 1.1 {\n  command a { arity 1 }\n}$".to_owned(),
+        ),
+        (
+            "high-unicode",
+            "speclib \u{1f4a9}\u{202e}demo 1.1 {\n  command \u{0301}\u{0301} { arity 1 }\n}"
+                .to_owned(),
+        ),
+        (
+            "rtl-override-in-name",
+            "speclib demo 1.1 {\n  command a\u{202e}b { arity 1 }\n}".to_owned(),
+        ),
+    ];
+
+    for (label, source) in cases {
+        let owned = source.clone();
+        let pack = within(label, Duration::from_secs(20), move || load_pack(&owned));
+        // Nothing is asserted about *what* loaded — only that a `Pack` came
+        // back and its own invariants hold.
+        assert!(
+            pack.commands.iter().all(|c| !c.spec.name.is_empty()),
+            "`{label}` produced a command with an empty name"
+        );
+    }
+}
+
+/// A truncated pack — cut at every byte offset of a valid one — never panics
+/// and never hangs.
+///
+/// Truncation is the shape a real editor produces constantly: a file saved
+/// mid-keystroke, a partial write, a `git checkout` racing the watcher. Every
+/// prefix of a well-formed pack is therefore an input the loader will see.
+#[test]
+fn every_prefix_of_a_valid_pack_loads() {
+    let full = "speclib demo 1.1 {\n\
+                \x20 display_name {Demo}\n\
+                \x20 file_extension dem -name {Demo files} -dialect tcl9.0\n\
+                \x20 values level { value fast -detail {Quick.} }\n\
+                \x20 command demo::run {\n\
+                \x20   dialects tcl8.6+\n\
+                \x20   arity 2\n\
+                \x20   arg 0 -role VarWrite\n\
+                \x20   arg 1 -role Body\n\
+                \x20   option -verbose -detail {Chatter.}\n\
+                \x20   subcommand now { arity 0 }\n\
+                \x20   hover { summary {Runs the demo.} }\n\
+                \x20 }\n\
+                }\n";
+
+    for cut in 0..=full.len() {
+        if !full.is_char_boundary(cut) {
+            continue;
+        }
+        let prefix = full[..cut].to_owned();
+        let pack = within(
+            &format!("prefix-{cut}"),
+            Duration::from_secs(20),
+            move || load_pack(&prefix),
+        );
+        assert!(
+            pack.commands.iter().all(|c| !c.spec.name.is_empty()),
+            "prefix of {cut} bytes produced a nameless command"
+        );
+    }
+}
+
+/// Deeply nested braces do not overflow the stack.
+///
+/// The loader reaches every level of a pack through the same `statements()`
+/// door, and a braced word's contents are re-segmented by a recursive call. A
+/// pack nesting braces thousands deep is a two-line file to write and, if the
+/// recursion is unguarded, an unconditional process abort — the one failure
+/// mode `reload_spec_packs`'s `spawn_blocking` catch cannot convert to a
+/// notice, because a stack overflow is not an unwind.
+#[test]
+fn deep_brace_nesting_does_not_overflow_the_stack() {
+    for depth in [64usize, 512, 4_096, 50_000] {
+        let source = format!(
+            "speclib demo 1.1 {{\n  command a {{ arity 1 hover {{ summary {}{}{} }} }}\n}}\n",
+            "{".repeat(depth),
+            "x",
+            "}".repeat(depth),
+        );
+        let pack = within(
+            &format!("nest-{depth}"),
+            Duration::from_secs(30),
+            move || load_pack(&source),
+        );
+        assert!(
+            pack.commands.iter().all(|c| !c.spec.name.is_empty()),
+            "depth {depth} produced a nameless command"
+        );
+    }
+}
+
+/// An unbalanced brace at each structural level degrades to a notice, and the
+/// declarations that *are* balanced still load where the design says they can.
+#[test]
+fn unbalanced_braces_degrade_rather_than_crash() {
+    let cases = [
+        (
+            "speclib-body-unclosed",
+            "speclib demo 1.1 {\n  command a { arity 1 }\n",
+        ),
+        (
+            "command-body-unclosed",
+            "speclib demo 1.1 {\n  command a { arity 1\n}\n",
+        ),
+        (
+            "extra-close",
+            "speclib demo 1.1 {\n  command a { arity 1 }}\n}\n",
+        ),
+        (
+            "hover-unclosed",
+            "speclib demo 1.1 {\n  command a { arity 1 hover { summary {x} }\n}\n",
+        ),
+        (
+            "second-command-recovers",
+            "speclib demo 1.1 {\n  command a { arity 1\n  command b { arity 1 }\n}\n",
+        ),
+    ];
+    for (label, source) in cases {
+        let owned = source.to_owned();
+        let pack = within(label, Duration::from_secs(20), move || load_pack(&owned));
+        assert!(
+            pack.commands.iter().all(|c| !c.spec.name.is_empty()),
+            "`{label}` produced a nameless command"
+        );
+    }
+}
+
+/// Absurd sizes — a megabyte-long command name, ten thousand words in one
+/// statement, a very long single line — load in bounded time.
+#[test]
+fn absurd_sizes_load_in_bounded_time() {
+    let mega_name = "x".repeat(1_000_000);
+    let cases: Vec<(&str, String)> = vec![
+        (
+            "megabyte-command-name",
+            format!("speclib demo 1.1 {{\n  command {mega_name} {{ arity 1 }}\n}}\n"),
+        ),
+        (
+            "megabyte-summary",
+            format!(
+                "speclib demo 1.1 {{\n  command a {{ arity 1 hover {{ summary {{{}}} }} }}\n}}\n",
+                "y".repeat(1_000_000)
+            ),
+        ),
+        (
+            "ten-thousand-words",
+            format!(
+                "speclib demo 1.1 {{\n  command a {{ arity 1 {} }}\n}}\n",
+                "-flag ".repeat(10_000)
+            ),
+        ),
+        (
+            "one-very-long-line",
+            format!(
+                "speclib demo 1.1 {{ {} }}\n",
+                "command a { arity 1 } ".repeat(5_000)
+            ),
+        ),
+    ];
+
+    for (label, source) in cases {
+        let started = Instant::now();
+        let pack = within(label, Duration::from_mins(1), move || load_pack(&source));
+        assert!(
+            started.elapsed() < Duration::from_mins(1),
+            "`{label}` took {:?}",
+            started.elapsed()
+        );
+        assert!(
+            pack.commands.iter().all(|c| !c.spec.name.is_empty()),
+            "`{label}` produced a nameless command"
+        );
+    }
+}
+
+/// A file that is not valid UTF-8 is reported and does not stop its neighbours
+/// from loading.
+///
+/// `read_sources` turns an unreadable file into a whole-file notice, which is
+/// the contract; what this pins is the *containment* — the good pack beside it
+/// still reaches the set.
+#[test]
+fn a_non_utf8_pack_file_is_a_notice_and_its_neighbour_still_loads() {
+    let root = scratch("non-utf8");
+    let dir = root.join(".tcl-lsp");
+    std::fs::create_dir_all(&dir).expect("pack dir");
+
+    let bad = dir.join("broken.tclspec");
+    // A lone 0x80 continuation byte: valid Tcl shape, invalid UTF-8.
+    let mut bytes = b"speclib broken 1.1 {\n  command b { arity 1 }\n}\n".to_vec();
+    bytes[9] = 0x80;
+    std::fs::write(&bad, &bytes).expect("write invalid utf-8");
+
+    write_pack(
+        &root,
+        "good.tclspec",
+        "speclib good 1.1 {\n  command good::cmd { arity 1 }\n}\n",
+    );
+
+    let set = load_workspace(&root);
+    assert!(
+        set.packs.iter().any(|p| p.name == "good"),
+        "the readable pack must still load: {:?}",
+        set.packs.iter().map(|p| &p.name).collect::<Vec<_>>()
+    );
+    assert!(
+        notice_text(&set).contains("cannot read pack file"),
+        "the unreadable file must be reported: {}",
+        notice_text(&set)
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+// ---------------------------------------------------------------------------
+// Axis 1b — semantics
+// ---------------------------------------------------------------------------
+
+/// An invalid lifecycle ordering is a notice and drops that lifecycle, and the
+/// command carrying it still loads — the "notice-only for packs" rule from
+/// `docs/design/spec-packs.md`.
+///
+/// The well-ordered `demo::sane` beside it is the control: without it, a loader
+/// that dropped *every* lifecycle would pass the ordering assertion for the
+/// wrong reason.
+#[test]
+fn an_invalid_lifecycle_ordering_is_a_notice_and_the_command_survives() {
+    let pack = load_pack(
+        "speclib demo 1.1 {\n\
+        \x20 command demo::backwards {\n\
+        \x20   arity 1\n\
+        \x20   introduced_version 2.0\n\
+        \x20   retired_version 1.0\n\
+        \x20 }\n\
+        \x20 command demo::sane {\n\
+        \x20   arity 1\n\
+        \x20   introduced_version 1.0\n\
+        \x20   retired_version 2.0\n\
+        \x20 }\n\
+        }\n",
+    );
+
+    let sane = pack
+        .command("demo::sane")
+        .expect("a well-ordered neighbour must be unaffected");
+    assert_eq!(
+        (sane.spec.lifecycle.introduced, sane.spec.lifecycle.retired),
+        (Some("1.0"), Some("2.0")),
+        "the control's own lifecycle must survive — otherwise the assertion \
+         below passes for the wrong reason"
+    );
+
+    let backwards = pack
+        .command("demo::backwards")
+        .expect("an invalid ordering must not drop the command itself");
+    assert_eq!(
+        (
+            backwards.spec.lifecycle.introduced,
+            backwards.spec.lifecycle.retired
+        ),
+        (None, None),
+        "an invalid ordering must fall back to UNSPECIFIED"
+    );
+    assert!(
+        pack.notices
+            .iter()
+            .any(|n| n.message.contains("predates the introducing release")),
+        "the ordering failure must be reported: {:#?}",
+        pack.notices
+    );
+}
+
+/// The same rule one level down — an option's own lifecycle — and the
+/// *containment* rule beside it, which is reported but **kept**.
+#[test]
+fn lifecycle_ordering_and_containment_are_checked_at_every_level() {
+    let pack = load_pack(
+        "speclib demo 1.1 {\n\
+        \x20 command demo::cmd {\n\
+        \x20   arity 1\n\
+        \x20   introduced_version 2.0\n\
+        \x20   option -backwards -introduced 2.0 -retired 1.0\n\
+        \x20   subcommand early {\n\
+        \x20     arity 0\n\
+        \x20     introduced_version 1.0\n\
+        \x20   }\n\
+        \x20 }\n\
+        }\n",
+    );
+
+    let cmd = pack.command("demo::cmd").expect("the command must load");
+    assert_eq!(
+        cmd.spec.lifecycle.introduced,
+        Some("2.0"),
+        "the command's own well-ordered lifecycle is untouched"
+    );
+    assert!(
+        pack.notices
+            .iter()
+            .any(|n| n.message.contains("`-backwards`")
+                && n.message.contains("predates the introducing release")),
+        "an option's invalid ordering must be reported: {:#?}",
+        pack.notices
+    );
+    assert!(
+        pack.notices.iter().any(|n| n.message.contains("`early`")
+            && n.message.contains("reaches outside")
+            && n.message.contains("kept as declared")),
+        "a subcommand reaching outside its command's window is reported but \
+         kept, unlike an ordering failure: {:#?}",
+        pack.notices
+    );
+}
+
+/// A `speclib` version this build does not know still loads what it can, and
+/// says so once.
+#[test]
+fn an_unknown_vocabulary_version_loads_what_it_can() {
+    for declared in ["2", "99.99", "banana", "1.1.1", "-1"] {
+        let source = format!("speclib demo {declared} {{\n  command demo::cmd {{ arity 1 }}\n}}\n");
+        let pack = load_pack(&source);
+        assert!(
+            pack.command("demo::cmd").is_some(),
+            "vocabulary `{declared}` must not cost the commands: {:#?}",
+            pack.notices
+        );
+        assert!(
+            !pack.notices.is_empty(),
+            "vocabulary `{declared}` must be reported"
+        );
+    }
+}
+
+/// Unknown words at every level are dropped with a notice, and their siblings
+/// still load — the compatibility policy's central promise.
+#[test]
+fn unknown_words_at_every_level_are_dropped_with_a_notice() {
+    let pack = load_pack(
+        "speclib demo 1.1 {\n\
+        \x20 no_such_pack_level_word {whatever}\n\
+        \x20 command demo::cmd {\n\
+        \x20   arity 1\n\
+        \x20   no_such_command_word 3\n\
+        \x20   arg 0 -role NoSuchRole\n\
+        \x20   option -x -no-such-flag 1\n\
+        \x20   subcommand sub { arity 0 no_such_sub_word 1 }\n\
+        \x20   hover { summary {Kept.} no_such_hover_word {x} }\n\
+        \x20 }\n\
+        }\n",
+    );
+
+    let cmd = pack
+        .command("demo::cmd")
+        .expect("the command must survive every unknown word");
+    assert_eq!(
+        cmd.spec.arity.min, 1,
+        "a known sibling word must still apply"
+    );
+    assert!(
+        pack.notices.len() >= 5,
+        "every unknown word gets its own notice, got {:#?}",
+        pack.notices
+    );
+}
+
+/// A `-dialect` naming no profile keeps the extension row without routing, and
+/// a bogus `dialects` word does not take the command down.
+#[test]
+fn bogus_dialect_names_degrade_to_a_notice() {
+    let pack = load_pack(
+        "speclib demo 1.1 {\n\
+        \x20 file_extension dem -dialect no-such-dialect-at-all\n\
+        \x20 command demo::cmd { arity 1 dialects no-such-dialect-at-all }\n\
+        }\n",
+    );
+
+    assert_eq!(
+        pack.file_extensions.len(),
+        1,
+        "the row is kept without routing: {:?}",
+        pack.file_extensions
+    );
+    assert!(
+        pack.file_extensions[0].dialect.is_none(),
+        "a typo must not intern a fake profile name"
+    );
+    assert!(
+        pack.command("demo::cmd").is_some(),
+        "a bogus `dialects` word must not drop the command"
+    );
+    assert!(
+        notice_text_for(&pack).contains("no dialect profile"),
+        "the bad routing must be reported: {:#?}",
+        pack.notices
+    );
+}
+
+/// Loader notices for one pack, joined.
+fn notice_text_for(pack: &tcl_spectcl::Pack) -> String {
+    pack.notices
+        .iter()
+        .map(|n| format!("{}:{} {}", n.context, n.line, n.message))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// A command declared twice — in one file and across two files of the same
+/// pack — is a notice with the first definition winning, never a silent
+/// overwrite.
+#[test]
+fn duplicate_command_declarations_are_reported_and_the_first_wins() {
+    let root = scratch("dupes");
+
+    // Within one file.
+    let single = write_pack(
+        &root,
+        "single.tclspec",
+        "speclib dupes 1.1 {\n\
+        \x20 command dupes::twice { arity 1 hover { summary {First.} } }\n\
+        \x20 command dupes::twice { arity 9 hover { summary {Second.} } }\n\
+        }\n",
+    );
+    let set = load_files(&[single]);
+    let merged = set
+        .packs
+        .iter()
+        .find(|p| p.name == "dupes")
+        .expect("the pack");
+    let twice = merged.command("dupes::twice").expect("one survivor");
+    assert_eq!(
+        twice.spec.arity.min, 1,
+        "the first declaration wins, not the last"
+    );
+    assert_eq!(
+        merged
+            .commands
+            .iter()
+            .filter(|c| c.spec.name == "dupes::twice")
+            .count(),
+        1,
+        "the duplicate must not be installed twice"
+    );
+    assert!(
+        notice_text(&set).contains("already defined"),
+        "the in-file duplicate must be reported: {}",
+        notice_text(&set)
+    );
+
+    // Across two files of one pack.
+    let a = write_pack(
+        &root,
+        "a-first.tclspec",
+        "speclib dupes2 1.1 {\n  command dupes2::twice { arity 1 }\n}\n",
+    );
+    let b = write_pack(
+        &root,
+        "b-second.tclspec",
+        "speclib dupes2 1.1 {\n  command dupes2::twice { arity 9 }\n}\n",
+    );
+    let set = load_files(&[a, b]);
+    let merged = set
+        .packs
+        .iter()
+        .find(|p| p.name == "dupes2")
+        .expect("the merged pack");
+    assert_eq!(
+        merged
+            .commands
+            .iter()
+            .filter(|c| c.spec.name == "dupes2::twice")
+            .count(),
+        1,
+        "a cross-file duplicate must not be installed twice"
+    );
+    assert_eq!(
+        merged
+            .command("dupes2::twice")
+            .expect("survivor")
+            .spec
+            .arity
+            .min,
+        1,
+        "merge order is sorted path order, so `a-first` wins"
+    );
+    assert!(
+        notice_text(&set).contains("already defined"),
+        "the cross-file duplicate must be reported: {}",
+        notice_text(&set)
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Two *different* packs claiming the same command name: both load, and
+/// installation picks one deterministically rather than corrupting the
+/// registry.
+#[test]
+fn two_packs_claiming_one_command_install_deterministically() {
+    let root = scratch("cross-pack-claim");
+    let a = write_pack(
+        &root,
+        "alpha.tclspec",
+        "speclib alpha 1.1 {\n  command shared::cmd { arity 1 hover { summary {Alpha.} } }\n}\n",
+    );
+    let b = write_pack(
+        &root,
+        "beta.tclspec",
+        "speclib beta 1.1 {\n  command shared::cmd { arity 4 hover { summary {Beta.} } }\n}\n",
+    );
+    let set = load_files(&[a, b]);
+    assert_eq!(set.packs.len(), 2, "two distinct packs, both loaded");
+
+    let installed = tcl_spectcl::install::registry_for_dialect_with_packs("tcl9.1", &set);
+    let spec = installed
+        .get("shared::cmd")
+        .expect("the contested command must reach the registry exactly once");
+    assert!(
+        installed
+            .command_names()
+            .filter(|n| *n == "shared::cmd")
+            .count()
+            == 1,
+        "a contested name must not be enumerable twice — completion would show a duplicate"
+    );
+
+    // Same inputs, same winner: repeat the whole install and compare.
+    let again = tcl_spectcl::install::registry_for_dialect_with_packs("tcl9.1", &set);
+    assert_eq!(
+        spec.arity,
+        again.get("shared::cmd").expect("still there").arity,
+        "which pack wins a contested command must be deterministic"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Two packs claiming the same `file_extension`: the owner invariant says one
+/// owner per extension, so the set must resolve to exactly one.
+#[test]
+fn one_owner_per_file_extension_across_packs() {
+    let root = scratch("extension-owners");
+    let a = write_pack(
+        &root,
+        "alpha.tclspec",
+        "speclib alpha 1.1 {\n\
+        \x20 file_extension shr -name {Alpha's} -dialect tcl9.0\n\
+        \x20 command alpha::cmd { arity 1 }\n\
+        }\n",
+    );
+    let b = write_pack(
+        &root,
+        "beta.tclspec",
+        "speclib beta 1.1 {\n\
+        \x20 file_extension shr -name {Beta's} -dialect tcl8.6\n\
+        \x20 command beta::cmd { arity 1 }\n\
+        }\n",
+    );
+    let set = load_files(&[a, b]);
+
+    let owners: Vec<(String, &'static str)> = set.extension_dialects();
+    let shr: Vec<_> = owners.iter().filter(|(ext, _)| ext == "shr").collect();
+    assert!(
+        shr.len() <= 1,
+        "an extension routed to two dialects has no defined answer — the \
+         consumer picks by iteration order: {owners:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// A pack redefining a shipped builtin does not change it unless it says
+/// `-override`, and either way the outcome is reported.
+#[test]
+fn a_pack_redefining_a_builtin_reports_and_does_not_silently_win() {
+    let root = scratch("builtin-clash");
+    let path = write_pack(
+        &root,
+        "clash.tclspec",
+        "speclib clash 1.1 {\n\
+        \x20 command lsort { arity 1 hover { summary {Not the real lsort.} } }\n\
+        }\n",
+    );
+    let set = load_files(&[path]);
+
+    let plain = tcl_registry::registry_for_dialect("tcl9.1");
+    let with_packs = tcl_spectcl::install::registry_for_dialect_with_packs("tcl9.1", &set);
+    let shipped = plain.get("lsort").expect("`lsort` is shipped");
+    let after = with_packs.get("lsort").expect("`lsort` is still there");
+    assert_eq!(
+        shipped.arity, after.arity,
+        "a pack without `-override` must not change a shipped command"
+    );
+
+    let collisions = pack::collision_notices(&set, &with_packs);
+    assert!(
+        collisions.iter().any(|n| n.message.contains("lsort")),
+        "the collision must be reported: {collisions:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+// ---------------------------------------------------------------------------
+// Axis 2 — scale
+// ---------------------------------------------------------------------------
+
+/// A generated pack with thousands of commands loads, installs, and stays
+/// queryable in bounded time.
+///
+/// The budget is deliberately loose — this is a stability gate, not a
+/// benchmark, and it runs on whatever CI hardware is going. What it catches is
+/// a quadratic: `merge_group`'s duplicate detection, `install`'s insertion, and
+/// the registry's own name lookup all have to be sub-quadratic for a pack this
+/// size to be usable at all.
+#[test]
+fn a_pack_with_thousands_of_commands_loads_and_installs() {
+    const COMMANDS: usize = 4_000;
+
+    let mut source = String::from("speclib bulk 1.1 {\n");
+    for i in 0..COMMANDS {
+        let _ = write!(
+            source,
+            "  command bulk::cmd{i} {{\n\
+             \x20   arity 2\n\
+             \x20   arg 0 -role Value\n\
+             \x20   option -opt{i} -detail {{Option {i}.}}\n\
+             \x20   subcommand sub{i} {{ arity 0 }}\n\
+             \x20   hover {{ summary {{Command {i}.}} }}\n\
+             \x20 }}\n"
+        );
+    }
+    source.push_str("}\n");
+
+    let root = scratch("bulk");
+    let path = write_pack(&root, "bulk.tclspec", &source);
+
+    let started = Instant::now();
+    let set = within("bulk-load", Duration::from_mins(3), move || {
+        load_files(&[path])
+    });
+    let load_time = started.elapsed();
+
+    let merged = set
+        .packs
+        .iter()
+        .find(|p| p.name == "bulk")
+        .expect("the pack");
+    assert_eq!(merged.commands.len(), COMMANDS, "every command must load");
+    assert!(
+        set.notices.is_empty(),
+        "a well-formed bulk pack must produce no notices: {:#?}",
+        &set.notices[..set.notices.len().min(5)]
+    );
+
+    let started = Instant::now();
+    let installed = tcl_spectcl::install::registry_for_dialect_with_packs("tcl9.1", &set);
+    let install_time = started.elapsed();
+
+    for i in [0usize, COMMANDS / 2, COMMANDS - 1] {
+        assert!(
+            installed.get(&format!("bulk::cmd{i}")).is_some(),
+            "`bulk::cmd{i}` did not reach the registry"
+        );
+    }
+    let enumerated = installed
+        .command_names()
+        .filter(|n| n.starts_with("bulk::cmd"))
+        .count();
+    assert_eq!(
+        enumerated, COMMANDS,
+        "every bulk command must be enumerable, or completion silently loses them"
+    );
+
+    eprintln!("bulk: {COMMANDS} commands loaded in {load_time:?}, installed in {install_time:?}");
+    assert!(
+        load_time < Duration::from_mins(2),
+        "loading {COMMANDS} commands took {load_time:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Many packs at once — one file each — discover, merge, and install without a
+/// blowup in either time or notices.
+#[test]
+fn many_packs_at_once_load_together() {
+    const PACKS: usize = 200;
+
+    let root = scratch("many-packs");
+    for i in 0..PACKS {
+        write_pack(
+            &root,
+            &format!("pack{i:03}.tclspec"),
+            &format!("speclib many{i} 1.1 {{\n  command many{i}::cmd {{ arity 1 }}\n}}\n"),
+        );
+    }
+
+    let started = Instant::now();
+    let root_for_load = root.clone();
+    let set = within("many-packs", Duration::from_mins(3), move || {
+        load_workspace(&root_for_load)
+    });
+    let elapsed = started.elapsed();
+
+    assert_eq!(set.packs.len(), PACKS, "every pack must be discovered");
+    assert!(
+        set.notices.is_empty(),
+        "well-formed packs produce no notices: {:#?}",
+        &set.notices[..set.notices.len().min(5)]
+    );
+    eprintln!("{PACKS} packs loaded in {elapsed:?}");
+
+    let installed = tcl_spectcl::install::registry_for_dialect_with_packs("tcl9.1", &set);
+    for i in [0usize, PACKS / 2, PACKS - 1] {
+        assert!(
+            installed.get(&format!("many{i}::cmd")).is_some(),
+            "`many{i}::cmd` did not reach the registry"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// One malformed pack among many good ones costs only itself.
+///
+/// This is the containment property that matters most in a real workspace: a
+/// user editing one `.tclspec` must not lose the commands every *other* pack
+/// declares while their file is mid-keystroke.
+#[test]
+fn one_broken_pack_does_not_cost_the_others() {
+    let root = scratch("broken-neighbour");
+    for i in 0..20 {
+        write_pack(
+            &root,
+            &format!("good{i:02}.tclspec"),
+            &format!("speclib good{i} 1.1 {{\n  command good{i}::cmd {{ arity 1 }}\n}}\n"),
+        );
+    }
+    write_pack(&root, "broken.tclspec", "speclib broken 1.1 {\n  command ");
+    write_pack(&root, "empty.tclspec", "");
+    write_pack(&root, "brace.tclspec", "{");
+
+    let set = load_workspace(&root);
+    for i in 0..20 {
+        assert!(
+            set.packs.iter().any(|p| p.name == format!("good{i}")),
+            "`good{i}` was lost to a broken neighbour: {:?}",
+            set.packs.iter().map(|p| &p.name).collect::<Vec<_>>()
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+// ---------------------------------------------------------------------------
+// Axis 6 — adversarial content
+// ---------------------------------------------------------------------------
+
+/// Injection shapes inside spec *strings* are data, not code.
+///
+/// A `.tclspec` is Tcl, and its `hover` bodies are braced words — so
+/// `[exec …]`, `${…}` and friends inside one must reach the registry as the
+/// literal bytes the author wrote. If any of them were ever substituted, a
+/// pack would be a remote-code-execution vector on open.
+#[test]
+fn injection_shapes_in_spec_strings_stay_literal() {
+    let hostile_summary =
+        r"[exec /bin/sh -c {touch /tmp/tcl-lsp-pwned}] ${env(HOME)} $::argv \x41 %s %n";
+    let source = format!(
+        "speclib evil 1.1 {{\n\
+        \x20 command evil::cmd {{\n\
+        \x20   arity 1\n\
+        \x20   hover {{ summary {{{hostile_summary}}} }}\n\
+        \x20 }}\n\
+        }}\n"
+    );
+    let pack = load_pack(&source);
+    let cmd = pack.command("evil::cmd").expect("the command must load");
+    let summary = cmd.spec.hover.map(|h| h.summary).unwrap_or_default();
+    assert!(
+        summary.contains("[exec") && summary.contains("${env(HOME)}"),
+        "the injection shapes must survive verbatim as data, got: {summary:?}"
+    );
+    assert!(
+        !Path::new("/tmp/tcl-lsp-pwned").exists(),
+        "loading a pack executed its `hover` body"
+    );
+}
+
+/// Path traversal in a path-like field is carried as text and never resolved
+/// by the loader.
+#[test]
+fn path_traversal_in_a_path_field_is_not_resolved() {
+    let pack = load_pack(
+        "speclib evil 1.1 {\n\
+        \x20 command evil::cmd {\n\
+        \x20   arity 1\n\
+        \x20   hover { source {../../../../../../etc/passwd} }\n\
+        \x20 }\n\
+        }\n",
+    );
+    let cmd = pack.command("evil::cmd").expect("the command must load");
+    // Whatever the field carries, the loader must not have opened anything —
+    // proven by the load having succeeded with no read error and the text
+    // arriving unchanged.
+    let source_field = cmd.spec.hover.map(|h| h.source).unwrap_or_default();
+    assert!(
+        source_field.contains("etc/passwd"),
+        "the field is data; got {source_field:?}"
+    );
+}
+
+/// A pack whose *own* file name and pack name are adversarial still routes to
+/// notices keyed by the real path.
+#[test]
+fn adversarial_pack_names_do_not_confuse_notice_routing() {
+    let root = scratch("evil-names");
+    let path = write_pack(
+        &root,
+        "..evil.tclspec",
+        "speclib ../../../etc/passwd 1.1 {\n  command ok { arity 1 }\n}\n",
+    );
+    let set = load_files(std::slice::from_ref(&path));
+    for notice in &set.notices {
+        assert_eq!(
+            notice.path, path,
+            "every notice must be keyed by the file it came from"
+        );
+    }
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+// ---------------------------------------------------------------------------
+// Axis 4 — the version gate, at the loader/analyser altitude
+// ---------------------------------------------------------------------------
+
+/// Analyse `source` with `packs` overlaid, returning the version-gate codes and
+/// messages only.
+fn version_gate_diags(packs: &PackSet, dialect: &str, source: &str) -> Vec<(String, String)> {
+    // Building the overlay registry is what puts the pack's specs where
+    // `with_pack_overlay` can find them — the same order `reload_spec_packs`
+    // uses, and the reason a test that skipped it would see a plain registry
+    // and no gate at all.
+    let _registry = tcl_spectcl::install::registry_for_dialect_with_packs(dialect, packs);
+    Analyser::new()
+        .with_pack_overlay(packs.key)
+        .analyse(source, dialect)
+        .diagnostics
+        .iter()
+        .filter(|d| matches!(d.code.as_str(), "W135" | "W136" | "W139" | "W144"))
+        .map(|d| (d.code.to_string(), d.message.clone()))
+        .collect()
+}
+
+/// A pack's own lifecycle stamps drive W135 / W139 / W144 against the
+/// document's `package require`, and a document that pins a satisfying version
+/// stays silent.
+///
+/// This is the pack half of the version gate: the same three codes a shipped
+/// spec produces, sourced from a `.tclspec` the user wrote. The controls
+/// matter as much as the positives — a gate that fired unconditionally would
+/// satisfy every positive assertion here.
+#[test]
+fn pack_lifecycle_stamps_drive_the_version_gate() {
+    let root = scratch("version-gate");
+    let path = write_pack(
+        &root,
+        "gated.tclspec",
+        "speclib gated 1.1 {\n\
+        \x20 command gated::future {\n\
+        \x20   arity 1\n\
+        \x20   required_package gatedlib\n\
+        \x20   introduced_version 2.0\n\
+        \x20 }\n\
+        \x20 command gated::oldish {\n\
+        \x20   arity 1\n\
+        \x20   required_package gatedlib\n\
+        \x20   introduced_version 1.0\n\
+        \x20   deprecated_version 1.5\n\
+        \x20 }\n\
+        \x20 command gated::gone {\n\
+        \x20   arity 1\n\
+        \x20   required_package gatedlib\n\
+        \x20   introduced_version 1.0\n\
+        \x20   retired_version 1.5\n\
+        \x20 }\n\
+        \x20 command gated::always {\n\
+        \x20   arity 1\n\
+        \x20   required_package gatedlib\n\
+        \x20 }\n\
+        }\n",
+    );
+    let set = load_files(&[path]);
+    assert!(
+        set.notices.is_empty(),
+        "the gated pack must load cleanly: {:#?}",
+        set.notices
+    );
+
+    // Floor 1.0: `future` is not there yet, `gone` is already gone, `oldish`
+    // is not yet deprecated, `always` is ungated.
+    let at_1_0 = version_gate_diags(
+        &set,
+        "tcl9.0",
+        "package require gatedlib 1.0\n\
+         gated::future x\n\
+         gated::oldish x\n\
+         gated::gone x\n\
+         gated::always x\n",
+    );
+    assert!(
+        at_1_0
+            .iter()
+            .any(|(code, msg)| code == "W135" && msg.contains("gated::future")),
+        "a command introduced at 2.0 must be W135 against a 1.0 pin: {at_1_0:?}"
+    );
+    assert!(
+        !at_1_0.iter().any(|(_, msg)| msg.contains("gated::always")),
+        "an ungated command must never draw a version diagnostic: {at_1_0:?}"
+    );
+    assert!(
+        !at_1_0
+            .iter()
+            .any(|(code, msg)| code == "W144" && msg.contains("gated::oldish")),
+        "1.0 is before the 1.5 deprecation — no W144 yet: {at_1_0:?}"
+    );
+
+    // Floor 1.5: `oldish` is now deprecated and `gone` retired; `future` is
+    // still not there.
+    let at_1_5 = version_gate_diags(
+        &set,
+        "tcl9.0",
+        "package require gatedlib 1.5\n\
+         gated::future x\n\
+         gated::oldish x\n\
+         gated::gone x\n\
+         gated::always x\n",
+    );
+    assert!(
+        at_1_5
+            .iter()
+            .any(|(code, msg)| code == "W144" && msg.contains("gated::oldish")),
+        "a command deprecated at 1.5 must be W144 against a 1.5 pin: {at_1_5:?}"
+    );
+    assert!(
+        at_1_5
+            .iter()
+            .any(|(code, msg)| code == "W139" && msg.contains("gated::gone")),
+        "a command retired at 1.5 must be W139 against a 1.5 pin — the \
+         retiring release is exclusive: {at_1_5:?}"
+    );
+    assert!(
+        !at_1_5.iter().any(|(_, msg)| msg.contains("gated::always")),
+        "an ungated command stays silent at every floor: {at_1_5:?}"
+    );
+
+    // Floor 2.0: everything the pack still has is silent.
+    let at_2_0 = version_gate_diags(
+        &set,
+        "tcl9.0",
+        "package require gatedlib 2.0\n\
+         gated::future x\n\
+         gated::oldish x\n\
+         gated::always x\n",
+    );
+    assert!(
+        !at_2_0
+            .iter()
+            .any(|(code, msg)| code == "W135" && msg.contains("gated::future")),
+        "2.0 satisfies the 2.0 introduction — W135 must clear: {at_2_0:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Editing a pack's lifecycle stamp changes the verdict — the same reload the
+/// editor performs, at this altitude.
+///
+/// The pack set's content key is what the overlay registry is cached under, so
+/// this is also the regression guard for a stale-overlay bug: if the second
+/// load reused the first key, the second analysis would answer with the first
+/// pack's stamps.
+#[test]
+fn editing_a_lifecycle_stamp_changes_the_verdict_on_reload() {
+    let root = scratch("gate-reload");
+    let source = "package require churnlib 1.0\nchurn::cmd x\n";
+
+    let path = write_pack(
+        &root,
+        "churn.tclspec",
+        "speclib churn 1.1 {\n\
+        \x20 command churn::cmd {\n\
+        \x20   arity 1\n\
+        \x20   required_package churnlib\n\
+        \x20   introduced_version 2.0\n\
+        \x20 }\n\
+        }\n",
+    );
+    let before = load_files(std::slice::from_ref(&path));
+    let gated = version_gate_diags(&before, "tcl9.0", source);
+    assert!(
+        gated
+            .iter()
+            .any(|(code, msg)| code == "W135" && msg.contains("churn::cmd")),
+        "the 2.0 introduction must gate a 1.0 pin: {gated:?}"
+    );
+
+    // The author fixes the stamp.
+    std::fs::write(
+        &path,
+        "speclib churn 1.1 {\n\
+        \x20 command churn::cmd {\n\
+        \x20   arity 1\n\
+        \x20   required_package churnlib\n\
+        \x20   introduced_version 1.0\n\
+        \x20 }\n\
+        }\n",
+    )
+    .expect("rewrite pack");
+    let after = load_files(&[path]);
+    assert_ne!(
+        before.key, after.key,
+        "an edited pack must produce a different content key, or every \
+         consumer keyed on it serves the pre-edit answer"
+    );
+    let cleared = version_gate_diags(&after, "tcl9.0", source);
+    assert!(
+        !cleared
+            .iter()
+            .any(|(code, msg)| code == "W135" && msg.contains("churn::cmd")),
+        "the edited stamp must clear the gate: {cleared:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
## Summary

- Pre-release stability sweep of the SpecTcl pack pipeline (discovery → loader → registry install → analyser/hover/completion → version gate), landed as **31 new tests in two suites** and **4 issues** for what it found.
- `rust/tcl-spectcl/tests/pack_torture.rs` (24 tests: 23 in CI, 1 manual tier) — the loader altitude: no `.tclspec`, however malformed, may panic, hang, or overflow the stack, and degradation must stay per-declaration.
- `editors/vscode/src/test/specPackTorture.test.ts` (8 tests: 7 in CI, 1 manual tier) — the editor altitude: none of it may wedge the extension host, and live pack churn while a consumer document is open must converge.
- **No product code changed.** Every defect found is filed, not patched, so this PR stays a pure test addition and the fixes can be reviewed on their own merits.

The two altitudes are deliberate: a loader panic reproduces in a five-line Rust test and belongs nowhere near VS Code, while "the editor stopped updating after I saved my pack" can only be observed through the extension host.

## What the sweep found

Four issues, all confirmed at the altitude that owns them. `docs/design/spec-packs.md` promises that unknown or malformed declarations are "dropped **with a logged notice**; the rest of the spec loads" — the containment half holds everywhere; the *notice* half has holes.

| # | Severity | Finding |
|---|---|---|
| #1634 | release-critical | Three zero-notice drop paths: `command NAME` with no body (`loader.rs:2985`, a bare `?` that never logs — the classic brace-on-the-next-line mistake loses the command silently), a second `speclib` block in one file (`loader.rs:636`), and an orphaned-block notice that interpolates the entire block body as the "property name" into a Problems-panel message |
| #1635 | release-critical | A `.tclspec` saved with a UTF-8 BOM loads **nothing** and reports ``no `speclib` declaration`` — the loader parses pack files with `LexerConfig::default()`, so `script_skips_leading_bom` (#1218's machinery) is never opted into at the file entry |
| #1637 | release-critical | Pack-vs-pack collisions resolve in silence: two packs claiming one command, or one `file_extension`, drop the loser with no notice and pick the winner by pack-name sort order. `collision_notices` is handed the *shipped* registry, in which the collision does not exist |
| #1638 | paper cuts (batched) | Duplicate-command notice lands on line 1 and names its own file; whitespace-bearing command names load unreported and reach completion; a version-less `speclib` takes the whole body as the pack name — which is then sent to every editor via `spec_packs_loaded` |

**Stability verdict: the pipeline does not crash, hang, or corrupt.** Nothing in the sweep produced a panic, a stack overflow, a hang, a wedged editor, or a corrupted registry — including 50 000-deep brace nesting on a 2 MiB stack, every byte-prefix of a valid pack, megabyte identifiers, non-UTF-8 bytes, and Tcl injection shapes inside spec strings. What it did produce is **silent data loss**: several ways for an author's command to disappear with nothing in the Problems panel. That is the release risk here, and it is a notice problem rather than a safety one.

## Test tiering

Per `AGENTS.md` ("Fuzzing is always manual"), the two generator-driven bodies are `#[ignore]`d / env-gated into the manual tier, each with a deterministic fixed-input counterpart holding the same ground in CI:

| manual-tier test | how to run | CI counterpart |
|---|---|---|
| `every_prefix_of_a_valid_pack_loads` (every truncation offset) | `cargo test -p tcl-spectcl --test pack_torture -- --ignored` | `truncation_at_each_parse_state_loads` — six fixed cuts, one per loader parse state |
| `a twenty-write edit storm still converges on the last write` | `SPECTCL_EXT_EDIT_STORM=1 make test-ext` | `a second write immediately after a first wins` — the minimal stale-publish shape |

Both share their subject with the CI test (`TRUNCATION_SUBJECT`, `goodPack()`), so the tiers cannot drift apart.

## The suites

### `rust/tcl-spectcl/tests/pack_torture.rs`

Each hostile input runs on a bounded thread (`within`), so a hang is an attributable failure naming the input rather than a CI job timeout, and a stack overflow is bounded to one thread rather than aborting the process unattributably.

- **Bytes** — empty, lone `{`, lone `}`, BOM, CRLF, lone CR, NUL, unterminated quote/bracket, trailing backslash, RTL overrides in names; truncation at each parse state; brace nesting at 64 / 512 / 4 096 / 50 000 deep; megabyte command names and summaries; ten thousand words in one statement; a non-UTF-8 file beside a readable one.
- **Semantics** — invalid lifecycle orderings at command *and* option level (dropped and reported) against the containment rule beside them (reported but **kept**, the documented asymmetry); unknown vocabulary versions; unknown words at every level; bogus `-dialect` names; duplicate commands within a file and across a pack's files; two packs claiming one command; extension ownership; a pack redefining a shipped builtin.
- **Scale** — 4 000 commands in one pack (~0.75s load, ~13ms install), 200 packs at once (~85ms), one broken pack among twenty good ones.
- **Version gate** — a pack's own lifecycle stamps driving W135 / W139 / W144 against `package require`, at three floors, each with ungated controls; plus an edit-and-reload proving the pack's content key moves with the stamps so the overlay registry cannot serve a pre-edit verdict.
- **Adversarial content** — `[exec …]`, `${env(HOME)}`, `$::argv` and format specifiers inside a `hover` summary stay literal (a pack must never be an RCE vector on open), with the sentinel under the test's own scratch directory and cleaned on both paths; path traversal in a path-like field is carried as text; adversarial pack and file names do not misroute notices.

### `editors/vscode/src/test/specPackTorture.test.ts`

A scratch `.tclspec` named by `tclLsp.specPacks`, edited / broken / fixed / deleted / renamed while a document using its commands stays open.

- **The hostile battery** — sixteen file bodies a real editor can put on disk. After each write the server is asked the same three questions the harness's own liveness probe asks (#1294), so a wedge is attributed to the write that caused it rather than to whichever later test times out first — the unattributable shape #1600 item 2 records. The battery ends by restoring the good pack and proving the command resolves again.
- **Break then fix**, **delete then re-create**, **rename** — a pack is a logical unit, not a file, so a rename is asserted invisible downstream via the new path in `spec_packs_loaded`.
- **Two back-to-back writes** — the stale-publish window `PublishedPackSet::seq` exists for. Both writes are well-formed and carry a `gen=` stamp in the hover, so the assertion names the exact write that must win rather than accepting any good pack.
- **Scale** — 2 000 commands in one pack (~505ms), editor still answering, original command still working.
- **Load notices** — an unknown property reaches the Problems panel on the pack file, names the offending word, leaves the rest of the pack loading, and clears when fixed.

Every barrier is a **positive** marker — the server's own `SpecTcl: N pack(s), …` reload line, or the pack's hover stamp. Absence is only ever read off a state a positive barrier has already converged, per the `crossFileDiagnostics` discipline. The suite-wide `suiteSetup` barrier follows #1622.

The scratch pack lives under `specPackTortureScratch/` — a plain directory, **not** `.tcl-lsp/` — so nothing is discovered by convention and no other suite's registry ever sees `torturepack`. Git-ignored, removed in `suiteTeardown`.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

All builds inline-prefixed `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=2`; the extension host reused one release server via `TCL_LSP_SERVER_BIN`.

```
cargo fmt --all -- --check                                  # clean
cargo clippy -p tcl-spectcl --all-targets                   # clean, no allows added
cargo test -p tcl-spectcl                                   # whole crate green
cargo test -p tcl-spectcl --test pack_torture               # 23 passed, 1 ignored (3x)
cargo test -p tcl-spectcl --test pack_torture -- --ignored  # 1 passed
npx tsc -p editors/vscode                                   # clean
make lint                                                   # ESLint + Prettier clean
make test-ext                                               # see below
SPECTCL_EXT_EDIT_STORM=1 make test-ext                      # 8 passing (storm included)
```

**`make test-ext`, four consecutive full runs before the review round:**

| run | single-root | multi-root | the new tests |
|---|---|---|---|
| 1 | 907 passing | 14 passing | 7/7 |
| 2 | 907 passing | 14 passing | 7/7 |
| 3 | 906 passing, 1 failing | 14 passing | 7/7 |
| 4 | 906 passing, 1 failing | 14 passing | 7/7 |

**After the review round**, three consecutive runs scoped to the suite: **7 passing, 1 pending** each time, and **8 passing** with the storm opted in.

The two failures above are both the **pre-existing** `Configuration Settings → disabling optimiser.enabled suppresses O1xx diagnostics` flake already tracked as **#1600 item 1** — same `[O111,O120]` residue both times, 4/4 passing in isolation, and it runs *before* this PR's suite in glob order so it cannot be implicated. I posted the reproduction rate (2 in 4 under concurrent load) and a narrowed root cause on #1600: the test waits on the deep-diagnostics **log line** then reads `getDiagnostics`, but the marker and the publish arrive on different channels with nothing ordering them, so under load the read returns the previous publish.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? **No** — tests only, no product code touched.
- [x] If yes, I updated the owning design doc. **N/A**
- [x] If I added or changed a diagnostic or optimisation code, I updated its KCS page. **N/A** — W135/W139/W144 are exercised, not changed.
- [x] If I added a design doc, I linked it from `docs/design/README.md`. **N/A**

## Notes for review

- The four issues are filed rather than fixed on purpose. Every landed test asserts behaviour that **currently holds**, so the suite is green today and none of it pins a bug in place; each issue carries a standalone repro for the fix PR to adopt.
- `one_owner_per_file_extension_across_packs` asserts the invariant (at most one owner) rather than the missing notice — the notice is #1637's to add.

---
Generated with [Claude Code](https://claude.com/claude-code)