### PR TITLE
feat(server): poll, wake, and timer telemetry for the #1657 wedge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ are *not* debt.
 - Rust stable with cargo, via [rustup](https://rustup.rs/).  The toolchain
   tracks the floating `stable` channel pinned in `rust-toolchain.toml`, so
   `Cargo.toml`'s `rust-version` bumps whenever stable does.  Current stable is
-  1.97.0, released 2026-07-07.  CI resolves `stable` at run time, so a fresh
+  1.98.0, released 2026-08-18.  CI resolves `stable` at run time, so a fresh
   release can fail `pr-gate`'s `cargo clippy -D warnings` on untouched code the
   day it lands — `rustup update` before debugging a clippy failure you cannot
   reproduce locally.
@@ -165,7 +165,7 @@ via [`scripts/dev/ensure-test-deps.sh`](scripts/dev/ensure-test-deps.sh)
 | Wasmtime         | v47.0.3       | `/opt/wasmtime-47.0.3/`         | `/usr/local/bin/wasmtime` |
 | Binaryen         | v132          | `/opt/binaryen-132/`            | `/usr/local/bin/wasm-merge`, `/usr/local/bin/wasm-opt` |
 | wasi-sdk         | 33.0          | `/opt/wasi-sdk-33.0/` (symlink `/opt/wasi-sdk`) | — (found by `runtime/rust/build.rs`) |
-| rustup + Rust    | floating `stable` (currently 1.97.1) | `/root/.rustup`, `/root/.cargo` | `/usr/local/bin/{cargo,rustc,rustup,rustfmt,clippy-driver}` |
+| rustup + Rust    | floating `stable` (currently 1.98.0) | `/root/.rustup`, `/root/.cargo` | `/usr/local/bin/{cargo,rustc,rustup,rustfmt,clippy-driver}` |
 | Tcl 8.4 source   | 8.4.20        | `tmp/tcl8.4.20/`                | —                         |
 | Tcl 8.5 source   | 8.5.19        | `tmp/tcl8.5.19/`                | —                         |
 | Tcl 8.6 source   | 8.6.16        | `tmp/tcl8.6.16/`                | —                         |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,20 @@ version = 4
 
 [[package]]
 name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli 0.32.3",
+]
+
+[[package]]
+name = "addr2line"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
 dependencies = [
- "gimli",
+ "gimli 0.33.0",
 ]
 
 [[package]]
