### PR TITLE
Fix signature help leaking from proc headers into bodies

### DIFF
--- a/docs/design/contracts/xdg-config.md
+++ b/docs/design/contracts/xdg-config.md
@@ -183,6 +183,12 @@ Toggle individual LSP features.  All default to `true`.
 | `selectionRange` | Smart selection |
 | `crossFileResolution` | Broader, bare-name workspace W123 inference — off by default (independent of `[xcDiagnostics]`, which is F5 XC Migration-specific). Exact C Tcl command candidates, including their cross-file E002/E003 arity checks, resolve without it; the opt-in setting only adds a deliberately lossier fallback. A workspace-injected `::tcl::mathfunc` override also resolves without it: that namespace is one table per interpreter, so the suppression is a language fact, not a cross-file inference |
 
+### `[signatureHelp]`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `disabled_commands` | comma- or whitespace-separated command names | (none) | Suppress automatic signatures for selected built-in commands (for example `set, incr`) while retaining other built-ins and user-defined proc signatures. Names are case-sensitive and canonicalised by `tcl-syntax::naming`, the shared Tcl qualified-name owner. |
+
 ### `[formatting]`
 
 | Key | Type | Default | Description |

--- a/docs/kcs/features/kcs-feature-signature-help.md
+++ b/docs/kcs/features/kcs-feature-signature-help.md
@@ -13,16 +13,19 @@ all-editors, analyser
 
 ## How to use
 
-- **Editor**: Shown automatically when typing arguments after a command or proc name.
-- **Settings**: Toggle with `tclLsp.features.signatureHelp`.
+- **Editor**: Shown automatically when typing arguments after a command or proc name. In a `proc` declaration it describes `proc name args body` while the declaration header is active; commands typed inside the braced body get their own signatures.
+- **Master setting**: Toggle with `tclLsp.features.signatureHelp`.
+- **Per-command setting**: Add built-in command names to `tclLsp.signatureHelp.disabledCommands`. For example, `["set", "incr"]` silences those built-ins while retaining help for `format` and user-defined procs.
+- **Config file**: The equivalent layered INI setting is `[signatureHelp] disabled_commands = set, incr`. Names are resolved through Tcl's shared qualified-name rules, so equivalent namespace-separator spellings select the same registry command.
 
 ## Operational context
 
-The provider looks up the command or proc under the cursor and shows the expected arguments, highlighting the current parameter position.
+The provider looks up the command or proc under the text caret and shows the expected arguments, highlighting the current parameter position. Registry-declared Tcl script bodies, switch/case actions, lambdas, definition bodies, and command substitutions establish nested command contexts. Ordinary braced data remains an argument of its containing command.
 
 ## Failure modes
 
 - Wrong parameter highlighted for commands with complex argument patterns.
+- A signature that stays open on comments or blank text inside a proc body indicates that the body was mistaken for the outer `proc` argument. Current releases close it by returning no active signature in those positions.
 
 ## Screenshots
 

--- a/docs/kcs/kcs-qa-what-config-sections-are-valid.md
+++ b/docs/kcs/kcs-qa-what-config-sections-are-valid.md
@@ -115,6 +115,12 @@ the server stop advertising or running that feature. Valid keys:
 `implementation`, `typeDefinition`, `declaration`,
 `linkedEditingRange`, `crossFileResolution`.
 
+### `[signatureHelp]`
+
+Controls selective suppression without disabling signature help globally:
+
+- `disabled_commands` — comma- or whitespace-separated built-in command names. For example, `set, incr` suppresses those built-in signatures while retaining `format` and user-defined proc signatures. Names are case-sensitive and use the shared Tcl qualified-name resolver (so `set`, `::set`, and equivalent separator spellings resolve to the same registry key).
+
 Delivery-model changes are not configuration toggles: diagnostics use push
 publication, while pull requests are supported only when a client requests
 them directly.

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettings.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettings.kt
@@ -25,6 +25,11 @@ import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.util.xmlb.XmlSerializerUtil
 
