### PR TITLE
hotfix(pages): use the wasm-safe clock in the stall timing #1664 added

### DIFF
--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -4772,7 +4772,11 @@ struct TurnHolder {
     /// The document it is for.
     uri: String,
     ticket: u64,
-    since: std::time::Instant,
+    /// `crate::rt::Instant`, never `std::time::Instant`: the latter compiles on
+    /// `wasm32-unknown-unknown` and then panics the moment it is called, which
+    /// aborts the browser worker and takes the page with it. The shim reads
+    /// `performance.now()` there and is a plain re-export of Tokio's natively.
+    since: crate::rt::Instant,
 }
 
 impl EditOrder {
@@ -4818,7 +4822,7 @@ impl EditOrder {
                     what: ticket.what,
                     uri: std::mem::take(&mut ticket.uri),
                     ticket: ticket.ticket,
-                    since: std::time::Instant::now(),
+                    since: crate::rt::Instant::now(),
                 });
                 return EditTurn { order: self };
             }


### PR DESCRIPTION
## Summary

Pages hotfix. #1664 (mine) turned the deploy red on the merge push, immediately
after #1663 had turned it green. Restores the deploy.

`std::time::Instant` **compiles** on `wasm32-unknown-unknown` and then panics the
moment it is called — "time not implemented on this platform". #1664 introduced
two uses of it, both in the `EditOrder` turn holder the stall report reads, so
the very first `didOpen` in the browser worker aborted:

```text
std::time::Instant::now
  <- tcl_lsp_server::EditOrder::wait_turn::{closure#0}
  <- Router::method::<DidOpenTextDocumentParams, .., did_open>
```

The abort kills the page — spec-studio's semantic-token request then times out
and the deploy fails. Same class F7 fixed in tcl-vm for #1661 / #1663; PR CI is
blind to it, which is #1662 and is now proven twice.

## The fix

`crate::rt::Instant` already exists for exactly this: a plain re-export of
Tokio's natively, a `performance.now()` shim on wasm, and its own doc says
`std::time::Instant` "compiles on wasm32-unknown-unknown but panics the moment it
is called, so timing sites use this instead". It is `Debug + Clone + Copy` and
has `elapsed()`, so it is a drop-in — two lines.

**Kept the timing rather than cfg-gating it off for wasm.** A turn held too long
is a bug in the browser worker too; the shim makes that reading correct there
rather than absent, so the diagnostic stays whole on every target. Gating would
have been less code and less honest.

## Sweep

Every `std::time::Instant` / `SystemTime` in the crate, not just the one in the
stack:

| site | verdict |
|---|---|
| `TurnHolder::since` (field) | **fixed** — was `std::time::Instant` |
| `TurnHolder::since` (`now()` in `wait_turn`) | **fixed** — the panicking call |
| `lib.rs:29459` `Instant::now`, `lib.rs:32538` `SystemTime::now` | inside `mod tests` (starts at 23119), never built for wasm |
| every other timing site (`3173`, `3233`, `14892`, `34212`) | already `crate::rt::Instant` |

Those two were the whole of #1664's exposure.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

**The gate that reproduces this class** (`make lsp-server-wasm-test`, built for
#1663):

- **before:** fails with the exact stack above — `RuntimeError: unreachable`,
  `std::time::Instant::now` ← `EditOrder::wait_turn::{closure#0}` ← `did_open`.
- **after:** `16/16 checks passed`.

Confirmed by stashing the fix and re-running, so this is a real before/after on
this tree rather than an inference from the CI log.

```
make lsp-server-wasm-test                     # 16/16, red before this change
make spec-studio-wasm                          # builds, 59M dist
make spec-studio-boot                          # skips — playwright not installed here
cargo fmt --all --check                        # rust/ and runtime/rust/ — clean
cargo clippy -p tcl-lsp-server --all-targets   # clean
cargo clippy -p tcl-lsp-server --target wasm32-unknown-unknown  # no new warnings
cargo check --workspace                        # clean
cargo test -p tcl-lsp-server                   # 475 lib + 1505 e2e + 42 others, 0 failed
```

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? **No** — two lines of
      timing in LSP transport instrumentation.
- [x] No diagnostic or optimisation code added or changed.
- [x] No new design doc; the reason is recorded on the field it governs.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o


---
_Generated by [Claude Code](https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o)_