### PR TITLE
fix(vm): give the wasm VM a JavaScript clock, so the browser language server stops trapping (#1661)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4602,6 +4602,7 @@ version = "0.1.0"
 name = "tcl-vm"
 version = "0.1.0"
 dependencies = [
+ "js-sys",
  "num-bigint 0.5.1",
  "num-integer",
  "num-traits",

--- a/rust/tcl-explorer-wasm/Cargo.lock
+++ b/rust/tcl-explorer-wasm/Cargo.lock
@@ -90,6 +90,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +127,17 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -155,6 +190,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro2"
@@ -268,6 +309,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "syn"
@@ -482,6 +529,7 @@ version = "0.1.0"
 name = "tcl-vm"
 version = "0.1.0"
 dependencies = [
+ "js-sys",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -490,6 +538,7 @@ dependencies = [
  "tcl-core-types",
  "tcl-dialect",
  "tcl-host-native",
+ "tcl-lexer",
  "tcl-platform",
  "tcl-regex",
  "tcl-registry",

--- a/rust/tcl-lsp-server-wasm/Cargo.lock
+++ b/rust/tcl-lsp-server-wasm/Cargo.lock
@@ -1591,6 +1591,7 @@ version = "0.1.0"
 name = "tcl-vm"
 version = "0.1.0"
 dependencies = [
+ "js-sys",
  "num-bigint 0.5.1",
  "num-integer",
  "num-traits",
@@ -1599,6 +1600,7 @@ dependencies = [
  "tcl-core-types",
  "tcl-dialect",
  "tcl-host-native",
+ "tcl-lexer",
  "tcl-platform",
  "tcl-regex",
  "tcl-registry",

--- a/rust/tcl-spec-studio-wasm/Cargo.lock
+++ b/rust/tcl-spec-studio-wasm/Cargo.lock
@@ -1217,6 +1217,7 @@ version = "0.1.0"
 name = "tcl-vm"
 version = "0.1.0"
 dependencies = [
+ "js-sys",
  "num-bigint 0.5.1",
  "num-integer",
  "num-traits",
@@ -1225,6 +1226,7 @@ dependencies = [
  "tcl-core-types",
  "tcl-dialect",
  "tcl-host-native",
+ "tcl-lexer",
  "tcl-platform",
  "tcl-regex",
  "tcl-registry",

--- a/rust/tcl-vm-wasm/Cargo.toml
+++ b/rust/tcl-vm-wasm/Cargo.toml
@@ -41,7 +41,15 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-tcl-vm = { path = "../tcl-vm" }
+# `default-features = false` drops `tcl-vm`'s `js-clock`, and with it the only
+# import this module would otherwise have. `js-clock` reads the wall clock from
+# JavaScript's `Date.now()` — right for the wasm-bindgen consumers (the language
+# server, the explorer, the spec studio), fatal here: this cdylib is loaded by a
+# bare `WebAssembly.instantiate` with no glue object, so a `js-sys` import makes
+# instantiation itself fail ("Import #0 module=__wbindgen_placeholder__"). The
+# VM's browser host then reports the epoch instead, which is what it did before
+# there was a clock to choose at all. `tcl-vm/tests/wasm_coro_e2e.rs` guards it.
+tcl-vm = { path = "../tcl-vm", default-features = false }
 tcl-compiler = { path = "../tcl-compiler" }
 tcl-registry = { path = "../tcl-registry" }
 tcl-bytecode = { path = "../tcl-bytecode" }

--- a/rust/tcl-vm/Cargo.toml
+++ b/rust/tcl-vm/Cargo.toml
@@ -68,10 +68,29 @@ num-traits = "0.2"
 # The browser half of the capability seam (`src/host_wasm.rs`), which is the
 # `Vm`'s default host on `wasm32-unknown-unknown`: there is no OS under that
 # target and `std::time::SystemTime::now` panics, so the wall clock has to come
-# from JavaScript's `Date.now()` (issue #1661). Target-gated so no native build
-# — and no `wasm32-wasip1` build, where std time works — carries wasm-bindgen.
+# from somewhere else (issue #1661). Target-gated so no native build — and no
+# `wasm32-wasip1` build, where std time works — carries wasm-bindgen.
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
-js-sys = "0.3"
+js-sys = { version = "0.3", optional = true }
+
+[features]
+# `js-clock` sources that wall clock from JavaScript's `Date.now()`, which is
+# what every wasm-bindgen consumer of this VM wants — the language server, the
+# compiler explorer and the spec studio all run inside a page that has one.
+# On by default so those three (which reach `tcl-vm` six crates deep, through
+# `tcl-spectcl` → `tcl-spec-hooks` → `tcl-engine-tclvm`) need no feature
+# plumbing at all.
+#
+# Turning it OFF leaves the browser host with a clock that reports the epoch
+# rather than one that panics, and — the point of the switch — leaves the wasm
+# module with **no imports whatsoever**. `tcl-vm-wasm` is built on exactly that
+# promise ("NO host imports and NO WASI"): it is instantiated by a bare
+# `WebAssembly.instantiate` with no wasm-bindgen glue, so a `js-sys` import
+# would make the module refuse to instantiate at all. It opts out with
+# `default-features = false`, and `tests/wasm_coro_e2e.rs` is the gate that
+# fails loudly if anything reintroduces an import.
+default = ["js-clock"]
+js-clock = ["dep:js-sys"]
 
 [dev-dependencies]
 # End-to-end tests compile real Tcl to bytecode then run it. Dev-only, so the

--- a/rust/tcl-vm/Cargo.toml
+++ b/rust/tcl-vm/Cargo.toml
@@ -65,6 +65,14 @@ num-bigint = "0.5"
 num-integer = "0.1"
 num-traits = "0.2"
 
+# The browser half of the capability seam (`src/host_wasm.rs`), which is the
+# `Vm`'s default host on `wasm32-unknown-unknown`: there is no OS under that
+# target and `std::time::SystemTime::now` panics, so the wall clock has to come
+# from JavaScript's `Date.now()` (issue #1661). Target-gated so no native build
+# — and no `wasm32-wasip1` build, where std time works — carries wasm-bindgen.
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+js-sys = "0.3"
+
 [dev-dependencies]
 # End-to-end tests compile real Tcl to bytecode then run it. Dev-only, so the
 # library itself stays off the compiler (CompileService is the runtime seam).

--- a/rust/tcl-vm/src/host_wasm.rs
+++ b/rust/tcl-vm/src/host_wasm.rs
@@ -19,7 +19,7 @@
 //! [`BrowserHost`] — the capability [`Host`] for `wasm32-unknown-unknown`.
 //!
 //! The other half of the seam [`host_native`](crate::host_native) owns, and the
-//! [`Vm`](crate::interp::Vm)'s default host wherever there is no operating
+//! [`Vm`](crate::Vm)'s default host wherever there is no operating
 //! system underneath: a browser tab, a Web Worker, a bare `WebAssembly`
 //! instantiation under node. `runtime/rust` has had this split since it learnt
 //! to link for wasm (`runtime/rust/src/host_wasm.rs`); this is the bytecode
@@ -43,7 +43,7 @@
 //! ## What each capability does here
 //!
 //! - **Clock** — real under the default `js-clock` feature, and the reason this
-//!   module is not a stub: the browser has a wall clock, so [`BrowserClock`]
+//!   module is not a stub: the browser has a wall clock, so `BrowserClock`
 //!   reads JavaScript's `Date.now()`. Millisecond resolution (what `Date.now()`
 //!   reports, and what browsers clamp to anyway), so `now_micros` keeps the
 //!   trait's `now_millis() * 1000` default rather than pretending to a
@@ -55,14 +55,13 @@
 //!   worker's `puts`; a host that wants the output owns the decision of where
 //!   it goes and can install its own [`Host`] with [`Vm::set_host`].
 //! - **Env** — empty, with `/` as the working directory. `std::env::vars` is
-//!   another `unsupported.rs` panic on this target, which is why
-//!   [`Vm::write_platform_globals`] already skips it here.
+//!   another `unsupported.rs` panic on this target, which is why the VM's
+//!   `write_platform_globals` already skips it here.
 //! - **Filesystem / process / sockets** — absent, so `tcl-cmd-core`'s portable
 //!   bodies take their documented "the platform cannot do this" path instead of
 //!   failing at a syscall.
 //!
-//! [`Vm::set_host`]: crate::interp::Vm::set_host
-//! [`Vm::write_platform_globals`]: crate::interp::Vm
+//! [`Vm::set_host`]: crate::Vm::set_host
 
 use tcl_platform::{Capabilities, Clock, Env, Host, HostError, StdIo};
 

--- a/rust/tcl-vm/src/host_wasm.rs
+++ b/rust/tcl-vm/src/host_wasm.rs
@@ -1,0 +1,166 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! [`BrowserHost`] — the capability [`Host`] for `wasm32-unknown-unknown`.
+//!
+//! The other half of the seam [`host_native`](crate::host_native) owns, and the
+//! [`Vm`](crate::interp::Vm)'s default host wherever there is no operating
+//! system underneath: a browser tab, a Web Worker, a bare `WebAssembly`
+//! instantiation under node. `runtime/rust` has had this split since it learnt
+//! to link for wasm (`runtime/rust/src/host_wasm.rs`); this is the bytecode
+//! VM's copy of the same decision, and it exists because the VM *runs* on that
+//! target now — the Tcl language server compiled to wasm evaluates `SpecTcl`
+//! pack hook bodies through it (`tcl_spectcl::hooks::ensure_thread_host`).
+//!
+//! Reaching [`NativeHost`](tcl_host_native::NativeHost) here is not a
+//! degradation, it is a **crash**: `std::time::SystemTime::now` on
+//! `wasm32-unknown-unknown` is `unsupported.rs`'s `panic!("time not implemented
+//! on this platform")`, and a wasm panic aborts (the module traps on
+//! `unreachable`) rather than unwinding, so every lock and refcount the aborted
+//! call held stays held. Issue #1661 is exactly that: the first bundled
+//! `.tclspec` to declare hook bodies (`specs/upf.tclspec`) made the language
+//! server build a hook host in the browser, `Vm::set_wall_clock_budget` read
+//! the native clock to arm its 250 ms budget, and the trap that followed
+//! stranded a salsa database handle — so the next input mutation blocked in
+//! `Storage::cancel_others` and panicked a second time inside parking_lot's
+//! `wasm` thread parker.
+//!
+//! ## What each capability does here
+//!
+//! - **Clock** — real, and the reason this module is not a stub: the browser
+//!   has a wall clock, so [`BrowserClock`] reads JavaScript's `Date.now()`.
+//!   Millisecond resolution (what `Date.now()` reports, and what browsers clamp
+//!   to anyway), so `now_micros` keeps the trait's `now_millis() * 1000`
+//!   default rather than pretending to a precision it does not have.
+//! - **`StdIo`** — discarded. There is no terminal on the other end of a
+//!   worker's `puts`; a host that wants the output owns the decision of where
+//!   it goes and can install its own [`Host`] with [`Vm::set_host`].
+//! - **Env** — empty, with `/` as the working directory. `std::env::vars` is
+//!   another `unsupported.rs` panic on this target, which is why
+//!   [`Vm::write_platform_globals`] already skips it here.
+//! - **Filesystem / process / sockets** — absent, so `tcl-cmd-core`'s portable
+//!   bodies take their documented "the platform cannot do this" path instead of
+//!   failing at a syscall.
+//!
+//! [`Vm::set_host`]: crate::interp::Vm::set_host
+//! [`Vm::write_platform_globals`]: crate::interp::Vm
+
+use tcl_platform::{Capabilities, Clock, Env, Host, HostError, StdIo};
+
+/// The browser/bare-wasm host: a real JS wall clock, and nothing else.
+pub struct BrowserHost {
+    clock: BrowserClock,
+    stdio: BrowserStdIo,
+    env: BrowserEnv,
+}
+
+impl BrowserHost {
+    /// Create the host.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            clock: BrowserClock,
+            stdio: BrowserStdIo,
+            env: BrowserEnv,
+        }
+    }
+}
+
+impl Default for BrowserHost {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Host for BrowserHost {
+    fn capabilities(&self) -> Capabilities {
+        // No filesystem, sockets, or subprocess in a browser tab.
+        Capabilities::empty()
+    }
+
+    fn clock(&self) -> &dyn Clock {
+        &self.clock
+    }
+
+    fn stdio(&self) -> &dyn StdIo {
+        &self.stdio
+    }
+
+    fn env(&self) -> &dyn Env {
+        &self.env
+    }
+    // filesystem()/sockets()/process() keep the trait's `None` defaults.
+}
+
+/// The wall clock, read from JavaScript's `Date.now()` — milliseconds since the
+/// Unix epoch, as an `f64`.
+///
+/// `Date.now()` is on the global object in a window, a worker, and node alike,
+/// so this needs no host import beyond `js-sys` and works in every context the
+/// language server's wasm build is loaded into.
+struct BrowserClock;
+
+impl Clock for BrowserClock {
+    fn now_secs(&self) -> i64 {
+        // `Date.now()` is an integral number of milliseconds; dividing before
+        // the cast keeps the seconds exact for every representable instant.
+        (js_sys::Date::now() / 1000.0) as i64
+    }
+
+    fn now_millis(&self) -> i128 {
+        js_sys::Date::now() as i128
+    }
+    // `now_micros` keeps the trait default (`now_millis() * 1000`): `Date.now()`
+    // has no sub-millisecond resolution to report.
+    //
+    // `local_offset_secs` keeps the trait default (0 = UTC), matching the std
+    // host — the browser knows its timezone, but wiring that is a behaviour
+    // change for `clock format`, not a crash fix.
+}
+
+/// `puts` output is discarded: a worker has no terminal, and an embedder that
+/// wants it installs its own host.
+struct BrowserStdIo;
+
+impl StdIo for BrowserStdIo {
+    fn write_stdout(&self, _bytes: &[u8]) {}
+    fn write_stderr(&self, _bytes: &[u8]) {}
+}
+
+/// No environment variables, and a fixed root working directory.
+struct BrowserEnv;
+
+impl Env for BrowserEnv {
+    fn get(&self, _key: &str) -> Option<String> {
+        None
+    }
+
+    fn set(&self, _key: &str, _val: &str) {}
+
+    fn vars(&self) -> Vec<(String, String)> {
+        Vec::new()
+    }
+
+    fn cwd(&self) -> Result<String, HostError> {
+        Ok("/".to_owned())
+    }
+
+    fn chdir(&self, _path: &str) -> Result<(), HostError> {
+        Err(HostError::Unsupported)
+    }
+}

--- a/rust/tcl-vm/src/host_wasm.rs
+++ b/rust/tcl-vm/src/host_wasm.rs
@@ -42,11 +42,15 @@
 //!
 //! ## What each capability does here
 //!
-//! - **Clock** — real, and the reason this module is not a stub: the browser
-//!   has a wall clock, so [`BrowserClock`] reads JavaScript's `Date.now()`.
-//!   Millisecond resolution (what `Date.now()` reports, and what browsers clamp
-//!   to anyway), so `now_micros` keeps the trait's `now_millis() * 1000`
-//!   default rather than pretending to a precision it does not have.
+//! - **Clock** — real under the default `js-clock` feature, and the reason this
+//!   module is not a stub: the browser has a wall clock, so [`BrowserClock`]
+//!   reads JavaScript's `Date.now()`. Millisecond resolution (what `Date.now()`
+//!   reports, and what browsers clamp to anyway), so `now_micros` keeps the
+//!   trait's `now_millis() * 1000` default rather than pretending to a
+//!   precision it does not have. With `js-clock` off — the import-free build
+//!   `tcl-vm-wasm` needs — it reports the epoch, which is a wrong answer rather
+//!   than a crash, and the posture `runtime/rust`'s `BrowserHost` has always
+//!   had.
 //! - **`StdIo`** — discarded. There is no terminal on the other end of a
 //!   worker's `puts`; a host that wants the output owns the decision of where
 //!   it goes and can install its own [`Host`] with [`Vm::set_host`].
@@ -107,14 +111,25 @@ impl Host for BrowserHost {
     // filesystem()/sockets()/process() keep the trait's `None` defaults.
 }
 
-/// The wall clock, read from JavaScript's `Date.now()` — milliseconds since the
-/// Unix epoch, as an `f64`.
+/// The wall clock.
 ///
-/// `Date.now()` is on the global object in a window, a worker, and node alike,
-/// so this needs no host import beyond `js-sys` and works in every context the
-/// language server's wasm build is loaded into.
+/// Under the default `js-clock` feature this is JavaScript's `Date.now()` —
+/// milliseconds since the Unix epoch, as an `f64`. `Date.now()` is on the
+/// global object in a window, a worker, and node alike, so it needs no host
+/// import beyond `js-sys` and works in every context the language server's wasm
+/// build is loaded into.
+///
+/// With `js-clock` off there is no JavaScript to ask (that build has no imports
+/// at all, by design), so it reports the epoch.
+///
+/// `now_micros` keeps the trait default (`now_millis() * 1000`) either way:
+/// `Date.now()` has no sub-millisecond resolution to report. So does
+/// `local_offset_secs` (0 = UTC), matching the std host — the browser knows its
+/// timezone, but wiring that is a behaviour change for `clock format`, not a
+/// crash fix.
 struct BrowserClock;
 
+#[cfg(feature = "js-clock")]
 impl Clock for BrowserClock {
     fn now_secs(&self) -> i64 {
         // `Date.now()` is an integral number of milliseconds; dividing before
@@ -125,12 +140,17 @@ impl Clock for BrowserClock {
     fn now_millis(&self) -> i128 {
         js_sys::Date::now() as i128
     }
-    // `now_micros` keeps the trait default (`now_millis() * 1000`): `Date.now()`
-    // has no sub-millisecond resolution to report.
-    //
-    // `local_offset_secs` keeps the trait default (0 = UTC), matching the std
-    // host — the browser knows its timezone, but wiring that is a behaviour
-    // change for `clock format`, not a crash fix.
+}
+
+#[cfg(not(feature = "js-clock"))]
+impl Clock for BrowserClock {
+    fn now_secs(&self) -> i64 {
+        0
+    }
+
+    fn now_millis(&self) -> i128 {
+        0
+    }
 }
 
 /// `puts` output is discarded: a worker has no terminal, and an embedder that

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -48,7 +48,17 @@ use crate::command::{BuiltinFn, Command, EnsembleDef, ProcDef, register_builtins
 use crate::error::TclError;
 use crate::expr::ExprEval;
 use crate::frame::{CallFrame, Local};
-use crate::host_native::NativeHost;
+// The default capability host, picked by target. Everywhere with an operating
+// system under it — including `wasm32-wasip1`, where `std::time` and `std::env`
+// both work — that is the full-capability std-backed `NativeHost`. On
+// `wasm32-unknown-unknown` there is no OS at all and `std::time::SystemTime::now`
+// *panics*, so the browser host reads the wall clock from JavaScript instead
+// (issue #1661). `runtime/rust`'s `Interp::new` has made the same split since it
+// learnt to link for wasm; this is the bytecode VM catching up.
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+use crate::host_native::NativeHost as DefaultHost;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use crate::host_wasm::BrowserHost as DefaultHost;
 use crate::value::Value;
 
 /// The proc-call recursion bound (C Tcl's default `interp recursionlimit`).
@@ -773,9 +783,13 @@ pub struct InterpState {
     oo_dispatch_depth: usize,
     /// The host environment: the capability seam (`tcl-platform`) through which
     /// every command reaches the filesystem, clock, env, stdio, subprocess, and
-    /// sockets. The bytecode VM is a native target, so this defaults to a
-    /// full-capability [`NativeHost`]; [`Vm::set_host`] swaps it (e.g. for a
-    /// sandboxed, WASM-posture host in capability tests). An `Rc` (not `Box`) so
+    /// sockets. Defaults to the host for the target being built: the
+    /// full-capability [`NativeHost`](crate::host_native::NativeHost) anywhere
+    /// with an operating system under it, and `host_wasm::BrowserHost` — a
+    /// JavaScript wall clock and nothing else — on `wasm32-unknown-unknown`,
+    /// where the std clock is a panic rather than a syscall (issue #1661).
+    /// [`Vm::set_host`] swaps it (e.g. for a sandboxed, WASM-posture host in
+    /// capability tests). An `Rc` (not `Box`) so
     /// a command can clone a handle and pass `&dyn Host` *alongside* a `&mut Vm`
     /// borrow (the VM is itself the `ValueOps` a shared helper takes).
     host: Rc<dyn Host>,
@@ -1344,7 +1358,7 @@ impl InterpState {
             recursion_depth: 0,
             control_fallback_depth: 0,
             oo_dispatch_depth: 0,
-            host: Rc::new(NativeHost::new()),
+            host: Rc::new(DefaultHost::new()),
             children: HashMap::new(),
             is_safe: false,
             recursion_limit: RECURSION_LIMIT,
@@ -1881,7 +1895,8 @@ impl Vm {
         Rc::clone(&self.host)
     }
 
-    /// Swap the host environment — e.g. a [`NativeHost::sandboxed`] to exercise
+    /// Swap the host environment — e.g. a
+    /// [`NativeHost::sandboxed`](crate::host_native::NativeHost::sandboxed) to exercise
     /// the WASM-posture "unsupported" paths natively.
     pub fn set_host(&mut self, host: Rc<dyn Host>) {
         self.host = host;

--- a/rust/tcl-vm/src/lib.rs
+++ b/rust/tcl-vm/src/lib.rs
@@ -34,6 +34,11 @@ pub mod debug;
 pub mod embed;
 pub mod error;
 pub mod host_native;
+// The `wasm32-unknown-unknown` half of the capability seam. Gated rather than
+// always-compiled because its clock is a JavaScript import (`js-sys`), which is
+// a dependency no native build should carry.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub mod host_wasm;
 pub mod value;
 mod value_ops;
 

--- a/rust/tcl-vm/tests/wasm_coro_e2e.rs
+++ b/rust/tcl-vm/tests/wasm_coro_e2e.rs
@@ -186,9 +186,14 @@ fn cargo_toml() -> String {
         format!("{name} = {{ path = \"{}\" }}", path.display())
     };
     format!(
+        // `default-features = false` drops `js-clock`, whose `Date.now()` is a
+        // wasm-bindgen import: `HARNESS_MJS` instantiates this module with an
+        // empty import object, so any import at all makes it fail to
+        // instantiate. That is the invariant this test exists to hold, for
+        // `tcl-vm-wasm` as much as for the scratch crate here.
         "[package]\nname = \"tcl-vm-wasm-coro\"\nversion = \"0.0.0\"\nedition = \"2024\"\n\
          publish = false\n\n[lib]\ncrate-type = [\"cdylib\"]\n\n[dependencies]\n\
-         tcl-vm = {{ path = \"{}\" }}\n{}\n{}\n{}\n\n[workspace]\n\n\
+         tcl-vm = {{ path = \"{}\", default-features = false }}\n{}\n{}\n{}\n\n[workspace]\n\n\
          [profile.release]\npanic = \"abort\"\nopt-level = \"s\"\n",
         base.display(),
         dep("tcl-compiler"),


### PR DESCRIPTION
## Summary

Fixes #1661 — the GitHub Pages deploy (BIG-IP report + compiler explorer + spec studio) has been red since 19 Aug because the in-browser wasm language server panics.

**Both panics on the issue are one defect, in a causal chain.**

`Vm::new()` hardcoded `NativeHost::new()` on every target. On `wasm32-unknown-unknown` that host's clock is `std::time::SystemTime::now`, which is `unsupported.rs`'s `panic!("time not implemented on this platform")` — and a wasm panic *aborts* (the `unreachable` page errors in the failing log) rather than unwinding, so nothing the trapped call held is ever released.

Nothing reached it until **#1566**. `specs/upf.tclspec`, added there by `23c5c955b` ("Add IEEE 1801-2024 UPF pack and bring SDC to 2.2 coverage", #1560), is the **first bundled pack to declare Tcl hook bodies** — 16 `-arity-hook {words ctx} {…}`. Proof the window is right:

```
$ git grep -c -E "hook \{|const_fold" 5a035d208 -- specs/    # last green Pages run
(nothing)
$ git grep -c -E "hook \{|const_fold" 2ba3d04f0 -- specs/    # first red Pages run
2ba3d04f0:specs/upf.tclspec:16
```

That flipped `HookPlan::is_empty()` false for the first time. The browser has no `specs/` directory, so the wasm server takes `tcl_spectcl::bundled`'s `include_str!` fallback, loads upf, and:

`hooks::publish` (rust/tcl-lsp-server/src/lib.rs:13796) → `ensure_thread_host` → `tcl_spec_hooks::tclvm_host()` → `TclVmEngine::set_budget` → `Vm::set_wall_clock_budget` (rust/tcl-vm/src/embed.rs:153) → `host_rc().clock().now_millis()` → **panic 2**.

The trap then stranded a salsa database handle, so the next input mutation hit `Storage::cancel_others`, saw `clones != 1`, and blocked on salsa's parking_lot `Condvar::wait` — **panic 1**. Log ordering agrees (clock first, condvar last), and fixing the clock makes both disappear.

The issue's guess at #1649 / #1652 / #1658 was off: the last green run is #267 (`5a035d208`, #1567) and run #268 (`2ba3d04f0`, #1566) already fails on the same step with the same two panics. Those later runs were simply already red.

**The fix.** `Vm` picks its default host by target, the way `runtime/rust`'s `Interp::new` already has since it learnt to link for wasm:

- `NativeHost` anywhere with an operating system under it — **`wasm32-wasip1` included**, where `std::time` and `std::env` both work;
- a new `tcl_vm::host_wasm::BrowserHost` on `wasm32-unknown-unknown`, whose clock reads JavaScript's `Date.now()`. Its other capabilities take the posture the target actually has: stdio discarded, env empty at `/`, no filesystem, sockets or subprocess.

**The JS clock is behind a default-on `js-clock` feature**, and that is load-bearing rather than decorative. There are two kinds of `wasm32-unknown-unknown` consumer here. The wasm-bindgen ones (language server, compiler explorer, spec studio) want the clock and reach `tcl-vm` six crates deep, through tcl-spectcl then tcl-spec-hooks then tcl-engine-tclvm — so default-on spares six manifests of feature plumbing. `tcl-vm-wasm` is the other kind, built on an explicit promise ("NO host imports and NO WASI") and instantiated by a bare `WebAssembly.instantiate(bytes, {})`; a single `js-sys` import makes it refuse to instantiate:

```
TypeError: WebAssembly.instantiate(): Import #0
module="__wbindgen_placeholder__": module is not an object or function
```

It opts out with `default-features = false`, as does the scratch crate `wasm_coro_e2e` synthesises to hold the same invariant. With the feature off the browser clock reports the epoch — a wrong answer rather than a crash, and the posture `runtime/rust`'s `BrowserHost` has always had. (It is also inert rather than harmful: a deadline of `0 + 250` against a clock that always reads `0` never fires, so no spurious "time limit exceeded".)

I did not write that guard — `tcl-vm/tests/wasm_coro_e2e.rs` already existed and caught the first version of this patch. Worth knowing it works.

Native behaviour is unchanged: on every non-wasm target `DefaultHost` *is* `NativeHost`, constructed identically.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

Everything below was run in a worktree, every cargo/make invocation prefixed `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=2`.

**Mutation-verified reproduction.** `make lsp-server-wasm-test` drives the real wasm module through a scripted LSP session under node — no browser needed, and it reproduces #1661 exactly, with the frames the browser stack was missing:

```
at ...std::time::SystemTime::now
at ...tcl_host_native::NativeClock as tcl_platform::Clock::now_micros
at ...tcl_vm::interp::Vm::set_wall_clock_budget
at ...tcl_spectcl::hooks::ensure_thread_host
```

After the fix: **16/16 checks passed**, 8 packs loaded, no panic.

| Gate | Result |
| --- | --- |
| `cargo fmt --all --check` (rust/ and runtime/rust) | clean |
| `cargo clippy -p tcl-vm --all-targets` | clean |
| `cargo clippy --target wasm32-unknown-unknown --all-targets` in tcl-lsp-server-wasm, `RUSTFLAGS=-D warnings` | clean |
| `cargo clippy --target wasm32-unknown-unknown --all-targets` in tcl-explorer-wasm, `RUSTFLAGS=-D warnings` | clean |
| `cargo check --workspace` | clean |
| `cargo test -p tcl-vm -p tcl-engine-tclvm -p tcl-spec-hooks -p tcl-host-native` | all green |
| `cargo test -p tcl-vm --test wasm_coro_e2e` | 3/3 (the import-free invariant) |
| `cargo test -p tcl-spectcl` | all green |
| `make lsp-server-wasm-test` | 16/16 |

**The Pages workflow's own build job, locally, end to end:**

| Step | Result |
| --- | --- |
| `make explorer-build` | ok, externref table growable |
| `make spec-studio-wasm` | ok, dist assembled (24 MB server wasm) |
| `node rust/tcl-spec-studio-wasm/test/boot.mjs` in headless chromium | **boot check passed** |
| `node rust/tcl-cli/gui/test/pages-boot.mjs site` on the assembled site | **passed** |

One tell worth flagging, because it says the trap was corrupting analysis and not merely printing panics: the failing CI run logged `note: no diagnostic appeared for the typed sample (not fatal)` after a 60-second wait. Locally that line is now `the language server published diagnostics into the editor`.

## The gate gap — filed as #1662

Nothing on a PR builds `tcl_lsp_server_wasm`, let alone runs it. `ci.yml`'s only wasm-bindgen job is `build-vsix`, which is `if: startsWith(github.ref, 'refs/tags/v')` — tag-only — and it builds the module without ever executing it. `wasm-real-link` and `wasm_coro_e2e` cover the VM on `wasm32-wasip1` and the import-free cdylib, neither of which can see this class of defect (wasip1 has a working `std::time` by construction). Only `github-pages.yml` runs the browser, post-merge on `rust`.

The cheap close is a PR-triggered job running `make lsp-server-wasm-test` — node, no browser, no playwright, and it catches exactly this. The cost is the release LTO wasm build (~7 min cold, Swatinem-cacheable), which is a CI-budget call rather than a technical one, so #1662 carries it with the path filters and the cheaper fallbacks (merge_group only / `cargo check` only / nightly) rather than this PR pre-empting the decision. Note the current path filters would not have caught #1661 anyway: it came in through `rust/tcl-vm/**` and `rust/tcl-spectcl/**`, which no filter names.

## Compiler / diagnostics checklist

- [ ] Did this change alter a compiler fact contract? — no. It is a per-target host selection in the VM; no compiler fact, diagnostic, or optimisation code is touched.
- [ ] If yes, I updated the owning design doc — n/a.
- [ ] If I added or changed a diagnostic or optimisation code — n/a.
- [ ] If I added a design doc — n/a. No new crate, so `docs/design/rust/current-architecture.md`'s member list and `docs/design/contracts/project-layout.md` are unchanged; `docs/design/compiler/wasm-target-surfaces.md` audits `runtime/rust`'s hosts, which this does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o)_