### PR TITLE
Fix Pages Monaco hover boot assertion

### DIFF
--- a/rust/tcl-spec-studio-wasm/test/boot.mjs
+++ b/rust/tcl-spec-studio-wasm/test/boot.mjs
@@ -241,8 +241,24 @@ async function main() {
     // Prove hover is connected to the visible Monaco model, rather than only
     // to the direct readiness probe above.
     const speclibLine = page.locator("#dslEditor .view-line", { hasText: "speclib" }).first();
-    await speclibLine.hover();
-    await page.waitForSelector("#dslEditor .monaco-hover", { state: "visible", timeout: 30_000 });
+    const speclibPoint = await speclibLine.evaluate((line) => {
+      const walker = document.createTreeWalker(line, NodeFilter.SHOW_TEXT);
+      for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+        const offset = node.textContent?.indexOf("speclib") ?? -1;
+        if (offset < 0) continue;
+        const range = document.createRange();
+        range.setStart(node, offset);
+        range.setEnd(node, offset + "speclib".length);
+        const rect = range.getBoundingClientRect();
+        return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
+      }
+      throw new Error("rendered speclib token has no text range");
+    });
+    await page.mouse.move(speclibPoint.x, speclibPoint.y);
+    // Monaco retains a hidden hover widget alongside the active one. Waiting
+    // on the broad selector makes Playwright choose that first, hidden node
+    // even when the second widget is already visible.
+    await page.locator("#dslEditor .monaco-hover:visible").waitFor({ timeout: 30_000 });
     console.log("    Pack DSL hover is visible in Monaco on initial load");
 
     // 4. The server actually analyses: type a broken pack line and expect the


### PR DESCRIPTION
## Summary

- move the Playwright pointer to the exact rendered `speclib` token rather than the centre of its Monaco line
- wait for Monaco's active visible hover widget instead of the retained hidden widget

This fixes the v2.1.24 tag Pages failure in run 32644920503.

## Validation

- reproduced the original 30-second timeout locally
- repaired assembled browser boot: registry, Monaco, in-page LSP, semantic colours, hover, diagnostics, imports, release diff, and fallback readiness all pass
- `make prep-pr`