### PR TITLE
test: make macOS diagnostics fixtures portable

### DIFF
--- a/editors/vscode/src/test/waitDiscipline.test.ts
+++ b/editors/vscode/src/test/waitDiscipline.test.ts
@@ -441,25 +441,33 @@ suite("Wait discipline (issue #1274)", () => {
       /pid unavailable/,
       `the server pid must still be reachable from the language client: ${evidence}`,
     );
-    assert.match(
-      evidence,
-      /server process: pid \d+, state \S+, \d+ thread\(s\)/,
-      `the process reading must name state and thread count: ${evidence}`,
-    );
-    assert.match(
-      evidence,
-      /CPU tick\(s\) and moved \d+ byte\(s\) in \/ \d+ byte\(s\) out/,
-      `the CPU and byte deltas are what separate spinning from stopped: ${evidence}`,
-    );
-    // The byte counters are process-wide (`/proc/<pid>/io` aggregates every
-    // descriptor), so the reading must say so rather than let a reader take
-    // movement as proof the LSP pipes are draining — a pack-discovery walk
-    // moves them too.
-    assert.match(
-      evidence,
-      /aggregate process I\/O, not the LSP pipes alone/,
-      `the byte counters must be labelled as process-wide: ${evidence}`,
-    );
+    if (process.platform === "linux") {
+      assert.match(
+        evidence,
+        /server process: pid \d+, state \S+, \d+ thread\(s\)/,
+        `the process reading must name state and thread count: ${evidence}`,
+      );
+      assert.match(
+        evidence,
+        /CPU tick\(s\) and moved \d+ byte\(s\) in \/ \d+ byte\(s\) out/,
+        `the CPU and byte deltas are what separate spinning from stopped: ${evidence}`,
+      );
+      // The byte counters are process-wide (`/proc/<pid>/io` aggregates every
+      // descriptor), so the reading must say so rather than let a reader take
+      // movement as proof the LSP pipes are draining — a pack-discovery walk
+      // moves them too.
+      assert.match(
+        evidence,
+        /aggregate process I\/O, not the LSP pipes alone/,
+        `the byte counters must be labelled as process-wide: ${evidence}`,
+      );
+    } else {
+      assert.match(
+        evidence,
+        /server process: pid \d+, but \/proc is unreadable \(already exited, or not Linux\)/,
+        `non-Linux hosts must retain the pid and explain the missing process sample: ${evidence}`,
+      );
+    }
     assert.match(evidence, /server log:/, `the server's last words must be quoted: ${evidence}`);
   });
 

--- a/rust/tcl-lsp-server/tests/e2e/spec_packs.rs
+++ b/rust/tcl-lsp-server/tests/e2e/spec_packs.rs
@@ -64,7 +64,10 @@ fn workspace(name: &str) -> PathBuf {
     ));
     let _ = std::fs::remove_dir_all(&root);
     std::fs::create_dir_all(&root).expect("workspace root");
-    root
+    // macOS exposes its temporary directory through `/var`, a symlink to
+    // `/private/var`. Pack discovery canonicalises paths before publishing
+    // diagnostics, so keep the client-side fixture URI in that same spelling.
+    std::fs::canonicalize(root).expect("canonical workspace root")
 }
 
 fn write(path: &Path, body: &str) {


### PR DESCRIPTION
## Summary

- canonicalise the native SpecTcl fixture workspace so its URI matches the server-published path on macOS (`/var` → `/private/var`)
- retain the detailed `/proc` liveness assertions on Linux and verify the documented fallback on non-Linux hosts

## Verification

- `make rust-check`
- `make prep-pr`
- SpecTcl native E2E: 18 passed
- macOS VS Code GUI: 921 passed, 1 intentional pending; multi-root: 14 passed
- focused WASM coroutine suite: 3 passed

Release-blocking portability correction discovered during the v2.1.23 macOS qualification.