### PR TITLE
iRulesLX: declare a plugin's workspace, and reach the JavaScript end from the editor

### DIFF
--- a/docs/design/iruleslx-remote-methods.md
+++ b/docs/design/iruleslx-remote-methods.md
@@ -264,6 +264,24 @@ Registering the provider is not itself an activation event: the extension
 activates on a Tcl language id or on a workspace containing Tcl sources, which
 an ILX workspace always does. A JavaScript-only project never activates it.
 
+### Desktop only, and why
+
+The whole relation — definition, hover and both directions of
+find-references — is **filesystem-path** shaped: `extensions/<name>/` is
+matched on path components, the entry point is resolved through
+`package.json`'s `main`, and the caller search lists directories. Every server
+tier therefore starts by turning the request's URI into a path, and a URI that
+is not `file:` has none.
+
+So on the web hosts (vscode.dev / github.dev, where documents are `vscode-vfs:`
+and friends) every ILX tier abstains, and has since the relation landed. The
+browser entry point deliberately does **not** register the JavaScript reference
+provider: it would send a request the server cannot answer. Making this work on
+the web means giving the relation a URI-shaped discovery path rather than a
+path-shaped one — extension lookup, entry-point resolution and directory
+listing all over the virtual filesystem — which is its own change, not a
+registration.
+
 ## Anchors
 
 - `rust/tcl-registry/src/remote_method.rs` — the descriptors.

--- a/docs/design/iruleslx-remote-methods.md
+++ b/docs/design/iruleslx-remote-methods.md
@@ -82,12 +82,57 @@ a `…/<ancestor>/PLUGIN/extensions/…` sibling. The workspace is never scanned
 wholesale. If no ancestor matches, or two distinct directories do, nothing
 resolves.
 
