### PR TITLE
feat(jetbrains): register pack-declared file extensions dynamically (#1650)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ curl -fsSL https://raw.githubusercontent.com/bitwisecook/tcl-lsp/rust/scripts/in
 | [Emacs](editors/emacs/) | Config snippet (Elisp) | Add to `init.el` for eglot or lsp-mode | Works with built-in eglot (Emacs 29+) |
 | [Helix](editors/helix/) | Config snippet (TOML) | Add to `~/.config/helix/languages.toml` | Minimal pure-TOML setup |
 | [Sublime Text](editors/sublime-text/) | Full package (.sublime-package) | Package Control or manual install | Works standalone (syntax + snippets) without LSP; enhanced with LSP package |
-| [JetBrains](editors/jetbrains/) | Full plugin (.zip) | Settings > Plugins > Install from Disk | Compiler explorer tool window, settings UI panel, IntelliJ IDEA 2024.1+ |
+| [JetBrains](editors/jetbrains/) | Full plugin (.zip) | Settings > Plugins > Install from Disk | Compiler explorer tool window, settings UI panel, dynamic file-type registration for pack-claimed extensions, IntelliJ IDEA 2024.1+ |
 
 All editors connect to the native Rust binary `tcl-lsp-server` over stdio
 (build it with `make rust-server`, or `cargo build -p tcl-lsp-server`).
@@ -1036,7 +1036,10 @@ The dialect is selected automatically using the following priority chain
    `.sdc`/`.upf` → `synopsys-eda-tcl`, `.xdc` → `xilinx-eda-tcl`.
    A SpecTcl pack can route further extensions to a dialect with a
    `file_extension` row, so a private library's own suffix opens in the
-   dialect it is written for.
+   dialect it is written for.  VS Code and the JetBrains IDEs also register
+   those extensions with the editor itself as the pack loads, so the file
+   opens as Tcl in the first place — see
+   [A file extension my SpecTcl pack claims opens as plain text](docs/kcs/kcs-issue-a-pack-claimed-file-extension-opens-as-plain-text.md).
 3. **Comment directive** -- a `# tcl-dialect: <dialect>` comment in the
    first 5 lines of a file pins the dialect for that file:
 

--- a/docs/design/dialect-and-package-registry-redesign.md
+++ b/docs/design/dialect-and-package-registry-redesign.md
@@ -764,8 +764,10 @@ environment attaches its documents to a generic contributed Tcl identity
 while the server tracks the real environment. A pack may request
 detection patterns; the editor adapter reports whether it can apply them
 dynamically (VS Code: workspace `files.associations` per #1626; JetBrains:
-#1650; Zed/Sublime: static manifests only) — the design never promises a
-new native file type where the host cannot register one.
+IDE-global `FileTypeManager` associations with a persisted ledger of what
+the plugin installed, per #1650; Zed/Sublime: static manifests only) — the
+design never promises a new native file type where the host cannot register
+one.
 
 - **Environments are the only user-facing names.** All six ingress kinds —
   `# tcl-dialect:` directives, `tclLsp.dialect` settings and

--- a/docs/design/spec-packs.md
+++ b/docs/design/spec-packs.md
@@ -777,6 +777,84 @@ count fitting no window at all stays an ordinary E002/E003.
   DSL for the private-library path. `tcl spec build` pre-warms the same
   cache — an optimisation, never a requirement.
 
+### Editor registration of pack-claimed file extensions
+
+A pack's `file_extension NAME -dialect D` row (and the `file_extensions` of a
+pack-declared `environment` block) routes the extension server-side the moment
+the pack is discovered. The editor is a step behind: it learns its
+extension-to-language mapping from a static manifest written long before the
+user's pack existed, so the file opens as plain text and the language client
+never attaches (issue #1626).
+
+The server closes that gap by *advertising* the pairs. `pack_file_extensions`
+appears on the `tcl-lsp.getEffectiveConfig` result and again in the
+`tcl-lsp/specPacksReloaded` notification, which is sent once a reload has
+fully landed — a client cannot derive that moment for itself. Each row carries
+the extension, the claiming pack, the dialect, and the **existing** editor
+language id the extension should ride, because no editor can mint a new
+language id at runtime.
+
+Registration is therefore a per-editor problem, and reversibility is the hard
+half: reconciliation has to delete as well as add, so "did we write this"
+must be answerable exactly.
+
+#### VS Code
+
+The advertised set is projected into **workspace-scoped**
+`files.associations`, and the entries the extension owns are remembered in
+workspace state as `{glob: languageId}` — the value written, not just the key.
+An entry is ours only while the configuration still says what we last wrote
+there, so a user who retargets `*.foo` by hand takes ownership permanently: it
+is neither rewritten nor retired. Globs are case-folded per character
+(`*.[fF][oO][oO]`), matching the server's case-insensitive routing.
+Already-open documents are flipped onto the new language with
+`setTextDocumentLanguage`, but only for the associations reconciliation
+actually owns.
+
+#### JetBrains
+
+`FileTypeManager` associations are **IDE-global** — there is no
+workspace-scoped layer to write into — so the JetBrains half (issue #1650)
+keeps its own ledger instead of relying on a scope to contain the damage.
+
+- **What is registered.** Each advertised row maps onto a file type the plugin
+  already contributes: `language_id` `tcl-irule` selects the **iRule** type,
+  every other id (including plain `tcl`) selects **Tcl**. Association happens
+  through `FileTypeManager.associate` with an `ExtensionFileNameMatcher`, on
+  the event dispatch thread inside a write action; the platform fires its own
+  file-types-changed event from there, so editors already showing a
+  newly-associated file re-detect without further help.
+- **The ownership ledger.** The application-level `TclLspPackAssociations`
+  state persists `{extension: fileTypeName}` for the associations *the plugin
+  itself installed*. An association is retired only when the extension is no
+  longer claimed **and** the IDE still reports exactly the file type the ledger
+  records. Anything else — an extension the plugin never claimed, or one whose
+  association the user has since changed — is dropped from the ledger and left
+  alone.
+- **Manual associations win.** Before claiming an extension the plugin asks
+  `FileTypeManager.getFileTypeByExtension`. If anything already owns it, the
+  claim is skipped and never recorded, so a later pack removal cannot delete a
+  user's mapping. That covers a user who mapped the extension to the plugin's
+  own Tcl type by hand: the plugin did not install it, so the plugin will not
+  remove it.
+- **Restart survival.** The ledger is persisted, and IDE file-type
+  associations persist on their own, so nothing is torn down at shutdown. The
+  first report of the next session is what retires an association whose pack
+  has gone: the extension is absent from the claim set, the recorded file type
+  still matches, so it is removed.
+- **Multi-project.** Associations are global but claims are per project. The
+  service keeps one claim set per open project and registers their **union**;
+  an association is retired only when no open project still claims it. If two
+  projects map the same extension to different file types the plain **Tcl**
+  type wins — both file types use the same language, so it is the safe
+  superset. A project that has not started its server yet contributes nothing,
+  so at startup an association can briefly retire and return; the file type
+  settles as soon as that project's server reports.
+- **Attachment follows the claim.** The plugin decides whether to start the
+  language server from the file's extension, so a dynamically-claimed
+  extension is added to that set too — otherwise the file would open as Tcl
+  and still get no server.
+
 ### Workspace trust: the setting is gated, the workspace tier is not
 
 VS Code's untrusted-workspace mode splits the loading rules above in two,

--- a/docs/design/spec-packs.md
+++ b/docs/design/spec-packs.md
@@ -849,7 +849,11 @@ keeps its own ledger instead of relying on a scope to contain the damage.
   type wins — both file types use the same language, so it is the safe
   superset. A project that has not started its server yet contributes nothing,
   so at startup an association can briefly retire and return; the file type
-  settles as soon as that project's server reports.
+  settles as soon as that project's server reports. A closing project drops
+  its claims through its own project service, and what it alone claimed is
+  retired there and then — but only while another project is still open,
+  because every project closes in turn when the IDE exits and a pass with
+  nothing left would retire the lot.
 - **Attachment follows the claim.** The plugin decides whether to start the
   language server from the file's extension, so a dynamically-claimed
   extension is added to that set too — otherwise the file would open as Tcl

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -48,6 +48,10 @@ symptom with several possible causes worth telling apart. See rule 13 in
 - [kcs-issue-sticky-scroll-shows-nothing.md](kcs-issue-sticky-scroll-shows-nothing.md)
   — sticky scroll pins nothing for Tcl files while the extension is
   enabled, even though breadcrumbs and the outline look fine.
+- [kcs-issue-a-pack-claimed-file-extension-opens-as-plain-text.md](kcs-issue-a-pack-claimed-file-extension-opens-as-plain-text.md)
+  — a file whose extension a SpecTcl pack claims opens as plain text with
+  no language server, and what each editor needs before it will treat the
+  extension as Tcl.
 - [kcs-issue-parallel-worktree-builds-serve-stale-artefacts.md](kcs-issue-parallel-worktree-builds-serve-stale-artefacts.md)
   — builds in one git worktree fail or pass with artefacts from a
   sibling checkout because the worktrees share one cargo target

--- a/docs/kcs/kcs-issue-a-pack-claimed-file-extension-opens-as-plain-text.md
+++ b/docs/kcs/kcs-issue-a-pack-claimed-file-extension-opens-as-plain-text.md
@@ -1,0 +1,92 @@
+# KCS: A file extension my SpecTcl pack claims opens as plain text
+
+> **Audience:** User
+> **Type:** Issue
+
+## Applies to
+
+VS Code, JetBrains, Zed, Sublime Text, Neovim, Helix, Emacs
+
+## Question
+
+My pack has a `file_extension` row for `.irulex`, but opening a `.irulex`
+file gives me plain text with no highlighting and no language server — how do
+I get the editor to treat it as Tcl?
+
+## Symptoms
+
+- The file opens with no highlighting, and the editor's language indicator
+  says **Plain Text** rather than Tcl or iRule.
+- No diagnostics, completion, or hover appear in that file, while `.tcl`
+  files in the same project are fine.
+- `tcl spec check` reports the pack loaded, and the commands it declares are
+  recognised in a `.tcl` file — so the pack itself is being read.
+
+## Answer
+
+The server routes a pack-claimed extension the moment it discovers the pack.
+The editor is a step behind: it learns which extensions are Tcl from a static
+manifest shipped with the extension or plugin, written long before your pack
+existed. Some editors can be told at runtime and some cannot, so the fix
+differs.
+
+### VS Code
+
+Nothing to do — the extension writes a workspace `files.associations` entry
+for every extension your packs claim, and flips an already-open file onto the
+Tcl language when the entry appears. If the file is still plain text:
+
+1. Save the `.tclspec` file. Registration follows the reload the save
+   triggers.
+2. Check the **Tcl Language Server** output channel for a `[packs] file
+   associations now:` line naming your extension.
+3. If an earlier entry for the same pattern exists in
+   `.vscode/settings.json` under `files.associations`, the extension leaves it
+   alone — a mapping you made by hand always wins. Remove it to hand the
+   extension back the pattern.
+
+### JetBrains
+
+Nothing to do — the plugin registers the claimed extensions with the IDE's
+file types while their packs are loaded, and retires them when the packs go.
+`tcl-irule` extensions become the **iRule** file type; everything else
+becomes **Tcl**. If the file is still plain text:
+
+1. Save the `.tclspec` file, and give the server a moment to reload.
+2. Check **Settings → Editor → File Types** for your extension under **Tcl**
+   or **iRule**.
+3. If it appears under some other file type, that mapping is yours and the
+   plugin will not touch it — remove it there and the plugin claims the
+   extension on the next reload.
+
+Two IDE-wide behaviours are worth knowing. Associations are shared by every
+open project, so the plugin registers what all of them claim together and
+drops an extension only when no open project claims it any more; a project
+whose server has not started yet claims nothing, so just after IDE startup an
+extension can briefly disappear and return. And nothing is removed when the
+IDE exits, so if you delete a pack while the IDE is closed, its extension is
+retired the first time a server reports in the next session.
+
+### Zed, Sublime Text, Neovim, Helix, Emacs
+
+These editors take their file-type mapping from a static configuration file,
+so add the extension yourself:
+
+1. **Zed** — add the suffix to `file_types` for the Tcl language in your
+   `settings.json`.
+2. **Sublime Text** — open a file of that type and use **View → Syntax →
+   Open all with current extension as… → Tcl**.
+3. **Neovim, Helix, Emacs** — add the extension to the filetype or
+   language-configuration mapping you already use for `.tcl`.
+
+The server does the rest: once the file arrives as Tcl, the pack's own
+`-dialect` decides which dialect it is analysed as, exactly as it does for a
+built-in extension.
+
+## Related
+
+- [How do I write a SpecTcl pack?](kcs-howto-write-a-tclspec-pack.md)
+- [Dialect selection](features/kcs-feature-dialect-selection.md)
+- [SpecTcl pack design](../design/spec-packs.md)
+- [KCS index](README.md)
+- [Glossary](../GLOSSARY.md)

--- a/editors/jetbrains/README.md
+++ b/editors/jetbrains/README.md
@@ -59,9 +59,11 @@ rather than per project:
   settings.
 - **Several open projects share one set of associations.** The plugin
   registers the union of what every open project's server reports, and drops
-  an extension only when no open project still claims it. A project whose
-  server has not started yet claims nothing, so shortly after IDE startup an
-  extension can disappear and come back once that project's server reports.
+  an extension only when no open project still claims it. Closing a project
+  retires what it alone claimed straight away, as long as another project is
+  still open. A project whose server has not started yet claims nothing, so
+  shortly after IDE startup an extension can disappear and come back once that
+  project's server reports.
 
 Nothing is torn down when the IDE exits, so the associations survive a
 restart. If a pack has been deleted in the meantime, the first report of the

--- a/editors/jetbrains/README.md
+++ b/editors/jetbrains/README.md
@@ -34,6 +34,38 @@ All features from the tcl-lsp server are supported:
 - **Compiler Explorer** tool window (IR, CFG, SSA, optimiser, shimmer) — also
   available by right-clicking a Tcl/iRule file → **Open In Tcl Compiler Explorer**
 - **Dialect support**: Tcl 8.4–9.0, F5 iRules, F5 iApps, EDA Tools
+- **Pack-declared file extensions** registered as the packs that claim them
+  load and unload (see below)
+
+## Pack-declared file extensions
+
+A SpecTcl pack can claim a file extension of its own with a
+`file_extension` row, or through the `file_extensions` of an `environment`
+block. The server routes those extensions as soon as it discovers the pack,
+but the IDE learns its file types from the plugin's static manifest, so a
+`.irulex` file would otherwise open as plain text with no server attached.
+
+The plugin registers the claimed extensions with `FileTypeManager` while their
+packs are loaded, and retires them again when the packs go. `tcl-irule` rows
+land on the **iRule** file type; everything else lands on **Tcl**. Two things
+are worth knowing, because JetBrains file-type associations are IDE-wide
+rather than per project:
+
+- **A mapping you made by hand always wins.** If the extension is already
+  associated with any file type — including the plugin's own — the plugin
+  leaves it alone and never removes it. It only ever retires an association it
+  installed itself and that still points where it left it. The ledger of what
+  it installed is kept in `TclLspPackAssociations.xml` beside your other IDE
+  settings.
+- **Several open projects share one set of associations.** The plugin
+  registers the union of what every open project's server reports, and drops
+  an extension only when no open project still claims it. A project whose
+  server has not started yet claims nothing, so shortly after IDE startup an
+  extension can disappear and come back once that project's server reports.
+
+Nothing is torn down when the IDE exits, so the associations survive a
+restart. If a pack has been deleted in the meantime, the first report of the
+next session is what removes its extension.
 
 ## Installation
 

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclFileType.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclFileType.kt
@@ -20,6 +20,7 @@ package com.tcllsp.jetbrains
 
 import com.intellij.openapi.fileTypes.LanguageFileType
 import com.intellij.openapi.vfs.VirtualFile
+import com.tcllsp.jetbrains.packs.PackClaimedExtensions
 import javax.swing.Icon
 
 class TclFileType private constructor() : LanguageFileType(TclLanguage) {
@@ -62,10 +63,15 @@ class TclFileType private constructor() : LanguageFileType(TclLanguage) {
         )
         // @generated:supported-extensions:end
 
+        // The statically contributed extensions, plus whatever a discovered
+        // SpecTcl pack claims and the plugin has managed to associate with one
+        // of its file types (issue #1650). Without the second half a
+        // pack-claimed file would open as Tcl and still get no language
+        // server, since this is what decides whether to start one.
         @JvmStatic
         fun isSupported(file: VirtualFile): Boolean {
             val ext = file.extension?.lowercase() ?: return false
-            return ext in SUPPORTED_EXTENSIONS
+            return ext in SUPPORTED_EXTENSIONS || PackClaimedExtensions.contains(ext)
         }
     }
 }

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclLspServerDescriptor.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclLspServerDescriptor.kt
@@ -25,10 +25,16 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.platform.lsp.api.Lsp4jClient
+import com.intellij.platform.lsp.api.LspServerListener
+import com.intellij.platform.lsp.api.LspServerNotificationsHandler
 import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
 import com.intellij.util.system.CpuArch
+import com.tcllsp.jetbrains.packs.TclLsp4jClient
+import com.tcllsp.jetbrains.packs.TclLspPackAssociations
 import com.tcllsp.jetbrains.settings.TclLspSettings
 import org.eclipse.lsp4j.ConfigurationItem
+import org.eclipse.lsp4j.InitializeResult
 import java.io.File
 import java.net.JarURLConnection
 import java.nio.file.Paths
@@ -40,6 +46,22 @@ class TclLspServerDescriptor(project: Project) :
 
     override fun isSupportedFile(file: VirtualFile): Boolean =
         TclFileType.isSupported(file)
+
+    // Pack-declared file extensions (issue #1650). The push is the main path:
+    // the server sends `tcl-lsp/specPacksReloaded` after every reload, this
+    // client is installed before the server process starts, so the startup
+    // reload is never missed.
+    override fun createLsp4jClient(handler: LspServerNotificationsHandler): Lsp4jClient =
+        TclLsp4jClient(handler, project)
+
+    // The pull half, for the case where a reload had already settled before
+    // anything was listening — a server restarted under a live IDE, say.
+    // Reconciliation is idempotent, so a redundant one costs a comparison.
+    override val lspServerListener: LspServerListener = object : LspServerListener {
+        override fun serverInitialized(params: InitializeResult) {
+            TclLspPackAssociations.getInstance().pull(project)
+        }
+    }
 
     override fun createCommandLine(): GeneralCommandLine {
         val settings = TclLspSettings.getInstance()

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/packs/PackAssociationReconciler.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/packs/PackAssociationReconciler.kt
@@ -121,6 +121,20 @@ object PackAssociationReconciler {
     }
 
     /**
+     * Whether a closing project's departure should be reconciled at once.
+     *
+     * Only while some other project is still claiming. Every project closes in
+     * turn when the IDE exits, so a pass taken with nothing left would retire
+     * every association the plugin owns at shutdown — and the whole point of
+     * persisting the ledger is that the associations survive to the next
+     * session, where the first report retires whatever no pack claims any
+     * more. With a project still open the union has genuinely shrunk, and the
+     * extensions only the departing project claimed have to go now rather than
+     * whenever something else happens to report.
+     */
+    fun reconcileAfterProjectClose(remainingProjects: Int): Boolean = remainingProjects > 0
+
+    /**
      * Decide what to associate, what to retire, and what the ledger becomes.
      *
      * `associatedWith` reports the file type the IDE currently resolves an

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/packs/PackAssociationReconciler.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/packs/PackAssociationReconciler.kt
@@ -1,0 +1,188 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// The reversibility rules for pack-declared file-extension registration
+// (issue #1650), kept free of every platform type so they can be tested
+// without an IDE.
+//
+// A JetBrains file-type association is IDE-global — there is no
+// workspace-scoped layer to write into, the way VS Code's `files.associations`
+// gives the extension one — so reconciliation cannot lean on a scope to bound
+// the damage it can do. It has to answer "did the plugin install this?"
+// exactly, from a ledger of what it wrote, and act only where the answer is
+// yes. Everything below is that decision, expressed as a plan the caller
+// applies.
+
+package com.tcllsp.jetbrains.packs
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+
+/** One extension, resolved to the name of a file type the plugin contributes. */
+data class PackExtensionClaim(val extension: String, val fileTypeName: String)
+
+/**
+ * The work one reconciliation pass has to do, plus the ledger that replaces
+ * the old one once it is done.
+ *
+ * `deferred` is the claims left to a manual association — reported so the log
+ * says why an extension a pack claims did not become ours.
+ */
+data class PackAssociationPlan(
+    val associate: List<PackExtensionClaim>,
+    val disassociate: List<PackExtensionClaim>,
+    val owned: Map<String, String>,
+    val deferred: List<PackExtensionClaim>,
+) {
+    val isEmpty: Boolean
+        get() = associate.isEmpty() && disassociate.isEmpty()
+}
+
+object PackAssociationReconciler {
+    /** The plugin's plain Tcl file type, as `FileType.getName()` spells it. */
+    const val TCL_FILE_TYPE: String = "Tcl"
+
+    /** The plugin's F5 iRule file type, as `FileType.getName()` spells it. */
+    const val IRULE_FILE_TYPE: String = "iRule"
+
+    private const val IRULE_LANGUAGE_ID = "tcl-irule"
+
+    /**
+     * The file type an advertised row rides.
+     *
+     * No editor can mint a language at runtime, so the server resolves every
+     * pack-claimed extension onto an id an editor already contributes. Of
+     * those the plugin contributes exactly two file types, and only
+     * `tcl-irule` names the iRule one; everything else — a dialect with its
+     * own id we have no separate file type for, and plain `tcl` for a row
+     * with no dialect at all — is Tcl. The dialect is still decided
+     * server-side, so the generic type costs nothing but the grammar's first
+     * paint.
+     */
+    fun fileTypeNameFor(languageId: String?): String =
+        if (languageId == IRULE_LANGUAGE_ID) IRULE_FILE_TYPE else TCL_FILE_TYPE
+
+    /**
+     * The claims carried by a `pack_file_extensions` array, or by an object
+     * that has one — the `tcl-lsp/specPacksReloaded` params and the
+     * `tcl-lsp.getEffectiveConfig` result both do, in the same shape.
+     */
+    fun claimsFrom(payload: JsonElement?): Map<String, String> {
+        val rows = when {
+            payload == null || payload.isJsonNull -> return emptyMap()
+            payload.isJsonArray -> payload.asJsonArray
+            payload.isJsonObject -> payload.asJsonObject.get("pack_file_extensions")
+                ?.takeIf { it.isJsonArray }?.asJsonArray ?: return emptyMap()
+            else -> return emptyMap()
+        }
+        val claims = LinkedHashMap<String, String>()
+        for (element in rows) {
+            val row = element as? JsonObject ?: continue
+            val extension = row.string("extension")?.trim()?.lowercase() ?: continue
+            if (extension.isEmpty() || extension.any { it == '.' || it.isWhitespace() }) continue
+            claims.putIfAbsent(extension, fileTypeNameFor(row.string("language_id")))
+        }
+        return claims
+    }
+
+    /**
+     * Merge the claim sets of every open project.
+     *
+     * Associations are global while claims are per project, so what gets
+     * registered is the union. Two projects claiming one extension for
+     * different file types is pathological rather than impossible, and the
+     * plain Tcl type wins: both file types carry the same language, so it is
+     * the safe superset, and picking by name rather than by whichever project
+     * reported first keeps the result independent of open order.
+     */
+    fun union(claimSets: Collection<Map<String, String>>): Map<String, String> {
+        val merged = sortedMapOf<String, String>()
+        for (claims in claimSets) {
+            for ((extension, fileTypeName) in claims) {
+                merged.merge(extension, fileTypeName) { a, b -> minOf(a, b) }
+            }
+        }
+        return merged
+    }
+
+    /**
+     * Decide what to associate, what to retire, and what the ledger becomes.
+     *
+     * `associatedWith` reports the file type the IDE currently resolves an
+     * extension to, or null when nothing claims it. It is asked inside the
+     * same write action that applies the plan, so the answer cannot go stale
+     * between the decision and the act.
+     *
+     * Two rules carry the whole design:
+     *
+     * 1. **Never remove what we did not add.** An extension is retired only
+     *    when the ledger records it *and* the IDE still says exactly what the
+     *    ledger records. A user who has since retargeted it no longer matches,
+     *    so it is forgotten rather than removed.
+     * 2. **A manual association wins.** An extension somebody else already
+     *    owns is never claimed and never recorded — including one the user
+     *    mapped to the plugin's own Tcl type by hand, which the plugin
+     *    therefore also never removes.
+     */
+    fun plan(
+        claimed: Map<String, String>,
+        owned: Map<String, String>,
+        associatedWith: (String) -> String?,
+    ): PackAssociationPlan {
+        val associate = mutableListOf<PackExtensionClaim>()
+        val disassociate = mutableListOf<PackExtensionClaim>()
+        val deferred = mutableListOf<PackExtensionClaim>()
+        val ledger = LinkedHashMap<String, String>()
+
+        for ((extension, fileTypeName) in claimed) {
+            val current = associatedWith(extension)
+            val recorded = owned[extension]
+            when {
+                current == null -> {
+                    associate += PackExtensionClaim(extension, fileTypeName)
+                    ledger[extension] = fileTypeName
+                }
+                // Ours, and still saying what we wrote.
+                current == recorded -> {
+                    if (current != fileTypeName) {
+                        // The claim moved between our two file types — a pack
+                        // gained or lost the `-dialect f5-irules` on its row.
+                        disassociate += PackExtensionClaim(extension, current)
+                        associate += PackExtensionClaim(extension, fileTypeName)
+                    }
+                    ledger[extension] = fileTypeName
+                }
+                else -> deferred += PackExtensionClaim(extension, current)
+            }
+        }
+
+        for ((extension, fileTypeName) in owned) {
+            if (claimed.containsKey(extension)) continue
+            if (associatedWith(extension) == fileTypeName) {
+                disassociate += PackExtensionClaim(extension, fileTypeName)
+            }
+            // Otherwise the user has changed it since we wrote it: drop it
+            // from the ledger without touching the association itself.
+        }
+
+        return PackAssociationPlan(associate, disassociate, ledger, deferred)
+    }
+
+    private fun JsonObject.string(name: String): String? =
+        get(name)?.takeIf { it.isJsonPrimitive }?.asString
+}

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/packs/PackAssociationsProjectTracker.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/packs/PackAssociationsProjectTracker.kt
@@ -18,23 +18,29 @@
 
 package com.tcllsp.jetbrains.packs
 
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.startup.StartupActivity
 
 /**
- * Loads the pack-association ledger while a project opens, and arms the
- * tracker that reports the project closing again.
+ * Tells the association service when a project goes away.
  *
- * Both services are otherwise instantiated by the first report, which arrives
- * from a server that only starts once a file the plugin recognises is opened.
- * A session whose only Tcl files carry a pack-claimed extension would never
- * get that far, so the extensions the ledger records have to be back in play
- * before the first file is opened — and a project that never reported still
- * has to be able to tell the service it has gone.
+ * A project service is disposed with its project, which is the only callback
+ * that arrives at the moment a project stops claiming anything. Without it a
+ * closed project's claims survive in the service until some *other* project
+ * happens to report, so an extension nothing claims any more stays associated
+ * — and, because the ledger is persisted, into the next session too.
  */
-class PackAssociationsStartupActivity : StartupActivity.DumbAware {
-    override fun runActivity(project: Project) {
-        TclLspPackAssociations.getInstance()
-        PackAssociationsProjectTracker.getInstance(project)
+@Service(Service.Level.PROJECT)
+class PackAssociationsProjectTracker(private val project: Project) : Disposable {
+
+    override fun dispose() {
+        TclLspPackAssociations.getInstance().projectClosed(project)
+    }
+
+    companion object {
+        @JvmStatic
+        fun getInstance(project: Project): PackAssociationsProjectTracker =
+            project.getService(PackAssociationsProjectTracker::class.java)
     }
 }

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/packs/PackAssociationsStartupActivity.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/packs/PackAssociationsStartupActivity.kt
@@ -1,0 +1,37 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains.packs
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.StartupActivity
+
+/**
+ * Loads the pack-association ledger while a project opens.
+ *
+ * The service is otherwise instantiated by the first report, which arrives
+ * from a server that only starts once a file the plugin recognises is opened.
+ * A session whose only Tcl files carry a pack-claimed extension would never
+ * get that far, so the extensions the ledger records have to be back in play
+ * before the first file is opened.
+ */
+class PackAssociationsStartupActivity : StartupActivity.DumbAware {
+    override fun runActivity(project: Project) {
+        TclLspPackAssociations.getInstance()
+    }
+}

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/packs/PackClaimedExtensions.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/packs/PackClaimedExtensions.kt
@@ -1,0 +1,44 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains.packs
+
+/**
+ * The pack-claimed extensions that currently resolve to one of the plugin's
+ * file types.
+ *
+ * Read by `TclFileType.isSupported`, which decides both whether to start the
+ * language server for an opened file and which files the server descriptor
+ * treats as its own. Associating an extension without this would open the
+ * file as Tcl and leave it with no server attached, which is the same
+ * half-working state the registration exists to fix.
+ *
+ * A plain holder rather than a call into the association service: file types
+ * are registered during IDE bootstrap, long before an application service is
+ * a reasonable thing to ask for.
+ */
+object PackClaimedExtensions {
+    @Volatile
+    private var extensions: Set<String> = emptySet()
+
+    fun contains(extension: String): Boolean = extension in extensions
+
+    fun replaceWith(claimed: Set<String>) {
+        extensions = claimed
+    }
+}

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/packs/TclLsp4jClient.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/packs/TclLsp4jClient.kt
@@ -1,0 +1,54 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains.packs
+
+import com.google.gson.Gson
+import com.intellij.openapi.project.Project
+import com.intellij.platform.lsp.api.Lsp4jClient
+import com.intellij.platform.lsp.api.LspServerNotificationsHandler
+import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
+
+/**
+ * The plugin's LSP client, extended with the one custom notification tcl-lsp
+ * sends.
+ *
+ * lsp4j builds its endpoint from the runtime class of the client object, so
+ * an annotated method here is enough to receive a method the platform has
+ * never heard of.
+ */
+@Suppress("UnstableApiUsage")
+class TclLsp4jClient(
+    handler: LspServerNotificationsHandler,
+    private val project: Project,
+) : Lsp4jClient(handler) {
+
+    /**
+     * `tcl-lsp/specPacksReloaded` — sent once a SpecTcl pack reload has fully
+     * landed, carrying the extensions the resulting pack set claims.
+     *
+     * The client cannot derive this moment for itself: it sees the same
+     * `.tclspec` write the server does, but not when the server has finished
+     * acting on it, and it never sees an edit under an absolute
+     * `tclLsp.specPacks` root at all.
+     */
+    @JsonNotification("tcl-lsp/specPacksReloaded")
+    fun specPacksReloaded(params: Any?) {
+        TclLspPackAssociations.getInstance().report(project, Gson().toJsonTree(params))
+    }
+}

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/packs/TclLspPackAssociations.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/packs/TclLspPackAssociations.kt
@@ -101,6 +101,26 @@ class TclLspPackAssociations : PersistentStateComponent<TclLspPackAssociations.S
     }
 
     /**
+     * Drop a closed project's claims, and retire whatever no open project
+     * claims any more.
+     *
+     * Called from [PackAssociationsProjectTracker.dispose], the one callback
+     * that arrives when a project stops claiming. Pruning on the next report
+     * is not enough on its own: with no other project reporting, nothing would
+     * ever come.
+     */
+    fun projectClosed(project: Project) {
+        val remaining = synchronized(lock) {
+            claimsByProject.remove(project)
+            claimsByProject.keys.removeAll { it.isDisposed }
+            claimsByProject.size
+        }
+        if (PackAssociationReconciler.reconcileAfterProjectClose(remaining)) {
+            scheduleReconcile()
+        }
+    }
+
+    /**
      * Ask a freshly-initialised server what its packs claim.
      *
      * The push covers every reload including the startup one, so this is the

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/packs/TclLspPackAssociations.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/packs/TclLspPackAssociations.kt
@@ -1,0 +1,227 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains.packs
+
+import com.google.gson.Gson
+import com.google.gson.JsonElement
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.fileTypes.ExtensionFileNameMatcher
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.fileTypes.FileTypeManager
+import com.intellij.openapi.fileTypes.UnknownFileType
+import com.intellij.openapi.project.Project
+import com.intellij.platform.lsp.api.LspServer
+import com.intellij.platform.lsp.api.LspServerManager
+import com.tcllsp.jetbrains.TclFileType
+import com.tcllsp.jetbrains.TclIruleFileType
+import com.tcllsp.jetbrains.TclLspServerSupportProvider
+import org.eclipse.lsp4j.ExecuteCommandParams
+import java.util.WeakHashMap
+
+private val LOG = Logger.getInstance(TclLspPackAssociations::class.java)
+
+/**
+ * Registers the file extensions discovered SpecTcl packs claim, and retires
+ * them again when the pack that claimed them goes away (issue #1650).
+ *
+ * The advertised set arrives two ways, both carrying the same
+ * `pack_file_extensions` array: pushed on `tcl-lsp/specPacksReloaded` once a
+ * reload has fully landed, and pulled once with `tcl-lsp.getEffectiveConfig`
+ * when a server finishes initialising, for the case where the push had
+ * already gone by.
+ *
+ * Claims are tracked per project because a JetBrains file-type association is
+ * not: `FileTypeManager` is application-wide, so what the plugin registers is
+ * the union over open projects, and it retires an association only when no
+ * open project still claims it. [PackAssociationReconciler] holds the rules;
+ * this class holds the ledger, the threading, and the platform calls.
+ */
+@Service
+@State(name = "TclLspPackAssociations", storages = [Storage("TclLspPackAssociations.xml")])
+class TclLspPackAssociations : PersistentStateComponent<TclLspPackAssociations.State> {
+
+    /**
+     * The associations the plugin itself installed: extension to the file
+     * type it was pointed at.
+     *
+     * Persisted because the question on cleanup — "did we write this, and is
+     * it still what we wrote?" — has to survive the restart that separates
+     * installing an association from discovering its pack is gone.
+     */
+    class State {
+        var owned: MutableMap<String, String> = LinkedHashMap()
+    }
+
+    private val lock = Any()
+    private var owned: MutableMap<String, String> = LinkedHashMap()
+    private val claimsByProject = WeakHashMap<Project, Map<String, String>>()
+
+    override fun getState(): State = State().also {
+        it.owned = synchronized(lock) { LinkedHashMap(owned) }
+    }
+
+    override fun loadState(state: State) {
+        synchronized(lock) { owned = LinkedHashMap(state.owned) }
+        // The IDE keeps its file-type associations across a restart, so what
+        // the ledger records is live again before any server has reported.
+        // Seeding from it is what lets a session that only ever opens a
+        // pack-claimed file start a server at all.
+        PackClaimedExtensions.replaceWith(state.owned.keys.toSet())
+    }
+
+    /** Record what one project's server says its packs claim, then reconcile. */
+    fun report(project: Project, payload: JsonElement?) {
+        val claims = PackAssociationReconciler.claimsFrom(payload)
+        synchronized(lock) {
+            claimsByProject.keys.removeAll { it.isDisposed }
+            claimsByProject[project] = claims
+        }
+        scheduleReconcile()
+    }
+
+    /**
+     * Ask a freshly-initialised server what its packs claim.
+     *
+     * The push covers every reload including the startup one, so this is the
+     * catch-up rather than the main path. Runs on a pooled thread: the request
+     * is synchronous, and the caller is the platform's own server-initialised
+     * callback, which is no place to block.
+     */
+    fun pull(project: Project) {
+        ApplicationManager.getApplication().executeOnPooledThread(
+            Runnable {
+                val result = try {
+                    requestEffectiveConfig(project)
+                } catch (error: Exception) {
+                    // A server still starting, or already stopped, has nothing
+                    // to say about packs yet; the push brings the answer when
+                    // it does.
+                    LOG.debug("Tcl spec-pack extension pull skipped", error)
+                    return@Runnable
+                }
+                if (result != null) {
+                    report(project, result)
+                }
+            },
+        )
+    }
+
+    private fun requestEffectiveConfig(project: Project): JsonElement? {
+        @Suppress("UnstableApiUsage")
+        val server = LspServerManager.getInstance(project)
+            .getServersForProvider(TclLspServerSupportProvider::class.java)
+            .firstOrNull() ?: return null
+        // The timeout is passed explicitly on purpose — see the note in
+        // TclLspActionBase.runCommand and the jetbrains-plugin-compat skill.
+        val result = server.sendRequestSync(LspServer.DEFAULT_REQUEST_TIMEOUT_MS) { lsp4j ->
+            lsp4j.workspaceService.executeCommand(
+                // The pack set is process-global on the server — one reload
+                // covers the bundled tier and every workspace folder — so this
+                // asks with no document rather than implying a per-file answer.
+                ExecuteCommandParams("tcl-lsp.getEffectiveConfig", listOf("")),
+            )
+        } ?: return null
+        return Gson().toJsonTree(result)
+    }
+
+    private fun scheduleReconcile() {
+        val application = ApplicationManager.getApplication()
+        application.invokeLater(
+            Runnable {
+                // FileTypeManager mutation is a model change: event dispatch
+                // thread, inside a write action. The platform fires its own
+                // file-types-changed event from there, which is what makes an
+                // editor already showing the file re-detect its type.
+                application.runWriteAction(Runnable { reconcile() })
+            },
+        )
+    }
+
+    private fun reconcile() {
+        val fileTypeManager = FileTypeManager.getInstance()
+        val claimed: Map<String, String>
+        val ledger: Map<String, String>
+        synchronized(lock) {
+            claimsByProject.keys.removeAll { it.isDisposed }
+            claimed = PackAssociationReconciler.union(claimsByProject.values.toList())
+            ledger = LinkedHashMap(owned)
+        }
+
+        val plan = PackAssociationReconciler.plan(claimed, ledger) { extension ->
+            associatedFileTypeName(fileTypeManager, extension)
+        }
+        for (claim in plan.disassociate) {
+            fileTypeFor(claim.fileTypeName)?.let {
+                fileTypeManager.removeAssociation(it, ExtensionFileNameMatcher(claim.extension))
+            }
+        }
+        for (claim in plan.associate) {
+            fileTypeFor(claim.fileTypeName)?.let {
+                fileTypeManager.associate(it, ExtensionFileNameMatcher(claim.extension))
+            }
+        }
+        synchronized(lock) { owned = LinkedHashMap(plan.owned) }
+
+        // Everything a pack claims that now resolves to one of our file
+        // types — including an extension the user associated by hand, which
+        // the plan deliberately leaves alone but the server still routes.
+        PackClaimedExtensions.replaceWith(
+            claimed.keys.filterTo(HashSet()) { isOurs(fileTypeManager.getFileTypeByExtension(it)) },
+        )
+
+        if (!plan.isEmpty) {
+            LOG.info(
+                "Tcl pack file associations: +" +
+                    plan.associate.joinToString(",") { it.extension }.ifEmpty { "-" } +
+                    " -" + plan.disassociate.joinToString(",") { it.extension }.ifEmpty { "-" },
+            )
+        }
+        for (claim in plan.deferred) {
+            LOG.info(
+                "Tcl pack file association for .${claim.extension} skipped: " +
+                    "already associated with \"${claim.fileTypeName}\"",
+            )
+        }
+    }
+
+    private fun associatedFileTypeName(manager: FileTypeManager, extension: String): String? {
+        val fileType = manager.getFileTypeByExtension(extension)
+        return if (fileType == UnknownFileType.INSTANCE) null else fileType.name
+    }
+
+    private fun fileTypeFor(name: String): FileType? = when (name) {
+        PackAssociationReconciler.TCL_FILE_TYPE -> TclFileType.INSTANCE
+        PackAssociationReconciler.IRULE_FILE_TYPE -> TclIruleFileType.INSTANCE
+        else -> null
+    }
+
+    private fun isOurs(fileType: FileType?): Boolean =
+        fileType === TclFileType.INSTANCE || fileType === TclIruleFileType.INSTANCE
+
+    companion object {
+        @JvmStatic
+        fun getInstance(): TclLspPackAssociations =
+            ApplicationManager.getApplication().getService(TclLspPackAssociations::class.java)
+    }
+}

--- a/editors/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/editors/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -76,6 +76,11 @@
         <postStartupActivity
             implementation="com.tcllsp.jetbrains.SpecStudioStartupActivity"/>
 
+        <!-- Restores the file extensions SpecTcl packs claimed in an earlier
+             session before the first file is opened. -->
+        <postStartupActivity
+            implementation="com.tcllsp.jetbrains.packs.PackAssociationsStartupActivity"/>
+
         <!-- Notification group for error messages -->
         <notificationGroup id="Tcl LSP" displayType="BALLOON"/>
     </extensions>

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/packs/PackAssociationReconcilerTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/packs/PackAssociationReconcilerTest.kt
@@ -3,6 +3,7 @@ package com.tcllsp.jetbrains.packs
 import com.google.gson.JsonParser
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class PackAssociationReconcilerTest {
@@ -159,6 +160,31 @@ class PackAssociationReconcilerTest {
 
         assertEquals(mapOf("aaa" to tcl, "bbb" to irule, "shared" to tcl), forward)
         assertEquals(forward, backward)
+    }
+
+    @Test
+    fun closingOneOfTwoProjectsRetiresOnlyWhatItAloneClaimed() {
+        // The surviving project's claims are the whole union now, so the
+        // extension only the closed project claimed has to go — and the one
+        // they shared must not.
+        val plan = PackAssociationReconciler.plan(
+            claimed = PackAssociationReconciler.union(listOf(mapOf("shared" to tcl))),
+            owned = mapOf("closedonly" to irule, "shared" to tcl),
+            associatedWith = { extension -> if (extension == "shared") tcl else irule },
+        )
+
+        assertEquals(listOf(PackExtensionClaim("closedonly", irule)), plan.disassociate)
+        assertEquals(emptyList(), plan.associate)
+        assertEquals(mapOf("shared" to tcl), plan.owned)
+    }
+
+    @Test
+    fun aClosingProjectIsReconciledOnlyWhileAnotherIsStillOpen() {
+        // Every project closes in turn at IDE shutdown. A pass with nothing
+        // left would retire every association the plugin owns, defeating the
+        // ledger's whole purpose.
+        assertTrue(PackAssociationReconciler.reconcileAfterProjectClose(1))
+        assertFalse(PackAssociationReconciler.reconcileAfterProjectClose(0))
     }
 
     @Test

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/packs/PackAssociationReconcilerTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/packs/PackAssociationReconcilerTest.kt
@@ -1,0 +1,180 @@
+package com.tcllsp.jetbrains.packs
+
+import com.google.gson.JsonParser
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PackAssociationReconcilerTest {
+
+    private val tcl = PackAssociationReconciler.TCL_FILE_TYPE
+    private val irule = PackAssociationReconciler.IRULE_FILE_TYPE
+
+    @Test
+    fun advertisedRowsResolveOntoTheTwoContributedFileTypes() {
+        val payload = JsonParser.parseString(
+            """
+            {"pack_file_extensions": [
+              {"extension": "IRULEX", "dialect": "f5-irules", "language_id": "tcl-irule", "pack": "extlib"},
+              {"extension": "packplain", "dialect": null, "language_id": "tcl", "pack": "extlib"},
+              {"extension": "pshx", "dialect": "probe-shell-tcl", "language_id": "tcl", "pack": "probe"}
+            ]}
+            """.trimIndent(),
+        )
+
+        assertEquals(
+            mapOf("irulex" to irule, "packplain" to tcl, "pshx" to tcl),
+            PackAssociationReconciler.claimsFrom(payload),
+        )
+    }
+
+    @Test
+    fun aBareArrayAndAnAbsentPayloadAreBothAccepted() {
+        val rows = JsonParser.parseString("""[{"extension": "foo", "language_id": "tcl"}]""")
+        assertEquals(mapOf("foo" to tcl), PackAssociationReconciler.claimsFrom(rows))
+        assertEquals(emptyMap(), PackAssociationReconciler.claimsFrom(null))
+        assertEquals(emptyMap(), PackAssociationReconciler.claimsFrom(JsonParser.parseString("{}")))
+    }
+
+    @Test
+    fun malformedRowsAreDroppedRatherThanRegistered() {
+        val payload = JsonParser.parseString(
+            """
+            [{"extension": ""}, {"extension": ".foo"}, {"extension": "two words"},
+             {"language_id": "tcl"}, "not an object", {"extension": "good"}]
+            """.trimIndent(),
+        )
+
+        assertEquals(mapOf("good" to tcl), PackAssociationReconciler.claimsFrom(payload))
+    }
+
+    @Test
+    fun anUnclaimedExtensionIsAssociatedAndRecorded() {
+        val plan = PackAssociationReconciler.plan(
+            claimed = mapOf("irulex" to irule),
+            owned = emptyMap(),
+            associatedWith = { null },
+        )
+
+        assertEquals(listOf(PackExtensionClaim("irulex", irule)), plan.associate)
+        assertEquals(emptyList(), plan.disassociate)
+        assertEquals(mapOf("irulex" to irule), plan.owned)
+    }
+
+    @Test
+    fun anAssociationWeInstalledIsRetiredOnceNoPackClaimsIt() {
+        val plan = PackAssociationReconciler.plan(
+            claimed = emptyMap(),
+            owned = mapOf("irulex" to irule),
+            associatedWith = { irule },
+        )
+
+        assertEquals(listOf(PackExtensionClaim("irulex", irule)), plan.disassociate)
+        assertEquals(emptyMap(), plan.owned)
+    }
+
+    @Test
+    fun anAssociationTheUserHasSinceChangedIsForgottenNotRemoved() {
+        // Recorded as ours, but the IDE now says something else: the user
+        // retargeted it. Retiring it here would delete their choice.
+        val plan = PackAssociationReconciler.plan(
+            claimed = emptyMap(),
+            owned = mapOf("irulex" to irule),
+            associatedWith = { "JSON" },
+        )
+
+        assertEquals(emptyList(), plan.disassociate)
+        assertEquals(emptyList(), plan.associate)
+        assertEquals(emptyMap(), plan.owned)
+    }
+
+    @Test
+    fun anExtensionSomebodyElseOwnsIsNeitherClaimedNorRecorded() {
+        val plan = PackAssociationReconciler.plan(
+            claimed = mapOf("irulex" to irule),
+            owned = emptyMap(),
+            associatedWith = { "JSON" },
+        )
+
+        assertEquals(emptyList(), plan.associate)
+        assertEquals(emptyList(), plan.disassociate)
+        assertEquals(emptyMap(), plan.owned)
+        assertEquals(listOf(PackExtensionClaim("irulex", "JSON")), plan.deferred)
+        assertTrue(plan.isEmpty)
+    }
+
+    @Test
+    fun ourOwnFileTypeAssociatedByHandIsRespectedAndNeverRetired() {
+        // The user pointed `.irulex` at the plugin's own Tcl type themselves.
+        // We did not install it, so we neither re-claim it nor remove it when
+        // the pack that claimed it goes away.
+        val claimed = PackAssociationReconciler.plan(
+            claimed = mapOf("irulex" to irule),
+            owned = emptyMap(),
+            associatedWith = { tcl },
+        )
+        assertEquals(emptyMap(), claimed.owned)
+        assertTrue(claimed.isEmpty)
+
+        val retired = PackAssociationReconciler.plan(
+            claimed = emptyMap(),
+            owned = claimed.owned,
+            associatedWith = { tcl },
+        )
+        assertTrue(retired.isEmpty)
+    }
+
+    @Test
+    fun aClaimThatMovesBetweenOurFileTypesIsRetargeted() {
+        val plan = PackAssociationReconciler.plan(
+            claimed = mapOf("irulex" to irule),
+            owned = mapOf("irulex" to tcl),
+            associatedWith = { tcl },
+        )
+
+        assertEquals(listOf(PackExtensionClaim("irulex", tcl)), plan.disassociate)
+        assertEquals(listOf(PackExtensionClaim("irulex", irule)), plan.associate)
+        assertEquals(mapOf("irulex" to irule), plan.owned)
+    }
+
+    @Test
+    fun aSteadyStateReconciliationTouchesNothing() {
+        val plan = PackAssociationReconciler.plan(
+            claimed = mapOf("irulex" to irule),
+            owned = mapOf("irulex" to irule),
+            associatedWith = { irule },
+        )
+
+        assertTrue(plan.isEmpty)
+        assertEquals(mapOf("irulex" to irule), plan.owned)
+    }
+
+    @Test
+    fun projectsUnionTheirClaimsAndDisagreementFallsBackToPlainTcl() {
+        val first = mapOf("aaa" to tcl, "shared" to irule)
+        val second = mapOf("bbb" to irule, "shared" to tcl)
+
+        val forward = PackAssociationReconciler.union(listOf(first, second))
+        val backward = PackAssociationReconciler.union(listOf(second, first))
+
+        assertEquals(mapOf("aaa" to tcl, "bbb" to irule, "shared" to tcl), forward)
+        assertEquals(forward, backward)
+    }
+
+    @Test
+    fun anExtensionClaimedByOneOfTwoProjectsSurvivesTheOtherReporting() {
+        // The multi-project rule: registration is the union, so a project that
+        // does not claim `irulex` must not retire it while another still does.
+        val claimed = PackAssociationReconciler.union(
+            listOf(mapOf("irulex" to irule), emptyMap()),
+        )
+        val plan = PackAssociationReconciler.plan(
+            claimed = claimed,
+            owned = mapOf("irulex" to irule),
+            associatedWith = { irule },
+        )
+
+        assertTrue(plan.isEmpty)
+        assertEquals(mapOf("irulex" to irule), plan.owned)
+    }
+}


### PR DESCRIPTION
Closes #1650.

The JetBrains half of the lazy extension-registration channel (#1626 / #1649): the plugin now consumes `pack_file_extensions` and registers or retires `FileTypeManager` associations as SpecTcl packs load and unload.

## Reversibility design

JetBrains associations are IDE-global, so the plugin cannot bound damage with a workspace scope the way the VS Code client does. Instead it keeps a ledger:

- **Ledger, not scope.** An application-level `PersistentStateComponent` (`TclLspPackAssociations.xml`) records `{extension: fileTypeName}` for exactly the associations the plugin installed.
- **Never remove what we did not add.** An association is retired only when no pack claims the extension *and* the IDE still resolves it to exactly what the ledger recorded. A user retarget drops the ledger entry and leaves the association alone.
- **A manual association wins.** An extension anything else already owns (including the plugin's own Tcl type mapped by hand) is never claimed and never recorded.
- **Multi-project.** Claims are tracked per project; the union is registered; an extension is retired only when no open project still claims it. Disagreements resolve to the plain Tcl type by name, independent of project open order.
- **Restart survival.** Nothing is torn down at shutdown; the first report of the next session retires a dead pack's extensions. A startup activity loads the ledger before the first file opens.
- **Re-detection.** `FileTypeManagerImpl.associate` fires the file-types-changed event (verified by disassembly at 2024.1), so open editors re-detect.

Push path: a `Lsp4jClient` subclass handles `tcl-lsp/specPacksReloaded`. Pull path: `LspServerListener.serverInitialized` requests `tcl-lsp.getEffectiveConfig` on a pooled thread. `TclFileType.isSupported` also consults the claimed set so a dynamically associated file starts a server.

The rules live in `PackAssociationReconciler`, free of platform types, and are unit-tested (12 tests). The platform mutation path itself has no harness (no LSP-plugin test harness exists), which is the same state as before.

## Gates

- `./gradlew test`: 52 tests, 0 failures
- `cargo xtask kcs-index-links`, `gen-editor-extensions --check`, `gen-jetbrains-catalog --check`: pass
- `./gradlew verifyPlugin` at IU 241 and 262: compatible, 0 compatibility problems. The task still exits non-zero on 12 pre-existing `INTERNAL_API_USAGES` in `CompilerExplorerToolWindowFactory` / `SpecStudioToolWindowFactory` (reproduced identically at the parent commit; not touched here).

## Docs

`docs/design/spec-packs.md` (editor registration section, VS Code / JetBrains split), new KCS issue note, `editors/jetbrains/README.md`, `README.md`, redesign doc #1650 reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRTFmQ5XHByfBZFXuqJbjX

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRTFmQ5XHByfBZFXuqJbjX)_