### PR TITLE
fix(lsp): stop re-waking deleted-on-disk buffers; route the last element-ref splits through their owner (#1624, #1606)

### DIFF
--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -92,6 +92,23 @@ entry point, or gate moves without this contract being updated.
   may sit at offset 0, so a zero-length array name is legal — `set (x) 5`
   writes element `x` of the array named `""`. Both runtimes' element
   splitters bind it (#1458).
+
+  Consumers: `tcl-vm` (`interp::elem_ref`, `command::looks_like_element`,
+  `command::parent_namespace_of`, `exec`'s `ARRAY_MAKE_STK` guard),
+  `tcl-compiler` (`codegen::values::split_array_ref` / `is_array_ref`, the
+  facade the whole codegen layer calls, and
+  `analyser::diagnostics::var_command`'s array-element harvest), and — inside
+  the owner's own file — `split_array_name_for_style` and
+  `split_array_name_braced_for_style`. The last four re-derived the split
+  rather than calling it until #1606; none could diverge on any input
+  (`ends_with(')') && contains('(')` cannot be satisfied by a one-byte name),
+  which is exactly why the drift went unnoticed. `cargo xtask
+  owner-resolution` validates the manifest, not call graphs, so it cannot
+  catch a listed consumer that never calls its owner.
+
+  Deliberately **not** a consumer: `tcl-compiler`'s
+  `sccp::array_element_base` is a narrower fold-safety predicate (documented
+  at the site) that excludes the zero-length array name this owner admits.
 - `boolean` — `Tcl_GetBoolean` word recognition (unique prefixes of
   `true`/`yes`/`on`/`false`/`no`/`off`). Its prefix rule is *not* the
   option-table matcher below — boolean words have a fixed six-word

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -10048,6 +10048,36 @@ fn analyse_w123_filtered_by_disabled_diagnostics() {
     );
 }
 
+/// **TN/TP for the array-element constant harvest** — the W307 input whose
+/// element predicate is [`tcl_syntax::naming::split_element_ref`] (issue
+/// #1606). A dispatch through `$cmd(k)` is resolved from the literal the
+/// element was set to: a real command suppresses W307, an unknown one does
+/// not. If the harvest stops recognising `cmd(k)` as an element it collects
+/// no constant and the first case warns.
+#[test]
+fn w307_reads_the_constant_an_array_element_was_set_to() {
+    // `var_command_sites` is populated by the analyser's walk dispatch, so
+    // this must go through `analyse` rather than the emitter pipeline.
+    let codes = |src: &str| {
+        let mut a = Analyser::new();
+        a.analyse(src, "tcl8.6")
+            .diagnostics
+            .iter()
+            .map(|d| d.code.to_string())
+            .collect::<Vec<_>>()
+    };
+    let known = codes("proc f {} { set cmd(k) puts\n $cmd(k) hi }");
+    assert!(
+        !known.contains(&"W307".to_string()),
+        "the element's literal proves the head is `puts`; got {known:?}",
+    );
+    let unknown = codes("proc f {} { set cmd(k) nosuchcommand\n $cmd(k) hi }");
+    assert!(
+        unknown.contains(&"W307".to_string()),
+        "an element set to a non-command must still warn; got {unknown:?}",
+    );
+}
+
 #[test]
 fn analyse_w307_var_as_command() {
     // ``proc foo {} { $cmd arg1 }`` — ``$cmd`` (a non-parameter local

--- a/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
@@ -2641,7 +2641,9 @@ fn harvest_array_element_set_constants(
 ) {
     use crate::ir::Statement;
     let is_literal = |s: &str| !s.contains('$') && !s.contains('[');
-    let is_array_elem = |name: &str| name.contains('(') && name.ends_with(')');
+    // `TclObjLookupVarEx`'s element rule, from the one owner rather than a
+    // local re-spelling of its two char tests (issue #1606).
+    let is_array_elem = |name: &str| tcl_syntax::naming::split_element_ref(name).is_some();
     let units = std::iter::once(&cu.top_level).chain(cu.procedures.values());
     for fu in units {
         for block in fu.cfg.blocks.values() {

--- a/rust/tcl-compiler/src/codegen/values.rs
+++ b/rust/tcl-compiler/src/codegen/values.rs
@@ -670,6 +670,20 @@ mod tests {
         assert_eq!(split_array_ref("arr(${inner})"), Some(("arr", "${inner}")));
     }
 
+    /// The owner's edge cases hold through this facade (issues #1458, #1606):
+    /// both halves may be empty, and a `(` with nothing closing it is not a
+    /// reference. A local re-spelling that adds a "base must be non-empty"
+    /// test would silently demote `set (x) 5` to a scalar.
+    #[test]
+    fn split_array_ref_matches_the_owners_edges() {
+        assert_eq!(split_array_ref("(x)"), Some(("", "x")));
+        assert_eq!(split_array_ref("arr()"), Some(("arr", "")));
+        assert_eq!(split_array_ref("()"), Some(("", "")));
+        assert_eq!(split_array_ref(")"), None);
+        assert_eq!(split_array_ref("a(b"), None);
+        assert!(is_array_ref("(x)"));
+    }
+
     // -- is_array_ref, is_qualified --
 
     #[test]

--- a/rust/tcl-compiler/src/codegen/values.rs
+++ b/rust/tcl-compiler/src/codegen/values.rs
@@ -241,19 +241,22 @@ impl CodegenCtx<'_> {
 // -- Array reference helpers --
 
 /// Split `arr(key)` into `("arr", "key")`, or `None` for scalars.
+///
+/// The codegen-side facade over the one element-split owner,
+/// [`split_element_ref`](tcl_syntax::naming::split_element_ref) —
+/// `TclObjLookupVarEx`'s rule (`tclVar.c(9.0.4):683-686`). It carried a
+/// byte-equivalent re-implementation until issue #1606; both halves may be
+/// empty, so `(x)` is element `x` of the array named `""` (issue #1458).
 #[must_use]
 pub fn split_array_ref(name: &str) -> Option<(&str, &str)> {
-    if let (Some(open), true) = (name.find('('), name.ends_with(')')) {
-        Some((&name[..open], &name[open + 1..name.len() - 1]))
-    } else {
-        None
-    }
+    tcl_syntax::naming::split_element_ref(name)
 }
 
-/// Return `true` if `name` is an array reference like `arr(key)`.
+/// Return `true` if `name` is an array reference like `arr(key)` — the
+/// predicate half of [`split_array_ref`], from the same owner.
 #[must_use]
 pub fn is_array_ref(name: &str) -> bool {
-    name.contains('(') && name.ends_with(')')
+    split_array_ref(name).is_some()
 }
 
 /// Return `true` for namespace-qualified variable names (`::foo`).

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -975,6 +975,13 @@ pub struct ExistenceFrame<'a> {
 /// dynamic `Params($k)`), `None` for every other shape.  Only a simple local
 /// base qualifies: a namespaced array (`::env(PATH)`) may be populated
 /// outside the function's view.
+///
+/// Deliberately **not**
+/// [`split_element_ref`](tcl_syntax::naming::split_element_ref) (issue #1606):
+/// this is a narrower *fold-safety* predicate, and its extra tests — non-empty
+/// base, bareword base — are the point. The owner admits the zero-length array
+/// name `(k)` that `TclObjLookupVarEx` admits, which is not a name this fold
+/// may reason about.
 fn array_element_base(var: &str) -> Option<&str> {
     let (base, rest) = var.split_once('(')?;
     if base.is_empty() || !rest.ends_with(')') {

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -3791,18 +3791,23 @@ impl IndexedDiagnosticChange {
 /// fact of its own — the common case, a caller that defines nothing — wakes
 /// nobody.
 ///
-/// Orphaned buffers are excluded (issue #1624). "Open but unindexed" is
-/// otherwise a *transient* state a document leaves for good at its first
-/// debounced publish, which is what makes the set self-limiting. A buffer whose
-/// backing file was deleted out of band is the one way to be in it permanently:
-/// [`publish_diagnostics_result`] deliberately calls `remove_document` for those
-/// rather than re-adding them (re-adding is what used to resurrect the ghost
-/// `did_change_watched_files` had just retired), so it is open and never indexed
-/// for as long as it stays open. Without this filter every fact-moving publish
-/// anywhere in the workspace re-woke it to re-derive the same answer — bounded
-/// and never a cascade (its own publish moves nothing, so it wakes nobody), but
-/// pure waste. The same `backing_file_deleted` flag the caller reads to choose
-/// removal over replacement decides it here.
+/// Orphaned buffers are excluded (issue #1624) — this is the **transient**
+/// set, and only transience makes it self-limiting: a document is in it just
+/// between its `didOpen` and its first debounced publish, after which
+/// `replace_document` puts it in the index and it leaves for good. A buffer
+/// whose backing file was deleted out of band is the one way to be in it
+/// permanently, because [`publish_diagnostics_result`] deliberately calls
+/// `remove_document` for those rather than re-adding them (re-adding is what
+/// used to resurrect the ghost `did_change_watched_files` had just retired), so
+/// it is open and never indexed for as long as it stays open. Blanket-waking it
+/// on every fact-moving publish anywhere in the workspace is the waste #1624
+/// describes.
+///
+/// That exclusion is **not** a ruling that an orphan needs no diagnostics
+/// refresh — it still consumes workspace facts, and losing that was the defect
+/// the #1666 review caught. [`orphaned_fact_consumers`] carries the consumption
+/// half, targeted by what actually moved; the two sets are disjoint by
+/// construction and are extended together at the one call site.
 fn unindexed_open_documents(
     index: &core_workspace_index::WorkspaceIndex,
     docs: &HashMap<Uri, DocumentState>,
@@ -3812,6 +3817,71 @@ fn unindexed_open_documents(
         .map(|(uri, _)| uri.as_str())
         .filter(|uri| !index.contains_document(uri))
         .map(ToOwned::to_owned)
+        .collect()
+}
+
+/// The **orphaned** open buffers a fact-moving publish must still wake.
+///
+/// Absence from the index is two separate facts about such a buffer, and
+/// [`unindexed_open_documents`] alone conflates them (#1666 review):
+///
+/// * It must not **contribute** facts. Its path is dead, so re-indexing it
+///   duplicates every proc of the file it was renamed to and sends
+///   go-to-definition somewhere the editor cannot open — the ghost
+///   `did_change_watched_files` had just retired. `publish_diagnostics_result`
+///   keeps calling `remove_document` for it, and that stays true.
+/// * It does still **consume** them. The buffer is on screen and its squiggles
+///   are read like any other's, so when a peer changes the arity of a proc it
+///   calls, its `E002`/`W123` are wrong until something recomputes them. No
+///   other set can name it: [`command_diagnostic_consumers`] and the source
+///   walkers all read the consumer's own records *from* the index, and it has
+///   none there for as long as it stays open.
+///
+/// So the contribution filter lives on the index write, and this is the
+/// consumption half — deliberately a *separate* set rather than a relaxation
+/// of [`unindexed_open_documents`], which must stay orphan-free to keep the
+/// property #1624 asked for: that set is the transient-race fallback, and it is
+/// self-limiting only because every document in it leaves at its first publish.
+///
+/// Targeted, not blanket — which is what makes this compatible with #1624's
+/// complaint rather than a revert of it:
+///
+/// * A **source or package** move can change what the orphan's own calls
+///   resolve to without renaming anything, so it is not filterable by name and
+///   wakes every orphan. These are rare (a `source`/`package require` edit),
+///   not the per-keystroke firehose.
+/// * A **command-signature** change wakes only orphans whose text mentions the
+///   changed name. A conservative substring test on purpose: any real call
+///   spells the name, so this cannot miss a consumer, and the worst case is a
+///   redundant re-analysis for a name that appears only in a comment. The
+///   precise index rule is unavailable here — its input is exactly the call-site
+///   records this document does not have — so it is approximated rather than
+///   re-derived, and approximated on the safe side.
+///
+/// Terminating for the same reason the transient set is: an orphan's own
+/// publish has `before = absent, after = absent`, so it moves no fact and wakes
+/// nobody.
+fn orphaned_fact_consumers(
+    docs: &HashMap<Uri, DocumentState>,
+    change: &IndexedDiagnosticChange,
+) -> Vec<String> {
+    // Match the index rule's key: it compares invocation names against the
+    // changed names' unqualified tails, and a call site spells the tail.
+    let tails: Vec<&str> = change
+        .command_names
+        .iter()
+        .map(|name| {
+            let qualified = name.trim_start_matches("::");
+            qualified.rsplit("::").next().unwrap_or(qualified)
+        })
+        .filter(|tail| !tail.is_empty())
+        .collect();
+    docs.iter()
+        .filter(|(_, doc)| doc.backing_file_deleted)
+        .filter(|(_, doc)| {
+            change.source_or_package_changed || tails.iter().any(|tail| doc.text.contains(tail))
+        })
+        .map(|(uri, _)| uri.as_str().to_owned())
         .collect()
 }
 
@@ -4026,10 +4096,15 @@ async fn publish_diagnostics_result(
                 consumers.extend(before.stale_source_consumers(&index, delivery.uri.as_str()));
                 consumers.extend(source_diagnostic_consumers(&index, delivery.uri.as_str()));
             }
-            // …plus the open documents this write could have raced — see
-            // [`unindexed_open_documents`] (issue #1619).
+            // …plus the open documents no index query can reach. Two disjoint
+            // sets, one per role: documents the index does not hold *yet*
+            // (the #1619 race, transient), and orphaned buffers it will never
+            // hold again but which still consume what this write moved (#1666
+            // review). Neither can be found by the queries above, for opposite
+            // reasons.
             if change.moved_workspace_facts() {
                 consumers.extend(unindexed_open_documents(&index, &docs));
+                consumers.extend(orphaned_fact_consumers(&docs, &change));
             }
             (change, consumers)
         };
@@ -24242,6 +24317,105 @@ mod tests {
             woken,
             HashSet::from([just_opened.as_str().to_owned()]),
             "only the transiently unindexed buffer is woken by hand",
+        );
+    }
+
+    /// **The other half of the same buffer's story** (#1666 review). Being
+    /// absent from the index is two facts about an orphan, not one: it must
+    /// not *contribute* — its path is dead, and re-adding it resurrects the
+    /// ghost `did_change_watched_files` retired — but it does still *consume*.
+    /// The buffer is on screen and its squiggles are read, so when a peer
+    /// changes the arity of a proc it calls, its E002/W123 must be recomputed.
+    /// Nothing else can name it: the index-driven consumer queries read its
+    /// call-site records from the index, and it has none there.
+    ///
+    /// TP: the orphan calls `helper`, whose signature moved. TN: a change to
+    /// an unrelated name leaves it alone, so this stays a targeted wake and
+    /// not the blanket re-wake #1624 removed.
+    #[test]
+    fn an_orphan_is_still_woken_by_a_signature_it_consumes() {
+        let orphan = Uri::from_file_path("/proj/orphan.tcl").unwrap();
+        let live = Uri::from_file_path("/proj/live.tcl").unwrap();
+        let mut docs: HashMap<Uri, DocumentState> = HashMap::new();
+        docs.insert(
+            orphan.clone(),
+            DocumentState::new("helper 1\n".to_owned(), "tcl8.6".to_owned()),
+        );
+        docs.insert(
+            live.clone(),
+            DocumentState::new("helper 1\n".to_owned(), "tcl8.6".to_owned()),
+        );
+        docs.get_mut(&orphan).unwrap().backing_file_deleted = true;
+
+        let consumed = IndexedDiagnosticChange {
+            command_names: HashSet::from(["::helper".to_owned()]),
+            source_or_package_changed: false,
+        };
+        assert_eq!(
+            orphaned_fact_consumers(&docs, &consumed),
+            vec![orphan.as_str().to_owned()],
+            "the orphan calls `helper`, so a change to its signature reaches it",
+        );
+
+        let unrelated = IndexedDiagnosticChange {
+            command_names: HashSet::from(["::unrelated".to_owned()]),
+            source_or_package_changed: false,
+        };
+        assert!(
+            orphaned_fact_consumers(&docs, &unrelated).is_empty(),
+            "a name the orphan never mentions must not wake it",
+        );
+
+        // A source-graph or package move can change what the orphan's own
+        // calls resolve to without renaming anything, so it is not filterable
+        // by name.
+        let graph_moved = IndexedDiagnosticChange {
+            command_names: HashSet::new(),
+            source_or_package_changed: true,
+        };
+        assert_eq!(
+            orphaned_fact_consumers(&docs, &graph_moved),
+            vec![orphan.as_str().to_owned()],
+        );
+    }
+
+    /// The same defect stated where it bites, over the **union** of every
+    /// consumer set a publish builds (#1666 review). `live.tcl` changes
+    /// `helper`'s arity; the orphan calls `helper 1` and is on screen with a
+    /// now-wrong E002. It is absent from the index, so
+    /// [`command_diagnostic_consumers`] cannot see its call site, and it is
+    /// excluded from [`unindexed_open_documents`] by #1624 — without
+    /// [`orphaned_fact_consumers`] no set names it and its squiggles stay
+    /// stale with no signal.
+    #[test]
+    fn every_consumer_set_together_still_names_an_orphaned_caller() {
+        let live = Uri::from_file_path("/proj/live.tcl").unwrap();
+        let orphan = Uri::from_file_path("/proj/orphan.tcl").unwrap();
+        // The index holds the publishing document only: the orphan was removed
+        // from it by its own publish, exactly as `remove_document` leaves it.
+        let index = ws_index(&[(&live, "proc helper {a b} {}\n")]);
+
+        let mut docs: HashMap<Uri, DocumentState> = HashMap::new();
+        docs.insert(
+            live.clone(),
+            DocumentState::new("proc helper {a b} {}\n".to_owned(), "tcl8.6".to_owned()),
+        );
+        docs.insert(
+            orphan.clone(),
+            DocumentState::new("helper 1\n".to_owned(), "tcl8.6".to_owned()),
+        );
+        docs.get_mut(&orphan).unwrap().backing_file_deleted = true;
+
+        let change = IndexedDiagnosticChange {
+            command_names: HashSet::from(["::helper".to_owned()]),
+            source_or_package_changed: false,
+        };
+        let mut consumers = command_diagnostic_consumers(&index, &change.command_names);
+        consumers.extend(unindexed_open_documents(&index, &docs));
+        consumers.extend(orphaned_fact_consumers(&docs, &change));
+        assert!(
+            consumers.contains(orphan.as_str()),
+            "an on-screen orphan consuming the changed signature must be woken; got {consumers:?}",
         );
     }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -3790,12 +3790,26 @@ impl IndexedDiagnosticChange {
 /// set this can draw from strictly shrinks, and a peer that moves no workspace
 /// fact of its own — the common case, a caller that defines nothing — wakes
 /// nobody.
+///
+/// Orphaned buffers are excluded (issue #1624). "Open but unindexed" is
+/// otherwise a *transient* state a document leaves for good at its first
+/// debounced publish, which is what makes the set self-limiting. A buffer whose
+/// backing file was deleted out of band is the one way to be in it permanently:
+/// [`publish_diagnostics_result`] deliberately calls `remove_document` for those
+/// rather than re-adding them (re-adding is what used to resurrect the ghost
+/// `did_change_watched_files` had just retired), so it is open and never indexed
+/// for as long as it stays open. Without this filter every fact-moving publish
+/// anywhere in the workspace re-woke it to re-derive the same answer — bounded
+/// and never a cascade (its own publish moves nothing, so it wakes nobody), but
+/// pure waste. The same `backing_file_deleted` flag the caller reads to choose
+/// removal over replacement decides it here.
 fn unindexed_open_documents(
     index: &core_workspace_index::WorkspaceIndex,
     docs: &HashMap<Uri, DocumentState>,
 ) -> Vec<String> {
-    docs.keys()
-        .map(|uri| uri.as_str())
+    docs.iter()
+        .filter(|(_, doc)| !doc.backing_file_deleted)
+        .map(|(uri, _)| uri.as_str())
         .filter(|uri| !index.contains_document(uri))
         .map(ToOwned::to_owned)
         .collect()
@@ -24190,6 +24204,40 @@ mod tests {
         assert_eq!(
             source_diagnostic_consumers(&index, child.as_str()),
             HashSet::from([root.as_str().to_owned(), grandchild.as_str().to_owned(),]),
+        );
+    }
+
+    /// **TP/TN for the hand-built wake set** (issues #1619, #1624).  A document
+    /// that is open but not in the index is woken — that is the race #1619
+    /// closed — *unless* its backing file was deleted out of band, in which case
+    /// it is unindexed permanently rather than transiently: the publish path
+    /// removes rather than replaces it, so it would otherwise be re-woken by
+    /// every fact-moving publish anywhere in the workspace, for ever, to
+    /// re-derive the same answer.  An indexed document is never in this set at
+    /// all — the index-driven consumer queries find those.
+    #[test]
+    fn the_wake_set_skips_a_buffer_whose_backing_file_was_deleted() {
+        let indexed = Uri::from_file_path("/proj/indexed.tcl").unwrap();
+        let just_opened = Uri::from_file_path("/proj/just-opened.tcl").unwrap();
+        let orphaned = Uri::from_file_path("/proj/orphaned.tcl").unwrap();
+        let index = ws_index(&[(&indexed, "proc helper {a} {}\n")]);
+
+        let mut docs: HashMap<Uri, DocumentState> = HashMap::new();
+        for uri in [&indexed, &just_opened, &orphaned] {
+            docs.insert(
+                uri.clone(),
+                DocumentState::new("helper 1\n".to_owned(), "tcl8.6".to_owned()),
+            );
+        }
+        docs.get_mut(&orphaned).unwrap().backing_file_deleted = true;
+
+        let woken: HashSet<String> = unindexed_open_documents(&index, &docs)
+            .into_iter()
+            .collect();
+        assert_eq!(
+            woken,
+            HashSet::from([just_opened.as_str().to_owned()]),
+            "only the transiently unindexed buffer is woken by hand",
         );
     }
 

--- a/rust/tcl-syntax/src/naming.rs
+++ b/rust/tcl-syntax/src/naming.rs
@@ -708,12 +708,13 @@ pub fn split_array_name_braced_for_style(
     if !braced_literal {
         return split_array_name_for_style(name, style);
     }
-    if name.ends_with(')')
-        && let Some(idx) = name.find('(')
-    {
-        return (&name[..idx], Some(&name[idx + 1..name.len() - 1]));
+    // A braced-literal word carries no sigil to strip, so the element split is
+    // the owner's rule applied to the whole word — call it rather than
+    // re-deriving it here (issue #1606).
+    match split_element_ref(name) {
+        Some((array, elem)) => (array, Some(elem)),
+        None => (name, None),
     }
-    (name, None)
 }
 
 /// Whether a variable's **name** can only ever appear in source inside


### PR DESCRIPTION
## Summary

Two independent pre-release items, kept in separate commits, plus one review fix.

**#1624 — the cross-file wake set no longer re-wakes a deleted-on-disk buffer** (`rust/tcl-lsp-server/src/lib.rs`)

`unindexed_open_documents` (added by #1622 to close the #1619 didOpen race) wakes every open document the workspace index does not hold. That state is normally *transient* — a document is in it only between its `didOpen` and its first debounced publish — which is what makes the set self-limiting. A buffer whose backing file was deleted out of band is the one way to be in it permanently: the publish path deliberately calls `remove_document` for those rather than re-adding them, so every fact-moving publish anywhere in the workspace re-woke it. The `backing_file_deleted` flag now decides membership, so the set holds only transiently unindexed documents by construction.

**Review follow-up — an orphan stops *contributing* facts but keeps *consuming* them** (`da2c13463`)

Codex raised a P2 that the above conflated two roles one set was serving, and it was right. Absence from the index says two different things about an orphaned buffer:

- It must not **contribute**: its path is dead, so re-indexing duplicates every proc of the file it was renamed to and sends go-to-definition somewhere the editor cannot open. `remove_document` stays.
- It does still **consume**: the buffer is on screen and its squiggles are read. If it calls `helper 1` and a peer changes `helper`'s arity, its E002/W123 is wrong, and nothing could name it — the index-driven queries read a consumer's own call-site records *from* the index, and it has none there.

Reproduced first: with every pre-fix consumer set in play, the computed set for that scenario came back **empty**. The fix is a second, consumption-side set (`orphaned_fact_consumers`) rather than a weaker filter, so #1624's property survives — `unindexed_open_documents` stays the transient-race fallback and stays orphan-free. Targeted, not blanket: a source/package move wakes every orphan (it changes resolution without renaming anything, and is rare), while a signature change wakes only orphans whose text mentions the changed name — a conservative substring test, since any real call spells the name, so it cannot miss a consumer.

**#1606 — the last element-ref split duplicates route through their owner** (`rust/tcl-syntax`, `rust/tcl-compiler`, contract doc)

`tcl_syntax::naming::split_element_ref` owns the `name(index)` split (`TclObjLookupVarEx`, `tclVar.c(9.0.4):683-686`). Three sites still re-derived it:

- `codegen::values::split_array_ref` / `is_array_ref` — a full re-implementation. Now one-line facades over the owner, keeping their names so the ~18 codegen call sites are untouched; this matches the pattern #1591 used for the VM copies (`interp::elem_ref`, `command::looks_like_element`).
- `analyser::diagnostics::var_command`'s array-element constant harvest — a local `contains('(') && ends_with(')')` closure.
- `naming::split_array_name_braced_for_style` — re-derived inside the owner's own file.

No behaviour change: one byte cannot satisfy both char tests, so each copy decided every input exactly as the owner does. Each also carried the #1458 zero-length-array-name admission by luck rather than by contract.

`sccp::array_element_base` stays hand-rolled per the issue, and now says so at the site: it is a narrower fold-safety predicate whose non-empty-base test is the point.

The owner's contract entry gains an explicit consumer list (both VM sites, both compiler sites, both in-file sites), the deliberate `sccp` non-consumer, and a note that `cargo xtask owner-resolution` validates the manifest rather than call graphs — which is why these survived it.

### Mutation verification

Every fix was committed before mutating, and the whole battery re-run against the final tree.

| Mutation | Consumer test that fails |
| --- | --- |
| wake set admits orphans (`!doc.backing_file_deleted` relaxed) | `the_wake_set_skips_a_buffer_whose_backing_file_was_deleted` |
| consumption filter `\|\|` to `&&` (under-approximate — the review's defect) | `an_orphan_is_still_woken_by_a_signature_it_consumes`, `every_consumer_set_together_still_names_an_orphaned_caller` |
| consumption filter replaced by `true` (blanket re-wake — the #1624 waste) | the TN half of `an_orphan_is_still_woken_by_a_signature_it_consumes` |
| owner rejects the zero-length array name (#1458) | `codegen::values::tests::split_array_ref_matches_the_owners_edges` |
| owner refuses names containing `k` | `split_array_ref_basic` (facade), `w307_reads_the_constant_an_array_element_was_set_to` (harvest), `naming::split_array_name_braced` doctest (in-file split) — one per routed consumer |

The zero-length mutation found a real coverage gap first: it was invisible to the entire `tcl-compiler` suite (5898 tests green). Nothing at the consumer end pinned that half of the contract, and the `var_command` harvest had no coverage at all. Both now do.

### Considered and deliberately not done

- **Indexing an orphan "consumer-only"** — keeping its invocation records while dropping its definitions — would make the index-driven queries reach it directly. Rejected: `contains_document` / `document_uris` feed several production paths (whole-workspace consumer coverage, disk re-analysis), so putting a dead path back in that list risks the exact ghost `remove_document` exists to prevent, and it would move a `tcl-lsp-core` surface every consuming crate reads. The per-role sets stay in the one file that already decides the roles.
- **Three further element-split spellings outside #1606's audited list**, each carrying an extra condition so none is a pure duplicate: `analyser/diagnostics/usage.rs` (W216 `${arr($foo)}` shape, plus a non-empty-name test), `tcl-lsp-core/src/semantic_tokens.rs` (inline predicate), `compiler/value_shapes.rs` (plus a `!contains('}')` test). Noted on #1606 for a follow-up rather than folded in here.

## Validation

All commands inline-prefixed with `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=2`, run from `rust/`, crate-scoped (shared box). Re-run on the final tree after the review fix.

- `cargo fmt --all --check` — clean in both `rust/` and `runtime/rust/`
- `cargo clippy -p tcl-syntax --features num-bigint --all-targets` / `-p tcl-compiler --all-targets` / `-p tcl-lsp-server --all-targets` — no warnings
- `cargo check --workspace` — clean
- `cargo run -p xtask -- owner-resolution` — OK, 21 owner rows
- Consuming-crate suites, all green: `cargo test -p tcl-syntax --features num-bigint` (`num-bigint` is required — the `number_tower` test backend needs `num_traits`, a pre-existing condition on `rust`), `-p tcl-compiler` (5899 lib + all integration), `-p tcl-lsp-server` (478 lib, 1505 e2e, 22 preview-ticket, 14 smoke, 6 stdio), `-p tcl-lsp-core`, `-p tcl-vm`, `-p tcl-registry`, `-p tcl-spec-studio`

- [x] I ran relevant tests/checks locally and listed the exact commands.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? No — the #1606 routing is behaviour-preserving, verified by equivalence and by the mutation table above.
- [x] The owning design doc was updated anyway: `docs/design/contracts/shared-utility-contracts-rust.md` gains the owner's consumer list and the `sccp` non-consumer note.
- [x] No diagnostic or optimisation code added or changed.
- [x] No new design doc.

Fixes #1624
Fixes #1606

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o