-A plugin deliberately named differently from its workspace is therefore **not
-navigable**. An explicit configured mapping (the "documented workspace/config
-mapping" half of issue #1707 criterion 2) is not implemented; approximating it
-by matching on the extension name alone would resolve to the wrong file in a
-workspace that has two plugins, which is exactly the guess criterion 4
-forbids.
+A plugin deliberately named differently from its workspace is not navigable by
+that rule alone, and approximating it by matching on the extension name would
+resolve to the wrong file in a workspace that has two plugins — exactly the
+guess criterion 4 forbids. So the user says it instead.
+
+### The declared mapping
+
+```ini
+# .tcl-lsp.ini, in the workspace folder
+[iruleslx.plugins]
+prod_plugin = workspaces/ws_alpha
+
+[iruleslx.rules]
+prod_plugin =
+    irules/http
+    irules/tcp
+```
+
+or, identically, the `tclLsp.iruleslx` editor setting:
+
+```json
+{ "tclLsp.iruleslx": {
+    "plugins": { "prod_plugin": "workspaces/ws_alpha" },
+    "rules":   { "prod_plugin": ["irules/http", "irules/tcp"] } } }
+```
+
+Every key is a plugin name — the `PLUGIN` word of `ILX::init`. Paths are
+relative to the workspace folder the configuration belongs to (absolute paths
+are taken as given) and are lexically normalised, so a declaration written
+`../shared/ws` compares equal to the same directory reached from a document's
+own ancestors. That equality is what lets the *JavaScript* end recognise a
+declared workspace as well.
+
+A declaration is **authoritative**: once `prod_plugin` is declared, the
+directory-name convention is not consulted for it at all. Treating the
+declaration as one more candidate would turn a workspace that happens to
+share the plugin's name into an `ExtensionAmbiguous` — an answer strictly
+worse than the one the user asked for.
+
+`[iruleslx.rules]` is the caller-side admission of the same gap: the deployed
+layout keeps every rule in `rules/`, but a repository routinely keeps its
+iRules elsewhere and builds the workspace at release time. Those directories
+*are* walked (the workspace's own `rules/` is not — see below), bounded to 8
+levels and 512 directories per request, because the user named them
+deliberately. A `rules` entry for a plugin with no `plugins` entry is dropped:
+extra caller directories are only meaningful once the plugin's workspace is
+known, and keeping a half-declaration would widen the search for a plugin the
+user never associated.
+
+The resolved associations are reported by `tcl-lsp.getEffectiveConfig` as
+`iruleslx_plugins`, so a client can see where a declaration actually pointed.
 
 ## Supported JavaScript
 
@@ -176,9 +221,17 @@ holding its iRules.
 
 From either end, the set is the registration(s) plus every literal
 `ILX::call` / `ILX::notify` of the same method **on the same extension**, in
-the open document and in the immediate children of the associated workspace's
-`rules/` directory (the documented layout puts every rule there). A rule
-outside that directory, or in a different workspace, is not searched.
+the open document, in the immediate children of the associated workspace's
+`rules/` directory (the documented layout puts every rule there), and in every
+directory declared for the plugin under `[iruleslx.rules]`.
+
+`rules/` is deliberately not walked recursively and the workspace is never
+scanned wholesale: a deeper walk of a directory the user did not point at
+would turn one find-references into a tree scan. A declared directory is
+different — it exists precisely because the callers are not in `rules/` — so
+it is walked, under the bounds above. A rule that is in neither is still not
+found, and that is now a configuration the user can make rather than a limit
+of the model.
 
 Every other file — a sibling rule, the extension's entry point, its
 `package.json` — is read the way the server's own cross-document providers read
@@ -188,10 +241,28 @@ navigation sees.
 
 The JavaScript end is gated on the document being the extension's resolved
 entry point, so an ordinary `.js` file elsewhere in a project is never
-scanned. It is reachable for a *closed* file (the server reads closed files
-through its source store); the VS Code extension does not associate `.js` with
-the Tcl server, so an editor-side "find references" started from inside
-`index.js` is not wired up yet.
+scanned.
+
+It is reachable two ways. The server reads closed files through its source
+store, so a `textDocument/references` naming a closed `index.js` is answered
+directly. For an **open** JavaScript buffer the VS Code extension registers a
+*second* `vscode.ReferenceProvider` for `javascript`, which calls the
+`tcl-lsp.ilxReferences` command with the buffer's own text and contributes the
+Tcl call sites alongside whatever the JavaScript language service found.
+
+A command rather than a document-selector entry, deliberately: adding
+`javascript` to the language client's selector would hand every JavaScript
+file in the project to the Tcl server — analyser, workspace index and
+diagnostics pipeline included — which has nothing true to say about a language
+it understands two API calls of. As a second provider the `.js` document never
+enters the Tcl document model at all, and neither provider displaces the
+other. The extension-entry gate is applied on the server as well as in the
+client's cheap `extensions/<name>/` pre-filter, so a request naming an
+ordinary `.js` file answers nothing rather than scanning it.
+
+Registering the provider is not itself an activation event: the extension
+activates on a Tcl language id or on a workspace containing Tcl sources, which
+an ILX workspace always does. A JavaScript-only project never activates it.
 
 ## Anchors
 
@@ -201,5 +272,8 @@ the Tcl server, so an editor-side "find references" started from inside
 - `rust/tcl-irules/src/ilx.rs` — the Tcl walk and the JavaScript scanner.
 - `rust/tcl-lsp-core/src/ilx_navigation.rs` — workspace association,
   definition / hover / references.
+- `rust/tcl-lsp-server/src/config_ini.rs` — the `[iruleslx.*]` INI sections.
+- `editors/vscode/src/ilxReferences.ts` — the client-side JavaScript
+  reference provider.
 - `rust/tcl-lsp-server/tests/e2e/issue1707_ilx_methods.rs` — the end-to-end
   suite, over a real on-disk ILX workspace.

--- a/docs/kcs/kcs-qa-what-config-sections-are-valid.md
+++ b/docs/kcs/kcs-qa-what-config-sections-are-valid.md
@@ -15,7 +15,7 @@ does each section accept, and what values are valid?
 ## Answer
 
 Both the global `config.ini` and the project `.tcl-lsp.ini` use the
-same INI schema. Nine sections are recognised in total — seven of
+same INI schema. Eleven sections are recognised in total — nine of
 them work in either file, plus one location-specific section for each
 file (`[global]` and `[project]`). Any section or key the parser does
 not know is silently ignored, so a typo turns into a no-op rather
@@ -155,6 +155,45 @@ Style settings that affect linting but not formatting.
 
 - `line_length` — integer.
 
+### `[iruleslx.plugins]` and `[iruleslx.rules]`
+
+iRulesLX only. They tell the server which directory holds a plugin's
+sources, so `ILX::call`/`ILX::notify` can navigate to the
+`ILXServer.addMethod` that implements the method.
+
+Every key is a **plugin name** — the `PLUGIN` word of
+`ILX::init PLUGIN EXTENSION` — so there is no fixed key list:
+
+```ini
+[iruleslx.plugins]
+prod_plugin = workspaces/ws_alpha
+
+[iruleslx.rules]
+prod_plugin =
+    irules/http
+    irules/tcp
+```
+
+- `[iruleslx.plugins]` — `PLUGIN = <workspace directory>`. Needed only
+  when the plugin's name differs from the directory that holds its
+  `extensions/`; when the two match, navigation already works with no
+  configuration. A declared plugin ignores the directory-name rule
+  entirely, so this can also correct a directory that happens to
+  collide with a plugin name.
+- `[iruleslx.rules]` — `PLUGIN = <directory>[, <directory>…]`, one per
+  line or comma-separated. Extra directories to search for iRules that
+  call this plugin, on top of the workspace's own `rules/`. Use it when
+  your repository keeps its iRules outside the workspace it builds.
+  These directories *are* searched recursively (to 8 levels); `rules/`
+  itself is not. An entry for a plugin with no `[iruleslx.plugins]`
+  entry is ignored.
+
+Paths are relative to the folder the config file is in; absolute paths
+are taken as given. In the global `config.ini` prefer absolute paths —
+a relative one resolves against whichever workspace folder is reading
+it. The same settings are available to editors as `tclLsp.iruleslx`
+(`{ "plugins": {…}, "rules": {…} }`).
+
 ### What you cannot put in an INI file
 
 A handful of settings are only honoured when they come from editor
@@ -174,4 +213,5 @@ for the full list of layers and where to put each kind of setting.
 - [How do I turn a diagnostic, optimisation, or shimmer off?](kcs-howto-suppress-diagnostics.md)
 - [How do I turn off all diagnostics for certain files?](kcs-howto-exclude-files-from-diagnostics.md)
 - [Per-code catalogue](codes/README.md)
+- [iRulesLX remote methods](../design/iruleslx-remote-methods.md)
 - [Glossary](../GLOSSARY.md)

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3366,6 +3366,33 @@
             "markdownDescription": "Extra SpecTcl spec packs (`.tclspec` files, or directories of them) to load for this workspace. Relative paths resolve against each workspace folder. Packs under a `.tcl-lsp/` directory, or beside a `tclpkg.tcl` manifest, are found without configuring anything; this setting is for packs that live somewhere else. See docs/design/spec-packs.md.",
             "order": 8
           },
+          "tclLsp.iruleslx": {
+            "scope": "resource",
+            "type": "object",
+            "default": {},
+            "properties": {
+              "plugins": {
+                "type": "object",
+                "markdownDescription": "iRulesLX plugin name (the `PLUGIN` word of `ILX::init PLUGIN EXTENSION`) to the workspace directory holding its `extensions/`. Only needed when the plugin's name differs from that directory's name — when they match, navigation works with no configuration. Relative paths resolve against the workspace folder.",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "rules": {
+                "type": "object",
+                "markdownDescription": "Extra directories to search for iRules that call a plugin, on top of its workspace's own `rules/`. Use this when your repository keeps its iRules outside the workspace it builds. Searched recursively; an entry for a plugin with no `plugins` entry is ignored.",
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false,
+            "markdownDescription": "iRulesLX plugin associations, so `ILX::call` / `ILX::notify` can navigate to the `ILXServer.addMethod` that implements a method. Also settable per project in `.tcl-lsp.ini` as `[iruleslx.plugins]` / `[iruleslx.rules]`. See docs/design/iruleslx-remote-methods.md.",
+            "order": 9
+          },
           "tclLsp.bigipVersion": {
             "scope": "resource",
             "type": "string",

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -86,6 +86,7 @@ import { registerHighlightingHealthChecks } from "./highlightingHealth";
 import { ensureStickyScrollDefaultModel } from "./stickyScrollHealth";
 import { DiffDiagnosticsSuppressor } from "./diffAnalysis";
 import { TCL_LANGUAGE_IDS, isTclLanguage, tclLanguageIdForPath } from "./languageIds";
+import { registerIlxReferenceProvider } from "./ilxReferences";
 import { PackFileExtension, syncPackFileAssociations } from "./packAssociations";
 
 const execFileAsync = promisify(execFile);
@@ -244,6 +245,15 @@ export async function activate(context: ExtensionContext) {
   // `handleDiagnostics` middleware by `buildClientOptions`.
   const diffSuppressor = new DiffDiagnosticsSuppressor();
   context.subscriptions.push(diffSuppressor);
+
+  // iRulesLX: find-references from an extension's JavaScript back to the
+  // iRules that call it (issue #1707). A second reference provider for
+  // `javascript`, deliberately *not* a document-selector entry on the language
+  // client — see ./ilxReferences for why a `.js` file must not become a Tcl
+  // document. `client` is read lazily because it is assigned further down.
+  context.subscriptions.push(
+    registerIlxReferenceProvider(() => client as LanguageClient | undefined),
+  );
 
   // Client options are shared with the browser entry — see ./clientCore.
   let clientOptions = buildClientOptions(diffSuppressor);

--- a/editors/vscode/src/ilxReferences.ts
+++ b/editors/vscode/src/ilxReferences.ts
@@ -137,6 +137,14 @@ export function createIlxReferenceProvider(
  * a Tcl language id or on a workspace containing Tcl sources, which an ILX
  * workspace always does (its `rules/`). A JavaScript-only project therefore
  * never activates it, and never pays for this.
+ *
+ * The **browser** entry point (`extensionBrowser.ts`) deliberately does not
+ * call this. The whole ILX relation is filesystem-path shaped — `extensions/`
+ * matched on path components, `package.json`'s `main`, directory listing — so
+ * every server tier begins by turning the URI into a path, and abstains for the
+ * `vscode-vfs:`-style URIs a web host uses. Registering there would send a
+ * request the server cannot answer. See
+ * `docs/design/iruleslx-remote-methods.md`.
  */
 export function registerIlxReferenceProvider(
   getClient: () => IlxReferenceClient | undefined,

--- a/editors/vscode/src/ilxReferences.ts
+++ b/editors/vscode/src/ilxReferences.ts
@@ -1,0 +1,151 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Find-references from an iRulesLX extension's JavaScript back to the iRules
+ * that call it (issue #1707).
+ *
+ * The Tcl server already answers both ends of the relation, but the JavaScript
+ * end was unreachable from the editor: `.js` is not a Tcl language id, so no
+ * request ever left the client. Adding `javascript` to the language client's
+ * document selector would have handed every JavaScript file in the project to
+ * the Tcl server — the analyser, the workspace index and the diagnostics
+ * pipeline all included — which is wrong for a file this extension understands
+ * only two API calls of.
+ *
+ * So this is a *second* reference provider instead. VS Code merges the results
+ * of every provider registered for a language, so the JavaScript language
+ * service keeps answering for JavaScript and this one contributes the Tcl call
+ * sites alongside it. The document never enters the Tcl document model at all.
+ */
+
+import * as vscode from "vscode";
+
+import type { JsonLocation } from "./showReferences";
+
+/** The `workspace/executeCommand` the server answers this with. */
+const ILX_REFERENCES_COMMAND = "tcl-lsp.ilxReferences";
+
+/** What the provider needs of the language client, and nothing more. */
+export interface IlxReferenceClient {
+  sendRequest(method: string, param: unknown): Promise<unknown>;
+}
+
+/**
+ * Whether `path` could be an ILX extension source — a cheap pre-filter so an
+ * ordinary JavaScript file never costs a round-trip.
+ *
+ * Deliberately looser than the server's own gate, which resolves the
+ * extension's real entry point (`package.json`'s `main`, else `index.js`) and
+ * requires this file to *be* it. This one only asks whether the path runs
+ * through an `extensions/<name>/` directory, which every candidate does; the
+ * server rejects the rest.
+ */
+export function looksLikeIlxExtensionSource(path: string): boolean {
+  const parts = path.split(/[\\/]/);
+  // `extensions` must be followed by the extension directory and then at least
+  // one more segment (the file itself), so a match at the tail is not enough.
+  const at = parts.indexOf("extensions");
+  return at >= 0 && parts.length - at >= 3;
+}
+
+/**
+ * The reference provider itself.
+ *
+ * Returns `undefined` (not an empty array) whenever this relation has nothing
+ * to say — an ordinary `.js` file, a position that is not on an `addMethod`
+ * name, a server that does not know the command — so VS Code falls back to
+ * whatever the JavaScript language service found rather than showing an
+ * emphatic "no references".
+ */
+export function createIlxReferenceProvider(
+  getClient: () => IlxReferenceClient | undefined,
+): vscode.ReferenceProvider {
+  return {
+    async provideReferences(document, position, context, token) {
+      if (document.uri.scheme !== "file") {
+        return undefined;
+      }
+      if (!looksLikeIlxExtensionSource(document.uri.fsPath)) {
+        return undefined;
+      }
+      const client = getClient();
+      if (!client || token.isCancellationRequested) {
+        return undefined;
+      }
+      let result: unknown;
+      try {
+        result = await client.sendRequest("workspace/executeCommand", {
+          command: ILX_REFERENCES_COMMAND,
+          arguments: [
+            {
+              uri: document.uri.toString(),
+              // The server holds no copy of a document it does not own, so the
+              // buffer travels with the request — an unsaved `addMethod` is
+              // then what navigation sees, as it is on the Tcl side.
+              text: document.getText(),
+              line: position.line,
+              character: position.character,
+              includeDeclaration: context.includeDeclaration,
+            },
+          ],
+        });
+      } catch {
+        // A server that predates the command, or one that is restarting: this
+        // provider simply has no answer, which is not an error to report.
+        return undefined;
+      }
+      if (!Array.isArray(result) || result.length === 0) {
+        return undefined;
+      }
+      return (result as JsonLocation[]).map(
+        (loc) =>
+          new vscode.Location(
+            vscode.Uri.parse(loc.uri),
+            new vscode.Range(
+              loc.range.start.line,
+              loc.range.start.character,
+              loc.range.end.line,
+              loc.range.end.character,
+            ),
+          ),
+      );
+    },
+  };
+}
+
+/**
+ * Register the provider for the JavaScript language ids VS Code uses for a
+ * Node extension's sources.
+ *
+ * Registration is not itself an activation event: this extension activates on
+ * a Tcl language id or on a workspace containing Tcl sources, which an ILX
+ * workspace always does (its `rules/`). A JavaScript-only project therefore
+ * never activates it, and never pays for this.
+ */
+export function registerIlxReferenceProvider(
+  getClient: () => IlxReferenceClient | undefined,
+): vscode.Disposable {
+  return vscode.languages.registerReferenceProvider(
+    [
+      { scheme: "file", language: "javascript" },
+      { scheme: "file", language: "javascriptreact" },
+    ],
+    createIlxReferenceProvider(getClient),
+  );
+}

--- a/editors/vscode/src/test/ilxReferences.test.ts
+++ b/editors/vscode/src/test/ilxReferences.test.ts
@@ -1,0 +1,169 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * The JavaScript end of the iRulesLX method relation (issue #1707).
+ *
+ * The provider itself is exercised against a stub client rather than a live
+ * server: what has to hold here is the client-side contract — which documents
+ * are even asked about, what the request carries, and that "no answer" stays
+ * `undefined` so the JavaScript language service's own references survive.
+ * That the server answers correctly is pinned by the Rust e2e suite, over a
+ * real on-disk ILX workspace.
+ */
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+
+import {
+  createIlxReferenceProvider,
+  looksLikeIlxExtensionSource,
+  type IlxReferenceClient,
+} from "../ilxReferences";
+
+/** A `TextDocument` with only the fields the provider reads. */
+function jsDocument(fsPath: string, text: string): vscode.TextDocument {
+  return {
+    uri: vscode.Uri.file(fsPath),
+    getText: () => text,
+  } as unknown as vscode.TextDocument;
+}
+
+const NEVER_CANCELLED = new vscode.CancellationTokenSource().token;
+const WITH_DECLARATION: vscode.ReferenceContext = { includeDeclaration: true };
+
+suite("iRulesLX JavaScript references", () => {
+  test("the pre-filter accepts an extension source and rejects everything else", () => {
+    assert.ok(looksLikeIlxExtensionSource("/w/ws/extensions/my_extension/index.js"));
+    assert.ok(
+      looksLikeIlxExtensionSource("/w/ws/extensions/my_extension/lib/server.js"),
+      "a package.json `main` may sit deeper",
+    );
+    assert.ok(!looksLikeIlxExtensionSource("/w/ws/tool.js"));
+    assert.ok(
+      !looksLikeIlxExtensionSource("/w/ws/extensions/index.js"),
+      "a file directly in `extensions/` is not inside an extension",
+    );
+    // Windows separators reach the same answer.
+    assert.ok(looksLikeIlxExtensionSource("C:\\w\\ws\\extensions\\my_extension\\index.js"));
+  });
+
+  test("an ordinary JavaScript file never reaches the server", async () => {
+    let calls = 0;
+    const client: IlxReferenceClient = {
+      sendRequest: async () => {
+        calls += 1;
+        return [];
+      },
+    };
+    const provider = createIlxReferenceProvider(() => client);
+    const found = await provider.provideReferences(
+      jsDocument("/w/ws/tool.js", "ilx.addMethod('m', cb);"),
+      new vscode.Position(0, 16),
+      WITH_DECLARATION,
+      NEVER_CANCELLED,
+    );
+    assert.strictEqual(found, undefined);
+    assert.strictEqual(calls, 0, "the pre-filter must spend no round-trip");
+  });
+
+  test("the request carries the buffer, and the reply becomes Locations", async () => {
+    let seen: Record<string, unknown> | undefined;
+    const client: IlxReferenceClient = {
+      sendRequest: async (_method, param) => {
+        seen = (param as { arguments: Record<string, unknown>[] }).arguments[0];
+        return [
+          {
+            uri: "file:///w/ws/rules/rule1.tcl",
+            range: { start: { line: 2, character: 34 }, end: { line: 2, character: 48 } },
+          },
+        ];
+      },
+    };
+    const provider = createIlxReferenceProvider(() => client);
+    const found = await provider.provideReferences(
+      jsDocument("/w/ws/extensions/my_extension/index.js", "ilx.addMethod('m', cb);"),
+      new vscode.Position(0, 16),
+      { includeDeclaration: false },
+      NEVER_CANCELLED,
+    );
+    // The server holds no copy of a document it does not own, so the unsaved
+    // buffer travels with the request.
+    assert.strictEqual(seen?.text, "ilx.addMethod('m', cb);");
+    assert.strictEqual(seen?.line, 0);
+    assert.strictEqual(seen?.character, 16);
+    assert.strictEqual(seen?.includeDeclaration, false);
+
+    const locations = found as vscode.Location[];
+    assert.strictEqual(locations.length, 1);
+    assert.strictEqual(locations[0].uri.fsPath, vscode.Uri.file("/w/ws/rules/rule1.tcl").fsPath);
+    assert.strictEqual(locations[0].range.start.line, 2);
+    assert.strictEqual(locations[0].range.start.character, 34);
+  });
+
+  test("no answer stays undefined so the JavaScript provider's own results survive", async () => {
+    const doc = jsDocument("/w/ws/extensions/my_extension/index.js", "ilx.listen();");
+    const empty = createIlxReferenceProvider(() => ({ sendRequest: async () => [] }));
+    assert.strictEqual(
+      await empty.provideReferences(
+        doc,
+        new vscode.Position(0, 4),
+        WITH_DECLARATION,
+        NEVER_CANCELLED,
+      ),
+      undefined,
+      "an empty list is not an emphatic `no references`",
+    );
+    const nullish = createIlxReferenceProvider(() => ({ sendRequest: async () => null }));
+    assert.strictEqual(
+      await nullish.provideReferences(
+        doc,
+        new vscode.Position(0, 4),
+        WITH_DECLARATION,
+        NEVER_CANCELLED,
+      ),
+      undefined,
+    );
+    // A server that predates the command, or one that is restarting.
+    const failing = createIlxReferenceProvider(() => ({
+      sendRequest: async () => {
+        throw new Error("Unhandled method");
+      },
+    }));
+    assert.strictEqual(
+      await failing.provideReferences(
+        doc,
+        new vscode.Position(0, 4),
+        WITH_DECLARATION,
+        NEVER_CANCELLED,
+      ),
+      undefined,
+    );
+    // No client at all (activation raced the server start).
+    const noClient = createIlxReferenceProvider(() => undefined);
+    assert.strictEqual(
+      await noClient.provideReferences(
+        doc,
+        new vscode.Position(0, 4),
+        WITH_DECLARATION,
+        NEVER_CANCELLED,
+      ),
+      undefined,
+    );
+  });
+});

--- a/rust/tcl-lsp-core/src/ilx_navigation.rs
+++ b/rust/tcl-lsp-core/src/ilx_navigation.rs
@@ -107,6 +107,13 @@ const EXTENSIONS_DIR: &str = "extensions";
 /// The directory that holds an ILX workspace's iRules.
 const RULES_DIR: &str = "rules";
 
+/// How deep a *declared* extra rule directory is walked.
+const MAX_RULE_DEPTH: usize = 8;
+
+/// How many directories one request may `read_dir` across all of its declared
+/// extra rule roots.
+const MAX_RULE_DIRS: usize = 512;
+
 /// The document a request is about: where it is, and the text the editor has.
 ///
 /// The text is carried rather than re-read because an open buffer is routinely
@@ -204,6 +211,38 @@ impl<'a> IlxFiles<'a> {
     }
 }
 
+/// One **configured** plugin, as the user declared it.
+///
+/// The source layout establishes an extension name but never a plugin name — a
+/// plugin is created *from* a workspace (`create ilx plugin P from-workspace
+/// W`) and the two need not match. Without a declaration the only association
+/// available is the directory-name convention, and a plugin named otherwise is
+/// simply not navigable; guessing from the extension name alone would pick the
+/// wrong file in a workspace holding two plugins, which is the guess issue
+/// #1707 criterion 4 forbids. So the user says it instead
+/// (`.tcl-lsp.ini [iruleslx.plugins]`, or the `tclLsp.iruleslx` settings key).
+///
+/// A declaration is **authoritative**: once a plugin name is configured, the
+/// convention is not consulted for it at all, so a mapping can also *correct* a
+/// directory that happens to collide with a plugin name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IlxPluginRoot {
+    /// The `PLUGIN` word of `ILX::init`.
+    pub plugin: String,
+    /// The ILX workspace directory holding `extensions/` (and usually
+    /// `rules/`), as an absolute path.
+    pub workspace: PathBuf,
+    /// Extra directories searched — recursively — for iRules that call this
+    /// plugin, beyond its workspace's own `rules/`.
+    ///
+    /// The deployed layout keeps every rule in `rules/`, but a repository
+    /// routinely keeps its iRules somewhere else entirely and builds the
+    /// workspace at release time. Those callers are unreachable from the
+    /// layout alone, and finding them by scanning the tree is the cost this
+    /// model refuses — so, again, the user names them.
+    pub extra_rule_dirs: Vec<PathBuf>,
+}
+
 /// What a request may consult beyond the document in front of it.
 #[derive(Clone, Copy)]
 pub struct IlxContext<'a> {
@@ -211,10 +250,15 @@ pub struct IlxContext<'a> {
     pub registry: &'a CommandRegistry,
     /// Where the other files this request reads come from.
     pub files: IlxFiles<'a>,
+    /// The user's declared plugin associations (see [`IlxPluginRoot`]).
+    /// Empty is the unconfigured case, where the directory-name convention is
+    /// the whole story.
+    pub plugins: &'a [IlxPluginRoot],
 }
 
 impl<'a> IlxContext<'a> {
-    /// A context that reads every other file from `store`.
+    /// A context that reads every other file from `store`, with no configured
+    /// plugin associations.
     #[must_use]
     pub const fn new(
         registry: &'a CommandRegistry,
@@ -223,6 +267,7 @@ impl<'a> IlxContext<'a> {
         Self {
             registry,
             files: IlxFiles::new(store),
+            plugins: &[],
         }
     }
 
@@ -234,6 +279,29 @@ impl<'a> IlxContext<'a> {
             files: self.files.with_open_documents(open),
             ..self
         }
+    }
+
+    /// This context, with the user's declared plugin associations.
+    #[must_use]
+    pub const fn with_plugins(self, plugins: &'a [IlxPluginRoot]) -> Self {
+        Self { plugins, ..self }
+    }
+
+    /// The configured entries declaring `plugin`, in configuration order.
+    fn declared(self, plugin: &str) -> impl Iterator<Item = &'a IlxPluginRoot> {
+        self.plugins.iter().filter(move |p| p.plugin == plugin)
+    }
+
+    /// The extra rule directories declared for whichever plugin(s) `workspace`
+    /// was configured as.
+    fn extra_rules_for_workspace(self, workspace: &Path) -> Vec<PathBuf> {
+        let mut out: Vec<PathBuf> = Vec::new();
+        for entry in self.plugins.iter().filter(|p| p.workspace == workspace) {
+            for dir in &entry.extra_rule_dirs {
+                push_unique(&mut out, dir.clone());
+            }
+        }
+        out
     }
 }
 
@@ -478,7 +546,7 @@ fn workspace_call_sites(
     method: &str,
 ) -> Vec<IlxLocation> {
     let mut out = call_sites_in(doc.path, doc.text, ctx, Some(target), method);
-    for rule in rule_files(&site.workspace, ctx.files.store) {
+    for rule in rule_files(&site.workspace, &site.extra_rules, ctx.files.store) {
         if rule == doc.path {
             continue;
         }
@@ -546,21 +614,42 @@ pub fn references_from_registration(
     let Some((workspace, extension)) = extension_of_entry(doc.path) else {
         return out;
     };
-    let Some(plugin) = directory_name(&workspace) else {
-        return out;
+    // Which `PLUGIN` word reaches this workspace. A declaration wins over the
+    // directory-name convention for the same reason it does on the Tcl side —
+    // the user has said what the plugin is called — and a workspace declared
+    // under more than one plugin name is searched for all of them.
+    let declared: Vec<String> = ctx
+        .plugins
+        .iter()
+        .filter(|entry| entry.workspace == workspace)
+        .map(|entry| entry.plugin.clone())
+        .collect();
+    let plugins = if declared.is_empty() {
+        directory_name(&workspace).into_iter().collect()
+    } else {
+        declared
     };
-    let target = IlxExtension { plugin, extension };
-    for rule in rule_files(&workspace, ctx.files.store) {
+    let targets: Vec<IlxExtension> = plugins
+        .into_iter()
+        .map(|plugin| IlxExtension {
+            plugin,
+            extension: extension.clone(),
+        })
+        .collect();
+    let extra = ctx.extra_rules_for_workspace(&workspace);
+    for rule in rule_files(&workspace, &extra, ctx.files.store) {
         let Some(text) = ctx.files.read(&rule) else {
             continue;
         };
-        out.extend(call_sites_in(
-            &rule,
-            &text,
-            ctx,
-            Some(&target),
-            &registration.name,
-        ));
+        for target in &targets {
+            out.extend(call_sites_in(
+                &rule,
+                &text,
+                ctx,
+                Some(target),
+                &registration.name,
+            ));
+        }
     }
     out
 }
@@ -607,6 +696,9 @@ struct ExtensionSite {
     workspace: PathBuf,
     /// The resolved entry point (`index.js`, or `package.json`'s `main`).
     entry: PathBuf,
+    /// Extra directories the configuration named as holding callers of this
+    /// plugin — see [`IlxPluginRoot::extra_rule_dirs`]. Empty unless declared.
+    extra_rules: Vec<PathBuf>,
 }
 
 /// Find the extension `target` names, relative to `document`.
@@ -618,6 +710,52 @@ fn locate_extension(
     target: &IlxExtension,
     ctx: IlxContext<'_>,
 ) -> Result<ExtensionSite, IlxUnresolved> {
+    let mut found: Vec<ExtensionSite> = Vec::new();
+    for (workspace, extra_rules) in candidate_workspaces(document, target, ctx) {
+        let dir = workspace.join(EXTENSIONS_DIR).join(&target.extension);
+        if !ctx.files.is_dir(&dir) {
+            continue;
+        }
+        let Some(entry) = entry_file(&dir, ctx.files) else {
+            continue;
+        };
+        if found.iter().any(|site| site.entry == entry) {
+            continue;
+        }
+        found.push(ExtensionSite {
+            workspace,
+            entry,
+            extra_rules,
+        });
+    }
+    match found.len() {
+        0 => Err(IlxUnresolved::ExtensionNotFound),
+        1 => Ok(found.remove(0)),
+        _ => Err(IlxUnresolved::ExtensionAmbiguous),
+    }
+}
+
+/// The workspace directories that may hold `target`, each with the extra rule
+/// directories declared alongside it.
+///
+/// A configured association *replaces* the convention for that plugin name
+/// rather than adding to it: the user has said where the plugin is, so a
+/// directory that merely shares its name is not a second candidate (which
+/// would make the declaration produce an ambiguity instead of an answer).
+fn candidate_workspaces(
+    document: &Path,
+    target: &IlxExtension,
+    ctx: IlxContext<'_>,
+) -> Vec<(PathBuf, Vec<PathBuf>)> {
+    let declared: Vec<(PathBuf, Vec<PathBuf>)> = ctx
+        .declared(&target.plugin)
+        .map(|entry| (entry.workspace.clone(), entry.extra_rule_dirs.clone()))
+        .collect();
+    if !declared.is_empty() {
+        return declared;
+    }
+    // The convention: `PLUGIN` names the workspace directory, looked for along
+    // the document's own ancestors only — never by scanning the tree.
     let mut workspaces: Vec<PathBuf> = Vec::new();
     let mut dir = document.parent();
     for _ in 0..MAX_ANCESTORS {
@@ -630,25 +768,10 @@ fn locate_extension(
         push_unique(&mut workspaces, current.join(&target.plugin));
         dir = current.parent();
     }
-    let mut found: Vec<ExtensionSite> = Vec::new();
-    for workspace in workspaces {
-        let dir = workspace.join(EXTENSIONS_DIR).join(&target.extension);
-        if !ctx.files.is_dir(&dir) {
-            continue;
-        }
-        let Some(entry) = entry_file(&dir, ctx.files) else {
-            continue;
-        };
-        if found.iter().any(|site| site.entry == entry) {
-            continue;
-        }
-        found.push(ExtensionSite { workspace, entry });
-    }
-    match found.len() {
-        0 => Err(IlxUnresolved::ExtensionNotFound),
-        1 => Ok(found.remove(0)),
-        _ => Err(IlxUnresolved::ExtensionAmbiguous),
-    }
+    workspaces
+        .into_iter()
+        .map(|workspace| (workspace, Vec::new()))
+        .collect()
 }
 
 /// The entry point of the extension directory `dir`.
@@ -667,13 +790,25 @@ fn entry_file(dir: &Path, files: IlxFiles<'_>) -> Option<PathBuf> {
     files.is_file(&fallback).then_some(fallback)
 }
 
-/// The rule files of an ILX workspace: the immediate children of its `rules/`
-/// directory that carry a Tcl-family source extension.
+/// The rule files to search for callers: the immediate children of the
+/// workspace's `rules/` directory, plus every Tcl source under each **declared**
+/// extra directory.
 ///
-/// Not recursive, and not the whole workspace: the documented layout puts
-/// every rule directly in `rules/`, and a deeper walk would turn one
-/// find-references into a tree scan.
-fn rule_files(workspace: &Path, store: &dyn crate::vfs::SourceStore) -> Vec<PathBuf> {
+/// The `rules/` half is deliberately not recursive and is not the whole
+/// workspace: the documented layout puts every rule directly in `rules/`, and a
+/// deeper walk there would turn one find-references into a tree scan of a
+/// directory the user never pointed at.
+///
+/// A declared directory is different — the user named it precisely because
+/// their iRules do not live in `rules/` — so it *is* walked, bounded by
+/// [`MAX_RULE_DEPTH`] and [`MAX_RULE_DIRS`] so a mapping that accidentally
+/// names a repository root still costs a bounded number of `read_dir` calls
+/// rather than an unbounded one.
+fn rule_files(
+    workspace: &Path,
+    extra: &[PathBuf],
+    store: &dyn crate::vfs::SourceStore,
+) -> Vec<PathBuf> {
     let mut out: Vec<PathBuf> = store
         .read_dir(&workspace.join(RULES_DIR))
         .unwrap_or_default()
@@ -682,8 +817,40 @@ fn rule_files(workspace: &Path, store: &dyn crate::vfs::SourceStore) -> Vec<Path
         .map(|entry| entry.path)
         .filter(|path| is_tcl_source(path))
         .collect();
+    let mut budget = MAX_RULE_DIRS;
+    for root in extra {
+        collect_tcl_sources(root, store, 0, &mut budget, &mut out);
+    }
     out.sort();
+    out.dedup();
     out
+}
+
+/// Depth-first walk of `dir` for Tcl sources, bounded in both depth and total
+/// directories visited (`budget`, shared across the roots of one request).
+fn collect_tcl_sources(
+    dir: &Path,
+    store: &dyn crate::vfs::SourceStore,
+    depth: usize,
+    budget: &mut usize,
+    out: &mut Vec<PathBuf>,
+) {
+    if depth > MAX_RULE_DEPTH || *budget == 0 {
+        return;
+    }
+    *budget -= 1;
+    let Ok(entries) = store.read_dir(dir) else {
+        return;
+    };
+    for entry in entries {
+        if entry.is_file {
+            if is_tcl_source(&entry.path) {
+                out.push(entry.path);
+            }
+        } else if entry.is_dir {
+            collect_tcl_sources(&entry.path, store, depth + 1, budget, out);
+        }
+    }
 }
 
 /// Whether `path` carries one of the Tcl-family source extensions the server
@@ -724,8 +891,9 @@ fn location(path: &Path, text: &str, span: Span, kind: IlxSite) -> IlxLocation {
 #[cfg(test)]
 mod tests {
     use super::{
-        IlxContext, IlxDocument, IlxSite, IlxTarget, IlxUnresolved, definition, is_extension_entry,
-        method_call_at, references, references_from_registration, registration_at,
+        IlxContext, IlxDocument, IlxPluginRoot, IlxSite, IlxTarget, IlxUnresolved, definition,
+        is_extension_entry, method_call_at, references, references_from_registration,
+        registration_at,
     };
     use crate::vfs::MemoryStore;
     use std::path::{Path, PathBuf};
@@ -845,6 +1013,140 @@ mod tests {
         let found = references_from_registration(doc, ctx, &registration);
         assert_eq!(found.len(), 3, "{found:?}");
         assert!(is_extension_entry(js, ctx.files));
+    }
+
+    /// A plugin whose name is *not* its workspace directory: the layout alone
+    /// cannot associate the two, so the declaration is the only thing that can.
+    const RENAMED_RULE: &str = concat!(
+        "when HTTP_REQUEST {\n",
+        "    set handle [ILX::init prod_plugin my_extension]\n",
+        "    set reply [ILX::call $handle my_js_function [HTTP::uri]]\n",
+        "}\n",
+    );
+
+    /// The same workspace as [`workspace_store`], but under a directory whose
+    /// name is not the plugin's — `create ilx plugin prod_plugin
+    /// from-workspace ws_alpha`.
+    fn renamed_plugin_store() -> MemoryStore {
+        let store = MemoryStore::new();
+        store.upsert(
+            "/w/ws_alpha/rules/rule1.tcl",
+            RENAMED_RULE.as_bytes().to_vec(),
+        );
+        store.upsert(
+            "/w/ws_alpha/extensions/my_extension/index.js",
+            EXTENSION.as_bytes().to_vec(),
+        );
+        store
+    }
+
+    fn declared(plugin: &str, workspace: &str, extra: &[&str]) -> Vec<IlxPluginRoot> {
+        vec![IlxPluginRoot {
+            plugin: plugin.to_owned(),
+            workspace: PathBuf::from(workspace),
+            extra_rule_dirs: extra.iter().map(PathBuf::from).collect(),
+        }]
+    }
+
+    #[test]
+    fn a_plugin_named_unlike_its_directory_needs_a_declaration() {
+        let store = renamed_plugin_store();
+        let registry = registry();
+        let doc = IlxDocument {
+            path: Path::new("/w/ws_alpha/rules/rule1.tcl"),
+            text: RENAMED_RULE,
+        };
+        // Undeclared: the directory-name convention has nothing to match, and
+        // guessing from the extension name alone is what criterion 4 forbids.
+        let bare = IlxContext::new(&registry, &store);
+        let call = method_call_at(doc, bare, 2, 34).expect("a method word");
+        assert!(matches!(
+            definition(doc, bare, &call),
+            IlxTarget::Unresolved(IlxUnresolved::ExtensionNotFound)
+        ));
+        // Declared: the user has said where `prod_plugin` lives.
+        let roots = declared("prod_plugin", "/w/ws_alpha", &[]);
+        let ctx = bare.with_plugins(&roots);
+        let IlxTarget::Resolved(location) = definition(doc, ctx, &call) else {
+            panic!("expected the declared workspace to resolve");
+        };
+        assert_eq!(
+            location.path,
+            Path::new("/w/ws_alpha/extensions/my_extension/index.js")
+        );
+    }
+
+    #[test]
+    fn a_declaration_replaces_the_convention_rather_than_competing_with_it() {
+        // Both a directory literally named `my_plugin` *and* a declaration
+        // pointing elsewhere. Treating the declaration as one more candidate
+        // would make it an ambiguity — an answer strictly worse than the one
+        // the user asked for — so it replaces the convention outright.
+        let store = MemoryStore::new();
+        store.upsert("/w/my_plugin/rules/rule1.tcl", RULE.as_bytes().to_vec());
+        store.upsert(
+            "/w/my_plugin/extensions/my_extension/index.js",
+            EXTENSION.as_bytes().to_vec(),
+        );
+        store.upsert(
+            "/w/ws_beta/extensions/my_extension/index.js",
+            EXTENSION.as_bytes().to_vec(),
+        );
+        let registry = registry();
+        let doc = IlxDocument {
+            path: Path::new("/w/my_plugin/rules/rule1.tcl"),
+            text: RULE,
+        };
+        let roots = declared("my_plugin", "/w/ws_beta", &[]);
+        let ctx = IlxContext::new(&registry, &store).with_plugins(&roots);
+        let call = method_call_at(doc, ctx, 2, 34).expect("a method word");
+        let IlxTarget::Resolved(location) = definition(doc, ctx, &call) else {
+            panic!("expected the declared workspace to win outright");
+        };
+        assert_eq!(
+            location.path,
+            Path::new("/w/ws_beta/extensions/my_extension/index.js")
+        );
+    }
+
+    #[test]
+    fn declared_rule_directories_are_searched_recursively() {
+        // A repository that keeps its iRules outside the workspace it builds:
+        // `rules/` holds nothing, and the caller is two directories down in a
+        // declared tree.
+        let store = MemoryStore::new();
+        store.upsert(
+            "/w/ws_alpha/extensions/my_extension/index.js",
+            EXTENSION.as_bytes().to_vec(),
+        );
+        store.upsert(
+            "/repo/irules/http/rule1.tcl",
+            RENAMED_RULE.as_bytes().to_vec(),
+        );
+        let registry = registry();
+        let doc = IlxDocument {
+            path: Path::new("/w/ws_alpha/extensions/my_extension/index.js"),
+            text: EXTENSION,
+        };
+        let roots = declared("prod_plugin", "/w/ws_alpha", &["/repo/irules"]);
+        let ctx = IlxContext::new(&registry, &store).with_plugins(&roots);
+        let registration = registration_at(doc, 2, 16).expect("the addMethod name");
+        let found = references_from_registration(doc, ctx, &registration);
+        assert_eq!(
+            found
+                .iter()
+                .filter(|l| l.path == Path::new("/repo/irules/http/rule1.tcl"))
+                .count(),
+            1,
+            "the declared tree's caller must be found: {found:?}"
+        );
+        // Undeclared, the same request finds only the registration itself —
+        // the workspace's own `rules/` is empty and nothing else is searched.
+        let bare = IlxContext::new(&registry, &store);
+        assert_eq!(
+            references_from_registration(doc, bare, &registration).len(),
+            1
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-server/src/config_ini.rs
+++ b/rust/tcl-lsp-server/src/config_ini.rs
@@ -265,7 +265,68 @@ pub fn settings_from_ini(content: &str, layer: Layer) -> Value {
         out.insert("style".to_owned(), Value::Object(style));
     }
 
+    insert_iruleslx(&sections, &mut out);
+
     Value::Object(out)
+}
+
+/// `[iruleslx.plugins]` / `[iruleslx.rules]` — the iRulesLX plugin ↔ workspace
+/// association (issue #1707 criterion 2's "documented workspace/config
+/// mapping").
+///
+/// ```ini
+/// [iruleslx.plugins]
+/// my_plugin = workspaces/prod_ws
+///
+/// [iruleslx.rules]
+/// my_plugin = irules/http, irules/tcp
+/// ```
+///
+/// Every key is a plugin name — the `PLUGIN` word of `ILX::init` — so the
+/// sections are read key-by-key like `[features]` rather than through a fixed
+/// key list. Paths are relative to the folder the config belongs to (absolute
+/// paths are taken as given), resolved by the server at read time.
+///
+/// The source layout can only establish an *extension* name; a plugin is
+/// created from a workspace and may be named anything, so without a
+/// declaration a plugin whose name differs from its directory is not
+/// navigable. `rules` is the same admission on the caller side: a repository
+/// routinely keeps its iRules outside the workspace it builds.
+fn insert_iruleslx(sections: &[Section], out: &mut Map<String, Value>) {
+    let mut ilx = Map::new();
+    if let Some(section) = sections.iter().find(|s| s.name == "iruleslx.plugins") {
+        let mut plugins = Map::new();
+        for (plugin, path) in &section.entries {
+            let path = path.trim();
+            if !plugin.is_empty() && !path.is_empty() {
+                plugins.insert(plugin.clone(), Value::String(path.to_owned()));
+            }
+        }
+        if !plugins.is_empty() {
+            ilx.insert("plugins".to_owned(), Value::Object(plugins));
+        }
+    }
+    if let Some(section) = sections.iter().find(|s| s.name == "iruleslx.rules") {
+        let mut rules = Map::new();
+        for (plugin, raw) in &section.entries {
+            // One directory per continuation line, or a comma list — the same
+            // rule `libraryPaths` / `entryPoints` take, since these are paths
+            // and a path may legitimately contain a comma.
+            let dirs = parse_path_list(raw);
+            if !plugin.is_empty() && !dirs.is_empty() {
+                rules.insert(
+                    plugin.clone(),
+                    Value::Array(dirs.into_iter().map(Value::String).collect()),
+                );
+            }
+        }
+        if !rules.is_empty() {
+            ilx.insert("rules".to_owned(), Value::Object(rules));
+        }
+    }
+    if !ilx.is_empty() {
+        out.insert("iruleslx".to_owned(), Value::Object(ilx));
+    }
 }
 
 /// `{ "enabled": b }` — the shape the `[shimmer]` / `[xcDiagnostics]` sections

--- a/rust/tcl-lsp-server/src/config_ini/tests.rs
+++ b/rust/tcl-lsp-server/src/config_ini/tests.rs
@@ -354,3 +354,47 @@ fn empty_or_absent_keys_emit_nothing() {
     assert_eq!(settings_from_ini("", Layer::Global), json!({}));
     assert_eq!(settings_from_ini("[global]\n", Layer::Global), json!({}));
 }
+
+#[test]
+fn iruleslx_sections_map_plugins_and_extra_rule_directories() {
+    let ini = concat!(
+        "[iruleslx.plugins]\n",
+        "prod_plugin = workspaces/ws_alpha\n",
+        "other = /abs/ws_beta\n",
+        "\n",
+        "[iruleslx.rules]\n",
+        "prod_plugin =\n",
+        "    irules/http\n",
+        "    irules/tcp\n",
+        "other = a, b\n",
+    );
+    let got = settings_from_ini(ini, Layer::Project);
+    assert_eq!(
+        got["iruleslx"]["plugins"],
+        json!({"prod_plugin": "workspaces/ws_alpha", "other": "/abs/ws_beta"})
+    );
+    // One directory per continuation line, and a comma list for a one-liner —
+    // the same rule `libraryPaths` / `entryPoints` take.
+    assert_eq!(
+        got["iruleslx"]["rules"],
+        json!({"prod_plugin": ["irules/http", "irules/tcp"], "other": ["a", "b"]})
+    );
+}
+
+#[test]
+fn iruleslx_sections_are_absent_when_unconfigured_or_empty() {
+    // No section at all.
+    assert_eq!(settings_from_ini("[project]\n", Layer::Project), json!({}));
+    // A section whose every entry is empty emits nothing rather than an empty
+    // object, so an unconfigured layer cannot mask a configured one below it.
+    assert_eq!(
+        settings_from_ini("[iruleslx.plugins]\np =\n", Layer::Project),
+        json!({})
+    );
+    // `rules` alone is kept in the JSON — dropping a half-declaration is
+    // `parse_ilx_plugins`' job, where the plugin list it needs is in scope.
+    assert_eq!(
+        settings_from_ini("[iruleslx.rules]\np = x\n", Layer::Project)["iruleslx"]["rules"],
+        json!({"p": ["x"]})
+    );
+}

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -6666,6 +6666,38 @@ struct FolderConfig {
     /// carries the key, so a folder list replaces the global one rather
     /// than unioning with it.
     diagnostics_exclude: Option<Vec<String>>,
+    /// `tclLsp.iruleslx` / `.tcl-lsp.ini [iruleslx.plugins]` + `[iruleslx.rules]`
+    /// — the declared iRulesLX plugin associations (#1707). Held per folder
+    /// because the paths are folder-relative, exactly as `entry_points` is.
+    iruleslx: Vec<IlxPluginSpec>,
+}
+
+/// One `[iruleslx.plugins]` entry, with any `[iruleslx.rules]` directories
+/// declared for the same plugin, as written in the configuration.
+///
+/// Paths stay unresolved here: a relative path means "under this folder", and
+/// the folder root is only known where the config is read
+/// ([`Backend::ilx_plugin_roots`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IlxPluginSpec {
+    /// The `PLUGIN` word of `ILX::init`.
+    plugin: String,
+    /// The workspace directory holding `extensions/`.
+    workspace: String,
+    /// Extra directories holding callers of this plugin.
+    extra_rule_dirs: Vec<String>,
+}
+
+/// The deepest workspace folder containing `uri` — the folder itself when a
+/// folder URI was passed. That is the scope whose overrides every per-folder
+/// value resolved through, so `tcl-lsp.getEffectiveConfig` reports it beside
+/// them.
+fn deepest_folder_containing(uri: &Uri, folders: &[Uri]) -> Option<String> {
+    folders
+        .iter()
+        .filter(|folder| uri_under_folder(uri.as_str(), folder.as_str()))
+        .max_by_key(|folder| folder.as_str().len())
+        .map(|folder| folder.as_str().to_owned())
 }
 
 /// Pick the value associated with the **longest** folder URI that `uri` sits
@@ -9459,18 +9491,21 @@ impl Backend {
     /// that defines its own `ILX::call` is therefore untouched.
     async fn ilx_method_at(
         &self,
+        uri: &Uri,
         doc: &DocumentState,
         path: &Path,
         pos: Position,
     ) -> Option<(core_ilx::MethodCall, core_ilx::IlxTarget)> {
         let registry = self.registry_for_dialect(&doc.dialect).await;
         let open = self.open_document_texts().await;
+        let plugins = self.ilx_plugin_roots(uri).await;
         let document = core_ilx::IlxDocument {
             path,
             text: &doc.text,
         };
-        let ctx =
-            core_ilx::IlxContext::new(&registry, self.store.as_ref()).with_open_documents(&open);
+        let ctx = core_ilx::IlxContext::new(&registry, self.store.as_ref())
+            .with_open_documents(&open)
+            .with_plugins(&plugins);
         let call = core_ilx::method_call_at(document, ctx, pos.line, pos.character)?;
         let target = core_ilx::definition(document, ctx, &call);
         Some((call, target))
@@ -9503,6 +9538,7 @@ impl Backend {
         let store = self.store.as_ref();
         let open = self.open_document_texts().await;
         let files = core_ilx::IlxFiles::new(store).with_open_documents(&open);
+        let plugins = self.ilx_plugin_roots(uri).await;
         // Which end of the relation the cursor is on decides which dialect's
         // registry reads the *rule* files, so the file gate is asked first —
         // it needs no registry at all.
@@ -9519,6 +9555,7 @@ impl Backend {
         let ctx = core_ilx::IlxContext {
             registry: &registry,
             files,
+            plugins: &plugins,
         };
         let found = if js_end {
             let registration = core_ilx::registration_at(document, pos.line, pos.character)?;
@@ -9534,6 +9571,75 @@ impl Backend {
                 .filter_map(Self::ilx_location)
                 .collect(),
         )
+    }
+
+    /// `tcl-lsp.ilxReferences` — find-references from a point inside an ILX
+    /// extension's **JavaScript** entry point (issue #1707 criterion 3).
+    ///
+    /// A command rather than a `textDocument/references` route because a `.js`
+    /// file is not a Tcl document and must not become one: routing it to this
+    /// server would put JavaScript through the Tcl analyser, the workspace
+    /// index and the diagnostics pipeline, none of which have anything true to
+    /// say about it. The VS Code client instead registers a *second*
+    /// `ReferenceProvider` for `javascript` that calls this and contributes its
+    /// answers alongside the JavaScript language service's own — so the editor
+    /// shows the Tcl call sites without either provider displacing the other.
+    ///
+    /// The caller passes the buffer's current `text`, since this server holds
+    /// no copy of a document it does not own; an unsaved `addMethod` is
+    /// therefore still what navigation sees, exactly as on the Tcl side.
+    ///
+    /// The extension-entry gate is applied here as well as in the client, so a
+    /// request naming an ordinary `.js` file answers nothing rather than
+    /// scanning it.
+    ///
+    /// `{ uri, text, line, character, includeDeclaration? }` →
+    /// `Location[]`, or `null` when the position is not on a registration.
+    async fn ilx_references_command(
+        &self,
+        args: &[serde_json::Value],
+    ) -> Option<serde_json::Value> {
+        let request = args.first().and_then(serde_json::Value::as_object)?;
+        let uri = Uri::from_str(request.get("uri").and_then(serde_json::Value::as_str)?).ok()?;
+        let path = uri.to_file_path()?.into_owned();
+        let text = request.get("text").and_then(serde_json::Value::as_str)?;
+        let line = u32::try_from(request.get("line").and_then(serde_json::Value::as_u64)?).ok()?;
+        let character = u32::try_from(
+            request
+                .get("character")
+                .and_then(serde_json::Value::as_u64)?,
+        )
+        .ok()?;
+        let include_decl = request
+            .get("includeDeclaration")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(true);
+
+        let open = self.open_document_texts().await;
+        let files = core_ilx::IlxFiles::new(self.store.as_ref()).with_open_documents(&open);
+        if !core_ilx::is_extension_entry(&path, files) {
+            return None;
+        }
+        let plugins = self.ilx_plugin_roots(&uri).await;
+        // JavaScript has no Tcl dialect of its own, so the rule files it is
+        // matched against are read with the dialect that owns the ILX surface.
+        let registry = self
+            .registry_for_dialect(core_ilx::EXTENSION_RULE_DIALECT)
+            .await;
+        let ctx = core_ilx::IlxContext {
+            registry: &registry,
+            files,
+            plugins: &plugins,
+        };
+        let document = core_ilx::IlxDocument { path: &path, text };
+        let registration = core_ilx::registration_at(document, line, character)?;
+        let found = core_ilx::references_from_registration(document, ctx, &registration);
+        let locations: Vec<Location> = found
+            .iter()
+            .filter(|location| include_decl || location.kind != core_ilx::IlxSite::Registration)
+            .filter_map(Self::ilx_location)
+            .collect();
+        serde_json::to_value(locations).ok()
     }
 
     /// Go-to-definition for an iRulesLX method word, or `None` when the cursor
@@ -9552,7 +9658,7 @@ impl Backend {
         pos: Position,
     ) -> Option<Vec<Location>> {
         let path = uri.to_file_path()?.into_owned();
-        let (_, target) = self.ilx_method_at(doc, &path, pos).await?;
+        let (_, target) = self.ilx_method_at(uri, doc, &path, pos).await?;
         Some(match target {
             core_ilx::IlxTarget::Resolved(location) => {
                 Self::ilx_location(&location).into_iter().collect()
@@ -13578,16 +13684,9 @@ impl Backend {
         let parsed_uri = Uri::from_str(uri_str).ok();
         let folder_overrides = self.folder_dialect_overrides().await;
         let known_folders = self.workspace_folder_urls().await;
-        // The deepest workspace folder containing the queried URI (the folder
-        // itself when a folder URI was passed) — the scope whose overrides the
-        // values below resolved through.
-        let folder_uri = parsed_uri.as_ref().and_then(|uri| {
-            known_folders
-                .iter()
-                .filter(|folder| uri_under_folder(uri.as_str(), folder.as_str()))
-                .max_by_key(|folder| folder.as_str().len())
-                .map(|folder| folder.as_str().to_owned())
-        });
+        let folder_uri = parsed_uri
+            .as_ref()
+            .and_then(|uri| deepest_folder_containing(uri, &known_folders));
         // Resolve the dialect via the open document when the URI names one.  A
         // folder (or any other non-document) URI is not readable as a document,
         // so it resolves through the per-folder override chain before falling
@@ -13620,6 +13719,7 @@ impl Backend {
         // deliberate session override counts: it is exactly "someone chose this
         // dialect", and a caller tracing a surprising dialect must be able to
         // see it (issue #1217).
+        let iruleslx_plugins = self.reported_ilx_plugin_roots().await;
         let session_override = self.session_dialect_override.lock().await.clone();
         let dialect_explicitly_set = parsed_uri
             .as_ref()
@@ -13726,6 +13826,10 @@ impl Backend {
             "docstring_style": docstring_style_str,
             "non_ascii_mode": non_ascii_mode_str(mode),
             "disabled_diagnostics": disabled_sorted,
+            // The declared iRulesLX plugin associations (#1707), resolved to
+            // absolute paths — session-wide, so a caller can see what is
+            // configured without naming a document inside the folder.
+            "iruleslx_plugins": iruleslx_plugins,
         })))
     }
 
@@ -15298,6 +15402,76 @@ impl Backend {
             ),
             None => (Vec::new(), None),
         }
+    }
+
+    /// The iRulesLX plugin associations declared for `uri`'s workspace folder
+    /// (issue #1707), with every path resolved against that folder's root.
+    ///
+    /// Folder-scoped for the same reason `entry_points` is: a relative path
+    /// here means "under this folder", and resolving it against every root in
+    /// a multi-root session would invent workspaces the user never declared.
+    /// A no-folder session — a single loose file — has none, and the
+    /// directory-name convention is then the whole story.
+    /// Every folder's declared iRulesLX plugin associations, resolved.
+    ///
+    /// The session-wide view `tcl-lsp.getEffectiveConfig` reports, so a client
+    /// (and the e2e config barrier) can see *that* a declaration has been
+    /// applied and *where* it resolved to, without having to name a document
+    /// inside the folder that carries it.
+    /// [`Self::all_ilx_plugin_roots`] as the JSON `tcl-lsp.getEffectiveConfig`
+    /// reports: `[{plugin, workspace, rules}]`, paths absolute.
+    async fn reported_ilx_plugin_roots(&self) -> Vec<serde_json::Value> {
+        self.all_ilx_plugin_roots()
+            .await
+            .into_iter()
+            .map(|root| {
+                serde_json::json!({
+                    "plugin": root.plugin,
+                    "workspace": root.workspace.to_string_lossy(),
+                    "rules": root
+                        .extra_rule_dirs
+                        .iter()
+                        .map(|dir| dir.to_string_lossy().into_owned())
+                        .collect::<Vec<String>>(),
+                })
+            })
+            .collect()
+    }
+
+    async fn all_ilx_plugin_roots(&self) -> Vec<core_ilx::IlxPluginRoot> {
+        let configs = self.folder_configs.lock().await;
+        let mut out: Vec<core_ilx::IlxPluginRoot> = Vec::new();
+        for (folder, fc) in configs.iter() {
+            let Some(root) = folder.to_file_path().map(std::borrow::Cow::into_owned) else {
+                continue;
+            };
+            out.extend(resolve_ilx_specs(&fc.iruleslx, &root));
+        }
+        out.sort_by(|a, b| (&a.plugin, &a.workspace).cmp(&(&b.plugin, &b.workspace)));
+        out.dedup();
+        out
+    }
+
+    async fn ilx_plugin_roots(&self, uri: &Uri) -> Vec<core_ilx::IlxPluginRoot> {
+        let configs = self.folder_configs.lock().await;
+        let mut best: Option<&(Uri, FolderConfig)> = None;
+        for entry in configs.iter() {
+            if uri_under_folder(uri.as_str(), entry.0.as_str())
+                && best.is_none_or(|b| entry.0.as_str().len() > b.0.as_str().len())
+            {
+                best = Some(entry);
+            }
+        }
+        let Some((folder, fc)) = best else {
+            return Vec::new();
+        };
+        if fc.iruleslx.is_empty() {
+            return Vec::new();
+        }
+        let Some(root) = folder.to_file_path().map(std::borrow::Cow::into_owned) else {
+            return Vec::new();
+        };
+        resolve_ilx_specs(&fc.iruleslx, &root)
     }
 
     /// Whether `uri` matches the resolved `tclLsp.diagnostics.exclude` glob
@@ -20506,6 +20680,7 @@ impl LanguageServer for Backend {
             }
             "tcl-lsp.compilerExplorer" => self.compiler_explorer_command(&params.arguments).await,
             "tcl-lsp.tkPreview" => self.tk_preview_command(&params.arguments).await,
+            "tcl-lsp.ilxReferences" => Ok(self.ilx_references_command(&params.arguments).await),
             _ => Ok(None),
         }
     }
@@ -21043,7 +21218,7 @@ impl LanguageServer for Backend {
         // commands reached it — they share the method target but not the
         // semantics — and, when nothing resolved, why.
         if let Some(path) = uri.to_file_path()
-            && let Some((call, target)) = self.ilx_method_at(&doc, &path, pos).await
+            && let Some((call, target)) = self.ilx_method_at(&uri, &doc, &path, pos).await
         {
             return Ok(Some(lift_hover(CoreHover {
                 value: core_ilx::hover_markdown(&call, &target),
@@ -22375,6 +22550,7 @@ fn parse_folder_config(cfg: &serde_json::Value) -> Option<FolderConfig> {
                 .collect(),
         );
     }
+    fc.iruleslx = parse_ilx_plugins(obj);
     // The disabled-diagnostics and non-ASCII helpers expect the value wrapped
     // under `tclLsp`; the per-folder pull hands us the section content directly.
     let wrapped = serde_json::json!({ "tclLsp": cfg });
@@ -22382,6 +22558,72 @@ fn parse_folder_config(cfg: &serde_json::Value) -> Option<FolderConfig> {
     fc.disabled_diagnostics = settings_disabled_diagnostics(&wrapped);
     fc.severity_overrides = settings_severity_overrides(&wrapped);
     Some(fc)
+}
+
+/// `tclLsp.iruleslx.plugins` / `.rules` → the folder's declared iRulesLX plugin
+/// associations (#1707).
+///
+/// A `rules` entry for a plugin with no `plugins` entry is dropped: extra
+/// caller directories are only meaningful once the plugin's own workspace is
+/// known, and keeping a half-declaration would silently widen the search for a
+/// plugin that still resolves by the directory-name convention — an
+/// association the user did not make.
+/// Resolve one folder's declared specs against that folder's root.
+///
+/// A relative path means "under this folder"; an absolute one is taken as
+/// given. Both are lexically normalised, so a declaration written as
+/// `../shared/ws` compares equal to the same directory reached from a
+/// document's own ancestors — which is what lets the JavaScript end recognise
+/// a declared workspace.
+fn resolve_ilx_specs(specs: &[IlxPluginSpec], root: &Path) -> Vec<core_ilx::IlxPluginRoot> {
+    specs
+        .iter()
+        .map(|spec| core_ilx::IlxPluginRoot {
+            plugin: spec.plugin.clone(),
+            workspace: tcl_lsp_core::source_graph::resolve_under(root, &spec.workspace),
+            extra_rule_dirs: spec
+                .extra_rule_dirs
+                .iter()
+                .map(|dir| tcl_lsp_core::source_graph::resolve_under(root, dir))
+                .collect(),
+        })
+        .collect()
+}
+
+fn parse_ilx_plugins(obj: &serde_json::Map<String, serde_json::Value>) -> Vec<IlxPluginSpec> {
+    let Some(ilx) = obj.get("iruleslx").and_then(serde_json::Value::as_object) else {
+        return Vec::new();
+    };
+    let Some(plugins) = ilx.get("plugins").and_then(serde_json::Value::as_object) else {
+        return Vec::new();
+    };
+    let rules = ilx.get("rules").and_then(serde_json::Value::as_object);
+    let mut out: Vec<IlxPluginSpec> = plugins
+        .iter()
+        .filter_map(|(plugin, workspace)| {
+            let workspace = workspace.as_str()?.trim();
+            (!plugin.is_empty() && !workspace.is_empty()).then(|| IlxPluginSpec {
+                plugin: plugin.clone(),
+                workspace: workspace.to_owned(),
+                extra_rule_dirs: rules
+                    .and_then(|r| r.get(plugin))
+                    .and_then(serde_json::Value::as_array)
+                    .map(|dirs| {
+                        dirs.iter()
+                            .filter_map(serde_json::Value::as_str)
+                            .map(str::trim)
+                            .filter(|d| !d.is_empty())
+                            .map(str::to_owned)
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+            })
+        })
+        .collect();
+    // A JSON object has no guaranteed order; a stable one keeps the resolved
+    // candidate list (and so an ambiguity report) reproducible.
+    out.sort_by(|a, b| a.plugin.cmp(&b.plugin));
+    out
 }
 
 /// Apply one LSP content change to `text` (incremental document sync).
@@ -25132,6 +25374,7 @@ fn build_server_capabilities(
                 "tcl-lsp.setSessionDialectOverride".to_owned(),
                 "tcl-lsp.compilerExplorer".to_owned(),
                 "tcl-lsp.tkPreview".to_owned(),
+                "tcl-lsp.ilxReferences".to_owned(),
             ],
             work_done_progress_options: WorkDoneProgressOptions::default(),
         }),
@@ -26714,6 +26957,74 @@ mod tests {
         assert_eq!(
             fc.entry_points,
             Some(vec!["main.tcl".to_owned(), "src/app.tcl".to_owned()])
+        );
+    }
+
+    #[test]
+    fn folder_config_parses_the_iruleslx_plugin_mapping() {
+        let fc = parse_folder_config(&serde_json::json!({
+            "iruleslx": {
+                "plugins": { "prod": "workspaces/ws_alpha", "other": "/abs/ws" },
+                "rules": { "prod": ["irules/http", "irules/tcp"] },
+            }
+        }))
+        .expect("folder config");
+        // Sorted by plugin name: a JSON object has no guaranteed order, and an
+        // unstable candidate list would make an ambiguity report unstable too.
+        assert_eq!(
+            fc.iruleslx,
+            vec![
+                IlxPluginSpec {
+                    plugin: "other".to_owned(),
+                    workspace: "/abs/ws".to_owned(),
+                    extra_rule_dirs: Vec::new(),
+                },
+                IlxPluginSpec {
+                    plugin: "prod".to_owned(),
+                    workspace: "workspaces/ws_alpha".to_owned(),
+                    extra_rule_dirs: vec!["irules/http".to_owned(), "irules/tcp".to_owned()],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn an_iruleslx_rules_entry_without_a_plugin_entry_is_dropped() {
+        // Extra caller directories are only meaningful once the plugin's own
+        // workspace is known. Keeping the half-declaration would widen the
+        // search for a plugin that still resolves by the directory-name
+        // convention — an association the user never made.
+        let fc = parse_folder_config(&serde_json::json!({
+            "iruleslx": { "rules": { "prod": ["irules"] } }
+        }))
+        .expect("folder config");
+        assert!(fc.iruleslx.is_empty());
+        // …and an empty workspace path is not a declaration either.
+        let blank = parse_folder_config(&serde_json::json!({
+            "iruleslx": { "plugins": { "prod": "  " } }
+        }))
+        .expect("folder config");
+        assert!(blank.iruleslx.is_empty());
+    }
+
+    #[test]
+    fn iruleslx_paths_resolve_against_the_folder_root() {
+        let specs = vec![IlxPluginSpec {
+            plugin: "prod".to_owned(),
+            workspace: "../shared/ws".to_owned(),
+            extra_rule_dirs: vec!["irules".to_owned(), "/abs/elsewhere".to_owned()],
+        }];
+        let roots = resolve_ilx_specs(&specs, Path::new("/repo/app"));
+        assert_eq!(roots.len(), 1);
+        // Lexically normalised, so this compares equal to the same directory
+        // reached from a document's own ancestors.
+        assert_eq!(roots[0].workspace, Path::new("/repo/shared/ws"));
+        assert_eq!(
+            roots[0].extra_rule_dirs,
+            vec![
+                PathBuf::from("/repo/app/irules"),
+                PathBuf::from("/abs/elsewhere"),
+            ]
         );
     }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -9538,11 +9538,19 @@ impl Backend {
         let store = self.store.as_ref();
         let open = self.open_document_texts().await;
         let files = core_ilx::IlxFiles::new(store).with_open_documents(&open);
-        let plugins = self.ilx_plugin_roots(uri).await;
         // Which end of the relation the cursor is on decides which dialect's
-        // registry reads the *rule* files, so the file gate is asked first —
-        // it needs no registry at all.
+        // registry reads the *rule* files — and which declarations apply — so
+        // the file gate is asked first; it needs no registry at all.
         let js_end = core_ilx::is_extension_entry(&path, files);
+        // A Tcl document belongs to a workspace folder, so its own folder's
+        // declarations are the ones that describe it. A JavaScript entry point
+        // is matched by *workspace path* instead, so which folder declared it
+        // is irrelevant — see `all_ilx_plugin_roots`.
+        let plugins = if js_end {
+            self.all_ilx_plugin_roots().await
+        } else {
+            self.ilx_plugin_roots(uri).await
+        };
         let registry = if js_end {
             // A JavaScript source has no Tcl dialect of its own, so the rule
             // files it is matched against are read with the dialect that owns
@@ -9620,7 +9628,9 @@ impl Backend {
         if !core_ilx::is_extension_entry(&path, files) {
             return None;
         }
-        let plugins = self.ilx_plugin_roots(&uri).await;
+        // Every declaration in the session, not just the ones the folder
+        // holding this `.js` made — see `all_ilx_plugin_roots`.
+        let plugins = self.all_ilx_plugin_roots().await;
         // JavaScript has no Tcl dialect of its own, so the rule files it is
         // matched against are read with the dialect that owns the ILX surface.
         let registry = self
@@ -15418,6 +15428,23 @@ impl Backend {
     /// (and the e2e config barrier) can see *that* a declaration has been
     /// applied and *where* it resolved to, without having to name a document
     /// inside the folder that carries it.
+    ///
+    /// It is also what the **JavaScript** end of the ILX relation resolves
+    /// against, rather than [`Self::ilx_plugin_roots`]. A declaration may point
+    /// outside the folder that made it (`prod = ../shared/ws`, or an absolute
+    /// path), and then the entry point is not under that folder at all — so a
+    /// folder-scoped lookup keyed on the `.js` URI would find nothing and fall
+    /// back to the workspace's *directory name*, which is exactly the name the
+    /// declaration exists to correct. Reverse references would then find no
+    /// callers even though Tcl-to-JavaScript navigation through the same
+    /// mapping worked (issue #1707 review).
+    ///
+    /// Widening cannot mismatch here, because the JavaScript end selects by
+    /// resolved **workspace path**: a declaration only applies when its
+    /// workspace *is* this entry point's. The Tcl end keeps the folder-scoped
+    /// lookup, where a session-wide one would make two folders that each
+    /// declare the same plugin name for their own workspace ambiguous for
+    /// both.
     /// [`Self::all_ilx_plugin_roots`] as the JSON `tcl-lsp.getEffectiveConfig`
     /// reports: `[{plugin, workspace, rules}]`, paths absolute.
     async fn reported_ilx_plugin_roots(&self) -> Vec<serde_json::Value> {

--- a/rust/tcl-lsp-server/tests/e2e/common/mod.rs
+++ b/rust/tcl-lsp-server/tests/e2e/common/mod.rs
@@ -1826,6 +1826,23 @@ fn config_reflected(requested: &Value, effective: &Value) -> bool {
                 effective.get(flat).is_some_and(|got| got == v)
             })
         }),
+        // `tclLsp.iruleslx` (#1707) is folder-scoped and reported resolved —
+        // absolute paths, which the request does not carry — so the barrier is
+        // that every declared plugin *name* has reached the applied config.
+        // That is the thing a test then depends on: an unapplied declaration
+        // resolves nothing at all.
+        "iruleslx" => want
+            .get("plugins")
+            .and_then(Value::as_object)
+            .is_none_or(|plugins| {
+                let got = effective.get("iruleslx_plugins").and_then(Value::as_array);
+                plugins.keys().all(|name| {
+                    got.is_some_and(|list| {
+                        list.iter()
+                            .any(|entry| entry.get("plugin").is_some_and(|p| p == name))
+                    })
+                })
+            }),
         "dialect" => effective.get("dialect").is_some_and(|got| got == want),
         "lineLength" => effective.get("line_length").is_some_and(|got| got == want),
         other => panic!(

--- a/rust/tcl-lsp-server/tests/e2e/issue1707_ilx_methods.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue1707_ilx_methods.rs
@@ -616,3 +616,126 @@ fn the_ilx_references_command_ignores_an_ordinary_javascript_file() {
     );
     assert!(result.is_null(), "{result:?}");
 }
+
+/// A declaration that points **outside** the folder that made it — the shape a
+/// `../shared/ws` mapping (or an absolute path, or a second workspace root)
+/// takes.
+///
+/// ```text
+/// <root>/app/rules/rule1.tcl                          <- the workspace folder
+/// <root>/ws_alpha/rules/rule2.tcl                     <- outside it
+/// <root>/ws_alpha/extensions/my_extension/index.js    <- outside it
+/// ```
+///
+/// The JavaScript entry point is not under the configuring folder, so a
+/// folder-scoped lookup keyed on its own URI finds no declaration and falls
+/// back to the workspace's directory name — the very name the declaration
+/// exists to correct.
+struct OutsideFolderFixture {
+    plugin: String,
+    root: PathBuf,
+    folder: PathBuf,
+    inside_uri: String,
+    workspace_rule_uri: String,
+    extension_uri: String,
+}
+
+impl OutsideFolderFixture {
+    fn new(label: &str) -> Self {
+        let plugin = format!("prod_{label}_{}", std::process::id());
+        let root = std::env::temp_dir().join(format!("tcl-lsp-e2e-1707o-{plugin}"));
+        let folder = root.join("app");
+        let workspace = root.join("ws_alpha");
+        let folder_rules = folder.join("rules");
+        let workspace_rules = workspace.join("rules");
+        let extension_dir = workspace.join("extensions").join("my_extension");
+        for dir in [&folder_rules, &workspace_rules, &extension_dir] {
+            std::fs::create_dir_all(dir).expect("mk dir");
+        }
+        let inside = folder_rules.join("rule1.tcl");
+        let workspace_rule = workspace_rules.join("rule2.tcl");
+        let extension_path = extension_dir.join("index.js");
+        std::fs::write(&inside, rule_source(&plugin)).expect("write folder rule");
+        std::fs::write(&workspace_rule, rule_source(&plugin)).expect("write workspace rule");
+        std::fs::write(&extension_path, EXTENSION).expect("write extension");
+        Self {
+            plugin,
+            inside_uri: uri_of(&inside),
+            workspace_rule_uri: uri_of(&workspace_rule),
+            extension_uri: uri_of(&extension_path),
+            folder,
+            root,
+        }
+    }
+
+    fn serve(&self) -> Lsp {
+        let config = serde_json::json!({
+            "iruleslx": { "plugins": { &self.plugin: "../ws_alpha" } }
+        });
+        let mut lsp = Lsp::with_config_at_root(config, &self.folder);
+        lsp.open_ready_lang(&self.inside_uri, &rule_source(&self.plugin), "tcl-irule");
+        lsp
+    }
+}
+
+impl Drop for OutsideFolderFixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+#[test]
+fn a_declaration_outside_its_folder_reaches_both_ends() {
+    let fixture = OutsideFolderFixture::new("outsidefolder");
+    let mut lsp = fixture.serve();
+
+    // The Tcl end: the rule *is* under the configuring folder, so its own
+    // folder's declarations describe it.
+    let from_tcl = locations(&lsp.definition(&fixture.inside_uri, CALL_METHOD.0, CALL_METHOD.1));
+    assert_eq!(from_tcl.len(), 1, "{from_tcl:?}");
+    assert_eq!(from_tcl[0].uri, fixture.extension_uri, "{from_tcl:?}");
+
+    // The JavaScript end: the entry point is *not* under that folder, so a
+    // lookup keyed on its own URI sees no declaration and falls back to the
+    // directory name `ws_alpha` — which no `ILX::init` in these rules writes.
+    // Resolving against every declaration in the session is what keeps the two
+    // directions symmetric.
+    let from_js = locations(&lsp.references(
+        &fixture.extension_uri,
+        REGISTRATION.0,
+        REGISTRATION.1,
+        false,
+    ));
+    assert_eq!(
+        from_js
+            .iter()
+            .filter(|l| l.uri == fixture.workspace_rule_uri)
+            .count(),
+        2,
+        "the declared workspace's own rules/ must still be searched: {from_js:?}"
+    );
+
+    // …and through the command the VS Code client uses for an open buffer.
+    let via_command = lsp.request(
+        "workspace/executeCommand",
+        serde_json::json!({
+            "command": "tcl-lsp.ilxReferences",
+            "arguments": [{
+                "uri": fixture.extension_uri,
+                "text": EXTENSION,
+                "line": REGISTRATION.0,
+                "character": REGISTRATION.1,
+                "includeDeclaration": false,
+            }],
+        }),
+    );
+    let found = locations(&via_command);
+    assert_eq!(
+        found
+            .iter()
+            .filter(|l| l.uri == fixture.workspace_rule_uri)
+            .count(),
+        2,
+        "{found:?}"
+    );
+}

--- a/rust/tcl-lsp-server/tests/e2e/issue1707_ilx_methods.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue1707_ilx_methods.rs
@@ -423,3 +423,196 @@ fn ordinary_tcl_named_ilx_call_is_untouched() {
         "plain Tcl must not get the ILX hover: {hover}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// The declared plugin ↔ workspace mapping, and the JavaScript-side route
+// (issue #1707 criteria 2 and 3, the halves PR #1730 left open)
+// ---------------------------------------------------------------------------
+
+/// A workspace whose **directory name is not the plugin name** — the shape a
+/// `create ilx plugin P from-workspace W` leaves behind, and the one the
+/// directory-name convention cannot resolve — plus a caller kept outside the
+/// workspace entirely, as a repository routinely does.
+///
+/// ```text
+/// <root>/ws_alpha/rules/rule1.tcl
+/// <root>/ws_alpha/extensions/my_extension/index.js
+/// <root>/elsewhere/http/rule2.tcl
+/// ```
+struct DeclaredFixture {
+    plugin: String,
+    root: PathBuf,
+    inside_uri: String,
+    outside_uri: String,
+    extension_uri: String,
+}
+
+impl DeclaredFixture {
+    fn new(label: &str) -> Self {
+        let plugin = format!("prod_{label}_{}", std::process::id());
+        let root = std::env::temp_dir().join(format!("tcl-lsp-e2e-1707d-{plugin}"));
+        let workspace = root.join("ws_alpha");
+        let rules = workspace.join("rules");
+        let extension_dir = workspace.join("extensions").join("my_extension");
+        let outside = root.join("elsewhere").join("http");
+        std::fs::create_dir_all(&rules).expect("mk rules dir");
+        std::fs::create_dir_all(&extension_dir).expect("mk extension dir");
+        std::fs::create_dir_all(&outside).expect("mk outside dir");
+        let inside = rules.join("rule1.tcl");
+        let outside_rule = outside.join("rule2.tcl");
+        let extension_path = extension_dir.join("index.js");
+        std::fs::write(&inside, rule_source(&plugin)).expect("write inside rule");
+        std::fs::write(&outside_rule, rule_source(&plugin)).expect("write outside rule");
+        std::fs::write(&extension_path, EXTENSION).expect("write extension");
+        Self {
+            plugin,
+            inside_uri: uri_of(&inside),
+            outside_uri: uri_of(&outside_rule),
+            extension_uri: uri_of(&extension_path),
+            root,
+        }
+    }
+
+    /// The `tclLsp.iruleslx` settings a user writes to associate the plugin
+    /// with its workspace, and to name where its callers live. Paths are
+    /// folder-relative, exactly as they are in `.tcl-lsp.ini`.
+    fn config(&self) -> Value {
+        serde_json::json!({
+            "iruleslx": {
+                "plugins": { &self.plugin: "ws_alpha" },
+                "rules": { &self.plugin: ["elsewhere"] },
+            }
+        })
+    }
+
+    fn serve(&self, config: Value) -> Lsp {
+        let mut lsp = Lsp::with_config_at_root(config, &self.root);
+        lsp.open_ready_lang(&self.inside_uri, &rule_source(&self.plugin), "tcl-irule");
+        lsp
+    }
+}
+
+impl Drop for DeclaredFixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+#[test]
+fn a_declared_plugin_resolves_where_the_directory_name_cannot() {
+    let fixture = DeclaredFixture::new("decl");
+
+    // Unconfigured: nothing in the layout says `prod_…` is `ws_alpha`, and
+    // matching on the extension name alone is the guess criterion 4 forbids —
+    // so this is a definitive "no target", not a fall-through.
+    let mut bare = fixture.serve(serde_json::json!({}));
+    assert!(
+        locations(&bare.definition(&fixture.inside_uri, CALL_METHOD.0, CALL_METHOD.1)).is_empty(),
+        "the convention must not guess the workspace"
+    );
+    drop(bare);
+
+    // Declared: the same request now crosses into the JavaScript.
+    let mut lsp = fixture.serve(fixture.config());
+    let found = locations(&lsp.definition(&fixture.inside_uri, CALL_METHOD.0, CALL_METHOD.1));
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0].uri, fixture.extension_uri, "{found:?}");
+}
+
+#[test]
+fn declared_rule_directories_reach_a_caller_outside_the_workspace() {
+    let fixture = DeclaredFixture::new("outside");
+    let mut lsp = fixture.serve(fixture.config());
+
+    let found = locations(&lsp.references(&fixture.inside_uri, CALL_METHOD.0, CALL_METHOD.1, true));
+    // The registration, both sites in the open rule, and both sites in the
+    // declared directory's rule — which no scan of `rules/` would ever see.
+    assert_eq!(
+        found
+            .iter()
+            .filter(|l| l.uri == fixture.outside_uri)
+            .count(),
+        2,
+        "the declared directory's caller must be found: {found:?}"
+    );
+    assert_eq!(
+        found
+            .iter()
+            .filter(|l| l.uri == fixture.extension_uri)
+            .count(),
+        1,
+        "{found:?}"
+    );
+}
+
+#[test]
+fn the_javascript_end_answers_through_the_ilx_references_command() {
+    let fixture = DeclaredFixture::new("jscmd");
+    let mut lsp = fixture.serve(fixture.config());
+
+    // What the VS Code client's second `ReferenceProvider` sends for a
+    // JavaScript document the Tcl server does not own: the buffer travels with
+    // the request, since the server holds no copy of it.
+    let result = lsp.request(
+        "workspace/executeCommand",
+        serde_json::json!({
+            "command": "tcl-lsp.ilxReferences",
+            "arguments": [{
+                "uri": fixture.extension_uri,
+                "text": EXTENSION,
+                "line": REGISTRATION.0,
+                "character": REGISTRATION.1,
+                "includeDeclaration": false,
+            }],
+        }),
+    );
+    let found = locations(&result);
+    assert_eq!(found.len(), 4, "both rules, two sites each: {found:?}");
+    assert!(
+        found
+            .iter()
+            .all(|l| l.uri == fixture.inside_uri || l.uri == fixture.outside_uri),
+        "`includeDeclaration: false` drops the registration itself: {found:?}"
+    );
+
+    // A position that is not on a registration name has no answer at all, so
+    // the client falls back to the JavaScript language service rather than
+    // showing an emphatic empty result.
+    let elsewhere = lsp.request(
+        "workspace/executeCommand",
+        serde_json::json!({
+            "command": "tcl-lsp.ilxReferences",
+            "arguments": [{
+                "uri": fixture.extension_uri,
+                "text": EXTENSION,
+                "line": 5,
+                "character": 4,
+            }],
+        }),
+    );
+    assert!(elsewhere.is_null(), "{elsewhere:?}");
+}
+
+#[test]
+fn the_ilx_references_command_ignores_an_ordinary_javascript_file() {
+    let fixture = DeclaredFixture::new("plainjs");
+    let mut lsp = fixture.serve(fixture.config());
+
+    // Same content, but not an extension entry point: the server's own gate
+    // refuses it even though the client's cheap pre-filter might not.
+    let plain = fixture.root.join("tool.js");
+    std::fs::write(&plain, EXTENSION).expect("write plain js");
+    let result = lsp.request(
+        "workspace/executeCommand",
+        serde_json::json!({
+            "command": "tcl-lsp.ilxReferences",
+            "arguments": [{
+                "uri": uri_of(&plain),
+                "text": EXTENSION,
+                "line": REGISTRATION.0,
+                "character": REGISTRATION.1,
+            }],
+        }),
+    );
+    assert!(result.is_null(), "{result:?}");
+}


### PR DESCRIPTION
## Summary

- The three halves of **#1707** that PR #1730 left open, listed in [that issue's reopening comment](https://github.com/bitwisecook/tcl-lsp/issues/1707#issuecomment-5470501560): the configured plugin ↔ workspace mapping (criterion 2's parenthetical), the references scope beyond `rules/` (criterion 3), and the JavaScript end being unreachable from the editor (criterion 3).

### 1. A configured plugin ↔ workspace association

The source layout establishes an *extension* name — the directory under `extensions/` — but never a *plugin* name: a plugin is created **from** a workspace (`create ilx plugin P from-workspace W`) and the two need not match. The only rule available was the directory-name convention, so a plugin named otherwise was not navigable at all; matching on the extension name alone would pick the wrong file in a workspace holding two plugins, which is the guess criterion 4 forbids. So the user says it instead:

```ini
# .tcl-lsp.ini
[iruleslx.plugins]
prod_plugin = workspaces/ws_alpha
```

```json
// or, identically
{ "tclLsp.iruleslx": { "plugins": { "prod_plugin": "workspaces/ws_alpha" } } }
```

Every key is a plugin name — the `PLUGIN` word of `ILX::init` — so the section is read key-by-key like `[features]` rather than through a fixed key list.

A declaration is **authoritative**: once a plugin is declared the convention is not consulted for it at all. Treating the declaration as one more candidate would turn a directory that happens to share the plugin's name into an `ExtensionAmbiguous` — an answer strictly worse than the one the user asked for — so it replaces the convention outright, which also lets a mapping *correct* such a collision.

### 2. Callers that live outside the workspace

```ini
[iruleslx.rules]
prod_plugin =
    irules/http
    irules/tcp
```

The deployed layout keeps every rule in `rules/`, but a repository routinely keeps its iRules elsewhere and builds the workspace at release time; those callers were unreachable. A **declared** directory is walked recursively (bounded to 8 levels and 512 directories per request, shared across the roots of one request). `rules/` still is not walked recursively and the workspace is still never scanned wholesale — a deeper walk of a directory nobody pointed at is exactly the tree scan this model refuses. A `rules` entry for a plugin with no `plugins` entry is dropped: extra caller directories are only meaningful once the plugin's own workspace is known, and keeping a half-declaration would widen the search for an association the user never made.

Paths are folder-relative (absolute taken as given) and lexically normalised, so a declaration written `../shared/ws` compares equal to the same directory reached from a document's own ancestors. That equality is what lets the **JavaScript** end recognise a declared workspace and use its declared plugin name rather than its directory name.

### 3. The JavaScript end, from the editor

Find-references from inside `index.js` was implemented, gated and covered end-to-end, but unreachable from an editor: `.js` is not a Tcl language id, so no request ever left the client.

Adding `javascript` to the language client's document selector would hand **every** JavaScript file in the project to the Tcl server — analyser, workspace index and diagnostics pipeline included — which has nothing true to say about a language it understands two API calls of. So the extension registers a *second* `vscode.ReferenceProvider` for `javascript` instead, calling a new `tcl-lsp.ilxReferences` command. VS Code merges providers, so the JavaScript language service keeps answering for JavaScript and this one contributes the Tcl call sites beside it; the document never enters the Tcl document model.

- The buffer's text travels with the request — the server holds no copy of a document it does not own — so an unsaved `addMethod` is still what navigation sees, as it already is on the Tcl side.
- "No answer" stays `undefined`, never an empty list, so a cursor that is not on a registration does not blank out the JavaScript provider's own results. Same for a server that predates the command, or one that is restarting.
- The extension-entry gate is applied on the **server** as well as in the client's cheap `extensions/<name>/` pre-filter, so a request naming an ordinary `.js` file answers nothing rather than scanning it.
- Registering the provider is not itself an activation event: the extension activates on a Tcl language id or a workspace containing Tcl sources, which an ILX workspace always does (its `rules/`). A JavaScript-only project never activates it and never pays for this.

Desktop only, and now said so in writing. The whole relation is filesystem-path shaped, so every server tier begins with `uri.to_file_path()` and abstains for the `vscode-vfs:`-style URIs a web host uses — true of the definition and hover tiers since #1730, not new here. The browser entry point therefore does **not** register the provider; making this reach the web needs URI-shaped discovery throughout, split out as **#1734**.

### Observability

`tcl-lsp.getEffectiveConfig` now reports `iruleslx_plugins` — the declared associations resolved to absolute paths — so a client can see *where* a declaration actually pointed. That also gives the e2e config barrier a real settle signal: `config_reflected` panics on an unmapped config key by design, and a silent skip would have made every test below race the config it depends on.

## Review round (Codex, two P2s)

**Resolve JavaScript requests against all declared roots — real, fixed in `ce7232f3`.** A declaration may point outside the folder that made it (`plugins.prod = ../shared/ws`, an absolute path, or a mapping to another workspace root). The entry point is then not under that folder, so a lookup keyed on its own URI found no declaration and fell back to the workspace's *directory name* — precisely the name the declaration exists to correct.

Reproduced before changing anything, with the new e2e vector `a_declaration_outside_its_folder_reaches_both_ends`. On the previous head it fails asymmetrically — the Tcl end resolves into the JavaScript, the JavaScript end finds neither call site:

```
assertion `left == right` failed: the declared workspace's own rules/ must still be searched: []
  left: 0
 right: 2
```

The JavaScript end now resolves against `all_ilx_plugin_roots` — every declaration in the session, each already resolved against the folder that made it. Widening cannot mismatch there, because that end selects by resolved **workspace path**: a declaration applies only when its workspace *is* this entry point's. The **Tcl** end deliberately keeps the folder-scoped lookup, where a session-wide one would make two folders that each declare the same plugin name for their own workspace resolve to `ExtensionAmbiguous` for both — a plausible multi-root setup, and a regression rather than a fix.

**Register the provider in the browser entry point — accurate observation, declined.** Every ILX tier (`ilx_references_command`, `ilx_references`, `ilx_definition`, hover) begins with `uri.to_file_path()`, which is `None` for a `vscode-vfs:` URI, so the relation already abstains entirely on vscode.dev / github.dev — including what #1730 shipped. Registering there would send a request the server cannot answer and advertise web support that does not exist. The real prerequisite is the one the finding names itself — non-`file` schemes and source-store synchronisation — which is a change to the relation's own contract. Recorded in the design doc and on `registerIlxReferenceProvider`, and split out as **#1734**; the thread carries the full reasoning.

### Tests

- `rust/tcl-lsp-core/src/ilx_navigation.rs` — a plugin named unlike its directory needs a declaration (and resolves with one); a declaration replaces the convention rather than competing with it (the same-named-directory case that would otherwise be an ambiguity); declared rule directories are searched recursively, and find nothing extra when undeclared.
- `rust/tcl-lsp-server/src/lib.rs` — the folder-config parse, the dropped half-declaration and blank workspace, and path resolution against the folder root including `..` normalisation.
- `rust/tcl-lsp-server/src/config_ini/tests.rs` — the two INI sections, continuation-line and comma list forms, and the absent/empty cases.
- `rust/tcl-lsp-server/tests/e2e/issue1707_ilx_methods.rs` — five tests over **real on-disk** workspaces. Four over a workspace whose directory name is not the plugin name, with a caller kept outside it: unconfigured go-to-definition abstains and configured resolves; references reach the outside caller; the `tcl-lsp.ilxReferences` command answers from the JavaScript end and honours `includeDeclaration`; and it refuses an ordinary `.js` file. Plus the review round's vector, over a folder declaring a workspace outside itself, asserting both ends stay symmetric.
- `editors/vscode/src/test/ilxReferences.test.ts` — the client contract: the pre-filter (including Windows separators and the `extensions/x.js` near-miss), that an ordinary `.js` spends no round-trip, that the request carries the buffer and the reply becomes `Location`s, and that every "nothing to say" path returns `undefined`.

### Documentation

- `docs/design/iruleslx-remote-methods.md` — the declared mapping, its authoritative-over-convention rule and its bounds; the widened references scope and why `rules/` stays shallow; the two ways the JavaScript end is now reachable and why it is a command rather than a document route; and "Desktop only, and why".
- `docs/kcs/kcs-qa-what-config-sections-are-valid.md` — the two new sections, with the section count corrected.
- `editors/vscode/package.json` — the `tclLsp.iruleslx` schema.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

Build isolation per AGENTS.md § "Parallel worktrees and agent build isolation" (a per-worktree target dir, never a shared one — issue #1052). Re-run in full after the review round, on `ce7232f3`:

```
cargo fmt --all -- --check
#   clean

cargo clippy --workspace --all-targets -- -D warnings
#   clean

RUSTFLAGS="-D warnings" cargo test -p tcl-lsp-core -p tcl-lsp-server --lib
#   2183 passed; 0 failed   /   495 passed; 0 failed

RUSTFLAGS="-D warnings" cargo test -p tcl-lsp-server --test e2e
#   1537 passed; 0 failed; 5 ignored

make xtask-check
#   exit 0 — all gates

cd editors/vscode && npm run lint     # eslint + prettier: clean
make compile                          # tsc -p ./: clean
```

`make test-ext` could not run here — the VS Code test host download (330 MB) aborts in this environment — so the extension's own suite was left to CI's `test-ext` job, which passed on this head.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? **No.** Nothing here touches the analyser, lowering or any fact contract: the association rule lives in `tcl_lsp_core::ilx_navigation`, the configuration in `tcl_lsp_server`, and the new command reuses the existing `references_from_registration` path unchanged.
- [x] If yes, I updated the owning design doc under `docs/design/compiler/` or `docs/design/contracts/`. — n/a
- [x] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/` and linked it from `docs/kcs/codes/README.md`. — n/a, no codes changed; this relation still emits no diagnostic (criterion 4).
- [x] If I added a design doc, I linked it from `docs/design/README.md`. — n/a, `docs/design/iruleslx-remote-methods.md` already exists and is linked; this updates it.

Closes #1707.