### PR TITLE
feat(registry): honour a per-argument lifecycle at the resolved floor

### DIFF
--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -445,19 +445,32 @@ entry point, or gate moves without this contract being updated.
    can be filtered out. A loader that tried to filter would have to pick
    one document's floor for every document that ever reads the registry.
 
-   **Not yet wired (issue #1644).** The re-projecting half of that division
-   currently has *no production implementation*: `project_arg_rows` is
-   called by the loader (at no floor) and by tests, and every analyser,
-   LSP and formatter consumer reads the parallel tables directly. A row
-   gated `-introduced 3.0` is therefore honoured at a 2.0 floor, and
-   per-argument lifecycle has no user-visible effect. The obstacle is not
-   volume but layering: the ~24 consuming sites take a `&CommandSpec` and
-   `tcl-registry` is deliberately document-agnostic, so there is no floor
-   at the call site to re-project with. Wiring it needs either a
-   floor-parameterised accessor surface or a per-document projected-spec
-   cache in the analyser — a design decision, tracked separately. The
-   *arity-window* axis of the same feature (invariant 7) is fully wired
-   and does resolve the floor.
+   **How a consumer re-projects (issue #1644).** Through the accessor
+   family every other lifecycle-bearing fact already uses:
+   `CommandSpec::arg_tables_at(package_version)` (and its `SubCommand`
+   twin) answers with the tables *as they exist at that floor*, and
+   `CommandRegistry::arg_indices_for_role_at` is the role query's
+   floor-aware form. The floor stays an **argument**, never registry
+   state — registry handles are cached per (profile, pack overlay) and
+   shared across documents, so one that remembered a floor would answer
+   the wrong document. `arg_rows.is_empty()` is the fast reject: no
+   shipped spec gates an argument, so those specs hand back their stored
+   `&'static` slices by reference and only a gated pack command ever
+   builds a projection.
+
+   The consumers wired to it are the **request-time** ones, which is the
+   only place the answer can be right: a document's floor is settled by
+   its `package require` lines, so it exists once the walk that records
+   them has finished. `document_floor::DocumentFloor` is the one place a
+   provider resolves it — completion's value offers go through
+   `available_arg_values_at`, which now applies the row gate before the
+   value gate, and the `expr`-argument context test resolves roles at the
+   floor. Consumers reading the tables **during** the walk keep the
+   permissive no-floor projection: their answers are formed before the
+   floor is knowable, which is exactly why the arity axis (invariant 7)
+   buffers its verdict and decides post-walk. Making a walk-time reader
+   floor-aware means giving it that same deferred-verdict treatment, and
+   is deliberately not done by pretending a floor exists mid-walk.
 7. A version floor is a lower bound and composes by taking the greatest.
    Three things can state one — a `package require` in the document, a
    `SpecTcl` pack's `ambient_package` row, and the profile's

--- a/rust/tcl-lsp-core/src/completion.rs
+++ b/rust/tcl-lsp-core/src/completion.rs
@@ -717,7 +717,14 @@ pub fn completions(
     // The context test is registry-driven (`ArgRole::Expr`); see
     // `crate::expr_context`.
     if let Some(registry) = registry
-        && crate::expr_context::expr_arg_context_at(source, line, character, &line_index, registry)
+        && crate::expr_context::expr_arg_context_at(
+            source,
+            line,
+            character,
+            &line_index,
+            registry,
+            crate::document_floor::DocumentFloor::new(analysis, profile),
+        )
     {
         items.extend(math_function_completions(registry, profile, &partial));
     }
@@ -1566,43 +1573,16 @@ fn registry_method_items(registry: &CommandRegistry, class_q: &str) -> Option<Ve
 /// The guaranteed-available version floor for a command's owning package,
 /// resolved from the document's `package require` statements.
 ///
-/// When several `package require <pkg> <req>` lines name the same package, the
-/// most restrictive (highest) lower bound wins.  Returns `None` when the
-/// command is not package-gated or the package was required without a version
-/// (permissive — every option surfaces).
+/// The rule itself lives in [`crate::document_floor::DocumentFloor`], the one
+/// place a request-time provider resolves a floor. Completion is no longer its
+/// only consumer, so the definition moved to where the next one can reach it
+/// without copying it (issue #1644).
 fn package_version_floor<'a>(
     analysis: &'a AnalysisResult,
     spec: &tcl_registry::CommandSpec,
     profile: &'static tcl_dialect::DialectProfile,
 ) -> Option<&'a str> {
-    let pkg = profile
-        .keyed_pin_for(spec)
-        .map(|pin| pin.package)
-        .or_else(|| spec.owning_package())?;
-    let require_floor = analysis
-        .package_requires
-        .iter()
-        // Only *unconditional* requires guarantee the version; an optional
-        // probe (`catch {package require Tk 8.7}`, or a `require` inside an
-        // `if` arm) must not raise the floor and hide a gated option/command.
-        .filter(|req| req.name == pkg && !req.conditional)
-        .filter_map(|req| req.version.as_deref())
-        .map(tcl_registry::version::requirement_lower_bound)
-        .max_by(|a, b| tcl_registry::version::compare(a, b));
-    // The profile's library pin supplies the base floor (§7.1: the shipped
-    // Tk on a plain Tcl base, a keyed vendor surface at its D5
-    // oldest-supported default); an explicit require can only raise it.
-    let pin_floor = profile.library_floor(pkg, &analysis.library_versions);
-    match (pin_floor, require_floor) {
-        (Some(pin), Some(req)) => {
-            if tcl_registry::version::compare(req, pin).is_gt() {
-                Some(req)
-            } else {
-                Some(pin)
-            }
-        }
-        (pin, require) => pin.or(require),
-    }
+    crate::document_floor::DocumentFloor::new(analysis, profile).for_spec(spec)
 }
 
 fn switch_partial_at_position(
@@ -3803,6 +3783,148 @@ mod tests {
         assert!(
             l2.iter().any(|l| l == "ttk::button"),
             "Tk 8.5 must offer ttk::button: {l2:?}",
+        );
+    }
+
+    /// A command whose second argument — values and role alike — a pack
+    /// author declared as arriving in release 3.0 (issue #1644).
+    ///
+    /// The stored parallel slices are the projection at *no floor*, exactly as
+    /// the pack loader seals them, with the authored rows retained beside
+    /// them.
+    fn gated_row_registry() -> CommandRegistry {
+        const LATER_VALUES: &[tcl_registry::ArgValue] = &[tcl_registry::ArgValue {
+            value: "brandnew",
+            ..tcl_registry::ArgValue::DEFAULT
+        }];
+        const ROWS: &[tcl_registry::spec::VersionedArgRow] = &[
+            // Argument 0 — ungated, the control.
+            tcl_registry::spec::VersionedArgRow {
+                index: 0,
+                values: LATER_VALUES,
+                ..tcl_registry::spec::VersionedArgRow::DEFAULT
+            },
+            // Argument 1 — an expression argument only from 3.0.
+            tcl_registry::spec::VersionedArgRow {
+                index: 1,
+                lifecycle: tcl_registry::lifecycle::Lifecycle::introduced_in("3.0"),
+                role: Some(tcl_registry::ArgRole::Expr),
+                ..tcl_registry::spec::VersionedArgRow::DEFAULT
+            },
+            // Argument 2 — its enumerable values arrive with it at 3.0.
+            tcl_registry::spec::VersionedArgRow {
+                index: 2,
+                lifecycle: tcl_registry::lifecycle::Lifecycle::introduced_in("3.0"),
+                values: LATER_VALUES,
+                ..tcl_registry::spec::VersionedArgRow::DEFAULT
+            },
+        ];
+        const VALUES: &[(u8, &[tcl_registry::ArgValue])] = &[(0, LATER_VALUES), (2, LATER_VALUES)];
+        const ROLES: &[(u8, tcl_registry::ArgRole)] = &[(1, tcl_registry::ArgRole::Expr)];
+        let mut registry = CommandRegistry::build_default();
+        registry.insert(tcl_registry::CommandSpec {
+            name: "gadget",
+            required_package: Some("Gadgetry"),
+            arg_rows: ROWS,
+            arg_values: VALUES,
+            arg_roles: ROLES,
+            arity: tcl_registry::Arity::at_least(0),
+            ..tcl_registry::CommandSpec::DEFAULT
+        });
+        registry
+    }
+
+    #[test]
+    fn arg_value_completion_gates_a_versioned_argument_row() {
+        // Issue #1644's acceptance, "not offered" half, end to end: the values
+        // of an argument introduced at 3.0 are offered against a 3.0 floor and
+        // not against a 2.0 one. Nothing in completion changed to make this
+        // work — the row gate lands inside `available_arg_values_at`, the
+        // accessor completion already calls with the document's floor.
+        let registry = gated_row_registry();
+        let labels = |src: &str| -> Vec<String> {
+            let analysis = analyse(src);
+            completions(
+                src,
+                1,
+                18,
+                &analysis,
+                Some(&registry),
+                None,
+                tcl_dialect::DialectProfile::by_name("tcl8.6"),
+            )
+            .into_iter()
+            .map(|i| i.label)
+            .collect()
+        };
+        let old = labels("package require Gadgetry 2.0\ngadget one two bra\n");
+        assert!(
+            !old.iter().any(|l| l == "brandnew"),
+            "a 2.0 floor must not offer the 3.0 argument's values: {old:?}"
+        );
+        let new = labels("package require Gadgetry 3.0\ngadget one two bra\n");
+        assert!(
+            new.iter().any(|l| l == "brandnew"),
+            "a 3.0 floor must offer them: {new:?}"
+        );
+    }
+
+    #[test]
+    fn ungated_argument_values_are_offered_at_every_floor() {
+        // FP control for the above: argument 0 of the same command carries no
+        // lifecycle, so the floor changes nothing about it. Without this, a
+        // gate that swallowed *every* row would read as a pass.
+        let registry = gated_row_registry();
+        for require in ["2.0", "3.0"] {
+            let src = format!("package require Gadgetry {require}\ngadget bra\n");
+            let analysis = analyse(&src);
+            let labels: Vec<String> = completions(
+                &src,
+                1,
+                10,
+                &analysis,
+                Some(&registry),
+                None,
+                tcl_dialect::DialectProfile::by_name("tcl8.6"),
+            )
+            .into_iter()
+            .map(|i| i.label)
+            .collect();
+            assert!(
+                labels.iter().any(|l| l == "brandnew"),
+                "an ungated argument is offered at {require}: {labels:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn math_function_completion_gates_a_versioned_expr_row() {
+        // The "not role-typed" half, through the same document floor: the
+        // `expr`-argument context test asks the registry which arguments are
+        // `ArgRole::Expr`, and at a 2.0 floor argument 1 is not one — so the
+        // math-function vocabulary is not offered inside it.
+        let registry = gated_row_registry();
+        let offers_math = |src: &str| -> bool {
+            let analysis = analyse(src);
+            completions(
+                src,
+                1,
+                14,
+                &analysis,
+                Some(&registry),
+                None,
+                tcl_dialect::DialectProfile::by_name("tcl8.6"),
+            )
+            .into_iter()
+            .any(|item| item.label == "sqrt")
+        };
+        assert!(
+            !offers_math("package require Gadgetry 2.0\ngadget one {sq\n"),
+            "argument 1 is not an expression at a 2.0 floor"
+        );
+        assert!(
+            offers_math("package require Gadgetry 3.0\ngadget one {sq\n"),
+            "it is from 3.0"
         );
     }
 

--- a/rust/tcl-lsp-core/src/document_floor.rs
+++ b/rust/tcl-lsp-core/src/document_floor.rs
@@ -1,0 +1,103 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The version floor a **request-time** provider answers at.
+//!
+//! Every lifecycle-bearing fact in the registry — a command, a subcommand, an
+//! option, an enumerable value, and since issue #1644 a per-argument row — is
+//! read through an accessor taking `package_version: Option<&str>`. The floor
+//! itself is a per-document fact, so `tcl-registry` never holds one: its
+//! handles are cached per (profile, pack overlay) and shared across documents.
+//!
+//! This is the provider-side half of that split, in one place so completion,
+//! and any provider that follows it, cannot drift on what a document's floor
+//! is. It is deliberately **request-time only**: the answer needs the whole
+//! document's `package require` lines, which exist only once the walk that
+//! records them has finished. A consumer running *during* the walk cannot use
+//! this — that is why the arity gate defers its verdict to a post-walk flush
+//! (issue #1627) rather than asking mid-walk.
+
+use tcl_compiler::analyser::AnalysisResult;
+use tcl_registry::profile_queries::ProfileQueries as _;
+
+/// One document's resolved-floor context, as a request-time provider sees it.
+///
+/// Copy-cheap (two references), so a provider threading it through helpers
+/// pays nothing for passing it by value.
+#[derive(Clone, Copy)]
+pub struct DocumentFloor<'a> {
+    analysis: &'a AnalysisResult,
+    profile: &'static tcl_dialect::DialectProfile,
+}
+
+impl<'a> DocumentFloor<'a> {
+    /// Bind the floor context to one analysed document under one profile.
+    #[must_use]
+    pub fn new(
+        analysis: &'a AnalysisResult,
+        profile: &'static tcl_dialect::DialectProfile,
+    ) -> Self {
+        Self { analysis, profile }
+    }
+
+    /// The guaranteed-available version floor for `spec`'s owning package.
+    ///
+    /// The profile's library pin supplies the base floor (§7.1: the shipped Tk
+    /// on a plain Tcl base, a keyed vendor surface at its D5 oldest-supported
+    /// default); an explicit `package require` can only **raise** it. When
+    /// several requires name the same package, the most restrictive (highest)
+    /// lower bound wins.
+    ///
+    /// Only *unconditional* requires count: an optional probe
+    /// (`catch {package require Tk 8.7}`, or a require inside an `if` arm)
+    /// guarantees nothing on every path, so counting it would raise the floor
+    /// and hide a gated option, value or argument that may not be there.
+    ///
+    /// `None` when the command is not package-gated, or the package was
+    /// required without a version — permissive, matching every other
+    /// lifecycle query.
+    #[must_use]
+    pub fn for_spec(&self, spec: &tcl_registry::CommandSpec) -> Option<&'a str> {
+        let package = self
+            .profile
+            .keyed_pin_for(spec)
+            .map(|pin| pin.package)
+            .or_else(|| spec.owning_package())?;
+        let require_floor = self
+            .analysis
+            .package_requires
+            .iter()
+            .filter(|req| req.name == package && !req.conditional)
+            .filter_map(|req| req.version.as_deref())
+            .map(tcl_registry::version::requirement_lower_bound)
+            .max_by(|a, b| tcl_registry::version::compare(a, b));
+        let pin_floor = self
+            .profile
+            .library_floor(package, &self.analysis.library_versions);
+        match (pin_floor, require_floor) {
+            (Some(pin), Some(required)) => {
+                if tcl_registry::version::compare(required, pin).is_gt() {
+                    Some(required)
+                } else {
+                    Some(pin)
+                }
+            }
+            (pin, required) => pin.or(required),
+        }
+    }
+}

--- a/rust/tcl-lsp-core/src/expr_context.rs
+++ b/rust/tcl-lsp-core/src/expr_context.rs
@@ -250,7 +250,12 @@ fn command_start_in_region(text: &str) -> usize {
 
 /// Whether the command whose word list contains `probe` treats that word as
 /// an [`ArgRole::Expr`] argument, per the registry's own role map.
-fn word_at_is_expr_argument(source: &str, probe: usize, registry: &CommandRegistry) -> bool {
+fn word_at_is_expr_argument(
+    source: &str,
+    probe: usize,
+    registry: &CommandRegistry,
+    floor: crate::document_floor::DocumentFloor<'_>,
+) -> bool {
     let Some((words, word_idx)) = command_words_at(source, probe) else {
         return false;
     };
@@ -267,8 +272,14 @@ fn word_at_is_expr_argument(source: &str, probe: usize, registry: &CommandRegist
     while arg_strs.len() <= arg_idx {
         arg_strs.push("");
     }
+    // At the document's resolved floor: an argument a later release
+    // introduced is not an expression argument here, so the math-function
+    // vocabulary is not offered inside it (issue #1644). An unversioned
+    // command — every shipped one — resolves no floor and answers exactly as
+    // before.
+    let package_version = registry.get(head).and_then(|spec| floor.for_spec(spec));
     registry
-        .arg_indices_for_role(head, &arg_strs, ArgRole::Expr)
+        .arg_indices_for_role_at(head, &arg_strs, ArgRole::Expr, package_version)
         .contains(&arg_idx)
 }
 
@@ -295,15 +306,16 @@ pub fn expr_arg_context_at(
     character: u32,
     line_index: &tcl_lexer::LineIndex,
     registry: &CommandRegistry,
+    floor: crate::document_floor::DocumentFloor<'_>,
 ) -> bool {
     let cursor_off =
         crate::definition::byte_offset_at(line_index, source, line, character) as usize;
     match innermost_unclosed_opener(source, cursor_off) {
         // Inside a braced word: that word is the candidate argument.
-        Some((pos, '{')) => word_at_is_expr_argument(source, pos, registry),
+        Some((pos, '{')) => word_at_is_expr_argument(source, pos, registry, floor),
         // Command position inside a `[…]` substitution, or plain script
         // context: the cursor's own word is the candidate argument.
-        _ => word_at_is_expr_argument(source, cursor_off, registry),
+        _ => word_at_is_expr_argument(source, cursor_off, registry, floor),
     }
 }
 
@@ -319,7 +331,18 @@ mod tests {
     /// tests keep passing a bare source string.
     fn ctx(source: &str, line: u32, character: u32) -> bool {
         let line_index = tcl_lexer::LineIndex::new(source);
-        expr_arg_context_at(source, line, character, &line_index, reg())
+        let analysis = tcl_compiler::analyser::Analyser::new().analyse(source, "tcl8.6");
+        expr_arg_context_at(
+            source,
+            line,
+            character,
+            &line_index,
+            reg(),
+            crate::document_floor::DocumentFloor::new(
+                &analysis,
+                tcl_dialect::DialectProfile::by_name("tcl8.6"),
+            ),
+        )
     }
 
     /// TP: the canonical incomplete-source shape from issue #974 defect 2.

--- a/rust/tcl-lsp-core/src/lib.rs
+++ b/rust/tcl-lsp-core/src/lib.rs
@@ -51,6 +51,7 @@ pub mod code_lens;
 pub mod completion;
 pub mod declaration;
 pub mod definition;
+pub mod document_floor;
 pub mod document_links;
 pub mod document_symbols;
 mod executable_regions;

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -180,7 +180,7 @@ pub mod prelude {
         ConnectionSide, SideEffect, SideEffectTarget, SideSwitchTarget, StorageType,
     };
     pub use crate::spec::{
-        BytePayloadSpec, CaseForceListShape, CaseListSpec, CommandSpec, ContextGate,
+        ArgTables, BytePayloadSpec, CaseForceListShape, CaseListSpec, CommandSpec, ContextGate,
         DefaultFormFirstWord, InlineCaseClause, ObjectClassSpec, OoContextFact, OptionConstraint,
         OptionScope, SubCommand, SubSubCommand, VersionedArgValue, leading_option_word_count,
         leading_option_word_count_with, resolve_option_prefix, resolve_option_prefix_with,
@@ -268,7 +268,7 @@ pub use result_stability::ResultStability;
 pub use semantic_operation::{InlineBodyErrorContext, SemanticOperationId};
 pub use side_effects::SideSwitchTarget;
 pub use spec::{
-    BytePayloadSpec, CaseForceListShape, CaseListSpec, CommandSpec, ContextGate,
+    ArgTables, BytePayloadSpec, CaseForceListShape, CaseListSpec, CommandSpec, ContextGate,
     DefaultFormFirstWord, InlineCaseClause, ObjectClassSpec, OoContextFact, OptionConstraint,
     OptionScope, SubCommand, SubSubCommand, VersionedArgValue,
 };

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -2951,9 +2951,37 @@ impl CommandRegistry {
     /// (`namespace upvar`'s leading namespace word) and still declare the
     /// repeating pair tail.
     ///
+    /// A per-argument row a pack gated with a lifecycle is honoured only by
+    /// [`Self::arg_indices_for_role_at`]; this form answers at no floor, which
+    /// is the permissive reading every other lifecycle query gives an
+    /// unresolved version.
+    ///
     /// [`RepeatedArgLayout`]: crate::repeated::RepeatedArgLayout
     #[must_use]
     pub fn arg_indices_for_role(&self, name: &str, args: &[&str], role: ArgRole) -> Vec<usize> {
+        self.arg_indices_for_role_at(name, args, role, None)
+    }
+
+    /// [`Self::arg_indices_for_role`] at a resolved package floor
+    /// (issue #1644).
+    ///
+    /// The static role table is the projection of the command's authored
+    /// per-argument rows, so an argument a later release introduced is not
+    /// role-typed at an older floor — the role half of the same gate
+    /// `available_arg_values_at` applies to enumerable values. Only the static
+    /// table moves: an `arg_role_resolver` is authored code rather than rows,
+    /// and repeated tails and option-value roles carry no lifecycle of their
+    /// own.
+    ///
+    /// `None` is permissive, exactly as for the unversioned form.
+    #[must_use]
+    pub fn arg_indices_for_role_at(
+        &self,
+        name: &str,
+        args: &[&str],
+        role: ArgRole,
+        package_version: Option<&str>,
+    ) -> Vec<usize> {
         // `CommandPrefix` positions (with their appended arities) are owned by
         // [`Self::command_prefixes`]; delegate so highlighting, param-trait
         // inference, and the call-reference extractor all read one source.
@@ -2989,7 +3017,8 @@ impl CommandRegistry {
                 );
             } else {
                 out.extend(
-                    sub.arg_roles
+                    sub.arg_tables_at(package_version)
+                        .roles()
                         .iter()
                         .filter(|(_, r)| *r == role)
                         .map(|(i, _)| *i as usize + 1),
@@ -3027,7 +3056,8 @@ impl CommandRegistry {
             );
         } else {
             out.extend(
-                spec.arg_roles
+                spec.arg_tables_at(package_version)
+                    .roles()
                     .iter()
                     .filter(|(_, r)| {
                         *r == role && (role != ArgRole::Body || case_body_roles_allowed)
@@ -6804,6 +6834,54 @@ mod tests {
 
     /// `trace add variable name ops body` declares arg 1
     /// (the variable name) as `VarWrite` via the registry.
+    #[test]
+    fn arg_indices_for_role_honours_a_gated_row_at_the_resolved_floor() {
+        // Issue #1644 — the role half. A pack argument introduced at 3.0 is
+        // not role-typed against a 2.0 floor, is from 3.0, and stays typed at
+        // no floor (permissive, matching every other lifecycle query).
+        const ROWS: &[crate::spec::VersionedArgRow] = &[
+            crate::spec::VersionedArgRow {
+                index: 0,
+                role: Some(ArgRole::VarWrite),
+                ..crate::spec::VersionedArgRow::DEFAULT
+            },
+            crate::spec::VersionedArgRow {
+                index: 1,
+                lifecycle: Lifecycle::introduced_in("3.0"),
+                role: Some(ArgRole::VarWrite),
+                ..crate::spec::VersionedArgRow::DEFAULT
+            },
+        ];
+        const ROLES: &[(u8, ArgRole)] = &[(0, ArgRole::VarWrite), (1, ArgRole::VarWrite)];
+        let mut reg = CommandRegistry::build_default();
+        reg.insert(CommandSpec {
+            name: "gatedwrite",
+            arg_rows: ROWS,
+            arg_roles: ROLES,
+            arity: Arity::at_least(0),
+            ..CommandSpec::DEFAULT
+        });
+        let writes = |floor: Option<&str>| {
+            reg.arg_indices_for_role_at("gatedwrite", &["a", "b"], ArgRole::VarWrite, floor)
+        };
+        assert_eq!(
+            writes(Some("2.0")),
+            vec![0],
+            "the 3.0 argument is not typed"
+        );
+        assert_eq!(writes(Some("3.0")), vec![0, 1], "typed from 3.0");
+        assert_eq!(
+            writes(None),
+            vec![0, 1],
+            "an unresolved floor is permissive"
+        );
+        assert_eq!(
+            reg.arg_indices_for_role("gatedwrite", &["a", "b"], ArgRole::VarWrite),
+            vec![0, 1],
+            "the unversioned form is the no-floor projection"
+        );
+    }
+
     #[test]
     fn arg_indices_for_role_trace_add_variable_var_write() {
         let reg = CommandRegistry::build_default();

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -2987,7 +2987,7 @@ impl CommandRegistry {
         // inference, and the call-reference extractor all read one source.
         if role == ArgRole::CommandPrefix {
             return self
-                .command_prefixes(name, args)
+                .command_prefixes_at(name, args, package_version)
                 .into_iter()
                 .map(|(i, _)| i)
                 .collect();
@@ -3546,9 +3546,43 @@ impl CommandRegistry {
     /// call-graph recording, and the callback-arity check.
     ///
     /// For subcommand-based commands pass the subcommand as `args[0]`.
+    ///
+    /// A per-argument row a pack gated with a lifecycle is honoured only by
+    /// [`Self::command_prefixes_at`]; this form answers at no floor, the
+    /// permissive reading every other lifecycle query gives an unresolved
+    /// version.
     #[must_use]
     pub fn command_prefixes(&self, name: &str, args: &[&str]) -> Vec<(usize, AppendedArity)> {
-        self.command_prefixes_with_arguments(name, CommandPrefixArguments::literals(args))
+        self.command_prefixes_at(name, args, None)
+    }
+
+    /// [`Self::command_prefixes`] at a resolved package floor (issue #1644,
+    /// PR #1674 review).
+    ///
+    /// A `-appends` row *is* a per-argument row — the loader gives it
+    /// [`ArgRole::CommandPrefix`] as its role — so a prefix position a later
+    /// release introduced must vanish at an older floor, both from the role
+    /// list and from the appended arity the callback-arity check reads. The
+    /// role query delegates here rather than filtering afterwards, so the
+    /// position and its arity can never disagree about which release they
+    /// belong to.
+    ///
+    /// Only the static table moves: a `command_prefix_resolver` is authored
+    /// code rather than rows, and an option-declared prefix carries the
+    /// option's own lifecycle, which `push_command_prefix_options` already
+    /// respects.
+    #[must_use]
+    pub fn command_prefixes_at(
+        &self,
+        name: &str,
+        args: &[&str],
+        package_version: Option<&str>,
+    ) -> Vec<(usize, AppendedArity)> {
+        self.command_prefixes_with_arguments(
+            name,
+            CommandPrefixArguments::literals(args),
+            package_version,
+        )
     }
 
     /// Source-aware command-prefix resolution.
@@ -3566,13 +3600,14 @@ impl CommandRegistry {
         let Some(arguments) = CommandPrefixArguments::structured(spellings, words) else {
             return Vec::new();
         };
-        self.command_prefixes_with_arguments(name, arguments)
+        self.command_prefixes_with_arguments(name, arguments, None)
     }
 
     fn command_prefixes_with_arguments(
         &self,
         name: &str,
         args: CommandPrefixArguments<'_>,
+        package_version: Option<&str>,
     ) -> Vec<(usize, AppendedArity)> {
         let Some(spec) = self.get(name) else {
             return Vec::new();
@@ -3593,7 +3628,8 @@ impl CommandRegistry {
                 );
             } else {
                 out.extend(
-                    sub.command_prefixes
+                    sub.arg_tables_at(package_version)
+                        .prefixes()
                         .iter()
                         .map(|(i, a)| (*i as usize + 1, *a)),
                 );
@@ -3606,7 +3642,12 @@ impl CommandRegistry {
         if let Some(resolver) = spec.command_prefix_resolver {
             out.extend(resolver(args).into_iter().map(|(i, a)| (i as usize, a)));
         } else {
-            out.extend(spec.command_prefixes.iter().map(|(i, a)| (*i as usize, *a)));
+            out.extend(
+                spec.arg_tables_at(package_version)
+                    .prefixes()
+                    .iter()
+                    .map(|(i, a)| (*i as usize, *a)),
+            );
         }
         push_command_prefix_options(&mut out, spec.options, args.spellings(), 0);
         out.retain(|&(idx, _)| idx < n);

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -1066,6 +1066,108 @@ pub struct ProjectedArgs {
     pub prefixes: Vec<(u8, crate::arg_role::AppendedArity)>,
 }
 
+/// One command's per-argument tables **as seen at a resolved package floor**
+/// (issue #1644).
+///
+/// Borrowed on the fast path and owned only when it must be: a spec whose rows
+/// are all ungated — every shipped command, and every pack that declares no
+/// lifecycle on an argument — keeps `arg_rows` empty, so its stored slices
+/// already *are* the answer at any floor and are handed back by reference. A
+/// gated row is the only thing that makes a projection necessary, and then the
+/// filtered tables are owned for the length of the query.
+///
+/// The floor stays an **argument** rather than becoming registry state:
+/// `CommandRegistry` handles are cached per (profile, pack overlay) and shared
+/// across documents, while a version floor is a per-document fact, so a
+/// registry that remembered one would answer the wrong document.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ArgTables<'a> {
+    /// No row is gated, so the spec's own slices answer at every floor.
+    Stored {
+        /// As `CommandSpec::arg_roles`.
+        roles: &'a [(u8, ArgRole)],
+        /// As `CommandSpec::arg_types`.
+        types: &'a [(u8, ArgTypeHint)],
+        /// As `CommandSpec::arg_values`.
+        values: &'a [(u8, &'static [ArgValue])],
+        /// As `CommandSpec::closed_value_args`.
+        closed: &'a [u8],
+        /// As `CommandSpec::arg_presentation`.
+        presentation: &'a [(u8, ArgPresentation)],
+        /// As `CommandSpec::command_prefixes`.
+        prefixes: &'a [(u8, crate::arg_role::AppendedArity)],
+    },
+    /// A gated row was filtered out at this floor.
+    Projected(ProjectedArgs),
+}
+
+impl ArgTables<'_> {
+    /// `(index, role)` rows that exist at this floor.
+    #[must_use]
+    pub fn roles(&self) -> &[(u8, ArgRole)] {
+        match self {
+            Self::Stored { roles, .. } => roles,
+            Self::Projected(projected) => &projected.roles,
+        }
+    }
+
+    /// `(index, type hint)` rows that exist at this floor.
+    #[must_use]
+    pub fn types(&self) -> &[(u8, ArgTypeHint)] {
+        match self {
+            Self::Stored { types, .. } => types,
+            Self::Projected(projected) => &projected.types,
+        }
+    }
+
+    /// `(index, values)` rows that exist at this floor.
+    #[must_use]
+    pub fn values(&self) -> &[(u8, &'static [ArgValue])] {
+        match self {
+            Self::Stored { values, .. } => values,
+            Self::Projected(projected) => &projected.values,
+        }
+    }
+
+    /// The enumerable values declared for `index` at this floor, empty when
+    /// the argument has no value set here — the floor-aware twin of
+    /// `CommandSpec::arg_values_at`.
+    #[must_use]
+    pub fn values_at(&self, index: u8) -> &'static [ArgValue] {
+        self.values()
+            .iter()
+            .find(|(i, _)| *i == index)
+            .map_or(&[], |(_, values)| values)
+    }
+
+    /// Closed-value argument indices that exist at this floor.
+    #[must_use]
+    pub fn closed(&self) -> &[u8] {
+        match self {
+            Self::Stored { closed, .. } => closed,
+            Self::Projected(projected) => &projected.closed,
+        }
+    }
+
+    /// `(index, presentation)` rows that exist at this floor.
+    #[must_use]
+    pub fn presentation(&self) -> &[(u8, ArgPresentation)] {
+        match self {
+            Self::Stored { presentation, .. } => presentation,
+            Self::Projected(projected) => &projected.presentation,
+        }
+    }
+
+    /// `(index, appended arity)` command-prefix rows that exist at this floor.
+    #[must_use]
+    pub fn prefixes(&self) -> &[(u8, crate::arg_role::AppendedArity)] {
+        match self {
+            Self::Stored { prefixes, .. } => prefixes,
+            Self::Projected(projected) => &projected.prefixes,
+        }
+    }
+}
+
 /// Project `rows` into the six parallel slices, keeping only rows that apply
 /// at `target`.
 ///
@@ -2421,6 +2523,33 @@ impl CommandSpec {
             .map(|(_, r)| *r)
     }
 
+    /// This command's per-argument tables as they exist at
+    /// `package_version` (issue #1644).
+    ///
+    /// The floor-aware form of the six parallel `arg_*` slices. With no gated
+    /// row — every shipped command, and every pack that put no lifecycle on an
+    /// argument — the stored slices are returned by reference and this is a
+    /// pointer copy; a gated row is what makes the projection necessary, and
+    /// only then is anything built.
+    ///
+    /// `None` is permissive, matching every other lifecycle query: with no
+    /// floor resolved there is nothing to gate against, so a versioned pack
+    /// answers exactly as an unversioned one until a floor is known.
+    #[must_use]
+    pub fn arg_tables_at(&self, package_version: Option<&str>) -> ArgTables<'_> {
+        if self.arg_rows.is_empty() {
+            return ArgTables::Stored {
+                roles: self.arg_roles,
+                types: self.arg_types,
+                values: self.arg_values,
+                closed: self.closed_value_args,
+                presentation: self.arg_presentation,
+                prefixes: self.command_prefixes,
+            };
+        }
+        ArgTables::Projected(project_arg_rows(self.arg_rows, package_version))
+    }
+
     /// Look up enumerable argument values for the 0-based `index`
     /// *after* the command name.  Returns an empty slice when this
     /// argument has no fixed value set.  Mirrors
@@ -2437,10 +2566,18 @@ impl CommandSpec {
     /// `package_version` — the command-level twin of
     /// [`SubCommand::arg_value_available_for_version`].
     ///
-    /// `index` is 0-based *after the command name*. Both gates apply: the
-    /// value's own [`ArgValue::lifecycle`] and any
-    /// [`Self::versioned_arg_values`] entry naming it. A value with neither
-    /// is ungated, and an ungated value is always available.
+    /// `index` is 0-based *after the command name*. Three gates apply, and a
+    /// value must pass all of them: the **row** the value was declared on
+    /// (issue #1644), the value's own [`ArgValue::lifecycle`], and any
+    /// [`Self::versioned_arg_values`] entry naming it. A value with none of
+    /// the three is ungated, and an ungated value is always available.
+    ///
+    /// The row gate is not the same question as the value gate, and reads
+    /// opposite when it fails: a value the row still declares but that is
+    /// itself gated out is *declared and unavailable*, while a value whose
+    /// whole argument does not exist at this floor is not declared here at
+    /// all. Both answer `false`, which is why the check is written as "the
+    /// value survives the row projection" rather than "the row survives".
     #[must_use]
     pub fn arg_value_available_for_version(
         &self,
@@ -2448,12 +2585,16 @@ impl CommandSpec {
         value: &str,
         package_version: Option<&str>,
     ) -> bool {
-        let declared = self
-            .arg_values_at(index)
+        let tables = self.arg_tables_at(package_version);
+        let survives_row = tables.values_at(index).iter().any(|v| v.value == value)
+            || !self.arg_values_at(index).iter().any(|v| v.value == value);
+        let declared = tables
+            .values_at(index)
             .iter()
             .find(|v| v.value == value)
             .is_none_or(|v| v.available_for_version(package_version));
-        declared
+        survives_row
+            && declared
             && self
                 .versioned_arg_values
                 .iter()
@@ -2471,7 +2612,11 @@ impl CommandSpec {
         index: u8,
         package_version: Option<&str>,
     ) -> Vec<&'static ArgValue> {
-        self.arg_values_at(index)
+        // Iterated over the *projected* table, so an argument whose whole row
+        // a later release introduced offers nothing at an older floor rather
+        // than being offered and then filtered value by value (issue #1644).
+        self.arg_tables_at(package_version)
+            .values_at(index)
             .iter()
             .filter(|value| {
                 self.arg_value_available_for_version(index, value.value, package_version)
@@ -3400,12 +3545,16 @@ impl SubCommand {
         value: &str,
         package_version: Option<&str>,
     ) -> bool {
-        let declared = self
-            .arg_values_at(index)
+        let tables = self.arg_tables_at(package_version);
+        let survives_row = tables.values_at(index).iter().any(|v| v.value == value)
+            || !self.arg_values_at(index).iter().any(|v| v.value == value);
+        let declared = tables
+            .values_at(index)
             .iter()
             .find(|v| v.value == value)
             .is_none_or(|v| v.available_for_version(package_version));
-        declared
+        survives_row
+            && declared
             && self
                 .versioned_arg_values
                 .iter()
@@ -3422,7 +3571,11 @@ impl SubCommand {
         index: u8,
         package_version: Option<&str>,
     ) -> Vec<&'static ArgValue> {
-        self.arg_values_at(index)
+        // Iterated over the *projected* table, so an argument whose whole row
+        // a later release introduced offers nothing at an older floor rather
+        // than being offered and then filtered value by value (issue #1644).
+        self.arg_tables_at(package_version)
+            .values_at(index)
             .iter()
             .filter(|value| {
                 self.arg_value_available_for_version(index, value.value, package_version)
@@ -3612,6 +3765,25 @@ impl SubCommand {
             }
         }
         specs
+    }
+
+    /// This subcommand's per-argument tables as they exist at
+    /// `package_version` — the subcommand twin of
+    /// [`CommandSpec::arg_tables_at`] (issue #1644), with the same fast path
+    /// and the same permissive `None`.
+    #[must_use]
+    pub fn arg_tables_at(&self, package_version: Option<&str>) -> ArgTables<'_> {
+        if self.arg_rows.is_empty() {
+            return ArgTables::Stored {
+                roles: self.arg_roles,
+                types: self.arg_types,
+                values: self.arg_values,
+                closed: self.closed_value_args,
+                presentation: self.arg_presentation,
+                prefixes: self.command_prefixes,
+            };
+        }
+        ArgTables::Projected(project_arg_rows(self.arg_rows, package_version))
     }
 
     /// Look up enumerable argument values for the 0-based
@@ -3976,5 +4148,105 @@ mod versioned_arg_row_tests {
             2,
             "an unresolved floor must not silently drop rows"
         );
+    }
+
+    /// A command that gates no argument answers from its stored slices at
+    /// every floor — the fast path (issue #1644).
+    ///
+    /// This is what keeps the wiring free for the whole shipped registry: no
+    /// spec has a gated row, so no projection is ever built and the tables a
+    /// consumer sees are the same `&'static` slices as before.
+    #[test]
+    fn an_ungated_command_answers_from_its_stored_slices() {
+        const ROLES: &[(u8, ArgRole)] = &[(0, ArgRole::VarWrite)];
+        const SPEC: CommandSpec = CommandSpec {
+            name: "ungated",
+            arg_roles: ROLES,
+            ..CommandSpec::DEFAULT
+        };
+        for floor in [None, Some("1.0"), Some("9.9")] {
+            let tables = SPEC.arg_tables_at(floor);
+            assert!(
+                matches!(tables, ArgTables::Stored { .. }),
+                "no gated row means nothing to project at {floor:?}"
+            );
+            assert_eq!(tables.roles(), ROLES);
+            assert!(
+                std::ptr::eq(tables.roles(), ROLES),
+                "the stored slice is handed back, not copied"
+            );
+        }
+    }
+
+    /// The answer #1644 exists to change: at a floor below the row's
+    /// introduction the argument is neither role-typed nor offered its values;
+    /// at and above it, both.
+    #[test]
+    fn a_gated_row_changes_the_role_and_value_answers() {
+        const NEW_VALUES: &[ArgValue] = &[ArgValue {
+            value: "later",
+            ..ArgValue::DEFAULT
+        }];
+        const ROWS: &[VersionedArgRow] = &[
+            VersionedArgRow {
+                index: 0,
+                role: Some(ArgRole::VarWrite),
+                ..VersionedArgRow::DEFAULT
+            },
+            VersionedArgRow {
+                index: 1,
+                lifecycle: Lifecycle::introduced_in("3.0"),
+                role: Some(ArgRole::Body),
+                values: NEW_VALUES,
+                ..VersionedArgRow::DEFAULT
+            },
+        ];
+        // The stored slices are the projection at no floor, exactly as the
+        // loader seals them.
+        const ROLES: &[(u8, ArgRole)] = &[(0, ArgRole::VarWrite), (1, ArgRole::Body)];
+        const VALUES: &[(u8, &[ArgValue])] = &[(1, NEW_VALUES)];
+        const SPEC: CommandSpec = CommandSpec {
+            name: "gated",
+            arg_rows: ROWS,
+            arg_roles: ROLES,
+            arg_values: VALUES,
+            ..CommandSpec::DEFAULT
+        };
+
+        let old = SPEC.arg_tables_at(Some("2.0"));
+        assert_eq!(
+            old.roles(),
+            &[(0, ArgRole::VarWrite)],
+            "the 3.0 argument is not role-typed at 2.0"
+        );
+        assert!(
+            old.values_at(1).is_empty(),
+            "and offers no values at 2.0: {:?}",
+            old.values_at(1)
+        );
+        assert!(
+            SPEC.available_arg_values_at(1, Some("2.0")).is_empty(),
+            "the value accessor completion calls must agree"
+        );
+        assert!(
+            !SPEC.arg_value_available_for_version(1, "later", Some("2.0")),
+            "a value whose whole argument does not exist yet is not available"
+        );
+
+        let new = SPEC.arg_tables_at(Some("3.0"));
+        assert_eq!(new.roles(), ROLES, "both arguments are typed from 3.0");
+        assert_eq!(
+            SPEC.available_arg_values_at(1, Some("3.0"))
+                .iter()
+                .map(|value| value.value)
+                .collect::<Vec<_>>(),
+            vec!["later"],
+            "and the value is offered from 3.0"
+        );
+        assert!(SPEC.arg_value_available_for_version(1, "later", Some("3.0")));
+
+        // FN guard: an unresolved floor stays permissive.
+        assert_eq!(SPEC.arg_tables_at(None).roles(), ROLES);
+        assert_eq!(SPEC.available_arg_values_at(1, None).len(), 1);
     }
 }

--- a/rust/tcl-spectcl/src/loader.rs
+++ b/rust/tcl-spectcl/src/loader.rs
@@ -5524,6 +5524,101 @@ mod tests {
         );
     }
 
+    /// A `-appends` row is a per-argument row like any other, so its
+    /// **command-prefix** position is gated too — on both legs (PR #1674
+    /// review).
+    ///
+    /// The loader gives a `-appends` row `ArgRole::CommandPrefix` when the
+    /// index has no role of its own, so the position reaches consumers through
+    /// the prefix query rather than the plain role table. That query answers
+    /// the role list *and* the appended arity the callback-arity check reads,
+    /// which is why the role lookup delegates to it: filtering one and not the
+    /// other would let a call site's position and its arity disagree about
+    /// which release they belong to.
+    #[test]
+    fn a_gated_appends_row_is_gated_on_both_legs() {
+        let pack = load_pack(
+            "speclib probe 1.2 {\n command demo {\n \
+             arity 3\n \
+             arg 0 -appends {Exactly 1}\n \
+             arg 1 -appends {Exactly 2} -introduced 3.0\n \
+             subcommand run {\n \
+             arity 3\n \
+             arg 0 -appends {Exactly 1}\n \
+             arg 1 -appends {Exactly 2} -introduced 3.0\n \
+             }\n \
+             }\n}",
+        );
+        assert!(pack.notices.is_empty(), "{:?}", pack.notices);
+        let mut registry = tcl_registry::registry::CommandRegistry::build_default();
+        registry.insert(pack.command("demo").expect("demo loads").spec.clone());
+
+        // Command leg: the 3.0 prefix position is absent at 1.0 — from the
+        // arity-bearing query and from the role list that delegates to it.
+        let args = ["a", "b", "c"];
+        assert_eq!(
+            registry.command_prefixes_at("demo", &args, Some("1.0")),
+            vec![(0, tcl_registry::arg_role::AppendedArity::Exactly(1))],
+            "the 3.0 prefix row must not appear at a 1.0 floor"
+        );
+        assert_eq!(
+            registry.arg_indices_for_role_at("demo", &args, ArgRole::CommandPrefix, Some("1.0")),
+            vec![0],
+            "and the role list must agree with it"
+        );
+        assert_eq!(
+            registry.command_prefixes_at("demo", &args, Some("3.0")),
+            vec![
+                (0, tcl_registry::arg_role::AppendedArity::Exactly(1)),
+                (1, tcl_registry::arg_role::AppendedArity::Exactly(2)),
+            ],
+            "both apply from 3.0"
+        );
+        assert_eq!(
+            registry.arg_indices_for_role_at("demo", &args, ArgRole::CommandPrefix, Some("3.0")),
+            vec![0, 1]
+        );
+        // FN guard: an unresolved floor stays permissive.
+        assert_eq!(
+            registry.arg_indices_for_role("demo", &args, ArgRole::CommandPrefix),
+            vec![0, 1],
+            "no floor resolved means no gating"
+        );
+
+        // Subcommand leg: same rows, one position further along.
+        let sub_args = ["run", "a", "b", "c"];
+        assert_eq!(
+            registry.command_prefixes_at("demo", &sub_args, Some("1.0")),
+            vec![(1, tcl_registry::arg_role::AppendedArity::Exactly(1))],
+            "a subcommand's gated prefix row is gated too"
+        );
+        assert_eq!(
+            registry.arg_indices_for_role_at(
+                "demo",
+                &sub_args,
+                ArgRole::CommandPrefix,
+                Some("1.0")
+            ),
+            vec![1]
+        );
+        assert_eq!(
+            registry.command_prefixes_at("demo", &sub_args, Some("3.0")),
+            vec![
+                (1, tcl_registry::arg_role::AppendedArity::Exactly(1)),
+                (2, tcl_registry::arg_role::AppendedArity::Exactly(2)),
+            ]
+        );
+        assert_eq!(
+            registry.arg_indices_for_role_at(
+                "demo",
+                &sub_args,
+                ArgRole::CommandPrefix,
+                Some("3.0")
+            ),
+            vec![1, 2]
+        );
+    }
+
     /// Windows and gated argument rows join the containment pass every other
     /// lifecycle already goes through: a row that outlives the command
     /// declaring it is a pack defect the author can only find if told.

--- a/rust/tcl-spectcl/src/loader.rs
+++ b/rust/tcl-spectcl/src/loader.rs
@@ -5473,6 +5473,57 @@ mod tests {
         );
     }
 
+    /// The authored row reaches the accessors consumers actually read
+    /// (issue #1644) — the loader's half of the wiring, end to end from pack
+    /// text to the answers a provider asks for.
+    ///
+    /// Before this, a row gated `-introduced 3.0` round-tripped through the
+    /// loader and the renderer and then changed nothing: every consumer read
+    /// the parallel slices, which are the projection at *no* floor.
+    #[test]
+    fn a_gated_arg_row_reaches_the_floor_aware_accessors() {
+        let pack = load_pack(
+            "speclib probe 1.2 {\n command demo {\n \
+             arity 3\n \
+             arg 0 -role Body\n \
+             arg 1 -role Expr -introduced 3.0 -values {brandnew}\n \
+             }\n}",
+        );
+        assert!(pack.notices.is_empty(), "{:?}", pack.notices);
+        let spec = pack.command("demo").expect("demo loads").spec;
+
+        // Roles: the argument is not typed below its introduction …
+        assert_eq!(
+            spec.arg_tables_at(Some("1.0")).roles(),
+            &[(0, ArgRole::Body)],
+            "the 3.0 argument is not role-typed at a 1.0 floor"
+        );
+        // … and is at and above it, and with no floor resolved.
+        assert_eq!(
+            spec.arg_tables_at(Some("3.0")).roles(),
+            &[(0, ArgRole::Body), (1, ArgRole::Expr)]
+        );
+        assert_eq!(
+            spec.arg_tables_at(None).roles(),
+            &[(0, ArgRole::Body), (1, ArgRole::Expr)],
+            "an unresolved floor stays permissive"
+        );
+
+        // Values: the same gate, through the accessor completion calls.
+        assert!(
+            spec.available_arg_values_at(1, Some("1.0")).is_empty(),
+            "its values are not offered at a 1.0 floor"
+        );
+        assert_eq!(
+            spec.available_arg_values_at(1, Some("3.0"))
+                .iter()
+                .map(|value| value.value)
+                .collect::<Vec<_>>(),
+            vec!["brandnew"],
+            "and are from 3.0"
+        );
+    }
+
     /// Windows and gated argument rows join the containment pass every other
     /// lifecycle already goes through: a row that outlives the command
     /// declaring it is a pack defect the author can only find if told.


### PR DESCRIPTION
## Summary

Fixes #1644.

`VersionedArgRow` was authorable and inert. A SpecTcl pack could gate an `arg` row `-introduced 3.0`, the loader round-tripped it through registry and renderer, and then every consumer read the six parallel `arg_*` slices — which are the projection at *no* floor — so the row changed no answer anywhere.

The layering decision is recorded on the issue; the short version is that this is **not a new mechanism**. Every other lifecycle-bearing fact already answers through a floor-parameterised accessor on the spec — `subcommand_table(dialect, package_version, …)`, `option_table(…)`, `optional_trailing_arg_names(…)`, `available_arg_values_at(index, package_version)`. The per-argument row was the only such surface with no accessor. It has one now.

## What was added

* `CommandSpec::arg_tables_at(package_version)` and its `SubCommand` twin, returning `ArgTables<'_>` — the tables **as they exist at that floor**.
* `CommandRegistry::arg_indices_for_role_at(name, args, role, package_version)`; the existing `arg_indices_for_role` is that call at `None`, which is the permissive reading every other lifecycle query gives an unresolved version.
* `available_arg_values_at` / `arg_value_available_for_version` now apply the **row** gate before the value gate. A value whose whole argument does not exist at this floor is not "declared and unavailable", it is not declared here at all — both answer `false`, and the check is written as "the value survives the row projection" so the two readings cannot drift.

Two properties keep this cheap and sound:

* **The floor stays an argument, never registry state.** Registry handles are cached per (profile, pack overlay) and shared across documents, so a registry that remembered a floor would answer the wrong document. That is also why no per-(spec, floor) cache is introduced.
* **`arg_rows.is_empty()` is a fast reject.** No shipped spec gates an argument, so those specs hand back their stored `&'static` slices *by reference* — `ArgTables::Stored`, a pointer copy — and only a gated pack command ever builds a projection. Pinned by `an_ungated_command_answers_from_its_stored_slices`, which asserts the returned slice is the same pointer.

## What was wired

The **request-time** providers, which is the only place the answer can be right: a document's floor is settled by its `package require` lines, so it exists once the walk that records them has finished.

* `document_floor::DocumentFloor` is now the one place a provider resolves a floor. Completion's private `package_version_floor` was the only implementation; it becomes a call to it, so the next consumer does not copy the rule.
* **Completion's value offers needed no new plumbing** — the row gate lands inside `available_arg_values_at`, the accessor completion already calls with the floor.
* The **`expr`-argument context test** resolves roles at the floor, so the math-function vocabulary is not offered inside an argument that is not an expression yet.

## What was deliberately not wired

Consumers that read the tables **during the walk** keep the permissive no-floor projection. Their answers are formed before the floor is knowable — precisely why the arity axis of the same feature buffers its verdict and decides post-walk (#1627). Making a walk-time reader floor-aware means giving it that same deferred-verdict treatment; it is not done here, and it is not faked by pretending a floor exists mid-walk. Invariant 6 in `shared-utility-contracts-rust.md` now records what is wired and what is not, in place of its "Not yet wired" note.

## Acceptance

> A gated `arg` row changes a real answer: an argument introduced at 3.0 is not offered / not role-typed at a 2.0 floor, and is at 3.0.

Both halves, at three levels:

| level | test |
|---|---|
| registry | `a_gated_row_changes_the_role_and_value_answers`, `arg_indices_for_role_honours_a_gated_row_at_the_resolved_floor` |
| pack authoring | `a_gated_arg_row_reaches_the_floor_aware_accessors` — from pack text through the loader to the accessors providers read |
| provider, end to end | `arg_value_completion_gates_a_versioned_argument_row` ("not offered"), `math_function_completion_gates_a_versioned_expr_row` ("not role-typed"), with `ungated_argument_values_are_offered_at_every_floor` as the FP control |

## Validation

All from `rust/`, prefixed `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=2`, with `TCLLIB_2_0_DIR` and `TCL_LSP_TCLSH86` set.

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p tcl-registry -p tcl-spectcl -p tcl-lsp-core --all-targets` — no warnings (Rust 1.98)
- [x] `cargo check --workspace` — clean
- [x] `cargo test -p tcl-registry -p tcl-spectcl` — 26 suites green
- [x] `cargo test -p tcl-lsp-core` — 33 suites green
- [x] `cargo test -p tcl-compiler` — 63 suites green **with the tcllib corpus present**
- [x] `make lsp-server-wasm-test` — 16/16 (both touched crates ship in the wasm server)

Mutation-verified from a green baseline: **6 mutants, 5 killed by name, 1 proven equivalent.**

Killed: the projection built at no floor; the fast reject taken unconditionally; the row gate dropped from the value predicate; roles read from the stored table; the provider resolving no floor.

The survivor makes `available_arg_values_at` iterate the *stored* table instead of the projected one. It is equivalent by construction rather than untested: the stored table is the projection at no floor, so it is a superset of the projected one, and each value then faces `arg_value_available_for_version`, which applies the same row gate (that predicate's own mutant *is* killed). Iterating the projected table is kept because it is what the accessor means — "the values that exist at this floor" — and because it does not walk rows it will then discard.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? Yes — the per-argument tables become floor-dependent for a consumer holding a floor. `docs/design/contracts/shared-utility-contracts-rust.md` invariant 6 is rewritten accordingly.
- [x] No diagnostic or optimisation code added or changed, so no `docs/kcs/codes/` page needed.
- [x] No new design doc, so no `docs/design/README.md` link needed.

## Notes for review

- `ArgTables` is an enum rather than a struct of `Cow`s so the fast path is a pointer copy with no allocation and no per-column branch at construction.
- The only signature changes are additive: `arg_indices_for_role_at` beside `arg_indices_for_role`, and `expr_arg_context_at` taking a `DocumentFloor` (one production caller).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o)_