### PR TITLE
Build portable GNU/Linux releases

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,13 +16,14 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-# Cross-compilation linkers for the native `tcl-lsp-server`.
+# Cross-compilation linkers for native Linux binaries.
 #
-# Every workspace crate is pure Rust (no C dependencies), so only the linker
-# varies per target. These two Linux cross targets need a cross GCC; install
-# them with `make ensure-server-cross-deps` (apt: gcc-aarch64-linux-gnu,
-# gcc-riscv64-linux-gnu). macOS Darwin targets use the system `cc`, and the
-# Windows MSVC targets build on a Windows runner — neither needs an entry here.
+# Local x86_64 hosts use these for foreign Linux targets. Release CI builds
+# aarch64 natively in UBI 8 (and overrides this linker with `gcc`) so both
+# x86_64 and aarch64 retain a GLIBC_2.28 ABI floor. RISC-V remains a cross
+# build, using Ubuntu 22.04's glibc 2.35 sysroot. Some workspace dependencies
+# compile C, so both the Rust linker and the target C compiler must come from
+# the selected builder rather than the newest general-purpose CI image.
 
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1332,9 +1332,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Git rejects the root-owned container's bind-mounted checkout as a
+          # dubious directory. Stamp provenance explicitly instead of letting
+          # tcl-version silently fall back to an empty commit.
+          export GIT_HASH="${GITHUB_SHA:0:8}"
           docker run --rm \
             --env TARGET \
             --env TCL_LSP_VERSION \
+            --env GIT_HASH \
             --env CARGO_HOME=/cargo \
             --env RUSTUP_HOME=/rustup \
             --volume "$GITHUB_WORKSPACE:/work" \
@@ -1357,6 +1362,16 @@ jobs:
               cargo build -p tcl-mcp --release --target "$TARGET"
               cargo build -p tcl-cli --release --target "$TARGET"
               cargo build -p f5-cli --release --target "$TARGET"
+              for binary in \
+                "target/$TARGET/release/tcl-lsp-server" \
+                "target/$TARGET/release/tcl-mcp" \
+                "target/$TARGET/release/tcl" \
+                "target/$TARGET/release/f5-query"; do
+                strings "$binary" | grep -F "+g$GIT_HASH" >/dev/null || {
+                  echo "error: $binary does not contain commit +g$GIT_HASH" >&2
+                  exit 1
+                }
+              done
             '
 
       # Ubuntu 22.04 is the oldest still-supported mainstream RISC-V distro and
@@ -1371,9 +1386,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          export GIT_HASH="${GITHUB_SHA:0:8}"
           docker run --rm \
             --env TARGET \
             --env TCL_LSP_VERSION \
+            --env GIT_HASH \
             --env CARGO_HOME=/cargo \
             --env RUSTUP_HOME=/rustup \
             --env DEBIAN_FRONTEND=noninteractive \
@@ -1394,6 +1411,16 @@ jobs:
               cargo build -p tcl-mcp --release --target "$TARGET"
               cargo build -p tcl-cli --release --target "$TARGET"
               cargo build -p f5-cli --release --target "$TARGET"
+              for binary in \
+                "target/$TARGET/release/tcl-lsp-server" \
+                "target/$TARGET/release/tcl-mcp" \
+                "target/$TARGET/release/tcl" \
+                "target/$TARGET/release/f5-query"; do
+                strings "$binary" | grep -F "+g$GIT_HASH" >/dev/null || {
+                  echo "error: $binary does not contain commit +g$GIT_HASH" >&2
+                  exit 1
+                }
+              done
               scripts/verify-glibc-baseline.sh 2.35 \
                 "target/$TARGET/release/tcl-lsp-server" \
                 "target/$TARGET/release/tcl-mcp" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1250,12 +1250,14 @@ jobs:
           gh release upload "$tag" install.sh --clobber
 
   # ---------------------------------------------------------------------
