### PR TITLE
fix(ci): gate standalone runtime Clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,8 +214,9 @@ jobs:
           echo "python_changed=$python_changed ext_changed=$ext_changed lsp_wasm_changed=$lsp_wasm_changed docs_only=$docs_only"
 
   # Fast PR gate.  Runs on every PR and every push.  Covers the Rust fast
-  # checks: `cargo fmt --check`, `cargo clippy --workspace`, and the
-  # generated-file drift gates (`make xtask-check`).  The test surface runs
+  # checks through the central `make rust-check` contract: root and standalone
+  # crate formatting/Clippy plus generated-file drift gates. The test surface
+  # runs
   # concurrently in `rust-tests`, `rust-tests-heavy`, `lsp-e2e`, `cargo-deny`,
   # `test-ext` and `python` — all on every PR and push.  See AGENTS.md for the
   # local gates (`make check-all`, plus the heavier suites) agents must run
@@ -245,26 +246,14 @@ jobs:
           toolchain: stable
           components: clippy, rustfmt
 
-      - name: Run fast CI gate (cargo fmt + clippy + generated-file drift)
+      - name: Run fast CI gate (format + Clippy + generated-file drift)
         # Skipped for pre-release (rust-line) tags and for tags whose SHA is
         # already green; job still succeeds so the release graph stays
         # unbroken.  Deliberately NOT skipped on already-green merge pushes:
         # this job's clippy cache is the base-branch fallback every PR run
         # restores from, so pushes to rust keep it warm.
         if: needs.channel.outputs.prerelease != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')
-        run: |
-          cargo fmt --all --check
-          cargo clippy --workspace --all-targets -- -D warnings
-          make xtask-check
-
-      # runtime/rust is a standalone crate excluded from the root workspace
-      # (it is `unsafe`; root forbids `unsafe`), so the root `cargo fmt --all
-      # --check` above never sees it. Gate it separately here so a drift like
-      # #1623 (four files unformatted, unnoticed until a manual `cargo fmt
-      # --all` run) can't recur silently.
-      - name: Run runtime/rust fmt gate
-        if: needs.channel.outputs.prerelease != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')
-        run: cd runtime/rust && cargo fmt --all --check
+        run: make rust-check
 
   # Build the native tcl-lsp-server release binary ONCE and share it via
   # artifact with every job that just needs to *run* it rather than build it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,12 +213,12 @@ The project uses GNU Make. Key targets:
 
 | Target             | Purpose                                  |
 |--------------------|------------------------------------------|
-| `make rust-check`  | **Rust PR gate** — `check-rust` (cargo `fmt --check` + `clippy`) + `xtask-check` (generated-file / docs-index drift gates via `cargo xtask …`). Mirrors the GitHub Actions `pr-gate` job. |
+| `make rust-check`  | **Rust PR gate** — root-workspace and standalone-runtime `fmt --check` + `clippy`, then `xtask-check` generated-file / docs-index drift gates. Mirrors the GitHub Actions `pr-gate` job. |
 | `make check-all`   | **Pre-push gate** — full lint + typecheck across **every** language: TypeScript via ESLint + Prettier + tsc, Rust via `cargo fmt --check` + `cargo clippy`, Python via `ruff` + `ty` + `pyright` (`lint-py` + `typecheck-py`). Run before every push. |
 | `make install-test-deps` | One-shot setup: install **everything** the full test suite needs (the system toolchain — all of `ensure-test-deps`). The target to run on a fresh checkout before running the heavier suites below. Same platform coverage as `ensure-test-deps`. |
 | `make ensure-test-deps` | Install the optional host toolchain (`tclsh9.0`, `node`+`npm`, `kotlinc`, Rust/rustup, Wasmtime, Binaryen, wasi-sdk, emacs, xvfb, …) on Debian/Ubuntu (apt-get), CentOS/RHEL/Rocky/Alma/Fedora (dnf or yum), or macOS (Homebrew). Idempotent. Builds Tcl 9 from `tmp/tcl9.0.4/` since most distros don't package it yet. Skip individual tools with `SKIP_TCLSH=1`, `SKIP_NODE=1`, `SKIP_KOTLINC=1`, `SKIP_RUST=1`, … Run `bash scripts/dev/ensure-test-deps.sh --check` for a non-mutating report, including whether `rustc` satisfies the workspace `rust-version`. |
 | `make ensure-rust-deps` | Install Rust/rustup + the `wasm32-wasip2` target needed by `check-rust` / the WASM build. |
