### PR TITLE
fix(compiler): one owner for dict canonicalisation; retire the producer-less `$={name}` marker (#1608, #1617)

### DIFF
--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -34,7 +34,7 @@ entry point, or gate moves without this contract being updated.
 | --- | --- | --- | --- | --- |
 | names / namespaces | `rust/tcl-syntax/src/naming.rs`; `rust/tcl-cmd-core/src/namespace.rs` | `qualifier_segments`; `command_resolution_candidates`; `qualifiers`; `tail`; `which_command`; `which_command_bytes`; `which_variable`; `variable_fqn`; `variable_fqn_bytes`; `origin`; `origin_bytes` | invariant, except `which_variable`'s alternate (global) candidate, which 9.0 drops; absolute-marker contract from #1493 | `xtask-resolution-drift` |
 | lists | `rust/tcl-syntax/src/list.rs` | `find_element`; `split_list`; `list_element`; `join_list`; `append_list_element`; `junk_fragment` | invariant | none |
-| dicts | `rust/tcl-syntax/src/list.rs`; `rust/tcl-syntax/src/value.rs` | `find_element`; `split_list`; `ValueOps::dict_pairs` | invariant | none |
+| dicts | `rust/tcl-syntax/src/list.rs`; `rust/tcl-syntax/src/value.rs` | `find_element`; `split_list`; `canonical_dict_slots`; `ValueOps::dict_pairs` | invariant | none |
 | glob matching | `rust/tcl-syntax/src/glob.rs` | `string_match`; `string_case_match` | invariant | none |
 | switch body grammar | `rust/tcl-syntax/src/switch_body.rs` | `tokenise_switch_body`; `parse_braced_pairs` | invariant | none |
 | numbers | `rust/tcl-syntax/src/number.rs`; `rust/tcl-dialect/src/expr_number.rs`; `rust/tcl-dialect/src/grammar.rs` | `parse`; `parse_whole_with`; `is_expr_number`; `scan_expr_number`; `scan_nan_payload`; `NumberSyntax` | `NumberSyntax` and expression-word grammar per release | `xtask-number-drift` |
@@ -577,6 +577,21 @@ helper without reading the rationale:
   `dict_parse_errors_use_the_dict_noun_and_error_code` (#1573);
   `rust/tcl-vm/tests/cross_version_command_surface_e2e.rs` — the
   *foldable* `dict create` availability vector.
+- `rust/tcl-vm/tests/dict_canonicalisation_parity.rs` — the cross-crate
+  gate for `canonical_dict_slots` (#1608). The canonicalisation rule
+  ("first-occurrence key position, last value wins") had three
+  independent implementations plus one surface that had *missed* it, and
+  `owner-resolution` cannot see that class of drift: it validates the
+  manifest, not whether a surface calls the owner at all. The rule is now
+  one function, and this suite feeds a duplicate-key / odd-shape corpus
+  through every binding — the `ValueOps` seam, the registry `dict`
+  const-folds via `run_const_fold`, and the codegen's
+  `fold_dict_create_cmd` — asserting byte identity against each other and
+  against real tclsh8.6/9.0. The WASM runtime's native dict rep
+  (`runtime/rust/src/dict.rs`) canonicalises *incrementally* across
+  mutation instead, so it binds the rule by agreement rather than by
+  construction; `duplicate_keys_canonicalise_like_the_shared_owner` there
+  is its leg of the same gate.
 - `rust/tcl-lexer/src/ranges.rs` —
   `braced_var_name_end_follows_the_release_rule`;
   `rust/tcl-vm/tests/cross_version_vars_e2e.rs` —

--- a/runtime/rust/src/dict.rs
+++ b/runtime/rust/src/dict.rs
@@ -555,7 +555,10 @@ mod tests {
                     .into_iter()
                     .map(|(k, val)| (k.as_bytes().to_vec(), val.as_bytes().to_vec()))
                     .collect();
-                assert_eq!(got, want, "native dict rep diverges from the owner on {source:?}");
+                assert_eq!(
+                    got, want,
+                    "native dict rep diverges from the owner on {source:?}"
+                );
                 unsafe { obj::decr_ref_count(v) };
             }
         });

--- a/runtime/rust/src/dict.rs
+++ b/runtime/rust/src/dict.rs
@@ -509,6 +509,58 @@ mod tests {
         });
     }
 
