### PR TITLE
Spec Studio: registry-owned end-to-end trait examples

### DIFF
--- a/docs/references/command-spec/fields.md
+++ b/docs/references/command-spec/fields.md
@@ -1236,7 +1236,7 @@ How untrusted data is tracked. A value read from the network is marked `TAINTED`
 | `PORT` | a validated port number |
 | `FQDN` | a validated fully-qualified domain name |
 | `PATH_JOINED` | produced by `file join` |
-| `CHANNEL` | a channel handle |
+| `CHANNEL` | an I/O channel handle |
 
 ### Traits
 

--- a/rust/tcl-registry/src/documentation.rs
+++ b/rust/tcl-registry/src/documentation.rs
@@ -1,0 +1,67 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Registry-owned worked examples for closed compiler vocabularies.
+//!
+//! These are deliberately data, not web-UI copy. A trait, taint colour, or
+//! side-effect target owns the Tcl program that explains its end-to-end
+//! consequence. Registry browsers serialise the same value, and exhaustive
+//! matches make a newly-added vocabulary item fail to compile until it has a
+//! worked example.
+
+/// One source-aligned explanation in a [`DocumentationExample`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DocumentationAnnotation {
+    /// Zero-based source line.
+    pub line: usize,
+    /// Exact text on `line` that the presentation should point at.
+    pub needle: &'static str,
+    /// What happens at this point in the end-to-end flow.
+    pub label: &'static str,
+}
+
+impl DocumentationAnnotation {
+    /// Construct one source annotation.
+    #[must_use]
+    pub const fn new(line: usize, needle: &'static str, label: &'static str) -> Self {
+        Self {
+            line,
+            needle,
+            label,
+        }
+    }
+}
+
+/// A complete Tcl example plus the source spans that explain its dataflow or
+/// observable effect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DocumentationExample {
+    /// Tcl source, normally showing input/state, the annotated operation, and
+    /// the resulting sink or observable value.
+    pub code: &'static str,
+    /// Ordered source annotations rendered as arrows by registry browsers.
+    pub annotations: &'static [DocumentationAnnotation],
+}
+
+impl DocumentationExample {
+    /// Construct a required worked example.
+    #[must_use]
+    pub const fn new(code: &'static str, annotations: &'static [DocumentationAnnotation]) -> Self {
+        Self { code, annotations }
+    }
+}

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -66,6 +66,7 @@ pub mod definer;
 pub mod deprecation;
 pub mod dialects;
 pub mod dispatch_stability;
+pub mod documentation;
 mod event_descriptions;
 pub mod event_facts;
 pub mod events;
@@ -140,6 +141,7 @@ pub mod prelude {
         DispatchDependencies, DispatchDependencyComposition, DispatchDependencyDescriptor,
         DispatchDependencyDomain,
     };
+    pub use crate::documentation::{DocumentationAnnotation, DocumentationExample};
     pub use crate::events::{
         ASM_PAYLOAD, BIGIP_EVENT_HANDLER_PRIORITY, CACHE_PAYLOAD, DIAMETER_PAYLOAD,
         DataCollectionAction, DataCollectionOperation, EventHandlerPriority, EventRequirementForm,

--- a/rust/tcl-registry/src/side_effects.rs
+++ b/rust/tcl-registry/src/side_effects.rs
@@ -19,6 +19,7 @@
 //! Side-effect metadata for structured effect analysis.
 
 use crate::dialects::DialectSet;
+use crate::documentation::{DocumentationAnnotation, DocumentationExample};
 use crate::lifecycle::{Lifecycle, LifecycleState};
 
 /// What kind of external state a command affects.
@@ -123,6 +124,156 @@ pub enum SideEffectTarget {
 }
 
 impl SideEffectTarget {
+    /// Every declared effect target, in stable author-facing order.
+    pub const ALL: &'static [Self] = &[
+        Self::Variable,
+        Self::SessionTable,
+        Self::PersistenceTable,
+        Self::DataGroup,
+        Self::HttpHeader,
+        Self::HttpBody,
+        Self::HttpStatus,
+        Self::HttpUri,
+        Self::HttpCookie,
+        Self::HttpMethod,
+        Self::Http2State,
+        Self::ResponseCommit,
+        Self::ConnectionControl,
+        Self::TcpState,
+        Self::SslState,
+        Self::UdpState,
+        Self::PoolSelection,
+        Self::NodeSelection,
+        Self::SnatSelection,
+        Self::FileIo,
+        Self::NetworkIo,
+        Self::LogIo,
+        Self::StreamProfile,
+        Self::DnsState,
+        Self::ClassificationState,
+        Self::Dosl7State,
+        Self::FlowState,
+        Self::LsnState,
+        Self::FtpState,
+        Self::IcapState,
+        Self::MessageState,
+        Self::IStats,
+        Self::ApmState,
+        Self::AsmState,
+        Self::BigipConfig,
+        Self::ProcDefinition,
+        Self::NamespaceState,
+        Self::InterpState,
+        Self::Process,
+        Self::ChannelIo,
+        Self::EventControl,
+        Self::Unknown,
+    ];
+
+    /// Rust spelling used in authoring formats.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Variable => "Variable",
+            Self::SessionTable => "SessionTable",
+            Self::PersistenceTable => "PersistenceTable",
+            Self::DataGroup => "DataGroup",
+            Self::HttpHeader => "HttpHeader",
+            Self::HttpBody => "HttpBody",
+            Self::HttpStatus => "HttpStatus",
+            Self::HttpUri => "HttpUri",
+            Self::HttpCookie => "HttpCookie",
+            Self::HttpMethod => "HttpMethod",
+            Self::Http2State => "Http2State",
+            Self::ResponseCommit => "ResponseCommit",
+            Self::ConnectionControl => "ConnectionControl",
+            Self::TcpState => "TcpState",
+            Self::SslState => "SslState",
+            Self::UdpState => "UdpState",
+            Self::PoolSelection => "PoolSelection",
+            Self::NodeSelection => "NodeSelection",
+            Self::SnatSelection => "SnatSelection",
+            Self::FileIo => "FileIo",
+            Self::NetworkIo => "NetworkIo",
+            Self::LogIo => "LogIo",
+            Self::StreamProfile => "StreamProfile",
+            Self::DnsState => "DnsState",
+            Self::ClassificationState => "ClassificationState",
+            Self::Dosl7State => "Dosl7State",
+            Self::FlowState => "FlowState",
+            Self::LsnState => "LsnState",
+            Self::FtpState => "FtpState",
+            Self::IcapState => "IcapState",
+            Self::MessageState => "MessageState",
+            Self::IStats => "IStats",
+            Self::ApmState => "ApmState",
+            Self::AsmState => "AsmState",
+            Self::BigipConfig => "BigipConfig",
+            Self::ProcDefinition => "ProcDefinition",
+            Self::NamespaceState => "NamespaceState",
+            Self::InterpState => "InterpState",
+            Self::Process => "Process",
+            Self::ChannelIo => "ChannelIo",
+            Self::EventControl => "EventControl",
+            Self::Unknown => "Unknown",
+        }
+    }
+
+    /// Resolve an authoring-format spelling.
+    #[must_use]
+    pub fn from_name(name: &str) -> Option<Self> {
+        Self::ALL.iter().copied().find(|item| item.name() == name)
+    }
+
+    /// Short author-facing description, owned with the effect declaration.
+    #[must_use]
+    pub const fn summary(self) -> &'static str {
+        match self {
+            Self::Variable => "Tcl variable read or write",
+            Self::SessionTable => "session table entry",
+            Self::PersistenceTable => "persistence record",
+            Self::DataGroup => "data group / class lookup",
+            Self::HttpHeader => "HTTP header read or write",
+            Self::HttpBody => "HTTP payload / body",
+            Self::HttpStatus => "HTTP status code",
+            Self::HttpUri => "HTTP URI components",
+            Self::HttpCookie => "HTTP cookie",
+            Self::HttpMethod => "HTTP method",
+            Self::Http2State => "HTTP/2 protocol state",
+            Self::ResponseCommit => "commits or sends an HTTP response",
+            Self::ConnectionControl => "drop / reject / discard / forward",
+            Self::TcpState => "TCP connection state",
+            Self::SslState => "SSL/TLS state",
+            Self::UdpState => "UDP state",
+            Self::PoolSelection => "pool selection",
+            Self::NodeSelection => "node selection",
+            Self::SnatSelection => "SNAT selection",
+            Self::FileIo => "filesystem I/O",
+            Self::NetworkIo => "network I/O",
+            Self::LogIo => "logging output",
+            Self::StreamProfile => "stream profile state",
+            Self::DnsState => "DNS state",
+            Self::ClassificationState => "classification state",
+            Self::Dosl7State => "L7 DoS state",
+            Self::FlowState => "flow state",
+            Self::LsnState => "LSN state",
+            Self::FtpState => "FTP state",
+            Self::IcapState => "ICAP state",
+            Self::MessageState => "message-routing state",
+            Self::IStats => "iStats counters",
+            Self::ApmState => "APM state",
+            Self::AsmState => "ASM state",
+            Self::BigipConfig => "BIG-IP configuration",
+            Self::ProcDefinition => "procedure definition table",
+            Self::NamespaceState => "namespace state",
+            Self::InterpState => "interpreter state",
+            Self::Process => "process creation / control",
+            Self::ChannelIo => "channel I/O",
+            Self::EventControl => "iRules event control flow",
+            Self::Unknown => "unclassified effect",
+        }
+    }
+
     /// Stable registry vocabulary for serialised effect and world-state views.
     #[must_use]
     pub const fn as_str(self) -> &'static str {
