### PR TITLE
Conform TclVM namespace and ensemble semantics

### DIFF
--- a/docs/design/contracts/runtime-variable-frame-model.md
+++ b/docs/design/contracts/runtime-variable-frame-model.md
@@ -110,6 +110,10 @@ frame target is canonicalised to the global namespace at the link site.
 * `#N` — absolute, counting from the global frame (`#0`).
 * `N` — relative, N frames up from the current (default `1`).
 * The target frame must exist (`upvar 3` from level 1 is an error).
+* A relative-qualified target name is resolved in the **target frame's**
+  namespace, not the active callee's. Thus `::B::inner` executing
+  `upvar 1 rel::x y` for a caller in `::A` links `y` to `::A::rel::x`; the
+  same rule applies to `rel::array(key)` and to deeper numeric levels.
 * `uplevel L {script}` sets the *active call frame* to frame `L` for the
   duration of `script`, then restores it. Both backends switch the current
   namespace with the frame (`tcl-vm::eval_at_level`, `runtime`'s

--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -32,9 +32,9 @@ entry point, or gate moves without this contract being updated.
 <!-- owner-resolution-manifest -->
 | Surface | Owner source paths | Public entry points | Dialect/release axis | Drift gate |
 | --- | --- | --- | --- | --- |
-| names / namespaces | `rust/tcl-syntax/src/naming.rs`; `rust/tcl-cmd-core/src/namespace.rs` | `qualifier_segments`; `command_resolution_candidates`; `qualifiers`; `tail`; `which_command`; `which_command_bytes`; `which_variable`; `variable_fqn`; `variable_fqn_bytes`; `origin`; `origin_bytes` | invariant, except `which_variable`'s alternate (global) candidate, which 9.0 drops; absolute-marker contract from #1493 | `xtask-resolution-drift` |
+| names / namespaces | `rust/tcl-syntax/src/naming.rs`; `rust/tcl-cmd-core/src/namespace.rs` | `qualifier_segments`; `command_resolution_candidates`; `qualifiers`; `tail`; `children`; `which_request`; `which_command`; `which_command_bytes`; `which_variable`; `variable_fqn`; `variable_fqn_bytes`; `import_pattern`; `origin`; `origin_bytes` | invariant, except `which_variable`'s alternate (global) candidate, which 9.0 drops; absolute-marker contract from #1493 | `xtask-resolution-drift` |
 | lists | `rust/tcl-syntax/src/list.rs` | `find_element`; `split_list`; `list_element`; `join_list`; `append_list_element`; `junk_fragment` | invariant | none |
-| dicts | `rust/tcl-syntax/src/list.rs`; `rust/tcl-syntax/src/value.rs` | `find_element`; `split_list`; `canonical_dict_slots`; `ValueOps::dict_pairs` | invariant | none |
+| dicts | `rust/tcl-syntax/src/list.rs`; `rust/tcl-syntax/src/value.rs`; `rust/tcl-cmd-core/src/dict.rs` | `find_element`; `split_list`; `canonical_dict_slots`; `ValueOps::dict_pairs`; `worded_parse_error` | invariant | none |
 | glob matching | `rust/tcl-syntax/src/glob.rs` | `string_match`; `string_case_match` | invariant | none |
 | switch body grammar | `rust/tcl-syntax/src/switch_body.rs` | `tokenise_switch_body`; `parse_braced_pairs` | invariant | none |
 | numbers | `rust/tcl-syntax/src/number.rs`; `rust/tcl-dialect/src/expr_number.rs`; `rust/tcl-dialect/src/grammar.rs` | `parse`; `parse_whole_with`; `is_expr_number`; `scan_expr_number`; `scan_nan_payload`; `NumberSyntax` | `NumberSyntax` and expression-word grammar per release | `xtask-number-drift` |
@@ -43,7 +43,7 @@ entry point, or gate moves without this contract being updated.
 | quotes / braces / word spans | `rust/tcl-lexer/src/ranges.rs` | `close_quote_offset`; `word_closer_offset`; `word_span_at`; `braced_var_name_end` | `${...}` close rule per release (`BracedVarStyle`); tmsh brace mode per dialect | none |
 | array-index source scan | `rust/tcl-lexer/src/ranges.rs`; `rust/tcl-dialect/src/grammar.rs` | `scan_array_index`; `ArrayIndexSyntax` | `LexerGrammar::array_index` per release | none |
 | indices | `rust/tcl-cmd-core/src/index.rs` | `resolve_with`; `drill` | grammar-parameterised, inheriting the number axis | none |
-| option words / subcommands | `rust/tcl-cmd-core/src/prefix.rs`; `rust/tcl-cmd-core/src/ensemble.rs`; `rust/tcl-registry/src/hover.rs`; `rust/tcl-registry/src/spec.rs` | `OptionTable`; `OptionSpec`; `SubCommand`; `first_positional_index`; `ensemble::CREATE_OPTIONS`; `ensemble::CONFIG_OPTIONS`; `ensemble::SUBCOMMANDS`; `ensemble::resolve_subcommand`; `ensemble::subcommand_choices`; `ensemble::unknown_subcommand_message` | option surface per release/dialect | `xtask-option-registry-drift` |
+| option words / subcommands | `rust/tcl-cmd-core/src/prefix.rs`; `rust/tcl-cmd-core/src/ensemble.rs`; `rust/tcl-registry/src/hover.rs`; `rust/tcl-registry/src/spec.rs` | `OptionTable`; `OptionSpec`; `SubCommand`; `first_positional_index`; `ensemble::CREATE_OPTIONS`; `ensemble::CONFIG_OPTIONS`; `ensemble::SUBCOMMANDS`; `ensemble::resolve_subcommand`; `ensemble::subcommand_choices`; `ensemble::unknown_subcommand_message`; `ensemble::validate_map_targets` | option surface per release/dialect | `xtask-option-registry-drift` |
 | trace argument decoding | `rust/tcl-cmd-core/src/trace.rs` | `TraceKind`; `resolve_option`; `resolve_type`; `parse_ops`; `parse_legacy_variable_ops`; `legacy_ops_letters`; `callback_op_word` | option surface per release (the 8.x-only `variable`/`vdelete`/`vinfo` forms) | none |
 | sort numeric parsing | `rust/tcl-cmd-core/src/sort.rs` | `parse_wide`; `parse_real` | `NumberSyntax` per release | none |
 | command errors | `rust/tcl-cmd-core/src/error.rs` | `CmdError`; `wrong_args`; `bad_choice` | invariant | none |
@@ -294,7 +294,9 @@ entry point, or gate moves without this contract being updated.
   namespace declare/find/parent/import/forget) and `command.rs`
   (rename re-homing, `proc` namespace derivation) are built on them.
   The generic cores cover `current` / `exists` / `parent` / `children`
-  / `which_command` and, since #1442, `which_variable` (the
+  (including Tcl string-hash enumeration order), the positional
+  `which_request`, import-source validation, `which_command` and, since
+  #1442, `which_variable` (the
   `Tcl_FindNamespaceVar` probe — namespace variable tables only, never
   a call frame; its *alternate* global-rooted candidate is the one
   release axis, dropped by 9.0's `flags |= TCL_NAMESPACE_ONLY`) and
@@ -309,7 +311,8 @@ entry point, or gate moves without this contract being updated.
   (`create` carries `-command` and no `-namespace`; `configure`
   carries `-namespace`, read-only, and no `-command`), the
   exact-then-unique-prefix subcommand scan, and the dispatch miss
-  messages. The scan is `prefix::scan`'s rule with one documented
+  messages, plus the non-empty implementation-prefix invariant for `-map`.
+  The scan is `prefix::scan`'s rule with one documented
   divergence: C's ensemble path is a `strncmp` over the word's length,
   so an **empty** subcommand prefixes every entry and resolves against
   a one-entry table, where `Tcl_GetIndexFromObj` forces the error

--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -32,10 +32,10 @@ entry point, or gate moves without this contract being updated.
 <!-- owner-resolution-manifest -->
 | Surface | Owner source paths | Public entry points | Dialect/release axis | Drift gate |
 | --- | --- | --- | --- | --- |
-| names / namespaces | `rust/tcl-syntax/src/naming.rs`; `rust/tcl-cmd-core/src/namespace.rs` | `qualifier_segments`; `command_resolution_candidates`; `qualifiers`; `tail`; `children`; `which_request`; `which_command`; `which_command_bytes`; `which_variable`; `variable_fqn`; `variable_fqn_bytes`; `import_pattern`; `origin`; `origin_bytes` | invariant, except `which_variable`'s alternate (global) candidate, which 9.0 drops; absolute-marker contract from #1493 | `xtask-resolution-drift` |
+| names / namespaces | `rust/tcl-syntax/src/naming.rs`; `rust/tcl-cmd-core/src/namespace.rs` | `qualifier_segments`; `command_resolution_candidates`; `qualifiers`; `tail`; `exists`; `exists_bytes`; `parent`; `parent_bytes`; `children`; `children_bytes`; `which_request`; `which_command`; `which_command_bytes`; `which_variable`; `variable_fqn`; `variable_fqn_bytes`; `import_pattern`; `origin`; `origin_bytes` | invariant, except `which_variable`'s alternate (global) candidate, which 9.0 drops; absolute-marker contract from #1493 | `xtask-resolution-drift` |
 | lists | `rust/tcl-syntax/src/list.rs` | `find_element`; `split_list`; `list_element`; `join_list`; `append_list_element`; `junk_fragment` | invariant | none |
 | dicts | `rust/tcl-syntax/src/list.rs`; `rust/tcl-syntax/src/value.rs`; `rust/tcl-cmd-core/src/dict.rs` | `find_element`; `split_list`; `canonical_dict_slots`; `ValueOps::dict_pairs`; `worded_parse_error` | invariant | none |
-| glob matching | `rust/tcl-syntax/src/glob.rs` | `string_match`; `string_case_match` | invariant | none |
+| glob matching | `rust/tcl-syntax/src/glob.rs` | `string_match`; `string_match_bytes`; `string_case_match` | invariant | none |
 | switch body grammar | `rust/tcl-syntax/src/switch_body.rs` | `tokenise_switch_body`; `parse_braced_pairs` | invariant | none |
 | numbers | `rust/tcl-syntax/src/number.rs`; `rust/tcl-dialect/src/expr_number.rs`; `rust/tcl-dialect/src/grammar.rs` | `parse`; `parse_whole_with`; `is_expr_number`; `scan_expr_number`; `scan_nan_payload`; `NumberSyntax` | `NumberSyntax` and expression-word grammar per release | `xtask-number-drift` |
 | backslash escapes | `rust/tcl-lexer/src/substitution.rs`; `rust/tcl-syntax/src/backslash.rs`; `rust/tcl-dialect/src/grammar.rs` | `backslash_subst`; `backslash_subst_in`; `decode_bytes_in`; `EscapeSyntax` | `LexerGrammar::escapes` per release | none |
@@ -294,9 +294,9 @@ entry point, or gate moves without this contract being updated.
   namespace declare/find/parent/import/forget) and `command.rs`
   (rename re-homing, `proc` namespace derivation) are built on them.
   The generic cores cover `current` / `exists` / `parent` / `children`
-  (including Tcl string-hash enumeration order), the positional
-  `which_request`, import-source validation, `which_command` and, since
-  #1442, `which_variable` (the
+  (including byte-valued twins and Tcl string-hash enumeration order), the
+  positional `which_request`, import-source validation, `which_command` and,
+  since #1442, `which_variable` (the
   `Tcl_FindNamespaceVar` probe — namespace variable tables only, never
   a call frame; its *alternate* global-rooted candidate is the one
   release axis, dropped by 9.0's `flags |= TCL_NAMESPACE_ONLY`) and

--- a/docs/design/runtime/namespace-tree.md
+++ b/docs/design/runtime/namespace-tree.md
@@ -13,9 +13,8 @@ The *contract* the tree implements is
 [`../contracts/runtime-variable-frame-model.md`](../contracts/runtime-variable-frame-model.md)
 (variables).
 
