### PR TITLE
fix(analyser): an untyped body that runs now can block the fall-through walk

### DIFF
--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -6988,23 +6988,13 @@ impl Analyser {
                 // Untyped is not the same as irrelevant (issue #1672). The
                 // registry types the arms whose *selection* it models; a body
                 // it does not type is still a body, and unless the command
-                // declared that it stores one, it runs it here. Whether
-                // control reaches the next statement is then exactly whether
-                // that body falls through — the same requirement `Always` and
-                // `FrameBoundary` carry, reached without a descriptor.
-                //
-                // `uplevel 1 {error stop}`, `eval {error stop}` and
-                // `oo::define C {error stop}` were walked past on the strength
-                // of having no descriptor, while tclsh 8.6.16 / 9.0.4 both
-                // never reach the statement after them. A `proc` declaration's
-                // body is the case the exemption exists for: it cannot run
-                // here, so `proc helper {a} {return $a}` still falls through.
+                // declared that it stores one (`DEFERS_BODY`), it runs it
+                // here — so `uplevel 1 {error stop}`, `eval {error stop}` and
+                // `oo::define C {error stop}` cannot be walked past on the
+                // strength of having no descriptor, which is what this branch
+                // used to do.
                 if self.body_runs_now(&arm.controller)
-                    && !self.static_prefix_falls_through(
-                        arm.body_span,
-                        arm.body_span.end(),
-                        depth + 1,
-                    )
+                    && self.untyped_body_provably_blocks(arm.body_span, depth + 1)
                 {
                     return false;
                 }
@@ -7359,7 +7349,7 @@ impl Analyser {
         {
             return true;
         }
-        !self.body_runs_now(seg)
+        self.body_runs_now(seg)
     }
 
     /// Whether `seg` runs its body argument as part of **this** invocation.
@@ -7387,6 +7377,66 @@ impl Analyser {
         !registry
             .invocation_traits(seg.name(), &args, self.profile.availability_mask)
             .contains(tcl_registry::Traits::DEFERS_BODY)
+    }
+
+    /// Whether a body the registry gives **no** control-arm semantics for is
+    /// proved to stop control before its own end (issue #1672).
+    ///
+    /// The typed arms above ask the opposite question — *prove* the body falls
+    /// through, or abstain — because a descriptor says what the body is for. An
+    /// untyped body carries no such promise, and asking it to prove
+    /// fall-through would abstain on every script written in a vocabulary this
+    /// walk does not model. A class definition script is the case that settles
+    /// it: `oo::class create C { superclass D }` is an untyped body running
+    /// now, and `superclass` is a definition command, not a command — nothing
+    /// here can type it, so demanding a proof of fall-through would abstain on
+    /// the one construct the computed-metaclass walk exists to read (the tcllib
+    /// clay corpus, issue #1571, is built out of exactly these).
+    ///
+    /// So the burden runs the other way: the enclosing statement is walked past
+    /// unless *this* body proves it blocks. Both proofs are registry-owned and
+    /// oracle-checked against tclsh 8.6.16 and 9.0.4, which agree exactly:
+    ///
+    /// * [`InvocationCompletion::Terminates`] — `uplevel 1 {error stop}`,
+    ///   `eval {error stop}`, `oo::define C {error stop}`: the statement after
+    ///   them never runs;
+    /// * [`InvocationCompletion::ReturnsResult`] — `oo::define C {return}`,
+    ///   `eval {return}`, `uplevel 1 {return}`: likewise, the completion
+    ///   propagates out of the body rather than ending at it.
+    ///
+    /// A statement whose completion is [`InvocationCompletion::Unknown`] ends
+    /// the scan with no proof, which leaves the enclosing walk exactly where it
+    /// was before this rule existed. That is the honest limit of an untyped
+    /// body, and it is why nested control inside one (`oo::define C {if {$x}
+    /// {error stop} else {error stop}}`) is not detected: the `if` itself
+    /// completes normally as far as the registry is concerned, and reading its
+    /// arms is the typed question this branch does not have an answer for.
+    ///
+    /// [`InvocationCompletion::Terminates`]: tcl_registry::registry::InvocationCompletion::Terminates
+    /// [`InvocationCompletion::ReturnsResult`]: tcl_registry::registry::InvocationCompletion::ReturnsResult
+    /// [`InvocationCompletion::Unknown`]: tcl_registry::registry::InvocationCompletion::Unknown
+    fn untyped_body_provably_blocks(&mut self, body_span: Span, depth: u32) -> bool {
+        if depth >= MAX_UNKNOWN_BODY_DEPTH || self.registry.is_none() {
+            return false;
+        }
+        let Some(statements) = self.direct_statements_in_span(body_span) else {
+            return false;
+        };
+        for seg in statements {
+            if self.static_statement_falls_through(&seg, depth) {
+                continue;
+            }
+            let Some(registry) = self.registry.as_deref() else {
+                return false;
+            };
+            let args: Vec<&str> = seg.args().iter().map(String::as_str).collect();
+            return matches!(
+                registry.invocation_completion(seg.name(), &args, self.profile.availability_mask),
+                tcl_registry::registry::InvocationCompletion::Terminates
+                    | tcl_registry::registry::InvocationCompletion::ReturnsResult(_)
+            );
+        }
+        false
     }
 
     fn control_arms_for_segment(&self, seg: &SegmentedCommand) -> ControlArms {

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -6985,6 +6985,29 @@ impl Analyser {
                 if is_control {
                     return false;
                 }
+                // Untyped is not the same as irrelevant (issue #1672). The
+                // registry types the arms whose *selection* it models; a body
+                // it does not type is still a body, and unless the command
+                // declared that it stores one, it runs it here. Whether
+                // control reaches the next statement is then exactly whether
+                // that body falls through — the same requirement `Always` and
+                // `FrameBoundary` carry, reached without a descriptor.
+                //
+                // `uplevel 1 {error stop}`, `eval {error stop}` and
+                // `oo::define C {error stop}` were walked past on the strength
+                // of having no descriptor, while tclsh 8.6.16 / 9.0.4 both
+                // never reach the statement after them. A `proc` declaration's
+                // body is the case the exemption exists for: it cannot run
+                // here, so `proc helper {a} {return $a}` still falls through.
+                if self.body_runs_now(&arm.controller)
+                    && !self.static_prefix_falls_through(
+                        arm.body_span,
+                        arm.body_span.end(),
+                        depth + 1,
+                    )
+                {
+                    return false;
+                }
                 continue;
             };
             saw_typed_arm = true;
@@ -7336,6 +7359,31 @@ impl Analyser {
         {
             return true;
         }
+        !self.body_runs_now(seg)
+    }
+
+    /// Whether `seg` runs its body argument as part of **this** invocation.
+    ///
+    /// The one place that answers it, for both the unreadable-body question
+    /// above and the untyped-arm question in
+    /// [`Self::static_statement_falls_through`] (issue #1672) — the two were
+    /// the same question asked in two places, and only one of them was asking
+    /// it.
+    ///
+    /// Registry data, never an inference: [`Traits::DEFERS_BODY`] is declared
+    /// by the commands that *store* a script (`proc`, `after`'s scheduling
+    /// forms, the iRules `when` registration), and everything that has not
+    /// declared it is assumed to run its body now. That default is the
+    /// abstaining direction — a body that runs can raise or return before the
+    /// walk reaches the statement it cares about, while a body that is merely
+    /// stored cannot.
+    ///
+    /// [`Traits::DEFERS_BODY`]: tcl_registry::Traits::DEFERS_BODY
+    fn body_runs_now(&self, seg: &SegmentedCommand) -> bool {
+        let Some(registry) = self.registry.as_deref() else {
+            return true;
+        };
+        let args: Vec<&str> = seg.args().iter().map(String::as_str).collect();
         !registry
             .invocation_traits(seg.name(), &args, self.profile.availability_mask)
             .contains(tcl_registry::Traits::DEFERS_BODY)

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -6131,10 +6131,31 @@ mod class_factories {
         // `after` is the same fact with a different mechanism: the script is
         // scheduled, not run, so both oracles reach the creation even when the
         // scheduled script would raise.
+        // The rest of the list is the widened audit PR #1676's review asked
+        // for: reading the *absence* of `DEFERS_BODY` as "runs now" makes a
+        // missing trait a silent wrong answer, so every store-only form the
+        // registry ships was enumerated and measured. Each row below is one
+        // that gained the trait, and each was proved on tclsh 8.6.16 and
+        // 9.0.4 with `proc p {} { FORM {error stop}; set ::reached 1 }` —
+        // `::reached` is set on both for all of them.
         for prefix in [
             "    proc helper {a} {return $a}\n",
             "    after 0 {error stop}\n",
             "    after idle {error stop}\n",
+            "    package ifneeded probe 1.0 {error stop}\n",
+            "    fileevent $ch readable {error stop}\n",
+            "    ::tcl::OptProc probe {} {error stop}\n",
+            "    tcltest::loadScript {error stop}\n",
+            "    lambda {} {error stop}\n",
+            "    lambda@ :: {} {error stop}\n",
+            "    defer::defer {error stop}\n",
+            "    defer::with {} {error stop}\n",
+            "    defer::autowith {error stop}\n",
+            "    processman::onexit probe {error stop}\n",
+            "    report::defstyle probe {} {error stop}\n",
+            "    snit::macro probe {} {error stop}\n",
+            "    snit::method ::T probe {} {error stop}\n",
+            "    snit::typemethod ::T probe {} {error stop}\n",
         ] {
             let src = COMPUTED_METACLASS.replace(
                 "    ::T::Mother create ${NSPACE}::class { superclass ::T::Mother }\n",

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -6048,6 +6048,110 @@ mod class_factories {
     }
 
     #[test]
+    fn a_readable_body_that_runs_now_but_is_untyped_still_abstains() {
+        // TP (#1672) — the readable twin of the #1652 guard. These commands
+        // carry no typed control-arm semantics, so the arm they contribute was
+        // *ignored*: the walk claimed the creation below on the strength of
+        // having no descriptor, not on any reading of the body.
+        //
+        // Every one of them runs its script as part of this call, and tclsh
+        // 8.6.16 / 9.0.4 agree the statement after it is not reached — the
+        // class does not exist afterwards — for both blocking completions the
+        // registry can prove: a raise (`error stop`, `Terminates`) and a
+        // propagating return (`return`, `ReturnsResult`). The `return` row is
+        // not merely the conservative reading: both interpreters really do
+        // leave the enclosing procedure, `oo::define`'s definition script
+        // included.
+        for prefix in [
+            "    uplevel 1 {error stop}\n",
+            "    eval {error stop}\n",
+            "    oo::define ::T::Mother {error stop}\n",
+            "    uplevel 1 {return}\n",
+            "    eval {return}\n",
+            "    oo::define ::T::Mother {return}\n",
+        ] {
+            let src = COMPUTED_METACLASS.replace(
+                "    ::T::Mother create ${NSPACE}::class { superclass ::T::Mother }\n",
+                &format!(
+                    "{prefix}    ::T::Mother create ${{NSPACE}}::class {{ superclass ::T::Mother }}\n"
+                ),
+            );
+            let result = analysis(&src, "tcl9.0");
+            assert!(
+                !result.all_classes.contains_key("::T::D::class"),
+                "an aborting body that runs now must abstain: {prefix:?}; got {:?}",
+                result.all_classes.keys().collect::<Vec<_>>()
+            );
+        }
+    }
+
+    #[test]
+    fn a_readable_body_that_runs_now_and_completes_is_not_a_blocker() {
+        // TP control: the rule must cost nothing when the body does not block.
+        // tclsh 8.6.16 / 9.0.4 agree the class *is* created after every prefix
+        // here.
+        //
+        // The third vector is the one that sets the burden of proof. A
+        // definition script is written in a vocabulary this walk cannot type —
+        // `method` is not a command, it is a word `oo::define` understands —
+        // so requiring an untyped body to *prove* it falls through would
+        // abstain here, and on `oo::class create C { superclass D }`, which is
+        // the construct the computed-metaclass walk exists to read. The rule is
+        // therefore the other way round: walk past unless the body proves it
+        // blocks (see `untyped_body_provably_blocks`).
+        for prefix in [
+            "    eval {set zz 1}\n",
+            "    uplevel 1 {set zz 1}\n",
+            "    oo::define ::T::Mother {method extra {} {}}\n",
+        ] {
+            let src = COMPUTED_METACLASS.replace(
+                "    ::T::Mother create ${NSPACE}::class { superclass ::T::Mother }\n",
+                &format!(
+                    "{prefix}    ::T::Mother create ${{NSPACE}}::class {{ superclass ::T::Mother }}\n"
+                ),
+            );
+            let result = analysis(&src, "tcl9.0");
+            assert!(
+                result.all_classes.contains_key("::T::D::class"),
+                "a body that completes must not abstain: {prefix:?}; got {:?}",
+                result.all_classes.keys().collect::<Vec<_>>()
+            );
+        }
+    }
+
+    #[test]
+    fn a_stored_body_that_cannot_fall_through_is_still_not_a_blocker() {
+        // FP guard, and the reason the rule is "runs now" rather than
+        // "readable": a `proc` body is *stored*. It never runs at this call,
+        // so what it would do to control flow says nothing about the
+        // declaration, which completes normally — tclsh 8.6.16 / 9.0.4 both
+        // create the class after `proc helper {a} {return $a}`, whose body
+        // manifestly does not fall through.
+        //
+        // `after` is the same fact with a different mechanism: the script is
+        // scheduled, not run, so both oracles reach the creation even when the
+        // scheduled script would raise.
+        for prefix in [
+            "    proc helper {a} {return $a}\n",
+            "    after 0 {error stop}\n",
+            "    after idle {error stop}\n",
+        ] {
+            let src = COMPUTED_METACLASS.replace(
+                "    ::T::Mother create ${NSPACE}::class { superclass ::T::Mother }\n",
+                &format!(
+                    "{prefix}    ::T::Mother create ${{NSPACE}}::class {{ superclass ::T::Mother }}\n"
+                ),
+            );
+            let result = analysis(&src, "tcl9.0");
+            assert!(
+                result.all_classes.contains_key("::T::D::class"),
+                "a stored body must stay ignorable: {prefix:?}; got {:?}",
+                result.all_classes.keys().collect::<Vec<_>>()
+            );
+        }
+    }
+
+    #[test]
     fn an_apply_of_an_unreadable_lambda_still_abstains() {
         // FP guard (#1656) — the same soundness class as the `uplevel` vector
         // above, reached through the *other* role. `apply`'s argument is

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -6278,6 +6278,35 @@ mod class_factories {
     }
 
     #[test]
+    fn deeply_nested_untyped_bodies_do_not_blow_the_static_walk_stack() {
+        // The same native-stack safety net for the *untyped* body relaxation
+        // (#1672). `untyped_body_provably_blocks` re-enters the statement walk,
+        // which can re-enter it: `eval {eval {eval {…}}}` drives that recursion
+        // by nesting alone, so it carries the same `MAX_UNKNOWN_BODY_DEPTH`
+        // bound. Past the cap it abstains, the direction it takes for anything
+        // it cannot read, so this asserts termination and a well-formed result
+        // rather than a resolution.
+        //
+        // 40 is many times the cap (8) and well under the braced-body descent's
+        // own limit, so a failure here is this walk's recursion, not that one's.
+        let mut nest = "    set zz 1\n".to_owned();
+        for _ in 0..40 {
+            nest = format!("    eval {{\n{nest}    }}\n");
+        }
+        let src = COMPUTED_METACLASS.replace(
+            "    ::T::Mother create ${NSPACE}::class { superclass ::T::Mother }\n",
+            &format!(
+                "{nest}    ::T::Mother create ${{NSPACE}}::class {{ superclass ::T::Mother }}\n"
+            ),
+        );
+        let result = analysis(&src, "tcl9.0");
+        assert!(
+            result.all_classes.contains_key("::T::Mother"),
+            "the literally-written metaclass must survive the deep walk"
+        );
+    }
+
+    #[test]
     fn deeply_nested_collection_loops_do_not_blow_the_static_walk_stack() {
         // Native-stack safety net (#996's family) for the relaxation above:
         // the fall-through walk re-enters itself once per control body it

--- a/rust/tcl-registry/src/commands/irules/after.rs
+++ b/rust/tcl-registry/src/commands/irules/after.rs
@@ -44,7 +44,13 @@ fn after_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
 pub const fn spec() -> CommandSpec {
     CommandSpec {
         name: "after",
-        traits: Traits::DIAGRAM_ACTION,
+        // `DEFERS_BODY` — the "deferred body" the comment below already
+        // states. The Tcl `after` carries it for the same reason
+        // (`tcl/after_.rs`); this is the iRules spec of the same command and
+        // must not disagree with it (issue #1672 audit). No iRules oracle
+        // exists here, but the TMOS `after` is the Tcl one with a timer
+        // wakeup, and the divergence would be the surprising claim.
+        traits: Traits::DIAGRAM_ACTION.union(Traits::DEFERS_BODY),
         dialects: Some(DialectSet::IRULES),
         arity: Arity::at_least(1),
         // The timer form's trailing nesting script is a deferred body

--- a/rust/tcl-registry/src/commands/stdlib/tcl__optproc.rs
+++ b/rust/tcl-registry/src/commands/stdlib/tcl__optproc.rs
@@ -37,10 +37,15 @@ pub fn spec() -> CommandSpec {
         // `IRULES_TOP_LEVEL_ONLY` are deliberately omitted — this is a
         // `package require opt` library proc, not a core keyword, and
         // nothing establishes the iRules-top-level restriction for it.
+        // `DEFERS_BODY` for the same reason `proc` carries it: this *defines*
+        // a procedure, so the body is stored, never run here. tclsh 8.6.16 /
+        // 9.0.4, byte-identical: `proc p {} { ::tcl::OptProc q {} {error
+        // stop}; set ::reached 1 }` sets `::reached` (issue #1672 audit).
         traits: Traits::NOT_PROC_FACTORY
             | Traits::BYTE_COMPILED
             | Traits::DEFINES_PROCEDURE
-            | Traits::NEVER_INLINE_BODY,
+            | Traits::NEVER_INLINE_BODY
+            | Traits::DEFERS_BODY,
         arg_roles: &[
             (0, ArgRole::Name),
             (1, ArgRole::ParamList),

--- a/rust/tcl-registry/src/commands/stdlib/tcltest__loadscript.rs
+++ b/rust/tcl-registry/src/commands/stdlib/tcltest__loadscript.rs
@@ -35,6 +35,10 @@ pub fn spec() -> CommandSpec {
         // The optional value is a Tcl script the harness later evaluates.
         arg_roles: &[(0, ArgRole::Body)],
         body_kind: BodyKind::Structural,
+        // `DEFERS_BODY` — "later evaluates" said in data. tclsh 8.6.16 /
+        // 9.0.4, byte-identical: `proc p {} { tcltest::loadScript {error
+        // stop}; set ::reached 1 }` sets `::reached` (issue #1672 audit).
+        traits: Traits::DEFERS_BODY,
         deprecated_replacement: Some("tcltest::configure"),
         ..CommandSpec::DEFAULT
     }

--- a/rust/tcl-registry/src/commands/tcl/after_.rs
+++ b/rust/tcl-registry/src/commands/tcl/after_.rs
@@ -127,7 +127,20 @@ pub fn spec() -> CommandSpec {
         // The `cancel` subform destroys a scheduled
         // handler (`Tcl_AfterObjCmd`, tclTimer.c) — see the `destructive`
         // flag on the `cancel` subcommand.
-        traits: Traits::BYTE_COMPILED,
+        //
+        // `DEFERS_BODY`: every form that takes a script *schedules* it — as a
+        // timer or an idle handler — and returns; nothing in it runs before
+        // the caller's next statement, and it runs at all only once the event
+        // loop is entered (`vwait` / `update`). A consumer asking "can this
+        // body stop control reaching my next statement?" must therefore be
+        // told no, exactly as `proc`'s stored body is (issue #1672).
+        //
+        // tclsh 8.6.16 and 9.0.4, byte-identical: with
+        // `proc p {} { after 0 {error stop}; set ::reached 1 }`, `p` completes
+        // and `::reached` is set — the scheduled error never touches this
+        // call. (It surfaces through `interp bgerror` later, which is the
+        // event loop's business, not this statement's.)
+        traits: Traits::BYTE_COMPILED.union(Traits::DEFERS_BODY),
         arity: Arity::at_least(1),
         arg_role_resolver: Some(after_arg_roles),
         // The default form's deferred script runs later, at global level

--- a/rust/tcl-registry/src/commands/tcl/fileevent.rs
+++ b/rust/tcl-registry/src/commands/tcl/fileevent.rs
@@ -72,7 +72,14 @@ pub fn spec() -> CommandSpec {
         // `ALL_TCL` omits the `IRULES` bit, so the spec never intersects
         // the bare `IRULES` availability mask.
         dialects: Some(DialectSet::ALL_TCL),
-        traits: Traits::BYTE_COMPILED,
+        // `DEFERS_BODY`: the handler script is *registered*, and runs only
+        // when the channel becomes ready and the event loop dispatches it —
+        // the same fact `body_kind` records below, said where a consumer
+        // asking "can this body stop control reaching my next statement?"
+        // can read it. tclsh 8.6.16 and 9.0.4, byte-identical: `proc p {} {
+        // fileevent $ch readable {error stop}; set ::reached 1 }` sets
+        // `::reached` (issue #1672 audit).
+        traits: Traits::BYTE_COMPILED.union(Traits::DEFERS_BODY),
         arity: Arity::new(2, 3),
         arg_roles: &[(0, ArgRole::Channel), (2, ArgRole::Body)],
         // "The script for a file event is executed at global level

--- a/rust/tcl-registry/src/commands/tcl/package_.rs
+++ b/rust/tcl-registry/src/commands/tcl/package_.rs
@@ -129,12 +129,17 @@ static SUBCOMMANDS: &[SubCommand] = &[
         // it as part of the enclosing `package ifneeded` call's own scope.
         arg_roles: &[(2, ArgRole::Body)],
         body_kind: BodyKind::Structural,
+        // `DEFERS_BODY` — "stored and run later" said in data, and scoped to
+        // this subcommand rather than to `package` as a whole, since it is the
+        // only `package` form with a body. tclsh 8.6.16 and 9.0.4,
+        // byte-identical: `proc p {} { package ifneeded x 1.0 {error stop};
+        // set ::reached 1 }` sets `::reached` (issue #1672 audit).
         analyser_hook: Some(crate::hooks::AnalyserHookId::PackageIfneeded),
         // Registering a load script names *this* file as the thing that
         // supplies `package`, so the commands it defines are public API a
         // `package require` in some other file reaches — the same
         // caller-set widening `provide` declares, one step earlier.
-        traits: Traits::PROVIDES_PACKAGE,
+        traits: Traits::PROVIDES_PACKAGE.union(Traits::DEFERS_BODY),
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/commands/tcl/timer.rs
+++ b/rust/tcl-registry/src/commands/tcl/timer.rs
@@ -255,7 +255,17 @@ static SIDE_EFFECTS: [SideEffect; 1] = [SideEffect {
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "timer",
-        traits: Traits::BYTE_COMPILED,
+        // `DEFERS_BODY`, exactly as `after` carries it (`tcl/after_.rs`) —
+        // this command shares `after`'s event queue and id namespace, as the
+        // module header above records. No 9.1 interpreter exists here to
+        // oracle, so the evidence is documentary and unambiguous:
+        // `doc/timer.n` in the 9.1b0 tree says "The delayed command is given
+        // by the argument script" for `timer in`/`timer at`, and for `timer
+        // idle`, "Arranges for the script to be evaluated later as an idle
+        // callback … the next time the event loop is entered". A scheduled
+        // script cannot stop control reaching the caller's next statement
+        // (issue #1672 audit).
+        traits: Traits::BYTE_COMPILED.union(Traits::DEFERS_BODY),
         dialects: Some(DialectSet::TCL91),
         arity: Arity::at_least(1),
         subcommands: &SUBCOMMANDS,

--- a/rust/tcl-registry/src/commands/tcllib/functional.rs
+++ b/rust/tcl-registry/src/commands/tcllib/functional.rs
@@ -53,6 +53,11 @@ fn lambda_specs() -> Vec<CommandSpec> {
             arity: Arity::at_least(2),
             arg_roles: &[(0, ArgRole::ParamList), (1, ArgRole::Body)],
             body_kind: BodyKind::Structural,
+            // `DEFERS_BODY`: a lambda *constructor* — it returns a command
+            // prefix, it does not run the body. tclsh 8.6.16 / 9.0.4,
+            // byte-identical: `proc p {} { lambda {} {error stop}; set
+            // ::reached 1 }` sets `::reached` (issue #1672 audit).
+            traits: Traits::DEFERS_BODY,
             hover: Some(HoverSnippet {
                 summary: "Construct an anonymous procedure (a lambda term).",
                 synopsis: &["lambda arguments body ?arg ...?"],
@@ -74,6 +79,9 @@ fn lambda_specs() -> Vec<CommandSpec> {
                 (2, ArgRole::Body),
             ],
             body_kind: BodyKind::Structural,
+            // `DEFERS_BODY`, for the same reason as `lambda` above and proved
+            // the same way on both oracles.
+            traits: Traits::DEFERS_BODY,
             hover: Some(HoverSnippet {
                 summary: "Construct an anonymous procedure that runs in a namespace.",
                 synopsis: &["lambda@ namespace arguments body ?arg ...?"],
@@ -105,6 +113,12 @@ fn defer_cmd(
             1 => &[(1, ArgRole::Body)],
             _ => &[],
         },
+        // `DEFERS_BODY`: the package's whole point is that the script runs at
+        // *scope exit*, not here. tclsh 8.6.16 and 9.0.4, byte-identical, for
+        // all three forms: with `proc p {} { defer::defer error stop; set
+        // ::reached 1 }`, `::reached` is set — the statement after the
+        // registration runs (issue #1672 audit).
+        traits: Traits::DEFERS_BODY,
         hover: Some(HoverSnippet::brief(
             summary,
             synopsis,

--- a/rust/tcl-registry/src/commands/tcllib/misc_ext.rs
+++ b/rust/tcl-registry/src/commands/tcllib/misc_ext.rs
@@ -2945,6 +2945,12 @@ fn processman_onexit_spec() -> CommandSpec {
         required_package: Some("processman"),
         arg_roles: &[(1, ArgRole::Body)],
         body_kind: BodyKind::Structural,
+        // `DEFERS_BODY` — the fact the doc comment above already states, now
+        // said in data: the eval happens later, in `::processman::events`.
+        // tclsh 8.6.16 / 9.0.4, byte-identical: `proc p {} {
+        // processman::onexit x {error stop}; set ::reached 1 }` sets
+        // `::reached` (issue #1672 audit).
+        traits: Traits::DEFERS_BODY,
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/tcllib/report__defstyle.rs
+++ b/rust/tcl-registry/src/commands/tcllib/report__defstyle.rs
@@ -50,6 +50,12 @@ pub fn spec() -> CommandSpec {
         // must opt out of the enclosing block's data flow, exactly like
         // `proc` and `snit::method` bodies.
         body_kind: BodyKind::Structural,
+        // `DEFERS_BODY`: the style script is stored against `styleName` and
+        // runs when a report applies that style, not at the definition.
+        // tclsh 8.6.16 / 9.0.4, byte-identical: `proc p {} {
+        // report::defstyle s {} {error stop}; set ::reached 1 }` sets
+        // `::reached` (issue #1672 audit).
+        traits: Traits::DEFERS_BODY,
         hover: Some(HoverSnippet {
             summary: "Defines the new style styleName.",
             synopsis: &["report::defstyle styleName arguments script"],

--- a/rust/tcl-registry/src/commands/tcllib/snit__macro.rs
+++ b/rust/tcl-registry/src/commands/tcllib/snit__macro.rs
@@ -45,6 +45,11 @@ pub fn spec() -> CommandSpec {
         forms: FORMS,
         side_effects: SIDE_EFFECTS,
         arg_roles: &[(1, ArgRole::ParamList), (2, ArgRole::Body)],
+        // `DEFERS_BODY`: the macro body is stored against the name and runs
+        // only when a type definition invokes it. tclsh 8.6.16 / 9.0.4,
+        // byte-identical: `proc p {} { snit::macro m {} {error stop}; set
+        // ::reached 1 }` sets `::reached` (issue #1672 audit).
+        traits: Traits::DEFERS_BODY,
         tcllib_package: Some("snit"),
         required_package: Some("snit"),
         ..CommandSpec::DEFAULT

--- a/rust/tcl-registry/src/commands/tcllib/snit__method.rs
+++ b/rust/tcl-registry/src/commands/tcllib/snit__method.rs
@@ -32,6 +32,11 @@ pub fn spec() -> CommandSpec {
         // not the caller's frame.  Body at index 3.
         arg_roles: &[(2, ArgRole::ParamList), (3, ArgRole::Body)],
         body_kind: BodyKind::Structural,
+        // `DEFERS_BODY`: a method *definition* stores the body against the
+        // type; it runs on dispatch, not here. tclsh 8.6.16 / 9.0.4,
+        // byte-identical: a type whose method body is `error stop` defines
+        // cleanly and the next statement runs (issue #1672 audit).
+        traits: Traits::DEFERS_BODY,
         hover: Some(HoverSnippet {
             summary: "Define an instance method outside a type definition body.",
             synopsis: &["snit::method type name arglist body"],

--- a/rust/tcl-registry/src/commands/tcllib/snit__typemethod.rs
+++ b/rust/tcl-registry/src/commands/tcllib/snit__typemethod.rs
@@ -31,6 +31,9 @@ pub fn spec() -> CommandSpec {
         // Snit typemethod bodies run in a dispatch context.
         arg_roles: &[(2, ArgRole::ParamList), (3, ArgRole::Body)],
         body_kind: BodyKind::Structural,
+        // `DEFERS_BODY`, for the same reason as `snit::method` and proved the
+        // same way on both oracles (issue #1672 audit).
+        traits: Traits::DEFERS_BODY,
         hover: Some(HoverSnippet {
             summary: "Define a type method outside a type definition body.",
             synopsis: &["snit::typemethod type name arglist body"],

--- a/rust/tcl-registry/src/commands/tk/bind.rs
+++ b/rust/tcl-registry/src/commands/tk/bind.rs
@@ -57,6 +57,14 @@ pub fn spec() -> CommandSpec {
         // treat it as structural.
         arg_role_resolver: Some(bind_arg_roles),
         body_kind: BodyKind::Structural,
+        // `DEFERS_BODY` — the "deferred event-handler body" above, said where
+        // a consumer asking "can this body stop control reaching my next
+        // statement?" can read it (issue #1672 audit). Documentary rather
+        // than oracle-measured: this environment is headless, so `package
+        // require Tk` is unavailable. Tk's `bind.n` is unambiguous — the
+        // script is *associated* with the tag and sequence, and "will be
+        // evaluated whenever the given event sequence occurs".
+        traits: Traits::DEFERS_BODY,
         hover: Some(HoverSnippet {
             summary: "Arrange for X event bindings on windows or tags.",
             synopsis: &[

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -7216,24 +7216,34 @@ mod tests {
                 for lead in ["x", "idle", "ifneeded", "0"] {
                     let mut args = vec!["x"; argc];
                     args[0] = lead;
-                    let mask = reg
-                        .get(name)
-                        .and_then(|spec| spec.dialects)
-                        .unwrap_or(DialectSet::TK_AND_TCL);
-                    let traits = reg.invocation_traits(name, &args, mask);
-                    if traits.contains(Traits::DEFERS_BODY)
-                        // A `CONTROL_FLOW` command is the registry's own
-                        // business: the analyser refuses to walk one whose arm
-                        // it cannot type rather than reading the body, so a
-                        // malformed probe shape of `if` / `try` is not a
-                        // missing stance.
-                        || traits.contains(Traits::CONTROL_FLOW)
-                    {
-                        continue;
-                    }
-                    for index in reg.arg_indices_for_role(name, &args, ArgRole::Body) {
-                        if reg.control_arm_semantics(name, &args, index).is_none() {
-                            untyped_body = true;
+                    // One name can carry more than one spec, resolved by
+                    // dialect — `after` has a Tcl spec and an iRules one, and
+                    // a sweep that looked at only one would let the other lose
+                    // its trait unnoticed. Iterating the specs (rather than a
+                    // list of masks) also keeps every probe on a mask the
+                    // command actually resolves under: an unresolvable call
+                    // answers with an empty trait set, which is indistinguish-
+                    // able from a spec whose only trait was `DEFERS_BODY`
+                    // until it was dropped — precisely the regression this
+                    // gate exists to catch.
+                    for spec in reg.specs(name) {
+                        let mask = spec.dialects.unwrap_or(DialectSet::TK_AND_TCL);
+                        let traits = reg.invocation_traits(name, &args, mask);
+                        if spec.traits.contains(Traits::DEFERS_BODY)
+                            || traits.contains(Traits::DEFERS_BODY)
+                            // A `CONTROL_FLOW` command is the registry's own
+                            // business: the analyser refuses to walk one whose
+                            // arm it cannot type rather than reading the body,
+                            // so a malformed probe shape of `if` / `try` is
+                            // not a missing stance.
+                            || traits.contains(Traits::CONTROL_FLOW)
+                        {
+                            continue;
+                        }
+                        for index in reg.arg_indices_for_role(name, &args, ArgRole::Body) {
+                            if reg.control_arm_semantics(name, &args, index).is_none() {
+                                untyped_body = true;
+                            }
                         }
                     }
                 }

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -7137,6 +7137,131 @@ mod tests {
         assert!(seen > 0, "the sweep must not be vacuous");
     }
 
+    /// Every command that carries an untyped [`ArgRole::Body`] position and
+    /// runs it *now*, pinned by name.
+    ///
+    /// The analyser reads the absence of `DEFERS_BODY` as "this body runs as
+    /// part of this invocation" and, since issue #1672, lets such a body stop
+    /// its fall-through walk. That makes a *missing* `DEFERS_BODY` a silent
+    /// wrong answer rather than a missing one, so the inventory is pinned:
+    /// adding a Body-role command fails this test until its author puts it on
+    /// one of the two lists below, which is the moment to ask the question.
+    ///
+    /// Store-only forms do not appear here — they carry `DEFERS_BODY` and the
+    /// sweep skips them. Commands the registry *types* do not appear either:
+    /// a typed arm is answered by [`ControlArmSemantics`], not by this trait.
+    ///
+    /// Every entry was measured against tclsh 8.6.16 and 9.0.4, which agreed
+    /// byte-for-byte, with the shape `proc p {} { FORM {error stop}; set
+    /// ::reached 1 }`: `::reached` unset means the body ran here.
+    const BODY_RUNS_NOW: &[&str] = &[
+        // Core Tcl: script evaluators and definition scripts.
+        "::tcl::dict::for",
+        "::tcl::dict::map",
+        "::tcl::dict::update",
+        "::tcl::dict::with",
+        "eval",
+        "oo::define",
+        "oo::objdefine",
+        "time",
+        "timerate",
+        "uplevel",
+        // Runs its body now, but *absorbs* its completion — the harness
+        // catches a failing test body and reports it. That is a completion
+        // boundary, which is a typed answer this trait cannot give, so it
+        // sits here and the walk over-abstains on it. Tracked separately.
+        "tcltest::test",
+        // tcllib: iterators and definition scripts.
+        "control::do",
+        "fileutil::foreachLine",
+        "lfilter",
+        "snit::compile",
+        "snit::type",
+        "snit::widget",
+        "snit::widgetadaptor",
+        "stooop::class",
+        "uri::register",
+        // itcl: `class` runs its definition script; `body` and `configbody`
+        // install a body against an already-declared member and look like
+        // store-only forms, but no itcl is installable in this environment,
+        // so they are recorded as unmeasured rather than marked on a guess.
+        "itcl::body",
+        "itcl::class",
+        "itcl::configbody",
+        // iRules: these run the script now, in a different flow context.
+        "clientside",
+        "peer",
+        "serverside",
+    ];
+
+    /// The gate for [`BODY_RUNS_NOW`]: no command may carry an untyped
+    /// `ArgRole::Body` position without an explicit stance on whether that
+    /// body runs now or is stored.
+    #[test]
+    fn every_untyped_body_role_declares_whether_its_body_runs_now() {
+        let mut reg = CommandRegistry::build_default();
+        reg.load_irules();
+        let names: Vec<String> = reg.command_names().map(str::to_owned).collect();
+        let mut unclassified: Vec<String> = Vec::new();
+        let mut seen_runs_now = 0usize;
+        for name in &names {
+            // Role resolution is argv-shaped, so probe the argument counts a
+            // grammar could take, and the leading words that select the
+            // script-bearing subforms of the ensembles in this sweep. Both
+            // questions are asked per shape, exactly as the analyser asks
+            // them: `DEFERS_BODY` can live on a subcommand rather than the
+            // command (`package ifneeded`), so a spec-level test would miss it.
+            let mut untyped_body = false;
+            for argc in 1..=6usize {
+                for lead in ["x", "idle", "ifneeded", "0"] {
+                    let mut args = vec!["x"; argc];
+                    args[0] = lead;
+                    let mask = reg
+                        .get(name)
+                        .and_then(|spec| spec.dialects)
+                        .unwrap_or(DialectSet::TK_AND_TCL);
+                    let traits = reg.invocation_traits(name, &args, mask);
+                    if traits.contains(Traits::DEFERS_BODY)
+                        // A `CONTROL_FLOW` command is the registry's own
+                        // business: the analyser refuses to walk one whose arm
+                        // it cannot type rather than reading the body, so a
+                        // malformed probe shape of `if` / `try` is not a
+                        // missing stance.
+                        || traits.contains(Traits::CONTROL_FLOW)
+                    {
+                        continue;
+                    }
+                    for index in reg.arg_indices_for_role(name, &args, ArgRole::Body) {
+                        if reg.control_arm_semantics(name, &args, index).is_none() {
+                            untyped_body = true;
+                        }
+                    }
+                }
+            }
+            if !untyped_body {
+                continue;
+            }
+            if BODY_RUNS_NOW.contains(&name.as_str()) {
+                seen_runs_now += 1;
+            } else {
+                unclassified.push(name.clone());
+            }
+        }
+        assert!(
+            seen_runs_now > 0,
+            "the sweep must not be vacuous — no runs-now command was reached"
+        );
+        assert!(
+            unclassified.is_empty(),
+            "these commands carry an untyped ArgRole::Body and declare no \
+             stance: either they store the body (give the spec \
+             Traits::DEFERS_BODY, with an oracle row) or they run it now (add \
+             them to BODY_RUNS_NOW, with an oracle row). Leaving them out \
+             makes the analyser's fall-through walk treat their body as one \
+             that can stop control — see issue #1672. Unclassified: {unclassified:?}"
+        );
+    }
+
     /// `DEFERS_BODY` and typed control-arm semantics are answers to different
     /// questions, and today no command gives both: everything the registry
     /// types (`if`, `switch`, `namespace eval`, `catch`, `try`, the loops,


### PR DESCRIPTION
Fixes #1672

## Summary

- `control_arms_for_segment` pushes every readable body word as a `ControlArm`. `static_statement_falls_through` then asked the registry what that arm meant and silently `continue`d when the answer was `None`; with no other arm the statement read as falling through, so the computed-metaclass walk claimed the creation after `uplevel 1 {error stop}`, `eval {error stop}` and `oo::define C {error stop}` — none of which tclsh 8.6.16 or 9.0.4 reach. This is the *readable* twin of the hole #1652 closed for unreadable bodies.
- An untyped arm whose command runs its body now (`DEFERS_BODY` unset) is now material. **The burden of proof runs opposite to the typed arms**, and that is the design decision worth reviewing: a typed arm (`Always` / `FrameBoundary` / `BoundedIteration`) must *prove* it falls through, because a descriptor says what the body is for; an untyped body is walked past unless it *proves it blocks*.
- Implementing the issue's literal direction ("prove fall-through or abstain") first, and measuring it, is what forced that: it abstains on 28 of the 142 `class_factories` tests, the tcllib clay corpus test (#1571) among them. The reason is not a bug in the rule but what the rule asks for — the first untyped body in the reproducer is a class definition script, `oo::class create ::T::Mother { superclass oo::class }`, and `superclass` is not a command but a word `oo::define` understands. Nothing in this walk can type it, so no proof of fall-through is available for any definition script, and demanding one abstains on the single construct the computed-metaclass walk exists to read. That measurement is mechanised as a mutant (M6 below).
- The blocking proof is registry-owned: `InvocationCompletion::Terminates` or `ReturnsResult`. An `Unknown` completion ends the scan with no proof, leaving the walk exactly where it was before the rule existed — the honest limit of an untyped body, recorded in prose on `untyped_body_provably_blocks` rather than asserted as an absence.
- `unreadable_body_is_material`'s second check and the new one were the same question asked in two places, and only one of them was asking it; both now go through a single `body_runs_now`.

**Corpus: no shift, in either direction.** `full_tcllib_clay_dialect_metaclass_resolves_when_the_corpus_is_available` proves exactly what it proved on `origin/rust` (9ff015851), run deliberately with `TCLLIB_2_0_DIR` set and the skip path not taken, before and after.

### Oracle rows for the walk change

tclsh 8.6.16 (`TCL_LSP_TCLSH86`) and 9.0.4, byte-identical. "Class created after the prefix?"

| prefix | tclsh | before | after |
|---|---|---|---|
| `uplevel 1 {error stop}` | no | claims | abstains |
| `eval {error stop}` | no | claims | abstains |
| `oo::define C {error stop}` | no | claims | abstains |
| `uplevel 1 {return}` | no | claims | abstains |
| `eval {return}` | no | claims | abstains |
| `oo::define C {return}` | no | claims | abstains |
| `eval {set zz 1}` | yes | claims | claims |
| `uplevel 1 {set zz 1}` | yes | claims | claims |
| `oo::define C {method extra {} {}}` | yes | claims | claims |
| `proc helper {a} {return $a}` | yes | claims | claims |

The `return` rows are not merely the conservative reading — both interpreters really do leave the enclosing procedure, `oo::define`'s definition script included.

## Registry audit (review feedback, thread r3826570474)

Codex's P2 was correct and generalised further than the four commands it named: reading the *absence* of `DEFERS_BODY` as "runs now" makes a missing trait a silent wrong answer, so a store-only form whose body contains `error` would provably-block and wrongly stop the walk.

The set was **enumerated** — a sweep for commands with an untyped `ArgRole::Body` position, probed across argument shapes and every spec behind each name, returning 45 forms — and each measured on both oracles with `proc p {} { FORM {error stop}; set ::reached 1 }`. Both agreed byte-for-byte on every row.

**Stored, now carrying `DEFERS_BODY` (oracle-proved):** `package ifneeded` (on the subcommand — the only `package` form with a body), `fileevent`, `tcl::OptProc`, `tcltest::loadScript`, `lambda`, `lambda@`, `defer::defer`, `defer::with`, `defer::autowith`, `processman::onexit`, `report::defstyle`, `snit::macro`, `snit::method`, `snit::typemethod`.

**Stored, documentary evidence with the reason at the spec:** Tcl 9.1 `timer` (no 9.1 interpreter available; `doc/timer.n` in the 9.1b0 tree says the script is evaluated later, and it shares `after`'s event queue and id namespace) and Tk `bind` (headless environment; `bind.n` associates the script with the sequence). The iRules `after` spec gains it too — the same command as the Tcl one, which must not disagree.

**Runs now, existing data already correct:** `eval`, `uplevel`, `oo::define`, `oo::objdefine`, the `::tcl::dict::*` script forms, `time`, `timerate`, `control::do`, `fileutil::foreachLine`, `snit::type` / `widget` / `widgetadaptor` / `compile`, `stooop::class`, `uri::register`.

**Two gaps recorded rather than mismarked.** `tcltest::test` runs its body now but *absorbs* the completion — a completion boundary, which is a typed answer this trait cannot give; it stays untyped and the walk over-abstains on it. `itcl::body` / `itcl::configbody` look store-only but no itcl is installable here, so they are listed as unmeasured.

**New gate:** `every_untyped_body_role_declares_whether_its_body_runs_now` requires each untyped Body-role command either to carry `DEFERS_BODY` or to be named in `BODY_RUNS_NOW`, so the next command added cannot default wrong in silence.

The first version of that gate had two defects, both found by mutating the data it guards rather than the gate itself — a self-referential mutant only looks like a pass. One name can carry several specs (`after` has a Tcl one and an iRules one), so a single dialect mask let the Tcl spec lose its trait unnoticed; and probing a mask the command does not resolve under answers with an empty trait set, indistinguishable from a spec whose only trait was `DEFERS_BODY` until it was dropped. Iterating `specs(name)` and probing each under its own dialects fixes both.

## Mutation battery

Ten mutants over the fix and the registry data, all killed from a green baseline, each by its intended test:

| mutant | killed by |
|---|---|
| M1 `unreadable_body_is_material` polarity flipped | 28 `class_factories` tests |
| M2 untyped arm ignores `DEFERS_BODY` | `a_stored_body_that_cannot_fall_through_is_still_not_a_blocker` |
| M3 `after` loses `DEFERS_BODY` | same |
| M4 blocking proof drops `ReturnsResult` | `a_readable_body_that_runs_now_but_is_untyped_still_abstains` |
| M5 blocking proof drops `Terminates` | same |
| M6 an `Unknown` completion counts as a blocker | 30 tests, the tcllib clay corpus test among them |
| M7 untyped arm ignored entirely (pre-fix null) | `a_readable_body_that_runs_now_but_is_untyped_still_abstains` |
| M8 `package ifneeded` loses `DEFERS_BODY` | `a_stored_body_…` |
| M9 `fileevent` loses `DEFERS_BODY` | same |
| M10 `lambda` loses `DEFERS_BODY` | same |

M1 is a real defect this battery caught: the refactor into `body_runs_now` inverted that return.

Seven further mutants over the data the new gate guards, all killed: dropping `DEFERS_BODY` from `package ifneeded`, `fileevent`, `lambda`, `after` or Tk `bind`, and dropping either of two `BODY_RUNS_NOW` entries. Three of those survived the gate's first version and drove the `specs(name)` fix above.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

All under `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=2`, with `TCLLIB_2_0_DIR=tmp/tcllib-2.0` and `TCL_LSP_TCLSH86=tmp/tcl8616-install/bin/tclsh8.6`:

- `cargo fmt --all -- --check` (root workspace and `runtime/rust`)
- `cargo clippy -p tcl-registry --all-targets -- -D warnings`
- `cargo clippy -p tcl-compiler --all-targets -- -D warnings`
- `cargo check --workspace`
- `cargo test -p tcl-registry`
- `cargo test -p tcl-compiler`
- consuming crates: `cargo test -p tcl-spectcl`, `-p tcl-lsp-core`, `-p tcl-vm`, `-p tcl-lsp-server`, `-p tcl-spec-studio` (the `reference_doc` drift test — traits are a registry-visible surface), `-p tcl-lsp-db`
- `make lsp-server-wasm-test` — 16/16 checks passed (`tcl-registry` and `tcl-compiler` ship in the wasm server; no `std::time` on any wasm-reachable path was added)

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? No. `DEFERS_BODY`'s meaning is unchanged — `docs/references/command-spec/fields.md` already reads "stores its script argument instead of running it; unset means the body is treated as executed", which is exactly what `body_runs_now` consults. The commands above gain the trait as *data* under that existing definition.
- [x] No new or changed diagnostic or optimisation code.
- [x] No new design doc.

Process note for anyone reusing the mutation driver: restoring a mutant by `rename` preserves the backup's mtime, and cargo fingerprints on mtime, so the clean source can be mistaken for the mutant's build and the battery silently re-runs the wrong binary. The first run of this battery was invalid for that reason; restores now `touch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqRAya5Xmdo4NJSWPm5C8o