@@ -169,6 +320,154 @@ impl SideEffectTarget {
             Self::ChannelIo => "channel-io",
             Self::EventControl => "event-control",
             Self::Unknown => "unknown",
+        }
+    }
+
+    /// Registry-owned program showing the state before the operation and the
+    /// observable read or write afterward. This exhaustive match is the
+    /// compile gate for side-effect documentation.
+    #[must_use]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one exhaustive closed-vocabulary documentation table; splitting it would weaken the compile gate"
+    )]
+    pub const fn example(self) -> DocumentationExample {
+        macro_rules! effect {
+            ($code:literal; $(($line:literal, $needle:literal, $label:literal)),+ $(,)?) => {
+                {
+                    const ANNOTATIONS: &[DocumentationAnnotation] =
+                        &[$(DocumentationAnnotation::new($line, $needle, $label)),+];
+                    DocumentationExample::new($code, ANNOTATIONS)
+                }
+            };
+        }
+        match self {
+            Self::Variable => {
+                effect!("set counter 1\nincr counter\nputs $counter"; (0, "counter 1", "creates variable state"), (1, "incr counter", "reads and writes it"), (2, "$counter", "observes 2"))
+            }
+            Self::SessionTable => {
+                effect!("table set session:key old\ntable set session:key new\nlog local0. [table lookup session:key]"; (0, "table set", "creates session state"), (1, "table set", "writes it"), (2, "table lookup", "reads new"))
+            }
+            Self::PersistenceTable => {
+                effect!("persist add uie $key 600\nset record [persist lookup uie $key]\nlog local0. $record"; (0, "persist add", "writes persistence state"), (1, "persist lookup", "reads it"), (2, "$record", "carries the result"))
+            }
+            Self::DataGroup => {
+                effect!("set key [HTTP::host]\nset route [class lookup $key routes]\npool $route"; (0, "HTTP::host", "supplies a lookup key"), (1, "class lookup", "reads the data group"), (2, "$route", "selects the pool"))
+            }
+            Self::HttpHeader => {
+                effect!("set host [HTTP::header value Host]\nHTTP::header replace X-Upstream $host\nlog local0. [HTTP::header value X-Upstream]"; (0, "HTTP::header value Host", "reads header state"), (1, "HTTP::header replace", "writes header state"), (2, "HTTP::header value X-Upstream", "observes it"))
+            }
+            Self::HttpBody => {
+                effect!("HTTP::collect\nset body [HTTP::payload]\nlog local0. $body"; (0, "HTTP::collect", "requests body state"), (1, "HTTP::payload", "reads the collected body"), (2, "$body", "flows to output"))
+            }
+            Self::HttpStatus => {
+                effect!("HTTP::respond 404 content missing\nset status [HTTP::status]\nlog local0. $status"; (0, "HTTP::respond 404", "writes response status"), (1, "HTTP::status", "reads it"), (2, "$status", "observes 404"))
+            }
+            Self::HttpUri => {
+                effect!("set original [HTTP::uri]\nHTTP::uri /rewritten\nlog local0. [HTTP::uri]"; (0, "HTTP::uri", "reads URI state"), (1, "HTTP::uri /rewritten", "writes it"), (2, "[HTTP::uri]", "observes the rewrite"))
+            }
+            Self::HttpCookie => {
+                effect!("set token [HTTP::cookie value session]\nHTTP::cookie remove session\nlog local0. $token"; (0, "HTTP::cookie value", "reads cookie state"), (1, "HTTP::cookie remove", "writes it"), (2, "$token", "retains the prior value"))
+            }
+            Self::HttpMethod => {
+                effect!("set original [HTTP::method]\nHTTP::method POST\nlog local0. [HTTP::method]"; (0, "HTTP::method", "reads method state"), (1, "HTTP::method POST", "writes it"), (2, "[HTTP::method]", "observes POST"))
+            }
+            Self::Http2State => {
+                effect!("set enabled [HTTP2::active]\nHTTP2::disable\nlog local0. $enabled"; (0, "HTTP2::active", "reads HTTP/2 state"), (1, "HTTP2::disable", "writes it"), (2, "$enabled", "retains the prior result"))
+            }
+            Self::ResponseCommit => {
+                effect!("set user [HTTP::uri]\nHTTP::respond 200 content $user\nHTTP::header value Host"; (0, "HTTP::uri", "supplies request data"), (1, "HTTP::respond", "commits it to the response"), (2, "HTTP::header", "is invalid after commit"))
+            }
+            Self::ConnectionControl => {
+                effect!("set blocked 1\nif {$blocked} { reject }\nlog local0. continued"; (0, "blocked 1", "supplies the action decision"), (1, "$blocked", "selects the action"), (1, "reject", "terminates connection flow"), (2, "continued", "is unreachable on that path"))
+            }
+            Self::TcpState => {
+                effect!("TCP::collect 1024\nset bytes [TCP::payload]\nTCP::release"; (0, "TCP::collect", "writes TCP collection state"), (1, "TCP::payload", "reads it"), (2, "TCP::release", "changes it again"))
+            }
+            Self::SslState => {
+                effect!("set before [SSL::enabled]\nSSL::disable\nlog local0. $before"; (0, "SSL::enabled", "reads TLS state"), (1, "SSL::disable", "writes it"), (2, "$before", "retains the prior value"))
+            }
+            Self::UdpState => {
+                effect!("set payload [UDP::payload]\nUDP::drop\nlog local0. $payload"; (0, "UDP::payload", "reads datagram state"), (1, "UDP::drop", "writes its disposition"), (2, "$payload", "contains the prior payload"))
+            }
+            Self::PoolSelection => {
+                effect!("set before [LB::server pool]\npool application_pool\nlog local0. [LB::server pool]"; (0, "LB::server pool", "reads selection state"), (1, "pool application_pool", "writes it"), (2, "[LB::server pool]", "observes the new pool"))
+            }
+            Self::NodeSelection => {
+                effect!("set address 192.0.2.10\nnode $address 443\nlog local0. [LB::server addr]"; (0, "192.0.2.10", "supplies the target"), (1, "node $address 443", "writes node selection"), (2, "LB::server addr", "observes it"))
+            }
+            Self::SnatSelection => {
+                effect!("set address 192.0.2.20\nsnat $address\nlog local0. selected"; (0, "192.0.2.20", "supplies the translated address"), (1, "snat $address", "writes SNAT selection"), (2, "selected", "runs with that selection"))
+            }
+            Self::FileIo => {
+                effect!("set path ./data.txt\nset channel [open $path w]\nputs $channel hello"; (0, "./data.txt", "selects a filesystem object"), (1, "open $path w", "creates file I/O state"), (2, "puts $channel", "writes external data"))
+            }
+            Self::NetworkIo => {
+                effect!("set host example.test\nset channel [socket $host 443]\nputs $channel request"; (0, "example.test", "selects a remote endpoint"), (1, "socket $host 443", "creates network state"), (2, "puts $channel", "writes to it"))
+            }
+            Self::LogIo => {
+                effect!("set user [gets stdin]\nlog local0. $user\nputs logged"; (0, "[gets stdin]", "supplies external data"), (1, "log local0. $user", "writes it to logging output"), (2, "puts logged", "continues after the effect"))
+            }
+            Self::StreamProfile => {
+                effect!("STREAM::expression {@old@new@}\nSTREAM::enable\nlog local0. enabled"; (0, "STREAM::expression", "writes rewrite rules"), (1, "STREAM::enable", "activates stream state"), (2, "enabled", "runs with rewriting active"))
+            }
+            Self::DnsState => {
+                effect!("set name [DNS::question name]\nDNS::answer insert \"$name. 60 IN A 192.0.2.1\"\nlog local0. $name"; (0, "DNS::question name", "reads DNS state"), (1, "DNS::answer insert", "writes it"), (2, "$name", "identifies the affected record"))
+            }
+            Self::ClassificationState => {
+                effect!("CLASSIFY::application set web\nset app [CLASSIFY::application]\nlog local0. $app"; (0, "CLASSIFY::application set", "writes classification state"), (1, "CLASSIFY::application", "reads it"), (2, "$app", "observes web"))
+            }
+            Self::Dosl7State => {
+                effect!("DOSL7::enable\nset state [DOSL7::profile]\nlog local0. $state"; (0, "DOSL7::enable", "writes DoS protection state"), (1, "DOSL7::profile", "reads it"), (2, "$state", "reports the active profile"))
+            }
+            Self::FlowState => {
+                effect!("set related [FLOW::create_related]\nFLOW::forward $related\nlog local0. $related"; (0, "FLOW::create_related", "creates flow state"), (1, "FLOW::forward", "changes its disposition"), (2, "$related", "identifies the flow"))
+            }
+            Self::LsnState => {
+                effect!("set address [LSN::address]\nLSN::disable\nlog local0. $address"; (0, "LSN::address", "reads LSN state"), (1, "LSN::disable", "writes it"), (2, "$address", "retains the prior value"))
+            }
+            Self::FtpState => {
+                effect!("set port [FTP::port]\nFTP::disable\nlog local0. $port"; (0, "FTP::port", "reads FTP state"), (1, "FTP::disable", "writes it"), (2, "$port", "retains the prior value"))
+            }
+            Self::IcapState => {
+                effect!("set method [ICAP::method]\nICAP::header insert X-Method $method\nlog local0. $method"; (0, "ICAP::method", "reads ICAP state"), (1, "ICAP::header insert", "writes it"), (2, "$method", "identifies the update"))
+            }
+            Self::MessageState => {
+                effect!("set id [MESSAGE::id]\nMESSAGE::field set route primary\nlog local0. $id"; (0, "MESSAGE::id", "reads message state"), (1, "MESSAGE::field set", "writes it"), (2, "$id", "identifies the message"))
+            }
+            Self::IStats => {
+                effect!("ISTATS::set app.requests 1\nISTATS::incr app.requests\nlog local0. [ISTATS::get app.requests]"; (0, "ISTATS::set", "creates counter state"), (1, "ISTATS::incr", "reads and writes it"), (2, "ISTATS::get", "observes 2"))
+            }
+            Self::ApmState => {
+                effect!("ACCESS::session data set session.custom.note ready\nset note [ACCESS::session data get session.custom.note]\nlog local0. $note"; (0, "ACCESS::session data set", "writes APM state"), (1, "ACCESS::session data get", "reads it"), (2, "$note", "observes ready"))
+            }
+            Self::AsmState => {
+                effect!("set before [ASM::status]\nASM::disable\nlog local0. $before"; (0, "ASM::status", "reads ASM state"), (1, "ASM::disable", "writes it"), (2, "$before", "retains the prior result"))
+            }
+            Self::BigipConfig => {
+                effect!("set old [tmsh::get_config /ltm/pool/app]\ntmsh::modify /ltm/pool/app members add {node:80}\nlog local0. $old"; (0, "tmsh::get_config", "reads BIG-IP configuration"), (1, "tmsh::modify", "writes it"), (2, "$old", "contains the previous configuration"))
+            }
+            Self::ProcDefinition => {
+                effect!("proc greet {} {return hello}\nrename greet welcome\nputs [welcome]"; (0, "proc greet", "creates command-table state"), (1, "rename greet welcome", "rewrites it"), (2, "welcome", "uses the new definition"))
+            }
+            Self::NamespaceState => {
+                effect!("namespace eval ::demo { set value 1 }\nnamespace delete ::demo\nputs [namespace exists ::demo]"; (0, "namespace eval ::demo", "creates namespace state"), (1, "namespace delete ::demo", "destroys it"), (2, "namespace exists", "observes false"))
+            }
+            Self::InterpState => {
+                effect!("set child [interp create]\ninterp eval $child {set value 1}\ninterp delete $child"; (0, "interp create", "creates interpreter state"), (1, "interp eval", "writes within it"), (2, "interp delete", "destroys it"))
+            }
+            Self::Process => {
+                effect!("set input [gets stdin]\nset output [exec helper -- $input]\nputs $output"; (0, "[gets stdin]", "supplies external data"), (1, "exec helper -- $input", "creates a process and passes the value"), (2, "$output", "observes process output"))
+            }
+            Self::ChannelIo => {
+                effect!("set channel [open data.txt r]\nset data [chan read $channel]\nputs $data"; (0, "open data.txt r", "creates a channel"), (1, "chan read $channel", "reads channel state"), (2, "$data", "carries the external bytes"))
+            }
+            Self::EventControl => {
+                effect!("when HTTP_REQUEST {\n    event disable all\n    log local0. unreachable\n}"; (0, "HTTP_REQUEST", "starts event execution"), (1, "event disable all", "changes event-control state"), (2, "unreachable", "is skipped for disabled flow"))
+            }
+            Self::Unknown => {
+                effect!("set before [opaque state]\nunknown_effect $before\nputs [opaque state]"; (0, "opaque state", "reads unclassified state"), (1, "unknown_effect", "may read or write any external domain"), (2, "opaque state", "must be treated as changed"))
+            }
         }
     }
 }

--- a/rust/tcl-registry/src/taint.rs
+++ b/rust/tcl-registry/src/taint.rs
@@ -26,6 +26,7 @@
 //! than maintaining its own command-name set.
 
 use crate::dialects::DialectSet;
+use crate::documentation::{DocumentationAnnotation, DocumentationExample};
 use crate::registry::CommandRegistry;
 use crate::traits::Traits;
 use crate::types::TclType;
@@ -154,6 +155,128 @@ impl TaintColourAtom {
         Self::PathJoined,
         Self::Channel,
     ];
