### PR TITLE
Chore: make rust the sole active branch

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: release
 description: >
-  Run the full release workflow: validate the release branch (2.x pre-releases
-  are cut from `rust`, 1.x stable from `main`), test, benchmark the release and
+  Run the full release workflow: validate the active `rust` release branch,
+  test, benchmark the release and
   regenerate the release-notes performance graphs, generate the changelog, tag,
   push, then let CI build and publish — approving the marketplace Environments
   with `gh` from the release laptop. Asks for patch/minor/major if not
@@ -41,14 +41,14 @@ scripts/release/rust_release.sh tag X.Y.Z       # re-verifies, then tag.sh
 than pushing — read the diff first. The steps below give the detail and the
 reasoning; do not substitute a hand-rolled sequence for the script.
 
-## Two release lines
+## One active release branch, two channels
 
-There are two, and they are cut from **different branches**:
+All active releases are cut from `rust`; the tag selects the channel:
 
 | Line | Branch | Channel | GitHub release |
 | --- | --- | --- | --- |
-| **1.x — stable** | `main` | VS Code stable / Open VSX stable / JetBrains stable | latest |
-| **2.x — pre-release** (the Python → Rust rewrite) | `rust` | VS Code pre-release / Open VSX pre-release / JetBrains eap | pre-release, never "latest" |
+| **2.x — stable** (even minor) | `rust` | VS Code stable / Open VSX stable / JetBrains stable | latest |
+| **2.x — pre-release** (odd minor) | `rust` | VS Code pre-release / Open VSX pre-release / JetBrains eap | pre-release, never "latest" |
 
 Nothing declares which line you are on except the version: `scripts/release/prerelease.sh`
 is the single source of truth, and it says a tag is a pre-release when
@@ -56,25 +56,20 @@ is the single source of truth, and it says a tag is a pre-release when
 be). CI reads that same script to decide the GitHub release's prerelease flag and
 the marketplace channel — you never pass a flag by hand.
 
-The rewrite is where the work is, so in practice a release is usually a **2.1.x
-pre-release cut from `rust`**. Do not "fix" this by tagging `main`: `main` does
-not contain the 2.x work, and tagging it would ship a stale tree under a new
-version.
+The former Python 1.x line is preserved as the locked `legacy-py` archive.
+Never branch, merge, or tag from it.
 
 ## Workflow
 
 Follow these steps **in order**. Stop and report on failure at any step.
 
-### 1. Pick the line, then guard the branch
+### 1. Guard the branch
 
-Work out the line from the version being cut, and require the matching branch:
+Require the active release branch:
 
 ```bash
-# The branch this line releases from: 2.x odd-minor => `rust`, otherwise `main`.
 branch=$(git branch --show-current)
-prev_tag=$(git describe --tags --abbrev=0)
-release_branch=$(git branch -r --contains "$prev_tag" \
-                   | grep -qE 'origin/(rust)$' && echo rust || echo main)
+release_branch=rust
 
 if [ "$branch" != "$release_branch" ]; then
   echo "ERROR: $release_branch is the release branch for this line (on '$branch')"
@@ -82,8 +77,7 @@ if [ "$branch" != "$release_branch" ]; then
 fi
 ```
 
-If the user asks for a release from the other branch, confirm with them before
-proceeding — do not silently switch lines.
+Do not release from `legacy-py`; it is a locked archive.
 
 ### 2. Pull latest
 
@@ -94,8 +88,8 @@ git pull origin "$release_branch"
 ### 3. Pre-release validation
 
 Every feature PR is expected to have passed `make check-all` before merge
-(the pre-push gate; see AGENTS.md). If you have any doubt that `main` is
-green at this tip, run the full suite once against `main` before tagging:
+(the pre-push gate; see AGENTS.md). If you have any doubt that `rust` is
+green at this tip, run the full suite once against `rust` before tagging:
 
 ```bash
 make check-all             # lint + typecheck, all languages
@@ -200,7 +194,7 @@ Two things to watch and report to the user rather than paper over:
 
 The release branch is protected, so the release-notes commit lands via a PR
 **against that branch** (`--base "$release_branch"` — a notes PR opened against
-`main` for a 2.x pre-release would land the notes on the wrong line). Step 5a
+another branch would land the notes on the wrong line). Step 5a
 already made the branch and the commit; push it and open the PR:
 
 ```bash