+internal fun signatureHelpDisabledCommandsOverride(
+    inheritFromIni: Boolean,
+    editorValue: String,
+): String? = if (inheritFromIni) null else editorValue
+
 @Service
 @State(name = "TclLspSettings", storages = [Storage("TclLspSettings.xml")])
 class TclLspSettings : PersistentStateComponent<TclLspSettings> {

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettings.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettings.kt
@@ -39,7 +39,9 @@ class TclLspSettings : PersistentStateComponent<TclLspSettings> {
     var dialect: String = "tcl8.6"
     var extraCommands: String = ""  // comma-separated
     var libraryPaths: String = ""   // comma-separated
-    var signatureHelpDisabledCommands: String = ""  // comma-separated built-ins
+    // null means this editor layer inherits config.ini; an explicit empty
+    // string clears a previously configured editor override.
+    var signatureHelpDisabledCommands: String? = null  // comma-separated built-ins
 
     // Feature toggles
 
@@ -338,15 +340,10 @@ class TclLspSettings : PersistentStateComponent<TclLspSettings> {
         val libPaths = libraryPaths.split(",")
             .map { it.trim() }
             .filter { it.isNotEmpty() }
-        val disabledSignatures = signatureHelpDisabledCommands.split(",")
-            .map { it.trim() }
-            .filter { it.isNotEmpty() }
-
-        return mapOf(
+        val settings = mutableMapOf<String, Any?>(
             "dialect" to dialect,
             "extraCommands" to extraCmds,
             "libraryPaths" to libPaths,
-            "signatureHelp" to mapOf("disabledCommands" to disabledSignatures),
             "features" to mapOf(
                 "hover" to featureHover,
                 "completion" to featureCompletion,
@@ -625,6 +622,13 @@ class TclLspSettings : PersistentStateComponent<TclLspSettings> {
                 "extraPrompts" to aiExtraPrompts,
             ),
         )
+        signatureHelpDisabledCommands?.let { configured ->
+            val disabledSignatures = configured.split(",")
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+            settings["signatureHelp"] = mapOf("disabledCommands" to disabledSignatures)
+        }
+        return settings
     }
 
     companion object {

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettings.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettings.kt
@@ -39,6 +39,7 @@ class TclLspSettings : PersistentStateComponent<TclLspSettings> {
     var dialect: String = "tcl8.6"
     var extraCommands: String = ""  // comma-separated
     var libraryPaths: String = ""   // comma-separated
+    var signatureHelpDisabledCommands: String = ""  // comma-separated built-ins
 
     // Feature toggles
 
@@ -337,11 +338,15 @@ class TclLspSettings : PersistentStateComponent<TclLspSettings> {
         val libPaths = libraryPaths.split(",")
             .map { it.trim() }
             .filter { it.isNotEmpty() }
+        val disabledSignatures = signatureHelpDisabledCommands.split(",")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
 
         return mapOf(
             "dialect" to dialect,
             "extraCommands" to extraCmds,
             "libraryPaths" to libPaths,
+            "signatureHelp" to mapOf("disabledCommands" to disabledSignatures),
             "features" to mapOf(
                 "hover" to featureHover,
                 "completion" to featureCompletion,

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
@@ -549,7 +549,7 @@ class TclLspSettingsPanel {
             dialectCombo.selectedIndex != TclLspSettings.DIALECT_OPTIONS.indexOfFirst { it.first == s.dialect } ||
             extraCommandsField.text != s.extraCommands ||
             libraryPathsField.text != s.libraryPaths ||
-            signatureHelpDisabledCommandsField.text != s.signatureHelpDisabledCommands ||
+            signatureHelpDisabledCommandsField.text != s.signatureHelpDisabledCommands.orEmpty() ||
             // Features
             featureHover.isSelected != s.featureHover ||
             featureCompletion.isSelected != s.featureCompletion ||
@@ -821,7 +821,9 @@ class TclLspSettingsPanel {
         s.dialect = TclLspSettings.DIALECT_OPTIONS.getOrNull(dialectCombo.selectedIndex)?.first ?: "tcl8.6"
         s.extraCommands = extraCommandsField.text
         s.libraryPaths = libraryPathsField.text
-        s.signatureHelpDisabledCommands = signatureHelpDisabledCommandsField.text
+        if (signatureHelpDisabledCommandsField.text != s.signatureHelpDisabledCommands.orEmpty()) {
+            s.signatureHelpDisabledCommands = signatureHelpDisabledCommandsField.text
+        }
 
         s.featureHover = featureHover.isSelected
         s.featureCompletion = featureCompletion.isSelected
@@ -1111,7 +1113,7 @@ class TclLspSettingsPanel {
         dialectCombo.selectedIndex = TclLspSettings.DIALECT_OPTIONS.indexOfFirst { it.first == s.dialect }.coerceAtLeast(0)
         extraCommandsField.text = s.extraCommands
         libraryPathsField.text = s.libraryPaths
-        signatureHelpDisabledCommandsField.text = s.signatureHelpDisabledCommands
+        signatureHelpDisabledCommandsField.text = s.signatureHelpDisabledCommands.orEmpty()
 
         featureHover.isSelected = s.featureHover
         featureCompletion.isSelected = s.featureCompletion

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
@@ -42,6 +42,7 @@ class TclLspSettingsPanel {
     private val extraCommandsField = JBTextField(30)
     private val libraryPathsField = JBTextField(30)
     private val signatureHelpDisabledCommandsField = JBTextField(30)
+    private val signatureHelpInheritDisabledCommands = JBCheckBox("Inherit from config.ini")
 
     // Feature toggles
     private val featureHover = JBCheckBox("Hover")
@@ -346,7 +347,14 @@ class TclLspSettingsPanel {
             JBLabel("Signature help disabled commands:"),
             signatureHelpDisabledCommandsField,
         )
-        builder.addTooltip("Comma-separated built-in command names to silence, such as set,incr. User-defined proc signatures remain enabled.")
+        builder.addTooltip("Comma-separated built-in command names to silence, such as set,incr. Leave Inherit unchecked and this list empty to show every signature. User-defined proc signatures remain enabled.")
+        builder.addComponent(signatureHelpInheritDisabledCommands)
+        signatureHelpInheritDisabledCommands.toolTipText =
+            "Use the disabled-command list from config.ini instead of overriding it in the IDE."
+        signatureHelpInheritDisabledCommands.addActionListener {
+            signatureHelpDisabledCommandsField.isEnabled =
+                !signatureHelpInheritDisabledCommands.isSelected
+        }
 
         // Features section
         builder.addComponent(TitledSeparator("Features"))
@@ -549,7 +557,10 @@ class TclLspSettingsPanel {
             dialectCombo.selectedIndex != TclLspSettings.DIALECT_OPTIONS.indexOfFirst { it.first == s.dialect } ||
             extraCommandsField.text != s.extraCommands ||
             libraryPathsField.text != s.libraryPaths ||
-            signatureHelpDisabledCommandsField.text != s.signatureHelpDisabledCommands.orEmpty() ||
+            signatureHelpDisabledCommandsOverride(
+                signatureHelpInheritDisabledCommands.isSelected,
+                signatureHelpDisabledCommandsField.text,
+            ) != s.signatureHelpDisabledCommands ||
             // Features
             featureHover.isSelected != s.featureHover ||
             featureCompletion.isSelected != s.featureCompletion ||
@@ -821,9 +832,10 @@ class TclLspSettingsPanel {
         s.dialect = TclLspSettings.DIALECT_OPTIONS.getOrNull(dialectCombo.selectedIndex)?.first ?: "tcl8.6"
         s.extraCommands = extraCommandsField.text
         s.libraryPaths = libraryPathsField.text
-        if (signatureHelpDisabledCommandsField.text != s.signatureHelpDisabledCommands.orEmpty()) {
-            s.signatureHelpDisabledCommands = signatureHelpDisabledCommandsField.text
-        }
+        s.signatureHelpDisabledCommands = signatureHelpDisabledCommandsOverride(
+            signatureHelpInheritDisabledCommands.isSelected,
+            signatureHelpDisabledCommandsField.text,
+        )
 
         s.featureHover = featureHover.isSelected
         s.featureCompletion = featureCompletion.isSelected
@@ -1114,6 +1126,8 @@ class TclLspSettingsPanel {
         extraCommandsField.text = s.extraCommands
         libraryPathsField.text = s.libraryPaths
         signatureHelpDisabledCommandsField.text = s.signatureHelpDisabledCommands.orEmpty()
+        signatureHelpInheritDisabledCommands.isSelected = s.signatureHelpDisabledCommands == null
+        signatureHelpDisabledCommandsField.isEnabled = !signatureHelpInheritDisabledCommands.isSelected
 
         featureHover.isSelected = s.featureHover
         featureCompletion.isSelected = s.featureCompletion

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
@@ -41,6 +41,7 @@ class TclLspSettingsPanel {
     )
     private val extraCommandsField = JBTextField(30)
     private val libraryPathsField = JBTextField(30)
+    private val signatureHelpDisabledCommandsField = JBTextField(30)
 
     // Feature toggles
     private val featureHover = JBCheckBox("Hover")
@@ -341,6 +342,11 @@ class TclLspSettingsPanel {
         builder.addTooltip("Comma-separated list of additional command names to treat as known.")
         builder.addLabeledComponent(JBLabel("Library paths:"), libraryPathsField)
         builder.addTooltip("Comma-separated directories to scan for Tcl packages.")
+        builder.addLabeledComponent(
+            JBLabel("Signature help disabled commands:"),
+            signatureHelpDisabledCommandsField,
+        )
+        builder.addTooltip("Comma-separated built-in command names to silence, such as set,incr. User-defined proc signatures remain enabled.")
 
         // Features section
         builder.addComponent(TitledSeparator("Features"))
@@ -543,6 +549,7 @@ class TclLspSettingsPanel {
             dialectCombo.selectedIndex != TclLspSettings.DIALECT_OPTIONS.indexOfFirst { it.first == s.dialect } ||
             extraCommandsField.text != s.extraCommands ||
             libraryPathsField.text != s.libraryPaths ||
+            signatureHelpDisabledCommandsField.text != s.signatureHelpDisabledCommands ||
             // Features
             featureHover.isSelected != s.featureHover ||
             featureCompletion.isSelected != s.featureCompletion ||
@@ -814,6 +821,7 @@ class TclLspSettingsPanel {
         s.dialect = TclLspSettings.DIALECT_OPTIONS.getOrNull(dialectCombo.selectedIndex)?.first ?: "tcl8.6"
         s.extraCommands = extraCommandsField.text
         s.libraryPaths = libraryPathsField.text
+        s.signatureHelpDisabledCommands = signatureHelpDisabledCommandsField.text
 
         s.featureHover = featureHover.isSelected
         s.featureCompletion = featureCompletion.isSelected
@@ -1103,6 +1111,7 @@ class TclLspSettingsPanel {
         dialectCombo.selectedIndex = TclLspSettings.DIALECT_OPTIONS.indexOfFirst { it.first == s.dialect }.coerceAtLeast(0)
         extraCommandsField.text = s.extraCommands
         libraryPathsField.text = s.libraryPaths
+        signatureHelpDisabledCommandsField.text = s.signatureHelpDisabledCommands
 
         featureHover.isSelected = s.featureHover
         featureCompletion.isSelected = s.featureCompletion

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsTest.kt
@@ -1,0 +1,30 @@
+package com.tcllsp.jetbrains.settings
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class TclLspSettingsTest {
+    @Test
+    fun unconfiguredSignatureSuppressionInheritsIni() {
+        val settings = TclLspSettings().toServerSettings()
+
+        assertFalse(settings.containsKey("signatureHelp"))
+    }
+
+    @Test
+    fun configuredSignatureSuppressionPreservesExplicitEmptyAndCommands() {
+        val settings = TclLspSettings()
+        settings.signatureHelpDisabledCommands = " set, ::incr "
+        assertEquals(
+            mapOf("disabledCommands" to listOf("set", "::incr")),
+            settings.toServerSettings()["signatureHelp"],
+        )
+
+        settings.signatureHelpDisabledCommands = ""
+        assertEquals(
+            mapOf("disabledCommands" to emptyList<String>()),
+            settings.toServerSettings()["signatureHelp"],
+        )
+    }
+}

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsTest.kt
@@ -27,4 +27,28 @@ class TclLspSettingsTest {
             settings.toServerSettings()["signatureHelp"],
         )
     }
+
+    @Test
+    fun signatureSuppressionOverrideCanReturnToIniInheritance() {
+        val settings = TclLspSettings()
+        settings.signatureHelpDisabledCommands = signatureHelpDisabledCommandsOverride(
+            inheritFromIni = false,
+            editorValue = "set,incr",
+        )
+        assertEquals(
+            mapOf("disabledCommands" to listOf("set", "incr")),
+            settings.toServerSettings()["signatureHelp"],
+        )
+
+        settings.signatureHelpDisabledCommands = signatureHelpDisabledCommandsOverride(
+            inheritFromIni = true,
+            editorValue = "",
+        )
+        assertFalse(settings.toServerSettings().containsKey("signatureHelp"))
+        assertEquals(
+            "",
+            signatureHelpDisabledCommandsOverride(inheritFromIni = false, editorValue = ""),
+            "an enabled empty override remains distinct from inherited null",
+        )
+    }
 }

--- a/editors/sublime-text/sublime-package.json
+++ b/editors/sublime-text/sublime-package.json
@@ -82,6 +82,18 @@
                                                 "documentLinks": { "type": "boolean", "default": true },
                                                 "selectionRange": { "type": "boolean", "default": true }
                                             }
+                                        },
+                                        "signatureHelp": {
+                                            "type": "object",
+                                            "markdownDescription": "Selective built-in signature-help suppression.",
+                                            "properties": {
+                                                "disabledCommands": {
+                                                    "type": "array",
+                                                    "items": { "type": "string" },
+                                                    "default": [],
+                                                    "markdownDescription": "Built-in command names to silence, such as set and incr. Other commands and user-defined procs retain signature help."
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3557,6 +3557,20 @@
             "description": "Override signature help (parameter hints). When null, inherits from editor.parameterHints.enabled.",
             "order": 11
           },
+          "tclLsp.signatureHelp.disabledCommands": {
+            "scope": "language-overridable",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true,
+            "default": null,
+            "markdownDescription": "Built-in Tcl command names whose automatic signature help is suppressed. For example, add `set` and `incr` to keep signatures for commands such as `format` and for user-defined procs while silencing those two built-ins. Names are case-sensitive and resolved with Tcl's qualified-name rules, so `set` and `::set` select the same registry command.",
+            "order": 12
+          },
           "tclLsp.features.workspaceSymbols": {
             "scope": "language-overridable",
             "type": [
@@ -3565,7 +3579,7 @@
             ],
             "default": null,
             "description": "Override workspace symbols (Cmd+T). When null, enabled.",
-            "order": 12
+            "order": 13
           },
           "tclLsp.features.inlayTypeHints": {
             "scope": "language-overridable",
@@ -3575,7 +3589,7 @@
             ],
             "default": null,
             "description": "Show inferred-type inlay hints on variables (and format-string specifiers). Off by default; set true to enable.",
-            "order": 13
+            "order": 14
           },
           "tclLsp.features.inlayParameterHints": {
             "scope": "language-overridable",
@@ -3585,7 +3599,7 @@
             ],
             "default": null,
             "description": "Show parameter-name inlay hints at proc/method call sites (e.g. NAME:, PROC_SCRIPT:). Verbose; off by default, set true to enable.",
-            "order": 14
+            "order": 15
           },
           "tclLsp.features.callHierarchy": {
             "scope": "language-overridable",
@@ -3595,7 +3609,7 @@
             ],
             "default": null,
             "description": "Override call hierarchy (incoming/outgoing calls for procs). When null, enabled.",
-            "order": 15
+            "order": 16
           },
           "tclLsp.features.documentLinks": {
             "scope": "language-overridable",
@@ -3605,7 +3619,7 @@
             ],
             "default": null,
             "description": "Override document links (clickable source paths and package requires). When null, enabled.",
-            "order": 16
+            "order": 17
           },
           "tclLsp.features.selectionRange": {
             "scope": "language-overridable",
@@ -3615,7 +3629,7 @@
             ],
             "default": null,
             "description": "Override selection range (smart expand/shrink). When null, enabled.",
-            "order": 17
+            "order": 18
           },
           "tclLsp.features.documentHighlight": {
             "scope": "language-overridable",
@@ -3625,7 +3639,7 @@
             ],
             "default": null,
             "description": "Override document highlight. When null, inherits from editor.occurrencesHighlight.",
-            "order": 18
+            "order": 19
           },
           "tclLsp.features.codeLens": {
             "scope": "language-overridable",
@@ -3635,7 +3649,7 @@
             ],
             "default": null,
             "description": "Override code lens (inline reference counts, test runners). When null, inherits from editor.codeLens.",
-            "order": 19
+            "order": 20
           },
           "tclLsp.features.workspaceFileOps": {
             "scope": "language-overridable",
@@ -3645,14 +3659,14 @@
             ],
             "default": null,
             "description": "Override workspace file operations (auto-rewrite source paths on rename). When null, enabled.",
-            "order": 20
+            "order": 21
           },
           "tclLsp.features.willSaveWaitUntil": {
             "scope": "language-overridable",
             "type": "boolean",
             "default": false,
             "description": "Format the document on save via textDocument/willSaveWaitUntil. Off by default; enable for format-on-save without relying on the editor's own editor.formatOnSave. Uses the resolved tclLsp.formatting.lineLength for the document's folder.",
-            "order": 21
+            "order": 22
           },
           "tclLsp.features.implementation": {
             "scope": "language-overridable",
@@ -3662,7 +3676,7 @@
             ],
             "default": null,
             "description": "Override Go to Implementation (TclOO method overrides). When null, enabled.",
-            "order": 23
+            "order": 24
           },
           "tclLsp.features.typeDefinition": {
             "scope": "language-overridable",
@@ -3672,7 +3686,7 @@
             ],
             "default": null,
             "description": "Override Go to Type Definition. When null, enabled.",
-            "order": 24
+            "order": 25
           },
           "tclLsp.features.declaration": {
             "scope": "language-overridable",
@@ -3682,7 +3696,7 @@
             ],
             "default": null,
             "description": "Override Go to Declaration. When null, enabled.",
-            "order": 25
+            "order": 26
           },
           "tclLsp.features.linkedEditingRange": {
             "scope": "language-overridable",
@@ -3692,7 +3706,7 @@
             ],
             "default": null,
             "description": "Override linked editing range. When null, inherits from editor.linkedEditing.",
-            "order": 26
+            "order": 27
           },
           "tclLsp.features.crossFileResolution": {
             "scope": "resource",
@@ -3702,7 +3716,7 @@
             ],
             "default": null,
             "description": "Resolve diagnostics across the whole workspace: suppress \"unknown command\" (W120/W123) for a proc defined in another file, and report wrong-argument-count errors (E002/E003) for cross-file calls. Off by default (scans every workspace file); set true to enable. An expr math function the workspace injects into ::tcl::mathfunc resolves without this setting, since that namespace is one table per interpreter. Independent of XC Migration diagnostics below.",
-            "order": 27
+            "order": 28
           }
         }
       },

--- a/editors/vscode/src/clientCore.ts
+++ b/editors/vscode/src/clientCore.ts
@@ -262,6 +262,20 @@ export function buildClientOptions(
                     }
                   }
                 }
+                // `null` means the command exclusion list was not configured
+                // in VS Code. Drop it so a lower-priority config.ini layer can
+                // supply the list; an explicit `[]` remains meaningful and
+                // clears that lower layer for this scope.
+                const signatureHelp = settings.signatureHelp;
+                if (signatureHelp && typeof signatureHelp === "object") {
+                  const signature = signatureHelp as Record<string, unknown>;
+                  if (
+                    signature.disabledCommands === null ||
+                    signature.disabledCommands === undefined
+                  ) {
+                    delete signature.disabledCommands;
+                  }
+                }
                 // `diagnostics.genericVariablePatterns` defaults to `[]`, but the
                 // server distinguishes "absent → built-in IRULE4002 patterns"
                 // from "explicit empty list → disable the check". Drop the empty

--- a/editors/vscode/src/test/configSettings.test.ts
+++ b/editors/vscode/src/test/configSettings.test.ts
@@ -734,6 +734,10 @@ suite("Configuration Settings", () => {
     assert.strictEqual(value.length, 0);
   });
 
+  test("signatureHelp.disabledCommands defaults to null (inherit config files)", () => {
+    assert.strictEqual(cfg().get<string[] | null>("signatureHelp.disabledCommands"), null);
+  });
+
   // ── Behavioral mutation tests ──────────────────────────────────────
   // Each test verifies that changing a setting actually affects LSP
   // behavior, not just that the config round-trips.
@@ -1019,6 +1023,52 @@ suite("Configuration Settings", () => {
     } finally {
       await config.update("signatureHelp", undefined, undefined);
       await waitForFeatureToggle(docUri, "signatureHelp", true);
+    }
+  });
+
+  test("signatureHelp.disabledCommands selectively suppresses built-ins", async () => {
+    const probe = await vscode.workspace.openTextDocument({
+      language: "tcl",
+      content: "set \nformat \nproc custom {value} {}\ncustom \n",
+    });
+    await vscode.window.showTextDocument(probe);
+    const signatureCount = async (line: number, character: number) => {
+      const result = (await getClient().sendRequest("textDocument/signatureHelp", {
+        textDocument: { uri: probe.uri.toString() },
+        position: { line, character },
+      })) as vscode.SignatureHelp | null;
+      return result?.signatures.length ?? 0;
+    };
+    const config = vscode.workspace.getConfiguration("tclLsp.signatureHelp", probe.uri);
+    try {
+      await pollUntil(
+        () => signatureCount(0, 4),
+        (count) => count > 0,
+        {
+          timeout: 10_000,
+          label: "set signature before command exclusion",
+        },
+      );
+
+      await config.update("disabledCommands", ["::::set", "incr"], undefined);
+      await waitForEffectiveConfig(
+        probe.uri,
+        (effective) =>
+          effective.signature_help_disabled_commands.includes("::set") &&
+          effective.signature_help_disabled_commands.includes("::incr"),
+        { label: "signature-help command exclusions" },
+      );
+
+      assert.strictEqual(await signatureCount(0, 4), 0, "set should be suppressed");
+      assert.ok(await signatureCount(1, 7), "format should retain signature help");
+      assert.ok(await signatureCount(3, 7), "user proc calls should retain signature help");
+    } finally {
+      await config.update("disabledCommands", undefined, undefined);
+      await waitForEffectiveConfig(
+        probe.uri,
+        (effective) => effective.signature_help_disabled_commands.length === 0,
+        { label: "signature-help command exclusions restored" },
+      );
     }
   });
 

