### PR TITLE
fix(analyser): form a creation call's verdict after the metaclass join settles

### DIFF
--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -6735,9 +6735,7 @@ impl Analyser {
         self.result
             .all_classes
             .insert(qualified.to_owned(), joined.clone());
-        if let Some(scope) =
-            super::scope::scope_at_mut(&mut self.result.global_scope, &scope_path.to_vec())
-        {
+        if let Some(scope) = super::scope::scope_at_mut(&mut self.result.global_scope, scope_path) {
             scope.classes.insert(simple, joined);
         }
     }

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -310,6 +310,17 @@ impl ManufacturerLayout {
 /// stopping early can only *lose* evidence, which abstains.
 const MAX_UNKNOWN_BODY_DEPTH: u32 = 8;
 
+/// How many unclassifiable creation calls one document keeps for the
+/// post-pass retry — see [`Analyser::defer_class_creation`] (issue #1660).
+///
+/// Only a call whose head names nothing the document knows is kept, so a real
+/// file holds a handful: the shape exists to catch a metaclass proved after
+/// the walk, and a document proves few. The cap bounds a generated or
+/// half-edited file whose calls are all to unknown commands; past it the
+/// document behaves exactly as it did before this pass existed, which is the
+/// abstaining direction.
+const MAX_DEFERRED_CLASS_CREATIONS: usize = 4096;
+
 /// One creation call inside a proc body whose name word reads a parameter —
 /// see [`Analyser::record_literal_parameter_definitions`].
 struct ParameterisedCreation {
@@ -6567,7 +6578,184 @@ impl Analyser {
     /// ([`tcl_registry::CommandRegistry::is_manufacturer_method`]) and the
     /// creation's structural template exists only when the ordinary generic
     /// handler classified it as a class creation.
+    /// Keep a creation call the walk declined, in case a metaclass proved
+    /// after the walk turns it into one (issue #1660).
+    ///
+    /// The gate is "nothing this document knows makes the head's verdict
+    /// final": a registry command has its own classification, and a recorded
+    /// **proc** is a command that is not a class, so neither can become a
+    /// factory later and neither is kept.
+    ///
+    /// A recorded **class** deliberately *is* kept, even though the walk knew
+    /// the name. A class can be recorded without a factory and gain one in the
+    /// post-pass — an `oo::define` on a computed-name metaclass makes exactly
+    /// such a stub, and the join then proves it — so "known" is not the same
+    /// question as "judged".
+    ///
+    /// A call needs at least a manufacturer word and a name word to be a
+    /// creation at all, so shorter ones are never kept. Buffering is bounded:
+    /// past [`MAX_DEFERRED_CLASS_CREATIONS`] a document keeps the behaviour it
+    /// had before this pass existed, which is the abstaining direction.
+    fn defer_class_creation(
+        &mut self,
+        cmd_name: &str,
+        args: &[String],
+        arg_tokens: &[Token],
+        scope_path: &[usize],
+        cmd_tok: Token,
+    ) {
+        // Cheapest questions first: this runs for every command the generic
+        // handler declines, which is most of a document.
+        if args.len() < 2
+            || arg_tokens.len() < 2
+            || self.deferred_class_creations.len() >= MAX_DEFERRED_CLASS_CREATIONS
+            || crate::naming::is_dynamic_word(cmd_name)
+            || self
+                .registry
+                .as_deref()
+                .is_some_and(|registry| registry.get(cmd_name).is_some())
+        {
+            return;
+        }
+        let namespace = self.command_resolution_namespace(scope_path);
+        if crate::naming::bareword_resolution_candidates(&namespace, cmd_name)
+            .into_iter()
+            .any(|candidate| self.result.all_procs.contains_key(&candidate))
+        {
+            return;
+        }
+        self.deferred_class_creations
+            .push(super::types::DeferredClassCreation {
+                cmd_name: cmd_name.to_owned(),
+                args: args.to_vec(),
+                arg_tokens: arg_tokens.to_vec(),
+                scope_path: scope_path.to_vec(),
+                cmd_tok,
+            });
+    }
+
+    /// Form the deferred verdicts, now that
+    /// [`Self::record_literal_parameter_definitions`] has settled the
+    /// parameterised-class join (issue #1660).
+    ///
+    /// Replayed in document order, so a chain settles in one pass: a class
+    /// this replay records is in the index before the next call is retried,
+    /// which is what lets `Meta create ::A::sub` and then `::A::sub create
+    /// ::A::leaf` both land when `Meta` itself was only proved post-pass.
+    ///
+    /// Each call goes back through the *same* handler the walk used, so a
+    /// replayed creation is recorded by one code path with the walk's own
+    /// rules — the manufacturer layout, the injected members, the body walk,
+    /// the W314/W315 emissions. The retry is gated on the head now naming a
+    /// factory, so a head that stayed unknown costs one lookup and records
+    /// nothing.
+    pub(super) fn replay_deferred_class_creations(&mut self) {
+        if self.deferred_class_creations.is_empty() {
+            return;
+        }
+        for deferred in std::mem::take(&mut self.deferred_class_creations) {
+            // What the walk already recorded under the name this call
+            // creates — an `oo::define` stub it made *because* the creation
+            // was invisible. Captured before the replay, which overwrites it.
+            let prior = self.deferred_creation_prior(&deferred);
+            if !self.handle_oo_class_command(
+                &deferred.cmd_name,
+                &deferred.args,
+                &deferred.arg_tokens,
+                &deferred.scope_path,
+                deferred.cmd_tok,
+            ) {
+                continue;
+            }
+            if let Some((qualified, prior)) = prior {
+                self.rejoin_replayed_class(&qualified, &prior, &deferred.scope_path);
+            }
+        }
+        // A replayed call has had its verdict, whichever way it went. The
+        // handler's decline path buffers again — it cannot tell a first
+        // hearing from a second — so the buffer is emptied here rather than
+        // left to be replayed once more against the same evidence.
+        self.deferred_class_creations.clear();
+    }
+
+    /// The class name a deferred call would record, paired with whatever the
+    /// walk already holds under it (issue #1660).
+    ///
+    /// `None` when the head still names no factory, when the layout puts no
+    /// name where this call has a word, or — the ordinary case — when nothing
+    /// was recorded under that name at all.
+    fn deferred_creation_prior(
+        &self,
+        deferred: &super::types::DeferredClassCreation,
+    ) -> Option<(String, ClassDef)> {
+        let resolved = self.resolve_class_creation(
+            &deferred.cmd_name,
+            &deferred.args,
+            &deferred.arg_tokens,
+            &deferred.scope_path,
+            deferred.cmd_tok,
+        )?;
+        let raw_name = deferred.args.get(resolved.layout.name_arg)?;
+        let namespace = self.command_resolution_namespace(&deferred.scope_path);
+        let qualified = qualify(&namespace, raw_name);
+        Some((
+            qualified.clone(),
+            self.result.all_classes.get(&qualified)?.clone(),
+        ))
+    }
+
+    /// Fold a record the walk made for a class whose creation call it could
+    /// not see back into the replayed creation (issue #1660).
+    ///
+    /// Because the creation was invisible, an `oo::define` on the same class
+    /// made a *stub* — and that stub is where its members went. The replay
+    /// then records the creation under the same name, so without this the
+    /// members the walk did record would be lost: strictly worse than before
+    /// the replay existed.
+    ///
+    /// The union is the one [`join_parameterised_class_observations`] already
+    /// owns, used exactly as the parameterised-class post-pass uses it, so a
+    /// stub joins a creation by one rule wherever the two meet. Two
+    /// observations that contradict each other publish the abstaining record
+    /// the house rule calls for — no factory, inheritance unknown — while
+    /// still keeping both sides' declarations, which are declarations of this
+    /// class either way.
+    fn rejoin_replayed_class(&mut self, qualified: &str, prior: &ClassDef, scope_path: &[usize]) {
+        let Some(observed) = self.result.all_classes.get(qualified) else {
+            return;
+        };
+        let joined = join_parameterised_class_observations(prior, observed).unwrap_or_else(|| {
+            let mut abstaining = observed.clone();
+            abstaining.factory = None;
+            abstaining.inheritance_unknown = true;
+            abstaining.absorb_declarations(prior);
+            abstaining
+        });
+        let simple = joined.name.clone();
+        self.result
+            .all_classes
+            .insert(qualified.to_owned(), joined.clone());
+        if let Some(scope) =
+            super::scope::scope_at_mut(&mut self.result.global_scope, &scope_path.to_vec())
+        {
+            scope.classes.insert(simple, joined);
+        }
+    }
+
     pub(super) fn record_literal_parameter_definitions(&mut self) {
+        self.record_parameterised_class_definitions();
+        // The join has settled, so the heads the walk could not judge can be
+        // judged now (issue #1660). Paired here rather than at each of the
+        // four entry points that run this tail: the order matters — a
+        // creation call can only be classified after the metaclass it names
+        // is proved — and pairing them is what makes that order impossible to
+        // get wrong. It also guarantees the buffer is drained on every path,
+        // so a reused analyser never carries one document's deferrals into
+        // the next.
+        self.replay_deferred_class_creations();
+    }
+
+    fn record_parameterised_class_definitions(&mut self) {
         let Some(registry) = self.registry.as_deref() else {
             return;
         };
@@ -8716,6 +8904,11 @@ impl Analyser {
             // to put in `all_classes`; ordinary instance manufacturers have
             // no class-definition body. Both are handled by their respective
             // object-value paths instead.
+            //
+            // …and a third case, which is not a verdict at all: the head may
+            // name a metaclass this document proves only *after* the walk
+            // (issue #1660). Keep it for the post-pass.
+            self.defer_class_creation(cmd_name, args, arg_tokens, scope_path, cmd_tok);
             return false;
         };
         if layout.name_arg >= args.len() || layout.name_arg >= arg_tokens.len() {

--- a/rust/tcl-compiler/src/analyser/snapshot.rs
+++ b/rust/tcl-compiler/src/analyser/snapshot.rs
@@ -109,6 +109,15 @@ pub struct AnalyserSnapshot {
     /// `pending_arity` post-walk). Snapshotted for the same rollback reason.
     pub(in crate::analyser) pending_option_conflicts:
         Vec<super::diagnostics::version_gate::GatedOptionConflict>,
+    /// Creation calls awaiting the parameterised-metaclass join (issue #1660,
+    /// PR #1673 review). Pending-verdict state like the buffers above, and
+    /// snapshotted for the same reason with one extra consequence: the
+    /// evidence that settles these calls — the placeholder class and the
+    /// load-time call site — travels in `result`, so a snapshot carrying that
+    /// evidence without the calls it settles makes the restored walk record
+    /// strictly less than a full one. That divergence is a wrong answer in
+    /// the incremental path, not merely a stale diagnostic.
+    pub(in crate::analyser) deferred_class_creations: Vec<super::types::DeferredClassCreation>,
 }
 
 impl Analyser {
@@ -145,6 +154,7 @@ impl Analyser {
             pending_ctor_arity: self.pending_ctor_arity.clone(),
             pending_next_arity: self.pending_next_arity.clone(),
             pending_option_conflicts: self.pending_option_conflicts.clone(),
+            deferred_class_creations: self.deferred_class_creations.clone(),
         }
     }
 
@@ -179,6 +189,7 @@ impl Analyser {
         self.pending_ctor_arity = snap.pending_ctor_arity;
         self.pending_next_arity = snap.pending_next_arity;
         self.pending_option_conflicts = snap.pending_option_conflicts;
+        self.deferred_class_creations = snap.deferred_class_creations;
     }
 }
 

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -1175,6 +1175,20 @@ pub struct Analyser {
     /// [`Self::irules_file_profiles`]; `None` until the first IRULE4003
     /// candidate asks for it.
     pub(super) irules_event_bodies: Option<Vec<(String, Vec<String>)>>,
+    /// Creation calls the walk could not classify because their head was not
+    /// yet known to be a class factory — replayed once the parameterised-class
+    /// observation join has settled (issue #1660).
+    ///
+    /// A metaclass whose identity is proved only by that post-pass does not
+    /// exist while the walk runs, so `Meta create ::T::W { … }` in the same
+    /// document reads as an ordinary call to an unknown command and the class
+    /// it makes goes unrecorded — no factory, no members, no completion. The
+    /// verdict on such a head cannot be formed during the walk at all, so it
+    /// is buffered and formed afterwards, the shape #1642 used for
+    /// version-floor arity.
+    ///
+    /// Cleared at the top of each `analyse` run.
+    pub(super) deferred_class_creations: Vec<super::types::DeferredClassCreation>,
 }
 
 /// W108 non-ASCII detection mode for the `tclLsp.style.nonAscii`
@@ -1485,6 +1499,7 @@ impl Analyser {
             per_item_fallback: None,
             irules_file_profiles: None,
             irules_event_bodies: None,
+            deferred_class_creations: Vec::new(),
         }
     }
 

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -2739,6 +2739,11 @@ impl Analyser {
         self.minted_synthetic_names.clear();
         self.pending_instances = None;
         self.deferred_instance_replays.clear();
+        // Normally drained by the replay, but a walk that never runs the
+        // post-walk tail (`analyse_commands` with `finalise: false`) leaves
+        // entries behind, and a reused analyser must not carry one document's
+        // deferred calls into the next.
+        self.deferred_class_creations.clear();
         self.pending_bareword_dispatch_sites = None;
         self.line_offsets = None;
         self.cached_line_index = tcl_lexer::LineIndex::new("");

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -1068,6 +1068,34 @@ pub struct ManufacturerSpec {
 /// when `Meta` is written in another document (issue #1276).
 pub type ClassFactoryIndex = BTreeMap<String, ClassFactory>;
 
+/// A creation call the walk could not classify, kept for a **second verdict**
+/// once the parameterised-class observation join has settled (issue #1660).
+///
+/// A metaclass proved only by that post-pass does not exist while the walk
+/// runs: `::T::D::class create ::T::W { … }` in the same document reads as a
+/// call to an unknown command, so the class it makes is recorded nowhere.
+/// Which verdict the head deserves is therefore not answerable during the
+/// walk — the same situation #1642 met with version-floor arity, and the same
+/// answer: buffer the inputs, decide afterwards.
+///
+/// Only calls whose head names **nothing this document knows** are kept, which
+/// is the one shape a later proof can turn into a creation; a head that
+/// already resolves has had its verdict, right or wrong, and is not revisited.
+#[derive(Debug, Clone)]
+pub struct DeferredClassCreation {
+    /// The call's head word, exactly as `handle_oo_class_command` received it.
+    pub cmd_name: String,
+    /// Its argument words.
+    pub args: Vec<String>,
+    /// Their tokens, for the name and body spans the replay records.
+    pub arg_tokens: Vec<Token>,
+    /// The scope the call was written in, so the replayed class homes where
+    /// the walk would have homed it.
+    pub scope_path: Vec<usize>,
+    /// The head's own token — the call offset a rename chain resolves at.
+    pub cmd_tok: Token,
+}
+
 /// Instance methods dispatchable on some workspace **descendant** of each
 /// class, keyed by the ancestor's fully-qualified name — what a host hands
 /// the analyser so the template-method abstention (issue #1367) can see a

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -6071,7 +6071,8 @@ mod class_factories {
         );
         assert!(
             result.class_factories().contains_key("::T::D::class"),
-            "the resolved metaclass must still publish a factory"        );
+            "the resolved metaclass must still publish a factory"
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -5827,6 +5827,75 @@ mod class_factories {
     }
 
     #[test]
+    fn the_incremental_path_records_the_same_classes_as_a_full_analysis() {
+        // The deferred creation is *pending verdict* state, so it has to
+        // survive a snapshot/restore exactly as the pending-arity buffers do
+        // (PR #1673 review, thread r3825697165). The LSP's incremental path
+        // restores a snapshot covering the clean prefix and re-walks only the
+        // dirty chunk: if the buffer is not in the snapshot, a creation call
+        // written in that prefix is gone, while the evidence that proves its
+        // metaclass — the placeholder and the load-time call — is restored
+        // with the result. The join then proves `::T::D::class` and nothing
+        // recreates `::T::W`, so the same document answers differently
+        // depending on which entry point analysed it.
+        let src = format!(
+            "{COMPUTED_METACLASS}\
+             ::T::D::class create ::T::W {{ method go {{}} {{ return went }} }}\n\
+             set unrelated 1\n"
+        );
+        let full = analysis(&src, "tcl9.0");
+        assert!(
+            full.all_classes.contains_key("::T::W"),
+            "precondition: the full analysis records the class"
+        );
+
+        let commands = tcl_compiler::segmenter::segment_commands(&src);
+        let split = commands.len() - 1;
+        let (prefix, dirty) = commands.split_at(split);
+        let mut analyser = Analyser::new();
+        let (_, snapshots) =
+            analyser.analyse_chunked(&src, vec![prefix.to_vec(), dirty.to_vec()], "tcl9.0");
+        // Re-analyse the dirty chunk from the clean prefix's snapshot, which
+        // is what an edit to the last line does.
+        let mut incremental = Analyser::new();
+        incremental.restore(snapshots[0].clone());
+        let restored = incremental.analyse_commands(&src, dirty, "tcl9.0", true);
+
+        let mut full_classes: Vec<&String> = full.all_classes.keys().collect();
+        let mut restored_classes: Vec<&String> = restored.all_classes.keys().collect();
+        full_classes.sort();
+        restored_classes.sort();
+        assert_eq!(
+            restored_classes, full_classes,
+            "incremental analysis must record the same classes as a full one"
+        );
+    }
+
+    #[test]
+    fn a_deferred_creation_never_leaks_into_the_next_document() {
+        // The other half of owning per-run state: an analyser is reused, and
+        // a walk that never runs the post-walk tail (`finalise: false`, the
+        // partial-snapshot path) leaves the buffer full. Those calls belong
+        // to a document that is over — their tokens index its source — so
+        // carrying them forward would let the *next* document, which happens
+        // to prove the same metaclass, record a class it never wrote.
+        let mut analyser = Analyser::new();
+        let first =
+            format!("{COMPUTED_METACLASS}::T::D::class create ::T::W {{ method go {{}} {{}} }}\n");
+        let first_commands = tcl_compiler::segmenter::segment_commands(&first);
+        let _ = analyser.analyse_commands(&first, &first_commands, "tcl9.0", false);
+
+        let second = COMPUTED_METACLASS.to_owned();
+        let second_commands = tcl_compiler::segmenter::segment_commands(&second);
+        let result = analyser.analyse_commands(&second, &second_commands, "tcl9.0", true);
+        assert!(
+            !result.all_classes.contains_key("::T::W"),
+            "the second document writes no creation call; got {:?}",
+            result.all_classes.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn a_creation_written_before_its_metaclass_is_proved_stays_unrecorded() {
         // The limit this deliberately keeps. Written in this order the
         // program does not run at all: tclsh 8.6.16 / 9.0.4 both raise

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -5739,6 +5739,246 @@ mod class_factories {
     }
 
     #[test]
+    fn a_post_pass_metaclass_classifies_a_creation_in_its_own_file() {
+        // TP (#1660) — `::T::D::class` is proved a metaclass only by the
+        // parameterised-class join, which runs *after* the walk, so a
+        // creation call naming it in the same document had nothing to be
+        // classified against and the class it makes went unrecorded: no
+        // factory, no members, no completion.
+        //
+        // tclsh 8.6.16 / 9.0.4 run the whole chain: `::T::W` exists, is a
+        // class, `info object class ::T::W` is `::T::D::class`, its methods
+        // are `go`, and `[[::T::W new] go]` answers `went`.
+        let src = format!(
+            "{COMPUTED_METACLASS}::T::D::class create ::T::W {{ method go {{}} {{ return went }} }}\n"
+        );
+        let result = analysis(&src, "tcl9.0");
+        let w = result
+            .all_classes
+            .get("::T::W")
+            .expect("the class the post-pass metaclass makes must be recorded");
+        assert!(
+            w.methods.contains_key("go"),
+            "its members come from the creation body; got {:?}",
+            w.methods.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            w.metaclass.ends_with("T::D::class"),
+            "the recorded metaclass is the head the source wrote; got {:?}",
+            w.metaclass
+        );
+        // `::T::W` declares no superclass, so it is an ordinary class rather
+        // than another factory — the replay must not manufacture one.
+        assert!(
+            !result.class_factories().contains_key("::T::W"),
+            "a plain class must publish no factory; got {:?}",
+            result.class_factories().keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn a_replayed_creation_can_itself_prove_the_next_one() {
+        // The replay runs in document order, so a chain settles in one pass:
+        // `::T::Sub` is created by the post-pass metaclass *and* declares it
+        // as its superclass, which makes `::T::Sub` a factory in turn, which
+        // is what classifies `::T::Leaf`.
+        //
+        // tclsh 8.6.16 / 9.0.4: `info object class ::T::Sub` is
+        // `::T::D::class`, `info object class ::T::Leaf` is `::T::Sub`, and
+        // `[[::T::Leaf new] go]` answers `leafy`.
+        let src = format!(
+            "{COMPUTED_METACLASS}\
+             ::T::D::class create ::T::Sub {{ superclass ::T::D::class }}\n\
+             ::T::Sub create ::T::Leaf {{ method go {{}} {{ return leafy }} }}\n"
+        );
+        let result = analysis(&src, "tcl9.0");
+        assert!(
+            result.class_factories().contains_key("::T::Sub"),
+            "a replayed class that inherits the metaclass is a factory too; got {:?}",
+            result.class_factories().keys().collect::<Vec<_>>()
+        );
+        let leaf = result
+            .all_classes
+            .get("::T::Leaf")
+            .expect("the second link of the chain must be recorded");
+        assert!(
+            leaf.methods.contains_key("go"),
+            "got {:?}",
+            leaf.methods.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn an_unknown_head_that_never_becomes_a_factory_records_nothing() {
+        // FP guard: deferring a call is not a claim about it. A head that is
+        // still unknown when the join has settled — no proc, no class, no
+        // registry command — must record exactly what it did before this
+        // pass existed, which is nothing at all.
+        let src = concat!(
+            "namespace eval ::T {}\n",
+            "::T::NoSuchMeta create ::T::Q { method m {} {} }\n",
+        );
+        let result = analysis(src, "tcl9.0");
+        assert!(
+            !result.all_classes.contains_key("::T::Q"),
+            "an unproved head must manufacture nothing; got {:?}",
+            result.all_classes.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn a_creation_written_before_its_metaclass_is_proved_stays_unrecorded() {
+        // The limit this deliberately keeps. Written in this order the
+        // program does not run at all: tclsh 8.6.16 / 9.0.4 both raise
+        // `invalid command name "::U::D::class"`, because the metaclass does
+        // not exist until `::U::mk` is called on the next line. The walk's
+        // own reachability proof stops at the unknown head, so nothing is
+        // claimed — the correct answer for a program with no successful run.
+        let src = concat!(
+            "namespace eval ::U {}\n",
+            "oo::class create ::U::Mother { superclass oo::class }\n",
+            "proc ::U::mk {name} { ::U::Mother create ${name}::class { superclass ::U::Mother } }\n",
+            "namespace eval ::U::D {}\n",
+            "::U::D::class create ::U::W { method go {} {} }\n",
+            "::U::mk ::U::D\n",
+        );
+        let result = analysis(src, "tcl9.0");
+        assert!(
+            !result.all_classes.contains_key("::U::W"),
+            "a creation that cannot have run must not be recorded; got {:?}",
+            result.all_classes.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn a_replayed_creation_keeps_the_members_its_define_stub_already_held() {
+        // The regression the replay would otherwise cause. While the creation
+        // was invisible, `oo::define ::T::W` had nothing to extend, so the
+        // walk made a *stub* and put `extra` in it. Recording the creation
+        // afterwards under the same name must not throw that away — the class
+        // really has both members (tclsh 8.6.16 / 9.0.4: `info class methods
+        // ::T::W` is `go extra`).
+        let src = format!(
+            "{COMPUTED_METACLASS}\
+             ::T::D::class create ::T::W {{ method go {{}} {{ return went }} }}\n\
+             ::oo::define ::T::W {{ method extra {{}} {{}} }}\n"
+        );
+        let result = analysis(&src, "tcl9.0");
+        let w = result
+            .all_classes
+            .get("::T::W")
+            .expect("the created class is recorded");
+        assert!(
+            w.methods.contains_key("go") && w.methods.contains_key("extra"),
+            "both the creation body's member and the stub's must survive; got {:?}",
+            w.methods.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !w.via_define,
+            "this file creates the class, so the record is not an extension stub"
+        );
+        assert!(
+            w.metaclass.ends_with("T::D::class"),
+            "got {:?}",
+            w.metaclass
+        );
+    }
+
+    #[test]
+    fn a_replayed_creation_with_a_relative_name_homes_where_it_was_written() {
+        // A replayed creation goes back through the handler the walk uses, so
+        // its name homes by the same rule: `create W` written inside
+        // `namespace eval ::T` is `::T::W`, not a global `::W`. Recording it
+        // anywhere else would put a class in the index no interpreter has.
+        //
+        // tclsh 8.6.16 / 9.0.4: `info commands ::T::W` finds it and
+        // `info commands ::W` does not.
+        let src = format!(
+            "{COMPUTED_METACLASS}namespace eval ::T {{\n    ::T::D::class create W {{ method go {{}} {{}} }}\n}}\n"
+        );
+        let result = analysis(&src, "tcl9.0");
+        assert!(
+            result.all_classes.contains_key("::T::W"),
+            "the relative name homes to the enclosing namespace; got {:?}",
+            result.all_classes.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !result.all_classes.contains_key("::W"),
+            "and nowhere else; got {:?}",
+            result.all_classes.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn a_head_the_walk_knew_only_as_a_define_stub_is_still_deferred() {
+        // "Known" is not "judged". The `oo::define` here records `::T::D::class`
+        // during the walk — as a stub with no factory, because the creation
+        // that proves it is still a computed name — so a creation call naming
+        // it looks like a call to a *recorded class*. Its verdict is no more
+        // final than an unknown head's: the post-pass join is what gives that
+        // stub its factory (#1653), and only then can this call be classified.
+        //
+        // tclsh 8.6.16 / 9.0.4 run it: `::T::D::class` has method `extra`,
+        // `info object class ::T::W` is `::T::D::class`, and `[[::T::W new] go]`
+        // answers `went`.
+        let src = format!(
+            "{COMPUTED_METACLASS}\
+             ::oo::define ::T::D::class {{ method extra {{}} {{ return e }} }}\n\
+             ::T::D::class create ::T::W {{ method go {{}} {{ return went }} }}\n"
+        );
+        let result = analysis(&src, "tcl9.0");
+        let w = result
+            .all_classes
+            .get("::T::W")
+            .expect("a stub-known metaclass must still classify its creation");
+        assert!(
+            w.methods.contains_key("go"),
+            "got {:?}",
+            w.methods.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            result
+                .all_classes
+                .get("::T::D::class")
+                .is_some_and(|meta| meta.methods.contains_key("extra")),
+            "and the metaclass keeps the stub's own member"
+        );
+    }
+
+    #[test]
+    fn a_stub_that_contradicts_the_replayed_creation_abstains_but_keeps_members() {
+        // The other side of that join: the stub and the creation body declare
+        // *different* superclasses. Two observations that disagree publish the
+        // abstaining record — no factory, inheritance unknown — exactly as a
+        // pair of disagreeing creations does, while both sides' declarations
+        // stay, because they are declarations of this class either way.
+        let src = format!(
+            "{COMPUTED_METACLASS}\
+             oo::class create ::T::Other {{}}\n\
+             ::T::D::class create ::T::W {{ superclass ::T::Mother\n method go {{}} {{}} }}\n\
+             ::oo::define ::T::W {{ superclass ::T::Other\n method extra {{}} {{}} }}\n"
+        );
+        let result = analysis(&src, "tcl9.0");
+        let w = result
+            .all_classes
+            .get("::T::W")
+            .expect("the contested class is still recorded");
+        assert!(
+            w.inheritance_unknown,
+            "two disagreeing superclass observations must abstain"
+        );
+        assert!(
+            w.methods.contains_key("go") && w.methods.contains_key("extra"),
+            "an abstaining record still holds every declaration; got {:?}",
+            w.methods.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !result.class_factories().contains_key("::T::W"),
+            "an abstaining record publishes no factory"
+        );
+    }
+
+    #[test]
     fn four_hundred_nested_foreach_bodies_do_not_abort_the_process() {
         // Issue #1654, on this test's own default-sized thread — which is
         // the whole point: the walks this drives must contain themselves on


### PR DESCRIPTION
## Summary

Fixes #1660.

A metaclass proved only by the parameterised-class post-pass could not classify a creation call in its own file. The walk that classifies creation heads runs **before** the observation join, so `::T::D::class create ::T::W { … }` read as a call to an unknown command and the class it makes went unrecorded — no factory, no members, no completion — even though the same document had just proved `::T::D::class` is a metaclass.

Measured on the reproducer:

| document | before | after |
|---|---|---|
| `COMPUTED_METACLASS` + `::T::D::class create ::T::W {…}` | classes `[::T::D::class, ::T::Mother]` | `[…, ::T::W]`, methods `go`, metaclass `::T::D::class` |
| control: same creation through the literally-written `::T::Mother` | `::T::X` recorded | unchanged |

tclsh 8.6.16 (via `TCL_LSP_TCLSH86`) and tclsh 9.0.4 agree, byte for byte, that the chain runs: `::T::W` exists, `info object class ::T::W` is `::T::D::class`, `info class methods ::T::W` is `go`, and `[[::T::W new] go]` answers `went`.

## The fix — a deferred verdict

Which verdict such a head deserves is not answerable during the walk at all, so it is not formed there. A creation call the generic handler declines is buffered with its words, tokens and scope; once `record_literal_parameter_definitions` has settled the join, each is replayed **through the very handler the walk uses**, so a replayed creation is recorded by one code path with the walk's own rules — manufacturer layout, injected members, body walk, name homing, diagnostics. The two passes are paired in one function, because the order is the whole point: a creation can only be classified after the metaclass it names is proved.

The second-pass alternative in the issue would have to re-walk the document to recover each call's scope; buffering carries it.

Buffering is narrow — a head naming a registry command or a recorded **proc** has a final verdict and is not kept — and bounded by a cap, past which the document behaves exactly as before.

## Three things the work turned up

1. **"Known" is not "judged".** The first gate skipped heads the walk had already recorded, which loses #1653's shape: an `oo::define` on a computed-name metaclass records it as a *stub with no factory*, so a creation naming it looks like a call to a known class while its verdict is just as open. Recorded classes are now kept; only registry commands and procs are excluded, neither of which can become a factory later.
2. **The replay would have destroyed what the walk did record.** Because the creation was invisible, `oo::define ::T::W` had nothing to extend and its members went into a stub; recording the creation over it dropped them — `["go"]` where both oracles say `go extra`. The prior record is captured before the replay and folded back through `join_parameterised_class_observations`, the same owner the post-pass uses, so a stub meets a creation by one rule wherever the two meet. A contradicting pair publishes the abstaining record the house rule calls for, keeping both sides' declarations.
3. **The replay re-buffered itself.** The handler's decline path cannot tell a first hearing from a second, so a failed replay re-deferred and the pass silently self-healed — which made the ordering unobservable (a mutant that replayed *before* the join survived). The buffer is cleared after the replay, so the order is load-bearing and that mutant now dies.

## Deliberately unchanged

A creation written *before* the call that proves its metaclass stays unrecorded. That program does not run at all — both oracles raise `invalid command name "::U::D::class"` — so claiming nothing is the correct answer, and it is pinned as such rather than left as an unexplained gap.

## Validation

All from `rust/`, prefixed `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=2`, with `TCLLIB_2_0_DIR=…/tmp/tcllib-2.0` and `TCL_LSP_TCLSH86=…/tmp/tcl8616-install/bin/tclsh8.6`.

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p tcl-compiler --all-targets` — no warnings (Rust 1.98)
- [x] `cargo check --workspace` — clean
- [x] `cargo test -p tcl-compiler` — 63 suites green **with the corpus present**, the #1571 clay test included
- [x] `cargo test -p tcl-lsp-core -p tcl-lsp-db -p tcl-registry` — 62 suites green

Mutation-verified from a green baseline: **8 mutants, 6 killed by name, 2 proven equivalent.**

Killed: no deferral; no replay; replay before the join; a head known as a class treated as judged; no re-join with the prior record; a contradiction joined as if compatible.

The survivors are resource guards with no verdict of their own — deferring registry heads as well, and dropping the buffer cap. The replay's factory gate, not the buffering gate, decides every outcome, so neither changes a result; they exist to keep the buffer small and bounded.

New tests, all in `class_factories`: the post-pass metaclass classifying its own file's creation; a replayed creation proving the next link of a chain; a head the walk knew only as a define stub; the stub's members surviving the replay; a contradicting stub abstaining but keeping members; a relative name homing where it was written; an unknown head that never becomes a factory recording nothing; and the out-of-order program staying unrecorded.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? No new descriptor or vocabulary — this is pass ordering inside the analyser. The rule it adds ("a creation call's verdict is formed after the join") is documented on the pair of methods that own it.
- [x] No diagnostic or optimisation code added or changed, so no `docs/kcs/codes/` page needed.
- [x] No new design doc, so no `docs/design/README.md` link needed.

## Notes for review

- The replay reuses `handle_oo_class_command`, so W314/W315 and every structural side effect happen exactly once per call — the walk's own attempt recorded nothing.
- `record_literal_parameter_definitions` is now a two-line pairing over `record_parameterised_class_definitions` (the old body, unchanged) and the replay, so all four entry points that run the post-walk tail get both, in order, and the buffer is drained on every path.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o)_