-Source of truth for the C semantics we're mirroring is Tcl 9.0.3 in
-`tmp/tcl9.0.3/.git` — read with `git -C tmp/tcl9.0.3 show HEAD:generic/<file>`.
-All C-file citations in this doc use that source.
+Source of truth for the C semantics we're mirroring is Tcl 9.0.4. All C-file
+citations in this doc use that release's source.
 
 ## 1. Goal & non-goals
 
@@ -218,10 +217,11 @@ Four fields of C's `Namespace` have no counterpart, deliberately:
   namespace is removed from its parent's `children` map and its arena slot is
   emptied, so there is no dying-but-reachable state to describe.
 
-`BTreeMap` (not `HashMap`) throughout, for the same reason `frame.rs` uses it:
-deterministic iteration order, so `info commands` / `info vars` /
-`namespace children` listings are stable run to run — which an oracle-diffed
-port needs — with no external dependency.
+`BTreeMap` (not `HashMap`) throughout gives deterministic storage and makes
+`info commands` / `info vars` stable run to run. `namespace children` is the
+exception where C's `Tcl_HashTable` bucket order is public behavior: the
+adapter supplies child ids in creation order and `tcl-cmd-core::namespace`
+reconstructs the Tcl string-hash enumeration, including resize reversals.
 
 ### `Command`
 
@@ -613,8 +613,9 @@ pub(crate) fn set_unknown_handler(&mut self, ns: NsId, handler: &[u8]);
 
 There are no visitor helpers: `command_names`, `var_names`, `proc_names`,
 `const_names`, `children`, and `descendant_ids` each return an owned or
-borrowed listing directly, which is what `info commands` / `info vars` /
-`namespace children` need and what `BTreeMap` makes cheap and ordered.
+borrowed listing directly. `children` returns creation order for the shared
+command core's Tcl-hash ordering step; the remaining table listings retain the
+cheap deterministic `BTreeMap` order.
 
 ## 8. Settled design points
 