--- a/editors/vscode/src/test/helper.ts
+++ b/editors/vscode/src/test/helper.ts
@@ -305,6 +305,7 @@ export interface EffectiveConfig {
   folder_uri: string | null;
   dialect: string;
   extra_commands: string[];
+  signature_help_disabled_commands: string[];
   non_ascii_mode: string | null;
   library_paths: string[];
   spec_packs: string[];

--- a/editors/zed/README.md
+++ b/editors/zed/README.md
@@ -136,6 +136,9 @@ Add to your Zed `settings.json` to configure the language server:
             "declaration": true,
             "linkedEditingRange": true
           },
+          "signatureHelp": {
+            "disabledCommands": ["set", "incr"]
+          },
           "diagnostics": {
             "W100": true,
             "W111": true

--- a/rust/tcl-lsp-core/src/executable_regions.rs
+++ b/rust/tcl-lsp-core/src/executable_regions.rs
@@ -15,7 +15,7 @@ use tcl_compiler::lambda_literal::split_lambda_literal;
 use tcl_compiler::realm::CommandBindingRealm;
 use tcl_compiler::segmenter::{SegmentedCommand, segment_commands_with_offset_and_config};
 use tcl_dialect::model::SurfaceQuery;
-use tcl_lexer::{Lexer, LexerConfig, SourceMap, Token, TokenType};
+use tcl_lexer::{Lexer, LexerConfig, SourceMap, Token, TokenType, close_quote_offset};
 use tcl_registry::definer::DefinitionBodyGrammar;
 use tcl_registry::{ArgRole, CommandRegistry, ScriptTiming};
 
@@ -393,16 +393,12 @@ fn quoted_literal_body_region(source: &str, token: Token) -> Option<(usize, usiz
     }
 
     let start = raw_start + 1;
-    // Non-empty quoted ESC tokens exclude the closer from their span. The
-    // lexer's empty-content clamp includes the closer in `""`, so normalize
-    // that one shape back to the same inner-end convention.
-    let end = if raw_end == start + 1 && bytes.get(start) == Some(&b'"') {
-        start
-    } else if bytes.get(raw_end) == Some(&b'"') {
-        raw_end
-    } else {
-        return None;
-    };
+    // The shared quote scanner owns close semantics (including escaped quotes
+    // and nested command substitutions). An unterminated opening token runs
+    // through EOF, which is also the provisional inner end signature help
+    // needs while the closing quote is still being typed.
+    let end = close_quote_offset(source, raw_start)
+        .map_or_else(|| (raw_end == source.len()).then_some(raw_end), Some)?;
     let content = source.get(start..end)?;
     (!content.as_bytes().contains(&b'\\')).then_some((start, end))
 }
@@ -582,6 +578,17 @@ mod tests {
                 u32::try_from(literal.find("format").expect("nested head")).unwrap(),
             )],
             "a substitution-free quoted body is executable at its written span",