@@ -264,6 +273,21 @@ dependencies = [
  "dunce",
  "fs_extra",
  "pkg-config",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line 0.25.1",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object 0.37.3",
+ "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -788,7 +812,7 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli",
+ "gimli 0.33.0",
  "hashbrown 0.17.1",
  "libm",
  "log",
@@ -1697,6 +1721,12 @@ dependencies = [
 
 [[package]]
 name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "gimli"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
@@ -2362,6 +2392,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4829,6 +4868,7 @@ version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -5261,7 +5301,7 @@ version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c80ca6098e0d4d06886d91d7f2cc3cb6623eb583c4c0ab3c89cbfb6098c8586c"
 dependencies = [
- "addr2line",
+ "addr2line 0.26.1",
  "async-trait",
  "bitflags 2.13.1",
  "bumpalo",
@@ -5272,7 +5312,7 @@ dependencies = [
  "log",
  "mach2",
  "memfd",
- "object",
+ "object 0.39.1",
  "once_cell",
  "postcard",
  "pulley-interpreter",
@@ -5304,11 +5344,11 @@ dependencies = [
  "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-entity",
- "gimli",
+ "gimli 0.33.0",
  "hashbrown 0.17.1",
  "indexmap",
  "log",
- "object",
+ "object 0.39.1",
  "postcard",
  "rustc-demangle",
  "semver",
@@ -5353,10 +5393,10 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-native",
- "gimli",
+ "gimli 0.33.0",
  "itertools",
  "log",
- "object",
+ "object 0.39.1",
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
@@ -5414,7 +5454,7 @@ dependencies = [
  "cfg-if",
  "cranelift-codegen",
  "log",
- "object",
+ "object 0.39.1",
  "wasmtime-environ",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,15 +157,15 @@ edition = "2024"
 # 2024 is the current Rust edition (editions ship ~every 3 years: 2015 / 2018 /
 # 2021 / 2024). MSRV tracks the toolchain the workspace is built and tested
 # against — the floating `stable` pinned by rust-toolchain.toml — so it bumps
-# whenever stable does. Current stable is 1.97.0, released 2026-07-07.
+# whenever stable does. Current stable is 1.98.0, released 2026-08-18.
 # (≥ 1.85 was already required for salsa 0.28 / tcl-lsp-db and the runtime/rust
 # port's is_none_or.)
 #
 # Because CI resolves `stable` at run time, a new release can start failing
-# pr-gate's `cargo clippy -D warnings` on untouched code the day it lands: 1.97
-# widened `question_mark` and added `manual_assert_eq`. `rustup update` before
+# pr-gate's `cargo clippy -D warnings` on untouched code the day it lands: 1.98
+# widened `redundant_closure_for_method_calls`. `rustup update` before
 # debugging a clippy failure you cannot reproduce locally.
-rust-version = "1.97"
+rust-version = "1.98"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/bitwisecook/tcl-lsp"
 authors = ["tcl-lsp contributors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,6 +192,10 @@ xxhash-rust = { version = "0.8", features = ["xxh3"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"
+# The #1657 taskdump evidence hook is gated on cfgs set only by local evidence
+# builds (RUSTFLAGS="--cfg tokio_unstable --cfg tokio_taskdump"); declared so
+# ordinary builds do not warn on the gate.
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tokio_unstable)", "cfg(tokio_taskdump)"] }
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@
 #
 # Prerequisites:
 #   - Rust stable with cargo (via rustup).  The workspace tracks the floating
-#     `stable` channel pinned in rust-toolchain.toml; current stable is 1.97.0,
-#     released 2026-07-07.  `Cargo.toml` `rust-version` is authoritative.
+#     `stable` channel pinned in rust-toolchain.toml; current stable is 1.98.0,
+#     released 2026-08-18.  `Cargo.toml` `rust-version` is authoritative.
 #   - Node.js 24+ with npm
 #
 

--- a/README.md
+++ b/README.md
@@ -1927,8 +1927,8 @@ an INI file you can commit alongside the project.
 ## Building and contributing
 
 - A Rust toolchain (current stable) via [rustup](https://rustup.rs/).  The
-  workspace tracks the floating `stable` channel; current stable is 1.97.0,
-  released 2026-07-07.
+  workspace tracks the floating `stable` channel; current stable is 1.98.0,
+  released 2026-08-18.
 - Node.js 24+ with npm (pinned to v12 via `packageManager`; run `corepack enable npm`)
 - VS Code 1.93+
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -217,6 +217,11 @@ against, and how it stays fast under an editor's keystroke load.
   the guardrails that pin it.
 - [rust/lsp-performance.md](rust/lsp-performance.md) — native LSP
   performance: results, optimisations, and how to measure.
+- [notes/tokio-task-resumption-wedge-repro.md](notes/tokio-task-resumption-wedge-repro.md)
+  — the #1657 whole-server wedge: the instrumented evidence chain (a task
+  woken twice and never polled again), what is excluded and by what, measured
+  repro rates per tokio version, and a self-contained distillation sample
+  with its honestly-reported results.
 
 ## Optional WASM extensions
 

--- a/docs/design/notes/tokio-task-resumption-wedge-repro.md
+++ b/docs/design/notes/tokio-task-resumption-wedge-repro.md
@@ -1,16 +1,56 @@
 # The #1657 task-resumption wedge: evidence, reproduction, and a distillation attempt
 
-Status: **open**. The wedge is characterised to a single mechanism-shaped
-question but not yet root-caused. Per direction, nothing here has been filed
-outside this repository.
+Status: **contained; runtime trigger still unproved**. Per direction, nothing
+here has been filed outside this repository.
+
+## Independent adversarial review — 2026-08-21
+
+The captures below prove a narrower fact than the original conclusion: the
+guard-owning future was woken and then was not polled again for tens of
+seconds. They do **not** prove where that wake was lost, that the task reached a
+Tokio run queue, or that a worker unpark was lost. In particular:
+
+- the external no-op-spawn probe produced no demonstrated resumption of the
+  exact frozen telemetry registration, so it is retained only as an opt-in
+  evidence experiment (`TCL_LSP_WEDGE_EVIDENCE`), never as normal recovery;
+- the useful waiter poll/wake telemetry wraps only the document map's contended
+  slow path; #1679's global every-handler poll counter and holder-send timeout
+  instrumentation are not retained on the normal hot path;
+- cancelling `SinkExt::send` at a timeout is not an atomic "nothing was
+  enqueued" operation: `start_send` may have succeeded before `poll_flush`
+  parked, so timeout-and-retry can duplicate a notification;
+- Tokio task dumps expose task IDs and traces, not scheduler state bits, and a
+  trace walk may omit an already-notified task. The evidence hook therefore
+  correlates the exact ID and reports absence without interpreting it as a
+  state;
+- the task-dump build needs both Tokio's `taskdump` Cargo feature and
+  `--cfg tokio_unstable`; this branch wires the feature only for an explicit
+  Linux `tokio_taskdump` evidence build.
+
+The production containment removes the convicted blast radius instead of
+guessing at scheduler recovery. A single persistent diagnostics publisher owns
+client I/O outside all request-critical locks. Producers atomically update the
+pull cache and deposit into a latest-wins per-URI mailbox while holding the
+document map, then release the map before awaiting delivery. A close either
+replaces a pending stale set or follows an already-started set on the same
+consumer. No client send is cancelled or retried, and a lost publisher stops
+diagnostics rather than the whole language server.
+
+The branch builds and tests with rustc 1.98.0 and resolves Tokio 1.53.1. The
+Tokio 1.51.1 reproduction remains useful negative version evidence, but is not
+a reason to pin an old runtime.
+
+The remainder of this note is the historical capture and distillation record;
+its "lost unpark" language documents the hypothesis tested at the time, not a
+current root-cause verdict.
 
 ## Environment
 
 | | |
 | --- | --- |
-| Server | `tcl-lsp-server`, branch `claude/f6h-1657-pollshim` (instrumentation merged to `rust` via #1667, #1670, #1677, #1679) |
+| Server | `tcl-lsp-server`, capture branch `claude/f6h-1657-pollshim` (earlier instrumentation from #1667, #1670, and #1677; #1679 was the unmerged attempted fix/repro reviewed here) |
 | rustc | 1.98.0 (88d9e12ae 2026-08-18) |
-| tokio | 1.53.1 pinned; also reproduced with `--precise 1.51.1` |
+| tokio | 1.53.1 locked/resolved; also reproduced with `--precise 1.51.1` |
 | OS | Ubuntu 24.04.4 LTS, kernel `6.18.44-fc-v21` (VM), 4 vCPUs |
 | Load | ext-host suite under `nproc/2` spinner processes |
 
@@ -74,20 +114,22 @@ Full trail: issue #1657, checkpoints 1–25. The captures that matter:
 | tokio 1.52+ scheduler changes | **byte-identical wedge on tokio 1.51.1** (checkpoint 25) |
 | transport parent starvation | handler futures polled during the stall window; the holder is a spawned task the transport does not own |
 
-## The open question, stated precisely
+## The historical open question and hypothesis
 
 A task whose waker is invoked — twice, from two sources — is never scheduled
 onto any queue a worker runs, for tens of seconds, while sibling tasks
 proceed; workers show parked in futex throughout; recovery coincides with the
 next external input.
 
-The frame that fits every observation is a **lost worker unpark**: waker runs
+The frame proposed at the time was a **lost worker unpark**: waker runs
 → task is queued → the final unpark of a parked worker is lost → the task
 sits runnable until some *other* event unparks a worker (in production, the
 next client message — which is why the wedge lasts "until the next request"
 and the server always recovers). Candidates below every line of this
 codebase: an old latent tokio park/unpark race, or futex/timer delivery at
-the kernel/VM layer (`6.18.44-fc-v21`). Neither is proven.
+the kernel/VM layer (`6.18.44-fc-v21`). Neither was proven, and the later
+external-spawn experiment did not validate the recovery consequence this
+hypothesis predicted.
 
 ## What reliably reproduces it: the in-repo loaded loop
 

--- a/docs/design/notes/tokio-task-resumption-wedge-repro.md
+++ b/docs/design/notes/tokio-task-resumption-wedge-repro.md
@@ -1,0 +1,613 @@
+# The #1657 task-resumption wedge: evidence, reproduction, and a distillation attempt
+
+Status: **open**. The wedge is characterised to a single mechanism-shaped
+question but not yet root-caused. Per direction, nothing here has been filed
+outside this repository.
+
+## Environment
+
+| | |
+| --- | --- |
+| Server | `tcl-lsp-server`, branch `claude/f6h-1657-pollshim` (instrumentation merged to `rust` via #1667, #1670, #1677, #1679) |
+| rustc | 1.98.0 (88d9e12ae 2026-08-18) |
+| tokio | 1.53.1 pinned; also reproduced with `--precise 1.51.1` |
+| OS | Ubuntu 24.04.4 LTS, kernel `6.18.44-fc-v21` (VM), 4 vCPUs |
+| Load | ext-host suite under `nproc/2` spinner processes |
+
+## The symptom
+
+Under the loaded VS Code ext-host suite, the whole server intermittently
+answers nothing for tens of seconds to minutes, then recovers. Every request
+handler waits on the document-sync barrier; the barrier's turn holder is
+parked on the open-document map; the map's holder never finishes a
+2-second-capped client send.
+
+## The evidence chain, compressed
+
+Full trail: issue #1657, checkpoints 1–25. The captures that matter:
+
+1. **The holder is parked at a named await** (phase markers, #1667): the turn
+   holder suspends at `documents.lock` with phase age equal to turn age.
+2. **The map names its holder** (holder tag, #1670): `publish_diagnostics_result
+   → cache_and_deliver`, holds of 45.8s–167.2s against a 2s send cap.
+3. **Free map, frozen acquisition counter** (#1677): a waiter parked on a
+   *free* map across a 250 ms sample window in which nobody acquired it — a
+   waiter that was never resumed, not contention.
+4. **The split-waker verdict** (#1679): the send runs under a hand-rolled
+   timeout whose two halves are polled through separate recording wakers.
+   Three captures, identical:
+
+   ```text
+   its publish send has run 45.8s against a 2.0s cap, polled 1 time(s) (last 45.8s ago),
+   send half woken 1 time(s), timer half woken 1 time(s) —
+   the timer FIRED 43.8s ago and the task was NEVER POLLED again
+   ```
+
+   In every capture `hold_age − timer_wake_age = 2.0s` exactly: **the timer
+   fires precisely on schedule**. The wake is delivered (the recording waker
+   runs before forwarding to the real waker). The task is never polled again —
+   here for 43.8s — while sibling tasks on the same runtime keep being polled
+   (the stall reporter itself ran a 10s timeout and a 250 ms sleep to produce
+   the line, and the transport's handler futures were polled during the
+   window).
+
+## Reconstruction timeline (fixed-binary capture, checkpoint 24)
+
+| t | event |
+| --- | --- |
+| 0 | holder (a spawned diagnostics worker) acquires the map, enters the capped publish send; poll 1 registers both halves |
+| ~0 | send half delivers one wake (channel capacity moved) — **no poll follows** |
+| 2.0s | timer half delivers its wake, exactly on the cap — **no poll follows** |
+| 2.0s → 45.8s+ | nothing: two wakes delivered through two independent wakers, zero polls, sibling tasks proceeding |
+| (production) | the wedge ends when the next client message arrives |
+
+## What is excluded, and by what
+
+| hypothesis | excluded by |
+| --- | --- |
+| lock cycles through the barrier | full transitive waits-for reachability (checkpoint 1) |
+| salsa `cancel_others` | census: zero outstanding snapshots in every capture |
+| slow/blocked holder (long hold) | phase clock: holder frozen *inside* a 2s-capped send |
+| unbounded send (pre-#1670) | send caps; then holds of 70–167s *through* the caps |
+| mutex contention / skipped waiter | acquisition counter frozen over a free map |
+| timer subsystem / tokio 1.53 time-driver rework | timer fires at exactly cap in every capture |
+| tokio 1.52+ scheduler changes | **byte-identical wedge on tokio 1.51.1** (checkpoint 25) |
+| transport parent starvation | handler futures polled during the stall window; the holder is a spawned task the transport does not own |
+
+## The open question, stated precisely
+
+A task whose waker is invoked — twice, from two sources — is never scheduled
+onto any queue a worker runs, for tens of seconds, while sibling tasks
+proceed; workers show parked in futex throughout; recovery coincides with the
+next external input.
+
+The frame that fits every observation is a **lost worker unpark**: waker runs
+→ task is queued → the final unpark of a parked worker is lost → the task
+sits runnable until some *other* event unparks a worker (in production, the
+next client message — which is why the wedge lasts "until the next request"
+and the server always recovers). Candidates below every line of this
+codebase: an old latent tokio park/unpark race, or futex/timer delivery at
+the kernel/VM layer (`6.18.44-fc-v21`). Neither is proven.
+
+## What reliably reproduces it: the in-repo loaded loop
+
+The full server under the loaded ext-host suite. This is the measured
+reproducer; rates below are from this investigation's logs.
+
+```sh
+# from the repo root, with the instrumented server built:
+CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=2 make rust-server
+# loop: burn nproc/2 cores in spinners, run the ext-host suite serially,
+# grep the server log for "[stall] document-sync barrier"; repeat.
+# (the loop script used in the investigation is quoted in #1657 checkpoint 9)
+```
+
+Observed capture rates (each "run" ≈ 4-minute suite, ~1000 diagnostics
+publishes):
+
+| build | runs to capture, per loop |
+| --- | --- |
+| tokio 1.53.1, phases only | 12, then 7, then 8 |
+| tokio 1.53.1, holder tag | 12 |
+| tokio 1.53.1, poll shim | 1, then 2, then 1 |
+| **tokio 1.51.1** (downgrade experiment) | **2** |
+
+Earlier in the investigation two 11–12-run clean stretches occurred; the rate
+is bursty. A clean streak is not evidence of health — that lesson recurred
+three times.
+
+The stall line to look for (the instrumentation prints the verdict):
+
+```text
+[stall] document-sync barrier has not advanced ... suspended at `did_open: documents.lock` ...
+the open-document map is held by cache_and_deliver: publish send — Xs in total, Xs at this point;
+its publish send has run Xs against a 2.0s cap ... — the timer FIRED ... NEVER POLLED again ...
+```
+
+## The standalone distillation — **does not reproduce**, stated plainly
+
+Per direction, a minimal self-contained sample was built from the convicted
+shape and instrumented identically, self-verdicting (exit 1 + verdict block on
+wedge, exit 0 on a measured clean pass, exit 2 on harness fault), including an
+**unpark probe**: on a detected wedge, a std thread outside the runtime spawns
+no-op tasks; if the wedged holder then gets polled, only the worker unpark was
+missing.
+
+It has **not** wedged in 5,400 trials on this box on tokio 1.53.1:
+
+| configuration | trials | wedges |
+| --- | --- | --- |
+| idle box | 400 | 0 |
+| 2 spinner threads (nproc/2, as the loop uses) | 2,000 | 0 |
+| 5 spinners + `spawn_blocking` churn + live I/O driver traffic + 512-task bursts | 3,000 | 0 |
+
+Compare ~1-in-2 loaded suite runs (~1000 publishes each) in the real server:
+if the distilled shape carried the trigger, 5,400 trials should have fired
+several times. It did not, so **the trigger involves something the
+distillation lacks**. Candidates, in rough order of suspicion: the sheer
+process-tree oversubscription of the real environment (VS Code + node + server
+on 4 vCPUs, cgroup scheduling), the server's real I/O topology (stdio through
+a pipe to a busy peer), or an unidentified server-specific ingredient. The
+sample is still shipped below: it is the faithful distillation, its harness
+prints the same verdict the server prints, and a machine or environment where
+it *does* fire would localise the trigger sharply.
+
+What was tried, so nobody repeats it blind: sweeping the receiver drain delay
+across the cap boundary (7 ms steps over 0–550 ms); mutex waiters parked
+behind the holder; 24-task churn; 512-task ready bursts (local-queue
+overflow); `spawn_blocking` completions (non-worker-thread wake path); live
+duplex I/O traffic; 2 and 5 spinner threads; 4 runtime workers as production.
+
+### `Cargo.toml`
+
+```toml
+[package]
+name = "wedge-repro"
+version = "0.1.0"
+edition = "2021"
+
+# Pin exactly what tcl-lsp ships. The wedge also reproduces with tokio pinned
+# to =1.51.1, so the version is not the variable — but the sample documents the
+# environment it was verified in.
+[dependencies]
+tokio = { version = "=1.53.1", features = ["rt-multi-thread", "sync", "time", "macros", "io-util"] }
+futures = "0.3"
+
+[profile.release]
+debug = true
+```
+
+### `src/main.rs`
+
+```rust
+//! Minimal reproducer for the tcl-lsp #1657 task-resumption wedge.
+//!
+//! Distilled from the convicted production shape: on a multi-thread tokio
+//! runtime under task churn, a spawned task holds a `tokio::sync::Mutex`
+//! while awaiting a deadline-capped `futures::mpsc` channel send against a
+//! slow receiver. In the production captures the holder's waker was invoked —
+//! by the send half AND by the timer half, through two independently
+//! instrumented wakers — and the task was never polled again for tens of
+//! seconds, while sibling tasks kept running. Byte-identical signature on
+//! tokio 1.53.1 and 1.51.1.
+//!
+//! Exit codes:
+//! * 0 — all trials completed, no wedge (the trial count is printed so a
+//!   clean pass is a measured claim, not silence);
+//! * 1 — wedge detected; a verdict block prints polls/wakes with ages,
+//!   mirroring the server's `[stall]` line, plus the unpark-probe outcome;
+//! * 2 — harness fault (a trial neither completed nor wedged in time).
+//!
+//! The unpark probe: on a detected wedge the watchdog — a plain std thread,
+//! deliberately outside the runtime — spawns no-op tasks into the runtime.
+//! If the wedged holder then gets polled, the wake chain was intact and only
+//! the final worker unpark was missing (the lost-unpark verdict). If it stays
+//! wedged, the queued task itself was lost.
+//!
+//! The race is probabilistic: trials sweep the receiver's drain delay across
+//! the cap boundary so the send-half and timer-half wakes land in varying
+//! proximity. Observed rates belong in the accompanying document.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Wake, Waker};
+use std::time::{Duration, Instant};
+
+use futures::SinkExt;
+use futures::StreamExt;
+
+const BUDGET: Duration = Duration::from_millis(250);
+const WEDGE_AFTER: Duration = Duration::from_secs(3);
+const TRIAL_LIMIT: Duration = Duration::from_secs(20);
+const TRIALS: u64 = 400;
+const CHURN_TASKS: usize = 24;
+/// Large enough to overflow a worker's 256-slot local queue.
+const BURST: usize = 512;
+const WAITERS: usize = 3;
+
+#[derive(Default, Clone, Copy)]
+struct WakeRec {
+    count: u64,
+    last: Option<Instant>,
+}
+
+/// One trial's holder telemetry — the same split accounting as the server.
+struct Telemetry {
+    /// `Some(start)` while a guarded send is in flight.
+    started: Mutex<Option<Instant>>,
+    polls: AtomicU64,
+    last_poll: Mutex<Option<Instant>>,
+    send_wakes: Arc<Mutex<WakeRec>>,
+    timer_wakes: Arc<Mutex<WakeRec>>,
+}
+
+impl Telemetry {
+    fn new() -> Self {
+        Self {
+            started: Mutex::new(None),
+            polls: AtomicU64::new(0),
+            last_poll: Mutex::new(None),
+            send_wakes: Arc::new(Mutex::new(WakeRec::default())),
+            timer_wakes: Arc::new(Mutex::new(WakeRec::default())),
+        }
+    }
+
+    /// Arm for a fresh trial. Counters reset BEFORE `started` is set, so the
+    /// watchdog can never pair a new trial with the previous trial's numbers.
+    fn arm(&self) {
+        self.polls.store(0, Ordering::Relaxed);
+        *self.last_poll.lock().unwrap() = None;
+        *self.send_wakes.lock().unwrap() = WakeRec::default();
+        *self.timer_wakes.lock().unwrap() = WakeRec::default();
+        *self.started.lock().unwrap() = Some(Instant::now());
+    }
+
+    fn disarm(&self) {
+        *self.started.lock().unwrap() = None;
+    }
+}
+
+struct Recorder {
+    real: Waker,
+    rec: Arc<Mutex<WakeRec>>,
+}
+
+impl Recorder {
+    fn note(&self) {
+        // Record BEFORE forwarding, so a poll caused by this wake can never be
+        // observed ahead of the wake that caused it.
+        let mut r = self.rec.lock().unwrap();
+        r.count += 1;
+        r.last = Some(Instant::now());
+    }
+}
+
+impl Wake for Recorder {
+    fn wake(self: Arc<Self>) {
+        self.note();
+        self.real.wake_by_ref();
+    }
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.note();
+        self.real.wake_by_ref();
+    }
+}
+
+/// `tokio::time::timeout`, hand-rolled so each half's wakes are recorded
+/// separately — identical to the server's instrumented delivery send.
+struct SplitTimeout<F> {
+    sleep: Pin<Box<tokio::time::Sleep>>,
+    fut: Pin<Box<F>>,
+    t: Arc<Telemetry>,
+}
+
+impl<F: Future> Future for SplitTimeout<F> {
+    type Output = Result<F::Output, ()>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let t = Arc::clone(&self.t);
+        t.polls.fetch_add(1, Ordering::Relaxed);
+        *t.last_poll.lock().unwrap() = Some(Instant::now());
+        let send_waker = Waker::from(Arc::new(Recorder {
+            real: cx.waker().clone(),
+            rec: Arc::clone(&t.send_wakes),
+        }));
+        let mut send_cx = Context::from_waker(&send_waker);
+        if let Poll::Ready(v) = self.fut.as_mut().poll(&mut send_cx) {
+            return Poll::Ready(Ok(v));
+        }
+        let timer_waker = Waker::from(Arc::new(Recorder {
+            real: cx.waker().clone(),
+            rec: Arc::clone(&t.timer_wakes),
+        }));
+        let mut timer_cx = Context::from_waker(&timer_waker);
+        if self.sleep.as_mut().poll(&mut timer_cx).is_ready() {
+            return Poll::Ready(Err(()));
+        }
+        Poll::Pending
+    }
+}
+
+fn age(i: Option<Instant>) -> String {
+    i.map_or_else(|| "never".into(), |i| format!("{:.1}s ago", i.elapsed().as_secs_f64()))
+}
+
+/// The out-of-runtime arbiter. Detects the wedge, prints the verdict, runs
+/// the unpark probe, exits with the appropriate code.
+fn watchdog(t: Arc<Telemetry>, handle: tokio::runtime::Handle) {
+    loop {
+        std::thread::sleep(Duration::from_millis(100));
+        let Some(t0) = *t.started.lock().unwrap() else {
+            continue;
+        };
+        let send = *t.send_wakes.lock().unwrap();
+        let timer = *t.timer_wakes.lock().unwrap();
+        let last_poll = *t.last_poll.lock().unwrap();
+        let polls = t.polls.load(Ordering::Relaxed);
+        let last_wake = match (send.last, timer.last) {
+            (Some(a), Some(b)) => Some(a.max(b)),
+            (a, b) => a.or(b),
+        };
+
+        // Wedge shape 1: woken, then never polled again.
+        let woken_not_polled = matches!(
+            (last_wake, last_poll),
+            (Some(w), Some(p)) if w > p && w.elapsed() > WEDGE_AFTER
+        );
+        // Wedge shape 2: the cap passed long ago and the timer wake was never
+        // delivered at all.
+        let timer_never_fired =
+            timer.count == 0 && t0.elapsed() > BUDGET + WEDGE_AFTER;
+
+        if woken_not_polled || timer_never_fired {
+            println!("WEDGE DETECTED after {:.1}s:", t0.elapsed().as_secs_f64());
+            println!(
+                "  guarded send: polled {polls} time(s) (last {}), cap {:.2}s",
+                age(last_poll),
+                BUDGET.as_secs_f64(),
+            );
+            println!(
+                "  send half woken {} time(s) ({}); timer half woken {} time(s) ({})",
+                send.count,
+                age(send.last),
+                timer.count,
+                age(timer.last),
+            );
+            if woken_not_polled {
+                println!(
+                    "  VERDICT: wake delivered, task never polled again — \
+                     the scheduler never ran this task"
+                );
+            } else {
+                println!(
+                    "  VERDICT: the cap passed and the timer wake was never \
+                     delivered — timer subsystem"
+                );
+            }
+
+            // Unpark probe: poke the runtime from outside.
+            let polls_before = t.polls.load(Ordering::Relaxed);
+            for _ in 0..4 {
+                handle.spawn(async {});
+            }
+            std::thread::sleep(Duration::from_secs(2));
+            let polls_after = t.polls.load(Ordering::Relaxed);
+            if polls_after > polls_before {
+                println!(
+                    "  UNPARK PROBE: spawning from outside UNWEDGED it \
+                     (polls {polls_before} -> {polls_after}) — the task was \
+                     queued and runnable; only the worker unpark was missing"
+                );
+            } else {
+                println!(
+                    "  UNPARK PROBE: still wedged after external spawns \
+                     (polls {polls_before} -> {polls_after}) — the queued \
+                     task itself was lost"
+                );
+            }
+            std::process::exit(1);
+        }
+
+        if t0.elapsed() > TRIAL_LIMIT {
+            println!(
+                "HARNESS FAULT: trial neither completed nor wedged in {:.0}s \
+                 (polls {polls}, send wakes {}, timer wakes {})",
+                TRIAL_LIMIT.as_secs_f64(),
+                send.count,
+                timer.count,
+            );
+            std::process::exit(2);
+        }
+    }
+}
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn main() {
+    // Oversubscribe the box, as the production wedge's loaded repro loop did
+    // (it burned half the cores in spinner processes). Self-contained here:
+    // plain std threads, outside the runtime, spinning for the whole run.
+    let spinners = env_u64(
+        "WEDGE_SPIN",
+        (std::thread::available_parallelism().map_or(4, |n| n.get()) / 2) as u64,
+    );
+    for _ in 0..spinners {
+        std::thread::spawn(|| loop {
+            std::hint::spin_loop();
+        });
+    }
+    let trials = env_u64("WEDGE_TRIALS", TRIALS);
+    println!(
+        "wedge-repro: {trials} trials, {spinners} spinner thread(s), cap {:?}",
+        BUDGET
+    );
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let t = Arc::new(Telemetry::new());
+    {
+        let t = Arc::clone(&t);
+        let handle = rt.handle().clone();
+        std::thread::spawn(move || watchdog(t, handle));
+    }
+
+    rt.block_on(async move {
+        // Steady churn, mirroring the loaded ext-host suite: tasks that
+        // yield, briefly sleep, and keep every worker busy-ish.
+        for i in 0..CHURN_TASKS {
+            tokio::spawn(async move {
+                let mut n = 0u64;
+                loop {
+                    tokio::task::yield_now().await;
+                    n += 1;
+                    if n % 64 == i as u64 % 64 {
+                        tokio::time::sleep(Duration::from_millis(1)).await;
+                    }
+                }
+            });
+        }
+        // Ready-task bursts, big enough to overflow a worker's local queue.
+        tokio::spawn(async {
+            loop {
+                for _ in 0..BURST {
+                    tokio::spawn(async {});
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        });
+        // spawn_blocking churn — the server runs analysis on the blocking pool
+        // constantly, and completions wake runtime tasks from non-worker
+        // threads, a distinct unpark path.
+        tokio::spawn(async {
+            loop {
+                let _ = tokio::task::spawn_blocking(|| std::hint::black_box(7u64) * 6).await;
+                tokio::time::sleep(Duration::from_millis(3)).await;
+            }
+        });
+        // Keep the I/O driver genuinely busy, as the server's stdin/stdout do:
+        // a duplex pipe with a writer task and a reader task.
+        let (mut a, mut b) = tokio::io::duplex(64);
+        tokio::spawn(async move {
+            use tokio::io::AsyncWriteExt as _;
+            loop {
+                if a.write_all(&[1u8; 16]).await.is_err() {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        });
+        tokio::spawn(async move {
+            use tokio::io::AsyncReadExt as _;
+            let mut buf = [0u8; 16];
+            while b.read_exact(&mut buf).await.is_ok() {}
+        });
+
+        let map = Arc::new(tokio::sync::Mutex::new(0u64));
+        for trial in 0..trials {
+            // Sweep the receiver's drain delay across the cap boundary.
+            let drain_delay =
+                Duration::from_millis((trial * 7) % (2 * BUDGET.as_millis() as u64 + 50));
+
+            // Zero-buffer channel: the pre-fill occupies the sender's one
+            // slot, so the guarded send genuinely parks — as the production
+            // send parks on tower-lsp's channel(1).
+            let (mut tx, mut rx) = futures::channel::mpsc::channel::<u64>(0);
+            tx.try_send(0).expect("pre-fill fits the sender slot");
+            assert!(
+                tx.try_send(0).is_err(),
+                "the channel must be full, or the guarded send will not park"
+            );
+
+            // Slow receiver — the "stalled client".
+            let receiver = tokio::spawn(async move {
+                tokio::time::sleep(drain_delay).await;
+                while rx.next().await.is_some() {}
+            });
+
+            // Waiters queued on the map, as in every production capture.
+            let mut waiters = Vec::new();
+            for _ in 0..WAITERS {
+                let map = Arc::clone(&map);
+                waiters.push(tokio::spawn(async move {
+                    *map.lock().await += 1;
+                }));
+            }
+
+            // The holder: lock the map, then the capped guarded send.
+            let holder = {
+                let map = Arc::clone(&map);
+                let t = Arc::clone(&t);
+                tokio::spawn(async move {
+                    let _guard = map.lock().await;
+                    t.arm();
+                    let out = SplitTimeout {
+                        sleep: Box::pin(tokio::time::sleep(BUDGET)),
+                        fut: Box::pin(async move { tx.send(1).await }),
+                        t: Arc::clone(&t),
+                    }
+                    .await;
+                    t.disarm();
+                    out
+                })
+            };
+
+            holder.await.expect("holder must not panic").ok();
+            for w in waiters {
+                w.await.expect("waiter must not panic");
+            }
+            receiver.await.expect("receiver must not panic");
+
+            if (trial + 1) % 50 == 0 {
+                println!("trial {}/{trials} clean", trial + 1);
+            }
+        }
+        println!("CLEAN PASS: {trials} trials, no wedge");
+    });
+}
+```
+
+### Running it
+
+```sh
+cargo build --release
+./target/release/wedge-repro                 # defaults: 400 trials, nproc/2 spinners
+WEDGE_TRIALS=3000 WEDGE_SPIN=5 ./target/release/wedge-repro
+echo $?   # 0 clean pass, 1 wedge (verdict printed), 2 harness fault
+```
+
+Expected on a healthy scheduler: `CLEAN PASS`, exit 0, in a few minutes.
+A wedge prints the same discrimination the server's stall line prints, plus
+the unpark-probe outcome.
+
+## Where the next session picks up
+
+1. The instruments are all merged; any future CI or loaded-loop wedge
+   self-diagnoses to the verdict line without new work.
+2. The discriminating observation still missing: during a live wedge, does an
+   *external* poke (a client request, or the probe's out-of-runtime spawn)
+   end it immediately? The production recovery pattern says yes; nobody has
+   triggered one on demand yet. The server-side equivalent of the unpark
+   probe — a std-thread watchdog that spawns a no-op task when the stall
+   reporter fires — would turn the ~100s recovery into a sub-second one *and*
+   confirm the lost-unpark frame in the same stroke. That is a candidate
+   mitigation, not a fix, and it is deliberately not implemented ahead of
+   direction.
+3. If confirmation is wanted at the OS layer: perf/ftrace on futex syscalls
+   around a live wedge would show whether the unpark futex op is issued and
+   lost or never issued.
+
+## Checkpoint index (issue #1657)
+
+Phases/census #1667: checkpoints 1–4 · holder tag + send caps #1670: 5–8 ·
+contention discriminator #1677: 13–17 · structure finding: 18 · poll shim +
+send telemetry #1679: 20–24 · tokio 1.51.1 result: 25.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -19,8 +19,7 @@
 # Floating stable toolchain. See docs/rust-rewrite.md for rationale.
 #
 # Resolved at run time, so `cargo clippy -D warnings` can start failing on
-# untouched code the day a new stable lands (1.97.0, 2026-07-07, widened
-# `question_mark` and added `manual_assert_eq`). Keep `Cargo.toml`'s
+# untouched code the day a new stable lands (1.98.0, 2026-08-18). Keep `Cargo.toml`'s
 # `rust-version` in step with whatever stable currently is.
 [toolchain]
 channel = "stable"

--- a/rust/tcl-lsp-server/Cargo.toml
+++ b/rust/tcl-lsp-server/Cargo.toml
@@ -93,6 +93,13 @@ tower = { version = "0.5", features = ["util"] }
 tokio = { version = "1", features = ["io-std", "io-util", "rt-multi-thread", "sync", "macros", "time"] }
 tower-lsp-server = "0.23"
 
+# Evidence-only extension of the native Tokio dependency. Cargo evaluates the
+# custom cfg from RUSTFLAGS, so the taskdump feature is absent from ordinary
+# and --all-features builds and present only for the explicit Linux evidence
+# invocation documented beside the hook in lib.rs.
+[target.'cfg(all(target_os = "linux", tokio_taskdump))'.dependencies]
+tokio = { version = "1", features = ["taskdump"] }
+
 [target.'cfg(target_family = "wasm")'.dependencies]
 # `io-std` and `rt-multi-thread` are hard compile errors on wasm32; `sync` and
 # `macros` are all the library needs, and both are runtime-free.

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -1314,6 +1314,205 @@ fn describe_documents_waiters(
     out
 }
 
+/// How far past its cap a holder send may run before the watchdog nudges.
+///
+/// The cap's timer is proven to fire exactly on time in every #1657 capture,
+/// so a send alive past `budget + this` means a delivered wake nobody polled —
+/// there is no legitimate cause.
+#[cfg(not(target_family = "wasm"))]
+const NUDGE_SEND_GRACE: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// How long a waiter may sit parked on a FREE map before the watchdog nudges
+/// (the run-12 shape). A held map never triggers this: waiters behind a
+/// holder are victims, and a long #1678-style hold must not cause false
+/// nudges.
+#[cfg(not(target_family = "wasm"))]
+const NUDGE_WAITER_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(4);
+
+/// Nudges fired since startup, for tests and post-mortem correlation.
+#[cfg(not(target_family = "wasm"))]
+pub static UNPARK_NUDGES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Why the watchdog would nudge right now, if it would.
+///
+/// Pure over the sampled telemetry, so the two trigger shapes are unit-tested
+/// exactly as the stall-line verdicts are. Both shapes are impossible on a
+/// healthy scheduler, which is the whole justification for acting on them:
+///
+/// * a holder send past its cap by [`NUDGE_SEND_GRACE`] — the cap's timer
+///   fires on time (four instrumented captures), so this is a delivered wake
+///   nobody polled;
+/// * a waiter parked on a **free** map past [`NUDGE_WAITER_THRESHOLD`] — a
+///   free fair mutex with a queued waiter hands over immediately.
+#[cfg(not(target_family = "wasm"))]
+fn nudge_reason(
+    contention: &DocumentsContention,
+    waiters: &[WaiterSnapshot],
+) -> Option<&'static str> {
+    if let Some(send) = contention.holder_send
+        && send.running_for > send.budget + NUDGE_SEND_GRACE
+    {
+        return Some("holder send past its cap");
+    }
+    if contention.held_by.is_none()
+        && waiters
+            .iter()
+            .any(|w| w.parked_for > NUDGE_WAITER_THRESHOLD)
+    {
+        return Some("waiter parked on a free map");
+    }
+    None
+}
+
+/// A progress signature: if any of this changes, the runtime resumed work.
+#[cfg(not(target_family = "wasm"))]
+fn nudge_progress_signature(
+    contention: &DocumentsContention,
+    waiters: &[WaiterSnapshot],
+) -> (Option<u64>, usize, u64) {
+    (
+        contention.holder_send.map(|s| s.polls),
+        waiters.len(),
+        waiters.iter().map(|w| w.polls).sum(),
+    )
+}
+
+/// One watchdog step: sample, decide, nudge, verify, report. Returns whether
+/// it nudged. Factored out of the thread loop so tests drive it directly.
+#[cfg(not(target_family = "wasm"))]
+fn unpark_watchdog_step(
+    store: &DocumentStore,
+    handle: &tokio::runtime::Handle,
+    log: &mut dyn std::io::Write,
+) -> bool {
+    let contention = store.contention();
+    let waiters = store.waiters();
+    let Some(reason) = nudge_reason(&contention, &waiters) else {
+        return false;
+    };
+    UNPARK_NUDGES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let before = nudge_progress_signature(&contention, &waiters);
+    // Plain facts, not the stall line's two-sample clauses — a nudge takes one
+    // sample, and borrowing wording that claims a sample window would be the
+    // instrument overclaiming again.
+    let holder = contention.held_by.map_or_else(
+        || "map free".to_owned(),
+        |h| format!("map held by {} ({:.1}s)", h.site, h.held.as_secs_f64()),
+    );
+    let send = contention.holder_send.map_or_else(
+        || "no send in flight".to_owned(),
+        |s| {
+            format!(
+                "{} at {:.1}s of a {:.1}s cap, polled {} time(s), timer woken {} time(s)",
+                s.what,
+                s.running_for.as_secs_f64(),
+                s.budget.as_secs_f64(),
+                s.polls,
+                s.timer_wakes,
+            )
+        },
+    );
+    let _ = writeln!(
+        log,
+        "[nudge] {reason}: {holder}; {send}; {} waiter(s) parked. Spawning no-op tasks \
+         from outside the runtime.",
+        waiters.len(),
+    );
+    // The poke: an external spawn takes the remote/inject path, which unparks
+    // a worker. Four, in case the first is consumed by an unrelated queue.
+    for _ in 0..4 {
+        handle.spawn(async {});
+    }
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    let after_c = store.contention();
+    let after_w = store.waiters();
+    let after = nudge_progress_signature(&after_c, &after_w);
+    if after == before {
+        let _ = writeln!(
+            log,
+            "[nudge] outcome: STILL WEDGED — polls unchanged 500ms after external spawns; \
+             the queued task itself is lost, not merely the worker unpark",
+        );
+    } else {
+        let _ = writeln!(
+            log,
+            "[nudge] outcome: resumed — progress signature {before:?} -> {after:?}; the task \
+             was queued and runnable, only the worker unpark was missing (issue #1657)",
+        );
+    }
+    true
+}
+
+/// Start the #1657 unpark watchdog: a plain std thread, deliberately outside
+/// the runtime it watches, so it cannot be starved by the fault it exists to
+/// break.
+///
+/// Samples the open-document map's telemetry every 250 ms; on a trigger shape
+/// (see [`nudge_reason`]) it spawns no-op tasks into the runtime from outside
+/// and logs the evidence and the outcome — to stderr always, and to the file
+/// named by `TCL_LSP_NUDGE_LOG` when set, because the ext-host harness does
+/// not reliably capture server stderr and the acceptance loop greps the file.
+///
+/// This is a mitigation, not a fix, and it hides nothing: every action logs
+/// the telemetry that triggered it and whether the poke worked, so a wedge
+/// that used to be invisible-but-minutes-long becomes visible-and-short. A
+/// `STILL WEDGED` outcome is the built-in falsifier for the lost-unpark frame.
+#[cfg(not(target_family = "wasm"))]
+pub fn spawn_unpark_watchdog(backend: &Backend, handle: tokio::runtime::Handle) {
+    let store = Arc::clone(&backend.documents);
+    std::thread::Builder::new()
+        .name("tcl-lsp-unpark-watchdog".into())
+        .spawn(move || {
+            let mut file = std::env::var("TCL_LSP_NUDGE_LOG").ok().and_then(|p| {
+                std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(p)
+                    .ok()
+            });
+            let mut last_nudge: Option<std::time::Instant> = None;
+            loop {
+                std::thread::sleep(std::time::Duration::from_millis(250));
+                // Rate limit: at most one nudge burst per second.
+                if last_nudge.is_some_and(|t| t.elapsed() < std::time::Duration::from_secs(1)) {
+                    continue;
+                }
+                let mut sink = NudgeLog {
+                    file: file.as_mut(),
+                };
+                if unpark_watchdog_step(&store, &handle, &mut sink) {
+                    last_nudge = Some(std::time::Instant::now());
+                }
+            }
+        })
+        .expect("spawning the unpark watchdog thread");
+}
+
+/// Tee for nudge lines: stderr always, plus the acceptance-loop file when set.
+#[cfg(not(target_family = "wasm"))]
+struct NudgeLog<'a> {
+    file: Option<&'a mut std::fs::File>,
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl std::io::Write for NudgeLog<'_> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let _ = std::io::stderr().write_all(buf);
+        if let Some(f) = self.file.as_mut() {
+            let _ = f.write_all(buf);
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        let _ = std::io::stderr().flush();
+        if let Some(f) = self.file.as_mut() {
+            let _ = f.flush();
+        }
+        Ok(())
+    }
+}
+
 /// Render the two contention samples a stall report takes into one clause.
 ///
 /// Split out of `Backend::report_edit_barrier_stall` to keep that function under
@@ -35625,6 +35824,152 @@ mod tests {
             !within_budget.contains("NEVER"),
             "a send inside its cap gets the plain reading, no verdict: \
              {within_budget}",
+        );
+    }
+
+    /// The nudge triggers exactly on the two impossible shapes, and on
+    /// nothing else.
+    ///
+    /// The watchdog acts on production state, so a wrong predicate is either a
+    /// mitigation that never fires (the wedge stays minutes long) or one that
+    /// fires on healthy states (pokes and log noise on every long #1678-style
+    /// hold). Each arm is pinned against its nearest legitimate neighbour.
+    #[test]
+    fn the_nudge_fires_on_impossible_shapes_only() {
+        let send = |running_ms: u64| SendSnapshot {
+            what: "publish send",
+            running_for: std::time::Duration::from_millis(running_ms),
+            budget: DELIVERY_SEND_BUDGET,
+            polls: 1,
+            since_last_poll: std::time::Duration::from_millis(running_ms),
+            timer_wakes: 1,
+            since_last_timer_wake: Some(std::time::Duration::from_millis(
+                running_ms.saturating_sub(2000),
+            )),
+            send_wakes: 0,
+        };
+        let held = HeldFor {
+            site: "deliver_if_current",
+            held: std::time::Duration::from_secs(5),
+            in_phase: std::time::Duration::from_secs(5),
+        };
+        let waiter = |parked_ms: u64| WaiterSnapshot {
+            site: "did_open",
+            parked_for: std::time::Duration::from_millis(parked_ms),
+            polls: 1,
+            since_last_poll: std::time::Duration::from_millis(parked_ms),
+            wakes: 0,
+            since_last_wake: None,
+        };
+        let contention =
+            |held_by: Option<HeldFor>, holder_send: Option<SendSnapshot>| DocumentsContention {
+                held_by,
+                last: None,
+                acquisitions: 1,
+                holder_send,
+            };
+
+        // Shape 1: a send past cap + grace. Its neighbour — a send merely past
+        // its cap — is what a healthy scheduler shows for an instant before
+        // the timer's poll lands; only the grace margin makes it impossible.
+        assert_eq!(
+            nudge_reason(&contention(Some(held), Some(send(4100))), &[]),
+            Some("holder send past its cap"),
+            "a send alive at cap+grace means a delivered wake nobody polled",
+        );
+        assert_eq!(
+            nudge_reason(&contention(Some(held), Some(send(2100))), &[]),
+            None,
+            "past the cap but inside the grace margin is the timer's poll in \
+             flight, not a wedge — nudging here would fire on healthy runs",
+        );
+
+        // Shape 2: a stale waiter on a FREE map. Its neighbour — the same
+        // waiter behind a HELD map — is every long #1678-style hold, and must
+        // not nudge.
+        assert_eq!(
+            nudge_reason(&contention(None, None), &[waiter(4100)]),
+            Some("waiter parked on a free map"),
+            "a fair mutex hands over immediately; a stale waiter on a free map \
+             was never resumed",
+        );
+        assert_eq!(
+            nudge_reason(&contention(Some(held), None), &[waiter(60_000)]),
+            None,
+            "a waiter behind a held map is a victim of the holder, however \
+             stale — nudging would fire on every long legitimate hold (#1678)",
+        );
+        assert_eq!(
+            nudge_reason(&contention(None, None), &[waiter(500)]),
+            None,
+            "a fresh waiter on a free map is an ordinary handoff in progress",
+        );
+        assert_eq!(
+            nudge_reason(&contention(None, None), &[]),
+            None,
+            "an idle map never nudges",
+        );
+    }
+
+    /// The watchdog step nudges a wedged-looking store and leaves a healthy
+    /// one alone — driven directly, as the thread loop drives it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn the_watchdog_step_nudges_only_a_wedged_store() {
+        let store = Arc::new(DocumentStore::default());
+        let handle = tokio::runtime::Handle::current();
+        let mut log = Vec::new();
+
+        // Healthy: idle store, no nudge, nothing logged.
+        assert!(
+            !unpark_watchdog_step(&store, &handle, &mut log),
+            "an idle store must not be nudged",
+        );
+        assert!(log.is_empty(), "no action, no log line");
+
+        // Wedged-looking: a holder send whose telemetry is backdated past
+        // cap + grace, registered exactly as the real send registers it.
+        let old = crate::rt::Instant::now() - (DELIVERY_SEND_BUDGET + NUDGE_SEND_GRACE * 2);
+        let telemetry = Arc::new(std::sync::Mutex::new(SendTelemetry {
+            what: "publish send",
+            started: old,
+            budget: DELIVERY_SEND_BUDGET,
+            polls: 1,
+            last_poll: old,
+            send_wakes: Arc::new(std::sync::Mutex::new(WakeRecord::default())),
+            timer_wakes: Arc::new(std::sync::Mutex::new(WakeRecord::default())),
+        }));
+        let _held = store.lock("test-holder").await;
+        let _registered = store.begin_holder_send(telemetry);
+
+        let nudges_before = UNPARK_NUDGES.load(std::sync::atomic::Ordering::Relaxed);
+        // Run the step off the runtime, as the real watchdog thread does — it
+        // sleeps 500ms inline, which must not block a worker in this test.
+        let stepped = {
+            let store = Arc::clone(&store);
+            let handle = handle.clone();
+            tokio::task::spawn_blocking(move || {
+                let mut log = Vec::new();
+                let stepped = unpark_watchdog_step(&store, &handle, &mut log);
+                (stepped, log)
+            })
+            .await
+            .expect("watchdog step must not panic")
+        };
+        assert!(stepped.0, "a send past cap+grace must be nudged");
+        let logged = String::from_utf8(stepped.1).expect("log is utf8");
+        assert!(
+            logged.contains("[nudge] holder send past its cap"),
+            "the nudge must log its reason and evidence: {logged}",
+        );
+        assert!(
+            logged.contains("[nudge] outcome:"),
+            "the nudge must log its outcome — the outcome line is the built-in \
+             falsifier for the lost-unpark frame: {logged}",
+        );
+        assert_eq!(
+            UNPARK_NUDGES.load(std::sync::atomic::Ordering::Relaxed),
+            nudges_before + 1,
+            "each nudge counts",
         );
     }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -812,23 +812,15 @@ impl DocumentStore {
     }
 
     /// The holder's in-flight send, if any, aged against `now`.
+    ///
+    /// A convenience for tests; [`Self::contention`] does **not** call this —
+    /// it clones the entry inside its own single tracking acquisition, so the
+    /// holder and the send it is paired with come from one snapshot (Codex P2
+    /// on #1679).
+    #[cfg(test)]
     fn holder_send_at(&self, now: crate::rt::Instant) -> Option<SendSnapshot> {
         let entry = self.tracking().holder_send.clone()?;
-        let t = entry
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        Some(SendSnapshot {
-            what: t.what,
-            running_for: now.duration_since(t.started),
-            budget: t.budget,
-            polls: t.polls,
-            since_last_poll: now.duration_since(t.last_poll),
-            timer_wakes: read_wake_record(&t.timer_wakes).count,
-            since_last_timer_wake: read_wake_record(&t.timer_wakes)
-                .last
-                .map(|w| now.duration_since(w)),
-            send_wakes: read_wake_record(&t.send_wakes).count,
-        })
+        Some(send_snapshot(&entry, now))
     }
 
     /// Every current waiter, aged against one clock reading.
@@ -865,19 +857,29 @@ impl DocumentStore {
         // *instant*. Both are needed — an earlier version had only the second
         // and could still pair one task's identity with another's metadata.
         let now = crate::rt::Instant::now();
-        let (held_by, last, acquisitions) = {
+        // ONE tracking acquisition for every pairing-sensitive field. The send
+        // entry is cloned in the same acquisition as the holder it belongs to:
+        // it is registered and cleared under the map hold, so an entry seen
+        // beside a holder was registered *by* that holder. Read in a second
+        // acquisition (as an earlier version did), a holder change in between
+        // attributed the new holder's send to the old holder — the torn-
+        // snapshot family this struct's single lock exists to close (Codex P2
+        // on #1679). The telemetry's own counters are read after, under its
+        // own lock; the *pairing* is what the tracking snapshot fixes.
+        let (held_by, last, acquisitions, send_entry) = {
             let tracking = self.tracking();
             (
                 tracking.holder.map(|h| held_for(&h, now)),
                 tracking.last.map(|h| (h.site, now.duration_since(h.since))),
                 tracking.acquisitions,
+                tracking.holder_send.clone(),
             )
         };
         DocumentsContention {
             held_by,
             last,
             acquisitions,
-            holder_send: self.holder_send_at(now),
+            holder_send: send_entry.map(|entry| send_snapshot(&entry, now)),
         }
     }
 
@@ -959,6 +961,35 @@ struct InstrumentedSendTimeout<S, F> {
     sleep: Pin<Box<S>>,
     send: Pin<Box<F>>,
     telemetry: Arc<std::sync::Mutex<SendTelemetry>>,
+}
+
+/// Snapshot one in-flight send, aged against `now`.
+///
+/// Each [`WakeRecord`] is read **once** into a local and both of its derived
+/// fields come from that read (Codex P2 on #1679). Read twice, a wake landing
+/// between the reads produced `timer_wakes: 0` alongside a `since_last_timer_wake`
+/// — and the verdict clause keys on the latter, so the stall line would print
+/// "timer half woken 0 time(s)" next to "the timer FIRED", a self-contradiction
+/// in exactly the discriminator the downgrade experiment depends on.
+fn send_snapshot(
+    entry: &Arc<std::sync::Mutex<SendTelemetry>>,
+    now: crate::rt::Instant,
+) -> SendSnapshot {
+    let t = entry
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let timer = read_wake_record(&t.timer_wakes);
+    let send = read_wake_record(&t.send_wakes);
+    SendSnapshot {
+        what: t.what,
+        running_for: now.duration_since(t.started),
+        budget: t.budget,
+        polls: t.polls,
+        since_last_poll: now.duration_since(t.last_poll),
+        timer_wakes: timer.count,
+        since_last_timer_wake: timer.last.map(|w| now.duration_since(w)),
+        send_wakes: send.count,
+    }
 }
 
 /// A [`WakeRecord`] read without poisoning concerns.
@@ -1231,7 +1262,9 @@ fn describe_documents_waiters(
         if map_held {
             let _ = write!(
                 out,
-                "The map's acquire queue holds {} (parked {:.1}s, polled {} time(s),                  woken {} time(s) — a victim of the holder above, no wake due until it                  releases). ",
+                "The map's acquire queue holds {} (parked {:.1}s, polled {} time(s), \
+                 woken {} time(s) — a victim of the holder above, no wake due until it \
+                 releases). ",
                 w.site,
                 w.parked_for.as_secs_f64(),
                 w.polls,
@@ -35019,8 +35052,17 @@ mod tests {
             );
             assert_eq!(snap.acquisitions, 2);
         }
+    }
 
-        // --- the concurrent half: a genuinely impossible pairing ---
+    /// The concurrent half of the snapshot-coherence pin: genuinely impossible
+    /// pairings, hammered.
+    ///
+    /// Split from [`a_contention_snapshot_never_mixes_two_states`]'s
+    /// deterministic transition checks purely for the line-count lint; the two
+    /// are one argument, and the doc comment there carries it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn a_contention_snapshot_survives_concurrent_hammering() {
+        let store = Arc::new(DocumentStore::default());
         //
         // Every acquisition uses a site name used exactly once, ever. A site can
         // then never be both the current holder and the most recent previous
@@ -35045,7 +35087,21 @@ mod tests {
                         // `&'static str` per acquisition. Leaked deliberately and
                         // bounded by the loop below; a few thousand short strings.
                         let site: &'static str = Box::leak(format!("hammer-{n}").into_boxed_str());
-                        drop(store.lock(site).await);
+                        let held = store.lock(site).await;
+                        // Run an instrumented send under the hold, tagged with
+                        // the SAME unique string, so the sampler can check that
+                        // a snapshot never pairs one holder with another
+                        // holder's send (Codex P2 on #1679: `contention` read
+                        // the holder and the send entry under two separate
+                        // tracking acquisitions, and a holder change between
+                        // them attributed the new holder's send to the old).
+                        let _ = instrumented_delivery_send(&store, site, async {
+                            for _ in 0..32 {
+                                crate::rt::yield_now().await;
+                            }
+                        })
+                        .await;
+                        drop(held);
                         crate::rt::yield_now().await;
                     }
                 })
@@ -35054,7 +35110,8 @@ mod tests {
 
         let mut previous = store.contention().acquisitions;
         let mut seen_both = 0_u32;
-        for _ in 0..20_000 {
+        let mut seen_pairs = 0_u32;
+        for _ in 0..100_000 {
             let snap = store.contention();
             assert!(
                 snap.acquisitions >= previous,
@@ -35076,6 +35133,18 @@ mod tests {
                     "a snapshot showing a holder must show its acquisition too",
                 );
             }
+            if let (Some(held), Some(send)) = (snap.held_by, snap.holder_send) {
+                seen_pairs += 1;
+                assert_eq!(
+                    held.site, send.what,
+                    "this snapshot pairs one holder with another holder's send. \
+                     Every hold tags its send with its own unique string, so the \
+                     two can only disagree if the holder and the send entry were \
+                     read under different tracking acquisitions — and a stall \
+                     line built from them would attribute the send verdict to \
+                     the wrong task (Codex P2 on #1679)",
+                );
+            }
         }
 
         stop.store(true, std::sync::atomic::Ordering::Relaxed);
@@ -35086,6 +35155,12 @@ mod tests {
             seen_both > 0,
             "the hammer never caught the map held with a previous holder \
              recorded, so the concurrent half proved nothing",
+        );
+        assert!(
+            seen_pairs > 0,
+            "the sampler never caught a holder together with its in-flight \
+             send, so the pairing assertion above was vacuous and proved \
+             nothing",
         );
     }
 
@@ -35334,7 +35409,8 @@ mod tests {
         );
         assert!(
             !held_victim.contains("lost or never sent"),
-            "a waiter behind a held map must not be given the lost-wake verdict:              {held_victim}",
+            "a waiter behind a held map must not be given the lost-wake verdict: \
+             {held_victim}",
         );
     }
 
@@ -35446,6 +35522,66 @@ mod tests {
             t.polls >= 2,
             "the expiry requires a poll after the wake, and it must be counted",
         );
+    }
+
+    /// A wake-record snapshot must come from one read, not two.
+    ///
+    /// Codex P2 on #1679. `SendSnapshot` used to read the same `WakeRecord`
+    /// twice — once for the count, once for the last-wake instant. A wake
+    /// landing between the reads produced `count: 0` alongside
+    /// `last: Some(..)`, and the verdict clause keys on the latter: the stall
+    /// line would print "timer half woken 0 time(s)" beside "the timer FIRED",
+    /// a self-contradiction in the exact discriminator the tokio-downgrade
+    /// experiment depends on.
+    ///
+    /// Raced with a fresh record per iteration because the counters are
+    /// monotonic: after the first wake, `count >= 1` for ever and the torn
+    /// pairing is unobservable, so one long-lived record would test nothing.
+    /// Per iteration the writer fires exactly one wake while the sampler
+    /// tight-loops; against the double-read implementation the sampler's
+    /// window lands inside the tear often enough that four thousand
+    /// iterations catch it dependably.
+    #[test]
+    fn a_wake_record_snapshot_is_one_read() {
+        for _ in 0..4_000 {
+            let entry = Arc::new(std::sync::Mutex::new(SendTelemetry {
+                what: "raced send",
+                started: crate::rt::Instant::now(),
+                budget: DELIVERY_SEND_BUDGET,
+                polls: 1,
+                last_poll: crate::rt::Instant::now(),
+                send_wakes: Arc::new(std::sync::Mutex::new(WakeRecord::default())),
+                timer_wakes: Arc::new(std::sync::Mutex::new(WakeRecord::default())),
+            }));
+            let record = Arc::clone(
+                &entry
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .timer_wakes,
+            );
+            let writer = std::thread::spawn(move || {
+                let mut r = record
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                r.count += 1;
+                r.last = Some(crate::rt::Instant::now());
+            });
+            let now = crate::rt::Instant::now();
+            loop {
+                let snap = send_snapshot(&entry, now);
+                assert!(
+                    snap.since_last_timer_wake.is_none() || snap.timer_wakes >= 1,
+                    "a snapshot reports a last timer wake with a zero wake count \
+                     — the two fields were read from the record at different \
+                     moments, and the stall line built from them contradicts \
+                     itself in the timer verdict (Codex P2 on #1679)",
+                );
+                if snap.timer_wakes >= 1 {
+                    break;
+                }
+            }
+            writer.join().expect("writer thread must not panic");
+        }
     }
 
     /// The holder-send clause must state the right verdict for each shape.

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -548,75 +548,6 @@ struct DocumentsTracking {
     /// Each entry is its own `Arc<Mutex<..>>` so the per-poll updates never
     /// touch this tracking lock.
     waiters: Vec<Arc<std::sync::Mutex<WaiterTelemetry>>>,
-    /// Telemetry for the client send the map's holder is currently awaiting,
-    /// if it is in one (issue #1657).
-    ///
-    /// The run-1 poll-shim capture found the holder frozen inside a 2s
-    /// `timeout` for 149.3s — on a runtime whose time driver was demonstrably
-    /// firing other timers, including the two that produced the very report.
-    /// This records what that timeout actually experienced: polls of the
-    /// combined future, wakes delivered by the send half, and wakes delivered
-    /// by the timer half, separately — because "the timer never fired" and
-    /// "the timer fired and the task was never polled again" are different
-    /// faults in different subsystems.
-    holder_send: Option<Arc<std::sync::Mutex<SendTelemetry>>>,
-}
-
-/// What the holder's capped client send has experienced so far.
-#[derive(Debug)]
-struct SendTelemetry {
-    /// Which send — the `[timing]` marker or the publish.
-    what: &'static str,
-    started: crate::rt::Instant,
-    /// The cap the send was given ([`DELIVERY_SEND_BUDGET`]).
-    budget: std::time::Duration,
-    polls: u64,
-    last_poll: crate::rt::Instant,
-    /// Wake deliveries, split by which half of the timeout delivered them.
-    ///
-    /// `Arc`s rather than inline fields: the wakers write these directly from
-    /// the wake path, which must not contend with (or wait on) the telemetry
-    /// lock a sampling reporter might be holding.
-    send_wakes: Arc<std::sync::Mutex<WakeRecord>>,
-    timer_wakes: Arc<std::sync::Mutex<WakeRecord>>,
-}
-
-/// Invocations of one wrapped waker: how many, and when last.
-#[derive(Debug, Clone, Copy, Default)]
-struct WakeRecord {
-    count: u64,
-    last: Option<crate::rt::Instant>,
-}
-
-/// A waker wrapper that records each invocation into a [`WakeRecord`] before
-/// forwarding. Record-then-forward, so a poll caused by this wake can never be
-/// sampled before the wake that caused it.
-struct RecordingWaker {
-    real: std::task::Waker,
-    record: Arc<std::sync::Mutex<WakeRecord>>,
-}
-
-impl RecordingWaker {
-    fn record(&self) {
-        let mut r = self
-            .record
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        r.count += 1;
-        r.last = Some(crate::rt::Instant::now());
-    }
-}
-
-impl std::task::Wake for RecordingWaker {
-    fn wake(self: Arc<Self>) {
-        self.record();
-        self.real.wake_by_ref();
-    }
-
-    fn wake_by_ref(self: &Arc<Self>) {
-        self.record();
-        self.real.wake_by_ref();
-    }
 }
 
 /// Poll/wake telemetry for one task parked on the open-document map.
@@ -652,17 +583,24 @@ struct WaiterTelemetry {
     /// Times this waiter's waker has been invoked.
     wakes: u64,
     last_wake: Option<crate::rt::Instant>,
+    /// Exact Tokio task waiting on this acquire. Native evidence only.
+    #[cfg(not(target_family = "wasm"))]
+    task_id: Option<tokio::task::Id>,
 }
 
 /// One waiter's telemetry, aged against a single clock reading for the report.
 #[derive(Debug, Clone, Copy)]
 struct WaiterSnapshot {
+    /// Identity of the telemetry registration, stable until deregistration.
+    telemetry_id: usize,
     site: &'static str,
     parked_for: std::time::Duration,
     polls: u64,
     since_last_poll: std::time::Duration,
     wakes: u64,
     since_last_wake: Option<std::time::Duration>,
+    #[cfg(not(target_family = "wasm"))]
+    task_id: Option<tokio::task::Id>,
 }
 
 /// Wraps the real waker so an invocation is recorded before it is forwarded.
@@ -783,6 +721,8 @@ impl DocumentStore {
             last_poll: now,
             wakes: 0,
             last_wake: None,
+            #[cfg(not(target_family = "wasm"))]
+            task_id: tokio::task::try_id(),
         }));
         self.tracking().waiters.push(Arc::clone(&telemetry));
         let _deregister = DeregisterWaiter {
@@ -796,33 +736,6 @@ impl DocumentStore {
         .await
     }
 
-    /// Register `telemetry` as the holder's in-flight send, returning a guard
-    /// that deregisters it — on completion or on cancellation alike.
-    ///
-    /// **Precondition:** the caller holds the map (same contract as
-    /// [`Self::retag_held`], and every call site is inside
-    /// `DeliveryCtx::cache_and_deliver`, which both callers run under their
-    /// guard).
-    fn begin_holder_send(
-        &self,
-        telemetry: Arc<std::sync::Mutex<SendTelemetry>>,
-    ) -> HolderSendGuard<'_> {
-        self.tracking().holder_send = Some(telemetry);
-        HolderSendGuard { store: self }
-    }
-
-    /// The holder's in-flight send, if any, aged against `now`.
-    ///
-    /// A convenience for tests; [`Self::contention`] does **not** call this —
-    /// it clones the entry inside its own single tracking acquisition, so the
-    /// holder and the send it is paired with come from one snapshot (Codex P2
-    /// on #1679).
-    #[cfg(test)]
-    fn holder_send_at(&self, now: crate::rt::Instant) -> Option<SendSnapshot> {
-        let entry = self.tracking().holder_send.clone()?;
-        Some(send_snapshot(&entry, now))
-    }
-
     /// Every current waiter, aged against one clock reading.
     fn waiters(&self) -> Vec<WaiterSnapshot> {
         let now = crate::rt::Instant::now();
@@ -834,15 +747,60 @@ impl DocumentStore {
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
                 WaiterSnapshot {
+                    telemetry_id: Arc::as_ptr(entry) as usize,
                     site: t.site,
                     parked_for: now.duration_since(t.parked_since),
                     polls: t.polls,
                     since_last_poll: now.duration_since(t.last_poll),
                     wakes: t.wakes,
                     since_last_wake: t.last_wake.map(|w| now.duration_since(w)),
+                    #[cfg(not(target_family = "wasm"))]
+                    task_id: t.task_id,
                 }
             })
             .collect()
+    }
+
+    /// One coherent watchdog sample. Holder, acquisition counter and waiter
+    /// registrations are cloned under one tracking lock and aged from one
+    /// clock reading, so the detector cannot combine states that never existed
+    /// together.
+    #[cfg(not(target_family = "wasm"))]
+    fn watchdog_snapshot(&self) -> (DocumentsContention, Vec<WaiterSnapshot>) {
+        let now = crate::rt::Instant::now();
+        let (held_by, last, acquisitions, waiter_entries) = {
+            let tracking = self.tracking();
+            (
+                tracking.holder.map(|h| held_for(&h, now)),
+                tracking.last.map(|h| (h.site, now.duration_since(h.since))),
+                tracking.acquisitions,
+                tracking.waiters.clone(),
+            )
+        };
+        let contention = DocumentsContention {
+            held_by,
+            last,
+            acquisitions,
+        };
+        let waiters = waiter_entries
+            .iter()
+            .map(|entry| {
+                let t = entry
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                WaiterSnapshot {
+                    telemetry_id: Arc::as_ptr(entry) as usize,
+                    site: t.site,
+                    parked_for: now.duration_since(t.parked_since),
+                    polls: t.polls,
+                    since_last_poll: now.duration_since(t.last_poll),
+                    wakes: t.wakes,
+                    since_last_wake: t.last_wake.map(|w| now.duration_since(w)),
+                    task_id: t.task_id,
+                }
+            })
+            .collect();
+        (contention, waiters)
     }
 
     /// Everything the stall line needs about this map in one sample.
@@ -857,29 +815,18 @@ impl DocumentStore {
         // *instant*. Both are needed — an earlier version had only the second
         // and could still pair one task's identity with another's metadata.
         let now = crate::rt::Instant::now();
-        // ONE tracking acquisition for every pairing-sensitive field. The send
-        // entry is cloned in the same acquisition as the holder it belongs to:
-        // it is registered and cleared under the map hold, so an entry seen
-        // beside a holder was registered *by* that holder. Read in a second
-        // acquisition (as an earlier version did), a holder change in between
-        // attributed the new holder's send to the old holder — the torn-
-        // snapshot family this struct's single lock exists to close (Codex P2
-        // on #1679). The telemetry's own counters are read after, under its
-        // own lock; the *pairing* is what the tracking snapshot fixes.
-        let (held_by, last, acquisitions, send_entry) = {
+        let (held_by, last, acquisitions) = {
             let tracking = self.tracking();
             (
                 tracking.holder.map(|h| held_for(&h, now)),
                 tracking.last.map(|h| (h.site, now.duration_since(h.since))),
                 tracking.acquisitions,
-                tracking.holder_send.clone(),
             )
         };
         DocumentsContention {
             held_by,
             last,
             acquisitions,
-            holder_send: send_entry.map(|entry| send_snapshot(&entry, now)),
         }
     }
 
@@ -887,9 +834,9 @@ impl DocumentStore {
     ///
     /// [`DocumentsGuard::retag`] is the same operation for a caller that has the
     /// guard in hand. This one exists for code that runs *under* a caller's
-    /// guard without being given it — `DeliveryCtx::cache_and_deliver`, which
-    /// both of its callers invoke while holding the map, and which has its own
-    /// awaits worth telling apart (issue #1657).
+    /// guard without being given it — `DeliveryCtx::cache_and_enqueue`, which
+    /// both of its callers invoke while holding the map, and whose pull-cache
+    /// await is worth naming separately (issue #1657).
     ///
     /// **Precondition:** the calling task must be the holder. There is no way to
     /// check that, so a call from a task that does not hold the map would
@@ -924,147 +871,6 @@ impl DocumentStore {
     }
 }
 
-/// Clears [`DocumentsTracking::holder_send`] when the send ends — by success,
-/// timeout, or the whole delivery future being dropped.
-struct HolderSendGuard<'a> {
-    store: &'a DocumentStore,
-}
-
-impl Drop for HolderSendGuard<'_> {
-    fn drop(&mut self) {
-        self.store.tracking().holder_send = None;
-    }
-}
-
-/// The holder's in-flight send, aged against one clock reading.
-#[derive(Debug, Clone, Copy)]
-struct SendSnapshot {
-    what: &'static str,
-    running_for: std::time::Duration,
-    budget: std::time::Duration,
-    polls: u64,
-    since_last_poll: std::time::Duration,
-    timer_wakes: u64,
-    since_last_timer_wake: Option<std::time::Duration>,
-    send_wakes: u64,
-}
-
-/// `crate::rt::timeout`, hand-rolled so each half's wakes are recorded
-/// separately (issue #1657).
-///
-/// Polls the send before the sleep, exactly as `tokio::time::timeout` does, so
-/// a send that completes at the deadline still wins. Each half is polled
-/// through its own [`RecordingWaker`], so a later stall line can say **which**
-/// wake arrived — "the timer never fired" and "the timer fired and the task
-/// was never polled again" indict different subsystems.
-struct InstrumentedSendTimeout<S, F> {
-    sleep: Pin<Box<S>>,
-    send: Pin<Box<F>>,
-    telemetry: Arc<std::sync::Mutex<SendTelemetry>>,
-}
-
-/// Snapshot one in-flight send, aged against `now`.
-///
-/// Each [`WakeRecord`] is read **once** into a local and both of its derived
-/// fields come from that read (Codex P2 on #1679). Read twice, a wake landing
-/// between the reads produced `timer_wakes: 0` alongside a `since_last_timer_wake`
-/// — and the verdict clause keys on the latter, so the stall line would print
-/// "timer half woken 0 time(s)" next to "the timer FIRED", a self-contradiction
-/// in exactly the discriminator the downgrade experiment depends on.
-fn send_snapshot(
-    entry: &Arc<std::sync::Mutex<SendTelemetry>>,
-    now: crate::rt::Instant,
-) -> SendSnapshot {
-    let t = entry
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let timer = read_wake_record(&t.timer_wakes);
-    let send = read_wake_record(&t.send_wakes);
-    SendSnapshot {
-        what: t.what,
-        running_for: now.duration_since(t.started),
-        budget: t.budget,
-        polls: t.polls,
-        since_last_poll: now.duration_since(t.last_poll),
-        timer_wakes: timer.count,
-        since_last_timer_wake: timer.last.map(|w| now.duration_since(w)),
-        send_wakes: send.count,
-    }
-}
-
-/// A [`WakeRecord`] read without poisoning concerns.
-fn read_wake_record(record: &Arc<std::sync::Mutex<WakeRecord>>) -> WakeRecord {
-    *record
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-}
-
-impl<S: Future<Output = ()>, F: Future> Future for InstrumentedSendTimeout<S, F> {
-    type Output = Result<F::Output, ()>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
-        let (send_record, timer_record) = {
-            let mut t = self
-                .telemetry
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            t.polls += 1;
-            t.last_poll = crate::rt::Instant::now();
-            (Arc::clone(&t.send_wakes), Arc::clone(&t.timer_wakes))
-        };
-        // Send half first, exactly as `tokio::time::timeout` orders its polls,
-        // so a send completing at the deadline still wins. Fresh wrappers per
-        // poll for the same reason as `InstrumentedAcquire`: each half replaces
-        // its registered waker on every poll, and a reused wrapper would count
-        // wakes delivered to a waker no longer registered anywhere.
-        let send_waker = std::task::Waker::from(Arc::new(RecordingWaker {
-            real: cx.waker().clone(),
-            record: send_record,
-        }));
-        let mut send_cx = std::task::Context::from_waker(&send_waker);
-        if let Poll::Ready(out) = self.send.as_mut().poll(&mut send_cx) {
-            return Poll::Ready(Ok(out));
-        }
-        let timer_waker = std::task::Waker::from(Arc::new(RecordingWaker {
-            real: cx.waker().clone(),
-            record: timer_record,
-        }));
-        let mut timer_cx = std::task::Context::from_waker(&timer_waker);
-        if self.sleep.as_mut().poll(&mut timer_cx).is_ready() {
-            return Poll::Ready(Err(()));
-        }
-        Poll::Pending
-    }
-}
-
-/// Run `send` under [`DELIVERY_SEND_BUDGET`], with the holder-send telemetry
-/// registered for the stall line while it runs (issue #1657).
-///
-/// The behavioural contract is `crate::rt::timeout(DELIVERY_SEND_BUDGET, send)`
-/// exactly; what is added is the split wake accounting above.
-async fn instrumented_delivery_send<F: Future>(
-    store: &DocumentStore,
-    what: &'static str,
-    send: F,
-) -> Result<F::Output, ()> {
-    let now = crate::rt::Instant::now();
-    let telemetry = Arc::new(std::sync::Mutex::new(SendTelemetry {
-        what,
-        started: now,
-        budget: DELIVERY_SEND_BUDGET,
-        polls: 0,
-        last_poll: now,
-        send_wakes: Arc::new(std::sync::Mutex::new(WakeRecord::default())),
-        timer_wakes: Arc::new(std::sync::Mutex::new(WakeRecord::default())),
-    }));
-    let _registered = store.begin_holder_send(Arc::clone(&telemetry));
-    InstrumentedSendTimeout {
-        sleep: Box::pin(crate::rt::sleep(DELIVERY_SEND_BUDGET)),
-        send: Box::pin(send),
-        telemetry,
-    }
-    .await
-}
 /// Removes a [`WaiterTelemetry`] registration when the acquire ends — by
 /// success **or** by cancellation. Identity is the `Arc` pointer, so two
 /// waiters from the same site never remove each other's entries.
@@ -1177,79 +983,24 @@ impl Drop for DocumentsGuard<'_> {
     }
 }
 
-/// Render the holder's in-flight send into its verdict clause (issue #1657).
-///
-/// The run-1 poll-shim capture found the holder inside a 2s cap for 149.3s and
-/// could not say why. This clause can. A send past its budget with:
-///
-/// * **zero timer wakes** — the deadline passed and the timer's wake was never
-///   delivered: the fault is in the timer subsystem (or the timer entry was
-///   lost), not in this task's scheduling.
-/// * **a timer wake after the last poll** — the timer fired and the task was
-///   never polled again: the wake was delivered and the scheduler never ran the
-///   task, which is a task-resumption fault.
-/// * **a poll after the deadline** — cannot happen while still parked: a poll
-///   after the deadline completes the timeout. Seeing it here means the clock
-///   and the report disagree, which is its own finding.
-fn describe_holder_send(send: &SendSnapshot) -> String {
-    let over_budget = send.running_for > send.budget;
-    let base = format!(
-        "; its {} has run {:.1}s against a {:.1}s cap, polled {} time(s) (last {:.1}s ago), \
-         send half woken {} time(s), timer half woken {} time(s)",
-        send.what,
-        send.running_for.as_secs_f64(),
-        send.budget.as_secs_f64(),
-        send.polls,
-        send.since_last_poll.as_secs_f64(),
-        send.send_wakes,
-        send.timer_wakes,
-    );
-    if !over_budget {
-        return base;
-    }
-    match send.since_last_timer_wake {
-        None => format!(
-            "{base} — the cap passed and the TIMER WAKE WAS NEVER DELIVERED: the fault is \
-             in the timer subsystem, not this task's scheduling"
-        ),
-        Some(age) if age < send.since_last_poll => format!(
-            "{base} — the timer FIRED {:.1}s ago and the task was NEVER POLLED again: the \
-             wake was delivered and the scheduler never ran this task",
-            age.as_secs_f64(),
-        ),
-        Some(_) => format!(
-            "{base} — a timer wake predates the last poll yet the send is still parked \
-             past its cap, which should be impossible: distrust the clock or this \
-             instrument before the runtime"
-        ),
-    }
-}
-
-/// Render the map's waiter telemetry and the parent-liveness counter into the
-/// stall line's poll-discrimination clause (issue #1657).
+/// Render the map's waiter telemetry into the stall line's
+/// poll-discrimination clause (issue #1657).
 ///
 /// This is the reading that separates the three remaining stories for a waiter
 /// parked on a free map:
 ///
 /// * **woken after its last poll** — the wake arrived and nothing polled the
-///   future again. With `handler_polls` climbing, the parent `buffer_unordered`
-///   is driving *other* children, so this one was lost between the parent and
-///   the child; with it frozen, the parent task itself is not being driven.
+///   future again. This proves the exact waiter is not being driven; it does not
+///   guess where between wake delivery and polling it was lost.
 /// * **never woken since parking** — the wake was genuinely lost (or never
 ///   sent).
 ///
 /// Pure formatting over snapshots, split out for the same reason as
 /// [`describe_documents_contention`].
-fn describe_documents_waiters(
-    waiters: &[WaiterSnapshot],
-    map_held: bool,
-    handler_polls: u64,
-) -> String {
+fn describe_documents_waiters(waiters: &[WaiterSnapshot], map_held: bool) -> String {
     if waiters.is_empty() {
-        return format!(
-            "No task is in the map's contended-acquire path (its instrumented slow path), \
-             and handler futures were polled {handler_polls} time(s) in the sample window."
-        );
+        return "No task is in the map's contended-acquire path (its instrumented slow path)."
+            .to_owned();
     }
     let mut out = String::new();
     for w in waiters {
@@ -1298,29 +1049,8 @@ fn describe_documents_waiters(
             w.wakes,
         );
     }
-    {
-        use std::fmt::Write as _;
-        let _ = write!(
-            out,
-            "Handler futures were polled {handler_polls} time(s) in the sample window{}.",
-            if handler_polls == 0 {
-                " — the transport's parent task is not being driven at all, which starves \
-                 every handler child together"
-            } else {
-                " — the parent task is alive and driving other children"
-            },
-        );
-    }
     out
 }
-
-/// How far past its cap a holder send may run before the watchdog nudges.
-///
-/// The cap's timer is proven to fire exactly on time in every #1657 capture,
-/// so a send alive past `budget + this` means a delivered wake nobody polled —
-/// there is no legitimate cause.
-#[cfg(not(target_family = "wasm"))]
-const NUDGE_SEND_GRACE: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// How long a waiter may sit parked on a FREE map before the watchdog nudges
 /// (the run-12 shape). A held map never triggers this: waiters behind a
@@ -1333,48 +1063,47 @@ const NUDGE_WAITER_THRESHOLD: std::time::Duration = std::time::Duration::from_se
 #[cfg(not(target_family = "wasm"))]
 pub static UNPARK_NUDGES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
+/// The exact telemetry registration a watchdog experiment acts on.
+#[cfg(not(target_family = "wasm"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct NudgeTarget {
+    telemetry_id: usize,
+    polls: u64,
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl NudgeTarget {
+    fn progressed(self, waiters: &[WaiterSnapshot]) -> bool {
+        waiters
+            .iter()
+            .find(|waiter| waiter.telemetry_id == self.telemetry_id)
+            .is_none_or(|waiter| waiter.polls > self.polls)
+    }
+}
+
 /// Why the watchdog would nudge right now, if it would.
 ///
-/// Pure over the sampled telemetry, so the two trigger shapes are unit-tested
-/// exactly as the stall-line verdicts are. Both shapes are impossible on a
-/// healthy scheduler, which is the whole justification for acting on them:
-///
-/// * a holder send past its cap by [`NUDGE_SEND_GRACE`] — the cap's timer
-///   fires on time (four instrumented captures), so this is a delivered wake
-///   nobody polled;
-/// * a waiter parked on a **free** map past [`NUDGE_WAITER_THRESHOLD`] — a
-///   free fair mutex with a queued waiter hands over immediately.
+/// Pure over the sampled telemetry, so the trigger is unit-tested exactly as
+/// the stall-line verdict is. A waiter parked on a **free** map past
+/// [`NUDGE_WAITER_THRESHOLD`] is anomalous: a fair mutex with a queued waiter
+/// hands over immediately. The external no-op spawn remains an opt-in evidence
+/// experiment, not a recovery guarantee.
 #[cfg(not(target_family = "wasm"))]
 fn nudge_reason(
     contention: &DocumentsContention,
     waiters: &[WaiterSnapshot],
-) -> Option<&'static str> {
-    if let Some(send) = contention.holder_send
-        && send.running_for > send.budget + NUDGE_SEND_GRACE
-    {
-        return Some("holder send past its cap");
-    }
+) -> Option<NudgeTarget> {
     if contention.held_by.is_none()
-        && waiters
+        && let Some(waiter) = waiters
             .iter()
-            .any(|w| w.parked_for > NUDGE_WAITER_THRESHOLD)
+            .find(|w| w.parked_for > NUDGE_WAITER_THRESHOLD)
     {
-        return Some("waiter parked on a free map");
+        return Some(NudgeTarget {
+            telemetry_id: waiter.telemetry_id,
+            polls: waiter.polls,
+        });
     }
     None
-}
-
-/// A progress signature: if any of this changes, the runtime resumed work.
-#[cfg(not(target_family = "wasm"))]
-fn nudge_progress_signature(
-    contention: &DocumentsContention,
-    waiters: &[WaiterSnapshot],
-) -> (Option<u64>, usize, u64) {
-    (
-        contention.holder_send.map(|s| s.polls),
-        waiters.len(),
-        waiters.iter().map(|w| w.polls).sum(),
-    )
 }
 
 /// One watchdog step: sample, decide, nudge, verify, report. Returns whether
@@ -1385,13 +1114,11 @@ fn unpark_watchdog_step(
     handle: &tokio::runtime::Handle,
     log: &mut dyn std::io::Write,
 ) -> bool {
-    let contention = store.contention();
-    let waiters = store.waiters();
-    let Some(reason) = nudge_reason(&contention, &waiters) else {
+    let (contention, waiters) = store.watchdog_snapshot();
+    let Some(target) = nudge_reason(&contention, &waiters) else {
         return false;
     };
     UNPARK_NUDGES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let before = nudge_progress_signature(&contention, &waiters);
     // Plain facts, not the stall line's two-sample clauses — a nudge takes one
     // sample, and borrowing wording that claims a sample window would be the
     // instrument overclaiming again.
@@ -1399,22 +1126,14 @@ fn unpark_watchdog_step(
         || "map free".to_owned(),
         |h| format!("map held by {} ({:.1}s)", h.site, h.held.as_secs_f64()),
     );
-    let send = contention.holder_send.map_or_else(
-        || "no send in flight".to_owned(),
-        |s| {
-            format!(
-                "{} at {:.1}s of a {:.1}s cap, polled {} time(s), timer woken {} time(s)",
-                s.what,
-                s.running_for.as_secs_f64(),
-                s.budget.as_secs_f64(),
-                s.polls,
-                s.timer_wakes,
-            )
-        },
-    );
+    let target_task = waiters
+        .iter()
+        .find(|waiter| waiter.telemetry_id == target.telemetry_id)
+        .and_then(|waiter| waiter.task_id)
+        .map_or_else(|| "unknown".to_owned(), |id| id.to_string());
     let _ = writeln!(
         log,
-        "[nudge] {reason}: {holder}; {send}; {} waiter(s) parked. Spawning no-op tasks \
+        "[nudge] waiter parked on a free map: target task {target_task}; {holder}; {} waiter(s) parked. Spawning no-op tasks \
          from outside the runtime.",
         waiters.len(),
     );
@@ -1424,40 +1143,54 @@ fn unpark_watchdog_step(
         handle.spawn(async {});
     }
     std::thread::sleep(std::time::Duration::from_millis(500));
-    let after_c = store.contention();
-    let after_w = store.waiters();
-    let after = nudge_progress_signature(&after_c, &after_w);
-    if after == before {
+    let (_, after_w) = store.watchdog_snapshot();
+    if target.progressed(&after_w) {
         let _ = writeln!(
             log,
-            "[nudge] outcome: STILL WEDGED — polls unchanged 500ms after external spawns; \
-             the queued task itself is lost, not merely the worker unpark",
+            "[nudge] outcome: target progressed — the exact telemetry registration polled \
+             or deregistered after the external spawns",
         );
-        // The direct observation, where the build allows it: walk every live
-        // task and print its trace and state. Requires
-        // RUSTFLAGS="--cfg tokio_unstable --cfg tokio_taskdump" (local
-        // evidence builds only; inert otherwise). Once per process — the dump
-        // is heavy and one wedge yields one state.
-        #[cfg(all(tokio_unstable, tokio_taskdump))]
-        try_taskdump(handle, log);
     } else {
         let _ = writeln!(
             log,
-            "[nudge] outcome: resumed — progress signature {before:?} -> {after:?}; the task \
-             was queued and runnable, only the worker unpark was missing (issue #1657)",
+            "[nudge] outcome: STILL WEDGED — the exact telemetry registration did not poll \
+             500ms after external spawns; the experiment did not recover it",
         );
+        // Evidence builds correlate the exact waiter task ID with every dump
+        // entry. A missing entry is reported as absence, not interpreted as a
+        // scheduler state bit: Tokio may skip an already-notified task. Requires
+        // RUSTFLAGS="--cfg tokio_unstable --cfg tokio_taskdump" (local
+        // Linux evidence builds only; inert otherwise). Once per process.
+        #[cfg(all(target_os = "linux", tokio_unstable, tokio_taskdump))]
+        {
+            let target_task_id = after_w
+                .iter()
+                .find(|waiter| waiter.telemetry_id == target.telemetry_id)
+                .and_then(|waiter| waiter.task_id);
+            try_taskdump(handle, log, target_task_id);
+        }
     }
     true
 }
 
-/// Dump every live task's trace into the nudge log — the wedged task's own
-/// await stack and state, observed directly rather than inferred.
+/// Dump the tasks Tokio can trace and correlate them with the exact target ID.
 ///
-/// Local evidence builds only (`--cfg tokio_unstable --cfg tokio_taskdump`);
-/// never enabled in CI. Bounded: once per process, five-second cap — a dump
-/// requires worker cooperation, and a wedged runtime may not give it.
-#[cfg(all(tokio_unstable, tokio_taskdump))]
-fn try_taskdump(handle: &tokio::runtime::Handle, log: &mut dyn std::io::Write) {
+/// Linux evidence builds only:
+/// `RUSTFLAGS="--cfg tokio_unstable --cfg tokio_taskdump" cargo build ...`.
+/// The custom cfg also enables Tokio's required `taskdump` Cargo feature via
+/// the target dependency in `Cargo.toml`. Never enabled in CI. Bounded: once
+/// per process, five-second cap.
+///
+/// Absence is deliberately not called a state verdict. Tokio's dump walk skips
+/// an owned task when `notify_for_tracing` finds it already notified and it was
+/// not drained from a scheduler queue; an empty trace likewise exposes no state
+/// bits. The task ID is the only sound correlation this API supplies.
+#[cfg(all(target_os = "linux", tokio_unstable, tokio_taskdump))]
+fn try_taskdump(
+    handle: &tokio::runtime::Handle,
+    log: &mut dyn std::io::Write,
+    target_task_id: Option<tokio::task::Id>,
+) {
     static ONCE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
     if ONCE.swap(true, std::sync::atomic::Ordering::Relaxed) {
         return;
@@ -1467,8 +1200,25 @@ fn try_taskdump(handle: &tokio::runtime::Handle, log: &mut dyn std::io::Write) {
     });
     match outcome {
         Ok(dump) => {
+            let mut target_seen = false;
             for (i, task) in dump.tasks().iter().enumerate() {
-                let _ = writeln!(log, "[taskdump] task {i}:\n{}", task.trace());
+                let is_target = target_task_id == Some(task.id());
+                target_seen |= is_target;
+                let _ = writeln!(
+                    log,
+                    "[taskdump] task index={i} id={} target={is_target}:\n{}",
+                    task.id(),
+                    task.trace(),
+                );
+            }
+            if let Some(target_task_id) = target_task_id
+                && !target_seen
+            {
+                let _ = writeln!(
+                    log,
+                    "[taskdump] target task id={target_task_id} ABSENT from dump; Tokio may \
+                     skip an already-notified task, so absence is evidence but not a state read",
+                );
             }
         }
         Err(_) => {
@@ -1481,9 +1231,8 @@ fn try_taskdump(handle: &tokio::runtime::Handle, log: &mut dyn std::io::Write) {
     }
 }
 
-/// Start the #1657 unpark watchdog: a plain std thread, deliberately outside
-/// the runtime it watches, so it cannot be starved by the fault it exists to
-/// break.
+/// Start the opt-in #1657 evidence watchdog on a plain std thread outside the
+/// runtime it observes.
 ///
 /// Samples the open-document map's telemetry every 250 ms; on a trigger shape
 /// (see [`nudge_reason`]) it spawns no-op tasks into the runtime from outside
@@ -1491,10 +1240,11 @@ fn try_taskdump(handle: &tokio::runtime::Handle, log: &mut dyn std::io::Write) {
 /// named by `TCL_LSP_NUDGE_LOG` when set, because the ext-host harness does
 /// not reliably capture server stderr and the acceptance loop greps the file.
 ///
-/// This is a mitigation, not a fix, and it hides nothing: every action logs
-/// the telemetry that triggered it and whether the poke worked, so a wedge
-/// that used to be invisible-but-minutes-long becomes visible-and-short. A
-/// `STILL WEDGED` outcome is the built-in falsifier for the lost-unpark frame.
+/// This is not a mitigation. The loaded experiment produced zero true
+/// resumptions and falsified the external-unpark recovery theory. Normal server
+/// startup therefore does not call this function; `main` requires the explicit
+/// `TCL_LSP_WEDGE_EVIDENCE` opt-in. The retained poke is a repeatable
+/// discriminator, and every action logs whether the exact target progressed.
 #[cfg(not(target_family = "wasm"))]
 pub fn spawn_unpark_watchdog(backend: &Backend, handle: tokio::runtime::Handle) {
     let store = Arc::clone(&backend.documents);
@@ -1569,17 +1319,12 @@ fn describe_documents_contention(
         // `in_phase` says whether *this* step is what is long. The counter is
         // deliberately not printed here — nobody else can acquire a held map,
         // so it is trivially zero and says nothing (issue #1657).
-        let mut line = format!(
+        return format!(
             "the open-document map is held by {} — {:.1}s in total, {:.1}s at this point",
             h.site,
             h.held.as_secs_f64(),
             h.in_phase.as_secs_f64(),
         );
-        if let Some(send) = after.holder_send {
-            use std::fmt::Write as _;
-            let _ = write!(line, "{}", describe_holder_send(&send));
-        }
-        return line;
     }
     let last = after.last.map_or_else(
         || "never held".to_owned(),
@@ -1638,8 +1383,6 @@ struct DocumentsContention {
     held_by: Option<HeldFor>,
     last: Option<(&'static str, std::time::Duration)>,
     acquisitions: u64,
-    /// The client send the holder is inside, when it is inside one.
-    holder_send: Option<SendSnapshot>,
 }
 
 /// Upper bound `semantic_tokens_full`/`_delta` wait for the fully enriched
@@ -1671,29 +1414,6 @@ const SEMANTIC_TOKENS_FAST_PATH_BUDGET: std::time::Duration = std::time::Duratio
 /// debounce-skip; [`DIAGNOSTICS_FAST_TIER_MIN_LINES`] is the timing-independent
 /// half that keeps trivial files a single publish regardless of cold-start.
 const DIAGNOSTICS_FAST_TIER_BUDGET: std::time::Duration = std::time::Duration::from_millis(40);
-
-/// How long a single client send may park while the `documents` lock is held
-/// before [`DeliveryCtx::cache_and_deliver`] gives the lock back and reschedules
-/// (issue #1657).
-///
-/// Sized against the two things it sits between. Far above any healthy drain —
-/// the outbound path is `channel(1)` into `stdio_pump`, whose `poll_write` is
-/// always `Ready`, so a send that has not completed in whole seconds is not
-/// merely busy. Far below [`EDIT_BARRIER_STALL_WARN`], so the document-sync
-/// barrier cannot reach the point of reporting a stall on account of a slow
-/// publish: the wedge is prevented rather than merely diagnosed.
-///
-/// Not comparable to [`DIAGNOSTICS_FAST_TIER_BUDGET`], which is a *drop*
-/// deadline for a best-effort push the deep tier will supersede anyway. This one
-/// is a *reschedule* deadline for a publish that must not be lost, so it is
-/// generous where that one is tight.
-const DELIVERY_SEND_BUDGET: std::time::Duration = std::time::Duration::from_secs(2);
-
-/// Inline send attempts for a [`DiagCurrency::ClosedFromDisk`] publish — the one
-/// delivery with no scheduler behind it. See
-/// [`DeliveryCtx::delivery_attempts`] for why closed runs cannot fall back to
-/// [`reschedule_self`], and why this stays small.
-const CLOSED_DELIVERY_ATTEMPTS: u32 = 2;
 
 /// How long [`Backend::report_edit_barrier_stall`] waits between its two
 /// [`DocumentStore::contention`] samples.
@@ -2420,6 +2140,7 @@ struct DiagToggles {
 #[derive(Clone)]
 struct DiagInputs {
     client: Client,
+    diagnostic_publisher: Arc<DiagnosticPublisher>,
     registry: Arc<CommandRegistry>,
     disabled: HashSet<String>,
     /// `tclLsp.diagnosticSeverity.<CODE>` per-code LSP severity overrides,
@@ -2584,12 +2305,11 @@ impl DiagInputs {
 ///   updates the client would otherwise not know to re-pull.
 /// - **Push-only client**: publish as before, the only channel it has.
 ///
-/// The `publish_diagnostics(..).await` here must stay an **inline await**, never
-/// a detached `tokio::spawn`: the transport's bounded, backpressured channel is
-/// what guarantees no diagnostic is dropped or unboundedly buffered under a slow
-/// client (the await *is* the wait-for-drain). Making it fire-and-forget would
-/// discard that backpressure — reordering publishes and hiding a
-/// state-gated/disconnected drop. See the delivery invariant in `main.rs`.
+/// This await runs only in [`DiagnosticPublisher`]'s single persistent
+/// consumer. The transport's backpressure is retained, but it can park only
+/// diagnostics delivery — never a global document/index guard or the request
+/// admission path. Do not detach an independent send per result: the mailbox's
+/// single-consumer order and latest-wins coalescing are the delivery invariant.
 async fn deliver_diagnostics(
     client: &Client,
     uri: &Uri,
@@ -2609,12 +2329,169 @@ async fn deliver_diagnostics(
     }
 }
 
+/// One diagnostics notification committed after its currency check.
+///
+/// The outbound LSP channel is deliberately consumed by a single persistent
+/// publisher.  A slow client may park that publisher, but it can no longer park
+/// the global document map (issue #1657).
+struct PendingDiagnosticPublish {
+    uri: Uri,
+    diagnostics: Vec<tower_lsp_server::ls_types::Diagnostic>,
+    version: Option<i32>,
+    client_supports_pull: bool,
+    announce: bool,
+    delivered: tokio::sync::oneshot::Sender<DiagnosticPublishOutcome>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DiagnosticPublishOutcome {
+    Delivered,
+    Superseded,
+}
+
+#[derive(Default)]
+struct DiagnosticMailboxState {
+    /// Latest not-yet-started publication per URI.
+    pending: HashMap<Uri, PendingDiagnosticPublish>,
+    /// Cross-URI commit order. Replacing a URI moves it to the tail, so the
+    /// order reflects the latest surviving commit rather than the stale one it
+    /// replaced.
+    order: VecDeque<Uri>,
+}
+
+/// Persistent diagnostics publisher with per-URI bounded coalescing.
+///
+/// The mailbox is latest-wins per URI: while the client is stalled, at most one
+/// not-yet-started diagnostic vector is retained for each URI.  The one item
+/// already being sent cannot be cancelled safely — `SinkExt::send` may have
+/// completed `start_send` before parking in `poll_flush` — so it is allowed to
+/// finish and the newest queued state follows it.  This gives close/edit
+/// ordering without timeout-and-retry duplicates.
+struct DiagnosticPublisher {
+    client: Client,
+    state: std::sync::Mutex<DiagnosticMailboxState>,
+    ready: tokio::sync::Notify,
+    started: std::sync::atomic::AtomicBool,
+}
+
+impl DiagnosticPublisher {
+    fn new(client: Client) -> Self {
+        Self {
+            client,
+            state: std::sync::Mutex::new(DiagnosticMailboxState::default()),
+            ready: tokio::sync::Notify::new(),
+            started: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+
+    /// Commit one publication and return an acknowledgement for its eventual
+    /// delivery. A superseded pending item is explicitly settled as such, so
+    /// its caller cannot emit a completion marker for a state never delivered.
+    fn enqueue(
+        self: &Arc<Self>,
+        uri: Uri,
+        diagnostics: Vec<tower_lsp_server::ls_types::Diagnostic>,
+        version: Option<i32>,
+        client_supports_pull: bool,
+        announce: bool,
+    ) -> tokio::sync::oneshot::Receiver<DiagnosticPublishOutcome> {
+        let (delivered, receipt) = tokio::sync::oneshot::channel();
+        let publish = PendingDiagnosticPublish {
+            uri: uri.clone(),
+            diagnostics,
+            version,
+            client_supports_pull,
+            announce,
+            delivered,
+        };
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(old) = state.pending.remove(&uri) {
+            let _ = old.delivered.send(DiagnosticPublishOutcome::Superseded);
+            state.order.retain(|queued| queued != &uri);
+        }
+        state.pending.insert(uri.clone(), publish);
+        state.order.push_back(uri);
+        drop(state);
+
+        self.ensure_started();
+        self.ready.notify_one();
+        receipt
+    }
+
+    fn ensure_started(self: &Arc<Self>) {
+        use std::sync::atomic::Ordering;
+
+        if self
+            .started
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        let publisher = Arc::clone(self);
+        drop(crate::rt::spawn(async move { publisher.run().await }));
+    }
+
+    fn pop(&self) -> Option<PendingDiagnosticPublish> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        while let Some(uri) = state.order.pop_front() {
+            if let Some(publish) = state.pending.remove(&uri) {
+                return Some(publish);
+            }
+        }
+        None
+    }
+
+    async fn run(&self) {
+        loop {
+            // Construct the notified future before checking the queue. A notify
+            // racing the empty check is then retained as the Notify permit.
+            let ready = self.ready.notified();
+            let Some(publish) = self.pop() else {
+                ready.await;
+                continue;
+            };
+
+            if publish.announce {
+                self.client
+                    .log_message(
+                        MessageType::LOG,
+                        format!(
+                            "[timing] diagnostics.publish.enqueued (uri={}, version={})",
+                            publish.uri.as_str(),
+                            publish
+                                .version
+                                .map_or_else(|| "none".to_owned(), |v| v.to_string()),
+                        ),
+                    )
+                    .await;
+            }
+            deliver_diagnostics(
+                &self.client,
+                &publish.uri,
+                publish.diagnostics,
+                publish.version,
+                publish.client_supports_pull,
+            )
+            .await;
+            let _ = publish.delivered.send(DiagnosticPublishOutcome::Delivered);
+        }
+    }
+}
+
 /// The publish-side handles + per-edit identity shared by every settled
 /// `run_diagnostics_core` path (master-off, F5, the analyser tail).  Borrows for
 /// one call so the early-return paths and the final publish all deliver through
 /// the same currency-guarded channel.
 struct DeliveryCtx<'a> {
     client: &'a Client,
+    diagnostic_publisher: &'a Arc<DiagnosticPublisher>,
     documents: &'a Arc<DocumentStore>,
     diag_slots: &'a Arc<Mutex<HashMap<Uri, DiagSlot>>>,
     pull_diag_cache: &'a Arc<Mutex<HashMap<Uri, PullDiagEntry>>>,
@@ -2663,22 +2540,21 @@ impl DeliveryCtx<'_> {
         }
     }
 
-    /// Publish `diags` iff this run is still current for `uri`, holding the
-    /// `documents` lock across the currency check AND the pull-cache/publish
-    /// delivery so a concurrent `did_close`/`did_change` cannot interleave
-    /// between them — otherwise a `did_close` that lands in that window clears
-    /// the squiggles and drops the pull-cache entry, only for this run's late
-    /// delivery to re-publish and re-cache them for the now-closed document.
-    /// Returns whether it published — a superseded (no
-    /// longer current) run returns `false` without touching the client.
+    /// Commit `diags` iff this run is still current for `uri`.
+    ///
+    /// The currency check, pull-cache update and mailbox deposit happen while
+    /// `documents` is held. Client I/O does not: this waits for the publisher's
+    /// acknowledgement only after releasing the map. A close or newer edit
+    /// therefore orders before or after this commit without a check/send race.
     async fn deliver_if_current(&self, diags: Vec<tower_lsp_server::ls_types::Diagnostic>) -> bool {
-        let docs = self.documents.lock("deliver_if_current").await;
-        if self.is_current(&docs).await {
-            self.cache_and_deliver(diags).await;
-            true
-        } else {
-            false
-        }
+        let receipt = {
+            let docs = self.documents.lock("deliver_if_current").await;
+            if !self.is_current(&docs).await {
+                return false;
+            }
+            self.cache_and_enqueue(diags).await
+        };
+        matches!(receipt.await, Ok(DiagnosticPublishOutcome::Delivered))
     }
 
     /// Deliver the #844 progressive **fast tier** — push-only, and only to a
@@ -2692,28 +2568,11 @@ impl DeliveryCtx<'_> {
     /// — its "early" signal would be a `workspace/diagnostic/refresh`, but a
     /// re-pull recomputes the full deep set synchronously, which defeats the fast
     /// tier's whole purpose, so such a client just gets the deep tier's refresh
-    /// as before.  Currency-guarded under the `documents` lock exactly like the
-    /// deep publish (held across the push), so a superseding edit or a
-    /// `did_close` in the window can never let a stale fast tier land.
+    /// as before. The currency check and mailbox deposit are atomic relative to
+    /// edits and closes; the client send happens outside `documents`.
     /// Publish the fast tier for a push client, iff this run's revision is still
     /// current. Skipped for a pull client (the pull path always serves the
     /// complete deep set, never the reduced fast tier).
-    ///
-    /// Like [`publish_diagnostics_result`], this holds the `documents` lock
-    /// **across** `publish_diagnostics().await`, and that is load-bearing: the
-    /// lock-across-send is what closes. Releasing `documents`
-    /// before the send would let a `did_close` clearing-publish land between the
-    /// currency check and the send, repainting squiggles on a now-closed document
-    /// that nothing downstream clears (the deep pass then finds `!is_current` and
-    /// returns without publishing). This is a *second* lock-held-across-send
-    /// publish per cycle, so under a transiently slow client (the bounded
-    /// `channel(1)` transport parks the send) it would otherwise freeze every other
-    /// document's `did_change`/hover for however long that client takes to drain.
-    /// To cap that, the send is bounded by `timeout(DIAGNOSTICS_FAST_TIER_BUDGET,
-    /// …)`: the lock is held for at most the budget, after which this best-effort
-    /// push is dropped (the deep tier still supersedes it — the same outcome as the
-    /// already-accepted lift-worker-panic drop). The lock is *not* released before
-    /// the send — that would reopen — only time-bounded.
     async fn deliver_fast_tier_if_current(
         &self,
         diags: Vec<tower_lsp_server::ls_types::Diagnostic>,
@@ -2723,93 +2582,29 @@ impl DeliveryCtx<'_> {
         }
         let docs = self.documents.lock("deliver_fast_tier_if_current").await;
         if self.is_current(&docs).await {
-            // Best-effort/droppable (see above): cap the lock hold so a slow client
-            // can't hold `documents` hostage for every other document's edits.
-            // Dropping the parked `channel(1)` send on timeout is atomic — the push
-            // is simply lost and the deep tier supersedes it.
-            let _ = crate::rt::timeout(
-                DIAGNOSTICS_FAST_TIER_BUDGET,
-                self.client
-                    .publish_diagnostics(self.uri.clone(), diags, self.version),
-            )
-            .await;
+            // Do not wait: the deep future is pinned in this same task and must
+            // keep progressing so its authoritative set can replace this one.
+            drop(self.diagnostic_publisher.enqueue(
+                self.uri.clone(),
+                diags,
+                self.version,
+                false,
+                false,
+            ));
         }
     }
 
-    /// Update the pull-diagnostic cache for `uri` to `diags` at this run's
-    /// `revision`, with a fresh `result_id`, then notify the client (push or
-    /// refresh) — the publish half shared by every settled path.
+    /// Update the pull cache and deposit its corresponding client notification.
     ///
-    /// # The client sends here are time-bounded (issue #1657)
-    ///
-    /// Both callers — [`Self::deliver_if_current`] and
-    /// `publish_diagnostics_result` — run this **while holding the `documents`
-    /// lock**, deliberately: delivering inside the lock is what stops a
-    /// `did_close` that lands between the currency check and the send from
-    /// having its clearing publish overwritten by this run's late squiggles.
-    ///
-    /// Both sends below go through `tower-lsp-server`'s bounded
-    /// `futures::mpsc::channel(1)`, so both can park. Unbounded, that made a
-    /// *global* lock hostage to a *per-document* send: the open-document map
-    /// stops, the document-sync handler holding the [`EditOrder`] turn blocks on
-    /// it, every request handler blocks on the barrier behind that turn, and the
-    /// server answers nothing. That is issue #1657, caught on CI with the turn
-    /// holder suspended at `did_change: documents.lock` and no salsa snapshot
-    /// outstanding.
-    ///
-    /// So each send is capped at [`DELIVERY_SEND_BUDGET`] and, if the cap is
-    /// hit, this returns **without having delivered** and marks its own slot
-    /// dirty so the scheduler runs the whole publish again from scratch. The
-    /// retry re-checks currency on its own, so a superseded run simply finds
-    /// itself superseded — the same answer it would have given had it never
-    /// been delayed.
-    ///
-    /// Why reschedule rather than retry inline: `publish_diagnostics_result`
-    /// holds this same lock across a workspace-index write, and replaying that
-    /// write is neither cheap nor obviously idempotent. Handing the work back to
-    /// the scheduler re-runs a *complete, fresh* pass through machinery that is
-    /// already correct, and does it with the lock released.
-    ///
-    /// The delivery invariant in `main.rs` is preserved. Nothing is
-    /// fire-and-forget: delivery is still an inline `.await`, ordering per URI
-    /// still comes from the currency check, and nothing is dropped — a send that
-    /// times out is *retried*, not abandoned. Dropping a parked `channel(1)`
-    /// send is atomic (the item never enters the channel), which is what makes
-    /// the retry duplicate-free; `deliver_fast_tier_if_current` already relies
-    /// on exactly that property.
-    ///
-    /// The pull cache is primed *before* the sends and deliberately left primed
-    /// on timeout: a `textDocument/diagnostic` request can then serve this
-    /// revision immediately, which is the one delivery channel a parked push
-    /// does not block.
-    ///
-    /// # What this does not fix, and why it cannot be reported
-    ///
-    /// If the outbound path is *dead* rather than slow, every rescheduled pass
-    /// times out again, so the document is re-analysed once per cycle for as
-    /// long as the session lasts (throttled by [`DIAGNOSTICS_DEBOUNCE`], since
-    /// the reschedule goes through the ordinary scheduler). That is wasteful,
-    /// and it is still strictly better than the alternative: the server keeps
-    /// answering everything else instead of wedging.
-    ///
-    /// It is deliberately *not* announced with a log line. Every log the server
-    /// emits goes to the client down the very channel that is stuck, so a
-    /// "delivery is not draining" warning is precisely the message that cannot
-    /// be delivered when it would be true. The condition is visible the moment
-    /// the transport recovers — the `[timing]` markers resume — and if it never
-    /// recovers the client is gone and there is nobody left to tell.
-    ///
-    /// Losing the stall line is the real cost here. Before this change a stuck
-    /// publish announced itself loudly, by wedging the barrier until
-    /// [`Backend::report_edit_barrier_stall`] described it. Now it does not
-    /// wedge, so it does not announce. That is the right trade — a wedged server
-    /// is not an acceptable diagnostic channel — but it is a trade.
-    async fn cache_and_deliver(&self, diags: Vec<tower_lsp_server::ls_types::Diagnostic>) {
-        // Phase markers within the held map — see `DocumentStore::retag_held`.
-        // Both callers run this under their `documents` guard, so a hold that
-        // stops in here reports only the caller without these (issue #1657).
+    /// Callers hold `documents`, making these one ordered commit relative to
+    /// edits and closes. This performs no client I/O. The returned receipt must
+    /// only be awaited after the document guard is released.
+    async fn cache_and_enqueue(
+        &self,
+        diags: Vec<tower_lsp_server::ls_types::Diagnostic>,
+    ) -> tokio::sync::oneshot::Receiver<DiagnosticPublishOutcome> {
         self.documents
-            .retag_held("cache_and_deliver: pull_diag_cache");
+            .retag_held("cache_and_enqueue: pull_diag_cache");
         self.pull_diag_cache.lock().await.insert(
             self.uri.clone(),
             PullDiagEntry {
@@ -2818,127 +2613,13 @@ impl DeliveryCtx<'_> {
                 diagnostics: diags.clone(),
             },
         );
-        // Announce the publish *before* enqueuing it. Both go through the same
-        // ordered client channel, so a client that reads up to this marker has
-        // provably NOT yet read the publish it announces — the publish is the
-        // next thing on the wire. That is the only way to observe "the worker
-        // has committed to publishing version N" without consuming version N's
-        // publish, which is what `diagnostics_delivery_smoke`'s burst phase
-        // needs to hold two publishes in flight at once (review of #1100).
-        // Emitted after the currency check, so a marker is followed by its
-        // publish.
-        //
-        // "Followed by" rather than "immediately followed by", since #1657: if
-        // the publish below times out, this marker has been sent and its publish
-        // has not, and the pairing is restored only when the rescheduled pass
-        // emits a fresh marker and publish together. A consumer that waits for a
-        // publish after a marker still gets one; a consumer that counts markers
-        // 1:1 against publishes would see one extra. That can only happen when a
-        // send parks for whole seconds, which is the failure this cap exists to
-        // survive — under any client that is draining at all, the two still go
-        // out back to back.
-        let attempts = self.delivery_attempts();
-        let marker = format!(
-            "[timing] diagnostics.publish.enqueued (uri={}, version={})",
-            self.uri.as_str(),
-            self.version
-                .map_or_else(|| "none".to_owned(), |v| v.to_string()),
-        );
-        let mut marker_sent = false;
-        self.documents.retag_held("cache_and_deliver: marker send");
-        for _ in 0..attempts {
-            if instrumented_delivery_send(
-                self.documents,
-                "marker send",
-                self.client.log_message(MessageType::LOG, marker.clone()),
-            )
-            .await
-            .is_ok()
-            {
-                marker_sent = true;
-                break;
-            }
-        }
-        if !marker_sent {
-            self.redeliver_later().await;
-            return;
-        }
-        let mut diags = diags;
-        self.documents.retag_held("cache_and_deliver: publish send");
-        for attempt in 0..attempts {
-            // The last attempt owns the payload; earlier ones must keep a copy
-            // to retry with. An open run has a single attempt, so it still moves
-            // the vector exactly as before.
-            let payload = if attempt + 1 == attempts {
-                std::mem::take(&mut diags)
-            } else {
-                diags.clone()
-            };
-            if instrumented_delivery_send(
-                self.documents,
-                "publish send",
-                deliver_diagnostics(
-                    self.client,
-                    self.uri,
-                    payload,
-                    self.version,
-                    self.client_supports_pull,
-                ),
-            )
-            .await
-            .is_ok()
-            {
-                return;
-            }
-        }
-        self.redeliver_later().await;
-    }
-
-    /// How many times a timed-out send may be re-attempted **inline**, before
-    /// falling back to [`Self::redeliver_later`].
-    ///
-    /// One for an open document: the scheduler owns it, so handing the publish
-    /// back is both cheaper and more complete than retrying under the lock.
-    ///
-    /// More than one for a closed-file run, because for those there is nothing
-    /// to hand back to (Codex P1 on #1670). `did_close` calls `evict_diag_slot`
-    /// *before* `publish_closed_file_diagnostics` runs, and that either removes
-    /// the slot outright or clears its `latest_inputs` — both of which make
-    /// `reschedule_self` a no-op. A closed publish is an inline, one-shot run,
-    /// not a scheduled one, so a timeout there would have silently dropped the
-    /// notification while the pull cache and the closed badge both read current:
-    /// a client that paused across the timeout during a close would never have
-    /// been told, until some unrelated event republished the URI.
-    ///
-    /// Bounded so the worst case stays under [`EDIT_BARRIER_STALL_WARN`]: two
-    /// attempts each for the marker and the publish is four sends of
-    /// [`DELIVERY_SEND_BUDGET`], which cannot reach the point where the
-    /// document-sync barrier reports a stall.
-    ///
-    /// Residual, and deliberately not engineered away here: if every attempt
-    /// fails, a push-only client still loses this closed publish. Covering that
-    /// completely needs a closed-file retry queue, which is more machinery than
-    /// this path warrants — a pull-capable client is already served by the cache
-    /// primed above, and the window a client must be stalled for has gone from
-    /// one budget to four.
-    fn delivery_attempts(&self) -> u32 {
-        delivery_attempts_for(self.currency)
-    }
-
-    /// Hand this URI's publish back to the diagnostics scheduler, because a
-    /// client send timed out while the `documents` lock was held.
-    ///
-    /// Marks the slot dirty and starts a worker if none is running — the same
-    /// two steps [`reschedule_peers`] takes, for this document rather than its
-    /// peers. The worker re-runs the publish from scratch once the caller has
-    /// released the lock, so the delivery is deferred rather than lost.
-    ///
-    /// Touches only `diag_slots`, never `documents`, so it is safe to call from
-    /// under the very lock whose hold it exists to cut short.
-    async fn redeliver_later(&self) {
-        self.documents
-            .retag_held("cache_and_deliver: redeliver_later");
-        reschedule_self(self.diag_slots, self.uri).await;
+        self.diagnostic_publisher.enqueue(
+            self.uri.clone(),
+            diags,
+            self.version,
+            self.client_supports_pull,
+            true,
+        )
     }
 }
 
@@ -3927,52 +3608,6 @@ async fn reindex_unopened_factory_consumers(
 
 /// Mark each peer dirty and start its worker if one is not already draining
 /// it. See [`spawn_diagnostics_worker`] for why this exists.
-/// Inline send attempts for a run of this currency — see
-/// [`DeliveryCtx::delivery_attempts`], which this backs.
-///
-/// A free function taking the currency rather than a method on the context, so
-/// the closed-versus-open decision can be asserted without standing up a whole
-/// `DeliveryCtx` (whose eight borrowed handles are not the thing under test).
-const fn delivery_attempts_for(currency: DiagCurrency) -> u32 {
-    match currency {
-        DiagCurrency::Open(_) => 1,
-        DiagCurrency::ClosedFromDisk(_) => CLOSED_DELIVERY_ATTEMPTS,
-    }
-}
-
-/// Queue `uri`'s **own** publish to run again, and start a worker if none is.
-///
-/// [`reschedule_peers`] does this for the documents a publish invalidated and
-/// deliberately skips the publishing document itself. This is the case that one
-/// excludes: a run that could not finish delivering and wants another pass over
-/// its own URI (issue #1657 — see [`DeliveryCtx::cache_and_deliver`], whose
-/// client sends are time-bounded because they run under the `documents` lock).
-///
-/// Takes only `diag_slots`. That is what makes it callable from under the
-/// `documents` lock whose hold it exists to cut short — it must not need the
-/// very lock its caller is trying to give back.
-///
-/// A slot with no `latest_inputs` is left alone: nothing can re-derive the
-/// publish, so marking it dirty would spin a worker that immediately finds
-/// nothing to do. The next edit re-establishes the inputs.
-async fn reschedule_self(slots: &Arc<Mutex<HashMap<Uri, DiagSlot>>>, uri: &Uri) {
-    let start_worker = {
-        let mut guard = slots.lock().await;
-        match guard.get_mut(uri) {
-            Some(slot) if slot.latest_inputs.is_some() => {
-                slot.mark_dirty();
-                let start = !slot.running;
-                slot.running = true;
-                start
-            }
-            _ => false,
-        }
-    };
-    if start_worker {
-        spawn_diagnostics_worker(Arc::clone(slots), uri.clone());
-    }
-}
-
 async fn reschedule_peers(
     slots: &Arc<Mutex<HashMap<Uri, DiagSlot>>>,
     self_uri: &Uri,
@@ -4600,6 +4235,7 @@ async fn run_diagnostics_core(inputs: DiagInputs, uri: &Uri, job: DiagJob) -> bo
 
     let delivery = DeliveryCtx {
         client: &inputs.client,
+        diagnostic_publisher: &inputs.diagnostic_publisher,
         documents: &inputs.documents,
         diag_slots: &inputs.diag_slots,
         pull_diag_cache: &inputs.pull_diag_cache,
@@ -5567,7 +5203,8 @@ async fn add_entry_point_diagnostic_consumers(
 }
 
 /// Publish the lifted diagnostics: re-check currency, refresh the workspace
-/// index, prime the pull cache, deliver to the client, and log timing.  Always
+/// index, atomically commit the pull cache + mailbox state, await delivery
+/// outside all global guards, and log timing. Always
 /// settled (`true`) — a stale revision or a lift-revision panic both keep the
 /// prior diagnostics rather than retrying.
 ///
@@ -5584,10 +5221,11 @@ async fn add_entry_point_diagnostic_consumers(
 ///
 /// Splitting the function is the other way out and is the wrong one here. What
 /// makes this body long is a single deliberate critical section — the
-/// `documents` lock held across the currency re-check, the index update and the
-/// delivery — and cutting it in half would put that lock's acquisition and its
-/// release in different functions. The lock scope being readable in one piece is
-/// the property this whole issue is about.
+/// `documents` lock held across the currency re-check, index update and mailbox
+/// commit — and cutting it in half would put that lock's acquisition and its
+/// release in different functions. The lock scope being readable in one piece
+/// is the property this whole issue is about. Client delivery is deliberately
+/// outside this section.
 #[allow(
     clippy::too_many_lines,
     reason = "the overrun is #1657 lock-phase markers, which are only correct as a complete set; \
@@ -5616,7 +5254,7 @@ async fn publish_diagnostics_result(
         }
     };
     let diag_count = diags.len();
-    let peers = {
+    let (peers, delivery_receipt) = {
         // A workspace query holds this gate from source-site reconciliation
         // through its final index snapshot. Take it before `documents` (the
         // same order as reconciliation's `read_document`) so this standalone
@@ -5625,15 +5263,16 @@ async fn publish_diagnostics_result(
         // intermittently resolve `::helper` instead of `::x::helper` (M9).
         let rehoming_guard = rehoming_gate.lock().await;
         // Hold the `documents` lock across the currency re-check, the
-        // workspace-index update, AND the pull-cache/publish delivery so a
+        // workspace-index update, AND the pull-cache/mailbox commit so a
         // concurrent `did_change`/`did_close` (which also take `documents`)
         // cannot interleave between them — the role the former global
         // `document_analysis_gate` served, now via the natural
         // `documents` → `workspace_index` and `documents` → `pull_diag_cache`
-        // lock order. Delivering *inside* the lock is what stops a `did_close`
-        // that ran between the currency check and the delivery from having its
-        // clearing empty publish overwritten (and its pull-cache removal
-        // undone) by this run's late squiggles.
+        // lock order. The mailbox deposit inside the lock is what stops a
+        // `did_close` from landing between currency check and publication: a
+        // later close replaces the pending state or follows an in-flight state
+        // on the single consumer. The actual client await is below, after this
+        // guard and `rehoming_guard` have been released (#1657).
         let docs = delivery.documents.lock("publish_diagnostics_result").await;
         if !delivery.is_current(&docs).await {
             // Superseded by a newer edit (open run), a reopen, or a newer closed
@@ -5715,10 +5354,23 @@ async fn publish_diagnostics_result(
         // `textDocument/diagnostic` request now returns this exact set with
         // a fresh `result_id`, and an editor that already holds it gets a
         // cheap `Unchanged` report.
-        docs.retag("publish_diagnostics_result: cache_and_deliver");
-        delivery.cache_and_deliver(diags).await;
-        peers
+        docs.retag("publish_diagnostics_result: cache_and_enqueue");
+        let receipt = delivery.cache_and_enqueue(diags).await;
+        (peers, receipt)
     };
+    // Client backpressure is isolated in the persistent publisher. Waiting for
+    // the authoritative delivery preserves the timing-marker contract, but the
+    // global documents map and rehoming gate have both been released first.
+    match delivery_receipt.await {
+        Ok(DiagnosticPublishOutcome::Delivered) => {}
+        Ok(DiagnosticPublishOutcome::Superseded) => return true,
+        Err(_) => {
+            // The persistent publisher task was lost. Do not claim that this
+            // publish reached the client; diagnostics stop, but request-critical
+            // state remains live and no unsafe second consumer is spawned.
+            return true;
+        }
+    }
     reschedule_peers(delivery.diag_slots, delivery.uri, peers).await;
     let elapsed_ms = timing.started.elapsed().as_secs_f64() * 1000.0;
     // The analyser runs a single, full ("deep") pass per publish — there is
@@ -5802,6 +5454,9 @@ struct PublishedPackSet {
 /// with the `Backend` rather than leaked for the process lifetime.
 pub struct Backend {
     client: Client,
+    /// Persistent latest-wins diagnostics delivery, isolated from every
+    /// request-critical lock (issue #1657).
+    diagnostic_publisher: Arc<DiagnosticPublisher>,
     /// Open documents. `Arc` so the detached diagnostics task can hold it.
     documents: Arc<DocumentStore>,
     /// Per-URI coalescing diagnostics scheduler state.  Each edit marks the
@@ -7221,8 +6876,10 @@ impl Backend {
             None,
             0,
         );
+        let diagnostic_publisher = Arc::new(DiagnosticPublisher::new(client.clone()));
         Self {
             client,
+            diagnostic_publisher,
             documents: Arc::new(DocumentStore::default()),
             diag_slots: Arc::new(Mutex::new(HashMap::new())),
             default_dialect: Mutex::new("tcl8.6".to_owned()),
@@ -8427,12 +8084,8 @@ impl Backend {
         // enough not to extend a stall anyone is waiting on and long enough for
         // a busy map to move (issue #1657).
         let before = self.documents.contention();
-        let handler_polls_before = crate::transport_liveness::HANDLER_FUTURE_POLLS
-            .load(std::sync::atomic::Ordering::Relaxed);
         crate::rt::sleep(DOCUMENTS_CONTENTION_SAMPLE_GAP).await;
         let after = self.documents.contention();
-        let handler_polls_after = crate::transport_liveness::HANDLER_FUTURE_POLLS
-            .load(std::sync::atomic::Ordering::Relaxed);
         // Re-read the barrier after the sample window, for the same reason
         // #1664 re-reads it after `edits_settled`'s timeout: the edit this
         // report is about may have landed while we slept. Announcing a
@@ -8457,11 +8110,8 @@ impl Backend {
             return;
         }
         let documents_holder = describe_documents_contention(&before, &after);
-        let waiters = describe_documents_waiters(
-            &self.documents.waiters(),
-            after.held_by.is_some(),
-            handler_polls_after.saturating_sub(handler_polls_before),
-        );
+        let waiters =
+            describe_documents_waiters(&self.documents.waiters(), after.held_by.is_some());
         self.client
             .log_message(
                 MessageType::WARNING,
@@ -9315,20 +8965,20 @@ impl Backend {
     /// Guarded on the document still being closed, so a `did_open` racing in
     /// cannot have this empty publish blank a freshly reopened buffer.
     async fn clear_closed_diagnostics(&self, uri: &Uri) {
-        let docs = self.documents.lock("clear_closed_diagnostics").await;
-        if docs.contains_key(uri) {
-            return;
-        }
-        // Hold `documents` across the clearing publish + pull-cache drop (the
-        // `documents` → `pull_diag_cache` order), exactly as the open publish
-        // holds it, so a concurrent reopen cannot interleave.
-        self.client
-            .publish_diagnostics(uri.clone(), Vec::new(), None)
-            .await;
-        self.pull_diag_cache.lock().await.remove(uri);
-        // Drop the closed-run generation too, so the map does not accumulate an
-        // entry for a URI that no longer carries a badge.
-        self.closed_diag_gen.lock().await.remove(uri);
+        let receipt = {
+            let docs = self.documents.lock("clear_closed_diagnostics").await;
+            if docs.contains_key(uri) {
+                return;
+            }
+            // Commit the clear, pull-cache removal and generation retirement in
+            // one document-ordered critical section. The publisher performs the
+            // client I/O after this guard is released (#1657).
+            self.pull_diag_cache.lock().await.remove(uri);
+            self.closed_diag_gen.lock().await.remove(uri);
+            self.diagnostic_publisher
+                .enqueue(uri.clone(), Vec::new(), None, false, false)
+        };
+        let _ = receipt.await;
         // …and its place in the closed-badge recency list, so a cleared URI does
         // not count against [`CLOSED_DIAG_BADGE_CAP`] (#1144).
         self.closed_diag_order
@@ -9410,6 +9060,7 @@ impl Backend {
             folder_db_config_tombstones: _,
             // Not keyed by a URI.
             client: _,
+            diagnostic_publisher: _,
             default_dialect: _,
             default_dialect_explicit: _,
             session_dialect_override: _,
@@ -15034,6 +14685,7 @@ impl Backend {
         let (entry_points, folder_root) = self.w120_inheritance_config(uri).await;
         DiagInputs {
             client: self.client.clone(),
+            diagnostic_publisher: Arc::clone(&self.diagnostic_publisher),
             registry,
             disabled,
             severity_overrides,
@@ -16390,12 +16042,16 @@ impl Backend {
             stale
         };
         for uri in stale {
-            self.client.publish_diagnostics(uri, Vec::new(), None).await;
+            let receipt = self
+                .diagnostic_publisher
+                .enqueue(uri, Vec::new(), None, false, false);
+            let _ = receipt.await;
         }
         for (uri, diagnostics) in by_uri {
-            self.client
-                .publish_diagnostics(uri, diagnostics, None)
-                .await;
+            let receipt = self
+                .diagnostic_publisher
+                .enqueue(uri, diagnostics, None, false, false);
+            let _ = receipt.await;
         }
     }
 
@@ -29789,6 +29445,8 @@ mod tests {
     /// after the fact.
     fn test_backend_over(db: tcl_lsp_db::TclDatabase) -> Backend {
         let (service, _socket) = tower_lsp_server::LspService::new(Backend::new);
+        let client = service.inner().client.clone();
+        let diagnostic_publisher = Arc::new(DiagnosticPublisher::new(client.clone()));
         let db_config = tcl_lsp_db::AnalyserConfig::new(
             &db,
             default_disabled_set().into_iter().collect(),
@@ -29799,7 +29457,8 @@ mod tests {
             0,
         );
         Backend {
-            client: service.inner().client.clone(),
+            client,
+            diagnostic_publisher,
             documents: Arc::new(DocumentStore::default()),
             diag_slots: Arc::new(Mutex::new(HashMap::new())),
             default_dialect: Mutex::new("tcl8.6".to_owned()),
@@ -30817,6 +30476,7 @@ mod tests {
         let diag = vec![tower_lsp_server::ls_types::Diagnostic::default()];
         let ctx = |generation: u64| DeliveryCtx {
             client: &backend.client,
+            diagnostic_publisher: &backend.diagnostic_publisher,
             documents: &backend.documents,
             diag_slots: &backend.diag_slots,
             pull_diag_cache: &backend.pull_diag_cache,
@@ -34970,161 +34630,152 @@ mod tests {
         }
     }
 
-    /// A delivery that could not finish must queue itself for another pass.
-    ///
-    /// This is the recovery half of the #1657 fix. `cache_and_deliver` runs its
-    /// client sends under the `documents` lock, so those sends are capped; when
-    /// a cap is hit it gives the lock back **without having published**, and the
-    /// only thing standing between that and a silently lost diagnostic is this
-    /// reschedule. The delivery invariant in `main.rs` forbids dropping a
-    /// publish, so "returned early" must mean "will run again".
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn a_delivery_that_timed_out_queues_itself_again() {
-        let backend = test_backend();
-        let uri = Uri::from_str("file:///w/redeliver.tcl").unwrap();
-        register(&backend, &uri, "set x 1\n").await;
-
-        // A slot the scheduler has never seen has nothing to re-derive from, so
-        // it must be left alone rather than spun.
-        reschedule_self(&backend.diag_slots, &uri).await;
-        assert!(
-            backend.diag_slots.lock().await.get(&uri).is_none(),
-            "rescheduling an unknown slot must not create one — a worker with no \
-             cached inputs would wake, find nothing to do, and stop",
-        );
-
-        // Give the URI a real slot with resolved inputs, the way an ordinary
-        // edit would, then let the worker settle.
-        backend
-            .reschedule_diagnostics(uri.clone(), "tcl8.6".to_owned())
-            .await;
-        let settled = crate::rt::timeout(std::time::Duration::from_secs(10), async {
-            loop {
-                {
-                    let slots = backend.diag_slots.lock().await;
-                    if let Some(slot) = slots.get(&uri)
-                        && slot.latest_inputs.is_some()
-                        && !slot.running
-                        && !slot.dirty
-                    {
-                        return;
-                    }
-                }
-                crate::rt::sleep(std::time::Duration::from_millis(10)).await;
-            }
-        })
-        .await;
-        assert!(
-            settled.is_ok(),
-            "the scheduled publish must settle before this test can say anything \
-             about re-scheduling it",
-        );
-
-        // The timed-out-delivery case: the slot is queued again.
-        reschedule_self(&backend.diag_slots, &uri).await;
-        let slots = backend.diag_slots.lock().await;
-        let slot = slots.get(&uri).expect("the slot exists");
-        assert!(
-            slot.dirty || slot.running,
-            "a delivery that returned without publishing must leave its slot \
-             queued (dirty) or already being drained (running); neither means \
-             the diagnostics for this revision are lost, which the main.rs \
-             delivery invariant forbids",
-        );
+    fn pending_diagnostic_summary(publisher: &DiagnosticPublisher, uri: &Uri) -> Option<bool> {
+        let state = publisher
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state
+            .pending
+            .get(uri)
+            .map(|pending| pending.diagnostics.is_empty())
     }
 
-    /// A closed-file publish must not depend on a slot `did_close` has already
-    /// evicted.
-    ///
-    /// Codex P1 on #1670. The two halves of the trap, pinned together:
-    ///
-    /// 1. `did_close` calls `evict_diag_slot` **before**
-    ///    `publish_closed_file_diagnostics` runs, and eviction either removes
-    ///    the slot or clears its `latest_inputs` — so `reschedule_self`, which
-    ///    requires cached inputs, can do nothing for a closed URI.
-    /// 2. A closed publish is therefore the one delivery with no scheduler
-    ///    behind it, so it must retry inline rather than hand the work back.
-    ///
-    /// Without the second half a timed-out closed publish is lost silently,
-    /// while the pull cache and the closed badge both read current — a client
-    /// that paused across the timeout during a close would never be told.
+    /// A client notification that never drains may stop diagnostics, but it
+    /// must not stop edits or requests from taking the global document map.
+    /// The close committed behind it must also replace the pending stale set.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn a_closed_file_publish_does_not_rely_on_an_evicted_slot() {
-        let backend = test_backend();
-        let uri = Uri::from_str("file:///w/closed-retry.tcl").unwrap();
-        register(&backend, &uri, "set x 1\n").await;
+    async fn stalled_diagnostic_delivery_cannot_hold_documents_and_close_wins() {
+        use std::sync::atomic::Ordering;
 
-        // Give the URI a real, fully populated slot…
+        let backend = Arc::new(test_backend());
+        // Keep the persistent consumer deliberately parked without involving
+        // transport timing. Enqueue still commits normally; receipts simply do
+        // not resolve until a newer state replaces them.
         backend
-            .reschedule_diagnostics(uri.clone(), "tcl8.6".to_owned())
-            .await;
-        // Wait for the worker to finish as well as populate: `evict_diag_slot`
-        // keeps a *running* slot (clearing its inputs) and removes an idle one,
-        // and only the second branch is unambiguous to assert on.
-        let ready = crate::rt::timeout(std::time::Duration::from_secs(10), async {
+            .diagnostic_publisher
+            .started
+            .store(true, Ordering::Release);
+        let uri = Uri::from_str("file:///w/mailbox-stall.tcl").unwrap();
+        register(&backend, &uri, "set x 1\n").await;
+        let revision = backend
+            .documents
+            .lock("test revision")
+            .await
+            .get(&uri)
+            .expect("registered document")
+            .revision;
+
+        let publishing_backend = Arc::clone(&backend);
+        let publishing_uri = uri.clone();
+        let publish = tokio::spawn(async move {
+            DeliveryCtx {
+                client: &publishing_backend.client,
+                diagnostic_publisher: &publishing_backend.diagnostic_publisher,
+                documents: &publishing_backend.documents,
+                diag_slots: &publishing_backend.diag_slots,
+                pull_diag_cache: &publishing_backend.pull_diag_cache,
+                closed_diag_gen: &publishing_backend.closed_diag_gen,
+                uri: &publishing_uri,
+                currency: DiagCurrency::Open(revision),
+                version: Some(1),
+                client_supports_pull: false,
+            }
+            .deliver_if_current(vec![tower_lsp_server::ls_types::Diagnostic::default()])
+            .await
+        });
+
+        crate::rt::timeout(std::time::Duration::from_secs(1), async {
             loop {
-                {
-                    let slots = backend.diag_slots.lock().await;
-                    if slots
-                        .get(&uri)
-                        .is_some_and(|s| s.latest_inputs.is_some() && !s.running && !s.dirty)
-                    {
-                        return;
-                    }
+                if pending_diagnostic_summary(&backend.diagnostic_publisher, &uri).is_some() {
+                    break;
                 }
-                crate::rt::sleep(std::time::Duration::from_millis(10)).await;
+                crate::rt::yield_now().await;
             }
         })
-        .await;
+        .await
+        .expect("the authoritative publish must reach the mailbox");
+
+        let mut docs = crate::rt::timeout(
+            std::time::Duration::from_millis(250),
+            backend.documents.lock("test close"),
+        )
+        .await
+        .expect("a pending client send must not retain the documents lock");
+        docs.remove(&uri);
+        drop(docs);
+
+        let clearing_backend = Arc::clone(&backend);
+        let clearing_uri = uri.clone();
+        let clear = tokio::spawn(async move {
+            clearing_backend
+                .clear_closed_diagnostics(&clearing_uri)
+                .await;
+        });
+
+        crate::rt::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                let close_is_pending =
+                    pending_diagnostic_summary(&backend.diagnostic_publisher, &uri) == Some(true);
+                if close_is_pending {
+                    break;
+                }
+                crate::rt::yield_now().await;
+            }
+        })
+        .await
+        .expect("the close must replace the pending stale diagnostics");
         assert!(
-            ready.is_ok(),
-            "the slot must be populated and settled before it is evicted",
+            !crate::rt::timeout(std::time::Duration::from_secs(1), publish)
+                .await
+                .expect("replacement must settle the stale receipt")
+                .expect("the publish task must not panic"),
+            "the superseded run must not claim delivery or emit its completion marker",
         );
-
-        // …then evict it exactly as `did_close` does, before the closed publish.
-        backend.evict_diag_slot(&uri).await;
-
-        // The scheduler fallback is now dead for this URI. This is the half that
-        // makes the inline retry necessary, not an incidental detail. Both of
-        // eviction's branches defeat it: the idle one drops the slot, and the
-        // running one clears the `latest_inputs` that `reschedule_self` requires.
-        reschedule_self(&backend.diag_slots, &uri).await;
-        let revivable = {
-            let slots = backend.diag_slots.lock().await;
-            slots
-                .get(&uri)
-                .is_some_and(|s| s.latest_inputs.is_some() && (s.dirty || s.running))
-        };
+        let state = backend
+            .diagnostic_publisher
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let pending = state.pending.get(&uri).expect("close clear stays pending");
         assert!(
-            !revivable,
-            "after `did_close` evicts the slot there is nothing for \
-             `reschedule_self` to drive — if this ever starts passing, the \
-             closed path gained a scheduler and `delivery_attempts` should be \
-             revisited",
-        );
-
-        // So a closed run must carry its own retries, and an open one must not
-        // pay for them (the scheduler is strictly better for open documents).
-        let closed = DiagCurrency::ClosedFromDisk(7);
-        let open = DiagCurrency::Open(3);
-        assert!(
-            delivery_attempts_for(closed) > 1,
-            "a closed publish has no scheduler to fall back on, so it must \
-             retry inline or the notification is lost",
+            pending.diagnostics.is_empty(),
+            "the newest retained state for a closed URI must be the clear",
         );
         assert_eq!(
-            delivery_attempts_for(open),
-            1,
-            "an open publish must hand back to the scheduler rather than retry \
-             under the `documents` lock",
+            state.order.iter().filter(|queued| *queued == &uri).count(),
+            1
         );
-        // Worst case must stay under the barrier's stall threshold: marker plus
-        // publish, each retried, is four sends.
-        assert!(
-            DELIVERY_SEND_BUDGET * 2 * delivery_attempts_for(closed) < EDIT_BARRIER_STALL_WARN,
-            "the inline retries must not themselves be able to hold `documents` \
-             long enough for the document-sync barrier to report a stall (#1657)",
+        drop(state);
+        clear.abort();
+    }
+
+    /// Latest-wins replacement is bounded per URI and moves the replacement to
+    /// its real cross-URI commit position.
+    #[tokio::test]
+    async fn diagnostic_mailbox_is_latest_wins_and_preserves_surviving_order() {
+        use std::sync::atomic::Ordering;
+
+        let backend = test_backend();
+        let publisher = &backend.diagnostic_publisher;
+        publisher.started.store(true, Ordering::Release);
+        let a = Uri::from_str("file:///a.tcl").unwrap();
+        let b = Uri::from_str("file:///b.tcl").unwrap();
+        let first_a = publisher.enqueue(a.clone(), Vec::new(), Some(1), false, false);
+        let _b = publisher.enqueue(b.clone(), Vec::new(), Some(1), false, false);
+        let _latest_a = publisher.enqueue(a.clone(), Vec::new(), Some(2), false, false);
+
+        assert_eq!(
+            first_a.await.expect("publisher remains alive"),
+            DiagnosticPublishOutcome::Superseded,
         );
+        let state = publisher
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert_eq!(state.pending.len(), 2, "one retained vector per URI");
+        assert_eq!(state.order, VecDeque::from([b, a.clone()]));
+        assert_eq!(state.pending.get(&a).expect("latest a").version, Some(2),);
     }
 
     /// The map must distinguish "nobody wants it" from "everyone but the
@@ -35325,19 +34976,9 @@ mod tests {
                         // bounded by the loop below; a few thousand short strings.
                         let site: &'static str = Box::leak(format!("hammer-{n}").into_boxed_str());
                         let held = store.lock(site).await;
-                        // Run an instrumented send under the hold, tagged with
-                        // the SAME unique string, so the sampler can check that
-                        // a snapshot never pairs one holder with another
-                        // holder's send (Codex P2 on #1679: `contention` read
-                        // the holder and the send entry under two separate
-                        // tracking acquisitions, and a holder change between
-                        // them attributed the new holder's send to the old).
-                        let _ = instrumented_delivery_send(&store, site, async {
-                            for _ in 0..32 {
-                                crate::rt::yield_now().await;
-                            }
-                        })
-                        .await;
+                        for _ in 0..32 {
+                            crate::rt::yield_now().await;
+                        }
                         drop(held);
                         crate::rt::yield_now().await;
                     }
@@ -35347,7 +34988,6 @@ mod tests {
 
         let mut previous = store.contention().acquisitions;
         let mut seen_both = 0_u32;
-        let mut seen_pairs = 0_u32;
         for _ in 0..100_000 {
             let snap = store.contention();
             assert!(
@@ -35370,18 +35010,6 @@ mod tests {
                     "a snapshot showing a holder must show its acquisition too",
                 );
             }
-            if let (Some(held), Some(send)) = (snap.held_by, snap.holder_send) {
-                seen_pairs += 1;
-                assert_eq!(
-                    held.site, send.what,
-                    "this snapshot pairs one holder with another holder's send. \
-                     Every hold tags its send with its own unique string, so the \
-                     two can only disagree if the holder and the send entry were \
-                     read under different tracking acquisitions — and a stall \
-                     line built from them would attribute the send verdict to \
-                     the wrong task (Codex P2 on #1679)",
-                );
-            }
         }
 
         stop.store(true, std::sync::atomic::Ordering::Relaxed);
@@ -35392,12 +35020,6 @@ mod tests {
             seen_both > 0,
             "the hammer never caught the map held with a previous holder \
              recorded, so the concurrent half proved nothing",
-        );
-        assert!(
-            seen_pairs > 0,
-            "the sampler never caught a holder together with its in-flight \
-             send, so the pairing assertion above was vacuous and proved \
-             nothing",
         );
     }
 
@@ -35583,27 +35205,26 @@ mod tests {
     /// The whole point of the shim is that a human reads the verdict off the
     /// stall line, so the mapping from counters to words is behaviour, not
     /// cosmetics: woken-after-last-poll must read as a driving problem,
-    /// never-woken as a lost wake, and a frozen parent counter as whole-parent
-    /// starvation.
+    /// and never-woken as a lost wake, without guessing which scheduler layer
+    /// failed to drive it.
     #[test]
     fn the_waiter_clause_states_the_verdict() {
         let base = WaiterSnapshot {
+            telemetry_id: 1,
             site: "did_open",
             parked_for: std::time::Duration::from_secs(18),
             polls: 1,
             since_last_poll: std::time::Duration::from_secs(18),
             wakes: 0,
             since_last_wake: None,
+            #[cfg(not(target_family = "wasm"))]
+            task_id: None,
         };
 
-        let never_woken = describe_documents_waiters(&[base], false, 42);
+        let never_woken = describe_documents_waiters(&[base], false);
         assert!(
             never_woken.contains("lost or never sent"),
             "a never-woken waiter is the lost-wake verdict: {never_woken}",
-        );
-        assert!(
-            never_woken.contains("driving other children"),
-            "a climbing handler-poll counter names the parent as alive: {never_woken}",
         );
 
         let woken_not_polled = describe_documents_waiters(
@@ -35613,7 +35234,6 @@ mod tests {
                 ..base
             }],
             false,
-            42,
         );
         assert!(
             woken_not_polled.contains("never polled again"),
@@ -35621,14 +35241,7 @@ mod tests {
              {woken_not_polled}",
         );
 
-        let parent_dead = describe_documents_waiters(&[base], false, 0);
-        assert!(
-            parent_dead.contains("not being driven at all"),
-            "a frozen handler-poll counter is the parent-starvation verdict: \
-             {parent_dead}",
-        );
-
-        let nobody = describe_documents_waiters(&[], false, 7);
+        let nobody = describe_documents_waiters(&[], false);
         assert!(
             nobody.contains("No task is in the map's contended-acquire path"),
             "an empty registry must say so rather than staying silent: {nobody}",
@@ -35639,7 +35252,7 @@ mod tests {
         // poll-shim capture printed the lost-wake wording for four such
         // victims, which invited suspicion of the mutex for waiters that were
         // merely queued behind a stuck holder.
-        let held_victim = describe_documents_waiters(&[base], true, 42);
+        let held_victim = describe_documents_waiters(&[base], true);
         assert!(
             held_victim.contains("a victim of the holder above"),
             "a waiter behind a held map must be framed as a victim: {held_victim}",
@@ -35651,299 +35264,61 @@ mod tests {
         );
     }
 
-    /// The instrumented send must behave exactly like the timeout it replaces,
-    /// and its timer half must record the wake that ends it.
-    ///
-    /// This is the instrument for the sharpest #1657 anomaly so far: a holder
-    /// frozen inside a 2s cap for 149.3s on a runtime whose time driver was
-    /// firing other timers. The verdict it enables — "timer wake never
-    /// delivered" versus "timer fired, task never polled again" — is only as
-    /// good as the timer-wake accounting, so a timeout that fires without its
-    /// wake being counted would print the timer-subsystem verdict for a timer
-    /// that demonstrably worked.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn the_instrumented_send_records_the_timer_wake_that_expires_it() {
-        let store = Arc::new(DocumentStore::default());
-
-        // A send that completes at once: Ok, and the registration is gone.
-        let ok = instrumented_delivery_send(&store, "marker send", async { 7_u8 }).await;
-        assert_eq!(ok, Ok(7), "a completing send must pass its output through");
-        assert!(
-            store.holder_send_at(crate::rt::Instant::now()).is_none(),
-            "a finished send must deregister — a stale entry would be printed \
-             by every later stall line as an in-flight send",
-        );
-
-        // A send that never completes: visible while pending, Err at the cap,
-        // with the timer wake that expired it recorded.
-        let pending_send = {
-            let store = Arc::clone(&store);
-            tokio::spawn(async move {
-                instrumented_delivery_send(&store, "publish send", std::future::pending::<()>())
-                    .await
-            })
-        };
-        let seen = crate::rt::timeout(std::time::Duration::from_secs(5), async {
-            loop {
-                if let Some(snap) = store.holder_send_at(crate::rt::Instant::now())
-                    && snap.what == "publish send"
-                    && snap.polls >= 1
-                {
-                    return snap;
-                }
-                crate::rt::sleep(std::time::Duration::from_millis(5)).await;
-            }
-        })
-        .await
-        .expect("the pending send must be visible while it runs");
-        assert_eq!(
-            seen.timer_wakes, 0,
-            "the cap has not passed yet, so no timer wake can have been recorded",
-        );
-
-        let outcome = crate::rt::timeout(DELIVERY_SEND_BUDGET * 3, pending_send)
-            .await
-            .expect("the cap must expire the send — that is the whole contract")
-            .expect("the send task must not panic");
-        assert_eq!(outcome, Err(()), "a capped-out send reports Err");
-        assert!(
-            store.holder_send_at(crate::rt::Instant::now()).is_none(),
-            "a capped-out send must deregister too",
-        );
-    }
-
-    /// The timer wake that expires a send must be counted as a timer wake.
-    ///
-    /// Split from the lifecycle test so the mutation that unwraps the timer
-    /// waker fails on exactly this claim. The telemetry `Arc` is captured while
-    /// the send is pending and read after it expires — the registration itself
-    /// is (correctly) gone by then.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn the_expiring_timer_wake_is_counted() {
-        let store = Arc::new(DocumentStore::default());
-        let send = {
-            let store = Arc::clone(&store);
-            tokio::spawn(async move {
-                instrumented_delivery_send(&store, "publish send", std::future::pending::<()>())
-                    .await
-            })
-        };
-        // Capture the live telemetry Arc while the send is pending.
-        let telemetry = crate::rt::timeout(std::time::Duration::from_secs(5), async {
-            loop {
-                if let Some(t) = store.tracking().holder_send.clone() {
-                    return t;
-                }
-                crate::rt::sleep(std::time::Duration::from_millis(5)).await;
-            }
-        })
-        .await
-        .expect("the pending send must register its telemetry");
-
-        crate::rt::timeout(DELIVERY_SEND_BUDGET * 3, send)
-            .await
-            .expect("the cap must expire the send")
-            .expect("the send task must not panic")
-            .expect_err("a pending-forever send can only end by cap");
-
-        let t = telemetry
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        assert!(
-            read_wake_record(&t.timer_wakes).count >= 1,
-            "the timer wake that expired this send must be counted: with it \
-             missed, a stall line would print 'TIMER WAKE WAS NEVER DELIVERED' — \
-             the timer-subsystem verdict — about a timer that demonstrably fired",
-        );
-        assert!(
-            t.polls >= 2,
-            "the expiry requires a poll after the wake, and it must be counted",
-        );
-    }
-
-    /// A wake-record snapshot must come from one read, not two.
-    ///
-    /// Codex P2 on #1679. `SendSnapshot` used to read the same `WakeRecord`
-    /// twice — once for the count, once for the last-wake instant. A wake
-    /// landing between the reads produced `count: 0` alongside
-    /// `last: Some(..)`, and the verdict clause keys on the latter: the stall
-    /// line would print "timer half woken 0 time(s)" beside "the timer FIRED",
-    /// a self-contradiction in the exact discriminator the tokio-downgrade
-    /// experiment depends on.
-    ///
-    /// Raced with a fresh record per iteration because the counters are
-    /// monotonic: after the first wake, `count >= 1` for ever and the torn
-    /// pairing is unobservable, so one long-lived record would test nothing.
-    /// Per iteration the writer fires exactly one wake while the sampler
-    /// tight-loops; against the double-read implementation the sampler's
-    /// window lands inside the tear often enough that four thousand
-    /// iterations catch it dependably.
-    #[test]
-    fn a_wake_record_snapshot_is_one_read() {
-        for _ in 0..4_000 {
-            let entry = Arc::new(std::sync::Mutex::new(SendTelemetry {
-                what: "raced send",
-                started: crate::rt::Instant::now(),
-                budget: DELIVERY_SEND_BUDGET,
-                polls: 1,
-                last_poll: crate::rt::Instant::now(),
-                send_wakes: Arc::new(std::sync::Mutex::new(WakeRecord::default())),
-                timer_wakes: Arc::new(std::sync::Mutex::new(WakeRecord::default())),
-            }));
-            let record = Arc::clone(
-                &entry
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner)
-                    .timer_wakes,
-            );
-            let writer = std::thread::spawn(move || {
-                let mut r = record
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                r.count += 1;
-                r.last = Some(crate::rt::Instant::now());
-            });
-            let now = crate::rt::Instant::now();
-            loop {
-                let snap = send_snapshot(&entry, now);
-                assert!(
-                    snap.since_last_timer_wake.is_none() || snap.timer_wakes >= 1,
-                    "a snapshot reports a last timer wake with a zero wake count \
-                     — the two fields were read from the record at different \
-                     moments, and the stall line built from them contradicts \
-                     itself in the timer verdict (Codex P2 on #1679)",
-                );
-                if snap.timer_wakes >= 1 {
-                    break;
-                }
-            }
-            writer.join().expect("writer thread must not panic");
-        }
-    }
-
-    /// The holder-send clause must state the right verdict for each shape.
-    #[test]
-    fn the_holder_send_clause_states_the_verdict() {
-        let base = SendSnapshot {
-            what: "publish send",
-            running_for: std::time::Duration::from_secs(149),
-            budget: std::time::Duration::from_secs(2),
-            polls: 1,
-            since_last_poll: std::time::Duration::from_secs(149),
-            timer_wakes: 0,
-            since_last_timer_wake: None,
-            send_wakes: 0,
-        };
-
-        let never_delivered = describe_holder_send(&base);
-        assert!(
-            never_delivered.contains("TIMER WAKE WAS NEVER DELIVERED"),
-            "over budget with zero timer wakes is the timer-subsystem verdict: \
-             {never_delivered}",
-        );
-
-        let fired_not_polled = describe_holder_send(&SendSnapshot {
-            timer_wakes: 1,
-            since_last_timer_wake: Some(std::time::Duration::from_secs(147)),
-            ..base
-        });
-        assert!(
-            fired_not_polled.contains("NEVER POLLED again"),
-            "a timer wake newer than the last poll is the task-resumption \
-             verdict: {fired_not_polled}",
-        );
-
-        let within_budget = describe_holder_send(&SendSnapshot {
-            running_for: std::time::Duration::from_millis(300),
-            since_last_poll: std::time::Duration::from_millis(300),
-            ..base
-        });
-        assert!(
-            !within_budget.contains("NEVER"),
-            "a send inside its cap gets the plain reading, no verdict: \
-             {within_budget}",
-        );
-    }
-
-    /// The nudge triggers exactly on the two impossible shapes, and on
-    /// nothing else.
+    /// The nudge triggers only for a stale waiter on a free map.
     ///
     /// The watchdog acts on production state, so a wrong predicate is either a
-    /// mitigation that never fires (the wedge stays minutes long) or one that
+    /// evidence probe that never fires (the wedge stays unobserved) or one that
     /// fires on healthy states (pokes and log noise on every long #1678-style
-    /// hold). Each arm is pinned against its nearest legitimate neighbour.
+    /// hold). The trigger is pinned against its nearest legitimate neighbour.
     #[test]
     fn the_nudge_fires_on_impossible_shapes_only() {
-        let send = |running_ms: u64| SendSnapshot {
-            what: "publish send",
-            running_for: std::time::Duration::from_millis(running_ms),
-            budget: DELIVERY_SEND_BUDGET,
-            polls: 1,
-            since_last_poll: std::time::Duration::from_millis(running_ms),
-            timer_wakes: 1,
-            since_last_timer_wake: Some(std::time::Duration::from_millis(
-                running_ms.saturating_sub(2000),
-            )),
-            send_wakes: 0,
-        };
         let held = HeldFor {
             site: "deliver_if_current",
             held: std::time::Duration::from_secs(5),
             in_phase: std::time::Duration::from_secs(5),
         };
         let waiter = |parked_ms: u64| WaiterSnapshot {
+            telemetry_id: 2,
             site: "did_open",
             parked_for: std::time::Duration::from_millis(parked_ms),
             polls: 1,
             since_last_poll: std::time::Duration::from_millis(parked_ms),
             wakes: 0,
             since_last_wake: None,
+            #[cfg(not(target_family = "wasm"))]
+            task_id: None,
         };
-        let contention =
-            |held_by: Option<HeldFor>, holder_send: Option<SendSnapshot>| DocumentsContention {
-                held_by,
-                last: None,
-                acquisitions: 1,
-                holder_send,
-            };
+        let contention = |held_by: Option<HeldFor>| DocumentsContention {
+            held_by,
+            last: None,
+            acquisitions: 1,
+        };
 
-        // Shape 1: a send past cap + grace. Its neighbour — a send merely past
-        // its cap — is what a healthy scheduler shows for an instant before
-        // the timer's poll lands; only the grace margin makes it impossible.
-        assert_eq!(
-            nudge_reason(&contention(Some(held), Some(send(4100))), &[]),
-            Some("holder send past its cap"),
-            "a send alive at cap+grace means a delivered wake nobody polled",
-        );
-        assert_eq!(
-            nudge_reason(&contention(Some(held), Some(send(2100))), &[]),
-            None,
-            "past the cap but inside the grace margin is the timer's poll in \
-             flight, not a wedge — nudging here would fire on healthy runs",
-        );
-
-        // Shape 2: a stale waiter on a FREE map. Its neighbour — the same
+        // A stale waiter on a FREE map. Its neighbour — the same
         // waiter behind a HELD map — is every long #1678-style hold, and must
         // not nudge.
         assert_eq!(
-            nudge_reason(&contention(None, None), &[waiter(4100)]),
-            Some("waiter parked on a free map"),
+            nudge_reason(&contention(None), &[waiter(4100)]),
+            Some(NudgeTarget {
+                telemetry_id: 2,
+                polls: 1,
+            }),
             "a fair mutex hands over immediately; a stale waiter on a free map \
              was never resumed",
         );
         assert_eq!(
-            nudge_reason(&contention(Some(held), None), &[waiter(60_000)]),
+            nudge_reason(&contention(Some(held)), &[waiter(60_000)]),
             None,
             "a waiter behind a held map is a victim of the holder, however \
              stale — nudging would fire on every long legitimate hold (#1678)",
         );
         assert_eq!(
-            nudge_reason(&contention(None, None), &[waiter(500)]),
+            nudge_reason(&contention(None), &[waiter(500)]),
             None,
             "a fresh waiter on a free map is an ordinary handoff in progress",
         );
         assert_eq!(
-            nudge_reason(&contention(None, None), &[]),
+            nudge_reason(&contention(None), &[]),
             None,
             "an idle map never nudges",
         );
@@ -35964,20 +35339,22 @@ mod tests {
         );
         assert!(log.is_empty(), "no action, no log line");
 
-        // Wedged-looking: a holder send whose telemetry is backdated past
-        // cap + grace, registered exactly as the real send registers it.
-        let old = crate::rt::Instant::now() - (DELIVERY_SEND_BUDGET + NUDGE_SEND_GRACE * 2);
-        let telemetry = Arc::new(std::sync::Mutex::new(SendTelemetry {
-            what: "publish send",
-            started: old,
-            budget: DELIVERY_SEND_BUDGET,
+        // Wedged-looking: a waiter registration on a free map, backdated past
+        // the evidence threshold. There is deliberately no acquire future to
+        // resume, so the outcome must report that the external spawns did not
+        // recover the exact target.
+        let old = crate::rt::Instant::now() - NUDGE_WAITER_THRESHOLD * 2;
+        let telemetry = Arc::new(std::sync::Mutex::new(WaiterTelemetry {
+            site: "did_open",
+            parked_since: old,
             polls: 1,
             last_poll: old,
-            send_wakes: Arc::new(std::sync::Mutex::new(WakeRecord::default())),
-            timer_wakes: Arc::new(std::sync::Mutex::new(WakeRecord::default())),
+            wakes: 0,
+            last_wake: None,
+            #[cfg(not(target_family = "wasm"))]
+            task_id: None,
         }));
-        let _held = store.lock("test-holder").await;
-        let _registered = store.begin_holder_send(telemetry);
+        store.tracking().waiters.push(telemetry);
 
         let nudges_before = UNPARK_NUDGES.load(std::sync::atomic::Ordering::Relaxed);
         // Run the step off the runtime, as the real watchdog thread does — it
@@ -35993,14 +35370,14 @@ mod tests {
             .await
             .expect("watchdog step must not panic")
         };
-        assert!(stepped.0, "a send past cap+grace must be nudged");
+        assert!(stepped.0, "a stale waiter on a free map must be nudged");
         let logged = String::from_utf8(stepped.1).expect("log is utf8");
         assert!(
-            logged.contains("[nudge] holder send past its cap"),
+            logged.contains("[nudge] waiter parked on a free map"),
             "the nudge must log its reason and evidence: {logged}",
         );
         assert!(
-            logged.contains("[nudge] outcome:"),
+            logged.contains("[nudge] outcome: STILL WEDGED"),
             "the nudge must log its outcome — the outcome line is the built-in \
              falsifier for the lost-unpark frame: {logged}",
         );
@@ -37451,6 +36828,7 @@ mod tests {
             let uri_string = publisher_b.to_string();
             let delivery = DeliveryCtx {
                 client: &publisher_backend.client,
+                diagnostic_publisher: &publisher_backend.diagnostic_publisher,
                 documents: &publisher_backend.documents,
                 diag_slots: &publisher_backend.diag_slots,
                 pull_diag_cache: &publisher_backend.pull_diag_cache,

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -548,6 +548,75 @@ struct DocumentsTracking {
     /// Each entry is its own `Arc<Mutex<..>>` so the per-poll updates never
     /// touch this tracking lock.
     waiters: Vec<Arc<std::sync::Mutex<WaiterTelemetry>>>,
+    /// Telemetry for the client send the map's holder is currently awaiting,
+    /// if it is in one (issue #1657).
+    ///
+    /// The run-1 poll-shim capture found the holder frozen inside a 2s
+    /// `timeout` for 149.3s — on a runtime whose time driver was demonstrably
+    /// firing other timers, including the two that produced the very report.
+    /// This records what that timeout actually experienced: polls of the
+    /// combined future, wakes delivered by the send half, and wakes delivered
+    /// by the timer half, separately — because "the timer never fired" and
+    /// "the timer fired and the task was never polled again" are different
+    /// faults in different subsystems.
+    holder_send: Option<Arc<std::sync::Mutex<SendTelemetry>>>,
+}
+
+/// What the holder's capped client send has experienced so far.
+#[derive(Debug)]
+struct SendTelemetry {
+    /// Which send — the `[timing]` marker or the publish.
+    what: &'static str,
+    started: crate::rt::Instant,
+    /// The cap the send was given ([`DELIVERY_SEND_BUDGET`]).
+    budget: std::time::Duration,
+    polls: u64,
+    last_poll: crate::rt::Instant,
+    /// Wake deliveries, split by which half of the timeout delivered them.
+    ///
+    /// `Arc`s rather than inline fields: the wakers write these directly from
+    /// the wake path, which must not contend with (or wait on) the telemetry
+    /// lock a sampling reporter might be holding.
+    send_wakes: Arc<std::sync::Mutex<WakeRecord>>,
+    timer_wakes: Arc<std::sync::Mutex<WakeRecord>>,
+}
+
+/// Invocations of one wrapped waker: how many, and when last.
+#[derive(Debug, Clone, Copy, Default)]
+struct WakeRecord {
+    count: u64,
+    last: Option<crate::rt::Instant>,
+}
+
+/// A waker wrapper that records each invocation into a [`WakeRecord`] before
+/// forwarding. Record-then-forward, so a poll caused by this wake can never be
+/// sampled before the wake that caused it.
+struct RecordingWaker {
+    real: std::task::Waker,
+    record: Arc<std::sync::Mutex<WakeRecord>>,
+}
+
+impl RecordingWaker {
+    fn record(&self) {
+        let mut r = self
+            .record
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        r.count += 1;
+        r.last = Some(crate::rt::Instant::now());
+    }
+}
+
+impl std::task::Wake for RecordingWaker {
+    fn wake(self: Arc<Self>) {
+        self.record();
+        self.real.wake_by_ref();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.record();
+        self.real.wake_by_ref();
+    }
 }
 
 /// Poll/wake telemetry for one task parked on the open-document map.
@@ -727,6 +796,41 @@ impl DocumentStore {
         .await
     }
 
+    /// Register `telemetry` as the holder's in-flight send, returning a guard
+    /// that deregisters it — on completion or on cancellation alike.
+    ///
+    /// **Precondition:** the caller holds the map (same contract as
+    /// [`Self::retag_held`], and every call site is inside
+    /// `DeliveryCtx::cache_and_deliver`, which both callers run under their
+    /// guard).
+    fn begin_holder_send(
+        &self,
+        telemetry: Arc<std::sync::Mutex<SendTelemetry>>,
+    ) -> HolderSendGuard<'_> {
+        self.tracking().holder_send = Some(telemetry);
+        HolderSendGuard { store: self }
+    }
+
+    /// The holder's in-flight send, if any, aged against `now`.
+    fn holder_send_at(&self, now: crate::rt::Instant) -> Option<SendSnapshot> {
+        let entry = self.tracking().holder_send.clone()?;
+        let t = entry
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        Some(SendSnapshot {
+            what: t.what,
+            running_for: now.duration_since(t.started),
+            budget: t.budget,
+            polls: t.polls,
+            since_last_poll: now.duration_since(t.last_poll),
+            timer_wakes: read_wake_record(&t.timer_wakes).count,
+            since_last_timer_wake: read_wake_record(&t.timer_wakes)
+                .last
+                .map(|w| now.duration_since(w)),
+            send_wakes: read_wake_record(&t.send_wakes).count,
+        })
+    }
+
     /// Every current waiter, aged against one clock reading.
     fn waiters(&self) -> Vec<WaiterSnapshot> {
         let now = crate::rt::Instant::now();
@@ -761,11 +865,19 @@ impl DocumentStore {
         // *instant*. Both are needed — an earlier version had only the second
         // and could still pair one task's identity with another's metadata.
         let now = crate::rt::Instant::now();
-        let tracking = self.tracking();
+        let (held_by, last, acquisitions) = {
+            let tracking = self.tracking();
+            (
+                tracking.holder.map(|h| held_for(&h, now)),
+                tracking.last.map(|h| (h.site, now.duration_since(h.since))),
+                tracking.acquisitions,
+            )
+        };
         DocumentsContention {
-            held_by: tracking.holder.map(|h| held_for(&h, now)),
-            last: tracking.last.map(|h| (h.site, now.duration_since(h.since))),
-            acquisitions: tracking.acquisitions,
+            held_by,
+            last,
+            acquisitions,
+            holder_send: self.holder_send_at(now),
         }
     }
 
@@ -810,6 +922,118 @@ impl DocumentStore {
     }
 }
 
+/// Clears [`DocumentsTracking::holder_send`] when the send ends — by success,
+/// timeout, or the whole delivery future being dropped.
+struct HolderSendGuard<'a> {
+    store: &'a DocumentStore,
+}
+
+impl Drop for HolderSendGuard<'_> {
+    fn drop(&mut self) {
+        self.store.tracking().holder_send = None;
+    }
+}
+
+/// The holder's in-flight send, aged against one clock reading.
+#[derive(Debug, Clone, Copy)]
+struct SendSnapshot {
+    what: &'static str,
+    running_for: std::time::Duration,
+    budget: std::time::Duration,
+    polls: u64,
+    since_last_poll: std::time::Duration,
+    timer_wakes: u64,
+    since_last_timer_wake: Option<std::time::Duration>,
+    send_wakes: u64,
+}
+
+/// `crate::rt::timeout`, hand-rolled so each half's wakes are recorded
+/// separately (issue #1657).
+///
+/// Polls the send before the sleep, exactly as `tokio::time::timeout` does, so
+/// a send that completes at the deadline still wins. Each half is polled
+/// through its own [`RecordingWaker`], so a later stall line can say **which**
+/// wake arrived — "the timer never fired" and "the timer fired and the task
+/// was never polled again" indict different subsystems.
+struct InstrumentedSendTimeout<S, F> {
+    sleep: Pin<Box<S>>,
+    send: Pin<Box<F>>,
+    telemetry: Arc<std::sync::Mutex<SendTelemetry>>,
+}
+
+/// A [`WakeRecord`] read without poisoning concerns.
+fn read_wake_record(record: &Arc<std::sync::Mutex<WakeRecord>>) -> WakeRecord {
+    *record
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+impl<S: Future<Output = ()>, F: Future> Future for InstrumentedSendTimeout<S, F> {
+    type Output = Result<F::Output, ()>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        let (send_record, timer_record) = {
+            let mut t = self
+                .telemetry
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            t.polls += 1;
+            t.last_poll = crate::rt::Instant::now();
+            (Arc::clone(&t.send_wakes), Arc::clone(&t.timer_wakes))
+        };
+        // Send half first, exactly as `tokio::time::timeout` orders its polls,
+        // so a send completing at the deadline still wins. Fresh wrappers per
+        // poll for the same reason as `InstrumentedAcquire`: each half replaces
+        // its registered waker on every poll, and a reused wrapper would count
+        // wakes delivered to a waker no longer registered anywhere.
+        let send_waker = std::task::Waker::from(Arc::new(RecordingWaker {
+            real: cx.waker().clone(),
+            record: send_record,
+        }));
+        let mut send_cx = std::task::Context::from_waker(&send_waker);
+        if let Poll::Ready(out) = self.send.as_mut().poll(&mut send_cx) {
+            return Poll::Ready(Ok(out));
+        }
+        let timer_waker = std::task::Waker::from(Arc::new(RecordingWaker {
+            real: cx.waker().clone(),
+            record: timer_record,
+        }));
+        let mut timer_cx = std::task::Context::from_waker(&timer_waker);
+        if self.sleep.as_mut().poll(&mut timer_cx).is_ready() {
+            return Poll::Ready(Err(()));
+        }
+        Poll::Pending
+    }
+}
+
+/// Run `send` under [`DELIVERY_SEND_BUDGET`], with the holder-send telemetry
+/// registered for the stall line while it runs (issue #1657).
+///
+/// The behavioural contract is `crate::rt::timeout(DELIVERY_SEND_BUDGET, send)`
+/// exactly; what is added is the split wake accounting above.
+async fn instrumented_delivery_send<F: Future>(
+    store: &DocumentStore,
+    what: &'static str,
+    send: F,
+) -> Result<F::Output, ()> {
+    let now = crate::rt::Instant::now();
+    let telemetry = Arc::new(std::sync::Mutex::new(SendTelemetry {
+        what,
+        started: now,
+        budget: DELIVERY_SEND_BUDGET,
+        polls: 0,
+        last_poll: now,
+        send_wakes: Arc::new(std::sync::Mutex::new(WakeRecord::default())),
+        timer_wakes: Arc::new(std::sync::Mutex::new(WakeRecord::default())),
+    }));
+    let _registered = store.begin_holder_send(Arc::clone(&telemetry));
+    InstrumentedSendTimeout {
+        sleep: Box::pin(crate::rt::sleep(DELIVERY_SEND_BUDGET)),
+        send: Box::pin(send),
+        telemetry,
+    }
+    .await
+}
 /// Removes a [`WaiterTelemetry`] registration when the acquire ends — by
 /// success **or** by cancellation. Identity is the `Arc` pointer, so two
 /// waiters from the same site never remove each other's entries.
@@ -922,6 +1146,54 @@ impl Drop for DocumentsGuard<'_> {
     }
 }
 
+/// Render the holder's in-flight send into its verdict clause (issue #1657).
+///
+/// The run-1 poll-shim capture found the holder inside a 2s cap for 149.3s and
+/// could not say why. This clause can. A send past its budget with:
+///
+/// * **zero timer wakes** — the deadline passed and the timer's wake was never
+///   delivered: the fault is in the timer subsystem (or the timer entry was
+///   lost), not in this task's scheduling.
+/// * **a timer wake after the last poll** — the timer fired and the task was
+///   never polled again: the wake was delivered and the scheduler never ran the
+///   task, which is a task-resumption fault.
+/// * **a poll after the deadline** — cannot happen while still parked: a poll
+///   after the deadline completes the timeout. Seeing it here means the clock
+///   and the report disagree, which is its own finding.
+fn describe_holder_send(send: &SendSnapshot) -> String {
+    let over_budget = send.running_for > send.budget;
+    let base = format!(
+        "; its {} has run {:.1}s against a {:.1}s cap, polled {} time(s) (last {:.1}s ago), \
+         send half woken {} time(s), timer half woken {} time(s)",
+        send.what,
+        send.running_for.as_secs_f64(),
+        send.budget.as_secs_f64(),
+        send.polls,
+        send.since_last_poll.as_secs_f64(),
+        send.send_wakes,
+        send.timer_wakes,
+    );
+    if !over_budget {
+        return base;
+    }
+    match send.since_last_timer_wake {
+        None => format!(
+            "{base} — the cap passed and the TIMER WAKE WAS NEVER DELIVERED: the fault is \
+             in the timer subsystem, not this task's scheduling"
+        ),
+        Some(age) if age < send.since_last_poll => format!(
+            "{base} — the timer FIRED {:.1}s ago and the task was NEVER POLLED again: the \
+             wake was delivered and the scheduler never ran this task",
+            age.as_secs_f64(),
+        ),
+        Some(_) => format!(
+            "{base} — a timer wake predates the last poll yet the send is still parked \
+             past its cap, which should be impossible: distrust the clock or this \
+             instrument before the runtime"
+        ),
+    }
+}
+
 /// Render the map's waiter telemetry and the parent-liveness counter into the
 /// stall line's poll-discrimination clause (issue #1657).
 ///
@@ -937,7 +1209,11 @@ impl Drop for DocumentsGuard<'_> {
 ///
 /// Pure formatting over snapshots, split out for the same reason as
 /// [`describe_documents_contention`].
-fn describe_documents_waiters(waiters: &[WaiterSnapshot], handler_polls: u64) -> String {
+fn describe_documents_waiters(
+    waiters: &[WaiterSnapshot],
+    map_held: bool,
+    handler_polls: u64,
+) -> String {
     if waiters.is_empty() {
         return format!(
             "No task is in the map's contended-acquire path (its instrumented slow path), \
@@ -947,6 +1223,22 @@ fn describe_documents_waiters(waiters: &[WaiterSnapshot], handler_polls: u64) ->
     let mut out = String::new();
     for w in waiters {
         use std::fmt::Write as _;
+        // A waiter behind a HELD map has not been woken because no wake was
+        // ever due — the holder has not released. Framing that as a lost wake
+        // (as the first capture with this clause did) invites the reader to
+        // suspect the mutex when the waiters are merely victims of the holder.
+        // The wake analysis below is only evidence when the map is free.
+        if map_held {
+            let _ = write!(
+                out,
+                "The map's acquire queue holds {} (parked {:.1}s, polled {} time(s),                  woken {} time(s) — a victim of the holder above, no wake due until it                  releases). ",
+                w.site,
+                w.parked_for.as_secs_f64(),
+                w.polls,
+                w.wakes,
+            );
+            continue;
+        }
         let wake = match w.since_last_wake {
             Some(age) if age < w.since_last_poll => format!(
                 "woken {:.1}s ago, AFTER its last poll — the wake arrived and the future was \
@@ -1007,12 +1299,17 @@ fn describe_documents_contention(
         // `in_phase` says whether *this* step is what is long. The counter is
         // deliberately not printed here — nobody else can acquire a held map,
         // so it is trivially zero and says nothing (issue #1657).
-        return format!(
+        let mut line = format!(
             "the open-document map is held by {} — {:.1}s in total, {:.1}s at this point",
             h.site,
             h.held.as_secs_f64(),
             h.in_phase.as_secs_f64(),
         );
+        if let Some(send) = after.holder_send {
+            use std::fmt::Write as _;
+            let _ = write!(line, "{}", describe_holder_send(&send));
+        }
+        return line;
     }
     let last = after.last.map_or_else(
         || "never held".to_owned(),
@@ -1071,6 +1368,8 @@ struct DocumentsContention {
     held_by: Option<HeldFor>,
     last: Option<(&'static str, std::time::Duration)>,
     acquisitions: u64,
+    /// The client send the holder is inside, when it is inside one.
+    holder_send: Option<SendSnapshot>,
 }
 
 /// Upper bound `semantic_tokens_full`/`_delta` wait for the fully enriched
@@ -2278,8 +2577,9 @@ impl DeliveryCtx<'_> {
         let mut marker_sent = false;
         self.documents.retag_held("cache_and_deliver: marker send");
         for _ in 0..attempts {
-            if crate::rt::timeout(
-                DELIVERY_SEND_BUDGET,
+            if instrumented_delivery_send(
+                self.documents,
+                "marker send",
                 self.client.log_message(MessageType::LOG, marker.clone()),
             )
             .await
@@ -2304,8 +2604,9 @@ impl DeliveryCtx<'_> {
             } else {
                 diags.clone()
             };
-            if crate::rt::timeout(
-                DELIVERY_SEND_BUDGET,
+            if instrumented_delivery_send(
+                self.documents,
+                "publish send",
                 deliver_diagnostics(
                     self.client,
                     self.uri,
@@ -7888,6 +8189,7 @@ impl Backend {
         let documents_holder = describe_documents_contention(&before, &after);
         let waiters = describe_documents_waiters(
             &self.documents.waiters(),
+            after.held_by.is_some(),
             handler_polls_after.saturating_sub(handler_polls_before),
         );
         self.client
@@ -34982,7 +35284,7 @@ mod tests {
             since_last_wake: None,
         };
 
-        let never_woken = describe_documents_waiters(&[base], 42);
+        let never_woken = describe_documents_waiters(&[base], false, 42);
         assert!(
             never_woken.contains("lost or never sent"),
             "a never-woken waiter is the lost-wake verdict: {never_woken}",
@@ -34998,6 +35300,7 @@ mod tests {
                 since_last_wake: Some(std::time::Duration::from_secs(9)),
                 ..base
             }],
+            false,
             42,
         );
         assert!(
@@ -35006,17 +35309,186 @@ mod tests {
              {woken_not_polled}",
         );
 
-        let parent_dead = describe_documents_waiters(&[base], 0);
+        let parent_dead = describe_documents_waiters(&[base], false, 0);
         assert!(
             parent_dead.contains("not being driven at all"),
             "a frozen handler-poll counter is the parent-starvation verdict: \
              {parent_dead}",
         );
 
-        let nobody = describe_documents_waiters(&[], 7);
+        let nobody = describe_documents_waiters(&[], false, 7);
         assert!(
             nobody.contains("No task is in the map's contended-acquire path"),
             "an empty registry must say so rather than staying silent: {nobody}",
+        );
+
+        // Behind a HELD map, zero wakes is the expected state, not evidence:
+        // the holder has not released, so no wake was ever due. The run-1
+        // poll-shim capture printed the lost-wake wording for four such
+        // victims, which invited suspicion of the mutex for waiters that were
+        // merely queued behind a stuck holder.
+        let held_victim = describe_documents_waiters(&[base], true, 42);
+        assert!(
+            held_victim.contains("a victim of the holder above"),
+            "a waiter behind a held map must be framed as a victim: {held_victim}",
+        );
+        assert!(
+            !held_victim.contains("lost or never sent"),
+            "a waiter behind a held map must not be given the lost-wake verdict:              {held_victim}",
+        );
+    }
+
+    /// The instrumented send must behave exactly like the timeout it replaces,
+    /// and its timer half must record the wake that ends it.
+    ///
+    /// This is the instrument for the sharpest #1657 anomaly so far: a holder
+    /// frozen inside a 2s cap for 149.3s on a runtime whose time driver was
+    /// firing other timers. The verdict it enables — "timer wake never
+    /// delivered" versus "timer fired, task never polled again" — is only as
+    /// good as the timer-wake accounting, so a timeout that fires without its
+    /// wake being counted would print the timer-subsystem verdict for a timer
+    /// that demonstrably worked.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn the_instrumented_send_records_the_timer_wake_that_expires_it() {
+        let store = Arc::new(DocumentStore::default());
+
+        // A send that completes at once: Ok, and the registration is gone.
+        let ok = instrumented_delivery_send(&store, "marker send", async { 7_u8 }).await;
+        assert_eq!(ok, Ok(7), "a completing send must pass its output through");
+        assert!(
+            store.holder_send_at(crate::rt::Instant::now()).is_none(),
+            "a finished send must deregister — a stale entry would be printed \
+             by every later stall line as an in-flight send",
+        );
+
+        // A send that never completes: visible while pending, Err at the cap,
+        // with the timer wake that expired it recorded.
+        let pending_send = {
+            let store = Arc::clone(&store);
+            tokio::spawn(async move {
+                instrumented_delivery_send(&store, "publish send", std::future::pending::<()>())
+                    .await
+            })
+        };
+        let seen = crate::rt::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if let Some(snap) = store.holder_send_at(crate::rt::Instant::now())
+                    && snap.what == "publish send"
+                    && snap.polls >= 1
+                {
+                    return snap;
+                }
+                crate::rt::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("the pending send must be visible while it runs");
+        assert_eq!(
+            seen.timer_wakes, 0,
+            "the cap has not passed yet, so no timer wake can have been recorded",
+        );
+
+        let outcome = crate::rt::timeout(DELIVERY_SEND_BUDGET * 3, pending_send)
+            .await
+            .expect("the cap must expire the send — that is the whole contract")
+            .expect("the send task must not panic");
+        assert_eq!(outcome, Err(()), "a capped-out send reports Err");
+        assert!(
+            store.holder_send_at(crate::rt::Instant::now()).is_none(),
+            "a capped-out send must deregister too",
+        );
+    }
+
+    /// The timer wake that expires a send must be counted as a timer wake.
+    ///
+    /// Split from the lifecycle test so the mutation that unwraps the timer
+    /// waker fails on exactly this claim. The telemetry `Arc` is captured while
+    /// the send is pending and read after it expires — the registration itself
+    /// is (correctly) gone by then.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn the_expiring_timer_wake_is_counted() {
+        let store = Arc::new(DocumentStore::default());
+        let send = {
+            let store = Arc::clone(&store);
+            tokio::spawn(async move {
+                instrumented_delivery_send(&store, "publish send", std::future::pending::<()>())
+                    .await
+            })
+        };
+        // Capture the live telemetry Arc while the send is pending.
+        let telemetry = crate::rt::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if let Some(t) = store.tracking().holder_send.clone() {
+                    return t;
+                }
+                crate::rt::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("the pending send must register its telemetry");
+
+        crate::rt::timeout(DELIVERY_SEND_BUDGET * 3, send)
+            .await
+            .expect("the cap must expire the send")
+            .expect("the send task must not panic")
+            .expect_err("a pending-forever send can only end by cap");
+
+        let t = telemetry
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert!(
+            read_wake_record(&t.timer_wakes).count >= 1,
+            "the timer wake that expired this send must be counted: with it \
+             missed, a stall line would print 'TIMER WAKE WAS NEVER DELIVERED' — \
+             the timer-subsystem verdict — about a timer that demonstrably fired",
+        );
+        assert!(
+            t.polls >= 2,
+            "the expiry requires a poll after the wake, and it must be counted",
+        );
+    }
+
+    /// The holder-send clause must state the right verdict for each shape.
+    #[test]
+    fn the_holder_send_clause_states_the_verdict() {
+        let base = SendSnapshot {
+            what: "publish send",
+            running_for: std::time::Duration::from_secs(149),
+            budget: std::time::Duration::from_secs(2),
+            polls: 1,
+            since_last_poll: std::time::Duration::from_secs(149),
+            timer_wakes: 0,
+            since_last_timer_wake: None,
+            send_wakes: 0,
+        };
+
+        let never_delivered = describe_holder_send(&base);
+        assert!(
+            never_delivered.contains("TIMER WAKE WAS NEVER DELIVERED"),
+            "over budget with zero timer wakes is the timer-subsystem verdict: \
+             {never_delivered}",
+        );
+
+        let fired_not_polled = describe_holder_send(&SendSnapshot {
+            timer_wakes: 1,
+            since_last_timer_wake: Some(std::time::Duration::from_secs(147)),
+            ..base
+        });
+        assert!(
+            fired_not_polled.contains("NEVER POLLED again"),
+            "a timer wake newer than the last poll is the task-resumption \
+             verdict: {fired_not_polled}",
+        );
+
+        let within_budget = describe_holder_send(&SendSnapshot {
+            running_for: std::time::Duration::from_millis(300),
+            since_last_poll: std::time::Duration::from_millis(300),
+            ..base
+        });
+        assert!(
+            !within_budget.contains("NEVER"),
+            "a send inside its cap gets the plain reading, no verdict: \
+             {within_budget}",
         );
     }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -1433,6 +1433,13 @@ fn unpark_watchdog_step(
             "[nudge] outcome: STILL WEDGED — polls unchanged 500ms after external spawns; \
              the queued task itself is lost, not merely the worker unpark",
         );
+        // The direct observation, where the build allows it: walk every live
+        // task and print its trace and state. Requires
+        // RUSTFLAGS="--cfg tokio_unstable --cfg tokio_taskdump" (local
+        // evidence builds only; inert otherwise). Once per process — the dump
+        // is heavy and one wedge yields one state.
+        #[cfg(all(tokio_unstable, tokio_taskdump))]
+        try_taskdump(handle, log);
     } else {
         let _ = writeln!(
             log,
@@ -1441,6 +1448,37 @@ fn unpark_watchdog_step(
         );
     }
     true
+}
+
+/// Dump every live task's trace into the nudge log — the wedged task's own
+/// await stack and state, observed directly rather than inferred.
+///
+/// Local evidence builds only (`--cfg tokio_unstable --cfg tokio_taskdump`);
+/// never enabled in CI. Bounded: once per process, five-second cap — a dump
+/// requires worker cooperation, and a wedged runtime may not give it.
+#[cfg(all(tokio_unstable, tokio_taskdump))]
+fn try_taskdump(handle: &tokio::runtime::Handle, log: &mut dyn std::io::Write) {
+    static ONCE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+    if ONCE.swap(true, std::sync::atomic::Ordering::Relaxed) {
+        return;
+    }
+    let outcome = handle.block_on(async {
+        tokio::time::timeout(std::time::Duration::from_secs(5), handle.dump()).await
+    });
+    match outcome {
+        Ok(dump) => {
+            for (i, task) in dump.tasks().iter().enumerate() {
+                let _ = writeln!(log, "[taskdump] task {i}:\n{}", task.trace());
+            }
+        }
+        Err(_) => {
+            let _ = writeln!(
+                log,
+                "[taskdump] timed out after 5s — the runtime would not cooperate, \
+                 which is itself evidence",
+            );
+        }
+    }
 }
 
 /// Start the #1657 unpark watchdog: a plain std thread, deliberately outside

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -43,10 +43,13 @@ pub mod uri_norm;
 pub mod vfs;
 
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::future::Future;
 use std::ops::ControlFlow;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::task::Poll;
 // `FutureExt::shared` lets the progressive diagnostics path compute the base
 // per-file analysis once and await it from both the deep pass and the fast tier.
 use futures_util::future::FutureExt;
@@ -536,6 +539,94 @@ struct DocumentsTracking {
     /// * **Frozen** — nothing wants the map, and a waiter that *is* queued was
     ///   never woken. That is a lost wakeup in the ordinary sense.
     acquisitions: u64,
+    /// Every task currently parked in [`DocumentStore::lock`]'s contended slow
+    /// path, with its poll/wake telemetry (issue #1657).
+    ///
+    /// Registered on entering the slow path, removed by a drop guard when the
+    /// acquire completes **or is cancelled** — a `did_close` future dropped
+    /// mid-wait must not leave a ghost waiter for the stall line to accuse.
+    /// Each entry is its own `Arc<Mutex<..>>` so the per-poll updates never
+    /// touch this tracking lock.
+    waiters: Vec<Arc<std::sync::Mutex<WaiterTelemetry>>>,
+}
+
+/// Poll/wake telemetry for one task parked on the open-document map.
+///
+/// # What this discriminates (issue #1657)
+///
+/// A captured wedge showed the map **free** with its acquisition count frozen
+/// while `did_open` sat parked on `documents.lock()` — a waiter that was never
+/// resumed. Two mechanisms produce that and they need different fixes:
+///
+/// * **The wake was lost.** The waiter's waker was never invoked: nothing told
+///   the task to run again. `wakes` stays at zero after the park.
+/// * **The wake arrived and nothing polled.** The waker fired — tokio's mutex
+///   handed the lock over — but the future was never polled afterwards. In
+///   this server every handler future is a child of the single
+///   `buffer_unordered` set inside `Server::serve`, so a child is only ever
+///   re-polled when that parent task runs; a fired wake with no subsequent
+///   poll says the parent (or the `FuturesUnordered` bookkeeping between them)
+///   stopped driving this child. `last_wake` newer than `last_poll`.
+///
+/// The stall line prints both counters and both ages so the reader gets the
+/// verdict, not the ambiguity.
+#[derive(Debug)]
+struct WaiterTelemetry {
+    /// The site passed to [`DocumentStore::lock`].
+    site: &'static str,
+    /// When the slow path was entered. `crate::rt::Instant`, never
+    /// `std::time::Instant` (the latter panics on wasm32).
+    parked_since: crate::rt::Instant,
+    /// Times the acquire future has been polled.
+    polls: u64,
+    last_poll: crate::rt::Instant,
+    /// Times this waiter's waker has been invoked.
+    wakes: u64,
+    last_wake: Option<crate::rt::Instant>,
+}
+
+/// One waiter's telemetry, aged against a single clock reading for the report.
+#[derive(Debug, Clone, Copy)]
+struct WaiterSnapshot {
+    site: &'static str,
+    parked_for: std::time::Duration,
+    polls: u64,
+    since_last_poll: std::time::Duration,
+    wakes: u64,
+    since_last_wake: Option<std::time::Duration>,
+}
+
+/// Wraps the real waker so an invocation is recorded before it is forwarded.
+///
+/// The record-then-forward order matters: recording after would let the woken
+/// task run, poll, and be sampled between the two writes, producing a poll
+/// with no wake that explains it.
+struct TelemetryWaker {
+    real: std::task::Waker,
+    telemetry: Arc<std::sync::Mutex<WaiterTelemetry>>,
+}
+
+impl TelemetryWaker {
+    fn record(&self) {
+        let mut t = self
+            .telemetry
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        t.wakes += 1;
+        t.last_wake = Some(crate::rt::Instant::now());
+    }
+}
+
+impl std::task::Wake for TelemetryWaker {
+    fn wake(self: Arc<Self>) {
+        self.record();
+        self.real.wake_by_ref();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.record();
+        self.real.wake_by_ref();
+    }
 }
 
 /// Who holds [`DocumentStore::docs`], and since when.
@@ -580,7 +671,14 @@ impl DocumentStore {
     /// `site` is a `&'static str` naming the caller — it ends up in a stall
     /// line a human reads, so name the function, not the file and line.
     async fn lock(&self, site: &'static str) -> DocumentsGuard<'_> {
-        let docs = self.docs.lock().await;
+        // Uncontended fast path: no waiter, so nothing to instrument, and the
+        // poll/wake shim's per-poll waker allocation is never paid. tokio's
+        // mutex is fair, so `try_lock` cannot barge past a queued waiter — a
+        // released permit is handed to the queue head, not left for grabs.
+        let docs = match self.docs.try_lock() {
+            Ok(docs) => docs,
+            Err(_) => self.lock_contended(site).await,
+        };
         // One clock reading for both ages, so a hold still in its first phase
         // reports them equal rather than a sub-millisecond difference to squint
         // at. Count and holder are set under the same lock, so no reader can
@@ -595,6 +693,60 @@ impl DocumentStore {
         });
         drop(tracking);
         DocumentsGuard { docs, store: self }
+    }
+
+    /// The contended acquire, instrumented (issue #1657).
+    ///
+    /// Registers a [`WaiterTelemetry`] for the stall line to read, counts every
+    /// poll of the acquire future, and wraps the waker so every wake of this
+    /// waiter is counted too. The registration is removed by a drop guard, so a
+    /// caller cancelled mid-wait (a dropped handler future) cannot leave a
+    /// ghost waiter behind for the report to accuse.
+    async fn lock_contended(
+        &self,
+        site: &'static str,
+    ) -> tokio::sync::MutexGuard<'_, HashMap<Uri, DocumentState>> {
+        let now = crate::rt::Instant::now();
+        let telemetry = Arc::new(std::sync::Mutex::new(WaiterTelemetry {
+            site,
+            parked_since: now,
+            polls: 0,
+            last_poll: now,
+            wakes: 0,
+            last_wake: None,
+        }));
+        self.tracking().waiters.push(Arc::clone(&telemetry));
+        let _deregister = DeregisterWaiter {
+            store: self,
+            telemetry: Arc::clone(&telemetry),
+        };
+        InstrumentedAcquire {
+            inner: Box::pin(self.docs.lock()),
+            telemetry,
+        }
+        .await
+    }
+
+    /// Every current waiter, aged against one clock reading.
+    fn waiters(&self) -> Vec<WaiterSnapshot> {
+        let now = crate::rt::Instant::now();
+        let entries: Vec<_> = self.tracking().waiters.clone();
+        entries
+            .iter()
+            .map(|entry| {
+                let t = entry
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                WaiterSnapshot {
+                    site: t.site,
+                    parked_for: now.duration_since(t.parked_since),
+                    polls: t.polls,
+                    since_last_poll: now.duration_since(t.last_poll),
+                    wakes: t.wakes,
+                    since_last_wake: t.last_wake.map(|w| now.duration_since(w)),
+                }
+            })
+            .collect()
     }
 
     /// Everything the stall line needs about this map in one sample.
@@ -658,6 +810,63 @@ impl DocumentStore {
     }
 }
 
+/// Removes a [`WaiterTelemetry`] registration when the acquire ends — by
+/// success **or** by cancellation. Identity is the `Arc` pointer, so two
+/// waiters from the same site never remove each other's entries.
+struct DeregisterWaiter<'a> {
+    store: &'a DocumentStore,
+    telemetry: Arc<std::sync::Mutex<WaiterTelemetry>>,
+}
+
+impl Drop for DeregisterWaiter<'_> {
+    fn drop(&mut self) {
+        self.store
+            .tracking()
+            .waiters
+            .retain(|w| !Arc::ptr_eq(w, &self.telemetry));
+    }
+}
+
+/// Polls the mutex acquire while recording every poll and routing the waker
+/// through [`TelemetryWaker`] so every wake is recorded too.
+///
+/// The inner future is boxed: this only exists on the contended path, so the
+/// allocation is paid exactly when a waiter exists to describe.
+/// The boxed mutex-acquire future [`InstrumentedAcquire`] drives.
+type BoxedMapAcquire<'a> = Pin<
+    Box<dyn Future<Output = tokio::sync::MutexGuard<'a, HashMap<Uri, DocumentState>>> + Send + 'a>,
+>;
+
+struct InstrumentedAcquire<'a> {
+    inner: BoxedMapAcquire<'a>,
+    telemetry: Arc<std::sync::Mutex<WaiterTelemetry>>,
+}
+
+impl<'a> Future for InstrumentedAcquire<'a> {
+    type Output = tokio::sync::MutexGuard<'a, HashMap<Uri, DocumentState>>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        {
+            let mut t = self
+                .telemetry
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            t.polls += 1;
+            t.last_poll = crate::rt::Instant::now();
+        }
+        // A fresh wrapper per poll, deliberately: futures may only use the
+        // waker from their *most recent* poll, and tokio's mutex replaces its
+        // registered waker on each poll — reusing one wrapper across polls
+        // would record wakes delivered to a waker the mutex no longer holds.
+        let waker = std::task::Waker::from(Arc::new(TelemetryWaker {
+            real: cx.waker().clone(),
+            telemetry: Arc::clone(&self.telemetry),
+        }));
+        let mut shim_cx = std::task::Context::from_waker(&waker);
+        self.inner.as_mut().poll(&mut shim_cx)
+    }
+}
+
 /// A held [`DocumentStore`], which clears the holder tag when dropped.
 ///
 /// Derefs to the map, so every call site reads exactly as it did when the field
@@ -711,6 +920,73 @@ impl Drop for DocumentsGuard<'_> {
             tracking.last = Some(departing);
         }
     }
+}
+
+/// Render the map's waiter telemetry and the parent-liveness counter into the
+/// stall line's poll-discrimination clause (issue #1657).
+///
+/// This is the reading that separates the three remaining stories for a waiter
+/// parked on a free map:
+///
+/// * **woken after its last poll** — the wake arrived and nothing polled the
+///   future again. With `handler_polls` climbing, the parent `buffer_unordered`
+///   is driving *other* children, so this one was lost between the parent and
+///   the child; with it frozen, the parent task itself is not being driven.
+/// * **never woken since parking** — the wake was genuinely lost (or never
+///   sent).
+///
+/// Pure formatting over snapshots, split out for the same reason as
+/// [`describe_documents_contention`].
+fn describe_documents_waiters(waiters: &[WaiterSnapshot], handler_polls: u64) -> String {
+    if waiters.is_empty() {
+        return format!(
+            "No task is in the map's contended-acquire path (its instrumented slow path), \
+             and handler futures were polled {handler_polls} time(s) in the sample window."
+        );
+    }
+    let mut out = String::new();
+    for w in waiters {
+        use std::fmt::Write as _;
+        let wake = match w.since_last_wake {
+            Some(age) if age < w.since_last_poll => format!(
+                "woken {:.1}s ago, AFTER its last poll — the wake arrived and the future was \
+                 never polled again, so its task is not being driven",
+                age.as_secs_f64(),
+            ),
+            Some(age) => format!(
+                "last woken {:.1}s ago, before its last poll — no wake has arrived since it \
+                 parked, so the wake it is waiting for was lost or never sent",
+                age.as_secs_f64(),
+            ),
+            None => "never woken at all — the wake it is waiting for was lost or never \
+                     sent"
+                .to_owned(),
+        };
+        let _ = write!(
+            out,
+            "The map's acquire queue holds {}: parked {:.1}s, polled {} time(s) (last \
+             {:.1}s ago), woken {} time(s) ({wake}). ",
+            w.site,
+            w.parked_for.as_secs_f64(),
+            w.polls,
+            w.since_last_poll.as_secs_f64(),
+            w.wakes,
+        );
+    }
+    {
+        use std::fmt::Write as _;
+        let _ = write!(
+            out,
+            "Handler futures were polled {handler_polls} time(s) in the sample window{}.",
+            if handler_polls == 0 {
+                " — the transport's parent task is not being driven at all, which starves \
+                 every handler child together"
+            } else {
+                " — the parent task is alive and driving other children"
+            },
+        );
+    }
+    out
 }
 
 /// Render the two contention samples a stall report takes into one clause.
@@ -7580,8 +7856,12 @@ impl Backend {
         // enough not to extend a stall anyone is waiting on and long enough for
         // a busy map to move (issue #1657).
         let before = self.documents.contention();
+        let handler_polls_before = crate::transport_liveness::HANDLER_FUTURE_POLLS
+            .load(std::sync::atomic::Ordering::Relaxed);
         crate::rt::sleep(DOCUMENTS_CONTENTION_SAMPLE_GAP).await;
         let after = self.documents.contention();
+        let handler_polls_after = crate::transport_liveness::HANDLER_FUTURE_POLLS
+            .load(std::sync::atomic::Ordering::Relaxed);
         // Re-read the barrier after the sample window, for the same reason
         // #1664 re-reads it after `edits_settled`'s timeout: the edit this
         // report is about may have landed while we slept. Announcing a
@@ -7606,15 +7886,19 @@ impl Backend {
             return;
         }
         let documents_holder = describe_documents_contention(&before, &after);
+        let waiters = describe_documents_waiters(
+            &self.documents.waiters(),
+            handler_polls_after.saturating_sub(handler_polls_before),
+        );
         self.client
             .log_message(
                 MessageType::WARNING,
                 format!(
                     "{EDIT_BARRIER_STALL_LOG} for {}s: now_serving={serving}, waiting for \
                      {target}, so {} document-sync notification(s) are queued behind it. \
-                     The turn is {culprit}. {documents_holder}. {waiting_on}. Every request \
-                     handler is blocked on this barrier and the server will answer nothing \
-                     until it moves (issue #1657).",
+                     The turn is {culprit}. {documents_holder}. {waiters} {waiting_on}. \
+                     Every request handler is blocked on this barrier and the server will \
+                     answer nothing until it moves (issue #1657).",
                     EDIT_BARRIER_STALL_WARN.as_secs(),
                     target.saturating_sub(serving),
                 ),
@@ -34549,6 +34833,190 @@ mod tests {
              limiter untouched — recording it would suppress the next real stall \
              at this position (#1664's lesson, reopened by the sample sleep and \
              closed again here)",
+        );
+    }
+
+    /// A contended acquire must be visible, counted, woken-counted, and gone
+    /// when it is over.
+    ///
+    /// This is the poll-discriminator's ground truth (issue #1657). The wedge
+    /// capture shows a waiter parked on a free map; the verdict the stall line
+    /// draws — wake lost, versus woken-but-never-polled — is only as good as
+    /// these counters. A waiter that did not register would be invisible; polls
+    /// that did not count would read as "never polled" (the parent-starvation
+    /// verdict) for a future being polled constantly; wakes that did not count
+    /// would read as "wake lost" (the extraordinary claim) for a wake that
+    /// arrived.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_contended_map_acquire_reports_its_polls_and_wakes() {
+        let store = Arc::new(DocumentStore::default());
+        assert!(
+            store.waiters().is_empty(),
+            "no waiter exists before anything contends",
+        );
+
+        let held = store.lock("holder").await;
+        assert!(
+            store.waiters().is_empty(),
+            "the fast path must not register a waiter — there is nothing \
+             waiting, and a ghost entry would be accused by the next stall line",
+        );
+
+        let contender = {
+            let store = Arc::clone(&store);
+            tokio::spawn(async move {
+                let _guard = store.lock("contender").await;
+            })
+        };
+
+        // The contender parks. Its registration and at least one poll must be
+        // visible while it waits.
+        let parked = crate::rt::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let waiters = store.waiters();
+                if let [w] = waiters.as_slice()
+                    && w.site == "contender"
+                    && w.polls >= 1
+                {
+                    return *w;
+                }
+                crate::rt::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("the parked contender must appear in the waiter registry");
+        assert_eq!(
+            parked.wakes, 0,
+            "nothing has released the map, so no wake can have been recorded — \
+             a phantom wake here would later disprove a real lost-wake verdict",
+        );
+
+        // Release. The fair mutex hands the lock to the queued contender, which
+        // requires waking it — that wake must be counted before the waiter
+        // finishes and deregisters. We can't sample the registry after the
+        // handoff (the entry is gone, correctly), so sample the Arc the
+        // registry shared: grab it while the waiter is still parked.
+        let telemetry = {
+            let tracking = store.tracking();
+            Arc::clone(&tracking.waiters[0])
+        };
+        drop(held);
+        crate::rt::timeout(std::time::Duration::from_secs(5), contender)
+            .await
+            .expect("the contender must acquire once the map is released")
+            .expect("the contender task must not panic");
+
+        assert!(
+            store.waiters().is_empty(),
+            "a completed acquire must deregister — a stale entry would be \
+             accused by every later stall line",
+        );
+        let t = telemetry
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert!(
+            t.wakes >= 1,
+            "releasing the map woke the queued waiter, and that wake must be \
+             counted: with it missed, a stall line would report 'never woken' — \
+             the lost-wake verdict — about a wake that demonstrably arrived",
+        );
+        assert!(
+            t.polls >= 2,
+            "the wake leads to a final successful poll, which must be counted \
+             like the first",
+        );
+    }
+
+    /// A waiter cancelled mid-wait must deregister.
+    ///
+    /// Handler futures are dropped wholesale (a closed connection, an aborted
+    /// request), taking any parked acquire with them. The registration is
+    /// removed by a drop guard precisely so that this case cannot leave a ghost
+    /// waiter — an entry that would sit in the registry forever and be accused
+    /// by every subsequent stall line as a decades-old parked task.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_cancelled_map_acquire_leaves_no_ghost_waiter() {
+        let store = Arc::new(DocumentStore::default());
+        let held = store.lock("holder").await;
+
+        {
+            let mut acquire = Box::pin(store.lock("doomed"));
+            assert!(
+                crate::rt::timeout(std::time::Duration::from_millis(50), &mut acquire)
+                    .await
+                    .is_err(),
+                "the acquire must park behind the held map, or dropping it \
+                 proves nothing",
+            );
+            assert_eq!(
+                store.waiters().len(),
+                1,
+                "the parked acquire must be registered",
+            );
+            // `acquire` drops here — cancellation.
+        }
+
+        assert!(
+            store.waiters().is_empty(),
+            "a cancelled acquire must deregister its waiter — the drop guard is \
+             the only thing between this and a permanent ghost entry (#1657)",
+        );
+        drop(held);
+    }
+
+    /// The waiter clause must state the right verdict for each telemetry shape.
+    ///
+    /// The whole point of the shim is that a human reads the verdict off the
+    /// stall line, so the mapping from counters to words is behaviour, not
+    /// cosmetics: woken-after-last-poll must read as a driving problem,
+    /// never-woken as a lost wake, and a frozen parent counter as whole-parent
+    /// starvation.
+    #[test]
+    fn the_waiter_clause_states_the_verdict() {
+        let base = WaiterSnapshot {
+            site: "did_open",
+            parked_for: std::time::Duration::from_secs(18),
+            polls: 1,
+            since_last_poll: std::time::Duration::from_secs(18),
+            wakes: 0,
+            since_last_wake: None,
+        };
+
+        let never_woken = describe_documents_waiters(&[base], 42);
+        assert!(
+            never_woken.contains("lost or never sent"),
+            "a never-woken waiter is the lost-wake verdict: {never_woken}",
+        );
+        assert!(
+            never_woken.contains("driving other children"),
+            "a climbing handler-poll counter names the parent as alive: {never_woken}",
+        );
+
+        let woken_not_polled = describe_documents_waiters(
+            &[WaiterSnapshot {
+                wakes: 1,
+                since_last_wake: Some(std::time::Duration::from_secs(9)),
+                ..base
+            }],
+            42,
+        );
+        assert!(
+            woken_not_polled.contains("never polled again"),
+            "a wake newer than the last poll is the not-being-driven verdict: \
+             {woken_not_polled}",
+        );
+
+        let parent_dead = describe_documents_waiters(&[base], 0);
+        assert!(
+            parent_dead.contains("not being driven at all"),
+            "a frozen handler-poll counter is the parent-starvation verdict: \
+             {parent_dead}",
+        );
+
+        let nobody = describe_documents_waiters(&[], 7);
+        assert!(
+            nobody.contains("No task is in the map's contended-acquire path"),
+            "an empty registry must say so rather than staying silent: {nobody}",
         );
     }
 

--- a/rust/tcl-lsp-server/src/main.rs
+++ b/rust/tcl-lsp-server/src/main.rs
@@ -95,6 +95,11 @@ async fn serve() {
     // carry the full derivation and the reason the queue has to be unbounded.
     let (stdout, stdout_drained) = stdio_pump::pump(tokio::io::stdout());
     let (service, socket) = LspService::new(Backend::new);
+    // The #1657 unpark watchdog: an out-of-runtime std thread that breaks the
+    // observed woken-but-never-polled wedge by spawning no-op tasks from
+    // outside (the remote/inject path unparks a worker), logging evidence and
+    // outcome for every action. See `spawn_unpark_watchdog`'s docs.
+    tcl_lsp_server::spawn_unpark_watchdog(service.inner(), tokio::runtime::Handle::current());
     // Wrap the service so every incoming message passes through the URI
     // canonicalisation shim (a no-op for a conforming client) and every
     // outgoing response through the type-hierarchy capability shim (a no-op for

--- a/rust/tcl-lsp-server/src/main.rs
+++ b/rust/tcl-lsp-server/src/main.rs
@@ -95,11 +95,12 @@ async fn serve() {
     // carry the full derivation and the reason the queue has to be unbounded.
     let (stdout, stdout_drained) = stdio_pump::pump(tokio::io::stdout());
     let (service, socket) = LspService::new(Backend::new);
-    // The #1657 unpark watchdog: an out-of-runtime std thread that breaks the
-    // observed woken-but-never-polled wedge by spawning no-op tasks from
-    // outside (the remote/inject path unparks a worker), logging evidence and
-    // outcome for every action. See `spawn_unpark_watchdog`'s docs.
-    tcl_lsp_server::spawn_unpark_watchdog(service.inner(), tokio::runtime::Handle::current());
+    // Evidence-only #1657 watchdog. The external-spawn experiment falsified
+    // its proposed recovery mechanism (zero true resumptions), so normal
+    // servers do not pay for or rely on it. An evidence run opts in explicitly.
+    if std::env::var_os("TCL_LSP_WEDGE_EVIDENCE").is_some() {
+        tcl_lsp_server::spawn_unpark_watchdog(service.inner(), tokio::runtime::Handle::current());
+    }
     // Wrap the service so every incoming message passes through the URI
     // canonicalisation shim (a no-op for a conforming client) and every
     // outgoing response through the type-hierarchy capability shim (a no-op for
@@ -107,30 +108,25 @@ async fn serve() {
     let service = service
         .map_request(normalise_request_uris)
         .map_response(|resp: Option<Response>| resp.map(inject_type_hierarchy_provider));
-    // INVARIANT (no lost and no reordered diagnostics under a slow client):
-    // the delivery path needs outbound messages to be *ordered* and *never
-    // dropped*. `tower-lsp-server` 0.23 gives the `Client` a bounded
-    // `futures::mpsc::channel(1)` drained by a single `.forward(FramedWrite(
-    // stdout))`, so a `client.publish_diagnostics(..).await` resolves only
-    // once the message is durably queued — it never `try_send`s
-    // (drop-on-full). Behind that, `stdio_pump` keeps a single FIFO queue
-    // drained by a single writer task, so ordering and no-drop both hold end
-    // to end; what it deliberately does not do is make a slow client stall the
-    // producer, because that coupling is what deadlocked the session (#1334).
+    // INVARIANT (ordered diagnostics without a server-wide backpressure blast
+    // radius): one persistent publisher owns every diagnostics `Client` await.
+    // Producers commit the pull-cache state and a latest-wins per-URI mailbox
+    // entry while their document ordering guard is held, then release that
+    // guard before awaiting the publisher's receipt. A superseded pending state
+    // is settled explicitly; an already-started send is never cancelled or
+    // retried (`SinkExt::send` can have completed `start_send` before parking
+    // in `poll_flush`, so retrying could duplicate it). The single consumer
+    // preserves the cross-URI order of surviving commits and sends a newer
+    // same-URI state after any in-flight predecessor.
     //
-    // Two things must not silently break this — re-audit the whole delivery
-    // path (`deliver_diagnostics`, `deliver_fast_tier_if_current`,
-    // `publish_diagnostics_result`) if either changes:
-    //   1. Swapping `tower-lsp-server` for a build whose client channel uses
-    //      `try_send`, or reordering the outbound path so more than one task
-    //      writes to the pump — outbound would then drop or interleave. The dep
-    //      is version-pinned in `Cargo.toml`; treat an upgrade that touches its
-    //      transport as a delivery-review gate.
-    //   2. Making any diagnostics publish fire-and-forget (e.g. wrapping it in a
-    //      detached `tokio::spawn` to avoid holding the `documents` lock across
-    //      the send). Concurrent publishes would reorder, and a
-    //      state-gated/disconnected drop would go unnoticed. Delivery MUST stay
-    //      an inline `.await`.
+    // `tower-lsp-server` 0.23 then queues each awaited client message through
+    // its bounded `futures::mpsc::channel(1)`, and `stdio_pump` preserves FIFO
+    // order to one writer without coupling stdout backpressure to stdin. Re-
+    // audit `deliver_diagnostics`, `DiagnosticPublisher`,
+    // `deliver_fast_tier_if_current` and `publish_diagnostics_result` if that
+    // transport changes. In particular: never add a second diagnostics
+    // consumer, never timeout/retry an in-flight send, and never await client
+    // I/O while holding `documents` or another request-critical guard.
     // Keep stdin routing independent of handler progress. The transport's
     // queue is always drained into pending futures, while the wrapper retains
     // the original four-handler application concurrency for ordinary work.

--- a/rust/tcl-lsp-server/src/transport_liveness.rs
+++ b/rust/tcl-lsp-server/src/transport_liveness.rs
@@ -29,7 +29,6 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::task::{Context, Poll};
 
 use tokio::sync::Semaphore;
@@ -49,39 +48,6 @@ pub const UNBOUNDED_TRANSPORT_CONCURRENCY: usize = usize::MAX;
 /// `tower-lsp-server`'s default transport configuration. JSON-RPC
 /// notifications do not consume these permits.
 pub const DEFAULT_HANDLER_CONCURRENCY: usize = 4;
-
-/// Total polls of every handler future this transport has ever driven.
-///
-/// The parent-liveness reading for issue #1657. Every handler future — request
-/// and notification alike — is a child of the single `buffer_unordered` set
-/// inside `Server::serve`, so a child is only re-polled when that parent task
-/// runs. A stall line that finds a waiter woken-but-never-polled needs to know
-/// whether the parent is driving *anything*:
-///
-/// * counter climbing during the stall → the parent runs and polls other
-///   children, so the un-polled waiter was lost between the parent and that
-///   one child (the `FuturesUnordered` bookkeeping, or the child's waker);
-/// * counter frozen → the parent task itself is not being driven, and every
-///   child starves together — the whole-server signature.
-///
-/// Relaxed: a diagnostic counter read by a human out of a log line, never a
-/// synchronisation point.
-pub static HANDLER_FUTURE_POLLS: AtomicU64 = AtomicU64::new(0);
-
-/// Counts every poll of the wrapped handler future in
-/// [`HANDLER_FUTURE_POLLS`], then forwards.
-struct PollCounted<F> {
-    inner: Pin<Box<F>>,
-}
-
-impl<F: Future> Future for PollCounted<F> {
-    type Output = F::Output;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        HANDLER_FUTURE_POLLS.fetch_add(1, Ordering::Relaxed);
-        self.inner.as_mut().poll(cx)
-    }
-}
 
 /// A service wrapper which keeps ordinary LSP requests at `limit` concurrent
 /// while admitting every notification immediately.
@@ -152,22 +118,20 @@ where
         // readiness contract, this lets LspService register a request with its
         // cancellation map before a later `$/cancelRequest` is read.
         let future = self.inner.call(request);
-        Box::pin(PollCounted {
-            inner: Box::pin(async move {
-                let permit = if is_notification {
-                    None
-                } else {
-                    Some(
-                        permits
-                            .acquire_owned()
-                            .await
-                            .expect("handler semaphore is owned by the queued futures"),
-                    )
-                };
-                let result = future.await;
-                drop(permit);
-                result
-            }),
+        Box::pin(async move {
+            let permit = if is_notification {
+                None
+            } else {
+                Some(
+                    permits
+                        .acquire_owned()
+                        .await
+                        .expect("handler semaphore is owned by the queued futures"),
+                )
+            };
+            let result = future.await;
+            drop(permit);
+            result
         })
     }
 }

--- a/rust/tcl-lsp-server/src/transport_liveness.rs
+++ b/rust/tcl-lsp-server/src/transport_liveness.rs
@@ -29,6 +29,7 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::task::{Context, Poll};
 
 use tokio::sync::Semaphore;
@@ -48,6 +49,39 @@ pub const UNBOUNDED_TRANSPORT_CONCURRENCY: usize = usize::MAX;
 /// `tower-lsp-server`'s default transport configuration. JSON-RPC
 /// notifications do not consume these permits.
 pub const DEFAULT_HANDLER_CONCURRENCY: usize = 4;
+
+/// Total polls of every handler future this transport has ever driven.
+///
+/// The parent-liveness reading for issue #1657. Every handler future — request
+/// and notification alike — is a child of the single `buffer_unordered` set
+/// inside `Server::serve`, so a child is only re-polled when that parent task
+/// runs. A stall line that finds a waiter woken-but-never-polled needs to know
+/// whether the parent is driving *anything*:
+///
+/// * counter climbing during the stall → the parent runs and polls other
+///   children, so the un-polled waiter was lost between the parent and that
+///   one child (the `FuturesUnordered` bookkeeping, or the child's waker);
+/// * counter frozen → the parent task itself is not being driven, and every
+///   child starves together — the whole-server signature.
+///
+/// Relaxed: a diagnostic counter read by a human out of a log line, never a
+/// synchronisation point.
+pub static HANDLER_FUTURE_POLLS: AtomicU64 = AtomicU64::new(0);
+
+/// Counts every poll of the wrapped handler future in
+/// [`HANDLER_FUTURE_POLLS`], then forwards.
+struct PollCounted<F> {
+    inner: Pin<Box<F>>,
+}
+
+impl<F: Future> Future for PollCounted<F> {
+    type Output = F::Output;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        HANDLER_FUTURE_POLLS.fetch_add(1, Ordering::Relaxed);
+        self.inner.as_mut().poll(cx)
+    }
+}
 
 /// A service wrapper which keeps ordinary LSP requests at `limit` concurrent
 /// while admitting every notification immediately.
@@ -118,20 +152,22 @@ where
         // readiness contract, this lets LspService register a request with its
         // cancellation map before a later `$/cancelRequest` is read.
         let future = self.inner.call(request);
-        Box::pin(async move {
-            let permit = if is_notification {
-                None
-            } else {
-                Some(
-                    permits
-                        .acquire_owned()
-                        .await
-                        .expect("handler semaphore is owned by the queued futures"),
-                )
-            };
-            let result = future.await;
-            drop(permit);
-            result
+        Box::pin(PollCounted {
+            inner: Box::pin(async move {
+                let permit = if is_notification {
+                    None
+                } else {
+                    Some(
+                        permits
+                            .acquire_owned()
+                            .await
+                            .expect("handler semaphore is owned by the queued futures"),
+                    )
+                };
+                let result = future.await;
+                drop(permit);
+                result
+            }),
         })
     }
 }


### PR DESCRIPTION
The poll/wake discriminators for #1657, the watchdog they enabled, and the falsifications they produced. **`Refs #1657`, not `Fixes`**: this diagnoses.

## What landed, in the order the captures forced it

**1. Waiter poll/wake telemetry.** `DocumentStore::lock` gains an instrumented contended slow path (`try_lock` first — the uncontended path pays nothing, and tokio's fair mutex means no barging past a queued waiter). Each parked waiter registers polls (count + last age) and wakes of its waker (count + last age). The waker wrapper is fresh **per poll**: tokio's mutex replaces its registered waker each poll, and a reused wrapper would count wakes delivered to a waker the mutex no longer holds. A drop guard deregisters on completion or cancellation, so a dropped handler future cannot leave a ghost waiter for later stall lines to accuse.

**2. Parent-liveness counter.** `transport_liveness::HANDLER_FUTURE_POLLS` counts every poll of every handler future the transport drives, sampled across the reporter's 250 ms window.

**3. The send-timeout instrument.** The two delivery sends run under a hand-rolled timeout — behaviourally identical to `crate::rt::timeout`, send polled before sleep exactly as tokio orders it — polling each half through its **own** recording waker, so the stall line states which wake arrived. Plus the honesty fix the first capture forced: waiters behind a *held* map are framed as victims, never given the lost-wake verdict.

**4. The unpark watchdog** (checkpoint 27's design, posted before implementation): an out-of-runtime std thread sampling the telemetry, acting on two shapes impossible on a healthy scheduler (send past cap+grace; stale waiter on a *free* map), logging evidence and outcome per action, stderr + `TCL_LSP_NUDGE_LOG` tee. **Its role is detector, not mitigation — see below.**

**5. A taskdump hook**, inert outside evidence builds (`#[cfg(all(tokio_unstable, tokio_taskdump))]`; tokio compile-errors on the feature without the cfg, so it cannot ride into CI even by accident; the workspace declares the cfgs via check-cfg).

## What the instruments established (checkpoints 21–29)

Four byte-identical captures — three on tokio 1.53.1, one on **1.51.1** (downgrade experiment, lockfile never committed):

```
its publish send has run 45.8s against a 2.0s cap, polled 1 time(s) (last 45.8s ago),
send half woken 1 time(s), timer half woken 1 time(s) —
the timer FIRED 43.8s ago and the task was NEVER POLLED again
```

The timer fires at **exactly** its cap every time; the wake is delivered (twice, via two independent wakers); the task is never polled again for 45–421+ seconds while sibling tasks proceed.

**Falsified by these instruments, in order:** the timer subsystem; the tokio 1.52/1.53 regression theories (identical wedge on 1.51.1); lost worker unpark (139 external-spawn pokes, zero true resumptions — the watchdog's built-in falsifier); a worker stuck inside a poll (live-wedge gdb: all workers parked); and wedge self-recovery (an orphaned specimen has held a 2s-capped send for 400+ seconds through constant pokes, with client traffic flowing during the original run).

**What survives:** the task's wake→schedule is a permanent no-op — the signature of a task whose NOTIFIED state is set while its queue entry no longer exists anywhere. That is a statement about tokio's scheduler internals (or memory corruption reaching them), not about code this repo owns. The taskdump hook exists to observe it directly; the evidence run is in progress.

One correction of ours banked on the issue: the watchdog's initial "resumed" outcome was a progress-signature false positive (a *new* waiter arriving counted as progress). True tally: 0 resumptions.

## Testing

Eight new tests; five mutation-verified on exactly the false-verdict claim each guards against (acquire waker unwrapped; deregistration neutered; send timer-waker unwrapped; nudge held-map guard removed; nudge grace margin removed). Verdict strings pinned per telemetry shape.

Gates: `cargo fmt --all --check`, `cargo clippy -p tcl-lsp-server --all-targets` (clean on 1.98.0, check-cfg declared), `cargo check --workspace`, 497 lib tests, `make lsp-server-wasm-test` 16/16. All clocks `crate::rt::Instant`.

Full evidence chain: #1657 checkpoints 20–29 and `docs/design/notes/tokio-task-resumption-wedge-repro.md` (in this PR), which also carries the standalone distillation sample with its honestly-reported non-reproduction (5,400 trials).

Refs #1657

🤖 Generated with [Claude Code](https://claude.com/claude-code)