+
+    /// Rust spelling used by specs and registry browsers.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Tainted => "TAINTED",
+            Self::PathPrefixed => "PATH_PREFIXED",
+            Self::NonDashPrefixed => "NON_DASH_PREFIXED",
+            Self::CrlfFree => "CRLF_FREE",
+            Self::ShellAtom => "SHELL_ATOM",
+            Self::ListCanonical => "LIST_CANONICAL",
+            Self::RegexLiteral => "REGEX_LITERAL",
+            Self::PathNormalised => "PATH_NORMALISED",
+            Self::PathBounded => "PATH_BOUNDED",
+            Self::HeaderTokenSafe => "HEADER_TOKEN_SAFE",
+            Self::HtmlEscaped => "HTML_ESCAPED",
+            Self::UrlEncoded => "URL_ENCODED",
+            Self::IpAddress => "IP_ADDRESS",
+            Self::Port => "PORT",
+            Self::Fqdn => "FQDN",
+            Self::PathJoined => "PATH_JOINED",
+            Self::Channel => "CHANNEL",
+        }
+    }
+
+    /// Resolve the spelling used by specs and registry browsers.
+    #[must_use]
+    pub fn from_name(name: &str) -> Option<Self> {
+        Self::ALL.iter().copied().find(|item| item.name() == name)
+    }
+
+    /// Short author-facing description, owned with the colour declaration.
+    #[must_use]
+    pub const fn summary(self) -> &'static str {
+        match self {
+            Self::Tainted => "attacker-controlled",
+            Self::PathPrefixed => "guaranteed to start with a path separator",
+            Self::NonDashPrefixed => "cannot begin with `-` (option-injection safe)",
+            Self::CrlfFree => "contains no CR or LF (header-injection safe)",
+            Self::ShellAtom => "a single shell atom (exec-safe)",
+            Self::ListCanonical => "canonical list form (eval-safe)",
+            Self::RegexLiteral => "quoted as a regex literal",
+            Self::PathNormalised => "path-normalised",
+            Self::PathBounded => "bounded within a known path root",
+            Self::HeaderTokenSafe => "safe as an HTTP header token",
+            Self::HtmlEscaped => "HTML-escaped",
+            Self::UrlEncoded => "URL-encoded",
+            Self::IpAddress => "a validated IP address",
+            Self::Port => "a validated port number",
+            Self::Fqdn => "a validated fully-qualified domain name",
+            Self::PathJoined => "produced by `file join`",
+            Self::Channel => "an I/O channel handle",
+        }
+    }
+
+    /// Registry-owned source → transform → sink example for this colour.
+    /// The exhaustive match makes missing documentation a compile error.
+    #[must_use]
+    pub const fn example(self) -> DocumentationExample {
+        macro_rules! taint_flow {
+            ($code:literal; $(($line:literal, $needle:literal, $label:literal)),+ $(,)?) => {
+                {
+                    const ANNOTATIONS: &[DocumentationAnnotation] =
+                        &[$(DocumentationAnnotation::new($line, $needle, $label)),+];
+                    DocumentationExample::new($code, ANNOTATIONS)
+                }
+            };
+        }
+        match self {
+            Self::Tainted => {
+                taint_flow!("set user [gets stdin]\nset copy $user\nputs $copy"; (0, "[gets stdin]", "introduces attacker-controlled data"), (1, "$user", "propagates without protection"), (2, "puts $copy", "reaches an output sink and reports T101"))
+            }
+            Self::PathPrefixed => {
+                taint_flow!("set uri [HTTP::uri]\nset path [string range $uri 0 end]\nopen $path r"; (0, "HTTP::uri", "returns tainted data that starts with /"), (1, "$uri", "retains the path-prefix proof"), (2, "open $path r", "uses the absolute path but still requires a bounded-root proof"))
+            }
+            Self::NonDashPrefixed => {
+                taint_flow!("set user [gets stdin]\nset value \"value:$user\"\nexec helper -- $value"; (0, "[gets stdin]", "introduces attacker-controlled data"), (1, "value:$user", "adds a literal non-dash prefix"), (2, "-- $value", "cannot be reinterpreted as an option"))
+            }
+            Self::CrlfFree => {
+                taint_flow!("set user [gets stdin]\nset clean [string map {\"\\r\" {} \"\\n\" {}} $user]\nHTTP::header replace X-Value $clean"; (0, "[gets stdin]", "may contain header delimiters"), (1, "string map", "removes CR and LF"), (2, "$clean", "is safe from header splitting at the sink"))
+            }
+            Self::ShellAtom => {
+                taint_flow!("set user [gets stdin]\nif {![regexp {^[[:alnum:]_.-]+$} $user]} { error invalid }\nexec helper -- $user"; (0, "[gets stdin]", "introduces attacker-controlled text"), (1, "regexp", "proves one shell-safe atom"), (2, "-- $user", "passes that atom as one process argument"))
+            }
+            Self::ListCanonical => {
+                taint_flow!("set user [gets stdin]\nset command [list puts $user]\neval $command"; (0, "[gets stdin]", "introduces attacker-controlled text"), (1, "list puts $user", "quotes it into canonical list form"), (2, "eval $command", "evaluates fixed structure with the value as one word"))
+            }
+            Self::RegexLiteral => {
+                taint_flow!("set user [gets stdin]\nset literal [regsub -all {[][(){}.*+?^$\\|]} $user {\\&}]\nregexp $literal $document"; (0, "[gets stdin]", "may contain regex syntax"), (1, "regsub -all", "escapes metacharacters"), (2, "$literal", "is consumed as literal pattern text"))
+            }
+            Self::PathNormalised => {
+                taint_flow!("set user [gets stdin]\nset normal [file normalize $user]\nopen $normal r"; (0, "[gets stdin]", "may contain traversal components"), (1, "file normalize $user", "canonicalises the path shape"), (2, "open $normal r", "still needs a bounded-root check before access"))
+            }
+            Self::PathBounded => {
+                taint_flow!("set user [gets stdin]\nset path [file normalize [file join /srv/data $user]]\nif {![string match /srv/data/* $path]} { error outside-root }\nopen $path r"; (0, "[gets stdin]", "supplies an untrusted relative path"), (1, "file normalize", "resolves traversal"), (2, "/srv/data/*", "proves the result remains under the intended root"), (3, "open $path r", "uses the bounded path"))
+            }
+            Self::HeaderTokenSafe => {
+                taint_flow!("set user [gets stdin]\nif {![regexp {^[!#$%&'*+.^_`|~0-9A-Za-z-]+$} $user]} { error invalid }\nHTTP::header replace $user value"; (0, "[gets stdin]", "may contain invalid header-name bytes"), (1, "regexp", "validates the HTTP token grammar"), (2, "$user", "is safe in the header-name position"))
+            }
+            Self::HtmlEscaped => {
+                taint_flow!("set user [gets stdin]\nset escaped [string map {& &amp; < &lt; > &gt; \" &quot;} $user]\nHTTP::respond 200 content \"<p>$escaped</p>\""; (0, "[gets stdin]", "may contain HTML markup"), (1, "string map", "escapes HTML text-context metacharacters"), (2, "$escaped", "is emitted in HTML text context"))
+            }
+            Self::UrlEncoded => {
+                taint_flow!("set user [gets stdin]\nset encoded [uri::encode $user]\nHTTP::redirect \"/search?q=$encoded\""; (0, "[gets stdin]", "may contain URL delimiters"), (1, "uri::encode $user", "percent-encodes the component"), (2, "$encoded", "is inserted as one query value"))
+            }
+            Self::IpAddress => {
+                taint_flow!("set user [gets stdin]\nif {![string is entier -strict [string map {. {}} $user]]} { error invalid-ip }\nsocket $user 443"; (0, "[gets stdin]", "supplies an untrusted address"), (1, "invalid-ip", "rejects values outside the accepted IP grammar"), (2, "socket $user 443", "uses the validated address"))
+            }
+            Self::Port => {
+                taint_flow!("set user [gets stdin]\nif {![string is integer -strict $user] || $user < 0 || $user > 65535} { error invalid-port }\nsocket example.test $user"; (0, "[gets stdin]", "supplies an untrusted port"), (1, "$user > 65535", "bounds it to the port domain"), (2, "$user", "is used as a validated port"))
+            }
+            Self::Fqdn => {
+                taint_flow!("set user [gets stdin]\nif {![regexp {^(?:[A-Za-z0-9-]+\\.)+[A-Za-z]{2,}$} $user]} { error invalid-host }\nsocket $user 443"; (0, "[gets stdin]", "supplies an untrusted hostname"), (1, "regexp", "validates a fully-qualified domain name"), (2, "$user", "is used as the validated endpoint"))
+            }
+            Self::PathJoined => {
+                taint_flow!("set user [gets stdin]\nset path [file join /srv/data $user]\nopen $path r"; (0, "[gets stdin]", "supplies an untrusted path component"), (1, "file join", "assembles a portable path but does not bound traversal"), (2, "open $path r", "still requires normalisation and a root check"))
+            }
+            Self::Channel => {
+                taint_flow!("set path ./data.txt\nset channel [open $path r]\nset data [read $channel]\nputs $data"; (1, "open $path r", "returns a channel handle"), (2, "$channel", "is accepted in channel position"), (3, "$data", "contains tainted bytes read through the handle"))
+            }
+        }
+    }
 
     /// The registry bit represented by this atom.
     #[must_use]

--- a/rust/tcl-registry/src/traits.rs
+++ b/rust/tcl-registry/src/traits.rs
@@ -52,6 +52,8 @@
 use std::fmt;
 use std::ops::{BitOr, BitOrAssign};
 
+use crate::documentation::{DocumentationAnnotation, DocumentationExample};
+
 /// Declare the closed vocabulary used to organise behavioural traits.
 ///
 /// A new category must be added here deliberately, with its author-facing