+        );
+
+        let unterminated = "proc p {} \"format {%d} 1";
+        assert_eq!(
+            visited_format_heads(unterminated, dialect),
+            vec![(
+                "format".to_owned(),
+                "format".to_owned(),
+                u32::try_from(unterminated.find("format").expect("nested head")).unwrap(),
+            )],
+            "an unterminated quoted body remains executable through EOF",
         );
 
         for source in [

--- a/rust/tcl-lsp-core/src/executable_regions.rs
+++ b/rust/tcl-lsp-core/src/executable_regions.rs
@@ -217,13 +217,16 @@ impl<F: FnMut(&SegmentedCommand, HeadWords<'_>, ExecutableContext) -> bool>
                 let Some(&token) = command.arg_tokens().get(index) else {
                     continue;
                 };
-                if token.kind != TokenType::Str {
-                    continue;
-                }
                 if case_list.is_some_and(|(_, case_index)| case_index == index) {
                     continue;
                 }
-                if let Some((body_start, body_end)) = braced_body_region(self.source, token)
+                let single_token = command
+                    .arg_single_token()
+                    .get(index)
+                    .copied()
+                    .unwrap_or(false);
+                if let Some((body_start, body_end)) =
+                    literal_body_region(self.source, token, single_token)
                     && self.region(
                         body_start,
                         body_end,
@@ -345,6 +348,22 @@ fn case_action_region(source: &str, token: Token) -> Option<(usize, usize)> {
     (start <= end).then_some((start, end))
 }
 
+/// Return a registry-declared body's statically source-mappable script region.
+///
+/// Braced words are literal by Tcl definition. A substitution-free quoted
+/// word is literal as well, provided it contains no backslash sequence whose
+/// decoded value would differ from the written source. Compound quoted words
+/// (`"puts $value"`, `"[build]"`) have multiple lexer fragments and are
+/// deliberately withheld: reparsing their written source would invent a body
+/// that does not exist until the enclosing command performs substitution.
+fn literal_body_region(source: &str, token: Token, single_token: bool) -> Option<(usize, usize)> {
+    match token.kind {
+        TokenType::Str => braced_body_region(source, token),
+        TokenType::Esc if single_token => quoted_literal_body_region(source, token),
+        _ => None,
+    }
+}
+
 /// Return a braced body's verbatim source content, excluding delimiters.
 fn braced_body_region(source: &str, token: Token) -> Option<(usize, usize)> {
     let start = token.span.start() as usize + token.content_offset as usize;
@@ -359,6 +378,33 @@ fn braced_body_region(source: &str, token: Token) -> Option<(usize, usize)> {
     // declining to segment commands, so signature help cannot fall back to
     // the containing command while the caret awaits the body's first command.
     (start <= end && end <= source.len()).then_some((start, end))
+}
+
+/// Return a substitution-free quoted body's verbatim content.
+fn quoted_literal_body_region(source: &str, token: Token) -> Option<(usize, usize)> {
+    if token.kind != TokenType::Esc || token.content_offset != 1 {
+        return None;
+    }
+    let raw_start = token.span.start() as usize;
+    let raw_end = token.span.end() as usize;
+    let bytes = source.as_bytes();
+    if raw_start >= source.len() || raw_end > source.len() || bytes[raw_start] != b'"' {
+        return None;
+    }
+
+    let start = raw_start + 1;
+    // Non-empty quoted ESC tokens exclude the closer from their span. The
+    // lexer's empty-content clamp includes the closer in `""`, so normalize
+    // that one shape back to the same inner-end convention.
+    let end = if raw_end == start + 1 && bytes.get(start) == Some(&b'"') {
+        start
+    } else if bytes.get(raw_end) == Some(&b'"') {
+        raw_end
+    } else {
+        return None;
+    };
+    let content = source.get(start..end)?;
+    (!content.as_bytes().contains(&b'\\')).then_some((start, end))
 }
 
 /// Locate active bracket substitutions inside one token, preserving absolute
@@ -519,6 +565,32 @@ mod tests {
                 )
                 .is_empty(),
                 "dynamic and malformed lists must not expose nested actions: {source}"
+            );
+        }
+    }
+
+    #[test]
+    fn quoted_declared_bodies_recurse_only_when_source_mappable() {
+        let dialect =
+            tcl_registry::model::ingress::resolve_environment("tcl8.6").analyser_profile();
+        let literal = "proc p {} \"format {%d} 1\"";
+        assert_eq!(
+            visited_format_heads(literal, dialect),
+            vec![(
+                "format".to_owned(),
+                "format".to_owned(),
+                u32::try_from(literal.find("format").expect("nested head")).unwrap(),
+            )],
+            "a substitution-free quoted body is executable at its written span",
+        );
+
+        for source in [
+            "proc p {} \"format $pattern 1\"",
+            "proc p {} \"format\\ {%d} 1\"",
+        ] {
+            assert!(
+                visited_format_heads(source, dialect).is_empty(),
+                "a substituted or backslash-decoded body is not source-mappable: {source}",
             );
         }
     }

--- a/rust/tcl-lsp-core/src/executable_regions.rs
+++ b/rust/tcl-lsp-core/src/executable_regions.rs
@@ -339,7 +339,10 @@ fn case_action_region(source: &str, token: Token) -> Option<(usize, usize)> {
     }
     let bytes = source.as_bytes();
     let start = start + usize::from(matches!(bytes.get(start), Some(b'{' | b'"')));
-    (start < end).then_some((start, end))
+    // Empty actions are still executable regions: the cursor between their
+    // delimiters must leave the containing `switch`/`expect` signature before
+    // the user types the action's first command.
+    (start <= end).then_some((start, end))
 }
 
 /// Return a braced body's verbatim source content, excluding delimiters.
@@ -352,7 +355,10 @@ fn braced_body_region(source: &str, token: Token) -> Option<(usize, usize)> {
     } else {
         raw_end
     };
-    (start < end && end <= source.len()).then_some((start, end))
+    // Keep `{}` as a zero-length region. `begin_region` probes it before
+    // declining to segment commands, so signature help cannot fall back to
+    // the containing command while the caret awaits the body's first command.
+    (start <= end && end <= source.len()).then_some((start, end))
 }
 
 /// Locate active bracket substitutions inside one token, preserving absolute

--- a/rust/tcl-lsp-core/src/executable_regions.rs
+++ b/rust/tcl-lsp-core/src/executable_regions.rs
@@ -35,6 +35,33 @@ pub(crate) enum ExecutableContext {
     PotentialBody,
 }
 
+/// The deepest statically executable source region containing a cursor.
+///
+/// `start` follows the delimiter that introduced the region. `depth` is the
+/// lexer nesting depth required to interpret its prefix with the same grammar
+/// as [`visit_executable_commands`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ExecutableRegion {
+    pub(crate) start: usize,
+    pub(crate) depth: u32,
+}
+
+struct RegionProbe {
+    cursor: usize,
+    best: Option<ExecutableRegion>,
+}
+
+impl RegionProbe {
+    fn consider(&mut self, start: usize, end: usize, depth: u32) {
+        if start <= self.cursor
+            && self.cursor <= end
+            && self.best.is_none_or(|best| depth > best.depth)
+        {
+            self.best = Some(ExecutableRegion { start, depth });
+        }
+    }
+}
+
 /// Visit every statically locatable command that Tcl can execute from
 /// `source`, preserving each command's absolute source spans.
 ///
@@ -58,8 +85,43 @@ pub(crate) fn visit_executable_commands(
         availability,
         identities,
         visitor,
+        region_probe: None,
     };
     let _ = walk.region(0, source.len(), 0, None, ExecutableContext::Direct);
+}
+
+/// Return the innermost registry-declared executable region containing
+/// `cursor`.
+///
+/// This is the cursor-oriented counterpart to [`visit_executable_commands`]:
+/// it follows the exact same body, clause-list, lambda, definition-member, and
+/// command-substitution metadata. Consumers therefore do not need to infer
+/// script bodies from brace characters or command names.
+pub(crate) fn innermost_executable_region_at(
+    source: &str,
+    config: LexerConfig,
+    registry: &CommandRegistry,
+    availability: Option<SurfaceQuery<'_>>,
+    identities: &CommandBindingRealm,
+    cursor: usize,
+) -> Option<ExecutableRegion> {
+    if cursor > source.len() {
+        return None;
+    }
+    let mut probe = RegionProbe { cursor, best: None };
+    let mut visitor =
+        |_command: &SegmentedCommand, _head: HeadWords<'_>, _context: ExecutableContext| false;
+    let mut walk = ExecutableWalker {
+        source,
+        config,
+        registry,
+        availability,
+        identities,
+        visitor: &mut visitor,
+        region_probe: Some(&mut probe),
+    };
+    let _ = walk.region(0, source.len(), 0, None, ExecutableContext::Direct);
+    probe.best
 }
 
 struct ExecutableWalker<'a, F> {
@@ -69,11 +131,22 @@ struct ExecutableWalker<'a, F> {
     availability: Option<SurfaceQuery<'a>>,
     identities: &'a CommandBindingRealm,
     visitor: &'a mut F,