-| `make check-rust`  | Rust format check + clippy across the workspace (and the Zed extension). Skip with `SKIP_CHECK_RUST=1`. |
+| `make check-rust`  | Broader Rust format + clippy gate across the workspace and every excluded crate, reusing the same standalone-runtime gate as `make rust-check`. Skip with `SKIP_CHECK_RUST=1`. |
 | `make prep-pr`     | The standard local gate: auto-formats code, runs codegen, lint/typecheck, and the smoke tier (`make smoke`). Deep suites run in CI — see "Workflow requirements" below. |
 | `make smoke`       | Fast per-module smoke tier (`cargo nextest run --profile smoke`): the `smoke_*` / `*_smoke.rs` subset, seconds warm, reusing the existing dev build. `make smoke-p P=<crate>` scopes it to one crate. |
 | `make test-exhaustive` | Manual-only tier: every `#[ignore]`d corpus sweep / fuzz gate / privileged test (`--run-ignored ignored-only`). Never run automatically. |

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 .PHONY: xtask-check xtask-editor-extensions xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-command-backing xtask-audit-option-dialects xtask-registry-oracle xtask-sslictcl-data xtask-runtime-stdlib tcltest-sweep tcltest-sweep-check xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership check-c-api-ownership
 .PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory
 # Lint / format / typecheck
-.PHONY: lint format lint-ts format-ts typecheck-ts check-rust rust-deny
+.PHONY: lint format lint-ts format-ts typecheck-ts check-rust check-rust-pr _check-rust-pr rust-deny
 .PHONY: build-report-assets build-report-pyz lint-report-ts typecheck-report-ts check-report-assets lint-spec-studio-ts typecheck-spec-studio-ts
 # Coverage
 .PHONY: coverage coverage-ext
@@ -904,7 +904,7 @@ _prep-pr-smoke-tier: smoke
 
 # Rust-side check gate (fmt + clippy + generated-file drift).  Mirrors the
 # pr-gate job in GitHub Actions (ci.yml).
-rust-check: check-rust xtask-check ## Rust fmt + clippy + generated-file drift gates (mirrors the GitHub Actions PR gate)
+rust-check: check-rust-pr xtask-check ## Rust fmt + clippy + generated-file drift gates (mirrors the GitHub Actions PR gate)
 
 # The local pre-push gate: format + codegen + lint/typecheck + the smoke test
 # tier.  Deliberately NOT the full test suite — CI runs the deep suites
@@ -1166,10 +1166,10 @@ server-cross-test-build: ## Cross-build then smoke-test tcl-lsp-server binaries
 ## Tests are NOT included here — run them separately (test-ext, test-rust,
 ## runtime-rust-test, test-emacs) before PR creation.
 
-# Rust: cargo fmt --check + cargo clippy on the root workspace and on each
-# crate excluded from it (the Zed extension and the wasm32 cdylibs, which have
-# their own targets and lockfiles).  Skip with SKIP_CHECK_RUST=1.
-check-rust: ensure-rust-deps ## Rust fmt-check + clippy on the workspace and the excluded wasm/Zed crates
+# CI-facing Rust fast gate: the root workspace plus the standalone runtime.
+# `check-rust` reuses this target before checking the remaining excluded
+# crates, so neither CI nor the broader local gate duplicates these commands.
+check-rust-pr: ensure-rust-deps
 	@set -eu; \
 	if [ -n "$${SKIP_CHECK_RUST:-}" ]; then \
 		echo "==> SKIP_CHECK_RUST set — skipping Rust lint/typecheck"; \
