### PR TITLE
Convert closed string vocabularies to enums (taint basis, graph/grep/lint/mermaid, explain kinds)

### DIFF
--- a/rust/f5-cli/src/commands/explain.rs
+++ b/rust/f5-cli/src/commands/explain.rs
@@ -30,15 +30,66 @@ use serde_json::Value;
 use tcl_bigip::parser::BigipConfig;
 use tcl_cli_support::{OutputTarget, write_text_output};
 
+/// Closed vocabulary of object kinds `f5 explain` resolves against. Threaded
+/// through [`Model::inv`]/[`Model::get`]/[`Model::resolve`] and the
+/// `kind_hint` walker in [`run_explain`], replacing what was a `&str`
+/// compared against string literals at every one of those sites (the same
+/// six spellings are enumerated as a separate, non-identical `(module,
+/// object_type)` vocabulary in `f5-cli/src/commands/diff.rs`'s `SPECIALISED`
+/// — that one is out of scope here: it has three more members and a
+/// different shape, and isn't part of this issue's verified inventory).
+///
+/// `ExplainReport::kind` / `ExplainJson::kind` (the JSON/text report's `kind`
+/// field) stay `String` — that's the serialised wire output — but are now
+/// populated via [`ExplainKind::as_str`] instead of a separate literal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ExplainKind {
+    Virtual,
+    Pool,
+    Profile,
+    Persistence,
+    Rule,
+    SnatPool,
+}
+
+impl ExplainKind {
+    const fn as_str(self) -> &'static str {
+        match self {
+            ExplainKind::Virtual => "virtual",
+            ExplainKind::Pool => "pool",
+            ExplainKind::Profile => "profile",
+            ExplainKind::Persistence => "persistence",
+            ExplainKind::Rule => "rule",
+            ExplainKind::SnatPool => "snatpool",
+        }
+    }
+}
+
+impl std::str::FromStr for ExplainKind {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "virtual" => Ok(ExplainKind::Virtual),
+            "pool" => Ok(ExplainKind::Pool),
+            "profile" => Ok(ExplainKind::Profile),
+            "persistence" => Ok(ExplainKind::Persistence),
+            "rule" => Ok(ExplainKind::Rule),
+            "snatpool" => Ok(ExplainKind::SnatPool),
+            _ => Err(()),
+        }
+    }
+}
+
 /// Map a `Placed.table_name` to the kinds explain resolves against.
-fn table_to_kind(table: &str) -> Option<&'static str> {
+fn table_to_kind(table: &str) -> Option<ExplainKind> {
     match table {
-        "virtual_servers" => Some("virtual"),
-        "pools" => Some("pool"),
-        "profiles" => Some("profile"),
-        "persistence" => Some("persistence"),
-        "rules" => Some("rule"),
-        "snat_pools" => Some("snatpool"),
+        "virtual_servers" => Some(ExplainKind::Virtual),
+        "pools" => Some(ExplainKind::Pool),
+        "profiles" => Some(ExplainKind::Profile),
+        "persistence" => Some(ExplainKind::Persistence),
+        "rules" => Some(ExplainKind::Rule),
+        "snat_pools" => Some(ExplainKind::SnatPool),
         _ => None,
     }
 }
