### PR TITLE
test(pages): invoke Monaco hover action directly

### DIFF
--- a/rust/tcl-spec-studio-wasm/test/boot.mjs
+++ b/rust/tcl-spec-studio-wasm/test/boot.mjs
@@ -159,6 +159,9 @@ async function main() {
   const base = `http://127.0.0.1:${port}/`;
   const browser = await chromium.launch();
   const page = await browser.newPage();
+  await page.addInitScript(() => {
+    window.__tclSpecStudioTestEnableEditorProbe = true;
+  });
 
   const problems = [];
   page.on("pageerror", (e) => problems.push(`page error: ${e.message}`));
@@ -239,36 +242,18 @@ async function main() {
     console.log("    Pack DSL semantic colours are visible in Monaco");
 
     // Prove hover is connected to the visible Monaco model, rather than only
-    // to the direct readiness probe above.
-    // Semantic repaint can replace a painted span between a bounding-box
-    // lookup and the mouse event in headless Chromium. Resolve the live text
-    // range for each attempt so this still tests the real pointer-driven
-    // Monaco hover path without depending on a stale render node.
-    const speclibLine = page.locator("#dslEditor .view-line", { hasText: "speclib" }).first();
-    // Monaco may portal an overflow widget outside the editor container. Its
-    // documented symbol content, not that platform-dependent parent, ties the
-    // visible widget to this DSL editor and this hover request.
+    // to the direct readiness probe above. Synthetic pointer hover is not
+    // portable across headless Chromium builds, so the page's opt-in test hook
+    // invokes Monaco's public show-hover action at the exact model position.
+    await page.evaluate(async () => {
+      if (typeof window.__tclSpecStudioTestShowDslHover !== "function") {
+        throw new Error("the Monaco deployment-test hover hook was not installed");
+      }
+      await window.__tclSpecStudioTestShowDslHover("speclib");
+    });
     const visibleHover = page.locator(".monaco-hover:visible", { hasText: "speclib" });
-    for (let attempt = 0; attempt < 6 && !(await visibleHover.isVisible()); attempt += 1) {
-      const speclibPoint = await speclibLine.evaluate((line) => {
-        const walker = document.createTreeWalker(line, NodeFilter.SHOW_TEXT);
-        for (let node = walker.nextNode(); node; node = walker.nextNode()) {
-          const offset = node.textContent?.indexOf("speclib") ?? -1;
-          if (offset < 0) continue;
-          const range = document.createRange();
-          range.setStart(node, offset);
-          range.setEnd(node, offset + "speclib".length);
-          const rect = range.getBoundingClientRect();
-          return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
-        }
-        throw new Error("rendered speclib token has no text range");
-      });
-      await page.mouse.move(speclibPoint.x, speclibPoint.y - 30);
-      await page.mouse.move(speclibPoint.x, speclibPoint.y, { steps: 4 });
-      await visibleHover.waitFor({ timeout: 5_000 }).catch(() => undefined);
-    }
     // Monaco retains a hidden hover widget alongside the active one.
-    await visibleHover.waitFor({ timeout: 1_000 });
+    await visibleHover.waitFor({ timeout: 30_000 });
     console.log("    Pack DSL hover is visible in Monaco on initial load");
 
     // 4. The server actually analyses: type a broken pack line and expect the

--- a/rust/tcl-spec-studio/web/src/monacoHost.ts
+++ b/rust/tcl-spec-studio/web/src/monacoHost.ts
@@ -82,6 +82,12 @@ const RUST_URI = "file:///__tcl_spec_studio__/command.rs";
 const STUB_URI = "file:///__tcl_spec_studio__/stubs.tcl";
 const EXPLORER_URI = "file:///__tcl_compiler_explorer__/source.tcl";
 
+/** Browser-only hooks installed solely when the deployment test opts in. */
+interface BrowserTestWindow extends Window {
+  __tclSpecStudioTestEnableEditorProbe?: boolean;
+  __tclSpecStudioTestShowDslHover?: (needle: string) => Promise<void>;
+}
+
 /** How long keystrokes settle before the change is pushed on. */
 const SETTLE_MS = 120;
 
@@ -460,6 +466,21 @@ class Surface {
     if (model) monaco.editor.setModelLanguage(model, model.getLanguageId());
   }
 
+  /** Run Monaco's public hover action at the first occurrence of `needle`. */
+  async showHoverAt(needle: string): Promise<void> {
+    const model = this.editor.getModel();
+    if (!model) throw new Error("the Monaco surface has no model");
+    const offset = model.getValue().indexOf(needle);
+    if (offset < 0) throw new Error(`the Monaco model does not contain ${needle}`);
+    const position = model.getPositionAt(offset);
+    this.editor.setPosition(position);
+    this.editor.revealPositionInCenterIfOutsideViewport(position);
+    this.editor.focus();
+    const action = this.editor.getAction("editor.action.showHover");
+    if (!action) throw new Error("Monaco's show-hover action is unavailable");
+    await action.run();
+  }
+
   layout(): void {
     this.editor.layout();
   }
@@ -599,6 +620,15 @@ export async function mountEditors(options: EditorHostOptions): Promise<EditorHo
   const sample = new Surface(options.sample, SAMPLE_URI, TCL_LANGUAGE, options.dialect, client);
   const rust = new OutputSurface(options.rust, RUST_URI, "rust", null, client);
   const stub = new OutputSurface(options.stub, STUB_URI, TCL_LANGUAGE, "spectcl", client);
+
+  // Pointer hover synthesis is not portable across headless Chromium builds.
+  // The deployment check opts into this narrow hook before page load so it can
+  // invoke Monaco's own action at an exact model position. Ordinary visitors
+  // get no test API on `window`.
+  const testWindow = window as BrowserTestWindow;
+  if (testWindow.__tclSpecStudioTestEnableEditorProbe) {
+    testWindow.__tclSpecStudioTestShowDslHover = (needle) => dsl.showHoverAt(needle);
+  }
 
   if (client) {
     // `initialize` proves only that the worker booted. `Surface` sent didOpen


### PR DESCRIPTION
## Summary
- add an opt-in browser-test hook that sets the exact DSL model position and runs Monaco public show-hover action
- expose no test API to ordinary visitors
- continue requiring a visible hover containing the speclib LSP documentation
- remove platform-dependent synthetic pointer motion

## Why
Linux headless Chromium did not render Monaco hover from Playwright pointer motion even though the same assembled bundle passed on macOS. The failed runs proved this was the remaining dependency. Calling Monaco public action tests the editor controller, registered LSP provider, and rendered widget directly without an OS input-synthesis dependency.

## Verification
- Spec Studio TypeScript and test projects type-check
- full assembled browser QA passes locally with the real LSP hover widget visible
- make prep-pr passes

This is the focused follow-up warranted by the Pages CI failure.