@@ -1156,6 +1158,132 @@ declare_traits! {
     /// keeps the abstaining behaviour a pack author never has to think
     /// about.
     DefersBody => DEFERS_BODY, ControlFlow, "stores its script argument instead of running it; unset means the body is treated as executed";
+}
+
+/// Declare the required end-to-end example for every behavioural trait.
+///
+/// This second exhaustive declaration is intentional: the behavioural flag
+/// and its prose stay compact in [`declare_traits!`], while adding a flag makes
+/// this generated `match` non-exhaustive until the author supplies a complete
+/// input → operation → outcome example. The Spec Studio serialises this data
+/// directly; it does not own a parallel trait-example table.
+macro_rules! declare_trait_examples {
+    ($($variant:ident => $example:expr);* $(;)?) => {
+        impl Trait {
+            /// A registry-owned Tcl program showing this trait's observable
+            /// end-to-end consequence.
+            #[must_use]
+            pub const fn example(self) -> DocumentationExample {
+                match self { $( Self::$variant => $example ),* }
+            }
+        }
+    };
+}
+
+macro_rules! flow {
+    ($code:literal; $(($line:literal, $needle:literal, $label:literal)),+ $(,)?) => {
+        {
+            const ANNOTATIONS: &[DocumentationAnnotation] =
+                &[$(DocumentationAnnotation::new($line, $needle, $label)),+];
+            DocumentationExample::new($code, ANNOTATIONS)
+        }
+    };
+}
+
+declare_trait_examples! {
+    ControlFlow => flow!("set ready 1\nif {$ready} { set result accepted }\nputs $result"; (0, "ready 1", "supplies the branch input"), (1, "if", "changes the control-flow graph"), (2, "$result", "only the selected path supplies the result"));
+    LanguageKeyword => flow!("set ready 1\nif {$ready} { puts accepted }"; (0, "ready 1", "supplies the tested value"), (1, "if", "is highlighted and analysed as a language keyword"), (1, "puts accepted", "the selected body runs"));
+    HasBooleanCond => flow!("set user_count [gets stdin]\nif {$user_count > 0} { puts busy }"; (0, "[gets stdin]", "supplies an external value"), (1, "$user_count > 0", "is parsed in boolean expression context"), (1, "puts busy", "runs only when the condition is true"));
+    TerminatesBlock => flow!("proc requireName {name} {\n    if {$name eq {}} { error {name required} }\n    puts $name\n}"; (1, "error", "terminates this basic block"), (2, "puts $name", "is unreachable on the error path"));
+    TerminatesProcess => flow!("set status 2\nexit $status\nputs unreachable"; (0, "status 2", "selects the process status"), (1, "exit", "ends the interpreter without Tcl unwinding"), (2, "puts unreachable", "can never execute"));
+    HasLoopBody => flow!("set items {alpha beta}\nforeach item $items { lappend seen $item }\nputs $seen"; (0, "{alpha beta}", "supplies loop values"), (1, "lappend seen $item", "is the recursively analysed loop body"), (2, "$seen", "contains the values produced by each iteration"));
+    NeverInlineBody => flow!("set items {alpha beta}\nforeach item $items { puts $item }\nputs done"; (0, "{alpha beta}", "supplies runtime iterations"), (1, "{ puts $item }", "must remain a distinct loop body"), (2, "puts done", "runs after the loop completes"));
+    LoopListHeader => flow!("set items {alpha beta}\nforeach item $items { puts $item }"; (0, "{alpha beta}", "supplies the list expression"), (1, "$items", "is evaluated once in the loop header"), (1, "$item", "receives one element per iteration"));
+    Pure => flow!("set input hello\nset n [string length $input]\nputs $n"; (0, "hello", "is the only input"), (1, "[string length $input]", "has no externally visible side effect"), (2, "$n", "is the complete observable result"));
+    CseCandidate => flow!("set input hello\nset a [string length $input]\nset b [string length $input]\nputs [expr {$a + $b}]"; (1, "[string length $input]", "computes the expression once"), (2, "[string length $input]", "can reuse the equivalent result"), (3, "$a + $b", "observes identical values"));
+    PureEvaluation => flow!("set price 20\nset total [expr {$price * 2}]\nputs $total"; (0, "price 20", "supplies the expression input"), (1, "expr {$price * 2}", "evaluates without changing external state"), (2, "$total", "receives the numeric result"));
+    DefinesProcedure => flow!("proc greet {name} { return \"hello $name\" }\nputs [greet Ada]"; (0, "proc greet", "adds a command definition"), (0, "{name}", "declares its parameter"), (1, "[greet Ada]", "resolves to the new procedure"));
+    DestroysVariable => flow!("set token secret\nunset token\ninfo exists token"; (0, "token", "creates variable state"), (1, "unset token", "destroys that state"), (2, "info exists token", "now returns false"));
+    ReadsBeforeWrite => flow!("set count 4\nincr count 2\nputs $count"; (0, "count 4", "supplies the old value"), (1, "incr count 2", "reads it before writing the incremented value"), (2, "$count", "observes 6"));
+    CreatesScopeAlias => flow!("set outer initial\nproc update {} { upvar 1 outer local; set local changed }\nupdate\nputs $outer"; (0, "outer", "lives in the caller"), (1, "upvar 1 outer local", "aliases it into the procedure"), (3, "$outer", "observes the write through the alias"));
+    AliasesGlobal => flow!("set ::mode old\nproc update {} { global mode; set mode new }\nupdate\nputs $::mode"; (0, "::mode", "lives in the global namespace"), (1, "global mode", "aliases it in the procedure"), (3, "$::mode", "observes the global write"));
+    CreatesBarrier => flow!("set script {set changed 1}\neval $script\nputs $changed"; (0, "{set changed 1}", "contains runtime-selected code"), (1, "eval $script", "blocks ordinary static dataflow across dynamic execution"), (2, "$changed", "is created by that code"));
+    EvaluatesCode => flow!("set user_script [gets stdin]\neval $user_script\nputs done"; (0, "[gets stdin]", "supplies attacker-controlled text"), (1, "eval $user_script", "executes the text as Tcl and reports T100"), (2, "puts done", "is reached only if that code returns normally"));
+    PerformsSubstitution => flow!("set template {[read $channel]}\nset value [subst $template]\nputs $value"; (0, "{[read $channel]}", "contains substitutions as data"), (1, "subst $template", "performs those substitutions at runtime"), (2, "$value", "carries their result"));
+    OpensChannel => flow!("set path [gets stdin]\nset channel [open $path r]\nputs [read $channel]"; (0, "[gets stdin]", "supplies an untrusted path"), (1, "open $path r", "opens an external resource"), (2, "read $channel", "observes data from the channel"));
+    SourcesFile => flow!("set path ./plugin.tcl\nsource $path\nplugin::run"; (0, "./plugin.tcl", "selects another source file"), (1, "source $path", "evaluates that file in this interpreter"), (2, "plugin::run", "uses a command the file defined"));
+    HasSwitchBody => flow!("set mode [gets stdin]\nswitch -- $mode { safe {puts ok} default {puts rejected} }"; (0, "[gets stdin]", "supplies the selector"), (1, "switch", "selects one clause body"), (1, "default {puts rejected}", "handles unmatched input"));
+    StringListConfusion => flow!("set values [list alpha beta]\nappend values { gamma delta}\nllength $values"; (0, "[list alpha beta]", "starts as a canonical list"), (1, "append values", "performs a string operation on it"), (2, "llength $values", "later reinterprets the changed string as a list"));
+    ConfiguresChannel => flow!("set channel [open data.bin r]\nfconfigure $channel -translation binary\nset bytes [read $channel]"; (0, "open data.bin r", "creates the channel"), (1, "fconfigure $channel", "changes its I/O semantics"), (2, "read $channel", "uses the configured translation"));
+    HasInterpEval => flow!("set child [interp create -safe]\ninterp eval $child {set value 42}\ninterp eval $child {puts $value}"; (0, "[interp create -safe]", "creates another interpreter"), (1, "interp eval", "evaluates code in that interpreter"), (2, "$value", "observes its separate state"));
+    HasDestructiveOps => flow!("set path ./cache.tmp\nfile delete -- $path\nfile exists $path"; (0, "./cache.tmp", "identifies existing state"), (1, "file delete", "irreversibly removes it"), (2, "file exists $path", "now reports false"));
+    IsEventHandler => flow!("when HTTP_REQUEST {\n    set uri [HTTP::uri]\n    log local0. $uri\n}"; (0, "when HTTP_REQUEST", "registers the deferred event handler"), (1, "HTTP::uri", "reads request data when the event fires"), (2, "$uri", "flows to the handler output"));
+    UnnormalisedHttpGetter => flow!("when HTTP_REQUEST {\n    set path [HTTP::path]\n    HTTP::respond 200 content $path\n}"; (1, "HTTP::path", "returns attacker-controlled, unnormalised path data"), (2, "$path", "reaches an output without protection and reports taint"));
+    RequiresHttpContext => flow!("when HTTP_REQUEST {\n    HTTP::respond 200\n    HTTP::header value Host\n}"; (1, "HTTP::respond 200", "commits the HTTP response"), (2, "HTTP::header", "requires the now-unavailable HTTP transaction and is diagnosed"));
+    ReturnsPath => flow!("set base /srv/app\nset path [file join $base data.txt]\nputs $path"; (0, "/srv/app", "supplies a path component"), (1, "file join", "returns a filesystem path"), (2, "$path", "carries that path to the caller"));
+    IsUnescape => flow!("set encoded [gets stdin]\nset decoded [encoding convertfrom utf-8 $encoded]\nputs $decoded"; (0, "[gets stdin]", "supplies encoded attacker-controlled data"), (1, "encoding convertfrom", "decodes and can reintroduce dangerous characters"), (2, "$decoded", "remains tainted at the output"));
+    ProducesCanonicalList => flow!("set user [gets stdin]\nset command [list puts $user]\neval $command"; (0, "[gets stdin]", "supplies one dynamic value"), (1, "list puts $user", "quotes it into canonical list form"), (2, "eval $command", "preserves it as one argument during evaluation"));
+    BuildsCommandPrefix => flow!("set user [gets stdin]\nset callback [list save $user]\nafter idle $callback"; (0, "[gets stdin]", "supplies a dynamic argument"), (1, "list save $user", "builds a safely quoted command prefix"), (2, "after idle $callback", "invokes that prefix later"));
+    WrapsCommandPrefix => flow!("namespace eval app { proc save {v} { puts $v } }\nset callback [namespace code [list save value]]\nafter idle $callback"; (0, "app", "defines the target namespace"), (1, "namespace code", "wraps the script with namespace context"), (2, "after idle $callback", "runs it later in that context"));
+    Unsafe => flow!("set child [interp create -safe]\ninterp eval $child {open secret.txt r}\nputs denied"; (0, "-safe", "creates a restricted interpreter"), (1, "open secret.txt r", "uses an unsafe command and is rejected"), (2, "puts denied", "represents the denied operation"));
+    PasswordOption => flow!("set password [gets stdin]\nlogin -password $password\nputs authenticated"; (0, "[gets stdin]", "supplies sensitive text"), (1, "-password $password", "marks the option value as a credential"), (2, "puts authenticated", "uses only the authentication result"));
+    IsSideSwitch => flow!("when HTTP_REQUEST {\n    serverside { TCP::collect }\n}"; (0, "HTTP_REQUEST", "starts on the client side"), (1, "serverside", "switches analysis to the server side"), (1, "TCP::collect", "mutates server-side TCP state"));
+    IrulesTopLevelOnly => flow!("when HTTP_REQUEST { puts request }\nproc invalid {} { when CLIENT_ACCEPTED { puts nested } }"; (0, "when HTTP_REQUEST", "is valid at iRules top level"), (1, "when CLIENT_ACCEPTED", "is nested and therefore diagnosed"));
+    SetsEventPriority => flow!("when HTTP_REQUEST priority 700 {\n    log local0. late-handler\n}"; (0, "priority 700", "sets this handler's inherited priority"), (1, "late-handler", "runs after lower-priority handlers"));
+    IsOoMetaclass => flow!("oo::class create Factory {}\nFactory create Product\nProduct create instance"; (0, "oo::class create Factory", "creates a class object"), (1, "Factory create Product", "uses it as a metaclass factory"), (2, "Product create instance", "constructs an instance of the manufactured class"));
+    ObjectCommandSurface => flow!("oo::class create Widget { method render {} {return ok} }\nset w [Widget new]\nputs [$w render]"; (0, "method render", "defines the object-command surface"), (1, "Widget new", "creates an object command"), (2, "$w render", "dispatches through that surface"));
+    ConfiguresByProperty => flow!("Widget create .w -text old\n.w configure -text new\nputs [.w cget -text]"; (0, "-text old", "initialises a declared property"), (1, "configure -text new", "writes that property"), (2, "cget -text", "reads the updated value"));
+    AbstractClassFactory => flow!("oo::class create AbstractWidget {}\nAbstractWidget create ConcreteWidget\nConcreteWidget create instance"; (0, "AbstractWidget", "is the class-manufacturing surface"), (1, "ConcreteWidget", "is a concrete class it manufactures"), (2, "instance", "is created by the concrete class, not the abstract factory"));
+    DiagramAction => flow!("when HTTP_REQUEST {\n    pool application_pool\n}"; (0, "HTTP_REQUEST", "starts the extracted event flow"), (1, "pool application_pool", "becomes an action node with a routing outcome"));
+    NeedsStartCmd => flow!("set command [list worker run]\nstart $command\nwait-for-result"; (0, "[list worker run]", "describes deferred work"), (1, "start $command", "explicitly starts it"), (2, "wait-for-result", "consumes the started operation"));
+    TaintSink => flow!("set user [gets stdin]\nputs $user"; (0, "[gets stdin]", "introduces attacker-controlled data"), (1, "puts $user", "is an unprotected output sink and reports T101"));
+    TaintSource => flow!("set user [gets stdin]\nset copy $user\nputs $copy"; (0, "gets stdin", "marks the returned value as attacker-controlled"), (1, "$user", "propagates through assignment"), (2, "$copy", "reaches an output sink and reports T101"));
+    IrulesDataGetter => flow!("when HTTP_REQUEST {\n    set host [HTTP::host]\n    log local0. $host\n}"; (1, "HTTP::host", "reads request data from BIG-IP state"), (2, "$host", "carries that data to the log sink"));
+    CreatesDynamicBarrier => flow!("set command [gets stdin]\n$command run\nputs done"; (0, "[gets stdin]", "supplies a runtime command name"), (1, "$command run", "creates a dynamic dispatch barrier"), (2, "puts done", "is analysed after an unknown call target"));
+    InvokesUserProc => flow!("proc transform {value} { return [string toupper $value] }\nset result [transform hello]\nputs $result"; (0, "proc transform", "defines user code"), (1, "transform hello", "invokes that procedure"), (2, "$result", "observes its returned value"));
+    ByteCompiled => flow!("set total 0\nforeach n {1 2 3} { incr total $n }\nputs $total"; (0, "set total 0", "initialises runtime state"), (1, "foreach", "is emitted through C Tcl bytecode compilation"), (2, "$total", "observes the compiled execution result"));
+    NotProcFactory => flow!("set name dynamic\nrename puts $name\n$name hello"; (0, "dynamic", "supplies a command name"), (1, "rename puts $name", "moves a command but does not create a procedure"), (2, "$name hello", "dispatches to the moved command"));
+    FramelessRuntime => flow!("proc caller {} { set before [info level]; set n [string length abc]; list $before [info level] $n }\nputs [caller]"; (0, "info level", "records the current call frame"), (0, "string length abc", "runs without pushing another Tcl frame"), (1, "caller", "returns matching before/after frame levels"));
+    FirstArgVarname => flow!("set value old\nunset value\nputs [info exists value]"; (0, "value", "names the variable"), (1, "unset value", "treats its first argument as that name"), (2, "info exists value", "observes that it was removed"));
+    WholeArrayArg => flow!("array set colours {sky blue grass green}\nparray colours\nputs $colours(sky)"; (0, "colours", "names the whole array"), (1, "parray colours", "reads the array as a unit"), (2, "$colours(sky)", "still addresses one element"));
+    DynamicEvalBody => flow!("set body [gets stdin]\napply [list {} $body]\nputs done"; (0, "[gets stdin]", "supplies a runtime body"), (1, "$body", "is dynamically evaluated as Tcl"), (2, "puts done", "runs only if that body completes"));
+    IntrospectsByName => flow!("proc worker {} {}\nset target worker\nputs [info args $target]"; (0, "proc worker", "creates named state"), (1, "target worker", "selects that state by name"), (2, "info args", "returns its parameter metadata"));
+    CurrentFrameIntrospection => flow!("proc where {} { return [info level] }\nset level [where]\nputs $level"; (0, "info level", "observes the active Tcl frame"), (1, "where", "returns the frame-dependent result"), (2, "$level", "cannot be treated as a context-free constant"));
+    ExpansionEscapeSafe => flow!("set args [list hello world]\nputs {*}$args\nputs done"; (0, "[list hello world]", "creates the expanded words"), (1, "{*}$args", "cannot introduce a frame-sensitive command name here"), (2, "puts done", "continues in the same frame"));
+    TargetsVariableByName => flow!("set name counter\nset $name 1\nincr $name\nputs [set $name]"; (0, "counter", "is the variable name carried as data"), (1, "set $name 1", "writes the named target"), (2, "incr $name", "reads and rewrites the same target"), (3, "set $name", "observes 2"));
+    FrameHashBuiltin => flow!("proc readLocal {} { set local value; return [set local] }\nputs [readLocal]"; (0, "set local value", "writes the frame's variable table"), (0, "set local", "reads through the frame-hash builtin"), (1, "readLocal", "returns the value"));
+    ReflectsCommandNames => flow!("proc hidden {} {}\nset names [info procs]\nputs [expr {hidden in $names}]"; (0, "proc hidden", "adds a command name"), (1, "info procs", "reflects command names as data"), (2, "hidden in $names", "observes the definition"));
+    AliasesCallerFrame => flow!("set outer old\nproc inner {} { upvar 1 outer alias; set alias new }\ninner\nputs $outer"; (0, "outer old", "lives in the caller frame"), (1, "upvar 1 outer alias", "aliases through a runtime-selected frame"), (3, "$outer", "observes the write"));
+    OverridableLibraryProc => flow!("proc ::tcl::mathfunc::custom {x} { expr {$x * 2} }\nset result [expr {custom(4)}]\nputs $result"; (0, "proc ::tcl::mathfunc::custom", "overrides a library-visible procedure"), (1, "custom(4)", "dispatches through that overridable surface"), (2, "$result", "observes 8"));
+    StructurallyCheckedArity => flow!("set args {name value extra}\nset {*}$args\nputs done"; (0, "{name value extra}", "supplies a runtime word shape"), (1, "set {*}$args", "validates arity after expansion"), (2, "puts done", "is unreachable when the structure is invalid"));
+    ExprConcatenatesArgs => flow!("set operator +\nset result [expr 1 $operator 2]\nputs $result"; (0, "operator +", "supplies one expression word"), (1, "expr 1 $operator 2", "concatenates all words before parsing the expression"), (2, "$result", "observes 3"));
+    ScriptConcatenatesArgs => flow!("set command puts\neval $command hello world\nputs done"; (0, "command puts", "supplies the first script fragment"), (1, "eval $command hello world", "concatenates trailing words into one script"), (2, "puts done", "runs after the constructed script"));
+    ScriptAppendsListArgs => flow!("set prefix [list puts]\nnamespace inscope :: $prefix hello\nputs done"; (0, "[list puts]", "builds a script prefix"), (1, "$prefix hello", "appends trailing words as list elements"), (2, "puts done", "runs after the safely extended script"));
+    EstablishesVariableTrace => flow!("proc changed {name index op} { puts $op }\ntrace add variable watched write changed\nset watched value"; (0, "proc changed", "defines the callback"), (1, "trace add variable watched write changed", "establishes the variable trace"), (2, "set watched value", "fires the callback with a write operation"));
+    TransfersControl => flow!("proc target {} { return reached }\nproc caller {} { tailcall target; return unreachable }\nputs [caller]"; (0, "target", "is the destination"), (1, "tailcall target", "transfers control away from caller"), (1, "return unreachable", "cannot run"), (2, "caller", "returns reached"));
+    FireAndForgetTeardown => flow!("set child [interp create]\ninterp delete $child\nputs deleted"; (0, "[interp create]", "creates live runtime state"), (1, "interp delete $child", "starts teardown with no value dependency"), (2, "puts deleted", "continues after teardown"));
+    OperatorCommand => flow!("set left 20\nset total [+ $left 22]\nputs $total"; (0, "left 20", "supplies an operand"), (1, "+ $left 22", "runs the operator in command form"), (2, "$total", "observes 42"));
+    TclooNextChain => flow!("oo::class create Base { method run {} {return base} }\noo::class create Child { superclass Base; method run {} { return [next] } }\nputs [[Child new] run]"; (0, "method run", "defines the superclass implementation"), (1, "next", "dispatches to the next method in the chain"), (2, "run", "returns base"));
+    TclooSelfDispatch => flow!("oo::class create Widget { method render {} {return ok}; method run {} {return [my render]} }\nputs [[Widget new] run]"; (0, "my render", "dispatches on the current object"), (1, "run", "observes the delegated result"));
+    TclooIntrospection => flow!("oo::class create Widget { method describe {} { return [self class] } }\nputs [[Widget new] describe]"; (0, "self class", "introspects the current method context"), (1, "describe", "returns the declaring class"));
+    BranchSelectedBody => flow!("set enabled [gets stdin]\nif {$enabled} { set value on } else { set value off }\nputs $value"; (0, "[gets stdin]", "supplies the branch input"), (1, "if {$enabled}", "selects at most one body"), (2, "$value", "joins the selected definition"));
+    CatchableThrow => flow!("set status [catch {error failure} message]\nputs [list $status $message]"; (0, "error failure", "throws a catchable Tcl error"), (0, "catch", "intercepts the error edge"), (1, "$status $message", "observes code 1 and the message"));
+    BreaksLoop => flow!("set seen {}\nforeach item {a stop c} { if {$item eq {stop}} break; lappend seen $item }\nputs $seen"; (1, "$item eq {stop}", "selects the loop exit"), (1, "break", "jumps to the post-loop target"), (2, "$seen", "contains only a"));
+    ContinuesLoop => flow!("set seen {}\nforeach item {a skip c} { if {$item eq {skip}} continue; lappend seen $item }\nputs $seen"; (1, "$item eq {skip}", "selects the skipped iteration"), (1, "continue", "jumps to the next iteration"), (2, "$seen", "contains a and c"));
+    ReplacesFrame => flow!("proc target {} { return reached }\nproc caller {} { tailcall target }\nputs [caller]"; (0, "target", "defines the replacement call"), (1, "tailcall target", "replaces caller's frame"), (2, "caller", "returns the target result directly"));
+    SafeInterpHidden => flow!("set child [interp create -safe]\nset status [catch {interp eval $child {open secret.txt}} message]\nputs [list $status $message]"; (0, "-safe", "creates the restricted command surface"), (1, "open secret.txt", "names a hidden command"), (2, "$status $message", "observes the rejection"));
+    ProvidesPackage => flow!("proc demo::run {} { return ok }\npackage provide demo 1.0\nputs [demo::run]"; (0, "demo::run", "defines public code"), (1, "package provide demo 1.0", "declares this unit loadable by external callers"), (2, "demo::run", "represents one such caller"));
+    LoadsExternalUnit => flow!("package require json\nset value [json::json2dict {\"ok\":true}]\nputs $value"; (0, "package require json", "loads another compilation unit"), (1, "json::json2dict", "uses a command it supplied"), (2, "$value", "observes the external result"));
+    ExportsCommand => flow!("namespace eval demo { proc run {} {return ok}; namespace export run }\nnamespace import demo::run\nputs [run]"; (0, "namespace export run", "publishes the command name"), (1, "namespace import demo::run", "binds it in another namespace"), (2, "run", "dispatches through the exported API"));
+    UnresolvedCommandHandler => flow!("proc unknown {command args} { return [list missing $command] }\nset result [doesNotExist value]\nputs $result"; (0, "proc unknown", "defines the fallback handler"), (1, "doesNotExist value", "cannot resolve normally and dispatches to it"), (2, "$result", "observes missing doesNotExist"));
+    EvaluatesInShiftedFrame => flow!("set value global\nproc caller {} { set value local; uplevel #0 {set value} }\nputs [caller]"; (0, "value global", "defines state in the selected frame"), (1, "uplevel #0", "runs the body in the global frame"), (2, "caller", "returns global, not local"));
+    InstallsNamedDefinition => flow!("set name dynamic\nproc $name {} { return ok }\nputs [$name]"; (0, "dynamic", "supplies the definition name"), (1, "proc $name", "installs the named command"), (2, "$name", "dispatches to the installed definition"));
+    TclooMethodContext => flow!("oo::class create Widget { method run {} { my render }; method render {} {return ok} }\nputs [[Widget new] run]"; (0, "my render", "resolves only inside this method context"), (1, "run", "observes the method dispatch"));
+    TclooBindsMethodAlias => flow!("oo::class create Widget { method render {} {return ok}; method run {} { link render; return [render] } }\nputs [[Widget new] run]"; (0, "link render", "binds a bareword alias for the method"), (0, "[render]", "uses the new alias"), (1, "run", "returns ok"));
+    TclooRequiresMethodFrame => flow!("oo::class create Widget { method run {} { return [self method] } }\nset result [[Widget new] run]\nputs $result"; (0, "self method", "is callable only with a real method frame"), (1, "run", "creates that frame"), (2, "$result", "observes run"));
+    DeclaresNamespace => flow!("namespace eval ::app::model { set ready 1 }\nputs $::app::model::ready"; (0, "namespace eval ::app::model", "creates missing parent and target namespaces"), (0, "set ready 1", "defines state inside the namespace"), (1, "$::app::model::ready", "observes the declaration"));
+    TkGeometryManager => flow!("frame .panel\nlabel .panel.name -text Name\npack .panel.name\nputs [winfo manager .panel.name]"; (0, ".panel", "creates a container"), (2, "pack .panel.name", "claims it with a geometry manager"), (3, "winfo manager", "observes pack"));
+    DefersBody => flow!("set body {puts later}\nproc runLater {} $body\nputs registered\nrunLater"; (0, "{puts later}", "contains the script"), (1, "proc runLater {} $body", "stores it without running it"), (2, "puts registered", "runs before the deferred body"), (3, "runLater", "runs the body later"));
 }
 
 /// Every trait that widens a file's caller set beyond the file itself — the

