### PR TITLE
fix(spectcl): close the four silent-drop gaps in `.tclspec` loading

### DIFF
--- a/editors/vscode/src/test/specPackTorture.test.ts
+++ b/editors/vscode/src/test/specPackTorture.test.ts
@@ -630,4 +630,73 @@ suite("SpecTcl pack torture through the extension host", () => {
       { timeout: 40_000, label: "the load notice to clear once the pack is fixed" },
     );
   });
+
+  test("a pack saved with a UTF-8 BOM still loads its commands (#1635)", async function () {
+    // The user-visible half of #1635. A Windows editor defaulting to "UTF-8
+    // with BOM" used to cost the author their entire pack, with a Problems
+    // entry blaming a missing `speclib` that was plainly there on line 1.
+    //
+    // Asserting the *hover generation* rather than merely "a pack loaded" is
+    // what makes this specific: the BOM'd bytes must produce this exact
+    // generation, so a stale pre-BOM registry cannot satisfy it.
+    this.timeout(180_000);
+
+    await writePack(`﻿${goodPack("bom")}`, "a pack prefixed with a UTF-8 BOM");
+    await awaitPackLoaded("the BOM'd pack to load");
+    await awaitHoverGeneration("bom", "the BOM'd pack's hover to reach the consumer");
+    await assertServerAlive("a pack prefixed with a UTF-8 BOM");
+
+    const packUri = vscode.Uri.file(PACK);
+    assert.deepStrictEqual(
+      vscode.languages.getDiagnostics(packUri).map((d) => d.message),
+      [],
+      "a byte-order mark is not a defect, so the Problems panel must stay clean",
+    );
+
+    await writePack(GOOD_PACK, "the un-BOM'd pack, restored");
+    await awaitHoverGeneration("base", "the baseline hover to return");
+  });
+
+  test("a command whose brace is on the next line is named in the Problems panel (#1634)", async function () {
+    // #1634's headline, at the surface where it bit: the author's command
+    // silently vanished and nothing in the Problems panel mentioned its name,
+    // so there was no thread to pull.
+    this.timeout(180_000);
+
+    await writePack(
+      `speclib ${PACK_NAME} 1.1 {\n  command ::torturepack::apply\n  {\n    arity 2\n  }\n}\n`,
+      "a command with its opening brace on the next line",
+    );
+
+    const packUri = vscode.Uri.file(PACK);
+    const diagnostics = await pollUntil(
+      () => vscode.languages.getDiagnostics(packUri),
+      (diags) => diags.some((d) => d.message.includes("::torturepack::apply")),
+      { timeout: 40_000, label: "a Problems entry naming the dropped command" },
+    );
+
+    const naming = diagnostics.find((d) => d.message.includes("::torturepack::apply"));
+    assert.ok(naming, "the dropped command must be named");
+    assert.ok(
+      naming.message.includes("body block"),
+      `and the notice must say what is missing, got: ${naming.message}`,
+    );
+    assert.strictEqual(
+      naming.range.start.line,
+      1,
+      "the squiggle belongs on the `command` line the author wrote",
+    );
+    // One readable line — the orphaned block must not have its whole body
+    // quoted back into a message (the third defect in #1634).
+    for (const diagnostic of diagnostics) {
+      assert.ok(
+        !diagnostic.message.includes("\n"),
+        `a Problems message must stay one line, got: ${JSON.stringify(diagnostic.message)}`,
+      );
+    }
+
+    await assertServerAlive("a command with its brace on the next line");
+    await writePack(GOOD_PACK, "the repaired pack");
+    await awaitHoverGeneration("base", "the baseline hover to return");
+  });
 });

--- a/rust/tcl-spectcl/src/cache.rs
+++ b/rust/tcl-spectcl/src/cache.rs
@@ -71,7 +71,7 @@ use rustc_hash::FxHashMap;
 use xxhash_rust::xxh3::Xxh3;
 
 use crate::VOCABULARY_VERSION;
-use crate::loader::{Pack, Stmt, Word};
+use crate::loader::{FileBom, Pack, Stmt, Word};
 
 /// Set to `1` to bypass the on-disk cache entirely (still correct, just
 /// slower). For bisecting a suspected cache bug without deleting a user's
