### PR TITLE
fix: a stub's default metaclass is not an observation; size the source-walk depth caps to a real stack budget

### DIFF
--- a/docs/design/compiler/recursive-descent-depth-limits.md
+++ b/docs/design/compiler/recursive-descent-depth-limits.md
@@ -283,19 +283,55 @@ walker's actual runtime environment can guarantee:
    parse degrades gracefully (a slightly-imprecise span for the
    pathological tail) instead of erroring the whole parse out.
 
+5. **A cap over a source-nesting walk is arithmetic against a stack
+   budget, not a convention number** — issue #1654, the third strategy,
+   added after the two above left a hole between them. Strategy 1 gives
+   *our* binaries 64 MiB; strategy 2 gives WASM-reachable walkers a small
+   calibrated cap. The braced-body walks fell between: not WASM-reachable,
+   so they kept the crate's conventional 256 — a number that matched three
+   sibling constants and nothing else. Re-measured with a stack-pointer
+   probe at each walk's depth-guarded entry (dev profile, x86-64 Linux),
+   `lowering`'s chain costs **18,864 bytes a level** (eight Rust frames),
+   `cfg_builder`'s **8,288**, `analyse_body`'s **3,840**. 256 lowering
+   levels therefore want ~4.6 MiB, so ~400 nested `foreach` bodies aborted
+   the process at about level 112 with the cap still 144 levels away: the
+   containment the cap exists to provide, absent exactly where it was
+   claimed, on any thread that had not opted into strategy 1. This is the
+   drift the "Problem 1" note above predicted, observed.
+
+   `tcl_compiler::depth_guard` now states the budget's three inputs
+   separately — `MIN_SOURCE_WALK_STACK` (2 MiB, the platform default
+   thread; a cap is a property of the walk, not of the callers we happen
+   to ship), `SOURCE_WALK_STACK_RESERVE` (a quarter, for everything on the
+   stack that is not the descent), and `SOURCE_WALK_BYTES_PER_LEVEL`
+   (20 KiB, the worst measured cost rounded up) — and
+   `MAX_SOURCE_NEST_DEPTH` is what they pay for. All three braced-body
+   caps read it, so the trio stays in lockstep as before while the number
+   itself can be re-derived from re-measured inputs.
+
+   The derivation is re-checked rather than asserted:
+   `depth_guard::tests::the_source_walk_cap_fits_its_stack_budget`
+   analyses a document nested past the cap on a thread sized to the
+   budget, so frame growth in any of the three walks fails a test instead
+   of resurfacing as an abort. It is given
+   `MIN_SOURCE_WALK_STACK - SOURCE_WALK_STACK_RESERVE` rather than the
+   whole 2 MiB, which is what makes passing it evidence that the reserve
+   is spare. Behaviour past the cap is unchanged — see (4).
+
+
 ## Guarded walkers — original pass
 
 | Walker | Cap constant / value | Stack strategy | Notes |
 |---|---|---|---|