--- a/runtime/rust/src/cmd_dict.rs
+++ b/runtime/rust/src/cmd_dict.rs
@@ -1055,15 +1055,7 @@ fn with(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 /// parse failure at all (`wrong # args`, a missing key) passes through
 /// untouched.
 fn dict_worded(msg: &str) -> String {
-    if let Some(rest) = msg.strip_prefix("list element in ") {
-        format!("dict element in {rest}")
-    } else if msg == "unmatched open brace in list" {
-        "unmatched open brace in dict".to_owned()
-    } else if msg == "unmatched open quote in list" {
-        "unmatched open quote in dict".to_owned()
-    } else {
-        msg.to_owned()
-    }
+    tcl_cmd_core::dict::worded_parse_error(msg)
 }
 
 /// The C `-errorcode` for a dict string-parse failure, keyed off the message the

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -208,8 +208,8 @@ fn ns_exists(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() != 3 {
         return interp.wrong_args(b"namespace exists name");
     }
-    let name = String::from_utf8_lossy(&obj_bytes(argv[2])).into_owned();
-    let v = tcl_cmd_core::namespace::exists(interp, &name);
+    let name = obj_bytes(argv[2]);
+    let v = tcl_cmd_core::namespace::exists_bytes(interp, &name);
     interp.set_result(v);
     Code::Ok
 }
@@ -220,15 +220,13 @@ fn ns_parent(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() > 3 {
         return interp.wrong_args(b"namespace parent ?name?");
     }
-    let name = argv
-        .get(2)
-        .map(|&a| String::from_utf8_lossy(&obj_bytes(a)).into_owned());
-    match tcl_cmd_core::namespace::parent(interp, name.as_deref()) {
+    let name = argv.get(2).map(|&arg| obj_bytes(arg));
+    match tcl_cmd_core::namespace::parent_bytes(interp, name.as_deref()) {
         Ok(v) => {
             interp.set_result(v);
             Code::Ok
         }
-        Err(e) => interp.set_error(e.message().as_bytes()),
+        Err(error) => interp.set_error(&error.message()),
     }
 }
 
@@ -238,18 +236,14 @@ fn ns_children(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() > 4 {
         return interp.wrong_args(b"namespace children ?name? ?pattern?");
     }
-    let name = argv
-        .get(2)
-        .map(|&a| String::from_utf8_lossy(&obj_bytes(a)).into_owned());
-    let pattern = argv
-        .get(3)
-        .map(|&a| String::from_utf8_lossy(&obj_bytes(a)).into_owned());
-    match tcl_cmd_core::namespace::children(interp, name.as_deref(), pattern.as_deref()) {
+    let name = argv.get(2).map(|&arg| obj_bytes(arg));
+    let pattern = argv.get(3).map(|&arg| obj_bytes(arg));
+    match tcl_cmd_core::namespace::children_bytes(interp, name.as_deref(), pattern.as_deref()) {
         Ok(v) => {
             interp.set_result(v);
             Code::Ok
         }
-        Err(e) => interp.set_error(e.message().as_bytes()),
+        Err(error) => interp.set_error(&error.message()),
     }
 }
 
@@ -535,10 +529,7 @@ fn dest_has_own(interp: &Interp, dest: NsId, simple: &[u8]) -> bool {
 /// pattern or text can only match byte-identically, handled by the equality
 /// fallback).
 fn glob_match_bytes(pattern: &[u8], text: &[u8]) -> bool {
-    match (core::str::from_utf8(pattern), core::str::from_utf8(text)) {
-        (Ok(p), Ok(t)) => tcl_syntax::glob::string_match(p, t),
-        _ => pattern == text,
-    }
+    tcl_syntax::glob::string_match_bytes(pattern, text)
 }
 
 /// Set the interp result to a Tcl list of the given byte strings.
@@ -2352,6 +2343,78 @@ mod tests {
                 tcl_cmd_core::namespace::origin(i, &String::from_utf8_lossy(raw)),
                 None
             );
+        });
+    }
+
+    /// #1613: an embedder can supply a plain string whose bytes are not UTF-8.
+    /// Drive the real `namespace` adapter with such objects rather than using a
+    /// script-created byte array (whose string shimmer is valid UTF-8), so any
+    /// lossy `&str` hop makes these two distinct namespace names disappear or
+    /// collide.
+    #[test]
+    fn byte_valued_namespace_navigation_uses_the_embedder_bytes_verbatim() {
+        fn invoke(interp: &mut Interp, words: &[&[u8]]) -> Code {
+            let argv: Vec<*mut crate::obj::TclObj> = words
+                .iter()
+                .map(|word| crate::obj::new_string_bytes(word))
+                .collect();
+            let code = super::namespace_cmd(interp, &argv);
+            for object in argv {
+                super::drop_fresh(object);
+            }
+            code
+        }
+
+        leak_free(|interp| {
+            let parent = b"::raw\xff";
+            let sibling = b"::raw\xfe";
+            let child = b"::raw\xff::child\xfd";
+            {
+                let mut namespaces = interp.namespaces_mut();
+                namespaces.ensure_namespace(crate::namespace::GLOBAL, parent);
+                namespaces.ensure_namespace(crate::namespace::GLOBAL, sibling);
+                namespaces.ensure_namespace(crate::namespace::GLOBAL, child);
+            }
+
+            assert_eq!(invoke(interp, &[b"namespace", b"exists", parent]), Code::Ok);
+            assert_eq!(interp.result_bytes(), b"1");
+            assert_eq!(
+                invoke(interp, &[b"namespace", b"exists", sibling]),
+                Code::Ok
+            );
+            assert_eq!(interp.result_bytes(), b"1");
+
+            assert_eq!(invoke(interp, &[b"namespace", b"parent", child]), Code::Ok);
+            assert_eq!(interp.result_bytes(), parent);
+
+            assert_eq!(
+                invoke(interp, &[b"namespace", b"children", parent]),
+                Code::Ok
+            );
+            assert_eq!(interp.result_bytes(), child);
+            assert_eq!(
+                invoke(interp, &[b"namespace", b"children", parent, child]),
+                Code::Ok
+            );
+            assert_eq!(interp.result_bytes(), child);
+
+            // Established invalid-byte glob policy: identity is defined, while
+            // wildcard interpretation is reserved for valid UTF-8 strings.
+            assert_eq!(
+                invoke(interp, &[b"namespace", b"children", parent, b"*"]),
+                Code::Ok
+            );
+            assert_eq!(interp.result_bytes(), b"");
+
+            let missing = b"::missing\xff";
+            assert_eq!(
+                invoke(interp, &[b"namespace", b"parent", missing]),
+                Code::Error
+            );
+            let mut message = b"namespace \"".to_vec();
+            message.extend_from_slice(missing);
+            message.extend_from_slice(b"\" not found");
+            assert_eq!(interp.result_bytes(), message);
         });
     }
 

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -277,38 +277,21 @@ fn ns_tail(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 /// Only `-command` resolution is implemented (variables aren't ns-scoped yet);
 /// `-variable` always yields the empty string.
 fn ns_which(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
-    let mut want_variable = false;
-    let mut name: Option<Vec<u8>> = None;
-    // The flags accept unambiguous prefix abbreviations (`-var`, `-com`), as
-    // Tcl's option table does; a non-flag argument (or one after another flag)
-    // is the name. Only one name is allowed.
-    for &a in &argv[2..] {
-        let b = obj_bytes(a);
-        let is_flag = b.first() == Some(&b'-') && name.is_none();
-        if is_flag && b.len() > 1 && b"-command".starts_with(b.as_slice()) {
-            // -command (default behaviour)
-        } else if is_flag && b.len() > 1 && b"-variable".starts_with(b.as_slice()) {
-            want_variable = true;
-        } else {
-            if name.is_some() {
-                return interp.wrong_args(b"namespace which ?-command? ?-variable? name");
-            }
-            name = Some(b);
-        }
-    }
-    let Some(name) = name else {
+    let args: Vec<Vec<u8>> = argv[2..].iter().map(|&arg| obj_bytes(arg)).collect();
+    let Some((kind, name_index)) = tcl_cmd_core::namespace::which_request(&args) else {
         return interp.wrong_args(b"namespace which ?-command? ?-variable? name");
     };
-    if want_variable {
+    let name = &args[name_index];
+    if kind == tcl_cmd_core::namespace::WhichKind::Variable {
         // `-variable` through the shared `Tcl_FindNamespaceVar` core — the
         // 8.x global-fallback candidate is a release axis, so the profile
         // goes with it.
         let profile = interp.dialect_profile();
-        let fqn = tcl_cmd_core::namespace::variable_fqn_bytes(interp, &name, profile);
+        let fqn = tcl_cmd_core::namespace::variable_fqn_bytes(interp, name, profile);
         interp.set_result_bytes(&fqn.unwrap_or_default());
     } else {
         // `-command` via the shared `Namespaces` resolution core.
-        let fqn = tcl_cmd_core::namespace::which_command_bytes(interp, &name);
+        let fqn = tcl_cmd_core::namespace::which_command_bytes(interp, name);
         interp.set_result_bytes(&fqn.unwrap_or_default());
     }
     Code::Ok
@@ -390,47 +373,19 @@ fn ns_import(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return Code::Ok;
     }
     for pat in &patterns {
-        // An empty pattern is rejected outright (C's `Tcl_Import`).
-        if pat.is_empty() {
-            return interp.set_error(b"empty import pattern");
-        }
-        // Split into the source-namespace qualifier and the simple glob tail.
-        // C distinguishes the two ways a pattern can fail to name another
-        // namespace: no qualifier at all (`pattern == simplePattern`) reports
-        // a *missing* source namespace, a qualifier that resolves back to the
-        // importing namespace reports the self-import.
-        let q = match tcl_cmd_core::namespace::qualifier(pat) {
-            tcl_cmd_core::namespace::Qualifier::Absolute(q)
-            | tcl_cmd_core::namespace::Qualifier::Relative(q) => q,
-            tcl_cmd_core::namespace::Qualifier::Unqualified => {
-                let mut m = b"no namespace specified in import pattern \"".to_vec();
-                m.extend_from_slice(pat);
-                m.push(b'"');
-                return interp.set_error(&m);
-            }
+        let destination = tcl_runtime_api::Namespaces::current(interp);
+        let validated = match tcl_cmd_core::namespace::import_pattern(interp, destination, pat) {
+            Ok(validated) => validated,
+            Err(problem) => return interp.set_error(&problem.message()),
         };
-        let tail_pat = tcl_cmd_core::namespace::tail(pat);
-        let Some(src_ns) = interp.namespaces().find_namespace(dest, q) else {
-            let mut m = b"unknown namespace in import pattern \"".to_vec();
-            m.extend_from_slice(pat);
-            m.push(b'"');
-            return interp.set_error(&m);
-        };
-        // Importing from one's own namespace is meaningless (C's `Tcl_Import`):
-        // the message names the source namespace by its simple name.
-        if src_ns == dest {
-            let mut m = b"import pattern \"".to_vec();
-            m.extend_from_slice(pat);
-            m.extend_from_slice(b"\" tries to import from namespace \"");
-            m.extend_from_slice(&interp.namespaces().simple_name(src_ns));
-            m.extend_from_slice(b"\" into itself");
-            return interp.set_error(&m);
-        }
+        let src_ns = validated.source.0 as usize;
+        let tail_pat = validated.tail;
         // Collect the matching, exported source commands first (borrow ends).
         let src_fqn = interp.namespaces().qualified_name(src_ns);
         let mut to_import: Vec<Vec<u8>> = Vec::new();
         for name in interp.visible_command_names_in(src_ns) {
-            if glob_match_bytes(tail_pat, &name) && interp.namespaces().is_exported(src_ns, &name) {
+            if glob_match_bytes(&tail_pat, &name) && interp.namespaces().is_exported(src_ns, &name)
+            {
                 to_import.push(name);
             }
         }
@@ -1013,7 +968,10 @@ fn ens_exists(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 
 /// Parse a `-map` dict (`sub {target prefix} …`) into (subcommand, prefix-words).
 fn parse_map(bytes: &[u8], map_ns: &[u8]) -> Result<EnsembleMap, Vec<u8>> {
-    let kvs = crate::parse::split_list(bytes).map_err(|e| e.message().to_vec())?;
+    let kvs = crate::parse::split_list(bytes).map_err(|error| {
+        tcl_cmd_core::dict::worded_parse_error(&String::from_utf8_lossy(error.message()))
+            .into_bytes()
+    })?;
     if kvs.len() % 2 != 0 {
         return Err(b"missing value to go with key".to_vec());
     }
@@ -1035,6 +993,8 @@ fn parse_map(bytes: &[u8], map_ns: &[u8]) -> Result<EnsembleMap, Vec<u8>> {
             None => map.push((pair[0].clone(), prefix)),
         }
     }
+    tcl_cmd_core::ensemble::validate_map_targets(&map)
+        .map_err(|error| error.into_message().into_bytes())?;
     Ok(map)
 }
 
@@ -1186,6 +1146,84 @@ mod tests {
             assert_eq!(i.result_bytes(), b"::n::gv");
             assert_eq!(i.eval_str(b"namespace which -variable ::n::nope"), Code::Ok);
             assert_eq!(i.result_bytes(), b"");
+        });
+    }
+
+    /// Tcl 9.0.4 oracle vectors from issue #1584. These exercise the runtime
+    /// adapter through the same shared namespace grammar as the bytecode VM.
+    #[test]
+    fn namespace_issue_1584_oracle_vectors() {
+        leak_free(|i| {
+            assert_eq!(
+                i.eval_str(
+                    b"namespace eval declared {variable only
+                      list [namespace which -variable only] [info vars] [info exists only]}"
+                ),
+                Code::Ok
+            );
+            assert_eq!(i.result_bytes(), b"::declared::only only 0");
+
+            for script in [
+                &b"namespace which -zork puts"[..],
+                b"namespace which -command puts extra",
+            ] {
+                assert_eq!(i.eval_str(script), Code::Error);
+                assert_eq!(
+                    i.result_bytes(),
+                    b"wrong # args: should be \"namespace which ?-command? ?-variable? name\""
+                );
+            }
+
+            assert_eq!(
+                i.eval_str(b"namespace eval self {namespace import ::self::*}"),
+                Code::Error
+            );
+            assert_eq!(
+                i.result_bytes(),
+                b"import pattern \"::self::*\" tries to import from namespace \"self\" into itself"
+            );
+            assert_eq!(
+                i.eval_str(b"namespace eval dest {namespace import ::nosuch::*}"),
+                Code::Error
+            );
+            assert_eq!(
+                i.result_bytes(),
+                b"unknown namespace in import pattern \"::nosuch::*\""
+            );
+
+            for script in [&b"namespace origin"[..], b"namespace origin set extra"] {
+                assert_eq!(i.eval_str(script), Code::Error);
+                assert_eq!(
+                    i.result_bytes(),
+                    b"wrong # args: should be \"namespace origin name\""
+                );
+            }
+
+            assert_eq!(
+                i.eval_str(
+                    b"namespace eval order {}
+                      foreach n {one two three four five six seven eight nine ten} {
+                          namespace eval ::order::$n {}
+                      }
+                      namespace children ::order"
+                ),
+                Code::Ok
+            );
+            assert_eq!(
+                i.result_bytes(),
+                b"::order::six ::order::four ::order::three ::order::eight \
+                  ::order::seven ::order::nine ::order::five ::order::two \
+                  ::order::one ::order::ten"
+            );
+        });
+
+        // The active command survives long enough to return even though the
+        // global namespace and command table have been torn down.
+        leak_free(|i| {
+            assert_eq!(i.eval_str(b"namespace delete ::"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"");
+            assert_eq!(i.eval_str(b"puts hi"), Code::Error);
+            assert_eq!(i.result_bytes(), b"invalid command name \"puts\"");
         });
     }
 
@@ -1518,6 +1556,69 @@ mod tests {
                 b"unknown or ambiguous subcommand \"set\": must be go"
             );
             i.eval_str(b"unset v");
+        });
+    }
+
+    /// Tcl 9.0.4 oracle vectors from issue #1583: dict validation, callback
+    /// prefix redispatch/reparse, and the user-facing default target name.
+    #[test]
+    fn ensemble_issue_1583_oracle_vectors() {
+        leak_free(|i| {
+            for (script, message) in [
+                (
+                    &b"namespace ensemble create -map {go}"[..],
+                    &b"missing value to go with key"[..],
+                ),
+                (
+                    b"namespace ensemble create -map {go {}}",
+                    b"ensemble subcommand implementations must be non-empty lists",
+                ),
+                (
+                    b"set badmap \"go \\{\"; namespace ensemble create -map $badmap",
+                    b"unmatched open brace in dict",
+                ),
+            ] {
+                assert_eq!(i.eval_str(script), Code::Error);
+                assert_eq!(i.result_bytes(), message);
+            }
+
+            assert_eq!(
+                i.eval_str(
+                    b"proc uh {ens args} {return [list list REPLACED $ens]}
+                      namespace eval se5 {
+                          namespace ensemble create -command ::se5 -subcommands {} -unknown ::uh
+                      }
+                      ::se5 nope 1 2"
+                ),
+                Code::Ok
+            );
+            assert_eq!(i.result_bytes(), b"REPLACED ::se5 1 2");
+
+            assert_eq!(
+                i.eval_str(
+                    b"proc define {ens args} {
+                          namespace eval se6 {
+                              proc nope args {return DEFINED}; namespace export nope
+                          }
+                          return {}
+                      }
+                      namespace eval se6 {
+                          namespace ensemble create -command ::se6 -unknown ::define
+                      }
+                      ::se6 nope"
+                ),
+                Code::Ok
+            );
+            assert_eq!(i.result_bytes(), b"DEFINED");
+
+            assert_eq!(
+                i.eval_str(
+                    b"namespace eval k1 {namespace ensemble create -subcommands ghost}
+                      ::k1 ghost"
+                ),
+                Code::Error
+            );
+            assert_eq!(i.result_bytes(), b"invalid command name \"ghost\"");
         });
     }
 

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -6685,28 +6685,32 @@ impl Interp {
             {
                 let resolved = &subs[idx];
                 // The target command prefix: a `-map` entry, else `<ns>::<sub>`.
-                let prefix: Vec<Vec<u8>> = cfg
-                    .map
-                    .as_ref()
-                    .and_then(|m| {
-                        m.iter()
-                            .find(|(k, _)| k == resolved)
-                            .map(|(_, p)| p.clone())
-                    })
-                    .unwrap_or_else(|| {
-                        let mut t = self.namespaces.borrow().qualified_name(cfg.ns);
-                        if cfg.ns != GLOBAL {
-                            t.extend_from_slice(b"::");
-                        }
-                        t.extend_from_slice(resolved);
-                        vec![t]
-                    });
+                let mapped = cfg.map.as_ref().and_then(|m| {
+                    m.iter()
+                        .find(|(k, _)| k == resolved)
+                        .map(|(_, p)| p.clone())
+                });
+                let default_target = mapped.is_none();
+                let prefix: Vec<Vec<u8>> = mapped.unwrap_or_else(|| {
+                    let mut t = self.namespaces.borrow().qualified_name(cfg.ns);
+                    if cfg.ns != GLOBAL {
+                        t.extend_from_slice(b"::");
+                    }
+                    t.extend_from_slice(resolved);
+                    vec![t]
+                });
                 // Spell-fix the subcommand to its resolved name in the recorded
                 // source, so an abbreviated `ev` is reported as `event` (C's
                 // `TclSpellFix`).
                 let mut source: Vec<Vec<u8>> = argv.iter().map(|&a| obj_bytes(a)).collect();
                 source[1 + nparams] = resolved.clone();
-                return self.dispatch_ensemble_target(&prefix, argv, nparams, source);
+                return self.dispatch_ensemble_target(
+                    &prefix,
+                    argv,
+                    nparams,
+                    source,
+                    default_target.then_some(resolved.as_slice()),
+                );
             }
             // Miss: try the `-unknown` handler once.
             if !cfg.unknown.is_empty() && !reparsed {
@@ -6714,7 +6718,7 @@ impl Interp {
                 match self.ensemble_unknown(cfg, argv) {
                     EnsembleUnknown::Prefix(prefix) => {
                         let source: Vec<Vec<u8>> = argv.iter().map(|&a| obj_bytes(a)).collect();
-                        return self.dispatch_ensemble_target(&prefix, argv, nparams, source);
+                        return self.dispatch_ensemble_target(&prefix, argv, nparams, source, None);
                     }
                     EnsembleUnknown::Reparse => continue,
                     EnsembleUnknown::Failed(code) => return code,
@@ -6762,7 +6766,12 @@ impl Interp {
         argv: &[*mut TclObj],
         nparams: usize,
         source: Vec<Vec<u8>>,
+        default_name: Option<&[u8]>,
     ) -> Code {
+        let default_target_was_missing = default_name.is_some()
+            && self
+                .resolve_cmd_fqn(prefix.first().map_or(b"", Vec::as_slice))
+                .is_none();
         let mut new_argv: Vec<*mut TclObj> = Vec::with_capacity(prefix.len() + argv.len() - 1);
         for w in prefix {
             let o = new_string(w);
@@ -6785,7 +6794,22 @@ impl Interp {
         // ensemble command, its `-parameters`, and the subcommand word (`2 +
         // nparams`) are removed; the target prefix + `-parameters` are inserted.
         let is_root = self.begin_ensemble_rewrite(source, 2 + nparams, prefix.len() + nparams);
-        let code = self.dispatch(&new_argv);
+        let mut code = self.dispatch(&new_argv);
+        if code == Code::Error && default_target_was_missing {
+            if let Some(name) = default_name {
+                let mut qualified = b"invalid command name \"".to_vec();
+                qualified.extend_from_slice(&prefix[0]);
+                qualified.push(b'"');
+                if obj_bytes(self.get_obj_result()) == qualified {
+                    let mut message = b"invalid command name \"".to_vec();
+                    message.extend_from_slice(name);
+                    message.push(b'"');
+                    let mut error_code = b"TCL LOOKUP COMMAND ".to_vec();
+                    error_code.extend_from_slice(name);
+                    code = self.error_with_code(&message, &error_code);
+                }
+            }
+        }
         if is_root {
             self.clear_ensemble_rewrite();
         }

--- a/runtime/rust/src/namespace.rs
+++ b/runtime/rust/src/namespace.rs
@@ -523,13 +523,6 @@ impl Namespaces {
         &mut self.arena[ns].vars
     }
 
-    /// The simple (unqualified) name of `ns` — its last component (`::a::b` →
-    /// `b`); empty for the global namespace. C's `Namespace.name`.
-    #[must_use]
-    pub(crate) fn simple_name(&self, ns: NsId) -> Vec<u8> {
-        self.arena[ns].name.clone()
-    }
-
     /// The fully-qualified name of `ns` (`::a::b`; global is `::`).
     #[must_use]
     pub fn qualified_name(&self, ns: NsId) -> Vec<u8> {
@@ -628,7 +621,9 @@ impl Namespaces {
     /// `ns`'s direct child namespaces (`namespace children`).
     #[must_use]
     pub fn children(&self, ns: NsId) -> Vec<NsId> {
-        self.arena[ns].children.values().copied().collect()
+        let mut children: Vec<NsId> = self.arena[ns].children.values().copied().collect();
+        children.sort_unstable();
+        children
     }
 
     /// `ns`'s `namespace unknown` handler, if one is set (an empty/`None` handler

--- a/rust/tcl-cmd-core/src/dict.rs
+++ b/rust/tcl-cmd-core/src/dict.rs
@@ -32,6 +32,25 @@ use tcl_syntax::value::ValueOps;
 
 use crate::error::CmdError;
 
+/// Re-word a list-codec parse failure as the dict failure C reports.
+///
+/// `SetDictFromAny` uses the same element grammar with the type strings
+/// `dict`/`DICTIONARY`; the shared list codec therefore supplies the structure
+/// and this owner supplies the public noun. Already dict-specific messages pass
+/// through unchanged.
+#[must_use]
+pub fn worded_parse_error(message: &str) -> String {
+    if let Some(rest) = message.strip_prefix("list element in ") {
+        format!("dict element in {rest}")
+    } else if message == "unmatched open brace in list" {
+        "unmatched open brace in dict".to_owned()
+    } else if message == "unmatched open quote in list" {
+        "unmatched open quote in dict".to_owned()
+    } else {
+        message.to_owned()
+    }
+}
+
 fn ilen(n: usize) -> i64 {
     i64::try_from(n).unwrap_or(i64::MAX)
 }

--- a/rust/tcl-cmd-core/src/ensemble.rs
+++ b/rust/tcl-cmd-core/src/ensemble.rs
@@ -92,6 +92,24 @@ pub enum SharedOption {
     Unknown,
 }
 
+/// Enforce C's invariant that every ensemble `-map` implementation is a
+/// non-empty command-prefix list. Callers parse and canonicalise their dict
+/// through the shared value seam (or a byte-native dict representation), then
+/// hand the resulting entries here before storing them.
+///
+/// # Errors
+/// `ensemble subcommand implementations must be non-empty lists` when any
+/// target prefix is empty.
+pub fn validate_map_targets<K, V>(map: &[(K, Vec<V>)]) -> Result<(), crate::CmdError> {
+    if map.iter().any(|(_, prefix)| prefix.is_empty()) {
+        Err(crate::CmdError::new(
+            "ensemble subcommand implementations must be non-empty lists",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
 /// A resolved `namespace ensemble create` option (the index into
 /// [`CREATE_OPTIONS`], named).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/rust/tcl-cmd-core/src/namespace.rs
+++ b/rust/tcl-cmd-core/src/namespace.rs
@@ -26,7 +26,7 @@
 //! the [`Namespaces`] role trait + [`ValueOps`].
 
 use tcl_runtime_api::{Namespaces, NsId};
-use tcl_syntax::glob::string_match;
+use tcl_syntax::glob::{string_match, string_match_bytes};
 use tcl_syntax::value::ValueOps;
 
 use crate::error::CmdError;
@@ -406,12 +406,49 @@ pub fn origin<O: Namespaces + ?Sized>(ops: &O, name: &str) -> Option<String> {
     origin_bytes(ops, name.as_bytes()).map(|fqn| String::from_utf8_lossy(&fqn).into_owned())
 }
 
-/// `namespace exists name` — whether `name` (resolved from the current
-/// namespace) names an existing namespace.
-pub fn exists<O: ValueOps + Namespaces>(ops: &mut O, name: &str) -> O::Value {
+/// A byte-valued namespace target that did not resolve.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamespaceLookupError {
+    name: Vec<u8>,
+}
+
+impl NamespaceLookupError {
+    /// Tcl's byte-exact `namespace "<name>" not found` result.
+    #[must_use]
+    pub fn message(&self) -> Vec<u8> {
+        let mut message = b"namespace \"".to_vec();
+        message.extend_from_slice(&self.name);
+        message.extend_from_slice(b"\" not found");
+        message
+    }
+}
+
+/// `namespace exists name` over a byte-valued namespace name.
+pub fn exists_bytes<O: ValueOps + Namespaces>(ops: &mut O, name: &[u8]) -> O::Value {
     let cur = Namespaces::current(ops);
-    let present = ops.find_namespace(cur, name).is_some();
+    let present = ops.find_namespace_bytes(cur, name).is_some();
     ops.new_bool(present)
+}
+
+/// [`exists_bytes`] for UTF-8-keyed adapters.
+pub fn exists<O: ValueOps + Namespaces>(ops: &mut O, name: &str) -> O::Value {
+    exists_bytes(ops, name.as_bytes())
+}
+
+/// `namespace parent ?name?` over a byte-valued namespace name.
+///
+/// # Errors
+/// `namespace "<name>" not found` if `name` is given and does not resolve.
+pub fn parent_bytes<O: ValueOps + Namespaces>(
+    ops: &mut O,
+    name: Option<&[u8]>,
+) -> Result<O::Value, NamespaceLookupError> {
+    let ns = resolve_target_bytes(ops, name)?;
+    let fqn = match ops.parent(ns) {
+        Some(parent) => ops.name_bytes(parent),
+        None => Vec::new(), // the global root has no parent
+    };
+    Ok(ops.new_bytes(&fqn))
 }
 
 /// `namespace parent ?name?` — the FQN of the (named, or current) namespace's
@@ -423,12 +460,59 @@ pub fn parent<O: ValueOps + Namespaces>(
     ops: &mut O,
     name: Option<&str>,
 ) -> Result<O::Value, CmdError> {
-    let ns = resolve_target(ops, name)?;
-    let fqn = match ops.parent(ns) {
-        Some(p) => ops.name(p),
-        None => String::new(), // the global root has no parent
-    };
-    Ok(ops.new_string(fqn))
+    parent_bytes(ops, name.map(str::as_bytes))
+        .map_err(|error| CmdError::new(String::from_utf8_lossy(&error.message()).into_owned()))
+}
+
+/// `namespace children ?name? ?pattern?` over byte-valued namespace names.
+///
+/// Child names and results remain byte-exact. Valid-UTF-8 patterns use Tcl's
+/// Unicode glob semantics; an invalid-UTF-8 pattern or name follows the shared
+/// collision-free byte policy in [`string_match_bytes`]: byte identity only.
+///
+/// # Errors
+/// `namespace "<name>" not found` if `name` is given and does not resolve.
+pub fn children_bytes<O: ValueOps + Namespaces>(
+    ops: &mut O,
+    name: Option<&[u8]>,
+    pattern: Option<&[u8]>,
+) -> Result<O::Value, NamespaceLookupError> {
+    let ns = resolve_target_bytes(ops, name)?;
+    let target_fqn = ops.name_bytes(ns);
+    let qualified = pattern.map(|pattern| {
+        if pattern.starts_with(b"::") {
+            pattern.to_vec()
+        } else if target_fqn == b"::" {
+            let mut qualified = b"::".to_vec();
+            qualified.extend_from_slice(pattern);
+            qualified
+        } else {
+            let mut qualified = target_fqn.clone();
+            qualified.extend_from_slice(b"::");
+            qualified.extend_from_slice(pattern);
+            qualified
+        }
+    });
+    // Adapters return children in creation order. Rebuild the string-key hash
+    // table C stores them in, including its bucket-chain reversal at a resize,
+    // because Tcl_FirstHashEntry order is observable in this command's list.
+    let mut names: Vec<Vec<u8>> = ops
+        .children(ns)
+        .into_iter()
+        .map(|child| ops.name_bytes(child))
+        .collect();
+    let order = tcl_string_hash_order(&names);
+    names = order
+        .into_iter()
+        .map(|index| names[index].clone())
+        .collect();
+    names.retain(|name| {
+        qualified
+            .as_deref()
+            .is_none_or(|pattern| string_match_bytes(pattern, name))
+    });
+    let items = names.iter().map(|name| ops.new_bytes(name)).collect();
+    Ok(ops.new_list(items))
 }
 
 /// `namespace children ?name? ?pattern?` — the FQNs of the (named, or current)
@@ -444,38 +528,14 @@ pub fn children<O: ValueOps + Namespaces>(
     name: Option<&str>,
     pattern: Option<&str>,
 ) -> Result<O::Value, CmdError> {
-    let ns = resolve_target(ops, name)?;
-    let target_fqn = ops.name(ns);
-    let qualified = pattern.map(|p| {
-        if p.starts_with("::") {
-            p.to_string()
-        } else if target_fqn == "::" {
-            format!("::{p}")
-        } else {
-            format!("{target_fqn}::{p}")
-        }
-    });
-    // Adapters return children in creation order. Rebuild the string-key hash
-    // table C stores them in, including its bucket-chain reversal at a resize,
-    // because Tcl_FirstHashEntry order is observable in this command's list.
-    let mut names: Vec<String> = Vec::new();
-    for child in ops.children(ns) {
-        names.push(ops.name(child));
-    }
-    let order = tcl_string_hash_order(&names);
-    names = order
-        .into_iter()
-        .map(|index| names[index].clone())
-        .collect();
-    names.retain(|n| qualified.as_deref().is_none_or(|p| string_match(p, n)));
-    let items: Vec<O::Value> = names.iter().map(|n| ops.new_str(n)).collect();
-    Ok(ops.new_list(items))
+    children_bytes(ops, name.map(str::as_bytes), pattern.map(str::as_bytes))
+        .map_err(|error| CmdError::new(String::from_utf8_lossy(&error.message()).into_owned()))
 }
 
 /// The enumeration order of Tcl's `TCL_STRING_KEYS` hash table after inserting
 /// `names` in the supplied order. Namespace child tables use the simple tail as
 /// their key, start at four buckets, and quadruple at a 3:1 load factor.
-fn tcl_string_hash_order<T: AsRef<str>>(names: &[T]) -> Vec<usize> {
+fn tcl_string_hash_order<T: AsRef<[u8]>>(names: &[T]) -> Vec<usize> {
     fn hash(bytes: &[u8]) -> usize {
         let mut iter = bytes.iter().copied();
         let mut result = usize::from(iter.next().unwrap_or(0));
@@ -490,7 +550,7 @@ fn tcl_string_hash_order<T: AsRef<str>>(names: &[T]) -> Vec<usize> {
     let mut buckets: Vec<Vec<usize>> = vec![Vec::new(); 4];
     let mut rebuild_size = 12usize;
     for (entry, name) in names.iter().enumerate() {
-        let key = tail(name.as_ref().as_bytes());
+        let key = tail(name.as_ref());
         let bucket = hash(key) & (buckets.len() - 1);
         buckets[bucket].insert(0, entry);
         if entry + 1 == rebuild_size {
@@ -498,7 +558,7 @@ fn tcl_string_hash_order<T: AsRef<str>>(names: &[T]) -> Vec<usize> {
             buckets = vec![Vec::new(); old.len() * 4];
             for chain in old {
                 for existing in chain {
-                    let key = tail(names[existing].as_ref().as_bytes());
+                    let key = tail(names[existing].as_ref());
                     let bucket = hash(key) & (buckets.len() - 1);
                     buckets[bucket].insert(0, existing);
                 }
@@ -512,16 +572,18 @@ fn tcl_string_hash_order<T: AsRef<str>>(names: &[T]) -> Vec<usize> {
 /// Resolve the optional `name` argument to a namespace handle: the current
 /// namespace when absent, else `name` resolved from it (erroring if it doesn't
 /// exist) — the shared first step of `namespace parent`/`children`.
-fn resolve_target<O: ValueOps + Namespaces>(
-    ops: &mut O,
-    name: Option<&str>,
-) -> Result<tcl_runtime_api::NsId, CmdError> {
+fn resolve_target_bytes<O: Namespaces + ?Sized>(
+    ops: &O,
+    name: Option<&[u8]>,
+) -> Result<tcl_runtime_api::NsId, NamespaceLookupError> {
     let cur = Namespaces::current(ops);
     match name {
         None => Ok(cur),
-        Some(n) => ops
-            .find_namespace(cur, n)
-            .ok_or_else(|| CmdError::new(format!("namespace \"{n}\" not found"))),
+        Some(name) => ops
+            .find_namespace_bytes(cur, name)
+            .ok_or_else(|| NamespaceLookupError {
+                name: name.to_vec(),
+            }),
     }
 }
 

--- a/rust/tcl-cmd-core/src/namespace.rs
+++ b/rust/tcl-cmd-core/src/namespace.rs
@@ -25,7 +25,7 @@
 //! `current`/`which` cores *do* read namespace state, so they are generic over
 //! the [`Namespaces`] role trait + [`ValueOps`].
 
-use tcl_runtime_api::Namespaces;
+use tcl_runtime_api::{Namespaces, NsId};
 use tcl_syntax::glob::string_match;
 use tcl_syntax::value::ValueOps;
 
@@ -137,6 +137,134 @@ pub fn imported_command_candidate(pattern: &str, name: &str) -> Option<String> {
         }
         Qualifier::Unqualified => (pattern_tail == name).then(|| name.to_owned()),
     }
+}
+
+/// What `namespace which` should resolve its name as.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WhichKind {
+    /// The default / `-command` form.
+    Command,
+    /// The `-variable` form.
+    Variable,
+}
+
+/// Parse the words after `namespace which` as C's `NamespaceWhichCmd` does.
+///
+/// One word is always the name, even when it starts with `-`. Two words are
+/// accepted only when the first is an unambiguous abbreviation of `-command`
+/// or `-variable`; every other shape is the command's wrong-arity path.
+#[must_use]
+pub fn which_request<T: AsRef<[u8]>>(args: &[T]) -> Option<(WhichKind, usize)> {
+    match args {
+        [_] => Some((WhichKind::Command, 0)),
+        [option, _] => {
+            let option = option.as_ref();
+            if option.len() > 1 && b"-command".starts_with(option) {
+                Some((WhichKind::Command, 1))
+            } else if option.len() > 1 && b"-variable".starts_with(option) {
+                Some((WhichKind::Variable, 1))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// A validated `namespace import` pattern: the source namespace and the glob
+/// tail matched against its exported command names.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportPattern {
+    /// The source namespace named by the pattern qualifier.
+    pub source: NsId,
+    /// The simple command-name glob after the qualifier.
+    pub tail: Vec<u8>,
+}
+
+/// Why a `namespace import` pattern cannot name a source namespace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportPatternError {
+    /// The whole pattern is empty.
+    Empty,
+    /// The pattern has no namespace qualifier.
+    Unqualified(Vec<u8>),
+    /// Its qualifier names no namespace.
+    Unknown(Vec<u8>),
+    /// Its qualifier resolves back to the importing namespace.
+    SelfImport {
+        /// The written pattern.
+        pattern: Vec<u8>,
+        /// The source namespace's simple name.
+        namespace: Vec<u8>,
+    },
+}
+
+impl ImportPatternError {
+    /// The exact Tcl error result bytes for this failure.
+    #[must_use]
+    pub fn message(&self) -> Vec<u8> {
+        match self {
+            Self::Empty => b"empty import pattern".to_vec(),
+            Self::Unqualified(pattern) => {
+                let mut message = b"no namespace specified in import pattern \"".to_vec();
+                message.extend_from_slice(pattern);
+                message.push(b'"');
+                message
+            }
+            Self::Unknown(pattern) => {
+                let mut message = b"unknown namespace in import pattern \"".to_vec();
+                message.extend_from_slice(pattern);
+                message.push(b'"');
+                message
+            }
+            Self::SelfImport { pattern, namespace } => {
+                let mut message = b"import pattern \"".to_vec();
+                message.extend_from_slice(pattern);
+                message.extend_from_slice(b"\" tries to import from namespace \"");
+                message.extend_from_slice(namespace);
+                message.extend_from_slice(b"\" into itself");
+                message
+            }
+        }
+    }
+}
+
+/// Resolve and validate one `namespace import` pattern against the namespace
+/// tree. This is C's `Tcl_Import` source-namespace gate, shared by both runtime
+/// adapters before either enumerates or binds commands.
+///
+/// # Errors
+/// Empty and unqualified patterns, unknown source namespaces, and self-imports
+/// receive their distinct Tcl diagnostics.
+pub fn import_pattern<O: Namespaces + ?Sized>(
+    ops: &O,
+    destination: NsId,
+    pattern: &[u8],
+) -> Result<ImportPattern, ImportPatternError> {
+    if pattern.is_empty() {
+        return Err(ImportPatternError::Empty);
+    }
+    let qualifier = match qualifier(pattern) {
+        Qualifier::Absolute(prefix) | Qualifier::Relative(prefix) => prefix,
+        Qualifier::Unqualified => {
+            return Err(ImportPatternError::Unqualified(pattern.to_vec()));
+        }
+    };
+    let source = ops
+        .find_namespace_bytes(destination, qualifier)
+        .ok_or_else(|| ImportPatternError::Unknown(pattern.to_vec()))?;
+    if source == destination {
+        let source_name = ops.name_bytes(source);
+        let simple = tail(&source_name);
+        return Err(ImportPatternError::SelfImport {
+            pattern: pattern.to_vec(),
+            namespace: simple.to_vec(),
+        });
+    }
+    Ok(ImportPattern {
+        source,
+        tail: tail(pattern).to_vec(),
+    })
 }
 
 /// `namespace current` — the fully-qualified name of the current namespace
@@ -304,7 +432,8 @@ pub fn parent<O: ValueOps + Namespaces>(
 }
 
 /// `namespace children ?name? ?pattern?` — the FQNs of the (named, or current)
-/// namespace's child namespaces, glob-filtered and sorted. A pattern without a
+/// namespace's child namespaces, glob-filtered in C's hash-table iteration
+/// order. A pattern without a
 /// leading `::` is qualified with the target namespace's FQN first (C's
 /// `NamespaceChildrenCmd`).
 ///
@@ -326,15 +455,58 @@ pub fn children<O: ValueOps + Namespaces>(
             format!("{target_fqn}::{p}")
         }
     });
-    // Collect child FQNs (the ids are owned, so the `name` lookups don't alias).
+    // Adapters return children in creation order. Rebuild the string-key hash
+    // table C stores them in, including its bucket-chain reversal at a resize,
+    // because Tcl_FirstHashEntry order is observable in this command's list.
     let mut names: Vec<String> = Vec::new();
     for child in ops.children(ns) {
         names.push(ops.name(child));
     }
+    let order = tcl_string_hash_order(&names);
+    names = order
+        .into_iter()
+        .map(|index| names[index].clone())
+        .collect();
     names.retain(|n| qualified.as_deref().is_none_or(|p| string_match(p, n)));
-    names.sort();
     let items: Vec<O::Value> = names.iter().map(|n| ops.new_str(n)).collect();
     Ok(ops.new_list(items))
+}
+
+/// The enumeration order of Tcl's `TCL_STRING_KEYS` hash table after inserting
+/// `names` in the supplied order. Namespace child tables use the simple tail as
+/// their key, start at four buckets, and quadruple at a 3:1 load factor.
+fn tcl_string_hash_order<T: AsRef<str>>(names: &[T]) -> Vec<usize> {
+    fn hash(bytes: &[u8]) -> usize {
+        let mut iter = bytes.iter().copied();
+        let mut result = usize::from(iter.next().unwrap_or(0));
+        for byte in iter {
+            result = result
+                .wrapping_add(result.wrapping_shl(3))
+                .wrapping_add(usize::from(byte));
+        }
+        result
+    }
+
+    let mut buckets: Vec<Vec<usize>> = vec![Vec::new(); 4];
+    let mut rebuild_size = 12usize;
+    for (entry, name) in names.iter().enumerate() {
+        let key = tail(name.as_ref().as_bytes());
+        let bucket = hash(key) & (buckets.len() - 1);
+        buckets[bucket].insert(0, entry);
+        if entry + 1 == rebuild_size {
+            let old = std::mem::take(&mut buckets);
+            buckets = vec![Vec::new(); old.len() * 4];
+            for chain in old {
+                for existing in chain {
+                    let key = tail(names[existing].as_ref().as_bytes());
+                    let bucket = hash(key) & (buckets.len() - 1);
+                    buckets[bucket].insert(0, existing);
+                }
+            }
+            rebuild_size *= 4;
+        }
+    }
+    buckets.into_iter().flatten().collect()
 }
 
 /// Resolve the optional `name` argument to a namespace handle: the current
@@ -403,5 +575,57 @@ mod tests {
             Some("::foo::".to_owned())
         );
         assert_eq!(imported_command_candidate("::src::im*", "other"), None);
+    }
+
+    #[test]
+    fn which_request_matches_namespace_whichs_positional_option_rule() {
+        assert_eq!(which_request(&["puts"]), Some((WhichKind::Command, 0)));
+        assert_eq!(which_request(&["-command"]), Some((WhichKind::Command, 0)));
+        assert_eq!(
+            which_request(&["-com", "puts"]),
+            Some((WhichKind::Command, 1))
+        );
+        assert_eq!(
+            which_request(&["-var", "name"]),
+            Some((WhichKind::Variable, 1))
+        );
+        assert_eq!(which_request::<&str>(&[]), None);
+        assert_eq!(which_request(&["-zork", "puts"]), None);
+        assert_eq!(which_request(&["-command", "-variable", "puts"]), None);
+    }
+
+    #[test]
+    fn tcl_string_hash_order_matches_namespace_children_oracle() {
+        let names = [
+            "::order::one",
+            "::order::two",
+            "::order::three",
+            "::order::four",
+            "::order::five",
+            "::order::six",
+            "::order::seven",
+            "::order::eight",
+            "::order::nine",
+            "::order::ten",
+        ];
+        let actual: Vec<_> = tcl_string_hash_order(&names)
+            .into_iter()
+            .map(|index| names[index])
+            .collect();
+        assert_eq!(
+            actual,
+            [
+                "::order::six",
+                "::order::four",
+                "::order::three",
+                "::order::eight",
+                "::order::seven",
+                "::order::nine",
+                "::order::five",
+                "::order::two",
+                "::order::one",
+                "::order::ten",
+            ]
+        );
     }
 }

--- a/rust/tcl-registry/src/commands/tcl/namespace_.rs
+++ b/rust/tcl-registry/src/commands/tcl/namespace_.rs
@@ -1061,7 +1061,7 @@ static SUBCOMMANDS: &[SubCommand] = &[
         traits: Traits::REFLECTS_COMMAND_NAMES,
         arity: Arity::exact(1),
         detail: "Returns the fully-qualified name of the original command.",
-        synopsis: "namespace origin command",
+        synopsis: "namespace origin name",
         pure: true,
         return_type: Some(TclType::String),
         // The single argument is a command name resolved (not called), so it

--- a/rust/tcl-runtime-api/src/lib.rs
+++ b/rust/tcl-runtime-api/src/lib.rs
@@ -255,7 +255,9 @@ pub trait Namespaces {
     fn find_namespace(&self, cxt: NsId, name: &str) -> Option<NsId>;
     /// The handle of `ns`'s parent (`parentPtr`), or `None` for the global root.
     fn parent(&self, ns: NsId) -> Option<NsId>;
-    /// The handles of `ns`'s direct child namespaces (`childTable`).
+    /// The handles of `ns`'s direct child namespaces (`childTable`) in creation
+    /// order. The shared command core reconstructs Tcl's observable string-hash
+    /// enumeration order from this stable insertion order.
     fn children(&self, ns: NsId) -> Vec<NsId>;
 
     // -- command enumeration (a namespace's `cmdTable`; backs `info commands`/

--- a/rust/tcl-syntax/src/glob.rs
+++ b/rust/tcl-syntax/src/glob.rs
@@ -37,6 +37,22 @@ pub fn string_match(pattern: &str, text: &str) -> bool {
     string_case_match(pattern, text, false)
 }
 
+/// Tcl `string match` over byte-valued strings.
+///
+/// Valid UTF-8 retains the ordinary Unicode-scalar semantics. An embedder can
+/// also supply an invalid-UTF-8 plain string; that is outside Tcl's normal
+/// script-created string representation, so the runtime's established policy
+/// is deliberately narrow and collision-free: such a pattern/text pair matches
+/// only when its bytes are identical. In particular, a valid `*` does not
+/// reinterpret an invalid byte string through replacement characters.
+#[must_use]
+pub fn string_match_bytes(pattern: &[u8], text: &[u8]) -> bool {
+    match (core::str::from_utf8(pattern), core::str::from_utf8(text)) {
+        (Ok(pattern), Ok(text)) => string_match(pattern, text),
+        _ => pattern == text,
+    }
+}
+
 /// Whether `pattern` contains no glob metacharacter, so
 /// [`string_match(pattern, text)`](string_match) is exactly `pattern == text`.
 ///
@@ -378,6 +394,14 @@ mod tests {
             assert!(string_match(pattern, other), "{pattern:?} vs {other:?}");
             assert_ne!(pattern, other);
         }
+    }
+
+    #[test]
+    fn byte_match_preserves_invalid_utf8_identity() {
+        assert!(string_match_bytes(b"plain*", b"plaintext"));
+        assert!(string_match_bytes(b"raw\xff", b"raw\xff"));
+        assert!(!string_match_bytes(b"raw\xff", b"raw\xfe"));
+        assert!(!string_match_bytes(b"*", b"raw\xff"));
     }
 
     #[test]

--- a/rust/tcl-vm/src/cmd_namespace.rs
+++ b/rust/tcl-vm/src/cmd_namespace.rs
@@ -166,17 +166,14 @@ fn cmd_namespace(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             // Default (and `-command`) resolves a command via the shared
             // `Namespaces` core; `-variable` (or an unambiguous prefix) resolves
             // a *variable* and returns its qualified name if it exists, else "".
-            // The name is the last word regardless of the flag.
-            let want_var = rest
-                .first()
-                .map(|v| v.to_str().to_string())
-                .filter(|_| rest.len() >= 2)
-                .is_some_and(|f| f.len() >= 2 && "-variable".starts_with(f.as_str()));
-            let name = rest
-                .last()
-                .map(|v| v.to_str().to_string())
-                .unwrap_or_default();
-            if want_var {
+            let words: Vec<_> = rest.iter().map(|word| word.to_str().to_string()).collect();
+            let Some((kind, name_index)) = tcl_cmd_core::namespace::which_request(&words) else {
+                return err(
+                    "wrong # args: should be \"namespace which ?-command? ?-variable? name\"",
+                );
+            };
+            let name = words[name_index].clone();
+            if kind == tcl_cmd_core::namespace::WhichKind::Variable {
                 // `Tcl_FindNamespaceVar` semantics via the shared core: the
                 // namespace variable tables only, never the call frame (the VM
                 // used to gate on `exists_var`, which walks proc locals).
@@ -186,7 +183,11 @@ fn cmd_namespace(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             }
         }
         "origin" => {
-            // `namespace origin command` → the original command's fully-qualified
+            let argument_count = u16::try_from(rest.len()).unwrap_or(u16::MAX);
+            if !subcommand.arity.accepts(argument_count) {
+                return err(tcl_cmd_core::CmdError::wrong_args(subcommand.synopsis).into_message());
+            }
+            // `namespace origin name` → the original command's fully-qualified
             // name (following imports) via the shared `TclGetOriginalCommand`
             // walk.  Visibility is checked before exposing the provenance: an
             // import of a builtin absent from this emulated release is no more
@@ -420,15 +421,11 @@ fn ns_import(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
         first_word = words.next();
     }
     for pattern in first_word.into_iter().chain(words) {
-        if pattern.is_empty() {
-            return err("empty import pattern");
-        }
-        // A pattern with no qualifier would import from the importing
-        // namespace itself; C reports that as a missing source namespace.
-        if !tcl_syntax::naming::is_qualified(pattern.as_bytes()) {
-            return err(format!(
-                "no namespace specified in import pattern \"{pattern}\""
-            ));
+        let destination = tcl_runtime_api::Namespaces::current(vm);
+        if let Err(problem) =
+            tcl_cmd_core::namespace::import_pattern(vm, destination, pattern.as_bytes())
+        {
+            return err(String::from_utf8_lossy(&problem.message()).into_owned());
         }
         vm.import_commands(&pattern);
     }
@@ -504,16 +501,15 @@ fn apply_shared_option(
     opts: &mut EnsembleOptions,
     which: tcl_cmd_core::ensemble::SharedOption,
     val: &Value,
-    vm: &Vm,
-) -> Result<(), String> {
+    vm: &mut Vm,
+) -> Result<(), Completion<Value>> {
     use tcl_cmd_core::ensemble::SharedOption;
     match which {
         SharedOption::Map => {
-            let elems = val.as_list().map_err(|e| e.message)?;
-            let mut it = elems.iter();
-            opts.map.clear();
-            while let (Some(k), Some(v)) = (it.next(), it.next()) {
-                let mut prefix = v.as_list().map_or_else(|_| vec![v.clone()], |l| l.to_vec());
+            let pairs = vm.dict_pairs(val)?;
+            let mut map = Vec::with_capacity(pairs.len());
+            for (key, value) in pairs {
+                let mut prefix = value.as_list().map_err(|e| err(e.message))?.to_vec();
                 // C qualifies the target at *parse* time, so the qualified
                 // name is what the ensemble stores, what dispatch calls, and
                 // what `-map` reads back — a target left raw would be looked
@@ -528,27 +524,26 @@ fn apply_shared_option(
                 // Dict semantics for a repeated key: the last value wins but
                 // keeps the first occurrence's position, so `-map` reads back
                 // in the order the keys first appeared.
-                let key = k.to_str().to_string();
-                match opts.map.iter_mut().find(|(existing, _)| *existing == key) {
-                    Some((_, slot)) => *slot = prefix,
-                    None => opts.map.push((key, prefix)),
-                }
+                map.push((key, prefix));
             }
+            tcl_cmd_core::ensemble::validate_map_targets(&map)
+                .map_err(|e| err(e.into_message()))?;
+            opts.map = map;
         }
         SharedOption::Subcommands => {
-            let elems = val.as_list().map_err(|e| e.message)?;
+            let elems = val.as_list().map_err(|e| err(e.message))?;
             opts.subcommands =
                 (!elems.is_empty()).then(|| elems.iter().map(|v| v.to_str().to_string()).collect());
         }
         SharedOption::Parameters => {
-            let elems = val.as_list().map_err(|e| e.message)?;
+            let elems = val.as_list().map_err(|e| err(e.message))?;
             opts.parameters = elems.iter().map(|v| v.to_str().to_string()).collect();
         }
         SharedOption::Prefixes => {
-            opts.prefixes = val.as_bool().map_err(|e| e.message)?;
+            opts.prefixes = val.as_bool().map_err(|e| err(e.message))?;
         }
         SharedOption::Unknown => {
-            let elems = val.as_list().map_err(|e| e.message)?;
+            let elems = val.as_list().map_err(|e| err(e.message))?;
             opts.unknown = (!elems.is_empty()).then(|| elems.to_vec());
         }
     }
@@ -588,8 +583,8 @@ fn ns_ensemble_create(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             command = Some(pair[1].to_str().to_string());
             continue;
         };
-        if let Err(message) = apply_shared_option(&mut opts, shared, &pair[1], vm) {
-            return err(message);
+        if let Err(completion) = apply_shared_option(&mut opts, shared, &pair[1], vm) {
+            return completion;
         }
     }
     // The default command is the namespace itself; an explicit -command binds in
@@ -680,8 +675,8 @@ fn ns_ensemble_configure(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         let Some(shared) = resolved.shared() else {
             return err("option -namespace is read-only");
         };
-        if let Err(message) = apply_shared_option(&mut opts, shared, &pair[1], vm) {
-            return err(message);
+        if let Err(completion) = apply_shared_option(&mut opts, shared, &pair[1], vm) {
+            return completion;
         }
     }
     let updated =

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -2123,6 +2123,7 @@ pub(crate) fn cmd_variable(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
                 "TCL UPVAR LOCAL_ELEMENT",
             );
         }
+        vm.declare_namespace_variable(&qual);
         vm.add_link(&local, 0, &qual);
         if i + 1 < args.len() {
             // `set_var` follows the alias just installed to the real cell.

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -575,25 +575,23 @@ fn dict_from_pairs(ps: &[(String, Value)]) -> Value {
 /// missing key — are returned untouched, so they keep the `errorCode` their own
 /// rules give them.
 pub(crate) fn dict_parse_err(message: &str) -> Completion<Value> {
-    let (msg, code) = if let Some(rest) = message.strip_prefix("list element in ") {
-        (
-            format!("dict element in {rest}"),
-            "TCL VALUE DICTIONARY JUNK",
-        )
-    } else if message == "unmatched open brace in list" {
+    let worded = tcl_cmd_core::dict::worded_parse_error(message);
+    let (msg, code) = if worded.starts_with("dict element in ") {
+        (worded, "TCL VALUE DICTIONARY JUNK")
+    } else if worded == "unmatched open brace in dict" {
         (
             "unmatched open brace in dict".to_owned(),
             "TCL VALUE DICTIONARY BRACE",
         )
-    } else if message == "unmatched open quote in list" {
+    } else if worded == "unmatched open quote in dict" {
         (
             "unmatched open quote in dict".to_owned(),
             "TCL VALUE DICTIONARY QUOTE",
         )
-    } else if message == "missing value to go with key" {
-        (message.to_owned(), "TCL VALUE DICTIONARY")
+    } else if worded == "missing value to go with key" {
+        (worded, "TCL VALUE DICTIONARY")
     } else {
-        return err(message.to_owned());
+        return err(worded);
     };
     crate::command::err_with_code(msg, code)
 }

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -5643,7 +5643,7 @@ impl Vm {
     ) -> Result<(), UpvarLinkError> {
         let (other_base, other_key) =
             elem_ref(other).map_or((other, None), |(base, key)| (base, Some(key)));
-        if !self.var_parent_exists(other_base) {
+        if !self.var_parent_exists_from(target_level, other_base) {
             return Err(UpvarLinkError::TargetNamespace);
         }
 
@@ -5726,10 +5726,20 @@ impl Vm {
     /// collapses colon runs (`a:::b` → `a::b`) and preserves a trailing run as
     /// the empty variable name (`foo:::` → `foo::`).
     fn canonical_var_name(&self, name: &str) -> String {
+        self.canonical_var_name_from(name, self.current_level())
+    }
+
+    /// Canonicalise a written variable name in the namespace belonging to
+    /// explicit frame `level`. This is the frame-addressed half of the shared
+    /// variable resolver: `upvar 1 rel::x` resolves `rel` in the caller's
+    /// namespace, not the active callee's, and the same rule reaches scalar and
+    /// array-element storage through [`Self::locate_from`].
+    fn canonical_var_name_from(&self, name: &str, level: usize) -> String {
         if !tcl_syntax::naming::is_qualified(name.as_bytes()) {
             return name.to_owned();
         }
-        tcl_syntax::naming::qualify(self.current_ns(), name)
+        let namespace = self.ns_stack.get(level).map_or("", String::as_str);
+        tcl_syntax::naming::qualify(namespace, name)
     }
 
     /// Validate the namespace portion of a qualified variable write.  Tcl's
@@ -5753,11 +5763,19 @@ impl Vm {
     /// Whether the parent namespace of a variable base exists. Element syntax
     /// is removed before qualification, so `v(x::y)` keeps `::` as key data.
     pub(crate) fn var_parent_exists(&self, name: &str) -> bool {
+        self.var_parent_exists_from(self.current_level(), name)
+    }
+
+    /// [`Self::var_parent_exists`] in the namespace context of explicit frame
+    /// `level`. Target validation and target lookup must use the same context;
+    /// otherwise `upvar` can validate one namespace and install a link into
+    /// another.
+    fn var_parent_exists_from(&self, level: usize, name: &str) -> bool {
         let base = tcl_syntax::naming::split_element_ref(name).map_or(name, |(base, _)| base);
         if !tcl_syntax::naming::is_qualified(base.as_bytes()) {
             return true;
         }
-        let rooted = self.canonical_var_name(base);
+        let rooted = self.canonical_var_name_from(base, level);
         let (parent, _) = tcl_syntax::naming::key_holder_and_tail(&rooted);
         self.namespace_exists(parent.strip_prefix("::").unwrap_or(parent))
     }
@@ -5767,7 +5785,7 @@ impl Vm {
     /// are canonicalised once at this boundary; link targets are already
     /// internal keys and must not be qualified again.
     fn locate_from(&self, name: &str, start: usize) -> (usize, String) {
-        let canonical = self.canonical_var_name(name);
+        let canonical = self.canonical_var_name_from(name, start);
         let stripped = canonical.strip_prefix("::").unwrap_or(&canonical);
         let qualified = tcl_syntax::naming::is_qualified(canonical.as_bytes());
         let level = if qualified { 0 } else { start };

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -45,7 +45,7 @@ use tcl_runtime_api::{
 };
 use tcl_syntax::expr::{eval, parse_expr};
 
-use crate::command::{BuiltinFn, Command, EnsembleDef, ProcDef, register_builtins};
+use crate::command::{BuiltinFn, Command, EnsembleDef, ProcDef, err_with_code, register_builtins};
 use crate::error::TclError;
 use crate::expr::ExprEval;
 use crate::frame::{CallFrame, Local};
@@ -3456,46 +3456,69 @@ impl Vm {
         let params = &argv[..nparams];
         let sub = argv[nparams].to_str().to_string();
         let rest = &argv[nparams + 1..];
-        let mut subs: Vec<String> = match &e.subcommands {
-            Some(list) => list.clone(),
-            None => self.exported_command_tails(&e.namespace),
-        };
-        for (k, _) in &e.map {
-            if !subs.contains(k) {
-                subs.push(k.clone());
+        let mut reparsed = false;
+        loop {
+            let mut subs: Vec<String> = match &e.subcommands {
+                Some(list) => list.clone(),
+                None => self.exported_command_tails(&e.namespace),
+            };
+            for (key, _) in &e.map {
+                if !subs.contains(key) {
+                    subs.push(key.clone());
+                }
             }
-        }
-        subs.sort();
-        subs.dedup();
-        match tcl_cmd_core::ensemble::resolve_subcommand(&subs, sub.as_bytes(), e.prefixes) {
-            Some(index) => {
+            subs.sort();
+            subs.dedup();
+            if let Some(index) =
+                tcl_cmd_core::ensemble::resolve_subcommand(&subs, sub.as_bytes(), e.prefixes)
+            {
                 let resolved = &subs[index];
-                let mut full: Vec<Value> = match e
-                    .map
-                    .iter()
-                    .find(|(k, _)| k == resolved)
-                    .map(|(_, words)| words)
-                {
-                    Some(words) => words.clone(),
-                    None => vec![Value::string(if e.namespace.is_empty() {
-                        resolved.clone()
-                    } else {
-                        format!("{}::{resolved}", e.namespace)
-                    })],
-                };
+                let mapped = e.map.iter().find(|(key, _)| key == resolved);
+                let mut full: Vec<Value> = mapped.map_or_else(
+                    || {
+                        vec![Value::string(if e.namespace.is_empty() {
+                            format!("::{resolved}")
+                        } else {
+                            format!("::{}::{resolved}", e.namespace)
+                        })]
+                    },
+                    |(_, words)| words.clone(),
+                );
                 full.extend_from_slice(params);
                 full.extend_from_slice(rest);
                 let target = full[0].to_str().to_string();
-                self.invoke_command(&target, &full[1..])
+                let target_was_missing = mapped.is_none()
+                    && self
+                        .resolve_command_fqn(self.current_ns(), &target)
+                        .is_none();
+                let completion = self.invoke_command(&target, &full[1..]);
+                if target_was_missing
+                    && completion.code == Code::Error
+                    && completion.result.to_str().as_ref()
+                        == format!("invalid command name \"{target}\"")
+                {
+                    return err_with_code(
+                        format!("invalid command name \"{resolved}\""),
+                        &format!("TCL LOOKUP COMMAND {resolved}"),
+                    );
+                }
+                return completion;
             }
-            None if e.unknown.is_some() => {
-                let mut full = e.unknown.clone().unwrap_or_default();
-                full.push(Value::string(ens_name));
-                full.extend_from_slice(argv);
-                let target = full[0].to_str().to_string();
-                self.invoke_command(&target, &full[1..])
+            if let Some(handler) = &e.unknown
+                && !reparsed
+            {
+                reparsed = true;
+                let mut replacement = match self.ensemble_unknown(ens_name, handler, argv) {
+                    Ok(Some(prefix)) => prefix,
+                    Ok(None) => continue,
+                    Err(completion) => return completion,
+                };
+                replacement.extend_from_slice(params);
+                replacement.extend_from_slice(rest);
+                let target = replacement[0].to_str().to_string();
+                return self.invoke_command(&target, &replacement[1..]);
             }
-            None => err(String::from_utf8_lossy(
+            return err(String::from_utf8_lossy(
                 &tcl_cmd_core::ensemble::unknown_subcommand_message(
                     &subs,
                     sub.as_bytes(),
@@ -3503,8 +3526,36 @@ impl Vm {
                     display_namespace(&e.namespace).as_bytes(),
                 ),
             )
-            .into_owned()),
+            .into_owned());
         }
+    }
+
+    /// Invoke an ensemble's `-unknown` prefix. A successful empty list asks the
+    /// caller to reparse once; a non-empty list is its replacement command
+    /// prefix. The handler sees the ensemble's fully-qualified command name.
+    fn ensemble_unknown(
+        &mut self,
+        ens_name: &str,
+        handler: &[Value],
+        argv: &[Value],
+    ) -> Result<Option<Vec<Value>>, Completion<Value>> {
+        let mut full = handler.to_vec();
+        let ensemble_fqn = self
+            .resolve_command_fqn(self.current_ns(), ens_name)
+            .map_or_else(|| ens_name.to_owned(), |key| display_namespace(&key));
+        full.push(Value::string(ensemble_fqn));
+        full.extend_from_slice(argv);
+        let target = full[0].to_str().to_string();
+        let completion = self.invoke_command(&target, &full[1..]);
+        if !completion.code.is_ok() {
+            return Err(completion);
+        }
+        let prefix = completion
+            .result
+            .as_list()
+            .map_err(|problem| err(problem.message))?
+            .to_vec();
+        Ok((!prefix.is_empty()).then_some(prefix))
     }
 
     /// Dispatch a child-as-command call (`$child sub ?arg …?`): the `interp`
@@ -4389,17 +4440,25 @@ impl Vm {
     /// Delete namespace `canonical` (no leading `::`) and every descendant,
     /// removing their commands/procs, namespace variables, export patterns, and
     /// interned ids. Returns `false` (deleting nothing) when the namespace does
-    /// not exist — the caller reports `unknown namespace`. The global namespace
-    /// (`""`) is never deletable.
+    /// not exist — the caller reports `unknown namespace`. Deleting the global
+    /// namespace tears down its full tree but leaves the root handle available
+    /// for the active command to return through, matching `namespace delete ::`.
     pub(crate) fn delete_namespace(&mut self, canonical: &str) -> bool {
         // Callers pass the canonical form; still normalise separator runs so
         // `namespace delete a:::b` removes `a::b` (tclsh8.6-verified).
         let canonical: &str = &canonical_ns_name(canonical);
-        if canonical.is_empty() || !self.namespaces.contains(canonical) {
+        let deleting_root = canonical.is_empty();
+        if !deleting_root && !self.namespaces.contains(canonical) {
             return false;
         }
-        let prefix = format!("{canonical}::");
-        let in_tree = |k: &str| k == canonical || k.starts_with(&prefix);
+        let prefix = (!deleting_root).then(|| format!("{canonical}::"));
+        let in_tree = |key: &str| {
+            deleting_root
+                || key == canonical
+                || prefix
+                    .as_deref()
+                    .is_some_and(|prefix| key.starts_with(prefix))
+        };
         // C deletes the namespace's ensembles *first* (`Tcl_DeleteNamespace`,
         // `tclNamesp.c:944-959`: `while (nsPtr->ensembles != NULL)` →
         // `Tcl_DeleteCommandFromToken`). An ensemble command is owned by the
@@ -4414,7 +4473,10 @@ impl Vm {
             .commands
             .iter()
             .filter(|(key, command)| {
-                key.starts_with(&prefix)
+                deleting_root
+                    || prefix
+                        .as_deref()
+                        .is_some_and(|prefix| key.starts_with(prefix))
                     || matches!(command, Command::Ensemble(def) if in_tree(&def.namespace))
             })
             .map(|(key, _)| key.clone())
@@ -4433,11 +4495,19 @@ impl Vm {
         self.builtin_identities
             .retain(|k, _| !removed_commands.contains(k));
         if let Some(g) = self.frames.first_mut() {
-            g.locals.retain(|k, _| !k.starts_with(&prefix));
+            g.locals.retain(|key, _| {
+                !deleting_root
+                    && prefix
+                        .as_deref()
+                        .is_none_or(|prefix| !key.starts_with(prefix))
+            });
         }
         self.namespaces.retain(|n| !in_tree(n));
         self.ns_exports.retain(|k, _| !in_tree(k));
         self.ns_intern.retain(|k, _| !in_tree(k));
+        if deleting_root {
+            self.ns_intern.insert(String::new(), ROOT_NS);
+        }
         // `TclTeardownNamespace` resets the namespace's own parameters
         // (`tclNamesp.c:1148-1165`): it drops its `namespace path`
         // (`UnlinkNsPath`), frees its `namespace unknown` handler, and then
@@ -4461,14 +4531,17 @@ impl Vm {
         } else {
             format!("{parent}::")
         };
-        self.namespaces
+        let mut children: Vec<(u32, String)> = self
+            .namespaces
             .iter()
             .filter(|ns| {
                 ns.strip_prefix(&prefix)
                     .is_some_and(|rest| !rest.is_empty() && !rest.contains("::"))
             })
-            .cloned()
-            .collect()
+            .filter_map(|name| self.ns_intern.get(name).map(|id| (id.0, name.clone())))
+            .collect();
+        children.sort_by_key(|(id, _)| *id);
+        children.into_iter().map(|(_, name)| name).collect()
     }
 
     /// Record a provided package version.
@@ -5496,8 +5569,11 @@ impl Vm {
                 // A namespace-scoped `Link` is a real cell in the namespace's
                 // table — see `namespace_var_exists` for why C's
                 // `CompiledLocal` exclusion does not apply to it.
-                .filter(|(_, l)| {
-                    matches!(l, Local::Scalar(_) | Local::Array(_) | Local::Link { .. })
+                .filter(|(_, local)| {
+                    matches!(
+                        local,
+                        Local::Undefined | Local::Scalar(_) | Local::Array(_) | Local::Link { .. }
+                    )
                 })
                 .filter_map(|(key, _)| direct_member_tail(key, canonical).map(str::to_owned))
                 .collect()
@@ -5521,6 +5597,19 @@ impl Vm {
                     name: target.to_owned(),
                 },
             );
+        }
+    }
+
+    /// Materialise an unset namespace-variable cell in the global storage
+    /// frame. `variable name` creates this table entry even without assigning a
+    /// value: namespace introspection sees it while `info exists` remains false.
+    pub(crate) fn declare_namespace_variable(&mut self, key: &str) {
+        let key = key.strip_prefix("::").unwrap_or(key);
+        if let Some(global) = self.frames.first_mut() {
+            global
+                .locals
+                .entry(key.to_owned())
+                .or_insert(Local::Undefined);
         }
     }
 
@@ -6947,7 +7036,6 @@ impl Namespaces for Vm {
     // here regardless, because this only ever probes `frames.first()` — the
     // global frame — and a proc's locals live in its own frame.
     //
-    // `Undefined` stays excluded: that is a materialised-but-unset cell.
     fn namespace_var_exists(&self, ns: NsId, simple: &str) -> bool {
         let canonical = self.ns_name(ns);
         let key = if canonical.is_empty() {
@@ -6958,7 +7046,7 @@ impl Namespaces for Vm {
         self.frames.first().is_some_and(|frame| {
             matches!(
                 frame.locals.get(&key),
-                Some(Local::Scalar(_) | Local::Array(_) | Local::Link { .. })
+                Some(Local::Undefined | Local::Scalar(_) | Local::Array(_) | Local::Link { .. })
             )
         })
     }

--- a/rust/tcl-vm/tests/namespace_surface_e2e.rs
+++ b/rust/tcl-vm/tests/namespace_surface_e2e.rs
@@ -17,7 +17,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 //! `namespace` command-surface regression vectors (issues #1442, #1446,
-//! #1451, #1453, #1463).
+//! #1451, #1453, #1463, #1583, #1584).
 //!
 //! Every expectation is pinned byte-for-byte against tclsh 8.6.16 *and*
 //! tclsh 9.0.4 unless a `9.0:` comment records a deliberate release
@@ -193,6 +193,30 @@ fn which_variable_global_fallback_is_a_release_axis() {
 }
 
 #[test]
+fn declared_but_unset_namespace_variables_are_introspectable() {
+    // Tcl 9.0.4: `variable only` materialises an unset varTable cell. Both
+    // namespace introspection surfaces see it; `info exists` still says 0.
+    assert_eq!(
+        run("namespace eval declared {variable only
+             list [namespace which -variable only] [info vars] [info exists only]}"),
+        "::declared::only only 0"
+    );
+}
+
+#[test]
+fn namespace_which_validates_its_positional_option_shape() {
+    let usage = "wrong # args: should be \"namespace which ?-command? ?-variable? name\"";
+    assert_eq!(run("catch {namespace which -zork puts} m; set m"), usage);
+    assert_eq!(
+        run("catch {namespace which -command puts extra} m; set m"),
+        usage
+    );
+    // With one word there is no option position: even an option-looking word
+    // is the command name, and an unresolved command produces the empty value.
+    assert_eq!(run("namespace which -command"), "");
+}
+
+#[test]
 fn origin_follows_import_chains() {
     // tclsh 8.6.16 / 9.0.4 (`NamespaceOriginCmd` → `TclGetOriginalCommand`).
     assert_eq!(
@@ -360,6 +384,18 @@ fn only_the_first_word_is_the_import_flag() {
     );
 }
 
+#[test]
+fn namespace_import_rejects_self_and_unknown_sources() {
+    assert_eq!(
+        run("namespace eval self {catch {namespace import ::self::*} m; set m}"),
+        "import pattern \"::self::*\" tries to import from namespace \"self\" into itself"
+    );
+    assert_eq!(
+        run("namespace eval dest {catch {namespace import ::nosuch::*} m; set m}"),
+        "unknown namespace in import pattern \"::nosuch::*\""
+    );
+}
+
 // #1451 — namespace teardown (`TclTeardownNamespace`, tclNamesp.c:1084)
 
 #[test]
@@ -464,6 +500,42 @@ fn namespace_path_checks_that_every_entry_exists() {
              namespace eval o {namespace path ::a; catch {namespace path {::a ::nope}}\n\
              namespace path}"),
         "::a"
+    );
+}
+
+#[test]
+fn namespace_delete_accepts_the_global_root() {
+    // Tcl 9.0.4 accepts the command and tears down the tree.
+    assert_eq!(run("namespace delete ::"), "");
+    assert_eq!(
+        run("namespace delete ::
+             puts hi"),
+        "invalid command name \"puts\""
+    );
+}
+
+#[test]
+fn namespace_origin_reports_its_own_usage_for_both_bad_arities() {
+    let usage = "wrong # args: should be \"namespace origin name\"";
+    assert_eq!(run("catch {namespace origin} m; set m"), usage);
+    assert_eq!(run("catch {namespace origin set extra} m; set m"), usage);
+}
+
+#[test]
+fn namespace_children_matches_tcls_string_hash_iteration_order() {
+    let setup = "namespace eval order {}
+                 foreach n {one two three four five six seven eight nine ten} {
+                     namespace eval ::order::$n {}
+                 }\n";
+    assert_eq!(
+        run(&format!("{setup}namespace children ::order")),
+        "::order::six ::order::four ::order::three ::order::eight \
+         ::order::seven ::order::nine ::order::five ::order::two \
+         ::order::one ::order::ten"
+    );
+    assert_eq!(
+        run(&format!("{setup}namespace children ::order ::order::t*")),
+        "::order::three ::order::two ::order::ten"
     );
 }
 
@@ -817,6 +889,57 @@ fn ensemble_subcommand_scan_matches_c_on_the_empty_word() {
              catch {::ab5 {}} m; set m"
         ),
         "unknown subcommand \"\": must be go"
+    );
+}
+
+#[test]
+fn ensemble_map_validation_matches_tcl_dict_and_target_errors() {
+    assert_eq!(
+        run("catch {namespace ensemble create -map {go}} m; set m"),
+        "missing value to go with key"
+    );
+    assert_eq!(
+        run("catch {namespace ensemble create -map {go {}}} m; set m"),
+        "ensemble subcommand implementations must be non-empty lists"
+    );
+    assert_eq!(
+        run("set badmap \"go \\{\"
+             catch {namespace ensemble create -map $badmap} m; set m"),
+        "unmatched open brace in dict"
+    );
+}
+
+#[test]
+fn ensemble_unknown_result_is_redispatched_as_a_command_prefix() {
+    assert_eq!(
+        run("proc uh {ens args} {return [list list REPLACED $ens]}
+             namespace eval se5 {
+                 namespace ensemble create -command ::se5 -subcommands {} -unknown ::uh
+             }
+             ::se5 nope 1 2"),
+        "REPLACED ::se5 1 2"
+    );
+    // An empty successful result requests one reparse, so a command exported
+    // by the callback becomes visible to the same ensemble invocation.
+    assert_eq!(
+        run("proc define {ens args} {
+                 namespace eval se6 {proc nope args {return DEFINED}; namespace export nope}
+                 return {}
+             }
+             namespace eval se6 {namespace ensemble create -command ::se6 -unknown ::define}
+             ::se6 nope"),
+        "DEFINED"
+    );
+}
+
+#[test]
+fn ensemble_default_target_miss_names_the_rewritten_subcommand() {
+    assert_eq!(
+        run(
+            "namespace eval k1 {namespace ensemble create -subcommands ghost}
+             catch {::k1 ghost} m; set m"
+        ),
+        "invalid command name \"ghost\""
     );
 }
 

--- a/rust/tcl-vm/tests/variable_name_resolution_e2e.rs
+++ b/rust/tcl-vm/tests/variable_name_resolution_e2e.rs
@@ -16,7 +16,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! Variable-name resolution on the compiled path — issues #1602, #1616, #1578.
+//! Variable-name resolution on the compiled path — issues #1602, #1616, #1578,
+//! #1745.
 //!
 //! One rule underlies the first two: **a variable name is the name word's
 //! substituted *value*, resolved exactly once.** The compiled path used to get
@@ -472,6 +473,42 @@ puts "literal-key=[lindex [array names r] 0]"
                   z(b)c get=a 1 b 2 names=a b size=2\n\
                   z(b)c after=b 2\n\
                   literal-key=$i",
+    },
+    // -- #1745: explicit-frame names use the target frame's namespace. --
+    Vector {
+        name: "relative-qualified upvar targets use the caller frame namespace",
+        script: r#"namespace eval A {
+    namespace eval rel { variable x A; variable arr; set arr(k) AK }
+    proc outer {} { ::B::inner }
+}
+namespace eval B {
+    namespace eval rel { variable x B; variable arr; set arr(k) BK }
+    proc inner {} {
+        upvar 1 rel::x scalar rel::arr(k) element
+        set scalar AS
+        set element AE
+        list $scalar $element
+    }
+}
+puts [list [::A::outer] $::A::rel::x $::A::rel::arr(k) $::B::rel::x $::B::rel::arr(k)]
+namespace eval C { proc middle {} { ::B::deep } }
+namespace eval A { proc deep_outer {} { ::C::middle } }
+namespace eval B { proc deep {} { upvar 2 rel::x target; append target -DEEP } }
+puts [list [::A::deep_outer] $::A::rel::x $::B::rel::x]
+namespace eval A2 { proc outer {} { ::B2::inner } }
+namespace eval B2 {
+    namespace eval rel { variable x B }
+    proc inner {} { upvar 1 rel::x y }
+}
+puts "missing=[catch {::A2::outer} message]:$message:$::errorCode"
+"#,
+        // Tcl 9.0.4 exact oracle; this frame rule is release-invariant.
+        want_8x: "{AS AE} AS AE B BK\n\
+                  AS-DEEP AS-DEEP B\n\
+                  missing=1:can't access \"rel::x\": parent namespace doesn't exist:TCL LOOKUP VARNAME rel::x",
+        want_90: "{AS AE} AS AE B BK\n\
+                  AS-DEEP AS-DEEP B\n\
+                  missing=1:can't access \"rel::x\": parent namespace doesn't exist:TCL LOOKUP VARNAME rel::x",
     },
     // -- #1582 / #1588: `upvar` resolves semantic homes before shape checks. --
     Vector {


### PR DESCRIPTION
## Summary

- centralize namespace and ensemble option parsing, prefix/error rendering, import/export validation, and redispatch semantics in `tcl-cmd-core` plus registry descriptors
- make ensemble unknown handlers redispatch returned command prefixes and enforce Tcl dictionary/map/target rules in both native and Rust runtimes
- align namespace variable introspection, `which`, import/origin/delete/path behavior, and Tcl string-hash children ordering with Tcl 9.0.4
- resolve relative-qualified `upvar` targets against the selected caller frame namespace, including scalar, array-element, deep-level, and missing-parent cases
- add byte-exact namespace exists/parent/children cores and a centralized invalid-UTF-8 glob policy so embedder byte names never take a lossy conversion or panic
- document the shared namespace/frame ownership boundaries and keep command-specific knowledge in the registry/shared owners

## Tcl 9.0.4 evidence

Exact oracle vectors use `/home/jimd/src/tcl9.0.4/unix/tclsh` with the matching 9.0.4 library. They cover ensemble dispatch/errors, namespace introspection/order, caller-frame-relative links, scalar/array/deep target frames, and missing-parent precedence.

## Validation

- `cargo test -p tcl-syntax --all-features glob` (11/11)
- `cargo test -p tcl-cmd-core` (96/96)
- `cargo test -p tcl-vm --test variable_name_resolution_e2e` (3/3)
- `cargo test -p tcl-vm --test namespace_surface_e2e` (38/38)
- runtime namespace suite (49/49)
- `make rust-check`
- `make prep-pr`

Closes #1583
Closes #1584
Closes #1613
Closes #1745