### PR TITLE
fix(lsp): resolve inherited TclOO callback captures by effective visibility

### DIFF
--- a/docs/design/contracts/tcloo-implementation.md
+++ b/docs/design/contracts/tcloo-implementation.md
@@ -80,6 +80,58 @@ Method resolution order uses a linearisation matching C Tcl's algorithm.  It
 lives in `tcl-syntax` so the analyser and the bytecode VM share one
 implementation without the VM depending on the compiler.
 
+### Export state vs. implementation (`ClassHierarchy::spine_map`)
+
+External dispatch reads **two independent facts** off the linearisation, and
+`TclOO` sources them from different classes:
+
+- the **export flag**, from the *most specific* class on the receiver's
+  superclass spine that *mentions* the member name;
+- the **implementation**, from the first class on the full MRO that declares a
+  body.
+
+They come apart because `export` / `unexport` accept a name their class does
+not define: C's `TclOODefineExportObjCmd` creates a body-less method-table
+entry whose only content is the flag.  `info class methods` does not list such
+an entry, so the state cannot be read off the member tables alone — the
+`ClassDef::exports` / `unexports` sets (and their class-object twins) are the
+record.  Oracle, byte-identical on tclsh 8.6.16 and 9.0.4:
+
+```tcl
+oo::class create Base   { method tick {} { return base } }
+oo::class create Child  { superclass Base } ; oo::define Child { unexport tick }
+[Child new] tick     ;# -> unknown method "tick"   (Base's public body, suppressed here)
+
+oo::class create Base3  { method tock {} { return b3 } ; unexport tock }
+oo::class create Child3 { superclass Base3 ; export tock }
+[Child3 new] tock    ;# -> b3                      (Base3's unexported body, revived here)
+[Base3 new] tock     ;# -> unknown method "tock"
+```
+
+`private` is not such a flag: it is a separate, class-local slot, and a
+subclass's `export` cannot lift it (9.0.4).  Internal (`my`) dispatch ignores
+the export flag entirely and reaches `Base`'s body in the first case above.
+
+**Mixins are excluded from the flag walk.** C's
+`AddSimpleClassChainToCallContext` enters each mixin with a *fresh copy* of
+the dispatch flags, so a mixin that unexports the name empties only its own
+branch while the superclass chain still answers; the same word on the spine
+decides the whole dispatch.  `ClassHierarchy::spine_map` is therefore a second
+linearisation — the same resolved `superclass` edges as `mro_map`, with the
+mixin edges withheld — built by the same
+[`tcl_syntax::mro`](../../../rust/tcl-syntax/src/mro.rs) owner so the two
+orders cannot disagree about which qualified name a bare `superclass Device`
+meant.  `WorkspaceIndex::class_linearisation_and_spine` is the cross-file
+twin, and both dispatch folds (`tcl_lsp_core::oo_dispatch::method_dispatch_provider`
+in-document, `WorkspaceIndex::dispatch_chain` across files) read the flag the
+same way (issue #1705).
+
+Known limit: with multiple `superclass`es the spine is walked in declaration
+order and the first mention wins.  C keeps each branch's flags independent, so
+a later branch disagreeing with the first is approximated rather than
+modelled — the same single-linearisation approximation `mro_map` already
+makes.
+
 ### VM runtime layer (`rust/tcl-vm/src/cmd_oo.rs`)
 
 The VM manages the object/class registry at runtime:
@@ -113,7 +165,9 @@ Reference results captured from real tclsh 8.4–9.0 are queryable via the
 |------|------|
 | `rust/tcl-vm/src/cmd_oo.rs` | OO runtime (object/class registry, dispatch, define body parsing) |
 | `rust/tcl-vm/src/cmd_info.rs` | `info object` / `info class` introspection |
-| `rust/tcl-syntax/src/mro.rs` | MRO linearisation (shared analyser ↔ VM) |
+| `rust/tcl-syntax/src/mro.rs` | MRO linearisation (shared analyser ↔ VM; also the mixin-free spine) |
+| `rust/tcl-lsp-core/src/oo_dispatch.rs` | In-document dispatch entry + effective export state |
+| `rust/tcl-lsp-core/src/workspace_index.rs` | Cross-file dispatch chain (same fold, workspace records) |
 | `rust/tcl-compiler/src/analyser/oo.rs` | Static OO analysis (class/method extraction) |
 | `rust/tcl-compiler/src/analyser/class_hierarchy.rs` | Owner-aware hierarchy index + one-hop class resolution |
 | `rust/tcl-registry/src/definer.rs` | Definer body grammars (TclOO / snit / itcl as data) |

--- a/docs/design/contracts/tcloo-implementation.md
+++ b/docs/design/contracts/tcloo-implementation.md
@@ -112,19 +112,48 @@ oo::class create Child3 { superclass Base3 ; export tock }
 subclass's `export` cannot lift it (9.0.4).  Internal (`my`) dispatch ignores
 the export flag entirely and reaches `Base`'s body in the first case above.
 
-**Mixins are excluded from the flag walk.** C's
+**Every `mixin` branch decides for itself.** C's
 `AddSimpleClassChainToCallContext` enters each mixin with a *fresh copy* of
-the dispatch flags, so a mixin that unexports the name empties only its own
-branch while the superclass chain still answers; the same word on the spine
-decides the whole dispatch.  `ClassHierarchy::spine_map` is therefore a second
-linearisation — the same resolved `superclass` edges as `mro_map`, with the
-mixin edges withheld — built by the same
-[`tcl_syntax::mro`](../../../rust/tcl-syntax/src/mro.rs) owner so the two
+the dispatch flags, so a branch's `export` / `unexport` governs that branch
+alone and never travels to another.  The dispatch is therefore a sequence of
+mixin-free spines — each reachable mixin branch, then the receiver's own
+`superclass` spine — and a provider answers to the flag of the **first branch
+that reaches it**:
+
+```tcl
+oo::class create A      { method m {} { return A-m } }
+oo::class create MBase  { method m {} { return MBase-m } }
+oo::class create MChild { superclass MBase } ; oo::define MChild { unexport m }
+oo::class create D { superclass A ; mixin MChild }
+[D new] m           ;# -> A-m       (the mixin branch is empty; the spine answers)
+
+oo::class create MPub { superclass MBase }
+oo::class create D2 { superclass A ; mixin MPub }
+[D2 new] m          ;# -> MBase-m   (a live mixin branch outranks the spine)
+
+oo::class create NBase  { method n {} { return NBase-n } ; unexport n }
+oo::class create NChild { superclass NBase ; export n }
+oo::class create A2 { method n {} { return A2-n } }
+oo::class create D3 { superclass A2 ; mixin NChild }
+[D3 new] n          ;# -> NBase-n   (the branch's own export revives its base)
+```
+
+Branch roots are collected transitively, so a `mixin` written on a superclass
+or on another mixin is walked the same way.  `ClassHierarchy::spine_map` is the
+mixin-free linearisation each branch is read along — the same resolved
+`superclass` edges as `mro_map`, with the mixin edges withheld, from the same
+[`tcl_syntax::mro`](../../../rust/tcl-syntax/src/mro.rs) owner, so the two
 orders cannot disagree about which qualified name a bare `superclass Device`
-meant.  `WorkspaceIndex::class_linearisation_and_spine` is the cross-file
-twin, and both dispatch folds (`tcl_lsp_core::oo_dispatch::method_dispatch_provider`
-in-document, `WorkspaceIndex::dispatch_chain` across files) read the flag the
-same way (issue #1705).
+meant — and `ClassHierarchy::mixin_map` carries the owner-resolved mixin edges
+that name the roots.  `WorkspaceIndex`'s `ClassEdges` is the cross-file twin,
+and both dispatch folds
+(`tcl_lsp_core::oo_dispatch::method_dispatch_provider` in-document,
+`WorkspaceIndex::dispatch_chain` across files) read the flag the same way
+(issue #1705).
+
+The two dispatch kinds can consequently land on **different classes** for one
+receiver, and consumers must ask separately: with the `MChild` shape above,
+`my m` inside `D` reaches `MBase::m` while `[list [self] m]` reaches `A::m`.
 
 Known limit: with multiple `superclass`es the spine is walked in declaration
 order and the first mention wins.  C keeps each branch's flags independent, so
@@ -165,7 +194,7 @@ Reference results captured from real tclsh 8.4–9.0 are queryable via the
 |------|------|
 | `rust/tcl-vm/src/cmd_oo.rs` | OO runtime (object/class registry, dispatch, define body parsing) |
 | `rust/tcl-vm/src/cmd_info.rs` | `info object` / `info class` introspection |
-| `rust/tcl-syntax/src/mro.rs` | MRO linearisation (shared analyser ↔ VM; also the mixin-free spine) |
+| `rust/tcl-syntax/src/mro.rs` | MRO linearisation (shared analyser ↔ VM; also each mixin-free branch spine) |
 | `rust/tcl-lsp-core/src/oo_dispatch.rs` | In-document dispatch entry + effective export state |
 | `rust/tcl-lsp-core/src/workspace_index.rs` | Cross-file dispatch chain (same fold, workspace records) |
 | `rust/tcl-compiler/src/analyser/oo.rs` | Static OO analysis (class/method extraction) |

--- a/rust/tcl-compiler/src/analyser/class_hierarchy.rs
+++ b/rust/tcl-compiler/src/analyser/class_hierarchy.rs
@@ -76,6 +76,32 @@ pub struct ClassHierarchy {
     pub classes: HashMap<String, ClassDef>,
     /// Class → linearised MRO (including self).
     pub mro_map: HashMap<String, Vec<String>>,
+    /// Class → its **mixin-free** linearisation (including self) — the
+    /// `superclass` spine alone, in the order `TclOO`'s call-chain builder
+    /// walks it.
+    ///
+    /// Separate from [`Self::mro_map`] because C's
+    /// `AddSimpleClassChainToCallContext` treats the two paths differently:
+    /// each mixin is entered with a *fresh copy* of the dispatch flags, so a
+    /// mixin that unexports a name empties only its own branch, whereas the
+    /// same word on the spine decides the whole dispatch.  Oracle,
+    /// byte-identical on tclsh 8.6.16 and 9.0.4:
+    ///
+    /// ```tcl
+    /// oo::class create A   { method m {} { return A-m } }
+    /// oo::class create Mix { method m {} { return Mix-m } }
+    /// oo::define Mix { unexport m }
+    /// oo::class create D { superclass A ; mixin Mix }
+    /// [D new] m          ;# -> A-m  (the mixin's unexport did not suppress A's m)
+    /// oo::class create B { superclass A }
+    /// oo::define B { unexport m }
+    /// [B new] m          ;# -> unknown method "m"  (the spine's unexport did)
+    /// ```
+    ///
+    /// Built by the same linearisation owner as `mro_map`, over the same
+    /// resolved superclass edges, so the two orders can never disagree about
+    /// which qualified name a bare `superclass Device` meant.
+    pub spine_map: HashMap<String, Vec<String>>,
     /// Class → direct subclasses.
     pub subclasses: HashMap<String, HashSet<String>>,
     /// Class → all descendants (transitive closure).
@@ -786,6 +812,17 @@ pub fn build_class_hierarchy<S: std::hash::BuildHasher>(
         }
     }
 
+    // The mixin-free spine, from the same resolved `supers_map` and the same
+    // linearisation owner — only the mixin edges are withheld.  Backfilled
+    // identically, so every indexed class has an entry.
+    let no_mixins: HashMap<String, Vec<String>> = HashMap::new();
+    let (mut spine_map, _spine_errors) = build_mro_map(&supers_map, &no_mixins);
+    for qname in classes.keys() {
+        if !spine_map.contains_key(qname) {
+            spine_map.insert(qname.clone(), vec![qname.clone()]);
+        }
+    }
+
     // Build direct-subclass map.  Initialise with empty sets
     // for every class so callers see a non-None entry even when
     // a class has no subclasses.
@@ -848,6 +885,7 @@ pub fn build_class_hierarchy<S: std::hash::BuildHasher>(
     ClassHierarchy {
         classes,
         mro_map,
+        spine_map,
         subclasses: direct_subs,
         transitive_subtypes: transitive,
         method_providers,

--- a/rust/tcl-compiler/src/analyser/class_hierarchy.rs
+++ b/rust/tcl-compiler/src/analyser/class_hierarchy.rs
@@ -76,6 +76,15 @@ pub struct ClassHierarchy {
     pub classes: HashMap<String, ClassDef>,
     /// Class → linearised MRO (including self).
     pub mro_map: HashMap<String, Vec<String>>,
+    /// Class → its owner-resolved **direct** `mixin` edges, in declaration
+    /// order — the same resolution [`Self::mro_map`] linearises through, kept
+    /// so a consumer can tell which *branch* of the call chain a provider was
+    /// reached on without re-resolving the names itself.
+    ///
+    /// C walks each mixin branch with a fresh copy of the dispatch flags, so
+    /// the branch a provider sits on is what decides its export state (see
+    /// [`Self::spine_map`]).
+    pub mixin_map: HashMap<String, Vec<String>>,
     /// Class → its **mixin-free** linearisation (including self) — the
     /// `superclass` spine alone, in the order `TclOO`'s call-chain builder
     /// walks it.
@@ -885,6 +894,7 @@ pub fn build_class_hierarchy<S: std::hash::BuildHasher>(
     ClassHierarchy {
         classes,
         mro_map,
+        mixin_map: mixins_map,
         spine_map,
         subclasses: direct_subs,
         transitive_subtypes: transitive,

--- a/rust/tcl-lsp-core/src/oo_dispatch.rs
+++ b/rust/tcl-lsp-core/src/oo_dispatch.rs
@@ -127,12 +127,12 @@ impl OoFrame {
 /// is *visible* in this context wins:
 ///
 /// * `external` (a `$obj m` / `CLASS m` dispatch) sees exported
-///   implementations only — and "exported" is the receiver's *effective*
-///   state ([`superclass_chain_export_state`]), not the provider's own
-///   declaration, because a subclass can `export` / `unexport` a name it
-///   inherits without redeclaring it.  A provider reached through a mixin
-///   keeps the per-entry reading: C enters each mixin with a fresh copy of
-///   the dispatch flags, so the spine's state does not travel there.
+///   implementations only — and "exported" is the *effective* state of the
+///   branch that reaches the provider ([`dispatch_branch_spines`] +
+///   [`spine_export_state`]), not the provider's own declaration, because a
+///   class can `export` / `unexport` a name it inherits without redeclaring
+///   it.  Each `mixin` branch decides for itself: C enters it with a fresh
+///   copy of the dispatch flags, so no branch's state travels to another.
 /// * an internal (`my m`) dispatch also reaches unexported ones, and
 ///   `private` ones only in the receiver's own class.  Export state is not
 ///   consulted at all: `my` ignores it (tclsh 8.6.16 / 9.0.4 —
@@ -158,13 +158,16 @@ pub(crate) fn method_dispatch_provider<'a>(
     let mro = hierarchy.mro_map.get(class_q)?;
     // Read once for the whole walk: the flag is a property of the *receiver*,
     // and every spine provider answers to it.
-    let spine_export = external
-        .then(|| superclass_chain_export_state(analysis, class_q, method, bucket))
-        .flatten();
-    let spine: &[String] = if spine_export.is_some() {
-        hierarchy.spine_map.get(class_q).map_or(&[], Vec::as_slice)
+    let branches: Vec<(Vec<String>, Option<bool>)> = if external {
+        dispatch_branch_spines(analysis, class_q)
+            .into_iter()
+            .map(|spine| {
+                let state = spine_export_state(analysis, &spine, method, bucket);
+                (spine, state)
+            })
+            .collect()
     } else {
-        &[]
+        Vec::new()
     };
     for provider_q in mro {
         let Some(cd) = analysis.all_classes.get(provider_q) else {
@@ -184,15 +187,13 @@ pub(crate) fn method_dispatch_provider<'a>(
         };
         let Some(md) = md else { continue };
         let visible = if external {
-            match spine_export {
+            match branch_export_state(&branches, provider_q) {
                 // `private` is the one state an `export` cannot lift: it is
                 // not a flag on a table entry but a separate, class-local
                 // slot (tclsh 9.0.4 — a subclass's `export priv` still
                 // leaves `[Child new] priv` an `unknown method`).
-                Some(exported) if spine.contains(provider_q) => {
-                    exported && md.visibility != "private"
-                }
-                _ => md.visibility == "public",
+                Some(exported) => exported && md.visibility != "private",
+                None => md.visibility == "public",
             }
         } else {
             md.visibility != "private" || provider_q == class_q
@@ -204,15 +205,96 @@ pub(crate) fn method_dispatch_provider<'a>(
     None
 }
 
+/// The export flag the branch that reaches `provider_q` decides, or `None`
+/// when no branch mentions the member at all (nothing decided — the caller's
+/// per-entry reading stands).
+///
+/// The **first** branch containing the provider wins, and `branches` is in the
+/// order the call chain walks them, so a provider that several branches reach
+/// answers to the one that got there first — the same rule the linearisation
+/// itself applies to the implementation.
+fn branch_export_state(branches: &[(Vec<String>, Option<bool>)], provider_q: &str) -> Option<bool> {
+    branches
+        .iter()
+        .find(|(spine, _)| spine.iter().any(|c| c == provider_q))
+        .and_then(|(_, state)| *state)
+}
+
+/// The mixin-free spines `TclOO`'s call-chain builder walks for a receiver of
+/// class `class_q`, in the order it walks them: every reachable `mixin`
+/// branch, then the receiver's own `superclass` spine.
+///
+/// C enters each mixin with a **fresh copy** of the dispatch flags, so a
+/// branch decides visibility only for the providers *it* reaches; the flags
+/// never travel between branches.  That is one rule, and it applies at every
+/// depth — a mixin that inherits the member from its own superclass and
+/// changes that name's visibility governs its branch exactly as the receiver
+/// governs the spine.  Oracle, byte-identical on tclsh 8.6.16 and 9.0.4:
+///
+/// ```tcl
+/// oo::class create A      { method m {} { return A-m } }
+/// oo::class create MBase  { method m {} { return MBase-m } }
+/// oo::class create MChild { superclass MBase } ; oo::define MChild { unexport m }
+/// oo::class create D { superclass A ; mixin MChild }
+/// [D new] m           ;# -> A-m       (the mixin branch is empty; the spine answers)
+///
+/// oo::class create MPub { superclass MBase }
+/// oo::class create D2 { superclass A ; mixin MPub }
+/// [D2 new] m          ;# -> MBase-m   (a live mixin branch outranks the spine)
+///
+/// oo::class create NBase  { method n {} { return NBase-n } ; unexport n }
+/// oo::class create NChild { superclass NBase ; export n }
+/// oo::class create A2 { method n {} { return A2-n } }
+/// oo::class create D3 { superclass A2 ; mixin NChild }
+/// [D3 new] n          ;# -> NBase-n   (the branch's own export revives its base)
+/// ```
+///
+/// Branch roots are collected transitively — a mixin declared on a superclass,
+/// or on another mixin, is walked the same way (`[D4 new] m` is `A-m` for
+/// `D4 superclass S`, `S mixin MChild`) — and ordered by where each root falls
+/// in `mro_map`, which is the order the chain builder reaches them.
+fn dispatch_branch_spines(analysis: &AnalysisResult, class_q: &str) -> Vec<Vec<String>> {
+    let hierarchy = analysis.class_hierarchy();
+    let spine_of = |q: &str| hierarchy.spine_map.get(q).cloned().unwrap_or_default();
+    let mut roots: Vec<String> = Vec::new();
+    let mut queue: std::collections::VecDeque<String> =
+        std::collections::VecDeque::from([class_q.to_owned()]);
+    let mut seen: std::collections::HashSet<String> =
+        std::collections::HashSet::from([class_q.to_owned()]);
+    while let Some(root) = queue.pop_front() {
+        for spine_q in spine_of(&root) {
+            for mixin in hierarchy.mixin_map.get(&spine_q).into_iter().flatten() {
+                if seen.insert(mixin.clone()) {
+                    roots.push(mixin.clone());
+                    queue.push_back(mixin.clone());
+                }
+            }
+        }
+    }
+    // `mro_map` is the order the chain builder reaches these classes; a root it
+    // does not list at all sorts last but keeps its discovery order.
+    let mro = hierarchy.mro_map.get(class_q);
+    roots.sort_by_key(|root| {
+        mro.and_then(|mro| mro.iter().position(|c| c == root))
+            .unwrap_or(usize::MAX)
+    });
+    roots
+        .into_iter()
+        .map(|root| spine_of(&root))
+        .chain(std::iter::once(spine_of(class_q)))
+        .collect()
+}
+
+/// The export flag an **external** dispatch (`$obj m`, `CLASS m`, or a
 /// The export flag an **external** dispatch (`$obj m`, `CLASS m`, or a
 /// captured `[self]` object command) reads for `method` on a receiver of
 /// class `class_q` — `None` when nothing on the superclass spine mentions the
 /// name, so there is no state to read.
 ///
-/// The spine is `ClassHierarchy::spine_map` — the mixin-free linearisation,
-/// built from the same resolved superclass edges as `mro_map`, because C
-/// enters each mixin with a fresh copy of the dispatch flags and so lets a
-/// mixin's `unexport` empty only its own branch.
+/// `spine` is one mixin-free linearisation from
+/// [`dispatch_branch_spines`] — the receiver's own, or a `mixin` branch's —
+/// because C enters each mixin with a fresh copy of the dispatch flags and so
+/// lets a branch's `unexport` empty only that branch.
 ///
 /// `TclOO` takes this flag from the *most specific* spine class that mentions
 /// the member and the **implementation** from the first class that declares a
@@ -244,14 +326,13 @@ pub(crate) fn method_dispatch_provider<'a>(
 /// keeps each branch's flags independent, so a *later* branch disagreeing
 /// with the first is approximated rather than modelled — the same
 /// single-linearisation approximation `mro_map` already makes.
-fn superclass_chain_export_state(
+fn spine_export_state(
     analysis: &AnalysisResult,
-    class_q: &str,
+    spine: &[String],
     method: &str,
     bucket: MethodBucket,
 ) -> Option<bool> {
-    let hierarchy = analysis.class_hierarchy();
-    for spine_q in hierarchy.spine_map.get(class_q)? {
+    for spine_q in spine {
         let Some(cd) = analysis.all_classes.get(spine_q) else {
             continue;
         };

--- a/rust/tcl-lsp-core/src/oo_dispatch.rs
+++ b/rust/tcl-lsp-core/src/oo_dispatch.rs
@@ -127,9 +127,17 @@ impl OoFrame {
 /// is *visible* in this context wins:
 ///
 /// * `external` (a `$obj m` / `CLASS m` dispatch) sees exported
-///   implementations only.
+///   implementations only — and "exported" is the receiver's *effective*
+///   state ([`superclass_chain_export_state`]), not the provider's own
+///   declaration, because a subclass can `export` / `unexport` a name it
+///   inherits without redeclaring it.  A provider reached through a mixin
+///   keeps the per-entry reading: C enters each mixin with a fresh copy of
+///   the dispatch flags, so the spine's state does not travel there.
 /// * an internal (`my m`) dispatch also reaches unexported ones, and
-///   `private` ones only in the receiver's own class.
+///   `private` ones only in the receiver's own class.  Export state is not
+///   consulted at all: `my` ignores it (tclsh 8.6.16 / 9.0.4 —
+///   `oo::define Child { unexport tick }` leaves `my tick` reaching
+///   `Base`'s body).
 ///
 /// `None` is a definitive "no implementation is callable here" — mirroring
 /// C's `unknown method` — not "look somewhere else".
@@ -148,6 +156,16 @@ pub(crate) fn method_dispatch_provider<'a>(
 ) -> Option<(&'a str, &'a MethodDef)> {
     let hierarchy = analysis.class_hierarchy();
     let mro = hierarchy.mro_map.get(class_q)?;
+    // Read once for the whole walk: the flag is a property of the *receiver*,
+    // and every spine provider answers to it.
+    let spine_export = external
+        .then(|| superclass_chain_export_state(analysis, class_q, method, bucket))
+        .flatten();
+    let spine: &[String] = if spine_export.is_some() {
+        hierarchy.spine_map.get(class_q).map_or(&[], Vec::as_slice)
+    } else {
+        &[]
+    };
     for provider_q in mro {
         let Some(cd) = analysis.all_classes.get(provider_q) else {
             continue;
@@ -166,12 +184,89 @@ pub(crate) fn method_dispatch_provider<'a>(
         };
         let Some(md) = md else { continue };
         let visible = if external {
-            md.visibility == "public"
+            match spine_export {
+                // `private` is the one state an `export` cannot lift: it is
+                // not a flag on a table entry but a separate, class-local
+                // slot (tclsh 9.0.4 — a subclass's `export priv` still
+                // leaves `[Child new] priv` an `unknown method`).
+                Some(exported) if spine.contains(provider_q) => {
+                    exported && md.visibility != "private"
+                }
+                _ => md.visibility == "public",
+            }
         } else {
             md.visibility != "private" || provider_q == class_q
         };
         if visible {
             return Some((provider_q.as_str(), md));
+        }
+    }
+    None
+}
+
+/// The export flag an **external** dispatch (`$obj m`, `CLASS m`, or a
+/// captured `[self]` object command) reads for `method` on a receiver of
+/// class `class_q` — `None` when nothing on the superclass spine mentions the
+/// name, so there is no state to read.
+///
+/// The spine is `ClassHierarchy::spine_map` — the mixin-free linearisation,
+/// built from the same resolved superclass edges as `mro_map`, because C
+/// enters each mixin with a fresh copy of the dispatch flags and so lets a
+/// mixin's `unexport` empty only its own branch.
+///
+/// `TclOO` takes this flag from the *most specific* spine class that mentions
+/// the member and the **implementation** from the first class that declares a
+/// body; the two are genuinely independent, because `export` / `unexport`
+/// accept a name their class does not define and create a body-less table
+/// entry whose only content is the flag.  `info class methods` does not list
+/// such an entry, which is why this cannot be read off the member tables
+/// alone.  Oracle, byte-identical on tclsh 8.6.16 and 9.0.4:
+///
+/// ```tcl
+/// oo::class create Base   { method tick {} { return base } }
+/// oo::class create Child  { superclass Base }
+/// oo::define Child { unexport tick }
+/// [Child new] tick    ;# -> unknown method "tick"  (Base's public body, suppressed here)
+/// oo::class create Base3  { method tock {} { return b3 } ; unexport tock }
+/// oo::class create Child3 { superclass Base3 ; export tock }
+/// [Child3 new] tock   ;# -> b3   (Base3's unexported body, revived here)
+/// [Base3 new] tock    ;# -> unknown method "tock"
+/// ```
+///
+/// A declaration on the deciding class outranks that class's own stub sets: a
+/// later `method g {…}` re-applies the name's default visibility over an
+/// earlier `unexport g` (tclsh 8.6.16 / 9.0.4 — `oo::define G { unexport g ;
+/// method g {} {…} }` leaves `[G new] g` callable), and the analyser has
+/// already folded that source order into `MethodDef::visibility`.
+///
+/// Multiple `superclass`es are walked in declaration order and the first
+/// mention wins, matching the order the chain builder appends them in.  C
+/// keeps each branch's flags independent, so a *later* branch disagreeing
+/// with the first is approximated rather than modelled — the same
+/// single-linearisation approximation `mro_map` already makes.
+fn superclass_chain_export_state(
+    analysis: &AnalysisResult,
+    class_q: &str,
+    method: &str,
+    bucket: MethodBucket,
+) -> Option<bool> {
+    let hierarchy = analysis.class_hierarchy();
+    for spine_q in hierarchy.spine_map.get(class_q)? {
+        let Some(cd) = analysis.all_classes.get(spine_q) else {
+            continue;
+        };
+        let (table, exports, unexports) = match bucket {
+            MethodBucket::Instance => (&cd.methods, &cd.exports, &cd.unexports),
+            MethodBucket::Class => (&cd.class_methods, &cd.class_exports, &cd.class_unexports),
+        };
+        if let Some(md) = table.get(method) {
+            return Some(md.visibility == "public");
+        }
+        if exports.contains(method) {
+            return Some(true);
+        }
+        if unexports.contains(method) {
+            return Some(false);
         }
     }
     None

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -1569,11 +1569,26 @@ pub(crate) fn method_references_for_class(
             if other_q.as_str() != class_q
                 && hierarchy.method_target(other_q, method) == Some(class_q)
             {
-                // An inheritor can export or unexport this inherited method,
-                // so provider visibility cannot prove whether a captured
-                // `[self]` object command is callable for that receiver.
-                // Preserve internal `my` references and abstain from inherited
-                // callbacks until #1705 models effective receiver visibility.
+                // An inheritor can `export` / `unexport` this inherited name
+                // without redeclaring it, so whether a captured `[self]`
+                // object command is callable is a fact about *that* receiver,
+                // not about the provider's own declaration (issue #1705).
+                // `my` captures are unaffected either way — they keep the
+                // current object's internal dispatch.
+                //
+                // Asked through the shared dispatch walk rather than re-read
+                // here, so this direction and the cursor-origin resolution in
+                // `list_built_self_method_target_at_cursor` cannot disagree
+                // about which family a capture belongs to — the exact
+                // invariant a half-applied rename would break.
+                let external_callback_allowed = crate::oo_dispatch::method_dispatch_provider(
+                    analysis,
+                    other_q,
+                    method,
+                    true,
+                    crate::definition::MethodBucket::Instance,
+                )
+                .is_some_and(|(provider, _)| provider == class_q);
                 let inherited_bodies = collect_member_bodies_scoped(other_cd, false);
                 call_spans.extend(scan_method_sites(
                     source,
@@ -1581,7 +1596,7 @@ pub(crate) fn method_references_for_class(
                     &inherited_bodies,
                     method,
                     Some(decl_span),
-                    false,
+                    external_callback_allowed,
                 ));
             }
         }
@@ -1614,6 +1629,13 @@ pub(crate) fn method_references_for_class(
 /// the exact word span as one of its callback references.  Definition,
 /// references, prepare-rename, and rename therefore cannot infer a callback
 /// target from looser syntax than the code lens uses.
+///
+/// An **inherited** provider is a normal answer (issue #1705): the walk
+/// applies the receiver's own effective export state, so a captured `[self]`
+/// callback in a subclass joins the provider's edit family exactly when
+/// `method_references_for_class` collects it from the other direction, and
+/// abstains — through the same [`crate::oo_dispatch::method_dispatch_provider`]
+/// reading — when the receiver has unexported the name.
 pub(crate) fn list_built_self_method_target_at_cursor(
     source: &str,
     dialect: &'static tcl_dialect::DialectProfile,
@@ -1635,9 +1657,6 @@ pub(crate) fn list_built_self_method_target_at_cursor(
         external,
         bucket,
     )?;
-    if provider != receiver_q {
-        return None;
-    }
     Some((provider.to_owned(), is_classmethod))
 }
 
@@ -2799,6 +2818,28 @@ fn scan_next_dispatch_region_with_target(
     }
 }
 
+/// What a **subclass-only** document cannot derive from its own tables, and
+/// so must be handed by the workspace tier that can — the two facts
+/// [`inherited_method_call_sites`] needs about a class it holds the
+/// `ClassDef` for but whose method's *definer* may live in a document it
+/// never mentions.
+#[derive(Clone, Copy, Debug)]
+pub struct InheritedReceiverFacts<'a> {
+    /// The workspace-wide class names that are valid bare-dispatch heads for
+    /// `method` when it is a `classmethod`.  A pure inheritor never declares a
+    /// copy of `method`, so its own `class_methods` map never lists it.  See
+    /// [`obj_method_call_sites`]'s identical parameter for the pure-consumer
+    /// case this mirrors.
+    pub extra_classmethod_cmd_names: &'a [String],
+    /// Whether this receiver can dispatch `method` **externally**, so a
+    /// captured `[self]` object command in its bodies really reaches the
+    /// declaration (issue #1705).  A subclass-only document cannot decide that
+    /// alone: its own `export` / `unexport` stub is local, but the provider's
+    /// declared visibility is next door.  A `my` capture needs no such
+    /// permission and is collected either way.
+    pub external_callback_allowed: bool,
+}
+
 /// Call sites of an **inherited** `method` inside `class_q`, a class that
 /// does *not* declare `method` itself but inherits it (its MRO resolves
 /// `method` to an ancestor).  Returns the intra-class `my method` sites in
@@ -2827,8 +2868,12 @@ pub(crate) fn inherited_method_call_sites(
     class_q: &str,
     method: &str,
     is_classmethod: bool,
-    extra_classmethod_cmd_names: &[String],
+    workspace: InheritedReceiverFacts<'_>,
 ) -> Vec<tcl_lexer::Span> {
+    let InheritedReceiverFacts {
+        extra_classmethod_cmd_names,
+        external_callback_allowed,
+    } = workspace;
     let Some(class_def) = analysis.all_classes.get(class_q) else {
         return Vec::new();
     };
@@ -2837,7 +2882,14 @@ pub(crate) fn inherited_method_call_sites(
     // inheritor itself, so its own classmethod bodies may still contain a
     // `my <method>` call reaching the inherited classmethod.
     let bodies = collect_member_bodies_scoped(class_def, is_classmethod);
-    let mut spans = scan_my_method_sites(source, dialect, &bodies, method, None);
+    let mut spans = scan_method_sites(
+        source,
+        dialect,
+        &bodies,
+        method,
+        None,
+        external_callback_allowed,
+    );
     spans.extend(find_obj_method_call_sites_with_extra_cmd_names(
         source,
         dialect,
@@ -6617,25 +6669,123 @@ mod tests {
     }
 
     #[test]
-    fn inherited_callback_cursor_abstains_with_the_reference_set() {
-        // Even a publicly declared provider is not enough: the inheriting
-        // receiver can independently export or unexport the effective method.
-        // Until #1705 models that state, both declaration-origin collection
-        // and cursor-origin navigation must abstain together.
+    fn inherited_callback_joins_the_providers_reference_set() {
+        // #1705: a captured `[self]` object command in an inheriting class
+        // reaches the provider's exported implementation — tclsh 8.6.16 /
+        // 9.0.4 both run `Base`'s body for `[list [Child new] tick]`.  Both
+        // directions must agree on that, or rename would edit one and not the
+        // other.
         let src = "oo::class create Base {\n    method tick {} { return 1 }\n}\noo::class create Child {\n    superclass Base\n    method wire {} {\n        after idle [list [self] tick]\n    }\n}\n";
         let analysis = analyse(src);
         let dialect = tcl_registry::model::ingress::resolve_environment("tcl").analyser_profile();
         let cursor = u32::try_from(src.find("] tick").unwrap() + 2).unwrap();
-        assert!(
-            list_built_self_method_target_at_cursor(src, dialect, &analysis, "tick", cursor,)
-                .is_none(),
-            "cursor-origin resolution must not produce a partial rename family"
+        assert_eq!(
+            list_built_self_method_target_at_cursor(src, dialect, &analysis, "tick", cursor),
+            Some(("::Base".to_owned(), false)),
+            "the inherited callback resolves to its effective provider"
         );
 
         let refs = references(src, dialect, 1, 11, &analysis, true);
         assert!(
-            !refs.iter().any(|range| range.start_line == 6),
+            refs.iter().any(|range| range.start_line == 6),
+            "declaration-origin references must collect the same site: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn a_receiver_that_unexports_the_inherited_name_abstains_both_ways() {
+        // The receiver's own `unexport` decides, not the provider's
+        // declaration: tclsh 8.6.16 / 9.0.4 answer `[Child new] tick` with
+        // `unknown method "tick"` even though `Base` exports it, so the
+        // capture is not a call site of `Base::tick` at all.
+        let src = "oo::class create Base {\n    method tick {} { return 1 }\n}\noo::class create Child {\n    superclass Base\n    unexport tick\n    method wire {} {\n        after idle [list [self] tick]\n    }\n}\n";
+        let analysis = analyse(src);
+        let dialect = tcl_registry::model::ingress::resolve_environment("tcl").analyser_profile();
+        let cursor = u32::try_from(src.find("] tick").unwrap() + 2).unwrap();
+        assert!(
+            list_built_self_method_target_at_cursor(src, dialect, &analysis, "tick", cursor)
+                .is_none(),
+            "an unexported receiver name must not resolve a captured [self] callback"
+        );
+
+        let refs = references(src, dialect, 1, 11, &analysis, true);
+        assert!(
+            !refs.iter().any(|range| range.start_line == 7),
             "declaration-origin references must make the same abstention: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn a_receiver_that_reexports_an_unexported_provider_resolves_both_ways() {
+        // The mirror case, and the one a provider-only reading gets wrong in
+        // the other direction: `Base` unexports its own `tock`, `Child`
+        // exports the inherited name, and tclsh 8.6.16 / 9.0.4 run `Base`'s
+        // body for `[Child new] tock`.
+        let src = "oo::class create Base {\n    method tock {} { return 1 }\n    unexport tock\n}\noo::class create Child {\n    superclass Base\n    export tock\n    method wire {} {\n        after idle [list [self] tock]\n    }\n}\n";
+        let analysis = analyse(src);
+        let dialect = tcl_registry::model::ingress::resolve_environment("tcl").analyser_profile();
+        let cursor = u32::try_from(src.find("] tock").unwrap() + 2).unwrap();
+        assert_eq!(
+            list_built_self_method_target_at_cursor(src, dialect, &analysis, "tock", cursor),
+            Some(("::Base".to_owned(), false)),
+            "a re-exporting receiver revives the inherited callback target"
+        );
+
+        let refs = references(src, dialect, 1, 11, &analysis, true);
+        assert!(
+            refs.iter().any(|range| range.start_line == 8),
+            "declaration-origin references must collect the same site: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn an_overriding_receiver_keeps_its_callback_in_its_own_family() {
+        // `Child` declares its own `tick`, so the capture dispatches there.
+        // `Base::tick`'s family must not claim it (renaming `Base::tick`
+        // would otherwise rewrite a word that never called it).
+        let src = "oo::class create Base {\n    method tick {} { return 1 }\n}\noo::class create Child {\n    superclass Base\n    method tick {} { return 2 }\n    method wire {} {\n        after idle [list [self] tick]\n    }\n}\n";
+        let analysis = analyse(src);
+        let dialect = tcl_registry::model::ingress::resolve_environment("tcl").analyser_profile();
+        let cursor = u32::try_from(src.find("] tick").unwrap() + 2).unwrap();
+        assert_eq!(
+            list_built_self_method_target_at_cursor(src, dialect, &analysis, "tick", cursor),
+            Some(("::Child".to_owned(), false)),
+            "the override, not the base, provides this capture"
+        );
+
+        let refs = references(src, dialect, 1, 11, &analysis, true);
+        assert!(
+            !refs.iter().any(|range| range.start_line == 7),
+            "the base declaration must not collect the override's capture: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn an_unrelated_class_does_not_collect_a_same_named_callback() {
+        // No `superclass` edge, so nothing links the two `tick`s.
+        let src = "oo::class create Base {\n    method tick {} { return 1 }\n}\noo::class create Other {\n    method tick {} { return 2 }\n    method wire {} {\n        after idle [list [self] tick]\n    }\n}\n";
+        let analysis = analyse(src);
+        let dialect = tcl_registry::model::ingress::resolve_environment("tcl").analyser_profile();
+        let refs = references(src, dialect, 1, 11, &analysis, true);
+        assert!(
+            !refs.iter().any(|range| range.start_line == 6),
+            "an unrelated class's capture is not a reference: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn a_mixins_unexport_does_not_suppress_the_superclass_capture() {
+        // C enters each mixin with a fresh copy of the dispatch flags, so a
+        // mixin that unexports the name empties only its own branch: tclsh
+        // 8.6.16 / 9.0.4 still run `Base`'s `tick` for `[Child new] tick`.
+        let src = "oo::class create Base {\n    method tick {} { return 1 }\n}\noo::class create Mix {\n    unexport tick\n}\noo::class create Child {\n    superclass Base\n    mixin Mix\n    method wire {} {\n        after idle [list [self] tick]\n    }\n}\n";
+        let analysis = analyse(src);
+        let dialect = tcl_registry::model::ingress::resolve_environment("tcl").analyser_profile();
+        let cursor = u32::try_from(src.find("] tick").unwrap() + 2).unwrap();
+        assert_eq!(
+            list_built_self_method_target_at_cursor(src, dialect, &analysis, "tick", cursor),
+            Some(("::Base".to_owned(), false)),
+            "a mixin's unexport must not suppress the spine's provider"
         );
     }
 

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -1566,39 +1566,54 @@ pub(crate) fn method_references_for_class(
             method_def.visibility == "public",
         ));
         for (other_q, other_cd) in &analysis.all_classes {
-            if other_q.as_str() != class_q
-                && hierarchy.method_target(other_q, method) == Some(class_q)
-            {
-                // An inheritor can `export` / `unexport` this inherited name
-                // without redeclaring it, so whether a captured `[self]`
-                // object command is callable is a fact about *that* receiver,
-                // not about the provider's own declaration (issue #1705).
-                // `my` captures are unaffected either way — they keep the
-                // current object's internal dispatch.
-                //
-                // Asked through the shared dispatch walk rather than re-read
-                // here, so this direction and the cursor-origin resolution in
-                // `list_built_self_method_target_at_cursor` cannot disagree
-                // about which family a capture belongs to — the exact
-                // invariant a half-applied rename would break.
-                let external_callback_allowed = crate::oo_dispatch::method_dispatch_provider(
+            if other_q.as_str() == class_q {
+                continue;
+            }
+            // The two dispatch kinds are asked separately because they can
+            // genuinely land on different classes.  An inheritor can `export`
+            // / `unexport` an inherited name without redeclaring it, and each
+            // `mixin` branch decides for itself, so whether a captured
+            // `[self]` object command reaches *this* declaration is a fact
+            // about that receiver's external dispatch — not about the
+            // provider's own visibility, and not the same question `my` asks
+            // (issue #1705).  Oracle, byte-identical on tclsh 8.6.16 and
+            // 9.0.4: with `MChild {superclass MBase; unexport m}` mixed into
+            // `D {superclass A}`, `my m` inside `D` reaches `MBase::m` while
+            // `[list [self] m]` reaches `A::m`.
+            //
+            // Both are asked through the shared dispatch walk rather than
+            // re-read here, so this direction and the cursor-origin
+            // resolution in `list_built_self_method_target_at_cursor` cannot
+            // disagree about which family a site belongs to — the exact
+            // invariant a half-applied rename would break.
+            let provider_for = |external| {
+                crate::oo_dispatch::method_dispatch_provider(
                     analysis,
                     other_q,
                     method,
-                    true,
+                    external,
                     crate::definition::MethodBucket::Instance,
                 )
-                .is_some_and(|(provider, _)| provider == class_q);
-                let inherited_bodies = collect_member_bodies_scoped(other_cd, false);
-                call_spans.extend(scan_method_sites(
-                    source,
-                    dialect,
-                    &inherited_bodies,
-                    method,
-                    Some(decl_span),
-                    external_callback_allowed,
-                ));
+                .is_some_and(|(provider, _)| provider == class_q)
+            };
+            let dispatches_internally = provider_for(false);
+            let external_callback_allowed = provider_for(true);
+            if !dispatches_internally && !external_callback_allowed {
+                continue;
             }
+            let inherited_bodies = collect_member_bodies_scoped(other_cd, false);
+            call_spans.extend(scan_method_sites_by_kind(
+                source,
+                dialect,
+                &inherited_bodies,
+                method,
+                Some(decl_span),
+                external_callback_allowed,
+                // `my` sites here belong to whichever family the *internal*
+                // dispatch reaches; when that is a different class, only the
+                // deferred captures are this declaration's.
+                !dispatches_internally,
+            ));
         }
     }
     // External `$obj method` / bare `ClassName method` sites.
@@ -6415,6 +6430,86 @@ mod tests {
         assert!(
             refs.iter().any(|r| r.start_line == 3),
             "the wrapped public `[self] changed` callback is missing: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn a_mixin_branch_decides_its_own_providers_visibility() {
+        // Codex review on PR #1726.  A mixin that inherits the member from its
+        // own superclass and unexports the name empties *its* branch only —
+        // the spine still answers.  tclsh 8.6.16 / 9.0.4 both run `A`'s body:
+        //   oo::class create MChild { superclass MBase } ; unexport m
+        //   oo::class create D { superclass A ; mixin MChild }
+        //   [D new] m  ->  A-m   (not MBase-m)
+        let src = "oo::class create A {\n    method m {} { return 1 }\n}\noo::class create MBase {\n    method m {} { return 2 }\n}\noo::class create MChild {\n    superclass MBase\n    unexport m\n}\noo::class create D {\n    superclass A\n    mixin MChild\n    method wire {} {\n        after idle [list [self] m]\n    }\n}\n";
+        let analysis = analyse(src);
+        let dialect = tcl_registry::model::ingress::resolve_environment("tcl").analyser_profile();
+        let cursor = u32::try_from(src.find("] m]").unwrap() + 2).unwrap();
+        assert_eq!(
+            list_built_self_method_target_at_cursor(src, dialect, &analysis, "m", cursor),
+            Some(("::A".to_owned(), false)),
+            "the suppressed mixin branch must not provide the capture"
+        );
+        assert!(
+            !references(src, dialect, 4, 11, &analysis, true)
+                .iter()
+                .any(|range| range.start_line == 14),
+            "`MBase::m` must not collect a capture its branch cannot dispatch"
+        );
+        assert!(
+            references(src, dialect, 1, 11, &analysis, true)
+                .iter()
+                .any(|range| range.start_line == 14),
+            "`A::m` — the provider the receiver actually reaches — must collect it"
+        );
+    }
+
+    #[test]
+    fn a_live_mixin_branch_still_outranks_the_spine() {
+        // The control for the case above: with the branch left public, the
+        // mixin's inherited `MBase::m` is what `[D new] m` enters (tclsh
+        // 8.6.16 / 9.0.4 -> MBase-m), so the capture belongs to *its* family.
+        let src = "oo::class create A {\n    method m {} { return 1 }\n}\noo::class create MBase {\n    method m {} { return 2 }\n}\noo::class create MPub {\n    superclass MBase\n}\noo::class create D {\n    superclass A\n    mixin MPub\n    method wire {} {\n        after idle [list [self] m]\n    }\n}\n";
+        let analysis = analyse(src);
+        let dialect = tcl_registry::model::ingress::resolve_environment("tcl").analyser_profile();
+        let cursor = u32::try_from(src.find("] m]").unwrap() + 2).unwrap();
+        assert_eq!(
+            list_built_self_method_target_at_cursor(src, dialect, &analysis, "m", cursor),
+            Some(("::MBase".to_owned(), false)),
+            "a live mixin branch provides the capture ahead of the spine"
+        );
+    }
+
+    #[test]
+    fn a_mixin_branch_can_revive_its_own_bases_unexported_member() {
+        // The mirror direction inside a branch: `NBase` unexports its own `n`,
+        // the mixin `NChild` exports the inherited name, and tclsh 8.6.16 /
+        // 9.0.4 run `NBase`'s body for `[D new] n` — ahead of the spine's
+        // public `A2::n`.
+        let src = "oo::class create A2 {\n    method n {} { return 1 }\n}\noo::class create NBase {\n    method n {} { return 2 }\n    unexport n\n}\noo::class create NChild {\n    superclass NBase\n    export n\n}\noo::class create D {\n    superclass A2\n    mixin NChild\n    method wire {} {\n        after idle [list [self] n]\n    }\n}\n";
+        let analysis = analyse(src);
+        let dialect = tcl_registry::model::ingress::resolve_environment("tcl").analyser_profile();
+        let cursor = u32::try_from(src.find("] n]").unwrap() + 2).unwrap();
+        assert_eq!(
+            list_built_self_method_target_at_cursor(src, dialect, &analysis, "n", cursor),
+            Some(("::NBase".to_owned(), false)),
+            "the branch's own export revives its base's body"
+        );
+    }
+
+    #[test]
+    fn a_mixin_declared_on_a_superclass_governs_its_branch_too() {
+        // Branch roots are collected transitively, so a `mixin` written on a
+        // superclass behaves exactly as one written on the receiver: tclsh
+        // 8.6.16 / 9.0.4 answer `[D new] m` with `A-m`.
+        let src = "oo::class create A {\n    method m {} { return 1 }\n}\noo::class create MBase {\n    method m {} { return 2 }\n}\noo::class create MChild {\n    superclass MBase\n    unexport m\n}\noo::class create S {\n    superclass A\n    mixin MChild\n}\noo::class create D {\n    superclass S\n    method wire {} {\n        after idle [list [self] m]\n    }\n}\n";
+        let analysis = analyse(src);
+        let dialect = tcl_registry::model::ingress::resolve_environment("tcl").analyser_profile();
+        let cursor = u32::try_from(src.find("] m]").unwrap() + 2).unwrap();
+        assert_eq!(
+            list_built_self_method_target_at_cursor(src, dialect, &analysis, "m", cursor),
+            Some(("::A".to_owned(), false)),
+            "a superclass-declared mixin's suppression empties that branch only"
         );
     }
 

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -1544,7 +1544,6 @@ pub(crate) fn method_references_for_class(
     // established evidence in this codebase of how classmethod inheritance
     // should fold into this specific intra-class scan, so this stays scoped
     // to `class_q`'s own class-method bodies only.
-    let hierarchy = analysis.class_hierarchy();
     if is_classmethod {
         let bodies: Vec<Span> = collect_member_bodies_scoped(class_def, true);
         call_spans.extend(scan_method_sites(

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -1070,18 +1070,23 @@ fn callback_prefix_target_in_workspace(
     } else {
         MethodAccess::Internal
     };
+    // The chain is the *gate*, not the answer: an empty one means this
+    // receiver cannot dispatch the member at all (a `[self]` capture of a name
+    // the receiver has unexported), so the position resolves to nothing.  What
+    // is returned is the **receiver**, exactly as the bare `$obj method` arms
+    // below return theirs — the family, definition and rename tiers each
+    // resolve the provider from it through this same chain, and handing them a
+    // provider instead would drop the receiver's own `export` / `unexport`
+    // stub on the way (issue #1705: `Base` unexports `tock`, `Child` exports
+    // the inherited name, and only a chain rooted at `Child` still reaches
+    // `Base`'s body).
     let chain = if is_classmethod {
         workspace.class_method_dispatch_chain(&receiver, word, access)
     } else {
         workspace.method_dispatch_chain(&receiver, word, access)
     };
-    let provider = chain.first()?;
-    Some((
-        provider.qualified_name.clone(),
-        word.to_owned(),
-        is_classmethod,
-        access,
-    ))
+    chain.first()?;
+    Some((receiver, word.to_owned(), is_classmethod, access))
 }
 
 /// [`method_target_with_access`] with the **workspace tier** available for
@@ -1285,10 +1290,9 @@ pub fn method_spans_in_document(
 /// inherited-method rename reaches `my method` / `$obj method` sites that
 /// live in a subclass-only file.
 ///
-/// `extra_classmethod_cmd_names`: see
-/// [`crate::references::inherited_method_call_sites`]'s identical parameter —
-/// the workspace-wide classmethod-dispatch names this subclass-only document
-/// cannot derive from its own (definer-less) `all_classes`.
+/// `workspace` carries the two facts a subclass-only document cannot derive
+/// from its own (definer-less) `all_classes` — see
+/// [`crate::references::InheritedReceiverFacts`].
 #[must_use]
 pub fn inherited_method_spans_in_document(
     source: &str,
@@ -1297,7 +1301,7 @@ pub fn inherited_method_spans_in_document(
     class_q: &str,
     method: &str,
     is_classmethod: bool,
-    extra_classmethod_cmd_names: &[String],
+    workspace: crate::references::InheritedReceiverFacts<'_>,
 ) -> Vec<tcl_lexer::Span> {
     crate::references::inherited_method_call_sites(
         source,
@@ -1306,7 +1310,7 @@ pub fn inherited_method_spans_in_document(
         class_q,
         method,
         is_classmethod,
-        extra_classmethod_cmd_names,
+        workspace,
     )
 }
 
@@ -2770,6 +2774,11 @@ mod tests {
             ("file:///base.tcl", &base),
             ("file:///child.tcl", &child),
         ]);
+        // The resolved target is the **receiver**, exactly as a bare `$obj
+        // method` position resolves to one: the provider is whatever the
+        // workspace chain rooted there reaches, and re-rooting the chain at
+        // the provider instead would drop the receiver's own `export` /
+        // `unexport` stub on the way (issue #1705).
         assert_eq!(
             method_target_with_access_in_workspace(
                 child_src,
@@ -2779,11 +2788,20 @@ mod tests {
                 Some((&index, "file:///child.tcl")),
             ),
             Some((
-                "::Base".to_owned(),
+                "::Child".to_owned(),
                 "read".to_owned(),
                 false,
                 MethodAccess::Internal,
             )),
+        );
+        // …and that chain still names `Base` as the provider, so the
+        // definition / lens / rename tiers reach the inherited declaration.
+        assert_eq!(
+            index
+                .method_dispatch_chain("::Child", "read", MethodAccess::Internal)
+                .first()
+                .map(|c| c.uri.as_str()),
+            Some("file:///base.tcl"),
         );
     }
 
@@ -2833,11 +2851,21 @@ mod tests {
                 Some((&index, "file:///child.tcl")),
             ),
             Some((
-                "::Mixin".to_owned(),
+                "::Child".to_owned(),
                 "read".to_owned(),
                 false,
                 MethodAccess::Internal,
             )),
+        );
+        // The MRO fact this test exists for, pinned where it is decided: a
+        // `mixin` is searched ahead of the class's own table, so the chain
+        // rooted at the receiver enters `Mixin::read`, not `Child`'s override.
+        assert_eq!(
+            index
+                .method_dispatch_chain("::Child", "read", MethodAccess::Internal)
+                .first()
+                .map(|c| c.uri.as_str()),
+            Some("file:///mixin.tcl"),
         );
     }
 

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -3620,7 +3620,7 @@ impl WorkspaceIndex {
                 // `export` / `unexport` govern that branch alone.
                 let branch_state = branches
                     .iter()
-                    .find(|(spine, _)| spine.iter().any(|c| *c == class_q))
+                    .find(|(spine, _)| spine.contains(&class_q))
                     .and_then(|(_, state)| *state);
                 let exported = match branch_state {
                     Some(exported) => exported,
@@ -3676,7 +3676,7 @@ impl WorkspaceIndex {
                 // capture belongs to that family instead.
                 self.dispatch_chain_over(&edges, cq, method, MethodAccess::External, side)
                     .first()
-                    .is_some_and(|entry| family.iter().any(|f| *f == entry.qualified_name.as_str()))
+                    .is_some_and(|entry| family.contains(&entry.qualified_name.as_str()))
             })
             .map(ToOwned::to_owned)
             .collect()

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -2000,14 +2000,57 @@ impl ClassEdges {
     /// linearise (the shared budget guard) — consumers abstain rather than
     /// guess.
     fn linearise(&self, class_q: &str) -> (Vec<String>, Vec<String>) {
-        let no_mixins: std::collections::HashMap<String, Vec<String>> =
-            std::collections::HashMap::new();
         (
             tcl_syntax::mro::tcloo_linearise(class_q, &self.supers_map, &self.mixins_map)
                 .unwrap_or_default(),
-            tcl_syntax::mro::tcloo_linearise(class_q, &self.supers_map, &no_mixins)
-                .unwrap_or_default(),
+            self.spine(class_q),
         )
+    }
+
+    /// `class_q`'s mixin-free linearisation — the `superclass` spine alone.
+    fn spine(&self, class_q: &str) -> Vec<String> {
+        let no_mixins: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        tcl_syntax::mro::tcloo_linearise(class_q, &self.supers_map, &no_mixins).unwrap_or_default()
+    }
+
+    /// The spines `TclOO`'s call-chain builder walks for a receiver of class
+    /// `class_q`, in the order it walks them: every reachable `mixin` branch,
+    /// then the receiver's own spine — the cross-file twin of
+    /// `tcl_lsp_core::oo_dispatch`'s `dispatch_branch_spines`, and the same
+    /// rule, since C enters each mixin with a **fresh copy** of the dispatch
+    /// flags and so lets a branch's `export` / `unexport` govern that branch
+    /// alone (issue #1705).
+    fn branch_spines(&self, class_q: &str, linearisation: &[String]) -> Vec<Vec<String>> {
+        let mut roots: Vec<String> = Vec::new();
+        let mut queue: std::collections::VecDeque<String> =
+            std::collections::VecDeque::from([class_q.to_owned()]);
+        let mut seen: std::collections::HashSet<String> =
+            std::collections::HashSet::from([class_q.to_owned()]);
+        while let Some(root) = queue.pop_front() {
+            for spine_q in self.spine(&root) {
+                for mixin in self.mixins_map.get(&spine_q).into_iter().flatten() {
+                    if seen.insert(mixin.clone()) {
+                        roots.push(mixin.clone());
+                        queue.push_back(mixin.clone());
+                    }
+                }
+            }
+        }
+        // The linearisation is the order the chain builder reaches these
+        // classes; a root it does not list sorts last but keeps its discovery
+        // order.
+        roots.sort_by_key(|root| {
+            linearisation
+                .iter()
+                .position(|c| c == root)
+                .unwrap_or(usize::MAX)
+        });
+        roots
+            .into_iter()
+            .map(|root| self.spine(&root))
+            .chain(std::iter::once(self.spine(class_q)))
+            .collect()
     }
 }
 
@@ -3475,28 +3518,23 @@ impl WorkspaceIndex {
         access: MethodAccess,
         side: MemberSide,
     ) -> Vec<&'a WorkspaceClass> {
-        self.dispatch_chain_over(
-            self.class_linearisation_and_spine(receiver_class),
-            receiver_class,
-            method,
-            access,
-            side,
-        )
+        let edges = self.class_edges();
+        self.dispatch_chain_over(&edges, receiver_class, method, access, side)
     }
 
-    /// [`Self::dispatch_chain`] over a linearisation pair the caller already
-    /// has — the form a bulk query uses so the O(classes) edge resolution
-    /// behind [`Self::class_edges`] is paid once for many receivers.
+    /// [`Self::dispatch_chain`] over edge maps the caller already has — the
+    /// form a bulk query uses so the O(classes) edge resolution behind
+    /// [`Self::class_edges`] is paid once for many receivers.
     fn dispatch_chain_over<'a>(
         &'a self,
-        linearisations: (Vec<String>, Vec<String>),
+        edges: &ClassEdges,
         receiver_class: &str,
         method: &str,
         access: MethodAccess,
         side: MemberSide,
     ) -> Vec<&'a WorkspaceClass> {
         let mut out: Vec<&WorkspaceClass> = Vec::new();
-        let (linearisation, spine) = linearisations;
+        let linearisation = edges.linearise(receiver_class).0;
         // The receiver's **effective** export flag, read once for the whole
         // walk (issue #1705).  A subclass can `export` / `unexport` a name it
         // inherits without redeclaring it: `export` / `unexport` accept a name
@@ -3513,9 +3551,18 @@ impl WorkspaceIndex {
         //     oo::class create Base3  { method tock {} { return b3 } ; unexport tock }
         //     oo::class create Child3 { superclass Base3 ; export tock }
         //     [Child3 new] tock   ;# -> b3
-        let spine_export = (access == MethodAccess::External)
-            .then(|| self.spine_export_state(&spine, method, side))
-            .flatten();
+        let branches: Vec<(Vec<String>, Option<bool>)> = if access == MethodAccess::External {
+            edges
+                .branch_spines(receiver_class, &linearisation)
+                .into_iter()
+                .map(|spine| {
+                    let state = self.spine_export_state(&spine, method, side);
+                    (spine, state)
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
         for class_q in linearisation {
             // Several records of one class (its creation site plus every
             // `oo::define` stub, possibly spread over files) are all kept, and
@@ -3567,15 +3614,19 @@ impl WorkspaceIndex {
                 // class methods ::R4` empty while `-private` lists `pub`), so
                 // the source member's own record is what this reads.
                 //
-                // A provider on the **spine** answers to the receiver's
-                // effective flag instead; one reached through a *mixin* keeps
-                // this per-record reading, because C enters each mixin with a
-                // fresh copy of the dispatch flags.
-                let exported = match spine_export {
-                    Some(exported) if spine.contains(&class_q) => exported,
-                    _ if any_exports => true,
-                    _ if any_unexports => false,
-                    _ => em.method.exported,
+                // …and a provider answers to the effective flag of the
+                // **branch** that reaches it, because C enters each mixin with
+                // a fresh copy of the dispatch flags and so lets a branch's
+                // `export` / `unexport` govern that branch alone.
+                let branch_state = branches
+                    .iter()
+                    .find(|(spine, _)| spine.iter().any(|c| *c == class_q))
+                    .and_then(|(_, state)| *state);
+                let exported = match branch_state {
+                    Some(exported) => exported,
+                    None if any_exports => true,
+                    None if any_unexports => false,
+                    None => em.method.exported,
                 };
                 let visible = match access {
                     MethodAccess::External => exported && !em.method.private,
@@ -3589,9 +3640,10 @@ impl WorkspaceIndex {
         out
     }
 
-    /// Which of `receivers` can dispatch `method` **externally** — the bulk
-    /// form of "is [`Self::method_dispatch_chain`] non-empty", answering every
-    /// receiver from one [`Self::class_edges`] build.
+    /// Which of `receivers` dispatch `method` **externally** into `family` —
+    /// the bulk form of "does [`Self::method_dispatch_chain`] land on one of
+    /// these classes", answering every receiver from one
+    /// [`Self::class_edges`] build.
     ///
     /// The caller is the cross-file method-family pass, which needs the answer
     /// per inheriting class before it scans each document (issue #1705): a
@@ -3604,6 +3656,7 @@ impl WorkspaceIndex {
     pub fn external_dispatch_receivers<'a>(
         &self,
         receivers: impl IntoIterator<Item = &'a str>,
+        family: &[&str],
         method: &str,
         is_classmethod: bool,
     ) -> std::collections::HashSet<String> {
@@ -3616,15 +3669,14 @@ impl WorkspaceIndex {
         receivers
             .into_iter()
             .filter(|cq| {
-                !self
-                    .dispatch_chain_over(
-                        edges.linearise(cq),
-                        cq,
-                        method,
-                        MethodAccess::External,
-                        side,
-                    )
-                    .is_empty()
+                // Non-empty is not enough: the chain must land *in this
+                // family*.  A receiver whose external dispatch reaches some
+                // other class's implementation (a live `mixin` branch ahead of
+                // the spine, say) is dispatching that other member, and its
+                // capture belongs to that family instead.
+                self.dispatch_chain_over(&edges, cq, method, MethodAccess::External, side)
+                    .first()
+                    .is_some_and(|entry| family.iter().any(|f| *f == entry.qualified_name.as_str()))
             })
             .map(ToOwned::to_owned)
             .collect()
@@ -5949,6 +6001,105 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["file:///base.tcl"],
             "the mixin's unexport must not suppress the superclass spine",
+        );
+    }
+
+    #[test]
+    fn a_mixin_branch_decides_its_own_providers_visibility_across_files() {
+        // Codex review on PR #1726.  A mixin that inherits the member from its
+        // own superclass and unexports the name empties *that branch* only —
+        // C enters each mixin with a fresh copy of the dispatch flags — so the
+        // receiver's spine still answers.  Oracle, byte-identical on tclsh
+        // 8.6.16 and 9.0.4:
+        //   oo::class create ::MChild { superclass ::MBase } ; unexport m
+        //   oo::class create ::D { superclass ::A ; mixin ::MChild }
+        //   [::D new] m  ->  A-m   (not MBase-m)
+        let a = analyse("oo::class create ::A { method m {} { return 1 } }\n");
+        let mbase = analyse("oo::class create ::MBase { method m {} { return 2 } }\n");
+        let mchild = analyse("oo::class create ::MChild { superclass ::MBase\n    unexport m\n}\n");
+        let d = analyse("oo::class create ::D { superclass ::A\n    mixin ::MChild\n}\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///a.tcl", &a),
+            ("file:///mbase.tcl", &mbase),
+            ("file:///mchild.tcl", &mchild),
+            ("file:///d.tcl", &d),
+        ]);
+        assert_eq!(
+            index
+                .method_dispatch_chain("::D", "m", MethodAccess::External)
+                .first()
+                .map(|c| c.uri.as_str()),
+            Some("file:///a.tcl"),
+            "the suppressed mixin branch must not answer; the spine must",
+        );
+        // TN for the permission the family pass reads: `::D` dispatches into
+        // `::A`'s family, not `::MBase`'s.
+        assert!(
+            index
+                .external_dispatch_receivers(["::D"], &["::A"], "m", false)
+                .contains("::D"),
+        );
+        assert!(
+            index
+                .external_dispatch_receivers(["::D"], &["::MBase"], "m", false)
+                .is_empty(),
+        );
+    }
+
+    #[test]
+    fn a_live_mixin_branch_outranks_the_spine_across_files() {
+        // The control: with the branch left public the mixin's inherited
+        // `::MBase::m` is what `[::D new] m` enters (tclsh 8.6.16 / 9.0.4 ->
+        // MBase-m), so the capture belongs to *its* family instead.
+        let a = analyse("oo::class create ::A { method m {} { return 1 } }\n");
+        let mbase = analyse("oo::class create ::MBase { method m {} { return 2 } }\n");
+        let mpub = analyse("oo::class create ::MPub { superclass ::MBase }\n");
+        let d = analyse("oo::class create ::D { superclass ::A\n    mixin ::MPub\n}\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///a.tcl", &a),
+            ("file:///mbase.tcl", &mbase),
+            ("file:///mpub.tcl", &mpub),
+            ("file:///d.tcl", &d),
+        ]);
+        assert_eq!(
+            index
+                .method_dispatch_chain("::D", "m", MethodAccess::External)
+                .first()
+                .map(|c| c.uri.as_str()),
+            Some("file:///mbase.tcl"),
+        );
+        assert!(
+            index
+                .external_dispatch_receivers(["::D"], &["::A"], "m", false)
+                .is_empty(),
+            "a receiver dispatching into another family must not join this one",
+        );
+    }
+
+    #[test]
+    fn a_mixin_branch_revives_its_own_bases_unexported_member_across_files() {
+        // The mirror direction inside a branch: `::NBase` unexports its own
+        // `n`, the mixin `::NChild` exports the inherited name, and tclsh
+        // 8.6.16 / 9.0.4 run `::NBase`'s body ahead of the spine's public
+        // `::A2::n`.
+        let a2 = analyse("oo::class create ::A2 { method n {} { return 1 } }\n");
+        let nbase =
+            analyse("oo::class create ::NBase { method n {} { return 2 }\n    unexport n\n}\n");
+        let nchild = analyse("oo::class create ::NChild { superclass ::NBase\n    export n\n}\n");
+        let d = analyse("oo::class create ::D { superclass ::A2\n    mixin ::NChild\n}\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///a2.tcl", &a2),
+            ("file:///nbase.tcl", &nbase),
+            ("file:///nchild.tcl", &nchild),
+            ("file:///d.tcl", &d),
+        ]);
+        assert_eq!(
+            index
+                .method_dispatch_chain("::D", "n", MethodAccess::External)
+                .first()
+                .map(|c| c.uri.as_str()),
+            Some("file:///nbase.tcl"),
+            "the branch's own export revives its base's body",
         );
     }
 

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -1978,6 +1978,39 @@ impl IncrementalSettledTargets {
     }
 }
 
+/// The owner-resolved class edges [`WorkspaceIndex::class_edges`] builds once
+/// and [`Self::linearise`] answers any number of receivers from.
+struct ClassEdges {
+    supers_map: std::collections::HashMap<String, Vec<String>>,
+    mixins_map: std::collections::HashMap<String, Vec<String>>,
+}
+
+impl ClassEdges {
+    /// `class_q`'s full linearisation and its **mixin-free** twin — the
+    /// `superclass` spine alone.
+    ///
+    /// The two are needed together because C's call-chain builder treats the
+    /// paths differently: each mixin is entered with a *fresh copy* of the
+    /// dispatch flags, so a mixin's `unexport` empties only its own branch
+    /// while the same word on the spine decides the whole dispatch (issue
+    /// #1705).  Both come from the one canonical
+    /// [`tcl_syntax::mro::tcloo_linearise`] over the same resolved edges, so
+    /// they cannot disagree about which qualified name a bare `superclass
+    /// Device` meant.  Empty when the hierarchy is cyclic or too complex to
+    /// linearise (the shared budget guard) — consumers abstain rather than
+    /// guess.
+    fn linearise(&self, class_q: &str) -> (Vec<String>, Vec<String>) {
+        let no_mixins: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        (
+            tcl_syntax::mro::tcloo_linearise(class_q, &self.supers_map, &self.mixins_map)
+                .unwrap_or_default(),
+            tcl_syntax::mro::tcloo_linearise(class_q, &self.supers_map, &no_mixins)
+                .unwrap_or_default(),
+        )
+    }
+}
+
 impl WorkspaceIndex {
     /// Empty index.
     #[must_use]
@@ -3178,6 +3211,31 @@ impl WorkspaceIndex {
     /// budget guard) — consumers abstain rather than guess.
     #[must_use]
     pub fn class_linearisation(&self, class_q: &str) -> Vec<String> {
+        self.class_linearisation_and_spine(class_q).0
+    }
+
+    /// [`Self::class_linearisation`] and its **mixin-free** twin — the
+    /// `superclass` spine alone — from one edge-map build.
+    ///
+    /// The two are needed together because C's call-chain builder treats the
+    /// paths differently: each mixin is entered with a *fresh copy* of the
+    /// dispatch flags, so a mixin's `unexport` empties only its own branch
+    /// while the same word on the spine decides the whole dispatch (issue
+    /// #1705).  Resolving the edge maps is the expensive half and is
+    /// O(classes) on its own, so it is deliberately not paid twice — see
+    /// [`Self::subclass_provided_members`] for what per-call rebuilding cost
+    /// the diagnostics worker.
+    fn class_linearisation_and_spine(&self, class_q: &str) -> (Vec<String>, Vec<String>) {
+        self.class_edges().linearise(class_q)
+    }
+
+    /// The owner-resolved `superclass` / `mixin` edge maps over every indexed
+    /// class — the expensive half of [`Self::class_linearisation_and_spine`],
+    /// built once so a caller with many receivers to linearise does not pay
+    /// O(classes) name resolution per receiver (see
+    /// [`Self::subclass_provided_members`] for what per-call rebuilding cost
+    /// the diagnostics worker).
+    fn class_edges(&self) -> ClassEdges {
         let (known, tail_index) = self.class_name_universe();
         // Build the resolved edge maps over the classes reachable from
         // `class_q` (bounded: every indexed class at worst).
@@ -3203,7 +3261,10 @@ impl WorkspaceIndex {
                 }
             }
         }
-        tcl_syntax::mro::tcloo_linearise(class_q, &supers_map, &mixins_map).unwrap_or_default()
+        ClassEdges {
+            supers_map,
+            mixins_map,
+        }
     }
 
     /// The project-wide **subclass-provided method** view behind the
@@ -3414,8 +3475,48 @@ impl WorkspaceIndex {
         access: MethodAccess,
         side: MemberSide,
     ) -> Vec<&'a WorkspaceClass> {
+        self.dispatch_chain_over(
+            self.class_linearisation_and_spine(receiver_class),
+            receiver_class,
+            method,
+            access,
+            side,
+        )
+    }
+
+    /// [`Self::dispatch_chain`] over a linearisation pair the caller already
+    /// has — the form a bulk query uses so the O(classes) edge resolution
+    /// behind [`Self::class_edges`] is paid once for many receivers.
+    fn dispatch_chain_over<'a>(
+        &'a self,
+        linearisations: (Vec<String>, Vec<String>),
+        receiver_class: &str,
+        method: &str,
+        access: MethodAccess,
+        side: MemberSide,
+    ) -> Vec<&'a WorkspaceClass> {
         let mut out: Vec<&WorkspaceClass> = Vec::new();
-        for class_q in self.class_linearisation(receiver_class) {
+        let (linearisation, spine) = linearisations;
+        // The receiver's **effective** export flag, read once for the whole
+        // walk (issue #1705).  A subclass can `export` / `unexport` a name it
+        // inherits without redeclaring it: `export` / `unexport` accept a name
+        // their class does not define and create a body-less table entry whose
+        // only content is the flag, so the flag comes from the most specific
+        // spine class that *mentions* the member while the implementation
+        // still comes from the first class that declares a body.  Oracle,
+        // byte-identical on tclsh 8.6.16 and 9.0.4:
+        //
+        //     oo::class create Base   { method tick {} { return base } }
+        //     oo::class create Child  { superclass Base }
+        //     oo::define Child { unexport tick }
+        //     [Child new] tick    ;# -> unknown method "tick"
+        //     oo::class create Base3  { method tock {} { return b3 } ; unexport tock }
+        //     oo::class create Child3 { superclass Base3 ; export tock }
+        //     [Child3 new] tock   ;# -> b3
+        let spine_export = (access == MethodAccess::External)
+            .then(|| self.spine_export_state(&spine, method, side))
+            .flatten();
+        for class_q in linearisation {
             // Several records of one class (its creation site plus every
             // `oo::define` stub, possibly spread over files) are all kept, and
             // the *first* is what go-to-definition answers with — so the order
@@ -3465,12 +3566,16 @@ impl WorkspaceIndex {
                 // {method Priv {} {…}; renamemethod Priv pub}` leaves `info
                 // class methods ::R4` empty while `-private` lists `pub`), so
                 // the source member's own record is what this reads.
-                let exported = if any_exports {
-                    true
-                } else if any_unexports {
-                    false
-                } else {
-                    em.method.exported
+                //
+                // A provider on the **spine** answers to the receiver's
+                // effective flag instead; one reached through a *mixin* keeps
+                // this per-record reading, because C enters each mixin with a
+                // fresh copy of the dispatch flags.
+                let exported = match spine_export {
+                    Some(exported) if spine.contains(&class_q) => exported,
+                    _ if any_exports => true,
+                    _ if any_unexports => false,
+                    _ => em.method.exported,
                 };
                 let visible = match access {
                     MethodAccess::External => exported && !em.method.private,
@@ -3482,6 +3587,85 @@ impl WorkspaceIndex {
             }
         }
         out
+    }
+
+    /// Which of `receivers` can dispatch `method` **externally** — the bulk
+    /// form of "is [`Self::method_dispatch_chain`] non-empty", answering every
+    /// receiver from one [`Self::class_edges`] build.
+    ///
+    /// The caller is the cross-file method-family pass, which needs the answer
+    /// per inheriting class before it scans each document (issue #1705): a
+    /// captured `[self]` object command in a subclass body is a call site of
+    /// the family's declaration only when that subclass can actually dispatch
+    /// the name.  Asking [`Self::method_dispatch_chain`] once per inheritor
+    /// would re-resolve every class edge each time — the O(classes²) shape
+    /// [`Self::subclass_provided_members`] documents the cost of.
+    #[must_use]
+    pub fn external_dispatch_receivers<'a>(
+        &self,
+        receivers: impl IntoIterator<Item = &'a str>,
+        method: &str,
+        is_classmethod: bool,
+    ) -> std::collections::HashSet<String> {
+        let side = if is_classmethod {
+            MemberSide::ClassObject
+        } else {
+            MemberSide::Instance
+        };
+        let edges = self.class_edges();
+        receivers
+            .into_iter()
+            .filter(|cq| {
+                !self
+                    .dispatch_chain_over(
+                        edges.linearise(cq),
+                        cq,
+                        method,
+                        MethodAccess::External,
+                        side,
+                    )
+                    .is_empty()
+            })
+            .map(ToOwned::to_owned)
+            .collect()
+    }
+
+    /// The export flag an external dispatch reads for `method` along `spine`
+    /// — the mixin-free linearisation from
+    /// [`Self::class_linearisation_and_spine`] — or `None` when no class on it
+    /// mentions the name at all, so there is no state to read and the
+    /// per-record union in [`Self::dispatch_chain`] stands.
+    ///
+    /// "Mentions" is deliberately wider than "declares": `export` / `unexport`
+    /// record a name their class need not define, and that body-less entry is
+    /// the whole point of this walk (issue #1705).  Within one class the
+    /// records are unordered across files, so the same
+    /// explicit-export-wins precedence [`Self::dispatch_chain`] applies to a
+    /// declaring class applies here too.
+    fn spine_export_state(&self, spine: &[String], method: &str, side: MemberSide) -> Option<bool> {
+        for class_q in spine {
+            let records = self.class_records(class_q);
+            let any_exports = records
+                .iter()
+                .any(|c| visibility_sets_for(c, side).0.iter().any(|e| e == method));
+            let any_unexports = records
+                .iter()
+                .any(|c| visibility_sets_for(c, side).1.iter().any(|e| e == method));
+            if any_exports {
+                return Some(true);
+            }
+            if any_unexports {
+                return Some(false);
+            }
+            if let Some(em) = self
+                .effective_members(class_q)
+                .into_iter()
+                .find(|em| em.name == method && method_side(em.method) == side)
+            {
+                return Some(em.method.exported);
+            }
+        }
+        None
     }
 
     /// Every record of the class `class_q`, in the workspace's stable order.
@@ -5657,6 +5841,115 @@ mod tests {
             }
             assert_eq!(methods, &slow, "bulk and per-class disagree on {ancestor}");
         }
+    }
+
+    #[test]
+    fn a_receivers_export_stub_decides_the_inherited_members_visibility() {
+        // Issue #1705.  `export` / `unexport` accept a name their class does
+        // not define, creating a body-less table entry whose only content is
+        // the flag; the flag comes from the most specific spine class that
+        // *mentions* the member while the implementation still comes from the
+        // first class that declares a body.  Oracle, byte-identical on tclsh
+        // 8.6.16 and 9.0.4:
+        //   oo::class create ::Base  { method tick {} { return base } }
+        //   oo::class create ::Child { superclass ::Base }
+        //   oo::define ::Child { unexport tick }
+        //   [::Child new] tick  ->  unknown method "tick": must be destroy
+        //   [::Base  new] tick  ->  base
+        let base = analyse("oo::class create ::Base { method tick {} { return 1 } }\n");
+        let child = analyse(
+            "oo::class create ::Child { superclass ::Base }\noo::define ::Child { unexport tick }\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///base.tcl", &base),
+            ("file:///child.tcl", &child),
+        ]);
+        assert!(
+            index
+                .method_dispatch_chain("::Child", "tick", MethodAccess::External)
+                .is_empty(),
+            "the receiver's own unexport suppresses the inherited implementation",
+        );
+        // `my` ignores the export flag entirely — it still reaches `Base`.
+        assert_eq!(
+            index
+                .method_dispatch_chain("::Child", "tick", MethodAccess::Internal)
+                .iter()
+                .map(|c| c.uri.as_str())
+                .collect::<Vec<_>>(),
+            ["file:///base.tcl"],
+            "internal dispatch is not gated on the export flag",
+        );
+        // TN: the provider's own receiver is untouched by the subclass's flip.
+        assert_eq!(
+            index
+                .method_dispatch_chain("::Base", "tick", MethodAccess::External)
+                .iter()
+                .map(|c| c.uri.as_str())
+                .collect::<Vec<_>>(),
+            ["file:///base.tcl"],
+        );
+    }
+
+    #[test]
+    fn a_receivers_export_stub_revives_an_unexported_inherited_member() {
+        // The mirror direction, which a provider-only reading gets wrong the
+        // other way.  Oracle, byte-identical on tclsh 8.6.16 and 9.0.4:
+        //   oo::class create ::Base  { method tock {} { return b3 } ; unexport tock }
+        //   oo::class create ::Child { superclass ::Base ; export tock }
+        //   [::Child new] tock  ->  b3
+        //   [::Base  new] tock  ->  unknown method "tock": must be destroy
+        let base = analyse(
+            "oo::class create ::Base { method tock {} { return 1 }\n    unexport tock\n}\n",
+        );
+        let child = analyse("oo::class create ::Child { superclass ::Base\n    export tock\n}\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///base.tcl", &base),
+            ("file:///child.tcl", &child),
+        ]);
+        assert_eq!(
+            index
+                .method_dispatch_chain("::Child", "tock", MethodAccess::External)
+                .iter()
+                .map(|c| c.uri.as_str())
+                .collect::<Vec<_>>(),
+            ["file:///base.tcl"],
+            "the receiver's export revives the inherited implementation",
+        );
+        assert!(
+            index
+                .method_dispatch_chain("::Base", "tock", MethodAccess::External)
+                .is_empty(),
+            "the provider itself stays unexported",
+        );
+    }
+
+    #[test]
+    fn a_mixins_unexport_does_not_suppress_the_spine_provider() {
+        // C enters each mixin with a fresh copy of the dispatch flags, so a
+        // mixin's `unexport` empties only its own branch.  Oracle,
+        // byte-identical on tclsh 8.6.16 and 9.0.4:
+        //   oo::class create ::Mix { method tick {} { return mix } ; unexport tick }
+        //   oo::class create ::Child { superclass ::Base ; mixin ::Mix }
+        //   [::Child new] tick  ->  base
+        let base = analyse("oo::class create ::Base { method tick {} { return 1 } }\n");
+        let mix =
+            analyse("oo::class create ::Mix { method tick {} { return 2 }\n    unexport tick\n}\n");
+        let child = analyse("oo::class create ::Child { superclass ::Base\n    mixin ::Mix\n}\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///base.tcl", &base),
+            ("file:///mix.tcl", &mix),
+            ("file:///child.tcl", &child),
+        ]);
+        assert_eq!(
+            index
+                .method_dispatch_chain("::Child", "tick", MethodAccess::External)
+                .iter()
+                .map(|c| c.uri.as_str())
+                .collect::<Vec<_>>(),
+            ["file:///base.tcl"],
+            "the mixin's unexport must not suppress the superclass spine",
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -6777,6 +6777,88 @@ struct ConsumerScan {
     classmethod_cmd_names: Vec<String>,
 }
 
+/// The document-local inputs [`family_spans_in_document`] scans one document
+/// with — bundled so the cross-file references and rename passes share one
+/// call shape rather than two near-identical argument lists.
+#[derive(Clone, Copy)]
+struct FamilySpanScan<'a> {
+    source: &'a str,
+    profile: &'static tcl_dialect::DialectProfile,
+    analysis: &'a AnalysisResult,
+    method: &'a str,
+    is_classmethod: bool,
+    /// See [`core_references::InheritedReceiverFacts::extra_classmethod_cmd_names`].
+    classmethod_cmd_names: &'a [String],
+    /// The receivers the workspace proved can dispatch `method` externally —
+    /// see [`MethodFamily::external_callback_receivers`].
+    external_receivers: &'a std::collections::HashSet<String>,
+}
+
+/// Which span set a **definer** in this document contributes — the one place
+/// the two cross-file legs differ.
+#[derive(Clone, Copy)]
+enum DefinerSpans {
+    /// Everything renaming the member must rewrite, declaration included.
+    Rename,
+    /// Everything Find All References reports, with the declaration included
+    /// only when the client asked for it.
+    References { include_declaration: bool },
+}
+
+/// Every span one document contributes to a method family: its **definers'**
+/// own set (per `definer_spans`) followed by its pure **inheritors'** call
+/// sites, in the order the classes were given.
+///
+/// Shared by the cross-file references and rename passes so the two cannot
+/// disagree about what a document contributes, and so the receiver-scoped
+/// `[self]`-capture permission (issue #1705) is read the same way on both.
+fn family_spans_in_document(
+    scan: FamilySpanScan<'_>,
+    definers: &[String],
+    inheritors: &[String],
+    definer_spans: DefinerSpans,
+) -> Vec<tcl_lexer::Span> {
+    let mut all: Vec<tcl_lexer::Span> = Vec::new();
+    for cq in definers {
+        match definer_spans {
+            DefinerSpans::Rename => all.extend(core_rename::method_spans_in_document(
+                scan.source,
+                scan.profile,
+                scan.analysis,
+                cq,
+                scan.method,
+                scan.is_classmethod,
+            )),
+            DefinerSpans::References {
+                include_declaration,
+            } => all.extend(core_references::method_reference_spans_in_document(
+                scan.source,
+                scan.profile,
+                scan.analysis,
+                cq,
+                scan.method,
+                include_declaration,
+                scan.is_classmethod,
+            )),
+        }
+    }
+    for cq in inheritors {
+        all.extend(core_rename::inherited_method_spans_in_document(
+            scan.source,
+            scan.profile,
+            scan.analysis,
+            cq,
+            scan.method,
+            scan.is_classmethod,
+            core_references::InheritedReceiverFacts {
+                extra_classmethod_cmd_names: scan.classmethod_cmd_names,
+                external_callback_allowed: scan.external_receivers.contains(cq),
+            },
+        ));
+    }
+    all
+}
+
 /// The family classes one document declares: the **definers** that (re)define
 /// the method and the pure **inheritors** that only inherit it.
 #[derive(Default)]
@@ -6791,6 +6873,22 @@ struct FamilyClasses {
 struct MethodFamily {
     by_uri: Vec<(String, FamilyClasses)>,
     classmethod_cmd_names: Vec<String>,
+    /// The inheriting receivers that can dispatch the method **externally**,
+    /// so a captured `[self]` object command written in their bodies really
+    /// reaches the family's declaration (issue #1705).
+    ///
+    /// A property of the receiver, not of the provider: a subclass can
+    /// `export` / `unexport` a name it inherits without redeclaring it, and
+    /// the two halves of the answer routinely live in different documents —
+    /// the stub next to the subclass, the declared visibility next to the
+    /// base.  The workspace dispatch chain already folds both, so it decides
+    /// here, under the same index read the family itself is built from, and
+    /// the per-document scans are handed a plain fact.
+    ///
+    /// A `my` capture is not gated on this: it keeps the current object's
+    /// internal dispatch, which ignores the export flag entirely (tclsh
+    /// 8.6.16 / 9.0.4).
+    external_callback_receivers: std::collections::HashSet<String>,
 }
 
 /// One memoised workspace-class-oracle analysis — see
@@ -11341,10 +11439,18 @@ impl Backend {
             classes.inheritors.sort();
             classes.inheritors.dedup();
         }
+        let external_callback_receivers = index.external_dispatch_receivers(
+            by_uri
+                .values()
+                .flat_map(|classes| classes.inheritors.iter().map(String::as_str)),
+            method,
+            is_classmethod,
+        );
         drop(index);
         MethodFamily {
             by_uri: by_uri.into_iter().collect(),
             classmethod_cmd_names,
+            external_callback_receivers,
         }
     }
     /// The cross-file **override-family** method rename, or `None` when the
@@ -11907,6 +12013,7 @@ impl Backend {
                 is_classmethod,
             )
             .await;
+        let external_callback_receivers = family.external_callback_receivers;
         let classmethod_cmd_names = family.classmethod_cmd_names;
         for (
             u,
@@ -11929,34 +12036,25 @@ impl Backend {
             let dialect = target_doc.dialect.clone();
             let method_owned = method.to_owned();
             let classmethod_cmd_names_cl = classmethod_cmd_names.clone();
+            let external_receivers_cl = external_callback_receivers.clone();
             let spans: Vec<tcl_lexer::Span> = crate::rt::spawn_blocking(move || {
-                // Resolved once for the whole closure: the profile is a pure
-                // function of `dialect`, so re-resolving it per iteration only
-                // repeats the lookup.
-                let profile = tcl_lsp_core::profile_for_dialect(&dialect);
-                let mut all: Vec<tcl_lexer::Span> = Vec::new();
-                for cq in &definers {
-                    all.extend(core_rename::method_spans_in_document(
-                        &src,
-                        profile,
-                        &analysis,
-                        cq,
-                        &method_owned,
+                family_spans_in_document(
+                    FamilySpanScan {
+                        source: &src,
+                        // Resolved once: the profile is a pure function of
+                        // `dialect`, so re-resolving it per class only repeats
+                        // the lookup.
+                        profile: tcl_lsp_core::profile_for_dialect(&dialect),
+                        analysis: &analysis,
+                        method: &method_owned,
                         is_classmethod,
-                    ));
-                }
-                for cq in &inheritors {
-                    all.extend(core_rename::inherited_method_spans_in_document(
-                        &src,
-                        profile,
-                        &analysis,
-                        cq,
-                        &method_owned,
-                        is_classmethod,
-                        &classmethod_cmd_names_cl,
-                    ));
-                }
-                all
+                        classmethod_cmd_names: &classmethod_cmd_names_cl,
+                        external_receivers: &external_receivers_cl,
+                    },
+                    &definers,
+                    &inheritors,
+                    DefinerSpans::Rename,
+                )
             })
             .await
             .unwrap_or_default();
@@ -12031,6 +12129,7 @@ impl Backend {
         let family = self
             .method_family_by_document(dialect, seed_class, method, is_classmethod)
             .await;
+        let external_callback_receivers = family.external_callback_receivers;
         let classmethod_cmd_names = family.classmethod_cmd_names;
         let mut out = Vec::new();
         for (
@@ -12057,35 +12156,27 @@ impl Backend {
             let dialect = target_doc.dialect.clone();
             let method_owned = method.to_owned();
             let classmethod_cmd_names_cl = classmethod_cmd_names.clone();
+            let external_receivers_cl = external_callback_receivers.clone();
             let spans: Vec<tcl_lexer::Span> = crate::rt::spawn_blocking(move || {
-                // Resolved once for the whole closure: the profile is a pure
-                // function of `dialect`, so re-resolving it per iteration only
-                // repeats the lookup.
-                let profile = tcl_lsp_core::profile_for_dialect(&dialect);
-                let mut all: Vec<tcl_lexer::Span> = Vec::new();
-                for cq in &definers {
-                    all.extend(core_references::method_reference_spans_in_document(
-                        &src,
-                        profile,
-                        &analysis,
-                        cq,
-                        &method_owned,
+                family_spans_in_document(
+                    FamilySpanScan {
+                        source: &src,
+                        // Resolved once: the profile is a pure function of
+                        // `dialect`, so re-resolving it per class only repeats
+                        // the lookup.
+                        profile: tcl_lsp_core::profile_for_dialect(&dialect),
+                        analysis: &analysis,
+                        method: &method_owned,
+                        is_classmethod,
+                        classmethod_cmd_names: &classmethod_cmd_names_cl,
+                        external_receivers: &external_receivers_cl,
+                    },
+                    &definers,
+                    &inheritors,
+                    DefinerSpans::References {
                         include_declaration,
-                        is_classmethod,
-                    ));
-                }
-                for cq in &inheritors {
-                    all.extend(core_rename::inherited_method_spans_in_document(
-                        &src,
-                        profile,
-                        &analysis,
-                        cq,
-                        &method_owned,
-                        is_classmethod,
-                        &classmethod_cmd_names_cl,
-                    ));
-                }
-                all
+                    },
+                )
             })
             .await
             .unwrap_or_default();

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -11439,10 +11439,18 @@ impl Backend {
             classes.inheritors.sort();
             classes.inheritors.dedup();
         }
+        // The family a receiver's capture may join is the set of definers
+        // this pass is about; a receiver whose external dispatch lands
+        // elsewhere is dispatching a different member (issue #1705).
+        let definer_names: Vec<&str> = by_uri
+            .values()
+            .flat_map(|classes| classes.definers.iter().map(String::as_str))
+            .collect();
         let external_callback_receivers = index.external_dispatch_receivers(
             by_uri
                 .values()
                 .flat_map(|classes| classes.inheritors.iter().map(String::as_str)),
+            &definer_names,
             method,
             is_classmethod,
         );

--- a/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
+++ b/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
@@ -404,17 +404,15 @@ fn tp_stored_callback_prefix_agrees_across_navigation_providers() {
     assert_eq!(edit_lines(&edits, &uri), vec![1, 3], "{edits:?}");
 }
 
-/// Inherited callback capture is deliberately conservative until #1705 can
-/// prove effective receiver visibility.  A cursor on such a callback must not
-/// offer a partial rename that edits the ancestor declaration but leaves this
-/// occurrence behind.
+/// #1705: a captured `[self]` object command in an inheriting class reaches
+/// the provider's exported implementation — tclsh 8.6.16 / 9.0.4 both run
+/// `Base`'s body for `[list [Child new] tick]` — so every provider must place
+/// the occurrence in `Base::tick`'s family, from either direction.
 #[test]
-fn tp_inherited_list_built_self_callback_cursor_abstains_everywhere() {
+fn tp_inherited_list_built_self_callback_joins_the_provider_family() {
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
-    lsp.open_ready(
-        &uri,
-        "oo::class create Base {\n\
+    let src = "oo::class create Base {\n\
              method tick {} { return 1 }\n\
          }\n\
          oo::class create Child {\n\
@@ -422,31 +420,212 @@ fn tp_inherited_list_built_self_callback_cursor_abstains_everywhere() {
              method wire {} {\n\
                  after idle [list [self] tick]\n\
              }\n\
-         }\n",
-    );
+         }\n";
+    let callback_char = u32::try_from(src.lines().nth(6).unwrap().rfind("tick").unwrap()).unwrap();
+    lsp.open_ready(&uri, src);
 
     let from_declaration = lsp.references(&uri, 1, 11, false);
     assert!(
-        !location_lines(&from_declaration, &uri).contains(&6),
-        "the inherited callback is outside the proven edit family: {from_declaration:?}"
+        location_lines(&from_declaration, &uri).contains(&6),
+        "the inherited callback is a call site of the provider: {from_declaration:?}"
     );
-    let definition = lsp.definition(&uri, 6, 36);
+    assert_eq!(
+        location_lines(&lsp.definition(&uri, 6, callback_char), &uri),
+        std::collections::BTreeSet::from([1]),
+        "go-to-definition from the callback word must reach the provider"
+    );
+    let from_callback = lsp.references(&uri, 6, callback_char, false);
+    assert_eq!(
+        location_lines(&from_callback, &uri),
+        location_lines(&from_declaration, &uri),
+        "references started on the callback must agree with the declaration"
+    );
+    let command = resolve_lens_on_line(&mut lsp, &uri, 1);
+    assert!(
+        location_lines(&lens_locations(&command), &uri).contains(&6),
+        "the lens must count and open the inherited callback: {command:?}"
+    );
+    assert_eq!(
+        lsp.prepare_rename(&uri, 6, callback_char)["placeholder"],
+        "tick"
+    );
+    let edits = rename_edits(&lsp.rename(&uri, 6, callback_char, "tock"));
+    assert!(
+        edit_lines(&edits, &uri).contains(&1) && edit_lines(&edits, &uri).contains(&6),
+        "rename must edit the declaration and the callback together: {edits:?}"
+    );
+}
+
+/// #1705: the receiver's own `unexport` decides, not the provider's
+/// declaration.  tclsh 8.6.16 / 9.0.4 answer `[Child new] tick` with `unknown
+/// method "tick"` even though `Base` exports it, so the capture is not a call
+/// site of `Base::tick` and no provider may offer a partial edit for it.
+#[test]
+fn tp_receiver_unexport_keeps_the_inherited_callback_out_of_the_family() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "oo::class create Base {\n\
+             method tick {} { return 1 }\n\
+         }\n\
+         oo::class create Child {\n\
+             superclass Base\n\
+             unexport tick\n\
+             method wire {} {\n\
+                 after idle [list [self] tick]\n\
+             }\n\
+         }\n";
+    let callback_char = u32::try_from(src.lines().nth(7).unwrap().rfind("tick").unwrap()).unwrap();
+    lsp.open_ready(&uri, src);
+
+    let from_declaration = lsp.references(&uri, 1, 11, false);
+    assert!(
+        !location_lines(&from_declaration, &uri).contains(&7),
+        "an unexported receiver name is not a callback call site: {from_declaration:?}"
+    );
+    let definition = lsp.definition(&uri, 7, callback_char);
     assert!(
         definition.is_null() || definition.as_array().is_some_and(Vec::is_empty),
-        "definition from an abstained callback cursor must be empty: {definition:?}"
-    );
-    let references = lsp.references(&uri, 6, 36, false);
-    assert!(
-        references.is_null() || references.as_array().is_some_and(Vec::is_empty),
-        "references from an abstained callback cursor must be empty: {references:?}"
+        "definition from a suppressed callback cursor must be empty: {definition:?}"
     );
     assert!(
-        lsp.prepare_rename(&uri, 6, 36).is_null(),
-        "prepareRename must reject a callback that cannot join the edit family"
+        lsp.prepare_rename(&uri, 7, callback_char).is_null(),
+        "prepareRename must reject a callback the receiver cannot dispatch"
     );
     assert!(
-        lsp.rename(&uri, 6, 36, "tock").is_null(),
+        lsp.rename(&uri, 7, callback_char, "tock").is_null(),
         "rename must not offer a partial ancestor-only edit"
+    );
+}
+
+/// #1705: an override answers the capture, so the base's family must not
+/// claim it — renaming `Base::tick` would otherwise rewrite a word that never
+/// called it.
+#[test]
+fn tp_overriding_receiver_keeps_its_callback_in_its_own_family() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "oo::class create Base {\n\
+             method tick {} { return 1 }\n\
+         }\n\
+         oo::class create Child {\n\
+             superclass Base\n\
+             method tick {} { return 2 }\n\
+             method wire {} {\n\
+                 after idle [list [self] tick]\n\
+             }\n\
+         }\n";
+    let callback_char = u32::try_from(src.lines().nth(7).unwrap().rfind("tick").unwrap()).unwrap();
+    lsp.open_ready(&uri, src);
+
+    assert!(
+        !location_lines(&lsp.references(&uri, 1, 11, false), &uri).contains(&7),
+        "the base declaration must not collect the override's capture"
+    );
+    assert_eq!(
+        location_lines(&lsp.definition(&uri, 7, callback_char), &uri),
+        std::collections::BTreeSet::from([5]),
+        "the capture resolves to the override"
+    );
+    assert!(
+        location_lines(&lsp.references(&uri, 5, 11, false), &uri).contains(&7),
+        "the override's own family collects it"
+    );
+}
+
+/// #1705: `Base` and `Child` in separate documents.  The workspace tier must
+/// answer with the same effective provider the single-document tier does, in
+/// references, lens, rename and call hierarchy alike.
+#[test]
+fn tp_cross_file_inherited_self_callback_agrees_everywhere() {
+    let mut lsp = Lsp::tcl();
+    let base = unique_uri("tcl");
+    let child = unique_uri("tcl");
+    lsp.open_ready(
+        &base,
+        "oo::class create Base {\n    method tick {} { return 1 }\n}\n",
+    );
+    let child_src = "oo::class create Child {\n    superclass Base\n    method wire {} {\n        after idle [list [self] tick]\n    }\n}\n";
+    let callback_char =
+        u32::try_from(child_src.lines().nth(3).unwrap().rfind("tick").unwrap()).unwrap();
+    lsp.open_ready(&child, child_src);
+
+    assert_eq!(
+        location_lines(&lsp.definition(&child, 3, callback_char), &base),
+        std::collections::BTreeSet::from([1]),
+        "the cross-file provider answers go-to-definition"
+    );
+    let refs = lsp.references(&base, 1, 11, true);
+    assert!(
+        location_lines(&refs, &child).contains(&3),
+        "cross-file callback missing from references: {refs:?}"
+    );
+    let lens = resolve_lens_on_line(&mut lsp, &base, 1);
+    assert!(
+        location_lines(&lens_locations(&lens), &child).contains(&3),
+        "cross-file callback missing from lens: {lens:?}"
+    );
+    let edits = rename_edits(&lsp.rename(&child, 3, callback_char, "tock"));
+    assert!(edit_lines(&edits, &base).contains(&1), "{edits:?}");
+    assert!(edit_lines(&edits, &child).contains(&3), "{edits:?}");
+
+    let item = lsp.prepare_call_hierarchy(&base, 1, 11)[0].clone();
+    let incoming = lsp.incoming_calls(item);
+    assert!(
+        incoming.to_string().contains("wire"),
+        "cross-file callback missing from hierarchy: {incoming:?}"
+    );
+}
+
+/// #1705: the mirror of the suppression case, and the one a provider-only
+/// reading gets wrong in the other direction.  `Base` unexports its own
+/// `tock`, the sibling document's `Child` exports the inherited name, and
+/// tclsh 8.6.16 / 9.0.4 run `Base`'s body for `[Child new] tock`.
+#[test]
+fn tp_cross_file_receiver_reexport_revives_the_inherited_callback() {
+    let mut lsp = Lsp::tcl();
+    let base = unique_uri("tcl");
+    let child = unique_uri("tcl");
+    lsp.open_ready(
+        &base,
+        "oo::class create Base {\n    method tock {} { return 1 }\n    unexport tock\n}\n",
+    );
+    let child_src = "oo::class create Child {\n    superclass Base\n    export tock\n    method wire {} {\n        after idle [list [self] tock]\n    }\n}\n";
+    let callback_char =
+        u32::try_from(child_src.lines().nth(4).unwrap().rfind("tock").unwrap()).unwrap();
+    lsp.open_ready(&child, child_src);
+
+    assert_eq!(
+        location_lines(&lsp.definition(&child, 4, callback_char), &base),
+        std::collections::BTreeSet::from([1]),
+        "a re-exporting receiver revives the inherited callback target"
+    );
+    let refs = lsp.references(&base, 1, 11, true);
+    assert!(
+        location_lines(&refs, &child).contains(&4),
+        "the revived cross-file callback is a reference: {refs:?}"
+    );
+}
+
+/// #1705: a class of the same simple name in an unrelated document shares no
+/// family, so its identically-spelled capture must stay out of the answer.
+#[test]
+fn tp_unrelated_same_named_class_keeps_its_callback_isolated() {
+    let mut lsp = Lsp::tcl();
+    let base = unique_uri("tcl");
+    let other = unique_uri("tcl");
+    lsp.open_ready(
+        &base,
+        "oo::class create Base {\n    method tick {} { return 1 }\n}\n",
+    );
+    lsp.open_ready(
+        &other,
+        "namespace eval other {\n    oo::class create Base {\n        method tick {} { return 2 }\n        method wire {} {\n            after idle [list [self] tick]\n        }\n    }\n}\n",
+    );
+
+    let refs = lsp.references(&base, 1, 11, true);
+    assert!(
+        !location_lines(&refs, &other).contains(&4),
+        "an unrelated namespace's class must not share the family: {refs:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Closes #1705.  A captured `[self]` object command in an **inheriting** class
  now resolves to its effective provider — same document and across files —
  instead of abstaining everywhere.  `after idle [list [self] tick]` written in
  a `Child` whose `Base` declares `tick` is a call site of `Base::tick` in Find
  All References, go-to-definition, the code lens, rename and call hierarchy
  alike, and the same occurrence drops out of all five when the receiver has
  unexported the name.  This was the last piece of the #1701 / #1703 / #1704
  callback family that was still explicitly deferred (the abstention was
  commented "until #1705 models effective receiver visibility").

- The model it needed: `TclOO` reads **two independent facts** off the
  linearisation.  The **export flag** comes from the most specific class that
  **mentions** the name on the branch reaching the provider; the
  **implementation** comes from the first class on the full MRO that declares a
  body.  They come apart because `export` / `unexport` accept a name their
  class does not define — C creates a body-less table entry whose only content
  is the flag, which `info class methods` does not list, so it cannot be read
  off the member tables at all.  Oracle, byte-identical on tclsh 8.6.16 and
  9.0.4:

  ```tcl
  oo::class create Base   { method tick {} { return base } }
  oo::class create Child  { superclass Base } ; oo::define Child { unexport tick }
  [Child new] tick     ;# -> unknown method "tick"   (Base's public body, suppressed here)

  oo::class create Base3  { method tock {} { return b3 } ; unexport tock }
  oo::class create Child3 { superclass Base3 ; export tock }
  [Child3 new] tock    ;# -> b3                      (Base3's unexported body, revived here)
  [Base3 new] tock     ;# -> unknown method "tock"
  ```

  `private` is not such a flag (a subclass's `export priv` still leaves
  `[Child new] priv` an `unknown method` on 9.0.4), and internal `my` dispatch
  ignores the flag entirely.

- **Every `mixin` branch decides for itself.**  C's
  `AddSimpleClassChainToCallContext` enters each mixin with a fresh *copy* of
  the dispatch flags, so a branch's `export` / `unexport` governs that branch
  alone and never travels to another.  Dispatch is therefore a sequence of
  mixin-free spines — each reachable mixin branch, then the receiver's own
  `superclass` spine — and a provider answers to the flag of the **first branch
  that reaches it**:

  ```tcl
  oo::class create A      { method m {} { return A-m } }
  oo::class create MBase  { method m {} { return MBase-m } }
  oo::class create MChild { superclass MBase } ; oo::define MChild { unexport m }
  oo::class create D { superclass A ; mixin MChild }
  [D new] m           ;# -> A-m       (the mixin branch is empty; the spine answers)

  oo::class create MPub { superclass MBase }
  oo::class create D2 { superclass A ; mixin MPub }
  [D2 new] m          ;# -> MBase-m   (a live mixin branch outranks the spine)

  oo::class create NBase  { method n {} { return NBase-n } ; unexport n }
  oo::class create NChild { superclass NBase ; export n }
  oo::class create A2 { method n {} { return A2-n } }
  oo::class create D3 { superclass A2 ; mixin NChild }
  [D3 new] n          ;# -> NBase-n   (the branch's own export revives its base)
  ```

  Branch roots are collected transitively, so a `mixin` written on a superclass
  or on another mixin is governed the same way.  `ClassHierarchy::spine_map` is
  the mixin-free linearisation each branch is read along — the same resolved
  `superclass` edges as `mro_map`, from the same `tcl_syntax::mro` owner, so
  the two orders cannot disagree about which qualified name a bare `superclass
  Device` meant — and `ClassHierarchy::mixin_map` carries the owner-resolved
  edges that name the roots.  `WorkspaceIndex`'s `ClassEdges` is the cross-file
  twin.

  (The first two shapes above are [Codex's P1 finding](https://github.com/bitwisecook/tcl-lsp/pull/1726#discussion_r3889419694)
  and the mirror case verifying it turned up; both were wrong in the original
  draft of this PR, which let the spine's state stand for a mixin-reached
  provider.)

- Both dispatch folds now read the flag the same way — in-document
  `oo_dispatch::method_dispatch_provider` and cross-file
  `WorkspaceIndex::dispatch_chain` — so the fix also lands on plain `$obj m`
  navigation for the same shapes, which previously answered the base's
  declaration through a subclass's `unexport` and answered nothing through a
  subclass's `export`.

- Consequence the reference scan has to respect: the two dispatch kinds can
  land on **different classes** for one receiver.  With the `MChild` shape
  above, `my m` inside `D` reaches `MBase::m` while `[list [self] m]` reaches
  `A::m`.  The declaration side gated inheritors on `method_target`, which is
  visibility-blind; it now asks the shared dispatch walk for each kind
  separately and sends a receiver's `my` sites and its captures to their own
  families.

- The cross-file callback arm resolves to the **receiver**, exactly as the bare
  `$obj method` arms beside it already do, with the dispatch chain as its gate
  rather than its answer.  Rooting the chain at the provider instead is what
  dropped the receiver's own stub on the way to the definition / family /
  rename tiers.

- `method_family_by_document` decides per inheriting receiver, under the index
  read it already takes, whether that receiver dispatches the member externally
  **into this family**, and hands the per-document scans that plain fact.  The
  bulk `WorkspaceIndex::external_dispatch_receivers` pays the O(classes) edge
  resolution once for the whole family rather than once per inheritor — the
  O(classes²) shape `subclass_provided_members` documents the cost of.

- Incidental tidy-up on the way: the cross-file references and rename passes
  had two near-identical per-document span loops and now share
  `family_spans_in_document`, so they cannot disagree about what a document
  contributes.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo clippy --workspace --all-targets -- -D warnings
RUSTFLAGS="-D warnings" cargo test -p tcl-lsp-core -p tcl-lsp-server -p tcl-compiler
cargo xtask owner-resolution
```

All green: workspace clippy clean, 1522 e2e tests plus every unit and doc test
passing, and the owner-resolution gate resolving all 21 owner rows.

Semantics were pinned against real interpreters before being coded, with
`tclsh8.6` (8.6.16), `tclsh9.0` (9.0.4) and `tclsh9.1` (9.1b0) agreeing on
every vector quoted above and in the new tests: inherited public dispatch,
receiver `unexport` suppression, receiver `export` revival, three-deep
intermediate suppression, mixin-branch isolation in both directions, a
superclass-declared mixin governing its own branch, `private` not being
liftable by a subclass `export`, and declaration-order-vs-stub precedence
(`unexport g` then `method g` leaves `[G new] g` callable).

New coverage:

- `rust/tcl-lsp-core/src/references.rs` — inherited capture joins the
  provider's family; receiver `unexport` and receiver `export` decide it; an
  override keeps its capture in its own family; an unrelated class does not
  collect a same-named capture; and four mixin-branch cases (suppressed
  branch, live branch, branch-local revival, superclass-declared mixin).
- `rust/tcl-lsp-core/src/workspace_index.rs` — the cross-file chain for the
  same shapes, including `my` still reaching the suppressed body and the
  family-membership gate on `external_dispatch_receivers`.
- `rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs` — five end-to-end cases
  covering references / definition / lens / rename / call hierarchy agreement,
  same-document and cross-file, plus the same-simple-name-in-another-namespace
  negative.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract?  Yes — `ClassHierarchy`
      gains `spine_map` and `mixin_map`, and external-dispatch visibility is
      now the effective state of the branch reaching the provider rather than
      the provider's own declaration.
- [x] If yes, I updated the owning design doc under `docs/design/compiler/` or
      `docs/design/contracts/` — `docs/design/contracts/tcloo-implementation.md`
      gains an "Export state vs. implementation" section, including the known
      multiple-`superclass` limit.
- [x] If I added or changed a diagnostic or optimisation code, I updated its
      page under `docs/kcs/codes/` and linked it from `docs/kcs/codes/README.md`
      — n/a, no diagnostic or optimisation code changed.
- [x] If I added a design doc, I linked it from `docs/design/README.md`
      (`cargo xtask kcs-index-links` enforces this) — n/a, no new design doc.