@@ -234,15 +228,14 @@ scripts/release/rust_release.sh tag X.Y.Z     # or: make release-rust-tag V=X.Y.
 `make release-tag V=X.Y.Z` is the bare primitive underneath — it handles
 validation (clean tree, correct branch, no existing tag) and pushes only the
 tag, with no source-file edits and no commit on the release branch. It is the
-entry point for the stable line cut from `main`:
+entry point for a stable-channel tag cut from `rust`:
 
 ```bash
 make release-tag V=X.Y.Z
 ```
 
-`tag.sh` derives the channel itself and enforces the branch that goes with it
-(pre-release → `rust`, stable → `main`), so it will refuse a tag cut from the
-wrong line.
+`tag.sh` derives the channel itself and requires `rust` for both stable and
+pre-release tags, so it will refuse a tag cut from the wrong branch.
 
 The tag push triggers `.github/workflows/ci.yml` to build artefacts, run
 `publish-checksums`, and publish the GitHub release — as a pre-release, with the

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -2,7 +2,7 @@
 # ceiling.  Cache *keys* in ci.yml are all stable (lockfile/version hashes),
 # so the bloat is not key churn — it's stale caches scoped to PR branches
 # that nothing ever deletes.  GitHub auto-evicts LRU over 10 GiB, which
-# silently guts hit rates; pruning proactively keeps main's caches warm.
+# silently guts hit rates; pruning proactively keeps rust's caches warm.
 #
 # Two triggers:
 #   * pull_request closed — delete the caches scoped to that PR's merge ref
@@ -67,18 +67,18 @@ jobs:
         run: |
           # Protect the caches of the long-lived branches that have
           # push-triggered blocking workflows. ci.yml runs on `push:
-          # branches: [main, rust]`, so its rust-cache entries live on both
-          # refs; purging refs/heads/rust every week forces cold rebuilds on
-          # the gate. Keep this in sync with ci.yml's push triggers.
-          echo "Sweeping caches not on a protected ref (main, rust)"
+          # branches: [rust]`, so its rust-cache entries live on that ref;
+          # purging refs/heads/rust every week forces cold rebuilds on the
+          # gate. Keep this in sync with ci.yml's push triggers.
+          echo "Sweeping caches not on the protected ref (rust)"
           # Single pass (limit 100); a residual >100 is caught next week.
           ids=$(gh cache list --repo "$REPO" --limit 100 --json id,ref \
-            --jq '.[] | select(.ref != "refs/heads/main" and .ref != "refs/heads/rust") | .id')
+            --jq '.[] | select(.ref != "refs/heads/rust") | .id')
           if [ -z "$ids" ]; then
             echo "  nothing to sweep"
           else
             for id in $ids; do
-              echo "  deleting non-main cache $id"
+              echo "  deleting non-rust cache $id"
               gh cache delete "$id" --repo "$REPO" || true
             done
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [main, rust]
+    branches: [rust]
     tags: ["v*"]
   pull_request:
-    branches: [main, rust]
+    branches: [rust]
   # Manual escape hatch: if a PR's initial `pull_request: opened` webhook
   # is ever dropped by GitHub (rare, but has happened — no runs show up
   # for the branch at all, not even a queued/pending one), this lets a
@@ -59,12 +59,12 @@ jobs:
   #                    match, or a match older than 24 h → false → full run.
   #                    True in exactly two shapes:
   #                      * a v* tag whose commit has a green push run on
-  #                        rust/main — the release flow (make release-tag) tags
+  #                        rust — the release flow (make release-tag) tags
   #                        an already-green tip, so the tag-time re-test was
   #                        pure repetition (measured: v2.1.18 re-ran the
   #                        identical 20-job surface on the same SHA 74 minutes
   #                        after it went green);
-  #                      * a push to rust/main of a merge commit whose tree is
+  #                      * a push to rust of a merge commit whose tree is
   #                        byte-identical to a PR head with a green PR run —
   #                        what the merge button produces when the PR was up to
   #                        date with the base.  Tree equality is the guarantee