@@ -1185,15 +1185,40 @@ check-rust: ensure-rust-deps ## Rust fmt-check + clippy on the workspace and the
 		echo "       Set SKIP_CHECK_RUST=1 to skip."; \
 		exit 1; \
 	fi; \
+	$(MAKE) --no-print-directory -C $(ROOT) _check-rust-pr
+
+_check-rust-pr:
+	@set -eu; \
 	echo "==> Checking top-level Rust workspace (fmt + clippy)"; \
 	cd $(ROOT); \
 	cargo fmt --all --check; \
 	cargo clippy --workspace --all-targets -- -D warnings; \
 	if [ -f "$(RUNTIME_RUST_DIR)/Cargo.toml" ]; then \
-		echo "==> Checking runtime/rust (fmt)"; \
-		cd $(RUNTIME_RUST_DIR); \
-		cargo fmt --all --check; \
+		echo "==> Checking runtime/rust (fmt + clippy)"; \
+		$(MAKE) --no-print-directory -C $(ROOT) runtime-rust-lint; \
+	fi
+
+# Broader local Rust gate: run the CI-facing workspace/runtime contract above,
+# then every other crate excluded from the root workspace (Zed and the wasm32
+# cdylibs, which have their own targets and lockfiles). Skip with
+# SKIP_CHECK_RUST=1.
+check-rust: ensure-rust-deps ## Rust fmt-check + clippy on the workspace and excluded standalone crates
+	@set -eu; \
+	if [ -n "$${SKIP_CHECK_RUST:-}" ]; then \
+		echo "==> SKIP_CHECK_RUST set — skipping Rust lint/typecheck"; \
+		exit 0; \
 	fi; \
+	if [ -x "$$HOME/.cargo/bin/rustup" ]; then \
+		export PATH="$$HOME/.cargo/bin:$$PATH"; \
+	elif [ -f "$$HOME/.cargo/env" ]; then \
+		. "$$HOME/.cargo/env"; \
+	fi; \
+	if ! command -v cargo >/dev/null 2>&1; then \
+		echo "ERROR: 'cargo' not found on PATH (need a current Rust stable toolchain)."; \
+		echo "       Set SKIP_CHECK_RUST=1 to skip."; \
+		exit 1; \
+	fi; \
+	$(MAKE) --no-print-directory -C $(ROOT) _check-rust-pr; \
 	if [ -f "$(ZED_DIR)/Cargo.toml" ]; then \
 		echo "==> Checking Zed extension (fmt + clippy --target wasm32-wasip2 + host tests)"; \
 		cd $(ZED_DIR); \
@@ -2245,16 +2270,16 @@ distclean: clean ## Remove build artifacts and node_modules
 	rm -f  $(EXT_DIR)/package-lock.json
 
 # Rust runtime port (runtime/rust) — standalone crate, excluded from the root
-# workspace (it is `unsafe`; root forbids `unsafe`). These are the gates the
-# rust-runtime-port doc + runtime/rust/README cite. Not wired into prep-pr: the
-# runtime port is a separate workstream from the LSP/compiler CI.
+# workspace (it is `unsafe`; root forbids `unsafe`). These are the direct gates
+# the rust-runtime-port doc + runtime/rust/README cite. `check-rust` reuses the
+# lint target so the local and CI PR gates cannot drift from this definition.
 RUNTIME_RUST_DIR := $(ROOT)runtime/rust
 
 runtime-rust-test: ## Run the Rust runtime port's cargo test (leak round-trip + unit/parse/eval suite)
 	cd $(RUNTIME_RUST_DIR) && cargo test
 
