### PR TITLE
Fix TclOO list-built self callback navigation

### DIFF
--- a/docs/CORPUS.md
+++ b/docs/CORPUS.md
@@ -1,0 +1,307 @@
+# External corpus sources
+
+This is the source catalogue for the external corpus work tracked by
+[#1181](https://github.com/bitwisecook/tcl-lsp/issues/1181).  It describes
+where to obtain material and why it is useful; it does **not** vendor or cache
+third-party source.  Downloaded checkouts, generated indexes, and experimental
+reductions must stay outside the repository (for example in a temporary
+directory or the ignored `scripts/perf/corpus/` directory).
+
+`scripts/perf/MANIFEST.toml` is the sole machine-readable benchmark contract:
+it contains the canonical clone URLs and exact commit IDs.  This document must
+not duplicate those IDs, as a stale duplicate is worse than no duplicate.
+
+## Status and fetch hygiene
+
+- **Benchmark-pinned** means a repository is one of the 35 public entries in
+  the revisioned performance corpus.  Its exact SHA, fetch command, scope and
+  file-selection rules are in [the manifest](../scripts/perf/MANIFEST.toml).
+  The one optional private entry has the same contract, but is fetched only
+  with credentials and `--include-private`; its source list is deliberately
+  not reproduced here.
+- **Research candidate** means it is valuable for a review, focused fixture or
+  a future benchmark revision, but is *not* an implied benchmark addition.
+  Adding, removing, or moving a benchmark pin changes the workload: update the
+  manifest revision and regenerate comparable measurements as described in
+  [the performance README](../scripts/perf/README.md).
+- Fetch to a disposable or ignored location, record the URL, revision and
+  retrieval date with any finding, and inspect the upstream licence before
+  copying even a small fixture.  Prefer a hand-written minimal regression test
+  in-tree; retain an attribution/link when a test is reduced from a source.
+- "Created" and "last push" below are GitHub metadata observed on **2026-08-24**
+  (a last push is not a release or a guarantee of maintenance).  "Dialect
+  guess" is an analyst's intended-language guess, not an assertion by the
+  upstream project or a tcl-lsp auto-detection result.  `NOASSERTION` means
+  GitHub did not supply an SPDX identifier: consult the canonical licence.
+
+## Machine-pinned benchmark sources
+
+These are deliberately grouped as the manifest groups, not ranked by quality.
+The short notes say what a targeted search should look for in each source.
+
+| Group / repository | Created; last push observed | Licence metadata | Dialect guess | Concise coverage / style note |
+| --- | --- | --- | --- | --- |
+| georgtree / [SpiceGenTcl](https://github.com/georgtree/SpiceGenTcl) | 2024; 2026-08-11 | NOASSERTION | Tcl 8.6 + TclOO | SPICE tooling; package/source forest, class-heavy application code. |
+| georgtree / [tclopt](https://github.com/georgtree/tclopt) | 2025; 2026-06-18 | MIT | Tcl 8.6+ | Option parsing and declarative CLI-like APIs. |
+| georgtree / [ruff](https://github.com/georgtree/ruff) | 2025; 2025-08-13 | BSD-2-Clause | Tcl 8.6+ | Documentation generator; TclOO and command-prefix library style. |
+| georgtree / [argparse](https://github.com/georgtree/argparse) | 2025; 2026-06-25 | MIT | Tcl 8.6+ | Compact argument grammar, `switch`/list-driven parsing. |
+| georgtree / [tcl_tools](https://github.com/georgtree/tcl_tools) | 2024; 2025-07-22 | MIT | Tcl 8.6+ | Utility package collection; `source` and maths helpers. |
+| georgtree / [tclinterp](https://github.com/georgtree/tclinterp) | 2024; 2026-06-15 | LGPL-2.1 | Tcl 8.6+ | Interpreter/metaprogramming code; nested evaluation and command names. |
+| georgtree / [tclmeasure](https://github.com/georgtree/tclmeasure) | 2025; 2026-06-14 | LGPL-2.1 | Tcl 8.6+ | Measurement utility; small modern procedure corpus. |
+| georgtree / [extexpr](https://github.com/georgtree/extexpr) | 2025; 2026-06-04 | LGPL-2.1 | Tcl 8.6+ | Extended-expression package; expression/list boundary cases. |
+| nico-robert / [ticklecharts](https://github.com/nico-robert/ticklecharts) | 2022; 2025-07-04 | MIT | Tcl/Tk 8.6 | Chart widgets; Tk callback and option-heavy style. |
+| nico-robert / [tomato](https://github.com/nico-robert/tomato) | 2021; 2026-01-20 | NOASSERTION | Tcl 8.6+ | TclOO framework; inheritance and object command idioms. |
+| nico-robert / [pix](https://github.com/nico-robert/pix) | 2024; 2026-08-05 | NOASSERTION | Tcl/Tk 8.6+ | Modern Tk/image application code. |
+| nico-robert / [zesty](https://github.com/nico-robert/zesty) | 2025; 2026-01-08 | MIT | Tcl/Tk 8.6+ | Small modern Tk package. |
+| nico-robert / [haru](https://github.com/nico-robert/haru) | 2022; 2025-07-08 | NOASSERTION | Tcl/Tk 8.6+ | GUI/library code and object-facing APIs. |
+| nico-robert / [implottk](https://github.com/nico-robert/implottk) | 2022; 2023-01-19 | MIT | Tcl/Tk 8.6 | Older plotting/Tk code; useful contrast with active projects. |
+| tcltk / [tcllib](https://github.com/tcltk/tcllib) | 2012; 2026-08-15 | NOASSERTION | Tcl 8.4–9 | Canonical broad pure-Tcl library corpus; package conventions and compatibility style. |
+| tcltk / [tklib](https://github.com/tcltk/tklib) | 2012; 2026-07-10 | NOASSERTION | Tcl/Tk 8.4–8.6 | Tk megawidgets, bindings and legacy-compatible packages. |
+| tcltk / [tk](https://github.com/tcltk/tk) | 2011; 2026-08-24 | NOASSERTION | Tk / Tcl core | Canonical Tk scripts, widget bindings and percent substitutions. |
+| aplsimple / [pave](https://github.com/aplsimple/pave) | 2019; 2026-07-08 | MIT | Tcl/Tk 8.6 | Editor-like TclOO/Tk application style. |
+| aplsimple / [alited](https://github.com/aplsimple/alited) | 2021; 2026-08-20 | MIT | Tcl/Tk 8.6 | Large editor application; UI callbacks and project-wide procedures. |
+| other / [XilinxTclStore](https://github.com/Xilinx/XilinxTclStore) | 2013; 2026-08-21 | NOASSERTION | Vivado Tcl dialect | Vendor EDA command DSL, configuration scripts and versioned APIs. |
+| other / [OSVVM-Scripts](https://github.com/OSVVM/OSVVM-Scripts) | 2019; 2026-08-20 | NOASSERTION | EDA Tcl dialect | Simulator/build orchestration and generated/configuration-style Tcl. |
+| irules-kaiwilke / [RADIUS Server](https://github.com/KaiWilke/F5-iRule-RADIUS-Server-Stack) | 2022; 2026-03-03 | GPL-3.0 | F5 iRules | Long, deeply nested iRule procedures; binary formats and events. |
+| irules-kaiwilke / [RADIUS Client](https://github.com/KaiWilke/F5-iRule-RADIUS-Client-Stack) | 2022; 2026-03-03 | GPL-3.0 | F5 iRules | Client counterpart; event-driven network handling. |
+| irules-kaiwilke / [Natural Speech Expression](https://github.com/KaiWilke/F5-Natural-Speech-Expression) | 2023; 2023-02-02 | GPL-3.0 | F5 iRules | Expression/compiler-like iRule code; older activity. |
+| irules-kaiwilke / [F5CrowdSRC](https://github.com/KaiWilke/F5CrowdSRC) | 2022; 2022-11-25 | GPL-3.0 | F5 iRules | Community iRule examples; frozen early snapshot. |
+| irules-kaiwilke / [PrismJS grammar](https://github.com/KaiWilke/F5-PrismJS-iRule-Language-Definition) | 2023; 2026-03-03 | GPL-3.0 | iRules metadata | Not executable Tcl; independent keyword/grammar reference. |
+| irules-f5devcentral / [agility labs](https://github.com/f5devcentral/f5-agility-labs-irules) | 2017; 2026-03-04 | MIT | F5 iRules | Vendor teaching examples and event idioms. |
+| irules-f5devcentral / [irules-toolbox](https://github.com/f5devcentral/irules-toolbox) | 2020; 2025-03-20 | MIT | F5 iRules | Reusable recipes across HTTP/TCP/LB namespaces. |
+| irules-community / [TesTcl](https://github.com/landro/TesTcl) | 2012; 2023-11-01 | BSD-3-Clause | F5 iRules + Tcl | iRule unit-test library; mocks plus executable rules. |
+| irules-community / [f5](https://github.com/e-XpertSolutions/f5) | 2016; 2017-10-26 | MIT | F5 iRules | Historical community rules. |
+| irules-community / [iRules](https://github.com/megamattzilla/iRules) | 2019; 2026-06-11 | NOASSERTION | F5 iRules | Active community collection, varied file naming. |
+| irules-community / [f5-irules-json](https://github.com/JuergenMang/f5-irules-json) | 2024; 2026-05-13 | GPL-3.0 | F5 iRules | Recent JSON/iRules-focused patterns. |
+| irules-community / [simple-sideband](https://github.com/pwhitef5/simple-sideband) | 2023; 2025-07-10 | Apache-2.0 | F5 iRules | Sideband networking callbacks and state. |
+| irules-community / [HTTP Debug iRule](https://github.com/0xHiteshPatel/HTTP_Debug_iRule) | 2015; 2015-07-02 | GPL-2.0 | F5 iRules | Single historical debugging rule. |
+| irules-community / [f5-irules](https://github.com/erkac/f5-irules) | 2021; 2023-09-21 | NOASSERTION | F5 iRules | Community snippets; limited recent activity. |
+| private / `tcl-lsp-testsrc` (optional; see manifest) | 2026; 2026-07-04 | private; licence/provenance are access-controlled | F5 iRules aggregate | Publicly sourced iRule aggregate used only with credentials; do not enumerate, copy, or treat it as a public source catalogue. |
+
+## Review and research candidates (not benchmark-pinned)
+
+These candidates were identified during the #1701 callback review.  They are
+not an endorsement to add every repository to a timing workload; first search
+for distinct syntax and avoid vendored copies.  Dates again are GitHub metadata
+observed on 2026-08-24 unless explicitly marked as a non-GitHub canonical
+source.
+
+| Source | Created; last activity observed | Licence/status | Intended-dialect guess | Why keep it in the research set / canonical-source note |
+| --- | --- | --- | --- | --- |
+| [jianiau/ezdit](https://github.com/jianiau/ezdit) | 2016; 2016-10-20 | NOASSERTION; historical candidate | Tcl/Tk 8.6 | Editor code: older Tk binding/callback style.  Do not mistake inactivity for incompatibility. |
+| [tcltk/bwidget](https://github.com/tcltk/bwidget) | 2013; 2026-03-20 | NOASSERTION (BSD-style upstream); active | Tcl/Tk 8.4+ | Canonical megawidgets; option schemas and binding-heavy Tk code. |
+| [tcltk/itcl](https://github.com/tcltk/itcl) | 2012; 2026-08-24 | NOASSERTION (Tcl-style upstream); active | \[incr Tcl\], Tcl/Tk | Third OO family: visibility wrappers, methods and object callbacks. |
+| [gustafn/nsf](https://github.com/gustafn/nsf) (includes NX) | 2014; 2026-07-06 | NOASSERTION; active | NSF/NX, Tcl 8.6+ | Canonical maintained NSF/NX source; rich meta-object, filters and method dispatch. |
+| [XOTcl canonical project](https://xotcl.org/) / [OpenACS xotcl-core](https://github.com/openacs/xotcl-core) | 2000; canonical site changed 2025-06-21; OpenACS mirror 2011; 2026-05-24 | upstream terms required; canonical distribution plus real-use mirror | XOTcl, Tcl 8.x | XOTcl's own release history begins in 2000; use the canonical distribution for language tests and the OpenACS mirror only for application usage.  Do not duplicate vendored XOTcl copies. |
+| [StefanSchippers/xschem](https://github.com/StefanSchippers/xschem) | 2020; 2026-08-23 | NOASSERTION; active | Tcl/Tk + EDA DSL | Large current EDA application; UI and schematic-command style distinct from Vivado. |
+| [tcltk/thread](https://github.com/tcltk/thread) | 2013; 2026-08-24 | NOASSERTION; active | Tcl Thread extension | Thread/event callback registration and cross-interpreter idioms. |
+| [TclTLS canonical Fossil](https://core.tcl-lang.org/tcltls/) | 1997 code lineage; 2026-07-01 release | upstream `license.terms`; active | TclTLS extension, Tcl 8.6/9 | `tls::socket` server callbacks, fileevents and option routing.  Prefer the Fossil project or the maintainer's current release mirror over stale forks. |
+| [tcl-mirror/tclhttpd](https://github.com/tcl-mirror/tclhttpd) | 2016; 2020-01-06 | NOASSERTION; mirror, inactive | TclHttpd / Tcl 8.x | Web-server callback and URL-dispatch corpus; mirror only, retain canonical project provenance. |
+| [TclRAL canonical Fossil](http://chiselapp.com/user/mangoa01/repository/tclral) / [GitHub mirror](https://github.com/tcl-mirror/tclral) | 2006; 2017-08-01 release; mirror 2019; 2021-03-03 | upstream terms required; canonical Fossil plus mirror | TclRAL / Raloo relational Tcl | Relation/value DSL and package style.  Raloo is an associated programming style, not a second copy to pin: use the canonical TclRAL source once. |
+| [tcl-mirror/tclws](https://github.com/tcl-mirror/tclws) | 2015; 2021-12-19 | NOASSERTION; mirror/candidate | Tcl web services | SOAP/web-service callbacks and generated-looking Tcl; use canonical provenance. |
+| [tcler/wub](https://github.com/tcler/wub) | 2015; 2019-03-08 | NOASSERTION; optional/inactive | Wub web server | Optional historical web/server callback corpus; do not include by default without a distinct pattern census. |
+| [Dash-OS/tcl-modules](https://github.com/Dash-OS/tcl-modules) | 2017; 2018-06-06 | MIT; historical | Tcl 8.x modules | Small modular package/application patterns. |
+| [Dash-OS/tcl-cluster](https://github.com/Dash-OS/tcl-cluster) | 2017; 2017-10-23 | MIT; historical | Tcl cluster/distributed code | Remote/event-oriented command dispatch; include only if it contributes non-duplicated shapes. |
+| [flightaware/tclrmq](https://github.com/flightaware/tclrmq) | 2017; 2021-08-19 | BSD-3-Clause; candidate | Tcl/RabbitMQ extension | Message-consumer callbacks and extension API style. |
+| [tcltk/tdbc](https://github.com/tcltk/tdbc) | 2012; 2014-03-20 | NOASSERTION; historical GitHub mirror | Tcl database connectivity | Handle commands and callback-adjacent database APIs; first establish maintained canonical location. |
+| [jdc8/tclzmq](https://github.com/jdc8/tclzmq) | 2012; 2021-12-20 | NOASSERTION; candidate | Tcl/ZeroMQ extension | Socket callback and event-loop API patterns. |
+| [AthenaModel/athena](https://github.com/AthenaModel/athena) | 2015; 2016-02-29 | NOASSERTION; historical | Tcl/Tk application | Larger application/object UI coding style; assess before harvesting. |
+
+### iRulesLX paired Tcl/JavaScript candidates
+
+iRulesLX needs a paired-language corpus: a Tcl iRule names a remote method in
+`ILX::call` or `ILX::notify`, while JavaScript or TypeScript registers that
+method on an `ILXServer`.  Harvesting only `.tcl` files loses the definition
+side needed for cross-language navigation and arity checks.  These public
+origins were verified on 2026-08-24; dates are GitHub creation and last-push
+metadata, and licences are GitHub SPDX metadata unless stated otherwise.
+
+| Source | Created; last push observed | Licence/status | Intended dialects | Distinctive paired patterns |
+| --- | --- | --- | --- | --- |
+| [ArtiomL/f5networks](https://github.com/ArtiomL/f5networks) | 2016; 2018-11-14 | MIT; historical | iRulesLX / Node.js, BIG-IP 12.1+ | Tutorial progression plus RADIUS, GraphQL and WebSocket examples; literal `ILX::call -timeout` names pair with `ILXServer.addMethod`. |
+| [f5devcentral/f5-professional-services](https://github.com/f5devcentral/f5-professional-services) | 2022; 2026-08-06 | NOASSERTION; active vendor collection | iRules/iRulesLX / Node.js | Current risk-engine and Let's Encrypt pairs inside a much broader F5 corpus; select subtrees rather than benchmarking the whole repository. |
+| [Netacea/f5-worker-template-typescript](https://github.com/Netacea/f5-worker-template-typescript) | 2020; 2026-06-30 | GPL-3.0; active | iRulesLX / TypeScript | Modern indirect handler registration, cached handles, repeated calls across HTTP events, and an explicit `RULE_INIT` availability caveat. |
+| [f5se/bigip-ai-scenes-demo](https://github.com/f5se/bigip-ai-scenes-demo) | 2026; 2026-08-20 | NOASSERTION; active F5 example | Current iRulesLX / Node.js | The only real public Tcl `ILX::notify` call site found in this search: a static handle sends repeated one-way audit-log messages. |
+| [Mikej81/f5-samlreplay](https://github.com/Mikej81/f5-samlreplay) | 2018; 2020-10-27 | NOASSERTION; historical | iRulesLX / Node.js | Multiple event handlers call hyphenated literal methods (`saml-request`, `saml-validate`) registered in the paired extension. |
+| [Mikej81/f5-wsstar-ilx](https://github.com/Mikej81/f5-wsstar-ilx) | 2016; 2020-10-27 | NOASSERTION; historical | iRulesLX / Node.js | Several rule variants, one- and two-argument `ILX::init`, and hyphenated WS-Federation/WS-Trust method names. |
+| [Mikej81/ILX-IDAM-AGS](https://github.com/Mikej81/ILX-IDAM-AGS) | 2016; 2016 | NOASSERTION; historical | iRulesLX / Node.js | LDAP RPC with three statically registered remote methods. |
+| [Mikej81/f5-webcifs-ilx](https://github.com/Mikej81/f5-webcifs-ilx) | 2016; 2019 | NOASSERTION; historical | iRulesLX streaming / Node.js | Streaming-only `ILXPlugin`/flow example with no Tcl RPC method registration; useful negative control for cross-language RPC indexing. |
+| [f5devcentral/f5-aws-lambda-proxy](https://github.com/f5devcentral/f5-aws-lambda-proxy) | 2019; 2021-03-30 | MIT; historical vendor example | iRulesLX / Node.js | Compact paired RPC example with literal plugin, extension and method names plus `catch`-based failure handling. |
+| [gregcoward/f5-aws-apigw-proxy](https://github.com/gregcoward/f5-aws-apigw-proxy) | 2019; 2024 | MIT; maintained candidate | iRulesLX / Node.js | Dynamic REST proxy with asynchronous Node-side I/O; separates Tcl's blocking RPC boundary from Node's internal callbacks. |
+| [akhmarov/f5_otp](https://github.com/akhmarov/f5_otp) | 2020; 2022-10-18 | Apache-2.0; historical | APM iRulesLX / Node.js | Plugin, extension, timeout and remote method can all come from `static::` variables; useful negative/unknown case for literal navigation. |
+| [aknot242/apm-ilx-sql-challenge](https://github.com/aknot242/apm-ilx-sql-challenge) | 2019; 2019 | MIT; historical | APM iRulesLX / Node.js | Compact SQL-backed RPC and `catch` error path. |
+| [islam-talaat/F5-IRule-LX-TCL-NodeJS](https://github.com/islam-talaat/F5-IRule-LX-TCL-NodeJS) | 2020; 2024 | NOASSERTION; maintained candidate | iRulesLX / Node.js | DNS response-bit manipulation with an uppercase/underscore remote method name. |
+| [cloudadc/nodejs-honeypot](https://github.com/cloudadc/nodejs-honeypot) | 2020; 2021-03-23 | Apache-2.0; historical | iRulesLX / Node.js | Small raw-text and static-file workspaces; zero-user-argument calls and multiple registered response methods. |
+| [cloudadc/nodejs-doh](https://github.com/cloudadc/nodejs-doh) | 2020; 2020 | Apache-2.0; historical | iRulesLX / Node.js | DNS-over-HTTPS resolver RPC; protocol payload handling around the method boundary. |
+| [ximeng890726/DoHDotiRulesLX](https://github.com/ximeng890726/DoHDotiRulesLX) | 2021; 2021 | NOASSERTION; historical | iRulesLX / Node.js | Paired DoH GET, POST and UDP variants; literal mixed-case/underscore remote methods. |
+| [johnalam/F5-iRules-LX-MSSQL](https://github.com/johnalam/F5-iRules-LX-MSSQL) | 2017; 2017 | NOASSERTION; historical | APM iRulesLX / Node.js | SQL RPC with duplicate Tcl variants; deduplicate before counting. |
+| [steveh565/ilx-zlib](https://github.com/steveh565/ilx-zlib) | 2019; 2020-07-10 | NOASSERTION; historical | iRulesLX / Node.js | Calls embedded inside `lindex` and `catch`, multiple rule variants, and vendored `f5-nodejs`; exclude vendored runtime copies from counts. |
+| [codygreen/F5-MFA](https://github.com/codygreen/F5-MFA) | 2016; 2017-12-07 | NOASSERTION; archived | APM iRulesLX / Node.js | Four literal remote methods spanning enrollment and verification, with handles created in different event lifetimes. |
+| [bepsoccer/iRulesLX](https://github.com/bepsoccer/iRulesLX) | 2017; 2017-04-27 | MIT; historical | APM iRulesLX / Node.js | Route53 update RPC with a larger fixed argument vector and repeated call shape. |
+| [colin-stubbs/f5-bigip-ilx-api](https://github.com/colin-stubbs/f5-bigip-ilx-api) | 2019; 2019-02-13 | Apache-2.0; archived | iRulesLX / Node.js | Deliberately dynamic remote method selected from an HTTP path; paired `addMethod` names look like URI paths and must not be mistaken for Tcl commands. |
+
+The manifest-pinned optional private aggregate was also checked at its exact
+manifest revision.  It contains 21 Tcl files mentioning ILX commands: 26
+`ILX::init` occurrences, 33 `ILX::call` occurrences, and no `ILX::notify`
+occurrence.  Those are physical occurrence counts, not distinct applications;
+the aggregate contains public-source mirrors.  Its upstream inventory remains
+private, and this document intentionally names only independently verified
+public origins.  A paired research sweep should fetch the public repositories
+above to a disposable location rather than copy their JavaScript into the
+aggregate or this repository.
+
+A separate public iRulesLX research sweep over 21 repositories found 28 Tcl
+files and 38 non-vendored JavaScript files, with 33 `ILX::init`, 40
+`ILX::call`, 17 `ILXServer`, and 29 `addMethod` occurrences.  Six calls used
+`-timeout` and 15 were wrapped in `catch`; no real Tcl `ILX::notify` occurred
+in that particular set.  Counts include variants and documentation snippets,
+so they describe syntax coverage rather than deployments.  The separately
+listed `f5se/bigip-ai-scenes-demo` adds the verified public notify pattern.
+
+### Source collections and fixture references
+
+These are sources for small, attributable fixtures and pattern taxonomy, not
+repositories to benchmark wholesale.
+
+| Collection | Status / age and recency observed | Pattern value |
+| --- | --- | --- |
+| [Tcl Wiki: callback](https://wiki.tcl-lang.org/page/callback), [command prefix](https://wiki.tcl-lang.org/page/command%2Bprefix), and [bindings and variable substitution](https://wiki.tcl-lang.org/page/Bindings%2Band%2Bvariable%2Bsubstitution) | Community pages; the search index observed updates in 2026, with material spanning older Tcl eras | Defines list-built prefixes, bind `+script`, appended arguments, and define-time vs fire-time substitution. |
+| [TclOO callback discussion](https://stackoverflow.com/questions/47527830/tcloo-private-method-and-method-as-callback) | 2017 answer, checked 2026-08-24 | `namespace code [list my ...]`, public/exported-method boundary and object callback construction. |
+| [TIP 379](https://core.tcl-lang.org/tips/doc/trunk/tip/379.md) and [TIP 419](https://core.tcl-lang.org/tips/doc/trunk/tip/419.md) | 2011/2012-era TIPs, current canonical TIP archive observed 2026-08-24 | Explicit command-prefix contracts and Tk binding substitution/append semantics. |
+| [TclOO: Past, Present and Future](https://www.tclcommunityassociation.org/wub/proceedings/Proceedings-2009/proceedings/tcloo/TclOO_Past_Present_Future.pdf) and [Adventures in TclOO](https://www.tclcommunityassociation.org/wub/proceedings/Proceedings-2010/DonalFellows/Adventures-in-TclOO.pdf) | 2009/2010 conference papers, archival sources | Historical TclOO idioms worth reducing to fixtures, not copying wholesale. |
+| [F5 Community iRulesLX search](https://community.f5.com/search?q=iRulesLX+ILX+call), [Getting Started part 3](https://community.f5.com/kb/technicalarticles/getting-started-with-irules-lx-part-3-coding--exception-handling/276218), and [Twilio paired example](https://community.f5.com/kb/codeshare/send-an-one-time-password-otp-via-the-twilio-sms-gateway/291444) | Material from 2016 onward; search and pages checked 2026-08-24 | Real paired Tcl/Node snippets, timeout/error handling, the payload limit, and event-context usage.  Search hits mentioning that `ILXServer.listen()` receives both call and notify traffic are not evidence of a Tcl `ILX::notify` call. |
+| [F5 iRulesLX API reference](https://clouddocs.f5.com/api/irules-lx/APIReference.html), [`ILX::call`](https://clouddocs.f5.com/api/irules/ILX__call.html), and [`ILX::notify`](https://clouddocs.f5.com/api/irules/ILX__notify.html) | Product documentation updated in 2026; commands introduced in BIG-IP 12.0/available generally in 12.1 and deprecated in BIG-IP Next 20.0.1 | Primary semantic oracle for RPC direction, timeout option, return shapes, payload limits, availability and deprecation; use Community/GitHub only for usage patterns. |
+
+## Callback semantic taxonomy
+
+Corpus searches must distinguish callback *semantics*, not merely search for a
+word such as `command` or `script`.  The Tcl Wiki, core manuals, Tcl/Tk source,
+tcllib, and iRules corpus show at least these families:
+
+- **Complete scripts** such as `after`, `fileevent`, `chan event`, and
+  `package ifneeded`.  They may be built with `list`, but the consumer executes
+  a whole script and does not necessarily append arguments.
+- **Command prefixes with appended arguments** such as `lsort -command`,
+  `regsub -command`, `socket -server`, `fcopy -command`, Tk widget callbacks,
+  and many trace registrations.  Their static contract includes the number or
+  shape of arguments supplied by the consumer.
+- **Namespace-wrapped or lambda prefixes**, commonly `namespace code [list
+  ...]` and `apply`.  The wrapper affects command resolution and must not be
+  flattened into an ordinary script by spelling alone.
+- **Stored and composed callbacks** placed in variables, arrays or dicts and
+  later invoked with `{*}`, `eval`, `uplevel`, or a package-specific dispatcher.
+  These require data-flow proof rather than local syntax recognition.
+- **Protocol callbacks** such as reflected channels (`chan create` / `chan
+  push`), whose receiver supplies a method name and method-specific arguments.
+- **Resumable commands** created by `coroutine`.  These participate in deferred
+  and event-driven programs, but are continuations rather than ordinary
+  fixed-arity callbacks.
+- **Event handlers and event producers** in iRules.  `when EVENT` owns a
+  structural event body; data collection and notification commands can cause a
+  later event, but they do not receive a Tcl command prefix.
+- **Remote calls and notifications** such as iRulesLX `ILX::call` and
+  `ILX::notify`.  These target JavaScript extension methods, not Tcl callbacks,
+  and need cross-language rather than TclOO method navigation.
+
+The existing registry describes much of the structural surface with
+`ArgRole::Body`, `ArgRole::CommandPrefix`, appended arity, and
+builds/wraps-command-prefix traits.  Future registry work should preserve the
+distinctions above and, where diagnostics need them, add typed timing,
+execution-context, error-routing, repeatability/cancellation, or protocol
+metadata.  It should not teach an analyser or LSP consumer a list of command
+spellings.
+
+### Normalized callback census
+
+The 35 machine-pinned public repositories were scanned by source/test-like
+file and content hash.  Of 3,763 files, 3,681 were unique within their corpus
+family: 425/424 iRules, 473/456 EDA, 2,067/2,023 tcllib+tklib, 728/708 Tk and
+applications, and 70/70 other Tcl.  The 2.2% duplicate rate is small, but raw
+occurrence counts below remain lexical lower bounds rather than semantic call
+counts.
+
+Exact prefix-builder substitutions found were 3 `[callback ...]`, 361
+`[mymethod ...]`, 33 `[myproc ...]`, 7 `[mytypemethod ...]`, 2 `[itcl::code
+...]`, and 172 `[namespace code ...]`.  Anchored command-head searches found:
+
+| Corpus family | `after` | `fileevent` | `trace` | `bind` | `interp alias` | `coroutine` | `fcopy` |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| iRules | 6 | 0 | 0 | 0 | 0 | 0 | 0 |
+| EDA | 10 | 3 | 4 | 0 | 20 | 0 | 0 |
+| tcllib + tklib | 284 | 118 | 129 | 1,368 | 451 | 22 | 42 |
+| Tk + applications | 394 | 5 | 57 | 1,459 | 50 | 10 | 0 |
+| other Tcl | 1 | 0 | 0 | 0 | 36 | 0 | 0 |
+
+The census also found about 3,056 callback-shaped `{*}$value` expansions,
+1,098 dynamic `uplevel` calls, and 196 dynamic `eval` calls.  Those figures
+argue against treating every list or string as executable.  Analysis should
+start at registry-declared sinks and builders, memoize decoded prefix spans,
+and use a bounded backward slice for stored prefixes.
+
+The most important registry gap is a typed prefix-result descriptor.  The
+current `BUILDS_COMMAND_PREFIX` flag says that builder argument zero becomes
+the returned command head; that is false for TclOO `callback`/`mymethod`, snit
+`mymethod`/`myproc`/`mytypemethod`, and `itcl::code`, where an object or family
+dispatcher is implicit.  A boolean flag would therefore create incorrect
+navigation.  A future descriptor needs to distinguish direct head arguments,
+current-object methods, snit instance/type methods, and Itcl object/method
+forms.  Callback slots also need an invocation-phase axis separate from
+argument shape: immediate/reentrant, stored/deferred, conditionally deferred,
+blocking external RPC, and fire-and-forget external dispatch.
+
+Additional high-confidence audits are HTTP/WebSocket callback options,
+tcllib's cron/FTP/RC4/textutil-patch/uevent/namespacex handlers, Tk subcommand
+deferral (`canvas bind`, `wm protocol`, `chan event`), and EDA `-rule_body` /
+`-command` options.  iRulesLX commands must instead describe external method
+dispatch: `ILX::init` is a one- or two-argument handle producer, while
+`ILX::call` and `ILX::notify` require a handle and method after their options.
+Their method slots are neither Tcl bodies nor Tcl command prefixes.
+
+Two concrete audit leads came from this review: `interp bgerror` appears to
+supply exactly two arguments to its handler on supporting Tcl releases, and
+tcllib's `fileutil::updateInPlace` invokes a supplied command prefix after
+appending the file contents.  Both require primary-source/release verification
+before changing registry data.  Generated tcllib rows describing callbacks
+(including websocket, HTML parsing, and channel utilities) also need a
+descriptor-coverage audit rather than broad name-based inference.
+
+The normalized iRules source corpus contains 742 unique `when EVENT` handlers,
+seven `clientside` blocks, six anchored `after` calls, and 16 TCP/HTTP/SSL collect
+operations that lead to later event handling.  It contains no `ILX::init`,
+`ILX::call`, or `ILX::notify` example.  Raw counts are physical-file counts:
+the one known duplicate is an SSL Orchestrator ICAP rule variant, and the
+agility-lab ILX material is documentation rather than source.  Registry-owned
+command-to-event provenance is tracked separately from Tcl callback-prefix
+analysis.
+
+## Callback-pattern coverage for #1701
+
+The #1701 regression is a deliberately narrow, statically knowable
+list-built command prefix whose receiver is `[self]` or `[self object]`.
+It is recognised in registry-declared `ArgRole::Body` and
+`ArgRole::CommandPrefix` positions.  The wider corpus taxonomy is role-based:
+candidate callback positions must be declared as **`ArgRole::Body` or
+`ArgRole::CommandPrefix`**, never inferred from a command spelling.  The
+following matrix keeps future corpus searches honest about what has and has not
+been covered; composed, wrapped, stored, quoted, and dynamically constructed
+prefixes remain research targets unless a corresponding registry contract and
+regression are landed.
+
+| Pattern | Registry role / form | Fixture/corpus search status | Expected static treatment |
+| --- | --- | --- | --- |
+| `bind $w <Event> [list [self] method %x %y]` | `ArgRole::Body` | #1701 regression | Reference to a public method; rename/find-references must include it. |
+| `[list [self object] method ...]` | `ArgRole::Body` | #1701 regression parity | Same as `[self]`. |
+| `lsort -command [list [self] compare] ...` | `ArgRole::CommandPrefix` | #1701 regression parity | Same exact list-built object-method target; the consumer appends arguments. |
+| Other generic command-prefix consumers (`socket -server`, widget `-command`, trace, hook) | `ArgRole::CommandPrefix`, as declared | Search candidates/Wiki/TIPs | The exact #1701 shape is recognised when both the role and builder trait prove it; audit registry coverage and composed forms separately. |
+| `namespace code [list my method ...]` | Wrapper around Body/CommandPrefix semantics | TclOO callback source collection | Separate wrapper/prefix form; add a focused fixture when resolver semantics are modelled. |
+| `callback` / `mymethod` helper APIs | Deferred-method builder semantics, not a consumer slot | Corpus search target | Do not infer from a helper name; require a registry-owned target descriptor or a proven wrapper model. |
+| Quoted script, `bind ... +script`, or additive/concatenated prefix | Body or CommandPrefix, but not a single list-built prefix | Wiki/TIP 419 search target | Not equivalent to the #1701 form; remain conservative until represented. |
+| Stored then later invoked/mutated prefix (`set cb [list ...]`, `lappend`, `eval`, `{*}$cb`) | Value/data-flow, not a direct role-local form | Corpus search target | Data-flow problem; not a direct reference unless a future analysis proves it. |
+| Inert list value (`set x [list [self] method]`) | Not Body/CommandPrefix | #1701 negative regression | Not a callback reference. |
+| Shadowed `list` command | Body/CommandPrefix position but wrong resolved builder | #1701 negative regression | Not a list-builder reference; command identity must be registry-resolved. |
+| Unexported/private target captured through object command | `ArgRole::Body` | #1701 negative regression | Not externally dispatchable; do not claim it as a callback reference. |
+
+When adding a result from any row above to #1181, state: canonical source,
+commit/release used, licence check, intended dialect, discovered pattern,
+whether it duplicates an existing source, and whether it is proposed as a
+micro-fixture, a manual sweep input, or a benchmark-pin change.

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -276,9 +276,8 @@ pub fn definition_with(
     let line_index = LineIndex::new(source);
 
     let decl_byte_offset = byte_offset_at(&line_index, source, line, character);
-    // Steps 1a-1d: everything decided by the cursor's *position* rather than
-    // by resolving a bareword — a `$var` read, a bareword declaration, an
-    // `expr` math-function call, and the two positions that are pure data.
+    // Steps 1a-1d are cursor-position decisions: a `$var` read, bareword
+    // declaration, `expr` math-function call, and two pure-data positions.
     // `Some` is definitive (including `Some(vec![])`).
     if let Some(result) = position_definition(
         source,
@@ -298,6 +297,11 @@ pub fn definition_with(
     let Some((word, _start, _end)) = find_word_span_at_position(source, line, character) else {
         return Vec::new();
     };
+    if let Some(result) =
+        list_built_self_method_definition(source, &line_index, analysis, &word, decl_byte_offset)
+    {
+        return result;
+    }
     // `$obj method` / `[$obj method]` — when the cursor sits on
     // the method-name token of an instance-method call and the
     // instance variable's class is known, jump to the method
@@ -337,11 +341,10 @@ pub fn definition_with(
     // `next` / `nextto` inside a method body — jump to the super-method in
     // the MRO chain that the enclosing method overrides (`next`), or to the
     // named class's copy of it (`nextto Cls`).
-    if is_next_chain_keyword_in(crate::profile_for_dialect(&analysis.dialect), &word)
-        && let Some(span) =
-            next_dispatch_target(analysis, source, &line_index, line, character, &word)
+    if let Some(result) =
+        next_dispatch_definition(analysis, source, &line_index, line, character, &word)
     {
-        return vec![span_to_range(source, &line_index, span)];
+        return result;
     }
     // Prefer the declaration whose own name span covers the cursor (so a
     // same-named proc in another namespace's own decl resolves to *that*
@@ -441,6 +444,43 @@ pub fn definition_with(
         return vec![span_to_range(source, &line_index, span)];
     }
     Vec::new()
+}
+
+fn list_built_self_method_definition(
+    source: &str,
+    line_index: &LineIndex,
+    analysis: &AnalysisResult,
+    word: &str,
+    cursor_offset: u32,
+) -> Option<Vec<LspRange>> {
+    let (provider, is_classmethod) = crate::references::list_built_self_method_target_at_cursor(
+        source,
+        crate::profile_for_dialect(&analysis.dialect),
+        analysis,
+        word,
+        cursor_offset,
+    )?;
+    let class_def = analysis.all_classes.get(&provider)?;
+    let method = if is_classmethod {
+        class_def.class_methods.get(word)
+    } else {
+        class_def.methods.get(word)
+    }?;
+    Some(vec![span_to_range(source, line_index, method.name_span)])
+}
+
+fn next_dispatch_definition(
+    analysis: &AnalysisResult,
+    source: &str,
+    line_index: &LineIndex,
+    line: u32,
+    character: u32,
+    word: &str,
+) -> Option<Vec<LspRange>> {
+    is_next_chain_keyword_in(crate::profile_for_dialect(&analysis.dialect), word)
+        .then(|| next_dispatch_target(analysis, source, line_index, line, character, word))
+        .flatten()
+        .map(|span| vec![span_to_range(source, line_index, span)])
 }
 
 /// The declaration span a word reaches through the document's command-table

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -694,6 +694,33 @@ pub fn references_in_program(
         return Vec::new();
     };
 
+    let cursor_offset = crate::definition::byte_offset_at(&line_index, source, line, character);
+    if let Some((provider, is_classmethod)) =
+        list_built_self_method_target_at_cursor(source, dialect, analysis, &word, cursor_offset)
+        && let Some((decl, mut sites)) =
+            method_references_for_class(source, dialect, analysis, &provider, &word, is_classmethod)
+    {
+        sites.extend(method_next_dispatch_spans(
+            analysis,
+            source,
+            dialect,
+            &provider,
+            &word,
+            is_classmethod,
+        ));
+        let mut out = Vec::new();
+        if include_declaration {
+            out.push(span_to_range(source, &line_index, decl));
+        }
+        out.extend(
+            sites
+                .into_iter()
+                .map(|span| span_to_range(source, &line_index, span)),
+        );
+        dedup_ranges(&mut out);
+        return out;
+    }
+
     // Class references (checked first, before proc names).
     if let Some(out) = class_references(&ctx, &word) {
         return out;
@@ -1487,12 +1514,12 @@ pub(crate) fn method_references_for_class(
 ) -> Option<(tcl_lexer::Span, Vec<tcl_lexer::Span>)> {
     use tcl_lexer::Span;
     let class_def = analysis.all_classes.get(class_q)?;
-    let decl_span = if is_classmethod {
+    let method_def = if is_classmethod {
         class_def.class_methods.get(method)
     } else {
         class_def.methods.get(method)
-    }
-    .map(|m| m.name_span)?;
+    }?;
+    let decl_span = method_def.name_span;
 
     let mut call_spans: Vec<Span> = Vec::new();
     // Intra-class `my method` dispatch: `self`/`my` is bound to the instance
@@ -1520,29 +1547,43 @@ pub(crate) fn method_references_for_class(
     let hierarchy = analysis.class_hierarchy();
     if is_classmethod {
         let bodies: Vec<Span> = collect_member_bodies_scoped(class_def, true);
-        call_spans.extend(scan_my_method_sites(
+        call_spans.extend(scan_method_sites(
             source,
             dialect,
             &bodies,
             method,
             Some(decl_span),
+            method_def.visibility == "public",
         ));
     } else {
-        let mut bodies: Vec<Span> = collect_member_bodies_scoped(class_def, false);
+        let bodies: Vec<Span> = collect_member_bodies_scoped(class_def, false);
+        call_spans.extend(scan_method_sites(
+            source,
+            dialect,
+            &bodies,
+            method,
+            Some(decl_span),
+            method_def.visibility == "public",
+        ));
         for (other_q, other_cd) in &analysis.all_classes {
             if other_q.as_str() != class_q
                 && hierarchy.method_target(other_q, method) == Some(class_q)
             {
-                bodies.extend(collect_member_bodies_scoped(other_cd, false));
+                // An inheritor can export or unexport this inherited method,
+                // so provider visibility cannot prove whether a captured
+                // `[self]` object command is callable for that receiver.
+                // Preserve internal `my` references and abstain from inherited
+                // callbacks until #1705 models effective receiver visibility.
+                let inherited_bodies = collect_member_bodies_scoped(other_cd, false);
+                call_spans.extend(scan_my_method_sites(
+                    source,
+                    dialect,
+                    &inherited_bodies,
+                    method,
+                    Some(decl_span),
+                ));
             }
         }
-        call_spans.extend(scan_my_method_sites(
-            source,
-            dialect,
-            &bodies,
-            method,
-            Some(decl_span),
-        ));
     }
     // External `$obj method` / bare `ClassName method` sites.
     call_spans.extend(find_obj_method_call_sites(
@@ -1561,6 +1602,75 @@ pub(crate) fn method_references_for_class(
     // 8.6.16 alike).
     call_spans.extend(member_reference_spans(source, dialect, class_def, method));
     Some((decl_span, call_spans))
+}
+
+/// Resolve a list-built `[self]` callback method word under `cursor_offset`
+/// to the class that provides it and the matching method table.
+///
+/// This is the cursor-side twin of [`method_references_for_class`].  It first
+/// resolves the enclosing receiver through the ordinary `TclOO` hierarchy, then
+/// accepts the position only when the shared declaration-driven scan reports
+/// the exact word span as one of its callback references.  Definition,
+/// references, prepare-rename, and rename therefore cannot infer a callback
+/// target from looser syntax than the code lens uses.
+pub(crate) fn list_built_self_method_target_at_cursor(
+    source: &str,
+    dialect: &'static tcl_dialect::DialectProfile,
+    analysis: &AnalysisResult,
+    word: &str,
+    cursor_offset: u32,
+) -> Option<(String, bool)> {
+    let receiver_q = crate::definition::enclosing_class_at(analysis, cursor_offset)?;
+    let receiver = analysis.all_classes.get(receiver_q)?;
+    let is_classmethod = receiver
+        .class_methods
+        .values()
+        .any(|method| span_contains_offset(method.body_span, cursor_offset));
+    let bucket = if is_classmethod {
+        crate::definition::MethodBucket::Class
+    } else {
+        crate::definition::MethodBucket::Instance
+    };
+    let body = if is_classmethod {
+        receiver
+            .class_methods
+            .values()
+            .find(|method| span_contains_offset(method.body_span, cursor_offset))?
+            .body_span
+    } else {
+        receiver
+            .methods
+            .values()
+            .chain(receiver.constructors.iter())
+            .chain(receiver.destructor.iter())
+            .find(|method| span_contains_offset(method.body_span, cursor_offset))?
+            .body_span
+    };
+    // The captured object command dispatches externally when the callback
+    // runs, so an unexported target is not a candidate here.
+    let (provider, _) =
+        crate::oo_dispatch::method_dispatch_provider(analysis, receiver_q, word, true, bucket)?;
+    let provider = provider.to_owned();
+    // Compare against callback-only spans from this one containing body. An
+    // ordinary `my method`, direct `[self] method`, external call, or member
+    // reference must stay on its established resolution path and access mode.
+    list_built_self_callback_sites(source, dialect, &[body], word)
+        .iter()
+        .any(|span| span_contains_offset(*span, cursor_offset))
+        .then_some((provider, is_classmethod))
+}
+
+fn span_contains_offset(span: tcl_lexer::Span, offset: u32) -> bool {
+    span.start() <= offset && offset < span.end()
+}
+
+fn list_built_self_callback_sites(
+    source: &str,
+    dialect: &'static tcl_dialect::DialectProfile,
+    bodies: &[tcl_lexer::Span],
+    method: &str,
+) -> Vec<tcl_lexer::Span> {
+    scan_method_sites_by_kind(source, dialect, bodies, method, None, true, true)
 }
 
 /// Resolve a property's declaration span plus every `my <property>` call
@@ -1833,6 +1943,41 @@ pub(crate) fn scan_my_method_sites(
     method: &str,
     skip: Option<tcl_lexer::Span>,
 ) -> Vec<tcl_lexer::Span> {
+    scan_method_sites(source, dialect, bodies, method, skip, false)
+}
+
+/// [`scan_my_method_sites`] with optional recognition of a list-built,
+/// externally-dispatched `[self]` callback.  The method resolver enables the
+/// latter only for public methods; keeping both shapes in this one traversal
+/// avoids a second full body scan for every code lens.
+fn scan_method_sites(
+    source: &str,
+    dialect: &'static tcl_dialect::DialectProfile,
+    bodies: &[tcl_lexer::Span],
+    method: &str,
+    skip: Option<tcl_lexer::Span>,
+    capture_list_built_self_callbacks: bool,
+) -> Vec<tcl_lexer::Span> {
+    scan_method_sites_by_kind(
+        source,
+        dialect,
+        bodies,
+        method,
+        skip,
+        capture_list_built_self_callbacks,
+        false,
+    )
+}
+
+fn scan_method_sites_by_kind(
+    source: &str,
+    dialect: &'static tcl_dialect::DialectProfile,
+    bodies: &[tcl_lexer::Span],
+    method: &str,
+    skip: Option<tcl_lexer::Span>,
+    capture_list_built_self_callbacks: bool,
+    callbacks_only: bool,
+) -> Vec<tcl_lexer::Span> {
     let registry = crate::registry_for_dialect_profile(dialect);
     let identities =
         tcl_compiler::head_identity::command_head_identities(source, dialect, registry);
@@ -1843,6 +1988,8 @@ pub(crate) fn scan_my_method_sites(
         identities: &identities,
         method,
         skip,
+        capture_list_built_self_callbacks,
+        callbacks_only,
     };
     let mut out: Vec<tcl_lexer::Span> = Vec::new();
     let mut seen: FxHashSet<(u32, u32)> = FxHashSet::default();
@@ -1868,6 +2015,12 @@ struct MyMethodScan<'a> {
     identities: &'a tcl_compiler::head_identity::HeadIdentityMap,
     method: &'a str,
     skip: Option<tcl_lexer::Span>,
+    /// `[list [self] METHOD ...]` later dispatches through the external
+    /// object command and therefore counts only for an exported method.
+    capture_list_built_self_callbacks: bool,
+    /// Suppress direct dispatches while proving a cursor sits on a deferred
+    /// callback target rather than an ordinary method reference.
+    callbacks_only: bool,
 }
 
 /// Scan a brace-delimited body span for `my method` call sites (stripping the
@@ -1917,7 +2070,9 @@ fn scan_my_method_region(
         tcl_lexer::LexerConfig::from_grammar(ctx.dialect.grammar),
     );
     for cmd in &commands {
-        if let (Some(head), Some(name_tok)) = (cmd.argv.first(), cmd.argv.get(1)) {
+        if !ctx.callbacks_only
+            && let (Some(head), Some(name_tok)) = (cmd.argv.first(), cmd.argv.get(1))
+        {
             let h_start = head.span.start() as usize;
             let h_end = head.span.end() as usize;
             // Registry query, not a `== "my"` literal: the self-dispatch
@@ -1956,6 +2111,14 @@ fn scan_my_method_region(
                 }
             }
         }
+        if ctx.capture_list_built_self_callbacks {
+            for span in list_built_self_reference_spans(ctx, cmd) {
+                let key = (span.start(), span.end());
+                if sink.seen.insert(key) {
+                    sink.out.push(span);
+                }
+            }
+        }
         for (inner_start, inner_end) in nested_dispatch_regions_with_identities(
             source,
             ctx.dialect,
@@ -1965,6 +2128,129 @@ fn scan_my_method_region(
         ) {
             scan_my_method_region(ctx, inner_start, inner_end, depth + 1, sink);
         }
+    }
+}
+
+/// Matching method words captured into this command's executable callback as
+/// `[list [self] METHOD ...]` or `[list [self object] METHOD ...]`.
+///
+/// The enclosing resolved registry spec must mark the argument as either a
+/// complete executable [`tcl_registry::ArgRole::Body`] or a first-class
+/// [`tcl_registry::ArgRole::CommandPrefix`], and the inner resolved spec must carry
+/// `BUILDS_COMMAND_PREFIX`; neither a callback consumer nor its builder is
+/// named here. Inert data such as `set x [list [self] METHOD]` therefore
+/// remains data.
+fn list_built_self_reference_spans(
+    ctx: MyMethodScan<'_>,
+    cmd: &tcl_compiler::segmenter::SegmentedCommand,
+) -> Vec<tcl_lexer::Span> {
+    use tcl_compiler::segmenter::segment_commands_with_offset_and_config;
+    use tcl_lexer::TokenType;
+    use tcl_registry::{ArgRole, Traits};
+
+    let (Some(head), Some(written_name)) = (cmd.argv.first(), cmd.texts.first()) else {
+        return Vec::new();
+    };
+    let resolved = ctx
+        .identities
+        .head_words(written_name, head.span.start())
+        .resolved;
+    let args: Vec<&str> = cmd.texts.iter().skip(1).map(String::as_str).collect();
+    let mut out = Vec::new();
+    let mut callback_indices = ctx
+        .registry
+        .arg_indices_for_role(resolved, &args, ArgRole::Body);
+    callback_indices.extend(ctx.registry.arg_indices_for_role(
+        resolved,
+        &args,
+        ArgRole::CommandPrefix,
+    ));
+    callback_indices.sort_unstable();
+    callback_indices.dedup();
+    for idx in callback_indices {
+        let Some(&body_tok) = cmd.argv.get(idx + 1) else {
+            continue;
+        };
+        // A compound outer word changes the command prefix after the list
+        // substitution has run: `[list [self] tick]Suffix` invokes
+        // `tickSuffix`, not `tick`.  Only a sole substitution is an exact,
+        // safely renameable representation of the built command.
+        if body_tok.kind != TokenType::Cmd || cmd.single_token_word.get(idx + 1) != Some(&true) {
+            continue;
+        }
+        let regions = cmd_substitution_regions(ctx.source, ctx.dialect, body_tok);
+        let [(inner_start, inner_end)] = regions.as_slice() else {
+            continue;
+        };
+        let built = segment_commands_with_offset_and_config(
+            &ctx.source[*inner_start..*inner_end],
+            u32::try_from(*inner_start).unwrap_or(0),
+            tcl_lexer::LexerConfig::from_grammar(ctx.dialect.grammar),
+        );
+        let [builder] = built.as_slice() else {
+            continue;
+        };
+        let (Some(builder_head), Some(builder_written)) =
+            (builder.argv.first(), builder.texts.first())
+        else {
+            continue;
+        };
+        let builder_resolved = ctx
+            .identities
+            .head_words(builder_written, builder_head.span.start())
+            .resolved;
+        if !ctx
+            .registry
+            .get(builder_resolved)
+            .is_some_and(|spec| spec.traits.contains(Traits::BUILDS_COMMAND_PREFIX))
+        {
+            continue;
+        }
+        let (Some(receiver), Some(method_text), Some(&method_tok)) = (
+            builder.texts.get(1),
+            builder.texts.get(2),
+            builder.argv.get(2),
+        ) else {
+            continue;
+        };
+        // The exact source range is safely writable only for a plain literal
+        // method word.  Quoted/braced/compound spellings remain a deliberate
+        // abstention rather than producing a rename edit over delimiters.
+        if builder.single_token_word.get(1) == Some(&true)
+            && exact_self_receiver_call(ctx, receiver)
+            && method_text == ctx.method
+            && method_tok.kind == TokenType::Esc
+            && !method_tok.in_quote
+            && builder.single_token_word.get(2) == Some(&true)
+        {
+            out.push(method_tok.span);
+        }
+    }
+    out
+}
+
+/// Whether a command-substitution word is exactly the registry-declared
+/// current `TclOO` receiver form valid on a method frame's command path.
+fn exact_self_receiver_call(ctx: MyMethodScan<'_>, receiver: &str) -> bool {
+    let Some((written, args)) = tcl_compiler::value_shapes::parse_command_substitution(receiver)
+    else {
+        return false;
+    };
+    // A rooted spelling bypasses a method frame's command path. Reject it
+    // when its resolved registry spec exists only through that method
+    // context; a genuinely qualified helper has its own unscoped spec and is
+    // accepted. Command identity stays wholly registry-owned.
+    if written.starts_with("::") && ctx.registry.resolves_only_in_method_context(&written) {
+        return false;
+    }
+    // TclOO installs `::oo::Helpers` on a method frame's command path, ahead
+    // of global fallback. A global `proc self` therefore does not shadow the
+    // helper. The receiver form is nevertheless exact: `self` takes no word,
+    // while `self object` takes exactly that one declared selector.
+    match args.as_slice() {
+        [] => ctx.registry.is_self_receiver_call(&written, None),
+        [arg] => ctx.registry.is_self_receiver_call(&written, Some(arg)),
+        _ => false,
     }
 }
 
@@ -5419,6 +5705,319 @@ mod tests {
         assert!(
             lines.contains(&2),
             "the [self] animTick call site is missing: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn references_from_decl_reach_a_list_built_self_callback() {
+        // Issue #1701: `bind` receives a deferred script built as a Tcl list.
+        // `[self]` is substituted while the method frame is live, leaving an
+        // object-command prefix that later dispatches `animTick` externally.
+        let src = "package require Tk\noo::class create C {\n    method animTick {} { return 1 }\n    method anim {wl} {\n        bind $wl <ButtonPress-1> [list [self] animTick %x %y]\n    }\n}\n";
+        let analysis = analyse(src);
+        let refs = references(
+            src,
+            tcl_dialect::DialectProfile::by_name("tcl"),
+            2,
+            11,
+            &analysis,
+            true,
+        );
+        let lines: Vec<u32> = refs.iter().map(|r| r.start_line).collect();
+        assert!(lines.contains(&2), "decl missing: {refs:?}");
+        assert!(
+            lines.contains(&4),
+            "the list-built bind callback is missing: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn references_reach_a_list_built_self_object_callback() {
+        let src = "package require Tk\noo::class create C {\n    method tick {} { return 1 }\n    method wire {wl} {\n        bind $wl <Expose> [list [self object] tick]\n    }\n}\n";
+        let refs = references(
+            src,
+            tcl_dialect::DialectProfile::by_name("tcl"),
+            2,
+            11,
+            &analyse(src),
+            true,
+        );
+        assert!(
+            refs.iter().any(|r| r.start_line == 4),
+            "the `[self object]` callback is missing: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn references_reach_a_list_built_self_after_callback() {
+        // Real #1181 corpus shape: Pave and Zesty both schedule methods this
+        // way. `after` exposes its script through the same registry Body role
+        // as `bind`, so no scheduler-specific branch belongs in this scan.
+        let src = "oo::class create C {\n    method tick {} { return 1 }\n    method wire {} {\n        after idle [list [self] tick]\n    }\n}\n";
+        let refs = references(
+            src,
+            tcl_dialect::DialectProfile::by_name("tcl"),
+            1,
+            11,
+            &analyse(src),
+            true,
+        );
+        assert!(
+            refs.iter().any(|r| r.start_line == 3),
+            "the list-built after callback is missing: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn references_reach_a_list_built_self_command_prefix() {
+        // CommandPrefix is distinct from Body: the registry says this word is
+        // a partial command and the consumer appends its own arguments. The
+        // object-method reference is nevertheless the same external dispatch.
+        let src = "oo::class create C {\n    method compare {a b} { return 0 }\n    method sort {items} {\n        lsort -command [list [self] compare] $items\n    }\n}\n";
+        let refs = references(
+            src,
+            tcl_dialect::DialectProfile::by_name("tcl"),
+            1,
+            11,
+            &analyse(src),
+            true,
+        );
+        assert!(
+            refs.iter().any(|r| r.start_line == 3),
+            "the list-built CommandPrefix callback is missing: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn inert_list_built_self_value_is_not_a_method_reference() {
+        let src = "oo::class create C {\n    method tick {} { return 1 }\n    method build {} {\n        set inert [list [self] tick]\n    }\n}\n";
+        let refs = references(
+            src,
+            tcl_dialect::DialectProfile::by_name("tcl"),
+            1,
+            11,
+            &analyse(src),
+            true,
+        );
+        assert!(
+            !refs.iter().any(|r| r.start_line == 3),
+            "an inert list value must not become a call site: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn dynamic_list_built_self_method_remains_unresolved() {
+        let src = "oo::class create C {\n    method tick {} { return 1 }\n    method build {methodName} {\n        after idle [list [self] $methodName]\n    }\n}\n";
+        let refs = references(
+            src,
+            tcl_dialect::DialectProfile::by_name("tcl"),
+            1,
+            11,
+            &analyse(src),
+            true,
+        );
+        assert!(
+            !refs.iter().any(|r| r.start_line == 3),
+            "a dynamic method word must remain an abstention: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn compound_list_built_self_word_is_not_the_spelled_method() {
+        // The list substitution produces an object command ending in `tick`,
+        // then Tcl concatenates `Suffix` onto that word. The invoked method is
+        // `tickSuffix`; rewriting the inner `tick` token would be incorrect.
+        let src = "oo::class create C {\n    method tick {} { return 1 }\n    method build {} {\n        after idle [list [self] tick]Suffix\n    }\n}\n";
+        let refs = references(
+            src,
+            tcl_dialect::DialectProfile::by_name("tcl"),
+            1,
+            11,
+            &analyse(src),
+            true,
+        );
+        assert!(
+            !refs.iter().any(|r| r.start_line == 3),
+            "a method fragment inside a compound word is not an exact reference: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn deferred_braced_self_script_is_not_a_method_reference() {
+        // The braces delay `[self]` itself until Tk runs the binding, after
+        // the defining method frame has gone.  This script cannot resolve the
+        // object and must not be credited as a method call.
+        let src = "package require Tk\noo::class create C {\n    method tick {} { return 1 }\n    method wire {wl} {\n        bind $wl <Expose> {[self] tick}\n    }\n}\n";
+        let refs = references(
+            src,
+            tcl_dialect::DialectProfile::by_name("tcl"),
+            2,
+            11,
+            &analyse(src),
+            true,
+        );
+        assert!(
+            !refs.iter().any(|r| r.start_line == 4),
+            "a later, out-of-frame `self` must not become a call site: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn list_built_self_callback_cannot_reach_an_unexported_method() {
+        // A captured `[self]` result is an object command.  Its later call is
+        // therefore external and cannot dispatch an unexported method.
+        let src = "package require Tk\noo::class create C {\n    method tick {} { return 1 }\n    unexport tick\n    method wire {wl} {\n        bind $wl <Expose> [list [self] tick]\n    }\n}\n";
+        let refs = references(
+            src,
+            tcl_dialect::DialectProfile::by_name("tcl"),
+            2,
+            11,
+            &analyse(src),
+            true,
+        );
+        assert!(
+            !refs.iter().any(|r| r.start_line == 5),
+            "an unexported method is not callable through the captured object: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn a_shadowing_list_command_does_not_build_a_callback_reference() {
+        let src = "package require Tk\nproc list args { return not-a-command-prefix }\noo::class create C {\n    method tick {} { return 1 }\n    method wire {wl} {\n        bind $wl <Expose> [list [self] tick]\n    }\n}\n";
+        let refs = references(
+            src,
+            tcl_dialect::DialectProfile::by_name("tcl"),
+            3,
+            11,
+            &analyse(src),
+            true,
+        );
+        assert!(
+            !refs.iter().any(|r| r.start_line == 5),
+            "a user command shadowing the registry builder must not inherit its semantics: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn a_global_self_command_does_not_shadow_the_tcloo_method_helper() {
+        let src = "package require Tk\nproc self args { return ::notTheCurrentObject }\noo::class create C {\n    method tick {} { return 1 }\n    method wire {wl} {\n        bind $wl <Expose> [list [self] tick]\n    }\n}\n";
+        let refs = references(
+            src,
+            tcl_dialect::DialectProfile::by_name("tcl"),
+            3,
+            11,
+            &analyse(src),
+            true,
+        );
+        assert!(
+            refs.iter().any(|r| r.start_line == 5),
+            "::oo::Helpers precedes global fallback on a method frame: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn malformed_self_object_receiver_is_not_a_callback_reference() {
+        let src = "oo::class create C {\n    method tick {} { return 1 }\n    method wire {} {\n        after idle [list [self object junk] tick]\n    }\n}\n";
+        let refs = references(
+            src,
+            tcl_dialect::DialectProfile::by_name("tcl"),
+            1,
+            11,
+            &analyse(src),
+            true,
+        );
+        assert!(
+            !refs.iter().any(|r| r.start_line == 3),
+            "a receiver call that errors cannot build a callback: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn explicitly_global_self_is_not_the_tcloo_method_helper() {
+        let src = "proc ::self {} { return ::notTheCurrentObject }\noo::class create C {\n    method tick {} { return 1 }\n    method wire {} {\n        after idle [list [::self] tick]\n    }\n}\n";
+        let refs = references(
+            src,
+            tcl_dialect::DialectProfile::by_name("tcl"),
+            2,
+            11,
+            &analyse(src),
+            true,
+        );
+        assert!(
+            !refs.iter().any(|r| r.start_line == 4),
+            "an absolute global receiver must not inherit method-path semantics: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn qualified_tcloo_self_helper_builds_the_same_callback() {
+        let src = "oo::class create C {\n    method tick {} { return 1 }\n    method wire {} {\n        after idle [list [::oo::Helpers::self] tick]\n    }\n}\n";
+        let refs = references(
+            src,
+            tcl_dialect::DialectProfile::by_name("tcl"),
+            1,
+            11,
+            &analyse(src),
+            true,
+        );
+        assert!(
+            refs.iter().any(|r| r.start_line == 3),
+            "the registry-declared qualified helper must remain valid: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn callback_cursor_classifier_reaches_constructor_and_destructor_bodies() {
+        let src = "oo::class create C {\n    method tick {} { return 1 }\n    constructor {} {\n        after idle [list [self] tick]\n    }\n    destructor {\n        after idle [list [self] tick]\n    }\n}\n";
+        let analysis = analyse(src);
+        let dialect = tcl_dialect::DialectProfile::by_name("tcl");
+        let first = src.find("] tick").unwrap() + 2;
+        let second = src[first + 1..].find("] tick").unwrap() + first + 3;
+        for cursor in [first, second] {
+            assert_eq!(
+                list_built_self_method_target_at_cursor(
+                    src,
+                    dialect,
+                    &analysis,
+                    "tick",
+                    u32::try_from(cursor).unwrap(),
+                ),
+                Some(("::C".to_owned(), false)),
+            );
+        }
+    }
+
+    #[test]
+    fn callback_cursor_classifier_rejects_ordinary_method_dispatches() {
+        let src = "oo::class create C {\n    method tick {} { return 1 }\n    method wire {} {\n        my tick\n        [self] tick\n    }\n}\n";
+        let analysis = analyse(src);
+        let dialect = tcl_dialect::DialectProfile::by_name("tcl");
+        let my_cursor = u32::try_from(src.find("my tick").unwrap() + 3).unwrap();
+        let self_cursor = u32::try_from(src.find("] tick").unwrap() + 2).unwrap();
+        assert!(
+            list_built_self_method_target_at_cursor(src, dialect, &analysis, "tick", my_cursor,)
+                .is_none()
+        );
+        assert!(
+            list_built_self_method_target_at_cursor(src, dialect, &analysis, "tick", self_cursor,)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn inherited_callback_abstains_without_effective_receiver_visibility() {
+        let src = "oo::class create Base {\n    method tick {} { return 1 }\n}\noo::class create Child {\n    superclass Base\n    unexport tick\n    method wire {} {\n        after idle [list [self] tick]\n    }\n}\n";
+        let refs = references(
+            src,
+            tcl_dialect::DialectProfile::by_name("tcl"),
+            1,
+            11,
+            &analyse(src),
+            true,
+        );
+        assert!(
+            !refs.iter().any(|r| r.start_line == 7),
+            "provider visibility cannot be reused for the child receiver: {refs:?}"
         );
     }
 

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -1650,6 +1650,13 @@ pub(crate) fn list_built_self_method_target_at_cursor(
     // runs, so an unexported target is not a candidate here.
     let (provider, _) =
         crate::oo_dispatch::method_dispatch_provider(analysis, receiver_q, word, true, bucket)?;
+    // `method_references_for_class` deliberately excludes callback captures
+    // from inheriting receivers until #1705 models their effective export
+    // state.  Cursor-origin resolution must make the same abstention or rename
+    // would accept this site but omit it from the edit set.
+    if provider != receiver_q {
+        return None;
+    }
     let provider = provider.to_owned();
     // Compare against callback-only spans from this one containing body. An
     // ordinary `my method`, direct `[self] method`, external call, or member
@@ -6018,6 +6025,29 @@ mod tests {
         assert!(
             !refs.iter().any(|r| r.start_line == 7),
             "provider visibility cannot be reused for the child receiver: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn inherited_callback_cursor_abstains_with_the_reference_set() {
+        // Even a publicly declared provider is not enough: the inheriting
+        // receiver can independently export or unexport the effective method.
+        // Until #1705 models that state, both declaration-origin collection
+        // and cursor-origin navigation must abstain together.
+        let src = "oo::class create Base {\n    method tick {} { return 1 }\n}\noo::class create Child {\n    superclass Base\n    method wire {} {\n        after idle [list [self] tick]\n    }\n}\n";
+        let analysis = analyse(src);
+        let dialect = tcl_dialect::DialectProfile::by_name("tcl");
+        let cursor = u32::try_from(src.find("] tick").unwrap() + 2).unwrap();
+        assert!(
+            list_built_self_method_target_at_cursor(src, dialect, &analysis, "tick", cursor,)
+                .is_none(),
+            "cursor-origin resolution must not produce a partial rename family"
+        );
+
+        let refs = references(src, dialect, 1, 11, &analysis, true);
+        assert!(
+            !refs.iter().any(|range| range.start_line == 6),
+            "declaration-origin references must make the same abstention: {refs:?}"
         );
     }
 

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -277,24 +277,22 @@ pub fn prepare_rename_in_program(
     // Proc?  Declaration-span hit, else the namespace-aware candidate
     // resolution — never a namespace-blind `p.name == word` first-hit scan
     // (which could seed the rename with an arbitrary same-named proc).
-    let (word, _start, _end) = find_word_span_at_position(source, line, character)?;
+    let (word, word_start, word_end) = find_word_span_at_position(source, line, character)?;
     let word_off = crate::definition::byte_offset_at(&line_index, source, line, character);
-    if let Some((_, proc_def)) =
-        crate::definition::resolve_proc_target_at(analysis, source, word_off, &word, resolution)
-    {
-        return Some(PrepareRename {
-            range: span_to_range(source, &line_index, proc_def.name_span),
-            placeholder: proc_def.name.clone(),
-        });
+    if let Some(preparation) = prepare_list_built_self_method_rename(
+        source,
+        line,
+        (word_start, word_end),
+        analysis,
+        &word,
+        word_off,
+    ) {
+        return Some(preparation);
     }
-    // Class?  Same resolution shape against `all_classes`.
-    if let Some((_, class_def)) =
-        crate::definition::resolve_class_target_at(analysis, resolution, word_off, &word)
+    if let Some(preparation) =
+        prepare_named_command_rename(source, &line_index, analysis, resolution, (&word, word_off))
     {
-        return Some(PrepareRename {
-            range: span_to_range(source, &line_index, class_def.name_span),
-            placeholder: class_def.name.clone(),
-        });
+        return Some(preparation);
     }
     // Method / classmethod / property inside a class body?
     let cursor_offset = crate::definition::byte_offset_at(&line_index, source, line, character);
@@ -492,25 +490,24 @@ pub fn rename_in_program(
         return Ok(Vec::new());
     };
 
-    if let Some(edits) = rename_proc(
+    if let Some(edits) = rename_list_built_self_method(
         source,
-        &word,
-        def_byte,
-        new_name,
+        dialect,
         analysis,
-        resolution,
         &line_index,
+        (&word, new_name),
+        def_byte,
     ) {
         return Ok(edits);
     }
-    if let Some(edits) = rename_class(
+
+    if let Some(edits) = rename_named_command(
         source,
-        &word,
-        def_byte,
-        new_name,
         analysis,
         resolution,
         &line_index,
+        (&word, new_name),
+        def_byte,
     ) {
         return Ok(edits);
     }
@@ -565,6 +562,113 @@ pub fn rename_in_program(
         &line_index,
     )
     .map(Option::unwrap_or_default)
+}
+
+fn prepare_list_built_self_method_rename(
+    source: &str,
+    line: u32,
+    word_range: (u32, u32),
+    analysis: &AnalysisResult,
+    word: &str,
+    cursor_offset: u32,
+) -> Option<PrepareRename> {
+    crate::references::list_built_self_method_target_at_cursor(
+        source,
+        crate::profile_for_dialect(&analysis.dialect),
+        analysis,
+        word,
+        cursor_offset,
+    )?;
+    Some(PrepareRename {
+        range: LspRange {
+            start_line: line,
+            start_character: word_range.0,
+            end_line: line,
+            end_character: word_range.1,
+        },
+        placeholder: word.to_owned(),
+    })
+}
+
+fn rename_list_built_self_method(
+    source: &str,
+    dialect: &'static tcl_dialect::DialectProfile,
+    analysis: &AnalysisResult,
+    line_index: &LineIndex,
+    names: (&str, &str),
+    cursor_offset: u32,
+) -> Option<Vec<TextEdit>> {
+    let (word, new_name) = names;
+    let (provider, is_classmethod) = crate::references::list_built_self_method_target_at_cursor(
+        source,
+        dialect,
+        analysis,
+        word,
+        cursor_offset,
+    )?;
+    rename_method_in_class(
+        source,
+        dialect,
+        (&provider, word, is_classmethod),
+        new_name,
+        analysis,
+        line_index,
+    )
+}
+
+fn prepare_named_command_rename(
+    source: &str,
+    line_index: &LineIndex,
+    analysis: &AnalysisResult,
+    resolution: crate::definition::CallResolution<'_>,
+    target: (&str, u32),
+) -> Option<PrepareRename> {
+    let (word, cursor_offset) = target;
+    if let Some((_, proc_def)) =
+        crate::definition::resolve_proc_target_at(analysis, source, cursor_offset, word, resolution)
+    {
+        return Some(PrepareRename {
+            range: span_to_range(source, line_index, proc_def.name_span),
+            placeholder: proc_def.name.clone(),
+        });
+    }
+    let (_, class_def) =
+        crate::definition::resolve_class_target_at(analysis, resolution, cursor_offset, word)?;
+    Some(PrepareRename {
+        range: span_to_range(source, line_index, class_def.name_span),
+        placeholder: class_def.name.clone(),
+    })
+}
+
+fn rename_named_command(
+    source: &str,
+    analysis: &AnalysisResult,
+    resolution: crate::definition::CallResolution<'_>,
+    line_index: &LineIndex,
+    names: (&str, &str),
+    cursor_offset: u32,
+) -> Option<Vec<TextEdit>> {
+    let (word, new_name) = names;
+    rename_proc(
+        source,
+        word,
+        cursor_offset,
+        new_name,
+        analysis,
+        resolution,
+        line_index,
+    )
+    .or_else(|| {
+        rename_class(
+            source,
+            word,
+            cursor_offset,
+            new_name,
+            analysis,
+            resolution,
+            line_index,
+        )
+    })
 }
 
 /// The **untargeted** member-rename tier, behind the safety gate — the last
@@ -971,6 +1075,17 @@ pub fn method_target_with_access_in_workspace(
     let line_index = LineIndex::new(source);
     let (word, _s, _e) = find_word_span_at_position(source, line, character)?;
     let cursor = crate::definition::byte_offset_at(&line_index, source, line, character);
+    if let Some((provider, is_classmethod)) =
+        crate::references::list_built_self_method_target_at_cursor(
+            source,
+            crate::profile_for_dialect(&analysis.dialect),
+            analysis,
+            &word,
+            cursor,
+        )
+    {
+        return Some((provider, word, is_classmethod, MethodAccess::External));
+    }
     // A bare receiver word resolves like any other command word — against the
     // namespace in effect where it is written, then the global one, then
     // through whatever `namespace import` has made reachable there. Both facts

--- a/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
+++ b/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
@@ -297,6 +297,71 @@ fn tp_consumer_rename_and_references_agree_on_the_same_sites() {
 
 // Issue #991 — code-lens click and count must match Find All References.
 
+/// Issue #1701: a Tk binding built with `[list [self] METHOD ...]` captures
+/// the current object command and later invokes the exported method.  The
+/// declaration's references, code lens, and rename must agree on that method
+/// word even though it is data inside the prefix-building `list` call.
+#[test]
+fn tp_list_built_self_bind_callback_is_a_method_reference_everywhere() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "package require Tk\n\
+         oo::class create Test {\n\
+             method animTick {x y} { return {} }\n\
+             method anim {wl} {\n\
+                 bind $wl <ButtonPress-1> [list [self] animTick %x %y]\n\
+             }\n\
+         }\n",
+    );
+
+    let refs = lsp.references(&uri, 2, 11, false);
+    assert_eq!(
+        location_lines(&refs, &uri),
+        std::collections::BTreeSet::from([4]),
+        "Find All References must return the callback method word: {refs:?}"
+    );
+
+    let command = resolve_lens_on_line(&mut lsp, &uri, 2);
+    assert_eq!(command["title"], expected_title(1), "{command:?}");
+    assert_eq!(
+        location_lines(&lens_locations(&command), &uri),
+        std::collections::BTreeSet::from([4]),
+        "the lens must open the same callback site: {command:?}"
+    );
+
+    let definition = lsp.definition(&uri, 4, 44);
+    assert_eq!(
+        location_lines(&definition, &uri),
+        std::collections::BTreeSet::from([2]),
+        "go-to-definition from the callback word must reach the method: {definition:?}"
+    );
+    let callback_refs = lsp.references(&uri, 4, 44, false);
+    assert_eq!(
+        location_lines(&callback_refs, &uri),
+        std::collections::BTreeSet::from([4]),
+        "references started on the callback must agree with the declaration: {callback_refs:?}"
+    );
+
+    let prepare = lsp.prepare_rename(&uri, 4, 44);
+    assert_eq!(prepare["placeholder"], "animTick", "{prepare:?}");
+    assert_eq!(prepare["range"]["start"]["line"], 4, "{prepare:?}");
+
+    let edits = rename_edits(&lsp.rename(&uri, 2, 11, "frameTick"));
+    assert_eq!(
+        edit_lines(&edits, &uri),
+        vec![2, 4],
+        "rename must update the declaration and callback word: {edits:?}"
+    );
+    let callback_edits = rename_edits(&lsp.rename(&uri, 4, 44, "frameTick"));
+    assert_eq!(
+        edit_lines(&callback_edits, &uri),
+        vec![2, 4],
+        "rename from the callback word must update the same family: {callback_edits:?}"
+    );
+}
+
 /// TP: the lens above `Animal`'s `speak` must count — and, on click, open —
 /// the sibling document's override declaration and its `$d speak` dispatch,
 /// exactly as Find All References on the same declaration does.

--- a/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
+++ b/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
@@ -362,6 +362,52 @@ fn tp_list_built_self_bind_callback_is_a_method_reference_everywhere() {
     );
 }
 
+/// Inherited callback capture is deliberately conservative until #1705 can
+/// prove effective receiver visibility.  A cursor on such a callback must not
+/// offer a partial rename that edits the ancestor declaration but leaves this
+/// occurrence behind.
+#[test]
+fn tp_inherited_list_built_self_callback_cursor_abstains_everywhere() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "oo::class create Base {\n\
+             method tick {} { return 1 }\n\
+         }\n\
+         oo::class create Child {\n\
+             superclass Base\n\
+             method wire {} {\n\
+                 after idle [list [self] tick]\n\
+             }\n\
+         }\n",
+    );
+
+    let from_declaration = lsp.references(&uri, 1, 11, false);
+    assert!(
+        !location_lines(&from_declaration, &uri).contains(&6),
+        "the inherited callback is outside the proven edit family: {from_declaration:?}"
+    );
+    let definition = lsp.definition(&uri, 6, 36);
+    assert!(
+        definition.is_null() || definition.as_array().is_some_and(Vec::is_empty),
+        "definition from an abstained callback cursor must be empty: {definition:?}"
+    );
+    let references = lsp.references(&uri, 6, 36, false);
+    assert!(
+        references.is_null() || references.as_array().is_some_and(Vec::is_empty),
+        "references from an abstained callback cursor must be empty: {references:?}"
+    );
+    assert!(
+        lsp.prepare_rename(&uri, 6, 36).is_null(),
+        "prepareRename must reject a callback that cannot join the edit family"
+    );
+    assert!(
+        lsp.rename(&uri, 6, 36, "tock").is_null(),
+        "rename must not offer a partial ancestor-only edit"
+    );
+}
+
 /// TP: the lens above `Animal`'s `speak` must count — and, on click, open —
 /// the sibling document's override declaration and its `$d speak` dispatch,
 /// exactly as Find All References on the same declaration does.

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -15,6 +15,10 @@ evidence rather than impression. It was built after a memory-leak review
 against the issue #1181 corpus, and its first output showed v2.1.14 holding
 479 MiB where v2.1.15 holds 170 MiB.
 
+For the human-readable source, dialect, age/recency, licence, and coding-style
+catalogue, see [`docs/CORPUS.md`](../../docs/CORPUS.md). The manifest below
+remains the sole machine-readable source of benchmark pins.
+
 ## Quick start
 
 ```bash


### PR DESCRIPTION
## Summary

- resolve exact `[list [self] METHOD ...]` and `[list [self object] METHOD ...]` callback references in registry-declared script and command-prefix slots
- include callback method words in definition, references, prepare-rename, rename, rename-safety, and method code-lens results
- catalogue the external Tcl/Tk/iRules/EDA/iRulesLX corpus in `docs/CORPUS.md` without vendoring downloaded sources

## Resolution contract

The new path is intentionally conservative and command-identity driven:

- the outer consumer must resolve to a registry role of `Body` or `CommandPrefix`
- the inner builder must resolve to a registry command with `BUILDS_COMMAND_PREFIX`
- the receiver must be exactly `[self]` or `[self object]`
- the method must be one exact, plain, unquoted word
- the target must be externally dispatchable for that receiver
- inert lists, shadowed builders, dynamic/quoted/compound method words, malformed receivers, and unexported methods abstain

Qualified TclOO `self` is supported. Explicit global `::self` is rejected through command identity, while method-frame `self` continues to win over an unrelated global procedure named `self`.

Inherited callback capture deliberately abstains until #1705 models effective receiver visibility; established internal `my` references are preserved.

## Corpus and follow-ups

The corpus audit normalized all 35 public benchmark repositories by content hash and separately searched Tcl Wiki, F5 documentation/community material, and paired iRulesLX Tcl/JavaScript repositories. The documentation records age/recency, licence metadata, intended dialect, coding style, callback taxonomy, duplicate-aware counts, and sources only.

The audit identified broader registry work tracked by #1703-#1708. In particular, TclOO/snit/Itcl prefix builders need a typed prefix-result descriptor: the existing boolean builder trait would incorrectly treat builder argument zero as the returned command head.

## Performance

Two clean alternating small-corpus benchmark pairs (113 Tcl files) found no material latency regression:

- references: 0.3375 s baseline vs 0.3385 s branch, about +0.3%
- code lens: 0.1665 s vs 0.1700 s, about +3.5 ms / +2.1%
- rename: 7.898 s vs 8.070 s, about +2.2% with high run-to-run variance
- peak RSS: about +3.4 MiB / +1.5%; divergence appeared before the affected path and is consistent with allocator/process noise

The scan is bounded to registry-declared sinks and method bodies. Future indexing/memoization is tracked in #1706.

## Verification

- `cargo test -p tcl-lsp-core list_built_self` — 8 passed
- `cargo test -p tcl-lsp-server --test e2e tp_list_built_self_bind_callback_is_a_method_reference_everywhere` — passed
- `make rust-check` — passed, including workspace/WASM/Zed clippy and all drift/provenance gates
- `make prep-pr` — passed, including format/codegen, TypeScript/report/Spec Studio checks, installer tests, and workspace smoke tier
- independent adversarial review found no remaining blocker

Fixes #1701