-  # build-server-matrix — cross-compile the native `tcl-lsp-server` for every
-  # supported platform.  Each runner builds its host's target triples (with
-  # cross-linkers for the foreign Linux arches), smoke-tests the native one,
-  # and uploads the binaries preserving `target/<triple>/release/`.  build-vsix
-  # downloads them all and packages both the untargeted universal VSIX and
-  # six platform-targeted VSIXes (one per vsce --target platform).
+  # build-server-matrix — compile the four native programs for every supported
+  # platform. Linux x86_64 and aarch64 build natively inside UBI 8 to retain a
+  # GLIBC_2.28 ABI floor; RISC-V uses an Ubuntu 22.04 container's glibc 2.35
+  # cross sysroot because EL8 did not ship a RISC-V architecture. No Zig or
+  # separately downloaded libc is involved. Each leg smoke-tests its binary
+  # and uploads it preserving `target/<triple>/release/`. build-vsix downloads
+  # them all and packages both the untargeted universal VSIX and six
+  # platform-targeted VSIXes.
   #
   # Per the no-marketplace-tokens invariant this uses only GitHub's built-in
   # token — nothing is published to a marketplace here.
@@ -1284,14 +1286,18 @@ jobs:
           - os: ubuntu-24.04
             id: linux-x64
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-24.04
+            ubi8: true
+            glibc_max: "2.28"
+          - os: ubuntu-24.04-arm
             id: linux-arm64
             target: aarch64-unknown-linux-gnu
-            cross: gcc-aarch64-linux-gnu
+            ubi8: true
+            glibc_max: "2.28"
           - os: ubuntu-24.04
             id: linux-riscv64
             target: riscv64gc-unknown-linux-gnu
-            cross: gcc-riscv64-linux-gnu
+            riscv_glibc: true
+            glibc_max: "2.35"
           - os: windows-latest
             id: win32-x64
             target: x86_64-pc-windows-msvc
@@ -1312,17 +1318,96 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Install Linux cross-linker
-        if: matrix.cross
+      # Use the runner's architecture-matched UBI image, so x86_64 and aarch64
+      # both link against the maintained EL8 glibc 2.28 ABI without a cross
+      # sysroot. The Rust installation is supplied by the pinned setup action;
+      # only the distro C toolchain lives in the container. aarch64 overrides
+      # the local-development cross-linker from .cargo/config.toml with native
+      # `gcc`/`ar`.
+      - name: Build GNU/Linux binaries against glibc 2.28
+        if: matrix.ubi8
+        env:
+          TARGET: ${{ matrix.target }}
+          TCL_LSP_VERSION: ${{ github.ref_name }}
+        shell: bash
         run: |
