### PR TITLE
fix(analyser): a lambda argument is script the fall-through walk must see

### DIFF
--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -7063,17 +7063,40 @@ impl Analyser {
             .arg_tokens()
             .iter()
             .position(|token| token.span == arm.body_span);
-        let body_index = direct.or_else(|| {
-            let (_, invocation) = registry.case_invocation(
-                arm.controller.name(),
-                &args,
-                self.profile.availability_mask,
-            )?;
-            let index = invocation.clause_list_index?;
-            let container = arm.controller.arg_tokens().get(index)?.span;
-            (container.start() <= arm.body_span.start() && arm.body_span.end() <= container.end())
+        let body_index = direct
+            .or_else(|| {
+                let (_, invocation) = registry.case_invocation(
+                    arm.controller.name(),
+                    &args,
+                    self.profile.availability_mask,
+                )?;
+                let index = invocation.clause_list_index?;
+                let container = arm.controller.arg_tokens().get(index)?.span;
+                (container.start() <= arm.body_span.start()
+                    && arm.body_span.end() <= container.end())
                 .then_some(index)
-        })?;
+            })
+            // …or one body nested inside a lambda literal, whose span likewise
+            // belongs to a list element rather than to the argv word
+            // (`apply {{} {…}}`, issue #1656).
+            .or_else(|| {
+                registry
+                    .arg_indices_for_role(
+                        arm.controller.name(),
+                        &args,
+                        tcl_registry::ArgRole::LambdaLiteral,
+                    )
+                    .into_iter()
+                    .find(|index| {
+                        arm.controller
+                            .arg_tokens()
+                            .get(*index)
+                            .is_some_and(|token| {
+                                token.span.start() <= arm.body_span.start()
+                                    && arm.body_span.end() <= token.span.end()
+                            })
+                    })
+            })?;
         registry.control_arm_semantics(arm.controller.name(), &args, body_index)
     }
 