-runtime-rust-lint: ## Rust runtime port: cargo fmt --check + clippy -D warnings
-	cd $(RUNTIME_RUST_DIR) && cargo fmt --check && cargo clippy --all-targets -- -D warnings
+runtime-rust-lint: ## Rust runtime port: cargo fmt --check + locked clippy -D warnings
+	cd $(RUNTIME_RUST_DIR) && cargo fmt --check && cargo clippy --locked --all-targets -- -D warnings
 
 zed-query-check: ## Validate the generated Zed highlight queries against the pinned tree-sitter grammar
 	cd $(ROOT)rust/zed-query-check && cargo test

--- a/runtime/rust/README.md
+++ b/runtime/rust/README.md
@@ -39,7 +39,7 @@ runtime-port churn.
 
 ```
 make runtime-rust-test     # cargo test  (the T1.1 leak round-trip gate)
-make runtime-rust-lint     # cargo fmt --check + clippy -D warnings
+make runtime-rust-lint     # direct cargo fmt + locked clippy gate (also in check-rust / CI)
 ```
 
 The acceptance gate is `round_trip_zero_residual`: `Tcl_NewObj` →

--- a/runtime/rust/src/cmd_fs.rs
+++ b/runtime/rust/src/cmd_fs.rs
@@ -471,7 +471,7 @@ fn file_time(interp: &mut Interp, argv: &[*mut TclObj], access: bool) -> Code {
             return interp.set_error(b"expected integer but got invalid time");
         };
         return match fs.set_times(
-            &as_str(&path),
+            as_str(&path),
             access.then_some(secs),
             (!access).then_some(secs),
         ) {
@@ -482,7 +482,7 @@ fn file_time(interp: &mut Interp, argv: &[*mut TclObj], access: bool) -> Code {
             Err(e) => host_fs_error(interp, b"could not set file time for", &path, &e.reason()),
         };
     }