-| `tcl_compiler::analyser::commands::analyse_body` | `MAX_BODY_DEPTH` = 256 | Big-stack entry points | Emits `E207` once per run when tripped. |
-| `tcl_compiler::cfg_builder::CfgBuilder::lower_script` | `MAX_LOWER_DEPTH` = 256 | Big-stack entry points | Pre-existing; stops descending, truncated-but-valid CFG. |
-| `tcl_compiler::lowering::Lowerer::lower_script`/`lower_body` | `MAX_LOWER_NEST_DEPTH` = 256 | Big-stack entry points | Emits a `Statement::Barrier` past the cap. |
+| `tcl_compiler::analyser::commands::analyse_body` | `MAX_BODY_DEPTH` = `depth_guard::MAX_SOURCE_NEST_DEPTH` | Derived stack budget (#1654) + big-stack entry points | Emits `E207` once per run when tripped. |
+| `tcl_compiler::cfg_builder::CfgBuilder::lower_script` | `MAX_LOWER_DEPTH` = `depth_guard::MAX_SOURCE_NEST_DEPTH` | Derived stack budget (#1654) + big-stack entry points | Pre-existing; stops descending, truncated-but-valid CFG. |
+| `tcl_compiler::lowering::Lowerer::lower_script`/`lower_body` | `MAX_LOWER_NEST_DEPTH` = `depth_guard::MAX_SOURCE_NEST_DEPTH` | Derived stack budget (#1654) + big-stack entry points | Emits a `Statement::Barrier` past the cap. The **fattest** of the three at ~18.4 KiB a level, so it sets the budget. |
 | `tcl_compiler::analyser::param_traits::scan_deep` / `infer_param_traits_deep_at_depth` | `MAX_DEPTH` = 8 | Big-stack entry points | `apply`-reset bypass fixed by this change. |
 | `tcl_compiler::optimiser::{propagation, expr_simplify, pattern_recognition, structure_elimination, code_sinking}` | `MAX_OPTIMISER_WALK_DEPTH` = 256 (shared, `optimiser/mod.rs`) | Big-stack entry points | Defence in depth: `lowering`'s cap already bounds the IR these passes see in the normal pipeline to 256 levels before they run. `code_sinking` additionally caps three more mutually-recursive query families, each answering conservatively past the cap. |
 | `tcl_compiler::codegen::structured::{walk_stmt, emit_if, emit_loop}` | `MAX_STRUCTURED_DEPTH` = 256 | Big-stack entry points | Covers both nested-body depth *and*, independently, `emit_if`'s own `elseif`-chain self-recursion. |
 | `tcl_lsp_core::references` (`scan_my_method_region`, `scan_obj_method_region`, `scan_next_dispatch_region`) | `MAX_DISPATCH_SCAN_DEPTH` = 256 | Big-stack entry points | Pre-existing; audited, no bypass found. |
 | `tcl_lsp_core::folding` | `MAX_FOLD_DEPTH` = 256 | Big-stack entry points | Pre-existing. |
-| `tcl_lsp_core::declaration` | `MAX_BODY_DEPTH` = 256 (local copy) | Big-stack entry points | Pre-existing. |
+| `tcl_lsp_core::declaration` | `MAX_BODY_DEPTH` = 256 (local copy) | Big-stack entry points | Pre-existing. No longer numerically tied to the compiler's cap (#1654 lowered that one); kept as defence-in-depth for a tree built some other way. |
 | `tcl_lsp_core::refactor` | `MAX_COMMAND_SEARCH_DEPTH` = 256 | Big-stack entry points | Pre-existing. |
 | `tcl_lsp_core::semantic_tokens` (`collect_lambda_literal` family) | `MAX_TOKEN_RECURSION` = 32 | Big-stack entry points | Pre-existing; audited, no bypass found. |
 | `tcl_lsp_core::formatting::engine::format_body`/`format_switch_body` | `MAX_FORMAT_DEPTH` = 128 | **Conservative cap** (WASM host: `bigip-query-wasm`) | Empirically measured 2 MiB-stack crash range: depth 800-1200. |

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -70,7 +70,12 @@ type CollectedHead = (
 /// diagnostics worker and the `tcl diag` / `lint` / `validate` CLIs. At
 /// the cap we stop descending into further nested bodies (the diagnostics
 /// already collected stand); no real source nests anywhere near this.
-const MAX_BODY_DEPTH: tcl_core_types::RecursionLimit = tcl_core_types::RecursionLimit(256);
+///
+/// The number itself is [`crate::depth_guard::MAX_SOURCE_NEST_DEPTH`],
+/// derived there from a stack budget and a measured per-level cost rather
+/// than picked to match a convention — see issue #1654 for what the old
+/// hand-picked 256 cost.
+const MAX_BODY_DEPTH: tcl_core_types::RecursionLimit = crate::depth_guard::MAX_SOURCE_NEST_DEPTH;
 
 /// The borrowed word-level view of one command, threaded into the
 /// dispatch-site diagnostic emitter ([`Analyser::emit_dispatch_site_diagnostics`]).

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -44,7 +44,9 @@ use crate::signature_scan::types::ParamDef;
 use crate::signature_scan::types::SignatureCommandAlias;
 
 use super::state::Analyser;
-use super::types::{ClassDef, ClassFactory, DefinedSymbol, FactoryMember, FactoryWord, ProcDef};
+use super::types::{
+    ClassDef, ClassFactory, DefinedSymbol, FactoryMember, FactoryWord, MetaclassProvenance, ProcDef,
+};
 use super::utils::{param_name_spans_for_token, parse_param_list};
 
 /// The three per-proc facts [`Analyser::infer_proc_param_traits`] derives from
@@ -419,13 +421,26 @@ fn substitute_bound_words(
 /// factory never disappears behind a later empty observation. Two different
 /// concrete superclass relations are not compatible evidence for one class;
 /// the caller must publish an abstaining record instead.
+///
+/// **Only facts a walk actually established take part in the conflict check.**
+/// Both sides here are `ClassDef`s, and `ClassDef::default()` fabricates one
+/// concrete-looking value — `metaclass: "oo::class"` — that no walk need have
+/// read. A record that never saw a creation command's head word carries it
+/// while having observed nothing, so it is compared only when
+/// [`ClassDef::metaclass_provenance`] says it was read; otherwise the observing
+/// side's answer is simply adopted. Without that gate an `oo::define` stub for
+/// a class made by a user metaclass contradicted the real metaclass and cost
+/// the record its factory and superclasses (issue #1653).
 fn join_parameterised_class_observations(
     existing: &ClassDef,
     observed: &ClassDef,
 ) -> Option<ClassDef> {
+    let metaclasses_conflict = existing.metaclass_provenance == MetaclassProvenance::Observed
+        && observed.metaclass_provenance == MetaclassProvenance::Observed
+        && crate::naming::normalise_qualified_name(&existing.metaclass)
+            != crate::naming::normalise_qualified_name(&observed.metaclass);
     if existing.qualified_name != observed.qualified_name
-        || crate::naming::normalise_qualified_name(&existing.metaclass)
-            != crate::naming::normalise_qualified_name(&observed.metaclass)
+        || metaclasses_conflict
         || (!existing.superclasses.is_empty()
             && !observed.superclasses.is_empty()
             && existing.superclasses != observed.superclasses)
@@ -443,6 +458,14 @@ fn join_parameterised_class_observations(
     } else {
         (observed.clone(), existing)
     };
+    // The stand-in loses to a real reading whichever side won above, so the
+    // joined record names the metaclass the source actually wrote.
+    if joined.metaclass_provenance != MetaclassProvenance::Observed
+        && other.metaclass_provenance == MetaclassProvenance::Observed
+    {
+        joined.metaclass.clone_from(&other.metaclass);
+        joined.metaclass_provenance = MetaclassProvenance::Observed;
+    }
     if joined.superclasses.is_empty() {
         joined.superclasses.clone_from(&other.superclasses);
     }
@@ -454,6 +477,18 @@ fn join_parameterised_class_observations(
     }
     joined.inheritance_unknown |= other.inheritance_unknown;
     joined.member_set_incomplete |= other.member_set_incomplete;
+    // One of these observations *is* the creation, so the joined record is
+    // not a cross-file extension stub even when the stub's side won above —
+    // go-to-definition must still prefer this file's creation site.
+    joined.via_define &= other.via_define;
+    // Whichever side lost, its declarations are still declarations: an
+    // `oo::define` stub's members belong to this class as surely as the
+    // creation body's do (issue #1653). Deliberately after the line above:
+    // `absorb_declarations` reads `via_define` on both records to decide who
+    // wins a name they both declare, and by here `joined`'s answers "were
+    // *both* of these observations stubs" — which is exactly the question
+    // that rule needs asked.
+    joined.absorb_declarations(other);
     Some(joined)
 }
 
@@ -8707,6 +8742,7 @@ impl Analyser {
             name_span,
             body_span,
             metaclass: cmd_name.to_string(),
+            metaclass_provenance: MetaclassProvenance::Observed,
             doc,
             inheritance_unknown: layout.inheritance_unknown,
             ..Default::default()
@@ -9933,6 +9969,49 @@ mod tests {
         let left = class_observation(Some("::T::Mother"), true);
         let right = class_observation(Some("::T::OtherMother"), true);
         assert!(join_parameterised_class_observations(&left, &right).is_none());
+    }
+
+    #[test]
+    fn parameterised_class_join_ignores_an_unobserved_metaclass() {
+        // Issue #1653 — the `oo::define` stub's `"oo::class"` is
+        // `ClassDef::default()`'s stand-in, not something a walk read, so it
+        // must neither contradict the proved `::T::Mother` nor survive into
+        // the joined record.
+        let stub = class_observation(None, false);
+        assert_ne!(stub.metaclass_provenance, MetaclassProvenance::Observed);
+        let proved = ClassDef {
+            metaclass: "::T::Mother".to_owned(),
+            metaclass_provenance: MetaclassProvenance::Observed,
+            ..class_observation(Some("::T::Mother"), true)
+        };
+
+        for (existing, observed) in [(&stub, &proved), (&proved, &stub)] {
+            let joined = join_parameterised_class_observations(existing, observed)
+                .expect("a stand-in metaclass is not conflicting evidence");
+            assert_eq!(joined.metaclass, "::T::Mother");
+            assert_eq!(joined.metaclass_provenance, MetaclassProvenance::Observed);
+            assert_eq!(joined.superclasses, vec!["::T::Mother"]);
+            assert!(joined.factory.is_some());
+        }
+    }
+
+    #[test]
+    fn parameterised_class_join_abstains_on_two_observed_metaclasses() {
+        // FP guard for the gate above: once *both* sides read a head word,
+        // a disagreement is still a real conflict.
+        let left = ClassDef {
+            metaclass: "::T::Mother".to_owned(),
+            metaclass_provenance: MetaclassProvenance::Observed,
+            ..class_observation(None, true)
+        };
+        let right = ClassDef {
+            metaclass: "::T::OtherMother".to_owned(),
+            metaclass_provenance: MetaclassProvenance::Observed,
+            ..class_observation(None, true)
+        };
+        assert!(join_parameterised_class_observations(&left, &right).is_none());
+        // …and identical observed metaclasses still join.
+        assert!(join_parameterised_class_observations(&left, &left).is_some());
     }
 
     fn esc_tok(span: Span) -> Token {

--- a/rust/tcl-compiler/src/analyser/mod.rs
+++ b/rust/tcl-compiler/src/analyser/mod.rs
@@ -87,8 +87,8 @@ pub use tcl_syntax::mro::{self, MroError, build_mro_map, tcloo_linearise};
 pub use types::{
     AnalysisResult, ClassDef, ClassFactory, ClassFactoryIndex, CodeFix, DefinedSymbol,
     DefinitionAbortKind, Diagnostic, FactoryMember, FactoryWord, FixSafety, ManufacturerSpec,
-    MemberRetractionRecord, MemberSide, MethodDef, ObjectMemberState, ObjectMethodDef,
-    ProcArgTrait, ProcDef, PropertyDef, QualifiedVarRef, RenamedMember, Scope, ScopeKind, Severity,
-    StubFlags, SubclassProvidedMethods, UnknownProcInfo, VarDef, class_constructor_key,
-    class_destructor_key, class_member_key, class_property_key,
+    MemberRetractionRecord, MemberSide, MetaclassProvenance, MethodDef, ObjectMemberState,
+    ObjectMethodDef, ProcArgTrait, ProcDef, PropertyDef, QualifiedVarRef, RenamedMember, Scope,
+    ScopeKind, Severity, StubFlags, SubclassProvidedMethods, UnknownProcInfo, VarDef,
+    class_constructor_key, class_destructor_key, class_member_key, class_property_key,
 };

--- a/rust/tcl-compiler/src/analyser/oo.rs
+++ b/rust/tcl-compiler/src/analyser/oo.rs
@@ -1363,6 +1363,7 @@ impl Analyser {
             name_span,
             body_span: body_tok.span,
             metaclass: cmd_name.to_string(),
+            metaclass_provenance: super::types::MetaclassProvenance::Observed,
             doc,
             ..Default::default()
         };
@@ -1743,6 +1744,7 @@ impl Analyser {
             name_span,
             body_span: body_tok.span,
             metaclass: cmd_name.to_string(),
+            metaclass_provenance: super::types::MetaclassProvenance::Observed,
             doc,
             ..Default::default()
         };

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -1193,6 +1193,28 @@ fn rehome_member(
     })
 }
 
+/// Where a [`ClassDef::metaclass`] value came from — issue #1653.
+///
+/// An enum rather than a bare flag because the interesting half is what the
+/// *default* means: `"oo::class"` sitting in a record no creation command
+/// ever touched is a placeholder, and a join that reads it as evidence
+/// invents a disagreement out of nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MetaclassProvenance {
+    /// Left at [`ClassDef::default()`]'s `"oo::class"` — no walk read it.
+    ///
+    /// The abstaining direction, and therefore the default: a record that
+    /// cannot say where its metaclass came from constrains nothing in a
+    /// join, while every consumer that simply reads `metaclass` keeps the
+    /// stand-in it always had.
+    #[default]
+    StandIn,
+    /// Read from a creation command's own head word — `oo::class create`
+    /// and the other `TclOO` metaclasses, `snit::type` / `snit::widget`,
+    /// `itcl::class`. The only spelling that is evidence.
+    Observed,
+}
+
 /// Class definition record.
 ///
 /// The structural fields (`superclasses`, `mixins`, `methods`,
@@ -1214,7 +1236,26 @@ pub struct ClassDef {
     /// Metaclass — one of ``"oo::class"`` / ``"oo::configurable"``
     /// / ``"oo::abstract"`` / ``"oo::singleton"``.  Defaults to
     /// ``"oo::class"``.
+    ///
+    /// The default is a *stand-in*, not a reading of the source: a record
+    /// built by anything other than a creation command — an
+    /// ``oo::define`` stub, the ``oo::objdefine`` holder — carries it
+    /// having observed nothing. [`Self::metaclass_provenance`] is what
+    /// tells the two apart.
     pub metaclass: String,
+    /// Where [`Self::metaclass`] came from — the observed-fields mask this
+    /// record needs, and the only entry it needs.
+    ///
+    /// Every other field defaults to a value that *is* its own "nothing
+    /// observed" reading — empty tables, empty superclass list, `None`,
+    /// `false`, a zero span — so a join can treat the default as a lower
+    /// bound and take the other side's. `metaclass` alone defaults to a
+    /// fabricated concrete name, which a join comparing it as evidence
+    /// reads as a walk having *proved* `oo::class`; a `via_define` stub for
+    /// a computed-name class made by `::T::Mother` then looked like two
+    /// walks disagreeing about the metaclass, and the record abstained down
+    /// to no factory and no superclasses (issue #1653).
+    pub metaclass_provenance: MetaclassProvenance,
     /// Direct superclasses in declaration order.  Each entry
     /// is a fully-qualified class name with leading ``::``.
     pub superclasses: Vec<String>,
@@ -1425,12 +1466,322 @@ pub struct ClassDef {
     pub factory: Option<ClassFactory>,
 }
 
+/// Concatenate an **appended** ordered slot (`variable`, `filter`) from a
+/// record whose words ran `from_ran_second` relative to `into`'s.
+///
+/// These slots accumulate rather than replace: on 8.6.16 and 9.0.4,
+/// `oo::class create C { filter f; variable x }` then
+/// `oo::define C { filter g; variable y }` reports filters `f g` and
+/// variables `x y`. A name the slot already carries is not repeated —
+/// declaring `variable x` twice leaves one `x` — and the surviving order
+/// is run order, which is why the earlier record's entries lead.
+///
+/// See [`ClassDef::absorb_declarations`] for the slots that replace instead.
+fn append_ordered_slot(into: &mut Vec<String>, from: &[String], from_ran_second: bool) {
+    let (mut merged, tail) = if from_ran_second {
+        (std::mem::take(into), from.to_vec())
+    } else {
+        (from.to_vec(), std::mem::take(into))
+    };
+    for name in tail {
+        if !merged.contains(&name) {
+            merged.push(name);
+        }
+    }
+    *into = merged;
+}
+
+/// Add `key`'s declaration to `table`, replacing an existing entry only
+/// when the contributing record is the one that ran second — see
+/// [`ClassDef::absorb_declarations`].
+fn insert_declaration<V: Clone>(
+    table: &mut HashMap<String, V>,
+    key: &str,
+    value: &V,
+    replace: bool,
+) {
+    match table.entry(key.to_owned()) {
+        std::collections::hash_map::Entry::Occupied(mut slot) => {
+            if replace {
+                slot.insert(value.clone());
+            }
+        }
+        std::collections::hash_map::Entry::Vacant(slot) => {
+            slot.insert(value.clone());
+        }
+    }
+}
+
+impl ClassDef {
+    /// Take every declaration `other` makes that this record does not
+    /// already carry.
+    ///
+    /// Two records can describe one class: the computed-name creation
+    /// observed inside a procedure body, and whatever the ordinary walk
+    /// already built under the proved name — in particular an
+    /// [`oo::define` stub](Self::via_define), whose members are a real
+    /// additional contribution to the same class rather than a second
+    /// reading of the same body. A join that simply picked the more
+    /// complete record therefore silently dropped the other's members,
+    /// which is how a stub's `method m` disappeared the moment the join
+    /// stopped abstaining (issue #1653).
+    ///
+    /// **This join knows the order.** An `oo::define` extending a class
+    /// necessarily runs after the creation it extends, so
+    /// [`via_define`](Self::via_define) tells the two records apart *and*
+    /// tells us which ran second. Every rule below is that ordering applied
+    /// to one kind of field, and each kind takes it differently — so the
+    /// rules are per-slot facts read off a real interpreter, not one
+    /// pattern assumed to generalise. Measured identically on tclsh 8.6.16
+    /// and 9.0.4, `oo::class create C {…}` followed by `oo::define C {…}`:
+    ///
+    /// | field | second definition supplies | result |
+    /// |---|---|---|
+    /// | `method m {a}` → `method m {a b}` | a new body | `{a b} …` — replace |
+    /// | `export m` → `unexport m` | the opposite bit | unexported; `m` leaves the public table |
+    /// | `mixin ::A` → `mixin ::B` | a new list | `::B` — replace (`mixin -append` is the additive form) |
+    /// | `superclass ::S0` → `superclass ::S9` | a new list | `::S9` — replace |
+    /// | `filter f` → `filter g` | another filter | `f g` — **append** |
+    /// | `variable x` → `variable y` | another name | `x y` — **append**, de-duplicated |
+    /// | `method m` → `deletemethod m` | a retraction | `m` is gone; dispatch raises `unknown method "m"` |
+    ///
+    /// So:
+    ///
+    /// * **Keyed tables** (`methods`, `class_methods`, `properties`,
+    ///   `linked_members`) union, and a key both records declare goes to
+    ///   whichever ran second. Where neither side is a stub the choice
+    ///   cannot matter: a second creation under a name already taken never
+    ///   runs (`can't create object "::D::class": command already exists
+    ///   with that name`, same tclsh), so two non-stub observations are two
+    ///   readings of one body and a colliding key holds the same
+    ///   declaration either way. This record then keeps its own, being the
+    ///   observation the caller judged more complete.
+    /// * **Visibility** (`exports`/`unexports` and the class-side pair) is
+    ///   one bit per member, not two independent sets, so a union can leave
+    ///   a member in both — and a workspace consumer reads an `exports`
+    ///   entry as decisive, which would advertise a method the later
+    ///   definition took away. The later record's bit wins and clears its
+    ///   opposite, the same last-writer-exclusive update
+    ///   `oo::apply_visibility_member` performs while walking one body.
+    /// * **Replaced ordered slots** (`mixins`) take the later record's list
+    ///   whole when it has one, and the earlier record's only when the
+    ///   later never set the slot.
+    /// * **Appended ordered slots** (`variables`, `filters`,
+    ///   `class_filters`) concatenate in run order, dropping a name the
+    ///   list already carries — `variable x` twice leaves one `x`.
+    /// * **Whole-body singletons** (`constructors`, `destructor`) follow the
+    ///   replace rule, taking the earlier record's only when the later
+    ///   declares none.
+    /// * **Retractions** are *applied*, not merely carried. A `deletemethod`
+    ///   in the later record removes the member from the joined table and a
+    ///   `renamemethod` moves it, because this join is the point where the
+    ///   ordering is known. The tombstones ride along as well, for the
+    ///   cross-file consumer that still needs them, but compiler-side
+    ///   consumers of `all_classes` never apply the workspace retraction
+    ///   fold and would otherwise treat a deleted member as live.
+    ///
+    /// Two observations of one identical body — the case this join was
+    /// written for, where neither record is a stub — remain a no-op under
+    /// every rule above.
+    ///
+    /// Identity, spans, provenance flags and `definition_aborts` are not
+    /// declarations and are left to the caller;
+    /// [`definition_aborts`](Self::definition_aborts) in particular is
+    /// transient and already consumed by W315 before either record reaches
+    /// a join.
+    pub(crate) fn absorb_declarations(&mut self, other: &Self) {
+        // Destructured exhaustively on purpose: a field added to
+        // `ClassDef` fails to compile here until it has been classified,
+        // rather than being quietly dropped by every join.
+        let Self {
+            name: _,
+            qualified_name: _,
+            name_span: _,
+            body_span: _,
+            metaclass: _,
+            metaclass_provenance: _,
+            superclasses: _,
+            mixins,
+            methods,
+            class_methods,
+            constructors,
+            destructor,
+            variables,
+            properties,
+            filters,
+            class_filters,
+            exports,
+            unexports,
+            class_exports,
+            class_unexports,
+            retracted_members,
+            definition_aborts: _,
+            renamed_members,
+            linked_members,
+            doc,
+            via_define,
+            inheritance_unknown: _,
+            class_command_fallback: _,
+            member_set_incomplete: _,
+            factory: _,
+        } = other;
+
+        // `other` is the `oo::define` that extends what this record created,
+        // so it ran second and its declarations replace rather than add.
+        // When *this* record is the stub the ordering is simply reversed:
+        // `other` ran first and only fills what this one never mentions.
+        let other_ran_second = *via_define && !self.via_define;
+        for (key, def) in methods {
+            insert_declaration(&mut self.methods, key, def, other_ran_second);
+        }
+        for (key, def) in class_methods {
+            insert_declaration(&mut self.class_methods, key, def, other_ran_second);
+        }
+        for (key, def) in properties {
+            insert_declaration(&mut self.properties, key, def, other_ran_second);
+        }
+        for (key, target) in linked_members {
+            insert_declaration(&mut self.linked_members, key, target, other_ran_second);
+        }
+
+        for side in [MemberSide::Instance, MemberSide::ClassObject] {
+            let (other_exports, other_unexports) = match side {
+                MemberSide::Instance => (exports, unexports),
+                MemberSide::ClassObject => (class_exports, class_unexports),
+            };
+            self.absorb_visibility(side, other_exports, other_unexports, other_ran_second);
+        }
+
+        // `mixin` (and the whole-body singletons) replace the slot;
+        // `variable` / `filter` append to it. Both confirmed on 8.6.16 and
+        // 9.0.4 — see this function's table.
+        if other_ran_second && !mixins.is_empty() || self.mixins.is_empty() {
+            self.mixins.clone_from(mixins);
+        }
+        for (into, from) in [
+            (&mut self.variables, variables),
+            (&mut self.filters, filters),
+            (&mut self.class_filters, class_filters),
+        ] {
+            append_ordered_slot(into, from, other_ran_second);
+        }
+        if other_ran_second && !constructors.is_empty() || self.constructors.is_empty() {
+            self.constructors.clone_from(constructors);
+        }
+        if other_ran_second && destructor.is_some() || self.destructor.is_none() {
+            self.destructor.clone_from(destructor);
+        }
+
+        for record in retracted_members {
+            if !self.retracted_members.contains(record) {
+                self.retracted_members.push(record.clone());
+            }
+        }
+        for record in renamed_members {
+            if !self.renamed_members.contains(record) {
+                self.renamed_members.push(record.clone());
+            }
+        }
+        if other_ran_second {
+            self.apply_retractions(retracted_members);
+        }
+        if self.doc.is_empty() {
+            self.doc.clone_from(doc);
+        }
+    }
+
+    /// Merge one side's `export` / `unexport` pair from a record whose
+    /// words ran `other_ran_second` relative to this one's.
+    ///
+    /// `TclOO` keeps one visibility *bit* per member, not two independent
+    /// sets: `export m` sets it and `unexport m` clears it, so the later
+    /// word wins outright and the earlier one leaves no trace. Confirmed on
+    /// 8.6.16 and 9.0.4 — after `oo::class create E1 { method m {} {};
+    /// export m }` then `oo::define E1 { unexport m }`,
+    /// `info class methods E1` is empty while `-private` still lists `m`,
+    /// and `[E1 new] m` raises `unknown method "m"`; the reverse order
+    /// re-exports it.
+    ///
+    /// The same last-writer-exclusive update
+    /// [`oo::apply_visibility_member`](crate::analyser::oo) performs while
+    /// walking a single body, applied across the two records this join
+    /// holds. A plain union would leave a member in both sets, and the
+    /// workspace reads an `exports` entry as decisive — so it would go on
+    /// advertising a method the later definition took away.
+    fn absorb_visibility(
+        &mut self,
+        side: MemberSide,
+        other_exports: &HashSet<String>,
+        other_unexports: &HashSet<String>,
+        other_ran_second: bool,
+    ) {
+        for (from, exported) in [(other_exports, true), (other_unexports, false)] {
+            for name in from {
+                let (exports, unexports) = side.visibility_sets(self);
+                let (mine, opposite) = if exported {
+                    (exports, unexports)
+                } else {
+                    (unexports, exports)
+                };
+                // Skip only a name this record already decided *and*
+                // decided later; otherwise `other`'s bit is the live one.
+                if !other_ran_second && (mine.contains(name) || opposite.contains(name)) {
+                    continue;
+                }
+                mine.insert(name.clone());
+                opposite.remove(name);
+            }
+        }
+    }
+
+    /// Apply retractions recorded by a definition that ran **after** this
+    /// record's members were declared.
+    ///
+    /// A `via_define` stub for a class created elsewhere finds nothing to
+    /// remove while it is walked, so `deletemethod m` / `renamemethod m n`
+    /// can only be written down as a tombstone. Across files that is all
+    /// anyone can say — load order is unknowable, which is why
+    /// [`Self::retracted_members`] is documented as unordered and the
+    /// workspace applies it as a fold. Here the order *is* known, and the
+    /// tombstone alone is not enough: compiler-side consumers of
+    /// `AnalysisResult::all_classes` never run that fold, so a deleted
+    /// member would stay dispatchable, keep answering method-existence
+    /// checks, and feed derived factory facts.
+    ///
+    /// tclsh 8.6.16 and 9.0.4 agree on both shapes: after
+    /// `oo::class create D1 { method m …; method keep … }` then
+    /// `oo::define D1 { deletemethod m }`, `info class methods D1` is
+    /// `keep` and `[D1 new] m` raises `unknown method "m"`; after
+    /// `renamemethod m n` the table holds `n` alone.
+    fn apply_retractions(&mut self, retractions: &[MemberRetractionRecord]) {
+        for record in retractions {
+            let table = record.side.table(self);
+            let Some(mut moved) = table.remove(&record.member) else {
+                continue;
+            };
+            // A move re-homes the member under the arrival name, whose
+            // declaration site is the `renamemethod` destination word — the
+            // token go-to-definition must answer with, and the only one a
+            // rename of the arrived member may rewrite.
+            let (Some(arrival), Some(span)) = (&record.arrival, record.arrival_span) else {
+                continue;
+            };
+            arrival.clone_into(&mut moved.name);
+            moved.name_span = span;
+            table.insert(arrival.clone(), moved);
+        }
+    }
+}
+
 impl Default for ClassDef {
     /// Default-construct a [`ClassDef`].
     ///
     /// All names default to empty strings, both spans default to
     /// ``Span::new(0, 0)``, and the metaclass defaults to
-    /// ``"oo::class"``.
+    /// ``"oo::class"`` — with
+    /// [`metaclass_provenance`](ClassDef::metaclass_provenance)
+    /// [`StandIn`](MetaclassProvenance::StandIn), so
+    /// that stand-in is never mistaken for a reading of the source.
     /// Used by handlers that build a class record incrementally
     /// (most common shape — only `name` / `qualified_name` /
     /// `name_span` / `body_span` need explicit values).
@@ -1442,6 +1793,7 @@ impl Default for ClassDef {
             name_span: zero,
             body_span: zero,
             metaclass: "oo::class".to_string(),
+            metaclass_provenance: MetaclassProvenance::StandIn,
             superclasses: Vec::new(),
             mixins: Vec::new(),
             methods: HashMap::new(),
@@ -2744,6 +3096,8 @@ mod tests {
         // the analyser depends on.
         let c = ClassDef::default();
         assert_eq!(c.metaclass, "oo::class");
+        // …and it is a stand-in, not an observation (issue #1653).
+        assert_eq!(c.metaclass_provenance, MetaclassProvenance::StandIn);
         assert!(c.constructors.is_empty());
         assert!(c.destructor.is_none());
         assert!(c.variables.is_empty());
@@ -2752,5 +3106,333 @@ mod tests {
         assert!(c.exports.is_empty());
         assert!(c.unexports.is_empty());
         assert!(c.doc.is_empty());
+    }
+
+    fn strings(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    fn string_set(items: &[&str]) -> HashSet<String> {
+        items.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    fn method(name: &str, params: &[&str]) -> MethodDef {
+        MethodDef {
+            name: name.to_owned(),
+            params: params
+                .iter()
+                .map(|p| crate::signature_scan::types::ParamDef {
+                    name: (*p).to_owned(),
+                    has_default: false,
+                    default_value: None,
+                })
+                .collect(),
+            params_computed: false,
+            name_span: Span::new(0, 0),
+            body_span: Span::new(0, 0),
+            kind: "method".to_owned(),
+            is_self_method: false,
+            visibility: "public".to_owned(),
+            doc: String::new(),
+            forward_target: None,
+        }
+    }
+
+    /// The pair this join sees: a computed-name creation and the
+    /// `oo::define` stub that extends it, the stub having run second.
+    fn creation_and_stub(creation: ClassDef, stub: ClassDef) -> (ClassDef, ClassDef) {
+        (
+            creation,
+            ClassDef {
+                via_define: true,
+                ..stub
+            },
+        )
+    }
+
+    #[test]
+    fn absorb_declarations_lets_the_later_definition_set_visibility() {
+        // Issue #1653 review (thread r3820723173). `export` / `unexport`
+        // are one bit per member, not two sets: on 8.6.16 and 9.0.4,
+        // `oo::class create E1 { method m {} {}; export m }` then
+        // `oo::define E1 { unexport m }` leaves `info class methods E1`
+        // empty while `-private` still lists `m`, and `[E1 new] m` raises
+        // `unknown method "m"`. The reverse order re-exports it. A union
+        // would leave `m` in both sets, and workspace dispatch reads an
+        // `exports` entry as decisive.
+        let (mut creation, stub) = creation_and_stub(
+            ClassDef {
+                exports: string_set(&["m"]),
+                class_exports: string_set(&["cm"]),
+                ..ClassDef::default()
+            },
+            ClassDef {
+                unexports: string_set(&["m"]),
+                class_unexports: string_set(&["cm"]),
+                ..ClassDef::default()
+            },
+        );
+        creation.absorb_declarations(&stub);
+        assert!(
+            creation.exports.is_empty() && creation.unexports == string_set(&["m"]),
+            "the later `unexport m` must clear the earlier `export m`; \
+             exports={:?} unexports={:?}",
+            creation.exports,
+            creation.unexports
+        );
+        assert!(
+            creation.class_exports.is_empty() && creation.class_unexports == string_set(&["cm"]),
+            "the class-object side takes the identical update"
+        );
+
+        // Reverse: the creation unexports, the later define re-exports.
+        let (mut creation, stub) = creation_and_stub(
+            ClassDef {
+                unexports: string_set(&["m"]),
+                ..ClassDef::default()
+            },
+            ClassDef {
+                exports: string_set(&["m"]),
+                ..ClassDef::default()
+            },
+        );
+        creation.absorb_declarations(&stub);
+        assert!(
+            creation.unexports.is_empty() && creation.exports == string_set(&["m"]),
+            "the later `export m` must clear the earlier `unexport m`"
+        );
+
+        // …and with the stub as the *winner* of the join, the creation it
+        // absorbs ran first, so the stub's own bit stands.
+        let mut stub = ClassDef {
+            via_define: true,
+            unexports: string_set(&["m"]),
+            ..ClassDef::default()
+        };
+        stub.absorb_declarations(&ClassDef {
+            exports: string_set(&["m", "untouched"]),
+            ..ClassDef::default()
+        });
+        assert!(
+            stub.unexports == string_set(&["m"]) && stub.exports == string_set(&["untouched"]),
+            "the stub ran second whichever side won the join; \
+             exports={:?} unexports={:?}",
+            stub.exports,
+            stub.unexports
+        );
+    }
+
+    #[test]
+    fn absorb_declarations_replaces_mixins_but_appends_variables_and_filters() {
+        // Issue #1653 review (thread r3820723184). The ordered slots are
+        // *not* uniform, which is why each was measured rather than
+        // assumed. On 8.6.16 and 9.0.4, a class created with
+        // `mixin ::FH ::A; filter f; variable x` and then
+        // `oo::define … { mixin ::FH ::B; filter g; variable y }` reports
+        // mixins `::FH ::B` (replaced — `mixin -append` is the additive
+        // form), filters `f g` and variables `x y` (both appended).
+        let (mut creation, stub) = creation_and_stub(
+            ClassDef {
+                mixins: strings(&["::FH", "::A"]),
+                filters: strings(&["f"]),
+                class_filters: strings(&["cf"]),
+                variables: strings(&["x"]),
+                ..ClassDef::default()
+            },
+            ClassDef {
+                mixins: strings(&["::FH", "::B"]),
+                filters: strings(&["g"]),
+                class_filters: strings(&["cg"]),
+                variables: strings(&["y"]),
+                ..ClassDef::default()
+            },
+        );
+        creation.absorb_declarations(&stub);
+        assert_eq!(creation.mixins, strings(&["::FH", "::B"]), "mixin replaces");
+        assert_eq!(creation.filters, strings(&["f", "g"]), "filter appends");
+        assert_eq!(creation.class_filters, strings(&["cf", "cg"]));
+        assert_eq!(creation.variables, strings(&["x", "y"]), "variable appends");
+
+        // Appends keep run order when the *stub* won the join, and never
+        // duplicate a name the slot already carries (`variable x` twice
+        // leaves one `x` on both interpreters).
+        let mut stub = ClassDef {
+            via_define: true,
+            filters: strings(&["g"]),
+            variables: strings(&["x", "y"]),
+            ..ClassDef::default()
+        };
+        stub.absorb_declarations(&ClassDef {
+            filters: strings(&["f"]),
+            variables: strings(&["x"]),
+            ..ClassDef::default()
+        });
+        assert_eq!(stub.filters, strings(&["f", "g"]), "earlier filter first");
+        assert_eq!(
+            stub.variables,
+            strings(&["x", "y"]),
+            "declared twice, kept once"
+        );
+
+        // A slot the later definition never sets keeps the earlier list.
+        let (mut creation, stub) = creation_and_stub(
+            ClassDef {
+                mixins: strings(&["::A"]),
+                ..ClassDef::default()
+            },
+            ClassDef::default(),
+        );
+        creation.absorb_declarations(&stub);
+        assert_eq!(creation.mixins, strings(&["::A"]));
+    }
+
+    #[test]
+    fn absorb_declarations_applies_a_later_retraction_to_the_member_table() {
+        // Issue #1653 review (thread r3820723192). A stub records
+        // `deletemethod m` as a tombstone because it has no table to remove
+        // from; the join is where the ordering is known, and compiler-side
+        // consumers of `all_classes` never run the workspace fold. On
+        // 8.6.16 and 9.0.4, `oo::class create D1 { method m …; method keep … }`
+        // then `oo::define D1 { deletemethod m }` reports `info class
+        // methods D1` = `keep`, and `[D1 new] m` raises `unknown method`.
+        let (mut creation, stub) = creation_and_stub(
+            ClassDef {
+                methods: [
+                    ("m".to_owned(), method("m", &[])),
+                    ("keep".to_owned(), method("keep", &[])),
+                ]
+                .into_iter()
+                .collect(),
+                ..ClassDef::default()
+            },
+            ClassDef {
+                retracted_members: vec![MemberRetractionRecord::deletion(
+                    "m".to_owned(),
+                    MemberSide::Instance,
+                )],
+                ..ClassDef::default()
+            },
+        );
+        creation.absorb_declarations(&stub);
+        assert_eq!(
+            creation
+                .methods
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+            vec!["keep"],
+            "the retracted member must leave the joined table"
+        );
+        assert_eq!(
+            creation.retracted_members.len(),
+            1,
+            "the tombstone still rides along for the cross-file consumer"
+        );
+
+        // A move re-homes the member under its arrival name, taking the
+        // destination word as its declaration site — `renamemethod m n`
+        // leaves `n` alone in the table on both interpreters.
+        let (mut creation, stub) = creation_and_stub(
+            ClassDef {
+                methods: [("m".to_owned(), method("m", &["a"]))]
+                    .into_iter()
+                    .collect(),
+                ..ClassDef::default()
+            },
+            ClassDef {
+                retracted_members: vec![MemberRetractionRecord {
+                    member: "m".to_owned(),
+                    side: MemberSide::Instance,
+                    arrival: Some("n".to_owned()),
+                    arrival_span: Some(Span::new(40, 41)),
+                }],
+                ..ClassDef::default()
+            },
+        );
+        creation.absorb_declarations(&stub);
+        let moved = creation
+            .methods
+            .get("n")
+            .expect("the moved member arrives under its new name");
+        assert!(
+            !creation.methods.contains_key("m"),
+            "the source name is gone"
+        );
+        assert_eq!(moved.params.len(), 1, "the moved member keeps its body");
+        assert_eq!(moved.name, "n");
+        assert_eq!(moved.name_span, Span::new(40, 41));
+
+        // The reverse order retracts nothing: a `deletemethod` the creation
+        // body itself ran already emptied its own table, and the stub's
+        // members were declared afterwards.
+        let mut stub = ClassDef {
+            via_define: true,
+            methods: [("m".to_owned(), method("m", &[]))].into_iter().collect(),
+            ..ClassDef::default()
+        };
+        stub.absorb_declarations(&ClassDef {
+            retracted_members: vec![MemberRetractionRecord::deletion(
+                "m".to_owned(),
+                MemberSide::Instance,
+            )],
+            ..ClassDef::default()
+        });
+        assert!(
+            stub.methods.contains_key("m"),
+            "an earlier retraction must not remove a later declaration"
+        );
+    }
+
+    #[test]
+    fn absorb_declarations_unions_the_remaining_tables() {
+        // The rules with no ordering component: keyed tables union with the
+        // later record winning a collision, whole-body singletons follow
+        // the replace rule, and `doc` fills only where absent.
+        let mut into = ClassDef {
+            linked_members: [("shared".to_owned(), "::mine".to_owned())]
+                .into_iter()
+                .collect(),
+            doc: "mine".to_owned(),
+            ..ClassDef::default()
+        };
+        let other = ClassDef {
+            linked_members: [
+                ("shared".to_owned(), "::theirs".to_owned()),
+                ("only-theirs".to_owned(), "::theirs".to_owned()),
+            ]
+            .into_iter()
+            .collect(),
+            doc: "theirs".to_owned(),
+            ..ClassDef::default()
+        };
+        into.absorb_declarations(&other);
+        // Neither side is a stub, so this record keeps the colliding key.
+        assert_eq!(
+            into.linked_members.get("shared").map(String::as_str),
+            Some("::mine")
+        );
+        assert_eq!(
+            into.linked_members.get("only-theirs").map(String::as_str),
+            Some("::theirs")
+        );
+        assert_eq!(into.doc, "mine");
+
+        // …and with `other` the stub, the colliding key goes to it.
+        let mut into = ClassDef {
+            linked_members: [("shared".to_owned(), "::mine".to_owned())]
+                .into_iter()
+                .collect(),
+            ..ClassDef::default()
+        };
+        into.absorb_declarations(&ClassDef {
+            via_define: true,
+            ..other
+        });
+        assert_eq!(
+            into.linked_members.get("shared").map(String::as_str),
+            Some("::theirs")
+        );
+        // A record with no doc of its own takes the other's.
+        assert_eq!(into.doc, "theirs");
     }
 }

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -203,7 +203,19 @@ pub(crate) struct CfgBuilder {
 /// treat the over-deep script as a non-fall-through tail, yielding a
 /// truncated-but-valid CFG instead of a crash. No real source nests
 /// anywhere near this.
-const MAX_LOWER_DEPTH: tcl_core_types::RecursionLimit = tcl_core_types::RecursionLimit(256);
+///
+/// Shares [`crate::depth_guard::MAX_SOURCE_NEST_DEPTH`] with the lowering
+/// and analyser body walks — one budget, derived from a measured per-level
+/// stack cost, rather than three copies of a hand-picked 256 (issue #1654).
+///
+/// Through the normal pipeline this cap is **unreachable**: `lowering`'s
+/// copy of the same number already bounds the IR handed here, so a
+/// `Module` built from source cannot nest deeper than the cap in the first
+/// place. It matters for a host that builds a `Module` some other way, and
+/// its 8,288 bytes a level is what the budget must still afford for that
+/// caller — the same defence-in-depth role the optimiser and codegen walks
+/// play over the same IR.
+const MAX_LOWER_DEPTH: tcl_core_types::RecursionLimit = crate::depth_guard::MAX_SOURCE_NEST_DEPTH;
 
 /// Maximum nested-`[...]` descent depth for
 /// [`CfgBuilder::upvar_defs_from_text_bounded`] /

--- a/rust/tcl-compiler/src/depth_guard.rs
+++ b/rust/tcl-compiler/src/depth_guard.rs
@@ -35,6 +35,11 @@
 //! conservative fallback matching that function's own return contract — see
 //! the per-site comments), exactly as `tcl_core_types::RecursionLimit`'s
 //! module docs prescribe.
+//!
+//! [`MAX_SOURCE_NEST_DEPTH`] joins them for the third category — the
+//! *braced-body* descent — and, unlike the two above, is not a convention
+//! number at all: it is arithmetic over a stated stack budget and a measured
+//! per-level cost. See its docs for why 256 was not (issue #1654).
 
 /// Depth cap for every walk over an `[expr]` operator-tree AST
 /// ([`tcl_syntax::expr::ast::ExprNode`], re-exported as
@@ -70,3 +75,224 @@ pub(crate) const MAX_EXPR_NODE_DEPTH: tcl_core_types::RecursionLimit =
 /// full-tree convention, for the same reasons.
 pub(crate) const MAX_BRACKET_TEXT_DEPTH: tcl_core_types::RecursionLimit =
     tcl_core_types::RecursionLimit(256);
+
+/// The smallest native stack the braced-body walks below must run to
+/// completion on — the platform default thread stack, 2 MiB on Linux.
+///
+/// It is what `std::thread::spawn`, a Tokio worker, and `cargo test`'s
+/// per-test thread all hand a caller who asks for nothing in particular.
+/// The `tcl` CLI, `tcl-lsp-server` and `tcl-mcp` deliberately ask for 64 MiB
+/// (issue #996's `WORKER_STACK_SIZE`), so their own entry points have 32×
+/// this — but a cap is a property of the walk, not of one caller, and a
+/// crate this one is embedded in owes us no such courtesy. Sizing to the
+/// floor keeps "the analyser aborts the process" off the table for every
+/// caller instead of only the ones we ship.
+pub(crate) const MIN_SOURCE_WALK_STACK: u32 = 2 * 1024 * 1024;
+
+/// The part of [`MIN_SOURCE_WALK_STACK`] the recursive descent may **not**
+/// spend: everything above it (the caller's own frames, the LSP request
+/// handler, the test harness) plus the deepest non-recursive work below it
+/// (segmenting one command, building its tokens).
+///
+/// A quarter is far more than the measurement needs — a 2 MiB thread was
+/// observed to reach 112 lowering levels before aborting, i.e. 2,112,768
+/// bytes of descent against a 2,097,152-byte stack, which puts the
+/// non-descent overhead in the tens of kilobytes — but the reserve also
+/// absorbs the difference between the deepest leaf this measurement
+/// happened to reach and the deepest one some other input reaches.
+const SOURCE_WALK_STACK_RESERVE: u32 = MIN_SOURCE_WALK_STACK / 4;
+
+/// Worst per-level native-stack cost across the braced-body walk family,
+/// **measured**, rounded up.
+///
+/// Taken with a stack-pointer probe at the depth-guarded entry of each
+/// walk, on x86-64 Linux, in a `dev`-profile build — the fattest frames the
+/// code ever has, and the profile `cargo test` and every developer run use:
+///
+/// | walk | bytes per nesting level |
+/// |---|---|
+/// | `lowering::Lowerer::lower_body` ↔ `lower_segmented` ↔ `lower_command` ↔ `lower_foreach` | 18,864 |
+/// | `cfg_builder::CfgBuilder::lower_script` | 8,288 |
+/// | `analyser::commands::Analyser::analyse_body` | 3,840 |
+///
+/// The lowering chain sets the number: eight Rust frames per braced-body
+/// level, several of them large. 20 KiB is that 18,864 rounded up, so the
+/// arithmetic below keeps a little slack even before the reserve.
+pub(crate) const SOURCE_WALK_BYTES_PER_LEVEL: u32 = 20 * 1024;
+
+/// Depth cap for the braced-body descent shared by the lowering, CFG-builder
+/// and analyser walks — issue #1654.
+///
+/// All three recurse once per `{ … }` nesting level over the same document,
+/// and all three carried a hand-picked 256 that matched this crate's
+/// full-tree convention. That number was never checked against a stack: at
+/// the lowering walk's measured 18,864 bytes a level, 256 levels want about
+/// 4.6 MiB, so ~400 nested `foreach` bodies aborted the process on any
+/// default-stack thread — the cap tripped at 256 long after the stack ran
+/// out at ~112 (issue #1654; the containment the caps exist to provide,
+/// absent exactly where it was claimed).
+///
+/// So it is derived rather than chosen: the levels
+/// [`MIN_SOURCE_WALK_STACK`] pays for at
+/// [`SOURCE_WALK_BYTES_PER_LEVEL`] each, after
+/// [`SOURCE_WALK_STACK_RESERVE`] is set aside. Every input is one of
+/// those three numbers, each of which says what it is and can be
+/// re-measured; the answer falls out. `the_source_walk_cap_fits_its_stack_budget`
+/// re-checks the claim by running a cap-deep document on a thread sized to
+/// the budget, so frame growth in any of the three walks fails a test
+/// instead of resurfacing as an abort.
+///
+/// The result is far below 256 and still far above anything a human writes;
+/// past it each walk degrades the way it already did — the lowering emits a
+/// `Statement::Barrier` for the unread region, the analyser reports E207 and
+/// stops descending.
+pub(crate) const MAX_SOURCE_NEST_DEPTH: tcl_core_types::RecursionLimit =
+    tcl_core_types::RecursionLimit(
+        (MIN_SOURCE_WALK_STACK - SOURCE_WALK_STACK_RESERVE) / SOURCE_WALK_BYTES_PER_LEVEL,
+    );
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        MAX_SOURCE_NEST_DEPTH, MIN_SOURCE_WALK_STACK, SOURCE_WALK_BYTES_PER_LEVEL,
+        SOURCE_WALK_STACK_RESERVE,
+    };
+
+    fn nested_foreach(levels: usize) -> String {
+        (0..levels)
+            .map(|i| format!("foreach v{i} {{a b}} {{\n"))
+            .chain(std::iter::once("set inner 1\n".to_owned()))
+            .chain((0..levels).map(|_| "}\n".to_owned()))
+            .collect()
+    }
+
+    /// Whether analysing `levels`-deep nesting reports having stopped.
+    fn reports_over_depth(levels: usize) -> bool {
+        crate::analyser::Analyser::new()
+            .analyse(&nested_foreach(levels), "tcl9.0")
+            .diagnostics
+            .iter()
+            .any(|d| d.code == tcl_core_types::DiagCode::E207)
+    }
+
+    /// A document nested several times deeper than the cap.
+    ///
+    /// Past the cap rather than exactly at it, and by a wide margin, so the
+    /// test answers two questions at once: every walk on this path runs its
+    /// full budget (the deepest descent the cap permits), *and* every walk
+    /// on this path actually stops there. A walk that kept its own larger
+    /// bound would sail past and overflow; one that merely fits would not
+    /// be distinguishable from one that stops.
+    fn over_cap_source() -> String {
+        nested_foreach(MAX_SOURCE_NEST_DEPTH.0 as usize * 4)
+    }
+
+    #[test]
+    fn the_source_walk_cap_is_the_arithmetic_it_claims_to_be() {
+        assert_eq!(
+            MAX_SOURCE_NEST_DEPTH.0,
+            (MIN_SOURCE_WALK_STACK - SOURCE_WALK_STACK_RESERVE) / SOURCE_WALK_BYTES_PER_LEVEL,
+        );
+        // Deep enough that no hand-written source reaches it, and far below
+        // the 256 that did not fit (issue #1654).
+        assert!((32..256).contains(&MAX_SOURCE_NEST_DEPTH.0));
+        // The reserve is the one input that is a *policy* rather than a
+        // measurement, and the one `the_source_walk_cap_fits_its_stack_budget`
+        // cannot judge for itself — that test sizes its thread from the
+        // reserve, so a reserve shrunk to nothing shrinks the standard it is
+        // held to as well. Pin a floor here instead: the margin exists to
+        // absorb frame-cost drift between measurements and a deeper leaf
+        // than the probe happened to reach, and neither is worth a rounding
+        // error.
+        const { assert!(SOURCE_WALK_STACK_RESERVE >= MIN_SOURCE_WALK_STACK / 8) }
+    }
+
+    /// The braced-body walks share one depth, which is the whole reason the
+    /// budget can be reasoned about at all: three walks over one document,
+    /// one number, so no consumer depends on one pass reaching deeper than
+    /// another. Each keeps its own named constant, so nothing but a test
+    /// stops one from drifting back to a private number that happens to
+    /// fit — which the analyser's 3,840 bytes a level easily would.
+    ///
+    /// Brackets the analyser's own trip point around
+    /// [`MAX_SOURCE_NEST_DEPTH`] rather than pinning it exactly: how a
+    /// document's outermost script maps onto the first `body_depth` is that
+    /// walk's business, and this is a statement about which *cap* it obeys.
+    #[test]
+    fn the_analyser_stops_at_the_shared_cap() {
+        let cap = MAX_SOURCE_NEST_DEPTH.0 as usize;
+        assert!(
+            !reports_over_depth(cap - 2),
+            "nesting below the shared cap must analyse in full"
+        );
+        assert!(
+            reports_over_depth(cap + 2),
+            "nesting above the shared cap must report that the walk stopped"
+        );
+    }
+
+    /// The claim [`MAX_SOURCE_NEST_DEPTH`] makes, re-checked rather than
+    /// asserted: a document nested well past the cap completes on a stack
+    /// the size of the budget the cap was divided out of — so every walk
+    /// this document drives both honours the shared cap and fits inside the
+    /// budget that cap was derived from.
+    ///
+    /// Sized to `MIN_SOURCE_WALK_STACK - SOURCE_WALK_STACK_RESERVE` and not
+    /// to the whole 2 MiB, so passing here proves the reserve is genuinely
+    /// spare on a real default-stack thread rather than quietly spent. If
+    /// any of the three walks grows fatter frames than
+    /// [`SOURCE_WALK_BYTES_PER_LEVEL`] records, this aborts — loudly, in
+    /// the one test whose job is to notice, instead of in a user's editor.
+    ///
+    /// **All three walks are driven explicitly, not only through
+    /// `analyse`.** `analyse` does reach the other two today — measured, by
+    /// fattening `CfgBuilder::lower_script` by 24 KiB a level and by
+    /// regressing `MAX_LOWER_NEST_DEPTH` to 256, both of which abort an
+    /// analyse-only version of this test. But it reaches them
+    /// *conditionally*: `AnalyserState::whole_file_command_trust` lowers the
+    /// document behind a `head_may_fold` gate, and the CFG arrives via
+    /// `unit_scope`. Which passes a given source shape triggers is a
+    /// property of those gates, not of this budget, and a change to them
+    /// would silently take the coverage away while leaving the test green.
+    /// Calling `lower_to_ir` and `build_cfg` here makes the coverage
+    /// unconditional and states which walks are being claimed — the more so
+    /// because lowering is 4.9× the analyser's per-level cost and is what
+    /// sets this budget in the first place.
+    #[test]
+    fn the_source_walk_cap_fits_its_stack_budget() {
+        let source = over_cap_source();
+        let (diagnostics, blocks) = std::thread::Builder::new()
+            .stack_size(
+                usize::try_from(MIN_SOURCE_WALK_STACK - SOURCE_WALK_STACK_RESERVE)
+                    .expect("the budget fits a usize"),
+            )
+            .spawn(move || {
+                let diagnostics = crate::analyser::Analyser::new()
+                    .analyse(&source, "tcl9.0")
+                    .diagnostics
+                    .len();
+                let registry = tcl_registry::registry_for_dialect("tcl9.0");
+                let module = crate::lowering::lower_to_ir(&source, registry);
+                let cfg = crate::cfg_builder::build_cfg(&module, false);
+                let blocks: usize = cfg.top_level.blocks.len()
+                    + cfg
+                        .procedures
+                        .values()
+                        .map(|f| f.blocks.len())
+                        .sum::<usize>();
+                (diagnostics, blocks)
+            })
+            .expect("spawn budget-sized thread")
+            .join()
+            .expect("every walk must return rather than abort the process");
+        assert!(
+            diagnostics > 0,
+            "a document past the cap must say so, not fall silent"
+        );
+        assert!(
+            blocks > 0,
+            "lowering and the CFG builder must produce a truncated-but-real \
+             result past the cap, not an empty one"
+        );
+    }
+}

--- a/rust/tcl-compiler/src/lowering/mod.rs
+++ b/rust/tcl-compiler/src/lowering/mod.rs
@@ -867,8 +867,17 @@ pub struct Lowerer<'r> {
 /// `tcl_compiler::analyser::commands::MAX_BODY_DEPTH` — all three
 /// independently-recursive walkers over the same source cap at the same
 /// depth, so no consumer of this crate depends on one pass reaching a
-/// deeper nesting level than another.
-const MAX_LOWER_NEST_DEPTH: tcl_core_types::RecursionLimit = tcl_core_types::RecursionLimit(256);
+/// deeper nesting level than another. All three now read that depth from
+/// [`crate::depth_guard::MAX_SOURCE_NEST_DEPTH`], which is where the three
+/// stopped being a shared *convention* and became a shared *budget*
+/// (issue #1654).
+///
+/// This walk is the one the budget is sized by: at eight Rust frames per
+/// nesting level it costs about 18.4 KiB a level, more than twice either
+/// sibling, and it is the walk whose recursion the ~400-nested-`foreach`
+/// reproducer aborted on.
+const MAX_LOWER_NEST_DEPTH: tcl_core_types::RecursionLimit =
+    crate::depth_guard::MAX_SOURCE_NEST_DEPTH;
 
 impl<'r> Lowerer<'r> {
     /// Create a new lowerer with the default (Tcl-8.5+) lexer config.

--- a/rust/tcl-compiler/src/optimiser/mod.rs
+++ b/rust/tcl-compiler/src/optimiser/mod.rs
@@ -83,15 +83,18 @@ use crate::compilation_unit::CompilationUnit;
 ///
 /// In the normal pipeline these passes only ever see IR produced by
 /// [`crate::lowering`], which already caps *its own* recursive descent at
-/// `MAX_LOWER_NEST_DEPTH` (256) and emits a `Statement::Barrier` (a leaf, not
-/// a further-nested body) past that point — so a pass walking
-/// lowering-produced IR can never actually be handed more than 256 levels of
-/// nesting today. This constant guards each pass independently anyway
-/// (matching the number, so it never trips before lowering's own cap would
-/// have already flattened the input): defence in depth against any future or
-/// test-only caller that builds a `Script` directly rather than through
-/// [`crate::lowering`], and — unlike relying solely on the caller's cap —
-/// keeps each pass safe to reason about in isolation.
+/// `MAX_LOWER_NEST_DEPTH` and emits a `Statement::Barrier` (a leaf, not a
+/// further-nested body) past that point — so a pass walking
+/// lowering-produced IR can never actually be handed more than that many
+/// levels of nesting today, and since issue #1654 that is
+/// [`crate::depth_guard::MAX_SOURCE_NEST_DEPTH`], comfortably under this
+/// number rather than equal to it. This constant guards each pass
+/// independently anyway (at or above lowering's, so it never trips before
+/// lowering's own cap would have already flattened the input): defence in
+/// depth against any future or test-only caller that builds a `Script`
+/// directly rather than through [`crate::lowering`], and — unlike relying
+/// solely on the caller's cap — keeps each pass safe to reason about in
+/// isolation.
 pub(crate) const MAX_OPTIMISER_WALK_DEPTH: tcl_core_types::RecursionLimit =
     tcl_core_types::RecursionLimit(256);
 use crate::interprocedural::InterproceduralAnalysis;

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -5739,6 +5739,35 @@ mod class_factories {
     }
 
     #[test]
+    fn four_hundred_nested_foreach_bodies_do_not_abort_the_process() {
+        // Issue #1654, on this test's own default-sized thread — which is
+        // the whole point: the walks this drives must contain themselves on
+        // the 2 MiB every unremarkable caller gets, not only on the 64 MiB
+        // the CLI and the LSP worker ask for. No parameterised creation
+        // anywhere in the file, so none of the machinery above runs; this
+        // is the plain braced-body descent, whose caps were hand-picked at
+        // 256 and wanted about 4.6 MiB to reach it.
+        //
+        // Past the cap the analyser abstains with a notice rather than
+        // truncating in silence, so the assertion is E207 and a returned
+        // result — not a resolution of anything inside.
+        let src: String = (0..400)
+            .map(|i| format!("foreach v{i} {{a b}} {{\n"))
+            .chain(std::iter::once("set inner 1\n".to_owned()))
+            .chain((0..400).map(|_| "}\n".to_owned()))
+            .collect();
+        let codes: Vec<_> = analysis(&src, "tcl9.0")
+            .diagnostics
+            .iter()
+            .map(|d| d.code.to_string())
+            .collect();
+        assert!(
+            codes.iter().any(|code| code == "E207"),
+            "past the cap the walk must say it stopped; got {codes:?}"
+        );
+    }
+
+    #[test]
     fn deeply_nested_collection_loops_do_not_blow_the_static_walk_stack() {
         // Native-stack safety net (#996's family) for the relaxation above:
         // the fall-through walk re-enters itself once per control body it
@@ -5749,13 +5778,14 @@ mod class_factories {
         // direction it already takes for anything it cannot read — so this
         // asserts termination and a well-formed result, not a resolution.
         //
-        // 64 is many times the cap (8) and far below the analyser's own
-        // whole-body nesting limit (`MAX_BODY_DEPTH`, 256), so a failure here
-        // is this walk's recursion and not the generic one's.
-        let nest: String = (0..64)
+        // 40 is many times this walk's cap (8) and comfortably below the
+        // braced-body descent's own limit (`MAX_BODY_DEPTH`, derived from a
+        // stack budget in `depth_guard` — see issue #1654), so a failure
+        // here is this walk's recursion and not the generic one's.
+        let nest: String = (0..40)
             .map(|i| format!("    foreach v{i} {{a b}} {{\n"))
             .chain(std::iter::once("    set zz 1\n".to_owned()))
-            .chain((0..64).map(|_| "    }\n".to_owned()))
+            .chain((0..40).map(|_| "    }\n".to_owned()))
             .collect();
         let src = COMPUTED_METACLASS.replace(
             "    ::T::Mother create ${NSPACE}::class { superclass ::T::Mother }\n",

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -4541,7 +4541,7 @@ mod report_scoped_commands {
 // ===========================================================================
 mod class_factories {
     use super::*;
-    use tcl_compiler::analyser::{AnalysisResult, ClassDef};
+    use tcl_compiler::analyser::{AnalysisResult, ClassDef, MetaclassProvenance};
 
     fn analysis(src: &str, dialect: &str) -> AnalysisResult {
         Analyser::new().analyse(src, dialect)
@@ -5861,6 +5861,160 @@ mod class_factories {
             !result.all_classes.contains_key("::T::${ns}::class"),
             "the unresolved placeholder must be retracted; got {:?}",
             result.all_classes.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn a_later_define_stub_does_not_cost_the_metaclass_its_factory() {
+        // TP (#1653) — an `oo::define` on the computed-name class creates a
+        // stub whose `metaclass` was never written, so it holds
+        // `ClassDef::default()`'s `"oo::class"`. That default is not an
+        // observation: joining it against the proved `::T::Mother` must not
+        // read as two walks disagreeing, which used to abstain the record
+        // down to `factory: None` with no superclasses.
+        let src =
+            format!("{COMPUTED_METACLASS}::oo::define ::T::D::class {{ method m {{}} {{}} }}\n");
+        let result = analysis(&src, "tcl9.0");
+        let class = result
+            .all_classes
+            .get("::T::D::class")
+            .expect("the resolved metaclass must still be recorded");
+        assert_eq!(
+            class.superclasses.as_slice(),
+            &["::T::Mother".to_owned()][..],
+            "the proved superclass must survive the stub join"
+        );
+        assert!(
+            result.class_factories().contains_key("::T::D::class"),
+            "the resolved metaclass must keep its factory; factories={:?}",
+            result.class_factories().keys().collect::<Vec<_>>()
+        );
+        assert!(
+            class.metaclass.ends_with("T::Mother"),
+            "the joined record must name the metaclass the source wrote, \
+             not the default stand-in; got {:?}",
+            class.metaclass
+        );
+        assert!(
+            class.methods.contains_key("m"),
+            "the stub's own member must still land; methods={:?}",
+            class.methods.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !class.via_define,
+            "the class is created in this file, so it is not an extension stub"
+        );
+    }
+
+    #[test]
+    fn a_define_stub_replaces_a_member_the_creation_body_also_declared() {
+        // #1653 — the two records the join unions are ordered whenever one
+        // of them is an `oo::define`: the class has to exist before it can
+        // be extended, so the stub ran second and its `method m` replaces.
+        // tclsh 8.6.16 on the same shape answers `{a b} …` for
+        // `info class definition ::T::D::class m`.
+        let src = format!(
+            "{}::oo::define ::T::D::class {{ method m {{a b}} {{}} }}\n",
+            COMPUTED_METACLASS.replace(
+                "    ::T::Mother create ${NSPACE}::class { superclass ::T::Mother }\n",
+                "    ::T::Mother create ${NSPACE}::class {\n\
+                 \x20       superclass ::T::Mother\n\
+                 \x20       method m {a} {}\n\
+                 \x20   }\n",
+            )
+        );
+        let result = analysis(&src, "tcl9.0");
+        let method = result
+            .all_classes
+            .get("::T::D::class")
+            .and_then(|class| class.methods.get("m"))
+            .expect("the contested member is recorded once");
+        assert_eq!(
+            method.params.len(),
+            2,
+            "the `oo::define` body's declaration is the live one; got {:?}",
+            method.params
+        );
+    }
+
+    #[test]
+    fn two_creations_naming_one_class_under_different_metaclasses_abstain() {
+        // FP guard for #1653 at the source level: the gate added there must
+        // stay a statement about *unobserved* metaclasses only. Both of
+        // these creations read a head word, and they disagree, so the
+        // record must still abstain — no factory, inheritance unknown —
+        // exactly as it did before the gate existed. Without this, dropping
+        // the `metaclass_provenance: Observed` at the creation site is invisible.
+        let src = concat!(
+            "namespace eval ::T {}\n",
+            "oo::class create ::T::MotherA { superclass oo::class }\n",
+            "oo::class create ::T::MotherB { superclass oo::class }\n",
+            "::T::MotherA create ::T::D::class { method m {} {} }\n",
+            "proc ::T::mk {name} {\n",
+            "    ::T::MotherB create ${name}::class { method m {} {} }\n",
+            "}\n",
+            "::T::mk ::T::D\n",
+        );
+        let result = analysis(src, "tcl9.0");
+        let class = result
+            .all_classes
+            .get("::T::D::class")
+            .expect("the contested class is still recorded");
+        assert!(
+            class.superclasses.is_empty()
+                && class.metaclass_provenance == MetaclassProvenance::Observed,
+            "both bodies declare no superclass, so the metaclass is the only \
+             thing this pair disagrees about"
+        );
+        assert!(
+            class.inheritance_unknown,
+            "two observed, disagreeing metaclasses must abstain the record"
+        );
+        assert!(
+            class.factory.is_none(),
+            "an abstaining record must publish no factory"
+        );
+    }
+
+    #[test]
+    fn a_define_stub_that_wins_the_join_still_sheds_its_stub_provenance() {
+        // The mirror of the case above (#1653): the stub declares the
+        // superclass and the creation body does not, so the *stub* is the
+        // more complete observation and wins the join. It is still not a
+        // cross-file extension record — this file creates the class — and
+        // the creation observation's own facts must survive underneath it.
+        let src = format!(
+            "{}::oo::define ::T::D::class {{ superclass ::T::Mother }}\n",
+            COMPUTED_METACLASS.replace(
+                "    ::T::Mother create ${NSPACE}::class { superclass ::T::Mother }\n",
+                "    ::T::Mother create ${NSPACE}::class { method m {} {} }\n",
+            )
+        );
+        let result = analysis(&src, "tcl9.0");
+        let class = result
+            .all_classes
+            .get("::T::D::class")
+            .expect("the resolved metaclass must still be recorded");
+        assert_eq!(
+            class.superclasses.as_slice(),
+            &["::T::Mother".to_owned()][..],
+            "the stub's superclass must survive"
+        );
+        assert!(
+            class.methods.contains_key("m"),
+            "the creation body's member must survive the stub winning; methods={:?}",
+            class.methods.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            class.metaclass.ends_with("T::Mother")
+                && class.metaclass_provenance == MetaclassProvenance::Observed,
+            "the winning stub never read a metaclass, so it must adopt the \
+             one the creation observed; got {:?}",
+            class.metaclass
+        );
+        assert!(
+            !class.via_define,
+            "a record one of whose observations is the creation is not a stub"
         );
     }
 

--- a/rust/tcl-lsp-core/src/declaration.rs
+++ b/rust/tcl-lsp-core/src/declaration.rs
@@ -42,9 +42,16 @@ use tcl_registry::CommandRegistry;
 use tcl_registry::arg_role::ArgRole;
 
 /// Recursion depth guard for nested body walks — a defensive stack-overflow
-/// bound, set to match the compiler analyser's `MAX_BODY_DEPTH` so deeply (but
-/// validly) nested code keeps full go-to-declaration support. Real source never
-/// nests anywhere near this.
+/// bound, kept at or above the compiler analyser's own `MAX_BODY_DEPTH` so
+/// deeply (but validly) nested code keeps full go-to-declaration support.
+/// Real source never nests anywhere near this.
+///
+/// It used to be the same 256 that cap was; since issue #1654 the compiler
+/// derives its number from a stack budget and lands well below this one, so
+/// a body tree this walk receives from the analyser can no longer reach
+/// here at all. The bound stays as defence-in-depth against a tree built or
+/// received some other way — the same role
+/// `document_symbols`' `MAX_SCOPE_WALK_DEPTH` plays.
 const MAX_BODY_DEPTH: tcl_core_types::RecursionLimit = tcl_core_types::RecursionLimit(256);
 
 use crate::definition::{LspRange, byte_offset_at, definition, scope_body_spans_at, span_to_range};

--- a/rust/tcl-lsp-core/src/document_symbols.rs
+++ b/rust/tcl-lsp-core/src/document_symbols.rs
@@ -1227,7 +1227,9 @@ mod tests {
     /// recurse once per nested namespace/proc scope, with no depth cap
     /// before this fix (`MAX_SCOPE_WALK_DEPTH`, `crate::lib`). A `Scope`
     /// tree built by the real analyser can never exceed its own
-    /// `MAX_BODY_DEPTH` (256) in practice, so this exercises deep-but-valid
+    /// `MAX_BODY_DEPTH` (256 when this was written; derived from a stack
+    /// budget and lower still since issue #1654), so this exercises
+    /// deep-but-valid
     /// nesting rather than this crate's own cap tripping — that cap is
     /// defence-in-depth against a scope tree built/received some other way.
     ///

--- a/rust/tcl-lsp-server/tests/e2e/issue996_stack_overflow.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue996_stack_overflow.rs
@@ -21,8 +21,9 @@
 //! nested 100-150 levels deep.
 //!
 //! Root cause (confirmed empirically, not just inferred): the analyser's
-//! `analyse_body` recursion is correctly bounded by `MAX_BODY_DEPTH` (256),
-//! but 256 real Rust stack frames of that recursive chain need more stack
+//! `analyse_body` recursion is correctly bounded by `MAX_BODY_DEPTH` (256 at
+//! the time), but 256 real Rust stack frames of that recursive chain need
+//! more stack
 //! than Tokio's default 2 MiB worker-thread stack provides — the thread the
 //! native LSP server actually runs analysis on via `tokio::spawn`. `ulimit -s
 //! 2048` against the *unfixed* binary reproduces a crash at nesting depth
@@ -30,6 +31,14 @@
 //! main.rs` now builds its Tokio runtime with a 64 MiB `thread_stack_size`,
 //! which eliminates it (verified: the same pathological input survives at
 //! every depth up to and well past the analyser's own cap).
+//!
+//! Issue #1654 later closed the other half: a big stack made the *shipped*
+//! entry points safe, but the cap itself still did not fit the 2 MiB any
+//! ordinary caller gets, and the lowering walk — fatter per level than
+//! `analyse_body`, and never in this suite's frame — aborted on ~400 nested
+//! `foreach` bodies. The braced-body caps are now derived from that budget
+//! in `tcl_compiler::depth_guard`, so they trip before the stack runs out
+//! rather than long after; the 64 MiB here remains as headroom.
 //!
 //! This suite drives the real, packaged native server (not the analyser
 //! library function directly — a unit test calling `Analyser::analyse` runs
@@ -88,7 +97,7 @@ fn nested_if_at_reported_crash_depth_survives_and_returns_diagnostics() {
     lsp.await_diagnostics(&other_uri);
 }
 
-/// Depth well past the analyser's own `MAX_BODY_DEPTH` cap (256) — the
+/// Depth well past the analyser's own `MAX_BODY_DEPTH` cap — the
 /// adversarial/`DoS` shape the issue calls out (deeply-nested generated /
 /// minified Tcl). Must still survive and respond within the harness's
 /// default timeout, not hang or abort.


### PR DESCRIPTION
## Summary

Two issues, two commits. Both are cases of a fact that was fabricated somewhere and then read as if it had been established.

### `fix(analyser)` — Fixes #1653

`join_parameterised_class_observations` compared both records' `metaclass` as evidence. `ClassDef::default()` fabricates exactly one concrete-looking value — `metaclass: "oo::class"` — and an `oo::define` stub for a class the walk has not yet named carries it having read nothing. A computed-name class made by a user metaclass therefore looked like two walks disagreeing, the join abstained, and the record lost its factory and its superclasses.

Only facts a walk established may take part in conflict detection, so the one field whose default is not its own "nothing observed" reading gets the one entry of observed-fields mask it needs: `ClassDef::metaclass_provenance`, set to `Observed` exactly where a creation command's head word is read (`oo::class create` and friends, `snit::type`, `itcl::class`). A two-variant enum rather than a flag because the interesting half is what the *default* means, and `StandIn` says it: a stand-in constrains nothing in a join and the observing side's answer is adopted, while two `Observed` sides that disagree abstain exactly as before.

Fixing the join then exposed the other half of the same bug. The join picks a winner wholesale, so the losing record's members were dropped — invisible while the metaclass mismatch abstained the whole join back onto the stub, which is what had been keeping them. Measured on the issue's reproducer, `COMPUTED_METACLASS` plus `::oo::define ::T::D::class { method m {} {} }`:

| `::T::D::class` | before | metaclass gate only | this branch |
|---|---|---|---|
| `superclasses` | `[]` | `["::T::Mother"]` | `["::T::Mother"]` |
| `factory` | absent | published | published |
| `methods` | `["m"]` | `[]` | `["m"]` |
| `inheritance_unknown` | `true` | `false` | `false` |

So `ClassDef::absorb_declarations` takes every declaration the loser makes that the winner lacks. Three rules, one per kind of field, chosen so the *original* case — two observations of one body — stays a no-op: keyed tables and export sets union; the ordered relations a definition body *sets* (`mixins`, `variables`, `filters`, `class_filters`, constructors, destructor) follow the empty-is-a-lower-bound rule `superclasses` already uses in this join, since `oo::define C { mixin M }` replaces the slot rather than appending to it; append-only records gain what they lack. Its `other` is destructured exhaustively, so a field added to `ClassDef` has to be classified before it compiles.

A key both records declare goes to the `via_define` one. That is not a tie-break, it is the order: an `oo::define` extending a class necessarily runs after the creation it extends, and its declaration replaces rather than adds. tclsh 8.6.16, on the same shape:

```
Mother create ::D::class { method m {a} … }
oo::define ::D::class { method m {a b} … }
info class definition ::D::class m   =>   {a b} { … }
```

`via_define` also clears in the join: one of the two observations *is* the creation, so the joined record is not a cross-file extension stub and go-to-definition must still prefer this file.

### `fix(compiler)` — Fixes #1654

Three walks descend once per `{ … }` nesting level over the same document — `lowering`'s `lower_body` chain, `cfg_builder`'s `lower_script`, the analyser's `analyse_body` — and each carried its own hand-picked 256, documented both as matching this crate's full-tree convention and as a guard against overflowing the native stack. It was never the second thing. A stack-pointer probe at each walk's depth-guarded entry, dev profile, x86-64 Linux:

| walk | bytes per nesting level |
|---|---|
| `Lowerer::lower_body` / `lower_segmented` / `lower_command` / `lower_foreach` | 18,864 |
| `CfgBuilder::lower_script` | 8,288 |
| `Analyser::analyse_body` | 3,840 |

At 18,864 bytes a level the lowering walk wants about 4.6 MiB to reach 256 — more than twice the 2 MiB a default thread has. So ~400 nested `foreach` bodies aborted the process at roughly level 112, with the cap that exists to prevent exactly that still 144 levels away. Confirmed under gdb: 900-odd frames of `lower_body` → `lower_body_in_irules_context` → `lower_body_inner` → `lower_segmented` → `lower_command` → `try_dispatch_structured_hook` → `lower_foreach` → `lower_body_from_tok`, eight per level, and **no analyser frame in the trace at all**. #996 gave the shipped entry points 64 MiB, which is why this never showed up there; the cap itself still did not fit the stack any ordinary caller gets.

The cap is now derived instead of chosen. `depth_guard` — already this crate's home for the #996 native-stack caps — states three inputs separately, each re-measurable on its own: `MIN_SOURCE_WALK_STACK` (2 MiB, the platform default thread — a cap is a property of the walk, and a host embedding this crate owes us no courtesy), `SOURCE_WALK_STACK_RESERVE` (a quarter, for everything on the stack that is not the descent), and `SOURCE_WALK_BYTES_PER_LEVEL` (20 KiB, the worst measured cost rounded up). `MAX_SOURCE_NEST_DEPTH` is what they pay for, and all three caps read it.

Behaviour past the cap is unchanged — the lowering emits its `Statement::Barrier` for the unread region, the analyser reports `E207` and stops descending — it simply arrives before the stack runs out instead of long after.

`depth_guard::tests::the_source_walk_cap_fits_its_stack_budget` re-checks the claim rather than restating it: a document nested four times deeper than the cap is analysed on a thread sized to the budget, so it answers two questions at once — every walk on that path stops at the shared cap, and the whole descent fits the budget the cap was divided out of. It is given `MIN_SOURCE_WALK_STACK - SOURCE_WALK_STACK_RESERVE` and not the whole 2 MiB, which is what makes passing it evidence that the reserve is spare. Frame growth in any of the three walks now fails a test instead of resurfacing as an abort in someone's editor.

## Validation

All from `rust/` unless noted, every invocation prefixed `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=2`.

- [x] `cargo fmt --all --check` — clean, in `rust/` and in `runtime/rust/`
- [x] `cargo clippy -p tcl-compiler --all-targets` — no warnings
- [x] `cargo clippy -p tcl-lsp-core -p tcl-lsp-server --all-targets` — no warnings
- [x] `cargo check --workspace` — clean
- [x] `cargo test -p tcl-compiler` — green (5,895 lib + 484 analyser + the rest)
- [x] `cargo test -p tcl-lsp-core` — green
- [x] `cargo test -p tcl-lsp-db` — green
- [x] `cargo test -p tcl-lsp-server` — green, including the `issue996_stack_overflow` e2e suite (140 / 150 / 500 / 2000-level nesting through the real server)
- [x] `cargo test -p tcl-registry -p tcl-spectcl` — green
- [x] `cargo xtask kcs-index-links` / `owner-resolution` / `resolution-drift` — OK
- [x] `cargo check -p tcl-compiler --all-targets` at the first commit alone — the branch is bisectable

Semantics rulings from `tmp/tcl8616-install/bin/tclsh8.6` (8.6.16), cited inline where they are used: an `oo::define` method replaces a same-named one from the creation body; a second creation under a name already taken raises `can't create object "…": command already exists with that name`.

Mutation-verified after committing, **18 mutants across two batteries, 17 killed and 1 proven equivalent**, with the first battery re-run after the second fix.

#1653 — 12 mutants, 11 killed:

- drop the observed gate entirely (restores the bug); gate on *either* side observed; gate never conflicting; `Default` claims the stand-in was observed; the creation site stops recording `Observed`; drop the metaclass adoption in the join; `via_define` joined with `|` instead of `&`; drop the declaration union; the stub never wins a colliding key; the ordered relations always overwrite; drop the export-set union.
- Three of these survived a first pass and drove three extra tests: `two_creations_naming_one_class_under_different_metaclasses_abstain` (an FP guard at source level, with both bodies declaring no superclass so the metaclass is the only disagreement), an assertion that the winning stub adopts the observed metaclass, and a unit test over `absorb_declarations` covering one field per rule.
- The survivor — *the loser always wins a colliding key* — is **provably equivalent** on reachable inputs, and the oracle is the proof: where neither record is a `via_define` stub the two are readings of one body, because a second creation under a taken name never runs (`can't create object …`). The rule stays as written; `a_define_stub_replaces_a_member_the_creation_body_also_declared` is the positive control that keeps the branch from going inert, and the "stub never replaces" mutant is killed by it.

#1654 — 6 mutants, all killed:

- understate `SOURCE_WALK_BYTES_PER_LEVEL`; `MAX_LOWER_NEST_DEPTH` back to 256; `MAX_BODY_DEPTH` back to 256; the reserve to zero; `MAX_LOWER_DEPTH` back to 256; suppress the `E207` notice (silent truncation).
- Two survived a first pass. The lowering-cap mutant escaped a budget test that only nested to the cap, which is why that test now nests four times past it; and the analyser-cap mutant escaped because 256 of *its* frames do fit, which is why `the_analyser_stops_at_the_shared_cap` now pins which cap it obeys rather than only that it has one. The reserve mutant needed a floor assertion, since the budget test sizes its thread from the reserve and so cannot judge it.
- `MAX_LOWER_DEPTH` (cfg-builder) is unreachable through the pipeline — `lowering`'s copy of the number already bounds the IR handed to it — so its mutant is killed only via the shared-cap tests; the code comment now records that it is defence-in-depth for a host that builds a `Module` some other way, and that its 8,288 bytes a level is what the budget must still afford that caller.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? Yes, twice: what counts as an observed field on a `ClassDef` for the computed-name join, and the depth at which every braced-body walk stops.
- [x] `docs/design/compiler/recursive-descent-depth-limits.md` gains strategy (5) — a cap over a source-nesting walk is arithmetic against a stack budget, not a convention number — with the measurements, and its cap table now names `MAX_SOURCE_NEST_DEPTH` for the three walks that read it. This is the drift its own "Problem 1" section predicted ("the *actual* frame cost … silently grows every time a hot function in it gains a local variable"), observed. The #1653 contract lives on `ClassDef::metaclass_provenance` and `ClassDef::absorb_declarations`, which is where the record's per-field knowledge lives.
- [x] No diagnostic or optimisation code added or changed — `E207` keeps its meaning and its wording, and its trip point was already documented as a cap rather than a number — so no `docs/kcs/codes/` page moves.
- [x] No new design doc, so no `docs/design/README.md` link needed (`cargo xtask kcs-index-links` passes).

## Notes for review

- **The new cap is well below 256.** That is the point, and nothing hand-written comes close, but it is the one behavioural change here that is not a bug fix: a document nested past it now gets `E207` and a `Barrier` where it previously got a full walk (on a big-enough stack) or an abort (on any other). The #996 e2e suite, which drives the real server at 140 / 150 / 500 / 2000 levels, is unchanged and green.
- **Three prose references to the old 256 were corrected** rather than left to rot — `tcl_lsp_core::declaration`'s local copy (kept at 256, now explicitly defence-in-depth and no longer claiming to match), `document_symbols`' comment, and `optimiser::MAX_OPTIMISER_WALK_DEPTH`'s "can never be handed more than 256 levels". The #996 e2e header records that #1654 closed the half a big stack could not.
- **`ClassDef` gained a field.** `absorb_declarations` destructures it exhaustively, so the next field added must be classified there; the alternative — a fresh field silently dropped by every join — is the failure this branch is fixing.
- **`MetaclassProvenance` is exported** from `tcl_compiler::analyser` alongside `ClassDef`. Nothing outside this crate reads it yet.

## Findings not fixed here

- **A metaclass proved by the post-pass cannot classify a creation call in its own file.** `::T::D::class create ::T::W {…}` after the resolving call site leaves `::T::W` unrecorded, because `materialise_parameterised_class` runs after the walk that would have classified it. Identical before and after every change here, and orthogonal to both issues; wants its own issue.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o)_