@@ -7100,14 +7123,22 @@ impl Analyser {
     /// declared `DEFERS_BODY` is assumed to run its body now. The first
     /// version of this helper read the *absence* of control-arm semantics as
     /// proof of dormancy, which is not what that absence means —
-    /// `uplevel 1 $script`, `apply $lambda` and `oo::define $c $script` have
-    /// no control-arm semantics either, and every one of them executes its
-    /// argument immediately and can raise or return before the enclosing walk
-    /// reaches the statement it cares about. That let the computed-metaclass
-    /// walk materialise a class created after `uplevel 1 $script`
-    /// (PR #1652 review, issue #1571). `BodyKind` cannot answer it either:
-    /// `proc` and `uplevel` are both `Structural`, because that descriptor
-    /// answers *which frame*, not *when*.
+    /// `uplevel 1 $script` and `oo::define $c $script` have no control-arm
+    /// semantics either, and both execute their argument immediately and can
+    /// raise or return before the enclosing walk reaches the statement it
+    /// cares about. That let the computed-metaclass walk materialise a class
+    /// created after `uplevel 1 $script` (PR #1652 review, issue #1571).
+    /// `BodyKind` cannot answer it either: `proc` and `uplevel` are both
+    /// `Structural`, because that descriptor answers *which frame*, not
+    /// *when*.
+    ///
+    /// `body_index` may name an [`ArgRole::LambdaLiteral`] word as well as an
+    /// [`ArgRole::Body`] one — an unreadable lambda is unreadable script on
+    /// the same terms (issue #1656), and `apply` types that position, so it
+    /// stops at the first check.
+    ///
+    /// [`ArgRole::Body`]: tcl_registry::ArgRole::Body
+    /// [`ArgRole::LambdaLiteral`]: tcl_registry::ArgRole::LambdaLiteral
     fn unreadable_body_is_material(&self, seg: &SegmentedCommand, body_index: usize) -> bool {
         let Some(registry) = self.registry.as_deref() else {
             return true;
@@ -7181,7 +7212,65 @@ impl Analyser {
                 complete &= !self.unreadable_body_is_material(seg, idx);
             }
         }
+        self.collect_lambda_arms(seg, &args, &mut arms, &mut complete);
         ControlArms { arms, complete }
+    }
+
+    /// The [`ArgRole::LambdaLiteral`] half of [`Self::control_arms_for_segment`]
+    /// (issue #1656).
+    ///
+    /// A lambda argument carries a script that runs *now* — `apply $lambda`
+    /// can raise before control ever reaches the next statement — but it is
+    /// not an [`ArgRole::Body`], so the loop above never sees it. The walk
+    /// therefore neither read such a lambda nor abstained on it, and claimed
+    /// past an aborting one: the same soundness class as the `uplevel` shape
+    /// PR #1652 closed, reached through the other role.
+    ///
+    /// The argument is one level removed from a body — a `{argList body ?ns?}`
+    /// **list** — so a readable one contributes its *body element*'s span,
+    /// split by the shared [`crate::lambda_literal`] owner rather than
+    /// re-segmented whole (the mis-read that named issue #954). A lambda whose
+    /// body cannot be located at exact source offsets — a computed word, a
+    /// malformed list, a body element that is not `{braced}` and so has its
+    /// escapes collapsed before `apply` sees it — is unreadable, and falls to
+    /// the same materiality question a `Body` word does.
+    ///
+    /// [`ArgRole::Body`]: tcl_registry::ArgRole::Body
+    /// [`ArgRole::LambdaLiteral`]: tcl_registry::ArgRole::LambdaLiteral
+    fn collect_lambda_arms(
+        &self,
+        seg: &SegmentedCommand,
+        args: &[&str],
+        arms: &mut Vec<ControlArm>,
+        complete: &mut bool,
+    ) {
+        let Some(registry) = self.registry.as_deref() else {
+            return;
+        };
+        let mut indices =
+            registry.arg_indices_for_role(seg.name(), args, tcl_registry::ArgRole::LambdaLiteral);
+        indices.sort_unstable();
+        indices.dedup();
+        for idx in indices {
+            // Read the body only where the registry says what running it
+            // means. `apply` types this position (a frame boundary that runs
+            // now); a command that carries the role without typing it has told
+            // the walk nothing, and an untyped script that runs now is exactly
+            // what `unreadable_body_is_material` abstains on.
+            let body = registry
+                .control_arm_semantics(seg.name(), args, idx)
+                .and_then(|_| seg.arg_tokens().get(idx).copied())
+                .and_then(|token| crate::lambda_literal::split_lambda_literal(&self.source, token))
+                .and_then(|elements| elements.braced_body());
+            if let Some(body_span) = body {
+                arms.push(ControlArm {
+                    controller: seg.clone(),
+                    body_span,
+                });
+            } else {
+                *complete &= !self.unreadable_body_is_material(seg, idx);
+            }
+        }
     }
 
     fn if_body_is_selected(

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -5739,6 +5739,103 @@ mod class_factories {
     }
 
     #[test]
+    fn an_apply_of_an_unreadable_lambda_still_abstains() {
+        // FP guard (#1656) — the same soundness class as the `uplevel` vector
+        // above, reached through the *other* role. `apply`'s argument is
+        // `ArgRole::LambdaLiteral`, not `Body`, so before this fix
+        // `control_arms_for_segment` never saw it: the walk neither read the
+        // lambda nor abstained on it, and claimed the creation below.
+        //
+        // A lambda word this walk cannot read can be anything, including a
+        // body that raises — tclsh 8.6.16 and 9.0.4 agree that the statement
+        // after `apply $lambda` is not reached when it does.
+        // The last two vectors are readable as *text* but not as a script: a
+        // body element that is not `{braced}` is list-decoded before `apply`
+        // evaluates it, so its source slice is not the script that runs.
+        //
+        // The quoted one is the sharp case, and the reason this walk takes
+        // only a braced body. Its slice is `puts a\;error stop` — an escaped
+        // semicolon, so *as source* it is one `puts` command that falls
+        // through. The script `apply` actually runs is the list-decoded
+        // `puts a;error stop`: two commands, the second of which raises.
+        // tclsh 8.6.16 / 9.0.4 agree (both print `a`, raise `stop`, and never
+        // create the class), so a walk that read the slice would claim a
+        // creation neither interpreter performs.
+        for prefix in [
+            "    apply $lambda\n",
+            "    apply $lambda a b\n",
+            "    apply [set lambda]\n",
+            "    apply {{} error\\ stop}\n",
+            "    apply {{} \"puts a\\;error stop\"}\n",
+        ] {
+            let src = COMPUTED_METACLASS.replace(
+                "    ::T::Mother create ${NSPACE}::class { superclass ::T::Mother }\n",
+                &format!(
+                    "{prefix}    ::T::Mother create ${{NSPACE}}::class {{ superclass ::T::Mother }}\n"
+                ),
+            );
+            let result = analysis(&src, "tcl9.0");
+            assert!(
+                !result.all_classes.contains_key("::T::D::class"),
+                "an unreadable lambda must abstain: {prefix:?}; got {:?}",
+                result.all_classes.keys().collect::<Vec<_>>()
+            );
+        }
+    }
+
+    #[test]
+    fn an_aborting_literal_lambda_cannot_be_walked_past() {
+        // The concrete harm, with the lambda in plain sight: both oracles
+        // agree the creation never happens.
+        //
+        //   proc mk {name} { apply {{} {error stop}}; Mother create … }
+        //
+        // tclsh 8.6.16 / 9.0.4: `::T::D::class` does not exist afterwards.
+        for prefix in [
+            "    apply {{} {error stop}}\n",
+            "    apply {{} {return -code error stop}}\n",
+        ] {
+            let src = COMPUTED_METACLASS.replace(
+                "    ::T::Mother create ${NSPACE}::class { superclass ::T::Mother }\n",
+                &format!(
+                    "{prefix}    ::T::Mother create ${{NSPACE}}::class {{ superclass ::T::Mother }}\n"
+                ),
+            );
+            let result = analysis(&src, "tcl9.0");
+            assert!(
+                !result.class_factories().contains_key("::T::D::class"),
+                "no factory may be published past an aborting lambda: {prefix:?}; got {:?}",
+                result.class_factories().keys().collect::<Vec<_>>()
+            );
+        }
+    }
+
+    #[test]
+    fn a_readable_lambda_that_falls_through_is_not_a_blocker() {
+        // TP control for the two guards above: the fix must not cost the walk
+        // every `apply`. This lambda's body is right there, it completes
+        // normally, and tclsh 8.6.16 / 9.0.4 both reach the statement after
+        // it — so the creation stays proved.
+        let src = COMPUTED_METACLASS.replace(
+            "    ::T::Mother create ${NSPACE}::class { superclass ::T::Mother }\n",
+            concat!(
+                "    apply {{} {set q 1}}\n",
+                "    ::T::Mother create ${NSPACE}::class { superclass ::T::Mother }\n",
+            ),
+        );
+        let result = analysis(&src, "tcl9.0");
+        assert!(
+            result.all_classes.contains_key("::T::D::class"),
+            "a readable falling-through lambda must not abstain the walk; got {:?}",
+            result.all_classes.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            result.class_factories().contains_key("::T::D::class"),
+            "the resolved metaclass must still publish a factory"
+        );
+    }
+
+    #[test]
     fn four_hundred_nested_foreach_bodies_do_not_abort_the_process() {
         // Issue #1654, on this test's own default-sized thread — which is
         // the whole point: the walks this drives must contain themselves on

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -2121,6 +2121,28 @@ impl CommandRegistry {
             }
             LoweringHookId::Switch => Some(ControlArmSemantics::Selected),
             LoweringHookId::NamespaceEval => Some(ControlArmSemantics::FrameBoundary),
+            // `apply`'s lambda runs **now**, in a fresh procedure frame that
+            // inherits none of the caller's locals — a frame boundary, and the
+            // only [`ArgRole::LambdaLiteral`] position in the registry today
+            // (issue #1656). The role is one level removed from a body (the
+            // argument is the `{argList body ?ns?}` *list*), so the index is
+            // gated on the role rather than assumed, exactly as the `if` arm
+            // above gates on `ArgRole::Body`.
+            //
+            // The boundary is not symmetric with `namespace eval`'s on one
+            // point, and a consumer reading completion out of this descriptor
+            // should know it: a `return` inside the lambda completes the
+            // *lambda*, so control does reach the statement after the `apply`,
+            // whereas `namespace eval`'s script propagates its `return` to the
+            // enclosing procedure (tclsh 8.6.16 / 9.0.4 agree on both). Errors
+            // propagate from either. The compiler's fall-through walk does not
+            // separate an early *normal* completion from an abnormal one — a
+            // limit recorded on PR #1652 — so it reads a lambda that returns
+            // as one it cannot walk past, which is conservative and sound.
+            LoweringHookId::Apply => self
+                .arg_indices_for_role(name, args, ArgRole::LambdaLiteral)
+                .contains(&body_index)
+                .then_some(ControlArmSemantics::FrameBoundary),
             LoweringHookId::Catch => Some(ControlArmSemantics::CompletionBoundary),
             // A collection loop iterates a value the invocation itself
             // supplies, so it runs a *finite* number of times: it terminates
@@ -6883,8 +6905,10 @@ mod tests {
     /// `BodyKind` cannot answer this — `proc` and `uplevel` are both
     /// `Structural`, because that descriptor answers *which frame*, not
     /// *when* — and neither can the absence of `control_arm_semantics`, which
-    /// `uplevel` / `apply` / `oo::define` share with `proc` (issue #1571,
-    /// PR #1652 review).
+    /// `uplevel` / `oo::define` share with `proc` (issue #1571, PR #1652
+    /// review). (`apply` was in that list until issue #1656 gave its lambda
+    /// position a typed frame boundary; it still declares no `DEFERS_BODY`,
+    /// which is what this test checks.)
     #[test]
     fn defers_body_marks_only_stored_bodies() {
         use crate::body_kind::BodyKind;
@@ -6927,9 +6951,77 @@ mod tests {
         );
     }
 
+    /// `apply`'s lambda position is a typed **frame boundary**: the script
+    /// runs as part of this call, in a fresh procedure frame (issue #1656).
+    ///
+    /// The declaration is what lets a consumer walking a statement stream
+    /// treat an unreadable `apply $lambda` as the missing answer it is — the
+    /// role alone never reached the question, so the walk claimed past a
+    /// lambda that can raise.
+    ///
+    /// Gated on the role, not on the argument number: only the
+    /// [`ArgRole::LambdaLiteral`] word is the script. `apply`'s trailing
+    /// `arg1 arg2 …` are ordinary values bound to the lambda's parameters.
+    #[test]
+    fn apply_types_its_lambda_position_as_a_frame_boundary() {
+        let reg = CommandRegistry::build_default();
+        assert_eq!(
+            reg.control_arm_semantics("apply", &["{{} {puts hi}}"], 0),
+            Some(ControlArmSemantics::FrameBoundary),
+            "`apply`'s lambda runs now, in a fresh frame"
+        );
+        for index in 1..4 {
+            assert_eq!(
+                reg.control_arm_semantics("apply", &["{{a b} {puts hi}}", "1", "2"], index),
+                None,
+                "argument {index} is a value bound to a parameter, not a script"
+            );
+        }
+        // The role is what the declaration keys on, so it survives a rename of
+        // the position and answers for any future command sharing the shape.
+        assert_eq!(
+            reg.arg_indices_for_role("apply", &["{{} {puts hi}}"], ArgRole::LambdaLiteral),
+            vec![0]
+        );
+    }
+
+    /// Every shipped command carrying [`ArgRole::LambdaLiteral`] types that
+    /// position, so the analyser's "read the body only where the registry says
+    /// what running it means" gate is never the thing deciding a shipped
+    /// command's fate.
+    ///
+    /// Pinned rather than assumed (issue #1656): `apply` is the only such
+    /// command today, so dropping that gate would change nothing here — but a
+    /// pack, or a future built-in, can carry the role without typing it, and
+    /// then the gate is what keeps an untyped script that runs *now* from
+    /// being walked into and claimed. This test says out loud that the shipped
+    /// set does not exercise it.
+    #[test]
+    fn every_shipped_lambda_position_is_typed() {
+        let mut reg = CommandRegistry::build_default();
+        reg.load_irules();
+        let names: Vec<String> = reg.command_names().map(str::to_owned).collect();
+        let mut seen = 0usize;
+        for name in names {
+            for argc in 1..=4 {
+                let args = vec!["{{} {puts hi}}"; argc];
+                for index in reg.arg_indices_for_role(&name, &args, ArgRole::LambdaLiteral) {
+                    seen += 1;
+                    assert!(
+                        reg.control_arm_semantics(&name, &args, index).is_some(),
+                        "{name}/{argc} carries a lambda at {index} without typing what running \
+                         it means"
+                    );
+                }
+            }
+        }
+        assert!(seen > 0, "the sweep must not be vacuous");
+    }
+
     /// `DEFERS_BODY` and typed control-arm semantics are answers to different
     /// questions, and today no command gives both: everything the registry
-    /// types (`if`, `switch`, `namespace eval`, `catch`, `try`, the loops)
+    /// types (`if`, `switch`, `namespace eval`, `catch`, `try`, the loops,
+    /// `apply`'s lambda)
     /// runs the arm it types.
     ///
     /// That is *why* a consumer cannot currently observe which of the two


### PR DESCRIPTION
## Summary

Fixes #1656.

`apply $lambda` was claimed past. The computed-name fall-through walk collects a command's bodies through `ArgRole::Body`, and `apply`'s argument is `ArgRole::LambdaLiteral` — one level removed, a `{argList body ?ns?}` **list** rather than a script — so `control_arms_for_segment` never saw it. The walk neither read the lambda nor abstained on it: a factory whose dominating prefix ran a lambda that raises materialised a class no interpreter ever makes. Same soundness class as the `uplevel` shape #1652 closed, reached through the other role.

Reproducing it turned up two things beyond the report:

1. **The literal shape was claimed too.** `apply {{} {error stop}}` — body in plain sight — was also walked past, because with no `Body`-role argument the arm set came back empty and "no arms" reads as "falls through". The gap is not only the unreadable case.
2. **A non-braced body element cannot be read at all.** `apply {{} "puts a\;error stop"}` *slices* as one falling-through `puts` command; the script `apply` really runs is the list-decoded `puts a;error stop`, whose second command raises.

## Oracle evidence

tclsh 8.6.16 (via `TCL_LSP_TCLSH86`) and tclsh 9.0.4, byte-identical on every row. `reached` = the statement after the `apply` runs.

```tcl
proc mk {name} {
    apply {{} {error stop}}
    Mother create ${name}::class { superclass Mother }
}
catch {mk ::T::D}          ;# ::T::D::class does not exist
```

| prefix | tclsh 8.6 / 9.0 | before | after |
|---|---|---|---|
| `apply $lambda` | not reached (if it raises) | claimed | abstains |
| `apply {{} {error stop}}` | not reached | claimed | abstains |
| `apply {{} {return -code error stop}}` | not reached | claimed | abstains |
| `apply {{} "puts a\;error stop"}` | not reached (prints `a`, raises `stop`) | claimed | abstains |
| `apply {{} {set q 1}}` | reached | claimed | **claimed** |

## The fix

The lambda position becomes registry data rather than an analyser inference: `LoweringHookId::Apply` types it `ControlArmSemantics::FrameBoundary` — the script runs as part of *this* call, in a fresh procedure frame — gated on `ArgRole::LambdaLiteral`, so `apply`'s trailing `arg1 arg2 …` (values bound to the lambda's parameters, never re-evaluated) stay untyped.

With that declared:

* an **unreadable** lambda reaches the materiality question #1652 built — `DEFERS_BODY` unset ⇒ the body runs now ⇒ the arm set is incomplete ⇒ abstain;
* a **readable** one contributes its body as an arm the walk descends, which is what keeps the last row above.

The body is taken only from a `{braced}` element, through the shared `lambda_literal` splitter (the owner that exists because generic `Body` walkers used to mis-read the whole `{argList body}` blob as script — #954). A non-braced element is list-decoded before `apply` evaluates it, so its source slice is not the script that runs; reading the slice would claim a creation neither interpreter performs.

One deliberate conservatism, recorded on the declaration: a `return` inside a lambda completes the **lambda**, so Tcl does reach the statement after the `apply` (`apply {{} {return}}` → reached), while `namespace eval`'s script propagates its return to the enclosing procedure (`namespace eval ::z {return}` → not reached; both releases agree on both). This walk does not separate an early *normal* completion from an abnormal one — the limit already recorded on #1652 for clay's `if … return` — so a returning lambda reads as one it cannot walk past. Abstaining is the safe direction.

## Validation

All from `rust/`, prefixed `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=2`, with `TCLLIB_2_0_DIR=…/tmp/tcllib-2.0` and `TCL_LSP_TCLSH86=…/tmp/tcl8616-install/bin/tclsh8.6`.

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p tcl-registry -p tcl-compiler --all-targets` — no warnings (Rust 1.98)
- [x] `cargo check --workspace` — clean
- [x] `cargo test -p tcl-compiler -p tcl-registry -p tcl-spectcl` — 89 suites green **with the corpus present**, `full_tcllib_clay_dialect_metaclass_resolves_when_the_corpus_is_available` included
- [x] `cargo test -p tcl-lsp-core -p tcl-lsp-db -p tcl-spec-studio` — 56 suites green (`reference_doc` drift test included)

Mutation-verified from a green baseline: **9 mutants, 8 killed by name, 1 proven equivalent.**

Killed: the lambda pass removed; an unreadable lambda made immaterial; a readable lambda contributing no arm; the lambda position untyped; typed `CompletionBoundary` instead of `FrameBoundary`; the role gate dropped from the declaration; any body element accepted, braced or not; the nested-body index left unresolvable in `control_arm_semantics_for`.

The survivor drops the analyser's "read the lambda only where the registry types it" gate. `apply` is the only shipped `LambdaLiteral` command, so nothing observable changes — an equivalence, not a hole. Rather than assume it, `every_shipped_lambda_position_is_typed` pins it, and the gate is what keeps a SpecTcl pack's untyped lambda from being walked into. An earlier survivor (accepting any body element) drove the quoted-escape vector in the table.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? Yes — `apply`'s lambda position now carries `ControlArmSemantics::FrameBoundary`. No new descriptor or variant; the fact is documented on its own declaration, which is where the registry's per-command knowledge lives.
- [x] No diagnostic or optimisation code added or changed, so no `docs/kcs/codes/` page needed.
- [x] No new design doc, so no `docs/design/README.md` link needed.

## Notes for review

- `ControlArmSemantics` gained no variant; only `apply`'s mapping is new. Consumers remain `tcl-registry`'s own mapping and `tcl-compiler/src/analyser/handlers.rs`.
- `method_body_terminates` abstains (returns `None`) on a method body containing an `apply`, where it previously read it as an ordinary falling-through statement — arms of any kind have always made it abstain. Conservative, and the `unknown_dispatch_*` FP guards stay green.

## Findings not fixed here

- **The same hole on the `Body` side.** A readable body that runs *now* but carries no typed control semantics is still claimed past: `uplevel 1 {error stop}`, `eval {error stop}` and `oo::define ::T::Mother {error stop}` in the dominating prefix all still materialise the class, though both oracles create nothing. #1652's guard covers the unreadable case only; the arm those commands contribute is silently ignored for want of semantics. Fixing it means deciding what an untyped, non-`DEFERS_BODY` arm obliges the walk to prove — a wider blast radius (every `eval` / `uplevel` / `oo::define` / `after` body in the corpus), so it wants its own issue and its own corpus run rather than riding along here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o)_