### PR TITLE
test(pages): allow portalled Monaco hover widget

### DIFF
--- a/rust/tcl-spec-studio-wasm/test/boot.mjs
+++ b/rust/tcl-spec-studio-wasm/test/boot.mjs
@@ -245,7 +245,10 @@ async function main() {
     // range for each attempt so this still tests the real pointer-driven
     // Monaco hover path without depending on a stale render node.
     const speclibLine = page.locator("#dslEditor .view-line", { hasText: "speclib" }).first();
-    const visibleHover = page.locator("#dslEditor .monaco-hover:visible");
+    // Monaco may portal an overflow widget outside the editor container. Its
+    // documented symbol content, not that platform-dependent parent, ties the
+    // visible widget to this DSL editor and this hover request.
+    const visibleHover = page.locator(".monaco-hover:visible", { hasText: "speclib" });
     for (let attempt = 0; attempt < 6 && !(await visibleHover.isVisible()); attempt += 1) {
       const speclibPoint = await speclibLine.evaluate((line) => {
         const walker = document.createTreeWalker(line, NodeFilter.SHOW_TEXT);


### PR DESCRIPTION
## Summary
- locate the visible Monaco hover by its speclib documentation content
- allow Monaco to mount the overflow widget outside the editor container on Linux
- retain the real pointer-driven hover and exact DSL symbol assertion

## Why
Pages run 32649643862 showed all six pointer attempts completed, but the editor-descendant selector found no widget. Monaco can portal overflow widgets outside the editor container depending on platform/layout. The content identifies the requested DSL hover without coupling the check to that private DOM parent.

## Verification
- full assembled Spec Studio browser QA passes locally
- make prep-pr passes

This is the follow-up authorised by the CI/CD failure.