+    /// Issue #1608 — this runtime's native dict rep is the one binding of the
+    /// canonicalisation rule that is *not* a call to the shared owner
+    /// [`tcl_syntax::value::canonical_dict_slots`]: it keeps a live key index
+    /// across mutation, so it canonicalises incrementally (one
+    /// `Tcl_DictObjPut` per insert) rather than in one walk over the elements.
+    /// That makes it exactly the shape the owner cannot enforce by
+    /// construction, so it is pinned by agreement instead — the same corpus
+    /// the cross-crate gate `rust/tcl-vm/tests/dict_canonicalisation_parity.rs`
+    /// drives through the other bindings.
+    #[test]
+    fn duplicate_keys_canonicalise_like_the_shared_owner() {
+        leak_free(|| {
+            for source in [
+                "a 1 a 2",
+                "a 1 b 2 a 3",
+                "x 1 x 2 y 3",
+                "a 1 a 2 a 3",
+                "{k k} 1 {k k} 2",
+                "a b b a a c",
+                "1 one 01 oh-one 1 uno",
+            ] {
+                // The owner's answer, from the same decoded elements.
+                let elements = tcl_syntax::list::split_list_lenient(source);
+                let keys: Vec<&str> = elements.iter().step_by(2).map(AsRef::as_ref).collect();
+                let want: Vec<(&str, &str)> =
+                    tcl_syntax::value::canonical_dict_slots(keys.iter().copied())
+                        .into_iter()
+                        .map(|(key_slot, value_slot)| {
+                            (
+                                elements[key_slot * 2].as_ref(),
+                                elements[value_slot * 2 + 1].as_ref(),
+                            )
+                        })
+                        .collect();
+
+                let v = new_string_bytes(source.as_bytes());
+                unsafe { obj::incr_ref_count(v) };
+                let got: Vec<(Vec<u8>, Vec<u8>)> = dict_pairs(v)
+                    .unwrap()
+                    .into_iter()
+                    .map(|(k, val)| (bytes(k), bytes(val)))
+                    .collect();
+                let want: Vec<(Vec<u8>, Vec<u8>)> = want
+                    .into_iter()
+                    .map(|(k, val)| (k.as_bytes().to_vec(), val.as_bytes().to_vec()))
+                    .collect();
+                assert_eq!(got, want, "native dict rep diverges from the owner on {source:?}");
+                unsafe { obj::decr_ref_count(v) };
+            }
+        });
+    }
+
     #[test]
     fn odd_length_string_is_an_error() {
         leak_free(|| {

--- a/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
+++ b/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
@@ -116,9 +116,7 @@ fn literal_true_expr() -> ExprNode {
 /// So the arm-pruning behaviour is unchanged, and an unsubstituted subject word
 /// can never be compared as if it were its own literal text.
 fn switch_subject_operand(subject: &str) -> ExprNode {
-    use crate::codegen::values::parse_braced_scalar_ref;
-
-    if parse_braced_scalar_ref(subject).is_some() || is_whole_var_ref(subject) {
+    if is_whole_var_ref(subject) {
         return ExprNode::Raw {
             text: subject.to_owned(),
         };

--- a/rust/tcl-compiler/src/codegen/cmd_subst.rs
+++ b/rust/tcl-compiler/src/codegen/cmd_subst.rs
@@ -25,7 +25,7 @@
 use tcl_registry::hooks::InlineCodegenHookId;
 
 use super::helpers::{SubstPart, parse_subst_template, regexp_to_glob};
-use super::values::{is_qualified, parse_braced_scalar_ref, parse_simple_var_ref, split_array_ref};
+use super::values::{is_qualified, parse_simple_var_ref, split_array_ref};
 use super::{CodegenCtx, INDEX_END, Op, Operand, bytecode_imm, parse_tcl_index, str_class_id};
 
 // Free functions — pure parsing, no emission state needed
@@ -391,10 +391,6 @@ impl CodegenCtx<'_> {
                 match part {
                     SubstPart::Lit(text) => self.push_lit(text),
                     SubstPart::Cmd(cmd) => self.emit_inline_cmd_subst(cmd),
-                    SubstPart::Scalar(name) => {
-                        self.push_lit(name);
-                        self.emit(Op::LOAD_STK, vec![]);
-                    }
                     SubstPart::Var(name) => self.load_var(name),
                 }
             }
@@ -405,12 +401,6 @@ impl CodegenCtx<'_> {
             return;
         }
         if !braced && arg.starts_with('$') {
-            // Braced scalar marker: $={name} → push + loadStk
-            if let Some(name) = parse_braced_scalar_ref(arg) {
-                self.push_lit(name);
-                self.emit(Op::LOAD_STK, vec![]);
-                return;
-            }
             // ${var} form
             if let Some(var_name) = parse_simple_var_ref(arg, self.braced_var) {
                 self.load_var(var_name);
@@ -515,10 +505,7 @@ impl CodegenCtx<'_> {
             self.emit_inline_cmd_subst(word);
             self.place_label(&end_label);
         } else if !braced && word.starts_with('$') {
-            if let Some(name) = parse_braced_scalar_ref(word) {
-                self.push_lit(name);
-                self.emit(Op::LOAD_STK, vec![]);
-            } else if let Some(var_name) = parse_simple_var_ref(word, self.braced_var) {
+            if let Some(var_name) = parse_simple_var_ref(word, self.braced_var) {
                 self.load_var(var_name);
             } else {
                 // Bare `$name` / `$name(idx)` — load the variable rather than
@@ -671,12 +658,6 @@ impl CodegenCtx<'_> {
     /// Extends the simplified `emit_value_interpolated` with command
     /// substitution inlining and `parse_subst_template` decomposition.
     pub fn emit_value(&mut self, value: &str, interpolate: bool) {
-        // Braced scalar marker: $={name} → push + loadStk
-        if let Some(name) = parse_braced_scalar_ref(value) {
-            self.push_lit(name);
-            self.emit(Op::LOAD_STK, vec![]);
-            return;
-        }
         // Variable reference: ${var} → load
         if let Some(var_name) = parse_simple_var_ref(value, self.braced_var) {
             self.load_var(var_name);
@@ -714,10 +695,6 @@ impl CodegenCtx<'_> {
                     SubstPart::Lit(text) => self.push_lit(text),
                     SubstPart::Cmd(cmd_text) => {
                         self.emit_inline_cmd_subst(cmd_text);
-                    }
-                    SubstPart::Scalar(name) => {
-                        self.push_lit(name);
-                        self.emit(Op::LOAD_STK, vec![]);
                     }
                     SubstPart::Var(name) => {
                         self.load_var(name);

--- a/rust/tcl-compiler/src/codegen/expressions.rs
+++ b/rust/tcl-compiler/src/codegen/expressions.rs
@@ -25,7 +25,7 @@
 use tcl_lexer::backslash_subst_in;
 use tcl_registry::expr_surface::RuntimeExprSurface;
 
-use super::values::{parse_braced_scalar_ref, parse_simple_var_ref};
+use super::values::parse_simple_var_ref;
 use super::{CodegenCtx, Op, Operand, bytecode_imm};
 use crate::depth_guard::MAX_EXPR_NODE_DEPTH;
 use crate::expr_ast::{BinOp, ExprNode, UnaryOp, render_expr};
@@ -246,10 +246,6 @@ impl CodegenCtx<'_> {
             match part {
                 SubstPart::Lit(t) => self.push_lit(t),
                 SubstPart::Var(name) => self.load_var(name),
-                SubstPart::Scalar(name) => {
-                    self.push_lit(name);
-                    self.emit(Op::LOAD_STK, vec![]);
-                }
                 SubstPart::Cmd(cmd_text) => self.emit_inline_cmd_subst(cmd_text),
             }
         }
@@ -456,11 +452,7 @@ impl CodegenCtx<'_> {
             }
 
             ExprNode::Raw { text } => {
-                // Braced scalar: $={name} → push name + loadStk
-                if let Some(name) = parse_braced_scalar_ref(text) {
-                    self.push_lit(name);
-                    self.emit(Op::LOAD_STK, vec![]);
-                } else if let Some(var_name) = parse_simple_var_ref(text, self.braced_var) {
+                if let Some(var_name) = parse_simple_var_ref(text, self.braced_var) {
                     self.load_var(var_name);
                 } else {
                     self.push_lit(text);
@@ -1016,8 +1008,12 @@ mod tests {
         assert_eq!(opcodes(&ctx), vec![Op::LOAD_SCALAR1]);
     }
 
+    /// `$={a(1)}` is not a variable reference — it is literal text in every
+    /// supported release, so a `Raw` operand spelling it takes the generic
+    /// `exprStk` fallback rather than the retired braced-scalar marker's
+    /// `push name; loadStk` (issue #1617).
     #[test]
-    fn emit_raw_braced_scalar() {
+    fn emit_raw_dollar_equals_is_not_a_var_ref() {
         let registry = CommandRegistry::build_default();
         let mut ctx = CodegenCtx::new(false, &[], &registry);
         let node = ExprNode::Raw {
@@ -1025,8 +1021,7 @@ mod tests {
         };
         let numeric = ctx.emit_expr(&node);
         assert!(!numeric);
-        // push name + loadStk
-        assert_eq!(opcodes(&ctx), vec![Op::PUSH1, Op::LOAD_STK]);
+        assert_eq!(opcodes(&ctx), vec![Op::PUSH1, Op::EXPR_STK]);
     }
 
     #[test]

--- a/rust/tcl-compiler/src/codegen/helpers.rs
+++ b/rust/tcl-compiler/src/codegen/helpers.rs
@@ -365,13 +365,13 @@ pub fn regexp_to_glob(pattern: &str) -> Option<String> {
 /// doesn't match or contains substitutions.
 #[must_use]
 pub fn fold_cmd_args(value: &str, prefix: &str) -> Option<String> {
-    Some(
-        fold_cmd_arg_values(value, prefix)?
-            .iter()
-            .map(|a| tcl_list_element(a))
-            .collect::<Vec<_>>()
-            .join(" "),
-    )
+    // `Tcl_Merge`, not a per-element `Tcl_ConvertElement` loop: a leading `#`
+    // is comment-unsafe only in list position 0, so mapping the single-element
+    // quoter over every argument rendered `[list a #]` as `a {#}` where both
+    // tclsh oracles print `a #` (issues #1439 / #1608).
+    Some(tcl_syntax::list::join_list(fold_cmd_arg_values(
+        value, prefix,
+    )?))
 }
 
 /// [`fold_cmd_args`]'s foldability check, stopping at the **argument values**
@@ -460,8 +460,16 @@ pub fn fold_list_cmd(value: &str) -> Option<String> {
 /// **Not** a plain list join of the arguments. `dict create` builds a
 /// dictionary, so it canonicalises: a repeated key keeps its
 /// **first-occurrence position** and its **last value**
-/// (`Tcl_DictObjPut` over `DictCreateCmd`'s argument walk), exactly the rule
-/// [`tcl_syntax::value::ValueOps::dict_pairs`] applies at runtime.
+/// (`Tcl_DictObjPut` over `DictCreateCmd`'s argument walk).
+///
+/// The walk is the shared owner's,
+/// [`tcl_syntax::value::canonical_dict_slots`] — the same function behind the
+/// runtime seam `ValueOps::dict_pairs` and the registry's `dict` const-folds.
+/// This site used to carry its own (`Vec::iter_mut().find`, O(N²)) copy; three
+/// correct copies and one place the rule had been missed is what issue #1608
+/// was filed about, and the cross-crate `dict_canonicalisation_parity` gate now
+/// fails if a copy reappears and diverges. Only the *rendering* is local: a
+/// folded `dict create` is re-quoted element by element here.
 ///
 /// Joining instead froze `[dict create a 1 a 2]` into the literal `a 1 a 2`,
 /// whose *string representation* is a dict nothing canonicalises — `dict size`
@@ -478,22 +486,19 @@ pub fn fold_dict_create_cmd(value: &str) -> Option<String> {
     if args.len() % 2 != 0 {
         return None;
     }
-    let mut pairs: Vec<(&str, &str)> = Vec::with_capacity(args.len() / 2);
-    for pair in args.chunks_exact(2) {
-        let (k, v) = (pair[0].as_str(), pair[1].as_str());
-        if let Some(slot) = pairs.iter_mut().find(|(pk, _)| *pk == k) {
-            slot.1 = v; // last value wins, position preserved
-        } else {
-            pairs.push((k, v));
-        }
-    }
-    Some(
-        pairs
-            .iter()
-            .flat_map(|(k, v)| [tcl_list_element(k), tcl_list_element(v)])
-            .collect::<Vec<_>>()
-            .join(" "),
-    )
+    let canonical: Vec<&str> =
+        tcl_syntax::value::canonical_dict_slots(args.iter().step_by(2).map(String::as_str))
+            .into_iter()
+            .flat_map(|(key_slot, value_slot)| {
+                [
+                    args[key_slot * 2].as_str(),
+                    args[value_slot * 2 + 1].as_str(),
+                ]
+            })
+            .collect();
+    // Rendered by the shared `Tcl_Merge` owner — the position-0-only `#` rule
+    // matters here too (`[dict create a #]` is `a #`, not `a {#}`).
+    Some(tcl_syntax::list::join_list(canonical))
 }
 
 /// Constant-fold `[format "..." arg ...]` → result string.

--- a/rust/tcl-compiler/src/codegen/helpers.rs
+++ b/rust/tcl-compiler/src/codegen/helpers.rs
@@ -193,10 +193,89 @@ fn flush_subst_lit(
     }
 }
 
+/// One `$`'s reading, per `Tcl_ParseVarName`'s three forms.
+enum DollarScan {
+    /// A real substitution: the part, and the offset just past it.
+    Subst(SubstPart, usize),
+    /// Not a substitution — "just a dollar sign", literal text.
+    Literal,
+    /// `${` with no close: a parse error, not a reading.
+    Unterminated,
+}
+
+/// Read the `$` at `at`, following `Tcl_ParseVarName`
+/// (tmp/tcl9.0.4/generic/tclParse.c:1367-1381 documents the three forms).
+///
+/// Form 1 is `${name}`, closed by the target release's rule; an unterminated
+/// one is C's `TCL_PARSE_MISSING_VAR_BRACE` ("missing close-brace for variable
+/// name", `tclParse.c:1414`), reported here as [`DollarScan::Unterminated`].
+///
+/// Form 2 is a bare name of letters/digits/underscores and `::` runs,
+/// optionally followed by an array index — including the **empty** name of
+/// `$(idx)`, which C admits explicitly ("Support for empty array names here",
+/// `tclParse.c:1449-1453`), so `$(k)` reads array `` element `k`.
+///
+/// Form 3 is everything else: a `$` before any other byte, or at the end of the
+/// string, is **not** a reference — `tclParse.c:1454` and `:1360` both jump to
+/// `justADollarSign` (`:1502`), which rewrites the token as the literal text
+/// `$` and returns `TCL_OK`. Parsing *continues*; the `$` is data.
+fn scan_dollar(
+    template: &str,
+    bytes: &[u8],
+    n: usize,
+    at: usize,
+    braced_var: tcl_dialect::BracedVarStyle,
+) -> DollarScan {
+    let i = at + 1;
+    if i >= n {
+        return DollarScan::Literal; // trailing `$` (`tclParse.c:1360`)
+    }
+    if bytes[i] == b'{' {
+        // Braced variable: ${name}, closed by the target release's
+        // `Tcl_ParseVarName` rule. This used to be `find('}')` — the 8.x
+        // first-close rule applied at every release, disagreeing with
+        // `values::parse_simple_var_ref`'s 9.x nesting rule on the very same
+        // encoding (issue #1568).
+        return match tcl_lexer::braced_var_name_end(bytes, i + 1, braced_var) {
+            tcl_lexer::BracedVarEnd::Closed(end) => {
+                DollarScan::Subst(SubstPart::Var(template[i + 1..end].to_owned()), end + 1)
+            }
+            tcl_lexer::BracedVarEnd::Unterminated => DollarScan::Unterminated,
+        };
+    }
+    // Bare variable: $varname, optionally with an array index `$arr(index)`
+    // whose index may itself contain substitutions. A `:` is a name character
+    // only as part of a `::` namespace separator: a lone colon ends the name,
+    // so `$action:` is `$action` then a literal `:`, not a variable `action:`.
+    // Once a `::` starts, the whole colon run is consumed (`$a:::b` names
+    // `a:::b`).
+    let start = i;
+    let mut end = i;
+    while end < n {
+        if bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_' {
+            end += 1;
+        } else if bytes[end] == b':' && end + 1 < n && bytes[end + 1] == b':' {
+            while end < n && bytes[end] == b':' {
+                end += 1;
+            }
+        } else {
+            break;
+        }
+    }
+    // An empty name is still a reference when an array index follows (`$(k)`);
+    // otherwise this is form 3 and the `$` is literal.
+    if end == start && bytes.get(end) != Some(&b'(') {
+        return DollarScan::Literal;
+    }
+    let end = consume_array_index(bytes, end);
+    DollarScan::Subst(SubstPart::Var(template[start..end].to_owned()), end)
+}
+
 /// Parse a substitution template into parts.
 ///
 /// Returns `None` if the template contains constructs we cannot
-/// inline (unbalanced brackets, bare `$` without a name, etc.).
+/// inline (unbalanced brackets, an unterminated `${`, etc.). A `$` that starts
+/// no substitution is **not** such a construct — see [`scan_dollar`].
 ///
 /// Only scans for `$`/`[` substitution triggers; literal text (including any
 /// backslash escapes within it) is left raw in the source and decoded in one
@@ -260,50 +339,23 @@ pub fn parse_subst_template(
         }
 
         if ch == b'$' {
-            flush_subst_lit(&mut parts, template, lit_start, i, escapes);
-            i += 1;
-            if i >= n {
-                return None;
-            }
-            if bytes[i] == b'{' {
-                // Braced variable: ${name}, closed by the target release's
-                // `Tcl_ParseVarName` rule. This used to be `find('}')` — the
-                // 8.x first-close rule applied at every release, disagreeing
-                // with `values::parse_simple_var_ref`'s 9.x nesting rule on the
-                // very same encoding (issue #1568).
-                let end = match tcl_lexer::braced_var_name_end(bytes, i + 1, braced_var) {
-                    tcl_lexer::BracedVarEnd::Closed(end) => end,
-                    tcl_lexer::BracedVarEnd::Unterminated => return None,
-                };
-                parts.push(SubstPart::Var(template[i + 1..end].to_owned()));
-                i = end + 1;
-            } else {
-                // Bare variable: $varname, optionally with an array index
-                // `$arr(index)` whose index may itself contain substitutions.
-                // A `:` is a name character only as part of a `::` namespace
-                // separator (matching the lexer, `Tcl_ParseVarName`): a lone
-                // colon ends the name, so `$action:` is `$action` then a literal
-                // `:`, not a variable `action:`. Once a `::` starts, the whole
-                // colon run is consumed (`$a:::b` names `a:::b`).
-                let start = i;
-                while i < n {
-                    if bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_' {
-                        i += 1;
-                    } else if bytes[i] == b':' && i + 1 < n && bytes[i + 1] == b':' {
-                        while i < n && bytes[i] == b':' {
-                            i += 1;
-                        }
-                    } else {
-                        break;
-                    }
+            // A `$` that starts no substitution is *data*, not a reason to give
+            // up on the whole word: C rewrites the token as the literal `$` and
+            // keeps parsing (`justADollarSign`). Bailing here left every word
+            // that mixes a literal `$` with a real substitution un-decomposed —
+            // `[list $={y}$x]` pushed its argument raw, so the `$x` was never
+            // substituted (both oracles: `{$={y}X}`; #1668 review).
+            match scan_dollar(template, bytes, n, i, braced_var) {
+                DollarScan::Subst(part, next) => {
+                    flush_subst_lit(&mut parts, template, lit_start, i, escapes);
+                    parts.push(part);
+                    i = next;
+                    lit_start = i;
                 }
-                if i == start {
-                    return None;
-                }
-                i = consume_array_index(bytes, i);
-                parts.push(SubstPart::Var(template[start..i].to_owned()));
+                // Stays inside the current literal run — do not flush.
+                DollarScan::Literal => i += 1,
+                DollarScan::Unterminated => return None,
             }
-            lit_start = i;
             continue;
         }
 
@@ -836,9 +888,45 @@ mod tests {
         assert_eq!(parts, vec![SubstPart::Lit("a\nb".into())]);
     }
 
+    /// A `$` that starts no substitution is literal text and the scan
+    /// continues — `Tcl_ParseVarName`'s third form (`justADollarSign`,
+    /// tmp/tcl9.0.4/generic/tclParse.c:1454 and :1502). `puts [list $ a]`
+    /// prints `{$} a` on tclsh8.6.16 and tclsh9.0.4.
     #[test]
-    fn subst_template_bare_dollar() {
-        assert!(template("$").is_none());
+    fn subst_template_bare_dollar_is_literal_text() {
+        assert_eq!(template("$"), Some(vec![SubstPart::Lit("$".into())]));
+        assert_eq!(template("a$"), Some(vec![SubstPart::Lit("a$".into())]));
+        // The whole point: a literal `$` must not cost the *rest* of the word
+        // its substitution (#1668 review).
+        assert_eq!(
+            template("$x$"),
+            Some(vec![SubstPart::Var("x".into()), SubstPart::Lit("$".into()),])
+        );
+        assert_eq!(
+            template("$ $x"),
+            Some(vec![
+                SubstPart::Lit("$ ".into()),
+                SubstPart::Var("x".into()),
+            ])
+        );
+    }
+
+    /// `$(idx)` is a reference to the **empty-named** array — C admits it
+    /// explicitly ("Support for empty array names here",
+    /// tmp/tcl9.0.4/generic/tclParse.c:1449-1453). `set (k) V; puts [list
+    /// a$(k)b]` prints `aVb` on both oracles, so the empty name must not be
+    /// mistaken for the bare-`$` form.
+    #[test]
+    fn subst_template_empty_array_name_is_a_reference() {
+        assert_eq!(template("$(k)"), Some(vec![SubstPart::Var("(k)".into())]));
+        assert_eq!(
+            template("a$(k)b"),
+            Some(vec![
+                SubstPart::Lit("a".into()),
+                SubstPart::Var("(k)".into()),
+                SubstPart::Lit("b".into()),
+            ])
+        );
     }
 
     #[test]
@@ -879,10 +967,39 @@ mod tests {
     /// (issue #1617). Both tclsh oracles print `$={y}` for `puts $={y}`.
     #[test]
     fn subst_template_dollar_equals_is_not_a_marker() {
-        // No name follows the `$`, so the word has no decomposable
-        // substitution at all and the caller pushes it as a literal.
-        assert!(template("$={a(1)}rest").is_none());
-        assert!(template("$={y}").is_none());
+        // No name follows the `$`, so the marker text is literal — and it is
+        // *only* the marker text: a real substitution later in the same word
+        // still decomposes (`Tcl_ParseVarName`'s `justADollarSign` keeps
+        // parsing; #1668 review).
+        assert_eq!(
+            template("$={a(1)}rest"),
+            Some(vec![SubstPart::Lit("$={a(1)}rest".into())])
+        );
+        assert_eq!(
+            template("$={y}"),
+            Some(vec![SubstPart::Lit("$={y}".into())])
+        );
+        assert_eq!(
+            template("$={y}$x"),
+            Some(vec![
+                SubstPart::Lit("$={y}".into()),
+                SubstPart::Var("x".into()),
+            ])
+        );
+        assert_eq!(
+            template("a$={y}$x"),
+            Some(vec![
+                SubstPart::Lit("a$={y}".into()),
+                SubstPart::Var("x".into()),
+            ])
+        );
+        assert_eq!(
+            template("$={y}${x}"),
+            Some(vec![
+                SubstPart::Lit("$={y}".into()),
+                SubstPart::Var("x".into()),
+            ])
+        );
         // The neighbouring real form is untouched.
         assert_eq!(template("${y}"), Some(vec![SubstPart::Var("y".into())]),);
     }

--- a/rust/tcl-compiler/src/codegen/helpers.rs
+++ b/rust/tcl-compiler/src/codegen/helpers.rs
@@ -213,7 +213,8 @@ enum DollarScan {
 /// Form 2 is a bare name of letters/digits/underscores and `::` runs,
 /// optionally followed by an array index — including the **empty** name of
 /// `$(idx)`, which C admits explicitly ("Support for empty array names here",
-/// `tclParse.c:1449-1453`), so `$(k)` reads array `` element `k`.
+/// `tclParse.c:1449-1453`), so `$(k)` reads element `k` of the array whose
+/// name is the empty string.
 ///
 /// Form 3 is everything else: a `$` before any other byte, or at the end of the
 /// string, is **not** a reference — `tclParse.c:1454` and `:1360` both jump to

--- a/rust/tcl-compiler/src/codegen/helpers.rs
+++ b/rust/tcl-compiler/src/codegen/helpers.rs
@@ -134,14 +134,18 @@ pub fn tcl_list_element(s: &str) -> String {
 }
 
 /// A part of a parsed substitution template.
+///
+/// There is deliberately **no** variant for the retired `$={name}`
+/// braced-scalar marker: nothing in this workspace ever emitted that spelling,
+/// so every word that reached its decoder came from the user's own source,
+/// where `$={y}` is plain literal text in every supported release (issue
+/// #1617).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SubstPart {
     /// Literal text.
     Lit(String),
     /// Variable reference (`$varname`).
     Var(String),
-    /// Braced scalar reference (`$={name}`).
-    Scalar(String),
     /// Command substitution (`[cmd ...]`).
     Cmd(String),
 }
@@ -261,17 +265,7 @@ pub fn parse_subst_template(
             if i >= n {
                 return None;
             }
-            if bytes[i] == b'=' && i + 1 < n && bytes[i + 1] == b'{' {
-                // Braced scalar: $={name}. The compiler's own marker for "load
-                // this name as a scalar", but its name is spelt by the same
-                // brace form, so it closes by the same release rule.
-                let end = match tcl_lexer::braced_var_name_end(bytes, i + 2, braced_var) {
-                    tcl_lexer::BracedVarEnd::Closed(end) => end,
-                    tcl_lexer::BracedVarEnd::Unterminated => return None,
-                };
-                parts.push(SubstPart::Scalar(template[i + 2..end].to_owned()));
-                i = end + 1;
-            } else if bytes[i] == b'{' {
+            if bytes[i] == b'{' {
                 // Braced variable: ${name}, closed by the target release's
                 // `Tcl_ParseVarName` rule. This used to be `find('}')` — the
                 // 8.x first-close rule applied at every release, disagreeing
@@ -873,12 +867,19 @@ mod tests {
         assert!(template("").is_none());
     }
 
+    /// `$=` is not a substitution trigger in any release: `=` is not a name
+    /// character, so `Tcl_ParseVarName` leaves the `$` literal. This decoder
+    /// used to read `$={name}` as the compiler's "braced scalar" marker — a
+    /// producer-less port artifact that only ever fired on the user's own text
+    /// (issue #1617). Both tclsh oracles print `$={y}` for `puts $={y}`.
     #[test]
-    fn subst_template_scalar() {
-        let parts = template("$={a(1)}rest").unwrap();
-        assert_eq!(parts.len(), 2);
-        assert_eq!(parts[0], SubstPart::Scalar("a(1)".into()));
-        assert_eq!(parts[1], SubstPart::Lit("rest".into()));
+    fn subst_template_dollar_equals_is_not_a_marker() {
+        // No name follows the `$`, so the word has no decomposable
+        // substitution at all and the caller pushes it as a literal.
+        assert!(template("$={a(1)}rest").is_none());
+        assert!(template("$={y}").is_none());
+        // The neighbouring real form is untouched.
+        assert_eq!(template("${y}"), Some(vec![SubstPart::Var("y".into())]),);
     }
 
     // -- parse_subst_template: full backslash decoding (issue #1441) --

--- a/rust/tcl-compiler/src/codegen/statements.rs
+++ b/rust/tcl-compiler/src/codegen/statements.rs
@@ -397,12 +397,6 @@ impl CodegenCtx<'_> {
     /// Full interpolation with command substitution requires the main
     /// emitter pipeline.
     pub fn emit_value_interpolated(&mut self, value: &str) {
-        // Braced scalar marker: $={name} → push + loadStk
-        if let Some(name) = super::values::parse_braced_scalar_ref(value) {
-            self.push_lit(name);
-            self.emit(Op::LOAD_STK, vec![]);
-            return;
-        }
         // Variable reference: ${var} → load
         if let Some(var_name) = parse_simple_var_ref(value, self.braced_var) {
             self.load_var(var_name);
@@ -452,10 +446,6 @@ impl CodegenCtx<'_> {
                 match part {
                     SubstPart::Lit(text) => self.push_lit(text),
                     SubstPart::Cmd(cmd_text) => self.emit_inline_cmd_subst(cmd_text),
-                    SubstPart::Scalar(name) => {
-                        self.push_lit(name);
-                        self.emit(Op::LOAD_STK, vec![]);
-                    }
                     SubstPart::Var(name) => self.load_var(name),
                 }
             }

--- a/rust/tcl-compiler/src/codegen/values.rs
+++ b/rust/tcl-compiler/src/codegen/values.rs
@@ -332,10 +332,6 @@ impl CodegenCtx<'_> {
                 match part {
                     super::helpers::SubstPart::Lit(text) => self.push_lit(text),
                     super::helpers::SubstPart::Cmd(cmd) => self.emit_inline_cmd_subst(cmd),
-                    super::helpers::SubstPart::Scalar(name) => {
-                        self.push_lit(name);
-                        self.emit(Op::LOAD_STK, vec![]);
-                    }
                     super::helpers::SubstPart::Var(name) => self.load_var(name),
                 }
             }
@@ -631,15 +627,36 @@ pub fn parse_simple_var_ref(value: &str, style: tcl_dialect::BracedVarStyle) -> 
     }
 }
 
-/// Extract variable name from a braced-scalar marker `$={name}`.
-///
-/// In Tcl, braces prevent array interpretation, so `${a(1)}` must be
-/// loaded as a scalar via `push + loadStk`.  The compiler marks these
-/// with `$={name}`.
-#[must_use]
-pub fn parse_braced_scalar_ref(value: &str) -> Option<&str> {
-    value.strip_prefix("$={").and_then(|s| s.strip_suffix('}'))
-}
+// The `$={name}` "braced scalar" marker used to be decoded here, by a
+// `strip_prefix("$={")` + `strip_suffix('}')` pair. It is gone (issue #1617).
+//
+// It was a port artifact: no pass in this workspace has ever *produced* that
+// spelling — the segmenter re-spells a braced variable word verbatim from
+// source (`${…}`, see `segmenter::word_piece`), and nothing else writes a `$=`
+// prefix. A marker with no producer is not an internal encoding at all: every
+// word that reached the decoder was the user's own text, and `$={y}` is
+// literal text in every supported release —
+//
+// ```tcl
+// set y hi
+// puts $={y}     ;# 8.4-9.0: $={y}   — we compiled it to `push y; loadStk` → hi
+// ```
+//
+// (`$` is only a substitution trigger before a name character, and `=` is not
+// one; `Tcl_ParseVarName`, tmp/tcl9.0.4/generic/tclParse.c). So the decoder was
+// pure wrong-code: a whole-word `$={name}` loaded the variable `name` instead
+// of pushing the literal. It was also unpinnable — the mutation inventory's
+// M3b (flip the marker arm's close scan) survived the whole corpus precisely
+// because no *real* program could tell the two halves apart (#1615).
+//
+// Nothing is lost by dropping it: the form it existed to spell, `${a(1)}`,
+// reaches `parse_simple_var_ref` and `load_var`, which agree with both tclsh
+// oracles (`set {a(1)} S; array set a {1 A}; puts ${a(1)}` → `A`, because
+// `TclObjLookupVar` parses the parens out of the *name* at lookup time).
+//
+// Do not reintroduce a marker in the `$…` space: any spelling a user can type
+// collides with real source. A future internal marker needs an out-of-band
+// channel (an IR node or a word flag), not a string prefix.
 
 /// Check if a string is an integer literal (optionally negative).
 fn is_integer_literal(s: &str) -> bool {
@@ -785,16 +802,31 @@ mod tests {
         assert_eq!(whole_var_reference("a$b"), None);
     }
 
-    // -- parse_braced_scalar_ref --
+    // -- the retired `$={name}` marker (issue #1617) --
 
+    /// A whole word spelt `$={name}` is the *user's* literal text — `=` is not
+    /// a name character, so `Tcl_ParseVarName` never starts a substitution
+    /// there and both tclsh oracles print `$={y}` for `puts $={y}`. The
+    /// producer-less "braced scalar" marker that used to claim this spelling
+    /// compiled it to `push "y"; loadStk`, silently reading a variable.
     #[test]
-    fn parse_braced_scalar_basic() {
-        assert_eq!(parse_braced_scalar_ref("$={a(1)}"), Some("a(1)"));
-    }
-
-    #[test]
-    fn parse_braced_scalar_no_match() {
-        assert_eq!(parse_braced_scalar_ref("${x}"), None);
+    fn dollar_equals_word_is_a_literal_not_a_variable_load() {
+        let registry = CommandRegistry::build_default();
+        let mut ctx = CodegenCtx::new(true, &["y"], &registry);
+        ctx.emit_value("$={y}", true);
+        assert_eq!(
+            ctx.instructions.iter().map(|i| i.op).collect::<Vec<_>>(),
+            vec![Op::PUSH1],
+            "`$={{y}}` must be pushed whole, not decoded as a variable load"
+        );
+        assert!(ctx.literals.entries().iter().any(|l| l == "$={y}"));
+        // The real braced form still loads.
+        let mut ctx = CodegenCtx::new(true, &["y"], &registry);
+        ctx.emit_value("${y}", true);
+        assert_eq!(
+            ctx.instructions.iter().map(|i| i.op).collect::<Vec<_>>(),
+            vec![Op::LOAD_SCALAR1],
+        );
     }
 
     // -- is_integer_literal --

--- a/rust/tcl-compiler/tests/compiler_residual.rs
+++ b/rust/tcl-compiler/tests/compiler_residual.rs
@@ -628,13 +628,18 @@ fn cmd_subst_arg_multipart_interpolation_concats() {
 }
 
 #[test]
-fn cmd_subst_arg_braced_scalar_marker() {
-    // The `$={name}` braced-scalar marker → push name; loadStk.
+fn cmd_subst_arg_dollar_equals_stays_literal() {
+    // `$={foo}` is *user text*, not a compiler marker: `=` is not a name
+    // character, so both tclsh oracles leave the `$` literal and print
+    // `$={foo}`. This used to decode as a "braced scalar" marker and compile
+    // to `push "foo"; loadStk` — a whole-word wrong-code path with no
+    // producer anywhere in the workspace (issue #1617).
     let reg = registry();
     let mut ctx = proc_ctx(&reg, &[]);
     ctx.emit_cmd_subst_arg("$={foo}", false);
-    assert_eq!(ctx_ops(&ctx), vec![Op::PUSH1, Op::LOAD_STK]);
-    assert!(ctx.literals.entries().iter().any(|l| l == "foo"));
+    assert_eq!(ctx_ops(&ctx), vec![Op::PUSH1]);
+    assert!(ctx.literals.entries().iter().any(|l| l == "$={foo}"));
+    assert!(!ctx.literals.entries().iter().any(|l| l == "foo"));
 }
 
 #[test]

--- a/rust/tcl-compiler/tests/optimiser_codegen_residual.rs
+++ b/rust/tcl-compiler/tests/optimiser_codegen_residual.rs
@@ -868,11 +868,10 @@ fn emit_cmd_subst_arg_composite_and_special_forms() {
     // A braced arg carrying substitution markers (`{$x}`) is re-wrapped and
     // pushed as a single literal (braces suppress substitution).
     assert_eq!(arg_ops(true, &[], "{$x}", true), vec![Op::PUSH1]);
-    // The `$={name}` braced-scalar marker → push name; loadStk.
-    assert_eq!(
-        arg_ops(true, &["n"], "$={n}", false),
-        vec![Op::PUSH1, Op::LOAD_STK],
-    );
+    // `$={n}` is literal user text, not a marker: `$` before `=` is not a
+    // substitution trigger in any release, so the whole word is pushed
+    // (issue #1617). It used to load the variable `n`.
+    assert_eq!(arg_ops(true, &["n"], "$={n}", false), vec![Op::PUSH1]);
     // A bare `$name` form loads the scalar directly.
     assert_eq!(arg_ops(true, &["v"], "$v", false), vec![Op::LOAD_SCALAR1]);
 }

--- a/rust/tcl-registry/src/const_fold.rs
+++ b/rust/tcl-registry/src/const_fold.rs
@@ -123,24 +123,29 @@ pub(crate) fn split_list(s: &str) -> Option<Vec<String>> {
     Some(out)
 }
 
-/// Quote one element for a Tcl list — bare when it has no list-special
-/// characters, brace-quoted when its braces are balanced and it does not
-/// end with a backslash, else backslash-escaped.
-pub(crate) fn list_element(s: &str) -> String {
-    // The canonical `Tcl_ScanElement`+`Tcl_ConvertElement` quoter, now shared
-    // with the runtime via `tcl-syntax` (and additionally correct on the
-    // leading-`#` and control-char cases the old local copy mis-quoted).
-    tcl_syntax::list::list_element(s)
-}
+// One element is quoted by the shared `Tcl_ScanElement`+`Tcl_ConvertElement`
+// owner, `tcl_syntax::list::list_element`, called directly where a lone element
+// is rendered. It quotes a leading `#` because it renders *list position 0*;
+// a whole list goes through [`list_join`] instead, which applies the rule
+// position by position.
 
-/// Join already-split elements into a Tcl list string (each element
-/// re-quoted via [`list_element`]).
+/// Join already-split elements into a Tcl list string — the shared `Tcl_Merge`
+/// owner [`tcl_syntax::list::join_list`], not a per-element loop over
+/// [`tcl_syntax::list::list_element`].
+///
+/// The difference is the comment-safety rule: `Tcl_ConvertElement` brace-quotes
+/// a leading `#` only in **list position 0**, because that is the only place a
+/// `#` could start a comment when the list is evaluated as a script.
+/// The single-element quoter always quotes it (it renders a *single* element,
+/// so it has to assume position 0), and mapping it over every element made every fold
+/// that re-renders a list disagree with C Tcl on any non-first `#`:
+/// `[dict keys {a 1 # 2}]` folded to `a {#}` where both tclsh oracles print
+/// `a #`, and likewise for `list`, `lrange`, `lreverse`, `lrepeat`, `split`
+/// and `dict create`/`values`/`merge`. Same elements, different *string* — and
+/// a fold bakes the string into the program (issues #1439 / #1608; found by
+/// the `dict_canonicalisation_parity` gate).
 pub(crate) fn list_join<S: AsRef<str>>(elems: &[S]) -> String {
-    elems
-        .iter()
-        .map(|e| list_element(e.as_ref()))
-        .collect::<Vec<_>>()
-        .join(" ")
+    tcl_syntax::list::join_list(elems)
 }
 
 /// Parse a Tcl index expression against a string/list of `length`, returning the
@@ -344,34 +349,34 @@ pub(crate) fn fold_lrange(args: &[&str]) -> Option<String> {
 ///
 /// Canonical means what `SetDictFromAny` (tclDictObj.c) produces: a repeated
 /// key keeps its **first-occurrence position** and its **last value**, because
-/// the `Tcl_DictObjPut` behind it overwrites on a hash collision. This is the
-/// same rule [`tcl_syntax::value::ValueOps::dict_pairs`] applies at runtime and
-/// that [`fold_dict_create`] below already applied — these folders were the
-/// odd ones out.
+/// the `Tcl_DictObjPut` behind it overwrites on a hash collision.
 ///
-/// It matters because these are *constant folds* feeding analyser and tooling
-/// evaluation: decoding the list rep straight into `chunks_exact(2)` pairs left
-/// both values of a duplicate key present, so every `find` read the **first**
-/// one and `[dict get {a 1 a 2} a]` folded to `1` where Tcl says `2` — an
-/// optimisation that changes program results (issue #1427).
+/// The rule is not restated here — it is
+/// [`tcl_syntax::value::canonical_dict_slots`], the same function the runtime
+/// seam [`tcl_syntax::value::ValueOps::dict_pairs`] and the compiler's
+/// `fold_dict_create_cmd` bind. That centralisation is the point of issue
+/// #1608: three hand-written copies of this walk plus one place it had been
+/// *missed* is what let these folders feed six `dict` folders first-match
+/// semantics, so `[dict get {a 1 a 2} a]` folded to `1` where both tclsh
+/// oracles say `2` — an "optimisation" that changed program results (issues
+/// #1427 / #1591). This layer keeps only what is local to it: how a malformed
+/// dict is reported (a declined fold, not an error).
 fn parse_dict(s: &str) -> Option<Vec<(String, String)>> {
     let elems = split_list(s)?;
     if elems.len() % 2 != 0 {
         return None;
     }
-    let mut index: std::collections::HashMap<String, usize> =
-        std::collections::HashMap::with_capacity(elems.len() / 2);
-    let mut pairs: Vec<(String, String)> = Vec::with_capacity(elems.len() / 2);
-    for kv in elems.chunks_exact(2) {
-        let (k, v) = (&kv[0], &kv[1]);
-        if let Some(&pos) = index.get(k) {
-            pairs[pos].1.clone_from(v); // last value wins, position preserved
-        } else {
-            index.insert(k.clone(), pairs.len());
-            pairs.push((k.clone(), v.clone()));
-        }
-    }
-    Some(pairs)
+    Some(
+        tcl_syntax::value::canonical_dict_slots(elems.iter().step_by(2).map(String::as_str))
+            .into_iter()
+            .map(|(key_slot, value_slot)| {
+                (
+                    elems[key_slot * 2].clone(),
+                    elems[value_slot * 2 + 1].clone(),
+                )
+            })
+            .collect(),
+    )
 }
 
 /// `dict get dictionary ?key ...?`.
@@ -438,25 +443,20 @@ pub(crate) fn fold_dict_values(args: &[&str]) -> Option<String> {
 
 /// `dict create ?key value ...?` — canonicalise duplicate keys (last
 /// value wins, original insertion position preserved), matching Tcl 9's
-/// `Tcl_DictObjPut`.
+/// `Tcl_DictObjPut` over `DictCreateCmd`'s argument walk.
+///
+/// The walk is [`tcl_syntax::value::canonical_dict_slots`]'s, not a second
+/// copy of it (issue #1608): `DictCreateCmd` puts its arguments into a fresh
+/// dict pairwise, which is the same rule `SetDictFromAny` applies to a list
+/// rep, so the same function answers for both.
 pub(crate) fn fold_dict_create(args: &[&str]) -> Option<String> {
     if !args.len().is_multiple_of(2) {
         return None;
     }
-    let mut order: Vec<String> = Vec::new();
-    let mut pos: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
-    for kv in args.chunks_exact(2) {
-        let (k, v) = (kv[0], kv[1]);
-        if let Some(&p) = pos.get(k) {
-            // Reuse the existing slot's allocation (clippy::assigning_clones).
-            order[p + 1].clear();
-            order[p + 1].push_str(v);
-        } else {
-            pos.insert(k, order.len());
-            order.push(k.to_owned());
-            order.push(v.to_owned());
-        }
-    }
+    let order: Vec<&str> = tcl_syntax::value::canonical_dict_slots(args.iter().step_by(2).copied())
+        .into_iter()
+        .flat_map(|(key_slot, value_slot)| [args[key_slot * 2], args[value_slot * 2 + 1]])
+        .collect();
     Some(list_join(&order))
 }
 
@@ -646,10 +646,33 @@ mod tests {
 
     #[test]
     fn list_element_quotes_like_tcl() {
+        use tcl_syntax::list::list_element;
         assert_eq!(list_element("foo"), "foo");
         assert_eq!(list_element(""), "{}");
         assert_eq!(list_element("a b"), "{a b}");
         assert_eq!(list_element("a$b"), "{a$b}");
+    }
+
+    /// A leading `#` is comment-unsafe only in **list position 0**
+    /// (`Tcl_Merge` passes `TCL_DONT_QUOTE_HASH` for every later element), so
+    /// the folds that re-render a list must not quote it everywhere. Each row
+    /// is the byte-exact output of `tclsh8.6.16` and `tclsh9.0.4`, which agree
+    /// (issues #1439 / #1608).
+    #[test]
+    fn folded_lists_quote_a_leading_hash_only_in_position_zero() {
+        assert_eq!(fold_list(&["a", "#"]).as_deref(), Some("a #"));
+        assert_eq!(fold_list(&["#", "a"]).as_deref(), Some("{#} a"));
+        assert_eq!(fold_lreverse(&["# a"]).as_deref(), Some("a #"));
+        assert_eq!(fold_lrepeat(&["2", "#"]).as_deref(), Some("{#} #"));
+        assert_eq!(fold_lrange(&["x # y", "1", "2"]).as_deref(), Some("{#} y"));
+        assert_eq!(fold_split(&["a-#", "-"]).as_deref(), Some("a #"));
+        assert_eq!(fold_concat(&["a", "#"]).as_deref(), Some("a #"));
+        assert_eq!(fold_dict_keys(&["a 1 # 2"]).as_deref(), Some("a #"));
+        assert_eq!(fold_dict_values(&["a # b 1"]).as_deref(), Some("{#} 1"));
+        assert_eq!(
+            fold_dict_create(&["a", "1", "#", "2"]).as_deref(),
+            Some("a 1 # 2")
+        );
     }
 
     #[test]

--- a/rust/tcl-syntax/src/value.rs
+++ b/rust/tcl-syntax/src/value.rs
@@ -180,9 +180,14 @@ where
 {
     // Key → its slot's position in `slots`, so a duplicate is O(1) to find: a
     // linear re-scan per element made this O(N²) on every dict operation (D3).
-    let mut first_seen: std::collections::HashMap<&'a K, usize> = std::collections::HashMap::new();
-    let mut slots: Vec<(usize, usize)> = Vec::new();
-    for (slot, key) in keys.into_iter().enumerate() {
+    // Both containers are sized from the iterator up front — this runs on every
+    // VM dict opcode, so the growth reallocations are worth avoiding.
+    let keys = keys.into_iter();
+    let expected = keys.size_hint().0;
+    let mut first_seen: std::collections::HashMap<&'a K, usize> =
+        std::collections::HashMap::with_capacity(expected);
+    let mut slots: Vec<(usize, usize)> = Vec::with_capacity(expected);
+    for (slot, key) in keys.enumerate() {
         if let Some(&position) = first_seen.get(key) {
             slots[position].1 = slot; // last value wins, first position kept
         } else {

--- a/rust/tcl-syntax/src/value.rs
+++ b/rust/tcl-syntax/src/value.rs
@@ -131,6 +131,68 @@ impl core::fmt::Display for ValueError {
 
 impl std::error::Error for ValueError {}
 
+/// Tcl's dict canonicalisation rule, as slot indices — **the** implementation of
+/// "first-occurrence key position, last value wins".
+///
+/// `keys` is one key string per key/value slot, in source order: slot `i` is
+/// elements `2i` / `2i + 1` of the flat list rep, or arguments `2i` / `2i + 1`
+/// of `dict create`. The result is one `(key_slot, value_slot)` entry per
+/// *surviving* key, in canonical order — the slot whose key spelling and
+/// position the dict keeps, and the slot whose value it keeps. With no
+/// duplicate key that is `[(0, 0), (1, 1), …]`; for `a 1 b 2 a 3` it is
+/// `[(0, 2), (1, 1)]`.
+///
+/// This is `SetDictFromAny` (`tmp/tcl9.0.4/generic/tclDictObj.c:589`) walking
+/// the list rep and `Tcl_DictObjPut`ing each pair: the hash entry for a
+/// repeated key already exists, so the *value* is overwritten while the entry
+/// keeps its original chain position. `DictCreateCmd` walks its arguments the
+/// same way, which is why one function answers for both.
+///
+/// Working in indices rather than values is what lets every layer share it:
+/// the runtime seam ([`ValueOps::dict_pairs`]) maps them back onto its own
+/// value handles, and the compile-time folders (`tcl_registry::const_fold`'s
+/// `parse_dict` / `fold_dict_create`, `tcl_compiler`'s `fold_dict_create_cmd`)
+/// map them onto their own strings — none of them re-derives the rule.
+///
+/// That mattered: the rule existed in three independent copies plus one place
+/// it had been *missed*, where `dict get {a 1 a 2} a` folded to `1` while both
+/// tclsh oracles say `2` (issues #1427, #1591, #1608). Callers must not
+/// re-implement the walk; the cross-crate parity gate
+/// `dict_canonicalisation_parity` fails when a copy reappears and diverges.
+///
+/// The odd-length check belongs to the caller: what an unpaired trailing
+/// element means (an error, or a declined fold) differs per layer.
+///
+/// The key type is borrowed and only `Eq + Hash`, so a byte-oriented value
+/// model can bind this with `&[u8]` keys as readily as a string one does with
+/// `&str` — keys are compared by their exact rep either way, which is what
+/// `Tcl_DictObjPut`'s hash does.
+///
+/// The WASM runtime's *native* dict rep (`runtime/rust/src/dict.rs`)
+/// deliberately does not call this: it maintains a live key index across
+/// mutation, so it canonicalises incrementally (one `Tcl_DictObjPut` per
+/// insert) rather than in one walk. Its agreement with this rule is pinned by
+/// its own parity test rather than by construction.
+#[must_use]
+pub fn canonical_dict_slots<'a, K>(keys: impl IntoIterator<Item = &'a K>) -> Vec<(usize, usize)>
+where
+    K: ?Sized + Eq + std::hash::Hash + 'a,
+{
+    // Key → its slot's position in `slots`, so a duplicate is O(1) to find: a
+    // linear re-scan per element made this O(N²) on every dict operation (D3).
+    let mut first_seen: std::collections::HashMap<&'a K, usize> = std::collections::HashMap::new();
+    let mut slots: Vec<(usize, usize)> = Vec::new();
+    for (slot, key) in keys.into_iter().enumerate() {
+        if let Some(&position) = first_seen.get(key) {
+            slots[position].1 = slot; // last value wins, first position kept
+        } else {
+            first_seen.insert(key, slots.len());
+            slots.push((slot, slot));
+        }
+    }
+    slots
+}
+
 /// The value operations a Tcl command core supplies its runtime.
 ///
 /// The shared command bodies in `tcl-cmd-core` drive these; construction,
@@ -277,21 +339,21 @@ pub trait ValueOps {
                 "missing value to go with key".to_string(),
             ));
         }
-        // Index keys → position for O(1) dedup (D3): a linear `Vec::position`
-        // scan per element made this O(N²) on every dict operation.
-        let mut index: std::collections::HashMap<Rc<str>, usize> =
-            std::collections::HashMap::with_capacity(elems.len() / 2);
-        let mut pairs: Vec<(Self::Value, Self::Value)> = Vec::new();
-        for chunk in elems.chunks_exact(2) {
-            let key = self.as_str(&chunk[0]);
-            if let Some(&pos) = index.get(&key) {
-                pairs[pos].1 = chunk[1].clone(); // last value wins, keep position
-            } else {
-                index.insert(key, pairs.len());
-                pairs.push((chunk[0].clone(), chunk[1].clone()));
-            }
-        }
-        Ok(pairs)
+        // The canonicalisation rule itself lives in `canonical_dict_slots` —
+        // this method binds it to a value model, it does not restate it.
+        let keys: Vec<Rc<str>> = elems
+            .chunks_exact(2)
+            .map(|chunk| self.as_str(&chunk[0]))
+            .collect();
+        Ok(canonical_dict_slots(keys.iter().map(AsRef::as_ref))
+            .into_iter()
+            .map(|(key_slot, value_slot)| {
+                (
+                    elems[key_slot * 2].clone(),
+                    elems[value_slot * 2 + 1].clone(),
+                )
+            })
+            .collect())
     }
 
     /// Build a dict value from canonical key/value pairs. The default interleaves

--- a/rust/tcl-vm/tests/cross_version_vars_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_vars_e2e.rs
@@ -1364,6 +1364,104 @@ fn compiled_composite_array_key_follows_the_emulated_release() {
     }
 }
 
+// ===========================================================================
+// Issue #1617 — `$={name}` is the user's literal text, not a compiler marker.
+//
+// The codegen used to decode a whole word spelt `$={name}` as an internal
+// "braced scalar" marker and compile it to `push "name"; loadStk`. Nothing in
+// this workspace has ever *produced* that spelling — the segmenter re-spells a
+// braced variable word verbatim from source — so the only words that ever
+// reached the decoder were the user's own, where `$=` is not a substitution
+// trigger in any release (`=` is not a name character; `Tcl_ParseVarName`,
+// tmp/tcl9.0.4/generic/tclParse.c). Every reach was wrong code, and because
+// producer and consumer were both release-blind in compatible ways no program
+// could tell the two halves apart — which is why mutation M3b (flip the marker
+// arm's close scan) survived the whole corpus.
+//
+// These vectors pin the literal reading on each route the marker decoder sat
+// on: a command word, a `set` value, the `switch` subject (`cfg_lower`), a
+// list argument, an array key, and a proc body (the LVT path).
+
+/// A bare command word.
+const DOLLAR_EQ_WORD_SCRIPT: &str = concat!("set y hi\n", "puts $={y}\n");
+
+/// The value half of a `set` — `emit_value` / `emit_value_interpolated`.
+const DOLLAR_EQ_SET_VALUE_SCRIPT: &str = concat!("set y hi\n", "set z $={y}\n", "puts $z\n");
+
+/// The `switch` subject, which `cfg_builder::cfg_lower` used to promote to a
+/// `Raw` (variable-reference) operand when it parsed as the marker.
+const DOLLAR_EQ_SWITCH_SUBJECT_SCRIPT: &str = concat!(
+    "set y hi\n",
+    "switch -- $={y} {\n",
+    "  hi { puts matched-var }\n",
+    "  default { puts literal }\n",
+    "}\n",
+);
+
+/// A list argument, so the literal is observable through list quoting.
+const DOLLAR_EQ_LIST_ARG_SCRIPT: &str = concat!("set y hi\n", "puts [list $={y}]\n");
+
+/// An array key — the `push_array_key` route.
+const DOLLAR_EQ_ARRAY_KEY_SCRIPT: &str = concat!(
+    "set y hi\n",
+    "set arr($={y}) V\n",
+    "puts [array names arr]\n",
+);
+
+/// Inside a proc, where a decoded name would have become an LVT slot load.
+const DOLLAR_EQ_IN_PROC_SCRIPT: &str = concat!("proc p {} { set y inner; puts $={y} }\n", "p\n");
+
+const DOLLAR_EQ_VECTORS: &[(&str, &str, &str)] = &[
+    ("command word", DOLLAR_EQ_WORD_SCRIPT, "$={y}"),
+    ("set value", DOLLAR_EQ_SET_VALUE_SCRIPT, "$={y}"),
+    ("switch subject", DOLLAR_EQ_SWITCH_SUBJECT_SCRIPT, "literal"),
+    ("list argument", DOLLAR_EQ_LIST_ARG_SCRIPT, "{$={y}}"),
+    ("array key", DOLLAR_EQ_ARRAY_KEY_SCRIPT, "{$={y}}"),
+    ("proc body", DOLLAR_EQ_IN_PROC_SCRIPT, "$={y}"),
+];
+
+/// The reading is the same at every release: `$=` never starts a substitution,
+/// so there is no release axis here to get wrong.
+#[test]
+fn compiled_dollar_equals_word_is_literal_at_every_release() {
+    for (label, script, want) in DOLLAR_EQ_VECTORS {
+        for version in [
+            TclVersion::V8_4,
+            TclVersion::V8_5,
+            TclVersion::V8_6,
+            TclVersion::V9_0,
+            TclVersion::V9_1,
+        ] {
+            assert_eq!(
+                vm_output(script, version),
+                *want,
+                "`$={{y}}` ({label}) at {version:?} must stay literal, not load a variable"
+            );
+        }
+    }
+}
+
+#[test]
+fn compiled_dollar_equals_word_matches_real_tclsh() {
+    let mut ran = 0;
+    for (_, script, _) in DOLLAR_EQ_VECTORS {
+        if let Some(got) = tclsh_output("TCL_LSP_TCLSH86", &["tclsh8.6"], script) {
+            assert_eq!(got, vm_output(script, TclVersion::V8_6));
+            ran += 1;
+        }
+        if let Some(got) = tclsh_output("TCL_LSP_TCLSH90", &["tclsh9.0"], script) {
+            assert_eq!(got, vm_output(script, TclVersion::V9_0));
+            ran += 1;
+        }
+    }
+    if ran == 0 {
+        eprintln!(
+            "SKIPPING the tclsh oracle comparison: neither tclsh8.6 (or \
+             $TCL_LSP_TCLSH86) nor tclsh9.0 (or $TCL_LSP_TCLSH90) was found"
+        );
+    }
+}
+
 #[test]
 fn compiled_composite_array_key_matches_real_tclsh() {
     let mut ran = 0;

--- a/rust/tcl-vm/tests/cross_version_vars_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_vars_e2e.rs
@@ -1411,6 +1411,70 @@ const DOLLAR_EQ_ARRAY_KEY_SCRIPT: &str = concat!(
 /// Inside a proc, where a decoded name would have become an LVT slot load.
 const DOLLAR_EQ_IN_PROC_SCRIPT: &str = concat!("proc p {} { set y inner; puts $={y} }\n", "p\n");
 
+// The **mixed** shape: a literal `$` and a real substitution in the *same*
+// word. `Tcl_ParseVarName` reads a `$` that starts no reference as the text
+// `$` and keeps parsing (form 3, `justADollarSign`,
+// tmp/tcl9.0.4/generic/tclParse.c:1454 and :1502) — so the substitution after
+// it still happens.
+//
+// The lone-`$=` vectors above cannot see this: a top-level word reaches codegen
+// through the segmenter, which re-spells a bare `$x` as `${x}`, and the runtime
+// `subst_word` fallback resolves that even from a word pushed raw. Inside an
+// inline command substitution the argument text is the **raw source**, bare
+// `$x` and all, so a decoder that gives up on the whole word loses the
+// substitution outright: `[list $={y}$x]` yielded `{$={y}$x}` where both
+// oracles give `{$={y}X}` (#1668 review).
+
+/// The reported repro — a literal `$=` marker-shaped run then a real `$x`,
+/// inside an inline `[list …]`.
+const DOLLAR_EQ_MIXED_LIST_ARG_SCRIPT: &str =
+    concat!("set x X\n", "set y Y\n", "puts [list $={y}$x]\n");
+
+/// The same word measured, so the *string* is pinned and not just its list
+/// rendering.
+const DOLLAR_EQ_MIXED_LENGTH_SCRIPT: &str =
+    concat!("set x X\n", "set y Y\n", "puts [string length $={y}$x]\n");
+
+/// The bare command-word route.
+const DOLLAR_EQ_MIXED_WORD_SCRIPT: &str = concat!("set x X\n", "set y Y\n", "puts $={y}$x\n");
+
+/// The `set` value route.
+const DOLLAR_EQ_MIXED_SET_VALUE_SCRIPT: &str =
+    concat!("set x X\n", "set y Y\n", "set z $={y}$x\n", "puts $z\n",);
+
+/// The `switch` subject route: the subject is the *substituted* word, so it
+/// matches neither arm and falls to `default`.
+const DOLLAR_EQ_MIXED_SWITCH_SCRIPT: &str = concat!(
+    "set x X\n",
+    "set y Y\n",
+    "switch -- $={y}$x {\n",
+    "  X { puts matched-var }\n",
+    "  default { puts literal }\n",
+    "}\n",
+);
+
+/// The array-key route.
+const DOLLAR_EQ_MIXED_ARRAY_KEY_SCRIPT: &str = concat!(
+    "set x X\n",
+    "set y Y\n",
+    "set arr($={y}$x) V\n",
+    "puts [array names arr]\n",
+);
+
+/// A proc body, where the substituted half is an LVT slot.
+const DOLLAR_EQ_MIXED_IN_PROC_SCRIPT: &str =
+    concat!("proc p {} { set x X; puts [list $=$x] }\n", "p\n");
+
+/// `$(idx)` is the **empty-named** array, not a bare `$` — C admits it
+/// explicitly ("Support for empty array names here", `tclParse.c:1449-1453`),
+/// so the literal-`$` rule must not swallow it. This composite was un-decodable
+/// before the same fix.
+const DOLLAR_EMPTY_ARRAY_MIXED_SCRIPT: &str =
+    concat!("set (k) EMPTY\n", "set x X\n", "puts [list a$(k)b$x]\n",);
+
+/// A `$` that is a whole word of its own, beside a real reference.
+const DOLLAR_ALONE_BESIDE_VAR_SCRIPT: &str = concat!("set x X\n", "puts [list $ $x]\n");
+
 const DOLLAR_EQ_VECTORS: &[(&str, &str, &str)] = &[
     ("command word", DOLLAR_EQ_WORD_SCRIPT, "$={y}"),
     ("set value", DOLLAR_EQ_SET_VALUE_SCRIPT, "$={y}"),
@@ -1418,6 +1482,40 @@ const DOLLAR_EQ_VECTORS: &[(&str, &str, &str)] = &[
     ("list argument", DOLLAR_EQ_LIST_ARG_SCRIPT, "{$={y}}"),
     ("array key", DOLLAR_EQ_ARRAY_KEY_SCRIPT, "{$={y}}"),
     ("proc body", DOLLAR_EQ_IN_PROC_SCRIPT, "$={y}"),
+    // Mixed: literal `$` run, then a real substitution in the same word.
+    (
+        "mixed list argument",
+        DOLLAR_EQ_MIXED_LIST_ARG_SCRIPT,
+        "{$={y}X}",
+    ),
+    ("mixed string length", DOLLAR_EQ_MIXED_LENGTH_SCRIPT, "6"),
+    ("mixed command word", DOLLAR_EQ_MIXED_WORD_SCRIPT, "$={y}X"),
+    (
+        "mixed set value",
+        DOLLAR_EQ_MIXED_SET_VALUE_SCRIPT,
+        "$={y}X",
+    ),
+    (
+        "mixed switch subject",
+        DOLLAR_EQ_MIXED_SWITCH_SCRIPT,
+        "literal",
+    ),
+    (
+        "mixed array key",
+        DOLLAR_EQ_MIXED_ARRAY_KEY_SCRIPT,
+        "{$={y}X}",
+    ),
+    ("mixed proc body", DOLLAR_EQ_MIXED_IN_PROC_SCRIPT, "{$=X}"),
+    (
+        "empty-name array beside a var",
+        DOLLAR_EMPTY_ARRAY_MIXED_SCRIPT,
+        "aEMPTYbX",
+    ),
+    (
+        "lone dollar beside a var",
+        DOLLAR_ALONE_BESIDE_VAR_SCRIPT,
+        "{$} X",
+    ),
 ];
 
 /// The reading is the same at every release: `$=` never starts a substitution,

--- a/rust/tcl-vm/tests/dict_canonicalisation_parity.rs
+++ b/rust/tcl-vm/tests/dict_canonicalisation_parity.rs
@@ -1,0 +1,366 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The cross-crate drift gate for Tcl's dict canonicalisation rule (#1608).
+//!
+//! "A repeated key keeps its **first-occurrence position** and its **last
+//! value**" (`SetDictFromAny`, `tmp/tcl9.0.4/generic/tclDictObj.c:589`, over
+//! `Tcl_DictObjPut`'s hash overwrite) is one rule, and it now has one
+//! implementation — [`tcl_syntax::value::canonical_dict_slots`] — which three
+//! layers bind:
+//!
+//! 1. the runtime seam `ValueOps::dict_pairs` (this crate's `Vm` binds it, and
+//!    every VM `dict` opcode goes through that),
+//! 2. `tcl_registry::const_fold`'s `dict` folders (`get`/`exists`/`size`/
+//!    `keys`/`values`/`create`/`merge`), reached here through the public
+//!    `run_const_fold` path the optimiser uses,
+//! 3. `tcl_compiler::codegen::helpers::fold_dict_create_cmd`, the codegen's
+//!    `[dict create …]` fold.
+//!
+//! Before #1608 those were three independent copies of the walk, plus a fourth
+//! place where the rule had been *missed* — `parse_dict`, which fed six folders
+//! first-match semantics, so `[dict get {a 1 a 2} a]` folded to `1` where both
+//! oracles say `2` (#1427 / #1591). `cargo xtask owner-resolution` cannot see
+//! that class of drift: it validates the manifest, not whether a surface calls
+//! the owner at all.
+//!
+//! So this suite is the semantic gate. It feeds one duplicate-key / odd-shape
+//! corpus through **every** layer and asserts byte identity, and — when a real
+//! `tclsh8.6` / `tclsh9.0` is present (`TCL_LSP_TCLSH86` / `TCL_LSP_TCLSH90`
+//! override the PATH names) — against C Tcl too. A fourth copy, or a diverging
+//! edit to any binding, fails a test by name here rather than shipping a fold
+//! that changes program results.
+
+use std::io::Write as _;
+
+use tcl_dialect::TclVersion;
+use tcl_registry::CommandRegistry;
+use tcl_syntax::value::ValueOps as _;
+
+/// Dict *strings* — what `SetDictFromAny` canonicalises on the way in.
+///
+/// Rows cover: no duplicate, adjacent and separated duplicates, a triple, the
+/// empty dict, an empty key and an empty value, a braced key whose string rep
+/// needs quoting, a nested dict value (never re-canonicalised), numeric-looking
+/// keys that are *not* equal as strings (`1` vs `01`), and a key that repeats
+/// only after a value spelling that looks like a key.
+const DICT_CORPUS: &[&str] = &[
+    "",
+    "a 1",
+    "a 1 b 2",
+    "a 1 a 2",
+    "a 1 a 2 a 3",
+    "a 1 b 2 a 3",
+    "x 1 x 2 y 3",
+    "{} 1 {} 2",
+    "a {} a {}",
+    "{k k} 1 {k k} 2",
+    "o {a 1 a 2} o {b 3}",
+    "1 one 01 oh-one 1 uno",
+    "a b b a a c",
+    // A leading `#` is comment-unsafe only in list position 0, so these rows
+    // pin the *rendering* of a canonicalised dict as well as its pairing.
+    "# 1 a 2",
+    "a 1 # 2",
+    "# 1 # 2",
+];
+
+/// `dict create` **argument lists** — `DictCreateCmd`'s walk, which puts each
+/// pair into a fresh dict and therefore obeys the same rule.
+const CREATE_CORPUS: &[&[&str]] = &[
+    &[],
+    &["a", "1"],
+    &["a", "1", "a", "2"],
+    &["a", "1", "b", "2", "a", "3"],
+    &["a", "1", "a", "2", "a", "3"],
+    &["", "1", "", "2"],
+    &["k k", "1", "k k", "2"],
+    &["a", "x y", "a", "z w"],
+    &["#", "1"],
+    &["a", "1", "#", "2"],
+];
+
+// -- the three bindings -----------------------------------------------------
+
+/// Leg 1 — the owner, through this crate's `ValueOps` binding (the same code
+/// path every VM `dict` opcode takes).
+fn owner_pairs(dict: &str) -> Vec<(String, String)> {
+    let mut vm = tcl_vm::Vm::new();
+    let value = vm.new_str(dict);
+    let pairs = vm
+        .dict_pairs(&value)
+        .expect("every corpus row is an even-length list");
+    pairs
+        .into_iter()
+        .map(|(k, v)| (vm.as_str(&k).to_string(), vm.as_str(&v).to_string()))
+        .collect()
+}
+
+/// Leg 2 — a registry `dict` const-fold, resolved exactly as the optimiser
+/// resolves it.
+fn registry_fold(registry: &CommandRegistry, sub: &str, args: &[&str]) -> Option<String> {
+    registry
+        .get("dict")?
+        .subcommand(sub)?
+        .run_const_fold(args, Some(TclVersion::V9_0))
+}
+
+/// Leg 3 — the codegen's `[dict create …]` fold, fed the source spelling it
+/// sees in a compiled word.
+fn compiler_dict_create_fold(args: &[&str]) -> Option<String> {
+    let mut source = String::from("[dict create");
+    for arg in args {
+        source.push(' ');
+        source.push_str(&tcl_syntax::list::list_element(arg));
+    }
+    source.push(']');
+    tcl_compiler::codegen::helpers::fold_dict_create_cmd(&source)
+}
+
+/// Leg 4 — real C Tcl, when it is installed. `None` means "not available", not
+/// "disagreed": the suite still checks the three in-tree legs against each
+/// other and prints a skip note.
+fn tclsh_value(script: &str) -> Vec<(&'static str, String)> {
+    let mut out = Vec::new();
+    for (env, name) in [
+        ("TCL_LSP_TCLSH86", "tclsh8.6"),
+        ("TCL_LSP_TCLSH90", "tclsh9.0"),
+    ] {
+        let mut candidates = Vec::new();
+        if let Ok(explicit) = std::env::var(env) {
+            candidates.push(explicit);
+        }
+        candidates.push(name.to_owned());
+        for candidate in candidates {
+            let Ok(mut child) = std::process::Command::new(&candidate)
+                .stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+            else {
+                continue;
+            };
+            child
+                .stdin
+                .as_mut()
+                .expect("stdin")
+                .write_all(script.as_bytes())
+                .expect("write");
+            let result = child.wait_with_output().expect("run");
+            if result.status.success() {
+                out.push((
+                    name,
+                    String::from_utf8_lossy(&result.stdout).trim().to_owned(),
+                ));
+            }
+            break;
+        }
+    }
+    out
+}
+
+/// Render a Tcl script word for a literal string.
+fn word(s: &str) -> String {
+    tcl_syntax::list::list_element(s)
+}
+
+// -- the gates --------------------------------------------------------------
+
+/// The owner and the registry folders must agree on every dict, key for key
+/// and value for value — the folders read a *string* and the owner a value,
+/// but the canonicalisation between them is the same function.
+#[test]
+fn registry_dict_folds_agree_with_the_owner() {
+    let registry = CommandRegistry::build_default();
+    for dict in DICT_CORPUS {
+        let pairs = owner_pairs(dict);
+        let keys: Vec<&str> = pairs.iter().map(|(k, _)| k.as_str()).collect();
+        let values: Vec<&str> = pairs.iter().map(|(_, v)| v.as_str()).collect();
+
+        assert_eq!(
+            registry_fold(&registry, "size", &[dict]),
+            Some(pairs.len().to_string()),
+            "`dict size` disagrees with the owner on {dict:?}"
+        );
+        assert_eq!(
+            registry_fold(&registry, "keys", &[dict]),
+            Some(tcl_syntax::list::join_list(&keys)),
+            "`dict keys` disagrees with the owner on {dict:?}"
+        );
+        assert_eq!(
+            registry_fold(&registry, "values", &[dict]),
+            Some(tcl_syntax::list::join_list(&values)),
+            "`dict values` disagrees with the owner on {dict:?}"
+        );
+        for (key, value) in &pairs {
+            assert_eq!(
+                registry_fold(&registry, "get", &[dict, key]),
+                Some(value.clone()),
+                "`dict get {key:?}` disagrees with the owner on {dict:?}"
+            );
+            assert_eq!(
+                registry_fold(&registry, "exists", &[dict, key]),
+                Some("1".to_owned()),
+                "`dict exists {key:?}` disagrees with the owner on {dict:?}"
+            );
+        }
+    }
+}
+
+/// The registry's `dict create` fold and the codegen's are the two
+/// compile-time renderings of the same walk — byte identity, not merely the
+/// same pairs.
+#[test]
+fn dict_create_folds_agree_across_registry_and_codegen() {
+    let registry = CommandRegistry::build_default();
+    for args in CREATE_CORPUS {
+        let from_registry = registry_fold(&registry, "create", args);
+        let from_codegen = compiler_dict_create_fold(args);
+        // Declining is always safe — an unfolded call is simply evaluated at
+        // run time — so the codegen fold is allowed to abstain, as it does on
+        // the no-argument form (`[dict create]` has no argument text for its
+        // `"[dict create "` prefix to match). Only a fold that *fires* has to
+        // agree, and it has to agree byte for byte.
+        if let Some(folded) = &from_codegen {
+            assert_eq!(
+                Some(folded),
+                from_registry.as_ref(),
+                "registry and codegen `dict create` folds differ on {args:?}"
+            );
+        } else {
+            assert!(
+                args.is_empty(),
+                "the codegen `dict create` fold stopped firing on {args:?}"
+            );
+        }
+        // And both must be the owner's canonical pairing of the same words.
+        let owner = owner_pairs(&tcl_syntax::list::join_list(*args));
+        let expected: Vec<String> = owner
+            .iter()
+            .flat_map(|(k, v)| [k.clone(), v.clone()])
+            .collect();
+        assert_eq!(
+            from_registry,
+            Some(tcl_syntax::list::join_list(&expected)),
+            "the `dict create` fold is not the owner's canonicalisation on {args:?}"
+        );
+    }
+}
+
+/// Every layer against real C Tcl. The oracle is the reason the parity above
+/// is worth anything: three implementations can agree and still be wrong.
+#[test]
+fn dict_canonicalisation_matches_real_tclsh() {
+    let registry = CommandRegistry::build_default();
+    let mut checked = 0usize;
+
+    for dict in DICT_CORPUS {
+        let script = format!(
+            "set d {}\nputs [dict size $d]\nputs [dict keys $d]\nputs [dict values $d]\n",
+            word(dict)
+        );
+        for (release, output) in tclsh_value(&script) {
+            let mut lines = output.lines();
+            let (size, keys, values) = (
+                lines.next().unwrap_or_default(),
+                lines.next().unwrap_or_default(),
+                lines.next().unwrap_or_default(),
+            );
+            let pairs = owner_pairs(dict);
+            let owner_keys: Vec<&str> = pairs.iter().map(|(k, _)| k.as_str()).collect();
+            let owner_values: Vec<&str> = pairs.iter().map(|(_, v)| v.as_str()).collect();
+            assert_eq!(
+                pairs.len().to_string(),
+                size,
+                "{release}: owner `dict size` differs on {dict:?}"
+            );
+            assert_eq!(
+                tcl_syntax::list::join_list(&owner_keys),
+                keys,
+                "{release}: owner `dict keys` differs on {dict:?}"
+            );
+            assert_eq!(
+                tcl_syntax::list::join_list(&owner_values),
+                values,
+                "{release}: owner `dict values` differs on {dict:?}"
+            );
+            assert_eq!(
+                registry_fold(&registry, "keys", &[dict]).as_deref(),
+                Some(keys),
+                "{release}: folded `dict keys` differs on {dict:?}"
+            );
+            assert_eq!(
+                registry_fold(&registry, "values", &[dict]).as_deref(),
+                Some(values),
+                "{release}: folded `dict values` differs on {dict:?}"
+            );
+            checked += 1;
+        }
+    }
+
+    for args in CREATE_CORPUS {
+        let mut script = String::from("puts [dict create");
+        for arg in *args {
+            script.push(' ');
+            script.push_str(&word(arg));
+        }
+        script.push_str("]\n");
+        for (release, want) in tclsh_value(&script) {
+            assert_eq!(
+                registry_fold(&registry, "create", args).as_deref(),
+                Some(want.as_str()),
+                "{release}: registry `dict create` fold differs on {args:?}"
+            );
+            if let Some(folded) = compiler_dict_create_fold(args) {
+                assert_eq!(
+                    folded, want,
+                    "{release}: codegen `dict create` fold differs on {args:?}"
+                );
+            }
+            checked += 1;
+        }
+    }
+
+    if checked == 0 {
+        eprintln!(
+            "SKIPPING the tclsh oracle comparison: neither tclsh8.6 (or \
+             $TCL_LSP_TCLSH86) nor tclsh9.0 (or $TCL_LSP_TCLSH90) was found"
+        );
+    }
+}
+
+/// The rule itself, stated once as slot indices, on the shapes the string and
+/// argument walks share. If this drifts, everything above drifts with it —
+/// which is the point of there being only one of it.
+#[test]
+fn canonical_dict_slots_is_first_position_last_value() {
+    use tcl_syntax::value::canonical_dict_slots;
+
+    assert_eq!(canonical_dict_slots(Vec::<&str>::new()), vec![]);
+    assert_eq!(canonical_dict_slots(["a", "b"]), vec![(0, 0), (1, 1)]);
+    assert_eq!(canonical_dict_slots(["a", "a"]), vec![(0, 1)]);
+    assert_eq!(canonical_dict_slots(["a", "b", "a"]), vec![(0, 2), (1, 1)]);
+    assert_eq!(canonical_dict_slots(["a", "a", "a"]), vec![(0, 2)]);
+    // Keys compare by their exact rep — `1` and `01` are different keys.
+    assert_eq!(canonical_dict_slots(["1", "01", "1"]), vec![(0, 2), (1, 1)]);
+    // Byte keys bind the same rule (the shape a byte-oriented value model uses).
+    assert_eq!(
+        canonical_dict_slots([b"a".as_slice(), b"a".as_slice()]),
+        vec![(0, 1)]
+    );
+}


### PR DESCRIPTION
## Summary

Two pre-release drift-gate issues, kept as separate commits because they are separate areas.

### #1617 — `$={name}` is the user's literal text, not a compiler marker

The issue records it as a latent producer/consumer blind spot (mutation survivor M3b). Investigating it turned up something stronger: **the marker has no producer at all**, and its consumer is a live wrong-code path.

Nothing in the tree — back to the Rust rewrite commit `4e403da80` — ever emits `$={name}`. The segmenter re-spells a braced variable word verbatim from source (`segmenter::word_piece`, from #1568), and no other pass writes a `$=` prefix. So every word that reached the decoder came from the user's own source, where `$=` is not a substitution trigger in any supported release (`=` is not a name character; `Tcl_ParseVarName`, `tmp/tcl9.0.4/generic/tclParse.c`):

```tcl
set y hi
puts $={y}
```

tclsh8.6.16 and tclsh9.0.4 both print `$={y}`; our VM printed `hi`. Five of the six routes were wrong — bare command word, `set` value, `switch` subject, list argument, proc body; only the array-key route already read it as a literal.

That producer/consumer blindness is precisely why M3b survived the corpus: no program could tell the two halves apart. So the encoding is removed rather than pinned — `SubstPart::Scalar`, its `parse_subst_template` arm, `values::parse_braced_scalar_ref`, and its five call sites (`cmd_subst` x3, `statements`, `expressions`, `cfg_lower`'s switch subject). Nothing is lost: the form the marker existed to spell, `${a(1)}`, already reaches `parse_simple_var_ref`/`load_var`, which agrees with both oracles (`set {a(1)} S; array set a {1 A}; puts ${a(1)}` prints `A` everywhere — `TclObjLookupVar` parses the parens out of the name at lookup time). A note where the decoder used to be records why a future internal marker needs an out-of-band channel (an IR node or a word flag) rather than a spelling in the `$…` space that user source can collide with.

### #1608 — one owner for dict canonicalisation, plus the cross-crate gate

`tcl_syntax::value::canonical_dict_slots` is now the only implementation of "first-occurrence key position, last value wins" (`SetDictFromAny` over `Tcl_DictObjPut`, `tclDictObj.c:589`). It answers in **slot indices** — one `(key_slot, value_slot)` per surviving key — which is what lets every layer share it: the runtime seam maps them onto value handles, the compile-time folders onto their own strings. `DictCreateCmd`'s argument walk is the same rule, so one function covers both entry points. Keys are borrowed and only `Eq + Hash`, so a byte-keyed value model can bind it too.

Bound by `ValueOps::dict_pairs`, `const_fold::parse_dict`, `const_fold::fold_dict_create`, and `codegen::helpers::fold_dict_create_cmd`.

The drift gate is `rust/tcl-vm/tests/dict_canonicalisation_parity.rs`: one duplicate-key / odd-shape corpus through every binding — the `ValueOps` seam via `Vm`, the registry folds via the public `run_const_fold` path the optimiser uses, and the codegen fold — asserted byte-identical to each other **and** to real tclsh8.6/9.0. `owner-resolution` cannot see this class of drift (it validates the manifest, not whether a surface calls the owner), so the gate is semantic.

The WASM runtime's native dict rep is deliberately **not** routed through the owner: it keeps a live key index across mutation, so it canonicalises incrementally (one `Tcl_DictObjPut` per insert) rather than in one walk. It gets its own leg of the same gate instead (`duplicate_keys_canonicalise_like_the_shared_owner`, same corpus), and the contracts doc says so.

**The gate immediately found a second, live defect** (the #1439 class, in the fold-side renderers rather than the codec). `Tcl_Merge` brace-quotes a leading `#` only in list position 0; the registry's `list_join` and the compiler's `fold_cmd_args` / `fold_dict_create_cmd` mapped the single-element quoter over every element:

| fold | was | tclsh 8.6 / 9.0 |
| --- | --- | --- |
| `[dict keys {a 1 # 2}]` | `a {#}` | `a #` |
| `[list a #]` | `a {#}` | `a #` |
| `[lrepeat 2 #]` | `{#} {#}` | `{#} #` |

Same elements, different *string* — and a fold bakes the string into the program. All three renderers now go through `tcl_syntax::list::join_list`, which applies the rule position by position; that also corrects the `lrange`, `lreverse`, `split`, `concat` and `dict create`/`values`/`merge` folds. Rows pinned in `folded_lists_quote_a_leading_hash_only_in_position_zero`, each byte-exact from tclsh8.6.16 and tclsh9.0.4.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

All runs prefixed with `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=2`, and with `TCL_LSP_TCLSH86=…/tmp/tcl8616-install/bin/tclsh8.6` exported so the oracle legs actually execute (tclsh9.0 from PATH).

Gates:

- `cargo fmt --all --check` — clean in `rust/` and in `runtime/rust`
- `cargo clippy -p tcl-syntax --all-targets --features num-bigint`, `cargo clippy -p tcl-registry -p tcl-compiler -p tcl-vm --all-targets`, and `cargo clippy --all-targets` in `runtime/rust` — no new warnings (the runtime's pre-existing `needless_borrow` warnings are all in `cmd_fs.rs`, untouched here; `clippy -p tcl-syntax` without `--features num-bigint` fails to build `number_tower.rs` on `rust` already)
- `cargo check --workspace` — green
- `cargo xtask owner-resolution` — OK, 21 rows
- `make lsp-server-wasm-test` — 16/16 checks passed (this change is below `tcl-lsp-server`; no `std::time` use added)

Suites (all green): `tcl-syntax` (with `num-bigint`), `tcl-registry`, `tcl-compiler`, `tcl-vm` (41 suites), `tcl-lsp-core`, `tcl-cli`, `tcl-lsp-server` (1505 e2e), `tcl-spec-studio` (incl. the `reference_doc` drift test), `tcl-irules`, `tcl-spectcl`, `tcl-mcp`, `tcl-explorer`, `tcl-debugger`, `tcl-diagram`, `tcl-cli-support`, `tcl-cmd-core`, `tcl-lsp-db`, `f5-cli`, `f5-xc`, `tcl-bigip`, `tcl-bigip-query`, `tcl-pkg`, `tcl-irule-test`, `tcl-bytecode`, `tcl-dialect`, `tcl-engine-tclvm`, `tcl-spec-hooks`, and `runtime/rust` (457 tests).

One flake seen, **not** a regression: `semantic_tokens_reference_client::large_file_range_semantic_tokens_converges_via_refresh` failed once under a loaded parallel run (server returned the coarse tier for one index) and passed in isolation and in a full clean re-run of `-p tcl-lsp-server --test e2e` (1505 passed).

Mutation verification (each from a green baseline; every mutant reverted, working tree clean):

| mutant | killed by |
| --- | --- |
| revive the `$={…}` decode in `emit_value` | `compiled_dollar_equals_word_is_literal_at_every_release`, `compiled_dollar_equals_word_matches_real_tclsh`, `dollar_equals_word_is_a_literal_not_a_variable_load` |
| revive it in `emit_cmd_subst_arg` | `cmd_subst_arg_dollar_equals_stays_literal`, `emit_cmd_subst_arg_composite_and_special_forms` |
| `canonical_dict_slots`: first value wins | `canonical_dict_slots_is_first_position_last_value`, `dict_canonicalisation_matches_real_tclsh` |
| `canonical_dict_slots`: duplicate moves to the end | same two |
| `list_join`: back to per-element quoting | `folded_lists_quote_a_leading_hash_only_in_position_zero`, and three of the four parity tests |
| a fourth copy of the walk re-added in `fold_dict_create_cmd` (first value wins) | `dict_create_folds_agree_across_registry_and_codegen`, `dict_canonicalisation_matches_real_tclsh` |

Worth noting from that table: the two cross-layer parity tests pass under a mutation of the **owner** itself, because every layer drifts together. That is exactly why the tclsh leg exists, and it is the leg that fails.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? Yes — the dicts owner row gains a public entry point.
- [x] If yes, I updated the owning design doc: `docs/design/contracts/shared-utility-contracts-rust.md` — `canonical_dict_slots` added to the dicts manifest row, with the new gate and the WASM runtime's position described in the named-test section (`cargo xtask owner-resolution` green).
- [x] No diagnostic or optimisation code added or changed, so no `docs/kcs/codes/` page moved.
- [x] No new design doc.

Fixes #1608
Fixes #1617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o)_