-    match fs.metadata(&as_str(&path)) {
+    match fs.metadata(as_str(&path)) {
         Ok(m) => {
             let value = if access { m.atime_secs } else { m.mtime_secs };
             interp.set_result_bytes(value.to_string().as_bytes());
@@ -501,13 +501,13 @@ fn file_attributes(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let Some(fs) = host.filesystem() else {
         return interp.set_error(b"filesystem not available");
     };
-    let meta = match fs.symlink_metadata(&as_str(&path)) {
+    let meta = match fs.symlink_metadata(as_str(&path)) {
         Ok(m) => m,
         Err(e) => return host_fs_error(interp, b"could not read", &path, &e.reason()),
     };
     if argv.len() == 3 {
         let tail = tcl_cmd_core::path::tail(&path);
-        let entries = vec![
+        let entries = [
             (b"-group".as_slice(), meta.gid.to_string().into_bytes()),
             (b"-owner".as_slice(), meta.uid.to_string().into_bytes()),
             (
@@ -600,9 +600,7 @@ fn file_copy(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let Some(fs) = host.filesystem() else {
         return interp.set_error(b"filesystem not available");
     };
-    let target_is_dir = fs
-        .symlink_metadata(&as_str(&target))
-        .is_ok_and(|m| m.is_dir);
+    let target_is_dir = fs.symlink_metadata(as_str(&target)).is_ok_and(|m| m.is_dir);
     let sources = &argv[i..argv.len() - 1];
     if sources.len() > 1 && !target_is_dir {
         return interp.set_error(b"target must be a directory");
@@ -614,10 +612,8 @@ fn file_copy(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         } else {
             target.clone()
         };
-        let recursive = fs
-            .symlink_metadata(&as_str(&source))
-            .is_ok_and(|m| m.is_dir);
-        if let Err(e) = fs.copy(&as_str(&source), &as_str(&destination), recursive, force) {
+        let recursive = fs.symlink_metadata(as_str(&source)).is_ok_and(|m| m.is_dir);
+        if let Err(e) = fs.copy(as_str(&source), as_str(&destination), recursive, force) {
             return host_fs_error(interp, b"error copying", &source, &e.reason());
         }
     }
@@ -662,7 +658,7 @@ fn file_link(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let Some(fs) = host.filesystem() else {
         return interp.set_error(b"filesystem not available");
     };
-    match fs.link(&as_str(&link), &as_str(&target), hard) {
+    match fs.link(as_str(&link), as_str(&target), hard) {
         Ok(()) => str_result(interp, &target),
         Err(e) => host_fs_error(interp, b"couldn't create link", &link, &e.reason()),
     }
@@ -680,7 +676,7 @@ fn file_readlink_at(interp: &mut Interp, path: &[u8]) -> Code {
     let Some(fs) = host.filesystem() else {
         return interp.set_error(b"filesystem not available");
     };
-    match fs.readlink(&as_str(path)) {
+    match fs.readlink(as_str(path)) {
         Ok(target) => str_result(interp, target.as_bytes()),
         Err(e) => host_fs_error(interp, b"couldn't read link", path, &e.reason()),
     }
@@ -715,9 +711,7 @@ fn file_rename(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let Some(fs) = host.filesystem() else {
         return interp.set_error(b"filesystem not available");
     };
-    let target_is_dir = fs
-        .symlink_metadata(&as_str(&target))
-        .is_ok_and(|m| m.is_dir);
+    let target_is_dir = fs.symlink_metadata(as_str(&target)).is_ok_and(|m| m.is_dir);
     let sources = &argv[i..argv.len() - 1];
     if sources.len() > 1 && !target_is_dir {
         return interp.set_error(b"target must be a directory");
@@ -729,7 +723,7 @@ fn file_rename(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         } else {
             target.clone()
         };
-        if let Err(e) = fs.rename(&as_str(&source), &as_str(&destination), force) {
+        if let Err(e) = fs.rename(as_str(&source), as_str(&destination), force) {
             return host_fs_error(interp, b"error renaming", &source, &e.reason());
         }
     }
@@ -751,9 +745,9 @@ fn file_stat(interp: &mut Interp, argv: &[*mut TclObj], no_follow: bool) -> Code
         return interp.set_error(b"filesystem not available");
     };
     let meta = match if no_follow {
-        fs.symlink_metadata(&as_str(&path))
+        fs.symlink_metadata(as_str(&path))
     } else {
-        fs.metadata(&as_str(&path))
+        fs.metadata(as_str(&path))
     } {
         Ok(m) => m,
         Err(e) => return host_fs_error(interp, b"could not read", &path, &e.reason()),
@@ -1432,10 +1426,7 @@ mod tests {
                 .parse::<i64>()
                 .is_ok()
         );
-        assert_eq!(
-            ok(&mut i, format!("file attributes {src_s}").as_bytes()).contains(&b'-'),
-            true
-        );
+        assert!(ok(&mut i, format!("file attributes {src_s}").as_bytes()).contains(&b'-'));
         assert_eq!(
             ok(&mut i, format!("file copy {src_s} {copy_s}").as_bytes()),
             b""


### PR DESCRIPTION
## Summary

- make `make rust-check` the single CI-facing Rust fast gate for the root workspace, the standalone Rust runtime, and generated/owner drift checks
- make the broader local `check-rust` reuse that same root/runtime helper before its excluded-crate checks
- run standalone runtime formatting plus locked all-target Clippy with warnings denied
- fix the Rust 1.98 `cmd_fs` lints mechanically while retaining focused file-command execution coverage

This puts the compiler-facing runtime under the same continuously enforced tool layer as its consumers, instead of letting the excluded crate drift behind a format-only CI step.

## Verification

- `make NPROC=1 rust-check`
- `make prep-pr`
- focused `cmd_fs` execution: 1/1
- standalone runtime baseline-excluded suite: 486/486 plus doctests
- SpecTcl legacy execution/equivalence: 15/15 + 3/3 + 4/4
- shipped packs parsed by exact Tcl 9.0.4: 1/1, non-skipped

The full standalone-runtime run also reproduced only the two pre-existing nested-array-index expectation failures tracked by #1732; neither parser/substitution file is changed here.

Closes #1758