### PR TITLE
fix(spec-studio): add inline help to catalogue items

### DIFF
--- a/rust/tcl-spec-studio-wasm/test/boot.mjs
+++ b/rust/tcl-spec-studio-wasm/test/boot.mjs
@@ -252,7 +252,14 @@ async function main() {
       );
       const group = key?.closest("details.group");
       if (group) group.open = true;
-      return ["EXPANSION_ESCAPE_SAFE", "DEFERS_BODY"].map((name) => {
+      const items = [
+        { name: "EXPANSION_ESCAPE_SAFE", carrier: "puts" },
+        { name: "DEFERS_BODY", carrier: "proc" },
+      ];
+      const rowsWithoutHelp = Array.from(
+        document.querySelectorAll(".trait-toggle"),
+      ).filter((row) => !row.querySelector("button.qbtn")).length;
+      return items.map(({ name, carrier: expectedCarrier }) => {
         const code = Array.from(
           document.querySelectorAll(".trait-copy code"),
         ).find((node) => node.textContent === name);
@@ -260,11 +267,29 @@ async function main() {
         if (toggleGroup) toggleGroup.open = true;
         if (!code?.parentElement)
           throw new Error(`${name} trait toggle is missing`);
+        const row = code.closest(".trait-toggle");
+        const help = row?.querySelector("button.qbtn");
+        if (!row || !help)
+          throw new Error(`${name} Spec-tab inline help is missing`);
+        const checkbox = row.querySelector('input[type="checkbox"]');
+        const checkedBeforeHelp = checkbox?.checked;
+        help.click();
+        const checkedAfterHelp = checkbox?.checked;
+        const carriers = Array.from(row.querySelectorAll("mark.example-carrier"));
+        const arrows = Array.from(row.querySelectorAll("pre.example-arrow"));
         return {
           name,
           tokenWidth: code.getBoundingClientRect().width,
           cellWidth: code.parentElement.getBoundingClientRect().width,
           justifySelf: getComputedStyle(code).justifySelf,
+          expanded: help.getAttribute("aria-expanded"),
+          carriers: carriers.length,
+          carrier: carriers[0]?.textContent ?? "",
+          expectedCarrier,
+          arrows: arrows.length,
+          checkedBeforeHelp,
+          checkedAfterHelp,
+          rowsWithoutHelp,
         };
       });
     });
@@ -272,7 +297,13 @@ async function main() {
       (chip) =>
         chip.justifySelf !== "start" ||
         chip.tokenWidth <= 0 ||
-        chip.tokenWidth >= chip.cellWidth - 8,
+        chip.tokenWidth >= chip.cellWidth - 8 ||
+        chip.expanded !== "true" ||
+        chip.carriers !== 1 ||
+        chip.carrier !== chip.expectedCarrier ||
+        chip.arrows < 2 ||
+        chip.checkedBeforeHelp !== chip.checkedAfterHelp ||
+        chip.rowsWithoutHelp !== 0,
     );
     if (stretchedChip) {
       throw new Error(
@@ -280,7 +311,7 @@ async function main() {
       );
     }
     console.log(
-      "    registry flows have numbered arrows, one command carrier, inline help, and tight trait labels",
+      "    registry flows have numbered arrows, one command carrier, Spec-tab item help, and tight trait labels",
     );
 
     // 2. Opening the Pack DSL tab loads the editor chunk and mounts Monaco.

--- a/rust/tcl-spec-studio/web/src/editors.ts
+++ b/rust/tcl-spec-studio/web/src/editors.ts
@@ -70,6 +70,8 @@ export const STRUCTURAL_KINDS = new Set([
 /** Everything an editor needs from the surrounding app. */
 export interface EditorContext {
   catalogues: Catalogues;
+  /** Builds the inline documentation control for one catalogue item. */
+  variantHelp: (variant: Variant) => { button: HTMLButtonElement; panel: HTMLElement };
   /** A fresh subcommand draft, for the subcommand list's add button. */
   newSubcommand: () => Record<string, Json>;
   /** Renders a nested subcommand form into `container`. */
@@ -300,13 +302,16 @@ export function makeEditors(ctx: EditorContext): Record<string, Editor> {
         const box = el("input", { type: "checkbox" });
         box.checked = bits.includes(entry.key);
         box.disabled = Boolean(kind.optional) && !declared;
-        const row = el("label", { class: "trait-toggle" }, [
+        const help = ctx.variantHelp(entry);
+        const choice = el("label", { class: "trait-choice" }, [
           box,
-          el("span", { class: "trait-copy" }, [
-            el("code", { text: entry.key }),
-            el("span", { class: "doc", text: entry.doc }),
-          ]),
+          el("code", { text: entry.key }),
         ]);
+        const copy = el("div", { class: "trait-copy" }, [
+          el("div", { class: "trait-title" }, [choice, help.button]),
+          el("span", { class: "doc", text: entry.doc }),
+        ]);
+        const row = el("div", { class: "trait-toggle" }, [copy, help.panel]);
         box.addEventListener("change", () => {
           const at = bits.indexOf(entry.key);
           if (box.checked && at < 0) bits.push(entry.key);

--- a/rust/tcl-spec-studio/web/src/studio.css
+++ b/rust/tcl-spec-studio/web/src/studio.css
@@ -168,16 +168,18 @@ footer a { color: var(--accent); }
 .toggle-group > summary .n { color: var(--muted); font-weight: 400; margin-left: .4rem; }
 .toggle-list { display: grid; grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr)); }
 .trait-toggle {
-  display: flex; gap: .5rem; align-items: flex-start; padding: .48rem .6rem;
-  border-top: 1px solid var(--border); cursor: pointer;
+  display: block; padding: .48rem .6rem; border-top: 1px solid var(--border);
 }
 .trait-toggle:hover { background: color-mix(in srgb, var(--accent) 5%, transparent); }
-.trait-toggle input { margin-top: .15rem; }
+.trait-choice { display: flex; gap: .5rem; align-items: flex-start; cursor: pointer; min-width: 0; }
+.trait-choice input { margin-top: .15rem; }
 .trait-copy { display: grid; gap: .12rem; min-width: 0; }
-.trait-copy code {
+.trait-title { display: flex; align-items: center; gap: .35rem; min-width: 0; }
+.trait-choice code {
   justify-self: start; width: fit-content; font-size: .74rem; overflow-wrap: anywhere;
 }
 .trait-copy .doc { margin: 0; font-size: .76rem; }
+.trait-toggle > .helptext { margin: .45rem 0 .1rem 1.35rem; }
 
 /* Long-form help: the ? buttons on groups and fields, and the panels they
    open. The same text backs the Reference tab. */

--- a/rust/tcl-spec-studio/web/src/studio.ts
+++ b/rust/tcl-spec-studio/web/src/studio.ts
@@ -61,6 +61,7 @@ import type {
   TestInspection,
   TestReport,
   TestToken,
+  Variant,
 } from "./types.js";
 
 const GITHUB_REPO = "bitwisecook/tcl-lsp";
@@ -2236,6 +2237,10 @@ function boot(): void {
 
       editors = makeEditors({
         catalogues: schema.catalogues,
+        variantHelp: (variant: Variant) => {
+          const panel = helpWithExample(variant.doc, variant.example);
+          return { button: helpButton(panel, variant.key), panel };
+        },
         newSubcommand: () => JSON.parse(wasm.new_subcommand()) as Draft,
         buildSubcommandForm: (container, draft, onChange) => {
           buildForm(container, schema.subcommand, draft, "subcommand", () => {


### PR DESCRIPTION
## Summary

- Put a (?) documentation control beside every generated catalogue item in the Spec tab.
- Render the registry-owned description and end-to-end example directly beneath the selected item.
- Keep the help control outside the checkbox label so opening documentation never changes the trait selection.
- Preserve tight token-sized trait labels and the command-carrier highlight contract.

## Validation

- Browser-tested all 187 generated catalogue items have help controls.
- Browser-tested EXPANSION_ESCAPE_SAFE highlights only puts and DEFERS_BODY highlights only proc.
- Browser-tested help leaves both checkboxes unchanged.
- Web format, lint, typecheck, and 32 unit tests pass.
- Spec Studio WASM production build passes.
- make rust-check passes.
- make prep-pr passes.