@@ -47,12 +98,12 @@ fn table_to_kind(table: &str) -> Option<&'static str> {
 /// fallback picks a deterministic key.
 struct Model {
     default_partition: String,
-    by_kind: HashMap<&'static str, Vec<(String, Value)>>,
+    by_kind: HashMap<ExplainKind, Vec<(String, Value)>>,
 }
 
 impl Model {
     fn build(cfg: &BigipConfig) -> Self {
-        let mut by_kind: HashMap<&'static str, Vec<(String, Value)>> = HashMap::new();
+        let mut by_kind: HashMap<ExplainKind, Vec<(String, Value)>> = HashMap::new();
         for placed in &cfg.objects {
             if let Some(kind) = table_to_kind(placed.table_name) {
                 by_kind
@@ -67,18 +118,18 @@ impl Model {
         }
     }
 
-    fn inv(&self, kind: &str) -> &[(String, Value)] {
-        self.by_kind.get(kind).map_or(&[][..], Vec::as_slice)
+    fn inv(&self, kind: ExplainKind) -> &[(String, Value)] {
+        self.by_kind.get(&kind).map_or(&[][..], Vec::as_slice)
     }
 
-    fn get(&self, kind: &str, path: &str) -> Option<&Value> {
+    fn get(&self, kind: ExplainKind, path: &str) -> Option<&Value> {
         self.inv(kind)
             .iter()
             .find(|(p, _)| p == path)
             .map(|(_, v)| v)
     }
 
-    fn resolve(&self, kind: &str, name: &str) -> Option<String> {
+    fn resolve(&self, kind: ExplainKind, name: &str) -> Option<String> {
         resolve_name(name, self.inv(kind), &self.default_partition)
     }
 }
@@ -153,9 +204,9 @@ fn explain_virtual(model: &Model, vs: &Value) -> Vec<Section> {
             continue;
         };
         let resolved = model
-            .resolve("profile", pref)
+            .resolve(ExplainKind::Profile, pref)
             .unwrap_or_else(|| pref.to_owned());
-        if let Some(profile) = model.get("profile", &resolved) {
+        if let Some(profile) = model.get(ExplainKind::Profile, &resolved) {
             let ptype = profile
                 .get("profile_type")
                 .and_then(|t| t.get("e"))
@@ -173,9 +224,9 @@ fn explain_virtual(model: &Model, vs: &Value) -> Vec<Section> {
     for v in list_items(vs.get("rules")) {
         let Some(rref) = v.as_str() else { continue };
         let resolved = model
-            .resolve("rule", rref)
+            .resolve(ExplainKind::Rule, rref)
             .unwrap_or_else(|| rref.to_owned());
-        if let Some(rule) = model.get("rule", &resolved) {
+        if let Some(rule) = model.get(ExplainKind::Rule, &resolved) {
             let body = rule.get("source").and_then(Value::as_str).unwrap_or("");
             let events: BTreeSet<String> = tcl_irules::when_blocks(body)
                 .into_iter()
@@ -204,9 +255,9 @@ fn explain_virtual(model: &Model, vs: &Value) -> Vec<Section> {
             continue;
         };
         let resolved = model
-            .resolve("persistence", pref)
+            .resolve(ExplainKind::Persistence, pref)
             .unwrap_or_else(|| pref.to_owned());
-        if let Some(prof) = model.get("persistence", &resolved) {
+        if let Some(prof) = model.get(ExplainKind::Persistence, &resolved) {
             let ptype = prof
                 .get("persistence_type")
                 .and_then(Value::as_str)
@@ -221,9 +272,9 @@ fn explain_virtual(model: &Model, vs: &Value) -> Vec<Section> {
     let mut snat = Vec::new();
     if let Some(snatpool) = non_empty_str(vs.get("snatpool")) {
         let resolved = model
-            .resolve("snatpool", snatpool)
+            .resolve(ExplainKind::SnatPool, snatpool)
             .unwrap_or_else(|| snatpool.to_owned());
-        if let Some(sp) = model.get("snatpool", &resolved) {
+        if let Some(sp) = model.get(ExplainKind::SnatPool, &resolved) {
             let members = list_items(sp.get("members")).len();
             snat.push(format!("snatpool {resolved} ({members} member(s))"));
         } else {
@@ -237,8 +288,8 @@ fn explain_virtual(model: &Model, vs: &Value) -> Vec<Section> {
 
     let mut pool_lines = Vec::new();
     if let Some(pool) = non_empty_str(vs.get("pool")) {
-        if let Some(resolved) = model.resolve("pool", pool) {
-            if let Some(p) = model.get("pool", &resolved) {
+        if let Some(resolved) = model.resolve(ExplainKind::Pool, pool) {
+            if let Some(p) = model.get(ExplainKind::Pool, &resolved) {
                 pool_lines = explain_pool_lines(p);
             }
         } else {
@@ -328,24 +379,24 @@ pub(crate) struct ExplainReport {
 pub(crate) fn compute_explain(
     cfg: &BigipConfig,
     target: &str,
-    kind_hint: Option<&str>,
+    kind_hint: Option<ExplainKind>,
 ) -> ExplainReport {
     let model = Model::build(cfg);
 
-    let resolved = if kind_hint.is_none() || kind_hint == Some("virtual") {
+    let resolved = if kind_hint.is_none() || kind_hint == Some(ExplainKind::Virtual) {
         model
-            .resolve("virtual", target)
-            .and_then(|p| model.get("virtual", &p).cloned())
-            .map(|vs| ("virtual", vs))
+            .resolve(ExplainKind::Virtual, target)
+            .and_then(|p| model.get(ExplainKind::Virtual, &p).cloned())
+            .map(|vs| (ExplainKind::Virtual, vs))
     } else {
         None
     }
     .or_else(|| {
-        if kind_hint.is_none() || kind_hint == Some("pool") {
+        if kind_hint.is_none() || kind_hint == Some(ExplainKind::Pool) {
             model
-                .resolve("pool", target)
-                .and_then(|p| model.get("pool", &p).cloned())
-                .map(|pool| ("pool", pool))
+                .resolve(ExplainKind::Pool, target)
+                .and_then(|p| model.get(ExplainKind::Pool, &p).cloned())
+                .map(|pool| (ExplainKind::Pool, pool))
         } else {
             None
         }
@@ -354,13 +405,13 @@ pub(crate) fn compute_explain(
     let Some((actual_kind, obj)) = resolved else {
         return ExplainReport {
             target: target.to_owned(),
-            kind: kind_hint.unwrap_or("?").to_owned(),
+            kind: kind_hint.map_or_else(|| "?".to_owned(), |k| k.as_str().to_owned()),
             found: false,
             sections: Vec::new(),
         };
     };
 
-    let sections = if actual_kind == "virtual" {
+    let sections = if actual_kind == ExplainKind::Virtual {
         explain_virtual(&model, &obj)
     } else {
         vec![("pool", explain_pool_lines(&obj))]
@@ -368,7 +419,7 @@ pub(crate) fn compute_explain(
 
     ExplainReport {
         target: target.to_owned(),
-        kind: actual_kind.to_owned(),
+        kind: actual_kind.as_str().to_owned(),
         found: true,
         sections,
     }
@@ -377,19 +428,19 @@ pub(crate) fn compute_explain(
 pub(crate) fn full_path_of(
     report: &ExplainReport,
     cfg: &BigipConfig,
-    kind_hint: Option<&str>,
+    kind_hint: Option<ExplainKind>,
 ) -> String {
     // Re-resolve to recover the matched object's full_path for the header.
     let model = Model::build(cfg);
     let target = &report.target;
-    if (kind_hint.is_none() || kind_hint == Some("virtual"))
-        && report.kind == "virtual"
-        && let Some(p) = model.resolve("virtual", target)
+    if (kind_hint.is_none() || kind_hint == Some(ExplainKind::Virtual))
+        && report.kind == ExplainKind::Virtual.as_str()
+        && let Some(p) = model.resolve(ExplainKind::Virtual, target)
     {
         return p;
     }
-    if report.kind == "pool"
-        && let Some(p) = model.resolve("pool", target)
+    if report.kind == ExplainKind::Pool.as_str()
+        && let Some(p) = model.resolve(ExplainKind::Pool, target)
     {
         return p;
     }
@@ -422,7 +473,15 @@ pub fn run_explain(
     json: bool,
     output: Option<&Path>,
 ) -> anyhow::Result<u8> {
-    let kind_hint = if kind == "auto" { None } else { Some(kind) };
+    // `kind` is clap-validated to "virtual"/"pool"/"auto" (see `cli.rs`), so
+    // the parse always succeeds for the non-"auto" case; unreachable via the
+    // CLI, an unparseable value now falls back to `None` (== "auto") rather
+    // than an opaque hint nothing could ever match.
+    let kind_hint = if kind == "auto" {
+        None
+    } else {
+        kind.parse::<ExplainKind>().ok()
+    };
 
     // Resolve inputs via the UCS-aware loader, so a `.ucs` — plain or encrypted
     // — is transparently extracted to SCF and parsed just like a `.conf`/`.scf`.

--- a/rust/f5-cli/src/commands/explain_flow.rs
+++ b/rust/f5-cli/src/commands/explain_flow.rs
@@ -951,8 +951,13 @@ fn compute_explain_flow(
             }
         }
 
-        let explain_report = explain::compute_explain(cfg_hit, &vs.full_path, Some("virtual"));
-        let explain_full_path = explain::full_path_of(&explain_report, cfg_hit, Some("virtual"));
+        let explain_report =
+            explain::compute_explain(cfg_hit, &vs.full_path, Some(explain::ExplainKind::Virtual));
+        let explain_full_path = explain::full_path_of(
+            &explain_report,
+            cfg_hit,
+            Some(explain::ExplainKind::Virtual),
+        );
         let explain_text = explain::format_text(&explain_report, &explain_full_path);
 
         let reset = analyse_reset(&session);

--- a/rust/f5-cli/src/commands/validate.rs
+++ b/rust/f5-cli/src/commands/validate.rs
@@ -155,7 +155,7 @@ pub(crate) fn to_json(findings: &[Finding]) -> String {
             "    {{\n      \"ruleId\": {},\n      \"severity\": {},\n      \"category\": {},\n      \"fullPath\": {},\n      \"message\": {}\n    }}",
             q(&f.rule_id),
             q(f.severity),
-            q(f.category),
+            q(f.category.as_str()),
             q(&f.full_path),
             q(&f.message),
         );

--- a/rust/f5-cli/tests/validate.rs
+++ b/rust/f5-cli/tests/validate.rs
@@ -60,6 +60,34 @@ fn lint_alias_matches_validate() {
     assert_eq!(vc, lc, "lint alias exit code differs from validate");
 }
 
+// JSON output pins the `"category"` field's wire spelling (issue #1614: the
+// enum backing this must not change what's on the wire).
+
+#[test]
+fn json_category_field_is_config_or_irule() {
+    let dir = fixtures_dir();
+    let conf = dir.join("validate-rules.conf");
+    let conf = conf.to_str().unwrap();
+    let (code, stdout, _) = run(&["validate", conf, "--format", "json"]);
+    assert_eq!(code, 1, "expected exit 1 for warning-severity findings");
+    assert!(
+        stdout.contains("\"category\": \"config\""),
+        "expected a config-category finding in JSON output: {stdout}"
+    );
+    assert!(
+        stdout.contains("\"category\": \"irule\""),
+        "expected an irule-category finding in JSON output: {stdout}"
+    );
+    // Every category value in the output must be one of the two — no stray
+    // spelling leaked from the enum's Debug/variant names.
+    for line in stdout.lines().filter(|l| l.contains("\"category\":")) {
+        assert!(
+            line.contains("\"config\"") || line.contains("\"irule\""),
+            "unexpected category spelling: {line}"
+        );
+    }
+}
+
 // Input error: missing file → `error: not a file: <path>` on stderr,
 //    exit 2 (the OS-error path).
 

--- a/rust/tcl-bigip-query/src/renderers/mermaid.rs
+++ b/rust/tcl-bigip-query/src/renderers/mermaid.rs
@@ -43,7 +43,61 @@ use crate::errors::QueryError;
 use crate::output::cell_str;
 use crate::value::Value;
 
-const DIRECTIONS: [&str; 4] = ["LR", "RL", "TB", "BT"];
+const DIRECTIONS: [&str; 4] = [
+    MermaidDirection::Lr.as_str(),
+    MermaidDirection::Rl.as_str(),
+    MermaidDirection::Tb.as_str(),
+    MermaidDirection::Bt.as_str(),
+];
+
+/// Closed vocabulary backing [`DIRECTIONS`]: the Mermaid flowchart `direction`
+/// query option. Validated once here (`direction.parse()`) instead of via
+/// `DIRECTIONS.contains(...)`, then carried as this enum (not the raw
+/// upper-cased string) into [`render_chain`], which `Display`s it straight
+/// into the emitted `graph {direction}` line — the exact "LR"/"RL"/"TB"/"BT"
+/// spelling a user's rendered diagram shows is unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MermaidDirection {
+    /// Left to right.
+    Lr,
+    /// Right to left.
+    Rl,
+    /// Top to bottom.
+    Tb,
+    /// Bottom to top.
+    Bt,
+}
+
+impl MermaidDirection {
+    const fn as_str(self) -> &'static str {
+        match self {
+            MermaidDirection::Lr => "LR",
+            MermaidDirection::Rl => "RL",
+            MermaidDirection::Tb => "TB",
+            MermaidDirection::Bt => "BT",
+        }
+    }
+}
+
+impl std::str::FromStr for MermaidDirection {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "LR" => Ok(MermaidDirection::Lr),
+            "RL" => Ok(MermaidDirection::Rl),
+            "TB" => Ok(MermaidDirection::Tb),
+            "BT" => Ok(MermaidDirection::Bt),
+            _ => Err(()),
+        }
+    }
+}
+
+impl std::fmt::Display for MermaidDirection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 /// Render *values* as Mermaid — registry entry point.
 ///
@@ -52,15 +106,15 @@ const DIRECTIONS: [&str; 4] = ["LR", "RL", "TB", "BT"];
 /// Returns [`QueryError::Renderer`] for an unknown `direction`, a non-boolean
 /// `reverse`, or a non-integer `max-depth`.
 pub fn render(values: &[Value], opts: &BTreeMap<String, String>) -> Result<String, QueryError> {
-    let direction = opts
+    let direction_str = opts
         .get("direction")
         .map_or_else(|| "LR".to_owned(), |s| s.to_uppercase());
-    if !DIRECTIONS.contains(&direction.as_str()) {
+    let Ok(direction) = direction_str.parse::<MermaidDirection>() else {
         let valid = DIRECTIONS.join(", ");
         return Err(QueryError::Renderer(format!(
-            "mermaid: unknown direction '{direction}' (expected one of {valid})"
+            "mermaid: unknown direction '{direction_str}' (expected one of {valid})"
         )));
-    }
+    };
 
     let all_object_refs =
         !values.is_empty() && values.iter().all(|v| matches!(v, Value::ObjectRef(_)));
@@ -72,12 +126,12 @@ pub fn render(values: &[Value], opts: &BTreeMap<String, String>) -> Result<Strin
         let _reverse = parse_bool(opts.get("reverse"), "reverse")?;
         let _max_depth =
             parse_optional_int(opts.get("max-depth").or_else(|| opts.get("max_depth")))?;
-        return Ok(render_chain(values, &direction));
+        return Ok(render_chain(values, direction));
     }
-    Ok(render_chain(values, &direction))
+    Ok(render_chain(values, direction))
 }
 
-fn render_chain(values: &[Value], direction: &str) -> String {
+fn render_chain(values: &[Value], direction: MermaidDirection) -> String {
     if values.is_empty() {
         return format!("graph {direction}\n");
     }

--- a/rust/tcl-bigip/src/graph.rs
+++ b/rust/tcl-bigip/src/graph.rs
@@ -984,7 +984,49 @@ pub struct GraphExport {
 }
 
 /// The supported `f5 graph` formats.
-pub const GRAPH_FORMATS: [&str; 3] = ["dot", "json", "mermaid"];
+pub const GRAPH_FORMATS: [&str; 3] = [
+    GraphFormat::Dot.as_str(),
+    GraphFormat::Json.as_str(),
+    GraphFormat::Mermaid.as_str(),
+];
+
+/// Closed vocabulary of `f5 graph` output formats. `export_graph` takes the
+/// CLI-typed `&str` (the wire spelling users type as `--format dot|json|mermaid`
+/// is preserved unchanged) and parses it to this enum for exhaustive internal
+/// dispatch — the previous `match fmt { "dot" => .., "json" => .., _ => .. }`
+/// let an unrecognised-but-validated string silently fall through to mermaid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GraphFormat {
+    Dot,
+    Json,
+    Mermaid,
+}
+
+impl GraphFormat {
+    /// The CLI spelling for this format — must stay byte-identical to the
+    /// pre-enum strings (`--format` value, `GRAPH_FORMATS`, the "unknown
+    /// graph format" error list).
+    const fn as_str(self) -> &'static str {
+        match self {
+            GraphFormat::Dot => "dot",
+            GraphFormat::Json => "json",
+            GraphFormat::Mermaid => "mermaid",
+        }
+    }
+}
+
+impl std::str::FromStr for GraphFormat {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "dot" => Ok(GraphFormat::Dot),
+            "json" => Ok(GraphFormat::Json),
+            "mermaid" => Ok(GraphFormat::Mermaid),
+            _ => Err(()),
+        }
+    }
+}
 
 /// A DOT-safe node id: `n_` + each non-alphanumeric char replaced by `_`.
 fn safe_id(node_id: &str) -> String {
@@ -1014,11 +1056,11 @@ pub fn export_graph(
     reverse: bool,
     max_depth: Option<usize>,
 ) -> Result<GraphExport, BigipError> {
-    if !GRAPH_FORMATS.contains(&fmt) {
+    let Ok(format) = fmt.parse::<GraphFormat>() else {
         return Err(BigipError::graph(format!(
             "unknown graph format {fmt:?} (expected one of {GRAPH_FORMATS:?})"
         )));
-    }
+    };
 
     // Flatten nodes in source order (across uris), keyed by node_id.
     let all_nodes: Vec<&ObjectNode> = graph
@@ -1029,10 +1071,10 @@ pub fn export_graph(
     let (kept, edges) = filter_to_subgraph(&all_nodes, &graph.edges, seeds, reverse, max_depth);
 
     let kept_ids: HashSet<&str> = kept.iter().map(|n| n.node_id.as_str()).collect();
-    let text = match fmt {
-        "dot" => to_dot(&kept, &edges, &kept_ids),
-        "json" => to_json(&kept, &edges, &kept_ids),
-        _ => to_mermaid(&kept, &edges, &kept_ids),
+    let text = match format {
+        GraphFormat::Dot => to_dot(&kept, &edges, &kept_ids),
+        GraphFormat::Json => to_json(&kept, &edges, &kept_ids),
+        GraphFormat::Mermaid => to_mermaid(&kept, &edges, &kept_ids),
     };
     Ok(GraphExport {
         fmt: fmt.to_owned(),

--- a/rust/tcl-bigip/src/grep.rs
+++ b/rust/tcl-bigip/src/grep.rs
@@ -37,6 +37,44 @@ use crate::range::Range;
 /// The accepted traversal directions.
 pub const DIRECTIONS: [&str; 3] = ["both", "forward", "reverse"];
 
+/// Closed vocabulary backing [`DIRECTIONS`]. `GrepArgs::direction` (CLI input)
+/// and `GrepReport::direction` (JSON/text output) stay `&str`/`String` — those
+/// are wire spellings a user types and a report emits, so the string is kept
+/// there per the #1405 boundary discipline — but the two BFS direction checks
+/// in [`expand_bfs`] dispatch on this enum via [`GrepDirection::from_str`]
+/// instead of re-matching the raw string at each site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GrepDirection {
+    Both,
+    Forward,
+    Reverse,
+}
+
+impl GrepDirection {
+    /// Whether this direction walks outgoing edges.
+    fn walks_forward(self) -> bool {
+        matches!(self, GrepDirection::Forward | GrepDirection::Both)
+    }
+
+    /// Whether this direction walks incoming edges.
+    fn walks_reverse(self) -> bool {
+        matches!(self, GrepDirection::Reverse | GrepDirection::Both)
+    }
+}
+
+impl std::str::FromStr for GrepDirection {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "both" => Ok(GrepDirection::Both),
+            "forward" => Ok(GrepDirection::Forward),
+            "reverse" => Ok(GrepDirection::Reverse),
+            _ => Err(()),
+        }
+    }
+}
+
 /// One object in the grep result — a seed or a related object.
 #[derive(Debug, Clone)]
 pub struct GrepObject {
@@ -503,7 +541,7 @@ impl Default for GrepArgs<'_> {
 
 /// Validate the direction / `max_nodes` invariants `compute_grep` relies on.
 fn validate_grep_args(args: &GrepArgs) -> Result<(), BigipError> {
-    if !DIRECTIONS.contains(&args.direction) {
+    if args.direction.parse::<GrepDirection>().is_err() {
         let mut sorted = DIRECTIONS;
         sorted.sort_unstable();
         return Err(BigipError::grep(format!(
@@ -552,6 +590,11 @@ fn expand_bfs(
     if !args.recurse {
         return depths;
     }
+    // `compute_grep` always runs `validate_grep_args` (which rejects any
+    // direction not in `DIRECTIONS`) before calling this, so the parse cannot
+    // fail in practice; `Both` is a harmless fallback rather than a silent
+    // behaviour change if that invariant is ever loosened.
+    let direction: GrepDirection = args.direction.parse().unwrap_or(GrepDirection::Both);
     let mut queue: VecDeque<String> = seed_ids.iter().cloned().collect();
     while let Some(nid) = queue.pop_front() {
         if depths.len() >= args.max_nodes {
@@ -562,14 +605,14 @@ fn expand_bfs(
             continue;
         }
         let mut neighbours: Vec<String> = Vec::new();
-        if matches!(args.direction, "forward" | "both")
+        if direction.walks_forward()
             && let Some(edges) = outgoing.get(nid.as_str())
         {
             for edge in edges {
                 neighbours.push(edge.target_id.clone());
             }
         }
-        if matches!(args.direction, "reverse" | "both")
+        if direction.walks_reverse()
             && let Some(edges) = incoming.get(nid.as_str())
         {
             for edge in edges {

--- a/rust/tcl-bigip/src/lint.rs
+++ b/rust/tcl-bigip/src/lint.rs
@@ -36,9 +36,52 @@ use crate::model::ModelObject;
 use crate::parser::driver::{BigipConfig, Placed};
 
 /// The lint rule categories, in fixed order.
-pub const CATEGORIES: [&str; 2] = ["config", "irule"];
+pub const CATEGORIES: [&str; 2] = [LintCategory::Config.as_str(), LintCategory::Irule.as_str()];
 /// The finding severities, in fixed order.
 pub const SEVERITIES: [&str; 3] = ["error", "warning", "info"];
+
+/// Closed vocabulary backing [`CATEGORIES`]. [`Finding::category`] (the JSON
+/// report's `"category"` field) and [`run_lint`]'s `category` filter argument
+/// (the CLI `--category config|irule` spelling) both use this internally, but
+/// the wire spelling itself — the JSON string value, the CLI `value_parser` list
+/// — stays `"config"`/`"irule"` via [`LintCategory::as_str`]/`FromStr`, unchanged
+/// from before this enum existed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LintCategory {
+    /// The BIG-IP model / config-structure rules.
+    Config,
+    /// The iRule-body rules.
+    Irule,
+}
+
+impl LintCategory {
+    /// The wire spelling: `"config"` or `"irule"`.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            LintCategory::Config => "config",
+            LintCategory::Irule => "irule",
+        }
+    }
+}
+
+impl std::str::FromStr for LintCategory {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "config" => Ok(LintCategory::Config),
+            "irule" => Ok(LintCategory::Irule),
+            _ => Err(()),
+        }
+    }
+}
+
+impl std::fmt::Display for LintCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 /// One lint finding.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -47,8 +90,8 @@ pub struct Finding {
     pub rule_id: String,
     /// `"error"`, `"warning"`, or `"info"`.
     pub severity: &'static str,
-    /// `"config"` or `"irule"`.
-    pub category: &'static str,
+    /// [`LintCategory::Config`] or [`LintCategory::Irule`].
+    pub category: LintCategory,
     /// The object full-path the finding is about.
     pub full_path: String,
     /// Human-readable message.
@@ -290,7 +333,7 @@ fn rule_orphan_monitor(view: &ModelView<'_>, out: &mut Vec<Finding>) {
             out.push(Finding {
                 rule_id: "orphan-monitor".to_owned(),
                 severity: "info",
-                category: "config",
+                category: LintCategory::Config,
                 full_path: path.to_owned(),
                 message: "monitor not referenced by any pool in this config".to_owned(),
             });
@@ -298,7 +341,7 @@ fn rule_orphan_monitor(view: &ModelView<'_>, out: &mut Vec<Finding>) {
             out.push(Finding {
                 rule_id: "orphan-monitor".to_owned(),
                 severity: "warning",
-                category: "config",
+                category: LintCategory::Config,
                 full_path: path.to_owned(),
                 message: "monitor not referenced by any pool".to_owned(),
             });
@@ -331,7 +374,7 @@ fn rule_empty_pool(view: &ModelView<'_>, out: &mut Vec<Finding>) {
             out.push(Finding {
                 rule_id: "empty-pool".to_owned(),
                 severity: "warning",
-                category: "config",
+                category: LintCategory::Config,
                 full_path: path.to_owned(),
                 message: "pool has no members".to_owned(),
             });
@@ -352,7 +395,7 @@ fn rule_virtual_without_pool(view: &ModelView<'_>, out: &mut Vec<Finding>) {
         out.push(Finding {
             rule_id: "virtual-without-pool".to_owned(),
             severity: "info",
-            category: "config",
+            category: LintCategory::Config,
             full_path: path.to_owned(),
             message: "virtual has no default pool and no iRules attached".to_owned(),
         });
@@ -375,7 +418,7 @@ fn rule_pool_without_monitor(view: &ModelView<'_>, out: &mut Vec<Finding>) {
         out.push(Finding {
             rule_id: "pool-without-monitor".to_owned(),
             severity: "warning",
-            category: "config",
+            category: LintCategory::Config,
             full_path: path.to_owned(),
             message: "pool has no health monitor (pool-level or per-member)".to_owned(),
         });
@@ -404,7 +447,7 @@ fn rule_irule_deprecated_command(view: &ModelView<'_>, out: &mut Vec<Finding>) {
                 out.push(Finding {
                     rule_id: "irule-deprecated-command".to_owned(),
                     severity: "warning",
-                    category: "irule",
+                    category: LintCategory::Irule,
                     full_path: path.to_owned(),
                     message: (*msg).to_owned(),
                 });
@@ -424,7 +467,7 @@ fn rule_irule_empty_when(view: &ModelView<'_>, out: &mut Vec<Finding>) {
             out.push(Finding {
                 rule_id: "irule-empty-when".to_owned(),
                 severity: "info",
-                category: "irule",
+                category: LintCategory::Irule,
                 full_path: path.to_owned(),
                 message: "iRule contains a `when` block with no statements".to_owned(),
             });
@@ -447,7 +490,7 @@ fn rule_irule_unknown_event(view: &ModelView<'_>, events: &EventRegistry, out: &
                 out.push(Finding {
                     rule_id: "irule-unknown-event".to_owned(),
                     severity: "warning",
-                    category: "irule",
+                    category: LintCategory::Irule,
                     full_path: path.to_owned(),
                     message: format!("iRule references unknown event {}", py_repr(&block.event)),
                 });
@@ -562,7 +605,7 @@ fn rule_irule_missing_object(
             out.push(Finding {
                 rule_id: format!("irule-missing-{kind}"),
                 severity: "warning",
-                category: "irule",
+                category: LintCategory::Irule,
                 full_path: path.to_owned(),
                 message: format!(
                     "iRule references {kind} {} (via `{}`) but no such object exists",
@@ -603,9 +646,12 @@ pub fn run_lint(
     let mut findings: Vec<Finding> = Vec::new();
 
     // The config-category rules, then the irule-category rules, in the fixed
-    // registration order.
-    let run_config = matches!(category, None | Some("config"));
-    let run_irule = matches!(category, None | Some("irule"));
+    // registration order. An unparseable `category` (neither "config" nor
+    // "irule") matches neither — same as before this enum, when it compared
+    // the raw string against both literals and matched neither.
+    let parsed_category = category.map(str::parse::<LintCategory>);
+    let run_config = matches!(parsed_category, None | Some(Ok(LintCategory::Config)));
+    let run_irule = matches!(parsed_category, None | Some(Ok(LintCategory::Irule)));
 
     if run_config {
         rule_orphan_monitor(&view, &mut findings);

--- a/rust/tcl-compiler/src/taint_interproc.rs
+++ b/rust/tcl-compiler/src/taint_interproc.rs
@@ -53,72 +53,100 @@ use crate::value_shapes::parse_command_substitution;
 
 // Basis lattices
 
-/// Ordered taint-colour bases. The
-/// per-parameter return scenarios are computed by seeding the parameter with
-/// each basis lattice in turn.
-const BASIS_ORDER: [&str; 17] = [
-    "generic",
-    "path",
-    "non_dash",
-    "crlf_free",
-    "shell_atom",
-    "list_canonical",
-    "regex_literal",
-    "path_normalised",
-    "path_bounded",
-    "header_token_safe",
-    "html_escaped",
-    "url_encoded",
-    "ip",
-    "port",
-    "fqdn",
-    "path_joined",
-    "channel",
-];
-
-/// The taint lattice each basis name seeds a parameter with.
-fn basis_lattice(basis: &str) -> TaintLattice {
-    let t = TaintColour::TAINTED;
-    let colour = match basis {
-        "generic" => t,
-        "path" => t | TaintColour::PATH_PREFIXED,
-        "non_dash" => t | TaintColour::NON_DASH_PREFIXED,
-        "crlf_free" => t | TaintColour::CRLF_FREE,
-        "shell_atom" => t | TaintColour::SHELL_ATOM,
-        "list_canonical" => t | TaintColour::LIST_CANONICAL,
-        "regex_literal" => t | TaintColour::REGEX_LITERAL,
-        "path_normalised" => t | TaintColour::PATH_NORMALISED,
-        // PATH_BOUNDED is set alongside PATH_NORMALISED (the basis entry is
-        // reserved for future branch-dependent refinement).
-        "path_bounded" => t | TaintColour::PATH_NORMALISED | TaintColour::PATH_BOUNDED,
-        "header_token_safe" => t | TaintColour::HEADER_TOKEN_SAFE,
-        "html_escaped" => t | TaintColour::HTML_ESCAPED,
-        "url_encoded" => t | TaintColour::URL_ENCODED,
-        "ip" => t | TaintColour::IP_ADDRESS,
-        "port" => t | TaintColour::PORT,
-        "fqdn" => t | TaintColour::FQDN,
-        "path_joined" => t | TaintColour::PATH_JOINED,
-        "channel" => t | TaintColour::CHANNEL,
-        unknown => panic!("BASIS_ORDER contains unknown taint basis {unknown:?}"),
-    };
-    TaintLattice { colours: colour }
+/// Closed vocabulary of taint-colour bases. The per-parameter return
+/// scenarios are computed by seeding the parameter with each basis lattice in
+/// turn, in [`TaintBasis::ALL`] order (which fixes `return_by_param_basis`'s
+/// index-to-basis mapping).
+///
+/// Purely an internal solver vocabulary: never serialised, never a CLI/`.tclspec`
+/// spelling, so no `FromStr`/`Display` boundary is needed (unlike the
+/// dialect-name discipline in #1405).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum TaintBasis {
+    Generic,
+    Path,
+    NonDash,
+    CrlfFree,
+    ShellAtom,
+    ListCanonical,
+    RegexLiteral,
+    PathNormalised,
+    PathBounded,
+    HeaderTokenSafe,
+    HtmlEscaped,
+    UrlEncoded,
+    Ip,
+    Port,
+    Fqdn,
+    PathJoined,
+    Channel,
 }
 
-/// Basis names whose lattice colour intersects `taint`'s colour, excluding
-/// `"generic"` (falling back to `["generic"]` when none match).
-fn basis_names_for_taint(taint: TaintLattice) -> Vec<&'static str> {
+impl TaintBasis {
+    /// Ordered taint-colour bases, fixing the index used by
+    /// `return_by_param_basis`.
+    const ALL: [TaintBasis; 17] = [
+        TaintBasis::Generic,
+        TaintBasis::Path,
+        TaintBasis::NonDash,
+        TaintBasis::CrlfFree,
+        TaintBasis::ShellAtom,
+        TaintBasis::ListCanonical,
+        TaintBasis::RegexLiteral,
+        TaintBasis::PathNormalised,
+        TaintBasis::PathBounded,
+        TaintBasis::HeaderTokenSafe,
+        TaintBasis::HtmlEscaped,
+        TaintBasis::UrlEncoded,
+        TaintBasis::Ip,
+        TaintBasis::Port,
+        TaintBasis::Fqdn,
+        TaintBasis::PathJoined,
+        TaintBasis::Channel,
+    ];
+
+    /// The taint lattice this basis seeds a parameter with.
+    fn lattice(self) -> TaintLattice {
+        let t = TaintColour::TAINTED;
+        let colour = match self {
+            TaintBasis::Generic => t,
+            TaintBasis::Path => t | TaintColour::PATH_PREFIXED,
+            TaintBasis::NonDash => t | TaintColour::NON_DASH_PREFIXED,
+            TaintBasis::CrlfFree => t | TaintColour::CRLF_FREE,
+            TaintBasis::ShellAtom => t | TaintColour::SHELL_ATOM,
+            TaintBasis::ListCanonical => t | TaintColour::LIST_CANONICAL,
+            TaintBasis::RegexLiteral => t | TaintColour::REGEX_LITERAL,
+            TaintBasis::PathNormalised => t | TaintColour::PATH_NORMALISED,
+            // PATH_BOUNDED is set alongside PATH_NORMALISED (the basis entry
+            // is reserved for future branch-dependent refinement).
+            TaintBasis::PathBounded => t | TaintColour::PATH_NORMALISED | TaintColour::PATH_BOUNDED,
+            TaintBasis::HeaderTokenSafe => t | TaintColour::HEADER_TOKEN_SAFE,
+            TaintBasis::HtmlEscaped => t | TaintColour::HTML_ESCAPED,
+            TaintBasis::UrlEncoded => t | TaintColour::URL_ENCODED,
+            TaintBasis::Ip => t | TaintColour::IP_ADDRESS,
+            TaintBasis::Port => t | TaintColour::PORT,
+            TaintBasis::Fqdn => t | TaintColour::FQDN,
+            TaintBasis::PathJoined => t | TaintColour::PATH_JOINED,
+            TaintBasis::Channel => t | TaintColour::CHANNEL,
+        };
+        TaintLattice { colours: colour }
+    }
+}
+
+/// Bases whose lattice colour intersects `taint`'s colour, excluding
+/// [`TaintBasis::Generic`] (falling back to `[Generic]` when none match).
+fn basis_names_for_taint(taint: TaintLattice) -> Vec<TaintBasis> {
     if !taint.is_tainted() {
         return Vec::new();
     }
-    let mut names: Vec<&'static str> = BASIS_ORDER
-        .iter()
-        .copied()
+    let mut names: Vec<TaintBasis> = TaintBasis::ALL
+        .into_iter()
         .filter(|basis| {
-            *basis != "generic" && basis_lattice(basis).colours.intersects(taint.colours)
+            *basis != TaintBasis::Generic && basis.lattice().colours.intersects(taint.colours)
         })
         .collect();
     if names.is_empty() {
-        names.push("generic");
+        names.push(TaintBasis::Generic);
     }
     names
 }
@@ -141,9 +169,9 @@ pub struct ProcTaintSummary {
     pub arity: Arity,
     /// Taint the call returns when no parameter is tainted.
     pub return_base: TaintLattice,
-    /// Per-parameter return taint, indexed by [`BASIS_ORDER`]: for each
+    /// Per-parameter return taint, indexed by [`TaintBasis::ALL`]: for each
     /// `(param, [taint_per_basis])`, `taint_per_basis[i]` is the taint the
-    /// call returns when `param` is seeded with `BASIS_ORDER[i]`'s lattice.
+    /// call returns when `param` is seeded with `TaintBasis::ALL[i]`'s lattice.
     pub return_by_param_basis: Vec<(String, Vec<TaintLattice>)>,
 }
 
@@ -165,7 +193,7 @@ impl ProcTaintSummary {
             return_base: clean,
             return_by_param_basis: params
                 .iter()
-                .map(|p| (p.clone(), vec![clean; BASIS_ORDER.len()]))
+                .map(|p| (p.clone(), vec![clean; TaintBasis::ALL.len()]))
                 .collect(),
         }
     }
@@ -227,7 +255,10 @@ pub fn apply_proc_return_summary(
             continue;
         }
         for basis in basis_names_for_taint(*t) {
-            let idx = BASIS_ORDER.iter().position(|b| *b == basis).unwrap_or(0);
+            let idx = TaintBasis::ALL
+                .iter()
+                .position(|b| *b == basis)
+                .unwrap_or(0);
             out = out.join(summary.scenario(p, idx));
         }
     }
@@ -327,7 +358,7 @@ fn collect_return_taint(
 /// taints and summaries. A thin wrapper threading the common arguments.
 ///
 /// `graph` carries the CFG-derived indices, built once by the caller: one
-/// summary inference runs this `1 + params × BASIS_ORDER` times and the
+/// summary inference runs this `1 + params × TaintBasis::ALL` times and the
 /// indices are identical across all of them (issue #1251).
 fn run_propagation(
     graph: &TaintGraph<'_>,
@@ -394,8 +425,8 @@ pub type InferProcSummaryFn<'a> = dyn FnMut(
 /// # Cost
 ///
 /// The summary is a transfer function: a clean base plus, for each parameter, a
-/// return taint per [`BASIS_ORDER`] entry.  Computed naively that is
-/// `1 + BASIS_ORDER.len() * params.len()` — `1 + 17P` — complete dataflow
+/// return taint per [`TaintBasis::ALL`] entry.  Computed naively that is
+/// `1 + TaintBasis::ALL.len() * params.len()` — `1 + 17P` — complete dataflow
 /// solves over the procedure's CFG, and this is the dominant cost of the whole
 /// interprocedural taint pass (about 80% of `run_all_checks` on tcllib's
 /// `practcl.tcl`).
@@ -465,13 +496,13 @@ pub fn infer_proc_summary(
         // it directly.  (This is a proof, not an approximation: the two runs
         // differ in no input.)
         if fu.ssa.var_symbol(param).is_none() {
-            by_param_basis.push((param.clone(), vec![return_base; BASIS_ORDER.len()]));
+            by_param_basis.push((param.clone(), vec![return_base; TaintBasis::ALL.len()]));
             continue;
         }
-        let mut scenario_values: Vec<TaintLattice> = Vec::with_capacity(BASIS_ORDER.len());
-        for basis in BASIS_ORDER {
+        let mut scenario_values: Vec<TaintLattice> = Vec::with_capacity(TaintBasis::ALL.len());
+        for basis in TaintBasis::ALL {
             let mut seed: HashMap<String, TaintLattice> = HashMap::new();
-            seed.insert(param.clone(), basis_lattice(basis));
+            seed.insert(param.clone(), basis.lattice());
             let seeded = run_propagation(
                 &graph,
                 fu,
@@ -1077,6 +1108,68 @@ mod tests {
     }
 
     #[test]
+    fn taint_basis_lattice_matches_expected_colours() {
+        // Mutation guard for the basis-name -> lattice mapping (issue #1614):
+        // pins each `TaintBasis` variant to its exact expected `TaintColour`
+        // set. Swapping which colour two variants map to (e.g. giving `Path`
+        // `NON_DASH_PREFIXED` and `NonDash` `PATH_PREFIXED`) flips two of
+        // these assertions and fails the test — the array/match could
+        // silently drift before #1614 (that was the whole point of the
+        // `panic!` fallthrough this enum removes), so this test is the
+        // regression net the exhaustiveness alone doesn't provide.
+        let t = TaintColour::TAINTED;
+        let expected: [(TaintBasis, TaintColour); 17] = [
+            (TaintBasis::Generic, t),
+            (TaintBasis::Path, t | TaintColour::PATH_PREFIXED),
+            (TaintBasis::NonDash, t | TaintColour::NON_DASH_PREFIXED),
+            (TaintBasis::CrlfFree, t | TaintColour::CRLF_FREE),
+            (TaintBasis::ShellAtom, t | TaintColour::SHELL_ATOM),
+            (TaintBasis::ListCanonical, t | TaintColour::LIST_CANONICAL),
+            (TaintBasis::RegexLiteral, t | TaintColour::REGEX_LITERAL),
+            (TaintBasis::PathNormalised, t | TaintColour::PATH_NORMALISED),
+            (
+                TaintBasis::PathBounded,
+                t | TaintColour::PATH_NORMALISED | TaintColour::PATH_BOUNDED,
+            ),
+            (
+                TaintBasis::HeaderTokenSafe,
+                t | TaintColour::HEADER_TOKEN_SAFE,
+            ),
+            (TaintBasis::HtmlEscaped, t | TaintColour::HTML_ESCAPED),
+            (TaintBasis::UrlEncoded, t | TaintColour::URL_ENCODED),
+            (TaintBasis::Ip, t | TaintColour::IP_ADDRESS),
+            (TaintBasis::Port, t | TaintColour::PORT),
+            (TaintBasis::Fqdn, t | TaintColour::FQDN),
+            (TaintBasis::PathJoined, t | TaintColour::PATH_JOINED),
+            (TaintBasis::Channel, t | TaintColour::CHANNEL),
+        ];
+        assert_eq!(expected.len(), TaintBasis::ALL.len());
+        for (basis, colour) in expected {
+            assert_eq!(
+                basis.lattice(),
+                TaintLattice { colours: colour },
+                "{basis:?} mapped to an unexpected lattice"
+            );
+        }
+        // Every non-generic basis is pairwise distinct — a swap between two
+        // bases (rather than a wrong constant) still fails via `intersects`
+        // returning true for both instead of one.
+        for i in 1..TaintBasis::ALL.len() {
+            for j in (i + 1)..TaintBasis::ALL.len() {
+                let a = TaintBasis::ALL[i].lattice();
+                let b = TaintBasis::ALL[j].lattice();
+                assert_ne!(
+                    a,
+                    b,
+                    "{:?} and {:?} must map to distinct lattices",
+                    TaintBasis::ALL[i],
+                    TaintBasis::ALL[j]
+                );
+            }
+        }
+    }
+
+    #[test]
     fn cross_proc_entry_taint_into_sink_warns() {
         // A tainted argument flowing into a proc parameter and then into a
         // sink inside that proc is reported (cross-proc entry-taint) — the
@@ -1168,9 +1261,9 @@ mod tests {
         let mut by_param_basis = Vec::new();
         for param in &proc.params {
             let mut values = Vec::new();
-            for basis in BASIS_ORDER {
+            for basis in TaintBasis::ALL {
                 let mut seed = HashMap::new();
-                seed.insert(param.clone(), basis_lattice(basis));
+                seed.insert(param.clone(), basis.lattice());
                 let seeded =
                     run_propagation(&graph, fu, &reg, interproc, None, Some(&seed), &summaries);
                 values.push(collect_return_taint(fu, &seeded, ctx));
@@ -1255,7 +1348,7 @@ mod tests {
             .find(|(p, _)| p == "b")
             .expect("parameter b recorded");
         assert_eq!(name, "b");
-        assert_eq!(values.len(), BASIS_ORDER.len());
+        assert_eq!(values.len(), TaintBasis::ALL.len());
         assert!(
             values.iter().all(|v| *v == s.return_base),
             "unread parameter must reproduce the base return, got {values:?}"


### PR DESCRIPTION
## Summary

Six independent, per-site commits converting closed `&str` vocabularies to enums, per the verified inventory in #1614. Each site keeps every wire spelling (CLI arg, JSON field, diagram text, error message) byte-identical — the enum is internal dispatch only, with `FromStr`/`as_str`/`Display` at the boundary. One site (tcl-cli diff formats) is confirmed to have nothing to convert.

### Per-site what/why

1. **Taint basis names** (`rust/tcl-compiler/src/taint_interproc.rs`) — highest value: `BASIS_ORDER: [&str; 17]` was paired with `basis_lattice(&str)`, whose fallthrough arm was `panic!("BASIS_ORDER contains unknown taint basis {unknown:?}")` — the compiler couldn't see the array and match were the same set. Added `TaintBasis`, a 17-variant enum with `TaintBasis::ALL` fixing the same index order `return_by_param_basis` relies on; the match is now exhaustive and the `panic!` arm is gone. Purely an internal solver vocabulary — verified never serialised (JSON, `.tclspec`, CLI arg) — so no `FromStr`/`Display` needed.
2. **tcl-bigip graph formats** (`graph.rs`) — `GRAPH_FORMATS` validated once then re-matched by string with a `_ => to_mermaid(...)` catch-all. Added `GraphFormat` (Dot/Json/Mermaid); `export_graph`'s public `fmt: &str` signature is unchanged (the CLI `--format` spelling), parsed once into the enum for exhaustive dispatch (no catch-all).
3. **tcl-bigip grep directions** (`grep.rs`) — `DIRECTIONS` re-matched by string at both BFS direction checks. Added `GrepDirection` with `walks_forward()`/`walks_reverse()`; `GrepArgs::direction`/`GrepReport::direction` (CLI input / JSON-text output) stay `&str`/`String` unchanged.
4. **tcl-bigip lint categories** (`lint.rs`) — `CATEGORIES` with `Finding::category: &'static str` set from literals at 8 sites. Added `LintCategory` (Config/Irule); `Finding::category` is now the enum, `run_lint`'s `category: Option<&str>` CLI-filter parameter is unchanged. `f5-cli`'s JSON renderer needed one `.as_str()` call at its only consumer.
5. **Mermaid directions** (`tcl-bigip-query/src/renderers/mermaid.rs`) — `DIRECTIONS` validated then interpolated straight into `graph {direction}`. Added `MermaidDirection`; `render()` parses once and threads the enum (not the raw string) into `render_chain`, which `Display`s it back out.
6. **f5-cli tmsh kinds** (`commands/explain.rs`) — `kind: &str` threaded through `Model::inv/get/resolve` and the `kind_hint` walker, six spellings matched by literal at every site. Added `ExplainKind` (Virtual/Pool/Profile/Persistence/Rule/SnatPool); `ExplainReport::kind`/`ExplainJson::kind` (JSON/text output) stay `String`, populated via `ExplainKind::as_str()`. `diff.rs`'s `SPECIALISED` (module, object_type) vocabulary — cited in the issue only as an example of the same *pattern* elsewhere — has three more members and a different shape; left alone as out of scope.
7. **tcl-cli diff formats** — confirmed, not converted: `rust/tcl-cli/src/cli.rs`'s `--json` is a genuine `bool` (JSON vs. unified-diff), not a format string. There is nothing to convert here, as the issue itself suspected.

## Boundary-check table

| Vocabulary | Serialised where? | Spelling pinned how? |
|---|---|---|
| Taint basis names | Nowhere (internal solver only) | N/A — verified no JSON/`.tclspec`/CLI surface |
| Graph export format | CLI `--format` arg; `GraphExport.fmt` echo | `export_graph`'s `&str` signature unchanged; `graph_export` integration suite (golden fixtures per format + reject-unknown-format test) |
| Grep direction | CLI `--direction` arg; JSON `"direction"` field; text `# Direction:` line | `GrepArgs`/`GrepReport` types unchanged; f5-cli's `grep_forward`/`grep_reverse`/`grep_both`/`grep_json` golden fixtures |
| Lint category | JSON `"category"` field; CLI `--category` filter arg | `run_lint`'s `Option<&str>` unchanged; new `json_category_field_is_config_or_irule` test through the CLI binary |
| Mermaid direction | Diagram text `graph {direction}`; error message | `MermaidDirection: Display` reproduces the exact 2-letter spelling; existing `mermaid_direction_lowercased_and_validated` (tcl-bigip-query) + `mermaid_bad_direction`/`mermaid_direction_tb` (f5-cli, through the CLI binary) |
| Explain kind | JSON `"kind"` field; text `explain {kind}:` header | `ExplainReport`/`ExplainJson::kind` stay `String`; `explain_virtual.{text,json}.golden` fixtures |

## Mutation evidence

Taint basis is the only site feeding security analysis (issue's own call-out). Added `taint_basis_lattice_matches_expected_colours`, pinning every basis to its exact `TaintColour` set plus pairwise distinctness. Verified locally: swapped `Path`'s and `NonDash`'s colours, re-ran the test — it failed (`assertion left == right failed: Path mapped to an unexpected lattice`) — then reverted. The full `tcl-compiler` test suite (5900 lib tests + all integration suites) stayed green throughout.

## Gates run (all commands prefixed `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=2`)

- `cargo fmt --all --check` — clean
- `cargo clippy -p tcl-compiler -p tcl-bigip -p tcl-bigip-query -p f5-cli --all-targets` — clean, zero new allows
- `cargo check --workspace` — clean
- `cargo test -p tcl-compiler` (5900 lib + all integration incl. `taint`/`taint_depth`/`fp_depth`) — green
- `cargo test -p tcl-lsp-core` (consumer, 2086+ tests across all suites) — green
- `cargo test -p tcl-vm` (consumer, full suite) — green
- `cargo test -p tcl-bigip -p tcl-bigip-query` — green
- `cargo test -p f5-cli` (full suite, incl. `grep`/`validate`/`irule`/`cli`/`explain_flow`/`query_render`) — green

Rebased onto `origin/rust` at `9ff015851` (post-#1674) with no conflicts; all gates re-run green after rebase.

## Adversary pass

Re-read the full diff hunting for behaviour changes. Found and fixed one bug during self-review: a blanket literal-replacement pass in `explain.rs` incorrectly turned two unrelated `serde_json::Value::get("snatpool"/"pool")` calls into `Value::get(ExplainKind::...)` (they read JSON object fields, not the `Model`'s kind-indexed inventory) — reverted those two before commit. No other behaviour changes: every error message, JSON key, CLI arg spelling, and diagram/text output byte confirmed unchanged via existing or new golden/integration tests.

Fixes #1614

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o)_