### PR TITLE
fix(ci): test browser LSP server before merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,10 @@ jobs:
   #                    compare, or a tag ref → everything counts as changed),
   #                    so jobs whose input surface didn't change stop
   #                    re-testing it on every PR.
+  #   lsp_wasm_changed — the browser LSP server or one of its transitive local
+  #                    dependencies changed.  This keeps the expensive real
+  #                    wasm-bindgen build and scripted LSP session targeted,
+  #                    while failing safe when path detection is ambiguous.
   channel:
     runs-on: ubuntu-24.04
     permissions:
@@ -96,6 +100,7 @@ jobs:
       already_green: ${{ steps.green.outputs.already_green }}
       python_changed: ${{ steps.paths.outputs.python_changed }}
       ext_changed: ${{ steps.paths.outputs.ext_changed }}
+      lsp_wasm_changed: ${{ steps.paths.outputs.lsp_wasm_changed }}
       docs_only: ${{ steps.paths.outputs.docs_only }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -171,6 +176,7 @@ jobs:
 
           python_changed=false
           ext_changed=false
+          lsp_wasm_changed=false
           docs_only=true
           if [ "$ok" = "true" ]; then
             while IFS= read -r f; do
@@ -183,6 +189,10 @@ jobs:
                   ext_changed=true ;;
               esac
               case "$f" in
+                rust/f5-xc/* | rust/tcl-bigip/* | rust/tcl-bytecode/* | rust/tcl-cmd-core/* | rust/tcl-compiler/* | rust/tcl-core-types/* | rust/tcl-diagram/* | rust/tcl-dialect/* | rust/tcl-engine-api/* | rust/tcl-engine-tclvm/* | rust/tcl-explorer/* | rust/tcl-host-native/* | rust/tcl-irules/* | rust/tcl-lexer/* | rust/tcl-lsp-core/* | rust/tcl-lsp-db/* | rust/tcl-lsp-server/* | rust/tcl-lsp-server-wasm/* | rust/tcl-platform/* | rust/tcl-regex/* | rust/tcl-registry/* | rust/tcl-runtime-api/* | rust/tcl-spec-hooks/* | rust/tcl-spectcl/* | rust/tcl-sslictcl/* | rust/tcl-syntax/* | rust/tcl-userdirs/* | rust/tcl-version/* | rust/tcl-vm/* | .cargo/config.toml | scripts/verify-wasm-externref.mjs | Cargo.toml | Cargo.lock | rust-toolchain.toml | Makefile | .github/workflows/ci.yml)
+                  lsp_wasm_changed=true ;;
+              esac
+              case "$f" in
                 docs/* | *.md | .claude/* | .gitignore | LICENSE) ;;
                 *) docs_only=false ;;
               esac
@@ -190,14 +200,16 @@ jobs:
           else
             python_changed=true
             ext_changed=true
+            lsp_wasm_changed=true
             docs_only=false
           fi
           {
             echo "python_changed=$python_changed"
             echo "ext_changed=$ext_changed"
+            echo "lsp_wasm_changed=$lsp_wasm_changed"
             echo "docs_only=$docs_only"
           } >>"$GITHUB_OUTPUT"
-          echo "python_changed=$python_changed ext_changed=$ext_changed docs_only=$docs_only"
+          echo "python_changed=$python_changed ext_changed=$ext_changed lsp_wasm_changed=$lsp_wasm_changed docs_only=$docs_only"
 
   # Fast PR gate.  Runs on every PR and every push.  Covers the Rust fast
   # checks: `cargo fmt --check`, `cargo clippy --workspace`, and the
@@ -474,9 +486,9 @@ jobs:
   # `cargo test --workspace --all-features --no-fail-fast`, Swatinem cache,
   # toolchain resolved from rust-toolchain.toml.
   #
-  # The cargo surface is split across FIVE concurrent jobs so the CPU-bound
+  # The Rust/WASM surface is split across SIX concurrent jobs so the CPU-bound
   # suites don't serialise behind each other.  Wall-clock is the max of the
-  # five, not their sum.  The first four are required status checks on `rust`:
+  # six, not their sum.  The first four are required status checks on `rust`:
   #
   #   rust-tests        workspace minus the VM-sim heavies and tcl-lsp-server,
   #                     plus ALL workspace doctests (cheap; nextest can't run
@@ -505,6 +517,9 @@ jobs:
   #                     `rust-tests`' workspace run too, so `wasm_real_link.rs`
   #                     also executes there — without the toolchain, where it
   #                     skips loudly by naming what is missing.
+  #   lsp-server-wasm   the real wasm-bindgen LSP server, driven through a
+  #                     scripted JSON-RPC session under Node.  Path-filtered
+  #                     to the browser server's local dependency closure.
   #
   # nextest runs every test binary's tests in ONE global parallel pool, so the
   # VM-sim suites overlap instead of running one binary at a time — a large
@@ -716,6 +731,50 @@ jobs:
           TCL_REQUIRE_WASM_LINK: '1'
         run: cargo test -p tcl-compiler --test wasm_real_link -- --test-threads=1
 
+  # The real browser LSP server: release-link the wasm-bindgen facade, verify
+  # the produced module, then drive a scripted JSON-RPC session under Node.
+  # This is intentionally distinct from `wasm-real-link`, which exercises the
+  # compiler's WASI runtime rather than the browser language server.  Before
+  # this job, browser-only regressions first appeared after merge in the Pages
+  # deployment (#1662).
+  lsp-server-wasm:
+    needs: [channel]
+    runs-on: ubuntu-26.04
+    env:
+      # Keep the expensive release/LTO link targeted to the browser server's
+      # local dependency closure.  An ambiguous path classification is true;
+      # already-green merge pushes and tags carry forward their PR/push result.
+      RUN_LSP_WASM: ${{ needs.channel.outputs.lsp_wasm_changed == 'true' && needs.channel.outputs.already_green != 'true' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Set up Rust
+        if: env.RUN_LSP_WASM == 'true'
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          cache-key: lsp-server-wasm
+          cache-workspaces: rust/tcl-lsp-server-wasm
+
+      - name: Install wasm-bindgen CLI
+        if: env.RUN_LSP_WASM == 'true'
+        uses: taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d # v2.85.12
+        with:
+          tool: wasm-bindgen-cli@0.2.127
+
+      - name: Set up Node.js
+        if: env.RUN_LSP_WASM == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
+      - name: Build and exercise the browser LSP server
+        if: env.RUN_LSP_WASM == 'true'
+        run: make lsp-server-wasm-test
+
   # Native-server lsp_e2e suite.  Its own job (hence its own status check)
   # because it is a distinct, heavier surface: it builds the `tcl-lsp-server`
   # binary and drives the end-to-end LSP suite against it over stdio JSON-RPC.
@@ -872,7 +931,7 @@ jobs:
     # whose SHA was never tested (or whose green is stale) runs everything
     # here in full.  cargo-deny always runs regardless.
     needs:
-      [channel, pr-gate, rust-tests, rust-tests-heavy, lsp-e2e, cargo-deny, python]
+      [channel, pr-gate, rust-tests, rust-tests-heavy, lsp-server-wasm, lsp-e2e, cargo-deny, python]
     runs-on: ubuntu-24.04
     permissions:
       contents: write        # gh release upload

--- a/rust/tcl-lsp-server-wasm/Cargo.lock
+++ b/rust/tcl-lsp-server-wasm/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +98,21 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
 
 [[package]]
 name = "base16ct"
@@ -528,6 +558,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +745,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,6 +805,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1036,6 +1090,12 @@ dependencies = [
  "spki",
  "zeroize",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -1690,6 +1750,7 @@ version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
+ "backtrace",
  "bytes",
  "pin-project-lite",
  "tokio-macros",

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -592,6 +592,7 @@ struct WaiterTelemetry {
 #[derive(Debug, Clone, Copy)]
 struct WaiterSnapshot {
     /// Identity of the telemetry registration, stable until deregistration.
+    #[cfg(not(target_family = "wasm"))]
     telemetry_id: usize,
     site: &'static str,
     parked_for: std::time::Duration,
@@ -747,6 +748,7 @@ impl DocumentStore {
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
                 WaiterSnapshot {
+                    #[cfg(not(target_family = "wasm"))]
                     telemetry_id: Arc::as_ptr(entry) as usize,
                     site: t.site,
                     parked_for: now.duration_since(t.parked_since),


### PR DESCRIPTION
## Summary

- fix the browser-only Rust 1.98 warning that broke the Pages build
- add a path-filtered Linux CI job that release-links the real browser LSP server and drives its scripted JSON-RPC session under Node 24
- cover the complete Cargo-resolved local dependency closure plus the build verifier, and make release creation depend on the job
- complete the excluded browser crate lockfile for Cargo 1.98 target-specific resolution

This is the final pre-release CI blocker identified in #1662.

## Validation

- make rust-check
- make prep-pr
- workflow YAML parse and local-dependency path-filter audit
- local WASM compilation reached the final link with warnings denied; Linux CI is the authoritative full link/session environment because the local macOS Rust 1.98 package is missing its bundled libLLVM.dylib

Closes #1662