-          sudo apt-get update
-          sudo apt-get install -y ${{ matrix.cross }} qemu-user
+          set -euo pipefail
+          docker run --rm \
+            --env TARGET \
+            --env TCL_LSP_VERSION \
+            --env CARGO_HOME=/cargo \
+            --env RUSTUP_HOME=/rustup \
+            --volume "$GITHUB_WORKSPACE:/work" \
+            --volume "$HOME/.cargo:/cargo" \
+            --volume "$HOME/.rustup:/rustup" \
+            --workdir /work \
+            registry.access.redhat.com/ubi8/ubi-minimal:8.10 \
+            /bin/bash -lc '
+              set -euo pipefail
+              microdnf install -y binutils cmake gcc gcc-c++ git make perl pkgconf-pkg-config
+              microdnf clean all
+              export PATH="/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+              if [[ "$TARGET" == aarch64-unknown-linux-gnu ]]; then
+                export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=gcc
+                export CC_aarch64_unknown_linux_gnu=gcc
+                export AR_aarch64_unknown_linux_gnu=ar
+              fi
+              rustup target add "$TARGET"
+              cargo build -p tcl-lsp-server --release --target "$TARGET"
+              cargo build -p tcl-mcp --release --target "$TARGET"
+              cargo build -p tcl-cli --release --target "$TARGET"
+              cargo build -p f5-cli --release --target "$TARGET"
+            '
+
+      # Ubuntu 22.04 is the oldest still-supported mainstream RISC-V distro and
+      # ships a complete glibc 2.35 cross toolchain. Keep it inside a container
+      # rather than pinning the outer GitHub runner to an aging image. The QEMU
+      # handshake runs in the same container so it uses that matching sysroot.
+      - name: Build RISC-V GNU/Linux binaries against glibc 2.35
+        if: matrix.riscv_glibc
+        env:
+          TARGET: ${{ matrix.target }}
+          TCL_LSP_VERSION: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --env TARGET \
+            --env TCL_LSP_VERSION \
+            --env CARGO_HOME=/cargo \
+            --env RUSTUP_HOME=/rustup \
+            --env DEBIAN_FRONTEND=noninteractive \
+            --volume "$GITHUB_WORKSPACE:/work" \
+            --volume "$HOME/.cargo:/cargo" \
+            --volume "$HOME/.rustup:/rustup" \
+            --workdir /work \
+            docker.io/library/ubuntu:22.04 \
+            /bin/bash -lc '
+              set -euo pipefail
+              apt-get update
+              apt-get install -y --no-install-recommends \
+                ca-certificates cmake gcc gcc-riscv64-linux-gnu git make perl pkg-config qemu-user
+              rm -rf /var/lib/apt/lists/*
+              export PATH="/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+              rustup target add "$TARGET"
+              cargo build -p tcl-lsp-server --release --target "$TARGET"
+              cargo build -p tcl-mcp --release --target "$TARGET"
+              cargo build -p tcl-cli --release --target "$TARGET"
+              cargo build -p f5-cli --release --target "$TARGET"
+              scripts/verify-glibc-baseline.sh 2.35 \
+                "target/$TARGET/release/tcl-lsp-server" \
+                "target/$TARGET/release/tcl-mcp" \
+                "target/$TARGET/release/tcl" \
+                "target/$TARGET/release/f5-query"
+              make server-cross-test
+            '
 
       # Stamp the release version into every user-facing binary. The
       # tcl-version crate prefers this over `git describe`; without it a tag
       # build would still be correct, but this avoids depending on the checkout
       # having tags fetched.
       - name: Cross-compile native binaries (server + mcp + CLIs)
+        if: matrix.ubi8 != true && matrix.riscv_glibc != true
         env:
           TCL_LSP_VERSION: ${{ github.ref_name }}
         shell: bash
@@ -1336,10 +1421,23 @@ jobs:
           cargo build -p tcl-cli --release --target "$t"
           cargo build -p f5-cli --release --target "$t"
 
+      - name: Verify GNU/Linux glibc ABI ceiling
+        if: matrix.glibc_max
+        shell: bash
+        run: |
+          set -euo pipefail
+          t="${{ matrix.target }}"
+          scripts/verify-glibc-baseline.sh "${{ matrix.glibc_max }}" \
+            "target/$t/release/tcl-lsp-server" \
+            "target/$t/release/tcl-mcp" \
+            "target/$t/release/tcl" \
+            "target/$t/release/f5-query"
+
       # scripts/test-cross-server.sh tests whatever is already built and skips
       # absent triples loudly, so each per-triple leg smoke-tests just its own
       # binary (natively or under QEMU where runnable).
       - name: Smoke-test built binaries
+        if: matrix.riscv_glibc != true
         shell: bash
         run: make server-cross-test
 
@@ -1365,6 +1463,55 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  # The per-architecture ELF gates above catch ABI drift at the producer. This
+  # fan-in repeats them over the uploaded release bytes, then starts the exact
+  # x86_64 server across a compact matrix of maintained glibc distributions.
+  # WASI/browser-WASM artefacts are produced by separate jobs and intentionally
+  # do not participate in a host-libc contract.
+  linux-release-portability:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [create-release, build-server-matrix]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Download server-matrix binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: server-bins-*
+          path: target
+          merge-multiple: true
+
+      - name: Verify Linux release ABI ceilings
+        shell: bash
+        run: |
+          set -euo pipefail
+          # upload-artifact intentionally normalises file modes. Restore the
+          # executable bit before both the ELF gate and the distro handshake.
+          chmod +x \
+            target/{x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu,riscv64gc-unknown-linux-gnu}/release/{tcl-lsp-server,tcl-mcp,tcl,f5-query}
+          for triple in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu; do
+            scripts/verify-glibc-baseline.sh 2.28 \
+              "target/$triple/release/tcl-lsp-server" \
+              "target/$triple/release/tcl-mcp" \
+              "target/$triple/release/tcl" \
+              "target/$triple/release/f5-query"
+          done
+          scripts/verify-glibc-baseline.sh 2.35 \
+            target/riscv64gc-unknown-linux-gnu/release/tcl-lsp-server \
+            target/riscv64gc-unknown-linux-gnu/release/tcl-mcp \
+            target/riscv64gc-unknown-linux-gnu/release/tcl \
+            target/riscv64gc-unknown-linux-gnu/release/f5-query
+
+      - name: Test the release server across supported Linux distributions
+        env:
+          CONTAINER_ENGINE: docker
+        run: scripts/test-linux-distro-compat.sh target/x86_64-unknown-linux-gnu/release/tcl-lsp-server
+
   # Publish the standalone native binaries as per-triple release assets
   # (`<name>-<triple>[.exe]` for tcl-lsp-server, tcl-mcp, tcl, f5-query), so
   # `install.sh` fetches a prebuilt binary for the host platform.
@@ -1380,7 +1527,7 @@ jobs:
   # covered automatically.
   publish-native-binaries:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [create-release, build-server-matrix]
+    needs: [create-release, build-server-matrix, linux-release-portability]
     runs-on: ubuntu-24.04
     permissions:
       contents: write # gh release upload
@@ -1439,7 +1586,7 @@ jobs:
     # the module; this one downloads its `wasi-module` artifact rather than
     # re-linking wasm32-wasip1 here, the same way it takes the native binaries
     # from `build-server-matrix` instead of cross-compiling them itself.
-    needs: [create-release, test-ext, test-ext-web, build-server-matrix, lsp-server-wasi]
+    needs: [create-release, test-ext, test-ext-web, build-server-matrix, linux-release-portability, lsp-server-wasi]
     runs-on: ubuntu-24.04
     permissions:
       contents: write        # gh release upload
@@ -1646,7 +1793,7 @@ jobs:
   # binaries rather than cross-compiling again — same source build-vsix uses.
   build-jetbrains:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [create-release, build-server-matrix]
+    needs: [create-release, build-server-matrix, linux-release-portability]
     runs-on: ubuntu-24.04
     permissions:
       contents: write        # gh release upload
@@ -1709,7 +1856,7 @@ jobs:
     # release will carry so plugin.py verifies its download against a digest
     # that travelled inside the package rather than one served from the same
     # release as the binary.
-    needs: [create-release, build-server-matrix]
+    needs: [create-release, build-server-matrix, linux-release-portability]
     runs-on: ubuntu-24.04
     permissions:
       contents: write        # gh release upload

--- a/INSTALL-cli.md
+++ b/INSTALL-cli.md
@@ -10,8 +10,10 @@ curl -fsSL https://raw.githubusercontent.com/bitwisecook/tcl-lsp/rust/scripts/in
   | TCL_LSP_VERSION=v2.1.19 sh
 ```
 
-Works on macOS and Linux (x86_64, arm64, and riscv64 on Linux).
-Re-run the same line to update.
+Works on macOS and glibc-based Linux (x86_64, arm64, and riscv64 on Linux).
+The x86_64 and arm64 binaries require glibc 2.28 or newer; RISC-V requires
+glibc 2.35 or newer. Alpine and other non-glibc systems build the native CLIs
+from source. Re-run the same line to update.
 
 To inspect first, or run unattended:
 

--- a/INSTALL-editors.md
+++ b/INSTALL-editors.md
@@ -10,6 +10,12 @@ arm64, plus Linux riscv64) and run the one matching your machine. The
 Sublime Text package and the Zed extension download the matching binary
 on first use.
 
+The Linux native binaries target glibc: x86_64 and arm64 require 2.28 or
+newer, while RISC-V requires 2.35 or newer. This covers the maintained GNU
+distribution families in the release matrix; Alpine does not run these native
+binaries. The separately published WASI server is independent of the host libc
+and is documented below for editors that can launch a WebAssembly runtime.
+
 On an architecture none of those seven covers, the same server is also
 published as a WebAssembly module — see
 [No prebuilt binary for your platform?](#no-prebuilt-binary-for-your-platform)

--- a/docs/design/contracts/release-and-publish.md
+++ b/docs/design/contracts/release-and-publish.md
@@ -121,6 +121,41 @@ maintainer doesn't have to remember the sequence.  `make publish-vsix` /
 `make publish-openvsx` / `make publish-jetbrains` remain laptop fallbacks if
 a CI publish job fails.
 
+## Linux release portability is an ABI-floor contract
+
+The published Linux targets remain the standard GNU triples:
+`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, and
+`riscv64gc-unknown-linux-gnu`. Release CI does not inherit the libc of the
+newest general-purpose runner:
+
+- x86_64 and aarch64 build natively inside the architecture-matched UBI 8
+  image and may reference no symbol newer than `GLIBC_2.28`;
+- RISC-V cross-builds on Ubuntu 22.04 with its packaged glibc 2.35 sysroot and
+  may reference no symbol newer than `GLIBC_2.35`. EL8 had no RISC-V release,
+  so imposing its x86/aarch64 floor there would add a custom sysroot without
+  serving a supported distribution.
+
+All three use the current Rust toolchain and ordinary GCC/binutils. There is no
+Zig toolchain or bundled libc. At runtime the binaries use the host's maintained
+glibc, so distro security updates apply without a tcl-lsp rebuild. Alpine and
+other non-glibc systems are not native-binary targets; their packagers can build
+from source, and the separately published WASI server remains available to
+hosts that choose a WebAssembly runtime.
+
+`scripts/verify-glibc-baseline.sh` inspects the versioned ELF imports for all
+four native programs in every Linux matrix leg and again after artifact fan-in.
+`scripts/test-linux-distro-compat.sh` then completes an LSP initialize exchange
+with the exact x86_64 release server in a compact matrix spanning Ubuntu,
+Debian, EL8/Oracle, Amazon Linux, openSUSE, Fedora, and Arch. The tag-only
+`linux-release-portability` job gates native publication and every editor
+package that embeds or downloads those binaries.
+
+The libc choice has no effect on WebAssembly. `lsp-server-wasi`, the browser
+server, the compiler/runtime WASM builds, and their Rust target libraries do
+not link a host libc. Their artifacts and tests remain separate CI jobs; the
+universal VSIX continues to receive its WASI module from `lsp-server-wasi`
+rather than from a Linux build leg.
+
 **Failure mode — a red `build-vsix` ancestor leaves a half-populated
 Release.**  `build-vsix` needs `lsp-server-wasi` (the universal package's
 `server/wasm/` module), `test-ext`, and `test-ext-web`, and
@@ -247,7 +282,8 @@ the secret is reachable by no other job.
 ## What CI may do
 
 * Build every release artefact: the native binaries (`tcl`, `f5-query`,
-  `tcl-lsp-server`, `tcl-mcp`) via `cargo build` / the cross-build targets,
+  `tcl-lsp-server`, `tcl-mcp`) via the architecture-specific glibc ABI-floor
+  jobs described above,
   plus `make build-editor-jetbrains` / `make build-editor-sublime` /
   `make build-editor-zed` / `make package-vsix package-vsix-targets` and
   the Claude-skills zip. The VS Code artefact is seven VSIX packages: one

--- a/docs/kcs/kcs-howto-build-multiplatform-vsix.md
+++ b/docs/kcs/kcs-howto-build-multiplatform-vsix.md
@@ -119,8 +119,11 @@ BUNDLED_TARGETS="$(make -s print-server-targets-all)"`.
 ### Build for release
 
 The real release artefacts are built by CI: the tag-triggered
-`build-server-matrix` job compiles all seven binaries on native runners
-(macOS, Ubuntu, and Windows), and `build-vsix` downloads them, then runs
+`build-server-matrix` job compiles the Darwin and Windows binaries on native
+runners, the x86_64/aarch64 GNU/Linux binaries in architecture-matched UBI 8
+containers, and RISC-V with Ubuntu 22.04's packaged cross toolchain. The
+`linux-release-portability` fan-in enforces those Linux ABI floors before
+`build-vsix` downloads the binaries and runs
 both `make package-vsix BUNDLED_TARGETS="$(make -s
 print-server-targets-all)"` (the universal package) and `make
 package-vsix-targets` (the six targeted packages). See
@@ -137,9 +140,9 @@ publish-vsix-targets` remain laptop fallbacks for when that job fails.
    `VSCE_TARGETS` too (also in the `Makefile`) so it gets its own
    targeted package; otherwise it is covered only by the universal
    fallback package, like riscv64 Linux today.
-3. Add the triple to the matching runner in the `build-server-matrix`
-   matrix in [`ci.yml`](../../.github/workflows/ci.yml), and add any new
-   cross-linker to `.cargo/config.toml`.
+3. Add the triple to the matching runner or ABI-floor container in the
+   `build-server-matrix` matrix in [`ci.yml`](../../.github/workflows/ci.yml),
+   and add any new cross-linker to `.cargo/config.toml`.
 4. Add the triple to `scripts/test-cross-server.sh` so it is
    smoke-tested.
 

--- a/scripts/test-linux-distro-compat.sh
+++ b/scripts/test-linux-distro-compat.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Run the released x86_64 GNU/Linux server in representative supported distro
+# userspaces. This checks the real release bytes, complementing the ELF symbol
+# ceiling asserted by verify-glibc-baseline.sh.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+binary="${1:-$root/target/x86_64-unknown-linux-gnu/release/tcl-lsp-server}"
+binary="$(realpath "$binary")"
+
+if [[ ! -x "$binary" ]]; then
+    printf 'error: executable server binary not found: %s\n' "$binary" >&2
+    exit 2
+fi
+"$root/scripts/verify-glibc-baseline.sh" 2.28 "$binary"
+
+engine="${CONTAINER_ENGINE:-}"
+if [[ -z "$engine" ]]; then
+    if command -v docker >/dev/null 2>&1; then
+        engine=docker
+    elif command -v podman >/dev/null 2>&1; then
+        engine=podman
+    else
+        printf 'error: docker or podman is required for the distro compatibility test\n' >&2
+        exit 2
+    fi
+fi
+command -v "$engine" >/dev/null 2>&1 || {
+    printf 'error: CONTAINER_ENGINE=%s is not available\n' "$engine" >&2
+    exit 2
+}
+
+if [[ -n "${TCL_LSP_DISTRO_IMAGES:-}" ]]; then
+    read -r -a images <<<"$TCL_LSP_DISTRO_IMAGES"
+else
+    # A compact ABI-family matrix, current as of 2026-09-01. EL8 covers the
+    # RHEL/Rocky/Alma family; Oracle is retained explicitly because it is a
+    # common downstream with its own release channel. Rolling distributions
+    # prove forward compatibility with a much newer glibc.
+    images=(
+        docker.io/library/ubuntu:22.04
+        docker.io/library/debian:12-slim
+        registry.access.redhat.com/ubi8/ubi-minimal:8.10
+        container-registry.oracle.com/os/oraclelinux:8-slim
+        docker.io/amazonlinux:2023
+        registry.opensuse.org/opensuse/leap:16.0
+        docker.io/library/fedora:44
+        docker.io/archlinux:base
+    )
+fi
+
+frame() {
+    local body="$1"
+    printf 'Content-Length: %d\r\n\r\n%s' "${#body}" "$body"
+}
+
+handshake_input() {
+    frame '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":null,"rootUri":null,"capabilities":{}}}'
+}
+
+failed=0
+for image in "${images[@]}"; do
+    printf '%-6s %s\n' PULL "$image"
+    "$engine" pull --quiet "$image" >/dev/null
+    output="$({
+        handshake_input | timeout 60 "$engine" run --rm -i --network=none \
+            -v "$binary:/tcl-lsp-server:ro" \
+            "$image" /tcl-lsp-server
+    } 2>&1 || true)"
+    if grep -q '"capabilities"' <<<"$output"; then
+        printf '%-6s %s\n' PASS "$image"
+    else
+        printf '%-6s %s (no initialize response)\n' FAIL "$image" >&2
+        printf '%s\n' "$output" >&2
+        failed=1
+    fi
+done
+
+exit "$failed"

--- a/scripts/verify-glibc-baseline.sh
+++ b/scripts/verify-glibc-baseline.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Assert that dynamically-linked GNU/Linux release binaries do not reference a
+# glibc symbol newer than the stated ABI ceiling.
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+    printf 'usage: %s MAX_GLIBC BINARY [BINARY ...]\n' "$0" >&2
+    exit 2
+fi
+
+ceiling="$1"
+shift
+
+version_greater_than() {
+    local candidate="$1"
+    local limit="$2"
+    [[ "$candidate" != "$limit" ]] &&
+        [[ "$(printf '%s\n%s\n' "$candidate" "$limit" | sort -V | tail -n 1)" == "$candidate" ]]
+}
+
+failed=0
+for binary in "$@"; do
+    if [[ ! -x "$binary" ]]; then
+        printf 'FAIL  %s (missing or not executable)\n' "$binary" >&2
+        failed=1
+        continue
+    fi
+
+    if ! readelf -h "$binary" 2>/dev/null | grep -q 'OS/ABI:.*UNIX - System V'; then
+        printf 'FAIL  %s (not a System V ELF executable)\n' "$binary" >&2
+        failed=1
+        continue
+    fi
+
+    interpreter="$(
+        readelf -l "$binary" 2>/dev/null |
+            sed -n 's/.*Requesting program interpreter: \([^]]*\).*/\1/p'
+    )"
+    if [[ -z "$interpreter" ]]; then
+        printf 'FAIL  %s (no dynamic program interpreter)\n' "$binary" >&2
+        failed=1
+        continue
+    fi
+
+    mapfile -t versions < <(
+        readelf --version-info "$binary" 2>/dev/null |
+            grep -oE 'GLIBC_[0-9]+([.][0-9]+)+' |
+            sed 's/^GLIBC_//' |
+            sort -Vu
+    )
+    if [[ ${#versions[@]} -eq 0 ]]; then
+        printf 'FAIL  %s (no versioned glibc references)\n' "$binary" >&2
+        failed=1
+        continue
+    fi
+
+    newest="${versions[${#versions[@]} - 1]}"
+    if version_greater_than "$newest" "$ceiling"; then
+        printf 'FAIL  %s requires GLIBC_%s (ceiling GLIBC_%s)\n' \
+            "$binary" "$newest" "$ceiling" >&2
+        failed=1
+        continue
+    fi
+
+    printf 'PASS  %s: interpreter=%s max=GLIBC_%s ceiling=GLIBC_%s\n' \
+        "$binary" "$interpreter" "$newest" "$ceiling"
+done
+
+exit "$failed"


### PR DESCRIPTION
## Summary

- build x86_64 and aarch64 GNU/Linux release binaries natively in UBI 8, enforcing a GLIBC_2.28 symbol ceiling
- build RISC-V with Ubuntu 22.04's packaged GCC/glibc 2.35 cross-toolchain
- require no Zig toolchain, custom libc download, or statically bundled libc
- verify all four Linux programs at the producing matrix leg and again after artifact fan-in
- run the exact x86_64 release server across Ubuntu, Debian, UBI/EL8, Oracle Linux, Amazon Linux, openSUSE, Fedora, and Arch before publishing
- document the native ABI contract and keep WASI/browser WASM explicitly independent

## Why

The existing release binaries inherited the newest GitHub runner glibc and could fail on maintained distributions with older ABI floors. Static musl fixes portability, but the measured parallel workspace scan regressed badly. Building against an old maintained glibc preserves normal glibc performance and host security updates while covering the common supported distro families.

RISC-V uses glibc 2.35 rather than forcing 2.28: EL8 did not ship RISC-V, while Ubuntu 22.04 provides a maintained packaged RISC-V cross-toolchain. This avoids pulling Zig into release CI for an ABI floor that serves no supported RISC-V distribution.

## Compatibility contract

- x86_64 GNU/Linux: GLIBC_2.28+
- aarch64 GNU/Linux: GLIBC_2.28+
- riscv64 GNU/Linux: GLIBC_2.35+
- Alpine/non-glibc: source builds or the separately published WASI server
- Nix/source-first packaging: packager-owned native build

## Measured impact

Compared with the static-musl experiment on x86_64:

| Artifact | static musl | glibc 2.28 | Delta |
|---|---:|---:|---:|
| tcl-lsp-server | 50,518,728 | 50,421,472 | -97,256 |
| tcl-mcp | 40,554,960 | 40,403,736 | -151,224 |
| tcl | 37,529,952 | 37,390,408 | -139,544 |
| f5-query | 43,332,128 | 43,230,792 | -101,336 |
| linux-x64 VSIX | 53,373,770 | 53,296,248 | -77,522 |

Against the prior newest-glibc server, the GLIBC_2.28 server is only 29,328 bytes larger raw; a paired x64 VSIX repack adds 12,654 bytes (0.024%).

Focused performance measurements:

- cold workspace scan: current glibc 2.163s; glibc 2.28 2.213s; static musl 24.728s
- edit loop: current glibc 0.703s; glibc 2.28 0.700s; static musl 1.247s

## WASM

No glibc or musl linkage reaches the WASI server, browser server, compiler/runtime WASM artifacts, or their CI jobs. The unchanged WASI suite passes 22 unit tests and 26 scripted LSP checks. WASM adds zero bytes as a consequence of this change.

## Validation

- make rust-check
- make prep-pr
- all four x86_64 GLIBC_2.28 binaries pass the ELF ABI gate
- x86_64 release server completes an LSP initialize handshake
- Rust RISC-V probe links against the Jammy sysroot, passes the GLIBC_2.35 ceiling, and runs under QEMU
- verifier rejects both a GLIBC_2.28 binary under a 2.27 ceiling and the existing newest-glibc binary under a 2.28 ceiling
- shell syntax and workflow YAML parse checks

Fixes #1739