@@ -116,7 +116,12 @@ fn override_of<T>(read: impl Fn(&(PathBuf, bool)) -> T) -> Option<T> {
 
 /// The on-disk format version. Bumped when the byte layout below changes; an
 /// entry written by any other version is simply not read.
-const FORMAT: u8 = 1;
+///
+/// Bumped to 2 when the memo key gained its BOM-disposition byte (issue
+/// #1635): a version-1 entry's per-entry records are one byte shorter, so
+/// reading one as version 2 would misalign every field after the first. The
+/// cache is disposable by contract, so an unread entry costs one reparse.
+const FORMAT: u8 = 2;
 
 /// File magic, so a stray file in the directory is never mistaken for an entry.
 const MAGIC: &[u8; 7] = b"TCLSPKC";
@@ -239,16 +244,33 @@ pub fn clear() -> std::io::Result<()> {
 
 /// A memoised segmentation table.
 ///
-/// Keyed by `(base_line, byte length, xxh3 of the text)`. The length is in the
-/// key alongside the digest because a memo hit returns statements *without*
-/// re-comparing the text: two different sources colliding would be a silent
-/// wrong parse, so the key carries a second, independent discriminator.
+/// Keyed by `(base_line, BOM disposition, byte length, xxh3 of the text)`. The
+/// length is in the key alongside the digest because a memo hit returns
+/// statements *without* re-comparing the text: two different sources colliding
+/// would be a silent wrong parse, so the key carries a second, independent
+/// discriminator.
+///
+/// The BOM disposition is in the key because it changes the answer, not just
+/// the input: the same bytes segment differently as a file (a leading U+FEFF is
+/// a prologue) and as a nested block (it is data), so a key without it would
+/// describe two different results identically (issue #1635).
+///
+/// **Defensive rather than load-bearing today**, which is worth saying plainly
+/// so nobody trims it believing it is covered. A memo is installed per *file* —
+/// [`load_pack_cached`] wraps one `load_pack` call and seeds it from that
+/// file's own entry — so two files never share one. Within a single file the
+/// two dispositions cannot meet either: the file entry is keyed on the whole
+/// source, and every block's text is strictly inside it, so the two can never
+/// be equal. The key is still right, because one that omits something
+/// affecting the answer is a silent wrong parse waiting for the first caller
+/// that shares a memo more widely — but no test can reach it today, and none
+/// pretends to.
 #[derive(Debug, Default)]
 struct Memo {
-    entries: FxHashMap<(u32, u32, u64), Vec<Stmt>>,
+    entries: FxHashMap<MemoKey, Vec<Stmt>>,
     /// Insertion order, so a written entry replays in the order the loader
     /// asked for it — a rewrite of an unchanged pack is then byte-identical.
-    order: Vec<(u32, u32, u64)>,
+    order: Vec<MemoKey>,
     /// Whether anything was segmented for real during this load.
     parsed_something_new: bool,
 }
@@ -266,33 +288,37 @@ thread_local! {
     static MEMO: RefCell<Option<Memo>> = const { RefCell::new(None) };
 }
 
-fn memo_key(source: &str, base_line: u32) -> (u32, u32, u64) {
+/// `(base_line, BOM disposition, byte length, xxh3)` — see [`Memo`].
+type MemoKey = (u32, u8, u32, u64);
+
+fn memo_key(source: &str, base_line: u32, bom: FileBom) -> MemoKey {
     (
         base_line,
+        bom.key(),
         u32::try_from(source.len()).unwrap_or(u32::MAX),
         xxhash_rust::xxh3::xxh3_64(source.as_bytes()),
     )
 }
 
 /// Look up a segmentation. `None` whenever no memo is installed.
-pub(crate) fn memo_get(source: &str, base_line: u32) -> Option<Vec<Stmt>> {
+pub(crate) fn memo_get(source: &str, base_line: u32, bom: FileBom) -> Option<Vec<Stmt>> {
     MEMO.with(|cell| {
         let memo = cell.borrow();
         memo.as_ref()?
             .entries
-            .get(&memo_key(source, base_line))
+            .get(&memo_key(source, base_line, bom))
             .cloned()
     })
 }
 
 /// Record a segmentation. A no-op whenever no memo is installed.
-pub(crate) fn memo_put(source: &str, base_line: u32, stmts: &[Stmt]) {
+pub(crate) fn memo_put(source: &str, base_line: u32, bom: FileBom, stmts: &[Stmt]) {
     MEMO.with(|cell| {
         let mut guard = cell.borrow_mut();
         let Some(memo) = guard.as_mut() else {
             return;
         };
-        let key = memo_key(source, base_line);
+        let key = memo_key(source, base_line, bom);
         memo.parsed_something_new = true;
         if memo.entries.insert(key, stmts.to_vec()).is_none() {
             memo.order.push(key);
@@ -346,8 +372,9 @@ fn write_entry(path: &Path, key: u64, memo: &Memo) {
         let Some(stmts) = memo.entries.get(entry_key) else {
             continue;
         };
-        let (base_line, text_len, text_hash) = *entry_key;
+        let (base_line, bom, text_len, text_hash) = *entry_key;
         buf.extend_from_slice(&base_line.to_le_bytes());
+        buf.push(bom);
         buf.extend_from_slice(&text_len.to_le_bytes());
         buf.extend_from_slice(&text_hash.to_le_bytes());
         put_stmts(&mut buf, stmts);
@@ -461,14 +488,15 @@ fn read_entry(path: &Path, key: u64) -> Option<Memo> {
     if reader.u64()? != key {
         return None;
     }
-    let entries = reader.count(16)?;
+    let entries = reader.count(17)?;
     let mut memo = Memo::default();
     for _ in 0..entries {
         let base_line = reader.u32()?;
+        let bom = reader.u8()?;
         let text_len = reader.u32()?;
         let text_hash = reader.u64()?;
         let stmts = get_stmts(&mut reader)?;
-        let entry_key = (base_line, text_len, text_hash);
+        let entry_key = (base_line, bom, text_len, text_hash);
         if memo.entries.insert(entry_key, stmts).is_none() {
             memo.order.push(entry_key);
         }

--- a/rust/tcl-spectcl/src/loader.rs
+++ b/rust/tcl-spectcl/src/loader.rs
@@ -70,7 +70,7 @@ use tcl_compiler::parsing::syntax::build::build_document;
 use tcl_compiler::parsing::syntax::segment::segments_from_document;
 use tcl_core_types::DiagCode;
 use tcl_dialect::{DialectSet, TclVersion};
-use tcl_lexer::{LexerConfig, SourceMap, TokenType};
+use tcl_lexer::{LeadingBom, LexerConfig, SourceMap, TokenType};
 use tcl_registry::abbrev::PrefixMatching;
 use tcl_registry::arg_role::{AppendedArity, ArgRole};
 use tcl_registry::arity::Arity;
@@ -180,7 +180,26 @@ impl Log {
     }
 
     fn unknown_property(&mut self, stmt: &Stmt) {
-        let word = stmt.word_text(0);
+        // `word_text(0)` on a braced word is *every byte between the braces*,
+        // so interpolating it raw put whole multi-line bodies into a
+        // Problems-panel message (issue #1634). A diagnostic has to stay one
+        // readable line, and a block that reached here is an orphan — the
+        // useful thing to say is that it has no preceding declaration, not to
+        // quote it back.
+        let stmt_is_block = stmt.words.first().is_some_and(|w| w.braced);
+        if stmt_is_block {
+            self.say(
+                stmt.line,
+                "a `{ … }` block with no preceding declaration was dropped \
+                 (an opening brace must be on the same line as the word it \
+                 belongs to)",
+            );
+            return;
+        }
+        // `quotable` is the existing helper for exactly this — `unknown_flag`
+        // has always used it; `unknown_property` simply never did, which is
+        // the whole of the defect.
+        let word = quotable(stmt.word_text(0));
         self.say(stmt.line, format!("unknown property `{word}` dropped"));
     }
 
@@ -266,31 +285,82 @@ impl Stmt {
     }
 }
 
+/// What a U+FEFF at byte 0 of the buffer being segmented *is*.
+///
+/// A `.tclspec` is a file, and a byte-order mark at the head of a file is a
+/// prologue rather than the first character of the first command word — which
+/// is exactly the distinction `tcl_dialect::LexerGrammar::script_skips_leading_bom`
+/// draws for Tcl 9's `source` (issue #1218). Nested blocks are *not* files:
+/// a U+FEFF at the start of a `hover` summary is a character the author typed,
+/// so only [`pack_statements`] and [`speclib_version_span`] may ask to skip it.
+///
+/// It is a parameter rather than a constant inside [`segment`] because
+/// [`block`] re-enters the same function for every braced word, and flipping
+/// the flag there would silently edit pack *content*.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FileBom {
+    /// This buffer is a whole pack file: a leading mark is a prologue.
+    Skip,
+    /// This buffer is a nested block: a leading mark is data.
+    Content,
+}
+
+impl FileBom {
+    /// The lexer's own spelling of the same question.
+    fn leading(self) -> LeadingBom {
+        match self {
+            FileBom::Skip => LeadingBom::Skip,
+            FileBom::Content => LeadingBom::Content,
+        }
+    }
+
+    /// A discriminator for the memo key. Two segmentations of the same bytes
+    /// under different dispositions are different answers, so they cannot
+    /// share a cache slot.
+    pub(crate) fn key(self) -> u8 {
+        match self {
+            FileBom::Skip => 1,
+            FileBom::Content => 0,
+        }
+    }
+}
+
 /// Segment `source` into statements, numbering lines from `base_line`.
 ///
 /// Comments, `;` separators, and line continuations are handled by the lexer,
 /// so the loader inherits exactly the Tcl an author already knows — including
 /// the trap that `#` only starts a comment where a command word would start.
 ///
-/// Segmentation is a **pure function of `(source, base_line)`**, which is what
-/// lets [`crate::cache`] memoise it: every level of a pack — the file, the
+/// Segmentation is a **pure function of `(source, base_line, bom)`**, which is
+/// what lets [`crate::cache`] memoise it: every level of a pack — the file, the
 /// `speclib` body, each `command` body, each descriptor block — reaches the
 /// CST through this one door, so memoising here captures the whole tree
 /// without the loader's readers knowing a cache exists. The memo is a no-op
 /// unless a caller installed one.
-fn statements(source: &str, base_line: u32) -> Vec<Stmt> {
-    if let Some(hit) = crate::cache::memo_get(source, base_line) {
+///
+/// `bom` joins the memo key as well as the signature, because it changes the
+/// answer rather than merely the question. That is a correctness measure, not
+/// a fix for a reachable bug — see [`crate::cache`]'s `Memo` for why the two
+/// dispositions cannot currently meet in one memo.
+fn statements(source: &str, base_line: u32, bom: FileBom) -> Vec<Stmt> {
+    if let Some(hit) = crate::cache::memo_get(source, base_line, bom) {
         return hit;
     }
-    let parsed = segment(source, base_line);
-    crate::cache::memo_put(source, base_line, &parsed);
+    let parsed = segment(source, base_line, bom);
+    crate::cache::memo_put(source, base_line, bom, &parsed);
     parsed
 }
 
 /// The uncached segmentation — [`statements`] minus the memo.
-fn segment(source: &str, base_line: u32) -> Vec<Stmt> {
+fn segment(source: &str, base_line: u32, bom: FileBom) -> Vec<Stmt> {
     let source_map = SourceMap::new(source);
-    let (document, _warnings) = build_document(source, LexerConfig::default());
+    let (document, _warnings) = build_document(
+        source,
+        LexerConfig {
+            leading_bom: bom.leading(),
+            ..LexerConfig::default()
+        },
+    );
     let mut line_starts: Vec<usize> = vec![0];
     for (offset, byte) in source.bytes().enumerate() {
         if byte == b'\n' {
@@ -325,14 +395,24 @@ fn segment(source: &str, base_line: u32) -> Vec<Stmt> {
 }
 
 /// The statements inside a braced block word.
+///
+/// [`FileBom::Content`], always: a block is not a file, so a U+FEFF at the head
+/// of a `hover` summary is a character the author typed and must survive into
+/// the string the registry gets.
 fn block(word: &Word) -> Vec<Stmt> {
-    statements(&word.text, word.line)
+    statements(&word.text, word.line, FileBom::Content)
 }
 
 /// Segment a whole pack source — the loader's entry into [`statements`], and
 /// the one [`crate::cache`] keys its on-disk entry from.
+///
+/// The one place [`FileBom::Skip`] is right: this is the file entry point, so a
+/// leading byte-order mark is a prologue. A `.tclspec` saved by an editor that
+/// writes "UTF-8 with BOM" otherwise loses its entire `speclib` declaration —
+/// the first word decodes as `\u{feff}speclib`, which matches nothing
+/// (issue #1635).
 pub(crate) fn pack_statements(source: &str) -> Vec<Stmt> {
-    statements(source, 1)
+    statements(source, 1, FileBom::Skip)
 }
 
 /// Locate the top-level `speclib` statement's version word: the byte range
@@ -343,10 +423,22 @@ pub(crate) fn pack_statements(source: &str) -> Vec<Stmt> {
 /// exactly the way [`load_pack`] does — same lexer, same segmentation — so
 /// `speclib demo {1.0} { … }` and `speclib demo "1.0" { … }` decode to
 /// `1.0` here just as they do at load.
+///
+/// Same [`FileBom::Skip`] as [`pack_statements`], and for the same reason: this
+/// reads a whole file. If it disagreed with the loader about whether a leading
+/// mark is a prologue, `tcl spec upgrade` would compute its byte range against
+/// a different tokenisation than the one `load_pack` used, and rewrite the
+/// wrong span.
 #[must_use]
 pub fn speclib_version_span(source: &str) -> Option<(std::ops::Range<usize>, String)> {
     let source_map = SourceMap::new(source);
-    let (document, _warnings) = build_document(source, LexerConfig::default());
+    let (document, _warnings) = build_document(
+        source,
+        LexerConfig {
+            leading_bom: FileBom::Skip.leading(),
+            ..LexerConfig::default()
+        },
+    );
     for segment in segments_from_document(document, &source_map) {
         if segment.texts.first().map(String::as_str) != Some("speclib") {
             continue;
@@ -566,6 +658,20 @@ pub struct PackCommand {
     /// The `clause_grammar` the command declares, when it has one. Both hook
     /// behaviours are derived from it by [`ClauseGrammar::walk`].
     pub clause_grammar: Option<ClauseGrammar>,
+    /// The line the `command` statement was declared on.
+    ///
+    /// Carried so a collision notice can point at the declaration that lost
+    /// rather than at the file's first line (issues #1637, #1638). The loader
+    /// knows the line; the *file* is added later by the merge, which is the
+    /// only layer that knows which file a command came from.
+    pub line: u32,
+    /// The file this command was declared in.
+    ///
+    /// Empty as the loader builds it — [`crate::loader`] parses one source at a
+    /// time and is never told its path. [`crate::pack::load`] fills it in
+    /// during the merge, so every command in a [`crate::MergedPack`] carries
+    /// exact `(file, line)` attribution even when the pack spans many files.
+    pub file: std::path::PathBuf,
 }
 
 /// A loaded `.tclspec` pack.
@@ -640,6 +746,22 @@ pub fn load_pack(source: &str) -> Pack {
     };
     for stray in top.iter().filter(|s| s.word_text(0) != "speclib") {
         log.unknown_property(stray);
+    }
+    report_extra_speclib_blocks(&top, &mut log);
+    // `speclib NAME VERSION { … }`. A file that omits the version puts the body
+    // block in the name's slot, and before issue #1638 that whole multi-line
+    // blob became `pack.name` — which is the merge key, is interpolated into
+    // every notice, and is reported to every editor as the `name` field of
+    // `spec_packs_loaded`. Refuse it instead: a braced word cannot be a pack
+    // name.
+    if speclib.arg(1).is_some_and(|w| w.braced) {
+        log.say(
+            speclib.line,
+            "`speclib` needs a name and a vocabulary version before its body \
+             block (`speclib NAME 1.1 { … }`); nothing loaded",
+        );
+        pack.notices = log.notices;
+        return pack;
     }
     speclib.word_text(1).clone_into(&mut pack.name);
     speclib.word_text(2).clone_into(&mut pack.dsl_version);
@@ -721,6 +843,35 @@ pub fn load_pack(source: &str) -> Pack {
 
     pack.notices = log.notices;
     pack
+}
+
+/// Report every `speclib` block after the first — none of them is loaded.
+///
+/// Only the first pack in a file is read, and before issue #1634 the rest went
+/// in total silence: `load_pack`'s `find` takes the first, and the stray-word
+/// loop beside it filters every `speclib` back out, so
+/// `cat a.tclspec b.tclspec > merged.tclspec` lost half its commands with
+/// nothing said. One notice per extra block, carrying the count it would have
+/// declared, because that number is what tells the author whether they have a
+/// problem.
+fn report_extra_speclib_blocks(top: &[Stmt], log: &mut Log) {
+    for extra in top.iter().filter(|s| s.word_text(0) == "speclib").skip(1) {
+        let extra_name = extra.word_text(1);
+        let commands = extra.arg(3).map_or(0, |body| {
+            block(body)
+                .iter()
+                .filter(|s| s.word_text(0) == "command")
+                .count()
+        });
+        log.say(
+            extra.line,
+            format!(
+                "a second `speclib` block (`{extra_name}`) in one file is not loaded; \
+                 only the first pack in a file is read, so its {commands} command(s) \
+                 are dropped — move it to its own `.tclspec`"
+            ),
+        );
+    }
 }
 
 /// The `SpecTcl` **vocabulary** versions this loader reads, newest last.
@@ -2975,14 +3126,54 @@ struct CommandAcc {
     clause_grammar: Option<ClauseGrammar>,
 }
 
-fn load_command(stmt: &Stmt, tables: &PackTables, log: &mut Log) -> Option<PackCommand> {
+/// The declared command name, if it is one a call site could ever match.
+///
+/// Two ways it is not. Empty is the obvious one. The other is a name carrying
+/// whitespace: Tcl dispatches on a single command word, so `command {evil name}`
+/// declares something no document can invoke — and before issue #1638 it loaded
+/// silently, was interned for the life of the process, and appeared in
+/// completion as an entry the user could not use. `command { }`, a name that is
+/// *only* whitespace, takes that branch too, which is why the empty check alone
+/// was not enough.
+fn command_name<'s>(stmt: &'s Stmt, log: &mut Log) -> Option<&'s str> {
     let name = stmt.word_text(1);
     if name.is_empty() {
         log.say(stmt.line, "`command` with no name dropped");
         return None;
     }
+    if name.chars().any(char::is_whitespace) {
+        log.say(
+            stmt.line,
+            format!(
+                "`command {}` contains whitespace; a command word cannot, so \
+                 nothing could ever invoke it — dropped",
+                quotable(name)
+            ),
+        );
+        return None;
+    }
+    Some(name)
+}
+
+fn load_command(stmt: &Stmt, tables: &PackTables, log: &mut Log) -> Option<PackCommand> {
+    let name = command_name(stmt, log)?;
     let overrides_shipped = stmt.words.iter().any(|w| w.text == "-override");
-    let body = stmt.words.iter().skip(2).find(|w| w.braced)?;
+    // Naming the command matters more here than anywhere else in the loader:
+    // the shape that reaches this branch is almost always the brace-on-the-
+    // next-line mistake, where the author's `{ … }` became a separate
+    // statement. Before issue #1634 this was a bare `?` — the command vanished
+    // and nothing in the Problems panel mentioned it, so the only clue was the
+    // orphaned block's own notice, which does not name the command at all.
+    let Some(body) = stmt.words.iter().skip(2).find(|w| w.braced) else {
+        log.say(
+            stmt.line,
+            format!(
+                "`command {name}` has no `{{ … }}` body block; dropped \
+                 (an opening brace must be on the same line as the command name)"
+            ),
+        );
+        return None;
+    };
 
     log.scoped(format!("command {name}"), |log| {
         let mut spec = CommandSpec {
@@ -3069,6 +3260,8 @@ fn load_command(stmt: &Stmt, tables: &PackTables, log: &mut Log) -> Option<PackC
             overrides_shipped,
             hooks: acc.hooks,
             clause_grammar: acc.clause_grammar,
+            line: stmt.line,
+            file: std::path::PathBuf::new(),
         })
     })
 }

--- a/rust/tcl-spectcl/src/loader.rs
+++ b/rust/tcl-spectcl/src/loader.rs
@@ -708,6 +708,16 @@ pub struct FileExtension {
     pub dialect: Option<&'static str>,
     /// The declaring line, for notices and editors.
     pub line: u32,
+    /// The file this row was declared in.
+    ///
+    /// Exactly the arrangement [`PackCommand::file`] uses, and for the same
+    /// reason: empty as the loader builds it, filled in by
+    /// [`crate::pack::load`] during the merge. A logical pack can span several
+    /// files, so the row's own path is the only thing that attributes a
+    /// collision notice to the file the author must edit — attaching it to the
+    /// merged pack's *first* file publishes a squiggle against a line that
+    /// belongs to a different document (found reviewing #1637).
+    pub file: std::path::PathBuf,
 }
 
 impl Pack {
@@ -910,6 +920,8 @@ fn file_extension_row(stmt: &Stmt, log: &mut Log) -> Option<FileExtension> {
         display_name: None,
         dialect: None,
         line: stmt.line,
+        // Filled in by the merge, the only layer that knows the path.
+        file: std::path::PathBuf::new(),
     };
     let words = &stmt.words;
     let mut i = 2;
@@ -3126,37 +3138,24 @@ struct CommandAcc {
     clause_grammar: Option<ClauseGrammar>,
 }
 
-/// The declared command name, if it is one a call site could ever match.
-///
-/// Two ways it is not. Empty is the obvious one. The other is a name carrying
-/// whitespace: Tcl dispatches on a single command word, so `command {evil name}`
-/// declares something no document can invoke — and before issue #1638 it loaded
-/// silently, was interned for the life of the process, and appeared in
-/// completion as an entry the user could not use. `command { }`, a name that is
-/// *only* whitespace, takes that branch too, which is why the empty check alone
-/// was not enough.
-fn command_name<'s>(stmt: &'s Stmt, log: &mut Log) -> Option<&'s str> {
+fn load_command(stmt: &Stmt, tables: &PackTables, log: &mut Log) -> Option<PackCommand> {
+    // A name carrying whitespace is deliberately *not* rejected here. A Tcl
+    // command name is an arbitrary string key in the namespace's command table
+    // — `Tcl_CreateObjCommand` hashes it without inspecting a character — so
+    // `proc {evil name}` is a real command and a braced or quoted call site
+    // invokes it. Verified against tclsh 8.6 and 9.0: created, listed by
+    // `info commands`, and successfully invoked, for names carrying a space, a
+    // tab, and a newline, and for a name that is only a space. Our own pipeline
+    // agrees — a braced command word lowers to `WordExpr::BracedLiteral`, whose
+    // `legacy_text` is the brace-stripped content, so the call site resolves to
+    // the same key the spec declares. Issue #1638 dropped such names with a
+    // notice; that was wrong and the drop was removed after review. See
+    // `a_whitespace_bearing_command_name_loads_and_is_installable`.
     let name = stmt.word_text(1);
     if name.is_empty() {
         log.say(stmt.line, "`command` with no name dropped");
         return None;
     }
-    if name.chars().any(char::is_whitespace) {
-        log.say(
-            stmt.line,
-            format!(
-                "`command {}` contains whitespace; a command word cannot, so \
-                 nothing could ever invoke it — dropped",
-                quotable(name)
-            ),
-        );
-        return None;
-    }
-    Some(name)
-}
-
-fn load_command(stmt: &Stmt, tables: &PackTables, log: &mut Log) -> Option<PackCommand> {
-    let name = command_name(stmt, log)?;
     let overrides_shipped = stmt.words.iter().any(|w| w.text == "-override");
     // Naming the command matters more here than anywhere else in the loader:
     // the shape that reaches this branch is almost always the brace-on-the-

--- a/rust/tcl-spectcl/src/pack.rs
+++ b/rust/tcl-spectcl/src/pack.rs
@@ -359,7 +359,20 @@ fn cross_pack_command_notices(packs: &[MergedPack]) -> Vec<PackNotice> {
     }
 
     let mut out = Vec::new();
-    let mut claimed: BTreeMap<&'static str, Claim> = BTreeMap::new();
+    // Every claim that still stands for a name, not just the most recent one.
+    //
+    // One entry per name is not enough, because claims can be *mutually
+    // exclusive*: several stand at once, one per vendor that could be live.
+    // Three packs claiming `report_timing` — the first for Synopsys, the next
+    // two for Cadence — leave the Synopsys claim standing while the two
+    // Cadence claims genuinely collide with each other. A single-entry map
+    // compares the third claim only against the first, finds them
+    // vendor-disjoint, and reports nothing; the real collision goes unreported
+    // (found reviewing #1637). So each claim is checked against every standing
+    // claim and settles against the first it *could* collide with — which is
+    // the one `install_into` would have let win, since both walk packs in the
+    // same order.
+    let mut claimed: BTreeMap<&'static str, Vec<Claim>> = BTreeMap::new();
 
     for pack in packs {
         for command in &pack.commands {
@@ -370,17 +383,23 @@ fn cross_pack_command_notices(packs: &[MergedPack]) -> Vec<PackNotice> {
                 package: command.spec.required_package,
                 tier: pack.tier,
             };
-            let Some(prior) = claimed.get(command.spec.name) else {
-                claimed.insert(command.spec.name, claim);
+            let standing = claimed.entry(command.spec.name).or_default();
+            let Some(idx) = standing
+                .iter()
+                .position(|prior| could_collide(prior.package, command.spec.required_package))
+            else {
+                // Nothing standing is ever live in the same registry as this
+                // one, so it shadows nothing and nothing shadows it: it joins
+                // the standing set rather than replacing it.
+                standing.push(claim);
                 continue;
             };
-            let (prior_pack, prior_file, prior_line) = (&prior.pack, &prior.file, prior.line);
-            if !could_collide(prior.package, command.spec.required_package) {
-                // Different vendors: no profile admits both, so neither is
-                // shadowing the other. Leave the standing claim in place.
-                continue;
-            }
-            if prior.tier == Tier::Bundled && pack.tier == Tier::Bundled {
+            // Copied out before the standing set is mutated below.
+            let prior_pack = standing[idx].pack.clone();
+            let prior_file = standing[idx].file.clone();
+            let prior_line = standing[idx].line;
+            let prior_tier = standing[idx].tier;
+            if prior_tier == Tier::Bundled && pack.tier == Tier::Bundled {
                 // Shipped layering — see the note above.
                 continue;
             }
@@ -401,7 +420,10 @@ fn cross_pack_command_notices(packs: &[MergedPack]) -> Vec<PackNotice> {
                     ),
                     severity: Severity::Warning,
                 });
-                claimed.insert(command.spec.name, claim);
+                // Replaces the claim it displaced, in place — the other
+                // standing claims for this name are for other vendors and are
+                // untouched by an override aimed at this one.
+                standing[idx] = claim;
             } else {
                 out.push(PackNotice {
                     path: command.file.clone(),
@@ -462,10 +484,12 @@ fn cross_pack_extension_notices(packs: &[MergedPack]) -> Vec<PackNotice> {
             let Some(dialect) = row.dialect else {
                 continue;
             };
-            let file = pack.files.first().cloned().unwrap_or_default();
             match owner.get(&row.extension) {
                 Some((prior_pack, prior_dialect)) => out.push(PackNotice {
-                    path: file,
+                    // The row's *own* file, not the merged pack's first one:
+                    // a logical pack can span several files, and `row.line` is
+                    // a line in this one (issue #1637 review).
+                    path: row.file.clone(),
                     line: row.line,
                     context: format!("file_extension {}", row.extension),
                     message: format!(
@@ -528,7 +552,11 @@ fn merge_group(
         if merged.display_name.is_none() {
             merged.display_name.clone_from(&pack.display_name);
         }
-        for row in pack.file_extensions {
+        for mut row in pack.file_extensions {
+            // Same reason as the command loop below: the merge is the only
+            // layer that knows which file of a multi-file pack a row came from
+            // (found reviewing #1637).
+            row.file.clone_from(&file.path);
             if !merged
                 .file_extensions
                 .iter()

--- a/rust/tcl-spectcl/src/pack.rs
+++ b/rust/tcl-spectcl/src/pack.rs
@@ -289,6 +289,11 @@ pub(crate) fn load_sources(
         packs.push(merge_group(&name, winning_tier, winners, &mut notices));
     }
 
+    // Cross-pack collisions, once every pack is merged — the only point where
+    // all of them are known at once (issue #1637).
+    notices.extend(cross_pack_command_notices(&packs));
+    notices.extend(cross_pack_extension_notices(&packs));
+
     notices.sort_by(|a, b| {
         (&a.path, a.line, &a.context, &a.message).cmp(&(&b.path, b.line, &b.context, &b.message))
     });
@@ -305,6 +310,179 @@ pub(crate) fn load_sources(
     // source of truth for its own extensions.
     tcl_registry::dialects::register_pack_extension_dialects(set.extension_dialects());
     set
+}
+
+/// Report every command name two *different* packs both claim.
+///
+/// The in-pack duplicate is caught by [`merge_group`] and the shipped-command
+/// clash by [`collision_notices`]; between two packs there was nothing at all
+/// before issue #1637 — the loser was dropped by [`installs_over`] and the
+/// winner decided by pack-name sort order, in silence.
+///
+/// This walks the packs in exactly the order [`crate::install::install_into`]
+/// does and applies the same rule, so the notice can never disagree with what
+/// actually reached the registry: a later claim wins only if it says
+/// `-override`, and either way the losing declaration is named.
+///
+/// # The vendor gate applies here too
+///
+/// [`crate::install::install_into`] skips a command whose `required_package`
+/// names a closed-world vendor package the profile does not ship, which is
+/// what lets the bundled tier carry all six EDA libraries at once: four of
+/// them declare a `report_timing`, and they never meet because no profile
+/// admits two vendors. A collision check that ignored that gate would report
+/// every one of those as a clash — a dozen warnings on the *shipped* packs, in
+/// every user's Problems panel, for something that cannot happen.
+///
+/// So two claims collide only when some profile would install both, which
+/// [`could_collide`] asks exactly.
+///
+/// # Two shipped packs layering on purpose is not a collision either
+///
+/// `sdc_base` declares the SDC commands every EDA vendor implements, and each
+/// vendor pack then declares its own richer spec for the same name. On a
+/// Cadence profile both are admitted and `eda_cadence` wins on pack-name
+/// order — which is the intended layering, not an accident. Reporting it would
+/// put six warnings on the shipped packs that no user can act on.
+///
+/// So a collision between two **bundled** packs is left alone. Every other
+/// combination is reported, including a workspace pack shadowing a bundled
+/// one, which is exactly the case a user can do something about.
+fn cross_pack_command_notices(packs: &[MergedPack]) -> Vec<PackNotice> {
+    /// The claim currently holding a name.
+    struct Claim {
+        pack: String,
+        file: PathBuf,
+        line: u32,
+        package: Option<&'static str>,
+        tier: Tier,
+    }
+
+    let mut out = Vec::new();
+    let mut claimed: BTreeMap<&'static str, Claim> = BTreeMap::new();
+
+    for pack in packs {
+        for command in &pack.commands {
+            let claim = Claim {
+                pack: pack.name.clone(),
+                file: command.file.clone(),
+                line: command.line,
+                package: command.spec.required_package,
+                tier: pack.tier,
+            };
+            let Some(prior) = claimed.get(command.spec.name) else {
+                claimed.insert(command.spec.name, claim);
+                continue;
+            };
+            let (prior_pack, prior_file, prior_line) = (&prior.pack, &prior.file, prior.line);
+            if !could_collide(prior.package, command.spec.required_package) {
+                // Different vendors: no profile admits both, so neither is
+                // shadowing the other. Leave the standing claim in place.
+                continue;
+            }
+            if prior.tier == Tier::Bundled && pack.tier == Tier::Bundled {
+                // Shipped layering — see the note above.
+                continue;
+            }
+            if command.overrides_shipped {
+                // This one replaces the standing claim; the notice belongs on
+                // the declaration that just lost its place.
+                out.push(PackNotice {
+                    path: prior_file.clone(),
+                    line: prior_line,
+                    context: format!("command {}", command.spec.name),
+                    message: format!(
+                        "`{}` is also declared by pack `{}` ({}:{}) with `-override`, \
+                         which replaces this one",
+                        command.spec.name,
+                        pack.name,
+                        command.file.display(),
+                        command.line
+                    ),
+                    severity: Severity::Warning,
+                });
+                claimed.insert(command.spec.name, claim);
+            } else {
+                out.push(PackNotice {
+                    path: command.file.clone(),
+                    line: command.line,
+                    context: format!("command {}", command.spec.name),
+                    message: format!(
+                        "`{}` is already declared by pack `{prior_pack}` ({}:{prior_line}); \
+                         that declaration wins and this one is not installed \
+                         (declare it `-override` to replace it)",
+                        command.spec.name,
+                        prior_file.display()
+                    ),
+                    severity: Severity::Warning,
+                });
+            }
+        }
+    }
+    out
+}
+
+/// Whether two commands' `required_package`s can ever be live in one registry.
+///
+/// The exact question [`crate::install::install_into`]'s vendor gate answers,
+/// asked across every profile rather than for one: two declarations collide
+/// only if some profile would admit both. Two different closed-world EDA
+/// vendors never do, which is why the six shipped loadables can all declare a
+/// `report_timing` without shadowing each other.
+///
+/// Identical requirements short-circuit to `true` — the common case, and one
+/// no profile sweep could disagree with.
+fn could_collide(a: Option<&'static str>, b: Option<&'static str>) -> bool {
+    use tcl_registry::profile_queries::ProfileQueries as _;
+
+    if a == b {
+        return true;
+    }
+    tcl_dialect::DialectProfile::all()
+        .iter()
+        .any(|profile| profile.package_available(a) && profile.package_available(b))
+}
+
+/// Report every `file_extension` two different packs both claim.
+///
+/// One owner per extension is the invariant, and [`PackSet::extension_dialects`]
+/// enforces it by dropping all but the first — silently, before issue #1637.
+/// The loser matters more here than for a command: an extension routed to the
+/// wrong dialect mis-lexes every file of that type.
+///
+/// Only rows carrying a `-dialect` can collide in the sense that matters, since
+/// those are the ones `extension_dialects` publishes for routing.
+fn cross_pack_extension_notices(packs: &[MergedPack]) -> Vec<PackNotice> {
+    let mut out = Vec::new();
+    // extension -> (pack name, dialect) of the row that owns the routing.
+    let mut owner: BTreeMap<String, (String, &'static str)> = BTreeMap::new();
+
+    for pack in packs {
+        for row in &pack.file_extensions {
+            let Some(dialect) = row.dialect else {
+                continue;
+            };
+            let file = pack.files.first().cloned().unwrap_or_default();
+            match owner.get(&row.extension) {
+                Some((prior_pack, prior_dialect)) => out.push(PackNotice {
+                    path: file,
+                    line: row.line,
+                    context: format!("file_extension {}", row.extension),
+                    message: format!(
+                        "`.{}` is already claimed by pack `{prior_pack}` (routing to \
+                         `{prior_dialect}`); one extension has one owner, so this row's \
+                         `-dialect {dialect}` is not used",
+                        row.extension
+                    ),
+                    severity: Severity::Warning,
+                }),
+                None => {
+                    owner.insert(row.extension.clone(), (pack.name.clone(), dialect));
+                }
+            }
+        }
+    }
+    out
 }
 
 /// Merge one tier's files for one pack name, first-definition-wins.
@@ -325,7 +503,7 @@ fn merge_group(
     };
     // Where each command name was first defined, so the duplicate notice can
     // name the file that won rather than just saying "somewhere else".
-    let mut first_seen: BTreeMap<&'static str, PathBuf> = BTreeMap::new();
+    let mut first_seen: BTreeMap<&'static str, (PathBuf, u32)> = BTreeMap::new();
     let first_file = merged.files.first().cloned().unwrap_or_default();
 
     for (file, pack) in files {
@@ -359,23 +537,39 @@ fn merge_group(
                 merged.file_extensions.push(row);
             }
         }
-        for command in pack.commands {
-            if let Some(first) = first_seen.get(command.spec.name) {
+        for mut command in pack.commands {
+            // The merge is the only layer that knows which file a command came
+            // from, so this is where that gets recorded (issues #1637, #1638).
+            command.file.clone_from(&file.path);
+            if let Some((first_path, first_line)) = first_seen.get(command.spec.name) {
                 notices.push(PackNotice {
                     path: file.path.clone(),
-                    line: 1,
+                    // The *ignored* declaration's own line, not line 1. The
+                    // squiggle belongs on the duplicate the author can delete,
+                    // not on the `speclib` header (issue #1638).
+                    line: command.line,
                     context: format!("command {}", command.spec.name),
-                    message: format!(
-                        "`{}` is already defined in pack `{name}` by {}; \
-                         this definition is ignored",
-                        command.spec.name,
-                        first.display()
-                    ),
+                    message: if *first_path == file.path {
+                        // Same file: naming the path the reader already has
+                        // open tells them nothing — the line does.
+                        format!(
+                            "`{}` is already defined on line {first_line} of this file; \
+                             this definition is ignored",
+                            command.spec.name
+                        )
+                    } else {
+                        format!(
+                            "`{}` is already defined in pack `{name}` by {}:{first_line}; \
+                             this definition is ignored",
+                            command.spec.name,
+                            first_path.display()
+                        )
+                    },
                     severity: Severity::Warning,
                 });
                 continue;
             }
-            first_seen.insert(command.spec.name, file.path.clone());
+            first_seen.insert(command.spec.name, (file.path.clone(), command.line));
             merged.commands.push(command);
         }
     }

--- a/rust/tcl-spectcl/tests/pack_torture.rs
+++ b/rust/tcl-spectcl/tests/pack_torture.rs
@@ -1671,31 +1671,174 @@ fn a_second_speclib_block_is_reported_with_its_command_count() {
     );
 }
 
-/// A command name carrying whitespace can never be invoked, so it is dropped
-/// with a notice rather than reaching completion (#1638).
+/// A command name carrying whitespace is **valid Tcl** and must load.
+///
+/// #1638 originally dropped these, reasoning that a command word cannot carry
+/// whitespace. It can: a Tcl command name is an arbitrary string key in the
+/// namespace command table, and a braced or quoted call site invokes it.
+/// Confirmed against tclsh 8.6 and 9.0 — `proc {evil name} {} {…}` is created,
+/// listed by `info commands`, and invoked as `{evil name}`; the same holds for
+/// a tab, a newline, and for a name that is only a space. Our own pipeline
+/// resolves such a call site too, since a braced command word lowers to
+/// `WordExpr::BracedLiteral` whose text is the brace-stripped content. The
+/// drop removed valid specs; this pins the reversal.
 #[test]
-fn a_whitespace_bearing_command_name_is_dropped_with_a_notice() {
-    for source in [
-        "speclib demo 1.1 {\n command { } { arity 1 }\n}\n",
-        "speclib demo 1.1 {\n command {evil name} { arity 1 }\n}\n",
+fn a_whitespace_bearing_command_name_loads_and_is_installable() {
+    for (source, expected) in [
+        (
+            "speclib demo 1.1 {\n command {evil name} { arity 1 }\n}\n",
+            "evil name",
+        ),
+        ("speclib demo 1.1 {\n command { } { arity 1 }\n}\n", " "),
+        (
+            "speclib demo 1.1 {\n command {tab\tname} { arity 1 }\n}\n",
+            "tab\tname",
+        ),
     ] {
         let pack = load_pack(source);
         assert!(
-            pack.commands.is_empty(),
-            "an uninvocable name must not reach the registry: {:?}",
+            pack.commands.iter().any(|c| c.spec.name == expected),
+            "a whitespace-bearing name is valid Tcl and must load; wanted \
+             {expected:?}, got {:?}",
             pack.commands
                 .iter()
                 .map(|c| c.spec.name)
                 .collect::<Vec<_>>()
         );
         assert!(
-            pack.notices
+            !pack
+                .notices
                 .iter()
-                .any(|n| n.message.contains("contains whitespace")),
-            "and must be reported: {:#?}",
+                .any(|n| n.message.contains("whitespace")),
+            "and must not be warned about: {:#?}",
             pack.notices
         );
     }
+}
+
+/// Three packs claim one name; two of them are live in the same profile.
+///
+/// The collision that matters is between the *second* and the *third*, and a
+/// standing-claim map holding one entry per name cannot see it: the third
+/// claim is compared only against the first, found vendor-disjoint, and waved
+/// through. Found reviewing #1637 — the fix keeps every standing claim, so a
+/// new one settles against the first claim it could actually share a registry
+/// with.
+#[test]
+fn a_collision_behind_a_vendor_disjoint_claim_is_still_reported() {
+    let root = scratch("three-way-claim");
+    let a = write_pack(
+        &root,
+        "alpha.tclspec",
+        "speclib alpha 1.1 {\n\
+        \x20 command vendor::report_timing {\n\
+        \x20   arity 1\n\
+        \x20   required_package synopsys\n\
+        \x20 }\n\
+        }\n",
+    );
+    let b = write_pack(
+        &root,
+        "bravo.tclspec",
+        "speclib bravo 1.1 {\n\
+        \x20 command vendor::report_timing {\n\
+        \x20   arity 2\n\
+        \x20   required_package cadence-genus\n\
+        \x20 }\n\
+        }\n",
+    );
+    let c = write_pack(
+        &root,
+        "charlie.tclspec",
+        "speclib charlie 1.1 {\n\
+        \x20 command vendor::report_timing {\n\
+        \x20   arity 3\n\
+        \x20   required_package cadence-genus\n\
+        \x20 }\n\
+        }\n",
+    );
+    let set = load_files(&[a, b, c]);
+
+    let notice = set
+        .notices
+        .iter()
+        .find(|n| n.message.contains("is already declared by pack"))
+        .unwrap_or_else(|| {
+            panic!(
+                "two packs live in one profile collide even behind a \
+                 vendor-disjoint claim: {:#?}",
+                set.notices
+            )
+        });
+    assert!(
+        notice.path.ends_with("charlie.tclspec"),
+        "the notice belongs on the claim that lost, got {}",
+        notice.path.display()
+    );
+    assert!(
+        notice.message.contains("`bravo`"),
+        "and must name the claim it actually collided with — `bravo`, not the \
+         vendor-disjoint `alpha`: {}",
+        notice.message
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// A logical pack spanning two files: an extension collision is attributed to
+/// the file that declared the row, not to the pack's first file.
+///
+/// The same class already fixed for commands via `PackCommand::file`. With the
+/// row's line published against the wrong document the squiggle lands on
+/// whatever sits at that line of a file the author was not editing.
+#[test]
+fn an_extension_collision_names_the_file_that_declared_the_row() {
+    let root = scratch("extension-attribution");
+    let alpha = write_pack(
+        &root,
+        "alpha.tclspec",
+        "speclib alpha 1.1 {\n\
+        \x20 file_extension shr -name {Alpha's} -dialect tcl9.0\n\
+        }\n",
+    );
+    // One logical pack, two files. The extension row sits several lines into
+    // the second, so a notice published against the first file would point at
+    // a line that file does not even have.
+    let beta_one = write_pack(
+        &root,
+        "beta-one.tclspec",
+        "speclib beta 1.1 {\n\
+        \x20 command beta::cmd { arity 1 }\n\
+        }\n",
+    );
+    let beta_two = write_pack(
+        &root,
+        "beta-two.tclspec",
+        "speclib beta 1.1 {\n\
+        \x20 command beta::other { arity 1 }\n\
+        \x20 command beta::third { arity 1 }\n\
+        \x20 file_extension shr -name {Beta's} -dialect tcl8.6\n\
+        }\n",
+    );
+    let set = load_files(&[alpha, beta_one, beta_two]);
+
+    let notice = set
+        .notices
+        .iter()
+        .find(|n| n.message.contains("is already claimed by pack"))
+        .expect("the extension collision must still be reported");
+    assert!(
+        notice.path.ends_with("beta-two.tclspec"),
+        "the row was declared in beta-two.tclspec, so the notice belongs there, \
+         got {}",
+        notice.path.display()
+    );
+    assert_eq!(
+        notice.line, 4,
+        "on the `file_extension` row's own line in that file"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
 }
 
 /// `speclib` with no version word is refused rather than taking the body as

--- a/rust/tcl-spectcl/tests/pack_torture.rs
+++ b/rust/tcl-spectcl/tests/pack_torture.rs
@@ -1491,6 +1491,31 @@ fn a_bom_prefixed_pack_loads_like_any_other() {
     );
 }
 
+/// `speclib_version_span` must skip a leading BOM exactly as the loader does.
+///
+/// This is the hook `tcl spec upgrade` rewrites through, and it is a *separate*
+/// entry point with its own `LexerConfig` — the pack-loading test above does
+/// not exercise it. If the two disagreed about whether a leading mark is a
+/// prologue, the upgrade would compute a byte range against a different
+/// tokenisation than the one `load_pack` used and rewrite the wrong span.
+/// (Caught by mutation testing during the #1641 review: flipping this entry's
+/// disposition alone left every existing test green.)
+#[test]
+fn the_version_span_skips_a_leading_bom_like_the_loader() {
+    let source = "\u{feff}speclib demo 1.1 {\n  command demo::a { arity 1 }\n}\n";
+
+    let (range, version) =
+        tcl_spectcl::speclib_version_span(source).expect("a BOM must not hide the version word");
+
+    assert_eq!(version, "1.1");
+    assert_eq!(
+        &source[range.clone()],
+        "1.1",
+        "the span must be the version word's own bytes, so a rewrite lands on \
+         it and not on the BOM-shifted text beside it"
+    );
+}
+
 /// …but a BOM *inside* a block is ordinary data (#1635).
 ///
 /// The half of the fix that is easy to get wrong: flipping the disposition for
@@ -1638,6 +1663,49 @@ fn an_orphaned_block_notice_is_one_readable_line() {
         !orphan.message.contains("arity 1"),
         "the block's own body must not be quoted into the message, got {:?}",
         orphan.message
+    );
+}
+
+/// An unknown *property* that is long or spans lines is elided, not quoted
+/// whole (#1634).
+///
+/// The orphaned-block test above returns before the quoting code, so it does
+/// not pin it — flipping `unknown_property` back to a raw `word_text(0)` left
+/// that test green (found by mutation testing during the #1641 review). This
+/// is the case that catches it: a word that is neither empty nor short, on the
+/// non-block path where `quotable` is the only thing keeping the message to
+/// one bounded line.
+#[test]
+fn a_long_unknown_property_is_elided_rather_than_quoted_whole() {
+    let pack = load_pack(
+        "speclib demo 1.1 {\n\
+        \x20 command demo::a {\n\
+        \x20   arity 1\n\
+        \x20   \"a very long unknown property name that runs well past the limit\n\
+        \x20    and then keeps going onto a second physical line\"\n\
+        \x20 }\n\
+        }\n",
+    );
+
+    let notice = pack
+        .notices
+        .iter()
+        .find(|n| n.message.contains("unknown"))
+        .unwrap_or_else(|| panic!("the unknown property must be reported: {:#?}", pack.notices));
+    assert!(
+        !notice.message.contains('\n'),
+        "a diagnostic message must stay one physical line, got {:?}",
+        notice.message
+    );
+    assert!(
+        notice.message.contains('…'),
+        "and must show it was elided rather than silently truncated, got {:?}",
+        notice.message
+    );
+    assert!(
+        !notice.message.contains("second physical line"),
+        "the tail must not reach the message, got {:?}",
+        notice.message
     );
 }
 

--- a/rust/tcl-spectcl/tests/pack_torture.rs
+++ b/rust/tcl-spectcl/tests/pack_torture.rs
@@ -710,10 +710,23 @@ fn duplicate_command_declarations_are_reported_and_the_first_wins() {
         1,
         "the duplicate must not be installed twice"
     );
+    // The notice lands on the *ignored* declaration (line 3 here), not on the
+    // file's first line, and does not send the reader to the path they already
+    // have open (issue #1638).
+    let in_file = set
+        .notices
+        .iter()
+        .find(|n| n.message.contains("already defined"))
+        .expect("the in-file duplicate must be reported");
+    assert_eq!(
+        in_file.line, 3,
+        "the squiggle belongs on the duplicate the author can delete, got line {}",
+        in_file.line
+    );
     assert!(
-        notice_text(&set).contains("already defined"),
-        "the in-file duplicate must be reported: {}",
-        notice_text(&set)
+        in_file.message.contains("on line 2 of this file"),
+        "an in-file duplicate must name the winning line, not the path: {}",
+        in_file.message
     );
 
     // Across two files of one pack.
@@ -752,10 +765,15 @@ fn duplicate_command_declarations_are_reported_and_the_first_wins() {
         1,
         "merge order is sorted path order, so `a-first` wins"
     );
+    let cross_file = set
+        .notices
+        .iter()
+        .find(|n| n.message.contains("already defined in pack"))
+        .expect("the cross-file duplicate must be reported");
     assert!(
-        notice_text(&set).contains("already defined"),
-        "the cross-file duplicate must be reported: {}",
-        notice_text(&set)
+        cross_file.message.contains("a-first.tclspec:2"),
+        "a cross-file duplicate names the winning file *and* line: {}",
+        cross_file.message
     );
 
     let _ = std::fs::remove_dir_all(&root);
@@ -801,6 +819,115 @@ fn two_packs_claiming_one_command_install_deterministically() {
         "which pack wins a contested command must be deterministic"
     );
 
+    // Deterministic is not enough on its own — the losing author has to be
+    // told, on their own declaration, which is what issue #1637 was about.
+    let notice = set
+        .notices
+        .iter()
+        .find(|n| n.message.contains("is already declared by pack"))
+        .expect("a cross-pack command collision must be reported");
+    assert!(
+        notice.path.ends_with("beta.tclspec") && notice.line == 2,
+        "the notice belongs on the declaration that lost, got {}:{}",
+        notice.path.display(),
+        notice.line
+    );
+    assert!(
+        notice.message.contains("`alpha`") && notice.message.contains("-override"),
+        "and must name the winner and the way out: {}",
+        notice.message
+    );
+    assert_eq!(spec.arity.min, 1, "`alpha` is the winner the notice names");
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// The `-override` direction of the same collision: the later pack wins, and
+/// the notice moves to the declaration it displaced (#1637).
+///
+/// The notice must track the install, not a fixed idea of who wins — otherwise
+/// it would tell the author the opposite of what the registry did.
+#[test]
+fn a_cross_pack_override_reports_on_the_declaration_it_replaces() {
+    let root = scratch("cross-pack-override");
+    let a = write_pack(
+        &root,
+        "alpha.tclspec",
+        "speclib alpha 1.1 {\n  command shared::cmd { arity 1 }\n}\n",
+    );
+    let b = write_pack(
+        &root,
+        "beta.tclspec",
+        "speclib beta 1.1 {\n  command shared::cmd -override { arity 4 }\n}\n",
+    );
+    let set = load_files(&[a, b]);
+
+    let installed = tcl_spectcl::install::registry_for_dialect_with_packs("tcl9.1", &set);
+    assert_eq!(
+        installed.get("shared::cmd").expect("installed").arity.min,
+        4,
+        "`-override` makes the later pack win"
+    );
+
+    let notice = set
+        .notices
+        .iter()
+        .find(|n| n.message.contains("with `-override`"))
+        .expect("the replacement must be reported");
+    assert!(
+        notice.path.ends_with("alpha.tclspec"),
+        "the notice belongs on the declaration that was replaced, got {}",
+        notice.path.display()
+    );
+    assert!(
+        notice.message.contains("`beta`"),
+        "and must name who replaced it: {}",
+        notice.message
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Two packs declaring the same name for **different vendor packages** are not
+/// a collision, and must not be reported (#1637).
+///
+/// This is the false positive that matters: the six shipped EDA loadables all
+/// declare `report_timing`, and `install_into`'s vendor gate means no profile
+/// ever admits two of them. A collision check that ignored the gate would put
+/// a dozen warnings on the packs tcl-lsp itself ships.
+#[test]
+fn different_vendor_packages_declaring_one_name_is_not_a_collision() {
+    let root = scratch("vendor-gate");
+    let a = write_pack(
+        &root,
+        "vendor-a.tclspec",
+        "speclib vendora 1.1 {\n\
+        \x20 command vendor::report_timing {\n\
+        \x20   arity 1\n\
+        \x20   required_package cadence-genus\n\
+        \x20 }\n\
+        }\n",
+    );
+    let b = write_pack(
+        &root,
+        "vendor-b.tclspec",
+        "speclib vendorb 1.1 {\n\
+        \x20 command vendor::report_timing {\n\
+        \x20   arity 4\n\
+        \x20   required_package synopsys\n\
+        \x20 }\n\
+        }\n",
+    );
+    let set = load_files(&[a, b]);
+
+    assert!(
+        !set.notices
+            .iter()
+            .any(|n| n.message.contains("is already declared by pack")),
+        "two vendors that never share a profile do not collide: {:#?}",
+        set.notices
+    );
+
     let _ = std::fs::remove_dir_all(&root);
 }
 
@@ -829,10 +956,31 @@ fn one_owner_per_file_extension_across_packs() {
 
     let owners: Vec<(String, &'static str)> = set.extension_dialects();
     let shr: Vec<_> = owners.iter().filter(|(ext, _)| ext == "shr").collect();
+    assert_eq!(
+        shr.len(),
+        1,
+        "one extension has exactly one owner: {owners:?}"
+    );
+    assert_eq!(shr[0].1, "tcl9.0", "the first pack in name order owns it");
+
+    // And the pack that lost the extension is told, on the row it declared
+    // (issue #1637). This matters more than the command case: an extension
+    // routed to the wrong dialect mis-lexes every file of that type.
+    let notice = set
+        .notices
+        .iter()
+        .find(|n| n.message.contains("is already claimed by pack"))
+        .expect("the extension collision must be reported");
     assert!(
-        shr.len() <= 1,
-        "an extension routed to two dialects has no defined answer — the \
-         consumer picks by iteration order: {owners:?}"
+        notice.path.ends_with("beta.tclspec") && notice.line == 2,
+        "the notice belongs on the losing `file_extension` row, got {}:{}",
+        notice.path.display(),
+        notice.line
+    );
+    assert!(
+        notice.message.contains("`alpha`") && notice.message.contains("tcl9.0"),
+        "and must name the owner and the routing that won: {}",
+        notice.message
     );
 
     let _ = std::fs::remove_dir_all(&root);
@@ -1315,4 +1463,257 @@ fn editing_a_lifecycle_stamp_changes_the_verdict_on_reload() {
     );
 
     let _ = std::fs::remove_dir_all(&root);
+}
+
+// ---------------------------------------------------------------------------
+// Regressions for the notice gaps this sweep found (#1634, #1635, #1637, #1638)
+// ---------------------------------------------------------------------------
+
+/// A `.tclspec` saved with a UTF-8 BOM loads normally (#1635).
+///
+/// The mark is a file prologue, exactly as Tcl 9's `source` treats it — so the
+/// `speclib` word is `speclib`, not `\u{feff}speclib`, and the pack is not
+/// lost to an editor that defaults to "UTF-8 with BOM".
+#[test]
+fn a_bom_prefixed_pack_loads_like_any_other() {
+    let pack = load_pack("\u{feff}speclib demo 1.1 {\n  command demo::a { arity 1 }\n}\n");
+
+    assert_eq!(
+        pack.name, "demo",
+        "the BOM must not hide the `speclib` word"
+    );
+    assert_eq!(pack.dsl_version, "1.1");
+    assert!(pack.command("demo::a").is_some());
+    assert!(
+        pack.notices.is_empty(),
+        "a BOM is not a defect to report: {:#?}",
+        pack.notices
+    );
+}
+
+/// …but a BOM *inside* a block is ordinary data (#1635).
+///
+/// The half of the fix that is easy to get wrong: flipping the disposition for
+/// every segmentation, rather than only the file entry, would silently edit
+/// pack content — a `hover` summary an author deliberately began with U+FEFF
+/// would reach the registry a character short.
+#[test]
+fn a_bom_inside_a_block_is_content_not_a_prologue() {
+    let pack = load_pack(
+        "speclib demo 1.1 {\n\
+        \x20 command demo::a {\n\
+        \x20   arity 1\n\
+        \x20   hover { summary {\u{feff}leading mark} }\n\
+        \x20 }\n\
+        }\n",
+    );
+    let summary = pack
+        .command("demo::a")
+        .expect("the command must load")
+        .spec
+        .hover
+        .map(|h| h.summary)
+        .unwrap_or_default();
+    assert!(
+        summary.starts_with('\u{feff}'),
+        "a mark inside a block is the author's character, got {summary:?}"
+    );
+}
+
+/// A BOM'd pack survives the compiled-pack cache round trip (#1635).
+///
+/// The fix bumped the on-disk `FORMAT`, so a cold load, a warm load, and a load
+/// with the cache thrown away mid-flight must all produce the same pack — both
+/// for the file's leading mark and for a mark inside a block, which are read
+/// under opposite dispositions.
+///
+/// # What this does *not* claim
+///
+/// It does not pin the BOM disposition's presence in the memo key. That is
+/// deliberate: a memo is installed per file (`load_pack_cached` seeds one
+/// `load_pack` call from that file's own entry), and within a file the
+/// file-entry text and any block's text can never be equal, so the two
+/// dispositions cannot meet in one memo and no test can force them to. The key
+/// still carries the disposition because a key that omits something affecting
+/// the answer is wrong on its face — but an assertion here would pass whether
+/// or not it were there, and a test that cannot fail is worse than none.
+#[test]
+fn a_bom_prefixed_pack_survives_the_cache_round_trip() {
+    let root = scratch("bom-cache");
+    let cache = root.join("cache");
+    tcl_spectcl::cache::redirect_for_test(Some((cache.clone(), false)));
+
+    let path = write_pack(
+        &root,
+        "bom.tclspec",
+        "\u{feff}speclib bomdemo 1.1 {\n\
+        \x20 command bomdemo::a {\n\
+        \x20   arity 1\n\
+        \x20   hover { summary {\u{feff}kept} }\n\
+        \x20 }\n\
+        }\n",
+    );
+
+    let shape = |set: &PackSet| {
+        let pack = set
+            .packs
+            .iter()
+            .find(|p| p.name == "bomdemo")
+            .expect("the BOM'd pack must load");
+        let summary = pack
+            .command("bomdemo::a")
+            .expect("bomdemo::a")
+            .spec
+            .hover
+            .map(|h| h.summary)
+            .unwrap_or_default();
+        (pack.name.clone(), pack.commands.len(), summary.to_owned())
+    };
+
+    let cold = load_files(std::slice::from_ref(&path));
+    assert!(
+        std::fs::read_dir(&cache).is_ok(),
+        "a cold load populated the cache directory"
+    );
+    let warm = load_files(std::slice::from_ref(&path));
+    assert_eq!(shape(&cold), shape(&warm), "a warm load is the same load");
+
+    // And with the cache thrown away, still the same — the disposability
+    // contract, with a BOM in play.
+    let _ = std::fs::remove_dir_all(&cache);
+    assert_eq!(
+        shape(&cold),
+        shape(&load_files(std::slice::from_ref(&path)))
+    );
+
+    let (name, commands, summary) = shape(&cold);
+    assert_eq!(name, "bomdemo", "the file's leading mark is a prologue");
+    assert_eq!(commands, 1);
+    assert_eq!(summary, "\u{feff}kept", "the mark inside a block is data");
+
+    tcl_spectcl::cache::redirect_for_test(None);
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// A `command` with no body block is named in a notice (#1634).
+///
+/// The shape is the brace-on-the-next-line mistake, which is valid Tcl and so
+/// reaches the loader as two statements. Before the fix the command vanished
+/// with nothing naming it.
+#[test]
+fn a_command_with_no_body_is_named_in_a_notice() {
+    let pack = load_pack("speclib demo 1.1 {\n  command demo::bar\n  {\n    arity 1\n  }\n}\n");
+
+    assert!(pack.command("demo::bar").is_none(), "it cannot load");
+    let naming = pack
+        .notices
+        .iter()
+        .find(|n| n.message.contains("demo::bar"))
+        .expect("some notice must name the dropped command");
+    assert_eq!(naming.line, 2, "the notice belongs on the declaration");
+    assert!(
+        naming.message.contains("no `{ … }` body block"),
+        "and must say why: {}",
+        naming.message
+    );
+}
+
+/// The orphaned block left over by that mistake gets a readable one-line
+/// notice, not its own body quoted back (#1634).
+#[test]
+fn an_orphaned_block_notice_is_one_readable_line() {
+    let pack = load_pack("speclib demo 1.1 {\n  command demo::bar\n  {\n    arity 1\n  }\n}\n");
+
+    let orphan = pack
+        .notices
+        .iter()
+        .find(|n| n.message.contains("with no preceding declaration"))
+        .expect("the orphaned block must be reported");
+    assert!(
+        !orphan.message.contains('\n'),
+        "a diagnostic message must stay one line, got {:?}",
+        orphan.message
+    );
+    assert!(
+        !orphan.message.contains("arity 1"),
+        "the block's own body must not be quoted into the message, got {:?}",
+        orphan.message
+    );
+}
+
+/// A second `speclib` block in one file is reported, with what it costs (#1634).
+#[test]
+fn a_second_speclib_block_is_reported_with_its_command_count() {
+    let pack = load_pack(
+        "speclib one 1.1 {\n\
+        \x20 command one::a { arity 1 }\n\
+        }\n\
+        speclib two 1.1 {\n\
+        \x20 command two::b { arity 1 }\n\
+        \x20 command two::c { arity 1 }\n\
+        }\n",
+    );
+
+    assert_eq!(
+        pack.name, "one",
+        "the first pack is still the one that loads"
+    );
+    assert!(pack.command("one::a").is_some());
+    let notice = pack
+        .notices
+        .iter()
+        .find(|n| n.message.contains("second `speclib` block"))
+        .expect("the discarded block must be reported");
+    assert!(
+        notice.message.contains("`two`") && notice.message.contains("2 command(s)"),
+        "naming the block and its cost is the actionable part: {}",
+        notice.message
+    );
+}
+
+/// A command name carrying whitespace can never be invoked, so it is dropped
+/// with a notice rather than reaching completion (#1638).
+#[test]
+fn a_whitespace_bearing_command_name_is_dropped_with_a_notice() {
+    for source in [
+        "speclib demo 1.1 {\n command { } { arity 1 }\n}\n",
+        "speclib demo 1.1 {\n command {evil name} { arity 1 }\n}\n",
+    ] {
+        let pack = load_pack(source);
+        assert!(
+            pack.commands.is_empty(),
+            "an uninvocable name must not reach the registry: {:?}",
+            pack.commands
+                .iter()
+                .map(|c| c.spec.name)
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            pack.notices
+                .iter()
+                .any(|n| n.message.contains("contains whitespace")),
+            "and must be reported: {:#?}",
+            pack.notices
+        );
+    }
+}
+
+/// `speclib` with no version word is refused rather than taking the body as
+/// the pack name (#1638).
+///
+/// The name is the merge key and the `name` field every editor is handed in
+/// `spec_packs_loaded`, so a multi-line blob there is not a cosmetic problem.
+#[test]
+fn a_speclib_without_a_version_does_not_become_a_pack_name() {
+    let pack = load_pack("speclib {\n command x { arity 1 }\n}\n");
+
+    assert_eq!(pack.name, "", "a braced word is not a pack name");
+    assert!(pack.commands.is_empty());
+    assert!(
+        pack.notices
+            .iter()
+            .any(|n| n.message.contains("needs a name and a vocabulary version")),
+        "and the author is told the shape: {:#?}",
+        pack.notices
+    );
 }


### PR DESCRIPTION
Fixes #1634
Fixes #1635
Fixes #1637
Fixes #1638

## Summary

- Every finding of the SPEC-STAB pre-release sweep (#1640, merged), fixed.
- The loader's **containment** contract already held — nothing crashes, hangs, or overflows. What failed was the other half of `docs/design/spec-packs.md`'s promise, that a dropped declaration is dropped **"with a logged notice"**. Four ways an author's command could vanish with nothing in the Problems panel.
- Two false positives had to be designed out along the way; without them this change would have put ~18 warnings on the packs tcl-lsp itself ships. Both are pinned by tests.
- Every notice is **mutation-verified**: reverting each fix individually fails its own test.
- **Codex review (3 × P2) addressed in e295847cc** — all three were real. One of them found a *wrong fix* of mine, not a missing one; details below.

## The fixes

### #1635 — a BOM'd pack loaded nothing

`segment` parsed pack files with `LexerConfig::default()`, so `script_skips_leading_bom` (#1218's machinery) was never opted into. `\u{feff}speclib` matched nothing: the whole pack was lost, and the notice blamed a missing `speclib` that was sitting on line 1.

Segmentation now takes a `FileBom` — `Skip` from `pack_statements` and `speclib_version_span` (the two whole-file entry points), `Content` everywhere else, so a mark at the head of a `hover` summary is still the author's character. `speclib_version_span` has to agree with the loader or `tcl spec upgrade` would rewrite a byte range computed against a different tokenisation.

**On the memo key.** The disposition joins it and the on-disk `FORMAT` bumps to 2. It is **defensive, not load-bearing**, and the code says so at its definition: a memo is installed per *file*, and a file's own text can never equal one of its blocks' (a block is strictly inside it), so the two dispositions cannot currently meet. The key is still right — one that omits something affecting the answer is a silent wrong parse waiting for the first caller that shares a memo more widely — but no test can reach it, and none pretends to. I originally wrote a test claiming to pin it; it passed under mutation, so I replaced it with a cache-round-trip test that actually bites and documented the reachability argument instead.

### #1634 — three zero-notice drop paths

| path | before | after |
|---|---|---|
| `command NAME` with no body | bare `?`, never logged | names the command *and* the cause — the shape that hits it is the brace-on-the-next-line mistake |
| a second `speclib` block in one file | `find` took the first, the stray loop filtered every `speclib` back out | one notice naming the block and the command count it cost |
| orphaned-block notice | `word_text(0)` raw — every byte between the braces, so whole multi-line bodies landed in a Problems message | uses `quotable`, the helper `unknown_flag` has always used; an orphaned block gets its own one-line explanation |

The third was the smallest fix and the clearest bug: `unknown_flag` had been calling `quotable` all along, and `unknown_property` simply never did.

### #1637 — pack-vs-pack collisions were silent

In-pack duplicates and shipped-command clashes were reported; between two packs nothing was, because `collision_notices` is handed the **shipped** registry, in which the collision does not exist.

`cross_pack_command_notices` walks packs in `install_into`'s own order and applies `installs_over`'s own rule, so the notice can never disagree with what actually reached the registry — including the `-override` direction, where the notice moves to the declaration that was *displaced*. Extension ownership gets the same treatment, and matters more: an extension routed to the wrong dialect mis-lexes every file of that type.

**Standing claims are tracked as a set, not one per name** (Codex P2). With three packs claiming one name and the first vendor-disjoint from the next two, a single-entry map compares the third claim only against the first, finds them disjoint, and reports nothing — while `install_into` admits the second and third together and silently drops one. `claimed` is now `BTreeMap<&'static str, Vec<Claim>>`; each new claim settles against the first standing claim it could share a registry with, and `-override` replaces the claim it displaced in place rather than clobbering the entry.

**The two false positives**, both pinned by tests:

- **The vendor gate.** `install_into` skips a command whose `required_package` names a closed-world vendor the profile does not ship — which is what lets the bundled tier carry all six EDA libraries at once. Four of them declare a `report_timing` and they never meet. `could_collide` asks whether *any* profile would install both, which is the same question at load altitude.
- **Deliberate shipped layering.** `sdc_base` declares the SDC commands every vendor implements, and each vendor pack then specialises them. Two **bundled** packs colliding is left alone; every other combination — including a workspace pack shadowing a bundled one — is reported, because that is the case a user can act on.

Both were caught by `cargo test -p tcl-spectcl` failing on the shipped packs, not by review — which is the argument for the bundled-pack load test existing.

### #1638 — paper cuts

- The duplicate-command notice hardcoded `line: 1` and named the file it was already attached to. `PackCommand` now carries its declaring line and the merge fills in its file, so an in-file duplicate says *"already defined on line N of this file"* and lands on the declaration the author can delete.
- `speclib` with no version word took the whole body block as `pack.name` — the merge key, and the `name` field every editor is handed in `spec_packs_loaded`. A braced word in the name slot is now refused.
- **Extension rows carry their declaring file** (Codex P2). `FileExtension` gains `file`, filled by the merge exactly as `PackCommand::file` is, and the collision notice publishes against the row's own path instead of `pack.files.first()`. A logical pack can span several files, so the old attribution put the row's line against a different document — and the pre-existing test missed it because both its packs were single-file, making `files.first()` accidentally correct.

### Reverted after review: the whitespace-name drop

The third #1638 paper cut was **wrong and has been removed**. I had dropped command names carrying whitespace, reasoning that a command word cannot contain whitespace so nothing could invoke them. Codex challenged it; the oracle says Codex is right.

Verified against tclsh 8.6 and 9.0 — identical on both:

```
proc {evil name} {} { return "called-ok" }
{evil name}              ;# -> called-ok
info commands {evil*}    ;# -> {evil name}
set c "evil name"; $c    ;# -> called-ok
```

The same holds for a tab, for a newline, and for a name that is *only* a space (`proc { }` is created and `{ }` calls it). A Tcl command name is an arbitrary string key in the namespace's command table — `Tcl_CreateObjCommand` hashes it into `nsPtr->cmdTable` without inspecting a character, and `Tcl_FindCommand` looks it up on the same key. "A command word cannot contain whitespace" is a claim about *parsing*, and braced or quoted words are exactly the mechanism that lifts it.

Our own pipeline carries these end-to-end too, which is the test that would have justified keeping the notice had it failed: a braced command word lowers to `WordExpr::BracedLiteral`, whose `legacy_text` is the brace-stripped content, so `words[0].legacy_text()` yields `evil name` — the key the spec declares. Nothing in `tcl-syntax::naming` rejects whitespace either.

The drop was removing valid specs and their hover/completion metadata. It is gone, along with the line-cap extraction that came with it, so `load_command` is back to its pre-#1638 shape. The empty-name check stays — it predates #1638 and is a DSL-level authoring error, not a naming question.

## Tests

`pack_torture.rs` goes from 24 to 38 (37 CI + 1 manual tier):

- **Updated** — the tests whose contracts changed now assert the new notices exactly (line, file, wording) rather than a substring that survived the change.
- **New** — a BOM'd pack loads; a BOM inside a block stays data; a BOM'd pack survives the cache round trip; **the version span skips a leading BOM**; the no-body notice names the command; the orphaned-block notice stays one line; **a long unknown property is elided rather than quoted whole**; the second-`speclib` notice carries its command count; a version-less `speclib` is refused; the cross-pack `-override` direction; the vendor-gate false-positive guard; **whitespace-bearing names load**; **a collision behind a vendor-disjoint claim is reported**; **an extension collision names the file that declared the row**.
- **Extension host** — two tests assert the user-visible halves of #1634 and #1635 in the Problems panel, including that no message spans multiple lines.

### Mutation verification

Each fix reverted individually, its own test re-run. The whole battery was re-run after the review fixes, since a fix can move traffic — which is how the two starred rows were found.

| mutation | test | result |
|---|---|---|
| file-entry BOM skip → `Content` | `a_bom_prefixed_pack_loads_like_any_other` | fails |
| ★ version-span BOM skip → `Content` | `the_version_span_skips_a_leading_bom_like_the_loader` | fails |
| no-body notice drops the name | `a_command_with_no_body_is_named_in_a_notice` | fails |
| orphaned-block branch removed | `an_orphaned_block_notice_is_one_readable_line` | fails |
| ★ `unknown_property` quotable → raw | `a_long_unknown_property_is_elided_rather_than_quoted_whole` | fails |
| second-`speclib` loop disabled | `a_second_speclib_block_is_reported_with_its_command_count` | fails |
| version-less `speclib` check disabled | `a_speclib_without_a_version_does_not_become_a_pack_name` | fails |
| duplicate notice back to `line: 1` | `duplicate_command_declarations_are_reported_and_the_first_wins` | fails |
| cross-pack command notices → empty | `two_packs_claiming_one_command_install_deterministically` | fails |
| cross-pack command notices → empty | `a_cross_pack_override_reports_on_the_declaration_it_replaces` | fails |
| cross-pack extension notices → empty | `one_owner_per_file_extension_across_packs` | fails |
| `could_collide` → always true | `different_vendor_packages_declaring_one_name_is_not_a_collision` | fails |
| standing claims → single entry (`truncate(1)`) | `a_collision_behind_a_vendor_disjoint_claim_is_still_reported` | fails |
| extension notice → `pack.files.first()` | `an_extension_collision_names_the_file_that_declared_the_row` | fails |
| whitespace drop restored | `a_whitespace_bearing_command_name_loads_and_is_installable` | fails |
| BOM skip + no-body notice, against a rebuilt server | both new extension-host tests | fail |

**★ Two coverage gaps the re-run exposed**, both since closed. Neither fix was wrong — both were unpinned while the PR body claimed otherwise:

- `speclib_version_span` is a *second* whole-file entry point with its own `LexerConfig`. Flipping its BOM disposition alone left every test green, because the BOM test only exercises `pack_statements`. Since this is the hook `tcl spec upgrade` rewrites through, a disagreement here is exactly the wrong-span rewrite its doc comment warns about.
- `unknown_property`'s `quotable` call was likewise unpinned: the orphaned-block test returns down the block branch *before* reaching the quoting code, so reverting to a raw `word_text(0)` did not fail it. The new test uses a long, line-spanning non-block property.

The memo key remains the one thing no mutation can break — see the note under #1635.

## Validation

```
cargo fmt --all -- --check                              # clean
cargo check --workspace                                 # clean (PackCommand and FileExtension gained public fields)
cargo clippy -p tcl-spectcl --all-targets               # clean, no allows added
cargo test -p tcl-spectcl                               # whole crate green (37 + 1 ignored in pack_torture)
cargo test -p tcl-registry -p tcl-spec-studio -p tcl-lsp-core
make test-ext   MOCHA_GREP="SpecTcl pack torture"       # 9 passing, 1 pending
```

Clippy flagged four things this change introduced; all four are fixed rather than allowed — `report_extra_speclib_blocks` was extracted to keep `load_pack` under the line cap, plus a `map_or` and a `clone_from`.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? **No.** Loader/merge notices only; no diagnostic code added or changed, and the analyser is untouched.
- [x] If yes, I updated the owning design doc. **N/A** — behaviour now matches what `docs/design/spec-packs.md` already specifies, rather than changing the spec.
- [x] KCS page for a new/changed diagnostic code. **N/A** — pack load notices are not `DiagCode`s.
- [x] New design doc linked from `docs/design/README.md`. **N/A**

## Notes for review

- `PackCommand` gains two public fields (`line`, `file`) and `FileExtension` one (`file`). Each is deliberately empty as the loader builds it — the loader parses one source and is never told its path — and filled in by the merge, which is the only layer that knows. All are documented at the field.
- The bundled-pack exemption in #1637 is a judgement call worth a second opinion: I read `sdc_base` being specialised by vendor packs as intended layering. If it is not, dropping the `Tier::Bundled` check surfaces it as six notices on the shipped specs.

---
Generated with [Claude Code](https://claude.com/claude-code)