### PR TITLE
fix(server): the document-sync barrier wedge — ticket loss, snapshot lifetime, and a self-diagnosing stall

### DIFF
--- a/editors/vscode/src/test/helper.ts
+++ b/editors/vscode/src/test/helper.ts
@@ -637,13 +637,118 @@ interface ProcSample {
    * in its own right: if nothing at all was read or written, that necessarily
    * includes stdin and stdout.
    *
-   * Narrowing this to the two transport descriptors would need per-fd counters
-   * (`/proc/<pid>/fdinfo/0` and `/1` positions); noted as the next step on the
-   * wedge this capture exists for, issue #1657.
+   * Narrowing this to the two transport descriptors by reading per-descriptor
+   * byte counts is **not possible**: `/proc/<pid>/fdinfo/N` reports `pos: 0`
+   * for a pipe and never advances, because a pipe is not seekable. What answers
+   * the question instead is [`threadSyscalls`], which says what each thread is
+   * blocked *in* — including the descriptor number a blocked `read` or `write`
+   * names.
    */
   readBytes: number;
   writeBytes: number;
   threads: number;
+  /** What each thread is blocked in — see [`threadSyscalls`]. */
+  syscalls: ThreadSyscalls;
+}
+
+/** Linux syscall numbers this capture cares about, per architecture.
+ *
+ *  Deliberately tiny: the point is to name the handful of waits an LSP server
+ *  can be sitting in, not to decode the whole table. Anything unlisted is
+ *  reported by number, which is still enough to look up. */
+const SYSCALL_NAMES: Record<string, Record<number, string>> = {
+  x64: {
+    0: "read",
+    1: "write",
+    7: "poll",
+    23: "select",
+    202: "futex",
+    230: "clock_nanosleep",
+    232: "epoll_wait",
+    271: "ppoll",
+    281: "epoll_pwait",
+  },
+  arm64: {
+    63: "read",
+    64: "write",
+    73: "ppoll",
+    98: "futex",
+    115: "clock_nanosleep",
+    22: "epoll_pwait",
+  },
+};
+
+/** What the server's threads are blocked in, and the two conclusions that
+ *  follow from it. */
+interface ThreadSyscalls {
+  /** One entry per thread, e.g. `read(fd 0)`, `futex`, `epoll_wait`. */
+  descriptions: string[];
+  /** A thread is blocked reading descriptor 0 — the server is waiting for the
+   *  editor to send it something, i.e. its stdin reader is alive and idle. */
+  readingStdin: boolean;
+  /** A thread is blocked writing descriptor 1 — the server has output it
+   *  cannot get rid of, i.e. the *client* is not draining. */
+  blockedWritingStdout: boolean;
+}
+
+/**
+ * Read `/proc/<pid>/task/<tid>/syscall` for every thread.
+ *
+ * This is the per-descriptor answer the aggregate byte counters cannot give.
+ * The file reports the syscall number followed by its arguments, so a thread
+ * parked in `read` or `write` names the descriptor it is parked on — which is
+ * exactly the "is anything still reading stdin / stuck writing stdout"
+ * question issue #1657 turns on.
+ *
+ * Syscall numbers are architecture-specific, so an unrecognised architecture
+ * degrades to bare numbers rather than guessing wrong names. A thread that is
+ * running rather than blocked reports `running`.
+ */
+function threadSyscalls(pid: number): ThreadSyscalls {
+  const names = SYSCALL_NAMES[process.arch] ?? {};
+  const descriptions: string[] = [];
+  let readingStdin = false;
+  let blockedWritingStdout = false;
+  try {
+    for (const tid of fs.readdirSync(`/proc/${pid}/task`)) {
+      let raw: string;
+      try {
+        raw = fs.readFileSync(`/proc/${pid}/task/${tid}/syscall`, "utf8").trim();
+      } catch {
+        continue;
+      }
+      // "running" for a thread that is not in a syscall; otherwise
+      // "<nr> <arg0> <arg1> …".
+      if (raw.startsWith("running") || raw === "-1") {
+        descriptions.push("running");
+        continue;
+      }
+      const fields = raw.split(/\s+/);
+      const nr = Number(fields[0]);
+      const name = names[nr] ?? `syscall ${nr}`;
+      if (name === "read" || name === "write") {
+        const fd = Number(fields[1]);
+        descriptions.push(`${name}(fd ${fd})`);
+        if (name === "read" && fd === 0) readingStdin = true;
+        if (name === "write" && fd === 1) blockedWritingStdout = true;
+      } else {
+        descriptions.push(name);
+      }
+    }
+  } catch {
+    // No /proc, or the process went away — the caller renders the empty case.
+  }
+  return { descriptions, readingStdin, blockedWritingStdout };
+}
+
+/** Collapse the per-thread list into `2x futex, 1x read(fd 0)` form. */
+function summariseSyscalls(descriptions: string[]): string {
+  const counts = new Map<string, number>();
+  for (const d of descriptions) counts.set(d, (counts.get(d) ?? 0) + 1);
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([name, n]) => `${n}x ${name}`)
+    .join(", ");
 }
 
 /** The server's pid, via the language client's child process.
@@ -683,6 +788,7 @@ function readProcSample(pid: number): ProcSample | undefined {
       readBytes: field("rchar"),
       writeBytes: field("wchar"),
       threads,
+      syscalls: threadSyscalls(pid),
     };
   } catch {
     return undefined;
@@ -752,6 +858,28 @@ export async function serverStateEvidence(): Promise<string> {
             "stdout: nothing is being read from or written to the LSP pipes. This is the " +
             "stdin-reader-stopped shape, and it is the one conclusive reading here.",
     );
+    // What each thread is parked in. This is the per-descriptor answer the
+    // aggregate counters above cannot give, and the one that separates a
+    // wedged *transport* from wedged *handlers*: the byte counters cannot say
+    // which descriptor moved, but a thread blocked in `read` names its fd.
+    const { descriptions, readingStdin, blockedWritingStdout } = after.syscalls;
+    if (descriptions.length === 0) {
+      lines.push("server threads: /proc/<pid>/task is unreadable, so no per-thread reading");
+    } else {
+      lines.push(`server threads: ${summariseSyscalls(descriptions)}`);
+      lines.push(
+        blockedWritingStdout
+          ? "  -> a thread is blocked WRITING descriptor 1, so the server has output it cannot " +
+              "get rid of: the client is not draining stdout. The fault is downstream of the server."
+          : readingStdin
+            ? "  -> a thread is blocked READING descriptor 0, so the server's input path is alive " +
+              "and simply has nothing to do. It is not deaf; it has already consumed everything " +
+              "sent and is answering none of it, which points at the handlers rather than the " +
+              "transport — a barrier or a permit nothing releases."
+            : "  -> nothing is parked on either LSP descriptor. The server is neither waiting for " +
+              "input nor stuck writing output, so whatever it is waiting on is internal.",
+      );
+    }
   }
   const log = getServerLog();
   const tail = log.slice(-SERVER_LOG_TAIL_LINES);

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -4754,6 +4754,25 @@ struct EditOrder {
     /// case a blocking mutex is for. Holding it across an await is what would
     /// make it a hazard, and nothing here does.
     abandoned: std::sync::Mutex<std::collections::BTreeSet<u64>>,
+    /// Who currently holds the turn, and since when.
+    ///
+    /// "The barrier has stopped" is only half a diagnosis — the other half is
+    /// *which handler* stopped it, and that cannot be recovered afterwards
+    /// because a wedged server writes nothing. Recording it at the grant makes
+    /// [`Backend::report_edit_barrier_stall`] able to name the culprit in the
+    /// one line it gets out (issue #1657).
+    holder: std::sync::Mutex<Option<TurnHolder>>,
+}
+
+/// The handler currently holding an [`EditOrder`] turn.
+#[derive(Debug, Clone)]
+struct TurnHolder {
+    /// The notification that drew the ticket — `didOpen`, `didChange`, `didClose`.
+    what: &'static str,
+    /// The document it is for.
+    uri: String,
+    ticket: u64,
+    since: std::time::Instant,
 }
 
 impl EditOrder {
@@ -4762,13 +4781,15 @@ impl EditOrder {
     ///
     /// The returned [`EditTicket`] is a reservation that must be accounted for
     /// however the handler ends — see its docs.
-    fn take_ticket(&self) -> EditTicket<'_> {
+    fn take_ticket(&self, what: &'static str, uri: &Uri) -> EditTicket<'_> {
         EditTicket {
             order: self,
             ticket: self
                 .next_ticket
                 .fetch_add(1, std::sync::atomic::Ordering::AcqRel),
             armed: true,
+            what,
+            uri: uri.as_str().to_owned(),
         }
     }
 
@@ -4790,6 +4811,15 @@ impl EditOrder {
                 // The turn is ours; the guard below now owns the release, so the
                 // reservation must not also account for it.
                 ticket.armed = false;
+                *self
+                    .holder
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(TurnHolder {
+                    what: ticket.what,
+                    uri: std::mem::take(&mut ticket.uri),
+                    ticket: ticket.ticket,
+                    since: std::time::Instant::now(),
+                });
                 return EditTurn { order: self };
             }
             advanced.await;
@@ -4876,6 +4906,10 @@ struct EditTicket<'a> {
     /// Still owing an accounting. Cleared when [`EditOrder::wait_turn`] hands
     /// ownership to the [`EditTurn`] it returns.
     armed: bool,
+    /// Carried so the grant can publish who holds the turn — see
+    /// [`EditOrder::holder`].
+    what: &'static str,
+    uri: String,
 }
 
 impl Drop for EditTicket<'_> {
@@ -4903,6 +4937,11 @@ struct EditTurn<'a> {
 
 impl Drop for EditTurn<'_> {
     fn drop(&mut self) {
+        *self
+            .order
+            .holder
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
         self.order
             .now_serving
             .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
@@ -6543,13 +6582,39 @@ impl Backend {
         {
             return;
         }
+        let holder = self
+            .edit_order
+            .holder
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        // Naming the holder is the difference between "the barrier stopped" and
+        // a diagnosis. No holder at all is itself informative: nobody is in the
+        // turn, so the sequence is stuck on a ticket whose handler never
+        // reached its grant.
+        let culprit = holder.map_or_else(
+            || {
+                "held by nobody — the sequence is stuck on a ticket whose handler never \
+                 reached its grant"
+                    .to_owned()
+            },
+            |h| {
+                format!(
+                    "held by {} for {:.1}s on {} (ticket {})",
+                    h.what,
+                    h.since.elapsed().as_secs_f64(),
+                    h.uri,
+                    h.ticket,
+                )
+            },
+        );
         self.client
             .log_message(
                 MessageType::WARNING,
                 format!(
                     "{EDIT_BARRIER_STALL_LOG} for {}s: now_serving={serving}, waiting for \
-                     {target}, so {} document-sync notification(s) are queued behind a turn \
-                     nothing has handed on. Every request handler is blocked on this barrier \
+                     {target}, so {} document-sync notification(s) are queued behind it. \
+                     The turn is {culprit}. Every request handler is blocked on this barrier \
                      and the server will answer nothing until it moves (issue #1657).",
                     EDIT_BARRIER_STALL_WARN.as_secs(),
                     target.saturating_sub(serving),
@@ -15629,7 +15694,9 @@ impl LanguageServer for Backend {
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
         // Apply document-sync mutations in arrival order (see `EditOrder`). The
         // ticket must be drawn before the first await.
-        let ticket = self.edit_order.take_ticket();
+        let ticket = self
+            .edit_order
+            .take_ticket("didOpen", &params.text_document.uri);
         let turn = self.edit_order.wait_turn(ticket).await;
         let dialect = self
             .dialect_for_open(
@@ -15728,7 +15795,9 @@ impl LanguageServer for Backend {
         // Apply document-sync mutations in arrival order (see `EditOrder`) —
         // otherwise two rapid incremental edits splice out of order and corrupt
         // the buffer. The ticket must be drawn before the first await.
-        let ticket = self.edit_order.take_ticket();
+        let ticket = self
+            .edit_order
+            .take_ticket("didChange", &params.text_document.uri);
         let turn = self.edit_order.wait_turn(ticket).await;
         let uri = params.text_document.uri.clone();
         if params.content_changes.is_empty() {
@@ -15933,7 +16002,9 @@ impl LanguageServer for Backend {
         // Apply document-sync mutations in arrival order (see `EditOrder`) so a
         // close can't be reordered ahead of an in-flight edit. The ticket must be
         // drawn before the first await.
-        let ticket = self.edit_order.take_ticket();
+        let ticket = self
+            .edit_order
+            .take_ticket("didClose", &params.text_document.uri);
         let turn = self.edit_order.wait_turn(ticket).await;
         let uri = &params.text_document.uri;
         {
@@ -32455,14 +32526,15 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn a_dropped_waiter_does_not_wedge_the_edit_order() {
         let order = EditOrder::default();
+        let uri = Uri::from_str("file:///w/ordering.tcl").unwrap();
 
         // Ticket 0 is held by an edit that is getting on with its work.
-        let first = order.take_ticket();
+        let first = order.take_ticket("didChange", &uri);
         let first_turn = order.wait_turn(first).await;
 
         // Ticket 1's handler is dropped while parked — it never reaches the
         // grant, so it never owns an `EditTurn`.
-        let abandoned = order.take_ticket();
+        let abandoned = order.take_ticket("didChange", &uri);
         let abandoned_n = abandoned.ticket;
         {
             let mut waiting = Box::pin(order.wait_turn(abandoned));
@@ -32476,7 +32548,7 @@ mod tests {
         }
 
         // Ticket 2 is a later edit, waiting its turn behind the abandoned one.
-        let third = order.take_ticket();
+        let third = order.take_ticket("didChange", &uri);
         let third_n = third.ticket;
         let next = order.wait_turn(third);
 
@@ -32513,7 +32585,7 @@ mod tests {
 
         // Stand in for a `didChange` that has arrived and taken its turn, but has
         // not yet spliced the buffer.
-        let ticket = backend.edit_order.take_ticket();
+        let ticket = backend.edit_order.take_ticket("didChange", &uri);
         let edit_in_flight = backend.edit_order.wait_turn(ticket).await;
 
         let mut reader = crate::rt::spawn({

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -4723,31 +4723,79 @@ struct EditOrder {
     next_ticket: std::sync::atomic::AtomicU64,
     now_serving: std::sync::atomic::AtomicU64,
     advanced: tokio::sync::Notify,
+    /// Tickets whose waiter went away before its turn came round.
+    ///
+    /// A drawn ticket is a reservation in a strictly increasing sequence, so
+    /// nothing after it can run until it has been accounted for. If its handler
+    /// simply vanishes there is no guard to release it and `now_serving` stops
+    /// at that number **for ever** — see [`EditTicket`]. Recording it here lets
+    /// [`Self::drain_abandoned`] step over it when the sequence reaches it.
+    ///
+    /// A `std::sync::Mutex`, deliberately: every critical section touching it is
+    /// a few integer operations with no `await` inside, which is exactly the
+    /// case a blocking mutex is for. Holding it across an await is what would
+    /// make it a hazard, and nothing here does.
+    abandoned: std::sync::Mutex<std::collections::BTreeSet<u64>>,
 }
 
 impl EditOrder {
     /// Draw the next ticket. **Must** be called before the handler's first
     /// `await`, while the future is still being first-polled in stream order.
-    fn take_ticket(&self) -> u64 {
-        self.next_ticket
-            .fetch_add(1, std::sync::atomic::Ordering::AcqRel)
+    ///
+    /// The returned [`EditTicket`] is a reservation that must be accounted for
+    /// however the handler ends — see its docs.
+    fn take_ticket(&self) -> EditTicket<'_> {
+        EditTicket {
+            order: self,
+            ticket: self
+                .next_ticket
+                .fetch_add(1, std::sync::atomic::Ordering::AcqRel),
+            armed: true,
+        }
     }
 
-    /// Wait for `ticket`'s turn. The guard releases it on drop — including on an
-    /// early return or a dropped (cancelled) handler future, so a turn is never
-    /// lost.
-    async fn wait_turn(&self, ticket: u64) -> EditTurn<'_> {
+    /// Wait for `ticket`'s turn, consuming the reservation and returning the
+    /// guard that holds it.
+    ///
+    /// Cancel-safe in the way the sequence needs: `ticket` is moved into this
+    /// future, so a caller dropped while parked here drops the reservation with
+    /// it, and [`EditTicket::drop`] records the abandonment rather than leaving
+    /// the sequence stuck on a number nobody will ever release.
+    async fn wait_turn<'a>(&'a self, mut ticket: EditTicket<'a>) -> EditTurn<'a> {
         loop {
             let advanced = self.advanced.notified();
             tokio::pin!(advanced);
             // Register before re-reading, so a turn granted between the check and
             // the await cannot be missed.
             advanced.as_mut().enable();
-            if self.now_serving.load(std::sync::atomic::Ordering::Acquire) == ticket {
+            if self.now_serving.load(std::sync::atomic::Ordering::Acquire) == ticket.ticket {
+                // The turn is ours; the guard below now owns the release, so the
+                // reservation must not also account for it.
+                ticket.armed = false;
                 return EditTurn { order: self };
             }
             advanced.await;
         }
+    }
+
+    /// Step `now_serving` over any run of consecutive abandoned tickets that
+    /// now sits at the head of the queue, and wake whoever that admits.
+    ///
+    /// Called from both ends: when a turn is handed on normally, and when a
+    /// ticket is abandoned. Either can be the event that makes an abandoned
+    /// ticket current.
+    fn drain_abandoned(&self) {
+        {
+            let mut abandoned = self
+                .abandoned
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            while abandoned.remove(&self.now_serving.load(std::sync::atomic::Ordering::Acquire)) {
+                self.now_serving
+                    .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+            }
+        }
+        self.advanced.notify_waiters();
     }
 
     /// Wait until every edit that had drawn a ticket *before this call* has been
@@ -4766,6 +4814,54 @@ impl EditOrder {
     }
 }
 
+/// A drawn but not-yet-granted place in the [`EditOrder`] sequence.
+///
+/// # Why this is a guard and not a bare number
+///
+/// A ticket is a reservation in a strictly increasing sequence: `now_serving`
+/// advances one at a time, so nothing after ticket N can run until N has been
+/// accounted for. [`EditTurn`] accounts for a ticket that was *granted*. Before
+/// the grant there was nothing, and a handler future dropped while parked in
+/// [`EditOrder::wait_turn`] therefore left `now_serving` pointing at a number
+/// no guard would ever release.
+///
+/// The result is not a lost edit but a stopped server. Every later
+/// document-sync notification blocks in `wait_turn`, every request handler
+/// blocks in [`EditOrder::settled`] and holds one of the four
+/// [`crate::transport_liveness::DeferredConcurrency`] permits, and the process
+/// sits at zero CPU answering nothing while its stdin reader — which the
+/// unbounded transport keeps running — goes on draining input it will never
+/// act on. That is precisely the steady state issue #1657 records.
+///
+/// So the reservation itself is the guard. `wait_turn` takes it by value, which
+/// puts it inside the very future that might be dropped; if that happens,
+/// `Drop` records the abandonment and the sequence steps over it.
+struct EditTicket<'a> {
+    order: &'a EditOrder,
+    ticket: u64,
+    /// Still owing an accounting. Cleared when [`EditOrder::wait_turn`] hands
+    /// ownership to the [`EditTurn`] it returns.
+    armed: bool,
+}
+
+impl Drop for EditTicket<'_> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        {
+            let mut abandoned = self
+                .order
+                .abandoned
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            abandoned.insert(self.ticket);
+        }
+        // This ticket may be the one the sequence is waiting on right now.
+        self.order.drain_abandoned();
+    }
+}
+
 /// A held turn in the [`EditOrder`] sequence; hands it on when dropped.
 struct EditTurn<'a> {
     order: &'a EditOrder,
@@ -4776,7 +4872,10 @@ impl Drop for EditTurn<'_> {
         self.order
             .now_serving
             .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
-        self.order.advanced.notify_waiters();
+        // Handing this turn on may make an abandoned ticket current, in which
+        // case the sequence must step over it rather than stop there.
+        // `drain_abandoned` wakes the waiters either way.
+        self.order.drain_abandoned();
     }
 }
 
@@ -32241,6 +32340,70 @@ mod tests {
     /// wait for the outstanding edit rather than racing ahead and answering from
     /// the pre-edit text (which yielded semantic tokens whose lines/lengths
     /// described text the client had already replaced).
+    /// #1657, the latent half: a ticket whose waiter is dropped *before* its
+    /// turn is granted must not stop the sequence for ever.
+    ///
+    /// [`EditOrder::wait_turn`]'s own docs claim this already holds — "the guard
+    /// releases it on drop — including on ... a dropped (cancelled) handler
+    /// future, so a turn is never lost". That is true only once the guard
+    /// exists, and the guard is created at the *grant*, not at the draw. A
+    /// future dropped while parked in the wait leaves `now_serving` pointing at
+    /// a ticket nobody holds and nobody will ever release.
+    ///
+    /// The consequence is total and permanent: every later document-sync
+    /// notification blocks in `wait_turn`, and every request handler blocks in
+    /// `edits_settled`, which is exactly the steady state #1657 records — no
+    /// CPU, no output, stdin still draining.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_dropped_waiter_does_not_wedge_the_edit_order() {
+        let order = EditOrder::default();
+
+        // Ticket 0 is held by an edit that is getting on with its work.
+        let first = order.take_ticket();
+        let first_turn = order.wait_turn(first).await;
+
+        // Ticket 1's handler is dropped while parked — it never reaches the
+        // grant, so it never owns an `EditTurn`.
+        let abandoned = order.take_ticket();
+        let abandoned_n = abandoned.ticket;
+        {
+            let mut waiting = Box::pin(order.wait_turn(abandoned));
+            // Poll it so it really is registered and parked, then drop it.
+            assert!(
+                crate::rt::timeout(std::time::Duration::from_millis(50), &mut waiting)
+                    .await
+                    .is_err(),
+                "ticket {abandoned_n} must not be granted while an earlier ticket holds the turn",
+            );
+        }
+
+        // Ticket 2 is a later edit, waiting its turn behind the abandoned one.
+        let third = order.take_ticket();
+        let third_n = third.ticket;
+        let next = order.wait_turn(third);
+
+        drop(first_turn);
+
+        assert!(
+            crate::rt::timeout(std::time::Duration::from_secs(5), next)
+                .await
+                .is_ok(),
+            "a waiter dropped before its turn was granted stopped the edit order for ever: \
+             ticket {third_n} never ran behind abandoned ticket {abandoned_n}. Every later edit \
+             and every request handler waiting on `edits_settled` would now be blocked \
+             permanently (#1657)",
+        );
+
+        // And the sequence is genuinely caught up, not merely unblocked: a
+        // request barrier taken now must see every drawn ticket accounted for.
+        assert!(
+            crate::rt::timeout(std::time::Duration::from_secs(5), order.settled())
+                .await
+                .is_ok(),
+            "`settled` must not still be waiting on the abandoned ticket",
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn read_document_waits_for_an_in_flight_edit() {
         let backend = Arc::new(test_backend());

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -6602,8 +6602,26 @@ impl Backend {
     /// a reader needs out of the captured tail. Reporting again once the
     /// sequence has moved on is intentional — a barrier that stalls repeatedly
     /// at successive positions is a different story from one that stopped dead.
+    ///
+    /// # The barrier is re-read before anything is claimed
+    ///
+    /// The caller's timeout can win its race by a hair: the wait expires, and
+    /// the edit it was waiting for lands before this runs. Reporting on the
+    /// strength of "the timeout fired" would then announce a permanent wedge
+    /// that is already over — with no holder and zero notifications queued,
+    /// which is the *ticket-loss* shape and so actively misleading.
+    ///
+    /// Worse than the noise is what it would do to the rate limiter. Recording
+    /// that position would make a later, genuine stall at the same position
+    /// suppress itself, so the false report could hide the real one. Both
+    /// failures land in the one diagnosis stream issue #1657 depends on, so the
+    /// re-read comes first and the suppression slot is only ever written for a
+    /// stall that is real at the moment it is claimed.
     async fn report_edit_barrier_stall(&self, target: u64) {
         let serving = self.edit_order.served();
+        if serving >= target {
+            return;
+        }
         if self
             .edit_barrier_stall_reported
             .swap(serving, std::sync::atomic::Ordering::AcqRel)
@@ -32549,6 +32567,43 @@ mod tests {
     /// wait for the outstanding edit rather than racing ahead and answering from
     /// the pre-edit text (which yielded semantic tokens whose lines/lengths
     /// described text the client had already replaced).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn read_document_waits_for_an_in_flight_edit() {
+        let backend = Arc::new(test_backend());
+        let uri = Uri::from_str("file:///ordering.tcl").unwrap();
+        register(&backend, &uri, "set x 1\n").await;
+
+        // Stand in for a `didChange` that has arrived and taken its turn, but has
+        // not yet spliced the buffer.
+        let ticket = backend.edit_order.take_ticket("didChange", &uri);
+        let edit_in_flight = backend.edit_order.wait_turn(ticket).await;
+
+        let mut reader = crate::rt::spawn({
+            let backend = Arc::clone(&backend);
+            let uri = uri.clone();
+            async move { backend.read_document(&uri).await.map(|d| d.text) }
+        });
+
+        // While the edit is in flight the read must not resolve.
+        let elapsed = std::time::Duration::from_millis(300);
+        if let Ok(done) = crate::rt::timeout(elapsed, &mut reader).await {
+            panic!("read_document returned {done:?} while an edit was still in flight");
+        }
+
+        // Land the edit, then release the ordering lock: the read must now
+        // resolve against the *settled* buffer, never the pre-edit text.
+        backend.documents.lock().await.insert(
+            uri.clone(),
+            DocumentState::new("set x 2\n".to_owned(), "tcl8.6".to_owned()),
+        );
+        drop(edit_in_flight);
+        let text = crate::rt::timeout(std::time::Duration::from_secs(5), reader)
+            .await
+            .expect("read_document must resolve once the edit lands")
+            .expect("reader task panicked");
+        assert_eq!(text.as_deref(), Some("set x 2\n"));
+    }
+
     /// #1657, the latent half: a ticket whose waiter is dropped *before* its
     /// turn is granted must not stop the sequence for ever.
     ///
@@ -32617,41 +32672,79 @@ mod tests {
         );
     }
 
+    /// The stall reporter must not announce a wedge that is already over.
+    ///
+    /// `edits_settled`'s timeout can win its race by a hair: the wait expires,
+    /// and the edit it was waiting for lands before the report runs. Reporting
+    /// on the strength of "the timeout fired" would then describe a permanent
+    /// wedge with no holder and zero notifications queued — which is the
+    /// *ticket-loss* shape, so the line would not merely be noise but point at
+    /// the wrong defect.
+    ///
+    /// The second half matters as much: recording that position in the rate
+    /// limiter would make a later, genuine stall at the same position suppress
+    /// itself. A false report could then hide the real one, in the single
+    /// diagnosis stream issue #1657 depends on.
+    ///
+    /// Constructed directly rather than by racing a ten-second timeout: the
+    /// state that race produces is simply "the reporter is called with a target
+    /// the barrier has already reached", which is what this hands it.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn read_document_waits_for_an_in_flight_edit() {
-        let backend = Arc::new(test_backend());
-        let uri = Uri::from_str("file:///ordering.tcl").unwrap();
-        register(&backend, &uri, "set x 1\n").await;
+    async fn a_barrier_that_has_caught_up_is_not_reported_as_a_stall() {
+        let backend = test_backend();
+        let uri = Uri::from_str("file:///w/caught-up.tcl").unwrap();
 
-        // Stand in for a `didChange` that has arrived and taken its turn, but has
-        // not yet spliced the buffer.
-        let ticket = backend.edit_order.take_ticket("didChange", &uri);
-        let edit_in_flight = backend.edit_order.wait_turn(ticket).await;
-
-        let mut reader = crate::rt::spawn({
-            let backend = Arc::clone(&backend);
-            let uri = uri.clone();
-            async move { backend.read_document(&uri).await.map(|d| d.text) }
-        });
-
-        // While the edit is in flight the read must not resolve.
-        let elapsed = std::time::Duration::from_millis(300);
-        if let Ok(done) = crate::rt::timeout(elapsed, &mut reader).await {
-            panic!("read_document returned {done:?} while an edit was still in flight");
-        }
-
-        // Land the edit, then release the ordering lock: the read must now
-        // resolve against the *settled* buffer, never the pre-edit text.
-        backend.documents.lock().await.insert(
-            uri.clone(),
-            DocumentState::new("set x 2\n".to_owned(), "tcl8.6".to_owned()),
+        // One edit drawn and handed on, so the barrier has reached its target —
+        // exactly the state the timeout can lose its race against.
+        let target = {
+            let ticket = backend.edit_order.take_ticket("didChange", &uri);
+            let target = backend.edit_order.settle_target();
+            drop(backend.edit_order.wait_turn(ticket).await);
+            target
+        };
+        assert!(
+            backend.edit_order.served() >= target,
+            "the barrier must have caught up, or this test proves nothing",
         );
-        drop(edit_in_flight);
-        let text = crate::rt::timeout(std::time::Duration::from_secs(5), reader)
-            .await
-            .expect("read_document must resolve once the edit lands")
-            .expect("reader task panicked");
-        assert_eq!(text.as_deref(), Some("set x 2\n"));
+
+        crate::rt::timeout(
+            std::time::Duration::from_secs(5),
+            backend.report_edit_barrier_stall(target),
+        )
+        .await
+        .expect("the reporter must return promptly rather than block");
+
+        assert_eq!(
+            backend
+                .edit_barrier_stall_reported
+                .load(std::sync::atomic::Ordering::Acquire),
+            u64::MAX,
+            "a barrier that has caught up must not be reported, and must not \
+             claim the rate limiter's slot — doing so would suppress the next \
+             genuine stall at this position (#1657)",
+        );
+
+        // The positive case still works: a turn that is genuinely held is
+        // reported, and only then does the position get recorded.
+        let held = backend.edit_order.take_ticket("didOpen", &uri);
+        let held_at = backend.edit_order.served();
+        let _turn = backend.edit_order.wait_turn(held).await;
+        let queued = backend.edit_order.take_ticket("didChange", &uri);
+        let stalled_target = backend.edit_order.settle_target();
+        crate::rt::timeout(
+            std::time::Duration::from_secs(5),
+            backend.report_edit_barrier_stall(stalled_target),
+        )
+        .await
+        .expect("the reporter must return promptly rather than block");
+        assert_eq!(
+            backend
+                .edit_barrier_stall_reported
+                .load(std::sync::atomic::Ordering::Acquire),
+            held_at,
+            "a genuine stall must still be reported and recorded",
+        );
+        drop(queued);
     }
 
     /// Wait for the single document-sync handler under test to draw its

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -5587,6 +5587,35 @@ impl Backend {
     /// own a separate copy of it.  The salsa `SourceFile::text` input is a
     /// `String`, so exactly one copy is made here — the same single copy the
     /// caller used to make before handing it over (issue #1184).
+    /// # INVARIANT (no wedged sessions): never hold a salsa snapshot across an await
+    ///
+    /// The `set_text` / `SourceFile` calls below take `&mut` on the database,
+    /// which salsa 0.28 grants through `Storage::cancel_others`:
+    ///
+    /// ```text
+    /// let mut clones = self.handle.coordinate.clones.lock();
+    /// while *clones != 1 { clones = self.handle.coordinate.cvar.wait(clones); }
+    /// ```
+    ///
+    /// That is a **blocking** condvar wait, on a Tokio worker thread, for every
+    /// other `DatabaseImpl` clone in the process to be dropped. And this
+    /// function is called from `did_open` / `did_change` **while they hold the
+    /// [`EditOrder`] turn**, so for as long as it waits:
+    ///
+    /// * `now_serving` does not advance, so every later document-sync
+    ///   notification blocks in `wait_turn`;
+    /// * every request handler blocks in [`Backend::edits_settled`] and holds
+    ///   one of `DeferredConcurrency`'s four permits;
+    /// * the server answers nothing, writes nothing, and burns no CPU, while
+    ///   its stdin reader goes on draining input.
+    ///
+    /// That is issue #1657's signature exactly. So a `db.lock().await.clone()`
+    /// anywhere in this crate must be **moved straight into the worker it was
+    /// cloned for** and never held across an unrelated `.await`: a snapshot that
+    /// outlives its query does not slow one request down, it stops the server.
+    /// `scratchpad`-style audits will not catch it either — the mutex is
+    /// released the instant the clone is made, so it is invisible to a
+    /// lock-guard analysis; it is the *clone* salsa waits on.
     async fn db_set_source(&self, uri: &Uri, text: &str, dialect: String) {
         use salsa::Setter as _;
         // Salsa's `SourceFile.text` is the analyser's input, so it stores the
@@ -13330,16 +13359,27 @@ impl Backend {
         if !cross_file_on {
             return None;
         }
-        let db = self.db.lock().await.clone();
+        // Resolve everything else *before* cloning the database, and clone it
+        // only on the branch that immediately hands it to a worker.
+        //
+        // A salsa snapshot is not an ordinary handle. `set_text` (and creating a
+        // `SourceFile`) goes through `Storage::cancel_others`, which parks on a
+        // condvar until every **other** clone has been dropped — a blocking
+        // wait, taken on a Tokio worker, from inside the `EditOrder` turn that
+        // `did_open` / `did_change` hold. So a live snapshot does not merely
+        // delay one query: it stalls the document-sync barrier, and with it
+        // every request handler in the server (issue #1657).
+        //
+        // Holding one across an unrelated `.await` — as this did across the
+        // `db_project` lock, and on the `None` branch across the whole
+        // function — widens that window for no benefit. Cloning last keeps the
+        // snapshot's life exactly the worker's.
         let project = *self.db_project.lock().await;
-        match project {
-            Some(p) => {
-                crate::rt::spawn_blocking(move || tcl_lsp_db::project_command_arities(&db, p))
-                    .await
-                    .ok()
-            }
-            None => None,
-        }
+        let p = project?;
+        let db = self.db.lock().await.clone();
+        crate::rt::spawn_blocking(move || tcl_lsp_db::project_command_arities(&db, p))
+            .await
+            .ok()
     }
 
     /// Run the compiler-check diagnostics for `text` off the event-loop thread.

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -331,6 +331,20 @@ const DIAGNOSTICS_DEBOUNCE: std::time::Duration = std::time::Duration::from_mill
 /// next schedule therefore re-resolves.
 const DIAG_INPUTS_RESOLVE_ATTEMPTS: u32 = 4;
 
+/// How long a request may wait on the document-sync barrier before the server
+/// says so on its log channel.
+///
+/// Well past any honest wait — the barrier covers a buffer splice and a salsa
+/// input set, which are milliseconds — and well inside the budgets the editor
+/// harness allows a request, so the line lands while the run is still going
+/// rather than after it has given up.
+const EDIT_BARRIER_STALL_WARN: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Greppable marker on the stall line, so a CI log scan can classify a wedged
+/// run without reading the prose. Mirrors the harness's own
+/// `VSCODE-WAIT-TIMEOUT`.
+const EDIT_BARRIER_STALL_LOG: &str = "[stall] document-sync barrier has not advanced";
+
 /// Upper bound `semantic_tokens_full`/`_delta` wait for the fully enriched
 /// (SSA/SCCP-informed: regex-source retagging, user-class object-method
 /// resolution) token stream before falling back to the cheap coarse tier
@@ -4433,6 +4447,10 @@ pub struct Backend {
     /// Monotonic stamp for "the configuration the diagnostics scheduler caches
     /// has moved".  See [`Backend::invalidate_diag_inputs`].
     diag_inputs_epoch: std::sync::atomic::AtomicU64,
+    /// The `now_serving` position the last document-sync barrier stall was
+    /// reported at, so a wedge logs once rather than once per blocked request.
+    /// See [`Backend::report_edit_barrier_stall`].
+    edit_barrier_stall_reported: std::sync::atomic::AtomicU64,
     /// Shimmer-detection master switch (`tclLsp.shimmer.enabled`). When off,
     /// the Shimmer-family diagnostics (`S100`–`S110`) are suppressed. Default
     /// on.
@@ -4798,10 +4816,26 @@ impl EditOrder {
         self.advanced.notify_waiters();
     }
 
-    /// Wait until every edit that had drawn a ticket *before this call* has been
-    /// applied. Edits arriving later do not hold the caller up.
-    async fn settled(&self) {
-        let target = self.next_ticket.load(std::sync::atomic::Ordering::Acquire);
+    /// The ticket number a barrier taken *now* would have to reach.
+    ///
+    /// Split out so a caller can snapshot the target, wait on it with a
+    /// timeout, and then resume waiting on the **same** target — re-calling
+    /// [`Self::settled`] would re-read this and start waiting for edits that
+    /// arrived in the meantime, which is a different (and stricter) question.
+    fn settle_target(&self) -> u64 {
+        self.next_ticket.load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    /// How far the sequence has actually got.
+    fn served(&self) -> u64 {
+        self.now_serving.load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    /// Wait until every edit that had drawn a ticket before `target` has been
+    /// applied. Edits arriving later do not hold the caller up, which is why
+    /// the target is snapshotted by the caller ([`Self::settle_target`]) rather
+    /// than re-read here.
+    async fn settled_to(&self, target: u64) {
         loop {
             let advanced = self.advanced.notified();
             tokio::pin!(advanced);
@@ -5455,6 +5489,7 @@ impl Backend {
             feature_toggles: Mutex::new(FeatureToggles::default()),
             optimiser_enabled: Mutex::new(true),
             diag_inputs_epoch: std::sync::atomic::AtomicU64::new(0),
+            edit_barrier_stall_reported: std::sync::atomic::AtomicU64::new(u64::MAX),
             shimmer_enabled: Mutex::new(true),
             optimiser_profile: Mutex::new(default_optimiser_profile()),
             optimiser_code_overrides: Mutex::new(HashMap::new()),
@@ -6458,8 +6493,58 @@ impl Backend {
     /// Waits only for the edits that had already arrived ([`EditOrder::settled`]),
     /// so a later edit does not hold this reader up and readers never serialise
     /// against one another.
+    ///
+    /// A wait here that never ends is the shape of issue #1657 — the whole
+    /// server stops answering while burning no CPU — and from the outside it is
+    /// indistinguishable from any other stall. So a wait that overruns
+    /// [`EDIT_BARRIER_STALL_WARN`] says so on the client's log channel before
+    /// resuming, which names the barrier as the culprit and says exactly where
+    /// the sequence stopped. The extension-host capture quotes the tail of that
+    /// channel, so the next occurrence carries this line with it.
     async fn edits_settled(&self) {
-        self.edit_order.settled().await;
+        // Snapshot the target so the resumed wait asks the same question the
+        // timed-out one did, rather than a stricter one that includes edits
+        // which arrived while we waited.
+        let target = self.edit_order.settle_target();
+        if crate::rt::timeout(EDIT_BARRIER_STALL_WARN, self.edit_order.settled_to(target))
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        self.report_edit_barrier_stall(target).await;
+        self.edit_order.settled_to(target).await;
+    }
+
+    /// Announce that the document-sync barrier has stopped advancing.
+    ///
+    /// Rate-limited to one line per stuck position: in a real wedge *every*
+    /// request handler arrives here, and a log storm would push the very lines
+    /// a reader needs out of the captured tail. Reporting again once the
+    /// sequence has moved on is intentional — a barrier that stalls repeatedly
+    /// at successive positions is a different story from one that stopped dead.
+    async fn report_edit_barrier_stall(&self, target: u64) {
+        let serving = self.edit_order.served();
+        if self
+            .edit_barrier_stall_reported
+            .swap(serving, std::sync::atomic::Ordering::AcqRel)
+            == serving
+        {
+            return;
+        }
+        self.client
+            .log_message(
+                MessageType::WARNING,
+                format!(
+                    "{EDIT_BARRIER_STALL_LOG} for {}s: now_serving={serving}, waiting for \
+                     {target}, so {} document-sync notification(s) are queued behind a turn \
+                     nothing has handed on. Every request handler is blocked on this barrier \
+                     and the server will answer nothing until it moves (issue #1657).",
+                    EDIT_BARRIER_STALL_WARN.as_secs(),
+                    target.saturating_sub(serving),
+                ),
+            )
+            .await;
     }
 
     /// A snapshot of `url`'s text, **normalised for analysis**: every lone
@@ -7416,6 +7501,7 @@ impl Backend {
             feature_toggles: _,
             optimiser_enabled: _,
             diag_inputs_epoch: _,
+            edit_barrier_stall_reported: _,
             shimmer_enabled: _,
             optimiser_profile: _,
             optimiser_code_overrides: _,
@@ -27631,6 +27717,7 @@ mod tests {
             feature_toggles: Mutex::new(FeatureToggles::default()),
             optimiser_enabled: Mutex::new(true),
             diag_inputs_epoch: std::sync::atomic::AtomicU64::new(0),
+            edit_barrier_stall_reported: std::sync::atomic::AtomicU64::new(u64::MAX),
             shimmer_enabled: Mutex::new(true),
             optimiser_profile: Mutex::new(default_optimiser_profile()),
             optimiser_code_overrides: Mutex::new(HashMap::new()),
@@ -32397,9 +32484,12 @@ mod tests {
         // And the sequence is genuinely caught up, not merely unblocked: a
         // request barrier taken now must see every drawn ticket accounted for.
         assert!(
-            crate::rt::timeout(std::time::Duration::from_secs(5), order.settled())
-                .await
-                .is_ok(),
+            crate::rt::timeout(
+                std::time::Duration::from_secs(5),
+                order.settled_to(order.settle_target()),
+            )
+            .await
+            .is_ok(),
             "`settled` must not still be waiting on the abandoned ticket",
         );
     }

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -6490,9 +6490,9 @@ impl Backend {
     /// offsets. LSP requires a request to observe every notification that
     /// preceded it.
     ///
-    /// Waits only for the edits that had already arrived ([`EditOrder::settled`]),
-    /// so a later edit does not hold this reader up and readers never serialise
-    /// against one another.
+    /// Waits only for the edits that had already arrived
+    /// ([`EditOrder::settled_to`]), so a later edit does not hold this reader up
+    /// and readers never serialise against one another.
     ///
     /// A wait here that never ends is the shape of issue #1657 — the whole
     /// server stops answering while burning no CPU — and from the outside it is
@@ -6501,11 +6501,22 @@ impl Backend {
     /// resuming, which names the barrier as the culprit and says exactly where
     /// the sequence stopped. The extension-host capture quotes the tail of that
     /// channel, so the next occurrence carries this line with it.
+    ///
+    /// That reporting must not be paid for on the hot path. **Every** request
+    /// handler calls this, and in the overwhelmingly common case there is no
+    /// edit in flight at all, so the barrier is already satisfied: the check
+    /// below settles it in two atomic loads, allocating nothing and registering
+    /// no timer. Only a wait that genuinely has to block reaches the timeout —
+    /// which is cheaper than the previous unconditional `settled()`, since that
+    /// built a `Notified` even when it had nothing to wait for.
     async fn edits_settled(&self) {
         // Snapshot the target so the resumed wait asks the same question the
         // timed-out one did, rather than a stricter one that includes edits
         // which arrived while we waited.
         let target = self.edit_order.settle_target();
+        if self.edit_order.served() >= target {
+            return;
+        }
         if crate::rt::timeout(EDIT_BARRIER_STALL_WARN, self.edit_order.settled_to(target))
             .await
             .is_ok()


### PR DESCRIPTION
## Summary

Refs #1657

The whole-server wedge, caught in the act and traced to a blocking wait inside
the document-sync turn. Two fixes, an invariant written down where the danger
is, and instrumentation so the next occurrence — including on CI, where a
debugger is not an option — carries its own diagnosis. It already has: **this
PR's own CI run reproduced the wedge and diagnosed itself**, see Validation.

**Deliberately `Refs`, not `Fixes`.** The mechanism is convicted and the one
instance of the hazard class I could find is fixed, but the wedge still
reproduces — including on this PR's CI run — so *some* snapshot is still
outliving its worker and I have not yet found which. Auto-closing on merge would
retire the place that evidence should land. What this PR buys is that the next
occurrence, here or on CI, arrives already diagnosed instead of only
re-runnable, plus two real defects gone. Convert it to `Fixes` if you would
rather; my preference is to close it on a clean stretch of CI once the remaining
holder is found.

## Caught in the act

The stall detector fired in a wedged run, and the whole picture arrives in one
failure block:

```text
LIVENESS: SERVER WEDGED — …
  document-free getEffectiveConfig did NOT answer after 4001ms
  hover on livenessProbe.tcl (a different document) did NOT answer after 4001ms
  hover retried on the stalled document did NOT answer after 4001ms
  extension host: a 250ms timer woke 1.0x late, so the host is dispatching normally
  server process: pid 3973, state S, 6 thread(s); burned 0 CPU tick(s) …
  server threads: 5x futex, 1x read(fd 0)
  server log: last 6 of 10563 line(s) —
    [stall] document-sync barrier has not advanced for 10s: now_serving=369,
      waiting for 370, so 1 document-sync notification(s) are queued behind a turn
      nothing has handed on.
```

`now_serving=369`, `next_ticket=370` — **exactly one ticket outstanding**, held
and never handed on, and it never moved again for the rest of the run. Not a
queue that is merely slow: a turn that stopped. This was with the ticket-loss fix
already in the binary, so abandoned tickets were being drained — it is a **held**
turn, not a lost one.

A later run, once the holder-naming instrumentation was in, says which handler:

```text
[stall] document-sync barrier has not advanced for 10s: now_serving=526,
  waiting for 527, so 1 document-sync notification(s) are queued behind it.
  The turn is held by didOpen for 10.0s on …/testFixture/folding.tcl (ticket 526).
```

`did_open`'s turn region has exactly one call in it that can block
indefinitely — `db_set_source` — which is the next section.

## Why a turn holder can block for ever

`did_open` and `did_change` hold the turn across `db_set_source`, which calls
salsa's `set_text` (or creates a `SourceFile`). Salsa 0.28 grants `&mut` on the
database through `Storage::cancel_others` — `salsa-0.28.2/src/storage.rs:160`:

```rust
let mut clones = self.handle.coordinate.clones.lock();
while *clones != 1 {
    clones = self.handle.coordinate.cvar.wait(clones);
}
```

A **blocking condvar wait**, on a Tokio worker thread, for every *other*
`DatabaseImpl` clone in the process to be dropped. So for as long as any snapshot
is alive:

- `now_serving` cannot advance, so every later document-sync notification blocks
  in `wait_turn`;
- every request handler blocks in `edits_settled` and holds one of
  `DeferredConcurrency`'s four permits, so nothing is admitted and nothing is
  answered;
- the worker is parked on a futex rather than spinning → **0 CPU**;
- nothing is written → **0 bytes out**;
- `read_input` keeps draining stdin because the unbounded transport never stops
  taking from its queue → **a thread in `read(fd 0)`**.

Every line of the observed evidence, from one mechanism. It also explains the
correlation with pack activity: a pack reload re-analyses and re-indexes, which
is exactly when the most snapshots are in flight.

**This class is invisible to a lock-guard audit**, which is why my earlier passes
came back clean: the mutex is released the instant `db.lock().await.clone()`
returns, and it is the *clone* salsa waits on, not a guard.

## The fixes

**1 — snapshot lifetime.** `project_callback_arities_if` cloned the database and
*then* awaited the `db_project` lock, and on its `None` branch kept the clone
alive to the end of the function. It now resolves the project first and clones
only on the branch that hands the snapshot straight to its worker, so the
snapshot's life is exactly the worker's. A sweep of every other
`db.lock().await.clone()` site found them all already safe —
`warm_open_documents` even documents the hazard and takes its permit before
cloning — so this was the single offender. The invariant is now stated on
`db_set_source`, where the danger is, with the `cancel_others` excerpt and the
reason a lock-guard audit cannot find these.

**2 — `EditOrder` ticket loss.** Independent of the above, and proven on its own.
`take_ticket` returned a bare `u64` and `wait_turn` created the releasing
`EditTurn` only at the **grant**; between the two there was nothing, so a handler
future dropped while parked left `now_serving` pointing at a number no guard
would ever release. `wait_turn`'s own doc comment claimed the opposite — "the
guard releases it on drop — including on … a dropped (cancelled) handler future,
so a turn is never lost" — which holds only once the guard exists. The
reservation is now the guard: `wait_turn` takes the `EditTicket` **by value**, so
it lives inside the very future that might be dropped, and a dropped ticket
records itself as abandoned for `drain_abandoned` to step over.

`a_dropped_waiter_does_not_wedge_the_edit_order` **fails on `origin/rust`** —
that is the defect, not a regression guard written after the fact.

## Instrumentation, so the next one diagnoses itself

**Server.** A wait on `edits_settled` that overruns 10s logs a greppable
`[stall] document-sync barrier has not advanced …` naming where the sequence
stopped, how many notifications are queued behind it, and **which handler holds
the turn and for how long** — "held by nobody" being informative in its own
right, since that is the ticket-loss shape rather than the held-turn one. Then it
resumes waiting on the *same* target (`settled` gained a `settled_to` split so
the resumed wait does not silently become a stricter question).

It re-reads the barrier before claiming anything: the timeout can win its race by
a hair, and a report of a wedge that is already over would print "held by nobody"
with zero notifications queued — the *ticket-loss* shape, so it would point at
the wrong defect — and, worse, would claim the rate limiter's slot and suppress
the next genuine stall at that position (thanks to Codex review for catching
that). Rate-limited to one line per stuck position: in a real wedge every request
handler arrives there, and a storm would push the lines a reader needs out of the
captured tail. The check itself is kept off the hot path — every request calls
`edits_settled`, so the already-satisfied case settles in two atomic loads, which
is cheaper than the unconditional `settled()` it replaces.

**Harness.** The liveness capture now reports what each server thread is blocked
*in*, from `/proc/PID/task/TID/syscall`, including the descriptor a blocked
`read` or `write` names — which is how the reading above could say "the input
path is alive and it is answering none of it". This **replaces** the
per-descriptor byte-count idea I suggested on #1657 and had to retract:
`/proc/PID/fdinfo/N` reports `pos: 0` for a pipe and never advances, because a
pipe is not seekable. Verified on a blocked pipe reader before building on it.

## Ruled out along the way

| hypothesis | how |
|---|---|
| A lock-order cycle among the `Backend` locks | The #1622 lock-table method mechanised over `lib.rs`, guard liveness tracked and closed **interprocedurally**. 48 ordered pairs, no cycles. |
| A lock held across the barrier | Nothing holds a guard across `edits_settled` / `read_document` / `wait_for_workspace_scan`. |
| The #1334 outbound transport cycle | `stdio_pump` makes `poll_write` unconditionally ready behind an unbounded queue, so `print_output` cannot stall and `buffer_unordered` keeps being polled. |
| `$/cancelRequest` dropping a sync handler | `Cancellable::call` wraps a future in `future::abortable` only when `req.id()` is `Some` — requests. Notifications bypass it; `cancel_all` runs only on `exit`. |

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo fmt --all --check                       # rust/ and runtime/rust/ — clean
cargo clippy -p tcl-lsp-server --all-targets  # clean
cargo check --workspace                       # clean
cargo test -p tcl-lsp-server                  # 475 lib + 1505 e2e + 42 others, 0 failed
```

Two mutations, each failing exactly its own test and no other:

| mutation | test that fails |
|---|---|
| disable the abandonment recording in `EditTicket::drop` | `a_dropped_waiter_does_not_wedge_the_edit_order` |
| drop the post-timeout barrier recheck in the stall reporter | `a_barrier_that_has_caught_up_is_not_reported_as_a_stall` |

Throughout both, the three existing edit-order ordering tests
(`read_document_waits_for_an_in_flight_edit`,
`did_change_hands_its_edit_turn_on_before_the_scheduling_tail`,
`did_close_hands_its_edit_turn_on_before_the_reindex_tail`) stay green.

Extension host, `xvfb-run`, full suites (not a `MOCHA_GREP` subset): **921
passing / 0 failing / 1 pending** on two runs of the final commit, with **zero**
false stall lines; earlier in the round, one run wedged and produced the
conviction quoted at the top of this description. Sixteen full runs in total,
three wedges, all carrying the new diagnosis.

### This PR's own CI run reproduced the wedge — and diagnosed itself

`test-ext` on `de46dca95` failed with 868 passing / 4 failing / 38 pending, and
the capture explains it without a re-run:

```text
server threads: 6x futex, 1x read(fd 0)
[stall] document-sync barrier has not advanced for 10s: now_serving=552,
  waiting for 564, so 12 document-sync notification(s) are queued behind it.
  The turn is held by didOpen for 20.2s on …/testFixture/livenessProbe.tcl
  (ticket 552).
```

`didOpen` holding the turn again — a second environment, a different fixture —
and 20.2s already held when the first report fired, so the snapshot holder is
long-lived rather than a momentary overlap. Full write-up on #1657.

That report is also evidence the review fix behaves: it is *correct*
(`552 < 564`, a holder named, 12 queued), where a wrongly-firing recheck would
have printed `0 … queued` / `held by nobody` and a wrongly-suppressing one would
have printed nothing at all. Exactly one stall line was emitted, quoted in two
failure blocks, so the rate limiter held too.

`prettier --check` and `eslint` clean on the touched TypeScript.

## What is still open

The wedge still reproduces: `didOpen` holds the turn, which pins the stall to
`db_set_source`'s salsa wait, so a `DatabaseImpl` clone somewhere is outliving
the worker it was cloned for. Every `db.lock().await.clone()` site in `lib.rs`
now hands the snapshot straight to a `spawn_blocking`, so the remaining holder is
most likely a blocking analysis that runs long without reaching a cancellation
checkpoint — the pack-activity correlation fits, since a reload re-analyses
everything at once, and the CI reading above shows a 20-second hold.

The next step I would take is to count outstanding snapshots (a thin wrapper
around the clone, incremented and decremented on `Drop`) and report the count and
the oldest clone's age in the same stall line. That turns "some snapshot" into
"this one", and it is cheap. I have stopped short of it here rather than keep
growing this PR.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? **No** — LSP transport
      sequencing, salsa handle lifetime, and test-harness instrumentation; no
      owner surface in `docs/design/contracts/shared-utility-contracts-rust.md`
      is touched.
- [x] No diagnostic or optimisation code added or changed, so no
      `docs/kcs/codes/` page needed updating.
- [x] No new design doc; the invariant is recorded on the function that enforces
      it, which is where a future reader will be standing when it matters.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o