@@ -131,9 +131,9 @@ jobs:
           cutoff="$(date -u -d '24 hours ago' '+%Y-%m-%dT%H:%M:%SZ')"
           api="repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs"
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            # Tag: does this exact SHA have a green push run on rust/main?
+            # Tag: does this exact SHA have a green push run on rust?
             n="$(gh api "$api?head_sha=$GITHUB_SHA&event=push&status=success&per_page=20" \
-                  --jq "[.workflow_runs[] | select((.head_branch==\"rust\" or .head_branch==\"main\") and .updated_at > \"$cutoff\")] | length" \
+                  --jq "[.workflow_runs[] | select(.head_branch==\"rust\" and .updated_at > \"$cutoff\")] | length" \
                   2>/dev/null || echo 0)"
             [ "${n:-0}" -gt 0 ] && already=true
           elif [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
@@ -227,7 +227,7 @@ jobs:
     # deliberate: skipping the whole job would transitively skip create-release
     # and every build/publish job (GitHub's success() propagates a skipped
     # ancestor through the needs graph).  Those tags are cut from `rust` and
-    # gated by the cargo jobs instead.  Runs in full for PRs, main pushes,
+    # gated by the cargo jobs instead.  Runs in full for PRs, rust pushes,
     # stable tags.
     needs: [channel]
     runs-on: ubuntu-26.04
@@ -250,7 +250,7 @@ jobs:
         # already green; job still succeeds so the release graph stays
         # unbroken.  Deliberately NOT skipped on already-green merge pushes:
         # this job's clippy cache is the base-branch fallback every PR run
-        # restores from, so pushes to rust/main keep it warm.
+        # restores from, so pushes to rust keep it warm.
         if: needs.channel.outputs.prerelease != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')
         run: |
           cargo fmt --all --check
@@ -611,7 +611,7 @@ jobs:
         if: env.RUN_EXT_WEB == 'true'
         run: cd editors/vscode && npm run test:web
 
-  # Rust product gate.  ci.yml triggers on both `main` and `rust`, so one
+  # Rust product gate.  ci.yml triggers on `rust`, so one
   # pipeline covers them.  Runs on every PR and push, because nothing else
   # exercises the Rust product on a PR.
   #
@@ -1188,7 +1188,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     # Gated on the fast gate (pr-gate) AND the whole cargo test surface.  Any
     # of those jobs may have step-skipped its work when the channel job proved
-    # this exact SHA already went green on rust/main within 24 h (see the
+    # this exact SHA already went green on rust within 24 h (see the
     # channel job header) — the jobs still report success, so the graph holds,
     # and the verdict they carry forward is the prior run's real one.  A tag
     # whose SHA was never tested (or whose green is stale) runs everything
@@ -1219,7 +1219,7 @@ jobs:
           sha="$(git rev-parse --short HEAD)"
           # Replace the @@INSTALLER_VERSION_*@@ placeholders so a user
           # running --version on the published asset sees the actual
-          # release. The in-tree script on main stays unstamped so
+          # release. The in-tree script on rust stays unstamped so
           # contributors don't see misleading version strings locally.
           tmp="$(mktemp)"
           sed \
@@ -1937,7 +1937,7 @@ jobs:
   # Environment, which PAUSES for manual approval and can never run on a
   # non-tag ref.  (The keyless OIDC -> Azure Entra path was rolled back
   # after it proved unreliable against the VS Code Marketplace; the PAT is
-  # the supported mechanism, matching the stable line on `main`.)  Hardening
+  # the supported mechanism, matching the stable channel from `rust`.)  Hardening
   # choices preserved from the keyless design:
   #   * VSCE_PAT is scoped to the publish step's `env:` only, so the
   #     freshly-fetched npm code in `npm ci` never runs with the token in

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,7 @@ name: CodeQL
 # runs on user machines: Python (LSP server / zipapps) and TypeScript
 # (VS Code extension).  CodeQL's `actions` query pack also lints the
 # workflows themselves, catching expression-injection and similar
-# mistakes before they reach main.
+# mistakes before they reach rust.
 #
 # Rust (editors/zed) is intentionally excluded.  CodeQL Rust support is
 # still maturing, and the extension cross-compiles to `wasm32-wasip2`

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -54,12 +54,11 @@ name: Deploy GitHub Pages (BIG-IP report + compiler explorer + spec studio)
 # no longer exists on the Python-free `rust` line.
 on:
   push:
-    # `rust` is the active development line these features land on; `main` is the
-    # long-term default. Deploy from whichever holds the merged code. Every
+    # `rust` is the active development and default line. Every
     # release tag also deploys from its exact commit: GitHub does not evaluate
     # `paths` filters for tag pushes, so a release-notes-only tag cannot leave
     # the live tools stamped with the preceding development version.
-    branches: [rust, main]
+    branches: [rust]
     tags: ["v*"]
     paths:
       # BIG-IP report generator + demo sources (query engine, model, renderer).

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -19,14 +19,14 @@ name: Performance
 
 on:
   push:
-    # `rust` and `main` give the running trend — every merge is a data point,
+    # `rust` gives the running trend — every merge is a data point,
     # which is what makes a release number interpretable rather than a lone
     # figure. `v*` gives the release record: those runs publish the graphs
     # that go into the release notes and READMEs.
-    branches: [main, rust]
+    branches: [rust]
     tags: ["v*"]
   pull_request:
-    branches: [main, rust]
+    branches: [rust]
   # The `benchmark` job stays off PRs — it is NOT GATING YET (see above), so a
   # PR-time run produced a number nothing consumed before merge, and the same
   # commit's numbers were then recomputed on the push and again on the tag.

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,7 +10,7 @@ on:
   schedule:
     - cron: "23 4 * * 2"
   push:
-    branches: [main]
+    branches: [rust]
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,15 +337,18 @@ worktree (`--check` shows what it would set and warns if the current
 `CARGO_TARGET_DIR` points elsewhere).  Agent instructions should reference
 that helper rather than repeating the env-var incantations.
 
-**Stable vs pre-release channels (odd/even-minor).**  Two lines run in
-parallel and the tag alone decides which:
+**Stable vs pre-release channels (odd/even-minor).**  `rust` is the sole
+active development and release branch; the former Python `main` line is
+preserved as the locked `legacy-py` archive.  The tag alone selects the
+publication channel:
 
-- **Stable / default** — `v1.x` and even-minor `v2.x` (`v2.2.0`), cut from
-  `main`.  Normal GitHub Release (`latest`) and normal Marketplace channel.
+- **Stable / default** — even-minor `v2.x` (`v2.2.0`), cut from `rust`.
+  Normal GitHub Release (`latest`) and normal Marketplace channel.
 - **Pre-release / "for the brave"** — odd-minor `v2.x` (`v2.1.0`,
-  `v2.1.1`, …), cut from `rust`.  Published as a GitHub `--prerelease`
-  (never `latest`) and to the Marketplace `--pre-release` channel, so 1.x
-  stays the default install until a user opts into pre-releases.
+  `v2.1.1`, …), also cut from `rust`.  Published as a GitHub `--prerelease`
+  (never `latest`) and to the Marketplace `--pre-release` channel.
+
+The 1.x Python line is frozen; do not branch, merge, or tag from `legacy-py`.
 
 The 2.x rewrite ships its alphas on `2.1.x` and promotes to the stable
 `2.2.0` when ready.  `scripts/release/prerelease.sh X.Y.Z` is the single
@@ -443,7 +446,7 @@ CI, and a manual-only exhaustive tier that never runs automatically.
 | Tier | When it runs | What runs |
 |---|---|---|
 | **smoke** (`make smoke`, `make smoke-p P=<crate>`) | locally, right after every compile; part of `make prep-pr` | the `smoke_*` / `*_smoke.rs` subset — one fast per-module sanity check per crate, seconds warm.  Reuses the dev-profile default-features build you just made (never `--all-features`), so it never forces a recompile |
-| **deep** (CI: `rust-tests`, `rust-tests-heavy`, `lsp-e2e`, `test-ext`, `test-ext-web`, `cargo-deny`, `python`) | every PR and every push to `rust`/`main`, automatically | the full workspace suite (native lsp_e2e included), the VM-sim heavies, the VS Code extension on the desktop **and** in a browser extension host, supply-chain audit, Python lint/typecheck.  CI skips work only when its inputs demonstrably didn't change (see "CI redundancy contract" below) |
+| **deep** (CI: `rust-tests`, `rust-tests-heavy`, `lsp-e2e`, `test-ext`, `test-ext-web`, `cargo-deny`, `python`) | every PR and every push to `rust`, automatically | the full workspace suite (native lsp_e2e included), the VM-sim heavies, the VS Code extension on the desktop **and** in a browser extension host, supply-chain audit, Python lint/typecheck.  CI skips work only when its inputs demonstrably didn't change (see "CI redundancy contract" below) |
 | **exhaustive / manual-only** (`make test-exhaustive`, `make fuzz`, `make tcltest-sweep[-check]`) | only when a human (or a deliberate scheduled job) invokes it by name | every `#[ignore]`d corpus sweep over `tmp/tcl*`/tcllib, differential-fuzz gates, privileged bpf/kernel tests, fuzz campaigns.  NEVER wire these into `prep-pr`, `test`, `check-all`, or CI |
 
 **Fuzzing is always manual.**  This covers campaigns (`make fuzz` /
@@ -489,8 +492,7 @@ skipped this step.
 
 ### Opening a PR: CI carries the deep suites
 
-Rebase off the branch you are targeting (`rust` for 2.x work, `main` for
-1.x stable), fix conflicts, run `make prep-pr`, and open the PR.  **Do not
+Rebase off `rust`, fix conflicts, run `make prep-pr`, and open the PR.  **Do not
 block on running the full suite locally** — CI runs the deep tier
 (`rust-tests` + `rust-tests-heavy` + `lsp-e2e` + `test-ext` + `test-ext-web`
 + `cargo-deny` + `python`) on every PR, in parallel, in a few minutes.
@@ -519,7 +521,7 @@ evidence.
 CI avoids re-testing what demonstrably didn't change, and the rules live in
 `ci.yml`'s `channel` job (read its header comment before touching them):
 
-- a **tag** whose SHA already went green on a `rust`/`main` push within 24 h
+- a **tag** whose SHA already went green on a `rust` push within 24 h
   step-skips the test surface (the release graph still runs);
 - a **merge push** whose tree is byte-identical to its already-green PR head
   downgrades tests to a cache-warming build (`--no-run`);

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,9 +553,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/Makefile
+++ b/Makefile
@@ -2120,7 +2120,7 @@ release-tag: ## Create + push the annotated release tag (V=x.y.z)
 # re-runs release-verify and checks the notes actually merged before handing
 # off to tag.sh, so it is the entry point to prefer over release-tag for a
 # pre-release; release-tag stays the bare tagging primitive (and the only
-# entry point for the stable line cut from main).
+# entry point for stable releases cut from rust).
 release-perf: ## Benchmark V=x.y.z and regenerate the release-notes graphs
 	@bash $(ROOT)scripts/release/perf_release.sh $(V) $(PERF_ARGS)
 
@@ -2151,10 +2151,10 @@ publish-flow: ## Print the release + marketplace publish cheat-sheet
 	@echo "    # SSLICTCL_SOURCE_DATA_WAIVER for release preflight."
 	@echo ""
 	@echo "  Channels (the tag decides — scripts/release/prerelease.sh):"
-	@echo "    stable / default   v1.x, v2.2.0 (even 2.x minor)  cut from main"
+	@echo "    stable / default   v2.2.0 (even 2.x minor)         cut from rust"
 	@echo "    pre-release/brave  v2.1.x (odd 2.x minor)         cut from rust"
 	@echo "    # odd-minor 2.x -> GitHub --prerelease + VS Code --pre-release channel;"
-	@echo "    # 1.x stays the default install until a user opts into pre-releases."
+	@echo "    # the 1.x Python line is frozen on the locked legacy-py archive."
 	@echo ""
 	@echo "  For the 2.1.x pre-release line, steps 1-2 are one program:"
 	@echo "    make release-prepare V=X.Y.Z     # preflight, benchmark, graphs, notes, verify, commit"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,7 @@ outside collaborators**
       collaborators` if release cadence allows.  This is the gate that
       stops a one-line malicious PR from running CI under your token.
 
-**Settings → Branches → Branch protection for `main`**
+**Settings → Rules → Rulesets → Branch protection for `rust`**
 
 - [x] `Require a pull request before merging` — on
 - [x] `Require approvals` — at least 1

--- a/docs/design/contracts/release-and-publish.md
+++ b/docs/design/contracts/release-and-publish.md
@@ -180,11 +180,13 @@ before a planned release.
 
 ## Stable vs pre-release channels (odd/even-minor)
 
-Two release lines run in parallel and the **tag alone** decides which:
+All active releases are cut from `rust`; the **tag alone** decides the
+publication channel. The former Python line is preserved, read-only, on
+`legacy-py` and is not a release source:
 
 | Line | Tags | Cut from | GitHub Release | VS Code Marketplace | Open VSX | JetBrains Marketplace |
 |---|---|---|---|---|---|---|
-| **Stable** (default) | `v1.x`, `v2.2.0`, … (even 2.x minor) | `main` | normal / `latest` | normal channel | normal channel | Stable channel |
+| **Stable** (default) | `v2.2.0`, … (even 2.x minor) | `rust` | normal / `latest` | normal channel | normal channel | Stable channel |
 | **Pre-release** ("for the brave") | `v2.1.x` (odd 2.x minor) | `rust` | `--prerelease` (never `latest`) | `--pre-release` channel | `--pre-release` channel | `eap` channel |
 
 This is the VS Code Marketplace
@@ -192,9 +194,8 @@ This is the VS Code Marketplace
 from major 2 onward an **odd** minor is a pre-release and an **even**
 minor is stable.  The 2.x rewrite ships its alphas on `2.1.x`
 (`2.1.0`, `2.1.1`, …) and promotes to the stable `2.2.0` when ready.
-The 1.x line predates the convention and is always stable, so it stays
-the default download and the default Marketplace install for everyone
-who has not opted into pre-releases.  Open VSX reads the same
+The 1.x line predates the convention and is frozen on `legacy-py`; it is not
+tagged again. Open VSX reads the same
 pre-release channel from the VSIX manifest
 (`Microsoft.VisualStudio.Code.PreRelease`) that `vsce package` bakes in
 at build time — `ovsx publish` ignores `--pre-release` for an
@@ -205,8 +206,8 @@ not separately at each publish step.
 It prints `true`/`false`, and every pre-release switch reads it so CI,
 the Makefile, and `tag.sh` can never disagree:
 
-* `tag.sh` expects an odd-minor 2.x tag to be cut from `rust`, an even /
-  1.x tag from `main` (override with `ALLOW_NON_MAIN_RELEASE=1`).
+* `tag.sh` expects every active tag to be cut from `rust` (override with
+  `ALLOW_NON_RUST_RELEASE=1`); odd/even minor parity selects only the channel.
 * the `create-release` CI job adds `--prerelease` to `gh release create`.
 * the `publish-vsix-marketplace` CI job (and the laptop `make publish-vsix`)
   add `--pre-release` to `vsce publish` for odd-minor 2.x tags.

--- a/editors/zed/README.md
+++ b/editors/zed/README.md
@@ -160,7 +160,7 @@ Add to your Zed `settings.json` to configure the language server:
 ### Full settings reference
 
 See the [VS Code extension
-documentation](https://github.com/bitwisecook/tcl-lsp/blob/main/editors/vscode/package.json)
+documentation](https://github.com/bitwisecook/tcl-lsp/blob/rust/editors/vscode/package.json)
 for the complete list of `tclLsp.*` settings — all are supported in Zed via
 the `lsp.tcl-lsp.settings` path.
 

--- a/rust/bigip-report-gen/python/deploy/README.md
+++ b/rust/bigip-report-gen/python/deploy/README.md
@@ -36,7 +36,7 @@ is installed from it and the two are kept byte-identical.
    browser, "Request desktop site" if needed): repo **Settings → Pages → Build
    and deployment → Source → "GitHub Actions"**.
 
-3. **Run it** — it runs automatically on pushes to `main` that touch the report,
+3. **Run it** — it runs automatically on pushes to `rust` that touch the report,
    or trigger it manually from the **Actions** tab → *Publish BIG-IP example
    report to GitHub Pages* → **Run workflow**.
 
@@ -52,7 +52,7 @@ The report is then served at `https://<owner>.github.io/<repo>/`.
   (they share the `pages` concurrency group / `github-pages` environment, so the
   most recent run wins). The old manual-only `pages.yml` it superseded is gone.
 - **Environment branch policy.** The `github-pages` environment may restrict
-  deployments to the default branch. Once this branch is merged to `main`, the
+  deployments to the default branch. Once this branch is merged to `rust`, the
   push trigger deploys automatically; to deploy from a feature branch first,
   allow it under Settings → Environments → github-pages.
 - **No wasm toolchain needed.** The Mermaid library and the wasm query engine

--- a/rust/bigip-report-gen/python/deploy/github-pages.yml
+++ b/rust/bigip-report-gen/python/deploy/github-pages.yml
@@ -54,12 +54,11 @@ name: Deploy GitHub Pages (BIG-IP report + compiler explorer + spec studio)
 # no longer exists on the Python-free `rust` line.
 on:
   push:
-    # `rust` is the active development line these features land on; `main` is the
-    # long-term default. Deploy from whichever holds the merged code. Every
+    # `rust` is the active development and default line. Every
     # release tag also deploys from its exact commit: GitHub does not evaluate
     # `paths` filters for tag pushes, so a release-notes-only tag cannot leave
     # the live tools stamped with the preceding development version.
-    branches: [rust, main]
+    branches: [rust]
     tags: ["v*"]
     paths:
       # BIG-IP report generator + demo sources (query engine, model, renderer).

--- a/rust/xtask/src/workflow_sync.rs
+++ b/rust/xtask/src/workflow_sync.rs
@@ -209,7 +209,7 @@ mod tests {
             "Pages workflow no longer runs for release tags"
         );
         assert!(
-            text.contains("    branches: [rust, main]") && text.contains("    paths:"),
+            text.contains("    branches: [rust]") && text.contains("    paths:"),
             "Pages workflow lost its path-filtered development deployments"
         );
         assert!(

--- a/scripts/release/prerelease.sh
+++ b/scripts/release/prerelease.sh
@@ -36,7 +36,7 @@
 #
 #   * `gh release create --prerelease`  (GitHub Release — keeps it off "latest")
 #   * `vsce package/publish --pre-release`  (VS Code Marketplace pre-release channel)
-#   * the branch tag.sh expects the tag to be cut from (rust vs main)
+#   * the publication channel; tag.sh always requires the active rust branch
 #
 # Keeping the rule here honours the release-and-publish contract: CI and
 # the Makefile *invoke* this script rather than re-deriving the parity.

--- a/scripts/release/rust_release.sh
+++ b/scripts/release/rust_release.sh
@@ -98,7 +98,7 @@ Usage: scripts/release/rust_release.sh <command> [args]
   prepare X.Y.Z [--push]    preflight + perf + notes + verify + commit
   tag X.Y.Z                 check the notes landed, then create + push the tag
 
-The 2.1.x pre-release line only; stable releases are cut from main by tag.sh.
+The 2.1.x pre-release line only; stable releases are also cut from rust by tag.sh.
 See the header of this file, and docs/design/contracts/release-and-publish.md.
 EOF
 }
@@ -113,12 +113,12 @@ need_version() {
 }
 
 # The 2.1.x line only. An even-minor or 1.x version is a stable release cut
-# from `main`, which this script knows nothing about — and quietly doing the
+# which this script knows nothing about — and quietly doing the
 # rust-line thing to it would put pre-release graphs in stable notes.
 require_prerelease_line() {
     local v="$1"
     [ "$(bash "$HERE/prerelease.sh" "$v")" = "true" ] ||
-        die "v$v is a stable release (cut from main). This script drives the
+        die "v$v is a stable release (cut from rust via tag.sh). This script drives the
        $RELEASE_BRANCH pre-release line only — see scripts/release/tag.sh."
 }
 
@@ -164,10 +164,10 @@ cmd_preflight() {
     # branch its own previous run left you on.
     local branch; branch="$(git -C "$ROOT" branch --show-current)"
     if [ "$branch" != "$RELEASE_BRANCH" ] && [ "$branch" != "release/v$v" ] &&
-       [ "${ALLOW_NON_MAIN_RELEASE:-0}" != "1" ]; then
+       [ "${ALLOW_NON_RUST_RELEASE:-0}" != "1" ]; then
         die "on branch '$branch'; 2.x pre-releases are cut from '$RELEASE_BRANCH'
        (or its 'release/v$v' preparation branch).
-       Set ALLOW_NON_MAIN_RELEASE=1 to override."
+       Set ALLOW_NON_RUST_RELEASE=1 to override."
     fi
     echo "    branch:   $branch"
 
@@ -331,7 +331,7 @@ cmd_tag() {
     # after: CI reads RELEASE_NOTES.md from the tagged commit, and perf.yml
     # attaches the graphs to the release the tag creates.
     local branch; branch="$(git -C "$ROOT" branch --show-current)"
-    [ "$branch" = "$RELEASE_BRANCH" ] || [ "${ALLOW_NON_MAIN_RELEASE:-0}" = "1" ] ||
+    [ "$branch" = "$RELEASE_BRANCH" ] || [ "${ALLOW_NON_RUST_RELEASE:-0}" = "1" ] ||
         die "on '$branch' — tag from '$RELEASE_BRANCH' so the tag carries the merged notes"
 
     head -1 "$ROOT/RELEASE_NOTES.md" | grep -qx "# v$v" ||

--- a/scripts/release/tag.sh
+++ b/scripts/release/tag.sh
@@ -25,7 +25,7 @@
 # All version literals in the repo derive from the latest annotated tag
 # (via hatch-vcs for the Python wheel, via the Makefile + ``git describe``
 # for every editor build). A release therefore needs no source-file edits
-# and no commit on ``main``; this script just validates state, tags HEAD,
+# and no commit on ``rust``; this script just validates state, tags HEAD,
 # and pushes the tag. The push triggers ``.github/workflows/ci.yml``,
 # which builds + publishes the release artefacts.
 set -euo pipefail
@@ -51,27 +51,25 @@ if git rev-parse "v$V" >/dev/null 2>&1; then
     exit 1
 fi
 
-# Channel for this version (odd/even-minor convention — see prerelease.sh):
-# pre-release (2.1.x) is cut from ``rust``; stable (1.x, 2.2.0, …) is cut
-# from ``main``.  CI marks the GitHub Release and the VS Code publish
-# accordingly off the very same parity, so the tag alone fully determines
-# the channel.
+# Channel for this version (odd/even-minor convention — see prerelease.sh).
+# Every active release is cut from ``rust``; parity controls only the GitHub
+# Release and Marketplace channel. The locked ``legacy-py`` branch is an
+# archive and is never a release source.
 prerelease="$(bash "$(dirname "$0")/prerelease.sh" "$V")"
 if [[ "$prerelease" == "true" ]]; then
     channel="pre-release"
-    expected_branch="rust"
 else
     channel="stable"
-    expected_branch="main"
 fi
+expected_branch="rust"
 echo "==> v$V is a $channel release (expected branch: $expected_branch)"
 
-# Sanity-check the branch. Override by setting ALLOW_NON_MAIN_RELEASE=1 if
+# Sanity-check the branch. Override by setting ALLOW_NON_RUST_RELEASE=1 if
 # you need to tag from elsewhere (RC branches, hot-fix branches, etc.).
 branch="$(git branch --show-current)"
-if [[ -n "$branch" && "$branch" != "$expected_branch" && "${ALLOW_NON_MAIN_RELEASE:-0}" != "1" ]]; then
+if [[ -n "$branch" && "$branch" != "$expected_branch" && "${ALLOW_NON_RUST_RELEASE:-0}" != "1" ]]; then
     echo "error: refusing to tag $channel release v$V from branch '$branch' (expected '$expected_branch')."
-    echo "       set ALLOW_NON_MAIN_RELEASE=1 to override."
+    echo "       set ALLOW_NON_RUST_RELEASE=1 to override."
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- route CI, performance, Pages, CodeQL documentation, Scorecard, and cache retention through rust
- make rust the only active release branch and preserve legacy-py as a frozen archive
- update generated-workflow checks, contributor guidance, and branch-specific links

## Verification
- make rust-check
- make prep-pr
- git diff --check
- repository-wide branch-reference audit