--- a/rust/tcl-spec-studio-wasm/test/boot.mjs
+++ b/rust/tcl-spec-studio-wasm/test/boot.mjs
@@ -64,7 +64,10 @@ const TYPES = {
 function serve() {
   const server = createServer((req, res) => {
     const url = new URL(req.url ?? "/", "http://localhost");
-    const rel = normalize(decodeURIComponent(url.pathname)).replace(/^(\.\.[/\\])+/, "");
+    const rel = normalize(decodeURIComponent(url.pathname)).replace(
+      /^(\.\.[/\\])+/,
+      "",
+    );
     const path = join(distDir, rel === "/" ? "index.html" : rel);
     if (!path.startsWith(distDir)) {
       res.writeHead(403).end("no");
@@ -72,7 +75,9 @@ function serve() {
     }
     readFile(path).then(
       (body) => {
-        res.writeHead(200, { "content-type": TYPES[extname(path)] ?? "application/octet-stream" });
+        res.writeHead(200, {
+          "content-type": TYPES[extname(path)] ?? "application/octet-stream",
+        });
         res.end(body);
       },
       () => res.writeHead(404).end("not found"),
@@ -169,7 +174,9 @@ async function main() {
     if (m.type() === "error") problems.push(`console error: ${m.text()}`);
   });
   page.on("requestfailed", (r) =>
-    problems.push(`request failed: ${r.url()} (${r.failure()?.errorText ?? "?"})`),
+    problems.push(
+      `request failed: ${r.url()} (${r.failure()?.errorText ?? "?"})`,
+    ),
   );
 
   try {
@@ -185,9 +192,85 @@ async function main() {
     const count = await page.textContent("#count");
     console.log(`    registry loaded: ${count.trim()}`);
 
+    // Registry-owned worked examples must show the full flow, not merely a
+    // generic attachment point. Each source span is highlighted with the same
+    // numbered colour as its arrow. Use a historically long trait name here
+    // too: its picker label used to stretch its background across the whole
+    // grid cell instead of hugging the token.
+    await page.click("#tab-reference");
+    const flowContract = await page.evaluate(() => {
+      const term = Array.from(document.querySelectorAll("code.term")).find(
+        (node) => node.textContent === "EXPANSION_ESCAPE_SAFE",
+      );
+      const row = term?.closest("details.refrow");
+      if (!row)
+        throw new Error("EXPANSION_ESCAPE_SAFE reference row is missing");
+      row.open = true;
+      const tokens = Array.from(row.querySelectorAll("mark.example-token"));
+      const arrows = Array.from(row.querySelectorAll("pre.example-arrow"));
+      return {
+        tokens: tokens.length,
+        arrows: arrows.length,
+        numbered: arrows.every((arrow, index) =>
+          (arrow.textContent ?? "").includes(`→ ${index + 1}.`),
+        ),
+        colours: new Set(tokens.map((token) => getComputedStyle(token).color))
+          .size,
+      };
+    });
+    if (
+      flowContract.tokens < 3 ||
+      flowContract.arrows !== flowContract.tokens ||
+      !flowContract.numbered ||
+      flowContract.colours < 3
+    ) {
+      throw new Error(
+        `annotated flow rendering drifted: ${JSON.stringify(flowContract)}`,
+      );
+    }
+    await page.click("#tab-editor");
+    const chipContracts = await page.evaluate(() => {
+      const key = Array.from(document.querySelectorAll(".field .key")).find(
+        (node) => node.textContent === "traits",
+      );
+      const group = key?.closest("details.group");
+      if (group) group.open = true;
+      return ["EXPANSION_ESCAPE_SAFE", "DEFERS_BODY"].map((name) => {
+        const code = Array.from(
+          document.querySelectorAll(".trait-copy code"),
+        ).find((node) => node.textContent === name);
+        const toggleGroup = code?.closest("details.toggle-group");
+        if (toggleGroup) toggleGroup.open = true;
+        if (!code?.parentElement)
+          throw new Error(`${name} trait toggle is missing`);
+        return {
+          name,
+          tokenWidth: code.getBoundingClientRect().width,
+          cellWidth: code.parentElement.getBoundingClientRect().width,
+          justifySelf: getComputedStyle(code).justifySelf,
+        };
+      });
+    });
+    const stretchedChip = chipContracts.find(
+      (chip) =>
+        chip.justifySelf !== "start" ||
+        chip.tokenWidth <= 0 ||
+        chip.tokenWidth >= chip.cellWidth - 8,
+    );
+    if (stretchedChip) {
+      throw new Error(
+        `trait token background still stretches: ${JSON.stringify(stretchedChip)}`,
+      );
+    }
+    console.log(
+      "    registry flows have numbered token highlights and tight trait labels",
+    );
+
     // 2. Opening the Pack DSL tab loads the editor chunk and mounts Monaco.
     await page.click("#tab-dsl");
-    await page.waitForSelector("#dslEditor .monaco-editor", { timeout: 60_000 });
+    await page.waitForSelector("#dslEditor .monaco-editor", {
+      timeout: 60_000,
+    });
     console.log("    Monaco mounted on the Pack DSL tab");
 
     // 3. The language server worker reaches `initialize`.
@@ -214,15 +297,21 @@ async function main() {
       packEditorContract.lspLanguage !== "spectcl" ||
       !packEditorContract.documentUri?.endsWith("/pack.tclspec")
     ) {
-      throw new Error(`Pack DSL editor contract drifted: ${JSON.stringify(packEditorContract)}`);
+      throw new Error(
+        `Pack DSL editor contract drifted: ${JSON.stringify(packEditorContract)}`,
+      );
     }
-    console.log("    Pack DSL model is Monaco spectcl + LSP spectcl (Tcl 9.0 profile)");
+    console.log(
+      "    Pack DSL model is Monaco spectcl + LSP spectcl (Tcl 9.0 profile)",
+    );
 
     // The success status is published only after Monaco itself has invoked the
     // semantic-token provider for this model, and hover has answered for it.
     // A direct transport probe is insufficient: editor.api exposes provider
     // registration even when the controller which consumes it was omitted.
-    console.log("    Pack DSL semantics and hover are served by the in-page LSP");
+    console.log(
+      "    Pack DSL semantics and hover are served by the in-page LSP",
+    );
 
     // Prove Monaco gets several semantic colours from the LSP. This catches a
     // provider whose legend contains theme scopes
@@ -231,8 +320,11 @@ async function main() {
     await page.waitForFunction(
       () => {
         const colours = new Set(
-          Array.from(document.querySelectorAll("#dslEditor .view-lines span[class*='mtk']"))
-            .map((node) => getComputedStyle(node).color),
+          Array.from(
+            document.querySelectorAll(
+              "#dslEditor .view-lines span[class*='mtk']",
+            ),
+          ).map((node) => getComputedStyle(node).color),
         );
         return colours.size > 1;
       },
@@ -247,11 +339,15 @@ async function main() {
     // invokes Monaco's public show-hover action at the exact model position.
     await page.evaluate(async () => {
       if (typeof window.__tclSpecStudioTestShowDslHover !== "function") {
-        throw new Error("the Monaco deployment-test hover hook was not installed");
+        throw new Error(
+          "the Monaco deployment-test hover hook was not installed",
+        );
       }
       await window.__tclSpecStudioTestShowDslHover("speclib");
     });
-    const visibleHover = page.locator(".monaco-hover:visible", { hasText: "speclib" });
+    const visibleHover = page.locator(".monaco-hover:visible", {
+      hasText: "speclib",
+    });
     // Monaco retains a hidden hover widget alongside the active one.
     await visibleHover.waitFor({ timeout: 30_000 });
     console.log("    Pack DSL hover is visible in Monaco on initial load");
@@ -261,14 +357,20 @@ async function main() {
     //    booted" and "the worker is doing the job".
     await page.click("#dslEditor .monaco-editor .view-lines");
     await page.keyboard.type("\ncommand");
-    const markers = await page.waitForFunction(
-      () => {
-        const node = document.querySelector("#dslEditor .monaco-editor");
-        return node && node.querySelectorAll(".squiggly-error, .squiggly-warning").length > 0;
-      },
-      null,
-      { timeout: 60_000 },
-    ).catch(() => null);
+    const markers = await page
+      .waitForFunction(
+        () => {
+          const node = document.querySelector("#dslEditor .monaco-editor");
+          return (
+            node &&
+            node.querySelectorAll(".squiggly-error, .squiggly-warning").length >
+              0
+          );
+        },
+        null,
+        { timeout: 60_000 },
+      )
+      .catch(() => null);
     console.log(
       markers
         ? "    the language server published diagnostics into the editor"
@@ -277,15 +379,20 @@ async function main() {
 
     // 5. The Test tab's second editor mounts on its own model.
     await page.click("#tab-test");
-    await page.waitForSelector("#testEditor .monaco-editor", { timeout: 30_000 });
+    await page.waitForSelector("#testEditor .monaco-editor", {
+      timeout: 30_000,
+    });
     await page.click("#testEditor .monaco-editor .view-lines");
     await page.keyboard.press("Control+End");
     await page.keyboard.type("set colour red\nputs $colour");
     await page.waitForFunction(
       () => {
         const colours = new Set(
-          Array.from(document.querySelectorAll("#testEditor .view-lines span[class*='mtk']"))
-            .map((node) => getComputedStyle(node).color),
+          Array.from(
+            document.querySelectorAll(
+              "#testEditor .view-lines span[class*='mtk']",
+            ),
+          ).map((node) => getComputedStyle(node).color),
         );
         return colours.size > 1;
       },
@@ -300,7 +407,9 @@ async function main() {
       sampleEditorContract.monacoLanguage !== "tcl" ||
       sampleEditorContract.lspLanguage !== "spectcl"
     ) {
-      throw new Error(`Test editor contract drifted: ${JSON.stringify(sampleEditorContract)}`);
+      throw new Error(
+        `Test editor contract drifted: ${JSON.stringify(sampleEditorContract)}`,
+      );
     }
     console.log("    Monaco mounted on the Test tab");
 
@@ -311,20 +420,28 @@ async function main() {
     await page.setInputFiles("#picker", {
       name: "widget.tcl",
       mimeType: "text/plain",
-      buffer: Buffer.from("proc widget::paint {colour} { return $colour }\n", "utf8"),
+      buffer: Buffer.from(
+        "proc widget::paint {colour} { return $colour }\n",
+        "utf8",
+      ),
     });
     await page.waitForSelector("#importOut .found", { timeout: 30_000 });
     await page.click("#importAll");
     await page.click("#tab-rs");
     await page.waitForFunction(
       () => {
-        const text = document.querySelector("#rsEditor .view-lines")?.textContent ?? "";
-        return text.includes("widget::paint") && !text.includes('name: "mycommand"');
+        const text =
+          document.querySelector("#rsEditor .view-lines")?.textContent ?? "";
+        return (
+          text.includes("widget::paint") && !text.includes('name: "mycommand"')
+        );
       },
       null,
       { timeout: 30_000 },
     );
-    console.log("    imported Tcl activates generated Rust for the imported command");
+    console.log(
+      "    imported Tcl activates generated Rust for the imported command",
+    );
 
     // 7. The Releases import mode and its GitHub panel are present and inert
     //    until asked — no request is made by opening them.
@@ -345,7 +462,8 @@ async function main() {
         mimeType: "application/zip",
         buffer: storedZip({
           "mylib-1.0/pkgIndex.tcl": "package ifneeded mylib 1.0 {}\n",
-          "mylib-1.0/mylib.tcl": "package provide mylib 1.0\nproc greet {who} { return $who }\n",
+          "mylib-1.0/mylib.tcl":
+            "package provide mylib 1.0\nproc greet {who} { return $who }\n",
         }),
       },
       {
@@ -363,25 +481,35 @@ async function main() {
       null,
       { timeout: 30_000 },
     );
-    const labels = await page.$$eval("#releaseList .ver", (nodes) => nodes.map((n) => n.value));
+    const labels = await page.$$eval("#releaseList .ver", (nodes) =>
+      nodes.map((n) => n.value),
+    );
     if (labels.join(",") !== "1.0,1.1") {
-      throw new Error(`version labels were not suggested from the file names: ${labels}`);
+      throw new Error(
+        `version labels were not suggested from the file names: ${labels}`,
+      );
     }
     await page.click("#releasesRun");
     await page.waitForSelector("#releasesOut .found", { timeout: 60_000 });
     const derived = await page.$$eval("#releasesOut .found", (cards) =>
       cards.map((card) => ({
         name: card.querySelector(".nm")?.textContent ?? "",
-        ranges: Array.from(card.querySelectorAll(".range")).map((r) => r.textContent ?? ""),
+        ranges: Array.from(card.querySelectorAll(".range")).map(
+          (r) => r.textContent ?? "",
+        ),
       })),
     );
     const farewell = derived.find((c) => c.name === "farewell");
     const greet = derived.find((c) => c.name === "greet");
     if (!farewell || !greet) {
-      throw new Error(`expected greet and farewell, got ${JSON.stringify(derived)}`);
+      throw new Error(
+        `expected greet and farewell, got ${JSON.stringify(derived)}`,
+      );
     }
     if (!farewell.ranges.includes("introduced 1.1")) {
-      throw new Error(`farewell should be introduced at 1.1: ${farewell.ranges.join(", ")}`);
+      throw new Error(
+        `farewell should be introduced at 1.1: ${farewell.ranges.join(", ")}`,
+      );
     }
     if (!greet.ranges.includes("introduced —")) {
       throw new Error(
@@ -410,7 +538,9 @@ async function main() {
       { timeout: 60_000 },
     );
     await mutation.click("#tab-dsl");
-    await mutation.waitForSelector("#dslEditor .monaco-editor", { timeout: 60_000 });
+    await mutation.waitForSelector("#dslEditor .monaco-editor", {
+      timeout: 60_000,
+    });
     await mutation.waitForFunction(
       () =>
         (document.getElementById("lspStatus")?.textContent ?? "").includes(
@@ -420,10 +550,14 @@ async function main() {
       { timeout: 60_000 },
     );
     await mutation.close();
-    console.log("    explicit post-didOpen LSP readiness survives a suppressed Monaco provider");
+    console.log(
+      "    explicit post-didOpen LSP readiness survives a suppressed Monaco provider",
+    );
   } catch (e) {
     const status = await page.textContent("#lspStatus").catch(() => "");
-    fail(`${e instanceof Error ? e.message : String(e)}; LSP status: ${status?.trim() ?? ""}`);
+    fail(
+      `${e instanceof Error ? e.message : String(e)}; LSP status: ${status?.trim() ?? ""}`,
+    );
   } finally {
     await browser.close();
     server.close();
@@ -431,7 +565,8 @@ async function main() {
 
   // A request to GitHub during a boot check would mean the panel is not opt-in.
   const network = problems.filter((p) => /github\.com/.test(p));
-  if (network.length) fail(`the page reached GitHub without being asked: ${network.join("; ")}`);
+  if (network.length)
+    fail(`the page reached GitHub without being asked: ${network.join("; ")}`);
   for (const problem of problems) fail(problem);
   if (!process.exitCode) console.log("==> boot check passed");
 }

--- a/rust/tcl-spec-studio/src/examples.rs
+++ b/rust/tcl-spec-studio/src/examples.rs
@@ -27,7 +27,10 @@
 
 use serde_json::{Value, json};
 
-use tcl_registry::traits::{Trait, TraitCategory};
+use tcl_registry::documentation::DocumentationExample;
+use tcl_registry::side_effects::SideEffectTarget;
+use tcl_registry::taint::TaintColourAtom;
+use tcl_registry::traits::Trait;
 
 /// One span in a source line that the browser annotates.
 #[derive(Debug, Clone, Copy)]
@@ -336,93 +339,6 @@ fn catalogue_template(id: &str) -> Option<Example> {
     }
 }
 
-const TRAIT_CONTROL: Example = Example {
-    code: "myflow {$ready} {\n    publish $payload\n}",
-    focuses: &[focus(
-        0,
-        "myflow",
-        "describes how this command controls scripts and execution",
-    )],
-};
-const TRAIT_PURITY: Example = Example {
-    code: "set result [mycommand $value]",
-    focuses: &[focus(
-        0,
-        "[mycommand $value]",
-        "describes optimisation and runtime properties of this call",
-    )],
-};
-const TRAIT_VARIABLES: Example = Example {
-    code: "mycommand target $value",
-    focuses: &[focus(
-        0,
-        "target",
-        "describes the name, variable, or frame selected here",
-    )],
-};
-const TRAIT_DYNAMIC: Example = Example {
-    code: "mycommand $script",
-    focuses: &[focus(
-        0,
-        "$script",
-        "marks dynamic execution or an analysis boundary here",
-    )],
-};
-const TRAIT_SECURITY: Example = Example {
-    code: "mycommand $untrusted",
-    focuses: &[focus(
-        0,
-        "$untrusted",
-        "describes I/O or security handling at this call",
-    )],
-};
-const TRAIT_CALLBACK: Example = Example {
-    code: "mycommand callback",
-    focuses: &[focus(
-        0,
-        "callback",
-        "describes a command prefix invoked from here",
-    )],
-};
-const TRAIT_IRULES: Example = Example {
-    code: "when HTTP_REQUEST {\n    mycommand $value\n}",
-    focuses: &[focus(
-        1,
-        "mycommand $value",
-        "describes this BIG-IP/iRules invocation",
-    )],
-};
-const TRAIT_OBJECTS: Example = Example {
-    code: "oo::class create Widget {\n    mycommand render {} { ... }\n}",
-    focuses: &[focus(
-        1,
-        "mycommand",
-        "describes this object/class operation",
-    )],
-};
-const TRAIT_PACKAGES: Example = Example {
-    code: "package mycommand demo 1.0",
-    focuses: &[focus(
-        0,
-        "mycommand",
-        "describes this package or external-unit operation",
-    )],
-};
-
-fn trait_template(key: &str) -> Option<Example> {
-    match Trait::from_name(key)?.category() {
-        TraitCategory::ControlFlow => Some(TRAIT_CONTROL),
-        TraitCategory::Runtime => Some(TRAIT_PURITY),
-        TraitCategory::Names => Some(TRAIT_VARIABLES),
-        TraitCategory::DynamicAnalysis => Some(TRAIT_DYNAMIC),
-        TraitCategory::Security => Some(TRAIT_SECURITY),
-        TraitCategory::Callbacks => Some(TRAIT_CALLBACK),
-        TraitCategory::Irules => Some(TRAIT_IRULES),
-        TraitCategory::Objects => Some(TRAIT_OBJECTS),
-        TraitCategory::Packages => Some(TRAIT_PACKAGES),
-    }
-}
-
 fn example_json(example: Example, subject: &str) -> Value {
     let annotations: Vec<Value> = example
         .focuses
@@ -432,6 +348,21 @@ fn example_json(example: Example, subject: &str) -> Value {
                 "line": item.line,
                 "needle": item.needle,
                 "label": format!("{subject} — {}", item.note),
+            })
+        })
+        .collect();
+    json!({ "code": example.code, "annotations": annotations })
+}
+
+fn registry_example_json(example: DocumentationExample, subject: &str) -> Value {
+    let annotations: Vec<Value> = example
+        .annotations
+        .iter()
+        .map(|item| {
+            json!({
+                "line": item.line,
+                "needle": item.needle,
+                "label": format!("{subject} — {}", item.label),
             })
         })
         .collect();
@@ -461,12 +392,19 @@ pub fn catalogue_example(id: &str, title: &str) -> Option<Value> {
 /// attachment point.
 #[must_use]
 pub fn variant_example(id: &str, key: &str, doc: &str) -> Option<Value> {
-    let example = if id == "traits" {
-        trait_template(key)
-    } else {
-        catalogue_template(id)
-    }?;
-    Some(example_json(example, &format!("{key}: {doc}")))
+    let subject = format!("{key}: {doc}");
+    match id {
+        "traits" => Trait::from_name(key)
+            .map(Trait::example)
+            .map(|example| registry_example_json(example, &subject)),
+        "taintColour" => TaintColourAtom::from_name(key)
+            .map(TaintColourAtom::example)
+            .map(|example| registry_example_json(example, &subject)),
+        "sideEffectTarget" => SideEffectTarget::from_name(key)
+            .map(SideEffectTarget::example)
+            .map(|example| registry_example_json(example, &subject)),
+        _ => catalogue_template(id).map(|example| example_json(example, &subject)),
+    }
 }
 
 #[cfg(test)]
@@ -474,26 +412,33 @@ mod tests {
     use super::*;
     use crate::{catalogue, schema};
 
-    fn assert_valid(example: &Value, owner: &str) {
+    fn validation_errors(example: &Value, owner: &str) -> Vec<String> {
+        let mut errors = Vec::new();
         let code = example["code"].as_str().expect("example code");
         let lines: Vec<&str> = code.lines().collect();
         let annotations = example["annotations"].as_array().expect("annotations");
-        assert!(!annotations.is_empty(), "{owner} has no arrow annotations");
+        if annotations.is_empty() {
+            errors.push(format!("{owner} has no arrow annotations"));
+        }
         for annotation in annotations {
             let line = usize::try_from(annotation["line"].as_u64().expect("line"))
                 .expect("line fits usize");
             let needle = annotation["needle"].as_str().expect("needle");
-            assert!(
-                lines.get(line).is_some_and(|text| text.contains(needle)),
-                "{owner}: line {line} does not contain {needle:?} in {code:?}"
-            );
-            assert!(
-                annotation["label"]
-                    .as_str()
-                    .is_some_and(|label| !label.is_empty()),
-                "{owner} has an empty arrow label"
-            );
+            if !lines.get(line).is_some_and(|text| text.contains(needle)) {
+                errors.push(format!(
+                    "{owner}: line {line} does not contain {needle:?} in {code:?}"
+                ));
+            }
+            if annotation["label"].as_str().is_none_or(str::is_empty) {
+                errors.push(format!("{owner} has an empty arrow label"));
+            }
         }
+        errors
+    }
+
+    fn assert_valid(example: &Value, owner: &str) {
+        let errors = validation_errors(example, owner);
+        assert!(errors.is_empty(), "{}", errors.join("\n"));
     }
 
     #[test]
@@ -514,10 +459,11 @@ mod tests {
 
     #[test]
     fn every_catalogue_and_variant_has_a_valid_example() {
+        let mut errors = Vec::new();
         for (id, title, _) in crate::help::CATALOGUE_HELP {
             let example = catalogue_example(id, title)
                 .unwrap_or_else(|| panic!("no catalogue example for {id}"));
-            assert_valid(&example, id);
+            errors.extend(validation_errors(&example, id));
         }
         let catalogues = schema::catalogues();
         for (id, variants) in catalogues.as_object().expect("catalogues") {
@@ -526,9 +472,10 @@ mod tests {
                 let doc = variant["doc"].as_str().expect("doc");
                 let example = variant_example(id, key, doc)
                     .unwrap_or_else(|| panic!("no variant example for {id}/{key}"));
-                assert_valid(&example, &format!("{id}/{key}"));
+                errors.extend(validation_errors(&example, &format!("{id}/{key}")));
             }
         }
+        assert!(errors.is_empty(), "{}", errors.join("\n"));
     }
 
     #[test]

--- a/rust/tcl-spec-studio/src/schema.rs
+++ b/rust/tcl-spec-studio/src/schema.rs
@@ -1852,14 +1852,14 @@ pub fn catalogues() -> Value {
         ("formatType", catalogue::FORMAT_TYPES),
         ("formKind", catalogue::FORM_KINDS),
         ("definedSymbolKind", catalogue::DEFINED_SYMBOL_KINDS),
-        ("sideEffectTarget", catalogue::SIDE_EFFECT_TARGETS),
+        ("sideEffectTarget", &catalogue::SIDE_EFFECT_TARGETS),
         ("connectionSide", catalogue::CONNECTION_SIDES),
         ("loweringHook", catalogue::LOWERING_HOOKS),
         ("codegenHook", catalogue::CODEGEN_HOOKS),
         ("inlineCodegenHook", catalogue::INLINE_CODEGEN_HOOKS),
         ("analyserHook", catalogue::ANALYSER_HOOKS),
         ("traits", &catalogue::TRAITS),
-        ("taintColour", catalogue::TAINT_COLOURS),
+        ("taintColour", &catalogue::TAINT_COLOURS),
         ("dialects", &catalogue::DIALECTS),
     ];
     let mut values = serde_json::Map::new();

--- a/rust/tcl-spec-studio/web/src/studio.css
+++ b/rust/tcl-spec-studio/web/src/studio.css
@@ -174,7 +174,9 @@ footer a { color: var(--accent); }
 .trait-toggle:hover { background: color-mix(in srgb, var(--accent) 5%, transparent); }
 .trait-toggle input { margin-top: .15rem; }
 .trait-copy { display: grid; gap: .12rem; min-width: 0; }
-.trait-copy code { font-size: .74rem; overflow-wrap: anywhere; }
+.trait-copy code {
+  justify-self: start; width: fit-content; font-size: .74rem; overflow-wrap: anywhere;
+}
 .trait-copy .doc { margin: 0; font-size: .76rem; }
 
 /* Long-form help: the ? buttons on groups and fields, and the panels they
@@ -205,7 +207,18 @@ summary .qbtn { margin-left: .45rem; }
   white-space: pre; overflow: visible;
 }
 .example-line { color: var(--fg); }
-.example-arrow { color: var(--accent); }
+.example-token {
+  border: 1px solid currentColor; border-radius: 3px; color: inherit;
+  font: inherit; padding: 0 1px;
+}
+.flow-step-1 { color: #3b82f6; }
+.flow-step-2 { color: #a855f7; }
+.flow-step-3 { color: #d97706; }
+.flow-step-4 { color: #059669; }
+.example-token.flow-step-1 { background: color-mix(in srgb, #3b82f6 22%, transparent); }
+.example-token.flow-step-2 { background: color-mix(in srgb, #a855f7 22%, transparent); }
+.example-token.flow-step-3 { background: color-mix(in srgb, #f59e0b 22%, transparent); }
+.example-token.flow-step-4 { background: color-mix(in srgb, #10b981 22%, transparent); }
 
 /* The Reference tab: searchable sections of fields and catalogue entries. */
 .refbar { display: flex; gap: .6rem; align-items: center; margin-bottom: .8rem; }

--- a/rust/tcl-spec-studio/web/src/studio.ts
+++ b/rust/tcl-spec-studio/web/src/studio.ts
@@ -218,14 +218,40 @@ function helpParagraphs(text: string): HTMLElement {
 function annotatedExample(example: CodeExample): HTMLElement {
   const node = el("figure", { class: "code-example" });
   const lines = example.code.split("\n");
+  const ordered = example.annotations.map((annotation, index) => ({ annotation, step: index + 1 }));
   lines.forEach((line, lineNumber) => {
-    node.appendChild(el("pre", { class: "example-line", text: line || " " }));
-    for (const annotation of example.annotations.filter((item) => item.line === lineNumber)) {
-      const at = line.indexOf(annotation.needle);
+    const onLine = ordered
+      .filter(({ annotation }) => annotation.line === lineNumber)
+      .map(({ annotation, step }) => ({ annotation, step, at: line.indexOf(annotation.needle) }))
+      .sort((left, right) => left.at - right.at);
+    const source = el("pre", { class: "example-line" });
+    let cursor = 0;
+    for (const { annotation, step, at } of onLine) {
+      // Overlapping annotations share the earlier highlight but still receive
+      // their own flow arrow below.
+      if (at < cursor) continue;
+      source.appendChild(document.createTextNode(line.slice(cursor, at)));
+      source.appendChild(
+        el("mark", {
+          class: `example-token flow-step-${((step - 1) % 4) + 1}`,
+          text: annotation.needle,
+          title: `Flow step ${step}: ${annotation.label}`,
+        }),
+      );
+      cursor = at + annotation.needle.length;
+    }
+    source.appendChild(document.createTextNode(line.slice(cursor) || (line ? "" : " ")));
+    node.appendChild(source);
+    for (const { annotation, step, at } of onLine) {
       const arrow =
         `${" ".repeat(Math.max(0, at))}└${"─".repeat(Math.max(1, annotation.needle.length - 1))}` +
-        `→ ${annotation.label}`;
-      node.appendChild(el("pre", { class: "example-arrow", text: arrow }));
+        `→ ${step}. ${annotation.label}`;
+      node.appendChild(
+        el("pre", {
+          class: `example-arrow flow-step-${((step - 1) % 4) + 1}`,
+          text: arrow,
+        }),
+      );
     }
   });
   return node;

--- a/rust/tcl-spectcl/src/catalogue.rs
+++ b/rust/tcl-spectcl/src/catalogue.rs
@@ -34,7 +34,8 @@
 use std::sync::LazyLock;
 
 use tcl_dialect::{DialectProfile, DialectSet};
-use tcl_registry::taint::TaintColour;
+use tcl_registry::side_effects::SideEffectTarget;
+use tcl_registry::taint::{TaintColour, TaintColourAtom};
 use tcl_registry::traits::{Trait, Traits};
 
 /// One selectable value in a picker — the Rust spelling plus a one-line
@@ -206,51 +207,13 @@ pub const DEFINED_SYMBOL_KINDS: &[Variant] = &[
     ),
 ];
 
-/// [`SideEffectTarget`] — what kind of state an effect touches.
-pub const SIDE_EFFECT_TARGETS: &[Variant] = &[
-    v("Variable", "Tcl variable read or write"),
-    v("SessionTable", "session table entry"),
-    v("PersistenceTable", "persistence record"),
-    v("DataGroup", "data group / class lookup"),
-    v("HttpHeader", "HTTP header read or write"),
-    v("HttpBody", "HTTP payload / body"),
-    v("HttpStatus", "HTTP status code"),
-    v("HttpUri", "HTTP URI components"),
-    v("HttpCookie", "HTTP cookie"),
-    v("HttpMethod", "HTTP method"),
-    v("Http2State", "HTTP/2 protocol state"),
-    v("ResponseCommit", "commits or sends an HTTP response"),
-    v("ConnectionControl", "drop / reject / discard / forward"),
-    v("TcpState", "TCP connection state"),
-    v("SslState", "SSL/TLS state"),
-    v("UdpState", "UDP state"),
-    v("PoolSelection", "pool selection"),
-    v("NodeSelection", "node selection"),
-    v("SnatSelection", "SNAT selection"),
-    v("FileIo", "filesystem I/O"),
-    v("NetworkIo", "network I/O"),
-    v("LogIo", "logging output"),
-    v("StreamProfile", "stream profile state"),
-    v("DnsState", "DNS state"),
-    v("ClassificationState", "classification state"),
-    v("Dosl7State", "L7 DoS state"),
-    v("FlowState", "flow state"),
-    v("LsnState", "LSN state"),
-    v("FtpState", "FTP state"),
-    v("IcapState", "ICAP state"),
-    v("MessageState", "message-routing state"),
-    v("IStats", "iStats counters"),
-    v("ApmState", "APM state"),
-    v("AsmState", "ASM state"),
-    v("BigipConfig", "BIG-IP configuration"),
-    v("ProcDefinition", "procedure definition table"),
-    v("NamespaceState", "namespace state"),
-    v("InterpState", "interpreter state"),
-    v("Process", "process creation / control"),
-    v("ChannelIo", "channel I/O"),
-    v("EventControl", "iRules event control flow"),
-    v("Unknown", "unclassified effect"),
-];
+/// [`SideEffectTarget`] — generated from the registry-owned names and prose.
+pub static SIDE_EFFECT_TARGETS: LazyLock<Vec<Variant>> = LazyLock::new(|| {
+    SideEffectTarget::ALL
+        .iter()
+        .map(|item| v(item.name(), item.summary()))
+        .collect()
+});
 
 /// [`ConnectionSide`] — which side of an iRules connection an effect applies to.
 pub const CONNECTION_SIDES: &[Variant] = &[
@@ -391,29 +354,13 @@ pub static TRAITS: LazyLock<Vec<Variant>> = LazyLock::new(|| {
         .collect()
 });
 
-/// [`TaintColour`] bits.
-pub const TAINT_COLOURS: &[Variant] = &[
-    v("TAINTED", "attacker-controlled"),
-    v("PATH_PREFIXED", "guaranteed to start with a path separator"),
-    v(
-        "NON_DASH_PREFIXED",
-        "cannot begin with `-` (option-injection safe)",
-    ),
-    v("CRLF_FREE", "contains no CR or LF (header-injection safe)"),
-    v("SHELL_ATOM", "a single shell atom (exec-safe)"),
-    v("LIST_CANONICAL", "canonical list form (eval-safe)"),
-    v("REGEX_LITERAL", "quoted as a regex literal"),
-    v("PATH_NORMALISED", "path-normalised"),
-    v("PATH_BOUNDED", "bounded within a known path root"),
-    v("HEADER_TOKEN_SAFE", "safe as an HTTP header token"),
-    v("HTML_ESCAPED", "HTML-escaped"),
-    v("URL_ENCODED", "URL-encoded"),
-    v("IP_ADDRESS", "a validated IP address"),
-    v("PORT", "a validated port number"),
-    v("FQDN", "a validated fully-qualified domain name"),
-    v("PATH_JOINED", "produced by `file join`"),
-    v("CHANNEL", "a channel handle"),
-];
+/// [`TaintColour`] bits, generated from the registry-owned atoms and prose.
+pub static TAINT_COLOURS: LazyLock<Vec<Variant>> = LazyLock::new(|| {
+    TaintColourAtom::ALL
+        .iter()
+        .map(|item| v(item.name(), item.summary()))
+        .collect()
+});
 
 /// Canonical dialect name ↔ primitive [`DialectSet`] bit — the vocabulary
 /// [`DIALECTS`] and [`dialect_bit`] both read.
@@ -914,14 +861,14 @@ mod tests {
             FORMAT_TYPES,
             FORM_KINDS,
             DEFINED_SYMBOL_KINDS,
-            SIDE_EFFECT_TARGETS,
+            SIDE_EFFECT_TARGETS.as_slice(),
             CONNECTION_SIDES,
             LOWERING_HOOKS,
             CODEGEN_HOOKS,
             INLINE_CODEGEN_HOOKS,
             ANALYSER_HOOKS,
             &TRAITS,
-            TAINT_COLOURS,
+            TAINT_COLOURS.as_slice(),
             DIALECTS.as_slice(),
         ] {
             let mut seen: Vec<&str> = Vec::new();

--- a/rust/tcl-spectcl/src/loader.rs
+++ b/rust/tcl-spectcl/src/loader.rs
@@ -4867,7 +4867,7 @@ mod tests {
             (
                 "side-effect target",
                 names(SIDE_EFFECT_TARGETS),
-                catalogue::SIDE_EFFECT_TARGETS,
+                catalogue::SIDE_EFFECT_TARGETS.as_slice(),
             ),
             (
                 "connection side",


### PR DESCRIPTION
## Summary

- make the Rust registry the single source of truth for trait, taint-colour, and side-effect documentation examples
- require exhaustive worked examples at compile time when those closed vocabularies grow
- render numbered, colour-matched arrows and highlighted Tcl tokens for each end-to-end flow
- keep trait-name grey backgrounds fitted to the name, including `EXPANSION_ESCAPE_SAFE` and `DEFERS_BODY`
- generate SpecTcl catalogue prose from the same registry vocabulary

## Verification

- `make rust-check`
- `make NPROC=1 prep-pr`
- `cargo test -p tcl-registry -p tcl-spectcl -p tcl-spec-studio`
- Spec Studio web lint, typecheck, and 32 unit tests
- real Chromium WASM boot regression: flow highlights/arrows, tight trait pills, Monaco, Tcl 9.0 SpecTcl LSP semantics, hover, and diagnostics

The sole Clippy expectation is scoped to the exhaustive side-effect documentation table: splitting that closed match would weaken the compile-time completeness gate.