+    region_probe: Option<&'a mut RegionProbe>,
 }
 
 impl<F: FnMut(&SegmentedCommand, HeadWords<'_>, ExecutableContext) -> bool>
     ExecutableWalker<'_, F>
 {
+    fn begin_region(&mut self, start: usize, end: usize, depth: u32) -> bool {
+        if MAX_EXECUTABLE_REGION_DEPTH.exceeded(depth) || start > end || end > self.source.len() {
+            return false;
+        }
+        if let Some(probe) = self.region_probe.as_deref_mut() {
+            probe.consider(start, end, depth);
+        }
+        start < end
+    }
+
     fn region(
         &mut self,
         start: usize,
@@ -82,7 +155,7 @@ impl<F: FnMut(&SegmentedCommand, HeadWords<'_>, ExecutableContext) -> bool>
         grammar: Option<&'static DefinitionBodyGrammar>,
         context: ExecutableContext,
     ) -> bool {
-        if MAX_EXECUTABLE_REGION_DEPTH.exceeded(depth) || start >= end || end > self.source.len() {
+        if !self.begin_region(start, end, depth) {
             return false;
         }
         let commands = segment_commands_with_offset_and_config(

--- a/rust/tcl-lsp-core/src/lib.rs
+++ b/rust/tcl-lsp-core/src/lib.rs
@@ -265,6 +265,11 @@ pub fn registry_for_dialect_profile(
 /// ```
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// The shared Tcl qualified-name canonicaliser, re-exported for LSP hosts that
+/// must normalise command names before passing provider options into this
+/// crate. The semantic owner remains `tcl-syntax::naming`.
+pub use tcl_syntax::naming::normalise_qualified_name as normalise_qualified_command_name;
+
 #[cfg(test)]
 mod dialect_ingress_tests {
 

--- a/rust/tcl-lsp-core/src/signature_help.rs
+++ b/rust/tcl-lsp-core/src/signature_help.rs
@@ -884,14 +884,32 @@ mod tests {
     #[test]
     fn empty_registry_declared_scripts_are_nested_cursor_regions() {
         let registry = CommandRegistry::build_default();
-        for src in ["proc p {} {}", "switch value {default {}}"] {
+        for (src, delimiter, occurrence) in [
+            ("proc p {} {}", "{", 2),
+            ("proc p {} \"\"", "\"", 1),
+            ("switch value {default {}}", "{", 2),
+        ] {
             let analysis = analyse(src);
-            let (line, character) = pos_after(src, "{", 2);
+            let (line, character) = pos_after(src, delimiter, occurrence);
             assert!(
                 signature_help(src, line, character, &analysis, Some(&registry)).is_none(),
                 "the containing command signature leaked into an empty script: {src}",
             );
         }
+    }
+
+    #[test]
+    fn substitution_free_quoted_proc_body_is_a_nested_script_region() {
+        let src = "proc p {} \"puts hi\"";
+        let analysis = analyse(src);
+        let registry = CommandRegistry::build_default();
+        let (line, character) = pos_after(src, "puts ", 1);
+        let help = signature_help(src, line, character, &analysis, Some(&registry))
+            .expect("quoted body command signature");
+        assert!(
+            help.signatures[0].label.starts_with("puts "),
+            "outer proc signature leaked into quoted body: {help:?}",
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/signature_help.rs
+++ b/rust/tcl-lsp-core/src/signature_help.rs
@@ -882,6 +882,19 @@ mod tests {
     }
 
     #[test]
+    fn empty_registry_declared_scripts_are_nested_cursor_regions() {
+        let registry = CommandRegistry::build_default();
+        for src in ["proc p {} {}", "switch value {default {}}"] {
+            let analysis = analyse(src);
+            let (line, character) = pos_after(src, "{", 2);
+            assert!(
+                signature_help(src, line, character, &analysis, Some(&registry)).is_none(),
+                "the containing command signature leaked into an empty script: {src}",
+            );
+        }
+    }
+
+    #[test]
     fn signature_help_is_available_in_proc_header_and_nested_proc_call() {
         let src = concat!(
             "proc helper {value} {}\n",

--- a/rust/tcl-lsp-core/src/signature_help.rs
+++ b/rust/tcl-lsp-core/src/signature_help.rs
@@ -20,9 +20,9 @@
 //!
 //! Surfaces a single [`SignatureInformation`] for the command
 //! whose name appears as the first word of the active command
-//! segment at the cursor.  The active parameter is derived from
-//! a simple whitespace-aware count of arguments typed so far on
-//! the current physical line.
+//! segment at the cursor. The active parameter is derived from a
+//! lexer-aware count of arguments in the innermost registry-declared
+//! executable region containing the cursor.
 //!
 //! Two lookup paths:
 //!
@@ -40,10 +40,10 @@
 //!    the command word; `hover.summary` becomes the
 //!    documentation.
 //!
-//! Limitations: only the cursor's physical line is walked, so
-//! multi-line command segments (continuation lines, embedded
-//! `[…]` / `{…}`) aren't understood, and rich doc-comment
-//! rendering isn't done — the summary is surfaced verbatim.
+//! Braced data remains part of its containing command, while registry-declared
+//! script bodies, clause actions, lambdas, definition members, and live
+//! command substitutions establish nested command contexts. Rich doc-comment
+//! rendering is not done — the summary is surfaced verbatim.
 
 use rustc_hash::FxHashSet;
 use tcl_compiler::analyser::{AnalysisResult, ProcDef};
@@ -80,6 +80,17 @@ pub struct SignatureHelp {
     /// Index of the active parameter (0-based) within the
     /// active signature.
     pub active_parameter: u32,
+}
+
+/// Per-request controls for signature-help rendering.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SignatureHelpOptions<'a> {
+    /// Canonical qualified registry command names whose built-in signature
+    /// should not be shown (for example `::set`). Canonicalisation belongs to
+    /// [`tcl_syntax::naming::normalise_qualified_name`].
+    /// User-defined procs keep their signatures even when they have the same
+    /// written name, because Tcl resolves those before the registry fallback.
+    pub disabled_builtin_commands: &'a [String],
 }
 
 /// Compute signature help for the command being typed at the
@@ -134,8 +145,32 @@ pub fn signature_help_in_program(
     analysis: &AnalysisResult,
     resolution: crate::definition::CallResolution<'_>,
 ) -> Option<SignatureHelp> {
+    signature_help_in_program_with_options(
+        source,
+        line,
+        character,
+        analysis,
+        resolution,
+        SignatureHelpOptions::default(),
+    )
+}
+
+/// [`signature_help_in_program`] with per-request rendering controls.
+#[must_use]
+pub fn signature_help_in_program_with_options(
+    source: &str,
+    line: u32,
+    character: u32,
+    analysis: &AnalysisResult,
+    resolution: crate::definition::CallResolution<'_>,
+    options: SignatureHelpOptions<'_>,
+) -> Option<SignatureHelp> {
     let registry = resolution.registry;
-    let (command, args, active_param) = command_context_with_args(source, line, character)?;
+    let profile = crate::profile_for_dialect(&analysis.dialect);
+    let structural_registry =
+        registry.unwrap_or_else(|| crate::registry_for_dialect_profile(profile));
+    let (command, args, active_param) =
+        command_context_with_args(source, line, character, profile, structural_registry)?;
     // Resolve the command from the namespace the cursor sits in, the way C
     // Tcl's own command resolution would (caller namespace, then global), so a
     // same-named proc in an unrelated namespace never hijacks the signature and
@@ -156,6 +191,13 @@ pub fn signature_help_in_program(
     }
     let registry = registry?;
     let spec = registry.get(&command)?;
+    let canonical_spec_name = tcl_syntax::naming::normalise_qualified_name(spec.name);
+    if options
+        .disabled_builtin_commands
+        .contains(&canonical_spec_name)
+    {
+        return None;
+    }
     // Subcommand-scoped signatures:
     // when the spec has subcommands and the first argument
     // matches one, prefer the subcommand's signature over the
@@ -204,8 +246,10 @@ fn command_context_with_args(
     source: &str,
     line: u32,
     character: u32,
+    profile: &'static tcl_dialect::DialectProfile,
+    registry: &CommandRegistry,
 ) -> Option<(String, Vec<String>, u32)> {
-    use tcl_lexer::{Lexer, LineIndex, TokenType, Utf16Col};
+    use tcl_lexer::{Lexer, LexerConfig, LineIndex, TokenType, Utf16Col};
 
     let cursor_offset = {
         let line_index = LineIndex::new(source);
@@ -222,10 +266,25 @@ fn command_context_with_args(
         line_index.offset_at_utf16(line, Utf16Col::new(character), source)
     };
 
-    // Lex the document up to the cursor's byte offset.  We
-    // walk the full token stream and stop including tokens
-    // once we cross `cursor_offset`.
-    let lexer = Lexer::new(source);
+    let config = LexerConfig::for_file_dialect(profile.name);
+    let identities =
+        tcl_compiler::realm::document_realm_bindings_with_config(source, config, registry);
+    let region = crate::executable_regions::innermost_executable_region_at(
+        source,
+        config,
+        registry,
+        Some(profile.surface_query()),
+        &identities,
+        cursor_offset as usize,
+    )?;
+
+    // Lex only the executable region's prefix up to the cursor. A braced word
+    // that is ordinary data remains in the containing region and therefore in
+    // the outer command. A registry-declared body starts a deeper region, so
+    // newlines/comments inside it reset that body's command context instead of
+    // leaving the outer command (notably `proc ... body`) active indefinitely.
+    let prefix = &source[region.start..cursor_offset as usize];
+    let lexer = Lexer::with_config(prefix, config.at_depth(region.depth));
     let Ok(tokens) = lexer.tokenise_all() else {
         return None;
     };
@@ -233,9 +292,6 @@ fn command_context_with_args(
     let mut current_segment: Vec<String> = Vec::new();
     let mut at_new_word = true;
     for tok in tokens {
-        if tok.span.start() >= cursor_offset {
-            break;
-        }
         match tok.kind {
             TokenType::Sep => {
                 at_new_word = true;
@@ -245,7 +301,7 @@ fn command_context_with_args(
                 // line-ending newline) resets the segment.
                 // Synthetic empty EOLs (used to terminate the
                 // stream) leave the segment alone.
-                let raw = &source[tok.span.start() as usize..tok.span.end() as usize];
+                let raw = &prefix[tok.span.start() as usize..tok.span.end() as usize];
                 if !raw.is_empty() {
                     current_segment.clear();
                     at_new_word = true;
@@ -261,7 +317,7 @@ fn command_context_with_args(
                 // segment unless we're mid-word (the previous
                 // token also contributed without an intervening
                 // SEP).
-                let raw = &source[tok.span.start() as usize..tok.span.end() as usize];
+                let raw = &prefix[tok.span.start() as usize..tok.span.end() as usize];
                 if at_new_word || current_segment.is_empty() {
                     current_segment.push(raw.to_owned());
                 } else if let Some(last) = current_segment.last_mut() {
@@ -785,6 +841,105 @@ mod tests {
         // the start of arg 1 and the cursor sits in its body
         // (which the segmenter rolls into the same word).
         assert!(h.is_some(), "expected signature help on continuation line");
+    }
+
+    #[test]
+    fn proc_signature_stops_at_its_script_body() {
+        // Issue #1735's screenshots put the caret at the ends of these body
+        // lines. Neither position belongs to the outer `proc` invocation: the
+        // body is a registry-declared nested Tcl script.
+        let src = concat!(
+            "proc someproc {arg1 arg2} {\n",
+            "    # this box always appears\n",
+            "    # can be closed with ESC but comes back on the next SPACE press..\n",
+            "    set evenWhenWritingCode\n",
+            "}\n",
+        );
+        let analysis = analyse(src);
+        let registry = CommandRegistry::build_default();
+
+        for (needle, occurrence) in [
+            ("# this box always appears", 1),
+            (
+                "# can be closed with ESC but comes back on the next SPACE press..",
+                1,
+            ),
+        ] {
+            let (line, character) = pos_after(src, needle, occurrence);
+            assert!(
+                signature_help(src, line, character, &analysis, Some(&registry)).is_none(),
+                "a body comment must close the outer proc signature: {needle}",
+            );
+        }
+
+        let (line, character) = pos_after(src, "set evenWhenWritingCode", 1);
+        let help = signature_help(src, line, character, &analysis, Some(&registry))
+            .expect("the nested set call has its own signature");
+        assert!(
+            help.signatures[0].label.starts_with("set "),
+            "outer proc signature leaked into body: {help:?}",
+        );
+    }
+
+    #[test]
+    fn signature_help_is_available_in_proc_header_and_nested_proc_call() {
+        let src = concat!(
+            "proc helper {value} {}\n",
+            "proc outer {arg} {\n",
+            "    helper \n",
+            "}\n",
+        );
+        let analysis = analyse(src);
+        let registry = CommandRegistry::build_default();
+
+        let (header_line, header_character) = pos_after(src, "proc outer ", 1);
+        let header = signature_help(
+            src,
+            header_line,
+            header_character,
+            &analysis,
+            Some(&registry),
+        )
+        .expect("proc declaration header signature");
+        assert!(header.signatures[0].label.starts_with("proc "));
+
+        let (call_line, call_character) = pos_after(src, "helper ", 2);
+        let call = signature_help(src, call_line, call_character, &analysis, Some(&registry))
+            .expect("nested proc call signature");
+        assert_eq!(call.signatures[0].label, "helper value");
+    }
+
+    #[test]
+    fn disabled_builtin_signatures_do_not_disable_other_commands_or_procs() {
+        let src = concat!(
+            "set \n",
+            "format \n",
+            "proc custom {value} {}\n",
+            "custom \n",
+        );
+        let analysis = analyse(src);
+        let registry = CommandRegistry::build_default();
+        let disabled = vec!["::set".to_owned(), "::incr".to_owned()];
+        let help = |needle, occurrence| {
+            let (line, character) = pos_after(src, needle, occurrence);
+            signature_help_in_program_with_options(
+                src,
+                line,
+                character,
+                &analysis,
+                crate::definition::CallResolution {
+                    registry: Some(&registry),
+                    program: None,
+                },
+                SignatureHelpOptions {
+                    disabled_builtin_commands: &disabled,
+                },
+            )
+        };
+
+        assert!(help("set ", 1).is_none());
+        assert!(help("format ", 1).is_some_and(|h| h.signatures[0].label.starts_with("format ")));
+        assert!(help("custom ", 2).is_some_and(|h| h.signatures[0].label == "custom value"));
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/signature_help.rs
+++ b/rust/tcl-lsp-core/src/signature_help.rs
@@ -910,6 +910,16 @@ mod tests {
             help.signatures[0].label.starts_with("puts "),
             "outer proc signature leaked into quoted body: {help:?}",
         );
+
+        let src = "proc p {} \"puts ";
+        let analysis = analyse(src);
+        let (line, character) = pos_after(src, "puts ", 1);
+        let help = signature_help(src, line, character, &analysis, Some(&registry))
+            .expect("unterminated quoted body command signature");
+        assert!(
+            help.signatures[0].label.starts_with("puts "),
+            "outer proc signature leaked into unterminated quoted body: {help:?}",
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-server/src/config_ini.rs
+++ b/rust/tcl-lsp-server/src/config_ini.rs
@@ -245,6 +245,21 @@ pub fn settings_from_ini(content: &str, layer: Layer) -> Value {
         }
     }
 
+    // [signatureHelp]: built-in commands whose automatic signature help is
+    // suppressed. Accept the INI-native snake_case spelling and the editor's
+    // camelCase key so exported settings can be pasted back unchanged.
+    if let Some(raw) = section_value(&sections, "signatureHelp", "disabled_commands")
+        .or_else(|| section_value(&sections, "signatureHelp", "disabledCommands"))
+    {
+        let commands = parse_comma_list(raw);
+        let mut signature_help = Map::new();
+        signature_help.insert(
+            "disabledCommands".to_owned(),
+            Value::Array(commands.into_iter().map(Value::String).collect()),
+        );
+        out.insert("signatureHelp".to_owned(), Value::Object(signature_help));
+    }
+
     insert_formatting(&sections, &mut out);
 
     // [style] `line_length` → the W111 threshold; `nonAscii` → the W108

--- a/rust/tcl-lsp-server/src/config_ini/tests.rs
+++ b/rust/tcl-lsp-server/src/config_ini/tests.rs
@@ -271,6 +271,27 @@ fn features_shimmer_xc_and_line_length() {
 }
 
 #[test]
+fn signature_help_disabled_commands_section() {
+    let snake = settings_from_ini(
+        "[signatureHelp]\ndisabled_commands = set, incr\n",
+        Layer::Global,
+    );
+    assert_eq!(
+        snake["signatureHelp"]["disabledCommands"],
+        json!(["set", "incr"])
+    );
+
+    let camel = settings_from_ini(
+        "[signatureHelp]\ndisabledCommands = set format\n",
+        Layer::Project,
+    );
+    assert_eq!(
+        camel["signatureHelp"]["disabledCommands"],
+        json!(["set", "format"])
+    );
+}
+
+#[test]
 fn formatting_section_maps_all_keys() {
     // Every `[formatting]` key maps to its camelCase editor key with the right
     // value type.

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -14102,11 +14102,10 @@ impl Backend {
         collapse_inlay_alias(&mut global_ini);
         collapse_inlay_alias(&mut cfg);
         collapse_inlay_alias(&mut primary_project);
-        let merged = config_ini::merge_settings(
-            &config_ini::merge_settings(&global_ini, &cfg),
-            &primary_project,
-        );
-        self.apply_global_config(&merged).await;
+        let global_editor = config_ini::merge_settings(&global_ini, &cfg);
+        let merged = config_ini::merge_settings(&global_editor, &primary_project);
+        self.apply_global_config_with_signature_fallback(&merged, &global_editor)
+            .await;
         // Per-folder editor configuration: VS Code resolves `tclLsp` settings
         // per scope, so pull each folder's resolved config, layer it between the
         // global `config.ini` and that folder's `.tcl-lsp.ini`, and store it for
@@ -14248,7 +14247,21 @@ impl Backend {
     /// the client and then handles per-folder configs) so the apply logic is
     /// unit-testable without a live editor client.
     // A long but flat sequence of independent `tclLsp.*` knob applications.
+    #[cfg(test)]
     async fn apply_global_config(&self, cfg: &serde_json::Value) {
+        self.apply_global_config_with_signature_fallback(cfg, cfg)
+            .await;
+    }
+
+    /// Apply the primary root's merged configuration while keeping signature
+    /// suppression's folder fallback at the user/editor layers. Project INI
+    /// settings belong to their own root and must not leak into siblings whose
+    /// merged folder configuration omits `signatureHelp`.
+    async fn apply_global_config_with_signature_fallback(
+        &self,
+        cfg: &serde_json::Value,
+        signature_fallback_cfg: &serde_json::Value,
+    ) {
         if !cfg.is_object() {
             return;
         }
@@ -14256,7 +14269,7 @@ impl Backend {
             self.feature_toggles.lock().await.apply(features);
         }
         self.apply_global_library_paths(cfg).await;
-        self.apply_global_toggles(cfg).await;
+        self.apply_global_toggles(cfg, signature_fallback_cfg).await;
         self.apply_global_formatting(cfg).await;
         self.apply_global_analyser_knobs(cfg).await;
         // Mirror the applied analyser knobs onto the salsa config input so the
@@ -14321,12 +14334,17 @@ impl Backend {
     /// Feature controls: per-command signature suppression, `xcDiagnostics`,
     /// optimiser enable/profile/per-code overrides, and the `shimmer` master
     /// switch.
-    async fn apply_global_toggles(&self, cfg: &serde_json::Value) {
-        // The production caller passes the fully merged configuration, so an
-        // absent section means the list was removed from every layer. Reset
-        // unconditionally rather than leaving the last applied exclusions
-        // latched after an INI edit.
-        let commands = cfg
+    async fn apply_global_toggles(
+        &self,
+        cfg: &serde_json::Value,
+        signature_fallback_cfg: &serde_json::Value,
+    ) {
+        // This fallback contains only the user-config and editor layers. Each
+        // project INI is represented by its FolderConfig, so the primary
+        // project's exclusions cannot bleed into a sibling root. An absent
+        // section means the list was removed from every fallback layer; reset
+        // unconditionally rather than latching stale exclusions after an edit.
+        let commands = signature_fallback_cfg
             .get("signatureHelp")
             .and_then(serde_json::Value::as_object)
             .and_then(|signature_help| signature_help.get("disabledCommands"))
@@ -33343,6 +33361,51 @@ mod tests {
                 .iter()
                 .any(|(u, _)| u == &folder_a),
             "proj-a must have a per-folder AnalyserConfig handle for extraCommands",
+        );
+    }
+
+    #[tokio::test]
+    async fn primary_project_signature_exclusions_do_not_leak_into_sibling_root() {
+        let backend = test_backend();
+        let folder_a = Uri::from_str("file:///proj-a").unwrap();
+        let folder_b = Uri::from_str("file:///proj-b").unwrap();
+        let file_a = Uri::from_str("file:///proj-a/file.tcl").unwrap();
+        let file_b = Uri::from_str("file:///proj-b/file.tcl").unwrap();
+        *backend.workspace_folders.lock().await = vec![folder_a.clone(), folder_b.clone()];
+
+        let global_editor = serde_json::json!({});
+        let primary_merged = serde_json::json!({
+            "signatureHelp": { "disabledCommands": ["set"] }
+        });
+        backend
+            .apply_global_config_with_signature_fallback(&primary_merged, &global_editor)
+            .await;
+        backend
+            .apply_folder_configs(vec![
+                (
+                    folder_a,
+                    parse_folder_config(&primary_merged).expect("primary config"),
+                ),
+                (
+                    folder_b,
+                    parse_folder_config(&global_editor).expect("sibling config"),
+                ),
+            ])
+            .await;
+
+        assert_eq!(
+            backend
+                .resolved_signature_help_disabled_commands(&file_a)
+                .await,
+            vec!["::set".to_owned()],
+            "the primary project keeps its own exclusion",
+        );
+        assert!(
+            backend
+                .resolved_signature_help_disabled_commands(&file_b)
+                .await
+                .is_empty(),
+            "a sibling without an exclusion inherits only global/editor layers",
         );
     }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -14322,23 +14322,18 @@ impl Backend {
     /// optimiser enable/profile/per-code overrides, and the `shimmer` master
     /// switch.
     async fn apply_global_toggles(&self, cfg: &serde_json::Value) {
-        if let Some(signature_help) = cfg
+        // The production caller passes the fully merged configuration, so an
+        // absent section means the list was removed from every layer. Reset
+        // unconditionally rather than leaving the last applied exclusions
+        // latched after an INI edit.
+        let commands = cfg
             .get("signatureHelp")
             .and_then(serde_json::Value::as_object)
-        {
-            // VS Code sends the nullable setting's containing object even
-            // after its middleware drops an inherited `null`. Treat that
-            // present-but-empty object as the empty list so clearing an editor
-            // override cannot leave the previous exclusions latched. A wholly
-            // absent section still follows this apply API's partial-update
-            // contract and preserves the last value.
-            let commands = signature_help
-                .get("disabledCommands")
-                .and_then(serde_json::Value::as_array)
-                .map_or(&[][..], Vec::as_slice);
-            *self.signature_help_disabled_commands.lock().await =
-                normalise_disabled_signature_commands(commands);
-        }
+            .and_then(|signature_help| signature_help.get("disabledCommands"))
+            .and_then(serde_json::Value::as_array)
+            .map_or(&[][..], Vec::as_slice);
+        *self.signature_help_disabled_commands.lock().await =
+            normalise_disabled_signature_commands(commands);
         // `tclLsp.xcDiagnostics.enabled` is a dedicated config section (the
         // shipped VS Code setting "XC Migration: Enabled"), not a `features.*`
         // key, so it must be mapped onto the `xcDiagnostics` feature toggle
@@ -25943,12 +25938,9 @@ mod tests {
             vec!["::incr".to_owned(), "::set".to_owned()],
         );
 
-        // A nullable editor setting is removed by client middleware, leaving
-        // the section present but empty. That must clear a previously applied
-        // list rather than latching stale suppression until restart.
-        backend
-            .apply_global_config(&serde_json::json!({ "signatureHelp": {} }))
-            .await;
+        // Removing the setting from every merged layer must clear a previously
+        // applied list rather than latching stale suppression until restart.
+        backend.apply_global_config(&serde_json::json!({})).await;
         assert!(
             backend
                 .signature_help_disabled_commands

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -14112,6 +14112,7 @@ impl Backend {
         // longest-prefix resolution at read time.  A single-root / no-folder
         // session skips this — the global pull above is the whole story.
         if !folders.is_empty() {
+            let primary_folder = folders.first().cloned();
             let items: Vec<ConfigurationItem> = folders
                 .iter()
                 .map(|f| ConfigurationItem {
@@ -14140,8 +14141,51 @@ impl Backend {
                     })
                     .collect();
                 self.apply_folder_configs(parsed).await;
+            } else {
+                // The unscoped pull succeeded, so retain its global/editor
+                // layer, but the primary project's higher-precedence INI
+                // exclusion must not disappear merely because the scoped pull
+                // failed. Patch only that root's override into the last good
+                // folder chain; sibling values remain isolated and intact.
+                self.apply_primary_project_signature_fallback(
+                    primary_folder.as_ref(),
+                    &primary_project,
+                )
+                .await;
             }
         }
+    }
+
+    /// Preserve the primary project's signature exclusion when a scoped
+    /// configuration pull fails, without replacing any last-known sibling
+    /// folder settings.
+    async fn apply_primary_project_signature_fallback(
+        &self,
+        primary_folder: Option<&Uri>,
+        primary_project: &serde_json::Value,
+    ) {
+        let Some(primary_folder) = primary_folder else {
+            return;
+        };
+        let project_override = signature_help_disabled_commands(primary_project);
+        let mut parsed = self.folder_configs.lock().await.clone();
+        if let Some((_, config)) = parsed
+            .iter_mut()
+            .find(|(folder, _)| folder == primary_folder)
+        {
+            config.signature_help_disabled_commands = project_override;
+        } else if let Some(commands) = project_override {
+            parsed.push((
+                primary_folder.clone(),
+                FolderConfig {
+                    signature_help_disabled_commands: Some(commands),
+                    ..FolderConfig::default()
+                },
+            ));
+        } else {
+            return;
+        }
+        self.apply_folder_configs(parsed).await;
     }
 
     /// The whole `didChangeConfiguration` reload pipeline, run **once** for a
@@ -14344,14 +14388,8 @@ impl Backend {
         // project's exclusions cannot bleed into a sibling root. An absent
         // section means the list was removed from every fallback layer; reset
         // unconditionally rather than latching stale exclusions after an edit.
-        let commands = signature_fallback_cfg
-            .get("signatureHelp")
-            .and_then(serde_json::Value::as_object)
-            .and_then(|signature_help| signature_help.get("disabledCommands"))
-            .and_then(serde_json::Value::as_array)
-            .map_or(&[][..], Vec::as_slice);
         *self.signature_help_disabled_commands.lock().await =
-            normalise_disabled_signature_commands(commands);
+            signature_help_disabled_commands(signature_fallback_cfg).unwrap_or_default();
         // `tclLsp.xcDiagnostics.enabled` is a dedicated config section (the
         // shipped VS Code setting "XC Migration: Enabled"), not a `features.*`
         // key, so it must be mapped onto the `xcDiagnostics` feature toggle
@@ -22564,6 +22602,13 @@ fn normalise_disabled_signature_commands(values: &[serde_json::Value]) -> Vec<St
     commands
 }
 
+fn signature_help_disabled_commands(cfg: &serde_json::Value) -> Option<Vec<String>> {
+    cfg.get("signatureHelp")
+        .and_then(|section| section.get("disabledCommands"))
+        .and_then(serde_json::Value::as_array)
+        .map(|commands| normalise_disabled_signature_commands(commands))
+}
+
 fn parse_folder_config(cfg: &serde_json::Value) -> Option<FolderConfig> {
     let obj = cfg.as_object()?;
     let mut fc = FolderConfig::default();
@@ -22612,13 +22657,7 @@ fn parse_folder_config(cfg: &serde_json::Value) -> Option<FolderConfig> {
                 .collect(),
         );
     }
-    if let Some(commands) = obj
-        .get("signatureHelp")
-        .and_then(|section| section.get("disabledCommands"))
-        .and_then(serde_json::Value::as_array)
-    {
-        fc.signature_help_disabled_commands = Some(normalise_disabled_signature_commands(commands));
-    }
+    fc.signature_help_disabled_commands = signature_help_disabled_commands(cfg);
     parse_folder_diagnostics(obj, &mut fc);
     // `tclLsp.libraryPaths` per-folder override.
     if let Some(paths) = obj
@@ -33406,6 +33445,70 @@ mod tests {
                 .await
                 .is_empty(),
             "a sibling without an exclusion inherits only global/editor layers",
+        );
+    }
+
+    #[tokio::test]
+    async fn scoped_pull_failure_keeps_primary_project_signature_exclusions_isolated() {
+        let backend = test_backend();
+        let folder_a = Uri::from_str("file:///proj-a").unwrap();
+        let folder_b = Uri::from_str("file:///proj-b").unwrap();
+        let file_a = Uri::from_str("file:///proj-a/file.tcl").unwrap();
+        let file_b = Uri::from_str("file:///proj-b/file.tcl").unwrap();
+        *backend.workspace_folders.lock().await = vec![folder_a.clone(), folder_b.clone()];
+        *backend.signature_help_disabled_commands.lock().await = vec!["::format".to_owned()];
+
+        // A prior successful scoped pull for the sibling must survive a later
+        // scoped-request failure while the primary's project INI is recovered.
+        backend
+            .apply_folder_configs(vec![(
+                folder_b,
+                FolderConfig {
+                    signature_help_disabled_commands: Some(vec!["::incr".to_owned()]),
+                    ..FolderConfig::default()
+                },
+            )])
+            .await;
+        backend
+            .apply_primary_project_signature_fallback(
+                Some(&folder_a),
+                &serde_json::json!({
+                    "signatureHelp": { "disabledCommands": ["set"] }
+                }),
+            )
+            .await;
+
+        assert_eq!(
+            backend
+                .resolved_signature_help_disabled_commands(&file_a)
+                .await,
+            vec!["::set".to_owned()],
+            "the primary root keeps its project exclusion after a scoped pull failure",
+        );
+        assert_eq!(
+            backend
+                .resolved_signature_help_disabled_commands(&file_b)
+                .await,
+            vec!["::incr".to_owned()],
+            "the fallback must preserve and not overwrite a sibling's last scoped value",
+        );
+
+        backend
+            .apply_primary_project_signature_fallback(Some(&folder_a), &serde_json::json!({}))
+            .await;
+        assert_eq!(
+            backend
+                .resolved_signature_help_disabled_commands(&file_a)
+                .await,
+            vec!["::format".to_owned()],
+            "removing the project setting restores global/editor inheritance",
+        );
+        assert_eq!(
+            backend
+                .resolved_signature_help_disabled_commands(&file_b)
+                .await,
+            vec!["::incr".to_owned()],
+            "clearing the primary override must still leave the sibling untouched",
         );
     }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -5706,6 +5706,10 @@ pub struct Backend {
     /// known by the unknown-command (W123) check; mirrored onto the salsa
     /// `AnalyserConfig`.
     extra_commands: Mutex<Vec<String>>,
+    /// Built-in command names whose automatic signature help is suppressed
+    /// (`tclLsp.signatureHelp.disabledCommands`). User-defined proc signatures
+    /// are deliberately unaffected.
+    signature_help_disabled_commands: Mutex<Vec<String>>,
     /// `tclLsp.specPacks` — extra `.tclspec` files or directories to load as
     /// `SpecTcl` packs, on top of the ones discovery finds by convention.
     spec_pack_paths: Mutex<Vec<String>>,
@@ -6639,6 +6643,9 @@ struct FolderConfig {
     shimmer_enabled: Option<bool>,
     /// `tclLsp.extraCommands` override; `None` inherits the global set.
     extra_commands: Option<Vec<String>>,
+    /// `tclLsp.signatureHelp.disabledCommands` override; `None` inherits the
+    /// global list. `Some([])` explicitly enables every built-in signature.
+    signature_help_disabled_commands: Option<Vec<String>>,
     /// `tclLsp.diagnostics.genericVariablePatterns` override. See
     /// [`FolderGenericPatterns`]: `Inherit` falls back to the global value,
     /// `BuiltinDefaults` selects the analyser's built-in set, and `Replace`
@@ -7077,6 +7084,7 @@ impl Backend {
             editor_library_paths: Mutex::new(Vec::new()),
             package_prefer_latest_default: Mutex::new(false),
             extra_commands: Mutex::new(Vec::new()),
+            signature_help_disabled_commands: Mutex::new(Vec::new()),
             spec_pack_paths: Mutex::new(Vec::new()),
             spec_packs: Arc::new(Mutex::new(PublishedPackSet::default())),
             spec_pack_reload: Arc::new(Mutex::new(())),
@@ -9254,6 +9262,7 @@ impl Backend {
             editor_library_paths: _,
             package_prefer_latest_default: _,
             extra_commands: _,
+            signature_help_disabled_commands: _,
             spec_pack_paths: _,
             spec_packs: _,
             spec_pack_reload: _,
@@ -13740,11 +13749,7 @@ impl Backend {
             Some(uri) => self.resolved_extra_commands(uri).await,
             None => self.extra_commands.lock().await.clone(),
         };
-        // Resolved through the same folder chain every provider gate uses, so a
-        // client polling this command observes the fact the provider will act
-        // on rather than the process-global one.  The two used to differ, which
-        // made a folder-scoped toggle invisible here and left the VS Code
-        // suite's toggle barrier waiting on the wrong fact (issue #1295).
+        let disabled_signatures = self.signature_disabled_for(parsed_uri.as_ref()).await;
         // Resolved through the same folder chain every provider gate uses, so a
         // client polling this command observes the fact the provider will act
         // on rather than the process-global one.  The two used to differ, which
@@ -13821,6 +13826,7 @@ impl Backend {
             // temporary chat-command override from a configured dialect.
             "session_dialect_override": session_override,
             "extra_commands": extra_commands,
+            "signature_help_disabled_commands": disabled_signatures,
             "known_folder_uris": known_folders
                 .iter()
                 .map(|f| f.as_str().to_owned())
@@ -14312,9 +14318,27 @@ impl Backend {
         }
     }
 
-    /// The boolean / enum feature switches: `xcDiagnostics`, optimiser
-    /// enable/profile/per-code overrides, and the `shimmer` master switch.
+    /// Feature controls: per-command signature suppression, `xcDiagnostics`,
+    /// optimiser enable/profile/per-code overrides, and the `shimmer` master
+    /// switch.
     async fn apply_global_toggles(&self, cfg: &serde_json::Value) {
+        if let Some(signature_help) = cfg
+            .get("signatureHelp")
+            .and_then(serde_json::Value::as_object)
+        {
+            // VS Code sends the nullable setting's containing object even
+            // after its middleware drops an inherited `null`. Treat that
+            // present-but-empty object as the empty list so clearing an editor
+            // override cannot leave the previous exclusions latched. A wholly
+            // absent section still follows this apply API's partial-update
+            // contract and preserves the last value.
+            let commands = signature_help
+                .get("disabledCommands")
+                .and_then(serde_json::Value::as_array)
+                .map_or(&[][..], Vec::as_slice);
+            *self.signature_help_disabled_commands.lock().await =
+                normalise_disabled_signature_commands(commands);
+        }
         // `tclLsp.xcDiagnostics.enabled` is a dedicated config section (the
         // shipped VS Code setting "XC Migration: Enabled"), not a `features.*`
         // key, so it must be mapped onto the `xcDiagnostics` feature toggle
@@ -15005,6 +15029,27 @@ impl Backend {
         match folder {
             Some(v) => v,
             None => self.extra_commands.lock().await.clone(),
+        }
+    }
+
+    /// The resolved built-in signature-help exclusion list for `uri`: a
+    /// folder override wins, else the process-global list.
+    async fn resolved_signature_help_disabled_commands(&self, uri: &Uri) -> Vec<String> {
+        let folder = {
+            let configs = self.folder_configs.lock().await;
+            longest_folder_match(&configs, uri)
+                .and_then(|f| f.signature_help_disabled_commands.clone())
+        };
+        match folder {
+            Some(v) => v,
+            None => self.signature_help_disabled_commands.lock().await.clone(),
+        }
+    }
+
+    async fn signature_disabled_for(&self, uri: Option<&Uri>) -> Vec<String> {
+        match uri {
+            Some(uri) => self.resolved_signature_help_disabled_commands(uri).await,
+            None => self.signature_help_disabled_commands.lock().await.clone(),
         }
     }
 
@@ -21146,6 +21191,7 @@ impl LanguageServer for Backend {
             return Ok(None);
         };
         let pos = params.text_document_position_params.position;
+        let disabled_commands = self.resolved_signature_help_disabled_commands(&uri).await;
         // Per-dialect cached registry — same source the
         // completion handler uses.  Threading it through lets
         // `S-signature-help-rich` surface signatures for
@@ -21161,7 +21207,7 @@ impl LanguageServer for Backend {
         let exports = self.export_snapshot().await;
         let uri_key = uri.as_str().to_owned();
         let result = crate::rt::spawn_blocking(move || {
-            core_sig::signature_help_in_program(
+            core_sig::signature_help_in_program_with_options(
                 &doc.text,
                 pos.line,
                 pos.character,
@@ -21172,6 +21218,9 @@ impl LanguageServer for Backend {
                         uri: &uri_key,
                         oracle: exports.as_ref(),
                     }),
+                },
+                core_sig::SignatureHelpOptions {
+                    disabled_builtin_commands: &disabled_commands,
                 },
             )
         })
@@ -22489,6 +22538,19 @@ fn parse_folder_diagnostics(
     }
 }
 
+fn normalise_disabled_signature_commands(values: &[serde_json::Value]) -> Vec<String> {
+    let mut commands: Vec<String> = values
+        .iter()
+        .filter_map(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|command| !command.is_empty())
+        .map(tcl_lsp_core::normalise_qualified_command_name)
+        .collect();
+    commands.sort();
+    commands.dedup();
+    commands
+}
+
 fn parse_folder_config(cfg: &serde_json::Value) -> Option<FolderConfig> {
     let obj = cfg.as_object()?;
     let mut fc = FolderConfig::default();
@@ -22536,6 +22598,13 @@ fn parse_folder_config(cfg: &serde_json::Value) -> Option<FolderConfig> {
                 .map(str::to_owned)
                 .collect(),
         );
+    }
+    if let Some(commands) = obj
+        .get("signatureHelp")
+        .and_then(|section| section.get("disabledCommands"))
+        .and_then(serde_json::Value::as_array)
+    {
+        fc.signature_help_disabled_commands = Some(normalise_disabled_signature_commands(commands));
     }
     parse_folder_diagnostics(obj, &mut fc);
     // `tclLsp.libraryPaths` per-folder override.
@@ -25859,6 +25928,34 @@ mod tests {
         for code in ["S100", "S101", "S102", "S103", "S110"] {
             assert!(disabled.contains(code), "{code} should be suppressed");
         }
+    }
+
+    #[tokio::test]
+    async fn signature_help_disabled_commands_apply_and_clear() {
+        let backend = test_backend();
+        backend
+            .apply_global_config(&serde_json::json!({
+                "signatureHelp": { "disabledCommands": [" ::::set ", "incr", "set"] }
+            }))
+            .await;
+        assert_eq!(
+            *backend.signature_help_disabled_commands.lock().await,
+            vec!["::incr".to_owned(), "::set".to_owned()],
+        );
+
+        // A nullable editor setting is removed by client middleware, leaving
+        // the section present but empty. That must clear a previously applied
+        // list rather than latching stale suppression until restart.
+        backend
+            .apply_global_config(&serde_json::json!({ "signatureHelp": {} }))
+            .await;
+        assert!(
+            backend
+                .signature_help_disabled_commands
+                .lock()
+                .await
+                .is_empty()
+        );
     }
 
     #[test]
@@ -30565,6 +30662,7 @@ mod tests {
             editor_library_paths: Mutex::new(Vec::new()),
             package_prefer_latest_default: Mutex::new(false),
             extra_commands: Mutex::new(Vec::new()),
+            signature_help_disabled_commands: Mutex::new(Vec::new()),
             spec_pack_paths: Mutex::new(Vec::new()),
             spec_packs: Arc::new(Mutex::new(PublishedPackSet::default())),
             spec_pack_reload: Arc::new(Mutex::new(())),
@@ -33138,6 +33236,7 @@ mod tests {
     fn parse_folder_config_reads_extra_library_and_generic_patterns() {
         let cfg = serde_json::json!({
             "extraCommands": ["mylib::send", "mylib::recv"],
+            "signatureHelp": { "disabledCommands": [" ::::set ", "incr", "set"] },
             "libraryPaths": ["/proj/lib"],
             "diagnostics": { "genericVariablePatterns": ["^proj_"] },
         });
@@ -33149,6 +33248,11 @@ mod tests {
         assert_eq!(
             fc.library_paths.as_deref(),
             Some(["/proj/lib".to_owned()].as_slice())
+        );
+        assert_eq!(
+            fc.signature_help_disabled_commands.as_deref(),
+            Some(["::incr".to_owned(), "::set".to_owned()].as_slice()),
+            "command names use the shared Tcl qualified-name canonicalisation",
         );
         assert_eq!(
             fc.generic_variable_patterns,
@@ -33192,8 +33296,10 @@ mod tests {
 
         // Global sets one extra command; proj-a overrides with its own.
         *backend.extra_commands.lock().await = vec!["globalcmd".to_owned()];
+        *backend.signature_help_disabled_commands.lock().await = vec!["::set".to_owned()];
         let fc = FolderConfig {
             extra_commands: Some(vec!["projacmd".to_owned()]),
+            signature_help_disabled_commands: Some(vec!["::incr".to_owned()]),
             generic_variable_patterns: FolderGenericPatterns::Replace(vec!["^proja_".to_owned()]),
             ..FolderConfig::default()
         };
@@ -33211,6 +33317,20 @@ mod tests {
             backend.resolved_extra_commands(&outside).await,
             vec!["globalcmd".to_owned()],
             "proj-b inherits the global extraCommands",
+        );
+        assert_eq!(
+            backend
+                .resolved_signature_help_disabled_commands(&inside)
+                .await,
+            vec!["::incr".to_owned()],
+            "proj-a replaces the global signature-help exclusion list",
+        );
+        assert_eq!(
+            backend
+                .resolved_signature_help_disabled_commands(&outside)
+                .await,
+            vec!["::set".to_owned()],
+            "proj-b inherits the global signature-help exclusion list",
         );
         // genericVariablePatterns resolve per folder.
         assert_eq!(


### PR DESCRIPTION
## Summary

- scope signature help to the innermost registry-declared executable region, so a `proc` declaration keeps its signature in the header but does not leak it across the body
- preserve signature help for commands and user procs called inside bodies, and preserve outer signatures across ordinary braced data
- add `signatureHelp.disabledCommands` / `[signatureHelp] disabled_commands` for selectively silencing built-in signatures while retaining commands such as `format` and user-defined procs
- canonicalise configured command names through the shared `tcl-syntax::naming` owner; `set`, `::set`, and redundant-root spellings resolve to the same registry key

## Issue analysis

The three captures in #1735 place the text caret at the ends of the two comment lines and the `set evenWhenWritingCode` line inside the braced proc body. The pointer is not visible. The persistent `proc name args body` panel is signature help, not hover: VS Code re-requests it on the server's SPACE trigger after Escape dismisses it.

The provider previously lexed the whole document prefix. Since the proc body is represented as one braced string token beginning before the caret, the outer `proc` call remained the apparent active command everywhere in that token. The fix reuses the existing registry-driven executable-region walker, including body roles, case actions, lambdas, definition bodies, and command substitutions.

## Configuration

```json
"tclLsp.signatureHelp.disabledCommands": ["set", "incr"]
```

```ini
[signatureHelp]
disabled_commands = set, incr
```

The setting is available in VS Code, JetBrains, Sublime Text, Zed configuration, and layered INI configuration. Clearing a nullable editor override also clears previously applied exclusions.

## Verification

- `make rust-check`
- `make prep-pr`
- focused core signature-help tests: 23 passed
- focused server setting/INI tests passed

Fixes #1735